### PR TITLE
[guards] Reconstruct fqn-mismatched functions when a guard is rooted at them

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1,11 +1,14 @@
 # Owner(s): ["module: dynamo"]
 
 import dataclasses
+import functools
+import io
 import itertools
 import pickle
 import sys
 import tempfile
 import types
+import typing
 import unittest
 import weakref
 from collections.abc import Iterator
@@ -67,6 +70,263 @@ class GlobalNestedModule(torch.nn.Module):
 
 def global_func(x):
     return x + 1
+
+
+def keep_defaults(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if len(func.__defaults__) == 2:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_kwdefaults(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__kwdefaults__["scale"] == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_annotations(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if len(func.__annotations__) == 2:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_type_params(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__type_params__[0].__name__ == "T":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_attribute(func):
+    func.scale_flag = 2.0
+
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.scale_flag == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_name(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "forward":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_renamed_name(func):
+    # __name__ reassigned away from co_name, so a reconstruction that falls back
+    # to code.co_name reads "forward" where the real function says otherwise.
+    # keep_name alone cannot catch that: there the two agree.
+    func.__name__ = "renamed_forward"
+
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "renamed_forward":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+FQN_MISMATCH_GLOBAL = 2
+
+
+def keep_global(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__globals__["FQN_MISMATCH_GLOBAL"] == 2:
+            x = x + 10
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_globals_length(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        return func(self, x) + len(func.__globals__)
+
+    return wrapper
+
+
+class UnpicklableDefault:
+    def __reduce__(self):
+        raise RuntimeError("unrelated default cannot pickle")
+
+
+def keep_name_with_unpicklable_default(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "forward":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+class DecoratedForwardModule(torch.nn.Module):
+    # forward is the wrapper; the undecorated function it closes over has the
+    # same __qualname__ but is unreachable from the module, which is what makes
+    # it unpicklable by reference.
+    @keep_defaults
+    def forward(self, x, scale=2.0, shift=1.0):
+        return x * scale + shift
+
+
+class DecoratedKwdefaultsForwardModule(torch.nn.Module):
+    @keep_kwdefaults
+    def forward(self, x, *, scale=2.0):
+        return x * scale
+
+
+class DecoratedAnnotationsForwardModule(torch.nn.Module):
+    @keep_annotations
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * 2
+
+
+class DecoratedTypeParamsForwardModule(torch.nn.Module):
+    def forward(self, x):
+        return x * 2
+
+
+if sys.version_info >= (3, 12):
+    exec(
+        "class DecoratedTypeParamsForwardModule(torch.nn.Module):\n"
+        "    @keep_type_params\n"
+        "    def forward[T](self, x):\n"
+        "        return x * 2\n",
+        globals(),
+    )
+
+
+class DecoratedAttributeForwardModule(torch.nn.Module):
+    @keep_attribute
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedNameForwardModule(torch.nn.Module):
+    @keep_name
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedRenamedNameForwardModule(torch.nn.Module):
+    @keep_renamed_name
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedGlobalForwardModule(torch.nn.Module):
+    @keep_global
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedGlobalsLengthForwardModule(torch.nn.Module):
+    @keep_globals_length
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedUnpicklableDefaultForwardModule(torch.nn.Module):
+    @keep_name_with_unpicklable_default
+    def forward(self, x, unused=UnpicklableDefault()):
+        return x * 2
+
+
+# --- module-scope wrappers that reach themselves through their own globals ---
+# `wrapped = deco(base)` at module scope: the wrapper is reachable from its own
+# __globals__, so a globals snapshot passed as a reduce ARG contains the very
+# object being reduced. pickle memoizes only after saving args, so that recursed
+# forever; two wrappers referencing each other do it across the pair.
+MODULE_SCOPE_CONST = 2
+
+
+def module_scope_wrapper(func):
+    @functools.wraps(func)
+    def wrapper(x):
+        # Roots a guard at func.__globals__, which forces the snapshot -- and
+        # the snapshot contains the wrappers themselves.
+        if func.__globals__["MODULE_SCOPE_CONST"] == 2:
+            x = x + 1
+        return func(x)
+
+    return wrapper
+
+
+def _module_scope_base_a(x):
+    return x * 2
+
+
+def _module_scope_base_b(x):
+    return x * 3
+
+
+MODULE_SCOPE_WRAPPED_A = module_scope_wrapper(_module_scope_base_a)
+MODULE_SCOPE_WRAPPED_B = module_scope_wrapper(_module_scope_base_b)
+
+
+# --- an empty closure cell -------------------------------------------------
+def keep_name_with_empty_cell(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "forward":
+            x = x + 1
+        if x is None:
+            return unset
+        return func(self, x)
+
+    if func is None:
+        unset = 1  # never runs, so the cell wrapper closes over stays EMPTY
+
+    return wrapper
+
+
+def _empty_cell_base(self, x):
+    return x * 2
+
+
+EMPTY_CELL_WRAPPED = keep_name_with_empty_cell(_empty_cell_base)
+
+
+# --- a guarded default whose VALUE must survive, not just the tuple length --
+def keep_default_value(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__defaults__[0] == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+class DecoratedDefaultValueForwardModule(torch.nn.Module):
+    @keep_default_value
+    def forward(self, x, scale=2.0):
+        return x * scale
 
 
 class ModuleNotSerializable(torch.nn.Module):
@@ -484,6 +744,253 @@ class TestGuardSerialization(TestGuardSerializationBase):
             return g(x) + 1
 
         self._test_serialization("TENSOR_MATCH", fn, torch.randn(3), foo)
+
+    def test_guard_rooted_at_module_scope_wrappers_that_reach_themselves(self):
+        # Driven through a real capture, not the pickler: two functools.wraps
+        # helpers bound at module scope and called from one compiled frame is
+        # ordinary code, and the globals snapshot each one carries contains
+        # both of them. Passing that snapshot as a reduce ARG recursed until
+        # RecursionError; it goes in reduce STATE, which pickle applies after
+        # memoizing, so the references resolve to the functions it already
+        # built.
+        def fn(x):
+            return MODULE_SCOPE_WRAPPED_A(x) + MODULE_SCOPE_WRAPPED_B(x)
+
+        x = torch.randn(3)
+        ref, loaded = self._test_serialization("EQUALS_MATCH", fn, x)
+        self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, True)
+
+    def test_reducer_handles_an_empty_cell_reached_directly(self):
+        # _reduce_cell only covers cells it builds for a reconstructed
+        # function. A cell reached directly -- a guarded __closure__ tuple, or
+        # the cell itself -- goes through reducer_override's CellType branch,
+        # which read cell_contents unguarded and raised ValueError out of the
+        # pickler, i.e. a package bypass. Pickler-level because a guard cannot
+        # root at a raw cell through a capture: CLOSURE_MATCH is dropped.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        empty = [
+            c for c in EMPTY_CELL_WRAPPED.__closure__ if not self._cell_has_contents(c)
+        ]
+        self.assertEqual(len(empty), 1)
+        buf = io.BytesIO()
+        GuardsStatePickler({}, {}, {}, buf).dump({"cell": empty[0]})
+        self.assertGreater(len(buf.getvalue()), 0)
+
+    def test_reduce_handles_an_empty_closure_cell(self):
+        # A free variable a decorator only assigns on a path that did not run
+        # has no contents; reading it raised ValueError out of the reducer,
+        # which reaches the caller as a package bypass.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        wrapped = EMPTY_CELL_WRAPPED
+        empty = [c for c in wrapped.__closure__ if not self._cell_has_contents(c)]
+        self.assertEqual(len(empty), 1)
+        gtv = {id(wrapped): wrapped}
+        buf = io.BytesIO()
+        GuardsStatePickler(gtv, {}, {}, buf).dump({"fn": wrapped})
+        self.assertGreater(len(buf.getvalue()), 0)
+
+    @staticmethod
+    def _cell_has_contents(cell):
+        try:
+            cell.cell_contents
+        except ValueError:
+            return False
+        return True
+
+    def test_fqn_mismatched_function_preserves_a_guarded_default_value(self):
+        # The SEQUENCE_LENGTH test pins the defaults TUPLE's length. This pins
+        # that a guarded element's value survives: forcing every default to
+        # _Missing passes that one and fails this one.
+        mod = DecoratedDefaultValueForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_keeps_a_shared_closure_cell_shared(self):
+        # Two functions closing over one variable must still share the cell
+        # after reload; rebuilding every cell silently unshares them.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        def outer():
+            shared = torch.zeros(2)
+
+            def a():
+                return shared
+
+            def b():
+                return shared
+
+            return a, b
+
+        a, b = outer()
+        self.assertIs(a.__closure__[0], b.__closure__[0])
+        buf = io.BytesIO()
+        cell = a.__closure__[0]
+        gtv = {id(a): a, id(b): b, id(cell): cell}
+        pickler = GuardsStatePickler(gtv, {}, {}, buf)
+        pickler.dump({"a": a, "b": b})
+        out = pickle.loads(buf.getvalue())
+        self.assertIs(out["a"].__closure__[0], out["b"].__closure__[0])
+
+    def test_guard_rooted_at_fqn_mismatched_function(self):
+        mod = DecoratedForwardModule()
+        ref, loaded = self._test_serialization("SEQUENCE_LENGTH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_kwdefaults(self):
+        mod = DecoratedKwdefaultsForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_annotations(self):
+        mod = DecoratedAnnotationsForwardModule()
+        ref, loaded = self._test_serialization("SEQUENCE_LENGTH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    @unittest.skipIf(sys.version_info < (3, 12), "requires PEP 695 type parameters")
+    def test_fqn_mismatched_function_preserves_type_params(self):
+        mod = DecoratedTypeParamsForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_type_parameter_reconstruction_preserves_configuration(self):
+        from torch._dynamo.guards import GuardsStatePickler
+
+        values = [
+            typing.TypeVar("Bound", bound=int, covariant=True),
+            typing.TypeVar("Constrained", int, str, contravariant=True),
+            typing.TypeVar("Inferred", infer_variance=True),
+            typing.ParamSpec("Params", bound=typing.Callable[..., object]),
+            typing.TypeVarTuple("Types"),
+        ]
+        if sys.version_info >= (3, 14):
+            values.extend(
+                [
+                    typing.TypeVar("Default", default=int),
+                    typing.ParamSpec("DefaultParams", default=[int, str]),
+                    typing.TypeVarTuple(
+                        "DefaultTypes", default=typing.Unpack[tuple[int, str]]
+                    ),
+                ]
+            )
+
+        buf = io.BytesIO()
+        GuardsStatePickler({}, {}, {}, buf).dump(values)
+        loaded = pickle.loads(buf.getvalue())
+        attributes = (
+            "__name__",
+            "__bound__",
+            "__constraints__",
+            "__covariant__",
+            "__contravariant__",
+            "__infer_variance__",
+            "__default__",
+        )
+        for expected, actual in zip(values, loaded):
+            for attribute in attributes:
+                self.assertEqual(
+                    getattr(actual, attribute, None),
+                    getattr(expected, attribute, None),
+                )
+
+    @unittest.skipIf(sys.version_info < (3, 14), "requires lazy annotations")
+    def test_unguarded_lazy_annotations_are_not_evaluated(self):
+        from torch._dynamo.guards import GuardsStatePickler
+
+        namespace = {"__name__": __name__}
+        source = "def unresolved(x: MissingName):\n    return x + 1\n"
+        exec(
+            compile(source, "<lazy_annotations>", "exec", dont_inherit=True), namespace
+        )
+        fn = namespace["unresolved"]
+        buf = io.BytesIO()
+        GuardsStatePickler({id(fn): fn}, {}, {}, buf).dump(fn)
+        loaded = pickle.loads(buf.getvalue())
+        self.assertEqual(loaded(3), 4)
+
+    def test_fqn_mismatched_function_preserves_attributes(self):
+        mod = DecoratedAttributeForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_name(self):
+        mod = DecoratedNameForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_a_renamed_name(self):
+        # keep_name's __name__ happens to equal co_name, so it passes even if
+        # reconstruction falls back to co_name. This one does not.
+        mod = DecoratedRenamedNameForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self.assertNotEqual(inner.__name__, inner.__code__.co_name)
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_guarded_globals(self):
+        global FQN_MISMATCH_GLOBAL
+
+        mod = DecoratedGlobalForwardModule()
+        x = torch.ones(1)
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, x)
+        inner = type(mod).forward.__wrapped__
+        inputs = {"self": mod, "x": x, "func": inner}
+        self._test_check_fn(ref, loaded, inputs, True)
+
+        try:
+            FQN_MISMATCH_GLOBAL = 3
+            self.assertFalse(ref.check(inputs))
+            guards_state = torch._dynamo.package.load_guards_state(
+                self._cached_guards_state
+            )
+            loaded = torch._dynamo.package.load_guard_manager(
+                guards_state,
+                self._cached_f_code,
+                globals(),
+            )
+            self.assertFalse(loaded.check(inputs))
+        finally:
+            FQN_MISMATCH_GLOBAL = 2
+
+    def test_fqn_mismatched_function_preserves_globals_structure(self):
+        mod = DecoratedGlobalsLengthForwardModule()
+        ref, loaded = self._test_serialization("DICT_KEYS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_prunes_unguarded_defaults(self):
+        mod = DecoratedUnpicklableDefaultForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
 
     def test_tensor_match(self):
         def f(x: torch.Tensor):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1311,8 +1311,9 @@ class GuardBuilder(GuardBuilderBase):
         check_fn_manager: CheckFunctionManager,
         save_guards: bool = False,
         runtime_global_scope: dict[str, object] | None = None,
-        guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
-        | None = None,
+        guard_filter_fn: (
+            Callable[[Sequence[GuardFilterEntry]], Sequence[bool]] | None
+        ) = None,
     ) -> None:
         self.f_code = f_code
         self.id_ref = id_ref
@@ -1637,11 +1638,9 @@ class GuardBuilder(GuardBuilderBase):
     def get_guard_manager_type(
         self,
         source: Source,
-        example_value: KeysView[Any]
-        | set[Any]
-        | frozenset[Any]
-        | dict[Any, Any]
-        | None,
+        example_value: (
+            KeysView[Any] | set[Any] | frozenset[Any] | dict[Any, Any] | None
+        ),
     ) -> GuardManagerType:
         guard_manager_enum = GuardManagerType.GUARD_MANAGER
         if self.requires_key_order_guarding(source):
@@ -4263,9 +4262,241 @@ class GuardsStatePickler(pickle.Pickler):
         qualname: str,
         argdefs: tuple[object, ...] | None,
         closure: tuple[types.CellType, ...] | None,
+        kwdefaults: dict[str, object] | None = None,
+        name: str | None = None,
+        attributes: dict[str, object] | None = None,
+        guarded_globals: dict[str, object] | None = None,
+        snapshot_globals: bool = False,
+        annotations: dict[str, object] | None = None,
+        type_params: tuple[object, ...] | None = None,
     ) -> types.FunctionType:
-        f_globals = importlib.import_module(module).__dict__
-        return types.FunctionType(code, f_globals, qualname, argdefs, closure)
+        if snapshot_globals:
+            # Deliberately no import_module here: the snapshot IS the scope, and
+            # importing a module only to discard it is a load-time failure mode
+            # this branch does not otherwise have.
+            f_globals: dict[str, Any] = dict(guarded_globals or {})
+        else:
+            # NB obj.__module__ is not reliably the module the function LIVES in
+            # -- functools.wraps copies it from the wrapped function -- so this
+            # scope can belong to a different file. It is only reached when no
+            # guard walks __globals__, since one that does registers the dict
+            # and forces the snapshot above.
+            f_globals = importlib.import_module(module).__dict__
+        fn = types.FunctionType(
+            code,
+            f_globals,
+            name if name is not None else code.co_name,
+            argdefs,
+            closure,
+        )
+        fn.__qualname__ = qualname
+        fn.__kwdefaults__ = kwdefaults
+        if type_params is not None:
+            setattr(fn, "__type_params__", type_params)
+        if annotations is not None:
+            fn.__annotations__ = annotations
+        if attributes:
+            fn.__dict__.update(attributes)
+        return fn
+
+    def _keep(self, value: object) -> bool:
+        """Whether a value a reconstructed function holds has to be carried.
+
+        Only values some guard tree node references: everything else becomes a
+        _Missing sentinel, so widening the set of reconstructed functions does
+        not drag unrelated -- and possibly unpicklable -- neighbours into the
+        pickle with them. Matching is by identity, which for an interned value
+        (True, None, a small int, a short str) can coincide with an unrelated
+        guarded one and keep it. That is harmless: such values are trivially
+        picklable, and a kept value is always the real one.
+        """
+        return id(value) in self.guard_tree_values
+
+    def _reduce_cell(self, cell: types.CellType) -> types.CellType:
+        """Carry a closure cell, or replace it with a sentinel one.
+
+        A carried cell is passed through UNCHANGED so that two functions
+        closing over the same variable still share it after reload, and so that
+        pickle can memoize it. Only a dropped cell is rebuilt.
+
+        An EMPTY cell -- a free variable a decorator only assigns on a path that
+        did not run -- has no contents to read at all, so presence is checked
+        before identity. Reading it unconditionally raised ValueError here,
+        which reaches the caller as a package bypass.
+        """
+        try:
+            contents = cell.cell_contents
+        except ValueError:
+            return type(self)._unpickle_cell(_Missing("empty function closure"))
+        if self._keep(cell) or self._keep(contents):
+            return cell
+        return type(self)._unpickle_cell(_Missing("unguarded function closure"))
+
+    @staticmethod
+    def _apply_function_globals(
+        fn: types.FunctionType, guarded_globals: dict[str, object]
+    ) -> None:
+        fn.__globals__.update(guarded_globals)
+
+    @staticmethod
+    def _function_annotations(obj: types.FunctionType) -> dict[str, object]:
+        if sys.version_info >= (3, 14):
+            import annotationlib
+
+            return annotationlib.get_annotations(
+                obj, format=annotationlib.Format.FORWARDREF
+            )
+        return obj.__annotations__
+
+    @staticmethod
+    def _unpickle_type_parameter(
+        kind: str, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> object:
+        import typing
+
+        constructor = getattr(typing, kind)
+        return constructor(*args, **kwargs)
+
+    @staticmethod
+    def _type_parameter_reduce_args(
+        obj: Any, kind: str
+    ) -> tuple[str, tuple[object, ...], dict[str, object]]:
+        import typing
+
+        constraints = getattr(obj, "__constraints__", ())
+        args = (obj.__name__, *constraints)
+        kwargs: dict[str, object] = {}
+        bound = getattr(obj, "__bound__", None)
+        if bound is not None:
+            kwargs["bound"] = bound
+        if kind in ("TypeVar", "ParamSpec"):
+            if obj.__infer_variance__:
+                kwargs["infer_variance"] = True
+            else:
+                kwargs["covariant"] = obj.__covariant__
+                kwargs["contravariant"] = obj.__contravariant__
+        if hasattr(obj, "__default__"):
+            default = obj.__default__
+            if default is not getattr(typing, "NoDefault", None):
+                kwargs["default"] = default
+        return kind, args, kwargs
+
+    def _reduce_nested_function(self, obj: types.FunctionType) -> tuple[Any, ...]:
+        snapshot_globals = id(obj.__globals__) in self.guard_tree_values
+        guarded_globals = (
+            {
+                name: (
+                    value
+                    if self._keep(value)
+                    else _Missing("unguarded function global")
+                )
+                for name, value in obj.__globals__.items()
+            }
+            if snapshot_globals
+            else None
+        )
+
+        defaults = obj.__defaults__
+        if defaults is not None:
+            keep_defaults = self._keep(defaults) or any(
+                self._keep(value) for value in defaults
+            )
+            defaults = (
+                tuple(
+                    (
+                        value
+                        if self._keep(value)
+                        else _Missing("unguarded function default")
+                    )
+                    for value in defaults
+                )
+                if keep_defaults
+                else None
+            )
+
+        kwdefaults = obj.__kwdefaults__
+        if kwdefaults is not None:
+            keep_kwdefaults = self._keep(kwdefaults)
+            kwdefaults = {
+                name: (
+                    value
+                    if self._keep(value)
+                    else _Missing("unguarded function keyword default")
+                )
+                for name, value in kwdefaults.items()
+                if keep_kwdefaults or self._keep(value)
+            }
+            if not kwdefaults and not keep_kwdefaults:
+                kwdefaults = None
+
+        annotations = self._function_annotations(obj)
+        keep_annotations = self._keep(annotations)
+        annotations = {
+            name: (
+                value
+                if self._keep(value)
+                else _Missing("unguarded function annotation")
+            )
+            for name, value in annotations.items()
+            if keep_annotations or self._keep(value)
+        }
+        if not annotations and not keep_annotations:
+            annotations = None
+
+        type_params = getattr(obj, "__type_params__", ())
+        keep_type_params = self._keep(type_params)
+        type_params = tuple(
+            (
+                value
+                if self._keep(value)
+                else _Missing("unguarded function type parameter")
+            )
+            for value in type_params
+        )
+        if not type_params and not keep_type_params:
+            type_params = None
+
+        closure = obj.__closure__
+        if closure is not None:
+            closure = tuple(self._reduce_cell(cell) for cell in closure)
+        attributes = (
+            dict(obj.__dict__)
+            if self._keep(obj.__dict__)
+            else {
+                name: value for name, value in obj.__dict__.items() if self._keep(value)
+            }
+        )
+        args = (
+            obj.__code__,
+            obj.__module__,
+            obj.__qualname__,
+            defaults,
+            closure,
+            kwdefaults,
+            obj.__name__,
+            attributes,
+            None,
+            snapshot_globals,
+            annotations,
+            type_params,
+        )
+        if not snapshot_globals:
+            return type(self)._unpickle_nested_function, args
+        # The snapshot goes in STATE, not in the args. pickle memoizes an object
+        # only after saving its reduce args, so a snapshot passed as an arg that
+        # reaches back to obj -- the ordinary `wrapped = deco(base)` at module
+        # scope, or two functools.wraps helpers referencing each other through
+        # the module dict -- recurses until RecursionError. State is applied
+        # AFTER memoization, so those references resolve to the function pickle
+        # already built.
+        return (
+            type(self)._unpickle_nested_function,
+            args,
+            guarded_globals,
+            None,
+            None,
+            type(self)._apply_function_globals,
+        )
 
     # pyrefly: ignore [bad-override]
     def reducer_override(
@@ -4395,6 +4626,16 @@ class GuardsStatePickler(pickle.Pickler):
         elif isinstance(obj, torch._dynamo.utils.dict_keys):
             return type(self)._unpickle_dict_keys, (list(obj),)
 
+        elif type(obj).__module__ == "typing" and type(obj).__name__ in (
+            "TypeVar",
+            "TypeVarTuple",
+            "ParamSpec",
+        ):
+            return (
+                type(self)._unpickle_type_parameter,
+                type(self)._type_parameter_reduce_args(obj, type(obj).__name__),
+            )
+
         elif isinstance(
             obj, torch._ops.OpOverloadPacket
         ) and obj._qualified_op_name.startswith("_C::"):
@@ -4419,19 +4660,15 @@ class GuardsStatePickler(pickle.Pickler):
 
         elif inspect.isfunction(obj):
             if "<locals>" in obj.__qualname__:
-                return type(self)._unpickle_nested_function, (
-                    obj.__code__,
-                    obj.__module__,
-                    obj.__qualname__,
-                    obj.__defaults__,
-                    obj.__closure__,
-                )
+                return self._reduce_nested_function(obj)
             if obj.__module__ in sys.modules:
                 f = sys.modules[obj.__module__]
                 for name in obj.__qualname__.split("."):
                     f = getattr(f, name, None)  # type: ignore[assignment]
                 if f is not obj:
-                    return _Missing, ("fqn mismatch",)
+                    if id(obj) not in self.guard_tree_values:
+                        return _Missing, ("fqn mismatch",)
+                    return self._reduce_nested_function(obj)
         elif inspect.ismethod(obj):
             func = obj.__func__
             method_self = obj.__self__
@@ -4442,7 +4679,16 @@ class GuardsStatePickler(pickle.Pickler):
                 return type(self)._unpickle_bound_method, (func, method_self)
 
         elif isinstance(obj, type((lambda x: lambda: x)(0).__closure__[0])):  # type: ignore[index] # noqa: PLC3002
-            return type(self)._unpickle_cell, (obj.cell_contents,)
+            # An EMPTY cell -- a free variable only assigned on a path that
+            # did not run -- has nothing to read, and reading it raised
+            # ValueError out of here, which reaches the caller as a package
+            # bypass. _reduce_cell handles the cells it builds; this is the
+            # path a cell reached directly takes.
+            try:
+                contents = obj.cell_contents
+            except ValueError:
+                contents = _Missing("empty function closure")
+            return type(self)._unpickle_cell, (contents,)
 
         if hasattr(torch.distributed, "distributed_c10d") and isinstance(
             obj, torch.distributed.distributed_c10d.Work
@@ -4551,8 +4797,20 @@ def pickle_guards_state(
 
     try:
         pickler.dump(state)
-    except AttributeError as e:
-        raise torch._dynamo.exc.PackageError(str(e)) from e
+    except torch._dynamo.exc.PackageError:
+        raise
+    except Exception as e:
+        # Deliberately broad, including AssertionError. It is tempting to let
+        # that one through as "our bug", but it is not ours to claim:
+        # GradScaler.__getstate__ asserts when pickled mid-iteration, tensor
+        # subclasses assert in __tensor_flatten__, and any user assert in a
+        # __reduce__ or a property lands here. Propagating those turns a
+        # serialization limitation into a hard torch.compile failure for a
+        # program that has nothing wrong with it.
+        # The caller turns PackageError into a package bypass, or re-raises it
+        # under strict_precompile. Name the original type so the reason stays
+        # diagnosable in the bypass message.
+        raise torch._dynamo.exc.PackageError(f"{type(e).__name__}: {e}") from e
     return buf.getvalue()
 
 
@@ -4568,8 +4826,9 @@ class CheckFunctionManager:
         output_graph: OutputGraphCommon,
         cache_entries: list[CacheEntry] | None = None,
         guard_fail_fn: Callable[[GuardFail], None] | None = None,
-        guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
-        | None = None,
+        guard_filter_fn: (
+            Callable[[Sequence[GuardFilterEntry]], Sequence[bool]] | None
+        ) = None,
         shape_code_parts: ShapeCodeParts | None = None,
         runtime_global_scope: dict[str, Any] | None = None,
         save_guards: bool = False,
@@ -4929,8 +5188,9 @@ class CheckFunctionManager:
         f_code: types.CodeType,
         output_graph: OutputGraphGuardsState,
         save_guards: bool,
-        guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
-        | None = None,
+        guard_filter_fn: (
+            Callable[[Sequence[GuardFilterEntry]], Sequence[bool]] | None
+        ) = None,
     ) -> tuple[GuardBuilder, GuardManagerWrapper]:
         guard_manager = GuardManagerWrapper(local_state=self.guard_build_local_state)
         guard_manager.diff_guard_sources = existing_diff_guard_sources


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Make guard serialization handle functions whose `__module__` and `__qualname__` do not resolve back to the same object, as commonly produced by `functools.wraps`. Reconstruct only guard-reachable functions and preserve only guard-reachable function state, including globals, defaults, closures, annotations, type parameters, names, and attributes. This keeps guards correct without pulling unrelated or unpicklable state into the package.

Differential Revision: [D116222522](https://our.internmc.facebook.com/intern/diff/D116222522/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98