### PR TITLE
[torchTLX] tri-state knob with a build-supplied default and a JustKnob override (#193873)

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1923,15 +1923,63 @@ class cpp:
     use_two_step_variance_threshold = 1024
 
 
-def tlx_mode_from_env() -> Literal["allow", "force"] | None:
-    # Only the explicit values "allow"/"force" enable torchTLX. Any other
-    # value -- unset, empty, a typo, or a legacy "default" -- maps to None so
-    # TLX stays off. See the "Knob" section of the torchTLX README under
-    # third-party/triton/.../tlx/language/tlx/inductor/README.md.
+def tlx_mode_default() -> Literal["allow", "force"] | None:
+    """Resolve torchTLX engagement, highest precedence first.
+
+    1. ``TORCHINDUCTOR_TLX_MODE``: "off", "allow" or "force". Unset is a
+       no-op. Any other value raises, so a typo fails loudly rather than
+       silently leaving TLX in whatever state the fleet is in.
+    2. ``pytorch/inductor:tlx_mode``, the fleet-wide rollout and killswitch:
+       1 off, 2 allow, 3 force. 0 is a no-op, and is also what
+       justknobs_getval_int reports for a knob that does not exist, an
+       unreachable JK, and PYTORCH_DISABLE_JUSTKNOBS -- hence a no-op rather
+       than a fleet-wide decision taken on absent information.
+    3. ``DEFAULT_MODE`` from the active Triton, which is where the TLX
+       templates live. Installing a Triton that ships the integration is
+       itself the opt-in; one that does not -- upstream OAI Triton -- has no
+       say and TLX stays off.
+
+    No fbcode gate is needed: outside fbcode the JustKnob stub reports 0,
+    which is already a no-op.
+
+    Off is spelled None rather than "off": get_hash() hashes every
+    non-compile-ignored config at its resolved value, so giving the off state
+    a new spelling would change the key for every Inductor process, TLX or
+    not, and invalidate the FX graph cache fleet-wide.
+    """
+    off_allow_force: tuple[Literal["allow", "force"] | None, ...] = (
+        None,
+        "allow",
+        "force",
+    )
+    env_modes = dict(zip(("off", "allow", "force"), off_allow_force))
+    # "default" was the documented spelling of off before this knob grew a
+    # JustKnob and a build default; keep honoring it so a job that still sets
+    # it does not die inside `import torch._inductor.config`.
+    env_modes["default"] = None
+
     mode = os.environ.get("TORCHINDUCTOR_TLX_MODE")
-    if mode in ("allow", "force"):
-        return cast("Literal['allow', 'force']", mode)
-    return None
+    if mode is not None:
+        if mode not in env_modes:
+            raise ValueError(
+                f"TORCHINDUCTOR_TLX_MODE={mode!r} is not one of {tuple(env_modes)}"
+            )
+        return env_modes[mode]
+
+    # JustKnob values 1/2/3 index off/allow/force; 0 falls through.
+    jk = torch._utils_internal.justknobs_getval_int("pytorch/inductor:tlx_mode")
+    if 1 <= jk <= len(off_allow_force):
+        return off_allow_force[jk - 1]
+
+    # A Triton that does not ship torchTLX has no default, so TLX stays off.
+    # Deliberately a module directly under `triton` rather than anything in
+    # triton.language.extra.tlx: that package eagerly imports the whole TLX
+    # DSL, and this runs in every Inductor process, GPU or not.
+    try:
+        from triton._torchtlx_default import DEFAULT_MODE
+    except ImportError:
+        return None
+    return DEFAULT_MODE
 
 
 class triton:
@@ -1939,12 +1987,12 @@ class triton:
     Config specific to codegen/triton.py
     """
 
-    # torchTLX enablement. None (the default) means TLX is never considered
-    # (standard Inductor behavior); "allow" lets TLX compete via autotuning;
-    # "force" uses only TLX templates plus forced epilogue fusion. Also a
-    # no-op unless the active Triton is the fbtriton fork (the integration
-    # import in template_heuristics/tlx.py fails cleanly otherwise).
-    tlx_mode: Literal["allow", "force"] | None = tlx_mode_from_env()
+    # torchTLX enablement. None (off) means TLX is never considered (standard
+    # Inductor behavior); "allow" lets TLX compete via autotuning; "force"
+    # uses only TLX templates plus forced epilogue fusion. Also a no-op
+    # unless the active Triton ships the integration (the import in
+    # heuristics/template/tlx.py fails cleanly otherwise).
+    tlx_mode: Literal["allow", "force"] | None = tlx_mode_default()
 
     # Use cudagraphs on output code
     cudagraphs = os.environ.get("TORCHINDUCTOR_CUDAGRAPHS") == "1"

--- a/torch/_inductor/heuristics/template/tlx.py
+++ b/torch/_inductor/heuristics/template/tlx.py
@@ -1,10 +1,28 @@
-# TorchTLX lives in the fbtriton, not in
-# PyTorch. Importing the integration registers TLX template heuristics and
-# installs config.inductor_choices_class; it succeeds only when the active
-# Triton is the fbtriton fork
-# and fails cleanly on trunk triton. Actual engagement is
-# still gated at runtime by TORCHINDUCTOR_TLX_MODE (config.triton.tlx_mode).
-try:
-    import triton.language.extra.tlx.inductor.registry  # noqa: F401  # type: ignore[import-not-used]
-except ImportError:
-    pass
+# TorchTLX lives in fbtriton, not in PyTorch. Importing the integration
+# registers the TLX template heuristics and installs
+# config.inductor_choices_class; it succeeds only when the active Triton ships
+# the integration, and fails cleanly on one that does not.
+#
+# Deferred rather than done at module import: the integration monkey-patches
+# TritonTemplate / TritonTemplateKernel and replaces inductor_choices_class,
+# and none of that belongs in a process that will never engage TLX.
+# virtualized._choices_default() calls maybe_install() on first use.
+
+import functools
+
+
+@functools.cache
+def _install() -> None:
+    try:
+        import triton.language.extra.tlx.inductor.registry  # noqa: F401  # type: ignore[import-not-used]
+    except ImportError:
+        pass
+
+
+def maybe_install() -> None:
+    from torch._inductor import config
+
+    # Mode is re-read every call rather than cached with _install: tests flip
+    # it with config.patch after the first choices handler already exists.
+    if config.triton.tlx_mode is not None:
+        _install()

--- a/torch/_inductor/virtualized.py
+++ b/torch/_inductor/virtualized.py
@@ -256,6 +256,11 @@ def _choices_default():
     """
     from torch._inductor import config
     from torch._inductor.choices import InductorChoices
+    from torch._inductor.heuristics.template import tlx
+
+    # Has to precede the inductor_choices_class read: installing the torchTLX
+    # integration is what sets it.
+    tlx.maybe_install()
 
     if config.inductor_choices_class is not None:
         rv = config.inductor_choices_class()


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookexperimental/triton/pull/2879

Refine torchTLX knob system
- env var `TORCHINDUCTOR_TLX_MODE`: off / allow / force; unset defers; anything else raises ValueError
- pytorch/inductor:tlx_mode (int JK): 0 no-op, 1 off, 2 allow, 3 force
- DEFAULT_MODE in the active Triton's tlx_config.py

```
        cases = (
            # (env, jk, DEFAULT_MODE, expected)
            ("allow", 1, None, "allow"),
            ("force", 2, None, "force"),
            ("off", 2, "allow", None),
            # No env var: the knob overrides the build default.
            (None, 1, "allow", None),
            (None, 2, None, "allow"),
            (None, 3, None, "force"),
            # jk == 0 is a no-op, which is also what a missing knob or an
            # unreachable JK returns: fall back to the build default.
            (None, 0, "allow", "allow"),
            (None, 0, None, None),
        )
```

Test Plan:
`buck2 test fbcode//caffe2/test/inductor/fb/tlx:test_tlx_config`

https://www.internalfb.com/intern/testinfra/testconsole/testrun/12384899165649998/

Reviewed By: htyu

Differential Revision: D116383493




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo