### PR TITLE
c10d: stop noisy warning on the renamed public collective aliases

### DIFF
--- a/test/distributed/test_c10d_collectives.py
+++ b/test/distributed/test_c10d_collectives.py
@@ -304,7 +304,7 @@ class AbstractCollectivesTest(C10dBackendTest):
             with self.assertRaises((RuntimeError, ValueError)):
                 dist.gather_single(input, output, dst=0)
 
-    def test_gather_into_tensor_deprecated(self):
+    def test_gather_into_tensor(self):
         if not self.supports_gather_single:
             self.skipTest(f"{self.backend_name} does not support gather_single")
         self._init_pg()
@@ -314,8 +314,7 @@ class AbstractCollectivesTest(C10dBackendTest):
             if self.rank == 0
             else None
         )
-        with self.assertWarnsRegex(FutureWarning, "gather_into_tensor` is deprecated"):
-            dist.gather_into_tensor(tensor, output, dst=0)
+        dist.gather_into_tensor(tensor, output, dst=0)
         if self.rank == 0:
             expected = torch.cat(
                 [

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -3024,7 +3024,6 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
             dist.all_reduce,
             dist.reduce_scatter,
             dist.reduce_scatter_single,
-            # pyrefly: ignore [deprecated]
             dist.reduce_scatter_tensor,
             # pyrefly: ignore [deprecated]
             dist._reduce_scatter_base,

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -5333,11 +5333,6 @@ def all_gather_single(
 
 
 @_exception_logger
-@deprecated(
-    "`torch.distributed.all_gather_into_tensor` is deprecated. "
-    "Please use `torch.distributed.all_gather_single` instead.",
-    category=FutureWarning,
-)
 def all_gather_into_tensor(
     output_tensor: torch.Tensor,
     input_tensor: torch.Tensor,
@@ -5347,9 +5342,8 @@ def all_gather_into_tensor(
     """
     Gather tensors from all ranks and put them in a single output tensor.
 
-    .. warning::
-        `all_gather_into_tensor` is deprecated. Users should use
-        `all_gather_single` instead.
+    Alias of :func:`all_gather_single`, kept for backward compatibility. New
+    code should call :func:`all_gather_single`, which takes the same arguments.
 
     """
     return all_gather_single(output_tensor, input_tensor, group, async_op)
@@ -5730,11 +5724,6 @@ def gather_single(
 
 
 @_exception_logger
-@deprecated(
-    "`torch.distributed.gather_into_tensor` is deprecated. "
-    "Please use `torch.distributed.gather_single` instead.",
-    category=FutureWarning,
-)
 def gather_into_tensor(
     tensor: torch.Tensor,
     gather_tensor: torch.Tensor | None = None,
@@ -5746,9 +5735,8 @@ def gather_into_tensor(
     """
     Gather the input tensor from all ranks into a single output tensor on ``dst``.
 
-    .. warning::
-        `gather_into_tensor` is deprecated. Users should use `gather_single`
-        instead.
+    Alias of :func:`gather_single`, kept for backward compatibility. New code
+    should call :func:`gather_single`, which takes the same arguments.
 
     """
     return gather_single(tensor, gather_tensor, dst, group, async_op, group_dst)
@@ -6086,11 +6074,6 @@ def reduce_scatter_single(
 
 
 @_exception_logger
-@deprecated(
-    "`torch.distributed.reduce_scatter_tensor` is deprecated. "
-    "Please use `torch.distributed.reduce_scatter_single` instead.",
-    category=FutureWarning,
-)
 def reduce_scatter_tensor(
     output: torch.Tensor,
     input: torch.Tensor,
@@ -6101,9 +6084,9 @@ def reduce_scatter_tensor(
     """
     Reduces, then scatters a tensor to all ranks in a group.
 
-    .. warning::
-        `reduce_scatter_tensor` is deprecated. Users should use
-        `reduce_scatter_single` instead.
+    Alias of :func:`reduce_scatter_single`, kept for backward compatibility.
+    New code should call :func:`reduce_scatter_single`, which takes the same
+    arguments.
 
     """
     return reduce_scatter_single(output, input, op, group, async_op)


### PR DESCRIPTION
`all_gather_into_tensor`, `gather_into_tensor` and `reduce_scatter_tensor` became one-line aliases when the collectives were renamed to the *_single scheme (#186123), and were marked `@deprecated`. However, marking these deprecated is resulting in noisy logs for users. 

In this PR, we keep the aliases, drop the warning, and move the guidance to the docstring. The private `_all_gather_base` and `_reduce_scatter_base` aliases keep `@deprecated` for a private API the warning is the only signal that the caller is reaching into internals.

Test Plan:

```
python test/distributed/test_c10d_collectives.py -k Gloo
# Ran 31 tests - OK (skipped=10, CUDA-gated)

python test/distributed/test_c10d_collectives.py -k NcclLegacy
# Ran 31 tests - 1 error in test_complex_collectives, which fails identically
# on a clean tree (nvrtc: failed to open libnvrtc-builtins.so.13.0)

python test/distributed/test_fake_pg.py
# Ran 74 tests - OK; output confirms _reduce_scatter_base still warns while
# the public aliases are silent
```

Also confirmed manually against a single-rank gloo group that repeated calls to the three public aliases emit no warnings and return correct results, and that both private aliases still raise FutureWarning.

Authored with assistance from Claude Code (AI).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98