### PR TITLE
[Testcase Refactoring] Add hw-classification in util_test

### DIFF
--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -14,8 +14,11 @@ from unittest import mock
 import torch.distributed as dist
 import torch.distributed.elastic.utils.store as store_util
 from torch.distributed.elastic.utils.logging import get_logger
-from torch.testing._internal.common_utils import run_tests, TestCase
-
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 class MockStore:
     _TEST_TIMEOUT = 1234
@@ -52,6 +55,8 @@ class MockStore:
 
 
 class StoreUtilTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_all_rank_0(self):
         world_size = 3
 
@@ -251,6 +256,8 @@ class StoreUtilTest(TestCase):
 
 
 class UtilTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_logger_different(self):
         logger1 = get_logger("name1")
         logger2 = get_logger("name2")

--- a/test/distributed/elastic/utils/util_test.py
+++ b/test/distributed/elastic/utils/util_test.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 
+
 class MockStore:
     _TEST_TIMEOUT = 1234
 


### PR DESCRIPTION
## Summary

Tags `StoreUtilTest` and `UtilTest` in
`test/distributed/elastic/utils/util_test.py` with
`hw_classification = HardwareClassification.GENERIC` so both classes can be
selected by the `--hw-classification` test filter. Both classes are bare
`TestCase` subclasses exercising CPU-only distributed-store and logger
helpers, with no device parameter and no `instantiate_device_type_tests`, so
`GENERIC` is the correct category for each.

## Changes

- `test/distributed/elastic/utils/util_test.py`: added `HardwareClassification`
  to the `torch.testing._internal.common_utils` import block (converted from
  single-line to multi-line, alphabetical order — `HardwareClassification`
  before `run_tests` before `TestCase`).
- `test/distributed/elastic/utils/util_test.py`: declared
  `hw_classification = HardwareClassification.GENERIC` as a class attribute
  on `StoreUtilTest`, placed immediately after the class header and before
  `test_get_all_rank_0`.
- `test/distributed/elastic/utils/util_test.py`: declared the same
  `hw_classification = HardwareClassification.GENERIC` class attribute on
  `UtilTest`, placed immediately after the class header and before
  `test_get_logger_different`.


## Motivation

PyTorch's test suite recently introduced the `HardwareClassification`
mechanism (see `torch/testing/_internal/common_utils.py`), which allows
filtering test classes by hardware category (`GENERIC`, `ACCELERATOR`,
`CPU`, `CUDA`, `MPS`, `XPU`) via the `--hw-classification` CLI flag. Test
classes that do not declare a `hw_classification` attribute are excluded
when the filter is used, so they cannot run in hardware-partitioned CI
workflows.

Both classes in this file fit the `GENERIC` definition ("tests that exercise
shared, device-agnostic logic ... typically do not use
`instantiate_device_type_tests`"):

- `StoreUtilTest` (8 tests) exercises `store_util.get_all`, `synchronize`,
  and `barrier` against `MockStore` and `dist.HashStore` with `ThreadPool`
  — pure store semantics, no tensor or device code.
- `UtilTest` (4 tests) exercises `get_logger()` name resolution — pure
  string/object identity checks, no device code.

Tagging them `GENERIC` brings them into the new filtering workflow without
altering test behavior.

## Test plan

- Run the test file:
 python test/distributed/elastic/utils/utils_test.py , 12 testcases pass
