### PR TITLE
Fix BatchNorm1d crash on unsupported dtypes with empty input

### DIFF
--- a/aten/src/ATen/AccumulateType.cpp
+++ b/aten/src/ATen/AccumulateType.cpp
@@ -20,7 +20,7 @@ c10::ScalarType toAccumulateType(c10::ScalarType type, c10::DeviceType device) {
     AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_EXCEPT_COMPLEX_HALF_F8NZ(DEFINE_CASE)
 #undef DEFINE_CASE
 
-    default: TORCH_INTERNAL_ASSERT(false, "Unrecognized ScalarType: ", type);
+    default: TORCH_CHECK_NOT_IMPLEMENTED(false, "toAccumulateType not implemented for '", type, "'");
   }
 }
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5149,6 +5149,11 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaises(ValueError):
             torch.nn.BatchNorm1d(10)(x)
 
+    def test_batchnorm_raises_error_for_unsupported_dtype_on_empty_input(self):
+        # https://github.com/pytorch/pytorch/issues/193825
+        with self.assertRaisesRegex(NotImplementedError, "not implemented for"):
+            torch.nn.BatchNorm1d(1)(torch.zeros(2, 0, dtype=torch.complex32))
+
     def test_batchnorm_raises_error_if_running_mean_is_not_same_size_as_input(self):
         input = torch.rand(2, 10)
         running_var = torch.rand(10)


### PR DESCRIPTION
## Summary

`torch.nn.BatchNorm1d(1)(torch.zeros(2, 0, dtype=torch.complex32))` crashes with an internal assert instead of a normal error:

```
false INTERNAL ASSERT FAILED at "aten/src/ATen/AccumulateType.cpp":23,
please report a bug to PyTorch. Unrecognized ScalarType: ComplexHalf
```

**Why:** BatchNorm has a fast path for empty (zero-element) inputs that skips the usual dtype-checking dispatch machinery. It calls `toAccumulateType()` directly, and that function's fallback case uses `TORCH_INTERNAL_ASSERT` — a macro meant for "this can never happen," even though any unsupported dtype (like `complex32`) can reach it. Non-empty inputs don't hit this fast path, which is why they already fail cleanly with a normal `NotImplementedError`.

**Fix:** Change that fallback in `AccumulateType.cpp` to raise `NotImplementedError` instead of crashing, matching the error non-empty inputs already get. One line, fixes it for every caller of `toAccumulateType`, not just BatchNorm.

Fixes #193825

## Test plan

The issue's repro now raises a normal error instead of crashing:

```python
import torch
torch.nn.BatchNorm1d(1)(torch.zeros(2, 0, dtype=torch.complex32))
# NotImplementedError: toAccumulateType not implemented for 'ComplexHalf'
```

Added a regression test (`test_batchnorm_raises_error_for_unsupported_dtype_on_empty_input` in `test/test_nn.py`) and ran it along with the related BatchNorm tests:

```
python test/test_nn.py -k test_batchnorm_raises_error_for_unsupported_dtype_on_empty_input -v
python test/test_nn.py -k batchnorm -v   # full sweep, 106 tests, all pass
```

`lintrunner -a` is clean on both changed files.

This PR was authored with AI assistance (Claude Code): the root cause was identified via source-level tracing and confirmed against a from-source build; I reviewed the diagnosis and patch end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)