### PR TITLE
[NN] Validate LSTMCell hidden state format

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2570,6 +2570,18 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
 
+    def test_LSTM_cell_forward_hidden_state_format(self):
+        input = torch.randn(3)
+        hidden = torch.zeros(3)
+        lstm = nn.LSTMCell(3, 3)
+
+        with self.assertRaisesRegex(TypeError, "Expected hx to be a tuple"):
+            lstm(input, torch.zeros(2, 3, 3))
+
+        for hx in ((hidden,), (hidden, hidden, hidden)):
+            with self.assertRaisesRegex(ValueError, "Expected hx to contain two tensors"):
+                lstm(input, hx)
+
 
     def test_Transformer_cell(self):
         # this is just a smoke test; these modules are implemented through

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1737,6 +1737,12 @@ class LSTMCell(RNNCellBase):
                 f"LSTMCell: Expected input to be 1D or 2D, got {input.dim()}D instead"
             )
         if hx is not None:
+            if not isinstance(hx, tuple):
+                raise TypeError("LSTMCell: Expected hx to be a tuple of two tensors")
+            if len(hx) != 2:
+                raise ValueError(
+                    f"LSTMCell: Expected hx to contain two tensors, got {len(hx)}"
+                )
             for idx, value in enumerate(hx):
                 if value.dim() not in (1, 2):
                     raise ValueError(


### PR DESCRIPTION
I reviewed the implementation and test results. Codex helped prepare the
contained summary below; it accurately describes the change.

> ## Issue
>
> Fixes #193823
>
> ## Summary
>
> Validate that `LSTMCell` receives a tuple containing exactly two hidden-state
> tensors before inspecting their dimensions or calling the native operator.
> This prevents malformed tensor input from reaching `_VF.lstm_cell` and
> terminating the process.
>
> ## Checklist
>
> - [x] Passes targeted RUFF lint
> - [x] Added regression tests
> - [ ] Updated documentation (not applicable)
> - [ ] Included benchmark results (not applicable)
>
> ## BC-breaking?
>
> No. Inputs outside the documented `(hx, cx)` format now raise a Python
> exception instead of crashing the process.
