### PR TITLE
[Inductor] Add device-dispatched graph benchmark hooks

### DIFF
--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -227,6 +227,165 @@ class TestBenchmarker(TestCase):
             _bench._BENCHMARK_DISPATCH.clear()
             _bench._BENCHMARK_DISPATCH.update(orig)
 
+    def test_graph_benchmarker_dispatch_and_restore(self):
+        from torch._inductor.runtime import benchmarking as _bench
+
+        original = dict(_bench._GRAPH_BENCHMARK_DISPATCH)
+        calls = []
+
+        def custom_graph(self, fn, *, device_type, grad_to_none=None, **kwargs):
+            calls.append((device_type, grad_to_none, kwargs))
+            return 4.0
+
+        try:
+            _bench.register_graph_benchmarker("cpu", custom_graph, override=True)
+            result = Benchmarker().benchmark_gpu_with_graph(
+                lambda: None,
+                device="cpu",
+                sample=True,
+            )
+        finally:
+            _bench._GRAPH_BENCHMARK_DISPATCH.clear()
+            _bench._GRAPH_BENCHMARK_DISPATCH.update(original)
+
+        self.assertEqual(result, 4.0)
+        self.assertEqual(calls, [("cpu", None, {"sample": True})])
+
+    def test_graph_benchmarker_rejects_unregistered_device(self):
+        from torch._inductor.runtime import benchmarking as _bench
+
+        original = dict(_bench._GRAPH_BENCHMARK_DISPATCH)
+        try:
+            _bench._GRAPH_BENCHMARK_DISPATCH.clear()
+            with self.assertRaisesRegex(
+                RuntimeError, "No graph benchmarker registered for device_type 'xpu'"
+            ):
+                Benchmarker().benchmark_gpu_with_graph(
+                    lambda: None,
+                    device="xpu",
+                )
+        finally:
+            _bench._GRAPH_BENCHMARK_DISPATCH.clear()
+            _bench._GRAPH_BENCHMARK_DISPATCH.update(original)
+
+    def test_cuda_graph_compatibility_handler_preserves_old_call(self):
+        calls = []
+
+        class FakeBenchmarker(Benchmarker):
+            def benchmark_gpu_with_cuda_graph(self, fn, **kwargs):
+                calls.append(kwargs)
+                return 5.0
+
+        result = FakeBenchmarker().benchmark_gpu_with_graph(
+            lambda: None,
+            device="cuda",
+            estimation_iters=2,
+        )
+
+        self.assertEqual(result, 5.0)
+        self.assertEqual(calls, [{"grad_to_none": None, "estimation_iters": 2}])
+
+    def test_benchmark_request_propagates_inferred_graph_device(self):
+        from torch._inductor import autotune_process
+
+        class Request(autotune_process.BenchmarkRequest):
+            def make_run_fn(self, *args, out):
+                return lambda: None
+
+            def cleanup_run_fn(self):
+                pass
+
+            def do_bench(self, fn, *args, out=None):
+                raise AssertionError("graph benchmark path should be used")
+
+        request = Request("test", [], [], ())
+        request.benchmark_with_cudagraphs = True
+        input_tensor = torch.randn(2)
+        output_tensor = torch.randn(2)
+        with (
+            patch.object(
+                autotune_process.benchmarker, "infer_device", return_value="xpu"
+            ) as infer,
+            patch.object(
+                autotune_process.benchmarker,
+                "benchmark_gpu_with_graph",
+                return_value=1.0,
+            ) as benchmark,
+        ):
+            self.assertEqual(request.benchmark(input_tensor, out=output_tensor), 1.0)
+        infer.assert_called_once_with(input_tensor, output_tensor)
+        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+
+    def test_extern_kernel_request_propagates_inferred_graph_device(self):
+        from torch._inductor import autotune_process
+
+        request = object.__new__(autotune_process.ExternKernelBenchmarkRequest)
+        request.has_out_variant = False
+        request.benchmark_with_cudagraphs = True
+        request.to_callable = lambda: (lambda tensor: tensor)
+        input_tensor = torch.randn(2)
+        output_tensor = torch.empty(2)
+        with (
+            patch.object(
+                autotune_process.benchmarker, "infer_device", return_value="xpu"
+            ) as infer,
+            patch.object(
+                autotune_process.benchmarker,
+                "benchmark_gpu_with_graph",
+                return_value=2.0,
+            ) as benchmark,
+        ):
+            self.assertEqual(request.benchmark(input_tensor, out=output_tensor), 2.0)
+        infer.assert_called_once_with(input_tensor, output_tensor)
+        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+
+    def test_subgraph_choice_caller_propagates_inferred_graph_device(self):
+        from torch._inductor.codegen import subgraph
+
+        request = object.__new__(subgraph.SubgraphChoiceCaller)
+        request._benchmark_with_cudagraphs = True
+        sym_input = torch.randn(2)
+        arg = torch.randn(2)
+        request.sym_input_values = [sym_input]
+        request._compiled_module = type(
+            "Compiled", (), {"call": lambda self, args: None}
+        )()
+        request._ensure_compiled = lambda: None
+        output_tensor = torch.empty(2)
+        with (
+            patch.object(
+                subgraph.benchmarker, "infer_device", return_value="xpu"
+            ) as infer,
+            patch.object(
+                subgraph.benchmarker,
+                "benchmark_gpu_with_graph",
+                return_value=4.0,
+            ) as benchmark,
+        ):
+            self.assertEqual(request.benchmark(arg, out=output_tensor), 4.0)
+        infer.assert_called_once_with(sym_input, arg, output_tensor)
+        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+
+    def test_choice_caller_propagates_inferred_graph_device(self):
+        from torch._inductor import ir
+
+        request = object.__new__(ir.ChoiceCaller)
+        request._benchmark_with_cudagraphs = True
+        request.to_callable = lambda: (lambda tensor: tensor)
+        input_tensor = torch.randn(2)
+        output_tensor = torch.empty(2)
+        with (
+            patch.object(ir.benchmarker, "infer_device", return_value="xpu") as infer,
+            patch.object(
+                ir.benchmarker,
+                "benchmark_gpu_with_graph",
+                return_value=5.0,
+            ) as benchmark,
+        ):
+            self.assertEqual(request.benchmark(input_tensor, out=output_tensor), 5.0)
+        infer.assert_called_once_with(input_tensor, output_tensor)
+        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+
     def test_default_profiler_benchmarker_selection_supports_xpu_only(self):
         from torch._inductor.runtime import benchmarking as _bench
 

--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -285,6 +285,55 @@ class TestBenchmarker(TestCase):
         self.assertEqual(result, 5.0)
         self.assertEqual(calls, [{"grad_to_none": None, "estimation_iters": 2}])
 
+    def test_has_graph_benchmarker(self):
+        from torch._inductor.runtime import benchmarking as _bench
+
+        original = dict(_bench._GRAPH_BENCHMARK_DISPATCH)
+        try:
+            _bench._GRAPH_BENCHMARK_DISPATCH.clear()
+            self.assertFalse(_bench.has_graph_benchmarker("xpu"))
+            _bench.register_graph_benchmarker("cpu", lambda *args, **kwargs: 1.0)
+            self.assertTrue(_bench.has_graph_benchmarker(torch.device("cpu")))
+        finally:
+            _bench._GRAPH_BENCHMARK_DISPATCH.clear()
+            _bench._GRAPH_BENCHMARK_DISPATCH.update(original)
+
+    def test_unregistered_xpu_uses_regular_benchmark(self):
+        from torch._inductor import autotune_process
+
+        class Request(autotune_process.BenchmarkRequest):
+            def make_run_fn(self, *args, out):
+                return lambda: None
+
+            def cleanup_run_fn(self):
+                pass
+
+            def do_bench(self, fn, *args, out=None):
+                return 6.0
+
+        request = Request("test", [], [], ())
+        request.benchmark_with_cudagraphs = True
+        input_tensor = torch.randn(2)
+        output_tensor = torch.randn(2)
+        with (
+            patch.object(
+                autotune_process.benchmarker,
+                "infer_device",
+                return_value=torch.device("xpu"),
+            ),
+            patch.object(
+                autotune_process.benchmarker,
+                "benchmark_gpu_with_graph",
+            ) as graph_benchmark,
+        ):
+            self.assertFalse(
+                autotune_process.has_graph_benchmarker(torch.device("xpu"))
+            )
+            result = request.benchmark(input_tensor, out=output_tensor)
+
+        self.assertEqual(result, 6.0)
+        graph_benchmark.assert_not_called()
+
     def test_benchmark_request_propagates_inferred_graph_device(self):
         from torch._inductor import autotune_process
 
@@ -304,8 +353,11 @@ class TestBenchmarker(TestCase):
         output_tensor = torch.randn(2)
         with (
             patch.object(
-                autotune_process.benchmarker, "infer_device", return_value="xpu"
+                autotune_process.benchmarker,
+                "infer_device",
+                return_value=torch.device("privateuseone"),
             ) as infer,
+            patch.object(autotune_process, "has_graph_benchmarker", return_value=True),
             patch.object(
                 autotune_process.benchmarker,
                 "benchmark_gpu_with_graph",
@@ -314,7 +366,9 @@ class TestBenchmarker(TestCase):
         ):
             self.assertEqual(request.benchmark(input_tensor, out=output_tensor), 1.0)
         infer.assert_called_once_with(input_tensor, output_tensor)
-        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+        self.assertEqual(
+            benchmark.call_args.kwargs["device"], torch.device("privateuseone")
+        )
 
     def test_extern_kernel_request_propagates_inferred_graph_device(self):
         from torch._inductor import autotune_process
@@ -327,8 +381,11 @@ class TestBenchmarker(TestCase):
         output_tensor = torch.empty(2)
         with (
             patch.object(
-                autotune_process.benchmarker, "infer_device", return_value="xpu"
+                autotune_process.benchmarker,
+                "infer_device",
+                return_value=torch.device("privateuseone"),
             ) as infer,
+            patch.object(autotune_process, "has_graph_benchmarker", return_value=True),
             patch.object(
                 autotune_process.benchmarker,
                 "benchmark_gpu_with_graph",
@@ -339,7 +396,9 @@ class TestBenchmarker(TestCase):
         self.assertEqual(infer.call_count, 1)
         self.assertIs(infer.call_args.args[0], input_tensor)
         self.assertIs(infer.call_args.args[1], input_tensor)
-        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+        self.assertEqual(
+            benchmark.call_args.kwargs["device"], torch.device("privateuseone")
+        )
 
     def test_subgraph_choice_caller_propagates_inferred_graph_device(self):
         from torch._inductor.codegen import subgraph
@@ -356,8 +415,11 @@ class TestBenchmarker(TestCase):
         output_tensor = torch.empty(2)
         with (
             patch.object(
-                subgraph.benchmarker, "infer_device", return_value="xpu"
+                subgraph.benchmarker,
+                "infer_device",
+                return_value=torch.device("privateuseone"),
             ) as infer,
+            patch.object(subgraph, "has_graph_benchmarker", return_value=True),
             patch.object(
                 subgraph.benchmarker,
                 "benchmark_gpu_with_graph",
@@ -366,7 +428,9 @@ class TestBenchmarker(TestCase):
         ):
             self.assertEqual(request.benchmark(arg, out=output_tensor), 4.0)
         infer.assert_called_once_with(sym_input, arg, output_tensor)
-        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+        self.assertEqual(
+            benchmark.call_args.kwargs["device"], torch.device("privateuseone")
+        )
 
     def test_choice_caller_propagates_inferred_graph_device(self):
         from torch._inductor import ir
@@ -377,7 +441,12 @@ class TestBenchmarker(TestCase):
         input_tensor = torch.randn(2)
         output_tensor = torch.empty(2)
         with (
-            patch.object(ir.benchmarker, "infer_device", return_value="xpu") as infer,
+            patch.object(
+                ir.benchmarker,
+                "infer_device",
+                return_value=torch.device("privateuseone"),
+            ) as infer,
+            patch.object(ir, "has_graph_benchmarker", return_value=True),
             patch.object(
                 ir.benchmarker,
                 "benchmark_gpu_with_graph",
@@ -386,7 +455,9 @@ class TestBenchmarker(TestCase):
         ):
             self.assertEqual(request.benchmark(input_tensor, out=output_tensor), 5.0)
         infer.assert_called_once_with(input_tensor, output_tensor)
-        self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
+        self.assertEqual(
+            benchmark.call_args.kwargs["device"], torch.device("privateuseone")
+        )
 
     def test_default_profiler_benchmarker_selection_supports_xpu_only(self):
         from torch._inductor.runtime import benchmarking as _bench

--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -336,7 +336,9 @@ class TestBenchmarker(TestCase):
             ) as benchmark,
         ):
             self.assertEqual(request.benchmark(input_tensor, out=output_tensor), 2.0)
-        infer.assert_called_once_with(input_tensor, output_tensor)
+        self.assertEqual(infer.call_count, 1)
+        self.assertIs(infer.call_args.args[0], input_tensor)
+        self.assertIs(infer.call_args.args[1], input_tensor)
         self.assertEqual(benchmark.call_args.kwargs["device"], "xpu")
 
     def test_subgraph_choice_caller_propagates_inferred_graph_device(self):

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -593,7 +593,8 @@ class BenchmarkRequest:
                 start_ts = time.time()
 
             if self.benchmark_with_cudagraphs:
-                res = benchmarker.benchmark_gpu_with_cuda_graph(fn)
+                device = benchmarker.infer_device(*input_tensors, out)
+                res = benchmarker.benchmark_gpu_with_graph(fn, device=device)
             else:
                 res = self.do_bench(fn, *input_tensors, out)
 
@@ -983,8 +984,9 @@ class ExternKernelBenchmarkRequest(BenchmarkRequest):
                 )
                 out.copy_(out_new)  # for correctness checking
             if self.benchmark_with_cudagraphs:
-                return benchmarker.benchmark_gpu_with_cuda_graph(
-                    lambda: algo(*input_tensors)
+                device = benchmarker.infer_device(*input_tensors, out_new)
+                return benchmarker.benchmark_gpu_with_graph(
+                    lambda: algo(*input_tensors), device=device
                 )
             if config.profile_bandwidth_with_do_bench_using_profiling:
                 return do_bench_using_profiling(lambda: algo(*input_tensors))

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
     )
 
 from . import config
-from .runtime.benchmarking import benchmarker
+from .runtime.benchmarking import benchmarker, has_graph_benchmarker
 from .virtualized import V
 
 
@@ -594,7 +594,10 @@ class BenchmarkRequest:
 
             if self.benchmark_with_cudagraphs:
                 device = benchmarker.infer_device(*input_tensors, out)
-                res = benchmarker.benchmark_gpu_with_graph(fn, device=device)
+                if has_graph_benchmarker(device):
+                    res = benchmarker.benchmark_gpu_with_graph(fn, device=device)
+                else:
+                    res = self.do_bench(fn, *input_tensors, out)
             else:
                 res = self.do_bench(fn, *input_tensors, out)
 
@@ -985,9 +988,10 @@ class ExternKernelBenchmarkRequest(BenchmarkRequest):
                 out.copy_(out_new)  # for correctness checking
             if self.benchmark_with_cudagraphs:
                 device = benchmarker.infer_device(*input_tensors, out_new)
-                return benchmarker.benchmark_gpu_with_graph(
-                    lambda: algo(*input_tensors), device=device
-                )
+                if has_graph_benchmarker(device):
+                    return benchmarker.benchmark_gpu_with_graph(
+                        lambda: algo(*input_tensors), device=device
+                    )
             if config.profile_bandwidth_with_do_bench_using_profiling:
                 return do_bench_using_profiling(lambda: algo(*input_tensors))
             return benchmarker.benchmark(algo, input_tensors, {})

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -26,7 +26,7 @@ from torch._inductor.ir import (
     ir_node_to_tensor,
     Layout,
 )
-from torch._inductor.runtime.benchmarking import benchmarker
+from torch._inductor.runtime.benchmarking import benchmarker, has_graph_benchmarker
 from torch._inductor.utils import do_bench_using_profiling
 from torch._inductor.virtualized import V
 from torch.utils._ordered_set import OrderedSet
@@ -273,7 +273,8 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
 
         if self._benchmark_with_cudagraphs:
             device = benchmarker.infer_device(*sym_inputs, *args, out)
-            return benchmarker.benchmark_gpu_with_graph(fn, device=device)
+            if has_graph_benchmarker(device):
+                return benchmarker.benchmark_gpu_with_graph(fn, device=device)
 
         if config.profile_bandwidth_with_do_bench_using_profiling:
             return do_bench_using_profiling(fn)

--- a/torch/_inductor/codegen/subgraph.py
+++ b/torch/_inductor/codegen/subgraph.py
@@ -272,7 +272,8 @@ class SubgraphChoiceCaller(ir.ChoiceCaller):
             return bm_func([*sym_inputs, *args])
 
         if self._benchmark_with_cudagraphs:
-            return benchmarker.benchmark_gpu_with_cuda_graph(fn)
+            device = benchmarker.infer_device(*sym_inputs, *args, out)
+            return benchmarker.benchmark_gpu_with_graph(fn, device=device)
 
         if config.profile_bandwidth_with_do_bench_using_profiling:
             return do_bench_using_profiling(fn)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -6345,7 +6345,10 @@ class ChoiceCaller:
     def benchmark(self, *args: Any, out: torch.Tensor) -> float:
         algo = self.to_callable()
         if self._benchmark_with_cudagraphs:
-            return benchmarker.benchmark_gpu_with_cuda_graph(lambda: algo(*args))
+            device = benchmarker.infer_device(*args, out)
+            return benchmarker.benchmark_gpu_with_graph(
+                lambda: algo(*args), device=device
+            )
         if config.profile_bandwidth_with_do_bench_using_profiling:
             return do_bench_using_profiling(lambda: algo(*args))  # type: ignore[arg-type]
         return benchmarker.benchmark(algo, args, {"out": out}, device=None)

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -109,7 +109,7 @@ from .dependencies import (
 )
 from .loop_body import LoopBody
 from .ops_handler import OpCounterCSE, OpCountResult, ReductionType, StoreMode
-from .runtime.benchmarking import benchmarker
+from .runtime.benchmarking import benchmarker, has_graph_benchmarker
 from .runtime.hints import DeviceProperties, ReductionHint
 from .utils import (
     argsort,
@@ -6346,9 +6346,10 @@ class ChoiceCaller:
         algo = self.to_callable()
         if self._benchmark_with_cudagraphs:
             device = benchmarker.infer_device(*args, out)
-            return benchmarker.benchmark_gpu_with_graph(
-                lambda: algo(*args), device=device
-            )
+            if has_graph_benchmarker(device):
+                return benchmarker.benchmark_gpu_with_graph(
+                    lambda: algo(*args), device=device
+                )
         if config.profile_bandwidth_with_do_bench_using_profiling:
             return do_bench_using_profiling(lambda: algo(*args))  # type: ignore[arg-type]
         return benchmarker.benchmark(algo, args, {"out": out}, device=None)

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -95,6 +95,7 @@ def gpu_benchmark_lock(fn: Callable[P, T]) -> Callable[P, T]:
 # Values are callables with signature:
 #   fn(self: Benchmarker, _callable: Callable[..., Any], *, warmup: int, rep: int, **kwargs) -> Any
 _BENCHMARK_DISPATCH: dict[str, Callable[..., Any]] = {}
+_GRAPH_BENCHMARK_DISPATCH: dict[str, Callable[..., Any]] = {}
 
 
 def register_benchmarker(
@@ -122,6 +123,26 @@ def register_benchmarker(
             f"Benchmarker for device_type '{device_type}' already registered"
         )
     _BENCHMARK_DISPATCH[device_type] = fn
+
+
+def register_graph_benchmarker(
+    device_type: str,
+    fn: Callable[..., Any],
+    *,
+    override: bool = False,
+) -> None:
+    """Register a graph benchmark handler for one torch.device.type."""
+    if not isinstance(device_type, str) or not device_type:
+        raise ValueError(
+            "device_type must be a non-empty string matching torch.device.type"
+        )
+    if not callable(fn):
+        raise TypeError("fn must be callable")
+    if not override and device_type in _GRAPH_BENCHMARK_DISPATCH:
+        raise ValueError(
+            f"Graph benchmarker for device_type '{device_type}' already registered"
+        )
+    _GRAPH_BENCHMARK_DISPATCH[device_type] = fn
 
 
 def may_distort_benchmarking_result(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -353,6 +374,32 @@ class Benchmarker:
     def benchmark_gpu(self: Self, *args: Any, **kwargs: Any) -> float:
         raise NotImplementedError
 
+    def benchmark_gpu_with_graph(
+        self: Self,
+        _callable: Callable[[], Any],
+        *,
+        device: str | torch.device,
+        grad_to_none: list[torch.Tensor] | None = None,
+        **kwargs: Any,
+    ) -> float:
+        resolved_device = torch.device(device) if isinstance(device, str) else device
+        if not isinstance(resolved_device, torch.device):
+            raise TypeError(f"Expected torch.device, got {type(resolved_device)}")
+
+        graph_benchmark_fn = _GRAPH_BENCHMARK_DISPATCH.get(resolved_device.type)
+        if graph_benchmark_fn is None:
+            raise RuntimeError(
+                "No graph benchmarker registered for "
+                f"device_type '{resolved_device.type}'"
+            )
+        return graph_benchmark_fn(
+            self,
+            _callable,
+            grad_to_none=grad_to_none,
+            device_type=resolved_device.type,
+            **kwargs,
+        )
+
     @time_and_count
     @gpu_benchmark_lock
     def benchmark_gpu_with_cuda_graph(
@@ -416,6 +463,18 @@ def _default_xpu_bench(self, f, *, warmup, rep, **kw):
 register_benchmarker("cpu", _default_cpu_bench, override=True)
 register_benchmarker("cuda", _default_cuda_bench, override=True)
 register_benchmarker("xpu", _default_xpu_bench, override=True)
+
+
+def _default_cuda_graph_bench(self, f, *, grad_to_none=None, **kw):
+    kw.pop("device_type", None)
+    return self.benchmark_gpu_with_cuda_graph(
+        f,
+        grad_to_none=grad_to_none,
+        **kw,
+    )
+
+
+register_graph_benchmarker("cuda", _default_cuda_graph_bench, override=True)
 
 
 def _get_callable_device_kernel_time_us(

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -145,6 +145,13 @@ def register_graph_benchmarker(
     _GRAPH_BENCHMARK_DISPATCH[device_type] = fn
 
 
+def has_graph_benchmarker(device: str | torch.device) -> bool:
+    resolved_device = torch.device(device) if isinstance(device, str) else device
+    if not isinstance(resolved_device, torch.device):
+        raise TypeError(f"Expected torch.device, got {type(resolved_device)}")
+    return resolved_device.type in _GRAPH_BENCHMARK_DISPATCH
+
+
 def may_distort_benchmarking_result(fn: Callable[..., Any]) -> Callable[..., Any]:
     from torch._inductor import config
 


### PR DESCRIPTION
  ## Summary

  Add a device-dispatched graph benchmarking hook to Inductor.

  ## Motivation

  Inductor's generic autotuning paths currently invoke the CUDA-specific
  `benchmark_gpu_with_cuda_graph()` method directly. This prevents an out-of-tree
  accelerator backend from registering and owning its graph capture and replay
  strategy.

  The ordinary benchmark path already supports device-specific handlers through
  `register_benchmarker()`. This PR applies the same ownership boundary to graph
  benchmarking without extending `DeviceInterface`.

  ## Changes

  - Add a graph benchmark registry and `register_graph_benchmarker()`.
  - Add `Benchmarker.benchmark_gpu_with_graph()` with exact device-type dispatch.
  - Add `has_graph_benchmarker()` for checking whether a graph handler is registered.
  - Preserve the existing CUDA behavior through an adapter to
    `benchmark_gpu_with_cuda_graph()`.
  - Infer the benchmark device at the four generic graph benchmark call sites:
    - `BenchmarkRequest.benchmark`
    - `ExternKernelBenchmarkRequest.benchmark`
    - `SubgraphChoiceCaller.benchmark`
    - `ChoiceCaller.benchmark`
  - Enter graph benchmarking only when the inferred device has a registered handler.
  - Preserve the existing ordinary benchmark path for unregistered devices.
  - Add coverage for registry dispatch, strict direct-call errors, CUDA
    compatibility, unregistered XPU fallback, and PrivateUse1 device propagation.

  ## Scope

  - No changes to `DeviceInterface`.
  - No new built-in graph implementation.
  - The existing CUDA graph implementation remains unchanged.
  - The CUDA-only NV Universal GEMM benchmark path remains unchanged.
  - Out-of-tree backends remain responsible for registering their own graph
    benchmark strategy.

  ## Validation

  - `test/inductor/test_benchmarking.py`
    - 23 passed
    - 12 skipped
    - 2 expected failures
  - `spin quicklint`
    - passed
  - `git diff --check`
    - passed