### PR TITLE
[Inductor] Resolve PrivateUse1 profiler device enums

### DIFF
--- a/test/inductor/test_benchmarking.py
+++ b/test/inductor/test_benchmarking.py
@@ -227,6 +227,25 @@ class TestBenchmarker(TestCase):
             _bench._BENCHMARK_DISPATCH.clear()
             _bench._BENCHMARK_DISPATCH.update(orig)
 
+    def test_profiler_device_enum_resolution(self):
+        from torch._inductor.runtime.benchmarking import _resolve_profiler_device_types
+
+        runtime_name = torch._C._get_privateuse1_backend_name()
+        activity, profiler_device_type = _resolve_profiler_device_types(runtime_name)
+        self.assertIs(activity, torch.profiler.ProfilerActivity.PrivateUse1)
+        self.assertIs(profiler_device_type, torch.autograd.DeviceType.PrivateUse1)
+
+        for device_type in ("cuda", "xpu"):
+            activity, profiler_device_type = _resolve_profiler_device_types(device_type)
+            self.assertIs(
+                activity,
+                getattr(torch.profiler.ProfilerActivity, device_type.upper()),
+            )
+            self.assertIs(
+                profiler_device_type,
+                getattr(torch.autograd.DeviceType, device_type.upper()),
+            )
+
     def test_default_profiler_benchmarker_selection_supports_xpu_only(self):
         from torch._inductor.runtime import benchmarking as _bench
 

--- a/torch/_inductor/runtime/benchmarking.py
+++ b/torch/_inductor/runtime/benchmarking.py
@@ -50,6 +50,22 @@ def _normalize_gpu_device_type(device_type: str | torch.device | None) -> str:
     return torch.device(device_type).type
 
 
+def _resolve_profiler_device_types(device_type: str) -> tuple[Any, Any]:
+    from torch.autograd import DeviceType
+
+    if device_type == torch._C._get_privateuse1_backend_name():
+        return (
+            torch.profiler.ProfilerActivity.PrivateUse1,
+            DeviceType.PrivateUse1,
+        )
+
+    enum_name = device_type.upper()
+    return (
+        getattr(torch.profiler.ProfilerActivity, enum_name),
+        getattr(DeviceType, enum_name),
+    )
+
+
 _GpuBenchmarkLockContext = Callable[[], contextlib.AbstractContextManager[None]]
 _gpu_benchmark_lock_context: _GpuBenchmarkLockContext | None = None
 
@@ -873,7 +889,9 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
         # Use both CPU and device activities, otherwise record_function
         # will not record the region.
         device_type_upper = device_type.upper()
-        profile_activity = getattr(torch.profiler.ProfilerActivity, device_type_upper)
+        profile_activity, profiler_device_type = _resolve_profiler_device_types(
+            device_type
+        )
         with torch.profiler.profile(
             activities=[
                 torch.profiler.ProfilerActivity.CPU,
@@ -896,9 +914,6 @@ class TorchProfilerBenchmarker(InductorBenchmarker):  # noqa: docstring_linter
         # This avoids prof.key_averages() which triggers expensive lazy
         # processing: _parse_kineto_results (wrapping every raw event in
         # a Python FunctionEvent), _build_tree, and grouping/aggregation.
-        from torch.autograd import DeviceType as _DeviceType
-
-        profiler_device_type = getattr(_DeviceType, device_type_upper)
         callable_gpu_time_us = 0.0
         for kineto_event in prof.profiler.kineto_results.events():
             if (

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -424,7 +424,9 @@ def _do_bench_using_profiling(
         may_ban_benchmarking()
 
     device_type = get_gpu_type()
-    device_type_upper = device_type.upper()
+    from torch._inductor.runtime.benchmarking import _resolve_profiler_device_types
+
+    profile_activity, profiler_device_type = _resolve_profiler_device_types(device_type)
     device_interface = get_interface_for_device(device_type)
     fn()
     device_interface.synchronize()
@@ -450,7 +452,6 @@ def _do_bench_using_profiling(
         fn()
 
     device_interface.synchronize()
-    profile_activity = getattr(torch.profiler.ProfilerActivity, device_type_upper)
     with torch.profiler.profile(
         activities=[
             torch.profiler.ProfilerActivity.CPU,
@@ -477,7 +478,7 @@ def _do_bench_using_profiling(
         p.profiler.kineto_results.events(),
         p.events(),
         n_repeat,
-        getattr(DeviceType, device_type_upper),
+        profiler_device_type,
     )
 
     log.debug("profiling time breakdown")


### PR DESCRIPTION
## Summary

Resolve profiler device enums correctly for the PrivateUse1 backend.

## Motivation

The PrivateUse1 runtime name is backend-defined and cannot be converted reliably into profiler enum names by uppercasing the string. For example, a runtime name such as `npu` does not correspond to an enum named `NPU`.

## Changes

- Map the dynamic PrivateUse1 runtime name to `torch.profiler.ProfilerActivity.PrivateUse1` and `torch.autograd.DeviceType.PrivateUse1`.
- Preserve the existing uppercase enum lookup for ordinary device types such as CUDA and XPU.
- Reuse the resolver in both Inductor profiler benchmark paths.
- Add regression coverage for PrivateUse1, CUDA, and XPU resolution.

## Test Plan

Tests were not run, per request.

Static validation was run:

```bash
git diff --check
```

Result: passed.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo