### PR TITLE
[Testcase Refactoring] Classify device-specific test classes for test_cpu_cpp_wrapper.py

### DIFF
--- a/test/inductor/test_cpu_cpp_wrapper.py
+++ b/test/inductor/test_cpu_cpp_wrapper.py
@@ -10,6 +10,7 @@ from torch.testing._internal.common_device_type import (
     get_desired_device_type_test_bases,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_MACOS,
     IS_WINDOWS,
     slowTest,
@@ -54,10 +55,12 @@ class CppWrapperTemplate:
 
 
 class TestCppWrapper(InductorTestCase):
+    hw_classification = HardwareClassification.CPU
     device = "cpu"
 
 
 class DynamicShapesCppWrapperCpuTests(InductorTestCase):
+    hw_classification = HardwareClassification.CPU
     device = "cpu"
 
 


### PR DESCRIPTION
## Summary
This PR hardware classify device-specific and device-agnostic test classes.

## Changes
- Instantiate device-agnostic test templates as device-specific test classes.
- Add `hw_classification = HardwareClassification.CPU` to tests class.

## Motivation
Instantiate and classify device-specific and device-agnostic test classes.

## Test Plan
- CI: `python test/inductor/test_cpu_cpp_wrapper.py --hw-classification CPU`
- Verified test cases correctly on cpu.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo