### PR TITLE
[Testcase Refactoring] Add hw-classification in launcher_test_api

### DIFF
--- a/test/distributed/launcher/test_api.py
+++ b/test/distributed/launcher/test_api.py
@@ -11,10 +11,16 @@ import os
 from unittest.mock import MagicMock, patch
 
 from torch.distributed.launcher.api import launch_agent, LaunchConfig
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class LauncherApiTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Save original environment variable if it exists


### PR DESCRIPTION
## Summary

Tags `LauncherApiTest` in `test/distributed/launcher/test_api.py` with
`hw_classification = HardwareClassification.GENERIC` so the class can be
selected by the `--hw-classification` test filter. The class is a bare
`TestCase` subclass exercising CPU-only `launch_agent` mock behavior, with no
device parameter and no `instantiate_device_type_tests`, so `GENERIC` is the
correct category.

## Changes

- `test/distributed/launcher/test_api.py`: added `HardwareClassification`
  to the `torch.testing._internal.common_utils` import block (converted
  from single-line to multi-line, alphabetical order —
  `HardwareClassification` before `run_tests` before `TestCase`, with Black
  magic trailing comma).
- `test/distributed/launcher/test_api.py`: declared
  `hw_classification = HardwareClassification.GENERIC` as a class attribute
  on `LauncherApiTest`, placed immediately after the class header and before
  `setUp`.


## Motivation

PyTorch's test suite recently introduced the `HardwareClassification`
mechanism (see `torch/testing/_internal/common_utils.py`), which allows
filtering test classes by hardware category (`GENERIC`, `ACCELERATOR`,
`CPU`, `CUDA`, `MPS`, `XPU`) via the `--hw-classification` CLI flag. Test
classes that do not declare a `hw_classification` attribute are excluded
when the filter is used, so they cannot run in hardware-partitioned CI
workflows.

`LauncherApiTest` fits the `GENERIC` definition ("tests that exercise shared,
device-agnostic logic ... typically do not use
`instantiate_device_type_tests`"): its two test methods
(`test_launch_agent_sets_signals_env_var` and
`test_launch_agent_default_signals`) mock `LocalElasticAgent` and
`rdzv_registry.get_rendezvous_handler`, then assert that the
`TORCHELASTIC_SIGNALS_TO_HANDLE` environment variable is set correctly —
pure mock + env-var assertions, no tensor or device code. Tagging it
`GENERIC` brings it into the new filtering workflow without altering test
behavior.

## Test plan

- Run the test file:
 python test/distributed/launcher/test_api.py , 2 testcases pass
