### PR TITLE
Introduce batched `wait_tensors` api for coalescing multi-output functional collectives

### DIFF
--- a/test/distributed/_tools/test_fake_collectives.py
+++ b/test/distributed/_tools/test_fake_collectives.py
@@ -116,6 +116,7 @@ class CollectiveTest(TorchDispatchMode):
         c10d.barrier.default,
         c10d.monitored_barrier_.default,
         _c10d_functional.wait_tensor.default,
+        _c10d_functional.wait_tensors.default,
     }
 
     def __init__(self, test: TestFakeCollectives, _dispatch_key=None):
@@ -126,7 +127,10 @@ class CollectiveTest(TorchDispatchMode):
         res = func(*args, **(kwargs or {}))
 
         if func in collective_ops:
-            if func != _c10d_functional.wait_tensor.default:
+            if func not in (
+                _c10d_functional.wait_tensor.default,
+                _c10d_functional.wait_tensors.default,
+            ):
                 pg = CollectiveOp.get_process_group(func, args)
                 self.test.assertIsInstance(
                     pg, ProcessGroup, "Error: pg is not an instance of ProcessGroup"

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -791,6 +791,24 @@ class CrossThreadWaitTest(TestCase):
         # Verify work was removed from registry
         self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
 
+    def test_wait_tensor_shared_work_is_consumed_once(self) -> None:
+        dist.init_process_group(backend="fake", rank=0, world_size=2)
+        try:
+            outputs = torch.ops._c10d_functional.all_reduce_coalesced(
+                [torch.rand(2, 2), torch.rand(2, 2)],
+                "sum",
+                "0",
+            )
+            self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 2)
+
+            torch.ops._c10d_functional.wait_tensor(outputs[0])
+            self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
+
+            torch.ops._c10d_functional.wait_tensor(outputs[1])
+            self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
+        finally:
+            dist.destroy_process_group()
+
 
 class PyWorkTest(TestCase):
     """

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -806,6 +806,14 @@ class CrossThreadWaitTest(TestCase):
         finally:
             dist.destroy_process_group()
 
+    def test_wait_tensors_empty_raises(self) -> None:
+        msg = "wait_tensors requires at least one tensor"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            torch.ops._c10d_functional.wait_tensors([])
+        fake_mode = torch._subclasses.FakeTensorMode()
+        with fake_mode, self.assertRaisesRegex(RuntimeError, msg):
+            torch.ops._c10d_functional.wait_tensors([])
+
 
 class PyWorkTest(TestCase):
     """

--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -791,7 +791,7 @@ class CrossThreadWaitTest(TestCase):
         # Verify work was removed from registry
         self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
 
-    def test_wait_tensor_shared_work_is_consumed_once(self) -> None:
+    def test_wait_tensors_consumes_shared_work(self) -> None:
         dist.init_process_group(backend="fake", rank=0, world_size=2)
         try:
             outputs = torch.ops._c10d_functional.all_reduce_coalesced(
@@ -801,10 +801,7 @@ class CrossThreadWaitTest(TestCase):
             )
             self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 2)
 
-            torch.ops._c10d_functional.wait_tensor(outputs[0])
-            self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
-
-            torch.ops._c10d_functional.wait_tensor(outputs[1])
+            torch.ops._c10d_functional.wait_tensors(outputs)
             self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
         finally:
             dist.destroy_process_group()
@@ -1002,6 +999,26 @@ class CompileTestCPU(TestCase):
         self._test_inductor_all_reduce_cpu(cpp_wrapper=False)
         self._test_inductor_all_reduce_cpu(cpp_wrapper=True)
 
+    @fresh_cache()
+    def test_inductor_all_reduce_coalesced_cpu(self):
+        def func(args: list[torch.Tensor]) -> list[torch.Tensor]:
+            return funcol.all_reduce_coalesced([arg + 42 for arg in args], "avg", "0")
+
+        args = [torch.rand(4, 4) for _ in range(2)]
+        compiled = torch.compile(func)
+        _, (code,) = run_and_get_code(compiled, args)
+        self.assertIn("torch.ops._c10d_functional.wait_tensors.default", code)
+
+        torch._dynamo.reset()
+        with (
+            torch._inductor.config.patch({"cpp_wrapper": True}),
+            self.assertRaisesRegex(
+                torch._inductor.exc.InductorError,
+                "wait_tensors is not supported with C\\+\\+ wrapper/AOTInductor",
+            ),
+        ):
+            torch.compile(func)(args)
+
 
 class CompileTest(TestCase):
     def setUp(self):
@@ -1086,10 +1103,8 @@ class CompileTest(TestCase):
             bufs = [arg + 42 for arg in args]
             # Expect in-place with inductor allocated buf
             ar0 = funcol.all_reduce_coalesced(bufs, "avg", "0")
-            ar0 = [funcol.wait_tensor(out) for out in ar0]
             # Expect no in-place with graph input
             ar1 = funcol.all_reduce_coalesced(args, "avg", "0")
-            ar1 = [funcol.wait_tensor(out) for out in ar1]
             return ar0, ar1
 
         args = [torch.rand(4, 4, device=self.device.type) for _ in range(2)]
@@ -1110,21 +1125,15 @@ class CompileTest(TestCase):
             .check(
                 f"torch.ops._c10d_functional.all_reduce_coalesced_.default([{buf1}, {buf3}]"
             )
-            .check(f"torch.ops._c10d_functional.wait_tensor.default({buf0}")
-            .check(f"torch.ops._c10d_functional.wait_tensor.default({buf2}")
-            .check(f"torch.ops._c10d_functional.wait_tensor.default({buf1}")
-            .check(f"torch.ops._c10d_functional.wait_tensor.default({buf3}")
+            .check(f"torch.ops._c10d_functional.wait_tensors.default([{buf0}, {buf2}])")
+            .check(f"torch.ops._c10d_functional.wait_tensors.default([{buf1}, {buf3}])")
             # Expect no extra copy on return
             .check(f"return ({buf0}, {buf2}, {buf1}, {buf3}, )")
             .run(code)
         )
-        if "= torch.ops._c10d_functional.wait_tensor.default" in code:
-            raise AssertionError(
-                "Expected wait_tensor return value to not be used in code"
-            )
+        if "= torch.ops._c10d_functional.wait_tensors.default" in code:
+            raise AssertionError("Expected wait_tensors to have no return value")
 
-        # Test aoti
-        out = AOTIRunnerUtil.run(func, (args,))  # noqa: F841
         torch.accelerator.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -1260,9 +1269,7 @@ class CompileTest(TestCase):
     @fresh_cache()
     def test_inductor_all_gather_into_tensor_coalesced(self):
         def func(args: list[torch.Tensor]) -> torch.Tensor:
-            ag0 = funcol.all_gather_single_coalesced(args, "0")
-            ag0 = [funcol.wait_tensor(out) for out in ag0]
-            return ag0
+            return funcol.all_gather_single_coalesced(args, "0")
 
         args = [torch.rand(4, 4, device=self.device.type) for _ in range(4)]
         compiled = torch.compile(func)
@@ -1277,17 +1284,15 @@ class CompileTest(TestCase):
             .check("buf2 = buf0[1]")
             .check("buf3 = buf0[2]")
             .check("buf4 = buf0[3]")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf1")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf2")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf3")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf4")
+            .check(
+                "torch.ops._c10d_functional.wait_tensors.default"
+                "([buf1, buf2, buf3, buf4])"
+            )
             # Expect no extra copy on return
             .check("return (buf1, buf2, buf3, buf4, )")
             .run(code)
         )
 
-        # Test aoti
-        out = AOTIRunnerUtil.run(func, (args,))  # noqa: F841
         torch.accelerator.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
@@ -1361,11 +1366,9 @@ class CompileTest(TestCase):
     @fresh_cache()
     def test_inductor_reduce_scatter_tensor_coalesced(self):
         def func(args: list[torch.Tensor]) -> torch.Tensor:
-            rs0 = funcol.reduce_scatter_single_coalesced(
+            return funcol.reduce_scatter_single_coalesced(
                 args, "avg", [0] * len(args), "0"
             )
-            rs0 = [funcol.wait_tensor(out) for out in rs0]
-            return rs0
 
         args = [torch.rand(4, 4, device=self.device.type) for _ in range(4)]
         compiled = torch.compile(func)
@@ -1380,17 +1383,15 @@ class CompileTest(TestCase):
             .check("buf2 = buf0[1]")
             .check("buf3 = buf0[2]")
             .check("buf4 = buf0[3]")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf1")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf2")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf3")
-            .check("torch.ops._c10d_functional.wait_tensor.default(buf4")
+            .check(
+                "torch.ops._c10d_functional.wait_tensors.default"
+                "([buf1, buf2, buf3, buf4])"
+            )
             # Expect no extra copy on return
             .check("return (buf1, buf2, buf3, buf4, )")
             .run(code)
         )
 
-        # Test aoti
-        AOTIRunnerUtil.run(func, (args,))
         torch.accelerator.synchronize()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")

--- a/test/dynamo/test_fake_distributed.py
+++ b/test/dynamo/test_fake_distributed.py
@@ -347,10 +347,7 @@ class GraphModule(torch.nn.Module):
         getitem: "f32[0]" = batch_p2p_ops[0]
         getitem_1: "f32[10]" = batch_p2p_ops[1];  batch_p2p_ops = None
 
-        wait_tensor: "f32[10]" = torch.ops._c10d_functional.wait_tensor(getitem_1);  getitem_1 = None
-
-        wait_tensor_1: "f32[0]" = torch.distributed._functional_collectives.wait_tensor(getitem);  getitem = wait_tensor_1 = None
-        wait_tensor_2: "f32[10]" = torch.distributed._functional_collectives.wait_tensor(wait_tensor);  wait_tensor = wait_tensor_2 = None
+        wait_tensors_default = torch.ops._c10d_functional.wait_tensors.default([getitem, getitem_1]);  getitem = getitem_1 = wait_tensors_default = None
         return ()
 """,
         )
@@ -371,6 +368,30 @@ class GraphModule(torch.nn.Module):
                 w.wait()
 
         fn(torch.ones(4), torch.zeros(4), torch.ones(4), torch.zeros(4))
+        self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
+
+    @torch._dynamo.config.patch(enable_p2p_compilation=True)
+    def test_compiled_batch_isend_irecv_preserves_separate_waits(self):
+        backend = EagerAndRecordGraphs()
+
+        @torch.compile(fullgraph=True, backend=backend)
+        def fn(send_tensor, recv_tensor):
+            work = dist.batch_isend_irecv(
+                [
+                    dist.P2POp(dist.isend, send_tensor, 1),
+                    dist.P2POp(dist.irecv, recv_tensor, 1),
+                ]
+            )
+            work[0].wait()
+            send_tensor.add_(1)
+            work[1].wait()
+            return send_tensor
+
+        fn(torch.ones(4), torch.zeros(4))
+        self.assertEqual(len(backend.graphs), 1)
+        graph = normalize_graph(backend.graphs[0])
+        self.assertNotIn("wait_tensors", graph)
+        self.assertEqual(graph.count("_functional_collectives.wait_tensor("), 2)
         self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
 
     @torch._dynamo.config.patch(enable_p2p_compilation=True)
@@ -417,32 +438,28 @@ class GraphModule(torch.nn.Module):
         l_y0_ = L_y0_
         l_y1_ = L_y1_
 
-        batch_p2p_ops = torch.ops._c10d_functional.batch_p2p_ops(['isend', 'irecv'], [1, 1], [0, 0], [l_x0_, l_y0_], '0')
+        batch_p2p_ops = torch.ops._c10d_functional.batch_p2p_ops(['isend', 'irecv'], [1, 1], [0, 0], [l_x0_, l_y0_], '0');  l_y0_ = None
         getitem: "f32[0]" = batch_p2p_ops[0]
         getitem_1: "f32[64, 64]" = batch_p2p_ops[1];  batch_p2p_ops = None
-
-        wait_tensor: "f32[64, 64]" = torch.ops._c10d_functional.wait_tensor(getitem_1);  getitem_1 = None
 
         mul: "f32[64, 64]" = l_x0_ * 2;  l_x0_ = None
         add: "f32[64, 64]" = mul + 1;  mul = None
 
-        add_1: "f32[64, 64]" = l_y0_ + add;  l_y0_ = add = None
+        wait_tensors_default = torch.ops._c10d_functional.wait_tensors.default([getitem, getitem_1]);  getitem = getitem_1 = None
+        getitem_4 = wait_tensors_default[1];  wait_tensors_default = None
 
-        wait_tensor_1: "f32[0]" = torch.distributed._functional_collectives.wait_tensor(getitem);  getitem = wait_tensor_1 = None
-        wait_tensor_2: "f32[64, 64]" = torch.distributed._functional_collectives.wait_tensor(wait_tensor);  wait_tensor = wait_tensor_2 = None
+        add_1: "f32[64, 64]" = getitem_4 + add;  getitem_4 = add = None
 
-        batch_p2p_ops_1 = torch.ops._c10d_functional.batch_p2p_ops(['isend', 'irecv'], [1, 1], [0, 0], [add_1, l_y1_], '0')
+        batch_p2p_ops_1 = torch.ops._c10d_functional.batch_p2p_ops(['isend', 'irecv'], [1, 1], [0, 0], [add_1, l_y1_], '0');  l_y1_ = None
         getitem_2: "f32[0]" = batch_p2p_ops_1[0]
         getitem_3: "f32[64, 64]" = batch_p2p_ops_1[1];  batch_p2p_ops_1 = None
 
-        wait_tensor_3: "f32[64, 64]" = torch.ops._c10d_functional.wait_tensor(getitem_3);  getitem_3 = None
-
         mul_1: "f32[64, 64]" = add_1 * 1.000244140625;  add_1 = None
 
-        add_2: "f32[64, 64]" = l_y1_ + mul_1;  l_y1_ = mul_1 = None
+        wait_tensors_default_1 = torch.ops._c10d_functional.wait_tensors.default([getitem_2, getitem_3]);  getitem_2 = getitem_3 = None
+        getitem_5 = wait_tensors_default_1[1];  wait_tensors_default_1 = None
 
-        wait_tensor_4: "f32[0]" = torch.distributed._functional_collectives.wait_tensor(getitem_2);  getitem_2 = wait_tensor_4 = None
-        wait_tensor_5: "f32[64, 64]" = torch.distributed._functional_collectives.wait_tensor(wait_tensor_3);  wait_tensor_3 = wait_tensor_5 = None
+        add_2: "f32[64, 64]" = getitem_5 + mul_1;  getitem_5 = mul_1 = None
         return (add_2,)
 """,
         )

--- a/test/dynamo/test_fake_distributed.py
+++ b/test/dynamo/test_fake_distributed.py
@@ -356,6 +356,24 @@ class GraphModule(torch.nn.Module):
         )
 
     @torch._dynamo.config.patch(enable_p2p_compilation=True)
+    def test_compiled_batch_isend_irecv_waits_clear_work_registry(self):
+        @torch.compile(fullgraph=True, backend="eager")
+        def fn(send0, recv0, send1, recv1):
+            work = dist.batch_isend_irecv(
+                [
+                    dist.P2POp(dist.isend, send0, 1),
+                    dist.P2POp(dist.irecv, recv0, 1),
+                    dist.P2POp(dist.isend, send1, 1),
+                    dist.P2POp(dist.irecv, recv1, 1),
+                ]
+            )
+            for w in work:
+                w.wait()
+
+        fn(torch.ones(4), torch.zeros(4), torch.ones(4), torch.zeros(4))
+        self.assertEqual(torch._C._distributed_c10d._get_work_registry_size(), 0)
+
+    @torch._dynamo.config.patch(enable_p2p_compilation=True)
     def test_compiled_p2p_interleave_graph(self):
         backend = EagerAndRecordGraphs()
         nxt, prv = 1, 1  # rank=0 in world_size=2

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -30,6 +30,7 @@ import importlib.util
 import inspect
 import itertools
 import logging
+import operator
 import os
 import re
 import sys
@@ -2861,6 +2862,119 @@ def _traceable_collectives_source(
     return AttrSource(path_source, inner_name)
 
 
+def _fuse_batch_p2p_waits(gm: torch.fx.GraphModule) -> None:
+    from torch.distributed._functional_collectives import wait_tensor
+
+    batch_targets = {
+        torch.ops._c10d_functional.batch_p2p_ops,
+        torch.ops._c10d_functional.batch_p2p_ops.default,
+    }
+    wait_targets = {
+        wait_tensor,
+        torch.ops._c10d_functional.wait_tensor,
+        torch.ops._c10d_functional.wait_tensor.default,
+    }
+    graph = gm.graph
+    changed = False
+
+    for batch in list(graph.nodes):
+        if batch.target not in batch_targets:
+            continue
+
+        outputs: dict[int, torch.fx.Node] = {}
+        for user in batch.users:
+            if (
+                user.target is not operator.getitem
+                or len(user.args) != 2
+                or not isinstance(user.args[1], int)
+            ):
+                outputs.clear()
+                break
+            outputs[user.args[1]] = user
+        if (
+            not outputs
+            or len(outputs) != len(batch.users)
+            or sorted(outputs) != list(range(len(outputs)))
+        ):
+            continue
+
+        waits: list[torch.fx.Node] = []
+        for output in (outputs[i] for i in range(len(outputs))):
+            output_waits = [
+                user for user in output.users if user.target in wait_targets
+            ]
+            if len(output.users) != 1 or len(output_waits) != 1:
+                waits.clear()
+                break
+            wait = output_waits[0]
+            if wait.users:
+                waits.clear()
+                break
+            waits.append(wait)
+        if not waits:
+            continue
+
+        nodes = list(graph.nodes)
+        positions = {node: i for i, node in enumerate(nodes)}
+        first = min(waits, key=positions.__getitem__)
+        last = max(waits, key=positions.__getitem__)
+        between = nodes[positions[first] : positions[last] + 1]
+        if any(node not in waits for node in between):
+            continue
+
+        op_list = batch.args[0]
+        tensors = batch.args[3]
+        has_static_inputs = (
+            isinstance(op_list, (list, tuple))
+            and isinstance(tensors, (list, tuple))
+            and len(op_list) == len(tensors) == len(outputs)
+        )
+        insert_before = first
+        if has_static_inputs:
+            for op, tensor in zip(op_list, tensors):
+                if op != "irecv" or not isinstance(tensor, torch.fx.Node):
+                    continue
+                for user in tensor.users:
+                    if (
+                        user is not batch
+                        and positions[batch]
+                        < positions.get(user, -1)
+                        < positions[insert_before]
+                    ):
+                        insert_before = user
+
+        with graph.inserting_before(insert_before):
+            wait_tensors = graph.call_function(
+                torch.ops._c10d_functional.wait_tensors.default,
+                args=([outputs[i] for i in range(len(outputs))],),
+            )
+
+        if has_static_inputs:
+            for i, (op, tensor) in enumerate(zip(op_list, tensors)):
+                if op != "irecv" or not isinstance(tensor, torch.fx.Node):
+                    continue
+                users = [
+                    user
+                    for user in tensor.users
+                    if user is not batch and positions.get(user, -1) > positions[batch]
+                ]
+                if not users:
+                    continue
+                with graph.inserting_after(wait_tensors):
+                    waited = graph.call_function(
+                        operator.getitem, args=(wait_tensors, i)
+                    )
+                for user in users:
+                    user.replace_input_with(tensor, waited)
+        for wait in waits:
+            graph.erase_node(wait)
+        changed = True
+
+    if changed:
+        graph.lint()
+        gm.recompile()
+
+
 class CollectiveFunctionRewriteVariable(UserFunctionVariable):
     """
     Some of the torch.distributed.* collective APIs are possible to rewrite to 'traceable' collectives.
@@ -3005,7 +3119,10 @@ class CollectiveFunctionRewriteVariable(UserFunctionVariable):
                 "tensors": variables.ListVariable(tensors),
                 "group_name": group_var,
             }
-            return self.replacement_var.call_function(tx, new_args, new_kwargs)
+            result = self.replacement_var.call_function(tx, new_args, new_kwargs)
+            if _fuse_batch_p2p_waits not in tx.output.register_finalizer_fns:
+                tx.output.add_graph_finalizer(_fuse_batch_p2p_waits)
+            return result
 
         if self.fn in (dist.isend, dist.irecv):
             if not config.enable_p2p_compilation:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -2330,13 +2330,23 @@ def force_save_collectives(joint_module: fx.GraphModule) -> None:
     unless they come from a user-annotated AC region.
     See Note [Recomputing collectives in the partitioner]
     """
+
+    def mark_leaf_tensor_outputs(node: fx.Node) -> None:
+        getitem_users = [user for user in node.users if user.target is operator.getitem]
+        if getitem_users:
+            for user in getitem_users:
+                mark_leaf_tensor_outputs(user)
+            return
+        if not isinstance(node.meta.get("val"), (tuple, list)):
+            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+
     for node in joint_module.graph.nodes:
         if (
             isinstance(node.target, torch._ops.OpOverload)
             and node.target.namespace == "_c10d_functional"
             and not must_recompute(node)
         ):
-            node.meta["recompute"] = CheckpointPolicy.MUST_SAVE
+            mark_leaf_tensor_outputs(node)
 
 
 def force_save_effectful_ops(joint_module: fx.GraphModule) -> None:

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1424,7 +1424,11 @@ def _extract_fwd_bwd_modules(
         # then the collective will generally by followed by a wait_tensor() call.
         # we need to peek one node further to see if this wait_tensor is dead as well.
         elif distributed_enabled and all(
-            n.target is torch.ops._c10d_functional.wait_tensor.default
+            n.target
+            in (
+                torch.ops._c10d_functional.wait_tensor.default,
+                torch.ops._c10d_functional.wait_tensors.default,
+            )
             and len(n.users) == 0
             for n in node.users
         ):
@@ -1719,7 +1723,11 @@ def default_partition(
             )
             and (
                 not distributed_enabled
-                or node.target is not torch.ops._c10d_functional.wait_tensor.default
+                or node.target
+                not in (
+                    torch.ops._c10d_functional.wait_tensor.default,
+                    torch.ops._c10d_functional.wait_tensors.default,
+                )
             )
         )
 

--- a/torch/_inductor/comm_lowering.py
+++ b/torch/_inductor/comm_lowering.py
@@ -408,6 +408,11 @@ def register_comm_lowerings():
         ir._WaitKernel.create_wait(c10d.wait_tensor.default, inp)
         return inp
 
+    @register_comm_lowering(c10d.wait_tensors)
+    def _wait_tensors(inputs):
+        ir._WaitKernel.create_wait(c10d.wait_tensors.default, inputs)
+        return inputs
+
     @register_comm_lowering(c10d.isend)  # type: ignore[misc]
     def _isend(inp, dst, tag, group_name):
         inp = ir.ExternKernel.require_contiguous(inp)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -912,9 +912,16 @@ def reorder_for_locality(graph: torch.fx.Graph):
         )
 
     def visit(other_node):
+        is_wait_tensors_getitem = (
+            other_node.target is operator.getitem
+            and torch.distributed.is_available()
+            and isinstance(other_node.args[0], torch.fx.Node)
+            and other_node.args[0].target
+            is torch.ops._c10d_functional.wait_tensors.default
+        )
         if (
             other_node.op == "call_function"
-            and other_node.target != operator.getitem
+            and (other_node.target is not operator.getitem or is_wait_tensors_getitem)
             and all((n in seen_nodes) for n in other_node.users)
             and get_mutation_region_id(graph, node)
             == get_mutation_region_id(graph, other_node)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -895,7 +895,10 @@ def reorder_for_locality(graph: torch.fx.Graph):
             # which cause hangs. Once we have SPMD mode, we can safely reorder them.
             # However, increasing the locality between a collective and its wait node
             # is generally worse for performance.
-            return node.target != torch.ops._c10d_functional.wait_tensor.default
+            return node.target not in (
+                torch.ops._c10d_functional.wait_tensor.default,
+                torch.ops._c10d_functional.wait_tensors.default,
+            )
     else:
 
         def check():

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -12081,6 +12081,16 @@ class _WaitKernel(_CollectiveKernel):
         self.set_cpp_kernel_name("aoti_torch_cpu__c10d_functional_wait_tensor")
 
     def codegen(self, wrapper: PythonWrapperCodegen) -> None:
+        if (
+            self.op_overload is torch.ops._c10d_functional.wait_tensors.default
+            and V.graph.cpp_wrapper
+        ):
+            from .exc import CppWrapperCodegenError
+
+            raise CppWrapperCodegenError(
+                "_c10d_functional.wait_tensors is not supported with "
+                "C++ wrapper/AOTInductor"
+            )
         wrapper.include_extra_header("torch/csrc/inductor/aoti_torch/c/shim_cpu.h")
         wrapper.generate_extern_kernel_alloc(self)
 
@@ -12088,7 +12098,15 @@ class _WaitKernel(_CollectiveKernel):
             self.codegen_size_asserts(wrapper)
 
     def get_volatile_reads(self) -> Sequence[IRNode]:
-        inp = self.inputs[0]
+        volatile_reads: list[IRNode] = []
+        for inp in pytree.tree_leaves(self.inputs):
+            if not isinstance(inp, IRNode):
+                raise AssertionError("Expected isinstance(inp, IRNode)")
+            volatile_reads.extend(self._get_volatile_reads(inp))
+        return volatile_reads
+
+    @staticmethod
+    def _get_volatile_reads(inp: IRNode) -> Sequence[IRNode]:
         if not isinstance(inp, IRNode):
             raise AssertionError("Expected isinstance(inp, IRNode)")
         if isinstance(inp, _CollectiveKernel):
@@ -12115,20 +12133,26 @@ class _WaitKernel(_CollectiveKernel):
             return []
 
     @classmethod
-    def create_wait(cls, kernel: _OpOverloads, inp: TensorBox) -> None:
+    def create_wait(
+        cls, kernel: _OpOverloads, inp: TensorBox | list[TensorBox]
+    ) -> None:
         with V.graph.fake_mode:
             result = cls.process_kernel(kernel, inp)
         if result.unbacked_bindings:
             raise AssertionError(f"{kernel} {result.unbacked_bindings}")
+        inps = pytree.tree_leaves(inp)
+        if not inps:
+            raise AssertionError(f"{kernel} requires at least one tensor")
+        device = inps[0].get_device()
         packed = cls(
-            NoneLayout(device=inp.get_device()),
+            NoneLayout(device=device),
             kernel,
             result.tensor_args,
             result.non_tensor_args,
             result.unflatten_args,
         )
-        packed.mutation_outputs.append(
-            MutationOutput(NoneLayout(device=inp.get_device()), inp, packed)
+        packed.mutation_outputs.extend(
+            MutationOutput(NoneLayout(device=device), tensor, packed) for tensor in inps
         )
 
     def get_read_writes(self) -> dependencies.ReadWrites:

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -477,7 +477,6 @@ std::vector<at::Tensor> batch_p2p_ops(
           static_cast<int64_t>(tag_list[i]));
       auto placeholder = at::empty({0}, t.options());
       if (!should_coalesce && work) {
-        c10d::register_work(t, work);
         c10d::register_work(placeholder, work);
       }
       result_tensors.push_back(std::move(placeholder));
@@ -755,6 +754,13 @@ TORCH_LIBRARY(_c10d_functional, m) {
       torch::dispatch(
           c10::DispatchKey::CompositeExplicitAutograd, c10d::wait_tensor),
       {at::Tag::pt2_compliant_tag});
+
+  m.def(
+      "wait_tensors(Tensor[] tensors) -> Tensor[]",
+      torch::dispatch(
+          c10::DispatchKey::CompositeExplicitAutograd, c10d::wait_tensors),
+      {at::Tag::pt2_compliant_tag});
+
   m.def(
       "isend(Tensor tensor, int dst, int tag, str group_name) -> Tensor",
       torch::dispatch(c10::DispatchKey::CompositeExplicitAutograd, c10d::isend),

--- a/torch/csrc/distributed/c10d/Functional.cpp
+++ b/torch/csrc/distributed/c10d/Functional.cpp
@@ -464,9 +464,7 @@ std::vector<at::Tensor> batch_p2p_ops(
   if (should_coalesce) {
     group->startCoalescing(device);
   }
-  std::vector<c10::intrusive_ptr<c10d::Work>> works;
   std::vector<at::Tensor> result_tensors;
-  works.reserve(N);
   result_tensors.reserve(N);
   for (uint32_t i = 0; i < N; ++i) {
     c10::intrusive_ptr<c10d::Work> work;
@@ -478,10 +476,9 @@ std::vector<at::Tensor> batch_p2p_ops(
           static_cast<int64_t>(peer_list[i]),
           static_cast<int64_t>(tag_list[i]));
       auto placeholder = at::empty({0}, t.options());
-      if (work) {
+      if (!should_coalesce && work) {
         c10d::register_work(t, work);
         c10d::register_work(placeholder, work);
-        works.push_back(std::move(work));
       }
       result_tensors.push_back(std::move(placeholder));
     } else if (op_list[i] == "irecv") {
@@ -489,9 +486,8 @@ std::vector<at::Tensor> batch_p2p_ops(
           tt,
           static_cast<int64_t>(peer_list[i]),
           static_cast<int64_t>(tag_list[i]));
-      if (work) {
+      if (!should_coalesce && work) {
         c10d::register_work(t, work);
-        works.push_back(std::move(work));
       }
       result_tensors.push_back(std::move(t));
     } else {

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -522,6 +522,7 @@ at::Tensor wait_tensor(const at::Tensor& tensor) {
 }
 
 std::vector<at::Tensor> wait_tensors(at::TensorList tensors) {
+  TORCH_CHECK(!tensors.empty(), "wait_tensors requires at least one tensor");
   std::vector<c10::intrusive_ptr<c10d::Work>> works;
   std::unordered_set<c10d::Work*> seen;
   for (const auto& tensor : tensors) {

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -483,7 +483,10 @@ void register_work(
   RankLocal<WorkRegistry>::get().register_work(tensor, work);
 }
 
-at::Tensor wait_tensor(const at::Tensor& tensor) {
+namespace {
+
+std::vector<c10::intrusive_ptr<c10d::Work>> pop_works(
+    const at::Tensor& tensor) {
   // First try to find work in the current thread's registry (fast path)
   auto works = RankLocal<WorkRegistry>::get().pop_works(tensor);
 
@@ -504,15 +507,34 @@ at::Tensor wait_tensor(const at::Tensor& tensor) {
       works = std::move(result.value());
     }
   }
+  return works;
+}
+
+} // namespace
+
+at::Tensor wait_tensor(const at::Tensor& tensor) {
+  auto works = pop_works(tensor);
 
   for (const auto& work : works) {
-    RankLocal<WorkRegistry>::find_across_all([&work](WorkRegistry& registry) {
-      registry.unregister_work(work);
-      return false;
-    });
     work->wait();
   }
   return tensor;
+}
+
+std::vector<at::Tensor> wait_tensors(at::TensorList tensors) {
+  std::vector<c10::intrusive_ptr<c10d::Work>> works;
+  std::unordered_set<c10d::Work*> seen;
+  for (const auto& tensor : tensors) {
+    for (auto& work : pop_works(tensor)) {
+      if (seen.insert(work.get()).second) {
+        works.push_back(std::move(work));
+      }
+    }
+  }
+  for (const auto& work : works) {
+    work->wait();
+  }
+  return tensors.vec();
 }
 
 void unregister_work(const c10::intrusive_ptr<c10d::Work>& work) {

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -506,6 +506,10 @@ at::Tensor wait_tensor(const at::Tensor& tensor) {
   }
 
   for (const auto& work : works) {
+    RankLocal<WorkRegistry>::find_across_all([&work](WorkRegistry& registry) {
+      registry.unregister_work(work);
+      return false;
+    });
     work->wait();
   }
   return tensor;

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -37,13 +37,16 @@ C10_EXPORT void register_work(
 
 C10_EXPORT at::Tensor wait_tensor(const at::Tensor& tensor);
 
+C10_EXPORT std::vector<at::Tensor> wait_tensors(at::TensorList tensors);
+
 // We only call `unregister_work()` in one case:
 // 1. If the work object is created from a non-functional collective call within
 //    the `with allow_inflight_collective_as_graph_input_ctx()` context manager.
 //
 // Q: What about the functional collective case?
 // A: The unregistration of work object for functional collective is done in
-//    the required user-side explicit call to `wait_tensor()`.
+//    the required user-side explicit call to `wait_tensor()` or
+//    `wait_tensors()`.
 C10_EXPORT void unregister_work(const c10::intrusive_ptr<c10d::Work>& work);
 
 C10_EXPORT size_t get_work_registry_size();

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -143,6 +143,13 @@ def wait_tensor(tensor):
     return torch.ops._c10d_functional.wait_tensor(tensor)  # type: ignore[attr-defined]
 
 
+def wait_tensors(tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+    """
+    Wait on tensors returned by the same multi-output collective.
+    """
+    return torch.ops._c10d_functional.wait_tensors(tensors)  # type: ignore[attr-defined, no-any-return]
+
+
 def broadcast(self: torch.Tensor, src: int, group: RANK_TYPES, tag: str = ""):
     """
     Broadcasts the tensor to all processes in the given process group.
@@ -409,7 +416,7 @@ def all_reduce_coalesced(
         reduceOp.lower(),
         _group_or_group_name(group),
     )
-    return list(map(_maybe_wrap_tensor, tensor_list))
+    return _maybe_wrap_tensors(tensor_list)
 
 
 def all_gather_single_coalesced(
@@ -438,7 +445,7 @@ def all_gather_single_coalesced(
         group_size,
         _group_or_group_name(group),
     )
-    return list(map(_maybe_wrap_tensor, tensor_list))
+    return _maybe_wrap_tensors(tensor_list)
 
 
 def reduce_scatter_single_coalesced(
@@ -486,7 +493,7 @@ def reduce_scatter_single_coalesced(
         _group_or_group_name(group),
     )
 
-    return list(map(_maybe_wrap_tensor, tensor_list))
+    return _maybe_wrap_tensors(tensor_list)
 
 
 # Guarded warning rather than the @deprecated wrapper so Dynamo can trace
@@ -926,7 +933,7 @@ def all_reduce_coalesced_backward(ctx, grad_outputs: list[torch.Tensor]):
         reduce_op,
         group_name,
     )
-    return (list(map(wait_tensor, grad_inputs)), None, None)
+    return (wait_tensors(grad_inputs), None, None)
 
 
 def all_reduce_coalesced_setup_context(ctx, inputs, output):
@@ -975,7 +982,7 @@ def all_gather_into_tensor_coalesced_backward(ctx, grad_outputs: list[torch.Tens
         group_size,
         group_name,
     )
-    return (list(map(wait_tensor, grad_inputs)), None, None)
+    return (wait_tensors(grad_inputs), None, None)
 
 
 def all_gather_into_tensor_coalesced_setup_context(ctx, inputs, output):
@@ -1030,7 +1037,7 @@ def reduce_scatter_tensor_coalesced_backward(ctx, grad_outputs: list[torch.Tenso
         group_size,
         group_name,
     )
-    return (list(map(wait_tensor, grad_inputs)), None, None, None)
+    return (wait_tensors(grad_inputs), None, None, None)
 
 
 def reduce_scatter_tensor_coalesced_setup_context(ctx, inputs, output):
@@ -1439,6 +1446,12 @@ def _maybe_wrap_tensor(self) -> torch.Tensor:
     return _wrap_tensor_autograd(self)
 
 
+def _maybe_wrap_tensors(tensors: list[torch.Tensor]) -> list[torch.Tensor]:
+    if _are_we_tracing():
+        return wait_tensors(tensors)
+    return list(map(_wrap_tensor_autograd, tensors))
+
+
 @contextlib.contextmanager
 def allow_inflight_collective_as_graph_input_ctx(value: bool = True):
     """
@@ -1503,6 +1516,10 @@ def _all_reduce_meta(self, *args):
 
 def _wait_tensor_meta(self, *args):
     return torch.empty_like(self)
+
+
+def _wait_tensors_meta(tensors):
+    return list(tensors)
 
 
 def _isend_meta(self, *args):
@@ -1619,6 +1636,7 @@ lib_impl.impl("all_reduce_", _all_reduce__meta, "Meta")
 lib_impl.impl("all_reduce_coalesced", _all_reduce_coalesced_meta, "Meta")
 lib_impl.impl("all_reduce_coalesced_", _all_reduce_coalesced__meta, "Meta")
 lib_impl.impl("wait_tensor", _wait_tensor_meta, "Meta")
+lib_impl.impl("wait_tensors", _wait_tensors_meta, "Meta")
 lib_impl.impl("isend", _isend_meta, "Meta")
 lib_impl.impl("irecv", _irecv_meta, "Meta")
 lib_impl.impl("batch_p2p_ops", _batch_p2p_ops_meta, "Meta")
@@ -1661,6 +1679,8 @@ lib_impl_autograd.impl("all_to_all_single", _all_to_all_single_meta, "Meta")
 # whose result tensors are ignored by user code.
 torch.fx.node.has_side_effect(torch.ops._c10d_functional.wait_tensor.default)  # type: ignore[has-type]
 torch.fx.node.has_side_effect(torch.ops._c10d_functional.wait_tensor)  # type: ignore[has-type]
+torch.fx.node.has_side_effect(torch.ops._c10d_functional.wait_tensors.default)  # type: ignore[has-type]
+torch.fx.node.has_side_effect(torch.ops._c10d_functional.wait_tensors)  # type: ignore[has-type]
 torch.fx.node.has_side_effect(torch.ops._c10d_functional.isend.default)  # type: ignore[has-type]
 torch.fx.node.has_side_effect(torch.ops._c10d_functional.isend)  # type: ignore[has-type]
 torch.fx.node.has_side_effect(torch.ops._c10d_functional.irecv.default)  # type: ignore[has-type]
@@ -1945,10 +1965,7 @@ def batch_p2p_ops_inplace(
         op_list, peer_list, tag_list, tensors, group_name
     )
     if _are_we_tracing():
-        return [
-            _maybe_wrap_tensor(t) if op == "irecv" else t
-            for op, t in zip(op_list, tensors)
-        ]
+        return tensors
     return list(map(_maybe_wrap_tensor, tensors))
 
 

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -1519,6 +1519,7 @@ def _wait_tensor_meta(self, *args):
 
 
 def _wait_tensors_meta(tensors):
+    torch._check(len(tensors) > 0, lambda: "wait_tensors requires at least one tensor")
     return list(tensors)
 
 

--- a/torch/distributed/_tools/fake_collectives.py
+++ b/torch/distributed/_tools/fake_collectives.py
@@ -50,6 +50,7 @@ functional_collectives: set[torch._ops.OpOverload] = {
     _c10d_functional.all_to_all_single.default,
     _c10d_functional_autograd.all_to_all_single.default,
     _c10d_functional.wait_tensor.default,
+    _c10d_functional.wait_tensors.default,
     _c10d_functional.all_reduce_.default,
     _c10d_functional.all_reduce_coalesced.default,
     _c10d_functional.all_reduce_coalesced_.default,
@@ -69,6 +70,7 @@ sync_ops: set[torch._ops.OpOverload] = {
     c10d.barrier.default,
     c10d.monitored_barrier_.default,
     _c10d_functional.wait_tensor.default,
+    _c10d_functional.wait_tensors.default,
 }
 
 collective_ops = set.union(functional_collectives, non_functional_collectives)


### PR DESCRIPTION
## Problem

  ### Work and storage

  A `Work` represents one asynchronous backend operation, such as an NCCL group. It owns completion state, typically a CUDA event for NCCL.

  Functional collectives return tensors rather than exposing `Work`. The work registry connects those tensors to their asynchronous operation:

  ```text
  StorageImpl -> [Work, ...]
  ```

  The key is the tensor's weak `StorageImpl` identity, not its tensor object or `data_ptr`. See `torch/csrc/distributed/c10d/ProcessGroup.cpp`.

  Consequently:

  - Views sharing storage share one registry entry.
  - Different storages have different entries.
  - One storage can have multiple pending works.
  - One work can be registered under multiple storages.

  For example, a coalesced all-reduce launches one `Work` and registers it against every output:

  ```text
  storage(out0) -> [W]
  storage(out1) -> [W]
  storage(out2) -> [W]
  ```

  ### `wait_tensor`

  `wait_tensor(out0)`:

  1. Looks up `storage(out0)`.
  2. Removes the complete work list for that storage.
  3. Calls `wait()` on every work in the list.

  Only the `out0` entry is removed:

  ```text
  Before:
  S0 -> [W]
  S1 -> [W]

  wait_tensor(out0):
  S0 entry removed
  W.wait()

  Remaining:
  S1 -> [W]
  ```

  A subsequent `wait_tensor(out1)` finds `W` again and calls `W.wait()` again.

  For NCCL, every `W.wait()` calls `synchronizeStream()`, making the current CUDA stream wait on the work's completion event:

  ```text
  wait_tensor(out0) -> current_stream.wait_event(W.end_event)
  wait_tensor(out1) -> current_stream.wait_event(W.end_event)  # repeated
  ```

  This is generally a CUDA stream dependency, not a device-wide or CPU synchronization. It can block the CPU when blocking-wait mode or a timeout is enabled. On the same stream, the second
  event wait is usually redundant overhead; on different streams, each dependency may be necessary.

  ### Why registry deduplication is insufficient

  Registration deduplicates a work only within one storage entry:

  ```text
  S0 -> [W]  # W is not appended twice here
  S1 -> [W]  # Still allowed because this is another entry
  ```

  There is no reverse `Work -> storages` map or global "already waited" state.

  Views do not have this issue because they share one storage:

  ```text
  view0 --+
          +--> S0 -> [W]
  view1 --+
  ```

  Waiting on either view removes `S0`; waiting on the other is then a no-op.

  ### `wait_tensors`

  `wait_tensors([out0, out1])` pops every supplied storage and deduplicates by `Work*`:

  ```text
  pop S0 -> W  # First occurrence
  pop S1 -> W  # Duplicate

  W.wait()     # Called exactly once
  ```

  This clears every storage registration and inserts one stream wait for the shared coalesced work. Deduplication applies within one `wait_tensors` call; separate later `wait_tensor` calls
  cannot recover that grouping.

  ## Solution

  Add `_c10d_functional.wait_tensors`, which consumes all registrations and waits on each unique `Work` once.

  For multi-output functional collectives:

  ```python
  # Before
  wait_tensor(out0)
  wait_tensor(out1)

  # After
  wait_tensors([out0, out1])
  ```

  For compiled `batch_isend_irecv`, Dynamo similarly combines adjacent, unused per-output waits:

  ```python
  # Before
  wait_tensor(send)
  wait_tensor(recv)

  # After
  wait_tensors([send, recv])
  ```

  Waits separated by computation remain separate, preserving their ordering.

  AOTAutograd saves multi-output collective leaves instead of rematerializing them. AOTInductor support is intentionally deferred; `wait_tensors` is not added to its ABI.

  ## Test Plan

```bash
python test/distributed/test_c10d_functional_native.py
python test/dynamo/test_fake_distributed.py
```

  `spin fixlint` passes the fast lint set but reports the pre-existing clang-tidy backlog in `torch/csrc/distributed/c10d/Functional.cpp`.

  Authored with AI assistance.

  cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98