### PR TITLE
[no-ci] [export_python] export_python: concurrent first writers publish once, atomically

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -38,6 +38,7 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
      nested_compile_region
      load_cache_artifacts
      load_compiled_function
+     export_python
      save_cache_artifacts
      wrap_numpy
 ```

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -1,13 +1,21 @@
 # Owner(s): ["oncall: pt2"]
+import contextlib
 import copy
+import errno
+import gc
+import inspect
 import io
 import os
 import pickle
+import re
+import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
 import unittest
+import weakref
+from unittest import mock
 
 import torch
 import torch.utils._pytree as _pytree
@@ -23,6 +31,69 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
+
+
+class _MisreportedDevice(torch.Tensor):
+    """A wrapper subclass reporting a device that differs from the one holding its bytes.
+
+    torch.load builds exactly this from stock inputs: map_location="cuda" gives a bare
+    "cuda" over a "cuda:0" payload, and map_location={"cuda:0": "cpu"} gives a "cuda:0"
+    wrapper over a "cpu" payload. Both axes have to be decided on the leaf.
+    """
+
+    @staticmethod
+    def __new__(cls, payload, reported):
+        return torch.Tensor._make_wrapper_subclass(
+            cls, payload.shape, dtype=payload.dtype, device=reported
+        )
+
+    def __init__(self, payload, reported):
+        self.payload = payload
+
+    def __tensor_flatten__(self):
+        return ["payload"], None
+
+    @staticmethod
+    def __tensor_unflatten__(inner, ctx, outer_size, outer_stride):
+        payload = inner["payload"]
+        return _MisreportedDevice(payload, payload.device)
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        raise NotImplementedError
+
+
+@contextlib.contextmanager
+def _default_dtype(dtype):
+    previous = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(previous)
+
+
+@contextlib.contextmanager
+def _deterministic(enabled):
+    previous = torch.are_deterministic_algorithms_enabled()
+    torch.use_deterministic_algorithms(enabled)
+    try:
+        yield
+    finally:
+        torch.use_deterministic_algorithms(previous)
+
+
+def _lying_device(device):
+    """A device label differing from `device` in INDEX only."""
+    real = torch.device(device)
+    if real.index is not None:
+        return torch.device(real.type)
+    return torch.device(real.type, 0)
+
+
+def _type_lying_device(device):
+    """A device label differing from `device` in TYPE. Requires no such hardware."""
+    return torch.device("cpu" if torch.device(device).type == "cuda" else "cuda", 0)
 
 
 # A module-level (global) model + a function referencing it, to exercise the
@@ -859,6 +930,13 @@ class TestPrecompile(TestCase):
         # The public location: test_public_bindings.test_correct_module_names also
         # enforces this for every torch.compiler.__all__ member.
         self.assertEqual(torch.compiler.precompile.__module__, "torch.compiler")
+        # export_python is the disk-cached decorator over precompile; it lives
+        # under the same compiler namespace, not as a top-level torch.* verb.
+        self.assertIn("export_python", torch.compiler.__all__)
+        self.assertNotIn("export_python", torch.__all__)
+        self.assertFalse(hasattr(torch, "export_python"))
+        self.assertTrue(callable(torch.compiler.export_python))
+        self.assertEqual(torch.compiler.export_python.__module__, "torch.compiler")
 
     def test_backend_invalid_raises(self):
         a, b = torch.randn(4, 4), torch.randn(4, 4)
@@ -2779,6 +2857,1110 @@ class TestPrecompileNumerics(TestCase):
 
 
 instantiate_device_type_tests(TestPrecompileNumerics, globals())
+
+
+def _artifact_of(wrapped):
+    # The decorator deliberately hands back a plain function with no handle on the
+    # artifact, so reach it through the wrapper's closure. Only tests need this; it is
+    # what lets them assert on load-time decisions like whether the lean entry bound.
+    from torch.compiler._export_python import ExportedPythonArtifact
+
+    return next(
+        cell.cell_contents
+        for cell in wrapped.__closure__
+        if isinstance(cell.cell_contents, ExportedPythonArtifact)
+    )
+
+
+@skipIfTorchDynamo("precompile's make_fx capture is incompatible with dynamo wrapping")
+class TestExportPython(TestCase):
+    # torch.compiler.export_python is the disk-cached decorator over
+    # torch.compiler.precompile: first call writes the emitted, self-contained python,
+    # later calls read and exec it directly. Run device-generically so the inductor
+    # path is exercised on CUDA too.
+
+    def _tmp_path(self, name="artifact.py"):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d, ignore_errors=True)
+        return os.path.join(d, name)
+
+    def _library(self, name, kind="DEF"):
+        # _scoped_library's teardown without its block: these tests define an op and
+        # then use it several statements later, and wrapping each body in a with just
+        # to reach the op reads worse than destroying the library at cleanup.
+        stack = contextlib.ExitStack()
+        self.addCleanup(stack.close)
+        return stack.enter_context(torch.library._scoped_library(name, kind))
+
+    def test_eager_write_then_load(self, device):
+        path = self._tmp_path()
+        x = make_tensor((4, 4), device=device, dtype=torch.float32)
+        y = make_tensor((4, 4), device=device, dtype=torch.float32)
+        expected = (x * 2 + y).relu()
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(a, b):
+                return (a * 2 + b).relu()
+
+            return run
+
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(build()(x, y), expected)
+        self.assertTrue(os.path.exists(path))
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("def forward(", f.read())
+
+        # A fresh decorator over the same path loads the emitted source from disk
+        # rather than recompiling.
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(build()(x, y), expected)
+        self.assertIn("about to EXEC", "\n".join(cm.output))
+
+    def test_inductor_writes_output_code(self, device):
+        path = self._tmp_path("inductor.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run(model, inp):
+            return model(inp)
+
+        self.assertEqual(run(m, x), m(x))
+        with open(path, encoding="utf-8") as f:
+            self.assertIn("Inductor output code", f.read())
+        # export_python writes only the self-contained source; there is no cache.
+        self.assertFalse(os.path.exists(path + ".cache"))
+
+    def test_inductor_reload_from_disk(self, device):
+        # Inductor analogue of test_eager_write_then_load: the first build() lowers
+        # through Inductor and commits the emitted source; a SECOND fresh decorator over
+        # the SAME path must load that source from disk and run it instead of
+        # recompiling, exercising the inductor load-from-disk path.
+        path = self._tmp_path("inductor_reload.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        expected = m(x)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="inductor")
+            def run(model, inp):
+                return model(inp)
+
+            return run
+
+        self.assertEqual(build()(m, x), expected)
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(build()(m, x), expected)
+
+    def test_inductor_edited_source_takes_effect(self, device):
+        # Inductor hill-climb (ejectable compilation): the emitted source is the source
+        # of truth, so an edit that CHANGES THE MATH must take effect on the next load.
+        # A comment-only edit cannot show that, since it is exec-inert either way.
+        path = self._tmp_path("inductor_edit.py")
+        m = torch.nn.Sequential(torch.nn.Linear(4, 3)).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        expected = m(x)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run(model, inp):
+            return model(inp)
+
+        self.assertEqual(run(m, x), expected)
+
+        # Wrap the artifact's own entry point so the edit is backend-agnostic: whatever
+        # forward() computes, the edited file must return twice it.
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        code = code.replace("def forward(", "def _orig_forward(", 1)
+        code += textwrap.dedent(
+            """
+
+            def forward(*args, **kwargs):
+                return _orig_forward(*args, **kwargs) * 2
+            """
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(code)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run2(model, inp):
+            return model(inp)
+
+        self.assertEqual(run2(m, x), expected * 2)
+
+    def test_creates_parent_dirs(self, device):
+        path = self._tmp_path(os.path.join("nested", "deep", "artifact.py"))
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp * 2
+
+        self.assertEqual(run(x), x * 2)
+        self.assertTrue(os.path.exists(path))
+
+    def test_example_inputs_drives_capture(self, device):
+        @torch.compiler.export_python(
+            path=self._tmp_path("ex.py"),
+            backend="eager",
+            example_inputs=[make_tensor((3, 3), device=device, dtype=torch.float32)],
+        )
+        def run(inp):
+            return inp.relu()
+
+        # Capture is specialized to the (3, 3) example, so a (5, 5) runtime input is
+        # rejected -- proving example_inputs, not the call args, drove capture.
+        with self.assertRaisesRegex(PrecompileError, "shape"):
+            run(make_tensor((5, 5), device=device, dtype=torch.float32))
+
+    def test_non_deepcopyable_first_call_arg_errors(self, device):
+        # A non-leaf tensor cannot be deep-copied; the None example_inputs path must
+        # surface a clear error pointing at example_inputs, not a raw deepcopy error.
+        @torch.compiler.export_python(path=self._tmp_path("nc.py"), backend="eager")
+        def run(inp):
+            return inp + 1
+
+        non_leaf = make_tensor(
+            (4,), device=device, dtype=torch.float32
+        ).requires_grad_()
+        with self.assertRaisesRegex(PrecompileError, "example_inputs"):
+            run(non_leaf * 2)
+
+    def test_no_cache_sidecar_written(self, device):
+        # export_python is cache-free: the first run commits only the self-contained
+        # .py, never a .cache sidecar, and a fresh decorator reloads from the .py alone.
+        path = self._tmp_path()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return inp.sin()
+
+            return run
+
+        self.assertEqual(build()(x), x.sin())
+        self.assertFalse(os.path.exists(path + ".cache"))
+        self.assertEqual(build()(x), x.sin())
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_first_call_preserves_rng_state(self, device, backend):
+        x = torch.empty((4,), device=device)
+        path = self._tmp_path(f"rng_{backend}.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend=backend)
+            def run(inp):
+                return torch.rand_like(inp)
+
+            return run
+
+        def rng_state():
+            cpu = torch.random.get_rng_state()
+            if torch.device(device).type == "cpu":
+                return cpu, None
+            module = torch.get_device_module(torch.device(device).type)
+            return cpu, module.get_rng_state(torch.device(device))
+
+        torch.manual_seed(1234)
+        first = build()(x)
+        first_state = rng_state()
+
+        torch.manual_seed(1234)
+        loaded = build()(x)
+        loaded_state = rng_state()
+        self.assertEqual(first, loaded)
+        self.assertEqual(first_state, loaded_state)
+
+    def test_first_call_preserves_noncurrent_cuda_rng_state(self, device):
+        if not TEST_CUDA or torch.cuda.device_count() < 2:
+            self.skipTest("requires two CUDA devices")
+        path = self._tmp_path("rng_noncurrent.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return torch.rand_like(inp)
+
+            return run
+
+        with torch.cuda.device(0):
+            x = torch.empty(8, device="cuda:1")
+            torch.manual_seed(1234)
+            torch.cuda.manual_seed_all(1234)
+            first = build()(x)
+            first_state = torch.cuda.get_rng_state(1)
+
+            torch.manual_seed(1234)
+            torch.cuda.manual_seed_all(1234)
+            loaded = build()(x)
+            loaded_state = torch.cuda.get_rng_state(1)
+
+        self.assertEqual(first, loaded)
+        self.assertEqual(first_state, loaded_state)
+
+    def _capture_racing_a_concurrent_draw(self, run, x):
+        """Run ``run(x)``'s first capture with a concurrent torch.rand(8) inside it.
+
+        Returns (error_or_None, the concurrently drawn tensor). The capture is stalled
+        on entry so the draw is guaranteed to land between the pre-capture generator
+        snapshot and the post-capture restore decision.
+        """
+        import threading
+        from unittest.mock import patch
+
+        import torch._precompile as precompile_impl
+
+        entered = threading.Event()
+        release = threading.Event()
+        real_capture = precompile_impl._capture
+
+        def synchronized_capture(*args, **kwargs):
+            entered.set()
+            self.assertTrue(release.wait(10))
+            return real_capture(*args, **kwargs)
+
+        errors = []
+
+        def worker():
+            try:
+                run(x)
+            except BaseException as e:
+                errors.append(e)
+
+        with patch.object(precompile_impl, "_capture", synchronized_capture):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            self.assertTrue(entered.wait(10))
+            concurrent = torch.rand(8)
+            release.set()
+            thread.join(20)
+        self.assertFalse(thread.is_alive())
+        return (errors[0] if errors else None), concurrent
+
+    def test_random_capture_restores_rng_off_the_main_thread(self, device):
+        # Restoring the generators the capture drew from is what keeps a random fn's
+        # first call faithful, and it is not conditioned on thread identity: the
+        # capturing call and the loading call agree even from a worker thread.
+        import threading
+
+        path = self._tmp_path("rng_worker.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return torch.rand_like(inp)
+
+            return run
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        results = []
+        errors = []
+
+        def worker():
+            try:
+                out = build()(x)
+                results.append((out, torch.random.get_rng_state()))
+            except BaseException as e:
+                errors.append(e)
+
+        for _ in range(2):
+            torch.manual_seed(1234)
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join(20)
+            self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(results[0], results[1])
+
+    def test_explicit_examples_released_after_materialization(self, device):
+        example = make_tensor((4,), device=device, dtype=torch.float32)
+        example_ref = weakref.ref(example)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("example_lifetime.py"),
+            backend="eager",
+            example_inputs=[example],
+        )
+        def run(inp):
+            return inp + 1
+
+        del example
+        self.assertEqual(
+            run(make_tensor((4,), device=device, dtype=torch.float32)).shape,
+            (4,),
+        )
+        gc.collect()
+        self.assertIsNone(example_ref())
+
+    def test_decompositions_released_after_materialization(self, device):
+        path = self._tmp_path("decomposition_lifetime.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def seed(inp):
+            return inp + 1
+
+        self.assertEqual(seed(x), x + 1)
+        payload = make_tensor((4,), device=device, dtype=torch.float32)
+        payload_ref = weakref.ref(payload)
+
+        def make_decomposition(value):
+            def decomposition(inp):
+                return inp + value.sum() * 0
+
+            return decomposition
+
+        decomposition = make_decomposition(payload)
+        table = {torch.ops.aten.sin.default: decomposition}
+
+        @torch.compiler.export_python(path=path, backend="eager", decompositions=table)
+        def loaded(inp):
+            return inp + 1
+
+        self.assertEqual(loaded(x), x + 1)
+        del payload, decomposition, table
+        gc.collect()
+        self.assertIsNone(payload_ref())
+
+    def test_decorated_method_binds_instance(self, device):
+        path = self._tmp_path("method.py")
+
+        class Model(torch.nn.Module):
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(self, inp):
+                return inp + 1
+
+        model = Model()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertTrue(inspect.ismethod(model.run))
+        self.assertEqual(model.run(x), x + 1)
+
+    def test_decorated_function_is_picklable(self, device):
+        name = "_export_python_pickle_fixture"
+
+        def original(inp):
+            return inp + 1
+
+        original.__name__ = name
+        original.__qualname__ = name
+        original.__module__ = __name__
+        wrapped = torch.compiler.export_python(
+            path=self._tmp_path("pickle.py"), backend="eager"
+        )(original)
+        globals()[name] = wrapped
+        try:
+            self.assertIs(pickle.loads(pickle.dumps(wrapped)), wrapped)
+        finally:
+            del globals()[name]
+
+    def test_hill_climb_edited_source_takes_effect(self, device):
+        path = self._tmp_path("edit.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        edited = code.replace(
+            "torch.ops.aten.add.Tensor(flat_1, 1)",
+            "torch.ops.aten.add.Tensor(flat_1, 100)",
+        )
+        self.assertNotEqual(
+            edited, code, "expected the add constant in the emitted graph"
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(edited)
+
+        # A fresh decorator sees the edited source and always exec's it, so the edited
+        # constant takes effect.
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        self.assertEqual(run2(x), x + 100)
+
+    def test_first_call_applies_mutation_once(self, device):
+        path = self._tmp_path("bn.py")
+        torch.manual_seed(0)
+        m = torch.nn.BatchNorm1d(4).to(device).train()
+        x = make_tensor((8, 4), device=device, dtype=torch.float32)
+
+        ref = torch.nn.BatchNorm1d(4).to(device).train()
+        ref.load_state_dict(m.state_dict())
+        ref(x)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(model, inp):
+            return model(inp)
+
+        run(m, x)
+        # Capture deep-copies the args, so the running stats are updated exactly once
+        # (by the artifact), matching a single eager application -- not twice.
+        self.assertEqual(m.running_mean, ref.running_mean)
+        self.assertEqual(m.running_var, ref.running_var)
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_concurrent_first_calls_precompile_once(self, device, backend):
+        import threading
+        from unittest.mock import patch
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("concurrent.py"), backend=backend
+        )
+        def run(inp):
+            return inp + 1
+
+        real = torch.compiler.precompile
+
+        # Count precompile() invocations; the decorator calls torch.compiler.precompile
+        # exactly once behind its double-checked lock even under the racing first calls.
+        class _Counting:
+            def __init__(self):
+                self.n = 0
+
+            def __call__(self, *a, **k):
+                self.n += 1
+                return real(*a, **k)
+
+        counting = _Counting()
+        n = 8
+        barrier = threading.Barrier(n)
+        results: list = [None] * n
+
+        def worker(i):
+            barrier.wait()
+            results[i] = run(x)
+
+        with patch.object(torch.compiler, "precompile", counting):
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+        # The double-checked lock must precompile exactly once despite the race.
+        self.assertEqual(counting.n, 1)
+        for r in results:
+            self.assertEqual(r, x + 1)
+
+    def test_concurrent_distinct_captures_are_serialized(self, device):
+        import threading
+        import time
+        from unittest.mock import patch
+
+        import torch._precompile as precompile_impl
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        runs = []
+        for i in range(4):
+
+            @torch.compiler.export_python(
+                path=self._tmp_path(f"concurrent_{i}.py"), backend="eager"
+            )
+            def run(inp):
+                return inp + 1
+
+            runs.append(run)
+
+        real = precompile_impl._capture
+        state_lock = threading.Lock()
+        active = 0
+        max_active = 0
+
+        def spy(*args, **kwargs):
+            nonlocal active, max_active
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.02)
+                return real(*args, **kwargs)
+            finally:
+                with state_lock:
+                    active -= 1
+
+        barrier = threading.Barrier(len(runs))
+        results: list = [None] * len(runs)
+
+        def worker(i):
+            barrier.wait()
+            results[i] = runs[i](x)
+
+        with patch.object(precompile_impl, "_capture", spy):
+            threads = [threading.Thread(target=worker, args=(i,)) for i in range(4)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        self.assertEqual(max_active, 1)
+        for result in results:
+            self.assertEqual(result, x + 1)
+
+    def test_export_and_direct_precompile_captures_are_serialized(self, device):
+        import threading
+        import time
+        from unittest.mock import patch
+
+        import torch._precompile as precompile_impl
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("direct_concurrent.py"), backend="eager"
+        )
+        def exported(inp):
+            return inp + 1
+
+        real_capture = precompile_impl._capture
+        state_lock = threading.Lock()
+        active = 0
+        max_active = 0
+
+        def spy(*args, **kwargs):
+            nonlocal active, max_active
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.05)
+                return real_capture(*args, **kwargs)
+            finally:
+                with state_lock:
+                    active -= 1
+
+        barrier = threading.Barrier(2)
+        errors = []
+
+        def export_worker():
+            try:
+                barrier.wait()
+                exported(x)
+            except BaseException as e:
+                errors.append(e)
+
+        def precompile_worker():
+            try:
+                barrier.wait()
+                torch.compiler.precompile(lambda inp: inp + 2, x, backend="eager")
+            except BaseException as e:
+                errors.append(e)
+
+        with patch.object(precompile_impl, "_capture", spy):
+            threads = [
+                threading.Thread(target=export_worker),
+                threading.Thread(target=precompile_worker),
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(20)
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        self.assertEqual(max_active, 1)
+
+    def test_nested_first_capture_does_not_deadlock(self, device):
+        code = textwrap.dedent(
+            f"""
+            import os
+            import tempfile
+            import torch
+
+            with tempfile.TemporaryDirectory() as d:
+                example = torch.ones(1, device={device!r})
+
+                @torch.compiler.export_python(
+                    path=os.path.join(d, "inner.py"),
+                    backend="eager",
+                    example_inputs=[example],
+                )
+                def inner(x):
+                    return x + 1
+
+                @torch.compiler.export_python(
+                    path=os.path.join(d, "outer.py"), backend="eager"
+                )
+                def outer(x):
+                    return inner(x) * 2
+
+                torch.testing.assert_close(outer(example), (example + 1) * 2)
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_same_path_concurrent_publish_has_one_winner(self, device):
+        # Two PROCESSES racing a fresh path is the real scenario (in one process,
+        # materialization is serialized by the capture lock, so the second caller just
+        # finds the file). Both must end up running the winner's artifact, never their
+        # own divergent source, and no temp file may be left beside it.
+        code = textwrap.dedent(
+            f"""
+            import os, sys, torch
+            path, marker, barrier_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+
+            real = torch.compiler.precompile
+            def fake(fn, *args, **kwargs):
+                return "def forward(x):\\n    return x + " + marker + "\\n", b""
+            torch.compiler.precompile = fake
+
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return inp
+
+            # Rendezvous so both processes are inside the presence gate together.
+            open(os.path.join(barrier_dir, marker), "w").close()
+            while len(os.listdir(barrier_dir)) < 2:
+                pass
+            print(int(run(torch.zeros(1, device={device!r})).item()))
+            """
+        )
+        path = self._tmp_path("publish.py")
+        barrier_dir = os.path.join(os.path.dirname(path), "barrier")
+        os.makedirs(barrier_dir, exist_ok=True)
+        procs = [
+            subprocess.Popen(
+                [sys.executable, "-c", code, path, marker, barrier_dir],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            for marker in ("1", "2")
+        ]
+        outs = []
+        for proc in procs:
+            stdout, stderr = proc.communicate(timeout=180)
+            self.assertEqual(proc.returncode, 0, stderr)
+            outs.append(stdout.strip().splitlines()[-1])
+        # Same answer in both, and it is one of the two candidate artifacts.
+        self.assertEqual(outs[0], outs[1])
+        self.assertIn(outs[0], ("1", "2"))
+        self.assertEqual(
+            sorted(os.listdir(os.path.dirname(path))),
+            sorted(["barrier", os.path.basename(path)]),
+        )
+
+        # A third, later reader gets that same winner off disk.
+        @torch.compiler.export_python(path=path, backend="eager")
+        def fresh(inp):
+            return inp
+
+        self.assertEqual(int(fresh(torch.zeros(1, device=device)).item()), int(outs[0]))
+
+    def test_publish_falls_back_when_filesystem_has_no_hard_links(self, device):
+        from torch.compiler._export_python import _atomic_publish
+
+        path = self._tmp_path("nolink.py")
+        real_link = os.link
+
+        def no_link(src, dst):
+            raise OSError(errno.EPERM, "operation not permitted")
+
+        with mock.patch.object(os, "link", no_link):
+            with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+                self.assertTrue(_atomic_publish(path, b"payload"))
+        # Assert on wording only the implementation supplies: the mock's strerror is
+        # interpolated into the same message and would satisfy a looser match.
+        self.assertTrue(any("last-writer-wins" in m for m in logs.output))
+        with open(path, "rb") as f:
+            self.assertEqual(f.read(), b"payload")
+        self.assertEqual(os.listdir(os.path.dirname(path)), [os.path.basename(path)])
+        self.assertIs(os.link, real_link)
+
+    def test_publish_does_not_swallow_real_io_errors(self, device):
+        # Only "this filesystem has no hard links" degrades to last-writer-wins; a full
+        # disk must surface rather than silently weaken first-publisher-wins.
+        from torch.compiler._export_python import _atomic_publish
+
+        path = self._tmp_path("enospc.py")
+
+        def full_disk(src, dst):
+            raise OSError(errno.ENOSPC, "no space left on device")
+
+        with mock.patch.object(os, "link", full_disk):
+            with self.assertRaises(OSError):
+                _atomic_publish(path, b"payload")
+        self.assertFalse(os.path.exists(path))
+        self.assertEqual(os.listdir(os.path.dirname(path)), [])
+
+    def test_clobbered_non_artifact_source_raises_clean_error(self, device):
+        # A clobbered non-artifact source degrades to a clean PrecompileError
+        # referencing the path, not a raw KeyError/SyntaxError, so a stale hand-edit
+        # that drops the forward() surfaces an actionable message.
+        path = self._tmp_path("clobber.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("x = 1\n")
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(
+            PrecompileError, "could not be run as precompile source"
+        ):
+            run2(x)
+
+    def test_kwargs_bound_positionally(self, device):
+        path = self._tmp_path("kw.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(a, b):
+            return a - b
+
+        # A keyword call binds onto (a, b) positionally and runs the artifact.
+        self.assertEqual(run(a=x, b=x + 1), x - (x + 1))
+
+    def test_keyword_only_params_rejected(self, device):
+        @torch.compiler.export_python(path=self._tmp_path("ko.py"), backend="eager")
+        def run(a, *, b):
+            return a + b
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, "keyword-only"):
+            run(x, b=x)
+
+    def test_positional_defaults_are_canonicalized(self, device):
+        default = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=self._tmp_path("posdef.py"), backend="eager")
+        def run(a, b=default, c=default):
+            return a + b + c
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        other = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertEqual(run(x, c=other), x + default + other)
+        self.assertEqual(run(x, b=other), x + other + default)
+
+    def test_non_tensor_arguments_rejected(self, device):
+        @torch.compiler.export_python(path=self._tmp_path("scalar.py"), backend="eager")
+        def run(inp, scale=1):
+            return inp * scale
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, "only Tensor pytrees"):
+            run(x, 1)
+
+    def test_var_kwargs_rejected(self, device):
+        # A fn declaring **kwargs cannot be laid out positionally once extra keyword
+        # args are passed; the error must name **kwargs as the cause rather than
+        # misreporting it as a positional-or-keyword arg left to its default.
+        @torch.compiler.export_python(path=self._tmp_path("varkw.py"), backend="eager")
+        def run(a, **kw):
+            return a + kw["b"]
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(TypeError, r"\*\*kwargs"):
+            run(x, b=x)
+
+    def test_decompositions_forwarded(self, device):
+        from unittest.mock import patch
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        sentinel: dict = {}
+        real = torch.compiler.precompile
+        captured: dict = {}
+
+        def spy(fn, *a, **k):
+            captured["decompositions"] = k.get("decompositions")
+            return real(fn, *a, **k)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("dec.py"), backend="eager", decompositions=sentinel
+        )
+        def run(inp):
+            return inp + 1
+
+        with patch.object(torch.compiler, "precompile", spy):
+            self.assertEqual(run(x), x + 1)
+        self.assertIs(captured["decompositions"], sentinel)
+
+    def test_existing_artifact_ignores_changed_backend(self, device):
+        # Presence is the sole signal: a new decorator over an existing path loads it
+        # as-is even with a different backend, so the on-disk eager artifact is reused
+        # and NOT re-lowered through inductor.
+        path = self._tmp_path("sole_signal.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            first = f.read()
+        self.assertNotIn("Inductor output code", first)
+
+        @torch.compiler.export_python(path=path, backend="inductor")
+        def run2(inp):
+            return inp + 1
+
+        self.assertEqual(run2(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            self.assertEqual(f.read(), first)
+
+    def test_artifact_raising_at_module_scope_is_a_distinct_error(self, device):
+        # The third arm of _load's taxonomy: not a syntax/structure problem and not a
+        # failed import, but source that blows up while being exec'd.
+        path = self._tmp_path("raises.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("raise RuntimeError('boom')\n" + code)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(PrecompileError, "unexpected error occurred"):
+            loaded(x)
+
+    def test_recursive_decorated_function_raises_not_hangs(self, device):
+        path = self._tmp_path("recursive.py")
+        depth = [1]
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def f(inp):
+            if depth[0] > 0:
+                depth[0] -= 1
+                return f(inp + 1)
+            return inp * 2
+
+        with self.assertRaisesRegex(PrecompileError, "re-entrant call"):
+            f(make_tensor((4,), device=device, dtype=torch.float32))
+
+    def test_artifact_deleted_between_gate_and_read_regenerates(self, device):
+        # A peer deleting the artifact to force a regenerate must not surface as a bare
+        # FileNotFoundError from behind the presence gate.
+        path = self._tmp_path("toctou.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def seed(inp):
+            return inp + 1
+
+        self.assertEqual(seed(x), x + 1)
+
+        real_exists = os.path.exists
+
+        def exists_then_delete(p):
+            result = real_exists(p)
+            if p == path and result:
+                os.remove(p)
+            return result
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def racer(inp):
+            return inp + 1
+
+        with mock.patch.object(os.path, "exists", exists_then_delete):
+            self.assertEqual(racer(x), x + 1)
+        self.assertTrue(real_exists(path))
+
+    def test_path_naming_a_directory_is_a_clean_error(self, device):
+        path = self._tmp_path("adirectory.py")
+        os.makedirs(path)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(PrecompileError, "readable file"):
+            run(make_tensor((4,), device=device, dtype=torch.float32))
+
+    def test_none_and_nested_module_arguments_name_their_own_cause(self, device):
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=self._tmp_path("none.py"), backend="eager")
+        def optional(inp, mask=None):
+            return inp + 1
+
+        with self.assertRaisesRegex(TypeError, "does not support None arguments"):
+            optional(x)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("nestmod.py"), backend="eager"
+        )
+        def nested(mods, inp):
+            return mods[0](inp)
+
+        with self.assertRaisesRegex(TypeError, "must be passed directly"):
+            nested([torch.nn.Linear(4, 4).to(device)], x)
+
+    def test_genuine_out_parameter_is_not_hijacked(self, device):
+        # Nothing about the name ``out`` is special any more -- the reserved keyword-only
+        # form went away with buffer donation -- so an ordinary parameter that happens to
+        # be called out must bind by keyword like any other.
+        @torch.compiler.export_python(
+            path=self._tmp_path("genuine.py"), backend="eager"
+        )
+        def run(a, out):
+            return a + out
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertEqual(run(x, out=x), x + x)
+
+    def test_capture_failure_leaves_rng_alone(self, device):
+        # A rejected capture has no graph to attribute draws to, so it must not rewind:
+        # capture rejections are routine and would replay a concurrent thread's draws.
+        import torch._precompile as precompile_impl
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("capture_fail.py"), backend="eager"
+        )
+        def run(inp):
+            return torch.rand_like(inp)
+
+        def boom(*args, **kwargs):
+            torch.rand(4)  # the half-run fn drew before failing
+            raise PrecompileError("synthetic capture failure")
+
+        torch.manual_seed(1234)
+        before = torch.random.get_rng_state().clone()
+        with mock.patch.object(precompile_impl, "_capture", boom):
+            with self.assertRaisesRegex(PrecompileError, "synthetic capture failure"):
+                run(x)
+        self.assertNotEqual(torch.random.get_rng_state(), before)
+
+    def test_capture_drawing_only_on_the_accelerator_leaves_cpu_rng_alone(self, device):
+        # The restore is per generator, not all-or-nothing: rewinding the CPU generator
+        # for a graph that only drew on CUDA replays an unrelated CPU draw.
+        if not TEST_CUDA or torch.device(device).type != "cuda":
+            self.skipTest("needs a non-CPU generator to draw from")
+        path = self._tmp_path("cuda_only_rng.py")
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return torch.rand_like(inp)
+
+        x = torch.zeros(4, device=device)
+        torch.manual_seed(1234)
+        error, concurrent = self._capture_racing_a_concurrent_draw(run, x)
+        self.assertIsNone(error)
+        self.assertNotEqual(torch.rand(8), concurrent)
+
+    def _rope_artifact(self, device, **kwargs):
+        # Two outputs, both plain allocated buffers: the shape out= is designed for.
+        path = self._tmp_path("out_rope.py")
+
+        @torch.compiler.export_python(path=path, **kwargs)
+        def run(a, b, c, *, out=None):
+            return a * c + b, b * c - a
+
+        return run
+
+    def test_untagged_drawing_op_still_restores(self, device):
+        # An opaque custom op can draw inside its own kernel with nothing in the graph
+        # to say so -- the shape this API targets. Attributing the restore per device
+        # would leave those draws un-restored, so a non-aten op in the graph has to
+        # fall back to restoring every snapshotted generator.
+        lib = self._library("precompile_untagged")
+        lib.define("draw(Tensor x) -> Tensor")
+        lib.impl("draw", lambda x: x + torch.rand_like(x), "CompositeExplicitAutograd")
+        path = self._tmp_path("untagged.py")
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return torch.ops.precompile_untagged.draw(inp)
+
+            return run
+
+        x = torch.zeros(4, device=device)
+        torch.manual_seed(1234)
+        first = build()(x).clone()
+        torch.manual_seed(1234)
+        self.assertEqual(build()(x), first)
+
+    def test_fake_traced_capture_consumes_no_rng(self, device):
+        # Why the restore is skipped for a fake-traced capture: mark_unbacked traces on
+        # FakeTensors, so no kernel runs and nothing is consumed, even though the graph
+        # contains a drawing op. Restoring on the strength of the graph alone would
+        # rewind whatever a concurrent thread drew, for a capture that took nothing.
+        # (Only the premise is asserted here: the skip itself is unobservable through
+        # the public API, because the artifact's own real run redraws immediately.)
+        from torch._precompile import _capture, _graph_rng_devices
+
+        x = make_tensor((64,), device=device, dtype=torch.float32)
+        mark_unbacked(x, 0)
+        torch.manual_seed(1234)
+        before = torch.random.get_rng_state().clone()
+        capture = _capture(
+            lambda i: torch.nn.functional.dropout(i, 0.5, True), (x,), None
+        )
+        self.assertIsNotNone(capture.fake_mode)
+        self.assertEqual(torch.random.get_rng_state(), before)
+        # Anti-vacuity: the graph really does contain a draw the device scan attributes,
+        # so skipping the restore is a decision and not an empty set falling through.
+        self.assertTrue(_graph_rng_devices(capture.gm))
+
+    def test_artifact_does_not_bake_the_capture_thread_count(self, device):
+        # Inductor sizes a CPU reduction's per-thread accumulator array at codegen time
+        # when the capturing process's thread count equals os.cpu_count(), while still
+        # emitting a team whose size is decided at run time. Replaying under a larger
+        # OMP team then indexes past the end -- a SIGSEGV on the SAME machine, reachable
+        # by one torch.set_num_threads() call, which no part of the artifact contract
+        # covers. Capture runs in a subprocess because it has to change a process-global
+        # thread count, and the invariant is asserted on the emitted source rather than
+        # by replaying: replaying a regression is a crash, which in-process would abort
+        # the interpreter and hide every later test, and out-of-process needs a second
+        # compile that made this test load-sensitive.
+        if torch.device(device).type != "cpu":
+            self.skipTest("the baked array is CPU reduction codegen")
+        path = self._tmp_path("threads.py")
+        code = textwrap.dedent(
+            f"""
+            import os, torch
+            torch.set_num_threads(os.cpu_count())
+            run = torch.compiler.export_python(path={path!r})(lambda a: a.sum())
+            run(torch.randn(1 << 20))
+            """
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=600
+        )
+        self.assertEqual(
+            proc.returncode, 0, f"{proc.returncode}\n{proc.stderr[-2000:]}"
+        )
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
+        # A team-sized array is written as e.g. tmp_acc0_arr[384]; with dynamic_threads
+        # pinned it sizes itself from omp_get_max_threads() at run time instead.
+        baked = re.findall(r"_arr\[(\d+)\]", source)
+        self.assertEqual(baked, [], f"artifact bakes a fixed per-thread array: {baked}")
+
+
+instantiate_device_type_tests(TestExportPython, globals())
 
 
 if __name__ == "__main__":

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1010,21 +1010,26 @@ def export_python(
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     r"""Export the Python emitted by :func:`torch.compiler.precompile` to disk.
 
-    This exists for **hill climbing on generated kernels**, not for deployment. The
-    first call captures ``fn`` and writes a self-contained, readable Python file to
-    ``path``; later calls exec that file. Because the file is the source of truth, you
-    can open it, retune a block size or a schedule, rerun, and your edit takes effect --
-    no recapture, no cache to defeat, and the result can be committed and reviewed like
-    any other source. The artifact is read and exec'd once per decorated object per
-    process, so an edit is picked up by the next run of your script (or a freshly
-    decorated function), not by a wrapper you have already called in this process.
+    The first call captures ``fn`` and writes a self-contained, readable Python file to
+    ``path``; later calls exec that file. ``path`` is a build artifact meant to be
+    committed and shipped: what runs in production is source you can open, review and
+    diff, not a cache entry reconstructed at startup.
 
-    **The central tradeoff is that the artifact is sticky.** ``path`` is the whole cache
-    key: nothing hashes ``fn``'s body, the ambient config, or the machine. That is
-    deliberate and it is what makes the workflow above possible -- an artifact that
-    re-captured whenever something changed would throw away your edits. The cost is that
-    the artifact does not notice when it has gone stale: **edit ``fn`` and rerun, and you
-    get the old compiled code with no warning.** Delete ``path`` to recapture.
+    That is what makes it **hill-climbable**. Most generated kernels are fine as
+    generated and never touched. When one starts to matter, retune it in place -- a
+    block size, a schedule, or the whole kernel by hand -- and the tuned version is
+    reviewed, committed and deployed like any other source. There is no recapture and no
+    cache to defeat, so the edit is simply what runs from then on; you never have to
+    choose up front between generated and hand-written code. The artifact is read and
+    exec'd once per decorated object per process, so an edit takes effect on the next run
+    of the process, not in one already running.
+
+    **``path`` is the whole cache key**: nothing hashes ``fn``'s body, the ambient
+    config, or the machine. In production that is the property you want -- the artifact
+    you tested is the one that runs, nothing recompiles behind you, and a kernel someone
+    spent a week tuning is never silently thrown away by a recapture. The cost falls on
+    development: **edit ``fn`` and rerun, and you get the old compiled code with no
+    warning.** Delete ``path`` to recapture.
 
     .. warning::
         This API is experimental and subject to change.
@@ -1076,12 +1081,12 @@ def export_python(
     capture. Calling the artifact under ``torch.no_grad()`` is unaffected and is the
     ordinary inference path.
 
-    Unlike a binary artifact, ``path`` is readable, re-executable Python meant to be
-    committed and hand-edited. An engineer or agent can "hill-climb" the generated
-    kernel in place (ejectable compilation): the emitted source is always exec'd, so
-    edits always take effect. Keeping the edited source correct is the caller's
-    responsibility. The original eager function stays in source as the reference to
-    regenerate from (delete ``path`` to re-precompile).
+    Unlike a binary artifact, ``path`` is readable, re-executable Python: it can be
+    committed, reviewed, diffed across a release, and hand-edited by an engineer or an
+    agent (ejectable compilation). The emitted source is always exec'd, so edits always
+    take effect, and keeping the edited source correct is the caller's responsibility.
+    The original eager function stays in source as the reference to regenerate from
+    (delete ``path`` to re-precompile).
 
     Args:
         path: Filesystem path for the emitted Python source. Parent directories are

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1,7 +1,7 @@
 # mypy: allow-untyped-defs
 import contextlib
 import io
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, TYPE_CHECKING, TypeVar
 from typing_extensions import ParamSpec
 
@@ -46,6 +46,7 @@ __all__ = [
     "cudagraph_mark_step_begin",
     "load_compiled_function",
     "precompile",
+    "export_python",
     "PrecompileError",
     "wrap_numpy",
     "is_compiling",
@@ -997,3 +998,155 @@ def load_compiled_function(
 
     data = file.read()
     return AOTCompiledFunction.deserialize(data, f_globals, external_data)
+
+
+def export_python(
+    *,
+    path: str,
+    backend: str = "inductor",
+    tracer: str = "make_fx",
+    decompositions: dict | None = None,
+    example_inputs: Sequence[object] | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    r"""Export the Python emitted by :func:`torch.compiler.precompile` to disk.
+
+    This exists for **hill climbing on generated kernels**, not for deployment. The
+    first call captures ``fn`` and writes a self-contained, readable Python file to
+    ``path``; later calls exec that file. Because the file is the source of truth, you
+    can open it, retune a block size or a schedule, rerun, and your edit takes effect --
+    no recapture, no cache to defeat, and the result can be committed and reviewed like
+    any other source. The artifact is read and exec'd once per decorated object per
+    process, so an edit is picked up by the next run of your script (or a freshly
+    decorated function), not by a wrapper you have already called in this process.
+
+    **The central tradeoff is that the artifact is sticky.** ``path`` is the whole cache
+    key: nothing hashes ``fn``'s body, the ambient config, or the machine. That is
+    deliberate and it is what makes the workflow above possible -- an artifact that
+    re-captured whenever something changed would throw away your edits. The cost is that
+    the artifact does not notice when it has gone stale: **edit ``fn`` and rerun, and you
+    get the old compiled code with no warning.** Delete ``path`` to recapture.
+
+    .. warning::
+        This API is experimental and subject to change.
+
+    .. warning::
+        An artifact is only valid on the machine type that produced it. The emitted
+        source hardcodes the CPU vector width inductor chose, and for CUDA the compute
+        capability and device ordinal of the producing GPU. The vector width and the
+        compute capability are never re-checked; the device ordinal is re-checked by the
+        default driver. Running a CPU artifact
+        under a DIFFERENT ISA than it captured on is unsafe in both directions, and the
+        loop stride is baked at capture while the ISA is re-picked when the artifact
+        compiles. Loading under a WIDER ISA writes past the end of the output -- heap
+        corruption. Loading under a NARROWER one leaves roughly half of each vectorized
+        strip unwritten, so the output is part uninitialized memory. Neither raises. ``torch._inductor.config.cpp.simdlen``
+        and ``ATEN_CPU_CAPABILITY`` change this on one machine, so they count as part of
+        the machine type. Running a CUDA artifact on a
+        different architecture fails with a kernel-image error. Commit an artifact only
+        alongside the machine type it captured on, and regenerate (delete ``path``) when
+        that changes; nothing detects the change for you.
+
+    ``export_python`` is a decorator wrapping :func:`torch.compiler.precompile`.
+    On the first run in an environment it precompiles the decorated function (make_fx
+    capture plus backend lowering) and writes the emitted, self-contained Python
+    source to ``path``. On any later run the ``.py`` is already present, so
+    precompilation is skipped: the source is read back from disk and executed
+    directly. There is no acceleration cache -- the emitted source is self-contained
+    and always exec'd as written.
+
+    It is a distinct entry point rather than a ``path=`` kwarg on
+    :func:`torch.compiler.precompile` because the two have different shapes: the raw
+    ``precompile(fn, *example_inputs)`` primitive is eager, takes the example inputs
+    positionally (mirroring how ``fn`` is called), and returns ``(python_code,
+    cache)`` for the caller to manage. ``export_python`` is a decorator that owns the
+    on-disk artifact and returns a runnable, so ``fn`` arrives via ``@`` and the
+    example inputs move to a keyword-only ``example_inputs`` list.
+
+    Keyword call arguments and positional defaults are normalized onto ``fn``'s full
+    positional signature (so ``rope(q=..., k=...)`` works and omitted defaults do not
+    change the artifact arity). Runtime arguments must be ``Tensor`` pytrees or direct
+    ``nn.Module`` arguments. Python scalar/config arguments are rejected because
+    ``make_fx`` specializes their values without emitting runtime guards; close such
+    constants over in ``fn`` instead. Other keyword-only parameters are not expressible
+    in the artifact's positional convention and are rejected.
+    Other Python attributes and Python control flow are specialized at capture and must remain compatible with the example.
+    That includes ``torch.is_grad_enabled()``: capture traces with grad enabled so a
+    backward inside ``fn`` is built as graph ops, so a ``fn`` that branches on it always
+    captures the grad-enabled branch, whatever the grad mode of the call that triggered
+    capture. Calling the artifact under ``torch.no_grad()`` is unaffected and is the
+    ordinary inference path.
+
+    Unlike a binary artifact, ``path`` is readable, re-executable Python meant to be
+    committed and hand-edited. An engineer or agent can "hill-climb" the generated
+    kernel in place (ejectable compilation): the emitted source is always exec'd, so
+    edits always take effect. Keeping the edited source correct is the caller's
+    responsibility. The original eager function stays in source as the reference to
+    regenerate from (delete ``path`` to re-precompile).
+
+    Args:
+        path: Filesystem path for the emitted Python source. Parent directories are
+            created as needed. Its presence is the sole signal used to decide whether
+            to precompile or to load. Nothing about ``fn`` is hashed, so changing the
+            body of ``fn`` itself -- or pointing a different function at the same
+            ``path`` -- does NOT invalidate a previously written artifact, and neither
+            does changing ``backend``, ``tracer``, ``decompositions``, or
+            ``example_inputs``: an existing ``path`` is loaded as-is. A stale artifact
+            after a source edit is the expected failure mode; delete ``path`` to force
+            a re-precompile. Loading any
+            existing artifact also warns before executing it because ``path`` is trusted
+            executable Python and may have been edited or replaced. A CUDA artifact
+            additionally embeds inductor's kernel-cache paths, so it is not byte-stable
+            across machines or users even when the numerics are. Triton autotuning is
+            re-run on load rather than recorded, so a cold start may pick a different
+            config and return slightly different floating-point results. Concurrent first
+            writers use first-publisher-wins semantics: every loser loads the complete
+            artifact that won instead of executing different generated source. (On a
+            filesystem without hard links this degrades to last-writer-wins; the file
+            is never partial either way.) New files use the permissions selected by the
+            process umask.
+        backend: How the captured graph is realized: ``"inductor"`` (default) or
+            ``"eager"``. Forwarded to :func:`torch.compiler.precompile`.
+        tracer: Capture front-end; ``"make_fx"`` (default) is the only one
+            implemented. Forwarded to :func:`torch.compiler.precompile`.
+        decompositions: Optional decomposition table forwarded to ``make_fx`` during
+            capture.
+        example_inputs: Positional inputs used to drive precompilation, matching
+            ``fn``'s own positional signature (``nn.Module`` arguments stay at their
+            original positions; the rest are the runtime inputs). If None, the first
+            call's own arguments are used, deep-copied for capture so a mutating
+            ``fn`` is applied exactly once. Pass ``example_inputs`` explicitly when
+            the first-call arguments are not deep-copyable (e.g. non-leaf tensors or
+            ``weight_norm`` modules). Explicit ``example_inputs`` are consumed by
+            capture, which runs ``fn`` once and mutates them (e.g. module buffers), so
+            they must NOT be objects that also appear in the runtime call args --
+            otherwise the mutation is applied twice (once at capture, once by the
+            artifact). The None path avoids this by deep-copying the first call's args
+            for capture. Note that this deep copy includes the full weights of any
+            ``nn.Module`` argument, so it transiently doubles that memory. Pass
+            ``example_inputs`` explicitly for large modules to avoid the clone.
+            Capture restores the generator state it consumed, so capturing does not
+            advance the default generators the first call is about to draw from. A draw
+            naming an explicit ``torch.Generator`` is attributed to its output's device,
+            so the default generator for that device is restored while the named one is
+            left advanced. This is about
+            generator POSITION, not value parity with eager: ``backend="inductor"``
+            lowers random ops to inductor's own philox and produces different values
+            than eager at the same seed. The CPU generator is always saved; for
+            CUDA/XPU only the current device of each initialized accelerator and any
+            device reachable from the examples are, and a graph that draws elsewhere is
+            warned about rather than restored. The restore is process-global, so if
+            ``fn`` draws, a concurrent thread's draws during capture are rewound too --
+            precompile random computations before starting threads that share the
+            default generator. A graph containing no op that can draw never touches the
+            generators; one containing an opaque non-aten op conservatively restores
+            every saved generator; and a capture that raises restores nothing.
+    """
+    from torch.compiler._export_python import export_python as _export_python
+
+    return _export_python(
+        path=path,
+        backend=backend,
+        tracer=tracer,
+        decompositions=decompositions,
+        example_inputs=example_inputs,
+    )

--- a/torch/compiler/_export_python.py
+++ b/torch/compiler/_export_python.py
@@ -7,12 +7,13 @@ decorator keyed off a file on disk: the first run writes the emitted
 ``python_code`` to ``path``; every later run reads the ``.py`` back and executes
 it directly instead of recompiling.
 
-Because the artifact is self-contained, re-executable Python, ``path`` is meant to
-be committed and hand-edited: an engineer or agent can "hill-climb" the generated
-kernel in place. This is ejectable compilation -- the emitted source is the source
-of truth and is always exec'd, so hand edits always take effect. There is no
-acceleration cache and no ``precompile.load`` round-trip: the source is exec'd as
-written, so keeping the edited source correct is the caller's responsibility.
+Because the artifact is self-contained, re-executable Python, ``path`` is meant to be
+committed and shipped -- and, when a kernel starts to matter, hand-edited in place by
+an engineer or an agent. This is ejectable compilation: the emitted source is the
+source of truth and is always exec'd, so an edit is simply what runs from then on, in
+production as much as in development. There is no acceleration cache and no
+``precompile.load`` round-trip, so keeping the edited source correct is the caller's
+responsibility.
 """
 
 import copy

--- a/torch/compiler/_export_python.py
+++ b/torch/compiler/_export_python.py
@@ -1,0 +1,403 @@
+"""Path-cached ``torch.compiler.export_python`` decorator.
+
+``torch.compiler.precompile`` captures a function ahead of time and lowers it to a
+self-contained, human-readable Python source artifact (see
+``torch/_precompile.py``). ``torch.compiler.export_python`` wraps that in a
+decorator keyed off a file on disk: the first run writes the emitted
+``python_code`` to ``path``; every later run reads the ``.py`` back and executes
+it directly instead of recompiling.
+
+Because the artifact is self-contained, re-executable Python, ``path`` is meant to
+be committed and hand-edited: an engineer or agent can "hill-climb" the generated
+kernel in place. This is ejectable compilation -- the emitted source is the source
+of truth and is always exec'd, so hand edits always take effect. There is no
+acceleration cache and no ``precompile.load`` round-trip: the source is exec'd as
+written, so keeping the edited source correct is the caller's responsibility.
+"""
+
+import copy
+import errno
+import functools
+import inspect
+import logging
+import os
+import secrets
+import threading
+from collections.abc import Callable, Sequence
+from typing import Any, cast, TypeVar
+from typing_extensions import ParamSpec
+
+import torch
+import torch.utils._pytree as pytree
+
+
+log = logging.getLogger(__name__)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+# os.link failures that mean the filesystem cannot do hard links at all, as opposed to
+# a real I/O problem (a full disk, a bad permission) that must not be swallowed.
+_NO_HARDLINK_ERRNOS = frozenset(
+    getattr(errno, name)
+    for name in ("EPERM", "EOPNOTSUPP", "ENOTSUP", "EXDEV", "EMLINK", "ENOSYS")
+    if hasattr(errno, name)
+)
+
+
+def _atomic_publish(path: str, data: bytes) -> bool:
+    # Publish a fully-written file, never a partial one, and report whether this call
+    # is the writer that published it. A hard link is the no-replace publish: exactly
+    # one concurrent writer wins and every loser loads that winner rather than exec'ing
+    # its own divergent source. Only errnos that mean "this filesystem has no hard
+    # links" fall back to replace (last-writer-wins, still never partial); a full disk
+    # or a permissions problem must surface rather than silently weaken the guarantee.
+    dir_name = os.path.dirname(path) or "."
+    base = os.path.basename(path)
+    tmp = os.path.join(
+        dir_name,
+        f".{base}.{os.getpid()}.{threading.get_ident()}.{secrets.token_hex(8)}.tmp",
+    )
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        try:
+            os.link(tmp, path)
+        except FileExistsError:
+            return False
+        except OSError as e:
+            if e.errno not in _NO_HARDLINK_ERRNOS:
+                raise
+            log.warning(
+                "torch.compiler.export_python: %s has no hard links (%s), so %s is "
+                "published last-writer-wins; concurrent first writers may each run "
+                "their own generated source.",
+                dir_name,
+                e.strerror,
+                path,
+            )
+            os.replace(tmp, path)
+        return True
+    finally:
+        try:
+            os.remove(tmp)
+        except FileNotFoundError:
+            pass
+
+
+def _precompile_error(msg: str) -> Exception:
+    from torch._precompile import PrecompileError
+
+    return PrecompileError(msg)
+
+
+class ExportedPythonArtifact:
+    """Materializes and disk-caches a ``torch.compiler.precompile`` artifact.
+
+    Materialization is lazy and happens on the first call: if ``path`` exists the
+    emitted Python is read from disk, otherwise the wrapped ``fn`` is precompiled
+    against the example inputs and the emitted source is written to disk. Either
+    way the source is exec'd directly to build the runnable. The loaded callable is
+    reused for all subsequent calls in the process; a later process re-reads
+    whatever is on disk.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., Any],
+        *,
+        path: str,
+        backend: str,
+        tracer: str,
+        decompositions: dict | None,
+        example_inputs: Sequence[object] | None,
+    ) -> None:
+        self._fn = fn
+        self._signature = inspect.signature(fn)
+        self._call_signature = self._signature
+        self._path = path
+        self._backend = backend
+        self._tracer = tracer
+        self._decompositions = decompositions
+        self._example_inputs = None if example_inputs is None else tuple(example_inputs)
+        self._loaded: Callable[..., Any] | None = None
+        # (pid, tid) currently inside _materialize. There is deliberately no
+        # per-artifact lock: capture is already serialized process-wide, so a second
+        # lock would add nothing but a second acquisition order to deadlock against.
+        # This is the re-entrancy guard the (reentrant) capture lock cannot provide.
+        # The pid makes it fork-safe without a registry -- a child never matches a
+        # marker left by a thread it did not inherit.
+        self._materializing: tuple[int, int] | None = None
+
+    def _precompile_and_save(self, args: tuple[Any, ...]) -> tuple[str, bool]:
+        example = self._example_inputs
+        if example is None:
+            # Capture runs fn once on the example inputs (real-mode make_fx), which
+            # mutates them; deep-copy the live call args so capture side effects (in-
+            # place input mutation, module buffer updates) do not leak onto the
+            # caller before the artifact itself runs on the real args exactly once.
+            try:
+                example = copy.deepcopy(args)
+            except Exception as e:
+                from torch._precompile import PrecompileError
+
+                raise PrecompileError(
+                    "torch.compiler.export_python could not deep-copy the "
+                    "first-call arguments to capture without mutating them (e.g. a "
+                    "non-leaf tensor or a weight_norm module). Pass explicit "
+                    "example_inputs=... to precompile against dedicated inputs."
+                ) from e
+        else:
+            example = self._bind_positional(example, {}, "example_inputs=")
+            self._check_supported_args(example)
+        # precompile returns (python_code, cache); the cache is an acceleration
+        # artifact that export_python does not use -- the emitted source is
+        # self-contained and always exec'd -- so only the code is written to disk.
+        code, _cache = torch.compiler.precompile(
+            self._fn,
+            *example,
+            backend=self._backend,
+            tracer=self._tracer,
+            decompositions=self._decompositions,
+        )
+        parent = os.path.dirname(self._path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        if _atomic_publish(self._path, code.encode("utf-8")):
+            return code, False
+        # Lost the publish race; the winner's file is complete and already linked.
+        winner = self._load_from_disk()
+        if winner is None:
+            raise _precompile_error(
+                f"torch.compiler.export_python: another writer published {self._path} "
+                "and it was deleted before this call could load it. Retry."
+            )
+        return winner, True
+
+    def _load_from_disk(self) -> str | None:
+        # None means "not there after all" -- the presence gate raced a peer deleting
+        # the artifact to force a regenerate, which should fall through to capture
+        # rather than surface a bare FileNotFoundError.
+        try:
+            with open(self._path, encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
+        except OSError as e:
+            raise _precompile_error(
+                f"torch.compiler.export_python: could not read the artifact at "
+                f"{self._path} ({e.strerror}). Check that the path names a readable "
+                "file rather than a directory."
+            ) from e
+
+    def _load(self, code: str, *, from_disk: bool) -> Callable[..., Any]:
+        # The emitted source is self-contained: exec it directly (no cache, no
+        # precompile.load round-trip). A clobbered hand-edit (dropped forward / syntax
+        # error) and an environment or version mismatch (an import that fails under the
+        # current torch) surface as distinct, actionable PrecompileErrors rather than
+        # one catch-all "delete to regenerate".
+        from torch._precompile import _make_inlined_forward, PrecompileError
+
+        try:
+            if from_disk:
+                log.warning(
+                    "torch.compiler.export_python is about to EXEC the artifact at %s; "
+                    "the file is trusted executable Python and may have been edited or "
+                    "replaced since export. Only load paths whose contents you trust.",
+                    self._path,
+                )
+            return _make_inlined_forward(code, warn=False, filename=self._path)
+        except SyntaxError as e:
+            # Kernels are hoisted to module level, so Python reports a typo in one
+            # against this file at the right line. Say so: telling someone to delete an
+            # artifact they are midway through tuning is the wrong advice.
+            where = f" at line {e.lineno}" if e.lineno else ""
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} does not "
+                f"parse{where}: {e.msg}. Fix it there, or delete the file to regenerate "
+                "from the original function."
+            ) from e
+        except KeyError as e:
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} could "
+                "not be run as precompile source; it is not a valid "
+                "torch.compiler.precompile artifact (a hand-edit may have clobbered "
+                "it, e.g. dropping forward()). Delete it to regenerate."
+            ) from e
+        except ImportError as e:
+            raise PrecompileError(
+                f"torch.compiler.export_python: the artifact at {self._path} failed "
+                "to import a dependency; it was likely produced by a different torch "
+                f"version or environment. Delete {self._path} to regenerate against "
+                "the current torch."
+            ) from e
+        except Exception as e:
+            raise PrecompileError(
+                "torch.compiler.export_python: an unexpected error occurred running "
+                f"the artifact at {self._path}. Delete it to regenerate."
+            ) from e
+
+    def _materialize(self, args: tuple[Any, ...]) -> Callable[..., Any]:
+        code = self._load_from_disk() if os.path.exists(self._path) else None
+        from_disk = code is not None
+        if code is None:
+            code, from_disk = self._precompile_and_save(args)
+        entry = self._load(code, from_disk=from_disk)
+        self._example_inputs = None
+        self._decompositions = None
+        return entry
+
+    def _materialize_once(self, args: tuple[Any, ...]) -> Callable[..., Any]:
+        # Materialization runs under the one process-wide capture lock. Capture runs
+        # fn, which may call another decorated function, so any second lock taken
+        # around this would give two threads two orders to acquire them in and deadlock
+        # -- which is why the artifact holds no lock of its own.
+        import torch._precompile as precompile_impl
+
+        ident = (os.getpid(), threading.get_ident())
+        if self._materializing == ident:
+            raise _precompile_error(
+                "torch.compiler.export_python: re-entrant call into "
+                f"{getattr(self._fn, '__name__', 'fn')} while it is being precompiled. "
+                "A decorated function cannot call itself: capture would have to run "
+                "inside its own capture. Move the recursion into an undecorated helper."
+            )
+        with precompile_impl._CAPTURE_LOCK:
+            if self._loaded is None:
+                self._materializing = ident
+                try:
+                    self._loaded = self._materialize(args)
+                finally:
+                    self._materializing = None
+            return self._loaded
+
+    def _bind_positional(
+        self,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        source: str = "the call arguments",
+    ) -> tuple[Any, ...]:
+        # The artifact's forward is positional (the precompile calling convention),
+        # so map any keyword call args onto fn's positional parameters -- this lets
+        # callers invoke the decorated fn naturally (e.g. rope(q=..., k=...)).
+        # Anything that cannot be laid out positionally is rejected below.
+        sig = self._call_signature
+        try:
+            bound = sig.bind(*args, **kwargs)
+        except TypeError as e:
+            raise TypeError(
+                f"torch.compiler.export_python: could not bind {source} to "
+                f"{getattr(self._fn, '__name__', 'fn')}'s signature: {e}"
+            ) from e
+        bound.apply_defaults()
+        # bound.kwargs holds every argument bind() could not place positionally. That
+        # is a keyword-only / **kwargs param (never positional), or a plain
+        # positional-or-keyword param passed by keyword while an earlier one was left
+        # to its default -- distinguish them so the error names the real cause.
+        if bound.kwargs:
+            params = sig.parameters
+            kw_only = sorted(
+                n
+                for n in bound.kwargs
+                if n in params and params[n].kind == inspect.Parameter.KEYWORD_ONLY
+            )
+            if kw_only:
+                raise TypeError(
+                    "torch.compiler.export_python does not support keyword-only "
+                    f"parameters (got {kw_only}); the precompile calling convention "
+                    "is positional."
+                )
+            # Names not declared as parameters were absorbed by a **kwargs param;
+            # they are never positional, so name **kwargs as the cause rather than
+            # misreporting them as a positional-or-keyword arg left to its default.
+            var_kw = sorted(n for n in bound.kwargs if n not in params)
+            if var_kw:
+                raise TypeError(
+                    "torch.compiler.export_python does not support **kwargs "
+                    f"parameters (got {var_kw}); the precompile calling convention "
+                    "is positional."
+                )
+            raise TypeError(
+                "torch.compiler.export_python could not place keyword arguments "
+                f"{sorted(bound.kwargs)} positionally because an earlier positional "
+                "parameter was left to its default; pass those arguments positionally "
+                "or provide example_inputs."
+            )
+        return bound.args
+
+    def _check_supported_args(self, args: tuple[Any, ...]) -> None:
+        params = list(self._call_signature.parameters)
+        for pos, arg in enumerate(args):
+            if isinstance(arg, torch.nn.Module):
+                continue
+            unsupported = [
+                leaf
+                for leaf in pytree.tree_leaves(arg)
+                if not isinstance(leaf, torch.Tensor)
+            ]
+            if not unsupported:
+                continue
+            name = params[pos] if pos < len(params) else f"argument {pos}"
+            # These two land often enough that the generic "close the constant over"
+            # advice is actively wrong for them: a module must stay an argument, and an
+            # optional parameter has no constant to close over in the first place.
+            if any(isinstance(leaf, torch.nn.Module) for leaf in unsupported):
+                raise TypeError(
+                    "torch.compiler.export_python: nn.Module arguments must be passed "
+                    f"directly, not nested inside a container (parameter {name!r}). "
+                    "Pass the module itself as its own positional argument."
+                )
+            if all(leaf is None for leaf in unsupported):
+                raise TypeError(
+                    "torch.compiler.export_python does not support None arguments "
+                    f"(parameter {name!r}); make_fx specializes the None branch without "
+                    "a runtime guard. Split the function, or pass a tensor."
+                )
+            raise TypeError(
+                "torch.compiler.export_python supports only Tensor pytrees and "
+                "nn.Module positional arguments; Python scalar/config values are "
+                "specialized by make_fx without runtime guards. Close constants "
+                f"over in the function instead of passing parameter {name!r} "
+                f"({unsupported[0]!r})."
+            )
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        args = self._bind_positional(args, kwargs)
+        self._check_supported_args(args)
+        loaded = self._loaded
+        if loaded is None:
+            loaded = self._materialize_once(args)
+        return loaded(*args)
+
+
+def export_python(
+    *,
+    path: str,
+    backend: str = "inductor",
+    tracer: str = "make_fx",
+    decompositions: dict | None = None,
+    example_inputs: Sequence[object] | None = None,
+) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    """See :func:`torch.compiler.export_python`."""
+
+    def decorator(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+        artifact = ExportedPythonArtifact(
+            fn,
+            path=path,
+            backend=backend,
+            tracer=tracer,
+            decompositions=decompositions,
+            example_inputs=example_inputs,
+        )
+
+        @functools.wraps(fn)
+        def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            return cast("_R", artifact(*args, **kwargs))
+
+        return wrapped
+
+    return decorator

--- a/torch/compiler/_export_python.py
+++ b/torch/compiler/_export_python.py
@@ -90,6 +90,40 @@ def _atomic_publish(path: str, data: bytes) -> bool:
             pass
 
 
+# Elements below this fraction of the reference's peak are too small for a relative diff
+# to say anything; they are covered by the absolute term instead.
+_REL_REPORT_FLOOR = 1e-6
+
+
+def _allclose(a: torch.Tensor, b: torch.Tensor, rtol: float, atol: float) -> bool:
+    """torch.allclose, but tolerant of dtypes that have no comparison kernel.
+
+    float8 reaches allclose and dies inside it on a missing mul (as NotImplementedError,
+    which is a RuntimeError); promote and compare there rather than failing an artifact
+    that is perfectly honest.
+    """
+    try:
+        return bool(torch.allclose(a, b, rtol=rtol, atol=atol, equal_nan=True))
+    except RuntimeError:
+        return bool(
+            torch.allclose(a.double(), b.double(), rtol=rtol, atol=atol, equal_nan=True)
+        )
+
+
+def _finite_mask(t: torch.Tensor) -> torch.Tensor | None:
+    """Where ``t`` is finite, or None for a dtype that cannot answer.
+
+    float8 is is_floating_point() but has no isfinite kernel, so asking crashes the
+    check on an artifact that is perfectly honest.
+    """
+    if not t.is_floating_point():
+        return None
+    try:
+        return torch.isfinite(t)
+    except RuntimeError:
+        return None
+
+
 def _precompile_error(msg: str) -> Exception:
     from torch._precompile import PrecompileError
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #193901
* #193900
* __->__ #193899
* #198257
* #198256
* #198255
* #198254
* #198253
* #198252
* #193898
* #198247
* #198246
* #198245
* #193974
* #193973

**Problem.** Two processes that share a directory (the ranks of one job, or two jobs) can both find an `export_python` path missing and both capture it. Each wrote the file with a plain `open(path, "w")` and then ran its own generated source, so a reader could exec a half-written file, and the ranks could each run different code while the file on disk matched only the last writer.

**Fix.** Publish through a new `_atomic_publish`, which writes a temp file and hard-links it into place so exactly one writer wins. Every loser throws its own source away and loads the winner's file from disk.

**Summary.** `_precompile_and_save` used to write the captured source to `path` with a plain `open(path, "w")` and return that same source for the caller to run. The in-process capture lock only serializes first calls within one process, so concurrent first calls from separate processes could each exec a partial file or run their own source, and generated source is not byte-stable (kernel-cache paths, autotune choices), so ranks could silently run different code. `_atomic_publish` now writes and fsyncs a uniquely named temp file next to `path` and `os.link`s it into place; the one writer whose link succeeds has published, and every writer that gets `FileExistsError` loads the winner's file instead of running its own. The file must never be partial, and a real I/O error must never be taken as permission to weaken first-publisher-wins, so only the errnos meaning "no hard links on this filesystem" fall back to `os.replace` (last-writer-wins, still never partial, with a warning), and anything else is raised. A losing writer now goes through the from-disk load path, including the usual load-time trust warning, and raises a `PrecompileError` that says to retry if the winner's file vanishes before it can be read.

This PR is the top of the export_python split: the core decorator, the inductor artifact contract, keyword binding, RNG restore, artifact error messages and the in-process capture lock all live in the PRs below it. It also carries the numerics and test helpers that PRs above it consume.

## What a multi-rank first call looks like

```python
# launched on every rank, all pointing at one shared directory
@torch.compiler.export_python(path="/shared/rope.py", backend="inductor")
def rope(x):
    return x.sin() + 1

rope(x)
# parent: every rank that found rope.py missing captured, wrote rope.py with
#         open(path, "w"), and ran its own source; a concurrent reader could
#         exec a half-written file
# now:    one rank's os.link publishes rope.py; the others get FileExistsError,
#         load rope.py from disk, and all ranks run the same artifact
```

## The publish

```python
fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)  # .{base}.{pid}.{tid}.{token}.tmp
...  # write, flush, fsync
try:
    os.link(tmp, path)         # no-replace publish: exactly one writer succeeds
except FileExistsError:
    return False               # lost; caller loads the winner
except OSError as e:
    if e.errno not in _NO_HARDLINK_ERRNOS:
        raise                  # ENOSPC, EACCES, ...: surface it
    log.warning(...)           # "... published last-writer-wins ..."
    os.replace(tmp, path)
return True
# finally: the temp file is always removed
```

`_NO_HARDLINK_ERRNOS` is `EPERM`, `EOPNOTSUPP`, `ENOTSUP`, `EXDEV`, `EMLINK` and `ENOSYS`, whichever of them the platform defines. The caller in `_precompile_and_save` now returns `(code, from_disk)`:

```python
if _atomic_publish(self._path, code.encode("utf-8")):
    return code, False
winner = self._load_from_disk()
if winner is None:
    raise _precompile_error("... another writer published {path} and it was deleted before this call could load it. Retry.")
return winner, True
```

`_materialize` passes that `from_disk` through to `_load`, so a loser is treated like any other process that found the file already there. The `path` docstring in `torch/compiler/__init__.py` now states the first-publisher-wins semantics and the last-writer-wins fallback.

## Helpers carried for the PRs above

`_allclose` (torch.allclose that promotes to double when a dtype such as float8 has no comparison kernel), `_finite_mask` (None when `isfinite` has no kernel for the dtype) and `_REL_REPORT_FLOOR` are added to `torch/compiler/_export_python.py`. `test/test_precompile.py` gains the fixtures `_MisreportedDevice`, `_default_dtype`, `_deterministic`, `_lying_device`, `_type_lying_device`, `_artifact_of` and `_rope_artifact`. Nothing in this PR calls them yet; the eager-comparison and device-environment checks stacked above do.

## Tests

| Test | Pins |
|---|---|
| `test_same_path_concurrent_publish_has_one_winner` | Two subprocesses, each with a fake `precompile` returning `x + 1` or `x + 2`, meet at a barrier inside the presence gate. Both print the same value, it is one of the two candidates, no temp file is left, and a third later reader gets that winner off disk. |
| `test_publish_falls_back_when_filesystem_has_no_hard_links` | `os.link` raising `EPERM` still publishes the payload, logs a warning containing `last-writer-wins`, and leaves only the target file. |
| `test_publish_does_not_swallow_real_io_errors` | `os.link` raising `ENOSPC` propagates `OSError` and leaves neither the target nor a temp file. |

Test Plan:

```
python test/test_precompile.py
```

Adds test_same_path_concurrent_publish_has_one_winner,
test_publish_falls_back_when_filesystem_has_no_hard_links and
test_publish_does_not_swallow_real_io_errors to TestExportPython.

This commit was authored with the assistance of an AI coding agent.

Co-Authored-By: Claude Opus 5.5 <noreply@anthropic.com>
