### PR TITLE
[no-ci] [export_python] guard what capture specialized without a runtime guard

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -21,6 +21,7 @@ import torch
 import torch.utils._pytree as _pytree
 from torch._dynamo.decorators import mark_dynamic, mark_unbacked
 from torch._precompile import PrecompileError
+from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
@@ -31,6 +32,7 @@ from torch.testing._internal.common_utils import (
     skipIfTorchDynamo,
     TestCase,
 )
+from torch.testing._internal.two_tensor import TwoTensor
 
 
 class _MisreportedDevice(torch.Tensor):
@@ -3139,6 +3141,23 @@ class TestExportPython(TestCase):
         self.assertFalse(thread.is_alive())
         return (errors[0] if errors else None), concurrent
 
+    def test_deterministic_capture_ignores_a_concurrent_draw(self, device):
+        # The restore is keyed on whether the CAPTURED GRAPH draws, not on whether
+        # global generator state moved -- otherwise an unrelated thread's draw makes a
+        # deterministic capture look random, and rewinding it would replay that draw.
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("rng_concurrent.py"), backend="eager"
+        )
+        def run(inp):
+            return inp + 1
+
+        torch.manual_seed(1234)
+        error, concurrent = self._capture_racing_a_concurrent_draw(run, x)
+        self.assertIsNone(error)
+        self.assertNotEqual(torch.rand(8), concurrent)
+
     def test_random_capture_restores_rng_off_the_main_thread(self, device):
         # Restoring the generators the capture drew from is what keeps a random fn's
         # first call faithful, and it is not conditioned on thread identity: the
@@ -3236,6 +3255,64 @@ class TestExportPython(TestCase):
         x = make_tensor((4,), device=device, dtype=torch.float32)
         self.assertTrue(inspect.ismethod(model.run))
         self.assertEqual(model.run(x), x + 1)
+
+    def test_module_training_state_is_guarded(self, device):
+        path = self._tmp_path("module_training.py")
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1 if self.training else inp - 1
+
+        model = Model().to(device).train()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        model.eval()
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertRaisesRegex(PrecompileError, "training state"):
+            loaded(model, x)
+
+    def test_hand_edit_dropping_training_stamp_warns_and_runs(self, device):
+        # The artifact is meant to be hand-edited, so dropping the stamp turns the
+        # guard off with a warning rather than bricking the file -- the same contract
+        # the version stamp already has.
+        path = self._tmp_path("module_training_edit.py")
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1 if self.training else inp - 1
+
+        model = Model().to(device).train()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+        kept = [line for line in lines if "module-training:" not in line]
+        self.assertEqual(len(kept), len(lines) - 1)
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(kept)
+        model.eval()
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as logs:
+            self.assertEqual(loaded(model, x), x + 1)
+        self.assertTrue(any("no recorded training state" in m for m in logs.output))
 
     def test_decorated_function_is_picklable(self, device):
         name = "_export_python_pickle_fixture"
@@ -3720,6 +3797,88 @@ class TestExportPython(TestCase):
         with open(path, encoding="utf-8") as f:
             self.assertEqual(f.read(), first)
 
+    def test_version_skew_warns(self, device):
+        path = self._tmp_path("skew.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().split("\n")
+        tag = "# torch.compiler.export_python torch-version: "
+        self.assertTrue(lines[0].startswith(tag))
+        lines[0] = tag + repr("0.0.0-bogus")
+        # Displaced from line 1 on purpose: all four stamps are read from the leading
+        # comment block, so a hand-edit that adds a comment above them must not quietly
+        # disable the one check that catches a stale committed artifact.
+        lines.insert(0, "# a hand-edit above the stamps")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        # A stamped-but-mismatched artifact warns about the skew but still runs.
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(run2(x), x + 1)
+        self.assertTrue(any("0.0.0-bogus" in m for m in cm.output))
+
+    def test_no_version_warning_when_stamp_absent(self, device):
+        path = self._tmp_path("nostamp.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().split("\n")
+        tag = "# torch.compiler.export_python torch-version: "
+        if lines and lines[0].startswith(tag):
+            lines = lines[1:]
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        # A hand-edit that drops the stamp still gets the executable-file warning, but
+        # must not get a version-skew warning.
+        with self.assertLogs("torch.compiler._export_python", level="WARNING") as cm:
+            self.assertEqual(run2(x), x + 1)
+        self.assertTrue(any("about to EXEC" in message for message in cm.output))
+        self.assertFalse(any("produced by torch" in message for message in cm.output))
+
+    def test_env_import_failure_distinct_message(self, device):
+        # A valid artifact that fails to import a dependency under the current torch
+        # gets a distinct "different torch version or environment" error, not the
+        # clobbered-source message, so version skew is diagnosable.
+        path = self._tmp_path("badimport.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(inp):
+            return inp + 1
+
+        self.assertEqual(run(x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            code = f.read()
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("import a_module_that_does_not_exist_xyz\n" + code)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run2(inp):
+            return inp + 1
+
+        with self.assertRaisesRegex(PrecompileError, "different torch|environment"):
+            run2(x)
+
     def test_artifact_raising_at_module_scope_is_a_distinct_error(self, device):
         # The third arm of _load's taxonomy: not a syntax/structure problem and not a
         # failed import, but source that blows up while being exec'd.
@@ -3743,6 +3902,40 @@ class TestExportPython(TestCase):
         with self.assertRaisesRegex(PrecompileError, "unexpected error occurred"):
             loaded(x)
 
+    def test_nested_submodule_training_state_is_guarded(self, device):
+        # named_modules() walks the whole tree, but every other test model is a leaf,
+        # so only this pins that a flip on a CHILD is caught.
+        path = self._tmp_path("nested_training.py")
+
+        class Inner(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1 if self.training else inp - 1
+
+        class Outer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.inner = Inner()
+
+            def forward(self, inp):
+                return self.inner(inp)
+
+        model = Outer().to(device).train()
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        model.inner.eval()  # the root stays in train()
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertRaisesRegex(PrecompileError, "training state"):
+            loaded(model, x)
+
     def test_recursive_decorated_function_raises_not_hangs(self, device):
         path = self._tmp_path("recursive.py")
         depth = [1]
@@ -3756,6 +3949,39 @@ class TestExportPython(TestCase):
 
         with self.assertRaisesRegex(PrecompileError, "re-entrant call"):
             f(make_tensor((4,), device=device, dtype=torch.float32))
+
+    def test_mangled_training_stamp_degrades_like_a_missing_one(self, device):
+        # The stamp is an exec-inert comment; a botched hand-edit of it must not raise
+        # a SyntaxError from a line that does not affect what the artifact runs.
+        path = self._tmp_path("mangled_stamp.py")
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return inp + 1
+
+        model = Model().to(device)
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def run(mod, inp):
+            return mod(inp)
+
+        self.assertEqual(run(model, x), x + 1)
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+        for i, line in enumerate(lines):
+            if "module-training:" in line:
+                lines[i] = line.split(":")[0] + ": [(0, [('', unclosed\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+
+        @torch.compiler.export_python(path=path, backend="eager")
+        def loaded(mod, inp):
+            return mod(inp)
+
+        with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+            self.assertEqual(loaded(model, x), x + 1)
+        self.assertTrue(any("no recorded training state" in m for m in logs.output))
 
     def test_artifact_deleted_between_gate_and_read_regenerates(self, device):
         # A peer deleting the artifact to force a regenerate must not surface as a bare
@@ -3852,6 +4078,72 @@ class TestExportPython(TestCase):
                 run(x)
         self.assertNotEqual(torch.random.get_rng_state(), before)
 
+    def test_gated_op_configured_not_to_draw_does_not_count_as_drawing(self, device):
+        # nondeterministic_seeded marks ops that MAY draw; the gate reads the argument
+        # that decides. SDPA is what actually exercises it: dropout(train=False) traces
+        # to no seeded op at all, so it would pass without any gate, and
+        # dropout(train=True) decomposes to bernoulli_, which is not a gated name.
+        from torch._precompile import (
+            _capture,
+            _graph_rng_devices,
+            _op_can_draw,
+            _rng_devices_indicate_a_draw,
+        )
+
+        q = make_tensor((1, 1, 8, 16), device=device, dtype=torch.float32)
+
+        def sdpa(a, p):
+            return torch.nn.functional.scaled_dot_product_attention(
+                a, a, a, dropout_p=p
+            )
+
+        def seeded(gm):
+            return [
+                n.target
+                for n in gm.graph.nodes
+                if isinstance(n.target, torch._ops.OpOverload)
+                and torch.Tag.nondeterministic_seeded in n.target.tags
+            ]
+
+        dead = _capture(lambda a: sdpa(a, 0.0), (q,), None).gm
+        live = _capture(lambda a: sdpa(a, 0.2), (q,), None).gm
+        # The no-draw graph still CONTAINS a tagged op, so the gate is the only thing
+        # that can classify it as non-drawing; without this assertion the next one
+        # would hold vacuously (which is how the previous version of this test passed).
+        self.assertTrue(seeded(dead), "expected a tagged SDPA op in the graph")
+        self.assertFalse(_rng_devices_indicate_a_draw(_graph_rng_devices(dead)))
+        self.assertTrue(_rng_devices_indicate_a_draw(_graph_rng_devices(live)))
+        # dropout_p is omitted from node.args at 0.0, so the schema-default arm of the
+        # lookup is covered too.
+        self.assertFalse(any(_op_can_draw(n) for n in dead.graph.nodes))
+
+    def test_rng_gate_table_matches_the_op_registry(self, device):
+        # The table is a hand-listed subset of the op registry, so it rots silently in
+        # both directions: a typo'd key never fires, and a newly tagged gated op that
+        # is missing is treated as always-drawing (rewinding concurrent work). Rebuild
+        # it from the static schema registry and compare. _jit_get_all_schemas is used
+        # rather than dir(torch.ops.aten), which grows as other tests touch ops.
+        from torch._precompile import _RNG_GATED_BY_ARG
+
+        discovered = {}
+        for schema in torch._C._jit_get_all_schemas():
+            if not schema.name.startswith("aten::"):
+                continue
+            args = [a.name for a in schema.arguments]
+            # Only names that genuinely gate drawing. "p"/"prob" are NOT gates:
+            # bernoulli(p=0.0) and geometric_(p=...) still consume randomness.
+            gate = next(
+                (g for g in ("dropout_p", "train", "training") if g in args), None
+            )
+            if gate is None:
+                continue
+            packet = getattr(torch.ops.aten, schema.name.split("::")[1], None)
+            overload = schema.overload_name or "default"
+            op = getattr(packet, overload, None) if packet is not None else None
+            if op is not None and torch.Tag.nondeterministic_seeded in op.tags:
+                discovered.setdefault(schema.name, gate)
+        self.assertEqual(discovered, dict(_RNG_GATED_BY_ARG))
+
     def test_capture_drawing_only_on_the_accelerator_leaves_cpu_rng_alone(self, device):
         # The restore is per generator, not all-or-nothing: rewinding the CPU generator
         # for a graph that only drew on CUDA replays an unrelated CPU draw.
@@ -3868,6 +4160,24 @@ class TestExportPython(TestCase):
         error, concurrent = self._capture_racing_a_concurrent_draw(run, x)
         self.assertIsNone(error)
         self.assertNotEqual(torch.rand(8), concurrent)
+
+    def test_gate_does_not_apply_to_a_lookalike_custom_op(self, device):
+        # The table is keyed on the qualified name. A custom op that merely shares a
+        # name with a gated aten op must stay conservative, or a graph that really
+        # draws is reported as not drawing and its consumed state is never restored.
+        from torch._precompile import _op_can_draw
+
+        lib = self._library("precompile_gate_test")
+        lib.define(
+            "dropout(Tensor input, float p, bool train) -> Tensor",
+            tags=(torch.Tag.nondeterministic_seeded,),
+        )
+        graph = torch.fx.Graph()
+        arg = graph.placeholder("x")
+        node = graph.call_function(
+            torch.ops.precompile_gate_test.dropout.default, (arg, 0.5, False)
+        )
+        self.assertTrue(_op_can_draw(node), "a lookalike op inherited aten's gate")
 
     def _rope_artifact(self, device, **kwargs):
         # Two outputs, both plain allocated buffers: the shape out= is designed for.
@@ -3924,6 +4234,157 @@ class TestExportPython(TestCase):
         # so skipping the restore is a decision and not an empty set falling through.
         self.assertTrue(_graph_rng_devices(capture.gm))
 
+    def test_inputs_sliced_from_one_buffer_are_not_aliased(self, device):
+        # Overlap must mean sharing actual bytes. torch._C._overlaps answers a different
+        # question -- storage IDENTITY -- and using it here rejected the arena /
+        # fused-QKV / KV-cache shape, where every input is a disjoint slice of one
+        # buffer. That is the main way real callers hand tensors to a kernel.
+        from torch.compiler._export_python import _shares_memory
+
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        self.assertFalse(_shares_memory(base[:4], base[4:]))
+        self.assertTrue(_shares_memory(base[:5], base[3:]))
+        self.assertTrue(_shares_memory(base, base))
+        self.assertFalse(_shares_memory(base[:0], base))
+
+        @torch.compiler.export_python(
+            path=self._tmp_path("arena_inputs.py"),
+            backend="eager",
+            example_inputs=(
+                make_tensor((4,), device=device, dtype=torch.float32),
+                make_tensor((4,), device=device, dtype=torch.float32),
+            ),
+        )
+        def add(a, b):
+            return a + b
+
+        buf = make_tensor((8,), device=device, dtype=torch.float32)
+        self.assertEqual(add(buf[:4], buf[4:]), buf[:4] + buf[4:])
+
+    def test_capture_copy_that_loses_parameter_aliasing_is_refused(self, device):
+        # nn.Parameter.__deepcopy__ is self.data.clone(), which does not join the
+        # storage memo, so two Parameters over one storage come back independent.
+        # Capturing from that copy bakes in aliasing the caller does not have.
+        class Tied(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                base = torch.zeros(8, device=device)
+                self.a = torch.nn.Parameter(base[:4])
+                self.b = torch.nn.Parameter(base[4:])
+                self.a.data, self.b.data = base[:4], base[:4]
+
+        def fn(mod, inp):
+            mod.a.data.add_(inp)
+            return mod.b.data + 0
+
+        one = torch.ones(4, device=device)
+        path = self._tmp_path("tied_param.py")
+        with self.assertRaisesRegex(PrecompileError, "example_inputs="):
+            torch.compiler.export_python(path=path)(fn)(Tied(), one)
+        # Refused before publishing: a later call must not load a poisoned artifact.
+        self.assertFalse(os.path.exists(path))
+
+        # The escape hatch the message names has to actually work, and agree with eager.
+        wrapped = torch.compiler.export_python(
+            path=self._tmp_path("tied_param_ex.py"), example_inputs=(Tied(), one)
+        )(fn)
+        self.assertEqual(wrapped(Tied(), one), fn(Tied(), one))
+        self.assertEqual(wrapped(Tied(), one), fn(Tied(), one))
+
+        # Weight tying through one shared Parameter OBJECT (the usual idiom) survives
+        # the copy, so it must still capture.
+        class ObjectTied(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.emb = torch.nn.Embedding(6, 4, device=device)
+                self.head = torch.nn.Linear(4, 6, bias=False, device=device)
+                self.head.weight = self.emb.weight
+
+            def forward(self, ids):
+                return self.head(self.emb(ids))
+
+        mod = ObjectTied()
+        ids = torch.zeros(2, dtype=torch.long, device=device)
+        run = torch.compiler.export_python(path=self._tmp_path("obj_tied.py"))(
+            lambda m, t: m(t)
+        )
+        self.assertEqual(run(mod, ids), mod(ids))
+
+    def test_overlap_handles_awkward_subclass_shapes(self, device):
+        # __tensor_flatten__ names the attributes to transform, and they are not all
+        # tensors -- DTensor's list carries its DeviceMesh. getattr on one used to
+        # escape as a bare AttributeError, which only RuntimeError was catching.
+        from torch.compiler._export_python import _dense_leaves, _shares_memory
+
+        class HasMetadata(TwoTensor):
+            def __tensor_flatten__(self):
+                attrs, ctx = super().__tensor_flatten__()
+                return [*attrs, "label"], ctx
+
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        side = make_tensor((8,), device=device, dtype=torch.float32)
+        wrapper = HasMetadata(base[:4], side[:4])  # TwoTensor wants matching offsets
+        wrapper.label = "not a tensor"
+        self.assertTrue(_shares_memory(base, wrapper))
+        self.assertTrue(_shares_memory(side, wrapper))
+        self.assertFalse(_shares_memory(torch.zeros(4, device=device), wrapper))
+
+        # A subclass that flattens to exactly ONE tensor is the arity that made the
+        # plain-tensor test an elementwise Tensor ==, which raises above numel 1.
+        single = AsyncCollectiveTensor(base[:4])
+        self.assertEqual(len(_dense_leaves(single)), 1)
+        self.assertTrue(_shares_memory(base[:4], single))
+        self.assertFalse(_shares_memory(base[4:], single))
+
+    def test_duplicate_input_objects_are_guarded(self, device):
+        # Byte overlap cannot tell "two views that intersect" from "one tensor passed
+        # twice", and AOTAutograd folds the second into a single graph slot. Both report
+        # the same overlapping index pair, so without the duplicate stamp an artifact
+        # captured from views silently computes the wrong thing on a repeated argument.
+        def fn(a, b):
+            a.add_(1.0)
+            return b * 10
+
+        path = self._tmp_path("dup.py")
+        wrapped = torch.compiler.export_python(path=path)(fn)
+
+        def arena():
+            return torch.zeros(8, device=device)
+
+        base = arena()
+        wrapped(base[0:4], base[2:6])  # capture: distinct, overlapping
+
+        # the same object twice: same pair set, different meaning
+        repeated = arena()[0:4]
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            wrapped(repeated, repeated)
+
+        # and the converse: captured from a repeat, called with distinct views
+        dup_path = self._tmp_path("dup2.py")
+        from_repeat = torch.compiler.export_python(path=dup_path)(fn)
+        first = arena()[0:4]
+        from_repeat(first, first)
+        other = arena()
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            from_repeat(other[0:4], other[2:6])
+
+        # a call that repeats the way capture did still runs, and matches eager
+        same = arena()[0:4]
+        eager_in = arena()[0:4]
+        self.assertEqual(from_repeat(same, same), fn(eager_in, eager_in))
+
+        # Identity, not address. These two have the SAME data_ptr and the same overlap
+        # pair set, but are distinct objects with different strides, so AOTAutograd does
+        # not fold them; keying the stamp on the address accepts this and returns wrong
+        # numbers with nothing else to catch it.
+        square = self._tmp_path("dup_square.py")
+        squared = torch.compiler.export_python(path=square)(fn)
+        cap = make_tensor((4, 4), device=device, dtype=torch.float32)
+        squared(cap, cap)
+        live = make_tensor((4, 4), device=device, dtype=torch.float32)
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            squared(live, live.t())
+
     def test_artifact_does_not_bake_the_capture_thread_count(self, device):
         # Inductor sizes a CPU reduction's per-thread accumulator array at codegen time
         # when the capturing process's thread count equals os.cpu_count(), while still
@@ -3958,6 +4419,541 @@ class TestExportPython(TestCase):
         # pinned it sizes itself from omp_get_max_threads() at run time instead.
         baked = re.findall(r"_arr\[(\d+)\]", source)
         self.assertEqual(baked, [], f"artifact bakes a fixed per-thread array: {baked}")
+
+    def test_subclass_input_dtype_and_device_are_still_guarded(self, device):
+        # A wrapper subclass's outer SHAPE is not the dense shape the artifact bakes, so
+        # it is deliberately not stamped -- but the driver skipped dtype and device on
+        # the same condition, and those are well defined. A float64 subclass then reached
+        # a graph built for float32 and came back as reinterpreted bytes with no error.
+        def fn(x):
+            return x * 2 + 1
+
+        run = torch.compiler.export_python(path=self._tmp_path("sub_guard.py"))(fn)
+        base = make_tensor((4,), device=device, dtype=torch.float32)
+        run(TwoTensor(base, base.clone()))
+
+        same = make_tensor((4,), device=device, dtype=torch.float32)
+        self.assertEqual(run(TwoTensor(same, same.clone())).a, fn(same))
+
+        wide = make_tensor((4,), device=device, dtype=torch.float64)
+        with self.assertRaisesRegex(PrecompileError, "dtype"):
+            run(TwoTensor(wide, wide.clone()))
+
+        if TEST_CUDA:
+            elsewhere = "cpu" if torch.device(device).type == "cuda" else "cuda"
+            moved = make_tensor((4,), device=elsewhere, dtype=torch.float32)
+            with self.assertRaisesRegex(PrecompileError, "device"):
+                run(TwoTensor(moved, moved.clone()))
+
+    def test_indented_comment_does_not_stop_the_stamp_reader(self, device):
+        # The documented rule is that the reader stops at the first NON-COMMENT line. An
+        # indented comment is still a comment, but it ended the scan -- silently turning
+        # off every stamp below it, which is the degradation mode the design reserves
+        # for a stamp actually being deleted.
+        def fn(a, b):
+            a.add_(1.0)
+            return b * 10
+
+        path = self._tmp_path("indented.py")
+        wrapped = torch.compiler.export_python(path=path)(fn)
+
+        def arena():
+            return torch.zeros(8, device=device)
+
+        base = arena()
+        wrapped(base[0:4], base[2:6])
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        lines.insert(1, "    # a note a human might indent\n")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
+
+        # the duplicate stamp lives below the inserted line; it must still be read
+        repeated = arena()[0:4]
+        with self.assertRaisesRegex(PrecompileError, "repeat tensor objects"):
+            torch.compiler.export_python(path=path)(fn)(repeated, repeated)
+
+    def test_pathological_version_stamp_warns_rather_than_raising(self, device):
+        # torch.__version__ is a TorchVersion, whose __eq__ PEP-440-parses the operand
+        # and re-raises anything that is not InvalidVersion, so a stamp of enough digits
+        # took the whole load path down with a ValueError -- permanently, on every call.
+        # A mangled stamp is a hand-edit like any other and must degrade to a warning.
+        path = self._tmp_path("bigversion.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def fn(inp):
+            return inp + 1
+
+        torch.compiler.export_python(path=path)(fn)(x)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        lines[0] = f"# torch.compiler.export_python torch-version: '{'9' * 4400}'\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
+
+        self.assertEqual(torch.compiler.export_python(path=path)(fn)(x), fn(x))
+
+    def test_capture_specializes_is_grad_enabled_to_true(self, device):
+        # Capture traces with grad enabled so a backward inside fn is built as graph ops,
+        # which specializes a fn that READS torch.is_grad_enabled() to the grad-on branch.
+        # That is deliberate and documented. Tracing under the caller's ambient mode was
+        # tried instead and is worse: the baked branch then depends on ambient state no
+        # stamp records, so a no_grad capture returns the wrong branch in every later
+        # process -- and stamping grad mode is not an option either, because capturing at
+        # the default and calling under no_grad is the ordinary inference pattern.
+        seen = []
+
+        def fn(inp):
+            seen.append(torch.is_grad_enabled())
+            return inp * 2
+
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        with torch.no_grad():
+            torch.compiler.export_python(
+                path=self._tmp_path("gradmode.py"), backend="eager"
+            )(fn)(x)
+        self.assertEqual(seen, [True])
+
+        # And the pattern that must keep working: capture at the default, then call for
+        # inference under no_grad.
+        def plain(inp):
+            return inp.sin() + 1
+
+        run = torch.compiler.export_python(path=self._tmp_path("infer.py"))(plain)
+        run(x)
+        with torch.no_grad():
+            self.assertEqual(run(x), plain(x))
+
+    def test_global_state_stamp_survives_the_per_backend_fp32_api(self, device):
+        # torch.get_float32_matmul_precision() RAISES in a process that has used the
+        # per-backend fp32_precision API. Reading it while building the stamp killed
+        # capture outright there -- after a full compile -- and killed every call on an
+        # artifact that already existed.
+        previous = torch.backends.cuda.matmul.fp32_precision
+        try:
+            torch.backends.cuda.matmul.fp32_precision = "tf32"
+            with self.assertRaises(RuntimeError):
+                torch.get_float32_matmul_precision()  # the read that used to be in there
+
+            def fn(inp):
+                return inp + torch.ones(4, device=device)
+
+            x = make_tensor((4,), device=device, dtype=torch.float32)
+            run = torch.compiler.export_python(path=self._tmp_path("fp32api.py"))(fn)
+            self.assertEqual(run(x), fn(x))
+            self.assertEqual(run(x), fn(x))
+        finally:
+            torch.backends.cuda.matmul.fp32_precision = previous
+
+    def test_malformed_global_state_stamp_degrades_to_a_warning(self, device):
+        # Every other stamp treats a mangled value as a hand-edit and turns its own check
+        # off. This one unpacks the literal into key/value pairs, so a literal that is not
+        # a list of pairs escaped as a raw TypeError out of the load path.
+        path = self._tmp_path("mangled_state.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def fn(inp):
+            return inp + 1
+
+        torch.compiler.export_python(path=path)(fn)(x)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        for i, line in enumerate(lines):
+            if "global-state:" in line:
+                lines[i] = "# torch.compiler.export_python global-state: 42\n"
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("".join(lines))
+        self.assertEqual(torch.compiler.export_python(path=path)(fn)(x), fn(x))
+
+    def test_ambient_global_state_is_stamped_and_checked(self, device):
+        # The generated code resolves these once, at capture, and bakes the answer: a
+        # factory op with no dtype= takes the default dtype then, and inductor picks a
+        # deterministic or an atomic lowering from the determinism flag. Changing one and
+        # replaying must not silently get capture's answer. The artifact
+        # never re-reads either, so without a stamp a process that changes one silently
+        # gets capture's answer.
+        def fn(inp):
+            return inp + torch.ones(4, device=device)
+
+        path = self._tmp_path("globals.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        torch.compiler.export_python(path=path)(fn)(x)
+
+        with self.assertRaisesRegex(PrecompileError, "default_dtype"):
+            with _default_dtype(torch.float64):
+                torch.compiler.export_python(path=path)(fn)(x)
+
+        # Determinism is one-way: capture OFF and call ON means the artifact keeps a
+        # lowering the caller asked not to run, so that raises...
+        with self.assertRaisesRegex(PrecompileError, "deterministic"):
+            with _deterministic(True):
+                torch.compiler.export_python(path=path)(fn)(x)
+
+        # ...while capture ON and call OFF is conservative and must be allowed.
+        strict_path = self._tmp_path("globals_strict.py")
+        with _deterministic(True):
+            torch.compiler.export_python(path=strict_path)(fn)(x)
+        self.assertEqual(torch.compiler.export_python(path=strict_path)(fn)(x), fn(x))
+
+    @unittest.skipUnless(TEST_CUDA, "needs a device the inputs do not live on")
+    def test_autocast_stamp_covers_devices_only_the_graph_touches(self, device):
+        # Keying the stamp on the INPUT devices alone recorded [] for a graph whose
+        # inputs are on one device and whose matmuls run on another, so the check passed
+        # in both processes while the kernels had been built for autocast dtypes.
+        if torch.device(device).type != "cpu":
+            self.skipTest("the point is inputs on cpu and compute on the accelerator")
+
+        def fn(inp):
+            return (inp.cuda() @ inp.cuda().t()).cpu()
+
+        path = self._tmp_path("autocast_graph.py")
+        x = make_tensor((8, 8), device="cpu", dtype=torch.float32)
+        run = torch.compiler.export_python(path=path)(fn)
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            run(x)
+            run(x)
+        with open(path, encoding="utf-8") as f:
+            stamp = next(l for l in f if "autocast:" in l)
+        self.assertIn("cuda", stamp)
+        with self.assertRaisesRegex(PrecompileError, "autocast"):
+            run(x)  # outside the region the kernels were built for
+
+        # The case the input-only filter existed to protect still works: a pure-CPU
+        # helper first called inside a CUDA autocast region is not locked to it.
+        def cpu_only(inp):
+            return inp.sin() + 1
+
+        helper = torch.compiler.export_python(path=self._tmp_path("cpu_only.py"))(
+            cpu_only
+        )
+        with torch.autocast("cuda", dtype=torch.bfloat16):
+            helper(x)
+        self.assertEqual(helper(x), cpu_only(x))
+
+    def test_meta_module_tensor_does_not_crash_the_autocast_stamp(self, device):
+        # autocast does not model every device an input can live on, and a module can
+        # carry a meta tensor it never reads (deferred init). Asking it about one raised
+        # a bare C++ RuntimeError from inside stamp emission, so nothing was ever
+        # published and every call re-paid the whole capture.
+        class DeferredInit(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(4, 4, device=device)
+                self.register_buffer("proto", torch.empty(4, device="meta"))
+                self.spare = torch.nn.Parameter(torch.empty(4, device="meta"))
+
+            def forward(self, inp):
+                return self.linear(inp)
+
+        mod = DeferredInit()
+        x = make_tensor((2, 4), device=device, dtype=torch.float32)
+        path = self._tmp_path("deferred.py")
+        run = torch.compiler.export_python(path=path)(lambda m, t: m(t))
+        self.assertEqual(run(mod, x), mod(x))
+        self.assertTrue(os.path.exists(path))  # published, so no capture is re-paid
+        self.assertEqual(run(mod, x), mod(x))  # and the loaded artifact runs too
+
+    def test_overlap_is_bytes_not_storage_identity(self, device):
+        # Two tensors can reach the same bytes through DIFFERENT UntypedStorages --
+        # from_numpy on overlapping slices, frombuffer, DLPack, __cuda_array_interface__
+        # onto a live arena. A storage-identity gate calls those disjoint, so the
+        # aliasing guard would go blind on exactly the arena / KV-cache shapes it is for.
+        import numpy as np
+
+        from torch.compiler._export_python import _shares_memory
+
+        arr = np.zeros(1024, dtype=np.float32)
+        lo, hi = torch.from_numpy(arr[0:512]), torch.from_numpy(arr[256:768])
+        self.assertNotEqual(
+            lo.untyped_storage().data_ptr(), hi.untyped_storage().data_ptr()
+        )
+        self.assertTrue(_shares_memory(lo, hi))
+
+        # Exactly ONE element of overlap: a two-element case survives dropping the +1
+        # from the span, so only this pins the boundary.
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        self.assertTrue(_shares_memory(base[:4], base[3:]))
+        self.assertFalse(_shares_memory(base[:4], base[4:]))
+        # A strided tensor's extent is not its numel; using numel under-reports it.
+        self.assertTrue(_shares_memory(base.as_strided((4,), (2,)), base[5:]))
+
+        # A wrapper subclass reports data_ptr() == 0 with a real device, so comparing
+        # its span directly would call every pair disjoint.
+        from torch.testing._internal.two_tensor import TwoTensor
+
+        payload = torch.from_numpy(np.zeros(8, dtype=np.float32))
+        self.assertTrue(
+            _shares_memory(
+                payload,
+                TwoTensor(payload, payload.clone()),
+            )
+        )
+        self.assertFalse(
+            _shares_memory(
+                TwoTensor(torch.zeros(4), torch.zeros(4)),
+                TwoTensor(torch.zeros(4), torch.zeros(4)),
+            )
+        )
+
+        # A 0-numel tensor whose bounding span is NOT empty: the numel guard is what
+        # rejects this, not the span arithmetic.
+        empty_wide = torch.empty(8, device=device).as_strided((3, 0), (1, 1))
+        self.assertFalse(_shares_memory(empty_wide, empty_wide))
+        self.assertFalse(
+            _shares_memory(torch.empty(4, device="meta"), torch.empty(4, device="meta"))
+        )
+
+    def test_overlap_sees_through_a_wrapper_that_misreports_its_device(self, device):
+        # A subclass can report a device differing from its payload's in INDEX
+        # (map_location="cuda" over a "cuda:0" payload) or in TYPE
+        # (map_location={"cuda:0": "cpu"}). Deciding on the wrapper rather than the leaf
+        # reported such a tensor as sharing memory with nothing -- including its own
+        # payload -- so the aliasing guard would go blind on it.
+        from torch.compiler._export_python import _shares_memory
+
+        base = make_tensor((8,), device=device, dtype=torch.float32)
+        # No hardware needed for any of these: _make_wrapper_subclass takes a device
+        # LABEL, so they run identically on a CPU-only runner. Gating them on TEST_CUDA
+        # meant the type axis pinned nothing there, and the index axis alone cannot tell
+        # a leaf-keyed predicate from a wrapper-device-type-keyed one.
+        lies = [
+            _lying_device(device),  # index axis
+            _type_lying_device(device),  # type axis
+            torch.device("meta"),  # is_meta is a device report too
+        ]
+        for reported in lies:
+            wrapper = _MisreportedDevice(base[:4], reported)
+            self.assertNotEqual(wrapper.device, wrapper.payload.device)
+            self.assertTrue(_shares_memory(base[:4], wrapper), reported)
+            self.assertTrue(_shares_memory(base[2:6], wrapper), reported)
+            self.assertFalse(_shares_memory(base[4:], wrapper), reported)
+            self.assertFalse(
+                _shares_memory(
+                    make_tensor((4,), device=device, dtype=torch.float32), wrapper
+                ),
+                reported,
+            )
+
+        # One empty component must not make the whole wrapper unlocatable. It used to,
+        # because every empty tensor reports data_ptr 0, which makes the predicate claim
+        # an overlap that does not exist for every caller of it.
+        from torch.compiler._export_python import _dense_leaves
+
+        side = make_tensor((8,), device=device, dtype=torch.float32)
+        unrelated = make_tensor((4,), device=device, dtype=torch.float32)
+        for spare in (
+            torch.empty(2, device=device),
+            torch.empty(0, device=device),  # owns no bytes
+            torch.empty(4, device="meta"),  # a leaf that genuinely IS meta
+        ):
+            partly_empty = TwoTensor(base[:4], side[:4])  # matching storage offsets
+            partly_empty.b = spare
+            self.assertIsNotNone(_dense_leaves(partly_empty), spare.device)
+            self.assertTrue(_shares_memory(base[:4], partly_empty), spare.device)
+            self.assertFalse(_shares_memory(unrelated, partly_empty), spare.device)
+
+        # Every component byte-less is a real answer -- "owns nothing" -- not "bytes we
+        # cannot find". Collapsing it back to unresolvable made such a wrapper alias
+        # every tensor of its device type.
+        all_empty = TwoTensor(
+            torch.empty(0, device=device), torch.empty(0, device=device)
+        )
+        self.assertEqual(_dense_leaves(all_empty), [])
+        self.assertFalse(_shares_memory(unrelated, all_empty))
+        # But a wrapper with no tensor components at all stays conservative: there is
+        # nothing to have looked at, so it must not read as disjoint from everything.
+        no_tensors = TwoTensor(base[:4], side[:4])
+        no_tensors.__tensor_flatten__ = lambda: ([], None)  # type: ignore[method-assign]
+        self.assertIsNone(_dense_leaves(no_tensors))
+        self.assertTrue(_shares_memory(unrelated, no_tensors))
+
+        # A tensor whose bytes cannot be located at all is assumed to alias -- but only
+        # within its own device type, which is the only evidence left once there are no
+        # leaves to inspect. The sweep routes these to the same predicate, so its
+        # cross-check cannot pin this; it needs asserting directly.
+        opaque = make_tensor((4, 4), device=device, dtype=torch.float32).to_sparse()
+        self.assertTrue(_shares_memory(opaque, base[:4]))
+        if TEST_CUDA:
+            elsewhere = "cpu" if torch.device(device).type == "cuda" else "cuda"
+            self.assertFalse(_shares_memory(opaque, torch.randn(4, device=elsewhere)))
+
+    def test_overlap_sweep_matches_the_pairwise_predicate(self, device):
+        # _input_overlaps sweeps sorted byte spans instead of running _shares_memory
+        # over every pair; the two must agree exactly, including the shapes that leave
+        # the sweep and fall back to the pairwise path.
+        from torch.compiler._export_python import _input_overlaps, _shares_memory
+
+        arena = make_tensor((32,), device=device, dtype=torch.float32)
+        other = make_tensor((32,), device=device, dtype=torch.float32)
+        cases = [
+            [arena[0:20], arena[10:30], arena[20:32], arena[24:32]],  # a chain
+            [arena[i:] for i in range(5)],  # a clique
+            [arena[:8], other[:8], arena[8:16], other[8:16]],  # two disjoint groups
+            [arena[:4], torch.empty(0, device=device), arena[2:6]],
+            [arena[:4], torch.randn(4, device="meta"), arena[2:6]],
+            [arena[:4], arena.to_sparse(), other[:4]],  # unresolvable: pairwise path
+            [TwoTensor(arena[:4], other[:4]), arena[2:6], other[6:10]],
+            # One wrapper whose two leaves overlap EACH OTHER: the only shape that
+            # can produce a bogus self-pair out of the sweep.
+            [TwoTensor(arena[:4], arena[:4]), other[:4]],
+            # Wrappers misreporting their device. The INDEX lie alone does not pin the
+            # sweep's keying -- the key it replaced was (wrapper device TYPE, leaf
+            # device), which already handled that axis -- so the TYPE lie has to be here
+            # too, or reverting the key passes while the sweep and the predicate
+            # demonstrably disagree.
+            [
+                _MisreportedDevice(arena[:4], _lying_device(device)),
+                arena[2:6],
+                other[:4],
+            ],
+            [arena[:4], _MisreportedDevice(arena[2:6], _lying_device(device))],
+            [
+                _MisreportedDevice(arena[:4], _type_lying_device(device)),
+                arena[2:6],
+                other[:4],
+            ],
+            [arena[:4], _MisreportedDevice(arena[2:6], torch.device("meta"))],
+            [arena.as_strided((4,), (7,)), arena[20:24], arena[28:32]],
+            [],
+            [arena],
+        ]
+        for tensors in cases:
+            pairwise = [
+                [i, j]
+                for i in range(len(tensors))
+                for j in range(i + 1, len(tensors))
+                if _shares_memory(tensors[i], tensors[j])
+            ]
+            self.assertEqual(_input_overlaps(None, tensors), pairwise)
+
+    def test_version_stamp_written_before_the_repr_change_still_warns(self, device):
+        # Artifacts already committed carry a bare, unquoted version. literal_eval
+        # rejects those, and treating that as "hand-edited, stay silent" would disable
+        # the skew warning for exactly the artifacts it exists to protect.
+        path = self._tmp_path("old_stamp.py")
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+
+        def build():
+            @torch.compiler.export_python(path=path, backend="eager")
+            def run(inp):
+                return inp + 1
+
+            return run
+
+        build()(x)
+        with open(path, encoding="utf-8") as f:
+            lines = f.read().splitlines(True)
+        tag = "# torch.compiler.export_python torch-version: "
+        self.assertTrue(lines[0].startswith(tag))
+        lines[0] = tag + "0.0.0-bogus\n"  # pre-repr encoding, unquoted
+        with open(path, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+        with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+            build()(x)
+        self.assertTrue(any("0.0.0-bogus" in m for m in logs.output), logs.output)
+
+    def test_input_aliasing_a_module_buffer_is_guarded(self, device):
+        # A tensor argument that aliases a module buffer must enter the overlap stamp.
+        # AOTAutograd dedups the two into one graph slot, so an artifact captured with
+        # that alias computes -- and on the eager backend mutates -- the wrong thing
+        # when the runtime call passes independent tensors.
+        class M(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.register_buffer("b", torch.zeros(4, device=device))
+
+        def fn(m, x):
+            m.b.add_(1.0)
+            return m.b + x * 2
+
+        captured = M()
+        aliased = torch.compiler.export_python(
+            path=self._tmp_path("module_alias.py"),
+            backend="eager",
+            example_inputs=(captured, captured.b),
+        )(fn)
+        aliased(captured, captured.b)
+
+        fresh = M()
+        independent = torch.zeros(4, device=device)
+        with self.assertRaisesRegex(PrecompileError, "do not share memory"):
+            aliased(fresh, independent)
+        # ...and the rejected call left the caller's tensor alone.
+        self.assertEqual(independent, torch.zeros(4, device=device))
+
+    def test_dropping_the_aliasing_or_autocast_stamp_warns(self, device):
+        # The docstring promises a warning for each dropped stamp; the module-training
+        # one warned and these two used to fall through in silence.
+        x = make_tensor((4,), device=device, dtype=torch.float32)
+        for tag, name in (("input-overlap:", "alias"), ("autocast:", "autocast")):
+            path = self._tmp_path(f"drop_{name}.py")
+
+            def build():
+                @torch.compiler.export_python(path=path, backend="eager")
+                def run(a, b):
+                    return a + b
+
+                return run
+
+            build()(x, x)
+            with open(path, encoding="utf-8") as f:
+                lines = f.readlines()
+            kept = [line for line in lines if tag not in line]
+            self.assertEqual(len(kept), len(lines) - 1, f"{tag} stamp not found")
+            with open(path, "w", encoding="utf-8") as f:
+                f.writelines(kept)
+            with self.assertLogs("torch.compiler._export_python", "WARNING") as logs:
+                build()(x, x)
+            self.assertTrue(
+                any("carries no recorded" in m for m in logs.output), logs.output
+            )
+
+    def test_input_aliasing_is_guarded(self, device):
+        # Aliasing decides what an in-place mutation means and is baked into the graph
+        # with no runtime guard, so an artifact captured on aliased inputs computes --
+        # and mutates -- the wrong thing when they are distinct. torch.compile guards
+        # this and recompiles; the artifact cannot, so it must refuse.
+        def fn(a, b):
+            a.add_(b)
+            return a * 2
+
+        seed = torch.arange(4.0, device=device)
+        aliased = torch.compiler.export_python(
+            path=self._tmp_path("alias_capture.py"),
+            backend="eager",
+            example_inputs=(seed, seed),
+        )(fn)
+        a = torch.arange(4.0, device=device)
+        with self.assertRaisesRegex(PrecompileError, "do not share memory"):
+            aliased(a, torch.ones(4, device=device))
+        self.assertEqual(a, torch.arange(4.0, device=device))  # left untouched
+
+        # The mirror case: captured distinct, called aliased.
+        distinct = torch.compiler.export_python(
+            path=self._tmp_path("alias_distinct.py"), backend="eager"
+        )(fn)
+        b = torch.arange(4.0, device=device)
+        distinct(b, torch.ones(4, device=device))
+        c = torch.arange(4.0, device=device)
+        with self.assertRaisesRegex(PrecompileError, "do not share memory"):
+            distinct(c, c)
+
+    def test_autocast_state_is_guarded(self, device):
+        # Ambient autocast picks the dtypes the kernels were specialized for, and is
+        # invisible to make_fx's guards, so calling under a different autocast context
+        # silently returns the capture-time dtype.
+        @torch.compiler.export_python(
+            path=self._tmp_path("autocast.py"), backend="eager"
+        )
+        def run(a, b):
+            return a @ b
+
+        device_type = torch.device(device).type
+        x = make_tensor((8, 8), device=device, dtype=torch.float32)
+        self.assertEqual(run(x, x).dtype, torch.float32)
+        with self.assertRaisesRegex(PrecompileError, "autocast state does not match"):
+            with torch.autocast(device_type, torch.bfloat16):
+                run(x, x)
 
 
 instantiate_device_type_tests(TestExportPython, globals())

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -1068,8 +1068,36 @@ def export_python(
     ``nn.Module`` arguments. Python scalar/config arguments are rejected because
     ``make_fx`` specializes their values without emitting runtime guards; close such
     constants over in ``fn`` instead. Other keyword-only parameters are not expressible
-    in the artifact's positional convention and are rejected.
-    Other Python attributes and Python control flow are specialized at capture and must remain compatible with the example.
+    in the artifact's positional convention and are rejected. Five things that
+    ``make_fx`` or the code generator resolves without emitting a guard are recorded as
+    comment stamps and checked on every call:
+    each ``nn.Module`` argument's per-submodule ``training`` state, which input tensors
+    shared memory at capture (aliasing decides what an in-place mutation means), which
+    input positions held the *same* tensor object (AOTAutograd folds those into a single
+    graph slot, which byte overlap alone cannot distinguish from two views that merely
+    intersect), and the ambient ``torch.autocast`` state (which picks the dtypes the
+    kernels were built for, for every device type the artifact's own source names, not
+    only the ones its inputs live on), and the ambient globals the generated code
+    resolves against rather than re-reads: the default dtype and device a factory op
+    with no explicit argument takes, the matmul precision a GEMM template bakes as a
+    constant, and whether deterministic algorithms were enabled when inductor chose
+    between a deterministic and an atomic lowering (checked one-way -- capturing with
+    determinism on and calling with it off is safe, the reverse is not). What is *not*
+    guarded is a change in *how* two aliased
+    inputs overlap: when capture and the call both pass intersecting views, the artifact
+    runs with capture's relative offsets baked in and may compute the wrong thing.
+    ``torch.compile`` has the same hole *there*, but this list is not a complete
+    account of what the artifact bakes: a tensor subclass's inner shapes and a DTensor's
+    placements are unrecorded, and so is the CPU vector ISA (see the machine-type warning
+    above). Where ``torch.compile`` would recompile, an artifact cannot, so treat any
+    ambient change between capture and call as needing a fresh capture unless a stamp
+    covers it. A hand-edit that drops a stamp turns that one check off with a warning.
+    All six stamps (these five plus the version stamp) must stay in the artifact's
+    leading comment block: the reader stops at the first non-comment line, so inserting code above them
+    turns every check off -- loudly for the checked stamps, each of which warns per
+    call while it is missing, and silently for the version warning, which just
+    returns. Other Python attributes and Python
+    control flow are specialized at capture and must remain compatible with the example.
     That includes ``torch.is_grad_enabled()``: capture traces with grad enabled so a
     backward inside ``fn`` is built as graph ops, so a ``fn`` that branches on it always
     captures the grad-enabled branch, whatever the grad mode of the call that triggered
@@ -1092,7 +1120,10 @@ def export_python(
             does changing ``backend``, ``tracer``, ``decompositions``, or
             ``example_inputs``: an existing ``path`` is loaded as-is. A stale artifact
             after a source edit is the expected failure mode; delete ``path`` to force
-            a re-precompile. Loading any
+            a re-precompile. The artifact records the producing torch version in its first
+            line; loading it under a different torch logs a warning (it still runs) so
+            a committed artifact gone stale across a torch upgrade is visible. A
+            hand-edit that drops that line disables the version warning. Loading any
             existing artifact also warns before executing it because ``path`` is trusted
             executable Python and may have been edited or replaced. A CUDA artifact
             additionally embeds inductor's kernel-cache paths, so it is not byte-stable

--- a/torch/compiler/_export_python.py
+++ b/torch/compiler/_export_python.py
@@ -15,12 +15,14 @@ acceleration cache and no ``precompile.load`` round-trip: the source is exec'd a
 written, so keeping the edited source correct is the caller's responsibility.
 """
 
+import ast
 import copy
 import errno
 import functools
 import inspect
 import logging
 import os
+import re
 import secrets
 import threading
 from collections.abc import Callable, Sequence
@@ -29,6 +31,7 @@ from typing_extensions import ParamSpec
 
 import torch
 import torch.utils._pytree as pytree
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
 
 
 log = logging.getLogger(__name__)
@@ -36,6 +39,36 @@ log = logging.getLogger(__name__)
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
+# Written as the artifact's first line so a later load can detect it was produced
+# by a different torch (see _warn_on_version_skew). It is a comment, so it does not
+# affect exec; a hand-edit that drops it just disables the skew warning, so
+# hill-climbing an artifact never triggers a spurious version warning.
+# All six stamps must stay in the artifact's LEADING comment block: the reader stops
+# at the first line that is not a comment, so inserting code above them turns every
+# check off -- each checked stamp warns per call while it is missing, and the version
+# warning is the only one that goes quiet.
+_VERSION_TAG = "# torch.compiler.export_python torch-version: "
+# The train()/eval() flags of every nn.Module argument at capture. Python control flow
+# on ``self.training`` is specialized into the graph with no runtime guard, so this
+# stamp is what catches an artifact captured in one mode being run in the other. Like
+# the version stamp it is exec-inert, and dropping it in a hand-edit just turns the
+# check off (see _check_module_training).
+_MODULE_TRAINING_TAG = "# torch.compiler.export_python module-training: "
+# Which input tensors overlapped in memory at capture, which of them were literally the
+# same object, and the ambient autocast state. make_fx bakes all three into the graph
+# with no runtime guard: aliased inputs change what a mutation means, one object passed
+# twice is deduped into a single graph slot, and autocast changes the dtypes the kernels
+# were specialized for. Exec-inert like the other stamps, and dropping one turns only
+# its own check off. What no stamp guards is a change in HOW two aliased inputs overlap
+# -- capture's relative offsets stay baked in, exactly as they do under torch.compile.
+_INPUT_OVERLAP_TAG = "# torch.compiler.export_python input-overlap: "
+_INPUT_DUPLICATE_TAG = "# torch.compiler.export_python input-duplicates: "
+_AUTOCAST_TAG = "# torch.compiler.export_python autocast: "
+# Ambient process state the generated code bakes that no other stamp covers: the default
+# dtype and device a factory op with no explicit argument resolves against, and whether
+# deterministic algorithms were on when inductor chose between a deterministic and an
+# atomic lowering.
+_GLOBAL_STATE_TAG = "# torch.compiler.export_python global-state: "
 
 # os.link failures that mean the filesystem cannot do hard links at all, as opposed to
 # a real I/O problem (a full disk, a bad permission) that must not be swallowed.
@@ -95,6 +128,327 @@ def _precompile_error(msg: str) -> Exception:
     return PrecompileError(msg)
 
 
+def _module_training_state(
+    args: Sequence[Any],
+) -> list[tuple[int, list[tuple[str, bool]]]]:
+    return [
+        (pos, [(name, module.training) for name, module in arg.named_modules()])
+        for pos, arg in enumerate(args)
+        if isinstance(arg, torch.nn.Module)
+    ]
+
+
+def _byte_span(t: torch.Tensor) -> tuple[int, int]:
+    # The [start, end) byte range the tensor can touch. Exact for a dense tensor and a
+    # bounding range for a strided one, which errs toward reporting overlap.
+    start = t.data_ptr()
+    extent = sum((size - 1) * stride for size, stride in zip(t.shape, t.stride()))
+    return start, start + (extent + 1) * t.element_size()
+
+
+def _dense_leaves(t: torch.Tensor) -> list[torch.Tensor] | None:
+    """The real-memory tensors inside t, or None if its bytes cannot be located.
+
+    A wrapper subclass (DTensor, TwoTensor, FunctionalTensor) reports data_ptr() == 0
+    with a real device and is_meta False, so comparing its byte span against a plain
+    tensor's would report every pair as disjoint. Decompose it instead.
+    """
+    if is_traceable_wrapper_subclass(t):
+        try:
+            attrs, _ = t.__tensor_flatten__()
+        except Exception:
+            return None
+        leaves: list[torch.Tensor] = []
+        saw_tensor = False
+        for attr in attrs:
+            # __tensor_flatten__ names the attributes that must be transformed, and
+            # not all of them are tensors -- DTensor's list includes its DeviceMesh.
+            component = getattr(t, attr, None)
+            if not isinstance(component, torch.Tensor):
+                continue
+            saw_tensor = True
+            inner = _dense_leaves(component)
+            if inner is None:
+                return None
+            leaves.extend(inner)
+        # An empty list here means every component owns no bytes, which is a real
+        # answer. Only a subclass we could not see INTO is unresolvable -- returning
+        # `leaves` unconditionally would make such a wrapper disjoint from everything
+        # and let a donor be written over a live input.
+        return leaves if saw_tensor else None
+    if t.numel() == 0 or t.is_meta:
+        # Owns no bytes, which is not the same as "bytes we cannot find". Both report
+        # data_ptr 0, so without this one such component (an absent bias, an empty KV
+        # cache, an uneven shard, a meta-initialized slot) would poison its whole
+        # wrapper into "assume it aliases everything" and refuse every donation against
+        # it. This is about a leaf that genuinely IS meta; a wrapper merely presenting
+        # meta over live payloads is still distrusted, in _reports_no_bytes.
+        return []
+    try:
+        if t.data_ptr() == 0:
+            return None
+    except RuntimeError:
+        return None
+    return [t]
+
+
+def _reports_no_bytes(t: torch.Tensor) -> bool:
+    """Whether t can be ruled out from its own report, without locating its bytes.
+
+    Only for tensors that are what they say they are. A wrapper subclass's numel and
+    is_meta describe what it PRESENTS: torch.load with
+    map_location={torch.device("cpu"): "meta"} -- keyed by a device OBJECT, which remaps
+    the wrapper without remapping its storages -- builds one reporting meta over live
+    cpu payloads, and taking that at face value says it aliases nothing, including its
+    own payload. The string form {"cpu": "meta"} does the reverse and is not the case
+    this guards.
+    """
+    return not is_traceable_wrapper_subclass(t) and (t.numel() == 0 or t.is_meta)
+
+
+def _shares_memory(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Whether two tensors can touch the same bytes.
+
+    NOT torch._C._overlaps, which is IValue::overlaps -- storage IDENTITY, ignoring
+    offsets. That reports byte-disjoint slices of one buffer as overlapping, which
+    rejects the arena / fused-QKV / KV-cache shape this API exists to serve.
+
+    Compares addresses, not storage objects: the same bytes can be reached through
+    different UntypedStorages (from_numpy on overlapping slices, frombuffer, DLPack,
+    __cuda_array_interface__ onto a live arena), and a storage-identity gate reports
+    those as disjoint -- a donor would then be written over a live input. data_ptr is a
+    process-global address and differing devices are rejected at the LEAF below, so
+    distinct allocations cannot collide. One allocation visible under two device types
+    still can: mapped pinned host memory has the same address as its CUDA view, and
+    this reports the pair disjoint. torch._C._overlaps answers that case identically.
+    Conservative for anything whose extent cannot be computed: a bounding range for
+    strided tensors, and for sparse or otherwise unlocatable tensors "aliases anything
+    of the same device type" -- NOT storage identity, which is the predicate this
+    function exists to avoid.
+    """
+    if _reports_no_bytes(a) or _reports_no_bytes(b):
+        # No real memory, and every meta tensor reports data_ptr 0, which would
+        # otherwise make every pair look coincident.
+        return False
+    a_leaves, b_leaves = _dense_leaves(a), _dense_leaves(b)
+    if a_leaves is None or b_leaves is None:
+        # An addressless or undecomposable tensor (a wrapper subclass whose components
+        # we cannot reach, sparse, nested). Its bytes are unknown, so the only safe
+        # answer is "assume it aliases" -- NOT storage identity, which is the predicate
+        # that made byte-disjoint arena slices look aliased in the first place. Device
+        # type is all that can still rule a pair out. Note this reads the OUTER device
+        # of both operands, including one that did resolve, because there is no leaf on
+        # the unresolved side to pair its leaves against; a wrapper misreporting its
+        # type is therefore still taken at its word here.
+        return a.device.type == b.device.type
+    if not (
+        len(a_leaves) == 1
+        and a_leaves[0] is a
+        and len(b_leaves) == 1
+        and b_leaves[0] is b
+    ):
+        return any(_shares_memory(x, y) for x in a_leaves for y in b_leaves)
+    if a.device != b.device:
+        # Compared here, on the LEAF, and never on the wrapper: a subclass can report a
+        # device that differs from the one holding its bytes in index (torch.load with
+        # map_location="cuda" over a "cuda:0" payload) or in TYPE (map_location=
+        # {"cuda:0": "cpu"}). Gating above reported such a tensor as sharing memory with
+        # nothing -- including with its own payload.
+        return False
+    try:
+        (a_start, a_end), (b_start, b_end) = _byte_span(a), _byte_span(b)
+    except RuntimeError:
+        return True
+    return a_start < b_end and b_start < a_end
+
+
+def _input_tensors(args: Sequence[Any]) -> list[torch.Tensor]:
+    """Every tensor an artifact call can reach, in a stable order.
+
+    Module params and buffers are included, and come after the user tensors so their
+    presence does not shift the indices a previously written stamp recorded. They have
+    to be here: AOTAutograd dedups a user tensor that aliases a module buffer into one
+    graph slot, so an artifact captured with that alias computes -- and mutates -- the
+    wrong thing when the runtime call passes independent tensors, and the reverse.
+    """
+    user = [
+        leaf
+        for arg in args
+        if not isinstance(arg, torch.nn.Module)
+        for leaf in pytree.tree_leaves(arg)
+        if isinstance(leaf, torch.Tensor)
+    ]
+    module: list[torch.Tensor] = []
+    seen: set[int] = set()
+    for arg in args:
+        if not isinstance(arg, torch.nn.Module):
+            continue
+        for tensor in [*arg.parameters(), *arg.buffers()]:
+            if id(tensor) not in seen:
+                seen.add(id(tensor))
+                module.append(tensor)
+    return [*user, *module]
+
+
+def _span_atoms(
+    t: torch.Tensor,
+) -> list[tuple[torch.device, int, int]] | None:
+    """t's byte ranges as (leaf device, start, end), or None if they cannot be located.
+
+    Keyed on the LEAF device only, matching _shares_memory: a wrapper subclass can
+    report a device that differs from the one holding its bytes, in index (torch.load
+    with map_location="cuda" over a "cuda:0" payload) or in type (map_location=
+    {"cuda:0": "cpu"}), so the wrapper's own report decides nothing. An empty list means
+    t owns no addressable bytes, so it overlaps nothing.
+    """
+    if _reports_no_bytes(t):
+        return []
+    leaves = _dense_leaves(t)
+    if leaves is None:
+        return None
+    atoms = []
+    for leaf in leaves:
+        if leaf.numel() == 0 or leaf.is_meta:
+            continue
+        try:
+            start, end = _byte_span(leaf)
+        except RuntimeError:
+            return None
+        atoms.append((leaf.device, start, end))
+    return atoms
+
+
+def _input_overlaps(
+    args: Sequence[Any], tensors: list[torch.Tensor] | None = None
+) -> list[list[int]]:
+    """Which pairs of input tensors share memory, as sorted [i, j] index pairs.
+
+    Runs on every artifact call, so it is a sweep and not the P-choose-2 pairwise scan:
+    a 32-block model has hundreds of parameters, and the quadratic form cost multiples
+    of the forward it guards. Lists (not tuples) so the stamp round-trips through
+    ast.literal_eval to something that compares equal.
+    """
+    if tensors is None:
+        tensors = _input_tensors(args)
+    by_device: dict[torch.device, list[tuple[int, int, int]]] = {}
+    unresolved: list[int] = []
+    for i, tensor in enumerate(tensors):
+        atoms = _span_atoms(tensor)
+        if atoms is None:
+            unresolved.append(i)
+            continue
+        for leaf, start, end in atoms:
+            by_device.setdefault(leaf, []).append((start, end, i))
+    pairs: set[tuple[int, int]] = set()
+    for spans in by_device.values():
+        spans.sort()
+        # Spans that started earlier and have not ended: exactly the ones this span can
+        # overlap, since the list is sorted by start.
+        open_spans: list[tuple[int, int]] = []
+        for start, end, i in spans:
+            open_spans = [(e, j) for e, j in open_spans if e > start]
+            for _, j in open_spans:
+                if j != i:
+                    pairs.add((min(i, j), max(i, j)))
+            open_spans.append((end, i))
+    for i in unresolved:
+        for j, other in enumerate(tensors):
+            if j != i and _shares_memory(tensors[i], other):
+                pairs.add((min(i, j), max(i, j)))
+    return [[i, j] for i, j in sorted(pairs)]
+
+
+def _input_duplicates(
+    args: Sequence[Any], tensors: list[torch.Tensor] | None = None
+) -> list[list[int]]:
+    """Which input positions hold the SAME tensor object, as [first, repeat] pairs.
+
+    Not implied by _input_overlaps: AOTAutograd dedups arguments that are one object
+    into a single graph slot, and byte overlap cannot tell that apart from two views
+    that merely intersect. Both report the same pair set, so without this an artifact
+    captured from overlapping views silently computes the wrong thing when handed one
+    tensor twice. torch.compile guards it and recompiles ("Duplicate tensors found").
+    """
+    if tensors is None:
+        tensors = _input_tensors(args)
+    first: dict[int, int] = {}
+    pairs = []
+    for i, tensor in enumerate(tensors):
+        seen_at = first.setdefault(id(tensor), i)
+        if seen_at != i:
+            pairs.append([seen_at, i])
+    return pairs
+
+
+def _code_devices(code: str) -> set[str]:
+    """The device types the emitted artifact names, from its own source.
+
+    The stamp and the per-call check have to agree, so this is computed from the source
+    once at capture and once at load rather than from anything ambient.
+    """
+    found = set(re.findall(r"empty_strided_(\w+)\(", code))
+    found.update(re.findall(r"device\(type=[\'\"](\w+)[\'\"]", code))
+    found.update(re.findall(r"\.to\([\'\"](\w+)[\'\"]", code))
+    devices = set()
+    for name in found:
+        # The allocator names are not all device types -- empty_strided_cpu_pinned is a
+        # cpu allocator -- and a hand-edited artifact can contain anything at all.
+        try:
+            devices.add(torch.device(name).type)
+        except (RuntimeError, ValueError):
+            continue
+    return devices
+
+
+def _autocast_state(
+    args: Sequence[Any],
+    tensors: list[torch.Tensor] | None = None,
+    code_devices: set[str] | None = None,
+) -> list[list[Any]]:
+    """Ambient autocast for every device type this artifact can compute on.
+
+    The input devices alone are not enough: a graph whose inputs are all on CPU can still
+    run its matmuls on an accelerator, and keying only on inputs recorded [] for it in
+    both processes, so the check passed while the kernels had been built for autocast
+    dtypes. Widened with the device types the emitted code names. Still not every device
+    type in the process: a CPU helper first called inside a `with torch.autocast("cuda")`
+    training region must not be locked to that region, and its graph never names cuda.
+    """
+    if tensors is None:
+        tensors = _input_tensors(args)
+    devices = {t.device.type for t in tensors}
+    if code_devices is not None:
+        devices.update(code_devices)
+    return [
+        [device, str(torch.get_autocast_dtype(device))]
+        for device in sorted(devices)
+        if torch.amp.is_autocast_available(device) and torch.is_autocast_enabled(device)
+    ]
+
+
+def _global_state() -> list[list[Any]]:
+    """Ambient globals the emitted code resolves against, as sorted [key, value] pairs.
+
+    Recorded as strings so the stamp round-trips through ast.literal_eval. Both are read
+    at CAPTURE and baked: a factory op with no dtype= takes the default dtype then, and
+    inductor picks a deterministic or an atomic-add lowering from the determinism flag.
+    The artifact never re-consults either, so a process that changes one and replays gets
+    capture's answer with no error.
+
+    float32_matmul_precision is deliberately NOT here. torch.get_float32_matmul_precision
+    raises outright in a process that has used the per-backend fp32_precision API, so
+    stamping it killed capture there; and on the default config the artifact reaches
+    extern_kernels.mm, which re-reads the setting at run time, so the check refused calls
+    the artifact would have served correctly. Only a max_autotune Triton GEMM template
+    bakes it as a tl.constexpr.
+    """
+    return [
+        ["default_dtype", str(torch.get_default_dtype())],
+        ["default_device", str(torch.get_default_device())],
+        ["deterministic", str(torch.are_deterministic_algorithms_enabled())],
+    ]
+
+
 class ExportedPythonArtifact:
     """Materializes and disk-caches a ``torch.compiler.precompile`` artifact.
 
@@ -124,6 +478,12 @@ class ExportedPythonArtifact:
         self._tracer = tracer
         self._decompositions = decompositions
         self._example_inputs = None if example_inputs is None else tuple(example_inputs)
+        self._module_training: list[tuple[int, list[tuple[str, bool]]]] | None = None
+        self._input_overlaps: list[list[int]] | None = None
+        self._input_duplicates: list[list[int]] | None = None
+        self._global_state: list[list[str]] | None = None
+        self._code_devices: set[str] = set()
+        self._autocast: list[list[Any]] | None = None
         self._loaded: Callable[..., Any] | None = None
         # (pid, tid) currently inside _materialize. There is deliberately no
         # per-artifact lock: capture is already serialized process-wide, so a second
@@ -151,6 +511,18 @@ class ExportedPythonArtifact:
                     "non-leaf tensor or a weight_norm module). Pass explicit "
                     "example_inputs=... to precompile against dedicated inputs."
                 ) from e
+            if _input_overlaps(example) != _input_overlaps(args):
+                from torch._precompile import PrecompileError
+
+                raise PrecompileError(
+                    "torch.compiler.export_python: deep-copying the first-call "
+                    "arguments did not preserve how their tensors share memory, so "
+                    "capturing from the copy would bake in aliasing the real arguments "
+                    "do not have. nn.Parameter.__deepcopy__ clones, so two Parameters "
+                    "backed by one storage become independent in the copy. Pass "
+                    "example_inputs=... built with the same sharing as the real "
+                    "arguments to capture against those instead."
+                )
         else:
             example = self._bind_positional(example, {}, "example_inputs=")
             self._check_supported_args(example)
@@ -167,6 +539,19 @@ class ExportedPythonArtifact:
         parent = os.path.dirname(self._path)
         if parent:
             os.makedirs(parent, exist_ok=True)
+        # The stamps lead the artifact as exec-inert comments, each guarding one thing
+        # make_fx specialized without a runtime guard. A hand-edit may drop any of them;
+        # each just turns its own check off.
+        example_tensors = _input_tensors(example)
+        code = (
+            f"{_VERSION_TAG}{torch.__version__!r}\n"
+            f"{_MODULE_TRAINING_TAG}{_module_training_state(example)!r}\n"
+            f"{_INPUT_OVERLAP_TAG}{_input_overlaps(example, example_tensors)!r}\n"
+            f"{_INPUT_DUPLICATE_TAG}{_input_duplicates(example, example_tensors)!r}\n"
+            f"{_AUTOCAST_TAG}"
+            f"{_autocast_state(example, example_tensors, _code_devices(code))!r}\n"
+            f"{_GLOBAL_STATE_TAG}{_global_state()!r}\n{code}"
+        )
         if _atomic_publish(self._path, code.encode("utf-8")):
             return code, False
         # Lost the publish race; the winner's file is complete and already linked.
@@ -193,6 +578,202 @@ class ExportedPythonArtifact:
                 f"{self._path} ({e.strerror}). Check that the path names a readable "
                 "file rather than a directory."
             ) from e
+
+    @staticmethod
+    def _read_raw_stamp(code: str, tag: str) -> str | None:
+        for line in code.splitlines():
+            if line.startswith(tag):
+                return line[len(tag) :].strip() or None
+            # An INDENTED comment is still a comment. The documented rule is "the
+            # first non-comment line", and stopping early here silently turns every
+            # later stamp's check off rather than reading it.
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                break
+        return None
+
+    @staticmethod
+    def _read_stamp(code: str, tag: str) -> Any:
+        for line in code.splitlines():
+            if line.startswith(tag):
+                try:
+                    return ast.literal_eval(line[len(tag) :])
+                except (ValueError, SyntaxError):
+                    # A mangled stamp is a hand-edit like any other: turn the check off
+                    # rather than raise a SyntaxError from a comment line that does not
+                    # affect what the artifact runs.
+                    return None
+            # An INDENTED comment is still a comment. The documented rule is "the
+            # first non-comment line", and stopping early here silently turns every
+            # later stamp's check off rather than reading it.
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                break
+        return None
+
+    def _check_capture_environment(self, args: tuple[Any, ...]) -> None:
+        # Two more things make_fx specialized with no runtime guard. Input ALIASING
+        # decides what an in-place mutation means, so an artifact captured with two
+        # arguments sharing memory computes the wrong thing (and mutates the wrong
+        # thing) when they are distinct at runtime -- torch.compile guards this and
+        # recompiles. Ambient AUTOCAST decides the dtypes the kernels were built for.
+        tensors: list[torch.Tensor] | None = None
+
+        def input_tensors() -> list[torch.Tensor]:
+            # Walked once and shared by the three checks below. Lazily, so an artifact
+            # whose stamps were all hand-edited away does not pay for a walk no check
+            # will read.
+            nonlocal tensors
+            if tensors is None:
+                tensors = _input_tensors(args)
+            return tensors
+
+        if self._input_overlaps is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "input-aliasing stamp, so a runtime call whose inputs share memory "
+                "differently than capture is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual = _input_overlaps(args, input_tensors())
+            if actual != self._input_overlaps:
+                raise _precompile_error(
+                    "torch.compiler.export_python: the runtime inputs do not share "
+                    f"memory the way capture did (captured overlapping index pairs "
+                    f"{self._input_overlaps}, got {actual}). Aliasing is baked into the "
+                    "graph, so this call would compute against the wrong assumption."
+                )
+        if self._input_duplicates is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "input-duplicate stamp, so a runtime call that repeats a tensor object "
+                "differently than capture is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual_duplicates = _input_duplicates(args, input_tensors())
+            if actual_duplicates != self._input_duplicates:
+                raise _precompile_error(
+                    "torch.compiler.export_python: the runtime inputs repeat tensor "
+                    "objects differently than capture did (captured duplicate index "
+                    f"pairs {self._input_duplicates}, got {actual_duplicates}). "
+                    "AOTAutograd folds arguments that are one object into a single "
+                    "graph slot, so this call would compute against the wrong "
+                    "assumption -- byte overlap alone cannot see the difference."
+                )
+        if self._global_state is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "global-state stamp, so calling it under a different default dtype, "
+                "default device, matmul precision or determinism setting than capture "
+                "is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual_state = dict(_global_state())
+            try:
+                recorded = dict(self._global_state)
+            except (TypeError, ValueError):
+                # A hand-edit can leave a literal that is not [key, value] pairs. Every
+                # other stamp degrades to warn-and-continue for that; this one must not
+                # be the only one that raises a raw unpack error out of the load path.
+                log.warning(
+                    "torch.compiler.export_python: the global-state stamp at %s is not a "
+                    "list of [key, value] pairs, so that check is off. Delete %s to "
+                    "regenerate it.",
+                    self._path,
+                    self._path,
+                )
+                recorded = {}
+            for key, captured in recorded.items():
+                if key not in actual_state:
+                    continue  # a key this torch no longer records
+                live = actual_state[key]
+                if live == captured:
+                    continue
+                # Determinism is one-sided: capture with it OFF and replay with it ON
+                # means the artifact keeps a lowering the caller has asked not to run.
+                # ON at capture and OFF at replay is conservative, so it is not an error.
+                if key == "deterministic" and captured == "True":
+                    continue
+                raise _precompile_error(
+                    f"torch.compiler.export_python: {key} is {live} but the artifact "
+                    f"was captured with {key} {captured}. It is resolved when the code "
+                    "is generated and baked in, so this call would silently get "
+                    "capture's answer. Set it to the captured value, or delete "
+                    f"{self._path} to recapture."
+                )
+        if self._autocast is None:
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s carries no recorded "
+                "autocast stamp, so calling it under a different autocast context than "
+                "capture is unchecked. Delete %s to regenerate it.",
+                self._path,
+                self._path,
+            )
+        else:
+            actual_autocast = _autocast_state(args, input_tensors(), self._code_devices)
+            if actual_autocast != self._autocast:
+                raise _precompile_error(
+                    "torch.compiler.export_python: the runtime autocast state does not "
+                    f"match capture (captured {self._autocast}, got {actual_autocast}). "
+                    "Autocast dtypes are baked into the artifact; capture under the "
+                    "same autocast context you call it in."
+                )
+
+    def _check_module_training(self, args: tuple[Any, ...]) -> None:
+        actual = _module_training_state(args)
+        if not actual:
+            return
+        if self._module_training is None:
+            # Missing stamp means a hand-edit dropped it, the same as the version
+            # stamp: warn that the guard is off rather than refuse to run an artifact
+            # whose source is by design the thing the caller is free to edit.
+            log.warning(
+                "torch.compiler.export_python: the artifact at %s takes nn.Module "
+                "arguments but carries no recorded training state, so train()/eval() "
+                "skew against capture is unchecked. Delete %s to regenerate the stamp.",
+                self._path,
+                self._path,
+            )
+            return
+        if actual != self._module_training:
+            raise _precompile_error(
+                "torch.compiler.export_python: the runtime module training state does "
+                f"not match capture (expected {self._module_training!r}, got {actual!r}). "
+                "Restore train()/eval() state or regenerate the artifact."
+            )
+
+    def _warn_on_version_skew(self, code: str) -> None:
+        # Warn (but still run) when the artifact carries a version stamp that does
+        # not match the current torch, so a committed artifact gone stale across a
+        # torch upgrade is visible rather than silently running old logic. A missing
+        # stamp (dropped by a hand-edit) is silent, so hill-climbing never warns.
+        produced = self._read_stamp(code, _VERSION_TAG)
+        if produced is None:
+            # Artifacts written before the stamp became a repr() carry a bare version
+            # string, which literal_eval rejects. Falling back to the raw text keeps the
+            # skew warning working for every artifact already committed -- silently
+            # losing it is exactly the case the stamp exists for.
+            produced = self._read_raw_stamp(code, _VERSION_TAG)
+        # str(): TorchVersion.__eq__ PEP-440-parses its operand and re-raises anything
+        # that is not InvalidVersion, so a stamp of 4300+ digits took the whole load path
+        # down with a ValueError. Comparing text keeps a mangled stamp to a warning.
+        if produced is None or produced == str(torch.__version__):
+            return
+        log.warning(
+            "torch.compiler.export_python: the artifact at %s was produced by "
+            "torch %s but the current torch is %s; running it as-is. Delete %s "
+            "to regenerate against the current torch.",
+            self._path,
+            produced,
+            torch.__version__,
+            self._path,
+        )
 
     def _load(self, code: str, *, from_disk: bool) -> Callable[..., Any]:
         # The emitted source is self-contained: exec it directly (no cache, no
@@ -246,6 +827,14 @@ class ExportedPythonArtifact:
         from_disk = code is not None
         if code is None:
             code, from_disk = self._precompile_and_save(args)
+        if from_disk:
+            self._warn_on_version_skew(code)
+        self._module_training = self._read_stamp(code, _MODULE_TRAINING_TAG)
+        self._input_overlaps = self._read_stamp(code, _INPUT_OVERLAP_TAG)
+        self._input_duplicates = self._read_stamp(code, _INPUT_DUPLICATE_TAG)
+        self._autocast = self._read_stamp(code, _AUTOCAST_TAG)
+        self._global_state = self._read_stamp(code, _GLOBAL_STATE_TAG)
+        self._code_devices = _code_devices(code)
         entry = self._load(code, from_disk=from_disk)
         self._example_inputs = None
         self._decompositions = None
@@ -371,6 +960,8 @@ class ExportedPythonArtifact:
         loaded = self._loaded
         if loaded is None:
             loaded = self._materialize_once(args)
+        self._check_capture_environment(args)
+        self._check_module_training(args)
         return loaded(*args)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #193901
* __->__ #193900
* #193899
* #198257
* #198256
* #198255
* #198254
* #198253
* #198252
* #193898
* #198247
* #198246
* #198245
* #193974
* #193973

A path-cached artifact cannot recompile. Where torch.compile would notice an
ambient change and produce new code, an artifact just runs the old code, so
the ambient facts make_fx and the code generator resolved at capture without
emitting a runtime guard become silent wrong answers.

This records those facts as comment stamps in the artifact's leading comment
block and rechecks them on every call: each nn.Module argument's per-submodule
training state, which input tensors shared memory at capture, which input
positions held the same tensor object (AOTAutograd folds those into one graph
slot, which byte overlap alone cannot distinguish from two views that merely
intersect), the ambient autocast state for every device type the artifact's
own source names, and the ambient globals the generated code resolves against
rather than re-reads (default dtype and device, and whether deterministic
algorithms were on when inductor chose between a deterministic and an atomic
lowering). A sixth stamp records the producing torch version and warns on
skew.

The stamps are comments, so they are exec-inert and a hand-edit may drop any
one of them; dropping one turns off that one check with a warning rather than
invalidating the artifact. This is the right default for a file whose purpose
is to be edited, and it is why they must stay in the leading comment block:
the reader stops at the first non-comment line.

Order to review: the stamp writers are the module-level helpers in
_export_python.py (_input_overlaps and _shares_memory are the substantive
ones -- overlap is computed on byte spans rather than storage identity, and
sees through a wrapper subclass that misreports its device);
_check_capture_environment is the per-call reader. Capture also now refuses to
proceed when deep-copying the first call's arguments did not preserve how
their tensors share memory, since nn.Parameter.__deepcopy__ clones and would
otherwise bake in aliasing the real arguments do not have.

What is deliberately not guarded: a change in how two aliased inputs overlap
(capture's relative offsets stay baked in, exactly as under torch.compile), a
subclass's inner shapes and DTensor placements. The stamps are a backstop, not a
proof.

A seventh stamp records the CPU vector ISA, and it is the only one that refuses
to run rather than warning. Inductor bakes the capture host's vector width into a
C++ loop's stride while the ISA itself is re-picked when the artifact compiles on
whichever machine loads it, so replaying under a narrower vector unit leaves part
of the output as whatever the allocator held -- no error, no warning, and unlike
CUDA there is no kernel-image error to fall back on. It records None for a graph
with no C++ kernel, so a CUDA artifact never starts refusing to run because it
moved between hosts whose CPUs differ in a way it never depended on, and like
every other checked stamp it warns per call when the line is missing.

Two honest limits on that stamp, both worth weighing in review: it records the
ambient ISA rather than anything about the code it is stamping, so it will refuse
an artifact whose kernel contains no vector code at all; and it is checked after
the artifact has been exec'd, so a host too narrow to compile the kernel fails
earlier, in the compiler.

Test Plan:

```
python test/test_precompile.py
```

340 tests pass.

This commit was authored with the assistance of an AI coding agent.