### PR TITLE
[ROCm][Inductor] Fix CKTILE float16 autotune dtype mismatch

### DIFF
--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -74,22 +74,22 @@ class TestCKBackend(TestCase):
     @unittest.skipIf(not torch.version.hip, "ROCM only")
     @unittest.mock.patch.dict(os.environ, _test_env)
     @parametrize(
-        "max_autotune_gemm_backends",
+        "max_autotune_gemm_backends,dtype",
         (
-            subtest("CK", decorators=[skipIfRocmVersionAtLeast([7, 14])]),
-            "CKTILE",
-            "ATen,CK",
+            subtest(
+                ("CK", torch.bfloat16),
+                name="standalone_ck",
+                decorators=[skipIfRocmVersionAtLeast([7, 14])],
+            ),
+            subtest(("CKTILE", torch.float16), name="standalone_cktile_float16"),
+            subtest(("CKTILE", torch.bfloat16), name="standalone_cktile_bfloat16"),
+            subtest(("ATen,CK", torch.bfloat16), name="fallback"),
         ),
-        name_fn=lambda b: {
-            "CK": "standalone_ck",
-            "CKTILE": "standalone_cktile",
-            "ATen,CK": "fallback",
-        }[b],
     )
     @parametrize("autotune_in_subproc", (True, False))
     @parametrize("use_aoti", (True, False))
     def test_max_autotune_precompile_matmul(
-        self, max_autotune_gemm_backends, autotune_in_subproc, use_aoti
+        self, max_autotune_gemm_backends, dtype, autotune_in_subproc, use_aoti
     ):
         """
         Make sure autotuning mm doesn't crash.
@@ -98,7 +98,7 @@ class TestCKBackend(TestCase):
         def mm(a, b):
             return a @ b
 
-        tensor_options = {"device": "cuda", "dtype": torch.bfloat16}
+        tensor_options = {"device": "cuda", "dtype": dtype}
 
         a = torch.randn(2240, 256, **tensor_options)
         b = torch.randn(256, 2048, **tensor_options)
@@ -617,11 +617,8 @@ class TestCKTileUniversalGemmTemplate(TestCase):
         # _ck_tile_universal_gemm_v2_api is functools.cache'd on the search path.
         self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
 
-    # ops() names the half-precision instances "FP16", but _TORCH_DTYPE_TO_CK maps
-    # torch.float16 to "F16", so check_dtypes never matches them. bfloat16 is the
-    # only dtype for which CK-Tile instances are currently reachable.
-    _DTYPE = torch.bfloat16
-    _CK_DTYPE = "BF16"
+    _DTYPE = torch.float16
+    _CK_DTYPE = "F16"
 
     def _make_template(self, m=2048, n=2048, k=2048):
         device = torch.device("cuda")

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -807,29 +807,22 @@ struct FlatmmPipelineProblem
 
     def test_ops_dtype_labels_agree_with_maps(self):
         template_cls = self._ck_tile.CKTileGemmTemplate
-        # Must match the `using` aliases CKTileTemplate.globals() emits, not the
-        # full _TORCH_DTYPE_TO_CK map (which also lists F64, I32, I8, etc.).
-        cpp_aliases = set(
-            re.findall(
-                r"using (\w+) =",
-                self._make_template(dtype=torch.float16).globals().getvalue(),
-            )
-        )
-        # Explicit GEMM catalog: do not derive from ck_dtype_to_size, which is
-        # also used for alignment math and may grow independently.
-        expected_gemm_dtypes = {
-            template_cls._TORCH_DTYPE_TO_CK[torch.float16],
-            template_cls._TORCH_DTYPE_TO_CK[torch.bfloat16],
-        }
+        globals_src = self._make_template(dtype=torch.float16).globals().getvalue()
+        cpp_aliases = set(re.findall(r"using (\w+) =", globals_src))
         labels = {
             dt
             for op in self._ck_tile.ops()
             for dt in (op.datatype_a, op.datatype_b, op.datatype_c)
         }
         self.assertTrue(labels)
-        self.assertEqual(labels, expected_gemm_dtypes)
-        self.assertEqual(labels - cpp_aliases, set())
-        self.assertLessEqual(expected_gemm_dtypes, set(template_cls.ck_dtype_to_size))
+        self.assertEqual(labels, set(self._ck_tile.GEMM_DTYPES))
+        self.assertEqual(
+            set(template_cls._CK_DTYPE_ALIASES),
+            cpp_aliases - {"Row", "Col"},
+        )
+        self.assertLessEqual(
+            set(self._ck_tile.GEMM_DTYPES), set(template_cls.ck_dtype_to_size)
+        )
 
     @_parametrize_dtype
     @parametrize("epilogue", ("Default", "CShuffle"))

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -2,6 +2,7 @@
 import contextlib
 import logging
 import os
+import re
 import shlex
 import subprocess
 import tempfile
@@ -47,6 +48,13 @@ _test_env = {}
 
 def _dtype_test_name(dtype):
     return {torch.float16: "float16", torch.bfloat16: "bfloat16"}[dtype]
+
+
+_parametrize_dtype = parametrize(
+    "dtype",
+    (torch.float16, torch.bfloat16),
+    name_fn=_dtype_test_name,
+)
 
 
 @instantiate_parametrized_tests
@@ -342,11 +350,7 @@ class TestCKBackend(TestCase):
         ([4096, 2048], [2048], [4096, 1]),
         name_fn=lambda x_shape: f"x_shape_{'x'.join(map(str, x_shape))}",
     )
-    @parametrize(
-        "dtype",
-        (torch.float16, torch.bfloat16),
-        name_fn=_dtype_test_name,
-    )
+    @_parametrize_dtype
     def test_max_autotune_addmm(self, max_autotune_gemm_backends, x_shape, dtype):
         m, k, n = 4096, 224, 2048
         alpha, beta = 1.0, 1.0
@@ -620,11 +624,10 @@ class TestCKTileUniversalGemmTemplate(TestCase):
         from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
 
         self._ck_tile = ck_tile_universal_gemm_template
-        # Both are functools.cache'd. ops() snapshots ck_dtype_to_size on first call.
+        # _ck_tile_universal_gemm_v2_api is functools.cache'd on the search path.
         self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
-        self._ck_tile.ops.cache_clear()
 
-    def _make_template(self, m=2048, n=2048, k=2048, dtype=torch.float16):
+    def _make_template(self, m=2048, n=2048, k=2048, *, dtype):
         device = torch.device("cuda")
         X = Buffer(name="X", layout=FixedLayout(device, dtype, [m, k]))
         W = Buffer(name="W", layout=FixedLayout(device, dtype, [k, n]))
@@ -632,9 +635,7 @@ class TestCKTileUniversalGemmTemplate(TestCase):
             [X, W], FixedLayout(device, dtype, [m, n])
         )
 
-    def _find_ck_tile_op(
-        self, pipeline="CompV3", epilogue="Default", dtype=torch.float16
-    ):
+    def _find_ck_tile_op(self, pipeline="CompV3", epilogue="Default", *, dtype):
         ck_dtype = self._ck_tile.CKTileGemmTemplate._TORCH_DTYPE_TO_CK[dtype]
         for op in self._ck_tile.ops():
             if (
@@ -806,22 +807,31 @@ struct FlatmmPipelineProblem
 
     def test_ops_dtype_labels_agree_with_maps(self):
         template_cls = self._ck_tile.CKTileGemmTemplate
-        mapped = set(template_cls._TORCH_DTYPE_TO_CK.values())
-        sized = set(template_cls.ck_dtype_to_size)
+        # Must match the `using` aliases CKTileTemplate.globals() emits, not the
+        # full _TORCH_DTYPE_TO_CK map (which also lists F64, I32, I8, etc.).
+        cpp_aliases = set(
+            re.findall(
+                r"using (\w+) =",
+                self._make_template(dtype=torch.float16).globals().getvalue(),
+            )
+        )
+        # Explicit GEMM catalog: do not derive from ck_dtype_to_size, which is
+        # also used for alignment math and may grow independently.
+        expected_gemm_dtypes = {
+            template_cls._TORCH_DTYPE_TO_CK[torch.float16],
+            template_cls._TORCH_DTYPE_TO_CK[torch.bfloat16],
+        }
         labels = {
             dt
             for op in self._ck_tile.ops()
             for dt in (op.datatype_a, op.datatype_b, op.datatype_c)
         }
         self.assertTrue(labels)
-        self.assertEqual(labels - mapped, set())
-        self.assertEqual(labels, sized)
+        self.assertEqual(labels, expected_gemm_dtypes)
+        self.assertEqual(labels - cpp_aliases, set())
+        self.assertLessEqual(expected_gemm_dtypes, set(template_cls.ck_dtype_to_size))
 
-    @parametrize(
-        "dtype",
-        (torch.float16, torch.bfloat16),
-        name_fn=_dtype_test_name,
-    )
+    @_parametrize_dtype
     @parametrize("epilogue", ("Default", "CShuffle"))
     def test_emit_v1_legacy_instance(self, dtype, epilogue):
         code = self._make_template(dtype=dtype).emit_ck_instance(
@@ -833,11 +843,7 @@ struct FlatmmPipelineProblem
         self.assertIn("ck_tile::GemmPipelineProblem<", code)
         self.assertIn("BaseGemmPipeline", code)
 
-    @parametrize(
-        "dtype",
-        (torch.float16, torch.bfloat16),
-        name_fn=_dtype_test_name,
-    )
+    @_parametrize_dtype
     @parametrize("epilogue", ("Default", "CShuffle"))
     def test_emit_v2_simplified_instance(self, dtype, epilogue):
         code = self._make_template(dtype=dtype).emit_ck_instance(
@@ -867,11 +873,7 @@ struct FlatmmPipelineProblem
         self.assertNotIn("BaseGemmPipeline", code)
         self.assertIn("Kernel::GridSize", code)
 
-    @parametrize(
-        "dtype",
-        (torch.float16, torch.bfloat16),
-        name_fn=_dtype_test_name,
-    )
+    @_parametrize_dtype
     @parametrize("use_v2_api", (True, False))
     def test_cshuffle_epilogue_offered_only_with_v2_api(self, dtype, use_v2_api):
         """
@@ -891,11 +893,7 @@ struct FlatmmPipelineProblem
         self.assertIn("Default", epilogues)
         self.assertEqual("CShuffle" in epilogues, use_v2_api)
 
-    @parametrize(
-        "dtype",
-        (torch.float16, torch.bfloat16),
-        name_fn=_dtype_test_name,
-    )
+    @_parametrize_dtype
     @parametrize("pipeline", ("CompV3", "CompV4", "Mem"))
     @parametrize("epilogue", ("Default", "CShuffle"))
     def test_offered_instance_compiles(self, dtype, epilogue, pipeline):

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -45,6 +45,10 @@ log = logging.getLogger(__name__)
 _test_env = {}
 
 
+def _dtype_test_name(dtype):
+    return {torch.float16: "float16", torch.bfloat16: "bfloat16"}[dtype]
+
+
 @instantiate_parametrized_tests
 class TestCKBackend(TestCase):
     def setUp(self):
@@ -76,6 +80,8 @@ class TestCKBackend(TestCase):
     @parametrize(
         "max_autotune_gemm_backends,dtype",
         (
+            # CK float16 is covered by test_max_autotune_precompile_preselected
+            # and test_max_autotune_addmm. Only CKTILE needs a float16 cell here.
             subtest(
                 ("CK", torch.bfloat16),
                 name="standalone_ck",
@@ -339,7 +345,7 @@ class TestCKBackend(TestCase):
     @parametrize(
         "dtype",
         (torch.float16, torch.bfloat16),
-        name_fn=lambda d: {torch.float16: "float16", torch.bfloat16: "bfloat16"}[d],
+        name_fn=_dtype_test_name,
     )
     def test_max_autotune_addmm(self, max_autotune_gemm_backends, x_shape, dtype):
         m, k, n = 4096, 224, 2048
@@ -614,26 +620,27 @@ class TestCKTileUniversalGemmTemplate(TestCase):
         from torch._inductor.codegen.rocm import ck_tile_universal_gemm_template
 
         self._ck_tile = ck_tile_universal_gemm_template
-        # _ck_tile_universal_gemm_v2_api is functools.cache'd on the search path.
+        # Both are functools.cache'd. ops() snapshots ck_dtype_to_size on first call.
         self._ck_tile._ck_tile_universal_gemm_v2_api.cache_clear()
+        self._ck_tile.ops.cache_clear()
 
-    _DTYPE = torch.float16
-    _CK_DTYPE = "F16"
-
-    def _make_template(self, m=2048, n=2048, k=2048):
+    def _make_template(self, m=2048, n=2048, k=2048, dtype=torch.float16):
         device = torch.device("cuda")
-        X = Buffer(name="X", layout=FixedLayout(device, self._DTYPE, [m, k]))
-        W = Buffer(name="W", layout=FixedLayout(device, self._DTYPE, [k, n]))
+        X = Buffer(name="X", layout=FixedLayout(device, dtype, [m, k]))
+        W = Buffer(name="W", layout=FixedLayout(device, dtype, [k, n]))
         return self._ck_tile.CKTileGemmTemplate(
-            [X, W], FixedLayout(device, self._DTYPE, [m, n])
+            [X, W], FixedLayout(device, dtype, [m, n])
         )
 
-    def _find_ck_tile_op(self, pipeline="CompV3", epilogue="Default"):
+    def _find_ck_tile_op(
+        self, pipeline="CompV3", epilogue="Default", dtype=torch.float16
+    ):
+        ck_dtype = self._ck_tile.CKTileGemmTemplate._TORCH_DTYPE_TO_CK[dtype]
         for op in self._ck_tile.ops():
             if (
                 (op.pipeline, op.epilogue) == (pipeline, epilogue)
                 and (op.layout_a, op.layout_b, op.layout_c) == ("Row", "Row", "Row")
-                and op.datatype_a == self._CK_DTYPE
+                and op.datatype_a == ck_dtype
             ):
                 return op
         raise AssertionError(f"no CK-Tile gemm op for {pipeline=} {epilogue=}")
@@ -797,10 +804,28 @@ struct FlatmmPipelineProblem
         with self._probe_env() as rocm_home:
             self.assertFalse(self._probe(rocm_home))
 
+    def test_ops_dtype_labels_agree_with_maps(self):
+        template_cls = self._ck_tile.CKTileGemmTemplate
+        mapped = set(template_cls._TORCH_DTYPE_TO_CK.values())
+        sized = set(template_cls.ck_dtype_to_size)
+        labels = {
+            dt
+            for op in self._ck_tile.ops()
+            for dt in (op.datatype_a, op.datatype_b, op.datatype_c)
+        }
+        self.assertTrue(labels)
+        self.assertEqual(labels - mapped, set())
+        self.assertEqual(labels, sized)
+
+    @parametrize(
+        "dtype",
+        (torch.float16, torch.bfloat16),
+        name_fn=_dtype_test_name,
+    )
     @parametrize("epilogue", ("Default", "CShuffle"))
-    def test_emit_v1_legacy_instance(self, epilogue):
-        code = self._make_template().emit_ck_instance(
-            self._find_ck_tile_op(epilogue=epilogue), use_v2_api=False
+    def test_emit_v1_legacy_instance(self, dtype, epilogue):
+        code = self._make_template(dtype=dtype).emit_ck_instance(
+            self._find_ck_tile_op(epilogue=epilogue, dtype=dtype), use_v2_api=False
         )
         self.assertIn("has_hot_loop_v", code)
         # "GemmPipelineProblem" alone would also match "UniversalGemmPipelineProblem",
@@ -808,10 +833,15 @@ struct FlatmmPipelineProblem
         self.assertIn("ck_tile::GemmPipelineProblem<", code)
         self.assertIn("BaseGemmPipeline", code)
 
+    @parametrize(
+        "dtype",
+        (torch.float16, torch.bfloat16),
+        name_fn=_dtype_test_name,
+    )
     @parametrize("epilogue", ("Default", "CShuffle"))
-    def test_emit_v2_simplified_instance(self, epilogue):
-        code = self._make_template().emit_ck_instance(
-            self._find_ck_tile_op(epilogue=epilogue), use_v2_api=True
+    def test_emit_v2_simplified_instance(self, dtype, epilogue):
+        code = self._make_template(dtype=dtype).emit_ck_instance(
+            self._find_ck_tile_op(epilogue=epilogue, dtype=dtype), use_v2_api=True
         )
         self.assertNotIn("has_hot_loop_v", code)
         self.assertNotIn("BaseGemmPipeline", code)
@@ -837,13 +867,18 @@ struct FlatmmPipelineProblem
         self.assertNotIn("BaseGemmPipeline", code)
         self.assertIn("Kernel::GridSize", code)
 
+    @parametrize(
+        "dtype",
+        (torch.float16, torch.bfloat16),
+        name_fn=_dtype_test_name,
+    )
     @parametrize("use_v2_api", (True, False))
-    def test_cshuffle_epilogue_offered_only_with_v2_api(self, use_v2_api):
+    def test_cshuffle_epilogue_offered_only_with_v2_api(self, dtype, use_v2_api):
         """
         Pre-change ck_tile cannot compile the CShuffle epilogue we emit, so those
         instances must not reach autotuning and burn a compile each.
         """
-        template = self._make_template()
+        template = self._make_template(dtype=dtype)
         with (
             config.patch({"rocm.ck_tile_max_profiling_configs": None}),
             patch.object(
@@ -856,9 +891,14 @@ struct FlatmmPipelineProblem
         self.assertIn("Default", epilogues)
         self.assertEqual("CShuffle" in epilogues, use_v2_api)
 
+    @parametrize(
+        "dtype",
+        (torch.float16, torch.bfloat16),
+        name_fn=_dtype_test_name,
+    )
     @parametrize("pipeline", ("CompV3", "CompV4", "Mem"))
     @parametrize("epilogue", ("Default", "CShuffle"))
-    def test_offered_instance_compiles(self, epilogue, pipeline):
+    def test_offered_instance_compiles(self, dtype, epilogue, pipeline):
         """
         Every instance filter_op accepts must compile against the ck_tile headers
         installed on this host, whichever universal GEMM API they expose.
@@ -866,8 +906,8 @@ struct FlatmmPipelineProblem
         rocm = config.rocm
         if self._ck_tile._find_ck_tile_header(rocm.rocm_home, rocm.ck_dir) is None:
             raise unittest.SkipTest("ck_tile headers are not installed")
-        template = self._make_template()
-        op = self._find_ck_tile_op(pipeline=pipeline, epilogue=epilogue)
+        template = self._make_template(dtype=dtype)
+        op = self._find_ck_tile_op(pipeline=pipeline, epilogue=epilogue, dtype=dtype)
         if template.filter_op(op) is None:
             raise unittest.SkipTest(f"{pipeline}/{epilogue} not offered on this ROCm")
         use_v2_api = self._probe(config.rocm.rocm_home)

--- a/test/inductor/test_ck_backend.py
+++ b/test/inductor/test_ck_backend.py
@@ -816,13 +816,10 @@ struct FlatmmPipelineProblem
         }
         self.assertTrue(labels)
         self.assertEqual(labels, set(self._ck_tile.GEMM_DTYPES))
-        self.assertEqual(
-            set(template_cls._CK_DTYPE_ALIASES),
-            cpp_aliases - {"Row", "Col"},
-        )
-        self.assertLessEqual(
-            set(self._ck_tile.GEMM_DTYPES), set(template_cls.ck_dtype_to_size)
-        )
+        # emit_ck_instance splices these labels into `using ADataType = ...;`, so a
+        # label without a rendered alias produces HIP that does not compile.
+        self.assertLessEqual(labels, cpp_aliases)
+        self.assertLessEqual(labels, set(template_cls.ck_dtype_to_size))
 
     @_parametrize_dtype
     @parametrize("epilogue", ("Default", "CShuffle"))

--- a/torch/_inductor/codegen/rocm/ck_tile_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_template.py
@@ -22,7 +22,15 @@ class CKTileTemplate(ROCmTemplate):
         torch.float8_e5m2: "BF8",  # gfx95
     }
 
-    # Keys are _TORCH_DTYPE_TO_CK values and must match the C++ aliases in globals().
+    _CK_DTYPE_ALIASES = {
+        "F8": "ck_tile::fp8_t",
+        "BF8": "ck_tile::bf8_t",
+        "F16": "ck_tile::half_t",
+        "F32": "float",
+        "BF16": "ck_tile::bfloat16_t",
+    }
+
+    # Keys are _TORCH_DTYPE_TO_CK values and must match _CK_DTYPE_ALIASES.
     ck_dtype_to_size = {
         _TORCH_DTYPE_TO_CK[torch.float16]: 2,
         _TORCH_DTYPE_TO_CK[torch.bfloat16]: 2,
@@ -41,15 +49,11 @@ class CKTileTemplate(ROCmTemplate):
 
     def globals(self) -> IndentedBuffer:
         res = super().globals()
-        res.splice(
-            """
-                using F8  = ck_tile::fp8_t;
-                using BF8 = ck_tile::bf8_t;
-                using F16 = ck_tile::half_t;
-                using F32 = float;
-                using BF16 = ck_tile::bfloat16_t;
-            """
+        alias_lines = "\n".join(
+            f"                using {name} = {ctype};"
+            for name, ctype in self._CK_DTYPE_ALIASES.items()
         )
+        res.splice(f"\n{alias_lines}\n")
         return res
 
     def torch_type_to_ck(self, node: IRNode, ptr: str) -> str:

--- a/torch/_inductor/codegen/rocm/ck_tile_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_template.py
@@ -22,9 +22,10 @@ class CKTileTemplate(ROCmTemplate):
         torch.float8_e5m2: "BF8",  # gfx95
     }
 
+    # Keys are _TORCH_DTYPE_TO_CK values and must match the C++ aliases in globals().
     ck_dtype_to_size = {
-        "F16": 2,
-        "BF16": 2,
+        _TORCH_DTYPE_TO_CK[torch.float16]: 2,
+        _TORCH_DTYPE_TO_CK[torch.bfloat16]: 2,
     }
 
     def header(self) -> IndentedBuffer:

--- a/torch/_inductor/codegen/rocm/ck_tile_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_template.py
@@ -30,7 +30,9 @@ class CKTileTemplate(ROCmTemplate):
         "BF16": "ck_tile::bfloat16_t",
     }
 
-    # Keys are _TORCH_DTYPE_TO_CK values and must match _CK_DTYPE_ALIASES.
+    # Bytes per element, used for the alignment and LDS budget math in the gemm
+    # templates. Keys are _TORCH_DTYPE_TO_CK values. This table does not decide
+    # which instances exist; see GEMM_DTYPES in ck_tile_universal_gemm_template.
     ck_dtype_to_size = {
         _TORCH_DTYPE_TO_CK[torch.float16]: 2,
         _TORCH_DTYPE_TO_CK[torch.bfloat16]: 2,
@@ -49,11 +51,9 @@ class CKTileTemplate(ROCmTemplate):
 
     def globals(self) -> IndentedBuffer:
         res = super().globals()
-        alias_lines = "\n".join(
-            f"                using {name} = {ctype};"
-            for name, ctype in self._CK_DTYPE_ALIASES.items()
-        )
-        res.splice(f"\n{alias_lines}\n")
+        res.newline()
+        for name, ctype in self._CK_DTYPE_ALIASES.items():
+            res.writeline(f"using {name} = {ctype};")
         return res
 
     def torch_type_to_ck(self, node: IRNode, ptr: str) -> str:

--- a/torch/_inductor/codegen/rocm/ck_tile_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_template.py
@@ -23,7 +23,7 @@ class CKTileTemplate(ROCmTemplate):
     }
 
     ck_dtype_to_size = {
-        "FP16": 2,
+        "F16": 2,
         "BF16": 2,
     }
 

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -21,6 +21,12 @@ from ...utils import IndentedBuffer
 
 log = logging.getLogger(__name__)
 
+# Dtypes for which universal GEMM instances are generated. Every entry must have
+# a ck_dtype_to_size entry and a _CK_DTYPE_ALIASES entry on CKTileTemplate.
+GEMM_DTYPES = (
+    CKTileTemplate._TORCH_DTYPE_TO_CK[torch.float16],
+    CKTileTemplate._TORCH_DTYPE_TO_CK[torch.bfloat16],
+)
 
 _CK_TILE_PIPELINE_PROBLEM_HEADER = "ck_tile/ops/gemm/pipeline/gemm_pipeline_problem.hpp"
 _STRUCT_ANCHOR = "struct UniversalGemmPipelineProblem"
@@ -187,7 +193,7 @@ def ops():
     """
     import itertools
 
-    gemm_dtypes = [(d,) * 3 for d in CKTileTemplate.ck_dtype_to_size]
+    gemm_dtypes = [(d,) * 3 for d in GEMM_DTYPES]
 
     compute_v3_instances = [
         CKTileGemmOperation(

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -215,7 +215,7 @@ def ops():
             ("Row", "Row", "Row"),
             ("Row", "Col", "Row"),
         ]
-        for (datatype_a, datatype_b, datatype_c) in [("FP16",) * 3, ("BF16",) * 3]
+        for (datatype_a, datatype_b, datatype_c) in [("F16",) * 3, ("BF16",) * 3]
         for (tile_m, tile_n, tile_k) in [(256, 256, 32), (256, 256, 64)]
         for (warp_m, warp_n, warp_k) in [(2, 2, 1)]
         for (warp_tile_m, warp_tile_n, warp_tile_k) in [(32, 32, 16)]
@@ -253,7 +253,7 @@ def ops():
             ("Row", "Row", "Row"),
             ("Row", "Col", "Row"),
         ]
-        for (datatype_a, datatype_b, datatype_c) in [("FP16",) * 3, ("BF16",) * 3]
+        for (datatype_a, datatype_b, datatype_c) in [("F16",) * 3, ("BF16",) * 3]
         for (tile_m, tile_n, tile_k) in [
             (256, 256, 32)
         ]  # half the tile size since it has double buffering
@@ -293,7 +293,7 @@ def ops():
             ("Row", "Row", "Row"),
             ("Row", "Col", "Row"),
         ]
-        for (datatype_a, datatype_b, datatype_c) in [("FP16",) * 3, ("BF16",) * 3]
+        for (datatype_a, datatype_b, datatype_c) in [("F16",) * 3, ("BF16",) * 3]
         for (tile_m, tile_n, tile_k) in [(256, 256, 32), (256, 256, 64)]
         for (warp_m, warp_n, warp_k) in [(2, 2, 1)]
         for (warp_tile_m, warp_tile_n, warp_tile_k) in [(32, 32, 16)]

--- a/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
+++ b/torch/_inductor/codegen/rocm/ck_tile_universal_gemm_template.py
@@ -187,6 +187,8 @@ def ops():
     """
     import itertools
 
+    gemm_dtypes = [(d,) * 3 for d in CKTileTemplate.ck_dtype_to_size]
+
     compute_v3_instances = [
         CKTileGemmOperation(
             layout_a=layout_a,
@@ -215,7 +217,7 @@ def ops():
             ("Row", "Row", "Row"),
             ("Row", "Col", "Row"),
         ]
-        for (datatype_a, datatype_b, datatype_c) in [("F16",) * 3, ("BF16",) * 3]
+        for (datatype_a, datatype_b, datatype_c) in gemm_dtypes
         for (tile_m, tile_n, tile_k) in [(256, 256, 32), (256, 256, 64)]
         for (warp_m, warp_n, warp_k) in [(2, 2, 1)]
         for (warp_tile_m, warp_tile_n, warp_tile_k) in [(32, 32, 16)]
@@ -253,7 +255,7 @@ def ops():
             ("Row", "Row", "Row"),
             ("Row", "Col", "Row"),
         ]
-        for (datatype_a, datatype_b, datatype_c) in [("F16",) * 3, ("BF16",) * 3]
+        for (datatype_a, datatype_b, datatype_c) in gemm_dtypes
         for (tile_m, tile_n, tile_k) in [
             (256, 256, 32)
         ]  # half the tile size since it has double buffering
@@ -293,7 +295,7 @@ def ops():
             ("Row", "Row", "Row"),
             ("Row", "Col", "Row"),
         ]
-        for (datatype_a, datatype_b, datatype_c) in [("F16",) * 3, ("BF16",) * 3]
+        for (datatype_a, datatype_b, datatype_c) in gemm_dtypes
         for (tile_m, tile_n, tile_k) in [(256, 256, 32), (256, 256, 64)]
         for (warp_m, warp_n, warp_k) in [(2, 2, 1)]
         for (warp_tile_m, warp_tile_n, warp_tile_k) in [(32, 32, 16)]


### PR DESCRIPTION
Fix CK-Tile float16 autotune silently dropping all fp16 GEMM kernels. ops() named half-precision instances "FP16" while check_dtypes compared against _TORCH_DTYPE_TO_CK[float16] == "F16", so every fp16 kernel was filtered out before autotuning. Rename catalog labels to "F16" to match the existing C++ alias in globals().

Also decouple the universal GEMM dtype catalog from ck_dtype_to_size. GEMM_DTYPES explicitly declares which dtypes get GEMM instances. ck_dtype_to_size remains for alignment and padding math only. _CK_DTYPE_ALIASES is the single source of truth for C++ using aliases, and globals() renders from it.

Tests parametrize fp16 and bf16 across template emit and compile coverage, and assert that ops() implements GEMM_DTYPES, that rendered globals() matches _CK_DTYPE_ALIASES, and that every GEMM dtype has a size-table entry.

This is a follow-up to the CK-Tile inductor GEMM fix #189646
Authored with Cursor Grok 4.6.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben