### PR TITLE
[WIP][pipelining] Release activation send buffers as soon as the send completes

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import copy
+import weakref
 
 from model_registry import MLPModule, MultiInterMediateModel
 
@@ -328,6 +329,143 @@ class StageBackwardTests(TestCase):
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             torch.testing.assert_close(p.grad, ref_p.grad)
+
+    def test_stage_backward_from_gradient_edge(self, device):
+        """Match tensor-rooted backward after releasing the output."""
+        mod = MLPModule(d_hid).to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        output_grad = torch.randn(batch_size, d_hid, device=device)
+
+        ref_mod = copy.deepcopy(mod).to(device)
+        ref_x = x.detach().clone().requires_grad_(True)
+
+        out = mod(x)
+        edge = torch.autograd.graph.get_gradient_edge(out)
+        # The edge must not keep the activation alive.
+        released = weakref.ref(out)
+        del out
+        self.assertIsNone(released())
+
+        grad_inputs = stage_backward(
+            stage_output=(edge,),
+            output_grads=(output_grad,),
+            input_values=(x,),
+        )
+
+        ref_out = ref_mod(ref_x)
+        ref_out.backward(output_grad)
+
+        torch.testing.assert_close(grad_inputs[0], ref_x.grad)
+        for name, p in mod.named_parameters():
+            torch.testing.assert_close(p.grad, ref_mod.get_parameter(name).grad)
+
+    def test_stage_backward_mixed_edge_and_tensor_outputs(self, device):
+        """Handle edge, tensor, and non-grad outputs together."""
+
+        class TwoOutputModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.net1 = torch.nn.Linear(d_hid, d_hid)
+                self.net2 = torch.nn.Linear(d_hid, d_hid)
+
+            def forward(self, x):
+                return self.net1(x), self.net2(x), torch.ones(1, device=x.device)
+
+        mod = TwoOutputModule().to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        grads = (
+            torch.randn(batch_size, d_hid, device=device),
+            torch.randn(batch_size, d_hid, device=device),
+            None,
+        )
+
+        ref_mod = copy.deepcopy(mod).to(device)
+        ref_x = x.detach().clone().requires_grad_(True)
+
+        first, second, no_grad_out = mod(x)
+        edge = torch.autograd.graph.get_gradient_edge(first)
+        del first
+
+        self.assertFalse(no_grad_out.requires_grad)
+        grad_inputs = stage_backward(
+            stage_output=(edge, second, None),
+            output_grads=grads,
+            input_values=(x,),
+        )
+
+        ref_first, ref_second, _ = ref_mod(ref_x)
+        torch.autograd.backward((ref_first, ref_second), (grads[0], grads[1]))
+
+        torch.testing.assert_close(grad_inputs[0], ref_x.grad)
+        for name, p in mod.named_parameters():
+            torch.testing.assert_close(p.grad, ref_mod.get_parameter(name).grad)
+
+    def test_stage_backward_edge_keeps_python_autograd_function_alive(self, device):
+        """Keep a Python autograd graph alive through its edge."""
+
+        class ScaleBy(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, factor):
+                ctx.factor = factor
+                return x * factor
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                return grad_out * ctx.factor, None
+
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        output_grad = torch.randn(batch_size, d_hid, device=device)
+
+        out = ScaleBy.apply(x, 3.0)
+        edge = torch.autograd.graph.get_gradient_edge(out)
+        del out
+
+        grad_inputs = stage_backward(
+            stage_output=(edge,),
+            output_grads=(output_grad,),
+            input_values=(x,),
+        )
+        torch.testing.assert_close(grad_inputs[0], output_grad * 3.0)
+
+    def test_stage_backward_input_from_gradient_edge(self, device):
+        """Match tensor-rooted split backward."""
+        mod = MLPModule(d_hid).to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        output_grad = torch.randn(batch_size, d_hid, device=device)
+
+        ref_mod = copy.deepcopy(mod).to(device)
+        ref_x = x.detach().clone().requires_grad_(True)
+
+        out = mod(x)
+        edge = torch.autograd.graph.get_gradient_edge(out)
+        del out
+
+        dinputs, param_groups = stage_backward_input(
+            stage_outputs_or_loss=[edge],
+            output_grads=[output_grad],
+            input_values=[x],
+            weights=mod.parameters(),
+        )
+        stage_backward_weight(mod.parameters(), param_groups)
+
+        ref_mod(ref_x).backward(output_grad)
+
+        torch.testing.assert_close(dinputs[0], ref_x.grad)
+        for name, p in mod.named_parameters():
+            torch.testing.assert_close(p.grad, ref_mod.get_parameter(name).grad)
+
+    def test_stage_backward_input_edge_requires_output_grads(self, device):
+        mod = MLPModule(d_hid).to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        edge = torch.autograd.graph.get_gradient_edge(mod(x))
+
+        with self.assertRaisesRegex(AssertionError, "requires output gradients"):
+            stage_backward_input(
+                stage_outputs_or_loss=[edge],
+                output_grads=None,
+                input_values=[x],
+                weights=mod.parameters(),
+            )
 
 
 instantiate_device_type_tests(StageBackwardTests, globals(), allow_xpu=True)

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -4,7 +4,8 @@ import copy
 import csv
 import logging
 import os
-from unittest.mock import MagicMock, patch
+import tempfile
+from unittest.mock import create_autospec, MagicMock, patch
 
 from model_registry import MultiMLP
 
@@ -28,10 +29,12 @@ from torch.distributed.pipelining.schedules import (
     _add_reduce_grad,
     _add_send_recv,
     _add_unshard_reshard,
+    _add_wait_send,
     _batch_p2p,
     _defer_recv_ops,
     _format_pipeline_order,
     _merge_bw,
+    _PendingSendTracker,
     _PipelineSchedule,
     _PipelineScheduleRuntime,
     _simulate_comms_compute,
@@ -40,14 +43,19 @@ from torch.distributed.pipelining.schedules import (
     F,
     get_schedule_class,
     I,
+    OVERLAP_F_B,
     PipelineScheduleMulti,
     PipelineScheduleSingle,
     RECV_B,
     RECV_F,
+    REDUCE_GRAD,
     RESHARD,
     SEND_B,
+    SEND_F,
     UNSHARD,
     W,
+    WAIT_SEND_B,
+    WAIT_SEND_F,
 )
 from torch.distributed.pipelining.stage import (
     _PipelineStageBase,
@@ -84,6 +92,7 @@ class MockPipelineStage(_PipelineStageBase):
         self.group_size = kwargs.get("group_size", 1)
         self.group_rank = kwargs.get("group_rank", 0)
         self.group = kwargs.get("group")
+        self.early_send_release = kwargs.get("early_send_release", False)
 
     def _create_grad_recv_info(self, *args, **kwargs):
         return None
@@ -1460,6 +1469,205 @@ class TestScheduleLowering(TestCase):
                 )
             self.assertEqual(len(result_sch[rank]), len(expected_sch[rank]))
 
+    def _wait_send_schedule(self, num_stages, num_microbatches):
+        """Build a lowered 1F1B-shaped schedule."""
+        compute = {
+            rank: [_Action(rank, F, mb) for mb in range(num_microbatches)]
+            + [_Action(rank, B, mb) for mb in range(num_microbatches)]
+            for rank in range(num_stages)
+        }
+        with_comms = _add_send_recv(
+            compute, stage_to_rank=lambda s: s, num_stages=num_stages
+        )
+        return _add_wait_send(with_comms)
+
+    def test_add_wait_send_pairs_every_forward_send(self):
+        num_stages, num_microbatches = 4, 4
+        lowered = self._wait_send_schedule(num_stages, num_microbatches)
+
+        for rank, actions in lowered.items():
+            sends = [a for a in actions if a.computation_type == SEND_F]
+            waits = [a for a in actions if a.computation_type == WAIT_SEND_F]
+            self.assertEqual(
+                [(a.stage_index, a.microbatch_index) for a in sends],
+                [(a.stage_index, a.microbatch_index) for a in waits],
+                f"rank {rank} sends and waits disagree",
+            )
+        # The last stage has no sends or waits.
+        self.assertEqual(
+            [a for a in lowered[num_stages - 1] if a.computation_type == WAIT_SEND_F],
+            [],
+        )
+
+    def test_add_wait_send_places_wait_after_backward(self):
+        lowered = self._wait_send_schedule(4, 4)
+        actions = lowered[0]
+        for mb in range(4):
+            backward = actions.index(_Action(0, B, mb))
+            wait = actions.index(_Action(0, WAIT_SEND_F, mb))
+            send = actions.index(_Action(0, SEND_F, mb))
+            # Backward implies that the peer received the activation.
+            self.assertLess(send, backward)
+            self.assertEqual(wait, backward + 1)
+
+    def test_add_wait_send_does_not_deadlock(self):
+        for num_stages, num_microbatches in ((2, 2), (4, 4), (4, 8)):
+            lowered = self._wait_send_schedule(num_stages, num_microbatches)
+            _simulate_comms_compute(
+                lowered, stage_to_rank=lambda s: s, num_stages=num_stages
+            )
+
+    def test_simulator_rejects_wait_before_the_peer_receive(self):
+        """Reject a wait whose peer never receives."""
+        # A send cannot complete before its peer receives it.
+        order = {
+            0: [
+                _Action(0, F, 0),
+                _Action(0, SEND_F, 0),
+                _Action(0, WAIT_SEND_F, 0),
+            ],
+            1: [],
+        }
+
+        with self.assertRaisesRegex(ValueError, "not progressing"):
+            _simulate_comms_compute(order, stage_to_rank=lambda s: s, num_stages=2)
+
+    def test_waits_survive_a_compute_comms_csv_round_trip(self):
+        """Preserve WAIT_SEND actions across CSV round trips."""
+
+        def stage(index, enabled):
+            mock_stage = create_autospec(PipelineStage, instance=True)
+            mock_stage.stage_index, mock_stage.num_stages = index, 4
+            mock_stage.group_rank, mock_stage.group_size = 0, 2
+            mock_stage.submod, mock_stage.early_send_release = None, enabled
+            return mock_stage
+
+        lowered = ScheduleInterleaved1F1B(
+            [stage(i, True) for i in (0, 2)], n_microbatches=4, loss_fn=None
+        )
+        self.assertTrue(lowered._early_send_release)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "schedule.csv")
+            lowered._dump_csv(path, "compute_comms")
+
+            # Disabled stages require the file to restore early release.
+            reloaded = ScheduleInterleaved1F1B(
+                [stage(i, False) for i in (0, 2)], n_microbatches=4, loss_fn=None
+            )
+            reloaded._load_csv(path, "compute_comms")
+
+        self.assertTrue(
+            reloaded._early_send_release,
+            "a reloaded schedule ignored the waits it was dumped with",
+        )
+        self.assertEqual(
+            sum(
+                1
+                for rank_actions in reloaded.pipeline_order_with_comms.values()
+                for a in rank_actions
+                if a.computation_type == WAIT_SEND_F
+            ),
+            sum(
+                1
+                for rank_actions in lowered.pipeline_order_with_comms.values()
+                for a in rank_actions
+                if a.computation_type == WAIT_SEND_F
+            ),
+        )
+
+    def test_enabling_after_construction_does_not_take_effect(self):
+        """Read early-release state only during lowering."""
+
+        def stage(index):
+            mock_stage = create_autospec(PipelineStage, instance=True)
+            mock_stage.stage_index, mock_stage.num_stages = index, 4
+            mock_stage.group_rank, mock_stage.group_size = 0, 2
+            mock_stage.submod, mock_stage.early_send_release = None, False
+            return mock_stage
+
+        stages = [stage(i) for i in (0, 2)]
+        schedule = ScheduleInterleaved1F1B(stages, n_microbatches=4, loss_fn=None)
+        self.assertFalse(schedule._early_send_release)
+
+        for mock_stage in stages:
+            mock_stage.early_send_release = True
+        self.assertFalse(
+            schedule._early_send_release,
+            "the setting is read once, when the schedule is lowered",
+        )
+        self.assertEqual(
+            [
+                a
+                for rank in schedule.pipeline_order_with_comms
+                for a in schedule.pipeline_order_with_comms[rank]
+                if a.computation_type == WAIT_SEND_F
+            ],
+            [],
+        )
+
+    def test_lowered_dualpipev_simulates_without_deadlock(self):
+        """Simulate DualPipeV backwards stored in sub-actions."""
+
+        def stage(index):
+            mock_stage = create_autospec(PipelineStage, instance=True)
+            mock_stage.stage_index, mock_stage.num_stages = index, 4
+            mock_stage.group_rank, mock_stage.group_size = 0, 2
+            mock_stage.submod, mock_stage.early_send_release = None, True
+            return mock_stage
+
+        order = ScheduleDualPipeV(
+            [stage(i) for i in (0, 3)], n_microbatches=8, loss_fn=None
+        ).pipeline_order_with_comms
+
+        sends = sum(1 for r in order for a in order[r] if a.computation_type == SEND_F)
+        waits = sum(
+            1 for r in order for a in order[r] if a.computation_type == WAIT_SEND_F
+        )
+        self.assertEqual(waits, sends)
+
+        # FSDP actions are unrelated to send ownership.
+        skipped = (UNSHARD, RESHARD, REDUCE_GRAD)
+        _simulate_comms_compute(
+            {
+                rank: [a for a in acts if a.computation_type not in skipped]
+                for rank, acts in order.items()
+            },
+            stage_to_rank=lambda s: 0 if s in (0, 3) else 1,
+            num_stages=4,
+        )
+
+    def test_add_wait_send_pairs_sends_completed_by_a_compound_backward(self):
+        """Pair sends with backwards inside OVERLAP_F_B."""
+        compute = {
+            0: [
+                _Action(0, F, 0),
+                _Action(
+                    -1,
+                    OVERLAP_F_B,
+                    None,
+                    (_Action(0, F, 1), _Action(0, B, 0)),
+                ),
+            ],
+            1: [_Action(1, F, 0), _Action(1, B, 0)],
+        }
+        with_comms = _add_send_recv(compute, stage_to_rank=lambda s: s, num_stages=2)
+        lowered = _add_wait_send(with_comms)
+
+        # Only microbatch 0 has a backward.
+        waits = [a for a in lowered[0] if a.computation_type == WAIT_SEND_F]
+        self.assertEqual(waits, [_Action(0, WAIT_SEND_F, 0)])
+
+        overlap = next(
+            i for i, a in enumerate(lowered[0]) if a.computation_type == OVERLAP_F_B
+        )
+        self.assertEqual(lowered[0].index(waits[0]), overlap + 1)
+
+    def test_wait_send_action_round_trips_through_str(self):
+        # Do not parse WAIT_SEND_F as the "W" prefix.
+        for action in (_Action(0, WAIT_SEND_F, 7), _Action(3, WAIT_SEND_B, 0)):
+            self.assertEqual(_Action.from_str(str(action)), action)
+
     def test_defer_recv_ops_no_deadlock(self):
         """Tests the issue from pytorch/pytorch#172668: RECV_F for stage 2 should not
         be placed before unrelated compute op 0F1 on the same rank, and the deferred
@@ -2076,6 +2284,222 @@ class TestBatchP2P(TestCase):
         mock_isend.assert_not_called()
         mock_irecv.assert_not_called()
         self.assertEqual(len(result), 4)
+
+
+class _FakeWork:
+    """Test-controlled ``dist.Work`` stub."""
+
+    def __init__(self, error: Exception | None = None):
+        self.completed = False
+        self.wait_count = 0
+        # Failed NCCL work reports complete but raises from wait().
+        self.error = error
+
+    def is_completed(self):
+        return self.completed or self.error is not None
+
+    def wait(self):
+        self.wait_count += 1
+        if self.error is not None:
+            raise self.error
+        self.completed = True
+        return True
+
+
+class TestPendingSendTracker(TestCase):
+    """Tests send-buffer lifetime tracking."""
+
+    def _make_batch(self, num_works=1):
+        works = [_FakeWork() for _ in range(num_works)]
+        op = MagicMock()
+        op.tensor = torch.zeros(4)
+        return works, [op]
+
+    def test_poll_retires_only_completed_batches(self):
+        tracker = _PendingSendTracker()
+        retired = []
+
+        slow_works, slow_ops = self._make_batch()
+        fast_works, fast_ops = self._make_batch()
+        tracker.register(slow_ops, slow_works, lambda: retired.append("slow"))
+        tracker.register(fast_ops, fast_works, lambda: retired.append("fast"))
+
+        tracker.poll()
+        self.assertEqual(retired, [])
+
+        fast_works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["fast"])
+        # Only the completed batch releases its buffer.
+        self.assertEqual(fast_ops, [])
+        self.assertEqual(len(slow_ops), 1)
+
+        slow_works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["fast", "slow"])
+        self.assertEqual(slow_ops, [])
+
+    def test_batch_retires_only_when_all_works_complete(self):
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch(num_works=2)
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, [])
+
+        works[1].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["batch"])
+
+    def test_poll_never_waits(self):
+        tracker = _PendingSendTracker()
+        works, ops = self._make_batch()
+        tracker.register(ops, works)
+
+        tracker.poll()
+        self.assertEqual(works[0].wait_count, 0)
+
+    def test_drain_waits_for_stragglers(self):
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch()
+        work = works[0]
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        tracker.drain()
+
+        self.assertEqual(work.wait_count, 1)
+        self.assertEqual(retired, ["batch"])
+        self.assertEqual(ops, [])
+        # A second drain must not retire the batch again.
+        tracker.drain()
+        self.assertEqual(retired, ["batch"])
+
+    def test_poll_is_a_noop_during_cuda_graph_capture(self):
+        """Avoid completion queries during graph capture."""
+        tracker = _PendingSendTracker()
+        retired = []
+
+        class _ExplodingWork(_FakeWork):
+            def is_completed(self):
+                raise AssertionError("queried completion during capture")
+
+        works, ops = [_ExplodingWork()], [MagicMock()]
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        with patch(
+            "torch.distributed.pipelining.schedules._stream_is_capturing",
+            return_value=True,
+        ):
+            tracker.poll()
+        self.assertEqual(retired, [])
+
+        # Poll normally outside capture.
+        works[0].is_completed = lambda: True
+        with patch(
+            "torch.distributed.pipelining.schedules._stream_is_capturing",
+            return_value=False,
+        ):
+            tracker.poll()
+        self.assertEqual(retired, ["batch"])
+
+    def test_disabled_tracker_defers_everything_to_drain(self):
+        """Preserve end-of-step ownership when disabled."""
+        tracker = _PendingSendTracker(enabled=False)
+        retired = []
+        works, ops = self._make_batch()
+        works[0].completed = True
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        tracker.poll()
+        self.assertEqual(retired, [])
+        self.assertEqual(len(ops), 1)
+
+        tracker.drain()
+        self.assertEqual(retired, ["batch"])
+
+    def test_poll_surfaces_a_failed_send(self):
+        # Waiting surfaces errors from completed work.
+        tracker = _PendingSendTracker()
+        retired = []
+        works = [_FakeWork(error=RuntimeError("NCCL send failed"))]
+        ops = [object()]
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        with self.assertRaisesRegex(RuntimeError, "NCCL send failed"):
+            tracker.poll()
+        self.assertEqual(retired, [])
+
+    def test_disabled_tracker_ignores_a_lowered_wait(self):
+        # Ignore waits left by an earlier lowering pass.
+        tracker = _PendingSendTracker(enabled=False)
+        retired = []
+        works, ops = self._make_batch()
+        key = (SEND_F, 0, 0)
+        tracker.register(ops, works, lambda: retired.append("batch"), key)
+
+        tracker.wait_send(key)
+        self.assertEqual(retired, [])
+        self.assertEqual(len(ops), 1, "the batch stays owned until the drain")
+
+        tracker.drain()
+        self.assertEqual(retired, ["batch"])
+
+    def test_wait_send_waits_the_stream_instead_of_polling(self):
+        # WAIT_SEND releases buffers without polling during capture.
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch()
+        work = works[0]
+        key = (SEND_F, 3, 7)
+        tracker.register(ops, works, lambda: retired.append("batch"), key)
+
+        with patch(
+            "torch.distributed.pipelining.schedules._stream_is_capturing",
+            return_value=True,
+        ):
+            tracker.poll()
+            self.assertEqual(retired, [], "poll must not retire during capture")
+            tracker.wait_send(key)
+
+        self.assertEqual(retired, ["batch"])
+        self.assertEqual(work.wait_count, 1)
+        self.assertEqual(ops, [])
+
+    def test_wait_send_is_a_noop_for_an_already_polled_batch(self):
+        # Eager polling may retire the batch before WAIT_SEND.
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch()
+        key = (SEND_F, 0, 0)
+        tracker.register(ops, works, lambda: retired.append("batch"), key)
+
+        works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["batch"])
+
+        tracker.wait_send(key)
+        self.assertEqual(retired, ["batch"], "retire must not run twice")
+
+    def test_wait_send_ignores_an_unknown_key(self):
+        tracker = _PendingSendTracker()
+        works, ops = self._make_batch()
+        tracker.register(ops, works, None, (SEND_F, 0, 0))
+
+        tracker.wait_send((SEND_B, 0, 0))
+        self.assertEqual(works[0].wait_count, 0)
+        self.assertEqual(len(ops), 1, "the unmatched batch stays owned")
+
+    def test_empty_batch_retires_immediately(self):
+        # Stages with nothing to send may still register a batch.
+        tracker = _PendingSendTracker()
+        retired = []
+        tracker.register([], [], lambda: retired.append("empty"))
+
+        tracker.poll()
+        self.assertEqual(retired, ["empty"])
 
 
 if __name__ == "__main__":

--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -58,6 +58,7 @@ from torch.distributed.pipelining.schedules import (
     WAIT_SEND_F,
 )
 from torch.distributed.pipelining.stage import (
+    _early_send_release_default,
     _PipelineStageBase,
     _RecvInfo,
     PipelineStage,
@@ -92,7 +93,9 @@ class MockPipelineStage(_PipelineStageBase):
         self.group_size = kwargs.get("group_size", 1)
         self.group_rank = kwargs.get("group_rank", 0)
         self.group = kwargs.get("group")
-        self.early_send_release = kwargs.get("early_send_release", False)
+        self.early_send_release = kwargs.get(
+            "early_send_release", _early_send_release_default()
+        )
 
     def _create_grad_recv_info(self, *args, **kwargs):
         return None

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -1,9 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
+import contextlib
 import copy
+import gc
 import logging
 import os
+from collections import Counter
 from dataclasses import dataclass
+from unittest.mock import patch
 
 from model_registry import (
     ConditionalGradStack,
@@ -33,16 +37,19 @@ from torch.distributed.pipelining import (
     ScheduleInterleaved1F1B,
     ScheduleInterleavedZeroBubble,
     ScheduleLoopedBFS,
+    schedules as pipelining_schedules,
     ScheduleZBVZeroBubble,
 )
 from torch.distributed.pipelining.microbatch import split_args_kwargs_into_chunks
 from torch.distributed.pipelining.schedules import (
     _Action,
+    _PendingSendTracker,
     _PipelineContext,
     _PipelineScheduleRuntime,
     _wait_batch_p2p,
     FORWARD,
     OVERLAP_F_B,
+    PipelineScheduleSingle,
 )
 from torch.distributed.pipelining.stage import _PipelineStageBase  # noqa: TC002
 from torch.nn.attention.flex_attention import BlockMask, create_block_mask
@@ -69,6 +76,9 @@ d_hid = 512
 batch_size = 64
 none_grad_d_hid = 32
 none_grad_microbatches = 8
+# Large activations make release visible in peak memory.
+release_d_hid = 512
+release_batch_size = 16384
 torch.manual_seed(0)
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 backend = dist.get_default_backend_for_device(device_type)
@@ -1414,6 +1424,193 @@ class ScheduleTest(MultiProcContinuousTest):
     @skip_if_lt_x_gpu(4)
     def test_NoneGrad_conditional_input_grad(self, ScheduleClass, pattern):
         self._run_none_grad_schedule(ScheduleClass, pattern)
+
+    @staticmethod
+    def _count_released_activations(stages):
+        """Count outputs dropped by ``retire_fwd_sends``."""
+        counter = Counter()
+
+        def make_counting_retire(stage, retire):
+            def counting_retire(chunk_id):
+                entry = stage.fwd_cache.get(chunk_id)
+                if entry is None:
+                    return retire(chunk_id)
+                before = sum(out is not None for out in entry.live_outputs)
+                retire(chunk_id)
+                after = sum(out is not None for out in entry.live_outputs)
+                counter["released"] += before - after
+
+            return counting_retire
+
+        for stage in stages:
+            stage.retire_fwd_sends = make_counting_retire(stage, stage.retire_fwd_sends)
+        return counter
+
+    def _run_release_sent_activations(
+        self, ScheduleClass, release: bool, forbid_polling: bool = False
+    ):
+        """Measure peak memory, gradients, and releases for one schedule."""
+        single_stage = issubclass(ScheduleClass, PipelineScheduleSingle)
+        v_shaped = issubclass(ScheduleClass, (ScheduleZBVZeroBubble, ScheduleDualPipeV))
+        stages_per_rank = 1 if single_stage else 2
+        n_stages = stages_per_rank * self.world_size
+        num_microbatches = 2 * self.world_size
+
+        torch.manual_seed(0)
+        mod = MultiMLP(release_d_hid, n_layers=n_stages).to(self.device)
+        x = torch.randn(release_batch_size, release_d_hid, device=self.device)
+        target = torch.randn(release_batch_size, release_d_hid, device=self.device)
+        loss_fn = torch.nn.MSELoss(reduction="sum")
+
+        # V schedules place mirrored stages on each rank.
+        stage_indices = [self.rank, n_stages - 1 - self.rank] if v_shaped else None
+        stages, stage_modules, _ = create_multi_stage_pipeline(
+            self.config, mod, stages_per_rank, n_stages, stage_indices
+        )
+        for stage in stages:
+            stage.early_send_release = release
+        released_count = self._count_released_activations(stages)
+        schedule = ScheduleClass(
+            stages[0] if single_stage else stages,
+            num_microbatches,
+            loss_fn=loss_fn,
+            scale_grads=False,
+        )
+
+        # Reused workers skip unittest cleanups, so this must unwind normally.
+        capturing = (
+            patch(
+                "torch.distributed.pipelining.schedules._stream_is_capturing",
+                return_value=True,
+            )
+            if forbid_polling
+            else contextlib.nullcontext()
+        )
+
+        peak = 0
+        # Measure the second step after buffers and metadata are initialized.
+        with capturing:
+            for step in range(2):
+                zero_gradients(stage_modules)
+                if step == 1:
+                    torch.accelerator.synchronize(self.device)
+                    torch.accelerator.reset_peak_memory_stats(self.device)
+                    baseline = torch.accelerator.memory_allocated(self.device)
+
+                if v_shaped:
+                    if self.rank == 0:
+                        schedule.step(x, target=target, losses=[])
+                    else:
+                        schedule.step()
+                elif self.rank == 0:
+                    schedule.step(x)
+                elif self.rank == self.world_size - 1:
+                    schedule.step(target=target, losses=[])
+                else:
+                    schedule.step()
+
+        torch.accelerator.synchronize(self.device)
+        peak = torch.accelerator.max_memory_allocated(self.device) - baseline
+        grads = {
+            f"{i}.{name}": p.grad.clone()
+            for i, stage_module in enumerate(stage_modules)
+            for name, p in stage_module.named_parameters()
+        }
+        return peak, grads, released_count["released"]
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    @parametrize(
+        "ScheduleClass",
+        [
+            ScheduleGPipe,
+            Schedule1F1B,
+            ScheduleInterleaved1F1B,
+            ScheduleInterleavedZeroBubble,
+            ScheduleZBVZeroBubble,
+        ],
+    )
+    def test_release_sent_activations(self, ScheduleClass):
+        """Early release lowers peak memory and leaves gradients untouched."""
+        kept_peak, kept_grads, kept_released = self._run_release_sent_activations(
+            ScheduleClass, release=False
+        )
+        gc.collect()
+        torch.accelerator.empty_cache()
+        (
+            released_peak,
+            released_grads,
+            released_count,
+        ) = self._run_release_sent_activations(ScheduleClass, release=True)
+
+        self.assertEqual(kept_grads.keys(), released_grads.keys())
+        for name, kept in kept_grads.items():
+            torch.testing.assert_close(
+                released_grads[name], kept, rtol=0, atol=0, msg=f"grad differs: {name}"
+            )
+
+        # Only a rank that owns just the last stage has nothing to release.
+        owns_only_last_stage = (
+            issubclass(ScheduleClass, PipelineScheduleSingle)
+            and self.rank == self.world_size - 1
+        )
+        activation_bytes = (
+            release_batch_size
+            // (2 * self.world_size)
+            * release_d_hid
+            * torch.float32.itemsize
+        )
+        saved = kept_peak - released_peak
+        logger.info(
+            "rank %d %s peak kept=%d released=%d saved=%d slots=%d",
+            self.rank,
+            ScheduleClass.__name__,
+            kept_peak,
+            released_peak,
+            saved,
+            released_count,
+        )
+        self.assertEqual(kept_released, 0)
+        if owns_only_last_stage:
+            self.assertEqual(released_count, 0)
+        else:
+            self.assertGreater(released_count, 0)
+            self.assertGreaterEqual(saved, activation_bytes)
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_release_sent_activations_without_polling(self):
+        """Verify WAIT_SEND releases buffers without polling."""
+        # Count retired transport references; backward already popped fwd_cache.
+        retired = Counter()
+        wait_send = _PendingSendTracker.wait_send
+        stream_is_capturing = pipelining_schedules._stream_is_capturing
+
+        def counting_wait_send(tracker, key):
+            before = len(tracker._pending)
+            wait_send(tracker, key)
+            retired["batches"] += before - len(tracker._pending)
+
+        with patch.object(_PendingSendTracker, "wait_send", counting_wait_send):
+            self._run_release_sent_activations(
+                ScheduleInterleaved1F1B, release=True, forbid_polling=True
+            )
+
+        self.assertGreater(
+            retired["batches"], 0, "no send was retired by a lowered WAIT_SEND"
+        )
+        # Ensure the reused worker did not retain the capture mock.
+        self.assertIs(
+            pipelining_schedules._stream_is_capturing,
+            stream_is_capturing,
+            "the capture mock outlived the run that installed it",
+        )
 
 
 instantiate_parametrized_tests(ScheduleTest)

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -163,7 +163,7 @@ class OutputSlotReleaseTest(TestCase):
             **kwargs,
         )
         stage.has_backward = True
-        # Opt in to the experimental path.
+        # Explicit, so the test does not depend on the default.
         stage.early_send_release = True
         # Avoid peer-dependent forward setup.
         stage.act_send_info = {0: dst_stages or [stage_index + 1]}
@@ -216,23 +216,23 @@ class OutputSlotReleaseTest(TestCase):
         stage.retire_fwd_sends(0)
         self.assertIsNotNone(entry.live_outputs[0])
 
-    def test_early_send_release_defaults_off(self):
-        # Do not inherit the caller's opt-in.
+    def test_early_send_release_defaults_on(self):
+        # Do not inherit the caller's opt-out.
         with mock.patch.dict(os.environ):
             os.environ.pop("TORCH_PIPELINING_EARLY_SEND_RELEASE", None)
-            self.assertFalse(_early_send_release_default())
-            stage = PipelineStage(
-                torch.nn.Linear(d_hid, d_hid), 0, 2, torch.device("cpu")
-            )
-            self.assertFalse(stage.early_send_release)
-
-    def test_early_send_release_env_opt_in(self):
-        with mock.patch.dict(os.environ, {"TORCH_PIPELINING_EARLY_SEND_RELEASE": "1"}):
             self.assertTrue(_early_send_release_default())
             stage = PipelineStage(
                 torch.nn.Linear(d_hid, d_hid), 0, 2, torch.device("cpu")
             )
             self.assertTrue(stage.early_send_release)
+
+    def test_early_send_release_env_opt_out(self):
+        with mock.patch.dict(os.environ, {"TORCH_PIPELINING_EARLY_SEND_RELEASE": "0"}):
+            self.assertFalse(_early_send_release_default())
+            stage = PipelineStage(
+                torch.nn.Linear(d_hid, d_hid), 0, 2, torch.device("cpu")
+            )
+            self.assertFalse(stage.early_send_release)
 
     def test_forward_only_keeps_no_backward_root(self):
         # An unused edge would retain the forward-only graph.
@@ -279,7 +279,7 @@ class OutputSlotReleaseTest(TestCase):
 
         stage = PipelineStage(TaggedModule(), 0, 2, torch.device("cpu"))
         stage.has_backward = True
-        # Opt in so the subclass check rejects the slot.
+        # Explicit, so the subclass check is what rejects the slot.
         stage.early_send_release = True
         stage.act_send_info = {0: [1]}
         stage.forward_one_chunk(0, (torch.randn(batch_size, d_hid),))

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -3,18 +3,24 @@
 
 import os
 import tempfile
+from unittest import mock
 
 from model_registry import ExampleCode, ModelWithKwargs, MultiMLP
 
 import torch
 import torch.distributed as dist
+from torch.autograd.graph import GradientEdge
 from torch.distributed.pipelining import (
     build_stage,
     pipeline,
     PipelineStage,
     ScheduleGPipe,
 )
-from torch.distributed.pipelining._utils import PipeliningMetadataError
+from torch.distributed.pipelining._utils import (
+    extract_tensor_meta,
+    PipeliningMetadataError,
+)
+from torch.distributed.pipelining.stage import _early_send_release_default, _RecvInfo
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_accelerator_dist_backend,
@@ -125,6 +131,206 @@ def get_flatten_hook():
         return tree_map_only(torch.Tensor, f, output)
 
     return flatten_hook
+
+
+class OutputSlotReleaseTest(TestCase):
+    """Tests forward-cache output release."""
+
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._owns_pg = not dist.is_initialized()
+        if self._owns_pg:
+            dist.init_process_group(
+                "gloo",
+                init_method=f"file://{os.path.join(self._tmpdir.name, 'pg')}",
+                rank=0,
+                world_size=1,
+            )
+
+    def tearDown(self):
+        if self._owns_pg and dist.is_initialized():
+            dist.destroy_process_group()
+        self._tmpdir.cleanup()
+        super().tearDown()
+
+    def _make_stage(self, *, stage_index=0, num_stages=2, dst_stages=None, **kwargs):
+        stage = PipelineStage(
+            torch.nn.Linear(d_hid, d_hid),
+            stage_index,
+            num_stages,
+            torch.device("cpu"),
+            **kwargs,
+        )
+        stage.has_backward = True
+        # Opt in to the experimental path.
+        stage.early_send_release = True
+        # Avoid peer-dependent forward setup.
+        stage.act_send_info = {0: dst_stages or [stage_index + 1]}
+        return stage
+
+    def _forward_and_send(self, stage, mb_index=0):
+        x = torch.randn(batch_size, d_hid)
+        stage.forward_one_chunk(mb_index, (x,))
+        return stage.get_fwd_send_ops(mb_index)
+
+    def test_output_released_when_send_retires(self):
+        stage = self._make_stage()
+        ops = self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(entry.pending_consumers, [1])
+        self.assertIsNotNone(entry.live_outputs[0])
+        self.assertIsInstance(entry.backward_roots[0], GradientEdge)
+
+        stage.retire_fwd_sends(0)
+
+        self.assertEqual(entry.pending_consumers, [0])
+        self.assertIsNone(entry.live_outputs[0])
+        self.assertIs(entry.stage_output_for_backward()[0], entry.backward_roots[0])
+
+    def test_output_kept_until_every_destination_retires(self):
+        stage = self._make_stage(num_stages=3, dst_stages=[1, 2])
+        ops = self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        # Destinations share one batched buffer lease.
+        self.assertEqual(len(ops), 2)
+        self.assertIs(ops[0].tensor, ops[1].tensor)
+        self.assertEqual(entry.pending_consumers, [1])
+
+        stage.retire_fwd_sends(0)
+        self.assertIsNone(entry.live_outputs[0])
+
+    def test_last_stage_output_never_released(self):
+        stage = self._make_stage(stage_index=0, num_stages=1, dst_stages=[None])
+        ops = self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(ops, [])
+        self.assertEqual(entry.releasable, (False,))
+        self.assertIsNone(entry.backward_roots[0])
+        self.assertEqual(stage._retained_output_reason, "last-stage output")
+
+        stage.retire_fwd_sends(0)
+        self.assertIsNotNone(entry.live_outputs[0])
+
+    def test_early_send_release_defaults_off(self):
+        # Do not inherit the caller's opt-in.
+        with mock.patch.dict(os.environ):
+            os.environ.pop("TORCH_PIPELINING_EARLY_SEND_RELEASE", None)
+            self.assertFalse(_early_send_release_default())
+            stage = PipelineStage(
+                torch.nn.Linear(d_hid, d_hid), 0, 2, torch.device("cpu")
+            )
+            self.assertFalse(stage.early_send_release)
+
+    def test_early_send_release_env_opt_in(self):
+        with mock.patch.dict(os.environ, {"TORCH_PIPELINING_EARLY_SEND_RELEASE": "1"}):
+            self.assertTrue(_early_send_release_default())
+            stage = PipelineStage(
+                torch.nn.Linear(d_hid, d_hid), 0, 2, torch.device("cpu")
+            )
+            self.assertTrue(stage.early_send_release)
+
+    def test_forward_only_keeps_no_backward_root(self):
+        # An unused edge would retain the forward-only graph.
+        stage = self._make_stage()
+        stage.has_backward = False
+        self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.backward_roots, (None,))
+        stage.retire_fwd_sends(0)
+        self.assertIsNone(entry.live_outputs[0])
+
+    def test_release_disabled_keeps_output(self):
+        stage = self._make_stage()
+        stage.early_send_release = False
+        self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.releasable, (False,))
+        stage.retire_fwd_sends(0)
+        self.assertIsNotNone(entry.live_outputs[0])
+        self.assertIsInstance(entry.stage_output_for_backward()[0], torch.Tensor)
+
+    def test_dw_builder_keeps_output(self):
+        stage = self._make_stage(dw_builder=lambda: (lambda: None))
+        self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.releasable, (False,))
+        stage.retire_fwd_sends(0)
+        self.assertIsNotNone(entry.live_outputs[0])
+
+    def test_tensor_subclass_output_kept(self):
+        class TaggedTensor(torch.Tensor):
+            pass
+
+        class TaggedModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(d_hid, d_hid)
+
+            def forward(self, x):
+                return TaggedTensor(self.linear(x))
+
+        stage = PipelineStage(TaggedModule(), 0, 2, torch.device("cpu"))
+        stage.has_backward = True
+        # Opt in so the subclass check rejects the slot.
+        stage.early_send_release = True
+        stage.act_send_info = {0: [1]}
+        stage.forward_one_chunk(0, (torch.randn(batch_size, d_hid),))
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.releasable, (False,))
+        self.assertIn("TaggedTensor", stage._retained_output_reason)
+
+    def test_retire_after_backward_consumed_the_entry(self):
+        # The final drain may run after backward pops the entry.
+        stage = self._make_stage()
+        self._forward_and_send(stage)
+        stage.fwd_cache.pop(0)
+        stage.retire_fwd_sends(0)
+
+    def test_split_backward_drops_edge_roots(self):
+        """Drop edge roots before split weight backward."""
+        # The first stage keeps its roots for weight backward.
+        stage = self._make_stage(stage_index=1, num_stages=3)
+        stage.chunks = 1
+        stage._stage_meta.inputs = (None,)
+
+        act_buffer = torch.randn(batch_size, d_hid, requires_grad=True)
+        stage.args_recv_info = {
+            0: (_RecvInfo("act_recv", 0, act_buffer, extract_tensor_meta(act_buffer)),)
+        }
+        stage.forward_one_chunk(0, ())
+        stage.get_fwd_send_ops(0)
+        stage.retire_fwd_sends(0)
+        self.assertIsNone(stage.fwd_cache[0].live_outputs[0])
+
+        grad_buffer = torch.randn(batch_size, d_hid)
+        stage.grad_recv_info = {
+            0: (
+                _RecvInfo(
+                    "grad_recv", 1, grad_buffer, extract_tensor_meta(grad_buffer)
+                ),
+            )
+        }
+        stage.backward_one_chunk(0, full_backward=False)
+
+        roots = stage.backward_state[0][2]
+        self.assertTrue(all(not isinstance(root, GradientEdge) for root in roots))
+
+    def test_send_after_release_is_rejected(self):
+        stage = self._make_stage()
+        self._forward_and_send(stage)
+        stage.retire_fwd_sends(0)
+
+        with self.assertRaisesRegex(AssertionError, "released before its send"):
+            stage.get_fwd_send_ops(0)
 
 
 class StageTest(MultiProcContinuousTest):

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -3,7 +3,7 @@
 import collections
 import logging
 from collections.abc import Iterator, Sequence
-from typing import Any
+from typing import Any, cast
 
 import torch
 from torch.autograd.graph import GradientEdge, Node
@@ -15,13 +15,17 @@ from ._debug import map_debug_info
 logger = logging.getLogger(__name__)
 
 
-def _get_grad_fn_or_grad_acc(t: torch.Tensor) -> Node | None:
+def _get_grad_fn_or_grad_acc(t: torch.Tensor | GradientEdge) -> Node | None:
     """
     Get the grad function or grad accumulator for a tensor.
 
     Accumulate grad nodes are lazily created, so we need to a
     dummy view in order to trigger its creation.
+
+    A ``GradientEdge`` directly supplies the backward root.
     """
+    if isinstance(t, GradientEdge):
+        return t.node
     if t.requires_grad and t.grad_fn is None:
         # if no grad function (leaf tensors) we use view
         viewed_t = t.view_as(t)
@@ -141,7 +145,7 @@ def get_param_groups(
 
 
 def _autograd_grad_for_inputs(
-    outputs: Sequence[torch.Tensor],
+    outputs: Sequence[torch.Tensor | GradientEdge],
     inputs: Sequence[Any],
     grad_outputs: Sequence[torch.Tensor | None] | None = None,
     retain_graph: bool = False,
@@ -161,7 +165,8 @@ def _autograd_grad_for_inputs(
         return tuple(None for _ in inputs)
 
     grads = torch.autograd.grad(
-        outputs=outputs,
+        # The stub does not model Autograd's GradientEdge support.
+        outputs=cast(Sequence[torch.Tensor], outputs),
         inputs=inputs_requiring_grad,
         grad_outputs=grad_outputs,
         retain_graph=retain_graph,
@@ -175,7 +180,7 @@ def _autograd_grad_for_inputs(
 
 
 def stage_backward_input(
-    stage_outputs_or_loss: list[torch.Tensor],
+    stage_outputs_or_loss: Sequence[torch.Tensor | GradientEdge | None],
     output_grads: list[torch.Tensor] | None,
     input_values: list[Any],
     weights: Iterator[Parameter],
@@ -184,21 +189,34 @@ def stage_backward_input(
     Compute the gradients for only the stage inputs with
     respect to the stage outputs (if non-last stage) or loss (if last stage)
 
+    Entries may be tensors, edges for released outputs, or ``None``.
+
     After computing input gradients, we save the intermediate nodes in `param_groups`
     for later use in stage_backward_weight. We don't need to save any other intermediate nodes
     that aren't needed for dW because when we do dW calculation, we start from saved intermediates.
     Detaching the stage_outputs_or_loss at the end of this function is important as
     it frees up the memory that the autograd graph is anticipating to be used later (but doesn't actually need).
     """
-    valid_outputs: list[torch.Tensor] = []
+    valid_outputs: list[torch.Tensor | GradientEdge] = []
     valid_output_grads: list[torch.Tensor | None] = []
     for i, stage_output in enumerate(stage_outputs_or_loss):
-        if not stage_output.requires_grad and stage_output.grad_fn is None:
-            continue
-        valid_outputs.append(stage_output)
-        valid_output_grads.append(
-            torch.ones_like(stage_output) if output_grads is None else output_grads[i]
-        )
+        if isinstance(stage_output, GradientEdge):
+            # Released activations receive gradients from the next stage.
+            if output_grads is None:
+                raise AssertionError(
+                    "A GradientEdge root requires output gradients from the next stage"
+                )
+            valid_outputs.append(stage_output)
+            valid_output_grads.append(output_grads[i])
+        elif isinstance(stage_output, torch.Tensor) and (
+            stage_output.requires_grad or stage_output.grad_fn is not None
+        ):
+            valid_outputs.append(stage_output)
+            valid_output_grads.append(
+                torch.ones_like(stage_output)
+                if output_grads is None
+                else output_grads[i]
+            )
 
     stage_output_grad_fns: list[Node] = list(
         filter(None, map(_get_grad_fn_or_grad_acc, valid_outputs))
@@ -262,7 +280,8 @@ def stage_backward_input(
 
         # drop output side graph state we no longer need
         for t in stage_outputs_or_loss:
-            t.detach_()
+            if isinstance(t, torch.Tensor):
+                t.detach_()
 
         return dinputs, param_groups
     except Exception as e:
@@ -358,6 +377,10 @@ def stage_backward(
     value(s), compute and accumulate gradients for all parameter values (leaves
     in the autograd trace) as well as return a list of the gradients for the
     input values
+
+    An output value may be a ``GradientEdge`` instead of a tensor when the stage
+    released the output after its send completed. Autograd starts from the edge's
+    node, so the released activation is not needed.
     """
     if outputs_with_grads_idxs is not None:
         # Deprecated, not used in runtime calls, only exists in compiler
@@ -367,7 +390,7 @@ def stage_backward(
     try:
         # stage_output may be a composite datatype like dict. Extract all individual
         # tensor values here
-        stage_output_tensors: list[torch.Tensor] = []
+        stage_output_tensors: list[torch.Tensor | GradientEdge] = []
         output_grad_tensors: list[torch.Tensor | None] = []
 
         def extract_tensors_with_grads(
@@ -376,7 +399,14 @@ def stage_backward(
             # Don't delete me- see [Note: ref cycle]
             extract_tensors_with_grads,
         ):
-            if isinstance(output_val, torch.Tensor):
+            if isinstance(output_val, GradientEdge):
+                if not isinstance(grad_val, torch.Tensor):
+                    raise AssertionError(
+                        f"A GradientEdge root requires a gradient but got {type(grad_val)}"
+                    )
+                stage_output_tensors.append(output_val)
+                output_grad_tensors.append(grad_val)
+            elif isinstance(output_val, torch.Tensor):
                 if not output_val.requires_grad and output_val.grad_fn is None:
                     return
                 if not isinstance(grad_val, (torch.Tensor, type(None))):
@@ -432,7 +462,7 @@ def stage_backward(
         )
 
         torch.autograd.backward(
-            stage_output_tensors,
+            cast(Sequence[torch.Tensor], stage_output_tensors),
             grad_tensors=output_grad_tensors,  # type: ignore[arg-type]
         )
 

--- a/torch/distributed/pipelining/_schedule_visualizer.py
+++ b/torch/distributed/pipelining/_schedule_visualizer.py
@@ -22,7 +22,10 @@ from torch.distributed.pipelining.schedules import (
     PipelineScheduleMulti,
     PipelineScheduleSingle,
 )
-from torch.distributed.pipelining.stage import PipelineStage
+from torch.distributed.pipelining.stage import (
+    _early_send_release_default,
+    PipelineStage,
+)
 
 
 class OpKey(NamedTuple):
@@ -68,7 +71,7 @@ def get_schedule_ops(
     mock_pipeline_stage.group_size = pp_degree
     mock_pipeline_stage.submod = None
     # autospec cannot see this instance attribute.
-    mock_pipeline_stage.early_send_release = False
+    mock_pipeline_stage.early_send_release = _early_send_release_default()
 
     # Check num_stages_per_rank is valid
     if issubclass(schedule_class, PipelineScheduleSingle):

--- a/torch/distributed/pipelining/_schedule_visualizer.py
+++ b/torch/distributed/pipelining/_schedule_visualizer.py
@@ -67,6 +67,8 @@ def get_schedule_ops(
     mock_pipeline_stage.group_rank = 0
     mock_pipeline_stage.group_size = pp_degree
     mock_pipeline_stage.submod = None
+    # autospec cannot see this instance attribute.
+    mock_pipeline_stage.early_send_release = False
 
     # Check num_stages_per_rank is valid
     if issubclass(schedule_class, PipelineScheduleSingle):

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -11,7 +11,7 @@ from collections import Counter, defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import Any, cast, Literal, NamedTuple, Protocol
 
 import torch
@@ -62,6 +62,9 @@ class _ComputationType(str, Enum):
     RECV_F = "RECV_F"
     SEND_B = "SEND_B"
     RECV_B = "RECV_B"
+    # Wait for a send without querying completion during graph capture.
+    WAIT_SEND_F = "WAIT_SEND_F"
+    WAIT_SEND_B = "WAIT_SEND_B"
     FULL_BACKWARD = "B"
     OVERLAP_F_B = "OVERLAP_F_B"
     REDUCE_GRAD = "REDUCE_GRAD"
@@ -83,6 +86,8 @@ SEND_F = _ComputationType.SEND_F
 RECV_F = _ComputationType.RECV_F
 SEND_B = _ComputationType.SEND_B
 RECV_B = _ComputationType.RECV_B
+WAIT_SEND_F = _ComputationType.WAIT_SEND_F
+WAIT_SEND_B = _ComputationType.WAIT_SEND_B
 FULL_BACKWARD = _ComputationType.FULL_BACKWARD
 OVERLAP_F_B = _ComputationType.OVERLAP_F_B
 REDUCE_GRAD = _ComputationType.REDUCE_GRAD
@@ -101,8 +106,10 @@ W = BACKWARD_WEIGHT
 B = FULL_BACKWARD
 
 # Helper to parse an action string like 1F0 into a tuple of (stage_index, computation_type, microbatch_index)
+# Match long names before prefixes such as W.
 _action_regex = re.compile(
-    r"(\d+)(F|I|B|W|UNSHARD|RESHARD|REDUCE_GRAD|SEND_F|RECV_F|SEND_B|RECV_B)(\d*)"
+    r"(\d+)(WAIT_SEND_F|WAIT_SEND_B|SEND_F|SEND_B|RECV_F|RECV_B|UNSHARD|RESHARD"
+    r"|REDUCE_GRAD|F|I|B|W)(\d*)"
 )
 
 
@@ -849,6 +856,96 @@ def _wait_batch_p2p(work: list[dist.Work]):
         w.wait()
 
 
+def _flatten_sorted_works(work_by_peer: dict[int, list[dist.Work]]) -> list[dist.Work]:
+    """Flatten one _sorted_batch_p2p result into a single list of works."""
+    return [work for peer_works in work_by_peer.values() for work in peer_works]
+
+
+# Identifies a send batch by direction, stage, and microbatch.
+_SendKey = tuple[_ComputationType, int, int]
+
+
+@dataclass
+class _PendingSendBatch:
+    """An in-flight send batch and its release callback."""
+
+    works: list[dist.Work]
+    # Keep transport buffers alive explicitly.
+    ops: list[dist.P2POp]
+    retire: Callable[[], None] | None
+    key: _SendKey | None = None
+
+
+def _stream_is_capturing() -> bool:
+    """Return whether completion queries are unsafe during graph capture."""
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
+class _PendingSendTracker:
+    """Own send buffers until completion or the end-of-step drain."""
+
+    def __init__(self, enabled: bool = True) -> None:
+        self._enabled = enabled
+        self._pending: list[_PendingSendBatch] = []
+
+    def register(
+        self,
+        ops: list[dist.P2POp],
+        works: list[dist.Work],
+        retire: Callable[[], None] | None = None,
+        key: _SendKey | None = None,
+    ) -> None:
+        self._pending.append(_PendingSendBatch(works, ops, retire, key))
+
+    def wait_send(self, key: _SendKey) -> None:
+        """Wait for and retire a keyed send without querying completion.
+
+        Missing keys are allowed because eager polling may retire them first.
+        Disabled trackers preserve end-of-step ownership.
+        """
+        if not self._enabled:
+            return
+
+        for i, batch in enumerate(self._pending):
+            if batch.key == key:
+                _wait_batch_p2p(batch.works)
+                self._retire(batch)
+                del self._pending[i]
+                return
+
+    def poll(self) -> None:
+        """Retire completed batches without blocking.
+
+        Poll all batches independently, except during graph capture.
+        """
+        if not self._enabled or not self._pending or _stream_is_capturing():
+            return
+
+        still_pending = []
+        for batch in self._pending:
+            if all(work.is_completed() for work in batch.works):
+                # wait() surfaces errors from completed work without blocking.
+                _wait_batch_p2p(batch.works)
+                self._retire(batch)
+            else:
+                still_pending.append(batch)
+        self._pending = still_pending
+
+    def drain(self) -> None:
+        """Wait for all remaining sends and retire them."""
+        for batch in self._pending:
+            _wait_batch_p2p(batch.works)
+            self._retire(batch)
+        self._pending.clear()
+
+    @staticmethod
+    def _retire(batch: _PendingSendBatch) -> None:
+        batch.works.clear()
+        batch.ops.clear()
+        if batch.retire is not None:
+            batch.retire()
+
+
 class PipelineScheduleSingle(_PipelineSchedule):
     """
     Base class for single-stage schedules.
@@ -1054,11 +1151,12 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
         self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
 
-        # Delay send waits
-        fwd_sends_to_wait: list[list[dist.Work]] = []
+        # Release each activation when its send completes.
+        pending_sends = _PendingSendTracker(self._stage.early_send_release)
 
         # Run microbatches
         for i in range(self._n_microbatches):
+            pending_sends.poll()
             with record_function(f"Forward {i}"):
                 ops = self._stage.get_fwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="fwd_recv")
@@ -1067,17 +1165,19 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
 
                 self._stage.forward_one_chunk(i, arg_mbs[i], kwarg_mbs[i])  # type: ignore[index]
 
-                ops = self._stage.get_fwd_send_ops(i)
-                works = _sorted_batch_p2p(ops, desc="fwd_send")
-                fwd_sends_to_wait.extend(works.values())
+                send_ops = self._stage.get_fwd_send_ops(i)
+                pending_sends.register(
+                    send_ops,
+                    _flatten_sorted_works(_sorted_batch_p2p(send_ops, desc="fwd_send")),
+                    partial(self._stage.retire_fwd_sends, i),
+                )
 
             logger.debug("[%s] Forwarded microbatch %s", self._stage.stage_index, i)
 
         # Wait for all forward sends to finish
         # This should not have performance impact because by the time the first
         # backward arrives all the forward sends should have been finished.
-        for work in fwd_sends_to_wait:
-            _wait_batch_p2p(work)
+        pending_sends.drain()
 
 
 class ScheduleGPipe(PipelineScheduleSingle):
@@ -1109,11 +1209,12 @@ class ScheduleGPipe(PipelineScheduleSingle):
             arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs
         )
 
-        # Delay send waits
-        fwd_sends_to_wait: list[list[dist.Work]] = []
+        # Release sends during GPipe's all-forward phase.
+        pending_sends = _PendingSendTracker(self._stage.early_send_release)
 
         # Run microbatches
         for i in range(self._n_microbatches):
+            pending_sends.poll()
             with record_function(f"Forward {i}"):
                 ops = self._stage.get_fwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="fwd_recv")
@@ -1124,9 +1225,12 @@ class ScheduleGPipe(PipelineScheduleSingle):
                     i, arg_mbs[i], kwarg_mbs[i], save_forward_output=return_outputs
                 )  # type: ignore[index]
 
-                ops = self._stage.get_fwd_send_ops(i)
-                works = _sorted_batch_p2p(ops, desc="fwd_send")
-                fwd_sends_to_wait.extend(works.values())
+                send_ops = self._stage.get_fwd_send_ops(i)
+                pending_sends.register(
+                    send_ops,
+                    _flatten_sorted_works(_sorted_batch_p2p(send_ops, desc="fwd_send")),
+                    partial(self._stage.retire_fwd_sends, i),
+                )
 
             logger.debug("[%s] Forwarded microbatch %s", self._stage.stage_index, i)
 
@@ -1135,13 +1239,12 @@ class ScheduleGPipe(PipelineScheduleSingle):
         # Wait for all forward sends to finish
         # This should not have performance impact because by the time the first
         # backward arrives all the forward sends should have been finished.
-        for work in fwd_sends_to_wait:
-            _wait_batch_p2p(work)
+        pending_sends.drain()
 
         # Run backward
         # Delay send waits
-        bwd_sends_to_wait: list[list[dist.Work]] = []
         for i in range(self._n_microbatches):
+            pending_sends.poll()
             with record_function(f"Backward {i}"):
                 ops = self._stage.get_bwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="bwd_recv")
@@ -1155,15 +1258,16 @@ class ScheduleGPipe(PipelineScheduleSingle):
                     last_backward=i == self._n_microbatches - 1,
                 )
 
-                ops = self._stage.get_bwd_send_ops(i)
-                works = _sorted_batch_p2p(ops, desc="bwd_send")
-                bwd_sends_to_wait.extend(works.values())
+                send_ops = self._stage.get_bwd_send_ops(i)
+                pending_sends.register(
+                    send_ops,
+                    _flatten_sorted_works(_sorted_batch_p2p(send_ops, desc="bwd_send")),
+                )
 
             logger.debug("[%s] Backwarded microbatch %s", self._stage.stage_index, i)
 
         # Wait for all backward sends to finish
-        for work in bwd_sends_to_wait:
-            _wait_batch_p2p(work)
+        pending_sends.drain()
 
         # Update losses if there is a container passed in
         self._update_losses(self._stage, losses)
@@ -1269,6 +1373,15 @@ or equal to the number of stages ({self._num_stages})."
         fwd_mb_index = 0
         bwd_mb_index = 0
 
+        # Microbatch owning the pending or in-flight forward send.
+        outstanding_fwd_mb: int | None = None
+
+        def retire_outstanding_fwd_send() -> None:
+            nonlocal outstanding_fwd_mb
+            if outstanding_fwd_mb is not None:
+                self._stage.retire_fwd_sends(outstanding_fwd_mb)
+                outstanding_fwd_mb = None
+
         # Warmup phase
         send_work: list[dist.Work] = []
         fwd_sends = []
@@ -1290,9 +1403,11 @@ or equal to the number of stages ({self._num_stages})."
             # case it doesn't create a lot of benefit to compute next chunk
             # eagerly either)
             _wait_batch_p2p(send_work)
+            retire_outstanding_fwd_send()
 
             # Send activations
             fwd_sends = self._stage.get_fwd_send_ops(fwd_mb_index)
+            outstanding_fwd_mb = fwd_mb_index
             if fwd_mb_index != warmup_chunks - 1:
                 # Safe to fire
                 send_work = _batch_p2p(fwd_sends, desc="fwd_send")
@@ -1314,6 +1429,8 @@ or equal to the number of stages ({self._num_stages})."
 
             # Now, we need to fire the fwd_sends and bwd_recvs together
             _wait_batch_p2p(_batch_p2p(fwd_sends + bwd_recvs, desc="fwd_send_bwd_recv"))
+            # Release the activation before backward allocates.
+            retire_outstanding_fwd_send()
 
             # Backward one chunk
             loss = self._maybe_get_loss(self._stage, bwd_mb_index)
@@ -1352,6 +1469,7 @@ or equal to the number of stages ({self._num_stages})."
 
             # Get the fwd send ops, but don't fire, leave it for the next iter (wrap-around)
             fwd_sends = self._stage.get_fwd_send_ops(fwd_mb_index)
+            outstanding_fwd_mb = fwd_mb_index
             fwd_mb_index += 1
 
         # Remember we still have some bwd_sends left over after the break? Now it is time to fire it
@@ -1612,6 +1730,42 @@ def _merge_bw(
         else:
             merged_actions.append(action)
     return merged_actions
+
+
+def _add_wait_send(
+    comm_actions: dict[int, list[_Action]],
+) -> dict[int, list[_Action]]:
+    """Insert WAIT_SEND_F after each matching backward.
+
+    The returned gradient proves the peer received the activation, so this wait
+    cannot deadlock. Backward sends remain in the end-of-step drain.
+    """
+    backward_types = (FULL_BACKWARD, BACKWARD_INPUT)
+
+    def backward_slots(action: _Action) -> list[tuple[int, int | None]]:
+        """Return backward slots, including compound sub-actions."""
+        return [
+            (part.stage_index, part.microbatch_index)
+            for part in (action.sub_actions or (action,))
+            if part.computation_type in backward_types
+        ]
+
+    out: dict[int, list[_Action]] = {}
+    for rank, actions in comm_actions.items():
+        sent = {
+            (a.stage_index, a.microbatch_index)
+            for a in actions
+            if a.computation_type == SEND_F
+        }
+        lowered: list[_Action] = []
+        for action in actions:
+            lowered.append(action)
+            for stage_index, microbatch_index in backward_slots(action):
+                if (stage_index, microbatch_index) in sent:
+                    lowered.append(_Action(stage_index, WAIT_SEND_F, microbatch_index))
+                    sent.discard((stage_index, microbatch_index))
+        out[rank] = lowered
+    return out
 
 
 def _add_send_recv(
@@ -2298,6 +2452,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
         for time_step, action in enumerate(self.pipeline_order[self.rank]):
             try:
                 ops: list[dist.P2POp] = []
+                # Forward send issued and waited on in this step.
+                sent_fwd: tuple[_PipelineStageBase, int] | None = None
                 if action is not None:
                     computation_type = action.computation_type
                     mb_index = action.microbatch_index
@@ -2319,6 +2475,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
                             stage, output, target_mbs, mb_index, loss_kwargs
                         )
                         ops.extend(stage.get_fwd_send_ops(mb_index))
+                        sent_fwd = (stage, mb_index)
                     elif computation_type == _ComputationType.FULL_BACKWARD:
                         # perform backward computation
                         stage = stage_index_to_stage[stage_index]
@@ -2435,6 +2592,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
                 # do the communication
                 _wait_batch_p2p(_batch_p2p(ops))
+                if sent_fwd is not None:
+                    sent_fwd[0].retire_fwd_sends(sent_fwd[1])
             except Exception as e:
                 logger.error(
                     "[Rank %s] pipeline schedule %s caught the following exception '%s' \
@@ -2481,6 +2640,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
 
     def __init__(self, *args, **kwargs):
         self._defer_pp_recv: bool = kwargs.pop("defer_pp_recv", False)
+        # Set when the schedule is prepared or loaded.
+        self._early_send_release: bool = False
         super().__init__(*args, **kwargs)
         # Action to custom function mapping
         self._comp_type_to_function_map: dict[_ComputationType, Callable] = {}
@@ -2586,6 +2747,11 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 num_stages=self._num_stages,
             )
 
+            if any(stage.early_send_release for stage in self._stages):
+                self.pipeline_order_with_comms = _add_wait_send(
+                    self.pipeline_order_with_comms
+                )
+
             if self._defer_pp_recv:
                 self.pipeline_order_with_comms = _defer_recv_ops(
                     self.pipeline_order_with_comms,
@@ -2593,6 +2759,15 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 )
         else:
             raise NotImplementedError(f"{format=} is not implemented")
+
+        # Loaded schedules infer early release from their WAIT_SEND actions.
+        self._early_send_release = any(
+            stage.early_send_release for stage in self._stages
+        ) or any(
+            action.computation_type in (WAIT_SEND_F, WAIT_SEND_B)
+            for rank_actions in self.pipeline_order_with_comms.values()
+            for action in rank_actions
+        )
 
     def _load_csv(
         self,
@@ -2694,8 +2869,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 "Must call _prepare_schedule_with_comms() before calling _step_microbatches()"
             )
 
-        # send ops should be waited on before step() exists, mainly for hygiene
-        send_ops: list[list[dist.Work]] = []
+        # Release completed send buffers between actions.
+        pending_sends = _PendingSendTracker(self._early_send_release)
 
         def _perform_action(action: _Action) -> None:
             comp_type = action.computation_type
@@ -2725,9 +2900,22 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             # However, I was wondering if I should avoid calling batched operators at all in the case that there is
             # only one operator per batch.  I could iterate through the 'fwd_send_ops' one by one and run them.
             if comp_type == SEND_F:
-                send_ops.append(_batch_p2p(stage.get_fwd_send_ops(mb_index)))
+                ops = stage.get_fwd_send_ops(mb_index)
+                pending_sends.register(
+                    ops,
+                    _batch_p2p(ops),
+                    partial(stage.retire_fwd_sends, mb_index),
+                    (SEND_F, stage_idx, mb_index),
+                )
             elif comp_type == SEND_B:
-                send_ops.append(_batch_p2p(stage.get_bwd_send_ops(mb_index)))
+                ops = stage.get_bwd_send_ops(mb_index)
+                pending_sends.register(
+                    ops, _batch_p2p(ops), None, (SEND_B, stage_idx, mb_index)
+                )
+            elif comp_type == WAIT_SEND_F:
+                pending_sends.wait_send((SEND_F, stage_idx, mb_index))
+            elif comp_type == WAIT_SEND_B:
+                pending_sends.wait_send((SEND_B, stage_idx, mb_index))
             elif comp_type == RECV_F:
                 if (stage_idx, mb_index) in self.fwd_recv_ops:
                     raise AssertionError(
@@ -2874,6 +3062,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 time_step,
                 action,
             )
+            pending_sends.poll()
             try:
                 with record_function(_get_profiler_function_name(action)):
                     if action.computation_type in self._comp_type_to_function_map:
@@ -2908,9 +3097,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 )
                 raise e
 
-        # Mostly these operations should have finished long ago, but there isn't an obvious time when to wait for them
-        while send_ops:
-            _wait_batch_p2p(send_ops.pop())
+        # Wait for sends left in flight.
+        pending_sends.drain()
 
         if len(self.unshard_ops) != 0:
             raise AssertionError("Unused unshard operations")
@@ -3928,10 +4116,16 @@ def _simulate_comms_compute(
         _schedule[rank].append(action)
         if action is not None:
             _prev_ops_rank[rank].add(action)
+            # Record compound sub-actions for dependency checks.
+            for sub_action in action.sub_actions or ():
+                _prev_ops_rank[rank].add(sub_action)
 
     def _ready_to_schedule(action: _Action | None) -> bool:
         if action is None:
             return True
+
+        if action.sub_actions is not None:
+            return all(_ready_to_schedule(sub) for sub in action.sub_actions)
 
         stage_idx = action.stage_index
         prev_ops = _prev_ops_rank[stage_to_rank(stage_idx)]
@@ -3984,6 +4178,17 @@ def _simulate_comms_compute(
             peer_stage_idx = stage_idx + 1
             expected_send = _Action(peer_stage_idx, SEND_B, action.microbatch_index)
             return expected_send in _prev_ops_rank[stage_to_rank(peer_stage_idx)]
+        elif action.computation_type in (WAIT_SEND_F, WAIT_SEND_B):
+            # A wait requires both the send and its peer receive.
+            forward = action.computation_type == WAIT_SEND_F
+            send = SEND_F if forward else SEND_B
+            if _Action(stage_idx, send, action.microbatch_index) not in prev_ops:
+                return False
+            peer_stage_idx = stage_idx + 1 if forward else stage_idx - 1
+            expected_recv = _Action(
+                peer_stage_idx, RECV_F if forward else RECV_B, action.microbatch_index
+            )
+            return expected_recv in _prev_ops_rank[stage_to_rank(peer_stage_idx)]
         else:
             raise ValueError(f"Unsupported action type {action}")
 

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -96,8 +96,14 @@ def _normalize_model_output_as_tuple(output: Any) -> tuple[Any]:
 
 
 def _early_send_release_default() -> bool:
-    """Return the experimental early-release opt-in setting."""
-    return os.environ.get("TORCH_PIPELINING_EARLY_SEND_RELEASE", "0") == "1"
+    """Return the early-release setting, on unless opted out.
+
+    Set ``TORCH_PIPELINING_EARLY_SEND_RELEASE=0`` to keep sent activations until
+    the end of the step. Configurations whose backward needs the output tensor
+    itself are already declined by :meth:`_output_slot_is_releasable`, so the
+    opt-out is for diagnosing a suspected regression rather than for correctness.
+    """
+    return os.environ.get("TORCH_PIPELINING_EARLY_SEND_RELEASE", "1") != "0"
 
 
 @dataclass

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -2,10 +2,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 import operator
+import os
 import warnings
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
@@ -14,6 +16,7 @@ import torch.distributed.config as dist_config
 import torch.fx as fx
 import torch.nn as nn
 from torch._subclasses.fake_tensor import is_fake_tensor
+from torch.autograd.graph import get_gradient_edge, GradientEdge
 from torch.distributed._composable.replicate_with_fsdp import replicate, ReplicateModule
 from torch.distributed.fsdp import FSDPModule, fully_shard
 from torch.distributed.pipelining._utils import (
@@ -90,6 +93,32 @@ def _normalize_model_output_as_tuple(output: Any) -> tuple[Any]:
     # `act_send_info`
     output_tuple = output if type(output) is tuple else (output,)
     return output_tuple
+
+
+def _early_send_release_default() -> bool:
+    """Return the experimental early-release opt-in setting."""
+    return os.environ.get("TORCH_PIPELINING_EARLY_SEND_RELEASE", "0") == "1"
+
+
+@dataclass
+class _ForwardCacheEntry:
+    """Forward state retained per microbatch.
+
+    Releasable outputs use ``backward_roots`` after their consumers retire.
+    """
+
+    backward_roots: tuple[GradientEdge | None, ...]
+    input_values: list[torch.Tensor]
+    live_outputs: list[torch.Tensor | None]
+    releasable: tuple[bool, ...]
+    pending_consumers: list[int]
+
+    def stage_output_for_backward(self) -> tuple[Any, ...]:
+        """Return each live tensor or its saved gradient edge."""
+        return tuple(
+            live if live is not None else root
+            for live, root in zip(self.live_outputs, self.backward_roots, strict=True)
+        )
 
 
 class _RecvInfo:
@@ -266,8 +295,8 @@ class _PipelineStageBase(ABC):
             )
 
         # Run time states
-        # map microbatch ID to list of forward tensor args
-        self.fwd_cache: dict[int, tuple[Any, list[torch.Tensor]]] = {}
+        # Forward state by microbatch.
+        self.fwd_cache: dict[int, _ForwardCacheEntry] = {}
         # map microbatch ID to list of backward grad tensor args
         self.bwd_cache: dict[int, tuple[torch.Tensor | None, ...]] = {}
         # Caching chunk outputs for final output merge or reduction
@@ -278,6 +307,11 @@ class _PipelineStageBase(ABC):
         self.has_backward = False
         # Log prefix
         self.log_prefix = f"[Stage {self.stage_index}]"
+
+        # Release sent activations and buffers before the step ends.
+        self.early_send_release = _early_send_release_default()
+        # Reason the stage kept an output tensor, logged once per stage.
+        self._retained_output_reason: str | None = None
 
         # Forward infra
         self.args_recv_info: dict[int, tuple[_RecvInfo, ...]] = {}
@@ -565,22 +599,77 @@ class _PipelineStageBase(ABC):
         recv_infos = self.grad_recv_info[bwd_chunk_id]
         return self._get_recv_ops(recv_infos, self._upstream_group)
 
+    def _output_slot_is_releasable(self, output: Any) -> tuple[bool, str]:
+        """Return whether an output may be released after sending."""
+        if not self.early_send_release:
+            return False, "early release disabled"
+        if self.is_last:
+            return False, "last-stage output"
+        if type(output) is not torch.Tensor:
+            # Gradient-edge backward is only validated for plain tensors.
+            return False, f"output type {type(output).__name__}"
+        if isinstance(self.submod, DistributedDataParallel):
+            # DDP builds its reducer from the output tensors.
+            return False, "DDP reducer requires live outputs"
+        if self.dw_builder is not None:
+            return False, "custom dw_builder may require live outputs"
+        return True, ""
+
+    def _make_fwd_cache_entry(
+        self, output_tuple: tuple[Any, ...], input_values: list[torch.Tensor]
+    ) -> _ForwardCacheEntry:
+        releasable: list[bool] = []
+        backward_roots: list[GradientEdge | None] = []
+        for out in output_tuple:
+            can_release, reason = self._output_slot_is_releasable(out)
+            releasable.append(can_release)
+            # Avoid retaining an autograd root in forward-only schedules.
+            backward_roots.append(
+                get_gradient_edge(out)
+                if self.has_backward and can_release and out.requires_grad
+                else None
+            )
+            if not can_release and self._retained_output_reason is None:
+                self._retained_output_reason = reason
+                logger.debug(
+                    "%s keeping output tensors alive until backward: %s",
+                    self.log_prefix,
+                    reason,
+                )
+
+        return _ForwardCacheEntry(
+            backward_roots=tuple(backward_roots),
+            input_values=input_values,
+            live_outputs=list(output_tuple),
+            releasable=tuple(releasable),
+            pending_consumers=[0] * len(output_tuple),
+        )
+
     def get_fwd_send_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Get the activation send ops for current stage's forward.
         Handles DTensor outputs by extracting local tensors.
+
+        Sent slots hold a lease until :meth:`retire_fwd_sends`.
         """
-        output_tuple, _ = self.fwd_cache[fwd_chunk_id]
+        entry = self.fwd_cache[fwd_chunk_id]
 
         ops: list[dist.P2POp] = []
 
-        for idx, out in enumerate(output_tuple):
-            dst_stages = self.act_send_info[idx]
+        for idx, out in enumerate(entry.live_outputs):
+            dst_stages = [dst for dst in self.act_send_info[idx] if dst is not None]
+            if not dst_stages:
+                continue
+            if out is None:
+                raise AssertionError(
+                    f"{self.log_prefix} output {idx} of chunk {fwd_chunk_id} was "
+                    "released before its send was issued"
+                )
+            # One lease covers the slot's batched sends.
+            entry.pending_consumers[idx] += 1
+            # Extract local tensor if DTensor
+            send_tensor = to_local_if_dtensor(out, detach=True)
             for dst in dst_stages:
-                if dst is None:
-                    continue
-                # Extract local tensor if DTensor
-                send_tensor = to_local_if_dtensor(out, detach=True)
                 logger.debug(
                     "%s Sending tensor to Stage %s: %s",
                     self.log_prefix,
@@ -598,6 +687,22 @@ class _PipelineStageBase(ABC):
                 )
 
         return ops
+
+    def retire_fwd_sends(self, fwd_chunk_id: int) -> None:
+        """Retire send leases and release unused output tensors.
+
+        A missing entry means backward already consumed it.
+        """
+        entry = self.fwd_cache.get(fwd_chunk_id)
+        if entry is None:
+            return
+
+        for idx, pending in enumerate(entry.pending_consumers):
+            if pending == 0:
+                continue
+            entry.pending_consumers[idx] = pending - 1
+            if entry.pending_consumers[idx] == 0 and entry.releasable[idx]:
+                entry.live_outputs[idx] = None
 
     def _get_grad_send_meta(self, input_idx: int) -> TensorMeta | None:
         """Return gradient metadata for ``input_idx`` if a recv was allocated."""
@@ -1002,9 +1107,8 @@ class _PipelineStageBase(ABC):
         flat_args = flatten_args(composite_args)
         flat_kwargs = flatten_args(composite_kwargs)
         flatten_input_tensors = flat_args + flat_kwargs
-        self.fwd_cache[fwd_chunk_id] = (
-            output_tuple,  # stage_output
-            flatten_input_tensors,  # input_values
+        self.fwd_cache[fwd_chunk_id] = self._make_fwd_cache_entry(
+            output_tuple, flatten_input_tensors
         )
 
         logger.debug(
@@ -1052,10 +1156,10 @@ class _PipelineStageBase(ABC):
 
         self._check_chunk_id(bwd_chunk_id)
 
-        (
-            stage_output,
-            input_values,
-        ) = self.fwd_cache.pop(bwd_chunk_id)
+        entry = self.fwd_cache.pop(bwd_chunk_id)
+        # Released slots use gradient edges as backward roots.
+        stage_output = entry.stage_output_for_backward()
+        input_values = entry.input_values
 
         # Compute backward
         if self.is_last:
@@ -1117,6 +1221,13 @@ class _PipelineStageBase(ABC):
                     # when the "stage_ouput" is a loss, then it is a tensor, otherwise it is a tuple of tensors
                     grads_input, param_groups = self.backward_maybe_with_nosync(
                         "input", bwd_kwargs, last_backward=last_backward
+                    )
+
+                    # Edges cannot be detached, so drop them before weight backward.
+                    # The first stage skips this path; tensor roots remain for DDP.
+                    bwd_kwargs["stage_output"] = tuple(
+                        None if isinstance(root, GradientEdge) else root
+                        for root in cast(tuple[Any, ...], bwd_kwargs["stage_output"])
                     )
 
                 # TODO: we don't need to save this, add to dw_runner?


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193903

Pipeline stages kept transmitted forward outputs alive until the end of the
step through both `fwd_cache` and pending send `Work` objects. This retained
`microbatches * stages_per_rank` activations that were no longer needed.

Use `GradientEdge` as the backward root where safe, and retire forward tensors
and send work once transmission completes. Eager schedules poll completed
sends; CUDA graph schedules use lowered waits because NCCL completion queries
are not capture-safe. Backward sends retain the end-of-step drain because they
have no dependency that guarantees safe earlier placement.

The optimization fails closed for last-stage outputs, tensor subclasses,
DDP-wrapped modules, and custom `dw_builder`s. Set
`TORCH_PIPELINING_EARLY_SEND_RELEASE=0` or `stage.early_send_release` to restore
legacy behavior.

On DeepSeek-V3 with sequence length 4096, PP=4, four virtual stages per rank,
and 64 microbatches, peak reserved memory dropped from 232.8 GiB to 220.9 GiB
per rank without a measured throughput change.

Test Plan:

Run from `test/distributed/pipelining`:

```
python test_backward.py
python test_schedule.py -k "not pre_split_flex_attention"
python test_stage.py
TORCH_PIPELINING_EARLY_SEND_RELEASE=0 python test_schedule_multiproc.py
TORCH_PIPELINING_EARLY_SEND_RELEASE=1 python test_schedule_multiproc.py
```

deepseek v3 16B, PP=4, VPP=4, num_mb=16, EP=2, FSDP=2, NO_AC, no cudagraph

  | Config   | off   | poll  | static | poll saved  | static saved | static / poll |
  |----------|-------|-------|--------|-------------|--------------|---------------|
  | seq 4096 | 81.53 | 78.91 | 80.04  | 2.62 (3.2%) | 1.49 (1.8%)  | 57%           |
  | seq 2048 | 67.53 | 66.03 | 66.81  | 1.50 (2.2%) | 0.72 (1.1%)  | 48%           |