### PR TITLE
[Inductor] Route AOTI device type through DeviceOpOverrides

### DIFF
--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -27,7 +27,6 @@ except ImportError:
 
 import torch._inductor.config as config
 from torch._inductor import cpu_vec_isa, metrics
-from torch._inductor.codegen import cpp_utils
 from torch._inductor.codegen.common import (
     get_scheduling_for_device,
     get_wrapper_codegen_for_device,
@@ -154,7 +153,6 @@ class ExtensionBackendTests(BaseExtensionBackendTests):
         def fn(a, b, c):
             return a * b + c
 
-        cpp_utils.DEVICE_TO_ATEN["extension_device"] = "at::kPrivateUse1"
         for cpp_wrapper_flag in [True, False]:
             with config.patch({"cpp_wrapper": cpp_wrapper_flag}):
                 metrics.reset()

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -49,6 +49,15 @@ class ExtensionDeviceOpOverrides(CpuDeviceOpOverrides):
         return "at::kPrivateUse1"
 
 
+class MissingAtenDeviceTypeOverrides(CpuDeviceOpOverrides):
+    pass
+
+
+class InvalidAtenDeviceTypeOverrides(CpuDeviceOpOverrides):
+    def aten_device_type(self) -> str:
+        return "c10::DeviceType::PrivateUse1"
+
+
 try:
     try:
         from . import test_torchinductor
@@ -64,6 +73,21 @@ run_and_get_cpp_code = test_torchinductor.run_and_get_cpp_code
 TestCase = test_torchinductor.TestCase
 
 
+class DeviceToAtenTests(TestCase):
+    def test_missing_aten_device_type(self):
+        device = "missing_aten_device_type"
+        register_device_op_overrides(device, MissingAtenDeviceTypeOverrides())
+        with self.assertRaisesRegex(RuntimeError, "No ATen device type mapping"):
+            device_to_aten(device)
+
+    def test_invalid_aten_device_type(self):
+        device = "invalid_aten_device_type"
+        register_device_op_overrides(device, InvalidAtenDeviceTypeOverrides())
+        with self.assertRaisesRegex(RuntimeError, "must return.*at::k"):
+            device_to_aten(device)
+
+
+@xfailIfS390X
 class BaseExtensionBackendTests(TestCase):
     module = None
 
@@ -178,6 +202,8 @@ class ExtensionBackendTests(BaseExtensionBackendTests):
                 FileCheck().check("void").check(load_expr).check(
                     "extension_device"
                 ).run(code)
+                if cpp_wrapper_flag:
+                    self.assertIn("CACHE_TORCH_DEVICE(privateuse1);", code)
                 opt_fn(x, y, z)
                 res = opt_fn(x, y, z)
                 self.assertEqual(ref, res.to(device="cpu"))

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -28,16 +28,15 @@ except ImportError:
 import torch._inductor.config as config
 from torch._inductor import cpu_vec_isa, metrics
 from torch._inductor.codegen.common import (
+    device_op_overrides_dict,
+    DeviceOpOverrides,
     get_scheduling_for_device,
     get_wrapper_codegen_for_device,
     register_backend_for_device,
     register_device_op_overrides,
 )
 from torch._inductor.codegen.cpp_utils import device_to_aten
-from torch._inductor.codegen.cpu_device_op_overrides import (
-    CpuDeviceOpOverrides,
-    NoOpDeviceOpOverrides,
-)
+from torch._inductor.codegen.cpu_device_op_overrides import CpuDeviceOpOverrides
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_FBCODE,
@@ -52,7 +51,7 @@ class ExtensionDeviceOpOverrides(CpuDeviceOpOverrides):
         return "at::kPrivateUse1"
 
 
-class MissingAtenDeviceTypeOverrides(NoOpDeviceOpOverrides):
+class MissingAtenDeviceTypeOverrides(DeviceOpOverrides):
     pass
 
 
@@ -77,15 +76,18 @@ TestCase = test_torchinductor.TestCase
 
 
 class DeviceToAtenTests(TestCase):
-    def test_builtin_device_types(self):
-        for device, expected in (
+    @parametrize(
+        "device, expected",
+        [
             ("cpu", "at::kCPU"),
             ("cuda", "at::kCUDA"),
             ("xpu", "at::kXPU"),
             ("mps", "at::kMPS"),
             ("meta", "at::kMeta"),
-        ):
-            self.assertEqual(device_to_aten(device), expected)
+        ],
+    )
+    def test_builtin_device_types(self, device, expected):
+        self.assertEqual(device_to_aten(device), expected)
 
     def test_unregistered_device_type(self):
         with self.assertRaisesRegex(RuntimeError, "No ATen device type mapping"):
@@ -94,19 +96,22 @@ class DeviceToAtenTests(TestCase):
     def test_missing_aten_device_type(self):
         device = "missing_aten_device_type"
         register_device_op_overrides(device, MissingAtenDeviceTypeOverrides())
+        self.addCleanup(device_op_overrides_dict.pop, device, None)
         with self.assertRaisesRegex(RuntimeError, "No ATen device type mapping"):
             device_to_aten(device)
 
     def test_invalid_aten_device_type(self):
         device = "invalid_aten_device_type"
         register_device_op_overrides(device, InvalidAtenDeviceTypeOverrides())
+        self.addCleanup(device_op_overrides_dict.pop, device, None)
         with self.assertRaisesRegex(RuntimeError, "must return.*at::k"):
             device_to_aten(device)
 
-    def test_unsupported_device_types(self):
-        for device in ("tpu", "mtia"):
-            with self.assertRaisesRegex(RuntimeError, "No ATen device type mapping"):
-                device_to_aten(device)
+    @parametrize("device", ["tpu", "mtia"])
+    def test_unsupported_device_types(self, device):
+        # MTIA has no aoti_torch_device_type_mtia shim yet; update this when it does.
+        with self.assertRaisesRegex(RuntimeError, "No ATen device type mapping"):
+            device_to_aten(device)
 
 
 class BaseExtensionBackendTests(TestCase):
@@ -253,6 +258,7 @@ class ExtensionBackendTests(BaseExtensionBackendTests):
         self.assertTrue(has_cpp_wrapper_for_device(device))
 
 
+instantiate_parametrized_tests(DeviceToAtenTests)
 instantiate_parametrized_tests(ExtensionBackendTests)
 
 

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -33,6 +33,7 @@ from torch._inductor.codegen.common import (
     register_backend_for_device,
     register_device_op_overrides,
 )
+from torch._inductor.codegen.cpp_utils import device_to_aten
 from torch._inductor.codegen.cpu_device_op_overrides import CpuDeviceOpOverrides
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -41,6 +42,11 @@ from torch.testing._internal.common_utils import (
     parametrize,
     xfailIfS390X,
 )
+
+
+class ExtensionDeviceOpOverrides(CpuDeviceOpOverrides):
+    def aten_device_type(self) -> str:
+        return "at::kPrivateUse1"
 
 
 try:
@@ -125,7 +131,13 @@ class ExtensionBackendTests(BaseExtensionBackendTests):
             ExtensionWrapperCodegen,
             ExtensionCppWrapperCodegen,
         )
-        register_device_op_overrides("extension_device", CpuDeviceOpOverrides())
+        register_device_op_overrides(
+            "extension_device", ExtensionDeviceOpOverrides()
+        )
+        self.assertEqual(
+            device_to_aten("extension_device"),
+            "at::kPrivateUse1",
+        )
         self.assertTrue(
             get_scheduling_for_device("extension_device") == ExtensionScheduling
         )

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -131,9 +131,7 @@ class ExtensionBackendTests(BaseExtensionBackendTests):
             ExtensionWrapperCodegen,
             ExtensionCppWrapperCodegen,
         )
-        register_device_op_overrides(
-            "extension_device", ExtensionDeviceOpOverrides()
-        )
+        register_device_op_overrides("extension_device", ExtensionDeviceOpOverrides())
         self.assertEqual(
             device_to_aten("extension_device"),
             "at::kPrivateUse1",

--- a/test/inductor/test_extension_backend.py
+++ b/test/inductor/test_extension_backend.py
@@ -34,7 +34,10 @@ from torch._inductor.codegen.common import (
     register_device_op_overrides,
 )
 from torch._inductor.codegen.cpp_utils import device_to_aten
-from torch._inductor.codegen.cpu_device_op_overrides import CpuDeviceOpOverrides
+from torch._inductor.codegen.cpu_device_op_overrides import (
+    CpuDeviceOpOverrides,
+    NoOpDeviceOpOverrides,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_FBCODE,
@@ -49,7 +52,7 @@ class ExtensionDeviceOpOverrides(CpuDeviceOpOverrides):
         return "at::kPrivateUse1"
 
 
-class MissingAtenDeviceTypeOverrides(CpuDeviceOpOverrides):
+class MissingAtenDeviceTypeOverrides(NoOpDeviceOpOverrides):
     pass
 
 
@@ -74,6 +77,20 @@ TestCase = test_torchinductor.TestCase
 
 
 class DeviceToAtenTests(TestCase):
+    def test_builtin_device_types(self):
+        for device, expected in (
+            ("cpu", "at::kCPU"),
+            ("cuda", "at::kCUDA"),
+            ("xpu", "at::kXPU"),
+            ("mps", "at::kMPS"),
+            ("meta", "at::kMeta"),
+        ):
+            self.assertEqual(device_to_aten(device), expected)
+
+    def test_unregistered_device_type(self):
+        with self.assertRaisesRegex(RuntimeError, "No ATen device type mapping"):
+            device_to_aten("unregistered_aten_device_type")
+
     def test_missing_aten_device_type(self):
         device = "missing_aten_device_type"
         register_device_op_overrides(device, MissingAtenDeviceTypeOverrides())
@@ -86,8 +103,12 @@ class DeviceToAtenTests(TestCase):
         with self.assertRaisesRegex(RuntimeError, "must return.*at::k"):
             device_to_aten(device)
 
+    def test_unsupported_device_types(self):
+        for device in ("tpu", "mtia"):
+            with self.assertRaisesRegex(RuntimeError, "No ATen device type mapping"):
+                device_to_aten(device)
 
-@xfailIfS390X
+
 class BaseExtensionBackendTests(TestCase):
     module = None
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -16,6 +16,7 @@ import threading
 from abc import ABC, abstractmethod
 from enum import auto, Enum
 from itertools import chain
+from textwrap import dedent
 from typing import Any, cast, ClassVar, Generic, NamedTuple, TYPE_CHECKING
 from typing_extensions import Self, TypeVar
 
@@ -420,6 +421,28 @@ class DeviceOpOverrides:
         raise NotImplementedError
 
 
+class NoOpDeviceOpOverrides(DeviceOpOverrides):
+    def import_get_raw_stream_as(self, name: str) -> str:
+        return dedent(
+            """
+            def get_raw_stream(_):
+                return 0
+            """
+        )
+
+    def cpp_kernel_type(self) -> str:
+        return "void*"
+
+    def set_device(self, device_idx: DeviceIdx) -> str:
+        return "pass"
+
+    def synchronize(self) -> str:
+        return "pass"
+
+    def device_guard(self, device_idx: DeviceIdx) -> str:
+        return "torch._ops.contextlib.nullcontext()"
+
+
 # Thread-safe lazy initialization for device op overrides
 device_op_overrides_lock = threading.RLock()
 device_op_overrides_dict: dict[str, DeviceOpOverrides] = {}
@@ -738,8 +761,10 @@ def _initialize_device_op_overrides():
         if _device_op_overrides_initialized:
             return
 
-        from . import mps_device_op_overrides  # noqa: F401
-        from .cpu_device_op_overrides import NoOpDeviceOpOverrides
+        from . import (
+            cpu_device_op_overrides,  # noqa: F401
+            mps_device_op_overrides,  # noqa: F401
+        )
         from .cuda import device_op_overrides  # noqa: F401
         from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
         from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -739,13 +739,13 @@ def _initialize_device_op_overrides():
             return
 
         from . import mps_device_op_overrides  # noqa: F401
-        from .cpu_device_op_overrides import CpuDeviceOpOverrides
+        from .cpu_device_op_overrides import NoOpDeviceOpOverrides
         from .cuda import device_op_overrides  # noqa: F401
         from .mtia import device_op_overrides as mtia_op_overrides  # noqa: F401
         from .xpu import device_op_overrides as xpu_op_overrides  # noqa: F401
 
         # TPU uses Pallas for codegen and only needs no-op overrides
-        register_device_op_overrides("tpu", CpuDeviceOpOverrides())
+        register_device_op_overrides("tpu", NoOpDeviceOpOverrides())
 
         _device_op_overrides_initialized = True
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -335,6 +335,10 @@ class DeviceOpOverrides:
         """
         return False
 
+    def aten_device_type(self) -> str:
+        """Return the C++ ATen DeviceType expression for this device."""
+        return "at::kPrivateUse1"
+
     def import_get_raw_stream_as(self, name: str) -> str:
         raise NotImplementedError
 

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -335,12 +335,6 @@ class DeviceOpOverrides:
         """
         return False
 
-    def aten_device_type(self) -> str:
-        """Return the C++ ATen DeviceType expression for this device."""
-        raise NotImplementedError(
-            f"{type(self).__name__} must implement aten_device_type()"
-        )
-
     def import_get_raw_stream_as(self, name: str) -> str:
         raise NotImplementedError
 
@@ -406,6 +400,14 @@ class DeviceOpOverrides:
         raise NotImplementedError
 
     def cpp_device_ptr(self) -> str:
+        raise NotImplementedError
+
+    def aten_device_type(self) -> str:
+        """Return the C++ ATen DeviceType expression for this device.
+
+        The returned value must use the ``at::k...`` form, for example
+        ``at::kPrivateUse1``.
+        """
         raise NotImplementedError
 
     def tma_descriptor_helpers(self) -> str:

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -337,7 +337,9 @@ class DeviceOpOverrides:
 
     def aten_device_type(self) -> str:
         """Return the C++ ATen DeviceType expression for this device."""
-        return "at::kPrivateUse1"
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement aten_device_type()"
+        )
 
     def import_get_raw_stream_as(self, name: str) -> str:
         raise NotImplementedError

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -90,30 +90,42 @@ DEVICE_TO_INT = {"cpu": 0, "cuda": 1}
 
 
 def device_to_aten(device_type: str) -> str:
+    # Meta has no registered DeviceOpOverrides.
     if device_type == "meta":
         return "at::kMeta"
 
-    from .common import get_device_op_overrides
+    from .common import DeviceOpOverrides, get_device_op_overrides
 
     try:
         overrides = get_device_op_overrides(device_type)
     except KeyError as exc:
-        raise RuntimeError(f"No ATen device type mapping for {device_type}") from exc
+        raise RuntimeError(
+            f"No ATen device type mapping for {device_type}: no DeviceOpOverrides "
+            f"is registered; call register_device_op_overrides({device_type!r}, ...)."
+        ) from exc
 
-    try:
-        aten_device_type = overrides.aten_device_type()
-    except NotImplementedError as exc:
-        raise RuntimeError(f"No ATen device type mapping for {device_type}") from exc
+    if type(overrides).aten_device_type is DeviceOpOverrides.aten_device_type:
+        raise RuntimeError(
+            f"No ATen device type mapping for {device_type}: "
+            f"{type(overrides).__name__} does not implement aten_device_type()."
+        )
 
-    if (
-        not isinstance(aten_device_type, str)
-        or not aten_device_type.startswith("at::k")
-        or len(aten_device_type) == len("at::k")
+    aten_device_type = overrides.aten_device_type()
+
+    if not isinstance(aten_device_type, str) or not aten_device_type.startswith(
+        "at::k"
     ):
         raise RuntimeError(
             f"{type(overrides).__name__}.aten_device_type() must return "
-            f"a non-empty ATen device type expression starting with 'at::k', "
+            f"an ATen device type expression starting with 'at::k', "
             f"got {aten_device_type!r}"
+        )
+    suffix = aten_device_type[len("at::k") :]
+    if not suffix.isidentifier():
+        raise RuntimeError(
+            f"{type(overrides).__name__}.aten_device_type() must return "
+            f"an ATen device type expression with a valid identifier suffix "
+            f"after 'at::k', got {aten_device_type!r}"
         )
 
     return aten_device_type

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -88,6 +88,20 @@ DEVICE_TO_ATEN = {
     "mps": "at::kMPS",
 }
 
+
+def device_to_aten(device_type: str) -> str:
+    if device_type in DEVICE_TO_ATEN:
+        return DEVICE_TO_ATEN[device_type]
+
+    from .common import get_device_op_overrides
+
+    try:
+        overrides = get_device_op_overrides(device_type)
+    except KeyError:
+        raise KeyError(f"No ATen device type mapping for {device_type}") from None
+    return overrides.aten_device_type()
+
+
 LAYOUT_TO_ATEN = {
     torch.strided: "at::kStrided",
     torch._mkldnn: "at::kMkldnn",  # type: ignore[attr-defined]

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -106,16 +106,12 @@ def device_to_aten(device_type: str) -> str:
     try:
         overrides = get_device_op_overrides(device_type)
     except KeyError as exc:
-        raise RuntimeError(
-            f"No ATen device type mapping for {device_type}"
-        ) from exc
+        raise RuntimeError(f"No ATen device type mapping for {device_type}") from exc
 
     try:
         aten_device_type = overrides.aten_device_type()
     except NotImplementedError as exc:
-        raise RuntimeError(
-            f"No ATen device type mapping for {device_type}"
-        ) from exc
+        raise RuntimeError(f"No ATen device type mapping for {device_type}") from exc
 
     if (
         not isinstance(aten_device_type, str)

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -80,14 +80,6 @@ DTYPE_TO_ATEN = {
     torch.float8_e8m0fnu: "at::kFloat8_e8m0fnu",
 }
 
-DEVICE_TO_ATEN = {
-    "meta": "at::kMeta",
-    "cpu": "at::kCPU",
-    "cuda": "at::kCUDA",
-    "xpu": "at::kXPU",
-    "mps": "at::kMPS",
-}
-
 LAYOUT_TO_ATEN = {
     torch.strided: "at::kStrided",
     torch._mkldnn: "at::kMkldnn",  # type: ignore[attr-defined]
@@ -98,8 +90,8 @@ DEVICE_TO_INT = {"cpu": 0, "cuda": 1}
 
 
 def device_to_aten(device_type: str) -> str:
-    if device_type in DEVICE_TO_ATEN:
-        return DEVICE_TO_ATEN[device_type]
+    if device_type == "meta":
+        return "at::kMeta"
 
     from .common import get_device_op_overrides
 

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -88,6 +88,14 @@ DEVICE_TO_ATEN = {
     "mps": "at::kMPS",
 }
 
+LAYOUT_TO_ATEN = {
+    torch.strided: "at::kStrided",
+    torch._mkldnn: "at::kMkldnn",  # type: ignore[attr-defined]
+}
+
+# matches c10/core/DeviceType.h
+DEVICE_TO_INT = {"cpu": 0, "cuda": 1}
+
 
 def device_to_aten(device_type: str) -> str:
     if device_type in DEVICE_TO_ATEN:
@@ -97,18 +105,31 @@ def device_to_aten(device_type: str) -> str:
 
     try:
         overrides = get_device_op_overrides(device_type)
-    except KeyError:
-        raise KeyError(f"No ATen device type mapping for {device_type}") from None
-    return overrides.aten_device_type()
+    except KeyError as exc:
+        raise RuntimeError(
+            f"No ATen device type mapping for {device_type}"
+        ) from exc
 
+    try:
+        aten_device_type = overrides.aten_device_type()
+    except NotImplementedError as exc:
+        raise RuntimeError(
+            f"No ATen device type mapping for {device_type}"
+        ) from exc
 
-LAYOUT_TO_ATEN = {
-    torch.strided: "at::kStrided",
-    torch._mkldnn: "at::kMkldnn",  # type: ignore[attr-defined]
-}
+    if (
+        not isinstance(aten_device_type, str)
+        or not aten_device_type.startswith("at::k")
+        or len(aten_device_type) == len("at::k")
+    ):
+        raise RuntimeError(
+            f"{type(overrides).__name__}.aten_device_type() must return "
+            f"a non-empty ATen device type expression starting with 'at::k', "
+            f"got {aten_device_type!r}"
+        )
 
-# matches c10/core/DeviceType.h
-DEVICE_TO_INT = {"cpu": 0, "cuda": 1}
+    return aten_device_type
+
 
 _IS_WINDOWS = sys.platform == "win32"
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -39,10 +39,10 @@ from .aoti_hipify_utils import maybe_hipify_code_wrapper
 from .common import get_device_op_overrides, IndentedBuffer, Kernel
 from .cpp_utils import (
     cexpr,
+    device_to_aten,
     DEVICE_TO_INT,
     DTYPE_TO_ATEN,
     DTYPE_TO_CPP,
-    device_to_aten,
     LAYOUT_TO_ATEN,
 )
 from .wrapper import (

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -39,10 +39,10 @@ from .aoti_hipify_utils import maybe_hipify_code_wrapper
 from .common import get_device_op_overrides, IndentedBuffer, Kernel
 from .cpp_utils import (
     cexpr,
-    DEVICE_TO_ATEN,
     DEVICE_TO_INT,
     DTYPE_TO_ATEN,
     DTYPE_TO_CPP,
+    device_to_aten,
     LAYOUT_TO_ATEN,
 )
 from .wrapper import (
@@ -2481,9 +2481,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
         self._codegen_runtime_assert(code, stmt)
 
     def codegen_device(self, device):
-        if device.type not in DEVICE_TO_ATEN:
-            raise AssertionError(device.type + " not found in DEVICE_TO_ATEN")
-        device_str = DEVICE_TO_ATEN[device.type][5:].lower()  # remove "at::k"
+        device_str = device_to_aten(device.type)[5:].lower()  # remove "at::k"
         self.used_cached_devices.add(device_str)
         return f"cached_torch_device_type_{device_str}, {device.index or 0}"
 
@@ -4033,13 +4031,9 @@ if (!custom_op_wrapper) {
                     return codegen_ivalue(raw_arg, arg_type.getElementType())
 
                 if isinstance(raw_arg, torch.device):
-                    if raw_arg.type not in DEVICE_TO_ATEN:
-                        raise AssertionError(
-                            raw_arg.type + " not found in DEVICE_TO_ATEN"
-                        )
                     return (
                         "c10::IValue(c10::Device("
-                        f"{DEVICE_TO_ATEN[raw_arg.type]}, "
+                        f"{device_to_aten(raw_arg.type)}, "
                         f"{raw_arg.index if raw_arg.index is not None else 0}))"
                     )
                 if isinstance(raw_arg, torch.dtype):

--- a/torch/_inductor/codegen/cpu_device_op_overrides.py
+++ b/torch/_inductor/codegen/cpu_device_op_overrides.py
@@ -1,30 +1,6 @@
 from __future__ import annotations
 
-from textwrap import dedent
-
-from .common import DeviceIdx, DeviceOpOverrides, register_device_op_overrides
-
-
-class NoOpDeviceOpOverrides(DeviceOpOverrides):
-    def import_get_raw_stream_as(self, name: str) -> str:
-        return dedent(
-            """
-            def get_raw_stream(_):
-                return 0
-            """
-        )
-
-    def cpp_kernel_type(self) -> str:
-        return "void*"
-
-    def set_device(self, device_idx: DeviceIdx) -> str:
-        return "pass"
-
-    def synchronize(self) -> str:
-        return "pass"
-
-    def device_guard(self, device_idx: DeviceIdx) -> str:
-        return "torch._ops.contextlib.nullcontext()"
+from .common import NoOpDeviceOpOverrides, register_device_op_overrides
 
 
 class CpuDeviceOpOverrides(NoOpDeviceOpOverrides):

--- a/torch/_inductor/codegen/cpu_device_op_overrides.py
+++ b/torch/_inductor/codegen/cpu_device_op_overrides.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from .common import DeviceIdx, DeviceOpOverrides, register_device_op_overrides
 
 
-class CpuDeviceOpOverrides(DeviceOpOverrides):
+class NoOpDeviceOpOverrides(DeviceOpOverrides):
     def import_get_raw_stream_as(self, name: str) -> str:
         return dedent(
             """
@@ -25,6 +25,11 @@ class CpuDeviceOpOverrides(DeviceOpOverrides):
 
     def device_guard(self, device_idx: DeviceIdx) -> str:
         return "torch._ops.contextlib.nullcontext()"
+
+
+class CpuDeviceOpOverrides(NoOpDeviceOpOverrides):
+    def aten_device_type(self) -> str:
+        return "at::kCPU"
 
 
 register_device_op_overrides("cpu", CpuDeviceOpOverrides())

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -404,6 +404,9 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
     def cpp_device_ptr(self) -> str:
         return "CUdeviceptr"
 
+    def aten_device_type(self) -> str:
+        return "at::kCUDA"
+
     def cpp_scratch(
         self, idx: int, workspace: TritonScratchWorkspace, prefix: str | None = None
     ) -> tuple[list[str], str] | None:

--- a/torch/_inductor/codegen/mps_device_op_overrides.py
+++ b/torch/_inductor/codegen/mps_device_op_overrides.py
@@ -25,5 +25,8 @@ class MPSDeviceOpOverrides(DeviceOpOverrides):
     def cpp_kernel_type(self) -> str:
         return "MTLFunction_t"
 
+    def aten_device_type(self) -> str:
+        return "at::kMPS"
+
 
 register_device_op_overrides("mps", MPSDeviceOpOverrides())

--- a/torch/_inductor/codegen/xpu/device_op_overrides.py
+++ b/torch/_inductor/codegen/xpu/device_op_overrides.py
@@ -66,6 +66,9 @@ class XPUDeviceOpOverrides(DeviceOpOverrides):
     def cpp_device_ptr(self) -> str:
         return "void *"
 
+    def aten_device_type(self) -> str:
+        return "at::kXPU"
+
     def cpp_scratch(
         self, idx: int, workspace: TritonScratchWorkspace, prefix: str | None = None
     ) -> tuple[list[str], str] | None:


### PR DESCRIPTION
## Summary

Route AOTI/C++ wrapper ATen device type mapping through
`DeviceOpOverrides` as the authoritative per-device contract.

This removes the mutable global `DEVICE_TO_ATEN` mapping and lets both
in-tree and out-of-tree backends provide their ATen device type through
the existing device codegen extension point.

## Changes

- Add `DeviceOpOverrides.aten_device_type()` as the per-device contract for
  C++ ATen device type mapping.
- Implement the mapping in the CPU, CUDA, XPU, and MPS device overrides.
- Remove the global `DEVICE_TO_ATEN` mapping.
- Keep `meta` as an explicit special case because it has no registered
  `DeviceOpOverrides`.
- Separate the generic no-op override behavior from CPU-specific device
  identity so TPU continues to use no-op overrides without inheriting the
  CPU ATen device type.
- Route AOTI/C++ wrapper device type generation through `device_to_aten()`.
- Remove the manual `DEVICE_TO_ATEN["extension_device"]` mutation from the
  extension backend test.
- Add coverage for built-in mappings, out-of-tree mappings, missing and
  invalid mappings, and unsupported TPU/MTIA mappings.

## Motivation

AOTI/C++ wrapper codegen previously looked up device types through the
hardcoded mutable `DEVICE_TO_ATEN` mapping.

That forced out-of-tree backends to mutate Inductor module state even when
they already registered a `DeviceOpOverrides` implementation. It also left
two competing mechanisms once an override hook was added: built-in devices
continued to use the global mapping while only out-of-tree devices used the
new hook.

Using `DeviceOpOverrides` as the authoritative backend-specific source keeps
ATen device identity with the existing per-device codegen contract and
removes the need for backends to mutate Inductor globals.

## Test Plan

- Verify CPU, CUDA, XPU, MPS, and meta resolve to their existing ATen device
  types.
- Verify an out-of-tree extension backend resolves to `at::kPrivateUse1`
  through its registered `DeviceOpOverrides`.
- Verify unregistered devices and overrides without an ATen device mapping
  fail explicitly.
- Verify invalid override return values fail with a clear error.
- Verify TPU and MTIA remain unsupported instead of inheriting another
  backend's mapping.
- Existing extension C++ wrapper coverage continues to exercise generated
  device code without mutating a global mapping.

## Out-of-tree backend migration

Out-of-tree backends that previously populated `cpp_utils.DEVICE_TO_ATEN`
should instead implement `aten_device_type()` on their registered
`DeviceOpOverrides`. The returned value must use the `at::k...` form, for
example `at::kPrivateUse1`.

## Notes

- Related RFC: #189137.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo