### PR TITLE
[Testcase Refactoring] Classify device-specific test classes for test_cpu_repro.py

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -27,9 +27,10 @@ from torch._prims_common import is_float_dtype
 from torch.autograd.functional import vjp
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn import functional as F
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     get_gcc_major_version,
-    instantiate_parametrized_tests,
+    HardwareClassification,
     IS_ARM64,
     IS_CI,
     IS_CPU_EXT_SVE_SUPPORTED,
@@ -141,8 +142,9 @@ class LstmModule(torch.nn.Module):
         return x, h
 
 
-@instantiate_parametrized_tests
 class CPUReproTests(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     common = check_model
 
     @skipIfNoLapack
@@ -7519,6 +7521,8 @@ class CPUReproTests(TestCase):
         )
         self.assertTrue(cuda_storage.has_exceeded_max_reads())
 
+
+instantiate_device_type_tests(CPUReproTests, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests


### PR DESCRIPTION
## Summary
This PR hardware classify device-specific and device-agnostic test classes.

## Changes
- Instantiate device-agnostic test templates as device-specific test classes.
- Add `hw_classification = HardwareClassification.CPU` to tests class.

## Motivation
Instantiate and classify device-specific and device-agnostic test classes.

## Test Plan
- CI: `python test/inductor/test_cpu_repro.py --hw-classification CPU`
- Verified test cases correctly on cpu.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo