### PR TITLE
[Testcase Refactoring] Add hw-classification in distributed_test_run

### DIFF
--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -16,10 +16,16 @@ from unittest.mock import MagicMock, patch
 
 import torch.distributed.run as run
 from torch.distributed.launcher.api import launch_agent, LaunchConfig
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class RunTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Save original environment variable if it exists


### PR DESCRIPTION
## Summary

Tags `RunTest` in `test/distributed/test_run.py` with
`hw_classification = HardwareClassification.GENERIC` so the class can be
selected by the `--hw-classification` test filter. The class is a bare
`TestCase` subclass exercising CPU-only `torch.distributed.run` argparse,
`launch_agent` mock, and `shtab` completion logic, with no device parameter
and no `instantiate_device_type_tests`, so `GENERIC` is the correct category.

## Changes

- `test/distributed/test_run.py`: added `HardwareClassification` to the
  `torch.testing._internal.common_utils` import block (converted from
  single-line to multi-line, alphabetical order —
  `HardwareClassification` before `run_tests` before `TestCase`, with
  Black magic trailing comma).
- `test/distributed/test_run.py`: declared
  `hw_classification = HardwareClassification.GENERIC` as a class attribute
  on `RunTest`, placed immediately after the class header and before
  `setUp`.


## Motivation

PyTorch's test suite recently introduced the `HardwareClassification`
mechanism (see `torch/testing/_internal/common_utils.py`), which allows
filtering test classes by hardware category (`GENERIC`, `ACCELERATOR`,
`CPU`, `CUDA`, `MPS`, `XPU`) via the `--hw-classification` CLI flag. Test
classes that do not declare a `hw_classification` attribute are excluded
when the filter is used, so they cannot run in hardware-partitioned CI
workflows.

`RunTest` fits the `GENERIC` definition ("tests that exercise shared,
device-agnostic logic ... typically do not use
`instantiate_device_type_tests`"): its 14 test methods cover
`run.get_args_parser`/`config_from_args` argparse behavior, mocked
`LocalElasticAgent`/`elastic_launch` paths, `rdzv_backend`/`master_port`
config assertions, `TORCHELASTIC_LOG_LINE_PREFIX_TEMPLATE` env-var
priority, and `shtab`-driven `--print-completion` shell completion —
pure config/string/mock logic with no tensor or device code. Tagging it
`GENERIC` brings it into the new filtering workflow without altering
test behavior.

## Test plan

- Run the test file:
 python test/distributed/test_run.py , 14 testcases pass
