### PR TITLE
[Inductor] Let DeviceInterface contribute CodeCache system metadata

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -121,6 +121,7 @@ torch._dynamo.config.fake_tensor_cache_crosscheck_enabled = True
 STATIC_LAUNCHER_DEVICES = ("cuda", "xpu")
 
 
+@instantiate_parametrized_tests
 class TestCacheKeyStrategy(TestCase):
     def _compact_sha256(self, data: bytes) -> str:
         return (
@@ -302,99 +303,34 @@ class TestCacheKeyStrategy(TestCase):
         finally:
             CacheBase.get_system.cache_clear()
 
-    def test_device_interface_cache_system_info_without_cuda(self):
-        class FakeDeviceInterface(DeviceInterface):
-            @staticmethod
-            def is_available() -> bool:
-                return True
-
-            @classmethod
-            def get_cache_system_info(cls):
-                return {"runtime": "1"}
-
-        CacheBase.get_system.cache_clear()
-        try:
-            with (
-                mock.patch(
-                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
-                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
-                ) as fake_strategy,
-                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
-                mock.patch.object(
-                    torch.cuda, "current_device", side_effect=RuntimeError
-                ),
-                mock.patch(
-                    "torch._inductor.codecache.get_registered_device_interfaces",
-                    return_value=[("fake", FakeDeviceInterface)],
-                ),
-            ):
-                system = CacheBase.get_system()
-                expected_payload = {
-                    "version": {"triton": None},
-                    "device_interfaces": {"fake": {"runtime": "1"}},
-                }
-                self.assertEqual(
-                    system,
-                    {
-                        **expected_payload,
-                        "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
-                            expected_payload
-                        ),
-                    },
-                )
-                self.assertEqual(
-                    fake_strategy.key_from_json.call_args.args[0],
-                    expected_payload,
-                )
-        finally:
-            CacheBase.get_system.cache_clear()
-
-    def test_cache_base_get_system_without_cuda_preserves_triton_hash(self):
-        CacheBase.get_system.cache_clear()
-        try:
-            with (
-                mock.patch(
-                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
-                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
-                ) as fake_strategy,
-                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
-                mock.patch.object(
-                    torch.cuda, "current_device", side_effect=RuntimeError
-                ),
-                mock.patch(
-                    "torch._inductor.codecache.get_registered_device_interfaces",
-                    return_value=[],
-                ),
-            ):
-                system = CacheBase.get_system()
-                expected_payload = {"version": {"triton": None}}
-                self.assertEqual(
-                    system,
-                    {
-                        **expected_payload,
-                        "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
-                            expected_payload
-                        ),
-                    },
-                )
-                self.assertEqual(
-                    fake_strategy.key_from_json.call_args.args[0], expected_payload
-                )
-        finally:
-            CacheBase.get_system.cache_clear()
-
-    def test_device_interface_cache_system_info_unavailable(self):
+    @parametrize(
+        "registered,available,info,expected,warns",
+        (
+            (False, True, None, None, False),
+            (True, True, {"runtime": "1"}, {"fake": {"runtime": "1"}}, False),
+            (True, True, {}, {"fake": {}}, False),
+            (True, False, {"runtime": "1"}, None, False),
+            (True, True, RuntimeError("test failure"), None, True),
+            (True, True, {"v": {1, 2}}, None, True),
+            (True, True, ["runtime", "1"], None, True),
+        ),
+    )
+    def test_device_interface_cache_system_info_without_cuda(
+        self, registered, available, info, expected, warns
+    ):
         class FakeDeviceInterface(DeviceInterface):
             calls = 0
 
             @staticmethod
             def is_available() -> bool:
-                return False
+                return available
 
             @classmethod
             def get_cache_system_info(cls):
                 cls.calls += 1
-                return {"runtime": "1"}
+                if isinstance(info, Exception):
+                    raise info
+                return info
 
         CacheBase.get_system.cache_clear()
         try:
@@ -409,130 +345,35 @@ class TestCacheKeyStrategy(TestCase):
                 ),
                 mock.patch(
                     "torch._inductor.codecache.get_registered_device_interfaces",
-                    return_value=[("fake", FakeDeviceInterface)],
-                ),
-            ):
-                system = CacheBase.get_system()
-                expected_payload = {"version": {"triton": None}}
-                self.assertNotIn("device_interfaces", system)
-                self.assertEqual(FakeDeviceInterface.calls, 0)
-                self.assertEqual(
-                    fake_strategy.key_from_json.call_args.args[0], expected_payload
-                )
-        finally:
-            CacheBase.get_system.cache_clear()
-
-    def test_device_interface_cache_system_info_raises(self):
-        class FakeDeviceInterface(DeviceInterface):
-            @staticmethod
-            def is_available() -> bool:
-                return True
-
-            @classmethod
-            def get_cache_system_info(cls):
-                raise RuntimeError("test failure")
-
-        CacheBase.get_system.cache_clear()
-        try:
-            with (
-                mock.patch(
-                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
-                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
-                ) as fake_strategy,
-                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
-                mock.patch.object(
-                    torch.cuda, "current_device", side_effect=RuntimeError
-                ),
-                mock.patch(
-                    "torch._inductor.codecache.get_registered_device_interfaces",
-                    return_value=[("fake", FakeDeviceInterface)],
+                    return_value=(
+                        [("fake", FakeDeviceInterface)] if registered else []
+                    ),
                 ),
                 mock.patch("torch._inductor.codecache.log") as fake_log,
             ):
                 system = CacheBase.get_system()
                 expected_payload = {"version": {"triton": None}}
-                self.assertNotIn("device_interfaces", system)
+                if expected is not None:
+                    expected_payload["device_interfaces"] = expected
+                self.assertEqual(
+                    system,
+                    {
+                        **expected_payload,
+                        "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
+                            expected_payload
+                        ),
+                    },
+                )
                 self.assertEqual(
                     fake_strategy.key_from_json.call_args.args[0], expected_payload
                 )
-                fake_log.warning.assert_called_once()
-                self.assertIn("fake", fake_log.warning.call_args.args[1])
-        finally:
-            CacheBase.get_system.cache_clear()
-
-    def test_device_interface_cache_system_info_empty_dict(self):
-        class FakeDeviceInterface(DeviceInterface):
-            @staticmethod
-            def is_available() -> bool:
-                return True
-
-            @classmethod
-            def get_cache_system_info(cls):
-                return {}
-
-        CacheBase.get_system.cache_clear()
-        try:
-            with (
-                mock.patch(
-                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
-                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
-                ) as fake_strategy,
-                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
-                mock.patch.object(
-                    torch.cuda, "current_device", side_effect=RuntimeError
-                ),
-                mock.patch(
-                    "torch._inductor.codecache.get_registered_device_interfaces",
-                    return_value=[("fake", FakeDeviceInterface)],
-                ),
-            ):
-                system = CacheBase.get_system()
-                expected_payload = {
-                    "version": {"triton": None},
-                    "device_interfaces": {"fake": {}},
-                }
-                self.assertEqual(system["device_interfaces"], {"fake": {}})
-                self.assertEqual(
-                    fake_strategy.key_from_json.call_args.args[0], expected_payload
-                )
-        finally:
-            CacheBase.get_system.cache_clear()
-
-    def test_device_interface_cache_system_info_invalid_metadata(self):
-        class FakeDeviceInterface(DeviceInterface):
-            @staticmethod
-            def is_available() -> bool:
-                return True
-
-            @classmethod
-            def get_cache_system_info(cls):
-                return {"v": {1, 2}}
-
-        CacheBase.get_system.cache_clear()
-        try:
-            with (
-                mock.patch(
-                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
-                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
-                ) as fake_strategy,
-                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
-                mock.patch.object(
-                    torch.cuda, "current_device", side_effect=RuntimeError
-                ),
-                mock.patch(
-                    "torch._inductor.codecache.get_registered_device_interfaces",
-                    return_value=[("fake", FakeDeviceInterface)],
-                ),
-                mock.patch("torch._inductor.codecache.log") as fake_log,
-            ):
-                system = CacheBase.get_system()
-                expected_payload = {"version": {"triton": None}}
-                self.assertNotIn("device_interfaces", system)
-                self.assertEqual(
-                    fake_strategy.key_from_json.call_args.args[0], expected_payload
-                )
-                fake_log.warning.assert_called_once()
-                self.assertIn("fake", fake_log.warning.call_args.args[1])
+                if warns:
+                    fake_log.warning.assert_called_once()
+                    self.assertIn("fake", fake_log.warning.call_args.args[1])
+                else:
+                    fake_log.warning.assert_not_called()
+                if registered and not available:
+                    self.assertEqual(FakeDeviceInterface.calls, 0)
         finally:
             CacheBase.get_system.cache_clear()
 

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -329,17 +329,27 @@ class TestCacheKeyStrategy(TestCase):
                 ),
             ):
                 system = CacheBase.get_system()
+                expected_payload = {
+                    "version": {"triton": None},
+                    "device_interfaces": {"fake": {"runtime": "1"}},
+                }
                 self.assertEqual(
-                    system["device_interfaces"], {"fake": {"runtime": "1"}}
+                    system,
+                    {
+                        **expected_payload,
+                        "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
+                            expected_payload
+                        ),
+                    },
                 )
                 self.assertEqual(
                     fake_strategy.key_from_json.call_args.args[0],
-                    {"device_interfaces": {"fake": {"runtime": "1"}}},
+                    expected_payload,
                 )
         finally:
             CacheBase.get_system.cache_clear()
 
-    def test_cache_base_get_system_without_cuda_preserves_empty_hash(self):
+    def test_cache_base_get_system_without_cuda_preserves_triton_hash(self):
         CacheBase.get_system.cache_clear()
         try:
             with (
@@ -357,11 +367,19 @@ class TestCacheKeyStrategy(TestCase):
                 ),
             ):
                 system = CacheBase.get_system()
+                expected_payload = {"version": {"triton": None}}
                 self.assertEqual(
                     system,
-                    {"hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json({})},
+                    {
+                        **expected_payload,
+                        "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
+                            expected_payload
+                        ),
+                    },
                 )
-                self.assertEqual(fake_strategy.key_from_json.call_args.args[0], {})
+                self.assertEqual(
+                    fake_strategy.key_from_json.call_args.args[0], expected_payload
+                )
         finally:
             CacheBase.get_system.cache_clear()
 
@@ -395,9 +413,12 @@ class TestCacheKeyStrategy(TestCase):
                 ),
             ):
                 system = CacheBase.get_system()
+                expected_payload = {"version": {"triton": None}}
                 self.assertNotIn("device_interfaces", system)
                 self.assertEqual(FakeDeviceInterface.calls, 0)
-                self.assertEqual(fake_strategy.key_from_json.call_args.args[0], {})
+                self.assertEqual(
+                    fake_strategy.key_from_json.call_args.args[0], expected_payload
+                )
         finally:
             CacheBase.get_system.cache_clear()
 
@@ -429,10 +450,126 @@ class TestCacheKeyStrategy(TestCase):
                 mock.patch("torch._inductor.codecache.log") as fake_log,
             ):
                 system = CacheBase.get_system()
+                expected_payload = {"version": {"triton": None}}
                 self.assertNotIn("device_interfaces", system)
-                self.assertEqual(fake_strategy.key_from_json.call_args.args[0], {})
+                self.assertEqual(
+                    fake_strategy.key_from_json.call_args.args[0], expected_payload
+                )
                 fake_log.warning.assert_called_once()
                 self.assertIn("fake", fake_log.warning.call_args.args[1])
+        finally:
+            CacheBase.get_system.cache_clear()
+
+    def test_device_interface_cache_system_info_empty_dict(self):
+        class FakeDeviceInterface(DeviceInterface):
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @classmethod
+            def get_cache_system_info(cls):
+                return {}
+
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(
+                    torch.cuda, "current_device", side_effect=RuntimeError
+                ),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[("fake", FakeDeviceInterface)],
+                ),
+            ):
+                system = CacheBase.get_system()
+                expected_payload = {
+                    "version": {"triton": None},
+                    "device_interfaces": {"fake": {}},
+                }
+                self.assertEqual(system["device_interfaces"], {"fake": {}})
+                self.assertEqual(
+                    fake_strategy.key_from_json.call_args.args[0], expected_payload
+                )
+        finally:
+            CacheBase.get_system.cache_clear()
+
+    def test_device_interface_cache_system_info_invalid_metadata(self):
+        class FakeDeviceInterface(DeviceInterface):
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @classmethod
+            def get_cache_system_info(cls):
+                return {"v": {1, 2}}
+
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(
+                    torch.cuda, "current_device", side_effect=RuntimeError
+                ),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[("fake", FakeDeviceInterface)],
+                ),
+                mock.patch("torch._inductor.codecache.log") as fake_log,
+            ):
+                system = CacheBase.get_system()
+                expected_payload = {"version": {"triton": None}}
+                self.assertNotIn("device_interfaces", system)
+                self.assertEqual(
+                    fake_strategy.key_from_json.call_args.args[0], expected_payload
+                )
+                fake_log.warning.assert_called_once()
+                self.assertIn("fake", fake_log.warning.call_args.args[1])
+        finally:
+            CacheBase.get_system.cache_clear()
+
+    def test_device_interface_cache_system_info_non_dict_metadata(self):
+        class FakeDeviceInterface(DeviceInterface):
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @classmethod
+            def get_cache_system_info(cls):
+                return ["runtime", "1"]
+
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(
+                    torch.cuda, "current_device", side_effect=RuntimeError
+                ),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[("fake", FakeDeviceInterface)],
+                ),
+                mock.patch("torch._inductor.codecache.log") as fake_log,
+            ):
+                system = CacheBase.get_system()
+                expected_payload = {"version": {"triton": None}}
+                self.assertNotIn("device_interfaces", system)
+                self.assertEqual(
+                    fake_strategy.key_from_json.call_args.args[0], expected_payload
+                )
+                self.assertEqual(fake_log.warning.call_count, 1)
         finally:
             CacheBase.get_system.cache_clear()
 

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -239,9 +239,7 @@ class TestCacheKeyStrategy(TestCase):
         fake_strategy.key_from_json.side_effect = lambda value: json.dumps(
             value, sort_keys=True
         )
-        fake_properties = types.SimpleNamespace(
-            name="test-gpu", gcnArchName="test-gcn"
-        )
+        fake_properties = types.SimpleNamespace(name="test-gpu", gcnArchName="test-gcn")
         CacheBase.get_system.cache_clear()
         try:
             with (
@@ -274,9 +272,7 @@ class TestCacheKeyStrategy(TestCase):
                 FakeDeviceInterface.info = ("runtime", "1")
                 CacheBase.get_system.cache_clear()
                 first = CacheBase.get_system()
-                self.assertEqual(
-                    first["device_interfaces"], {"fake": ("runtime", "1")}
-                )
+                self.assertEqual(first["device_interfaces"], {"fake": ("runtime", "1")})
                 self.assertEqual(FakeDeviceInterface.calls, 2)
                 FakeDeviceInterface.info = ("runtime", "2")
                 CacheBase.get_system.cache_clear()
@@ -325,9 +321,7 @@ class TestCacheKeyStrategy(TestCase):
         finally:
             CacheBase.get_system.cache_clear()
 
-        self.assertEqual(
-            system["device_interfaces"], {"fake": ("runtime", "1")}
-        )
+        self.assertEqual(system["device_interfaces"], {"fake": ("runtime", "1")})
         self.assertEqual(
             strategy.key_from_json.call_args.args[0],
             {"device_interfaces": {"fake": ("runtime", "1")}},

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -230,23 +230,23 @@ class TestCacheKeyStrategy(TestCase):
             info = None
             calls = 0
 
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
             @classmethod
             def get_cache_system_info(cls):
                 cls.calls += 1
                 return cls.info
 
-        fake_strategy = mock.MagicMock()
-        fake_strategy.key_from_json.side_effect = lambda value: json.dumps(
-            value, sort_keys=True
-        )
         fake_properties = types.SimpleNamespace(name="test-gpu", gcnArchName="test-gcn")
         CacheBase.get_system.cache_clear()
         try:
             with (
                 mock.patch(
                     "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
-                    fake_strategy,
-                ),
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
                 mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
                 mock.patch.object(torch.cuda, "current_device", return_value=0),
                 mock.patch.object(
@@ -265,49 +265,60 @@ class TestCacheKeyStrategy(TestCase):
             ):
                 base = CacheBase.get_system()
                 self.assertNotIn(
-                    "device_interfaces", fake_strategy.key_from_json.call_args.args[0]
+                    "device_interfaces",
+                    fake_strategy.key_from_json.call_args.args[0],
                 )
                 self.assertEqual(FakeDeviceInterface.calls, 1)
 
-                FakeDeviceInterface.info = ("runtime", "1")
+                FakeDeviceInterface.info = {"runtime": "1"}
                 CacheBase.get_system.cache_clear()
                 first = CacheBase.get_system()
-                self.assertEqual(first["device_interfaces"], {"fake": ("runtime", "1")})
+                self.assertEqual(first["device_interfaces"], {"fake": {"runtime": "1"}})
                 self.assertEqual(FakeDeviceInterface.calls, 2)
-                FakeDeviceInterface.info = ("runtime", "2")
+                first_payload = copy.deepcopy(
+                    fake_strategy.key_from_json.call_args.args[0]
+                )
+                self.assertEqual(
+                    first_payload,
+                    {
+                        "device": {"name": "test-gpu"},
+                        "version": {"triton": None, "cuda": "test-cuda"},
+                        "device_interfaces": {"fake": {"runtime": "1"}},
+                    },
+                )
+                FakeDeviceInterface.info = {"runtime": "2"}
                 CacheBase.get_system.cache_clear()
                 second = CacheBase.get_system()
+                self.assertNotEqual(first["hash"], second["hash"])
+                self.assertEqual(
+                    base["hash"],
+                    SYSTEM_CACHE_KEY_STRATEGY.key_from_json(
+                        {
+                            "device": {"name": "test-gpu"},
+                            "version": {"triton": None, "cuda": "test-cuda"},
+                        }
+                    ),
+                )
         finally:
             CacheBase.get_system.cache_clear()
 
-        self.assertNotEqual(first["hash"], second["hash"])
-        self.assertEqual(
-            base["hash"],
-            json.dumps(
-                {
-                    "device": {"name": "test-gpu"},
-                    "version": {"triton": None, "cuda": "test-cuda"},
-                },
-                sort_keys=True,
-            ),
-        )
-
     def test_device_interface_cache_system_info_without_cuda(self):
         class FakeDeviceInterface(DeviceInterface):
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
             @classmethod
             def get_cache_system_info(cls):
-                return ("runtime", "1")
+                return {"runtime": "1"}
 
-        strategy = mock.MagicMock()
-        strategy.key_from_json.side_effect = lambda value: json.dumps(
-            value, sort_keys=True
-        )
         CacheBase.get_system.cache_clear()
         try:
             with (
                 mock.patch(
-                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY", strategy
-                ),
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
                 mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
                 mock.patch.object(
                     torch.cuda, "current_device", side_effect=RuntimeError
@@ -318,26 +329,24 @@ class TestCacheKeyStrategy(TestCase):
                 ),
             ):
                 system = CacheBase.get_system()
+                self.assertEqual(
+                    system["device_interfaces"], {"fake": {"runtime": "1"}}
+                )
+                self.assertEqual(
+                    fake_strategy.key_from_json.call_args.args[0],
+                    {"device_interfaces": {"fake": {"runtime": "1"}}},
+                )
         finally:
             CacheBase.get_system.cache_clear()
 
-        self.assertEqual(system["device_interfaces"], {"fake": ("runtime", "1")})
-        self.assertEqual(
-            strategy.key_from_json.call_args.args[0],
-            {"device_interfaces": {"fake": ("runtime", "1")}},
-        )
-
     def test_cache_base_get_system_without_cuda_preserves_empty_hash(self):
-        strategy = mock.MagicMock()
-        strategy.key_from_json.side_effect = lambda value: json.dumps(
-            value, sort_keys=True
-        )
         CacheBase.get_system.cache_clear()
         try:
             with (
                 mock.patch(
-                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY", strategy
-                ),
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
                 mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
                 mock.patch.object(
                     torch.cuda, "current_device", side_effect=RuntimeError
@@ -348,11 +357,84 @@ class TestCacheKeyStrategy(TestCase):
                 ),
             ):
                 system = CacheBase.get_system()
+                self.assertEqual(
+                    system,
+                    {"hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json({})},
+                )
+                self.assertEqual(fake_strategy.key_from_json.call_args.args[0], {})
         finally:
             CacheBase.get_system.cache_clear()
 
-        self.assertEqual(system, {"hash": json.dumps({}, sort_keys=True)})
-        self.assertEqual(strategy.key_from_json.call_args.args[0], {})
+    def test_device_interface_cache_system_info_unavailable(self):
+        class FakeDeviceInterface(DeviceInterface):
+            calls = 0
+
+            @staticmethod
+            def is_available() -> bool:
+                return False
+
+            @classmethod
+            def get_cache_system_info(cls):
+                cls.calls += 1
+                return {"runtime": "1"}
+
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(
+                    torch.cuda, "current_device", side_effect=RuntimeError
+                ),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[("fake", FakeDeviceInterface)],
+                ),
+            ):
+                system = CacheBase.get_system()
+                self.assertNotIn("device_interfaces", system)
+                self.assertEqual(FakeDeviceInterface.calls, 0)
+                self.assertEqual(fake_strategy.key_from_json.call_args.args[0], {})
+        finally:
+            CacheBase.get_system.cache_clear()
+
+    def test_device_interface_cache_system_info_raises(self):
+        class FakeDeviceInterface(DeviceInterface):
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @classmethod
+            def get_cache_system_info(cls):
+                raise RuntimeError("test failure")
+
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    wraps=SYSTEM_CACHE_KEY_STRATEGY,
+                ) as fake_strategy,
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(
+                    torch.cuda, "current_device", side_effect=RuntimeError
+                ),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[("fake", FakeDeviceInterface)],
+                ),
+                mock.patch("torch._inductor.codecache.log") as fake_log,
+            ):
+                system = CacheBase.get_system()
+                self.assertNotIn("device_interfaces", system)
+                self.assertEqual(fake_strategy.key_from_json.call_args.args[0], {})
+                fake_log.warning.assert_called_once()
+                self.assertIn("fake", fake_log.warning.call_args.args[1])
+        finally:
+            CacheBase.get_system.cache_clear()
 
     def test_autotune_prepare_key_uses_strategy(self):
         from torch._inductor.runtime.autotune_cache import AutotuneCache

--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 import torch
 from torch._dynamo import reset
+from torch._dynamo.device_interface import DeviceInterface
 from torch._dynamo.package import DynamoCache
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.utils import counters
@@ -221,6 +222,143 @@ class TestCacheKeyStrategy(TestCase):
             },
         )
         self.assertTrue(fake_strategy.sort_keys)
+
+    def test_device_interface_cache_system_info(self):
+        self.assertIsNone(DeviceInterface.get_cache_system_info())
+
+        class FakeDeviceInterface(DeviceInterface):
+            info = None
+            calls = 0
+
+            @classmethod
+            def get_cache_system_info(cls):
+                cls.calls += 1
+                return cls.info
+
+        fake_strategy = mock.MagicMock()
+        fake_strategy.key_from_json.side_effect = lambda value: json.dumps(
+            value, sort_keys=True
+        )
+        fake_properties = types.SimpleNamespace(
+            name="test-gpu", gcnArchName="test-gcn"
+        )
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY",
+                    fake_strategy,
+                ),
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(torch.cuda, "current_device", return_value=0),
+                mock.patch.object(
+                    torch.cuda,
+                    "get_device_properties",
+                    return_value=fake_properties,
+                ),
+                mock.patch.object(torch.version, "cuda", "test-cuda"),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[
+                        ("fake", FakeDeviceInterface),
+                        ("fake:0", FakeDeviceInterface),
+                    ],
+                ),
+            ):
+                base = CacheBase.get_system()
+                self.assertNotIn(
+                    "device_interfaces", fake_strategy.key_from_json.call_args.args[0]
+                )
+                self.assertEqual(FakeDeviceInterface.calls, 1)
+
+                FakeDeviceInterface.info = ("runtime", "1")
+                CacheBase.get_system.cache_clear()
+                first = CacheBase.get_system()
+                self.assertEqual(
+                    first["device_interfaces"], {"fake": ("runtime", "1")}
+                )
+                self.assertEqual(FakeDeviceInterface.calls, 2)
+                FakeDeviceInterface.info = ("runtime", "2")
+                CacheBase.get_system.cache_clear()
+                second = CacheBase.get_system()
+        finally:
+            CacheBase.get_system.cache_clear()
+
+        self.assertNotEqual(first["hash"], second["hash"])
+        self.assertEqual(
+            base["hash"],
+            json.dumps(
+                {
+                    "device": {"name": "test-gpu"},
+                    "version": {"triton": None, "cuda": "test-cuda"},
+                },
+                sort_keys=True,
+            ),
+        )
+
+    def test_device_interface_cache_system_info_without_cuda(self):
+        class FakeDeviceInterface(DeviceInterface):
+            @classmethod
+            def get_cache_system_info(cls):
+                return ("runtime", "1")
+
+        strategy = mock.MagicMock()
+        strategy.key_from_json.side_effect = lambda value: json.dumps(
+            value, sort_keys=True
+        )
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY", strategy
+                ),
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(
+                    torch.cuda, "current_device", side_effect=RuntimeError
+                ),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[("fake", FakeDeviceInterface)],
+                ),
+            ):
+                system = CacheBase.get_system()
+        finally:
+            CacheBase.get_system.cache_clear()
+
+        self.assertEqual(
+            system["device_interfaces"], {"fake": ("runtime", "1")}
+        )
+        self.assertEqual(
+            strategy.key_from_json.call_args.args[0],
+            {"device_interfaces": {"fake": ("runtime", "1")}},
+        )
+
+    def test_cache_base_get_system_without_cuda_preserves_empty_hash(self):
+        strategy = mock.MagicMock()
+        strategy.key_from_json.side_effect = lambda value: json.dumps(
+            value, sort_keys=True
+        )
+        CacheBase.get_system.cache_clear()
+        try:
+            with (
+                mock.patch(
+                    "torch._inductor.codecache.SYSTEM_CACHE_KEY_STRATEGY", strategy
+                ),
+                mock.patch("torch._inductor.runtime.triton_compat.HAS_TRITON", False),
+                mock.patch.object(
+                    torch.cuda, "current_device", side_effect=RuntimeError
+                ),
+                mock.patch(
+                    "torch._inductor.codecache.get_registered_device_interfaces",
+                    return_value=[],
+                ),
+            ):
+                system = CacheBase.get_system()
+        finally:
+            CacheBase.get_system.cache_clear()
+
+        self.assertEqual(system, {"hash": json.dumps({}, sort_keys=True)})
+        self.assertEqual(strategy.key_from_json.call_args.args[0], {})
 
     def test_autotune_prepare_key_uses_strategy(self):
         from torch._inductor.runtime.autotune_cache import AutotuneCache

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -138,8 +138,9 @@ class DeviceInterface:
         Returning None opts out. An empty dict still contributes metadata.
         Implementations should return only metadata that invalidates generated
         or autotuned code when changed, without unnecessarily initializing hardware.
-        This hook is sampled through the cached CacheBase.get_system() path, so
-        interfaces must be registered before its first use.
+        Only called when is_available() returns True. This hook is sampled through
+        the cached CacheBase.get_system() path, so interfaces must be registered
+        and available before its first use.
         """
         return None
 

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -131,6 +131,15 @@ class DeviceInterface:
     def get_device_properties(cls, device: torch.types.Device = None) -> Any:
         return cls.Worker.get_device_properties(device)
 
+    @classmethod
+    def get_cache_system_info(cls) -> tuple[Any, ...] | None:
+        """Return stable, JSON-serializable metadata for the code cache key.
+
+        Implementations should return only metadata that invalidates generated
+        or autotuned code when changed, without unnecessarily initializing hardware.
+        """
+        return None
+
     @staticmethod
     def get_compute_capability(device: torch.types.Device = None) -> Any:
         raise NotImplementedError

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -132,7 +132,7 @@ class DeviceInterface:
         return cls.Worker.get_device_properties(device)
 
     @classmethod
-    def get_cache_system_info(cls) -> tuple[Any, ...] | None:
+    def get_cache_system_info(cls) -> dict[str, Any] | None:
         """Return stable, JSON-serializable metadata for the code cache key.
 
         Implementations should return only metadata that invalidates generated

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -132,11 +132,14 @@ class DeviceInterface:
         return cls.Worker.get_device_properties(device)
 
     @classmethod
-    def get_cache_system_info(cls) -> dict[str, Any] | None:
+    def get_cache_system_info(cls) -> dict[str, object] | None:
         """Return stable, JSON-serializable metadata for the code cache key.
 
+        Returning None opts out. An empty dict still contributes metadata.
         Implementations should return only metadata that invalidates generated
         or autotuned code when changed, without unnecessarily initializing hardware.
+        This hook is sampled through the cached CacheBase.get_system() path, so
+        interfaces must be registered before its first use.
         """
         return None
 

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -360,6 +360,8 @@ class CacheBase:
 
         device_interface_info: dict[str, dict[str, object]] = {}
         for name, interface in get_registered_device_interfaces():
+            # The registry contains both the base device name and indexed local
+            # instances; collect cache metadata only once per backend.
             if ":" in name:
                 continue
 
@@ -370,12 +372,14 @@ class CacheBase:
                 if not interface.is_available():
                     continue
                 info = interface.get_cache_system_info()
-                if info is not None:
-                    if not isinstance(info, dict):
-                        raise TypeError(
-                            "get_cache_system_info() must return a dict or None"
-                        )
-                    json.dumps(info, sort_keys=True)
+                if info is None:
+                    continue
+                if not isinstance(info, dict):
+                    raise TypeError(f"expected a dict or None, got {type(info)}")
+                # Probe serializability here before key_from_json() and
+                # update_local_cache() serialize this metadata later.
+                json.dumps(info, sort_keys=True)
+                device_interface_info[name] = info
             except Exception:
                 log.warning(
                     "Failed to collect cache system info from device interface %s",
@@ -383,8 +387,6 @@ class CacheBase:
                     exc_info=True,
                 )
                 continue
-            if info is not None:
-                device_interface_info[name] = info
 
         if device_interface_info:
             hash_input["device_interfaces"] = device_interface_info

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -48,7 +48,10 @@ import torch
 import torch._library.opaque_object as opaque_object
 import torch.distributed as dist
 from torch import SymInt, Tensor
-from torch._dynamo.device_interface import get_interface_for_device
+from torch._dynamo.device_interface import (
+    get_interface_for_device,
+    get_registered_device_interfaces,
+)
 from torch._dynamo.exc import SkipFrame
 from torch._dynamo.utils import (
     CompileEventLogger,
@@ -163,6 +166,7 @@ class SystemInfo(TypedDict):
     hash: str
     device: NotRequired[SystemDeviceInfo]
     version: NotRequired[SystemVersionInfo]
+    device_interfaces: NotRequired[dict[str, Any]]
 
 
 class CacheInfo(TypedDict, total=False):
@@ -333,6 +337,8 @@ class CacheBase:
         with dynamo_timed("CacheBase.get_system.triton_key"):
             triton_version = triton_key()
 
+        hash_input: dict[str, Any] = {}
+        system: dict[str, Any] = {}
         try:
             device_info: SystemDeviceInfo = {"name": None}
             version_info: SystemVersionInfo = {"triton": triton_version}
@@ -345,18 +351,34 @@ class CacheBase:
             else:
                 device_info["name"] = device_properties.gcnArchName
                 version_info["hip"] = torch.version.hip
-            hash_input: dict[str, Any] = {
-                "device": device_info,
-                "version": version_info,
-            }
-            return {
-                "device": device_info,
-                "version": version_info,
-                "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(hash_input),
-            }
+            hash_input.update(
+                {
+                    "device": device_info,
+                    "version": version_info,
+                }
+            )
+            system.update(
+                {
+                    "device": device_info,
+                    "version": version_info,
+                }
+            )
         except (AssertionError, RuntimeError):
             # If cuda is not installed, none of the above config is relevant.
-            return {"hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json({})}
+            pass
+
+        device_interface_info = {
+            name: info
+            for name, interface in get_registered_device_interfaces()
+            if ":" not in name
+            if (info := interface.get_cache_system_info()) is not None
+        }
+        if device_interface_info:
+            hash_input["device_interfaces"] = device_interface_info
+            system["device_interfaces"] = device_interface_info
+
+        system["hash"] = SYSTEM_CACHE_KEY_STRATEGY.key_from_json(hash_input)
+        return cast(SystemInfo, system)
 
     @staticmethod
     @clear_on_fresh_cache

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -42,7 +42,7 @@ from types import (
     ModuleType,
 )
 from typing import Any, cast, Generic, Literal, NoReturn, TYPE_CHECKING, TypeVar
-from typing_extensions import NotRequired, override, Self, TypedDict
+from typing_extensions import override, Self, TypedDict
 
 import torch
 import torch._library.opaque_object as opaque_object
@@ -163,9 +163,9 @@ class SystemVersionInfo(TypedDict, total=False):
 
 
 class SystemCacheInfo(TypedDict, total=False):
-    device: NotRequired[SystemDeviceInfo]
-    version: NotRequired[SystemVersionInfo]
-    device_interfaces: NotRequired[dict[str, dict[str, Any]]]
+    device: SystemDeviceInfo
+    version: SystemVersionInfo
+    device_interfaces: dict[str, dict[str, object]]
 
 
 class SystemInfo(SystemCacheInfo):
@@ -340,10 +340,10 @@ class CacheBase:
         with dynamo_timed("CacheBase.get_system.triton_key"):
             triton_version = triton_key()
 
-        system_info: SystemCacheInfo = {}
+        version_info: SystemVersionInfo = {"triton": triton_version}
+        hash_input: SystemCacheInfo = {"version": version_info}
         try:
             device_info: SystemDeviceInfo = {"name": None}
-            version_info: SystemVersionInfo = {"triton": triton_version}
             device_properties = torch.cuda.get_device_properties(
                 torch.cuda.current_device()
             )
@@ -353,30 +353,29 @@ class CacheBase:
             else:
                 device_info["name"] = device_properties.gcnArchName
                 version_info["hip"] = torch.version.hip
-            system_info["device"] = device_info
-            system_info["version"] = version_info
+            hash_input["device"] = device_info
         except (AssertionError, RuntimeError):
-            # If cuda is not installed, none of the above config is relevant.
+            # If CUDA is not installed, omit CUDA/HIP-specific device information.
             pass
 
-        device_interface_info: dict[str, dict[str, Any]] = {}
+        device_interface_info: dict[str, dict[str, object]] = {}
         for name, interface in get_registered_device_interfaces():
             if ":" in name:
                 continue
 
+            # CacheBase.get_system() participates in every compile's FX graph
+            # cache key, so a broken third-party backend must not break CPU-only
+            # compilation.
             try:
                 if not interface.is_available():
                     continue
-            except Exception:
-                log.warning(
-                    "Failed to check availability for device interface %s",
-                    name,
-                    exc_info=True,
-                )
-                continue
-
-            try:
                 info = interface.get_cache_system_info()
+                if info is not None:
+                    if not isinstance(info, dict):
+                        raise TypeError(
+                            "get_cache_system_info() must return a dict or None"
+                        )
+                    json.dumps(info, sort_keys=True)
             except Exception:
                 log.warning(
                     "Failed to collect cache system info from device interface %s",
@@ -388,11 +387,11 @@ class CacheBase:
                 device_interface_info[name] = info
 
         if device_interface_info:
-            system_info["device_interfaces"] = device_interface_info
+            hash_input["device_interfaces"] = device_interface_info
 
         return {
-            **system_info,
-            "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(system_info),
+            **hash_input,
+            "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(hash_input),
         }
 
     @staticmethod

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -162,11 +162,14 @@ class SystemVersionInfo(TypedDict, total=False):
     hip: str | None
 
 
-class SystemInfo(TypedDict):
-    hash: str
+class SystemCacheInfo(TypedDict, total=False):
     device: NotRequired[SystemDeviceInfo]
     version: NotRequired[SystemVersionInfo]
-    device_interfaces: NotRequired[dict[str, Any]]
+    device_interfaces: NotRequired[dict[str, dict[str, Any]]]
+
+
+class SystemInfo(SystemCacheInfo):
+    hash: str
 
 
 class CacheInfo(TypedDict, total=False):
@@ -337,8 +340,7 @@ class CacheBase:
         with dynamo_timed("CacheBase.get_system.triton_key"):
             triton_version = triton_key()
 
-        hash_input: dict[str, Any] = {}
-        system: dict[str, Any] = {}
+        system_info: SystemCacheInfo = {}
         try:
             device_info: SystemDeviceInfo = {"name": None}
             version_info: SystemVersionInfo = {"triton": triton_version}
@@ -351,34 +353,47 @@ class CacheBase:
             else:
                 device_info["name"] = device_properties.gcnArchName
                 version_info["hip"] = torch.version.hip
-            hash_input.update(
-                {
-                    "device": device_info,
-                    "version": version_info,
-                }
-            )
-            system.update(
-                {
-                    "device": device_info,
-                    "version": version_info,
-                }
-            )
+            system_info["device"] = device_info
+            system_info["version"] = version_info
         except (AssertionError, RuntimeError):
             # If cuda is not installed, none of the above config is relevant.
             pass
 
-        device_interface_info = {
-            name: info
-            for name, interface in get_registered_device_interfaces()
-            if ":" not in name
-            if (info := interface.get_cache_system_info()) is not None
-        }
-        if device_interface_info:
-            hash_input["device_interfaces"] = device_interface_info
-            system["device_interfaces"] = device_interface_info
+        device_interface_info: dict[str, dict[str, Any]] = {}
+        for name, interface in get_registered_device_interfaces():
+            if ":" in name:
+                continue
 
-        system["hash"] = SYSTEM_CACHE_KEY_STRATEGY.key_from_json(hash_input)
-        return cast(SystemInfo, system)
+            try:
+                if not interface.is_available():
+                    continue
+            except Exception:
+                log.warning(
+                    "Failed to check availability for device interface %s",
+                    name,
+                    exc_info=True,
+                )
+                continue
+
+            try:
+                info = interface.get_cache_system_info()
+            except Exception:
+                log.warning(
+                    "Failed to collect cache system info from device interface %s",
+                    name,
+                    exc_info=True,
+                )
+                continue
+            if info is not None:
+                device_interface_info[name] = info
+
+        if device_interface_info:
+            system_info["device_interfaces"] = device_interface_info
+
+        return {
+            **system_info,
+            "hash": SYSTEM_CACHE_KEY_STRATEGY.key_from_json(system_info),
+        }
 
     @staticmethod
     @clear_on_fresh_cache


### PR DESCRIPTION
## Summary

Allow registered `DeviceInterface` implementations to contribute stable
device and runtime metadata to the Inductor CodeCache system key.

This lets out-of-tree backends participate in cache invalidation without
replacing `CacheBase.get_system()` or hardcoding backend-specific runtime
information in Inductor.

## Changes

- Add `DeviceInterface.get_cache_system_info()`, returning optional stable,
  JSON-serializable metadata for the code cache key.
- Define the hook contract so `None` opts out while an empty dict still
  participates in the cache key.
- Extend `CacheBase.get_system()` to collect metadata from registered and
  available device interfaces.
- Skip indexed device aliases such as `cuda:0` when collecting metadata so
  each backend contributes only once.
- Validate contributed metadata before adding it to the cache key:
  non-dict or non-JSON-serializable metadata is warned about and skipped
  instead of breaking unrelated compilation.
- Keep interface availability checks, metadata collection, and metadata
  validation isolated so a broken third-party backend cannot break CPU-only
  compilation.
- Preserve Triton version information in the system cache key even when CUDA
  device probing is unavailable.
- Continue collecting out-of-tree backend metadata when CUDA is unavailable.

## Motivation

`CacheBase.get_system()` currently derives cache-invalidating system
information primarily from CUDA/HIP device properties and runtime versions.

Out-of-tree backends that need their own device or runtime version to
invalidate generated or autotuned code therefore have no backend-owned
extension point for contributing that information.

Providing this through `DeviceInterface` keeps backend-specific system
metadata behind the existing device abstraction and avoids requiring
out-of-tree backends to replace `CacheBase.get_system()` or duplicate its
cache hashing logic.

The default `DeviceInterface.get_cache_system_info()` implementation returns
`None`, so backends opt in explicitly.

Because `CacheBase.get_system()` is cached, the interface must be registered
before the hook is first sampled.

## Test Plan

Added or updated coverage for:

- The default `DeviceInterface.get_cache_system_info()` returning `None`.
- Preserving existing CUDA system cache input when no interface contributes
  additional metadata.
- Including registered interface metadata in the system cache key.
- Changing interface metadata changing the resulting system hash.
- Ignoring indexed device aliases such as `fake:0`.
- Skipping unavailable device interfaces.
- Continuing compilation when a device interface raises while contributing
  cache metadata.
- Treating an empty metadata dict as participating in the cache key rather
  than as an opt-out.
- Rejecting non-JSON-serializable metadata without propagating the failure.
- Rejecting JSON-serializable non-dict metadata that violates the hook
  contract.
- Collecting interface metadata when CUDA is unavailable.
- Preserving Triton version information in the cache key when CUDA is
  unavailable.

## Follow-up work

This PR intentionally does not migrate the existing CUDA/HIP-specific fields
in `CacheBase.get_system()` into `CudaInterface.get_cache_system_info()`.

That migration would change the existing serialized cache payload shape and
invalidate existing on-disk caches, so it should be handled separately rather
than combined with introducing this extension point.

`XpuInterface.get_cache_system_info()` is a natural first in-tree adopter of
the new hook because XPU currently does not contribute equivalent device or
runtime metadata to this system cache key. Unlike moving the existing
CUDA/HIP fields, adding XPU metadata would introduce new cache-key information
rather than relocate existing fields.

## Notes

- Preserving Triton version information when CUDA probing is unavailable
  changes the previous non-CUDA cache payload and therefore causes a one-time
  cache invalidation for those environments.
- Related RFC: #189137.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98