### PR TITLE
[DCP] Add an opt-in cooperative load planner for replicated reads

### DIFF
--- a/test/distributed/checkpoint/test_cooperative_planner.py
+++ b/test/distributed/checkpoint/test_cooperative_planner.py
@@ -1,0 +1,70 @@
+# Owner(s): ["oncall: distributed"]
+
+import torch
+from torch.distributed.checkpoint.cooperative_planner import (
+    _create_cooperative_plans,
+    _read_signature,
+)
+from torch.distributed.checkpoint.metadata import MetadataIndex
+from torch.distributed.checkpoint.planner import (
+    LoadItemType,
+    LoadPlan,
+    ReadItem,
+)
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+def _read_item(fqn: str) -> ReadItem:
+    index = MetadataIndex(fqn, (0,))
+    return ReadItem(
+        type=LoadItemType.TENSOR,
+        dest_index=index,
+        dest_offsets=torch.Size([0]),
+        storage_index=index,
+        storage_offsets=torch.Size([0]),
+        lengths=torch.Size([8]),
+    )
+
+
+def _plan(*items: ReadItem, shape=(8,)) -> LoadPlan:
+    metadata = {
+        _read_signature(item): (shape, "torch.float32", "cuda", 32)
+        for item in items
+    }
+    return LoadPlan(items=list(items), planner_data=metadata)
+
+
+class TestCooperativeLoadPlanner(TestCase):
+    def test_deduplicates_and_byte_balances_readers(self):
+        weight = _read_item("model.weight")
+        bias = _read_item("model.bias")
+        plans = _create_cooperative_plans(
+            [_plan(weight, bias), _plan(bias, weight)],
+            global_ranks=(0, 1),
+            min_tensor_bytes=0,
+        )
+
+        self.assertEqual(2, sum(len(plan.items) for plan in plans))
+        schedules = [plan.planner_data.schedule for plan in plans]
+        self.assertEqual(schedules[0], schedules[1])
+        self.assertEqual({0, 1}, {task.src for task in schedules[0]})
+        self.assertEqual(
+            ["model.bias", "model.weight"],
+            [task.read_item.dest_index.fqn for task in schedules[0]],
+        )
+
+    def test_keeps_native_reads_on_metadata_mismatch(self):
+        weight = _read_item("model.weight")
+        plans = [_plan(weight, shape=(8,)), _plan(weight, shape=(4,))]
+        result = _create_cooperative_plans(
+            plans,
+            global_ranks=(0, 1),
+            min_tensor_bytes=0,
+        )
+
+        self.assertEqual([1, 1], [len(plan.items) for plan in result])
+        self.assertEqual([(), ()], [plan.planner_data.schedule for plan in result])
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/distributed/checkpoint/__init__.py
+++ b/torch/distributed/checkpoint/__init__.py
@@ -1,5 +1,6 @@
 from . import _extension
 from .api import CheckpointException
+from .cooperative_planner import CooperativeLoadPlanner
 from .default_planner import DefaultLoadPlanner, DefaultSavePlanner
 from .filesystem import FileSystemReader, FileSystemWriter
 from .hf_storage import HuggingFaceStorageReader, HuggingFaceStorageWriter

--- a/torch/distributed/checkpoint/cooperative_planner.py
+++ b/torch/distributed/checkpoint/cooperative_planner.py
@@ -1,0 +1,228 @@
+# mypy: allow-untyped-defs
+
+import dataclasses
+from collections import defaultdict
+from typing import Any, cast
+
+import torch
+import torch.distributed as dist
+
+from .default_planner import DefaultLoadPlanner
+from .planner import LoadItemType, LoadPlan, ReadItem
+
+
+_ReadSignature = tuple[
+    int,
+    str,
+    tuple[int, ...],
+    tuple[int, ...],
+    str,
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+]
+_TensorMetadata = tuple[tuple[int, ...], str, str, int]
+
+
+@dataclasses.dataclass(frozen=True)
+class _BroadcastTask:
+    read_item: ReadItem
+    ranks: tuple[int, ...]
+    src: int
+
+
+@dataclasses.dataclass(frozen=True)
+class _CooperativePlan:
+    schedule: tuple[_BroadcastTask, ...]
+    groups: tuple[tuple[int, ...], ...]
+
+
+def _index_offset(index) -> tuple[int, ...]:
+    return tuple(index.offset) if index.offset is not None else ()
+
+
+def _read_signature(item: ReadItem) -> _ReadSignature:
+    return (
+        item.type.value,
+        item.dest_index.fqn,
+        _index_offset(item.dest_index),
+        tuple(item.dest_offsets),
+        item.storage_index.fqn,
+        _index_offset(item.storage_index),
+        tuple(item.storage_offsets),
+        tuple(item.lengths),
+    )
+
+
+def _create_cooperative_plans(
+    all_plans: list[LoadPlan],
+    global_ranks: tuple[int, ...],
+    min_tensor_bytes: int,
+) -> list[LoadPlan]:
+    requests: dict[
+        _ReadSignature,
+        list[tuple[int, ReadItem, _TensorMetadata]],
+    ] = defaultdict(list)
+
+    for plan_rank, plan in enumerate(all_plans):
+        tensor_metadata = cast(dict[_ReadSignature, _TensorMetadata], plan.planner_data)
+        for item in plan.items:
+            if item.type != LoadItemType.TENSOR:
+                continue
+            signature = _read_signature(item)
+            metadata = tensor_metadata.get(signature)
+            if metadata is not None:
+                requests[signature].append((plan_rank, item, metadata))
+
+    candidates = []
+    for signature, occurrences in requests.items():
+        plan_ranks = [rank for rank, _, _ in occurrences]
+        metadata = {value for _, _, value in occurrences}
+        if (
+            len(occurrences) <= 1
+            or len(plan_ranks) != len(set(plan_ranks))
+            or len(metadata) != 1
+        ):
+            continue
+        nbytes = next(iter(metadata))[3]
+        if nbytes < min_tensor_bytes:
+            continue
+        candidates.append((nbytes, signature, occurrences))
+
+    assigned_bytes = [0] * len(all_plans)
+    tasks = []
+    drops: list[set[_ReadSignature]] = [set() for _ in all_plans]
+    for nbytes, signature, occurrences in sorted(
+        candidates, key=lambda value: (-value[0], value[1])
+    ):
+        plan_ranks = tuple(sorted(rank for rank, _, _ in occurrences))
+        leader = min(plan_ranks, key=lambda rank: (assigned_bytes[rank], rank))
+        assigned_bytes[leader] += nbytes
+        ranks = tuple(global_ranks[rank] for rank in plan_ranks)
+        task = _BroadcastTask(
+            read_item=occurrences[0][1],
+            ranks=ranks,
+            src=global_ranks[leader],
+        )
+        tasks.append(task)
+        for plan_rank in plan_ranks:
+            if plan_rank != leader:
+                drops[plan_rank].add(signature)
+
+    schedule = tuple(sorted(tasks, key=lambda task: _read_signature(task.read_item)))
+    groups = tuple(sorted({task.ranks for task in schedule}))
+    result = []
+    for plan_rank, plan in enumerate(all_plans):
+        rank = global_ranks[plan_rank]
+        local_schedule = tuple(task for task in schedule if rank in task.ranks)
+        items = [
+            item
+            for item in plan.items
+            if _read_signature(item) not in drops[plan_rank]
+        ]
+        result.append(
+            dataclasses.replace(
+                plan,
+                items=items,
+                planner_data=_CooperativePlan(local_schedule, groups),
+            )
+        )
+    return result
+
+
+class CooperativeLoadPlanner(DefaultLoadPlanner):
+    """Deduplicate identical tensor reads and broadcast them to peer ranks.
+
+    The global planning step produces the only collective schedule. A tensor is
+    cooperative only when every peer reports an identical read request and
+    destination tensor metadata; all other reads retain default DCP behavior.
+
+    The planner and dcp.load must receive the same process group.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        process_group: dist.ProcessGroup | None = None,
+        min_tensor_bytes: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.process_group = process_group
+        self.min_tensor_bytes = min_tensor_bytes
+        self._schedule: tuple[_BroadcastTask, ...] = ()
+        self._groups: tuple[tuple[int, ...], ...] = ()
+
+    def _global_ranks(self) -> tuple[int, ...]:
+        if not dist.is_available() or not dist.is_initialized():
+            return (0,)
+        world_size = dist.get_world_size(self.process_group)
+        return tuple(
+            dist.get_global_rank(self.process_group, rank)
+            if self.process_group is not None
+            else rank
+            for rank in range(world_size)
+        )
+
+    def create_local_plan(self) -> LoadPlan:
+        plan = super().create_local_plan()
+        tensor_metadata = {}
+        for item in plan.items:
+            if item.type != LoadItemType.TENSOR:
+                continue
+            tensor = self.resolve_tensor(item)
+            tensor_metadata[_read_signature(item)] = (
+                tuple(tensor.shape),
+                str(tensor.dtype),
+                tensor.device.type,
+                tensor.numel() * tensor.element_size(),
+            )
+        return dataclasses.replace(plan, planner_data=tensor_metadata)
+
+    def create_global_plan(self, all_plans: list[LoadPlan]) -> list[LoadPlan]:
+        all_plans = super().create_global_plan(all_plans)
+        return _create_cooperative_plans(
+            all_plans,
+            self._global_ranks(),
+            self.min_tensor_bytes,
+        )
+
+    def finish_plan(self, new_plan: LoadPlan) -> LoadPlan:
+        plan = super().finish_plan(new_plan)
+        planner_data = cast(_CooperativePlan, plan.planner_data)
+        self._schedule = planner_data.schedule
+        self._groups = planner_data.groups
+        return plan
+
+    def finish_load(self) -> None:
+        if not self._schedule:
+            return
+
+        rank = dist.get_rank()
+        process_ranks = self._global_ranks()
+        groups: dict[tuple[int, ...], dist.ProcessGroup] = {}
+        created_groups = []
+
+        try:
+            for ranks in self._groups:
+                if rank not in ranks:
+                    continue
+                if ranks == process_ranks:
+                    group = self.process_group or dist.group.WORLD
+                else:
+                    group = dist.new_group(
+                        ranks=list(ranks),
+                        use_local_synchronization=True,
+                    )
+                    created_groups.append(group)
+                groups[ranks] = group
+
+            for task in self._schedule:
+                tensor = self.resolve_tensor(task.read_item)
+                buffer = tensor if tensor.is_contiguous() else tensor.contiguous()
+                dist.broadcast(buffer, src=task.src, group=groups[task.ranks])
+                if buffer is not tensor:
+                    tensor.copy_(buffer)
+        finally:
+            for group in reversed(created_groups):
+                dist.destroy_process_group(group)

--- a/torch/distributed/checkpoint/planner.py
+++ b/torch/distributed/checkpoint/planner.py
@@ -327,6 +327,9 @@ class LoadPlanner:
     5) resolve_tensor and commit_tensor - called multiple times on each rank
         They are called in pair for each Tensor value in state_dict.
 
+    6) finish_load - called on all ranks after storage reads complete.
+        This gives planners a synchronized post-read phase for globally planned work.
+
     Users are recommended to extend DefaultLoadPlanner instead of this interface directly as
     most changes can be expressed by changes in a single method.
 
@@ -448,3 +451,6 @@ class LoadPlanner:
 
         The contents of tensor will follow its device synchronization model.
         """
+
+    def finish_load(self) -> None:
+        """Run planner work that requires all storage reads to be complete."""

--- a/torch/distributed/checkpoint/state_dict_loader.py
+++ b/torch/distributed/checkpoint/state_dict_loader.py
@@ -316,6 +316,10 @@ def _load_state_dict(
         read_data()
         distW.barrier()
 
+    if planner is None:
+        raise AssertionError("planner is None")
+    planner.finish_load()
+
 
 def _load_state_dict_from_keys(
     keys: set[str] | str | None = None,


### PR DESCRIPTION
# [DCP] Add an opt-in cooperative load planner for replicated reads

## Summary

Adds `CooperativeLoadPlanner`, an **opt-in** `LoadPlanner` for Distributed Checkpoint load.

When several ranks request the **same** tensor read (typical `Replicate` / HSDP replicate dim), native DCP issues that read on every rank. This planner:

1. Deduplicates identical `ReadItem`s.
2. Assigns each unique item to one owner with deterministic byte balancing (largest-first, least-loaded rank; smaller global rank breaks ties).
3. Broadcasts the loaded tensor from the owner after storage reads complete.

This is **not** splitting one tensor into pieces. It assigns **whole unique logical items** to different owners. Unique bytes stay **1×**; non-owners drop the duplicate read and receive the tensor over the process group.

Default `dcp.load()` is unchanged. Callers must construct and pass this planner.

## Motivation

`create_default_global_load_plan` does not rewrite per-rank read plans. On cold or contended shared storage that becomes:

```text
N ranks × same logical bytes  →  N× storage bandwidth + N× metadata
```

Interconnect is usually faster than a shared filesystem. One native DCP read plus a collective fill is the cheaper path when replicas would otherwise all hit the same bytes.

The schedule is decided in **global planning**, not inferred from local `state_dict` iteration order. A read is cooperative only if every participant reports the same read identity **and** matching destination metadata; otherwise that item stays on the native path.

## Design

- **Read identity:** item type, dest FQN / chunk / offsets, storage FQN / chunk / offsets, lengths.
- **Destination gate:** shape, dtype, device type, and nbytes must match; ByteIO and mismatches stay native.
- **Owner assignment:** sort candidates by descending nbytes then stable identity; assign to the participant with the smallest accumulated bytes.
- **Schedule:** broadcast tasks sorted by read identity and stored in `LoadPlan.planner_data`.
- **Hook:** `LoadPlanner.finish_load()` is a default **no-op**. The loader calls it on all ranks after storage reads have been synchronized. Only this planner uses it.
- **Groups:** one process group per distinct participant set; WORLD / caller PG is reused when the set is the full group; created groups are destroyed in reverse order.
- **Backend:** `torch.distributed.broadcast` / `new_group` only. Works with whichever PG backend `dcp.load` already uses (NCCL, HCCL, Gloo). No device-specific code. Validated on HCCL (Ascend NPU); also compatible with NCCL (CUDA GPU).

The planner and `dcp.load` **must** receive the same process group.

```python
import torch.distributed as dist
import torch.distributed.checkpoint as dcp

planner = dcp.CooperativeLoadPlanner(process_group=dist.group.WORLD)
dcp.load(
    state_dict,
    checkpoint_id=path,
    planner=planner,
    process_group=dist.group.WORLD,
)
```

## Load flow

Native DCP load is unchanged through storage read. Cooperative work is two extra steps on the existing planner lifecycle: rewrite the global plan, then `broadcast` after every rank has finished reading.

```mermaid
flowchart TD
  A["1. set_up_planner"] --> B["2. create_local_plan<br/>native ReadItems"]
  B --> C{"CooperativeLoadPlanner?"}
  C -->|no| D["DefaultLoadPlanner<br/>local plan unchanged"]
  C -->|yes| E["Attach dest shape / dtype /<br/>device / nbytes to planner_data"]
  D --> F["3. create_global_plan"]
  E --> F
  F --> G{"Identical read identity<br/>and dest metadata<br/>on 2+ ranks?"}
  G -->|no| H["Keep native ReadItem<br/>on every requesting rank"]
  G -->|yes| I["Byte-balance one owner<br/>drop duplicate reads<br/>attach ordered broadcast schedule"]
  H --> J["4. finish_plan"]
  I --> J
  J --> K["5. StorageReader.read_data + wait<br/>unique bytes 1x for cooperative items"]
  K --> L["6. finish_load"]
  L --> M{"schedule empty?"}
  M -->|yes / default planner| N["no-op"]
  M -->|no| O["broadcast from owner<br/>on the same process group"]
```

```text
Native:      local plan → global plan → read N× identical bytes → done
Cooperative: local plan → global plan (dedupe + assign) → read 1× unique → broadcast
```

Default `dcp.load()` takes the left path. Passing `CooperativeLoadPlanner` takes the right path for matching items only; ByteIO and mismatches stay native.

## Invasiveness

This PR has low invasiveness: the algorithm lives in a new file `cooperative_planner.py`; the only changes to existing upstream files are a default no-op `finish_load()` hook and the corresponding call site. `DefaultLoadPlanner`, `StorageReader` / `FileSystemReader`, on-disk format, and metadata are untouched. Custom `LoadPlanner` subclasses inherit the no-op hook and do not need changes.

## Out of scope

- Changing default load behavior or adding env-var switches in PyTorch.
- Tensor slicing, packing, retry policy, or `torch_checkpointing`.

## Validated experiments

Date: 2026-08-18. Backend: Ascend NPU + **HCCL** + NFSv3. The five-file patch was applied onto vendor PyTorch DCP Python modules (not a CUDA NCCL CI run).

Pass bar for cooperative: planner selected, read-plan deduped, SHA256 matches native load, and (where measured) client NFS reads drop.

### Unit tests (in this PR)

| Test | Result |
|---|---|
| Dedup + byte-balanced owners; ranks may present local items in different order; schedules still identical | pass |
| Destination metadata mismatch keeps native reads; schedule empty | pass |

### 2-rank DCP smoke (HCCL)

One replicated tensor. Default planner vs `CooperativeLoadPlanner`. SHA256 vs seed.

| Size | default `sum(local_plan_items)` | cooperative | SHA256 |
|---|---:|---:|---|
| 1 MiB | 2 | **1** (rank0=1, rank1=0) | default = cooperative = seed |
| 64 MiB | 2 | **1** | same |

### Qwen3-0.6B load-only (2 NPU / HCCL)

Default planner vs opt-in `CooperativeLoadPlanner` on the same checkpoint.

| Check | Native load | Cooperative |
|---|---|---|
| Exit | 0 | 0 |
| Planner log | default | `Using PyTorch DCP CooperativeLoadPlanner` |
| `local_plan_items` | native FileSystemReader | rank0=**152**, rank1=**159** (split owners, not 2× full) |
| SHA256 vs native | — | pass, `mismatches=[]`, `n_ranks=2` |

Qwen is not a single-tensor replicate smoke, so plan items are not a strict 2→1. Eligible duplicate reads are still assigned across owners.

### 6-rank replicated NFS load (HCCL)

Same seed: 4×64 MiB unique = 256 MiB; world size 6, full replicate; cold `posix_fadvise`.

| Metric | Native | Cooperative |
|---|---|---|
| `sum(local_plan_items)` | **24** (6×4) | **4** (one owner per unique item; 2 ranks read 0) |
| SHA256 | 6 ranks agree | matches native |
| NFSv3 client `normal-read` | **1,686,289,794** B (~6×256 MiB) | **281,055,814** B (~1×256 MiB) |
| NFSv3 `server-read` (unique backing) | 268,443,267 B | 268,443,267 B |

Client NFS volume **~6× → 1×**, matching plan items 24→4. `server-read` stays one unique payload on a shared mount namespace and is **not** used as the dedupe metric.

**Claimed:** opt-in planner is selected, duplicate reads are dropped, load hashes match native, 6-rank NFS client reads fall to ~1/6.

**Not claimed:** trainer resume-one-step; NCCL/Gloo CI; scaling to 512+ ranks.

## Test plan (remaining)

- [ ] 2/4-rank Gloo and NCCL matrix (CI / CUDA).
- [ ] Non-contiguous destinations, process subgroups, injected mismatches under multi-process.

## Compatibility

Opt-in. Existing `dcp.load()` users see one extra no-op `finish_load()` after reads. Checkpoint bytes on disk do not change.
