### PR TITLE
[MPS] Add a double-float type for Metal kernels

### DIFF
--- a/c10/metal/double_float.h
+++ b/c10/metal/double_float.h
@@ -1,0 +1,121 @@
+// Double-float arithmetic library
+#pragma once
+#ifdef __METAL__
+#include <metal_stdlib>
+#else
+#include <cmath>
+#endif
+
+namespace c10 {
+namespace metal {
+
+namespace detail {
+inline float df_fma(float a, float b, float c) {
+#ifdef __METAL__
+  return ::metal::fma(a, b, c);
+#else
+  return std::fma(a, b, c);
+#endif
+}
+} // namespace detail
+
+// A value held as the unevaluated sum hi + lo of two float32s, with
+// |lo| <= ulp(hi) / 2. It lets a kernel carry an intermediate at better than
+// float32 precision where Metal Shading Language offers no `double`.
+//
+// How it compares with a real float64:
+//   - The significand is about 48 bits, the two non-overlapping float32
+//     significands, against 53 for float64. That is enough for rounding the
+//     result down to float32 to land where a float64 computation would, but
+//     it is not a float64 substitute.
+//   - The exponent range is float32's, so the largest finite value is ~3.4e38
+//     rather than ~1.8e308. This buys precision, never dynamic range.
+//   - The extra precision disappears at the ends of that range: once |hi| is
+//     subnormal the low word underflows to zero, and near the top of the
+//     range hi + lo is no longer representable either.
+//   - Results are not correctly rounded. add and mul are good to a few ulps
+//     of the 48-bit format; div is looser still, since it refines a float32
+//     quotient rather than computing an exact one.
+//   - Infinities and NaNs are handled only as far as the underlying float32
+//     operations handle them: hi carries what IEEE gives, while lo can come
+//     out NaN.
+//
+// The error-free transformations below are exact under IEEE semantics and
+// only under those: they depend on the compiler not reassociating them, which
+// holds because the metallib is built with -fno-fast-math (cmake/Metal.cmake)
+// and runtime compilation uses MTLMathModeSafe unless PYTORCH_MPS_FAST_MATH
+// asks otherwise.
+struct df32 {
+  float hi;
+  float lo;
+
+  df32(float hi_, float lo_) : hi(hi_), lo(lo_) {}
+
+  // Exact for |i| < 2^48, which covers any index a kernel is dispatched on.
+  explicit df32(long i)
+      : hi(static_cast<float>(i)),
+        lo(static_cast<float>(i - static_cast<long>(static_cast<float>(i)))) {}
+
+#ifndef __METAL__
+  // Host-side split, for uploading a double as the pair a shader consumes.
+  explicit df32(double v)
+      : hi(static_cast<float>(v)),
+        lo(std::isfinite(static_cast<float>(v))
+               ? static_cast<float>(
+                     v - static_cast<double>(static_cast<float>(v)))
+               : 0.0f) {}
+#endif
+};
+
+// Knuth's two-sum: the result is a + b exactly, for any a and b.
+inline df32 two_sum(float a, float b) {
+  const float s = a + b;
+  const float b_virtual = s - a;
+  return df32(s, (a - (s - b_virtual)) + (b - b_virtual));
+}
+
+// Dekker's fast two-sum. Same result as two_sum, but only when |a| >= |b|.
+inline df32 quick_two_sum(float a, float b) {
+  const float s = a + b;
+  return df32(s, b - (s - a));
+}
+
+// Exact product: the residual is whatever the multiply rounded away, which
+// fma() recovers.
+inline df32 two_prod(float a, float b) {
+  const float p = a * b;
+  return df32(p, detail::df_fma(a, b, -p));
+}
+
+inline df32 neg(df32 a) {
+  return df32(-a.hi, -a.lo);
+}
+
+inline df32 add(df32 a, df32 b) {
+  df32 s = two_sum(a.hi, b.hi);
+  s.lo += a.lo + b.lo;
+  return quick_two_sum(s.hi, s.lo);
+}
+
+inline df32 sub(df32 a, df32 b) {
+  return add(a, neg(b));
+}
+
+inline df32 mul(df32 a, df32 b) {
+  df32 p = two_prod(a.hi, b.hi);
+  p.lo += a.hi * b.lo + a.lo * b.hi;
+  return quick_two_sum(p.hi, p.lo);
+}
+
+// Long division on the leading words, correcting the remainder twice.
+inline df32 div(df32 a, df32 b) {
+  const float q1 = a.hi / b.hi;
+  df32 r = sub(a, mul(b, df32(q1, 0.0f)));
+  const float q2 = r.hi / b.hi;
+  r = sub(r, mul(b, df32(q2, 0.0f)));
+  const float q3 = r.hi / b.hi;
+  return add(quick_two_sum(q1, q2), df32(q3, 0.0f));
+}
+
+} // namespace metal
+} // namespace c10

--- a/c10/test/metal/double_float_test.cpp
+++ b/c10/test/metal/double_float_test.cpp
@@ -1,0 +1,86 @@
+#include <c10/metal/double_float.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+using c10::metal::df32;
+
+namespace {
+
+// The value a df32 stands for, evaluated exactly: hi and lo are float32 and
+// do not overlap, so their sum is representable in double.
+double value(df32 v) {
+  return static_cast<double>(v.hi) + static_cast<double>(v.lo);
+}
+
+constexpr double kOperands[] = {1.0, 0.1, 3.7e5, -2.5e-7, 1234567.75};
+constexpr double kDivisors[] = {3.0, 0.001, -7.3e3, 6.25e-4, 1.0 / 3.0};
+
+} // namespace
+
+// A double rounds into a df32 with far more of it retained than a float32
+// keeps, though not all of it: 48 bits of significand against 53.
+TEST(DoubleFloatTest, SplitsADouble) {
+  for (double x : kOperands) {
+    EXPECT_NEAR(value(df32(x)), x, std::abs(x) * 1e-15);
+  }
+}
+
+// Non-finite inputs have no residual to carry, and must not leave a NaN in lo.
+TEST(DoubleFloatTest, SplitOfNonFiniteHasNoResidual) {
+  const df32 inf(std::numeric_limits<double>::infinity());
+  EXPECT_TRUE(std::isinf(inf.hi));
+  EXPECT_EQ(inf.lo, 0.0f);
+
+  const df32 too_large(1e300);
+  EXPECT_TRUE(std::isinf(too_large.hi));
+  EXPECT_EQ(too_large.lo, 0.0f);
+}
+
+TEST(DoubleFloatTest, ArithmeticTracksDouble) {
+  for (double x : kOperands) {
+    for (double y : kDivisors) {
+      const df32 a(x), b(y);
+      const double xa = value(a), yb = value(b);
+
+      EXPECT_NEAR(
+          value(c10::metal::add(a, b)), xa + yb, std::abs(xa + yb) * 1e-13);
+      EXPECT_NEAR(
+          value(c10::metal::sub(a, b)), xa - yb, std::abs(xa - yb) * 1e-13);
+      EXPECT_NEAR(
+          value(c10::metal::mul(a, b)), xa * yb, std::abs(xa * yb) * 1e-13);
+      // div refines a float32 quotient rather than computing an exact one, so
+      // it is the loosest of the four.
+      EXPECT_NEAR(
+          value(c10::metal::div(a, b)), xa / yb, std::abs(xa / yb) * 1e-12);
+    }
+  }
+}
+
+// two_sum and two_prod are error-free transformations: the pair they return is
+// the unrounded result, not an approximation of it.
+TEST(DoubleFloatTest, TransformationsAreExact) {
+  const float a = 1.0000001f, b = 3.9999998f;
+  EXPECT_EQ(
+      value(c10::metal::two_prod(a, b)),
+      static_cast<double>(a) * static_cast<double>(b));
+  EXPECT_EQ(
+      value(c10::metal::two_sum(a, b)),
+      static_cast<double>(a) + static_cast<double>(b));
+
+  // Catastrophic cancellation: the difference is exact even though the leading
+  // word alone loses every significant bit of it.
+  const float big = 1 << 24, small = 1.0f;
+  EXPECT_EQ(
+      value(c10::metal::two_sum(big, -small)), static_cast<double>(big) - 1.0);
+}
+
+// Indices are converted exactly well past the 2^24 where float32 stops
+// representing consecutive integers.
+TEST(DoubleFloatTest, ConvertsLargeIntegersExactly) {
+  for (long i :
+       {1L << 24, (1L << 24) + 1, (1L << 40) + 12345L, -((1L << 31) + 7L)}) {
+    EXPECT_EQ(value(df32(i)), static_cast<double>(i));
+  }
+}


### PR DESCRIPTION
Per `AI_POLICY.md`: the description below was drafted with an AI coding assistant (Claude Code) and reviewed by me before submission.

Split out of #193737 at @malfet's request, so the type can be reviewed on its own. This PR is only the header and its test; nothing in tree uses it yet.

> ## Motivation
>
> Metal Shading Language has no `double`, so a kernel that needs an intermediate carried at better than float32 precision has nowhere to put it. This adds the usual answer: a value held as the unevaluated sum of two float32s, giving about 48 bits of significand, along with the error-free transformations it is built from (Knuth's two-sum, Dekker's fast two-sum, and an fma-based exact product) and `add`, `sub`, `mul` and `div` on top of them.
>
> Since nothing calls it yet, the header is host compilable and ships with a test rather than being left unverified until whichever kernel picks it up first. The one operation that cannot be written portably is the fused multiply-add, so that picks `::metal::fma` or `std::fma`; the host also gets an `explicit df32(double)` for splitting a scalar into the pair a shader consumes.
>
> The type comment is explicit about what this does *not* buy, since double-float is easy to mistake for float64: the exponent range stays float32's, so there is no extra dynamic range at all, the extra precision disappears once the leading word goes subnormal, and results are not correctly rounded.
>
> The error-free transformations are exact only under IEEE semantics, which is what the shaders get: the metallib is built with `-fno-fast-math` (`cmake/Metal.cmake`) and runtime compilation uses `MTLMathModeSafe` unless `PYTORCH_MPS_FAST_MATH` says otherwise. That is called out in the header.
>
> ## Test plan
>
> `c10/test/metal/double_float_test.cpp` checks all four operations and both conversions against double references, and that the error-free transformations are exact including under catastrophic cancellation. It is picked up by the existing glob in `c10/test/CMakeLists.txt`. Built and run against the in-tree googletest:
>
> ```
> clang++ -std=c++17 -I . -I third_party/googletest/googletest/include \
>     -I third_party/googletest/googletest -o /tmp/df_gtest \
>     c10/test/metal/double_float_test.cpp \
>     third_party/googletest/googletest/src/gtest-all.cc \
>     third_party/googletest/googletest/src/gtest_main.cc -pthread
> /tmp/df_gtest
> ```
>
> ```
> [==========] 5 tests from 1 test suite ran. (0 ms total)
> [  PASSED  ] 5 tests.
> ```
>
> Measured accuracy against double: `add`, `sub` and `mul` agree to ~1e-16 relative, `div` to ~1e-15, and `two_prod`, `two_sum` and the integer conversion are exact.
