### PR TITLE
Validate that LSTM hidden and cell states have the same number of layers

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1170,6 +1170,9 @@ std::tuple<io_type, Tensor, Tensor> _lstm_impl(
       const io_type& input,
       const std::vector<cell_params>& params, const Tensor& hx, const Tensor& cx,
       int64_t num_layers, double dropout_p, bool train, bool bidirectional) {
+  TORCH_CHECK(hx.size(0) == cx.size(0),
+      "Expected hidden state h_0 and cell state c_0 to have the same size at dim 0, but got ",
+      hx.size(0), " and ", cx.size(0));
   // It's much more useful for us to work on lists of pairs of hx and cx for each layer, so we need
   // to transpose a pair of those tensors.
   auto layer_hx = hx.unbind(0);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3442,6 +3442,33 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         hidden_c_shape = update_shape(correct_hidden_c_shape, 0, bad_size)
         test(input_shape, hidden_h_shape, hidden_c_shape)
 
+    def test_lstm_hidden_state_layer_mismatch(self):
+        # float64 keeps this on the native path: oneDNN claims CPU LSTM for
+        # float32, bfloat16 and float16 and returns before _lstm_impl runs.
+        dtype = torch.float64
+        hidden_size = 8
+        num_layers = 3
+        params = [torch.randn(4 * hidden_size, hidden_size, dtype=dtype),
+                  torch.randn(4 * hidden_size, hidden_size, dtype=dtype)] * num_layers
+        hx = torch.randn(num_layers + 1, 2, hidden_size, dtype=dtype)
+        cx = torch.randn(num_layers, 2, hidden_size, dtype=dtype)
+
+        input = torch.randn(5, 2, hidden_size, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, "same size at dim 0"):
+            torch.ops.aten.lstm.input(input, [hx, cx], params, False, num_layers,
+                                      0.0, False, False, False)
+
+        data = torch.randn(10, hidden_size, dtype=dtype)
+        batch_sizes = torch.tensor([10], dtype=torch.int64)
+        with self.assertRaisesRegex(RuntimeError, "same size at dim 0"):
+            torch.ops.aten.lstm.data(data, batch_sizes, [hx, cx], params, False,
+                                     num_layers, 0.0, False, False)
+
+        # The longer cell state was previously dropped without an error.
+        with self.assertRaisesRegex(RuntimeError, "same size at dim 0"):
+            torch.ops.aten.lstm.input(input, [cx, hx], params, False, num_layers,
+                                      0.0, False, False, False)
+
     def test_rnn_initial_hidden_state(self):
         rnn_modes = ['RNN', 'GRU', 'LSTM']
         for mode in rnn_modes:


### PR DESCRIPTION
Fixes #173946

## Root cause

`_lstm_impl` in `aten/src/ATen/native/RNN.cpp` unbinds `hx` and `cx` into
per-layer lists, but it derives the layer count from `hx` alone, then uses that
count to index into the `cx` list:

```cpp
auto layer_hx = hx.unbind(0);
auto layer_cx = cx.unbind(0);
int64_t total_layers = layer_hx.size();
...
hiddens.emplace_back(std::move(layer_hx[i]), std::move(layer_cx[i]));
```

When `cx` has fewer layers than `hx`, `layer_cx[i]` reads past the end of a
`std::vector`. That is undefined behaviour, and it is the root cause of both
the segfault and the "double free or corruption" reported in the issue.

The other direction was wrong too, more quietly: when `cx` had more layers than
`hx`, the extra cell states were dropped and the call returned a result with no
error at all.

Nothing upstream of this catches it. `check_attributes` in `RNN.h` compares
device and dtype, never shape.

## Fix

One `TORCH_CHECK` before the unbind. It sits in `_lstm_impl`, so it covers all
four call sites (`lstm`, `lstm.data`, and the two quantized variants) in one
place.

I used `size(0)` rather than `sym_size(0)` deliberately. `unbind(0)` already
specializes on dim 0, so this adds no new dynamic shape guard.

## Scope

Three adjacent checks are already covered elsewhere, so this PR does not add
them:

- layer count against `num_layers`: RNN.cpp:1116 already raises "Expected more
  hidden states in stacked_rnn". It could not fire before, because the
  out-of-bounds read happened first.
- hidden size against the weights: already raises from matmul.
- `hx.dim() == 3`: already guarded at all four call sites, which read
  `hx[0].size(2)` before calling `_lstm_impl`.

## Not fixed here

- On CPU float32, oneDNN claims the op before `_lstm_impl` runs, so mismatched
  shapes still return silently wrong output on that path. This is a separate
  bug and I have not touched it.
- `torch/_decomp/decompositions.py` registers `aten.lstm.input` and
  `aten.lstm.data` for compile and export, so those paths do not carry this
  check. Eager and compiled therefore diverge on invalid input.

## Test Plan

Reproducing the crash on the unpatched build. float64 matters here: on CPU
float32 oneDNN takes the op and `_lstm_impl` never runs.

```python
import torch
H = 8
params = [torch.randn(4 * H, H, dtype=torch.float64),
          torch.randn(4 * H, H, dtype=torch.float64)] * 3
hx = torch.randn(4, 2, H, dtype=torch.float64)
cx = torch.randn(3, 2, H, dtype=torch.float64)
torch.ops.aten.lstm.input(torch.randn(5, 2, H, dtype=torch.float64),
                          [hx, cx], params, False, 3, 0.0, False, False, False)
```

```
before the fix: Segmentation fault, exit 139
after the fix:  RuntimeError: Expected hidden state h_0 and cell state c_0 to
                have the same size at dim 0, but got 4 and 3
```

The new regression test, run against the unpatched build first:

```
python test/test_nn.py -k test_lstm_hidden_state_layer_mismatch
```

```
before the fix: Segmentation fault, exit 139
after the fix:  Ran 1 test in 0.056s -- OK
```

The test asserts the raised message rather than the absence of a crash, because
unpatched `aten.lstm` returns silently on some platforms instead of faulting.

```
python test/test_nn.py -k lstm
```

```
Ran 9 tests in 0.175s -- OK (skipped=3)
```

I could not get a clean local baseline for the wider sweeps on this machine
(Windows, built without cuDNN, `fbgemm` unavailable so the only quantized engine
is `onednn`). `test_nn.py -k LSTM` has one failure and the quantized LSTM tests
have two failures and one error, all of them numerical or backend availability
problems that the new check cannot produce: it never fired in any of those runs,
and a `TORCH_CHECK` that does not fire cannot change a numeric result.
`test/nn/test_packed_sequence.py` is unstable on this box across runs, and it
never constructs an LSTM, so it does not touch this code path. I am relying on
CI for those.

_This PR was drafted with the help of an AI coding assistant and reviewed by me
before submitting._
