### PR TITLE
[TEST] Add hw_classification to custom backend and operator tests

### DIFF
--- a/test/custom_backend/test_custom_backend.py
+++ b/test/custom_backend/test_custom_backend.py
@@ -5,10 +5,16 @@ import tempfile
 from backend import get_custom_backend_library_path, Model, to_custom_backend
 
 import torch
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestCustomBackend(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Load the library containing the custom backend.

--- a/test/custom_operator/test_custom_ops.py
+++ b/test/custom_operator/test_custom_ops.py
@@ -9,13 +9,20 @@ from model import get_custom_op_library_path, Model
 import torch
 import torch._library.utils as utils
 from torch import ops
-from torch.testing._internal.common_utils import IS_WINDOWS, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_WINDOWS,
+    run_tests,
+    TestCase,
+)
 
 
 torch.ops.import_module("pointwise")
 
 
 class TestCustomOperators(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.library_path = get_custom_op_library_path()

--- a/test/custom_operator/test_infer_schema_annotation.py
+++ b/test/custom_operator/test_infer_schema_annotation.py
@@ -6,7 +6,12 @@ import unittest
 
 import torch
 from torch import Tensor, types
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 if typing.TYPE_CHECKING:
@@ -18,6 +23,8 @@ mutates_args = {}
 
 @skipIfTorchDynamo("custom operator tests not applicable to dynamo")
 class TestInferSchemaWithAnnotation(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_tensor(self):
         def foo_op(x: torch.Tensor) -> torch.Tensor:
             return x.clone()

--- a/test/custom_operator/test_inplace_tag.py
+++ b/test/custom_operator/test_inplace_tag.py
@@ -4,6 +4,7 @@ from torch import Tensor
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._library.utils import is_inplace
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -31,6 +32,8 @@ _test_lib.impl("add_", lambda self_, other: self_, "Meta")
 
 @skipIfTorchDynamo("custom operator tests not applicable to dynamo")
 class TestInplaceTag(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.lib = torch.library.Library("_TestInplaceTag", "FRAGMENT")  # noqa: SCOPED_LIBRARY

--- a/test/custom_operator/test_out_variant.py
+++ b/test/custom_operator/test_out_variant.py
@@ -5,6 +5,7 @@ from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._library._out_variant import check_out_variant, to_out_variant
 from torch._library.utils import is_out
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -48,6 +49,8 @@ _test_lib.impl("add_mul.out", _add_mul_out_impl, "CompositeExplicitAutograd")
 
 @skipIfTorchDynamo("custom operator tests not applicable to dynamo")
 class TestOutVariant(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.lib = torch.library.Library("_TestOutVariant", "FRAGMENT")  # noqa: SCOPED_LIBRARY


### PR DESCRIPTION
## Summary

Apply hardware classification to custom backend and custom operator tests following #186918 guidelines.

**`test/custom_backend/test_custom_backend.py`**
- **TestCustomBackend**: `GENERIC` (custom backend extension tests)

**`test/custom_operator/test_custom_ops.py`**
- **TestCustomOperators**: `GENERIC` (custom op library loading and execution)

**`test/custom_operator/test_infer_schema_annotation.py`**
- **TestInferSchemaWithAnnotation**: `GENERIC` (schema inference from type annotations)

**`test/custom_operator/test_inplace_tag.py`**
- **TestInplaceTag**: `GENERIC` (in-place custom op tagging)

**`test/custom_operator/test_out_variant.py`**
- **TestOutVariant**: `GENERIC` (out-variant custom op tests)

## Test plan

```
lintrunner -a test/custom_backend/test_custom_backend.py test/custom_operator/test_custom_ops.py test/custom_operator/test_infer_schema_annotation.py test/custom_operator/test_inplace_tag.py test/custom_operator/test_out_variant.py
# ok No lint issues.

python test/custom_backend/test_custom_backend.py --hw-classification GENERIC -v
python test/custom_operator/test_custom_ops.py --hw-classification GENERIC -v
python test/custom_operator/test_infer_schema_annotation.py --hw-classification GENERIC -v
python test/custom_operator/test_inplace_tag.py --hw-classification GENERIC -v
python test/custom_operator/test_out_variant.py --hw-classification GENERIC -v
```

> Authored with an AI assistant.