### PR TITLE
[Testcase Refactoring] Classify device-agnostic test classes for test_block_analysis.py

### DIFF
--- a/test/inductor/test_block_analysis.py
+++ b/test/inductor/test_block_analysis.py
@@ -7,6 +7,7 @@ from torch._inductor.codegen.block_analysis import BlockPatternMatcher
 from torch._inductor.utils import sympy_dot
 from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -22,6 +23,8 @@ x, y = sympy.symbols("x y")
 
 @instantiate_parametrized_tests
 class BlockAnalysisTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
## Summary
This PR hardware classify device-agnostic test classes.

## Changes
- Add `HardwareClassification.GENERIC` to these device-generic tests class.

## Motivation
Classify device-specific and device-agnostic test classes.

## Test Plan
- CI: `python test/inductor/test_block_analysis.py --hw-classification GENERIC`
- Verified test cases correctly on CPU, GPU, XPU and MPS.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo