### PR TITLE
[Testcase Refactoring] Classify device-agnostic test classes for test_block_ptr_store_dtype.py

### DIFF
--- a/test/inductor/test_block_ptr_store_dtype.py
+++ b/test/inductor/test_block_ptr_store_dtype.py
@@ -18,6 +18,7 @@ import torch
 from torch._inductor.codegen.common import InplacedBuffer, REMOVED
 from torch._inductor.codegen.triton import triton_store_type
 from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestBlockPtrStoreDtype(TestCase):
@@ -32,6 +33,8 @@ class TestBlockPtrStoreDtype(TestCase):
                 store_dtype = V.graph.get_dtype(buf.other_names[0])
         value = f"{value}.to({triton_store_type(store_dtype)})"
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @staticmethod
     def _resolve_store_dtype(name, inplace_buffers, get_dtype):


### PR DESCRIPTION
## Summary
This PR hardware classify device-agnostic test classes.

## Changes
- Add `HardwareClassification.GENERIC` to these device-generic tests class.

## Motivation
Classify device-specific and device-agnostic test classes.

## Test Plan
- CI: `python test/inductor/test_block_ptr_store_dtype.py --hw-classification GENERIC`
- Verified test cases correctly on CPU, GPU, XPU and MPS.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo