### PR TITLE
[Testcase Refactoring] Classify device-agnostic test classes for test_cache_dir_utils.py

### DIFF
--- a/test/inductor/test_cache_dir_utils.py
+++ b/test/inductor/test_cache_dir_utils.py
@@ -7,9 +7,12 @@ from unittest import mock
 
 from torch._inductor.runtime import cache_dir_utils
 from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import HardwareClassification
 
 
 class TestCacheDirUtils(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_cache_dir_resolves_relative_env(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             old_cwd = os.getcwd()


### PR DESCRIPTION
## Summary
This PR hardware classify device-agnostic test classes.

## Changes
- Add `HardwareClassification.GENERIC` to these device-generic tests class.

## Motivation
Classify device-specific and device-agnostic test classes.

## Test Plan
- CI: `python test/inductor/test_cache_dir_utils.py --hw-classification GENERIC`
- Verified test cases correctly on CPU, GPU, XPU and MPS.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo