### PR TITLE
Preserve device context in reentrant checkpoint recomputation

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -12140,6 +12140,21 @@ for shape in [(1,), ()]:
 
         b.backward()
 
+    def test_reentrant_checkpoint_preserves_device_context(self):
+        devices = []
+
+        def fn(x):
+            devices.append(torch.empty(1).device.type)
+            return x.sin()
+
+        x = torch.randn(4, requires_grad=True)
+        with torch.device("meta"):
+            y = checkpoint(fn, x, use_reentrant=True)
+
+        self.assertEqual(devices, ["meta"])
+        y.sum().backward()
+        self.assertEqual(devices, ["meta", "meta"])
+
     def test_save_on_cpu_and_checkpoint(self):
         a = torch.randn(2, 2, requires_grad=True)
 

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -242,6 +242,19 @@ class CheckpointFunction(torch.autograd.Function):
         check_backward_validity(args)
         ctx.run_function = run_function
         ctx.preserve_rng_state = preserve_rng_state
+
+        from torch.overrides import _get_current_function_mode_stack
+        from torch.utils._device import DeviceContext
+
+        ctx.device_context_device = next(
+            (
+                mode.device
+                for mode in reversed(_get_current_function_mode_stack())
+                if isinstance(mode, DeviceContext)
+            ),
+            None,
+        )
+
         # Accommodates the (remote) possibility that autocast is enabled for cpu AND gpu.
         ctx.device_type = _infer_device_type(*args)
         ctx.device_autocast_kwargs, ctx.cpu_autocast_kwargs = _get_autocast_kwargs(
@@ -314,7 +327,21 @@ class CheckpointFunction(torch.autograd.Function):
             device_autocast_ctx = torch.amp.autocast(
                 device_type=ctx.device_type, **ctx.device_autocast_kwargs
             ) if torch.amp.is_autocast_available(ctx.device_type) else contextlib.nullcontext()
-            with torch.enable_grad(), device_autocast_ctx, torch.amp.autocast("cpu", **ctx.cpu_autocast_kwargs):  # type: ignore[attr-defined]
+
+            from torch.utils._device import DeviceContext
+
+            device_ctx = (
+                DeviceContext(ctx.device_context_device)
+                if ctx.device_context_device is not None
+                else contextlib.nullcontext()
+            )
+
+            with (
+                torch.enable_grad(),
+                device_autocast_ctx,
+                torch.amp.autocast("cpu", **ctx.cpu_autocast_kwargs),
+                device_ctx,
+            ):  # type: ignore[attr-defined]
                 outputs = ctx.run_function(*detached_inputs)
 
         if isinstance(outputs, torch.Tensor):


### PR DESCRIPTION
Fixes #124788.

Reentrant activation checkpointing recomputes the wrapped function during backward, but unlike the non-reentrant implementation it did not restore the `torch.device(...)` context that was active during the original forward. As a result, device-less tensor constructors could fall back to CPU during recomputation.

This change captures the active `DeviceContext` device in `CheckpointFunction.forward` and enters a fresh `DeviceContext` around the recomputation in `CheckpointFunction.backward`. A fresh context is used rather than re-entering the original mode instance, matching the approach used by the non-reentrant checkpoint path.

The regression test uses the `meta` device so it does not require accelerator hardware and verifies that a device-less tensor constructor observes `meta` in both the original forward and the reentrant recomputation.