### PR TITLE
[Testcase Refactoring] Modification of parameter type for passing arguments.

### DIFF
--- a/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
+++ b/test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
@@ -1800,7 +1800,7 @@ class IntegrationTest(TestCase):
         handler2 = self._create_handler(
             min_nodes=1,
             max_nodes=2,
-            keep_alive_interval=timedelta(seconds=1),
+            keep_alive_interval=1,
         )
         handler3 = self._create_handler(
             min_nodes=1,


### PR DESCRIPTION
Summary:
•	When running pytest dynamic_rendezvous_test.py, an error occurred: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'datetime.timedelta'
•	Modified test/distributed/elastic/rendezvous/dynamic_rendezvous_test.py
from ‘keep_alive_interval=timedelta(seconds=1) ‘to ‘keep_alive_interval=1’.
