### PR TITLE
[profiler] Stop OVERHEAD activities from claiming device time

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3012,6 +3012,33 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
                 "Error: No kernel events in trace contained grid/block metadata",
             )
 
+    @onlyAccelerator
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    def test_overhead_activities_own_no_device_time(self, device):
+        """
+        OVERHEAD events (profiler-internal host cost) must report zero device time
+        """
+        device_type = device.split(":")[0]
+        # Skip warm-up: the first traced launches are the ones that emit overhead records.
+        with profile(activities=get_profiler_activities(device_type)) as prof:
+            self.payload(device=device)
+
+        events = prof.events()
+        total_device_time = sum(
+            e.self_device_time_total for e in events if e.device_type != DeviceType.CPU
+        )
+
+        for e in events:
+            if e.activity_type == "overhead":
+                self.assertEqual(e.self_device_time_total, 0)
+                self.assertEqual(e.device_time_total, 0)
+
+            # No single row may own more device time than the whole trace spent on device.
+            self.assertLessEqual(
+                e.self_device_time_total,
+                total_device_time,
+            )
+
 
 instantiate_device_type_tests(TestProfilerDevice, globals())
 

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3028,12 +3028,16 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
             e.self_device_time_total for e in events if e.device_type != DeviceType.CPU
         )
 
-        for e in events:
-            if e.activity_type == "overhead":
-                self.assertEqual(e.self_device_time_total, 0)
-                self.assertEqual(e.device_time_total, 0)
+        overhead_events = [e for e in events if e.activity_type == "overhead"]
+        self.assertGreater(
+            len(overhead_events), 0, "Expected at least one overhead event"
+        )
+        for e in overhead_events:
+            self.assertEqual(e.self_device_time_total, 0)
+            self.assertEqual(e.device_time_total, 0)
 
-            # No single row may own more device time than the whole trace spent on device.
+        # No single row may own more device time than the whole trace spent on device.
+        for e in events:
             self.assertLessEqual(
                 e.self_device_time_total,
                 total_device_time,

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -3013,6 +3013,7 @@ if KinetoStepTracker.current_step() != initial_step + 2 * niters:
             )
 
     @onlyAccelerator
+    @skipIfRocm(msg="ROCm does not emit OVERHEAD activity records")
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     def test_overhead_activities_own_no_device_time(self, device):
         """

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -770,7 +770,10 @@ class profile:
                     device_corr_map[corr_id] = []
                 device_corr_map[corr_id].append(fe)
             elif corr_id == 0:
-                frontend_function_events.append(fe)
+                # Skip OVERHEAD events (profiler-internal host cost):
+                # they do no device work and would otherwise inflate reported device time.
+                if fe.activity_type != "overhead":
+                    frontend_function_events.append(fe)
             else:
                 raise RuntimeError(
                     f"Got negative correlation id {corr_id} in profiler post processing"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #193924

# Motivation
Originated from https://github.com/pytorch/pytorch/pull/193392 (@aostrowski-hbn takes AL)
Co-author: @aostrowski-hbn

https://github.com/pytorch/pytorch/pull/176351 introduces `OVERHEAD` activities for CUDA, and https://github.com/pytorch/pytorch/pull/187835 introduced them for XPU. However, this causes a regression where host-side OVERHEAD activities (e.g., CUDA "Lazy Function Loading" and XPU "Instrumentation") are incorrectly counted as **device total time**.

OVERHEAD activities inherit the correlation ID of the enclosing operator. As a result, `parse_kineto_results()` associates the operator's device kernels with each OVERHEAD record, causing device total time to be counted multiple times. This is particularly severe on XPU, where hundreds of overhead records can be generated during a kernel launch. On CUDA, only a few records are typically generated, so the issue has gone largely unnoticed until now.

# Additional Context
fix https://github.com/intel/torch-xpu-ops/issues/4824

Mini reproducer:
```python
import torch

acc = torch.accelerator.current_accelerator().type
input1 = torch.randn(3, 3, device=0)
input2 = torch.randn(3, 3, device=0)

with torch.profiler.profile(
    activities=[
        torch.profiler.ProfilerActivity.CPU,
        getattr(torch.profiler.ProfilerActivity, acc.upper()),
    ]
) as prof:
    output1 = input1 + 1.0
    output2 = input2 + 2.0
    output = output1 + output2
print(prof.key_averages().table(sort_by=f"{acc}_time_total"))
```

Find OVERHEAD "Lazy Function Loading" on CUDA
<img width="1476" height="261" alt="image" src="https://github.com/user-attachments/assets/177f3a88-6a1a-4e24-af91-3dd861d5744f" />

With this fix on **CUDA total time**: 37.696us -> 13.312us
<img width="1472" height="279" alt="image" src="https://github.com/user-attachments/assets/51af2d7b-a71f-4164-b4d9-780129851217" />

Find OVERHEAD "Instrumentation" ON XPU:
<img width="1376" height="425" alt="image" src="https://github.com/user-attachments/assets/eec1e103-2e75-4d48-8b5e-5625d69ec5d5" />

With this fix on **XPU total time**: 2.435ms -> 17.600us
<img width="1381" height="427" alt="image" src="https://github.com/user-attachments/assets/8263c7d4-aa96-4a3c-9e6f-fcbd086e7169" />

