### PR TITLE
Add RBLN-SW/torch-rbln to CRCR allowlist as L1

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -42,6 +42,7 @@ L1:
   - NVIDIA/pytorch-windows-ci
   - google-pytorch/torch_tpu
   - Isalia20/pytorch-mps-ci
+  - RBLN-SW/torch-rbln
 
 L2:
   - TorchedHat/pytorch-redhat-ci


### PR DESCRIPTION
Following the CRCR onboarding guide, I propose to add [RBLN-SW/torch-rbln](https://github.com/RBLN-SW/torch-rbln) as L1 to the CRCR allowlist. torch-rbln is the PrivateUse1-based backend for Rebellions NPUs, and we are actively working on it.