### PR TITLE
[ROCm] c10/cuda cleanup

### DIFF
--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -304,7 +304,7 @@ struct SegmentRange {
   SegmentRange(void* p, size_t s) : ptr(static_cast<char*>(p)), size(s) {}
 };
 
-#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED) || \
+#if (!defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)) || \
     defined(USE_ROCM)
 
 /*
@@ -548,12 +548,16 @@ struct ExpandableSegment {
       prop.location.id = static_cast<int>(device_);
 #ifdef USE_ROCM
       auto status = hipMemCreate(&handle, segment_size_, &prop, 0);
+      constexpr auto kMemCreateOk = hipSuccess;
+      constexpr auto kMemCreateOom = hipErrorOutOfMemory;
 #else
       auto status =
           DriverAPI::get()->cuMemCreate_(&handle, segment_size_, &prop, 0);
+      constexpr auto kMemCreateOk = CUDA_SUCCESS;
+      constexpr auto kMemCreateOom = CUDA_ERROR_OUT_OF_MEMORY;
 #endif
-      if (status != CUDA_SUCCESS) {
-        if (status == CUDA_ERROR_OUT_OF_MEMORY) {
+      if (status != kMemCreateOk) {
+        if (status == kMemCreateOom) {
           {
             size_t device_free = 0;
             size_t device_total = 0;
@@ -768,7 +772,7 @@ struct ExpandableSegment {
         void* myfd_handle =
             reinterpret_cast<void*>(static_cast<uintptr_t>(myfd));
 #else
-        void* myfd_handle = (void*)(uintptr_t)&myfd;
+        void* myfd_handle = static_cast<void*>(&myfd);
 #endif
         C10_CUDA_CHECK(hipMemImportFromShareableHandle(
             &handle, myfd_handle, hipMemHandleTypePosixFileDescriptor));

--- a/c10/cuda/CUDAFunctions.h
+++ b/c10/cuda/CUDAFunctions.h
@@ -90,7 +90,7 @@ C10_CUDA_API void __inline__ memcpy_and_sync(
     (*interp)->trace_gpu_stream_synchronization(
         c10::kCUDA, reinterpret_cast<uintptr_t>(stream));
   }
-#if defined(USE_ROCM) && USE_ROCM
+#if defined(USE_ROCM)
 #if ROCM_VERSION < 71400
   // As of ROCm 6.4.1-7.13.x, HIP runtime does not raise an error during capture
   // of hipMemcpyWithStream which is a synchronous call. Thus, we add a check

--- a/c10/cuda/CUDAStream.h
+++ b/c10/cuda/CUDAStream.h
@@ -19,10 +19,9 @@
  * The first pool contains only the default stream. When the default stream
  * is requested it's returned.
  *
- * The second pool is the "low priority" or "default priority" streams. In
- * HIP builds there is no distinction between streams in this pool and streams
- * in the third pool (below). There are 32 of these streams per device, and
- * when a stream is requested one of these streams is returned round-robin.
+ * The second pool is the "low priority" or "default priority" streams. There
+ * are 32 of these streams per device, and when a stream is requested one of
+ * these streams is returned round-robin.
  * That is, the first stream requested is at index 0, the second at index 1...
  * to index 31, then index 0 again.
  *

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -295,7 +295,7 @@ std::string get_nvml_fabric_info([[maybe_unused]] c10::DeviceIndex dev) {
 #endif
   return std::move(oss).str();
 #else
-  return "fabric info unsupported (requires CUDA >= 12.4)";
+  return "fabric info unsupported on this platform";
 #endif
 }
 


### PR DESCRIPTION
Check hipMemCreate against hipSuccess/hipErrorOutOfMemory instead of the CUDA CUresult constants that only coincidentally match today. The rest is consistency cleanup: macro guard, cast, parens, stale comment, error string.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
