### PR TITLE
[Testcase Refactoring] Add hw-classification in launcher_api_test

### DIFF
--- a/test/distributed/launcher/api_test.py
+++ b/test/distributed/launcher/api_test.py
@@ -34,6 +34,7 @@ from torch.distributed.launcher.api import (
     LaunchConfig,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
 )
@@ -121,6 +122,8 @@ def short_hash():
 
 
 class ElasticLaunchTest(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         # start a standalone, single process etcd server to use for all tests.


### PR DESCRIPTION
## Summary

Tags `ElasticLaunchTest` in `test/distributed/launcher/api_test.py` with
`hw_classification = HardwareClassification.GENERIC` so the class can be
selected by the `--hw-classification` test filter. The class subclasses
`unittest.TestCase` and exercises CPU-only `elastic_launch`/`launch_agent`
behavior via etcd rendezvous, mocks, and `dist.init_process_group(backend="gloo")`,
with no device parameter and no `instantiate_device_type_tests`, so `GENERIC`
is the correct category.

## Changes

- `test/distributed/launcher/api_test.py`: added `HardwareClassification`
  to the existing `torch.testing._internal.common_utils` multi-line import
  block, in alphabetical position before `skip_but_pass_in_sandcastle_if`
  and `TEST_WITH_DEV_DBG_ASAN`.
- `test/distributed/launcher/api_test.py`: declared
  `hw_classification = HardwareClassification.GENERIC` as a class attribute
  on `ElasticLaunchTest`, placed immediately after the class header and
  before the `setUpClass` classmethod.


## Motivation

PyTorch's test suite recently introduced the `HardwareClassification`
mechanism (see `torch/testing/_internal/common_utils.py`), which allows
filtering test classes by hardware category (`GENERIC`, `ACCELERATOR`,
`CPU`, `CUDA`, `MPS`, `XPU`) via the `--hw-classification` CLI flag. Test
classes that do not declare a `hw_classification` attribute are excluded
when the filter is used, so they cannot run in hardware-partitioned CI
workflows.

`ElasticLaunchTest` fits the `GENERIC` definition ("tests that exercise
shared, device-agnostic logic ... typically do not use
`instantiate_device_type_tests`"): its 13 test methods cover
`elastic_launch` multi-process spawning against an in-process etcd server,
mocked `LocalElasticAgent`/`rdzv_registry` paths, `rdzv_handler.shutdown`
semantics on agent signal vs. error, and `_get_entrypoint_name` string
resolution — pure launcher/rendezvous logic with no tensor or device code
(`_dist_sum` uses `backend="gloo"`, which is CPU). Tagging it `GENERIC`
brings it into the new filtering workflow without altering test behavior.

## Test plan

- Run the test file:
 pytest test/distributed/launcher/api_test.py , 13 testcases pass
