### PR TITLE
Fix file descriptor leak in _create_file_store()

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -24,6 +24,7 @@ from torch.distributed.elastic.rendezvous import (
 )
 from torch.distributed.elastic.rendezvous.c10d_rendezvous_backend import (
     C10dRendezvousBackend,
+    _create_file_store,
     create_backend,
 )
 from torch.distributed.elastic.utils.distributed import get_free_port
@@ -273,6 +274,22 @@ class CreateBackendTest(TestCase):
             r"The file creation for C10d store has failed. See inner exception for details.",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
+    )
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    def test_create_file_store_closes_tempfile_fd(
+        self, mkstemp_mock, os_close_mock, filestore_mock
+    ) -> None:
+        mkstemp_mock.return_value = (123, self._expected_endpoint_file)
+        self._params_filestore.endpoint = ""
+
+        _create_file_store(self._params_filestore)
+
+        os_close_mock.assert_called_once_with(123)
+        filestore_mock.assert_called_once_with(self._expected_endpoint_file)
 
     @mock.patch(
         "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,11 +192,13 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."
             ) from exc
+        else:
+            os.close(fd)
 
     try:
         store = FileStore(path)


### PR DESCRIPTION
Fixes #191394

## Summary
`_create_file_store()` discards the file descriptor returned by `tempfile.mkstemp()` without closing it. `FileStore` opens the path independently, so the descriptor remains owned by the process and leaks on every rendezvous creation without an endpoint.

Capture the fd and close it via `try`/`else` so it is closed exactly once after a successful `mkstemp()` call.

## Changes
- `torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py`: capture and close the fd
- `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py`: new test asserting `os.close()` is called with the mkstemp fd and `FileStore` receives the path

## Test Plan
```
python -m unittest c10d_rendezvous_backend_test.CreateBackendTest.test_create_file_store_closes_tempfile_fd
```
Note: on Windows the full file-store suite hits pre-existing tearDown failures (`PermissionError` from an open file handle) and TCPStore requires libuv; this change does not affect those paths.

> This PR was authored with AI assistance (opencode). The user reviewed and approved the final diff before submission.