### PR TITLE
[TEST] Add hw_classification to python_native tests

### DIFF
--- a/test/python_native/test_cutedsl_smoketest.py
+++ b/test/python_native/test_cutedsl_smoketest.py
@@ -14,7 +14,12 @@ import unittest
 
 import torch
 from torch.testing._internal.common_cuda import SM80OrLater, TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfNoCuteDSL,
+    TestCase,
+)
 from torch.utils.dlpack import ReadOnlyTensorWrapper
 
 
@@ -674,6 +679,8 @@ def _build_cta_norm():
 @skipIfNoCuteDSL
 @unittest.skipIf(not TEST_CUDA, "CUDA required")
 class TestCuteDSLSmoketest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """Smoke tests that compile, run, and verify cuteDSL kernels.
 
     Run before bumping cuteDSL version pins in torch/_native/cutedsl_utils.py.
@@ -808,6 +815,8 @@ class TestCuteDSLSmoketest(TestCase):
 @skipIfNoCuteDSL
 @unittest.skipIf(not TEST_CUDA, "CUDA required")
 class TestCuteDSLReadOnlyWrapper(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     """ReadOnlyTensorWrapper interop with cuteDSL.
 
     The tvm-ffi exchange path is the supported route: it goes through the const

--- a/test/python_native/test_decomp.py
+++ b/test/python_native/test_decomp.py
@@ -14,7 +14,12 @@ import uuid
 import torch
 import torch._native.registry as registry_module
 from torch._native.registry import native_decomp_table, register_op_override
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 # Common predicates/impls used across several tests.
@@ -37,6 +42,8 @@ def _make_fill_impl(value):
 
 @skipIfTorchDynamo("Decomp tests don't need dynamo compilation")
 class TestNativeDecompTable(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for native_decomp_table() and register/deregister syncing."""
 
     def setUp(self):

--- a/test/python_native/test_dsl_registry.py
+++ b/test/python_native/test_dsl_registry.py
@@ -3,10 +3,16 @@
 from unittest.mock import Mock
 
 from torch._vendor.packaging.version import Version
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestDSLRegistry(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Comprehensive tests for DSL registry functionality."""
 
     def setUp(self):

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -9,6 +9,7 @@ import uuid
 from unittest.mock import patch
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -41,6 +42,8 @@ def _import_module_directly(module_name, file_name):
 
 
 class TestNativeDSLOps(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for the torch._native DSL ops framework."""
 
     def setUp(self):

--- a/test/python_native/test_registry.py
+++ b/test/python_native/test_registry.py
@@ -6,7 +6,12 @@ import torch
 import torch._dynamo.trace_rules as trace_rules
 import torch._native.registry as registry_module
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 class _CowStateWrapperTensor(torch.Tensor):
@@ -43,6 +48,8 @@ class _CowStateWrapperTensor(torch.Tensor):
 
 @skipIfTorchDynamo("Registry tests don't need dynamo compilation")
 class TestRegistry(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for the torch._native.registry module."""
 
     def setUp(self):
@@ -352,6 +359,8 @@ class TestRegistry(TestCase):
 
 @skipIfTorchDynamo("Runtime registry tests exercise the dispatcher directly")
 class TestRegistryRuntime(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """End-to-end runtime tests that exercise the real dispatcher.
 
     These tests register overrides on real aten ops and therefore must fully

--- a/test/python_native/test_torch_backends.py
+++ b/test/python_native/test_torch_backends.py
@@ -4,7 +4,12 @@ import os
 from unittest.mock import patch
 
 import torch.backends.python_native as pn
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfTorchDynamo,
+    TestCase,
+)
 
 
 class RegistryTestMixin:
@@ -56,6 +61,8 @@ class RegistryTestMixin:
 
 @skipIfTorchDynamo("Backend tests don't need dynamo compilation")
 class TestTorchBackendsPythonNative(RegistryTestMixin, TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for torch.backends.python_native user-facing API."""
 
     def test_module_import(self):
@@ -512,6 +519,8 @@ class TestTorchBackendsPythonNative(RegistryTestMixin, TestCase):
 
 
 class TestTorchBackendsPythonNativeIntegration(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Integration tests for torch.backends.python_native with actual DSLs."""
 
     def test_real_dsl_integration(self):


### PR DESCRIPTION
## Summary

Apply hardware classification to python_native tests following #186918 guidelines.

**`test/python_native/test_decomp.py`**
- **TestNativeDecompTable**: `GENERIC`

**`test/python_native/test_dsl_registry.py`**
- **TestDSLRegistry**: `GENERIC`

**`test/python_native/test_native_dsl_ops.py`**
- **TestNativeDSLOps**: `GENERIC`

**`test/python_native/test_registry.py`**
- **TestRegistry**: `GENERIC`
- **TestRegistryRuntime**: `GENERIC`

**`test/python_native/test_torch_backends.py`**
- **TestTorchBackendsPythonNative**: `GENERIC`
- **TestTorchBackendsPythonNativeIntegration**: `GENERIC`

**`test/python_native/test_cutedsl_smoketest.py`**
- **TestCuteDSLSmoketest**: `CUDA`
- **TestCuteDSLReadOnlyWrapper**: `CUDA`

## Test plan

```
lintrunner -a test/python_native/test_decomp.py test/python_native/test_dsl_registry.py test/python_native/test_native_dsl_ops.py test/python_native/test_registry.py test/python_native/test_torch_backends.py test/python_native/test_cutedsl_smoketest.py
# ok No lint issues.

python test/python_native/test_decomp.py --hw-classification GENERIC -v
python test/python_native/test_dsl_registry.py --hw-classification GENERIC -v
python test/python_native/test_native_dsl_ops.py --hw-classification GENERIC -v
python test/python_native/test_registry.py --hw-classification GENERIC -v
python test/python_native/test_torch_backends.py --hw-classification GENERIC -v
python test/python_native/test_cutedsl_smoketest.py --hw-classification CUDA -v
```

> Authored with an AI assistant.