### PR TITLE
[distributed] sac_estimator: replace "cuda" literal with generic accelerator check

### DIFF
--- a/torch/distributed/_tools/sac_estimator.py
+++ b/torch/distributed/_tools/sac_estimator.py
@@ -406,9 +406,10 @@ class SACEstimator(TorchDispatchMode):
         out_storages_cuda: set[UntypedStorage] = set()
         out_storages_cpu: set[UntypedStorage] = set()
         cuda_devices: set[torch.device] = set()
+        accelerator = torch.accelerator.current_accelerator()
         for o in flat_outs:
             if isinstance(o, torch.Tensor):
-                if o.device.type == "cuda":
+                if accelerator is not None and o.device.type == accelerator.type:
                     out_storages_cuda.update(get_untyped_storages(o))
                     cuda_devices.add(o.device)
                 else:
@@ -417,7 +418,7 @@ class SACEstimator(TorchDispatchMode):
         # Check if there's more than 1 CUDA device
         if len(cuda_devices) > 1:
             raise AssertionError(
-                f"{func.__name__}'s output has more than 1 CUDA devices {cuda_devices}"
+                f"{func.__name__}'s output has more than 1 accelerator devices {cuda_devices}"
             )
 
         # 2. Get the memory consumed by output


### PR DESCRIPTION
## Summary

Replaces a hardcoded `"cuda"` device-type literal in
`torch/distributed/_tools/sac_estimator.py` with a generic accelerator
identity check, so `SACEstimator` correctly recognizes tensors on any
registered accelerator device (e.g. PrivateUse1 backends like Ascend
NPU), not just literal CUDA.

## Problem

In `SACEstimator.__torch_dispatch__`, tensor storages are bucketed into
an accelerator-memory set (subject to allocator-rounded byte accounting)
or a CPU-memory set, based on:

```python
if o.device.type == "cuda":
    out_storages_cuda.update(get_untyped_storages(o))
    cuda_devices.add(o.device)
else:
    ...
```

Any device whose `.type` isn't literally `"cuda"` falls into the `else`
branch and is silently treated as non-accelerator memory. For a
PrivateUse1-registered backend (e.g. NPU), this means SAC's memory
estimates would incorrectly exclude accelerator tensors from the
accelerator-memory accounting, skewing the estimate.

## Fix

Replace the literal string comparison with
`torch.accelerator.current_accelerator()`, which is the public,
generic API for resolving the active accelerator device and already
correctly handles any registered backend, PrivateUse1 included.

```python
accelerator = torch.accelerator.current_accelerator()
if accelerator is not None and o.device.type == accelerator.type:
    out_storages_cuda.update(get_untyped_storages(o))
    cuda_devices.add(o.device)
else:
    ...
```

## Why this is safe

This is a pure device-identity check, not a capability or behavioral
decision -- it only answers "is this tensor on an accelerator," not
"does this backend support some specific feature." No numeric
computation, kernel dispatch, or backend-specific library call depends
on the outcome here beyond which bucket a storage pointer lands in.

CUDA-only behavior is unchanged: on a CUDA-only build,
`current_accelerator()` resolves to the same `"cuda"` device type as
the literal it replaces, so existing CUDA users see no behavior change.

## Scope note

An adjacent constant in the same function,
`_PYTORCH_MIN_ALLOCATE = 2**9 if ... else 1`, is a byte-rounding value
hardcoded to CUDA's caching-allocator internals and is intentionally
**not** touched here. Unlike the identity check above, this is a
capability/behavior value with no generic query available today, and
guessing wrong would produce a real numerical error in SAC's memory
estimates rather than a harmless fallback. Left as a known limitation
for separate investigation once real NPU allocator granularity is
confirmed.

## Testing

Pure identity-check swap; behavior on CUDA builds is unchanged (same resolved device type). No new external dependency
introduced -- `torch.accelerator.current_accelerator()` is existing
public API already used elsewhere in the codebase

### Related RFC

This change is part of the work described in #194355.