### PR TITLE
[autograd] saved_tensors_hooks: resolve default device_type generical…

### DIFF
--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -404,8 +404,11 @@ class save_on_cpu(saved_tensors_hooks):
         >>> # all intermediary tensors are released (deleted) after the call to backward
     """
 
-    def __init__(self, pin_memory: bool = False, device_type: str = "cuda") -> None:
-        device_module = getattr(torch, device_type, torch.cuda)
+   def __init__(self, pin_memory: bool = False, device_type: Optional[str] = None) -> None:
+        if device_type is None:
+            accelerator = torch.accelerator.current_accelerator()
+            device_type = accelerator.type
+        device_module = getattr(torch, device_type)
 
         def pack_to_cpu(tensor: torch.Tensor) -> tuple[torch.device, torch.Tensor]:
             if not pin_memory:

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -404,7 +404,9 @@ class save_on_cpu(saved_tensors_hooks):
         >>> # all intermediary tensors are released (deleted) after the call to backward
     """
 
-    def __init__(self, pin_memory: bool = False, device_type: Optional[str] = None) -> None:
+    def __init__(
+        self, pin_memory: bool = False, device_type: str | None = None
+    ) -> None:
         if device_type is None:
             accelerator = torch.accelerator.current_accelerator()
             device_type = accelerator.type if accelerator is not None else "cuda"

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -404,11 +404,11 @@ class save_on_cpu(saved_tensors_hooks):
         >>> # all intermediary tensors are released (deleted) after the call to backward
     """
 
-   def __init__(self, pin_memory: bool = False, device_type: Optional[str] = None) -> None:
+    def __init__(self, pin_memory: bool = False, device_type: Optional[str] = None) -> None:
         if device_type is None:
             accelerator = torch.accelerator.current_accelerator()
-            device_type = accelerator.type
-        device_module = getattr(torch, device_type)
+            device_type = accelerator.type if accelerator is not None else "cuda"
+        device_module = getattr(torch, device_type, torch.cuda)
 
         def pack_to_cpu(tensor: torch.Tensor) -> tuple[torch.device, torch.Tensor]:
             if not pin_memory:


### PR DESCRIPTION
## Summary

Replaces the hardcoded "cuda" default for `device_type` in `torch.autograd.graph.save_on_cpu`'s
(`saved_tensors_hooks`) `__init__` with a generic accelerator resolution, so the default device
module picked when no `device_type` is explicitly passed resolves to whichever accelerator is
actually active, not always CUDA.

## Problem

```python
def __init__(self, pin_memory: bool = False, device_type: str = "cuda") -> None:
    device_module = getattr(torch, device_type, torch.cuda)
```

If a user on a PrivateUse1-registered backend (e.g. Ascend NPU) doesn't explicitly pass
`device_type`, they silently get `torch.cuda` as the device module unless they remember to
override the default themselves. The line immediately below already tolerates any device-type
string via `getattr(torch, device_type, torch.cuda)` — the only literal is the default value itself.

## Fix

```python
def __init__(self, pin_memory: bool = False, device_type: Optional[str] = None) -> None:
    if device_type is None:
        accelerator = torch.accelerator.current_accelerator()
        device_type = accelerator.type if accelerator is not None else "cuda"
    device_module = getattr(torch, device_type, torch.cuda)
```

When no `device_type` is given, resolve it from `torch.accelerator.current_accelerator()` (the
public, generic API for identifying the active accelerator) instead of assuming CUDA.
`current_accelerator()` returns `None` on a build/environment with no active accelerator — most
notably CPU-only builds, which `save_on_cpu` is commonly exercised on directly — so that case is
guarded explicitly and falls back to `"cuda"`, preserving old behavior exactly. The `getattr(...,
torch.cuda)` fallback on the following line is also preserved unchanged from the original, as a
second safety net for any device-type string that doesn't resolve to a real `torch` submodule.

## Why this is safe

- This is a default-value identity resolution, not a capability or behavioral decision.
- CUDA-only behavior is unchanged: on a CUDA-only build, `current_accelerator()` resolves to
  `"cuda"`, matching the previous hardcoded default exactly.
- CPU-only behavior is unchanged: `current_accelerator()` returns `None`, the guard catches it,
  `device_type` falls back to `"cuda"` exactly as the old literal default did — `save_on_cpu()`
  with no explicit `device_type` continues to work with no crash on CPU-only builds.
- Every other backend (XPU, MPS, MTIA, a registered PrivateUse1 backend) is now picked up
  automatically with no code change required when a new one is added.

## Fixes from previous revision

An earlier revision of this diff omitted the `None`-guard on `accelerator` and dropped the
`torch.cuda` fallback on `getattr`, which would raise `AttributeError: 'NoneType' object has no
attribute 'type'` on any CPU-only build calling `save_on_cpu()` without an explicit `device_type`.
Both are restored in this revision.

## Testing

- CPU-only path: `save_on_cpu()` with no `device_type` now resolves to `"cuda"` via the guarded
  fallback instead of raising, matching pre-PR behavior.
- CUDA-only path: resolves to `"cuda"` via `current_accelerator()`, matching pre-PR behavior.
- Adding an explicit CPU-only unit test constructing `save_on_cpu()` with no `device_type`, to
  cover this exact regression path going forward.

## Related RFC

This change is part of the work described in #194355.