### PR TITLE
Support `nvidia-cutlass-operators==0.2.0`

### DIFF
--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py
@@ -571,7 +571,12 @@ def _init_efc_jit(kernel, epilogue_args):
     object. We replicate just those two steps so that disk-cached artifacts can
     be rewrapped without recompiling the CuTe DSL kernel.
     """
-    from cutlass.operators.providers.cutedsl.evt.common_efc import EFC
+    try:
+        # `nvidia-cutlass-operators>=0.2.0` have `efc` not `common_efc`
+        from cutlass.operators.providers.cutedsl.evt.efc import EFC
+    except ModuleNotFoundError:
+        from cutlass.operators.providers.cutedsl.evt.common_efc import EFC
+
     from cutlass.operators.utils.tensor import TensorWrapper
 
     efc = kernel.impl.efc

--- a/torch/_inductor/kernel/vendored_templates/cutedsl/dense_gemm_efc.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/dense_gemm_efc.py
@@ -34,12 +34,21 @@ import cuda.bindings.driver as cuda  # pyrefly: ignore [missing-import]
 
 import cutlass
 import cutlass.cute as cute
-import cutlass.operators.providers.cutedsl.evt.common_efc as common_efc
+
+
+try:
+    # `nvidia-cutlass-operators>=0.2.0` has `efc` not `common_efc`
+    import cutlass.operators.providers.cutedsl.evt.efc as common_efc
+except ModuleNotFoundError:
+    import cutlass.operators.providers.cutedsl.evt.common_efc as common_efc
+
 import cutlass.pipeline as pipeline
 import cutlass.utils as utils
 import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
-from cutlass.operators.providers.cutedsl.evt.common_efc import log
+
+
+log = common_efc.log
 
 from torch._inductor.kernel.gemm_epilogue import GemmReductionDescriptor
 from torch._inductor.kernel.vendored_templates.cutedsl.reduction_utils import (


### PR DESCRIPTION
which has `efc` not `common_efc` in the namespace of `cutlass.operators.providers.cutedsl.evt`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo