### PR TITLE
Share `NCCLDevCommManager` singleton across DSOs

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -811,6 +811,7 @@ libtorch_cuda_distributed_extra_sources = [
     "torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.cu",
     "torch/csrc/distributed/c10d/symm_mem/nccl_extension.cu",
     "torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_bridge.cpp",
+    "torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.cpp",
     "torch/csrc/distributed/c10d/symm_mem/ops/nccl_reduce_scatter_offset.cu",
     "torch/csrc/distributed/c10d/symm_mem/ops/nccl_all_to_all_nd.cu",
     "torch/csrc/distributed/c10d/symm_mem/intra_node_comm.cpp",

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_bridge.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_bridge.cpp
@@ -19,7 +19,6 @@
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
 
 namespace c10d::symmetric_memory {
-
 namespace {
 
 // Installed at load time (before any process group is created).

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_bridge.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_bridge.cpp
@@ -5,6 +5,8 @@
 // ProcessGroupNCCL -- lands it in NCCLDevCommManager for symmetric memory,
 // without the backend having to depend on the manager header. This is the one
 // place the opaque void* comm from the hook is cast back to ncclComm_t.
+// Also defines NCCLDevCommManager::get() so the Meyer singleton registry
+// lives in this DSO rather than being duplicated into extension modules.
 //
 // Gated on NCCL_HAS_SYMMEM_SUPPORT (via nccl_dev_cap.hpp), matching the other
 // symm_mem NCCL translation units: the macro is only defined when NCCL is built
@@ -18,7 +20,26 @@
 #include <torch/csrc/distributed/c10d/NCCLCommRegistrationHook.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
 
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
 namespace c10d::symmetric_memory {
+
+NCCLDevCommManager& NCCLDevCommManager::get(const c10::Device device) {
+  static std::mutex mu;
+  static std::
+      unordered_map<c10::DeviceIndex, std::unique_ptr<NCCLDevCommManager>>
+          managers;
+  std::lock_guard<std::mutex> lock(mu);
+  auto& slot = managers[device.index()];
+  if (!slot) {
+    slot = std::unique_ptr<NCCLDevCommManager>(new NCCLDevCommManager(device));
+    LOG(INFO) << "[NCCLDevCommManager] created manager for device=" << device;
+  }
+  return *slot;
+}
+
 namespace {
 
 // Installed at load time (before any process group is created).

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_bridge.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_bridge.cpp
@@ -5,8 +5,6 @@
 // ProcessGroupNCCL -- lands it in NCCLDevCommManager for symmetric memory,
 // without the backend having to depend on the manager header. This is the one
 // place the opaque void* comm from the hook is cast back to ncclComm_t.
-// Also defines NCCLDevCommManager::get() so the Meyer singleton registry
-// lives in this DSO rather than being duplicated into extension modules.
 //
 // Gated on NCCL_HAS_SYMMEM_SUPPORT (via nccl_dev_cap.hpp), matching the other
 // symm_mem NCCL translation units: the macro is only defined when NCCL is built
@@ -20,25 +18,7 @@
 #include <torch/csrc/distributed/c10d/NCCLCommRegistrationHook.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
 
-#include <memory>
-#include <mutex>
-#include <unordered_map>
-
 namespace c10d::symmetric_memory {
-
-NCCLDevCommManager& NCCLDevCommManager::get(const c10::Device device) {
-  static std::mutex mu;
-  static std::
-      unordered_map<c10::DeviceIndex, std::unique_ptr<NCCLDevCommManager>>
-          managers;
-  std::lock_guard<std::mutex> lock(mu);
-  auto& slot = managers[device.index()];
-  if (!slot) {
-    slot = std::unique_ptr<NCCLDevCommManager>(new NCCLDevCommManager(device));
-    LOG(INFO) << "[NCCLDevCommManager] created manager for device=" << device;
-  }
-  return *slot;
-}
 
 namespace {
 

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
+
+#ifdef NCCL_HAS_SYMMEM_SUPPORT
+
+#include <memory>
+
+namespace c10d::symmetric_memory {
+
+NCCLDevCommManager& NCCLDevCommManager::get(const c10::Device device) {
+  static std::mutex mu;
+  static std::
+      unordered_map<c10::DeviceIndex, std::unique_ptr<NCCLDevCommManager>>
+          managers;
+  std::lock_guard<std::mutex> lock(mu);
+  auto& slot = managers[device.index()];
+  if (!slot) {
+    slot = std::unique_ptr<NCCLDevCommManager>(new NCCLDevCommManager(device));
+    LOG(INFO) << "[NCCLDevCommManager] created manager for device=" << device;
+  }
+  return *slot;
+}
+
+} // namespace c10d::symmetric_memory
+
+#endif // NCCL_HAS_SYMMEM_SUPPORT

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
@@ -34,22 +34,13 @@ class TORCH_API NCCLDevCommManager {
   // @param device The CUDA device this manager is associated with
   explicit NCCLDevCommManager(const c10::Device device) : device_(device) {}
 
-  // Per-device singleton: lazily creates one manager per CUDA device so
-  // callers on different devices don't share state.
-  static NCCLDevCommManager& get(const c10::Device device) {
-    static std::mutex mu;
-    static std::
-        unordered_map<c10::DeviceIndex, std::unique_ptr<NCCLDevCommManager>>
-            managers;
-    std::lock_guard<std::mutex> lock(mu);
-    auto& slot = managers[device.index()];
-    if (!slot) {
-      slot =
-          std::unique_ptr<NCCLDevCommManager>(new NCCLDevCommManager(device));
-      LOG(INFO) << "[NCCLDevCommManager] created manager for device=" << device;
-    }
-    return *slot;
-  }
+  // Per-device singleton: Defined out-of-line in nccl_dev_comm_bridge.cpp
+  // (libtorch_cuda) so the function-local registry is process-wide. An inline
+  // definition is hidden by
+  // `-fvisibility-inlines-hidden`, so a separately linked DSO (e.g.
+  // torch._nccl_ep) gets its own empty map and cannot see ProcessGroup / hook
+  // registration.
+  static NCCLDevCommManager& get(const c10::Device device);
 
 #ifdef NCCL_HAS_SYMMEM_DEVICE_SUPPORT
   // Get an NCCL device communicator for a group, for the caller function.  By

--- a/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp
@@ -34,7 +34,7 @@ class TORCH_API NCCLDevCommManager {
   // @param device The CUDA device this manager is associated with
   explicit NCCLDevCommManager(const c10::Device device) : device_(device) {}
 
-  // Per-device singleton: Defined out-of-line in nccl_dev_comm_bridge.cpp
+  // Per-device singleton: Defined out-of-line in nccl_devcomm_manager.cpp
   // (libtorch_cuda) so the function-local registry is process-wide. An inline
   // definition is hidden by
   // `-fvisibility-inlines-hidden`, so a separately linked DSO (e.g.


### PR DESCRIPTION
`NCCLDevCommManager::get()` was a header-inline Meyer singleton. With `-fvisibility-inlines-hidden`, each DSO that includes the header gets its own function-local managers map.

`ProcessGroupNCCL` and the registration hooks publish the host `ncclComm_t` from `libtorch_cuda`, but separately linked modules such as `torch._nccl_ep` look up the same group in an empty map and raise "NCCL host communicator for group ... not found".

Define get() out-of-line in nccl_devcomm_manager.cpp so the registry lives in `libtorch_cuda`.

Authored with Cursor Grok 4.6 High