### PR TITLE
[Testcase Refactoring] Add hw-classification in test_launcher

### DIFF
--- a/test/distributed/test_launcher.py
+++ b/test/distributed/test_launcher.py
@@ -14,6 +14,7 @@ if not dist.is_available():
     sys.exit(0)
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
@@ -32,6 +33,8 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestDistributedLaunch(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_launch_user_script(self):
         nnodes = 1
         nproc_per_node = 4


### PR DESCRIPTION
## Summary

Tags `TestDistributedLaunch` in `test/distributed/test_launcher.py` with
`hw_classification = HardwareClassification.GENERIC` so the class can be
selected by the `--hw-classification` test filter. The class subclasses
`torch.testing._internal.common_utils.TestCase` and exercises CPU-only
`torch.distributed.launch.main(args)` CLI behavior, with no device
parameter and no `instantiate_device_type_tests`, so `GENERIC` is the
correct category.

## Changes

- `test/distributed/test_launcher.py`: added `HardwareClassification` to
  the existing `torch.testing._internal.common_utils` multi-line import
  block, in alphabetical position before `run_tests`,
  `TEST_WITH_DEV_DBG_ASAN`, and `TestCase`.
- `test/distributed/test_launcher.py`: declared
  `hw_classification = HardwareClassification.GENERIC` as a class attribute
  on `TestDistributedLaunch`, placed immediately after the class header
  and before `test_launch_user_script`.


## Motivation

PyTorch's test suite recently introduced the `HardwareClassification`
mechanism (see `torch/testing/_internal/common_utils.py`), which allows
filtering test classes by hardware category (`GENERIC`, `ACCELERATOR`,
`CPU`, `CUDA`, `MPS`, `XPU`) via the `--hw-classification` CLI flag. Test
classes that do not declare a `hw_classification` attribute are excluded
when the filter is used, so they cannot run in hardware-partitioned CI
workflows.

`TestDistributedLaunch` fits the `GENERIC` definition ("tests that
exercise shared, device-agnostic logic ... typically do not use
`instantiate_device_type_tests`"): its single test method
(`test_launch_user_script`) builds a CLI args list (`--nnodes`,
`--nproc-per-node`, `--master-addr`, `--master-port`, `--use-env`, etc.)
and invokes `torch.distributed.launch.main(args)` to spawn workers
running `bin/test_script.py` — pure launcher/CLI wiring with no tensor
or device code. Tagging it `GENERIC` brings it into the new filtering
workflow without altering test behavior.

## Test plan

- Run the test file:
 pytest test/distributed/test_launcher.py , 1 smoke testcase pass
