### PR TITLE
[Test] Refactor test/functorch/test_leaf_function.py and add hardware classification

### DIFF
--- a/test/functorch/test_leaf_function.py
+++ b/test/functorch/test_leaf_function.py
@@ -18,6 +18,7 @@ from torch._dynamo.testing import normalize_gm
 from torch._higher_order_ops.invoke_leaf_function import invoke_leaf_function
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -36,6 +37,8 @@ def extract_graph(fx_g, _, graph_cell):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionMakeFx(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _has_invoke_leaf_function_node(self, gm):
         for node in gm.graph.nodes:
             if node.op == "call_function" and node.target is invoke_leaf_function:
@@ -292,6 +295,8 @@ class f(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionAotFunction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aot_function_simple(self):
         @leaf_function
         def my_fn(x, y):
@@ -499,6 +504,8 @@ class GraphModule(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionEscapedGradients(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aot_function_escaped_gradient_multiple_closures(self):
         weight1 = torch.randn(3, 3, requires_grad=True)
         weight2 = torch.randn(3, 3, requires_grad=True)
@@ -635,6 +642,8 @@ class TestLeafFunctionEscapedGradients(TestCase):
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionMakeFxAndCompile(TestCase):
     """Tests for @leaf_function when mixing torch.compile and make_fx."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_not_called_during_compilation(self):
         """The real leaf_fn body runs only at runtime, not during compilation."""
@@ -840,6 +849,8 @@ class outer(torch.nn.Module):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionDynamo(PytreeRegisteringTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -2500,6 +2511,8 @@ instantiate_parametrized_tests(TestLeafFunctionDynamo)
 class TestLeafFunctionRegisterHook(TestCase):
     """Tests for @leaf_function's register_multi_grad_hook API."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_hook_fires_on_backward(self):
         hook_grads = []
 
@@ -2757,6 +2770,8 @@ class TestLeafFunctionRegisterHook(TestCase):
 
 @skipIfTorchDynamo("leaf_function tests manage their own compilation")
 class TestLeafFunctionGradDtype(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _make_pair(self, size, dtype, grad_dtype):
         torch.manual_seed(42)
         x_ref = torch.randn(size, dtype=dtype, requires_grad=True)


### PR DESCRIPTION
## Summary

Tag the test classes in `test/functorch/test_leaf_function.py` as `GENERIC` so CI can route them via `--hw-classification`. These are Dynamo/AOTAutograd framework tests: every tensor is on CPU, no class requires an accelerator, and the file intentionally does not use `instantiate_device_type_tests` (its dtype coverage comes from `@parametrize`). No runtime behavior is changed -- without the flag, discovery and execution are identical.

## Changes

Import `HardwareClassification` and set `hw_classification = GENERIC` on `TestLeafFunctionMakeFx`, `TestLeafFunctionAotFunction`, `TestLeafFunctionEscapedGradients`, `TestLeafFunctionMakeFxAndCompile`, `TestLeafFunctionDynamo`, `TestLeafFunctionRegisterHook` and `TestLeafFunctionGradDtype`.

## Test Plan

```bash
python test/functorch/test_leaf_function.py
# Ran 103 tests -> OK (skipped=1), unchanged from before

python test/functorch/test_leaf_function.py --hw-classification GENERIC
# Ran 103 tests -> OK (skipped=1)
# HW classification mode active (['GENERIC']): total=103, passed=103, unclassified=0, mismatched=0

python test/functorch/test_leaf_function.py --hw-classification ACCELERATOR
# NO TESTS RAN, mismatched=103
```

Part of https://github.com/pytorch/pytorch/issues/142029.