### PR TITLE
[TEST] Add `hw_classification` to `test_functional_autograd_benchmark.py`

### DIFF
--- a/test/autograd/test_node_lifecycle.py
+++ b/test/autograd/test_node_lifecycle.py
@@ -18,7 +18,11 @@ from enum import auto, Enum
 
 import torch
 from torch.autograd import Function
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class NodeType(Enum):
@@ -107,6 +111,8 @@ class Marker:
 
 
 class TestNodeLifecycle(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Single output, various node types / hooks / backward states."""
 
     def _run(self, node_type, hook_type, backward_state):
@@ -296,6 +302,8 @@ class TestNodeLifecycle(TestCase):
 
 
 class TestLeafNodeLifecycle(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Leaf-specific tests (AccumulateGrad)."""
 
     def test_accumulate_grad_freed_refcount(self):
@@ -342,6 +350,8 @@ class TestLeafNodeLifecycle(TestCase):
 
 
 class TestSharedGradFn(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for grad_fn shared by multiple output tensors."""
 
     def test_cpp_shared_grad_fn_one_deleted(self):
@@ -418,6 +428,8 @@ class TestSharedGradFn(TestCase):
 
 
 class TestChainLifecycle(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests for chains of nodes."""
 
     def test_cpp_chain_freed_refcount(self):
@@ -462,6 +474,8 @@ class TestChainLifecycle(TestCase):
 
 
 class TestSavedVariableLifecycle(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """Tests that saved tensors are freed at the right time.
 
     Uses b**2 for C++ tests (PowBackward0 saves self) and PythonMul for

--- a/test/test_autograd_fallback.py
+++ b/test/test_autograd_fallback.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 from torch.library import _scoped_library
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -26,6 +27,8 @@ def autograd_fallback_mode(mode):
 
 
 class TestAutogradFallback(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     test_ns = "_test_autograd_fallback"
 
     def setUp(self):

--- a/test/test_functional_autograd_benchmark.py
+++ b/test/test_functional_autograd_benchmark.py
@@ -6,6 +6,7 @@ import subprocess
 import unittest
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     run_tests,
     slowTest,
@@ -18,6 +19,8 @@ PYTORCH_COLLECT_COVERAGE = bool(os.environ.get("PYTORCH_COLLECT_COVERAGE"))
 
 # This is a very simple smoke test for the functional autograd benchmarking script.
 class TestFunctionalAutogradBenchmark(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def _test_runner(self, model, disable_gpu=False):
         # Note about windows:
         # The temporary file is exclusively open by this process and the child process


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to `TestFunctionalAutogradBenchmark`. Tests invoke autograd benchmark scripts via subprocess — the subprocess auto-detects GPU but the test framework has no device dependency (no `@requires_cuda`, no `instantiate_device_type_tests`)

Depends on: #186918

Follows the RFC Test class classification (#185142, #185590)

## Test Plan

```
python test/test_functional_autograd_benchmark.py -v    # Ran 2 tests — 1 pre-existing failure, 1 skip (both match baseline)
```

Verified locally and on 8xH200

Co-authored with Opus 4.6

cc @vishalgoyal316 @mansiag05 @RiyaP2508