### PR TITLE
[autograd] Expose queue_callback as torch.autograd.graph.queue_callback

### DIFF
--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -446,6 +446,10 @@ to avoid a reference cycle when the saved tensor is a graph output; see
 ```
 
 ```{eval-rst}
+.. autofunction:: torch.autograd.graph.queue_callback
+```
+
+```{eval-rst}
 .. autofunction:: torch.autograd.graph.region_activation_memory_budget
 ```
 

--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -5651,6 +5651,7 @@ xfail_divergence_from_eager = {
 }
 
 skipped_tests = set()
+skipped_tests.add("test_graph_queue_callback")
 
 if not HAS_CUDA_AND_TRITON:
     # Found Tesla M60 which is too old to be supported by the triton GPU compiler

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9080,6 +9080,20 @@ for shape in [(1,), ()]:
         self.assertEqual(ret["outer"], 1)
         self.assertEqual(ret["inner"], 1)
 
+    def test_graph_queue_callback(self):
+        # The public API matches Variable._execution_engine.queue_callback.
+        counter = [0]
+        t = torch.rand(3, requires_grad=True)
+        t.register_hook(
+            lambda _: torch.autograd.graph.queue_callback(
+                lambda: counter.__setitem__(0, counter[0] + 1)
+            )
+        )
+        t.sum().backward()
+        self.assertEqual(counter[0], 1)
+        with self.assertRaisesRegex(RuntimeError, "during backward"):
+            torch.autograd.graph.queue_callback(lambda: None)
+
     def test_reentrant_with_leaf_variable_hook(self):
         handle = None
         param = torch.rand(10, requires_grad=True)

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9080,7 +9080,9 @@ for shape in [(1,), ()]:
         self.assertEqual(ret["outer"], 1)
         self.assertEqual(ret["inner"], 1)
 
-    @skipIfTorchDynamo("callbacks don't fire when backward runs under compiled autograd")
+    @skipIfTorchDynamo(
+        "callbacks don't fire when backward runs under compiled autograd"
+    )
     def test_graph_queue_callback(self):
         # The public API matches Variable._execution_engine.queue_callback.
         counter = [0]

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -9080,6 +9080,7 @@ for shape in [(1,), ()]:
         self.assertEqual(ret["outer"], 1)
         self.assertEqual(ret["inner"], 1)
 
+    @skipIfTorchDynamo("callbacks don't fire when backward runs under compiled autograd")
     def test_graph_queue_callback(self):
         # The public API matches Variable._execution_engine.queue_callback.
         counter = [0]

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -46,6 +46,7 @@ __all__ = [
     "GradientEdge",
     "get_gradient_edge",
     "increment_version",
+    "queue_callback",
     "region_activation_memory_budget",
     "set_warn_on_accumulate_grad_stream_mismatch",
     "set_override_stale_capture_stream",
@@ -268,6 +269,28 @@ def increment_version(tensor: torch.Tensor | Iterable[torch.Tensor]) -> None:
     if isinstance(tensor, torch.Tensor):
         tensor = (tensor,)
     torch._C._increment_version(tensor)
+
+
+def queue_callback(callback: Callable[[], None]) -> None:
+    """Queue a callback to run after the current backward pass completes.
+
+    Must be called during a backward pass, for example from a
+    :class:`torch.autograd.Function` backward or a backward hook. The callback
+    runs once the backward pass currently executing on this thread finishes.
+    Callbacks queued multiple times run multiple times, in queueing order.
+
+    Example::
+
+        >>> t = torch.rand(3, requires_grad=True)
+        >>>
+        >>> def hook(unused_grad):
+        ...     torch.autograd.graph.queue_callback(lambda: print("backward done"))
+        >>>
+        >>> _ = t.register_hook(hook)
+        >>> t.sum().backward()
+        backward done
+    """
+    Variable._execution_engine.queue_callback(callback)
 
 
 class saved_tensors_hooks:

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -276,7 +276,8 @@ def queue_callback(callback: Callable[[], None]) -> None:
 
     Must be called during a backward pass, for example from a
     :class:`torch.autograd.Function` backward or a backward hook. The callback
-    runs once the backward pass currently executing on this thread finishes.
+    runs once the backward pass currently executing on this thread completes
+    successfully; it is not run if the backward pass raises an error.
     Callbacks queued multiple times run multiple times, in queueing order.
 
     Example::


### PR DESCRIPTION
Fixes #66199.

`Variable._execution_engine.queue_callback` is the only way to run code right after the backward pass finishes, but it is a private engine method. We want to use it in [TransformerEngine](https://github.com/NVIDIA/TransformerEngine) to schedule FP8 [delayed scaling](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html#Delayed-scaling) amax/scale updates at the end of backward, and we'd rather not depend on an API with no stability guarantees.

This adds `torch.autograd.graph.queue_callback(callback)` as a thin public wrapper over the engine method, with identical semantics — no engine changes. Docs entry, `__all__` and a small test included (+44 lines total).

---
*Drafted with an AI assistant (Claude Code), reviewed by the author.*


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo