### PR TITLE
[inductor] Keep subgraph inputs from inheriting donation indices

### DIFF
--- a/test/higher_order_ops/test_invoke_subgraph.py
+++ b/test/higher_order_ops/test_invoke_subgraph.py
@@ -272,6 +272,30 @@ class TestInvokeSubgraphCompile(TestCase):
         self.assertEqual(x.grad, x_clone.grad)
         self.assertEqual(y.grad, y_clone.grad)
 
+    @torch._functorch.config.patch("donated_buffer", True)
+    @requires_cuda_and_triton
+    def test_reused_subgraph_square_backward(self):
+        @nested_compile_region
+        def region(x, weight):
+            return x / torch.sqrt(x.square().mean(dim=-1, keepdim=True) + 1e-5) * weight
+
+        def fn(x, weight1, weight2):
+            return region(x, weight1).sum() + region(x, weight2).sum()
+
+        inputs = (
+            torch.randn(4, 8, device="cuda", requires_grad=True),
+            torch.randn(1, 8, device="cuda", requires_grad=True),
+            torch.randn(1, 8, device="cuda", requires_grad=True),
+        )
+        compiled_inputs = tuple(
+            value.detach().clone().requires_grad_(True) for value in inputs
+        )
+
+        fn(*inputs).backward()
+        torch.compile(fn, fullgraph=True)(*compiled_inputs).backward()
+
+        self.assertEqual(inputs[0].grad, compiled_inputs[0].grad)
+
     def test_module_forward(self):
         class Mod(torch.nn.Module):
             def __init__(self):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -3200,6 +3200,8 @@ class SubgraphLowering(GraphLowering):
     def __init__(self, parent: GraphLowering, *args: Any, **kwargs: Any) -> None:
         self.parent = parent
         super().__init__(*args, **kwargs)
+        # Donation indices use the parent graph's placeholder ordering, not ours.
+        self.bw_donated_idxs = None
 
     def allocate_non_dup_const_name(self, name: str | None, data: Tensor) -> str:
         name = super().allocate_non_dup_const_name(name, data)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193960

Backward donated-buffer indices are computed in the outer graph's
placeholder order. SubgraphLowering inherited those indices and applied
them to its unrelated placeholder order, which could mark an input as
donated accidentally. A reused nested_compile_region could then overwrite
a saved input during its first backward invocation and corrupt gradients
from later invocations.

Clear the inherited indices for subgraph lowering. There is no
per-subgraph donation metadata to map safely, so keeping these inputs
non-donated is the conservative correct behavior. Add a regression test
covering a reused RMS-normalization-shaped region.

Test Plan:

```
python test/higher_order_ops/test_invoke_subgraph.py TestInvokeSubgraphCompile.test_reused_subgraph_square_backward
lintrunner -a
```

The targeted test passes. lintrunner reports existing repository-wide Pyrefly
environment errors unrelated to the changed files.

This PR was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo