### PR TITLE
Error when TORCH_TARGET_VERSION is newer than the libtorch being compiled against

### DIFF
--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -258,6 +258,92 @@ int main() { return 0; }
     _expect_compilation_failure(compile_flags_with_both, "both macros")
 
 
+def check_torch_target_version_guard(install_root: Path) -> None:
+    """
+    TORCH_TARGET_VERSION must be <= TORCH_ABI_VERSION of the headers in this
+    install. Targeting an older ABI compiles; targeting one minor past the
+    build fails with the version.h #error.
+    """
+
+    def _header_torch_version(include_dir: Path) -> tuple[int, int]:
+        version_h = include_dir / "torch" / "headeronly" / "version.h"
+        if not version_h.exists():
+            raise AssertionError(f"Expected {version_h} to be present")
+        text = version_h.read_text()
+        major_match = re.search(r"#define TORCH_VERSION_MAJOR\s+(\d+)", text)
+        minor_match = re.search(r"#define TORCH_VERSION_MINOR\s+(\d+)", text)
+        if not major_match or not minor_match:
+            raise RuntimeError(
+                f"Could not parse TORCH_VERSION_MAJOR/MINOR from {version_h}"
+            )
+        return int(major_match.group(1)), int(minor_match.group(1))
+
+    def _get_standard_version_format(packed: int | str) -> str:
+        if isinstance(packed, str):
+            packed = int(packed, 16)
+        ver_major = (packed >> 56) & 0xFF
+        ver_minor = (packed >> 48) & 0xFF
+        ver_patch = (packed >> 40) & 0xFF
+        if ver_patch:
+            return f"{ver_major}.{ver_minor}.{ver_patch}"
+        return f"{ver_major}.{ver_minor}"
+
+    include_dir = install_root / "include"
+    if not include_dir.exists():
+        raise AssertionError(f"Expected {include_dir} to be present")
+
+    major, minor = _header_torch_version(include_dir)
+    old_target = f"0x{2:02x}{10:02x}000000000000"  # TORCH_TARGET_VERSION=2.10
+    new_target = f"0x{major:02x}{minor + 1:02x}000000000000"  # TORCH_TARGET_VERSION=major.(minor+1)
+    old_target_standard_format = _get_standard_version_format(old_target)
+    new_target_standard_format = _get_standard_version_format(new_target)
+    print(
+        f"Checking TORCH_TARGET_VERSION guard against headers {major}.{minor}: "
+        f"ok={old_target} ({old_target_standard_format}) "
+        f"fail={new_target} ({new_target_standard_format})"
+    )
+
+    test_cpp_content = """
+#include <torch/csrc/stable/version.h>
+int main() { return 0; }
+"""
+    compile_flags = [
+        "g++",
+        "-std=c++17",
+        f"-I{include_dir}",
+        "-c",
+    ]
+
+    _compile_and_extract_symbols(
+        cpp_content=test_cpp_content,
+        compile_flags=compile_flags + [f"-DTORCH_TARGET_VERSION={old_target}"],
+    )
+    print(
+        f"Compilation succeeded with TORCH_TARGET_VERSION={old_target} ({old_target_standard_format})"
+    )
+
+    expected_error_msg = "TORCH_TARGET_VERSION is newer than the libtorch headers this build is compiling against."
+    try:
+        _compile_and_extract_symbols(
+            cpp_content=test_cpp_content,
+            compile_flags=compile_flags + [f"-DTORCH_TARGET_VERSION={new_target}"],
+        )
+    except RuntimeError as e:
+        if expected_error_msg not in str(e):
+            raise RuntimeError(
+                f"Expected error message to contain:\n  '{expected_error_msg}'\n"
+                f"but got:\n{str(e)[:1000]}"
+            ) from e
+    else:
+        raise RuntimeError(
+            f"Expected compilation to fail with TORCH_TARGET_VERSION={new_target} ({new_target_standard_format}), "
+            "but it succeeded"
+        )
+    print(
+        f"Compilation correctly failed with TORCH_TARGET_VERSION={new_target} ({new_target_standard_format})"
+    )
+
+
 def check_stable_api_symbols(install_root: Path) -> None:
     """
     Test that stable API headers still expose symbols with TORCH_STABLE_ONLY.
@@ -496,6 +582,7 @@ def main() -> None:
 
     # Check symbols when TORCH_STABLE_ONLY is defined
     check_stable_only_symbols(install_root)
+    check_torch_target_version_guard(install_root)
     check_stable_api_symbols(install_root)
     check_headeronly_symbols(install_root)
     check_aoti_shim_symbols(install_root)

--- a/.ci/pytorch/smoke_test/check_binary_symbols.py
+++ b/.ci/pytorch/smoke_test/check_binary_symbols.py
@@ -258,92 +258,6 @@ int main() { return 0; }
     _expect_compilation_failure(compile_flags_with_both, "both macros")
 
 
-def check_torch_target_version_guard(install_root: Path) -> None:
-    """
-    TORCH_TARGET_VERSION must be <= TORCH_ABI_VERSION of the headers in this
-    install. Targeting an older ABI compiles; targeting one minor past the
-    build fails with the version.h #error.
-    """
-
-    def _header_torch_version(include_dir: Path) -> tuple[int, int]:
-        version_h = include_dir / "torch" / "headeronly" / "version.h"
-        if not version_h.exists():
-            raise AssertionError(f"Expected {version_h} to be present")
-        text = version_h.read_text()
-        major_match = re.search(r"#define TORCH_VERSION_MAJOR\s+(\d+)", text)
-        minor_match = re.search(r"#define TORCH_VERSION_MINOR\s+(\d+)", text)
-        if not major_match or not minor_match:
-            raise RuntimeError(
-                f"Could not parse TORCH_VERSION_MAJOR/MINOR from {version_h}"
-            )
-        return int(major_match.group(1)), int(minor_match.group(1))
-
-    def _get_standard_version_format(packed: int | str) -> str:
-        if isinstance(packed, str):
-            packed = int(packed, 16)
-        ver_major = (packed >> 56) & 0xFF
-        ver_minor = (packed >> 48) & 0xFF
-        ver_patch = (packed >> 40) & 0xFF
-        if ver_patch:
-            return f"{ver_major}.{ver_minor}.{ver_patch}"
-        return f"{ver_major}.{ver_minor}"
-
-    include_dir = install_root / "include"
-    if not include_dir.exists():
-        raise AssertionError(f"Expected {include_dir} to be present")
-
-    major, minor = _header_torch_version(include_dir)
-    old_target = f"0x{2:02x}{10:02x}000000000000"  # TORCH_TARGET_VERSION=2.10
-    new_target = f"0x{major:02x}{minor + 1:02x}000000000000"  # TORCH_TARGET_VERSION=major.(minor+1)
-    old_target_standard_format = _get_standard_version_format(old_target)
-    new_target_standard_format = _get_standard_version_format(new_target)
-    print(
-        f"Checking TORCH_TARGET_VERSION guard against headers {major}.{minor}: "
-        f"ok={old_target} ({old_target_standard_format}) "
-        f"fail={new_target} ({new_target_standard_format})"
-    )
-
-    test_cpp_content = """
-#include <torch/csrc/stable/version.h>
-int main() { return 0; }
-"""
-    compile_flags = [
-        "g++",
-        "-std=c++17",
-        f"-I{include_dir}",
-        "-c",
-    ]
-
-    _compile_and_extract_symbols(
-        cpp_content=test_cpp_content,
-        compile_flags=compile_flags + [f"-DTORCH_TARGET_VERSION={old_target}"],
-    )
-    print(
-        f"Compilation succeeded with TORCH_TARGET_VERSION={old_target} ({old_target_standard_format})"
-    )
-
-    expected_error_msg = "TORCH_TARGET_VERSION is newer than the libtorch headers this build is compiling against."
-    try:
-        _compile_and_extract_symbols(
-            cpp_content=test_cpp_content,
-            compile_flags=compile_flags + [f"-DTORCH_TARGET_VERSION={new_target}"],
-        )
-    except RuntimeError as e:
-        if expected_error_msg not in str(e):
-            raise RuntimeError(
-                f"Expected error message to contain:\n  '{expected_error_msg}'\n"
-                f"but got:\n{str(e)[:1000]}"
-            ) from e
-    else:
-        raise RuntimeError(
-            f"Expected compilation to fail with TORCH_TARGET_VERSION={new_target} ({new_target_standard_format}), "
-            "but it succeeded"
-        )
-    print(
-        f"Compilation correctly failed with TORCH_TARGET_VERSION={new_target} ({new_target_standard_format})"
-    )
-
-
 def check_stable_api_symbols(install_root: Path) -> None:
     """
     Test that stable API headers still expose symbols with TORCH_STABLE_ONLY.
@@ -582,7 +496,6 @@ def main() -> None:
 
     # Check symbols when TORCH_STABLE_ONLY is defined
     check_stable_only_symbols(install_root)
-    check_torch_target_version_guard(install_root)
     check_stable_api_symbols(install_root)
     check_headeronly_symbols(install_root)
     check_aoti_shim_symbols(install_root)

--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -264,7 +264,7 @@ Extensions can select the minimum abi version to be compatible with using:
 #define TORCH_TARGET_VERSION (((0ULL + major) << 56) | ((0ULL + minor) << 48))
 ```
 
-before including any stable headers or by passing the equivalent `-D` option to the compiler. Otherwise, the default will be the current `TORCH_ABI_VERSION`.
+before including any stable headers or by passing the equivalent `-D` option to the compiler. Otherwise, the default will be the current `TORCH_ABI_VERSION`. The chosen `TORCH_TARGET_VERSION` must be less than or equal to the `TORCH_ABI_VERSION` of the libtorch headers being compiled against; a larger value is a compile error.
 
 The above ensures that if a user defines `TORCH_TARGET_VERSION` to be 0x0209000000000000 (2.9) and attempts to use a C shim API `foo` that was introduced in version 2.10, a compilation error will be raised. Similarly, the C++ wrapper APIs in `torch/csrc/stable` are compatible with older libtorch binaries up to the TORCH_ABI_VERSION they are exposed in and forward compatible with newer libtorch binaries.
 

--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -266,7 +266,7 @@ Extensions can select the minimum abi version to be compatible with using:
 
 before including any stable headers or by passing the equivalent `-D` option to the compiler. Otherwise, the default will be the current `TORCH_ABI_VERSION`.
 
-You cannot target a newer ABI than the libtorch you are compiling against. Setting TORCH_TARGET_VERSION above that will result in a compile error.
+You cannot target a newer ABI than the libtorch you are compiling against. Setting `TORCH_TARGET_VERSION` above `TORCH_ABI_VERSION` will result in a compile error.
 
 The above ensures that if a user defines `TORCH_TARGET_VERSION` to be 0x0209000000000000 (2.9) and attempts to use a C shim API `foo` that was introduced in version 2.10, a compilation error will be raised. Similarly, the C++ wrapper APIs in `torch/csrc/stable` are compatible with older libtorch binaries up to the TORCH_ABI_VERSION they are exposed in and forward compatible with newer libtorch binaries.
 

--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -266,7 +266,8 @@ Extensions can select the minimum abi version to be compatible with using:
 
 before including any stable headers or by passing the equivalent `-D` option to the compiler. Otherwise, the default will be the current `TORCH_ABI_VERSION`.
 
-You cannot target a newer ABI than the libtorch you are compiling against. Setting `TORCH_TARGET_VERSION` above `TORCH_ABI_VERSION` will result in a compile error.
+You cannot target a newer ABI version than the libtorch you are compiling against. Setting `TORCH_TARGET_VERSION` above the torch version (`TORCH_ABI_VERSION`) you are
+building with will result in a compile error.
 
 The above ensures that if a user defines `TORCH_TARGET_VERSION` to be 0x0209000000000000 (2.9) and attempts to use a C shim API `foo` that was introduced in version 2.10, a compilation error will be raised. Similarly, the C++ wrapper APIs in `torch/csrc/stable` are compatible with older libtorch binaries up to the TORCH_ABI_VERSION they are exposed in and forward compatible with newer libtorch binaries.
 

--- a/docs/source/notes/libtorch_stable_abi.md
+++ b/docs/source/notes/libtorch_stable_abi.md
@@ -264,7 +264,9 @@ Extensions can select the minimum abi version to be compatible with using:
 #define TORCH_TARGET_VERSION (((0ULL + major) << 56) | ((0ULL + minor) << 48))
 ```
 
-before including any stable headers or by passing the equivalent `-D` option to the compiler. Otherwise, the default will be the current `TORCH_ABI_VERSION`. The chosen `TORCH_TARGET_VERSION` must be less than or equal to the `TORCH_ABI_VERSION` of the libtorch headers being compiled against; a larger value is a compile error.
+before including any stable headers or by passing the equivalent `-D` option to the compiler. Otherwise, the default will be the current `TORCH_ABI_VERSION`.
+
+You cannot target a newer ABI than the libtorch you are compiling against. Setting TORCH_TARGET_VERSION above that will result in a compile error.
 
 The above ensures that if a user defines `TORCH_TARGET_VERSION` to be 0x0209000000000000 (2.9) and attempts to use a C shim API `foo` that was introduced in version 2.10, a compilation error will be raised. Similarly, the C++ wrapper APIs in `torch/csrc/stable` are compatible with older libtorch binaries up to the TORCH_ABI_VERSION they are exposed in and forward compatible with newer libtorch binaries.
 

--- a/test/cpp_extensions/test_target_version_guard.py
+++ b/test/cpp_extensions/test_target_version_guard.py
@@ -6,19 +6,13 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from torch.testing._internal.common_utils import (
-    run_tests,
-    skipIfWindows,
-    TestCase,
-)
+from torch.testing._internal.common_utils import run_tests, skipIfWindows, TestCase
 from torch.utils.cpp_extension import get_cxx_compiler, include_paths
 
 
 class TestTargetVersionGuard(TestCase):
     def _compile_target_version_snippet(self, target_expr: str) -> tuple[bool, str]:
-        pytorch_includes = [
-            f"-I{path}" for path in include_paths(device_type="cpu")
-        ]
+        pytorch_includes = [f"-I{path}" for path in include_paths(device_type="cpu")]
         with tempfile.TemporaryDirectory(prefix="target_version_guard_") as tmp:
             src_file = Path(tmp) / "target_version_guard.cpp"
             obj_file = Path(tmp) / "target_version_guard.o"
@@ -48,15 +42,14 @@ int main() {{ return 0; }}
 
     @skipIfWindows(msg="uses gcc/clang compile flags")
     def test_target_version_must_not_exceed_abi_version(self):
-        """TORCH_TARGET_VERSION must be <= TORCH_ABI_VERSION of these headers.
-        """
+        """TORCH_TARGET_VERSION must be <= TORCH_ABI_VERSION of these headers."""
         success, error_msg = self._compile_target_version_snippet("TORCH_ABI_VERSION")
         self.assertTrue(
             success,
             f"Expected TORCH_TARGET_VERSION=TORCH_ABI_VERSION to compile. Error: {error_msg}",
         )
 
-        # test failure of next minor version. 
+        # test failure of next minor version.
         success, error_msg = self._compile_target_version_snippet(
             "(TORCH_ABI_VERSION + (1ULL << 48))"
         )

--- a/test/cpp_extensions/test_target_version_guard.py
+++ b/test/cpp_extensions/test_target_version_guard.py
@@ -1,0 +1,74 @@
+# Owner(s): ["module: cpp"]
+
+"""Compile-time TORCH_TARGET_VERSION vs TORCH_ABI_VERSION guard."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+from torch.testing._internal.common_utils import (
+    run_tests,
+    skipIfWindows,
+    TestCase,
+)
+from torch.utils.cpp_extension import get_cxx_compiler, include_paths
+
+
+class TestTargetVersionGuard(TestCase):
+    def _compile_target_version_snippet(self, target_expr: str) -> tuple[bool, str]:
+        pytorch_includes = [
+            f"-I{path}" for path in include_paths(device_type="cpu")
+        ]
+        with tempfile.TemporaryDirectory(prefix="target_version_guard_") as tmp:
+            src_file = Path(tmp) / "target_version_guard.cpp"
+            obj_file = Path(tmp) / "target_version_guard.o"
+            src_file.write_text(
+                f"""\
+#include <torch/headeronly/version.h>
+#define TORCH_TARGET_VERSION {target_expr}
+#include <torch/csrc/stable/version.h>
+int main() {{ return 0; }}
+"""
+            )
+            result = subprocess.run(
+                [
+                    get_cxx_compiler(),
+                    "-c",
+                    "-std=c++17",
+                    *pytorch_includes,
+                    str(src_file),
+                    "-o",
+                    str(obj_file),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return result.returncode == 0, result.stderr
+
+    @skipIfWindows(msg="uses gcc/clang compile flags")
+    def test_target_version_must_not_exceed_abi_version(self):
+        """TORCH_TARGET_VERSION must be <= TORCH_ABI_VERSION of these headers.
+        """
+        success, error_msg = self._compile_target_version_snippet("TORCH_ABI_VERSION")
+        self.assertTrue(
+            success,
+            f"Expected TORCH_TARGET_VERSION=TORCH_ABI_VERSION to compile. Error: {error_msg}",
+        )
+
+        # test failure of next minor version. 
+        success, error_msg = self._compile_target_version_snippet(
+            "(TORCH_ABI_VERSION + (1ULL << 48))"
+        )
+        self.assertFalse(
+            success,
+            "Expected TORCH_TARGET_VERSION newer than TORCH_ABI_VERSION to fail to compile, but it compiled cleanly.",
+        )
+        self.assertIn(
+            "TORCH_TARGET_VERSION is newer than the libtorch headers",
+            error_msg,
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/cpp_extensions/test_target_version_guard.py
+++ b/test/cpp_extensions/test_target_version_guard.py
@@ -32,7 +32,7 @@ int main() {{ return 0; }}
                 ],
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=60,
             )
             return result.returncode == 0, result.stderr
 

--- a/test/cpp_extensions/test_target_version_guard.py
+++ b/test/cpp_extensions/test_target_version_guard.py
@@ -15,10 +15,8 @@ class TestTargetVersionGuard(TestCase):
         pytorch_includes = [f"-I{path}" for path in include_paths(device_type="cpu")]
         with tempfile.TemporaryDirectory(prefix="target_version_guard_") as tmp:
             src_file = Path(tmp) / "target_version_guard.cpp"
-            obj_file = Path(tmp) / "target_version_guard.o"
             src_file.write_text(
                 f"""\
-#include <torch/headeronly/version.h>
 #define TORCH_TARGET_VERSION {target_expr}
 #include <torch/csrc/stable/version.h>
 int main() {{ return 0; }}
@@ -27,12 +25,10 @@ int main() {{ return 0; }}
             result = subprocess.run(
                 [
                     get_cxx_compiler(),
-                    "-c",
+                    "-fsyntax-only",
                     "-std=c++17",
                     *pytorch_includes,
                     str(src_file),
-                    "-o",
-                    str(obj_file),
                 ],
                 capture_output=True,
                 text=True,
@@ -41,15 +37,28 @@ int main() {{ return 0; }}
             return result.returncode == 0, result.stderr
 
     @skipIfWindows(msg="uses gcc/clang compile flags")
-    def test_target_version_must_not_exceed_abi_version(self):
-        """TORCH_TARGET_VERSION must be <= TORCH_ABI_VERSION of these headers."""
+    def test_target_version_equal_to_abi_version_compiles(self):
+        """TORCH_TARGET_VERSION == TORCH_ABI_VERSION must compile."""
         success, error_msg = self._compile_target_version_snippet("TORCH_ABI_VERSION")
         self.assertTrue(
             success,
             f"Expected TORCH_TARGET_VERSION=TORCH_ABI_VERSION to compile. Error: {error_msg}",
         )
 
-        # test failure of next minor version.
+    @skipIfWindows(msg="uses gcc/clang compile flags")
+    def test_target_version_older_than_abi_version_compiles(self):
+        """TORCH_TARGET_VERSION one minor below TORCH_ABI_VERSION must compile."""
+        success, error_msg = self._compile_target_version_snippet(
+            "(TORCH_ABI_VERSION - (1ULL << 48))"
+        )
+        self.assertTrue(
+            success,
+            f"Expected TORCH_TARGET_VERSION older than TORCH_ABI_VERSION to compile. Error: {error_msg}",
+        )
+
+    @skipIfWindows(msg="uses gcc/clang compile flags")
+    def test_target_version_newer_than_abi_version_fails(self):
+        """TORCH_TARGET_VERSION one minor past TORCH_ABI_VERSION must #error."""
         success, error_msg = self._compile_target_version_snippet(
             "(TORCH_ABI_VERSION + (1ULL << 48))"
         )

--- a/torch/csrc/stable/version.h
+++ b/torch/csrc/stable/version.h
@@ -21,6 +21,10 @@
 //     #include <torch/csrc/stable/library.h>
 
 #ifdef TORCH_TARGET_VERSION
+#if TORCH_TARGET_VERSION > TORCH_ABI_VERSION
+#error TORCH_TARGET_VERSION is newer than the libtorch headers this build is compiling against. \
+Lower TORCH_TARGET_VERSION to <= TORCH_ABI_VERSION, or compile against a newer PyTorch.
+#endif
 #define TORCH_FEATURE_VERSION TORCH_TARGET_VERSION
 #else
 #define TORCH_FEATURE_VERSION TORCH_ABI_VERSION

--- a/torch/csrc/stable/version.h
+++ b/torch/csrc/stable/version.h
@@ -19,11 +19,15 @@
 //   including any header files:
 //     #define TORCH_TARGET_VERSION (((0ULL + 2) << 56) | ((0ULL + 9) << 48))
 //     #include <torch/csrc/stable/library.h>
+//
+// TORCH_TARGET_VERSION must be <= TORCH_ABI_VERSION of the libtorch headers on
+// the include path. A larger value is a compile error.
 
 #ifdef TORCH_TARGET_VERSION
 #if TORCH_TARGET_VERSION > TORCH_ABI_VERSION
-#error TORCH_TARGET_VERSION is newer than the libtorch headers this build is compiling against. \
-Lower TORCH_TARGET_VERSION to <= TORCH_ABI_VERSION, or compile against a newer PyTorch.
+#error \
+    "TORCH_TARGET_VERSION is newer than the libtorch headers this build is compiling against. " \
+    "Lower TORCH_TARGET_VERSION to <= TORCH_ABI_VERSION (see torch/headeronly/version.h), or compile against a newer PyTorch."
 #endif
 #define TORCH_FEATURE_VERSION TORCH_TARGET_VERSION
 #else


### PR DESCRIPTION
Add a check in `torch/csrc/stable/version.h` so that an #error is thrown if `TORCH_TARGET_VERSION > TORCH_ABI_VERSION`, so an extension cannot target APIs that are not in the headers on its include path. `check_binary_symbols.py` compiles a stub with a target below the build (must succeed) and one minor past the build (must fail with that #error).

cc @janeyx99 

## Test Plan
python test/cpp_extensions/test_target_version_guard.py -v

## Test Results
Passed