### PR TITLE
Fix typos and grammar in comments and docstrings

### DIFF
--- a/torch/_dynamo/comptime.py
+++ b/torch/_dynamo/comptime.py
@@ -143,7 +143,7 @@ class ComptimeVar:
         if isinstance(self.__variable, SymNodeVariable):
             self.__variable.evaluate_expr()
         elif self.__variable.is_python_constant():
-            # TODO: Maybe complain if this isn't a int/bool/float variable
+            # TODO: Maybe complain if this isn't an int/bool/float variable
             pass
         else:
             raise AssertionError(

--- a/torch/ao/quantization/backend_config/backend_config.py
+++ b/torch/ao/quantization/backend_config/backend_config.py
@@ -375,7 +375,7 @@ class BackendConfig:
 
     def set_backend_pattern_config(self, config: BackendPatternConfig) -> BackendConfig:
         """
-        Set the config for an pattern that can be run on the target backend.
+        Set the config for a pattern that can be run on the target backend.
         This overrides any existing config for the given pattern.
         """
         # Avoid circular dependencies

--- a/torch/ao/quantization/fx/quantize_handler.py
+++ b/torch/ao/quantization/fx/quantize_handler.py
@@ -144,7 +144,7 @@ def _get_pattern_to_quantize_handlers(
 ) -> dict[Pattern, QuantizerCls]:
     """
     Note: Quantize handler is just a holder for some check methods like
-    (should_insert_observer_for_output), maybe this can be a enum as well,
+    (should_insert_observer_for_output), maybe this can be an enum as well,
     we can refactor this after we convert the path for fbgemm/qnnpack fully to the
     new path, this is not exposed to backend developers
     """

--- a/torch/csrc/jit/backends/backend_debug_handler.h
+++ b/torch/csrc/jit/backends/backend_debug_handler.h
@@ -56,7 +56,7 @@ namespace torch::jit {
  *  serialized. Now we know a. debug handles and b. how to map debug handles to
  *  model source code. Thus we can either do eager symbolication by converting
  *  debug handles to corresponding source code at runtime, or do lazy
- *  symbolicattion offline.
+ *  symbolication offline.
  *
  *  Note that it is not necessary to serialize [debug-handle, DebugInfoTuple]
  *  corresponding to lowered backend if the lowering process, that is

--- a/torch/csrc/jit/codegen/onednn/graph_helper.cpp
+++ b/torch/csrc/jit/codegen/onednn/graph_helper.cpp
@@ -343,7 +343,7 @@ static void mayAddListConstructIntoConcatPartition(
     Node* n,
     OpPartitionMap& opToOwningPartition) {
   // Since prim::ListConstruct is not visible to the LLGA,
-  // it will not be in any partition returned from partfuseritioning results.
+  // it will not be in any partition returned from partitioning results.
   // We need rewrite opToOwningPartition to make the prim::ListConstruct to be
   // 'virtually' in the same partition with the aten::cat, so that
   // prim::ListConstruct can be fused into the fusion group by graph fuser.

--- a/torch/csrc/jit/passes/guard_elimination.cpp
+++ b/torch/csrc/jit/passes/guard_elimination.cpp
@@ -272,7 +272,7 @@ struct GuardElimination {
   // to compute any properties `isSummarized()` isn't amenable to guard
   // elimination.
   // Categories:
-  // * Functional-like(e.g. add, sub, le) operations with broadcast semenatics
+  // * Functional-like(e.g. add, sub, le) operations with broadcast semantics
   //   Guards can be removed if all inputs are guarded and `isSummarized()`
   //   returns
   //   false or inputs are `prim::Constant`

--- a/torch/csrc/jit/passes/utils/subgraph_utils.cpp
+++ b/torch/csrc/jit/passes/utils/subgraph_utils.cpp
@@ -30,8 +30,8 @@ std::vector<std::optional<const Use>> gatherLastUses(
 // Values which do not have uses or which do not have a last use
 // outside of the subgraph to be merged into we do not need to track.
 struct ValueMapper {
-  // `to_merge` is the node we're merginginto a subgraph, `existing_subgraph` is
-  // the subgraph node that we're merging into if it exists
+  // `to_merge` is the node we're merging into a subgraph, `existing_subgraph`
+  // is the subgraph node that we're merging into if it exists
   ValueMapper(
       Node* to_merge,
       AliasDb& db,

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -18,7 +18,7 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
 namespace torch::jit {
 
 // GraphExecutor creates specializations of Graphs for different
-// dimensionalitities and types of inputs.
+// dimensionalities and types of inputs.
 
 struct ArgumentInfo {
   friend struct ArgumentSpec;
@@ -380,7 +380,7 @@ struct CompleteArgumentInfo {
   }
 
  private:
-  // offsetinto sizes_strides() array where the sizes start for tensor j
+  // offset into sizes_strides() array where the sizes start for tensor j
   // [valid range] valid range is [0, ninputs]
   // (i.e. you can ask for the offset at ninputs, which would be the offset of
   // the next tensor if it existed)

--- a/torch/csrc/jit/serialization/export.h
+++ b/torch/csrc/jit/serialization/export.h
@@ -65,7 +65,7 @@ TORCH_API std::string serialize_model_proto_to_string(
 
 TORCH_API void check_onnx_proto(const std::string& proto_string);
 
-// Serializer for both oldsyle and unified format TorchScript serialization
+// Serializer for both oldstyle and unified format TorchScript serialization
 class TORCH_API ScriptModuleSerializer {
  public:
   explicit ScriptModuleSerializer(

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -193,7 +193,7 @@ class ShardedTensorBase(torch.Tensor):
 
 class ShardedTensor(ShardedTensorBase):
     """
-    ShardedTensor is an torch.Tensor subclass to represent Tensors that are sharded
+    ShardedTensor is a torch.Tensor subclass to represent Tensors that are sharded
     across multiple devices and multiple processes.
 
     ShardedTensor is initialized in an SPMD like fashion where each rank

--- a/torch/fx/passes/splitter_base.py
+++ b/torch/fx/passes/splitter_base.py
@@ -1014,7 +1014,7 @@ class _SplitterBase:
         while parent_nodes:
             node = None
 
-            # Find a acc node that depends on visited nodes only
+            # Find an acc node that depends on visited nodes only
             for n in parent_nodes:
                 if deps[n] <= visited_nodes and n in self.acc_nodes:
                     node = n

--- a/torch/headeronly/cuda/Atomic.h
+++ b/torch/headeronly/cuda/Atomic.h
@@ -243,7 +243,7 @@ inline __device__ at::BFloat16 gpuAtomicAdd(
 }
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 600)
-// from CUDA C Programmic Guide
+// from CUDA C Programming Guide
 inline __device__ double atomicAdd(double* address, double val)
 #if defined(__clang__) && defined(__CUDA__)
 #pragma GCC diagnostic push

--- a/torch/library.py
+++ b/torch/library.py
@@ -1238,7 +1238,7 @@ def register_fake(
         >>> @torch.library.register_fake("mylib::custom_nonzero")
         >>> def _(x):
         >>> # Number of nonzero-elements is data-dependent.
-        >>> # Since we cannot peek at the data in an fake impl,
+        >>> # Since we cannot peek at the data in a fake impl,
         >>> # we use the ctx object to construct a new symint that
         >>> # represents the data-dependent size.
         >>>     ctx = torch.library.get_ctx()
@@ -1696,7 +1696,7 @@ def _check_pystubs_once(func, qualname, actual_module_name):
 def get_ctx() -> "torch._library.fake_impl.FakeImplCtx":
     """get_ctx() returns the current AbstractImplCtx object.
 
-    Calling ``get_ctx()`` is only valid inside of an fake impl
+    Calling ``get_ctx()`` is only valid inside of a fake impl
     (see :func:`torch.library.register_fake` for more usage details.
     """
     return torch._library.fake_impl.global_ctx_getter()

--- a/torch/nn/modules/pooling.py
+++ b/torch/nn/modules/pooling.py
@@ -1355,7 +1355,7 @@ class AdaptiveMaxPool2d(_AdaptiveMaxPoolNd):
         output_size: the target output size of the image of the form :math:`H_{out} \times W_{out}`.
                      Can be a tuple :math:`(H_{out}, W_{out})` or a single :math:`H_{out}` for a
                      square image :math:`H_{out} \times H_{out}`. :math:`H_{out}` and :math:`W_{out}`
-                     can be either a ``int``, or ``None`` which means the size will be the same as that
+                     can be either an ``int``, or ``None`` which means the size will be the same as that
                      of the input.
         return_indices: if ``True``, will return the indices along with the outputs.
                         Useful to pass to nn.MaxUnpool2d. Default: ``False``
@@ -1398,7 +1398,7 @@ class AdaptiveMaxPool3d(_AdaptiveMaxPoolNd):
         output_size: the target output size of the image of the form :math:`D_{out} \times H_{out} \times W_{out}`.
                      Can be a tuple :math:`(D_{out}, H_{out}, W_{out})` or a single
                      :math:`D_{out}` for a cube :math:`D_{out} \times D_{out} \times D_{out}`.
-                     :math:`D_{out}`, :math:`H_{out}` and :math:`W_{out}` can be either a
+                     :math:`D_{out}`, :math:`H_{out}` and :math:`W_{out}` can be either an
                      ``int``, or ``None`` which means the size will be the same as that of the input.
 
         return_indices: if ``True``, will return the indices along with the outputs.
@@ -1483,7 +1483,7 @@ class AdaptiveAvgPool2d(_AdaptiveAvgPoolNd):
     Args:
         output_size: the target output size of the image of the form H x W.
                      Can be a tuple (H, W) or a single H for a square image H x H.
-                     H and W can be either a ``int``, or ``None`` which means the size will
+                     H and W can be either an ``int``, or ``None`` which means the size will
                      be the same as that of the input.
 
     Shape:
@@ -1523,7 +1523,7 @@ class AdaptiveAvgPool3d(_AdaptiveAvgPoolNd):
     Args:
         output_size: the target output size of the form D x H x W.
                      Can be a tuple (D, H, W) or a single number D for a cube D x D x D.
-                     D, H and W can be either a ``int``, or ``None`` which means the size will
+                     D, H and W can be either an ``int``, or ``None`` which means the size will
                      be the same as that of the input.
 
     Shape:

--- a/torch/testing/_internal/opinfo/definitions/fft.py
+++ b/torch/testing/_internal/opinfo/definitions/fft.py
@@ -597,7 +597,7 @@ op_db: list[OpInfo] = [
         # See https://github.com/pytorch/pytorch/pull/78358
         check_batched_forward_grad=False,
         dtypes=all_types_and(torch.bool),
-        # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archss
+        # CUDA supports Half/ComplexHalf Precision FFT only on SM53 or later archs
         dtypesIfCUDA=all_types_and(torch.bool, torch.half, torch.bfloat16),
         check_batched_grad=False,
         check_batched_gradgrad=False,

--- a/torch/utils/_strobelight/cli_function_profiler.py
+++ b/torch/utils/_strobelight/cli_function_profiler.py
@@ -58,7 +58,7 @@ class StrobelightCLIFunctionProfiler:
 
     StrobelightCLIFunctionProfiler can be used to profile a python function and
     generate a strobelight link with the results. It works on meta servers but
-    does not requires an fbcode target.
+    does not require an fbcode target.
     When stop_at_error is false(default), error during profiling does not prevent
     the work function from running.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Corrects misspellings ("symbolicattion", "partfuseritioning", "merginginto",
"dimensionalitities", "oldsyle", "semenatics", "archss", "Programmic"), missing
word breaks ("offsetinto"), incorrect articles ("a int"/"an fake"), and a
subject-verb disagreement in comments and docstrings across torch. No
functional changes.

Test Plan: comment- and docstring-only changes, so no behavior to test. Lint
was verified with:

```
lintrunner -a
```

Authored with the assistance of an AI coding assistant.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal @voznesenskym @penguinwu @EikanWang @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98