### PR TITLE
[inductor] Branch on dynamic divisibility with noinline Triton helpers

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -39,6 +39,7 @@ from torch._inductor.virtualized import V
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
+    HAS_CUDA_AND_TRITON,
     HAS_GPU,
     HAS_GPU_AND_TRITON,
 )
@@ -277,6 +278,61 @@ def helper(x):
         self.assertTrue(
             V.graph.sizevars.statically_known_multiple_of(s2, 16),
         )
+
+    @unittest.skipUnless(
+        HAS_CUDA_AND_TRITON and torch.version.hip is None and GPU_TYPE == "cuda",
+        "requires NVIDIA CUDA and Triton",
+    )
+    @inductor_config.patch(
+        {"force_pointwise_cat": True, "triton.divisible_by_16": True}
+    )
+    def test_runtime_divisibility_specializes_dynamic_kernel(self):
+        from torch._dynamo.testing import CompileCounterWithBackend
+
+        def fn(*inputs):
+            return torch.cat(inputs, dim=-1) + 1
+
+        def make_inputs(rows, widths):
+            return [
+                torch.randn(rows, width, device=GPU_TYPE, dtype=torch.bfloat16)
+                for width in widths
+            ]
+
+        counter = CompileCounterWithBackend("inductor")
+        compiled = torch.compile(fn, backend=counter, dynamic=True, fullgraph=True)
+
+        aligned = make_inputs(96, (16, 32, 48, 64, 80))
+        actual, code = run_and_get_code(compiled, *aligned)
+        self.assertEqual(actual, fn(*aligned))
+
+        source = "\n".join(code)
+        self.assertEqual(source.count("@triton.jit(noinline=True)"), 2)
+        self.assertIn("_aligned(", source)
+        self.assertIn("_fallback(", source)
+        self.assertGreater(source.count(" = tl.multiple_of(tl.where("), 4)
+        self.assertGreater(source.count("_is_aligned = "), 4)
+        self.assertIn(
+            "ks0 = tl.multiple_of(tl.where(ks0 % 16 == 0, ks0, 16), 16)",
+            source,
+        )
+        self.assertNotIn("tl.debug_barrier()", source)
+        self.assertLess(
+            source.index("@triton.jit(noinline=True)"),
+            source.index("@triton_heuristics.pointwise"),
+        )
+
+        unaligned = make_inputs(96, (17, 31, 48, 64, 80))
+        self.assertEqual(compiled(*unaligned), fn(*unaligned))
+        self.assertEqual(counter.frame_count, 1)
+
+        with inductor_config.patch("force_disable_caches", True):
+            unaligned_compiled = torch.compile(fn, dynamic=True, fullgraph=True)
+            actual, code = run_and_get_code(unaligned_compiled, *unaligned)
+        self.assertEqual(actual, fn(*unaligned))
+        source = "\n".join(code)
+        self.assertNotIn("@triton.jit(noinline=True)", source)
+        self.assertNotIn("_aligned(", source)
+        self.assertNotIn("_fallback(", source)
 
     @inductor_config.patch("triton.divisible_by_16", True)
     def test_config_of_skips_graph_input_tensor_divisibility_for_cpp_wrapper_jit(self):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7371,6 +7371,36 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         self._filter_pdl(self.body)
 
+        runtime_divisible_by_16: tuple[int, ...] = ()
+        # Keep runtime specialization to two paths in memory-heavy pointwise kernels.
+        if (
+            config.triton.divisible_by_16
+            and torch.version.hip is None
+            and props_device.type == "cuda"
+            and not self.features.is_reduction()
+            and not self.is_combo_kernel
+            and not self.uses_tma
+            and not self.atomic_add_found
+            and self.num_load >= 4
+        ):
+            candidates = tuple(
+                (i, arg.expr)
+                for i, arg in enumerate(signature)
+                if isinstance(arg, SizeArg)
+                and arg.expr is not None
+                and triton_meta_signature[argdefs[i].name] in ("i32", "i64")
+                and not arg.name.startswith("load_seed_offset")
+                and bool(getattr(arg.expr, "free_symbols", ()))
+                and not V.graph.sizevars.statically_known_multiple_of(arg.expr, 16)
+            )
+            # Optimization hints do not add guards. Avoid paying for a specialization
+            # on workloads whose observed dynamic sizes cannot take its fast path.
+            if candidates and all(
+                V.graph.sizevars.optimization_hint(expr, fallback=1) % 16 == 0
+                for _, expr in candidates
+            ):
+                runtime_divisible_by_16 = tuple(i for i, _ in candidates)
+
         # Compute configs after codegen_body() so we know if the kernel
         # uses atomic ops. On HIP, buffer ops don't support atomics, so
         # we must not tag any args with pointer_range_32 in that case.
@@ -7393,6 +7423,41 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         for helper in self.helper_functions:
             code.writeline("")
             code.splice(helper)
+
+        runtime_divisible_names = tuple(
+            argdefs[i].name for i in runtime_divisible_by_16
+        )
+
+        def codegen_kernel_body() -> None:
+            self.codegen_static_numels(code)
+            for old, new in self.args.aliases():
+                code.writeline(f"{old} = {new}")
+            code.splice(self.body)
+
+        kernel_name = name or str(Placeholder.KERNEL_NAME)
+        aligned_body_name = f"{kernel_name}_aligned"
+        fallback_body_name = f"{kernel_name}_fallback"
+        if runtime_divisible_by_16:
+            for body_name, aligned in (
+                (aligned_body_name, True),
+                (fallback_body_name, False),
+            ):
+                code.writeline("")
+                code.writeline("@triton.jit(noinline=True)")
+                code.writeline(
+                    f"def {body_name}({', '.join(x.full_name() for x in argdefs)}):"
+                )
+                with code.indent():
+                    if aligned:
+                        # The outer branch guarantees every predicate is true. The
+                        # fallback 16 makes each tl.where a fresh always-divisible SSA
+                        # value; Triton drops hints on noinline function parameters.
+                        for arg_name in runtime_divisible_names:
+                            code.writeline(
+                                f"{arg_name} = tl.multiple_of("
+                                f"tl.where({arg_name} % 16 == 0, {arg_name}, 16), 16)"
+                            )
+                    codegen_kernel_body()
 
         if self.fixed_config:
             heuristics_line = f"""
@@ -7430,17 +7495,27 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 @triton.jit
             """
         code.splice(heuristics_line)
-        kernel_name = name or str(Placeholder.KERNEL_NAME)
         code.writeline(
             f"def {kernel_name}({', '.join(x.full_name() for x in argdefs)}):"
         )
         with code.indent():
             if config.triton.proton_profiling:
                 code.writeline(f'pl.enter_scope("{kernel_name}")')
-            self.codegen_static_numels(code)
-            for old, new in self.args.aliases():
-                code.writeline(f"{old} = {new}")
-            code.splice(self.body)
+            if runtime_divisible_by_16:
+                for arg_name in runtime_divisible_names:
+                    code.writeline(f"{arg_name}_is_aligned = {arg_name} % 16 == 0")
+                condition = " and ".join(
+                    f"{arg_name}_is_aligned" for arg_name in runtime_divisible_names
+                )
+                call_args = ", ".join(arg.name for arg in argdefs)
+                code.writeline(f"if {condition}:")
+                with code.indent():
+                    code.writeline(f"{aligned_body_name}({call_args})")
+                code.writeline("else:")
+                with code.indent():
+                    code.writeline(f"{fallback_body_name}({call_args})")
+            else:
+                codegen_kernel_body()
             if config.triton.proton_profiling:
                 code.writeline(f'pl.exit_scope("{kernel_name}")')
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193964

Issue: https://github.com/pytorch/pytorch/issues/189940

Dynamic pointwise kernels cannot attach Triton's 16-byte divisibility metadata
to symbolic shape arguments unless Inductor can prove their divisibility
statically. In the issue repro, the missing metadata keeps a fused concat kernel
on scalar loads even though its runtime sizes are divisible by 16.

Graph-level alignment guards would recompile the whole graph and can expose a
combinatorial set of alignment states when a fused kernel has many arguments.
Keep the decision local to one Triton kernel instead. For memory-heavy NVIDIA
pointwise kernels whose observed dynamic sizes are aligned, emit aligned and
fallback device functions before the ordinary top-level kernel:

```python
@triton.jit(noinline=True)
def triton_poi_0_aligned(..., ks0, ks1, xnumel, XBLOCK: tl.constexpr):
    ks0 = tl.multiple_of(tl.where(ks0 % 16 == 0, ks0, 16), 16)
    ks1 = tl.multiple_of(tl.where(ks1 % 16 == 0, ks1, 16), 16)
    xnumel = tl.multiple_of(
        tl.where(xnumel % 16 == 0, xnumel, 16), 16
    )
    ... original kernel body ...

@triton.jit(noinline=True)
def triton_poi_0_fallback(..., ks0, ks1, xnumel, XBLOCK: tl.constexpr):
    ... original kernel body ...

@triton_heuristics.pointwise(...)
@triton.jit
def triton_poi_0(..., ks0, ks1, xnumel, XBLOCK: tl.constexpr):
    ks0_is_aligned = ks0 % 16 == 0
    ks1_is_aligned = ks1 % 16 == 0
    xnumel_is_aligned = xnumel % 16 == 0
    if ks0_is_aligned and ks1_is_aligned and xnumel_is_aligned:
        triton_poi_0_aligned(..., ks0, ks1, xnumel, XBLOCK)
    else:
        triton_poi_0_fallback(..., ks0, ks1, xnumel, XBLOCK)
```

The noinline boundary prevents Triton from merging the paths and discarding the
aligned-path optimization. Triton 3.7 drops hints attached directly to noinline
function parameters, so the aligned function deliberately recreates each value
with `tl.where` before applying `tl.multiple_of`. The outer branch guarantees the
original value is selected, while the constant fallback makes the new SSA value
divisible on every path. This preserves the argument's i32 or i64 type.

The body remains unchanged and is simply spliced into both device functions.
There is one top-level kernel, one Triton source compilation, no debug barrier,
no extra launch argument, and no Dynamo guard. The all-or-none policy always
produces two paths rather than 2^N paths, so it also handles kernels with more
than four candidate size arguments.

Specialization remains limited to NVIDIA pointwise kernels with at least four
loads and only when every candidate's non-guarding optimization hint is aligned.
Reductions, combo kernels, TMA, atomics, HIP, and unaligned-first workloads retain
their generic behavior. The existing `triton.divisible_by_16` setting remains
the opt-out, with no new user-facing flag.

On the issue repro, aligned execution improves from about 0.158 ms to 0.057 ms;
the manually hinted kernel is about 0.045 ms. A 20-input concat experiment runs
the noinline aligned path in about 0.071 ms versus 0.186 ms generic, with about
11% additional cold compilation time.

The single-kernel approach has an inherent launch-configuration tradeoff. The
aligned and fallback functions share the XBLOCK, warps, and stages selected while
autotuning the first aligned invocation. A later unaligned invocation therefore
takes about 0.270 ms instead of the generic kernel's 0.158 ms. The separate
multi-kernel approach avoids that regression by selecting different compiled
launch configurations; this commit keeps the noinline experiment isolated for
comparison.

An ordinary inline branch and a debug-barrier branch were also considered. The
inline form is merged by Triton and loses the branch-local divisibility benefit.
A barrier preserves the branch but introduces an unrelated side effect. Noinline
device functions express the required optimization boundary directly and follow
an existing Inductor pattern used by combo kernels.

Test Plan:

```bash
python test/inductor/test_codegen_triton.py TestCodegenTriton.test_config_of_sizearg TestCodegenTriton.test_config_of_sizearg_with_check_constraint TestCodegenTriton.test_config_of_skips_graph_input_tensor_divisibility_for_cpp_wrapper_jit TestCodegenTriton.test_runtime_divisibility_specializes_dynamic_kernel
python test/inductor/test_combo_kernels.py ComboKernelTests.test_activation_functions ComboKernelDynamicShapesTests.test_dynamic_shapes_activations
python -m py_compile test/inductor/test_codegen_triton.py torch/_inductor/codegen/triton.py
git diff --check
git diff --cached --check
```

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo