### PR TITLE
Fix grammar and spelling errors in comments and docstrings

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -39,8 +39,8 @@ static thread_local std::string g_aoti_last_error;
             std::to_string(actual_size));                         \
   } while (0)
 
-// AOTInductor uses at::addmm_out, which doesn't supports
-// arguments that requires gradient. For this reason, we
+// AOTInductor uses at::addmm_out, which doesn't support
+// arguments that require gradient. For this reason, we
 // enforce no_grad context for run APIs.
 //
 // A RAII, thread local (!) guard that enables or disables grad mode upon

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -177,7 +177,7 @@ def use_native_matmul(mat1, mat2):
     # If the shape has unbacked symbols, don't do native matmul.
     # This is related to the behavior of statically_known_multiple_of on unbacked symints.
     # Since statically_known_multiple_of just returns False for unbacked symbols
-    # due to the expensive cost, codegen fails when there is a unbacked symbol.
+    # due to the expensive cost, codegen fails when there is an unbacked symbol.
     # In particular, it fails at _split_iteration_ranges in codegen/simd.py.
     # See this : https://github.com/pytorch/pytorch/pull/131649
     if any(map(has_free_unbacked_symbols, [m, k, n])):

--- a/torch/csrc/autograd/custom_function.cpp
+++ b/torch/csrc/autograd/custom_function.cpp
@@ -403,7 +403,7 @@ static optional_variable_list _process_backward_mode_ad(
   int num_diff_outputs = 0;
 
   for (const auto i : c10::irange(num_outputs)) {
-    // We put a undefined_input placeholder for outputs that are not tensor and
+    // We put an undefined_input placeholder for outputs that are not tensor and
     // for when the output tensor is not differentiable (see below)
     if (!raw_outputs[i].has_value()) {
       if (cdata) {

--- a/torch/csrc/distributed/c10d/Work.hpp
+++ b/torch/csrc/distributed/c10d/Work.hpp
@@ -47,7 +47,7 @@ enum class WorkResult : std::uint8_t {
 // Converts OpType to human readable string.
 TORCH_API std::string opTypeToString(OpType opType);
 
-// Whether or not an OP is an p2p op (SEND, RECV, RECVANYSOURCE)
+// Whether or not an OP is a p2p op (SEND, RECV, RECVANYSOURCE)
 TORCH_API bool isP2POp(OpType opType, bool batchP2P = false);
 
 // Please do not use Work API, it is going away, to be

--- a/torch/csrc/distributed/rpc/request_callback_impl.cpp
+++ b/torch/csrc/distributed/rpc/request_callback_impl.cpp
@@ -249,7 +249,7 @@ c10::intrusive_ptr<JitFuture> RequestCallbackImpl::processRpcWithErrors(
     py::gil_scoped_acquire acquire;
     e.restore(); // Release ownership on py::objects and also restore
                  // Python Error Indicator.
-    PyErr_Clear(); // Clear the Python Error Indicator as we has
+    PyErr_Clear(); // Clear the Python Error Indicator as we have
                    // recorded the exception in the response message.
     return future;
   } catch (std::exception& e) {

--- a/torch/csrc/jit/backends/backend_debug_handler.cpp
+++ b/torch/csrc/jit/backends/backend_debug_handler.cpp
@@ -22,7 +22,7 @@ int64_t BackendDebugInfoRecorder::getNextDebugHandle(const Node* node) {
 }
 
 BackendDebugInfoMapType BackendDebugInfoRecorder::stopRecording() {
-  // Note that this is return by copy and since
+  // Note that this is returned by copy and since
   // InlinedCallStackPtrs are intrusive ptr it will result in
   // bump of refcount. Not performant, but this is not intended
   // to be used in perf critical path.

--- a/torch/csrc/jit/passes/quantization/helper.h
+++ b/torch/csrc/jit/passes/quantization/helper.h
@@ -142,12 +142,12 @@ TORCH_API std::vector<std::string> getModuleAccessPath(
 TORCH_API Module
 findChildModule(const Module& module, const std::vector<std::string>& path);
 
-// Given an CallMethod node, get the module instance corresponding
+// Given a CallMethod node, get the module instance corresponding
 // to the instance Value
 // TODO: refactor all current uses of this function to the Opt one
 TORCH_API Module getInvokedModule(Module& module, Node* n, Value* self);
 
-// Given an CallMethod node, get the module instance corresponding
+// Given a CallMethod node, get the module instance corresponding
 // to the instance Value if the instance is a module, otherwise return
 // std::nullopt
 std::optional<Module> getInvokedModuleOpt(

--- a/torch/csrc/jit/python/pybind_utils.h
+++ b/torch/csrc/jit/python/pybind_utils.h
@@ -181,7 +181,7 @@ struct VISIBILITY_HIDDEN PythonFutureWrapper
               // Release ownership on py::objects and also restore Python
               // Error Indicator.
               e.restore();
-              // Clear the Python Error Indicator as we has recorded the
+              // Clear the Python Error Indicator as we have recorded the
               // exception in the response message.
               PyErr_Clear();
             }
@@ -207,7 +207,7 @@ struct VISIBILITY_HIDDEN PythonFutureWrapper
               // Release ownership on py::objects and also restore Python
               // Error Indicator.
               e.restore();
-              // Clear the Python Error Indicator as we has recorded the
+              // Clear the Python Error Indicator as we have recorded the
               // exception in the response message.
               PyErr_Clear();
             }

--- a/torch/distributed/checkpoint/_checkpointer.py
+++ b/torch/distributed/checkpoint/_checkpointer.py
@@ -43,7 +43,7 @@ class _Checkpointer:
         """Initializes the Checkpointer instance.
 
         Args:
-            storage_writer: Instance of StorageWrite used to perform writes.
+            storage_writer: Instance of StorageWriter used to perform writes.
             storage_reader: StorageReader used to load data from.
             process_group: ProcessGroup to be used for cross-rank synchronization.
             coordinator_rank: Rank to use to coordinate the checkpoint. rank0 is used by default.

--- a/torch/distributed/tensor/_op_schema.py
+++ b/torch/distributed/tensor/_op_schema.py
@@ -102,7 +102,7 @@ class OpSpec:
     DTensorSpec; when the return value is a tuple of Optional[DTensor],
     output_specs is a tuple of Optional[DTensorSpec].
 
-    note: we MUST produce an DTensorSpec for every output that is a Tensor.  None
+    note: we MUST produce a DTensorSpec for every output that is a Tensor.  None
     entries only occur for non-Tensor outputs (e.g., operators that return Optional[Tensor],
     or non-Tensor outputs.)
 

--- a/torch/distributed/tensor/_ops/_common_rules.py
+++ b/torch/distributed/tensor/_ops/_common_rules.py
@@ -82,7 +82,7 @@ def einop_rule(
 
     def merge_sharding(dim: str, a: int, b: int) -> int:
         # merge the sharding of inputs if it's able to merge, i.e. we can merge
-        # replicate and shard to shard, but this will trigger an reshard operation
+        # replicate and shard to shard, but this will trigger a reshard operation
         if a != b:
             if a == -1 or b == -1:
                 # reshard the replicate to match the sharded one

--- a/torch/nativert/graph/passes/SubgraphRewriter.h
+++ b/torch/nativert/graph/passes/SubgraphRewriter.h
@@ -57,7 +57,7 @@ inline std::ostream& operator<<(std::ostream& out, const Match& match) {
  *
  * Constraints for Patterns with Multiple Output Nodes:
  * To avoid an exponential increase in the search space, this implementation
- * starts searching from the first output node as an anchor as an heuristic. It
+ * starts searching from the first output node as an anchor as a heuristic. It
  * assumes that all other output nodes in the pattern are interconnected through
  * the graph from this anchor node, allowing the matcher to traverse from the
  * anchor to other outputs.

--- a/torch/onnx/_internal/exporter/_type_casting.py
+++ b/torch/onnx/_internal/exporter/_type_casting.py
@@ -25,7 +25,7 @@ def get_float4_shape(tensor: torch.Tensor) -> tuple[int, ...]:
     The float4_e2m1fn_x2 type is a shell type described in
     https://github.com/pytorch/pytorch/issues/146414.
 
-    the shell dtype is takes up 1 byte per element and semantically represents
+    the shell dtype takes up 1 byte per element and semantically represents
     two fp4 values packed into 1 byte. Semantically it represents (*tensor.shape[:-1], tensor.shape[-1]*2)
     fp4 elements.
     """

--- a/torch/onnx/_internal/fx/_pass.py
+++ b/torch/onnx/_internal/fx/_pass.py
@@ -215,7 +215,7 @@ class Transform(abc.ABC):
     ) -> tuple[Any, ...]:
         if fake_mode is None:
             return args
-        # NB: This should hit the cache if tensors were fakefied before.
+        # NB: This should hit the cache if tensors were fakified before.
         # E.g., when the fx graph is produced by Dynamo.
         return tuple(
             fake_mode.from_tensor(t) if isinstance(t, torch.Tensor) else t for t in args

--- a/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
+++ b/torch/onnx/_internal/torchscript_exporter/symbolic_opset11.py
@@ -1062,7 +1062,7 @@ def _get_im2col_indices_along_dim(
     kernel_grid = torch.arange(0, kernel_size_d * dilation_d, dilation_d)
     kernel_grid = g.op("Constant", value_t=kernel_grid.unsqueeze(0))
 
-    # Broadcast and add kernel staring positions (indices) with
+    # Broadcast and add kernel starting positions (indices) with
     # kernel_grid along dim d, to get block indices along dim d
     blocks_d_indices = symbolic_helper._unsqueeze_helper(
         g, blocks_d_indices, [0]

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -479,7 +479,7 @@ def _unpack_efficient_attention_nested_shapes(
     max_seqlen_k,
 ) -> Iterator[tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...], tuple[int, ...] | None]]:
     """
-    Given inputs to a efficient_attention_(forward|backward) kernel, this will handle behavior for
+    Given inputs to an efficient_attention_(forward|backward) kernel, this will handle behavior for
     NestedTensor inputs by effectively unbinding the NestedTensor and yielding the shapes for
     each batch element.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193965

Corrects article agreement ("an unbacked" / "a DTensorSpec"), subject-verb
agreement ("we have recorded"), and a handful of typos ("staring" ->
"starting", "fakefied" -> "fakified", "StorageWrite" -> "StorageWriter")
across comments and docstrings. Comments and docstrings only; no functional
changes.

This PR was authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo