### PR TITLE
Fix dispatch failure on a tensor subclass with no __torch_dispatch__

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1226,6 +1226,79 @@ class SubclassTests(_SubclassCompileCheckMixin, torch._dynamo.test_case.TestCase
         self.assertEqual(res_exp, res_act)
         self.assertEqual(x0, x1)
 
+    # https://github.com/pytorch/pytorch/issues/193932
+    @torch._functorch.config.patch(check_custom_op_aliasing=True)
+    def test_bare_subclass_matmul(self):
+        # matmul lowers to an extern kernel, so the compiled code re-enters
+        # dispatch with the subclass input still wrapped.
+        class Bare(torch.Tensor):
+            pass
+
+        def fn(t):
+            return t @ t.t()
+
+        x = torch.randn(4, 4)
+        res_exp = fn(x.as_subclass(Bare))
+        opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        res_act = opt_fn(x.as_subclass(Bare))
+        self.assertEqual(res_exp, res_act)
+        self.assertIsInstance(res_act, Bare)
+
+    # https://github.com/pytorch/pytorch/issues/193932
+    @torch._functorch.config.patch(check_custom_op_aliasing=True)
+    def test_bare_subclass_matmul_aot_eager(self):
+        # Same failure without inductor: aten.t.default re-enters dispatch under
+        # AOTAutograd's runtime wrapper.
+        class Bare(torch.Tensor):
+            pass
+
+        def fn(t):
+            return t @ t.t()
+
+        x = torch.randn(4, 4)
+        res_exp = fn(x.as_subclass(Bare))
+        opt_fn = torch.compile(fn, backend="aot_eager", fullgraph=True)
+        res_act = opt_fn(x.as_subclass(Bare))
+        self.assertEqual(res_exp, res_act)
+        self.assertIsInstance(res_act, Bare)
+
+    def test_analyze_custom_op_mode_subclass_deferral(self):
+        # Pins the deferral predicate directly, so the coverage does not depend on a
+        # backend lowering to an op that re-enters dispatch.
+        from torch._functorch._aot_autograd.runtime_wrappers import (
+            _AnalyzeCustomOpInputOutputMode,
+        )
+        from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+
+        class Bare(torch.Tensor):
+            pass
+
+        x = torch.randn(4, 4)
+        bare_inp = x.as_subclass(Bare)
+        two_inp = TwoTensor(x, torch.randn(4, 4))
+        with _AnalyzeCustomOpInputOutputMode():
+            # No __torch_dispatch__ to defer to, so the mode has to handle this itself.
+            bare_out = torch.ops.aten.add.Tensor(bare_inp, 1)
+            # A subclass that has one must still be deferred to.
+            two_out = torch.ops.aten.add.Tensor(two_inp, 1)
+        self.assertIsInstance(bare_out, Bare)
+        self.assertIsInstance(two_out, TwoTensor)
+        # Deferral is the mode returning NotImplemented, which the assertion above
+        # cannot tell apart from the mode handling the op itself.
+        self.assertIs(
+            _AnalyzeCustomOpInputOutputMode().__torch_dispatch__(
+                torch.ops.aten.add.Tensor, (TwoTensor,), (two_inp, 1)
+            ),
+            NotImplemented,
+        )
+        # A fake tensor must be handled here, not deferred to: FakeTensor returns
+        # NotImplemented itself while its own mode is on the stack.
+        with FakeTensorMode() as fake_mode:
+            fake_inp = fake_mode.from_tensor(x)
+            with _AnalyzeCustomOpInputOutputMode():
+                fake_out = torch.ops.aten.add.Tensor(fake_inp, 1)
+        self.assertIsInstance(fake_out, FakeTensor)
+
     # ACT (AsyncCollectiveTensor) can be constructed directly, so the guard
     # relaxation for ACT inputs is exercised here on CPU without a process group.
     # The end-to-end path with a real collective + inductor is covered by

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -44,7 +44,6 @@ from torch._ops import OpOverload
 from torch._prims_common import CUDARngStateHelper
 from torch._subclasses.fake_tensor import is_fake_tensor
 from torch.fx.experimental._backward_state import BackwardState
-from torch.fx.experimental.proxy_tensor import HANDLED_TYPES
 from torch.multiprocessing.reductions import StorageWeakRef
 from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
@@ -471,7 +470,15 @@ class _AnalyzeCustomOpInputOutputMode(TorchDispatchMode):
             underlying_tensor = tensor
             if isinstance(tensor, torch.nn.Parameter):
                 underlying_tensor = tensor.data
-            if type(underlying_tensor) not in HANDLED_TYPES:
+            # A subclass with no __torch_dispatch__ has no handler to defer to, so
+            # returning NotImplemented for it makes the dispatch fail outright.
+            # `types` cannot replace the check because HigherOrderOperator.dispatch
+            # passes it empty and this mode accepts HOPs.
+            if (
+                not is_fake_tensor(underlying_tensor)
+                and type(underlying_tensor).__torch_dispatch__
+                is not torch._C._disabled_torch_dispatch_impl
+            ):
                 return NotImplemented
 
         res = func(*args, **kwargs)


### PR DESCRIPTION
## Issue

Fixes #193932

## Summary

`_AnalyzeCustomOpInputOutputMode.__torch_dispatch__` returns `NotImplemented` for any tensor whose exact type is outside `HANDLED_TYPES`, deferring to a subclass `__torch_dispatch__` below it. A bare subclass (`class Bare(torch.Tensor): pass`) has none, so dispatch runs out of candidates and raises: `aten.mm.out` from inductor's extern mm, `aten.t.default` under `aot_eager`. Pointwise ops inductor codegens never re-enter dispatch, so `add`/`sum`/`relu` on the same subclass already compile. The mode now defers only if the type really implements `__torch_dispatch__`, by the same `torch._C._disabled_torch_dispatch_impl` identity test `HigherOrderOperator.dispatch` uses in `torch/_ops.py`. Same shape as #174485, which handled the `nn.Parameter` case on this line.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.

---
AI assistance was used: Claude Code helped locate the root cause and draft the patch and test, which I reviewed and ran locally.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98