### PR TITLE
[dynamo] Keep the subclass type when resyncing tensor metadata

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1299,6 +1299,26 @@ class SubclassTests(_SubclassCompileCheckMixin, torch._dynamo.test_case.TestCase
                 fake_out = torch.ops.aten.add.Tensor(fake_inp, 1)
         self.assertIsInstance(fake_out, FakeTensor)
 
+    def test_inplace_op_preserves_subclass_type(self):
+        # An inplace op resyncs the VariableTracker metadata from the fake tensor,
+        # which no longer carries a non-traceable subclass type.
+        class MySubclass(torch.Tensor):
+            pass
+
+        def fn(x):
+            y = torch.empty_like(x)
+            y.copy_(x)
+            return y
+
+        x = torch.randn(2, 2).as_subclass(MySubclass)
+
+        fn_opt = compile_full_eager(fn)
+
+        res_exp = fn(x)
+        res_act = fn_opt(x)
+        self.assertIsInstance(res_act, MySubclass)
+        self.assertEqual(res_exp, res_act)
+
     # ACT (AsyncCollectiveTensor) can be constructed directly, so the guard
     # relaxation for ACT inputs is exercised here on CPU without a process group.
     # The end-to-end path with a real collective + inductor is covered by

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -1319,6 +1319,45 @@ class SubclassTests(_SubclassCompileCheckMixin, torch._dynamo.test_case.TestCase
         self.assertIsInstance(res_act, MySubclass)
         self.assertEqual(res_exp, res_act)
 
+        # The wrong class is also observable inside the graph, where it silently
+        # takes the other branch instead of raising.
+        def observe_intermediate(x):
+            y = torch.empty_like(x)
+            y.copy_(x)
+            return isinstance(y, MySubclass)
+
+        def observe_input(x):
+            x.add_(1)
+            return isinstance(x, MySubclass)
+
+        self.assertTrue(compile_full_eager(observe_intermediate)(x))
+        self.assertTrue(compile_full_eager(observe_input)(x.clone()))
+
+    def test_comparison_with_torch_function_disabled(self):
+        # A subclass that disables __torch_function__ does not intercept the
+        # comparison, so the result is a plain tensor and must be modelled as one.
+        class DisabledTF(torch.Tensor):
+            __torch_function__ = torch._C._disabled_torch_function_impl
+
+        class MyParam(torch.nn.Parameter):
+            pass
+
+        def fn(x):
+            return x > 0
+
+        def fn_inplace(x):
+            x.add_(1)
+            return x > 0
+
+        base = torch.randn(2, 2)
+        for cls in (DisabledTF, MyParam):
+            for f in (fn, fn_inplace):
+                res_exp = f(base.clone().as_subclass(cls))
+                res_act = compile_full_eager(f)(base.clone().as_subclass(cls))
+                self.assertIs(type(res_exp), torch.Tensor)
+                self.assertIs(type(res_act), torch.Tensor)
+                self.assertEqual(res_exp, res_act)
+
     # ACT (AsyncCollectiveTensor) can be constructed directly, so the guard
     # relaxation for ACT inputs is exercised here on CPU without a process group.
     # The end-to-end path with a real collective + inductor is covered by

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -316,8 +316,11 @@ class TensorVariable(VariableTracker):
         for k in ("_size", "stride", "is_contiguous"):
             if k not in specialized_props:
                 setattr(self, k, None)
+        # class_type is not resynced: a non-traceable tensor subclass lives only on
+        # the VariableTracker, so the fake tensor would resolve it to torch.Tensor.
         for k, v in specialized_props.items():
-            setattr(self, k, v)
+            if k != "class_type":
+                setattr(self, k, v)
 
     def _get_fake_version(self) -> int | None:
         """Get the current version of self's fake tensor, or None if unavailable."""

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -397,7 +397,9 @@ class TensorVariable(VariableTracker):
         proxy = tx.output.create_proxy(
             "call_function", op_fn, (self.as_proxy(), other.as_proxy()), {}
         )
-        return wrap_fx_proxy_cls(type(self), tx, proxy)
+        # Getting here means no __torch_function__ intercepted the comparison, so the
+        # result is a plain tensor even when self models a subclass.
+        return wrap_fx_proxy_cls(TensorVariable, tx, proxy)
 
     @staticmethod
     def specialize(value: torch.Tensor) -> TensorSpecializedProps:


### PR DESCRIPTION
## Issue

Fixes #193933

## Summary

Dynamo models a tensor subclass without `__torch_dispatch__` as a `TensorWithTFOverrideVariable` holding the Python type in `class_type`, while the fake tensor behind the proxy stays a plain `FakeTensor`. When an inplace op bumps the fake version, `synchronize_attributes` re-derives every specialized property from that fake tensor, and `get_specialized_props` resolves `class_type` back to `torch.Tensor` (`torch/_dynamo/variables/builder.py:4334`); codegen then loads `__subclass_Tensor_<id>_c0`, a global `install_global` never installed. This excludes `class_type` from the resync, since the version-bump resync cannot change the Python type of the object being modelled. That resync fires for every inplace op since #187890 removed the `has_tensor_arg` gate.

The same cause reaches a second path with no inplace op involved. A subclass that sets `__torch_function__ = _disabled_torch_function_impl` -- every `nn.Parameter` subclass does -- does not intercept `__gt__`, so the comparison lands in `TensorVariable.tp_richcompare_impl`, which wrapped the result with `type(self)` and rebuilt the same broken `TensorWithTFOverrideVariable`. It now wraps with `TensorVariable`, matching eager, which returns a plain tensor there. On `main`, `torch.compile(lambda x: x > 0, backend="eager")` on an `nn.Parameter` subclass raises the same `NameError`.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.

---
AI assistance was used in developing this change: investigation, validation, and additional testing


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98