### PR TITLE
[distributed_tools] Reconstruct _op_index in MemoryTracker.load()

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,11 +1,32 @@
 # Owner(s): ["oncall: distributed"]
+import io
 import os
+import pickle
 import unittest
+from contextlib import redirect_stdout
 
 import torch
 import torch.nn as nn
 from torch.distributed._tools import MemoryTracker
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, TemporaryFileName, TestCase
+
+
+class FakeDeviceModule:
+    """Stub of a device module so ``MemoryTracker`` can record stats without an accelerator."""
+
+    def __init__(self, allocated_mbs):
+        self._allocated_mbs = iter(allocated_mbs)
+        self._current = 0
+
+    def memory_allocated(self):
+        self._current = next(self._allocated_mbs) * 1024 * 1024
+        return self._current
+
+    def memory_reserved(self):
+        return self._current * 2
+
+    def memory_stats(self):
+        return {"active_bytes.all.current": self._current}
 
 
 class TestMemoryTracker(TestCase):
@@ -62,6 +83,67 @@ class TestMemoryTracker(TestCase):
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))
+
+    @staticmethod
+    def _capture_summary(tracker):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            tracker.summary()
+        return buf.getvalue()
+
+    def test_save_load_restores_op_index(self):
+        """
+        A ``save_stats()``/``load()`` round trip into a fresh tracker should
+        restore the operation count so that ``summary()`` reports the same
+        per-operator memory deltas as the original tracker.
+        """
+        original = MemoryTracker()
+        original._device_module = FakeDeviceModule([0, 100, 250])
+        for op_name in (
+            "net.forward.conv2d_0",
+            "net.forward.relu_0",
+            "net.forward.addmm_0",
+        ):
+            original._record_memory_stats(op_name)
+        self.assertEqual(original._op_index, 3)
+        original_summary = self._capture_summary(original)
+        self.assertIn("net.forward.addmm_0", original_summary)
+
+        with TemporaryFileName() as path:
+            original.save_stats(path)
+
+            loaded = MemoryTracker()
+            loaded.load(path)
+
+        self.assertEqual(loaded._op_index, original._op_index)
+        self.assertEqual(loaded.memories_allocated, original.memories_allocated)
+        self.assertEqual(loaded.memories_active, original.memories_active)
+        self.assertEqual(loaded.memories_reserved, original.memories_reserved)
+        self.assertEqual(self._capture_summary(loaded), original_summary)
+
+    def test_load_stats_without_op_index(self):
+        """
+        ``load()`` should restore the operation count from stats files that
+        only contain the memory traces (the format ``save_stats()`` has always
+        written, with no explicit operation count).
+        """
+        old_stats = {
+            "memories_allocated": {0: ("op_0", 0.0), 1: ("op_1", 128.0)},
+            "memories_active": {0: ("op_0", 0.0), 1: ("op_1", 128.0)},
+            "memories_reserved": {0: ("op_0", 0.0), 1: ("op_1", 256.0)},
+            "markers": {"fw_start": 0},
+            "num_alloc_retries": 0,
+        }
+        with TemporaryFileName() as path:
+            with open(path, "wb") as f:
+                pickle.dump(old_stats, f, pickle.HIGHEST_PROTOCOL)
+
+            tracker = MemoryTracker()
+            tracker.load(path)
+
+        self.assertEqual(tracker._op_index, 2)
+        summary = self._capture_summary(tracker)
+        self.assertIn("op_1: 128.0MB", summary)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -227,6 +227,9 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        # ``_record_memory_stats()`` keeps ``_op_index`` equal to the number of
+        # recorded entries; reconstruct it so ``summary()`` works after a load.
+        self._op_index = len(self.memories_allocated)
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
Fixes #191397

`save_stats()` pickles the trace dicts, markers, and `num_alloc_retries`, but not `_op_index`; `load()` left it at 0, so `summary()` printed no per-operator deltas on a loaded tracker.

Since `_record_memory_stats()` writes each dict at key `_op_index` and then increments it, `_op_index == len(memories_allocated)` always holds. `load()` now reconstructs the count from the loaded traces. The stats-file format is unchanged, so previously saved stats files load correctly.

**Tests:** `test_save_load_restores_op_index` does a full save/load round trip via real `_record_memory_stats()` calls with a stubbed device module (runs without an accelerator) and asserts the restored count, traces, and captured `summary()` output match the original. `test_load_stats_without_op_index` pins the on-disk format with a hand-written stats dict. Both fail without the fix.

**Disclosure per AI_POLICY.md:** this PR was prepared with AI assistance (Claude Code); I have reviewed the change and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)