### PR TITLE
[export_python] inductor: opt-in readable python wrapper that emits kernels as code

### DIFF
--- a/test/inductor/test_readable_wrapper.py
+++ b/test/inductor/test_readable_wrapper.py
@@ -1,0 +1,151 @@
+# Owner(s): ["module: inductor"]
+
+import os
+import re
+import tempfile
+
+import torch
+from torch._inductor import config
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.triton_utils import requires_cuda_and_triton
+
+
+def _code_for(fn, *args, **config_kwargs):
+    torch._dynamo.reset()
+    with config.patch(**config_kwargs):
+        result, codes = run_and_get_code(torch.compile(fn), *args)
+    return result, "\n".join(codes)
+
+
+class TestReadableWrapperCodegen(TestCase):
+    """The readable wrapper emits kernels as code rather than as source strings."""
+
+    @requires_cuda_and_triton
+    def test_triton_kernel_is_defined_at_module_level(self):
+        def fn(x):
+            return torch.softmax(x * 2, dim=-1)
+
+        x = torch.randn(64, 128, device="cuda")
+        _, code = _code_for(fn, x, readable_wrapper=True)
+        self.assertNotIn("async_compile.triton", code)
+        # A module-level def, not a string: no leading indent, and the heuristics
+        # decorator that builds the autotuner is right above it.
+        self.assertTrue(
+            re.search(r"^@triton_heuristics\.\w+\(", code, re.MULTILINE),
+            code[:2000],
+        )
+        self.assertTrue(
+            re.search(r"^def triton_\w+\(", code, re.MULTILINE), code[:2000]
+        )
+        # The launch site is unchanged, which is what makes the hoist a pure
+        # reformatting: the name still binds a CachingAutotuner.
+        self.assertIn(".run(", code)
+
+    @requires_cuda_and_triton
+    def test_async_compile_is_dropped_when_no_backend_needs_it(self):
+        def fn(x):
+            return (x * 2).relu()
+
+        x = torch.randn(256, device="cuda")
+        _, code = _code_for(fn, x, readable_wrapper=True)
+        self.assertNotIn("AsyncCompile()", code)
+        self.assertNotIn("async_compile.wait", code)
+        self.assertNotIn("del async_compile", code)
+
+    def test_async_compile_survives_when_a_backend_needs_it(self):
+        # C++ kernels cannot be hoisted -- the text is C++ and producing the value
+        # needs a compiler invocation -- so the lifecycle has to stay for them. The
+        # decision is per-graph, not per-mode.
+        def fn(x):
+            return (x + 1).relu().sum(0)
+
+        x = torch.randn(1024)
+        _, code = _code_for(fn, x, readable_wrapper=True)
+        if "async_compile.cpp" not in code:
+            self.skipTest("graph did not lower to a C++ kernel")
+        self.assertIn("AsyncCompile()", code)
+        self.assertIn("async_compile.wait", code)
+
+    @requires_cuda_and_triton
+    def test_every_kernel_is_defined_exactly_once(self):
+        # Hoisting puts kernel names in one module namespace, so a duplicate definition
+        # would silently shadow rather than fail.
+        def fn(x):
+            return torch.softmax(x, dim=-1).sum(0), (x * 3).relu().mean(1)
+
+        x = torch.randn(64, 128, device="cuda")
+        _, code = _code_for(fn, x, readable_wrapper=True)
+        names = re.findall(r"^def (triton_\w+)\(", code, re.MULTILINE)
+        self.assertGreater(len(names), 1)
+        self.assertEqual(len(names), len(set(names)), names)
+
+    @requires_cuda_and_triton
+    def test_subgraph_kernels_are_hoisted_too(self):
+        # graph_partition is on by default in OSS, so the subgraph wrapper is on the
+        # normal path; delegating it to the stock subgraph class would leave these
+        # kernels stringified.
+        def fn(p, x):
+            return torch.cond(p, lambda t: t.sin(), lambda t: t.cos(), (x,))
+
+        p = torch.tensor(True, device="cuda")
+        x = torch.randn(64, 128, device="cuda")
+        _, code = _code_for(fn, p, x, readable_wrapper=True)
+        self.assertNotIn("async_compile.triton", code)
+        self.assertTrue(re.search(r"^def triton_\w+\(", code, re.MULTILINE))
+
+    @requires_cuda_and_triton
+    def test_emitted_module_runs_standalone_and_matches_eager(self):
+        # The point of the mode: the file on its own is the program. Compile it from a
+        # real path -- @triton.jit resolves its own source by filename, so a hoisted
+        # kernel cannot be exec'd from a bare string.
+        def fn(x):
+            return torch.softmax(x * 2, dim=-1)
+
+        x = torch.randn(64, 128, device="cuda")
+        expected, code = _code_for(fn, x, readable_wrapper=True)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "artifact.py")
+            with open(path, "w") as f:
+                f.write(code)
+            ns: dict[str, object] = {"__file__": path, "__name__": "_readable_artifact"}
+            with open(path) as f:
+                exec(compile(f.read(), path, "exec"), ns)
+            got = ns["call"]([x])  # type: ignore[operator]
+        self.assertEqual(got[0], expected)
+
+    @requires_cuda_and_triton
+    def test_default_wrapper_still_uses_async_compile(self):
+        def fn(x):
+            return torch.softmax(x * 2, dim=-1)
+
+        x = torch.randn(64, 128, device="cuda")
+        _, code = _code_for(fn, x, readable_wrapper=False)
+        self.assertIn("async_compile.triton", code)
+        self.assertIn("AsyncCompile()", code)
+
+    @requires_cuda_and_triton
+    def test_shadowing_kernel_names_are_refused(self):
+        def fn(x):
+            return (x * 2).relu()
+
+        x = torch.randn(256, device="cuda")
+        with self.assertRaisesRegex(Exception, "unique_kernel_names"):
+            _code_for(
+                fn, x, readable_wrapper=True, **{"triton.unique_kernel_names": False}
+            )
+
+    @requires_cuda_and_triton
+    def test_benchmark_kernel_is_refused(self):
+        # benchmark_kernel appends a get_args()/call()/__main__ harness to each kernel;
+        # at module level those collide with each other and with the wrapper's own call.
+        def fn(x):
+            return (x * 2).relu()
+
+        x = torch.randn(256, device="cuda")
+        with self.assertRaisesRegex(Exception, "benchmark_kernel"):
+            _code_for(fn, x, readable_wrapper=True, benchmark_kernel=True)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_readable_wrapper.py
+++ b/test/inductor/test_readable_wrapper.py
@@ -115,6 +115,21 @@ class TestReadableWrapperCodegen(TestCase):
         self.assertEqual(got[0], expected)
 
     @requires_cuda_and_triton
+    def test_no_stale_pointer_to_a_cache_file(self):
+        # Inductor stamps each kernel "# kernel path: /tmp/torchinductor_.../x.py",
+        # naming where the kernel WOULD have been compiled from. It is defined in this
+        # file instead, and pointing a reader at a cache file is the confusion this mode
+        # exists to remove.
+        def fn(x):
+            return torch.softmax(x * 2, dim=-1)
+
+        x = torch.randn(64, 128, device="cuda")
+        _, code = _code_for(fn, x, readable_wrapper=True)
+        self.assertNotIn("# kernel path:", code)
+        # the rest of the provenance comment is still worth having
+        self.assertIn("Original ATen:", code)
+
+    @requires_cuda_and_triton
     def test_default_wrapper_still_uses_async_compile(self):
         def fn(x):
             return torch.softmax(x * 2, dim=-1)

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -500,7 +500,22 @@ def get_wrapper_codegen_for_device(
                     return CppWrapperCpuArrayRef
             return cpp_wrapper_codegen
         else:
-            return wrapper_codegen_obj.wrapper_codegen
+            python_wrapper_codegen = wrapper_codegen_obj.wrapper_codegen
+            # readable_wrapper is a per-compile config, so like allow_stack_allocation
+            # above it is resolved here rather than at registration. The identity guard
+            # keeps an out-of-tree python wrapper (or PythonWrapperMtia) from being
+            # silently replaced by one that knows nothing about that backend.
+            from .wrapper import PythonWrapperCodegen
+            from .wrapper_readable import readable_wrapper_requested
+
+            if (
+                python_wrapper_codegen is PythonWrapperCodegen
+                and readable_wrapper_requested()
+            ):
+                from .wrapper_readable import ReadablePythonWrapperCodegen
+
+                return ReadablePythonWrapperCodegen
+            return python_wrapper_codegen
     return None
 
 

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1561,6 +1561,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
         metadata: str | None = None,
         gpu: bool = False,
         cpp_definition: str | None = None,
+        # A C++ wrapper never defines a kernel as module-level python, so the readable
+        # python wrapper's standalone form cannot reach here; accepted to keep one
+        # signature across _define_kernel_helper implementations.
+        standalone: bool = False,
+        autotune_body: str | None = None,
     ):
         # Misnomer: `gpu` actually means "is this a Triton kernel?"
         if gpu:

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -1387,6 +1387,11 @@ class CppWrapperGpu(CppWrapperCpu):
         metadata: str | None = None,
         gpu: bool = True,
         cpp_definition: str | None = None,
+        # A C++ wrapper never defines a kernel as module-level python, so the readable
+        # python wrapper's standalone form cannot reach here; accepted to keep one
+        # signature across _define_kernel_helper implementations.
+        standalone: bool = False,
+        autotune_body: str | None = None,
     ):
         if gpu:
             self._kernel_name_to_body[kernel_name] = kernel_body

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -8031,24 +8031,24 @@ class TritonScheduling(SIMDScheduling):
         ):
             return  # External handler handled it
 
-        compile_wrapper = IndentedBuffer()
+        current_device = V.graph.get_current_device_or_throw()
 
-        if async_compile.use_process_pool():
+        if wrapper.async_compiles_triton_kernels and async_compile.use_process_pool():
             # The process pool is warm, we can shell out to workers right away. This
             # allows us to save the result in async_compile.CompiledTritonKernels,
             # so that the second time we call async_compile.triton, we do no work.
             async_compile.triton(subs_name, src_code)
 
-        compile_wrapper.writeline(f"async_compile.triton({subs_name!r}, '''")
-
-        compile_wrapper.splice(src_code, strip=True)
-        current_device = V.graph.get_current_device_or_throw()
-        compile_wrapper.writeline(f"''', device_str='{current_device.type}')")
-
         metadata_comment = f"# kernel path: {kernel_path}"
         origins, detailed_origins = get_kernel_metadata(node_schedule, wrapper)
         metadata_comment += "\n" + origins + "\n" + detailed_origins
-        wrapper.define_kernel(kernel_name, compile_wrapper.getvalue(), metadata_comment)
+        wrapper.emit_triton_kernel_definition(
+            kernel_name,
+            subs_name,
+            src_code,
+            current_device.type,
+            metadata=metadata_comment,
+        )
 
     def define_kernel(self, src_code, node_schedule, kernel):
         wrapper = V.graph.wrapper_code

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -771,6 +771,8 @@ class KernelDefinitionLine(WrapperLine):
     metadata: str | None = None
     gpu: bool = True
     cpp_definition: str | None = None
+    standalone: bool = False
+    autotune_body: str | None = None
 
     def codegen(self, code: IndentedBuffer) -> None:
         self.wrapper._define_kernel_helper(
@@ -779,6 +781,8 @@ class KernelDefinitionLine(WrapperLine):
             metadata=self.metadata,
             gpu=self.gpu,
             cpp_definition=self.cpp_definition,
+            standalone=self.standalone,
+            autotune_body=self.autotune_body,
         )
 
     def codegen_fx(self, converter: FxConverter) -> FxConversionFunc:
@@ -1404,6 +1408,9 @@ class PythonWrapperCodegen(CodeGen):
         # If the generated source code is exactly the same, reuse the
         # pre-existing kernel for it
         self.src_to_kernel: dict[str, str] = {}
+        # Set by define_kernel when a backend binds its kernel through AsyncCompile.
+        # Only meaningful once every kernel has been defined, i.e. after line replay.
+        self.uses_async_compile = False
         self.kernel_numel_expr: OrderedSet[tuple[str, GraphLowering]] = OrderedSet()
         self.lines: list[Line] = []
         self.declare = ""
@@ -1555,10 +1562,10 @@ class PythonWrapperCodegen(CodeGen):
                 empty_strided_mtia = torch._C._dynamo.guards._empty_strided_mtia
                 reinterpret_tensor = torch._C._dynamo.guards._reinterpret_tensor
                 alloc_from_pool = torch.ops.inductor._alloc_from_pool
-                async_compile = AsyncCompile()
             """,
             strip=True,
         )
+        self.write_async_compile_binding()
         try:
             # Only add empty_strided_p2p() if distributed and SymmetricMemory
             # is available
@@ -1750,6 +1757,9 @@ class PythonWrapperCodegen(CodeGen):
             self.prefix.writeline(line)
             line = f"assert not {name}.isinf().any().item()"
             self.prefix.writeline(line)
+
+    def write_async_compile_binding(self) -> None:
+        self.header.writeline("async_compile = AsyncCompile()")
 
     def write_async_compile_wait(self) -> None:
         self.prefix.splice(
@@ -3246,7 +3256,14 @@ class PythonWrapperCodegen(CodeGen):
         metadata: str | None = None,
         gpu: bool = True,
         cpp_definition: str | None = None,
+        standalone: bool = False,
+        autotune_body: str | None = None,
     ):
+        # Every backend's kernel definition funnels through here, so this is the one
+        # place that can tell whether the emitted module still needs an AsyncCompile at
+        # all -- ten of the eleven backends bind their kernel by calling one.
+        if "async_compile." in kernel_body:
+            self.uses_async_compile = True
         self.writeline(
             KernelDefinitionLine(
                 self,
@@ -3255,18 +3272,27 @@ class PythonWrapperCodegen(CodeGen):
                 metadata=metadata,
                 gpu=gpu,
                 cpp_definition=cpp_definition,
+                standalone=standalone,
+                autotune_body=autotune_body,
             )
         )
 
     @staticmethod
     def _format_kernel_definition(
-        kernel_name: str, kernel_body: str, metadata: str | None = None
+        kernel_name: str,
+        kernel_body: str,
+        metadata: str | None = None,
+        standalone: bool = False,
     ):
         if config.triton.autotune_at_compile_time and metadata:
             # Generating autotune block
             # Need to replace C++ comment starter with Python comment starter
             metadata = re.sub(r"^// ", "# ", metadata, flags=re.MULTILINE)
         metadata_comment = f"{metadata}\n" if metadata else ""
+        # A standalone body already binds kernel_name itself (it is a decorated def, not
+        # an expression), so assigning it would be a syntax error rather than a rebind.
+        if standalone:
+            return f"\n\n{metadata_comment}{kernel_body}"
         body = f"\n\n{metadata_comment}{kernel_name} = {kernel_body}"
         return body
 
@@ -3277,10 +3303,18 @@ class PythonWrapperCodegen(CodeGen):
         metadata: str | None = None,
         gpu: bool = True,
         cpp_definition: str | None = None,
+        standalone: bool = False,
+        autotune_body: str | None = None,
     ):
         if config.triton.autotune_at_compile_time and gpu:
+            # The autotune block is exec'd rather than emitted, so it wants whichever
+            # form runs there, not the one meant to be read: a standalone kernel carries
+            # filename=__file__, which is undefined in that exec.
             body = self._format_kernel_definition(
-                kernel_name, kernel_body, metadata=metadata
+                kernel_name,
+                autotune_body if autotune_body is not None else kernel_body,
+                metadata=metadata,
+                standalone=standalone and autotune_body is None,
             )
             self.kernel_autotune_defs.splice(body)
             if V.graph.cpp_wrapper:
@@ -3288,9 +3322,44 @@ class PythonWrapperCodegen(CodeGen):
                 return
 
         body = self._format_kernel_definition(
-            kernel_name, kernel_body, metadata=metadata
+            kernel_name, kernel_body, metadata=metadata, standalone=standalone
         )
         self.header.splice(body)
+
+    # Whether Triton kernels are bound by handing their source to AsyncCompile (the
+    # default) or defined directly at module level. Only the former can fan compilation
+    # out to the worker pool, so this also decides whether priming it pays.
+    async_compiles_triton_kernels = True
+
+    def emit_triton_kernel_definition(
+        self,
+        kernel_name: str,
+        subs_name: str,
+        src_code: str,
+        device_type: str,
+        metadata: str | None = None,
+    ) -> None:
+        """Bind ``kernel_name`` to a launchable Triton kernel at module scope.
+
+        The default form hands the kernel to AsyncCompile as a source STRING, which is
+        what lets compilation fan out to the worker pool. Subclasses that care more
+        about the emitted module being readable can define the kernel as code instead.
+        """
+        self.define_kernel(
+            kernel_name,
+            self.async_compile_triton_body(subs_name, src_code, device_type),
+            metadata,
+        )
+
+    @staticmethod
+    def async_compile_triton_body(
+        subs_name: str, src_code: str, device_type: str
+    ) -> str:
+        compile_wrapper = IndentedBuffer()
+        compile_wrapper.writeline(f"async_compile.triton({subs_name!r}, '''")
+        compile_wrapper.splice(src_code, strip=True)
+        compile_wrapper.writeline(f"''', device_str='{device_type}')")
+        return compile_wrapper.getvalue()
 
     def define_subgraph_launcher_fn(self, name: str, subgraph_code):
         self.subgraph_definitions.splice(subgraph_code.value)

--- a/torch/_inductor/codegen/wrapper_readable.py
+++ b/torch/_inductor/codegen/wrapper_readable.py
@@ -59,6 +59,16 @@ class ReadablePythonWrapperCodegen(PythonWrapperCodegen):
         # @triton.jit def. Spliced at module level it binds kernel_name to the same
         # object async_compile.triton would have returned, so the launch site
         # (KERNEL.run(...)) is unchanged.
+        # The provenance comment leads with "# kernel path: /tmp/torchinductor_.../x.py",
+        # which is where the kernel WOULD have been compiled from. It is defined right
+        # here instead, and pointing a reader at a cache file is the exact confusion this
+        # mode exists to remove. The source-op mapping below it is worth keeping.
+        if metadata:
+            metadata = "\n".join(
+                line
+                for line in metadata.splitlines()
+                if not line.startswith("# kernel path:")
+            )
         self.define_kernel(
             kernel_name,
             src_code,

--- a/torch/_inductor/codegen/wrapper_readable.py
+++ b/torch/_inductor/codegen/wrapper_readable.py
@@ -1,0 +1,144 @@
+"""Python wrapper codegen for output that is meant to be read and hand-edited.
+
+Inductor's normal python wrapper is written to be loaded by inductor. This variant is
+written to be opened by a person (or an agent) who wants to retune the generated kernel
+in place: it emits Triton kernels as ordinary module-level code rather than as source
+strings handed to ``AsyncCompile``, and it drops the ``AsyncCompile`` lifecycle when no
+backend still needs it. See ``torch.compiler.export_python``, which is the consumer.
+
+The tradeoff is deliberate and is the reason this is opt-in: a kernel defined at module
+level compiles serially, in process, on its first launch, instead of fanning out to the
+compile worker pool.
+"""
+
+from typing_extensions import override
+
+import torch._inductor.config as config
+from torch.utils._indented_buffer import DeferredLineBase
+
+from .. import ir
+from .wrapper import PythonWrapperCodegen, SubgraphPythonWrapperCodegen
+
+
+class _LineIfAsyncCompileUsed(DeferredLineBase):
+    """A line that survives assembly only if some kernel actually bound via AsyncCompile.
+
+    Whether the emitted module needs an ``AsyncCompile`` is not known when the preamble
+    is written -- ``write_header`` runs from ``__init__``, before a single kernel has
+    been defined -- so the decision is deferred to ``getvalue()``, which runs after
+    every kernel definition has been replayed.
+    """
+
+    def __init__(self, line: str, wrapper: PythonWrapperCodegen) -> None:
+        super().__init__(line)
+        self.wrapper = wrapper
+
+    def __call__(self) -> str | None:
+        return self.line if self.wrapper.uses_async_compile else None
+
+    def _new_line(self, line: str) -> "_LineIfAsyncCompileUsed":
+        return _LineIfAsyncCompileUsed(line, self.wrapper)
+
+
+class ReadablePythonWrapperCodegen(PythonWrapperCodegen):
+    """Emit kernels as code rather than as strings passed to AsyncCompile."""
+
+    async_compiles_triton_kernels = False
+
+    @override
+    def emit_triton_kernel_definition(
+        self,
+        kernel_name: str,
+        subs_name: str,
+        src_code: str,
+        device_type: str,
+        metadata: str | None = None,
+    ) -> None:
+        # src_code is already a complete module: the triton imports, the
+        # @triton_heuristics.* decorator that builds the CachingAutotuner, and the
+        # @triton.jit def. Spliced at module level it binds kernel_name to the same
+        # object async_compile.triton would have returned, so the launch site
+        # (KERNEL.run(...)) is unchanged.
+        self.define_kernel(
+            kernel_name,
+            src_code,
+            metadata,
+            standalone=True,
+            # The compile-time autotune block execs its kernels instead of emitting
+            # them, and a module-level kernel there has no __file__ to name itself by,
+            # so that block keeps the AsyncCompile form.
+            autotune_body=(
+                self.async_compile_triton_body(subs_name, src_code, device_type)
+                if config.triton.autotune_at_compile_time
+                else None
+            ),
+        )
+
+    @override
+    def write_async_compile_binding(self) -> None:
+        self.header.writeline(
+            _LineIfAsyncCompileUsed("async_compile = AsyncCompile()", self)
+        )
+
+    @override
+    def write_async_compile_wait(self) -> None:
+        self.prefix.writeline("")
+        self.prefix.writeline(
+            _LineIfAsyncCompileUsed("async_compile.wait(globals())", self)
+        )
+        self.prefix.writeline(_LineIfAsyncCompileUsed("del async_compile", self))
+
+    @override
+    @staticmethod
+    def create(
+        is_subgraph: bool,
+        subgraph_name: str | None,
+        parent_wrapper: PythonWrapperCodegen | None,
+        partition_signatures: ir.GraphPartitionSignature | None = None,
+    ) -> PythonWrapperCodegen:
+        if is_subgraph:
+            if subgraph_name is None:
+                raise AssertionError("expected subgraph_name to be set")
+            if parent_wrapper is None:
+                raise AssertionError("expected parent_wrapper to be set")
+            # graph_partition is on by default in OSS, so partition subgraphs are the
+            # common case rather than an exotic one -- delegating them to the stock
+            # subgraph wrapper would leave their kernels stringified. Compose instead,
+            # with this class first so its kernel emission wins.
+            return _ReadableSubgraphPythonWrapperCodegen(
+                subgraph_name, parent_wrapper, partition_signatures
+            )
+        return ReadablePythonWrapperCodegen()
+
+
+class _ReadableSubgraphPythonWrapperCodegen(
+    ReadablePythonWrapperCodegen, SubgraphPythonWrapperCodegen
+):
+    """Subgraph wrapper that keeps readable kernel emission.
+
+    MRO puts ReadablePythonWrapperCodegen first, so kernels stay unstringified while the
+    subgraph overrides (no duplicate header, no benchmark harness) still apply.
+    """
+
+
+def readable_wrapper_requested() -> bool:
+    """Whether this compile asked for readable output, and can actually have it."""
+    if not config.readable_wrapper:
+        return False
+    if not config.triton.unique_kernel_names:
+        # Every kernel would be named `triton_`, so hoisting them to module level makes
+        # all but the last unreachable -- an artifact that runs and is wrong.
+        raise RuntimeError(
+            "torch._inductor.config.readable_wrapper defines kernels at module level, "
+            "which requires triton.unique_kernel_names so they do not shadow each "
+            "other. Enable unique_kernel_names or disable readable_wrapper."
+        )
+    if config.benchmark_kernel:
+        # benchmark_kernel appends get_args()/call()/__main__ to each kernel's source;
+        # at module level those collide with each other and with the wrapper's own call.
+        raise RuntimeError(
+            "torch._inductor.config.readable_wrapper is incompatible with "
+            "benchmark_kernel, which appends a get_args()/call()/__main__ harness to "
+            "every kernel; defined at module level those collide."
+        )
+    return True

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -206,6 +206,15 @@ cpp_wrapper_build_separate: bool = (
 
 fx_wrapper: bool = os.environ.get("TORCHINDUCTOR_FX_WRAPPER", "0") == "1"
 
+# Emit a python wrapper meant to be READ and hand-edited rather than only executed:
+# Triton kernels are defined at module level as ordinary code instead of as source
+# strings handed to AsyncCompile, and the AsyncCompile lifecycle is emitted only when
+# some backend still needs it. This trades compile throughput for legibility -- hoisted
+# kernels compile serially, in process, on first launch instead of fanning out to the
+# worker pool -- so it is for artifacts a person tunes (torch.compiler.export_python),
+# not for a normal compile.
+readable_wrapper: bool = os.environ.get("TORCHINDUCTOR_READABLE_WRAPPER", "0") == "1"
+
 # Controls automatic precompiling of common include files for codecache.CppCodeCache
 # (i.e. for cpp_wrapper mode and for cpp kernels on CPU).  AOTI header precompiling is
 # controlled by a separate flag.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #193901
* #193900
* #193899
* #198257
* #198256
* #198255
* #198254
* #198253
* #198252
* #193898
* #198247
* #198246
* #198245
* #193974
* __->__ #193973

**Problem.** Inductor's python wrapper is written to be loaded by inductor, not read. Every Triton kernel in it is a source string passed to `async_compile.triton(...)`. So when the emitted module is the deliverable, as it is for torch.compiler.export_python later in this stack, the kernel a person or an agent wants to retune in place is a string literal and not code.

**Fix.** A new opt-in config, `torch._inductor.config.readable_wrapper` (env `TORCHINDUCTOR_READABLE_WRAPPER=1`), selects a `ReadablePythonWrapperCodegen`. It defines each Triton kernel as ordinary module-level code, and it emits the AsyncCompile lifecycle only when some backend in the graph still needs it.

**Summary.** Today the python wrapper binds every Triton kernel with `name = async_compile.triton('name', '''<source>''', device_str='cuda')`, so the kernel's source only exists as a string. That makes it awkward to edit, and a syntax error in an edited kernel is reported against an opaque cache file instead of against the artifact. With `readable_wrapper=True`, `TritonScheduling` calls a new `emit_triton_kernel_definition` virtual, and the readable wrapper splices the kernel's complete source (the `@triton_heuristics.*` decorator plus the `@triton.jit def`) straight into the module, with `async_compile = AsyncCompile()`, `async_compile.wait(globals())` and `del async_compile` kept only if some other kernel (for example a C++ one) still binds through AsyncCompile. The key constraint is that the header is written from `__init__`, before any kernel has been defined, so the lifecycle lines are deferred lines that decide whether to exist at assembly time. The mode is off by default because a module-level kernel compiles serially, in process, on first launch instead of fanning out to the compile worker pool, and the default emitted source is byte-identical to before.

## What the flag does to the emitted module

Take the fixture from `test_triton_kernel_is_defined_at_module_level`:

```python
def fn(x):
    return torch.softmax(x * 2, dim=-1)

x = torch.randn(64, 128, device="cuda")
with config.patch(readable_wrapper=True):
    _, codes = run_and_get_code(torch.compile(fn), x)
```

The kernel binding in the emitted wrapper changes like this (kernel name and body elided):

```python
# default (readable_wrapper=False): the kernel is a string handed to AsyncCompile
async_compile = AsyncCompile()

# kernel path: /tmp/torchinductor_<user>/.../x.py
# Original ATen: ...
triton_per_fused__softmax_mul_0 = async_compile.triton('triton_per_fused__softmax_mul_0', '''
import triton
...
@triton_heuristics.persistent_reduction(...)
@triton.jit
def triton_per_fused__softmax_mul_0(...):
    ...
''', device_str='cuda')

async_compile.wait(globals())
del async_compile
```

```python
# readable_wrapper=True: the same source, spliced at module level as code
# Original ATen: ...
import triton
...
@triton_heuristics.persistent_reduction(...)
@triton.jit
def triton_per_fused__softmax_mul_0(...):
    ...
```

Either way the name ends up bound to the same CachingAutotuner object that `async_compile.triton` would have returned, so the launch site (`triton_per_fused__softmax_mul_0.run(...)`) doesn't change and the hoist is purely a reformatting. There is no AsyncCompile in this graph at all, because no backend needed it. The `# kernel path:` provenance line is dropped: it names the cache file the kernel would have been compiled from, and pointing a reader at a cache file is exactly the confusion this mode exists to remove. The rest of the provenance comment (`Original ATen:` and the source-op mapping) is kept.

Tests: `test_triton_kernel_is_defined_at_module_level` (no `async_compile.triton`, a `^@triton_heuristics.` decorator, a `^def triton_` at column 0, `.run(` still present), `test_no_stale_pointer_to_a_cache_file`, and `test_default_wrapper_still_uses_async_compile` for the unchanged default.

## The AsyncCompile lifecycle is decided per graph, not per mode

```python
# Triton-only graph (test_async_compile_is_dropped_when_no_backend_needs_it)
def fn(x):
    return (x * 2).relu()
fn(torch.randn(256, device="cuda"))
# now: no "AsyncCompile()", no "async_compile.wait", no "del async_compile"

# CPU graph (test_async_compile_survives_when_a_backend_needs_it)
def fn(x):
    return (x + 1).relu().sum(0)
fn(torch.randn(1024))
# now: still emits async_compile.cpp(...), so AsyncCompile() and async_compile.wait stay
```

A C++ kernel can't be hoisted. Its text is C++, and producing the value takes a compiler invocation. So a graph that contains one keeps the lifecycle, while a Triton-only graph carries none.

Here is how that decision is made. Every backend's kernel definition goes through `PythonWrapperCodegen.define_kernel`, and ten of the eleven backends bind their kernel by calling AsyncCompile. That makes `define_kernel` the one place that can tell whether the module still needs AsyncCompile, and it sets `self.uses_async_compile = True` when the body contains `async_compile.`. The header and prefix lines are written before any kernel exists, because `write_header` runs from `__init__`. So the readable wrapper overrides `write_async_compile_binding` (a new hook split out of `write_header`) and `write_async_compile_wait` to emit `_LineIfAsyncCompileUsed` deferred lines. Each line resolves in `getvalue()`, after every kernel definition has been replayed, and returns `None` if nothing used AsyncCompile.

## Order to review

```python
# torch/_inductor/codegen/wrapper.py -- the new virtual; the default builds today's string
def emit_triton_kernel_definition(self, kernel_name, subs_name, src_code, device_type, metadata=None):
    self.define_kernel(kernel_name, self.async_compile_triton_body(subs_name, src_code, device_type), metadata)
```

1. `emit_triton_kernel_definition` on `PythonWrapperCodegen`. The default builds today's `async_compile.triton(...)` string through `async_compile_triton_body`, and `TritonScheduling._emit_kernel_to_wrapper` in `triton.py` calls it instead of assembling that string itself.
2. `wrapper_readable.py` is the mode. Its kernel override is short: it strips the `# kernel path:` line and calls `define_kernel(..., standalone=True)`. The interesting part is `_LineIfAsyncCompileUsed`, described above. `standalone=True` makes `_format_kernel_definition` splice the body as-is instead of writing `name = <body>`, because a decorated `def` already binds the name, and assigning it would be a syntax error.
3. Selection happens in `get_wrapper_codegen_for_device` (`common.py`). It mirrors the `allow_stack_allocation` branch directly above it, since `readable_wrapper` is a per-compile config resolved at selection time rather than at registration. It also keeps that branch's identity guard (`python_wrapper_codegen is PythonWrapperCodegen`), so an out-of-tree python wrapper (or `PythonWrapperMtia`) is not silently replaced by one that knows nothing about that backend.

The diff also covers three smaller details:

- **Process pool.** `async_compiles_triton_kernels` is a class attribute: `True` on the base, `False` on the readable wrapper. Only the AsyncCompile form can fan out to the worker pool, so when the attribute is `False`, `triton.py` skips priming the pool with `async_compile.triton(subs_name, src_code)`.
- **Compile-time autotune block.** Under `triton.autotune_at_compile_time`, the autotune block is exec'd rather than emitted, and a module-level kernel has no `__file__` to name itself by there. So the readable wrapper passes an `autotune_body` in the AsyncCompile form, and `_define_kernel_helper` uses that for the autotune block.
- **Subgraphs.** `create()` returns `_ReadableSubgraphPythonWrapperCodegen(ReadablePythonWrapperCodegen, SubgraphPythonWrapperCodegen)` for subgraphs. `graph_partition` defaults on in OSS, so subgraph wrappers are on the normal path, and delegating them to the stock subgraph class would leave their kernels stringified. With the readable class first in the MRO, its kernel emission wins, and the subgraph overrides (no duplicate header, no benchmark harness) still apply. Pinned by `test_subgraph_kernels_are_hoisted_too` (a `torch.cond` graph).

## Two configurations are refused rather than mis-emitted

```python
with config.patch(readable_wrapper=True, **{"triton.unique_kernel_names": False}):
    torch.compile(fn)(x)
# RuntimeError: ... readable_wrapper defines kernels at module level, which requires
#               triton.unique_kernel_names so they do not shadow each other ...

with config.patch(readable_wrapper=True, benchmark_kernel=True):
    torch.compile(fn)(x)
# RuntimeError: ... readable_wrapper is incompatible with benchmark_kernel, which appends
#               a get_args()/call()/__main__ harness to every kernel ...
```

Without `unique_kernel_names`, every kernel is named `triton_`, and hoisting them into one module namespace makes all but the last unreachable. `benchmark_kernel` appends a `get_args()`/`call()`/`__main__` harness to each kernel, and at module level those collide with each other and with the wrapper's own `call`. Either configuration would produce an artifact that runs and is wrong. `readable_wrapper_requested()` raises for both, and `test_shadowing_kernel_names_are_refused` and `test_benchmark_kernel_is_refused` pin them. The shadowing hazard also motivates `test_every_kernel_is_defined_exactly_once`: in a multi-kernel graph, a duplicate `def` would silently shadow rather than fail.

## The emitted file is the program

```python
# test_emitted_module_runs_standalone_and_matches_eager
path = os.path.join(d, "artifact.py")
open(path, "w").write(code)
ns = {"__file__": path, "__name__": "_readable_artifact"}
exec(compile(open(path).read(), path, "exec"), ns)
assertEqual(ns["call"]([x])[0], expected)
```

`@triton.jit` resolves its own source by filename, so a hoisted kernel has to be compiled from a real path rather than exec'd from a bare string. The same property means a syntax error in a hand-edited kernel is reported against the artifact at the right line.

## What does not change

Default codegen is untouched. The emitted source for a normal compile is byte-identical before and after this change, which was verified by diffing the generated module. The only change visible to other wrappers is that `_define_kernel_helper` grew `standalone` (and `autotune_body`) parameters, so the two C++ wrapper overrides (`cpp_wrapper_cpu.py`, `cpp_wrapper_gpu.py`) accept them too. A C++ wrapper never takes the standalone form.

Test Plan:

```
python test/inductor/test_readable_wrapper.py
python test/inductor/test_wrapper_codegen.py
python test/inductor/test_compile_to_python.py
python test/inductor/test_multi_kernel.py
python test/inductor/test_kernel_benchmark.py
python test/inductor/test_triton_wrapper.py
python test/inductor/test_torchinductor.py
```

10 new tests, covering a hoisted kernel, a multi-kernel graph (each kernel
defined exactly once, since hoisting shares one namespace and a duplicate would
shadow rather than fail), a torch.cond graph (subgraph wrappers are on the
normal path because graph_partition defaults on in OSS), the CPU graph that
must keep AsyncCompile, both refused configurations, an end-to-end check
that the emitted module runs standalone from a file and matches eager, and that the
artifact carries no stale "# kernel path:" pointer at a cache file it is not compiled
from. Each was
mutation-checked: reverting the kernel override fails 3, dropping the lifecycle
unconditionally fails 1.

test_multi_kernel has 4 pre-existing cpp_wrapper errors on this machine (no
cuda.h available); they are identical with and without this change.

This commit was authored with the assistance of an AI coding agent.
