### PR TITLE
[aot_autograd] Cache graphs that enter an autocast region inside the graph

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -489,6 +489,34 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_autocast_region_inside_the_graph_is_cacheable(self):
+        """
+        An autocast region entered inside the traced region.
+
+        Dynamo lands it as _enter_autocast/_exit_autocast call_function nodes.
+        They are module-level torch functions carrying no state, so the graph
+        must cache rather than bypass -- a bypass drops the bundled artifact for
+        the whole graph, not just the autocast part of it.
+        """
+
+        def fn(x):
+            with torch.amp.autocast("cpu", dtype=torch.bfloat16):
+                return (x @ x).sum()
+
+        a = torch.rand(8, 8)
+        compiled_fn = torch.compile(fn, backend="inductor")
+        self.assertEqual(fn(a), compiled_fn(a))
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_saved"], 1)
+
+        self._clear_dynamo_and_codecache()
+        self.assertEqual(fn(a), compiled_fn(a))
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     def test_basic(self):
         """
         Verify the interactions between FXGraphCache and AOTAutogradCache.

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -172,6 +172,12 @@ def check_node_safe(node: Node) -> None:
         "torch.sym_sum",
         "torch.autograd.grad",
         "torch.distributed.tensor._api.from_local",
+        # An autocast region entered INSIDE the graph lands as these two nodes.
+        # They are module-level torch functions with no captured state, so they
+        # serialize by reference; rejecting them bypasses the cache for the
+        # whole graph, which loses the bundled artifact a precompile needs.
+        "torch.amp.autocast_mode._enter_autocast",
+        "torch.amp.autocast_mode._exit_autocast",
     )
     SAFE_NON_TORCH_FUNCTIONS = (
         "einops.einops.rearrange",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195070
* #195014
* #194966
* #194952
* #194951
* #194950
* #194949
* #194948
* #194677
* #194629
* #194622
* #194619
* #194549
* #194542
* #194541
* #194534
* #194488
* #194479
* #194455
* #194454
* #194453
* #194452
* #194451
* #194450
* #194449
* #194428
* #194427
* #194426
* #194409
* #194394
* #194393
* #194390
* #194389
* #194388
* #194387
* #194386
* #194385
* #194384
* #194383
* #194320
* #194319
* #194318
* #194317
* #194316
* #194302
* #194301
* #194300
* #194286
* #194285
* #194284
* #194283
* #194282
* #194250
* #194249
* #194248
* #194158
* #192379
* __->__ #193977
* #193976
* #193697
* #192374
* #192866
* #193725

Last of the six enablers.

An autocast region entered inside the traced region lands in the FX graph as
`_enter_autocast` / `_exit_autocast` call_function nodes. Both are private, so
`is_cacheable_function` rejected them and AOTAutograd bypassed its cache for the
whole graph.

For torch.compile that costs a cache entry. For the precompile PR at the top of
this stack it is fatal: a bypass records no bundled artifact, while the backend
id is already on the package, so rendering the artifact fails with every graph
compiled and nothing to serialize. On the ranking model this stack is aimed at,
4 of 49 graphs bypassed for exactly this reason and no artifact could be built.

Both functions are module-level torch functions holding no state, so they
serialize by reference; allowlist them.

Test Plan:

```
python test/dynamo/test_aot_autograd_cache.py
```

The new test compiles a function whose autocast region is inside the graph and
asserts the cache saves and then hits, with no bypass.

Authored with an AI assistant.

Differential Revision: [D116528372](https://our.internmc.facebook.com/intern/diff/D116528372)