### PR TITLE
[ROCm] Unskip symmetric memory UTs on rocm 10.1+

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -46,7 +46,6 @@ from torch.testing._internal.common_distributed import (
     setup_torchcomms_pg,
     skip_if_lt_x_gpu,
     skip_if_rocm_multiprocess,
-    skip_if_rocm_ver_atleast_multiprocess,
     skip_if_rocm_ver_lessthan_multiprocess,
 )
 from torch.testing._internal.common_utils import (
@@ -284,7 +283,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_get_signal_pad(self) -> None:
         self._init_process()
 
@@ -349,7 +348,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_rendezvous_via_pg_allgather(self) -> None:
         import pickle
 
@@ -416,7 +415,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_rendezvous_custom_backend(self) -> None:
         # Simulate the ncclx multi-backend setup.  NCCLXStub wraps NCCL
         # (CUDA-only, like ncclx) and registers via extended_api=True.
@@ -481,7 +480,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_pg_rendezvous_abort_after(self) -> None:
         self._init_process()
 
@@ -508,7 +507,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     @parametrize("symm_mem_input", [True, False])
     def test_low_contention_all_gather(self, symm_mem_input: bool) -> None:
         self._init_process()
@@ -630,7 +629,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     @parametrize("reduce_op", ["sum", "avg"])
     @parametrize("symm_mem_input", [True, False])
     def test_low_contention_reduce_scatter(
@@ -785,7 +784,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_dispatcher_torchbind_symmetric_memory(self) -> None:
         self._init_process()
         group_name = dist.group.WORLD.group_name
@@ -805,7 +804,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_cuda_multimem_barrier_kernel(self) -> None:
         self._init_process()
 
@@ -1298,7 +1297,7 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     @parametrize("set_device", [True, False])
     def test_empty_strided_p2p(self, set_device: bool) -> None:
         self._init_process(set_device)
@@ -1318,9 +1317,8 @@ class SymmMemEmptySetDeviceTest(MultiProcessTestCase):
     @skipIf(
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
-    @skip_if_rocm_ver_lessthan_multiprocess((7, 0))
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     @parametrize("set_device", [True, False])
     def test_empty_strided_p2p_persistent(self, set_device: bool) -> None:
         self._init_process(set_device)
@@ -1658,7 +1656,7 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(4)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_two_shot_all_reduce(self) -> None:
         self._init_process()
         group_name = dist.group.WORLD.group_name
@@ -2534,7 +2532,7 @@ class SymmMemPoolTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
+    @skip_if_rocm_ver_lessthan_multiprocess((10, 1))
     def test_mempool_compute_ops(self):
         self._init_process()
         group_name = dist.group.WORLD.group_name


### PR DESCRIPTION
Few symmetric memory UTs were skipped on ROCm 7.14 and ROCm 10.0 due to a hip runtime issue, which has now been fixed [(rocm systems PR #9908)](https://github.com/ROCm/rocm-systems/pull/9908). 

## CI Validation

 `skip_if_rocm_ver_atleast_multiprocess([7, 14])` → `skip_if_rocm_ver_lessthan_multiprocess((10, 1))` on 12 tests in
  `test/distributed/test_symmetric_memory.py`.

  | Workflow | ROCm ver | Result | Detail |
  |---|---|---|---|
  | [mi200](https://github.com/pytorch/pytorch/actions/runs/34392585289/job/102612744128) | n/a | 12/12 skipped | Pre-existing arch gate (`SymmMem not supported on this ROCm arch`). mi200 never supports symm-mem regardless of ROCm version. This PR is a no-op here. |
  | [mi300](https://github.com/pytorch/pytorch/actions/runs/34392586781/job/102613848561) | 10.0.0 | 12/12 skipped | `ROCm (10, 0, 0) is available but (10, 1) required` - correctly gated off, version < 10.1 |
  | [trunk / mi350](https://github.com/pytorch/pytorch/actions/runs/34392788398/job/102615680809) | 10.0.0 | 12/12 skipped | Same version message as mi300 |
  | [preview / mi350](https://github.com/pytorch/pytorch/actions/runs/34392790926/job/102616865273) | 10.1 | 10/12 passed | 2 skipped for unrelated reasons (see below) |

  **Preview skips (unrelated to this PR, match the PR author's own description):**

  | Test | Reason |
  |---|---|
  | `test_cuda_multimem_barrier_kernel` | "multicast support is not available" - hardware/driver gate |
  | `test_two_shot_all_reduce` | "Need at least 4 accelerator devices" - shard only had 2 GPUs |

  **Unrelated CI failure on this run:** mi200 `distributed` [shard
  2/3](https://github.com/pytorch/pytorch/actions/runs/34392585289/job/102612743596) -
  `test_c10d_nccl.py::test_grad_layout_1devicemodule_1replicaperprocess`. Different test file; `test_symmetric_memory.py` runs
  entirely in shard 1/3. Not caused by this PR.

  **Verdict:** gating behaves exactly as intended on all four flavors - no discrepancies.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang