### PR TITLE
[fake_pg] handle varied buffer shapes and sizes in all_to_all_single

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -613,6 +613,31 @@ class TestFakePG(TestCase):
         )
         self.assertEqual(out_tensor, torch.empty_like(out_tensor))
 
+    @parametrize("noncontiguous_buffer", ["input", "output"])
+    def test_alltoall_base_requires_contiguous(self, noncontiguous_buffer):
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+
+        in_tensor = torch.arange(8.0).reshape(4, 2)
+        out_tensor = torch.empty(4, 2)
+        if noncontiguous_buffer == "input":
+            in_tensor = torch.arange(8.0).reshape(2, 4).t()
+        else:
+            out_tensor = torch.empty(2, 4).t()
+
+        with self.assertRaisesRegex(RuntimeError, "Tensors must be contiguous"):
+            dist.all_to_all_single(out_tensor, in_tensor)
+
+    def test_alltoall_base_channels_last(self):
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+
+        in_tensor = torch.arange(32.0).reshape(2, 2, 2, 4)
+        in_tensor = in_tensor.contiguous(memory_format=torch.channels_last)
+        out_tensor = torch.empty_like(in_tensor)
+        dist.all_to_all_single(out_tensor, in_tensor)
+        self.assertEqual(out_tensor, in_tensor)
+
     def test_alltoall_list_size_validation(self):
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -625,7 +625,7 @@ class TestFakePG(TestCase):
         else:
             out_tensor = torch.empty(2, 4).t()
 
-        with self.assertRaisesRegex(RuntimeError, "Tensors must be contiguous"):
+        with self.assertRaisesRegex(RuntimeError, "tensor must be contiguous"):
             dist.all_to_all_single(out_tensor, in_tensor)
 
     def test_alltoall_base_channels_last(self):

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -462,12 +462,10 @@ class TestFakePG(TestCase):
         self.assertEqual(out_tensor, in_tensor)
 
     @parametrize("rank", [0, 1])
-    def test_alltoall_base_split_sizes_repeat(self, rank):
+    def test_alltoall_base_output_larger_than_input(self, rank):
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=rank, world_size=2, store=store)
 
-        # Slot 1 (size 6) is larger than the input buffer (size 4),
-        # so the input is repeated to fill it.
         in_tensor = torch.arange(4.0).reshape(4, 1)
         out_tensor = torch.empty(8, 1)
         dist.all_to_all_single(
@@ -477,17 +475,15 @@ class TestFakePG(TestCase):
             input_split_sizes=[1, 3],
         )
         expected = torch.tensor(
-            [[0.0], [1.0], [0.0], [1.0], [2.0], [3.0], [0.0], [1.0]]
+            [[0.0], [1.0], [2.0], [3.0], [0.0], [0.0], [0.0], [0.0]]
         )
         self.assertEqual(out_tensor, expected)
 
     @parametrize("rank", [0, 1])
-    def test_alltoall_base_split_sizes_truncate(self, rank):
+    def test_alltoall_base_output_smaller_than_input(self, rank):
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=rank, world_size=2, store=store)
 
-        # Each output slot is smaller than the input buffer, so input is
-        # truncated to slot size.
         in_tensor = torch.arange(8.0).reshape(8, 1)
         out_tensor = torch.empty(4, 1)
         dist.all_to_all_single(
@@ -496,8 +492,22 @@ class TestFakePG(TestCase):
             output_split_sizes=[1, 3],
             input_split_sizes=[4, 4],
         )
-        expected = torch.tensor([[0.0], [0.0], [1.0], [2.0]])
+        expected = torch.tensor([[0.0], [1.0], [2.0], [3.0]])
         self.assertEqual(out_tensor, expected)
+
+    def test_alltoall_base_empty_output_split_sizes(self):
+        store = FakeStore()
+        dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
+
+        in_tensor = torch.arange(4.0).reshape(4, 1)
+        out_tensor = torch.empty(4, 1)
+        dist.all_to_all_single(
+            out_tensor,
+            in_tensor,
+            output_split_sizes=[],
+            input_split_sizes=[2, 2],
+        )
+        self.assertEqual(out_tensor, in_tensor)
 
     def test_alltoall_base_split_size_validation(self):
         store = FakeStore()
@@ -532,13 +542,14 @@ class TestFakePG(TestCase):
         store = FakeStore()
         dist.init_process_group(backend="fake", rank=0, world_size=2, store=store)
 
-        with self.assertRaisesRegex(RuntimeError, "inputBuffer is empty"):
-            dist.all_to_all_single(
-                torch.empty(2, 1),
-                torch.empty(0, 1),
-                output_split_sizes=[1, 1],
-                input_split_sizes=[0, 0],
-            )
+        out_tensor = torch.ones(2, 1)
+        dist.all_to_all_single(
+            out_tensor,
+            torch.empty(0, 2),
+            output_split_sizes=[0, 2],
+            input_split_sizes=[0, 0],
+        )
+        self.assertEqual(out_tensor, torch.zeros_like(out_tensor))
 
     def test_alltoall_list_size_validation(self):
         store = FakeStore()

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -332,24 +332,26 @@ class FakeProcessGroup : public Backend {
     c10d::checkSplitSizes(inputSplitSizes, inputBuffer, size_);
     c10d::checkSplitSizes(outputSplitSizes, outputBuffer, size_);
     TORCH_CHECK(
-        inputBuffer.is_contiguous(inputBuffer.suggest_memory_format()) &&
-            outputBuffer.is_contiguous(outputBuffer.suggest_memory_format()),
-        "Tensors must be contiguous");
+        inputBuffer.is_contiguous(inputBuffer.suggest_memory_format()),
+        "Input tensor must be contiguous");
+    TORCH_CHECK(
+        outputBuffer.is_contiguous(outputBuffer.suggest_memory_format()),
+        "Output tensor must be contiguous");
     // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     // Approximation: inputs from other ranks are unavailable here, so copy as
     // much of the local input as fits and zero the remainder.
     auto flat_input = inputBuffer.as_strided(
         {inputBuffer.numel()}, {1}, inputBuffer.storage_offset());
-    auto flat_output = outputBuffer.as_strided(
-        {outputBuffer.numel()}, {1}, outputBuffer.storage_offset());
+    auto flat_output =
+        outputBuffer
+            .as_strided(
+                {outputBuffer.numel()}, {1}, outputBuffer.storage_offset())
+            .zero_();
     auto copy_size = std::min(flat_input.numel(), flat_output.numel());
     if (copy_size > 0) {
       flat_output.narrow(0, 0, copy_size)
           .copy_(flat_input.narrow(0, 0, copy_size));
-    }
-    if (copy_size < flat_output.numel()) {
-      flat_output.narrow(0, copy_size, flat_output.numel() - copy_size).zero_();
     }
     return c10::make_intrusive<FakeWork>();
   }

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -331,19 +331,26 @@ class FakeProcessGroup : public Backend {
     checkCollectiveError();
     c10d::checkSplitSizes(inputSplitSizes, inputBuffer, size_);
     c10d::checkSplitSizes(outputSplitSizes, outputBuffer, size_);
+    TORCH_CHECK(
+        inputBuffer.is_contiguous(inputBuffer.suggest_memory_format()) &&
+            outputBuffer.is_contiguous(outputBuffer.suggest_memory_format()),
+        "Tensors must be contiguous");
     // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     // Approximation: inputs from other ranks are unavailable here, so copy as
     // much of the local input as fits and zero the remainder.
-    auto copy_size = std::min(inputBuffer.numel(), outputBuffer.numel());
-    auto flat_input = inputBuffer.reshape({-1});
-    auto flat_buffer =
-        at::zeros({outputBuffer.numel()}, outputBuffer.options());
+    auto flat_input = inputBuffer.as_strided(
+        {inputBuffer.numel()}, {1}, inputBuffer.storage_offset());
+    auto flat_output = outputBuffer.as_strided(
+        {outputBuffer.numel()}, {1}, outputBuffer.storage_offset());
+    auto copy_size = std::min(flat_input.numel(), flat_output.numel());
     if (copy_size > 0) {
-      flat_buffer.narrow(0, 0, copy_size)
+      flat_output.narrow(0, 0, copy_size)
           .copy_(flat_input.narrow(0, 0, copy_size));
     }
-    outputBuffer.copy_(flat_buffer.view_as(outputBuffer));
+    if (copy_size < flat_output.numel()) {
+      flat_output.narrow(0, copy_size, flat_output.numel() - copy_size).zero_();
+    }
     return c10::make_intrusive<FakeWork>();
   }
 

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -333,33 +333,13 @@ class FakeProcessGroup : public Backend {
     c10d::checkSplitSizes(outputSplitSizes, outputBuffer, size_);
     // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
-    if (outputSplitSizes.empty() && inputSplitSizes.empty()) {
-      outputBuffer.copy_(inputBuffer);
-    } else {
-      // Approximation: rank j's inputSplitSizes are unavailable here, so
-      // each output slot is filled by repeating inputBuffer[0:slot]. The
-      // values are deterministic but arbitrary; do not assert on them.
-      int64_t out_offset = 0;
-      auto in_size = inputBuffer.size(0);
-      for (int j = 0; j < size_; ++j) {
-        int64_t remaining = outputSplitSizes[j];
-        if (remaining > 0) {
-          TORCH_CHECK(
-              in_size > 0,
-              "alltoall_base: inputBuffer is empty but outputSplitSizes[",
-              j,
-              "] > 0");
-        }
-        int64_t dst = out_offset;
-        while (remaining > 0) {
-          auto chunk = std::min(remaining, in_size);
-          outputBuffer.narrow(0, dst, chunk)
-              .copy_(inputBuffer.narrow(0, 0, chunk));
-          dst += chunk;
-          remaining -= chunk;
-        }
-        out_offset += outputSplitSizes[j];
-      }
+    // Approximation: inputs from other ranks are unavailable here, so copy as
+    // much of the local input as fits and zero the remainder.
+    outputBuffer.zero_();
+    auto copy_size = std::min(inputBuffer.size(0), outputBuffer.size(0));
+    if (copy_size > 0) {
+      outputBuffer.narrow(0, 0, copy_size)
+          .copy_(inputBuffer.narrow(0, 0, copy_size));
     }
     return c10::make_intrusive<FakeWork>();
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #193985

Before the pr, fake_pg all_to_all_single assumes non-empty input. This
rejected a valid zero-send and nonzero-receive configuration. The nested
loop is also complicated to reason about.

This pr simplifies the fake_pg implementation by just copying
input_buffer to output_buffer and fill remaining with zeros.

Filling zero seems to be the least opinionated option and works for
all dtypes. It's hard to justify why filled with other values e.g. 1.
This is flexible to change though. People shouldn't really rely on the
actual value of fake_pg. We could change to 1 if we absolutely feel
the necessity of avoiding 0s.

Test Plan:

updated the expected values for
test_alltoall_base_output_larger_than_input,
test_alltoall_base_output_smaller_than_input,
test_alltoall_base_zero_sized_input

added a few new tests:
test_alltoall_base_empty_output_split_sizes
test_alltoall_base_empty_input_split_sizes
test_alltoall_base_equal_split_numel_mismatch
test_alltoall_base_flat_copy_equal_splits
test_alltoall_base_flat_copy_explicit_splits
test_alltoall_base_zero_sized_output
test_alltoall_base_requires_contiguous
test_alltoall_base_channels_last

Authored with an AI assistant.