### PR TITLE
[precompile] Add guard_policy="varying" to serialize only discriminating guards

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -112,6 +112,16 @@ def _precompile_closure_entry_factory():
     return entry
 
 
+def _precompile_scaled(x, k):
+    return x * k
+
+
+def _precompile_branchy(x, flag):
+    if flag:
+        return (x * 2).sum()
+    return (x + 1).sum()
+
+
 def _precompile_call_model(model, x):
     return model(x)
 
@@ -2991,6 +3001,58 @@ class TestPrecompile(TestCase):
             self.assertEqual(loaded(x), _precompile_unreachable_helper_caller(x))
             # Served, not recompiled: the whole point of installing.
             self.assertEqual(counters["stats"]["unique_graphs"], 0)
+
+    def test_guard_policy_varying_drops_guards_that_never_varied(self):
+        # k is the same in every example, so nothing depends on its guard to
+        # pick a variant. Under guard_policy="varying" it is not serialized,
+        # and an uncovered k therefore serves the captured graph rather than
+        # raising -- the documented trade the policy makes.
+        from torch._precompile import _parse_artifact_metadata
+
+        xs = [torch.randn(3), torch.randn(5)]
+        examples = [(x, 2) for x in xs]
+        sizes = {}
+        for policy in ("all", "varying"):
+            torch._dynamo.reset()
+            code, cache = torch.compiler.precompile(
+                _precompile_scaled,
+                backend="eager",
+                dynamic=False,
+                example_inputs=examples,
+                guard_policy=policy,
+            )
+            sizes[policy] = len(code)
+            self.assertEqual(_parse_artifact_metadata(code)["TRACER"], "multigraph")
+            torch._dynamo.reset()
+            loaded = torch.compiler.precompile.load(code, cache)
+            x = torch.randn(3)
+            with torch.no_grad():
+                self.assertEqual(loaded(x, 2), x * 2)
+                if policy == "all":
+                    with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+                        loaded(x, 5)
+                else:
+                    self.assertEqual(loaded(x, 5), x * 2)
+        self.assertLess(sizes["varying"], sizes["all"])
+
+    def test_guard_policy_varying_keeps_what_discriminates(self):
+        # flag DOES vary across the examples, so its guard is what selects
+        # between the two variants and must survive the policy.
+        x = torch.randn(4)
+        with torch.no_grad():
+            expected = {f: _precompile_branchy(x, f) for f in (False, True)}
+        code, cache = torch.compiler.precompile(
+            _precompile_branchy,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(x, False), (x, True)],
+            guard_policy="varying",
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            for flag in (False, True):
+                self.assertEqual(loaded(x, flag), expected[flag])
 
     def test_multi_graph_installed_entry_with_closure_is_refused(self):
         # An installed artifact rebuilds the entry from its code object, and

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4873,6 +4873,15 @@ class CheckFunctionManager:
                     True,
                     guard_filter_fn=serialization_guard_filter_fn,
                 )
+                # Value pruning keys off the guard tree: anything the tree does
+                # not reach is replaced by a placeholder. Dropping a guard must
+                # not drop the VALUE it named, because the rest of the state
+                # still refers to it -- a pruned tensor comes back with no
+                # dtype. So prune against the unfiltered tree.
+                serialization_builder.guard_tree_values = {
+                    **builder.guard_tree_values,
+                    **serialization_builder.guard_tree_values,
+                }
 
             self.guard_manager = guard_manager
             self.compile_check_fn(builder, runtime_guards, guard_fail_fn)

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -126,6 +126,7 @@ artifacts transparently without an explicit capture block.
 
 from __future__ import annotations
 
+import collections
 import contextlib
 import functools
 import hashlib
@@ -1049,6 +1050,36 @@ def _wont_generalize(
     return tuple(sorted(pinned))
 
 
+def varying_guard_slots(
+    guard_sets: Mapping[tuple[str, str, int], Sequence[frozenset[_GuardFact]]],
+) -> frozenset[tuple[str, str]]:
+    """The guard slots that actually discriminate between captured variants.
+
+    A slot is ``(guard_type, normalized source)``. It varies when two variants
+    of one frame recorded DIFFERENT facts for it, and also when it is present in
+    some variants and absent in others -- a guard only one variant carries is
+    what tells that variant apart, and comparing values alone would call it
+    invariant and drop it. On a 62-frame ranking model that second case is 260
+    of the 344 slots kept, so it is the majority of the answer, not an edge.
+
+    Everything else held identically in every variant, so under
+    ``guard_policy="varying"`` it is not serialized.
+    """
+    varying: set[tuple[str, str]] = set()
+    for variants in guard_sets.values():
+        seen: dict[tuple[str, str], set[tuple[tuple[str, ...], str]]] = {}
+        present: collections.Counter[tuple[str, str]] = collections.Counter()
+        for facts in variants:
+            for slot in {(f.guard_type, f.source) for f in facts}:
+                present[slot] += 1
+            for f in facts:
+                seen.setdefault((f.guard_type, f.source), set()).add((f.code, f.value))
+        for slot, rendered in seen.items():
+            if len(rendered) > 1 or present[slot] != len(variants):
+                varying.add(slot)
+    return frozenset(varying)
+
+
 def _summarize(
     entry: _DynamoCacheEntry,
     dropped: set[tuple[str, str]],
@@ -1093,6 +1124,7 @@ class PrecompileSession:
         dynamic: bool | None = None,
         example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
         invariants: str | None = None,
+        keep_only: frozenset[tuple[str, str]] | None = None,
     ) -> None:
         # Not `example_inputs or ()`: truth-testing the caller's object turns the
         # likeliest mistake -- passing the tensors themselves instead of a
@@ -1118,6 +1150,11 @@ class PrecompileSession:
         self._fn = fn
         self._backend = backend
         self._custom_guard_filter = guard_filter_fn is not None
+        # guard_policy="varying" fills this with the slots that DID vary; every
+        # other slot is dropped. None means the ordinary "serialize everything
+        # serializable" policy.
+        self._keep_only: frozenset[tuple[str, str]] | None = keep_only
+        self._policy_dropped_guards: set[tuple[str, str]] = set()
         self._dropped_guards: set[tuple[str, str]] = set()
         self._kept_guards: set[tuple[str, str]] = set()
         self._risky_dropped_guards: set[tuple[str, str]] = set()
@@ -1368,15 +1405,49 @@ class PrecompileSession:
         def filter_fn(entries: Sequence[GuardFilterEntry]) -> Sequence[bool]:
             decisions = inner(entries)
             namespaces = _module_namespaces(entries)
+            # guard_policy="varying": a slot whose fact was identical in every
+            # variant of every frame discriminates nothing, so it is not
+            # serialized. Recorded separately from the ordinary drops, which are
+            # "could not be serialized"; these could, and were not wanted.
+            policy_dropped: set[int] = set()
+            if self._keep_only is not None:
+                for i, entry in enumerate(entries):
+                    # An unmodelled guard never enters _guard_sets, so it was
+                    # never shown to be constant -- only never analyzed. This
+                    # policy drops what it PROVED invariant, so these stay.
+                    # SHAPE_ENV is the one that matters: it carries symbolic
+                    # shape constraints that no TENSOR_MATCH repeats.
+                    if entry.guard_type in _UNMODELLED_GUARD_TYPES:
+                        continue
+                    if (
+                        decisions[i]
+                        and (
+                            entry.guard_type,
+                            _normalize(entry.name),
+                        )
+                        not in self._keep_only
+                    ):
+                        policy_dropped.add(i)
+                decisions = [
+                    keep and i not in policy_dropped for i, keep in enumerate(decisions)
+                ]
             facts: set[_GuardFact] = set()
             undetermined: set[_GuardFact] = set()
-            for keep, entry in zip(decisions, entries):
+            for i, (keep, entry) in enumerate(zip(decisions, entries)):
+                slot = (entry.guard_type, entry.name)
+                if i in policy_dropped:
+                    # Not "risky": the policy is the caller stating that the
+                    # environment is fixed and every variation is in the inputs,
+                    # so a slot that never varied is out of the artifact's
+                    # declared domain rather than an unchecked hazard.
+                    self._policy_dropped_guards.add(slot)
+                    continue
                 target = self._kept_guards if keep else self._dropped_guards
-                target.add((entry.guard_type, entry.name))
+                target.add(slot)
                 if not keep and (
                     self._custom_guard_filter or _is_risky_drop(entry, namespaces)
                 ):
-                    self._risky_dropped_guards.add((entry.guard_type, entry.name))
+                    self._risky_dropped_guards.add(slot)
                 unmodelled = entry.guard_type in _UNMODELLED_GUARD_TYPES
                 fact = _GuardFact(
                     guard_type=entry.guard_type,
@@ -2069,6 +2140,7 @@ def precompile_capture(
     dynamic: bool | None = None,
     example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
     invariants: str | None = None,
+    keep_only: frozenset[tuple[str, str]] | None = None,
 ) -> PrecompileSession:
     r"""Begin capturing ``fn`` into a multi-graph artifact.
 
@@ -2100,6 +2172,7 @@ def precompile_capture(
         dynamic=dynamic,
         example_inputs=example_inputs,
         invariants=invariants,
+        keep_only=keep_only,
     )
 
 

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -3781,6 +3781,7 @@ class _PrecompileApi:
         require_complete: bool = True,
         require_no_risky_drops: bool = True,
         require_no_dropped_guards: bool = False,
+        guard_policy: str = "all",
     ) -> tuple[str, bytes]:
         """Ahead-of-time precompile ``fn`` against example inputs.
 
@@ -3988,6 +3989,29 @@ class _PrecompileApi:
                     f"has no tracer choice; drop tracer={tracer!r}. It applies only to "
                     "the positional source-artifact path."
                 )
+            keep_only = None
+            if guard_policy == "varying":
+                # Which guards discriminate is only knowable once every variant
+                # exists, and guards are serialized per compilation, as each one
+                # is produced. So learn it from a throwaway capture first, then
+                # capture again keeping only those. The examples fully determine
+                # the capture, so the second pass reproduces the first: measured
+                # identical on a 62-frame model (53 frames, 121 variants, no
+                # frame differing in variant count).
+                from torch._dynamo.precompile_package import varying_guard_slots
+
+                probe = self.capture(
+                    fn,
+                    backend=backend,
+                    guard_filter_fn=guard_filter_fn,
+                    recompile_limit=recompile_limit,
+                    dynamic=dynamic,
+                    example_inputs=example_inputs,
+                )
+                with probe:
+                    pass
+                keep_only = varying_guard_slots(probe._session._guard_sets)
+                torch._dynamo.reset()
             session = self.capture(
                 fn,
                 backend=backend,
@@ -3996,6 +4020,7 @@ class _PrecompileApi:
                 dynamic=dynamic,
                 example_inputs=example_inputs,
                 invariants=invariants,
+                keep_only=keep_only,
             )
             with session:
                 pass
@@ -4044,6 +4069,7 @@ class _PrecompileApi:
         dynamic: bool | None = None,
         example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
         invariants: str | None = None,
+        keep_only: frozenset[tuple[str, str]] | None = None,
     ) -> PrecompileSession:
         r"""capture(fn, *, backend="inductor", guard_filter_fn=None, recompile_limit=256, dynamic=None, example_inputs=None, invariants=None) -> PrecompileSession
 
@@ -4103,6 +4129,7 @@ class _PrecompileApi:
                 dynamic=dynamic,
                 example_inputs=example_inputs,
                 invariants=invariants,
+                keep_only=keep_only,
             )
         except PackageError as e:
             raise PrecompileError(str(e)) from e


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #193987
* #192379
* #193977
* #193976
* #193697
* #192374
* #192866
* #193725

Builds on torch.compiler.precompile below it. The contract that API asks for is
that the environment is identical between capture and runtime and that every
variation in computation comes from the inputs. Under that contract a guard
whose value was the same in every captured variant selects nothing: it is either
environment, which is pinned by assumption, or an input dimension the caller
chose not to vary, and the examples are the artifact's declared domain either
way. This serializes only the guards that actually discriminate.

A slot is (guard_type, normalized source), and it is kept when two variants of
its frame recorded different facts for it OR when it is present in some variants
and absent in others. The second case is not a refinement, it is most of the
answer: on a 62-frame ranking model it is 260 of the 344 slots kept, because a
guard only one variant carries is exactly what tells that variant apart.
Comparing the values of shared slots alone reports such a frame as having no
discriminator at all and collapses its variants.

Guards Dynamo never models -- SHAPE_ENV, GLOBAL_STATE and the rest of
_UNMODELLED_GUARD_TYPES -- are exempt. They never enter the fact sets, so they
were never shown to be constant, only never analyzed, and SHAPE_ENV in
particular carries symbolic shape constraints that no TENSOR_MATCH repeats.

Which guards discriminate is only knowable once every variant exists, and guards
are serialized per compilation as each one is produced, so this runs the capture
twice: once to learn, then again keeping only what varied. The two passes agree
by construction rather than by luck: PrecompileSession gives each session a
fresh PGO state and enters under _use_code_state, so the second pass cannot
inherit the first's automatic-dynamic learning.

One fix in guards.py is required rather than incidental. Value pruning keys off
the guard tree: anything the tree does not reach is replaced by a placeholder.
Dropping a guard therefore dropped the VALUE it named while the rest of the
state still referred to it, and the artifact failed to load with
"empty_strided(): argument 'dtype' must be torch.dtype, not _Missing". Pruning
now follows the unfiltered tree. Note this only masks the underlying issue:
missing_values is keyed by id, so one unguarded attribute holding torch.bfloat16
can stand in for every reference to that dtype in the pickle. That is a latent
bug of its own and wants a separate fix.

The trade is explicit and is why the default is unchanged: with the policy on, a
call outside the captured domain serves a captured graph instead of raising.
Drops made by the policy are recorded apart from the ordinary "could not be
serialized" drops and are not counted risky, since the contract covers them.

Test Plan:

```
python test/test_precompile.py
python test/dynamo/test_package.py
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_misc.py
```

One test asserts the trade directly -- a value that never varied is no longer
checked, so an uncovered value serves the captured graph while the default still
raises -- and one asserts that a value that DID vary keeps its guard and both
variants still serve correctly. On the ranking model above: 863 of 1207 slots
dropped, artifact 5,086,268 -> 4,068,095 chars, all five captured calls exact
with zero graphs compiled while serving, capture 6.1s -> 10.3s for the two
passes.

Authored with an AI assistant.

Differential Revision: [D116528373](https://our.internmc.facebook.com/intern/diff/D116528373)