### PR TITLE
Export Better Benchmark model rollups to HUD

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1163,17 +1163,17 @@ if count < 1:
 print(",".join(str(index) for index in range(count)))
 PY
 )"
-  local accounting_dir="${debug_dir}/model-accounting"
-  python scripts/generate_occurrence_sidecars.py \
-    --corpus-root repros \
-    --output-dir "${accounting_dir}/occurrences" \
-    --extern-cache "${accounting_dir}/extern-cache.json" \
-    --all \
-    --devices "${gpu_indices}"
-  python scripts/build_model_accounting.py \
-    --occdir "${accounting_dir}/occurrences" \
-    --output "${test_reports_dir}/model_accounting/b200" \
-    --prune
+
+  python scripts/bench_parallel.py \
+    repros/canonical \
+    --all-shapes \
+    --gpus "${gpu_indices}" \
+    --output "${debug_dir}/current.json"
+  python scripts/dashboard_export.py \
+    --input "${debug_dir}/current.json" \
+    --model-accounting benchmarks/model_accounting/b200 \
+    --timing auto \
+    --ci-json "${test_reports_dir}/inductor_kernel_benchmark.json"
   popd
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1153,30 +1153,16 @@ test_better_benchmark() {
     https://github.com/karthickai/better-benchmark.git "${benchmark_dir}"
   pushd "${benchmark_dir}"
 
-  local gpu_indices
-  gpu_indices="$(python - <<'PY'
-import sys
-import torch
-
-count = torch.cuda.device_count()
-if count < 1:
-    raise RuntimeError("Expected at least one GPU")
-print(f"Found {count} GPUs", file=sys.stderr)
-print(",".join(str(index) for index in range(count)))
-PY
-)"
-
-  python scripts/bench_parallel.py \
-    repros/canonical \
-    --all-shapes \
-    --gpus "${gpu_indices}" \
-    --output "${debug_dir}/current.json"
-  python scripts/dashboard_export.py \
-    --input "${debug_dir}/current.json" \
-    --model-accounting benchmarks/model_accounting_b200.json \
-    --timing auto \
-    --arch "NVIDIA B200" \
-    --ci-json "${test_reports_dir}/inductor_kernel_benchmark.json"
+  local accounting_dir="${debug_dir}/model-accounting"
+  python scripts/generate_occurrence_sidecars.py \
+    --corpus-root repros \
+    --output-dir "${accounting_dir}/occurrences" \
+    --extern-cache "${accounting_dir}/extern-cache.json" \
+    --all \
+    --device 0
+  python scripts/build_model_accounting.py \
+    --occdir "${accounting_dir}/occurrences" \
+    --output "${accounting_dir}/model_accounting_b200.json"
   popd
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1153,16 +1153,27 @@ test_better_benchmark() {
     https://github.com/karthickai/better-benchmark.git "${benchmark_dir}"
   pushd "${benchmark_dir}"
 
+  local gpu_indices
+  gpu_indices="$(python - <<'PY'
+import torch
+
+count = torch.cuda.device_count()
+if count < 1:
+    raise RuntimeError("Expected at least one GPU")
+print(",".join(str(index) for index in range(count)))
+PY
+)"
   local accounting_dir="${debug_dir}/model-accounting"
   python scripts/generate_occurrence_sidecars.py \
     --corpus-root repros \
     --output-dir "${accounting_dir}/occurrences" \
     --extern-cache "${accounting_dir}/extern-cache.json" \
     --all \
-    --device 0
+    --devices "${gpu_indices}"
   python scripts/build_model_accounting.py \
     --occdir "${accounting_dir}/occurrences" \
-    --output "${test_reports_dir}/model_accounting_b200.json"
+    --output "${test_reports_dir}/model_accounting/b200" \
+    --prune
   popd
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1162,7 +1162,7 @@ test_better_benchmark() {
     --device 0
   python scripts/build_model_accounting.py \
     --occdir "${accounting_dir}/occurrences" \
-    --output "${accounting_dir}/model_accounting_b200.json"
+    --output "${test_reports_dir}/model_accounting_b200.json"
   popd
 }
 

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1149,8 +1149,8 @@ test_better_benchmark() {
   benchmark_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/better-benchmark.XXXXXX")"
   mkdir -p "${test_reports_dir}" "${debug_dir}"
 
-  git clone --depth 1 --branch better-benchmark-dashboard \
-    https://github.com/karthickai/better-benchmark.git "${benchmark_dir}"
+  git clone --depth 1 --branch main \
+    https://github.com/eellison/better-benchmark.git "${benchmark_dir}"
   pushd "${benchmark_dir}"
 
   local gpu_indices

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1149,7 +1149,8 @@ test_better_benchmark() {
   benchmark_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/better-benchmark.XXXXXX")"
   mkdir -p "${test_reports_dir}" "${debug_dir}"
 
-  git clone --depth 1 --branch main https://github.com/eellison/better-benchmark.git "${benchmark_dir}"
+  git clone --depth 1 --branch better-benchmark-dashboard \
+    https://github.com/karthickai/better-benchmark.git "${benchmark_dir}"
   pushd "${benchmark_dir}"
 
   local gpu_indices
@@ -1170,11 +1171,11 @@ PY
     --all-shapes \
     --gpus "${gpu_indices}" \
     --output "${debug_dir}/current.json"
-  # TODO: Add a single-input CI export mode to bench_report.py. For now it
-  # requires --compare, so compare the result with itself and export the
-  # unchanged head values as PyTorch v3 dashboard records.
-  python scripts/bench_report.py \
-    --compare "${debug_dir}/current.json" "${debug_dir}/current.json" \
+  python scripts/dashboard_export.py \
+    --input "${debug_dir}/current.json" \
+    --model-accounting benchmarks/model_accounting_b200.json \
+    --timing auto \
+    --arch "NVIDIA B200" \
     --ci-json "${test_reports_dir}/inductor_kernel_benchmark.json"
   popd
 }

--- a/.github/workflows/better-benchmark-b200.yml
+++ b/.github/workflows/better-benchmark-b200.yml
@@ -2,10 +2,6 @@
 name: Better Benchmark B200
 
 on:
-  pull_request:
-    paths:
-      - .ci/pytorch/test.sh
-      - .github/workflows/better-benchmark-b200.yml
   schedule:
     - cron: 0 7 * * *
   workflow_dispatch:

--- a/.github/workflows/better-benchmark-b200.yml
+++ b/.github/workflows/better-benchmark-b200.yml
@@ -2,6 +2,10 @@
 name: Better Benchmark B200
 
 on:
+  pull_request:
+    paths:
+      - .ci/pytorch/test.sh
+      - .github/workflows/better-benchmark-b200.yml
   schedule:
     - cron: 0 7 * * *
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Add scheduled and manually dispatched Better Benchmark CI on an eight-GPU B200 runner.
- Run the merged upstream `eellison/better-benchmark` implementation.
- Export measured kernel latency and projected model latency records using versioned per-model B200 accounting.
- Upload the output through PyTorch's existing benchmark v3 test-report path for HUD comparisons.

## Test plan

- [x] Validate `.ci/pytorch/test.sh` shell syntax.
- [x] Run the complete Better Benchmark B200 workflow.
- [x] Benchmark 4,977 shape points across eight B200 GPUs.
- [x] Load all 166 per-model accounting entries.
- [x] Export and upload 10,283 records: 9,954 kernel records, 163 projected-model latency records, and 166 model-coverage records.
- [x] Verify incomplete models are excluded with explicit coverage and reasons.

Successful validation: https://github.com/pytorch/pytorch/actions/runs/32319886060/attempts/2