### PR TITLE
[CUDA RNG] Allocate graph capture state on its capture stream

### DIFF
--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.cpp
@@ -84,38 +84,54 @@ Generator createCUDAGenerator(DeviceIndex device_index) {
 
 /**
  * Allocate GPU tensors for this capture state.
- *
- * We allocate on the default stream so that the caching allocator routes
- * these tensors to the default memory pool, not the graph's capture pool.
  */
-void CUDAGeneratorCaptureState::initialize(uint64_t seed) {
+void CUDAGeneratorCaptureState::initialize(
+    uint64_t seed,
+    c10::DeviceIndex device,
+    CaptureId_t capture_id,
+    c10::MempoolId_t graph_pool_id) {
   if (is_initialized()) {
     return;
   }
 
-  auto options = at::TensorOptions().device(at::kCUDA).dtype(at::kLong);
+  auto options = at::TensorOptions()
+                     .device(at::Device(at::kCUDA, device))
+                     .dtype(at::kLong);
   c10::InferenceMode inference_guard(false);
 
-  // Allocate on the default stream so that the caching allocator routes
-  // these tensors to the default memory pool, not the graph's capture pool.
-  // The relaxed capture mode guard is needed because the thread-local capture
-  // mode may be Global (set by cudaStreamBeginCapture), which would block
-  // cudaMalloc even on a non-capturing stream.
-  c10::cuda::CUDAStreamCaptureModeGuard capture_mode_guard(
-      cudaStreamCaptureModeRelaxed);
-  c10::cuda::CUDAStreamGuard stream_guard(c10::cuda::getDefaultCUDAStream());
+  auto allocate_state = [&]() {
+    rng_state_seed_extragraph_ = at::empty({1}, options);
+    rng_state_offset_extragraph_ = at::empty({1}, options);
+  };
 
-  rng_state_seed_extragraph_ = at::empty({1}, options);
-  rng_state_offset_extragraph_ = at::empty({1}, options);
+#if !defined(USE_ROCM)
+  if (c10::cuda::CUDACachingAllocator::name() == "native" &&
+      c10::cuda::CUDACachingAllocator::isEnabled()) {
+    auto stream = c10::cuda::getCurrentCUDAStream(device);
+    auto current_capture_id = c10::cuda::captureIdMayInitCtx(stream.stream());
+    TORCH_INTERNAL_ASSERT(
+        current_capture_id.has_value() &&
+            current_capture_id.value() == capture_id,
+        "RNG capture state must be initialized on its capture stream.");
+    c10::cuda::CUDACachingAllocator::withPoolRoutingDisabled(
+        device, graph_pool_id, allocate_state);
+  } else
+#endif
+  {
+    // Other allocator backends retain the established default-stream path.
+    c10::cuda::CUDAStreamCaptureModeGuard capture_mode_guard(
+        cudaStreamCaptureModeRelaxed);
+    c10::cuda::CUDAStreamGuard stream_guard(
+        c10::cuda::getDefaultCUDAStream(device));
+    allocate_state();
+    c10::cuda::getDefaultCUDAStream(device).synchronize();
+  }
+
   // Captured graphs bake in these buffers' addresses, and philox_state hands
   // out aliases of them; make the storage non-resizable so nothing can
   // reallocate it.
   rng_state_seed_extragraph_.storage().unsafeGetStorageImpl()->set_resizable(false);
   rng_state_offset_extragraph_.storage().unsafeGetStorageImpl()->set_resizable(false);
-
-  // Synchronize the default stream so that any prior work completes before
-  // a different stream writes to this memory.
-  c10::cuda::getDefaultCUDAStream().synchronize();
 
   offset_intragraph_ = 0;
 }
@@ -139,12 +155,13 @@ uint64_t CUDAGeneratorCaptureState::finalize() {
 /**
  * Note [RNG state tensor lifetime and recordStream]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- * RNG state tensors (seed and offset) are allocated on the default stream
- * so they land in the default memory pool, not the graph's capture pool.
- * This avoids false positives in the CUDA graph tree memory leak checker.
+ * RNG state tensors (seed and offset) live outside the graph's private pool.
+ * The native allocator places them in the normal pool on the capture stream.
+ * This avoids false positives in the CUDA graph tree memory leak checker
+ * without accessing the default stream during capture.
  *
  * However, during replay these tensors are filled and then read by the
- * graph on the replay stream (which may differ from the default stream).
+ * graph on the replay stream (which may differ from the capture stream).
  * If the graph is deleted while a replay is still in flight, the tensors
  * are freed and the allocator could recycle their memory before the replay
  * finishes reading them — a use-after-free.
@@ -195,7 +212,8 @@ CUDAGeneratorCaptureState* CUDAGeneratorState::get_capture_state(CaptureId_t cap
       "RNG op during graph capture but could not find the CUDAGraph object.");
 
   auto capture_state = make_intrusive<CUDAGeneratorCaptureState>();
-  capture_state->initialize(seed_);
+  capture_state->initialize(
+      seed_, graph->capture_dev_, capture_id, graph->mempool_id_);
 
   graph->register_generator_state(
       c10::intrusive_ptr<CUDAGeneratorState>::reclaim_copy(this));

--- a/aten/src/ATen/cuda/CUDAGeneratorImpl.h
+++ b/aten/src/ATen/cuda/CUDAGeneratorImpl.h
@@ -111,7 +111,11 @@ struct CUDAGeneratorCaptureState : public c10::intrusive_ptr_target {
   CUDAGeneratorCaptureState() = default;
 
   bool is_initialized() const { return rng_state_seed_extragraph_.defined(); }
-  void initialize(uint64_t seed);
+  void initialize(
+      uint64_t seed,
+      c10::DeviceIndex device,
+      CaptureId_t capture_id,
+      c10::MempoolId_t graph_pool_id);
   void increase(uint64_t increment);
   uint64_t finalize();
   void setup_for_replay(uint64_t seed, uint64_t philox_offset);

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -108,6 +108,8 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
       const Tensor& scalar_cuda_pred_tensor);
 
  private:
+  friend struct at::CUDAGeneratorState;
+
   template <typename StreamType>
   std::function<bool(StreamType)> create_allocate_filter() const;
   std::function<bool(cudaStream_t)> create_child_allocate_filter();

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -1533,6 +1533,12 @@ class DeviceCachingAllocator {
   // intentional: metadata labels a region of source code, not a device.
   static thread_local std::string user_metadata;
 
+  // Private-pool routes temporarily disabled by the calling thread. Include
+  // the allocator instance so a scope for one device cannot affect another.
+  static thread_local std::vector<
+      std::pair<const DeviceCachingAllocator*, MempoolId_t>>
+      disabled_pool_routes;
+
  public:
   explicit DeviceCachingAllocator(c10::DeviceIndex id)
       : device_id(id),
@@ -3097,6 +3103,21 @@ class DeviceCachingAllocator {
 
   // See Note [Interaction with CUDA graph capture]
 
+  void withPoolRoutingDisabled(
+      MempoolId_t mempool_id,
+      const std::function<void()>& fn) {
+    disabled_pool_routes.emplace_back(this, mempool_id);
+    auto restore = c10::make_scope_exit([this, mempool_id]() {
+      TORCH_INTERNAL_ASSERT(
+          !disabled_pool_routes.empty() &&
+              disabled_pool_routes.back().first == this &&
+              disabled_pool_routes.back().second == mempool_id,
+          "Pool routing scopes must end in LIFO order on their creating thread.");
+      disabled_pool_routes.pop_back();
+    });
+    fn();
+  }
+
   // Routes allocations matching `filter` into the private mempool
   // identified by `mempool_id` for the duration of the matching
   // endAllocateToPool call. Callers include CUDAGraph::capture_begin (during
@@ -3638,6 +3659,14 @@ class DeviceCachingAllocator {
         cudaStreamCaptureStatusNone;
   }
 
+  bool isPoolRoutingDisabled(MempoolId_t pool_id) const {
+    return std::find(
+               disabled_pool_routes.begin(),
+               disabled_pool_routes.end(),
+               std::pair<const DeviceCachingAllocator*, MempoolId_t>{
+                   this, pool_id}) != disabled_pool_routes.end();
+  }
+
   BlockPool& get_pool(size_t size, cudaStream_t stream) {
     // allocation_scopes_ tracks active mempool diversions (real captures or
     // user-managed pools via use_mem_pool / NCCL registration / inductor
@@ -3646,7 +3675,7 @@ class DeviceCachingAllocator {
     if (C10_UNLIKELY(!allocation_scopes_.empty())) {
       // Search allocation_scopes_ in LIFO order.
       for (auto& [pool_id, scope] : std::views::reverse(allocation_scopes_)) {
-        if (scope(stream)) {
+        if (scope(stream) && !isPoolRoutingDisabled(pool_id)) {
           auto it1 = graph_pools.find(pool_id);
           TORCH_INTERNAL_ASSERT(it1 != graph_pools.end());
           if (size <= kSmallSize) {
@@ -4522,6 +4551,8 @@ static void local_raw_delete(void* ptr);
 // NOLINTBEGIN(misc-use-internal-linkage)
 thread_local std::stack<std::string> DeviceCachingAllocator::compile_context;
 thread_local std::string DeviceCachingAllocator::user_metadata;
+thread_local std::vector<std::pair<const DeviceCachingAllocator*, MempoolId_t>>
+    DeviceCachingAllocator::disabled_pool_routes;
 // NOLINTEND(misc-use-internal-linkage)
 
 class NativeCachingAllocator : public CUDAAllocator {
@@ -5084,6 +5115,14 @@ class NativeCachingAllocator : public CUDAAllocator {
     device_allocator[device]->endAllocateToPool(mempool_id);
   }
 
+  void withPoolRoutingDisabled(
+      c10::DeviceIndex device,
+      MempoolId_t mempool_id,
+      const std::function<void()>& fn) {
+    assertValidDevice(device);
+    device_allocator[device]->withPoolRoutingDisabled(mempool_id, fn);
+  }
+
   void markCaptureBegin(c10::DeviceIndex device) override {
     assertValidDevice(device);
     device_allocator[device]->markCaptureBegin();
@@ -5322,6 +5361,16 @@ void local_raw_delete(void* ptr) {
 }
 
 } // namespace Native
+
+void withPoolRoutingDisabled(
+    c10::DeviceIndex device,
+    MempoolId_t mempool_id,
+    const std::function<void()>& fn) {
+  TORCH_INTERNAL_ASSERT(
+      get()->name() == "native",
+      "Disabling pool routing is only supported by the native CUDA allocator.");
+  Native::allocator.withPoolRoutingDisabled(device, mempool_id, fn);
+}
 
 namespace CudaMallocAsync {
 // If this is put in its own header file, it gets incorrectly renamed in HIPify.

--- a/c10/cuda/CUDACachingAllocator.h
+++ b/c10/cuda/CUDACachingAllocator.h
@@ -423,6 +423,12 @@ inline DataPtr allocateWithAddress(size_t size, void* addr) {
 }
 
 // CUDAGraph interactions
+// Temporarily skip one private-pool routing scope on the calling thread.
+C10_CUDA_API void withPoolRoutingDisabled(
+    c10::DeviceIndex device,
+    MempoolId_t mempool_id,
+    const std::function<void()>& fn);
+
 inline void beginAllocateToPool(
     c10::DeviceIndex device,
     MempoolId_t mempool_id,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3336,12 +3336,109 @@ torch.cuda.synchronize()
         self.assertEqual(buf0, ref0)
         self.assertEqual(buf1, ref1)
 
-    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/177001")
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @unittest.skipIf(
+        TEST_WITH_ROCM or TEST_CUDAMALLOCASYNC,
+        "capture-stream pool routing is specific to the native CUDA allocator",
+    )
+    def test_graph_rng_capture_stream_pool_routing(self):
+        for pool in (None, torch.cuda.MemPool()):
+            with self.subTest(pool="default" if pool is None else "explicit"):
+                generator = torch.Generator(device="cuda")
+                stream = torch.cuda.Stream()
+                graph = torch.cuda.CUDAGraph()
+                pool_context = (
+                    contextlib.nullcontext()
+                    if pool is None
+                    else torch.cuda.use_mem_pool(pool)
+                )
+
+                with torch.cuda.stream(stream):
+                    graph.capture_begin()
+                    with pool_context:
+                        torch.rand(1, device="cuda", generator=generator)
+                        seed, offset, _ = generator.philox_state(0)
+                    graph.capture_end()
+
+                # Only the graph pool is skipped; an explicit MemPool still wins.
+                expected_pool = (0, 0) if pool is None else pool.id
+                state_addresses = {
+                    seed.untyped_storage().data_ptr(),
+                    offset.untyped_storage().data_ptr(),
+                }
+                state_placements = {
+                    block["address"]: (
+                        segment["segment_pool_id"],
+                        segment["stream"],
+                    )
+                    for segment in torch.cuda.memory_snapshot(include_traces=False)
+                    for block in segment["blocks"]
+                    if block["address"] in state_addresses
+                }
+                self.assertEqual(
+                    state_placements,
+                    dict.fromkeys(state_addresses, (expected_pool, stream.cuda_stream)),
+                )
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @unittest.skipIf(
+        TEST_WITH_ROCM or TEST_CUDAMALLOCASYNC,
+        "captured-event regression is specific to the native CUDA allocator",
+    )
+    def test_graph_rng_thread_local_capture_with_pending_event(self):
+        test_script = """
+import torch
+
+capture_stream = torch.cuda.Stream()
+pending = torch.empty(1, device="cuda")
+graph = torch.cuda.CUDAGraph()
+
+with torch.cuda.stream(capture_stream):
+    graph.capture_begin(capture_error_mode="thread_local")
+    with torch.cuda.stream(torch.cuda.default_stream()):
+        pending.record_stream(capture_stream)
+        pending.untyped_storage().resize_(0)
+    output = torch.rand(1, device="cuda")
+    graph.capture_end()
+
+graph.replay()
+torch.cuda.synchronize()
+"""
+        subprocess.check_call([sys.executable, "-c", test_script])
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
+    @unittest.skipIf(
+        TEST_WITH_ROCM or TEST_CUDAMALLOCASYNC,
+        "cache-disabled fallback is specific to the native CUDA allocator",
+    )
+    def test_graph_rng_with_caching_disabled(self):
+        stream = torch.cuda.Stream()
+        output = torch.empty(1, device="cuda")
+        graph = torch.cuda.CUDAGraph()
+
+        with torch.cuda.memory.caching_allocator_disabled():
+            with torch.cuda.stream(stream):
+                graph.capture_begin(capture_error_mode="thread_local")
+                output.uniform_()
+                graph.capture_end()
+
+        graph.replay()
+        torch.cuda.synchronize()
+
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
     @unittest.skipIf(
         TEST_WITH_ROCM, "ROCM does not support nvrtc or external cuda graph events"
+    )
+    @unittest.skipIf(
+        TEST_CUDAMALLOCASYNC, "requires native CUDA allocator block statistics"
     )
     @unittest.skipIf(not SM70OrLater, "SM70+ required for inline ptx")
     def test_graph_rng_replay_record_stream(self):
@@ -3382,13 +3479,17 @@ torch.cuda.synchronize()
         # Reference replay
         flag_cpu[0] = 1
         buf.zero_()
-        g.replay()
+        with torch.cuda.stream(s):
+            g.replay()
         torch.cuda.synchronize()
 
-        # Race: replay with spin held, then delete graph
+        # Race: replay with spin held on a stream distinct from the state
+        # tensors' allocation stream, then delete the graph.
         flag_cpu[0] = 0
         buf.zero_()
-        with torch.cuda.stream(s):
+        replay_stream = torch.cuda.Stream()
+        replay_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(replay_stream):
             g.replay()  # GPU spinning
 
         g.reset()
@@ -3418,6 +3519,7 @@ torch.cuda.synchronize()
             "RNG state tensors should be freed after sync + empty_cache",
         )
 
+    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/177001")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )


### PR DESCRIPTION
### Summary

This change allocates CUDA graph RNG state on the active capture stream while keeping it outside the graph execution pool.

### Motivation

The previous initializer switched to the default stream so the RNG seed and offset tensors would not enter the graph pool. That switch can expose an unrelated allocator event while capture is active:

```python
import torch

capture_stream = torch.cuda.Stream()
pending = torch.empty(1, device="cuda")
graph = torch.cuda.CUDAGraph()

with torch.cuda.stream(capture_stream):
    graph.capture_begin(capture_error_mode="thread_local")
    with torch.cuda.stream(torch.cuda.default_stream()):
        pending.record_stream(capture_stream)
        pending.untyped_storage().resize_(0)
    output = torch.rand(1, device="cuda")  # first RNG use
    graph.capture_end()
```

The first `torch.rand` creates two RNG state tensors. On the old path, their default-stream allocations can poll the pending event recorded on `capture_stream`, which fails with `cudaErrorCapturedEvent`. (See also https://github.com/pytorch/pytorch/issues/193982)

### Storage choice

RNG state could live in the graph execution pool, the default pool, or a shared RNG-only pool. The graph pool is natural but CUDA Graph Tree checkpoint restoration can invalidate state created after a checkpoint, while a shared RNG-only pool needs new lifetime and memory-reclamation bookkeeping. This change therefore keeps the existing default-pool placement, which uses normal allocator accounting and stays outside graph checkpoints, but allocates on the capture stream. A narrow allocator scope skips only the graph execution pool, preserves an explicit `MemPool`, and avoids new pool or checkpoint machinery.

### Remaining allocator limitation

The native caching allocator still has a broader edge case when a default-stream free records an event on a capturing stream and a later default-stream allocation polls it. That allocator-wide problem is tracked separately https://github.com/pytorch/pytorch/issues/193982.

RNG no longer enters that path after this change. A general fix would require broader target-stream event and capture-transition tracking, so it is outside this focused change.
