### PR TITLE
[precompile] Add training=True so a capture carries its backward

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -112,6 +112,16 @@ def _precompile_closure_entry_factory():
     return entry
 
 
+class _PrecompileTrainMod(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = torch.nn.Linear(8, 8)
+        self.b = torch.nn.Linear(8, 8)
+
+    def forward(self, x):
+        return torch.relu(self.b(torch.relu(self.a(x))))
+
+
 def _precompile_scaled(x, k):
     return x * k
 
@@ -3001,6 +3011,54 @@ class TestPrecompile(TestCase):
             self.assertEqual(loaded(x), _precompile_unreachable_helper_caller(x))
             # Served, not recompiled: the whole point of installing.
             self.assertEqual(counters["stats"]["unique_graphs"], 0)
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_training_capture_serves_a_backward_without_a_loss(self, backend):
+        # The capture never sees a loss and never calls .backward(). The joint
+        # trace synthesizes tangents from the forward outputs, and the backward
+        # is lowered eagerly, so a served output is still wired to
+        # AOTAutograd's CompiledFunction and .backward() runs precompiled code.
+        model = _PrecompileTrainMod()
+        xs = [torch.randn(n, 8) for n in (4, 6)]
+        expected = []
+        for x in xs:
+            model.zero_grad(set_to_none=True)
+            _precompile_call_model(model, x).sum().backward()
+            expected.append([p.grad.clone() for p in model.parameters()])
+        model.zero_grad(set_to_none=True)
+
+        code, cache = torch.compiler.precompile(
+            _precompile_call_model,
+            backend=backend,
+            dynamic=False,
+            example_inputs=[(model, x) for x in xs],
+            training=True,
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        for x, grads in zip(xs, expected):
+            model.zero_grad(set_to_none=True)
+            out = loaded(model, x)
+            self.assertTrue(out.requires_grad)
+            out.sum().backward()
+            for want, param in zip(grads, model.parameters()):
+                self.assertEqual(want, param.grad)
+
+    def test_inference_capture_stays_grad_free(self):
+        # The default is unchanged: examples run under no_grad, so a served
+        # output carries no autograd history.
+        model = _PrecompileTrainMod()
+        x = torch.randn(4, 8)
+        code, cache = torch.compiler.precompile(
+            _precompile_call_model,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(model, x)],
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            self.assertFalse(loaded(model, x).requires_grad)
 
     def test_guard_policy_varying_drops_guards_that_never_varied(self):
         # k is the same in every example, so nothing depends on its guard to

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4119,7 +4119,11 @@ class GuardsStatePickler(pickle.Pickler):
             pytype,
             torch._C.DispatchKeySet.from_raw_repr(dispatch_keys_raw),
         )
-        ret.grad = grad
+        # A .grad the guards never read is pruned to the _Missing sentinel on
+        # the way in, and only a training capture has one to prune at all. It
+        # was not guarded on, so the reconstructed tensor does not need it --
+        # but assigning the sentinel raises.
+        ret.grad = grad if isinstance(grad, torch.Tensor) else None
         return ret
 
     @classmethod
@@ -4454,7 +4458,9 @@ class GuardsStatePickler(pickle.Pickler):
                 obj.device,
                 pytype,
                 torch._C._dispatch_keys(obj).raw_repr(),
-                obj.grad,
+                # Reading .grad off a non-leaf warns and is always None anyway;
+                # a training capture hits plenty of non-leaf tensors.
+                obj.grad if obj.is_leaf else None,
             )
 
         elif isinstance(obj, torch.nn.Module):

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -185,8 +185,8 @@ _ALLOW_EMPTY_GRAPHS = torch._dynamo.config._make_closure_patcher(
 )
 
 
-_CAPTURE_CONFIG_STATE: ContextVar[tuple[int, tuple[bool, bool] | None]] = ContextVar(
-    "precompile_capture_config_state", default=(0, None)
+_CAPTURE_CONFIG_STATE: ContextVar[tuple[int, tuple[bool, bool, bool] | None]] = (
+    ContextVar("precompile_capture_config_state", default=(0, None))
 )
 
 # Not a public surface -- see the module docstring. This exists so `from ...
@@ -205,16 +205,24 @@ __all__ = [
 
 
 @contextlib.contextmanager
-def _capture_config() -> Iterator[None]:
+def _capture_config(training: bool = False) -> Iterator[None]:
     depth, prior = _CAPTURE_CONFIG_STATE.get()
     dynamo_config: Any = torch._dynamo.config
     if depth == 0:
         prior = (
             functorch_config.bundled_autograd_cache,
             dynamo_config.allow_empty_graphs,
+            functorch_config.force_non_lazy_backward_lowering,
         )
         functorch_config.bundled_autograd_cache = True
         dynamo_config.allow_empty_graphs = True
+        if training:
+            # AOTAutograd lowers the backward on the first .backward() call, so
+            # a capture that never calls one records a forward and nothing else.
+            # Lower it eagerly instead: the joint trace already synthesizes
+            # tangents from the forward outputs' metadata, so the backward graph
+            # exists without the caller having to produce a loss.
+            functorch_config.force_non_lazy_backward_lowering = True
     _CAPTURE_CONFIG_STATE.set((depth + 1, prior))
     try:
         yield
@@ -226,6 +234,7 @@ def _capture_config() -> Iterator[None]:
         if depth == 0:
             functorch_config.bundled_autograd_cache = prior[0]
             dynamo_config.allow_empty_graphs = prior[1]
+            functorch_config.force_non_lazy_backward_lowering = prior[2]
             _CAPTURE_CONFIG_STATE.set((0, None))
         else:
             _CAPTURE_CONFIG_STATE.set((depth, prior))
@@ -1125,6 +1134,7 @@ class PrecompileSession:
         example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
         invariants: str | None = None,
         keep_only: frozenset[tuple[str, str]] | None = None,
+        training: bool = False,
     ) -> None:
         # Not `example_inputs or ()`: truth-testing the caller's object turns the
         # likeliest mistake -- passing the tensors themselves instead of a
@@ -1154,6 +1164,10 @@ class PrecompileSession:
         # other slot is dropped. None means the ordinary "serialize everything
         # serializable" policy.
         self._keep_only: frozenset[tuple[str, str]] | None = keep_only
+        # A training capture traces with grad on and lowers the backward
+        # eagerly, so the artifact carries AOTAutograd's CompiledFunction and
+        # calling .backward() on a served output runs precompiled code.
+        self._training = training
         self._policy_dropped_guards: set[tuple[str, str]] = set()
         self._dropped_guards: set[tuple[str, str]] = set()
         self._kept_guards: set[tuple[str, str]] = set()
@@ -1266,7 +1280,7 @@ class PrecompileSession:
         stack = contextlib.ExitStack()
         # Backends must serialize into the artifact rather than into the
         # process-local inductor cache.
-        stack.enter_context(_capture_config())
+        stack.enter_context(_capture_config(self._training))
         self._stack = stack
         try:
             if self._example_inputs:
@@ -1316,8 +1330,15 @@ class PrecompileSession:
                 for value in tree_leaves((args, kwargs)):
                     if isinstance(value, torch.nn.Module):
                         self._check_module_state(value)
-                with torch.inference_mode(False), torch.no_grad():
-                    self._call(*args, **kwargs)
+                if self._training:
+                    # Grad must be ON: the point of a training capture is that
+                    # AOTAutograd builds its CompiledFunction and the joint
+                    # graph, which it only does when the outputs require grad.
+                    with torch.inference_mode(False), torch.enable_grad():
+                        self._call(*args, **kwargs)
+                else:
+                    with torch.inference_mode(False), torch.no_grad():
+                        self._call(*args, **kwargs)
         except BaseException as e:
             self._record_capture_error(e)
             # A __enter__ that raises never gets its __exit__, so without this
@@ -1888,11 +1909,11 @@ class PrecompileSession:
                 "Precompilation captured graphs but their compiled backends were "
                 "never recorded, so there is nothing to serialize. AOTAutograd only "
                 "records the bundled artifact once the BACKWARD compiles, so a "
-                "forward-only capture with grad enabled -- the default, and what "
-                "model.eval() still leaves you in -- records nothing. Capture under "
-                "torch.no_grad() or torch.inference_mode() for an inference "
-                "artifact, or run .backward() inside the capture block for a "
-                "training one."
+                "forward-only capture with grad enabled records nothing on its own. "
+                "Pass training=True to lower the backward eagerly (the joint "
+                "trace synthesizes tangents, so no loss is needed), capture "
+                "under torch.no_grad()/torch.inference_mode() for an inference "
+                "artifact, or run .backward() inside the capture block."
             ) from e
         log.info("precompile: saved %s to %s", summary, path)
         return summary
@@ -1925,11 +1946,11 @@ class PrecompileSession:
                 "Precompilation captured graphs but their compiled backends were "
                 "never recorded, so there is nothing to serialize. AOTAutograd only "
                 "records the bundled artifact once the BACKWARD compiles, so a "
-                "forward-only capture with grad enabled -- the default, and what "
-                "model.eval() still leaves you in -- records nothing. Capture under "
-                "torch.no_grad() or torch.inference_mode() for an inference "
-                "artifact, or run .backward() inside the capture block for a "
-                "training one."
+                "forward-only capture with grad enabled records nothing on its own. "
+                "Pass training=True to lower the backward eagerly (the joint "
+                "trace synthesizes tangents, so no loss is needed), capture "
+                "under torch.no_grad()/torch.inference_mode() for an inference "
+                "artifact, or run .backward() inside the capture block."
             )
         return {str(b): collected[b] for b in entry.backend_ids}
 
@@ -2141,6 +2162,7 @@ def precompile_capture(
     example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
     invariants: str | None = None,
     keep_only: frozenset[tuple[str, str]] | None = None,
+    training: bool = False,
 ) -> PrecompileSession:
     r"""Begin capturing ``fn`` into a multi-graph artifact.
 
@@ -2173,6 +2195,7 @@ def precompile_capture(
         example_inputs=example_inputs,
         invariants=invariants,
         keep_only=keep_only,
+        training=training,
     )
 
 

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -374,7 +374,7 @@ graphsafe_rng_functionalization = True
 # used by AOT compile and other settings
 # TODO: once AOT compile calls aot autograd directly instead of
 # through compile_fx, we can remove this
-force_non_lazy_backward_lowering = False
+force_non_lazy_backward_lowering: bool = False
 
 # only for testing, used to turn functionalization off in AOTDispatcher
 _test_disable_functionalization = True

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -3782,6 +3782,7 @@ class _PrecompileApi:
         require_no_risky_drops: bool = True,
         require_no_dropped_guards: bool = False,
         guard_policy: str = "all",
+        training: bool = False,
     ) -> tuple[str, bytes]:
         """Ahead-of-time precompile ``fn`` against example inputs.
 
@@ -4007,6 +4008,7 @@ class _PrecompileApi:
                     recompile_limit=recompile_limit,
                     dynamic=dynamic,
                     example_inputs=example_inputs,
+                    training=training,
                 )
                 with probe:
                     pass
@@ -4021,6 +4023,7 @@ class _PrecompileApi:
                 example_inputs=example_inputs,
                 invariants=invariants,
                 keep_only=keep_only,
+                training=training,
             )
             with session:
                 pass
@@ -4070,6 +4073,7 @@ class _PrecompileApi:
         example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
         invariants: str | None = None,
         keep_only: frozenset[tuple[str, str]] | None = None,
+        training: bool = False,
     ) -> PrecompileSession:
         r"""capture(fn, *, backend="inductor", guard_filter_fn=None, recompile_limit=256, dynamic=None, example_inputs=None, invariants=None) -> PrecompileSession
 
@@ -4130,6 +4134,7 @@ class _PrecompileApi:
                 example_inputs=example_inputs,
                 invariants=invariants,
                 keep_only=keep_only,
+                training=training,
             )
         except PackageError as e:
             raise PrecompileError(str(e)) from e


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #193997
* __->__ #193995
* #193987
* #192379
* #193977
* #193976
* #193697
* #192374
* #192866
* #193725

Makes torch.compiler.precompile a drop-in for torch.compile on a training
step. Until now an automatic capture ran its examples under no_grad, so the
artifact was inference-only, and the only way to get a backward was to call
.backward() inside a manual capture block -- which means having a loss, and
means the caller structuring their code around the capture.

None of that is necessary, because AOTAutograd already does the hard part. Its
joint trace synthesizes tangents from the forward outputs' own metadata, and it
already wraps the result in CompiledFunction, a torch.autograd.Function. What
was missing is that the backward graph is LOWERED lazily, on the first
.backward() call, so a capture that never makes one records a forward and
nothing else. training=True traces with grad enabled and sets
force_non_lazy_backward_lowering, which lowers the backward at forward-compile
time. A served output then arrives with grad_fn=CompiledFunctionBackward and
.backward() runs precompiled code, with no loss anywhere in the capture.

Two serialization bugs sat on that path and had to be fixed, both reachable
only once a capture has grads to serialize. A parameter's .grad is not read by
any guard, so it is pruned to the _Missing sentinel, and _unpickle_tensor then
assigned the sentinel and raised "assigned grad expected to be a Tensor or None
but got grad of type _Missing" at LOAD -- the artifact built fine and could not
be opened. The reducer also read .grad off non-leaf tensors, which is always
None and warns; a training capture walks a great many non-leaf tensors.

The default is unchanged: without training=True examples still run under
no_grad and a served output has no autograd history. The error text for a
capture that recorded no backends is updated, since "run .backward() inside the
capture block" is no longer the only way out.

Test Plan:

```
python test/test_precompile.py
python test/dynamo/test_package.py
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_misc.py
```

The new tests capture a two-layer model with no loss and no .backward() during
capture, then assert the served output requires grad and that its gradients
equal eager's, on both backends; a second test pins that the default stays
grad-free. On the 62-frame ranking model this stack has been developed against:
capture 6.3s, gradients match eager, zero graphs compiled while serving.

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98