### PR TITLE
[TEST] Add `hw_classification` to `test_decomp.py`

### DIFF
--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     is_iterable_of_tensors,
     run_tests,
     skipIfCrossRef,
@@ -576,6 +577,7 @@ comprehensive_failures = {
 
 @unMarkDynamoStrictTest
 class TestDecomp(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
     longMessage = True
 
     # NB: This actually overlaps with test_comprehensive, but it only
@@ -1178,6 +1180,8 @@ instantiate_device_type_tests(TestDecomp, globals())
 
 
 class DecompOneOffTests(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyNativeDeviceTypes
     @skipIfCrossRef
     def test_contiguous_softmax(self, device):
@@ -1536,6 +1540,8 @@ instantiate_device_type_tests(DecompOneOffTests, globals())
 
 
 class HasDecompTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.maxDiff = None


### PR DESCRIPTION
## Summary

Add `hw_classification` attributes to all 3 test classes in `test/test_decomp.py` per RFC in #185142 and #185590

- `TestDecomp`: `ACCELERATOR` — uses `instantiate_device_type_tests`, tests run across all accelerators via device parameter with `@onlyNativeDeviceTypes`/`@onlyCPU`/`@onlyCUDA` method-level routing
- `DecompOneOffTests`: `ACCELERATOR` — uses `instantiate_device_type_tests`, tests run across all accelerators via device parameter
- `HasDecompTest`: `GENERIC` — no device routing, all tests are CPU-only/device-agnostic (decomposition table checks, conv1d, mm)

No class splitting needed, the two ACCELERATOR classes use method-level decorators for device routing.

## Test plan

- [x] `pytest --collect-only` → 18,458 tests 
- [x] `HasDecompTest` subset: 4 pass in 12s
- [x] `lintrunner -a` clean
- [x] `ast.parse` validates

Depends on #186918 for the `HardwareClassification` enum

Co-authored with Opus 4.6

cc @RiyaP2508 @mansiag05 @vishalgoyal316 