### PR TITLE
[precompile] Remove the manual capture block from the public API

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -57,8 +57,8 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
    runnable Python source string plus an acceleration cache as ``(python_code, cache)``.
    The ``example_inputs`` keyword accepts a sequence of positional-argument tuples,
    captures every graph-break continuation and guarded recompilation exercised by those
-   calls under full runtime guards, and returns a session whose ``save(path)`` writes a
-   package for ``precompile.load_package``. This is execution-driven coverage, not an
+   calls under full runtime guards, and returns the same ``(python_code, cache)`` pair.
+   This is execution-driven coverage, not an
    exhaustive analysis: paths and values that no example executes are absent. ``fn`` is
    the whole computation, taking the model(s) as
    explicit arguments, e.g. ``lambda model, x: model(x)`` or a training step. The
@@ -116,8 +116,7 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        and the parameter gradients are accumulated onto the runtime model like eager). A
        source-artifact path requires one full graph; pass a list of calls through the
        ``example_inputs`` keyword when Python graph-breaks or when several guarded/recompiled
-       variants must be retained, or use ``torch.compiler.precompile.capture`` below when
-       the calls must be made manually. Unlike ``make_fx``, the dynamo driver
+       variants must be retained. Unlike ``make_fx``, the dynamo driver
        does NOT re-validate the
        runtime model/inputs, so on the eager backend a drifted model (broken weight tying,
        a retyped/reshaped weight) or a broadcast-compatible input-shape mismatch can
@@ -160,17 +159,12 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
            scale = y.sum().item()  # a graph break
            return y * scale
 
-       session = torch.compiler.precompile(
+       python_code, cache = torch.compiler.precompile(
            staged,
            example_inputs=[(example_a,), (example_b,)],
        )
-       session.save("model.pt")
-
-       with (
-           torch.compiler.precompile.load_package(staged, "model.pt") as compiled,
-           torch.no_grad(),
-           torch.compiler.precompile.serving(),
-       ):
+       compiled = torch.compiler.precompile.load(python_code, cache)
+       with compiled, torch.no_grad():
            out = compiled(example_a)
 ```
 
@@ -202,114 +196,6 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        paired with a different ``python_code`` (mismatched ``backend`` tag, ``tracer``
        tag, or ``code_hash``), or if a runtime call violates the precompile contract.
 
-.. py:method:: precompile.capture(fn, *, backend="inductor", guard_filter_fn=None, recompile_limit=256, dynamic=None, example_inputs=None, invariants=None)
-
-   Begin an execution-driven multi-graph capture. The yielded callable uses Dynamo and
-   records every graph produced by the calls made during the capture block: the entry
-   frame, resume continuations after graph breaks, and every guarded recompiled variant.
-   Capture every path and specialization the artifact must serve, then call ``save(path)``
-   on the returned session after the block exits. The yielded callable is valid only inside
-   the block, and a capture session is one-shot rather than re-enterable.
-
-   When every call is known up front, the shorter equivalent is
-   ``precompile(fn, example_inputs=[(x1,), (x2,)])``; use ``capture`` when calls must be
-   made manually or under a caller-selected grad mode.
-
-   ``example_inputs`` may be a sequence of positional-argument tuples. Those calls run
-   automatically under ordinary ``torch.no_grad()`` when the capture begins, even if the
-   caller is in inference mode; calls made explicitly in the block use the ambient grad
-   mode. Automatic inputs and module parameters/buffers must not be inference tensors;
-   create them outside inference mode, or use manual capture and serve under the matching
-   mode.
-   ``recompile_limit`` defaults to 256 because an ahead-of-time capture intentionally
-   collects variants rather than treating them as a runaway recompilation. It overrides a
-   lower ambient ``accumulated_recompile_limit`` for this capture. Exercised branches with no
-   tensor operations are still recorded as guarded empty variants rather than eager-only
-   skips.
-
-   Live capture retains all runtime guards so supplied calls cannot silently reuse the
-   wrong variant. ``guard_filter_fn`` applies only to the serialized copy: it receives a
-   sequence of guard entries and returns one boolean per entry, with ``True`` serializing
-   that guard. The default drops identity guards that cannot be serialized; ``save()``
-   refuses the risky subset by default, and every custom-filter drop counts as risky.
-   Refusing every drop is opt-in (``require_no_dropped_guards=True``).
-   ``dynamic`` is forwarded to ``torch.compile``. ``invariants`` names a report file written
-   after a successful capture.
-
-   The session's ``summary()`` reports graph, frame, coverage, and guard information.
-   ``save`` refuses incomplete captures by default; see its error and summary for capture
-   exceptions, uncovered, bypassed, or truncated frames. ``summary().complete`` is relative
-   to the calls that executed successfully and cannot detect an unexercised branch. The
-   session records a call that raises as incomplete even if the block catches the exception.
-   The callable and source it reaches must be importable on the loading host.
-
-   Save with
-   ``session.save(path, *, require_complete=True, require_no_risky_drops=True,``
-   ``require_no_dropped_guards=False)``. ``require_complete`` rejects missing variants or
-   frames and captures that raised. ``require_no_risky_drops`` rejects dropped identity
-   guards on configuration-like slots, every custom-filter drop, and every dropped guard
-   whose SOURCE held different values across captured variants. ``require_no_dropped_guards`` rejects every
-   guard omitted from the serialized artifact; it is off by default because every model
-   drops identity guards that cannot be serialized, so requiring none would refuse
-   essentially every real artifact. The risky subset is the rail that is on, and it is a
-   lint, not a proof; set ``require_no_risky_drops=False`` to accept its flagged drops.
-
-   .. warning::
-
-      Capture is by execution, so unexercised paths are absent. Non-tensor values crossing
-      a graph break are equality-guarded and may need one captured variant per value.
-      Identity guards cannot be serialized and are dropped from the artifact, which is
-      why ``require_no_dropped_guards`` is off by default: those drops can make two
-      variants match the same call and silently select the wrong graph. Explicit
-      forward-only inference calls in
-      the capture block should run under ``torch.no_grad()`` or
-      ``torch.inference_mode()``, and serving must use the same grad mode.
-
-   Example::
-
-       session = torch.compiler.precompile.capture(staged, backend="inductor")
-       with session as compiled, torch.no_grad():
-           compiled(example_a)
-           compiled(example_b)  # another guarded/recompiled variant
-       session.save("model.pt")
-
-.. py:method:: precompile.load_package(fn, path, *, backend="inductor", guard_filter_fn=None, recompile_limit=256, dynamic=None)
-
-   Load a multi-graph artifact written by ``precompile.capture(...).save(path)`` and
-   install its guarded bytecode and compiled backends on ``fn``'s code objects. The
-   returned callable is also a context manager; exit it or call ``unload()`` to remove
-   the installed entries and globals.
-
-   ``guard_filter_fn``, ``recompile_limit``, and ``dynamic`` configure any uncovered call
-   that is allowed to compile outside ``precompile.serving()``. The explicit limit overrides
-   a lower ambient accumulated-recompile limit. The filter controls the serialized copy only;
-   live runtime guards remain intact, and no-op branches compile into guarded empty variants.
-
-   Loading writes compiled and resume functions into module globals, but guarded dispatch
-   is scoped to the returned callable's isolated compile region. Multiple loaded artifacts
-   may share code objects without evicting each other; call each returned object to select
-   its artifact, and unload it when finished. Treat the artifact file as trusted input;
-   ``load_package`` warns before unpickling it.
-
-.. py:method:: precompile.serving()
-
-   Return a context manager that forbids compilation. Use it around calls to a loaded
-   multi-graph artifact so an input or path missing from the capture raises instead of
-   silently compiling a new variant.
-
-   The scope is THREAD-LOCAL: it constrains only the thread that entered it. A serving
-   process must enter it on every request thread, or the threads that did not will
-   quietly compile the variants this is meant to catch.
-
-   Example::
-
-       with (
-           torch.compiler.precompile.load_package(model, "model.pt") as compiled,
-           torch.no_grad(),
-           torch.compiler.precompile.serving(),
-       ):
-           out = compiled(runtime_input)
-
 .. py:class:: precompile.ExampleInput(args=(), kwargs={})
 
    One capture call for ``example_inputs`` when positional arguments alone are not
@@ -326,17 +212,8 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 
 .. autoexception:: torch.compiler.PrecompileError
 
-.. autoclass:: torch.compiler.PrecompileSession
-   :members:
-
 .. autoclass:: torch.compiler.PrecompiledCallable
    :members:
 
-.. autoclass:: torch.compiler.PrecompileSummary
-   :members:
 
-.. autoclass:: torch.compiler.FrameInvariants
-
-.. autoclass:: torch.compiler.GuardFact
-   :members:
 ```

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -2895,7 +2895,7 @@ class TestPrecompilePackage(torch._inductor.test_case.TestCase):
     def test_eager_artifact_accepts_cpu_codegen_target_skew(self):
         model = PrecompileEmptyGraph()
         x = torch.randn(4)
-        session = torch.compiler.precompile.capture(
+        session = precompile_capture(
             model,
             backend="eager",
             dynamic=False,
@@ -2903,7 +2903,7 @@ class TestPrecompilePackage(torch._inductor.test_case.TestCase):
         )
         with session:
             pass
-        session._session.save(self.path())
+        session.save(self.path())
         captured = SystemInfo.current()
         serving_info = dataclasses.replace(
             captured,
@@ -2927,7 +2927,7 @@ class TestPrecompilePackage(torch._inductor.test_case.TestCase):
         model = PrecompileEmptyGraph()
         x = torch.randn(16)
         with torch._inductor.config.patch({"cpp.simdlen": 256}):
-            session = torch.compiler.precompile.capture(
+            session = precompile_capture(
                 model,
                 backend="inductor",
                 dynamic=False,
@@ -2935,8 +2935,8 @@ class TestPrecompilePackage(torch._inductor.test_case.TestCase):
             )
             with session:
                 pass
-            capture_target = session._session._package.cache_entry().system_info
-        session._session.save(self.path())
+            capture_target = session._package.cache_entry().system_info
+        session.save(self.path())
         saved = _SingleFileStore().read(self.path()).dynamo.system_info
 
         self.assertEqual(capture_target.cpu_codegen_target[4], 256)
@@ -3112,15 +3112,15 @@ class TestPrecompilePackage(torch._inductor.test_case.TestCase):
         model = PrecompileEmptyGraph()
         x = torch.randn(4)
         with mock.patch.object(cpu_vec_isa, "pick_vec_isa", no_toolchain):
-            session = torch.compiler.precompile.capture(
+            session = precompile_capture(
                 model, backend="eager", dynamic=False, example_inputs=[(x,)]
             )
             with session:
                 pass
-            entry = session._session._package.cache_entry()
+            entry = session._package.cache_entry()
             self.assertFalse(entry.requires_native_backend_compatibility)
             self.assertIsNone(entry.system_info.cpu_codegen_target)
-            session._session.save(self.path())
+            session.save(self.path())
 
             torch._dynamo.reset()
             loaded = precompile_load(model, self.path(), backend="eager", dynamic=False)
@@ -3287,7 +3287,7 @@ class TestPrecompilePackage(torch._inductor.test_case.TestCase):
         paths = []
         for cls, scale in ((shared.ModelOne, 3.0), (shared.ModelTwo, 7.0)):
             torch._dynamo.reset()
-            session = torch.compiler.precompile.capture(
+            session = precompile_capture(
                 cls(scale),
                 backend="eager",
                 dynamic=False,
@@ -3298,7 +3298,7 @@ class TestPrecompilePackage(torch._inductor.test_case.TestCase):
             self.assertTrue(session.summary().complete)
             self.assertEqual(session.summary().risky_dropped_guards, ())
             path = self.path(f"shared_{cls.__name__}.pt")
-            session._session.save(path, require_no_dropped_guards=False)
+            session.save(path, require_no_dropped_guards=False)
             paths.append(path)
 
         torch._dynamo.reset()

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -112,6 +112,14 @@ def _precompile_closure_entry_factory():
     return entry
 
 
+def _precompile_capture(fn, **kwargs):
+    """What the removed public ``precompile.capture`` did, for tests that need
+    to drive a capture directly rather than through ``precompile()``."""
+    from torch._precompile import _capture_session, PrecompileSession
+
+    return PrecompileSession(_capture_session(fn, **kwargs))
+
+
 class _PrecompileTrainMod(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -1131,30 +1139,30 @@ class TestPrecompile(TestCase):
         self.assertFalse(hasattr(torch, "precompile"))
         self.assertTrue(callable(torch.compiler.precompile))
         self.assertTrue(callable(torch.compiler.precompile.load))
-        self.assertTrue(callable(torch.compiler.precompile.capture))
         self.assertIs(torch.compiler.precompile.PrecompileError, PrecompileError)
+        # Driving a capture by hand is not public: precompile() runs the
+        # examples itself, so nothing returns a session and these types are
+        # not reachable.
         for name in (
+            "capture",
             "PrecompileSession",
             "PrecompileSummary",
             "FrameInvariants",
             "GuardFact",
         ):
-            self.assertIn(name, torch.compiler.__all__)
-            self.assertIs(
-                getattr(torch.compiler.precompile, name, None),
-                getattr(torch.compiler, name),
-            )
+            self.assertFalse(hasattr(torch.compiler.precompile, name))
+            self.assertNotIn(name, torch.compiler.__all__)
         # The public location: test_public_bindings.test_correct_module_names also
         # enforces this for every torch.compiler.__all__ member.
         self.assertEqual(torch.compiler.precompile.__module__, "torch.compiler")
 
-    @parametrize("name", ["load", "capture"])
+    @parametrize("name", ["load"])
     def test_precompile_method_public_location(self, name):
         method = getattr(torch.compiler.precompile, name)
         self.assertEqual(method.__module__, "torch.compiler")
         self.assertEqual(method.__qualname__, f"precompile.{name}")
 
-    @parametrize("name", ["capture"])
+    @parametrize("name", ["load"])
     def test_precompile_method_type_hints_resolve(self, name):
         typing.get_type_hints(getattr(torch.compiler.precompile, name))
 
@@ -1168,38 +1176,36 @@ class TestPrecompile(TestCase):
 
     @parametrize("name", ["artifact", "summary", "invariants", "write_invariants"])
     def test_precompile_session_method_is_documented(self, name):
-        session_type = typing.get_type_hints(torch.compiler.precompile.capture)[
-            "return"
-        ]
-        self.assertIsNotNone(inspect.getdoc(getattr(session_type, name)))
+        from torch._precompile import PrecompileSession
+
+        self.assertIsNotNone(inspect.getdoc(getattr(PrecompileSession, name)))
 
     def test_precompile_session_save_documents_guard_requirements(self):
-        session_type = typing.get_type_hints(torch.compiler.precompile.capture)[
-            "return"
-        ]
-        doc = inspect.getdoc(session_type.artifact)
+        from torch._precompile import PrecompileSession
+
+        doc = inspect.getdoc(PrecompileSession.artifact)
         self.assertIn("require_no_risky_drops", doc)
         self.assertIn("require_no_dropped_guards", doc)
         self.assertTrue(
-            inspect.signature(session_type.artifact)
+            inspect.signature(PrecompileSession.artifact)
             .parameters["require_no_risky_drops"]
             .default
         )
 
     def test_precompile_public_result_types(self):
-        session_type = typing.get_type_hints(torch.compiler.precompile.capture)[
-            "return"
-        ]
-        self.assertIs(session_type, torch.compiler.PrecompileSession)
-        self.assertIs(
-            typing.get_type_hints(session_type.summary)["return"],
-            torch.compiler.PrecompileSummary,
+        # The public surface is the pair and the loader; the session types it
+        # is built from are internal.
+        from torch._precompile import PrecompileSession
+
+        self.assertEqual(
+            typing.get_type_hints(torch.compiler.precompile.__call__)["return"],
+            tuple[str, bytes],
         )
         self.assertEqual(
-            typing.get_type_hints(session_type.invariants)["return"],
-            tuple[torch.compiler.FrameInvariants, ...],
+            typing.get_type_hints(PrecompileSession.artifact)["return"],
+            tuple[str, bytes],
         )
-        params = inspect.signature(session_type.artifact).parameters
+        params = inspect.signature(PrecompileSession.artifact).parameters
         # The risky-drop lint is the rail that is ON by default. Requiring NO
         # dropped guards at all is not, and must not be: every model drops the
         # identity guards precompile cannot serialize, so it would refuse
@@ -1207,11 +1213,9 @@ class TestPrecompile(TestCase):
         self.assertTrue(params["require_no_risky_drops"].default)
         self.assertFalse(params["require_no_dropped_guards"].default)
 
-    @parametrize("name", ["capture"])
-    def test_precompile_package_method_documents_guard_filter(self, name):
-        doc = inspect.getdoc(getattr(torch.compiler.precompile, name))
+    def test_precompile_documents_guard_filter(self):
+        doc = inspect.getdoc(torch.compiler.precompile)
         self.assertIn("guard_filter_fn", doc)
-        self.assertIn("one boolean per", doc)
 
     def test_backend_invalid_raises(self):
         a, b = torch.randn(4, 4), torch.randn(4, 4)
@@ -2375,7 +2379,7 @@ class TestPrecompile(TestCase):
     def test_multi_graph_capture_graph_breaks_and_recompiles(self):
         inputs = [torch.randn(*shape) for shape in ((4, 8), (5, 8), (6, 8))]
         expected = [_precompile_multi_graph(x) for x in inputs]
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph, backend="eager", dynamic=False
         )
         with session as compiled:
@@ -2386,7 +2390,7 @@ class TestPrecompile(TestCase):
     def test_multi_graph_capture_from_precompile_example_inputs(self):
         inputs = [torch.randn(*shape) for shape in ((4, 8), (5, 8), (6, 8))]
         expected = [_precompile_multi_graph(x) for x in inputs]
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph,
             dynamic=False,
             example_inputs=[(x,) for x in inputs],
@@ -2399,7 +2403,7 @@ class TestPrecompile(TestCase):
 
     def test_multi_graph_capture_keeps_guards_while_collecting_variants(self):
         x = torch.linspace(-1, 1, 4)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph_callable, backend="eager", dynamic=False
         )
         with session as compiled:
@@ -2411,7 +2415,7 @@ class TestPrecompile(TestCase):
         self.assertTrue(summary.complete)
 
         torch._dynamo.reset()
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph_callable,
             backend="eager",
             dynamic=False,
@@ -2429,7 +2433,7 @@ class TestPrecompile(TestCase):
         def drop_all(entries):
             return [False] * len(entries)
 
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph_callable,
             backend="eager",
             dynamic=False,
@@ -2448,7 +2452,7 @@ class TestPrecompile(TestCase):
     @torch._dynamo.config.patch(caching_precompile=True)
     def test_multi_graph_capture_keeps_guards_under_caching_precompile(self):
         x = torch.linspace(-1, 1, 4)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph_callable, backend="eager", dynamic=False
         )
         with session as compiled:
@@ -2462,7 +2466,7 @@ class TestPrecompile(TestCase):
         PrecompileContext.clear()
         try:
             x = torch.randn(2, 8)
-            session = torch.compiler.precompile.capture(
+            session = _precompile_capture(
                 _precompile_multi_graph, backend="eager", dynamic=False
             )
             with session as compiled:
@@ -2502,7 +2506,7 @@ class TestPrecompile(TestCase):
 
     def test_multi_graph_failed_capture_is_incomplete(self):
         x = torch.randn(4, 8)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph, backend="eager", dynamic=False
         )
         with self.assertRaisesRegex(KeyError, "capture failed"):
@@ -2522,7 +2526,7 @@ class TestPrecompile(TestCase):
 
     def test_multi_graph_failed_automatic_example_is_incomplete(self):
         x = torch.randn(4)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_raises_on_flag,
             backend="eager",
             dynamic=False,
@@ -2582,7 +2586,7 @@ class TestPrecompile(TestCase):
         import torch._functorch.config as functorch_config
 
         before = functorch_config.bundled_autograd_cache
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph,
             backend="definitely_missing_backend",
             dynamic=False,
@@ -2605,12 +2609,8 @@ class TestPrecompile(TestCase):
             functorch_config.patch("bundled_autograd_cache", False),
             torch._dynamo.config.patch(allow_empty_graphs=False),
         ):
-            first = torch.compiler.precompile.capture(
-                _precompile_multi_graph, backend="eager"
-            )
-            second = torch.compiler.precompile.capture(
-                _precompile_multi_graph, backend="eager"
-            )
+            first = _precompile_capture(_precompile_multi_graph, backend="eager")
+            second = _precompile_capture(_precompile_multi_graph, backend="eager")
             first.__enter__()
             second.__enter__()
             first.__exit__(None, None, None)
@@ -2631,9 +2631,7 @@ class TestPrecompile(TestCase):
         states = []
 
         def run(first):
-            session = torch.compiler.precompile.capture(
-                _precompile_single_graph, backend="eager"
-            )
+            session = _precompile_capture(_precompile_single_graph, backend="eager")
             try:
                 session.__enter__()
                 (first_entered if first else second_entered).set()
@@ -2688,7 +2686,7 @@ class TestPrecompile(TestCase):
             self.assertFalse(torch._dynamo.config.allow_empty_graphs)
 
     def test_multi_graph_worker_thread_inherits_capture_behavior(self):
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_identity, backend="eager", dynamic=False
         )
         errors = []
@@ -2726,7 +2724,7 @@ class TestPrecompile(TestCase):
 
         backend_name = f"precompile_exit_waits_{id(entered)}"
         register_backend(blocking_backend, name=backend_name)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_single_graph, backend=backend_name, dynamic=False
         )
         compiled = session.__enter__()
@@ -2763,7 +2761,7 @@ class TestPrecompile(TestCase):
 
     def test_multi_graph_caught_call_failure_is_incomplete(self):
         x = torch.randn(4)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_raises_on_flag, backend="eager", dynamic=False
         )
         with session as compiled:
@@ -2778,7 +2776,7 @@ class TestPrecompile(TestCase):
     def test_multi_graph_session_releases_examples_and_failure_tracebacks(self):
         example = torch.randn(1024)
         example_ref = weakref.ref(example)
-        completed = torch.compiler.precompile.capture(
+        completed = _precompile_capture(
             _precompile_multi_graph,
             backend="eager",
             dynamic=False,
@@ -2794,7 +2792,7 @@ class TestPrecompile(TestCase):
 
         failed = torch.randn(1024)
         failed_ref = weakref.ref(failed)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_raises_on_flag, backend="eager", dynamic=False
         )
         with session as compiled:
@@ -2807,7 +2805,7 @@ class TestPrecompile(TestCase):
 
     def test_multi_graph_capture_callable_is_scoped_to_session(self):
         x = torch.randn(4, 8)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph, backend="eager", dynamic=False
         )
         with session as compiled:
@@ -2826,7 +2824,7 @@ class TestPrecompile(TestCase):
         x = torch.randn(3, 8)
         with torch.no_grad():
             expected = model(x)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_call_model,
             backend=backend,
             dynamic=False,
@@ -3165,9 +3163,7 @@ class TestPrecompile(TestCase):
             torch.compiler.precompile(lambda: None, backend="eager", dynamic=False)
 
     def test_multi_graph_public_errors_are_precompile_errors(self):
-        session = torch.compiler.precompile.capture(
-            _precompile_multi_graph, backend="eager"
-        )
+        session = _precompile_capture(_precompile_multi_graph, backend="eager")
         with session:
             pass
         with self.assertRaisesRegex(PrecompileError, "captured no compiled code"):
@@ -3187,7 +3183,7 @@ class TestPrecompile(TestCase):
             )
 
     def test_multi_graph_manual_keep_all_filter_uses_public_error(self):
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph,
             backend="eager",
             dynamic=False,
@@ -3198,7 +3194,7 @@ class TestPrecompile(TestCase):
                 compiled(torch.randn(2, 8))
 
     def test_multi_graph_capture_exit_wait_interrupt_is_retryable(self):
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_single_graph, backend="eager", dynamic=False
         )
         session.__enter__()
@@ -3220,7 +3216,7 @@ class TestPrecompile(TestCase):
     @torch._dynamo.config.patch(accumulated_recompile_limit=2)
     def test_multi_graph_recompile_limit_overrides_accumulated_limit(self):
         inputs = [torch.randn(n, 8) for n in (2, 3, 4)]
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph,
             backend="eager",
             dynamic=False,
@@ -3242,7 +3238,7 @@ class TestPrecompile(TestCase):
             self.assertEqual(warm(x), _precompile_multi_graph(x))
 
         x = torch.randn(4, 8)
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_multi_graph,
             backend="eager",
             dynamic=False,
@@ -3258,7 +3254,7 @@ class TestPrecompile(TestCase):
         self.assertEqual(summary.guarded_codes, 3)
 
     def test_multi_graph_session_is_one_shot(self):
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_single_graph,
             backend="eager",
             dynamic=False,
@@ -3277,7 +3273,7 @@ class TestPrecompile(TestCase):
         from torch._dynamo.types import FrameAction
 
         torch._dynamo.reset()
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_single_graph,
             backend="eager",
             dynamic=False,
@@ -3323,7 +3319,7 @@ class TestPrecompile(TestCase):
         self.assertEqual(ordinary_frame_count(), 2)
         torch._dynamo.reset()
 
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_single_graph, backend="eager", dynamic=None
         )
         with session as compiled:
@@ -3337,7 +3333,7 @@ class TestPrecompile(TestCase):
     def test_multi_graph_round_trip_exercised_empty_resume(self, backend):
         x = torch.arange(3.0)
         expected = [_precompile_empty_resume(x, flag) for flag in (False, True)]
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             _precompile_empty_resume,
             backend=backend,
             dynamic=False,
@@ -3362,7 +3358,7 @@ class TestPrecompile(TestCase):
         PrecompileContext.clear()
         try:
             x = torch.randn(2, 8)
-            session = torch.compiler.precompile.capture(
+            session = _precompile_capture(
                 _precompile_multi_graph,
                 backend=backend,
                 dynamic=False,
@@ -3394,7 +3390,7 @@ class TestPrecompile(TestCase):
 
         x = torch.randn(3)
         example_input = torch.compiler.precompile.ExampleInput
-        session = torch.compiler.precompile.capture(
+        session = _precompile_capture(
             fn,
             backend="eager",
             dynamic=False,

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -282,8 +282,7 @@ def _precompile_no_match_message(
     lines = [
         f"\nFailed on all {len(mine)} precompiled variant(s). "
         "If this call is served from a torch.compiler.precompile artifact, it "
-        "is not covered by the capture: exercise it inside precompile.capture() "
-        "or add it to example_inputs."
+        "is not covered by the capture: add it to example_inputs."
     ]
     shown = 0
     for i, entry in enumerate(mine):

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -9,58 +9,36 @@ recompiled variant of each -- into a single serializable artifact.
 
 Usage::
 
-    session = torch.compiler.precompile.capture(model, backend="inductor")
-    with session as compiled:
-        for variant in variants:  # every path you want covered
-            with variant:
-                compiled(*args)
-    session.save("snapshots/model.pt")
-
-``example_inputs`` runs the calls for you, under ``torch.no_grad()``, so an
-inference capture with nothing conditional in it is one statement, and
-``invariants`` writes a readable report of what the capture established::
-
-    with torch.compiler.precompile.capture(
-        model,
+    python_code, cache = torch.compiler.precompile(
+        step,  # e.g. lambda model, x: model(x)
         backend="inductor",
-        example_inputs=[(x1,), (x2,)],
-        invariants="model.invariants",
-    ) as compiled:
-        pass
-
-Calls in the block body run in the caller's grad mode rather than under
-no_grad, so a training capture -- one that calls ``.backward()`` -- goes there
-rather than in ``example_inputs``, and passing one call both ways compiles it
-twice, once per grad mode.
-
-Live capture retains every runtime guard so later examples trigger the same
-recompilations as ordinary ``torch.compile``. ``guard_filter_fn`` applies only
-to the serialized copy. If serialization drops a configuration-dependent guard,
-``save()`` refuses by default rather than writing variants whose dispatch would
-be ambiguous after load.
-
-Per frame, that report separates the guards that held in EVERY compiled variant
-from the ones that differed. The first set are the preconditions the artifact is
-only valid under -- a call violating one cannot be served by any graph in it --
-and each is marked enforced or dropped, so a precondition nothing rechecks at
-load is visible rather than implied. The second set is what tells the compiled
-graphs apart. Intersection is per frame because guards from different frames are
-not comparable: the entry frame guards its arguments, a resume frame guards
-whatever crossed the break. See ``PrecompileSession.invariants``.
-
-Both path kwargs name a FILE and write exactly it, creating parent directories:
-``snapshots/invariants.txt`` is a text file you can commit and diff, and
-``save("snapshots/model.pt")`` is the artifact itself, handed straight back to
-``precompile_load``. That is deliberately unlike ``DiskDynamoStore``, whose path
-is a directory it fills, because a content-addressed cache owns its layout while
-an artifact you name is a file you move around.
+        example_inputs=[(model, x1), (model, x2)],
+    )
 
     # later, in a fresh process
-    compiled = torch.compiler.precompile.load_package(
-        model, path, backend="inductor"
-    )
-    with torch.no_grad(), torch.compiler.precompile.serving():
-        compiled(*args)
+    compiled = torch.compiler.precompile.load(python_code, cache)
+    with compiled, torch.no_grad():
+        compiled(model, x1)
+
+The examples ARE the capture: each one is run for you and every frame, break
+continuation and guarded variant it exercises is recorded. There is no manual
+capture block -- driving the calls yourself is not part of the public surface.
+
+Calls run under ``torch.no_grad()``. ``training=True`` runs them with grad
+enabled and lowers the backward eagerly instead, so the artifact carries one
+and a served output can be backpropagated. No loss is needed for that: the
+joint trace synthesizes tangents from the forward outputs' own metadata.
+
+Live capture retains every runtime guard, so later examples trigger the same
+recompilations as ordinary ``torch.compile``. ``guard_filter_fn`` applies only
+to the serialized copy. If serialization drops a configuration-dependent guard,
+the artifact is refused by default rather than written with variants whose
+dispatch would be ambiguous after load. ``invariants`` writes a readable report
+that separates, per frame, the guards holding in EVERY variant from the ones
+that differed: the first are preconditions the artifact is only valid under,
+the second are what tell its graphs apart. Guards from different frames are not
+comparable -- an entry frame guards its arguments, a resume frame guards
+whatever crossed the break -- so the intersection is per frame.
 
 Capture is by execution: a resume function only exists once the frame ahead of
 it has actually run, so every variant must be exercised. Whatever you do not
@@ -70,17 +48,16 @@ call that raises marks the session incomplete even if caller code catches it.
 
 Know these before relying on an artifact in production:
 
-* Capture inference artifacts under ``torch.no_grad()`` or
-  ``torch.inference_mode()``. With ``backend="inductor"`` and parameters that
-  require grad, AOTAutograd only records a bundled backend once the BACKWARD
-  compiles, so a forward-only capture with grad enabled -- the default, and what
-  ``model.eval()`` still leaves you in -- records no backends and cannot be
-  saved. Capturing a training step that calls ``.backward()`` works too.
+* An inference artifact is the default: examples run under ``torch.no_grad()``.
+  For a training artifact pass ``training=True``, which traces with grad on and
+  lowers the backward eagerly -- without it, AOTAutograd defers the backward to
+  the first ``.backward()`` call, so a grad-enabled capture that never makes one
+  records no backends and cannot be written.
 * A non-tensor argument, and any value that crosses a graph break, is guarded
   by equality, so an int/bool/str argument or a break coming from ``.item()``
   yields an artifact that only serves calls reproducing those exact values.
   ``summary().wont_generalize`` lists them; exercise every value you need to
-  serve inside the capture block, or expect poor coverage on new data.
+  serve through ``example_inputs``, or expect poor coverage on new data.
   ``dynamic=True`` helps with shapes but not with pinned values.
 * Identity guards cannot be serialized, so precompiling gives up on noticing
   that a guarded object was rebound. ``summary().dropped_guards`` is the
@@ -114,11 +91,10 @@ Know these before relying on an artifact in production:
 This wraps CompilePackage, which is the low-level component and is not meant to
 be used directly.
 
-The public surface is ``torch.compiler.precompile`` with ``example_inputs``,
-``torch.compiler.precompile.capture``,
-``torch.compiler.precompile.load_package``, and
-``torch.compiler.precompile.serving``. The helpers in this module implement that
-surface and remain internal. The positional ``torch.compiler.precompile`` form
+The public surface is ``torch.compiler.precompile`` -- with ``example_inputs``
+for this multi-graph form -- and ``torch.compiler.precompile.load``. The
+helpers in this module, including the capture session, implement that surface
+and remain internal. The positional ``torch.compiler.precompile`` form
 produces a self-contained Python source artifact from one example call. Both are distinct from
 ``torch._dynamo.config.caching_precompile``, which caches ``torch.compile``
 artifacts transparently without an explicit capture block.

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -23,11 +23,10 @@ dynamic shapes, and a ``decompositions`` table all work with it. See the ``trace
 the bottom of Note [precompile programming model].
 
 For a computation with graph breaks, or to retain several guarded/recompiled variants,
-pass a sequence of calls through ``example_inputs=[(...,), (...,)]``. That form returns
-an execution-driven session whose ``save()`` writes a package reloaded with
-``torch.compiler.precompile.load``. ``torch.compiler.precompile.capture`` remains
-available when the calls must be made manually, such as a training capture. The positional
-form above remains the self-contained source-artifact path and requires one full Dynamo
+pass a sequence of calls through ``example_inputs=[(...,), (...,)]``. That form runs the
+calls for you and returns the same ``(python_code, cache)`` pair, reloaded with
+``torch.compiler.precompile.load``; add ``training=True`` for an artifact that carries a
+backward. The positional form above remains the self-contained source-artifact path and requires one full Dynamo
 graph.
 
 Multi-graph capture keeps all live guards while running examples, then filters only the
@@ -282,8 +281,8 @@ it.
 #
 # Scope and differences from make_fx: the source-artifact call needs one transformed
 # bytecode and therefore still requires a single Dynamo graph. A graph-breaking fn raises
-# a PrecompileError pointing at ``torch.compiler.precompile.capture``, whose execution-
-# driven package preserves every graph-break continuation, guard, and recompiled variant.
+# a PrecompileError pointing at ``example_inputs``, whose execution-driven capture
+# preserves every graph-break continuation, guard, and recompiled variant.
 # The source-artifact path does NOT check Dynamo's guards at
 # runtime, NOR does
 # it reproduce the make_fx drivers' upfront runtime validation (the param/buffer structural
@@ -336,7 +335,6 @@ from torch import Tensor
 from torch.compiler._precompile_types import (
     ExampleInput,
     FrameInvariants,
-    GuardFact,
     PrecompileSummary,
 )
 from torch.fx.experimental.proxy_tensor import make_fx
@@ -1940,7 +1938,7 @@ def _capture_dynamo(
     ``torch.autograd.grad`` rather than graph-breaking, then CAPTURES TWICE when needed so
     the accumulating form of the ``.grad`` update is the one baked (Note [precompile dynamo
     training grad accumulation]). Other graph-breaking Python still raises a
-    PrecompileError pointing at ``torch.compiler.precompile.capture``.
+    PrecompileError pointing at ``example_inputs``.
     """
     # get_traced_fn refuses anything that is not a function, bound method or
     # nn.Module -- a functools.partial, a callable object -- and Dynamo reaches
@@ -2057,8 +2055,7 @@ def _capture_dynamo(
         raise PrecompileError(
             "precompile tracer='dynamo' could not capture fn as a single full graph "
             f"({reason}). For graph-breaking code, pass example_inputs=[(...,), ...] "
-            "to torch.compiler.precompile, or use torch.compiler.precompile.capture "
-            "when the calls must be made manually; otherwise use tracer='make_fx' for "
+            "to torch.compiler.precompile; otherwise use tracer='make_fx' for "
             "a single non-strict trace."
         ) from e
     except GuardOnDataDependentSymNode as e:
@@ -3705,6 +3702,21 @@ class PrecompiledModule:
         return buf.getvalue()
 
 
+def _capture_session(fn, **kwargs):
+    """Start an internal multi-graph capture, mapping package errors to ours.
+
+    precompile() drives the capture itself -- there is no public session -- so
+    this exists to keep the error translation in one place.
+    """
+    from torch._dynamo.exc import PackageError
+    from torch._dynamo.precompile_package import precompile_capture
+
+    try:
+        return precompile_capture(fn, **kwargs)
+    except PackageError as e:
+        raise PrecompileError(str(e)) from e
+
+
 def _make_inlined_forward(python_code: str) -> Callable[..., object]:
     """Fallback: execute the self-contained python string (JITs kernels).
 
@@ -3745,7 +3757,6 @@ class _PrecompileApi:
     # The error type raised by precompile, reachable as
     # ``torch.compiler.precompile.PrecompileError``.
     PrecompileError = PrecompileError
-    PrecompileSession = PrecompileSession
 
     # One capture call carrying keyword arguments, for ``example_inputs``. A
     # plain tuple there is positional args; this is what the TypeError raised
@@ -3859,8 +3870,7 @@ class _PrecompileApi:
           graph-break), and the artifact accumulates the resulting parameter gradients onto
           the runtime model exactly like eager. This source-artifact path requires one full
           graph; for graph breaks and multiple guarded/recompiled variants, pass
-          ``example_inputs=[(...,), ...]`` or use ``torch.compiler.precompile.capture``
-          when the calls must be made manually.
+          ``example_inputs=[(...,), ...]``.
           Dynamo's runtime guards are not embedded, and -- UNLIKE the ``make_fx`` tracer --
           the dynamo driver does NOT re-validate the runtime model/inputs at load: it does
           not reproduce the ``make_fx`` driver's param/buffer structural check (invariant 2)
@@ -4001,7 +4011,7 @@ class _PrecompileApi:
                 # frame differing in variant count).
                 from torch._dynamo.precompile_package import varying_guard_slots
 
-                probe = self.capture(
+                probe = _capture_session(
                     fn,
                     backend=backend,
                     guard_filter_fn=guard_filter_fn,
@@ -4012,18 +4022,20 @@ class _PrecompileApi:
                 )
                 with probe:
                     pass
-                keep_only = varying_guard_slots(probe._session._guard_sets)
+                keep_only = varying_guard_slots(probe._guard_sets)
                 torch._dynamo.reset()
-            session = self.capture(
-                fn,
-                backend=backend,
-                guard_filter_fn=guard_filter_fn,
-                recompile_limit=recompile_limit,
-                dynamic=dynamic,
-                example_inputs=example_inputs,
-                invariants=invariants,
-                keep_only=keep_only,
-                training=training,
+            session = PrecompileSession(
+                _capture_session(
+                    fn,
+                    backend=backend,
+                    guard_filter_fn=guard_filter_fn,
+                    recompile_limit=recompile_limit,
+                    dynamic=dynamic,
+                    example_inputs=example_inputs,
+                    invariants=invariants,
+                    keep_only=keep_only,
+                    training=training,
+                )
             )
             with session:
                 pass
@@ -4061,84 +4073,6 @@ class _PrecompileApi:
         # sha256 over exactly the bytes returned to the caller (a matched pair loads).
         python_code = compiled.to_python_code()
         return python_code, compiled.to_cache_bytes(python_code)
-
-    def capture(
-        self,
-        fn: Callable[..., object],
-        *,
-        backend: str = "inductor",
-        guard_filter_fn: Callable[[Sequence[Any]], Sequence[bool]] | None = None,
-        recompile_limit: int = 256,
-        dynamic: bool | None = None,
-        example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
-        invariants: str | None = None,
-        keep_only: frozenset[tuple[str, str]] | None = None,
-        training: bool = False,
-    ) -> PrecompileSession:
-        r"""capture(fn, *, backend="inductor", guard_filter_fn=None, recompile_limit=256, dynamic=None, example_inputs=None, invariants=None) -> PrecompileSession
-
-        Begin an execution-driven multi-graph precompile capture.
-
-        Use this form when calls must be made manually. The shorter
-        ``precompile(fn, example_inputs=[...])`` form runs known inference examples for you.
-        Both preserve Dynamo graph breaks, resume continuations, and every recompiled
-        variant exercised by the supplied calls. The yielded callable is valid only inside
-        the capture block, and the session cannot be re-entered after that block exits.
-
-        Capture is by execution: call the yielded function on every path and specialization
-        the artifact must serve. ``example_inputs`` can make positional-only inference
-        calls automatically under ordinary ``torch.no_grad()``; calls in the block use the
-        ambient grad mode, so wrap forward-only inference calls in ``torch.no_grad()``.
-        Automatic inputs and an ``nn.Module``'s parameters/buffers must not be inference
-        tensors. Live capture retains all guards. The filter controls only which guards are
-        serialized, and ``save()`` rejects the risky ones by default. A complete
-        summary covers only successful calls that actually ran; unexercised paths remain
-        absent. Any captured call that raises marks the session incomplete, even when the
-        exception is caught inside the block.
-
-        Args:
-            fn (Callable): callable to capture.
-            backend (str, optional): ``torch.compile`` backend. Default: ``"inductor"``.
-            guard_filter_fn (Callable, optional): receives a sequence of guard entries and
-              returns one boolean per entry, where ``True`` serializes the guard. Live
-              capture always retains it. The default drops identity guards that cannot be
-              serialized. ``save()`` refuses only the RISKY drops by default, and every
-              custom-filter drop counts as risky; ``require_no_dropped_guards=True``
-              refuses all of them.
-              Default: ``None``.
-            recompile_limit (int, optional): maximum variants captured per frame. Default:
-              ``256``. This overrides a lower ambient accumulated-recompile limit for the
-              capture.
-            dynamic (bool, optional): dynamic-shape policy forwarded to ``torch.compile``.
-              Default: ``None``.
-            example_inputs (Sequence[tuple], optional): positional-argument tuples run
-              automatically under ``torch.no_grad()``. Inference tensors are rejected;
-              create automatic inputs outside inference mode. Default: ``None``.
-            invariants (str, optional): file receiving the invariant report after a
-              successful capture. Default: ``None``.
-
-        Returns:
-            PrecompileSession: session whose context manager yields the callable to
-            exercise and whose ``save()`` method writes the artifact.
-        """
-        from torch._dynamo.exc import PackageError
-        from torch._dynamo.precompile_package import precompile_capture
-
-        try:
-            session = precompile_capture(
-                fn,
-                backend=backend,
-                guard_filter_fn=guard_filter_fn,
-                recompile_limit=recompile_limit,
-                dynamic=dynamic,
-                example_inputs=example_inputs,
-                invariants=invariants,
-                keep_only=keep_only,
-                training=training,
-            )
-        except PackageError as e:
-            raise PrecompileError(str(e)) from e
-        return PrecompileSession(session)
 
     def load(
         self,
@@ -4310,12 +4244,6 @@ precompile.__doc__ = _PrecompileApi.__call__.__doc__
 # underlying functions.
 PrecompileError.__module__ = "torch.compiler"
 PrecompileError.__qualname__ = "precompile.PrecompileError"
-PrecompileSession.__module__ = "torch.compiler"
 PrecompiledCallable.__module__ = "torch.compiler"
-_PrecompileApi.FrameInvariants = FrameInvariants
-_PrecompileApi.GuardFact = GuardFact
-_PrecompileApi.PrecompileSummary = PrecompileSummary
 _PrecompileApi.load.__module__ = "torch.compiler"
 _PrecompileApi.load.__qualname__ = "precompile.load"
-_PrecompileApi.capture.__module__ = "torch.compiler"
-_PrecompileApi.capture.__qualname__ = "precompile.capture"

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -19,13 +19,9 @@ from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
 # conventional ``except torch.compiler.PrecompileError`` works; its ``__module__`` is already
 # forced to "torch.compiler" in the impl module, matching this public location.
 from torch._precompile import (
-    FrameInvariants as FrameInvariants,
-    GuardFact as GuardFact,
     precompile as precompile,
     PrecompiledCallable as PrecompiledCallable,
     PrecompileError as PrecompileError,
-    PrecompileSession as PrecompileSession,
-    PrecompileSummary as PrecompileSummary,
 )
 
 from . import config
@@ -56,10 +52,6 @@ __all__ = [
     "precompile",
     "PrecompiledCallable",
     "PrecompileError",
-    "PrecompileSession",
-    "PrecompileSummary",
-    "FrameInvariants",
-    "GuardFact",
     "wrap_numpy",
     "is_compiling",
     "is_dynamo_compiling",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #193997
* #193995
* #193987
* #192379
* #193977
* #193976
* #193697
* #192374
* #192866
* #193725

With training=True below it, the multi-graph path no longer needs a capture the
caller drives by hand. That was the only way to get a backward -- you called
.backward() yourself inside the block -- and it is what made precompile awkward
to adopt: the caller had to have a loss and had to restructure around a session
object. Now that example_inputs covers both inference and training, one entry
point covers the whole surface.

So torch.compiler.precompile.capture is gone, and with it the types only it
could produce: PrecompileSession, PrecompileSummary, FrameInvariants and
GuardFact leave torch.compiler.__all__. What is left is the pair and the loader
-- precompile(...) -> (python_code, cache) and precompile.load(...) -- plus
PrecompileError, ExampleInput, and PrecompiledCallable, which load() returns for
an installed artifact.

The session itself is unchanged and stays as the internal implementation that
precompile() drives; it simply is not something a caller holds. Tests that need
to drive one reach it through precompile_capture in
torch._dynamo.precompile_package, which test_package.py already used, so the
coverage of summary(), the invariants report and capture-error recording is
preserved rather than deleted.

The docs needed more than this change: precompile.load_package and
precompile.serving were removed from the API earlier in this stack and were
still documented, including autoclass entries that would fail a docs build. The
doc-page test only checks that particular false claims are ABSENT, so nothing
caught it. They are removed here along with capture, and the module docstring
is rewritten rather than patched: incremental edits across this stack had left
it describing a save()/load_package()/serving() workflow that no longer exists.

Test Plan:

```
python test/test_precompile.py
python test/dynamo/test_package.py
python test/dynamo/test_misc.py
python test/dynamo/test_guard_serialization.py
```

test_public_api_surface now asserts the removed names are absent from both
torch.compiler.precompile and torch.compiler.__all__, rather than present.

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98