### PR TITLE
[docs] Advertise torch_remat for region-level SAC

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1706,6 +1706,15 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
     Use this with `torch.utils.checkpoint.checkpoint` to control which
     operations are recomputed during the backward pass.
 
+    .. note::
+
+        If you would like to specify selective activation checkpointing
+        policies over regions of source code rather than individual ATen
+        operators, we recommend trying
+        `torch_remat <https://github.com/meta-pytorch/remat>`_. This can make
+        it easier to distinguish between different uses of the same operator
+        or to apply policies to custom kernels.
+
     Args:
         policy_fn_or_list (Callable or List):
           - If a policy function is provided, it should accept a

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -1708,12 +1708,26 @@ def create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mu
 
     .. note::
 
-        If you would like to specify selective activation checkpointing
-        policies over regions of source code rather than individual ATen
-        operators, we recommend trying
-        `torch_remat <https://github.com/meta-pytorch/remat>`_. This can make
-        it easier to distinguish between different uses of the same operator
-        or to apply policies to custom kernels.
+        This API expresses selective activation checkpointing policies at the
+        level of individual ATen operators. If you would rather define
+        save/recompute decisions over regions of source code, we recommend
+        trying the separate
+        `torch_remat <https://github.com/meta-pytorch/remat>`_ package. Its
+        region-based API lets you:
+
+        * assign different policies to different uses of the same operator;
+        * apply policies to arbitrary multi-operation code, including custom
+          :class:`torch.autograd.Function` implementations, without wrapping
+          the region in a custom operator;
+        * in eager mode, retain only tensors needed for backward or subsequent
+          recomputation instead of caching every output of a selected
+          operator; and
+        * avoid the eager-mode ``TorchDispatchMode`` overhead of per-operator
+          policies.
+
+        ``torch_remat`` also provides eager-mode tracing and memory diagnostics
+        for named regions, while its core save/recompute policy works with
+        :func:`torch.compile`.
 
     Args:
         policy_fn_or_list (Callable or List):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #193998

Selective activation checkpointing policies are defined per ATen operator. Point users to torch_remat when they instead want to annotate source-code regions, including call-site-specific decisions and arbitrary multi-operation code such as custom torch.autograd.Function implementations.

Document eager-mode save elision and lower dispatch overhead, plus named-region diagnostics and torch.compile support.

Test Plan:

```
source /home/jw3468/local/miniconda3/etc/profile.d/conda.sh && conda activate /home/jw3468/local/a/pytorch-env && https_proxy=http://fwdproxy:8080 http_proxy=http://fwdproxy:8080 UV_NO_CONFIG=1 lintrunner -a
source /home/jw3468/local/miniconda3/etc/profile.d/conda.sh && conda activate /home/jw3468/local/a/pytorch-env && https_proxy=http://fwdproxy:8080 http_proxy=http://fwdproxy:8080 UV_NO_CONFIG=1 spin quicklint
git diff --check
```

Authored with assistance from an AI coding agent.