### PR TITLE
[AOTInductor] Pluggable model-container lifecycle observer interface (#193999)

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -1,5 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <atomic>
 #include <condition_variable>
 #include <cstdlib>
@@ -12,7 +13,9 @@
 #include <thread>
 #include <vector>
 
+#include <ATen/record_function.h>
 #include <torch/csrc/inductor/aoti_package/model_package_loader.h>
+#include <torch/csrc/inductor/aoti_runner/model_container_observer.h>
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h>
 #if defined(USE_CUDA)
 #include <c10/cuda/CUDACachingAllocator.h>
@@ -1223,6 +1226,209 @@ void test_aoti_const_fold_separate_stream() {
   }
 }
 #endif // USE_CUDA || USE_ROCM
+
+// RECORD_USER_SCOPE callbacks are raw function pointers and cannot capture, so
+// the names they see are collected here.
+std::vector<std::string>& recordedScopeNames() {
+  static std::vector<std::string> names;
+  return names;
+}
+
+// Records the (event, ctx, succeeded) sequence an observer is handed, so a test
+// can assert begin/end pairing and the failure signal.
+class RecordingObserver : public torch::inductor::AOTIModelContainerObserver {
+ public:
+  struct Record {
+    torch::inductor::AOTIContainerEvent event;
+    size_t num_constants;
+    bool use_inactive;
+    bool succeeded;
+  };
+
+  void on_begin(
+      torch::inductor::AOTIContainerEvent event,
+      const torch::inductor::AOTIObserverContext& ctx) override {
+    begins.push_back({event, ctx.num_constants, ctx.use_inactive, true});
+    ++depth;
+  }
+
+  void on_end(
+      torch::inductor::AOTIContainerEvent event,
+      const torch::inductor::AOTIObserverContext& ctx,
+      bool succeeded) override {
+    ends.push_back({event, ctx.num_constants, ctx.use_inactive, succeeded});
+    --depth;
+  }
+
+  std::vector<Record> begins;
+  std::vector<Record> ends;
+  int depth = 0;
+};
+
+void test_aoti_observer(const std::string& device) {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+
+  std::string path_attr = "model_so_path_" + device;
+  std::string inputs_attr = "inputs_" + device;
+  std::string weights_attr = "w_pre_" + device;
+  std::string add_attr = "w_add_" + device;
+  const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
+  auto input_tensors =
+      data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
+  const auto& weight_tensors =
+      data_loader.attr(weights_attr.c_str()).toTensor();
+  const auto& add_tensors = data_loader.attr(add_attr.c_str()).toTensor();
+
+  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
+  if (device == "cpu") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
+        model_so_path);
+#if defined(USE_CUDA) || defined(USE_ROCM)
+  } else if (device == "cuda") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_so_path);
+#endif
+  } else {
+    FAIL() << "unsupported device: " << device;
+  }
+
+  // A null observer is accepted and never consumes the attach-once slot.
+  runner->set_observer(nullptr);
+
+  auto observer = std::make_shared<RecordingObserver>();
+  runner->set_observer(observer);
+  // Attaching a second observer is a usage error, not a silent swap: the
+  // lifetime argument for the raw pointer on the hot path depends on the
+  // owning shared_ptr never being replaced.
+  EXPECT_THROW(
+      runner->set_observer(std::make_shared<RecordingObserver>()), c10::Error);
+
+  // Inference reports exactly one begin/end pair, and does not nest.
+  runner->run(input_tensors);
+  ASSERT_EQ(observer->begins.size(), 1);
+  ASSERT_EQ(observer->ends.size(), 1);
+  EXPECT_EQ(
+      observer->begins[0].event,
+      torch::inductor::AOTIContainerEvent::kInference);
+  EXPECT_EQ(
+      observer->ends[0].event, torch::inductor::AOTIContainerEvent::kInference);
+  EXPECT_TRUE(observer->ends[0].succeeded);
+  EXPECT_EQ(observer->depth, 0);
+
+  // A successful constants update reports how many constants moved and which
+  // buffer they went to.
+  torch::inductor::TensorConstantMap real_map;
+  real_map.emplace("L__self___w_pre", new at::Tensor(weight_tensors));
+  real_map.emplace("L__self___w_add", new at::Tensor(add_tensors));
+  runner->update_constant_buffer(
+      real_map, /* use_inactive = */ false, /* check_full_update = */ false);
+  ASSERT_FALSE(observer->ends.empty());
+  EXPECT_EQ(
+      observer->ends.back().event,
+      torch::inductor::AOTIContainerEvent::kUpdateConstantBuffer);
+  EXPECT_EQ(observer->ends.back().num_constants, real_map.size());
+  EXPECT_FALSE(observer->ends.back().use_inactive);
+  EXPECT_TRUE(observer->ends.back().succeeded);
+
+  // A failing operation still reports on_end, with succeeded == false. Without
+  // that flag a failed call would land in the observer's latency distribution
+  // as if it had completed normally.
+  const size_t ends_before = observer->ends.size();
+  torch::inductor::TensorConstantMap missing_map;
+  missing_map.emplace("L__self___w_pre", new at::Tensor(at::randn({4, 4})));
+  try {
+    runner->update_constant_buffer(
+        missing_map,
+        /* use_inactive = */ false,
+        /* check_full_update = */ true);
+    ADD_FAILURE() << "expected an incomplete constants update to throw";
+  } catch (const std::exception&) {
+  }
+  ASSERT_EQ(observer->ends.size(), ends_before + 1);
+  EXPECT_EQ(
+      observer->ends.back().event,
+      torch::inductor::AOTIContainerEvent::kUpdateConstantBuffer);
+  EXPECT_FALSE(observer->ends.back().succeeded);
+
+  // Every begin was paired with an end, including the one that threw.
+  EXPECT_EQ(observer->begins.size(), observer->ends.size());
+  EXPECT_EQ(observer->depth, 0);
+
+  for (auto& pair : real_map) {
+    delete pair.second;
+  }
+  for (auto& pair : missing_map) {
+    delete pair.second;
+  }
+}
+
+// The observer is not the only way to see these events: the same call sites are
+// bracketed with RECORD_USER_SCOPE, so a profiler (or any RecordFunction
+// callback) picks them up without attaching an observer at all.
+void test_aoti_record_function(const std::string& device) {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+
+  std::string path_attr = "model_so_path_" + device;
+  std::string inputs_attr = "inputs_" + device;
+  const auto& model_so_path = data_loader.attr(path_attr.c_str()).toStringRef();
+  auto input_tensors =
+      data_loader.attr(inputs_attr.c_str()).toTensorList().vec();
+
+  std::unique_ptr<torch::inductor::AOTIModelContainerRunner> runner;
+  if (device == "cpu") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCpu>(
+        model_so_path);
+#if defined(USE_CUDA) || defined(USE_ROCM)
+  } else if (device == "cuda") {
+    runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+        model_so_path);
+#endif
+  } else {
+    FAIL() << "unsupported device: " << device;
+  }
+
+  recordedScopeNames().clear();
+  auto handle = at::addThreadLocalCallback(
+      at::RecordFunctionCallback(
+          [](const at::RecordFunction& fn)
+              -> std::unique_ptr<at::ObserverContext> {
+            recordedScopeNames().emplace_back(fn.name());
+            return nullptr;
+          })
+          .scopes({at::RecordScope::USER_SCOPE}));
+
+  // No observer attached: RecordFunction is the only consumer here.
+  runner->run(input_tensors);
+  runner->swap_constant_buffer();
+
+  at::removeCallback(handle);
+
+  // Deliberately not EXPECT_THAT/IsSupersetOf: test_aoti_inference links
+  // gtest_main but not gmock, and the unordered-container matchers are not
+  // header-only (HasSubstr, used elsewhere in this file, is).
+  const auto& names = recordedScopeNames();
+  const auto sawScope = [&names](const char* name) {
+    return std::find(names.begin(), names.end(), name) != names.end();
+  };
+  EXPECT_TRUE(sawScope("AOTIModelContainerRunner::run"));
+  EXPECT_TRUE(sawScope("AOTIModelContainerRunner::swap_constant_buffer"));
+
+  // Callbacks are torn down again, so later tests are unaffected.
+  const size_t recorded = recordedScopeNames().size();
+  runner->run(input_tensors);
+  EXPECT_EQ(recordedScopeNames().size(), recorded);
+}
+
 } // namespace
 
 namespace torch::aot_inductor {
@@ -1324,6 +1530,24 @@ TEST_F(AotInductorTest, ConcurrentRunConstFoldCuda) {
 #if defined(USE_CUDA) || defined(USE_ROCM)
 TEST_F(AotInductorTest, ConstFoldSeparateStreamCuda) {
   test_aoti_const_fold_separate_stream();
+}
+#endif // USE_CUDA || USE_ROCM
+
+TEST_F(AotInductorTest, ObserverCpu) {
+  test_aoti_observer("cpu");
+}
+
+TEST_F(AotInductorTest, RecordFunctionCpu) {
+  test_aoti_record_function("cpu");
+}
+
+#if defined(USE_CUDA) || defined(USE_ROCM)
+TEST_F(AotInductorTest, ObserverCuda) {
+  test_aoti_observer("cuda");
+}
+
+TEST_F(AotInductorTest, RecordFunctionCuda) {
+  test_aoti_record_function("cuda");
 }
 #endif // USE_CUDA || USE_ROCM
 

--- a/torch/csrc/inductor/aoti_runner/model_container_observer.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_observer.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstddef>
+
+namespace torch::inductor {
+
+// Lifecycle events an AOTInductor model container reports to an observer.
+enum class AOTIContainerEvent {
+  kLoadConstants, // constants blob loaded into the container
+  kUpdateConstantBuffer, // in-place constants/weights update
+  // Same operation as kUpdateConstantBuffer, but the source tensors live on the
+  // host so it also pays a host-to-device copy of every constant. Separate
+  // because the two have very different cost profiles.
+  kUpdateConstantBufferFromCpu,
+  kSwapConstantBuffer, // active <-> inactive constants-buffer swap
+  kRunConstantFolding, // constant-folding pass
+  // run() / boxed_run(); warmup is inference too. Single-threaded mode is a
+  // construction-time flag that swaps run_func_ inside these, not a separate
+  // entry point.
+  kInference,
+  kFreeInactiveBuffer, // release of the inactive constants buffer
+};
+
+// Context passed with each event. Fields that don't apply to a given event keep
+// their defaults. Deliberately trivial so it stays cheap to construct on the
+// hot path.
+struct AOTIObserverContext {
+  size_t num_constants = 0;
+  bool use_inactive = false; // update/fold target buffer
+};
+
+// Observer for AOTInductor container lifecycle events. Attach a subclass to a
+// container runner via set_observer() to receive begin/end callbacks bracketing
+// each event; measure durations yourself between on_begin and on_end. Attaching
+// is optional -- a null observer is zero overhead.
+//
+// on_end always runs, including when the bracketed operation threw; `succeeded`
+// says which happened, so a failed call is not silently recorded as a
+// normal-latency sample. Implementations must be cheap and must not throw:
+// callbacks can run on the serving hot path, and on_end runs during stack
+// unwinding, where an escaping exception would terminate the process.
+class AOTIModelContainerObserver {
+ public:
+  virtual ~AOTIModelContainerObserver() = default;
+
+  virtual void on_begin(
+      AOTIContainerEvent event,
+      const AOTIObserverContext& ctx) = 0;
+  virtual void on_end(
+      AOTIContainerEvent event,
+      const AOTIObserverContext& ctx,
+      bool succeeded) = 0;
+};
+
+} // namespace torch::inductor

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -1,5 +1,6 @@
 #if !defined(C10_MOBILE) && !defined(ANDROID)
 #include <ATen/DynamicLibrary.h>
+#include <ATen/record_function.h>
 #include <c10/util/ScopeExit.h>
 
 #include <torch/csrc/inductor/aoti_runner/model_container_runner.h>
@@ -8,6 +9,8 @@
 #include <torch/csrc/inductor/aoti_torch/utils.h>
 
 #include <c10/util/FileSystem.h>
+
+#include <exception>
 
 #include <fcntl.h>
 #ifdef _WIN32
@@ -22,6 +25,67 @@
 #endif // _WIN32
 
 namespace torch::inductor {
+
+namespace {
+// RAII: fires observer->on_begin on construction and on_end on destruction, so
+// the bracketed region is reported even if it throws. No-op when observer is
+// null.
+class ScopedObserverEvent {
+ public:
+  ScopedObserverEvent(
+      AOTIModelContainerObserver* observer,
+      AOTIContainerEvent event,
+      AOTIObserverContext ctx)
+      : observer_(observer),
+        event_(event),
+        ctx_(ctx),
+        uncaught_on_entry_(std::uncaught_exceptions()) {
+    if (observer_ != nullptr) {
+      // Observers must not throw. Contain a throwing on_begin here rather than
+      // letting it escape: an exception out of the constructor skips the
+      // destructor, which would drop the paired on_end and leave the observer
+      // seeing unbalanced events.
+      try {
+        observer_->on_begin(event_, ctx_);
+      } catch (...) {
+        TORCH_WARN(
+            "AOTI observer on_begin threw for event ",
+            static_cast<int>(event_),
+            "; ignoring");
+      }
+    }
+  }
+  ~ScopedObserverEvent() {
+    if (observer_ != nullptr) {
+      // More exceptions in flight than when we were constructed means the
+      // bracketed region threw. Without this an observer would record a failed
+      // call as a normal-latency sample and quietly skew its own percentiles.
+      const bool succeeded = std::uncaught_exceptions() <= uncaught_on_entry_;
+      // A throwing on_end during stack unwinding would call std::terminate;
+      // swallow defensively, but say so -- a silently broken observer is
+      // exactly the thing this instrumentation exists to avoid.
+      try {
+        observer_->on_end(event_, ctx_, succeeded);
+      } catch (...) {
+        TORCH_WARN(
+            "AOTI observer on_end threw for event ",
+            static_cast<int>(event_),
+            "; ignoring");
+      }
+    }
+  }
+  ScopedObserverEvent(const ScopedObserverEvent&) = delete;
+  ScopedObserverEvent& operator=(const ScopedObserverEvent&) = delete;
+  ScopedObserverEvent(ScopedObserverEvent&&) = delete;
+  ScopedObserverEvent& operator=(ScopedObserverEvent&&) = delete;
+
+ private:
+  AOTIModelContainerObserver* observer_;
+  AOTIContainerEvent event_;
+  AOTIObserverContext ctx_;
+  int uncaught_on_entry_;
+};
+} // namespace
 
 AOTIModelContainerRunner::AOTIModelContainerRunner() = default;
 
@@ -239,6 +303,9 @@ std::vector<at::Tensor> AOTIModelContainerRunner::run_impl(
 std::vector<at::Tensor> AOTIModelContainerRunner::run(
     const std::vector<at::Tensor>& inputs,
     void* stream_handle) {
+  RECORD_USER_SCOPE("AOTIModelContainerRunner::run");
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kInference, {});
   std::vector<AtenTensorHandle> input_handles =
       torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(inputs);
   return run_impl(input_handles, stream_handle);
@@ -247,6 +314,9 @@ std::vector<at::Tensor> AOTIModelContainerRunner::run(
 std::vector<at::Tensor> AOTIModelContainerRunner::boxed_run(
     std::vector<at::Tensor>&& inputs,
     void* stream_handle) {
+  RECORD_USER_SCOPE("AOTIModelContainerRunner::boxed_run");
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kInference, {});
   std::vector<AtenTensorHandle> input_handles =
       torch::aot_inductor::unsafe_alloc_new_handles_from_tensors(inputs);
   std::move(inputs).clear();
@@ -309,6 +379,12 @@ void AOTIModelContainerRunner::update_constant_buffer(
     bool use_inactive,
     bool check_full_update,
     bool user_managed) {
+  RECORD_USER_SCOPE("AOTIModelContainerRunner::update_constant_buffer");
+  AOTIObserverContext ctx;
+  ctx.num_constants = const_map.size();
+  ctx.use_inactive = use_inactive;
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kUpdateConstantBuffer, ctx);
   if (user_managed) {
     AOTI_RUNTIME_ERROR_CODE_CHECK(update_user_managed_constant_buffer_func_(
         container_handle_,
@@ -329,6 +405,12 @@ void AOTIModelContainerRunner::update_constant_buffer(
     bool use_inactive,
     bool check_full_update,
     bool user_managed) {
+  RECORD_USER_SCOPE("AOTIModelContainerRunner::update_constant_buffer");
+  AOTIObserverContext ctx;
+  ctx.num_constants = tensor_map.size();
+  ctx.use_inactive = use_inactive;
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kUpdateConstantBuffer, ctx);
   TensorConstantMap const_map;
   for (auto& [k, v] : tensor_map) {
     const_map.emplace(k, &v);
@@ -352,6 +434,15 @@ void AOTIModelContainerRunner::update_constant_buffer_from_cpu(
     const TensorConstantMap& const_map,
     bool use_inactive,
     bool check_full_update) {
+  RECORD_USER_SCOPE(
+      "AOTIModelContainerRunner::update_constant_buffer_from_cpu");
+  AOTIObserverContext ctx;
+  ctx.num_constants = const_map.size();
+  ctx.use_inactive = use_inactive;
+  // The tensor_map overload delegates here, so instrumenting this one covers
+  // both without double-firing.
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kUpdateConstantBufferFromCpu, ctx);
   TORCH_CHECK(
       update_constant_buffer_from_cpu_func_ != nullptr,
       "No update_constant_buffer_from_cpu in .so! Consider rebuild your model with the latest AOTInductor.");
@@ -375,6 +466,10 @@ void AOTIModelContainerRunner::update_constant_buffer_from_cpu(
 
 void AOTIModelContainerRunner::update_constant_buffer_from_blob(
     const std::string& weights_path) {
+  RECORD_USER_SCOPE(
+      "AOTIModelContainerRunner::update_constant_buffer_from_blob");
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kLoadConstants, {});
   uint64_t weights_size;
   AOTI_RUNTIME_ERROR_CODE_CHECK(
       get_constants_blob_size_func_(container_handle_, &weights_size));
@@ -441,6 +536,13 @@ void AOTIModelContainerRunner::update_constant_buffer_from_blob(
 
 void AOTIModelContainerRunner::update_inactive_constant_buffer(
     const TensorConstantMap& const_map) {
+  RECORD_USER_SCOPE(
+      "AOTIModelContainerRunner::update_inactive_constant_buffer");
+  AOTIObserverContext ctx;
+  ctx.num_constants = const_map.size();
+  ctx.use_inactive = true;
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kUpdateConstantBuffer, ctx);
   AOTI_RUNTIME_ERROR_CODE_CHECK(update_inactive_constant_buffer_func_(
       container_handle_, (AOTInductorConstantMapHandle)&const_map));
 }
@@ -448,6 +550,11 @@ void AOTIModelContainerRunner::update_inactive_constant_buffer(
 void AOTIModelContainerRunner::run_const_fold(
     bool use_inactive,
     AOTInductorStreamHandle cuda_stream_handle) {
+  RECORD_USER_SCOPE("AOTIModelContainerRunner::run_const_fold");
+  AOTIObserverContext ctx;
+  ctx.use_inactive = use_inactive;
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kRunConstantFolding, ctx);
   AOTI_RUNTIME_ERROR_CODE_CHECK(run_const_fold_func_(
       container_handle_,
       use_inactive,
@@ -456,10 +563,16 @@ void AOTIModelContainerRunner::run_const_fold(
 }
 
 void AOTIModelContainerRunner::swap_constant_buffer() {
+  RECORD_USER_SCOPE("AOTIModelContainerRunner::swap_constant_buffer");
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kSwapConstantBuffer, {});
   AOTI_RUNTIME_ERROR_CODE_CHECK(swap_constant_buffer_func_(container_handle_));
 }
 
 void AOTIModelContainerRunner::free_inactive_constant_buffer() {
+  RECORD_USER_SCOPE("AOTIModelContainerRunner::free_inactive_constant_buffer");
+  ScopedObserverEvent observer_event(
+      observer(), AOTIContainerEvent::kFreeInactiveBuffer, {});
   TORCH_CHECK(
       free_inactive_constant_buffer_func_ != nullptr,
       "No free_inactive_constant_buffer in .so! Consider rebuild your model with the latest AOTInductor.");

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -2,8 +2,12 @@
 #pragma once
 
 #include <ATen/Tensor.h>
+#include <torch/csrc/inductor/aoti_runner/model_container_observer.h>
 #include <torch/csrc/inductor/aoti_runtime/interface.h>
 #include <torch/csrc/inductor/aoti_torch/proxy_executor.h>
+
+#include <atomic>
+#include <memory>
 
 // Forward declare DynamicLibrary
 namespace at {
@@ -79,6 +83,35 @@ class TORCH_API AOTIModelContainerRunner {
                            : std::unordered_map<std::string, c10::IValue>{};
   }
 
+  // Attach an observer to receive begin/end callbacks bracketing container
+  // lifecycle events (constants load, constant-buffer update/swap/fold/free,
+  // inference). Optional; a null observer is zero overhead.
+  //
+  // Attach-once, and detaching is NOT supported: the hot path reads the
+  // observer through an atomic raw pointer, and because the owning shared_ptr
+  // is never replaced that pointer stays valid for the lifetime of the runner.
+  // Allowing a swap or a detach would race with -- and could free the observer
+  // out from under -- an in-flight run(). The slot is claimed with a
+  // compare-exchange rather than a plain check so a second concurrent caller
+  // reliably throws instead of racing on observer_owner_; only the winner
+  // assigns it. Passing nullptr is always an unconditional no-op.
+  void set_observer(std::shared_ptr<AOTIModelContainerObserver> observer) {
+    if (observer == nullptr) {
+      return;
+    }
+    AOTIModelContainerObserver* expected = nullptr;
+    TORCH_CHECK(
+        observer_.compare_exchange_strong(
+            expected,
+            observer.get(),
+            std::memory_order_release,
+            std::memory_order_relaxed),
+        "AOTIModelContainerRunner::set_observer() may only be called once per runner");
+    // Safe to publish before taking ownership: the caller's shared_ptr keeps
+    // the observer alive across this call.
+    observer_owner_ = std::move(observer);
+  }
+
  protected:
   AOTIModelContainerRunner(
       const std::string& model_so_path,
@@ -150,6 +183,11 @@ class TORCH_API AOTIModelContainerRunner {
 
   AOTIProxyExecutorHandle proxy_executor_handle_ = nullptr;
 
+  // Read on the hot path; see set_observer() for why this is attach-once.
+  AOTIModelContainerObserver* observer() const {
+    return observer_.load(std::memory_order_acquire);
+  }
+
  private:
   void load_aoti_symbols(
       const std::string& model_so_path,
@@ -157,6 +195,13 @@ class TORCH_API AOTIModelContainerRunner {
       bool run_single_threaded);
 
   std::unique_ptr<torch::aot_inductor::ProxyExecutor> proxy_executor_;
+
+  // Private, not protected: the lifetime argument in set_observer() only holds
+  // while every write goes through that compare-exchange, so subclasses (and
+  // out-of-tree runners registered via RegisterAOTIModelRunner) must not be
+  // able to assign these directly. They get the observer() accessor instead.
+  std::shared_ptr<AOTIModelContainerObserver> observer_owner_;
+  std::atomic<AOTIModelContainerObserver*> observer_{nullptr};
 };
 
 using CreateAOTIModelRunnerFunc = std::unique_ptr<AOTIModelContainerRunner> (*)(


### PR DESCRIPTION
Summary:

AOTInductor's model-container runner now supports a pluggable lifecycle observer so that serving systems can attribute latency (inference, constants swap, buffer updates, const-fold) to individual containers — something `RecordFunction` cannot express because its callbacks are global or thread-local, neither of which maps to per-container identity in a multi-model process.

The observer is optional and attach-once; the hot path reads it through an atomic pointer, so the cost when unattached is a single null check. Every instrumented site also emits a `RECORD_USER_SCOPE` so events appear in torch.profiler/Kineto unconditionally.

`on_end` reports a `succeeded` flag (derived from `std::uncaught_exceptions`) to prevent failed calls from polluting latency percentiles. The immediate downstream consumer is the per-transition AOTI freshness record (`aoti_constants_swap_duration`), wired in a follow-up (D115139404).

No behavior change when no observer is attached.

Test Plan:
New tests in `test/cpp/aoti_inference/test.cpp` (`AotInductorTest.ObserverCpu` / `ObserverCuda`, via `test_aoti_observer`), using a `RecordingObserver` that logs every `(event, ctx, succeeded)`:

- `set_observer(nullptr)` is accepted and does not consume the attach-once slot; a second `set_observer()` throws `c10::Error`.
- `run()` fires exactly one `kInference` begin/end pair and does not nest.
- A successful `update_constant_buffer` reports `num_constants` and `use_inactive`, with `succeeded == true`.
- An incomplete constants update throws, and `on_end` still fires for it with `succeeded == false` -- the central claim of `ScopedObserverEvent`.
- Every `on_begin` is paired with an `on_end`, including the call that threw.

`AotInductorTest.RecordFunctionCpu` / `RecordFunctionCuda` cover the other half: with **no observer attached**, a thread-local `RecordFunctionCallback` scoped to `RecordScope::USER_SCOPE` sees `AOTIModelContainerRunner::run` and `::swap_constant_buffer`, and stops seeing them once the callback is removed.

Those assertions use `std::find` rather than `EXPECT_THAT(..., IsSupersetOf(...))` on purpose: `test_aoti_inference` links `gtest_main` but not gmock, and the unordered-container matchers are not header-only, so `IsSupersetOf` fails to link with undefined references to `UnorderedElementsAreMatcherImplBase`. An earlier version of this diff hit exactly that in OSS CI. `HasSubstr`, used elsewhere in this file, is header-only and links fine; it is now the only gmock construct left here.

Builds:
```
buck2 build fbcode//mode/opt fbcode//caffe2:libtorch
EXIT=0
```

This test directory is CMake-only upstream and has no buck target, so `test.cpp` was compile-checked internally via a scratch `cpp_binary` over a copy of it plus `//caffe2:torch-cpp`:
```
buck2 build fbcode//mode/opt <scratch cpp_binary over test.cpp>
EXIT=0
```
(the only diagnostics were two pre-existing `-Wunused-variable` hits at lines 607-608, under fbcode's `-Werror`, unrelated to this change)

Caveat on that check: it verifies compilation, not the OSS link. The internal googletest target bundles gmock, so a scratch target cannot reproduce `test_aoti_inference`'s gtest-only link line -- confirmed by re-adding `IsSupersetOf` to the scratch copy and watching it link anyway. The gmock-library dependency was therefore removed by auditing every `::testing::` use in the file, not by reproducing the link failure locally. OSS CI is the check that matters for it.

Reviewed By: desertfire

Differential Revision: D114303586


