### PR TITLE
bump tolerances for flex attn test

### DIFF
--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -903,6 +903,7 @@ class TestFlexDecoding(InductorTestCase):
     @parametrize_device_dtype("dtypes")
     @common_utils.parametrize("score_mod", test_score_mods)
     @common_utils.parametrize("BLOCK_SIZE", test_block_size)
+    @with_tf32_off
     def test_builtin_score_mods_different_block_size(
         self,
         device,

--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -402,7 +402,7 @@ class TestFlexDecoding(InductorTestCase):
             # Note, it seems like we really are less accurate than the float32
             # computation, likely due to the online softmax
             if dtype == torch.float32:
-                fudge_factor = 10.0
+                fudge_factor = 12.0
             else:
                 fudge_factor = 1.1
 
@@ -903,7 +903,6 @@ class TestFlexDecoding(InductorTestCase):
     @parametrize_device_dtype("dtypes")
     @common_utils.parametrize("score_mod", test_score_mods)
     @common_utils.parametrize("BLOCK_SIZE", test_block_size)
-    @with_tf32_off
     def test_builtin_score_mods_different_block_size(
         self,
         device,


### PR DESCRIPTION
~~Shouldn't be used by flex itself but prevents the references from being too far off
Not in the spirit of the test to exercise TF32~~

corrected by claude, just bump tolerances instead

authored manually

cc @mruberry @zasdfgbnm @ptrblck @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @Chillee @drisspg @yanboliang @BoyuanFeng @liangel-02 @howardzhang-cv