### PR TITLE
[torchfuzz][bugfix] Require exact supported-op matches (#194002)

### DIFF
--- a/tools/experimental/torchfuzz/ops_fuzzer.py
+++ b/tools/experimental/torchfuzz/ops_fuzzer.py
@@ -56,6 +56,7 @@ def _get_template_filtered_operators(
 
     # Filter operators based on allowed_ops
     filtered_ops = {}
+    allowed_ops_set = set(allowed_ops)
 
     for op_name, operator in all_operators.items():
         # Always include operations that don't have a specific torch operation
@@ -68,18 +69,10 @@ def _get_template_filtered_operators(
             filtered_ops[op_name] = operator
             continue
 
-        # Check if the operator supports any of the allowed operations
-        should_include = False
-        for supported_op in allowed_ops:
-            # Direct torch operation matching
-            if torch_op == supported_op:
-                should_include = True
-                break
-
-            # Direct name matching as fallback
-            if supported_op in op_name or op_name in supported_op:
-                should_include = True
-                break
+        # Accept either the fully qualified torch operation or the exact
+        # registry key. Substring matching makes similarly named operators
+        # indistinguishable, such as exp/expand and squeeze/unsqueeze.
+        should_include = torch_op in allowed_ops_set or op_name in allowed_ops_set
 
         if should_include:
             # Set template on operators that support it

--- a/tools/experimental/torchfuzz/tests/test_ops_fuzzer.py
+++ b/tools/experimental/torchfuzz/tests/test_ops_fuzzer.py
@@ -1,0 +1,47 @@
+import unittest
+
+from torchfuzz.ops_fuzzer import _get_template_filtered_operators
+
+
+class SupportedOpsFilteringTest(unittest.TestCase):
+    def _torch_op_names(self, supported_op: str) -> set[str | None]:
+        operators = _get_template_filtered_operators(
+            template="default", supported_ops=[supported_op]
+        )
+        return {operator.torch_op_name for operator in operators.values()}
+
+    def test_expand_does_not_match_exp(self) -> None:
+        names = self._torch_op_names("torch.expand")
+
+        self.assertIn("torch.expand", names)
+        self.assertNotIn("torch.exp", names)
+
+    def test_exp_does_not_match_expand(self) -> None:
+        names = self._torch_op_names("torch.exp")
+
+        self.assertIn("torch.exp", names)
+        self.assertNotIn("torch.expand", names)
+
+    def test_unsqueeze_does_not_match_squeeze(self) -> None:
+        names = self._torch_op_names("torch.unsqueeze")
+
+        self.assertIn("torch.unsqueeze", names)
+        self.assertNotIn("torch.squeeze", names)
+
+    def test_squeeze_does_not_match_unsqueeze(self) -> None:
+        names = self._torch_op_names("torch.squeeze")
+
+        self.assertIn("torch.squeeze", names)
+        self.assertNotIn("torch.unsqueeze", names)
+
+    def test_registry_key_requires_exact_match(self) -> None:
+        names = self._torch_op_names("expand")
+
+        self.assertIn("torch.expand", names)
+        self.assertNotIn("torch.exp", names)
+
+    def test_partial_registry_key_does_not_match(self) -> None:
+        names = self._torch_op_names("expan")
+
+        self.assertNotIn("torch.expand", names)
+        self.assertNotIn("torch.exp", names)


### PR DESCRIPTION
Summary:

Make `--supported-ops` filter the registry by exact fully qualified API name or exact registry key. The previous substring fallback allowed similarly named operators such as `torch.exp` for `torch.expand` and `torch.squeeze` for `torch.unsqueeze`, making targeted generation unreliable.

Differential Revision: D116484855


