### PR TITLE
[ROCm] Add MIOpen API-based tuning for Batchnorm

### DIFF
--- a/aten/src/ATen/miopen/miopen-wrapper.h
+++ b/aten/src/ATen/miopen/miopen-wrapper.h
@@ -26,3 +26,10 @@ miopenStatus_t miopenSetConvolutionFindMode(
     miopenConvolutionFindMode_t findMode);
 }
 #endif
+
+#if MIOPEN_VERSION_MAJOR > 3 || (MIOPEN_VERSION_MAJOR == 3 && MIOPEN_VERSION_MINOR >= 6)
+// miopen 3.6 added tuning policy APIs (miopenGet/SetTuningPolicy)
+#define MIOPEN_HAS_TUNING_POLICY 1
+#else
+#define MIOPEN_HAS_TUNING_POLICY 0
+#endif

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -41,6 +41,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
 #include <ATen/miopen/Descriptors.h>
 #include <ATen/miopen/Types.h>
 #include <ATen/miopen/Utils.h>
+#include <ATen/miopen/miopen-wrapper.h>
 
 #include <ATen/TensorUtils.h>
 
@@ -57,6 +58,31 @@ Tensor expandScale(const Tensor& t, int64_t dim) {
 }
 
 }  // namespace
+
+#if MIOPEN_HAS_TUNING_POLICY
+struct MiopenTuningPolicyGuard {
+  miopenHandle_t handle;
+  miopenTuningPolicy_t previous_policy{};
+  bool restore_tuning_policy = false;
+
+  explicit MiopenTuningPolicyGuard(miopenHandle_t handle_) : handle(handle_) {
+    const auto tuning_policy = at::globalContext().benchmarkCuDNN()
+        ? miopenTuningPolicySearch
+        : miopenTuningPolicyNone;
+    MIOPEN_CHECK(miopenGetTuningPolicy(handle, &previous_policy));
+    if (previous_policy != tuning_policy) {
+      MIOPEN_CHECK(miopenSetTuningPolicy(handle, tuning_policy));
+      restore_tuning_policy = true;
+    }
+  }
+
+  ~MiopenTuningPolicyGuard() {
+    if (restore_tuning_policy) {
+      MIOPEN_CHECK(miopenSetTuningPolicy(handle, previous_policy));
+    }
+  }
+};
+#endif
 
 std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     const Tensor& input_t, const Tensor& weight_t, const std::optional<Tensor>& bias_t_opt, const std::optional<Tensor>& running_mean_t_opt, const std::optional<Tensor>& running_var_t_opt,
@@ -114,6 +140,10 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
   Tensor save_mean, save_var;
+
+#if MIOPEN_HAS_TUNING_POLICY
+  MiopenTuningPolicyGuard tuning_policy_guard(handle);
+#endif
 
   if (training) {
     int64_t num_features = input_t.size(1);
@@ -223,6 +253,9 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
   Constant one(dataType, 1);
   Constant zero(dataType, 0);
 
+#if MIOPEN_HAS_TUNING_POLICY
+  MiopenTuningPolicyGuard tuning_policy_guard(handle);
+#endif
   MIOPEN_CHECK(miopenBatchNormalizationBackward(
     handle, mode, &one, &zero, &one, &zero,
     idesc.desc(), input->const_data_ptr(),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12,6 +12,8 @@ import itertools
 import warnings
 import os
 import pickle
+import subprocess
+import sys
 import re
 import dataclasses
 from copy import deepcopy
@@ -4030,6 +4032,50 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             _train(memory_format, ref_backend, mixed, dtype)
         else:
             _inference(memory_format, ref_backend, mixed, dtype)
+
+    @unittest.skipIf(not TEST_WITH_ROCM, "ROCm only")
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_batchnorm_miopen_tuning(self):
+        # MIOpen API-based tuning is enabled for MIOpen 3.6.0 and higher.
+        miopen_version = torch._C._cudnn.getRuntimeVersion()
+        if miopen_version < (3, 6, 0):
+            raise unittest.SkipTest("MIOpen tuning requires MIOpen 3.6.0+")
+
+        test_script = """
+import os
+import torch
+import torch.nn as nn
+
+benchmark = os.getenv("TEST_BATCHNORM_MIOPEN_TUNING_ENABLED", "0") == "1"
+
+C = 8
+inp = torch.randint(1, 10, (4, C, 2, 2), dtype=torch.float32, device="cuda").requires_grad_()
+grad = torch.randint(1, 10, (4, C, 2, 2), dtype=torch.float32, device="cuda")
+
+with torch.backends.cudnn.flags(enabled=True, benchmark=benchmark):
+    mod = nn.BatchNorm2d(C).cuda().train()
+    out = mod(inp)
+    out.backward(grad)
+"""
+
+        def run_with_miopen_logging(benchmark):
+            env = os.environ.copy()
+            env["MIOPEN_ENABLE_LOGGING"] = "1"
+            env["TEST_BATCHNORM_MIOPEN_TUNING_ENABLED"] = "1" if benchmark else "0"
+            return subprocess.run(
+                [sys.executable, "-c", test_script],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+        result = run_with_miopen_logging(True)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("miopenSetTuningPolicy", result.stderr)
+
+        result = run_with_miopen_logging(False)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertNotIn("miopenSetTuningPolicy", result.stderr)
 
     def test_batchnorm_load_state_dict(self):
         bn = torch.nn.BatchNorm2d(3)


### PR DESCRIPTION
## Summary

Enable MIOpen API-based kernel tuning for batch normalization on ROCm when `torch.backends.cudnn.benchmark` is enabled 

- Add `MiopenTuningPolicyGuard` wrapper in `BatchNorm_miopen.cpp` that sets `miopenTuningPolicySearch` on the MIOpen handle before forward/backward batch norm calls and restores the previous policy afterward.
- Add compile-time guard `MIOPEN_HAS_TUNING_POLICY` in `miopen-wrapper.h` so builds against MIOpen headers older than 3.6 do not reference `miopenGetTuningPolicy` / `miopenSetTuningPolicy`.
- Add ROCm-only test `test_batchnorm_miopen_tuning` that verifies tuning policy is applied via MIOpen logs.

## Motivation

MIOpen introduced handle-level tuning policy APIs (`miopenGetTuningPolicy` / `miopenSetTuningPolicy`) to control kernel search/tuning. Convolution already benefits from benchmark-driven tuning via `miopenSetConvolutionFindMode`; batch norm had no equivalent hook. This change wires batch norm into the same `torch.backends.cudnn.benchmark` flag used on ROCm.

## Implementation

**`aten/src/ATen/miopen/miopen-wrapper.h`**
- Define `MIOPEN_HAS_TUNING_POLICY` when `MIOPEN_VERSION >= 3.6`.

**`aten/src/ATen/native/miopen/BatchNorm_miopen.cpp`**
- `MiopenTuningPolicyGuard` sets tuning policy based on `at::globalContext().benchmarkCuDNN()`:
  - `benchmark=True` -> `miopenTuningPolicySearch`
  - `benchmark=False` -> `miopenTuningPolicyNone`
- Calls `miopenGetTuningPolicy` on every forward/backward; calls `miopenSetTuningPolicy` only when the desired policy differs from the current one.
- Guard is installed in both `miopen_batch_norm` (forward) and `miopen_batch_norm_backward`.
- Version gating by `#if MIOPEN_HAS_TUNING_POLICY`

## Why `miopenGetTuningPolicy` is called on every batch norm

The MIOpen handle is long-lived and shared across ops, but `torch.backends.cudnn.benchmark` can change at any time via nested Python contexts. We read the current handle policy on each batch norm call so we can:

1. **React to the current `benchmarkCuDNN()` value** — evaluated at call time, not cached.
2. **Skip `miopenSetTuningPolicy` when already correct** — compare desired vs current policy before setting.
3. **Restore the previous handle policy in the destructor** — save what was on the handle before we potentially changed it.

Nested contexts illustrate why per-call reads are necessary:

```python
with torch.backends.cudnn.flags(enabled=True, benchmark=True):
    # benchmark=True -> MIOpen tuning ON
    bn(x)

    with torch.backends.cudnn.flags(enabled=True, benchmark=False):
        # benchmark=False -> MIOpen tuning OFF
        bn(x)

    # benchmark=True again (outer context restored)
    bn(x)

# original benchmark value restored
bn(x)
```

Each `bn(x)` may need a different tuning policy depending on the active context. Because the handle outlives any single op, we cannot assume its policy still matches `benchmarkCuDNN()` from a prior call.

## Test plan

- [x] `lintrunner -a aten/src/ATen/miopen/miopen-wrapper.h aten/src/ATen/native/miopen/BatchNorm_miopen.cpp test/test_nn.py`
- [ ] ROCm: `python test_nn.py -v -k test_batchnorm_miopen_tuning`
- [ ] ROCm: batch norm test suite passes (e.g. `python test_nn.py -v -k test_batchnorm`)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang