### PR TITLE
[AI Codemod][PerfAICT-General] Share a single AliasDb across peephole sub-passes to cut redundant builds

### DIFF
--- a/torch/csrc/jit/passes/concat_opt.cpp
+++ b/torch/csrc/jit/passes/concat_opt.cpp
@@ -516,8 +516,8 @@ std::vector<Value*> getConcatInputs(Node* concat) {
 
 class ConcatCombiner {
  public:
-  explicit ConcatCombiner(std::shared_ptr<Graph> graph)
-      : graph_(std::move(graph)), aliasDb_(graph_) {}
+  ConcatCombiner(std::shared_ptr<Graph> graph, AliasDb& alias_db)
+      : graph_(std::move(graph)), aliasDb_(alias_db) {}
 
   bool run() {
     collectOptimizableConcats();
@@ -682,15 +682,20 @@ class ConcatCombiner {
   std::vector<CombinableConcat> combinable_concats_;
 
   std::shared_ptr<Graph> graph_;
-  AliasDb aliasDb_;
+  AliasDb& aliasDb_;
 };
 
 } // namespace
 
-bool CombineConcats(const std::shared_ptr<Graph>& graph) {
-  bool changed = ConcatCombiner(graph).run();
+bool CombineConcats(const std::shared_ptr<Graph>& graph, AliasDb& alias_db) {
+  bool changed = ConcatCombiner(graph, alias_db).run();
   GRAPH_DUMP("After combining concats", graph);
   return changed;
+}
+
+bool CombineConcats(const std::shared_ptr<Graph>& graph) {
+  AliasDb alias_db(graph);
+  return CombineConcats(graph, alias_db);
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/passes/concat_opt.h
+++ b/torch/csrc/jit/passes/concat_opt.h
@@ -14,4 +14,8 @@ TORCH_API void ExpandConcatAndEliminateRedundancy(
 
 TORCH_API bool CombineConcats(const std::shared_ptr<Graph>& graph);
 
+TORCH_API bool CombineConcats(
+    const std::shared_ptr<Graph>& graph,
+    AliasDb& alias_db);
+
 } // namespace torch::jit

--- a/torch/csrc/jit/passes/peephole.cpp
+++ b/torch/csrc/jit/passes/peephole.cpp
@@ -2,6 +2,7 @@
 
 #include <ATen/core/jit_type.h>
 #include <c10/util/irange.h>
+#include <torch/csrc/jit/ir/alias_analysis.h>
 #include <torch/csrc/jit/jit_log.h>
 #include <torch/csrc/jit/passes/concat_opt.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
@@ -27,11 +28,38 @@ struct PeepholeOptimizeImpl {
 
   bool run() {
     bool changed = optimizeBlock(graph_->block());
-    changed |= PeepholeOptimizeListIdioms(graph_);
-    changed |= PeepholeOptimizeDictIdioms(graph_);
-    changed |= PeepholeOptimizeAliasSensitive(graph_, shape_peepholes_);
-    changed |= PeepholeOptimizeNonTensor(graph_);
-    changed |= CombineConcats(graph_);
+
+    std::optional<AliasDb> alias_db;
+    auto invalidate_alias_db = [&] { alias_db.reset(); };
+    auto get_alias_db = [&]() -> AliasDb& {
+      if (!alias_db) {
+        alias_db.emplace(graph_);
+      }
+      return *alias_db;
+    };
+
+    if (PeepholeOptimizeListIdioms(
+            graph_, /*refine_list_len=*/false, get_alias_db())) {
+      changed = true;
+      invalidate_alias_db();
+    }
+    if (PeepholeOptimizeDictIdioms(graph_, get_alias_db())) {
+      changed = true;
+      invalidate_alias_db();
+    }
+    if (PeepholeOptimizeAliasSensitive(
+            graph_, shape_peepholes_, get_alias_db())) {
+      changed = true;
+      invalidate_alias_db();
+    }
+    if (PeepholeOptimizeNonTensor(graph_)) {
+      changed = true;
+      invalidate_alias_db();
+    }
+    if (CombineConcats(graph_, get_alias_db())) {
+      changed = true;
+      invalidate_alias_db();
+    }
     return changed;
   }
 

--- a/torch/csrc/jit/passes/peephole_alias_sensitive.cpp
+++ b/torch/csrc/jit/passes/peephole_alias_sensitive.cpp
@@ -10,9 +10,10 @@ namespace torch::jit {
 struct PeepholeOptimizeAliasSensitiveImpl {
   PeepholeOptimizeAliasSensitiveImpl(
       std::shared_ptr<Graph> graph,
-      bool shape_peepholes)
+      bool shape_peepholes,
+      AliasDb& alias_db)
       : graph_(std::move(graph)),
-        aliasDb_(std::make_unique<AliasDb>(graph_)),
+        aliasDb_(alias_db),
         shape_peepholes_(shape_peepholes) {}
 
   bool run() {
@@ -53,14 +54,14 @@ struct PeepholeOptimizeAliasSensitiveImpl {
         // This is to handle potential resize_ calls, however unlikely.
         // If we add more checks related to resize_ in the graph,
         // factor this out like collectResizeSet in shape_analysis.
-        if (!aliasDb_->hasWriters(node->output())) {
+        if (!aliasDb_.hasWriters(node->output())) {
           for (const Use& dim_use : dim_uses) {
             replaceWithIValue(dim_use.user->output(), output_size);
           }
           changed = true;
         } else {
           for (const Use& dim_use : dim_uses) {
-            if (aliasDb_->moveAfterTopologicallyValid(node, dim_use.user)) {
+            if (aliasDb_.moveAfterTopologicallyValid(node, dim_use.user)) {
               replaceWithIValue(dim_use.user->output(), output_size);
               changed = true;
             }
@@ -129,7 +130,7 @@ struct PeepholeOptimizeAliasSensitiveImpl {
   }
 
   bool tryToReplaceOutputWithInput(Value* input, Value* output) {
-    if (!aliasDb_->safeToChangeAliasingRelationship(input, output)) {
+    if (!aliasDb_.safeToChangeAliasingRelationship(input, output)) {
       return false;
     }
     // whenever we replace an output with an input, all of the aliasing
@@ -141,7 +142,7 @@ struct PeepholeOptimizeAliasSensitiveImpl {
     // invalidating all of the memory dag caches, we just keep a set of values
     // which are "stale" (aliasing properties not up to date), and avoid doing
     // further optimizations on values which alias them
-    if (aliasDb_->mayAlias({input, output}, stale_alias_values_)) {
+    if (aliasDb_.mayAlias({input, output}, stale_alias_values_)) {
       return false;
     }
     output->replaceAllUsesWith(input);
@@ -152,15 +153,23 @@ struct PeepholeOptimizeAliasSensitiveImpl {
 
   ValueSet stale_alias_values_;
   std::shared_ptr<Graph> graph_;
-  std::unique_ptr<AliasDb> aliasDb_;
+  AliasDb& aliasDb_;
   bool shape_peepholes_;
 };
 
 bool PeepholeOptimizeAliasSensitive(
     const std::shared_ptr<Graph>& graph,
-    bool shape_peepholes) {
-  PeepholeOptimizeAliasSensitiveImpl opt(graph, shape_peepholes);
+    bool shape_peepholes,
+    AliasDb& alias_db) {
+  PeepholeOptimizeAliasSensitiveImpl opt(graph, shape_peepholes, alias_db);
   return opt.run();
+}
+
+bool PeepholeOptimizeAliasSensitive(
+    const std::shared_ptr<Graph>& graph,
+    bool shape_peepholes) {
+  AliasDb alias_db(graph);
+  return PeepholeOptimizeAliasSensitive(graph, shape_peepholes, alias_db);
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/passes/peephole_alias_sensitive.h
+++ b/torch/csrc/jit/passes/peephole_alias_sensitive.h
@@ -12,4 +12,9 @@ TORCH_API bool PeepholeOptimizeAliasSensitive(
     const std::shared_ptr<Graph>& graph,
     bool shape_peepholes);
 
+TORCH_API bool PeepholeOptimizeAliasSensitive(
+    const std::shared_ptr<Graph>& graph,
+    bool shape_peepholes,
+    AliasDb& alias_db);
+
 } // namespace torch::jit

--- a/torch/csrc/jit/passes/peephole_dict_idioms.cpp
+++ b/torch/csrc/jit/passes/peephole_dict_idioms.cpp
@@ -141,8 +141,10 @@ bool isDict(Value* v) {
 
 class PeepholeOptimizeDictIdiomsImpl {
  public:
-  explicit PeepholeOptimizeDictIdiomsImpl(std::shared_ptr<Graph> graph)
-      : graph_(std::move(graph)), aliasDb_(std::make_unique<AliasDb>(graph_)) {}
+  PeepholeOptimizeDictIdiomsImpl(
+      std::shared_ptr<Graph> graph,
+      const AliasDb& alias_db)
+      : graph_(std::move(graph)), aliasDb_(alias_db) {}
 
   bool run() {
     collectMutatedDicts(graph_->block());
@@ -151,7 +153,7 @@ class PeepholeOptimizeDictIdiomsImpl {
 
  private:
   void checkForMutatedDicts(Value* v) {
-    if (isDict(v) && aliasDb_->hasWriters(v)) {
+    if (isDict(v) && aliasDb_.hasWriters(v)) {
       mutated_dicts_.insert(v);
     }
   }
@@ -256,15 +258,22 @@ class PeepholeOptimizeDictIdiomsImpl {
 
   std::shared_ptr<Graph> graph_;
   std::unordered_set<Value*> mutated_dicts_;
-  std::unique_ptr<AliasDb> aliasDb_;
+  const AliasDb& aliasDb_;
   std::unordered_map<Node*, DictNode> dict_cache_;
 };
 
 } // namespace
 
-bool PeepholeOptimizeDictIdioms(const std::shared_ptr<Graph>& graph) {
-  PeepholeOptimizeDictIdiomsImpl opt(graph);
+bool PeepholeOptimizeDictIdioms(
+    const std::shared_ptr<Graph>& graph,
+    const AliasDb& alias_db) {
+  PeepholeOptimizeDictIdiomsImpl opt(graph, alias_db);
   return opt.run();
+}
+
+bool PeepholeOptimizeDictIdioms(const std::shared_ptr<Graph>& graph) {
+  AliasDb alias_db(graph);
+  return PeepholeOptimizeDictIdioms(graph, alias_db);
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/passes/peephole_dict_idioms.h
+++ b/torch/csrc/jit/passes/peephole_dict_idioms.h
@@ -33,4 +33,8 @@ namespace torch::jit {
 // return true if graph is modified.
 TORCH_API bool PeepholeOptimizeDictIdioms(const std::shared_ptr<Graph>& graph);
 
+TORCH_API bool PeepholeOptimizeDictIdioms(
+    const std::shared_ptr<Graph>& graph,
+    const AliasDb& alias_db);
+
 } // namespace torch::jit

--- a/torch/csrc/jit/passes/peephole_list_idioms.cpp
+++ b/torch/csrc/jit/passes/peephole_list_idioms.cpp
@@ -154,9 +154,10 @@ struct ListLenRefiner {
 struct PeepholeOptimizeListIdiomsImpl {
   PeepholeOptimizeListIdiomsImpl(
       std::shared_ptr<Graph> graph,
-      bool refine_list_len)
+      bool refine_list_len,
+      const AliasDb& alias_db)
       : graph_(std::move(graph)),
-        aliasDb_(std::make_unique<AliasDb>(graph_)),
+        aliasDb_(alias_db),
         refine_list_len_(refine_list_len) {}
 
   bool run() {
@@ -170,7 +171,7 @@ struct PeepholeOptimizeListIdiomsImpl {
 
  private:
   void checkForMutatedList(Value* v) {
-    if (v->type()->castRaw<ListType>() && aliasDb_->hasWriters(v)) {
+    if (v->type()->castRaw<ListType>() && aliasDb_.hasWriters(v)) {
       mutated_lists_.insert(v);
     }
   }
@@ -310,15 +311,23 @@ struct PeepholeOptimizeListIdiomsImpl {
 
   std::unordered_set<Value*> mutated_lists_;
   std::shared_ptr<Graph> graph_;
-  std::unique_ptr<AliasDb> aliasDb_;
+  const AliasDb& aliasDb_;
   bool refine_list_len_;
 };
 
 bool PeepholeOptimizeListIdioms(
     const std::shared_ptr<Graph>& graph,
-    bool refine_list_len) {
-  PeepholeOptimizeListIdiomsImpl opt(graph, refine_list_len);
+    bool refine_list_len,
+    const AliasDb& alias_db) {
+  PeepholeOptimizeListIdiomsImpl opt(graph, refine_list_len, alias_db);
   return opt.run();
+}
+
+bool PeepholeOptimizeListIdioms(
+    const std::shared_ptr<Graph>& graph,
+    bool refine_list_len) {
+  AliasDb alias_db(graph);
+  return PeepholeOptimizeListIdioms(graph, refine_list_len, alias_db);
 }
 
 } // namespace torch::jit

--- a/torch/csrc/jit/passes/peephole_list_idioms.h
+++ b/torch/csrc/jit/passes/peephole_list_idioms.h
@@ -67,4 +67,9 @@ TORCH_API bool PeepholeOptimizeListIdioms(
     const std::shared_ptr<Graph>& graph,
     bool refine_list_len = false);
 
+TORCH_API bool PeepholeOptimizeListIdioms(
+    const std::shared_ptr<Graph>& graph,
+    bool refine_list_len,
+    const AliasDb& alias_db);
+
 } // namespace torch::jit


### PR DESCRIPTION
Summary:
This diff is created by PerfAICT to optimize `torch::jit::preoptimizeGraph` in "fbcode/caffe2/torch/csrc/jit/api/function_impl.cpp", by reducing CPU cycles spent in this function.

### Optimization Details

`PeepholeOptimizeImpl::run` previously invoked four sub-passes — `PeepholeOptimizeListIdioms`, `PeepholeOptimizeDictIdioms`, `PeepholeOptimizeAliasSensitive`, and `CombineConcats` — each of which independently constructed its own full-graph `AliasDb`, even though they run back-to-back on the same graph. Building `AliasDb` (full-graph alias analysis) dominates the cost of each pass.

`run()` now owns a single `std::optional<AliasDb>` and exposes two local accessors: `get_alias_db()`, which builds it on first use, and `invalidate_alias_db()`, which discards it. Every sub-pass follows the same shape — the pass is invoked with `get_alias_db()`, and if it reports a change the db is invalidated so the next `get_alias_db()` rebuilds against the mutated graph. Because construction is lazy, invalidating costs nothing when no later pass needs the db, so the pattern can be applied uniformly without special cases.

Each sub-pass takes the db as a non-owning `AliasDb&` — `const AliasDb&` for `PeepholeOptimizeListIdioms` and `PeepholeOptimizeDictIdioms`, which only call the `const` method `hasWriters`, so the compiler enforces that they cannot invalidate what they borrow. The original entry points are retained as thin overloads that construct a local db, leaving external callers unaffected.

This collapses four `AliasDb` constructions into one whenever the passes leave the graph untouched, a deterministic reduction that does not depend on graph contents. Applied identically to the fbcode and xplat copies.

Differential Revision: D114168715


