### PR TITLE
[DO NOT LAND] gpu-coverage probe: sm90 test behind a predicate the descriptor pins

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -20,6 +20,10 @@ from torch._inductor.select_algorithm import (
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache, get_num_sms, TMA_DESCRIPTOR_SIZE
 from torch._inductor.virtualized import V
+from torch.testing._internal.common_cuda import (
+    PLATFORM_SUPPORTS_GREEN_CONTEXT,
+    SM90OrLater,
+)
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -1113,6 +1117,13 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
         # Ensure hash checking is enabled
         with patch.object(inductor_config.lookup_table, "check_src_hash", True):
             self.run_model("mm", tensors)
+
+
+class TestForcedPredicateProbe(TestCase):
+    @unittest.skipIf(not SM90OrLater, "needs sm90")
+    @unittest.skipIf(not PLATFORM_SUPPORTS_GREEN_CONTEXT, "needs green context")
+    def test_sm90_behind_a_forced_predicate(self):
+        self.assertTrue(True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

Covers a defect found in adversarial review. `platforms._cuda_caps` pins
`PLATFORM_SUPPORTS_GREEN_CONTEXT` to False at **every** simulated capability, so a
test co-gated on it and on `SM90OrLater` skips at sm86, sm90 and sm100 alike. The
difference `ran@sm90 - ran@sm86` is then empty, and the test dropped out with no
gap and no warning -- on a test that genuinely needs an H100 and is in neither
smoke list.

Expected: the check reports the file as unclassifiable, naming the pinned
predicate, rather than passing silently. Locally:

```
why:  PLATFORM_SUPPORTS_GREEN_CONTEXT is pinned to one value by the descriptor at
      every capability, so a test gating on it shows no difference
fix:  if such a test needs an H100 or B200, list it by hand
```

The forced set is derived by evaluating the descriptor's own overrides across the
capability sweep, not listed in the checker -- and deliberately narrower than
"skipped everywhere", which flagged 1299 tests in `test_linalg.py` that skip for
reasons unrelated to capability.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo