### PR TITLE
[DO NOT LAND] gpu-coverage probe: sm90 gate raised from setUpClass

### DIFF
--- a/test/inductor/test_lookup_table.py
+++ b/test/inductor/test_lookup_table.py
@@ -20,6 +20,7 @@ from torch._inductor.select_algorithm import (
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache, get_num_sms, TMA_DESCRIPTOR_SIZE
 from torch._inductor.virtualized import V
+from torch.testing._internal.common_cuda import SM90OrLater
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -1113,6 +1114,17 @@ class TestLookupTableE2E(BaseE2ELookupTableTest):
         # Ensure hash checking is enabled
         with patch.object(inductor_config.lookup_table, "check_src_hash", True):
             self.run_model("mm", tensors)
+
+
+class TestClassLevelSkipProbe(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not SM90OrLater:
+            raise unittest.SkipTest("needs sm90")
+
+    def test_gated_by_class_setup(self):
+        self.assertTrue(True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

Covers the second defect found in adversarial review. `setUpClass` is not gutted,
so a class-level `raise unittest.SkipTest` reaches the recorder through a unittest
`_ErrorHolder`, which has no `_testMethodName`. Reaching for it unguarded raised
out of `suite.run`; the file was reported unmeasurable **and the check still
printed `OK` and exited 0**.

Expected: the class-level skip is observed normally, so the test is classified and
routed to both smoke lists. Locally:

```
test_gated_by_class_setup  -- runs on h100, not on a10g
test_gated_by_class_setup  -- runs on b200, not on a10g
```

Also relevant here: `N file(s) OK` now reads `N of M file(s) OK, K NOT MEASURED`,
so a file the check could not read is never folded into the OK count.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo