### PR TITLE
Add DeviceIPCTypes for device-agnostic IPC data structures

### DIFF
--- a/build_variables.bzl
+++ b/build_variables.bzl
@@ -937,6 +937,7 @@ libtorch_python_core_sources = [
     "torch/csrc/DataLoader.cpp",
     "torch/csrc/DeviceAccelerator.cpp",
     "torch/csrc/Device.cpp",
+    "torch/csrc/DeviceIPCTypes.cpp",
     "torch/csrc/Dtype.cpp",
     "torch/csrc/DynamicTypes.cpp",
     "torch/csrc/Exceptions.cpp",

--- a/torch/csrc/DeviceIPCTypes.cpp
+++ b/torch/csrc/DeviceIPCTypes.cpp
@@ -1,0 +1,216 @@
+#include <torch/csrc/DeviceIPCTypes.h>
+#include <ATen/MapAllocator.h>
+#include <c10/util/Logging.h>
+#include <map>
+
+namespace torch {
+
+namespace {
+
+void warnProducerTerminatedBeforeSharedTensorsReleased() {
+  static bool warned = false;
+  if (!warned) {
+    LOG(WARNING)
+        << "Producer process has been terminated before all shared device "
+           "tensors released. See Note [Sharing device tensors]";
+    warned = true;
+  }
+}
+
+struct DeviceIPCGlobalEntities {
+  // Trivial bool avoids static destruction order issues.
+  static bool alive;
+
+  std::mutex ref_counters_mutex_;
+  std::map<std::string, std::shared_ptr<DeviceIPCRefCountersFile>>
+      ref_counters_files_;
+  std::shared_ptr<DeviceIPCRefCountersFile> next_available_ref_counters_file_;
+  DeviceIPCSentDataLimbo DeviceIPCSentDataLimbo_;
+
+  DeviceIPCGlobalEntities() {
+    alive = true;
+  }
+  DeviceIPCGlobalEntities(const DeviceIPCGlobalEntities&) = delete;
+  DeviceIPCGlobalEntities(DeviceIPCGlobalEntities&&) = delete;
+  DeviceIPCGlobalEntities& operator=(const DeviceIPCGlobalEntities&) = delete;
+  DeviceIPCGlobalEntities& operator=(DeviceIPCGlobalEntities&&) = delete;
+  ~DeviceIPCGlobalEntities() {
+    alive = false;
+    DeviceIPCSentDataLimbo_.collect();
+    safe_clean_current_file();
+    if (next_available_ref_counters_file_) {
+      warnProducerTerminatedBeforeSharedTensorsReleased();
+    }
+  }
+  void safe_clean_current_file() {
+    std::lock_guard<std::mutex> lock(ref_counters_mutex_);
+    if (next_available_ref_counters_file_ &&
+        next_available_ref_counters_file_->offsets_in_use() == 0) {
+      ref_counters_files_.erase(next_available_ref_counters_file_->handle());
+      next_available_ref_counters_file_.reset();
+    }
+  }
+};
+
+bool DeviceIPCGlobalEntities::alive = false;
+DeviceIPCGlobalEntities device_ipc_global_entities;
+
+DeviceIPCSentDataLimbo::~DeviceIPCSentDataLimbo() {
+  collect();
+  if (size() > 0) {
+    warnProducerTerminatedBeforeSharedTensorsReleased();
+  }
+}
+
+bool DeviceIPCSentDataLimbo::collect() {
+  bool freed_memory = false;
+  std::vector<std::unique_ptr<DeviceIPCSentData>> reset_blocks;
+  {
+    std::lock_guard<std::mutex> lock(limbo_mutex_);
+    std::vector<std::unique_ptr<DeviceIPCSentData>> kept_blocks;
+    for (auto& sd : shared_blocks_) {
+      if (sd->counter_value() > 0) {
+        kept_blocks.push_back(std::move(sd));
+      } else {
+        freed_memory = true;
+        reset_blocks.push_back(std::move(sd));
+      }
+    }
+    shared_blocks_ = std::move(kept_blocks);
+  }
+  // Need to reset blocks out of the critical section here, otherwise it
+  // deadlocks.
+  for (auto& sd : reset_blocks) {
+    sd.reset();
+  }
+  return freed_memory;
+}
+
+void DeviceIPCSentDataLimbo::add(
+    std::unique_ptr<DeviceIPCSentData> shared_block) {
+  std::lock_guard<std::mutex> lock(limbo_mutex_);
+  static bool warned = false;
+  if (static_cast<int64_t>(shared_blocks_.size()) >
+          DEVICE_IPC_WARN_AFTER_X_BLOCKS_IN_LIMBO &&
+      !warned) {
+    LOG(WARNING)
+        << "Producer process tried to deallocate over "
+        << DEVICE_IPC_WARN_AFTER_X_BLOCKS_IN_LIMBO
+        << " memory blocks referred by consumer processes. Deallocation might "
+           "be significantly slowed down. "
+        << "We assume it will never going to be the case, but if it is, "
+           "please file a bug at https://github.com/pytorch/pytorch";
+    warned = true;
+  }
+  shared_blocks_.push_back(std::move(shared_block));
+}
+
+uint64_t DeviceIPCSentDataLimbo::size() {
+  std::lock_guard<std::mutex> lock(limbo_mutex_);
+  return shared_blocks_.size();
+}
+
+void DeviceIPCSentDataDelete(void* ptr) {
+  std::unique_ptr<DeviceIPCSentData> sent_data(
+      static_cast<DeviceIPCSentData*>(ptr));
+  if (!DeviceIPCGlobalEntities::alive) {
+    return;
+  }
+  if (sent_data->counter_value() > 0) {
+    device_ipc_global_entities.DeviceIPCSentDataLimbo_.add(
+        std::move(sent_data));
+  }
+  device_ipc_global_entities.DeviceIPCSentDataLimbo_.collect();
+}
+
+void ReturnRefCounter(const std::string& handle, uint64_t offset /* unused */) {
+  if (!DeviceIPCGlobalEntities::alive) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(
+      device_ipc_global_entities.ref_counters_mutex_);
+  auto& map = device_ipc_global_entities.ref_counters_files_;
+  auto it = map.find(handle);
+  if (it != map.end()) {
+    it->second->return_offset(offset);
+    if (it->second->offsets_in_use() == 0 && !it->second->have_offsets()) {
+      map.erase(handle);
+    }
+  }
+}
+
+} // namespace
+
+DeviceIPCSentData::DeviceIPCSentData(
+    std::string handle,
+    uint64_t offset,
+    uint64_t* counter_ptr,
+    at::Device device)
+    : handle_(std::move(handle)),
+      offset_(offset),
+      counter_ptr_(counter_ptr),
+      device_(device) {}
+
+DeviceIPCSentData::~DeviceIPCSentData() {
+  if (!DeviceIPCGlobalEntities::alive) {
+    original_ptr_.release_context();
+  }
+  ReturnRefCounter(handle_, offset_);
+}
+
+uint64_t DeviceIPCSentData::counter_value() {
+  return *counter_ptr_;
+}
+
+at::DataPtr GetNewRefCountedSentDataForDevice(void* data, at::Device device) {
+  {
+    std::lock_guard<std::mutex> lock(
+        device_ipc_global_entities.ref_counters_mutex_);
+    if (!device_ipc_global_entities.next_available_ref_counters_file_) {
+      std::string ref_counter_handle = at::NewProcessWideShmHandle();
+
+      int flags =
+          at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_EXCLUSIVE;
+      at::DataPtr sptr = at::RefcountedMapAllocator::makeDataPtr(
+          ref_counter_handle.c_str(),
+          flags,
+          sizeof(uint64_t) * DEVICE_IPC_REF_COUNTER_FILE_SIZE,
+          nullptr);
+      auto rc = std::make_shared<DeviceIPCRefCountersFile>(
+          ref_counter_handle,
+          DEVICE_IPC_REF_COUNTER_FILE_SIZE,
+          std::move(sptr));
+      device_ipc_global_entities.ref_counters_files_[ref_counter_handle] = rc;
+      device_ipc_global_entities.next_available_ref_counters_file_ = rc;
+    }
+  }
+  device_ipc_global_entities.next_available_ref_counters_file_->set_counter(1);
+  auto sent_data = new DeviceIPCSentData(
+      device_ipc_global_entities.next_available_ref_counters_file_->handle(),
+      device_ipc_global_entities.next_available_ref_counters_file_
+          ->get_offset(),
+      device_ipc_global_entities.next_available_ref_counters_file_
+          ->counter_ptr(),
+      device);
+
+  device_ipc_global_entities.next_available_ref_counters_file_->rotate_offset();
+  if (!device_ipc_global_entities.next_available_ref_counters_file_
+           ->have_offsets()) {
+    device_ipc_global_entities.next_available_ref_counters_file_.reset();
+  }
+  return at::DataPtr(data, sent_data, DeviceIPCSentDataDelete, device);
+}
+
+bool DeviceIPCCollect() {
+  if (!DeviceIPCGlobalEntities::alive) {
+    return true;
+  }
+  bool freed_memory =
+      device_ipc_global_entities.DeviceIPCSentDataLimbo_.collect();
+  if (device_ipc_global_entities.DeviceIPCSentDataLimbo_.size() == 0) {
+    device_ipc_global_entities.safe_clean_current_file();
+  }
+  return freed_memory;
+}
+
+} // namespace torch

--- a/torch/csrc/DeviceIPCTypes.h
+++ b/torch/csrc/DeviceIPCTypes.h
@@ -1,0 +1,128 @@
+#pragma once
+#include <c10/core/Allocator.h>
+#include <torch/csrc/Export.h>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace torch {
+
+TORCH_API bool DeviceIPCCollect();
+
+struct DeviceIPCReceivedData final {
+  DeviceIPCReceivedData() = default;
+  explicit DeviceIPCReceivedData(std::shared_ptr<void> shared_ptr)
+      : shared_ptr_(std::move(shared_ptr)) {}
+  std::shared_ptr<void> shared_ptr_;
+};
+
+struct DeviceIPCSentData final {
+  std::string handle_;
+  uint64_t offset_;
+  uint64_t* counter_ptr_;
+  at::DataPtr original_ptr_;
+  // Empty string means no event-based sync required.
+  std::string event_bytes_;
+  at::Device device_;
+
+  DeviceIPCSentData(
+      std::string handle,
+      uint64_t offset,
+      uint64_t* counter_ptr,
+      at::Device device);
+  ~DeviceIPCSentData();
+
+  uint64_t counter_value();
+
+  const std::string& handle() const {
+    return handle_;
+  }
+  uint64_t offset() const {
+    return offset_;
+  }
+  void set_original_ptr(at::DataPtr data_ptr) {
+    original_ptr_ = std::move(data_ptr);
+  }
+  void set_event_bytes(std::string bytes) {
+    event_bytes_ = std::move(bytes);
+  }
+  const std::string& event_bytes() const {
+    return event_bytes_;
+  }
+};
+
+TORCH_API at::DataPtr GetNewRefCountedSentDataForDevice(
+    void* data,
+    at::Device device);
+
+namespace {
+
+inline constexpr int64_t DEVICE_IPC_REF_COUNTER_FILE_SIZE = 10000;
+inline constexpr int64_t DEVICE_IPC_WARN_AFTER_X_BLOCKS_IN_LIMBO = 1000;
+
+// All to be deleted data blocks with non-zero reference counter go there
+struct DeviceIPCSentDataLimbo final {
+  ~DeviceIPCSentDataLimbo();
+  bool collect();
+  void add(std::unique_ptr<DeviceIPCSentData> shared_block);
+  uint64_t size();
+
+ private:
+  std::vector<std::unique_ptr<DeviceIPCSentData>> shared_blocks_;
+  std::mutex limbo_mutex_;
+};
+
+struct DeviceIPCRefCountersFile final {
+  DeviceIPCRefCountersFile(
+      std::string handle,
+      uint64_t size,
+      at::DataPtr data_ptr)
+      : size_(size),
+        handle_(std::move(handle)),
+        refcounted_shared_mem_(std::move(data_ptr)) {}
+
+  uint64_t* counter_ptr() {
+    return static_cast<uint64_t*>(refcounted_shared_mem_.get()) + next_offset_;
+  }
+
+  void set_counter(uint64_t value) {
+    *counter_ptr() = value;
+  }
+
+  bool have_offsets() {
+    return next_offset_ < size_;
+  }
+
+  bool offsets_in_use() {
+    return used_slots_;
+  }
+
+  uint64_t get_offset() {
+    return next_offset_;
+  }
+
+  void rotate_offset() {
+    next_offset_++;
+    used_slots_++;
+  }
+
+  void return_offset(uint64_t /* offset */) {
+    used_slots_--;
+  }
+
+  const std::string& handle() const {
+    return handle_;
+  }
+
+ private:
+  uint64_t next_offset_{0};
+  uint64_t size_;
+  uint64_t used_slots_{0};
+  std::string handle_;
+  at::DataPtr refcounted_shared_mem_;
+};
+
+} // namespace
+} // namespace torch


### PR DESCRIPTION
### Summary
Adds `torch/csrc/DeviceIPCTypes.h` and `torch/csrc/DeviceIPCTypes.cpp`, a device-agnostic IPC data-structure layer modelled after `CudaIPCTypes.h/.cpp`. `CudaIPCTypes` is not modified. A separate file is used rather than modifying `CudaIPCTypes` to keep the CUDA path untouched and avoid coupling the new device-agnostic path to CUDA's event lifecycle and OOM callback machinery.

**What is added:**

- `DeviceIPCSentData`: producer-side shared tensor metadata: shared memory handle, refcount slot pointer, original allocation, serialised event bytes, and device index.
- `DeviceIPCReceivedData`: holds a `shared_ptr<void>` on the consumer side to keep the mapped memory region alive.
- `DeviceIPCSentDataLimbo`: deferred-free list for blocks whose refcount has not yet reached zero at producer teardown.
- `GetNewRefCountedSentDataForDevice`: allocates a refcount slot via `RefcountedMapAllocator` and returns a `DataPtr` whose deleter decrements that slot when the producer tensor is freed.
- `DeviceIPCCollect`: drains the limbo list; wired to storage-sharing logic in a follow-up PR.

`std::string event_bytes_` replaces `cudaEvent_t`; an empty string means no event-based sync required. `DeviceIPCTypes.cpp` is added to `build_variables.bzl` outside any `USE_CUDA` guard so the build is unconditional.

This is **PR 2 of 5** in the implementation series for RFC #192099 (Adding IPC Support for Third-Party Devices).

cc @fffrog @albanD @cyyever
