### PR TITLE
Move B200 CUDA 13.2 sm100 jobs from test-b200.yml to unstable.yml, allowing all commits to run B200 tests

### DIFF
--- a/.github/workflows/test-b200.yml
+++ b/.github/workflows/test-b200.yml
@@ -4,7 +4,8 @@
 # This workflow runs smoke tests on B200 hardware
 #
 # Flow:
-# 1. Builds PyTorch with CUDA 13.0 and 13.2 for B200's sm100 architecture
+# 1. Builds PyTorch with CUDA 13.0 for B200's sm100 architecture
+#    (CUDA 13.2 sm100 jobs moved to trunk.yml so every commit gets tested on B200)
 # 2. Runs smoke tests on linux.dgx.b200 runner
 # 3. Tests executed are defined in .ci/pytorch/test.sh -> test_python_smoke_b200() function
 #    - Includes matmul, scaled_matmul, FP8, and FlashAttention CuTe tests
@@ -24,7 +25,7 @@ on:
       - .github/workflows/test-b200.yml
   workflow_dispatch:
   schedule:
-    - cron: 0 */2 * * *  # every 2 hours
+    - cron: 0 */6 * * *  # every 6 hours
   push:
     tags:
       - ciflow/b200/*
@@ -85,40 +86,4 @@ jobs:
       python-version: "3.12"
       compiler: gcc11
       cuda-version: "13.0"
-    secrets: inherit
-
-  linux-jammy-cuda13_2-py3_12-gcc11-sm100-build:
-    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
-    uses: ./.github/workflows/_linux-build.yml
-    needs: get-label-type
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: linux.r7i.4xlarge
-      build-environment: linux-jammy-cuda13.2-py3.12-gcc11-sm100
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.2-cudnn9-py3.12-gcc11
-      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      cuda-arch-list: '10.0'
-      test-matrix: |
-        { include: [
-          { config: "smoke_b200", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
-        ]}
-      # config: "smoke_b200" maps to test_python_smoke_b200() in .ci/pytorch/test.sh
-      python-version: "3.12"
-      compiler: gcc11
-      cuda-version: "13.2"
-    secrets: inherit
-
-  linux-jammy-cuda13_2-py3_12-gcc11-sm100-test:
-    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - linux-jammy-cuda13_2-py3_12-gcc11-sm100-build
-      - get-label-type
-    with:
-      build-environment: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.test-matrix }}
-      python-version: "3.12"
-      compiler: gcc11
-      cuda-version: "13.2"
     secrets: inherit

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -348,6 +348,49 @@ jobs:
       cuda-version: "13.2"
     secrets: inherit
 
+  linux-jammy-cuda13_2-py3_12-gcc11-sm100-build:
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.2-py3.12-gcc11-sm100 ') }}
+    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+    uses: ./.github/workflows/_linux-build.yml
+    needs:
+      - get-label-type
+      - job-filter
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner: linux.r7i.4xlarge
+      build-environment: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.2-cudnn9-py3.12-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      cuda-arch-list: '10.0'
+      test-matrix: |
+        { include: [
+          { config: "smoke_b200", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+        ]}
+      # config: "smoke_b200" maps to test_python_smoke_b200() in .ci/pytorch/test.sh
+      python-version: "3.12"
+      compiler: gcc11
+      cuda-version: "13.2"
+    secrets: inherit
+
+  linux-jammy-cuda13_2-py3_12-gcc11-sm100-test:
+    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.2-py3.12-gcc11-sm100 ') }}
+    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-cuda13_2-py3_12-gcc11-sm100-build
+      - target-determination
+      - job-filter
+      - get-label-type
+    with:
+      build-environment: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.test-matrix }}
+      tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
+      python-version: "3.12"
+      compiler: gcc11
+      cuda-version: "13.2"
+    secrets: inherit
+
   macos-py3-arm64-build:
     if: ${{ github.repository_owner == 'pytorch' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' macos-py3-arm64 ')) }}
     name: macos-py3-arm64

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -348,49 +348,6 @@ jobs:
       cuda-version: "13.2"
     secrets: inherit
 
-  linux-jammy-cuda13_2-py3_12-gcc11-sm100-build:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.2-py3.12-gcc11-sm100 ') }}
-    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
-    uses: ./.github/workflows/_linux-build.yml
-    needs:
-      - get-label-type
-      - job-filter
-    with:
-      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      runner: linux.r7i.4xlarge
-      build-environment: linux-jammy-cuda13.2-py3.12-gcc11-sm100
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.2-cudnn9-py3.12-gcc11
-      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      cuda-arch-list: '10.0'
-      test-matrix: |
-        { include: [
-          { config: "smoke_b200", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
-        ]}
-      # config: "smoke_b200" maps to test_python_smoke_b200() in .ci/pytorch/test.sh
-      python-version: "3.12"
-      compiler: gcc11
-      cuda-version: "13.2"
-    secrets: inherit
-
-  linux-jammy-cuda13_2-py3_12-gcc11-sm100-test:
-    if: ${{ needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' linux-jammy-cuda13.2-py3.12-gcc11-sm100 ') }}
-    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
-    uses: ./.github/workflows/_linux-test.yml
-    needs:
-      - linux-jammy-cuda13_2-py3_12-gcc11-sm100-build
-      - target-determination
-      - job-filter
-      - get-label-type
-    with:
-      build-environment: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.test-matrix }}
-      tests-to-include: ${{ github.event.inputs.tests-to-include || '' }}
-      python-version: "3.12"
-      compiler: gcc11
-      cuda-version: "13.2"
-    secrets: inherit
-
   macos-py3-arm64-build:
     if: ${{ github.repository_owner == 'pytorch' && (needs.job-filter.outputs.jobs == '' || contains(needs.job-filter.outputs.jobs, ' macos-py3-arm64 ')) }}
     name: macos-py3-arm64

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -163,3 +163,43 @@ jobs:
       python-version: "3.10"
       compiler: gcc11
     secrets: inherit
+
+  # B200 CUDA 13.2 sm100 smoke coverage, staged here to gauge B200 runner
+  # reliability/availability on every main commit before it graduates to trunk.
+  linux-jammy-cuda13_2-py3_12-gcc11-sm100-build:
+    if: github.repository_owner == 'pytorch'
+    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      runner: linux.r7i.4xlarge
+      build-environment: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda13.2-cudnn9-py3.12-gcc11
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      cuda-arch-list: '10.0'
+      test-matrix: |
+        { include: [
+          { config: "smoke_b200", shard: 1, num_shards: 1, runner: "linux.dgx.b200" },
+        ]}
+      # config: "smoke_b200" maps to test_python_smoke_b200() in .ci/pytorch/test.sh
+      python-version: "3.12"
+      compiler: gcc11
+      cuda-version: "13.2"
+    secrets: inherit
+
+  linux-jammy-cuda13_2-py3_12-gcc11-sm100-test:
+    if: github.repository_owner == 'pytorch'
+    name: linux-jammy-cuda13.2-py3.12-gcc11-sm100
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-cuda13_2-py3_12-gcc11-sm100-build
+      - target-determination
+    with:
+      build-environment: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-cuda13_2-py3_12-gcc11-sm100-build.outputs.test-matrix }}
+      python-version: "3.12"
+      compiler: gcc11
+      cuda-version: "13.2"
+    secrets: inherit


### PR DESCRIPTION
## Summary

> This PR description was drafted with the help of an AI assistant (Claude Code); reviewed by @nWEIdia before opening.

- Moves `linux-jammy-cuda13_2-py3_12-gcc11-sm100-build`/`-test` from `test-b200.yml` (schedule + `ciflow/b200` only) into `trunk.yml`, so every commit to `main`/`release/*`/`landchecks/*` gets B200 CUDA 13.2 coverage.
- `test-b200.yml` now only builds/tests the CUDA 13.0 sm100 config (a separate follow-up is planned to bump this to CUDA 13.4).
- Reverts the `test-b200.yml` schedule from every 2 hours back to every 6 hours, since CUDA 13.2 B200 coverage now happens continuously via trunk.

Opened as draft — marking for review before merge.

## Test plan
- [x] Validated both workflow files parse as valid YAML
- [x] Confirm the new trunk.yml `linux-jammy-cuda13.2-py3.12-gcc11-sm100` build/test jobs run and pass in CI on this PR
- [x] Confirm `test-b200.yml` still runs/passes for the remaining CUDA 13.0 sm100 jobs

### Additional Human Notes
linux.dgx.b200 availability shown in https://hud.pytorch.org/runners/pytorch?search=dgx.b200 
08/19: updates has been done to move to unstable.yml instead of trunk.yml to address reviewers reservation wrt the runner availability and reliability. 

cc @ptrblck @eqy @tinglvv @atalman @huydhn @ngimel @drisspg @albanD @malfet