### PR TITLE
[CI] Bump scikit-image to 0.26.0 for Python >= 3.13

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -105,10 +105,12 @@ mypy==1.16.0 ; platform_system == "Linux"
 #Pinned versions: 1.16.0
 #test that import: test_typing.py, test_type_hints.py
 
-networkx==2.8.8
+networkx==2.8.8 ; python_version < "3.13"
+networkx==3.5 ; python_version >= "3.13"
+# scikit-image 0.26.0 requires networkx>=3.0
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
-#Pinned versions: 2.8.8
+#Pinned versions: 2.8.8, 3.5
 #test that import: functorch
 
 ninja==1.13.0
@@ -244,9 +246,13 @@ pygments==2.20.0
 #Pinned versions: 14.1.0
 #test that import:
 
-scikit-image==0.22.0
+scikit-image==0.22.0 ; python_version < "3.13"
+scikit-image==0.26.0 ; python_version >= "3.13"
+# 0.22.0 has no cp313/cp314 wheel, so pip builds it from source and picks up an
+# unpinned pythran that no longer compiles under the -std=c++14 its meson build
+# uses. 0.26.0 ships cp313/cp313t/cp314/cp314t wheels, so there is no source build.
 #Description: image processing routines
-#Pinned versions: 0.22.0
+#Pinned versions: 0.22.0, 0.26.0
 #test that import: test_nn.py
 
 #scikit-learn


### PR DESCRIPTION
The py3.13/3.14/3.14t clang21 docker images have been failing to build since
2026-08-17. `scikit-image==0.22.0` has no cp313/cp314 wheel, so pip builds it
from source and resolves an unpinned `pythran` into the build-isolation
overlay. Current pythran requires C++17, but scikit-image's meson build
compiles the generated C++ with `-std=c++14`, so it fails on
`std::is_integral_v`. Nothing changed on the PyTorch side; this is an upstream
release of an unpinned build-time dependency.

0.26.0 ships cp313/cp313t/cp314/cp314t manylinux wheels, so there is no source
build at all. It requires `networkx>=3.0`, so networkx moves to 3.5 for the
same Pythons -- without that pip cannot resolve the file. networkx 3.6.1 is
avoided because its `requires_python` excludes 3.14.1, which deadsnakes could
land on. Older Pythons keep 0.22.0 / 2.8.8, and their resolved output is
unchanged.

Fixes https://github.com/meta-pytorch/pytorch-gha-infra/issues/1433

This PR was authored with assistance from Claude Code.