### PR TITLE
[CUDA] Validate BatchNorm running stats dtypes

### DIFF
--- a/aten/src/ATen/native/cuda/Normalization.cu
+++ b/aten/src/ATen/native/cuda/Normalization.cu
@@ -438,6 +438,12 @@ std::tuple<Tensor&, Tensor&, Tensor&> batch_norm_cuda_out(const Tensor& self, co
   const bool has_running_var = (running_var_opt.has_value() && running_var_opt->defined());
   TORCH_CHECK_VALUE(has_running_mean == has_running_var,
     "running_mean and running_var must either both be None or neither be None");
+  if (has_running_mean) {
+    TORCH_CHECK(
+        running_mean_opt->scalar_type() == running_var_opt->scalar_type(),
+        "running_mean and running_var must have the same dtype, but got ",
+        running_mean_opt->scalar_type(), " and ", running_var_opt->scalar_type());
+  }
 
   if (train) {
     batch_norm_mean_var(self, save_mean, save_invstd);

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -9150,6 +9150,15 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(mod.bias.grad, torch.tensor([0., 0, 0], device=device))
 
     @onlyCUDA
+    def test_batch_norm_mismatched_running_stats_dtype(self, device):
+        input = torch.ones((2, 1), dtype=torch.bfloat16, device=device)
+        running_mean = torch.zeros(1, dtype=torch.float64, device=device)
+        running_var = torch.ones(2, dtype=torch.float32, device=device)[1:]
+
+        with self.assertRaisesRegex(RuntimeError, "running_mean and running_var must have the same dtype"):
+            F.batch_norm(input, running_mean, running_var, training=True)
+
+    @onlyCUDA
     @largeTensorTest('16GB')
     def test_prelu_backward_32bit_indexing(self, device):
         m = torch.nn.PReLU().cuda().half()


### PR DESCRIPTION
Human review note: I reviewed this change and am submitting it to address #193698.

> AI-generated summary:
> The CUDA BatchNorm running-stat update kernel dispatches on running_mean's dtype while writing both running statistics. Mismatched running_mean and running_var dtypes can therefore cause an incorrectly sized write. This change validates that the CUDA running statistics use the same dtype before launching the update kernel.
>
> The CUDA validation follows the existing CPU dtype-checking convention.
>
> Fixes #193698

Test Plan:
```bash
python test/test_nn.py -k test_batch_norm_mismatched_running_stats_dtype
```