### PR TITLE
[Testcase Refactoring]Add HardwareClassification label to test_torchbind.py

### DIFF
--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -13,10 +13,7 @@ from torch._inductor import aot_compile, ir
 from torch._inductor.codecache import WritableTempFile
 from torch._inductor.package import package_aoti
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_device_type import (
-    instantiate_device_type_tests,
-    onlyAccelerator,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import HardwareClassification, skipIfWindows
 from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,
@@ -433,10 +430,9 @@ class TestTorchbindAccelerator(TestCase):
         super().setUp()
         init_torchbind_implementations()
 
-    @onlyAccelerator
     @torch._dynamo.config.patch("capture_dynamic_output_shape_ops", True)
     @torch._inductor.config.patch("graph_partition", True)
-    def test_torchbind_compile_gpu_op_symint_graph_partition(self, device):
+    def test_torchbind_compile_accelerator_op_symint_graph_partition(self, device):
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -444,8 +440,8 @@ class TestTorchbindAccelerator(TestCase):
 
             def forward(self, x):
                 a = torch.ops._TorchScriptTesting.takes_foo_tensor_return(self.attr, x)
-                a_cuda = a.to(device=device)
-                return a_cuda + 1
+                a_device = a.to(device=device)
+                return a_device + 1
 
         m = M()
         inputs = (torch.ones(2, 3),)
@@ -455,7 +451,11 @@ class TestTorchbindAccelerator(TestCase):
 
 
 instantiate_device_type_tests(
-    TestTorchbindAccelerator, globals(), allow_xpu=True, except_for="cpu"
+    TestTorchbindAccelerator,
+    globals(),
+    allow_xpu=True,
+    allow_mps=True,
+    except_for="cpu",
 )
 
 

--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -377,26 +377,6 @@ class TestTorchbind(TestCase):
         result = optimized(*inputs)
         self.assertEqual(result, orig_res)
 
-    @onlyAccelerator
-    @torch._dynamo.config.patch("capture_dynamic_output_shape_ops", True)
-    @torch._inductor.config.patch("graph_partition", True)
-    def test_torchbind_compile_gpu_op_symint_graph_partition(self, device):
-        class M(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.attr = torch.classes._TorchScriptTesting._Foo(2, 3)
-
-            def forward(self, x):
-                a = torch.ops._TorchScriptTesting.takes_foo_tensor_return(self.attr, x)
-                a_cuda = a.to(device=device)
-                return a_cuda + 1
-
-        m = M()
-        inputs = (torch.ones(2, 3),)
-        orig_res = m(*inputs)
-        new_res = torch.compile(m, backend="inductor")(*inputs)
-        self.assertTrue(torch.allclose(orig_res, new_res))
-
     def test_torchbind_input_aot_compile(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -446,7 +426,35 @@ class TestTorchbind(TestCase):
         self.assertEqual(result, orig_res)
 
 
-instantiate_device_type_tests(TestTorchbind, globals(), allow_xpu=True)
+class TestTorchbindAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def setUp(self):
+        super().setUp()
+        init_torchbind_implementations()
+
+    @onlyAccelerator
+    @torch._dynamo.config.patch("capture_dynamic_output_shape_ops", True)
+    @torch._inductor.config.patch("graph_partition", True)
+    def test_torchbind_compile_gpu_op_symint_graph_partition(self, device):
+        class M(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.attr = torch.classes._TorchScriptTesting._Foo(2, 3)
+
+            def forward(self, x):
+                a = torch.ops._TorchScriptTesting.takes_foo_tensor_return(self.attr, x)
+                a_cuda = a.to(device=device)
+                return a_cuda + 1
+
+        m = M()
+        inputs = (torch.ones(2, 3),)
+        orig_res = m(*inputs)
+        new_res = torch.compile(m, backend="inductor")(*inputs)
+        self.assertTrue(torch.allclose(orig_res, new_res))
+
+
+instantiate_device_type_tests(TestTorchbindAccelerator, globals(), allow_xpu=True, except_for="cpu")
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -454,7 +454,9 @@ class TestTorchbindAccelerator(TestCase):
         self.assertTrue(torch.allclose(orig_res, new_res))
 
 
-instantiate_device_type_tests(TestTorchbindAccelerator, globals(), allow_xpu=True, except_for="cpu")
+instantiate_device_type_tests(
+    TestTorchbindAccelerator, globals(), allow_xpu=True, except_for="cpu"
+)
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -13,7 +13,7 @@ from torch._inductor import aot_compile, ir
 from torch._inductor.codecache import WritableTempFile
 from torch._inductor.package import package_aoti
 from torch._inductor.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import skipIfWindows
+from torch.testing._internal.common_utils import HardwareClassification, skipIfWindows
 from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
 from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,
@@ -22,6 +22,8 @@ from torch.testing._internal.torchbind_impls import (
 
 
 class TestTorchbind(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         init_torchbind_implementations()

--- a/test/inductor/test_torchbind.py
+++ b/test/inductor/test_torchbind.py
@@ -13,8 +13,11 @@ from torch._inductor import aot_compile, ir
 from torch._inductor.codecache import WritableTempFile
 from torch._inductor.package import package_aoti
 from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import HardwareClassification, skipIfWindows
-from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
 from torch.testing._internal.torchbind_impls import (
     _empty_tensor_queue,
     init_torchbind_implementations,
@@ -374,10 +377,10 @@ class TestTorchbind(TestCase):
         result = optimized(*inputs)
         self.assertEqual(result, orig_res)
 
-    @requires_gpu()
+    @onlyAccelerator
     @torch._dynamo.config.patch("capture_dynamic_output_shape_ops", True)
     @torch._inductor.config.patch("graph_partition", True)
-    def test_torchbind_compile_gpu_op_symint_graph_partition(self):
+    def test_torchbind_compile_gpu_op_symint_graph_partition(self, device):
         class M(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -385,7 +388,7 @@ class TestTorchbind(TestCase):
 
             def forward(self, x):
                 a = torch.ops._TorchScriptTesting.takes_foo_tensor_return(self.attr, x)
-                a_cuda = a.to(device=GPU_TYPE)
+                a_cuda = a.to(device=device)
                 return a_cuda + 1
 
         m = M()
@@ -441,6 +444,9 @@ class TestTorchbind(TestCase):
         optimized = torch._inductor.aoti_load_package(pt2_path)
         result = optimized(*inputs)
         self.assertEqual(result, orig_res)
+
+
+instantiate_device_type_tests(TestTorchbind, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add hw_classification = HardwareClassification.GENERIC to TestTorchbind

Metadata-only change. No functional impact.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo