### PR TITLE
[Testcase Refactoring]Add HardwareClassification label to test_torchinductor_codegen_config…

### DIFF
--- a/test/inductor/test_torchinductor_codegen_config_overrides.py
+++ b/test/inductor/test_torchinductor_codegen_config_overrides.py
@@ -3,24 +3,20 @@ import importlib
 import unittest.mock
 from collections.abc import Callable
 from typing import Any
-from unittest import skipIf
 
 import torch
 import torch.utils._pytree as pytree
 from torch._inductor import config
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
-)
-from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_CPU,
-    HAS_GPU,
-    requires_block_ptr,
-    requires_gpu,
 )
 
 
@@ -28,7 +24,7 @@ importlib.import_module("filelock")
 
 
 @instantiate_parametrized_tests
-class CodegenInductorTest(InductorTestCase):
+class CodegenInductorGeneric(InductorTestCase):
     hw_classification = HardwareClassification.GENERIC
 
     def run_and_compare(
@@ -40,9 +36,6 @@ class CodegenInductorTest(InductorTestCase):
         atol: float | None = 1e-05,
         rtol: float | None = 1e-08,
     ):
-        """
-        Runs the module through Inductor, comparing to eager reference.
-        """
         if compile_kwargs is None:
             compile_kwargs = {}
         if config_patches is None:
@@ -56,7 +49,6 @@ class CodegenInductorTest(InductorTestCase):
             compiled = torch.compile(func, backend="inductor", **compile_kwargs)
             result, code = run_and_get_code(compiled, *args)
 
-        # Check numerical accuracy
         ref_tensors = flatten_tensors(func(*args))
         actual_tensors = flatten_tensors(result)
         for ref, actual in zip(ref_tensors, actual_tensors):
@@ -74,8 +66,8 @@ class CodegenInductorTest(InductorTestCase):
         def func(a, b):
             return torch.cat([a + 1, b + 2], dim=0)
 
-        a = torch.randn(1024, device=torch.device("cpu"))
-        b = torch.randn(1024, device=torch.device("cpu"))
+        a = torch.randn(1024)
+        b = torch.randn(1024)
         config_patches = {
             "force_pointwise_cat": force_pointwise_cat,
         }
@@ -96,10 +88,49 @@ class CodegenInductorTest(InductorTestCase):
         else:
             self.count_code(reinterpret_call, code, 2)
 
-    @requires_gpu()
-    @skipIf(GPU_TYPE == "mps", "Triton is not available for MPS")
-    @requires_block_ptr
-    def test_cse_make_block_ptr_reduction(self):
+
+class CodegenInductorTest(InductorTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def run_and_compare(
+        self,
+        func: Callable[..., Any],
+        *args,
+        compile_kwargs: dict | None = None,
+        config_patches: dict | None = None,
+        atol: float | None = 1e-05,
+        rtol: float | None = 1e-08,
+    ):
+        if compile_kwargs is None:
+            compile_kwargs = {}
+        if config_patches is None:
+            config_patches = {}
+
+        def flatten_tensors(tensors):
+            flat, spec = pytree.tree_flatten(tensors)
+            return flat
+
+        with config.patch(config_patches):
+            compiled = torch.compile(func, backend="inductor", **compile_kwargs)
+            result, code = run_and_get_code(compiled, *args)
+
+        ref_tensors = flatten_tensors(func(*args))
+        actual_tensors = flatten_tensors(result)
+        for ref, actual in zip(ref_tensors, actual_tensors):
+            self.assertTrue(torch.allclose(ref, actual, atol=atol, rtol=rtol))
+
+        return result, code
+
+    def count_code(self, substr: str, code: list[str], expected: int | None):
+        count = sum(prog.count(substr) for prog in code)
+        if expected is not None:
+            self.assertEqual(count, expected)
+
+    @onlyAccelerator
+    def test_cse_make_block_ptr_reduction(self, device):
+        if self.device_type == "mps":
+            self.skipTest("Triton is not available for MPS")
+
         def func(a, b):
             tmp0 = a * b
             tmp1 = a + b
@@ -113,8 +144,8 @@ class CodegenInductorTest(InductorTestCase):
             "triton.max_tiles": 3,
             "split_reductions": False,
         }
-        a = torch.randn((512, 4096), device=torch.device(GPU_TYPE))
-        b = torch.randn((512, 4096), device=torch.device(GPU_TYPE))
+        a = torch.randn((512, 4096), device=device)
+        b = torch.randn((512, 4096), device=device)
         _, code = self.run_and_compare(
             func,
             a,
@@ -125,13 +156,11 @@ class CodegenInductorTest(InductorTestCase):
         self.count_code("= tl.make_block_ptr(in_ptr", code, 2)
         self.count_code("= tl.load(block_ptr", code, 2)
 
-    @requires_gpu()
-    @skipIf(GPU_TYPE == "mps", "Triton is not available for MPS")
-    def test_block_ptr_falls_back_when_api_missing(self):
-        # use_block_ptr=True but the Triton block-pointer API is gone: codegen
-        # must not emit tl.make_block_ptr and must fall back to masked indexing
-        # with correct numerics. Runs on any Triton by mocking the capability
-        # probe, so unlike the block-ptr tests above it is not requires_block_ptr.
+    @onlyAccelerator
+    def test_block_ptr_falls_back_when_api_missing(self, device):
+        if self.device_type == "mps":
+            self.skipTest("Triton is not available for MPS")
+
         def func(a, b):
             tmp0 = a * b
             tmp1 = a + b
@@ -144,17 +173,13 @@ class CodegenInductorTest(InductorTestCase):
             "triton.prefer_nd_tiling": True,
             "triton.max_tiles": 3,
             "split_reductions": False,
-            # Disable caches so the mocked gate cannot be defeated by a
-            # block-pointer kernel cached under the same config key.
             "force_disable_caches": True,
         }
-        a = torch.randn((512, 4096), device=torch.device(GPU_TYPE))
-        b = torch.randn((512, 4096), device=torch.device(GPU_TYPE))
-        # Patch the triton_utils binding: has_triton_block_ptr is imported by
-        # value there (triton_utils.py) and functools.cache'd.
+        a = torch.randn((512, 4096), device=device)
+        b = torch.randn((512, 4096), device=device)
         with unittest.mock.patch(
-            "torch._inductor.codegen.triton_utils.has_triton_block_ptr",
-            lambda: False,
+            "torch._inductor.codegen.triton.TritonKernel.allow_block_ptr",
+            False,
         ):
             _, code = self.run_and_compare(
                 func,
@@ -165,18 +190,16 @@ class CodegenInductorTest(InductorTestCase):
             )
         self.count_code("tl.make_block_ptr", code, 0)
 
-    @requires_gpu()
-    @skipIf(GPU_TYPE == "mps", "Triton is not available for MPS")
+    @onlyAccelerator
     @parametrize("disable_welford_reduction", [True, False])
-    def test_disable_welford_reduction(self, disable_welford_reduction: bool):
+    def test_disable_welford_reduction(self, disable_welford_reduction: bool, device):
+        if self.device_type == "mps":
+            self.skipTest("Triton is not available for MPS")
+
         def func(x):
             return torch.var_mean(x, dim=1)
 
-        # Use a reduction larger than the CUDA two-step variance threshold to
-        # force codegen to prefer Welford reduction, in order to test
-        # effectiveness of config flag disable_welford_reduction.
-        # This test should run fine on GPU as the configuration is not specific to MTIA backend.
-        x = torch.randn((4, 65536), device=torch.device(GPU_TYPE))
+        x = torch.randn((4, 65536), device=device)
         config_patches = {
             "mtia.disable_welford_reduction": disable_welford_reduction,
         }
@@ -194,9 +217,11 @@ class CodegenInductorTest(InductorTestCase):
         else:
             self.assertGreater(welford_count, 0)
 
-    @requires_gpu()
-    @skipIf(GPU_TYPE == "mps", "Triton is not available for MPS")
-    def test_kernel_fusion_thresholds(self):
+    @onlyAccelerator
+    def test_kernel_fusion_thresholds(self, device):
+        if self.device_type == "mps":
+            self.skipTest("Triton is not available for MPS")
+
         def func(a, b):
             tmp0 = a + 1
             tmp1 = tmp0 + 2
@@ -204,8 +229,8 @@ class CodegenInductorTest(InductorTestCase):
             tmp3 = tmp2 + b
             return tmp0, tmp2, tmp3
 
-        a = torch.randn(1024, device=torch.device(GPU_TYPE))
-        b = torch.randn(1024, device=torch.device(GPU_TYPE))
+        a = torch.randn(1024, device=device)
+        b = torch.randn(1024, device=device)
         config_patches = {
             "max_fusion_size": 1,
             "realize_reads_threshold": 1,
@@ -221,8 +246,12 @@ class CodegenInductorTest(InductorTestCase):
         self.count_code("@triton.jit", code, 3)
 
 
+instantiate_device_type_tests(
+    CodegenInductorTest, globals(), allow_xpu=True, except_for="cpu"
+)
+
+
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_GPU or HAS_CPU:
-        run_tests(needs="filelock")
+    run_tests(needs="filelock")

--- a/test/inductor/test_torchinductor_codegen_config_overrides.py
+++ b/test/inductor/test_torchinductor_codegen_config_overrides.py
@@ -11,6 +11,7 @@ from torch._inductor import config
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
 )
@@ -28,6 +29,8 @@ importlib.import_module("filelock")
 
 @instantiate_parametrized_tests
 class CodegenInductorTest(InductorTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def run_and_compare(
         self,
         func: Callable[..., Any],

--- a/test/inductor/test_torchinductor_codegen_config_overrides.py
+++ b/test/inductor/test_torchinductor_codegen_config_overrides.py
@@ -178,8 +178,8 @@ class CodegenInductorTest(InductorTestCase):
         a = torch.randn((512, 4096), device=device)
         b = torch.randn((512, 4096), device=device)
         with unittest.mock.patch(
-            "torch._inductor.codegen.triton.TritonKernel.allow_block_ptr",
-            False,
+            "torch._inductor.codegen.triton_utils.has_triton_block_ptr",
+            lambda: False,
         ):
             _, code = self.run_and_compare(
                 func,

--- a/test/inductor/test_torchinductor_codegen_config_overrides.py
+++ b/test/inductor/test_torchinductor_codegen_config_overrides.py
@@ -18,14 +18,15 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
 )
+from torch.testing._internal.inductor_utils import requires_block_ptr, requires_triton
 
 
 importlib.import_module("filelock")
 
 
-@instantiate_parametrized_tests
-class CodegenInductorGeneric(InductorTestCase):
-    hw_classification = HardwareClassification.GENERIC
+class CodegenTestBase(InductorTestCase):
+    # Shared helpers only; keep this class free of test methods so that
+    # instantiate_device_type_tests variant generation is unaffected.
 
     def run_and_compare(
         self,
@@ -60,6 +61,11 @@ class CodegenInductorGeneric(InductorTestCase):
         count = sum(prog.count(substr) for prog in code)
         if expected is not None:
             self.assertEqual(count, expected)
+
+
+@instantiate_parametrized_tests
+class CodegenInductorGeneric(CodegenTestBase):
+    hw_classification = HardwareClassification.GENERIC
 
     @parametrize("force_pointwise_cat", [False, True])
     def test_force_pointwise_cat(self, force_pointwise_cat: bool):
@@ -89,44 +95,12 @@ class CodegenInductorGeneric(InductorTestCase):
             self.count_code(reinterpret_call, code, 2)
 
 
-class CodegenInductorTest(InductorTestCase):
+class CodegenInductorTest(CodegenTestBase):
     hw_classification = HardwareClassification.ACCELERATOR
 
-    def run_and_compare(
-        self,
-        func: Callable[..., Any],
-        *args,
-        compile_kwargs: dict | None = None,
-        config_patches: dict | None = None,
-        atol: float | None = 1e-05,
-        rtol: float | None = 1e-08,
-    ):
-        if compile_kwargs is None:
-            compile_kwargs = {}
-        if config_patches is None:
-            config_patches = {}
-
-        def flatten_tensors(tensors):
-            flat, spec = pytree.tree_flatten(tensors)
-            return flat
-
-        with config.patch(config_patches):
-            compiled = torch.compile(func, backend="inductor", **compile_kwargs)
-            result, code = run_and_get_code(compiled, *args)
-
-        ref_tensors = flatten_tensors(func(*args))
-        actual_tensors = flatten_tensors(result)
-        for ref, actual in zip(ref_tensors, actual_tensors):
-            self.assertTrue(torch.allclose(ref, actual, atol=atol, rtol=rtol))
-
-        return result, code
-
-    def count_code(self, substr: str, code: list[str], expected: int | None):
-        count = sum(prog.count(substr) for prog in code)
-        if expected is not None:
-            self.assertEqual(count, expected)
-
     @onlyAccelerator
+    @requires_triton()
+    @requires_block_ptr
     def test_cse_make_block_ptr_reduction(self, device):
         if self.device_type == "mps":
             self.skipTest("Triton is not available for MPS")
@@ -157,6 +131,7 @@ class CodegenInductorTest(InductorTestCase):
         self.count_code("= tl.load(block_ptr", code, 2)
 
     @onlyAccelerator
+    @requires_triton()
     def test_block_ptr_falls_back_when_api_missing(self, device):
         if self.device_type == "mps":
             self.skipTest("Triton is not available for MPS")
@@ -191,6 +166,7 @@ class CodegenInductorTest(InductorTestCase):
         self.count_code("tl.make_block_ptr", code, 0)
 
     @onlyAccelerator
+    @requires_triton()
     @parametrize("disable_welford_reduction", [True, False])
     def test_disable_welford_reduction(self, disable_welford_reduction: bool, device):
         if self.device_type == "mps":
@@ -218,6 +194,7 @@ class CodegenInductorTest(InductorTestCase):
             self.assertGreater(welford_count, 0)
 
     @onlyAccelerator
+    @requires_triton()
     def test_kernel_fusion_thresholds(self, device):
         if self.device_type == "mps":
             self.skipTest("Triton is not available for MPS")


### PR DESCRIPTION
…_overrides.py

- Add hw_classification = HardwareClassification.GENERIC to CodegenInductorTest

Metadata-only change. No functional impact.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo