### PR TITLE
[Testcase Refactoring] Add hw_classification label and multi-accelerator support to test_torchinductor_opinfo.py

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -61,6 +61,7 @@ from torch.utils._dtype_abbrs import dtype_abbrs
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_leaves, tree_map
 
+
 try:
     try:
         from .test_torchinductor import check_model, check_model_gpu
@@ -308,6 +309,7 @@ intentionally_not_handled = {
 # This is only fixed when this config is set
 # We should eventually always turn it on
 import torch._functorch.config as functorch_config
+
 
 if not functorch_config.view_replay_for_aliased_outputs:
     intentionally_not_handled['("as_strided", "partial_views")'] = {
@@ -1368,9 +1370,7 @@ class TestInductorOpInfo(TestCase):
             in inductor_expected_failures_single_sample[device_type].get(op_name, set())
         ) or dtype in inductor_gradient_expected_failures_single_sample[
             device_type
-        ].get(
-            op_name, set()
-        ):
+        ].get(op_name, set()):
             test_expect = ExpectedTestResult.XFAILURE
         else:
             test_expect = ExpectedTestResult.SUCCESS  # noqa: F841

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_CI,
     IS_LINUX,
@@ -1277,6 +1278,8 @@ def _inductor_extra_samples(op_name, device, dtype, requires_grad):
 
 @wrapper_noop_set_seed_decorator
 class TestInductorOpInfo(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -33,34 +33,33 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_CI,
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
     IS_X86,
-    MI200_ARCH,
-    TEST_MKL,
-    TEST_WITH_ASAN,
-    TEST_WITH_ROCM,
-    HardwareClassification,
     isRocmArchAnyOf,
+    MI200_ARCH,
     skipCUDAMemoryLeakCheckIf,
     skipIfCrossRef,
     skipIfTorchDynamo,
     suppress_warnings,
+    TEST_MKL,
+    TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
     HAS_CPU,
     HAS_CUDA_AND_TRITON,
-    HAS_XPU_AND_TRITON,
     has_triton,
+    HAS_XPU_AND_TRITON,
     maybe_skip_size_asserts,
 )
 from torch.utils._dtype_abbrs import dtype_abbrs
 from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_leaves, tree_map
-
 
 try:
     try:
@@ -178,13 +177,11 @@ def print_seen():
     for device_type in sorted({device_type for device_type, _ in seen_failed}):
         expected_failures[device_type]
         nl = "\n"
-        print(
-            f"""
+        print(f"""
 inductor_expected_failures_single_sample[\"{device_type}\"] = {{
 {nl.join(expected_failures[device_type])}
 }}
-"""
-        )
+""")
 
 
 if COLLECT_EXPECT:
@@ -311,7 +308,6 @@ intentionally_not_handled = {
 # This is only fixed when this config is set
 # We should eventually always turn it on
 import torch._functorch.config as functorch_config
-
 
 if not functorch_config.view_replay_for_aliased_outputs:
     intentionally_not_handled['("as_strided", "partial_views")'] = {
@@ -1372,7 +1368,9 @@ class TestInductorOpInfo(TestCase):
             in inductor_expected_failures_single_sample[device_type].get(op_name, set())
         ) or dtype in inductor_gradient_expected_failures_single_sample[
             device_type
-        ].get(op_name, set()):
+        ].get(
+            op_name, set()
+        ):
             test_expect = ExpectedTestResult.XFAILURE
         else:
             test_expect = ExpectedTestResult.SUCCESS  # noqa: F841

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -175,7 +175,7 @@ def print_seen():
                 f"    {format_op(op)}: {fmt_dtypes(failed_dtypes)},{reasons}"
             )
 
-    for device_type in sorted({device_type for device_type, _ in seen_failed}):
+    for device_type in sorted({dt for dt, _ in seen_failed}):
         expected_failures[device_type]
         nl = "\n"
         print(f"""

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -33,22 +33,22 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
-    HardwareClassification,
     IS_ARM64,
     IS_CI,
     IS_LINUX,
     IS_MACOS,
     IS_WINDOWS,
     IS_X86,
-    isRocmArchAnyOf,
     MI200_ARCH,
+    TEST_MKL,
+    TEST_WITH_ASAN,
+    TEST_WITH_ROCM,
+    HardwareClassification,
+    isRocmArchAnyOf,
     skipCUDAMemoryLeakCheckIf,
     skipIfCrossRef,
     skipIfTorchDynamo,
     suppress_warnings,
-    TEST_MKL,
-    TEST_WITH_ASAN,
-    TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
     HAS_CPU,
@@ -1386,7 +1386,7 @@ class TestInductorOpInfo(TestCase):
         )
         if (
             TEST_WITH_ROCM
-            and device_type == self.device_type
+            and device_type != "cpu"
             and op_name == "addmm"
             and dtype is f16
             and isRocmArchAnyOf(MI200_ARCH)
@@ -1532,11 +1532,11 @@ class TestInductorOpInfo(TestCase):
                             adjusted_kwargs.update(
                                 copy_to_gpu=False,
                             )
-                            if device_type == self.device_type:
+                            if device_type != "cpu":
                                 adjusted_kwargs["reference_in_float"] = False
 
                         # skip checking gradient on CPU for now
-                        if device_type == self.device_type:
+                        if device_type != "cpu":
                             # Only check gradients if there are input tensors requiring gradients
                             has_grad_inputs = any(
                                 getattr(x, "requires_grad", False)
@@ -1560,7 +1560,7 @@ class TestInductorOpInfo(TestCase):
                         # XPU has additional layout optimizations that change strides differently from eager mode.
                         if exact_stride and self.device_type == "xpu":
                             exact_stride = op_name not in inductor_skip_exact_stride_xpu
-                        if device_type == self.device_type:
+                        if device_type != "cpu":
                             self.check_model_gpu(
                                 fn,
                                 args,

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -23,10 +23,13 @@ from torch._subclasses.fake_tensor import (
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    onlyAccelerator,
+    onlyNativeDeviceTypes,
     OpDTypes,
     ops,
+    skipCPUIf,
+    skipCUDAIf,
     skipOps,
+    skipXPUIf,
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
@@ -48,6 +51,9 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
+    HAS_CPU,
+    HAS_CUDA_AND_TRITON,
+    HAS_XPU_AND_TRITON,
     has_triton,
     maybe_skip_size_asserts,
 )
@@ -1297,12 +1303,17 @@ class TestInductorOpInfo(TestCase):
     check_model = check_model
     check_model_gpu = check_model_gpu
 
-    @onlyAccelerator
+    @onlyNativeDeviceTypes
     @suppress_warnings
     @skipCUDAMemoryLeakCheckIf(
         True
     )  # inductor kernels failing this test intermittently
-    @unittest.skipUnless(has_triton(), "Skipped! Triton not found")
+    @skipCUDAIf(not HAS_CUDA_AND_TRITON, "Skipped! Triton not found")
+    @skipXPUIf(
+        not HAS_XPU_AND_TRITON, "Skipped! Supported XPU compiler and Triton not found"
+    )
+    @skipCPUIf(not HAS_CPU, "Skipped! Supported CPU compiler not found")
+    @skipCPUIf(IS_MACOS, "Skipped under macOS")
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfTorchDynamo("Test uses dynamo already")
     @skipIfCrossRef
@@ -1583,9 +1594,7 @@ class TestInductorOpInfo(TestCase):
         #     print(f"SUCCEEDED OP {op_name} on {device_type} with {dtype}", flush=True, file=f)
 
 
-instantiate_device_type_tests(
-    TestInductorOpInfo, globals(), allow_xpu=True, except_for="cpu"
-)
+instantiate_device_type_tests(TestInductorOpInfo, globals(), allow_xpu=True)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -169,7 +169,7 @@ def print_seen():
                 f"    {format_op(op)}: {fmt_dtypes(failed_dtypes)},{reasons}"
             )
 
-    for device_type in sorted(set(dtype for (dtype, _) in seen_failed.keys())):
+    for device_type in sorted({device_type for device_type, _ in seen_failed}):
         expected_failures[device_type]
         nl = "\n"
         print(

--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -23,13 +23,10 @@ from torch._subclasses.fake_tensor import (
 from torch.testing._internal.common_cuda import SM80OrLater
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    onlyNativeDeviceTypes,
+    onlyAccelerator,
     OpDTypes,
     ops,
-    skipCPUIf,
-    skipCUDAIf,
     skipOps,
-    skipXPUIf,
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
@@ -51,11 +48,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
 )
 from torch.testing._internal.inductor_utils import (
-    GPU_TYPE,
-    HAS_CPU,
-    HAS_CUDA_AND_TRITON,
     has_triton,
-    HAS_XPU_AND_TRITON,
     maybe_skip_size_asserts,
 )
 from torch.utils._dtype_abbrs import dtype_abbrs
@@ -176,7 +169,7 @@ def print_seen():
                 f"    {format_op(op)}: {fmt_dtypes(failed_dtypes)},{reasons}"
             )
 
-    for device_type in ("cpu", GPU_TYPE):
+    for device_type in sorted(set(dtype for (dtype, _) in seen_failed.keys())):
         expected_failures[device_type]
         nl = "\n"
         print(
@@ -1304,17 +1297,12 @@ class TestInductorOpInfo(TestCase):
     check_model = check_model
     check_model_gpu = check_model_gpu
 
-    @onlyNativeDeviceTypes
+    @onlyAccelerator
     @suppress_warnings
     @skipCUDAMemoryLeakCheckIf(
         True
     )  # inductor kernels failing this test intermittently
-    @skipCUDAIf(not HAS_CUDA_AND_TRITON, "Skipped! Triton not found")
-    @skipXPUIf(
-        not HAS_XPU_AND_TRITON, "Skipped! Supported XPU compiler and Triton not found"
-    )
-    @skipCPUIf(not HAS_CPU, "Skipped! Supported CPU compiler not found")
-    @skipCPUIf(IS_MACOS, "Skipped under macOS")
+    @unittest.skipUnless(has_triton(), "Skipped! Triton not found")
     @unittest.skipIf(TEST_WITH_ASAN, "Skipped under ASAN")
     @skipIfTorchDynamo("Test uses dynamo already")
     @skipIfCrossRef
@@ -1329,7 +1317,7 @@ class TestInductorOpInfo(TestCase):
     def test_comprehensive(self, device, dtype, op):
         device_type = torch.device(device).type
 
-        if device_type not in (GPU_TYPE, "cpu"):
+        if device_type not in (self.device_type, "cpu"):
             raise AssertionError(f"Unexpected device_type: {device_type}")
 
         torch._dynamo.reset()
@@ -1387,7 +1375,7 @@ class TestInductorOpInfo(TestCase):
         )
         if (
             TEST_WITH_ROCM
-            and device_type == GPU_TYPE
+            and device_type == self.device_type
             and op_name == "addmm"
             and dtype is f16
             and isRocmArchAnyOf(MI200_ARCH)
@@ -1533,11 +1521,11 @@ class TestInductorOpInfo(TestCase):
                             adjusted_kwargs.update(
                                 copy_to_gpu=False,
                             )
-                            if device_type == GPU_TYPE:
+                            if device_type == self.device_type:
                                 adjusted_kwargs["reference_in_float"] = False
 
                         # skip checking gradient on CPU for now
-                        if device_type == GPU_TYPE:
+                        if device_type == self.device_type:
                             # Only check gradients if there are input tensors requiring gradients
                             has_grad_inputs = any(
                                 getattr(x, "requires_grad", False)
@@ -1559,9 +1547,9 @@ class TestInductorOpInfo(TestCase):
                         if exact_stride and device_type == "cpu":
                             exact_stride = op_name not in inductor_skip_exact_stride_cpu
                         # XPU has additional layout optimizations that change strides differently from eager mode.
-                        if exact_stride and GPU_TYPE == "xpu":
+                        if exact_stride and self.device_type == "xpu":
                             exact_stride = op_name not in inductor_skip_exact_stride_xpu
-                        if device_type == GPU_TYPE:
+                        if device_type == self.device_type:
                             self.check_model_gpu(
                                 fn,
                                 args,
@@ -1595,7 +1583,9 @@ class TestInductorOpInfo(TestCase):
         #     print(f"SUCCEEDED OP {op_name} on {device_type} with {dtype}", flush=True, file=f)
 
 
-instantiate_device_type_tests(TestInductorOpInfo, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestInductorOpInfo, globals(), allow_xpu=True, except_for="cpu"
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
- Add `hw_classification = HardwareClassification.ACCELERATOR` to `TestInductorOpInfo`
- Wire up `instantiate_device_type_tests` for multi-accelerator (CUDA / XPU / out-of-tree privateuse1) test instantiation

This PR started as a metadata-only labeling change, but per review feedback it now also includes the following device-decoupling adjustments to the test file, listed here for transparency:

- Replace `GPU_TYPE` global references with `self.device_type`-based checks
- Remove the `HAS_CUDA_AND_TRITON` / `HAS_XPU_AND_TRITON` module constants; collapse `@skipCUDAIf(...)` + `@skipXPUIf(...)` into a single `@skipIf(not has_triton(), "Skipped! Triton not found", device_type=("cuda", "xpu"))` (per @fffrog's suggestion)
- Merge per-backend `torch.cuda.empty_cache()` / `torch.xpu.empty_cache()` into `torch.accelerator.empty_cache()` (no-op for CPU variants; also fixes an old `elif device == "xpu"` branch that compared the full device string instead of the device type)
- Remove the redundant `device_type not in (GPU_TYPE, "cpu")` guard in `test_comprehensive`
- Generalize the `COLLECT_EXPECT` debug output to derive device types from `seen_failed` instead of a hardcoded accelerator guess

Known behavior notes:
- `device_type != "cpu"` checks now cover all accelerator variants (previously only the single detected GPU type) — intentional direction of the device-agnostic refactoring.
- `has_triton()` is a global (any-device) capability check, so per-device Triton capability distinction is deferred to a follow-up deep-refactoring PR, as agreed with @lizhihai137 during the Aug-25 review round.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo