### PR TITLE
Add hw_classification labels and instantiate_device_type_tests migration to codegen dynamic shapes tests

### DIFF
--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -12,16 +12,14 @@ from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
-    HardwareClassification,
     IS_LINUX,
     MI350_ARCH,
-    skipIfRocmArch,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
+    HardwareClassification,
+    skipIfRocmArch,
 )
-from torch.testing._internal.inductor_utils import (
-    _check_has_dynamic_shape,
-)
+from torch.testing._internal.inductor_utils import _check_has_dynamic_shape
 
 
 importlib.import_module("filelock")
@@ -30,12 +28,12 @@ importlib.import_module("filelock")
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
-    add_test_failures,
     CommonTemplate,
+    TestFailure,
+    add_test_failures,
     make_compile_fx_wrapper_with_dynamic_dim_assertions,
     run_and_get_cpp_code,
     run_and_get_triton_code,
-    TestFailure,
 )
 from inductor.test_torchinductor_dynamic_shapes import (  # @manual
     make_dynamic_cls,
@@ -725,9 +723,7 @@ def _apply_test_failures_to_subclasses(prefix, scope, test_failures):
             _apply_test_failures(scope[name], test_failures)
 
 
-_copy_template_tests(
-    DynamicShapesCodegenCommonTemplate, DynamicShapesCodegenCpuTests
-)
+_copy_template_tests(DynamicShapesCodegenCommonTemplate, DynamicShapesCodegenCpuTests)
 
 _apply_test_failures(DynamicShapesCodegenCpuTests, test_failures)
 
@@ -754,9 +750,9 @@ if not TEST_WITH_ASAN:
             cls, "test_randint_distribution_dynamic_shapes"
         ):
             # gfx950 randint64 distribution mismatch for high bounds.
-            cls.test_randint_distribution_dynamic_shapes = skipIfRocmArch(
-                MI350_ARCH
-            )(cls.test_randint_distribution_dynamic_shapes)
+            cls.test_randint_distribution_dynamic_shapes = skipIfRocmArch(MI350_ARCH)(
+                cls.test_randint_distribution_dynamic_shapes
+            )
 else:
     del DynamicShapesCodegenGPUTests
 

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import _check_has_dynamic_shape
 
+
 importlib.import_module("filelock")
 
 # Make the helper files in test/ importable

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -8,6 +8,7 @@ import torch
 from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     MI350_ARCH,
     skipIfRocmArch,
@@ -536,6 +537,7 @@ class DynamicShapesCodegenTestCase(TestCase):
 if HAS_CPU:
 
     class DynamicShapesCodegenCpuTests(TestCase):
+        hw_classification = HardwareClassification.CPU
         maxDiff = None
         device = "cpu"
 
@@ -656,6 +658,7 @@ if HAS_CPU:
 if HAS_GPU and not TEST_WITH_ASAN:
 
     class DynamicShapesCodegenGPUTests(DynamicShapesCodegenTestCase):
+        hw_classification = HardwareClassification.CUDA
         maxDiff = None
         device = GPU_TYPE
 

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -12,15 +12,14 @@ from torch._inductor import config
 from torch._inductor.test_case import TestCase
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_LINUX,
     MI350_ARCH,
+    skipIfRocmArch,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
-    HardwareClassification,
-    skipIfRocmArch,
 )
 from torch.testing._internal.inductor_utils import _check_has_dynamic_shape
-
 
 importlib.import_module("filelock")
 
@@ -28,12 +27,12 @@ importlib.import_module("filelock")
 pytorch_test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(pytorch_test_dir)
 from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
-    CommonTemplate,
-    TestFailure,
     add_test_failures,
+    CommonTemplate,
     make_compile_fx_wrapper_with_dynamic_dim_assertions,
     run_and_get_cpp_code,
     run_and_get_triton_code,
+    TestFailure,
 )
 from inductor.test_torchinductor_dynamic_shapes import (  # @manual
     make_dynamic_cls,

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -1,12 +1,16 @@
 # Owner(s): ["module: inductor"]
 import contextlib
+import copy
+import functools
 import importlib
 import os
 import sys
+import unittest
 
 import torch
 from torch._inductor import config
 from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_LINUX,
@@ -17,9 +21,6 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import (
     _check_has_dynamic_shape,
-    GPU_TYPE,
-    HAS_CPU,
-    HAS_GPU,
 )
 
 
@@ -31,7 +32,6 @@ sys.path.append(pytorch_test_dir)
 from inductor.test_torchinductor import (  # @manual=fbcode//caffe2/test/inductor:test_inductor-library
     add_test_failures,
     CommonTemplate,
-    copy_tests,
     make_compile_fx_wrapper_with_dynamic_dim_assertions,
     run_and_get_cpp_code,
     run_and_get_triton_code,
@@ -504,7 +504,7 @@ if not TEST_WITH_ROCM:
     test_failures.update(
         {
             "test_custom_op_fixed_layout_sequential_dynamic_shapes": TestFailure(
-                ("cuda") if IS_LINUX else ("cpu", "cuda", "xpu")
+                ("cuda",) if IS_LINUX else ("cpu", "cuda", "xpu")
             ),
         }
     )
@@ -533,174 +533,247 @@ class DynamicShapesCodegenTestCase(TestCase):
         cls._triton_assert_stack.close()
         super().tearDownClass()
 
+    @property
+    def device(self):
+        return self.device_type
 
-if HAS_CPU:
 
-    class DynamicShapesCodegenCpuTests(TestCase):
-        hw_classification = HardwareClassification.CPU
-        maxDiff = None
-        device = "cpu"
+def _copy_template_tests(template_cls, target_cls):
+    for name, value in template_cls.__dict__.items():
+        if name.startswith("test_") and callable(value):
 
-        @torch._dynamo.config.patch(assume_static_by_default=False)
-        def test_assert_dynamic_dims_rejects_specialized_dim(self):
-            def fn(x):
-                if x.size(0) == 3:
-                    return x + 1
-                return x - 1
+            @functools.wraps(value)
+            def new_test(self, value=value):
+                return value(self)
 
-            with self.assertRaisesRegex(
-                torch._dynamo.exc.BackendCompilerFailed,
-                "Expected user tensor input 0 dim 0 to be dynamic",
-            ):
-                self.common(
-                    fn,
-                    (torch.randn(3, 4),),
-                    assert_dynamic_dims={0: (0, 1)},
-                )
+            new_test.__dict__ = copy.deepcopy(value.__dict__)
+            setattr(target_cls, name, new_test)
+    if hasattr(template_cls, "is_dtype_supported"):
+        target_cls.is_dtype_supported = template_cls.is_dtype_supported
 
-        @torch._dynamo.config.patch(assume_static_by_default=False)
-        def test_assert_dynamic_dims_indexes_user_inputs_not_parameters(self):
-            class Model(torch.nn.Module):
-                def __init__(self):
-                    super().__init__()
-                    self.weight = torch.nn.Parameter(torch.randn(4))
-                    self.register_buffer("bias", torch.randn(4))
 
-                def forward(self, x):
-                    return x + self.weight + self.bias
+def _apply_test_failures(test_cls, test_failures):
+    cls_device_type = getattr(test_cls, "device_type", None)
+    if cls_device_type is None:
+        return
 
+    suffix = f"_{cls_device_type}"
+    for name in dir(test_cls):
+        if not name.startswith("test_") or not name.endswith(suffix):
+            continue
+        value = getattr(test_cls, name)
+        if not callable(value):
+            continue
+        base_name = name[: -len(suffix)]
+        tf = test_failures.get(base_name)
+        if not tf or cls_device_type not in tf.suffixes:
+            continue
+
+        if tf.is_skip:
+            wrapped = unittest.skip("Skipped!")(value)
+        else:
+            # unittest.expectedFailure modifies the function in-place, so we
+            # create a wrapper first to avoid affecting other classes that
+            # share the same method object.
+            @functools.wraps(value)
+            def new_test(self, fn=value):
+                return fn(self)
+
+            new_test.__dict__ = copy.deepcopy(value.__dict__)
+            wrapped = unittest.expectedFailure(new_test)
+        setattr(test_cls, name, wrapped)
+
+
+class DynamicShapesCodegenCpuTests(DynamicShapesCodegenTestCase):
+    hw_classification = HardwareClassification.GENERIC
+    maxDiff = None
+
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_assert_dynamic_dims_rejects_specialized_dim(self):
+        def fn(x):
+            if x.size(0) == 3:
+                return x + 1
+            return x - 1
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.BackendCompilerFailed,
+            "Expected user tensor input 0 dim 0 to be dynamic",
+        ):
             self.common(
-                Model(),
+                fn,
                 (torch.randn(3, 4),),
+                assert_dynamic_dims={0: (0, 1)},
+            )
+
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_assert_dynamic_dims_indexes_user_inputs_not_parameters(self):
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(4))
+                self.register_buffer("bias", torch.randn(4))
+
+            def forward(self, x):
+                return x + self.weight + self.bias
+
+        self.common(
+            Model(),
+            (torch.randn(3, 4),),
+            assert_dynamic_dims={0: (0,)},
+        )
+
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_assert_dynamic_dims_preserves_keyword_input_order(self):
+        def fn(*, z, a):
+            if z.size(0) == 3:
+                return z.sum() + a
+            return z.sum() - a
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.BackendCompilerFailed,
+            "Expected user tensor input 0 dim 0 to be dynamic",
+        ):
+            self.common(
+                fn,
+                (),
+                kwargs={"z": torch.randn(3, 4), "a": torch.randn(5, 4)},
                 assert_dynamic_dims={0: (0,)},
             )
 
-        @torch._dynamo.config.patch(assume_static_by_default=False)
-        def test_assert_dynamic_dims_preserves_keyword_input_order(self):
-            def fn(*, z, a):
-                if z.size(0) == 3:
-                    return z.sum() + a
-                return z.sum() - a
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_assert_dynamic_dims_rejects_eliminated_input(self):
+        def fn(x, y):
+            return y + 1
 
-            with self.assertRaisesRegex(
-                torch._dynamo.exc.BackendCompilerFailed,
-                "Expected user tensor input 0 dim 0 to be dynamic",
-            ):
-                self.common(
-                    fn,
-                    (),
-                    kwargs={"z": torch.randn(3, 4), "a": torch.randn(5, 4)},
-                    assert_dynamic_dims={0: (0,)},
-                )
-
-        @torch._dynamo.config.patch(assume_static_by_default=False)
-        def test_assert_dynamic_dims_rejects_eliminated_input(self):
-            def fn(x, y):
-                return y + 1
-
-            with self.assertRaisesRegex(
-                torch._dynamo.exc.BackendCompilerFailed,
-                "Expected user tensor input 0 to be present in the Dynamo graph",
-            ):
-                self.common(
-                    fn,
-                    (torch.randn(3, 4), torch.randn(5, 4)),
-                    assert_dynamic_dims={0: (0,)},
-                )
-
-        @torch._dynamo.config.patch(assume_static_by_default=False)
-        def test_assert_dynamic_dims_sorts_positional_inputs_numerically(self):
-            def fn(*xs):
-                result = xs[10].sum()
-                if xs[2].size(0) == 4:
-                    result = result + xs[2].sum()
-                for i, x in enumerate(xs):
-                    if i not in (2, 10):
-                        result = result + x.sum()
-                return result
-
-            with self.assertRaisesRegex(
-                torch._dynamo.exc.BackendCompilerFailed,
-                "Expected user tensor input 2 dim 0 to be dynamic",
-            ):
-                self.common(
-                    fn,
-                    tuple(torch.randn(i + 2, 4) for i in range(11)),
-                    assert_dynamic_dims={2: (0,)},
-                )
-
-        def common(
-            self: TestCase,
-            model,
-            example_inputs,
-            kwargs=None,
-            assert_dynamic_dims=None,
-            **_rest,
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.BackendCompilerFailed,
+            "Expected user tensor input 0 to be present in the Dynamo graph",
         ):
-            return check_codegen(
-                self=self,
-                model=model,
-                example_inputs=example_inputs,
-                device=self.device,
-                kwargs=kwargs,
-                is_cpp_code=torch._inductor.config.cpu_backend == "cpp",
-                assert_dynamic_dims=assert_dynamic_dims,
+            self.common(
+                fn,
+                (torch.randn(3, 4), torch.randn(5, 4)),
+                assert_dynamic_dims={0: (0,)},
             )
 
-    copy_tests(
-        DynamicShapesCodegenCommonTemplate,
-        DynamicShapesCodegenCpuTests,
-        "cpu",
-        test_failures,
-    )
+    @torch._dynamo.config.patch(assume_static_by_default=False)
+    def test_assert_dynamic_dims_sorts_positional_inputs_numerically(self):
+        def fn(*xs):
+            result = xs[10].sum()
+            if xs[2].size(0) == 4:
+                result = result + xs[2].sum()
+            for i, x in enumerate(xs):
+                if i not in (2, 10):
+                    result = result + x.sum()
+            return result
 
-
-if HAS_GPU and not TEST_WITH_ASAN:
-
-    class DynamicShapesCodegenGPUTests(DynamicShapesCodegenTestCase):
-        hw_classification = HardwareClassification.CUDA
-        maxDiff = None
-        device = GPU_TYPE
-
-        def common(
-            self: TestCase,
-            model,
-            example_inputs,
-            kwargs=None,
-            copy_to_gpu=True,
-            assert_dynamic_dims=None,
-            **_rest,
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.BackendCompilerFailed,
+            "Expected user tensor input 2 dim 0 to be dynamic",
         ):
-            return check_codegen(
-                self=self,
-                model=model,
-                example_inputs=example_inputs,
-                device=self.device,
-                kwargs=kwargs,
-                is_cpp_code=False,
-                copy_to_gpu=copy_to_gpu,
-                assert_dynamic_dims=assert_dynamic_dims,
+            self.common(
+                fn,
+                tuple(torch.randn(i + 2, 4) for i in range(11)),
+                assert_dynamic_dims={2: (0,)},
             )
 
-    copy_tests(
-        DynamicShapesCodegenCommonTemplate,
-        DynamicShapesCodegenGPUTests,
-        GPU_TYPE,
-        test_failures,
-    )
-
-    if HAS_GPU and hasattr(
-        DynamicShapesCodegenGPUTests,
-        "test_randint_distribution_dynamic_shapes_cuda",
+    def common(
+        self,
+        model,
+        example_inputs,
+        kwargs=None,
+        assert_dynamic_dims=None,
+        **_rest,
     ):
-        # gfx950 shows a deterministic randint64 distribution mismatch for high bounds.
-        DynamicShapesCodegenGPUTests.test_randint_distribution_dynamic_shapes_cuda = skipIfRocmArch(
-            MI350_ARCH
-        )(DynamicShapesCodegenGPUTests.test_randint_distribution_dynamic_shapes_cuda)
+        return check_codegen(
+            self=self,
+            model=model,
+            example_inputs=example_inputs,
+            device=self.device_type,
+            kwargs=kwargs,
+            is_cpp_code=torch._inductor.config.cpu_backend == "cpp",
+            assert_dynamic_dims=assert_dynamic_dims,
+        )
+
+
+class DynamicShapesCodegenGPUTests(DynamicShapesCodegenTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+    maxDiff = None
+
+    def common(
+        self,
+        model,
+        example_inputs,
+        kwargs=None,
+        copy_to_gpu=True,
+        assert_dynamic_dims=None,
+        **_rest,
+    ):
+        return check_codegen(
+            self=self,
+            model=model,
+            example_inputs=example_inputs,
+            device=self.device_type,
+            kwargs=kwargs,
+            is_cpp_code=False,
+            copy_to_gpu=copy_to_gpu,
+            assert_dynamic_dims=assert_dynamic_dims,
+        )
+
+
+def _apply_test_failures_to_subclasses(prefix, scope, test_failures):
+    for name in list(scope.keys()):
+        if name.startswith(prefix) and name != prefix:
+            _apply_test_failures(scope[name], test_failures)
+
+
+_copy_template_tests(
+    DynamicShapesCodegenCommonTemplate, DynamicShapesCodegenCpuTests
+)
+
+instantiate_device_type_tests(
+    DynamicShapesCodegenCpuTests,
+    globals(),
+    only_for="cpu",
+)
+
+_apply_test_failures_to_subclasses(
+    "DynamicShapesCodegenCpuTests", globals(), test_failures
+)
+
+
+if not TEST_WITH_ASAN:
+    _copy_template_tests(
+        DynamicShapesCodegenCommonTemplate, DynamicShapesCodegenGPUTests
+    )
+
+    instantiate_device_type_tests(
+        DynamicShapesCodegenGPUTests,
+        globals(),
+        only_for=["cuda", "xpu"],
+        allow_xpu=True,
+    )
+
+    _apply_test_failures_to_subclasses(
+        "DynamicShapesCodegenGPUTests", globals(), test_failures
+    )
+
+    for name in list(globals().keys()):
+        cls = globals()[name]
+        if name.startswith("DynamicShapesCodegenGPUTestsCUDA") and hasattr(
+            cls, "test_randint_distribution_dynamic_shapes"
+        ):
+            # gfx950 randint64 distribution mismatch for high bounds.
+            cls.test_randint_distribution_dynamic_shapes = skipIfRocmArch(
+                MI350_ARCH
+            )(cls.test_randint_distribution_dynamic_shapes)
+else:
+    del DynamicShapesCodegenGPUTests
+
+
+del DynamicShapesCodegenCommonTemplate
 
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests
 
-    if HAS_CPU or HAS_GPU:
-        run_tests(needs="filelock")
+    run_tests(needs="filelock")

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -557,15 +557,13 @@ def _apply_test_failures(test_cls, test_failures):
     if cls_device_type is None:
         return
 
-    suffix = f"_{cls_device_type}"
     for name in dir(test_cls):
-        if not name.startswith("test_") or not name.endswith(suffix):
+        if not name.startswith("test_"):
             continue
         value = getattr(test_cls, name)
         if not callable(value):
             continue
-        base_name = name[: -len(suffix)]
-        tf = test_failures.get(base_name)
+        tf = test_failures.get(name)
         if not tf or cls_device_type not in tf.suffixes:
             continue
 
@@ -585,8 +583,9 @@ def _apply_test_failures(test_cls, test_failures):
 
 
 class DynamicShapesCodegenCpuTests(DynamicShapesCodegenTestCase):
-    hw_classification = HardwareClassification.GENERIC
+    hw_classification = HardwareClassification.CPU
     maxDiff = None
+    device_type = "cpu"
 
     @torch._dynamo.config.patch(assume_static_by_default=False)
     def test_assert_dynamic_dims_rejects_specialized_dim(self):
@@ -730,15 +729,7 @@ _copy_template_tests(
     DynamicShapesCodegenCommonTemplate, DynamicShapesCodegenCpuTests
 )
 
-instantiate_device_type_tests(
-    DynamicShapesCodegenCpuTests,
-    globals(),
-    only_for="cpu",
-)
-
-_apply_test_failures_to_subclasses(
-    "DynamicShapesCodegenCpuTests", globals(), test_failures
-)
+_apply_test_failures(DynamicShapesCodegenCpuTests, test_failures)
 
 
 if not TEST_WITH_ASAN:


### PR DESCRIPTION
## Summary

This PR adds `hw_classification` labels to the codegen dynamic-shapes test classes and migrates the GPU tests to `instantiate_device_type_tests`. The CPU tests intentionally stay on the existing `copy_tests` pattern to keep their test IDs stable.

### CPU tests (`DynamicShapesCodegenCpuTests`)

- Add `hw_classification = HardwareClassification.CPU`. The section keeps main's `if HAS_CPU:` guard and `copy_tests(..., "cpu", test_failures)` structure unchanged, so every CPU test keeps its `_cpu`-suffixed ID and `test/slow_tests.json` / disable-test records keyed on those IDs keep matching. Only the label line is added.

### GPU tests (`DynamicShapesCodegenGPUTests`)

- The GPU class is now an instantiation base that inherits `DynamicShapesCodegenCommonTemplate` (its tests are exposed on the generated variant classes through MRO under their original unsuffixed names) and is instantiated via `instantiate_device_type_tests(..., allow_xpu=True, except_for="cpu")` under `if not TEST_WITH_ASAN:`, generating per-device variant classes (e.g. `DynamicShapesCodegenGPUTestsCUDA`, `DynamicShapesCodegenGPUTestsXPU`, and variant classes for privateuse1 accelerators).
- `hw_classification = HardwareClassification.ACCELERATOR`, matching the enum semantics for tests instantiated across multiple accelerators via `instantiate_device_type_tests`.
- `test_failures` (the non-CPU xfail/skip entries, ~159 tests) is re-attached after instantiation: for each entry/device suffix, the unsuffixed template method is looked up on the generated variant class and wrapped with `unittest.skip`/`unittest.expectedFailure` as a per-variant copy, matching `copy_tests` semantics. The per-variant copy is required because `expectedFailure` mutates the test item in place on Python >= 3.12, which would otherwise leak the marker to sibling variants through the shared template method.
- The gfx950 `skipIfRocmArch(MI350_ARCH)` guard for `test_randint_distribution_dynamic_shapes` is applied per variant after instantiation (via MRO the unsuffixed name resolves on every variant).

### Test ID changes (GPU only)

- `test_foo_dynamic_shapes_cuda (__main__.DynamicShapesCodegenGPUTests)` → `test_foo_dynamic_shapes (__main__.DynamicShapesCodegenGPUTestsCUDA)`.
- The two slow-test entries for the GPU classes in `test/slow_tests.json` are updated accordingly; the CPU entries are byte-identical to main.

### Coverage notes

- Pre-PR, `device = GPU_TYPE` could resolve to `mtia`; the `instantiate_device_type_tests` path covers CUDA/XPU/privateuse1 but not MTIA (`HardwareClassification` has no `MTIA` member). MTIA can be added once the enum gains a member.
- Aside from MTIA, accelerator coverage expands: privateuse1 devices (e.g. Ascend NPU) now automatically get variant classes; verified on NPU below.
- Minor latent fix kept from the earlier revision: `("cuda")` → `("cuda",)` in a `TestFailure` suffixes entry (the un-commaed form was a bare string, not a 1-tuple).

### Verification

- Local overlay (torch 2.15.0a0 nightly CPU): test discovery and names equivalent to main for the CPU section (1403 tests, skip/xfail marker counts identical); no test-count explosion; per-variant marker isolation verified.
- Remote NPU environment (torch 2.14.0a0, 4x Ascend NPU): the `DynamicShapesCodegenGPUTestsNPU` variant is generated with `device=npu` / `hw_classification=ACCELERATOR`; 1398 discoverable tests == template test count; 104 `test_failures` markers applied on the NPU variant; the CPU section is equivalent to the pre-PR baseline in both plain and NPU-import modes; smoke tests: direct run passes, a `test_failures` skip sample is skipped, an xfail sample reports expected failure.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo