### PR TITLE
[jit] Skip type-tag restoration for archives at version >= 3 (#194035)

### DIFF
--- a/test/cpp/jit/test_save_load.cpp
+++ b/test/cpp/jit/test_save_load.cpp
@@ -154,6 +154,90 @@ TEST(SerializationTest, TypeTags) {
   }
 }
 
+namespace {
+
+// A class whose __setstate__ takes a precisely typed nested container, so that
+// tag restoration has something observable to correct.
+Module moduleWithNestedListState() {
+  Module m("m");
+  m.define(R"JIT(
+    def __getstate__(self) -> List[List[int]]:
+      return [[1, 2, 3]]
+
+    def __setstate__(self, state: List[List[int]]) -> None:
+      pass
+  )JIT");
+  return m;
+}
+
+// What the unpickler hands to the object loader for an archive that carries no
+// serialized container type strings: the right values, but generic tags.
+c10::impl::GenericList genericallyTaggedNestedList() {
+  auto inner = c10::impl::GenericList(AnyType::get());
+  inner.push_back(1);
+  inner.push_back(2);
+  auto outer = c10::impl::GenericList(AnyType::get());
+  outer.push_back(inner);
+  return outer;
+}
+
+} // namespace
+
+// See [type tag serialization] in unpickler.h. Archives at version 2 or lower
+// carry no container type strings, so the object loader has to re-derive the
+// tags from __setstate__'s schema before __setstate__ can run at all.
+TEST(SerializationTest, ObjLoaderRestoresTypeTagsForLegacyArchive) {
+  auto m = moduleWithNestedListState();
+  at::StrongTypePtr type(m._ivalue()->compilation_unit(), m.type());
+
+  auto outer = genericallyTaggedNestedList();
+  auto inner = outer.get(0).toList();
+
+  ObjLoaderFuncWithVersion(type, IValue(outer), /*archive_version=*/2);
+
+  // Corrected in place, on the nested container as well as the outer one.
+  EXPECT_EQ(*outer.elementType(), *ListType::create(IntType::get()));
+  EXPECT_EQ(*inner.elementType(), *IntType::get());
+}
+
+// The two-argument overload has no version to go on, so it stays on the legacy
+// path. Callers that pass it as an ObjLoader depend on this.
+TEST(SerializationTest, ObjLoaderWithoutVersionRestoresTypeTags) {
+  auto m = moduleWithNestedListState();
+  at::StrongTypePtr type(m._ivalue()->compilation_unit(), m.type());
+
+  auto outer = genericallyTaggedNestedList();
+
+  ObjLoaderFunc(type, IValue(outer));
+
+  EXPECT_EQ(*outer.elementType(), *ListType::create(IntType::get()));
+}
+
+// From version 3 on the unpickler has already applied the serialized type
+// strings, so the loader skips the traversal and passes the state through
+// untouched.
+TEST(SerializationTest, ObjLoaderSkipsTypeTagRestorationForModernArchive) {
+  auto m = moduleWithNestedListState();
+  at::StrongTypePtr type(m._ivalue()->compilation_unit(), m.type());
+
+  // An already-tagged state, which is what a version >= 3 archive produces,
+  // loads without the traversal.
+  auto tagged_inner = c10::impl::GenericList(IntType::get());
+  tagged_inner.push_back(1);
+  auto tagged = c10::impl::GenericList(ListType::create(IntType::get()));
+  tagged.push_back(tagged_inner);
+  ObjLoaderFuncWithVersion(type, IValue(tagged), /*archive_version=*/3);
+  EXPECT_EQ(*tagged.elementType(), *ListType::create(IntType::get()));
+
+  // A generically tagged state is left exactly as it arrived. Nothing corrects
+  // it, so __setstate__'s own type check is what rejects it -- which is why
+  // this path is only safe once the unpickler tags containers eagerly.
+  auto untagged = genericallyTaggedNestedList();
+  EXPECT_ANY_THROW(
+      ObjLoaderFuncWithVersion(type, IValue(untagged), /*archive_version=*/3));
+  EXPECT_EQ(*untagged.elementType(), *AnyType::get());
+}
+
 TEST(SerializationTest, TestJitStream_CUDA) {
   torch::jit::Module model;
   std::vector<torch::jit::IValue> inputs;

--- a/torch/csrc/jit/serialization/import.cpp
+++ b/torch/csrc/jit/serialization/import.cpp
@@ -10,6 +10,7 @@
 #include <ATen/core/functional.h>
 #include <ATen/core/ivalue_inl.h>
 #include <c10/util/Exception.h>
+#include <c10/util/Logging.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/jit/frontend/script_type_parser.h>
 #include <torch/csrc/jit/ir/graph_utils.h>
@@ -29,6 +30,7 @@
 #include <ATen/ATen.h>
 #include <fmt/format.h>
 
+#include <atomic>
 #include <string>
 #include <utility>
 #include <vector>
@@ -65,12 +67,33 @@ static void postSetStateValidate(const IValue& v) {
   }
 }
 
+namespace {
+// Records, once per process, which type-tag recovery path the archives being
+// loaded took. Cheap, and it makes the version gate below observable in a
+// deployed binary instead of having to be inferred from timing.
+void logTypeTagPolicyOnce(uint64_t archive_version, bool restoring) {
+  // A plain atomic rather than a call-once primitive: logging can allocate,
+  // and so can throw, and the standard once-flag is not exception-resilient
+  // in practice (a throwing callable can deadlock it). Losing the line on the
+  // losing thread of a race is fine; deadlocking a model load is not.
+  static std::atomic<bool> logged{false};
+  if (logged.exchange(true, std::memory_order_relaxed)) {
+    return;
+  }
+  LOG(INFO) << "[jit] restoreAccurateTypeTags: archive_version="
+            << archive_version
+            << (restoring ? " -> restoring tags"
+                          : " -> skipped (see [type tag serialization])");
+}
+} // namespace
+
 // Decouple how to get obj from type. In this file it's dependent on
 // Method.run() and graph executor, etc.
 // For bytecode import we need to decouple these dependencies.
-c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
+c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFuncWithVersion(
     const at::StrongTypePtr& type,
-    IValue input) {
+    IValue input,
+    uint64_t archive_version) {
   const auto& cls = type.type_->expectRef<at::ClassType>();
   auto qn = cls.name();
   size_t n = cls.numAttributes();
@@ -86,9 +109,20 @@ c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
     // type and may access the tags. Since setstate has a known input type, we
     // can correctly restore the tags now by apply the input type of set_state
     // to the state object being passed.
-    // TODO: Remove once [serialization type tags] is landed
-    restoreAccurateTypeTags(
-        input, set_state.getSchema().arguments().at(1).type());
+    //
+    // See [type tag serialization] in unpickler.h. Only archives at version 2
+    // or lower lack the serialized container type strings; from version 3 on
+    // the unpickler has already applied them through restore_type_tag ->
+    // restoreContainerTypeTags as each container was constructed, so this walk
+    // finds nothing to correct. It is not free: it traverses the whole object
+    // graph reachable from the state, which on a large model runs into
+    // hundreds of millions of nodes and tens of seconds per load.
+    const bool restore_tags = archive_version <= 2;
+    logTypeTagPolicyOnce(archive_version, restore_tags);
+    if (restore_tags) {
+      restoreAccurateTypeTags(
+          input, set_state.getSchema().arguments().at(1).type());
+    }
     set_state({obj, input});
     postSetStateValidate(obj);
     return obj;
@@ -100,6 +134,13 @@ c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
     }
     return obj;
   }
+}
+
+c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
+    const at::StrongTypePtr& type,
+    IValue input) {
+  return ObjLoaderFuncWithVersion(
+      type, std::move(input), /*archive_version=*/0);
 }
 
 namespace {
@@ -173,12 +214,20 @@ IValue ScriptModuleDeserializer::readArchive(const std::string& archive_name) {
     return c10::StrongTypePtr(compilation_unit_, std::move(cls));
   };
 
+  // See [type tag serialization]: the loader needs the archive version to know
+  // whether container type tags still have to be re-derived.
+  const uint64_t archive_version = reader_->version();
+  auto obj_loader = [archive_version](
+                        const at::StrongTypePtr& type, IValue input) {
+    return ObjLoaderFuncWithVersion(type, std::move(input), archive_version);
+  };
+
   return readArchiveAndTensors(
       /*archive_name=*/archive_name,
       /*pickle_prefix=*/pickle_dir_prefix_,
       /*tensor_prefix=*/tensor_dir_prefix_,
       type_resolver,
-      ObjLoaderFunc,
+      obj_loader,
       device_,
       *reader_,
       nullptr,

--- a/torch/csrc/jit/serialization/import.h
+++ b/torch/csrc/jit/serialization/import.h
@@ -140,8 +140,22 @@ TORCH_API Module load_jit_module_from_stream(
     ExtraFilesMap& extra_files,
     std::optional<at::Device> device = std::nullopt);
 
+// Equivalent to ObjLoaderFuncWithVersion with an unknown archive version, i.e.
+// container type tags are always re-derived. Kept with this exact signature so
+// it continues to convert to ObjLoader.
 TORCH_API c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFunc(
     const at::StrongTypePtr& type,
     IValue input);
+
+// `archive_version` is the file-format version of the archive being read, as
+// reported by PyTorchStreamReader::version(). See [type tag serialization] in
+// unpickler.h: for version >= 3 the archive carries container type strings and
+// the unpickler applies them as each container is built, so re-deriving them
+// here is unnecessary and can cost tens of seconds on a large model. Pass 0 if
+// the version is unknown, which conservatively keeps the historical behaviour.
+TORCH_API c10::intrusive_ptr<c10::ivalue::Object> ObjLoaderFuncWithVersion(
+    const at::StrongTypePtr& type,
+    IValue input,
+    uint64_t archive_version);
 
 } // namespace torch::jit


### PR DESCRIPTION
Summary:

`ObjLoaderFunc` calls `restoreAccurateTypeTags` on every pickled object that
has a `__setstate__`, unconditionally. For modern archives that call finds
nothing to correct, and it is extremely expensive.

Per [type tag serialization] (`unpickler.h`), the two tag-recovery paths are
mutually exclusive:

- **version <= 2**: recover tags by recursively descending the object graph.
- **version >= 3**: the archive carries container type strings, and the
  unpickler applies them as each container is constructed
  (`restore_type_tag` -> `restoreContainerTypeTags`, `unpickler.cpp`).

`Unpickler::parse_ivalue` already gates its own call on `version_ <= 2`.
`ObjLoaderFunc` never got the same gate, most likely because its signature had
no way to see the archive version.

## Shape of the change

`ObjLoaderFunc` keeps its **exact existing signature**, so it still converts to
`ObjLoader` and every current caller is untouched. A new
`ObjLoaderFuncWithVersion` takes the archive version and applies the gate;
`ObjLoaderFunc` delegates to it with 0 ("unknown"), which is `<= 2` and so
preserves today's behaviour. Only `ScriptModuleDeserializer::readArchive`
opts in, passing `reader_->version()`.

An earlier revision of this diff instead added a defaulted third parameter to
`ObjLoaderFunc`. That is subtly wrong: default arguments are not part of a
function's type, so the two-argument `ObjLoader` conversion stops working. It
broke `caffe2/torch/fb/distributed/wireSerializer` (`WireSerializer.cpp:366`),
which was caught by a ServiceLab build. The current shape avoids the problem by
not touching the existing signature at all.

## Why it matters

Measured on the CG1 Sigrid predictor (tenant m2125804315), Cogwheel workload
`cogwheel_ipnext_cw_inplace_stream_m2125804315_slatest_default_cg1`,
ServiceLab E1727110318567547:

```
[RESTORE_TAGS] big_call works=1280000009 ptr_works=320000004 scanned=320000004 ms=45442
  root_type=Tuple[Tuple[int, float, float, List[Tuple[int, int, int]]], Optional[int], Tensor]
[RESTORE_TAGS] big_call kinds: TensorType:1 TupleType:320000002 ListType:1 FloatType:2 IntType:960000002 OptionalType:1
[RESTORE_TAGS] big_call tags list_ptr_eq=0 list_struct_eq=1 list_differs=0 dict_ptr_eq=0 dict_struct_eq=0 dict_differs=0
```

One `List[Tuple[int, int, int]]` holding 320M tuples. The traversal processes
**1.28 billion** work items, at **45 s per model load**, three loads per test.
Its entire useful output is setting the element type on that one list, to the
value it already had.

The decisive number is `list_differs=0` / `dict_differs=0`, holding on every
call, cumulatively across all 16 calls, on both sides of an A/A run: **no
container needed retagging**. The v>=3 path had already done the work.

## Safety

- The condition is identical to the one `unpickler.cpp` has used for years.
- Every existing caller keeps the old behaviour; only the ScriptModule load
  path opts in.
- `logTypeTagPolicyOnce` emits one INFO line recording the archive version and
  which path was taken, so the gate is observable in a deployed binary rather
  than having to be inferred from timing.
- If the gate were ever wrong it fails loudly and immediately: a container
  arrives as `List[Any]` and `__setstate__`'s type check rejects it at load
  time, rather than silently mistagging.

Related: D115295360 changed the container inside this function and made it
2.73x slower (115 s vs 42 s per load); D116346069 reverts that. This diff
removes the call for modern archives, which subsumes the problem on that path.

Test Plan:
## Tests

Three cases in `caffe2/test/cpp/jit/test_save_load.cpp`, next to the existing
`SerializationTest.TypeTags`. Added in response to review: the version <= 2
branch had no coverage.

- `ObjLoaderRestoresTypeTagsForLegacyArchive` -- feeds the loader the shape an
  unpickled version <= 2 archive produces (right values, `List[Any]` tags) and
  asserts the tags are corrected in place, on the nested container as well as
  the outer one. This is the branch the review asked about.
- `ObjLoaderWithoutVersionRestoresTypeTags` -- the two-argument `ObjLoaderFunc`
  has no version to go on and must stay on the legacy path. This pins the
  compatibility promise that existing `ObjLoader` callers depend on.
- `ObjLoaderSkipsTypeTagRestorationForModernArchive` -- an already-tagged state
  (what a version >= 3 archive produces) loads untouched; a generically tagged
  one is passed through unchanged, so `__setstate__`'s own type check rejects
  it. That second half is what makes the skip observable, and documents that
  the path is only safe because the unpickler tags containers eagerly.

`test_save_load.cpp` is already listed in both `BUCK` and `CMakeLists.txt`, so
no build-file change was needed and OSS CI picks the cases up.

## How they were verified

**The shared gtest binary could not run them.**
`//caffe2/test/cpp/jit:jit` segfaults during static initialization, before any
test body executes. This is pre-existing and unrelated to this diff -- it
reproduces on an unmodified tree, and a filter matching *zero* tests segfaults
identically:

```
$ ./jit --gtest_filter=ThisMatchesNothingAtAll ; echo $?
Segmentation fault
139
$ ./jit --gtest_list_tests ; echo $?
Segmentation fault
139
```

So the assertions were validated by a standalone binary linking
`//caffe2:torch-cpp` and running the same three scenarios:

```
[version 2: legacy archive, tags restored]
  PASS  outer element type   got=List[int]   want=List[int]
  PASS  inner element type   got=int   want=int
[no version: two-arg overload keeps legacy behaviour]
  PASS  outer element type   got=List[int]   want=List[int]
[version 3: modern archive, traversal skipped]
  PASS  already-tagged state loads without throwing
  PASS  tagged element type unchanged   got=List[int]   want=List[int]
  PASS  generically tagged state is rejected by __setstate__
  PASS  untagged element type left alone   got=Any   want=Any

ALL CHECKS PASSED
```

**Mutation check.** To confirm the legacy case actually exercises the gate
rather than passing trivially, the gate was temporarily broken
(`archive_version <= 2` -> `<= 1`, so version 2 takes the skip path) and the
same binary re-run. It fails, in exactly the way the production code would:

```
__setstate__() Expected a value of type 'List[List[int]]' for argument 'state'
but instead found type 'List[Any]'.
Declaration: __setstate__(__torch__.m self, int[][] state) -> NoneType
# 6  torch::jit::ObjLoaderFuncWithVersion(...)
```

The mutation was reverted and the binary re-run clean before submitting.

To be explicit about the gap: the cases are correct and their logic is
verified, but I have not been able to watch them execute under gtest itself
because of the pre-existing crash in that target. OSS CI will be the first
gtest run.

## Build

Clean, exit code captured directly rather than through a pipe. Includes
`wire_serializer`, which an earlier revision of this diff broke:

```
$ buck2 build fbcode//mode/opt fbcode//caffe2:_libtorch \
    fbcode//caffe2/torch/fb/distributed/wireSerializer:wire_serializer > /tmp/b.log 2>&1; echo "REAL_EXIT=$?"
REAL_EXIT=0
```

`arc lint -e extra` reports nothing on the files this diff touches. The two
remaining CLANGTIDY findings (`bugprone-unchecked-optional-access`,
`clang-diagnostic-range-loop-bind-reference`) are pre-existing in
`recreateObject` and are not touched here.

## Cogwheel A/B vs current prod

ServiceLab **E2105961143339521**, workload
`cogwheel_ipnext_cw_inplace_stream_m2125804315_slatest_default_cg1`,
side A = current prod, side B = this diff.

```
[PASSED] [Test Suite] (1417.27s)
[PASSED] test_predictor_ab_response_checker (732.69s)
```

Gate fired, and only on side B, which also proves the candidate binary bound:

```
side b: I0818 18:31:47 import.cpp:77] [jit] restoreAccurateTypeTags: archive_version=4 -> skipped (see [type tag serialization])
side a: (no such line - prod does not carry this change)
```

Startup, measured from `parseSubmodToUVMString` to `Setting fb303 status to ALIVE`:

| side | marker | ALIVE | elapsed |
|---|---|---|---|
| A (current prod) | 18:31:22.220 | 18:35:00.502 | 218.3 s |
| B (this diff) | 18:31:22.199 | 18:33:11.366 | **109.2 s** |

**109.1 s faster per cold start.** Response correctness is unchanged --
`test_predictor_ab_response_checker` compares side B's outputs against prod and
passed, which is the check that would catch a container left mistagged.

For reference, the same measurement from E2245630172674916, which A/B'd the two
containers with identical instrumentation:

| config | parseSubmod -> ALIVE |
|---|---|
| `std::unordered_set` (what D116346069 restores) | 147.4 s |
| `c10::FastSet` (master) | 218.6 s |
| current prod | 218.3 s |
| **this diff** | **109.2 s** |

Two things follow. Current prod's startup profile matches the `c10::FastSet`
arm rather than the `std::unordered_set` arm, so prod is already carrying the
D115295360 regression. And skipping the call outright is ~38 s better than
reverting the container, because it removes the whole traversal rather than
making it cheaper.

Differential Revision: D116540489


