### PR TITLE
[Testcase Refactoring] Register attention.flex_attention capability

### DIFF
--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -348,6 +348,7 @@ class Capability:
 
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
+        flex_attention = "attention.flex_attention"
 
 
 class DeviceTypeTestBase(TestCase):
@@ -793,6 +794,9 @@ class CPUTestBase(DeviceTypeTestBase):
             Capability.dtype.bf16: lambda: True,
             Capability.attention.flash_attention: lambda: True,
             Capability.attention.mem_efficient_attention: lambda: False,
+            Capability.attention.flex_attention: lambda: (
+                IS_FLEX_ATTENTION_CPU_PLATFORM_SUPPORTED
+            ),
         }
 
 
@@ -820,8 +824,15 @@ class CUDATestBase(DeviceTypeTestBase):
         return {
             Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
             Capability.dtype.bf16: lambda: SM80OrLater,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-            Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            Capability.attention.flash_attention: lambda: (
+                PLATFORM_SUPPORTS_FLASH_ATTENTION
+            ),
+            Capability.attention.mem_efficient_attention: lambda: (
+                PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
+            ),
+            Capability.attention.flex_attention: lambda: (
+                IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED
+            ),
         }
 
     @classmethod
@@ -907,6 +918,9 @@ class MPSTestBase(DeviceTypeTestBase):
             Capability.dtype.bf16: lambda: True,
             Capability.attention.flash_attention: lambda: False,
             Capability.attention.mem_efficient_attention: lambda: False,
+            Capability.attention.flex_attention: lambda: (
+                IS_FLEX_ATTENTION_MPS_PLATFORM_SUPPORTED
+            ),
         }
 
 
@@ -923,8 +937,13 @@ class XPUTestBase(DeviceTypeTestBase):
         return {
             Capability.dtype.fp8: lambda: True,
             Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+            Capability.attention.flash_attention: lambda: (
+                PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU
+            ),
             Capability.attention.mem_efficient_attention: lambda: True,
+            Capability.attention.flex_attention: lambda: (
+                IS_FLEX_ATTENTION_XPU_PLATFORM_SUPPORTED
+            ),
         }
 
     @classmethod
@@ -1040,9 +1059,7 @@ device_type_test_bases = get_device_type_test_bases()
 
 def filter_desired_device_types(device_type_test_bases, except_for=None, only_for=None):
     # device type cannot appear in both except_for and only_for
-    intersect = set(except_for if except_for else []) & set(
-        only_for if only_for else []
-    )
+    intersect = set(except_for or []) & set(only_for or [])
     if intersect:
         raise AssertionError(
             f"device ({intersect}) appeared in both except_for and only_for"


### PR DESCRIPTION
### Summary

The Capability-based test skip mechanism (#190846) registered
dtype.fp8, dtype.bf16, attention.flash_attention, and
attention.mem_efficient_attention, but attention.flex_attention -- referenced by
downstream test refactoring efforts -- was never defined, causing
ImportError and SkipTest failures.

This change registers the missing capability:

- Capability.attention.flex_attention: wraps the existing
  IS_FLEX_ATTENTION_*_PLATFORM_SUPPORTED checks; replaces
  flex_attention_supported_platform

### Changes

1. Add flex_attention to Capability.attention
2. Register it in _capabilities() on CPUTestBase, CUDATestBase,
   MPSTestBase, and XPUTestBase with per-device lambdas

### Test Plan

```
python -c 'from torch.testing._internal.common_device_type import Capability; print(Capability.attention.flex_attention)'
python -c 'from torch.testing._internal.common_device_type import CPUTestBase; print(sorted(CPUTestBase.get_capabilities().keys()))'
```
