### PR TITLE
[CUDA] Handle empty reflection_pad2d backward outputs

### DIFF
--- a/aten/src/ATen/native/cuda/ReflectionPad.cu
+++ b/aten/src/ATen/native/cuda/ReflectionPad.cu
@@ -667,6 +667,10 @@ void reflection_pad2d_backward_out_template(
       ", Got: ",
       grad_output_.size(dim_h));
 
+  if (grad_output_.numel() == 0) {
+    return;
+  }
+
   Tensor grad_output = grad_output_.contiguous();
 
   int64_t output_plane_size = output_h * output_w;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8928,6 +8928,27 @@ class TestNNDeviceType(NNTestCase):
             # avoid this state leaking outside of this test
             torch.use_deterministic_algorithms(original_deterministic)
 
+    @onlyCUDA
+    @parametrize_test("deterministic", [False, True])
+    def test_ReflectionPad2d_empty_output_backward(self, device, deterministic):
+        original_deterministic = torch.are_deterministic_algorithms_enabled()
+        try:
+            torch.use_deterministic_algorithms(deterministic)
+
+            input_tensor = torch.ones(
+                (2, 2, 4, 4),
+                dtype=torch.float64,
+                device=device,
+                requires_grad=True,
+            )
+            output = F.pad(input_tensor, (0, 0, -4, 0), mode="reflect")
+
+            self.assertEqual(output.shape, (2, 2, 0, 4))
+            output.backward(torch.empty_like(output))
+            self.assertEqual(input_tensor.grad, torch.zeros_like(input_tensor))
+        finally:
+            torch.use_deterministic_algorithms(original_deterministic)
+
     @onlyNativeDeviceTypes
     def test_LocalResponseNorm_empty(self, device):
         mod = torch.nn.LocalResponseNorm(2).to(device)


### PR DESCRIPTION
I reviewed the implementation and verification results below. The early return is appropriate because both CUDA backward entry points initialize `grad_input` to zero before invoking the shared template.

> **AI disclosure:** The following description was drafted with Codex and reviewed by a human.
>
> ## Summary
>
> `reflection_pad2d_backward_out_template` can receive an empty `grad_output` when negative padding removes an entire spatial dimension. The CUDA implementation still attempted to configure and launch a backward kernel. In deterministic mode, that kernel could read from an invalid address.
>
> Return after validating the output shape when `grad_output` is empty. Both callers initialize `grad_input` to zero, so the resulting input gradient remains correct.
>
> Add a CUDA regression test covering both deterministic and nondeterministic execution.
>
> Fixes #193694
>
> ## Test plan
>
> ```bash
> python test/test_nn.py TestNNDeviceTypeCUDA.test_ReflectionPad2d_empty_output_backward_deterministic_False_cuda TestNNDeviceTypeCUDA.test_ReflectionPad2d_empty_output_backward_deterministic_True_cuda
> python test/test_nn.py TestNNDeviceTypeCUDA.test_ReflectionPad2d_large_cuda TestNNDeviceTypeCUDA.test_ReflectionPad2d_large_deterministic_cuda
> .venv/bin/spin lint -- --take CLANGFORMAT,CLANGTIDY,RUFF,FLAKE8,PYFMT,SPACES aten/src/ATen/native/cuda/ReflectionPad.cu test/test_nn.py
> ```
>
> The issue reproducer also completed under Compute Sanitizer with `ERROR SUMMARY: 0 errors`.