### PR TITLE
[Dynamo] Return the wrapped type from StreamVariable.python_type

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -220,6 +220,15 @@ class TestStreamsGeneric(torch._dynamo.test_case.TestCase):
             self.assertIn(TestEvent, in_graph_classes)
             self.assertNotIn(DeviceInterface.Stream, in_graph_classes)
             self.assertNotIn(DeviceInterface.Event, in_graph_classes)
+    
+    def test_stream_variable_python_type_uses_wrapped_value_type(self):
+        from torch._dynamo.variables.streams import StreamVariable
+
+        class FakeStream:
+            device = torch.device("cpu")
+
+        stream_var = StreamVariable(None, FakeStream())  # type: ignore[arg-type]
+        self.assertIs(stream_var.python_type(), FakeStream)
 
     def test_full_barrier_forward_deps_respect_partition(self) -> None:
         from torch._functorch._aot_autograd.streams import _collect_sync_forward_deps

--- a/torch/_dynamo/variables/streams.py
+++ b/torch/_dynamo/variables/streams.py
@@ -400,7 +400,7 @@ class StreamVariable(StreamContextVariable):
         super().__init__(None, **kwargs)
 
     def python_type(self) -> type:
-        return self._cpython_type
+        return type(self.value)
 
     def _stream_device_handle_get(
         self: "StreamVariable", tx: "InstructionTranslatorBase"


### PR DESCRIPTION
Fixes #194041

Make `StreamVariable.python_type()` return the runtime type of its wrapped stream value.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98