### PR TITLE
Make _transformer_encoder_layer_fwd meta return a contiguous output

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -954,6 +954,28 @@ class TestTransformers(NNTestCase):
         # Without the fix this raises GuardOnDataDependentSymNode while tracing.
         make_fx(fn, tracing_mode="symbolic")(torch.tensor(3, device=device))
 
+    def test_transformer_encoder_layer_fwd_noncontiguous(self, device):
+        # The fused kernel always returns a contiguous tensor, so its meta rule
+        # must not hand back the strides of a non-contiguous src: inductor asserts
+        # the fallback's runtime metadata against them.
+        model = torch.nn.TransformerEncoderLayer(
+            d_model=16,
+            nhead=4,
+            dim_feedforward=64,
+            dropout=0.0,
+            batch_first=True,
+        ).to(device).eval()
+
+        x = torch.rand(4, 64, 16, device=device).transpose(1, 2).contiguous().transpose(1, 2)
+        self.assertFalse(x.is_contiguous())
+
+        with torch.no_grad():
+            eager_out = model(x)
+            compiled_out = torch.compile(model, fullgraph=True)(x)
+
+        self.assertEqual(eager_out.stride(), compiled_out.stride())
+        self.assertEqual(eager_out, compiled_out)
+
     @skipIfTorchDynamo(msg="https://github.com/pytorch/pytorch/issues/101787")
     @unittest.skipIf(sys.version_info < (3, 11), "not supported on pre-3.11 Python")
     def test_decoder_padding_and_src_mask_bool(self):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -234,7 +234,8 @@ def meta__transformer_encoder_layer_fwd(
     # and can't be decided, assume non-empty (the common case) instead of DDE-ing.
     if guard_or_false(src.numel() == 0):
         return src.clone()
-    return torch.empty_like(src)
+    # The kernel's result comes out of layer_norm / addmm, so it is contiguous.
+    return torch.empty_like(src, memory_format=torch.contiguous_format)
 
 
 @register_meta([aten.linalg_cross.default, aten.linalg_cross.out])


### PR DESCRIPTION
## Issue

Fixes #193966

## Summary

`meta__transformer_encoder_layer_fwd` returns `torch.empty_like(src)`, whose default `preserve_format` copies the stride permutation of a dense non-contiguous `src`. The kernel returns `at::layer_norm`'s / `addmm`'s allocation, never a view of `src` (`aten/src/ATen/native/transformers/transformer.cpp:145`), so its output is contiguous. Inductor's assert on the fallback's metadata then fires (`expected size 64==64, stride 16==1 at dim=1`), and with `size_asserts=False` nothing fires but a consumer silently reads the buffer with the wrong layout. The `numel() == 0` branch is left alone: eager is `src.clone()` there, which also preserves strides.

The new test in `test/test_transformers.py` fails before this change and passes after.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. The fake output's strides now match what eager already returned.

---
AI assistance was used to investigate this bug, write the test and draft this description.