### PR TITLE
[CI] Move experimental-arch docker images to their own workflow

### DIFF
--- a/.github/workflows/docker-builds-experimental.yml
+++ b/.github/workflows/docker-builds-experimental.yml
@@ -1,5 +1,10 @@
 # Owner(s): ["module: ci"]
-name: docker-builds
+name: docker-builds-experimental
+
+# Docker images for experimental, non-mainstream architectures live here rather
+# than in docker-builds.yml. They are maintained by the teams contributing those
+# architectures, and a break in one of them should not turn the mainstream
+# x86/aarch64 docker-builds check red. See #175193.
 
 on:
   workflow_dispatch:
@@ -11,7 +16,7 @@ on:
       - ciflow/docker/*
     paths:
       - .ci/docker/**
-      - .github/workflows/docker-builds.yml
+      - .github/workflows/docker-builds-experimental.yml
       - .lintrunner.toml
   schedule:
     - cron: 1 3 * * 3
@@ -38,57 +43,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # BuildKit is a *remote* builder running on OSDC; the orchestrator
-        # runner just streams context and waits, so the smallest pool fits
-        # both amd64 and arm64 builds. Only `buildkit_addr` differs per arch.
         buildkit_addr: ["tcp://buildkitd-amd64.buildkit:1234"]
-        # Experimental, non-mainstream architecture images (riscv64 today) live
-        # in docker-builds-experimental.yml so that a break in one of them does
-        # not gate the mainstream x86/aarch64 builds. See #175193.
         docker-image-name: [
-          pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11,
-          pytorch-linux-jammy-cuda13.2-cudnn9-py3-gcc11,
-          pytorch-linux-jammy-cuda13.2-cudnn9-py3-gcc11-inductor-benchmarks,
-          pytorch-linux-jammy-cuda13.2-cudnn9-py3.12-gcc11,
-          pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11,
-          pytorch-linux-jammy-cuda13.4-cudnn9-py3-gcc11,
-          pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-vllm,
-          pytorch-linux-jammy-cuda13.0-cudnn9-py3-gcc11-inductor-benchmarks,
-          pytorch-linux-jammy-cuda13.0-cudnn9-py3.12-gcc11-inductor-benchmarks,
-          pytorch-linux-jammy-py3.10-clang21,
-          pytorch-linux-jammy-py3.11-clang21,
-          pytorch-linux-jammy-py3.12-clang21,
-          pytorch-linux-jammy-py3.13-clang21,
-          pytorch-linux-jammy-py3.14-clang21,
-          pytorch-linux-jammy-py3.14t-clang21,
-          pytorch-linux-jammy-rocm-n-py3,
-          pytorch-linux-noble-rocm-n-py3,
-          pytorch-linux-noble-rocm-preview-py3,
-          pytorch-linux-jammy-rocm-n-py3-benchmarks,
-          pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-clang20,
-          pytorch-linux-jammy-cuda13.2-cudnn9-py3.10-clang20,
-          pytorch-linux-jammy-py3-gcc11-inductor-benchmarks,
-          pytorch-linux-jammy-py3.12-halide,
-          pytorch-linux-jammy-cuda13.0-py3.12-pallas,
-          pytorch-linux-jammy-tpu-py3.12-pallas,
-          pytorch-linux-jammy-xpu-n-1-py3,
-          pytorch-linux-noble-xpu-n-py3,
-          pytorch-linux-noble-xpu-n-py3-client,
-          pytorch-linux-noble-xpu-n-py3-inductor-benchmarks,
-          pytorch-linux-jammy-linter,
-          pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-linter,
-          # TODO: Re-enable me when docker pin update happens
-          # pytorch-linux-jammy-py3-clang21-executorch,
-          pytorch-linux-jammy-py3.12-triton-cpu
+          pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build
         ]
         include:
-          - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc13
-            buildkit_addr: "tcp://buildkitd-arm64.buildkit:1234"
-            runner_label: mt-l-arm64g4-16-62
-          - docker-image-name: pytorch-linux-jammy-aarch64-py3.10-gcc13-inductor-benchmarks
-            buildkit_addr: "tcp://buildkitd-arm64.buildkit:1234"
-            timeout-minutes: 600
-            runner_label: mt-l-arm64g4-16-62
+          - docker-image-name: pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build
+            runner_label: mt-l-x86iavx512-8-64
     runs-on: ${{ matrix.runner_label || 'mt-l-x86iavx512-8-64' }}
     container:
       image: ghcr.io/actions/actions-runner:latest
@@ -162,18 +123,3 @@ jobs:
             -t "${GHCR_REPOSITORY}:${{ matrix.docker-image-name }}-${DOCKER_TAG}" \
             -t "${GHCR_REPOSITORY}:${{ matrix.docker-image-name }}" \
             "${ECR_DOCKER_IMAGE}"
-
-      - name: Generate output
-        if: contains(matrix.docker-image-name, 'rocm')
-        run: |
-          docker_image_name="${{ matrix.docker-image-name }}"
-          docker_image_tag="${{ steps.tag.outputs.docker-image }}"
-          echo "${docker_image_name}=${docker_image_tag}" >> "docker-builds-output-${docker_image_name}.txt"
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4.4.0
-        if: contains(matrix.docker-image-name, 'rocm')
-        with:
-          name: docker-builds-artifacts-${{ matrix.docker-image-name }}
-          retention-days: 14
-          path: ./docker-builds-output-${{ matrix.docker-image-name }}.txt


### PR DESCRIPTION
Refs #175193.

## Why

@malfet's action item on #175193, 2026-02-23: *"AI is to move non-standard docker builds into it's own workflow, so that it does not block others."* This does that piece.

`pytorch-linux-noble-riscv64-py3.12-gcc14-cross-build` was one leg of the shared `docker-builds.yml` matrix, sitting next to the CUDA, ROCm and XPU images. `fail-fast: false` means a break there does not cancel its siblings, but it does turn the whole `docker-builds` check red, which is how the zlib.net tarball disappearing in #175193 ended up blocking unrelated work. The riscv64 *build* workflow already lives on its own in `riscv64.yml` behind `ciflow/riscv64`; the docker-image leg was the last part still coupled to the mainstream matrix.

## What changed

- New `.github/workflows/docker-builds-experimental.yml` holding the riscv64 cross image, with the same triggers as `docker-builds.yml`: pushes to `main` and `release/*`, `ciflow/docker/*` tags, and the same weekly cron. So the image is still built, pushed to ECR and mirrored to GHCR on exactly the same occasions as before, and consumers that pull it by tag (`riscv64.yml`, `_linux-build.yml`) are unaffected.
- The image is removed from the `docker-builds.yml` matrix, and a comment there points at the new file so the policy is discoverable rather than folklore.
- The copied job carries only what these images need. The two `contains(matrix.docker-image-name, 'rocm')` artifact steps are not duplicated, so the new workflow is 7 steps against 9.

After this, the mainstream matrix has no experimental-arch legs left, and a future s390x or similar image has an obvious home.

## Verification

`actionlint` is clean on both files. Parsing them confirms the split: `docker-builds.yml` goes from 33 to 32 images with no `riscv` entry remaining, and the new workflow has exactly 1. `docker-builds.yml` is hand-maintained, not emitted by `generate_ci_workflows.py` (that script only covers the binary-build templates), so there is no generator to re-run.

I cannot exercise the ECR or GHCR pushes from a fork, so the real proof is a `ciflow/docker` run on this PR.

## One open question

I kept the job body duplicated rather than extracting a reusable `workflow_call` file, on the grounds that the smaller diff is easier to review and leaves the mainstream path untouched. If you would rather have one job body with two thin callers, say so and I will restructure. @malfet @huydhn @luhenry

cc @malfet @pytorch/pytorch-dev-infra