### PR TITLE
Fix stale event id in trace_gpu_event_creation on first record

### DIFF
--- a/c10/xpu/XPUEvent.h
+++ b/c10/xpu/XPUEvent.h
@@ -107,10 +107,12 @@ struct XPUEvent {
   void record(const XPUStream& stream) {
     namespace syclex = sycl::ext::oneapi::experimental;
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
+    bool submitted_on_create = false;
     if (!isCreated()) {
       createEvent(stream.device_index());
       if (!reusable_) {
         assignEvent(stream.queue());
+        submitted_on_create = true;
       }
       if (C10_UNLIKELY(interp)) {
         (*interp)->trace_gpu_event_creation(
@@ -129,7 +131,7 @@ struct XPUEvent {
 #if SYCL_COMPILER_VERSION >= 20260200
       syclex::enqueue_signal_event(stream.queue(), *event_);
 #endif
-    } else {
+    } else if (!submitted_on_create) {
       reassignEvent(stream.queue());
     }
 

--- a/c10/xpu/XPUEvent.h
+++ b/c10/xpu/XPUEvent.h
@@ -107,12 +107,12 @@ struct XPUEvent {
   void record(const XPUStream& stream) {
     namespace syclex = sycl::ext::oneapi::experimental;
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
-    bool submitted_on_create = false;
+    bool just_created = false;
     if (!isCreated()) {
       createEvent(stream.device_index());
+      just_created = true;
       if (!reusable_) {
         assignEvent(stream.queue());
-        submitted_on_create = true;
       }
       if (C10_UNLIKELY(interp)) {
         (*interp)->trace_gpu_event_creation(
@@ -131,8 +131,10 @@ struct XPUEvent {
 #if SYCL_COMPILER_VERSION >= 20260200
       syclex::enqueue_signal_event(stream.queue(), *event_);
 #endif
-    } else if (!submitted_on_create) {
-      reassignEvent(stream.queue());
+    } else {
+      if (!just_created) {
+        reassignEvent(stream.queue());
+      }
     }
 
     if (C10_UNLIKELY(interp)) {


### PR DESCRIPTION
Problem: TestXpuTrace::test_event_creation_callback failed with "expected call not found", the creation callback reporting a different pointer than the live event id

Root cause: #188888 inserted 'if (reuseable_) { ... }' in front of the existing 'else ( reassignEvent(...) }', re-binding that else from 'if (!isCreated())' to 'if (reuseable_)'. On a non-reuseable device the first record() then ran assignEvent() and reassignEvent(): the sycl::event was allocated twice, so trace_gpu_event_creation reported a pointer that was freed immediately after, while the record/deletion traces and _as_parameter_ reported the second one.

Fix: track whether the creation path already submitted, and skip the redundant reassignEvent(0. First record now allocates and submits exactly once, so creation, record and deletion traces all report the same live pointer.

Validation: test/test_xpu.py -k TestXpuTrace -> 7 passed (was 2 failed)

Fixes: https://github.com/intel/torch-xpu-ops/issues/5009