### PR TITLE
[nn] Print device in Parameter{List,Dict} repr for all accelerators

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -30,6 +30,11 @@ __all__ = [
 T = TypeVar("T", bound=Module)
 _V = TypeVar("_V")
 
+# Device types whose parameters carry no materialized storage worth reporting in
+# a repr. Listing the non-accelerators rather than the accelerators means a newly
+# supported backend starts printing its device without an edit here.
+_NO_DEVICE_STR_TYPES = ("cpu", "meta", "xla", "lazy")
+
 
 # Copied from torch.nn.modules.module, required for a custom __repr__ for ModuleList
 def _addindent(s_, numSpaces):
@@ -774,7 +779,7 @@ class ParameterList(Module):
         for k, p in enumerate(self):
             if isinstance(p, torch.Tensor):
                 size_str = "x".join(str(size) for size in p.size())
-                if p.device.type in ["cuda", torch._C._get_privateuse1_backend_name()]:
+                if p.device.type not in _NO_DEVICE_STR_TYPES:
                     device_str = f" ({p.device})"
                 else:
                     device_str = ""
@@ -1009,7 +1014,7 @@ class ParameterDict(Module):
         for k, p in self.items():
             if isinstance(p, torch.Tensor):
                 size_str = "x".join(str(size) for size in p.size())
-                if p.device.type in ["cuda", torch._C._get_privateuse1_backend_name()]:
+                if p.device.type not in _NO_DEVICE_STR_TYPES:
                     device_str = f" ({p.device})"
                 else:
                     device_str = ""


### PR DESCRIPTION
# Why we need this PR?

`ParameterList.extra_repr` and `ParameterDict.extra_repr` printed the device string only when the parameter was on CUDA or PrivateUse1. Parameters on XPU, MPS, HPU and MTIA printed with no device at all, even though the repr of the same `Parameter` on its own does show it.

Related to this RFC: #194355

# Change

Invert the check: skip the device string only for device types that carry no materialized storage worth reporting.

```python
_NO_DEVICE_STR_TYPES = ("cpu", "meta", "xla", "lazy")
...
if p.device.type not in _NO_DEVICE_STR_TYPES:
```

An exclusion list of non-accelerators does not need touching when a new backend appears, it falls through to "print" automatically.

# Alternatives considered

p.device.type == torch.accelerator.current_accelerator().type looks like the device-generic option but getAccelerator() returns PrivateUse1 unconditionally whenever a PrivateUse1 backend is registered (aten/src/ATen/DeviceAccelerator.cpp). So in a process with a PrivateUse1 backend loaded alongside CUDA, CUDA parameters would stop printing their device.

at::accelerator::isAccelerator(DeviceType) (DeviceAccelerator.h:30) is the exact predicate and is immune to all of the above, but it has no Python binding. Exposing it as torch.accelerator.is_accelerator(device) would let this collapse to a single call and would serve other call sites doing the same hand-rolled check; worth doing separately.

# Test plan

lintrunner torch/nn/modules/container.py
python -m pytest test/test_nn.py -k "ParameterList or ParameterDict or repr" -q
python -m pytest test/test_modules.py -k "test_repr" -q
python -m pytest test/test_nn.py -q