### PR TITLE
[NN] Validate hidden state inputs in RNNCell, LSTMCell, and GRUCell to prevent segfault

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -694,11 +694,18 @@ tpair_of<Tensor> hidden_slice(const tpair_of<Tensor>& t, int64_t start, int64_t 
 
 void check_rnn_cell_forward_input(const Tensor& input, const c10::SymInt& input_size) {
   TORCH_CHECK(
+    input.dim() == 2,
+    "input must be 2D, got ", input.dim(), "D");
+  TORCH_CHECK(
     input.sym_size(1) == input_size,
     "input has inconsistent input_size: got ", input.sym_size(1), " expected ", input_size);
 }
 
 void check_rnn_cell_forward_hidden(const Tensor& input, const Tensor& hx, const c10::SymInt& hidden_size, const c10::SymInt& hidden_label) {
+  TORCH_CHECK(
+    hx.dim() == 2,
+    "hidden", hidden_label, " must be 2D, got ", hx.dim(), "D");
+
   TORCH_CHECK(
     input.sym_size(0) == hx.sym_size(0),
     "Input batch size ", input.sym_size(0), " doesn't match hidden", hidden_label, " batch size ", hx.sym_size(0));

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2570,6 +2570,51 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
 
+    def test_RNN_cell_invalid_hx(self):
+        for cell_cls in (nn.RNNCell, nn.GRUCell):
+            cell = cell_cls(3, 3)
+            # Passing non-tensor
+            with self.assertRaises(TypeError):
+                cell(torch.randn(3), "invalid")
+            with self.assertRaises(TypeError):
+                cell(torch.randn(3), (torch.zeros(3), torch.zeros(3)))
+            # Passing invalid dimensions (>2D)
+            with self.assertRaises(ValueError):
+                cell(torch.randn(3), torch.zeros(2, 3, 3))
+            with self.assertRaises(ValueError):
+                cell(torch.randn(2, 3), torch.zeros(2, 3, 3))
+
+    def test_LSTM_cell_invalid_hx(self):
+        lstm = nn.LSTMCell(3, 3)
+        input_1d = torch.randn(3)
+        input_2d = torch.randn(2, 3)
+
+        # Passing a single tensor instead of a tuple/list of two tensors (issue #193823)
+        with self.assertRaises(TypeError):
+            lstm(input_1d, torch.zeros(2, 3, 3))
+        with self.assertRaises(TypeError):
+            lstm(input_2d, torch.zeros(2, 3, 3))
+        with self.assertRaises(TypeError):
+            lstm(input_1d, torch.zeros(3, 3))
+
+        # Passing a tuple of wrong length
+        with self.assertRaises(TypeError):
+            lstm(input_1d, (torch.zeros(3),))
+        with self.assertRaises(TypeError):
+            lstm(input_1d, (torch.zeros(3), torch.zeros(3), torch.zeros(3)))
+
+        # Passing non-tensors inside tuple
+        with self.assertRaises(TypeError):
+            lstm(input_1d, ("invalid", torch.zeros(3)))
+        with self.assertRaises(TypeError):
+            lstm(input_1d, (torch.zeros(3), "invalid"))
+
+        # Passing invalid dimensions inside tuple
+        with self.assertRaises(ValueError):
+            lstm(input_1d, (torch.zeros(2, 3, 3), torch.zeros(3)))
+        with self.assertRaises(ValueError):
+            lstm(input_2d, (torch.zeros(3), torch.zeros(2, 3, 3)))
+
 
     def test_Transformer_cell(self):
         # this is just a smoke test; these modules are implemented through

--- a/torch/nn/modules/rnn.py
+++ b/torch/nn/modules/rnn.py
@@ -1615,10 +1615,15 @@ class RNNCell(RNNCellBase):
             raise ValueError(
                 f"RNNCell: Expected input to be 1D or 2D, got {input.dim()}D instead"
             )
-        if hx is not None and hx.dim() not in (1, 2):
-            raise ValueError(
-                f"RNNCell: Expected hidden to be 1D or 2D, got {hx.dim()}D instead"
-            )
+        if hx is not None:
+            if not isinstance(hx, Tensor):
+                raise TypeError(
+                    f"RNNCell: Expected hidden to be a Tensor, got {type(hx).__name__}"
+                )
+            if hx.dim() not in (1, 2):
+                raise ValueError(
+                    f"RNNCell: Expected hidden to be 1D or 2D, got {hx.dim()}D instead"
+                )
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)
@@ -1737,7 +1742,15 @@ class LSTMCell(RNNCellBase):
                 f"LSTMCell: Expected input to be 1D or 2D, got {input.dim()}D instead"
             )
         if hx is not None:
+            if not isinstance(hx, (tuple, list)) or len(hx) != 2:
+                raise TypeError(
+                    f"LSTMCell: Expected hx to be a tuple or list of two Tensors (hx, cx), got {type(hx).__name__ if not isinstance(hx, (tuple, list)) else f'sequence of length {len(hx)}'}"
+                )
             for idx, value in enumerate(hx):
+                if not isinstance(value, Tensor):
+                    raise TypeError(
+                        f"LSTMCell: Expected hx[{idx}] to be a Tensor, got {type(value).__name__}"
+                    )
                 if value.dim() not in (1, 2):
                     raise ValueError(
                         f"LSTMCell: Expected hx[{idx}] to be 1D or 2D, got {value.dim()}D instead"
@@ -1846,10 +1859,15 @@ class GRUCell(RNNCellBase):
             raise ValueError(
                 f"GRUCell: Expected input to be 1D or 2D, got {input.dim()}D instead"
             )
-        if hx is not None and hx.dim() not in (1, 2):
-            raise ValueError(
-                f"GRUCell: Expected hidden to be 1D or 2D, got {hx.dim()}D instead"
-            )
+        if hx is not None:
+            if not isinstance(hx, Tensor):
+                raise TypeError(
+                    f"GRUCell: Expected hidden to be a Tensor, got {type(hx).__name__}"
+                )
+            if hx.dim() not in (1, 2):
+                raise ValueError(
+                    f"GRUCell: Expected hidden to be 1D or 2D, got {hx.dim()}D instead"
+                )
         is_batched = input.dim() == 2
         if not is_batched:
             input = input.unsqueeze(0)


### PR DESCRIPTION
### Summary

Fixes #193823

Passing a malformed hidden-state tensor (such as a 3D tensor \	orch.zeros(2, 3, 3)\ instead of a tuple \(hx, cx)\) into \	orch.nn.LSTMCell\ caused the process to crash with a segmentation fault because \enumerate(hx)\ sliced the tensor into 2D sub-tensors and passed the outer 3D tensor down to native \_VF.lstm_cell\, causing an illegal memory access / SIGSEGV.

Similarly, passing non-tensor objects into \RNNCell\ or \GRUCell\ could lead to unhelpful errors or invalid native calls.

### Changes
1. **\	orch/nn/modules/rnn.py\**:
   - In \LSTMCell.forward\: validate that \hx\ is a tuple/list of two \Tensor\ instances with valid 1D/2D shapes, raising clean \TypeError\ / \ValueError\ with clear messages.
   - In \RNNCell.forward\ and \GRUCell.forward\: validate \isinstance(hx, Tensor)\.
2. **\ten/src/ATen/native/RNN.cpp\**:
   - In \check_rnn_cell_forward_input\: add \TORCH_CHECK(input.dim() == 2)\ check.
   - In \check_rnn_cell_forward_hidden\: add \TORCH_CHECK(hx.dim() == 2)\ check for native defense-in-depth against direct C++/LibTorch invalid invocations.
3. **\	est/test_nn.py\**:
   - Added unit tests \	est_LSTM_cell_invalid_hx\ and \	est_RNN_cell_invalid_hx\ covering invalid types, dimensions, tuple lengths, and non-tensor items.

### Test Plan
Ran test suite covering:
- Invalid 3D tensors passed to \LSTMCell\ -> raises \TypeError\
- Single 2D tensors passed to \LSTMCell\ -> raises \TypeError\
- Tuple with non-tensor elements -> raises \TypeError\
- Tuple of invalid lengths -> raises \TypeError\
- Non-tensor passed to \RNNCell\ / \GRUCell\ -> raises \TypeError\
- Normal batched and unbatched forward/backward passes on \LSTMCell\, \RNNCell\, and \GRUCell\ continue to pass cleanly.

cc @pytorch/oncall-core