### PR TITLE
Reject upsample_bilinear2d spatial extents above INT_MAX

### DIFF
--- a/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
+++ b/aten/src/ATen/native/cuda/UpSampleBilinear2d.cu
@@ -349,6 +349,35 @@ __global__ void upsample_bilinear2d_backward_nhwc_out_frame(
   }
 }
 
+// Spatial extents are narrowed to int for the kernels' index math, so an extent
+// above INT_MAX wraps and can produce a negative source index (gh-193689).
+// Check the untruncated sizes. numel is deliberately not checked: it may exceed
+// INT_MAX safely, because these kernels address memory through accessor64 and
+// are launched over height*width rather than over the element count.
+static void check_upsample_2d_extents(
+    int64_t input_height,
+    int64_t input_width,
+    int64_t output_height,
+    int64_t output_width,
+    const char* name) {
+  constexpr int64_t kMax = std::numeric_limits<int>::max();
+  TORCH_CHECK(
+      input_height <= kMax && input_width <= kMax && output_height <= kMax &&
+          output_width <= kMax,
+      name,
+      ": spatial dimensions must each be at most ",
+      kMax,
+      ", but got input (",
+      input_height,
+      ", ",
+      input_width,
+      ") and output (",
+      output_height,
+      ", ",
+      output_width,
+      ")");
+}
+
 static void upsample_bilinear2d_out_cuda_template(
     const Tensor& output,
     const Tensor& input,
@@ -358,6 +387,10 @@ static void upsample_bilinear2d_out_cuda_template(
     std::optional<double> scales_w) {
   TensorArg input_arg{input, "input", 1}, output_arg{output, "output", 2};
   checkAllSameGPU(__func__, {input_arg, output_arg});
+
+  check_upsample_2d_extents(
+      input.size(2), input.size(3), output_size[0], output_size[1],
+      "upsample_bilinear2d");
 
   int output_height = output_size[0];
   int output_width = output_size[1];
@@ -460,6 +493,10 @@ static void upsample_bilinear2d_backward_out_cuda_template(
 
   int output_height = output_size[0];
   int output_width = output_size[1];
+
+  check_upsample_2d_extents(
+      input_size[2], input_size[3], output_size[0], output_size[1],
+      "upsample_bilinear2d_backward");
 
   int nbatch = input_size[0];
   int channels = input_size[1];

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6529,6 +6529,15 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertRaises(RuntimeError, lambda: F.interpolate(x, scale_factor=-1e20, mode="bilinear"))
         self.assertRaises(RuntimeError, lambda: F.interpolate(x, scale_factor=1e20, mode="bilinear"))
 
+    @largeTensorTest("5GB", device="cuda")
+    def test_interpolate_spatial_dim_exceeds_int32(self):
+        # A spatial extent above INT_MAX was narrowed to int on the host, which
+        # made the computed scale negative and the kernel read before the input.
+        # https://github.com/pytorch/pytorch/issues/193689
+        x = torch.empty((1, 1, 2**31, 1), dtype=torch.float16, device="cuda")
+        with self.assertRaisesRegex(RuntimeError, "spatial dimensions must each be at most"):
+            F.interpolate(x, size=(2, 1), mode="bilinear", align_corners=True)
+
     def test_interpolate_buffer_overflow(self):
         # Test buffer overflow issue due to inaccurate floating point
         # representation for integer values. See issue below for details.


### PR DESCRIPTION
## Issue

Fixes #193689

## Summary

Bluntly: 
A spatial dimension larger than INT_MAX (rare case) silently wraps, which makes a computed scale negative and causes the kernel to read before the input buffer. This fix rejects the number that's too large up front instead so that it raises an error. Open to any feedback.

Technically:
A spatial extent above INT_MAX is narrowed to `int` on the host, so `input.size(2)` of `2**32` becomes `0`. The scale then computes as `(0 - 1) / (output_height - 1)` = `-1` and the kernel reads element `-1`. The extents are now checked before they are narrowed, in the forward and backward templates.

`numel` is deliberately not checked. The nhwc branch above does check it, because its kernel indexes over the element count, but these kernels are launched over `height*width` and address memory through `accessor64` — so a numel guard would reject valid work such as `64x3x4096x4096` (3.2e9 elements, extents of 4096), which computes correctly today and was verified to still do so.

Verified on an A10: the reproducer is clean under `compute-sanitizer` after the change, the added test fails on an unpatched build of the same commit, and `test_nn.py -k interpolate` is unchanged at 87 passed. 

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf) (N/A)

## BC-breaking?

No. Inputs with a spatial extent above INT_MAX previously read out of bounds; they now raise.