### PR TITLE
[prims] Resolve functionalized RNG state through device modules

### DIFF
--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -367,6 +367,51 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
         with self.assertWarnsRegex(FutureWarning, 'will be removed in the future'):
             torch._prims_common.check(True, lambda: 'message')
 
+    def test_rng_state_fns_resolve_via_device_module(self):
+        from torch._prims.rng_prims import _rng_state_fns
+
+        # CPU keeps its accessors at the top level; accelerators expose them on
+        # torch.<device_type>. Neither needs CUDA to be present to resolve.
+        for device_type, mod in (('cpu', torch), ('cuda', torch.cuda)):
+            self.assertEqual(
+                _rng_state_fns(device_type), (mod.get_rng_state, mod.set_rng_state)
+            )
+
+        with self.assertRaisesRegex(RuntimeError, 'get_rng_state and set_rng_state'):
+            _rng_state_fns('not_a_registered_backend')
+
+        with self.assertRaisesRegex(RuntimeError, 'requires a device'):
+            _rng_state_fns(None)
+
+    def test_run_with_rng_state_restores_state_on_exception(self):
+        from torch._prims.rng_prims import run_with_rng_state
+
+        saved = torch.get_rng_state()
+        torch.rand(4)  # advance the generator away from `saved`
+        before = torch.get_rng_state()
+
+        class _Boom(Exception):
+            pass
+
+        def _raises(_):
+            raise _Boom
+
+        with self.assertRaises(_Boom):
+            run_with_rng_state(saved, _raises, torch.empty(0))
+
+        # Without the finally, the generator would be left holding `saved`.
+        self.assertEqual(torch.get_rng_state(), before)
+
+    def test_rng_state_hops_cover_privateuse1(self):
+        # An out-of-tree backend registers under PrivateUse1; both HOPs must have
+        # a kernel there or functionalized RNG fails before reaching the device
+        # module lookup above.
+        from torch._C import DispatchKey
+        from torch._prims.rng_prims import run_and_save_rng_state, run_with_rng_state
+
+        for hop in (run_and_save_rng_state, run_with_rng_state):
+            self.assertIn(DispatchKey.PrivateUse1, hop.py_kernels)
+
 
 instantiate_device_type_tests(TestPrims, globals())
 

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -6,8 +6,8 @@ import unittest
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_utils import (parametrize, run_tests, TestCase, TEST_SCIPY,
-                                                  set_default_dtype)
+from torch.testing._internal.common_utils import (HardwareClassification, parametrize, run_tests,
+                                                  TestCase, TEST_SCIPY, set_default_dtype)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
@@ -35,6 +35,8 @@ NVPRIM_ATEN_FALLBACK_WARNING = "fallback to aten executor"
 GET_ISOLATED_GRAPHMODULE_ERROR = "get_isolated_graphmodule failed on decomposition"
 
 class TestPrims(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @onlyCUDA
     @dtypes(torch.float32)
     def test_broadcast_in_dim(self, device, dtype):
@@ -332,7 +334,40 @@ class TestPrims(TestCase):
         self.assertEqual(result.device.type, "cpu")
         self.assertEqual(result.shape, (1,))
 
+    def test_functionalized_rng_state_round_trip(self, device):
+        from torch._prims.rng_prims import run_and_save_rng_state, run_with_rng_state
+
+        state, first = run_and_save_rng_state(
+            torch.ops.aten.rand.default, [8], device=device
+        )
+        replay = run_with_rng_state(
+            state, torch.ops.aten.rand.default, [8], device=device
+        )
+        self.assertEqual(first, replay)
+
+    def test_functionalized_rng_state_restored_on_exception(self, device):
+        from torch._prims.rng_prims import _rng_state_fns, run_with_rng_state
+
+        get_rng_state, _ = _rng_state_fns(torch.device(device).type)
+        saved = get_rng_state()
+        torch.rand(8, device=device)  # advance the generator away from `saved`
+        before = get_rng_state()
+
+        class _Boom(Exception):
+            pass
+
+        def _raises(_):
+            raise _Boom
+
+        with self.assertRaises(_Boom):
+            run_with_rng_state(saved, _raises, torch.empty(0, device=device))
+
+        # Without the finally, the generator would be left holding `saved`.
+        self.assertEqual(get_rng_state(), before)
+
 class TestPrimsBasic(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_torch_ops(self):
         r = make_tensor((2,), device='cpu', dtype=torch.float)
         self.assertEqual(torch.ops.prims.sin(r), torch.sin(r))
@@ -382,25 +417,6 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
 
         with self.assertRaisesRegex(RuntimeError, 'requires a device'):
             _rng_state_fns(None)
-
-    def test_run_with_rng_state_restores_state_on_exception(self):
-        from torch._prims.rng_prims import run_with_rng_state
-
-        saved = torch.get_rng_state()
-        torch.rand(4)  # advance the generator away from `saved`
-        before = torch.get_rng_state()
-
-        class _Boom(Exception):
-            pass
-
-        def _raises(_):
-            raise _Boom
-
-        with self.assertRaises(_Boom):
-            run_with_rng_state(saved, _raises, torch.empty(0))
-
-        # Without the finally, the generator would be left holding `saved`.
-        self.assertEqual(torch.get_rng_state(), before)
 
     def test_rng_state_hops_cover_privateuse1(self):
         # An out-of-tree backend registers under PrivateUse1; both HOPs must have

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -147,6 +147,38 @@ def get_device(args, kwargs):
     return None
 
 
+# CPU exposes its RNG state accessors at the top level; every accelerator follows
+# the torch.<device_type>.get_rng_state / set_rng_state convention. PrivateUse1
+# covers every out-of-tree backend, so registering a new one needs no entry here.
+_RNG_STATE_DISPATCH_KEYS = (
+    DispatchKey.CPU,
+    DispatchKey.CUDA,
+    DispatchKey.HPU,
+    DispatchKey.XPU,
+    DispatchKey.PrivateUse1,
+)
+
+
+def _rng_state_fns(device_type):
+    """Return ``(get_rng_state, set_rng_state)`` for ``device_type``."""
+    if device_type is None:
+        raise RuntimeError(
+            "Functionalizing an RNG operator requires a device, but none of the "
+            "arguments carried one."
+        )
+    if device_type == "cpu":
+        return torch.get_rng_state, torch.set_rng_state
+    device_module = getattr(torch, device_type, None)
+    get_state = getattr(device_module, "get_rng_state", None)
+    set_state = getattr(device_module, "set_rng_state", None)
+    if get_state is None or set_state is None:
+        raise RuntimeError(
+            f"Functionalizing an RNG operator on {device_type} requires "
+            f"torch.{device_type} to provide get_rng_state and set_rng_state."
+        )
+    return get_state, set_state
+
+
 def register_run_and_save_rng_state_op():
     class RunAndSaveRngState(HigherOrderOperator):
         def __init__(self):
@@ -162,37 +194,13 @@ def register_run_and_save_rng_state_op():
         autograd_not_implemented(run_and_save_rng_state, deferred_error=True)
     )
 
-    @run_and_save_rng_state.py_impl(DispatchKey.CUDA)
-    def impl_cuda(op, *args, **kwargs):
-        return torch.cuda.get_rng_state(), op(*args, **kwargs)
-
-    @run_and_save_rng_state.py_impl(DispatchKey.CPU)
-    def impl_cpu(op, *args, **kwargs):
-        return torch.get_rng_state(), op(*args, **kwargs)
-
-    @run_and_save_rng_state.py_impl(DispatchKey.HPU)
-    def impl_hpu(op, *args, **kwargs):
-        if hasattr(torch, "hpu"):
-            return torch.hpu.get_rng_state(), op(*args, **kwargs)
-        raise RuntimeError("functionalize a hpu RNG operator is not supported.")
-
-    @run_and_save_rng_state.py_impl(DispatchKey.XPU)
-    def impl_xpu(op, *args, **kwargs):
-        return torch.xpu.get_rng_state(), op(*args, **kwargs)
-
     @run_and_save_rng_state.py_impl(DispatchKey.BackendSelect)
     def impl_backend_select(op, *args, **kwargs):
-        impl_map = {
-            "cuda": impl_cuda,
-            "cpu": impl_cpu,
-            "hpu": impl_hpu,
-            "xpu": impl_xpu,
-        }
-        device = get_device(args, kwargs)
-        if device not in impl_map:
-            raise AssertionError(f"Backend not supported for {device}")
-        impl = impl_map[device]
-        return impl(op, *args, **kwargs)
+        get_rng_state, _ = _rng_state_fns(get_device(args, kwargs))
+        return get_rng_state(), op(*args, **kwargs)
+
+    for _key in _RNG_STATE_DISPATCH_KEYS:
+        run_and_save_rng_state.py_impl(_key)(impl_backend_select)
 
     @register_fake(run_and_save_rng_state, skip_cache=True)
     def impl_fake_tensor_mode(op, *args, **kwargs):
@@ -227,39 +235,20 @@ def register_run_with_rng_state_op():
         autograd_not_implemented(run_with_rng_state, deferred_error=True)
     )
 
-    @run_with_rng_state.py_impl(DispatchKey.CUDA)
-    def impl_cuda(rng_state, op, *args, **kwargs):
-        current_state = torch.cuda.get_rng_state()
-        torch.cuda.set_rng_state(rng_state.cpu())
-        out = op(*args, **kwargs)
-        torch.cuda.set_rng_state(current_state)
-        return out
+    @run_with_rng_state.py_impl(DispatchKey.BackendSelect)
+    def impl_backend_select(rng_state, op, *args, **kwargs):
+        get_state, set_state = _rng_state_fns(get_device(args, kwargs))
+        current_state = get_state()
+        # Generators reject a non-CPU state (at::detail::check_rng_state), and the
+        # saved state may have been placed on the device by the caller.
+        set_state(rng_state.cpu())
+        try:
+            return op(*args, **kwargs)
+        finally:
+            set_state(current_state)
 
-    @run_with_rng_state.py_impl(DispatchKey.CPU)
-    def impl_cpu(rng_state, op, *args, **kwargs):
-        current_state = torch.get_rng_state()
-        torch.set_rng_state(rng_state)
-        out = op(*args, **kwargs)
-        torch.set_rng_state(current_state)
-        return out
-
-    @run_with_rng_state.py_impl(DispatchKey.HPU)
-    def impl_hpu(rng_state, op, *args, **kwargs):
-        if hasattr(torch, "hpu"):
-            current_state = torch.hpu.get_rng_state()
-            torch.hpu.set_rng_state(rng_state)
-            out = op(*args, **kwargs)
-            torch.hpu.set_rng_state(current_state)
-            return out
-        raise RuntimeError("functionalize a hpu RNG operator is not supported.")
-
-    @run_with_rng_state.py_impl(DispatchKey.XPU)
-    def impl_xpu(rng_state, op, *args, **kwargs):
-        current_state = torch.xpu.get_rng_state()
-        torch.xpu.set_rng_state(rng_state)
-        out = op(*args, **kwargs)
-        torch.xpu.set_rng_state(current_state)
-        return out
+    for _key in _RNG_STATE_DISPATCH_KEYS:
+        run_with_rng_state.py_impl(_key)(impl_backend_select)
 
     @run_with_rng_state.py_impl(ProxyTorchDispatchMode)
     def impl_proxy_dispatch_mode(mode, rng_state, op, *args, **kwargs):
@@ -273,20 +262,6 @@ def register_run_with_rng_state_op():
             "call_function", run_with_rng_state, proxy_args, proxy_kwargs
         )
         return track_tensor_tree(out, out_proxy, constant=None, tracer=mode.tracer)
-
-    @run_with_rng_state.py_impl(DispatchKey.BackendSelect)
-    def impl_backend_select(rng_state, op, *args, **kwargs):
-        impl_map = {
-            "cuda": impl_cuda,
-            "cpu": impl_cpu,
-            "hpu": impl_hpu,
-            "xpu": impl_xpu,
-        }
-        device = get_device(args, kwargs)
-        if device not in impl_map:
-            raise AssertionError(f"Backend not supported for {device}")
-        impl = impl_map[device]
-        return impl(rng_state, op, *args, **kwargs)
 
     @register_fake(run_with_rng_state, skip_cache=True)
     def impl_fake_tensor_mode(rng_state, op, *args, **kwargs):


### PR DESCRIPTION
Related to this RFC: #194355

## Description

`torch._prims.rng_prims` currently uses a hard-coded mapping of device types (`cpu`, `cuda`, `hpu`, `xpu`) to RNG state implementations.

This prevents out-of-tree backends from using the functionalized RNG primitives without adding backend-specific logic to `rng_prims.py`.

For example, a `PrivateUse1` backend may provide `torch.<device_type>.get_rng_state()` and `torch.<device_type>.set_rng_state()`, but `rng_prims` does not currently resolve these implementations dynamically.

### Proposed solution

Instead of maintaining a hard-coded device-to-RNG implementation map, resolve the RNG state functions through the corresponding device module:

```python
device_module = getattr(torch, device_type)
get_rng_state = device_module.get_rng_state
set_rng_state = device_module.set_rng_state
```

This would allow out-of-tree backends that implement the standard RNG state APIs to work with functionalized RNG primitives without requiring changes to `torch._prims.rng_prims`.

It would also make the implementation easier to extend as new device backends are added.


### Additional consideration

`run_with_rng_state` should restore the original RNG state even when the wrapped operation raises an exception. Using `try/finally` ensures that the RNG state is restored in both success and failure cases.

### Expected outcome

* Out-of-tree backends can use functionalized RNG primitives through their existing RNG state APIs.
* No backend-specific entries are required in `rng_prims.py`.
* RNG state is correctly restored when `run_with_rng_state` fails.