### PR TITLE
Fix warnings that fire on every trigger instead of once

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -444,7 +444,7 @@ static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(D
 #endif
   }
   if (cublasStatus != CUBLAS_STATUS_SUCCESS) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
       "bgemm_internal_cublaslt error: ",
       at::cuda::blas::_cublasGetErrorEnum(cublasStatus),
       " when calling cublasLtMatmul with transpose_mat1 ",
@@ -1681,7 +1681,7 @@ bool gemm_and_bias(
 #endif
   }
   if (cublasStatus != CUBLAS_STATUS_SUCCESS) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
       "gemm_and_bias error: ",
       at::cuda::blas::_cublasGetErrorEnum(cublasStatus),
       " when calling cublasLtMatmul with transpose_mat1 ",

--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -3764,7 +3764,7 @@ Tensor& _int_mm_out_cpu(const Tensor& self, const Tensor& mat2, Tensor& result) 
       mkldnn_matmul_i8i8i32(self, mat2, result);
       dispatched = true;
     } catch ([[maybe_unused]] const std::exception& e) {
-      TORCH_WARN(func_name, " failed, switching to BLAS gemm: ", e.what());
+      TORCH_WARN_ONCE(func_name, " failed, switching to BLAS gemm: ", e.what());
     }
   }
   if (!dispatched) {

--- a/aten/src/ATen/native/cudnn/RNN.cpp
+++ b/aten/src/ATen/native/cudnn/RNN.cpp
@@ -1478,7 +1478,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _cudnn_rnn(
   auto input = input_r;
   auto weight_buf = weight_buf_r;
   if (!weight_buf.defined()) {
-    TORCH_WARN(WEIGHT_FORMAT_WARN);
+    TORCH_WARN_ONCE(WEIGHT_FORMAT_WARN);
   }
   if (fn_dropout_state.defined()) {
     auto input_arg = TensorArg(input, "input", 1);

--- a/aten/src/ATen/native/mkl/SparseCsrLinearAlgebra.cpp
+++ b/aten/src/ATen/native/mkl/SparseCsrLinearAlgebra.cpp
@@ -221,20 +221,20 @@ Tensor& _sparse_mm_mkl_(
     const Scalar& beta) {
   if (is_mkl_int32_index()) {
     if (sparse_.crow_indices().scalar_type() != kInt) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "Pytorch is compiled with MKL LP64 and will convert crow_indices to int32.");
     }
     if (sparse_.col_indices().scalar_type() != kInt) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "Pytorch is compiled with MKL LP64 and will convert col_indices to int32.");
     }
   } else { // This is for future proofing if we ever change to using MKL ILP64.
     if (sparse_.crow_indices().scalar_type() != kLong) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "Pytorch is compiled with MKL ILP64 and will convert crow_indices dtype to int64.");
     }
     if (sparse_.col_indices().scalar_type() != kLong) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "Pytorch is compiled with MKL ILP64 and will convert col_indices dtype to int64.");
     }
   }

--- a/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/ScaledBlas.cpp
@@ -268,7 +268,7 @@ Tensor& _scaled_gemm(
   // Note: XPU does not support fast_accum for now, we will warn and always pass
   // false to the call.
   if (use_fast_accum) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "scaled_mm: fast_accum is not supported in XPU for now. It would silently set use_fast_accum to false.");
   }
   // TODO: scale_result is not defined or used!
@@ -337,7 +337,7 @@ Tensor& _scaled_mm_out_xpu(
   // Note: XPU does not support fast_accum for now, we will warn and always pass
   // false to the call.
   if (use_fast_accum) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "scaled_mm: fast_accum is not supported in XPU for now. It would silently set use_fast_accum to false.");
   }
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -346,7 +346,7 @@ at::Tensor make_contiguous_and_aligned(
   at::Tensor out = memory_format.has_value() ? tensor.contiguous(*memory_format)
                                              : tensor.contiguous();
   if (!is_64_bytes_aligned(out)) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "Tensor is not 64-byte aligned. Cloning to ensure alignment for oneDNN "
         "operations, which incurs a device-to-device copy.");
     out = out.clone();

--- a/aten/src/ATen/native/quantized/cpu/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/quantized/cpu/AdaptiveAveragePooling.cpp
@@ -322,8 +322,8 @@ Tensor& adaptive_avg_pool3d_out_quantized_cpu(
     at::Tensor& output) {
 #ifdef USE_PYTORCH_QNNPACK
   if (at::globalContext().qEngine() == at::QEngine::QNNPACK) {
-    TORCH_WARN("Quantized Adaptive Average Pool 3D is not implemented for ",
-               "QNNPACK. Falling back to default implementation.");
+    TORCH_WARN_ONCE("Quantized Adaptive Average Pool 3D is not implemented for ",
+                    "QNNPACK. Falling back to default implementation.");
   }
 #endif
   AT_DISPATCH_QINT_TYPES(

--- a/aten/src/ATen/native/quantized/cpu/TensorShape.cpp
+++ b/aten/src/ATen/native/quantized/cpu/TensorShape.cpp
@@ -164,7 +164,7 @@ Tensor cat_quantized_cpu(const ITensorListRef& qxs, int64_t dim) {
 
   if (!all_inputs_sharing_qparams(materialized)) {
       // TODO: if possible change this warning to an error T194501002
-      TORCH_WARN("All inputs of this cat operator must share the same quantization parameters. Otherwise large numerical inaccuracies may occur.");
+      TORCH_WARN_ONCE("All inputs of this cat operator must share the same quantization parameters. Otherwise large numerical inaccuracies may occur.");
   }
   check_cat_no_zero_dim(materialized);
   dim = legacy_cat_wrap_dim(dim, materialized);

--- a/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qconv_dynamic.cpp
@@ -79,7 +79,7 @@ at::Tensor PackedConvWeightsQnnp<kSpatialDim>::apply_dynamic(
     const at::Tensor& input,
     bool reduce_range) {
   if (reduce_range) {
-    TORCH_WARN("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release.");
+    TORCH_WARN_ONCE("Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release.");
   }
 
   // On empty input, no output data will be generated,

--- a/aten/src/ATen/native/quantized/cpu/qrelu.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qrelu.cpp
@@ -204,7 +204,7 @@ class QLeakyRelu final {
   static Tensor run(Tensor self, const Scalar& negative_slope, bool inplace, double output_scale, int64_t output_zero_point) {
     // inplace argument is ignored now, TODO:support inplace
     if (inplace) {
-      TORCH_WARN("inplace=True is not supported for quantized::leaky_relu yet");
+      TORCH_WARN_ONCE("inplace=True is not supported for quantized::leaky_relu yet");
     }
     const auto qx = self.contiguous(self.suggest_memory_format());
     auto qy = at::_empty_affine_quantized(qx.sizes(),

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1754,13 +1754,16 @@ except RuntimeError as e:
                 self.assertNotWarn(
                     lambda: next(it), "Should not warn before exceeding length"
                 )
-            for _ in range(3):
-                with self.assertWarnsRegex(
-                    UserWarning,
-                    r"but [0-9]+ samples have been fetched\. For multiprocessing data-loading, this",
-                    msg="Should always warn after exceeding length",
-                ):
-                    next(it)
+            with self.assertWarnsRegex(
+                UserWarning,
+                r"but [0-9]+ samples have been fetched\. For multiprocessing data-loading, this",
+                msg="Should warn after exceeding length",
+            ):
+                next(it)
+            for _ in range(2):
+                self.assertNotWarn(
+                    lambda: next(it), "Should warn only once after exceeding length"
+                )
         # [no auto-batching] test that workers exit gracefully
         workers = dataloader_iter._workers
         del dataloader_iter

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -39,7 +39,7 @@ from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, r
     download_file, get_function_arglist, load_tests, skipIfMPS, MACOS_VERSION, \
     IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
-    skipIfTorchDynamo, gcIfJetson, set_default_dtype, skipIfNoCuteDSL
+    skipIfTorchDynamo, gcIfJetson, set_default_dtype, skipIfNoCuteDSL, set_warn_always_context
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, \
     SM80OrLater, SM90OrLater, _get_torch_rocm_version
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
@@ -2734,13 +2734,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 weight.set_(weight_data)
 
             for _ in range(2):
+                # The weight format warning is a TORCH_WARN_ONCE; force
+                # warn-always so this test doesn't depend on being the
+                # first trigger in the process.
                 with warnings.catch_warnings(record=True) as w:
-                    output_noncontig = rnn(input, hx)
+                    warnings.simplefilter("always")
+                    with set_warn_always_context(True):
+                        output_noncontig = rnn(input, hx)
                 if first_warn:
                     self.assertEqual(len(w), 1)
                     self.assertIn('weights are not part of single contiguous chunk of memory', w[0].message.args[0])
                     first_warn = False
-                    warnings.resetwarnings()
                 output_noncontig[0].sum().backward()
                 grads_noncontig = [v.grad.data.clone() for v in all_vars]
                 for v in all_vars:

--- a/torch/csrc/api/include/torch/nn/functional/loss.h
+++ b/torch/csrc/api/include/torch/nn/functional/loss.h
@@ -48,7 +48,7 @@ inline Tensor kl_div(
   torch::Reduction::Reduction reduction_enum{};
 
   if (std::holds_alternative<enumtype::kMean>(reduction)) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "reduction: 'mean' divides the total loss by both the batch size and the support size."
         "'batchmean' divides only by the batch size, and aligns with the KL div math definition."
         "'mean' will be changed to behave the same as 'batchmean' in the next major release.");
@@ -103,7 +103,7 @@ inline Tensor mse_loss(
     const Tensor& target,
     MSELossFuncOptions::reduction_t reduction) {
   if (!(target.sizes() == input.sizes())) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "Using a target size (",
         target.sizes(),
         ") that is different to the input size (",
@@ -345,7 +345,7 @@ inline Tensor smooth_l1_loss(
     SmoothL1LossFuncOptions::reduction_t reduction,
     std::optional<double> beta_opt = std::nullopt) {
   if (target.sizes() != input.sizes()) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "Using a target size (",
         target.sizes(),
         ") that is different to the input size (",
@@ -418,7 +418,7 @@ inline Tensor huber_loss(
     HuberLossFuncOptions::reduction_t reduction,
     double delta = 1.) {
   if (target.sizes() != input.sizes()) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "Using a target size (",
         target.sizes(),
         ") that is different to the input size (",

--- a/torch/csrc/api/include/torch/nn/functional/upsampling.h
+++ b/torch/csrc/api/include/torch/nn/functional/upsampling.h
@@ -53,7 +53,7 @@ inline std::vector<int64_t> _interp_output_size(
       }
     }
     if (is_float_scale_factor) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "The default behavior for interpolate/upsample with float scale_factor changed "
           "in 1.6.0 to align with other frameworks/libraries, and uses scale_factor directly, "
           "instead of relying on the computed output size. "
@@ -90,7 +90,7 @@ inline Tensor interpolate(
     }
   } else {
     if (align_corners == std::nullopt) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "Default upsampling behavior when mode=",
           enumtype::get_enum_name(mode),
           " is changed "

--- a/torch/csrc/api/include/torch/nn/functional/vision.h
+++ b/torch/csrc/api/include/torch/nn/functional/vision.h
@@ -77,7 +77,7 @@ inline Tensor grid_sample(
   }
 
   if (!align_corners.has_value()) {
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "Default grid_sample and affine_grid behavior has changed ",
         "to align_corners=False since 1.3.0. Please specify ",
         "align_corners=True if the old behavior is desired. ",

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -5715,7 +5715,7 @@ Tensor log1p_backward(const Tensor& grad, const Tensor& self) {
     // The warning only applies to the sparsity of self, dense grad is never
     // materialized so if self is strided and grad is sparse nothing unexpected
     // happens memory wise
-    TORCH_WARN(
+    TORCH_WARN_ONCE(
         "log1p_backward: received self with sparse layout, but backward requires materialization of a dense tensor with this shape");
     self_p1_conj = (self.to_dense() + 1).conj();
   } else {

--- a/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
+++ b/torch/csrc/jit/runtime/register_prim_ops_fulljit.cpp
@@ -430,7 +430,7 @@ at::Tensor interpolate(
     }
   } else {
     if (align_corners == std::nullopt) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "Default upsampling behavior when mode=",
           mode,
           " is changed "
@@ -468,7 +468,7 @@ at::Tensor interpolate(
     }
 
     if (warn_recompute_scale_factor) {
-      TORCH_WARN(
+      TORCH_WARN_ONCE(
           "The default behavior for interpolate/upsample with float scale_factor will change "
           "in 1.5.0 to align with other frameworks/libraries, and use scale_factor directly, "
           "instead of relying on the computed output size. "

--- a/torch/distributed/algorithms/join.py
+++ b/torch/distributed/algorithms/join.py
@@ -248,10 +248,11 @@ class Join:
 
         i = 0
         WARN_THRESHOLD = 1000
-        warnings.simplefilter("once")
 
         while not all_procs_joined:
-            if i > WARN_THRESHOLD:
+            # Warn exactly once when the threshold is crossed; do not touch
+            # the global warning filters (simplefilter would clobber them).
+            if i == WARN_THRESHOLD:
                 warnings.warn(
                     "Detected uneven input skew of greater than "
                     f"{WARN_THRESHOLD}. This means that rank "

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -777,10 +777,13 @@ class _PipelineStageBase(ABC):
                     activation = info.buffer.requires_grad_(effective_requires_grad)
                 # Activation must be a leaf so backward terminates here.
                 if effective_requires_grad and not activation.is_leaf:
+                    # Use the grad_fn type name, not its repr: the repr embeds
+                    # a fresh object address every microbatch, which defeats
+                    # the warnings module's dedup and spams every step.
                     warnings.warn(
                         f"Stage {self.stage_index}: activation "
                         f"'{info.input_name}' is not a leaf "
-                        f"(grad_fn={activation.grad_fn}); using "
+                        f"(grad_fn={type(activation.grad_fn).__name__}); using "
                         f"retain_grad() as fallback",
                         stacklevel=2,
                     )

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -694,6 +694,7 @@ class _BaseDataLoaderIter:
         )
         self._persistent_workers = loader.persistent_workers
         self._num_yielded = 0
+        self._len_warned = False
         self._profile_name = f"enumerate(DataLoader)#{self.__class__.__name__}.__next__"
 
     def __iter__(self) -> Self:
@@ -728,7 +729,11 @@ class _BaseDataLoaderIter:
                 self._dataset_kind == _DatasetKind.Iterable
                 and self._IterableDataset_len_called is not None
                 and self._num_yielded > self._IterableDataset_len_called
+                and not self._len_warned
             ):
+                # The message embeds _num_yielded, so it defeats the warnings
+                # module's dedup; guard with a flag to warn only once.
+                self._len_warned = True
                 warn_msg = (
                     f"Length of IterableDataset {self._dataset} was reported to be {self._IterableDataset_len_called}"
                     f"(when accessing len(dataloader)), but {self._num_yielded} samples have been fetched. "

--- a/torch/utils/hooks.py
+++ b/torch/utils/hooks.py
@@ -85,7 +85,11 @@ def warn_if_has_hooks(tensor) -> None:
         for k in tensor._backward_hooks:
             hook = tensor._backward_hooks[k]
             if not hasattr(hook, "__torch_unserializable__"):
-                warnings.warn(f"backward hook {repr(hook)} on tensor will not be "
+                # Use a stable name rather than repr(hook): the repr embeds
+                # the object's address, which defeats the warnings module's
+                # dedup and re-warns for every new hook object.
+                name = getattr(hook, "__qualname__", None) or type(hook).__name__
+                warnings.warn(f"backward hook {name} on tensor will not be "
                               "serialized.  If this is expected, you can "
                               "decorate the function with @torch.utils.hooks.unserializable_hook "
                               "to suppress this warning", stacklevel=2)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194075

Audit of warning call sites that are intended as one-time advisories
but re-fire on every trigger. Two root causes:

In C++, TORCH_WARN in per-op-call paths fires on every invocation, and
in libtorch, TorchScript, and autograd threads there is no Python-side
dedup, so a hot-path advisory (fallback notice, perf hint, support
caveat) spams the log once per op call per iteration. These are
converted to TORCH_WARN_ONCE.

In Python, the warnings module dedups on (message, category, lineno),
which breaks when the message embeds a changing value: the dataloader
IterableDataset length warning embeds the incrementing _num_yielded
counter (so it warned on every batch for the rest of the epoch), the
pipelining stage non-leaf warning embedded grad_fn's repr (a fresh
memory address every microbatch), and warn_if_has_hooks embedded
repr(hook) (an address, re-warning per hook object per torch.save).
Additionally, Join.__exit__ called warnings.simplefilter("once") on the
global filter on every exit, silently clobbering user-configured
filters (including -W error); it now warns exactly once by construction
(i == WARN_THRESHOLD) without touching filters.

Review order: start with the four Python fixes (dataloader.py,
pipelining/stage.py, utils/hooks.py, algorithms/join.py) and their test
updates; the C++ changes are then mechanical TORCH_WARN ->
TORCH_WARN_ONCE conversions of per-call advisories (cuBLASLt fallbacks,
MKL sparse index conversion, quantized ops, cuDNN RNN weight format,
sparse log1p_backward, and the C++ frontend / TorchScript loss and
interpolate warnings).

Test updates: test_dataloader.py previously asserted the
length-exceeded warning fires on every over-fetch and now asserts
warn-once semantics; test_nn.py::test_cudnn_weight_format wraps the RNN
call in set_warn_always_context(True) so it does not depend on being
the first trigger in the process.

Deliberately left as repeating (per-call semantics arguably intended):
expanded-tensor/uint8 indexing deprecations, vmap batching-rule
fallback (has its own toggle API), resize_output/arange resize
warnings, profiler per-event warnings, and the autograd-not-implemented
fallback (has a Warn/Nothing mode).

Test Plan:

No local build is available, so the C++ changes (single-token macro
swaps with identical variadic signature) are compile-verified by CI.
Python changes were syntax-checked and linted:

```
python -m py_compile torch/utils/data/dataloader.py torch/distributed/pipelining/stage.py torch/utils/hooks.py torch/distributed/algorithms/join.py test/test_dataloader.py test/test_nn.py
lintrunner -a
```

Relevant CI coverage: test/test_dataloader.py (IterableDataset length
warning) and test/test_nn.py -k test_cudnn_weight_format.

Authored with Claude Code.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01