### PR TITLE
[AOTInductor] Support host-side PDL launches (#194079)

### DIFF
--- a/test/inductor/test_aoti_pdl.py
+++ b/test/inductor/test_aoti_pdl.py
@@ -1,0 +1,66 @@
+# Owner(s): ["module: inductor"]
+
+import unittest
+
+import torch
+from torch._inductor import config
+from torch._inductor.test_case import run_tests, TestCase
+from torch._inductor.utils import fresh_cache, run_and_get_cpp_code
+from torch.testing import FileCheck
+from torch.testing._internal.common_cuda import SM90OrLater
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    TEST_WITH_ROCM,
+)
+
+
+@unittest.skipIf(
+    not SM90OrLater or TEST_WITH_ROCM,
+    "AOTInductor PDL requires NVIDIA sm90+",
+)
+class AOTInductorPDLTest(TestCase):
+    @parametrize("enable_pdl", [False, True])
+    def test_package_uses_host_pdl_launch(self, enable_pdl):
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                intermediate = torch.sin(x.sum(dim=1))
+                return intermediate.sum(dim=0)
+
+        model = Model().cuda()
+        inputs = (torch.randn(1024, 1024, device="cuda"),)
+        expected = model(*inputs)
+
+        with config.patch({"triton.enable_pdl": enable_pdl}), fresh_cache():
+            exported = torch.export.export(model, inputs, strict=True)
+
+            def compile_package():
+                return torch._inductor.aoti_compile_and_package(exported)
+
+            package_path, code = run_and_get_cpp_code(compile_package)
+            loaded = torch._inductor.aoti_load_package(package_path)
+            actual = loaded(*inputs)
+
+        self.assertEqual(actual, expected, atol=1e-4, rtol=1e-4)
+        FileCheck().check_regex(
+            rf"launchKernel\([^;]+stream_, {str(enable_pdl).lower()}\);"
+        ).run(code)
+        if enable_pdl:
+            (
+                FileCheck()
+                .check("'launch_pdl': True")
+                .check("gdc_wait")
+                .check("gdc_launch_dependents")
+                .run(code)
+            )
+        else:
+            FileCheck().check("'launch_pdl': False").run(code)
+            self.assertNotIn("gdc_wait", code)
+            self.assertNotIn("gdc_launch_dependents", code)
+
+
+instantiate_parametrized_tests(AOTInductorPDLTest)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -1,4 +1,6 @@
 # Owner(s): ["module: inductor"]
+from unittest import mock
+
 import torch
 from torch._inductor.codegen.aoti_hipify_utils import maybe_hipify_code_wrapper
 from torch._inductor.codegen.common import get_device_op_overrides
@@ -38,7 +40,10 @@ class TestCppWrapperHipify(TestCase):
 
     def test_hipify_aoti_driver_header(self) -> None:
         cuda_codegen = get_device_op_overrides("cuda")
-        header = cuda_codegen.kernel_driver()
+        with mock.patch.object(
+            cuda_codegen, "cpp_kernel_launch_supports_pdl", return_value=False
+        ):
+            header = cuda_codegen.kernel_driver()
         expected = """
             #define CUDA_DRIVER_CHECK(EXPR)                    \\
             do {                                               \\

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -14,12 +14,13 @@ from torch._inductor import config
 from torch._inductor.codegen.common import TritonScratchWorkspace
 from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch._inductor.codegen.cpp_wrapper_gpu import (
+    _launch_pdl_cpp_literal,
     CppWrapperGpu,
     DeferredTritonCallWrapper,
 )
 from torch._inductor.codegen.cuda.device_op_overrides import CUDADeviceOpOverrides
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import IndentedBuffer
+from torch._inductor.utils import DualIndentedBuffer, IndentedBuffer
 from torch._inductor.virtualized import V
 from torch.testing._internal.common_utils import (
     find_library_location,
@@ -342,8 +343,13 @@ class TestGpuWrapper(InductorTestCase):
 
     @skipIfXpu(msg="tests CUDA/ROCm CUDADeviceOpOverrides codegen")
     def test_triton_wrapper_scales_scratch_with_num_ctas(self):
+        class FakeDeviceCodegen:
+            @staticmethod
+            def cpp_kernel_launch_supports_pdl():
+                return True
+
         class FakeWrapper:
-            device = "cuda"
+            device_codegen = FakeDeviceCodegen()
 
             def __init__(self):
                 self.scratch_spaces = None
@@ -381,6 +387,139 @@ class TestGpuWrapper(InductorTestCase):
         ).generate_launch_kernel(prefix, wrapper, "kernel_var", params)
 
         self.assertEqual(wrapper.scratch_spaces, {"global_scratch": 256 * 8})
+
+    @parametrize(
+        "triton_meta,expected",
+        [
+            (None, "false"),
+            ({}, "false"),
+            ({"launch_pdl": False}, "false"),
+            ({"launch_pdl": True}, "true"),
+            ({"launch_pdl": 0}, "false"),
+            ({"launch_pdl": 1}, "true"),
+            ({"launch_pdl": None}, "false"),
+            (
+                {"launch_pdl": False, "backend_options": {"launch_pdl": True}},
+                "true",
+            ),
+            (
+                {"launch_pdl": True, "backend_options": {"launch_pdl": False}},
+                "false",
+            ),
+        ],
+    )
+    def test_launch_pdl_cpp_literal(self, triton_meta, expected):
+        self.assertEqual(_launch_pdl_cpp_literal(triton_meta), expected)
+
+    @parametrize("enable_kernel_profile", [False, True])
+    @parametrize("supports_pdl,launch_pdl_arg", [(True, ", true"), (False, "")])
+    def test_triton_wrapper_forwards_launch_pdl(
+        self, enable_kernel_profile, supports_pdl, launch_pdl_arg
+    ):
+        class FakeDeviceCodegen:
+            @staticmethod
+            def cpp_kernel_launch_supports_pdl():
+                return supports_pdl
+
+        class FakeWrapper:
+            device_codegen = FakeDeviceCodegen()
+
+            @staticmethod
+            def generate_args_decl(
+                prefix,
+                call_args,
+                arg_types,
+                arg_signatures,
+                is_triton_kernel=True,
+                scratch_spaces=None,
+            ):
+                return ""
+
+        prefix = IndentedBuffer()
+        params = {
+            "triton_meta": {
+                "signature": {"x": "*fp32"},
+                "constants": {},
+                "launch_pdl": True,
+            },
+            "def_args": ["x"],
+            "call_args": ["x"],
+            "config": {},
+            "num_warps": 4,
+            "shared_mem": 0,
+        }
+        with config.patch({"cpp.enable_kernel_profile": enable_kernel_profile}):
+            DeferredTritonCallWrapper(
+                wrapper_name="wrapper",
+                kernel_name="kernel",
+                kernel_name_to_body={},
+                arg_types=[torch.float32],
+            ).generate_launch_kernel(prefix, FakeWrapper(), "kernel_var", params)
+
+        self.assertIn(
+            "launchKernel(kernel_var, grid_0, grid_1, grid_2, 4, 0, "
+            f"kernel_args_, stream_{launch_pdl_arg});",
+            prefix.getvalue(),
+        )
+
+    @parametrize("supports_pdl,launch_pdl_arg", [(True, ", true"), (False, "")])
+    def test_lazy_triton_wrapper_forwards_launch_pdl(
+        self, supports_pdl, launch_pdl_arg
+    ):
+        class FakeDeviceCodegen:
+            @staticmethod
+            def cpp_device_ptr():
+                return "CUdeviceptr"
+
+            @staticmethod
+            def cpp_kernel_launch_supports_pdl():
+                return supports_pdl
+
+        class FakeWrapper:
+            device_codegen = FakeDeviceCodegen()
+
+            @staticmethod
+            def generate_args_decl(
+                prefix,
+                call_args,
+                arg_types,
+                arg_signatures,
+                is_triton_kernel=True,
+                scratch_spaces=None,
+            ):
+                return ""
+
+            @staticmethod
+            def codegen_dtype(dtype):
+                return "at::ScalarType::Byte"
+
+            @staticmethod
+            def codegen_device(device):
+                return "c10::DeviceType::CUDA, 0"
+
+        prefix = DualIndentedBuffer()
+        deferred = DeferredTritonCallWrapper(
+            wrapper_name="wrapper",
+            kernel_name="kernel",
+            kernel_name_to_body={},
+            arg_types=[torch.float32],
+            triton_meta={
+                "signature": {"x": "*fp32"},
+                "constants": {},
+                "launch_pdl": True,
+            },
+        )
+        deferred._generate_lazy_launch(prefix, FakeWrapper(), ["x"], ["x"])
+
+        expected_args = (
+            "grid_0, grid_1, grid_2, kernel_result.num_warps, "
+            f"kernel_result.shared_mem, kernel_args_, stream_{launch_pdl_arg}"
+        )
+        self.assertIn(f"launchKernel(kernel, {expected_args});", prefix.getvalue())
+        self.assertIn(
+            f"launchKernel(kernels_.kernel, {expected_args});",
+            prefix.aot.getvalue(),
+        )
 
     @parametrize("per_subkernel_blocks", [False, True])
     def test_lazy_compile_combo_kernel_default_config(self, per_subkernel_blocks):

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -377,6 +377,9 @@ class DeviceOpOverrides:
     def kernel_driver(self) -> str:
         raise NotImplementedError
 
+    def cpp_kernel_launch_supports_pdl(self) -> bool:
+        return False
+
     def cpp_stream_type(self) -> str:
         raise NotImplementedError
 

--- a/torch/_inductor/codegen/cpp_wrapper_gpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_gpu.py
@@ -73,6 +73,16 @@ def cpp_string_literal(s: str) -> str:
     return f'"{escaped}"'
 
 
+def _launch_pdl_cpp_literal(triton_meta: TritonMeta | None) -> str:
+    """Resolve Triton's effective per-kernel PDL launch option."""
+    if triton_meta is None:
+        return "false"
+
+    backend_options = triton_meta.get("backend_options") or {}
+    launch_pdl = backend_options.get("launch_pdl", triton_meta.get("launch_pdl", False))
+    return "true" if launch_pdl else "false"
+
+
 def generate_aoti_kernel_config_header(kernel_names: list[str]) -> str:
     """Generate a C header defining macros for each lazy-compiled kernel.
 
@@ -611,11 +621,17 @@ class DeferredTritonCallWrapper:
         )
         call_args_str = self._generate_lazy_scratch(prefix, wrapper, call_args_str)
 
+        launch_pdl = (
+            _launch_pdl_cpp_literal(self.triton_meta)
+            if wrapper.device_codegen.cpp_kernel_launch_supports_pdl()
+            else None
+        )
+        launch_pdl_arg = f", {launch_pdl}" if launch_pdl is not None else ""
         common_launch_args = (
             f"grid_0, grid_1, grid_2,"
             f" {kernel_name}_result.num_warps,"
             f" {kernel_name}_result.shared_mem,"
-            f" kernel_args_, stream_"
+            f" kernel_args_, stream_{launch_pdl_arg}"
         )
         # stream_ comes from the generated wrapper signature on both JIT and
         # AOTI sides.
@@ -649,6 +665,7 @@ class DeferredTritonCallWrapper:
                     *launch_kernel_args,
                     "kernel_args_",
                     "stream_",
+                    *([launch_pdl] if launch_pdl is not None else []),
                 ],
                 num_warps=f"{kernel_name}_result.num_warps",
                 shared_mem=f"{kernel_name}_result.shared_mem",
@@ -919,6 +936,8 @@ class DeferredTritonCallWrapper:
             "kernel_args_",
             "stream_",
         ]
+        if wrapper.device_codegen.cpp_kernel_launch_supports_pdl():
+            launch_kernel_args.append(_launch_pdl_cpp_literal(triton_meta))
 
         enable_kernel_profile = config.cpp.enable_kernel_profile and sys.platform in [
             "linux",

--- a/torch/_inductor/codegen/cuda/device_op_overrides.py
+++ b/torch/_inductor/codegen/cuda/device_op_overrides.py
@@ -57,6 +57,9 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
         """
         return source_codes
 
+    def cpp_kernel_launch_supports_pdl(self) -> bool:
+        return torch.version.hip is None
+
     def kernel_driver(self) -> str:
         """Return C++ host-side helpers (loadKernel, launchKernel, CUDA_DRIVER_CHECK)
         embedded in AOTI-generated wrapper code."""
@@ -131,6 +134,49 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                 return func;
             }
 
+            __LAUNCH_KERNEL__
+        """
+        if self.cpp_kernel_launch_supports_pdl():
+            launch_kernel = """
+            static inline void launchKernel(
+                    CUfunction func,
+                    uint32_t gridX,
+                    uint32_t gridY,
+                    uint32_t gridZ,
+                    uint32_t numWarps,
+                    uint32_t sharedMemBytes,
+                    void* args[],
+                    cudaStream_t stream,
+                    bool launchPdl) {
+                if (!launchPdl) {
+                    CUDA_DRIVER_CHECK(cuLaunchKernel(
+                        func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
+                    ));
+                    return;
+                }
+
+                CUlaunchAttribute launchAttr{};
+                launchAttr.id =
+                    CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+                launchAttr.value.programmaticStreamSerializationAllowed = 1;
+
+                CUlaunchConfig launchConfig{};
+                launchConfig.gridDimX = gridX;
+                launchConfig.gridDimY = gridY;
+                launchConfig.gridDimZ = gridZ;
+                launchConfig.blockDimX = __WARP_SIZE__ * numWarps;
+                launchConfig.blockDimY = 1;
+                launchConfig.blockDimZ = 1;
+                launchConfig.sharedMemBytes = sharedMemBytes;
+                launchConfig.hStream = stream;
+                launchConfig.attrs = &launchAttr;
+                launchConfig.numAttrs = 1;
+                CUDA_DRIVER_CHECK(
+                    cuLaunchKernelEx(&launchConfig, func, args, nullptr));
+            }
+            """
+        else:
+            launch_kernel = """
             static inline void launchKernel(
                     CUfunction func,
                     uint32_t gridX,
@@ -144,13 +190,16 @@ class CUDADeviceOpOverrides(DeviceOpOverrides):
                     func, gridX, gridY, gridZ, __WARP_SIZE__*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
                 ));
             }
-        """
+            """
+
         if torch.version.hip is not None and torch.cuda.is_available():
             device = torch.device("cuda", torch.cuda.current_device())
             warp_size = get_warp_size(device)
         else:
             warp_size = 32
-        return source_codes.replace("__WARP_SIZE__", str(warp_size))
+        return source_codes.replace("__LAUNCH_KERNEL__", launch_kernel.strip()).replace(
+            "__WARP_SIZE__", str(warp_size)
+        )
 
     def tma_descriptor_helpers(self) -> str:
         """


### PR DESCRIPTION
Summary:

Forward Triton's effective per-kernel `launch_pdl` option through normal, lazy, and profiled AOTI CUDA launches.

Use a backend capability to keep non-PDL launch signatures unchanged. NVIDIA CUDA uses `cuLaunchKernelEx` with `CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION` for enabled kernels, while disabled CUDA kernels and ROCm retain the legacy launch path.

Add focused source-generation coverage and SM90 package coverage for both enabled and disabled PDL launches.

Test Plan:
Validated option precedence and truthiness plus capable/non-capable normal, lazy, and profiled launch signatures:

```
buck2 test fbcode//mode/opt \
  fbcode//caffe2/test/inductor:gpu_cpp_wrapper -- \
  test_cpp_scratch_scales_with_grid_size_for_tma \
  test_triton_wrapper_scales_scratch_with_num_ctas \
  test_launch_pdl_cpp_literal \
  test_lazy_triton_wrapper_forwards_launch_pdl \
  test_triton_wrapper_forwards_launch_pdl
```

Result: 18 passed.

Validated PDL-disabled and PDL-enabled AOTInductor packages on H100. Both variants compile, load, execute, and match eager; generated code checks the corresponding `false`/`true` host launch argument and absence/presence of device PDL intrinsics:

```
buck2 test fbcode//mode/opt \
  -c fbcode.enable_gpu_sections=true \
  fbcode//caffe2/test/inductor:aoti_pdl
```

Result: 3 passed.

Ran `arc lint -a` on the changed Python files and the repository validators. All configured validators passed.

Differential Revision: D116457083




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo