### PR TITLE
Fix undefined ProcessGroupOptions docstring reference

### DIFF
--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -2436,7 +2436,7 @@ def init_process_group(
             When TORCH_NCCL_BLOCKING_WAIT is set, the process will block and wait for this timeout.
 
         group_name (str, optional, deprecated): Group name. This argument is ignored
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. As of now, the only
             options we support is ``ProcessGroupNCCL.Options`` for the ``nccl``
@@ -6721,7 +6721,7 @@ def split_group(
             list determines the group rank in the new group. All ranks must pass
             the same ordering.
         timeout (timedelta, optional): see `init_process_group` for details and default value.
-        pg_options (ProcessGroupOptions, optional): Additional options need to be passed in during
+        pg_options (Backend.Options, optional): Additional options need to be passed in during
             the construction of specific process groups. i.e.``is_high_priority_stream``
             can be specified so that process group can pick up high priority cuda streams.
         group_desc (str, optional): a string to describe the process group.
@@ -7003,7 +7003,7 @@ def new_group(
             ``Backend.GLOO``). If ``None`` is passed in, the backend
             corresponding to the default process group will be used. Default is
             ``None``.
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. i.e. for the ``nccl``
             backend, ``is_high_priority_stream`` can be specified so that
@@ -7278,7 +7278,7 @@ def new_subgroups(
             ``Backend.GLOO``). If ``None`` is passed in, the backend
             corresponding to the default process group will be used. Default is
             ``None``.
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. i.e. for the ``nccl``
             backend, ``is_high_priority_stream`` can be specified so that
@@ -7378,7 +7378,7 @@ def new_subgroups_by_enumeration(
              ``Backend.GLOO``). If ``None`` is passed in, the backend
              corresponding to the default process group will be used. Default is
              ``None``.
-        pg_options (ProcessGroupOptions, optional): process group options
+        pg_options (Backend.Options, optional): process group options
             specifying what additional options need to be passed in during
             the construction of specific process groups. i.e. for the ``nccl``
             backend, ``is_high_priority_stream`` can be specified so that
@@ -7545,7 +7545,7 @@ def shrink_group(
             ``SHRINK_ABORT`` will attempt to terminate ongoing operations
             in the parent communicator before shrinking.
             Defaults to ``SHRINK_DEFAULT``.
-        pg_options (ProcessGroupOptions, optional): Backend-specific options to apply
+        pg_options (Backend.Options, optional): Backend-specific options to apply
             to the shrunken process group. If provided, the backend will use
             these options when creating the new group. If omitted, the new group
             inherits defaults from the parent.


### PR DESCRIPTION
## Summary

Several `pg_options` docstrings in `torch/distributed/distributed_c10d.py` reference a `ProcessGroupOptions` type that is never defined anywhere in the codebase (searched `.py`, `.pyi`, `.md`, `.rst`).

The actual accepted base type is `Backend.Options` — this matches:
- the type annotation already used on `init_process_group`'s `pg_options` parameter (`C10DBackend.Options`, where `C10DBackend` is `Backend` imported from `torch._C._distributed_c10d`)
- the nested `Options` class declared under `Backend` in `torch/_C/_distributed_c10d.pyi`
- the existing pattern in `docs/source/distributed.md`, which already points users to concrete subclasses like `torch.distributed.ProcessGroupNCCL.Options`

This updates the six `pg_options (ProcessGroupOptions, optional)` docstring references to `pg_options (Backend.Options, optional)`.

Fixes #130958

## Test plan

- [x] `grep -rn "ProcessGroupOptions"` across `.py`/`.pyi`/`.md`/`.rst` returns no remaining references
- Docs-only change, no functional/behavioral code touched