### PR TITLE
[MPS] fail loudly on large reductions

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -275,10 +275,10 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
     return;
   }
 
-  TORCH_CHECK(canUse32BitIndexMath(input, 1LL << 32),
-              "MPS norm: tensors requiring 64-bit indexing are not supported (numel=",
-              input.numel(),
-              ")");
+  TORCH_CHECK_NOT_IMPLEMENTED(canUse32BitIndexMath(input, 1LL << 32),
+                              "MPS norm: tensors requiring 64-bit indexing are not supported (numel=",
+                              input.numel(),
+                              ")");
   // Number of input elements that are reduced into one output element
   uint32_t reduction_size = input.numel() / output.numel();
 
@@ -925,11 +925,11 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
     return;
   }
 
-  TORCH_CHECK(canUse32BitIndexMath(input, 1LL << 32),
-              func_name,
-              ": tensors requiring 64-bit indexing are not supported on MPS (numel=",
-              input.numel(),
-              ")");
+  TORCH_CHECK_NOT_IMPLEMENTED(canUse32BitIndexMath(input, 1LL << 32),
+                              func_name,
+                              ": tensors requiring 64-bit indexing are not supported on MPS (numel=",
+                              input.numel(),
+                              ")");
   const auto kernel_name = fmt::format("{}_reduction_{}_long", op_prefix, in_str);
 
   NormParams params{};
@@ -1015,12 +1015,12 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
     }
   }
 
-  TORCH_CHECK(canUse32BitIndexMath(input_orig, 1LL << 32),
-              "MPS ",
-              opts.prefix,
-              "reduction: tensors requiring 64-bit indexing are not supported (numel=",
-              input_orig.numel(),
-              ")");
+  TORCH_CHECK_NOT_IMPLEMENTED(canUse32BitIndexMath(input_orig, 1LL << 32),
+                              "MPS ",
+                              opts.prefix,
+                              "reduction: tensors requiring 64-bit indexing are not supported (numel=",
+                              input_orig.numel(),
+                              ")");
   const uint32_t reduction_size = input_orig.numel() / output.numel();
   constexpr uint32_t NCHAINS = SUM_NCHAINS;
   MPSStream* stream = getCurrentMPSStream();

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -275,6 +275,10 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
     return;
   }
 
+  TORCH_CHECK(canUse32BitIndexMath(input, 1LL << 32),
+              "MPS norm: tensors requiring 64-bit indexing are not supported (numel=",
+              input.numel(),
+              ")");
   // Number of input elements that are reduced into one output element
   uint32_t reduction_size = input.numel() / output.numel();
 
@@ -343,7 +347,7 @@ static void norm_kernel_mps(TensorIterator& iter, const Scalar& p_scalar) {
       mtl_setArgs(compute_encoder, input, output, params);
 
       auto threads_per_group = std::min(MAX_THREADGROUP_SIZE, reduction_size);
-      uint32_t num_threads = output.numel() * threads_per_group;
+      const auto num_threads = static_cast<uint64_t>(output.numel()) * threads_per_group;
 
       [compute_encoder dispatchThreads:MTLSizeMake(num_threads, 1, 1)
                  threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
@@ -921,6 +925,11 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
     return;
   }
 
+  TORCH_CHECK(canUse32BitIndexMath(input, 1LL << 32),
+              func_name,
+              ": tensors requiring 64-bit indexing are not supported on MPS (numel=",
+              input.numel(),
+              ")");
   const auto kernel_name = fmt::format("{}_reduction_{}_long", op_prefix, in_str);
 
   NormParams params{};
@@ -944,7 +953,7 @@ static void argmax_argmin_out_mps(const Tensor& input_t,
       // Op::identity() and skip the per-thread scan, keeping the two-stage
       // SIMD reduction well-defined for all reduction sizes.
       const auto threads_per_group = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(params.reduction_size, 32u));
-      const auto num_threads = static_cast<uint32_t>(output_view.numel()) * threads_per_group;
+      const auto num_threads = static_cast<uint64_t>(output_view.numel()) * threads_per_group;
       [ce dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
       getMPSProfiler().endProfileKernel(ps, stream);
     }
@@ -1006,6 +1015,12 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
     }
   }
 
+  TORCH_CHECK(canUse32BitIndexMath(input_orig, 1LL << 32),
+              "MPS ",
+              opts.prefix,
+              "reduction: tensors requiring 64-bit indexing are not supported (numel=",
+              input_orig.numel(),
+              ")");
   const uint32_t reduction_size = input_orig.numel() / output.numel();
   constexpr uint32_t NCHAINS = SUM_NCHAINS;
   MPSStream* stream = getCurrentMPSStream();
@@ -1643,7 +1658,7 @@ static void reduction_dispatch_mps(TensorIterator& iter, const ReductionDispatch
       // is not zero. Padding threads load Op::identity() and contribute
       // nothing to the result.
       const auto threads_per_group = std::min(MAX_THREADGROUP_SIZE, c10::metal::round_up(reduction_size, 32u));
-      uint32_t num_threads = output.numel() * threads_per_group;
+      const auto num_threads = static_cast<uint64_t>(output.numel()) * threads_per_group;
       [ce dispatchThreads:MTLSizeMake(num_threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
       getMPSProfiler().endProfileKernel(ps, stream);
     }

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16718,7 +16718,9 @@ class TestConsistency(TestCaseMPS):
         x[-1, -1, :] = 1000.0
         x = x.requires_grad_(True)
         weight = torch.ones(C, device=device, dtype=dtype, requires_grad=True)
-        torch.group_norm(x, num_groups=C, weight=weight).sum().backward()
+        # .sum() over >2**32 elements raises on MPS; pass the gradient directly
+        out = torch.group_norm(x, num_groups=C, weight=weight)
+        out.backward(torch.ones((), device=device, dtype=dtype).expand(out.shape))
 
         x_last_cpu = x[-1:, -1:].detach().cpu().requires_grad_(True)
         weight_last_cpu = torch.ones(1, dtype=dtype, requires_grad=True)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16718,9 +16718,13 @@ class TestConsistency(TestCaseMPS):
         x[-1, -1, :] = 1000.0
         x = x.requires_grad_(True)
         weight = torch.ones(C, device=device, dtype=dtype, requires_grad=True)
-        # .sum() over >2**32 elements raises on MPS; pass the gradient directly
+        # .sum() over >2**32 elements raises on MPS; reuse out as its own ones
+        # gradient to keep peak memory at the old sum().backward() level
+        # (out is not saved for backward, so the in-place fill is safe)
         out = torch.group_norm(x, num_groups=C, weight=weight)
-        out.backward(torch.ones((), device=device, dtype=dtype).expand(out.shape))
+        with torch.no_grad():
+            out.fill_(1)
+        out.backward(out)
 
         x_last_cpu = x[-1:, -1:].detach().cpu().requires_grad_(True)
         weight_last_cpu = torch.ones(1, dtype=dtype, requires_grad=True)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2515,7 +2515,8 @@ class TestReductions(TestCase):
         subtest((lambda x: x.argmax(), (1 << 32) + 4095), name="argmax"),
         subtest((lambda x: x.min(), 0), name="min"),
         subtest((lambda x: x.argmin(), 0), name="argmin"),
-        subtest((lambda x: x.sum(), 1), name="sum"),
+        # sum promotes int8 to int64, materializing a 32GB cast of the input on CUDA
+        subtest((lambda x: x.sum(), 1), name="sum", decorators=[largeTensorTest("36GB", device="cuda")]),
         subtest((lambda x: x.any(), True), name="any"),
         subtest((lambda x: x.all(), False), name="all"),
         subtest((lambda x: x.view(-1, 4096).max(0).indices[4095], 1 << 20), name="max_dim"),

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -20,7 +20,7 @@ from torch.testing._internal.common_dtype import (
 )
 from torch.testing._internal.common_utils import (
     TestCase, run_tests, skipIfNoSciPy, slowTest, torch_to_numpy_dtype_dict,
-    parametrize, serialTest,
+    parametrize, serialTest, subtest,
     gradcheck, gradgradcheck,
     skipIfMPS,
     skipIfTorchDynamo,
@@ -2496,7 +2496,6 @@ class TestReductions(TestCase):
         run_test(torch.zeros(64, 1, dtype=dtype, device=device))
 
     @onlyAccelerator
-    @skipIfMPS
     def test_argminmax_large_axis(self, device):
         # Regression test for gh-32863
         x = torch.zeros(2**31, device=device, dtype=torch.int8)
@@ -2506,6 +2505,29 @@ class TestReductions(TestCase):
         x[-1] = -1
         self.assertEqual(x.argmin(0), x.shape[0] - 1)
         self.assertEqual(x.min(0).indices, x.shape[0] - 1)
+
+    @onlyAccelerator
+    @serialTest()
+    @largeMPSBufferTest("5GB")
+    @largeTensorTest("5GB")
+    @parametrize("fn,expected", [
+        subtest((lambda x: x.max(), 1), name="max"),
+        subtest((lambda x: x.argmax(), (1 << 32) + 4095), name="argmax"),
+        subtest((lambda x: x.min(), 0), name="min"),
+        subtest((lambda x: x.argmin(), 0), name="argmin"),
+        subtest((lambda x: x.sum(), 1), name="sum"),
+        subtest((lambda x: x.any(), True), name="any"),
+        subtest((lambda x: x.all(), False), name="all"),
+        subtest((lambda x: x.view(-1, 4096).max(0).indices[4095], 1 << 20), name="max_dim"),
+    ])
+    def test_reductions_above_uint32(self, device, fn, expected):
+        x = torch.zeros((1 << 32) + 4096, device=device, dtype=torch.int8)
+        x[-1] = 1
+        # MPS reduction kernels index in 32 bits and should raise
+        if self.device_type == "mps":
+            self.assertRaisesRegex(RuntimeError, "64-bit indexing", fn, x)
+        else:
+            self.assertEqual(fn(x), expected)
 
     def test_argminmax_axis_with_dim_one(self, device):
         # See: https://github.com/pytorch/pytorch/issues/38922

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2525,7 +2525,7 @@ class TestReductions(TestCase):
         x[-1] = 1
         # MPS reduction kernels index in 32 bits and should raise
         if self.device_type == "mps":
-            self.assertRaisesRegex(RuntimeError, "64-bit indexing", fn, x)
+            self.assertRaisesRegex(NotImplementedError, "64-bit indexing", fn, x)
         else:
             self.assertEqual(fn(x), expected)
 


### PR DESCRIPTION
In torch 2.13, different sorts of reductions either failed silently or loudly. We moved reductions from MPS Graph to metal kernels in 2.14 release window so now all of them fail silently which is undesirable. 

On 2.13:
```
2.13.0
max: LOUD, MPSGraph does not support tensor dims larger than INT_MAX
min: LOUD, MPSGraph does not support tensor dims larger than INT_MAX
argmax: SILENT, got 0, expected 4294971391
argmin: SILENT, got 0, expected 4294971390
sum: LOUD, Invalid buffer size: 32.00 GiB
any: SILENT, got False, expected True
all: SILENT, got False, expected False
/AppleInternal/Library/BuildRoots/4~CVgYugAT3S26YKw_WTHjKp2atJ12TlDHkpTIXrw/Library/Caches/com.apple.xbs/TemporaryDirectory.j9fbvO/Sources/MetalPerformanceShadersGraph/mpsgraph/MetalPerformanceShadersGraph/Runtimes/MPSRuntime/Operations/GPUMemrefOps.mm:696: failed assertion `Failed to allocate MTLBuffer of 17179885568 B for oversized fused alloc.'
zsh: abort      python temp.py
```

After this PR:
```
2.15.0a0+gitfd3c978
max: LOUD, MPS max_reduction: tensors requiring 64-bit indexing are not supported (numel=4294971392)
min: LOUD, MPS min_reduction: tensors requiring 64-bit indexing are not supported (numel=4294971392)
argmax: LOUD, argmax_out_mps: tensors requiring 64-bit indexing are not supported on MPS (numel=4294971392)
argmin: LOUD, argmin_out_mps: tensors requiring 64-bit indexing are not supported on MPS (numel=4294971392)
sum: LOUD, MPS sum_reduction: tensors requiring 64-bit indexing are not supported (numel=4294971392)
any: LOUD, MPS any_reduction: tensors requiring 64-bit indexing are not supported (numel=4294971392)
all: LOUD, MPS all_reduction: tensors requiring 64-bit indexing are not supported (numel=4294971392)
max.dim: LOUD, max_out_mps: tensors requiring 64-bit indexing are not supported on MPS (numel=4294971392)
min.dim: LOUD, min_out_mps: tensors requiring 64-bit indexing are not supported on MPS (numel=4294971392)
```