### PR TITLE
[TEST] Refactor test_python_dispatch.py with hw_classification

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
     first_sample,
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_WINDOWS,
     parametrize,
@@ -106,6 +107,8 @@ class _ClassmethodUnflattenWrapper(_TraceableWrapperSubclassTestBase):
 
 
 class TestDispatcherPythonBindings(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_call_boxed(self) -> None:
         sin = torch._C._dispatch_find_schema_or_throw("aten::sin", "")
         x = torch.randn(3)
@@ -114,6 +117,7 @@ class TestDispatcherPythonBindings(TestCase):
 
 
 class TestPythonRegistration(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     test_ns = "_test_python_registration"
 
     def tearDown(self):
@@ -556,136 +560,6 @@ class TestPythonRegistration(TestCase):
         # Validate that the old behavior is restored for sum
         self.assertEqual(torch.sum(x), torch.tensor(3))
 
-    def test_override_cuda_with_jiterator(self) -> None:
-        def override_where_cuda() -> None:
-            # Example 1: Invert the behavior of where's condition input
-            not_where_code_string = """
-            template <typename T> T inverted_where(bool cond, T a, T b){
-                return !cond ? a : b;
-            }
-            """
-            jitted_where = _create_jit_fn(not_where_code_string)
-
-            CALLED = [False]
-
-            def inverted_where(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_where(*args, **kwargs)
-
-            # overriding where's cuda kernel with Jiterator generated kernel
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::where.self", inverted_where, "CUDA")
-
-                device = "cuda"
-                cond = torch.tensor(
-                    [True, True, False], device=device, dtype=torch.bool
-                )
-                x = torch.tensor([1, 2, 3], device=device)
-                y = torch.tensor([-1, -2, -3], device=device)
-
-                self.assertEqual(torch.where(cond, x, y), torch.tensor([-1, -2, 3]))
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertEqual(torch.where(cond, x, y), torch.tensor([1, 2, -3]))
-
-        def override_gelu_cuda() -> None:
-            # Example 2: Use relu to approximate gelu for faster compute
-            fastest_gelu_code_string = """
-            template <typename T> T fast_gelu(T a){
-                return a > 0 ? a : 0;
-            }
-            """
-            jitted_gelu = _create_jit_fn(fastest_gelu_code_string)
-
-            CALLED = [False]
-
-            def fast_gelu(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_gelu(*args, **kwargs)
-
-            # overriding gelu's cuda kernel with Jiterator generated relu kernel
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::gelu", fast_gelu, "CUDA")
-
-                x = torch.rand([3, 3], device="cuda", dtype=torch.float)
-                self.assertEqual(
-                    torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
-                )
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertNotEqual(
-                torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
-            )
-
-        def override_exp_cuda() -> None:
-            # Example 3: Preventing exp from exploding for float16
-            clipped_exp_code_string = """
-            template <typename T> T clipped_exp(T a){
-                return a > T(10.0) ? T(22026.4657948) : exp(a);
-            }
-            """
-            jitted_exp = _create_jit_fn(clipped_exp_code_string)
-
-            CALLED = [False]
-
-            def clipped_exp(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_exp(*args, **kwargs)
-
-            # overriding exp's cuda kernel with clipped_exp kernel
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::exp", clipped_exp, "CUDA")
-
-                x = torch.tensor([0.0, 100.0], device="cuda", dtype=torch.float16)
-                self.assertEqual(
-                    torch.exp(x),
-                    torch.tensor([1.0, 22026.4657948], dtype=torch.float16),
-                )
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertEqual(
-                torch.exp(x), torch.tensor([1.0, torch.inf], dtype=torch.float16)
-            )
-
-        def override_add_cuda() -> None:
-            # Example 4: simulate a hardware bug, where the adder is always off by 1
-            buggy_add_code_string = """
-            template <typename T> T buggy_add(T a, T b){
-                return a + b + T(1);
-            }
-            """
-            jitted_add = _create_jit_fn(buggy_add_code_string)
-
-            CALLED = [False]
-
-            def buggy_add(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_add(*args, **kwargs)
-
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::add.Tensor", buggy_add, "CUDA")
-
-                x_cpu = torch.rand([3, 3], device="cpu")
-                y_cpu = torch.rand([3], device="cpu")
-
-                x_cuda = x_cpu.cuda()
-                y_cuda = y_cpu.cuda()
-
-                self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu + 1)
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu)
-
-        if torch.cuda.is_available() and not TEST_WITH_ROCM:
-            override_where_cuda()
-            override_gelu_cuda()
-            override_exp_cuda()
-            override_add_cuda()
-
     def test_extend_library_with_dispatch_key_arg(self):
         def my_sum(*args, **kwargs):
             return args[0].clone()
@@ -879,7 +753,143 @@ class TestPythonRegistration(TestCase):
 instantiate_parametrized_tests(TestPythonRegistration)
 
 
+class TestPythonRegistrationCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def test_override_cuda_with_jiterator(self) -> None:
+        def override_where_cuda() -> None:
+            # Example 1: Invert the behavior of where's condition input
+            not_where_code_string = """
+            template <typename T> T inverted_where(bool cond, T a, T b){
+                return !cond ? a : b;
+            }
+            """
+            jitted_where = _create_jit_fn(not_where_code_string)
+
+            CALLED = [False]
+
+            def inverted_where(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_where(*args, **kwargs)
+
+            # overriding where's cuda kernel with Jiterator generated kernel
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::where.self", inverted_where, "CUDA")
+
+                device = "cuda"
+                cond = torch.tensor(
+                    [True, True, False], device=device, dtype=torch.bool
+                )
+                x = torch.tensor([1, 2, 3], device=device)
+                y = torch.tensor([-1, -2, -3], device=device)
+
+                self.assertEqual(torch.where(cond, x, y), torch.tensor([-1, -2, 3]))
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertEqual(torch.where(cond, x, y), torch.tensor([1, 2, -3]))
+
+        def override_gelu_cuda() -> None:
+            # Example 2: Use relu to approximate gelu for faster compute
+            fastest_gelu_code_string = """
+            template <typename T> T fast_gelu(T a){
+                return a > 0 ? a : 0;
+            }
+            """
+            jitted_gelu = _create_jit_fn(fastest_gelu_code_string)
+
+            CALLED = [False]
+
+            def fast_gelu(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_gelu(*args, **kwargs)
+
+            # overriding gelu's cuda kernel with Jiterator generated relu kernel
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::gelu", fast_gelu, "CUDA")
+
+                x = torch.rand([3, 3], device="cuda", dtype=torch.float)
+                self.assertEqual(
+                    torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
+                )
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertNotEqual(
+                torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
+            )
+
+        def override_exp_cuda() -> None:
+            # Example 3: Preventing exp from exploding for float16
+            clipped_exp_code_string = """
+            template <typename T> T clipped_exp(T a){
+                return a > T(10.0) ? T(22026.4657948) : exp(a);
+            }
+            """
+            jitted_exp = _create_jit_fn(clipped_exp_code_string)
+
+            CALLED = [False]
+
+            def clipped_exp(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_exp(*args, **kwargs)
+
+            # overriding exp's cuda kernel with clipped_exp kernel
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::exp", clipped_exp, "CUDA")
+
+                x = torch.tensor([0.0, 100.0], device="cuda", dtype=torch.float16)
+                self.assertEqual(
+                    torch.exp(x),
+                    torch.tensor([1.0, 22026.4657948], dtype=torch.float16),
+                )
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertEqual(
+                torch.exp(x), torch.tensor([1.0, torch.inf], dtype=torch.float16)
+            )
+
+        def override_add_cuda() -> None:
+            # Example 4: simulate a hardware bug, where the adder is always off by 1
+            buggy_add_code_string = """
+            template <typename T> T buggy_add(T a, T b){
+                return a + b + T(1);
+            }
+            """
+            jitted_add = _create_jit_fn(buggy_add_code_string)
+
+            CALLED = [False]
+
+            def buggy_add(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_add(*args, **kwargs)
+
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::add.Tensor", buggy_add, "CUDA")
+
+                x_cpu = torch.rand([3, 3], device="cpu")
+                y_cpu = torch.rand([3], device="cpu")
+
+                x_cuda = x_cpu.cuda()
+                y_cuda = y_cpu.cuda()
+
+                self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu + 1)
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu)
+
+        if torch.cuda.is_available() and not TEST_WITH_ROCM:
+            override_where_cuda()
+            override_gelu_cuda()
+            override_exp_cuda()
+            override_add_cuda()
+
+
 class TestPythonDispatch(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self) -> None:
         with capture_logs() as logs:
             x = LoggingTensor(torch.tensor([3.0]), requires_grad=True)
@@ -2792,6 +2802,8 @@ def forward(self, x_1):
 
 
 class TestPythonDispatcher(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         x = torch.randn(2, requires_grad=True)
         r = torch._C._EnablePythonDispatcher()
@@ -2807,6 +2819,8 @@ class TestPythonDispatcher(TestCase):
 
 
 class TestWrapperSubclassAliasing(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_wrapper_subclass_aliasing(self, op, args, kwargs):
         def to_subclass(t: torch.Tensor):
             return TwoTensor(t, t.clone())


### PR DESCRIPTION
## Summary
Apply hardware classification structure following #186918 guidelines.

- Add `hw_classification = GENERIC` to `TestDispatcherPythonBindings`, `TestPythonRegistration`, `TestPythonDispatch`, `TestPythonDispatcher` — none of these exercise real accelerator numerics, they test dispatcher/library-registration/subclass mechanics on plain CPU tensors.
- Add `hw_classification = ACCELERATOR` to `TestWrapperSubclassAliasing` — already parameterized via `instantiate_device_type_tests`, no structural changes needed.
- Split `TestPythonRegistration`: extracted `test_override_cuda_with_jiterator` (relies on the CUDA/ROCm-only Jiterator runtime compiler, skipped entirely under ROCm) into a new `TestPythonRegistrationCUDA` class classified `CUDA`.

## Test Plan

    python test/test_python_dispatch.py -v
    Ran 150 tests in 2.902s — OK

    python test/test_python_dispatch.py -v --hw-classification GENERIC
    Ran 109 tests in 1.623s — OK

    python test/test_python_dispatch.py -v --hw-classification ACCELERATOR
    Ran 40 tests in 1.065s — OK

    python test/test_python_dispatch.py -v --hw-classification CUDA
    Ran 1 test in 1.090s — OK
