### PR TITLE
[dynamo] Replace three Any annotations in compiled_autograd/decorators

### DIFF
--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -60,6 +60,7 @@ from torch.fx.experimental.proxy_tensor import (
     track_tensor_tree,
 )
 from torch.fx.experimental.symbolic_shapes import DimDynamic, ShapeEnv
+from torch.fx.node import Argument
 from torch.fx.traceback import preserve_node_meta, set_stack_trace
 from torch.types import FloatLikeType, IntLikeType
 from torch.utils._ordered_set import OrderedSet
@@ -1079,14 +1080,6 @@ class AutogradCompilerInstance:
 
         return []
 
-    def is_sym_node(self, node: Any) -> bool:
-        return (
-            isinstance(node, torch.fx.Node)
-            and node.op == "call_function"
-            and node.target
-            in [torch.ops.aten.sym_size.int, torch.ops.aten.sym_numel.default]
-        )
-
     def dce(self) -> None:
         # Most of these removed nodes would have been removed during Dynamo and AOTDispatch
         # Remove some of these nodes earlier to improve compilation speed
@@ -1290,7 +1283,7 @@ class AutogradCompilerInstance:
         return runtime_wrapper, self.compiler_fn(graph)
 
     @staticmethod
-    def get_all_nodes(args: Sequence[Any]) -> list[torch.fx.Node]:
+    def get_all_nodes(args: Sequence[Argument]) -> list[torch.fx.Node]:
         # filter out non-Node args, like None
         nodes = [n for n in args if type(n) is torch.fx.Node]
         return nodes

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -1737,7 +1737,7 @@ def override_cudagraphs(
     return CudagraphOverrideContextManager(fwd=fwd, bwd=bwd)
 
 
-def override_optimization_hint(x: Any, val: int) -> None:
+def override_optimization_hint(x: object, val: int) -> None:
     """Override the optimization hint for a scalar unbacked symbol.
 
     When the compiler or runtime needs a non-guarding integer hint for an


### PR DESCRIPTION
Three parameters in these two files were annotated `Any` and consumed only by
an `isinstance`/`type()` guard. Each one turns out to want a different fix, so
review them in the order below.

`AutogradCompilerInstance.is_sym_node` is deleted rather than re-annotated: it
has no callers. The method was added in #138968 with two call sites in `dce`,
and #141289 ("[ca] dead code elimination for compile time") removed both while
leaving the method behind. Nothing in `torch/`, `test/`, `benchmarks/`, or
`torch/csrc/dynamo/` invokes it, there is no dynamic/name-keyed dispatch to it,
and `AutogradCompilerInstance` has no subclasses. The surviving references to
that identifier -- `docs/source/fx.experimental.md` and
`test/allowlist_for_publicAPI.json` -- both name the unrelated free function
`torch.fx.experimental.proxy_tensor.is_sym_node`, which is untouched here.

`AutogradCompilerInstance.get_all_nodes` becomes `Sequence[Argument]`. Both
call sites pass FX argument data -- `reorder_accumulate_grad_nodes` passes
`node.args[0:3]` and `delay_unpack_hook_nodes` passes `node.args[1]` -- and
`Node.args` is `tuple[Argument, ...]`. `Argument` names the contract the body
implements: a sequence of FX argument values, some of which are `Node`s, which
is exactly what the `type(n) is torch.fx.Node` filter sifts. This does not
start checking anything today, because `Graph.find_nodes` returns `list[Any]`,
so `node` and therefore `node.args[...]` are statically `Any` at both call
sites; it starts checking as soon as `find_nodes` is annotated.

`override_optimization_hint` becomes `x: object` -- deliberately the top type
rather than the `IntLikeType` its docstring would suggest. `int | SymInt` looks
correct, but `Tensor.item()` is stubbed `-> Number` (`int | float | bool`), so
it would make the docstring's own primary example a type error:

    ERROR Argument `bool | float | int` is not assignable to parameter `x`
    with type `SymInt | int` [bad-argument-type]

Every typed user following the documented `u = x.item()` pattern would need a
cast or a suppression, so `IntLikeType` here buys checking by breaking the
supported usage. `Number | SymInt` avoids that but is a different lie -- the
body raises `TypeError` on `float`. The honest description of this function is
that it accepts anything and validates at runtime, which is what `object` says.

To be precise about what that buys, since it is easy to overstate: for a
*parameter*, `object` and `Any` accept exactly the same arguments, so this
restores nothing on the caller side. The gain is entirely inside the body --
the checker now verifies the `isinstance(x, int)` early return and the
`isinstance(x, torch.SymInt)` gate, and that `x.node.shape_env` / `x.node.expr`
/ `_set_unbacked_var_to_hint_override` all run on the narrowed `SymInt`,
instead of skipping the whole chain. `val: int` is left alone; it also has a
runtime `isinstance` guard, but its annotation is already precise.

Test Plan:

Type checking is the entire behavioral surface here, so the check that matters
is that the CI type checker reports nothing new. Baseline (at the merge base)
and post-change runs both report 90 errors and 10,962 suppressed, with
byte-identical sorted error lists -- no new errors and no new suppressions,
i.e. this needed zero casts and zero `pyrefly: ignore` comments:

```
uvx pyrefly@0.58.0 check --config=pyrefly.toml
```

The `IntLikeType` error quoted above is from a scratch probe under the same
config, since a false positive that only fires in user code would not show up
in the repo-wide run:

```
uvx pyrefly@0.58.0 check agent_space/probe_intlike.py --config=pyrefly.toml
```

Lint is clean on the touched files:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a \
  torch/_dynamo/decorators.py \
  torch/_dynamo/compiled_autograd.py
```

Neither file uses `from __future__ import annotations`, so annotations are
evaluated at definition time; `object` and `Sequence[Argument]` are ordinary
runtime values and annotations are only stored in `__annotations__`. The one
change with any runtime surface at all is the `is_sym_node` deletion, which is
covered by the caller search above. Verified the modules still byte-compile:

```
python -m py_compile \
  torch/_dynamo/decorators.py \
  torch/_dynamo/compiled_autograd.py
```

This checkout is not built, so the suites covering this code
(`test/inductor/test_unbacked_symints.py -k override_optimization_hint`,
`test/inductor/test_compiled_autograd.py`) are left to CI; `ciflow/trunk` is
applied.

This PR was authored with the assistance of an AI coding assistant.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk