### PR TITLE
Fix invalid padding length in reflection_pad2d_backward

### DIFF
--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -272,6 +272,11 @@ void reflection_pad2d_out_template(
 void reflection_pad2d_backward_out_template(
     Tensor &grad_input, const Tensor &grad_output,
     const Tensor &input, IntArrayRef padding) {
+  TORCH_CHECK(
+    padding.size() == 4,
+    "padding size is expected to be 4, but got: ",
+    padding.size());
+
   int dim_w = 2;
   int dim_h = 1;
 

--- a/aten/src/ATen/native/ReflectionPad.cpp
+++ b/aten/src/ATen/native/ReflectionPad.cpp
@@ -272,7 +272,7 @@ void reflection_pad2d_out_template(
 void reflection_pad2d_backward_out_template(
     Tensor &grad_input, const Tensor &grad_output,
     const Tensor &input, IntArrayRef padding) {
-  TORCH_CHECK(
+  TORCH_CHECK_VALUE(
     padding.size() == 4,
     "padding size is expected to be 4, but got: ",
     padding.size());

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8856,6 +8856,18 @@ class TestNNDeviceType(NNTestCase):
             inp = torch.randn(3, 3, 10, 10, 10, device=device)
             torch.ops.aten.reflection_pad2d(inp, (2, 2, 2, 2))
 
+        grad_output = torch.randn(1, 1, 1, device=device)
+        inp = torch.randn(1, 1, 1, device=device)
+
+        for padding in [(), (0,), (0, 0), (0, 0, 0), (0, 0, 0, 0, 0)]:
+            with self.assertRaisesRegex(
+                RuntimeError,
+                rf"padding size is expected to be 4, but got: {len(padding)}",
+            ):
+                torch.ops.aten.reflection_pad2d_backward(
+                    grad_output, inp, padding
+                )
+
         with self.assertRaisesRegex(RuntimeError, r'Padding size 6 is not supported for 6D input tensor'):
             mod = torch.nn.ReflectionPad3d(3)
             inp = torch.randn(3, 3, 10, 10, 10, 10, device=device)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8861,7 +8861,7 @@ class TestNNDeviceType(NNTestCase):
 
         for padding in [(), (0,), (0, 0), (0, 0, 0), (0, 0, 0, 0, 0)]:
             with self.assertRaisesRegex(
-                RuntimeError,
+                ValueError,
                 rf"padding size is expected to be 4, but got: {len(padding)}",
             ):
                 torch.ops.aten.reflection_pad2d_backward(


### PR DESCRIPTION
Fixes #194048

### Summary

`reflection_pad2d_backward` assumes that the `padding` argument contains exactly four values. When a shorter padding list is passed, the implementation accesses padding elements before validating the size of the list, which can result in an out-of-bounds read and an invalid runtime error.

This PR adds an explicit validation to `reflection_pad2d_backward_out_template` to ensure that `padding` contains exactly four values before accessing its elements.

### Changes

- Added a `TORCH_CHECK` requiring `padding.size() == 4`.
- Added regression coverage for invalid padding lengths:
  - `()`
  - `(0,)`
  - `(0, 0)`
  - `(0, 0, 0)`
  - `(0, 0, 0, 0, 0)`
- Valid four-element padding remains unchanged.

### Testing

Ran the targeted regression test:

```text
python test/test_nn.py -v -k test_ReflectionPad_fails

test_ReflectionPad_fails_cpu (__main__.TestNNDeviceTypeCPU) ... ok

Ran 1 test in 0.009s
OK