### PR TITLE
[inductor] Guard mutation tests requiring Triton block pointers

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -49,6 +49,7 @@ from torch.testing._internal.inductor_utils import (
     HAS_CUDA_AND_TRITON,
     HAS_GPU,
     HAS_XPU_AND_TRITON,
+    requires_block_ptr,
     TRITON_HAS_CPU,
 )
 from torch.testing._internal.logging_utils import log_settings, logs_to_string
@@ -4288,6 +4289,7 @@ class MutationTests(torch._inductor.test_case.TestCase):
             ["O_ptr"],
         )
 
+    @requires_block_ptr
     @make_mutation_test
     def test_for_loop_arg_2():
         @triton.jit
@@ -4348,6 +4350,7 @@ class MutationTests(torch._inductor.test_case.TestCase):
             ["o_ptr"],
         )
 
+    @requires_block_ptr
     @make_mutation_test
     def test_while_loop():
         @triton.jit
@@ -5018,6 +5021,11 @@ if HAS_GPU:
 
         if kernel.fn.__name__ == "add_kernel_2d_autotuned":
             fn = unittest.skip("Fails with Triton update")(fn)
+        elif kernel.fn.__name__ in {
+            "add_kernel_with_block_ptr",
+            "kernel_with_block_ptr_2d",
+        }:
+            fn = requires_block_ptr(fn)
 
         setattr(MutationTests, name, fn)
 


### PR DESCRIPTION
Triton removed block pointer frontend support in https://github.com/triton-lang/triton/pull/10833. PyTorch already guards most block-pointer-specific coverage, but four mutation tests still construct `tl.make_block_ptr` or call `tl.advance`.

In this PR we guard the remaining tests with `requires_block_ptr`. They continue to run with older Triton and skip only when the frontend API is unavailable. This will help unblock the next Triton pin without reducing coverage on older Triton versions

Failures that this addresses from test triton pin update https://github.com/pytorch/pytorch/pull/190440:
* [inductor / unit-test / inductor-test-cuda132 / test (inductor_cpp_wrapper, 1, 2, mt-l-x86aavx2-29-113-a10g)](https://hud.pytorch.org/pr/pytorch/pytorch/190440#95889003604) ([gh](https://github.com/pytorch/pytorch/actions/runs/32173038980/job/95889003604))
test/inductor/test_triton_kernels.py::MutationTests::test_for_loop_arg_2
* [inductor / unit-test / inductor-test-cuda132 / test (inductor_cpp_wrapper, 2, 2, mt-l-x86aavx2-29-113-a10g)](https://hud.pytorch.org/pr/pytorch/pytorch/190440#95889003813) ([gh](https://github.com/pytorch/pytorch/actions/runs/32173038980/job/95889003813))
test/inductor/test_triton_kernels.py::MutationTests::test_mutations_add_kernel_with_block_ptr
* [periodic / linux-jammy-cuda13.0-py3.10-gcc11 / test (default, 2, 5, mt-l-x86aavx2-29-113-l4)](https://hud.pytorch.org/pr/pytorch/pytorch/190440#95908302762) ([gh](https://github.com/pytorch/pytorch/actions/runs/32173038311/job/95908302762))
test/inductor/test_triton_kernels.py::MutationTests::test_for_loop_arg_2
* [periodic / linux-jammy-cuda13.0-py3.10-gcc11-debug / test (default, 3, 7, mt-l-x86aavx2-29-113-l4, oncall:debug-build)](https://hud.pytorch.org/pr/pytorch/pytorch/190440#95908301952) ([gh](https://github.com/pytorch/pytorch/actions/runs/32173038311/job/95908301952))
test/inductor/test_triton_kernels.py::MutationTests::test_for_loop_arg_2
* [periodic / linux-jammy-cuda13.2-py3.10-gcc11 / test (default, 2, 5, mt-l-x86aavx2-29-113-l4)](https://hud.pytorch.org/pr/pytorch/pytorch/190440#95915066756) ([gh](https://github.com/pytorch/pytorch/actions/runs/32173038311/job/95915066756))
test/inductor/test_triton_kernels.py::MutationTests::test_for_loop_arg_2
* [periodic / linux-jammy-cuda13.2-py3.10-gcc11-debug / test (default, 3, 7, mt-l-x86aavx2-29-113-l4, oncall:debug-build)](https://hud.pytorch.org/pr/pytorch/pytorch/190440#95913674655) ([gh](https://github.com/pytorch/pytorch/actions/runs/32173038311/job/95913674655))
test/inductor/test_triton_kernels.py::MutationTests::test_for_loop_arg_2


Test plan:
- On Triton trunk we confirm the affected tests are skipped
- On Triton 3.8 and below we confirm affected tests run and pass
- `lintrunner -a test/inductor/test_triton_kernels.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo