### PR TITLE
Dedup findings in the pr-review skill

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -129,6 +129,8 @@ A single line of code can have deep cross-cutting implications: a missing device
 
 The review checklist is large. You cannot hold the full context of every infrastructure system in your head. **Spawn sub-agents** to investigate whether checklist items apply: read surrounding code, infrastructure the PR should be using, or tests that should exist. Spawn them in parallel for independent areas. A typical medium PR should spawn 3-8 sub-agents.
 
+Sub-agents overlap on purpose. Expect the same defect back from two or three of them in different words; that signals importance, not multiplicity. Reconcile in Step 4, before spending verification agents on it.
+
 ## Review Workflow
 
 ### Step 1: Understand Context
@@ -147,13 +149,23 @@ Go through **every changed line** in the diff and evaluate it against the review
 
 Evaluate BC implications per [bc-guidelines.md](bc-guidelines.md). For non-trivial BC questions, spawn a sub-agent to search for existing callers of the modified API.
 
-### Step 4: Formulate Review
+### Step 4: Consolidate Findings
 
-Structure your review with actionable feedback organized by category. Every finding should be traceable to a specific line in the diff.
+Deduplicate **before** you draft, and before Step 5 — every duplicate carried forward costs a verification agent and survives it.
+
+Flatten every candidate — yours and every sub-agent's — into a list of `(file:line, one-line claim)` pairs, then collapse it:
+
+- **Same root cause → one finding.** Two sub-agents describing one defect from different angles is the expected outcome of fanning out over adjacent areas, not corroboration of two defects.
+- **Same fix → one finding.** If a single edit resolves several bullets, that is one finding with several consequences.
+- **Same `file:line` twice → merge**, unless you can name two independent defects.
+
+Only then assign each survivor to exactly one section (see "One finding, one section" under Output Format) and write it up. Every finding must be traceable to a specific line in the diff.
 
 ### Step 5: Fact-Check
 
-After drafting the review, spawn a sub-agent per reported issue (in parallel) to independently verify the claim by re-reading the relevant code and surrounding context. Each sub-agent returns **valid**, **invalid**, or **needs rewording**. Drop invalid issues, reword the rest. If unsure, leave the issue with a comment for the author that this low confidence.
+Fact-check the **consolidated** list — one sub-agent per surviving finding, never one per raw candidate.
+
+Spawn the agents in parallel. Each independently verifies the claim by re-reading the relevant code and surrounding context, and returns **valid**, **invalid**, or **needs rewording**. Drop invalid issues, reword the rest. If unsure, leave the issue with a comment for the author that this is low confidence.
 
 ## Output Format
 
@@ -201,19 +213,36 @@ Missing tests (new functionality without tests, bug fixes without regression tes
 [Brief justification — focus on what blocks approval, if anything]
 ```
 
+**One finding, one section.** The categories overlap by construction — a missing test for a bad public API is legitimately API Design, Testing, and Code Quality. Assign each finding to exactly one section, first match wins:
+
+1. **Security** — has a security consequence
+2. **Thread Safety** — has a concurrency consequence
+3. **Backward Compatibility** — breaks or risks breaking existing callers
+4. **API Design** — the defect is in a public or frozen interface (names, signatures, documented semantics)
+5. **Infrastructure** — a missing or incorrect hook into an existing PyTorch subsystem
+6. **Testing** — the defect is *only* absent or inadequate coverage
+7. **Performance**
+8. **Code Quality** — everything else
+
+State the finding's full consequence once, in its assigned section. When it genuinely spans categories, say so inline in that one bullet ("this is also a BC break for out-of-tree backends") rather than adding a second bullet under the other section.
+
+This precedence governs the eight finding sections only. Summary and Recommendation are not finding buckets — see their rules in the template above. Neither is Specific Comments — see its rules below.
+
+Do not invent sections outside this template. File a finding by its *consequence*, not its file type: a docstring that misstates operator semantics is API Design, not documentation. Where [review-checklist.md](review-checklist.md) groups or names a topic differently — e.g. it nests API Design under Code Quality, calls its infrastructure section "PyTorch Infrastructure", and has no Backward Compatibility section at all (that lives in [bc-guidelines.md](bc-guidelines.md)) — that organizes the checklist, not the output; this precedence wins.
+
 ### Specific Comments (Detailed Review Only)
 
 **Only include this section if the user requests a "detailed" or "in depth" review.**
 
-**Do not repeat observations already made in other sections.** This section is for additional file-specific feedback that doesn't fit into the categorized sections above.
+**Do not repeat observations already made in other sections.** This section is for points too localized to carry their own categorized finding — single-line naming, wording, or stale-comment notes. Anything with a behavioral or interface consequence belongs in one of the eight sections above.
 
 When requested, add file-specific feedback with line references:
 
 ```markdown
 ### Specific Comments
-- `src/module.py:42` - Consider extracting this logic into a named function for clarity
-- `test/test_feature.py:100-105` - Missing test for error case when input is None
-- `torch/nn/modules/linear.py:78` - This allocation could be moved outside the loop
+- `torch/example/module.py:78` - reuses the name of the enclosing loop variable
+- `aten/src/ATen/native/Example.cpp:203` - the `TORCH_CHECK` message says "tensor", but the parameter is a list
+- `torch/example/lowering.py:512` - stale comment: describes the pre-refactor control flow
 ```
 
 ## Files to Reference

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -151,7 +151,7 @@ Evaluate BC implications per [bc-guidelines.md](bc-guidelines.md). For non-trivi
 
 ### Step 4: Consolidate Findings
 
-Deduplicate **before** you draft, and before Step 5 — every duplicate carried forward costs a verification agent and survives it.
+Deduplicate **before** you draft, and before Step 5 as it would slow it down significantly.
 
 Flatten every candidate — yours and every sub-agent's — into a list of `(file:line, one-line claim)` pairs, then collapse it:
 


### PR DESCRIPTION
## Author Notes

Small change to reduce duplicate reports in the skill as it started to do that a lot more recently.

## Agent Notes

The `pr-review` skill produced the same finding several times per review. Two mechanisms drove it:

- The workflow fans out 3-8 sub-agents over deliberately adjacent areas, then fact-checks one sub-agent per drafted bullet. Overlapping agents return the same defect worded differently, and verification confirms every copy as valid, so duplicates survive the one step that could have caught them.
- The eight output categories overlap by construction — a missing test for a bad public API is legitimately API Design, Testing, and Code Quality — and nothing said which one wins, so findings got filed under two.

This adds:

- **Step 4 "Consolidate Findings"** (replacing "Formulate Review"): flatten every candidate from all sub-agents into `(file:line, claim)` pairs and collapse on shared root cause, shared fix, or shared `file:line` before drafting, and before Step 5.
- **Step 5** now runs on the consolidated list, one agent per surviving finding.
- **"One finding, one section"**: an 8-level precedence order for assigning each finding to exactly one output section, with an inline escape hatch for findings that genuinely span categories, and a note that it overrides `review-checklist.md`'s different grouping.

Docs-only change to a skill file; no code or test impact. `spin lint` is clean.

Authored with Claude, reviewed by running the skill against its own diff.
