### PR TITLE
[inductor] Fix Triton reduction CSE for logical arg indices

### DIFF
--- a/test/inductor/test_triton_reduction_cse.py
+++ b/test/inductor/test_triton_reduction_cse.py
@@ -1,0 +1,26 @@
+# Owner(s): ["module: inductor"]
+
+import torch
+from torch._inductor.test_case import TestCase
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.inductor_utils import GPU_TYPE
+from torch.testing._internal.triton_utils import requires_gpu_and_triton
+
+
+class TritonReductionCSETest(TestCase):
+    @requires_gpu_and_triton
+    def test_argmax_cache_key_includes_logical_index(self):
+        def fn(x):
+            return x.argmax(), x.t().argmax()
+
+        x = torch.tensor(
+            [[0.0, 3.0], [2.0, 1.0]],
+            device=GPU_TYPE,
+        )
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+
+        self.assertEqual(compiled(x), fn(x))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5556,7 +5556,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 return "value"
             return "index"
 
-        cache_key = (src_dtype, reduction_type, value)
+        if logical_index is not None:
+            logical_index_key = cast(CSEVariable, logical_index)
+            cache_key = src_dtype, reduction_type, (value, logical_index_key)
+        else:
+            cache_key = src_dtype, reduction_type, value
         if cache_key in self.cse.reduction_cache:
             return self.cse.reduction_cache[cache_key]
 


### PR DESCRIPTION
## Summary

Include the logical reduction index in Triton's reduction CSE cache key.

This addresses the remaining Triton cache-key blocker described in #193661 and on #193680: two arg reductions can operate on the same value expression while using different logical index mappings. Caching only by `(src_dtype, reduction_type, value)` can therefore incorrectly reuse one reduction for the other.

The C++ codegen already includes the logical index in its reduction cache key. This change makes Triton follow the same rule.

## Regression

Add focused CUDA/Triton coverage that compiles `x.argmax()` and `x.t().argmax()` in the same graph. They share the same underlying values but require different logical indices, directly exercising the reduction-CSE collision.

## Context

This PR previously targeted the narrower adaptive-average-pool symptom from #193492. That issue was closed in favor of the broader logical-vs-physical reduction indexing problem in #193661. The branch is repurposed to address the explicit Triton CSE blocker for the broader fix in #193680.

Related: #193661
Unblocks: #193680

## Validation

- `python -m py_compile torch/_inductor/codegen/triton.py test/inductor/test_triton_reduction_cse.py`
- `git diff --check`

Both checks completed successfully on the branch update runner. Full GPU regression coverage is left to PyTorch CI.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo