### PR TITLE
[ATen][RNN] Validate gate and hidden state dimensions in differentiable LSTM/GRU cell backward ops

### DIFF
--- a/aten/src/ATen/native/RNN.cpp
+++ b/aten/src/ATen/native/RNN.cpp
@@ -1617,6 +1617,31 @@ _thnn_differentiable_lstm_cell_backward( const std::optional<Tensor>& grad_hy_op
   if (!grad_hy.defined() && !grad_cy.defined()) {
     return std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor>();
   }
+
+  TORCH_CHECK(input_gates.dim() == 2, "_thnn_differentiable_lstm_cell_backward: input_gates must be 2D, got ", input_gates.dim(), "D");
+  TORCH_CHECK(hidden_gates.dim() == 2, "_thnn_differentiable_lstm_cell_backward: hidden_gates must be 2D, got ", hidden_gates.dim(), "D");
+  TORCH_CHECK(input_gates.size(1) % 4 == 0 && input_gates.size(1) > 0,
+              "_thnn_differentiable_lstm_cell_backward: input_gates dimension 1 must be divisible by 4 and positive, got ", input_gates.size(1));
+  TORCH_CHECK(hidden_gates.size(1) % 4 == 0 && hidden_gates.size(1) > 0,
+              "_thnn_differentiable_lstm_cell_backward: hidden_gates dimension 1 must be divisible by 4 and positive, got ", hidden_gates.size(1));
+  TORCH_CHECK(input_gates.sizes() == hidden_gates.sizes(),
+              "_thnn_differentiable_lstm_cell_backward: input_gates and hidden_gates must have the same sizes, got ", input_gates.sizes(), " and ", hidden_gates.sizes());
+
+  int64_t hidden_size = input_gates.size(1) / 4;
+  int64_t batch_size = input_gates.size(0);
+  TORCH_CHECK(cx.dim() == 2 && cx.size(0) == batch_size && cx.size(1) == hidden_size,
+              "_thnn_differentiable_lstm_cell_backward: cx must be 2D with shape (", batch_size, ", ", hidden_size, "), got ", cx.sizes());
+  TORCH_CHECK(cy.dim() == 2 && cy.size(0) == batch_size && cy.size(1) == hidden_size,
+              "_thnn_differentiable_lstm_cell_backward: cy must be 2D with shape (", batch_size, ", ", hidden_size, "), got ", cy.sizes());
+  if (grad_hy.defined()) {
+    TORCH_CHECK(grad_hy.dim() == 2 && grad_hy.size(0) == batch_size && grad_hy.size(1) == hidden_size,
+                "_thnn_differentiable_lstm_cell_backward: grad_hy must be 2D with shape (", batch_size, ", ", hidden_size, "), got ", grad_hy.sizes());
+  }
+  if (grad_cy.defined()) {
+    TORCH_CHECK(grad_cy.dim() == 2 && grad_cy.size(0) == batch_size && grad_cy.size(1) == hidden_size,
+                "_thnn_differentiable_lstm_cell_backward: grad_cy must be 2D with shape (", batch_size, ", ", hidden_size, "), got ", grad_cy.sizes());
+  }
+
   Tensor gates = input_gates + hidden_gates;
   if (input_bias.defined()) {
     gates = gates + input_bias;
@@ -1665,6 +1690,22 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> _thnn_differentiable_gru_cell
   c10::MaybeOwned<Tensor> input_bias_maybe_owned = at::borrow_from_optional_tensor(input_bias_opt);
   const Tensor& input_bias = *input_bias_maybe_owned;
   const Tensor& hidden_bias = hidden_bias_opt.value_or(Tensor());
+
+  TORCH_CHECK(input_gates.dim() == 2, "_thnn_differentiable_gru_cell_backward: input_gates must be 2D, got ", input_gates.dim(), "D");
+  TORCH_CHECK(hidden_gates.dim() == 2, "_thnn_differentiable_gru_cell_backward: hidden_gates must be 2D, got ", hidden_gates.dim(), "D");
+  TORCH_CHECK(input_gates.size(1) % 3 == 0 && input_gates.size(1) > 0,
+              "_thnn_differentiable_gru_cell_backward: input_gates dimension 1 must be divisible by 3 and positive, got ", input_gates.size(1));
+  TORCH_CHECK(hidden_gates.size(1) % 3 == 0 && hidden_gates.size(1) > 0,
+              "_thnn_differentiable_gru_cell_backward: hidden_gates dimension 1 must be divisible by 3 and positive, got ", hidden_gates.size(1));
+  TORCH_CHECK(input_gates.sizes() == hidden_gates.sizes(),
+              "_thnn_differentiable_gru_cell_backward: input_gates and hidden_gates must have the same sizes, got ", input_gates.sizes(), " and ", hidden_gates.sizes());
+
+  int64_t hidden_size = input_gates.size(1) / 3;
+  int64_t batch_size = input_gates.size(0);
+  TORCH_CHECK(hx.dim() == 2 && hx.size(0) == batch_size && hx.size(1) == hidden_size,
+              "_thnn_differentiable_gru_cell_backward: hx must be 2D with shape (", batch_size, ", ", hidden_size, "), got ", hx.sizes());
+  TORCH_CHECK(grad_hy.dim() == 2 && grad_hy.size(0) == batch_size && grad_hy.size(1) == hidden_size,
+              "_thnn_differentiable_gru_cell_backward: grad_hy must be 2D with shape (", batch_size, ", ", hidden_size, "), got ", grad_hy.sizes());
 
   Tensor in_g = input_gates;
   Tensor h_g = hidden_gates;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2570,6 +2570,63 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertRaises(Exception, lambda: lstm(input, (hx, cx)))
         self.assertRaises(Exception, lambda: lstm(input, (cx, hx)))
 
+    def test_differentiable_cell_backward_invalid_gate_sizes(self):
+        # Issue #194049: Ensure differentiable GRU and LSTM cell backward operators
+        # validate gate dimensions and do not crash on undersized gate tensors.
+        with self.assertRaisesRegex(RuntimeError, "input_gates dimension 1 must be divisible by 3"):
+            torch.ops.aten._thnn_differentiable_gru_cell_backward(
+                torch.ones((1, 1)),
+                torch.ones((1, 1)),
+                torch.ones((1, 3)),
+                torch.ones((1, 1)),
+                None,
+                None,
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "hidden_gates dimension 1 must be divisible by 3"):
+            torch.ops.aten._thnn_differentiable_gru_cell_backward(
+                torch.ones((1, 1)),
+                torch.ones((1, 3)),
+                torch.ones((1, 2)),
+                torch.ones((1, 1)),
+                None,
+                None,
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "input_gates and hidden_gates must have the same sizes"):
+            torch.ops.aten._thnn_differentiable_gru_cell_backward(
+                torch.ones((1, 1)),
+                torch.ones((1, 3)),
+                torch.ones((1, 6)),
+                torch.ones((1, 1)),
+                None,
+                None,
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "input_gates dimension 1 must be divisible by 4"):
+            torch.ops.aten._thnn_differentiable_lstm_cell_backward(
+                torch.ones((1, 1)),
+                None,
+                torch.ones((1, 1)),
+                torch.ones((1, 4)),
+                None,
+                None,
+                torch.ones((1, 1)),
+                torch.ones((1, 1)),
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "hidden_gates dimension 1 must be divisible by 4"):
+            torch.ops.aten._thnn_differentiable_lstm_cell_backward(
+                torch.ones((1, 1)),
+                None,
+                torch.ones((1, 4)),
+                torch.ones((1, 2)),
+                None,
+                None,
+                torch.ones((1, 1)),
+                torch.ones((1, 1)),
+            )
+
 
     def test_Transformer_cell(self):
         # this is just a smoke test; these modules are implemented through


### PR DESCRIPTION
### Summary
Fixes #194049

### Problem
`_thnn_differentiable_lstm_cell_backward` and `_thnn_differentiable_gru_cell_backward` in `aten/src/ATen/native/RNN.cpp` called `unsafe_chunk(4, 1)` and `unsafe_chunk(3, 1)` without validating that the input gate tensors are 2D with the second dimension divisible by 4 (for LSTM) or 3 (for GRU).

When passed undersized gate tensors (e.g. `(1, 1)` or `(1, 2)`), `unsafe_chunk` produced fewer chunks than expected (e.g. 1 chunk), causing out-of-bounds vector indexing `chunked_gates[1]`, `chunked_gates[2]`, `chunked_gates[3]` and resulting in ASAN heap-buffer-overflow reads and segfaults.

### Fix
Added tensor dimension and shape validation to both `_thnn_differentiable_lstm_cell_backward` and `_thnn_differentiable_gru_cell_backward`:
- Ensure `input_gates` and `hidden_gates` are 2D with matching dimensions.
- Ensure `input_gates.size(1)` is positive and divisible by 4 (LSTM) or 3 (GRU).
- Ensure `cx`, `cy`, `hx`, `grad_hy`, and `grad_cy` match `(batch_size, hidden_size)`.
- Added unit tests in `test/test_nn.py` verifying `RuntimeError` is properly raised on invalid gate and hidden state dimensions.

### Test Plan
Run unit tests in `test/test_nn.py`:
```bash
pytest test/test_nn.py -k "test_differentiable_cell_backward_invalid_gate_sizes"
```
