### PR TITLE
[ROCm] Check AOTriton attention errors at the originating callsite

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1756,7 +1756,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
     auto seed_output = mk_philoxtensor(use_philox_state ? seed_t.data_ptr<int64_t>() : nullptr);
     auto offset_output = mk_philoxtensor(use_philox_state ? offset_t.data_ptr<int64_t>() : nullptr);
     auto persistent_counter = mk_atomictensor(is_causal ? atomic_counter.data_ptr<int32_t>() : nullptr);
-    hipError_t err; // TODO: Error handling
     using aotriton::v3::flash::CausalType;
     using aotriton::v3::flash::VarlenType;
     using aotriton::v3::flash::WindowValue;
@@ -1795,9 +1794,8 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt> _efficient_
     } else {
       params.varlen_type = VarlenType::None;
     }
-    err = aotriton::v3::flash::attn_fwd(params,
-                                        aotriton::v3::flash::attn_fwd_params::kVersion,
-                                        stream);
+    AT_CUDA_CHECK(aotriton::v3::flash::attn_fwd(
+        params, aotriton::v3::flash::attn_fwd_params::kVersion, stream));
 #else
     TORCH_CHECK(false, "Attempting to use AOTriton mem_eff_forward backend in a build that has not built AOTriton");
 #endif
@@ -2091,14 +2089,13 @@ at::Tensor& _fill_mem_eff_dropout_mask_(
   const auto options = at::dtype(at::kLong).device(at::kCUDA);
   seed_t = at::scalar_tensor(at::Scalar(seed), options);
   offset_t = at::scalar_tensor(at::Scalar(offset), options);
-  hipError_t err; // TODO: Error handling
-
-  err = debug_simulate_encoded_softmax(mk_aotensor(self, "r"),
-                                       dropout_p,
-                                       mk_aoscalartensor(seed_t),
-                                       mk_aoscalartensor(offset_t),
-                                       0,
-                                       stream);
+  AT_CUDA_CHECK(debug_simulate_encoded_softmax(
+      mk_aotensor(self, "r"),
+      dropout_p,
+      mk_aoscalartensor(seed_t),
+      mk_aoscalartensor(offset_t),
+      0,
+      stream));
 #else
   TORCH_CHECK(false, "_fill_mem_eff_dropout_mask_ is only enabled with aotriton");
 #endif

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -638,7 +638,6 @@ _efficient_attention_backward(
     const auto lse_batch_size =
         cu_seqlens_q.has_value() ? cu_seqlens_q->size(0) - 1 : B;
     at::Tensor softmax_lse = logsumexp.view({lse_batch_size * nH, max_seqlen_q});
-    hipError_t err;
     using sdp::aotriton_adapter::mk_aotensor;
     using sdp::aotriton_adapter::mk_aoscalartensor;
     using sdp::aotriton_adapter::cast_dtype;
@@ -693,10 +692,11 @@ _efficient_attention_backward(
     }
     aotriton::v3::flash::attn_options opts;
     opts.deterministic = deterministic;
-    err = aotriton::v3::flash::attn_bwd(params,
-                                        aotriton::v3::flash::attn_bwd_params::kVersion,
-                                        stream,
-                                        &opts);
+    AT_CUDA_CHECK(aotriton::v3::flash::attn_bwd(
+        params,
+        aotriton::v3::flash::attn_bwd_params::kVersion,
+        stream,
+        &opts));
 #else  // DISABLE_AOTRITON
     TORCH_CHECK(false, "Attempting to use aotriton mem_eff_backward backend in a build that has not built AOTriton");
 #endif

--- a/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/aot/mha_all_aot.hip
@@ -256,7 +256,6 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
     atomic_counter = at::zeros({1}, opts.dtype(at::kInt));
   }
 
-  hipError_t err; // TODO: Error handling
   using sdp::aotriton_adapter::mk_aotensor;
   using sdp::aotriton_adapter::mk_aoscalartensor;
   using sdp::aotriton_adapter::mk_philoxtensor;
@@ -292,9 +291,8 @@ mha_fwd_aot(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x 
   params.varlen_type = VarlenType::None;
   params.window_left = window_left;
   params.window_right = window_right;
-  err = aotriton::v3::flash::attn_fwd(params,
-                                      aotriton::v3::flash::attn_fwd_params::kVersion,
-                                      stream);
+  AT_CUDA_CHECK(aotriton::v3::flash::attn_fwd(
+      params, aotriton::v3::flash::attn_fwd_params::kVersion, stream));
   // Note: These are propagated up to the return of mha_fwd(). comments
   //       represent the assignments at that level
   return {out,          // output
@@ -446,7 +444,6 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
     prepare_philox_arguments(p_dropout, batch_size * num_heads * 32);
 
   if (max_seqlen_k > 0) {
-    hipError_t err; // TODO: Error handling
     using sdp::aotriton_adapter::mk_aotensor;
     using sdp::aotriton_adapter::mk_aoscalartensor;
     using sdp::aotriton_adapter::mk_philoxtensor;
@@ -503,9 +500,8 @@ mha_varlen_fwd_aot(const at::Tensor &q,  // total_q x num_heads x head_size, tot
     }
     params.window_left = window_left;
     params.window_right = window_right;
-    err = aotriton::v3::flash::attn_fwd(params,
-                                        aotriton::v3::flash::attn_fwd_params::kVersion,
-                                        stream);
+    AT_CUDA_CHECK(aotriton::v3::flash::attn_fwd(
+        params, aotriton::v3::flash::attn_fwd_params::kVersion, stream));
   } else {
     // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.
     out.zero_();
@@ -643,7 +639,6 @@ mha_bwd_aot(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x hea
 
   int d_head = head_size_og;
   bool use_fused_bwd = d_head <= 192 && d_head * seqlen_q < 64 * 512;
-  hipError_t err; // TODO: Error handling
   using sdp::aotriton_adapter::mk_aotensor;
   using sdp::aotriton_adapter::mk_aoscalartensor;
   // Fused BWD does not support SWA
@@ -680,10 +675,11 @@ mha_bwd_aot(const at::Tensor &dout,  // batch_size x seqlen_q x num_heads, x hea
   params.DQ_ACC = mklazy_fp32zeros<4>(&lazy_dq_acc);
   aotriton::v3::flash::attn_options options;
   options.deterministic = deterministic;
-  err = aotriton::v3::flash::attn_bwd(params,
-                                      aotriton::v3::flash::attn_bwd_params::kVersion,
-                                      stream,
-                                      &options);
+  AT_CUDA_CHECK(aotriton::v3::flash::attn_bwd(
+      params,
+      aotriton::v3::flash::attn_bwd_params::kVersion,
+      stream,
+      &options));
 
   return { dq, dk, dv, softmax_d };
 }
@@ -847,7 +843,6 @@ mha_varlen_bwd_aot(const at::Tensor &dout,  // total_q x num_heads, x head_size
     }
   }
   if (max_seqlen_q > 0) {
-    hipError_t err; // TODO: Error handling
     using sdp::aotriton_adapter::mk_aotensor;
     using sdp::aotriton_adapter::mk_aoscalartensor;
     using aotriton::v3::flash::CausalType;
@@ -885,10 +880,11 @@ mha_varlen_bwd_aot(const at::Tensor &dout,  // total_q x num_heads, x head_size
     params.DQ_ACC = mklazy_fp32zeros<4>(&lazy_dq_acc);
     aotriton::v3::flash::attn_options options;
     options.deterministic = deterministic;
-    err = aotriton::v3::flash::attn_bwd(params,
-                                        aotriton::v3::flash::attn_bwd_params::kVersion,
-                                        stream,
-                                        &options);
+    AT_CUDA_CHECK(aotriton::v3::flash::attn_bwd(
+        params,
+        aotriton::v3::flash::attn_bwd_params::kVersion,
+        stream,
+        &options));
   } else {
     // If seqlen_q == 0, then we have an empty tensor. We need to set the output to 0.
     dq.zero_();


### PR DESCRIPTION
## Summary

Check the return values of AOTriton forward and backward attention calls with `AT_CUDA_CHECK`.

## Motivation

AOTriton returns a `hipError_t`, but the existing code stores it in a local variable and never checks it. A synchronous launch failure can therefore appear successful at the originating operation and surface during a later, unrelated HIP call.

This makes failures difficult to diagnose and can incorrectly attribute them to subsequent operations.

## Changes

Add immediate error checking to all AOTriton attention callsites:

- Forward attention
- Variable-length forward attention
- Backward attention
- Variable-length backward attention

Launch failures are now reported at the operation that caused them using PyTorch’s standard accelerator error handling.

## Testing

- Source lint checks passed.
- `git diff --check` passed.
- Verified that all four AOTriton forward/backward callsites are checked and no ignored `hipError_t` variables remain.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang