### PR TITLE
[ROCm] Unskip test_cholesky_solve_batched_many_batches on rocm 10.1+

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -28,7 +28,7 @@ from torch.testing._internal.common_utils import \
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, subtest, skipIfTorchDynamo,
-     skipIfRocmArch, skipIfRocmVersionAtLeast, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
+     skipIfRocmArch, skipIfRocmVersionLessThan, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest, skipIfRocm,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA,
      skipIfNoNvmath)
 from torch.testing._internal.common_device_type import \
@@ -3133,7 +3133,8 @@ class TestLinalg(TestCase):
 
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
-    @skipIfRocmVersionAtLeast([7, 14])
+    # rocBLAS trsm large-batch regression; fixed in ROCm 10.1 (rocm-libraries#10503)
+    @skipIfRocmVersionLessThan((10, 1))
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})


### PR DESCRIPTION
Re-enable the ROCm 7.14+ skip for batched cholesky_solve after the rocBLAS trsm large-batch fix (ROCm/rocm-libraries#10503).

## CI Validation

  Decorator changed: `@skipIfRocmVersionAtLeast([7, 14])` → `@skipIfRocmVersionLessThan((10, 1))`
  Test: `test/test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches` (config: `default`)
  Expected: **SKIPPED** on ROCm < 10.1 (mi200, mi300, trunk/mi350), **PASSED** on ROCm 10.1 (preview)

  | Workflow | Job link | Shard | Result |
  |---|---|---|---|
  | mi200 (`rocm-mi200`) | https://github.com/pytorch/pytorch/actions/runs/34392184011/job/102615618116 | default 1/10 | SKIPPED (all 4 dtypes) |
  | mi300 (`rocm-mi300`) | https://github.com/pytorch/pytorch/actions/runs/34392183923/job/102615071450 | default 1/8 | SKIPPED (all 4 dtypes) |
  | preview (`rocm-preview`) | https://github.com/pytorch/pytorch/actions/runs/34392336412/job/102620412876 | default 1/8 | PASSED (all 4 dtypes) |
  | trunk (`trunk`, mi350) | https://github.com/pytorch/pytorch/actions/runs/34392334696/job/102614179632 | default 1/8 | SKIPPED (all 4 dtypes) |

  ### mi200 / mi300 / trunk — exact skip lines
  ```
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_complex128 SKIPPED [X.XXXXs] (ROCm version less than (10, 1) required) [ 53%]
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_complex64  SKIPPED [X.XXXXs] (ROCm version less than (10, 1) required) [ 53%]
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_float32    SKIPPED [X.XXXXs] (ROCm version less than (10, 1) required) [ 53%]
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_float64    SKIPPED [X.XXXXs] (ROCm version less than (10, 1) required) [ 53%]
  ```

  ### preview — exact pass lines
  ```
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_complex128 PASSED [0.0285s] [ 53%]
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_complex64  PASSED [0.0139s] [ 53%]
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_float32    PASSED [0.0186s] [ 53%]
  test_linalg.py::TestLinalgCUDA::test_cholesky_solve_batched_many_batches_cuda_float64    PASSED [0.0149s] [ 53%]
  ```

  ### Conclusion
  Skip reason string exactly matches the new `skipIfRocmVersionLessThan((10, 1))` decorator on all three sub-10.1 workflows, and the test runs + passes cleanly on preview (10.1). Behaves as designed; no discrepancies found.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang