### PR TITLE
[ROCm][CI] Restore patch matching for TheRock wheel pins

### DIFF
--- a/.ci/docker/common/install_rocm.sh
+++ b/.ci/docker/common/install_rocm.sh
@@ -39,15 +39,24 @@ install_rocm() {
     : "${THEROCK_INDEX_URL:?THEROCK_INDEX_URL must be set}"
     : "${ROCM_VERSION:?ROCM_VERSION must be set}"
 
+    # Major.minor pins (e.g. 7.14) accept later patches via ==7.14.*.
+    # Fully specified preview pins (e.g. 7.15.0a20260712) stay exact; PEP 440
+    # rejects ==7.15.0a20260712.*.
+    rocm_pip_version="${ROCM_VERSION}"
+    if [[ "${ROCM_VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        rocm_pip_version="${ROCM_VERSION}.*"
+    fi
+
     echo "=============================================="
     echo "ROCm Multi-Arch Wheel Installation (TheRock)"
     echo "Index URL:  ${THEROCK_INDEX_URL}"
     echo "ROCm version: ${ROCM_VERSION}"
+    echo "ROCm spec:  rocm[libraries,devel,device-all]==${rocm_pip_version}"
     echo "=============================================="
 
     # device-all pulls kernels for every supported gfx target (multi-arch wheel);
     # libraries+devel provide the runtime libs + headers/hipcc to compile against ROCm.
-    python3 -m pip install --index-url "${THEROCK_INDEX_URL}" "rocm[libraries,devel,device-all]==${ROCM_VERSION}"
+    python3 -m pip install --index-url "${THEROCK_INDEX_URL}" "rocm[libraries,devel,device-all]==${rocm_pip_version}"
 
     # Discover the real install root/bin via the rocm-sdk CLI (rocm-sdk-core wheel).
     ROCM_HOME="$(rocm-sdk path --root)"


### PR DESCRIPTION
## Problem
#188429 pinned TheRock wheels with `==${ROCM_VERSION}`, so `7.14` matches 7.14.0 but not a later patch such as 7.14.1.

## Changes
Major.minor pins use prefix matching (`==7.14.*`). Fully specified preview pins stay exact because PEP 440 rejects `==7.15.0a20260712.*`.

## Validation
`bash -n .ci/docker/common/install_rocm.sh`. Regex check: `7.14`/`10.1` become `.*`; `7.15.0a20260712` stays exact. Trunk CI requested via `ciflow/trunk`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @ScottTodd
