### PR TITLE
Fix compiler error due to invalid % escape in CUDA inline assembly

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh
@@ -63,7 +63,7 @@ __device__ __forceinline__ size_t global_timer_ns() {
   return clock64() / MI300_FREQ_GHZ;
 #else
   size_t val;
-  asm volatile("mov.u64 %0, %globaltimer;" : "=l"(val) : : "memory");
+  asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(val) : : "memory");
   return val;
 #endif
 }


### PR DESCRIPTION
Fixes a clang compiler error in `CUDASymmetricMemory-inl.cuh` caused by an unescaped `%` character in a CUDA inline assembly string:

```
torch/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory-inl.cuh:66:31: error: invalid % escape in inline assembly string
   66 |   asm volatile("mov.u64 %0, %globaltimer;" : "=l"(val) : : "memory");
```

This PR escapes the `%` character to ensure the assembly string is parsed correctly by clang.