### PR TITLE
Use torch.accelerator memory APIs in MemoryTracker to fix MPS crash

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -59,6 +59,11 @@ class TestMemoryTracker(TestCase):
         self.assertEqual(len(tracker.memories_allocated), tracker._op_index)
         self.assertEqual(len(tracker.memories_active), tracker._op_index)
         self.assertEqual(len(tracker.memories_reserved), tracker._op_index)
+        # The stats must come from a real allocator: with live activations,
+        # nonzero allocated memory should be observed at some operator.
+        self.assertTrue(
+            any(mem > 0 for (_, mem) in tracker.memories_allocated.values())
+        )
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -82,7 +82,6 @@ class MemoryTracker:
         self._cur_module_name: str = ""
         self._op_index: int = 0
         self._num_alloc_retries: int = 0
-        self._device_module = torch.get_device_module()
 
     @no_type_check
     def start_monitor(self, root_module: nn.Module) -> None:
@@ -107,7 +106,7 @@ class MemoryTracker:
             # clear and remove it for now as it does not really capture important info.
             # h3 = m.register_backward_hook(self._create_backward_hook(name))
             self._hooks.extend([h1, h2])
-        self._device_module.empty_cache()
+        torch.accelerator.empty_cache()
         if getattr(self, "profile_mode", None) is not None:
             raise AssertionError
         self.profile_mode = MemoryProfileDispatchMode(self)
@@ -120,7 +119,7 @@ class MemoryTracker:
 
         Get some aggregated stats when the memory_tracker() is enabled, like ``num_alloc_retries``.
         """
-        self._num_alloc_retries = self._device_module.memory_stats().get(
+        self._num_alloc_retries = torch.accelerator.memory_stats().get(
             "num_alloc_retries", 0
         )
 
@@ -274,10 +273,10 @@ class MemoryTracker:
 
         The memory stats dict is indexed with ``self._op_index``.
         """
-        memory_allocated: float = self._device_module.memory_allocated() / BYTES_PER_MB
-        memory_reserved: float = self._device_module.memory_reserved() / BYTES_PER_MB
+        memory_allocated: float = torch.accelerator.memory_allocated() / BYTES_PER_MB
+        memory_reserved: float = torch.accelerator.memory_reserved() / BYTES_PER_MB
         memory_active: float = (
-            self._device_module.memory_stats().get("active_bytes.all.current", 0)
+            torch.accelerator.memory_stats().get("active_bytes.all.current", 0)
             / BYTES_PER_MB
         )
         self.memories_allocated[self._op_index] = (fn_name, memory_allocated)


### PR DESCRIPTION
Fixes #194105

`MemoryTracker` resolved memory APIs through `torch.get_device_module()`, which crashes on MPS: `torch.mps` defines none of `memory_allocated`/`memory_reserved`/`memory_stats`, so `test_memory_tracker.py` (accelerator-generic since #159543) fails on every MPS machine with `AttributeError: module 'torch.mps' has no attribute 'memory_allocated'`.

The device-module indirection was an explicit stopgap — #150703 said it avoided `torch.accelerator` because that API was "still in-progress". It is now complete on MPS (#186748 wired the MPS allocator into `c10::DeviceAllocator`; #193838 completed `active_bytes`; together closing #167447) and exposes every key MemoryTracker reads with identical flattened names on CUDA/XPU/MPS.

This PR switches the five call sites to `torch.accelerator` and drops the stored `_device_module`. On CUDA/XPU the same `DeviceStats` are read through `at::accelerator::getDeviceStats`, so reported numbers are unchanged. The test additionally asserts a nonzero allocated reading is observed, so stats are real rather than defaulted zeros.

**Test plan:** `python test/distributed/_tools/test_memory_tracker.py` on an Apple Silicon Mac (MPS): OK (previously `AttributeError`). Sanity: `torch.accelerator.memory_allocated()` grows by exactly 64MB for a 64MB MPS tensor. lintrunner clean on both files.

**AI disclosure (per AI_POLICY.md):** I used Claude (Anthropic) to help investigate the device-module parity gap and draft this change; it was verified by running the repro and the test on my own MPS hardware, and I reviewed the change and take responsibility for it.