### PR TITLE
Fix integer overflow in max_pool1d shape checks

### DIFF
--- a/aten/src/ATen/div_rtn.h
+++ b/aten/src/ATen/div_rtn.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <type_traits>
+
 // Integer division rounding to -Infinity
 template <typename T>
 static inline T div_rtn(T x, T y) {
-  int q = x / y;
-  int r = x % y;
+  static_assert(
+      std::is_integral_v<T>, "div_rtn is only valid for integral types");
+  T q = x / y;
+  T r = x % y;
   if ((r != 0) && ((r < 0) != (y < 0)))
     --q;
   return q;

--- a/aten/src/ATen/native/Pool.h
+++ b/aten/src/ATen/native/Pool.h
@@ -3,6 +3,7 @@
 #include <ATen/TensorUtils.h>
 #include <ATen/native/DispatchStub.h>
 #include <c10/util/TypeCast.h>
+#include <c10/util/safe_numerics.h>
 #include <c10/util/irange.h>
 
 #include <utility>
@@ -55,6 +56,21 @@ safe_downcast(src_t v)
   return c10::checked_convert<dest_t>(v, "dest_t");
 }
 
+// dilation * (kernelSize - 1) + 1, i.e. how far the kernel reaches into the
+// input. Overflow wraps this negative, which makes every shape check computed
+// from it meaningless, so reject it instead.
+template<typename T>
+inline T effective_kernel_size(T kernelSize, T dilation) {
+    T size = 0;
+    bool overflow = c10::add_overflows(kernelSize, T(-1), &size);
+    overflow |= c10::mul_overflows(size, dilation, &size);
+    overflow |= c10::add_overflows(size, T(1), &size);
+    TORCH_CHECK(!overflow,
+                "effective kernel size overflows, but got kernel_size=",
+                kernelSize, " and dilation=", dilation);
+    return size;
+}
+
 template<typename T>
 inline T pooling_output_shape_pad_lr(
         T inputSize, T kernelSize, T pad_l, T pad_r, T stride, T dilation,
@@ -78,7 +94,7 @@ inline T pooling_output_shape(
     TORCH_CHECK(stride != 0, "stride should not be zero");
     TORCH_CHECK(pad >= 0,
                 "pad must be non-negative, but got pad: ", pad);
-    TORCH_CHECK(pad <= ((kernelSize - 1) * dilation + 1) / 2,
+    TORCH_CHECK(pad <= effective_kernel_size(kernelSize, dilation) / 2,
                 "pad should be at most half of effective kernel size, but got pad=",
                 pad, ", kernel_size=", kernelSize, " and dilation=", dilation)
     return pooling_output_shape_pad_lr(

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -439,6 +439,9 @@ class TestPoolingNN(NNTestCase):
         )
         check([[1, 2]], (2, 1, 1, 2, False, False), [[2, 1]])
         check([[1, 2]], (2, 2, 1, 2, False, True), [[2, 2]])
+        # window reaching past the input: used to overflow the ceil division
+        # bounding the output range, and read out of bounds
+        check([[1, 2, 3, 4]], (2, 2**63 - 1, 0, 2147483647, False, True), [[1]])
 
     @parametrize_test("dtype", [torch.float16, torch.float32])
     def test_max_pool_indices_corner_cases(self, dtype):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3886,6 +3886,24 @@ def error_inputs_max_pool1d(op_info, device, **kwargs):
                                      kwargs={'kernel_size': 5, 'stride': 1, 'padding': 0, 'dilation': 1}),
                          error_regex=error_msg)
 
+        # error inputs for invalid output size, with a kernel past INT32_MAX:
+        # div_rtn() used to floor-divide in `int`, wrapping the negative output
+        # size positive and letting the kernel read out of bounds.
+        for kernel_size in (2 ** 31 - 1, 2 ** 31, 2147483697):
+            yield ErrorInput(SampleInput(make_arg((2, 10, 4)),
+                                         kwargs={'kernel_size': kernel_size, 'stride': kernel_size,
+                                                 'padding': 0, 'dilation': kernel_size, 'ceil_mode': True}),
+                             error_regex='Invalid computed output size: -')
+        yield ErrorInput(SampleInput(make_arg((2, 10, 4)),
+                                     kwargs={'kernel_size': 2 ** 63 - 1, 'stride': 2 ** 63 - 1}),
+                         error_regex='Invalid computed output size: 0')
+
+        # error inputs when dilation * (kernel_size - 1) + 1 overflows int64
+        yield ErrorInput(SampleInput(make_arg((1, 2, 3)),
+                                     kwargs={'kernel_size': 8608480567731124087, 'padding': 1250999896764,
+                                             'dilation': 1250999896764, 'ceil_mode': True}),
+                         error_regex='effective kernel size overflows')
+
         # error inputs when kernel_size=0
         error_msg = 'kernel_size must be greater than zero'
         yield ErrorInput(SampleInput(x, kwargs={'kernel_size': 0}),


### PR DESCRIPTION
`torch.max_pool1d` segfaults for several out-of-domain integer arguments.
There are three separate silent integer overflows in the shape math, and all three have to go for the op to be safe — fixing (1) alone makes (3) newly reachable.

### 1. `div_rtn()` floor-divides in `int`

```c++
 template <typename T>
 static inline T div_rtn(T x, T y) {
-  int q = x / y;
-  int r = x % y;
+  T q = x / y;
+  T r = x % y;
```

Every call site passes `div_rtn<int64_t>`, so the truncated remainder gets the wrong sign, the floor correction is skipped, and the quotient wraps. For #73190 (`kernel_size = stride = dilation = 2147483697`) the true output size `-2147483694` becomes `+2147483602` and sails past `TORCH_CHECK(OW > 0)`; for #136719 (`kernel_size = stride = INT64_MAX`) a true `0` becomes `1`. In both cases the kernel then indexes out of bounds.

The helper is shared, so this also affects the shape checks in `im2col_shape_check.h`, `ConvolutionMM2d/3d.cpp`, `DilatedConvolutionUtils.h`, the CUDA `Im2Col`/`Col2Im`/`ConvolutionMM2d` kernels and MPS `Pooling.mm`. Two side effects, both improvements: `slow_conv_dilated2d` with `dilation = 2147483697` used to silently return a `[1, 1, 0, 0]` tensor and now raises `calculated output size -1 -1 is too small`, and `F.unfold` with an INT32-boundary stride now fails in the `im2col` shape check instead of downstream in `numel`.

Checked the two bodies against an `__int128` floor-division reference: identical on all 1,000,100 realistic in-range cases (`|x| <= 5000`, `|y| <= 50`); over 3,000,000 random `int64` pairs the old one is wrong 1,499,994 times and the new one 0.

### 2. `dilation * (kernel_size - 1) + 1` overflows in `pooling_output_shape()`

This is #142454, a different root — `div_rtn` is doing exact arithmetic on already-garbage input. With `kernel_size = 8608480567731124087` and `dilation = 1250999896764`, the effective kernel size wraps to `+3689346979942061737`, so the pad check passes; the numerator wraps to `+4919136089788855880`, so `OW` comes out `1`. Computed with `c10::mul_overflows`/`add_overflows` and rejected instead.

This is also where the nonsensical `pad should be at most half of effective kernel size, but got pad=0` messages came from: the wrapped bound went negative, so `pad = 0` failed a check about padding for reasons that had nothing to do with padding. Those inputs now report the actual problem.

### 3. `at::divup()` overflows — handled in #195035

`PoolingParams1D::valid_output_end` bounds the output range with `divup`, so with a large stride the CPU kernel got a range whose window starts past the end of the input:

```python
torch.max_pool1d(torch.full((2, 10, 4), 0.5, dtype=torch.float64),
                 [2], [2**63 - 1], [0], [2147483647], True)   # SIGSEGV with only (1) applied
```

Reachable only once (1) is fixed, and only on the non-autograd CPU path — `max_pool1d_with_indices` rejects such strides in `safe_downcast<int>`, which is why it stayed hidden. `OW = 1` is correct here; the fixed result matches what `max_pool1d_with_indices` computes for the same arguments.

### Testing

Error cases added to the `nn.functional.max_pool1d` OpInfo (the INT32-boundary kernels, the `INT64_MAX` kernel, and the effective-kernel-size overflow). (3) produces a *correct* result rather than an error, so it goes in the existing `test_max_pool1d_corner_cases` as one more `check(...)` — adding it as an OpInfo *sample* input instead fails 10 generic tests, since the `with_indices` variant legitimately rejects INT64_MAX strides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
