### PR TITLE
FSDP: allow extensions to release all-gather outputs

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_extensions.py
@@ -397,6 +397,142 @@ class TestFullyShardAllGatherExtensionsMultiThread(
             raise AssertionError("Expected tls.ran_pre_all_gather to be True")
 
     @skip_if_lt_x_gpu(1)
+    def test_release_all_gather_outputs_after_post_all_gather(self):
+        self.run_subtests(
+            {"reshard_after_forward": [True, False]},
+            self._test_release_all_gather_outputs_after_post_all_gather,
+        )
+
+    def _test_release_all_gather_outputs_after_post_all_gather(
+        self, reshard_after_forward: bool
+    ):
+        tls = threading.local()
+        tls.num_post_all_gather_calls = 0
+
+        def fsdp_pre_all_gather(
+            self,
+            mesh: DeviceMesh,
+            outer_size: torch.Size,
+            outer_stride: tuple[int, ...],
+            module: nn.Module,
+            mp_policy: MixedPrecisionPolicy,
+        ) -> tuple[tuple[torch.Tensor, ...], Any]:
+            del mesh, outer_size, outer_stride, module, mp_policy
+            return (self,), None
+
+        @torch.no_grad()
+        def fsdp_post_all_gather(
+            self,
+            all_gather_outputs: tuple[torch.Tensor, ...],
+            metadata: Any,
+            param_dtype: torch.dtype,
+            *,
+            out: torch.Tensor | None = None,
+        ) -> tuple[torch.Tensor, tuple[torch.Tensor, ...]] | None:
+            del self
+            if metadata is not None:
+                raise AssertionError(f"Expected metadata to be None, got {metadata}")
+            (tensor,) = all_gather_outputs
+            if tensor.dtype != param_dtype:
+                raise AssertionError(
+                    f"Expected tensor dtype {param_dtype}, got {tensor.dtype}"
+                )
+            tls.num_post_all_gather_calls += 1
+            if out is not None:
+                with _unsafe_preserve_version_counter(out):
+                    out.copy_(tensor)
+                return None
+            transformed = tensor.clone()
+            return transformed, (transformed,)
+
+        def fsdp_should_release_all_gather_outputs_after_post_all_gather(
+            self,
+        ) -> bool:
+            del self
+            return True
+
+        test_device = self.device
+
+        class InspectLinear(nn.Linear):
+            def __init__(self) -> None:
+                super().__init__(8, 8, device=test_device)
+                self.storage_observations: list[
+                    tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]
+                ] = []
+
+            def forward(self, input: torch.Tensor) -> torch.Tensor:
+                state = fully_shard.state(self)
+                param_group = state._fsdp_param_group
+                if param_group is None:
+                    raise AssertionError("Expected an FSDP parameter group")
+                fsdp_params = {
+                    fsdp_param._module_info.param_name: fsdp_param
+                    for fsdp_param in param_group.fsdp_params
+                }
+                weight = fsdp_params["weight"]
+                bias = fsdp_params["bias"]
+                self.storage_observations.append(
+                    (
+                        tuple(
+                            tensor.untyped_storage().size()
+                            for tensor in weight.all_gather_outputs
+                        ),
+                        tuple(
+                            tensor.untyped_storage().size()
+                            for tensor in weight._unsharded_inner_tensors
+                        ),
+                        tuple(
+                            tensor.untyped_storage().size()
+                            for tensor in bias.all_gather_outputs
+                        ),
+                    )
+                )
+                return super().forward(input)
+
+        model = InspectLinear()
+        fully_shard(model, reshard_after_forward=reshard_after_forward)
+        local_weight = model.weight._local_tensor
+        local_weight.fsdp_pre_all_gather = fsdp_pre_all_gather.__get__(local_weight)
+        local_weight.fsdp_post_all_gather = fsdp_post_all_gather.__get__(local_weight)
+        local_weight.fsdp_should_release_all_gather_outputs_after_post_all_gather = (
+            fsdp_should_release_all_gather_outputs_after_post_all_gather.__get__(
+                local_weight
+            )
+        )
+
+        inp = torch.randn((2, 8), device=device_type)
+        for _ in range(2):
+            output = model(inp)
+            weight_outputs, weight_inner_tensors, bias_outputs = (
+                model.storage_observations[-1]
+            )
+            self.assertTrue(all(size == 0 for size in weight_outputs))
+            self.assertTrue(all(size > 0 for size in weight_inner_tensors))
+            self.assertTrue(all(size > 0 for size in bias_outputs))
+
+            output.sum().backward()
+            state = fully_shard.state(model)
+            param_group = state._fsdp_param_group
+            if param_group is None:
+                raise AssertionError("Expected an FSDP parameter group")
+            for fsdp_param in param_group.fsdp_params:
+                self.assertTrue(
+                    all(
+                        tensor.untyped_storage().size() == 0
+                        for tensor in fsdp_param.all_gather_outputs
+                    )
+                )
+                self.assertTrue(
+                    all(
+                        tensor.untyped_storage().size() == 0
+                        for tensor in fsdp_param._unsharded_inner_tensors
+                    )
+                )
+
+        expected_post_all_gather_calls = 4 if reshard_after_forward else 2
+        self.assertEqual(tls.num_post_all_gather_calls, expected_post_all_gather_calls)
+
+    @skip_if_lt_x_gpu(1)
     def test_all_gather_extension_outer_size_stride(self):
         """
         NOTE: We cannot easily test the incorrect case where the user-defined

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -840,7 +840,7 @@ class FSDPParam:
         if has_fsdp_pre_all_gather:
             self._extensions_data = ExtensionsData()
         self._release_all_gather_outputs_after_post_all_gather = False
-        if has_release_all_gather_outputs:
+        if release_all_gather_outputs_fn is not None:
             # The extension owns whether its post-all-gather representation
             # aliases the raw all-gather outputs, so it must declare when those
             # outputs are no longer needed.

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -208,6 +208,7 @@ class FSDPParam:
     # All-gather extension attributes
     _extensions_data: ExtensionsData
     _unsharded_inner_tensors: list[torch.Tensor]
+    _release_all_gather_outputs_after_post_all_gather: bool
     _orig_param_uid: int
 
     def __init__(
@@ -819,13 +820,47 @@ class FSDPParam:
         inner_tensor = self._sharded_local_tensor
         has_fsdp_pre_all_gather = hasattr(inner_tensor, "fsdp_pre_all_gather")
         has_fsdp_post_all_gather = hasattr(inner_tensor, "fsdp_post_all_gather")
+        release_all_gather_outputs_fn = getattr(
+            inner_tensor,
+            "fsdp_should_release_all_gather_outputs_after_post_all_gather",
+            None,
+        )
+        has_release_all_gather_outputs = release_all_gather_outputs_fn is not None
         if has_fsdp_pre_all_gather != has_fsdp_post_all_gather:
             raise AssertionError(
                 "Both fsdp_pre_all_gather and fsdp_post_all_gather should be defined "
                 f"if using all-gather extensions: {inner_tensor}"
             )
+        if has_release_all_gather_outputs and not has_fsdp_post_all_gather:
+            raise AssertionError(
+                "fsdp_should_release_all_gather_outputs_after_post_all_gather "
+                "requires fsdp_pre_all_gather and fsdp_post_all_gather to be "
+                f"defined: {inner_tensor}"
+            )
         if has_fsdp_pre_all_gather:
             self._extensions_data = ExtensionsData()
+        self._release_all_gather_outputs_after_post_all_gather = False
+        if has_release_all_gather_outputs:
+            # The extension owns whether its post-all-gather representation
+            # aliases the raw all-gather outputs, so it must declare when those
+            # outputs are no longer needed.
+            should_release = release_all_gather_outputs_fn()
+            if not isinstance(should_release, bool):
+                raise AssertionError(
+                    "fsdp_should_release_all_gather_outputs_after_post_all_gather "
+                    f"must return a bool, got {type(should_release)}"
+                )
+            if (
+                should_release
+                and self.post_forward_mesh_info is not None
+                and self.post_forward_mesh_info != self.mesh_info
+            ):
+                raise NotImplementedError(
+                    "Releasing all-gather outputs after post-all-gather is not "
+                    "supported when reshard_after_forward is an int because FSDP "
+                    "uses those outputs to construct the post-forward shard"
+                )
+            self._release_all_gather_outputs_after_post_all_gather = should_release
         self._unsharded_inner_tensors: list[torch.Tensor] = []
 
     def init_all_gather_outputs(
@@ -857,6 +892,7 @@ class FSDPParam:
                 out=self._unsharded_param,
             )
             self._extensions_data.clear()
+            self._release_all_gather_outputs_if_needed()
             return
         inner_tensor = self._sharded_local_tensor
         if hasattr(inner_tensor, "fsdp_post_all_gather"):
@@ -894,6 +930,11 @@ class FSDPParam:
         self._unsharded_param = nn.Parameter(
             unsharded_param, requires_grad=self.sharded_param.requires_grad
         )
+        self._release_all_gather_outputs_if_needed()
+
+    def _release_all_gather_outputs_if_needed(self) -> None:
+        if self._release_all_gather_outputs_after_post_all_gather:
+            self.free_all_gather_outputs()
 
     def _get_unsharded_dtensor_spec(self, unsharded_param: torch.Tensor) -> DTensorSpec:
         if self._unsharded_dtensor_spec is None:
@@ -1041,10 +1082,13 @@ class FSDPParam:
         for tensor in self.all_gather_outputs:
             alloc_storage(tensor)
 
+    def free_all_gather_outputs(self) -> None:
+        for tensor in self.all_gather_outputs:
+            free_storage(tensor)
+
     def free_unsharded_param(self) -> None:
-        for tensor in itertools.chain(
-            self.all_gather_outputs, self._unsharded_inner_tensors
-        ):
+        self.free_all_gather_outputs()
+        for tensor in self._unsharded_inner_tensors:
             free_storage(tensor)
 
     @property


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #194114

Adds an optional per-parameter FSDP tensor-subclass hook allowing post-all-gather transformations to release the original all-gather buffers immediately while retaining transformed  tensors until normal resharding. Using this capability requires a tensor-subclass parameter implementing the FSDP extension hooks; existing extensions remain unchanged.