### PR TITLE
fix-193938-align-randn bug

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -13516,6 +13516,37 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertEqual(code.count("triton_helpers.rand_eager_kernel"), 1)
         self.assertEqual(code.count("tl.rand("), 0)
 
+    @xfail_if_mps  # Only works for Triton on CUDA
+    @config.patch(align_random_eager=True)
+    def test_align_random_eager_randn(self):
+        if self.device != "cuda":
+            raise unittest.SkipTest("Only valid for CUDA!")
+
+        @torch.compile
+        def fn():
+            return torch.randn([4096], device=self.device)
+
+        torch.manual_seed(1234)
+        result, (code,) = run_and_get_code(fn)
+        self.assertEqual(result.shape, (4096,))
+        self.assertEqual(code.count("triton_helpers.rand_eager_kernel"), 0)
+
+        x = torch.empty(4096, device=self.device)
+
+        @torch.compile
+        def fn_like(t):
+            return torch.randn_like(t)
+
+        torch.manual_seed(5678)
+        result_like = fn_like(x)
+        self.assertEqual(result_like.shape, x.shape)
+
+        for t in (result, result_like):
+            self.assertGreater((t < 0).sum().item(), 0)
+            self.assertGreater((t > 1).sum().item(), 0)
+            self.assertTrue(-0.2 < t.mean().item() < 0.2)
+            self.assertTrue(0.7 < t.std().item() < 1.3)
+
     @xfail_if_mps  # Only works for triton
     def test_randint_kernel_count(self):
         if self.device != GPU_TYPE:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -3174,7 +3174,7 @@ def inductor_random(
     ).make_indexer()
     seed_loader = seed.make_loader()
 
-    if config.align_random_eager and device.type == "cuda":
+    if config.align_random_eager and device.type == "cuda" and mode == "rand":
         threads_per_round = get_threads_per_round(device)
 
         def _vec_from_dtype(dt: torch.dtype) -> int:


### PR DESCRIPTION
### Summary

Fixes #193938.

When `torch._inductor.config.align_random_eager=True`, compiled `torch.randn` and `torch.randn_like` on CUDA were incorrectly lowered through `ops.rand_eager`, which produces uniform `[0, 1)` values.

The FX random replacement only uses the eager-aligned seed/offset path for `rand`, but `inductor_random()` applied the corresponding lowering to all CUDA random modes when `align_random_eager` was enabled.

This change restricts the eager-aligned lowering to:

```python
mode == "rand"
```

so `randn` and `randn_like` continue through the existing normal random lowering instead of the uniform `rand_eager` kernel.

A regression test covers both `torch.randn` and `torch.randn_like` with `align_random_eager=True` and verifies that the generated code does not use `triton_helpers.rand_eager_kernel` and that the output has standard-normal characteristics.

### Test plan

Passed locally:

```text
python -m py_compile torch/_inductor/lowering.py
python -m py_compile test/inductor/test_torchinductor.py
git diff --check
```

CUDA/Inductor runtime tests were not run locally because the checkout is not built with the required PyTorch C extensions and the environment does not have a CUDA GPU.

Relevant tests for CUDA CI:

```text
test_align_random_eager_randn
test_align_random_eager_skips_rand4x
test_randn_uses_randn4x
test/inductor/test_dropout_align_random_eager.py
```


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo