### PR TITLE
[pipelining][1/4] Let backward start from a GradientEdge instead of the output

### DIFF
--- a/test/distributed/pipelining/test_backward.py
+++ b/test/distributed/pipelining/test_backward.py
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import copy
+import weakref
 
 from model_registry import MLPModule, MultiInterMediateModel
 
@@ -328,6 +329,143 @@ class StageBackwardTests(TestCase):
         for name, p in mod.named_parameters():
             ref_p = ref_mod.get_parameter(name)
             torch.testing.assert_close(p.grad, ref_p.grad)
+
+    def test_stage_backward_from_gradient_edge(self, device):
+        """Match tensor-rooted backward after releasing the output."""
+        mod = MLPModule(d_hid).to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        output_grad = torch.randn(batch_size, d_hid, device=device)
+
+        ref_mod = copy.deepcopy(mod).to(device)
+        ref_x = x.detach().clone().requires_grad_(True)
+
+        out = mod(x)
+        edge = torch.autograd.graph.get_gradient_edge(out)
+        # The edge must not keep the activation alive.
+        released = weakref.ref(out)
+        del out
+        self.assertIsNone(released())
+
+        grad_inputs = stage_backward(
+            stage_output=(edge,),
+            output_grads=(output_grad,),
+            input_values=(x,),
+        )
+
+        ref_out = ref_mod(ref_x)
+        ref_out.backward(output_grad)
+
+        torch.testing.assert_close(grad_inputs[0], ref_x.grad)
+        for name, p in mod.named_parameters():
+            torch.testing.assert_close(p.grad, ref_mod.get_parameter(name).grad)
+
+    def test_stage_backward_mixed_edge_and_tensor_outputs(self, device):
+        """Handle edge, tensor, and non-grad outputs together."""
+
+        class TwoOutputModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.net1 = torch.nn.Linear(d_hid, d_hid)
+                self.net2 = torch.nn.Linear(d_hid, d_hid)
+
+            def forward(self, x):
+                return self.net1(x), self.net2(x), torch.ones(1, device=x.device)
+
+        mod = TwoOutputModule().to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        grads = (
+            torch.randn(batch_size, d_hid, device=device),
+            torch.randn(batch_size, d_hid, device=device),
+            None,
+        )
+
+        ref_mod = copy.deepcopy(mod).to(device)
+        ref_x = x.detach().clone().requires_grad_(True)
+
+        first, second, no_grad_out = mod(x)
+        edge = torch.autograd.graph.get_gradient_edge(first)
+        del first
+
+        self.assertFalse(no_grad_out.requires_grad)
+        grad_inputs = stage_backward(
+            stage_output=(edge, second, None),
+            output_grads=grads,
+            input_values=(x,),
+        )
+
+        ref_first, ref_second, _ = ref_mod(ref_x)
+        torch.autograd.backward((ref_first, ref_second), (grads[0], grads[1]))
+
+        torch.testing.assert_close(grad_inputs[0], ref_x.grad)
+        for name, p in mod.named_parameters():
+            torch.testing.assert_close(p.grad, ref_mod.get_parameter(name).grad)
+
+    def test_stage_backward_edge_keeps_python_autograd_function_alive(self, device):
+        """Keep a Python autograd graph alive through its edge."""
+
+        class ScaleBy(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, factor):
+                ctx.factor = factor
+                return x * factor
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                return grad_out * ctx.factor, None
+
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        output_grad = torch.randn(batch_size, d_hid, device=device)
+
+        out = ScaleBy.apply(x, 3.0)
+        edge = torch.autograd.graph.get_gradient_edge(out)
+        del out
+
+        grad_inputs = stage_backward(
+            stage_output=(edge,),
+            output_grads=(output_grad,),
+            input_values=(x,),
+        )
+        torch.testing.assert_close(grad_inputs[0], output_grad * 3.0)
+
+    def test_stage_backward_input_from_gradient_edge(self, device):
+        """Match tensor-rooted split backward."""
+        mod = MLPModule(d_hid).to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        output_grad = torch.randn(batch_size, d_hid, device=device)
+
+        ref_mod = copy.deepcopy(mod).to(device)
+        ref_x = x.detach().clone().requires_grad_(True)
+
+        out = mod(x)
+        edge = torch.autograd.graph.get_gradient_edge(out)
+        del out
+
+        dinputs, param_groups = stage_backward_input(
+            stage_outputs_or_loss=[edge],
+            output_grads=[output_grad],
+            input_values=[x],
+            weights=mod.parameters(),
+        )
+        stage_backward_weight(mod.parameters(), param_groups)
+
+        ref_mod(ref_x).backward(output_grad)
+
+        torch.testing.assert_close(dinputs[0], ref_x.grad)
+        for name, p in mod.named_parameters():
+            torch.testing.assert_close(p.grad, ref_mod.get_parameter(name).grad)
+
+    def test_stage_backward_input_edge_requires_output_grads(self, device):
+        mod = MLPModule(d_hid).to(device)
+        x = torch.randn(batch_size, d_hid, device=device, requires_grad=True)
+        edge = torch.autograd.graph.get_gradient_edge(mod(x))
+
+        with self.assertRaisesRegex(AssertionError, "requires output gradients"):
+            stage_backward_input(
+                stage_outputs_or_loss=[edge],
+                output_grads=None,
+                input_values=[x],
+                weights=mod.parameters(),
+            )
 
 
 instantiate_device_type_tests(StageBackwardTests, globals(), allow_xpu=True)

--- a/test/distributed/pipelining/test_stage.py
+++ b/test/distributed/pipelining/test_stage.py
@@ -3,18 +3,24 @@
 
 import os
 import tempfile
+from unittest import mock
 
 from model_registry import ExampleCode, ModelWithKwargs, MultiMLP
 
 import torch
 import torch.distributed as dist
+from torch.autograd.graph import GradientEdge
 from torch.distributed.pipelining import (
     build_stage,
     pipeline,
     PipelineStage,
     ScheduleGPipe,
 )
-from torch.distributed.pipelining._utils import PipeliningMetadataError
+from torch.distributed.pipelining._utils import (
+    extract_tensor_meta,
+    PipeliningMetadataError,
+)
+from torch.distributed.pipelining.stage import _early_send_release_default, _RecvInfo
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_accelerator_dist_backend,
@@ -125,6 +131,206 @@ def get_flatten_hook():
         return tree_map_only(torch.Tensor, f, output)
 
     return flatten_hook
+
+
+class OutputSlotReleaseTest(TestCase):
+    """Tests forward-cache output release."""
+
+    def setUp(self):
+        super().setUp()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._owns_pg = not dist.is_initialized()
+        if self._owns_pg:
+            dist.init_process_group(
+                "gloo",
+                init_method=f"file://{os.path.join(self._tmpdir.name, 'pg')}",
+                rank=0,
+                world_size=1,
+            )
+
+    def tearDown(self):
+        if self._owns_pg and dist.is_initialized():
+            dist.destroy_process_group()
+        self._tmpdir.cleanup()
+        super().tearDown()
+
+    def _make_stage(self, *, stage_index=0, num_stages=2, dst_stages=None, **kwargs):
+        stage = PipelineStage(
+            torch.nn.Linear(d_hid, d_hid),
+            stage_index,
+            num_stages,
+            torch.device("cpu"),
+            **kwargs,
+        )
+        stage.has_backward = True
+        # Explicit, so the test does not depend on the default.
+        stage.early_send_release = True
+        # Avoid peer-dependent forward setup.
+        stage.act_send_info = {0: dst_stages or [stage_index + 1]}
+        return stage
+
+    def _forward_and_send(self, stage, mb_index=0):
+        x = torch.randn(batch_size, d_hid)
+        stage.forward_one_chunk(mb_index, (x,))
+        return stage.get_fwd_send_ops(mb_index)
+
+    def test_output_released_when_send_retires(self):
+        stage = self._make_stage()
+        ops = self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(len(ops), 1)
+        self.assertEqual(entry.pending_consumers, [1])
+        self.assertIsNotNone(entry.live_outputs[0])
+        self.assertIsInstance(entry.backward_roots[0], GradientEdge)
+
+        stage.retire_fwd_sends(0)
+
+        self.assertEqual(entry.pending_consumers, [0])
+        self.assertIsNone(entry.live_outputs[0])
+        self.assertIs(entry.stage_output_for_backward()[0], entry.backward_roots[0])
+
+    def test_output_kept_until_every_destination_retires(self):
+        stage = self._make_stage(num_stages=3, dst_stages=[1, 2])
+        ops = self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        # Destinations share one batched buffer lease.
+        self.assertEqual(len(ops), 2)
+        self.assertIs(ops[0].tensor, ops[1].tensor)
+        self.assertEqual(entry.pending_consumers, [1])
+
+        stage.retire_fwd_sends(0)
+        self.assertIsNone(entry.live_outputs[0])
+
+    def test_last_stage_output_never_released(self):
+        stage = self._make_stage(stage_index=0, num_stages=1, dst_stages=[None])
+        ops = self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(ops, [])
+        self.assertEqual(entry.releasable, (False,))
+        self.assertIsNone(entry.backward_roots[0])
+        self.assertEqual(stage._retained_output_reason, "last-stage output")
+
+        stage.retire_fwd_sends(0)
+        self.assertIsNotNone(entry.live_outputs[0])
+
+    def test_early_send_release_defaults_on(self):
+        # Do not inherit the caller's opt-out.
+        with mock.patch.dict(os.environ):
+            os.environ.pop("TORCH_PIPELINING_EARLY_SEND_RELEASE", None)
+            self.assertTrue(_early_send_release_default())
+            stage = PipelineStage(
+                torch.nn.Linear(d_hid, d_hid), 0, 2, torch.device("cpu")
+            )
+            self.assertTrue(stage.early_send_release)
+
+    def test_early_send_release_env_opt_out(self):
+        with mock.patch.dict(os.environ, {"TORCH_PIPELINING_EARLY_SEND_RELEASE": "0"}):
+            self.assertFalse(_early_send_release_default())
+            stage = PipelineStage(
+                torch.nn.Linear(d_hid, d_hid), 0, 2, torch.device("cpu")
+            )
+            self.assertFalse(stage.early_send_release)
+
+    def test_forward_only_keeps_no_backward_root(self):
+        # An unused edge would retain the forward-only graph.
+        stage = self._make_stage()
+        stage.has_backward = False
+        self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.backward_roots, (None,))
+        stage.retire_fwd_sends(0)
+        self.assertIsNone(entry.live_outputs[0])
+
+    def test_release_disabled_keeps_output(self):
+        stage = self._make_stage()
+        stage.early_send_release = False
+        self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.releasable, (False,))
+        stage.retire_fwd_sends(0)
+        self.assertIsNotNone(entry.live_outputs[0])
+        self.assertIsInstance(entry.stage_output_for_backward()[0], torch.Tensor)
+
+    def test_dw_builder_keeps_output(self):
+        stage = self._make_stage(dw_builder=lambda: (lambda: None))
+        self._forward_and_send(stage)
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.releasable, (False,))
+        stage.retire_fwd_sends(0)
+        self.assertIsNotNone(entry.live_outputs[0])
+
+    def test_tensor_subclass_output_kept(self):
+        class TaggedTensor(torch.Tensor):
+            pass
+
+        class TaggedModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = torch.nn.Linear(d_hid, d_hid)
+
+            def forward(self, x):
+                return TaggedTensor(self.linear(x))
+
+        stage = PipelineStage(TaggedModule(), 0, 2, torch.device("cpu"))
+        stage.has_backward = True
+        # Explicit, so the subclass check is what rejects the slot.
+        stage.early_send_release = True
+        stage.act_send_info = {0: [1]}
+        stage.forward_one_chunk(0, (torch.randn(batch_size, d_hid),))
+        entry = stage.fwd_cache[0]
+
+        self.assertEqual(entry.releasable, (False,))
+        self.assertIn("TaggedTensor", stage._retained_output_reason)
+
+    def test_retire_after_backward_consumed_the_entry(self):
+        # The final drain may run after backward pops the entry.
+        stage = self._make_stage()
+        self._forward_and_send(stage)
+        stage.fwd_cache.pop(0)
+        stage.retire_fwd_sends(0)
+
+    def test_split_backward_drops_edge_roots(self):
+        """Drop edge roots before split weight backward."""
+        # The first stage keeps its roots for weight backward.
+        stage = self._make_stage(stage_index=1, num_stages=3)
+        stage.chunks = 1
+        stage._stage_meta.inputs = (None,)
+
+        act_buffer = torch.randn(batch_size, d_hid, requires_grad=True)
+        stage.args_recv_info = {
+            0: (_RecvInfo("act_recv", 0, act_buffer, extract_tensor_meta(act_buffer)),)
+        }
+        stage.forward_one_chunk(0, ())
+        stage.get_fwd_send_ops(0)
+        stage.retire_fwd_sends(0)
+        self.assertIsNone(stage.fwd_cache[0].live_outputs[0])
+
+        grad_buffer = torch.randn(batch_size, d_hid)
+        stage.grad_recv_info = {
+            0: (
+                _RecvInfo(
+                    "grad_recv", 1, grad_buffer, extract_tensor_meta(grad_buffer)
+                ),
+            )
+        }
+        stage.backward_one_chunk(0, full_backward=False)
+
+        roots = stage.backward_state[0][2]
+        self.assertTrue(all(not isinstance(root, GradientEdge) for root in roots))
+
+    def test_send_after_release_is_rejected(self):
+        stage = self._make_stage()
+        self._forward_and_send(stage)
+        stage.retire_fwd_sends(0)
+
+        with self.assertRaisesRegex(AssertionError, "released before its send"):
+            stage.get_fwd_send_ops(0)
 
 
 class StageTest(MultiProcContinuousTest):

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -3,7 +3,7 @@
 import collections
 import logging
 from collections.abc import Iterator, Sequence
-from typing import Any
+from typing import Any, cast
 
 import torch
 from torch.autograd.graph import GradientEdge, Node
@@ -15,13 +15,17 @@ from ._debug import map_debug_info
 logger = logging.getLogger(__name__)
 
 
-def _get_grad_fn_or_grad_acc(t: torch.Tensor) -> Node | None:
+def _get_grad_fn_or_grad_acc(t: torch.Tensor | GradientEdge) -> Node | None:
     """
     Get the grad function or grad accumulator for a tensor.
 
     Accumulate grad nodes are lazily created, so we need to a
     dummy view in order to trigger its creation.
+
+    A ``GradientEdge`` directly supplies the backward root.
     """
+    if isinstance(t, GradientEdge):
+        return t.node
     if t.requires_grad and t.grad_fn is None:
         # if no grad function (leaf tensors) we use view
         viewed_t = t.view_as(t)
@@ -141,7 +145,7 @@ def get_param_groups(
 
 
 def _autograd_grad_for_inputs(
-    outputs: Sequence[torch.Tensor],
+    outputs: Sequence[torch.Tensor | GradientEdge],
     inputs: Sequence[Any],
     grad_outputs: Sequence[torch.Tensor | None] | None = None,
     retain_graph: bool = False,
@@ -161,7 +165,8 @@ def _autograd_grad_for_inputs(
         return tuple(None for _ in inputs)
 
     grads = torch.autograd.grad(
-        outputs=outputs,
+        # The stub does not model Autograd's GradientEdge support.
+        outputs=cast(Sequence[torch.Tensor], outputs),
         inputs=inputs_requiring_grad,
         grad_outputs=grad_outputs,
         retain_graph=retain_graph,
@@ -175,7 +180,7 @@ def _autograd_grad_for_inputs(
 
 
 def stage_backward_input(
-    stage_outputs_or_loss: list[torch.Tensor],
+    stage_outputs_or_loss: Sequence[torch.Tensor | GradientEdge | None],
     output_grads: list[torch.Tensor] | None,
     input_values: list[Any],
     weights: Iterator[Parameter],
@@ -184,21 +189,34 @@ def stage_backward_input(
     Compute the gradients for only the stage inputs with
     respect to the stage outputs (if non-last stage) or loss (if last stage)
 
+    Entries may be tensors, edges for released outputs, or ``None``.
+
     After computing input gradients, we save the intermediate nodes in `param_groups`
     for later use in stage_backward_weight. We don't need to save any other intermediate nodes
     that aren't needed for dW because when we do dW calculation, we start from saved intermediates.
     Detaching the stage_outputs_or_loss at the end of this function is important as
     it frees up the memory that the autograd graph is anticipating to be used later (but doesn't actually need).
     """
-    valid_outputs: list[torch.Tensor] = []
+    valid_outputs: list[torch.Tensor | GradientEdge] = []
     valid_output_grads: list[torch.Tensor | None] = []
     for i, stage_output in enumerate(stage_outputs_or_loss):
-        if not stage_output.requires_grad and stage_output.grad_fn is None:
-            continue
-        valid_outputs.append(stage_output)
-        valid_output_grads.append(
-            torch.ones_like(stage_output) if output_grads is None else output_grads[i]
-        )
+        if isinstance(stage_output, GradientEdge):
+            # Released activations receive gradients from the next stage.
+            if output_grads is None:
+                raise AssertionError(
+                    "A GradientEdge root requires output gradients from the next stage"
+                )
+            valid_outputs.append(stage_output)
+            valid_output_grads.append(output_grads[i])
+        elif isinstance(stage_output, torch.Tensor) and (
+            stage_output.requires_grad or stage_output.grad_fn is not None
+        ):
+            valid_outputs.append(stage_output)
+            valid_output_grads.append(
+                torch.ones_like(stage_output)
+                if output_grads is None
+                else output_grads[i]
+            )
 
     stage_output_grad_fns: list[Node] = list(
         filter(None, map(_get_grad_fn_or_grad_acc, valid_outputs))
@@ -262,7 +280,8 @@ def stage_backward_input(
 
         # drop output side graph state we no longer need
         for t in stage_outputs_or_loss:
-            t.detach_()
+            if isinstance(t, torch.Tensor):
+                t.detach_()
 
         return dinputs, param_groups
     except Exception as e:
@@ -358,6 +377,10 @@ def stage_backward(
     value(s), compute and accumulate gradients for all parameter values (leaves
     in the autograd trace) as well as return a list of the gradients for the
     input values
+
+    An output value may be a ``GradientEdge`` instead of a tensor when the stage
+    released the output after its send completed. Autograd starts from the edge's
+    node, so the released activation is not needed.
     """
     if outputs_with_grads_idxs is not None:
         # Deprecated, not used in runtime calls, only exists in compiler
@@ -367,7 +390,7 @@ def stage_backward(
     try:
         # stage_output may be a composite datatype like dict. Extract all individual
         # tensor values here
-        stage_output_tensors: list[torch.Tensor] = []
+        stage_output_tensors: list[torch.Tensor | GradientEdge] = []
         output_grad_tensors: list[torch.Tensor | None] = []
 
         def extract_tensors_with_grads(
@@ -376,7 +399,14 @@ def stage_backward(
             # Don't delete me- see [Note: ref cycle]
             extract_tensors_with_grads,
         ):
-            if isinstance(output_val, torch.Tensor):
+            if isinstance(output_val, GradientEdge):
+                if not isinstance(grad_val, torch.Tensor):
+                    raise AssertionError(
+                        f"A GradientEdge root requires a gradient but got {type(grad_val)}"
+                    )
+                stage_output_tensors.append(output_val)
+                output_grad_tensors.append(grad_val)
+            elif isinstance(output_val, torch.Tensor):
                 if not output_val.requires_grad and output_val.grad_fn is None:
                     return
                 if not isinstance(grad_val, (torch.Tensor, type(None))):
@@ -432,7 +462,7 @@ def stage_backward(
         )
 
         torch.autograd.backward(
-            stage_output_tensors,
+            cast(Sequence[torch.Tensor], stage_output_tensors),
             grad_tensors=output_grad_tensors,  # type: ignore[arg-type]
         )
 

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -2,10 +2,12 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 import logging
 import operator
+import os
 import warnings
 import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, cast
 
 import torch
@@ -14,6 +16,7 @@ import torch.distributed.config as dist_config
 import torch.fx as fx
 import torch.nn as nn
 from torch._subclasses.fake_tensor import is_fake_tensor
+from torch.autograd.graph import get_gradient_edge, GradientEdge
 from torch.distributed._composable.replicate_with_fsdp import replicate, ReplicateModule
 from torch.distributed.fsdp import FSDPModule, fully_shard
 from torch.distributed.pipelining._utils import (
@@ -90,6 +93,38 @@ def _normalize_model_output_as_tuple(output: Any) -> tuple[Any]:
     # `act_send_info`
     output_tuple = output if type(output) is tuple else (output,)
     return output_tuple
+
+
+def _early_send_release_default() -> bool:
+    """Return the early-release setting, on unless opted out.
+
+    Set ``TORCH_PIPELINING_EARLY_SEND_RELEASE=0`` to keep sent activations until
+    the end of the step. Configurations whose backward needs the output tensor
+    itself are already declined by :meth:`_output_slot_is_releasable`, so the
+    opt-out is for diagnosing a suspected regression rather than for correctness.
+    """
+    return os.environ.get("TORCH_PIPELINING_EARLY_SEND_RELEASE", "1") != "0"
+
+
+@dataclass
+class _ForwardCacheEntry:
+    """Forward state retained per microbatch.
+
+    Releasable outputs use ``backward_roots`` after their consumers retire.
+    """
+
+    backward_roots: tuple[GradientEdge | None, ...]
+    input_values: list[torch.Tensor]
+    live_outputs: list[torch.Tensor | None]
+    releasable: tuple[bool, ...]
+    pending_consumers: list[int]
+
+    def stage_output_for_backward(self) -> tuple[Any, ...]:
+        """Return each live tensor or its saved gradient edge."""
+        return tuple(
+            live if live is not None else root
+            for live, root in zip(self.live_outputs, self.backward_roots, strict=True)
+        )
 
 
 class _RecvInfo:
@@ -266,8 +301,8 @@ class _PipelineStageBase(ABC):
             )
 
         # Run time states
-        # map microbatch ID to list of forward tensor args
-        self.fwd_cache: dict[int, tuple[Any, list[torch.Tensor]]] = {}
+        # Forward state by microbatch.
+        self.fwd_cache: dict[int, _ForwardCacheEntry] = {}
         # map microbatch ID to list of backward grad tensor args
         self.bwd_cache: dict[int, tuple[torch.Tensor | None, ...]] = {}
         # Caching chunk outputs for final output merge or reduction
@@ -278,6 +313,11 @@ class _PipelineStageBase(ABC):
         self.has_backward = False
         # Log prefix
         self.log_prefix = f"[Stage {self.stage_index}]"
+
+        # Release sent activations and buffers before the step ends.
+        self.early_send_release = _early_send_release_default()
+        # Reason the stage kept an output tensor, logged once per stage.
+        self._retained_output_reason: str | None = None
 
         # Forward infra
         self.args_recv_info: dict[int, tuple[_RecvInfo, ...]] = {}
@@ -565,22 +605,77 @@ class _PipelineStageBase(ABC):
         recv_infos = self.grad_recv_info[bwd_chunk_id]
         return self._get_recv_ops(recv_infos, self._upstream_group)
 
+    def _output_slot_is_releasable(self, output: Any) -> tuple[bool, str]:
+        """Return whether an output may be released after sending."""
+        if not self.early_send_release:
+            return False, "early release disabled"
+        if self.is_last:
+            return False, "last-stage output"
+        if type(output) is not torch.Tensor:
+            # Gradient-edge backward is only validated for plain tensors.
+            return False, f"output type {type(output).__name__}"
+        if isinstance(self.submod, DistributedDataParallel):
+            # DDP builds its reducer from the output tensors.
+            return False, "DDP reducer requires live outputs"
+        if self.dw_builder is not None:
+            return False, "custom dw_builder may require live outputs"
+        return True, ""
+
+    def _make_fwd_cache_entry(
+        self, output_tuple: tuple[Any, ...], input_values: list[torch.Tensor]
+    ) -> _ForwardCacheEntry:
+        releasable: list[bool] = []
+        backward_roots: list[GradientEdge | None] = []
+        for out in output_tuple:
+            can_release, reason = self._output_slot_is_releasable(out)
+            releasable.append(can_release)
+            # Avoid retaining an autograd root in forward-only schedules.
+            backward_roots.append(
+                get_gradient_edge(out)
+                if self.has_backward and can_release and out.requires_grad
+                else None
+            )
+            if not can_release and self._retained_output_reason is None:
+                self._retained_output_reason = reason
+                logger.debug(
+                    "%s keeping output tensors alive until backward: %s",
+                    self.log_prefix,
+                    reason,
+                )
+
+        return _ForwardCacheEntry(
+            backward_roots=tuple(backward_roots),
+            input_values=input_values,
+            live_outputs=list(output_tuple),
+            releasable=tuple(releasable),
+            pending_consumers=[0] * len(output_tuple),
+        )
+
     def get_fwd_send_ops(self, fwd_chunk_id: int) -> list[dist.P2POp]:
         """
         Get the activation send ops for current stage's forward.
         Handles DTensor outputs by extracting local tensors.
+
+        Sent slots hold a lease until :meth:`retire_fwd_sends`.
         """
-        output_tuple, _ = self.fwd_cache[fwd_chunk_id]
+        entry = self.fwd_cache[fwd_chunk_id]
 
         ops: list[dist.P2POp] = []
 
-        for idx, out in enumerate(output_tuple):
-            dst_stages = self.act_send_info[idx]
+        for idx, out in enumerate(entry.live_outputs):
+            dst_stages = [dst for dst in self.act_send_info[idx] if dst is not None]
+            if not dst_stages:
+                continue
+            if out is None:
+                raise AssertionError(
+                    f"{self.log_prefix} output {idx} of chunk {fwd_chunk_id} was "
+                    "released before its send was issued"
+                )
+            # One lease covers the slot's batched sends.
+            entry.pending_consumers[idx] += 1
+            # Extract local tensor if DTensor
+            send_tensor = to_local_if_dtensor(out, detach=True)
             for dst in dst_stages:
-                if dst is None:
-                    continue
-                # Extract local tensor if DTensor
-                send_tensor = to_local_if_dtensor(out, detach=True)
                 logger.debug(
                     "%s Sending tensor to Stage %s: %s",
                     self.log_prefix,
@@ -598,6 +693,22 @@ class _PipelineStageBase(ABC):
                 )
 
         return ops
+
+    def retire_fwd_sends(self, fwd_chunk_id: int) -> None:
+        """Retire send leases and release unused output tensors.
+
+        A missing entry means backward already consumed it.
+        """
+        entry = self.fwd_cache.get(fwd_chunk_id)
+        if entry is None:
+            return
+
+        for idx, pending in enumerate(entry.pending_consumers):
+            if pending == 0:
+                continue
+            entry.pending_consumers[idx] = pending - 1
+            if entry.pending_consumers[idx] == 0 and entry.releasable[idx]:
+                entry.live_outputs[idx] = None
 
     def _get_grad_send_meta(self, input_idx: int) -> TensorMeta | None:
         """Return gradient metadata for ``input_idx`` if a recv was allocated."""
@@ -1002,9 +1113,8 @@ class _PipelineStageBase(ABC):
         flat_args = flatten_args(composite_args)
         flat_kwargs = flatten_args(composite_kwargs)
         flatten_input_tensors = flat_args + flat_kwargs
-        self.fwd_cache[fwd_chunk_id] = (
-            output_tuple,  # stage_output
-            flatten_input_tensors,  # input_values
+        self.fwd_cache[fwd_chunk_id] = self._make_fwd_cache_entry(
+            output_tuple, flatten_input_tensors
         )
 
         logger.debug(
@@ -1052,10 +1162,10 @@ class _PipelineStageBase(ABC):
 
         self._check_chunk_id(bwd_chunk_id)
 
-        (
-            stage_output,
-            input_values,
-        ) = self.fwd_cache.pop(bwd_chunk_id)
+        entry = self.fwd_cache.pop(bwd_chunk_id)
+        # Released slots use gradient edges as backward roots.
+        stage_output = entry.stage_output_for_backward()
+        input_values = entry.input_values
 
         # Compute backward
         if self.is_last:
@@ -1117,6 +1227,13 @@ class _PipelineStageBase(ABC):
                     # when the "stage_ouput" is a loss, then it is a tensor, otherwise it is a tuple of tensors
                     grads_input, param_groups = self.backward_maybe_with_nosync(
                         "input", bwd_kwargs, last_backward=last_backward
+                    )
+
+                    # Edges cannot be detached, so drop them before weight backward.
+                    # The first stage skips this path; tensor roots remain for DDP.
+                    bwd_kwargs["stage_output"] = tuple(
+                        None if isinstance(root, GradientEdge) else root
+                        for root in cast(tuple[Any, ...], bwd_kwargs["stage_output"])
                     )
 
                 # TODO: we don't need to save this, add to dw_runner?


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194122
* #194121
* #194120
* __->__ #194119

A pipeline stage keeps every forward output alive until the end of the step, because `fwd_cache` holds the output tensor and that tensor is where backward starts. Releasing an output early therefore needs somewhere else for backward to begin, which is what this adds. Nothing releases anything yet: the machinery is in place and inert until a later change gives it a trigger.

`_backward.py` accepts a `torch.autograd.graph.GradientEdge` wherever it previously required a tensor root. `_get_grad_fn_or_grad_acc` returns the edge's node, and both the full and split backward helpers take edge roots.

`stage.py` replaces the raw `fwd_cache` tuple with `_ForwardCacheEntry`, which tracks per-output backward roots, live tensors, releasability and pending consumer counts. `stage_output_for_backward()` hands backward the live tensor when it is still there and the edge otherwise, so an output that was never released behaves exactly as before. `retire_fwd_sends()` drops a live output once every consumer has confirmed its send.

`_output_slot_is_releasable()` fails closed. It declines the last stage, anything that is not exactly a `torch.Tensor` (so DTensor and every tensor subclass), a DDP-wrapped submodule, and a custom `dw_builder`. A declined slot keeps its tensor and stores no root, and the reason is logged once per stage.

A backward root is only captured when the stage has a backward. A forward-only schedule still runs with grad enabled, and an edge kept for a backward that never runs would pin the graph node and whatever it saved, which for an op that saves its own output is the storage this exists to release.

Split backward needs one extra step. `stage_backward_input` calls `detach_()` on the tensor roots so the graph above them can be freed before the weight step. A gradient edge has no tensor to detach and would pin that graph instead, which costs more than the activation it releases. Edge roots are therefore cleared from `backward_state` after the input step on a non-first stage; tensor roots stay for DDP's `_find_tensors`.

`TORCH_PIPELINING_EARLY_SEND_RELEASE=0`, or assigning `stage.early_send_release`, turns the whole thing off.

Tests: gradient-edge roots through full and split backward, output-slot releasability and every fail-closed case, the forward-only root, and the split-backward edge clearing.