### PR TITLE
[pipelining][2/4] Retire send buffers by polling for completion

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -32,6 +32,7 @@ from torch.distributed.pipelining.schedules import (
     _defer_recv_ops,
     _format_pipeline_order,
     _merge_bw,
+    _PendingSendTracker,
     _PipelineSchedule,
     _PipelineScheduleRuntime,
     _simulate_comms_compute,
@@ -50,6 +51,7 @@ from torch.distributed.pipelining.schedules import (
     W,
 )
 from torch.distributed.pipelining.stage import (
+    _early_send_release_default,
     _PipelineStageBase,
     _RecvInfo,
     PipelineStage,
@@ -84,6 +86,9 @@ class MockPipelineStage(_PipelineStageBase):
         self.group_size = kwargs.get("group_size", 1)
         self.group_rank = kwargs.get("group_rank", 0)
         self.group = kwargs.get("group")
+        self.early_send_release = kwargs.get(
+            "early_send_release", _early_send_release_default()
+        )
 
     def _create_grad_recv_info(self, *args, **kwargs):
         return None
@@ -2076,6 +2081,162 @@ class TestBatchP2P(TestCase):
         mock_isend.assert_not_called()
         mock_irecv.assert_not_called()
         self.assertEqual(len(result), 4)
+
+
+class _FakeWork:
+    """Test-controlled ``dist.Work`` stub."""
+
+    def __init__(self, error: Exception | None = None):
+        self.completed = False
+        self.wait_count = 0
+        # Failed NCCL work reports complete but raises from wait().
+        self.error = error
+
+    def is_completed(self):
+        return self.completed or self.error is not None
+
+    def wait(self):
+        self.wait_count += 1
+        if self.error is not None:
+            raise self.error
+        self.completed = True
+        return True
+
+
+class TestPendingSendTracker(TestCase):
+    """Tests send-buffer lifetime tracking."""
+
+    def _make_batch(self, num_works=1):
+        works = [_FakeWork() for _ in range(num_works)]
+        op = MagicMock()
+        op.tensor = torch.zeros(4)
+        return works, [op]
+
+    def test_poll_retires_only_completed_batches(self):
+        tracker = _PendingSendTracker()
+        retired = []
+
+        slow_works, slow_ops = self._make_batch()
+        fast_works, fast_ops = self._make_batch()
+        tracker.register(slow_ops, slow_works, lambda: retired.append("slow"))
+        tracker.register(fast_ops, fast_works, lambda: retired.append("fast"))
+
+        tracker.poll()
+        self.assertEqual(retired, [])
+
+        fast_works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["fast"])
+        # Only the completed batch releases its buffer.
+        self.assertEqual(fast_ops, [])
+        self.assertEqual(len(slow_ops), 1)
+
+        slow_works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["fast", "slow"])
+        self.assertEqual(slow_ops, [])
+
+    def test_batch_retires_only_when_all_works_complete(self):
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch(num_works=2)
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, [])
+
+        works[1].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["batch"])
+
+    def test_poll_never_waits(self):
+        tracker = _PendingSendTracker()
+        works, ops = self._make_batch()
+        tracker.register(ops, works)
+
+        tracker.poll()
+        self.assertEqual(works[0].wait_count, 0)
+
+    def test_drain_waits_for_stragglers(self):
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch()
+        work = works[0]
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        tracker.drain()
+
+        self.assertEqual(work.wait_count, 1)
+        self.assertEqual(retired, ["batch"])
+        self.assertEqual(ops, [])
+        # A second drain must not retire the batch again.
+        tracker.drain()
+        self.assertEqual(retired, ["batch"])
+
+    def test_poll_is_a_noop_during_cuda_graph_capture(self):
+        """Avoid completion queries during graph capture."""
+        tracker = _PendingSendTracker()
+        retired = []
+
+        class _ExplodingWork(_FakeWork):
+            def is_completed(self):
+                raise AssertionError("queried completion during capture")
+
+        works, ops = [_ExplodingWork()], [MagicMock()]
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        with patch(
+            "torch.distributed.pipelining.schedules._stream_is_capturing",
+            return_value=True,
+        ):
+            tracker.poll()
+        self.assertEqual(retired, [])
+
+        # Poll normally outside capture.
+        works[0].is_completed = lambda: True
+        with patch(
+            "torch.distributed.pipelining.schedules._stream_is_capturing",
+            return_value=False,
+        ):
+            tracker.poll()
+        self.assertEqual(retired, ["batch"])
+
+    def test_disabled_tracker_defers_everything_to_drain(self):
+        """Preserve end-of-step ownership when disabled."""
+        tracker = _PendingSendTracker(enabled=False)
+        retired = []
+        works, ops = self._make_batch()
+        works[0].completed = True
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        tracker.poll()
+        self.assertEqual(retired, [])
+        self.assertEqual(len(ops), 1)
+
+        tracker.drain()
+        self.assertEqual(retired, ["batch"])
+
+    def test_poll_surfaces_a_failed_send(self):
+        # Waiting surfaces errors from completed work.
+        tracker = _PendingSendTracker()
+        retired = []
+        works = [_FakeWork(error=RuntimeError("NCCL send failed"))]
+        ops = [object()]
+        tracker.register(ops, works, lambda: retired.append("batch"))
+
+        with self.assertRaisesRegex(RuntimeError, "NCCL send failed"):
+            tracker.poll()
+        self.assertEqual(retired, [])
+
+    def test_empty_batch_retires_immediately(self):
+        # Stages with nothing to send may still register a batch.
+        tracker = _PendingSendTracker()
+        retired = []
+        tracker.register([], [], lambda: retired.append("empty"))
+
+        tracker.poll()
+        self.assertEqual(retired, ["empty"])
 
 
 if __name__ == "__main__":

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -1,8 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
 import copy
+import gc
 import logging
 import os
+from collections import Counter
 from dataclasses import dataclass
 
 from model_registry import (
@@ -43,6 +45,7 @@ from torch.distributed.pipelining.schedules import (
     _wait_batch_p2p,
     FORWARD,
     OVERLAP_F_B,
+    PipelineScheduleSingle,
 )
 from torch.distributed.pipelining.stage import _PipelineStageBase  # noqa: TC002
 from torch.nn.attention.flex_attention import BlockMask, create_block_mask
@@ -69,6 +72,9 @@ d_hid = 512
 batch_size = 64
 none_grad_d_hid = 32
 none_grad_microbatches = 8
+# Large activations make release visible in peak memory.
+release_d_hid = 512
+release_batch_size = 16384
 torch.manual_seed(0)
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 backend = dist.get_default_backend_for_device(device_type)
@@ -1414,6 +1420,148 @@ class ScheduleTest(MultiProcContinuousTest):
     @skip_if_lt_x_gpu(4)
     def test_NoneGrad_conditional_input_grad(self, ScheduleClass, pattern):
         self._run_none_grad_schedule(ScheduleClass, pattern)
+
+    @staticmethod
+    def _count_released_activations(stages):
+        """Count outputs dropped by ``retire_fwd_sends``."""
+        counter = Counter()
+
+        def make_counting_retire(stage, retire):
+            def counting_retire(chunk_id):
+                entry = stage.fwd_cache.get(chunk_id)
+                if entry is None:
+                    return retire(chunk_id)
+                before = sum(out is not None for out in entry.live_outputs)
+                retire(chunk_id)
+                after = sum(out is not None for out in entry.live_outputs)
+                counter["released"] += before - after
+
+            return counting_retire
+
+        for stage in stages:
+            stage.retire_fwd_sends = make_counting_retire(stage, stage.retire_fwd_sends)
+        return counter
+
+    def _run_release_sent_activations(self, ScheduleClass, release: bool):
+        """Measure peak memory, gradients, and releases for one schedule."""
+        single_stage = issubclass(ScheduleClass, PipelineScheduleSingle)
+        v_shaped = issubclass(ScheduleClass, (ScheduleZBVZeroBubble, ScheduleDualPipeV))
+        stages_per_rank = 1 if single_stage else 2
+        n_stages = stages_per_rank * self.world_size
+        num_microbatches = 2 * self.world_size
+
+        torch.manual_seed(0)
+        mod = MultiMLP(release_d_hid, n_layers=n_stages).to(self.device)
+        x = torch.randn(release_batch_size, release_d_hid, device=self.device)
+        target = torch.randn(release_batch_size, release_d_hid, device=self.device)
+        loss_fn = torch.nn.MSELoss(reduction="sum")
+
+        # V schedules place mirrored stages on each rank.
+        stage_indices = [self.rank, n_stages - 1 - self.rank] if v_shaped else None
+        stages, stage_modules, _ = create_multi_stage_pipeline(
+            self.config, mod, stages_per_rank, n_stages, stage_indices
+        )
+        for stage in stages:
+            stage.early_send_release = release
+        released_count = self._count_released_activations(stages)
+        schedule = ScheduleClass(
+            stages[0] if single_stage else stages,
+            num_microbatches,
+            loss_fn=loss_fn,
+            scale_grads=False,
+        )
+
+        peak = 0
+        # Measure the second step after buffers and metadata are initialized.
+        for step in range(2):
+            zero_gradients(stage_modules)
+            if step == 1:
+                torch.accelerator.synchronize(self.device)
+                torch.accelerator.reset_peak_memory_stats(self.device)
+                baseline = torch.accelerator.memory_allocated(self.device)
+
+            if v_shaped:
+                if self.rank == 0:
+                    schedule.step(x, target=target, losses=[])
+                else:
+                    schedule.step()
+            elif self.rank == 0:
+                schedule.step(x)
+            elif self.rank == self.world_size - 1:
+                schedule.step(target=target, losses=[])
+            else:
+                schedule.step()
+
+        torch.accelerator.synchronize(self.device)
+        peak = torch.accelerator.max_memory_allocated(self.device) - baseline
+        grads = {
+            f"{i}.{name}": p.grad.clone()
+            for i, stage_module in enumerate(stage_modules)
+            for name, p in stage_module.named_parameters()
+        }
+        return peak, grads, released_count["released"]
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    @parametrize(
+        "ScheduleClass",
+        [
+            ScheduleGPipe,
+            Schedule1F1B,
+            ScheduleInterleaved1F1B,
+            ScheduleInterleavedZeroBubble,
+            ScheduleZBVZeroBubble,
+        ],
+    )
+    def test_release_sent_activations(self, ScheduleClass):
+        """Early release lowers peak memory and leaves gradients untouched."""
+        kept_peak, kept_grads, kept_released = self._run_release_sent_activations(
+            ScheduleClass, release=False
+        )
+        gc.collect()
+        torch.accelerator.empty_cache()
+        (
+            released_peak,
+            released_grads,
+            released_count,
+        ) = self._run_release_sent_activations(ScheduleClass, release=True)
+
+        self.assertEqual(kept_grads.keys(), released_grads.keys())
+        for name, kept in kept_grads.items():
+            torch.testing.assert_close(
+                released_grads[name], kept, rtol=0, atol=0, msg=f"grad differs: {name}"
+            )
+
+        # Only a rank that owns just the last stage has nothing to release.
+        owns_only_last_stage = (
+            issubclass(ScheduleClass, PipelineScheduleSingle)
+            and self.rank == self.world_size - 1
+        )
+        activation_bytes = (
+            release_batch_size
+            // (2 * self.world_size)
+            * release_d_hid
+            * torch.float32.itemsize
+        )
+        saved = kept_peak - released_peak
+        logger.info(
+            "rank %d %s peak kept=%d released=%d saved=%d slots=%d",
+            self.rank,
+            ScheduleClass.__name__,
+            kept_peak,
+            released_peak,
+            saved,
+            released_count,
+        )
+        self.assertEqual(kept_released, 0)
+        if owns_only_last_stage:
+            self.assertEqual(released_count, 0)
+        else:
+            self.assertGreater(released_count, 0)
+            self.assertGreaterEqual(saved, activation_bytes)
 
 
 instantiate_parametrized_tests(ScheduleTest)

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -11,7 +11,7 @@ from collections import Counter, defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import Any, cast, Literal, NamedTuple, Protocol
 
 import torch
@@ -849,6 +849,74 @@ def _wait_batch_p2p(work: list[dist.Work]):
         w.wait()
 
 
+def _flatten_sorted_works(work_by_peer: dict[int, list[dist.Work]]) -> list[dist.Work]:
+    """Flatten one _sorted_batch_p2p result into a single list of works."""
+    return [work for peer_works in work_by_peer.values() for work in peer_works]
+
+
+@dataclass
+class _PendingSendBatch:
+    """An in-flight send batch and its release callback."""
+
+    works: list[dist.Work]
+    # Keep transport buffers alive explicitly.
+    ops: list[dist.P2POp]
+    retire: Callable[[], None] | None
+
+
+def _stream_is_capturing() -> bool:
+    """Return whether completion queries are unsafe during graph capture."""
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
+class _PendingSendTracker:
+    """Own send buffers until completion or the end-of-step drain."""
+
+    def __init__(self, enabled: bool = True) -> None:
+        self._enabled = enabled
+        self._pending: list[_PendingSendBatch] = []
+
+    def register(
+        self,
+        ops: list[dist.P2POp],
+        works: list[dist.Work],
+        retire: Callable[[], None] | None = None,
+    ) -> None:
+        self._pending.append(_PendingSendBatch(works, ops, retire))
+
+    def poll(self) -> None:
+        """Retire completed batches without blocking.
+
+        Poll all batches independently, except during graph capture.
+        """
+        if not self._enabled or not self._pending or _stream_is_capturing():
+            return
+
+        still_pending = []
+        for batch in self._pending:
+            if all(work.is_completed() for work in batch.works):
+                # wait() surfaces errors from completed work without blocking.
+                _wait_batch_p2p(batch.works)
+                self._retire(batch)
+            else:
+                still_pending.append(batch)
+        self._pending = still_pending
+
+    def drain(self) -> None:
+        """Wait for all remaining sends and retire them."""
+        for batch in self._pending:
+            _wait_batch_p2p(batch.works)
+            self._retire(batch)
+        self._pending.clear()
+
+    @staticmethod
+    def _retire(batch: _PendingSendBatch) -> None:
+        batch.works.clear()
+        batch.ops.clear()
+        if batch.retire is not None:
+            batch.retire()
+
+
 class PipelineScheduleSingle(_PipelineSchedule):
     """
     Base class for single-stage schedules.
@@ -1054,11 +1122,12 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
         maybe_first_target = target_mbs[0] if target_mbs is not None else None
         self._initialize_stage(arg_mbs[0], kwarg_mbs[0], maybe_first_target)
 
-        # Delay send waits
-        fwd_sends_to_wait: list[list[dist.Work]] = []
+        # Release each activation when its send completes.
+        pending_sends = _PendingSendTracker(self._stage.early_send_release)
 
         # Run microbatches
         for i in range(self._n_microbatches):
+            pending_sends.poll()
             with record_function(f"Forward {i}"):
                 ops = self._stage.get_fwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="fwd_recv")
@@ -1067,17 +1136,19 @@ class _ScheduleForwardOnly(PipelineScheduleSingle):
 
                 self._stage.forward_one_chunk(i, arg_mbs[i], kwarg_mbs[i])  # type: ignore[index]
 
-                ops = self._stage.get_fwd_send_ops(i)
-                works = _sorted_batch_p2p(ops, desc="fwd_send")
-                fwd_sends_to_wait.extend(works.values())
+                send_ops = self._stage.get_fwd_send_ops(i)
+                pending_sends.register(
+                    send_ops,
+                    _flatten_sorted_works(_sorted_batch_p2p(send_ops, desc="fwd_send")),
+                    partial(self._stage.retire_fwd_sends, i),
+                )
 
             logger.debug("[%s] Forwarded microbatch %s", self._stage.stage_index, i)
 
         # Wait for all forward sends to finish
         # This should not have performance impact because by the time the first
         # backward arrives all the forward sends should have been finished.
-        for work in fwd_sends_to_wait:
-            _wait_batch_p2p(work)
+        pending_sends.drain()
 
 
 class ScheduleGPipe(PipelineScheduleSingle):
@@ -1109,11 +1180,12 @@ class ScheduleGPipe(PipelineScheduleSingle):
             arg_mbs[0], kwarg_mbs[0], maybe_first_target, loss_kwargs
         )
 
-        # Delay send waits
-        fwd_sends_to_wait: list[list[dist.Work]] = []
+        # Release sends during GPipe's all-forward phase.
+        pending_sends = _PendingSendTracker(self._stage.early_send_release)
 
         # Run microbatches
         for i in range(self._n_microbatches):
+            pending_sends.poll()
             with record_function(f"Forward {i}"):
                 ops = self._stage.get_fwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="fwd_recv")
@@ -1124,9 +1196,12 @@ class ScheduleGPipe(PipelineScheduleSingle):
                     i, arg_mbs[i], kwarg_mbs[i], save_forward_output=return_outputs
                 )  # type: ignore[index]
 
-                ops = self._stage.get_fwd_send_ops(i)
-                works = _sorted_batch_p2p(ops, desc="fwd_send")
-                fwd_sends_to_wait.extend(works.values())
+                send_ops = self._stage.get_fwd_send_ops(i)
+                pending_sends.register(
+                    send_ops,
+                    _flatten_sorted_works(_sorted_batch_p2p(send_ops, desc="fwd_send")),
+                    partial(self._stage.retire_fwd_sends, i),
+                )
 
             logger.debug("[%s] Forwarded microbatch %s", self._stage.stage_index, i)
 
@@ -1135,13 +1210,12 @@ class ScheduleGPipe(PipelineScheduleSingle):
         # Wait for all forward sends to finish
         # This should not have performance impact because by the time the first
         # backward arrives all the forward sends should have been finished.
-        for work in fwd_sends_to_wait:
-            _wait_batch_p2p(work)
+        pending_sends.drain()
 
         # Run backward
         # Delay send waits
-        bwd_sends_to_wait: list[list[dist.Work]] = []
         for i in range(self._n_microbatches):
+            pending_sends.poll()
             with record_function(f"Backward {i}"):
                 ops = self._stage.get_bwd_recv_ops(i)
                 works = _sorted_batch_p2p(ops, desc="bwd_recv")
@@ -1155,15 +1229,16 @@ class ScheduleGPipe(PipelineScheduleSingle):
                     last_backward=i == self._n_microbatches - 1,
                 )
 
-                ops = self._stage.get_bwd_send_ops(i)
-                works = _sorted_batch_p2p(ops, desc="bwd_send")
-                bwd_sends_to_wait.extend(works.values())
+                send_ops = self._stage.get_bwd_send_ops(i)
+                pending_sends.register(
+                    send_ops,
+                    _flatten_sorted_works(_sorted_batch_p2p(send_ops, desc="bwd_send")),
+                )
 
             logger.debug("[%s] Backwarded microbatch %s", self._stage.stage_index, i)
 
         # Wait for all backward sends to finish
-        for work in bwd_sends_to_wait:
-            _wait_batch_p2p(work)
+        pending_sends.drain()
 
         # Update losses if there is a container passed in
         self._update_losses(self._stage, losses)
@@ -1269,6 +1344,15 @@ or equal to the number of stages ({self._num_stages})."
         fwd_mb_index = 0
         bwd_mb_index = 0
 
+        # Microbatch owning the pending or in-flight forward send.
+        outstanding_fwd_mb: int | None = None
+
+        def retire_outstanding_fwd_send() -> None:
+            nonlocal outstanding_fwd_mb
+            if outstanding_fwd_mb is not None:
+                self._stage.retire_fwd_sends(outstanding_fwd_mb)
+                outstanding_fwd_mb = None
+
         # Warmup phase
         send_work: list[dist.Work] = []
         fwd_sends = []
@@ -1290,9 +1374,11 @@ or equal to the number of stages ({self._num_stages})."
             # case it doesn't create a lot of benefit to compute next chunk
             # eagerly either)
             _wait_batch_p2p(send_work)
+            retire_outstanding_fwd_send()
 
             # Send activations
             fwd_sends = self._stage.get_fwd_send_ops(fwd_mb_index)
+            outstanding_fwd_mb = fwd_mb_index
             if fwd_mb_index != warmup_chunks - 1:
                 # Safe to fire
                 send_work = _batch_p2p(fwd_sends, desc="fwd_send")
@@ -1314,6 +1400,8 @@ or equal to the number of stages ({self._num_stages})."
 
             # Now, we need to fire the fwd_sends and bwd_recvs together
             _wait_batch_p2p(_batch_p2p(fwd_sends + bwd_recvs, desc="fwd_send_bwd_recv"))
+            # Release the activation before backward allocates.
+            retire_outstanding_fwd_send()
 
             # Backward one chunk
             loss = self._maybe_get_loss(self._stage, bwd_mb_index)
@@ -1352,6 +1440,7 @@ or equal to the number of stages ({self._num_stages})."
 
             # Get the fwd send ops, but don't fire, leave it for the next iter (wrap-around)
             fwd_sends = self._stage.get_fwd_send_ops(fwd_mb_index)
+            outstanding_fwd_mb = fwd_mb_index
             fwd_mb_index += 1
 
         # Remember we still have some bwd_sends left over after the break? Now it is time to fire it
@@ -2298,6 +2387,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
         for time_step, action in enumerate(self.pipeline_order[self.rank]):
             try:
                 ops: list[dist.P2POp] = []
+                # Forward send issued and waited on in this step.
+                sent_fwd: tuple[_PipelineStageBase, int] | None = None
                 if action is not None:
                     computation_type = action.computation_type
                     mb_index = action.microbatch_index
@@ -2319,6 +2410,7 @@ class PipelineScheduleMulti(_PipelineSchedule):
                             stage, output, target_mbs, mb_index, loss_kwargs
                         )
                         ops.extend(stage.get_fwd_send_ops(mb_index))
+                        sent_fwd = (stage, mb_index)
                     elif computation_type == _ComputationType.FULL_BACKWARD:
                         # perform backward computation
                         stage = stage_index_to_stage[stage_index]
@@ -2435,6 +2527,8 @@ class PipelineScheduleMulti(_PipelineSchedule):
 
                 # do the communication
                 _wait_batch_p2p(_batch_p2p(ops))
+                if sent_fwd is not None:
+                    sent_fwd[0].retire_fwd_sends(sent_fwd[1])
             except Exception as e:
                 logger.error(
                     "[Rank %s] pipeline schedule %s caught the following exception '%s' \
@@ -2694,8 +2788,10 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 "Must call _prepare_schedule_with_comms() before calling _step_microbatches()"
             )
 
-        # send ops should be waited on before step() exists, mainly for hygiene
-        send_ops: list[list[dist.Work]] = []
+        # Release completed send buffers between actions.
+        pending_sends = _PendingSendTracker(
+            any(stage.early_send_release for stage in self._stages)
+        )
 
         def _perform_action(action: _Action) -> None:
             comp_type = action.computation_type
@@ -2725,9 +2821,15 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             # However, I was wondering if I should avoid calling batched operators at all in the case that there is
             # only one operator per batch.  I could iterate through the 'fwd_send_ops' one by one and run them.
             if comp_type == SEND_F:
-                send_ops.append(_batch_p2p(stage.get_fwd_send_ops(mb_index)))
+                ops = stage.get_fwd_send_ops(mb_index)
+                pending_sends.register(
+                    ops,
+                    _batch_p2p(ops),
+                    partial(stage.retire_fwd_sends, mb_index),
+                )
             elif comp_type == SEND_B:
-                send_ops.append(_batch_p2p(stage.get_bwd_send_ops(mb_index)))
+                ops = stage.get_bwd_send_ops(mb_index)
+                pending_sends.register(ops, _batch_p2p(ops))
             elif comp_type == RECV_F:
                 if (stage_idx, mb_index) in self.fwd_recv_ops:
                     raise AssertionError(
@@ -2874,6 +2976,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 time_step,
                 action,
             )
+            pending_sends.poll()
             try:
                 with record_function(_get_profiler_function_name(action)):
                     if action.computation_type in self._comp_type_to_function_map:
@@ -2908,9 +3011,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 )
                 raise e
 
-        # Mostly these operations should have finished long ago, but there isn't an obvious time when to wait for them
-        while send_ops:
-            _wait_batch_p2p(send_ops.pop())
+        # Wait for sends left in flight.
+        pending_sends.drain()
 
         if len(self.unshard_ops) != 0:
             raise AssertionError("Unused unshard operations")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194122
* #194121
* __->__ #194120
* #194119

The runtime appends every send `Work` to a step-wide list and drains it only after all actions have run, so a rank holds `microbatches * stages_per_rank` activations it has already transmitted. With backward now able to start from a gradient edge, those buffers can go as soon as the transport is done with them.

`_PendingSendTracker` owns the batches. The runtime polls it at action boundaries, and a batch whose sends have all completed is waited on and handed back to its stage, which drops the transport references and the live output. Polling never blocks: a batch still in flight simply stays owned, and the end-of-step drain remains the backstop.

Waiting before retiring matters for more than tidiness. `is_completed()` is also true for work that failed, so waiting is what surfaces an asynchronous send error instead of discarding it with the batch, and ProcessGroupNCCL only unstashes its own references to the send buffers inside `wait()`. The wait cannot block there, the work having already completed.

Every pending batch is checked rather than only the oldest. Sends to different peers land independently, and holding a completed buffer behind a slow one would give back the memory this exists to release.

`Schedule1F1B` retires at its own send points instead of through the tracker, since it already waits for the previous send in the steady state.

Polling is skipped while a CUDA graph is being captured, because `Work.is_completed()` is an event query that ProcessGroupNCCL disallows there. A captured step therefore keeps the legacy end-of-step ownership; a later change gives it a release point it can use.

Measured on DeepSeek-V3 16B (PP=4, 7 virtual stages, EP=2, FSDP=2, 16 microbatches, seq 4096, no AC), peak reserved memory falls 2.62 GiB per rank, 81.53 -> 78.91, and the saving grows with microbatch count: 4.44 GiB at 32 microbatches.

Tests: tracker ownership across poll and drain, a failed send surfacing from poll, an empty batch, the disabled path deferring everything to the drain, and an end-to-end multiprocess test over five schedules checking peak memory, released counts, and gradient equality.