### PR TITLE
[pipelining][3/4] Name the release points in the schedule for graph capture

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -4,7 +4,8 @@ import copy
 import csv
 import logging
 import os
-from unittest.mock import MagicMock, patch
+import tempfile
+from unittest.mock import create_autospec, MagicMock, patch
 
 from model_registry import MultiMLP
 
@@ -28,6 +29,7 @@ from torch.distributed.pipelining.schedules import (
     _add_reduce_grad,
     _add_send_recv,
     _add_unshard_reshard,
+    _add_wait_send,
     _batch_p2p,
     _defer_recv_ops,
     _format_pipeline_order,
@@ -41,14 +43,19 @@ from torch.distributed.pipelining.schedules import (
     F,
     get_schedule_class,
     I,
+    OVERLAP_F_B,
     PipelineScheduleMulti,
     PipelineScheduleSingle,
     RECV_B,
     RECV_F,
+    REDUCE_GRAD,
     RESHARD,
     SEND_B,
+    SEND_F,
     UNSHARD,
     W,
+    WAIT_SEND_B,
+    WAIT_SEND_F,
 )
 from torch.distributed.pipelining.stage import (
     _early_send_release_default,
@@ -1465,6 +1472,205 @@ class TestScheduleLowering(TestCase):
                 )
             self.assertEqual(len(result_sch[rank]), len(expected_sch[rank]))
 
+    def _wait_send_schedule(self, num_stages, num_microbatches):
+        """Build a lowered 1F1B-shaped schedule."""
+        compute = {
+            rank: [_Action(rank, F, mb) for mb in range(num_microbatches)]
+            + [_Action(rank, B, mb) for mb in range(num_microbatches)]
+            for rank in range(num_stages)
+        }
+        with_comms = _add_send_recv(
+            compute, stage_to_rank=lambda s: s, num_stages=num_stages
+        )
+        return _add_wait_send(with_comms)
+
+    def test_add_wait_send_pairs_every_forward_send(self):
+        num_stages, num_microbatches = 4, 4
+        lowered = self._wait_send_schedule(num_stages, num_microbatches)
+
+        for rank, actions in lowered.items():
+            sends = [a for a in actions if a.computation_type == SEND_F]
+            waits = [a for a in actions if a.computation_type == WAIT_SEND_F]
+            self.assertEqual(
+                [(a.stage_index, a.microbatch_index) for a in sends],
+                [(a.stage_index, a.microbatch_index) for a in waits],
+                f"rank {rank} sends and waits disagree",
+            )
+        # The last stage has no sends or waits.
+        self.assertEqual(
+            [a for a in lowered[num_stages - 1] if a.computation_type == WAIT_SEND_F],
+            [],
+        )
+
+    def test_add_wait_send_places_wait_after_backward(self):
+        lowered = self._wait_send_schedule(4, 4)
+        actions = lowered[0]
+        for mb in range(4):
+            backward = actions.index(_Action(0, B, mb))
+            wait = actions.index(_Action(0, WAIT_SEND_F, mb))
+            send = actions.index(_Action(0, SEND_F, mb))
+            # Backward implies that the peer received the activation.
+            self.assertLess(send, backward)
+            self.assertEqual(wait, backward + 1)
+
+    def test_add_wait_send_does_not_deadlock(self):
+        for num_stages, num_microbatches in ((2, 2), (4, 4), (4, 8)):
+            lowered = self._wait_send_schedule(num_stages, num_microbatches)
+            _simulate_comms_compute(
+                lowered, stage_to_rank=lambda s: s, num_stages=num_stages
+            )
+
+    def test_simulator_rejects_wait_before_the_peer_receive(self):
+        """Reject a wait whose peer never receives."""
+        # A send cannot complete before its peer receives it.
+        order = {
+            0: [
+                _Action(0, F, 0),
+                _Action(0, SEND_F, 0),
+                _Action(0, WAIT_SEND_F, 0),
+            ],
+            1: [],
+        }
+
+        with self.assertRaisesRegex(ValueError, "not progressing"):
+            _simulate_comms_compute(order, stage_to_rank=lambda s: s, num_stages=2)
+
+    def test_waits_survive_a_compute_comms_csv_round_trip(self):
+        """Preserve WAIT_SEND actions across CSV round trips."""
+
+        def stage(index, enabled):
+            mock_stage = create_autospec(PipelineStage, instance=True)
+            mock_stage.stage_index, mock_stage.num_stages = index, 4
+            mock_stage.group_rank, mock_stage.group_size = 0, 2
+            mock_stage.submod, mock_stage.early_send_release = None, enabled
+            return mock_stage
+
+        lowered = ScheduleInterleaved1F1B(
+            [stage(i, True) for i in (0, 2)], n_microbatches=4, loss_fn=None
+        )
+        self.assertTrue(lowered._early_send_release)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "schedule.csv")
+            lowered._dump_csv(path, "compute_comms")
+
+            # Disabled stages require the file to restore early release.
+            reloaded = ScheduleInterleaved1F1B(
+                [stage(i, False) for i in (0, 2)], n_microbatches=4, loss_fn=None
+            )
+            reloaded._load_csv(path, "compute_comms")
+
+        self.assertTrue(
+            reloaded._early_send_release,
+            "a reloaded schedule ignored the waits it was dumped with",
+        )
+        self.assertEqual(
+            sum(
+                1
+                for rank_actions in reloaded.pipeline_order_with_comms.values()
+                for a in rank_actions
+                if a.computation_type == WAIT_SEND_F
+            ),
+            sum(
+                1
+                for rank_actions in lowered.pipeline_order_with_comms.values()
+                for a in rank_actions
+                if a.computation_type == WAIT_SEND_F
+            ),
+        )
+
+    def test_enabling_after_construction_does_not_take_effect(self):
+        """Read early-release state only during lowering."""
+
+        def stage(index):
+            mock_stage = create_autospec(PipelineStage, instance=True)
+            mock_stage.stage_index, mock_stage.num_stages = index, 4
+            mock_stage.group_rank, mock_stage.group_size = 0, 2
+            mock_stage.submod, mock_stage.early_send_release = None, False
+            return mock_stage
+
+        stages = [stage(i) for i in (0, 2)]
+        schedule = ScheduleInterleaved1F1B(stages, n_microbatches=4, loss_fn=None)
+        self.assertFalse(schedule._early_send_release)
+
+        for mock_stage in stages:
+            mock_stage.early_send_release = True
+        self.assertFalse(
+            schedule._early_send_release,
+            "the setting is read once, when the schedule is lowered",
+        )
+        self.assertEqual(
+            [
+                a
+                for rank in schedule.pipeline_order_with_comms
+                for a in schedule.pipeline_order_with_comms[rank]
+                if a.computation_type == WAIT_SEND_F
+            ],
+            [],
+        )
+
+    def test_lowered_dualpipev_simulates_without_deadlock(self):
+        """Simulate DualPipeV backwards stored in sub-actions."""
+
+        def stage(index):
+            mock_stage = create_autospec(PipelineStage, instance=True)
+            mock_stage.stage_index, mock_stage.num_stages = index, 4
+            mock_stage.group_rank, mock_stage.group_size = 0, 2
+            mock_stage.submod, mock_stage.early_send_release = None, True
+            return mock_stage
+
+        order = ScheduleDualPipeV(
+            [stage(i) for i in (0, 3)], n_microbatches=8, loss_fn=None
+        ).pipeline_order_with_comms
+
+        sends = sum(1 for r in order for a in order[r] if a.computation_type == SEND_F)
+        waits = sum(
+            1 for r in order for a in order[r] if a.computation_type == WAIT_SEND_F
+        )
+        self.assertEqual(waits, sends)
+
+        # FSDP actions are unrelated to send ownership.
+        skipped = (UNSHARD, RESHARD, REDUCE_GRAD)
+        _simulate_comms_compute(
+            {
+                rank: [a for a in acts if a.computation_type not in skipped]
+                for rank, acts in order.items()
+            },
+            stage_to_rank=lambda s: 0 if s in (0, 3) else 1,
+            num_stages=4,
+        )
+
+    def test_add_wait_send_pairs_sends_completed_by_a_compound_backward(self):
+        """Pair sends with backwards inside OVERLAP_F_B."""
+        compute = {
+            0: [
+                _Action(0, F, 0),
+                _Action(
+                    -1,
+                    OVERLAP_F_B,
+                    None,
+                    (_Action(0, F, 1), _Action(0, B, 0)),
+                ),
+            ],
+            1: [_Action(1, F, 0), _Action(1, B, 0)],
+        }
+        with_comms = _add_send_recv(compute, stage_to_rank=lambda s: s, num_stages=2)
+        lowered = _add_wait_send(with_comms)
+
+        # Only microbatch 0 has a backward.
+        waits = [a for a in lowered[0] if a.computation_type == WAIT_SEND_F]
+        self.assertEqual(waits, [_Action(0, WAIT_SEND_F, 0)])
+
+        overlap = next(
+            i for i, a in enumerate(lowered[0]) if a.computation_type == OVERLAP_F_B
+        )
+        self.assertEqual(lowered[0].index(waits[0]), overlap + 1)
+
+    def test_wait_send_action_round_trips_through_str(self):
+        # Do not parse WAIT_SEND_F as the "W" prefix.
+        for action in (_Action(0, WAIT_SEND_F, 7), _Action(3, WAIT_SEND_B, 0)):
+            self.assertEqual(_Action.from_str(str(action)), action)
+
     def test_defer_recv_ops_no_deadlock(self):
         """Tests the issue from pytorch/pytorch#172668: RECV_F for stage 2 should not
         be placed before unrelated compute op 0F1 on the same rank, and the deferred
@@ -2228,6 +2434,82 @@ class TestPendingSendTracker(TestCase):
         with self.assertRaisesRegex(RuntimeError, "NCCL send failed"):
             tracker.poll()
         self.assertEqual(retired, [])
+
+    def test_disabled_tracker_ignores_a_lowered_wait(self):
+        # Ignore waits left by an earlier lowering pass.
+        tracker = _PendingSendTracker(enabled=False)
+        retired = []
+        works, ops = self._make_batch()
+        key = (SEND_F, 0, 0)
+        tracker.register(ops, works, lambda: retired.append("batch"), key)
+
+        tracker.wait_send(key)
+        self.assertEqual(retired, [])
+        self.assertEqual(len(ops), 1, "the batch stays owned until the drain")
+
+        tracker.drain()
+        self.assertEqual(retired, ["batch"])
+
+    def test_static_mode_retires_only_at_the_lowered_wait(self):
+        # Polling off reproduces capture's release strategy without capturing,
+        # so the two can be compared on the same run.
+        tracker = _PendingSendTracker(poll=False)
+        retired = []
+        works, ops = self._make_batch()
+        key = (SEND_F, 1, 2)
+        tracker.register(ops, works, lambda: retired.append("batch"), key)
+
+        works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, [], "polling should be off")
+
+        tracker.wait_send(key)
+        self.assertEqual(retired, ["batch"])
+
+    def test_wait_send_waits_the_stream_instead_of_polling(self):
+        # WAIT_SEND releases buffers without polling during capture.
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch()
+        work = works[0]
+        key = (SEND_F, 3, 7)
+        tracker.register(ops, works, lambda: retired.append("batch"), key)
+
+        with patch(
+            "torch.distributed.pipelining.schedules._stream_is_capturing",
+            return_value=True,
+        ):
+            tracker.poll()
+            self.assertEqual(retired, [], "poll must not retire during capture")
+            tracker.wait_send(key)
+
+        self.assertEqual(retired, ["batch"])
+        self.assertEqual(work.wait_count, 1)
+        self.assertEqual(ops, [])
+
+    def test_wait_send_is_a_noop_for_an_already_polled_batch(self):
+        # Eager polling may retire the batch before WAIT_SEND.
+        tracker = _PendingSendTracker()
+        retired = []
+        works, ops = self._make_batch()
+        key = (SEND_F, 0, 0)
+        tracker.register(ops, works, lambda: retired.append("batch"), key)
+
+        works[0].completed = True
+        tracker.poll()
+        self.assertEqual(retired, ["batch"])
+
+        tracker.wait_send(key)
+        self.assertEqual(retired, ["batch"], "retire must not run twice")
+
+    def test_wait_send_ignores_an_unknown_key(self):
+        tracker = _PendingSendTracker()
+        works, ops = self._make_batch()
+        tracker.register(ops, works, None, (SEND_F, 0, 0))
+
+        tracker.wait_send((SEND_B, 0, 0))
+        self.assertEqual(works[0].wait_count, 0)
+        self.assertEqual(len(ops), 1, "the unmatched batch stays owned")
 
     def test_empty_batch_retires_immediately(self):
         # Stages with nothing to send may still register a batch.

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -1,11 +1,13 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates
 # Owner(s): ["oncall: distributed"]
+import contextlib
 import copy
 import gc
 import logging
 import os
 from collections import Counter
 from dataclasses import dataclass
+from unittest.mock import patch
 
 from model_registry import (
     ConditionalGradStack,
@@ -35,11 +37,13 @@ from torch.distributed.pipelining import (
     ScheduleInterleaved1F1B,
     ScheduleInterleavedZeroBubble,
     ScheduleLoopedBFS,
+    schedules as pipelining_schedules,
     ScheduleZBVZeroBubble,
 )
 from torch.distributed.pipelining.microbatch import split_args_kwargs_into_chunks
 from torch.distributed.pipelining.schedules import (
     _Action,
+    _PendingSendTracker,
     _PipelineContext,
     _PipelineScheduleRuntime,
     _wait_batch_p2p,
@@ -1442,7 +1446,9 @@ class ScheduleTest(MultiProcContinuousTest):
             stage.retire_fwd_sends = make_counting_retire(stage, stage.retire_fwd_sends)
         return counter
 
-    def _run_release_sent_activations(self, ScheduleClass, release: bool):
+    def _run_release_sent_activations(
+        self, ScheduleClass, release: bool, forbid_polling: bool = False
+    ):
         """Measure peak memory, gradients, and releases for one schedule."""
         single_stage = issubclass(ScheduleClass, PipelineScheduleSingle)
         v_shaped = issubclass(ScheduleClass, (ScheduleZBVZeroBubble, ScheduleDualPipeV))
@@ -1471,26 +1477,37 @@ class ScheduleTest(MultiProcContinuousTest):
             scale_grads=False,
         )
 
+        # Reused workers skip unittest cleanups, so this must unwind normally.
+        capturing = (
+            patch(
+                "torch.distributed.pipelining.schedules._stream_is_capturing",
+                return_value=True,
+            )
+            if forbid_polling
+            else contextlib.nullcontext()
+        )
+
         peak = 0
         # Measure the second step after buffers and metadata are initialized.
-        for step in range(2):
-            zero_gradients(stage_modules)
-            if step == 1:
-                torch.accelerator.synchronize(self.device)
-                torch.accelerator.reset_peak_memory_stats(self.device)
-                baseline = torch.accelerator.memory_allocated(self.device)
+        with capturing:
+            for step in range(2):
+                zero_gradients(stage_modules)
+                if step == 1:
+                    torch.accelerator.synchronize(self.device)
+                    torch.accelerator.reset_peak_memory_stats(self.device)
+                    baseline = torch.accelerator.memory_allocated(self.device)
 
-            if v_shaped:
-                if self.rank == 0:
-                    schedule.step(x, target=target, losses=[])
+                if v_shaped:
+                    if self.rank == 0:
+                        schedule.step(x, target=target, losses=[])
+                    else:
+                        schedule.step()
+                elif self.rank == 0:
+                    schedule.step(x)
+                elif self.rank == self.world_size - 1:
+                    schedule.step(target=target, losses=[])
                 else:
                     schedule.step()
-            elif self.rank == 0:
-                schedule.step(x)
-            elif self.rank == self.world_size - 1:
-                schedule.step(target=target, losses=[])
-            else:
-                schedule.step()
 
         torch.accelerator.synchronize(self.device)
         peak = torch.accelerator.max_memory_allocated(self.device) - baseline
@@ -1562,6 +1579,38 @@ class ScheduleTest(MultiProcContinuousTest):
         else:
             self.assertGreater(released_count, 0)
             self.assertGreaterEqual(saved, activation_bytes)
+
+    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+    )
+    @skip_if_lt_x_gpu(4)
+    def test_release_sent_activations_without_polling(self):
+        """Verify WAIT_SEND releases buffers without polling."""
+        # Count retired transport references; backward already popped fwd_cache.
+        retired = Counter()
+        wait_send = _PendingSendTracker.wait_send
+        stream_is_capturing = pipelining_schedules._stream_is_capturing
+
+        def counting_wait_send(tracker, key):
+            before = len(tracker._pending)
+            wait_send(tracker, key)
+            retired["batches"] += before - len(tracker._pending)
+
+        with patch.object(_PendingSendTracker, "wait_send", counting_wait_send):
+            self._run_release_sent_activations(
+                ScheduleInterleaved1F1B, release=True, forbid_polling=True
+            )
+
+        self.assertGreater(
+            retired["batches"], 0, "no send was retired by a lowered WAIT_SEND"
+        )
+        # Ensure the reused worker did not retain the capture mock.
+        self.assertIs(
+            pipelining_schedules._stream_is_capturing,
+            stream_is_capturing,
+            "the capture mock outlived the run that installed it",
+        )
 
 
 instantiate_parametrized_tests(ScheduleTest)

--- a/torch/distributed/pipelining/_schedule_visualizer.py
+++ b/torch/distributed/pipelining/_schedule_visualizer.py
@@ -22,7 +22,10 @@ from torch.distributed.pipelining.schedules import (
     PipelineScheduleMulti,
     PipelineScheduleSingle,
 )
-from torch.distributed.pipelining.stage import PipelineStage
+from torch.distributed.pipelining.stage import (
+    _early_send_release_default,
+    PipelineStage,
+)
 
 
 class OpKey(NamedTuple):
@@ -67,6 +70,8 @@ def get_schedule_ops(
     mock_pipeline_stage.group_rank = 0
     mock_pipeline_stage.group_size = pp_degree
     mock_pipeline_stage.submod = None
+    # autospec cannot see this instance attribute.
+    mock_pipeline_stage.early_send_release = _early_send_release_default()
 
     # Check num_stages_per_rank is valid
     if issubclass(schedule_class, PipelineScheduleSingle):

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -32,7 +32,12 @@ from .microbatch import (
     split_args_kwargs_into_chunks,
     TensorChunkSpec,
 )
-from .stage import _PipelineStageBase, _RecvInfo, PipelineStage
+from .stage import (
+    _PipelineStageBase,
+    _RecvInfo,
+    _send_release_poll_default,
+    PipelineStage,
+)
 
 
 __all__ = [
@@ -62,6 +67,9 @@ class _ComputationType(str, Enum):
     RECV_F = "RECV_F"
     SEND_B = "SEND_B"
     RECV_B = "RECV_B"
+    # Wait for a send without querying completion during graph capture.
+    WAIT_SEND_F = "WAIT_SEND_F"
+    WAIT_SEND_B = "WAIT_SEND_B"
     FULL_BACKWARD = "B"
     OVERLAP_F_B = "OVERLAP_F_B"
     REDUCE_GRAD = "REDUCE_GRAD"
@@ -83,6 +91,8 @@ SEND_F = _ComputationType.SEND_F
 RECV_F = _ComputationType.RECV_F
 SEND_B = _ComputationType.SEND_B
 RECV_B = _ComputationType.RECV_B
+WAIT_SEND_F = _ComputationType.WAIT_SEND_F
+WAIT_SEND_B = _ComputationType.WAIT_SEND_B
 FULL_BACKWARD = _ComputationType.FULL_BACKWARD
 OVERLAP_F_B = _ComputationType.OVERLAP_F_B
 REDUCE_GRAD = _ComputationType.REDUCE_GRAD
@@ -101,8 +111,10 @@ W = BACKWARD_WEIGHT
 B = FULL_BACKWARD
 
 # Helper to parse an action string like 1F0 into a tuple of (stage_index, computation_type, microbatch_index)
+# Match long names before prefixes such as W.
 _action_regex = re.compile(
-    r"(\d+)(F|I|B|W|UNSHARD|RESHARD|REDUCE_GRAD|SEND_F|RECV_F|SEND_B|RECV_B)(\d*)"
+    r"(\d+)(WAIT_SEND_F|WAIT_SEND_B|SEND_F|SEND_B|RECV_F|RECV_B|UNSHARD|RESHARD"
+    r"|REDUCE_GRAD|F|I|B|W)(\d*)"
 )
 
 
@@ -854,6 +866,10 @@ def _flatten_sorted_works(work_by_peer: dict[int, list[dist.Work]]) -> list[dist
     return [work for peer_works in work_by_peer.values() for work in peer_works]
 
 
+# Identifies a send batch by direction, stage, and microbatch.
+_SendKey = tuple[_ComputationType, int, int]
+
+
 @dataclass
 class _PendingSendBatch:
     """An in-flight send batch and its release callback."""
@@ -862,6 +878,7 @@ class _PendingSendBatch:
     # Keep transport buffers alive explicitly.
     ops: list[dist.P2POp]
     retire: Callable[[], None] | None
+    key: _SendKey | None = None
 
 
 def _stream_is_capturing() -> bool:
@@ -872,8 +889,11 @@ def _stream_is_capturing() -> bool:
 class _PendingSendTracker:
     """Own send buffers until completion or the end-of-step drain."""
 
-    def __init__(self, enabled: bool = True) -> None:
+    def __init__(self, enabled: bool = True, poll: bool | None = None) -> None:
         self._enabled = enabled
+        # Polling retires as soon as a send lands. Without it only the lowered
+        # WAIT_SEND actions retire, which is how a captured step behaves.
+        self._poll = _send_release_poll_default() if poll is None else poll
         self._pending: list[_PendingSendBatch] = []
 
     def register(
@@ -881,15 +901,37 @@ class _PendingSendTracker:
         ops: list[dist.P2POp],
         works: list[dist.Work],
         retire: Callable[[], None] | None = None,
+        key: _SendKey | None = None,
     ) -> None:
-        self._pending.append(_PendingSendBatch(works, ops, retire))
+        self._pending.append(_PendingSendBatch(works, ops, retire, key))
+
+    def wait_send(self, key: _SendKey) -> None:
+        """Wait for and retire a keyed send without querying completion.
+
+        Missing keys are allowed because eager polling may retire them first.
+        Disabled trackers preserve end-of-step ownership.
+        """
+        if not self._enabled:
+            return
+
+        for i, batch in enumerate(self._pending):
+            if batch.key == key:
+                _wait_batch_p2p(batch.works)
+                self._retire(batch)
+                del self._pending[i]
+                return
 
     def poll(self) -> None:
         """Retire completed batches without blocking.
 
         Poll all batches independently, except during graph capture.
         """
-        if not self._enabled or not self._pending or _stream_is_capturing():
+        if (
+            not self._enabled
+            or not self._poll
+            or not self._pending
+            or _stream_is_capturing()
+        ):
             return
 
         still_pending = []
@@ -1701,6 +1743,42 @@ def _merge_bw(
         else:
             merged_actions.append(action)
     return merged_actions
+
+
+def _add_wait_send(
+    comm_actions: dict[int, list[_Action]],
+) -> dict[int, list[_Action]]:
+    """Insert WAIT_SEND_F after each matching backward.
+
+    The returned gradient proves the peer received the activation, so this wait
+    cannot deadlock. Backward sends remain in the end-of-step drain.
+    """
+    backward_types = (FULL_BACKWARD, BACKWARD_INPUT)
+
+    def backward_slots(action: _Action) -> list[tuple[int, int | None]]:
+        """Return backward slots, including compound sub-actions."""
+        return [
+            (part.stage_index, part.microbatch_index)
+            for part in (action.sub_actions or (action,))
+            if part.computation_type in backward_types
+        ]
+
+    out: dict[int, list[_Action]] = {}
+    for rank, actions in comm_actions.items():
+        sent = {
+            (a.stage_index, a.microbatch_index)
+            for a in actions
+            if a.computation_type == SEND_F
+        }
+        lowered: list[_Action] = []
+        for action in actions:
+            lowered.append(action)
+            for stage_index, microbatch_index in backward_slots(action):
+                if (stage_index, microbatch_index) in sent:
+                    lowered.append(_Action(stage_index, WAIT_SEND_F, microbatch_index))
+                    sent.discard((stage_index, microbatch_index))
+        out[rank] = lowered
+    return out
 
 
 def _add_send_recv(
@@ -2575,6 +2653,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
 
     def __init__(self, *args, **kwargs):
         self._defer_pp_recv: bool = kwargs.pop("defer_pp_recv", False)
+        # Set when the schedule is prepared or loaded.
+        self._early_send_release: bool = False
         super().__init__(*args, **kwargs)
         # Action to custom function mapping
         self._comp_type_to_function_map: dict[_ComputationType, Callable] = {}
@@ -2680,6 +2760,11 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 num_stages=self._num_stages,
             )
 
+            if any(stage.early_send_release for stage in self._stages):
+                self.pipeline_order_with_comms = _add_wait_send(
+                    self.pipeline_order_with_comms
+                )
+
             if self._defer_pp_recv:
                 self.pipeline_order_with_comms = _defer_recv_ops(
                     self.pipeline_order_with_comms,
@@ -2687,6 +2772,15 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 )
         else:
             raise NotImplementedError(f"{format=} is not implemented")
+
+        # Loaded schedules infer early release from their WAIT_SEND actions.
+        self._early_send_release = any(
+            stage.early_send_release for stage in self._stages
+        ) or any(
+            action.computation_type in (WAIT_SEND_F, WAIT_SEND_B)
+            for rank_actions in self.pipeline_order_with_comms.values()
+            for action in rank_actions
+        )
 
     def _load_csv(
         self,
@@ -2789,9 +2883,7 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
             )
 
         # Release completed send buffers between actions.
-        pending_sends = _PendingSendTracker(
-            any(stage.early_send_release for stage in self._stages)
-        )
+        pending_sends = _PendingSendTracker(self._early_send_release)
 
         def _perform_action(action: _Action) -> None:
             comp_type = action.computation_type
@@ -2826,10 +2918,17 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                     ops,
                     _batch_p2p(ops),
                     partial(stage.retire_fwd_sends, mb_index),
+                    (SEND_F, stage_idx, mb_index),
                 )
             elif comp_type == SEND_B:
                 ops = stage.get_bwd_send_ops(mb_index)
-                pending_sends.register(ops, _batch_p2p(ops))
+                pending_sends.register(
+                    ops, _batch_p2p(ops), None, (SEND_B, stage_idx, mb_index)
+                )
+            elif comp_type == WAIT_SEND_F:
+                pending_sends.wait_send((SEND_F, stage_idx, mb_index))
+            elif comp_type == WAIT_SEND_B:
+                pending_sends.wait_send((SEND_B, stage_idx, mb_index))
             elif comp_type == RECV_F:
                 if (stage_idx, mb_index) in self.fwd_recv_ops:
                     raise AssertionError(
@@ -4030,10 +4129,16 @@ def _simulate_comms_compute(
         _schedule[rank].append(action)
         if action is not None:
             _prev_ops_rank[rank].add(action)
+            # Record compound sub-actions for dependency checks.
+            for sub_action in action.sub_actions or ():
+                _prev_ops_rank[rank].add(sub_action)
 
     def _ready_to_schedule(action: _Action | None) -> bool:
         if action is None:
             return True
+
+        if action.sub_actions is not None:
+            return all(_ready_to_schedule(sub) for sub in action.sub_actions)
 
         stage_idx = action.stage_index
         prev_ops = _prev_ops_rank[stage_to_rank(stage_idx)]
@@ -4086,6 +4191,17 @@ def _simulate_comms_compute(
             peer_stage_idx = stage_idx + 1
             expected_send = _Action(peer_stage_idx, SEND_B, action.microbatch_index)
             return expected_send in _prev_ops_rank[stage_to_rank(peer_stage_idx)]
+        elif action.computation_type in (WAIT_SEND_F, WAIT_SEND_B):
+            # A wait requires both the send and its peer receive.
+            forward = action.computation_type == WAIT_SEND_F
+            send = SEND_F if forward else SEND_B
+            if _Action(stage_idx, send, action.microbatch_index) not in prev_ops:
+                return False
+            peer_stage_idx = stage_idx + 1 if forward else stage_idx - 1
+            expected_recv = _Action(
+                peer_stage_idx, RECV_F if forward else RECV_B, action.microbatch_index
+            )
+            return expected_recv in _prev_ops_rank[stage_to_rank(peer_stage_idx)]
         else:
             raise ValueError(f"Unsupported action type {action}")
 

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -106,6 +106,17 @@ def _early_send_release_default() -> bool:
     return os.environ.get("TORCH_PIPELINING_EARLY_SEND_RELEASE", "1") != "0"
 
 
+def _send_release_poll_default() -> bool:
+    """Return whether completed sends are retired by polling.
+
+    Set ``TORCH_PIPELINING_SEND_RELEASE_POLL=0`` to retire only at the points
+    the schedule names, which is what a captured step does because it cannot
+    query completion. Running that way eagerly makes the two release strategies
+    comparable without capturing anything.
+    """
+    return os.environ.get("TORCH_PIPELINING_SEND_RELEASE_POLL", "1") != "0"
+
+
 @dataclass
 class _ForwardCacheEntry:
     """Forward state retained per microbatch.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194122
* __->__ #194121
* #194120
* #194119

Polling cannot run while a CUDA graph is being captured, because `Work.is_completed()` is an event query ProcessGroupNCCL disallows there, so a captured step keeps every sent activation for its whole duration. `Work.wait()` records a stream dependency instead of querying, which is legal during capture and becomes part of the graph. `WAIT_SEND_F`/`WAIT_SEND_B` actions do exactly that, and `_add_wait_send` places them when the schedule is lowered.

Placement is what makes a stream-ordered wait safe. A badly placed one deadlocks at replay, with the rank stalled on a send whose receive the peer has not accepted while the peer waits on something the stalled rank has yet to issue. A wait is therefore only emitted where completion is already implied and no new cross-rank dependency appears: immediately after the local backward for the same microbatch. That backward consumes the gradient the next stage produced, which that stage could only compute after receiving this very activation. Compound actions such as `OVERLAP_F_B` carry their backward in sub-actions, so those are matched too. Backward sends have no answering traffic to prove completion and keep using the drain.

The cost of proving it is release latency. A wait fires after the backward rather than when the send lands, so it recovers roughly half of what polling recovers: measured on DeepSeek-V3 16B (PP=4, 7 virtual stages, EP=2, FSDP=2, 16 microbatches, no AC), 1.49 GiB against polling's 2.62 at seq 4096, and 0.72 against 1.50 at seq 2048.

`TORCH_PIPELINING_SEND_RELEASE_POLL=0` runs this strategy eagerly, which is how those two were compared on identical hardware without capturing anything.

The decision is settled once, after the schedule order is final, and reused when it executes, so the lowered actions and the tracker cannot disagree. It accounts for the actions as well as the stage flag, so a schedule reloaded from a CSV dump honours the waits it was dumped with instead of quietly falling back to end-of-step retirement. A disabled tracker ignores a lowered wait.

`_simulate_comms_compute` models the new actions, requiring both the local send and the peer's matching receive, so the existing deadlock check covers them. It also understands compound actions now, which it previously rejected outright, so lowered DualPipeV schedules can be validated.

Two smaller notes: the action regex matches the longer names first, since `W` would otherwise shadow `WAIT_SEND_F` and silently parse it as BACKWARD_WEIGHT; and the schedule visualizer pins `early_send_release` on its autospec stage, which cannot see an attribute the stage sets in `__init__`.

Tests: send/wait pairing, placement after the backward, compound backwards, deadlock-free simulation including DualPipeV, a wait placed before its peer receive failing that check, string round-tripping, waits surviving a compute_comms CSV round trip, enabling the flag after construction having no effect, and a multiprocess run with polling forbidden that proves a lowered wait carries the release on its own.

Where this sits in the space of release strategies. Numbers are for DeepSeek-V3 16B (PP=4, 7 virtual stages, EP=2, FSDP=2, 16 microbatches, seq 4096, no activation checkpointing), where one boundary tensor is 16 MiB and the baseline holds `M * V` forward sends plus `M * V` backward sends:

| strategy | rule | outstanding | budget | capture-able |
|---|---|---|---|---|
| end of step | drain after every action has run | 112 fwd + 112 bwd | ~3.5 GiB, uncapped | yes |
| proof point (this change) | wait where completion is already implied | ~28 fwd + 112 bwd | falls out of the schedule | yes |
| count budget (K-distance) | at most K sends outstanding | K | `K * S`, exact when `S` is uniform | yes |
| byte budget | at most Q bytes outstanding | varies with buffer size | `Q`, directly | yes |
| polling | wait once the transport reports completion | a few | emergent, ~0.1 GiB | no |
| immediate | wait right after each send | 0 | ~0 GiB | yes |

Polling is the only one whose bound is a runtime event rather than a position in the schedule, which is exactly why it cannot be captured. The count and byte budgets coincide whenever every boundary carries the same hidden state, as it does for splits between transformer blocks; they diverge only for uneven boundaries, such as an encoder-decoder split or a stage boundary that changes width.

Note that this change releases forward sends only. A backward send has no answering traffic to prove it landed, so it keeps the end-of-step drain, and that accounts for most of the remaining gap to polling rather than release latency doing so.