### PR TITLE
[pipelining][4/4] Bound the memory outstanding sends hold with a count budget

### DIFF
--- a/test/distributed/pipelining/test_schedule.py
+++ b/test/distributed/pipelining/test_schedule.py
@@ -30,6 +30,7 @@ from torch.distributed.pipelining.schedules import (
     _add_send_recv,
     _add_unshard_reshard,
     _add_wait_send,
+    _add_wait_send_budget,
     _batch_p2p,
     _defer_recv_ops,
     _format_pipeline_order,
@@ -61,6 +62,7 @@ from torch.distributed.pipelining.stage import (
     _early_send_release_default,
     _PipelineStageBase,
     _RecvInfo,
+    _send_release_budget_default,
     PipelineStage,
 )
 from torch.testing._internal.common_distributed import requires_accelerator_dist_backend
@@ -1519,6 +1521,150 @@ class TestScheduleLowering(TestCase):
             _simulate_comms_compute(
                 lowered, stage_to_rank=lambda s: s, num_stages=num_stages
             )
+
+    def _outstanding_sends(self, actions):
+        """Peak sends a rank holds, and how many are left for the drain."""
+        held: set[tuple] = set()
+        peak = 0
+        for action in actions:
+            comp_type = action.computation_type
+            if comp_type in (SEND_F, SEND_B):
+                held.add((comp_type, action.stage_index, action.microbatch_index))
+                peak = max(peak, len(held))
+            elif comp_type in (WAIT_SEND_F, WAIT_SEND_B):
+                send = SEND_F if comp_type == WAIT_SEND_F else SEND_B
+                held.discard((send, action.stage_index, action.microbatch_index))
+        return peak, len(held)
+
+    def test_budget_caps_the_sends_a_rank_holds(self):
+        num_stages, num_microbatches, budget = 4, 8, 4
+        lowered = self._wait_send_schedule(num_stages, num_microbatches)
+        capped = _add_wait_send_budget(lowered, lambda s: s, budget)
+
+        drained, uncapped_drained = 0, 0
+        for rank in capped:
+            uncapped_peak, uncapped_drain = self._outstanding_sends(lowered[rank])
+            peak, drain = self._outstanding_sends(capped[rank])
+            self.assertGreater(uncapped_peak, budget, f"rank {rank} was never over")
+            self.assertLessEqual(peak, budget, f"rank {rank} stays over budget")
+            self.assertLessEqual(drain, uncapped_drain, f"rank {rank} drains later")
+            drained += drain
+            uncapped_drained += uncapped_drain
+        # Backward sends are what the local backward leaves for the drain.
+        self.assertLess(drained, uncapped_drained)
+
+    def test_budget_releases_backward_sends(self):
+        """Cover the direction the local backward cannot prove."""
+        lowered = self._wait_send_schedule(4, 8)
+        self.assertEqual(
+            [
+                a
+                for actions in lowered.values()
+                for a in actions
+                if a.computation_type == WAIT_SEND_B
+            ],
+            [],
+        )
+
+        capped = _add_wait_send_budget(lowered, lambda s: s, 4)
+        self.assertNotEqual(
+            [
+                a
+                for actions in capped.values()
+                for a in actions
+                if a.computation_type == WAIT_SEND_B
+            ],
+            [],
+        )
+
+    def test_budget_waits_once_per_send(self):
+        capped = _add_wait_send_budget(self._wait_send_schedule(4, 8), lambda s: s, 4)
+        wait_types = (WAIT_SEND_F, WAIT_SEND_B)
+        for rank, actions in capped.items():
+            waits = [a for a in actions if a.computation_type in wait_types]
+            self.assertEqual(
+                len(waits), len(set(waits)), f"rank {rank} waits for a send twice"
+            )
+            waited = {
+                (
+                    SEND_F if a.computation_type == WAIT_SEND_F else SEND_B,
+                    a.stage_index,
+                    a.microbatch_index,
+                )
+                for a in waits
+            }
+            issued = {
+                (a.computation_type, a.stage_index, a.microbatch_index)
+                for a in actions
+                if a.computation_type in (SEND_F, SEND_B)
+            }
+            self.assertTrue(
+                waited <= issued, f"rank {rank} waits for a send it never issues"
+            )
+
+    def test_budget_keeps_the_rest_of_the_schedule_intact(self):
+        lowered = self._wait_send_schedule(4, 8)
+        capped = _add_wait_send_budget(lowered, lambda s: s, 4)
+        wait_types = (WAIT_SEND_F, WAIT_SEND_B)
+        for rank, actions in capped.items():
+            self.assertEqual(
+                [a for a in actions if a.computation_type not in wait_types],
+                [a for a in lowered[rank] if a.computation_type not in wait_types],
+            )
+
+    def test_budget_does_not_deadlock(self):
+        for num_stages, num_microbatches in ((2, 2), (4, 4), (4, 8)):
+            lowered = self._wait_send_schedule(num_stages, num_microbatches)
+            for budget in (0, 1, 2, 4):
+                capped = _add_wait_send_budget(lowered, lambda s: s, budget)
+                _simulate_comms_compute(
+                    capped, stage_to_rank=lambda s: s, num_stages=num_stages
+                )
+
+    def test_budget_reports_what_it_could_not_release(self):
+        """Warn rather than silently hold more than asked."""
+        lowered = self._wait_send_schedule(4, 8)
+        with self.assertLogs(
+            "torch.distributed.pipelining.schedules", level="WARNING"
+        ) as logs:
+            _add_wait_send_budget(lowered, lambda s: s, 0)
+        self.assertRegex("\n".join(logs.output), "budget of 0 not met")
+
+    def test_budget_setting_rejects_a_non_count(self):
+        with patch.dict(os.environ, {"TORCH_PIPELINING_SEND_RELEASE_BUDGET": "4"}):
+            self.assertEqual(_send_release_budget_default(), 4)
+        for bad in ("-1", "some"):
+            with patch.dict(os.environ, {"TORCH_PIPELINING_SEND_RELEASE_BUDGET": bad}):
+                with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                    _send_release_budget_default()
+
+    def test_budget_applies_to_a_lowered_interleaved_schedule(self):
+        def build(budget):
+            def stage(index):
+                mock_stage = create_autospec(PipelineStage, instance=True)
+                mock_stage.stage_index, mock_stage.num_stages = index, 8
+                mock_stage.group_rank, mock_stage.group_size = 0, 4
+                mock_stage.submod, mock_stage.early_send_release = None, True
+                return mock_stage
+
+            setting = "TORCH_PIPELINING_SEND_RELEASE_BUDGET"
+            with patch.dict(os.environ):
+                os.environ.pop(setting, None)
+                if budget is not None:
+                    os.environ[setting] = str(budget)
+                schedule = ScheduleInterleaved1F1B(
+                    [stage(i) for i in (0, 4)], n_microbatches=8, loss_fn=None
+                )
+            order = schedule.pipeline_order_with_comms
+            return [self._outstanding_sends(order[rank]) for rank in sorted(order)]
+
+        budget = 4
+        for (uncapped_peak, uncapped_drain), (peak, drain) in zip(
+            build(None), build(budget)
+        ):
+            self.assertGreater(uncapped_peak, budget)
+            self.assertLessEqual(peak, budget)
+            self.assertLess(drain, uncapped_drain)
 
     def test_simulator_rejects_wait_before_the_peer_receive(self):
         """Reject a wait whose peer never receives."""

--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -7,7 +7,7 @@ import itertools
 import logging
 import re
 from abc import ABC, abstractmethod
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
@@ -35,6 +35,7 @@ from .microbatch import (
 from .stage import (
     _PipelineStageBase,
     _RecvInfo,
+    _send_release_budget_default,
     _send_release_poll_default,
     PipelineStage,
 )
@@ -1781,6 +1782,190 @@ def _add_wait_send(
     return out
 
 
+def _add_wait_send_budget(
+    comm_actions: dict[int, list[_Action]],
+    stage_to_rank: Callable[[int], int],
+    budget: int,
+) -> dict[int, list[_Action]]:
+    """Cap the sends a rank keeps outstanding, holding their memory to a budget.
+
+    Waiting for a send is safe once the peer has posted the matching receive:
+    the transfer then needs nothing further from either side. This walks the
+    schedule in causal order, so the walk position itself proves which receives
+    the peer reaches first, and adds a release point whenever a rank holds more
+    than ``budget`` sends.
+
+    Two proofs, and they differ in cost rather than in safety. A rank has word
+    of a peer only through the messages it has received, so the walk also
+    carries that knowledge: every send stamps what its sender knew and every
+    receive hands the stamp to the rank consuming it. A send that knowledge
+    covers has already landed, so waiting for it is free; a send only the walk
+    order covers has not, so waiting for it stalls the rank until the peer posts
+    its receive. Free releases therefore come first, and the budget decides how
+    much of the second kind to buy.
+    """
+    ranks = sorted(comm_actions)
+    # Direction of a send, as the step to the peer stage and the receive it pairs with.
+    send_types = {SEND_F: (1, RECV_F), SEND_B: (-1, RECV_B)}
+
+    recv_at: dict[tuple[int, _ComputationType, int, int | None], int] = {}
+    for rank in ranks:
+        for index, action in enumerate(comm_actions[rank]):
+            if action.computation_type in (RECV_F, RECV_B):
+                key = (
+                    rank,
+                    action.computation_type,
+                    action.stage_index,
+                    action.microbatch_index,
+                )
+                recv_at[key] = index
+
+    # Pair every send with its receive, addressed both ways.
+    recv_of_send: dict[tuple[int, int], tuple[int, int]] = {}
+    send_of_recv: dict[tuple[int, int], tuple[int, int]] = {}
+    for rank in ranks:
+        for index, action in enumerate(comm_actions[rank]):
+            if action.computation_type not in send_types:
+                continue
+            step, recv_type = send_types[action.computation_type]
+            peer_stage = action.stage_index + step
+            peer_rank = stage_to_rank(peer_stage)
+            recv = (
+                peer_rank,
+                recv_at[(peer_rank, recv_type, peer_stage, action.microbatch_index)],
+            )
+            recv_of_send[(rank, index)] = recv
+            send_of_recv[recv] = (rank, index)
+
+    # Causal order: each rank's own sequence, plus every send before its receive.
+    successors: dict[tuple[int, int], list[tuple[int, int]]] = defaultdict(list)
+    in_degree: dict[tuple[int, int], int] = {
+        (rank, index): 0 for rank in ranks for index in range(len(comm_actions[rank]))
+    }
+    for rank in ranks:
+        for index in range(1, len(comm_actions[rank])):
+            successors[(rank, index - 1)].append((rank, index))
+            in_degree[(rank, index)] += 1
+    for send, recv in recv_of_send.items():
+        successors[send].append(recv)
+        in_degree[recv] += 1
+
+    def consumed_recvs(action: _Action, rank: int) -> list[int]:
+        """Positions of the receives an action has waited on before it runs."""
+        found = []
+        for part in action.sub_actions or (action,):
+            if part.computation_type == F:
+                recv_type = RECV_F
+            elif part.computation_type in (FULL_BACKWARD, BACKWARD_INPUT):
+                recv_type = RECV_B
+            else:
+                continue
+            key = (rank, recv_type, part.stage_index, part.microbatch_index)
+            if key in recv_at:
+                found.append(recv_at[key])
+        return found
+
+    # What each rank knows of every other rank's progress, as an action position.
+    knowledge: dict[int, dict[int, int]] = {
+        rank: dict.fromkeys(ranks, -1) for rank in ranks
+    }
+    knowledge_at_send: dict[tuple[int, int], dict[int, int]] = {}
+    outstanding: dict[int, dict[_Action, tuple[int, int]]] = {
+        rank: {} for rank in ranks
+    }
+    lowered: dict[int, list[_Action]] = {rank: [] for rank in ranks}
+    # Receives the walk has passed, so the peer posts them before this point.
+    posted_recvs: set[tuple[int, int]] = set()
+    peak = 0
+    stalling = {SEND_F: 0, SEND_B: 0}
+
+    def release(rank: int, keep: int) -> None:
+        """Wait for sends until at most ``keep`` remain, free proofs first."""
+        known = knowledge[rank]
+        held = outstanding[rank]
+        for landed in (True, False):
+            for send, (peer_rank, recv_index) in list(held.items()):
+                if len(held) <= keep:
+                    return
+                if landed:
+                    if known[peer_rank] < recv_index:
+                        continue
+                else:
+                    if (peer_rank, recv_index) not in posted_recvs:
+                        continue
+                    stalling[send.computation_type] += 1
+                wait_type = (
+                    WAIT_SEND_F if send.computation_type == SEND_F else WAIT_SEND_B
+                )
+                lowered[rank].append(
+                    _Action(send.stage_index, wait_type, send.microbatch_index)
+                )
+                del held[send]
+
+    queue = deque(sorted(node for node, degree in in_degree.items() if degree == 0))
+    walked = 0
+    while queue:
+        rank, index = queue.popleft()
+        walked += 1
+        action = comm_actions[rank][index]
+        known = knowledge[rank]
+        known[rank] = index
+        comp_type = action.computation_type
+
+        if comp_type in send_types:
+            release(rank, budget - 1)
+            lowered[rank].append(action)
+            knowledge_at_send[(rank, index)] = dict(known)
+            outstanding[rank][action] = recv_of_send[(rank, index)]
+            peak = max(peak, len(outstanding[rank]))
+        elif comp_type in (WAIT_SEND_F, WAIT_SEND_B):
+            send = _Action(
+                action.stage_index,
+                SEND_F if comp_type == WAIT_SEND_F else SEND_B,
+                action.microbatch_index,
+            )
+            # Drop a wait for a send the budget already released.
+            if outstanding[rank].pop(send, None) is not None:
+                lowered[rank].append(action)
+        else:
+            if comp_type in (RECV_F, RECV_B):
+                posted_recvs.add((rank, index))
+            lowered[rank].append(action)
+            for recv_index in consumed_recvs(action, rank):
+                for peer_rank, position in knowledge_at_send[
+                    send_of_recv[(rank, recv_index)]
+                ].items():
+                    known[peer_rank] = max(known[peer_rank], position)
+            release(rank, budget)
+
+        for successor in successors[(rank, index)]:
+            in_degree[successor] -= 1
+            if in_degree[successor] == 0:
+                queue.append(successor)
+
+    if walked != len(in_degree):
+        raise AssertionError("Schedule sends and receives form a cycle")
+
+    if peak > budget:
+        logger.warning(
+            "Send release budget of %d not met everywhere: a rank holds up to "
+            "%d sends at points where no release can be proven safe.",
+            budget,
+            peak,
+        )
+    logger.info(
+        "Send release budget %d: a rank holds at most %d sends, and %d forward "
+        "and %d backward release points wait for a peer rather than for a send "
+        "already known to have landed. Raise the budget to buy that waiting "
+        "back; the useful setting is the smallest one reporting none.",
+        budget,
+        peak,
+        stalling[SEND_F],
+        stalling[SEND_B],
+    )
+    return lowered
+
+
 def _add_send_recv(
     compute_actions: dict[int, list[_Action]],
     stage_to_rank: Callable[[int], int],
@@ -2760,7 +2945,8 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 num_stages=self._num_stages,
             )
 
-            if any(stage.early_send_release for stage in self._stages):
+            early_send_release = any(stage.early_send_release for stage in self._stages)
+            if early_send_release:
                 self.pipeline_order_with_comms = _add_wait_send(
                     self.pipeline_order_with_comms
                 )
@@ -2769,6 +2955,15 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 self.pipeline_order_with_comms = _defer_recv_ops(
                     self.pipeline_order_with_comms,
                     stage_to_rank=lambda s: self.stage_index_to_group_rank[s],
+                )
+
+            # Runs last so it reasons about the positions the schedule ends up with.
+            budget = _send_release_budget_default()
+            if early_send_release and budget is not None:
+                self.pipeline_order_with_comms = _add_wait_send_budget(
+                    self.pipeline_order_with_comms,
+                    stage_to_rank=lambda s: self.stage_index_to_group_rank[s],
+                    budget=budget,
                 )
         else:
             raise NotImplementedError(f"{format=} is not implemented")

--- a/torch/distributed/pipelining/stage.py
+++ b/torch/distributed/pipelining/stage.py
@@ -117,6 +117,26 @@ def _send_release_poll_default() -> bool:
     return os.environ.get("TORCH_PIPELINING_SEND_RELEASE_POLL", "1") != "0"
 
 
+def _send_release_budget_default() -> int | None:
+    """Return how many sends a rank may keep outstanding, or None for no cap.
+
+    Set ``TORCH_PIPELINING_SEND_RELEASE_BUDGET`` to a non-negative count to have
+    the schedule name a release point as soon as a rank holds more sends than
+    that, bounding the memory they occupy at roughly the count times the size of
+    a stage boundary. Unset, release points are only named where the local
+    backward implies the send has landed.
+    """
+    budget = os.environ.get("TORCH_PIPELINING_SEND_RELEASE_BUDGET")
+    if budget is None:
+        return None
+    if not budget.isdigit():
+        raise ValueError(
+            "TORCH_PIPELINING_SEND_RELEASE_BUDGET must be a non-negative "
+            f"integer, got {budget!r}"
+        )
+    return int(budget)
+
+
 @dataclass
 class _ForwardCacheEntry:
     """Forward state retained per microbatch.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194122
* #194121
* #194120
* #194119

Naming release points where the local backward proves completion recovers about half of what polling recovers, and it leaves every backward send to the end-of-step drain, because a backward send has no answering traffic to prove it landed. `TORCH_PIPELINING_SEND_RELEASE_BUDGET=K` instead caps how many sends a rank holds at once in either direction, which bounds the memory they occupy at roughly `K` times the size of a stage boundary.

Waiting for a send is safe from the moment the peer posts the matching receive: the transfer then needs nothing further from either side, so the wait cannot deadlock. `_add_wait_send_budget` walks the lowered schedule in causal order, which is each rank's own sequence plus every send before the receive it pairs with, and every release point it names sits after that receive in the walk. No edge it adds runs backwards through the order, so the result stays acyclic and `_simulate_comms_compute` accepts it.

Two proofs, and they differ in cost rather than in safety. A rank has word of a peer only through the messages it has received, so the walk also carries that knowledge: every send stamps what its sender knew, and every receive hands the stamp to the rank consuming it. A send that knowledge covers has already landed, so waiting for it is free. A send only the walk order covers has not, so waiting for it stalls the rank until the peer gets to its receive. Free releases therefore come first, and the budget decides how much of the second kind to buy, which is what makes the setting a memory-for-latency trade rather than a switch.

How much of a budget is free is a property of the schedule, and it is what the setting should be tuned on. On DeepSeek-V3 16B with 28 stages over 4 ranks and 16 microbatches, `K=16` and `K=8` name 800 and 832 release points and not one of them stalls; `K=4` stalls at 6 of 848, `K=2` at 784 of 856, and `K=0` at all 863. The count is logged for exactly this reason, and the useful setting is the smallest budget that still reports zero.

It is logged per direction, but only to show that one budget is enough rather than to invite two. The two directions turn out to have the same cost curve: at `K=4` the stalls are 4 forward against 2 backward, at `K=2` they are 390 against 394, and at `K=0` they are 432 against 431. Nor is there an imbalance in what is left over to trade against, since the drain is backward sends alone -- the proof point already releases all 432 forward sends at every budget, so lowering a forward-only budget would only move releases earlier, buying at most the 80 MiB the peak count implies while paying stalls for it. A budget per direction would be two knobs for one bound, and releasing the free proofs first already spends the bound on whichever direction is cheap.

The budget is a target rather than a promise. A rank cannot release the sends it issues before its first receive, and the walk proves nothing at the very start of a step or in the tail after the last receive. What is left over is reported instead of passed off as met.

The pass runs last in the lowering, after `_defer_recv_ops`, so it reasons about the positions the schedule ends up with.

Measured on that model (PP=4, 7 virtual stages, EP=2, FSDP=2, 16 microbatches, seq 4096, no activation checkpointing), eager throughout so the strategies are comparable. Four runs of each arm arranged as a Latin square, so every arm runs once in each position and warm-up cannot be mistaken for an arm, with throughput averaged over the settled steps:

| strategy | peak | saved | tps |
|---|---|---|---|
| release off | 82.87 +/- 0.00 GiB | -- | 6995 +/- 109 |
| budget K=8 | 80.34 +/- 0.18 GiB | 2.53 GiB | 6984 +/- 112 |
| budget K=0 | 80.37 +/- 0.25 GiB | 2.50 GiB | 6723 +/- 232 |
| polling | 79.94 +/- 0.49 GiB | 2.93 GiB | 6904 +/- 139 |

`K=8` recovers 86% of what polling recovers, sitting 0.40 GiB above it, and costs nothing measurable: 0.2% +/- 1.1% against release off, and 1.2% +/- 1.3% against polling. That is the point of the exercise, since polling cannot run under capture and this can.

`K=0` is the counter-example and it lands where the free-and-stalling split predicts. It buys no memory over `K=8` at all, the two being 0.03 GiB apart against a spread of 0.25, because by `K=8` the schedule has already released everything it can prove early; the remaining sends are the ones held before a rank's first receive, which no budget reaches. It does pay for the 863 stalling release points, at 3.9% +/- 1.8% under release off and 2.6% +/- 2.0% under polling. Spending latency past the point where the budget is free is not worth it here.

A separate single-run scan of `K` in 16, 8, 4, 2, 0 puts peak memory within 0.9 GiB across the whole range, which agrees: the budget reaches its floor as soon as its release points stop being free.

Tests: the budget being met, backward sends released where the proof point releases none, one wait per send, everything but the waits left untouched, deadlock-free simulation across several budgets, the report when the budget cannot be met, the setting rejecting a non-count, and the budget applied through a lowered `ScheduleInterleaved1F1B`. The multiprocess suite passes with the budget set to 2, apart from a flex-attention tolerance failure that reproduces without this change.