### PR TITLE
[ROCm] Set USE_ARC in ROCm workflows

### DIFF
--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -217,6 +217,7 @@ jobs:
           TESTS_TO_INCLUDE: ${{ inputs.tests-to-include }}
           DASHBOARD_TAG: ${{ inputs.dashboard-tag }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
+          USE_ARC: "1"
         timeout-minutes: ${{ fromJson(steps.test-timeout.outputs.timeout) }}
         run: |
           set -x
@@ -268,6 +269,7 @@ jobs:
             -e TESTS_TO_INCLUDE \
             -e HUGGING_FACE_HUB_TOKEN \
             -e DASHBOARD_TAG \
+            -e USE_ARC \
             --env-file="${RUNNER_TEMP}/github_env_${GITHUB_RUN_ID}" \
             --ulimit stack=10485760:83886080 \
             --ulimit core=0 \


### PR DESCRIPTION
The `USE_ARC` variable will be used to export `OMP_NUM_THREADS` in [test.sh](https://github.com/pytorch/pytorch/blob/5eea65726685805edc26b95ce991adc21023dddc/.ci/pytorch/test.sh#L186-L207). According to the script, setting `OMP_NUM_THREADS` to a number less than the number of available cores can avoid OpenMP's busy waiting, therefore improve performance.
[This parity report](https://github.com/ROCm/pytorch/actions/runs/33442276179) shows a speedup of ~3.5% compared to main trunk. It's a comparison between [this PR's trunk run](https://github.com/pytorch/pytorch/actions/runs/33421695762/job/99592395133?pr=194123) and [a recent trunk run on main](https://github.com/pytorch/pytorch/actions/runs/33391494475/job/99560196213)
```
TOTAL 04A989B1 RUNNING TIME	104578.73    <--- This PR
TOTAL 4F0443D2 RUNNING TIME	108417.80    <--- main trunk
```

The main run's parallel information shows
```
+ python -c 'import torch; print(torch.__config__.parallel_info())'
ATen/Parallel:
	at::get_num_threads() : 18
	at::get_num_interop_threads() : 18
OpenMP 201511 (a.k.a. OpenMP 4.5)
	omp_get_max_threads() : 18
Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications
	mkl_get_max_threads() : 18
Intel(R) MKL-DNN v3.12.0 (Git Hash 80afa71049cd69a3df32adcccb623b12cd7baa22)
std::thread::hardware_concurrency() : 192
Environment variables:
	OMP_NUM_THREADS : [not set]
	MKL_NUM_THREADS : [not set]
ATen parallel backend: OpenMP
```

And this PR's is
```
+ python -c 'import torch; print(torch.__config__.parallel_info())'
ATen/Parallel:
	at::get_num_threads() : 4
	at::get_num_interop_threads() : 18
OpenMP 201511 (a.k.a. OpenMP 4.5)
	omp_get_max_threads() : 4
Intel(R) oneAPI Math Kernel Library Version 2024.2-Product Build 20240605 for Intel(R) 64 architecture applications
	mkl_get_max_threads() : 4
Intel(R) MKL-DNN v3.12.0 (Git Hash 80afa71049cd69a3df32adcccb623b12cd7baa22)
std::thread::hardware_concurrency() : 192
Environment variables:
	OMP_NUM_THREADS : 4
	MKL_NUM_THREADS : [not set]
ATen parallel backend: OpenMP
```

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang