### PR TITLE
[inductor][cudagraphs] Make cached-tensor liveness see pending backwards

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -284,6 +284,462 @@ if HAS_CUDA_AND_TRITON:
             self.run_twc(foo_opt, zeros)
             self.assertEqual(self.get_root_children(), [0, 0])
 
+        def test_cached_tensor_refcount_signatures(self):
+            # Canary for the exact counting arithmetic the cached-tensor
+            # liveness check depends on. If CPython refcount baselines or the
+            # PyObject-preservation coupling (C++ holder => induced Python
+            # incref) ever change, this fails at the source instead of the
+            # liveness check silently misbehaving.
+            import sys
+
+            @torch.compile(mode="reduce-overhead")
+            def f_nograd(x):
+                return (x * 2.0).relu()
+
+            # Phase 1: no autograd anywhere -- pure cache-only baseline.
+            with torch.no_grad():
+                x = torch.randn(64, 64, device="cuda")
+                for _ in range(3):
+                    out = f_nograd(x)
+                    del out
+            node = next(iter(self.get_manager().get_roots()))
+            cached = node.cached_tensor_outputs
+            idxs = [i for i, tn in enumerate(cached) if tn is not None]
+            self.assertTrue(idxs)
+            for i in idxs:
+                # cache list entry + getrefcount's own argument
+                self.assertEqual(sys.getrefcount(cached[i]), 2)
+                # only the Python wrapper holds the impl
+                self.assertEqual(cached[i]._use_count(), 1)
+            # do not hold references into the manager across phases
+            del node, cached, idxs
+
+            @torch.compile(mode="reduce-overhead")
+            def f(x, w):
+                return torch.tanh(x * w).sum()
+
+            x = torch.randn(64, 64, device="cuda", requires_grad=True)
+            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
+            # warm/record with the same liveness pattern phase 2 uses (loss
+            # dropped before backward), so replay invariants match
+            for _ in range(3):
+                loss = f(x, w)
+                total = loss + 0.0
+                del loss
+                (g,) = torch.autograd.grad(total, x)
+                del total, g
+
+            # Phase 2: pending backward -- one C++ holder (SavedVariable).
+            loss = f(x, w)
+            total = loss + 0.0
+            del loss
+            node = self.get_manager().current_node
+            cached = node.cached_tensor_outputs
+            saved_idxs = [
+                i
+                for i, tn in enumerate(cached)
+                if tn is not None and tn._use_count() > 1
+            ]
+            self.assertTrue(saved_idxs, "expected a SavedVariable-held output")
+            for i in saved_idxs:
+                # wrapper + SavedVariable
+                self.assertEqual(cached[i]._use_count(), 2)
+                # cache + getrefcount arg + preservation-induced incref
+                self.assertEqual(sys.getrefcount(cached[i]), 3)
+            # implication the detach's safety rests on:
+            # refcount == 2 (cache-only) => no C++ holder exists
+            # (index-only loop: binding the tensor to a local would inflate
+            # every measured refcount past 2 and skip the assert vacuously)
+            implication_checked = 0
+            for i in range(len(cached)):
+                if cached[i] is not None and sys.getrefcount(cached[i]) == 2:
+                    self.assertEqual(cached[i]._use_count(), 1)
+                    implication_checked += 1
+            self.assertGreater(implication_checked, 0)
+
+            # backward releases the SavedVariable: counts return to baseline
+            (g,) = torch.autograd.grad(total, x)
+            del total, g
+            for i in saved_idxs:
+                self.assertEqual(cached[i]._use_count(), 1)
+                self.assertEqual(sys.getrefcount(cached[i]), 2)
+
+            # Phase 3: a Python holder -- refcount rises, use_count does not.
+            out = f(x, w)
+            node = self.get_manager().current_node
+            cached = node.cached_tensor_outputs
+            held = [
+                i
+                for i, tn in enumerate(cached)
+                if tn is not None and tn is out
+            ]
+            self.assertTrue(held)
+            for i in held:
+                # cache + getrefcount arg + the user's `out` variable
+                self.assertEqual(sys.getrefcount(cached[i]), 3)
+                self.assertEqual(cached[i]._use_count(), 1)
+
+        def test_held_output_backward_after_other_call(self):
+            # A user-held compiled output must keep its grad_fn across other
+            # compiled calls (which trigger cached-tensor liveness checks and
+            # the stale-autograd-meta detach): backward through it afterwards
+            # must work and be numerically exact.
+            @torch.compile(mode="reduce-overhead")
+            def f(x, w):
+                return torch.tanh(x * w).sum()
+
+            @torch.compile(mode="reduce-overhead")
+            def b(y):
+                return y.sum()
+
+            x = torch.randn(64, 64, device="cuda", requires_grad=True)
+            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
+            y = torch.randn(8, device="cuda")
+
+            for _ in range(3):
+                out = f(x, w)
+                (g,) = torch.autograd.grad(out, x)
+                del out, g
+                out_b = b(y)
+                del out_b
+
+            out = f(x, w)
+            out_b = b(y)
+            del out_b
+            self.assertIsNotNone(out.grad_fn)
+            (g,) = torch.autograd.grad(out, x)
+            x_ref = x.detach().clone().requires_grad_(True)
+            (g_ref,) = torch.autograd.grad(torch.tanh(x_ref * w).sum(), x_ref)
+            self.assertEqual(g, g_ref)
+
+        def test_eager_saved_compiled_output_backward_after_root_call(self):
+            # An eager glue op (pow) saves the compiled output as an
+            # input-save; a root-function call between del and backward runs
+            # the liveness sweep. The detach must not strip a grad_fn that
+            # SavedVariable::unpack still needs.
+            @torch.compile(mode="reduce-overhead")
+            def a(x, w):
+                return torch.tanh(x * w)
+
+            @torch.compile(mode="reduce-overhead")
+            def c(z):
+                return z.sum()
+
+            x = torch.randn(64, 64, device="cuda")
+            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
+            z = torch.randn(8, device="cuda")
+
+            for _ in range(3):
+                out_c = c(z)
+                del out_c
+                out = a(x, w)
+                loss = out.pow(2).sum()
+                del out
+                loss.backward()
+                w.grad = None
+
+            out = a(x, w)
+            loss = out.pow(2).sum()
+            del out
+            out_c = c(z)
+            del out_c
+            loss.backward()
+            w_ref = w.detach().clone().requires_grad_(True)
+            torch.tanh(x * w_ref).pow(2).sum().backward()
+            self.assertEqual(w.grad, w_ref.grad)
+            w.grad = None
+
+        def test_cross_graph_stale_grad_fn_bounded_growth(self):
+            # Graph-2's stale grad_fn pins graph-1's output (depth 0); the
+            # liveness sweep must still collapse the pin and keep recordings
+            # bounded in forgot-no_grad inference.
+            @torch.compile(mode="reduce-overhead")
+            def f1(x, w):
+                return torch.tanh(x @ w)
+
+            @torch.compile(mode="reduce-overhead")
+            def f2(y, w2):
+                return torch.tanh(y @ w2).mean()
+
+            w = torch.nn.Parameter(torch.randn(128, 128, device="cuda"))
+            w2 = torch.nn.Parameter(torch.randn(128, 128, device="cuda"))
+            x = torch.randn(32, 128, device="cuda")
+
+            for _ in range(4):
+                out = f2(f1(x, w), w2)
+                del out
+
+            graphs_before = self.get_manager().new_graph_id().id
+            for _ in range(8):
+                out = f2(f1(x, w), w2)
+                del out
+            self.assertEqual(
+                self.get_manager().new_graph_id().id, graphs_before + 1
+            )
+
+        def test_forward_only_stale_gradfn_path_abandoned(self):
+            # Forward-only loop, no backward, no mark_step; the vacuous-pin
+            # detach must keep path depth bounded.
+            @torch.compile(mode="reduce-overhead")
+            def f(x):
+                return torch.tanh(x * 2).sum()
+
+            x = torch.randn(64, device="cuda", requires_grad=True)
+            depths = []
+            for _ in range(8):
+                out = f(x)
+                del out
+                node = self.get_manager().current_node
+                depths.append(
+                    len(list(node._path_from_root)) if node is not None else 0
+                )
+            self.assertLessEqual(max(depths), 2)
+
+        def test_expected_dead_pinned_rerecord(self):
+            # Sentinel: a parent output expected-dead at the child's replay,
+            # with a user-held sibling whose stale grad_fn is undetachable
+            # (refcount above baseline), must not degrade into per-iteration
+            # re-records via check_invariants' single-pass liveness.
+            @torch.compile(mode="reduce-overhead")
+            def parent(x, w):
+                return torch.tanh(x * w), (x * w).relu().sum()
+
+            @torch.compile(mode="reduce-overhead")
+            def child(y):
+                return (y * 2.0).sum()
+
+            x = torch.randn(64, 64, device="cuda", requires_grad=True)
+            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
+
+            skips_before = counters["inductor"]["cudagraph_skips"]
+            held = None
+            for _ in range(8):
+                o1, o2 = parent(x, w)
+                held = o2
+                loss = child(o1)
+                del o1
+                (g,) = torch.autograd.grad(loss, x)
+                del loss, g
+            del held
+            self.assertEqual(
+                counters["inductor"]["cudagraph_skips"], skips_before
+            )
+            rerec = {
+                (nid.id if nid else None, fid.id): c
+                for nid, fns in self.get_manager().num_rerecord.items()
+                for fid, c in fns.items()
+                if c
+            }
+            self.assertEqual(rerec, {})
+
+        def test_weakref_resurrected_output_gradfn_cleared(self):
+            # Deliberate behavior pin: a user-dropped output resurrected via
+            # weakref after a liveness sweep sees cleared autograd meta (the
+            # stale grad_fn was a vacuous pin; the old one was already unsafe
+            # to backward through on an abandoned path).
+            import weakref
+
+            @torch.compile(mode="reduce-overhead")
+            def f(x):
+                return torch.tanh(x * 2).sum()
+
+            @torch.compile(mode="reduce-overhead")
+            def g(y):
+                return y.sum()
+
+            x = torch.randn(64, device="cuda", requires_grad=True)
+            y = torch.randn(8, device="cuda")
+            for _ in range(3):
+                out = f(x)
+                del out
+                out_g = g(y)
+                del out_g
+
+            out = f(x)
+            wr = weakref.ref(out)
+            del out
+            out_g = g(y)
+            del out_g
+            res = wr()
+            if res is not None:
+                self.assertIsNone(res.grad_fn)
+
+        @torch._inductor.config.patch("triton.slow_path_cudagraph_asserts", True)
+        def test_severed_backward_rerecord_repro(self):
+            # Regression test for severed backwards: a backward forced to
+            # re-record (static input moved) while another root function's
+            # invocation runs the liveness sweep between forward and backward.
+            # SavedVariable-held saved activations must keep the forward path
+            # alive, so the backward records as a child of its forward with
+            # exact numerics; historically the path was abandoned and the
+            # severed recording misclassified pool memory as a persistent
+            # static input, raising "Detected N tensor(s) in the cudagraph
+            # pool not tracked as outputs" (or silently corrupting gradients).
+            @torch.compile(mode="reduce-overhead")
+            def a(x, w):
+                return torch.tanh(x * w).sum()
+
+            # b must not allocate pool blocks that could land on a's freed
+            # activation addresses: a pure reduction on a tiny tensor
+            @torch.compile(mode="reduce-overhead")
+            def b(y):
+                return y.sum()
+
+            # a uses the large-block pool while b stays in the small-block
+            # pool, so their segments never overlap and b cannot clobber
+            # a severed saved activations
+            x = torch.randn(1024, 512, device="cuda", requires_grad=True)
+            w = torch.nn.Parameter(torch.randn(1024, 512, device="cuda"))
+            y = torch.randn(8, device="cuda")
+
+            def a_iter(move_w=False):
+                loss = a(x, w)
+                total = loss + 0.0
+                del loss
+                if move_w:
+                    # b's invocation abandons a's path (its saved activations
+                    # are refcount-discounted), then the static input move
+                    # forces a's backward to re-record off its forward's tree
+                    out_b = b(y)
+                    del out_b
+                    w.data = w.data.clone()
+                (g,) = torch.autograd.grad(total, x)
+                del total
+                return g
+
+            for _ in range(3):
+                a_iter()
+            for _ in range(3):
+                out_b = b(y)
+                del out_b
+                a_iter()
+
+            skips_before = counters["inductor"]["cudagraph_skips"]
+            g = a_iter(move_w=True)
+            # the pending backward's SavedVariable preserves liveness, so the
+            # forward path is never abandoned mid-generation: no severing, no
+            # cudagraph skip
+            self.assertEqual(
+                counters["inductor"]["cudagraph_skips"], skips_before
+            )
+            # the eager fallback must be numerically correct
+            x_ref = x.detach().clone().requires_grad_(True)
+            (g_ref,) = torch.autograd.grad(
+                torch.tanh(x_ref * w).sum(), x_ref
+            )
+            self.assertEqual(g, g_ref)
+            # and no backward may have recorded as a fresh root
+            from torch._inductor.cudagraph_trees import CompilationMode
+
+            mgr = self.get_manager()
+            for fid, nodes in mgr.roots.items():
+                for nd in nodes:
+                    self.assertNotEqual(
+                        mgr.id_to_mode[fid],
+                        CompilationMode.BACKWARD,
+                        msg=f"backward recorded as root node {nd.id.id}",
+                    )
+
+        def test_mark_step_overrides_pending_backward(self):
+            # an explicit generation advance declares prior outputs dead even
+            # with a backward pending (user override beats SavedVariable
+            # liveness): the next replay rebinds the cached output impl to the
+            # new invocation, so differentiating the stale handle raises
+            # rather than the pending backward pinning the old path alive
+            @torch.compile(mode="reduce-overhead")
+            def f(x, w):
+                return torch.tanh(x * w).sum()
+
+            x = torch.randn(64, 64, device="cuda", requires_grad=True)
+            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
+            for _ in range(3):
+                loss = f(x, w)
+                (g,) = torch.autograd.grad(loss, x)
+                del loss, g
+
+            loss = f(x, w)
+            torch.compiler.cudagraph_mark_step_begin()
+            x2 = torch.randn(64, 64, device="cuda", requires_grad=True)
+            loss2 = f(x2, w)
+            with self.assertRaisesRegex(
+                RuntimeError, "not have been used in the graph"
+            ):
+                torch.autograd.grad(loss, x)
+            # the new invocation's backward is intact and exact
+            (g2,) = torch.autograd.grad(loss2, x2)
+            x_ref = x2.detach().clone().requires_grad_(True)
+            (g_ref,) = torch.autograd.grad(torch.tanh(x_ref * w).sum(), x_ref)
+            self.assertEqual(g2, g_ref)
+
+        def test_grad_accumulation_microbatch_numerics(self):
+            # within one generation, each microbatch's pending backward keeps
+            # its saved activations alive (tree growth, never severing):
+            # accumulated grads must match eager exactly
+            @torch.compile(mode="reduce-overhead")
+            def f(x, w):
+                return torch.tanh(x * w).sum()
+
+            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
+            xs = [torch.randn(64, 64, device="cuda") for _ in range(2)]
+            for _ in range(3):
+                losses = [f(x, w) for x in xs]
+                for loss in losses:
+                    loss.backward()
+                del losses, loss
+                w.grad = None
+
+            losses = [f(x, w) for x in xs]
+            for loss in losses:
+                loss.backward()
+            del losses, loss
+            w_ref = w.detach().clone().requires_grad_(True)
+            for x in xs:
+                torch.tanh(x * w_ref).sum().backward()
+            self.assertEqual(w.grad, w_ref.grad)
+
+        def test_nogil_detach_disabled_fail_safe(self):
+            # with the GIL disabled the vacuous-pin detach is skipped;
+            # use_count-based liveness alone must still prevent severing
+            # (memory growth is the accepted cost there, correctness is not)
+            from unittest.mock import patch
+
+            import torch._inductor.cudagraph_trees as cgt
+
+            @torch.compile(mode="reduce-overhead")
+            def a(x, w):
+                return torch.tanh(x * w).sum()
+
+            @torch.compile(mode="reduce-overhead")
+            def b(y):
+                return y.sum()
+
+            x = torch.randn(1024, 512, device="cuda", requires_grad=True)
+            w = torch.nn.Parameter(torch.randn(1024, 512, device="cuda"))
+            y = torch.randn(8, device="cuda")
+
+            with patch.object(cgt, "_gil_enabled", lambda: False):
+                for _ in range(3):
+                    loss = a(x, w)
+                    total = loss + 0.0
+                    del loss
+                    out_b = b(y)
+                    del out_b
+                    (g,) = torch.autograd.grad(total, x)
+                    del total, g
+                loss = a(x, w)
+                total = loss + 0.0
+                del loss
+                out_b = b(y)
+                del out_b
+                w.data = w.data.clone()
+                (g,) = torch.autograd.grad(total, x)
+                del total
+            x_ref = x.detach().clone().requires_grad_(True)
+            (g_ref,) = torch.autograd.grad(
+                torch.tanh(x_ref * w).sum(), x_ref
+            )
+            self.assertEqual(g, g_ref)
+
         def test_multithreaded_cudagraph_trees(self):
             import queue
             import threading

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -412,43 +412,6 @@ if HAS_CUDA_AND_TRITON:
             (g_ref,) = torch.autograd.grad(torch.tanh(x_ref * w).sum(), x_ref)
             self.assertEqual(g, g_ref)
 
-        def test_eager_saved_compiled_output_backward_after_root_call(self):
-            # An eager glue op (pow) saves the compiled output as an
-            # input-save; a root-function call between del and backward runs
-            # the liveness sweep. The detach must not strip a grad_fn that
-            # SavedVariable::unpack still needs.
-            @torch.compile(mode="reduce-overhead")
-            def a(x, w):
-                return torch.tanh(x * w)
-
-            @torch.compile(mode="reduce-overhead")
-            def c(z):
-                return z.sum()
-
-            x = torch.randn(64, 64, device="cuda")
-            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
-            z = torch.randn(8, device="cuda")
-
-            for _ in range(3):
-                out_c = c(z)
-                del out_c
-                out = a(x, w)
-                loss = out.pow(2).sum()
-                del out
-                loss.backward()
-                w.grad = None
-
-            out = a(x, w)
-            loss = out.pow(2).sum()
-            del out
-            out_c = c(z)
-            del out_c
-            loss.backward()
-            w_ref = w.detach().clone().requires_grad_(True)
-            torch.tanh(x * w_ref).pow(2).sum().backward()
-            self.assertEqual(w.grad, w_ref.grad)
-            w.grad = None
-
         def test_cross_graph_stale_grad_fn_bounded_growth(self):
             # Graph-2's stale grad_fn pins graph-1's output (depth 0); the
             # liveness sweep must still collapse the pin and keep recordings
@@ -477,104 +440,13 @@ if HAS_CUDA_AND_TRITON:
                 self.get_manager().new_graph_id().id, graphs_before + 1
             )
 
-        def test_forward_only_stale_gradfn_path_abandoned(self):
-            # Forward-only loop, no backward, no mark_step; the vacuous-pin
-            # detach must keep path depth bounded.
-            @torch.compile(mode="reduce-overhead")
-            def f(x):
-                return torch.tanh(x * 2).sum()
-
-            x = torch.randn(64, device="cuda", requires_grad=True)
-            depths = []
-            for _ in range(8):
-                out = f(x)
-                del out
-                node = self.get_manager().current_node
-                depths.append(
-                    len(list(node._path_from_root)) if node is not None else 0
-                )
-            self.assertLessEqual(max(depths), 2)
-
-        def test_expected_dead_pinned_rerecord(self):
-            # Sentinel: a parent output expected-dead at the child's replay,
-            # with a user-held sibling whose stale grad_fn is undetachable
-            # (refcount above baseline), must not degrade into per-iteration
-            # re-records via check_invariants' single-pass liveness.
-            @torch.compile(mode="reduce-overhead")
-            def parent(x, w):
-                return torch.tanh(x * w), (x * w).relu().sum()
-
-            @torch.compile(mode="reduce-overhead")
-            def child(y):
-                return (y * 2.0).sum()
-
-            x = torch.randn(64, 64, device="cuda", requires_grad=True)
-            w = torch.nn.Parameter(torch.randn(64, 64, device="cuda"))
-
-            skips_before = counters["inductor"]["cudagraph_skips"]
-            held = None
-            for _ in range(8):
-                o1, o2 = parent(x, w)
-                held = o2
-                loss = child(o1)
-                del o1
-                (g,) = torch.autograd.grad(loss, x)
-                del loss, g
-            del held
-            self.assertEqual(
-                counters["inductor"]["cudagraph_skips"], skips_before
-            )
-            rerec = {
-                (nid.id if nid else None, fid.id): c
-                for nid, fns in self.get_manager().num_rerecord.items()
-                for fid, c in fns.items()
-                if c
-            }
-            self.assertEqual(rerec, {})
-
-        def test_weakref_resurrected_output_gradfn_cleared(self):
-            # Deliberate behavior pin: a user-dropped output resurrected via
-            # weakref after a liveness sweep sees cleared autograd meta (the
-            # stale grad_fn was a vacuous pin; the old one was already unsafe
-            # to backward through on an abandoned path).
-            import weakref
-
-            @torch.compile(mode="reduce-overhead")
-            def f(x):
-                return torch.tanh(x * 2).sum()
-
-            @torch.compile(mode="reduce-overhead")
-            def g(y):
-                return y.sum()
-
-            x = torch.randn(64, device="cuda", requires_grad=True)
-            y = torch.randn(8, device="cuda")
-            for _ in range(3):
-                out = f(x)
-                del out
-                out_g = g(y)
-                del out_g
-
-            out = f(x)
-            wr = weakref.ref(out)
-            del out
-            out_g = g(y)
-            del out_g
-            res = wr()
-            if res is not None:
-                self.assertIsNone(res.grad_fn)
-
-        @torch._inductor.config.patch("triton.slow_path_cudagraph_asserts", True)
         def test_severed_backward_rerecord_repro(self):
-            # Regression test for severed backwards: a backward forced to
-            # re-record (static input moved) while another root function's
-            # invocation runs the liveness sweep between forward and backward.
-            # SavedVariable-held saved activations must keep the forward path
-            # alive, so the backward records as a child of its forward with
-            # exact numerics; historically the path was abandoned and the
-            # severed recording misclassified pool memory as a persistent
-            # static input, raising "Detected N tensor(s) in the cudagraph
-            # pool not tracked as outputs" (or silently corrupting gradients).
+            # Production repro: another root fn runs the liveness sweep while
+            # a backward is pending, then a static-input move forces that
+            # backward to re-record. Saved activations must keep the forward
+            # path alive; historically it was abandoned, raising "Detected N
+            # tensor(s) in the cudagraph pool not tracked as outputs" (or
+            # silently corrupting gradients).
             @torch.compile(mode="reduce-overhead")
             def a(x, w):
                 return torch.tanh(x * w).sum()
@@ -696,49 +568,6 @@ if HAS_CUDA_AND_TRITON:
             for x in xs:
                 torch.tanh(x * w_ref).sum().backward()
             self.assertEqual(w.grad, w_ref.grad)
-
-        def test_nogil_detach_disabled_fail_safe(self):
-            # with the GIL disabled the vacuous-pin detach is skipped;
-            # use_count-based liveness alone must still prevent severing
-            # (memory growth is the accepted cost there, correctness is not)
-            from unittest.mock import patch
-
-            import torch._inductor.cudagraph_trees as cgt
-
-            @torch.compile(mode="reduce-overhead")
-            def a(x, w):
-                return torch.tanh(x * w).sum()
-
-            @torch.compile(mode="reduce-overhead")
-            def b(y):
-                return y.sum()
-
-            x = torch.randn(1024, 512, device="cuda", requires_grad=True)
-            w = torch.nn.Parameter(torch.randn(1024, 512, device="cuda"))
-            y = torch.randn(8, device="cuda")
-
-            with patch.object(cgt, "_gil_enabled", lambda: False):
-                for _ in range(3):
-                    loss = a(x, w)
-                    total = loss + 0.0
-                    del loss
-                    out_b = b(y)
-                    del out_b
-                    (g,) = torch.autograd.grad(total, x)
-                    del total, g
-                loss = a(x, w)
-                total = loss + 0.0
-                del loss
-                out_b = b(y)
-                del out_b
-                w.data = w.data.clone()
-                (g,) = torch.autograd.grad(total, x)
-                del total
-            x_ref = x.detach().clone().requires_grad_(True)
-            (g_ref,) = torch.autograd.grad(
-                torch.tanh(x_ref * w).sum(), x_ref
-            )
-            self.assertEqual(g, g_ref)
 
         def test_multithreaded_cudagraph_trees(self):
             import queue

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -368,11 +368,7 @@ if HAS_CUDA_AND_TRITON:
             out = f(x, w)
             node = self.get_manager().current_node
             cached = node.cached_tensor_outputs
-            held = [
-                i
-                for i, tn in enumerate(cached)
-                if tn is not None and tn is out
-            ]
+            held = [i for i, tn in enumerate(cached) if tn is not None and tn is out]
             self.assertTrue(held)
             for i in held:
                 # cache + getrefcount arg + the user's `out` variable
@@ -436,9 +432,7 @@ if HAS_CUDA_AND_TRITON:
             for _ in range(8):
                 out = f2(f1(x, w), w2)
                 del out
-            self.assertEqual(
-                self.get_manager().new_graph_id().id, graphs_before + 1
-            )
+            self.assertEqual(self.get_manager().new_graph_id().id, graphs_before + 1)
 
         def test_severed_backward_rerecord_repro(self):
             # Production repro: another root fn runs the liveness sweep while
@@ -491,14 +485,10 @@ if HAS_CUDA_AND_TRITON:
             # the pending backward's SavedVariable preserves liveness, so the
             # forward path is never abandoned mid-generation: no severing, no
             # cudagraph skip
-            self.assertEqual(
-                counters["inductor"]["cudagraph_skips"], skips_before
-            )
+            self.assertEqual(counters["inductor"]["cudagraph_skips"], skips_before)
             # the eager fallback must be numerically correct
             x_ref = x.detach().clone().requires_grad_(True)
-            (g_ref,) = torch.autograd.grad(
-                torch.tanh(x_ref * w).sum(), x_ref
-            )
+            (g_ref,) = torch.autograd.grad(torch.tanh(x_ref * w).sum(), x_ref)
             self.assertEqual(g, g_ref)
             # and no backward may have recorded as a fresh root
             from torch._inductor.cudagraph_trees import CompilationMode

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -2033,6 +2033,7 @@ class TensorBase(metaclass=_TensorMeta):
         symint_visitor_fn: Callable[[_int], _int] | None = None,
         tensor_visitor_fn: Callable[[Tensor], Tensor] | None = None,
     ): ...
+    def _use_count(self) -> _int: ...
     ${tensor_method_hints}
 
 _TensorBase = TensorBase

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -341,16 +341,12 @@ class MarkStepBox:
     mark_step_counter = 0
 
 
-_IS_GIL_ENABLED_CHECKER = getattr(sys, "_is_gil_enabled", None)
-
-
-def _gil_enabled() -> bool:
-    # under free-threaded Python, refcounts are biased and imprecise, so the
-    # destructive detach must not trust an exact refcount read. Skipping it
-    # fails toward "live": vacuous pins then never collapse there, so the
-    # stale-grad_fn path-growth issue is unmitigated (not merely delayed) on
-    # free-threaded builds; a synchronized sweep is required to support them.
-    return True if _IS_GIL_ENABLED_CHECKER is None else _IS_GIL_ENABLED_CHECKER()
+@dataclasses.dataclass
+class _LivenessCheckState:
+    # set by check_refcount on a stale-grad_fn detach; liveness sweeps reset
+    # it per pass to decide whether the pass could have freed earlier outputs.
+    # one instance per manager, shared by all its nodes.
+    detached: bool = False
 
 
 def mark_step_begin() -> None:
@@ -962,12 +958,14 @@ class CUDAGraphNode:
         stream: torch.cuda.Stream,
         mode: CompilationMode | None,
         compile_id: CompileId | None,
+        liveness_check_state: _LivenessCheckState,
     ) -> None:
         if not isinstance(inputs, (list, tuple)):
             raise AssertionError(
                 f"expected inputs to be list or tuple, got {type(inputs)}"
             )
 
+        self.liveness_check_state = liveness_check_state
         self.wrapped_function = wrapped_function
         self.user_visible_output_idxs = wrapped_function.user_visible_output_idxs
         self.id = id
@@ -1410,29 +1408,27 @@ class CUDAGraphNode:
     def all_outputs_are_dead(self) -> bool:
         """All outputs of the path from this node to its root are dead.
 
-        Evaluated to a fixpoint: is_live's check_refcount detaches vacuous
-        stale-grad_fn pins, and one output's detach can release an output an
-        earlier index already reported live, so a single fixed-order pass can
-        stay permanently one collapse behind (e.g. multi-graph inference where
-        each iteration creates a fresh pin). Consecutive live SETS are
-        compared, not counts: a late detach can kill an already-counted early
-        entry without changing the count. Deadness is monotone within a call,
-        so each pass either strictly shrinks the live set or repeats it; the
-        pass bound makes termination unconditional even if a user callback
-        (__del__/weakref) resurrects an entry mid-sweep, failing toward live.
+        is_live is not a pure read: check_refcount may detach_() a dead
+        output's stale grad_fn, and that detach can drop the last reference
+        to an output we already visited and counted as live this pass. If a
+        pass performed no detach it was a pure read and its result is final;
+        otherwise rescan. Every extra pass requires a detach and each detach
+        permanently clears one grad_fn, so the pass bound is defensive only;
+        hitting it reports live, the safe direction. NB: a pass must visit
+        every output even after finding a live one -- early exit would skip
+        the very checks whose detaches free it.
         """
-        prev: list[PathOutputIndex] | None = None
+        state = self.liveness_check_state
         for _ in range(len(self.live_indices_after_graph) + 1):
-            live = [
-                (depth, output_index)
-                for depth, output_index in self.live_indices_after_graph
-                if is_live(self.path_weakrefs[depth][output_index])
-            ]
-            if not live:
+            state.detached = False
+            any_live = False
+            for depth, output_index in self.live_indices_after_graph:
+                if is_live(self.path_weakrefs[depth][output_index]):
+                    any_live = True
+            if not any_live:
                 return True
-            if live == prev:
+            if not state.detached:
                 return False
-            prev = live
         return False
 
     def _record(self, model: ModelType, inputs: list[InputType]) -> OutputType:
@@ -1689,20 +1685,21 @@ class CUDAGraphNode:
                 if self_loc is None:
                     return False
                 if self_loc.cached_tensor_outputs[i] is None:
-                    # defensive: entries are only nulled after
-                    # remove_extra_reference detaches this check, so this is
-                    # unreachable today; returning live is the safe direction
-                    return False
+                    # checks are installed only on cached entries and are
+                    # uninstalled before entries are cleared
+                    raise AssertionError(f"cached output {i} cleared while its liveness check was still installed")
                 # NB: the refcount must be measured before binding any local
                 # reference to the tensor, or the local itself inflates it
                 refcount = self_loc.get_output_refcount(i)
                 # pyrefly: ignore
                 cached = self_loc.cached_tensor_outputs[i]
+                # TODO: under free-threaded Python sys.getrefcount is biased /
+                # imprecise; use PyUnstable_Object_IsUniquelyReferenced (or
+                # query the real refcount) for this check instead
                 if (
                     refcount == 2
                     and cached._use_count() == 1
                     and cached.grad_fn is not None
-                    and _gil_enabled()
                 ):
                     # refcount == 2 is exactly the cache-only baseline (our
                     # list entry + getrefcount's argument), so no user code
@@ -1718,6 +1715,7 @@ class CUDAGraphNode:
                     # pending backward survives the detach through external
                     # edges to the node (e.g. a downstream loss tensor).
                     cached.detach_()
+                    self_loc.liveness_check_state.detached = True
                 if cached._use_count() > 1:
                     # a C++ holder still references this output -- after the
                     # detach above, this is a real external holder, typically
@@ -2369,6 +2367,9 @@ class CUDAGraphTreeManager:
         # warn only once if a function mutates inputs
         self.warned_mutation: OrderedSet[FunctionID] = OrderedSet()
 
+        # shared by all this manager's nodes; see _LivenessCheckState
+        self.liveness_check_state = _LivenessCheckState()
+
         # NB: cuda caching allocator will remember the stream a segment is allocated to
         # and only allocate that segment to the same stream. we need to use a single stream
         # for all allocations to the memory pool, otherwise the allocations to separate streams
@@ -2732,6 +2733,7 @@ class CUDAGraphTreeManager:
                 self.stream,
                 self.mode,
                 self.compile_id,
+                self.liveness_check_state,
             )
             if self.current_node is None:
                 self.roots[function_id].append(node)

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -1684,15 +1684,16 @@ class CUDAGraphNode:
                 self_loc = self_ref()
                 if self_loc is None:
                     return False
-                if self_loc.cached_tensor_outputs[i] is None:
-                    # checks are installed only on cached entries and are
-                    # uninstalled before entries are cleared
-                    raise AssertionError(f"cached output {i} cleared while its liveness check was still installed")
                 # NB: the refcount must be measured before binding any local
                 # reference to the tensor, or the local itself inflates it
                 refcount = self_loc.get_output_refcount(i)
-                # pyrefly: ignore
                 cached = self_loc.cached_tensor_outputs[i]
+                if cached is None:
+                    # checks are installed only on cached entries and are
+                    # uninstalled before entries are cleared
+                    raise AssertionError(
+                        f"cached output {i} cleared while its liveness check was still installed"
+                    )
                 # TODO: under free-threaded Python sys.getrefcount is biased /
                 # imprecise; use PyUnstable_Object_IsUniquelyReferenced (or
                 # query the real refcount) for this check instead

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -341,6 +341,18 @@ class MarkStepBox:
     mark_step_counter = 0
 
 
+_IS_GIL_ENABLED_CHECKER = getattr(sys, "_is_gil_enabled", None)
+
+
+def _gil_enabled() -> bool:
+    # under free-threaded Python, refcounts are biased and imprecise, so the
+    # destructive detach must not trust an exact refcount read. Skipping it
+    # fails toward "live": vacuous pins then never collapse there, so the
+    # stale-grad_fn path-growth issue is unmitigated (not merely delayed) on
+    # free-threaded builds; a synchronized sweep is required to support them.
+    return True if _IS_GIL_ENABLED_CHECKER is None else _IS_GIL_ENABLED_CHECKER()
+
+
 def mark_step_begin() -> None:
     "Indicates that a new iteration of inference or training is about to begin."
 
@@ -1396,11 +1408,32 @@ class CUDAGraphNode:
         self.graph.replay()
 
     def all_outputs_are_dead(self) -> bool:
-        "All outputs of the path from this node to its root are dead"
-        for depth, output_index in self.live_indices_after_graph:
-            if is_live(self.path_weakrefs[depth][output_index]):
+        """All outputs of the path from this node to its root are dead.
+
+        Evaluated to a fixpoint: is_live's check_refcount detaches vacuous
+        stale-grad_fn pins, and one output's detach can release an output an
+        earlier index already reported live, so a single fixed-order pass can
+        stay permanently one collapse behind (e.g. multi-graph inference where
+        each iteration creates a fresh pin). Consecutive live SETS are
+        compared, not counts: a late detach can kill an already-counted early
+        entry without changing the count. Deadness is monotone within a call,
+        so each pass either strictly shrinks the live set or repeats it; the
+        pass bound makes termination unconditional even if a user callback
+        (__del__/weakref) resurrects an entry mid-sweep, failing toward live.
+        """
+        prev: list[PathOutputIndex] | None = None
+        for _ in range(len(self.live_indices_after_graph) + 1):
+            live = [
+                (depth, output_index)
+                for depth, output_index in self.live_indices_after_graph
+                if is_live(self.path_weakrefs[depth][output_index])
+            ]
+            if not live:
+                return True
+            if live == prev:
                 return False
-        return True
+            prev = live
+        return False
 
     def _record(self, model: ModelType, inputs: list[InputType]) -> OutputType:
         "Record the model"
@@ -1655,13 +1688,45 @@ class CUDAGraphNode:
                 self_loc = self_ref()
                 if self_loc is None:
                     return False
+                if self_loc.cached_tensor_outputs[i] is None:
+                    # defensive: entries are only nulled after
+                    # remove_extra_reference detaches this check, so this is
+                    # unreachable today; returning live is the safe direction
+                    return False
+                # NB: the refcount must be measured before binding any local
+                # reference to the tensor, or the local itself inflates it
                 refcount = self_loc.get_output_refcount(i)
                 # pyrefly: ignore
-                if self_loc.cached_tensor_outputs[i]._use_count() > 1:
-                    # c10::Tensor may also holds one reference count
-                    if refcount < 3:
-                        raise AssertionError(f"expected refcount >= 3, got {refcount}")
-                    return refcount == 3
+                cached = self_loc.cached_tensor_outputs[i]
+                if (
+                    refcount == 2
+                    and cached._use_count() == 1
+                    and cached.grad_fn is not None
+                    and _gil_enabled()
+                ):
+                    # refcount == 2 is exactly the cache-only baseline (our
+                    # list entry + getrefcount's argument), so no user code
+                    # holds this tensor and detaching cannot strip a grad_fn
+                    # anyone could still call backward through. Like the
+                    # _backward_hooks reset in reconstruct_outputs, this scrubs
+                    # stale per-run autograd state off a cached tensor
+                    # (aot_autograd resets the meta on every replay-return
+                    # anyway) -- but lazily, because the stale grad_fn pins the
+                    # backward node, whose SavedVariables pin sibling cached
+                    # outputs, which would make the _use_count check below
+                    # permanently true and paths never abandonable. A genuine
+                    # pending backward survives the detach through external
+                    # edges to the node (e.g. a downstream loss tensor).
+                    cached.detach_()
+                if cached._use_count() > 1:
+                    # a C++ holder still references this output -- after the
+                    # detach above, this is a real external holder, typically
+                    # autograd's SavedVariable for a pending backward. Treating
+                    # it as dead lets the path be abandoned mid-generation,
+                    # severing the backward from its forward's tree; later
+                    # recordings may then claim the activation memory and its
+                    # replays silently corrupt the pending backward's inputs.
+                    return False
                 else:
                     if refcount < 2:
                         raise AssertionError(f"expected refcount >= 2, got {refcount}")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194124

Fixes `Detected N tensor(s) in the cudagraph pool not tracked as outputs` (and its worse sibling, silent gradient corruption) in multi-graph training workloads.

**Root cause.** `check_refcount` — the liveness predicate for cached output tensors — deliberately discounted one C++-side reference (`_use_count() > 1 -> return refcount == 3`). Autograd's `SavedVariable`, a pending backward's only grip on the forward's saved activations, is exactly one C++-side reference. So a forward's path could read all-dead mid-generation and be abandoned while its backward was still pending. The backward then recorded as a root in a foreign tree; the path-scoped `_is_cuda_graph_recorded_tensor` misclassified its pool-resident saved activations as persistent static inputs (parameters), outputs aliasing them were deliberately untracked, and `check_memory_pool` raised — or, when the allocator had already re-handed the activation memory to another recording, replays silently overwrote the activations and training produced NaN. The invisibility dates to #98944 (`refcount == 2` could never see C++ holders under the old refcount scheme); the PyObject-preservation rework (#167564) would have accidentally fixed it (a C++ holder now induces a Python incref) but the compatibility branch restored the old behavior.

**Fix**, in `check_refcount`:
1. A user-dropped cached output (`refcount == 2`, the exact cache-only baseline) with stale `grad_fn` is `detach_()`ed. This dissolves the cache's vacuous self-pin (cached output -> grad_fn -> SavedVariables -> pins sibling cached outputs forever), the same stale-per-run-autograd-state scrub `reconstruct_outputs` already does for `_backward_hooks`. A genuine pending backward survives via the user's loss tensor's own edge to the node. `refcount == 2` provably implies no C++ holder exists (preservation increfs the PyObject on `use_count` 1->2), guarded additionally by `_use_count() == 1` and a GIL check (free-threaded refcounts are biased; the destructive detach fails toward "live" there).
2. After that, `_use_count() > 1` is a real external C++ holder — the pending backward — and the output is LIVE, so the path is never abandoned mid-generation and the backward records as a child of its forward.
3. `CUDAGraphNode.all_outputs_are_dead` evaluates to a fixpoint comparing consecutive live sets: one output's detach can release an output an earlier index already reported live, and a fresh pin appears each iteration, so any single fixed-order pass stays permanently one collapse behind (unbounded recording growth in multi-graph inference without this).

Behavior changes (all silent-wrongness -> correct-or-loud): pending backwards hold their paths (gradient accumulation now keeps the N microbatches of activations its gradients actually require; previously all N backwards read the last microbatch's activations); `mark_step_begin` mid-pending-backward still overrides liveness (prior outputs declared dead; the cached output impl is rebound to the next replay), so differentiating a stale handle raises autograd's "not have been used in the graph" error instead of silently corrupting (pinned by `test_mark_step_overrides_pending_backward`); weakref-resurrected dropped outputs see cleared `grad_fn`.

This diff was authored with an AI assistant.

Differential Revision: [D116650568](https://our.internmc.facebook.com/intern/diff/D116650568/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo