### PR TITLE
[AOTI] Fix data race in load_json_file

### DIFF
--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -237,12 +237,12 @@ bool _is_windows_os() {
 namespace torch::inductor {
 
 namespace {
-const nlohmann::json& load_json_file(const std::string& json_path) {
+nlohmann::json load_json_file(const std::string& json_path) {
   TORCH_CHECK(fs::exists(json_path), "File not found: ", json_path);
 
   std::ifstream json_file(json_path);
   TORCH_CHECK(json_file.is_open());
-  static nlohmann::json json_obj;
+  nlohmann::json json_obj;
   json_file >> json_obj;
 
   return json_obj;


### PR DESCRIPTION
`load_json_file()` in `torch/csrc/inductor/aoti_package/model_package_loader.cpp` parsed every JSON file into a function-local `static nlohmann::json` and returned a reference to it. When multiple `AOTIModelPackageLoader` instances are constructed concurrently (e.g. a C++ inference server loading several `.pt2` packages in parallel), all threads parse into and read from the same object with no synchronization. Depending on timing this surfaces as:

- `[json.exception.type_error.302] type must be string, but is null` from `load_metadata()`,
- `No device information found.` (metadata map observed empty), or
- heap corruption (`double free or corruption` / SIGSEGV).

This PR parses into a local and returns by value. All five call sites already copy the result into a `const nlohmann::json` value, so no call-site changes are needed. The reference return saved one move of a small metadata object on a cold path (package load); correctness under concurrent loads is worth it.

Python-threaded callers were shielded by the GIL, which is why this never surfaced in the Python test suite; C++ users of libtorch hit it intermittently at model-load time. 

## Test plan

- Existing AOTI package tests cover the sequential path.
- The race itself: reproducer in the linked issue (CPU-only, no GPU needed) —
  sequential control passes, concurrent rounds fail before this change.