### PR TITLE
Make stream selection device-agnostic in test_prepare_for_pickle_clears_benchmark_failure_reasons

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -25,6 +25,7 @@ import torch._functorch._aot_autograd.autograd_cache as autograd_cache
 import torch._functorch.aot_autograd as aot_autograd
 import torch._inductor.compile_fx as compile_fx
 from torch._dynamo import config as dynamo_config
+from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._functorch._aot_autograd.autograd_cache import (
@@ -4143,7 +4144,6 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        from torch._dynamo.device_interface import get_interface_for_device
         device_interface = get_interface_for_device(GPU_TYPE)
         stream = device_interface.get_raw_stream(device_interface.current_device())
         autotuner.run(inp, out, xnumel, stream=stream)

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -4143,17 +4143,9 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        current_stream = torch.get_device_module(GPU_TYPE).current_stream()
-        stream = next(
-            filter(
-                lambda x: x is not None,
-                (
-                    getattr(current_stream, "cuda_stream", None),
-                    getattr(current_stream, "sycl_queue", None),
-                ),
-            ),
-            None,
-        )
+        from torch._dynamo.device_interface import get_interface_for_device
+        device_interface = get_interface_for_device(GPU_TYPE)
+        stream = device_interface.get_raw_stream(device_interface.current_device())
         autotuner.run(inp, out, xnumel, stream=stream)
         self.assertEqual(out, inp + 1.0)
 

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -61,7 +61,6 @@ from torch.testing._internal.common_utils import (
     IS_LINUX,
     parametrize,
     skipIfWindows,
-    skipIfXpu,
     subtest,
     TEST_CUDA,
     TEST_WITH_ASAN,
@@ -4096,7 +4095,6 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         ):
             AOTAutogradCache._pickle_entry(entry, remote=False)
 
-    @skipIfXpu(msg="https://github.com/intel/torch-xpu-ops/issues/4091")
     @requires_gpu_and_triton
     def test_prepare_for_pickle_clears_benchmark_failure_reasons(self):
         """prepare_for_pickle clears benchmark_failure_reasons which can hold
@@ -4145,7 +4143,18 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        autotuner.run(inp, out, xnumel, stream=torch.cuda.current_stream().cuda_stream)
+        current_stream = torch.get_device_module(GPU_TYPE).current_stream()
+        stream = next(
+            filter(
+                lambda x: x is not None,
+                (
+                    getattr(current_stream, "cuda_stream", None),
+                    getattr(current_stream, "sycl_queue", None),
+                ),
+            ),
+            None,
+        )
+        autotuner.run(inp, out, xnumel, stream=stream)
         self.assertEqual(out, inp + 1.0)
 
         # Inject a launcher key into benchmark_failure_reasons — this is how

--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -25,7 +25,6 @@ import torch._functorch._aot_autograd.autograd_cache as autograd_cache
 import torch._functorch.aot_autograd as aot_autograd
 import torch._inductor.compile_fx as compile_fx
 from torch._dynamo import config as dynamo_config
-from torch._dynamo.device_interface import get_interface_for_device
 from torch._dynamo.utils import counters
 from torch._functorch import config as functorch_config
 from torch._functorch._aot_autograd.autograd_cache import (
@@ -4144,9 +4143,9 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         xnumel = 256
         inp = torch.randn(xnumel, device=GPU_TYPE)
         out = torch.empty_like(inp)
-        device_interface = get_interface_for_device(GPU_TYPE)
-        stream = device_interface.get_raw_stream(device_interface.current_device())
-        autotuner.run(inp, out, xnumel, stream=stream)
+        autotuner.run(
+            inp, out, xnumel, stream=torch.accelerator.current_stream().native_handle
+        )
         self.assertEqual(out, inp + 1.0)
 
         # Inject a launcher key into benchmark_failure_reasons — this is how


### PR DESCRIPTION
Fixes issue reported in https://github.com/intel/torch-xpu-ops/issues/4091

Test case:
`test_aot_autograd_cache.py::AOTAutogradCachePicklerTests::test_prepare_for_pickle_clears_benchmark_failure_reasons`

Initially caused by https://github.com/pytorch/pytorch/pull/169241

Changes stream selection for `autotuner.run` from `torch.cuda.current_stream().cuda_stream` to device-agnostic `device_interface.get_raw_stream(device_interface.current_device())`.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98