### PR TITLE
[elastic] Close the descriptor returned by mkstemp in _create_file_store

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import errno
 import os
 import tempfile
 from base64 import b64encode
@@ -260,6 +261,30 @@ class CreateBackendTest(TestCase):
                     ValueError, r"^The read timeout must be a positive integer.$"
                 ):
                     create_backend(self._params)
+
+    def test_create_backend_closes_the_descriptor_returned_by_tempfile(self) -> None:
+        # ``FileStore`` opens the path on its own, so the descriptor handed back
+        # by ``mkstemp()`` has to be closed or it is leaked for the lifetime of
+        # the process.
+        fd, path = tempfile.mkstemp()
+
+        self._params_filestore.endpoint = ""
+
+        try:
+            with mock.patch("tempfile.mkstemp", return_value=(fd, path)):
+                create_backend(self._params_filestore)
+
+            with self.assertRaises(OSError) as ctx:
+                os.fstat(fd)
+
+            self.assertEqual(ctx.exception.errno, errno.EBADF)
+        finally:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            if os.path.exists(path):
+                os.remove(path)
 
     @mock.patch("tempfile.mkstemp")
     def test_create_backend_raises_error_if_tempfile_creation_fails(

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,11 +192,16 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."
             ) from exc
+
+        # ``FileStore`` opens the path itself, so the descriptor returned by
+        # ``mkstemp()`` is never used. Close it here -- before ``FileStore`` is
+        # constructed -- so that it is released even if construction fails.
+        os.close(fd)
 
     try:
         store = FileStore(path)


### PR DESCRIPTION
## Issue

Fixes #191394

## Summary

`_create_file_store()` unpacked `tempfile.mkstemp()` as `_, path` and kept only the path. `FileStore` opens that path on its own, so the descriptor `mkstemp()` returned stayed owned by the process and was never closed — repeated file-store rendezvous creation therefore consumes descriptors and can eventually hit the process limit. This closes the descriptor as soon as the path has been retained, i.e. *before* `FileStore` is constructed, so that it is also released when construction fails and `RendezvousConnectionError` is raised.

The regression test asserts the fd is actually gone rather than mocking `os.close`: it hands a real descriptor to a patched `mkstemp()` and then checks that `os.fstat(fd)` raises `EBADF` once `create_backend()` returns. It fails with `AssertionError: OSError not raised` on `main`.

## Checklist

- [x] Passes lint — `ruff format --diff` and `ruff check` are clean on both touched files, using ruff `0.14.4` (the version pinned in `tools/linter/adapters/pyfmt_linter.py`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — n/a
- [ ] Included benchmark results (for PRs impacting perf) — n/a

Verified by running the full `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py` file (31 passed), and by running the new test against unpatched sources first to confirm it fails there.

## BC-breaking?

No.

---

_Prepared with AI assistance. I have read and reviewed the analysis and the implementation, and I stand behind both._
