### PR TITLE
[elastic] Only close a socket that find_free_port actually created

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,12 +6,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +60,37 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+
+class FindFreePortTest(unittest.TestCase):
+    _ADDR = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+
+    def test_find_free_port_tries_next_address_if_socket_creation_fails(self):
+        real_socket = socket.socket
+        attempts = []
+
+        def fake_socket(family, type, proto):
+            attempts.append(family)
+            if len(attempts) == 1:
+                raise OSError("socket creation failed")
+            return real_socket(family, type, proto)
+
+        with (
+            mock.patch("socket.getaddrinfo", return_value=[self._ADDR, self._ADDR]),
+            mock.patch("socket.socket", side_effect=fake_socket),
+        ):
+            sock = find_free_port()
+
+        try:
+            self.assertEqual(len(attempts), 2)
+            self.assertGreater(sock.getsockname()[1], 0)
+        finally:
+            sock.close()
+
+    def test_find_free_port_raises_runtime_error_if_every_address_fails(self):
+        with (
+            mock.patch("socket.getaddrinfo", return_value=[self._ADDR]),
+            mock.patch("socket.socket", side_effect=OSError("socket creation failed")),
+        ):
+            with self.assertRaisesRegex(RuntimeError, r"^Failed to create a socket$"):
+                find_free_port()

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,18 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            # ``socket.socket()`` itself may raise, in which case there is no
+            # socket to close; closing unconditionally would shadow ``e`` with
+            # an ``UnboundLocalError``.
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Issue

Fixes #191395

## Summary

`find_free_port()` assigns `s` inside the `try` block but calls `s.close()` unconditionally from `except OSError`. When `socket.socket()` itself is the call that raises — resource exhaustion, an unsupported address family, or any platform socket error — `s` was never bound, so the cleanup raises `UnboundLocalError`. That both discards the real diagnostic and aborts the loop, so the remaining addresses are never tried and the documented `RuntimeError` is never reached. This initializes `s` to `None` and closes it only when a socket was actually created; the `# type: ignore[possibly-undefined]` that flagged the hazard is no longer needed.

Two regression tests, one per path: a first address whose socket cannot be created now falls through to the next one, and a run where every address fails raises `RuntimeError` instead of `UnboundLocalError`. Both fail on `main` with `UnboundLocalError: cannot access local variable 's' where it is not associated with a value`.

## Checklist

- [x] Passes lint — `ruff format --diff` and `ruff check` are clean on both touched files, using ruff `0.14.4` (the version pinned in `tools/linter/adapters/pyfmt_linter.py`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — n/a
- [ ] Included benchmark results (for PRs impacting perf) — n/a

The new tests are pure-mock and need no etcd binary, so they run even where the surrounding `EtcdServerTest` cases cannot.

## BC-breaking?

No.

---

_Prepared with AI assistance. I have read and reviewed the analysis and the implementation, and I stand behind both._
