### PR TITLE
[distributed][tools] Restore MemoryTracker operation count on load

### DIFF
--- a/test/distributed/_tools/test_memory_tracker.py
+++ b/test/distributed/_tools/test_memory_tracker.py
@@ -1,6 +1,9 @@
 # Owner(s): ["oncall: distributed"]
 import os
+import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 
 import torch
 import torch.nn as nn
@@ -62,6 +65,41 @@ class TestMemoryTracker(TestCase):
         self.assertTrue(len(tracker._markers) == 2)
         self.assertTrue(tracker._cur_module_name != "")
         self.assertTrue(hasattr(tracker, "_num_alloc_retries"))
+
+    def test_save_load_restores_operation_count(self):
+        """
+        ``summary()`` bounds its iteration with ``_op_index``, so a tracker
+        restored from a stats file has to get that count back or it silently
+        reports no operators at all.
+        """
+        tracker = MemoryTracker()
+        for index, name in enumerate(["aten::conv2d", "aten::relu", "aten::linear"]):
+            tracker.memories_allocated[index] = (name, float(index))
+            tracker.memories_active[index] = (name, float(index))
+            tracker.memories_reserved[index] = (name, float(index))
+            tracker._op_index += 1
+        tracker._num_alloc_retries = 2
+
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            tracker.save_stats(path)
+
+            loaded = MemoryTracker()
+            loaded.load(path)
+
+            self.assertEqual(loaded._op_index, tracker._op_index)
+
+            expected, actual = StringIO(), StringIO()
+            with redirect_stdout(expected):
+                tracker.summary()
+            with redirect_stdout(actual):
+                loaded.summary()
+
+            self.assertEqual(actual.getvalue(), expected.getvalue())
+            self.assertIn("aten::relu", actual.getvalue())
+        finally:
+            os.remove(path)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/_tools/memory_tracker.py
+++ b/torch/distributed/_tools/memory_tracker.py
@@ -212,6 +212,7 @@ class MemoryTracker:
             "memories_reserved": self.memories_reserved,
             "markers": self._markers,
             "num_alloc_retries": self._num_alloc_retries,
+            "op_index": self._op_index,
         }
 
         with open(path, "wb") as f:
@@ -227,6 +228,11 @@ class MemoryTracker:
         self.memories_reserved = stats["memories_reserved"]
         self._markers = stats["markers"]
         self._num_alloc_retries = stats["num_alloc_retries"]
+        # ``summary()`` iterates up to ``_op_index``; without restoring it a
+        # loaded tracker reports no operators at all. Stats files written before
+        # ``op_index`` was persisted are handled by rebuilding the count from the
+        # traces, which are keyed by a contiguous range of operation indices.
+        self._op_index = stats.get("op_index", len(self.memories_allocated))
 
     def _create_pre_forward_hook(self, name: str) -> Callable:
         """Prefix operator name with current module and 'forward', and insert 'fw_start' marker at forward pass start."""


### PR DESCRIPTION
## Issue

Fixes #191397

## Summary

`save_stats()` persisted the memory traces but not `_op_index`, and `load()` restored the traces without reconstructing it. Since `summary()` iterates `range(1, self._op_index)`, a tracker loaded from a stats file has `_op_index == 0` and prints no operator deltas at all — silently dropping one of the main outputs of `MemoryTracker` for exactly the offline-analysis case `save_stats()`/`load()` exist to serve.

This persists `op_index` alongside the traces and restores it in `load()`. Existing stats files stay readable: the count falls back to `len(memories_allocated)`, which is exact because `_update_stats()` writes a contiguous key range starting at 0 and `_clear_state()` resets both together.

The existing `test_local_model` did not catch this because it calls `save_stats()` and `load()` on the same tracker instance, which still holds `_op_index` from its own run. The new test loads into a fresh tracker and compares both the restored count and the rendered `summary()` output; it fails on `main` with `AssertionError: 0 != 3`. It builds its trace entries directly rather than by profiling a model, so unlike `test_local_model` it is not gated on an accelerator being present.

## Checklist

- [x] Passes lint — `ruff format --diff` and `ruff check` are clean on both touched files, using ruff `0.14.4` (the version pinned in `tools/linter/adapters/pyfmt_linter.py`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable) — n/a
- [ ] Included benchmark results (for PRs impacting perf) — n/a

One note for reviewers: the new test writes `(name, value)` tuples into `memories_allocated` / `memories_active` / `memories_reserved`, matching what `_update_stats()` actually stores. The annotations on those attributes say `dict[int, dict[str, float]]`, which looks incorrect, but I have left that alone as it is unrelated to this fix.

## BC-breaking?

No. `load()` accepts stats files written before this change.

---

_Prepared with AI assistance. I have read and reviewed the analysis and the implementation, and I stand behind both._
