### PR TITLE
[ROCm][Inductor] Apply tt.pointer_range guards to template kernels

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -1007,6 +1007,63 @@ def helper(x):
         code_str = " ".join(code)
         self.assertIn("tt.pointer_range", code_str)
 
+    def _skip_unless_annotation_is_literal(self):
+        """Only the V4 descriptor puts ``tt.pointer_range`` in the generated code.
+
+        Earlier versions carry it as a ``pointer_range_32`` field on a descriptor
+        object, so asserting on the literal string would pass whatever the code did.
+        """
+        from torch._inductor.utils import (
+            get_triton_attrs_descriptor_version,
+            TritonAttrsDescriptorVersion,
+        )
+
+        if (
+            get_triton_attrs_descriptor_version()
+            != TritonAttrsDescriptorVersion.V4_DICT
+        ):
+            self.skipTest(
+                "tt.pointer_range is only literal with the V4 attrs descriptor"
+            )
+
+    @staticmethod
+    def _flex_inputs(requires_grad=False):
+        return [
+            torch.randn(
+                1,
+                4,
+                256,
+                64,
+                device=GPU_TYPE,
+                dtype=torch.float16,
+                requires_grad=requires_grad,
+            )
+            for _ in range(3)
+        ]
+
+    @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_pointer_range_applied_to_template_kernel(self):
+        """A template kernel without atomics must still be tagged.
+
+        The positive half of the two tests below: without it, a regression that
+        dropped the annotation for every template kernel -- losing buffer ops on
+        every matmul and attention kernel on ROCm -- would leave them all green.
+        """
+        self._skip_unless_annotation_is_literal()
+        from torch.nn.attention.flex_attention import flex_attention
+
+        q, k, v = self._flex_inputs()
+        _, kernels = run_and_get_kernels(
+            torch.compile(flex_attention, fullgraph=True), q, k, v, remove_quote=True
+        )
+        templates = [x for x in kernels if "triton_tem_" in x]
+        self.assertTrue(templates, "no template kernel was generated")
+        self.assertTrue(
+            any("tt.pointer_range" in x for x in templates),
+            "template kernel without atomics should carry tt.pointer_range",
+        )
+
     @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
     @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
     @inductor_config.patch("triton.emit_pointer_range_32", False)
@@ -1017,18 +1074,17 @@ def helper(x):
         TritonTemplateKernel.jit_lines() rather than going through
         TritonKernel.codegen_kernel(), so the two can disagree.
         """
+        self._skip_unless_annotation_is_literal()
         from torch.nn.attention.flex_attention import flex_attention
 
-        q, k, v = (
-            torch.randn(1, 4, 256, 64, device=GPU_TYPE, dtype=torch.float16)
-            for _ in range(3)
+        q, k, v = self._flex_inputs()
+        _, kernels = run_and_get_kernels(
+            torch.compile(flex_attention, fullgraph=True), q, k, v, remove_quote=True
         )
-        _, code = run_and_get_code(
-            torch.compile(flex_attention, fullgraph=True), q, k, v
-        )
-        code_str = " ".join(code)
-        self.assertIn("triton_tem_fused", code_str)
-        self.assertNotIn("tt.pointer_range", code_str)
+        templates = [x for x in kernels if "triton_tem_" in x]
+        self.assertTrue(templates, "no template kernel was generated")
+        for kernel in templates:
+            self.assertNotIn("tt.pointer_range", kernel)
 
     @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
     @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
@@ -1040,14 +1096,10 @@ def helper(x):
         backend pick buffer atomics, which are far slower than global atomics when
         many lanes target the same address.
         """
+        self._skip_unless_annotation_is_literal()
         from torch.nn.attention.flex_attention import flex_attention
 
-        q, k, v = (
-            torch.randn(
-                1, 4, 256, 64, device=GPU_TYPE, dtype=torch.float16, requires_grad=True
-            )
-            for _ in range(3)
-        )
+        q, k, v = self._flex_inputs(requires_grad=True)
         bias = torch.randn(4, device=GPU_TYPE, dtype=torch.float16, requires_grad=True)
 
         def score_mod(score, b, h, q_idx, kv_idx):
@@ -1060,10 +1112,16 @@ def helper(x):
             out.sum().backward()
             return out
 
-        _, code = run_and_get_code(fwd_bwd, q, k, v)
-        for chunk in re.split(r"\n(?=@triton_heuristics\.)", " ".join(code)):
-            if re.search(r"tl\.atomic_\w+", chunk):
-                self.assertNotIn("tt.pointer_range", chunk)
+        _, kernels = run_and_get_kernels(fwd_bwd, q, k, v, remove_quote=True)
+        atomic = [x for x in kernels if re.search(r"tl\.atomic_\w+", x)]
+        # the whole point is the *template* kernel, so a pointwise atomic kernel
+        # alone would not exercise this
+        self.assertTrue(
+            any("triton_tem_" in x for x in atomic),
+            "no template kernel using atomics was generated",
+        )
+        for kernel in atomic:
+            self.assertNotIn("tt.pointer_range", kernel)
 
     def test_is_multiple_of_rules(self):
         """Test structural divisibility rules in _is_multiple_of."""

--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -2,6 +2,7 @@
 import ast
 import contextlib
 import dataclasses
+import re
 import unittest
 from collections import namedtuple, OrderedDict
 from enum import Enum, IntEnum
@@ -1005,6 +1006,64 @@ def helper(x):
         _, code = run_and_get_code(torch.compile(fn), x)
         code_str = " ".join(code)
         self.assertIn("tt.pointer_range", code_str)
+
+    @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    @inductor_config.patch("triton.emit_pointer_range_32", False)
+    def test_pointer_range_disabled_for_template_kernels(self):
+        """The config flag must reach template kernels, not just the pointwise path.
+
+        Template kernels build their own triton_meta in
+        TritonTemplateKernel.jit_lines() rather than going through
+        TritonKernel.codegen_kernel(), so the two can disagree.
+        """
+        from torch.nn.attention.flex_attention import flex_attention
+
+        q, k, v = (
+            torch.randn(1, 4, 256, 64, device=GPU_TYPE, dtype=torch.float16)
+            for _ in range(3)
+        )
+        _, code = run_and_get_code(
+            torch.compile(flex_attention, fullgraph=True), q, k, v
+        )
+        code_str = " ".join(code)
+        self.assertIn("triton_tem_fused", code_str)
+        self.assertNotIn("tt.pointer_range", code_str)
+
+    @unittest.skipUnless(torch.version.hip is not None, "pointer_range_32 is HIP-only")
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_pointer_range_not_applied_to_template_kernel_with_atomics(self):
+        """Kernels using atomics must not be tagged, including template kernels.
+
+        A score_mod capturing a tensor that requires grad makes the flex_attention
+        backward accumulate into it with tl.atomic_add. Tagging that kernel lets the
+        backend pick buffer atomics, which are far slower than global atomics when
+        many lanes target the same address.
+        """
+        from torch.nn.attention.flex_attention import flex_attention
+
+        q, k, v = (
+            torch.randn(
+                1, 4, 256, 64, device=GPU_TYPE, dtype=torch.float16, requires_grad=True
+            )
+            for _ in range(3)
+        )
+        bias = torch.randn(4, device=GPU_TYPE, dtype=torch.float16, requires_grad=True)
+
+        def score_mod(score, b, h, q_idx, kv_idx):
+            return score + bias[h]
+
+        def fwd_bwd(q, k, v):
+            out = torch.compile(flex_attention, fullgraph=True)(
+                q, k, v, score_mod=score_mod
+            )
+            out.sum().backward()
+            return out
+
+        _, code = run_and_get_code(fwd_bwd, q, k, v)
+        for chunk in re.split(r"\n(?=@triton_heuristics\.)", " ".join(code)):
+            if re.search(r"tl\.atomic_\w+", chunk):
+                self.assertNotIn("tt.pointer_range", chunk)
 
     def test_is_multiple_of_rules(self):
         """Test structural divisibility rules in _is_multiple_of."""

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7396,6 +7396,24 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 return True
         return False
 
+    def pointer_range_kwargs(self) -> dict[str, Any]:
+        """``config_of`` kwargs deciding whether ``tt.pointer_range=32`` may be emitted.
+
+        On HIP the annotation lets the backend use buffer ops. Buffer atomics exist but
+        are far slower than global atomics under contention, so a kernel that uses
+        atomics must not be tagged. Every path that builds triton_meta has to reach the
+        same decision -- this class and ``TritonTemplateKernel``, which does not go
+        through ``codegen_kernel`` -- so the rule lives in one place.
+
+        Only valid once the kernel body exists, since it depends on
+        ``atomic_add_found``.
+        """
+        if torch.version.hip is not None and (
+            self.atomic_add_found or not config.triton.emit_pointer_range_32
+        ):
+            return {"pointer_range_override": ()}
+        return {}
+
     def codegen_kernel(self, name=None) -> str:
         """
         Convert the TritonKernel from Inductor SIMD IR to triton code, including inductor triton heuristics, imports,
@@ -7593,24 +7611,14 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         self._filter_pdl(self.body)
 
-        # Compute configs after codegen_body() so we know if the kernel
-        # uses atomic ops. On HIP, buffer ops don't support atomics, so
-        # we must not tag any args with pointer_range_32 in that case.
-        # Also disable pointer_range_32 when the config flag is off.
-        if torch.version.hip is not None and (
-            self.atomic_add_found or not config.triton.emit_pointer_range_32
-        ):
-            triton_meta["configs"] = [
-                config_of(
-                    signature,
-                    pointer_range_override=(),
-                    skip_cpp_wrapper_input_tensor_alignment=True,
-                )
-            ]
-        else:
-            triton_meta["configs"] = [
-                config_of(signature, skip_cpp_wrapper_input_tensor_alignment=True)
-            ]
+        # Computed after codegen_body() so self.atomic_add_found is accurate.
+        triton_meta["configs"] = [
+            config_of(
+                signature,
+                skip_cpp_wrapper_input_tensor_alignment=True,
+                **self.pointer_range_kwargs(),
+            )
+        ]
 
         for helper in self.helper_functions:
             code.writeline("")

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7396,23 +7396,17 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 return True
         return False
 
-    def pointer_range_kwargs(self) -> dict[str, Any]:
-        """``config_of`` kwargs deciding whether ``tt.pointer_range=32`` may be emitted.
+    def pointer_range_override(self) -> tuple[int, ...] | None:
+        """Suppress ``tt.pointer_range=32`` when this kernel uses atomics.
 
-        On HIP the annotation lets the backend use buffer ops. Buffer atomics exist but
-        are far slower than global atomics under contention, so a kernel that uses
-        atomics must not be tagged. Every path that builds triton_meta has to reach the
-        same decision -- this class and ``TritonTemplateKernel``, which does not go
-        through ``codegen_kernel`` -- so the rule lives in one place.
-
-        Only valid once the kernel body exists, since it depends on
-        ``atomic_add_found``.
+        On HIP the annotation lets the backend use buffer ops, and buffer atomics are
+        far slower than global ones under contention. ``()`` suppresses; ``None`` lets
+        ``config_of`` decide, which is also where the config flag is applied. Only
+        valid once the kernel body exists, since it reads ``atomic_add_found``.
         """
-        if torch.version.hip is not None and (
-            self.atomic_add_found or not config.triton.emit_pointer_range_32
-        ):
-            return {"pointer_range_override": ()}
-        return {}
+        if torch.version.hip is not None and self.atomic_add_found:
+            return ()
+        return None
 
     def codegen_kernel(self, name=None) -> str:
         """
@@ -7616,7 +7610,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             config_of(
                 signature,
                 skip_cpp_wrapper_input_tensor_alignment=True,
-                **self.pointer_range_kwargs(),
+                pointer_range_override=self.pointer_range_override(),
             )
         ]
 

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -932,7 +932,18 @@ class ComboKernel(Kernel):
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index,union-attr]
 
         triton_meta["configs"] = [
-            config_of(signature, skip_cpp_wrapper_input_tensor_alignment=True)
+            config_of(
+                signature,
+                # sub-kernel bodies are spliced into this kernel, so their
+                # atomics are this kernel's atomics
+                pointer_range_override=(
+                    ()
+                    if torch.version.hip is not None
+                    and any(k.atomic_add_found for k in self.sub_kernels)
+                    else None
+                ),
+                skip_cpp_wrapper_input_tensor_alignment=True,
+            )
         ]
 
         mutated_args = self.get_mutated_args_sub_kernels()

--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -425,7 +425,7 @@ def config_of(
     # can use 32-bit pointer offsets and emit buffer load/store ops.
     if pointer_range_override is not None:
         pointer_range_32 = pointer_range_override
-    elif torch.version.hip is not None:
+    elif torch.version.hip is not None and config.triton.emit_pointer_range_32:
         pointer_range_32 = tuple(
             i
             for i, arg in zip(indices, args)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -493,6 +493,10 @@ class ModificationWrapper(V.WrapperHandler):  # type: ignore[name-defined]
         if mode != "atomic_add":
             raise AssertionError("Only atomic_add is supported for inner stores")
 
+        # Record it on the kernel: these atomics never pass through
+        # TritonKernel.store, so nothing else would mark the kernel as using them.
+        self.kernel.atomic_add_found = True
+
         buf_name = self._add_kernel_input(name)
         index_str = self._broadcast_index(index, f"{value}.shape")
         return f"tl.atomic_add({buf_name} + {index_str}, {value}, {self.mask}, sem='relaxed')"
@@ -910,7 +914,9 @@ class TritonTemplateKernel(TritonKernel):
             "device": DeviceProperties.create(self.output_node.get_device()),
             "constants": {},
         }
-        triton_meta["configs"] = [config_of(signature)]
+        # Rendered from a deferred hook, so the body -- including any subgraph
+        # modifications that emit atomics -- already exists at this point.
+        triton_meta["configs"] = [config_of(signature, **self.pointer_range_kwargs())]
         for arg_num in equal_1_arg_indices(signature):  # type: ignore[index]
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index,union-attr]
         matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", None)

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -916,7 +916,9 @@ class TritonTemplateKernel(TritonKernel):
         }
         # Rendered from a deferred hook, so the body -- including any subgraph
         # modifications that emit atomics -- already exists at this point.
-        triton_meta["configs"] = [config_of(signature, **self.pointer_range_kwargs())]
+        triton_meta["configs"] = [
+            config_of(signature, pointer_range_override=self.pointer_range_override())
+        ]
         for arg_num in equal_1_arg_indices(signature):  # type: ignore[index]
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index,union-attr]
         matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", None)


### PR DESCRIPTION
`TORCHINDUCTOR_EMIT_POINTER_RANGE_32=0` does not work for template kernels. The flag is documented as an escape hatch for Triton compiler bugs, but `flex_attention` keeps every one of its annotations with it set to `0`. It is consulted in `TritonKernel.codegen_kernel()`, which template kernels never reach: `TritonTemplateKernel.jit_lines()` builds its own `triton_meta` and calls `config_of()` with no override.

The same bypass disables the other guard on that annotation. Inductor also skips `tt.pointer_range=32` for kernels that use atomics, and template kernels miss that too. That one matters for `flex_attention`, because a `score_mod` capturing a tensor that requires grad makes the backward accumulate into it with `tl.atomic_add` — and with the kernel tagged anyway, the backend selects buffer atomics for that accumulation. Gradients are unaffected, but the kernel can get much slower.

How much slower is set by contention rather than by addressing, so it ranges over orders of magnitude. On MI350X (gfx950), ROCm 7.2.1, fp16, `B=1 H=8 S=2048 D=64`, backward only, median of 60 iterations after a clock ramp:

| captured buffer | before | after | ratio |
|---|---|---|---|
| `bias[h]` (8 elements) | 425.2 ms | 6.8 ms | 62.9x |
| `bias[h, q_idx]` (16384 elements) | 324.9 us | 296.8 us | 1.09x |

`bias[h]` funnels roughly 4.2M score positions per head into eight addresses, while `bias[h, q_idx]` spreads the same traffic across 16384 and the penalty nearly disappears. Those are the only two points measured, so 62.9x is the worst end of a range rather than a representative figure. Workloads that capture nothing requiring a gradient — causal masks, sliding windows, document masking, constant soft-capping — are unaffected, as is the forward pass in every case.

The decision now lives in one place, `TritonKernel.pointer_range_kwargs()`, called from both `codegen_kernel()` and `jit_lines()`. Copying the condition into `jit_lines()` would also work, but would leave the same room for the two paths to drift apart again. The atomics guard additionally needs the kernel to know it emitted atomics: `flex_attention`'s captured-buffer gradients go through `ModificationWrapper.store()` (the `zeros_and_scatter` lowering) rather than `TritonKernel.store()`, so `atomic_add_found` was never set for template kernels, and it is now recorded there. Without that, extending the guard to template kernels would have been a no-op. Ordering works out because `jit_lines()` runs from a deferred `<DEF_KERNEL>` hook, after the subgraph modifications that emit the atomics.

With this, the flag disables the annotation for template kernels, no kernel carries both `tt.pointer_range` and `tl.atomic_*`, and the backward in the first row above drops from 425 ms to 6.8 ms. Gradients are unchanged, with a maximum absolute deviation from eager of 4.88e-4 in fp16 and 8.05e-7 in fp32.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben