### PR TITLE
[symm_mem] Add record_function to non-dispatched Python functions

### DIFF
--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -159,6 +159,7 @@ def _get_backend_stream(priority: int = 0) -> torch.Stream:
     return _backend_streams[priority]
 
 
+@torch.profiler.record_function("symm_mem::_pipelined_multi_all_gather_and_consume")
 def _pipelined_multi_all_gather_and_consume(
     shard: list[torch.Tensor],
     shard_consumer: Callable[[list[torch.Tensor], int], None],
@@ -309,6 +310,7 @@ def _pipelined_multi_all_gather_and_consume(
     symm_mem.barrier(channel=0)
 
 
+@torch.profiler.record_function("symm_mem::_pipelined_all_gather_and_consume")
 def _pipelined_all_gather_and_consume(
     shard: torch.Tensor,
     shard_consumer: Callable[[torch.Tensor, int], None],
@@ -338,6 +340,7 @@ def _pipelined_all_gather_and_consume(
     )
 
 
+@torch.profiler.record_function("symm_mem::_pipelined_produce_and_all2all")
 def _pipelined_produce_and_all2all(
     chunk_producer: Callable[[int, torch.Tensor], None],
     output: torch.Tensor,
@@ -782,6 +785,7 @@ def _fused_all_gather_matmul_impl(
     return A, [unflatten(output) for output in outputs]
 
 
+@torch.profiler.record_function("symm_mem::_pipelined_all_gather_and_consume_last_dim")
 def _pipelined_all_gather_and_consume_last_dim(
     shard: torch.Tensor,
     shard_consumer: Callable[[torch.Tensor, int], None],
@@ -2247,6 +2251,7 @@ def _resolve_group_name(group: c10d.GroupName | ProcessGroup) -> c10d.GroupName:
     raise TypeError(f"unsupported group type: {type(group)}")
 
 
+@torch.profiler.record_function("symm_mem::rendezvous")
 def rendezvous(
     tensor: torch.Tensor, group: c10d.GroupName | ProcessGroup
 ) -> _SymmetricMemory:
@@ -2497,6 +2502,7 @@ def get(
         raise ValueError(f"get: unsupported backend: {backend}")
 
 
+@torch.profiler.record_function("symm_mem::put_signal")
 def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
     r"""
     put_signal(src, hdl, peer) -> None
@@ -2520,6 +2526,7 @@ def put_signal(src: torch.Tensor, hdl: _SymmetricMemory, peer: int) -> None:
         raise ValueError(f"put_signal: unsupported backend: {backend}")
 
 
+@torch.profiler.record_function("symm_mem::wait_signal")
 def wait_signal(hdl: _SymmetricMemory, peer: int) -> None:
     r"""
     wait_signal(hdl, peer) -> None
@@ -2540,6 +2547,7 @@ def wait_signal(hdl: _SymmetricMemory, peer: int) -> None:
         raise ValueError(f"wait_signal: unsupported backend: {backend}")
 
 
+@torch.profiler.record_function("symm_mem::reduce_scatter_offset")
 def reduce_scatter_offset(
     input: torch.Tensor,
     out: list[torch.Tensor],
@@ -2631,6 +2639,7 @@ def is_symm_mem_tensor(tensor: torch.Tensor) -> bool:
     return _SymmetricMemory.is_symm_mem_tensor(tensor)
 
 
+@torch.profiler.record_function("symm_mem::all_to_all_nd")
 def all_to_all_nd(
     input: torch.Tensor,
     out: torch.Tensor,


### PR DESCRIPTION
Fixes #192181

## Summary

Add `torch.profiler.record_function` annotations to the non-dispatched Python symmetric-memory functions identified in #192181, using `symm_mem::<function>` labels.

This covers `rendezvous`, the four pipelined helpers, `put_signal`, `wait_signal`, `reduce_scatter_offset`, and `all_to_all_nd`. Dispatcher-registered operators are left unchanged so they do not get duplicate profiler ranges.

The annotations are applied as decorators, keeping the change limited to one line per function and avoiding re-indenting the pipelined implementations.

## Testing

Verified that the branch diff is limited to the nine requested profiler annotations (9 additions, 0 deletions). Also ran a local CPU profiler smoke test confirming that `torch.profiler.record_function` used as a decorator emits the expected event on repeated calls.

cc @RohitRathore1 @ngimel