### PR TITLE
[Testcase Refactoring] Make injected device rank-aware for MultiProcContinuousTest

### DIFF
--- a/test/test_rank_aware_device.py
+++ b/test/test_rank_aware_device.py
@@ -1,0 +1,63 @@
+# Owner(s): ["module: tests"]
+
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_distributed import MultiProcContinuousTest
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestResolveInjectedDeviceUnit(TestCase):
+    """Unit test for ``MultiProcContinuousTest._resolve_injected_device``: the
+    framework method that rewrites the rank-0 injected device to this worker's
+    per-rank device (called by ``instantiate_device_type_tests``' wrapper)."""
+
+    @staticmethod
+    def _make(rank):
+        inst = MultiProcContinuousTest.__new__(MultiProcContinuousTest)
+        inst.rank = rank
+        return inst
+
+    def test_accelerator_device_rebinds_to_rank(self):
+        # The injected "{type}:0" is rebound to the string "{type}:{rank}" (the
+        # injected `device` arg is a str, so the param keeps its type). "cuda:0"
+        # is portable: the cuda device type is always recognized and
+        # torch.device("cuda:0") is lazy (no CUDA hardware required).
+        self.assertEqual(self._make(3)._resolve_injected_device("cuda:0"), "cuda:3")
+
+    def test_cpu_passes_through(self):
+        # CPU is a single shared device with no per-rank split; pass through.
+        self.assertEqual(self._make(3)._resolve_injected_device("cpu"), "cpu")
+
+
+class TestRankAwareDeviceInjectionHook(TestCase):
+    """Self-test for the call-time hook in ``instantiate_device_type_tests``'
+    wrapper: when a test class defines ``_resolve_injected_device``, the injected
+    ``device`` arg is rewritten to carry ``self.rank`` before the test body runs.
+
+    Single-process (a plain ``TestCase``, not ``MultiProcContinuousTest``) so it
+    exercises the wrapper hook without the multi-process spawn path. The
+    ``device`` is compared as a string (no tensor placement), so the rank-N
+    device need not physically exist -- runs on a single accelerator, no
+    multi-accelerator requirement.
+    """
+
+    rank = 1  # simulate a non-zero multi-process rank
+
+    def _resolve_injected_device(self, device):
+        dev = torch.device(device)
+        if dev.type == "cpu":
+            return device
+        return f"{dev.type}:{self.rank}"
+
+    def test_injected_device_carries_rank(self, device):
+        # The wrapper rewrote the injected "{type}:0" to "{type}:{rank}".
+        self.assertEqual(device, f"{torch.device(device).type}:{self.rank}")
+
+
+instantiate_device_type_tests(
+    TestRankAwareDeviceInjectionHook, globals(), except_for=["cpu"]
+)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -624,6 +624,12 @@ class DeviceTypeTestBase(TestCase):
                 guard_precision = self.precision
                 guard_rel_tol = self.rel_tol
                 try:
+                    resolve = getattr(self, "_resolve_injected_device", None)
+                    if resolve is not None and "device" in param_kwargs:
+                        param_kwargs = {
+                            **param_kwargs,
+                            "device": resolve(param_kwargs["device"]),
+                        }
                     self._apply_precision_override_for_test(test, param_kwargs)
                     result = test(self, **param_kwargs)
                 except RuntimeError as rte:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1853,6 +1853,16 @@ class MultiProcContinuousTest(TestCase):
     # Flag for lazy process spawning (to support instantiate_device_type_tests)
     _processes_spawned: bool = False
 
+    def _resolve_injected_device(self, device):
+        # Called by instantiate_device_type_tests' wrapper when present: rewrite
+        # the injected device to this worker's per-rank device. Returns a string
+        # (the injected `device` arg is a str) so the param keeps its type. CPU
+        # has no per-rank split, so it passes through unchanged.
+        dev = torch.device(device)
+        if dev.type == "cpu":
+            return device
+        return f"{dev.type}:{self.rank}"
+
     @classmethod
     def backend_str(cls) -> str | None:
         """


### PR DESCRIPTION
## Summary

`instantiate_device_type_tests` injects the primary device (rank-0, e.g. `"{type}:0"`) into every device-parametrized test. For multi-process tests each worker instead needs its own rank's device. This PR adds a framework-level, duck-typed call-time hook so the injected `device` itself carries the worker's rank, removing the per-file boilerplate.

## Changes

- **`torch/testing/_internal/common_device_type.py`**: in the `instantiated_test` wrapper's `try:` block (before `_apply_precision_override_for_test`), if the instance defines `_resolve_injected_device`, rewrite the injected `device` kwarg via that method. Duck-typed (`getattr(self, "_resolve_injected_device", None)`) — classes without the method (all plain `DeviceTypeTestBase` tests) are unaffected, so it's a no-op for the existing device-type test suite.
- **`torch/testing/_internal/common_distributed.py`**: `_resolve_injected_device` on `MultiProcContinuousTest` (CPU passes through; else `"{dev.type}:{self.rank}"`). Returns a string to match the injected `device` arg's type (`device_arg: str`), keeping the param's type consistent across all tests.
- **`test/test_rank_aware_device.py`** (new): self-test — `TestResolveInjectedDeviceUnit` (unit: the method rebinds `"{type}:0"`→`"{type}:{rank}"`, CPU passthrough; always runs) + `TestRankAwareDeviceInjectionHook` (single-process `TestCase` exercising the wrapper hook: the injected `device` carries `self.rank`; `device` is compared as a string so the rank-N device need not physically exist — runs on a single accelerator, no multi-accelerator requirement).

## Motivation

Part of the test case refactoring initiative (#185590). Multi-process distributed tests currently each carry a per-file helper to rebind the rank-0 injected device to the worker's rank; a framework-level hook lets them use the injected `device` directly, removing the per-file boilerplate and keeping the rank→device binding in one place.
