### PR TITLE
[autograd] Expose isDifferentiableType to Python

### DIFF
--- a/test/test_autograd_differentiable_type.py
+++ b/test/test_autograd_differentiable_type.py
@@ -1,0 +1,35 @@
+import torch
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestIsDifferentiableType(TestCase):
+    def test_is_differentiable_type(self):
+        differentiable = (
+            torch.float16,
+            torch.float32,
+            torch.float64,
+            torch.bfloat16,
+            torch.complex64,
+            torch.complex128,
+        )
+        non_differentiable = (
+            torch.bool,
+            torch.uint8,
+            torch.int8,
+            torch.int16,
+            torch.int32,
+            torch.int64,
+        )
+
+        for dtype in differentiable:
+            self.assertTrue(torch._C._is_differentiable_type(dtype))
+        for dtype in non_differentiable:
+            self.assertFalse(torch._C._is_differentiable_type(dtype))
+
+    def test_is_differentiable_type_requires_dtype(self):
+        with self.assertRaisesRegex(TypeError, "dtype must be a torch.dtype"):
+            torch._C._is_differentiable_type("float32")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -3,6 +3,7 @@
 #include <c10/core/ScalarType.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/Exceptions.h>
+#include <torch/csrc/autograd/variable.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
@@ -97,6 +98,24 @@ static PyObject* THPDtype_to_complex(PyObject* _self, PyObject* noargs) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject* THPDtype_is_differentiable_type(
+    PyObject* _unused,
+    PyObject* dtype) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK_TYPE(
+      THPDtype_Check(dtype),
+      "dtype must be a torch.dtype (got ",
+      Py_TYPE(dtype)->tp_name,
+      ")");
+  const auto scalar_type = reinterpret_cast<THPDtype*>(dtype)->scalar_type;
+  if (torch::autograd::isDifferentiableType(scalar_type)) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+  END_HANDLE_TH_ERRORS
+}
+
 typedef PyObject* (*getter)(PyObject*, void*);
 
 static const std::initializer_list<PyGetSetDef> THPDtype_properties = {
@@ -133,6 +152,12 @@ static const std::initializer_list<PyMethodDef> THPDtype_methods = {
     {"to_complex", THPDtype_to_complex, METH_NOARGS, nullptr},
     {nullptr} /* Sentinel */
 };
+
+static PyMethodDef THPDtype_is_differentiable_type_method = {
+    "_is_differentiable_type",
+    THPDtype_is_differentiable_type,
+    METH_O,
+    nullptr};
 
 static PyObject* THPDtype_repr(THPDtype* self) {
   return THPUtils_packString(std::string("torch.") + self->name);
@@ -191,4 +216,13 @@ void THPDtype_init(PyObject* module) {
       PyDict_SetItemString(THPDtypeType.tp_dict, "__module__", torch_name) >=
       0);
   PyType_Modified(&THPDtypeType);
+
+  auto is_differentiable_type = THPObjectPtr(
+      PyCFunction_New(&THPDtype_is_differentiable_type_method, nullptr));
+  TORCH_CHECK_PYTHON(is_differentiable_type);
+  TORCH_CHECK_PYTHON(
+      PyModule_AddObject(
+          module,
+          "_is_differentiable_type",
+          is_differentiable_type.release()) >= 0);
 }


### PR DESCRIPTION
Fixes #67187

## Summary

Expose autograd's canonical `isDifferentiableType` predicate to Python as `torch._C._is_differentiable_type`.

The binding accepts a `torch.dtype` and returns whether the dtype is supported by autograd. A focused regression test covers floating-point and complex dtypes, non-differentiable integral/bool dtypes, and invalid input types.

## Testing

Not run locally because this change requires rebuilding the PyTorch C++ extension. The added test is intended to run in upstream CI.