### PR TITLE
[autograd] Detect mutation of backward gradient inputs

### DIFF
--- a/test/test_autograd_backward_input_mutation.py
+++ b/test/test_autograd_backward_input_mutation.py
@@ -1,0 +1,28 @@
+import torch
+from torch.autograd import Function
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class TestAutogradBackwardInputMutation(TestCase):
+    def test_custom_function_backward_input_mutation_raises(self):
+        class MyFunction(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                grad_output.add_(1)
+                return grad_output
+
+        x = torch.rand(2, 4, requires_grad=True)
+        grad_output = torch.ones_like(x)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "modified a gradient input in-place during backward"
+        ):
+            torch.autograd.grad(MyFunction.apply(x), x, grad_outputs=grad_output)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -3,6 +3,7 @@ import functools
 import inspect
 import itertools
 import warnings
+import weakref
 from collections import OrderedDict
 from collections.abc import Callable
 from typing import Any, Concatenate, TypeVar
@@ -351,6 +352,37 @@ class BackwardCFunction(_C._FunctionBase, FunctionCtx, _HookMixin):
             )
         return vjp_fn if vjp_fn is not Function.vjp else backward_fn
 
+    @staticmethod
+    def _snapshot_input_versions(args):
+        versions = []
+
+        def visit(arg):
+            if isinstance(arg, torch.Tensor):
+                try:
+                    version = arg._version
+                except RuntimeError:
+                    return
+                versions.append((weakref.ref(arg), version))
+            elif isinstance(arg, (list, tuple)):
+                for item in arg:
+                    visit(item)
+
+        for arg in args:
+            visit(arg)
+        return versions
+
+    def _call_user_fn(self, user_fn, args):
+        input_versions = self._snapshot_input_versions(args)
+        result = user_fn(self, *args)
+        for input_ref, expected_version in input_versions:
+            input = input_ref()
+            if input is not None and input._version != expected_version:
+                raise RuntimeError(
+                    f"custom autograd Function {self.name()} modified a gradient "
+                    "input in-place during backward"
+                )
+        return result
+
     def apply(self, *args):
         r"""
         Apply method used when executing this Node during the backward.
@@ -363,7 +395,7 @@ class BackwardCFunction(_C._FunctionBase, FunctionCtx, _HookMixin):
         fwd_cls = self._forward_cls  # type: ignore[attr-defined]  # pyrefly: ignore[missing-attribute]
         if getattr(fwd_cls, "boxed_grads_call", False):
             args = (list(args),)
-        return user_fn(self, *args)
+        return self._call_user_fn(user_fn, args)
 
     def apply_boxed(self, *args):
         r"""
@@ -371,7 +403,7 @@ class BackwardCFunction(_C._FunctionBase, FunctionCtx, _HookMixin):
         is True. Grads arrive as a single mutable list argument, allowing
         backward to free individual grads mid-execution.
         """
-        return self._get_user_fn()(self, *args)
+        return self._call_user_fn(self._get_user_fn(), args)
 
     def apply_jvp(self, *args):
         r"""


### PR DESCRIPTION
Fixes #81417

## Summary

Detect in-place mutation of gradient inputs passed to Python custom autograd backward functions.

The backward wrapper snapshots version counters before invoking the user function and checks them afterwards. Weak references are used so the check does not keep gradient tensors alive, including for the boxed-grads path.

A focused regression test covers a custom `Function.backward` that mutates `grad_output` with `add_` and verifies that autograd raises instead of silently accepting the mutation.

## Testing

The added regression test is targeted at the reported failure mode. Full upstream test coverage will run in CI.