### PR TITLE
docs: remove EOL Ubuntu 25.10 from get_start_xpu supported OS list

### DIFF
--- a/docs/source/notes/get_start_xpu.md
+++ b/docs/source/notes/get_start_xpu.md
@@ -12,8 +12,8 @@
 
 | Supported OS | Validated Hardware |
 |---|---|
-| Windows 11 & Ubuntu 24.04/25.10/26.04 & WSL2 Ubuntu 24.04/26.04 | Intel® Arc™ A-Series Graphics (CodeName: Alchemist)<br>Intel® Arc™ B-Series Graphics (CodeName: Battlemage)<br>Intel® Core™ Ultra Processors with Intel® Arc™ Graphics (CodeName: Meteor Lake-H)<br>Intel® Core™ Ultra Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Arrow Lake-H)<br>Intel® Core™ Ultra Mobile Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Lunar Lake) |
-| Windows 11 & Ubuntu 25.10/26.04 & WSL2 Ubuntu 24.04/26.04 | Intel® Core™ Ultra Mobile Processors (Series 3) with Intel® Arc™ Graphics (CodeName: Panther Lake) |
+| Windows 11 & Ubuntu 24.04/26.04 & WSL2 Ubuntu 24.04/26.04 | Intel® Arc™ A-Series Graphics (CodeName: Alchemist)<br>Intel® Arc™ B-Series Graphics (CodeName: Battlemage)<br>Intel® Core™ Ultra Processors with Intel® Arc™ Graphics (CodeName: Meteor Lake-H)<br>Intel® Core™ Ultra Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Arrow Lake-H)<br>Intel® Core™ Ultra Mobile Processors (Series 2) with Intel® Arc™ Graphics (CodeName: Lunar Lake) |
+| Windows 11 & Ubuntu 26.04 & WSL2 Ubuntu 24.04/26.04 | Intel® Core™ Ultra Mobile Processors (Series 3) with Intel® Arc™ Graphics (CodeName: Panther Lake) |
 
 Intel GPUs support (Prototype) is ready from PyTorch\* 2.5 for Intel® Client GPUs and Intel® Data Center GPU Max Series on both Linux and Windows, which brings Intel GPUs and the SYCL\* software stack into the official PyTorch stack with consistent user experience to embrace more AI application scenarios.
 


### PR DESCRIPTION
Ubuntu 25.10 has reached end-of-life and is no longer a supported OS. Remove it from both the general Client GPU row and the Panther Lake row in the XPU getting started doc, keeping Ubuntu 24.04/26.04 and WSL2 Ubuntu 24.04/26.04 entries intact.