### PR TITLE
Use c10::bit_cast for type punning instead of memcpy

### DIFF
--- a/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_convert.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ATen/cpu/vec/vec_base.h>
 #include <ATen/cpu/vec/vec_convert.h>
+#include <c10/util/bit_cast.h>
 
 namespace at::vec {
 inline namespace CPU_CAPABILITY {
@@ -201,9 +202,7 @@ inline void convertFromBf16Impl(
   uint64_t len = static_cast<uint64_t>(n);
   for (uint64_t i = 0; i < len; i++) {
     uint32_t tmp = static_cast<uint32_t>(srcPtr[i]) << 16;
-    float tmpF;
-    __builtin_memcpy(&tmpF, &tmp, sizeof(float));
-    dst[i] = static_cast<to_type>(tmpF);
+    dst[i] = static_cast<to_type>(c10::bit_cast<float>(tmp));
   }
 }
 #define CONVERT_FROM_BF16_TEMPLATE(to_type)                                \

--- a/aten/src/ATen/native/cpu/int4mm_kernel.cpp
+++ b/aten/src/ATen/native/cpu/int4mm_kernel.cpp
@@ -10,6 +10,7 @@
 #include <ATen/native/cpu/utils.h>
 #include <cmath>
 #include <c10/util/Unroll.h>
+#include <c10/util/bit_cast.h>
 #include <c10/util/irange.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -810,16 +811,12 @@ static void ref_dyn_quant_matmul_4bit_channelwise_kernel_bf16(
   // Cast bfloat16 to float32 inline
   auto cast_bf16_to_f32 = [](uint16_t bf16_val) {
     uint32_t tmp = static_cast<uint32_t>(bf16_val) << 16;
-    float f;
-    std::memcpy(&f, &tmp, sizeof(f));
-    return f;
+    return c10::bit_cast<float>(tmp);
   };
 
   // Cast float32 to bfloat16 inline
   auto cast_f32_to_bf16 = [](float f) {
-    uint32_t bits;
-    std::memcpy(&bits, &f, sizeof(bits));
-    return static_cast<uint16_t>(bits >> 16);
+    return static_cast<uint16_t>(c10::bit_cast<uint32_t>(f) >> 16);
   };
 
   // Quantization pack lambda (channelwise QA8DX)

--- a/c10/test/util/bfloat16_test.cpp
+++ b/c10/test/util/bfloat16_test.cpp
@@ -3,6 +3,7 @@
 #include <c10/util/BFloat16-math.h>
 #include <c10/util/irange.h>
 // clang-format on
+#include <c10/util/bit_cast.h>
 #include <gtest/gtest.h>
 
 namespace {
@@ -14,9 +15,7 @@ float float_from_bytes(uint32_t sign, uint32_t exponent, uint32_t fraction) {
   bytes <<= 23;
   bytes |= fraction;
 
-  float res = 0;
-  std::memcpy(&res, &bytes, sizeof(res));
-  return res;
+  return c10::bit_cast<float>(bytes);
 }
 
 TEST(BFloat16Conversion, FloatToBFloat16AndBack) {
@@ -154,9 +153,7 @@ TEST(BFloat16Math, NextAfterZero) {
 }
 
 float BinaryToFloat(uint32_t bytes) {
-  float res = 0;
-  std::memcpy(&res, &bytes, sizeof(res));
-  return res;
+  return c10::bit_cast<float>(bytes);
 }
 
 struct BFloat16TestParam {

--- a/torch/csrc/jit/runtime/argument_spec.h
+++ b/torch/csrc/jit/runtime/argument_spec.h
@@ -2,6 +2,7 @@
 
 #include <ATen/core/jit_type.h>
 #include <ATen/core/stack.h>
+#include <c10/util/bit_cast.h>
 #include <c10/util/hash.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/Export.h>
@@ -115,9 +116,8 @@ struct ArgumentSpec {
   }
 
   void combineHash(const ArgumentInfo& arg) {
-    ArgumentInfo::plain_data_type arg_data = 0;
-    std::memcpy(&arg_data, &arg, sizeof(ArgumentInfo));
-    hash_code = c10::hash_combine(hash_code, arg_data);
+    hash_code = c10::hash_combine(
+        hash_code, c10::bit_cast<ArgumentInfo::plain_data_type>(arg));
   }
 
   // equality is fast: check ninputs, and then check the raw array data,


### PR DESCRIPTION
Description drafted with an AI assistant, quoted below; I've reviewed the change.

> Replaces the `memcpy(&dst, &src, sizeof(...))` type-punning idiom with
> `c10::bit_cast`, which is what C++20 provides for it. `argument_spec.h` already
> had a `static_assert` on the size equality that `bit_cast` now enforces itself.
>
> Sites left alone: SVE sizeless vector types in `vec128_float_neon.h` (not
> trivially copyable), the copy inside a codegen string literal in
> `cpp_intrinsics.h`, same-type copies, and the `bit_cast` fallback itself.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01