### PR TITLE
[ROCm][Inductor] Let user kernel_options override the ROCm flex-attention knobs

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4669,13 +4669,11 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @skip_on_cpu
     @skip_on_mps
     @skip_on_xpu
-    @unittest.skipUnless(torch.version.hip is not None, "ROCm-specific kernel_options")
+    @unittest.skipUnless(TEST_WITH_ROCM, "ROCm-specific kernel_options")
     def test_rocm_kernel_options_are_respected(self, device):
-        """kpack/matrix_instr_nonkdim/waves_per_eu are documented FlexKernelOptions.
-
-        They used to be assigned from the heuristic config unconditionally, which
-        overwrote whatever the caller passed, so none of the three could be tuned.
-        The forward, backward and decoding templates all apply them.
+        """A caller-supplied kpack/matrix_instr_nonkdim/waves_per_eu has to win
+        over the heuristic's, in each of the forward, backward and decoding
+        templates.
         """
         from torch._inductor.heuristics.template.triton import get_default_kpack
 

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4675,23 +4675,51 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
 
         They used to be assigned from the heuristic config unconditionally, which
         overwrote whatever the caller passed, so none of the three could be tuned.
+        The forward, backward and decoding templates all apply them.
         """
+        from torch._inductor.heuristics.template.triton import get_default_kpack
+
+        # kpack's default is architecture dependent (1 on gfx942, 2 elsewhere), so
+        # pick whichever value the heuristic would not have produced here.
+        kpack = 1 if get_default_kpack() != 1 else 2
+        kernel_options = {"kpack": kpack, "matrix_instr_nonkdim": 16, "waves_per_eu": 3}
+
+        def check_templates(code):
+            templates = [c for c in code if "triton_tem_fused" in c]
+            self.assertTrue(templates, "no template kernel was generated")
+            for kernel_code in templates:
+                FileCheck().check(f"kpack : tl.constexpr = {kpack}").run(kernel_code)
+                FileCheck().check("matrix_instr_nonkdim : tl.constexpr = 16").run(
+                    kernel_code
+                )
+                FileCheck().check("waves_per_eu : tl.constexpr = 3").run(kernel_code)
+
+        compiled = torch.compile(flex_attention, fullgraph=True)
         make_tensor = functools.partial(
-            torch.randn, (2, 2, 128, 64), device=device, dtype=torch.float16
+            torch.randn,
+            (2, 2, 128, 64),
+            device=device,
+            dtype=torch.float16,
+            requires_grad=True,
         )
         q, k, v = make_tensor(), make_tensor(), make_tensor()
 
-        # Values chosen to differ from every default the heuristic produces.
         _, code = run_and_get_code(
-            torch.compile(flex_attention, fullgraph=True),
-            q,
-            k,
-            v,
-            kernel_options={"kpack": 1, "matrix_instr_nonkdim": 16, "waves_per_eu": 3},
+            lambda: compiled(q, k, v, kernel_options=kernel_options).sum().backward()
         )
-        FileCheck().check("kpack : tl.constexpr = 1").run(code[0])
-        FileCheck().check("matrix_instr_nonkdim : tl.constexpr = 16").run(code[0])
-        FileCheck().check("waves_per_eu : tl.constexpr = 3").run(code[0])
+        self.assertIn(
+            "flex_attention_backward", "\n".join(code), "backward kernel not built"
+        )
+        check_templates(code)
+
+        # a single query token routes to the decoding template, which carries its
+        # own copy of the same logic
+        with torch.no_grad():
+            q = torch.randn(2, 2, 1, 64, device=device, dtype=torch.float16)
+            _, code = run_and_get_code(
+                compiled, q, k.detach(), v.detach(), kernel_options=kernel_options
+            )
+        check_templates(code)
 
     @supported_platform
     @skip_on_cpu

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4669,6 +4669,34 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
     @skip_on_cpu
     @skip_on_mps
     @skip_on_xpu
+    @unittest.skipUnless(torch.version.hip is not None, "ROCm-specific kernel_options")
+    def test_rocm_kernel_options_are_respected(self, device):
+        """kpack/matrix_instr_nonkdim/waves_per_eu are documented FlexKernelOptions.
+
+        They used to be assigned from the heuristic config unconditionally, which
+        overwrote whatever the caller passed, so none of the three could be tuned.
+        """
+        make_tensor = functools.partial(
+            torch.randn, (2, 2, 128, 64), device=device, dtype=torch.float16
+        )
+        q, k, v = make_tensor(), make_tensor(), make_tensor()
+
+        # Values chosen to differ from every default the heuristic produces.
+        _, code = run_and_get_code(
+            torch.compile(flex_attention, fullgraph=True),
+            q,
+            k,
+            v,
+            kernel_options={"kpack": 1, "matrix_instr_nonkdim": 16, "waves_per_eu": 3},
+        )
+        FileCheck().check("kpack : tl.constexpr = 1").run(code[0])
+        FileCheck().check("matrix_instr_nonkdim : tl.constexpr = 16").run(code[0])
+        FileCheck().check("waves_per_eu : tl.constexpr = 3").run(code[0])
+
+    @supported_platform
+    @skip_on_cpu
+    @skip_on_mps
+    @skip_on_xpu
     def test_backward_kernel_options_filtering(self, device):
         if not PLATFORM_SUPPORTS_BF16:
             self.skipTest("bf16 is required for this regression test")

--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -4674,7 +4674,15 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         """A caller-supplied kpack/matrix_instr_nonkdim/waves_per_eu has to win
         over the heuristic's, in each of the forward, backward and decoding
         templates.
+
+        Asserted on what reaches ``triton.compile``. These are backend compile
+        options, so arriving in its ``options`` argument is the only thing that
+        makes them take effect -- the templates also declare them as ``tl.constexpr``
+        but never read those names, so finding them in the generated source would
+        prove nothing.
         """
+        import triton
+
         from torch._inductor.heuristics.template.triton import get_default_kpack
 
         # kpack's default is architecture dependent (1 on gfx942, 2 elsewhere), so
@@ -4682,15 +4690,20 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         kpack = 1 if get_default_kpack() != 1 else 2
         kernel_options = {"kpack": kpack, "matrix_instr_nonkdim": 16, "waves_per_eu": 3}
 
-        def check_templates(code):
-            templates = [c for c in code if "triton_tem_fused" in c]
-            self.assertTrue(templates, "no template kernel was generated")
-            for kernel_code in templates:
-                FileCheck().check(f"kpack : tl.constexpr = {kpack}").run(kernel_code)
-                FileCheck().check("matrix_instr_nonkdim : tl.constexpr = 16").run(
-                    kernel_code
-                )
-                FileCheck().check("waves_per_eu : tl.constexpr = 3").run(kernel_code)
+        captured: list[dict[str, object]] = []
+        real_compile = triton.compile
+
+        def spy(*args, **kwargs):
+            options = dict(kwargs.get("options") or {})
+            captured.append({k: options[k] for k in kernel_options if k in options})
+            return real_compile(*args, **kwargs)
+
+        def assert_reached_compiler(what):
+            self.assertIn(
+                kernel_options,
+                captured,
+                f"{what}: kernel_options never reached triton.compile, got {captured}",
+            )
 
         compiled = torch.compile(flex_attention, fullgraph=True)
         make_tensor = functools.partial(
@@ -4702,22 +4715,30 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         )
         q, k, v = make_tensor(), make_tensor(), make_tensor()
 
-        _, code = run_and_get_code(
-            lambda: compiled(q, k, v, kernel_options=kernel_options).sum().backward()
+        # compile_threads=1 keeps compilation in-process so the spy sees it.
+        compile_in_process = config.patch(
+            {"compile_threads": 1, "force_disable_caches": True}
         )
+
+        with compile_in_process, patch.object(triton, "compile", side_effect=spy):
+            _, code = run_and_get_code(
+                lambda: compiled(q, k, v, kernel_options=kernel_options)
+                .sum()
+                .backward()
+            )
         self.assertIn(
             "flex_attention_backward", "\n".join(code), "backward kernel not built"
         )
-        check_templates(code)
+        assert_reached_compiler("forward/backward")
 
         # a single query token routes to the decoding template, which carries its
         # own copy of the same logic
+        captured.clear()
         with torch.no_grad():
             q = torch.randn(2, 2, 1, 64, device=device, dtype=torch.float16)
-            _, code = run_and_get_code(
-                compiled, q, k.detach(), v.detach(), kernel_options=kernel_options
-            )
-        check_templates(code)
+            with compile_in_process, patch.object(triton, "compile", side_effect=spy):
+                compiled(q, k.detach(), v.detach(), kernel_options=kernel_options)
+        assert_reached_compiler("decoding")
 
     @supported_platform
     @skip_on_cpu

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -462,6 +462,37 @@ class TestTritonHeuristics(TestCase):
             self.assertEqual(configs[0].num_consumer_groups, num_consumer_groups)
             self.assertEqual(configs[0].num_buffers_warp_spec, num_buffers_warp_spec)
 
+    @parametrize("hip", [True, False])
+    def test_template_forwards_rocm_backend_options(self, hip):
+        """The ROCm knobs reach the compiler through Config.kwargs, not triton_meta.
+
+        _create_compile_meta turns every Config kwarg that is not a kernel argument
+        into a triton.compile ``options`` entry, so a template kernel built with an
+        empty kwargs dict reaches the backend with none of them however carefully
+        the caller set them.
+        """
+        triton_meta = {
+            "device": MagicMock(),
+            "matrix_instr_nonkdim": 16,
+            "waves_per_eu": 3,
+            "kpack": 1,
+        }
+        expected = (
+            {"matrix_instr_nonkdim": 16, "waves_per_eu": 3, "kpack": 1} if hip else {}
+        )
+
+        with (
+            patch.object(torch.version, "hip", "7.2" if hip else None),
+            patch(
+                "torch._inductor.runtime.triton_heuristics.cached_autotune"
+            ) as mock_cached_autotune,
+        ):
+            template(num_stages=1, num_warps=4, triton_meta=triton_meta)
+
+        mock_cached_autotune.assert_called_once()
+        configs = mock_cached_autotune.call_args[0][1]
+        self.assertEqual(configs[0].kwargs, expected)
+
     @runOnRocm
     def test_amd_special_config_args(self):
         """

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -506,9 +506,7 @@ def flex_attention(
                 )
             continue
 
-        # ROCm specific kernargs. setdefault rather than assignment: these are
-        # documented kernel_options, so a user-supplied value has to win over the
-        # heuristic's, as it does for BLOCK_M/BLOCK_N/num_stages/num_warps above.
+        # ROCm specific kernargs
         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
             if hasattr(conf, attrib):
                 cur_kernel_options.setdefault(attrib, getattr(conf, attrib))
@@ -1098,9 +1096,7 @@ def flex_attention_backward(*args, **kwargs):
                 )
             continue
 
-        # ROCm specific kernargs. setdefault rather than assignment: these are
-        # documented kernel_options, so a user-supplied value has to win over the
-        # heuristic's, as it does for BLOCK_M/BLOCK_N/num_stages/num_warps above.
+        # ROCm specific kernargs
         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
             if hasattr(conf, attrib):
                 cur_kernel_options.setdefault(attrib, getattr(conf, attrib))

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -506,10 +506,12 @@ def flex_attention(
                 )
             continue
 
-        # ROCm specific kernargs
+        # ROCm specific kernargs. setdefault rather than assignment: these are
+        # documented kernel_options, so a user-supplied value has to win over the
+        # heuristic's, as it does for BLOCK_M/BLOCK_N/num_stages/num_warps above.
         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
             if hasattr(conf, attrib):
-                cur_kernel_options[attrib] = getattr(conf, attrib)
+                cur_kernel_options.setdefault(attrib, getattr(conf, attrib))
 
         error = flex_attention_template.maybe_append_choice(
             choices=choices,
@@ -1096,10 +1098,12 @@ def flex_attention_backward(*args, **kwargs):
                 )
             continue
 
-        # ROCm specific kernargs
+        # ROCm specific kernargs. setdefault rather than assignment: these are
+        # documented kernel_options, so a user-supplied value has to win over the
+        # heuristic's, as it does for BLOCK_M/BLOCK_N/num_stages/num_warps above.
         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
             if hasattr(conf, attrib):
-                cur_kernel_options[attrib] = getattr(conf, attrib)
+                cur_kernel_options.setdefault(attrib, getattr(conf, attrib))
 
         flex_attention_backward_template.maybe_append_choice(
             choices=choices,

--- a/torch/_inductor/kernel/flex/flex_decoding.py
+++ b/torch/_inductor/kernel/flex/flex_decoding.py
@@ -406,7 +406,7 @@ def create_flex_decoding_kernel(*args, **kwargs):
         # Add ROCm-specific parameters if they exist in the config
         for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
             if hasattr(conf, attrib):
-                cur_kernel_options[attrib] = getattr(conf, attrib)
+                cur_kernel_options.setdefault(attrib, getattr(conf, attrib))
 
         flex_decoding_template.maybe_append_choice(
             choices=choices,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -4945,6 +4945,11 @@ def template(
         "num_stages": num_stages,
         "num_warps": num_warps,
     }
+    # Backend compile options travel in Config.kwargs, not in triton_meta:
+    # _create_compile_meta forwards every Config kwarg that is not a kernel argument
+    # to triton.compile as an `options` entry. A template kernel built with an empty
+    # kwargs dict therefore reaches the compiler with none of them.
+    config_kwargs: dict[str, Any] = {}
 
     # Conditionally add arguments based on HAS_WARP_SPEC
     if HAS_WARP_SPEC:
@@ -4955,13 +4960,18 @@ def template(
             }
         )
 
+    if torch.version.hip:
+        for k in ("matrix_instr_nonkdim", "waves_per_eu", "kpack"):
+            if k in triton_meta:
+                config_kwargs[k] = triton_meta[k]
+
     for k in tlx_only_cuda_options():
         if v := triton_meta.get(k, None):
             config_args[k] = v
 
     return cached_autotune(
         None,
-        [triton.Config({}, **config_args)],
+        [triton.Config(config_kwargs, **config_args)],
         triton_meta=triton_meta,
         inductor_meta=inductor_meta,
         heuristic_type=HeuristicType.TEMPLATE,


### PR DESCRIPTION
`kpack`, `matrix_instr_nonkdim` and `waves_per_eu` are documented entries in `FlexKernelOptions`, but a caller-supplied value for any of them never reaches the kernel. All three flex call sites — forward and backward in `torch/_inductor/kernel/flex/flex_attention.py`, and `create_flex_decoding_kernel` in `flex_decoding.py` — assign them from the heuristic config unconditionally:

```python
for attrib in ["kpack", "matrix_instr_nonkdim", "waves_per_eu"]:
    if hasattr(conf, attrib):
        cur_kernel_options[attrib] = getattr(conf, attrib)
```

`cur_kernel_options` starts as a copy of the user's `kernel_options`, so this overwrites whatever they passed. Every other option in the same loops is applied with `setdefault` — `num_stages`, `num_warps`, `BLOCK_M`, `BLOCK_N`, `USE_TMA`, and both sparse block sizes — which makes these three look like an oversight rather than a deliberate exception. The practical effect is that the three ROCm-specific knobs cannot be tuned at all through the public API.

The change is `setdefault` at all three sites. This is a bug fix rather than a performance change: no default moves, only whether an explicitly requested value is honoured.

The test passes a value for each of the three, then runs a forward, a backward, and a decode-shaped forward, asserting the values reach every generated template. Reverting any one of the three sites on its own fails it. `kpack` is derived from `get_default_kpack()` rather than hardcoded because its default is architecture dependent — 1 on gfx942, 2 elsewhere — so a fixed value would have made that one assertion vacuous on part of the fleet.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
