### PR TITLE
[ROCm][Inductor] Add gfx950 FlexAttention backward default configs

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -9,6 +9,8 @@ import unittest
 from unittest import skipUnless
 from unittest.mock import MagicMock, patch, PropertyMock
 
+import sympy
+
 import torch
 from torch._dynamo.testing import rand_strided
 from torch._inductor.runtime.triton_compat import HAS_WARP_SPEC
@@ -520,6 +522,77 @@ class TestTritonHeuristics(TestCase):
                 config_heuristic.get_mm_configs()(3, 3, 3, dtype_size=4, op_name="mm")
             )
             self.assertEqual(len(configs), expected_count)
+
+    @runOnRocm
+    @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
+    def test_flex_default_configs_gated_on_arch_name(self):
+        """A gfx target gets tuned flex defaults only if registered for them.
+
+        get_device_capability() on ROCm reports the gfx major/minor, which
+        neither orders by capability nor identifies the product line, so gating
+        on `>= (9, 5)` also matches gfx1030, gfx1100 and gfx1250 (MI450) and
+        hands them tables measured on gfx950.
+        """
+        from torch._inductor.heuristics.template.triton import ROCmConfigHeuristic
+        from torch._inductor.utils import rocm_gfx_arch
+
+        heuristic = ROCmConfigHeuristic()
+        dtype, head_dim = torch.float16, 128
+
+        # the registries are keyed on the bare target, so the features that
+        # gcnArchName carries ("gfx950:sramecc+:xnack-") have to be stripped
+        self.assertNotIn(":", rocm_gfx_arch())
+        self.assertTrue(
+            torch.cuda.get_device_properties(0).gcnArchName.startswith(rocm_gfx_arch())
+        )
+
+        # stands in for any target that has no measured values of its own, and
+        # gives the fallback to compare against without pinning its values here
+        unregistered = "gfx000"
+        # RDNA3 is deliberately absent: it has its own branch, keyed by sequence
+        # length rather than by target, so it is not part of this dispatch.
+        targets = ("gfx942", "gfx950", "gfx1250", unregistered)
+
+        def configs_for(arch, get_configs):
+            with (
+                patch(
+                    "torch._inductor.heuristics.template.triton.rocm_gfx_arch",
+                    lambda: arch,
+                ),
+                patch(
+                    "torch._inductor.heuristics.template.triton.using_rocm_rdna3",
+                    lambda: False,
+                ),
+            ):
+                return get_configs()
+
+        paths = (
+            (
+                "forward",
+                heuristic.flex_fwd_config_by_arch,
+                lambda: heuristic.get_flex_attn_fwd_configs(
+                    head_dim, sympy.Integer(1024), dtype
+                ),
+            ),
+            (
+                "backward",
+                heuristic.flex_bwd_config_by_arch,
+                lambda: heuristic.get_flex_attn_bwd_configs(head_dim, dtype),
+            ),
+        )
+        for path, registry, get_configs in paths:
+            with self.subTest(path=path):
+                self.assertIn("gfx950", registry)
+                self.assertNotIn(unregistered, registry)
+                fallback = configs_for(unregistered, get_configs)
+                for arch in targets:
+                    configs = configs_for(arch, get_configs)
+                    tuned = registry.get(arch, {}).get((dtype, head_dim))
+                    if tuned is None:
+                        self.assertEqual(configs, fallback, msg=arch)
+                    else:
+                        self.assertEqual(configs, [tuned], msg=arch)
+                        self.assertNotEqual(configs, fallback, msg=arch)
 
     @skipUnless(HAS_GPU_AND_TRITON, "requires gpu and triton")
     def test_compile_time_autotune_not_repeated_at_runtime(self):

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -38,6 +38,7 @@ from ...utils import (
     get_default_kpack,
     get_num_sms,
     get_tma_workspace_arg,
+    rocm_gfx_arch,
     TMA_DESCRIPTOR_SIZE,
     triton_type,
     using_b200,
@@ -1723,6 +1724,19 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.float16, 256): ROCmFlexConfig(64, 16, 1, 4, waves_per_eu=2),
         }
 
+        # Selection is an exact match on the gfx target, so a target only gets
+        # values that were measured on it. gfx numbers neither order by
+        # capability nor identify the product line -- gfx1250 is MI450, a CDNA5
+        # part -- so there is no direction along which tuning can be inherited.
+        # Targets absent here fall back to the shared ROCm defaults below.
+        self.flex_fwd_config_by_arch = {
+            "gfx942": self.gfx942_default_flex_config,
+            "gfx950": self.gfx950_default_flex_config,
+        }
+        self.flex_bwd_config_by_arch = {
+            "gfx950": self.gfx950_default_flex_bwd_config,
+        }
+
         self.flex_attn_fwd_autotune_configs: list[FlexConfig] = [
             ROCmFlexConfig(BLOCK1, BLOCK2, 1, w, kpack=default_kpack)
             for BLOCK1 in [16, 64, 128]
@@ -1907,7 +1921,6 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                 return self.exhaustive_flex_attn_fwd_configs
             flex_attn_fwd_configs += self.flex_attn_fwd_autotune_configs
 
-        capability = torch.cuda.get_device_capability()
         default_kpack = get_default_kpack()
 
         if head_dim <= 256:
@@ -1929,14 +1942,10 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
                     default_config = self.rdna3_default_flex_config.get(
                         (dtype, head_dim), default_config
                     )
-            elif capability >= (9, 5):  # gfx950 (MI350X/MI355X)
-                default_config = self.gfx950_default_flex_config.get(
-                    (dtype, head_dim), default_config
-                )
-            elif capability >= (9, 4):  # gfx942 (MI300X/MI325X)
-                default_config = self.gfx942_default_flex_config.get(
-                    (dtype, head_dim), default_config
-                )
+            else:
+                default_config = self.flex_fwd_config_by_arch.get(
+                    rocm_gfx_arch(), {}
+                ).get((dtype, head_dim), default_config)
         else:
             if dtype == torch.float32:
                 default_config = ROCmFlexConfig(32, 16, 1, 4, kpack=default_kpack)
@@ -1959,14 +1968,15 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
         default_kpack = get_default_kpack()
-        capability = torch.cuda.get_device_capability()
-        gfx950_bwd = self.gfx950_default_flex_bwd_config.get((dtype, head_dim))
+        arch_bwd_config = self.flex_bwd_config_by_arch.get(rocm_gfx_arch(), {}).get(
+            (dtype, head_dim)
+        )
         if dtype == torch.float32:
             default_config = ROCmFlexBwDConfig(
                 16, 16, 16, 16, 1, 4, kpack=default_kpack
             )
-        elif capability >= (9, 5) and gfx950_bwd is not None:
-            default_config = gfx950_bwd
+        elif arch_bwd_config is not None:
+            default_config = arch_bwd_config
         elif head_dim <= 256:
             if head_dim == 64:
                 default_config = ROCmFlexBwDConfig(

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -1682,6 +1682,25 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             (torch.float16, 256): ROCmFlexConfig(32, 32, 1, 8, kpack=default_kpack),
         }
 
+        # Backward defaults measured on gfx950. Only the head dims covered here were
+        # measured; anything else keeps the shared ROCm values below. The block shape
+        # and num_stages=2 have to move together: on gfx950 either one alone is a
+        # regression at head_dim 128, while the pair is a gain at both head dims.
+        self.gfx950_default_flex_bwd_config = {
+            (torch.bfloat16, 64): ROCmFlexBwDConfig(
+                32, 128, 128, 32, 2, 4, kpack=default_kpack
+            ),
+            (torch.bfloat16, 128): ROCmFlexBwDConfig(
+                32, 128, 128, 32, 2, 4, kpack=default_kpack
+            ),
+            (torch.float16, 64): ROCmFlexBwDConfig(
+                32, 128, 128, 32, 2, 4, kpack=default_kpack
+            ),
+            (torch.float16, 128): ROCmFlexBwDConfig(
+                32, 128, 128, 32, 2, 4, kpack=default_kpack
+            ),
+        }
+
         # RDNA3 (gfx11xx) optimal configs profiled on gfx1151 (head_dim=256).
         # Three seq_len tiers to match CU occupancy on 16-CU RDNA3:
         #   short  (seq < 128): BLOCK_M=16, tiny tiles keep all CUs busy
@@ -1940,10 +1959,14 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             flex_attn_bwd_configs += self.flex_attn_bwd_autotune_configs
 
         default_kpack = get_default_kpack()
+        capability = torch.cuda.get_device_capability()
+        gfx950_bwd = self.gfx950_default_flex_bwd_config.get((dtype, head_dim))
         if dtype == torch.float32:
             default_config = ROCmFlexBwDConfig(
                 16, 16, 16, 16, 1, 4, kpack=default_kpack
             )
+        elif capability >= (9, 5) and gfx950_bwd is not None:
+            default_config = gfx950_bwd
         elif head_dim <= 256:
             if head_dim == 64:
                 default_config = ROCmFlexBwDConfig(

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2510,11 +2510,23 @@ def _rocm_native_device_arch_name(device: str) -> str:
 
 
 @functools.lru_cache
+def rocm_gfx_arch() -> str:
+    """Canonical gfx target of the current device, e.g. "gfx950". Empty if not ROCm.
+
+    Prefer this over get_device_capability() for target-specific behaviour. On
+    ROCm that call reports the gfx major/minor, which does not order by
+    capability and spans two product lines: gfx1250 (MI450) reports (12, 5) and
+    gfx1100 (RDNA3) reports (11, 0), both greater than gfx950's (9, 5). Target
+    features are stripped, so "gfx950:sramecc+:xnack-" becomes "gfx950".
+    """
+    if not torch.version.hip or not torch.cuda.is_available():
+        return ""
+    return _rocm_native_device_arch_name("cuda").split(":", 1)[0]
+
+
 def using_rocm_rdna3() -> bool:
     """Returns true if the device is based on RDNA3, otherwise returns false."""
-    return torch.cuda.is_available() and _rocm_native_device_arch_name(
-        "cuda"
-    ).startswith("gfx11")
+    return rocm_gfx_arch().startswith("gfx11")
 
 
 @functools.cache


### PR DESCRIPTION
The ROCm backward heuristic returns one table for every AMD GPU, with `num_stages=1` throughout: `(64, 64, 64, 64, 1, 4)` at head_dim 64 and `(64, 128, 128, 64, 1, 4)` at head_dim 128. The forward path already picks its defaults per architecture; the backward never got the same treatment.

Measured on gfx950, `(32, 128, 128, 32, 2, 4)` beats the current default at both head dims, for bf16 and fp16, across sequence lengths and for dense, GQA and block-sparse masks:

| shape | bf16 speedup |
|---|---|
| head_dim 64, dense, S=2048 / 4096 / 8192 | 1.80x / 2.09x / 2.31x |
| head_dim 64, GQA, S=4096 | 1.55x |
| head_dim 128, dense, S=2048 / 4096 / 8192 | 1.18x / 1.17x / 1.14x |
| head_dim 128, GQA, S=4096 | 1.41x |
| head_dim 128, block-sparse, S=4096 | 1.36x |

fp16 tracks bf16 — 2.09x at head_dim 64 and 1.16x at head_dim 128 at S=4096. head_dim 64 gains most because its current default also uses smaller K/V blocks, so it is further from the tuned shape.

Worth noting that the block shape and `num_stages` have to move together, so this is not simply "enable pipelining for the backward". At head_dim 128 each change alone is a regression on dense shapes — `(32, 128, 128, 32, 1, 4)` is 0.85x to 0.89x, and `(64, 128, 128, 64, 2, 4)` is 0.93x to 0.99x — while the pair is a gain.

The change is scoped to what was measured: gfx950, bf16 and fp16, head dims 64 and 128. fp32, head_dim 256, and every other target keep today's values.

Gradient error against eager is unchanged by the new config: 3.12e-02 for bf16 and 7.81e-03 for fp16 at S=4096 with both old and new configs, against a gradient magnitude of about 1.4e+01, so this is ordinary low-precision rounding rather than anything the config introduces.

Timings are medians of three `do_bench` medians after a clock ramp, on a device verified idle.

### Selecting the target

The first version of this gated on `torch.cuda.get_device_capability() >= (9, 5)`, which is wrong. On ROCm that call reports the gfx major/minor, so it neither orders by capability nor identifies the product line:

| target | product | capability | `>= (9, 5)` |
|---|---|---|---|
| gfx942 | MI300 series | (9, 4) | no |
| gfx950 | MI350 series | (9, 5) | yes |
| gfx1030 | RDNA2 | (10, 3) | yes |
| gfx1100 | RDNA3 | (11, 0) | yes |
| gfx1250 | MI450 | (12, 5) | yes |

So the comparison would have handed configs measured on MI350X to RDNA2, RDNA3, RDNA4 and MI450. Since MI450 is gfx1250, "gfx9xx is CDNA, gfx1xxx is RDNA" is not a usable fallback either.

The deeper problem is that the capability idiom carries an assumption that does not hold here. On NVIDIA, compute capability is monotonic and features accrete, so `>=` reads as "this generation and later" and a newer part inheriting older tuning is merely suboptimal. On AMD there is no such direction: the matrix-core geometry and LDS size differ across CDNA generations and again between CDNA and RDNA, so inheriting gfx950's tuning is wrong rather than approximate.

Selection is therefore an exact match on the target, with no inheritance. `rocm_gfx_arch()` returns the bare target, stripping the features `gcnArchName` carries, which is how `torch/cuda/_utils.py` already distinguishes gfx950 from gfx1250. The per-target tables are keyed on it:

```python
self.flex_fwd_config_by_arch = {
    "gfx942": self.gfx942_default_flex_config,
    "gfx950": self.gfx950_default_flex_config,
}
```

That mirrors `CUDAConfigHeuristic`, which classifies into a `capability_class` and looks up a `config_map` rather than threading comparisons through the selection logic — the structure is the same, only the classifier differs. Targets absent from the registry fall back to the shared ROCm defaults, and adding a target is one table plus one entry. `using_rocm_rdna3()` is rewritten in terms of `rocm_gfx_arch()` and keeps its own branch, since its seq-length tiers are a different lookup shape.

This also fixes the forward path, which had the same gate from #181283. `using_rocm_rdna3()` was tested first so gfx11xx was shielded, but gfx1030, gfx1201 and gfx1250 all reached the gfx950 table.

Behaviour on gfx950 and gfx942 is unchanged. The test asserts the invariant rather than specific values: a target gets a tuned table if and only if it is registered, and every unregistered target agrees with the fallback. It therefore neither pins the shared defaults, which are tuned independently of this, nor needs updating when a target is added. It fails against the capability comparison, and fails if an unregistered target is made to inherit a tuned table.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
