### PR TITLE
Name the foreach norm block reduction once

### DIFF
--- a/aten/src/ATen/native/cuda/ForeachReduceOp.cu
+++ b/aten/src/ATen/native/cuda/ForeachReduceOp.cu
@@ -247,6 +247,15 @@ std::vector<Tensor> foreach_tensor_max_cuda(TensorList tensors) {
   return result;
 }
 
+template <NormType norm_type, typename T>
+__device__ T block_reduce_norm(T val, T* shared) {
+  if constexpr (norm_type == NormType::LInf) {
+    return at::native::cuda_utils::BlockReduceMax(val, shared);
+  } else {
+    return at::native::cuda_utils::BlockReduceSum(val, shared);
+  }
+}
+
 template <
     typename T,
     NormType norm_type,
@@ -325,10 +334,7 @@ struct LpNormFunctor {
         val += vals[i];
       }
     }
-    auto final_val = norm_type == NormType::L0 || norm_type == NormType::L1 ||
-            norm_type == NormType::L2
-        ? at::native::cuda_utils::BlockReduceSum(val, s_vals)
-        : at::native::cuda_utils::BlockReduceMax(val, s_vals);
+    const auto final_val = block_reduce_norm<norm_type>(val, s_vals);
 
     if (threadIdx.x == 0) {
       output_per_tensor_ptr
@@ -360,10 +366,7 @@ __global__ void lpnorm_cleanup(
       val += output_this_tensor[i];
     }
   }
-  out_opmath_t final_val = norm_type == NormType::L0 ||
-          norm_type == NormType::L1 || norm_type == NormType::L2
-      ? at::native::cuda_utils::BlockReduceSum<out_opmath_t>(val, vals)
-      : at::native::cuda_utils::BlockReduceMax(val, vals);
+  const auto final_val = block_reduce_norm<norm_type>(val, vals);
   if (threadIdx.x == 0) {
     out_opmath_t result = final_val;
     if constexpr (apply_root && norm_type == NormType::L2) {


### PR DESCRIPTION
Description drafted with an AI assistant, quoted below; I've reviewed the change.

> `LpNormFunctor` and `lpnorm_cleanup` each spell the sum-vs-max predicate twice
> in mutually inverse forms -- an `L0 || L1 || L2` enumeration at the reduction,
> and its `LInf` complement four lines above in the accumulation loop. A new norm
> type would have to be added to both. This names it once.
>
> No size or runtime effect: `BlockReduceSum` and `BlockReduceMax` are inline
> device templates whose specializations the translation unit needs either way.
