### PR TITLE
[AOT Autograd] Reuse real inputs during lazy backward compilation

### DIFF
--- a/test/functorch/test_codegen_runtime_wrapper.py
+++ b/test/functorch/test_codegen_runtime_wrapper.py
@@ -492,6 +492,66 @@ class TestCodegenRuntimeWrapper(TestCase):
         self.assertIn(".requires_grad", source)
         self.assertIn(".copy_(", source)
 
+    def test_autograd_backward_compiler_real_inputs_prevents_defake(self):
+        """
+        Verify that passing all_args to _AutogradBackwardCompiler.get_or_compile
+        sets V.real_inputs during backward compilation so that Inductor's extract_real_inputs()
+        uses real input tensors directly and avoids calling defake() on FakeTensor placeholders (issue #194046).
+        """
+        from unittest.mock import patch
+
+        from torch._functorch._aot_autograd.runtime_wrappers import (
+            _AutogradBackwardCompiler,
+            AutogradLazyBackwardCompileInfo,
+        )
+        from torch._inductor.codegen.cpp_wrapper_gpu import CppWrapperGpu
+        from torch._inductor.graph import GraphLowering
+        from torch._inductor.virtualized import NullHandler, V
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        all_args = [torch.randn(4, 4), torch.randn(4, 4)]
+        fake_mode = FakeTensorMode()
+        placeholders = [fake_mode.from_tensor(t) for t in all_args]
+        extracted_inputs = []
+
+        def mock_bw_compiler(bw_module, placeholder_list):
+            graph = GraphLowering(bw_module, example_inputs=placeholder_list, cpp_wrapper=True)
+            graph.device_types = {"cuda"}
+            graph.wrapper_code = CppWrapperGpu()
+            graph.wrapper_code._lazy_kernel_names = ["kernel_1"]
+
+            def intercept_run_jit_variant(wrapper_code, kernel_code, extract_real_inputs_fn, lazy_kernel_names):
+                extracted_inputs.extend(extract_real_inputs_fn())
+
+            with patch.object(graph, "_run_jit_variant_for_autotune", side_effect=intercept_run_jit_variant):
+                graph.codegen_with_cpp_wrapper()
+
+            return lambda *args: args
+
+        compiler = _AutogradBackwardCompiler(
+            compiled_bw=None,
+            lazy_backward_info=AutogradLazyBackwardCompileInfo(
+                bw_module=torch.fx.GraphModule({}, torch.fx.Graph()),
+                placeholder_list=placeholders,
+                saved_context=None,
+                saved_compile_context=None,
+            ),
+            disable_amp=False,
+            bw_compiler=mock_bw_compiler,
+            aot_config=None,
+            fw_metadata=None,
+            try_save_cache_entry=None,
+        )
+
+        with patch("torch._inductor.graph.defake") as mock_defake:
+            compiler.get_or_compile(saved_tensors_use_once=True, all_args=all_args)
+
+        mock_defake.assert_not_called()
+        self.assertEqual(len(extracted_inputs), len(all_args))
+        for extracted_t, real_t in zip(extracted_inputs, all_args):
+            self.assertIs(extracted_t, real_t)
+        self.assertTrue(isinstance(V._real_inputs._get_handler(), NullHandler))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2857,7 +2857,12 @@ class _AutogradBackwardCompiler:
     fw_metadata: ViewAndMutationMeta
     try_save_cache_entry: Callable[..., Any] | None
 
-    def get_or_compile(self, *, saved_tensors_use_once: bool) -> Callable[..., Any]:
+    def get_or_compile(
+        self,
+        *,
+        saved_tensors_use_once: bool,
+        all_args: list[Any] | None = None,
+    ) -> Callable[..., Any]:
         if self.compiled_bw is not None:
             return self.compiled_bw
 
@@ -2878,6 +2883,13 @@ class _AutogradBackwardCompiler:
 
         context = torch._C._DisableAutocast if self.disable_amp else nullcontext
         metrics_context = get_metrics_context()
+        if all_args is not None:
+            from torch._inductor.virtualized import V
+
+            set_real_inputs_ctx = V.set_real_inputs(all_args)
+        else:
+            set_real_inputs_ctx = nullcontext()
+
         with (
             tracing(saved_context),
             compile_context(saved_compile_context),
@@ -2896,6 +2908,7 @@ class _AutogradBackwardCompiler:
                 CallbackTrigger.LAZY_BACKWARD,
                 str(CompileContext.current_compile_id()),
             ),
+            set_real_inputs_ctx,
         ):
             CompileEventLogger.compilation_metric(is_forward=False)
             # See Note: [Backward graph lazy lowering]
@@ -3586,7 +3599,8 @@ class _AOTDispatchAutogradFunctionFactory:
                     not torch._C._autograd._get_current_graph_task_keep_graph()
                 )
                 compiled_bw = backward_compiler.get_or_compile(
-                    saved_tensors_use_once=saved_tensors_use_once
+                    saved_tensors_use_once=saved_tensors_use_once,
+                    all_args=all_args,
                 )
                 CompiledFunction.compiled_bw = compiled_bw
 


### PR DESCRIPTION
## Summary

Fixes the unnecessary peak GPU memory allocation during lazy backward compilation described in #194046.

During two-pass `cpp_wrapper` compilation, the backward compiler can materialize `FakeTensor` placeholders into new real tensors for Inductor compilation, even though the corresponding real runtime inputs are already available in `all_args`.

This change passes `all_args` to the lazy backward compiler and binds them through `V.set_real_inputs()` during compilation, allowing Inductor to reuse the existing runtime tensors instead of defaking the placeholders.

## Changes

- Pass `all_args` to `_AutogradBackwardCompiler.get_or_compile()`.
- Bind `V.real_inputs` during lazy backward compilation.
- Add a regression test verifying that the existing real tensors are reused and `defake()` is not called.

## Testing

- `python3 -m py_compile torch/_functorch/_aot_autograd/runtime_wrappers.py test/functorch/test_codegen_runtime_wrapper.py`
- `git diff HEAD^ HEAD --check`

The full PyTorch runtime test suite could not be run locally because this checkout does not have the compiled PyTorch C++ extension available.

Fixes #194046