### PR TITLE
Register SparseXPU dispatch for aten::linalg_vector_norm

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -14551,7 +14551,7 @@
   variants: function
   structured_delegate: linalg_vector_norm.out
   dispatch:
-    SparseCPU, SparseCUDA, SparseMPS: linalg_vector_norm_sparse
+    SparseCPU, SparseCUDA, SparseMPS, SparseXPU: linalg_vector_norm_sparse
   tags: reduction
 
 - func: linalg_vector_norm.out(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)


### PR DESCRIPTION
In https://github.com/pytorch/pytorch/pull/185309, `linalg_vector_norm` registered its sparse kernel `linalg_vector_norm_sparse` for SparseCPU, SparseCUDA, and SparseMPS, but SparseXPU was omitted. `linalg_vector_norm_sparse` kernel is device-agnostic and it forwards to `at::native_norm` which already has SparseXPU dispatch.
This PR is to add registration directly. 