### PR TITLE
[DTensor]: propagate grad_dtype through from_local and to_local

### DIFF
--- a/test/distributed/tensor/test_dtensor.py
+++ b/test/distributed/tensor/test_dtensor.py
@@ -106,6 +106,38 @@ class DTensorTest(DTensorTestBase):
             )
 
     @with_comms
+    def test_from_local_to_local_grad_dtype(self):
+        device_mesh = self.build_device_mesh()
+        local_tensor = torch.randn(
+            4,
+            4,
+            device=self.device_type,
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        local_tensor.grad_dtype = torch.float32
+
+        dtensor = DTensor.from_local(
+            local_tensor, device_mesh, [Replicate()], run_check=False
+        )
+        self.assertEqual(dtensor.dtype, torch.bfloat16)
+        self.assertEqual(dtensor.grad_dtype, torch.float32)
+
+        local_output = dtensor.to_local()
+        self.assertEqual(local_output.dtype, torch.bfloat16)
+        self.assertEqual(local_output.grad_dtype, torch.float32)
+
+        grad_value = 1.0 + 2.0**-8
+        self.assertNotEqual(
+            torch.tensor(grad_value, dtype=torch.bfloat16).float().item(), grad_value
+        )
+        grad = torch.full_like(local_output, grad_value, dtype=torch.float32)
+        local_output.backward(grad)
+
+        self.assertEqual(local_tensor.grad.dtype, torch.float32)
+        self.assertEqual(local_tensor.grad, grad)
+
+    @with_comms
     def test_meta_dtensor(self):
         device_mesh = self.build_device_mesh()
         dist_specs = [[Shard(0)], [Replicate()]]

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -115,7 +115,10 @@ class _ToTorchTensor(torch.autograd.Function):
         # We need to return a fresh Tensor object there as autograd metadata
         # will be inplaced into it. So we don't want to pollute the Tensor
         # object stored in the _local_tensor of this DTensor.
-        return local_tensor.view_as(local_tensor)
+        output = local_tensor.view_as(local_tensor)
+        if input.requires_grad:
+            ctx.set_output_grad_dtype(input.grad_dtype)
+        return output
 
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor | None):  # type: ignore[override]
@@ -292,6 +295,8 @@ class _FromTorchTensor(torch.autograd.Function):
             # pyrefly: ignore [unexpected-keyword]
             requires_grad=input.requires_grad,
         )
+        if input.requires_grad:
+            ctx.set_output_grad_dtype(input.grad_dtype)
         return dist_tensor
 
     @staticmethod


### PR DESCRIPTION
## Description

This PR builds on the new grad_dtype API introduced in #189633 and reimplements grad_dtype propagation across DTensor's to_local() and from_local() conversions.  For additional background, see #173990 and #174007.

**Key Changes:**
Propagated grad_dtype in DTensor operations: Updated to_local and from_local. 

**Example:**
Here is an example demonstrating this in an FSDP + EP scenario:
**AS IS:**
```text
W(dtensor) ---> (to_local) ---> W(tensor) -------> (gmm) --------> Y
dtype=bf16                      dtype=bf16                    dtype=bf16
grad_dtype=fp32

(leaf node)                     (non-leaf)                       
                                                                   
dW(dtensor) <--(to_local_bwd)-- dW(tensor) <------(gmmbwd) <------ dY
dtype=fp32                      dtype=bf16      with fp32 out   dtype=bf16
      ^                               ^                         
      |____[upcast to fp32]          |____[downcast to bf16] (align to W dtype)
```
**TO BE:**
Since grad_dtype is passed through to_local, backward gradients are no longer downcasted
```text
W(dtensor) ---> (to_local) ---> W(tensor) -------> (gmm) --------> Y
dtype=bf16                      dtype=bf16                    dtype=bf16
grad_dtype=fp32                 grad_dtype=fp32

(leaf node)                     (non-leaf)                       
                                                                   
dW(dtensor) <--(to_local_bwd)-- dW(tensor) <------(gmmbwd) <------ dY
dtype=fp32                      dtype=fp32      with fp32 out   dtype=bf16
                                      ^                         
                                      |____[no cast] (align to W grad_dtype)
```

> **AI disclosure:** The quoted PR title and description below were drafted
> with Codex, an AI coding assistant, and reviewed by the author.
>
> ## Summary
>
> The [`grad_dtype` RFC](https://github.com/pytorch/pytorch/issues/189633)
> introduces an autograd contract that lets gradients use a dtype independent
> of a tensor's storage dtype. DTensor's `from_local()` and `to_local()`
> conversions are autograd boundaries, so their outputs otherwise fall back to
> the storage dtype and lose a wider input `grad_dtype`.
>
> Propagate the input's effective `grad_dtype` to each differentiable conversion
> output with `ctx.set_output_grad_dtype(input.grad_dtype)`. The propagation is
> guarded by `input.requires_grad`, leaving non-differentiable inputs unchanged.
>
> Add a round-trip regression test using BF16 storage and FP32 gradients. The
> test checks both public `grad_dtype` values and verifies that an FP32 gradient
> value that is not exactly representable in BF16 reaches the original local
> tensor without truncation.
>
> ## Test plan
>
> Built a CPU and distributed configuration on the remote compilation host:
>
> ```bash
> USE_CUDA=0 USE_ROCM=0 USE_XPU=0 USE_NUMA=0 USE_DISTRIBUTED=1 USE_NCCL=0 USE_MPI=0 USE_TENSORPIPE=0 USE_FBGEMM=0 MAX_JOBS=64 python -m pip install -e . -v --no-build-isolation
> ```
>
> Ran the new DTensor test on four ranks:
>
> ```bash
> python test/distributed/tensor/test_dtensor.py DTensorTest.test_from_local_to_local_grad_dtype
> ```
>
> Ran the existing local-conversion regression coverage:
>
> ```bash
> python test/distributed/tensor/test_dtensor.py DTensorTest.test_from_local DTensorTest.test_from_local_backward DTensorTest.test_to_local DTensorTest.test_to_local_grad_hint DTensorTest.test_to_local_from_local_backward DTensorTest.test_from_local_then_to_local
> ```
>
> Ran the generated LocalTensor variant:
>
> ```bash
> python test/distributed/tensor/test_dtensor.py DTensorTestWithLocalTensor.test_from_local_to_local_grad_dtype
> ```
>
> Ran the integer-input regression path on eight ranks to verify the
> `requires_grad` guard:
>
> ```bash
> python test/distributed/tensor/test_dtensor.py DTensorMeshTest.test_vmap_embedding
> ```
