### PR TITLE
Set clang-format Standard to c++20

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -99,7 +99,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        c++17
+Standard:        c++20
 StatementMacros:
   - C10_DEFINE_bool
   - C10_DEFINE_int

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -294,7 +294,7 @@ struct MHAParams {
 namespace {
 
 template <typename T>
-concept HasSetAlignment = requires(T & attributes, int64_t alignment) {
+concept HasSetAlignment = requires(T& attributes, int64_t alignment) {
   attributes.set_alignment(alignment);
 };
 

--- a/torch/csrc/utils/pyobject_preservation.h
+++ b/torch/csrc/utils/pyobject_preservation.h
@@ -15,9 +15,7 @@ class PyObjectPreservation {
   // Store a PyObject wrapper on a fresh c10 wrapper. The caller must hold
   // a unique reference to `target`.
   template <typename T>
-  requires requires(T& t) {
-    t.pyobj_slot();
-  }
+    requires requires(T& t) { t.pyobj_slot(); }
   static void init_fresh_nonatomic(T& target, PyObject* pyobj) {
     auto* slot = target.pyobj_slot();
     TORCH_INTERNAL_ASSERT(slot->load_pyobj() == nullptr);
@@ -40,9 +38,7 @@ class PyObjectPreservation {
   // if another thread races and wins, the factory's result is destroyed and
   // the winner's wrapper is returned instead.
   template <typename T, typename Factory>
-  requires requires(T& t) {
-    t.pyobj_slot();
-  }
+    requires requires(T& t) { t.pyobj_slot(); }
   static PyObject* get_or_init(T& target, Factory&& pyobj_factory) {
     auto* slot = target.pyobj_slot();
     PyObject* obj = slot->load_pyobj();


### PR DESCRIPTION
`CMakeLists.txt` sets `CMAKE_CXX_STANDARD 20`, but `.clang-format` still
declared `Standard: c++17`, so clang-format parsed concepts as pre-C++20
tokens. In `MHA.cpp` that formatted a reference parameter as what reads like a
binary and:

```cpp
concept HasSetAlignment = requires(T & attributes, int64_t alignment) {
```

It also mis-indents any `requires` clause, gluing the `&&` of a fold to its
operand.

Only two files reformat as a result; both are included here.

Authored with an AI assistant.
