### PR TITLE
Address FlyDSL topk review follow-ups

### DIFF
--- a/test/python_native/test_topk_flydsl.py
+++ b/test/python_native/test_topk_flydsl.py
@@ -4,7 +4,11 @@ import unittest
 
 import torch
 import torch.backends.python_native as pn
-from torch._native.ops.topk.flydsl_impl import _REGISTER_KS as _impl_register_ks
+from torch._native import flydsl_utils as fu
+from torch._native.ops.topk.flydsl_impl import (
+    _REGISTER_KS as _impl_register_ks,
+    _SUPPORTED_ARCHES,
+)
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
@@ -28,8 +32,6 @@ def _unsupported_environment_reason() -> str | None:
     if not TEST_CUDA or torch.version.hip is None:
         return "ROCm required"
 
-    from torch._native import flydsl_utils as fu
-
     if fu.check_native_jit_disabled():
         return "native DSL overrides are disabled via TORCH_DISABLE_NATIVE_JIT"
     if not fu.runtime_available():
@@ -37,9 +39,7 @@ def _unsupported_environment_reason() -> str | None:
     if not fu._version_is_ok():
         return f"FlyDSL {fu.runtime_version()} is outside the supported release"
 
-    from torch._native.ops.topk.flydsl_impl import _is_supported_arch
-
-    if not _is_supported_arch(torch.cuda.current_device()):
+    if not fu._is_supported_arch(torch.cuda.current_device(), _SUPPORTED_ARCHES):
         return "FlyDSL TopK override requires gfx950"
     return None
 
@@ -108,9 +108,7 @@ class TestFlyDSLTopKGates(TestCase):
     def test_int32_buffer_span(
         self, rows_m: int, n: int, itemsize: int, expected: bool
     ):
-        from torch._native.ops.topk.flydsl_impl import _fits_int32_buffer_span
-
-        self.assertEqual(_fits_int32_buffer_span(rows_m, n, itemsize), expected)
+        self.assertEqual(fu._fits_int32_buffer_span(rows_m, n, itemsize), expected)
 
 
 @unittest.skipIf(_UNSUPPORTED_REASON is not None, str(_UNSUPPORTED_REASON))
@@ -156,6 +154,14 @@ class TestFlyDSLTopK(TestCase):
         x = make_tensor((_test_m(), _test_n(k)), device="cuda", dtype=torch.float32)
         self._assert_topk_matches_aten(x, k)
 
+    def test_register_correctness_with_odd_rows(self):
+        k = 8
+        rows = _test_m()
+        if rows % 2 == 0:
+            rows += 1
+        x = make_tensor((rows, _test_n(k)), device="cuda", dtype=torch.float32)
+        self._assert_topk_matches_aten(x, k)
+
     @parametrize("k", (8, 64, 257, 704, 1023))
     def test_correctness_with_duplicates(self, k: int):
         torch.manual_seed(1)
@@ -176,7 +182,7 @@ class TestFlyDSLTopK(TestCase):
         self._assert_topk_matches_aten(x, k)
 
     @parametrize("k", (8, 512))
-    def test_correctness_with_nan(self, k: int):
+    def test_nan_count_and_finite_subsequence_match_aten(self, k: int):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
         torch.manual_seed(10)
@@ -196,6 +202,8 @@ class TestFlyDSLTopK(TestCase):
         self.assertEqual(topk_cache_info(_expected_kernel(k, n)).misses, 1)
         gathered = torch.gather(x, -1, got_i)
         self.assertEqual(gathered.view(torch.int32), got_v.view(torch.int32))
+        # NaN ordinals are canonicalized, so payload and index choices may
+        # differ while the NaN count and finite subsequence still match aten.
         self.assertEqual(got_v.isnan().sum(dim=-1), ref_v.isnan().sum(dim=-1))
         ref_finite = ref_v.masked_select(~ref_v.isnan()).reshape(m, -1)
         got_finite = got_v.masked_select(~got_v.isnan()).reshape(m, -1)
@@ -361,7 +369,7 @@ class TestFlyDSLTopK(TestCase):
         self.assertEqual(torch.gather(x, -1, got_i), got_v)
 
     @parametrize("k", (64, 257, 704, 1023))
-    def test_deterministic_mode_matches_aten_with_heavy_ties(self, k: int):
+    def test_deterministic_radix_matches_aten_with_heavy_ties(self, k: int):
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
         torch.manual_seed(6)
@@ -450,10 +458,9 @@ class TestFlyDSLTopK(TestCase):
     )
     @parametrize("k", (8, 704))
     def test_each_device_gets_its_own_specialization(self, k: int):
-        from torch._native.ops.topk.flydsl_impl import _is_supported_arch
         from torch._native.ops.topk.flydsl_kernels import topk_cache_info
 
-        if not all(_is_supported_arch(index) for index in (0, 1)):
+        if not all(fu._is_supported_arch(index, _SUPPORTED_ARCHES) for index in (0, 1)):
             self.skipTest("requires two gfx950 devices")
 
         old_device = torch.cuda.current_device()

--- a/torch/_native/ops/topk/flydsl_impl.py
+++ b/torch/_native/ops/topk/flydsl_impl.py
@@ -8,15 +8,17 @@ Two kernels, picked by (K, N) - see ``flydsl_kernels.py``:
     ``torch.use_deterministic_algorithms``; only the gather invariant is
     checked against aten, not the tie order.
   * radix: (K, N) in a row of ``_RADIX_GATE_RANGES``, K padded up to a
-    power of 2 for the bitonic network. Deterministic mode gathers in
-    input order and matches aten on values and indices; otherwise indices
-    on threshold ties vary across runs.
+    power of 2 for the bitonic network. For finite inputs, deterministic
+    mode gathers in input order and matches aten on values and indices;
+    otherwise indices on threshold ties vary across runs. All NaNs share
+    one ordinal, so distinct NaN payload/index choices can differ from aten.
 
 ``_cond`` also requires fp32 on ``_SUPPORTED_ARCHES``, largest+sorted, a
-contiguous last-axis reduction, one CU-wave of rows, and ``M * N *
-itemsize`` inside the 32-bit span an AMD buffer descriptor addresses. The
-N bounds are closed intervals - both kernels lose to aten again at large
-N; anything outside falls through.
+contiguous last-axis reduction, one CU-wave of rows, and the input
+(``M * N * itemsize``) plus indices output (``M * K * 8``) buffers inside
+the 32-bit span an AMD buffer descriptor addresses. The N bounds are closed
+intervals - both kernels lose to aten again at large N; anything outside
+falls through.
 
 ``self`` is read through ``ConstTensorWrapper`` so a COW input dispatches
 without materialising; ``out=`` is written, so ``_out_cond`` declines COW.
@@ -37,20 +39,27 @@ from ._common import (
 )
 
 
-_RUNTIME_AVAILABLE: bool = fu.runtime_available()
 _SUPPORTED_ARCHES = ("gfx950",)
 _REGISTER_KS: frozenset[int] = frozenset({2, 4, 8, 16})
 
 # One (min, max) N range shared by every K in _REGISTER_KS, tuned on MI355.
 _REGISTER_N_BOUNDS: tuple[int, int] = (1024, 8192)
 
-# Per-K-range (min, max) N ranges tuned on MI355.
+# Per-K-range (min, max) N ranges tuned on MI355.  Each row keeps
+# ``2 * K <= N`` so ``M * K * 8 <= M * N * 4`` whenever the input fits the
+# 32-bit buffer span.
 _RADIX_GATE_RANGES = (
     ((64, 256), (8192, 32768)),
     ((257, 383), (16384, 32768)),
     ((384, 831), (32768, 131072)),
     ((832, 1024), (32768, 262144)),
 )
+
+
+def _fits_topk_buffer_span(rows_m: int, n: int, k: int, itemsize: int) -> bool:
+    if not fu._fits_int32_buffer_span(rows_m, n, itemsize):
+        return False
+    return rows_m * k * 8 <= (1 << 32) - 1
 
 
 def _is_pow2(x: int) -> bool:
@@ -75,22 +84,6 @@ def _kernel_for(k: int, n: int) -> str | None:
 
 
 @functools.cache
-def _is_supported_arch(device_index: int) -> bool:
-    arch = fu._resolve_rocm_arch(device_index)
-    return arch is not None and arch.split(":", 1)[0] in _SUPPORTED_ARCHES
-
-
-def _fits_int32_buffer_span(rows_m: int, n: int, itemsize: int) -> bool:
-    int32_max = (1 << 31) - 1
-    buffer_bytes_max = (1 << 32) - 1
-    return (
-        0 < rows_m <= int32_max
-        and 0 < n <= int32_max
-        and rows_m * n * itemsize <= buffer_bytes_max
-    )
-
-
-@functools.cache
 def _min_rows_for_full_wave(device_idx: int) -> int:
     return torch.cuda.get_device_properties(device_idx).multi_processor_count
 
@@ -98,14 +91,12 @@ def _min_rows_for_full_wave(device_idx: int) -> int:
 def _eligible(
     self: torch.Tensor, k: int, dim: int, largest: bool, sorted_: bool
 ) -> bool:
-    if not _RUNTIME_AVAILABLE:
-        return False
-    if torch.version.hip is None:
-        return False
     if not self.is_cuda or self.dtype != torch.float32:
         return False
     device_index = self.device.index
-    if device_index is None or not _is_supported_arch(device_index):
+    if device_index is None or not fu._is_supported_arch(
+        device_index, _SUPPORTED_ARCHES
+    ):
         return False
     if not largest or not sorted_:
         return False
@@ -115,7 +106,7 @@ def _eligible(
         return False
     N = self.shape[-1] if self.ndim >= 1 else 0
     M = self.numel() // N if N else 0
-    if not _fits_int32_buffer_span(M, N, self.element_size()):
+    if not _fits_topk_buffer_span(M, N, k, self.element_size()):
         return False
     if M < _min_rows_for_full_wave(device_index):
         return False
@@ -174,8 +165,6 @@ def _run(self: torch.Tensor, k: int) -> tuple[torch.Tensor, torch.Tensor]:
 def _flatten_topk_out(out: torch.Tensor, k: int) -> torch.Tensor:
     if out.ndim == 2:
         return out
-    if out.ndim == 1:
-        return out.view(1, k)
     return out.view(-1, k)
 
 

--- a/torch/_native/ops/topk/flydsl_kernels.py
+++ b/torch/_native/ops/topk/flydsl_kernels.py
@@ -10,8 +10,9 @@ phase 1 zero the 256 histogram bins one per thread).
      preserve input order, lowest-index ties win. Otherwise LDS atomic
      counters claim slots and ties resolve per run.
   3. Bitonic sort over ``sort_len`` slots; padding carries ordinal
-     INT32_MIN, which no float maps to. Comparator is lex
-     ``(ord desc, idx asc)`` when deterministic, ord-only otherwise.
+     INT32_MIN, which no float maps to. Comparator is always lexicographic
+     ``(ord desc, idx asc)``; ``deterministic`` only controls which
+     threshold-tied elements phase 2 gathers.
   4. Write K (value, index) pairs.
 
 ``topk_register`` - one wave per row. Each lane bitonic-sorts its
@@ -22,8 +23,9 @@ hit gmem.
 ``_f32_to_ord`` leaves positives alone and inverts all but the sign bit of
 negatives, so ordinals compare as signed i32 in float order; NaN
 canonicalises to INT32_MAX. Not injective on NaN, so ``decode_key``
-re-reads gmem for that case. Phase 1's xor by ``_RADIX_SIGN_BIT`` is
-separate: it puts the top byte in unsigned bin order for the scan.
+re-reads gmem for that case, but exact aten NaN payload/index selection is
+not guaranteed. Phase 1's xor by ``_RADIX_SIGN_BIT`` is separate: it puts
+the top byte in unsigned bin order for the scan.
 
 ``_make_topk_storage`` unions ``s_hist``, the phase-2 counters, ``s_scan``
 and ``s_keys`` - they alias, each live only within its phase. Anything
@@ -97,7 +99,7 @@ def _make_topk_storage(sort_len: int, block_threads: int):
 
     @fx.union
     class PhaseStorage:
-        s_hist: Array[Int32, 256, 16]
+        s_hist: Array[Int32, _N_HIST_BINS, 16]
         s_counters: CounterStorage
         s_scan: Array[Int32, block_threads + 1, 16]
         s_keys: Array[Int64, sort_len, 16]
@@ -162,7 +164,7 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool, arch: s
         s_idxs = storage.s_idxs.peek().view(fx.make_layout(sort_len, 1))
 
         def load_vec_f32(idx):
-            r = fx.make_rmem_tensor(4, Float32)
+            r = fx.make_rmem_tensor(_VEC, Float32)
             fx.copy_atom_call(copy_atom_v, fx.slice(input_div, (None, idx)), r)
             return fx.memref_load_vec(r)
 
@@ -476,7 +478,10 @@ def _build_register_topk_module(n: int, k: int, arch: str, rows_per_cta: int = 2
     # power of two, with threads_per_row = 32 or 64.
     group = max(k, _VEC)
     if vec % group or group % _VEC:
-        raise AssertionError(f"vec={vec} and group={group} must divide by _VEC")
+        raise AssertionError(
+            f"group={group} must divide vec={vec}, and "
+            f"_VEC={_VEC} must divide group={group}"
+        )
     group_loads = group // _VEC
     num_groups = vec // group
     num_stages_group = int(math.log2(group))

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5513,6 +5513,13 @@ def sample_inputs_topk(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(get_tensor_input(()), 1, 0, True, True)
     yield SampleInput(get_tensor_input(()), 1, -1, True, True)
 
+
+def _make_dsl_topk_arg(shape, *, device, dtype):
+    # Generic tests compare indices exactly; tie behavior has dedicated tests.
+    values = torch.randperm(math.prod(shape), dtype=torch.int64, device=device)
+    return values.reshape(shape).to(dtype)
+
+
 def sample_inputs_cutedsl_topk(op_info, device, dtype, requires_grad, **kwargs):
     """Samples for the CuTeDSL ``topk`` override.
 
@@ -5527,10 +5534,7 @@ def sample_inputs_cutedsl_topk(op_info, device, dtype, requires_grad, **kwargs):
         _REGISTER_N_RANGE,
     )
 
-    def make_arg(shape):
-        # Generic tests compare indices exactly; tie behavior has dedicated tests.
-        values = torch.randperm(math.prod(shape), dtype=torch.int64, device=device)
-        return values.reshape(shape).to(dtype)
+    make_arg = partial(_make_dsl_topk_arg, device=device, dtype=dtype)
 
     # M=256 is >= typical GPU SM count so the cond's SM-wave gate passes.
     for K in (64, 128, 256, 512, 1024):
@@ -5548,9 +5552,7 @@ def sample_inputs_cutedsl_topk(op_info, device, dtype, requires_grad, **kwargs):
 def sample_inputs_flydsl_topk(op_info, device, dtype, requires_grad, **kwargs):
     from torch._native.ops.topk.flydsl_impl import _radix_n_range, _REGISTER_N_BOUNDS
 
-    def make_arg(shape):
-        values = torch.randperm(math.prod(shape), dtype=torch.int64, device=device)
-        return values.reshape(shape).to(dtype)
+    make_arg = partial(_make_dsl_topk_arg, device=device, dtype=dtype)
 
     # M=256 covers the gfx950 occupancy gate.
     for K in (64, 256, 257, 383, 384, 831, 832, 1024):
@@ -5583,6 +5585,44 @@ def _topk_method_deterministic(self, *args, **kwargs):
         return self.topk(*args, **kwargs)
     finally:
         torch.use_deterministic_algorithms(prior)
+
+
+def _topk_dsl_skips(availability_decorator):
+    return (
+        DecorateInfo(
+            skipCUDAIf(not torch.cuda.is_available(), "CUDA not available")
+        ),
+        DecorateInfo(availability_decorator),
+        DecorateInfo(
+            unittest.skip("topk override requires contiguous input"),
+            "TestCommon",
+            "test_noncontiguous_samples",
+        ),
+        DecorateInfo(
+            unittest.skip("Sample generator allocates on the primary CUDA device"),
+            "TestCommon",
+            "test_multiple_devices",
+        ),
+        # These are deterministic OpInfo assertion failures, not crashes.
+        # Keep them as xfails so an XPASS signals that coverage can be restored.
+        DecorateInfo(unittest.expectedFailure, "TestCommon", "test_dtypes"),
+        DecorateInfo(
+            unittest.skip("topk override incompatible with FakeTensor"),
+            "TestFakeTensor",
+        ),
+        DecorateInfo(
+            unittest.skip("topk override not introspectable for tag inference"),
+            "TestTags",
+        ),
+        DecorateInfo(
+            unittest.skip(
+                "topk override not introspectable for conjugate/negate views"
+            ),
+            "TestMathBits",
+        ),
+        DecorateInfo(unittest.expectedFailure, "TestCommon", "test_out"),
+        DecorateInfo(unittest.expectedFailure, "TestCommon", "test_out_warning"),
+    )
 
 
 def reference_topk(a, k, dim=-1, largest=True, sorted=True):
@@ -23005,26 +23045,7 @@ if "cutedsl" in dsl_ops_by_dsl:
     # falls through to aten. Two variants exercise both kernel paths:
     # default (atomic gather, ord-only sort) and deterministic
     # (prefix-sum gather, lex (ord, -idx) sort).
-    _cutedsl_topk_skips = (
-        DecorateInfo(skipCUDAIf(not torch.cuda.is_available(), "CUDA not available")),
-        DecorateInfo(skipIfNoCuteDSL),
-        DecorateInfo(unittest.skip("topk override requires contiguous input"),
-                     "TestCommon", "test_noncontiguous_samples"),
-        DecorateInfo(unittest.skip("Sample generator allocates on the primary CUDA device"),
-                     "TestCommon", "test_multiple_devices"),
-        DecorateInfo(unittest.skip("torch.topk supports more dtypes than the DSL override"),
-                     "TestCommon", "test_dtypes"),
-        DecorateInfo(unittest.skip("topk override incompatible with FakeTensor"),
-                     "TestFakeTensor"),
-        DecorateInfo(unittest.skip("topk override not introspectable for tag inference"),
-                     "TestTags"),
-        DecorateInfo(unittest.skip("topk override not introspectable for conjugate/negate views"),
-                     "TestMathBits"),
-        DecorateInfo(unittest.skip("torch.topk supports out= even though the DSL OpInfo does not exercise it"),
-                     "TestCommon", "test_out"),
-        DecorateInfo(unittest.skip("torch.topk supports out= even though the DSL OpInfo does not exercise it"),
-                     "TestCommon", "test_out_warning"),
-    )
+    _cutedsl_topk_skips = _topk_dsl_skips(skipIfNoCuteDSL)
     _cutedsl_topk_kwargs = dict(
         dtypes=_dispatch_dtypes((torch.float32,)),
         dtypesIfCUDA=_dispatch_dtypes((torch.float32,)),
@@ -23060,11 +23081,9 @@ if "cutedsl" in dsl_ops_by_dsl:
     ])
 
 if "flydsl" in dsl_ops_by_dsl:
-    from torch._native.flydsl_utils import (
-        _is_supported_arch as _is_flydsl_supported_arch,
-    )
+    from torch._native import flydsl_utils as _flydsl_utils
     from torch._native.ops.norm.flydsl_rmsnorm_impl import (
-        _SUPPORTED_ARCHES as _FLYDSL_RMSNORM_ARCHES,
+        _SUPPORTED_ARCHES as _flydsl_rmsnorm_supported_arches,
     )
 
     dsl_ops_by_dsl["flydsl"].append(
@@ -23085,8 +23104,9 @@ if "flydsl" in dsl_ops_by_dsl:
                 skipCUDAIf(
                     not (
                         TEST_CUDA
-                        and _is_flydsl_supported_arch(
-                            torch.cuda.current_device(), _FLYDSL_RMSNORM_ARCHES
+                        and _flydsl_utils._is_supported_arch(
+                            torch.cuda.current_device(),
+                            _flydsl_rmsnorm_supported_arches,
                         )
                     ),
                     "flydsl rms_norm override requires gfx950",
@@ -23106,28 +23126,10 @@ if "flydsl" in dsl_ops_by_dsl:
     )
 
     from torch._native.ops.topk.flydsl_impl import (
-        _is_supported_arch as _is_flydsl_topk_supported_arch,
+        _SUPPORTED_ARCHES as _flydsl_topk_supported_arches,
     )
 
-    _flydsl_topk_skips = (
-        DecorateInfo(skipCUDAIf(not torch.cuda.is_available(), "CUDA not available")),
-        DecorateInfo(unittest.skip("topk override requires contiguous input"),
-                     "TestCommon", "test_noncontiguous_samples"),
-        DecorateInfo(unittest.skip("Sample generator allocates on the primary CUDA device"),
-                     "TestCommon", "test_multiple_devices"),
-        DecorateInfo(unittest.skip("torch.topk supports more dtypes than the DSL override"),
-                     "TestCommon", "test_dtypes"),
-        DecorateInfo(unittest.skip("topk override incompatible with FakeTensor"),
-                     "TestFakeTensor"),
-        DecorateInfo(unittest.skip("topk override not introspectable for tag inference"),
-                     "TestTags"),
-        DecorateInfo(unittest.skip("topk override not introspectable for conjugate/negate views"),
-                     "TestMathBits"),
-        DecorateInfo(unittest.skip("torch.topk supports out= even though the DSL OpInfo does not exercise it"),
-                     "TestCommon", "test_out"),
-        DecorateInfo(unittest.skip("torch.topk supports out= even though the DSL OpInfo does not exercise it"),
-                     "TestCommon", "test_out_warning"),
-    )
+    _flydsl_topk_skips = _topk_dsl_skips(skipIfNoFlyDSL)
     _flydsl_topk_kwargs = dict(
         dtypes=_dispatch_dtypes((torch.float32,)),
         dtypesIfCUDA=_dispatch_dtypes((torch.float32,)),
@@ -23139,13 +23141,13 @@ if "flydsl" in dsl_ops_by_dsl:
         supports_out=False,
         decorators=[
             DecorateInfo(onlyCUDA),
-            DecorateInfo(skipIfNoFlyDSL),
             DecorateInfo(
                 skipCUDAIf(
                     not (
                         torch.cuda.is_available()
-                        and _is_flydsl_topk_supported_arch(
-                            torch.cuda.current_device()
+                        and _flydsl_utils._is_supported_arch(
+                            torch.cuda.current_device(),
+                            _flydsl_topk_supported_arches,
                         )
                     ),
                     "flydsl topk override requires gfx950",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #193548
* #191447
* __->__ #194175

Reuse shared flydsl_utils predicates, gate dispatch on both input and
indices buffer spans, and tighten OpInfo skips for DSL topk coverage.
Also add an odd-row register correctness test and clarify NaN/tie test
intent.

Test Plan:
```
PATH=/tmp/lintvenv2/bin:$PATH lintrunner -a test/python_native/test_topk_flydsl.py torch/_native/ops/topk/flydsl_impl.py torch/_native/ops/topk/flydsl_kernels.py torch/testing/_internal/common_methods_invocations.py
```

Authored with assistance from an AI coding assistant.

Co-authored-by: Cursor <cursoragent@cursor.com>