### PR TITLE
Key sparse Triton tuning tables by the current accelerator

### DIFF
--- a/benchmarks/sparse/triton_ops.py
+++ b/benchmarks/sparse/triton_ops.py
@@ -225,7 +225,9 @@ if __name__ == "__main__":
         bm = bm_list[0]
         bk = bk_list[0] or bm
         if "bsr_scatter_mm6" in ops:
-            meta = torch.sparse._triton_ops.scatter_mm_meta(m, k, n, bm, bk)
+            meta = torch.sparse._triton_ops.scatter_mm_meta(
+                m, k, n, bm, bk, device=args.device
+            )
         elif "bsr_dense_mm_with_meta" in ops:
             meta = torch.sparse._triton_ops.bsr_dense_mm_meta(m, k, n, bm, bk)
         else:

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -6,10 +6,10 @@ import io
 import itertools
 import operator
 import random
-import subprocess
-import sys
+import types
 import unittest
 from contextlib import redirect_stderr
+from unittest.mock import patch
 
 import torch
 from torch.testing import FileCheck, make_tensor
@@ -4395,77 +4395,58 @@ class TestSparseCompressedTritonKernels(TestCase):
                          dict(GROUP_SIZE_ROW=4, SPLIT_N=4, num_stages=1, num_warps=4))
 
 
-# Renaming PrivateUse1 is process-global and one-shot, and it makes
-# torch.accelerator.current_accelerator() report a backend that has no
-# torch.<name> module, which torch.get_device_module() and
-# torch.accelerator.is_available() both raise for. Deriving a tuning cache key
-# must not: a miss is meant to fall back to the reference parameters below.
-_UNREGISTERED_BACKEND_SCRIPT = """\
-import torch
-from torch.sparse._triton_ops import bsr_dense_addmm_meta
-from torch.sparse._triton_ops_meta import _get_device_name
-
-torch.utils.rename_privateuse1_backend("tuningkeytestbackend")
-print(repr(_get_device_name()))
-print(bsr_dense_addmm_meta(256, 256, 256, 16, 16, 0, 1))
-"""
-
-
 class TestSparseTritonMetaDeviceName(TestCase):
     """_get_device_name supplies the device component of the key under which
     _operation_device_version_data stores tuned Triton parameters. It sits on the
-    miss path of an optimization lookup, so it must be total, and it must key on
-    the device the inputs are on rather than on whatever the process configured."""
+    miss path of an optimization lookup, so it must never raise, and it must key on
+    the device the inputs are on so that a lookup finds what a tuning run stored."""
 
     hw_classification = HardwareClassification.GENERIC
 
+    def _device_module(self, **attrs):
+        # privateuseone stands in for an accelerator that is neither cuda nor xpu.
+        # Patching the attribute avoids torch.utils.rename_privateuse1_backend,
+        # which is process-global and can only be called once.
+        return patch.object(
+            torch, "privateuseone", types.SimpleNamespace(**attrs), create=True
+        )
+
     def test_device_module_without_get_device_name_is_unnamed(self):
-        # torch.cpu, torch.mps and torch.mtia are all in this position.
         from torch.sparse._triton_ops_meta import _get_device_name
 
+        with self._device_module(is_available=lambda: True):
+            self.assertEqual(_get_device_name("privateuseone"), "")
+        # torch.cpu, torch.mps and torch.mtia are in the same position today.
         self.assertEqual(_get_device_name("cpu"), "")
 
-    def test_no_accelerator_is_unnamed(self):
+    def test_no_cuda_or_xpu_is_unnamed(self):
         from torch.sparse._triton_ops_meta import _get_device_name
 
-        with unittest.mock.patch.object(
-            torch.accelerator, "current_accelerator", lambda check_available=False: None
+        with patch.object(torch.cuda, "is_available", lambda: False), patch.object(
+            torch.xpu, "is_available", lambda: False
         ):
             self.assertEqual(_get_device_name(), "")
-            # What the tuning entry points pass when there is no accelerator.
-            self.assertEqual(_get_device_name(""), "")
 
-    def test_explicit_device_is_used_instead_of_the_accelerator(self):
+    def test_explicit_device_is_used_instead_of_the_default(self):
         from torch.sparse._triton_ops_meta import _get_device_name
 
-        with unittest.mock.patch.object(
-            torch.cpu, "get_device_name", create=True,
-            new=lambda device: f"Fake device {device}"
-        ):
-            self.assertEqual(_get_device_name("cpu"), "Fake device cpu")
-            self.assertEqual(_get_device_name(torch.device("cpu")), "Fake device cpu")
-
-    @skipIfTorchDynamo("spawns a subprocess")
-    @unittest.skipIf(IS_FBCODE, "spawns a subprocess")
-    def test_accelerator_without_a_device_module_is_unnamed(self):
-        out = subprocess.check_output(
-            [sys.executable, "-c", _UNREGISTERED_BACKEND_SCRIPT],
-            stderr=subprocess.DEVNULL,
-        ).decode("ascii").strip().splitlines()
-        self.assertEqual(
-            out,
-            ["''", "{'SPLIT_N': 16, 'GROUP_SIZE_ROW': 4, 'num_stages': 1, 'num_warps': 4}"]
-        )
+        with self._device_module(get_device_name=lambda device: f"Fake {device}"):
+            self.assertEqual(_get_device_name("privateuseone"), "Fake privateuseone")
+            self.assertEqual(
+                _get_device_name(torch.device("privateuseone")), "Fake privateuseone"
+            )
+            self.assertNotEqual(_get_device_name(), "Fake privateuseone")
 
     def test_tuned_parameters_are_found_through_the_input_device(self):
         # Round trip: what update() stores under a device's name must be found
-        # again by a lookup that only knows the input tensor's device. Nothing
-        # here needs an accelerator, or a second one.
+        # again by a lookup that only knows the input tensor's device. Needs no
+        # accelerator, and no second one.
         from torch.sparse._triton_ops import bsr_dense_addmm_meta
         from torch.sparse._triton_ops_meta import _operation_device_version_data, update
 
-        device_name = "Fake device cpu"
-        version = ("test_tuned_parameters_are_found_through_the_input_device", torch.float16, 0.5)
+        device_name = "Fake privateuseone"
+        version = ("test_tuned_parameters_are_found_through_the_input_device",
+                   torch.float16, 0.5)
         key = (256, 256, 256, 16, 16, True, False, True)
         tuned = dict(GROUP_SIZE_ROW=2, SPLIT_N=8, num_stages=3, num_warps=5)
 
@@ -4477,15 +4458,48 @@ class TestSparseTritonMetaDeviceName(TestCase):
 
         update("bsr_dense_addmm", device_name, version, key, tuple(tuned[k] for k in sorted(tuned)))
         try:
-            with unittest.mock.patch.object(
-                torch.cpu, "get_device_name", create=True, new=lambda device: device_name
-            ):
-                self.assertEqual(get_meta(device="cpu"), tuned)
-            # Without the device, the process accelerator names the key instead,
-            # and it is never this one, so the entry must not be found.
+            with self._device_module(get_device_name=lambda device: device_name):
+                self.assertEqual(get_meta(device="privateuseone"), tuned)
+            # Without the device the caller-less default names the key instead, and
+            # that is never this one, so the entry must not be found.
             self.assertNotEqual(get_meta(), tuned)
         finally:
             del _operation_device_version_data["bsr_dense_addmm", device_name, version]
+
+    def test_the_input_device_reaches_the_tuning_key(self):
+        # The device= arguments at these two call sites are the whole mechanism:
+        # without them the key comes from the caller-less default and a tuning run
+        # on any other device becomes unfindable. Nothing else in the suite
+        # exercises them, and no hardware configuration can -- the key is a device
+        # name and what differs here is the device type. The lookups are
+        # intercepted, so this needs no Triton and launches no kernel.
+        from torch.sparse import _triton_ops
+
+        class StopAtLookup(Exception):
+            pass
+
+        seen = []
+
+        def intercept(*args, device=None, **kwargs):
+            seen.append(device)
+            raise StopAtLookup
+
+        f = io.StringIO()
+        with redirect_stderr(f):
+            dense = torch.zeros(32, 16)
+            blocked = torch.zeros(32, 32)
+            blocked[:16, :16] = 1
+            bsr = blocked.to_sparse_bsr((16, 16))
+
+        with patch.object(_triton_ops, "scatter_mm_meta", intercept):
+            with self.assertRaises(StopAtLookup):
+                _triton_ops.bsr_scatter_mm_indices_data(bsr, dense)
+
+        with patch.object(_triton_ops, "bsr_dense_addmm_meta", intercept):
+            with self.assertRaises(StopAtLookup):
+                _triton_ops.bsr_dense_addmm(dense.clone(), bsr, dense)
+
+        self.assertEqual(seen, [bsr.device, bsr.device])
 
 
 # e.g., TestSparseCSRCPU and TestSparseCSRCUDA

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -6,6 +6,7 @@ import io
 import itertools
 import operator
 import random
+import types
 import unittest
 from contextlib import redirect_stderr
 
@@ -4388,6 +4389,43 @@ class TestSparseCompressedTritonKernels(TestCase):
         # ... or not:
         self.assertEqual(get_meta_with_checks(32, 32, 64, warn_count=1),
                          dict(GROUP_SIZE_ROW=4, SPLIT_N=4, num_stages=1, num_warps=4))
+
+
+class TestSparseTritonMetaDeviceName(TestCase):
+    """_get_device_name keys the Triton tuning tables, so it has to name whatever
+    accelerator is in use rather than only CUDA and XPU."""
+
+    def _patched(self, device_type, module):
+        return unittest.mock.patch.multiple(
+            torch,
+            accelerator=unittest.mock.MagicMock(
+                current_accelerator=lambda check_available=False: (
+                    None if device_type is None else torch.device(device_type)
+                )
+            ),
+            get_device_module=lambda _: module,
+        )
+
+    def test_uses_the_device_module(self):
+        from torch.sparse._triton_ops_meta import _get_device_name
+
+        module = types.SimpleNamespace(get_device_name=lambda: "Fake Accelerator")
+        with self._patched("privateuseone", module):
+            self.assertEqual(_get_device_name(), "Fake Accelerator")
+
+    def test_module_without_get_device_name_is_unnamed(self):
+        from torch.sparse._triton_ops_meta import _get_device_name
+
+        # MPS and MTIA register a device module but no get_device_name; that must
+        # key as unnamed rather than raising.
+        with self._patched("privateuseone", types.SimpleNamespace()):
+            self.assertEqual(_get_device_name(), "")
+
+    def test_no_accelerator_is_unnamed(self):
+        from torch.sparse._triton_ops_meta import _get_device_name
+
+        with self._patched(None, types.SimpleNamespace()):
+            self.assertEqual(_get_device_name(), "")
 
 
 # e.g., TestSparseCSRCPU and TestSparseCSRCUDA

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -4391,9 +4391,11 @@ class TestSparseCompressedTritonKernels(TestCase):
                          dict(GROUP_SIZE_ROW=4, SPLIT_N=4, num_stages=1, num_warps=4))
 
 
-class TestSparseTritonMetaDeviceName(TestCase):
-    """_get_device_name keys the Triton tuning tables, so it has to name whatever
-    accelerator is in use rather than only CUDA and XPU."""
+class TestSparseTritonMetaDeviceNameFallbacks(TestCase):
+    """The two cases real hardware cannot produce: a device module with no
+    get_device_name, and no accelerator at all. Both must key as unnamed."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def _patched(self, device_type, module):
         return unittest.mock.patch.multiple(
@@ -4428,10 +4430,38 @@ class TestSparseTritonMetaDeviceName(TestCase):
             self.assertEqual(_get_device_name(), "")
 
 
+class TestSparseTritonMetaDeviceName(TestCase):
+    """_get_device_name supplies the device component of the Triton tuning cache
+    key, so an accelerator that keys as unnamed silently loses its tuned
+    parameters. Instantiated per device so every backend checks its own name."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_device_name_is_the_accelerator_name(self, device):
+        from torch.sparse._triton_ops_meta import _get_device_name
+
+        device_type = torch.device(device).type
+        accelerator = torch.accelerator.current_accelerator(check_available=True)
+        if accelerator is None or accelerator.type != device_type:
+            self.skipTest(f"{device_type} is not the accelerator in use")
+
+        get_device_name = getattr(
+            torch.get_device_module(device_type), "get_device_name", None
+        )
+        if get_device_name is None:
+            self.assertEqual(_get_device_name(), "")
+        else:
+            self.assertEqual(_get_device_name(), get_device_name())
+            self.assertNotEqual(_get_device_name(), "")
+
+
 # e.g., TestSparseCSRCPU and TestSparseCSRCUDA
 instantiate_device_type_tests(TestSparseCSR, globals())
 instantiate_device_type_tests(TestSparseCompressed, globals())
 instantiate_device_type_tests(TestSparseCompressedTritonKernels, globals())
+instantiate_device_type_tests(
+    TestSparseTritonMetaDeviceName, globals(), allow_mps=True, allow_xpu=True
+)
 
 if __name__ == '__main__':
     run_tests()

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -6,7 +6,8 @@ import io
 import itertools
 import operator
 import random
-import types
+import subprocess
+import sys
 import unittest
 from contextlib import redirect_stderr
 
@@ -4268,7 +4269,8 @@ class TestSparseCompressedTritonKernels(TestCase):
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "Test requires Triton")
     def test_triton_tune(self, op, device, dtype, out_dtype):
         from torch.sparse._triton_ops import bsr_dense_addmm, _int_bsr_dense_addmm
-        from torch.sparse._triton_ops_meta import (create_blocked_tensor, tune_bsr_dense_addmm, tune__int_bsr_dense_addmm, get_meta)
+        from torch.sparse._triton_ops_meta import (create_blocked_tensor, tune_bsr_dense_addmm,
+                                                   tune__int_bsr_dense_addmm, get_meta, _get_device_name)
 
         if out_dtype == "unspecified":
             out_dtype = None
@@ -4308,7 +4310,8 @@ class TestSparseCompressedTritonKernels(TestCase):
             def get_current_meta():
                 version = (0, version_dtype, sparsity)
                 meta_key = (M, K, N, *blocksize, False, True, True)
-                return get_meta(op, meta_key, version=version, exact=True)
+                # The tuner keys on the inputs' device; read it back the same way.
+                return get_meta(op, meta_key, _get_device_name(device), version=version, exact=True)
         else:
             raise NotImplementedError(op)
 
@@ -4325,6 +4328,7 @@ class TestSparseCompressedTritonKernels(TestCase):
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "Test requires Triton")
     def test_triton_bsr_dense_addmm_meta(self, device):
         from torch.sparse._triton_ops import bsr_dense_addmm_meta
+        from torch.sparse._triton_ops_meta import _get_device_name
         from torch.sparse._triton_ops_meta import update as update_bsr_dense_addmm_meta
 
         dtype = torch.float32
@@ -4334,11 +4338,11 @@ class TestSparseCompressedTritonKernels(TestCase):
 
         def get_meta(M, K, N, sparsity=None):
             return bsr_dense_addmm_meta(M, K, N, Ms, Ks, beta, alpha, dtype=dtype, sparsity=sparsity,
-                                        _version="test_triton_bsr_dense_addmm_meta")
+                                        _version="test_triton_bsr_dense_addmm_meta", device=device)
 
         def update_meta(M, K, N, value, sparsity=0.5):
             key = (M, K, N, Ms, Ks, beta == 0, beta == 1, alpha == 1)
-            update_bsr_dense_addmm_meta("bsr_dense_addmm", torch.cuda.get_device_name(),
+            update_bsr_dense_addmm_meta("bsr_dense_addmm", _get_device_name(device),
                                         ("test_triton_bsr_dense_addmm_meta", dtype, sparsity),
                                         key, value)
 
@@ -4391,77 +4395,103 @@ class TestSparseCompressedTritonKernels(TestCase):
                          dict(GROUP_SIZE_ROW=4, SPLIT_N=4, num_stages=1, num_warps=4))
 
 
-class TestSparseTritonMetaDeviceNameFallbacks(TestCase):
-    """The two cases real hardware cannot produce: a device module with no
-    get_device_name, and no accelerator at all. Both must key as unnamed."""
+# Renaming PrivateUse1 is process-global and one-shot, and it makes
+# torch.accelerator.current_accelerator() report a backend that has no
+# torch.<name> module, which torch.get_device_module() and
+# torch.accelerator.is_available() both raise for. Deriving a tuning cache key
+# must not: a miss is meant to fall back to the reference parameters below.
+_UNREGISTERED_BACKEND_SCRIPT = """\
+import torch
+from torch.sparse._triton_ops import bsr_dense_addmm_meta
+from torch.sparse._triton_ops_meta import _get_device_name
+
+torch.utils.rename_privateuse1_backend("tuningkeytestbackend")
+print(repr(_get_device_name()))
+print(bsr_dense_addmm_meta(256, 256, 256, 16, 16, 0, 1))
+"""
+
+
+class TestSparseTritonMetaDeviceName(TestCase):
+    """_get_device_name supplies the device component of the key under which
+    _operation_device_version_data stores tuned Triton parameters. It sits on the
+    miss path of an optimization lookup, so it must be total, and it must key on
+    the device the inputs are on rather than on whatever the process configured."""
 
     hw_classification = HardwareClassification.GENERIC
 
-    def _patched(self, device_type, module):
-        return unittest.mock.patch.multiple(
-            torch,
-            accelerator=unittest.mock.MagicMock(
-                current_accelerator=lambda check_available=False: (
-                    None if device_type is None else torch.device(device_type)
-                )
-            ),
-            get_device_module=lambda _: module,
-        )
-
-    def test_uses_the_device_module(self):
+    def test_device_module_without_get_device_name_is_unnamed(self):
+        # torch.cpu, torch.mps and torch.mtia are all in this position.
         from torch.sparse._triton_ops_meta import _get_device_name
 
-        module = types.SimpleNamespace(get_device_name=lambda: "Fake Accelerator")
-        with self._patched("privateuseone", module):
-            self.assertEqual(_get_device_name(), "Fake Accelerator")
-
-    def test_module_without_get_device_name_is_unnamed(self):
-        from torch.sparse._triton_ops_meta import _get_device_name
-
-        # MPS and MTIA register a device module but no get_device_name; that must
-        # key as unnamed rather than raising.
-        with self._patched("privateuseone", types.SimpleNamespace()):
-            self.assertEqual(_get_device_name(), "")
+        self.assertEqual(_get_device_name("cpu"), "")
 
     def test_no_accelerator_is_unnamed(self):
         from torch.sparse._triton_ops_meta import _get_device_name
 
-        with self._patched(None, types.SimpleNamespace()):
+        with unittest.mock.patch.object(
+            torch.accelerator, "current_accelerator", lambda check_available=False: None
+        ):
             self.assertEqual(_get_device_name(), "")
+            # What the tuning entry points pass when there is no accelerator.
+            self.assertEqual(_get_device_name(""), "")
 
-
-class TestSparseTritonMetaDeviceName(TestCase):
-    """_get_device_name supplies the device component of the Triton tuning cache
-    key, so an accelerator that keys as unnamed silently loses its tuned
-    parameters. Instantiated per device so every backend checks its own name."""
-
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    def test_device_name_is_the_accelerator_name(self, device):
+    def test_explicit_device_is_used_instead_of_the_accelerator(self):
         from torch.sparse._triton_ops_meta import _get_device_name
 
-        device_type = torch.device(device).type
-        accelerator = torch.accelerator.current_accelerator(check_available=True)
-        if accelerator is None or accelerator.type != device_type:
-            self.skipTest(f"{device_type} is not the accelerator in use")
+        with unittest.mock.patch.object(
+            torch.cpu, "get_device_name", create=True,
+            new=lambda device: f"Fake device {device}"
+        ):
+            self.assertEqual(_get_device_name("cpu"), "Fake device cpu")
+            self.assertEqual(_get_device_name(torch.device("cpu")), "Fake device cpu")
 
-        get_device_name = getattr(
-            torch.get_device_module(device_type), "get_device_name", None
+    @skipIfTorchDynamo("spawns a subprocess")
+    @unittest.skipIf(IS_FBCODE, "spawns a subprocess")
+    def test_accelerator_without_a_device_module_is_unnamed(self):
+        out = subprocess.check_output(
+            [sys.executable, "-c", _UNREGISTERED_BACKEND_SCRIPT],
+            stderr=subprocess.DEVNULL,
+        ).decode("ascii").strip().splitlines()
+        self.assertEqual(
+            out,
+            ["''", "{'SPLIT_N': 16, 'GROUP_SIZE_ROW': 4, 'num_stages': 1, 'num_warps': 4}"]
         )
-        if get_device_name is None:
-            self.assertEqual(_get_device_name(), "")
-        else:
-            self.assertEqual(_get_device_name(), get_device_name())
-            self.assertNotEqual(_get_device_name(), "")
+
+    def test_tuned_parameters_are_found_through_the_input_device(self):
+        # Round trip: what update() stores under a device's name must be found
+        # again by a lookup that only knows the input tensor's device. Nothing
+        # here needs an accelerator, or a second one.
+        from torch.sparse._triton_ops import bsr_dense_addmm_meta
+        from torch.sparse._triton_ops_meta import _operation_device_version_data, update
+
+        device_name = "Fake device cpu"
+        version = ("test_tuned_parameters_are_found_through_the_input_device", torch.float16, 0.5)
+        key = (256, 256, 256, 16, 16, True, False, True)
+        tuned = dict(GROUP_SIZE_ROW=2, SPLIT_N=8, num_stages=3, num_warps=5)
+
+        def get_meta(**kwargs):
+            f = io.StringIO()
+            with redirect_stderr(f):
+                return bsr_dense_addmm_meta(256, 256, 256, 16, 16, 0, 1, dtype=torch.float16,
+                                            sparsity=0.5, _version=version[0], **kwargs)
+
+        update("bsr_dense_addmm", device_name, version, key, tuple(tuned[k] for k in sorted(tuned)))
+        try:
+            with unittest.mock.patch.object(
+                torch.cpu, "get_device_name", create=True, new=lambda device: device_name
+            ):
+                self.assertEqual(get_meta(device="cpu"), tuned)
+            # Without the device, the process accelerator names the key instead,
+            # and it is never this one, so the entry must not be found.
+            self.assertNotEqual(get_meta(), tuned)
+        finally:
+            del _operation_device_version_data["bsr_dense_addmm", device_name, version]
 
 
 # e.g., TestSparseCSRCPU and TestSparseCSRCUDA
 instantiate_device_type_tests(TestSparseCSR, globals())
 instantiate_device_type_tests(TestSparseCompressed, globals())
 instantiate_device_type_tests(TestSparseCompressedTritonKernels, globals())
-instantiate_device_type_tests(
-    TestSparseTritonMetaDeviceName, globals(), allow_mps=True, allow_xpu=True
-)
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/sparse/_triton_ops.py
+++ b/torch/sparse/_triton_ops.py
@@ -526,10 +526,11 @@ def scatter_mm_meta(
     SPLIT_N=None,
     num_warps=None,
     num_stages=None,
+    device=None,
     **extra,
 ):
     if {TILE_M, TILE_N, SPLIT_N, num_warps, num_stages, GROUP_SIZE} == {None}:
-        device_name = _get_device_name()
+        device_name = _get_device_name(device)
         meta = get_meta(
             "scatter_mm",
             (M, K, N, Ms, Ks),
@@ -773,6 +774,7 @@ def bsr_dense_addmm_meta(
     dtype=None,
     out_dtype=None,
     _version=0,
+    device=None,
     **extra,
 ):
     # Specifying _version is useful for situations when one wants to
@@ -785,7 +787,7 @@ def bsr_dense_addmm_meta(
     if sparsity is None:
         sparsity = 0.5
     if {SPLIT_N, num_warps, num_stages, GROUP_SIZE_ROW} == {None}:
-        device_name = _get_device_name()
+        device_name = _get_device_name(device)
         key = (M, K, N, Ms, Ks, beta == 0, beta == 1, alpha == 1)
         if dtype is out_dtype:
             version_dtype = dtype
@@ -1053,7 +1055,7 @@ def bsr_scatter_mm_indices_data(
         raise AssertionError(f"other K ({K_}) != bsr K ({K})")
     nbatches = other.shape[:-2].numel()
 
-    meta = scatter_mm_meta(M, K, N, Ms, Ks, **meta_input)
+    meta = scatter_mm_meta(M, K, N, Ms, Ks, device=bsr.device, **meta_input)
     if "allow_tf32" not in meta_input:
         meta.update(allow_tf32=bsr.dtype in {torch.float16, torch.bfloat16})
     SPLIT_N = meta["SPLIT_N"]
@@ -1276,6 +1278,7 @@ def bsr_dense_addmm(
             sparsity=sparsity,
             dtype=dense.dtype,
             out_dtype=out.dtype,
+            device=bsr.device,
         )
     out_backup = out
 

--- a/torch/sparse/_triton_ops_meta.py
+++ b/torch/sparse/_triton_ops_meta.py
@@ -111,13 +111,25 @@ from torch.hub import tqdm
 from torch.testing import make_tensor
 
 
+def _get_current_accelerator_type() -> str:
+    """Return the device type of the accelerator in use, or "" if there is none."""
+    acc = torch.accelerator.current_accelerator(check_available=True)
+    return "" if acc is None else acc.type
+
+
 def _get_device_name() -> str:
-    """Return the current accelerator device name for use as a Triton tuning cache key."""
-    if torch.cuda.is_available():
-        return torch.cuda.get_device_name()
-    if torch.xpu.is_available():
-        return torch.xpu.get_device_name()
-    return ""
+    """Return the current accelerator device name for use as a Triton tuning cache key.
+
+    Backends expose ``torch.<device_type>.get_device_name``; one that does not is
+    treated as unnamed, which is how an absent accelerator has always been keyed.
+    """
+    device_type = _get_current_accelerator_type()
+    if not device_type:
+        return ""
+    get_device_name = getattr(
+        torch.get_device_module(device_type), "get_device_name", None
+    )
+    return "" if get_device_name is None else get_device_name()
 
 
 def get_meta(op, key, device_name=None, version=(0, torch.float16, 0.5), exact=False):
@@ -486,12 +498,13 @@ def create_blocked_tensor(B, M, N, blocksize, sparsity, dtype, device):
 
 
 def optimize_scatter_mm(
-    m, k, n, bm, bk, dtype=torch.float16, device="cuda", sparsity=0.5, force=False
+    m, k, n, bm, bk, dtype=torch.float16, device=None, sparsity=0.5, force=False
 ):
     import triton
 
     from torch.sparse._triton_ops import bsr_scatter_mm, bsr_scatter_mm_indices_data
 
+    device = device or _get_current_accelerator_type()
     key = (m, k, n, bm, bk)
 
     version = (0, dtype, sparsity)
@@ -774,12 +787,13 @@ def optimize_bsr_dense_addmm(
     use_right_alpha=False,
     dtype=torch.float16,
     out_dtype=None,
-    device="cuda",
+    device=None,
     sparsity=0.5,
     force=False,
     verbose=False,
     opname=None,
 ):
+    device = device or _get_current_accelerator_type()
     torch.manual_seed(0)
     bsr = create_blocked_tensor(
         0, m, k, (bm, bk), sparsity, dtype, device
@@ -810,8 +824,10 @@ def optimize_bsr_dense_addmm(
     )
 
 
-def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True):
+def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device=None):
     import itertools
+
+    device = device or _get_current_accelerator_type()
 
     sizes_lst = [
         256,
@@ -847,7 +863,15 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True):
                     continue
                 if op == "scatter_mm":
                     optimize_scatter_mm(
-                        M, K, N, BM, BK, force=force, sparsity=sparsity, dtype=dtype
+                        M,
+                        K,
+                        N,
+                        BM,
+                        BK,
+                        force=force,
+                        sparsity=sparsity,
+                        dtype=dtype,
+                        device=device,
                     )
                 elif op in {"bsr_dense_addmm", "_int_bsr_dense_addmm"}:
                     if M == K and N == 50432:
@@ -865,6 +889,7 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True):
                             force=force,
                             sparsity=sparsity,
                             dtype=dtype,
+                            device=device,
                             verbose=verbose,
                             opname=op,
                         )
@@ -894,9 +919,9 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True):
             for sparsity1 in sparsity_lst:
                 torch.manual_seed(0)
                 bsr = create_blocked_tensor(
-                    0, M, K, (BM, BK), sparsity1, dtype, device="cuda"
+                    0, M, K, (BM, BK), sparsity1, dtype, device
                 ).to_sparse_bsr((BM, BK))
-                dense = make_tensor(K, N, dtype=dtype, device="cuda")
+                dense = make_tensor(K, N, dtype=dtype, device=device)
                 meta_lst = []
                 for sparsity in sparsity_lst:
                     meta = get_meta(op, key, version=(0, dtype, sparsity), exact=True)

--- a/torch/sparse/_triton_ops_meta.py
+++ b/torch/sparse/_triton_ops_meta.py
@@ -111,44 +111,32 @@ from torch.hub import tqdm
 from torch.testing import make_tensor
 
 
-def _get_current_accelerator_type() -> str:
-    """Return the device type of the accelerator in use, or "" if there is none.
-
-    ``torch.accelerator.current_accelerator(check_available=True)`` is not usable
-    here: its availability check goes through ``torch.get_device_module``, which
-    raises for a PrivateUse1 backend that has been renamed without registering a
-    ``torch.<name>`` module. Deriving a tuning cache key must never raise, so such
-    a backend is reported as absent instead. ``is_available()`` is still consulted,
-    because that is what the previous cuda/xpu chain used to reject a backend that
-    is built but has no usable device.
-    """
-    acc = torch.accelerator.current_accelerator()
-    if acc is None:
-        return ""
-    is_available = getattr(getattr(torch, acc.type, None), "is_available", None)
-    return acc.type if is_available is not None and is_available() else ""
-
-
 def _get_device_name(device=None) -> str:
     """Return the device name that keys the Triton tuning tables.
 
     The key is persisted data: ``dump()`` writes it into this module's source
     during an offline tuning run and a different process reads it back, so the same
-    hardware must always produce the same name and producing it must never raise --
+    device must always produce the same name and producing it must never raise --
     a lookup miss is a designed outcome of :func:`get_meta`, a failure is not.
 
-    ``device`` names the device the parameters are tuned for or looked up for; when
-    it is unspecified the accelerator in use is used instead. A backend that
-    exposes no ``torch.<device_type>.get_device_name`` is unnamed, which is how an
-    absent accelerator has always been keyed.
+    ``device`` names the device the parameters are tuned for or looked up for. When
+    it is not given, the question is which device runs sparse Triton ops for a
+    caller that did not say, which is what ``check_device`` in
+    ``torch/sparse/_triton_ops.py`` answers with a hardcoded ``("cuda", "xpu")``;
+    that has no generic equivalent today, so this is deliberately not routed
+    through the accelerator API. Doing so would also key a CUDA process that has
+    registered a PrivateUse1 backend under the wrong device, since
+    ``at::getAccelerator`` returns PrivateUse1 ahead of CUDA.
+
+    A backend that exposes no ``torch.<device_type>.get_device_name`` is unnamed.
     """
-    if device == "":
-        # The tuning entry points pass "" when there is no accelerator in use.
-        device = None
-    device_type = (
-        _get_current_accelerator_type() if device is None else torch.device(device).type
-    )
-    module = getattr(torch, device_type, None) if device_type else None
+    if device is None:
+        if torch.cuda.is_available():
+            return torch.cuda.get_device_name()
+        if torch.xpu.is_available():
+            return torch.xpu.get_device_name()
+        return ""
+    module = getattr(torch, torch.device(device).type, None)
     get_device_name = getattr(module, "get_device_name", None)
     return "" if get_device_name is None else get_device_name(device)
 
@@ -519,13 +507,12 @@ def create_blocked_tensor(B, M, N, blocksize, sparsity, dtype, device):
 
 
 def optimize_scatter_mm(
-    m, k, n, bm, bk, dtype=torch.float16, device=None, sparsity=0.5, force=False
+    m, k, n, bm, bk, dtype=torch.float16, device="cuda", sparsity=0.5, force=False
 ):
     import triton
 
     from torch.sparse._triton_ops import bsr_scatter_mm, bsr_scatter_mm_indices_data
 
-    device = device or _get_current_accelerator_type()
     key = (m, k, n, bm, bk)
 
     version = (0, dtype, sparsity)
@@ -712,8 +699,8 @@ def tune_bsr_dense_addmm(
         version_dtype = (dtype, out_dtype)
     version = (0, version_dtype, sparsity)
     key = (M, K, N, BM, BK, beta == 0, beta == 1, alpha == 1)
-    # Key on the device the inputs live on, not on the process accelerator: the
-    # lookup below and the update at the end of this function must agree.
+    # Key on the device the inputs live on rather than on the caller-less default,
+    # so the lookup below and the update at the end of this function agree.
     device_name = _get_device_name(bsr.device)
 
     # For tuning, for an initial state, use parameters from the
@@ -811,13 +798,12 @@ def optimize_bsr_dense_addmm(
     use_right_alpha=False,
     dtype=torch.float16,
     out_dtype=None,
-    device=None,
+    device="cuda",
     sparsity=0.5,
     force=False,
     verbose=False,
     opname=None,
 ):
-    device = device or _get_current_accelerator_type()
     torch.manual_seed(0)
     bsr = create_blocked_tensor(
         0, m, k, (bm, bk), sparsity, dtype, device
@@ -848,11 +834,8 @@ def optimize_bsr_dense_addmm(
     )
 
 
-def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device=None):
+def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True):
     import itertools
-
-    device = device or _get_current_accelerator_type()
-    device_name = _get_device_name(device)
 
     sizes_lst = [
         256,
@@ -888,15 +871,7 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device
                     continue
                 if op == "scatter_mm":
                     optimize_scatter_mm(
-                        M,
-                        K,
-                        N,
-                        BM,
-                        BK,
-                        force=force,
-                        sparsity=sparsity,
-                        dtype=dtype,
-                        device=device,
+                        M, K, N, BM, BK, force=force, sparsity=sparsity, dtype=dtype
                     )
                 elif op in {"bsr_dense_addmm", "_int_bsr_dense_addmm"}:
                     if M == K and N == 50432:
@@ -914,7 +889,6 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device
                             force=force,
                             sparsity=sparsity,
                             dtype=dtype,
-                            device=device,
                             verbose=verbose,
                             opname=op,
                         )
@@ -944,18 +918,12 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device
             for sparsity1 in sparsity_lst:
                 torch.manual_seed(0)
                 bsr = create_blocked_tensor(
-                    0, M, K, (BM, BK), sparsity1, dtype, device
+                    0, M, K, (BM, BK), sparsity1, dtype, device="cuda"
                 ).to_sparse_bsr((BM, BK))
-                dense = make_tensor(K, N, dtype=dtype, device=device)
+                dense = make_tensor(K, N, dtype=dtype, device="cuda")
                 meta_lst = []
                 for sparsity in sparsity_lst:
-                    meta = get_meta(
-                        op,
-                        key,
-                        device_name,
-                        version=(0, dtype, sparsity),
-                        exact=True,
-                    )
+                    meta = get_meta(op, key, version=(0, dtype, sparsity), exact=True)
                     if meta is None:
                         continue
 
@@ -1005,12 +973,9 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device
                 print(sparsity1, index, key, meta_lst, speeddiff)
 
                 if index > 0:
+                    device_name = _get_device_name()
                     meta = get_meta(
-                        op,
-                        key,
-                        device_name,
-                        version=(0, dtype, meta_lst[0][1]),
-                        exact=True,
+                        op, key, version=(0, dtype, meta_lst[0][1]), exact=True
                     )
                     update(
                         op,

--- a/torch/sparse/_triton_ops_meta.py
+++ b/torch/sparse/_triton_ops_meta.py
@@ -112,24 +112,45 @@ from torch.testing import make_tensor
 
 
 def _get_current_accelerator_type() -> str:
-    """Return the device type of the accelerator in use, or "" if there is none."""
-    acc = torch.accelerator.current_accelerator(check_available=True)
-    return "" if acc is None else acc.type
+    """Return the device type of the accelerator in use, or "" if there is none.
 
-
-def _get_device_name() -> str:
-    """Return the current accelerator device name for use as a Triton tuning cache key.
-
-    Backends expose ``torch.<device_type>.get_device_name``; one that does not is
-    treated as unnamed, which is how an absent accelerator has always been keyed.
+    ``torch.accelerator.current_accelerator(check_available=True)`` is not usable
+    here: its availability check goes through ``torch.get_device_module``, which
+    raises for a PrivateUse1 backend that has been renamed without registering a
+    ``torch.<name>`` module. Deriving a tuning cache key must never raise, so such
+    a backend is reported as absent instead. ``is_available()`` is still consulted,
+    because that is what the previous cuda/xpu chain used to reject a backend that
+    is built but has no usable device.
     """
-    device_type = _get_current_accelerator_type()
-    if not device_type:
+    acc = torch.accelerator.current_accelerator()
+    if acc is None:
         return ""
-    get_device_name = getattr(
-        torch.get_device_module(device_type), "get_device_name", None
+    is_available = getattr(getattr(torch, acc.type, None), "is_available", None)
+    return acc.type if is_available is not None and is_available() else ""
+
+
+def _get_device_name(device=None) -> str:
+    """Return the device name that keys the Triton tuning tables.
+
+    The key is persisted data: ``dump()`` writes it into this module's source
+    during an offline tuning run and a different process reads it back, so the same
+    hardware must always produce the same name and producing it must never raise --
+    a lookup miss is a designed outcome of :func:`get_meta`, a failure is not.
+
+    ``device`` names the device the parameters are tuned for or looked up for; when
+    it is unspecified the accelerator in use is used instead. A backend that
+    exposes no ``torch.<device_type>.get_device_name`` is unnamed, which is how an
+    absent accelerator has always been keyed.
+    """
+    if device == "":
+        # The tuning entry points pass "" when there is no accelerator in use.
+        device = None
+    device_type = (
+        _get_current_accelerator_type() if device is None else torch.device(device).type
     )
-    return "" if get_device_name is None else get_device_name()
+    module = getattr(torch, device_type, None) if device_type else None
+    get_device_name = getattr(module, "get_device_name", None)
+    return "" if get_device_name is None else get_device_name(device)
 
 
 def get_meta(op, key, device_name=None, version=(0, torch.float16, 0.5), exact=False):
@@ -508,7 +529,7 @@ def optimize_scatter_mm(
     key = (m, k, n, bm, bk)
 
     version = (0, dtype, sparsity)
-    device_name = _get_device_name()
+    device_name = _get_device_name(device)
 
     reference_meta = dict(
         GROUP_SIZE=1,
@@ -601,7 +622,6 @@ def optimize_scatter_mm(
     print(f"{meta=} {speedup=:.1f} % {timing=:.3f} ms")
     if speedup < 0:
         return
-    device_name = _get_device_name()
 
     update(
         "scatter_mm", device_name, version, key, tuple(meta[k] for k in sorted(meta))
@@ -692,13 +712,18 @@ def tune_bsr_dense_addmm(
         version_dtype = (dtype, out_dtype)
     version = (0, version_dtype, sparsity)
     key = (M, K, N, BM, BK, beta == 0, beta == 1, alpha == 1)
+    # Key on the device the inputs live on, not on the process accelerator: the
+    # lookup below and the update at the end of this function must agree.
+    device_name = _get_device_name(bsr.device)
 
     # For tuning, for an initial state, use parameters from the
     # database if available, otherwise, use the reference parameters.
-    initial_meta = get_meta(opname, key, version=version, exact=True)
+    initial_meta = get_meta(opname, key, device_name, version=version, exact=True)
     if initial_meta is None:
         may_skip_update = False
-        initial_meta = get_meta(opname, key, version=(0, dtype, 0.5), exact=True)
+        initial_meta = get_meta(
+            opname, key, device_name, version=(0, dtype, 0.5), exact=True
+        )
         if initial_meta is None:
             initial_meta = reference_meta
     elif not force:
@@ -763,7 +788,6 @@ def tune_bsr_dense_addmm(
     if store and not (
         may_skip_update and meta == initial_meta and initial_meta is not reference_meta
     ):
-        device_name = _get_device_name()
         update(
             opname,
             device_name,
@@ -828,6 +852,7 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device
     import itertools
 
     device = device or _get_current_accelerator_type()
+    device_name = _get_device_name(device)
 
     sizes_lst = [
         256,
@@ -924,7 +949,13 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device
                 dense = make_tensor(K, N, dtype=dtype, device=device)
                 meta_lst = []
                 for sparsity in sparsity_lst:
-                    meta = get_meta(op, key, version=(0, dtype, sparsity), exact=True)
+                    meta = get_meta(
+                        op,
+                        key,
+                        device_name,
+                        version=(0, dtype, sparsity),
+                        exact=True,
+                    )
                     if meta is None:
                         continue
 
@@ -974,9 +1005,12 @@ def main(op="scatter_mm", force=False, dtype=torch.float16, verbose=True, device
                 print(sparsity1, index, key, meta_lst, speeddiff)
 
                 if index > 0:
-                    device_name = _get_device_name()
                     meta = get_meta(
-                        op, key, version=(0, dtype, meta_lst[0][1]), exact=True
+                        op,
+                        key,
+                        device_name,
+                        version=(0, dtype, meta_lst[0][1]),
+                        exact=True,
                     )
                     update(
                         op,


### PR DESCRIPTION

Related to this RFC: #194355

### Summary

`_get_device_name()` supplies the device component of the key under which
`_operation_device_version_data` stores tuned Triton parameters. It was a
two-branch chain over `torch.cuda` and `torch.xpu` returning `""` for anything
else, and it took no arguments -- so the key named whatever the *process* was
configured for, never the device the inputs were actually on. An accelerator
outside that pair keyed as unnamed: `get_meta` found no entry, `bsr_dense_addmm`
and `scatter_mm` silently used default kernel parameters, and there was no way to
store tuned ones under a name that would be found again.

`_get_device_name` now takes the device the parameters are tuned for or looked up
for, and every caller that holds a tensor passes it:

- `bsr_scatter_mm_indices_data` -> `scatter_mm_meta(..., device=bsr.device)`
- `bsr_dense_addmm` -> `bsr_dense_addmm_meta(..., device=bsr.device)`
- `tune_bsr_dense_addmm` -> `bsr.device`, at its lookups *and* its store, which
  previously disagreed
- `optimize_scatter_mm` -> the `device` argument it already had
- `benchmarks/sparse/triton_ops.py` -> `args.device`

A backend that exposes no `torch.<device_type>.get_device_name` is unnamed, which
is how `torch.mps` and `torch.mtia` were already treated.

### What the caller-less default deliberately does not do

When no device is given, the question is which device runs sparse Triton ops for a
caller that did not say. That is the same question `check_device` in
`torch/sparse/_triton_ops.py` answers with a hardcoded `("cuda", "xpu")`, and this
PR argues below that it has no generic expression today -- so that branch keeps the
pre-PR chain verbatim rather than routing through
`torch.accelerator.current_accelerator()`.

An earlier version of this PR did route it through the accelerator API, and that
was a regression. `at::getAccelerator` returns PrivateUse1 on name registration
alone, ahead of CUDA, and `aten/src/ATen/DeviceAccelerator.cpp` states that
coexistence is deliberate. `torch_openreg` -- the in-tree reference out-of-tree
backend -- calls `rename_privateuse1_backend` and `_register_device_module` on
import, and its module has `is_available` but no `get_device_name`. So on a CUDA
host `import torch_openreg` moved the key from the CUDA device name to `""`, and
every entry in the shipped table stopped being found:

```
                                       pre-PR                            via accelerator
no PrivateUse1 backend      'NVIDIA GeForce RTX 2060 SUPER'    'NVIDIA GeForce RTX 2060 SUPER'
after import torch_openreg  'NVIDIA GeForce RTX 2060 SUPER'    ''
```

With the caller-less branch left alone, no configuration's key moves. Thanks to
@pearu for catching this.

### What this changes today, concretely

Nothing on CUDA or XPU, by construction. Every key in the shipped
`_operation_device_version_data` is `NVIDIA A100-SXM4-80GB` and `get_meta`'s only
fuzzy fallback rewrites `NVIDIA A100*` names and otherwise returns `None`, so no
other device has tuned parameters to find in the first place. What this enables is
the write side: a backend outside cuda/xpu is keyed by its own device name wherever
a tensor names it, so a tuning run's output is findable at runtime instead of being
stored under the process's name and looked up under the same -- and
`tune_bsr_dense_addmm` no longer reads under one key while storing under another.

### What this deliberately does not touch

`check_device` in `torch/sparse/_triton_ops.py` gates on `("cuda", "xpu")` and is
the same class of problem, but it cannot be expressed generically today.
`has_triton()` answers "is Triton usable somewhere in this process", not "on this
device", and its own `triton_supported_devices` table is a dict local to the
function body with no registration entry point. Routing `check_device` through it
would move the hardcoded list one file deeper and make the gate wrong -- it would
approve a device because some *other* device in the process has Triton. A
per-device `has_triton_for_device()` backed by a registerable table would fix both;
that seemed like a separate change and I did not want to bundle an API addition
with this.

Also left alone: the `NVIDIA A100` name matching in `get_meta` and in
`optimize_scatter_mm`'s step function, the A100-gated hard-skip set for parameter
combinations that break CUDA state, and the shipped table itself.

### Left for a follow-up

Resolving `device=None` to the accelerator in the offline tuning entry points
(`optimize_scatter_mm`, `optimize_bsr_dense_addmm`, `main`) is a new capability --
tuning on a non-CUDA accelerator -- rather than part of this fix, and their only
in-repo caller sits inside a disabled `if 0 and ...` block, so it has nowhere to be
tested here. Those three keep their pre-PR `device="cuda"`.

### Test plan

`TestSparseTritonMetaDeviceName` in `test/test_sparse_csr.py` (`GENERIC`), five
tests, all of which run on a CPU-only build with no accelerator, no Triton, no
subprocess and no process-global state:

- `test_the_input_device_reaches_the_tuning_key` -- `scatter_mm_meta` and
  `bsr_dense_addmm_meta` each receive `bsr.device`, checked through
  `bsr_scatter_mm_indices_data` and `bsr_dense_addmm`. The lookups are intercepted,
  so no kernel is launched;
- `test_tuned_parameters_are_found_through_the_input_device` -- an
  `update()` / `get_meta()` round trip: what is stored under a device's name is
  found by a lookup that only knows the input tensor's device, and is *not* found
  without it;
- an explicit device overriding the caller-less default;
- a device module with no `get_device_name` (`torch.cpu`, and `torch.mps` /
  `torch.mtia` by the same route);
- neither CUDA nor XPU available.

`privateuseone` is used as the stand-in for a device type that is neither cuda nor
xpu, patched as an attribute rather than through
`torch.utils.rename_privateuse1_backend`, which is process-global and one-shot.

```
python test/test_sparse_csr.py -k TestSparseTritonMetaDeviceName -v
Ran 5 tests -- OK        # CPU-only build, and again on a CUDA box
```

Both halves are non-vacuous. Reverting either `device=bsr.device` fails
`test_the_input_device_reaches_the_tuning_key` -- before it existed, that revert
left the whole suite green. Making `_get_device_name` ignore its `device` argument
fails three of the five.

On a Tesla T4 with Triton, `test_triton_tune` (28) and
`test_triton_bsr_dense_addmm_meta` (2) pass, and their output is identical to a run
on `main` one commit before this branch. `_get_device_name()`,
`_get_device_name("cuda")` and `_get_device_name(torch.device("cuda", 0))` all
return `'Tesla T4'` there, matching `torch.cuda.get_device_name()`.

```
lintrunner   # RUFF, PYFMT, FLAKE8, CODESPELL, IMPORT_LINTER, TEST_DEVICE_BIAS, ... -- ok No lint issues.
```
