### PR TITLE
[inductor] Vendor and adapt QuACK symmetric GEMM

### DIFF
--- a/test/inductor/test_symmetric_mm.py
+++ b/test/inductor/test_symmetric_mm.py
@@ -1,0 +1,31 @@
+# Owner(s): ["module: inductor", "module: optimizer"]
+
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class SymmetricMMTest(TestCase):
+    def test_quack_grouped_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        from torch._vendor.quack.gemm_symmetric import gemm_symmetric
+
+        x = torch.randn(2, 512, 1024, device=device, dtype=torch.bfloat16)
+        gram = torch.empty(2, 512, 512, device=device, dtype=torch.bfloat16)
+        gemm_symmetric(x, gram)
+        self.assertEqual(gram, torch.bmm(x, x.mT))
+
+        update = torch.empty_like(gram)
+        gemm_symmetric(gram, update, C=gram, alpha=2.0315, beta=-4.775)
+        expected = torch.baddbmm(gram, gram, gram, beta=-4.775, alpha=2.0315)
+        self.assertEqual(update, expected, rtol=2e-2, atol=5e-1)
+        self.assertEqual(update, update.mT)
+
+
+instantiate_device_type_tests(SymmetricMMTest, globals(), only_for="cuda")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tools/vendoring/quack/flex_gemm_patches/0015-inductor-symmetric-gemm.patch
+++ b/tools/vendoring/quack/flex_gemm_patches/0015-inductor-symmetric-gemm.patch
@@ -1,0 +1,753 @@
+# Adapt QuACK's symmetric GEMM to the composable epilogue and runtime
+# interfaces introduced by the preceding PyTorch FlexGEMM patches.
+#
+# Base: 99bd7973bf3dc6db40961e413d4bdfea6c6fee3e
+#
+--- a/gemm_symmetric.py
++++ b/gemm_symmetric.py
+@@ -1,344 +1,121 @@
+-from typing import Dict, Tuple, Optional, Callable
++import statistics
++import threading
+
++import torch
+ from torch import Tensor
+
+-import cutlass
+ import cutlass.cute as cute
+-from cutlass import Int32, Float32, Boolean, const_expr
+-from cutlass.cute.runtime import make_ptr
++from cutlass import Float32
+
+-from quack.compile_utils import make_fake_tensor as fake_tensor
+-from quack.cute_dsl_utils import get_device_capacity, get_max_active_clusters, torch2cute_dtype_map
+-from quack.activation import act_fn_map
+-from quack.gemm_act import GemmActMixin
+-from quack.gemm_sm80 import GemmSm80
+-from quack.gemm_sm90 import GemmSm90
+-from quack.gemm_sm100 import GemmSm100
+-from quack.gemm_sm120 import GemmSm120
+-from quack.gemm_tvm_ffi_utils import (
++from .cache import jit_cache
++from .compile_utils import make_fake_tensor as fake_tensor
++from .cute_dsl_utils import (
++    get_device_capacity,
++    get_max_active_clusters,
++    torch2cute_dtype_map,
++)
++from .gemm_default_epi import GemmDefaultEpiMixin
++from .gemm_act import GemmActMixin
++from .gemm_sm100 import GemmSm100
++from .gemm_tvm_ffi_utils import (
++    compile_gemm_kernel,
+     div_for_dtype,
+-    perm3d,
+-    get_majors,
+-    get_dtypes,
+-    make_scheduler_args,
++    get_major,
+     make_fake_scheduler_args,
+-    compile_gemm_kernel,
++    make_scheduler_args,
+ )
+-from quack.cache import jit_cache
+-from quack.tile_scheduler import TriangularTileScheduler
+-from quack.varlen_utils import VarlenManager
+-import quack.copy_utils as copy_utils
+-from quack.rounding import RoundingMode, epilogue_sr_seed
++from .tile_scheduler import TriangularTileScheduler
+
+
+ class GemmSymmetricMixin(GemmActMixin):
++    EpilogueArguments = GemmActMixin.EpilogueArguments
++
+     def get_scheduler_class(self, varlen_m: bool = False):
+         return TriangularTileScheduler
+
+     @cute.jit
+-    def epilogue(
+-        self,
+-        params: GemmActMixin.EpilogueParams,
+-        epi_smem_tensors: Dict[str, cute.Tensor],
+-        epi_pipeline: Optional[cutlass.pipeline.PipelineAsync],
+-        epi_store_pipeline: Optional[cutlass.pipeline.PipelineAsync],
+-        epi_read_state: Optional[cutlass.pipeline.PipelineState],
+-        epi_producer_state: Optional[cutlass.pipeline.PipelineState],
+-        epi_tile: cute.Tile,
+-        load_acc_subtile: Callable,
+-        tRS_rD: cute.Tensor,
+-        tRS_rC: Optional[cute.Tensor],
+-        tiled_copy_t2r: Optional[cute.TiledCopy],  # Only for Sm100
+-        tiled_copy_r2s: cute.TiledCopy,
+-        tRS_sD: cute.Tensor,
+-        tiled_copy_s2r: Optional[cute.ThrCopy],
+-        tSR_rC: Optional[cute.Tensor],
+-        tSR_sC: Optional[cute.Tensor],
+-        copy_D: Optional[Callable],
+-        copy_C: Optional[Callable],
+-        tile_coord_mnkl: cute.Coord,
+-        varlen_manager: VarlenManager,
+-        epilogue_barrier: cutlass.pipeline.NamedBarrier,
+-        tile_scheduler,
+-        tidx: Int32,
+-        is_tma_warp: Boolean,
+-    ) -> Tuple[cutlass.pipeline.PipelineState, cutlass.pipeline.PipelineState]:
+-        has_C = const_expr(tRS_rC is not None)
+-        has_epi_load = const_expr(self.epi_c_stage > 0)
+-        has_D = const_expr(copy_D is not None)
+-        use_tma_epi = const_expr(epi_store_pipeline is not None)
+-        use_tma_c = const_expr(epi_pipeline is not None)
+-        inline_epi_load = const_expr(copy_C is not None)
+-        use_stochastic_rounding = const_expr(
+-            self.rounding_mode == RoundingMode.RS
+-            and self.acc_dtype == cutlass.Float32
+-            and self.d_dtype == cutlass.BFloat16
+-        )
+-
+-        # Setup aux output (returns None for default epilogue, context tuple for Act)
+-        aux_out_ctx = self.epi_setup_aux_out(
+-            params,
+-            epi_smem_tensors,
+-            tiled_copy_r2s,
+-            tiled_copy_t2r,
+-            tile_coord_mnkl,
+-            varlen_manager,
+-            tidx,
++    def epi_visit_subtile(self, params, epi_loop_tensors, tRS_rD, tRS_rC=None):
++        GemmDefaultEpiMixin.epi_visit_subtile(
++            self, params, epi_loop_tensors, tRS_rD, tRS_rC
+         )
+-
+-        epi_tile_shape = cute.zipped_divide(
+-            cute.make_layout(self.cta_tile_shape_mnk[:2]), epi_tile
+-        ).shape[1]
+-        epi_tile_layout = cute.make_ordered_layout(
+-            epi_tile_shape, order=(0, 1) if const_expr(self.epi_m_major) else (1, 0)
+-        )
+-        epi_tile_num = cute.size(epi_tile_shape)
+-        num_prev_subtiles = tile_scheduler.num_tiles_executed * epi_tile_num
+-
+-        # Symmetric guard: skip the mirrored aux write on the diagonal,
+-        # otherwise we'd write the same gmem location twice.
+-        square_tile_m = tile_coord_mnkl[0] // self.cluster_shape_mnk[0]
+-        square_tile_n = tile_coord_mnkl[1] // self.cluster_shape_mnk[1]
+-
+-        epi_tensors = self.epi_begin(
+-            params,
+-            epi_smem_tensors,
+-            epi_tile,
+-            tiled_copy_t2r,
+-            tiled_copy_r2s,
+-            tile_coord_mnkl,
+-            varlen_manager,
+-            epilogue_barrier,
+-            tidx,
+-            tRS_rD.layout,
+-        )
+-
+-        if const_expr(inline_epi_load):
+-            for epi_idx in cutlass.range(min(epi_tile_num, self.epi_c_stage), unroll=1):
+-                epi_coord_C = epi_tile_layout.get_hier_coord(epi_idx)
+-                if const_expr(use_tma_c):
+-                    if is_tma_warp:
+-                        epi_pipeline.producer_acquire(epi_producer_state)
+-                        copy_C(src_idx=epi_coord_C, producer_state=epi_producer_state)
+-                        epi_pipeline.producer_commit(epi_producer_state)
+-                    epi_producer_state.advance()
+-                else:
+-                    # TODO: turn this to cp.async instead of direct G2R copy
+-                    copy_C(src_idx=epi_coord_C, dst_idx=epi_idx % self.epi_c_stage)
+-            if const_expr(use_tma_c):
+-                epilogue_barrier.arrive_and_wait()
+-
+-        for epi_idx in cutlass.range_constexpr(epi_tile_num):
+-            epi_coord = epi_tile_layout.get_hier_coord(epi_idx)  # (epi_m, epi_n)
+-            # Copy from acc to D registers
+-            load_acc_subtile(tRS_rD, epi_coord)
+-            if const_expr(has_epi_load):
+-                if const_expr(use_tma_c):
+-                    epi_pipeline.consumer_wait(epi_read_state)
+-                    if const_expr(has_C):
+-                        cute.copy(
+-                            tiled_copy_s2r, tSR_sC[None, None, None, epi_read_state.index], tSR_rC
+-                        )
+-                    self.epi_tile_load_s2r(params, epi_tensors, epi_read_state.index)
+-                    cute.arch.fence_view_async_shared()
+-                    cute.arch.sync_warp()
+-                    with cute.arch.elect_one():
+-                        epi_pipeline.consumer_release(epi_read_state)
+-                    epi_read_state.advance()
+-                else:
+-                    c_buffer = epi_idx % self.epi_c_stage
+-                    cute.copy(tiled_copy_s2r, tSR_sC[None, None, None, c_buffer], tSR_rC)
+-                    # TODO: cp.async wait once we switch to cp.async
+-                    epilogue_barrier.arrive_and_wait()
+-            epi_loop_tensors = self.epi_begin_loop(params, epi_tensors, epi_coord)
+-            if const_expr(inline_epi_load and epi_idx + self.epi_c_stage < epi_tile_num):
+-                epi_coord_C = epi_tile_layout.get_hier_coord(epi_idx + self.epi_c_stage)
+-                if const_expr(use_tma_c):
+-                    if is_tma_warp:
+-                        epi_pipeline.producer_acquire(epi_producer_state)
+-                        copy_C(src_idx=epi_coord_C, producer_state=epi_producer_state)
+-                        epi_pipeline.producer_commit(epi_producer_state)
+-                    epi_producer_state.advance()
+-                else:
+-                    epilogue_barrier.arrive_and_wait()
+-                    copy_C(
+-                        src_idx=epi_coord_C,
+-                        dst_idx=(epi_idx + self.epi_c_stage) % self.epi_c_stage,
+-                    )
+-            tRS_rAuxOut = self.epi_visit_subtile(params, epi_loop_tensors, tRS_rD, tRS_rC)
+-            self.epi_end_loop(
+-                params,
+-                epi_tensors,
+-                epi_coord,
+-                epi_tile,
+-                tiled_copy_t2r,
+-                tiled_copy_r2s,
+-                tile_coord_mnkl,
+-                varlen_manager,
+-                tidx,
+-            )
+-            if const_expr(aux_out_ctx is not None):
+-                tRS_rAuxOut_out = self.epi_convert_aux_out(
+-                    tRS_rAuxOut,
+-                    epi_loop_tensors.get("sr_seed"),
+-                    tidx,
+-                    tile_coord_mnkl,
+-                    num_prev_subtiles,
+-                    epi_idx,
+-                )
+-            if const_expr(use_tma_epi):
+-                if is_tma_warp:
+-                    epi_store_pipeline.producer_acquire()
+-            else:
+-                epilogue_barrier.arrive_and_wait()
+-            if const_expr(use_tma_epi):
+-                epilogue_barrier.arrive_and_wait()
+-            epi_buffer = (num_prev_subtiles + epi_idx) % self.epi_stage
+-            if const_expr(has_D):
+-                tRS_sD_cur = tRS_sD[None, None, None, epi_buffer]
+-                if const_expr(use_stochastic_rounding):
+-                    seed = epilogue_sr_seed(
+-                        epi_loop_tensors.get("sr_seed"),
+-                        tile_coord_mnkl,
+-                        num_prev_subtiles + epi_idx,
+-                    )
+-                    copy_utils.sr_cvt_copy(tiled_copy_r2s, tRS_rD, tRS_sD_cur, seed, tidx)
+-                else:
+-                    copy_utils.cvt_copy(tiled_copy_r2s, tRS_rD, tRS_sD_cur)
+-            if const_expr(aux_out_ctx is not None):
+-                tiled_copy_aux_out_r2s, tRS_sAuxOut, copy_aux_out = aux_out_ctx
+-                cute.copy(
+-                    tiled_copy_aux_out_r2s,
+-                    # Need contiguous for Sm80 and Sm120 where acc layout is ((2, 2), MMA_M, MMA_N)
+-                    copy_utils.contiguous(tiled_copy_aux_out_r2s.retile(tRS_rAuxOut_out)),
+-                    tRS_sAuxOut[None, None, None, epi_buffer],
+-                )
+-            if const_expr(use_tma_epi):
+-                cute.arch.fence_view_async_shared()
+-                epilogue_barrier.arrive_and_wait()
+-                if is_tma_warp:
+-                    if const_expr(has_D):
+-                        copy_D(src_idx=epi_buffer, dst_idx=epi_coord)
+-                    if const_expr(aux_out_ctx is not None):
+-                        if square_tile_m != square_tile_n:  # don't write twice on the diagonal
+-                            copy_aux_out(src_idx=epi_buffer, dst_idx=epi_coord)
+-                    epi_store_pipeline.producer_commit()
+-            else:
+-                epilogue_barrier.arrive_and_wait()
+-                if const_expr(has_D):
+-                    copy_D(src_idx=epi_buffer, dst_idx=epi_coord)
+-                if const_expr(aux_out_ctx is not None):
+-                    if square_tile_m != square_tile_n:  # don't write twice on the diagonal
+-                        copy_aux_out(src_idx=epi_buffer, dst_idx=epi_coord)
+-                epilogue_barrier.arrive_and_wait()
+-
+-        self.epi_end(
+-            params,
+-            epi_tensors,
+-            epi_tile,
+-            tiled_copy_t2r,
+-            tiled_copy_r2s,
+-            tile_coord_mnkl,
+-            varlen_manager,
+-            tidx,
+-        )
+-
+-        return epi_read_state, epi_producer_state
+-
+-
+-class GemmSymmetricSm80(GemmSymmetricMixin, GemmSm80):
+-    pass
+-
+-
+-class GemmSymmetricSm90(GemmSymmetricMixin, GemmSm90):
+-    pass
++        return tRS_rD
+
+
+ class GemmSymmetricSm100(GemmSymmetricMixin, GemmSm100):
+     pass
+
+
+-class GemmSymmetricSm120(GemmSymmetricMixin, GemmSm120):
+-    pass
++_AUTOTUNE_CACHE: dict[
++    tuple[torch.device, torch.dtype, int, int, int, bool],
++    tuple[tuple[int, int], tuple[int, int, int], int],
++] = {}
++_AUTOTUNE_LOCK = threading.Lock()
+
+
+ @jit_cache
+ def _compile_gemm_symmetric(
+     a_dtype,
+-    b_dtype,
+     d_dtype,
+-    c_dtype,
+-    c_major,
+-    postact_dtype,
+     a_major,
+-    b_major,
+     d_major,
+     postact_major,
+     tile_shape_mn,
+     cluster_shape_mnk,
+-    pingpong,
+-    persistent,
+-    is_dynamic_persistent,
+-    alpha_mode,
+-    beta_mode,
+     device_capacity,
++    has_c,
+ ):
+-    sm_to_cls = {
+-        8: GemmSymmetricSm80,
+-        9: GemmSymmetricSm90,
+-        10: GemmSymmetricSm100,
+-        11: GemmSymmetricSm100,
+-        12: GemmSymmetricSm120,
+-    }
+-    GemmCls = sm_to_cls[device_capacity[0]]
+-    # Symmetric GEMM: m == n, so reuse the same sym_int for shape checking
+     m, k, l = cute.sym_int(), cute.sym_int(), cute.sym_int()
+-    a_leading = 1 if a_major == "k" else 0
+-    b_leading = 1 if b_major == "k" else 0
+-    d_leading = 1 if d_major == "n" else 0
+-    c_leading = 1 if c_major == "n" else 0
+-    div_a, div_b = div_for_dtype(a_dtype), div_for_dtype(b_dtype)
+-    div_d, div_c = div_for_dtype(d_dtype), div_for_dtype(c_dtype) if c_dtype else 1
+-    mA = fake_tensor(a_dtype, (m, k, l), leading_dim=a_leading, divisibility=div_a)
+-    mB = fake_tensor(b_dtype, (m, k, l), leading_dim=b_leading, divisibility=div_b)
+-    mD = fake_tensor(d_dtype, (m, m, l), leading_dim=d_leading, divisibility=div_d)
+-    mC = fake_tensor(c_dtype, (m, m, l), leading_dim=c_leading, divisibility=div_c)
+-    # PostAct = D.mT, so it has the opposite major from D (m↔n swapped)
+-    div_pa = div_for_dtype(postact_dtype)
+-    postact_leading = 1 if postact_major == "n" else 0
++    div_a = div_for_dtype(a_dtype)
++    div_d = div_for_dtype(d_dtype)
++    mA = fake_tensor(
++        a_dtype,
++        (m, k, l),
++        leading_dim=1 if a_major == "k" else 0,
++        divisibility=div_a,
++    )
++    mB = fake_tensor(
++        a_dtype,
++        (m, k, l),
++        leading_dim=1 if a_major == "k" else 0,
++        divisibility=div_a,
++    )
++    mD = fake_tensor(
++        d_dtype,
++        (m, m, l),
++        leading_dim=1 if d_major == "n" else 0,
++        divisibility=div_d,
++    )
++    mC = (
++        fake_tensor(
++            d_dtype,
++            (m, m, l),
++            leading_dim=1 if d_major == "n" else 0,
++            divisibility=div_d,
++        )
++        if has_c
++        else None
++    )
+     mAuxOut = fake_tensor(
+-        postact_dtype, (m, m, l), leading_dim=postact_leading, divisibility=div_pa
++        d_dtype,
++        (m, m, l),
++        leading_dim=1 if postact_major == "n" else 0,
++        divisibility=div_d,
+     )
+-
+-    def fake_scalar(mode):
+-        if mode == 0:
+-            return None
+-        elif mode == 1:
+-            return Float32(1.0)
+-        else:
+-            return make_ptr(Float32, 0, cute.AddressSpace.gmem, assumed_align=4)
+-
+-    activation = None  # identity
+-    act_fn = act_fn_map[activation]
+-    epi_args = GemmCls.EpilogueArguments(
++    epi_args = GemmSymmetricMixin.EpilogueArguments(
+         mAuxOut,
+-        act_fn,
+-        alpha=fake_scalar(alpha_mode),
+-        beta=fake_scalar(beta_mode),
++        alpha=Float32(0.0) if has_c else None,
++        beta=Float32(0.0) if has_c else None,
+     )
+-    scheduler_args = make_fake_scheduler_args(
+-        (is_dynamic_persistent and device_capacity[0] == 9), False, l
+-    )
+-    varlen_args = None
++    scheduler_args = make_fake_scheduler_args(False, False, l)
+     return compile_gemm_kernel(
+-        GemmCls,
++        GemmSymmetricSm100,
+         a_dtype,
+         tile_shape_mn,
+         cluster_shape_mnk,
+-        pingpong,
+-        persistent,
+         False,
+-        is_dynamic_persistent,
++        True,
++        False,
++        True,
+         device_capacity,
+         mA,
+         mB,
+@@ -346,109 +123,249 @@
+         mC,
+         epi_args,
+         scheduler_args,
+-        varlen_args,
++        None,
+     )
+
+
+ def gemm_symmetric(
+-    A: Tensor,  # (l, m, k)
+-    B: Tensor,  # (l, m, k)
+-    D: Optional[Tensor],  # (l, m, m)
+-    C: Optional[Tensor],  # (l, m, m)
+-    tile_count_semaphore: Optional[Tensor],  # (1,)
+-    tile_M: int,
+-    tile_N: int,
+-    cluster_M: int,
+-    cluster_N: int,
+-    tile_K: int | None = None,
+-    pingpong: bool = False,
+-    persistent: bool = True,
+-    is_dynamic_persistent: bool = False,
+-    max_swizzle_size: int = 8,
+-    alpha: float | Tensor = 1.0,
+-    beta: float | Tensor = 1.0,
++    A: Tensor,
++    out: Tensor,
++    C: Tensor | None = None,
++    alpha: float | None = None,
++    beta: float | None = None,
++    *,
++    tile_shape_mn: tuple[int, int] = (256, 256),
++    cluster_shape_mnk: tuple[int, int, int] = (2, 1, 1),
++    scheduler_group_size: int = 8,
++    autotune: bool = False,
+ ) -> None:
+-    # Transpose D so the "activation" is a write to the mirrored tile
+-    PostAct = D.mT
+-
+-    A_p, B_p, D_p, C_p = perm3d(A, B, D, C)
+-    PostAct_p = PostAct.permute(1, 2, 0) if PostAct.ndim == 3 else PostAct
+-    a_major, b_major, d_major, c_major = get_majors(A_p, B_p, D_p, C_p)
+-    a_dtype, b_dtype, d_dtype, c_dtype = get_dtypes(A, B, D, C)
+-    postact_dtype = torch2cute_dtype_map[PostAct.dtype]
+-    # PostAct = D.mT has swapped major: if D is n-major, PostAct is m-major
+-    postact_major = "n" if PostAct_p.stride(1) == 1 else "m"
++    """Compute a symmetric Gram matrix, optionally with a symmetric C epilogue.
+
++    Inputs are contiguous `(M, K)` tensors or homogeneous `(L, M, K)` batches.
++    When C is supplied, it must be symmetric and alpha and beta must also be
++    supplied; the result is `alpha * A @ A.mT + beta * C`.
++    """
++    if A.ndim not in (2, 3) or out.ndim != A.ndim:
++        raise NotImplementedError(
++            "vendored symmetric GEMM currently supports 2-D tensors or homogeneous batches"
++        )
++    if A.dtype not in (torch.float16, torch.bfloat16) or out.dtype != A.dtype:
++        raise NotImplementedError("vendored symmetric GEMM requires matching fp16 or bf16 tensors")
++    if not A.is_contiguous() or not out.is_contiguous():
++        raise ValueError("symmetric GEMM requires contiguous input and output tensors")
++    if out.device != A.device:
++        raise ValueError("symmetric GEMM input and output must be on the same device")
++    if not (
++        (C is None and alpha is None and beta is None)
++        or (C is not None and alpha is not None and beta is not None)
++    ):
++        raise ValueError("symmetric GEMM requires C, alpha, and beta together")
+     device_capacity = get_device_capacity(A.device)
+-    assert device_capacity[0] in [8, 9, 10, 11, 12], (
+-        "Only SM8x, SM90, SM100, SM110, and SM120 are supported"
+-    )
++    if device_capacity[0] not in (10, 11):
++        raise NotImplementedError("vendored symmetric GEMM prototype requires SM100 or SM110")
+
+-    if is_dynamic_persistent and device_capacity[0] <= 9:
+-        assert tile_count_semaphore is not None, (
+-            "Dynamic persistent tile scheduler in SM90 requires a semaphore in GMEM"
++    if A.ndim == 2:
++        m, k = A.shape
++        batch = 1
++        batch_stride = 0
++        out_batch_stride = 0
++    else:
++        batch, m, k = A.shape
++        batch_stride = A.stride(0)
++        out_batch_stride = out.stride(0)
++    if out.shape != (*A.shape[:-2], m, m):
++        raise ValueError("symmetric GEMM output has an invalid shape")
++    if C is not None and (
++        C.shape != out.shape
++        or C.dtype != out.dtype
++        or C.device != out.device
++        or not C.is_contiguous()
++    ):
++        raise ValueError("symmetric GEMM C tensor has incompatible metadata")
++    if autotune and (C is None or C.data_ptr() != out.data_ptr()):
++        key = (A.device, A.dtype, m, k, batch, C is not None)
++        config = _AUTOTUNE_CACHE.get(key)
++        if config is None:
++            with torch.cuda.device(A.device):
++                capturing = torch.cuda.is_current_stream_capturing()
++            if not capturing:
++                with _AUTOTUNE_LOCK:
++                    config = _AUTOTUNE_CACHE.get(key)
++                    if config is None:
++                        config = _autotune_gemm_symmetric(A, out, C, alpha, beta)
++                        _AUTOTUNE_CACHE[key] = config
++        if config is not None:
++            tile_shape_mn, cluster_shape_mnk, scheduler_group_size = config
++    A_p = A.as_strided((m, k, batch), (A.stride(-2), A.stride(-1), batch_stride))
++    D_p = out.as_strided(
++        (m, m, batch), (out.stride(-2), out.stride(-1), out_batch_stride)
++    )
++    PostAct_p = out.as_strided(
++        (m, m, batch), (out.stride(-1), out.stride(-2), out_batch_stride)
++    )
++    C_p = (
++        C.as_strided(
++            (m, m, batch),
++            (C.stride(-2), C.stride(-1), C.stride(0) if C.ndim == 3 else 0),
+         )
+-
+-    tile_shape_mn = (tile_M, tile_N, tile_K) if tile_K is not None else (tile_M, tile_N)
+-    cluster_shape_mnk = (cluster_M, cluster_N, 1)
+-    alpha_mode = 2 if isinstance(alpha, Tensor) else (1 if alpha != 1.0 else 0)
+-    beta_mode = 2 if isinstance(beta, Tensor) else (1 if beta != 1.0 else 0)
+-
++        if C is not None
++        else None
++    )
++    a_major = get_major(A_p, "m", "k")
++    d_major = get_major(D_p, "m", "n")
++    postact_major = get_major(PostAct_p, "m", "n")
++    a_dtype = torch2cute_dtype_map[A.dtype]
++    d_dtype = torch2cute_dtype_map[out.dtype]
+     compiled_fn = _compile_gemm_symmetric(
+         a_dtype,
+-        b_dtype,
+         d_dtype,
+-        c_dtype,
+-        c_major,
+-        postact_dtype,
+         a_major,
+-        b_major,
+         d_major,
+         postact_major,
+         tile_shape_mn,
+         cluster_shape_mnk,
+-        pingpong,
+-        persistent,
+-        is_dynamic_persistent,
+-        alpha_mode,
+-        beta_mode,
+         device_capacity,
++        C is not None,
+     )
+
+-    from quack.cache import is_compile_only
++    from .cache import is_compile_only
+
+     if is_compile_only():
+         return
+-
+-    cluster_size = cluster_M * cluster_N
+-    max_active_clusters = (
+-        get_max_active_clusters(cluster_size, device_capacity=device_capacity) if persistent else 0
+-    )
+-
+-    def scalar_arg(scalar, mode):
+-        if mode == 0:
+-            return None
+-        elif mode == 1:
+-            return Float32(scalar)
+-        else:
+-            return scalar.data_ptr()
+-
+-    epi_args = GemmActMixin.EpilogueArguments(
++    epi_args = GemmSymmetricMixin.EpilogueArguments(
+         PostAct_p,
+-        None,  # act_fn is Constexpr, baked in at compile time
+-        alpha=scalar_arg(alpha, alpha_mode),
+-        beta=scalar_arg(beta, beta_mode),
++        act_fn=None,
++        tensor_epilogue_fn=None,
++        tensor_epilogue_arg_kinds=None,
++        tensor_epilogue_returns_aux=None,
++        tensor_epilogue_returns_local_reduce=None,
++        local_reduce_feeds_main=None,
++        local_reduce_group=None,
++        local_reduce_axis=None,
++        local_reduce_combine_fn=None,
++        local_reduce_finalize_fn=None,
++        alpha=Float32(alpha) if alpha is not None else None,
++        beta=Float32(beta) if beta is not None else None,
+         rounding_mode=None,
+-        sr_seed=None,
+-    )
+-    scheduler_args = make_scheduler_args(
+-        max_active_clusters,
+-        max_swizzle_size,
+-        tile_count_semaphore,
+     )
+-    varlen_args = None
++    device_index = A.device.index
++    if device_index is None:
++        device_index = torch.cuda.current_device()
++    with torch.cuda.device(A.device):
++        scheduler_args = make_scheduler_args(
++            get_max_active_clusters(
++                cluster_shape_mnk[0] * cluster_shape_mnk[1],
++                device_capacity=device_capacity,
++                device_id=device_index,
++            ),
++            scheduler_group_size,
++            None,
++        )
++        compiled_fn(
++            A_p,
++            A_p,
++            D_p,
++            C_p,
++            epi_args,
++            scheduler_args,
++            None,
++            None,
++            None,
++            None,
++        )
+
+-    if device_capacity[0] in [10, 11]:
+-        compiled_fn(A_p, B_p, D_p, C_p, epi_args, scheduler_args, varlen_args, None, None, None)
++
++def _autotune_gemm_symmetric(
++    A: Tensor,
++    out: Tensor,
++    C: Tensor | None,
++    alpha: float | None,
++    beta: float | None,
++) -> tuple[tuple[int, int], tuple[int, int, int], int]:
++    if A.shape[-2] >= 4096:
++        candidates = tuple(
++            ((256, 256), (2, 1, 1), group_size)
++            for group_size in (2, 4, 8, 16, 32)
++        )
+     else:
+-        compiled_fn(A_p, B_p, D_p, C_p, epi_args, scheduler_args, varlen_args, None)
++        candidates = (
++            ((256, 256), (2, 1, 1), 8),
++            ((128, 128), (2, 1, 1), 8),
++            ((128, 128), (1, 1, 1), 8),
++        )
++    samples = {candidate: [] for candidate in candidates}
++    with torch.cuda.device(A.device):
++        for _ in range(25):
++            gemm_symmetric(A, out, C, alpha, beta)
++        for tile, cluster, group_size in candidates:
++            for _ in range(5):
++                gemm_symmetric(
++                    A,
++                    out,
++                    C,
++                    alpha,
++                    beta,
++                    tile_shape_mn=tile,
++                    cluster_shape_mnk=cluster,
++                    scheduler_group_size=group_size,
++                )
++        for round_index in range(8):
++            ordered = candidates if round_index % 2 == 0 else candidates[::-1]
++            for tile, cluster, group_size in ordered:
++                start = torch.cuda.Event(enable_timing=True)
++                end = torch.cuda.Event(enable_timing=True)
++                start.record()
++                for _ in range(5):
++                    gemm_symmetric(
++                        A,
++                        out,
++                        C,
++                        alpha,
++                        beta,
++                        tile_shape_mn=tile,
++                        cluster_shape_mnk=cluster,
++                        scheduler_group_size=group_size,
++                    )
++                end.record()
++                end.synchronize()
++                samples[(tile, cluster, group_size)].append(start.elapsed_time(end))
++    timings = [
++        (statistics.median(values), *candidate)
++        for candidate, values in samples.items()
++    ]
++    best = min(timings)
++    default = next(timing for timing in timings if timing[-1] == 8)
++    selected = default
++    if default[0] > 1.05 * best[0]:
++        confirmation = {tuple(default[1:]): [], tuple(best[1:]): []}
++        with torch.cuda.device(A.device):
++            for round_index in range(10):
++                ordered = tuple(confirmation)
++                if round_index % 2:
++                    ordered = ordered[::-1]
++                for tile, cluster, group_size in ordered:
++                    start = torch.cuda.Event(enable_timing=True)
++                    end = torch.cuda.Event(enable_timing=True)
++                    start.record()
++                    for _ in range(10):
++                        gemm_symmetric(
++                            A,
++                            out,
++                            C,
++                            alpha,
++                            beta,
++                            tile_shape_mn=tile,
++                            cluster_shape_mnk=cluster,
++                            scheduler_group_size=group_size,
++                        )
++                    end.record()
++                    end.synchronize()
++                    confirmation[(tile, cluster, group_size)].append(
++                        start.elapsed_time(end)
++                    )
++        default_time = statistics.median(confirmation[tuple(default[1:])])
++        best_time = statistics.median(confirmation[tuple(best[1:])])
++        if default_time > 1.05 * best_time:
++            selected = best
++    _, tile, cluster, group_size = selected
++    return tile, cluster, group_size

--- a/tools/vendoring/quack/flex_gemm_patches/series
+++ b/tools/vendoring/quack/flex_gemm_patches/series
@@ -17,3 +17,4 @@
 0012-flex-gemm-grouped-main-output.patch
 0013-flex-gemm-output-storage-layouts.patch
 0014-flex-gemm-bool-main-output.patch
+0015-inductor-symmetric-gemm.patch

--- a/tools/vendoring/quack/vendor.sh
+++ b/tools/vendoring/quack/vendor.sh
@@ -87,6 +87,7 @@ FILES=(
     gemm_blockscaled_interface.py
     gemm_config.py
     gemm_default_epi.py
+    gemm_symmetric.py
     gemm_sm100.py
     gemm_sm120.py
     gemm_sm80.py

--- a/torch/_vendor/quack/gemm_symmetric.py
+++ b/torch/_vendor/quack/gemm_symmetric.py
@@ -1,5 +1,3 @@
-# Copyright (c) 2025, Tri Dao.
-
 import statistics
 import threading
 

--- a/torch/_vendor/quack/gemm_symmetric.py
+++ b/torch/_vendor/quack/gemm_symmetric.py
@@ -1,0 +1,373 @@
+# Copyright (c) 2025, Tri Dao.
+
+import statistics
+import threading
+
+import torch
+from torch import Tensor
+
+import cutlass.cute as cute
+from cutlass import Float32
+
+from .cache import jit_cache
+from .compile_utils import make_fake_tensor as fake_tensor
+from .cute_dsl_utils import (
+    get_device_capacity,
+    get_max_active_clusters,
+    torch2cute_dtype_map,
+)
+from .gemm_default_epi import GemmDefaultEpiMixin
+from .gemm_act import GemmActMixin
+from .gemm_sm100 import GemmSm100
+from .gemm_tvm_ffi_utils import (
+    compile_gemm_kernel,
+    div_for_dtype,
+    get_major,
+    make_fake_scheduler_args,
+    make_scheduler_args,
+)
+from .tile_scheduler import TriangularTileScheduler
+
+
+class GemmSymmetricMixin(GemmActMixin):
+    EpilogueArguments = GemmActMixin.EpilogueArguments
+
+    def get_scheduler_class(self, varlen_m: bool = False):
+        return TriangularTileScheduler
+
+    @cute.jit
+    def epi_visit_subtile(self, params, epi_loop_tensors, tRS_rD, tRS_rC=None):
+        GemmDefaultEpiMixin.epi_visit_subtile(
+            self, params, epi_loop_tensors, tRS_rD, tRS_rC
+        )
+        return tRS_rD
+
+
+class GemmSymmetricSm100(GemmSymmetricMixin, GemmSm100):
+    pass
+
+
+_AUTOTUNE_CACHE: dict[
+    tuple[torch.device, torch.dtype, int, int, int, bool],
+    tuple[tuple[int, int], tuple[int, int, int], int],
+] = {}
+_AUTOTUNE_LOCK = threading.Lock()
+
+
+@jit_cache
+def _compile_gemm_symmetric(
+    a_dtype,
+    d_dtype,
+    a_major,
+    d_major,
+    postact_major,
+    tile_shape_mn,
+    cluster_shape_mnk,
+    device_capacity,
+    has_c,
+):
+    m, k, l = cute.sym_int(), cute.sym_int(), cute.sym_int()
+    div_a = div_for_dtype(a_dtype)
+    div_d = div_for_dtype(d_dtype)
+    mA = fake_tensor(
+        a_dtype,
+        (m, k, l),
+        leading_dim=1 if a_major == "k" else 0,
+        divisibility=div_a,
+    )
+    mB = fake_tensor(
+        a_dtype,
+        (m, k, l),
+        leading_dim=1 if a_major == "k" else 0,
+        divisibility=div_a,
+    )
+    mD = fake_tensor(
+        d_dtype,
+        (m, m, l),
+        leading_dim=1 if d_major == "n" else 0,
+        divisibility=div_d,
+    )
+    mC = (
+        fake_tensor(
+            d_dtype,
+            (m, m, l),
+            leading_dim=1 if d_major == "n" else 0,
+            divisibility=div_d,
+        )
+        if has_c
+        else None
+    )
+    mAuxOut = fake_tensor(
+        d_dtype,
+        (m, m, l),
+        leading_dim=1 if postact_major == "n" else 0,
+        divisibility=div_d,
+    )
+    epi_args = GemmSymmetricMixin.EpilogueArguments(
+        mAuxOut,
+        alpha=Float32(0.0) if has_c else None,
+        beta=Float32(0.0) if has_c else None,
+    )
+    scheduler_args = make_fake_scheduler_args(False, False, l)
+    return compile_gemm_kernel(
+        GemmSymmetricSm100,
+        a_dtype,
+        tile_shape_mn,
+        cluster_shape_mnk,
+        False,
+        True,
+        False,
+        True,
+        device_capacity,
+        mA,
+        mB,
+        mD,
+        mC,
+        epi_args,
+        scheduler_args,
+        None,
+    )
+
+
+def gemm_symmetric(
+    A: Tensor,
+    out: Tensor,
+    C: Tensor | None = None,
+    alpha: float | None = None,
+    beta: float | None = None,
+    *,
+    tile_shape_mn: tuple[int, int] = (256, 256),
+    cluster_shape_mnk: tuple[int, int, int] = (2, 1, 1),
+    scheduler_group_size: int = 8,
+    autotune: bool = False,
+) -> None:
+    """Compute a symmetric Gram matrix, optionally with a symmetric C epilogue.
+
+    Inputs are contiguous `(M, K)` tensors or homogeneous `(L, M, K)` batches.
+    When C is supplied, it must be symmetric and alpha and beta must also be
+    supplied; the result is `alpha * A @ A.mT + beta * C`.
+    """
+    if A.ndim not in (2, 3) or out.ndim != A.ndim:
+        raise NotImplementedError(
+            "vendored symmetric GEMM currently supports 2-D tensors or homogeneous batches"
+        )
+    if A.dtype not in (torch.float16, torch.bfloat16) or out.dtype != A.dtype:
+        raise NotImplementedError("vendored symmetric GEMM requires matching fp16 or bf16 tensors")
+    if not A.is_contiguous() or not out.is_contiguous():
+        raise ValueError("symmetric GEMM requires contiguous input and output tensors")
+    if out.device != A.device:
+        raise ValueError("symmetric GEMM input and output must be on the same device")
+    if not (
+        (C is None and alpha is None and beta is None)
+        or (C is not None and alpha is not None and beta is not None)
+    ):
+        raise ValueError("symmetric GEMM requires C, alpha, and beta together")
+    device_capacity = get_device_capacity(A.device)
+    if device_capacity[0] not in (10, 11):
+        raise NotImplementedError("vendored symmetric GEMM prototype requires SM100 or SM110")
+
+    if A.ndim == 2:
+        m, k = A.shape
+        batch = 1
+        batch_stride = 0
+        out_batch_stride = 0
+    else:
+        batch, m, k = A.shape
+        batch_stride = A.stride(0)
+        out_batch_stride = out.stride(0)
+    if out.shape != (*A.shape[:-2], m, m):
+        raise ValueError("symmetric GEMM output has an invalid shape")
+    if C is not None and (
+        C.shape != out.shape
+        or C.dtype != out.dtype
+        or C.device != out.device
+        or not C.is_contiguous()
+    ):
+        raise ValueError("symmetric GEMM C tensor has incompatible metadata")
+    if autotune and (C is None or C.data_ptr() != out.data_ptr()):
+        key = (A.device, A.dtype, m, k, batch, C is not None)
+        config = _AUTOTUNE_CACHE.get(key)
+        if config is None:
+            with torch.cuda.device(A.device):
+                capturing = torch.cuda.is_current_stream_capturing()
+            if not capturing:
+                with _AUTOTUNE_LOCK:
+                    config = _AUTOTUNE_CACHE.get(key)
+                    if config is None:
+                        config = _autotune_gemm_symmetric(A, out, C, alpha, beta)
+                        _AUTOTUNE_CACHE[key] = config
+        if config is not None:
+            tile_shape_mn, cluster_shape_mnk, scheduler_group_size = config
+    A_p = A.as_strided((m, k, batch), (A.stride(-2), A.stride(-1), batch_stride))
+    D_p = out.as_strided(
+        (m, m, batch), (out.stride(-2), out.stride(-1), out_batch_stride)
+    )
+    PostAct_p = out.as_strided(
+        (m, m, batch), (out.stride(-1), out.stride(-2), out_batch_stride)
+    )
+    C_p = (
+        C.as_strided(
+            (m, m, batch),
+            (C.stride(-2), C.stride(-1), C.stride(0) if C.ndim == 3 else 0),
+        )
+        if C is not None
+        else None
+    )
+    a_major = get_major(A_p, "m", "k")
+    d_major = get_major(D_p, "m", "n")
+    postact_major = get_major(PostAct_p, "m", "n")
+    a_dtype = torch2cute_dtype_map[A.dtype]
+    d_dtype = torch2cute_dtype_map[out.dtype]
+    compiled_fn = _compile_gemm_symmetric(
+        a_dtype,
+        d_dtype,
+        a_major,
+        d_major,
+        postact_major,
+        tile_shape_mn,
+        cluster_shape_mnk,
+        device_capacity,
+        C is not None,
+    )
+
+    from .cache import is_compile_only
+
+    if is_compile_only():
+        return
+    epi_args = GemmSymmetricMixin.EpilogueArguments(
+        PostAct_p,
+        act_fn=None,
+        tensor_epilogue_fn=None,
+        tensor_epilogue_arg_kinds=None,
+        tensor_epilogue_returns_aux=None,
+        tensor_epilogue_returns_local_reduce=None,
+        local_reduce_feeds_main=None,
+        local_reduce_group=None,
+        local_reduce_axis=None,
+        local_reduce_combine_fn=None,
+        local_reduce_finalize_fn=None,
+        alpha=Float32(alpha) if alpha is not None else None,
+        beta=Float32(beta) if beta is not None else None,
+        rounding_mode=None,
+    )
+    device_index = A.device.index
+    if device_index is None:
+        device_index = torch.cuda.current_device()
+    with torch.cuda.device(A.device):
+        scheduler_args = make_scheduler_args(
+            get_max_active_clusters(
+                cluster_shape_mnk[0] * cluster_shape_mnk[1],
+                device_capacity=device_capacity,
+                device_id=device_index,
+            ),
+            scheduler_group_size,
+            None,
+        )
+        compiled_fn(
+            A_p,
+            A_p,
+            D_p,
+            C_p,
+            epi_args,
+            scheduler_args,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def _autotune_gemm_symmetric(
+    A: Tensor,
+    out: Tensor,
+    C: Tensor | None,
+    alpha: float | None,
+    beta: float | None,
+) -> tuple[tuple[int, int], tuple[int, int, int], int]:
+    if A.shape[-2] >= 4096:
+        candidates = tuple(
+            ((256, 256), (2, 1, 1), group_size)
+            for group_size in (2, 4, 8, 16, 32)
+        )
+    else:
+        candidates = (
+            ((256, 256), (2, 1, 1), 8),
+            ((128, 128), (2, 1, 1), 8),
+            ((128, 128), (1, 1, 1), 8),
+        )
+    samples = {candidate: [] for candidate in candidates}
+    with torch.cuda.device(A.device):
+        for _ in range(25):
+            gemm_symmetric(A, out, C, alpha, beta)
+        for tile, cluster, group_size in candidates:
+            for _ in range(5):
+                gemm_symmetric(
+                    A,
+                    out,
+                    C,
+                    alpha,
+                    beta,
+                    tile_shape_mn=tile,
+                    cluster_shape_mnk=cluster,
+                    scheduler_group_size=group_size,
+                )
+        for round_index in range(8):
+            ordered = candidates if round_index % 2 == 0 else candidates[::-1]
+            for tile, cluster, group_size in ordered:
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                for _ in range(5):
+                    gemm_symmetric(
+                        A,
+                        out,
+                        C,
+                        alpha,
+                        beta,
+                        tile_shape_mn=tile,
+                        cluster_shape_mnk=cluster,
+                        scheduler_group_size=group_size,
+                    )
+                end.record()
+                end.synchronize()
+                samples[(tile, cluster, group_size)].append(start.elapsed_time(end))
+    timings = [
+        (statistics.median(values), *candidate)
+        for candidate, values in samples.items()
+    ]
+    best = min(timings)
+    default = next(timing for timing in timings if timing[-1] == 8)
+    selected = default
+    if default[0] > 1.05 * best[0]:
+        confirmation = {tuple(default[1:]): [], tuple(best[1:]): []}
+        with torch.cuda.device(A.device):
+            for round_index in range(10):
+                ordered = tuple(confirmation)
+                if round_index % 2:
+                    ordered = ordered[::-1]
+                for tile, cluster, group_size in ordered:
+                    start = torch.cuda.Event(enable_timing=True)
+                    end = torch.cuda.Event(enable_timing=True)
+                    start.record()
+                    for _ in range(10):
+                        gemm_symmetric(
+                            A,
+                            out,
+                            C,
+                            alpha,
+                            beta,
+                            tile_shape_mn=tile,
+                            cluster_shape_mnk=cluster,
+                            scheduler_group_size=group_size,
+                        )
+                    end.record()
+                    end.synchronize()
+                    confirmation[(tile, cluster, group_size)].append(
+                        start.elapsed_time(end)
+                    )
+        default_time = statistics.median(confirmation[tuple(default[1:])])
+        best_time = statistics.median(confirmation[tuple(best[1:])])
+        if default_time > 1.05 * best_time:
+            selected = best
+    _, tile, cluster, group_size = selected
+    return tile, cluster, group_size


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194181
* #194180
* #194179
* #194178
* __->__ #194177

Human commentary from the author: "and add architecture descriptions and examples to each PR to make it clear"

> AI-assisted change description:
>
> ## Summary
>
> A product such as `X @ X.T` is symmetric, so a conventional GEMM computes
> two equal output triangles. Vendor the existing QuACK symmetric GEMM from the
> pinned upstream revision and adapt it to PyTorch runtime interfaces. The kernel
> schedules one triangle and writes each result to both symmetric locations. It
> supports contiguous FP16 and BF16 matrices, homogeneous batches, and an optional
> symmetric `C` epilogue.
>
> ## Architecture
>
> The vendoring script copies `quack/gemm_symmetric.py` from QuACK commit
> `99bd7973bf3dc6db40961e413d4bdfea6c6fee3e` and applies the PyTorch adaptation
> in `0015-inductor-symmetric-gemm.patch`. The resulting kernel composes existing
> QuACK building blocks rather than defining another GEMM mainloop:
>
> ```text
> GemmSm100 tensor-core mainloop
>          +
> GemmSymmetricMixin
>   - selects TriangularTileScheduler
>   - exposes the transposed output view to the epilogue
>          =
> GemmSymmetricSm100
> ```
>
> `TriangularTileScheduler` assigns only tiles on one side of the diagonal.
> The normal SM100 TMA, MMA, pipeline, and cluster implementation remains
> unchanged. The epilogue stores the computed tile through both the ordinary
> and transposed output views, producing a dense symmetric result without a
> second GEMM.
>
> The compiled kernel uses symbolic `M`, `K`, and batch dimensions, so one
> compiled binary can serve multiple sizes with the same dtype, layout, tile,
> and epilogue configuration. The existing QuACK object cache stores the
> compiled binary. Optional runtime autotuning selects between a small set of
> tile, cluster, and scheduler-group configurations and remembers the result.
>
> Supported operations are:
>
> ```text
> D = A @ A.mT
> D = alpha * A @ A.mT + beta * C    # C must also be symmetric
> ```
>
> ## Example
>
> ```python
> from torch._vendor.quack.gemm_symmetric import gemm_symmetric
>
> x = torch.randn(4096, 14336, device="cuda", dtype=torch.bfloat16)
> gram = torch.empty(4096, 4096, device="cuda", dtype=torch.bfloat16)
> gemm_symmetric(x, gram, autotune=True)
> torch.testing.assert_close(gram, x @ x.T)
>
> update = torch.empty_like(gram)
> gemm_symmetric(
>     gram,
>     update,
>     C=gram,
>     alpha=2.0315,
>     beta=-4.775,
>     autotune=True,
> )
> ```
>
> Unsupported architectures, dtypes, layouts, or shapes raise before launch;
> later integration commits decide when to select this kernel versus GEMM.
>
> ## Benchmark results
>
> Development measurements used BF16 on an NVIDIA GB200 and compare against
> the ordinary cuBLAS GEMM used for `A @ A.T`:
>
> | `A` shape | symmetric kernel | cuBLAS | speedup |
> |---|---:|---:|---:|
> | `(4096, 11008)` | 0.143 ms | 0.256 ms | 1.79x |
> | `(4096, 14336)` | 0.182 ms | 0.294 ms | 1.62x |
> | `(8192, 28672)` | 1.328 ms | 2.450 ms | 1.85x |
>
> The measured outputs were exactly symmetric, with maximum error versus the
> FP32 reference of approximately 0.004. These are development microbenchmarks,
> not performance guarantees.
>
> ## Test Plan
>
> ```text
> CUDA_VISIBLE_DEVICES=0 TORCHINDUCTOR_CACHE_DIR=/tmp/codex-pytorch2-final-symmetric-cache .venv/bin/python test/inductor/test_symmetric_mm.py -v
> CUDA_VISIBLE_DEVICES=0,1 .venv/bin/python -c 'import torch; from torch._vendor.quack.gemm_symmetric import gemm_symmetric; torch.cuda.set_device(0); x=torch.randn(512,1024,device="cuda:1",dtype=torch.bfloat16); out=torch.empty(512,512,device="cuda:1",dtype=torch.bfloat16); gemm_symmetric(x,out); torch.cuda.synchronize(1); torch.testing.assert_close(out,x@x.T); assert torch.cuda.current_device()==0'
> source .venv/bin/activate && lintrunner -a
> ```
>
> Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo