### PR TITLE
[optim] Let compiled Muon process updates together

### DIFF
--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -70,6 +70,22 @@ def _zeropower_via_newtonschulz(
     return ortho_grad
 
 
+def _foreach_zeropower_via_newtonschulz(
+    grad: Tensor, a: float, b: float, c: float, ns_steps: int, eps: float
+) -> Tensor:
+    transpose = grad.size(0) > grad.size(1)
+    ortho_grad = grad.bfloat16()
+    ortho_grad = ortho_grad.T if transpose else ortho_grad
+    ortho_grad = ortho_grad / ortho_grad.norm().clamp(min=eps)
+    for _ in range(ns_steps):
+        gram_matrix = ortho_grad @ ortho_grad.T
+        gram_update = torch.addmm(
+            gram_matrix, gram_matrix, gram_matrix, beta=b, alpha=c
+        )
+        ortho_grad = torch.addmm(ortho_grad, gram_update, ortho_grad, beta=a)
+    return ortho_grad.T if transpose else ortho_grad
+
+
 def _adjust_lr(lr: float, adjust_lr_fn: str | None, param_shape: torch.Size) -> float:
     """Default learning rate adjustment used by Muon."""
     A, B = param_shape[:2]
@@ -192,6 +208,7 @@ class Muon(Optimizer):
                 params_with_grad,
                 grads,
                 muon_momentum_bufs,
+                foreach=torch.compiler.is_compiling(),
                 lr=lr,
                 weight_decay=weight_decay,
                 momentum=momentum,
@@ -351,6 +368,48 @@ def _single_tensor_muon(
         param.add_(update, alpha=-adjusted_lr)
 
 
+def _foreach_muon(
+    params: list[Tensor],
+    grads: list[Tensor],
+    muon_momentum_bufs: list[Tensor],
+    *,
+    lr: float,
+    weight_decay: float,
+    momentum: float,
+    nesterov: bool,
+    ns_coefficients: tuple[float, float, float],
+    ns_steps: int,
+    eps: float,
+    adjust_lr_fn: str | None,
+    has_complex: bool,
+) -> None:
+    from torch._higher_order_ops import foreach_map
+
+    if has_complex:
+        raise ValueError("Complex parameters are not supported")
+    lr = _to_scalar(lr)
+    torch._foreach_lerp_(muon_momentum_bufs, grads, 1 - momentum)
+    updates = (
+        torch._foreach_lerp(grads, muon_momentum_bufs, momentum)
+        if nesterov
+        else muon_momentum_bufs
+    )
+    a, b, c = ns_coefficients
+    updates = foreach_map(
+        _foreach_zeropower_via_newtonschulz,
+        updates,
+        a,
+        b,
+        c,
+        ns_steps,
+        eps,
+    )
+    for param, update in zip(params, updates):
+        adjusted_lr = _adjust_lr(lr, adjust_lr_fn, param.shape)
+        param.mul_(1 - lr * weight_decay)
+        param.add_(update, alpha=-adjusted_lr)
+
+
 @_disable_dynamo_if_unsupported(single_tensor_fn=_single_tensor_muon)
 def muon(
     params: list[Tensor],
@@ -372,10 +431,7 @@ def muon(
 
     See :class:`~torch.optim.Muon` for details.
     """
-    if foreach is not None and foreach:
-        raise RuntimeError("Foreach is not supported for Muon yet")
-
-    func = _single_tensor_muon
+    func = _foreach_muon if foreach else _single_tensor_muon
 
     func(
         params,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194181
* __->__ #194180
* #194179
* #194178
* #194177

Human commentary from the author: "and add architecture descriptions and examples to each PR to make it clear"

> AI-assisted change description:
>
> ## Summary
>
> Express Muon's Newton-Schulz calculation with `foreach_map` while
> `torch.compile` is tracing the optimizer. This preserves the fact that the
> same function is applied to a list of independent updates, enabling a later
> Inductor lowering to plan them together.
>
> ## Architecture
>
> Before this change, tracing observed a sequence of unrelated scalar tensor
> programs:
>
> ```text
> update_0 -> Newton-Schulz body
> update_1 -> Newton-Schulz body
> update_2 -> Newton-Schulz body
> ```
>
> The compiled path now exposes one higher-order operation:
>
> ```text
> foreach_map(Newton-Schulz body, [update_0, update_1, update_2])
> ```
>
> `_foreach_zeropower_via_newtonschulz` contains the same normalization,
> quintic coefficients, iteration count, and transpose behavior as the
> existing scalar implementation. `Muon.step()` selects this representation
> only while the compiler is tracing; ordinary eager execution remains on the
> existing one-tensor-at-a-time path in this commit. The functional `muon()`
> API continues to honor its explicit `foreach` choice.
>
> This commit changes the captured program structure but does not itself pick
> a grouped GPU kernel. Unsupported compiler backends can still execute the
> `foreach_map` body normally.
>
> ## Example
>
> ```python
> params = [
>     torch.randn(1536, 5120, device="cuda", requires_grad=True),
>     torch.randn(2048, 7168, device="cuda", requires_grad=True),
> ]
> optimizer = torch.optim.Muon(params, lr=1e-3)
>
> for param in params:
>     param.grad = torch.randn_like(param)
>
> compiled_step = torch.compile(optimizer.step, fullgraph=True)
> compiled_step()
> ```
>
> The captured graph contains one `foreach_map` whose tensor lanes correspond
> to the two parameter updates.
>
> ## Benchmark results
>
> This is an enabling graph-representation change rather than a standalone
> kernel optimization. On an NVIDIA GB200, one unbatched `(2048, 7168)` full
> Muon step took 0.7776 ms with the symmetric path versus 0.6307 ms with the
> ordinary PyTorch path (0.81x), while grouping 4-384 matrices of that shape
> made the Gram calculation 1.62-1.75x faster. Preserving the list structure
> in `foreach_map` is what lets the following lowering recover that missing
> parallelism.
>
> ## Test Plan
>
> ```text
> CUDA_VISIBLE_DEVICES=1 .venv/bin/python test/test_optim.py -k Muon -v
> CUDA_VISIBLE_DEVICES=0 TORCHINDUCTOR_CACHE_DIR=/tmp/codex-pytorch2-final-symmetric-cache .venv/bin/python test/inductor/test_symmetric_mm.py -v
> source .venv/bin/activate && lintrunner -a
> ```
>
> Authored with an AI assistant.