### PR TITLE
[inductor] Speed up batches of Muon updates

### DIFF
--- a/test/inductor/test_symmetric_mm.py
+++ b/test/inductor/test_symmetric_mm.py
@@ -1,0 +1,379 @@
+# Owner(s): ["module: inductor", "module: optimizer"]
+
+from unittest import mock
+
+import torch
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import parametrize, run_tests, TestCase
+
+
+class SymmetricMMTest(TestCase):
+    def _check_grouped_muon(
+        self,
+        params,
+        expected_plans=1,
+        *,
+        lr=1e-3,
+        nesterov=True,
+        ns_steps=5,
+        adjust_lr_fn=None,
+    ):
+        from torch._inductor.kernel.muon import _PLAN_CACHE
+        from torch.optim._muon import muon
+
+        _PLAN_CACHE.clear()
+        expected = [param.clone() for param in params]
+        expected_bufs = [torch.zeros_like(param) for param in params]
+        optimizer = torch.optim.Muon(
+            params,
+            lr=lr,
+            nesterov=nesterov,
+            ns_steps=ns_steps,
+            adjust_lr_fn=adjust_lr_fn,
+        )
+        stream = torch.cuda.Stream(device=params[0].device)
+        torch._dynamo.reset()
+        compiled_step = torch.compile(optimizer.step, fullgraph=True)
+        with torch.cuda.stream(stream):
+            for _ in range(2):
+                grads = [torch.randn_like(param) for param in params]
+                for param, grad in zip(params, grads):
+                    param.grad = grad
+                compiled_step()
+
+                with torch.no_grad():
+                    muon(
+                        expected,
+                        grads,
+                        expected_bufs,
+                        lr=lr,
+                        weight_decay=0.1,
+                        momentum=0.95,
+                        nesterov=nesterov,
+                        ns_coefficients=(3.4445, -4.775, 2.0315),
+                        ns_steps=ns_steps,
+                        eps=1e-7,
+                        adjust_lr_fn=adjust_lr_fn,
+                        has_complex=False,
+                    )
+        stream.synchronize()
+        self.assertEqual(params, expected, rtol=2e-2, atol=2e-2)
+        plans = next(iter(_PLAN_CACHE.values()))
+        self.assertEqual(
+            sum(plan is not None for _, plan in plans.chunks), expected_plans
+        )
+        return plans
+
+    def test_grouped_muon_rejects_inexact_normalization(self, device):
+        from torch._inductor.kernel.muon import match_muon_foreach
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        x.meta["val"] = torch.empty(8, 16, device=device, dtype=torch.bfloat16)
+        denominator = graph.call_function(torch.ops.aten.clamp_min.default, (x, 1e-7))
+        normalized = graph.call_function(torch.ops.aten.div.Tensor, (x, denominator))
+        transpose = graph.call_function(
+            torch.ops.aten.permute.default, (normalized, [1, 0])
+        )
+        gram = graph.call_function(torch.ops.aten.mm.default, (normalized, transpose))
+        update = graph.call_function(
+            torch.ops.aten.addmm.default,
+            (gram, gram, gram),
+            {"beta": -4.775, "alpha": 2.0315},
+        )
+        result = graph.call_function(
+            torch.ops.aten.addmm.default,
+            (normalized, update, normalized),
+            {"beta": 3.4445},
+        )
+        graph.output(result)
+
+        self.assertIsNone(match_muon_foreach(torch.fx.GraphModule({}, graph)))
+
+    @parametrize("shape", [(4096, 4096), (5120, 8192)])
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_quack_symmetric_mm(self, device, shape, dtype):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        def fn(x):
+            return x @ x.T
+
+        from torch._vendor.quack.gemm_symmetric import _AUTOTUNE_CACHE
+
+        x = torch.randn(shape, device=device, dtype=dtype)
+        _AUTOTUNE_CACHE.clear()
+        torch._dynamo.reset()
+        compiled = torch.compile(fn, fullgraph=True)
+        stream = torch.cuda.Stream(device=device)
+        with torch.cuda.stream(stream):
+            actual = compiled(x)
+            expected = fn(x)
+        stream.synchronize()
+        self.assertTrue(
+            any(key[2:5] == (shape[0], shape[1], 1) for key in _AUTOTUNE_CACHE)
+        )
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual, actual.T)
+
+    @parametrize("shape", [(2, 4096, 4096), (2, 4096, 8192)])
+    def test_quack_batched_symmetric_mm(self, device, shape):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        def fn(x):
+            return torch.bmm(x, x.mT)
+
+        from torch._vendor.quack.gemm_symmetric import _AUTOTUNE_CACHE
+
+        x = torch.randn(shape, device=device, dtype=torch.bfloat16)
+        _AUTOTUNE_CACHE.clear()
+        torch._dynamo.reset()
+        actual = torch.compile(fn, fullgraph=True)(x)
+        used_quack = any(
+            key[2:5] == (shape[-2], shape[-1], shape[0]) for key in _AUTOTUNE_CACHE
+        )
+        self.assertEqual(used_quack, shape[-2] == shape[-1])
+        self.assertEqual(actual, fn(x))
+        self.assertEqual(actual, actual.mT)
+
+    def test_quack_symmetric_mm_requires_cutedsl(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        from torch._vendor.quack.gemm_symmetric import _AUTOTUNE_CACHE
+
+        x = torch.randn(4096, 4352, device=device, dtype=torch.bfloat16)
+        _AUTOTUNE_CACHE.clear()
+        torch._dynamo.reset()
+        with mock.patch(
+            "torch._inductor.fx_passes.post_grad.ensure_cute_available",
+            return_value=False,
+        ):
+            actual = torch.compile(lambda value: value @ value.T, fullgraph=True)(x)
+        self.assertEqual(actual, x @ x.T)
+        self.assertEqual(_AUTOTUNE_CACHE, {})
+
+    def test_quack_grouped_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        from torch._vendor.quack.gemm_symmetric import gemm_symmetric
+
+        x = torch.randn(2, 512, 1024, device=device, dtype=torch.bfloat16)
+        gram = torch.empty(2, 512, 512, device=device, dtype=torch.bfloat16)
+        gemm_symmetric(x, gram)
+        self.assertEqual(gram, torch.bmm(x, x.mT))
+
+        update = torch.empty_like(gram)
+        gemm_symmetric(gram, update, C=gram, alpha=2.0315, beta=-4.775)
+        expected = torch.baddbmm(gram, gram, gram, beta=-4.775, alpha=2.0315)
+        self.assertEqual(update, expected, rtol=2e-2, atol=5e-1)
+        self.assertEqual(update, update.mT)
+
+    def test_quack_pointer_grouped_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        from torch._inductor.kernel.grouped_symmetric_mm import GroupedSymmetricPlan
+
+        inputs = [
+            torch.randn(512, 1024, device=device, dtype=torch.bfloat16),
+            torch.randn(768, 1536, device=device, dtype=torch.bfloat16),
+        ]
+        gram_plan = GroupedSymmetricPlan(inputs)
+        with self.assertRaisesRegex(ValueError, "compiled.*incompatible"):
+            GroupedSymmetricPlan(inputs[:1], compiled_plan=gram_plan)
+        grams = gram_plan()
+        for x, gram in zip(inputs, grams):
+            self.assertEqual(gram, torch.mm(x, x.T))
+
+        reuse_inputs = [
+            torch.randn(x.shape[0], 2048, device=device, dtype=torch.bfloat16)
+            for x in inputs
+        ]
+        reuse_plan = GroupedSymmetricPlan(reuse_inputs, compiled_plan=gram_plan)
+        self.assertIs(reuse_plan.compiled, gram_plan.compiled)
+        for x, gram in zip(reuse_inputs, reuse_plan()):
+            self.assertEqual(gram, torch.mm(x, x.T))
+
+        update_plan = GroupedSymmetricPlan(grams, c=grams, alpha=2.0315, beta=-4.775)
+        updates = update_plan()
+        for gram, update in zip(grams, updates):
+            expected = torch.addmm(gram, gram, gram, beta=-4.775, alpha=2.0315)
+            self.assertEqual(update, expected, rtol=2e-2, atol=5e-1)
+            self.assertEqual(update, update.T)
+
+    def test_muon_uses_grouped_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [
+            torch.randn(
+                (1536, 5120) if index % 2 == 0 else (5120, 1536),
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            for index in range(4)
+        ]
+        plans = self._check_grouped_muon(params)
+        plan = next(plan for _, plan in plans.chunks if plan is not None)
+        self.assertIs(plan.gram_plans[0].compiled, plan.update_plan.compiled)
+
+    def test_muon_foreach_map_compile(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        from torch.optim._muon import muon
+
+        params = [
+            torch.randn(512, 1024, device=device, dtype=torch.bfloat16)
+            for _ in range(4)
+        ]
+        grads = [torch.randn_like(param) for param in params]
+        bufs = [torch.zeros_like(param) for param in params]
+        expected = [param.clone() for param in params]
+        expected_bufs = [buf.clone() for buf in bufs]
+
+        def step(step_params, step_grads, step_bufs, foreach):
+            muon(
+                step_params,
+                step_grads,
+                step_bufs,
+                foreach=foreach,
+                lr=1e-3,
+                weight_decay=0.1,
+                momentum=0.95,
+                nesterov=True,
+                ns_coefficients=(3.4445, -4.775, 2.0315),
+                ns_steps=5,
+                eps=1e-7,
+                adjust_lr_fn=None,
+                has_complex=False,
+            )
+
+        step(expected, grads, expected_bufs, False)
+        torch.compile(step, fullgraph=True)(params, grads, bufs, True)
+        self.assertEqual(params, expected, rtol=2e-2, atol=2e-2)
+        self.assertEqual(bufs, expected_bufs)
+
+    def test_muon_merges_sparse_small_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [
+            torch.randn(m, 1024, device=device, dtype=torch.bfloat16)
+            for m in (128, 256, 512)
+            for _ in range(4)
+        ]
+        self._check_grouped_muon(params)
+
+    def test_muon_groups_heterogeneous_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = []
+        for k in (5120, 7168):
+            params.extend(
+                torch.randn(1536, k, device=device, dtype=torch.bfloat16)
+                for _ in range(4)
+            )
+        self._check_grouped_muon(params)
+
+    def test_muon_uses_singleton_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [torch.randn(4096, 8192, device=device, dtype=torch.bfloat16)]
+        self._check_grouped_muon(params)
+
+    @parametrize("count", [2, 4])
+    def test_muon_uses_direct_symmetric_mm(self, device, count):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [
+            torch.randn(
+                (4096, 8192) if index % 2 == 0 else (8192, 4096),
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            for index in range(count)
+        ]
+        self._check_grouped_muon(params)
+
+    def test_muon_groups_small_symmetric_mm(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [
+            torch.randn(m, 1024, device=device, dtype=torch.bfloat16)
+            for m in (128, 256)
+            for _ in range(10)
+        ]
+        self._check_grouped_muon(params, expected_plans=2)
+
+    @parametrize("dtype", [torch.float32, torch.float64])
+    @parametrize("contiguous", [True, False])
+    def test_muon_grouped_non_bfloat16_without_nesterov(
+        self, device, dtype, contiguous
+    ):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = []
+        for _ in range(4):
+            param = torch.randn(128, 1024, device=device, dtype=dtype)
+            params.append(param if contiguous else param.T.contiguous().T)
+        self._check_grouped_muon(params, expected_plans=0, nesterov=False, ns_steps=4)
+
+    @parametrize("lr_device", ["cpu", "cuda"])
+    def test_muon_grouped_tensor_lr(self, device, lr_device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [
+            torch.randn(128, 1024, device=device, dtype=torch.bfloat16)
+            for _ in range(4)
+        ]
+        lr = torch.tensor(1e-3, device=lr_device)
+        self._check_grouped_muon(params, lr=lr)
+
+    @parametrize("adjust_lr_fn", ["original", "match_rms_adamw", "spectral_unclamped"])
+    def test_muon_grouped_adjust_lr(self, device, adjust_lr_fn):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [
+            torch.randn(
+                (1536, 5120) if index % 2 == 0 else (5120, 1536),
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            for index in range(4)
+        ]
+        self._check_grouped_muon(params, adjust_lr_fn=adjust_lr_fn)
+
+    def test_muon_grouped_requires_cutedsl(self, device):
+        if torch.cuda.get_device_capability(device)[0] not in (10, 11):
+            self.skipTest("requires SM100 or SM110")
+
+        params = [
+            torch.randn(128, 1024, device=device, dtype=torch.bfloat16)
+            for _ in range(4)
+        ]
+        from torch._inductor.kernel.muon import _PLAN_CACHE
+
+        _PLAN_CACHE.clear()
+        with mock.patch(
+            "torch._inductor.utils.ensure_cute_available", return_value=False
+        ):
+            plans = self._check_grouped_muon(params, expected_plans=0)
+        self.assertTrue(all(plan is None for _, plan in plans.chunks))
+
+
+instantiate_device_type_tests(SymmetricMMTest, globals(), only_for="cuda")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/kernel/muon.py
+++ b/torch/_inductor/kernel/muon.py
@@ -1,0 +1,363 @@
+import math
+import threading
+from collections import OrderedDict
+from typing import Any
+
+import torch
+
+
+def _match_normalization(
+    placeholder: torch.fx.Node,
+    numerator: Any,
+    denominator: Any,
+) -> tuple[float, bool] | None:
+    """Match the decomposed BF16 X / max(||X||_F, eps) normalization."""
+
+    def converted_input(node: Any, dtype: torch.dtype) -> torch.fx.Node | None:
+        if (
+            isinstance(node, torch.fx.Node)
+            and node.target is torch.ops.prims.convert_element_type.default
+            and len(node.args) == 2
+            and node.args[1] is dtype
+            and not node.kwargs
+        ):
+            input_node = node.args[0]
+            return input_node if isinstance(input_node, torch.fx.Node) else None
+        return None
+
+    if not isinstance(numerator, torch.fx.Node):
+        return None
+    source = numerator
+    transposed = False
+    if source.target is torch.ops.aten.permute.default:
+        if source.args[1:] != ([1, 0],):
+            return None
+        source = source.args[0]
+        transposed = True
+    cast_source = converted_input(source, torch.bfloat16)
+    if cast_source is not None:
+        source = cast_source
+    else:
+        source_val = placeholder.meta.get("val")
+        if (
+            not isinstance(source_val, torch.Tensor)
+            or source_val.dtype is not torch.bfloat16
+        ):
+            return None
+    if source is not placeholder:
+        return None
+
+    clamp = converted_input(denominator, torch.bfloat16)
+    if (
+        not isinstance(clamp, torch.fx.Node)
+        or clamp.target is not torch.ops.aten.clamp_min.default
+        or len(clamp.args) != 2
+        or clamp.kwargs
+        or not isinstance(clamp.args[1], (int, float))
+    ):
+        return None
+    rounded_norm = converted_input(clamp.args[0], torch.float32)
+    norm = converted_input(rounded_norm, torch.bfloat16)
+    if (
+        not isinstance(norm, torch.fx.Node)
+        or norm.target is not torch.ops.aten.pow.Tensor_Scalar
+        or len(norm.args) != 2
+        or norm.args[1] != 0.5
+        or norm.kwargs
+    ):
+        return None
+    total = norm.args[0]
+    if (
+        not isinstance(total, torch.fx.Node)
+        or total.target is not torch.ops.aten.sum.dim_IntList
+        or len(total.args) != 2
+        or total.args[1] is not None
+        or total.kwargs
+    ):
+        return None
+    squared = total.args[0]
+    if (
+        not isinstance(squared, torch.fx.Node)
+        or squared.target is not torch.ops.aten.pow.Tensor_Scalar
+        or len(squared.args) != 2
+        or squared.args[1] != 2
+        or squared.kwargs
+        or converted_input(squared.args[0], torch.float32) is not numerator
+    ):
+        return None
+    return float(clamp.args[1]), transposed
+
+
+def match_muon_foreach(
+    gm: torch.fx.GraphModule,
+) -> tuple[tuple[float, float, float, int, float], list[int]] | None:
+    """Match the functional Muon Newton-Schulz body captured by foreach_map."""
+    all_placeholders = [node for node in gm.graph.nodes if node.op == "placeholder"]
+    positions = [
+        index
+        for index, node in enumerate(all_placeholders)
+        if isinstance(node.meta.get("val"), torch.Tensor)
+    ]
+    placeholders = [all_placeholders[index] for index in positions]
+    output = next((node for node in gm.graph.nodes if node.op == "output"), None)
+    if output is None or len(output.args) != 1:
+        return None
+    outputs = output.args[0]
+    if isinstance(outputs, torch.fx.Node) and len(placeholders) == 1:
+        outputs = (outputs,)
+    if not isinstance(outputs, (list, tuple)) or len(outputs) != len(placeholders):
+        return None
+    options: tuple[float, float, float, int, float] | None = None
+    for placeholder, result in zip(placeholders, outputs):
+        if not isinstance(result, torch.fx.Node):
+            return None
+        output_transposed = False
+        if result.target is torch.ops.aten.permute.default:
+            if result.args[1] != [1, 0]:
+                return None
+            result = result.args[0]
+            output_transposed = True
+        steps = 0
+        lane_options = None
+        while (
+            isinstance(result, torch.fx.Node)
+            and result.target is torch.ops.aten.addmm.default
+            and "alpha" not in result.kwargs
+        ):
+            x, gram_update, rhs = result.args
+            if (
+                x is not rhs
+                or not isinstance(gram_update, torch.fx.Node)
+                or gram_update.target is not torch.ops.aten.addmm.default
+            ):
+                return None
+            gram = gram_update.args[0]
+            if gram_update.args != (gram, gram, gram) or not isinstance(
+                gram, torch.fx.Node
+            ):
+                return None
+            if gram.target is torch.ops.inductor.quack_symmetric_mm.default:
+                if gram.args != (x,):
+                    return None
+            else:
+                if (
+                    gram.target is not torch.ops.aten.mm.default
+                    or gram.args[0] is not x
+                ):
+                    return None
+                transpose = gram.args[1]
+                if (
+                    not isinstance(transpose, torch.fx.Node)
+                    or transpose.target is not torch.ops.aten.permute.default
+                    or transpose.args != (x, [1, 0])
+                ):
+                    return None
+            current = (
+                result.kwargs["beta"],
+                gram_update.kwargs.get("beta", 1.0),
+                gram_update.kwargs.get("alpha", 1.0),
+            )
+            if lane_options is not None and current != lane_options:
+                return None
+            lane_options = current
+            result = x
+            steps += 1
+        if (
+            steps == 0
+            or not isinstance(result, torch.fx.Node)
+            or result.target is not torch.ops.aten.div.Tensor
+            or len(result.args) != 2
+        ):
+            return None
+        normalization = _match_normalization(placeholder, *result.args)
+        if normalization is None:
+            return None
+        eps, input_transposed = normalization
+        if input_transposed != output_transposed or lane_options is None:
+            return None
+        a, b, c = lane_options
+        if not (
+            isinstance(a, (int, float))
+            and isinstance(b, (int, float))
+            and isinstance(c, (int, float))
+        ):
+            return None
+        lane_options = (
+            float(a),
+            float(b),
+            float(c),
+            steps,
+            float(eps),
+        )
+        if options is not None and lane_options != options:
+            return None
+        options = lane_options
+    return (options, positions) if options is not None else None
+
+
+def _reference(
+    x: torch.Tensor,
+    coefficients: tuple[float, float, float],
+    steps: int,
+    eps: float,
+) -> torch.Tensor:
+    transpose = x.shape[0] > x.shape[1]
+    x = x.T if transpose else x
+    x = x.bfloat16() / x.bfloat16().norm().clamp_min(eps)
+    a, b, c = coefficients
+    for _ in range(steps):
+        gram = x @ x.T
+        update = torch.addmm(gram, gram, gram, beta=b, alpha=c)
+        x = torch.addmm(x, update, x, beta=a)
+    return x.T if transpose else x
+
+
+def _supports(
+    device: torch.device,
+    dtype: torch.dtype,
+    shapes: list[tuple[int, int]],
+    steps: int,
+) -> bool:
+    if device.type != "cuda" or dtype is not torch.bfloat16 or steps == 0:
+        return False
+    from torch._inductor.utils import ensure_cute_available
+
+    m = shapes[0][0]
+    count = len(shapes)
+    max_k = max(shape[1] for shape in shapes)
+    return (
+        ensure_cute_available()
+        and torch.cuda.get_device_capability(device)[0] in (10, 11)
+        and (count >= 4 or m >= 5120 or (m >= 4096 and (count >= 2 or max_k >= 2 * m)))
+    )
+
+
+class _MuonForeachPlan:
+    def __init__(
+        self,
+        inputs: list[torch.Tensor],
+        coefficients: tuple[float, float, float],
+        steps: int,
+    ) -> None:
+        self._run_lock = threading.Lock()
+        buckets: dict[tuple[torch.device, int | tuple[int, int]], list[int]] = {}
+        small: dict[torch.device, dict[tuple[int, int], list[int]]] = {}
+        for index, x in enumerate(inputs):
+            shape = (min(x.shape), max(x.shape))
+            m = shape[0]
+            if m <= 1024:
+                small.setdefault(x.device, {}).setdefault(shape, []).append(index)
+            else:
+                bucket = shape if m >= 4096 else m
+                buckets.setdefault((x.device, bucket), []).append(index)
+        for device, shape_buckets in small.items():
+            remainder = []
+            for shape, indices in shape_buckets.items():
+                if len(indices) >= 6:
+                    buckets[(device, shape)] = indices
+                else:
+                    remainder.extend(indices)
+            if remainder:
+                buckets[(device, 0)] = remainder
+        self.chunks: list[tuple[list[int], Any | None]] = []
+        for (device, _), indices in buckets.items():
+            indices.sort(
+                key=lambda index: (min(inputs[index].shape), max(inputs[index].shape))
+            )
+            m = min(inputs[indices[0]].shape)
+            max_chunk = 4 if m >= 7168 else 8 if m >= 4096 else 32
+            count = math.ceil(len(indices) / max_chunk)
+            size, extra = divmod(len(indices), count)
+            offset = 0
+            for chunk_index in range(count):
+                chunk = indices[offset : offset + size + (chunk_index < extra)]
+                offset += len(chunk)
+                shapes = [
+                    (min(inputs[index].shape), max(inputs[index].shape))
+                    for index in chunk
+                ]
+                plan = None
+                if _supports(device, inputs[chunk[0]].dtype, shapes, steps):
+                    from .grouped_symmetric_mm import (
+                        GroupedMuonPlan,
+                        PackedSymmetricMuonPlan,
+                        SequentialSymmetricMuonPlan,
+                    )
+
+                    if len(shapes) <= 3:
+                        plan = SequentialSymmetricMuonPlan(
+                            shapes, device, coefficients, steps
+                        )
+                    elif shapes[0][0] >= 4096 and all(
+                        shape == shapes[0] for shape in shapes
+                    ):
+                        plan = PackedSymmetricMuonPlan(
+                            shapes, device, coefficients, steps
+                        )
+                    else:
+                        plan = GroupedMuonPlan(shapes, device, coefficients, steps)
+                self.chunks.append((chunk, plan))
+        self.coefficients = coefficients
+        self.steps = steps
+
+    def __call__(self, inputs: list[torch.Tensor], eps: float) -> list[torch.Tensor]:
+        outputs = [inputs[0]] * len(inputs)
+        for indices, plan in self.chunks:
+            selected = [inputs[index] for index in indices]
+            if plan is None:
+                results = [
+                    _reference(x, self.coefficients, self.steps, eps) for x in selected
+                ]
+            else:
+                results = plan(selected, eps)
+                results = [
+                    result.T if source.shape[0] > source.shape[1] else result
+                    for source, result in zip(selected, results)
+                ]
+            for index, result in zip(indices, results):
+                outputs[index] = result.clone(memory_format=torch.contiguous_format)
+        return outputs
+
+
+_PLAN_CACHE: OrderedDict[tuple[Any, ...], _MuonForeachPlan] = OrderedDict()
+_PLAN_LOCK = threading.Lock()
+_MAX_CACHED_PLANS = 32
+
+
+@torch.library.custom_op("inductor::grouped_muon", mutates_args=())
+def grouped_muon(
+    inputs: list[torch.Tensor], a: float, b: float, c: float, steps: int, eps: float
+) -> list[torch.Tensor]:
+    streams = tuple(
+        torch.cuda.current_stream(x.device).cuda_stream
+        if x.device.type == "cuda"
+        else None
+        for x in inputs
+    )
+    key = (
+        tuple((x.device, x.dtype, tuple(x.shape)) for x in inputs),
+        streams,
+        a,
+        b,
+        c,
+        steps,
+    )
+    with _PLAN_LOCK:
+        plan = _PLAN_CACHE.get(key)
+        if plan is None:
+            plan = _MuonForeachPlan(inputs, (a, b, c), steps)
+            _PLAN_CACHE[key] = plan
+            if len(_PLAN_CACHE) > _MAX_CACHED_PLANS:
+                _PLAN_CACHE.popitem(last=False)
+        else:
+            _PLAN_CACHE.move_to_end(key)
+    with plan._run_lock:
+        return plan(inputs, eps)
+
+
+@grouped_muon.register_fake
+def _(inputs, a, b, c, steps, eps):
+    return [
+        torch.empty(input.shape, device=input.device, dtype=torch.bfloat16)
+        for input in inputs
+    ]

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -1031,6 +1031,14 @@ def _foreach_map(subgraph, *args, **kwargs):
     inputs = args
 
     gm = subgraph.graph_module
+    from .kernel.muon import match_muon_foreach
+
+    muon_match = match_muon_foreach(gm)
+    if muon_match is not None:
+        muon_options, input_positions = muon_match
+        return fallback_handler(
+            torch.ops.inductor.grouped_muon.default, add_to_fallback_set=False
+        )([inputs[index] for index in input_positions], *muon_options)
     pw_subgraph = PointwiseSubgraphLowering(gm, root_graph_lowering=V.graph)
     with V.set_graph_handler(pw_subgraph):  # type: ignore[arg-type]
         pw_subgraph.run(*inputs)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194181
* #194180
* #194179
* #194178
* #194177

Human commentary from the author: "and add architecture descriptions and examples to each PR to make it clear"

> AI-assisted change description:
>
> ## Summary
>
> Recognize Muon's complete Newton-Schulz program inside `foreach_map`, group
> compatible matrices, and execute profitable groups through the reusable
> symmetric plans. Unsupported or unprofitable lanes retain the ordinary
> reference calculation.
>
> ## Architecture
>
> The lowering has three stages:
>
> ```text
> foreach_map body graph
>          |
>          v
> exact Muon matcher
> - BF16 conversion and optional transpose
> - Frobenius normalization and epsilon clamp
> - repeated Gram / polynomial / update sequence
> - identical coefficients and step count across lanes
>          |
>          v
> _MuonForeachPlan
> - bucket by device and compatible dimensions
> - choose sequential, packed, grouped, or reference execution
> - cap large chunks to control workspace and launch shape
>          |
>          v
> inductor::grouped_muon custom op
> - cache by tensor metadata, CUDA stream, coefficients, and steps
> - serialize use of shared plan workspaces
> - return normal contiguous BF16 tensors
> ```
>
> The matcher accepts either an ordinary `X @ X.T` Gram node or the symmetric
> custom op introduced earlier in the stack. It rejects partial matches,
> differing coefficients, inconsistent transpose behavior, or intermediates
> that do not form the complete Newton-Schulz chain.
>
> Profitability checks require CuTeDSL, SM100/SM110, BF16 inputs, and measured
> shape/count thresholds. Small groups and unsupported cases execute the
> reference tensor program. The process-wide LRU holds at most 32 plans.
> Cache keys include current CUDA stream IDs, and each plan has a run lock
> because its output and workspace tensors are intentionally reused.
>
> ## Example
>
> ```python
> params = [
>     torch.randn(1536, 5120, device="cuda", requires_grad=True)
>     for _ in range(4)
> ]
> optimizer = torch.optim.Muon(params, lr=1e-3, ns_steps=5)
> for param in params:
>     param.grad = torch.randn_like(param)
>
> compiled_step = torch.compile(optimizer.step, fullgraph=True)
> compiled_step()  # creates and caches a grouped plan
> compiled_step()  # reuses compiled code, outputs, metadata, and workspaces
> ```
>
> The user-facing optimizer API remains unchanged. The custom operation is an
> internal lowering target selected only after the full Muon pattern and
> support checks succeed.
>
> ## Benchmark results
>
> Median steady-state BF16 optimizer-step times on an NVIDIA GB200, including
> momentum, normalization, five Newton-Schulz iterations, and parameter
> updates:
>
> | representative rank workload | functional baseline | compiled grouped path | speedup |
> |---|---:|---:|---:|
> | Qwen TP8/PP8, 56 weights | 40.424 ms | 29.340 ms | 1.378x |
> | GLM PP16/EP40, 120 weights | 119.049 ms | 89.066 ms | 1.337x |
>
> The Qwen case saved 11.083 ms per optimizer step and the GLM case saved
> 29.982 ms. Compilation time is excluded; these are development benchmarks,
> not performance guarantees.
>
> ## Test Plan
>
> ```text
> CUDA_VISIBLE_DEVICES=0 TORCHINDUCTOR_CACHE_DIR=/tmp/codex-pytorch2-final-symmetric-cache .venv/bin/python test/inductor/test_symmetric_mm.py -v
> CUDA_VISIBLE_DEVICES=1 .venv/bin/python test/test_optim.py -k Muon -v
> source .venv/bin/activate && lintrunner -a
> ```
>
> Authored with an AI assistant.