### PR TITLE
[XPU][Test]Port device agnostic cases in 3 test files to Intel GPU

### DIFF
--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -321,7 +321,7 @@ class TestDropoutNNDeviceType(NNTestCase):
                         )
 
 
-instantiate_device_type_tests(TestDropoutNNDeviceType, globals(), allow_mps=True)
+instantiate_device_type_tests(TestDropoutNNDeviceType, globals(), allow_mps=True, allow_xpu=True)
 instantiate_parametrized_tests(TestDropoutNN)
 
 if __name__ == "__main__":

--- a/test/nn/test_dropout.py
+++ b/test/nn/test_dropout.py
@@ -321,7 +321,9 @@ class TestDropoutNNDeviceType(NNTestCase):
                         )
 
 
-instantiate_device_type_tests(TestDropoutNNDeviceType, globals(), allow_mps=True, allow_xpu=True)
+instantiate_device_type_tests(
+    TestDropoutNNDeviceType, globals(), allow_mps=True, allow_xpu=True
+)
 instantiate_parametrized_tests(TestDropoutNN)
 
 if __name__ == "__main__":

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -19,6 +19,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     dtypes,
     OpDTypes,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_methods_invocations import (
     op_db,
@@ -41,6 +42,78 @@ NVPRIM_ATEN_FALLBACK_WARNING = "fallback to aten executor"
 GET_ISOLATED_GRAPHMODULE_ERROR = "get_isolated_graphmodule failed on decomposition"
 
 class TestPrimsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim(self, device, dtype):
+        def _wrapper(a, b, broadcast_dimensions):
+            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            # Same shape
+            shape = (5, 5)
+            a = make_arg(shape)
+            b = make_arg(shape, low=0.0, high=0.0)
+            result = fn(a, b, (0, 1))
+
+            self.assertEqual(result.shape, a.shape)
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(a, result)
+
+            # Error input: reordering dims
+            with self.assertRaises(Exception):
+                result = fn(a, b, (1, 0))
+
+            # Adding outermost dimensions
+            a = make_arg((5, 5))
+            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
+            result = fn(a, b, (2, 3))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.broadcast_to(b.shape), result)
+
+            # Expands
+            a = make_arg((1, 5, 1))
+            b = make_arg((3, 5, 7), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 2))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.expand_as(result), result)
+
+            # Unsqueezes
+            a = make_arg((1, 2, 3))
+            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 3))
+
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.unsqueeze(2), result)
+
+    @onlyAccelerator
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim_sum(self, device, dtype):
+        def _wrapper(a):
+            a_sum = prims.sum(a, [0, 1])
+            a_bc = prims.broadcast_in_dim(a_sum, [], [])
+            return a_bc
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            result = fn(a)
+
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
+
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
     @dtypes(torch.float64, torch.long)
     def test_cbrt_prim(self, device, dtype):
@@ -110,6 +183,26 @@ class TestPrimsDevice(TestCase):
             node.target.name().startswith("prims") for node in call_function_nodes
         )
         self.assertTrue(all_prims_namespace)
+
+    @onlyAccelerator
+    @dtypes(torch.float32)
+    @parametrize("correction", [0, 1])
+    def test_var(self, device, dtype, correction):
+        def _wrapper(a):
+            return prims.var(a, [0, 1], correction=correction)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            result = fn(a)
+
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
 
     @dtypes(torch.float32)
     def test_memory_format_strides(self, device, dtype):
@@ -248,86 +341,6 @@ class TestPrimsDevice(TestCase):
         self.assertEqual(result.device.type, "cpu")
         self.assertEqual(result.shape, (1,))
 
-
-class TestPrimsAccelerator(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim(self, device, dtype):
-        def _wrapper(a, b, broadcast_dimensions):
-            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            shape = (5, 5)
-            a = make_arg(shape)
-            b = make_arg(shape, low=0.0, high=0.0)
-            result = fn(a, b, (0, 1))
-
-            self.assertEqual(result.shape, a.shape)
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(a, result)
-
-            with self.assertRaises(Exception):
-                fn(a, b, (1, 0))
-
-            a = make_arg((5, 5))
-            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
-            result = fn(a, b, (2, 3))
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.broadcast_to(b.shape), result)
-
-            a = make_arg((1, 5, 1))
-            b = make_arg((3, 5, 7), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 2))
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.expand_as(result), result)
-
-            a = make_arg((1, 2, 3))
-            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 3))
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.unsqueeze(2), result)
-
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim_sum(self, device, dtype):
-        def _wrapper(a):
-            a_sum = prims.sum(a, [0, 1])
-            a_bc = prims.broadcast_in_dim(a_sum, [], [])
-            return a_bc
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            a = make_arg((5, 5))
-            result = fn(a)
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
-
-    @dtypes(torch.float32)
-    @parametrize("correction", [0, 1])
-    def test_var(self, device, dtype, correction):
-        def _wrapper(a):
-            return prims.var(a, [0, 1], correction=correction)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            a = make_arg((5, 5))
-            result = fn(a)
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
-
-
 class TestPrimsBasic(TestCase):
     def test_torch_ops(self):
         r = make_tensor((2,), device='cpu', dtype=torch.float)
@@ -364,9 +377,8 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
             torch._prims_common.check(True, lambda: 'message')
 
 
-instantiate_device_type_tests(TestPrimsDevice, globals(), allow_xpu=True)
 instantiate_device_type_tests(
-    TestPrimsAccelerator, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+    TestPrimsDevice, globals(), only_for=("cpu", "cuda", "xpu"), allow_xpu=True
 )
 
 
@@ -435,7 +447,7 @@ class TestRefs(TestCase):
 
 
 
-instantiate_device_type_tests(TestRefs, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestRefs, globals())
 
 
 class TestDecomp(TestCase):
@@ -481,7 +493,7 @@ class TestDecomp(TestCase):
         self.assertEqual(res, expected)
 
 
-instantiate_device_type_tests(TestDecomp, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestDecomp, globals())
 
 
 if __name__ == "__main__":

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -6,13 +6,20 @@ import unittest
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_utils import (parametrize, run_tests, TestCase, TEST_SCIPY,
-                                                  set_default_dtype)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    run_tests,
+    TestCase,
+    TEST_SCIPY,
+    set_default_dtype,
+)
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
     dtypes,
     OpDTypes,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_methods_invocations import (
     op_db,
@@ -34,8 +41,10 @@ if TEST_SCIPY:
 NVPRIM_ATEN_FALLBACK_WARNING = "fallback to aten executor"
 GET_ISOLATED_GRAPHMODULE_ERROR = "get_isolated_graphmodule failed on decomposition"
 
-class TestPrims(TestCase):
-    @onlyCUDA
+class TestPrimsAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
     @dtypes(torch.float32)
     def test_broadcast_in_dim(self, device, dtype):
         def _wrapper(a, b, broadcast_dimensions):
@@ -84,7 +93,7 @@ class TestPrims(TestCase):
             self.assertEqual(result.shape, b.shape)
             self.assertEqual(a.unsqueeze(2), result)
 
-    @onlyCUDA
+    @onlyAccelerator
     @dtypes(torch.float32)
     def test_broadcast_in_dim_sum(self, device, dtype):
         def _wrapper(a):
@@ -175,7 +184,7 @@ class TestPrims(TestCase):
         )
         self.assertTrue(all_prims_namespace)
 
-    @onlyCUDA
+    @onlyAccelerator
     @dtypes(torch.float32)
     @parametrize("correction", [0, 1])
     def test_var(self, device, dtype, correction):
@@ -368,7 +377,7 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
             torch._prims_common.check(True, lambda: 'message')
 
 
-instantiate_device_type_tests(TestPrims, globals())
+instantiate_device_type_tests(TestPrimsAccelerator, globals(), allow_xpu=True)
 
 
 class TestRefs(TestCase):
@@ -436,7 +445,7 @@ class TestRefs(TestCase):
 
 
 
-instantiate_device_type_tests(TestRefs, globals())
+instantiate_device_type_tests(TestRefs, globals(), allow_xpu=True)
 
 
 class TestDecomp(TestCase):
@@ -482,7 +491,7 @@ class TestDecomp(TestCase):
         self.assertEqual(res, expected)
 
 
-instantiate_device_type_tests(TestDecomp, globals())
+instantiate_device_type_tests(TestDecomp, globals(), allow_xpu=True)
 
 
 if __name__ == "__main__":

--- a/test/test_prims.py
+++ b/test/test_prims.py
@@ -19,7 +19,6 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     dtypes,
     OpDTypes,
-    onlyAccelerator,
 )
 from torch.testing._internal.common_methods_invocations import (
     op_db,
@@ -41,79 +40,7 @@ if TEST_SCIPY:
 NVPRIM_ATEN_FALLBACK_WARNING = "fallback to aten executor"
 GET_ISOLATED_GRAPHMODULE_ERROR = "get_isolated_graphmodule failed on decomposition"
 
-class TestPrimsAccelerator(TestCase):
-    hw_classification = HardwareClassification.ACCELERATOR
-
-    @onlyAccelerator
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim(self, device, dtype):
-        def _wrapper(a, b, broadcast_dimensions):
-            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            # Same shape
-            shape = (5, 5)
-            a = make_arg(shape)
-            b = make_arg(shape, low=0.0, high=0.0)
-            result = fn(a, b, (0, 1))
-
-            self.assertEqual(result.shape, a.shape)
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(a, result)
-
-            # Error input: reordering dims
-            with self.assertRaises(Exception):
-                result = fn(a, b, (1, 0))
-
-            # Adding outermost dimensions
-            a = make_arg((5, 5))
-            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
-            result = fn(a, b, (2, 3))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.broadcast_to(b.shape), result)
-
-            # Expands
-            a = make_arg((1, 5, 1))
-            b = make_arg((3, 5, 7), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 2))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.expand_as(result), result)
-
-            # Unsqueezes
-            a = make_arg((1, 2, 3))
-            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
-            result = fn(a, b, (0, 1, 3))
-
-            self.assertEqual(result.shape, b.shape)
-            self.assertEqual(a.unsqueeze(2), result)
-
-    @onlyAccelerator
-    @dtypes(torch.float32)
-    def test_broadcast_in_dim_sum(self, device, dtype):
-        def _wrapper(a):
-            a_sum = prims.sum(a, [0, 1])
-            a_bc = prims.broadcast_in_dim(a_sum, [], [])
-            return a_bc
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            shape = (5, 5)
-            a = make_arg(shape)
-            result = fn(a)
-
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
-
+class TestPrimsDevice(TestCase):
     @unittest.skipIf(not TEST_SCIPY, "SciPy not found")
     @dtypes(torch.float64, torch.long)
     def test_cbrt_prim(self, device, dtype):
@@ -183,26 +110,6 @@ class TestPrimsAccelerator(TestCase):
             node.target.name().startswith("prims") for node in call_function_nodes
         )
         self.assertTrue(all_prims_namespace)
-
-    @onlyAccelerator
-    @dtypes(torch.float32)
-    @parametrize("correction", [0, 1])
-    def test_var(self, device, dtype, correction):
-        def _wrapper(a):
-            return prims.var(a, [0, 1], correction=correction)
-
-        traced = make_traced(_wrapper)
-        make_arg = partial(make_tensor, device=device, dtype=dtype)
-
-        for executor in ('aten',):
-            fn = partial(traced, executor=executor)
-            shape = (5, 5)
-            a = make_arg(shape)
-            result = fn(a)
-
-            self.assertEqual(result.shape, ())
-            self.assertTrue(result.is_contiguous)
-            self.assertEqual(_wrapper(a), result)
 
     @dtypes(torch.float32)
     def test_memory_format_strides(self, device, dtype):
@@ -341,6 +248,86 @@ class TestPrimsAccelerator(TestCase):
         self.assertEqual(result.device.type, "cpu")
         self.assertEqual(result.shape, (1,))
 
+
+class TestPrimsAccelerator(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim(self, device, dtype):
+        def _wrapper(a, b, broadcast_dimensions):
+            return prims.broadcast_in_dim(a, b.shape, broadcast_dimensions)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            shape = (5, 5)
+            a = make_arg(shape)
+            b = make_arg(shape, low=0.0, high=0.0)
+            result = fn(a, b, (0, 1))
+
+            self.assertEqual(result.shape, a.shape)
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(a, result)
+
+            with self.assertRaises(Exception):
+                fn(a, b, (1, 0))
+
+            a = make_arg((5, 5))
+            b = make_arg((3, 3, 5, 5), low=0.0, high=0.0)
+            result = fn(a, b, (2, 3))
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.broadcast_to(b.shape), result)
+
+            a = make_arg((1, 5, 1))
+            b = make_arg((3, 5, 7), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 2))
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.expand_as(result), result)
+
+            a = make_arg((1, 2, 3))
+            b = make_arg((1, 2, 1, 3), low=0.0, high=0.0)
+            result = fn(a, b, (0, 1, 3))
+            self.assertEqual(result.shape, b.shape)
+            self.assertEqual(a.unsqueeze(2), result)
+
+    @dtypes(torch.float32)
+    def test_broadcast_in_dim_sum(self, device, dtype):
+        def _wrapper(a):
+            a_sum = prims.sum(a, [0, 1])
+            a_bc = prims.broadcast_in_dim(a_sum, [], [])
+            return a_bc
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            a = make_arg((5, 5))
+            result = fn(a)
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
+
+    @dtypes(torch.float32)
+    @parametrize("correction", [0, 1])
+    def test_var(self, device, dtype, correction):
+        def _wrapper(a):
+            return prims.var(a, [0, 1], correction=correction)
+
+        traced = make_traced(_wrapper)
+        make_arg = partial(make_tensor, device=device, dtype=dtype)
+
+        for executor in ('aten',):
+            fn = partial(traced, executor=executor)
+            a = make_arg((5, 5))
+            result = fn(a)
+            self.assertEqual(result.shape, ())
+            self.assertTrue(result.is_contiguous)
+            self.assertEqual(_wrapper(a), result)
+
+
 class TestPrimsBasic(TestCase):
     def test_torch_ops(self):
         r = make_tensor((2,), device='cpu', dtype=torch.float)
@@ -377,7 +364,10 @@ $1: f32[2] = torch._ops.prims.sin.default($0)""")
             torch._prims_common.check(True, lambda: 'message')
 
 
-instantiate_device_type_tests(TestPrimsAccelerator, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestPrimsDevice, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestPrimsAccelerator, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 
 class TestRefs(TestCase):

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -1978,52 +1978,65 @@ class TestTensorCreation(TestCase):
     @onlyNativeDeviceTypes
     @deviceCountAtLeast(1)
     def test_tensor_device(self, devices):
-        device_type = torch.device(devices[0]).type
-        if device_type == 'cpu':
-            self.assertEqual('cpu', torch.tensor(5).device.type)
-            self.assertEqual('cpu',
-                             torch.ones((2, 3), dtype=torch.float32, device='cpu').device.type)
-            self.assertEqual('cpu',
-                             torch.ones((2, 3), dtype=torch.float32, device='cpu:0').device.type)
-            self.assertEqual('cpu',
-                             torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cpu:0').device.type)
-            self.assertEqual('cpu', torch.tensor(np.random.randn(2, 3), device='cpu').device.type)
-        if device_type == 'cuda':
-            self.assertEqual('cuda:0', str(torch.tensor(5).cuda(0).device))
-            self.assertEqual('cuda:0', str(torch.tensor(5).cuda('cuda:0').device))
-            self.assertEqual('cuda:0',
-                             str(torch.tensor(5, dtype=torch.int64, device=0).device))
-            self.assertEqual('cuda:0',
-                             str(torch.tensor(5, dtype=torch.int64, device='cuda:0').device))
-            self.assertEqual('cuda:0',
-                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cuda:0').device))
+        device = torch.device(devices[0])
+        self.assertEqual('cpu', torch.tensor(5).device.type)
+        self.assertEqual(device, torch.ones((2, 3), dtype=torch.float32, device=device).device)
+        self.assertEqual(device, torch.tensor(torch.ones((2, 3), dtype=torch.float32), device=device).device)
+        self.assertEqual(device, torch.tensor(np.random.randn(2, 3), device=device).device)
 
-            self.assertEqual('cuda:0', str(torch.tensor(np.random.randn(2, 3), device='cuda:0').device))
+        for current_device in devices:
+            current_device = torch.device(current_device)
+            self.assertEqual(
+                current_device,
+                torch.tensor(5, dtype=torch.int64, device=current_device).device,
+            )
 
-            for device in devices:
-                with torch.cuda.device(device):
-                    device_string = 'cuda:' + str(torch.cuda.current_device())
-                    self.assertEqual(device_string,
-                                     str(torch.tensor(5, dtype=torch.int64, device='cuda').device))
+        if len(devices) > 1:
+            second_device = torch.device(devices[1])
+            self.assertEqual(second_device, torch.tensor(5, device=second_device).device)
+            self.assertEqual(
+                second_device,
+                torch.tensor(np.random.randn(2, 3), device=second_device).device,
+            )
 
-            with self.assertRaises(RuntimeError):
-                torch.tensor(5).cuda('cpu')
-            with self.assertRaises(RuntimeError):
-                torch.tensor(5).cuda('cpu:0')
+    @onlyCUDA
+    @deviceCountAtLeast(1)
+    def test_tensor_device_cuda_legacy(self, devices):
+        self.assertEqual('cuda:0', str(torch.tensor(5).cuda(0).device))
+        self.assertEqual('cuda:0', str(torch.tensor(5).cuda('cuda:0').device))
+        self.assertEqual('cuda:0',
+                         str(torch.tensor(5, dtype=torch.int64, device=0).device))
+        self.assertEqual('cuda:0',
+                         str(torch.tensor(5, dtype=torch.int64, device='cuda:0').device))
+        self.assertEqual('cuda:0',
+                         str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
+                             device='cuda:0').device))
+        self.assertEqual('cuda:0',
+                         str(torch.tensor(np.random.randn(2, 3), device='cuda:0').device))
 
-            if len(devices) > 1:
-                self.assertEqual('cuda:1', str(torch.tensor(5).cuda(1).device))
-                self.assertEqual('cuda:1', str(torch.tensor(5).cuda('cuda:1').device))
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(5, dtype=torch.int64, device=1).device))
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(5, dtype=torch.int64, device='cuda:1').device))
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
-                                     device='cuda:1').device))
+        for device in devices:
+            with torch.cuda.device(device):
+                device_string = 'cuda:' + str(torch.cuda.current_device())
+                self.assertEqual(device_string,
+                                 str(torch.tensor(5, dtype=torch.int64, device='cuda').device))
 
-                self.assertEqual('cuda:1',
-                                 str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
+        with self.assertRaises(RuntimeError):
+            torch.tensor(5).cuda('cpu')
+        with self.assertRaises(RuntimeError):
+            torch.tensor(5).cuda('cpu:0')
+
+        if len(devices) > 1:
+            self.assertEqual('cuda:1', str(torch.tensor(5).cuda(1).device))
+            self.assertEqual('cuda:1', str(torch.tensor(5).cuda('cuda:1').device))
+            self.assertEqual('cuda:1',
+                             str(torch.tensor(5, dtype=torch.int64, device=1).device))
+            self.assertEqual('cuda:1',
+                             str(torch.tensor(5, dtype=torch.int64, device='cuda:1').device))
+            self.assertEqual('cuda:1',
+                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
+                                 device='cuda:1').device))
+            self.assertEqual('cuda:1',
+                             str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
 
     # TODO: this test should be updated
     @onlyNativeDeviceTypes
@@ -4555,12 +4568,12 @@ class TestAsArray(TestCase):
         self.assertNotEqual(original.data_ptr(), tensor.data_ptr())
 
 
-instantiate_device_type_tests(TestTensorCreation, globals())
-instantiate_device_type_tests(TestRandomTensorCreation, globals())
-instantiate_device_type_tests(TestLikeTensorCreation, globals())
-instantiate_device_type_tests(TestBufferProtocol, globals(), only_for="cpu")
-instantiate_device_type_tests(TestFromBlob, globals(), only_for="cpu")
-instantiate_device_type_tests(TestAsArray, globals())
+instantiate_device_type_tests(TestTensorCreation, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestRandomTensorCreation, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestLikeTensorCreation, globals(), allow_xpu=True)
+instantiate_device_type_tests(TestBufferProtocol, globals(), only_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(TestFromBlob, globals(), only_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(TestAsArray, globals(), allow_xpu=True)
 
 if __name__ == '__main__':
     TestCase._default_dtype_check_enabled = True

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -4561,8 +4561,8 @@ class TestAsArray(TestCase):
 instantiate_device_type_tests(TestTensorCreation, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestRandomTensorCreation, globals(), allow_xpu=True)
 instantiate_device_type_tests(TestLikeTensorCreation, globals(), allow_xpu=True)
-instantiate_device_type_tests(TestBufferProtocol, globals(), only_for="cpu", allow_xpu=True)
-instantiate_device_type_tests(TestFromBlob, globals(), only_for="cpu", allow_xpu=True)
+instantiate_device_type_tests(TestBufferProtocol, globals(), only_for="cpu")
+instantiate_device_type_tests(TestFromBlob, globals(), only_for="cpu")
 instantiate_device_type_tests(TestAsArray, globals(), allow_xpu=True)
 
 if __name__ == '__main__':

--- a/test/test_tensor_creation_ops.py
+++ b/test/test_tensor_creation_ops.py
@@ -40,7 +40,7 @@ from torch.testing._internal.common_utils import (
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta, instantiate_device_type_tests, deviceCountAtLeast, onlyNativeDeviceTypes,
     onlyCPU, largeTensorTest, precisionOverride, dtypes,
-    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, skipMeta, onlyAccelerator)
+    onlyCUDA, skipCPUIf, dtypesIfCUDA, dtypesIfCPU, dtypesIfXPU, skipMeta, onlyAccelerator)
 from torch.testing._internal.common_dtype import (
     all_types_and_complex, all_types_and_complex_and, all_types_and, floating_and_complex_types, complex_types,
     floating_types, floating_and_complex_types_and, integral_types, integral_types_and, get_all_dtypes,
@@ -1073,6 +1073,9 @@ class TestTensorCreation(TestCase):
     # NumPy may have the same behavior.
     @onlyNativeDeviceTypes
     @unittest.skipIf(IS_PPC, "Test is broken on PowerPC, see https://github.com/pytorch/pytorch/issues/39671")
+    # XPU float->int finite conversion differs for int32/int64; see:
+    # https://github.com/intel/torch-xpu-ops/issues/5054
+    @dtypesIfXPU(torch.bool, torch.uint8, torch.int8, torch.int16)
     @dtypes(torch.bool, torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
     def test_float_to_int_conversion_finite(self, device, dtype):
         min = torch.finfo(torch.float).min
@@ -1978,65 +1981,52 @@ class TestTensorCreation(TestCase):
     @onlyNativeDeviceTypes
     @deviceCountAtLeast(1)
     def test_tensor_device(self, devices):
-        device = torch.device(devices[0])
-        self.assertEqual('cpu', torch.tensor(5).device.type)
-        self.assertEqual(device, torch.ones((2, 3), dtype=torch.float32, device=device).device)
-        self.assertEqual(device, torch.tensor(torch.ones((2, 3), dtype=torch.float32), device=device).device)
-        self.assertEqual(device, torch.tensor(np.random.randn(2, 3), device=device).device)
+        device_type = torch.device(devices[0]).type
+        if device_type == 'cpu':
+            self.assertEqual('cpu', torch.tensor(5).device.type)
+            self.assertEqual('cpu',
+                             torch.ones((2, 3), dtype=torch.float32, device='cpu').device.type)
+            self.assertEqual('cpu',
+                             torch.ones((2, 3), dtype=torch.float32, device='cpu:0').device.type)
+            self.assertEqual('cpu',
+                             torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cpu:0').device.type)
+            self.assertEqual('cpu', torch.tensor(np.random.randn(2, 3), device='cpu').device.type)
+        if device_type == 'cuda':
+            self.assertEqual('cuda:0', str(torch.tensor(5).cuda(0).device))
+            self.assertEqual('cuda:0', str(torch.tensor(5).cuda('cuda:0').device))
+            self.assertEqual('cuda:0',
+                             str(torch.tensor(5, dtype=torch.int64, device=0).device))
+            self.assertEqual('cuda:0',
+                             str(torch.tensor(5, dtype=torch.int64, device='cuda:0').device))
+            self.assertEqual('cuda:0',
+                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32), device='cuda:0').device))
 
-        for current_device in devices:
-            current_device = torch.device(current_device)
-            self.assertEqual(
-                current_device,
-                torch.tensor(5, dtype=torch.int64, device=current_device).device,
-            )
+            self.assertEqual('cuda:0', str(torch.tensor(np.random.randn(2, 3), device='cuda:0').device))
 
-        if len(devices) > 1:
-            second_device = torch.device(devices[1])
-            self.assertEqual(second_device, torch.tensor(5, device=second_device).device)
-            self.assertEqual(
-                second_device,
-                torch.tensor(np.random.randn(2, 3), device=second_device).device,
-            )
+            for device in devices:
+                with torch.cuda.device(device):
+                    device_string = 'cuda:' + str(torch.cuda.current_device())
+                    self.assertEqual(device_string,
+                                     str(torch.tensor(5, dtype=torch.int64, device='cuda').device))
 
-    @onlyCUDA
-    @deviceCountAtLeast(1)
-    def test_tensor_device_cuda_legacy(self, devices):
-        self.assertEqual('cuda:0', str(torch.tensor(5).cuda(0).device))
-        self.assertEqual('cuda:0', str(torch.tensor(5).cuda('cuda:0').device))
-        self.assertEqual('cuda:0',
-                         str(torch.tensor(5, dtype=torch.int64, device=0).device))
-        self.assertEqual('cuda:0',
-                         str(torch.tensor(5, dtype=torch.int64, device='cuda:0').device))
-        self.assertEqual('cuda:0',
-                         str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
-                             device='cuda:0').device))
-        self.assertEqual('cuda:0',
-                         str(torch.tensor(np.random.randn(2, 3), device='cuda:0').device))
+            with self.assertRaises(RuntimeError):
+                torch.tensor(5).cuda('cpu')
+            with self.assertRaises(RuntimeError):
+                torch.tensor(5).cuda('cpu:0')
 
-        for device in devices:
-            with torch.cuda.device(device):
-                device_string = 'cuda:' + str(torch.cuda.current_device())
-                self.assertEqual(device_string,
-                                 str(torch.tensor(5, dtype=torch.int64, device='cuda').device))
+            if len(devices) > 1:
+                self.assertEqual('cuda:1', str(torch.tensor(5).cuda(1).device))
+                self.assertEqual('cuda:1', str(torch.tensor(5).cuda('cuda:1').device))
+                self.assertEqual('cuda:1',
+                                 str(torch.tensor(5, dtype=torch.int64, device=1).device))
+                self.assertEqual('cuda:1',
+                                 str(torch.tensor(5, dtype=torch.int64, device='cuda:1').device))
+                self.assertEqual('cuda:1',
+                                 str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
+                                     device='cuda:1').device))
 
-        with self.assertRaises(RuntimeError):
-            torch.tensor(5).cuda('cpu')
-        with self.assertRaises(RuntimeError):
-            torch.tensor(5).cuda('cpu:0')
-
-        if len(devices) > 1:
-            self.assertEqual('cuda:1', str(torch.tensor(5).cuda(1).device))
-            self.assertEqual('cuda:1', str(torch.tensor(5).cuda('cuda:1').device))
-            self.assertEqual('cuda:1',
-                             str(torch.tensor(5, dtype=torch.int64, device=1).device))
-            self.assertEqual('cuda:1',
-                             str(torch.tensor(5, dtype=torch.int64, device='cuda:1').device))
-            self.assertEqual('cuda:1',
-                             str(torch.tensor(torch.ones((2, 3), dtype=torch.float32),
-                                 device='cuda:1').device))
-            self.assertEqual('cuda:1',
-                             str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
+                self.assertEqual('cuda:1',
+                                 str(torch.tensor(np.random.randn(2, 3), device='cuda:1').device))
 
     # TODO: this test should be updated
     @onlyNativeDeviceTypes


### PR DESCRIPTION
Port device agnostic cases in test/nn/test_dropout.py, test/test_prims.py and test/test_tensor_creation_ops.py to Intel GPU.

- change @onlyCUDA to @onlyAccelerator for device agnostic cases in test/test_prims.py
- add `@dtypesIfXPU` for test_float_to_int_conversion_finite
- enable XPU for test/nn/test_dropout.py, test/test_prims.py and test/test_tensor_creation_ops.py
- add hardware classification