### PR TITLE
Stop instantiating unreachable cat kernels

### DIFF
--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -333,14 +333,11 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
   // 16 Byte boundary.
 
   constexpr bool isContig = stride_size == 1;
-#ifdef USE_ROCM
+#ifndef USE_ROCM
   // CatArrayBatchedCopy_contig is faster on ROCm, see #118685.
-  constexpr bool useAlignedKernels = false;
-#else
-  constexpr bool useAlignedKernels = true;
-#endif
-  bool isAligned = useAlignedKernels;
+  bool isAligned = true;
   constexpr int alignment = 16;
+#endif
 
   // Next, let's initialize the size, stride arrays for the output Tensor.
   // for contig case, we'll canonicalize output strides, so that
@@ -374,15 +371,16 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
   at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
 
 
+#ifndef USE_ROCM
   // for channels last computing slice size correctly is much more involved, so we never send it
   // on the fully vectorized path
   // we need output stride in cat dimension to be multiple of alignment,
   // if we ever use it to compute offsets
   // for catting in 0th dimension it doesn't matter
-  bool isInOutAligned = useAlignedKernels && isContig &&
-                        at::native::memory::get_alignment(data) >= alignment &&
+  bool isInOutAligned = isContig && at::native::memory::get_alignment(data) >= alignment &&
                         memory_format == c10::MemoryFormat::Contiguous && (dimension == 0 ||
                         outputParam.tensorStride[dimension - 1] * sizeof(scalar_t) % alignment == 0);
+#endif
   unsigned int max_elements_per_tensor = 0;
 
   // Now we loop
@@ -398,6 +396,7 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       // high-dimensional tensor
       if (inputs[i+batchCounter].get().numel() > 0) {
         dimSize = inputs[i+batchCounter].get().size(dimension);
+#ifndef USE_ROCM
         if (isInOutAligned) {
           auto t = inputs[i+batchCounter].get();
           // similarly to output stride, we cannot trust stride value to
@@ -408,6 +407,7 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
           slice_size *= sizeof(scalar_t);
           isInOutAligned &= (slice_size % alignment == 0);
         }
+#endif
       }
 
       catMetaData.input[batchCounter] = (scalar_t*)(inputs[i+batchCounter].get().const_data_ptr());
@@ -415,12 +415,12 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       catMetaData.dimSize[batchCounter] = dimSize;
       catMetaData.nElements[batchCounter] = inputs[i+batchCounter].get().numel();
 
+#ifndef USE_ROCM
       // If at least one of the inputs is not aligned, we can't call the
       // CatArrayBatchedCopy_alignedK_contig
-      if constexpr (useAlignedKernels) {
-        isAligned &= is_aligned_vec4(catMetaData.input[batchCounter]);
-        isInOutAligned &= at::native::memory::get_alignment(catMetaData.input[batchCounter]) >= alignment;
-      }
+      isAligned &= is_aligned_vec4(catMetaData.input[batchCounter]);
+      isInOutAligned &= at::native::memory::get_alignment(catMetaData.input[batchCounter]) >= alignment;
+#endif
 
       if (stride_size > 1) {
         auto strides = inputs[i+batchCounter].get().strides();
@@ -466,8 +466,9 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       getCatGrid(batchCounter, catGrid);
     }
 #endif
-    int32_t trailingSize = 0;
     int nDimsLocal = nDims;
+#ifndef USE_ROCM
+    int32_t trailingSize = 0;
     TensorSizeStride<unsigned int, CAT_ARRAY_MAX_INPUT_DIMS> kernelOutputParam;
     if (isInOutAligned) {
       // in this case we can and should flatten the tensors after the cat dim
@@ -491,6 +492,7 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
         kernelOutputParam.tensorStride[i] /= elems_per_vec;
       }
     }
+#endif
 
     int cat_dim = dimension;
     if (memory_format != c10::MemoryFormat::Contiguous) {
@@ -505,26 +507,35 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       }
     }
     // Template Declarations for dim = 1, 2, 3, 4
+    // #ifdef can't nest in a macro body, so ROCm (contig/generic only) and
+    // CUDA (the full aligned/vectorized chain) get separate definitions.
+#ifdef USE_ROCM
 #define HANDLE_CASE(DIMS) \
-    if (useAlignedKernels && isInOutAligned) {\
-      if constexpr (useAlignedKernels) {\
-        constexpr auto elems_per_vec = alignment / sizeof(scalar_t); \
-        CatArrayBatchedCopy_vectorized<scalar_t, unsigned int, DIMS, batch_size, stride_size, alignment, elems_per_vec><<<\
-        catGrid, applyBlock, 0, stream.stream()>>>(\
-          reinterpret_cast<char*>(data), catMetaData, kernelOutputParam, cat_dim, trailingSize);\
-      }\
-    } else if (useAlignedKernels && isContig && isAligned && sizeof(scalar_t) > 2 && sizeof(scalar_t) <= 8) {\
-      if constexpr (useAlignedKernels) {\
-        CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_16><<<\
-            catGrid, applyBlock, 0, stream.stream()>>>(\
-                data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
-      }\
-    } else if (useAlignedKernels && isContig && isAligned && sizeof(scalar_t) == 2) { \
-      if constexpr (useAlignedKernels) {\
-        CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_8><<<\
-            catGrid, applyBlock, 0, stream.stream()>>>(\
-                data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
-      }\
+    if constexpr (isContig) {\
+      CatArrayBatchedCopy_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
+          catGrid, applyBlock, 0, stream.stream()>>>(\
+              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+    } else {\
+      CatArrayBatchedCopy<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
+          catGrid, applyBlock, 0, stream.stream()>>>(\
+              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+    }\
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+#else
+#define HANDLE_CASE(DIMS) \
+    if (isInOutAligned) {\
+      constexpr auto elems_per_vec = alignment / sizeof(scalar_t); \
+      CatArrayBatchedCopy_vectorized<scalar_t, unsigned int, DIMS, batch_size, stride_size, alignment, elems_per_vec><<<\
+      catGrid, applyBlock, 0, stream.stream()>>>(\
+        reinterpret_cast<char*>(data), catMetaData, kernelOutputParam, cat_dim, trailingSize);\
+    } else if (isContig && isAligned && sizeof(scalar_t) > 2 && sizeof(scalar_t) <= 8) {\
+      CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_16><<<\
+          catGrid, applyBlock, 0, stream.stream()>>>(\
+              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+    } else if (isContig && isAligned && sizeof(scalar_t) == 2) { \
+      CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_8><<<\
+          catGrid, applyBlock, 0, stream.stream()>>>(\
+              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
     } else if constexpr (isContig) {\
       CatArrayBatchedCopy_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
           catGrid, applyBlock, 0, stream.stream()>>>(\
@@ -535,6 +546,7 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
               data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
     }\
     C10_CUDA_KERNEL_LAUNCH_CHECK();
+#endif
     switch (nDimsLocal) {
       case 1:
         HANDLE_CASE(1);

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -333,7 +333,13 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
   // 16 Byte boundary.
 
   constexpr bool isContig = stride_size == 1;
-  bool isAligned = true;
+#ifdef USE_ROCM
+  // CatArrayBatchedCopy_contig is faster on ROCm, see #118685.
+  constexpr bool useAlignedKernels = false;
+#else
+  constexpr bool useAlignedKernels = true;
+#endif
+  bool isAligned = useAlignedKernels;
   constexpr int alignment = 16;
 
   // Next, let's initialize the size, stride arrays for the output Tensor.
@@ -373,7 +379,8 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
   // we need output stride in cat dimension to be multiple of alignment,
   // if we ever use it to compute offsets
   // for catting in 0th dimension it doesn't matter
-  bool isInOutAligned = isContig && at::native::memory::get_alignment(data) >= alignment &&
+  bool isInOutAligned = useAlignedKernels && isContig &&
+                        at::native::memory::get_alignment(data) >= alignment &&
                         memory_format == c10::MemoryFormat::Contiguous && (dimension == 0 ||
                         outputParam.tensorStride[dimension - 1] * sizeof(scalar_t) % alignment == 0);
   unsigned int max_elements_per_tensor = 0;
@@ -408,16 +415,12 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
       catMetaData.dimSize[batchCounter] = dimSize;
       catMetaData.nElements[batchCounter] = inputs[i+batchCounter].get().numel();
 
-#ifdef USE_ROCM
-      // On ROCm, CatArrayBatchedCopy_contig is faster
-      isAligned = false;
-      isInOutAligned = false;
-#else
       // If at least one of the inputs is not aligned, we can't call the
       // CatArrayBatchedCopy_alignedK_contig
-      isAligned &= is_aligned_vec4(catMetaData.input[batchCounter]);
-      isInOutAligned &= at::native::memory::get_alignment(catMetaData.input[batchCounter]) >= alignment;
-#endif
+      if constexpr (useAlignedKernels) {
+        isAligned &= is_aligned_vec4(catMetaData.input[batchCounter]);
+        isInOutAligned &= at::native::memory::get_alignment(catMetaData.input[batchCounter]) >= alignment;
+      }
 
       if (stride_size > 1) {
         auto strides = inputs[i+batchCounter].get().strides();
@@ -503,20 +506,26 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
     }
     // Template Declarations for dim = 1, 2, 3, 4
 #define HANDLE_CASE(DIMS) \
-    if (isInOutAligned) {\
-      constexpr auto elems_per_vec = alignment / sizeof(scalar_t); \
-      CatArrayBatchedCopy_vectorized<scalar_t, unsigned int, DIMS, batch_size, stride_size, alignment, elems_per_vec><<<\
-      catGrid, applyBlock, 0, stream.stream()>>>(\
-        (char*)data, catMetaData, kernelOutputParam, cat_dim, trailingSize);\
-    } else if (isContig && isAligned && sizeof(scalar_t) > 2 && sizeof(scalar_t) <= 8) {\
-      CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_16><<<\
-          catGrid, applyBlock, 0, stream.stream()>>>(\
-              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
-    } else if (isContig && isAligned && sizeof(scalar_t) == 2) { \
-      CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_8><<<\
-          catGrid, applyBlock, 0, stream.stream()>>>(\
-              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
-    } else if (isContig) {\
+    if (useAlignedKernels && isInOutAligned) {\
+      if constexpr (useAlignedKernels) {\
+        constexpr auto elems_per_vec = alignment / sizeof(scalar_t); \
+        CatArrayBatchedCopy_vectorized<scalar_t, unsigned int, DIMS, batch_size, stride_size, alignment, elems_per_vec><<<\
+        catGrid, applyBlock, 0, stream.stream()>>>(\
+          reinterpret_cast<char*>(data), catMetaData, kernelOutputParam, cat_dim, trailingSize);\
+      }\
+    } else if (useAlignedKernels && isContig && isAligned && sizeof(scalar_t) > 2 && sizeof(scalar_t) <= 8) {\
+      if constexpr (useAlignedKernels) {\
+        CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_16><<<\
+            catGrid, applyBlock, 0, stream.stream()>>>(\
+                data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+      }\
+    } else if (useAlignedKernels && isContig && isAligned && sizeof(scalar_t) == 2) { \
+      if constexpr (useAlignedKernels) {\
+        CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_8><<<\
+            catGrid, applyBlock, 0, stream.stream()>>>(\
+                data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+      }\
+    } else if constexpr (isContig) {\
       CatArrayBatchedCopy_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
           catGrid, applyBlock, 0, stream.stream()>>>(\
               data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -452,15 +452,20 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
           max_elements_per_tensor, batchCounter);
 #else
     dim3 applyBlock, catGrid;
-    if (isInOutAligned) {
-      std::tie(catGrid, applyBlock) = getCatGridContig<scalar_t, alignment>(
-        max_elements_per_tensor, batchCounter);
-    } else if (isContig && isAligned && sizeof(scalar_t) > 2) {
-      std::tie(catGrid, applyBlock) = getCatGridContig<scalar_t, ALIGNED_VEC_LOAD_BYTES_16>(
+    if constexpr (isContig) {
+      if (isInOutAligned) {
+        std::tie(catGrid, applyBlock) = getCatGridContig<scalar_t, alignment>(
           max_elements_per_tensor, batchCounter);
-    } else if (isContig && isAligned && sizeof(scalar_t) == 2) {
-      std::tie(catGrid, applyBlock) = getCatGridContig<scalar_t, ALIGNED_VEC_LOAD_BYTES_8>(
-          max_elements_per_tensor, batchCounter);
+      } else if (isAligned && sizeof(scalar_t) > 2) {
+        std::tie(catGrid, applyBlock) = getCatGridContig<scalar_t, ALIGNED_VEC_LOAD_BYTES_16>(
+            max_elements_per_tensor, batchCounter);
+      } else if (isAligned && sizeof(scalar_t) == 2) {
+        std::tie(catGrid, applyBlock) = getCatGridContig<scalar_t, ALIGNED_VEC_LOAD_BYTES_8>(
+            max_elements_per_tensor, batchCounter);
+      } else {
+        applyBlock = dim3(32 * 16);
+        getCatGrid(batchCounter, catGrid);
+      }
     } else {
       applyBlock = dim3(32 * 16);
       getCatGrid(batchCounter, catGrid);

--- a/aten/src/ATen/native/cuda/Shape.cu
+++ b/aten/src/ATen/native/cuda/Shape.cu
@@ -523,23 +523,25 @@ void parallel_cat(const Tensor &out, const MaterializedITensorListRef& inputs, i
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 #else
 #define HANDLE_CASE(DIMS) \
-    if (isInOutAligned) {\
-      constexpr auto elems_per_vec = alignment / sizeof(scalar_t); \
-      CatArrayBatchedCopy_vectorized<scalar_t, unsigned int, DIMS, batch_size, stride_size, alignment, elems_per_vec><<<\
-      catGrid, applyBlock, 0, stream.stream()>>>(\
-        reinterpret_cast<char*>(data), catMetaData, kernelOutputParam, cat_dim, trailingSize);\
-    } else if (isContig && isAligned && sizeof(scalar_t) > 2 && sizeof(scalar_t) <= 8) {\
-      CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_16><<<\
-          catGrid, applyBlock, 0, stream.stream()>>>(\
-              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
-    } else if (isContig && isAligned && sizeof(scalar_t) == 2) { \
-      CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_8><<<\
-          catGrid, applyBlock, 0, stream.stream()>>>(\
-              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
-    } else if constexpr (isContig) {\
-      CatArrayBatchedCopy_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
-          catGrid, applyBlock, 0, stream.stream()>>>(\
-              data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+    if constexpr (isContig) {\
+      if (isInOutAligned) {\
+        constexpr auto elems_per_vec = alignment / sizeof(scalar_t); \
+        CatArrayBatchedCopy_vectorized<scalar_t, unsigned int, DIMS, batch_size, stride_size, alignment, elems_per_vec><<<\
+        catGrid, applyBlock, 0, stream.stream()>>>(\
+          reinterpret_cast<char*>(data), catMetaData, kernelOutputParam, cat_dim, trailingSize);\
+      } else if (isAligned && sizeof(scalar_t) > 2 && sizeof(scalar_t) <= 8) {\
+        CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_16><<<\
+            catGrid, applyBlock, 0, stream.stream()>>>(\
+                data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+      } else if (isAligned && sizeof(scalar_t) == 2) { \
+        CatArrayBatchedCopy_alignedK_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size, ALIGNED_VEC_LOAD_BYTES_8><<<\
+            catGrid, applyBlock, 0, stream.stream()>>>(\
+                data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+      } else {\
+        CatArrayBatchedCopy_contig<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
+            catGrid, applyBlock, 0, stream.stream()>>>(\
+                data, catMetaData, outputParam, cat_dim, outputParam.tensorStride[cat_dim]);\
+      }\
     } else {\
       CatArrayBatchedCopy<scalar_t, unsigned int, DIMS, batch_size, stride_size><<<\
           catGrid, applyBlock, 0, stream.stream()>>>(\


### PR DESCRIPTION
`parallel_cat` cleared `isAligned` and `isInOutAligned` at runtime under
`USE_ROCM`, because `CatArrayBatchedCopy_contig` is faster there (#118685). That
makes `CatArrayBatchedCopy_alignedK_contig` and `CatArrayBatchedCopy_vectorized`
unreachable on ROCm, but a runtime flag cannot drop them: `__global__` functions
are DCE roots, so both families are still instantiated and emitted. A
`constexpr bool` does, as in `SoftMax.cu:1109`.

The tail of the same chain has the problem on every backend: `isContig` is
already `constexpr`, but under a plain `if` both `CatArrayBatchedCopy_contig` and
`CatArrayBatchedCopy` instantiate while only one is reachable per `parallel_cat`
configuration.

Same issue on the CUDA side of the chain: for the `stride_size != 1`
instantiation, `isInOutAligned` is unreachable at runtime (its own definition
ANDs in `isContig`), but the `alignedK_contig`/`vectorized` branches were plain
runtime `if`s, so all three kernels were still instantiated there too. They're
now nested under `if constexpr (isContig)`.

The grid-selection block right above the kernel launch has the identical
pattern -- `getCatGridContig<scalar_t, N>` is a template too, picked by the
same unreachable `isInOutAligned`/`isContig &&`-gated chain -- so it gets the
same `if constexpr (isContig)` treatment.

Nothing changes for reachable kernels. Not compile-tested; CI is what validates
this.

Authored with an AI assistant.


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
