### PR TITLE
[Testcase Refactoring] Decouple PruningOpTest for out-of-tree backends

### DIFF
--- a/test/test_pruning_op.py
+++ b/test/test_pruning_op.py
@@ -4,12 +4,18 @@ import hypothesis.strategies as st
 from hypothesis import given
 import numpy as np
 import torch
-from torch.testing._internal.common_utils import TestCase, run_tests, skipIfTorchDynamo
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    run_tests,
+    skipIfTorchDynamo,
+)
 import torch.testing._internal.hypothesis_utils as hu
 hu.assert_deadline_disabled()
 
 
 class PruningOpTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     # Generate rowwise mask vector based on indicator and threshold value.
     # indicator is a vector that contains one value per weight row and it


### PR DESCRIPTION
## Summary

Add `hw_classification = HardwareClassification.GENERIC` to `PruningOpTest` in `test/test_pruning_op.py`.

Both tests exercise `torch._rowwise_prune` on CPU tensors with hypothesis-based property testing and do not depend on any accelerator, so the class is classified as `GENERIC` per the HardwareClassification spec.

Changes:
- Import `HardwareClassification` from `torch.testing._internal.common_utils`
- Annotate `PruningOpTest` with `hw_classification = HardwareClassification.GENERIC`

No test semantics, case count, or execution logic are changed.

## Test Plan

- CPU: `python test/test_pruning_op.py` -> `Ran 2 tests OK`
- CUDA: covered by upstream CI (CUDA jobs); these tests have no CUDA-specific behavior.

## Related

- RFC: pytorch#185142 / pytorch#185590
- HardwareClassification infra: pytorch#186918