### PR TITLE
[inductor] Disable batch_linear_lhs by default (fixes Qwen regression)

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -796,20 +796,17 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(counters["inductor"]["batch_dropout"], 1)
         counters.clear()
 
-    @unittest.skipUnless(
-        torch.xpu.is_available(),
-        "batch_linear_lhs auto-enable is XPU-only for now",
+    @unittest.skipUnless(torch.xpu.is_available(), "batch_linear_lhs is XPU-only")
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={
+            "batch_linear_lhs": {"devices": ("xpu",), "min_fuse_set_size": 2},
+        },
     )
-    def test_xpu_auto_enable_batch_linear_lhs(self):
-        # Verify that batch_linear_lhs fusion is auto-enabled when example inputs
-        # contain XPU tensors, driven by the "devices" key in the default
-        # config.pre_grad_fusion_options.
-        default_options = config.pre_grad_fusion_options
-        self.assertIn("batch_linear_lhs", default_options)
-        self.assertEqual(default_options["batch_linear_lhs"]["devices"], ("xpu",))
+    def test_xpu_batch_linear_lhs(self):
+        # batch_linear_lhs is disabled by default; enabling it for XPU via mock
+        # config must make the fusion fire on XPU tensors.
         z = 10
         for has_bias in [True, False]:
-            orig_fusion_options = dict(config.pre_grad_fusion_options)
             counters.clear()
             module = MyModule4(z, "xpu", has_bias)
             input = [torch.randn(20, z, device="xpu")]
@@ -823,11 +820,6 @@ class TestGroupBatchFusion(TestCase):
             res.sum().backward()
             self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
             self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
-            self.assertEqual(
-                orig_fusion_options,
-                dict(config.pre_grad_fusion_options),
-                "config.pre_grad_fusion_options should not be mutated by auto-enable",
-            )
             counters.clear()
 
     @requires_gpu()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -364,12 +364,14 @@ batch_fusion = True
 # merge_splits_pass
 # mutate_cat_pass
 # split_cat_pass
-pre_grad_fusion_options: dict[str, dict[str, Any]] = {
-    "batch_linear_lhs": {
-        "devices": ("xpu",),
-        "min_fuse_set_size": 2,
-    },
-}
+# For each fusion, the "devices" key specifies the devices on which the fusion is enabled.
+# e.g. pre_grad_fusion_options = {
+#     "batch_linear_lhs": {
+#         "devices": ("xpu",),
+#         "min_fuse_set_size": 2,
+#     },
+# }
+pre_grad_fusion_options: dict[str, dict[str, Any]] = {}
 
 # Post grad fusion and options, set to empty dict to disable fusion.
 # Call `torch._inductor.fx_passes.group_batch_fusion.list_group_batch_fusions(False)` to see available fusions.


### PR DESCRIPTION
## Summary

`batch_linear_lhs` was auto-enabled on XPU in PyTorch 2.14. It causes a regression for Qwen models — the fusion emits non-contiguous split views that break layout-sensitive consumers, so vLLM serving Qwen3.5/3.8 crashes. We've found this feature is not mature enough yet, so this PR disables it by default to fix the regression.

The Qwen layout-safety issue will be fixed separately in a follow-up PR (https://github.com/pytorch/pytorch/pull/193295).

## Changes

- `torch/_inductor/config.py`: remove `batch_linear_lhs` from `pre_grad_fusion_options` (disabled by default), with a comment documenting the `devices` key usage.
- `test/inductor/test_group_batch_fusion.py`: rename `test_xpu_auto_enable_batch_linear_lhs` → `test_xpu_batch_linear_lhs`, using mock config to explicitly enable the fusion for testing (since it's now disabled by default).

## Test plan

- Local XPU (B580): 6 `batch_linear_lhs` tests pass; fusion no longer fires under default config (counter == 0).
- `lintrunner --take FLAKE8,PYFMT` clean.
