### PR TITLE
Skip unreachable dispatch branches in mem-eff attention

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/cutlassB.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/cutlassB.h
@@ -8,6 +8,7 @@
 // This file is auto-generated. See "generate_kernels.py"
 #pragma once
 #include <ATen/native/transformers/cuda/mem_eff_attention/kernel_backward.h>
+#include <c10/cuda/CUDAArchList.h>
 using namespace PyTorchMemEffAttention;
 // ======== f16 / sm70 ========
 __global__ void __launch_bounds__(
@@ -868,31 +869,31 @@ template <typename T> void dispatch_cutlassB_f32_sm80(T cb, int cc) {
 template <typename DT, typename T>
 void dispatch_cutlassB(T cb, int cc = 0) {
 
-    if (std::is_same_v<DT, cutlass::half_t> && 70 <= cc && cc <= 74) {
-        dispatch_cutlassB_f16_sm70(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(70, 74)) {
+        if (70 <= cc && cc <= 74) { dispatch_cutlassB_f16_sm70(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::bfloat16_t> && 80 <= cc && cc <= 121) {
-        dispatch_cutlassB_bf16_sm80(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::bfloat16_t> && c10::cuda::targets_any_arch_in(80, 121)) {
+        if (80 <= cc && cc <= 121) { dispatch_cutlassB_bf16_sm80(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::half_t> && 80 <= cc && cc <= 121) {
-        dispatch_cutlassB_f16_sm80(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(80, 121)) {
+        if (80 <= cc && cc <= 121) { dispatch_cutlassB_f16_sm80(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::half_t> && 50 <= cc && cc <= 69) {
-        dispatch_cutlassB_f16_sm50(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(50, 69)) {
+        if (50 <= cc && cc <= 69) { dispatch_cutlassB_f16_sm50(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 50 <= cc && cc <= 69) {
-        dispatch_cutlassB_f32_sm50(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(50, 69)) {
+        if (50 <= cc && cc <= 69) { dispatch_cutlassB_f32_sm50(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 70 <= cc && cc <= 74) {
-        dispatch_cutlassB_f32_sm70(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(70, 74)) {
+        if (70 <= cc && cc <= 74) { dispatch_cutlassB_f32_sm70(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::half_t> && 75 <= cc && cc <= 79) {
-        dispatch_cutlassB_f16_sm75(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(75, 79)) {
+        if (75 <= cc && cc <= 79) { dispatch_cutlassB_f16_sm75(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 75 <= cc && cc <= 79) {
-        dispatch_cutlassB_f32_sm75(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(75, 79)) {
+        if (75 <= cc && cc <= 79) { dispatch_cutlassB_f32_sm75(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 80 <= cc && cc <= 121) {
-        dispatch_cutlassB_f32_sm80(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(80, 121)) {
+        if (80 <= cc && cc <= 121) { dispatch_cutlassB_f32_sm80(cb, cc); }
     }
 }

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/cutlassF.h
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/cutlassF.h
@@ -8,6 +8,7 @@
 // This file is auto-generated. See "generate_kernels.py"
 #pragma once
 #include <ATen/native/transformers/cuda/mem_eff_attention/kernel_forward.h>
+#include <c10/cuda/CUDAArchList.h>
 using namespace PyTorchMemEffAttention;
 // ======== bf16 / sm80 ========
 __global__ void __launch_bounds__(
@@ -283,31 +284,31 @@ template <typename T> void dispatch_cutlassF_f32_sm80(T cb, int cc) {
 template <typename DT, typename T>
 void dispatch_cutlassF(T cb, int cc = 0) {
 
-    if (std::is_same_v<DT, cutlass::bfloat16_t> && 80 <= cc && cc <= 121) {
-        dispatch_cutlassF_bf16_sm80(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::bfloat16_t> && c10::cuda::targets_any_arch_in(80, 121)) {
+        if (80 <= cc && cc <= 121) { dispatch_cutlassF_bf16_sm80(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::half_t> && 50 <= cc && cc <= 69) {
-        dispatch_cutlassF_f16_sm50(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(50, 69)) {
+        if (50 <= cc && cc <= 69) { dispatch_cutlassF_f16_sm50(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::half_t> && 70 <= cc && cc <= 74) {
-        dispatch_cutlassF_f16_sm70(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(70, 74)) {
+        if (70 <= cc && cc <= 74) { dispatch_cutlassF_f16_sm70(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::half_t> && 75 <= cc && cc <= 79) {
-        dispatch_cutlassF_f16_sm75(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(75, 79)) {
+        if (75 <= cc && cc <= 79) { dispatch_cutlassF_f16_sm75(cb, cc); }
     }
-    if (std::is_same_v<DT, cutlass::half_t> && 80 <= cc && cc <= 121) {
-        dispatch_cutlassF_f16_sm80(cb, cc);
+    if constexpr (std::is_same_v<DT, cutlass::half_t> && c10::cuda::targets_any_arch_in(80, 121)) {
+        if (80 <= cc && cc <= 121) { dispatch_cutlassF_f16_sm80(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 50 <= cc && cc <= 69) {
-        dispatch_cutlassF_f32_sm50(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(50, 69)) {
+        if (50 <= cc && cc <= 69) { dispatch_cutlassF_f32_sm50(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 70 <= cc && cc <= 74) {
-        dispatch_cutlassF_f32_sm70(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(70, 74)) {
+        if (70 <= cc && cc <= 74) { dispatch_cutlassF_f32_sm70(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 75 <= cc && cc <= 79) {
-        dispatch_cutlassF_f32_sm75(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(75, 79)) {
+        if (75 <= cc && cc <= 79) { dispatch_cutlassF_f32_sm75(cb, cc); }
     }
-    if (std::is_same_v<DT, float> && 80 <= cc && cc <= 121) {
-        dispatch_cutlassF_f32_sm80(cb, cc);
+    if constexpr (std::is_same_v<DT, float> && c10::cuda::targets_any_arch_in(80, 121)) {
+        if (80 <= cc && cc <= 121) { dispatch_cutlassF_f32_sm80(cb, cc); }
     }
 }

--- a/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
+++ b/aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py
@@ -330,6 +330,7 @@ def write_decl_impl(
     declarations = cpp_file_header + "#pragma once\n"
     # declarations += f"#ifndef {disable_def}\n"
     declarations += f"""#include {impl_file}\n"""
+    declarations += "#include <c10/cuda/CUDAArchList.h>\n"
     declarations += """using namespace PyTorchMemEffAttention;\n"""
 
     # Declaration of kernel functions
@@ -353,8 +354,8 @@ def write_decl_impl(
             declarations += f"    {_call}"
         declarations += "}\n\n"
         dispatch_all += f"""
-    if (std::is_same_v<DT, {DTYPES[cat_dt]}> && {cat_sm} <= cc && cc <= {cat_sm_max}) {{
-        {dispatch_category_fn}(cb, cc);
+    if constexpr (std::is_same_v<DT, {DTYPES[cat_dt]}> && c10::cuda::targets_any_arch_in({cat_sm}, {cat_sm_max})) {{
+        if ({cat_sm} <= cc && cc <= {cat_sm_max}) {{ {dispatch_category_fn}(cb, cc); }}
     }}"""
 
     declarations += f"""

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -41,6 +41,7 @@ set(C10_CUDA_SRCS
 )
 set(C10_CUDA_HEADERS
     CUDAAllocatorConfig.h
+    CUDAArchList.h
     CUDACachingAllocator.h
     CUDADeviceAssertionHost.h
     CUDAException.h

--- a/c10/cuda/CUDAArchList.h
+++ b/c10/cuda/CUDAArchList.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+namespace c10::cuda {
+
+// nvcc defines __CUDA_ARCH_LIST__ in the host pass too. It is per translation
+// unit, not per build, and holds virtual architectures, so a +PTX build is not
+// credited with its JIT range.
+constexpr C10_HOST_DEVICE bool targets_any_arch_in(
+    [[maybe_unused]] int sm_lo,
+    [[maybe_unused]] int sm_hi) {
+#ifdef __CUDA_ARCH_LIST__
+  constexpr int archs[] = {__CUDA_ARCH_LIST__};
+  for (int arch : archs) {
+    if (arch / 10 >= sm_lo && arch / 10 <= sm_hi) {
+      return true;
+    }
+  }
+  return false;
+#else
+  return true;
+#endif
+}
+
+} // namespace c10::cuda

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3458,6 +3458,7 @@ C10_MAPPINGS = collections.OrderedDict([
     ("CUDA_LAUNCH_BLOCKING", "AMD_SERIALIZE_KERNEL"),
     ("c10/cuda/CUDAAlgorithm.h", "c10/hip/HIPAlgorithm.h"),
     ("c10/cuda/CUDAAllocatorConfig.h", "c10/hip/HIPAllocatorConfig.h"),
+    ("c10/cuda/CUDAArchList.h", "c10/hip/HIPArchList.h"),
     ("c10/cuda/CUDACachingAllocator.h", "c10/hip/HIPCachingAllocator.h"),
     ("c10/cuda/CUDADeviceAssertion.h", "c10/hip/HIPDeviceAssertion.h"),
     ("c10/cuda/CUDADeviceAssertionHost.h", "c10/hip/HIPDeviceAssertionHost.h"),


### PR DESCRIPTION
The generator already guards each kernel body by architecture on the device side
(`#if __CUDA_ARCH__ >= 500 / <= 690` around the sm50-sm69 kernels). The host-side
dispatch had no matching guard, so every category was instantiated whatever the
build targets. This adds the other half:

```cpp
if constexpr (std::is_same_v<DT, cutlass::half_t> &&
              c10::cuda::targets_any_arch_in(50, 69)) {
    if (50 <= cc && cc <= 69) { dispatch_cutlassF_f16_sm50(cb, cc); }
}
```

`targets_any_arch_in` reads `__CUDA_ARCH_LIST__`, which nvcc defines in the host
pass as well -- `c10/util/TypeIndex.h` already relies on that. `arch / 10` is an
identity, not a heuristic: `__CUDA_ARCH__` is `major * 100 + minor * 10` and the
`cc` these ranges are compared against is `major * 10 + minor`.

This reaches the expensive part because `AttentionKernel`'s nested
`SharedStorage` / `MM0` / `MM1` are only completed where `launchKernel` evaluates
`sizeof(Kernel::SharedStorage)` and odr-uses `Kernel::kAlignmentQ`; the
namespace-scope `__launch_bounds__` declarations need only `kNumThreads` and
`kMinBlocksPerSm`. `kernels/*.cu` is untouched, so which kernels get compiled
does not change -- only the host-side instantiations in `attention.cu` and
`attention_backward.cu`.

`c10/cuda/CUDAArchList.h` is added identically by #194213, so either can land
first.

## Test Plan

```bash
python aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/generate_kernels.py -o /tmp/gen
diff -rq /tmp/gen aten/src/ATen/native/transformers/cuda/mem_eff_attention/kernels/
```

reproduces both headers byte for byte. No CUDA locally, so the build is on CI.

Authored with an AI assistant.
