### PR TITLE
Fix fd leak in FileStore rendezvous and socket error masking in find_free_port

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,23 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.os.close"
+    )
+    @mock.patch("tempfile.mkstemp")
+    def test_create_backend_closes_fd_from_mkstemp(
+        self, mock_mkstemp, mock_os_close
+    ) -> None:
+        mock_mkstemp.return_value = (42, "/tmp/fake_rendezvous_path")
+
+        self._params_filestore.endpoint = ""
+
+        # FileStore will fail on the fake path, but we only care that
+        # os.close(fd) was called before that happens.
+        try:
+            create_backend(self._params_filestore)
+        except (RendezvousConnectionError, RendezvousError):
+            pass
+
+        mock_os_close.assert_called_once_with(42)

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -58,3 +58,29 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+
+class FindFreePortTest(unittest.TestCase):
+    """Tests for find_free_port() error handling."""
+
+    def test_find_free_port_returns_listening_socket(self):
+        from torch.distributed.elastic.rendezvous.etcd_server import find_free_port
+
+        s = find_free_port()
+        try:
+            self.assertIsNotNone(s)
+            self.assertGreater(s.getsockname()[1], 0)
+        finally:
+            s.close()
+
+    @unittest.mock.patch("socket.socket")
+    def test_find_free_port_no_unbound_local_error_when_socket_fails(
+        self, mock_socket_cls
+    ):
+        """socket.socket() raising OSError must not cause UnboundLocalError."""
+        from torch.distributed.elastic.rendezvous.etcd_server import find_free_port
+
+        mock_socket_cls.side_effect = OSError("Address family not supported")
+
+        with self.assertRaises(RuntimeError):
+            find_free_port()

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,8 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Summary

Fixes two small resource handling bugs in distributed elastic rendezvous.

### File descriptor leak in `_create_file_store`

`tempfile.mkstemp()` returns `(fd, path)` but the code was discarding the fd with `_, path = ...`. Since `FileStore` opens the file separately, that original fd just stays open forever -- one leaked fd per rendezvous creation. Eventually hits the system fd limit in long-running training jobs.

Fix: capture the fd and close it immediately.

Fixes #191394

### `UnboundLocalError` in `find_free_port`

If `socket.socket()` itself throws (e.g., unsupported address family), `s` was never assigned, so `s.close()` in the except block raises `UnboundLocalError`. This masks the real error and skips trying remaining address families.

Fix: init `s = None` before the try and guard the close.

Fixes #191395

## Test plan

- [x] Added test verifying `os.close(fd)` is called after `mkstemp()` in file store creation path
- [x] Added test verifying `find_free_port` raises `RuntimeError` (not `UnboundLocalError`) when `socket.socket()` fails
- [x] Existing tests unaffected