### PR TITLE
Add Isalia20/pytorch-mps-ci to CRCR allowlist (L1)

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -41,6 +41,7 @@ L1:
   - NVIDIA-dev/pytorch-oot-internal
   - NVIDIA/pytorch-windows-ci
   - google-pytorch/torch_tpu
+  - Isalia20/pytorch-mps-ci
 
 L2:
   - TorchedHat/pytorch-redhat-ci


### PR DESCRIPTION
Following the [CRCR Onboarding Guide - Step 2](https://github.com/pytorch/crcr-test/blob/main/README.md#step-2-add-your-repository-to-the-allowlist), add [Isalia20/pytorch-mps-ci](https://github.com/Isalia20/pytorch-mps-ci) to the allowlist at L1.

The repository will run MPS tests against upstream PyTorch events on macOS arm64 runners. The relay GitHub App is installed on the repository.