### PR TITLE
[Testcase Refactoring][DCP] Classify checkpoint barrier tests by hardware requirements

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_barriers.py
+++ b/test/distributed/checkpoint/_experimental/test_barriers.py
@@ -4,10 +4,16 @@ import unittest.mock as mock
 
 from torch.distributed.checkpoint._experimental.barriers import TCPStoreBarrier
 from torch.distributed.checkpoint._experimental.types import RankInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestBarriers(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     @mock.patch("torch.distributed.TCPStore")
     @mock.patch("torch.distributed.elastic.utils.store.barrier")
     def test_tcpstore_barrier_initialization(self, _, mock_tcpstore):


### PR DESCRIPTION
I reviewed the code and the quoted PR draft below, verified the reported results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
>
> Part of #185590. This references the tracking issue only and does not close it.
>
> ## Summary
>
> Classify the checkpoint barrier tests as hardware-independent generic tests.
>
> ## Changes
>
> - Mark `TestBarriers` with `HardwareClassification.GENERIC`.
> - Preserve the mocked store and barrier behavior.
>
> ## Motivation
>
> These tests validate barrier coordination through mocked stores and do not require a concrete accelerator. Explicit generic classification keeps collection independent of hardware.
>
> ## Test Plan
>
> ```bash
> PYTHONPYCACHEPREFIX=/tmp/pr194199-pycache /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/checkpoint/_experimental/test_barriers.py
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/spin lint -- --take FLAKE8,PYFMT,SPACES,TABS,NEWLINE test/distributed/checkpoint/_experimental/test_barriers.py
> git diff --cached --check
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python test/distributed/checkpoint/_experimental/test_barriers.py
> ```
>
> Results: `py_compile` PASS; scoped lint PASS; diff check PASS; 2 tests, 2 passed.
>
> ## Notes
>
> - Replayed from `main@d535485edf2704e6ab55d5465e4584ac6121584d`.
> - The candidate contains exactly `test/distributed/checkpoint/_experimental/test_barriers.py`.
> - Shared framework changes and other consumer files are outside this PR.
> - This PR was authored with assistance from OpenAI Codex.
>
> ## Checklist
>
> - [x] Passes lint (`spin lint` scoped to the changed file).
> - [x] Added/updated tests.
> - [x] Updated documentation (not applicable; internal test classification only).
> - [x] Included benchmark results (not applicable; no performance behavior change).
>
> ## BC-breaking?
>
> No.
