### PR TITLE
[Testcase Refactoring][DCP] Classify checkpoint writer tests by hardware requirements

### DIFF
--- a/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
+++ b/test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
@@ -13,7 +13,11 @@ from torch.distributed.checkpoint._experimental.checkpoint_writer import (
     WriterHook,
 )
 from torch.distributed.checkpoint._experimental.types import RankInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class MockWriterHook(WriterHook):
@@ -39,6 +43,8 @@ class MockWriterHook(WriterHook):
 
 
 class TestCheckpointWriterConfig(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_default_values(self):
         """Test that CheckpointWriterConfig has the correct default values."""
         options = CheckpointWriterConfig()
@@ -51,6 +57,8 @@ class TestCheckpointWriterConfig(TestCase):
 
 
 class TestCheckpointWriter(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         # Create a temporary directory for test checkpoints


### PR DESCRIPTION
I reviewed the code and the quoted PR draft below, verified the reported results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
>
> Part of #185590. This references the tracking issue only and does not close it.
>
> ## Summary
>
> Classify the checkpoint writer configuration and writer tests as hardware-independent generic tests.
>
> ## Changes
>
> - Mark `TestCheckpointWriterConfig` and `TestCheckpointWriter` with `HardwareClassification.GENERIC`.
> - Preserve the existing writer hooks, configuration checks, and mocked behavior.
>
> ## Motivation
>
> These tests exercise checkpoint writer control flow and configuration without requiring a concrete accelerator. Explicit generic classification avoids unnecessary hardware admission.
>
> ## Test Plan
>
> ```bash
> PYTHONPYCACHEPREFIX=/tmp/pr194200-pycache /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/spin lint -- --take FLAKE8,PYFMT,SPACES,TABS,NEWLINE test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
> git diff --cached --check
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python test/distributed/checkpoint/_experimental/test_checkpoint_writer.py
> ```
>
> Results: `py_compile` PASS; scoped lint PASS; diff check PASS; 8 tests, 8 passed.
>
> ## Notes
>
> - Replayed from `main@d535485edf2704e6ab55d5465e4584ac6121584d`.
> - The candidate contains exactly `test/distributed/checkpoint/_experimental/test_checkpoint_writer.py`.
> - Shared framework changes and other consumer files are outside this PR.
> - This PR was authored with assistance from OpenAI Codex.
>
> ## Checklist
>
> - [x] Passes lint (`spin lint` scoped to the changed file).
> - [x] Added/updated tests.
> - [x] Updated documentation (not applicable; internal test classification only).
> - [x] Included benchmark results (not applicable; no performance behavior change).
>
> ## BC-breaking?
>
> No.
