### PR TITLE
[Testcase Refactoring][DCP] Decouple fine-tuning tests from accelerator selection

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -1,15 +1,19 @@
 # Owner(s): ["module: PrivateUse1"]
 
-import inspect
 import unittest
 from collections import defaultdict
 from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_device_type import (
     Capability,
+    CPUTestBase,
+    CUDATestBase,
     dtypes,
+    HPUTestBase,
     instantiate_device_type_tests,
     onlyCUDA,
     onlyOn,
@@ -17,6 +21,7 @@ from torch.testing._internal.common_device_type import (
     precisionOverride,
     PrivateUse1TestBase,
     requires_capabilities,
+    XPUTestBase,
 )
 from torch.testing._internal.common_utils import run_tests, TestCase
 from torch.testing._internal.opinfo.core import DecorateInfo, OpInfo
@@ -308,22 +313,10 @@ class TestCapabilityGating(TestCase):
     """Verify that @requires_capabilities gates tests on PrivateUse1 backends."""
 
     executed_count = 0
-
-    @classmethod
-    def setUpClass(cls):
-        cls._saved_capabilities = inspect.getattr_static(
-            PrivateUse1TestBase, "_capabilities"
-        )
-        PrivateUse1TestBase._capabilities = classmethod(
-            lambda cls: {
-                Capability.dtype.fp8: lambda: True,
-                Capability.dtype.bf16: lambda: False,
-            }
-        )
+    setup_count = 0
 
     @classmethod
     def tearDownClass(cls):
-        PrivateUse1TestBase._capabilities = cls._saved_capabilities
         expected_runs = 3
         if cls.executed_count != expected_runs:
             raise AssertionError(
@@ -331,17 +324,23 @@ class TestCapabilityGating(TestCase):
                 f"Expected {expected_runs} tests to run, "
                 f"but {cls.executed_count} tests executed."
             )
+        if cls.setup_count != expected_runs:
+            raise AssertionError(
+                f"Capability preflight failed! "
+                f"Expected {expected_runs} test setups to run, "
+                f"but {cls.setup_count} setups executed."
+            )
         super().tearDownClass()
 
-    @requires_capabilities(Capability.dtype.fp8)
+    @requires_capabilities(Capability.lib.triton)
     def test_capability_supported(self, device):
         type(self).executed_count += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
-    @requires_capabilities(Capability.dtype.bf16)
+    @requires_capabilities(Capability.dtype.fp64)
     def test_capability_unsupported(self, device):
         type(self).executed_count += 1
-        self.fail("Expected skip: dtype.bf16 is unsupported on this device")
+        self.fail("Expected skip: dtype.fp64 is unsupported on this device")
 
     def test_capability_missing(self, device):
         """@requires_capabilities raises AssertionError for undeclared capabilities."""
@@ -362,7 +361,7 @@ class TestCapabilityGating(TestCase):
         includes an undeclared capability."""
 
         @requires_capabilities(
-            Capability.dtype.fp8,
+            Capability.lib.triton,
             Capability.dtype.bf16,
             Capability.attention.flash_attention,
         )
@@ -377,7 +376,69 @@ class TestCapabilityGating(TestCase):
         type(self).executed_count += 1
 
 
+def _openreg_test_capabilities(_cls):
+    capabilities = PrivateUse1TestBase._capabilities()
+    capabilities[Capability.lib].update({Capability.lib.triton: lambda: True})
+    capabilities[Capability.dtype] = {
+        Capability.dtype.bf16: lambda: False,
+        Capability.dtype.fp64: lambda: False,
+    }
+    return capabilities
+
+
+def _openreg_capability_test_setup(self):
+    PrivateUse1TestBase.setUp(self)
+    type(self).setup_count += 1
+
+
 instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")
+_capability_test_cls = globals()["TestCapabilityGatingOPENREG"]
+_capability_test_cls._capabilities = classmethod(_openreg_test_capabilities)
+_capability_test_cls.setUp = _openreg_capability_test_setup
+del _capability_test_cls
+
+
+class TestFP64CapabilityDeclarations(TestCase):
+    def test_static_fp64_capabilities(self):
+        for test_base, expected in (
+            (CPUTestBase, True),
+            (CUDATestBase, True),
+            (HPUTestBase, False),
+        ):
+            predicate = test_base._capabilities()[Capability.dtype][
+                Capability.dtype.fp64
+            ]
+            self.assertEqual(predicate(), expected)
+
+    def test_hpu_distributed_capabilities_follow_backend_availability(self):
+        nested_capabilities = HPUTestBase._capabilities()
+        self.assertEqual(
+            set(nested_capabilities[Capability.distributed]),
+            {
+                Capability.distributed.backend,
+                Capability.distributed.fsdp,
+            },
+        )
+
+        for expected in (True, False):
+            with patch(
+                "torch.testing._internal.common_device_type._distributed_backend_available",
+                return_value=expected,
+            ) as backend_available:
+                capabilities = HPUTestBase.get_capabilities()
+                self.assertEqual(capabilities[Capability.distributed.backend], expected)
+                self.assertEqual(capabilities[Capability.distributed.fsdp], expected)
+                self.assertEqual(backend_available.call_count, 2)
+                backend_available.assert_called_with("hpu")
+
+    def test_xpu_fp64_capability_tracks_device_properties(self):
+        predicate = XPUTestBase._capabilities()[Capability.dtype][Capability.dtype.fp64]
+        for expected in (True, False):
+            properties = SimpleNamespace(has_fp64=expected)
+            with patch.object(
+                torch.xpu, "get_device_properties", return_value=properties
+            ):
+                self.assertEqual(predicate(), expected)
 
 
 @unittest.skipIf(not dist.is_available(), "Distributed not available, skipping tests")

--- a/test/distributed/checkpoint/e2e/test_fine_tuning.py
+++ b/test/distributed/checkpoint/e2e/test_fine_tuning.py
@@ -16,8 +16,17 @@ from torch.distributed.checkpoint.state_dict import (
 )
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -80,6 +89,8 @@ class FineTuningModel(nn.Module):
 
 
 class TestFineTuning(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return min(4, torch.accelerator.device_count())
@@ -89,16 +100,17 @@ class TestFineTuning(DTensorTestBase):
         curr_backend = dist.get_default_backend_for_device(self.device_type)
         return f"cpu:gloo,{self.device_type}:{curr_backend}"
 
-    def pretrain(self, pretrain_dir: str) -> None:
-        device_mesh = init_device_mesh(self.device_type, (self.world_size,))
+    def pretrain(self, device, pretrain_dir: str) -> None:
+        device_type = torch.device(device).type
+        device_mesh = init_device_mesh(device_type, (self.world_size,))
 
-        model = PreTrainedModel().to(self.device_type)
+        model = PreTrainedModel().to(device_type)
         model = FSDP(model, device_mesh=device_mesh)
         optim = torch.optim.Adam(model.parameters(), lr=1e-3)
 
         # Training
         for _ in range(3):
-            batch = torch.rand(32, DIM, device=self.device_type)
+            batch = torch.rand(32, DIM, device=device_type)
             loss = model(batch).sum()
             loss.backward()
             optim.step()
@@ -112,10 +124,11 @@ class TestFineTuning(DTensorTestBase):
             storage_writer=dist_cp.FileSystemWriter(pretrain_dir),
         )
 
-    def finetune(self, pretrain_dir: str, finetune_dir: str) -> None:
-        device_mesh = init_device_mesh(self.device_type, (self.world_size,))
+    def finetune(self, device, pretrain_dir: str, finetune_dir: str) -> None:
+        device_type = torch.device(device).type
+        device_mesh = init_device_mesh(device_type, (self.world_size,))
 
-        model = FineTuningModel().to(self.device_type)
+        model = FineTuningModel().to(device_type)
         # TODO: make the parallelism more complicated, e.g., using 2D + DDP.
         model = FSDP(model, use_orig_params=True, device_mesh=device_mesh)
         optim = torch.optim.Adam(model.parameters(), lr=1e-3)
@@ -163,7 +176,7 @@ class TestFineTuning(DTensorTestBase):
 
             # Training
             for _ in range(3):
-                batch = torch.rand(32, DIM, device=self.device_type)
+                batch = torch.rand(32, DIM, device=device_type)
                 loss = model(batch).sum()
                 loss.backward()
                 optim.step()
@@ -182,9 +195,14 @@ class TestFineTuning(DTensorTestBase):
             )
 
     @skip_if_lt_x_gpu(4)
+    @requires_capabilities(
+        Capability.distributed.backend,
+        Capability.distributed.dtensor,
+        Capability.distributed.fsdp,
+    )
     @with_comms
     @with_temp_dir
-    def test_fine_tuning(self) -> None:
+    def test_fine_tuning(self, device) -> None:
         self.assertTrue(os.path.exists(self.temp_dir))
         pretrain_dir = os.path.join(self.temp_dir, "pretrain")
         finetune_dir = os.path.join(self.temp_dir, "finetune")
@@ -197,8 +215,13 @@ class TestFineTuning(DTensorTestBase):
         self.assertTrue(os.path.exists(pretrain_dir))
         self.assertTrue(os.path.exists(finetune_dir))
 
-        self.pretrain(pretrain_dir)
-        self.finetune(pretrain_dir, finetune_dir)
+        self.pretrain(device, pretrain_dir)
+        self.finetune(device, pretrain_dir, finetune_dir)
+
+
+instantiate_device_type_tests(
+    TestFineTuning, globals(), except_for=("cpu",), allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -2,6 +2,7 @@
 
 import copy
 import gc
+import importlib.util
 import inspect
 import logging
 import os
@@ -328,9 +329,7 @@ class Capability:
 
     Tests declare requirements with :func:`requires_capabilities`::
 
-        @requires_capabilities(
-            Capability.dtype.fp8, Capability.attention.flash_attention
-        )
+        @requires_capabilities(Capability.lib.triton, Capability.dtype.fp8)
         def test_foo(self, device): ...
 
     Device test bases declare what they support by overriding
@@ -338,16 +337,81 @@ class Capability:
     """
 
     class dtype:
-        """Data type capabilities (fp8, bf16, etc.)."""
+        """Data type capabilities (fp8, bf16, fp64, etc.)."""
 
         fp8 = "dtype.fp8"
         bf16 = "dtype.bf16"
+        fp64 = "dtype.fp64"
+
+    class lib:
+        """Third-party library capabilities (triton, etc.)."""
+
+        safetensors = "lib.safetensors"
+        triton = "lib.triton"
 
     class attention:
         """Attention backend capabilities."""
 
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
+
+    class distributed:
+        """Distributed runtime capabilities."""
+
+        backend = "distributed.backend"
+        dtensor = "distributed.dtensor"
+        fsdp = "distributed.fsdp"
+
+    class memory:
+        """Device memory capabilities."""
+
+        non_blocking_copy = "memory.non_blocking_copy"
+
+    class stream:
+        """Device stream capabilities."""
+
+        generic = "stream.generic"
+
+
+def _check_capabilities(test_case, required_capabilities) -> None:
+    device_caps = type(test_case).get_capabilities()
+    missing = set(required_capabilities) - device_caps.keys()
+    unsupported = {
+        cap
+        for cap in required_capabilities
+        if cap in device_caps and not device_caps[cap]
+    }
+
+    if missing:
+        raise AssertionError(
+            f"Device '{type(test_case).device_type}' has not declared capabilities: "
+            f"{', '.join(sorted(missing))}. "
+            f"Add them to {type(test_case).__name__}._capabilities()."
+        )
+    if unsupported:
+        raise unittest.SkipTest(
+            f"Device '{type(test_case).device_type}' has unsupported capabilities: "
+            f"{', '.join(sorted(unsupported))}"
+        )
+
+
+def _distributed_backend_available(device_type: str) -> bool:
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        return False
+    try:
+        backend = dist.get_default_backend_for_device(device_type)
+    except (AttributeError, ValueError):
+        return False
+    return dist.is_backend_available(backend)
+
+
+def _device_module_available(device_type: str) -> bool:
+    try:
+        return torch.get_device_module(device_type).is_available()
+    except (AttributeError, RuntimeError):
+        return False
 
 
 class DeviceTypeTestBase(TestCase):
@@ -420,16 +484,38 @@ class DeviceTypeTestBase(TestCase):
 
     # Returns the capability map used by @requires_capabilities.
     # Subclasses (CPUTestBase, CUDATestBase, etc.) override _capabilities() to
-    # declare supported capabilities. This method evaluates the support checks.
+    # declare supported capabilities grouped by namespace. This method flattens
+    # the nested map and evaluates the support checks.
     @classmethod
     def get_capabilities(cls) -> dict[str, bool]:
-        return {k: bool(fn()) for k, fn in cls._capabilities().items()}
+        return {
+            k: bool(fn())
+            for sub in cls._capabilities().values()
+            for k, fn in sub.items()
+        }
 
-    # Returns a capability map from capability identifier to a callable that
-    # determines whether the current device supports it.
+    # Returns a nested capability map grouped by namespace.
+    # Each namespace (e.g. Capability.dtype) groups related capabilities
+    # (e.g. Capability.dtype.fp8) mapped to callables that determine whether
+    # the current device supports them.
     @classmethod
-    def _capabilities(cls) -> dict[str, Callable[[], bool]]:
-        return {}
+    def _capabilities(cls) -> dict[type, dict[str, Callable[[], bool]]]:
+        return {
+            Capability.lib: {
+                Capability.lib.safetensors: lambda: importlib.util.find_spec(
+                    "safetensors"
+                )
+                is not None,
+            }
+        }
+
+    def setUp(self) -> None:
+        test_method = getattr(self, self._testMethodName)
+        required_capabilities = getattr(test_method, "_required_capabilities", ())
+        if required_capabilities:
+            _check_capabilities(self, required_capabilities)
+
+        super().setUp()
 
     # Flag to disable test suite early due to unrecoverable error such as CUDA error.
     _stop_test_suite = False
@@ -788,12 +874,41 @@ class CPUTestBase(DeviceTypeTestBase):
 
     @classmethod
     def _capabilities(cls):
-        return {
-            Capability.dtype.fp8: lambda: True,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: True,
-            Capability.attention.mem_efficient_attention: lambda: False,
-        }
+        from torch.utils._triton import has_triton
+
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: False,
+                    Capability.dtype.fp64: lambda: True,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: False,
+                    Capability.attention.mem_efficient_attention: lambda: False,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: False,
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: False,
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: False,
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
 
 class CUDATestBase(DeviceTypeTestBase):
@@ -816,13 +931,47 @@ class CUDATestBase(DeviceTypeTestBase):
             PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
             SM80OrLater,
         )
+        from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
-            Capability.dtype.bf16: lambda: SM80OrLater,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
-            Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: PLATFORM_SUPPORTS_FP8,
+                    Capability.dtype.bf16: lambda: SM80OrLater,
+                    Capability.dtype.fp64: lambda: True,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
+                    Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -900,15 +1049,6 @@ class MPSTestBase(DeviceTypeTestBase):
     def _should_stop_test_suite(self):
         return False
 
-    @classmethod
-    def _capabilities(cls):
-        return {
-            Capability.dtype.fp8: lambda: False,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: False,
-            Capability.attention.mem_efficient_attention: lambda: False,
-        }
-
 
 class XPUTestBase(DeviceTypeTestBase):
     device_type = "xpu"
@@ -919,13 +1059,47 @@ class XPUTestBase(DeviceTypeTestBase):
         from torch.testing._internal.common_xpu import (
             PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
         )
+        from torch.utils._triton import has_triton
 
-        return {
-            Capability.dtype.fp8: lambda: True,
-            Capability.dtype.bf16: lambda: True,
-            Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
-            Capability.attention.mem_efficient_attention: lambda: True,
-        }
+        capabilities = super()._capabilities()
+        capabilities.update(
+            {
+                Capability.dtype: {
+                    Capability.dtype.fp8: lambda: True,
+                    Capability.dtype.bf16: lambda: True,
+                    Capability.dtype.fp64: lambda: torch.xpu.get_device_properties().has_fp64,
+                },
+                Capability.attention: {
+                    Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
+                    Capability.attention.mem_efficient_attention: lambda: True,
+                },
+                Capability.distributed: {
+                    Capability.distributed.backend: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.dtensor: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                    Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.memory: {
+                    Capability.memory.non_blocking_copy: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+                Capability.stream: {
+                    Capability.stream.generic: lambda: _device_module_available(
+                        cls.device_type
+                    ),
+                },
+            }
+        )
+        capabilities[Capability.lib].update(
+            {Capability.lib.triton: lambda: has_triton()}
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -957,6 +1131,26 @@ class XPUTestBase(DeviceTypeTestBase):
 class HPUTestBase(DeviceTypeTestBase):
     device_type = "hpu"
     primary_device: ClassVar[str]
+
+    @classmethod
+    def _capabilities(cls):
+        capabilities = super()._capabilities()
+        capabilities.setdefault(Capability.dtype, {}).update(
+            {
+                Capability.dtype.fp64: lambda: False,
+            }
+        )
+        capabilities.setdefault(Capability.distributed, {}).update(
+            {
+                Capability.distributed.backend: lambda: _distributed_backend_available(
+                    cls.device_type
+                ),
+                Capability.distributed.fsdp: lambda: _distributed_backend_available(
+                    cls.device_type
+                ),
+            }
+        )
+        return capabilities
 
     @classmethod
     def get_primary_device(cls):
@@ -1188,35 +1382,17 @@ def requires_capabilities(*caps: str):
     Raises AssertionError if a capability is not declared in the
     device's ``_capabilities()`` map.
     """
-    caps_set = set(caps)
+    caps_set = frozenset(caps)
 
     def decorator(fn):
         @wraps(fn)
         def wrapper(self, *args, **kwargs):
-            device_caps = type(self).get_capabilities()
-
-            unsupported = set()
-            missing = set()
-            for c in caps_set:
-                if c in device_caps:
-                    if not device_caps[c]:
-                        unsupported.add(c)
-                else:
-                    missing.add(c)
-
-            if missing:
-                raise AssertionError(
-                    f"Device '{type(self).device_type}' has not declared capabilities: "
-                    f"{', '.join(sorted(missing))}. "
-                    f"Add them to {type(self).__name__}._capabilities()."
-                )
-            if unsupported:
-                raise unittest.SkipTest(
-                    f"Device '{type(self).device_type}' has unsupported capabilities: "
-                    f"{', '.join(sorted(unsupported))}"
-                )
+            _check_capabilities(self, caps_set)
             return fn(self, *args, **kwargs)
 
+        wrapper._required_capabilities = (
+            frozenset(getattr(fn, "_required_capabilities", ())) | caps_set
+        )
         return wrapper
 
     return decorator


### PR DESCRIPTION
I reviewed the code, current diff, review context, and validation results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it.
>
> ## Summary
> Make the distributed checkpoint fine-tuning end-to-end test use the device supplied by the device-test harness.
>
> ## Changes
> - Classify `TestFineTuning` as `HardwareClassification.ACCELERATOR` and instantiate it through the device-type harness.
> - Pass the harness device through pretraining, fine-tuning, model placement, tensor creation, and device-mesh setup.
> - Preserve four-device admission and add distributed backend, DTensor, and FSDP capability gates.
>
> ## Motivation
> The test validates distributed checkpointing with DTensor and FSDP on an accelerator, but its device selection should come from the harness rather than an implicit backend default. This keeps the consumer reusable across supported accelerators.
>
> ## Test Plan
> ```bash
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/checkpoint/e2e/test_fine_tuning.py
> git diff --check
> ```
>
> Results: py_compile and diff check PASS. `spin`/`uvx` lint was not run because the bootstrap is unavailable in this WSL environment; no accelerator runtime was run for this head, so runtime validation is PARTIAL.
>
> ## Notes
> - Base: `main@cb1ce48b4b211092ad702bbd58ef3139f939e52f`.
> - Head: `51683ee80c60d1063c2e426103df6366210014df`.
> - Remote view: 2 commits, 3 files, `+352/-92`; two framework/helper files are inherited ancestry.
> - Topic-level consumer is `test/distributed/checkpoint/e2e/test_fine_tuning.py`; shared capability/classification infrastructure is maintained separately.
>
> ## Checklist
> - [ ] Scoped lint — not run because `spin`/`uvx` is unavailable.
> - [x] Added/updated tests.
> - [x] Documentation update not applicable; this is internal test classification.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No.