### PR TITLE
[Testcase Refactoring][FSDP] Decouple gradient accumulation tests from accelerator selection

### DIFF
--- a/test/distributed/fsdp/test_fsdp_grad_acc.py
+++ b/test/distributed/fsdp/test_fsdp_grad_acc.py
@@ -13,6 +13,11 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import (
     BackwardPrefetch,
     ShardingStrategy,
 )
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
@@ -21,7 +26,7 @@ from torch.testing._internal.common_fsdp import (
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
@@ -82,12 +87,15 @@ class TestGradAcc(FSDPTestContinuous):
     """Tests ``FullyShardedDataParallel``'s gradient accumulation via both its
     ``no_sync()`` context manager and without the context manager."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 2
 
     def _test_grad_acc(
         self,
+        device,
         batch_dim: int,
         configs: list[_GradAccConfig],
         cpu_offload: CPUOffload,
@@ -104,6 +112,7 @@ class TestGradAcc(FSDPTestContinuous):
         specified by the last element of ``configs``.
 
         Arguments:
+            device (str): Device supplied by ``instantiate_device_type_tests``.
             batch_dim (int): Batch dimension in the input tensor to be passed
                 into the model for the forward pass.
             configs (List[_GradAccConfig]): :class:`list` of configurations
@@ -133,7 +142,7 @@ class TestGradAcc(FSDPTestContinuous):
             deterministic=True,
             add_bn=False,  # disable BN since the test uses varying batch sizes
         )
-        device = torch.device("cuda")
+        device_type = torch.device(device).type
         optim = torch.optim.SGD(
             fsdp_model.parameters(),
             lr=0.01,
@@ -145,7 +154,7 @@ class TestGradAcc(FSDPTestContinuous):
         def permute_tensor(x: torch.Tensor):
             return x.view(-1)[torch.randperm(x.numel())].view_as(x)
 
-        batch: tuple[torch.Tensor, ...] = fsdp_model.module.get_input(device)
+        batch: tuple[torch.Tensor, ...] = fsdp_model.module.get_input(device_type)
         batches: list[tuple[torch.Tensor, ...]] = [batch]
         num_iters_to_acc = sum(config.num_iters for config in configs)
         for _ in range(num_iters_to_acc - 1):
@@ -229,6 +238,7 @@ class TestGradAcc(FSDPTestContinuous):
             ],
         }
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize(
         "configs",
@@ -252,6 +262,7 @@ class TestGradAcc(FSDPTestContinuous):
     @parametrize("use_orig_params", [False, True])
     def test_grad_acc(
         self,
+        device,
         configs: _GradAccConfigs,
         use_orig_params: bool,
     ):
@@ -269,15 +280,18 @@ class TestGradAcc(FSDPTestContinuous):
         self.run_subtests(
             subtest_config,
             self._test_grad_acc,
+            device=device,
             batch_dim=1,
             configs=configs.configs,
             use_orig_params=use_orig_params,
         )
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("use_orig_params", [False, True])
     def test_grad_acc_cpu_offload(
         self,
+        device,
         use_orig_params: bool,
     ):
         """
@@ -294,13 +308,19 @@ class TestGradAcc(FSDPTestContinuous):
         self.run_subtests(
             subtest_config,
             self._test_grad_acc,
+            device=device,
             batch_dim=1,
             configs=configs.configs,
             use_orig_params=use_orig_params,
         )
 
 
-instantiate_parametrized_tests(TestGradAcc)
+instantiate_device_type_tests(
+    TestGradAcc,
+    globals(),
+    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/fsdp/test_fsdp_grad_acc.py
+++ b/test/distributed/fsdp/test_fsdp_grad_acc.py
@@ -318,7 +318,7 @@ class TestGradAcc(FSDPTestContinuous):
 instantiate_device_type_tests(
     TestGradAcc,
     globals(),
-    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -39,6 +39,17 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+try:
+    from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+except ImportError:
+    # PyTorch can be built without distributed support (USE_DISTRIBUTED=0),
+    # e.g. standard macOS CI, where torch._C._distributed_c10d is absent and
+    # common_distributed cannot be imported. TestSkipIfLtXGpu is skipped below via
+    # _SKIP_IF_LT_X_GPU_DISTRIBUTED when USE_DISTRIBUTED=0.
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = False
+else:
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = True
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -3143,6 +3154,41 @@ class TestHardwareClassifications(TestCase):
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)
+
+
+@unittest.skipIf(
+    not _SKIP_IF_LT_X_GPU_DISTRIBUTED,
+    "requires a distributed build (USE_DISTRIBUTED=1)",
+)
+class TestSkipIfLtXGpu(TestCase):
+    @unittest.mock.patch("torch.get_device_module")
+    @unittest.mock.patch("torch._C._accelerator_getAccelerator")
+    def test_allow_cpu_with_compile_only_accelerator(
+        self, mock_get_accelerator, mock_get_device_module
+    ):
+        """Regression test: allow_cpu=True must fall back to CPU when PyTorch is
+        compiled with an accelerator but that accelerator is unavailable at runtime.
+
+        Without check_available=True, current_accelerator() returns the compile-time
+        accelerator even if no device is present. In that case acc is not None, but
+        device_module.is_available() is False, so the allow_cpu=True branch that
+        guards the CPU fallback (``acc is None``) is never taken and the test is
+        skipped instead of running on CPU.
+        """
+        mock_device = unittest.mock.MagicMock()
+        mock_device.type = "cuda"
+        mock_get_accelerator.return_value = mock_device
+
+        mock_module = unittest.mock.MagicMock()
+        mock_module.is_available.return_value = False
+        mock_module.device_count.return_value = 0
+        mock_get_device_module.return_value = mock_module
+
+        @skip_if_lt_x_gpu(2, allow_cpu=True)
+        def test_func():
+            return "cpu_fallback"
+
+        self.assertEqual(test_func(), "cpu_fallback")
 
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -300,6 +300,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -308,14 +312,28 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if (
-                torch.accelerator.is_available()
-                and torch.accelerator.device_count() >= x
-            ):
+            # Use check_available=True because current_accelerator() defaults to
+            # compile-time detection. On builds compiled with an accelerator but
+            # with no runtime device available, it would still return that
+            # accelerator, causing allow_cpu=True tests to be skipped instead of
+            # taking the CPU fallback.
+            acc = torch.accelerator.current_accelerator(check_available=True)
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if allow_cpu and not torch.accelerator.is_available():
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-device-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-device-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -73,17 +73,19 @@ if TEST_WITH_ROCM:
 else:
     DEVICE_COUNT = 4
 
-if TEST_CUDA:
-    DEVICE_TYPE = "cuda"
-    DISTRIBUTED_BACKEND = "nccl"
-    DEVICE_COUNT = torch.cuda.device_count()
-elif TEST_HPU:
+if TEST_HPU:
+    # HPU is registered as "fake" in Backend.default_device_backend_map by default.
+    # The real HCCL backend should be registered by torch_hpu; this branch handles
+    # environments where that registration has not occurred.
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
-elif TEST_XPU:
-    DEVICE_TYPE = "xpu"
-    DISTRIBUTED_BACKEND = "xccl"
-    DEVICE_COUNT = torch.xpu.device_count()
+elif torch.accelerator.is_available():
+    acc = torch.accelerator.current_accelerator()
+    DEVICE_TYPE = str(acc)
+    # Use the backend registered for this accelerator type. If no backend is
+    # registered, the accelerator's companion plugin is missing or broken.
+    DISTRIBUTED_BACKEND = dist.Backend.default_device_backend_map[acc.type]
+    DEVICE_COUNT = torch.get_device_module(acc.type).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1245,7 +1247,8 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1591,8 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1639,8 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
I reviewed the code, current diff, review context, and validation results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it. Depends on #187650.
>
> ## Summary
> Make the FSDP gradient-accumulation tests use the device supplied by the device-test harness.
>
> ## Changes
> - Classify `TestGradAcc` as `HardwareClassification.ACCELERATOR`.
> - Pass the harness device through gradient-accumulation helpers and test methods.
> - Replace fixed device selection with the injected device type.
> - Preserve device-count and parameterized coverage, with distributed backend and FSDP capability gates.
> - Retain `except_for=("cpu",)` and the reviewed `allow_xpu=True` opt-in.
>
> ## Motivation
> Gradient accumulation is accelerator-generic FSDP behavior. Explicit harness-device injection and capability admission avoid dependence on a single backend while preserving the assertions.
>
> ## Test Plan
> ```bash
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/fsdp/test_fsdp_grad_acc.py
> git diff --check
> ```
>
> Results: py_compile and diff check PASS. Lint was not run because `uvx` is unavailable; no accelerator runtime was run for this head, so runtime validation is PARTIAL.
>
> ## Notes
> - Base: `main@ff9d60a3e6a3002b92dd89bd9949c70a82e3688f`.
> - Head: `0c8609b75254d1ca5df2d89d1f60dc1f8f7d7f80`.
> - Remote view: 2 commits, 4 files, `+111/-22`; the three helper/framework files are inherited ancestry.
> - Topic-level consumer is `test/distributed/fsdp/test_fsdp_grad_acc.py`; #191919 capability/OpenReg files are intentionally not included.
>
> ## Checklist
> - [ ] Scoped lint — not run because `uvx` is unavailable.
> - [x] Added/updated tests.
> - [x] Documentation update not applicable; this is internal test classification.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No.