### PR TITLE
[Testcase Refactoring][FSDP] Decouple input handling tests from accelerator selection

### DIFF
--- a/test/distributed/fsdp/test_fsdp_input.py
+++ b/test/distributed/fsdp/test_fsdp_input.py
@@ -126,7 +126,7 @@ class TestInput(FSDPTestContinuous):
 instantiate_device_type_tests(
     TestInput,
     globals(),
-    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 if __name__ == "__main__":

--- a/test/distributed/fsdp/test_fsdp_input.py
+++ b/test/distributed/fsdp/test_fsdp_input.py
@@ -6,10 +6,15 @@ from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.nn import Linear, Module
 from torch.optim import SGD
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTestContinuous
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     parametrize,
     run_tests,
     subtest,
@@ -29,14 +34,17 @@ if TEST_WITH_DEV_DBG_ASAN:
 
 
 class TestInput(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 1
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(1)
     @parametrize("input_cls", [subtest(dict, name="dict"), subtest(list, name="list")])
     def test_input_type(self, device, input_cls):
-        """Test FSDP with input being a list or a dict, only single GPU."""
+        """Test FSDP with input being a list or a dict on one accelerator."""
 
         class Model(Module):
             def __init__(self):
@@ -72,6 +80,7 @@ class TestInput(FSDPTestContinuous):
             optim.step()
             optim.zero_grad()
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(1)
     @parametrize("input_cls", [subtest(dict, name="dict"), subtest(list, name="list")])
     def test_input_identity_preserved(self, device, input_cls):
@@ -114,7 +123,11 @@ class TestInput(FSDPTestContinuous):
             self.assertIn("added", in_data)
 
 
-devices = ("cuda", "hpu", "xpu")
-instantiate_device_type_tests(TestInput, globals(), only_for=devices, allow_xpu=True)
+instantiate_device_type_tests(
+    TestInput,
+    globals(),
+    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    allow_xpu=True,
+)
 if __name__ == "__main__":
     run_tests()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -39,6 +39,17 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+try:
+    from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+except ImportError:
+    # PyTorch can be built without distributed support (USE_DISTRIBUTED=0),
+    # e.g. standard macOS CI, where torch._C._distributed_c10d is absent and
+    # common_distributed cannot be imported. TestSkipIfLtXGpu is skipped below via
+    # _SKIP_IF_LT_X_GPU_DISTRIBUTED when USE_DISTRIBUTED=0.
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = False
+else:
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = True
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -3143,6 +3154,41 @@ class TestHardwareClassifications(TestCase):
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)
+
+
+@unittest.skipIf(
+    not _SKIP_IF_LT_X_GPU_DISTRIBUTED,
+    "requires a distributed build (USE_DISTRIBUTED=1)",
+)
+class TestSkipIfLtXGpu(TestCase):
+    @unittest.mock.patch("torch.get_device_module")
+    @unittest.mock.patch("torch._C._accelerator_getAccelerator")
+    def test_allow_cpu_with_compile_only_accelerator(
+        self, mock_get_accelerator, mock_get_device_module
+    ):
+        """Regression test: allow_cpu=True must fall back to CPU when PyTorch is
+        compiled with an accelerator but that accelerator is unavailable at runtime.
+
+        Without check_available=True, current_accelerator() returns the compile-time
+        accelerator even if no device is present. In that case acc is not None, but
+        device_module.is_available() is False, so the allow_cpu=True branch that
+        guards the CPU fallback (``acc is None``) is never taken and the test is
+        skipped instead of running on CPU.
+        """
+        mock_device = unittest.mock.MagicMock()
+        mock_device.type = "cuda"
+        mock_get_accelerator.return_value = mock_device
+
+        mock_module = unittest.mock.MagicMock()
+        mock_module.is_available.return_value = False
+        mock_module.device_count.return_value = 0
+        mock_get_device_module.return_value = mock_module
+
+        @skip_if_lt_x_gpu(2, allow_cpu=True)
+        def test_func():
+            return "cpu_fallback"
+
+        self.assertEqual(test_func(), "cpu_fallback")
 
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -300,6 +300,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -308,14 +312,28 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if (
-                torch.accelerator.is_available()
-                and torch.accelerator.device_count() >= x
-            ):
+            # Use check_available=True because current_accelerator() defaults to
+            # compile-time detection. On builds compiled with an accelerator but
+            # with no runtime device available, it would still return that
+            # accelerator, causing allow_cpu=True tests to be skipped instead of
+            # taking the CPU fallback.
+            acc = torch.accelerator.current_accelerator(check_available=True)
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if allow_cpu and not torch.accelerator.is_available():
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-device-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-device-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -73,17 +73,19 @@ if TEST_WITH_ROCM:
 else:
     DEVICE_COUNT = 4
 
-if TEST_CUDA:
-    DEVICE_TYPE = "cuda"
-    DISTRIBUTED_BACKEND = "nccl"
-    DEVICE_COUNT = torch.cuda.device_count()
-elif TEST_HPU:
+if TEST_HPU:
+    # HPU is registered as "fake" in Backend.default_device_backend_map by default.
+    # The real HCCL backend should be registered by torch_hpu; this branch handles
+    # environments where that registration has not occurred.
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
-elif TEST_XPU:
-    DEVICE_TYPE = "xpu"
-    DISTRIBUTED_BACKEND = "xccl"
-    DEVICE_COUNT = torch.xpu.device_count()
+elif torch.accelerator.is_available():
+    acc = torch.accelerator.current_accelerator()
+    DEVICE_TYPE = str(acc)
+    # Use the backend registered for this accelerator type. If no backend is
+    # registered, the accelerator's companion plugin is missing or broken.
+    DISTRIBUTED_BACKEND = dist.Backend.default_device_backend_map[acc.type]
+    DEVICE_COUNT = torch.get_device_module(acc.type).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1245,7 +1247,8 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1591,8 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1639,8 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
I reviewed the code, current diff, review context, and validation results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it. Depends on #187650.
>
> ## Summary
> Classify the FSDP input-handling tests by accelerator requirements and use the shared capability admission path.
>
> ## Changes
> - Mark the input test class as `HardwareClassification.ACCELERATOR`.
> - Add distributed backend and FSDP capability gates.
> - Use the harness-selected device consistently while preserving list and dictionary input semantics.
> - Retain `except_for=("cpu",)` and the reviewed `allow_xpu=True` opt-in.
>
> ## Motivation
> The test validates accelerator-generic FSDP input handling. Explicit requirements prevent collection from being tied to a fixed device-name list while preserving behavior.
>
> ## Test Plan
> ```bash
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/fsdp/test_fsdp_input.py
> git diff --check
> ```
>
> Results: py_compile and diff check PASS. Lint was not run because `uvx` is unavailable; no accelerator runtime was run for this head, so runtime validation is PARTIAL.
>
> ## Notes
> - Base: `main@ff9d60a3e6a3002b92dd89bd9949c70a82e3688f`.
> - Head: `44cd2328c5c926d94d73320a8cacf783cda6169c`.
> - Remote view: 2 commits, 4 files, `+104/-22`; the three helper/framework files are inherited ancestry.
> - Topic-level consumer is `test/distributed/fsdp/test_fsdp_input.py`; #191919 capability/OpenReg files are intentionally not included.
>
> ## Checklist
> - [ ] Scoped lint — not run because `uvx` is unavailable.
> - [x] Added/updated tests.
> - [x] Documentation update not applicable; this is internal test classification.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No.