### PR TITLE
[Testcase Refactoring][FSDP] Decouple overlap tests from accelerator selection

### DIFF
--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -284,7 +284,7 @@ class TestForwardOverlapWorldSizeTwo(TestForwardOverlapWorldSizeOne):
 instantiate_device_type_tests(
     TestForwardOverlapWorldSizeOne,
     globals(),
-    only_for=("cuda", "hpu", "xpu"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 if __name__ == "__main__":

--- a/test/distributed/fsdp/test_fsdp_overlap.py
+++ b/test/distributed/fsdp/test_fsdp_overlap.py
@@ -2,7 +2,6 @@
 
 import sys
 import time
-import unittest
 from statistics import mean
 from unittest.mock import patch
 
@@ -10,13 +9,18 @@ import torch
 import torch.nn as nn
 from torch import distributed as dist, Event
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTestContinuous
 from torch.testing._internal.common_utils import (
+    device_sleep,
     get_cycles_per_ms,
+    HardwareClassification,
     run_tests,
-    TEST_HPU,
     TEST_WITH_DEV_DBG_ASAN,
     TEST_XPU,
     xfailIf,
@@ -34,13 +38,12 @@ if TEST_WITH_DEV_DBG_ASAN:
     )
     sys.exit(0)
 
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
-
 
 class Layer(nn.Module):
-    def __init__(self, compute_cycles, has_params: bool):
+    def __init__(self, compute_cycles, has_params: bool, device_type: str):
         super().__init__()
         self.sleep_cycles = compute_cycles
+        self.device_type = device_type
         self.optional_param = None
         if has_params:
             self.optional_param = nn.Parameter(torch.rand(1))
@@ -53,8 +56,7 @@ class Layer(nn.Module):
         # Record the fake forward compute time.
         self.e1.record()
         if self.sleep_cycles > 0:
-            if torch.cuda.is_available():
-                torch.cuda._sleep(self.sleep_cycles)
+            device_sleep(self.device_type, self.sleep_cycles)
         if self.optional_param is not None:
             x = x + self.optional_param  # force the param to be part of the graph
         self.e2.record()
@@ -65,15 +67,28 @@ class Layer(nn.Module):
         return self.e1.elapsed_time(self.e2)
 
 
-def _create_model(compute_cycles, has_params: bool):
+def _create_model(compute_cycles, has_params: bool, device):
+    device_type = torch.device(device).type
     # Use `limit_all_gathers=False` since the timing being tested relies on the
     # CPU running ahead of the GPU
     model = FSDP(
         nn.Sequential(
-            FSDP(Layer(compute_cycles, has_params), limit_all_gathers=False),
-            FSDP(Layer(compute_cycles, has_params), limit_all_gathers=False),
-            FSDP(Layer(compute_cycles, has_params), limit_all_gathers=False),
-            FSDP(Layer(compute_cycles, has_params), limit_all_gathers=False),
+            FSDP(
+                Layer(compute_cycles, has_params, device_type),
+                limit_all_gathers=False,
+            ),
+            FSDP(
+                Layer(compute_cycles, has_params, device_type),
+                limit_all_gathers=False,
+            ),
+            FSDP(
+                Layer(compute_cycles, has_params, device_type),
+                limit_all_gathers=False,
+            ),
+            FSDP(
+                Layer(compute_cycles, has_params, device_type),
+                limit_all_gathers=False,
+            ),
         ),
         limit_all_gathers=False,
     ).to(device_type)
@@ -97,11 +112,14 @@ class Min10:
 
 
 class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 1
 
-    def _dist_train(self):
+    def _dist_train(self, device):
+        device_type = torch.device(device).type
         rank = self.rank
         world_size = self.world_size
         # Save the original torch.distributed.all_gather_single function since we will
@@ -110,7 +128,7 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
 
         def run(compute_cycles, all_gather_cycles):
             has_params = all_gather_cycles > 0
-            model = _create_model(compute_cycles, has_params)
+            model = _create_model(compute_cycles, has_params, device)
 
             # Get the input and sets the input's requires_grad to True because
             # we have a fake compute in the forward pass.
@@ -141,8 +159,7 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
                 def _delayed_all_gather(*args, **kwargs):
                     nonlocal all_gather_called
                     all_gather_called = True
-                    if torch.cuda.is_available():
-                        torch.cuda._sleep(all_gather_cycles)
+                    device_sleep(device_type, all_gather_cycles)
                     if not orig_all_gather:
                         raise AssertionError("Expected orig_all_gather to be truthy")
                     return orig_all_gather(*args, **kwargs)
@@ -193,7 +210,7 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
                 "gpu_total": gpu_total.avg(),
             }
 
-        sleep_cycles = int(100 * get_cycles_per_ms())
+        sleep_cycles = int(100 * get_cycles_per_ms(device_type))
 
         e1 = run(0, 0)  # no compute, no all-gather
         e2 = run(0, sleep_cycles)  # no compute, only all-gather
@@ -248,11 +265,14 @@ class TestForwardOverlapWorldSizeOne(FSDPTestContinuous):
             both = e4["gpu_total"]
             self.assertTrue(compute_only + all_gather_only > 1.1 * both)
 
-    @unittest.skipIf(TEST_HPU, "HPU doesn't has HW sleep API support, skipping")
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @xfailIf(TEST_XPU)  # https://github.com/intel/torch-xpu-ops/issues/1504
     @skip_if_lt_x_gpu(2)
-    def test_forward_overlap(self):
-        self._dist_train()
+    def test_forward_overlap(self, device):
+        device_type = torch.device(device).type
+        if not hasattr(torch.get_device_module(device_type), "_sleep"):
+            self.skipTest(f"{device_type} does not support device sleep")
+        self._dist_train(device)
 
 
 class TestForwardOverlapWorldSizeTwo(TestForwardOverlapWorldSizeOne):
@@ -261,9 +281,11 @@ class TestForwardOverlapWorldSizeTwo(TestForwardOverlapWorldSizeOne):
         return 2
 
 
-devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(
-    TestForwardOverlapWorldSizeOne, globals(), only_for=devices, allow_xpu=True
+    TestForwardOverlapWorldSizeOne,
+    globals(),
+    only_for=("cuda", "hpu", "xpu"),
+    allow_xpu=True,
 )
 if __name__ == "__main__":
     run_tests()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -39,6 +39,17 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+try:
+    from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+except ImportError:
+    # PyTorch can be built without distributed support (USE_DISTRIBUTED=0),
+    # e.g. standard macOS CI, where torch._C._distributed_c10d is absent and
+    # common_distributed cannot be imported. TestSkipIfLtXGpu is skipped below via
+    # _SKIP_IF_LT_X_GPU_DISTRIBUTED when USE_DISTRIBUTED=0.
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = False
+else:
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = True
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -3143,6 +3154,41 @@ class TestHardwareClassifications(TestCase):
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)
+
+
+@unittest.skipIf(
+    not _SKIP_IF_LT_X_GPU_DISTRIBUTED,
+    "requires a distributed build (USE_DISTRIBUTED=1)",
+)
+class TestSkipIfLtXGpu(TestCase):
+    @unittest.mock.patch("torch.get_device_module")
+    @unittest.mock.patch("torch._C._accelerator_getAccelerator")
+    def test_allow_cpu_with_compile_only_accelerator(
+        self, mock_get_accelerator, mock_get_device_module
+    ):
+        """Regression test: allow_cpu=True must fall back to CPU when PyTorch is
+        compiled with an accelerator but that accelerator is unavailable at runtime.
+
+        Without check_available=True, current_accelerator() returns the compile-time
+        accelerator even if no device is present. In that case acc is not None, but
+        device_module.is_available() is False, so the allow_cpu=True branch that
+        guards the CPU fallback (``acc is None``) is never taken and the test is
+        skipped instead of running on CPU.
+        """
+        mock_device = unittest.mock.MagicMock()
+        mock_device.type = "cuda"
+        mock_get_accelerator.return_value = mock_device
+
+        mock_module = unittest.mock.MagicMock()
+        mock_module.is_available.return_value = False
+        mock_module.device_count.return_value = 0
+        mock_get_device_module.return_value = mock_module
+
+        @skip_if_lt_x_gpu(2, allow_cpu=True)
+        def test_func():
+            return "cpu_fallback"
+
+        self.assertEqual(test_func(), "cpu_fallback")
 
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -300,6 +300,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -308,14 +312,28 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if (
-                torch.accelerator.is_available()
-                and torch.accelerator.device_count() >= x
-            ):
+            # Use check_available=True because current_accelerator() defaults to
+            # compile-time detection. On builds compiled with an accelerator but
+            # with no runtime device available, it would still return that
+            # accelerator, causing allow_cpu=True tests to be skipped instead of
+            # taking the CPU fallback.
+            acc = torch.accelerator.current_accelerator(check_available=True)
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if allow_cpu and not torch.accelerator.is_available():
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-device-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-device-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -73,17 +73,19 @@ if TEST_WITH_ROCM:
 else:
     DEVICE_COUNT = 4
 
-if TEST_CUDA:
-    DEVICE_TYPE = "cuda"
-    DISTRIBUTED_BACKEND = "nccl"
-    DEVICE_COUNT = torch.cuda.device_count()
-elif TEST_HPU:
+if TEST_HPU:
+    # HPU is registered as "fake" in Backend.default_device_backend_map by default.
+    # The real HCCL backend should be registered by torch_hpu; this branch handles
+    # environments where that registration has not occurred.
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
-elif TEST_XPU:
-    DEVICE_TYPE = "xpu"
-    DISTRIBUTED_BACKEND = "xccl"
-    DEVICE_COUNT = torch.xpu.device_count()
+elif torch.accelerator.is_available():
+    acc = torch.accelerator.current_accelerator()
+    DEVICE_TYPE = str(acc)
+    # Use the backend registered for this accelerator type. If no backend is
+    # registered, the accelerator's companion plugin is missing or broken.
+    DISTRIBUTED_BACKEND = dist.Backend.default_device_backend_map[acc.type]
+    DEVICE_COUNT = torch.get_device_module(acc.type).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1245,7 +1247,8 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1591,8 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1639,8 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
I reviewed the code, current diff, review context, and validation results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it. Depends on #187650.
>
> ## Summary
> Make the FSDP overlap test use the harness device and shared device-sleep capability.
>
> ## Changes
> - Classify `TestForwardOverlapWorldSizeOne` as `HardwareClassification.ACCELERATOR`.
> - Pass the harness device through model creation and distributed training.
> - Replace direct CUDA sleep calls with `device_sleep` and retain a runtime skip when the selected device module lacks `_sleep`.
> - Preserve resource/capability admission and the existing overlap assertions.
> - Retain `except_for=("cpu",)` and the reviewed `allow_xpu=True` opt-in.
>
> ## Motivation
> The test measures computation/communication overlap rather than a vendor-specific runtime. Shared device sleep keeps it hardware-aware without hard-coding CUDA APIs.
>
> ## Test Plan
> ```bash
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/fsdp/test_fsdp_overlap.py
> git diff --check
> ```
>
> Results: py_compile and diff check PASS. Lint was not run because `uvx` is unavailable; no accelerator runtime was run for this head, so runtime validation is PARTIAL. Devices without sleep support continue to SKIP at runtime.
>
> ## Notes
> - Base: `main@ff9d60a3e6a3002b92dd89bd9949c70a82e3688f`.
> - Head: `9ad7cad7e058b3f7a6a06e5383511cf5ae6635fe`.
> - Remote view: 2 commits, 4 files, `+132/-41`; the three helper/framework files are inherited ancestry.
> - Topic-level consumer is `test/distributed/fsdp/test_fsdp_overlap.py`; #191919 capability/OpenReg files are intentionally not included.
>
> ## Checklist
> - [ ] Scoped lint — not run because `uvx` is unavailable.
> - [x] Added/updated tests.
> - [x] Documentation update not applicable; this is internal test classification.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No.