### PR TITLE
[Testcase Refactoring][FSDP] Decouple hybrid-shard tests from accelerator selection

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -547,13 +547,13 @@ class TestHSDPSyncModuleStates(FSDPTestMultiThread):
 instantiate_device_type_tests(
     TestFSDPHybridShard,
     globals(),
-    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestHSDPSyncModuleStates,
     globals(),
-    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 

--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -24,6 +24,11 @@ from torch.distributed.fsdp._init_utils import (
 )
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.nn import TransformerDecoderLayer, TransformerEncoderLayer
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
@@ -33,7 +38,7 @@ from torch.testing._internal.common_fsdp import (
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
 )
@@ -49,8 +54,6 @@ if TEST_WITH_DEV_DBG_ASAN:
         file=sys.stderr,
     )
     sys.exit(0)
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 @contextlib.contextmanager
@@ -98,6 +101,8 @@ class ShardingStrategyMode(Enum):
 
 
 class TestFSDPHybridShard(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return max(torch.accelerator.device_count(), 2)
@@ -106,8 +111,10 @@ class TestFSDPHybridShard(FSDPTestContinuous):
     def process_group(self):
         return dist.distributed_c10d._get_default_group()
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_raises_manual_wrap_hybrid_shard_when_none_policy(self):
+    def test_raises_manual_wrap_hybrid_shard_when_none_policy(self, device):
+        device_type = torch.device(device).type
         model = MyModel().to(device_type)
         err_ctx = self.assertRaisesRegex(
             ValueError,
@@ -120,8 +127,10 @@ class TestFSDPHybridShard(FSDPTestContinuous):
         with err_ctx:
             model = FSDP(model, sharding_strategy=ShardingStrategy._HYBRID_SHARD_ZERO2)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(4)
-    def test_hsdp_save_load_state_dict(self):
+    def test_hsdp_save_load_state_dict(self, device):
+        device_type = torch.device(device).type
         model = MyModel().to(device_type)
         num_node_devices = torch.accelerator.device_count()
         shard_rank_lists = (
@@ -154,7 +163,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
         model = fsdp_ctor(model)
         optim = torch.optim.AdamW(model.parameters())
         # Initialize optimizer states
-        model(torch.randn(2, 10)).sum().backward()
+        model(torch.randn(2, 10, device=device_type)).sum().backward()
         optim.step()
         shard_g = model.process_group
         replicate_g = model._inter_node_pg
@@ -177,8 +186,10 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             FSDP.optim_state_dict_to_load(load_model, load_optim, osd)
         load_optim.load_state_dict(osd)
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(4)
-    def test_hsdp_sync_module_state(self):
+    def test_hsdp_sync_module_state(self, device):
+        device_type = torch.device(device).type
         model = MyModel().to(device_type)
         num_node_devices = torch.accelerator.device_count()
         shard_rank_lists = (
@@ -220,8 +231,10 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             self.assertTrue((model.lin2.weight == 0).all())
             self.assertTrue((model.lin3.weight == 0).all())
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_invalid_pg_specification_raises(self):
+    def test_invalid_pg_specification_raises(self, device):
+        device_type = torch.device(device).type
         pol = ModuleWrapPolicy({nn.Linear})
         model = MyModel().to(device_type)
         with self.assertRaisesRegex(
@@ -237,14 +250,16 @@ class TestFSDPHybridShard(FSDPTestContinuous):
     # TODO - add test for ZeRO-2 style sharding ensure params are not
     # resharded after forward.
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_fsdp_hybrid_shard_basic_setup(self):
+    def test_fsdp_hybrid_shard_basic_setup(self, device):
         """
         Tests basic functionality of HYBRID_SHARD and _HYBRID_SHARD_ZERO2:
             1. Inter and intra-node process groups are correctly setup
             2. Process groups are the same across FSDP wrapped instances
             3. reduce_scatter and allreduce called the expected no. of times
         """
+        device_type = torch.device(device).type
         self.run_subtests(
             {
                 "hsdp_sharding_strategy": [
@@ -259,6 +274,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
                 "use_device_mesh": [False, True],
             },
             self._test_fsdp_hybrid_shard_basic_setup,
+            device_type=device_type,
         )
 
     def _test_fsdp_hybrid_shard_basic_setup(
@@ -267,6 +283,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
         sharding_strategy_mode: ShardingStrategyMode,
         use_orig_params: bool,
         use_device_mesh: bool,
+        device_type: str,
     ):
         if use_device_mesh:
             device_mesh = init_device_mesh(device_type, (1, self.world_size))
@@ -277,6 +294,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             sharding_strategy_mode,
             use_orig_params,
             hsdp_device_mesh=device_mesh,
+            device_type=device_type,
         )
         # All FSDP modules should have state.process_group as the process group over which to
         # shard (default process group), and state._inter_node_pg (process group containing only
@@ -325,7 +343,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             patch_allreduce(patched_allreduce),
             patch_reduce_scatter(patched_reduce_scatter),
         ):
-            inp = hsdp_model.get_input(device=torch.accelerator.current_device_index())
+            inp = hsdp_model.get_input(device=torch.device(device_type))
             out = hsdp_model(inp[0], inp[1])
             loss = hsdp_model.get_loss(inp, out)
             loss.backward()
@@ -342,8 +360,10 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             self.assertEqual(num_hsdp_flat_params, cntr[orig_ar])
             self.assertEqual(num_flat_params, cntr[orig_rs])
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(4)
-    def test_fsdp_hybrid_shard_parity(self):
+    def test_fsdp_hybrid_shard_parity(self, device):
+        device_type = torch.device(device).type
         self.run_subtests(
             {
                 "hsdp_sharding_strategy": [
@@ -353,12 +373,16 @@ class TestFSDPHybridShard(FSDPTestContinuous):
                 "use_orig_params": [False, True],
             },
             self._test_fsdp_hybrid_shard_parity,
+            device_type=device_type,
         )
 
     def _test_fsdp_hybrid_shard_parity(
-        self, hsdp_sharding_strategy: ShardingStrategy, use_orig_params: bool
+        self,
+        hsdp_sharding_strategy: ShardingStrategy,
+        use_orig_params: bool,
+        device_type: str,
     ):
-        fsdp_model = self._init_fsdp_model(use_orig_params)
+        fsdp_model = self._init_fsdp_model(use_orig_params, device_type)
         global_pg = dist.distributed_c10d._get_default_group()
         hsdp_pgs = _init_intra_and_inter_node_groups(global_pg, 2)
         hsdp_model = self._init_hsdp_model(
@@ -366,6 +390,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             ShardingStrategyMode.ALL_HYBRID_SHARD,
             use_orig_params,
             hsdp_process_groups=hsdp_pgs,
+            device_type=device_type,
         )
         if not (hsdp_model._inter_node_pg.size() > 1):
             raise AssertionError("HSDP model initialized without replication")
@@ -383,19 +408,19 @@ class TestFSDPHybridShard(FSDPTestContinuous):
                 optim.step()
             self.assertEqual(losses[0], losses[1])
 
-    def _init_fsdp_model(self, use_orig_params: bool) -> nn.Module:
+    def _init_fsdp_model(self, use_orig_params: bool, device_type: str) -> nn.Module:
         auto_wrap_policy = ModuleWrapPolicy(
             {TransformerEncoderLayer, TransformerDecoderLayer},
         )
         hsdp_kwargs = {
             "auto_wrap_policy": auto_wrap_policy,
-            "device_id": torch.accelerator.current_device_index(),
+            "device_id": device_type,
             "use_orig_params": use_orig_params,
         }
         fsdp_model = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.RECURSIVE,
-            DEVICEInitMode.DEVICE_BEFORE,
+            DEVICEInitMode.DEVICE_NEVER,
             hsdp_kwargs,
             deterministic=True,
         )
@@ -406,6 +431,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
         hsdp_sharding_strategy: ShardingStrategy,
         sharding_strategy_mode: str,
         use_orig_params: bool,
+        device_type: str,
         hsdp_process_groups: tuple[dist.ProcessGroup, dist.ProcessGroup] | None = None,
         hsdp_device_mesh: Optional = None,
     ):
@@ -417,7 +443,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             {TransformerEncoderLayer, TransformerDecoderLayer},
         )
         hsdp_kwargs = {
-            "device_id": torch.accelerator.current_device_index(),
+            "device_id": device_type,
             "auto_wrap_policy": auto_wrap_policy,
             "sharding_strategy": hsdp_sharding_strategy,
             "use_orig_params": use_orig_params,
@@ -427,7 +453,7 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             hsdp_model = TransformerWithSharedParams.init(
                 hsdp_process_groups or self.process_group,
                 FSDPInitMode.RECURSIVE,
-                DEVICEInitMode.DEVICE_BEFORE,
+                DEVICEInitMode.DEVICE_NEVER,
                 hsdp_kwargs,
                 deterministic=True,
             )
@@ -435,16 +461,16 @@ class TestFSDPHybridShard(FSDPTestContinuous):
             model = TransformerWithSharedParams.init(
                 hsdp_process_groups or self.process_group,
                 FSDPInitMode.NO_FSDP,
-                DEVICEInitMode.DEVICE_BEFORE,
+                DEVICEInitMode.DEVICE_NEVER,
                 {},
                 deterministic=True,
-            )
+            ).to(device_type)
             # Use the HSDP strategy for the transformer module
             model.transformer = FSDP(model.transformer, **hsdp_kwargs)
             # Use `FULL_SHARD` for the embedding and output projection
             hsdp_model = FSDP(
                 model,
-                device_id=torch.accelerator.current_device_index(),
+                device_id=device_type,
                 sharding_strategy=ShardingStrategy.FULL_SHARD,
                 use_orig_params=use_orig_params,
             )
@@ -452,6 +478,8 @@ class TestFSDPHybridShard(FSDPTestContinuous):
 
 
 class TestHSDPSyncModuleStates(FSDPTestMultiThread):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     class _ModelWithBuffer(nn.Module):
         def __init__(self, device):
             super().__init__()
@@ -465,8 +493,9 @@ class TestHSDPSyncModuleStates(FSDPTestMultiThread):
     def world_size(self) -> int:
         return 4
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(1)
-    def test_hsdp_buffer_sync_from_meta_device(self):
+    def test_hsdp_buffer_sync_from_meta_device(self, device):
         """Test that HSDP sync_module_states correctly broadcasts buffers
         when only rank 0 has real weights and other ranks use meta device.
 
@@ -482,6 +511,7 @@ class TestHSDPSyncModuleStates(FSDPTestMultiThread):
         unconditionally included in every sync call. This test specifically
         targets buffers, which are the only tensors gated by FSDP_SYNCED.
         """
+        device_type = torch.device(device).type
         dev = torch.device(device_type)
         mesh_2d = init_device_mesh(device_type, (2, self.world_size // 2))
 
@@ -514,7 +544,18 @@ class TestHSDPSyncModuleStates(FSDPTestMultiThread):
         self.assertEqual(model.bn.running_var, torch.full((10,), 7.0))
 
 
-instantiate_parametrized_tests(TestFSDPHybridShard)
+instantiate_device_type_tests(
+    TestFSDPHybridShard,
+    globals(),
+    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestHSDPSyncModuleStates,
+    globals(),
+    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -39,6 +39,17 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+try:
+    from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+except ImportError:
+    # PyTorch can be built without distributed support (USE_DISTRIBUTED=0),
+    # e.g. standard macOS CI, where torch._C._distributed_c10d is absent and
+    # common_distributed cannot be imported. TestSkipIfLtXGpu is skipped below via
+    # _SKIP_IF_LT_X_GPU_DISTRIBUTED when USE_DISTRIBUTED=0.
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = False
+else:
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = True
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -3143,6 +3154,41 @@ class TestHardwareClassifications(TestCase):
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)
+
+
+@unittest.skipIf(
+    not _SKIP_IF_LT_X_GPU_DISTRIBUTED,
+    "requires a distributed build (USE_DISTRIBUTED=1)",
+)
+class TestSkipIfLtXGpu(TestCase):
+    @unittest.mock.patch("torch.get_device_module")
+    @unittest.mock.patch("torch._C._accelerator_getAccelerator")
+    def test_allow_cpu_with_compile_only_accelerator(
+        self, mock_get_accelerator, mock_get_device_module
+    ):
+        """Regression test: allow_cpu=True must fall back to CPU when PyTorch is
+        compiled with an accelerator but that accelerator is unavailable at runtime.
+
+        Without check_available=True, current_accelerator() returns the compile-time
+        accelerator even if no device is present. In that case acc is not None, but
+        device_module.is_available() is False, so the allow_cpu=True branch that
+        guards the CPU fallback (``acc is None``) is never taken and the test is
+        skipped instead of running on CPU.
+        """
+        mock_device = unittest.mock.MagicMock()
+        mock_device.type = "cuda"
+        mock_get_accelerator.return_value = mock_device
+
+        mock_module = unittest.mock.MagicMock()
+        mock_module.is_available.return_value = False
+        mock_module.device_count.return_value = 0
+        mock_get_device_module.return_value = mock_module
+
+        @skip_if_lt_x_gpu(2, allow_cpu=True)
+        def test_func():
+            return "cpu_fallback"
+
+        self.assertEqual(test_func(), "cpu_fallback")
 
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -300,6 +300,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -308,14 +312,28 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if (
-                torch.accelerator.is_available()
-                and torch.accelerator.device_count() >= x
-            ):
+            # Use check_available=True because current_accelerator() defaults to
+            # compile-time detection. On builds compiled with an accelerator but
+            # with no runtime device available, it would still return that
+            # accelerator, causing allow_cpu=True tests to be skipped instead of
+            # taking the CPU fallback.
+            acc = torch.accelerator.current_accelerator(check_available=True)
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if allow_cpu and not torch.accelerator.is_available():
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-device-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-device-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -73,17 +73,19 @@ if TEST_WITH_ROCM:
 else:
     DEVICE_COUNT = 4
 
-if TEST_CUDA:
-    DEVICE_TYPE = "cuda"
-    DISTRIBUTED_BACKEND = "nccl"
-    DEVICE_COUNT = torch.cuda.device_count()
-elif TEST_HPU:
+if TEST_HPU:
+    # HPU is registered as "fake" in Backend.default_device_backend_map by default.
+    # The real HCCL backend should be registered by torch_hpu; this branch handles
+    # environments where that registration has not occurred.
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
-elif TEST_XPU:
-    DEVICE_TYPE = "xpu"
-    DISTRIBUTED_BACKEND = "xccl"
-    DEVICE_COUNT = torch.xpu.device_count()
+elif torch.accelerator.is_available():
+    acc = torch.accelerator.current_accelerator()
+    DEVICE_TYPE = str(acc)
+    # Use the backend registered for this accelerator type. If no backend is
+    # registered, the accelerator's companion plugin is missing or broken.
+    DISTRIBUTED_BACKEND = dist.Backend.default_device_backend_map[acc.type]
+    DEVICE_COUNT = torch.get_device_module(acc.type).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1245,7 +1247,8 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1591,8 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1639,8 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
I reviewed the code, current diff, review context, and validation results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it. Depends on #187650.
>
> ## Summary
> Make the FSDP hybrid-shard tests use the device supplied by the device-test harness.
>
> ## Changes
> - Classify the hybrid-shard classes as `HardwareClassification.ACCELERATOR`.
> - Pass the harness device through model initialization, HSDP subtests, device meshes, and input creation.
> - Replace module-level current-device lookups with the selected device type.
> - Preserve world-size, hybrid-shard, distributed, and FSDP capability gates.
> - Retain `except_for=("cpu",)` and the reviewed `allow_xpu=True` opt-in.
>
> ## Motivation
> Hybrid sharding is accelerator-generic FSDP behavior with explicit resource requirements. Injecting the device keeps rank-local placement and mesh construction aligned with the harness.
>
> ## Test Plan
> ```bash
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/fsdp/test_fsdp_hybrid_shard.py
> git diff --check
> ```
>
> Results: py_compile and diff check PASS. Lint was not run because `uvx` is unavailable; no accelerator runtime was run for this head, so runtime validation is PARTIAL.
>
> ## Notes
> - Base: `main@ff9d60a3e6a3002b92dd89bd9949c70a82e3688f`.
> - Head: `9f5eacb51048acf44a55fb9e539a48c87d284b29`.
> - Remote view: 2 commits, 4 files, `+151/-41`; the three helper/framework files are inherited ancestry.
> - Topic-level consumer is `test/distributed/fsdp/test_fsdp_hybrid_shard.py`; #191919 capability/OpenReg files are intentionally not included.
>
> ## Checklist
> - [ ] Scoped lint — not run because `uvx` is unavailable.
> - [x] Added/updated tests.
> - [x] Documentation update not applicable; this is internal test classification.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No.