### PR TITLE
[Testcase Refactoring][FSDP] Decouple ignored-module tests from accelerator selection

### DIFF
--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -481,7 +481,7 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
 instantiate_device_type_tests(
     TestFSDPIgnoredModules,
     globals(),
-    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    except_for=("cpu",),
     allow_xpu=True,
 )
 

--- a/test/distributed/fsdp/test_fsdp_ignored_modules.py
+++ b/test/distributed/fsdp/test_fsdp_ignored_modules.py
@@ -10,6 +10,11 @@ import torch.nn as nn
 from torch import distributed as dist
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy, transformer_auto_wrap_policy
+from torch.testing._internal.common_device_type import (
+    Capability,
+    instantiate_device_type_tests,
+    requires_capabilities,
+)
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import (
     DEVICEInitMode,
@@ -18,7 +23,7 @@ from torch.testing._internal.common_fsdp import (
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
-    instantiate_parametrized_tests,
+    HardwareClassification,
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
@@ -35,8 +40,6 @@ if TEST_WITH_DEV_DBG_ASAN:
         file=sys.stderr,
     )
     sys.exit(0)
-
-device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
 
 
 class Model(torch.nn.Module):
@@ -95,11 +98,13 @@ class ModelWithIgnoredModules(Model):
 
 
 class TestFSDPIgnoredModules(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return min(torch.accelerator.device_count(), 2)
 
-    def _train_model(self, model, optim, num_iters, device=torch.device(device_type)):
+    def _train_model(self, model, optim, num_iters, device):
         for _ in range(num_iters):
             module = model.module if isinstance(model, FSDP) else model
             inp = module.get_input(device)
@@ -108,10 +113,12 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
             module.run_backward(loss)
             optim.step()
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_ignored_modules_transformer(self):
+    def test_ignored_modules_transformer(self, device):
         """Tests that ignored modules' parameters are not flattened for a
         transformer model with shared parameters."""
+        device_type = torch.device(device).type
         self.run_subtests(
             {
                 "use_orig_params": [False, True],
@@ -119,6 +126,7 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
                 "use_auto_wrap": [False, True],
             },
             self._test_ignored_modules_transformer,
+            device_type=device_type,
         )
 
     def _test_ignored_modules_transformer(
@@ -126,15 +134,16 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
         use_orig_params: bool,
         ignore_modules: bool,  # as opposed to `ignored_states`
         use_auto_wrap: bool,
+        device_type: str,
     ):
         # Initialize an FSDP-wrapped transformer model that has FSDP ignore
         # the `nn.Transformer` module's parameters
         model: nn.Module = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            DEVICEInitMode.DEVICE_BEFORE,
+            DEVICEInitMode.DEVICE_NEVER,
             deterministic=True,
-        )
+        ).to(device_type)
         fsdp_kwargs = {"process_group": self.process_group}
         if use_auto_wrap:
             # Unshare the output projection weight and embedding weight to be
@@ -152,9 +161,9 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
         nonwrapped_model: nn.Module = TransformerWithSharedParams.init(
             self.process_group,
             FSDPInitMode.NO_FSDP,
-            DEVICEInitMode.DEVICE_BEFORE,
+            DEVICEInitMode.DEVICE_NEVER,
             deterministic=True,
-        )
+        ).to(device_type)
         if use_auto_wrap:
             nonwrapped_model.output_proj.weight = nn.Parameter(
                 nonwrapped_model.output_proj.weight.clone()
@@ -183,21 +192,26 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
         self.assertEqual(fsdp_managed_numel, nonignored_numel)
         # Check that we can run a few iterations
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
-        self._train_model(wrapped_model, optim, 3)
+        self._train_model(wrapped_model, optim, 3, torch.device(device_type))
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_ignored_modules_nested(self):
+    def test_ignored_modules_nested(self, device):
         """Tests that passing a module with nested FSDP modules does not
         error and still ignores non-FSDP modules' parameters."""
+        device_type = torch.device(device).type
         self.run_subtests(
             {
                 "use_orig_params": [False, True],
                 "ignore_modules": [True, False],
             },
             self._test_ignored_modules_nested,
+            device_type=device_type,
         )
 
-    def _test_ignored_modules_nested(self, use_orig_params: bool, ignore_modules: bool):
+    def _test_ignored_modules_nested(
+        self, use_orig_params: bool, ignore_modules: bool, device_type: str
+    ):
         # Initialize an FSDP-wrapped nested model that first wraps the nested
         # sequential's second linear layer (`layer1[1]`) and then wraps the
         # overall model while ignoring the nested sequential (`layer1`)
@@ -233,10 +247,12 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
             self.assertEqual(flat_param_numel, nonignored_numel)
         # Check that we can run a few iterations
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
-        self._train_model(wrapped_model, optim, 3)
+        self._train_model(wrapped_model, optim, 3, torch.device(device_type))
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_ignored_states_auto_wrap(self):
+    def test_ignored_states_auto_wrap(self, device):
+        device_type = torch.device(device).type
         transformer_policy = functools.partial(
             transformer_auto_wrap_policy, transformer_layer_cls={nn.Sequential}
         )
@@ -246,9 +262,12 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
                 "ignore_bias": [True, False],
             },
             self._test_ignored_states_auto_wrap,
+            device_type=device_type,
         )
 
-    def _test_ignored_states_auto_wrap(self, policy, ignore_bias: bool):
+    def _test_ignored_states_auto_wrap(
+        self, policy, ignore_bias: bool, device_type: str
+    ):
         model = Model().to(device_type)
         ignored_states = [model.layer1[1].weight]
         if ignore_bias:
@@ -284,10 +303,12 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
             fsdp_model.module._flat_param.numel(), expected_model_sharded_numel
         )
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_ignored_modules_invalid(self):
+    def test_ignored_modules_invalid(self, device):
         """Tests that passing an FSDP module as an ignored module or the
         top-level module itself errors."""
+        device_type = torch.device(device).type
         model = Model().to(device_type)
         wrap_cls = FSDP
         model.layer1 = wrap_cls(model.layer1)
@@ -308,8 +329,9 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
             new_model = Model().to(device_type)
             wrap_cls(new_model, ignored_modules=[new_model])
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
-    def test_diff_ignored_modules_across_ranks(self):
+    def test_diff_ignored_modules_across_ranks(self, device):
         """
         Tests ignoring different modules across ranks.
 
@@ -320,18 +342,21 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
                 all ignored modules (representing a superset of the children's
                 ignored modules) to the root FSDP instance.
         """
+        device_type = torch.device(device).type
         self.run_subtests(
             {
                 "pass_ignored_modules_to_root": [False, True],
                 "ignore_modules": [True, False],
             },
             self._test_diff_ignored_modules_across_ranks,
+            device_type=device_type,
         )
 
     def _test_diff_ignored_modules_across_ranks(
         self,
         pass_ignored_modules_to_root: bool,
         ignore_modules: bool,
+        device_type: str,
     ):
         # To exercise different `FlatParameter` enumerations across ranks,
         # we wrap `layer3` with FSDP, where `layer3` is registered as a module
@@ -368,11 +393,13 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
         )
         wrapped_model = wrap_cls(model, **ignore_kwargs_top)
         optim = torch.optim.Adam(wrapped_model.parameters(), lr=1e-3)
-        self._train_model(wrapped_model, optim, 3)
+        self._train_model(wrapped_model, optim, 3, torch.device(device_type))
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(2)
     @parametrize("ignore_modules", [True, False])
-    def test_ignored_modules_not_under_wrapped_root(self, ignore_modules: bool):
+    def test_ignored_modules_not_under_wrapped_root(self, device, ignore_modules: bool):
+        device_type = torch.device(device).type
         model = Model().to(device_type)
         ignored_modules = list(model.layer1.children())[1:]
 
@@ -398,20 +425,23 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
         )
 
         optim = torch.optim.Adam(model.parameters(), lr=1e-3)
-        self._train_model(model, optim, 3)
+        self._train_model(model, optim, 3, torch.device(device_type))
 
+    @requires_capabilities(Capability.distributed.backend, Capability.distributed.fsdp)
     @skip_if_lt_x_gpu(1)
-    def test_ignored_states_check(self):
+    def test_ignored_states_check(self, device):
         """
         Tests that passing invalid ``ignored_modules`` or ``ignored_states``
         raises an appropriate error.
         """
+        device_type = torch.device(device).type
         self.run_subtests(
             {"ignore_modules": [True, False]},
             self._test_ignored_states_check,
+            device_type=device_type,
         )
 
-    def _test_ignored_states_check(self, ignore_modules: bool):
+    def _test_ignored_states_check(self, ignore_modules: bool, device_type: str):
         model = Model().to(device_type)
         ignored_modules = list(model.layer1.children())[1:]
         ignored_params = {p for m in ignored_modules for p in m.parameters()}
@@ -448,7 +478,12 @@ class TestFSDPIgnoredModules(FSDPTestContinuous):
                 FSDP(model, ignored_states=ignored_states)
 
 
-instantiate_parametrized_tests(TestFSDPIgnoredModules)
+instantiate_device_type_tests(
+    TestFSDPIgnoredModules,
+    globals(),
+    only_for=("cuda", "hpu", "xpu", "privateuse1"),
+    allow_xpu=True,
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -39,6 +39,17 @@ from torch.testing._internal.opinfo.core import SampleInput, DecorateInfo, OpInf
 import operator
 import string
 
+try:
+    from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
+except ImportError:
+    # PyTorch can be built without distributed support (USE_DISTRIBUTED=0),
+    # e.g. standard macOS CI, where torch._C._distributed_c10d is absent and
+    # common_distributed cannot be imported. TestSkipIfLtXGpu is skipped below via
+    # _SKIP_IF_LT_X_GPU_DISTRIBUTED when USE_DISTRIBUTED=0.
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = False
+else:
+    _SKIP_IF_LT_X_GPU_DISTRIBUTED = True
+
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
     # Ensure that assertEqual handles numpy arrays properly
@@ -3143,6 +3154,41 @@ class TestHardwareClassifications(TestCase):
 
 instantiate_device_type_tests(TestOpInfoSampleFunctions, globals())
 instantiate_parametrized_tests(TestImports)
+
+
+@unittest.skipIf(
+    not _SKIP_IF_LT_X_GPU_DISTRIBUTED,
+    "requires a distributed build (USE_DISTRIBUTED=1)",
+)
+class TestSkipIfLtXGpu(TestCase):
+    @unittest.mock.patch("torch.get_device_module")
+    @unittest.mock.patch("torch._C._accelerator_getAccelerator")
+    def test_allow_cpu_with_compile_only_accelerator(
+        self, mock_get_accelerator, mock_get_device_module
+    ):
+        """Regression test: allow_cpu=True must fall back to CPU when PyTorch is
+        compiled with an accelerator but that accelerator is unavailable at runtime.
+
+        Without check_available=True, current_accelerator() returns the compile-time
+        accelerator even if no device is present. In that case acc is not None, but
+        device_module.is_available() is False, so the allow_cpu=True branch that
+        guards the CPU fallback (``acc is None``) is never taken and the test is
+        skipped instead of running on CPU.
+        """
+        mock_device = unittest.mock.MagicMock()
+        mock_device.type = "cuda"
+        mock_get_accelerator.return_value = mock_device
+
+        mock_module = unittest.mock.MagicMock()
+        mock_module.is_available.return_value = False
+        mock_module.device_count.return_value = 0
+        mock_get_device_module.return_value = mock_module
+
+        @skip_if_lt_x_gpu(2, allow_cpu=True)
+        def test_func():
+            return "cpu_fallback"
+
+        self.assertEqual(test_func(), "cpu_fallback")
 
 
 if __name__ == '__main__':

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -300,6 +300,10 @@ def _maybe_handle_skip_if_lt_x_gpu(args, msg) -> bool:
 def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     """Skip if fewer than x accelerators available.
 
+    NOTE: The naming retains "gpu" for backward compatibility, but the logic
+    is hardware-agnostic and works for any accelerator supported by
+    torch.accelerator (e.g., CUDA, XPU, HPU, and PrivateUse1-based backends).
+
     Args:
         x: Minimum number of accelerators required.
         allow_cpu: If True, run the test on CPU-only machines (no accelerators).
@@ -308,14 +312,28 @@ def skip_if_lt_x_gpu(x, *, allow_cpu=False):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if (
-                torch.accelerator.is_available()
-                and torch.accelerator.device_count() >= x
-            ):
+            # Use check_available=True because current_accelerator() defaults to
+            # compile-time detection. On builds compiled with an accelerator but
+            # with no runtime device available, it would still return that
+            # accelerator, causing allow_cpu=True tests to be skipped instead of
+            # taking the CPU fallback.
+            acc = torch.accelerator.current_accelerator(check_available=True)
+            if acc is not None:
+                device_type = acc.type
+                device_module = torch.get_device_module(device_type)
+                if device_module.device_count() >= x:
+                    return func(*args, **kwargs)
+
+            # CPU path: allow running a degenerate version if explicitly requested
+            if allow_cpu and acc is None:
                 return func(*args, **kwargs)
-            if allow_cpu and not torch.accelerator.is_available():
-                return func(*args, **kwargs)
+
+            # NOTE: TEST_SKIPS uses "multi-device-{x}" naming for historical/
+            # backward-compatibility reasons only. The skip logic itself is
+            # hardware-agnostic and does not assume CUDA/GPU.
             test_skip = TEST_SKIPS[f"multi-device-{x}"]
+            # NOTE: _maybe_handle_skip_if_lt_x_gpu retains "gpu" in its name
+            # for backward compatibility; it is hardware-agnostic.
             if not _maybe_handle_skip_if_lt_x_gpu(args, test_skip.message):
                 sys.exit(test_skip.exit_code)
 

--- a/torch/testing/_internal/common_fsdp.py
+++ b/torch/testing/_internal/common_fsdp.py
@@ -73,17 +73,19 @@ if TEST_WITH_ROCM:
 else:
     DEVICE_COUNT = 4
 
-if TEST_CUDA:
-    DEVICE_TYPE = "cuda"
-    DISTRIBUTED_BACKEND = "nccl"
-    DEVICE_COUNT = torch.cuda.device_count()
-elif TEST_HPU:
+if TEST_HPU:
+    # HPU is registered as "fake" in Backend.default_device_backend_map by default.
+    # The real HCCL backend should be registered by torch_hpu; this branch handles
+    # environments where that registration has not occurred.
     DEVICE_TYPE = "hpu:0"
     DISTRIBUTED_BACKEND = "hccl"
-elif TEST_XPU:
-    DEVICE_TYPE = "xpu"
-    DISTRIBUTED_BACKEND = "xccl"
-    DEVICE_COUNT = torch.xpu.device_count()
+elif torch.accelerator.is_available():
+    acc = torch.accelerator.current_accelerator()
+    DEVICE_TYPE = str(acc)
+    # Use the backend registered for this accelerator type. If no backend is
+    # registered, the accelerator's companion plugin is missing or broken.
+    DISTRIBUTED_BACKEND = dist.Backend.default_device_backend_map[acc.type]
+    DEVICE_COUNT = torch.get_device_module(acc.type).device_count()
 else:
     DEVICE_TYPE = "cpu"
     DISTRIBUTED_BACKEND = "gloo"
@@ -1245,7 +1247,8 @@ class FSDPTestMixin:
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1588,7 +1591,8 @@ class FSDPTest(FSDPTestMixin, MultiProcessTestCase):
 
         device_ids = None
         device_id = self.rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
         device_ids = [device_id]
 
@@ -1635,7 +1639,8 @@ class FSDPTestContinuous(FSDPTestMixin, MultiProcContinuousTest):
             sys.exit(TEST_SKIPS[f"multi-device-{world_size}"].exit_code)
 
         device_id = rank % DEVICE_COUNT
-        if TEST_CUDA or TEST_XPU:
+        # Keep the same semantics as the original `TEST_CUDA or TEST_XPU`
+        if torch.accelerator.is_available() and not TEST_HPU:
             torch.accelerator.set_device_index(device_id)
 
         super()._init_pg(rank, world_size, rdvz_file)


### PR DESCRIPTION
I reviewed the code, current diff, review context, and validation results, and take responsibility for this submission. The title and quoted body were prepared with agent assistance.

> ## Issue
> Part of #185590. This references the tracking issue only and does not close it. Depends on #187650.
>
> ## Summary
> Make the FSDP ignored-module tests use the device supplied by the device-test harness.
>
> ## Changes
> - Classify `TestFSDPIgnoredModules` as `HardwareClassification.ACCELERATOR`.
> - Remove module-level current-device selection.
> - Pass the harness device through model construction, nested subtests, ignored-state checks, and optimizer steps.
> - Preserve ignored-module assertions and distributed/FSDP capability gates.
> - Retain `except_for=("cpu",)` and the reviewed `allow_xpu=True` opt-in.
>
> ## Motivation
> Ignored-module handling is accelerator-generic FSDP behavior. Explicit device injection removes a global assumption and keeps nested model placement on the harness-selected device.
>
> ## Test Plan
> ```bash
> /home/daniel/workspace/pytorch-dev/pytorch/.venv/bin/python -m py_compile test/distributed/fsdp/test_fsdp_ignored_modules.py
> git diff --check
> ```
>
> Results: py_compile and diff check PASS. Lint was not run because `uvx` is unavailable; no accelerator runtime was run for this head, so runtime validation is PARTIAL.
>
> ## Notes
> - Base: `main@ff9d60a3e6a3002b92dd89bd9949c70a82e3688f`.
> - Head: `9f4aaf9507f82f0dc0822128e1b5e12cd7be6031`.
> - Remote view: 2 commits, 4 files, `+145/-41`; the three helper/framework files are inherited ancestry.
> - Topic-level consumer is `test/distributed/fsdp/test_fsdp_ignored_modules.py`; #191919 capability/OpenReg files are intentionally not included.
>
> ## Checklist
> - [ ] Scoped lint — not run because `uvx` is unavailable.
> - [x] Added/updated tests.
> - [x] Documentation update not applicable; this is internal test classification.
> - [x] Benchmark results not applicable; no performance behavior changes.
>
> ## BC-breaking?
> No.