### PR TITLE
[Test] Add hardware classification to test_import_stats.py

### DIFF
--- a/test/test_import_stats.py
+++ b/test/test_import_stats.py
@@ -1,12 +1,18 @@
 # Owner(s): ["module: ci"]
 
-from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    TestCase,
+    run_tests,
+)
 
 
 # these tests could eventually be changed to fail if the import/init
 # time is greater than a certain threshold, but for now we just use them
 # as a way to track the duration of `import torch`.
 class TestImportTime(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_time_import_torch(self):
         TestCase.runWithPytorchAPIUsageStderr("import torch")
 


### PR DESCRIPTION
Mark `TestImportTime` as `GENERIC` since it measures import timing (`import torch` and `torch.accelerator.device_count()`) without requiring any specific device. This ensures the test is included when `--hw-classification` filtering is active in CI rather than being silently dropped as unclassified.

Part of #142029

Test Plan:

```bash
python -m pytest test/test_import_stats.py -v
python -m pytest test/test_import_stats.py --hw-classification GENERIC
```

No test coverage delta — the file has a single class with 2 tests, neither device-parameterized nor instantiated via `instantiate_device_type_tests`. The change only adds the `GENERIC` label so the tests are discoverable under `--hw-classification` filtering; test count and device coverage are unchanged.

```
HW classification mode active (['GENERIC']): total=2, passed=2, unclassified=0, mismatched=0
```

This PR was authored with the assistance of Claude Code.