### PR TITLE
Do not instantiate the size 8 vectorized kernel outside sm_90 and sm_10x

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -38,6 +38,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <c10/core/DynamicCast.h>
 #include <c10/core/ScalarType.h>
+#include <c10/cuda/CUDAArchList.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/TypeCast.h>
 
@@ -215,6 +216,14 @@ __forceinline__ __device__ void vectorized_elementwise_kernel_impl(
   }
 }
 
+// Read by the device #if, the build guard and the runtime check below. The
+// three differ in scope: a +PTX build can pass the last two and still JIT from
+// another arch. Macros because the device guards are #if.
+#define AT_VEC8_SM_LO 90
+#define AT_VEC8_SM_HI 109
+#define AT_VEC8_128B_SM_LO 100
+#define AT_VEC8_128B_SM_HI 109
+
 template <
     int vec_size,
     typename func_t,
@@ -223,7 +232,8 @@ template <
 C10_LAUNCH_BOUNDS_1(num_threads())
 __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
   if constexpr (vec_size == 8 && use_128b_tws) {
-#if __CUDA_ARCH__ / 100 == 10
+#if __CUDA_ARCH__ / 10 >= AT_VEC8_128B_SM_LO && \
+    __CUDA_ARCH__ / 10 <= AT_VEC8_128B_SM_HI
     using output_t = typename function_traits<func_t>::result_type;
     constexpr auto input_size = calc_io_size<func_t>() - sizeof(output_t);
     constexpr auto tws_128b = elems_per_thread_128b<input_size>(sizeof(output_t));
@@ -235,7 +245,7 @@ __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
         "work size supports only sm_10x. Please report an issue on GitHub.");
 #endif
   } else if constexpr (vec_size == 8) {
-#if __CUDA_ARCH__ / 100 == 9 || __CUDA_ARCH__ / 100 == 10
+#if __CUDA_ARCH__ / 10 >= AT_VEC8_SM_LO && __CUDA_ARCH__ / 10 <= AT_VEC8_SM_HI
     constexpr auto io_size = calc_io_size<func_t>();
     constexpr auto tws = elems_per_thread<io_size>();
     vectorized_elementwise_kernel_impl<vec_size, tws>(N, f, data);
@@ -243,7 +253,7 @@ __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
     CUDA_KERNEL_ASSERT(
       false && "Fatal! vectorized_elementwise_kernel<8,...> supports only "
       "sm_90 and sm_10x. Please report an issue on GitHub.");
-#endif // __CUDA_ARCH__ / 100 == 9 || __CUDA_ARCH__ / 100 == 10
+#endif
   } else {
     constexpr auto io_size = calc_io_size<func_t>();
     constexpr auto tws = elems_per_thread<io_size>();
@@ -345,8 +355,12 @@ static inline void launch_vectorized_kernel(
   // (the larger thread work size decreases thread level parallelism,
   // which is important for small footprints).
   constexpr int64_t min_sm107_io_size = 16 * 1024 * 1024;
+  // Not just the device: a build without sm_10x must not take this path either.
+  constexpr bool vec8_128b_supported =
+      c10::cuda::targets_any_arch_in(AT_VEC8_128B_SM_LO, AT_VEC8_128B_SM_HI);
+  const int cc = p->major * 10 + p->minor;
   const bool use_sm107_optimizations =
-      p->major == 10 && p->minor == 7 && N * io_size >= min_sm107_io_size;
+      vec8_128b_supported && cc == 107 && N * io_size >= min_sm107_io_size;
   if (use_sm107_optimizations) {
     using args_t = typename function_traits<func_t>::ArgsTuple;
     constexpr auto max_input_size = at::native::max_of_sizes(
@@ -355,9 +369,12 @@ static inline void launch_vectorized_kernel(
   }
   vec_size = std::min<uint16_t>(vec_size, max_vec_size);
   // due to excessive binary size the `vectorized_elementwise_kernel` of
-  // the size 8 is compiled for sm_90 and sm_10x only.
+  // the size 8 is compiled for sm_90 and sm_10x only, and only when the build
+  // targets one of them.
   // TODO: Lift this limitation when CUDA 12.x support is fully dropped
-  if (p->major != 9 && p->major != 10) {
+  constexpr bool vec_size_8_supported =
+      c10::cuda::targets_any_arch_in(AT_VEC8_SM_LO, AT_VEC8_SM_HI);
+  if (!vec_size_8_supported || cc < AT_VEC8_SM_LO || cc > AT_VEC8_SM_HI) {
     vec_size = std::min<uint16_t>(vec_size, 4);
   }
 #if !defined(CUDA_VERSION) || CUDA_VERSION < 12080
@@ -388,11 +405,18 @@ static inline void launch_vectorized_kernel(
           <<<grid, num_threads(), 0, stream>>>(N, f, data);
 #else
       if (use_sm107_optimizations) {
-        vectorized_elementwise_kernel<8, func_t, array_t, tws_128b >= 8>
-            <<<grid, num_threads(), 0, stream>>>(N, f, data);
-      } else {
+        if constexpr (vec8_128b_supported) {
+          vectorized_elementwise_kernel<8, func_t, array_t, tws_128b >= 8>
+              <<<grid, num_threads(), 0, stream>>>(N, f, data);
+        } else {
+          TORCH_INTERNAL_ASSERT(false, "vec_size 8 reached without an sm_10x target");
+        }
+      } else if constexpr (vec_size_8_supported) {
         vectorized_elementwise_kernel<8, func_t, array_t>
             <<<grid, num_threads(), 0, stream>>>(N, f, data);
+      } else {
+        TORCH_INTERNAL_ASSERT(
+            false, "vec_size 8 reached without an sm_90 or sm_10x target");
       }
 #endif
       C10_CUDA_KERNEL_LAUNCH_CHECK();

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -41,6 +41,7 @@ set(C10_CUDA_SRCS
 )
 set(C10_CUDA_HEADERS
     CUDAAllocatorConfig.h
+    CUDAArchList.h
     CUDACachingAllocator.h
     CUDADeviceAssertionHost.h
     CUDAException.h

--- a/c10/cuda/CUDAArchList.h
+++ b/c10/cuda/CUDAArchList.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+namespace c10::cuda {
+
+// nvcc defines __CUDA_ARCH_LIST__ in the host pass too. It is per translation
+// unit, not per build, and holds virtual architectures, so a +PTX build is not
+// credited with its JIT range.
+constexpr C10_HOST_DEVICE bool targets_any_arch_in(
+    [[maybe_unused]] int sm_lo,
+    [[maybe_unused]] int sm_hi) {
+#ifdef __CUDA_ARCH_LIST__
+  constexpr int archs[] = {__CUDA_ARCH_LIST__};
+  for (int arch : archs) {
+    if (arch / 10 >= sm_lo && arch / 10 <= sm_hi) {
+      return true;
+    }
+  }
+  return false;
+#else
+  return true;
+#endif
+}
+
+} // namespace c10::cuda

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3458,6 +3458,7 @@ C10_MAPPINGS = collections.OrderedDict([
     ("CUDA_LAUNCH_BLOCKING", "AMD_SERIALIZE_KERNEL"),
     ("c10/cuda/CUDAAlgorithm.h", "c10/hip/HIPAlgorithm.h"),
     ("c10/cuda/CUDAAllocatorConfig.h", "c10/hip/HIPAllocatorConfig.h"),
+    ("c10/cuda/CUDAArchList.h", "c10/hip/HIPArchList.h"),
     ("c10/cuda/CUDACachingAllocator.h", "c10/hip/HIPCachingAllocator.h"),
     ("c10/cuda/CUDADeviceAssertion.h", "c10/hip/HIPDeviceAssertion.h"),
     ("c10/cuda/CUDADeviceAssertionHost.h", "c10/hip/HIPDeviceAssertionHost.h"),


### PR DESCRIPTION
`CUDALoops.cuh` says the size 8 `vectorized_elementwise_kernel` "is compiled for
sm_90 and sm_10x only", but the check is on the running device, so it is
instantiated for every architecture the build targets. This makes the
restriction real, via `c10::cuda::targets_any_arch_in` over `__CUDA_ARCH_LIST__`.
The runtime check stays, and the clamp keeps `vec_size` from reaching a case
whose body has gone.

The 128-byte-per-thread variant needs a separate guard: its body is built for
sm_10x alone, so a build targeting only sm_90, running on an sm_10.7 device,
would take that path and trip the assert inside the kernel. Guarding it also
drops that instantiation from every CUDA 12.6 wheel, whose arch lists contain no
sm_10x.

Same failure as the JIT case: an `8.0+PTX` build on an sm_90 device passed
`p->major == 9`, entered the size 8 path, and hit `CUDA_KERNEL_ASSERT` because
the kernel's arch guard was resolved when the PTX was generated. It now falls
back to `vec_size` 4.

The outer sm_90-or-sm_10x guard is true for every shipped arch list, so that
half only fires for narrowed local builds, and what it removes there is a
trap-only shell -- #148320 already stopped the real body from being instantiated
off-target.

`c10/cuda/CUDAArchList.h` is added identically by #194195, so either can land
first. No CUDA locally, so the build is on CI.

Authored with an AI assistant.
