### PR TITLE
[TEST] Refactor test_opaque_obj_v2.py with hw_classification

### DIFF
--- a/test/test_opaque_obj_v2.py
+++ b/test/test_opaque_obj_v2.py
@@ -50,6 +50,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental.symbolic_shapes import ShapeEnv
 from torch.fx.graph import _illegal_char_regex
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_LINUX,
     parametrize,
@@ -445,6 +446,8 @@ class TensorWithCounter(torch.Tensor):
 
 
 class TestOpaqueObject(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         # Must run first: super().setUp() can raise SkipTest (e.g. under
         # PYTORCH_TEST_SKIP_FAST), and unittest skips tearDown when setUp
@@ -3771,49 +3774,6 @@ class GraphModule(torch.nn.Module):
         result = compiled([m, x])
         self.assertEqual(result, (x * 2,))
 
-    @unittest.skipIf(
-        not has_cpp_wrapper_for_device("cpu"),
-        "requires CPU cpp wrapper",
-    )
-    @inductor_config.patch(cpp_wrapper=True)
-    def test_cpp_wrapper_opaque_object_state_input_slot(self):
-        m = OpaqueMultiplier(2.0)
-        x = torch.ones(3)
-        y = torch.arange(3, dtype=torch.float32)
-
-        graph = torch.fx.Graph()
-        fake_mode = FakeTensorMode()
-        x_node = graph.placeholder("x")
-        x_node.meta["val"] = fake_mode.from_tensor(x)
-        m_node = graph.placeholder("m")
-        m_node.meta["val"] = m
-        y_node = graph.placeholder("y")
-        y_node.meta["val"] = fake_mode.from_tensor(y)
-        out = graph.call_function(torch.ops.aten.add.Tensor, (x_node, y_node))
-        out.meta["val"] = fake_mode.from_tensor(x + y)
-        graph.output((out,))
-
-        gm = torch.fx.GraphModule({}, graph)
-        compiled = compile_fx_inner(gm, [x, m, y], cpp_wrapper=True)
-        result = compiled([x, m, y])
-        self.assertEqual(result, (x + y,))
-
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
-    def test_benchmark_harness_no_pickle_for_opaque_inputs(self):
-        """Opaque graph inputs must not be pickled in the benchmark harness."""
-        a = torch.randn(4, 4, device=GPU_TYPE)
-        b = torch.randn(4, 4, device=GPU_TYPE)
-        twc = TensorWithCounter(a, b, Counter(0, 10), SizeStore(4))
-
-        def fn(x):
-            return x + 1
-
-        compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
-        _, codes = run_and_get_code(compiled_fn, twc)
-        self.assertGreater(len(codes), 0)
-        for code in codes:
-            self.assertNotIn("pickle", code)
-
     def test_opaque_object_state_in_graph_output(self):
         """When compile_fx_inner receives a graph where a raw opaque reference
         type appears in the outputs (not just inputs), inductor must handle it.
@@ -4055,8 +4015,61 @@ class GraphModule(torch.nn.Module):
 instantiate_parametrized_tests(TestOpaqueObject)
 
 
+class TestOpaqueObjectCPU(TestCase):
+    hw_classification = HardwareClassification.CPU
+
+    @unittest.skipIf(
+        not has_cpp_wrapper_for_device("cpu"),
+        "requires CPU cpp wrapper",
+    )
+    @inductor_config.patch(cpp_wrapper=True)
+    def test_cpp_wrapper_opaque_object_state_input_slot(self):
+        m = OpaqueMultiplier(2.0)
+        x = torch.ones(3)
+        y = torch.arange(3, dtype=torch.float32)
+
+        graph = torch.fx.Graph()
+        fake_mode = FakeTensorMode()
+        x_node = graph.placeholder("x")
+        x_node.meta["val"] = fake_mode.from_tensor(x)
+        m_node = graph.placeholder("m")
+        m_node.meta["val"] = m
+        y_node = graph.placeholder("y")
+        y_node.meta["val"] = fake_mode.from_tensor(y)
+        out = graph.call_function(torch.ops.aten.add.Tensor, (x_node, y_node))
+        out.meta["val"] = fake_mode.from_tensor(x + y)
+        graph.output((out,))
+
+        gm = torch.fx.GraphModule({}, graph)
+        compiled = compile_fx_inner(gm, [x, m, y], cpp_wrapper=True)
+        result = compiled([x, m, y])
+        self.assertEqual(result, (x + y,))
+
+
+class TestOpaqueObjectCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
+    def test_benchmark_harness_no_pickle_for_opaque_inputs(self):
+        """Opaque graph inputs must not be pickled in the benchmark harness."""
+        a = torch.randn(4, 4, device=GPU_TYPE)
+        b = torch.randn(4, 4, device=GPU_TYPE)
+        twc = TensorWithCounter(a, b, Counter(0, 10), SizeStore(4))
+
+        def fn(x):
+            return x + 1
+
+        compiled_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+        _, codes = run_and_get_code(compiled_fn, twc)
+        self.assertGreater(len(codes), 0)
+        for code in codes:
+            self.assertNotIn("pickle", code)
+
+
 @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
 class TestOpaqueGenerator(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_make_fx_with_generator(self):
         """make_fx should trace through Generator inputs as opaque values."""
         from torch._prims.rng_prims import graphsafe_run_with_rng_state


### PR DESCRIPTION
## Summary

Adds `hw_classification` per the device-agnostic test-classification initiative.

- `TestOpaqueObject` (82 tests) → `GENERIC`. It exercises dynamo/AOTAutograd/Inductor tracing for opaque custom objects entirely through `FakeTensorMode`/CPU tensors, with no device coupling.
- `test_cpp_wrapper_opaque_object_state_input_slot` split into new `TestOpaqueObjectCPU` (`CPU`) — gated on `has_cpp_wrapper_for_device("cpu")`, exercising Inductor's CPU cpp-wrapper codegen path specifically.
- `test_benchmark_harness_no_pickle_for_opaque_inputs` split into new `TestOpaqueObjectCUDA` (`CUDA`) — gated on `HAS_GPU`, allocates on `GPU_TYPE`. Plain class (no `instantiate_device_type_tests`), matching this file's existing `TestOpaqueGenerator` shape.
- `TestOpaqueGenerator` (4 tests, pre-existing CUDA-only Generator/RNG interop) gets `hw_classification = CUDA` added in place — not split or renamed, since it was already 100% CUDA-locked.

## Test plan

```
python test/test_opaque_obj_v2.py -v
Ran 93 tests in 18.707s — OK (skipped=2)

python test/test_opaque_obj_v2.py -v --hw-classification GENERIC
Ran 87 tests — OK (skipped=2)

python test/test_opaque_obj_v2.py -v --hw-classification CPU
Ran 1 test — OK

python test/test_opaque_obj_v2.py -v --hw-classification CUDA
Ran 5 tests — OK
```

> Authored with an AI assistant.