### PR TITLE
[Testcase Refactoring] Add HardwareClassification to distributed_test.py

### DIFF
--- a/test/distributed/elastic/utils/distributed_test.py
+++ b/test/distributed/elastic/utils/distributed_test.py
@@ -20,6 +20,7 @@ from torch.distributed.elastic.utils.distributed import (
     get_socket_with_port,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_MACOS,
     IS_WINDOWS,
     MI200_ARCH,
@@ -51,6 +52,8 @@ if IS_WINDOWS or IS_MACOS:
 
 
 class DistributedUtilTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_create_store_single_server(self):
         store = create_c10d_store(is_server=True, server_addr=socket.gethostname())
         self.assertIsNotNone(store)


### PR DESCRIPTION
## Summary

Tags `DistributedUtilTest` in `test/distributed/elastic/utils/distributed_test.py` with
`hw_classification = HardwareClassification.GENERIC`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in `test/distributed/elastic/utils/distributed_test.py`.
- Added `hw_classification = HardwareClassification.GENERIC` as the first class attribute of `DistributedUtilTest`.

## Context

`DistributedUtilTest` is a plain `TestCase` . `GENERIC` is the
documented category for tests exercising shared, device-agnostic logic that do
not use `instantiate_device_type_tests`, so this class is classified as `GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
  `python test/distributed/elastic/utils/distributed_test.py`.

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.
