### PR TITLE
 Remove unload_xpu_triton_pyds() to fix fatal access violation in Windows+XPU inductor tests

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1676,26 +1676,12 @@ def unload_xpu_triton_pyds() -> None:
         driver_mod = sys.modules["triton.runtime.driver"]
         if hasattr(driver_mod.driver.active, "utils"):
             utils_cls = type(driver_mod.driver.active.utils)
-            if hasattr(utils_cls, "instance"):
-                del utils_cls.instance
-            elif hasattr(utils_cls, "_instance"):
+            if hasattr(utils_cls, "_instance"):
                 utils_cls._instance = None
-            # Note: intentionally NOT `del driver_mod.driver.active.utils`
-            # here. Empirically (see intel/torch-xpu-ops#4950), deleting this
-            # cached instance attribute drops the refcount of the native
-            # spirv_utils "utils" object to zero right here (the class-level
-            # singleton above was just cleared, so this is its last live
-            # reference), which triggers an immediate, synchronous native
-            # deallocation - unloading spirv_utils.pyd - while we may still be
-            # executing Python/native code originating from that very module's
-            # call stack. On Windows this can unmap the DLL out from under a
-            # function it defines (e.g. its own tp_dealloc) while that function
-            # is still on the stack, causing a fatal access violation. Clearing
-            # only the class-level singleton avoids this: the object is left to
-            # be dropped normally (and safely) by refcounting/GC once nothing
-            # else references it, at the cost of not proactively unloading the
-            # DLL here (same trade-off already accepted below via
-            # ignore_errors=is_windows() for files that stay locked).
+            # Do NOT `del driver_mod.driver.active.utils` as it's the last
+            # reference to the native spirv_utils, so deleting it unloads
+            # spirv_utils.pyd synchronously and can crash if native pyd
+            # code from is still on stack (see intel/torch-xpu-ops#4950)
 
     gc.collect()
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1680,7 +1680,22 @@ def unload_xpu_triton_pyds() -> None:
                 del utils_cls.instance
             elif hasattr(utils_cls, "_instance"):
                 utils_cls._instance = None
-            del driver_mod.driver.active.utils
+            # Note: intentionally NOT `del driver_mod.driver.active.utils`
+            # here. Empirically (see intel/torch-xpu-ops#4950), deleting this
+            # cached instance attribute drops the refcount of the native
+            # spirv_utils "utils" object to zero right here (the class-level
+            # singleton above was just cleared, so this is its last live
+            # reference), which triggers an immediate, synchronous native
+            # deallocation - unloading spirv_utils.pyd - while we may still be
+            # executing Python/native code originating from that very module's
+            # call stack. On Windows this can unmap the DLL out from under a
+            # function it defines (e.g. its own tp_dealloc) while that function
+            # is still on the stack, causing a fatal access violation. Clearing
+            # only the class-level singleton avoids this: the object is left to
+            # be dropped normally (and safely) by refcounting/GC once nothing
+            # else references it, at the cost of not proactively unloading the
+            # DLL here (same trade-off already accepted below via
+            # ignore_errors=is_windows() for files that stay locked).
 
     gc.collect()
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1681,7 +1681,7 @@ def unload_xpu_triton_pyds() -> None:
             # Do NOT `del driver_mod.driver.active.utils` as it's the last
             # reference to the native spirv_utils, so deleting it unloads
             # spirv_utils.pyd synchronously and can crash if native pyd
-            # code from is still on stack (see intel/torch-xpu-ops#4950)
+            # code is still on stack (see intel/torch-xpu-ops#4950)
 
     gc.collect()
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1645,47 +1645,6 @@ def get_all_devices(gm: torch.fx.GraphModule) -> OrderedSet[torch.device]:
     return input_devices | out_devices
 
 
-import gc
-
-
-def unload_xpu_triton_pyds() -> None:
-    # unload __triton_launcher.pyd
-    for module_name in list(sys.modules.keys()):
-        if not module_name.startswith("torch._inductor.runtime.compile_tasks."):
-            continue
-        m = sys.modules[module_name]
-        for attr_name in m.__dict__:
-            if attr_name.startswith("triton_"):
-                kernel = getattr(m, attr_name)
-                if isinstance(
-                    kernel, torch._inductor.runtime.triton_heuristics.CachingAutotuner
-                ):
-                    for result in kernel.compile_results:
-                        if isinstance(
-                            result,
-                            torch._inductor.runtime.triton_heuristics.TritonCompileResult,
-                        ):
-                            # pyrefly: ignore [missing-attribute]
-                            run = result.kernel.run
-                            if hasattr(run, "mod"):
-                                run.mod.__del__()
-        del sys.modules[module_name]
-
-    # unload spirv_utils.pyd
-    if "triton.runtime.driver" in sys.modules:
-        driver_mod = sys.modules["triton.runtime.driver"]
-        if hasattr(driver_mod.driver.active, "utils"):
-            utils_cls = type(driver_mod.driver.active.utils)
-            if hasattr(utils_cls, "_instance"):
-                utils_cls._instance = None
-            # Do NOT `del driver_mod.driver.active.utils` as it's the last
-            # reference to the native spirv_utils, so deleting it unloads
-            # spirv_utils.pyd synchronously and can crash if native pyd
-            # code is still on stack (see intel/torch-xpu-ops#4950)
-
-    gc.collect()
-
-
 _registered_caches: list[Any] = []
 
 
@@ -1768,9 +1727,6 @@ def fresh_cache(
                             }
                         )
         if delete:
-            if is_windows() and torch.xpu.is_available():
-                unload_xpu_triton_pyds()
-
             shutil.rmtree(
                 inductor_cache_dir,
                 # Let's not fail if we can't clean up the temp dir. Also note that for


### PR DESCRIPTION
Windows+XPU inductor tests were crashing the test worker with an access violation (0xC0000005) during test teardown, inside fresh_cache()'s call to unload_xpu_triton_pyds(). See intel/torch-xpu-ops#4950.

The function manually dropped the last Python reference to the native spirv_utils "utils" object (`del driver_mod.driver.active.utils`) to force an immediate unload of spirv_utils.pyd. This could happen while native code from that same module was still on the call stack, unmapping the DLL out from under itself and causing the fatal access violation.

This manual unload is no longer needed: #159025 already added ignore_errors=is_windows() to the shutil.rmtree() call in fresh_cache(), so a still-mapped Triton .pyd no longer fails test cleanup. This PR removes unload_xpu_triton_pyds() and its call site entirely, letting the object be released normally by refcounting/GC.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo