### PR TITLE
Do not instantiate rowwise FP8 kernels the build cannot reach

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -1,8 +1,10 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <c10/cuda/CUDAArchList.h>
 #include <c10/macros/Macros.h>
 
 // Two warnings in Cutlass included header files
@@ -96,14 +98,6 @@ struct Schedule</*LargeTile=*/true, /*FastAccum=*/true> {
   using type = cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
   using epilogue_type = cutlass::epilogue::TmaWarpSpecialized;
 };
-
-int ceildiv(int a, int b) {
-  return (a + b - 1) / b;
-}
-
-int round_up_to_nearest_multiple(int a, int b) {
-  return ceildiv(a, b) * b;
-}
 
 // Cutlass rowwise kernel for sm90
 template <
@@ -731,9 +725,10 @@ void dispatch_fp8_rowwise_kernel_on_tile_size(
   // We prefer to use smaller tiles (less wasted compute in case of padding),
   // but if this causes us to have more CUDA blocks than there are SMs on the
   // GPU then we'll hit wave quantization, hence we'll switch to larger tiles.
-  const bool use_smaller_tiles = ceildiv(M, 64 * cute::get<0>(ClusterShape{})) *
-          ceildiv(N, 128 * cute::get<1>(ClusterShape{})) <=
-      smTarget / cute::size(ClusterShape{});
+  const auto [cluster_m, cluster_n, cluster_k] = ClusterShape{};
+  const bool use_smaller_tiles = at::ceil_div<int>(M, 64 * cluster_m) *
+          at::ceil_div<int>(N, 128 * cluster_n) <=
+      smTarget / (cluster_m * cluster_n * cluster_k);
 
   if (use_smaller_tiles) {
     if constexpr (std::is_same_v<ArchTag, cutlass::arch::Sm90>) {
@@ -817,8 +812,8 @@ void dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose(
 
   // All the tiles we use have sizes which are multiples of 64, hence any
   // non-multiple of 64 will get padded anyways. Let's round up to simplify.
-  M = round_up_to_nearest_multiple(M, 64);
-  N = round_up_to_nearest_multiple(N, 64);
+  M = at::round_up(M, 64);
+  N = at::round_up(N, 64);
 
   // Small/skinny shapes with odd multiples of 64.
   if (M == 64 && N >= 3072) {
@@ -960,29 +955,48 @@ void dispatch_fp8_rowwise_kernel_on_sm(
   const bool sm10x = properties != nullptr && properties->major == 10;
   const bool sm11x = properties != nullptr && properties->major == 11;
   const bool sm12x = properties != nullptr && properties->major == 12;
+  constexpr bool built_sm89 = c10::cuda::targets_any_arch_in(89, 89);
+  constexpr bool built_sm9x = c10::cuda::targets_any_arch_in(90, 99);
+  constexpr bool built_sm10x_11x = c10::cuda::targets_any_arch_in(100, 119);
+  constexpr bool built_sm12x = c10::cuda::targets_any_arch_in(120, 129);
   if (!(sm89 || sm9x || sm10x || sm11x || sm12x)) {
     TORCH_CHECK(
         false, "Rowwise scaling is not currently supported on your device");
   }
 
+  // Guard inside the branch, not around it: an arch the build skipped must
+  // fail below, not fall through to another arch's kernel.
   if (sm9x) {
-    dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose<
-      /*ArchTag=*/cutlass::arch::Sm90,
-      Types...>(XQ, WQ, x_scale, w_scale, bias, out);
+    if constexpr (built_sm9x) {
+      return dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose<
+        /*ArchTag=*/cutlass::arch::Sm90,
+        Types...>(XQ, WQ, x_scale, w_scale, bias, out);
+    }
   } else if (sm10x || sm11x) {
-    dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose<
-      /*ArchTag=*/cutlass::arch::Sm100,
-      Types...>(XQ, WQ, x_scale, w_scale, bias, out);
+    if constexpr (built_sm10x_11x) {
+      return dispatch_fp8_rowwise_kernel_on_cluster_size_and_transpose<
+        /*ArchTag=*/cutlass::arch::Sm100,
+        Types...>(XQ, WQ, x_scale, w_scale, bias, out);
+    }
   } else if (sm12x) {
-    // sm12x doesn't have multicast feature
-    handle_transposition<
-      /*ClusterShape=*/cute::Shape<cute::_1, cute::_1, cute::_1>,
-      /*Transposed=*/std::false_type,
-      /*ArchTag=*/cutlass::arch::Sm120,
-      Types...>(XQ, WQ, x_scale, w_scale, bias, out);
-  } else {
-    dispatch_fp8_rowwise_kernel_sm89<Types...>(XQ, WQ, x_scale, w_scale, bias, out);
+    if constexpr (built_sm12x) {
+      // sm12x doesn't have multicast feature
+      return handle_transposition<
+        /*ClusterShape=*/cute::Shape<cute::_1, cute::_1, cute::_1>,
+        /*Transposed=*/std::false_type,
+        /*ArchTag=*/cutlass::arch::Sm120,
+        Types...>(XQ, WQ, x_scale, w_scale, bias, out);
+    }
+  } else if (sm89) {
+    if constexpr (built_sm89) {
+      return dispatch_fp8_rowwise_kernel_sm89<Types...>(XQ, WQ, x_scale, w_scale, bias, out);
+    }
   }
+  TORCH_CHECK(
+      false,
+      "Rowwise scaling was not built for sm",
+      properties->major,
+      properties->minor);
 }
 
 template <typename... Types>

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -41,6 +41,7 @@ set(C10_CUDA_SRCS
 )
 set(C10_CUDA_HEADERS
     CUDAAllocatorConfig.h
+    CUDAArchList.h
     CUDACachingAllocator.h
     CUDADeviceAssertionHost.h
     CUDAException.h

--- a/c10/cuda/CUDAArchList.h
+++ b/c10/cuda/CUDAArchList.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+namespace c10::cuda {
+
+// nvcc defines __CUDA_ARCH_LIST__ in the host pass too. It is per translation
+// unit, not per build, and holds virtual architectures, so a +PTX build is not
+// credited with its JIT range.
+constexpr C10_HOST_DEVICE bool targets_any_arch_in(
+    [[maybe_unused]] int sm_lo,
+    [[maybe_unused]] int sm_hi) {
+#ifdef __CUDA_ARCH_LIST__
+  constexpr int archs[] = {__CUDA_ARCH_LIST__};
+  for (int arch : archs) {
+    if (arch / 10 >= sm_lo && arch / 10 <= sm_hi) {
+      return true;
+    }
+  }
+  return false;
+#else
+  return true;
+#endif
+}
+
+} // namespace c10::cuda

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3458,6 +3458,7 @@ C10_MAPPINGS = collections.OrderedDict([
     ("CUDA_LAUNCH_BLOCKING", "AMD_SERIALIZE_KERNEL"),
     ("c10/cuda/CUDAAlgorithm.h", "c10/hip/HIPAlgorithm.h"),
     ("c10/cuda/CUDAAllocatorConfig.h", "c10/hip/HIPAllocatorConfig.h"),
+    ("c10/cuda/CUDAArchList.h", "c10/hip/HIPArchList.h"),
     ("c10/cuda/CUDACachingAllocator.h", "c10/hip/HIPCachingAllocator.h"),
     ("c10/cuda/CUDADeviceAssertion.h", "c10/hip/HIPDeviceAssertion.h"),
     ("c10/cuda/CUDADeviceAssertionHost.h", "c10/hip/HIPDeviceAssertionHost.h"),


### PR DESCRIPTION
`dispatch_fp8_rowwise_kernel_on_sm` picks between four CUTLASS configurations
from the running device's compute capability, so all four are instantiated
whatever the build targets. The device side already knows better: the kernels are
wrapped in `enable_2x_kernel_for_sm89`, `enable_3x_kernel_for_sm9x` and
`enable_3x_kernel_for_sm10_or_later`, which empty out the body on the wrong
architecture.

Each arm now carries `c10::cuda::targets_any_arch_in` for the range it serves.
The guard is inside the branch, not around it -- wrapping the branch would let an
sm90 device fall through the chain into the sm89 arm. Each guarded arm returns on
success and the chain ends in a `TORCH_CHECK` naming the device.

The ranges follow this file's own arch list, which `cmake/Codegen.cmake:144`
extends beyond the global one: sm89 when the build has sm86, 90a when it has
sm90, 100a and 103f when it has sm100, 120a and 121a when it has sm120. So a CUDA
12.6 wheel, whose list stops at sm90, drops the Sm100 and Sm120 arms; a 13.x
wheel keeps all four. These are full CUTLASS GEMM instantiations, not stubs.

`c10/cuda/CUDAArchList.h` is added identically by #194195 and #194213, so any of
them can land first. No CUDA locally, so the build is on CI.

Authored with an AI assistant.
