### PR TITLE
[Testcase Refactoring] Add HardwareClassification to file_based_local_timer_test.py

### DIFF
--- a/test/distributed/elastic/timer/file_based_local_timer_test.py
+++ b/test/distributed/elastic/timer/file_based_local_timer_test.py
@@ -15,6 +15,7 @@ import uuid
 
 import torch.distributed.elastic.timer as timer
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_MACOS,
     IS_WINDOWS,
@@ -36,6 +37,8 @@ if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
                 time.sleep(0.2)
 
     class FileTimerTest(TestCase):
+        hw_classification = HardwareClassification.GENERIC
+
         def setUp(self):
             super().setUp()
             self.max_interval = 0.01
@@ -196,6 +199,8 @@ if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
             time.sleep(interval)
 
     class FileTimerClientTest(TestCase):
+        hw_classification = HardwareClassification.GENERIC
+
         def test_send_request_without_server(self):
             client = timer.FileTimerClient("test_file")
             timer.configure(client)
@@ -204,6 +209,8 @@ if not (IS_WINDOWS or IS_MACOS or IS_ARM64):
                     time.sleep(0.1)
 
     class FileTimerServerTest(TestCase):
+        hw_classification = HardwareClassification.GENERIC
+
         def setUp(self):
             super().setUp()
             self.file_path = f"/tmp/test_file_path_{os.getpid()}_{uuid.uuid4()}"


### PR DESCRIPTION
## Summary

Tags `FileTimerTest`, `FileTimerClientTest` and `FileTimerServerTest` in `test/distributed/elastic/timer/file_based_local_timer_test.py` with
`hw_classification = HardwareClassification.GENERIC`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in `test/distributed/elastic/timer/file_based_local_timer_test.py`.
- Added `hw_classification = HardwareClassification.GENERIC` as the first class attribute of `FileTimerTest`, `FileTimerClientTest` and `FileTimerServerTest`.

## Context

`FileTimerTest`, `FileTimerClientTest` and `FileTimerServerTest` are plain `TestCase` . `GENERIC` is the
documented category for tests exercising shared, device-agnostic logic that do
not use `instantiate_device_type_tests`, so these classes are classified as `GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
  `python test/distributed/elastic/timer/file_based_local_timer_test.py`.

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.
