### PR TITLE
[Testcase Refactoring] Add HardwareClassification to local_timer_test.py

### DIFF
--- a/test/distributed/elastic/timer/local_timer_test.py
+++ b/test/distributed/elastic/timer/local_timer_test.py
@@ -15,6 +15,7 @@ import torch.distributed.elastic.timer as timer
 from torch.distributed.elastic.timer.api import TimerRequest
 from torch.distributed.elastic.timer.local_timer import MultiprocessingRequestQueue
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_ARM64,
     IS_MACOS,
     IS_WINDOWS,
@@ -39,6 +40,8 @@ if not INVALID_PLATFORMS:
                 time.sleep(0.2)
 
     class LocalTimerTest(TestCase):
+        hw_classification = HardwareClassification.GENERIC
+
         def setUp(self):
             super().setUp()
             self.ctx = mp.get_context("spawn")
@@ -135,6 +138,8 @@ if not INVALID_PLATFORMS:
 if not INVALID_PLATFORMS:
 
     class MultiprocessingRequestQueueTest(TestCase):
+        hw_classification = HardwareClassification.GENERIC
+
         def test_get(self):
             mp_queue = mp.Queue()
             request_queue = MultiprocessingRequestQueue(mp_queue)
@@ -202,6 +207,8 @@ if not INVALID_PLATFORMS:
 if not INVALID_PLATFORMS:
 
     class LocalTimerServerTest(TestCase):
+        hw_classification = HardwareClassification.GENERIC
+
         def setUp(self):
             super().setUp()
             self.mp_queue = mp.Queue()


### PR DESCRIPTION
## Summary

Tags `LocalTimerTest`, `MultiprocessingRequestQueueTest` and `LocalTimerServerTest` in `test/distributed/elastic/timer/local_timer_test.py` with
`hw_classification = HardwareClassification.GENERIC`, opting the class into the
hardware-classification test selection introduced by `--hw-classification`.

## Changes

- Added `HardwareClassification` import in `test/distributed/elastic/timer/local_timer_test.py`.
- Added `hw_classification = HardwareClassification.GENERIC` as the first class attribute of `LocalTimerTest`, `MultiprocessingRequestQueueTest` and `LocalTimerServerTest`.

## Context

`LocalTimerTest`, `MultiprocessingRequestQueueTest` and `LocalTimerServerTest` are plain `TestCase` . `GENERIC` is the
documented category for tests exercising shared, device-agnostic logic that do
not use `instantiate_device_type_tests`, so these classes are classified as `GENERIC`.

When `--hw-classification` is not passed, test discovery and execution are
unchanged; the tag only takes effect when the selection flag is used.

## Test plan

- Run the test file:
  `python test/distributed/elastic/timer/local_timer_test.py`.

## Notes

- This is part of the test case refactoring initiative tracked in https://github.com/pytorch/pytorch/issues/185590.