### PR TITLE
Fix fast gradcheck when non-differentiable outputs precede differentiable ones

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -6845,6 +6845,13 @@ Done""",
         check(fast_mode=True)
         check(fast_mode=False)
 
+    def test_gradcheck_mixed_differentiable_outputs(self):
+        def fn(x):
+            return torch.ones_like(x), x.square()
+
+        x = torch.randn(2, dtype=torch.double, requires_grad=True)
+        self.assertTrue(gradcheck(fn, (x,), fast_mode=True))
+
     @parametrize(
         "layout",
         (

--- a/test/test_ops_gradients.py
+++ b/test/test_ops_gradients.py
@@ -120,7 +120,6 @@ class TestBwdGradients(TestGradients):
             skip("nn.functional.max_unpool1d"),
             skip("nn.functional.max_unpool2d"),
             skip("nn.functional.max_unpool3d"),
-            xfail("cat"),
             xfail("nn.functional.ctc_loss", dtypes=(torch.float64,)),
             xfail("nn.functional.linear_cross_entropy", variant_name="chunked_none"),
             xfail("nn.functional.linear_cross_entropy", variant_name="chunked"),

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -695,7 +695,7 @@ def _get_numerical_vJu(
         all_Ju = _get_numerical_jvp_wrt_specific_input(
             fn, inp_idx, inputs, u, eps, is_forward_ad
         )
-        # Filter out the Ju for non floating point outputs
+        # Keep numerical JVPs aligned with outputs checked by the analytical path.
         filtered_Ju = []
         func_out = _as_tuple(func_out)
         if len(all_Ju) != len(func_out):
@@ -704,11 +704,11 @@ def _get_numerical_vJu(
                 f"but got {len(all_Ju)} and {len(func_out)}"
             )
         for Ju, output in zip(all_Ju, func_out):
-            if _is_float_or_complex_tensor(output):
-                filtered_Ju.append(Ju)
-            else:
+            if not _is_float_or_complex_tensor(output):
                 # TODO: handle the other Ju
-                pass
+                continue
+            if is_forward_ad or output.requires_grad:
+                filtered_Ju.append(Ju)
         if all_v is not None:
             jacobian_scalars: list[torch.Tensor] = []
             for v, Ju in zip(all_v, filtered_Ju):
@@ -1950,7 +1950,6 @@ def _fast_gradcheck(
         eps,
         is_forward_ad=use_forward_ad,
     )
-    # TODO: replicate https://github.com/pytorch/pytorch/pull/77743 for fast gradcheck as well
     if use_forward_ad:
         if all_v is not None:
             raise AssertionError("Expected all_v to be None.")


### PR DESCRIPTION
# Fixing an Issue

## Issue

Fixes #77230

## Summary

Fast backward-mode gradcheck creates projection vectors only for differentiable outputs, while the numerical path retained all floating-point and complex outputs. When a non-differentiable output came first, this could pair a projection vector with the numerical JVP of a different output.

This change skips non-differentiable numerical outputs in backward mode, keeping the numerical and analytical paths aligned without changing forward AD behavior. A regression test covers this output ordering.

The original `torch.linalg.slogdet` example no longer reproduces the issue on current main because both outputs now require gradients. `torch.linalg.lu` still reproduces the same underlying problem and passes with this change.

## Test plan

- Targeted `test/test_autograd.py -k gradcheck` against the patched source: 32 passed, 2 skipped
- `TestBwdGradientsCPU` cat gradgrad checks for `float64` and `complex128`: passed
- `torch.linalg.lu` fast gradcheck with backward and forward AD checks: passed
- `python -m spin quicklint`
- `git diff --check`

## Checklist

- [x] Passes lint (`spin quicklint`)
- [x] Added/updated tests
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable)

## BC-breaking?

No.

## AI assistance

I used Codex to help investigate the issue, reproduce it, and validate the change.
