### PR TITLE
Do not instantiate grouped GEMM kernels the build cannot reach

### DIFF
--- a/aten/src/ATen/native/cuda/GroupMM.cu
+++ b/aten/src/ATen/native/cuda/GroupMM.cu
@@ -1,8 +1,10 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
+#include <ATen/ceil_div.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
+#include <c10/cuda/CUDAArchList.h>
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/macros/Macros.h>
 #include <c10/util/irange.h>
@@ -72,14 +74,6 @@ struct Schedule {
     cute::conditional_t<PONGOr2SM, PongEpilogueSchedule, CooperativeEpilogueSchedule>>;
 
 };
-
-int ceildiv(int a, int b) {
-  return (a + b - 1) / b;
-}
-
-int round_up_to_nearest_multiple(int a, int b) {
-  return ceildiv(a, b) * b;
-}
 
 template <
     typename ArchTag,
@@ -206,7 +200,7 @@ void bf16bf16_grouped_gemm_impl_sm90_sm100(
   // due to bug in cuda < 12.4 the pointers have to be aligned to 128 bits
   const int group_alignment = 16 / sizeof(void*);
   const int aligned_group_count =
-      round_up_to_nearest_multiple(group_count, group_alignment);
+      at::round_up(group_count, group_alignment);
   int64_t input_args_size = aligned_group_count * 3 * sizeof(void*) +
       problem_shape_size + stride_size;
 
@@ -344,21 +338,28 @@ void dispatch_bf16_grouped_kernel_on_tile_size(
   //        (K >= 2048 && N >= 2048));
   bool small = (M <= 128 || N <= 128);
   cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
-  const bool sm10x = properties != nullptr && properties->major == 10;
-  const bool sm11x = properties != nullptr && properties->major == 11;
+  TORCH_CHECK(properties != nullptr, "Failed to query device properties");
+  const bool sm9x = properties->major == 9;
+  const bool sm10x = properties->major == 10;
+  const bool sm11x = properties->major == 11;
+  constexpr bool built_sm9x = c10::cuda::targets_any_arch_in(90, 99);
+  constexpr bool built_sm10x_11x = c10::cuda::targets_any_arch_in(100, 119);
 
+  // Guard inside the branch, not around it: an arch the build skipped must
+  // fail below, not fall through to another arch's kernel.
   if (sm10x || sm11x) {
-    if (small){
-      bf16bf16_grouped_gemm_impl_sm90_sm100<
-        cutlass::arch::Sm100,
-        a_row_major,
-        b_row_major,
-        /*PONGOr2SM*/ false,
-        cute::_128,
-        cute::_256,
-        cute::_64>(mat_a, mat_b, offs, bias, out); // Tile shape taken from CUTLASS examples, 64 = 128/sizeof(bfloat16)
-    } else {
-      bf16bf16_grouped_gemm_impl_sm90_sm100<
+    if constexpr (built_sm10x_11x) {
+      if (small) {
+        return bf16bf16_grouped_gemm_impl_sm90_sm100<
+          cutlass::arch::Sm100,
+          a_row_major,
+          b_row_major,
+          /*PONGOr2SM*/ false,
+          cute::_128,
+          cute::_256,
+          cute::_64>(mat_a, mat_b, offs, bias, out); // Tile shape taken from CUTLASS examples, 64 = 128/sizeof(bfloat16)
+      }
+      return bf16bf16_grouped_gemm_impl_sm90_sm100<
         cutlass::arch::Sm100,
         a_row_major,
         b_row_major,
@@ -367,18 +368,19 @@ void dispatch_bf16_grouped_kernel_on_tile_size(
         cute::_256,
         cute::_64>(mat_a, mat_b, offs, bias, out); // Same as above ^
     }
-  } else {
-    if(small) {
-      bf16bf16_grouped_gemm_impl_sm90_sm100<
-        cutlass::arch::Sm90,
-        a_row_major,
-        b_row_major,
-        /*PONGOr2SM*/ true,
-        cute::_64,
-        cute::_128,
-        cute::_128>(mat_a, mat_b, offs, bias, out);
-    } else {
-      bf16bf16_grouped_gemm_impl_sm90_sm100<
+  } else if (sm9x) {
+    if constexpr (built_sm9x) {
+      if (small) {
+        return bf16bf16_grouped_gemm_impl_sm90_sm100<
+          cutlass::arch::Sm90,
+          a_row_major,
+          b_row_major,
+          /*PONGOr2SM*/ true,
+          cute::_64,
+          cute::_128,
+          cute::_128>(mat_a, mat_b, offs, bias, out);
+      }
+      return bf16bf16_grouped_gemm_impl_sm90_sm100<
         cutlass::arch::Sm90,
         a_row_major,
         b_row_major,
@@ -388,6 +390,11 @@ void dispatch_bf16_grouped_kernel_on_tile_size(
         cute::_64>(mat_a, mat_b, offs, bias, out);
     }
   }
+  TORCH_CHECK(
+      false,
+      "Grouped GEMM was not built for sm",
+      properties->major,
+      properties->minor);
 }
 
 void dispatch_bf16_grouped_kernel_on_ab_transpose(

--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -41,6 +41,7 @@ set(C10_CUDA_SRCS
 )
 set(C10_CUDA_HEADERS
     CUDAAllocatorConfig.h
+    CUDAArchList.h
     CUDACachingAllocator.h
     CUDADeviceAssertionHost.h
     CUDAException.h

--- a/c10/cuda/CUDAArchList.h
+++ b/c10/cuda/CUDAArchList.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <c10/macros/Macros.h>
+
+namespace c10::cuda {
+
+// nvcc defines __CUDA_ARCH_LIST__ in the host pass too. It is per translation
+// unit, not per build, and holds virtual architectures, so a +PTX build is not
+// credited with its JIT range.
+constexpr C10_HOST_DEVICE bool targets_any_arch_in(
+    [[maybe_unused]] int sm_lo,
+    [[maybe_unused]] int sm_hi) {
+#ifdef __CUDA_ARCH_LIST__
+  constexpr int archs[] = {__CUDA_ARCH_LIST__};
+  for (int arch : archs) {
+    if (arch / 10 >= sm_lo && arch / 10 <= sm_hi) {
+      return true;
+    }
+  }
+  return false;
+#else
+  return true;
+#endif
+}
+
+} // namespace c10::cuda

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3458,6 +3458,7 @@ C10_MAPPINGS = collections.OrderedDict([
     ("CUDA_LAUNCH_BLOCKING", "AMD_SERIALIZE_KERNEL"),
     ("c10/cuda/CUDAAlgorithm.h", "c10/hip/HIPAlgorithm.h"),
     ("c10/cuda/CUDAAllocatorConfig.h", "c10/hip/HIPAllocatorConfig.h"),
+    ("c10/cuda/CUDAArchList.h", "c10/hip/HIPArchList.h"),
     ("c10/cuda/CUDACachingAllocator.h", "c10/hip/HIPCachingAllocator.h"),
     ("c10/cuda/CUDADeviceAssertion.h", "c10/hip/HIPDeviceAssertion.h"),
     ("c10/cuda/CUDADeviceAssertionHost.h", "c10/hip/HIPDeviceAssertionHost.h"),


### PR DESCRIPTION
`dispatch_bf16_grouped_kernel_on_tile_size` picks between the Sm90 and Sm100
CUTLASS configurations from the running device's compute capability, so both are
instantiated whatever the build targets. The device side already knows better:
`GemmKernel` is wrapped in `enable_3x_kernel_for_sm10` or
`enable_3x_kernel_for_sm9x` depending on `ArchTag`, which empties the body on the
wrong architecture.

Guard each arm with `c10::cuda::targets_any_arch_in` on the range the arm serves.
The guard goes inside the branch, not around it, so a device never falls through
into the other arm's kernel. `cmake/Codegen.cmake:150` gives this file 90a, 100a,
103f and 110a on top of the global list, each conditional on the base
architecture already being there, so a build without sm90 drops the Sm90 arm and
one without sm100 drops the Sm100 arm.

The Sm90 arm was a bare `else`, so an sm80 or sm120 device reached the sm90
kernel and failed at launch with "no kernel image is available". It now tests
`sm9x` and the chain ends in a `TORCH_CHECK` naming the device.
`GroupedBlas.cpp:764` routes only major 9 and 10 here today, so this is a better
message rather than a behaviour change.

The local `ceildiv` and `round_up_to_nearest_multiple` were reached only from the
guarded arms, so a build for sm_86 alone would have left them unreferenced and
failed `-Werror`. They duplicated `at::ceil_div` and `at::round_up`, so use
those.

`c10/cuda/CUDAArchList.h` is added identically by #194195, #194213 and #194218,
so any of them can land first. No CUDA locally, so the build is on CI.

Authored with an AI assistant.
