### PR TITLE
Enable the grouped GEMM fast path on sm11x

### DIFF
--- a/aten/src/ATen/native/cuda/GroupedBlas.cpp
+++ b/aten/src/ATen/native/cuda/GroupedBlas.cpp
@@ -761,7 +761,10 @@ std::optional<c10::ScalarType> out_dtype) {
     out_dtype.value_or(at::kBFloat16) == at::kBFloat16
   );
 #ifndef USE_ROCM
-  bool use_fast_path = scaled_mm_arch_allowed(/*sm90_only=*/true, /*sm100_only=*/true) && a_b_and_out_are_bf16;
+  // GroupMM.cu dispatches sm9x and sm10x/sm11x; scaled_mm_arch_allowed cannot
+  // express sm11x, and this op is not scaled anyway.
+  const auto dprops = at::cuda::getCurrentDeviceProperties();
+  bool use_fast_path = dprops->major >= 9 && dprops->major <= 11 && a_b_and_out_are_bf16;
   const auto out_dtype_ = _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
   Tensor out = create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
   if (use_fast_path) {


### PR DESCRIPTION
#164836 added an sm11x arm to `dispatch_bf16_grouped_kernel_on_tile_size` and
gave `GroupMM.cu` a 110a gencode, but left the host-side gate alone, so the arm
has never been reachable. `_grouped_mm_cuda` admits a device through
`scaled_mm_arch_allowed(sm90_only, sm100_only)`, which is `major == 9 || major ==
10` and has no way to spell sm11x, so a Thor device falls back to the mm/bmm loop
and pays a d2h sync while the kernel built for it is never launched. Test the
major range directly instead, matching `should_use_cublaslt_grouped_gemm` in the
same file.

The other route, `should_use_cublaslt_grouped_gemm`, does admit major 9 to 11,
but it needs CUDA 13.3 and for bf16 an opt-in that defaults to false, so it does
not cover this.

The other two `scaled_mm_arch_allowed(true, true)` call sites are left alone:
they guard the scaled grouped GEMMs, whose kernels are Sm90 only.

No sm11x device to test on, so correctness here rests on #164836 having got the
kernel right; CI covers that nothing on sm9x/sm10x changes.

Related: #194226 guards the same dispatch by build arch, so a build without 100a
or 110a gives a clear error here instead of "no kernel image is available".

Authored with an AI assistant.
