### PR TITLE
[DTensor] Propagate grad dtype through redistribute

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -39,6 +39,7 @@ from torch.distributed.tensor._redistribute import (
     _redistribute_cost_sort_key,
     _TransformInfo,
     disable_redistribute_transform_optimization,
+    NestedRedistribute,
     redistribute_local_tensor,
     use_min_cost_redistribution_plan,
 )
@@ -3239,8 +3240,7 @@ class _CollectiveDtypeTracer(torch.utils._python_dispatch.TorchDispatchMode):
 
 
 class RedistributeBackwardDtypeTest(TestCase):
-    """Verify ``DTensor.redistribute(..., backward_dtype=...)`` actually runs the
-    backward collective at the requested dtype.
+    """Verify the backward dtype semantics of ``DTensor.redistribute``.
 
     A fake process group lets us run this single-process; a TorchDispatchMode
     tracer captures the dtype of each ``_c10d_functional`` collective.
@@ -3299,6 +3299,99 @@ class RedistributeBackwardDtypeTest(TestCase):
         self.assertEqual(tracer.dtypes_for("all_gather_into_tensor"), [torch.bfloat16])
         self.assertEqual(tracer.dtypes_for("reduce_scatter_tensor"), [torch.float32])
         self.assertEqual(local.grad.dtype, torch.float32)
+
+    @parametrize("backward_dtype", [torch.bfloat16, torch.float32])
+    def test_grad_dtype_propagates_independently_of_backward_dtype(
+        self, backward_dtype
+    ):
+        mesh = init_device_mesh("cpu", (4,), mesh_dim_names=("dp",))
+        dt = DTensor.from_local(
+            torch.randn(16, 8, dtype=torch.bfloat16), mesh, [Shard(0)]
+        ).requires_grad_()
+        dt.grad_dtype = torch.float32
+
+        tracer = _CollectiveDtypeTracer()
+        with tracer:
+            out = dt.redistribute(
+                mesh,
+                [Replicate()],
+                forward_dtype=torch.bfloat16,
+                backward_dtype=backward_dtype,
+            )
+            self.assertEqual(out.grad_dtype, torch.float32)
+            grad_d = DTensor.from_local(
+                torch.ones(64, 8, dtype=torch.float32), mesh, [Partial()]
+            )
+            out.backward(grad_d)
+
+        self.assertEqual(tracer.dtypes_for("reduce_scatter_tensor"), [backward_dtype])
+        self.assertEqual(dt.grad.dtype, torch.float32)
+
+    def test_backward_output_uses_input_grad_dtype(self):
+        mesh = init_device_mesh("cpu", (4,), mesh_dim_names=("dp",))
+        dt = DTensor.from_local(
+            torch.randn(16, 8, dtype=torch.bfloat16), mesh, [Replicate()]
+        ).requires_grad_()
+        dt.grad_dtype = torch.float32
+
+        out = dt.redistribute(
+            mesh,
+            [Replicate()],
+            forward_dtype=torch.bfloat16,
+            backward_dtype=torch.float32,
+        )
+        local_grad = torch.full((16, 8), 1.0001, dtype=torch.float32)
+        out.backward(DTensor.from_local(local_grad, mesh, [Replicate()]))
+
+        self.assertEqual(dt.grad.to_local(), local_grad)
+
+    def test_none_grad_dtype_does_not_force_backward_output_dtype(self):
+        mesh = init_device_mesh("cpu", (4,), mesh_dim_names=("dp",))
+        dt = DTensor.from_local(
+            torch.randn(16, 8, dtype=torch.bfloat16), mesh, [Shard(0)]
+        ).requires_grad_()
+        dt.grad_dtype = None
+
+        out = dt.redistribute(
+            mesh,
+            [Replicate()],
+            forward_dtype=torch.bfloat16,
+            backward_dtype=torch.float32,
+        )
+        self.assertIsNone(out.grad_dtype)
+        grad_d = DTensor.from_local(
+            torch.ones(64, 8, dtype=torch.float64), mesh, [Partial()]
+        )
+        out.backward(grad_d)
+
+        self.assertEqual(dt.grad.dtype, torch.float32)
+
+    def test_nested_redistribute_propagates_its_input_grad_dtype(self):
+        mesh = init_device_mesh("cpu", (4,), mesh_dim_names=("dp",))
+        grad_output = DTensor.from_local(
+            torch.randn(16, 8, dtype=torch.float32), mesh, [Replicate()]
+        ).requires_grad_()
+        grad_output.grad_dtype = torch.float64
+
+        output = NestedRedistribute.apply(
+            grad_output,
+            grad_output._spec,
+            False,
+            torch.float32,
+            torch.float32,
+        )
+        self.assertEqual(output.dtype, torch.float32)
+        self.assertEqual(output.grad_dtype, torch.float64)
+
+        grad2_output = DTensor.from_local(
+            torch.ones(16, 8, dtype=torch.float64), mesh, [Replicate()]
+        )
+        output.backward(grad2_output)
+
+        self.assertEqual(grad_output.grad.dtype, torch.float64)
+
+
+instantiate_parametrized_tests(RedistributeBackwardDtypeTest)
 
 
 if __name__ == "__main__":

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -760,10 +760,10 @@ class DTensor(torch.Tensor):
                 no conversion is performed. Default: None
             backward_dtype (torch.dtype, optional): cast the gradient to
                 ``backward_dtype`` before running the backward collective.
-                After the collective the gradient is always cast back to the
-                input DTensor's dtype. If ``None``, the backward collective
-                runs at the input DTensor's dtype (not ``forward_dtype``).
-                Default: None
+                After the collective the gradient is cast to the input
+                DTensor's ``grad_dtype`` when it is not ``None``. If
+                ``backward_dtype`` is ``None``, the backward collective runs at
+                the input DTensor's dtype (not ``forward_dtype``). Default: None
 
         Returns:
             A :class:`DTensor` object
@@ -808,6 +808,7 @@ class DTensor(torch.Tensor):
         placements = tuple(placements)
 
         input_dtype = self._local_tensor.dtype
+        input_grad_dtype = self.grad_dtype if self.requires_grad else input_dtype
         forward_dtype = forward_dtype or input_dtype
         # pyre-fixme[16]: `Redistribute` has no attribute `apply`.
         return Redistribute.apply(
@@ -822,7 +823,7 @@ class DTensor(torch.Tensor):
                     # Absent backward_dtype means the backward collective runs
                     # at the input's storage dtype (matching pre-fix behavior).
                     "op_dtype": backward_dtype or input_dtype,
-                    "out_dtype": input_dtype,
+                    "out_dtype": input_grad_dtype,
                 },
             },
         )

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -1847,7 +1847,7 @@ def _redistribute_backward(
     grad_output: "dtensor.DTensor",
     previous_spec: DTensorSpec,
     *,
-    out_dtype: torch.dtype,
+    out_dtype: torch.dtype | None,
     op_dtype: torch.dtype,
     async_op: bool = False,
 ):
@@ -1859,7 +1859,8 @@ def _redistribute_backward(
         grad_output: The output gradient tensor.
         previous_spec: DTensorSpec prior to redistribution.
         out_dtype: dtype to cast the returned gradient to. Pinned by autograd
-                to match the dtype of the input of the node above this one.
+                to match the grad dtype of the input of the node above this
+                one. If None, the returned gradient is not cast.
         op_dtype: dtype to run the backward collective at.
         async_op: whether to perform the DTensor redistribute operation
                 asynchronously or not. Default: False
@@ -1921,7 +1922,7 @@ def _redistribute_backward(
         async_op=async_op,
     )
 
-    if output.dtype != out_dtype:
+    if out_dtype is not None and output.dtype != out_dtype:
         output = output.to(out_dtype)
 
     spec = DTensorSpec(
@@ -1939,7 +1940,7 @@ def _redistribute_backward(
 
 class _BackwardDtypeConfig(TypedDict):
     op_dtype: torch.dtype  # dtype the backward collective runs at
-    out_dtype: torch.dtype  # dtype the returned gradient is cast to
+    out_dtype: torch.dtype | None  # dtype the returned gradient is cast to
 
 
 class _DtypeConfig(TypedDict):
@@ -1963,6 +1964,8 @@ class Redistribute(torch.autograd.Function):
         bwd = dtype_config["backward_options"]
         ctx.bwd_op_dtype = bwd["op_dtype"]
         ctx.bwd_out_dtype = bwd["out_dtype"]
+        if input.requires_grad:
+            ctx.set_output_grad_dtype(ctx.bwd_out_dtype)
 
         op_dtype = dtype_config["op_dtype"]
         out_dtype = dtype_config["out_dtype"]
@@ -2061,12 +2064,16 @@ class NestedRedistribute(torch.autograd.Function):
         previous_spec: DTensorSpec,
         async_op: bool,
         op_dtype: torch.dtype,
-        out_dtype: torch.dtype,
+        out_dtype: torch.dtype | None,
     ):
         # Persist op_dtype so the double-backward reuses the same collective
         # dtype one level down.
         ctx.async_op = async_op
-        ctx.original_dtype = grad_output._local_tensor.dtype
+        ctx.input_grad_dtype = (
+            grad_output.grad_dtype
+            if grad_output.requires_grad
+            else grad_output._local_tensor.dtype
+        )
         ctx.op_dtype = op_dtype
 
         output, spec = _redistribute_backward(
@@ -2080,26 +2087,28 @@ class NestedRedistribute(torch.autograd.Function):
         ctx.current_spec = spec
 
         # pyrefly: ignore [bad-argument-type]
-        return dtensor.DTensor(
+        output_dtensor = dtensor.DTensor(
             # pyrefly: ignore [bad-argument-count]
             output,
             spec,
             # pyrefly: ignore [unexpected-keyword]
             requires_grad=grad_output.requires_grad,
         )
+        if grad_output.requires_grad:
+            ctx.set_output_grad_dtype(ctx.input_grad_dtype)
+        return output_dtensor
 
     @staticmethod
     def backward(ctx, grad2_output: "dtensor.DTensor"):  # type: ignore[override]
         previous_spec = ctx.current_spec
-        # Reuse the same op_dtype one level down; pin out_dtype to the dtype
-        # of the grad we received at this level, since that's what the node
-        # above us expects back.
+        # Reuse the same op_dtype one level down. The returned gradient must
+        # follow this Function's input grad dtype.
         output_dtensor = NestedRedistribute.apply(
             grad2_output,
             previous_spec,
             ctx.async_op,
             ctx.op_dtype,
-            ctx.original_dtype,
+            ctx.input_grad_dtype,
         )
 
         return (


### PR DESCRIPTION
## Summary

This PR builds on the grad dtype APIs introduced under #189633 and propagates the input DTensor's `grad_dtype` through `redistribute`.

In particular, this PR:

- declares the expected output gradient dtype of `Redistribute` with `ctx.set_output_grad_dtype(...)`;
- keeps `backward_dtype` responsible only for the dtype used by the backward collective;
- casts the result of the backward collective to the input DTensor's `grad_dtype` instead of its storage dtype; and
- applies the same contract recursively in `NestedRedistribute` for higher-order autograd.

When the input `grad_dtype` is `None`, the returned gradient remains unconstrained and no final dtype cast is forced. The default behavior is unchanged because a DTensor's `grad_dtype` defaults to its storage dtype.

## Motivation

SimpleFSDP mixed-precision execution propagates the parameter gradient dtype through the parameter materialization path:

```text
param -> redistribute -> to_local -> computation
```

Previously, `redistribute` always cast the gradient returned by its backward to the input DTensor's storage dtype. This loses the gradient dtype contract when the parameter storage dtype and accumulation dtype differ.

This change separates the two responsibilities: `backward_dtype` controls the communication dtype, while the input DTensor's `grad_dtype` controls the dtype returned to the preceding autograd node. This allows the gradient dtype contract to propagate through `redistribute` without changing the dtype behavior of the subsequent computation or the final loss.

## Testing

Added coverage for:

- propagating an FP32 `grad_dtype` independently of BF16 or FP32 backward communication;
- returning the backward result in the input `grad_dtype` without an intermediate cast through the input storage dtype;
- preserving the unconstrained behavior of `grad_dtype=None`;
- propagating the contract through `NestedRedistribute`; and
- existing forward/backward dtype-conversion and double-backward behavior.

The change was also built and tested in a CPU-only remote environment.

