### PR TITLE
Remove Bazel leftovers that point at deleted files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,8 +245,6 @@ docs/source/scripts/lr_scheduler_images/
 
 # build, distribute, and bins (+ python proto bindings)
 build/
-# Allow tools/build/bazel for build support.
-!tools/build/bazel
 build_host_protoc
 build_android
 build_ios
@@ -304,9 +302,6 @@ cmake-build-debug
 
 # Scratch space for agent-authored throwaway files
 agent_space/
-
-# Downloaded bazel
-tools/bazel
 
 # Visual Studio Code files
 .vs

--- a/cmake/FileMirroring.cmake
+++ b/cmake/FileMirroring.cmake
@@ -29,7 +29,6 @@ install(DIRECTORY
 install(DIRECTORY
   "${PROJECT_SOURCE_DIR}/tools/autograd/"
   DESTINATION "${SKBUILD_PLATLIB_DIR}/torchgen/packaged/autograd"
-  PATTERN "BUILD.bazel" EXCLUDE
   PATTERN "*.bzl" EXCLUDE
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ exclude = [
     "**/*.sh",
     "**/*.proto",
     "**/*.pyi.in",   # codegen templates -> .pyi at build time
-    "**/BUCK.oss",   # Bazel build file
+    "**/BUCK.oss",   # Buck build file
     # Docs and editor / dev metadata that scikit-build-core's package walk
     # picks up but legacy setup.py omitted.
     "**/*.md",


### PR DESCRIPTION
#180883 removed the Bazel build. These references outlived it:

- `.gitignore` un-ignores `tools/build/bazel` and ignores a downloaded
  `tools/bazel`; neither path exists.
- `cmake/FileMirroring.cmake` excludes `tools/autograd/BUILD.bazel`, which that
  commit deleted. The neighbouring `"*.bzl"` EXCLUDE is still needed and does not
  cover `BUILD.bazel`.
- `pyproject.toml` calls `BUCK.oss` a Bazel file. It is Buck.

The `build.bzl` files defining `define_targets(rules)` are left alone: nothing
here loads them, but the shim shares definitions with the internal Buck build.

Authored with an AI assistant.
