### PR TITLE
Remove runTaskWithID from ThreadPool

### DIFF
--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -1,6 +1,7 @@
 #include <c10/core/thread_pool.h>
 #include <c10/util/Logging.h>
 #include <c10/util/thread_name.h>
+#include <utility>
 #if !defined(__powerpc__) && !defined(__s390x__)
 #include <cpuinfo.h>
 #endif
@@ -40,13 +41,13 @@ ThreadPool::ThreadPool(
       available_(threads_.size()),
       total_(threads_.size()),
       numa_node_id_(numa_node_id) {
-  for (std::size_t i = 0; i < threads_.size(); ++i) {
-    threads_[i] = std::thread([this, i, init_thread]() {
+  for (auto& thread : threads_) {
+    thread = std::thread([this, init_thread]() {
       c10::setThreadName("pt_thread_pool");
       if (init_thread) {
         init_thread();
       }
-      this->main_loop(i);
+      this->main_loop();
     });
   }
 }
@@ -102,7 +103,7 @@ void ThreadPool::waitWorkComplete() {
   completed_.wait(lock, [&]() { return complete_; });
 }
 
-void ThreadPool::main_loop(std::size_t index) {
+void ThreadPool::main_loop() {
   std::unique_lock<std::mutex> lock(mutex_);
   while (running_) {
     // Wait on condition variable while the task is empty and
@@ -119,7 +120,7 @@ void ThreadPool::main_loop(std::size_t index) {
     // useful in the event that the function contains
     // shared_ptr arguments bound via bind.
     {
-      task_element_t tasks = std::move(tasks_.front());
+      std::function<void()> task = std::move(tasks_.front());
       tasks_.pop();
       // Decrement count, indicating thread is no longer available.
       --available_;
@@ -128,20 +129,15 @@ void ThreadPool::main_loop(std::size_t index) {
 
       // Run the task.
       try {
-        if (tasks.run_with_id) {
-          tasks.with_id(index);
-        } else {
-          tasks.no_id();
-        }
+        task();
       } catch (const std::exception& e) {
         LOG(ERROR) << "Exception in thread pool task: " << e.what();
       } catch (...) {
         LOG(ERROR) << "Exception in thread pool task: unknown";
       }
 
-      // Destruct tasks before taking the lock.  As tasks
-      // are user provided std::function, they can run
-      // arbitrary code during destruction, including code
+      // Destruct task before taking the lock. As a user-provided std::function,
+      // it can run arbitrary code during destruction, including code
       // that can reentrantly call into ThreadPool (which would
       // cause a deadlock if we were holding the lock).
     }

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -55,7 +55,7 @@ ThreadPool::ThreadPool(
 ThreadPool::~ThreadPool() {
   // Set running flag to false then notify all threads.
   {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     running_ = false;
     condition_.notify_all();
   }
@@ -74,7 +74,7 @@ size_t ThreadPool::size() const {
 }
 
 size_t ThreadPool::numAvailable() const {
-  std::unique_lock<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   return available_;
 }
 
@@ -89,7 +89,7 @@ bool ThreadPool::inThreadPool() const {
 
 void ThreadPool::run(std::function<void()> func) {
   TORCH_CHECK(!threads_.empty(), "No threads to run a task");
-  std::unique_lock<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
 
   // Set task and signal condition variable so that a worker thread will
   // wake up and use the task.

--- a/c10/core/thread_pool.h
+++ b/c10/core/thread_pool.h
@@ -7,7 +7,6 @@
 #include <mutex>
 #include <queue>
 #include <thread>
-#include <utility>
 #include <vector>
 
 #include <c10/macros/Export.h>
@@ -40,20 +39,7 @@ class C10_API TaskThreadPoolBase {
 
 class C10_API ThreadPool : public c10::TaskThreadPoolBase {
  protected:
-  struct task_element_t {
-    bool run_with_id;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-    const std::function<void()> no_id;
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
-    const std::function<void(std::size_t)> with_id;
-
-    explicit task_element_t(std::function<void()> f)
-        : run_with_id(false), no_id(std::move(f)), with_id(nullptr) {}
-    explicit task_element_t(std::function<void(std::size_t)> f)
-        : run_with_id(true), no_id(nullptr), with_id(std::move(f)) {}
-  };
-
-  std::queue<task_element_t> tasks_;
+  std::queue<std::function<void()>> tasks_;
   std::vector<std::thread> threads_;
   mutable std::mutex mutex_;
   std::condition_variable condition_;
@@ -82,23 +68,12 @@ class C10_API ThreadPool : public c10::TaskThreadPoolBase {
 
   void run(std::function<void()> func) override;
 
-  template <typename Task>
-  void runTaskWithID(Task task) {
-    std::unique_lock<std::mutex> lock(mutex_);
-
-    // Set task and signal condition variable so that a worker thread will
-    // wake up and use the task.
-    tasks_.emplace(static_cast<std::function<void(std::size_t)>>(task));
-    complete_ = false;
-    condition_.notify_one();
-  }
-
   /// @brief Wait for queue to be empty
   void waitWorkComplete();
 
  private:
   // @brief Entry point for pool threads.
-  void main_loop(std::size_t index);
+  void main_loop();
 };
 
 class C10_API TaskThreadPool : public c10::ThreadPool {


### PR DESCRIPTION
The last time this function was touched was 6 years ago, and there are no callers. Removing it simplifies the class.