### PR TITLE
[ROCm] Add ARC passthrough mapping for DOKS MI350 sandbox runners

### DIFF
--- a/.github/arc.yaml
+++ b/.github/arc.yaml
@@ -114,6 +114,10 @@ runner_mapping:
   # runners via this prefix; passthrough so the OSDC build's runner mapping keeps it.
   amd-sandbox-linux.rocm.gpu.mi350.1: amd-sandbox-linux.rocm.gpu.mi350.1
   amd-sandbox-linux.rocm.gpu.mi350.2: amd-sandbox-linux.rocm.gpu.mi350.2
+  # '-doks' variants target AMD DigitalOcean DOKS MI350 GPUs in DPX partition mode;
+  # passthrough, distinct scale sets from the two labels above.
+  amd-sandbox-linux-doks.rocm.gpu.mi350.1: amd-sandbox-linux-doks.rocm.gpu.mi350.1
+  amd-sandbox-linux-doks.rocm.gpu.mi350.2: amd-sandbox-linux-doks.rocm.gpu.mi350.2
 
 # Runners whose hardware exists only on the Meta fleet (no LF / no AWS EC2
 # equivalent). The mapper forces the 'mt-' prefix on these regardless of which


### PR DESCRIPTION
## Summary
Jobs using `amd-sandbox-linux-doks.rocm.gpu.mi350.1` / `.2` fail in OSDC with `error: no ARC runner found` because `map_ec2_to_arc.py` only accepts labels listed in `.github/arc.yaml`.

Those labels are identity passthroughs for AMD's DigitalOcean DOKS MI350 ARC scale sets (DPX partition mode). They are distinct from the existing `amd-sandbox-linux.rocm.gpu.mi350.{1,2}` mappings, which already target a different cluster.

## Test plan
- [ ] Confirm `python .github/scripts/map_ec2_to_arc.py --prefix mt- '{include: [{runner: "amd-sandbox-linux-doks.rocm.gpu.mi350.1"}]}'` emits the same label (no `mt-` prefix)
- [ ] Confirm the same for `.2`
- [ ] Re-run a trunk-rocm-sandbox / OSDC job that selects `amd-sandbox-linux-doks.rocm.gpu.mi350.1` and verify it gets past `map_ec2_to_arc.py`

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang