### PR TITLE
[native_aot][2/7] export: arch identity and compiler versions in the sidecar

### DIFF
--- a/tools/native_aot/export.py
+++ b/tools/native_aot/export.py
@@ -127,12 +127,11 @@ def _file_hash(path: str) -> str:
         return hashlib.sha256(f.read()).hexdigest()[:16]
 
 
-# Loaded modules under these prefixes belong in the source closure and are not
-# caught by the tools/*.py glob below: torch._native is the builder's own
-# closure, torchgen.native_aot the shared declaration machinery, and
-# torch._vendor the vendored DSL packages -- which hold real kernel bodies, so
-# without them an edited body left every closure unchanged and a relink shipped
-# kernels compiled from the old source, unreported.
+# Loaded modules whose CONTENTS decide what an exported artifact means, and which
+# the tools/*.py glob below cannot see: torch._native holds the builders,
+# torchgen.native_aot the declaration machinery they are validated against, and
+# torch._vendor the vendored DSL packages -- kernel bodies included. Editing any of
+# them changes what a re-export would produce, so their hashes belong in the closure.
 _CLOSURE_PREFIXES = ("torch._native", "torch._vendor", "torchgen.native_aot")
 
 # Tool sources that cannot change what an artifact MEANS, so hashing them would
@@ -140,7 +139,7 @@ _CLOSURE_PREFIXES = ("torch._native", "torch._vendor", "torchgen.native_aot")
 # gen_aot_lib.py only consumes sidecars, and build_stage2.py only decides whether
 # stage 2 runs -- it passes no kernel-affecting option, the arch list being read
 # here (see main()).
-_CLOSURE_EXCLUDED = ("gen_aot_lib.py", "build_stage2.py")
+_CLOSURE_EXCLUDED = frozenset({"gen_aot_lib.py", "build_stage2.py"})
 
 
 def source_closure(decl_path: str | None = None) -> dict[str, str]:
@@ -466,7 +465,11 @@ def runtimes_current(sidecar: dict) -> bool:
     Ignorance is not staleness: with none of the kind's distributions installed
     this returns True, which is the generation-only run on a machine without the
     DSL wheels, where re-exporting is impossible anyway."""
-    tc = toolchains.get_toolchain(sidecar.get("kind", "cutedsl"))
+    # sidecar["kind"], not a default: both callers reach here past a schema check
+    # that proves the field (export._job_needed's guard, gen_aot_lib's sidecar
+    # validation), and guessing would judge one toolchain's artifact by another's
+    # compiler versions.
+    tc = toolchains.get_toolchain(sidecar["kind"])
     current = runtime_versions(tc.kind)
     # all() over an empty dict is True, so a kind with no RUNTIME_DISTS takes
     # this arm too: nothing whose version could have changed.

--- a/tools/native_aot/export.py
+++ b/tools/native_aot/export.py
@@ -161,9 +161,10 @@ def source_closure(decl_path: str | None = None) -> dict[str, str]:
 
 
 def _json_normal(value):
-    """The spec as a sidecar reads it back: tuples become lists, JSON having no
-    tuple type. Skip detection compares a live grid point against a recorded
-    spec, so without this a tuple-valued field re-exports on every run."""
+    """The spec as a sidecar reads it back: tuples become lists, since
+    JSON has no tuple type. Skip detection compares a live grid point
+    against a recorded spec, so a tuple-valued field must be converted
+    or it never matches its own sidecar and re-exports on every run."""
     if isinstance(value, (tuple, list)):
         return [_json_normal(v) for v in value]
     if isinstance(value, dict):
@@ -361,12 +362,14 @@ _CLEAN_HINT = (
 
 
 def _read_sidecar(path: str) -> dict:
-    """A sidecar's JSON. Unreadable ones are fatal.
+    """A sidecar's JSON. Unreadable sidecars are fatal.
 
-    The sidecar is written LAST, so its presence marks a completed export. One
-    that will not parse means the artifacts beside it are of unknown provenance,
-    and re-exporting would only make the directory look consistent. Reached even
-    under --force, via _collect_jobs' orphan scan.
+    The sidecar is written LAST, so its presence marks a completed
+    export. One that exists but will not parse means the tree is
+    corrupted and the .o/.h beside it are of unknown provenance.
+    Re-exporting would just make the directory look consistent again.
+    Reached even under --force, via the orphan scan in _collect_jobs, so
+    gen_aot_lib never links artifacts nothing validated.
     """
     try:
         with open(path) as f:

--- a/tools/native_aot/export.py
+++ b/tools/native_aot/export.py
@@ -1,19 +1,21 @@
 """AOT-export DSL kernels for native-AOT declarations.
 
-Stage 2 of the two-stage build (build torch -> build the AOT lib): runs
-with the BUILT torch importable, so kernel builder modules are ordinary
-package imports (``torch._native.ops.<op>.<module>``) and may freely
-share code with their JIT wrappers -- the same-kernel property is then
-by construction, not by parallel restatement. Only the aot.py
-DECLARATION modules stay torch-free at module scope (torchgen loads
-those during stage 1, before torch exists).
+Stage 2 of the two-stage build: runs with the BUILT torch importable, so kernel
+builders are ordinary package imports (``torch._native.ops.<op>.<module>``) and
+share code with their JIT wrappers -- making the same-kernel property structural
+rather than a parallel restatement. Only the aot.py DECLARATION modules stay
+torch-free at module scope, since torchgen loads those during stage 1.
 
 For each ``torch/_native/ops/<op>/aot.py``, expands the spec grid (list
 fields cross-multiply) and for every grid point runs the toolchain's
 compile + export into ``<out-dir>/<op>/``, writing:
 
     <prefix>.h / <prefix>.o    C-ABI header + kernel object
-    <prefix>.json              marshalling sidecar {spec, tensor_args}
+    <prefix>.json              marshalling sidecar {spec, arch, tensor_args}
+
+Prefixes carry their arch (``topk_..._det__sm100a``): every exported C
+symbol derives from the prefix, so two arches sharing one would be
+duplicate definitions once both link into libtorch_cuda.
 
 The builder module must expose ``build(spec)`` returning a dict whose
 ``kind`` selects the toolchain; see tools/native_aot/toolchains.py for
@@ -23,24 +25,18 @@ naming the missing keys.
 
 Idempotent: existing artifacts are skipped unless --force.
 
-Spec points compile on a forkserver process pool. Each point is
-independent, so results do not depend on --jobs. --jobs follows the
-torch build's parallelism (MAX_JOBS, then CMAKE_BUILD_PARALLEL_LEVEL,
-then half the CPU count); --jobs 1 forces serial. Plain fork is
-unusable: the parent has initialized CUDA and forked workers inherit a
-dead context, silently -- they report is_initialized() False and cannot
-allocate. forkserver forks from a pre-CUDA server process instead, and
-pays the torch import once there rather than per worker. Only torch is
-preloaded; cutlass or triton would build state in that fork parent.
+Spec points compile on a forkserver process pool; each is independent, so
+results do not depend on --jobs (which follows MAX_JOBS, then
+CMAKE_BUILD_PARALLEL_LEVEL, then half the CPU count; 1 forces serial). Plain
+fork is unusable -- the parent has initialized CUDA and forked workers inherit a
+dead context silently. Only torch is preloaded; cutlass or triton would build
+state in the fork parent.
 
-With --arch (one or more sm strings) export never touches the CUDA
-driver, so kernels build on GPU-less machines. The arch is per-COMPILE
-state: CuTeDSL takes a --gpu-arch option, which outranks CUTE_DSL_ARCH
-(base_dsl/dsl.py prefers compile_options.gpu_arch over envar.arch), and
-Triton gets a fixed-target driver per export. So a single pool serves
-every (point, arch) job. Multiple archs still nest under
-<out-dir>/<arch>/ to keep each tree independently linkable.
-CuTeDSL needs one warmup compile per process for this to work; see
+With --arch (one or more sm strings) export never touches the CUDA driver, so
+kernels build on GPU-less machines. The arch is per-COMPILE state (CuTeDSL's
+--gpu-arch outranks CUTE_DSL_ARCH, and Triton gets a fixed-target driver), so
+one pool serves every (point, arch) job and each arch's tree stays independently
+linkable. CuTeDSL needs one warmup compile per process for this; see
 tools/native_aot/cutedsl_warmup.py.
 
 Usage (from the repo root, venv with torch built and the DSL wheel
@@ -60,16 +56,12 @@ import sys
 REPO = os.path.normpath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
 )
-# Run as a script (`python tools/native_aot/export.py`), sys.path[0] is this
-# directory, so `tools.native_aot` is importable only when the cwd happens to
-# be the repo root. Put the root on the path explicitly instead of loading
-# siblings by file path, which also keeps the imports legible to type checkers.
+# As a script sys.path[0] is this directory, so the repo root has to go on the
+# path for `tools.native_aot` to import from any cwd.
 #
-# APPEND, never insert(0): stage 2 runs against the INSTALLED wheel, and the
-# repo root contains a torch/ source tree with no compiled extension. Ahead of
-# site-packages it shadows the real torch, so every worker's `import torch`
-# dies with "loaded the torch/_C folder of the PyTorch repository". Invisible
-# in a `pip install -e .` checkout, where that tree IS the installed torch.
+# APPEND, never insert(0): stage 2 runs against the INSTALLED wheel, and the repo
+# root holds a torch/ source tree with no compiled extension that would shadow it.
+# An editable checkout hides this, because there that tree IS the installed torch.
 sys.path.append(REPO)
 
 # torchgen is pure Python and imports with no built torch, which this
@@ -88,18 +80,16 @@ OPS_DIR = os.path.join(REPO, "torch", "_native", "ops")
 # mismatched sidecars (re-export rather than debugging a garbled .cpp).
 SIDECAR_VERSION = 1
 
-# Pool start method: forkserver, never "fork" (the parent has initialized
-# CUDA, and forked workers inherit a dead context that fails silently).
-# forkserver forks from a pre-CUDA server process, so it is as safe as
-# spawn while paying the torch import once instead of per worker.
-# TODO(native-aot): forkserver does not exist on Windows. Nothing calls
-# this from the build there yet (stage 2 targets libtorch_cuda.so only),
-# so fall back to "spawn" when Windows CUDA builds start exporting.
+# Never "fork": the parent has initialized CUDA and forked workers inherit a
+# dead context that fails silently. forkserver forks from a pre-CUDA server
+# process, so it is as safe as spawn but pays the torch import once.
+# TODO(native-aot): forkserver does not exist on Windows; fall back to "spawn"
+# when Windows CUDA builds start exporting.
 POOL_START_METHOD = "forkserver"
 
-# Preloaded in the forkserver's server process, so every worker inherits
-# it already imported. Only modules that are safe in a fork PARENT belong
-# here: importing torch neither initializes CUDA nor builds any DSL state.
+# Preloaded in the forkserver's server process, so every worker inherits it
+# imported. Only what is safe in a fork PARENT: torch neither initializes CUDA
+# nor builds DSL state.
 POOL_PRELOAD = ("torch",)
 
 
@@ -120,12 +110,20 @@ def _file_hash(path: str) -> str:
         return hashlib.sha256(f.read()).hexdigest()[:16]
 
 
-# Loaded modules under these prefixes belong in the source closure:
-# torch._native is the builder's own closure, torchgen.native_aot the
-# shared declaration machinery (expand_specs picks the grid points, the
-# validating loader decides what a declaration means). Neither is caught
-# by the tools/*.py glob below -- they live outside tools/.
-_CLOSURE_PREFIXES = ("torch._native", "torchgen.native_aot")
+# Loaded modules under these prefixes belong in the source closure and are not
+# caught by the tools/*.py glob below: torch._native is the builder's own
+# closure, torchgen.native_aot the shared declaration machinery, and
+# torch._vendor the vendored DSL packages -- which hold real kernel bodies, so
+# without them an edited body left every closure unchanged and a relink shipped
+# kernels compiled from the old source, unreported.
+_CLOSURE_PREFIXES = ("torch._native", "torch._vendor", "torchgen.native_aot")
+
+# Tool sources that cannot change what an artifact MEANS, so hashing them would
+# re-export every kernel for an edit that could not have changed one:
+# gen_aot_lib.py only consumes sidecars, and build_stage2.py only decides whether
+# stage 2 runs -- it passes no kernel-affecting option, the arch list being read
+# here (see main()).
+_CLOSURE_EXCLUDED = ("gen_aot_lib.py", "build_stage2.py")
 
 
 def source_closure(decl_path: str | None = None) -> dict[str, str]:
@@ -135,21 +133,18 @@ def source_closure(decl_path: str | None = None) -> dict[str, str]:
     sources (a launcher-template edit in toolchains.py counts), and the
     op's own aot.py.
 
-    Recorded per sidecar; gen_aot_lib re-hashes from disk and refuses to
-    pair edited sources with stale artifacts. Deliberately
-    over-approximates -- staleness must err toward re-export.
+    Recorded per sidecar; gen_aot_lib re-hashes from disk and refuses to pair
+    edited sources with stale artifacts. Deliberately over-approximates --
+    staleness must err toward re-export.
 
-    Only IMPORTED modules appear in sys.modules, which is why the tools/
-    sources are globbed from disk instead -- and why decl_path is passed
-    explicitly: declarations are loaded by file path and never enter
-    sys.modules, so KERNEL_MODULE or kernel_precompile_grid() edits would
-    otherwise reuse artifacts built from the old grid."""
+    Only IMPORTED modules appear in sys.modules, hence globbing the tools/
+    sources and passing decl_path explicitly: declarations are loaded by file
+    path, so grid edits would otherwise reuse artifacts built from the old one."""
     import glob
-    import sys
 
     out = {}
     # Snapshot: hashing can trigger imports, and mutating sys.modules
-    # mid-iteration raises "dictionary changed size during iteration".
+    # mid-iteration raises.
     for name, mod in list(sys.modules.items()):
         if not name.startswith(_CLOSURE_PREFIXES):
             continue
@@ -157,10 +152,7 @@ def source_closure(decl_path: str | None = None) -> dict[str, str]:
         if f and os.path.exists(f):
             out[os.path.relpath(f, REPO)] = _file_hash(f)
     for f in glob.glob(os.path.join(_HERE, "*.py")):
-        # gen_aot_lib.py only CONSUMES sidecars (its edits are picked up
-        # by re-running generation); hashing it would re-export every
-        # kernel on a generation-only change.
-        if os.path.basename(f) == "gen_aot_lib.py":
+        if os.path.basename(f) in _CLOSURE_EXCLUDED:
             continue
         out[os.path.relpath(f, REPO)] = _file_hash(f)
     if decl_path and os.path.exists(decl_path):
@@ -169,10 +161,9 @@ def source_closure(decl_path: str | None = None) -> dict[str, str]:
 
 
 def _json_normal(value):
-    """The spec as a sidecar reads it back: tuples become lists, since
-    JSON has no tuple type. Skip detection compares a live grid point
-    against a recorded spec, so a tuple-valued field must be converted
-    or it never matches its own sidecar and re-exports on every run."""
+    """The spec as a sidecar reads it back: tuples become lists, JSON having no
+    tuple type. Skip detection compares a live grid point against a recorded
+    spec, so without this a tuple-valued field re-exports on every run."""
     if isinstance(value, (tuple, list)):
         return [_json_normal(v) for v in value]
     if isinstance(value, dict):
@@ -180,41 +171,101 @@ def _json_normal(value):
     return value
 
 
-def _effective_arch(arch: str | None, tc: toolchains.Toolchain) -> str | None:
+def _detected_arch() -> str | None:
+    """The local device as an sm string ("sm_100"), or None without CUDA.
+
+    Without this in the sidecar an on-device export's artifacts carry no arch
+    identity, and the generated gate falls back to the declaration's ARCHS --
+    advertising hardware nothing was compiled for (a B200 build offering major 9
+    because ARCHS lists sm_90). Recorded without the "a" suffix: the gate compares
+    major.minor, which both spellings share."""
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        major, minor = torch.cuda.get_device_capability()
+    except Exception:
+        return None
+    return f"sm_{major * 10 + minor}"
+
+
+def _arch_tag(arch: str) -> str:
+    """Arch as an artifact-name tag: "sm_100a" -> "sm100a".
+
+    Short because it lands in every exported C symbol, and those are already
+    long (cute_dsl_<prefix>_wrapper over a spec-derived prefix)."""
+    return arch.replace("_", "", 1)
+
+
+def _effective_arch(
+    arch: str | None, tc: toolchains.Toolchain | None = None
+) -> str | None:
     """The arch the artifacts are really compiled for: the explicit one if
-    given, else whatever the toolchain's own env var selects
-    (Toolchain.ARCH_ENV_VAR, e.g. CUTE_DSL_ARCH).
+    given, else whatever a toolchain's own env var selects
+    (Toolchain.ARCH_ENV_VAR, e.g. CUTE_DSL_ARCH), else the local device.
 
-    Resolving it on BOTH sides -- recorded in the sidecar, recomputed by
-    the skip check -- is what makes a flat --out-dir safe across runs that
-    set only that variable:
+    ONE resolver for both the sidecar and the directory name, so a tree can never
+    disagree with its own sidecars -- the runtime gate comes from the sidecar, and
+    a directory saying otherwise would make the layout lie.
 
-        CUTE_DSL_ARCH=sm_90a  export.py --out-dir build/native_aot
-        CUTE_DSL_ARCH=sm_100a export.py --out-dir build/native_aot
+    Recorded and recomputed by the skip check, so two runs differing only in that
+    variable are told apart; comparing the raw --arch value left both at None and
+    the second skipped every point.
 
-    Comparing the raw --arch value would leave both runs at None, so the
-    second matches on spec alone, skips every point, and the sm_90a
-    objects stay on disk behind a sidecar the caller reads as sm_100a."""
-    return arch or (os.getenv(tc.ARCH_ENV_VAR) if tc.ARCH_ENV_VAR else None)
+    ``tc`` is omitted when choosing a directory, before any builder (and so kind)
+    exists, and the variable is then taken from whichever registered kind declares
+    one -- only CuTeDSL today. Two kinds naming different variables have no single
+    answer, and picking one would make the directory depend on registry order."""
+    if arch:
+        return arch
+    # An arch variable with no --arch is REFUSED, not honoured: it is per-kind, so
+    # it answers only for kinds that declare one. With CUTE_DSL_ARCH=sm_90a set, a
+    # tree named sm_90a held a sidecar recording the DETECTED sm_100 for a kind
+    # with no variable -- and generation filters by directory while the shipped
+    # gate comes from the sidecar. Refusing leaves one arch=None path that every
+    # kind answers identically.
+    named = {
+        k.ARCH_ENV_VAR: os.getenv(k.ARCH_ENV_VAR)
+        for k in toolchains.TOOLCHAINS.values()
+        if k.ARCH_ENV_VAR and os.getenv(k.ARCH_ENV_VAR)
+    }
+    if named:
+        example = sorted(named.items())[0][1]
+        raise RuntimeError(
+            "arch variable(s) "
+            + ", ".join(f"{k}={v}" for k, v in sorted(named.items()))
+            + " are set but --arch is not. They are per-toolchain, so they cannot "
+            "name the arch for every kind in one export; pass --arch "
+            f"(e.g. --arch {example}) to state it once."
+        )
+    return _detected_arch()
+
+
+def _claimed_spelling(arch: str, claimed: tuple[str, ...]) -> str | None:
+    """The spelling in ``claimed`` for ``arch``'s capability, or None.
+
+    Prefers the arch-conditional spelling when a declaration lists both, matching
+    the generator's tie-break: it is what the kernels were written against."""
+    want = decl.cc_of(arch)
+    same_cc = [a for a in claimed if decl.cc_of(a) == want]
+    return min(same_cc, key=lambda a: (not a.endswith("a"), a)) if same_cc else None
 
 
 def export_point(
     op_pkg: str, kernel_module: str, point: dict, out_dir: str, arch: str | None = None
 ) -> str:
-    """Compile + export ONE spec point and write its sidecar. Self-
-    contained (module-level function, picklable args) so it runs
-    identically inline and as a pool job. ``arch`` is an explicit sm
-    string, passed through to the toolchain (CuTeDSL takes it as
-    --gpu-arch, Triton as a fixed GPUTarget); no process-global state, so
-    one process may serve any mix of arches.
+    """Compile + export ONE spec point and write its sidecar.
 
-    A missing DSL runtime is FATAL here, not a skip: a declaration that
-    reaches this point targets this build's backend (build_stage2 filtered
-    on Toolchain.BACKENDS), so its kernels were asked for, and exporting
-    only some of them would ship a wheel that silently underperforms.
-    Build without the DSL wheels via TORCH_NATIVE_AOT=0 instead. The
-    ImportError arm exists because a builder cannot be asked its kind
-    without importing its runtime -- build() constructs the kernel."""
+    Self-contained (module-level, picklable args) so it runs identically inline
+    and as a pool job. ``arch`` is passed through to the toolchain as per-compile
+    state, so one process may serve any mix of arches.
+
+    A missing DSL runtime is FATAL here, not a skip: a declaration reaching this
+    point targets this build's backend, so its kernels were asked for, and
+    exporting only some would ship a wheel that silently underperforms
+    (TORCH_NATIVE_AOT=0 builds without them). The ImportError arm exists because
+    a builder cannot be asked its kind without importing its runtime."""
     try:
         build = load_builder(op_pkg, kernel_module)
         b = build(point)
@@ -224,6 +275,8 @@ def export_point(
             f"({e.name or e}). Install it, or set TORCH_NATIVE_AOT=0 to "
             f"build without embedded DSL kernels."
         ) from e
+    # Builder dicts may omit kind (CuTeDSL is the default); sidecars always
+    # carry it, written below.
     tc = toolchains.get_toolchain(b.get("kind", "cutedsl"))
     missing = tc.missing_runtimes()
     if missing:
@@ -233,6 +286,12 @@ def export_point(
             f"embedded DSL kernels."
         )
     tc.validate_build_result(b)
+    # Arch-qualifying the prefix is what lets several arches ship in one library:
+    # every exported C symbol derives from it, so two arches sharing one are
+    # duplicate definitions at link time.
+    effective_arch = _effective_arch(arch, tc)
+    if effective_arch:
+        b["prefix"] = f"{b['prefix']}__{_arch_tag(effective_arch)}"
     prefix = b["prefix"]
     extra = tc.export(b, out_dir, arch=arch)
     sidecar = {
@@ -240,10 +299,12 @@ def export_point(
         "prefix": prefix,
         "kind": tc.kind,
         "spec": point,
-        "arch": _effective_arch(arch, tc),
-        # The declaration lives at a path fixed by construction, so it needs
-        # no threading through the job tuple.
+        "arch": effective_arch,
+        # The declaration's path is fixed by construction, so it needs no
+        # threading through the job tuple.
         "sources": source_closure(os.path.join(OPS_DIR, op_pkg, "aot.py")),
+        # The compiler, which no source file names (see runtimes_current).
+        "runtimes": runtime_versions(tc.kind),
         **extra,
     }
     with open(os.path.join(out_dir, prefix + ".json"), "w") as f:
@@ -300,14 +361,12 @@ _CLEAN_HINT = (
 
 
 def _read_sidecar(path: str) -> dict:
-    """A sidecar's JSON. Unreadable sidecars are fatal.
+    """A sidecar's JSON. Unreadable ones are fatal.
 
-    The sidecar is written LAST, so its presence marks a completed
-    export. One that exists but will not parse means the tree is
-    corrupted and the .o/.h beside it are of unknown provenance.
-    Re-exporting would just make the directory look consistent again.
-    Reached even under --force, via the orphan scan in _collect_jobs, so
-    gen_aot_lib never links artifacts nothing validated.
+    The sidecar is written LAST, so its presence marks a completed export. One
+    that will not parse means the artifacts beside it are of unknown provenance,
+    and re-exporting would only make the directory look consistent. Reached even
+    under --force, via _collect_jobs' orphan scan.
     """
     try:
         with open(path) as f:
@@ -366,6 +425,43 @@ def _check_no_orphan_artifacts(out_dir: str, specs=None) -> None:
         )
 
 
+def runtime_versions(kind: str) -> dict[str, str]:
+    """{distribution: version} for the runtimes that COMPILE this kind.
+
+    Metadata only, no import of the DSL itself. An uninstalled distribution is
+    recorded as absent rather than omitted, so "compiled where the wheel was
+    missing" differs from "compiled before this was recorded"."""
+    import importlib.metadata as md
+
+    out = {}
+    for dist in toolchains.get_toolchain(kind).RUNTIME_DISTS:
+        try:
+            out[dist] = md.version(dist)
+        except md.PackageNotFoundError:
+            out[dist] = "absent"
+    return dict(sorted(out.items()))
+
+
+def runtimes_current(sidecar: dict) -> bool:
+    """True if the sidecar was compiled by the DSL versions installed now.
+
+    The compiler is not in the source closure -- no file on disk changes when the
+    wheel is upgraded -- so without this an upgrade re-exports nothing and the tree
+    mixes artifacts from two compilers while the build reports one. A sidecar
+    predating this record counts as stale.
+
+    Ignorance is not staleness: with none of the kind's distributions installed
+    this returns True, which is the generation-only run on a machine without the
+    DSL wheels, where re-exporting is impossible anyway."""
+    tc = toolchains.get_toolchain(sidecar.get("kind", "cutedsl"))
+    current = runtime_versions(tc.kind)
+    # all() over an empty dict is True, so a kind with no RUNTIME_DISTS takes
+    # this arm too: nothing whose version could have changed.
+    if all(v == "absent" for v in current.values()):
+        return True
+    return sidecar.get("runtimes") == current
+
+
 def sources_current(sidecar: dict) -> bool:
     """True if every source file recorded in the sidecar's closure
     still hashes the same on disk. Sidecars without a closure or from
@@ -383,20 +479,16 @@ def sources_current(sidecar: dict) -> bool:
 
 
 def _job_needed(job, force: bool) -> bool:
-    """Cheap skip check without compiling: an exported point's sidecar
-    records its spec, its arch and its source closure; skip only when
-    all three match -- the spec, the arch the artifacts were compiled
-    for, and every recorded source file unchanged on disk (so an edited
-    kernel module re-exports without --force).
+    """Cheap skip check without compiling: skip only when the sidecar's spec, its
+    arch and every file in its source closure all still match, so an edited kernel
+    module re-exports without --force.
 
-    The arch check is load-bearing for SEQUENTIAL single-arch runs into
-    one --out-dir: those keep the flat <out-root>/<decl_id>/ layout (only
-    a multi-arch run nests per-arch), so `--arch sm_100` followed by
-    `--arch sm_100a` lands in the same directory. Without comparing arch,
-    the second run matches the first run's sidecar on spec alone and
-    skips every point, leaving sm_100 objects behind a sidecar that
-    claims sm_100a. The comparison goes through _effective_arch so runs
-    that set only the toolchain's arch env var are caught the same way."""
+    Per-arch directories stop two arches colliding in one tree, so the arch
+    comparison guards the cases where the RECORDED arch differs from what this run
+    resolves to: artifacts predating arch identity, and a tree carried between
+    machines. Both must re-export, since the recorded arch is what the runtime gate
+    is built from. Compared through _effective_arch, so both sides resolve
+    --arch, the toolchain's env var and the local device identically."""
     if force:
         return True
     _, _, point, out_dir, arch = job
@@ -405,26 +497,28 @@ def _job_needed(job, force: bool) -> bool:
         if not fn.endswith(".json"):
             continue
         sc = _read_sidecar(os.path.join(out_dir, fn))
-        tc = toolchains.get_toolchain(sc.get("kind", "cutedsl"))
+        # SCHEMA FIRST: every field below is read by name. A version dropping or
+        # renaming "kind" used to raise a bare KeyError naming no file and no
+        # remedy, where the version field exists so the point re-exports.
+        if sc.get("version") != SIDECAR_VERSION or "kind" not in sc:
+            return True
+        tc = toolchains.get_toolchain(sc["kind"])
         if sc.get("spec") == spec and sc.get("arch") == _effective_arch(arch, tc):
-            # The sidecar is the skip marker, but it is not proof the
-            # artifacts it describes are still on disk: anything that
-            # removes a .o/.h without its .json (a partial clean, an
-            # over-eager prune) would otherwise be skipped here and fail
-            # much later as a missing include at compile time.
+            # The sidecar marks the skip but does not prove its artifacts are
+            # still there: a partial clean that took a .o/.h without its .json
+            # would be skipped here and fail later as a missing include.
             prefix = sc.get("prefix", "")
             if any(
                 not os.path.exists(os.path.join(out_dir, prefix + e))
                 for e in tc.artifact_exts
             ):
                 return True
-            return not sources_current(sc)
+            return not (sources_current(sc) and runtimes_current(sc))
     return True
 
 
 def _run_job(job) -> str:
-    op_pkg, kernel_module, point, out_dir, arch = job
-    return export_point(op_pkg, kernel_module, point, out_dir, arch)
+    return export_point(*job)
 
 
 def archs_from_cuda_arch_list(arch_list: str) -> list[str]:

--- a/tools/test/test_native_aot_tools.py
+++ b/tools/test/test_native_aot_tools.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import json
 import os
+import sys
 import tempfile
+import types
 import unittest
+import unittest.mock as mock
 
 # Ordinary package imports, like every other tools test (CI runs
 # `PYTHONPATH=$(pwd) pytest tools/test`). These modules keep their module
@@ -15,6 +19,11 @@ from tools.native_aot import export, toolchains
 
 _TOOLS_FILE = os.path.abspath(toolchains.__file__)
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(_TOOLS_FILE)))
+
+
+# The DSL versions this environment would compile with; sidecars must carry
+# them or the skip check treats them as built by a different compiler.
+_RUNTIMES = export.runtime_versions("cutedsl")
 
 SIDECAR = {
     "prefix": "fakeop_f32_n1024_k8",
@@ -31,12 +40,94 @@ SIDECAR = {
 }
 
 
-def _touch_artifacts(out_dir, prefix, exts=(".o", ".h")):
-    """Create the files a sidecar claims. _job_needed verifies they exist,
-    so a fixture that writes only the .json would always re-export."""
+def _no_ambient_arch(device=None):
+    """Take the ambient environment out of arch resolution.
+
+    ``device`` is what _detected_arch should report -- None for "no GPU", or an
+    sm string to test the device fallback, which only answers once no arch env
+    var does.
+
+    _effective_arch resolves an unspecified arch from the builder's GPU or from
+    a toolchain's ARCH_ENV_VAR, so a sidecar written without one is legitimately
+    stale when either answers. Tests about spec/source matching say nothing
+    about arch and must not depend on the runner's hardware -- nor on the
+    ambient environment: with CUTE_DSL_ARCH exported (the invocation export.py's
+    own docstring documents) patching only the device left six of them failing."""
+    env = {
+        tc.ARCH_ENV_VAR: "" for tc in toolchains.TOOLCHAINS.values() if tc.ARCH_ENV_VAR
+    }
+    stack = contextlib.ExitStack()
+    stack.enter_context(
+        mock.patch.object(export, "_detected_arch", return_value=device)
+    )
+    # patch.dict cannot unset, and os.getenv("") is falsy, which is what
+    # _effective_arch tests -- so an empty value is equivalent to absent here.
+    stack.enter_context(mock.patch.dict(os.environ, env, clear=False))
+    return stack
+
+
+_DECL_REL = os.path.relpath(
+    os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"), export.REPO
+)
+
+
+def _current_sources():
+    """A source closure that matches this tree, for sidecars meant to look
+    current."""
+    return {_DECL_REL: export._file_hash(os.path.join(export.REPO, _DECL_REL))}
+
+
+def _write_sidecar(d, point, prefix="x", exts=(".o", ".h"), **over):
+    """Write into ``d`` the artifacts and the sidecar a current export would have
+    left for ``point``, so _job_needed sees a skippable job. ``over`` replaces or
+    adds fields (arch, sources, ...) for the cases that are about one of them."""
+    _touch_artifacts(d, prefix, exts=exts)
+    sc = {
+        "version": export.SIDECAR_VERSION,
+        "prefix": prefix,
+        "kind": "cutedsl",
+        "spec": point,
+        "sources": _current_sources(),
+        "runtimes": _RUNTIMES,
+    }
+    sc.update(over)
+    with open(os.path.join(d, prefix + ".json"), "w") as f:
+        json.dump(sc, f)
+
+
+def _touch_artifacts(out_dir, prefix, exts=(".o", ".h"), tensor_args=None):
+    """Create the files a sidecar claims. _job_needed verifies they exist, so a
+    fixture that writes only the .json would always re-export.
+
+    The .h is DERIVED from the sidecar's own tensor_args -- one struct per tensor,
+    named <prefix>_Tensor_<name>_t, with each array bound equal to the number of
+    dims that tensor claims. validate_abi requires that equality (an over-claim
+    stores past the end of the struct; an under-claim leaves the kernel reading an
+    uninitialized slot), so a header with hand-picked bounds described an ABI no
+    export could produce, and every generation fixture built on it was exercising
+    the guard against an impossible input."""
+    args = SIDECAR["tensor_args"] if tensor_args is None else tensor_args
     for e in exts:
+        body = ""
+        if e == ".h":
+            body = "#pragma once\n#include <stdint.h>\n"
+            for a in args:
+                fields = ["  void* data;"]
+                if a.get("dynamic_sizes"):
+                    fields.append(
+                        f"  int32_t dynamic_shapes[{len(a['dynamic_sizes'])}];"
+                    )
+                if a.get("dynamic_strides"):
+                    fields.append(
+                        f"  int64_t dynamic_strides[{len(a['dynamic_strides'])}];"
+                    )
+                body += (
+                    "typedef struct {\n"
+                    + "\n".join(fields)
+                    + f"\n}} {prefix}_Tensor_{a['name']}_t;\n"
+                )
         with open(os.path.join(out_dir, prefix + e), "w") as f:
-            f.write("")
+            f.write(body)
 
 
 class TestExportJobs(unittest.TestCase):
@@ -44,61 +135,28 @@ class TestExportJobs(unittest.TestCase):
         # Skip detection matches the sidecar's recorded spec AND a
         # current source closure; a spec match alone (no/mismatched
         # sources) re-exports.
-        import json as _json
-        import tempfile
-
-        rel = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-            export.REPO,
-        )
-        current = {rel: export._file_hash(os.path.join(export.REPO, rel))}
         with tempfile.TemporaryDirectory() as d:
             point = {"dtype": "float32", "N": 4096}
             job = ("fakeop", "aot_kernel.py", point, d, None)
             self.assertTrue(export._job_needed(job, force=False))
-            _touch_artifacts(d, "x")
-            with open(os.path.join(d, "x.json"), "w") as f:
-                _json.dump(
-                    {
-                        "version": export.SIDECAR_VERSION,
-                        "prefix": "x",
-                        "spec": point,
-                        "sources": current,
-                    },
-                    f,
-                )
-            self.assertFalse(export._job_needed(job, force=False))
-            self.assertTrue(export._job_needed(job, force=True))
-            other = ("fakeop", "aot_kernel.py", {"dtype": "bfloat16"}, d, None)
-            self.assertTrue(export._job_needed(other, force=False))
+            _write_sidecar(d, point)
+            with _no_ambient_arch():
+                self.assertFalse(export._job_needed(job, force=False))
+                self.assertTrue(export._job_needed(job, force=True))
+                other = ("fakeop", "aot_kernel.py", {"dtype": "bfloat16"}, d, None)
+                self.assertTrue(export._job_needed(other, force=False))
 
     def test_job_skip_survives_json_round_trip(self):
         # Tuple-valued grid fields read back from the sidecar as lists;
         # skip detection must normalize both sides or such points
         # re-export on every run (the pointwise family's in_dtypes hit
         # this).
-        import json as _json
-        import tempfile
-
-        rel = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-            export.REPO,
-        )
-        current = {rel: export._file_hash(os.path.join(export.REPO, rel))}
         with tempfile.TemporaryDirectory() as d:
             point = {"aten": "add.Tensor", "in_dtypes": ("float32", "bfloat16")}
             job = ("fakeop", "aot_kernel.py", point, d, None)
-            sidecar = {
-                "version": export.SIDECAR_VERSION,
-                "prefix": "x",
-                "spec": export._json_normal(point),
-                "sources": current,
-            }
-            _touch_artifacts(d, "x")
-            _touch_artifacts(d, "x")
-            with open(os.path.join(d, "x.json"), "w") as f:
-                _json.dump(sidecar, f)
-            self.assertFalse(export._job_needed(job, force=False))
+            _write_sidecar(d, point, spec=export._json_normal(point))
+            with _no_ambient_arch():
+                self.assertFalse(export._job_needed(job, force=False))
 
     def test_run_job_is_module_level(self):
         # The pool pickles the job function by qualified name; a closure
@@ -109,12 +167,10 @@ class TestExportJobs(unittest.TestCase):
         self.assertEqual(export.export_point.__qualname__, "export_point")
 
     def test_pool_never_forks_after_cuda_init(self):
-        # Plain "fork" gives workers a dead CUDA context (measured:
-        # is_initialized() False, allocation fails, no exception) because
-        # the parent initializes CUDA before the pool starts.
-        # Pinned to forkserver, not just "not fork": main() calls
-        # set_forkserver_preload unconditionally, which a spawn context
-        # would silently ignore.
+        # Plain "fork" gives workers a dead CUDA context (is_initialized() False,
+        # allocation fails, no exception), the parent having initialized CUDA
+        # first. Pinned to forkserver rather than "not fork" because main() calls
+        # set_forkserver_preload unconditionally, which spawn silently ignores.
         self.assertEqual(export.POOL_START_METHOD, "forkserver")
 
     def test_cutedsl_export_passes_gpu_arch(self):
@@ -125,7 +181,6 @@ class TestExportJobs(unittest.TestCase):
         # suite runs in the linter image, which has no DSL installed.
         import sys
         import types
-        import unittest.mock as mock
         from typing import Any, cast
 
         seen = {}
@@ -177,22 +232,34 @@ class TestExportJobs(unittest.TestCase):
         )
 
     def test_missing_runtime_is_fatal_not_skipped(self):
-        # A declaration whose toolchain targets this build's backend was
-        # ASKED for, so a missing runtime must fail rather than quietly
-        # ship a wheel with fewer kernels than declared. TORCH_NATIVE_AOT=0
-        # is the supported way to build without the DSL wheels.
-        import unittest.mock as mock
-
-        with mock.patch.object(
-            toolchains.CuteDslToolchain, "missing_runtimes", classmethod(lambda cls: [])
+        # A declaration whose toolchain targets this backend was ASKED for, so a
+        # missing runtime must fail rather than ship a wheel with fewer kernels
+        # than declared (TORCH_NATIVE_AOT=0 is the way to build without them).
+        #
+        # export is STUBBED on the runtime-present half: the real one imports
+        # cutlass into the test process, leaks CUTE_DSL_LIBS into os.environ, and
+        # with CUTE_DSL_ARCH set made the asserted exception come from arch
+        # resolution rather than the gate.
+        reached = []
+        with (
+            mock.patch.object(
+                toolchains.CuteDslToolchain,
+                "missing_runtimes",
+                classmethod(lambda cls: []),
+            ),
+            mock.patch.object(
+                toolchains.CuteDslToolchain,
+                "export",
+                lambda self, b, out_dir, arch=None: reached.append(arch) or {},
+            ),
+            _no_ambient_arch(device="sm_100a"),
         ):
             b = {"prefix": "p", "fn": None, "fake_args": (), "tensor_args": []}
             with mock.patch.object(export, "load_builder", lambda *a: lambda p: b):
-                # Runtime present: gets past the gate (fails later, on the
-                # real compile, which this harness cannot do).
-                with self.assertRaises(Exception) as cm:
-                    export.export_point("fakeop", "aot_kernel.py", {}, "/tmp")
-                self.assertNotIn("TORCH_NATIVE_AOT=0", str(cm.exception))
+                with tempfile.TemporaryDirectory() as d:
+                    export.export_point("fakeop", "aot_kernel.py", {}, d)
+        # Runtime present: it got PAST the gate and into the toolchain's export.
+        self.assertEqual(len(reached), 1)
 
         with mock.patch.object(
             toolchains.CuteDslToolchain,
@@ -229,89 +296,156 @@ class TestExportJobs(unittest.TestCase):
 
 
 class TestArch(unittest.TestCase):
-    def test_effective_arch_is_per_toolchain(self):
-        # Only kinds that declare an ARCH_ENV_VAR read one, so a kind that
-        # takes its target another way (Triton: an explicit GPUTarget) is
-        # not perturbed by CUTE_DSL_ARCH.
-        import unittest.mock as mock
-
+    def test_effective_arch_answers_identically_for_every_kind(self):
+        # The invariant the refusal above buys: with no --arch, resolution is
+        # device detection, which does not vary by kind -- so a tree can never
+        # disagree with its own sidecars. This is what a per-kind env var broke.
         cutedsl = toolchains.get_toolchain("cutedsl")
         no_env = toolchains.Toolchain()
         self.assertIsNone(no_env.ARCH_ENV_VAR)
+        with _no_ambient_arch(device="sm_100"):
+            self.assertEqual(export._effective_arch(None, cutedsl), "sm_100")
+            self.assertEqual(export._effective_arch(None, no_env), "sm_100")
+            self.assertEqual(export._effective_arch(None), "sm_100")
+        # An explicit arch wins for every kind alike.
         with mock.patch.dict(os.environ, {"CUTE_DSL_ARCH": "sm_90a"}):
-            self.assertEqual(export._effective_arch(None, cutedsl), "sm_90a")
-            self.assertIsNone(export._effective_arch(None, no_env))
-            # An explicit arch always wins over the env var.
             self.assertEqual(export._effective_arch("sm_100a", cutedsl), "sm_100a")
+            self.assertEqual(export._effective_arch("sm_100a", no_env), "sm_100a")
 
-    def test_job_skip_sees_the_arch_env_var(self):
-        # Two runs into ONE --out-dir differing only in CUTE_DSL_ARCH. Both
-        # pass arch=None, so comparing the raw value would match on spec
-        # alone and skip the second run -- leaving the first arch's objects
-        # behind a sidecar the caller reads as the second arch.
-        import unittest.mock as mock
+    def test_arch_tag_is_short(self):
+        # The tag lands in every exported C symbol, so its shape is part of
+        # the artifact ABI: one underscore dropped, nothing else.
+        self.assertEqual(export._arch_tag("sm_100a"), "sm100a")
+        self.assertEqual(export._arch_tag("sm_90"), "sm90")
 
-        rel = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-            export.REPO,
-        )
-        current = {rel: export._file_hash(os.path.join(export.REPO, rel))}
+    def test_an_arch_env_var_without_explicit_arch_is_refused(self):
+        # An arch variable is PER KIND, so it answers only for kinds that declare
+        # one: with CUTE_DSL_ARCH=sm_90a set, a tree named sm_90a held a sidecar
+        # recording the DETECTED sm_100 for a kind with no variable -- and
+        # generation filters by directory while the gate comes from the sidecar.
+        # Refusing leaves one arch=None path that every kind answers identically.
+        class _Other(toolchains.Toolchain):
+            kind = "other"
+            ARCH_ENV_VAR = "OTHER_DSL_ARCH"
+
+        registry = dict(toolchains.TOOLCHAINS, other=_Other())
+        with (
+            mock.patch.dict(toolchains.TOOLCHAINS, registry, clear=True),
+            mock.patch.dict(
+                os.environ, {"CUTE_DSL_ARCH": "sm_90a", "OTHER_DSL_ARCH": "sm_100a"}
+            ),
+            mock.patch.object(export, "_detected_arch", return_value=None),
+        ):
+            # Named in the message so the user knows WHICH variable to unset, and
+            # both are named when both are set.
+            with self.assertRaisesRegex(RuntimeError, "CUTE_DSL_ARCH=sm_90a"):
+                export._effective_arch(None)
+            with self.assertRaisesRegex(RuntimeError, "OTHER_DSL_ARCH=sm_100a"):
+                export._effective_arch(None)
+            # Agreeing values are refused too: the point is not a conflict
+            # between them, it is that neither can speak for the other kinds.
+            with mock.patch.dict(os.environ, {"OTHER_DSL_ARCH": "sm_90a"}):
+                with self.assertRaisesRegex(RuntimeError, "--arch"):
+                    export._effective_arch(None)
+            # An explicit --arch is the way to say it, for every kind at once.
+            self.assertEqual(export._effective_arch("sm_100a"), "sm_100a")
+
+    def test_export_prefix_is_arch_qualified(self):
+        # Two arches must not produce the same prefix: the exported symbols
+        # (cute_dsl_<prefix>_wrapper, <prefix>_Kernel_Module_Load) are derived
+        # from it, so an unqualified prefix is a duplicate definition when both
+        # arches link into one libtorch_cuda.
+        seen = []
+
+        class _FakeTc(toolchains.Toolchain):
+            kind = "cutedsl"
+            artifact_exts = (".o", ".h")
+            # So the sidecar's recorded compiler versions are non-empty below.
+            RUNTIME_DISTS = ("nvidia-cutlass-dsl",)
+
+            def missing_runtimes(self):
+                return []
+
+            def validate_build_result(self, b):
+                pass
+
+            def export(self, b, out_dir, arch=None):
+                seen.append(b["prefix"])
+                _touch_artifacts(out_dir, b["prefix"])
+                return {"tensor_args": []}
+
+        fake = _FakeTc()
+        with tempfile.TemporaryDirectory() as d:
+            with (
+                mock.patch.object(
+                    export,
+                    "load_builder",
+                    return_value=lambda p: {"prefix": "k", "kind": "cutedsl"},
+                ),
+                mock.patch.object(toolchains, "get_toolchain", return_value=fake),
+            ):
+                for arch in ("sm_90a", "sm_100a"):
+                    export.export_point("fakeop", "aot_kernel.py", {"n": 1}, d, arch)
+                self.assertEqual(seen, ["k__sm90a", "k__sm100a"])
+                # The sidecar WRITER, against what the readers require. It had
+                # no test: deleting "version" and "arch" from what export_point
+                # writes left the suite green, since every reader passes against
+                # hand-written fixtures. Asserted inside the patch, so the same
+                # toolchain answers here as when the file was written.
+                with open(os.path.join(d, "k__sm100a.json")) as f:
+                    written = json.load(f)
+                self.assertEqual(written["version"], export.SIDECAR_VERSION)
+                self.assertEqual(written["arch"], "sm_100a")
+                self.assertEqual(written["kind"], "cutedsl")
+                self.assertEqual(written["prefix"], "k__sm100a")
+                self.assertEqual(written["spec"], {"n": 1})
+                self.assertTrue(written["sources"], "no source closure recorded")
+                self.assertEqual(
+                    written["runtimes"], export.runtime_versions("cutedsl")
+                )
+                # ...and what it wrote is what the readers accept.
+                self.assertTrue(export.sources_current(written))
+                self.assertTrue(export.runtimes_current(written))
+
+    def test_job_skip_compares_the_arch(self):
+        # Two exports into ONE --out-dir differing only in arch: comparing spec
+        # alone would skip the second and leave the first arch's objects behind a
+        # sidecar the caller reads as the second arch.
         with tempfile.TemporaryDirectory() as d:
             point = {"dtype": "float32", "N": 4096}
             job = ("fakeop", "aot_kernel.py", point, d, None)
-            _touch_artifacts(d, "x")
-            with open(os.path.join(d, "x.json"), "w") as f:
-                json.dump(
-                    {
-                        "version": export.SIDECAR_VERSION,
-                        "prefix": "x",
-                        "kind": "cutedsl",
-                        "spec": point,
-                        "arch": "sm_90a",
-                        "sources": current,
-                    },
-                    f,
-                )
-            with mock.patch.dict(os.environ, {"CUTE_DSL_ARCH": "sm_90a"}):
-                self.assertFalse(export._job_needed(job, force=False))
-            with mock.patch.dict(os.environ, {"CUTE_DSL_ARCH": "sm_100a"}):
-                self.assertTrue(export._job_needed(job, force=False))
-            # Env var gone: an on-device export is not the sm_90a one either.
-            with mock.patch.dict(os.environ, {}, clear=True):
-                self.assertTrue(export._job_needed(job, force=False))
+            _write_sidecar(d, point, arch="sm_90a")
+            # _collect_jobs resolves the arch once and puts it in the job, so the
+            # comparison is job-vs-sidecar and needs no ambient variable.
+            with _no_ambient_arch():
+                same = ("fakeop", "aot_kernel.py", point, d, "sm_90a")
+                other = ("fakeop", "aot_kernel.py", point, d, "sm_100a")
+                self.assertFalse(export._job_needed(same, force=False))
+                self.assertTrue(export._job_needed(other, force=False))
+                # An on-device job (arch resolved from the device) is not the
+                # sm_90a one either.
+                with mock.patch.object(export, "_detected_arch", return_value="sm_100"):
+                    self.assertTrue(export._job_needed(job, force=False))
 
     def test_job_skip_rejects_arch_less_sidecar_when_env_set(self):
         # The reported case, from the other side: a sidecar that recorded no
         # arch at all (an on-device export) must NOT satisfy a run whose
         # CUTE_DSL_ARCH names a target, or the env-var run silently inherits
         # objects built for whatever the builder's GPU was.
-        import unittest.mock as mock
-
-        rel = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-            export.REPO,
-        )
-        current = {rel: export._file_hash(os.path.join(export.REPO, rel))}
         with tempfile.TemporaryDirectory() as d:
             point = {"dtype": "float32", "N": 4096}
             job = ("fakeop", "aot_kernel.py", point, d, None)
-            _touch_artifacts(d, "x")
-            with open(os.path.join(d, "x.json"), "w") as f:
-                json.dump(
-                    {
-                        "version": export.SIDECAR_VERSION,
-                        "prefix": "x",
-                        "kind": "cutedsl",
-                        "spec": point,
-                        "arch": None,
-                        "sources": current,
-                    },
-                    f,
-                )
-            with mock.patch.dict(os.environ, {"CUTE_DSL_ARCH": "sm_100a"}):
-                self.assertTrue(export._job_needed(job, force=False))
-            # ...while a genuine on-device re-run still skips.
-            with mock.patch.dict(os.environ, {}, clear=True):
+            _write_sidecar(d, point, arch=None)
+            with _no_ambient_arch():
+                named = ("fakeop", "aot_kernel.py", point, d, "sm_100a")
+                self.assertTrue(export._job_needed(named, force=False))
+                # ...and where an arch IS resolvable it does not satisfy an
+                # on-device run either: that run knows its arch, the sidecar names
+                # none. _detected_arch patched rather than trusted, so the claim
+                # does not depend on the runner having a GPU.
+                with mock.patch.object(export, "_detected_arch", return_value="sm_100"):
+                    self.assertTrue(export._job_needed(job, force=False))
+                # Only where no arch can be resolved at all is it a match.
                 self.assertFalse(export._job_needed(job, force=False))
 
     def test_archs_from_cuda_arch_list(self):
@@ -439,91 +573,6 @@ class TestArch(unittest.TestCase):
         self.assertEqual(
             export.expand_specs([{"N": 4096, "K": 64}]), [{"N": 4096, "K": 64}]
         )
-
-
-class TestSourceStaleness(unittest.TestCase):
-    def test_closure_covers_shared_declaration_machinery(self):
-        # The grid expander and the validating loader decide which spec
-        # points exist and what a declaration means, so editing them
-        # changes what an artifact MEANS. They live in torchgen (outside
-        # the tools/*.py glob) and arrive by ordinary import, so only the
-        # sys.modules half of the closure can catch them -- which used to
-        # filter on "torch._native" alone and silently missed them.
-        # Compared by basename: an editable install can resolve torchgen
-        # to a different checkout than REPO, and relpath then yields a
-        # ../.. traversal rather than the tidy repo-relative path.
-        names = {os.path.basename(p) for p in export.source_closure()}
-        for want in (
-            "native_aot_spec_grid.py",
-            "native_aot_decl.py",
-            "toolchains.py",
-        ):
-            self.assertIn(want, names, f"{want} must invalidate artifacts")
-
-    def test_closure_survives_sys_modules_mutation(self):
-        # source_closure hashes files while walking sys.modules, and
-        # hashing imports hashlib lazily -- so on a cold interpreter the
-        # walk mutates the dict it is iterating and raises "dictionary
-        # changed size during iteration". Force that ordering by having
-        # the hash step import a module that is definitely not loaded yet.
-        import sys
-        import unittest.mock as mock
-
-        real_hash = export._file_hash
-
-        def hash_and_import(path):
-            importlib.import_module("wave")  # stdlib, unlikely to be loaded
-            return real_hash(path)
-
-        sys.modules.pop("wave", None)
-        with mock.patch.object(export, "_file_hash", hash_and_import):
-            export.source_closure()
-
-    def test_sources_current_roundtrip(self):
-        # A sidecar whose recorded closure matches the tree is current;
-        # editing any recorded file (or recording none) makes it stale.
-        rel = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-            export.REPO,
-        )
-        h = export._file_hash(os.path.join(export.REPO, rel))
-        good = {"version": export.SIDECAR_VERSION, "sources": {rel: h}}
-        self.assertTrue(export.sources_current(good))
-        # schema-version mismatch is stale even with current sources
-        self.assertFalse(export.sources_current({"version": 0, "sources": {rel: h}}))
-        self.assertFalse(export.sources_current({"sources": {rel: "0" * 16}}))
-        self.assertFalse(export.sources_current({}))
-        self.assertFalse(export.sources_current({"sources": {"no/such/file.py": "aa"}}))
-
-    def test_stale_point_reexports_without_force(self):
-        import json as _json
-
-        with tempfile.TemporaryDirectory() as d:
-            point = {"dtype": "float32"}
-            job = ("fakeop", "aot_kernel.py", point, d, None)
-            rel = os.path.relpath(
-                os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-                export.REPO,
-            )
-            current = {rel: export._file_hash(os.path.join(export.REPO, rel))}
-            _touch_artifacts(d, "x")
-            with open(os.path.join(d, "x.json"), "w") as f:
-                _json.dump(
-                    {
-                        "version": export.SIDECAR_VERSION,
-                        "prefix": "x",
-                        "spec": point,
-                        "sources": current,
-                    },
-                    f,
-                )
-            self.assertFalse(export._job_needed(job, force=False))
-            _touch_artifacts(d, "x")
-            with open(os.path.join(d, "x.json"), "w") as f:
-                _json.dump(
-                    {"prefix": "x", "spec": point, "sources": {rel: "0" * 16}}, f
-                )
-            self.assertTrue(export._job_needed(job, force=False))
 
 
 class TestLauncherCodegen(unittest.TestCase):
@@ -997,6 +1046,131 @@ class TestAbiValidation(unittest.TestCase):
         toolchains.CuteDslToolchain().validate_abi(dict(SIDECAR, _dir="/nonexistent"))
 
 
+class TestReadOnlyInputs(unittest.TestCase):
+    # read_only tensor args must go through const_data_ptr in every
+    # toolchain's launcher: a mutable data_ptr() materializes
+    # copy-on-write inputs on each call.
+
+    def test_closure_covers_shared_declaration_machinery(self):
+        # The grid expander and the validating loader decide which spec
+        # points exist and what a declaration means, so editing them changes what
+        # an artifact MEANS. They live outside the tools/*.py glob and arrive by
+        # ordinary import, so only the sys.modules half of the closure catches
+        # them -- and it used to filter on "torch._native" alone.
+        #
+        # By basename: an editable install can resolve torchgen to a different
+        # checkout than REPO, where relpath yields a ../.. traversal.
+        names = {os.path.basename(p) for p in export.source_closure()}
+        for want in (
+            "native_aot_spec_grid.py",
+            "native_aot_decl.py",
+            "toolchains.py",
+        ):
+            self.assertIn(want, names, f"{want} must invalidate artifacts")
+
+    def test_closure_excludes_the_consumer_tools(self):
+        # Neither can change what an artifact MEANS, and hashing them is
+        # expensive in a way that is easy to miss: every kernel of every arch
+        # re-exports (minutes) for an edit that could not have changed one.
+        # gen_aot_lib.py only reads sidecars; build_stage2.py only decides
+        # whether stage 2 runs and then relinks -- export.py reads the arch
+        # list itself, so the driver passes it nothing kernel-affecting.
+        names = {os.path.basename(p) for p in export.source_closure()}
+        for unwanted in ("gen_aot_lib.py", "build_stage2.py"):
+            self.assertNotIn(unwanted, names)
+
+    def test_closure_survives_sys_modules_mutation(self):
+        # source_closure hashes files while walking sys.modules, and
+        # hashing imports hashlib lazily -- so on a cold interpreter the
+        # walk mutates the dict it is iterating and raises "dictionary
+        # changed size during iteration". Force that ordering by having
+        # the hash step import a module that is definitely not loaded yet.
+        import sys
+
+        real_hash = export._file_hash
+
+        def hash_and_import(path):
+            importlib.import_module("wave")  # stdlib, unlikely to be loaded
+            return real_hash(path)
+
+        sys.modules.pop("wave", None)
+        with mock.patch.object(export, "_file_hash", hash_and_import):
+            export.source_closure()
+
+    def test_runtimes_current_detects_a_compiler_upgrade(self):
+        # The DSL's version is in no file the closure hashes, so an upgraded
+        # wheel changes nothing on disk and without this re-exports nothing,
+        # leaving the tree mixing compilers.
+        #
+        # runtime_versions is PATCHED, not read from this machine: CI's image has
+        # no DSL wheels, where the live call is all-"absent" and runtimes_current
+        # takes its ignorance arm -- which left the comparison uncovered in CI.
+        current = {"nvidia-cutlass-dsl": "4.6.2", "apache-tvm-ffi": "0.1.11"}
+        with mock.patch.object(export, "runtime_versions", lambda kind: current):
+            self.assertTrue(
+                export.runtimes_current({"kind": "cutedsl", "runtimes": current})
+            )
+            older = dict.fromkeys(current, "0.0.1")
+            self.assertFalse(
+                export.runtimes_current({"kind": "cutedsl", "runtimes": older})
+            )
+            # A sidecar predating the record is stale, like one with no closure.
+            self.assertFalse(export.runtimes_current({"kind": "cutedsl"}))
+
+    def test_runtimes_current_does_not_call_ignorance_staleness(self):
+        # Generation may run where the DSL wheels are absent. Declaring every
+        # artifact stale there would fail a build that cannot re-export anyway.
+        with mock.patch.object(
+            export, "runtime_versions", lambda kind: {"nvidia-cutlass-dsl": "absent"}
+        ):
+            self.assertTrue(export.runtimes_current({"kind": "cutedsl"}))
+
+    def test_runtime_versions_reads_metadata_not_the_module(self):
+        # Distribution names, so the skip path never imports the DSL (importing
+        # cutlass pulls MLIR bindings in). The mapping is not derivable: module
+        # `cutlass` ships in the nvidia-cutlass-dsl distribution.
+        self.assertIn(
+            "nvidia-cutlass-dsl", toolchains.get_toolchain("cutedsl").RUNTIME_DISTS
+        )
+        versions = export.runtime_versions("cutedsl")
+        # Sorted keys, so two runs on one machine record byte-identical sidecars
+        # (a dict whose order drifts would compare unequal and re-export).
+        self.assertEqual(list(versions), sorted(versions))
+        self.assertEqual(
+            sorted(versions), sorted(toolchains.get_toolchain("cutedsl").RUNTIME_DISTS)
+        )
+        for dist, v in versions.items():
+            self.assertTrue(v, f"{dist} recorded an empty version")
+
+    def test_sources_current_roundtrip(self):
+        # A sidecar whose recorded closure matches the tree is current;
+        # editing any recorded file (or recording none) makes it stale.
+        rel = _DECL_REL
+        h = export._file_hash(os.path.join(export.REPO, rel))
+        good = {"version": export.SIDECAR_VERSION, "sources": {rel: h}}
+        self.assertTrue(export.sources_current(good))
+        # schema-version mismatch is stale even with current sources
+        self.assertFalse(export.sources_current({"version": 0, "sources": {rel: h}}))
+        self.assertFalse(export.sources_current({"sources": {rel: "0" * 16}}))
+        self.assertFalse(export.sources_current({}))
+        self.assertFalse(export.sources_current({"sources": {"no/such/file.py": "aa"}}))
+
+    def test_stale_point_reexports_without_force(self):
+        with tempfile.TemporaryDirectory() as d:
+            point = {"dtype": "float32"}
+            job = ("fakeop", "aot_kernel.py", point, d, None)
+            _write_sidecar(d, point)
+            with _no_ambient_arch():
+                self.assertFalse(export._job_needed(job, force=False))
+            _write_sidecar(d, point, sources={_DECL_REL: "0" * 16})
+            # Inside the guard like the call above: unguarded, the recorded arch
+            # (None) mismatched the DETECTED one and _job_needed answered True on
+            # that, never reaching staleness -- and with CUTE_DSL_ARCH set it
+            # raised instead.
+            with _no_ambient_arch():
+                self.assertTrue(export._job_needed(job, force=False))
+
+
 class TestToolchainRegistry(unittest.TestCase):
     def test_cutedsl_registered(self):
         self.assertIn("cutedsl", toolchains.TOOLCHAINS)
@@ -1025,8 +1199,21 @@ class TestDeclarationStaleness(unittest.TestCase):
             self.assertIn(rel, closure)
             self.assertEqual(closure[rel], export._file_hash(decl_path))
 
-    def test_source_closure_without_declaration_is_unchanged(self):
-        self.assertNotIn("aot.py", " ".join(export.source_closure()))
+    def test_source_closure_omits_a_declaration_not_passed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            decl_path = os.path.join(tmpdir, "aot.py")
+            with open(decl_path, "w") as f:
+                f.write("ATEN_OP = 'fake'\n")
+            # The closure records the declaration it is GIVEN, so one it was not
+            # given must be absent -- otherwise editing any aot.py anywhere would
+            # invalidate every other op's artifacts.
+            self.assertNotIn(
+                os.path.relpath(decl_path, export.REPO), export.source_closure()
+            )
+            self.assertIn(
+                os.path.relpath(decl_path, export.REPO),
+                export.source_closure(decl_path),
+            )
 
 
 class TestStaleGridPointArtifacts(unittest.TestCase):
@@ -1073,55 +1260,139 @@ class TestRegistryConsistency(unittest.TestCase):
         toolchains._assert_link_exts_are_exportable(toolchains.TOOLCHAINS)
 
 
+class TestClaimedSpellingPreference(unittest.TestCase):
+    def test_the_conditional_spelling_wins_when_both_are_claimed(self):
+        # Alphabetical order would pick sm_100 over sm_100a. The conditional one
+        # is what the generator's tie-break keeps for a capability, so exporting
+        # the plain build would pay a compile and then lose that tie-break.
+        both = ("sm_100", "sm_100a", "sm_90", "sm_90a")
+        self.assertEqual(export._claimed_spelling("sm_100", both), "sm_100a")
+        self.assertEqual(export._claimed_spelling("sm_100a", both), "sm_100a")
+        self.assertEqual(export._claimed_spelling("sm_90", both), "sm_90a")
+
+    def test_a_capability_that_is_not_claimed_has_no_spelling(self):
+        self.assertIsNone(export._claimed_spelling("sm_103", ("sm_100a",)))
+
+    def test_the_plain_spelling_is_used_when_it_is_the_only_claim(self):
+        # A declaration pinning the plain build must not be handed a conditional
+        # target its kernels were not written for.
+        self.assertEqual(export._claimed_spelling("sm_100a", ("sm_100",)), "sm_100")
+
+
+class TestSidecarSchemaIsReadFirst(unittest.TestCase):
+    """gen_aot_lib refuses a mismatched sidecar SCHEMA before reading any field,
+    because a different version need not mean the same thing by a name. The skip
+    check has to do the same: it read sc["kind"] first and raised a bare KeyError,
+    naming no file and no remedy, where the version field exists precisely so the
+    point re-exports."""
+
+    def _job(self, d, sidecar):
+        _touch_artifacts(d, "x")
+        with open(os.path.join(d, "x.json"), "w") as f:
+            json.dump(sidecar, f)
+        return (
+            "fakeop",
+            "aot_kernel.py",
+            {"dtype": "float32", "N": 4096},
+            d,
+            "sm_100a",
+        )
+
+    def _sidecar(self, **over):
+        sc = {
+            "version": export.SIDECAR_VERSION,
+            "prefix": "x",
+            "kind": "cutedsl",
+            "spec": {"dtype": "float32", "N": 4096},
+            "arch": "sm_100a",
+            "sources": _current_sources(),
+            "runtimes": _RUNTIMES,
+        }
+        sc.update(over)
+        return sc
+
+    def test_a_matching_sidecar_still_skips(self):
+        # The control: without it, "re-exports" below could be for any reason.
+        with tempfile.TemporaryDirectory() as d:
+            job = self._job(d, self._sidecar())
+            with _no_ambient_arch():
+                self.assertFalse(export._job_needed(job, force=False))
+
+    def test_a_sidecar_from_another_schema_re_exports(self):
+        with tempfile.TemporaryDirectory() as d:
+            job = self._job(d, self._sidecar(version=export.SIDECAR_VERSION + 1))
+            with _no_ambient_arch():
+                self.assertTrue(export._job_needed(job, force=False))
+
+    def test_a_sidecar_without_a_kind_re_exports_instead_of_raising(self):
+        sc = self._sidecar()
+        del sc["kind"]
+        with tempfile.TemporaryDirectory() as d:
+            job = self._job(d, sc)
+            with _no_ambient_arch():
+                self.assertTrue(export._job_needed(job, force=False))
+
+
+class TestSourceClosureCoversVendoredKernels(unittest.TestCase):
+    def test_a_loaded_vendored_module_is_hashed(self):
+        # torch/_vendor/quack/ holds real CuTeDSL kernel bodies, and a
+        # declaration's build() is meant to share code with its JIT wrapper. With
+        # the prefix missing, editing a vendored body left every artifact's
+        # closure unchanged, sources_current() True, and a relink shipping kernels
+        # compiled from the old source -- silently.
+        #
+        # REPO and _HERE both redirected into a temp tree: the first version of
+        # this test put its probe file under tools/native_aot/, which the closure
+        # hashes by GLOB whatever the prefixes say, so it passed with
+        # torch._vendor removed. The file has to sit where only the prefix reaches.
+        with tempfile.TemporaryDirectory() as root:
+            here = os.path.join(root, "tools", "native_aot")
+            vendored = os.path.join(root, "torch", "_vendor", "quack")
+            os.makedirs(here)
+            os.makedirs(vendored)
+            path = os.path.join(vendored, "rmsnorm.py")
+            with open(path, "w") as f:
+                f.write("# a stand-in for a vendored kernel body\n")
+            mod = types.ModuleType("torch._vendor.quack.rmsnorm")
+            mod.__file__ = path
+            with (
+                mock.patch.object(export, "REPO", root),
+                mock.patch.object(export, "_HERE", here),
+                mock.patch.dict(
+                    sys.modules, {"torch._vendor.quack.rmsnorm": mod}, clear=False
+                ),
+            ):
+                closure = export.source_closure()
+            rel = os.path.join("torch", "_vendor", "quack", "rmsnorm.py")
+            self.assertIn(rel, closure)
+            # ...and the recorded hash is the file's, so an edit invalidates it.
+            self.assertEqual(closure[rel], export._file_hash(path))
+
+
 class TestMissingArtifacts(unittest.TestCase):
     def test_missing_artifacts_reexport_despite_current_sidecar(self):
         # Sidecar matches spec/arch/sources, but its .o is gone: skipping
         # here surfaces as a missing include when torch_cuda compiles.
-        rel = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-            export.REPO,
-        )
-        current = {rel: export._file_hash(os.path.join(export.REPO, rel))}
         point = {"dtype": "float32", "N": 4096}
-        sidecar = {
-            "version": export.SIDECAR_VERSION,
-            "prefix": "x",
-            "spec": point,
-            "sources": current,
-            "kind": "cutedsl",
-        }
         with tempfile.TemporaryDirectory() as d:
             job = ("fakeop", "aot_kernel.py", point, d, None)
-            with open(os.path.join(d, "x.json"), "w") as f:
-                json.dump(sidecar, f)
-            _touch_artifacts(d, "x")
-            self.assertFalse(export._job_needed(job, force=False))
+            _write_sidecar(d, point)
+            with _no_ambient_arch():
+                self.assertFalse(export._job_needed(job, force=False))
 
-            os.remove(os.path.join(d, "x.o"))
-            self.assertTrue(export._job_needed(job, force=False))
+                os.remove(os.path.join(d, "x.o"))
+                self.assertTrue(export._job_needed(job, force=False))
 
     def test_missing_header_also_reexports(self):
-        rel = os.path.relpath(
-            os.path.join(os.path.dirname(__file__), "..", "native_aot", "decl.py"),
-            export.REPO,
-        )
-        current = {rel: export._file_hash(os.path.join(export.REPO, rel))}
         point = {"dtype": "float32", "N": 4096}
         with tempfile.TemporaryDirectory() as d:
             job = ("fakeop", "aot_kernel.py", point, d, None)
-            with open(os.path.join(d, "x.json"), "w") as f:
-                json.dump(
-                    {
-                        "version": export.SIDECAR_VERSION,
-                        "prefix": "x",
-                        "spec": point,
-                        "sources": current,
-                        "kind": "cutedsl",
-                    },
-                    f,
-                )
-            _touch_artifacts(d, "x", exts=(".o",))  # .h missing
-            self.assertTrue(export._job_needed(job, force=False))
+            _write_sidecar(d, point, exts=(".o",))  # .h missing
+            # _no_ambient_arch: the job resolves arch=None, so an exported
+            # CUTE_DSL_ARCH (this commit's Test Plan sets one) would refuse rather
+            # than answer, failing this test for a reason it is not about.
+            with _no_ambient_arch():
+                self.assertTrue(export._job_needed(job, force=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191669
* #190899
* #190898
* #190897
* #195877
* #194243
* #194242
* #194241
* #194240
* #194239
* __->__ #194238
* #190896

Human note:

There are lots of potential footguns in the process - compile w/one compiler, link
with another, perform linking w/one set of archs, but generated a different set, etc.

Encode all pertinent info into the sidecar so both sides of the contract know what's
happening.

Claude note:

The sidecar is all generation reads about an artifact, so this commit fixes what
it records -- the arch the kernels were really compiled for, and the compiler that
built them. The artifact layout is next.

_effective_arch is the single resolver (explicit --arch, then a toolchain's env
var, then the device), so a tree can never disagree with its own sidecars. An arch
env var without --arch is now refused: it is per-kind, and a tree named sm_90a
held a sidecar recording the detected sm_100. Prefixes gain an arch tag, because
every exported C symbol derives from the prefix and two arches sharing one are
duplicate definitions at link time.

The layout that belongs with that tag lands in the next commit, which nests
unconditionally. Until it does, a single-arch export still writes flat into
--out-dir, so two hand runs with different --arch values accumulate both trees
where the arch-free prefix overwrote -- stated in the module docstring as well.
No build path calls export before [7/7], so nothing exercises it.

The compiler is recorded because no file on disk names it: the DSL version appears
in nothing the source closure hashes, so upgrading the wheel invalidated nothing
and a tree quietly mixed artifacts from two compilers. torch._vendor joins the
closure for the same bug one level down -- the vendored packages hold real kernel
bodies. Sidecar reads are schema-first throughout, so a renamed field re-exports
instead of raising a bare KeyError naming no file.

Test Plan:

```
pytest tools/test/test_native_aot_tools.py
```

Run at this commit's own tree, in a checkout with no built torch -- which is
what lint.yml's "Test tools" job has. This commit's tests cover arch
resolution and the arch-tagged prefixes, the refusal of a per-kind arch env
var with no --arch, recorded-versus-installed compiler versions, and the
source closure covering vendored kernel bodies, schema-first sidecar reads
re-exporting instead of raising, and the arch-conditional spelling winning
where a declaration claims both.

Authored with an AI assistant (Claude Code).