### PR TITLE
[native_aot][3/7] export: one artifact tree per arch, orphan reporting, CLI

### DIFF
--- a/tools/native_aot/export.py
+++ b/tools/native_aot/export.py
@@ -386,20 +386,33 @@ def _collect_jobs(ops_filter, out_root: str, archs):
                 #     plain spelling, so a declaration pinning ('sm_100a',) got a
                 #     tree it disowned.
                 if arch is not None:
-                    # Validated even though the comparison below is by string:
-                    # cc_of is the only thing that rejects a malformed sm string,
-                    # and without it `--arch sm100a` matched no declaration and
-                    # exported nothing at exit 0 -- a typo that looked like success.
-                    decl.cc_of(layout_arch)
+                    # main() has already refused an --arch outside KNOWN_ARCHES, so
+                    # the string comparison below is against a spelling that parses.
                     claims = decl.archs_of(d)
                     if layout_arch not in claims:
-                        # Claiming this CAPABILITY under another spelling is always a
-                        # mistake, so it is reported HERE, per arch. The misses
-                        # collected below are suppressed once the declaration ships
-                        # for any arch, which hid exactly this case: the matched
-                        # arches embed and pass the post-relink check while every
-                        # device of the missed capability falls back to aten, with
-                        # nothing in the build log.
+                        # REPORTED, not refused: the two spellings are distinct
+                        # nvcc targets for one piece of hardware, so a declaration
+                        # pinning "sm_100a" is stating that its kernels need the
+                        # arch-conditional target, and a plain-10.0 build genuinely
+                        # cannot use them. Falling back to aten is the right answer
+                        # there; what is worth saying out loud is that this build
+                        # asked for a capability the declaration covers under the
+                        # other name.
+                        #
+                        # Reported HERE, per arch, because the whole-declaration
+                        # misses collected below are suppressed once the declaration
+                        # ships for ANY arch -- which hid exactly this case: the
+                        # matched arches embed and pass the post-relink check while
+                        # every device of the missed capability falls back to aten,
+                        # with nothing in the build log.
+                        #
+                        # The asymmetry to know about: archs_from_cuda_arch_list
+                        # collapses a capability to the CONDITIONAL spelling, so a
+                        # declaration pinning only the plain one loses under a
+                        # release list naming both, even though plain-target kernels
+                        # would run on the conditional build. Matching by capability
+                        # instead would need the tree name and the declaration's
+                        # claim to disagree, which generation filters on.
                         other = _claimed_spelling(layout_arch, claims)
                         if other:
                             print(
@@ -664,10 +677,10 @@ def archs_from_cuda_arch_list(arch_list: str) -> list[str]:
         major, _, minor = entry.removesuffix("+PTX").partition(".")
         suffix = "a" if minor.endswith("a") else ""
         minor = minor.removesuffix("a")
-        # str.isdigit accepts a non-ASCII digit that int() then rejects, so an
-        # entry like "\N{SUPERSCRIPT TWO}.0" raises rather than being skipped. Kept
-        # as-is: no release arch list holds one, and \d would behave identically.
-        if not (major.isdigit() and minor.isdigit()):
+        # isascii too: str.isdigit is Unicode-aware, so an Arabic-Indic or
+        # full-width digit satisfies it AND converts, which torchgen's sm parsing
+        # rejects for the same reason.
+        if not all(p.isascii() and p.isdigit() for p in (major, minor)):
             continue  # named arch ("Hopper") or malformed: skip
         sm = f"sm_{int(major) * 10 + int(minor)}{suffix}"
         if sm in EXPORTABLE_ARCHES and sm not in out:
@@ -733,6 +746,21 @@ def main(argv: list[str] | None = None) -> None:
         "explicit GPUTarget). Default: detect from the local device.",
     )
     args = parser.parse_args(argv)
+    # An explicit --arch is checked HERE, before anything reads the disk. The same
+    # check used to sit three loops deep (inside the per-declaration, per-arch walk),
+    # where a tree with no declaration never reached it: `--arch sm100a` then matched
+    # nothing and exited 0, the typo-that-looks-like-success this refuses.
+    #
+    # TORCH_CUDA_ARCH_LIST is FILTERED a few lines below rather than refused, because
+    # a release list names arches AOT does not ship (7.5, 8.6) and must not fail the
+    # build for naming them.
+    for named_arch in args.arch or ():
+        if named_arch not in decl.KNOWN_ARCHES:
+            raise RuntimeError(
+                f"--arch {named_arch} is not an arch this tooling knows "
+                f"({' '.join(decl.KNOWN_ARCHES)}). To target another, add it there "
+                f"and give the declaration an ARCHS entry naming it."
+            )
     if args.jobs is None:
         env_jobs = os.getenv("MAX_JOBS") or os.getenv("CMAKE_BUILD_PARALLEL_LEVEL")
         # Half the CPU count, not all of it: os.cpu_count() reports SMT

--- a/tools/native_aot/export.py
+++ b/tools/native_aot/export.py
@@ -389,29 +389,11 @@ def _collect_jobs(ops_filter, out_root: str, archs):
                     # the string comparison below is against a spelling that parses.
                     claims = decl.archs_of(d)
                     if layout_arch not in claims:
-                        # REPORTED, not refused: the two spellings are distinct
-                        # nvcc targets for one piece of hardware, so a declaration
-                        # pinning "sm_100a" is stating that its kernels need the
-                        # arch-conditional target, and a plain-10.0 build genuinely
-                        # cannot use them. Falling back to aten is the right answer
-                        # there; what is worth saying out loud is that this build
-                        # asked for a capability the declaration covers under the
-                        # other name.
-                        #
-                        # Reported HERE, per arch, because the whole-declaration
-                        # misses collected below are suppressed once the declaration
-                        # ships for ANY arch -- which hid exactly this case: the
-                        # matched arches embed and pass the post-relink check while
-                        # every device of the missed capability falls back to aten,
-                        # with nothing in the build log.
-                        #
-                        # The asymmetry to know about: archs_from_cuda_arch_list
-                        # collapses a capability to the CONDITIONAL spelling, so a
-                        # declaration pinning only the plain one loses under a
-                        # release list naming both, even though plain-target kernels
-                        # would run on the conditional build. Matching by capability
-                        # instead would need the tree name and the declaration's
-                        # claim to disagree, which generation filters on.
+                        # REPORTED, not refused: the spellings are distinct nvcc
+                        # targets, so a declaration pinning one cannot serve a build
+                        # compiled for the other, and aten is the right answer there.
+                        # Per arch, because the whole-declaration misses below are
+                        # suppressed once anything ships -- which hid this case.
                         other = _claimed_spelling(layout_arch, claims)
                         if other:
                             print(
@@ -447,9 +429,6 @@ def _collect_jobs(ops_filter, out_root: str, archs):
     shipped = {os.path.basename(j[3]) for j in jobs}
     for did, missed in sorted(skipped.items()):
         if did not in shipped:
-            # The declaration's OWN ARCHS, not an illustration: a fixed example
-            # contradicted the case at hand (it read "an ARCHS of ('sm_100a',)" for a
-            # declaration claiming sm_100), which sends the reader the wrong way.
             print(
                 f"{did}: declares kernels but none for this build -- requested "
                 f"{' '.join(missed)}, and the declaration's ARCHS "
@@ -694,31 +673,10 @@ def archs_from_cuda_arch_list(arch_list: str) -> list[str]:
     return [a for a in out if a.endswith("a") or a not in conditional]
 
 
-# Which TORCH_CUDA_ARCH_LIST entries are ELIGIBLE for AOT kernels on the
-# automatic export path. A filter, never a build list: it cannot cause an
-# export, only permit one, and an explicit --arch bypasses it. So a list
-# with no eligible entry exports nothing and stage 2 skips, printing why.
-#
-# Distinct from a declaration's ARCHS (what the KERNELS support, sm_90+);
-# this says what the standard build SHIPS. Both spellings of a capability are
-# listed because they are distinct nvcc targets used by different builds for
-# the same hardware -- "10.0a" (arch-conditional, needed by tcgen05/wgmma) in
-# b200-native-aot.yml, plain "10.0" elsewhere and in the manywheel lists.
-# Omitting either silently exports nothing there.
-#
-# WHICH capabilities, and what admitting one costs: every entry a build's arch
-# list names is another full set of compiled kernels inside its libtorch_cuda
-# (one duplicate arch measured 54 objects / 3.5 MiB), and past this filter the
-# DSL runtimes stop being optional -- build_stage2.should_run reads this tuple to
-# decide whether stage 2 runs at all, so a box whose GPU is listed here and whose
-# wheels are missing fails the build instead of skipping. Hopper is listed
-# because every release arch list names 9.0 and the default ARCHS already covers
-# it; no CI job exercises AOT kernels there yet -- the one functional AOT job in
-# this stack runs on B200 and arrives with the first declaration -- so Hopper's
-# coverage is this suite plus that Blackwell job. sm_103
-# stays absent because no arch list we see names 10.3, and adding it would only
-# grow wheels.
-EXPORTABLE_ARCHES = ("sm_90", "sm_90a", "sm_100", "sm_100a")
+# Re-exported: build_stage2 and the tests read the shipped-arch set off the exporter.
+# DEFINED beside the set this tooling can target (torchgen.native_aot_decl), so the
+# two cannot drift; a list with no eligible entry exports nothing and stage 2 skips.
+EXPORTABLE_ARCHES = decl.EXPORTABLE_ARCHES
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tools/native_aot/export.py
+++ b/tools/native_aot/export.py
@@ -8,7 +8,8 @@ torch-free at module scope, since torchgen loads those during stage 1.
 
 For each ``torch/_native/ops/<op>/aot.py``, expands the spec grid (list
 fields cross-multiply) and for every grid point runs the toolchain's
-compile + export into ``<out-dir>/<op>/``, writing:
+compile + export into ``<out-dir>/<arch>/<op>/`` -- one tree per arch,
+whatever the arch count -- writing:
 
     <prefix>.h / <prefix>.o    C-ABI header + kernel object
     <prefix>.json              marshalling sidecar {spec, arch, tensor_args}
@@ -315,13 +316,23 @@ def export_point(
 def _collect_jobs(ops_filter, out_root: str, archs):
     """(op_pkg, kernel_module, point, out_dir, arch) per spec point per
     arch across every declaration; grids expand here (cheap,
-    torch-light), skip detection is _job_needed's sidecar scan. A
-    single arch (or None = detect from the local device) keeps the flat
-    <out-root>/<decl_id>/ layout; a multi-arch fan-out nests
-    <out-root>/<arch>/<decl_id>/ so per-arch artifact trees stay
-    independently gen-able and linkable."""
+    torch-light), skip detection is _job_needed's sidecar scan.
+
+    ONE layout whatever the arch count: <out-root>/<arch>/<decl_id>/, so adding
+    an arch is another directory rather than a different shape. A per-count layout
+    left the other shape's tree behind when a build switched between one arch and
+    several, and the same arch then appeared twice for one declaration
+    (gen_aot_lib's duplicate-prefix check stays as a backstop).
+
+    The generated .cpp sits at <out-root>/<decl_id>/, covering all of them."""
     jobs = []
-    multi = len(archs) > 1
+    # Declarations that matched NO requested arch, reported at the end: an ARCHS
+    # of only conditional spellings ships nothing for a release list of plain ones,
+    # and with several declarations the result is partial but looks healthy -- the
+    # matched ops embed and pass the post-relink check while the rest are simply
+    # absent, with no tree for generation to complain about.
+    skipped: dict[str, list[str]] = {}
+    declared: dict[str, tuple[str, ...]] = {}
     for entry in sorted(os.listdir(OPS_DIR)):
         op_dir = os.path.join(OPS_DIR, entry)
         if not os.path.exists(os.path.join(op_dir, "aot.py")):
@@ -331,29 +342,72 @@ def _collect_jobs(ops_filter, out_root: str, archs):
             if ops_filter and entry not in ops_filter and d.ATEN_OP not in ops_filter:
                 continue
             for arch in archs:
-                # Declaration-level arch support: skip (declaration x
-                # arch) pairs the op's kernels are not valid on. An
-                # on-device export (arch None) is not filtered -- the
-                # builder machine is the target by construction.
-                if arch is not None and arch not in decl.archs_of(d):
-                    continue
-                # `multi` implies explicit sm strings (a [None] arch
-                # list is always length 1); the arch check narrows for
-                # the type checker.
-                root = os.path.join(out_root, arch) if multi and arch else out_root
-                out_dir = os.path.join(root, did)
+                # No unnamed layout: an artifact whose arch nobody can state
+                # cannot be matched to hardware by the runtime gate.
+                layout_arch = _effective_arch(arch)
+                if not layout_arch:
+                    raise RuntimeError(
+                        "cannot determine the arch to export for: no --arch "
+                        "given and no local GPU to detect from. Pass --arch "
+                        "(e.g. --arch sm_100a), which also lets export run on "
+                        "a machine without a GPU."
+                    )
+                # TWO paths, because this name is also what generation filters
+                # trees by (--archs, from the same list stage 2 passed here):
+                #
+                #   * an EXPLICIT arch is used verbatim, and a declaration not
+                #     claiming it is skipped. Resolving it to another spelling
+                #     named the tree something generation was never told about, so
+                #     it embedded nothing -- silently, since no sources reads as
+                #     "no declaration ships kernels". Every plain spelling in a
+                #     release arch list hit this.
+                #   * an ON-DEVICE arch adopts the spelling the declaration claims
+                #     for the detected capability, as the generator's tie-break
+                #     does. It passes no --archs, so it cannot desynchronize, and
+                #     it is the path that needed resolving: the device reports the
+                #     plain spelling, so a declaration pinning ('sm_100a',) got a
+                #     tree it disowned.
+                if arch is not None:
+                    # Validated even though the comparison below is by string:
+                    # cc_of is the only thing that rejects a malformed sm string,
+                    # and without it `--arch sm100a` matched no declaration and
+                    # exported nothing at exit 0 -- a typo that looked like success.
+                    decl.cc_of(layout_arch)
+                    if layout_arch not in decl.archs_of(d):
+                        skipped.setdefault(did, []).append(layout_arch)
+                        declared[did] = tuple(decl.archs_of(d))
+                        continue
+                else:
+                    claimed = _claimed_spelling(layout_arch, decl.archs_of(d))
+                    if claimed is None:
+                        continue
+                    layout_arch = claimed
+                out_dir = os.path.join(out_root, layout_arch, did)
                 os.makedirs(out_dir, exist_ok=True)
                 points = expand_specs(d.kernel_precompile_grid())
                 _check_no_orphan_artifacts(out_dir, points)
                 for point in points:
-                    jobs.append((entry, d.KERNEL_MODULE, point, out_dir, arch))
+                    # The arch is named for the COMPILE too, so artifacts are built
+                    # for what the sidecar records, not what the toolchain picks.
+                    jobs.append((entry, d.KERNEL_MODULE, point, out_dir, layout_arch))
+    shipped = {os.path.basename(j[3]) for j in jobs}
+    for did, missed in sorted(skipped.items()):
+        if did not in shipped:
+            # The declaration's OWN ARCHS, not an illustration: a fixed example
+            # contradicted the case at hand (it read "an ARCHS of ('sm_100a',)" for a
+            # declaration claiming sm_100), which sends the reader the wrong way.
+            print(
+                f"{did}: declares kernels but none for this build -- requested "
+                f"{' '.join(missed)}, and the declaration's ARCHS "
+                f"({' '.join(declared[did])}) names none of them, so this op falls back "
+                f"to aten. The spellings must match exactly."
+            )
     return jobs
 
 
-# Every "this tree is inconsistent" error ends the same way. `spin clean`
-# does clear the default --out-dir (build/ sits above .gitignore's
-# NOT-CLEAN-FILES marker), but it takes the whole build tree with it, so
-# name the surgical command first.
+# Every "this tree is inconsistent" error ends the same way. `spin clean` does
+# clear the default --out-dir, but takes the whole build tree with it, so the
+# surgical command comes first.
 _CLEAN_HINT = (
     "run `rm -rf {d}` and re-export (`spin clean` also clears it, "
     "along with the rest of the build tree)"
@@ -379,43 +433,69 @@ def _read_sidecar(path: str) -> dict:
         ) from e
 
 
-def _check_no_orphan_artifacts(out_dir: str, specs=None) -> None:
-    """Fail if a directory holds kernel artifacts no current grid point
-    claims.
+def _check_no_orphan_artifacts(out_dir: str, specs) -> None:
+    """Report or refuse kernel artifacts no current grid point claims.
 
-    Two ways that happens. Artifacts with NO sidecar at all: the sidecar is
-    the commit marker, so they mean an interrupted or hand-edited export.
-    Artifacts whose sidecar records a spec that is no longer in the grid:
-    dropping a point from kernel_precompile_grid() generates no job for it
-    and nothing prunes it. Either way the CMake globs link *.o by pattern,
-    so the object ships with no launcher referencing it -- exactly what this
-    check exists to prevent. An EMPTY directory is fine (clean build, or a
-    new spec point).
+    Two ways that happens, and they differ in how recoverable they are.
 
-    ``specs`` is the expanded grid for this (declaration, arch); None skips
-    the stale-point half, for callers that do not have the grid in hand.
+    Artifacts NO SIDECAR CLAIMS, beside points that did commit: an export that
+    died between writing them and writing its sidecar (a Ctrl-C, an OOM-killed
+    worker, a compile failure -- the DSL writes the .h before the .o, so even the
+    last of those strands one). REPORTED, not fatal: nothing links an artifact no
+    sidecar names, so the cost is disk, and a re-export of that point overwrites
+    it. As a refusal it turned every transient failure in a 48-point grid into a
+    hand-delete of the directory, which --force could not clear either -- this scan
+    runs before that flag is read.
+
+    An entire directory of them, with nothing committed: not an interrupt in a
+    live grid but a partial copy or a hand-edit, so the tree cannot be read at
+    all. Fatal.
+
+    Artifacts whose sidecar records a spec no longer in the grid: dropping a point
+    from kernel_precompile_grid() generates no job for it and nothing prunes it.
+    Fatal, because the sidecar makes it look exported.
+
+    An EMPTY directory is fine (clean build, or a new spec point).
+
+    ``specs`` is the expanded grid for this (declaration, arch).
     """
-    exts = {e for tc in toolchains.TOOLCHAINS.values() for e in tc.artifact_exts}
+    exts = toolchains.all_artifact_exts()
     names = os.listdir(out_dir)
-    if not any(n.endswith(".json") for n in names):
-        orphans = sorted(n for n in names if os.path.splitext(n)[1] in exts)
-        if orphans:
-            raise RuntimeError(
-                f"{out_dir}: kernel artifacts with no sidecar "
-                f"({', '.join(orphans[:4])}{', ...' if len(orphans) > 4 else ''}). "
-                f"The sidecar is written last, so this is an interrupted or "
-                f"hand-edited export; {_CLEAN_HINT.format(d=out_dir)}."
-            )
-        return
-    if specs is None:
-        return
-    live = [_json_normal(p) for p in specs]
-    stale = sorted(
-        fn
-        for fn in names
-        if fn.endswith(".json")
-        and _read_sidecar(os.path.join(out_dir, fn)).get("spec") not in live
+    # Per artifact, not per directory: an interrupt lands among points that already
+    # committed, so "does this directory hold any sidecar" would see nothing wrong.
+    claimed = {os.path.splitext(n)[0] for n in names if n.endswith(".json")}
+    orphans = sorted(
+        n
+        for n in names
+        if os.path.splitext(n)[1] in exts and os.path.splitext(n)[0] not in claimed
     )
+    if orphans:
+        listed = f"{', '.join(orphans[:4])}{', ...' if len(orphans) > 4 else ''}"
+        if not claimed:
+            raise RuntimeError(
+                f"{out_dir}: kernel artifacts with no sidecar ({listed}). "
+                f"The sidecar is written last and this directory holds none, so it "
+                f"is a partial copy or a hand-edited export, not an interrupted one; "
+                f"{_CLEAN_HINT.format(d=out_dir)}."
+            )
+        print(
+            f"{out_dir}: {len(orphans)} artifact(s) no sidecar claims ({listed}); an "
+            f"export died before committing them. Not linked -- a re-export of that "
+            f"point overwrites them, or delete the directory to reclaim the disk."
+        )
+    live = [_json_normal(p) for p in specs]
+
+    def _is_stale(fn: str) -> bool:
+        sc = _read_sidecar(os.path.join(out_dir, fn))
+        # SCHEMA FIRST, as everywhere: "spec" is read by name, and a bump that
+        # changed its representation would make the first export in an existing
+        # tree demand `rm -rf` rather than re-export. Another schema is not
+        # stale, it is unreadable.
+        if sc.get("version") != SIDECAR_VERSION:
+            return False
+        return sc.get("spec") not in live
+
+    stale = sorted(fn for fn in names if fn.endswith(".json") and _is_stale(fn))
     if stale:
         raise RuntimeError(
             f"{out_dir}: sidecars for spec points no longer in the grid "
@@ -525,49 +605,51 @@ def archs_from_cuda_arch_list(arch_list: str) -> list[str]:
     """TORCH_CUDA_ARCH_LIST -> the sm strings from it that are
     EXPORTABLE_ARCHES, order-preserving and deduplicated.
 
-    "9.0a;10.0a" (or space-separated) -> ["sm_100a"]. A +PTX suffix is
-    stripped; named entries ("Hopper") are not translated -- callers
-    should pass numeric lists (CI does). Dedup matters: "10.0;10.0+PTX" names
-    one arch twice, and a repeated entry would otherwise read as
-    multi-arch downstream (nested artifact layout, --jobs > 1)."""
+    "9.0a;10.0a" (or space-separated) -> ["sm_100a"]. A +PTX suffix is stripped;
+    named entries ("Hopper") are not translated, and CI passes numeric lists.
+    Dedup matters because "10.0;10.0+PTX" names one arch twice, which would read
+    as multi-arch downstream.
+
+    ONE arch per compute capability, preferring the arch-conditional spelling:
+    "10.0;10.0a" is one piece of hardware, and exporting both builds two full sets
+    of which generation uses one (_by_arch prefers the conditional, what the
+    kernels were written against). The loser is more than wasted compile time --
+    it used to ship inside libtorch_cuda with no launcher (54 objects / 3.5 MiB
+    measured). CUDA 13.x manywheel lists reach here, so this is the common case."""
     out = []
     for entry in arch_list.replace(";", " ").split():
-        entry = entry.removesuffix("+PTX")
-        parts = entry.split(".")
-        if len(parts) != 2 or not parts[0].isdigit():
-            continue  # named arch ("Hopper") or malformed: skip
-        minor = parts[1]
+        major, _, minor = entry.removesuffix("+PTX").partition(".")
         suffix = "a" if minor.endswith("a") else ""
-        minor_num = minor.removesuffix("a")
-        if not minor_num.isdigit():
-            continue
-        sm = f"sm_{int(parts[0]) * 10 + int(minor_num)}{suffix}"
+        minor = minor.removesuffix("a")
+        # str.isdigit accepts a non-ASCII digit that int() then rejects, so an
+        # entry like "\N{SUPERSCRIPT TWO}.0" raises rather than being skipped. Kept
+        # as-is: no release arch list holds one, and \d would behave identically.
+        if not (major.isdigit() and minor.isdigit()):
+            continue  # named arch ("Hopper") or malformed: skip
+        sm = f"sm_{int(major) * 10 + int(minor)}{suffix}"
         if sm in EXPORTABLE_ARCHES and sm not in out:
             out.append(sm)
-    return out
+    # Collapse per capability, keeping the conditional spelling wherever the
+    # list named it. Order-preserving on the survivors.
+    conditional = {a.removesuffix("a") for a in out if a.endswith("a")}
+    return [a for a in out if a.endswith("a") or a not in conditional]
 
 
 # Which TORCH_CUDA_ARCH_LIST entries are ELIGIBLE for AOT kernels on the
-# automatic export path. A filter, never a build list: it cannot cause an
-# export, only permit one, and an explicit --arch bypasses it. So a list
-# with no eligible entry exports nothing and stage 2 skips, printing why.
+# automatic path. A filter, never a build list: it permits an export, never
+# causes one, and an explicit --arch bypasses it -- so a list with no eligible
+# entry exports nothing and stage 2 skips, printing why. Distinct from a
+# declaration's ARCHS, which is what the KERNELS support.
 #
-# Distinct from a declaration's ARCHS (what the KERNELS support, sm_90+);
-# this says what the standard build SHIPS. Both spellings of a CC are
-# listed because they are distinct nvcc targets used by different builds
-# for the same hardware -- "10.0a" (arch-conditional, needed by
-# tcgen05/wgmma) in b200-native-aot.yml, plain "10.0" elsewhere and in the
-# manywheel lists. Omitting either silently exports nothing there.
-#
-# sm_103/sm_103a are deliberately absent: nothing names 10.3, sm_100 SASS
-# is forward-compatible to it, and _arch_gate compares only the CUDA
-# major -- so an sm_103 artifact would pass the gate on a 10.0 device and
-# then fail the module load instead of declining. Re-add with a
-# major+minor gate.
-EXPORTABLE_ARCHES = ("sm_100", "sm_100a")
+# Both spellings of a capability are listed because they are distinct nvcc
+# targets used by different builds for the same hardware ("10.0a" in
+# b200-native-aot.yml, plain "10.0" in the manywheel lists), and omitting either
+# silently exports nothing there. sm_103 stays absent because no arch list we see
+# names 10.3, and adding it would only grow wheels.
+EXPORTABLE_ARCHES = ("sm_90", "sm_90a", "sm_100", "sm_100a")
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out-dir", default=os.path.join(REPO, "build", "native_aot"))
     parser.add_argument(
@@ -580,10 +662,9 @@ def main() -> None:
         "--jobs",
         type=int,
         default=None,
-        help="parallel compile processes (forkserver). Default follows "
-        "the torch build's parallelism: MAX_JOBS, then "
-        "CMAKE_BUILD_PARALLEL_LEVEL, then half the CPU count -- the same "
-        "pair pyproject.toml's [tool.scikit-build.env] hands to cmake.",
+        help="parallel compile processes (forkserver). Default follows the "
+        "torch build: MAX_JOBS, then CMAKE_BUILD_PARALLEL_LEVEL, then half the "
+        "CPU count.",
     )
     parser.add_argument(
         "--arch",
@@ -591,30 +672,26 @@ def main() -> None:
         default=None,
         metavar="SM",
         help="target architecture(s), e.g. --arch sm_90a sm_100a. With an "
-        "explicit arch, export never touches the CUDA driver and runs on "
-        "GPU-less machines (CuTeDSL via --gpu-arch; Triton via an "
-        "explicit GPUTarget). Default: detect from the local device. "
-        "Multiple archs nest artifacts under <out-dir>/<arch>/.",
+        "explicit arch export never touches the CUDA driver, so it runs on "
+        "GPU-less machines. Default: detect from the local device.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.jobs is None:
         env_jobs = os.getenv("MAX_JOBS") or os.getenv("CMAKE_BUILD_PARALLEL_LEVEL")
-        # Half the CPU count, not all of it: os.cpu_count() reports SMT
-        # siblings, and one compile per virtual thread oversubscribes.
+        # Half the CPU count: os.cpu_count() reports SMT siblings, and one
+        # compile per virtual thread oversubscribes.
         args.jobs = int(env_jobs) if env_jobs else max(1, (os.cpu_count() or 2) // 2)
     if args.arch is None and os.getenv("TORCH_CUDA_ARCH_LIST"):
-        # Standard-build integration: export for the Blackwell subset of
-        # the architectures the main build compiled for (the wheel may
-        # run on machines unlike the builder). Explicit --arch wins.
+        # Standard-build integration: export for the exportable subset of what
+        # the main build compiled for. Explicit --arch wins.
         args.arch = archs_from_cuda_arch_list(os.environ["TORCH_CUDA_ARCH_LIST"])
-        if args.arch:
-            print(f"arch from TORCH_CUDA_ARCH_LIST: {' '.join(args.arch)}")
-        else:
+        if not args.arch:
             print(
                 "TORCH_CUDA_ARCH_LIST contains no AOT-exportable arch "
                 f"(exportable: {' '.join(EXPORTABLE_ARCHES)}); nothing to export"
             )
             return
+        print(f"arch from TORCH_CUDA_ARCH_LIST: {' '.join(args.arch)}")
     archs = args.arch if args.arch else [None]
     jobs = _collect_jobs(args.ops, args.out_dir, archs)
     todo = [j for j in jobs if _job_needed(j, args.force)]
@@ -628,9 +705,8 @@ def main() -> None:
             print(f"  {prefix}: exported")
             total += 1
     else:
-        # ONE pool over every (point, arch) job: each toolchain takes its
-        # arch per compile (CuTeDSL --gpu-arch, Triton a fixed GPUTarget),
-        # so no process is pinned to an arch and mixed jobs pack freely.
+        # ONE pool over every (point, arch) job: the arch is per-compile state,
+        # so no process is pinned to one and mixed jobs pack freely.
         import multiprocessing
         from concurrent.futures import as_completed, ProcessPoolExecutor
 

--- a/tools/test/test_native_aot_tools.py
+++ b/tools/test/test_native_aot_tools.py
@@ -826,23 +826,6 @@ class TestSidecarIntegrity(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "could not be read"):
                 export._read_sidecar(path)
 
-    def test_cross_product(self):
-        pts = export.expand_specs(
-            [{"dtype": ["float32", "bfloat16"], "N": [1024, 2048], "K": 8}]
-        )
-        self.assertEqual(len(pts), 4)
-        self.assertIn({"dtype": "float32", "N": 2048, "K": 8}, pts)
-        self.assertIn({"dtype": "bfloat16", "N": 1024, "K": 8}, pts)
-
-    def test_multiple_blocks_concatenate(self):
-        pts = export.expand_specs([{"N": [1, 2]}, {"N": 3, "extra": True}])
-        self.assertEqual(pts, [{"N": 1}, {"N": 2}, {"N": 3, "extra": True}])
-
-    def test_scalar_only_spec(self):
-        self.assertEqual(
-            export.expand_specs([{"N": 4096, "K": 64}]), [{"N": 4096, "K": 64}]
-        )
-
 
 # mX with one size and one stride slot, and with none at all: the two claims the
 # per-argument checks are made against, with SIDECAR's own mOut beside them.
@@ -1763,6 +1746,25 @@ class TestExportMain(unittest.TestCase):
 
 
 class TestCollectJobsRefusals(unittest.TestCase):
+    def test_an_unknown_arch_is_refused_before_the_ops_walk(self):
+        # THE case the old placement could not reach: with no declaration on disk
+        # the per-declaration walk never ran, so `--arch sm100a` matched nothing and
+        # exited 0. That is the state of this tree until a declaration lands, and it
+        # is what a --ops typo looks like forever.
+        with (
+            tempfile.TemporaryDirectory() as ops,
+            tempfile.TemporaryDirectory() as out,
+        ):
+            with mock.patch.object(export, "OPS_DIR", ops):
+                self.assertEqual(os.listdir(ops), [], "no declaration on disk")
+                for bad in ("sm100a", "SM_100", "sm_1000", "sm_86", "90"):
+                    with self.subTest(arch=bad):
+                        with self.assertRaisesRegex(RuntimeError, "not an arch"):
+                            export.main(["--arch", bad, "--out-dir", out])
+                # ...and a known arch gets past the check (it exports nothing here,
+                # which is the honest answer for a tree with no declarations).
+                export.main(["--arch", "sm_100a", "--out-dir", out])
+
     def test_an_unnameable_arch_is_refused(self):
         # There is no unnamed layout: an artifact whose arch nobody can state is
         # one the runtime gate cannot match to hardware. Untested before --

--- a/tools/test/test_native_aot_tools.py
+++ b/tools/test/test_native_aot_tools.py
@@ -607,6 +607,15 @@ class TestArch(unittest.TestCase):
         self.assertEqual(f("10.0;10.0+PTX"), ["sm_100"])
         self.assertEqual(f("10.0a 10.0a"), ["sm_100a"])
 
+    def test_the_shipped_arches_are_ones_the_tooling_can_target(self):
+        # The two sets live beside each other so they cannot drift; the import-time
+        # check is what makes that true rather than merely intended.
+        self.assertLessEqual(
+            set(native_aot_decl.EXPORTABLE_ARCHES), set(native_aot_decl.KNOWN_ARCHES)
+        )
+        # ...and the exporter's name is the same object, not a copy that could age.
+        self.assertIs(export.EXPORTABLE_ARCHES, native_aot_decl.EXPORTABLE_ARCHES)
+
     def test_archs_from_cuda_arch_list_collapses_one_capability(self):
         # Both spellings of a capability are the same hardware, and generation
         # can only use one of them (_by_arch prefers the arch-conditional

--- a/tools/test/test_native_aot_tools.py
+++ b/tools/test/test_native_aot_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import io
 import json
 import os
 import sys
@@ -93,6 +94,21 @@ def _write_sidecar(d, point, prefix="x", exts=(".o", ".h"), **over):
     sc.update(over)
     with open(os.path.join(d, prefix + ".json"), "w") as f:
         json.dump(sc, f)
+
+
+def _write_fake_decl(ops_dir, archs_line="", grid="[{'N': 1}]"):
+    """One declaration under ops_dir/fakeop/, the minimum _collect_jobs loads:
+    one grid point and the two C++ hooks, whose text nothing here reads."""
+    os.makedirs(os.path.join(ops_dir, "fakeop"), exist_ok=True)
+    with open(os.path.join(ops_dir, "fakeop", "aot.py"), "w") as f:
+        f.write(
+            'ATEN_OP = "fakeop"\nDISPATCH_KEY = "CUDA"\nKERNEL_MODULE = "k.py"\n'
+            + archs_line
+            + f"def kernel_precompile_grid():\n    return {grid}\n"
+            "def covered_axes(self):\n    return {}\n"
+            "def cpp_dispatch(spec):\n    return 'true'\n"
+            "def cpp_launch(spec, launch_fn):\n    return launch_fn\n"
+        )
 
 
 def _touch_artifacts(out_dir, prefix, exts=(".o", ".h"), tensor_args=None):
@@ -453,43 +469,50 @@ class TestArch(unittest.TestCase):
         # malformed, +PTX and non-exportable entries drop out.
         f = export.archs_from_cuda_arch_list
         self.assertEqual(f("7.5 8.9"), [])
-        self.assertEqual(f("9.0a;10.0a"), ["sm_100a"])
-        self.assertEqual(f("8.0 9.0 10.0+PTX"), ["sm_100"])
+        # Hopper and Blackwell together: one tree per arch, selected at
+        # runtime by capability.
+        self.assertEqual(f("9.0a;10.0a"), ["sm_90a", "sm_100a"])
+        self.assertEqual(f("8.0 9.0 10.0+PTX"), ["sm_90", "sm_100"])
         # Both spellings of a CC are separate nvcc targets, and both are
         # exportable: CI passes "10.0a", the wheel builds pass "10.0".
         self.assertEqual(f("10.0"), ["sm_100"])
-        # 10.3 is not exportable while the runtime gate is major-only.
+        # 10.3 stays unexportable -- nothing names it, so shipping it would
+        # only grow wheels (the gate itself is major.minor and would be safe).
         self.assertEqual(f("Hopper 10.3a"), [])
 
     def test_archs_from_cuda_arch_list_dedups(self):
-        # "10.0;10.0+PTX" names one arch twice. Without dedup the result
-        # reads as multi-arch downstream: nested <out>/<arch>/ layout the
-        # one-level CMake globs do not walk, and a --jobs 1 hard exit.
+        # "10.0;10.0+PTX" names one arch twice; a repeated entry would read as
+        # multi-arch downstream and export a second full set of kernels.
         f = export.archs_from_cuda_arch_list
         self.assertEqual(f("10.0;10.0+PTX"), ["sm_100"])
         self.assertEqual(f("10.0a 10.0a"), ["sm_100a"])
-        # Distinct spellings are distinct targets, so both survive.
-        self.assertEqual(f("10.0;10.0a"), ["sm_100", "sm_100a"])
+
+    def test_archs_from_cuda_arch_list_collapses_one_capability(self):
+        # Both spellings of a capability are the same hardware, and generation
+        # can only use one of them (_by_arch prefers the arch-conditional
+        # build). Exporting both compiles a second full set of kernels whose
+        # objects then ship inside libtorch_cuda with no launcher referencing
+        # them. CUDA 13.x manywheel lists reach this, so it is the common case.
+        f = export.archs_from_cuda_arch_list
+        self.assertEqual(f("10.0;10.0a"), ["sm_100a"])
+        self.assertEqual(f("10.0a;10.0"), ["sm_100a"])
+        # Different capabilities are untouched, and order is preserved.
+        self.assertEqual(f("9.0a;10.0;10.0a"), ["sm_90a", "sm_100a"])
+        self.assertEqual(f("10.0a;9.0"), ["sm_100a", "sm_90"])
 
     def test_collect_jobs_respects_declaration_archs(self):
         # A declaration pinning ARCHS gets no jobs for other arches; an
         # on-device export (arch None) is never filtered.
-        import tempfile
-        import unittest.mock as mock
-
-        decl_body = (
-            'ATEN_OP = "fakeop"\nDISPATCH_KEY = "CUDA"\n'
-            'KERNEL_MODULE = "k.py"\nARCHS = ("sm_100a",)\n'
-            "def kernel_precompile_grid():\n    return [{'dtype': 'float32'}]\n"
-            "def covered_axes(self):\n    return {}\n"
-            "def cpp_dispatch(spec):\n    return 'true'\n"
-            "def cpp_launch(spec, launch_fn):\n    return launch_fn\n"
-        )
         with tempfile.TemporaryDirectory() as ops, tempfile.TemporaryDirectory() as out:
-            os.makedirs(os.path.join(ops, "fakeop"))
-            with open(os.path.join(ops, "fakeop", "aot.py"), "w") as f:
-                f.write(decl_body)
-            with mock.patch.object(export, "OPS_DIR", ops):
+            _write_fake_decl(ops, 'ARCHS = ("sm_100a",)\n')
+            # _detected_arch patched: the on-device call below resolves the
+            # directory from it, and an unpatched run would pass only on a
+            # machine with a GPU -- this suite must also pass in the linter
+            # image, which has no built torch at all.
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                _no_ambient_arch(device="sm_100a"),
+            ):
                 blackwell = export._collect_jobs(None, out, ["sm_100a"])
                 hopper = export._collect_jobs(None, out, ["sm_90a"])
                 on_device = export._collect_jobs(None, out, [None])
@@ -498,64 +521,39 @@ class TestArch(unittest.TestCase):
         self.assertEqual(len(on_device), 1)
 
     def test_multi_arch_jobs_nest_per_arch(self):
-        # Multi-arch fan-out nests <out>/<arch>/<decl_id>; single arch
-        # (or default None) keeps the flat layout.
-        import tempfile
-        import unittest.mock as mock
-
+        # Every job nests under <out>/<arch>/<decl_id>, one arch or several:
+        # adding an arch to an op is then just another directory. There is no
+        # second (flat) layout -- the assertions below pin that for the
+        # single-arch and on-device cases too.
         with tempfile.TemporaryDirectory() as ops, tempfile.TemporaryDirectory() as out:
-            os.makedirs(os.path.join(ops, "fakeop"))
-            with open(os.path.join(ops, "fakeop", "aot.py"), "w") as f:
-                f.write(
-                    'ATEN_OP = "fakeop"\nDISPATCH_KEY = "CUDA"\n'
-                    'KERNEL_MODULE = "k.py"\n'
-                    "def kernel_precompile_grid():\n    return [{'dtype': 'float32'}]\n"
-                    "def covered_axes(self):\n    return {}\n"
-                    "def cpp_dispatch(spec):\n    return 'true'\n"
-                    "def cpp_launch(spec, launch_fn):\n    return launch_fn\n"
-                )
-            with mock.patch.object(export, "OPS_DIR", ops):
+            _write_fake_decl(ops)
+            # _detected_arch patched, not read from the runner: the layout must
+            # be the same shape everywhere, and an unpatched call would make
+            # this test depend on whether the machine has a GPU.
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                # Device-only resolution: an ambient CUTE_DSL_ARCH would outrank
+                # it and put the on-device job in a different arch directory.
+                _no_ambient_arch(device="sm_100"),
+            ):
                 multi = export._collect_jobs(None, out, ["sm_90a", "sm_100a"])
                 single = export._collect_jobs(None, out, [None])
         self.assertEqual(len(multi), 2)
         dirs = sorted(os.path.basename(os.path.dirname(j[3])) for j in multi)
         self.assertEqual(dirs, ["sm_100a", "sm_90a"])
         self.assertEqual({j[4] for j in multi}, {"sm_90a", "sm_100a"})
+        # ONE layout: a single arch nests under its own directory too, so
+        # adding an arch to an op is just another directory.
         (sj,) = single
         self.assertEqual(os.path.basename(sj[3]), "fakeop")
-        self.assertIsNone(sj[4])
-
-    def test_empty_dir_is_fine(self):
-        # A clean build (or a newly added spec point) has no sidecar and
-        # no artifacts; it must export, not fail.
-        with tempfile.TemporaryDirectory() as d:
-            export._check_no_orphan_artifacts(d)
-
-    def test_artifacts_without_sidecar_are_fatal(self):
-        # An export that died between compiling and writing the sidecar.
-        # The CMake globs link *.o by pattern, so an undescribed orphan
-        # would otherwise be linked silently.
-        with tempfile.TemporaryDirectory() as d:
-            open(os.path.join(d, "k_f32.o"), "w").close()
-            with self.assertRaisesRegex(RuntimeError, "no sidecar"):
-                export._check_no_orphan_artifacts(d)
-
-    def test_artifacts_with_sidecar_are_fine(self):
-        with tempfile.TemporaryDirectory() as d:
-            open(os.path.join(d, "k.o"), "w").close()
-            with open(os.path.join(d, "k.json"), "w") as f:
-                json.dump({"prefix": "k"}, f)
-            export._check_no_orphan_artifacts(d)
-
-    def test_unreadable_sidecar_is_fatal(self):
-        # Present but unparsable: corruption, not an interrupted run.
-        # Re-exporting would paper over it (and --force skips the check).
-        with tempfile.TemporaryDirectory() as d:
-            path = os.path.join(d, "k.json")
-            with open(path, "w") as f:
-                f.write("{truncated")
-            with self.assertRaisesRegex(RuntimeError, "could not be read"):
-                export._read_sidecar(path)
+        # sm_100a, not the detected sm_100: an on-device export adopts the
+        # spelling the DECLARATION claims, as the generator's tie-break does. So
+        # the tree cannot be one the declaration disowns -- a declaration pinning
+        # ("sm_100a",) got an sm_100 tree, and generation's "delete and re-export"
+        # remedy rebuilt the identical one -- and the job carries that arch
+        # explicitly, so kernels match what is recorded.
+        self.assertEqual(os.path.basename(os.path.dirname(sj[3])), "sm_100a")
+        self.assertEqual(sj[4], "sm_100a")
 
     def test_cross_product(self):
         pts = export.expand_specs(
@@ -609,6 +607,88 @@ class TestLauncherCodegen(unittest.TestCase):
     def test_module_load_is_once_per_process(self):
         src = self._launcher()
         self.assertIn("c10::call_once", src)
+
+
+class TestSidecarIntegrity(unittest.TestCase):
+    """The sidecar is written after the artifacts, so it is the commit
+    marker: absent means not-yet-exported, corrupt or orphaned means the
+    tree cannot be trusted."""
+
+    def test_empty_dir_is_fine(self):
+        # A clean build (or a newly added spec point) has no sidecar and
+        # no artifacts; it must export, not fail.
+        with tempfile.TemporaryDirectory() as d:
+            export._check_no_orphan_artifacts(d, [])
+
+    def test_artifacts_without_sidecar_are_fatal(self):
+        # An export that died between compiling and writing the sidecar.
+        # Generation names artifacts from sidecars, so an undescribed orphan
+        # is never linked -- it is disk nothing reclaims, hence fatal here.
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, "k_f32.o"), "w").close()
+            with self.assertRaisesRegex(RuntimeError, "no sidecar"):
+                export._check_no_orphan_artifacts(d, [])
+
+    def test_an_orphan_beside_a_committed_point_is_reported_not_fatal(self):
+        # Where an interrupt actually lands: among points that already committed.
+        # Keyed per DIRECTORY the check saw a sidecar and asked nothing further, so
+        # this pair survived every later export unreported. Keyed per artifact and
+        # FATAL it went too far the other way: the DSL writes the .h before the .o, so
+        # a single failed compile in a 48-point grid made every later export refuse the
+        # directory -- including --force, which is read after this scan.
+        with tempfile.TemporaryDirectory() as d:
+            for name in ("k_n1.o", "k_n1.h", "k_n2.h"):
+                open(os.path.join(d, name), "w").close()
+            with open(os.path.join(d, "k_n1.json"), "w") as f:
+                json.dump({"prefix": "k_n1", "kind": "cutedsl", "spec": {"N": 1}}, f)
+            with contextlib.redirect_stdout(io.StringIO()) as out:
+                export._check_no_orphan_artifacts(d, [{"N": 1}, {"N": 2}])
+        self.assertIn("k_n2.h", out.getvalue())
+        self.assertIn("no sidecar claims", out.getvalue())
+
+    def test_a_directory_of_uncommitted_artifacts_is_still_fatal(self):
+        # Nothing committed at all is not an interrupt in a live grid: it is a partial
+        # copy or a hand-edit, and the tree cannot be read from sidecars that are not
+        # there.
+        with tempfile.TemporaryDirectory() as d:
+            for name in ("k_n1.o", "k_n1.h"):
+                open(os.path.join(d, name), "w").close()
+            with self.assertRaisesRegex(RuntimeError, "no sidecar"):
+                export._check_no_orphan_artifacts(d, [{"N": 1}])
+
+    def test_artifacts_with_sidecar_are_fine(self):
+        with tempfile.TemporaryDirectory() as d:
+            open(os.path.join(d, "k.o"), "w").close()
+            with open(os.path.join(d, "k.json"), "w") as f:
+                json.dump({"prefix": "k", "kind": "cutedsl", "spec": {"N": 1}}, f)
+            export._check_no_orphan_artifacts(d, [{"N": 1}])
+
+    def test_unreadable_sidecar_is_fatal(self):
+        # Present but unparsable: corruption, not an interrupted run.
+        # Re-exporting would paper over it (and --force skips the check).
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "k.json")
+            with open(path, "w") as f:
+                f.write("{truncated")
+            with self.assertRaisesRegex(RuntimeError, "could not be read"):
+                export._read_sidecar(path)
+
+    def test_cross_product(self):
+        pts = export.expand_specs(
+            [{"dtype": ["float32", "bfloat16"], "N": [1024, 2048], "K": 8}]
+        )
+        self.assertEqual(len(pts), 4)
+        self.assertIn({"dtype": "float32", "N": 2048, "K": 8}, pts)
+        self.assertIn({"dtype": "bfloat16", "N": 1024, "K": 8}, pts)
+
+    def test_multiple_blocks_concatenate(self):
+        pts = export.expand_specs([{"N": [1, 2]}, {"N": 3, "extra": True}])
+        self.assertEqual(pts, [{"N": 1}, {"N": 2}, {"N": 3, "extra": True}])
+
+    def test_scalar_only_spec(self):
+        self.assertEqual(
+            export.expand_specs([{"N": 4096, "K": 64}]), [{"N": 4096, "K": 64}]
+        )
 
 
 # mX with one size and one stride slot, and with none at all: the two claims the
@@ -1222,21 +1302,41 @@ class TestStaleGridPointArtifacts(unittest.TestCase):
         # launcher referencing it.
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "gone.json"), "w") as f:
-                json.dump({"prefix": "gone", "spec": {"N": 4096}}, f)
+                # version, because a real sidecar always has one: the check reads
+                # the schema first, so a version-less fixture is "unreadable", not
+                # "stale", and would test nothing.
+                json.dump(
+                    {
+                        "version": export.SIDECAR_VERSION,
+                        "prefix": "gone",
+                        "spec": {"N": 4096},
+                    },
+                    f,
+                )
             with self.assertRaisesRegex(RuntimeError, "no longer in the grid"):
                 export._check_no_orphan_artifacts(tmpdir, [{"N": 1024}])
+
+    def test_a_sidecar_from_another_schema_is_not_called_stale(self):
+        # It cannot be read, so it cannot be judged: the next SIDECAR_VERSION bump
+        # would otherwise make the first export in an existing tree demand
+        # `rm -rf` instead of re-exporting the points it no longer understands.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "old.json"), "w") as f:
+                json.dump(
+                    {
+                        "version": export.SIDECAR_VERSION + 1,
+                        "prefix": "old",
+                        "spec": {"N": 4096},
+                    },
+                    f,
+                )
+            export._check_no_orphan_artifacts(tmpdir, [{"N": 1024}])
 
     def test_sidecar_still_in_grid_is_accepted(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "live.json"), "w") as f:
                 json.dump({"prefix": "live", "spec": {"N": 1024}}, f)
             export._check_no_orphan_artifacts(tmpdir, [{"N": 1024}])
-
-    def test_grid_unknown_skips_the_stale_check(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with open(os.path.join(tmpdir, "live.json"), "w") as f:
-                json.dump({"prefix": "live", "spec": {"N": 1024}}, f)
-            export._check_no_orphan_artifacts(tmpdir)
 
 
 class TestRegistryConsistency(unittest.TestCase):
@@ -1367,6 +1467,201 @@ class TestSourceClosureCoversVendoredKernels(unittest.TestCase):
             self.assertIn(rel, closure)
             # ...and the recorded hash is the file's, so an edit invalidates it.
             self.assertEqual(closure[rel], export._file_hash(path))
+
+
+class TestExportMain(unittest.TestCase):
+    """export.main() had no coverage at all, including the TORCH_CUDA_ARCH_LIST
+    translation that another comment in the same file depends on: _CLOSURE_EXCLUDED
+    justifies keeping build_stage2.py out of the source closure on the grounds
+    that "export.py reads the arch list itself, so the driver passes it nothing
+    kernel-affecting"."""
+
+    def _main(self, argv, env, jobs_seen):
+        with (
+            tempfile.TemporaryDirectory() as out,
+            mock.patch.dict(os.environ, env, clear=False),
+            mock.patch.object(
+                export,
+                "_collect_jobs",
+                lambda ops, root, archs: jobs_seen.append(archs) or [],
+            ),
+        ):
+            export.main([*argv, "--out-dir", out])
+
+    def test_the_arch_list_is_translated_into_arches(self):
+        seen = []
+        self._main([], {"TORCH_CUDA_ARCH_LIST": "9.0a;10.0a"}, seen)
+        self.assertEqual(seen, [["sm_90a", "sm_100a"]])
+
+    def test_an_explicit_arch_wins_over_the_arch_list(self):
+        seen = []
+        self._main(["--arch", "sm_90a"], {"TORCH_CUDA_ARCH_LIST": "10.0a"}, seen)
+        self.assertEqual(seen, [["sm_90a"]])
+
+    def test_no_arch_list_means_on_device(self):
+        # archs [None] is what makes _collect_jobs resolve from the device.
+        seen = []
+        self._main([], {"TORCH_CUDA_ARCH_LIST": ""}, seen)
+        self.assertEqual(seen, [[None]])
+
+    def test_an_arch_list_with_no_exportable_arch_exports_nothing(self):
+        # Not an error: a CUDA build for Ampere alone simply has no AOT kernels.
+        seen = []
+        self._main([], {"TORCH_CUDA_ARCH_LIST": "8.0;8.6"}, seen)
+        self.assertEqual(seen, [], "_collect_jobs should not even be reached")
+
+
+class TestCollectJobsRefusals(unittest.TestCase):
+    def test_an_unnameable_arch_is_refused(self):
+        # There is no unnamed layout: an artifact whose arch nobody can state is
+        # one the runtime gate cannot match to hardware. Untested before --
+        # replacing the raise with a placeholder left the suite green, because both
+        # existing _collect_jobs tests patch _detected_arch to a real sm string.
+        with tempfile.TemporaryDirectory() as ops, tempfile.TemporaryDirectory() as out:
+            _write_fake_decl(ops)
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                _no_ambient_arch(device=None),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "cannot determine the arch"):
+                    export._collect_jobs(None, out, [None])
+
+    def test_a_malformed_arch_is_refused(self):
+        # The explicit path compares ARCHS by STRING, and routing every arch
+        # through _claimed_spelling used to be the only thing that ever validated
+        # an sm string. Without cc_of here, `--arch sm100a` (or sm_1000, SM_100)
+        # matched no declaration, exported nothing, and exited 0 -- a typo that
+        # looked like a successful build. `gen_aot_lib.py`'s own stale-artifact
+        # advice tells users to run export with --arch, so this is a live path.
+        for bad in ("sm100a", "SM_100", "sm_1000", "sm_9", "90", "sm_100+PTX"):
+            with self.subTest(arch=bad):
+                with (
+                    tempfile.TemporaryDirectory() as ops,
+                    tempfile.TemporaryDirectory() as out,
+                ):
+                    _write_fake_decl(ops)
+                    with (
+                        mock.patch.object(export, "OPS_DIR", ops),
+                        _no_ambient_arch(device=None),
+                    ):
+                        with self.assertRaisesRegex(RuntimeError, "compute capability"):
+                            export._collect_jobs(None, out, [bad])
+
+    def test_a_declaration_that_ships_nothing_says_so(self):
+        # ARCHS spelling is load-bearing on the explicit path: a declaration
+        # pinning ('sm_100a',) ships nothing for a release list of plain spellings
+        # ("10.0"), and with several declarations that is PARTIAL -- the build
+        # embeds the ops that matched, relinks, passes its post-relink check, and
+        # the others are simply absent. Nothing downstream can report it, because
+        # there is no tree for generation to complain about.
+        with (
+            tempfile.TemporaryDirectory() as ops,
+            tempfile.TemporaryDirectory() as out,
+        ):
+            _write_fake_decl(ops, "ARCHS = ('sm_100a',)\n")
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                _no_ambient_arch(device=None),
+                contextlib.redirect_stdout(io.StringIO()) as printed,
+            ):
+                jobs = export._collect_jobs(None, out, ["sm_100"])
+        self.assertEqual(jobs, [])
+        said = printed.getvalue()
+        self.assertIn("declares kernels but none for this build", said)
+        self.assertIn("sm_100", said)
+        # The report is the ONLY thing that surfaces this, so it has to state the
+        # declaration's real ARCHS: it used to end with a fixed illustration, which
+        # read "an ARCHS of ('sm_100a',)" for declarations claiming something else.
+        self.assertIn("ARCHS (sm_100a)", said)
+
+    def test_a_declaration_that_does_ship_is_not_reported(self):
+        # The control: the report must not fire for the ordinary case, or it is
+        # noise on every build.
+        with (
+            tempfile.TemporaryDirectory() as ops,
+            tempfile.TemporaryDirectory() as out,
+        ):
+            _write_fake_decl(ops, "ARCHS = ('sm_100', 'sm_100a')\n")
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                _no_ambient_arch(device=None),
+                contextlib.redirect_stdout(io.StringIO()) as printed,
+            ):
+                jobs = export._collect_jobs(None, out, ["sm_100"])
+        self.assertTrue(jobs)
+        self.assertNotIn("declares kernels but none", printed.getvalue())
+
+    def test_a_declaration_that_disowns_the_local_capability_is_skipped(self):
+        # Skipped, not exported into a tree the declaration disowns: that tree made
+        # generation refuse with "delete and re-export", whose remedy rebuilt the
+        # identical tree, so `pip install -e .` failed permanently.
+        with tempfile.TemporaryDirectory() as ops, tempfile.TemporaryDirectory() as out:
+            _write_fake_decl(ops, "ARCHS = ('sm_90a',)\n")
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                _no_ambient_arch(device="sm_100"),
+            ):
+                self.assertEqual(export._collect_jobs(None, out, [None]), [])
+                self.assertEqual(os.listdir(out), [], "no tree for a disowned arch")
+
+    def test_the_declarations_spelling_is_adopted_for_the_local_capability(self):
+        # sm_100 detected, ('sm_100a',) claimed: same capability, so the job is
+        # created and BOTH the tree and the compile target use the declaration's
+        # spelling. Preferring the conditional one matches the generator's
+        # tie-break, which drops the plain build for the same capability anyway.
+        with tempfile.TemporaryDirectory() as ops, tempfile.TemporaryDirectory() as out:
+            _write_fake_decl(ops, "ARCHS = ('sm_100a',)\n")
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                _no_ambient_arch(device="sm_100"),
+            ):
+                (job,) = export._collect_jobs(None, out, [None])
+        self.assertEqual(os.path.basename(os.path.dirname(job[3])), "sm_100a")
+        self.assertEqual(job[4], "sm_100a")
+
+
+class TestOrphanCheckIsCalled(unittest.TestCase):
+    def test_collect_jobs_runs_the_orphan_check(self):
+        # Every orphan test calls _check_no_orphan_artifacts DIRECTLY, so deleting
+        # its only production call site left the suite green -- the same
+        # missing-call-site shape already fixed for validate_abi and _write_atomic.
+        # An undescribed .o would then be linked with no launcher referencing it.
+        seen = []
+        with (
+            tempfile.TemporaryDirectory() as ops,
+            tempfile.TemporaryDirectory() as out,
+        ):
+            _write_fake_decl(ops)
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                mock.patch.object(
+                    export,
+                    "_check_no_orphan_artifacts",
+                    lambda d, points: seen.append(d),
+                ),
+                _no_ambient_arch(device="sm_100"),
+            ):
+                export._collect_jobs(None, out, [None])
+        self.assertEqual(len(seen), 1, "the orphan check must run per (decl, arch)")
+        self.assertTrue(seen[0].endswith(os.path.join("sm_100a", "fakeop")))
+
+    def test_an_undescribed_artifact_fails_collection(self):
+        # End to end through the call site: an .o with no sidecar must stop the
+        # export, not ride along into the link.
+        with (
+            tempfile.TemporaryDirectory() as ops,
+            tempfile.TemporaryDirectory() as out,
+        ):
+            _write_fake_decl(ops)
+            stray = os.path.join(out, "sm_100a", "fakeop")
+            os.makedirs(stray)
+            open(os.path.join(stray, "leftover.o"), "w").close()
+            with (
+                mock.patch.object(export, "OPS_DIR", ops),
+                _no_ambient_arch(device="sm_100"),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "no sidecar"):
+                    export._collect_jobs(None, out, [None])
 
 
 class TestMissingArtifacts(unittest.TestCase):

--- a/torchgen/native_aot_decl.py
+++ b/torchgen/native_aot_decl.py
@@ -78,9 +78,24 @@ _OPTIONAL_FNS = {
 # Every sm spelling this tooling can parse and target. export checks an explicit
 # --arch against it before touching the disk, so a typo bails out naming the set
 # instead of matching no declaration and exporting nothing at exit 0. Deliberately
-# WIDER than export.EXPORTABLE_ARCHES, which is what the standard build ships: an
-# explicit --arch is how a hand run targets something the release wheels do not.
+# WIDER than EXPORTABLE_ARCHES below: an explicit --arch is how a hand run targets
+# something the release wheels do not.
 KNOWN_ARCHES = ("sm_90", "sm_90a", "sm_100", "sm_100a", "sm_103", "sm_103a")
+
+# Which of them the STANDARD build ships: the TORCH_CUDA_ARCH_LIST entries eligible
+# on the automatic export path, which an explicit --arch bypasses. Both spellings of
+# a capability are listed because they are distinct nvcc targets for the same
+# hardware -- "10.0a" (needed by tcgen05/wgmma) in b200-native-aot.yml, plain "10.0"
+# in the manywheel lists -- and omitting either silently exports nothing there. Each
+# entry also costs another full set of compiled kernels in every wheel naming it, and
+# makes the DSL runtimes mandatory on a builder with that GPU. sm_103 stays out: no
+# arch list we see names 10.3.
+EXPORTABLE_ARCHES = ("sm_90", "sm_90a", "sm_100", "sm_100a")
+if not set(EXPORTABLE_ARCHES) <= set(KNOWN_ARCHES):
+    raise AssertionError(
+        f"EXPORTABLE_ARCHES names arches this tooling cannot target: "
+        f"{sorted(set(EXPORTABLE_ARCHES) - set(KNOWN_ARCHES))}"
+    )
 
 # Default ARCHS: every current kernel requires sm90+ features (TMA,
 # clusters, cp.async.bulk); Blackwell variants included. Declarations

--- a/torchgen/native_aot_decl.py
+++ b/torchgen/native_aot_decl.py
@@ -75,10 +75,19 @@ _OPTIONAL_FNS = {
     "cpp_covers": 0,
 }
 
+# Every sm spelling this tooling can parse and target. export checks an explicit
+# --arch against it before touching the disk, so a typo bails out naming the set
+# instead of matching no declaration and exporting nothing at exit 0. Deliberately
+# WIDER than export.EXPORTABLE_ARCHES, which is what the standard build ships: an
+# explicit --arch is how a hand run targets something the release wheels do not.
+KNOWN_ARCHES = ("sm_90", "sm_90a", "sm_100", "sm_100a", "sm_103", "sm_103a")
+
 # Default ARCHS: every current kernel requires sm90+ features (TMA,
 # clusters, cp.async.bulk); Blackwell variants included. Declarations
 # override to narrow (e.g. a Blackwell-only kernel pins ("sm_100a",)).
-_DEFAULT_ARCHS = ("sm_90", "sm_90a", "sm_100", "sm_100a", "sm_103", "sm_103a")
+# The same tuple as KNOWN_ARCHES today, named separately because "the tooling can
+# target this arch" is not "every declaration's kernels work on it".
+_DEFAULT_ARCHS = KNOWN_ARCHES
 
 _SM_RE = r"sm_\d+a?"
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* #191669
* #190899
* #190898
* #190897
* #195877
* #194243
* #194242
* #194241
* #194240
* __->__ #194239
* #194238
* #190896

Human note:

Setup directory structure for 1+ architectures to be consistent. Setup ordering for
similar but distinct architectures (sm100 vs. sm100a for instance).

Claude note:

Where artifacts go, what an inconsistent tree means, and which arch lists the
automatic path accepts.

One layout whatever the arch count, <out-dir>/<arch>/<decl_id>/. The old shape
depended on how many arches were requested, so switching between one and several
left the other shape behind and one arch then appeared twice for a declaration. A
declaration matching no requested arch is now reported by name: with several
declarations the result is partial but looks healthy.

The orphan scan splits by how recoverable each case is. Artifacts no sidecar
claims are an export that died before writing one: reported, never fatal, since
nothing links them -- as a refusal it turned one failed compile in a 48-point grid
into a hand-delete that --force could not clear either, and it called every
interrupted first export of a new arch a corrupt tree, which is the shape a fresh
one always has. A sidecar recording a spec the grid no longer holds stays fatal:
nothing prunes it, and it makes an artifact nothing will launch look exported.

TORCH_CUDA_ARCH_LIST collapses to one arch per capability. "10.0;10.0a" is one
piece of hardware, and exporting both shipped the loser inside libtorch_cuda with
no launcher (54 objects, 3.5 MiB measured) -- the common case for CUDA 13.x
manywheel lists.

EXPORTABLE_ARCHES gains Hopper (sm_90, sm_90a), so a release list naming 9.0
exports for it instead of skipping. That is one more full set of kernels in every
CUDA 13.x wheel and in the H100 build jobs (topk's grid is 48 points), and past
this filter the DSL runtimes stop being optional: an H100 box without the
cutlass-dsl wheel now fails stage 2 where it used to skip, as a B200 box already
did. No CI job exercises AOT kernels on Hopper: the one functional AOT job in this
stack runs on B200 and arrives with the first declaration, so the coverage here
is the tools suite alone.

Test Plan:

```
pytest tools/test/test_native_aot_tools.py
```

Run at this commit's own tree, in a checkout with no built torch -- which is
what lint.yml's "Test tools" job has. This commit's tests cover the per-arch
layout, the CLI's arch resolution (--arch, TORCH_CUDA_ARCH_LIST, on-device),
unclaimed artifacts being reported and never fatal -- including the fresh tree
whose first export died -- a sidecar for a dropped grid point staying fatal, and
the arch-list collapse to one spelling per capability.

Authored with an AI assistant (Claude Code).