### PR TITLE
[RAWTHROW][2a] Inline THPByteUtils_unpackReal; delete torch/csrc/*.h exclude

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -597,7 +597,6 @@ exclude_patterns = [
     'test/cpp_extensions/**',
     'tools/autograd/**',
     'torch/csrc/*.cpp',
-    'torch/csrc/*.h',
     'torch/csrc/autograd/**',
     'torch/csrc/distributed/**',
     'torch/csrc/dynamo/**',

--- a/torch/csrc/Exceptions.h
+++ b/torch/csrc/Exceptions.h
@@ -1,4 +1,3 @@
-// @allow-raw-throw
 #pragma once
 
 #include <exception>

--- a/torch/csrc/utils.h
+++ b/torch/csrc/utils.h
@@ -21,40 +21,17 @@
 #define THP_EXPECT(x, y) (x)
 #endif
 
-#define THPUtils_unpackReal_FLOAT(object)           \
-  (PyFloat_Check(object) ? PyFloat_AsDouble(object) \
-       : PyLong_Check(object)                       \
-       ? PyLong_AsLongLong(object)                  \
-       : (throw std::runtime_error("Could not parse real"), 0))
-
 #define THPUtils_checkReal_INT(object) PyLong_Check(object)
 
-#define THPUtils_unpackReal_INT(object) \
-  (PyLong_Check(object)                 \
-       ? PyLong_AsLongLong(object)      \
-       : (throw std::runtime_error("Could not parse real"), 0))
-
-#define THPUtils_unpackReal_BOOL(object) \
-  (PyBool_Check(object)                  \
-       ? object                          \
-       : (throw std::runtime_error("Could not parse real"), Py_False))
-
-#define THPUtils_unpackReal_COMPLEX(object)                                   \
-  (PyComplex_Check(object)                                                    \
-       ? (c10::complex<double>(                                               \
-             PyComplex_RealAsDouble(object), PyComplex_ImagAsDouble(object))) \
-       : PyFloat_Check(object)                                                \
-       ? (c10::complex<double>(PyFloat_AsDouble(object), 0))                  \
-       : PyLong_Check(object)                                                 \
-       ? (c10::complex<double>(PyLong_AsLongLong(object), 0))                 \
-       : (throw std::runtime_error("Could not parse real"),                   \
-          c10::complex<double>(0, 0)))
-
-#define THPBoolUtils_unpackReal(object) THPUtils_unpackReal_BOOL(object)
 #define THPBoolUtils_checkAccreal(object) THPUtils_checkReal_BOOL(object)
 #define THPByteUtils_checkReal(object) THPUtils_checkReal_INT(object)
-#define THPByteUtils_unpackReal(object) \
-  (unsigned char)THPUtils_unpackReal_INT(object)
+
+// A function, not a macro: TORCH_CHECK is a statement, and callers use this in
+// expression position.
+inline unsigned char THPByteUtils_unpackReal(PyObject* object) {
+  TORCH_CHECK(PyLong_Check(object), "Could not parse real");
+  return static_cast<unsigned char>(PyLong_AsLongLong(object));
+}
 
 /*
    From https://github.com/python/cpython/blob/v3.7.0/Modules/xxsubtype.c


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194379
* #194378
* #194245
* __->__ #194244

## Author Notes

Still working on this, do not review yet.

## Agent Notes

Written by Claude Code:

> This is the change that ended the previous attempt at this project. The four
> `THPUtils_unpackReal_*` macros put their failure arm inside a conditional
> operator:
>
>     #define THPUtils_unpackReal_INT(object) \
>       (PyLong_Check(object)                 \
>            ? PyLong_AsLongLong(object)      \
>            : (throw std::runtime_error("Could not parse real"), 0))
>
> `TORCH_CHECK` expands to an `if` statement, so substituting it into a comma
> expression is a syntax error, and all 21 build jobs went red. A function has no
> such problem, which is why the guard here becomes one.
>
> Most of the block turned out to be dead. Only `THPByteUtils_unpackReal` and
> `THPByteUtils_checkReal` have callers - five, in Storage.cpp and
> StorageMethods.cpp. `THPUtils_unpackReal_FLOAT`, `_BOOL` and `_COMPLEX` have
> none, and neither does `THPBoolUtils_unpackReal`, which aliases `_BOOL`. Three
> of the four raw throws are therefore in code nobody calls, and they are deleted
> rather than ported.
>
> Deleting rather than converting needs justifying, since these macros could in
> principle be reached by token pasting - `THPUtils_(NAME)` on line 14 exists to
> build exactly these names via `TH_CONCAT_4(THP, Real, Utils_, NAME)`. It is
> never used, `Real` is never defined anywhere in the repo, and there is no other
> `##`-pasting of `Utils_unpackReal`. A second signal: the neighbouring
> `THPBoolUtils_checkAccreal` expands to `THPUtils_checkReal_BOOL`, which is not
> defined at all, so that macro could not compile if anything referenced it. It is
> left alone here because it contains no throw.
>
> What remains is one function covering the single live path:
>
>     inline unsigned char THPByteUtils_unpackReal(PyObject* object) {
>       TORCH_CHECK(PyLong_Check(object), "Could not parse real");
>       return static_cast<unsigned char>(PyLong_AsLongLong(object));
>     }
>
> Same truncating cast, same absent overflow check on `PyLong_AsLongLong`, and
> `std::runtime_error` and `c10::Error` both reach Python as `RuntimeError`.
>
> Also removed: the file-level `// @allow-raw-throw` at the top of Exceptions.h.
> Since markers became line-scoped it no longer licenses anything, and it is
> itself an `orphaned-allow-raw-throw` violation - masked until now only because
> the exclude hid the file. It is the last thing standing between
> `torch/csrc/*.h` and a clean bill; every other throw in that header is either
> allowed by rule or already annotated.
>
> Two things in utils.h are deliberately left alone, since neither contains a
> throw and rule 3 keeps this PR to throw handling: the unused `THPUtils_(NAME)`
> paster on line 14, and `THPBoolUtils_checkAccreal`, which expands to the
> never-defined `THPUtils_checkReal_BOOL`.
>
> Worth noting for out-of-tree code: `torch/csrc/**/*.h` is installed into the
> wheel, so deleting these macros is a source-compatibility change for anything
> outside the repo that includes utils.h and uses them. They are not part of the
> stable ABI surface, and they are unusable in practice - three of the four
> depend on a `Real` token that is never defined.
>
> Test Plan:
>
> ```
> bash -ic 'BUILD_CONFIG spin develop'
> ```
>
> Builds clean - the point of this PR.
>
> ```
> python -m pytest -q test/test_serialization.py test/test_torch.py \
>     -k "storage or Storage or serial"
> ```
>
> 337 passed, 28 skipped.
>
> The live path exercised directly, since the five call sites are byte-storage
> operations:
>
> ```
> s = torch.UntypedStorage(4); s.fill_(7); s[1] = 200
> s[0] = 300          # still truncates to 44, as the (unsigned char) cast did
> s.fill_('nope')     # RuntimeError, from the caller's own check
> ```
>
> ```
> lintrunner --take RAWTHROW --all-files
> ```
>
> Clean with the `torch/csrc/*.h` exclude removed, which is what makes the two
> changes above enforced rather than merely done.
> CLANGTIDY is skipped locally because this checkout's compiler makes it fail
> spuriously; CI's clang job covers it. Both changed translation units were also
> recompiled with CI's bare `-Werror`, which the local build does not set.