### PR TITLE
[ROCm] Restore preview_unsafeAtomicAdd for ROCm < 6.4 in headeronly

### DIFF
--- a/torch/headeronly/cuda/KernelUtils.h
+++ b/torch/headeronly/cuda/KernelUtils.h
@@ -13,7 +13,85 @@
 
 #include <torch/headeronly/cuda/detail/ROCmMacros.h>
 
+// ROCm < 6.4 ships no packed unsafeAtomicAdd overload for __half2 /
+// __hip_bfloat162, so supply equivalents until every consumer is on 6.4+.
+// ROCM_VERSION arrives as -DROCM_VERSION=FB_ROCM_VERSION and collapses to 0
+// wherever the tp2 toolchain does not substitute it, which selects this branch.
+#if ROCM_VERSION < 60400
+__device__ inline __hip_bfloat162 preview_unsafeAtomicAdd(
+    __hip_bfloat162* address,
+    __hip_bfloat162 value) {
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2bf16)) {
+    typedef unsigned short __attribute__((ext_vector_type(2))) vec_short2;
+    static_assert(sizeof(vec_short2) == sizeof(__hip_bfloat162_raw));
+    union {
+      __hip_bfloat162_raw bf162_raw;
+      vec_short2 vs2;
+    } u{static_cast<__hip_bfloat162_raw>(value)};
+    u.vs2 =
+        __builtin_amdgcn_flat_atomic_fadd_v2bf16((vec_short2*)address, u.vs2);
+    return static_cast<__hip_bfloat162>(u.bf162_raw);
+  } else {
+    static_assert(sizeof(unsigned int) == sizeof(__hip_bfloat162_raw));
+    union u_hold {
+      __hip_bfloat162_raw h2r;
+      unsigned int u32;
+    };
+    u_hold old_val, new_val;
+    old_val.u32 = __hip_atomic_load(
+        (unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    do {
+      new_val.h2r = __hadd2(old_val.h2r, value);
+    } while (!__hip_atomic_compare_exchange_strong(
+        (unsigned int*)address,
+        &old_val.u32,
+        new_val.u32,
+        __ATOMIC_RELAXED,
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT));
+    return old_val.h2r;
+  }
+}
+
+__device__ inline __half2 preview_unsafeAtomicAdd(
+    __half2* address,
+    __half2 value) {
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_flat_atomic_fadd_v2f16)) {
+    // The api expects an ext_vector_type of half
+    typedef _Float16 __attribute__((ext_vector_type(2))) vec_fp162;
+    static_assert(sizeof(vec_fp162) == sizeof(__half2_raw));
+    union {
+      __half2_raw h2r;
+      vec_fp162 fp16;
+    } u{static_cast<__half2_raw>(value)};
+    u.fp16 =
+        __builtin_amdgcn_flat_atomic_fadd_v2f16((vec_fp162*)address, u.fp16);
+    return static_cast<__half2>(u.h2r);
+  } else {
+    static_assert(sizeof(__half2_raw) == sizeof(unsigned int));
+    union u_hold {
+      __half2_raw h2r;
+      unsigned int u32;
+    };
+    u_hold old_val, new_val;
+    old_val.u32 = __hip_atomic_load(
+        (unsigned int*)address, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);
+    do {
+      new_val.h2r = __hadd2(old_val.h2r, value);
+    } while (!__hip_atomic_compare_exchange_strong(
+        (unsigned int*)address,
+        &old_val.u32,
+        new_val.u32,
+        __ATOMIC_RELAXED,
+        __ATOMIC_RELAXED,
+        __HIP_MEMORY_SCOPE_AGENT));
+    return old_val.h2r;
+  }
+}
+#define ATOMICADD preview_unsafeAtomicAdd
+#else
 #define ATOMICADD unsafeAtomicAdd
+#endif
 #define NATIVE_ZERO_BF16 __float2bfloat16(0.0f)
 #else
 #define ATOMICADD atomicAdd


### PR DESCRIPTION
Summary:
D115291025 removed the `ROCM_VERSION < 60400` branch from
`ATen/native/cuda/KernelUtils.cuh`, which defined `preview_unsafeAtomicAdd` for
`__half2` / `__hip_bfloat162` and selected it via `ATOMICADD`. D116043660 then
migrated the remaining (unguarded) code to
`torch/headeronly/cuda/KernelUtils.h`, so `ATOMICADD` is now unconditionally
`unsafeAtomicAdd`.

ROCm 6.2.1's `amd_hip_unsafe_atomics.h` only provides `float*` and `double*`
overloads, so any target still pinned below 6.4 fails to compile
`fbcode//caffe2:ATen-hip`:

```
KernelUtils.h:107:5: error: no matching function for call to 'unsafeAtomicAdd'
    ATOMICADD(reinterpret_cast<__hip_bfloat162*>(target_addr), value2);
```

`sigrid.predictor.hip` pins ROCm 6.2.1 (`ovr_config//third-party/rocm/constraints:6.2.1`,
with a "ROCm 7.0 migration pending" note), so its container manifest
`tw.ipnext.ads.sigrid_predictor.hip` has been unbuildable since this landed.

This restores the version-gated overloads at their new home. `ROCM_VERSION` is
supplied as `-DROCM_VERSION=FB_ROCM_VERSION` and collapses to 0 where the tp2
toolchain does not substitute it, so the guard degrades to the compatible
`preview_unsafeAtomicAdd` path rather than the broken one.

Test Plan: `buck2 run fbcode//sigrid/predictor:sigrid.predictor.hip -- --build-remote`

Reviewed By: janeyx99

Differential Revision: D116741222




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang