### PR TITLE
Fix grammar and typos in comments and docstrings

### DIFF
--- a/torch/_dynamo/cache_size.py
+++ b/torch/_dynamo/cache_size.py
@@ -165,7 +165,7 @@ def compute_cache_size(
 def is_recompilation(cache_size: CacheSizeRelevantForFrame) -> bool:
     """
     If the frame (earlier parsed by compute_cache_size) has more than 1 cache
-    entry with same ID_MATCH'd objects, then its a recompilation.
+    entry with same ID_MATCH'd objects, then it's a recompilation.
     """
     # Note that you can have multiple entries in the cache but still not a
     # recompile, e.g., you can have 64 nn module instances, each one having an

--- a/torch/_inductor/codegen/cutlass/scheduling.py
+++ b/torch/_inductor/codegen/cutlass/scheduling.py
@@ -265,7 +265,7 @@ class CUTLASSScheduling(BaseScheduling):
         support fusion with Pointwise operations, wrapped in (named) ComputedBuffer nodes.
 
         Args:
-            cutlass_template_buffer : A CUTLASSTemplateBuffer object representing the CUTLASS template and it's result buffer
+            cutlass_template_buffer : A CUTLASSTemplateBuffer object representing the CUTLASS template and its result buffer
             existing_epilogue_nodes : List[SchedulerNode]: The list of already fused epilogue nodes.
             node_to_fuse: The SchedulerNode node to be checked if it can be fused with the epilogue.
         Returns:

--- a/torch/_inductor/kernel/flex/flex_attention.py
+++ b/torch/_inductor/kernel/flex/flex_attention.py
@@ -697,7 +697,7 @@ def process_joint_outputs(
     joint_buffer = all_joint_outputs[0]
     other_grads = all_joint_outputs[num_placeholders - 1 :]
 
-    # outer_grads has the structure: Len(other_buffer_grads) if buffer doesn't require grad than it will be None
+    # outer_grads has the structure: Len(other_buffer_grads) if buffer doesn't require grad then it will be None
     # We only grab the buffers that require grad for inlining into kernel
     grads_compute = [buf for buf in other_grads if buf is not None]
 

--- a/torch/_inductor/subgraph_lowering.py
+++ b/torch/_inductor/subgraph_lowering.py
@@ -113,7 +113,7 @@ class PointwiseSubgraphLowering(torch.fx.Interpreter):
             if target is operator.getitem and isinstance(args[0], (list, tuple, dict)):
                 return super().call_function(target, args, kwargs)
 
-            # These takes precedence over the main lowerings
+            # These take precedence over the main lowerings
             if self.additional_lowerings is not None:
                 if target in self.additional_lowerings:
                     if not isinstance(target, OpOverload):

--- a/torch/csrc/acc/Module.cpp
+++ b/torch/csrc/acc/Module.cpp
@@ -34,7 +34,7 @@ struct PythonHooks final : public at::PrivateUse1HooksInterface {
         bool, at::PrivateUse1HooksInterface, "is_available", isBuilt, );
   }
 
-  // TODO(qihqi): these is not supported from python yet
+  // TODO(qihqi): these are not supported from python yet
   const at::Generator& getDefaultGenerator(
       c10::DeviceIndex device_index) const override {
     return at::PrivateUse1HooksInterface::getDefaultGenerator(device_index);

--- a/torch/csrc/jit/ir/node_hashing.cpp
+++ b/torch/csrc/jit/ir/node_hashing.cpp
@@ -273,7 +273,7 @@ bool EqualNode::operator()(const Node* lhs, const Node* rhs) const {
   if (!attributesEqualCSE(lhs, rhs))
     return false;
 
-  // Check if the blocks contained in a op are the same
+  // Check if the blocks contained in an op are the same
   if (lhs->blocks().size() != rhs->blocks().size()) {
     return false;
   }

--- a/torch/csrc/jit/passes/onnx/helper.h
+++ b/torch/csrc/jit/passes/onnx/helper.h
@@ -38,7 +38,7 @@ TORCH_API Value* addInputToBlock(Block* block);
 
 TORCH_API std::optional<at::ScalarType> ONNXTypeToATenType(int32_t onnx_type);
 
-// Use int return type as no sable way exists to forward declare protobuf enum
+// Use int return type as no stable way exists to forward declare protobuf enum
 TORCH_API int ATenTypeToOnnxType(at::ScalarType at_type);
 
 TORCH_API void ONNXLintGraph(const std::shared_ptr<Graph>& graph);

--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -23,7 +23,7 @@ namespace torch::jit::interpreter {
 template <class Ttarget, class Tsource>
 Ttarget safe_narrow_cast(Tsource v) {
   Ttarget res = static_cast<Ttarget>(v);
-  // Casting it back to check whether it overflew.
+  // Casting it back to check whether it overflowed.
   if (static_cast<Tsource>(res) != v) {
     TORCH_WARN(
         "ATTENTION: your model computation is overflowing, safe_narrow_cast<>() failed");

--- a/torch/csrc/lazy/core/lazy_graph_executor.h
+++ b/torch/csrc/lazy/core/lazy_graph_executor.h
@@ -286,7 +286,7 @@ class TORCH_API LazyGraphExecutor {
 
     std::vector<LazyTensorPtr> GetLiveTensors(const BackendDevice* device);
 
-    // Overriding it allow derived class to use their own IRs for Value.
+    // Overriding it allows derived classes to use their own IRs for Value.
     virtual Value GetRngSeed(const BackendDevice& device);
     uint64_t GetRunningSeed(const BackendDevice& device);
     void SetRngSeed(const BackendDevice& device, uint64_t seed);
@@ -302,7 +302,7 @@ class TORCH_API LazyGraphExecutor {
         const std::function<void(DeviceContext*)>& fn,
         const BackendDevice* device);
 
-    // Overriding it allow derived class to use their own conversions.
+    // Overriding it allows derived classes to use their own conversions.
     virtual Value IrValueFromScalar(
         const at::Scalar& value,
         at::ScalarType scalar_type,

--- a/torch/distributed/flight_recorder/components/utils.py
+++ b/torch/distributed/flight_recorder/components/utils.py
@@ -391,7 +391,7 @@ def match_coalesced_groups_with_non_p2p(
 
             # 2. we found a partial match but some ranks are missing
             # 3. we found no match
-            #  -> since its not a complete collective, no entry goes into collectives but we still record a nccl call
+            #  -> since it's not a complete collective, no entry goes into collectives but we still record a nccl call
             else:
                 logger.debug("Non-matching collective inside coalesced group")
                 idx_map = {

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -94,7 +94,7 @@ same host, we need to make sure that each instance (job) is
 setup on different ports to avoid port conflicts (or worse, two jobs being merged
 as a single job). To do this you have to run with ``--rdzv-backend=c10d``
 and specify a different port by setting ``--rdzv-endpoint=localhost:$PORT_k``.
-For ``--nodes=1``, its often convenient to let ``torchrun`` pick a free random
+For ``--nodes=1``, it's often convenient to let ``torchrun`` pick a free random
 port automatically instead of manually assigning different ports for each run.
 
 ::

--- a/torch/distributed/tensor/_collective_utils.py
+++ b/torch/distributed/tensor/_collective_utils.py
@@ -391,7 +391,7 @@ def allgather_cost(bytes_gb: float, mesh_topo: MeshTopoInfo, mesh_dim: int) -> f
 def allreduce_cost(bytes_gb: float, mesh_topo: MeshTopoInfo, mesh_dim: int) -> float:
     num_devices_on_mesh_dim = mesh_topo.mesh_dim_devices[mesh_dim]
     mesh_dim_bandwidth = mesh_topo.mesh_dim_bandwidth[mesh_dim]
-    # allreduce have almost 2x comm bytes compare to allgather/reduce_scatter
+    # allreduce have almost 2x comm bytes compared to allgather/reduce_scatter
     num_hops = 2 * (num_devices_on_mesh_dim - 1)
 
     latency = 6.6 + num_hops * mesh_topo.mesh_dim_latency[mesh_dim]

--- a/torch/distributed/tensor/_ops/_mask_buffer.py
+++ b/torch/distributed/tensor/_ops/_mask_buffer.py
@@ -36,7 +36,7 @@ class MaskBuffer:
 
         # NOTE: MaskPartial is being used by the embedding op and the gather op.
         # For gather, the mask has the same dimension as the output tensor, whereas
-        # the output of the embedding op has an additional dimension compare to the input,
+        # the output of the embedding op has an additional dimension compared to the input,
         # hence the output masking logic below having two different cases.
         if tensor.ndim == self.data.ndim:
             tensor[self.data] = 0.0

--- a/torch/fx/experimental/partitioner_utils.py
+++ b/torch/fx/experimental/partitioner_utils.py
@@ -99,7 +99,7 @@ class PartitionerConfig(NamedTuple):
 
 def get_extra_size_of(node: Node, nodes: set[Node]) -> int:
     """Given a node and a set of nodes,
-    this function return the extra size that needed
+    this function returns the extra size that is needed
     if this node is included in this set.
     """
     # Find all its input nodes

--- a/torch/headeronly/core/DeviceType.h
+++ b/torch/headeronly/core/DeviceType.h
@@ -14,7 +14,7 @@
 
 namespace c10 {
 
-// These contains all device types that also have a BackendComponent
+// These contain all device types that also have a BackendComponent
 // and therefore participate in per-backend functionality dispatch keys.
 // This is most backends except PrivateUse2 and PrivateUse3
 #define C10_FORALL_BACKEND_DEVICE_TYPES(_, extra) \

--- a/torch/nn/utils/_named_member_accessor.py
+++ b/torch/nn/utils/_named_member_accessor.py
@@ -125,7 +125,7 @@ class NamedMemberAccessor:
         For example, to get the submodule mod.layer1.conv1,
         use accessor.get_submodule("layer1.conv1")
 
-        Compare to mod.get_submodule("layer1.conv1"), this method will cache the
+        Compared to mod.get_submodule("layer1.conv1"), this method will cache the
         intermediate submodule access to speed up future lookups.
         """
         if not name:
@@ -169,7 +169,7 @@ class NamedMemberAccessor:
         For example, to get the attribute mod.layer1.conv1.weight,
         use accessor.get_tensor('layer1.conv1.weight')
 
-        Compare to mod.get_parameter("layer1.conv1.weight"), this method will
+        Compared to mod.get_parameter("layer1.conv1.weight"), this method will
         cache the intermediate submodule access to speed up future lookups.
         """
         prefix, _, attr = name.rpartition(".")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194247

Corrects a set of grammatical slips and one misspelling ("sable" -> "stable") across comments and docstrings in Dynamo, Inductor, distributed, FX, JIT, lazy, and nn utilities. Mostly subject-verb agreement, missing possessives/contractions ("its" vs "it's"), and "compare to" -> "compared to".

Comment-only change; no functional impact.

Test Plan: no runtime behavior changes, so no tests were run.

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98