### PR TITLE
[S615805][S694227][PyTorch] Safely preserve tensor strides (#194251)

### DIFF
--- a/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
+++ b/test/distributed/_shard/sharded_tensor/test_sharded_tensor.py
@@ -144,6 +144,50 @@ class TestShardedTensorMetadata(TestCase):
             st_metadata = pickle.loads(pickled_obj)
             self.assertEqual(expected_st_metadata, st_metadata)
 
+    def test_wrapper_subclass_preserves_strides(self):
+        spec = ChunkShardingSpec(dim=0, placements=["rank:0/cpu"])
+        strides = (1, 4)
+        st = ShardedTensorBase.__new__(
+            ShardedTensor,
+            spec,
+            4,
+            1,
+            dtype=torch.float32,
+            layout=torch.strided,
+            pin_memory=False,
+            requires_grad=False,
+            strides=strides,
+        )
+        with torch._C.DisableTorchFunction():
+            self.assertEqual(st.stride(), strides)
+        self.assertEqual(st.metadata().tensor_properties.strides, strides)
+
+    def test_wrapper_subclass_defaults_to_contiguous_strides(self):
+        shard_metadata = ShardMetadata(
+            shard_offsets=[0, 0],
+            shard_sizes=[4, 2],
+            placement="rank:0/cpu",
+        )
+        metadata = ShardedTensorMetadata(
+            shards_metadata=[shard_metadata],
+            size=torch.Size([4, 2]),
+            tensor_properties=TensorProperties(
+                dtype=torch.float32,
+                layout=torch.strided,
+                requires_grad=False,
+                pin_memory=False,
+                strides=None,
+            ),
+        )
+        st = ShardedTensorBase._init_from_local_shards_and_global_metadata(
+            [Shard(torch.empty(4, 2), shard_metadata)],
+            metadata,
+        )
+
+        self.assertIsNone(st.metadata().tensor_properties.strides)
+        with torch._C.DisableTorchFunction():
+            self.assertEqual(st.stride(), (2, 1))
+
 
 class TestCreateTensorFromParams(TestCase):
     @skip_but_pass_in_sandcastle_if(not TEST_CUDA, "CUDA GPU is needed")

--- a/test/distributed/checkpoint/test_compatibility.py
+++ b/test/distributed/checkpoint/test_compatibility.py
@@ -1,10 +1,16 @@
 # Owner(s): ["oncall: distributed"]
 
+from typing import cast
 from unittest.mock import patch
 
 import torch
 import torch.distributed.checkpoint as dcp
+from torch.distributed._shard.sharded_tensor.metadata import (
+    MEM_FORMAT_ENCODING as SHARDED_MEM_FORMAT_ENCODING,
+    TensorProperties as ShardedTensorProperties,
+)
 from torch.distributed.checkpoint.metadata import (
+    _MEM_FORMAT_ENCODING,
     BytesStorageMetadata,
     ChunkStorageMetadata,
     Metadata,
@@ -18,6 +24,15 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.testing._internal.distributed.checkpoint_utils import with_temp_dir
+
+
+class _TensorLikeWithoutStride:
+    dtype = torch.float32
+    layout = torch.strided
+    requires_grad = False
+
+    def is_pinned(self) -> bool:
+        return False
 
 
 class TestDCPCompatbility(TestCase):
@@ -100,6 +115,95 @@ class TestDCPCompatbility(TestCase):
         dcp._version._act_like_version = None
         dcp.load(load_sd, checkpoint_id=self.temp_dir)
         self.assertEqual(sd, load_sd)
+
+    def test_tensor_properties_backward_compat_without_strides(self) -> None:
+        """Ensure TensorProperties pickled before the strides field was added can still be loaded."""
+        import pickle
+
+        # Simulate an old checkpoint's pickled TensorProperties (5-element state, no strides).
+        props = TensorProperties(dtype=torch.float32)
+        old_state = (
+            torch.float32,
+            torch.strided,
+            False,
+            _MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT,
+            False,
+        )
+
+        # Verify the current round-trip works (6-element state).
+        props_bytes = pickle.dumps(props)
+        restored_new = pickle.loads(props_bytes)
+        self.assertIsNone(restored_new.strides)
+
+        # Directly test __setstate__ with a 5-element tuple.
+        restored_old = TensorProperties.__new__(TensorProperties)
+        restored_old.__setstate__(old_state)
+        self.assertIsNone(restored_old.strides)
+        self.assertEqual(restored_old.dtype, torch.float32)
+        self.assertEqual(restored_old.memory_format, torch.contiguous_format)
+
+    def test_tensor_properties_strides_survive_pickle_roundtrip(self) -> None:
+        """Ensure strides survive a pickle round-trip (as used by torch.save/load)."""
+        import pickle
+
+        tensor = torch.rand(3, 4)
+        props = TensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (4, 1))
+
+        restored = pickle.loads(pickle.dumps(props))
+        self.assertEqual(restored.strides, (4, 1))
+        self.assertEqual(restored.dtype, torch.float32)
+
+    def test_tensor_properties_tensor_like_without_stride(self) -> None:
+        tensor_like = cast(torch.Tensor, _TensorLikeWithoutStride())
+        props = TensorProperties.create_from_tensor(tensor_like)
+        self.assertIsNone(props.strides)
+        self.assertFalse(props.pin_memory)
+
+    def test_sharded_tensor_properties_tensor_like_without_stride(self) -> None:
+        tensor_like = cast(torch.Tensor, _TensorLikeWithoutStride())
+        props = ShardedTensorProperties.create_from_tensor(tensor_like)
+        self.assertIsNone(props.strides)
+        self.assertFalse(props.pin_memory)
+
+    def test_sharded_tensor_properties_backward_compat_without_strides(self) -> None:
+        """Ensure sharded tensor TensorProperties also handles old pickles without strides."""
+        old_state = (
+            torch.float32,
+            torch.strided,
+            False,
+            SHARDED_MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT,
+            False,
+        )
+        restored = ShardedTensorProperties.__new__(ShardedTensorProperties)
+        restored.__setstate__(old_state)
+        self.assertIsNone(restored.strides)
+        self.assertEqual(restored.dtype, torch.float32)
+
+    def test_sharded_tensor_properties_strides_roundtrip(self) -> None:
+        """Ensure sharded tensor TensorProperties preserves strides through getstate/setstate."""
+        tensor = torch.rand(3, 4)
+        props = ShardedTensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (4, 1))
+
+        state = props.__getstate__()
+        self.assertEqual(len(state), 6)
+
+        restored = ShardedTensorProperties.__new__(ShardedTensorProperties)
+        restored.__setstate__(state)
+        self.assertEqual(restored.strides, (4, 1))
+        self.assertEqual(restored.dtype, torch.float32)
+
+    def test_sharded_tensor_properties_non_contiguous_strides(self) -> None:
+        """Ensure sharded tensor TensorProperties captures non-contiguous strides."""
+        tensor = torch.rand(5, 10).t()  # shape [10, 5], strides (1, 10)
+        props = ShardedTensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (1, 10))
+
+        state = props.__getstate__()
+        restored = ShardedTensorProperties.__new__(ShardedTensorProperties)
+        restored.__setstate__(state)
+        self.assertEqual(restored.strides, (1, 10))
 
 
 if __name__ == "__main__":

--- a/test/distributed/checkpoint/test_planner.py
+++ b/test/distributed/checkpoint/test_planner.py
@@ -165,6 +165,33 @@ class TestCheckpointableTensorDistributed(DTensorTestBase):
         self.assertEqual(expected, loaded)
 
 
+class TestTensorPropertiesStrides(TestCase):
+    def test_create_from_tensor_populates_strides(self):
+        tensor = torch.rand(4, 8)  # shape [4, 8], strides (8, 1)
+        props = TensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (8, 1))
+
+    def test_create_from_tensor_non_contiguous_strides(self):
+        tensor = torch.rand(5, 10).t()  # shape [10, 5], strides (1, 10)
+        props = TensorProperties.create_from_tensor(tensor)
+        self.assertEqual(props.strides, (1, 10))
+
+    def test_create_from_tensor_transposed_strides(self):
+        tensor = torch.rand(2, 1).t()  # shape [1, 2], strides (1, 1)
+        self.assertEqual(tensor.shape, (1, 2))
+        self.assertEqual(tensor.stride(), (1, 1))
+
+        props = TensorProperties.create_from_tensor(tensor)
+        # Test that even though (2, 1) is a valid stride,
+        # but we still retain the original strides (1, 1)
+        self.assertEqual(props.strides, tensor.stride())
+        self.assertNotEqual(props.strides, (2, 1))
+
+    def test_strides_default_none(self):
+        props = TensorProperties(dtype=torch.float32)
+        self.assertIsNone(props.strides)
+
+
 class TestSavePlan(TestCase):
     @with_fake_comms(rank=1, world_size=4)
     def test_local_plan(self):

--- a/torch/distributed/_shard/sharded_tensor/api.py
+++ b/torch/distributed/_shard/sharded_tensor/api.py
@@ -97,8 +97,9 @@ class ShardedTensorBase(torch.Tensor):
         if dtype is None:
             dtype = torch.get_default_dtype()
 
+        strides = kwargs.get("strides")
         tensor_properties = TensorProperties(
-            dtype, layout, requires_grad, pin_memory=pin_memory
+            dtype, layout, requires_grad, pin_memory=pin_memory, strides=strides
         )
         sharded_tensor_metadata = sharding_spec.build_metadata(
             sizes, tensor_properties=tensor_properties
@@ -107,6 +108,7 @@ class ShardedTensorBase(torch.Tensor):
         r = torch.Tensor._make_wrapper_subclass(
             cls,
             sizes,
+            strides=strides,
             dtype=dtype,
             layout=layout,
             pin_memory=pin_memory,
@@ -171,6 +173,7 @@ class ShardedTensorBase(torch.Tensor):
             layout=tensor_properties.layout,
             pin_memory=tensor_properties.pin_memory,
             requires_grad=tensor_properties.requires_grad,
+            strides=tensor_properties.strides,
         )
 
         # check if shards_metadata have overlap shards
@@ -995,6 +998,7 @@ class ShardedTensor(ShardedTensorBase):
             layout=tensor_properties.layout,
             pin_memory=tensor_properties.pin_memory,
             requires_grad=tensor_properties.requires_grad,
+            strides=tensor_properties.strides,
         )
 
         def _raise_if_mismatch(expected, actual, prop_name, rank, is_property=False):

--- a/torch/distributed/_shard/sharded_tensor/metadata.py
+++ b/torch/distributed/_shard/sharded_tensor/metadata.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import cast
 
 import torch
 from torch.distributed._shard.metadata import ShardMetadata
@@ -23,6 +24,8 @@ class TensorProperties:
     memory_format: torch.memory_format = field(default=torch.contiguous_format)
     pin_memory: bool = False
 
+    strides: tuple[int, ...] | None = None
+
     def __getstate__(self):
         # Since torch.memory_format cannot be pickled!
         memory_format = self.memory_format
@@ -41,19 +44,31 @@ class TensorProperties:
             self.requires_grad,
             mem_format_encoding,
             self.pin_memory,
+            self.strides,
         )
 
     def __setstate__(
         self,
         state,
     ):
-        (
-            self.dtype,
-            self.layout,
-            self.requires_grad,
-            mem_format_encoding,
-            self.pin_memory,
-        ) = state
+        if len(state) == 5:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+            ) = state
+            self.strides = None
+        else:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+                self.strides,
+            ) = state
 
         if mem_format_encoding == MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT:
             memory_format = torch.contiguous_format
@@ -70,12 +85,14 @@ class TensorProperties:
 
     @staticmethod
     def create_from_tensor(tensor: torch.Tensor) -> "TensorProperties":
+        stride = getattr(tensor, "stride", None)
         return TensorProperties(
             dtype=tensor.dtype,
             layout=tensor.layout,
             requires_grad=tensor.requires_grad,
             memory_format=torch.contiguous_format,
             pin_memory=tensor.is_pinned(),
+            strides=cast(tuple[int, ...], stride()) if callable(stride) else None,
         )
 
 

--- a/torch/distributed/checkpoint/metadata.py
+++ b/torch/distributed/checkpoint/metadata.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 import torch
 from torch.distributed.checkpoint.stateful import StatefulT
@@ -54,6 +54,8 @@ class TensorProperties:
     # This field is deprecated.
     pin_memory: bool = False
 
+    strides: tuple[int, ...] | None = None
+
     def __getstate__(self):
         # Since torch.memory_format cannot be pickled!
         memory_format = self.memory_format
@@ -72,19 +74,31 @@ class TensorProperties:
             self.requires_grad,
             mem_format_encoding,
             self.pin_memory,
+            self.strides,
         )
 
     def __setstate__(
         self,
         state,
     ):
-        (
-            self.dtype,
-            self.layout,
-            self.requires_grad,
-            mem_format_encoding,
-            self.pin_memory,
-        ) = state
+        if len(state) == 5:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+            ) = state
+            self.strides = None
+        else:
+            (
+                self.dtype,
+                self.layout,
+                self.requires_grad,
+                mem_format_encoding,
+                self.pin_memory,
+                self.strides,
+            ) = state
 
         if mem_format_encoding == _MEM_FORMAT_ENCODING.TORCH_CONTIGUOUS_FORMAT:
             memory_format = torch.contiguous_format
@@ -101,12 +115,14 @@ class TensorProperties:
 
     @staticmethod
     def create_from_tensor(tensor: torch.Tensor) -> "TensorProperties":
+        stride = getattr(tensor, "stride", None)
         return TensorProperties(
             dtype=tensor.dtype,
             layout=tensor.layout,
             requires_grad=tensor.requires_grad,
             memory_format=torch.contiguous_format,
             pin_memory=tensor.is_pinned(),
+            strides=cast(tuple[int, ...], stride()) if callable(stride) else None,
         )
 
 

--- a/torch/distributed/checkpoint/planner_helpers.py
+++ b/torch/distributed/checkpoint/planner_helpers.py
@@ -171,6 +171,7 @@ def _sharded_tensor_metadata(
         requires_grad=shard_properties.requires_grad,
         memory_format=shard_properties.memory_format,
         pin_memory=shard_properties.pin_memory,
+        strides=shard_properties.strides,
     )
 
     return TensorWriteData(


### PR DESCRIPTION
Summary:

Add optional strides to PyTorch DCP and sharded TensorProperties while preserving legacy pickle compatibility. S694227 occurred because PartiallyMaterializedTensor is passed through APIs typed as torch.Tensor but has no stride attribute. Both shared metadata constructors now call stride only when a callable attribute exists and record None otherwise, allowing downstream contiguous fallback. Regression coverage includes generic tensor-like objects and a real FBGEMM PartiallyMaterializedTensor through both ModelStore metadata paths.

Test Plan:
buck test fbcode//mode/opt fbcode//caffe2/test/distributed/checkpoint:test_planner fbcode//caffe2/test/distributed/checkpoint:test_compatibility fbcode//aiplatform/modelstore/experimental/DCP/planners/tests:modelstore_save_planner_test
https://www.internalfb.com/intern/testinfra/testrun/5910974891858832 (42 passed)

buck test fbcode//mode/opt fbcode//aiplatform/modelstore/experimental/DCP/planners/tests:modelstore_save_planner_test-library-type-checking fbcode//aiplatform/modelstore/experimental/DCP/planners/tests:modelstore_save_planner_test
https://www.internalfb.com/intern/testinfra/testrun/5348024939975086 (5 passed)

S694227 regression on the full stack:
buck test fbcode//mode/opt fbcode//minimal_viable_ai/models/blue_reels_vdd/v5/gpu_tests:hstu_standalone_cint_toy_train_and_publish_test -- --exact 'fbcode//minimal_viable_ai/models/blue_reels_vdd/v5/gpu_tests:hstu_standalone_cint_toy_train_and_publish_test - test_train (minimal_viable_ai.models.blue_reels_vdd.v5.gpu_tests.hstu_standalone_cint_toy_train_and_publish_test.ModelHstuStandaloneCintTest)'
https://www.internalfb.com/intern/testinfra/testrun/6192449817165760 (1 passed)

buck test fbcode//mode/opt fbcode//aiplatform/modelstore/experimental/integration_tests/tests/nosan:multi_rank_kvtensor_save_load_test
https://www.internalfb.com/intern/testinfra/testrun/10696049303744220 (3 passed)

arc f
arc lint

Reviewed By: meetv18, sibuachu

Differential Revision: D115449673


