### PR TITLE
[precompile] emit Dynamo training artifacts

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -50,7 +50,7 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 % intentionally omitted from the autosummary block above.
 
 ```{eval-rst}
-.. py:function:: precompile(fn, *, example_inputs, backend="inductor", tracer="make_fx", decompositions=None)
+.. py:function:: precompile(fn, *, example_inputs, backend="inductor", tracer="make_fx", decompositions=None, training=False)
 
    Ahead-of-time precompile ``fn`` against example inputs, returning a self-contained,
    runnable Python source string plus an acceleration cache as ``(python_code, cache)``.
@@ -97,6 +97,14 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
       functions that capture its locals, and ``nn.Module`` arguments are not supported
       yet because their identity guards are not serializable.
 
+      Pass ``training=True`` with ``tracer="dynamo"`` and ``backend="inductor"`` to
+      capture differentiable graphs. Each compiled segment contains readable Inductor
+      source for both its AOTAutograd forward and backward, bridged by an emitted
+      ``torch.autograd.Function``. Outputs retain their ``grad_fn``, so a later
+      ``backward()`` executes the captured backward kernels. Training works across the
+      captured recompilations and graph breaks. Only first-order backward is supported;
+      tensor-subclass and ``BackwardState`` training graphs are rejected.
+
    With ``tracer="make_fx"``, if ``fn`` runs a backward, the artifact re-runs the whole
    forward and backward and scatters the resulting parameter gradients onto the runtime
    model's ``parameters()`` ``.grad`` fields, accumulating (``p.grad += g``) exactly like
@@ -123,6 +131,9 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
    :param decompositions: Optional decomposition table (``dict`` of ``OpOverload`` to a
        decomposition function) forwarded to ``make_fx``; defaults to ``None`` and is not
        yet supported with ``tracer="dynamo"``.
+   :param training: If ``True``, capture a differentiable Dynamo/Inductor artifact whose
+       outputs can be passed to ``backward()``. Defaults to ``False`` and currently
+       requires ``tracer="dynamo"`` and ``backend="inductor"``.
    :returns: ``(python_code, cache)`` -- a self-contained Python source string (the
        single source of truth for the calling convention) and a binary acceleration
        cache (no weights, no calling-convention metadata; it carries a small
@@ -146,6 +157,16 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        )
        f = torch.compiler.precompile.load(python_code, cache)
        out = f(torch.randn(7, 4))  # served by the captured dynamic variant
+
+   Dynamo training::
+
+       examples = [(torch.randn(n, 4, requires_grad=True),) for n in (2, 3)]
+       python_code, cache = torch.compiler.precompile(
+           fn, example_inputs=examples, tracer="dynamo", training=True
+       )
+       f = torch.compiler.precompile.load(python_code, cache)
+       x = torch.randn(7, 4, requires_grad=True)
+       f(x).sum().backward()  # executes the captured backward kernels
 ```
 
 ```{eval-rst}

--- a/docs/source/user_guide/torch_compiler/torch.compiler.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler.md
@@ -48,6 +48,9 @@ one from all capture examples can silently miscompute. Initial support is for Py
 functions with tensor, scalar, and Python-container arguments. Graph breaks and
 closure-free `torch._dynamo.disable` functions are preserved; top-level closures,
 nested functions that capture locals, and `nn.Module` arguments are not supported yet.
+With `training=True` and the Inductor backend, Dynamo graphs include readable compiled
+forward and backward code, so served outputs retain a `grad_fn` and can be passed to
+`backward()`. This training mode works across captured recompilations and graph breaks.
 See the {ref}`API reference <torch.compiler_api>` for details.
 
 :::{warning}

--- a/test/functorch/test_compile_to_python.py
+++ b/test/functorch/test_compile_to_python.py
@@ -203,6 +203,56 @@ class TestAOTCompileToPython(TestCase):
                     load_from_python(src, cache)(_flat_inputs(m, x))[0], m(x)
                 )
 
+    def test_training_graph_composes_forward_and_backward(self):
+        # grad_enabled with inputs that require grad makes AOTAutograd emit a
+        # JOINT forward+backward: two dense graphs, bridged by an autograd
+        # Function the composer emits (its forward/backward bodies are
+        # AOTAutograd's own codegen'd source). The served output must therefore
+        # carry grad_fn and its .backward() must run the compiled backward.
+        m = torch.nn.Linear(4, 3)
+        x = torch.randn(5, 4)
+        for p in m.parameters():
+            p.grad = None
+        m(x).sum().backward()
+        expected = {n: p.grad.detach().clone() for n, p in m.named_parameters()}
+
+        gm = _capture(m, x)
+        with torch.enable_grad():
+            src, _cache = compile_to_python(gm, _flat_inputs(m, x), grad_enabled=True)
+        # Both inductor modules and the backward wrappers are inlined as source.
+        self.assertIn("_inner_call_fw", src)
+        self.assertIn("_inner_call_bw", src)
+        self.assertIn("def _backward_prologue(", src)
+        self.assertIn("class _CompiledFunction(torch.autograd.Function):", src)
+        self.assertNotIn("pickle.loads", src)
+
+        out = _exec(src)(_flat_inputs(m, x))
+        out = out[0] if isinstance(out, (list, tuple)) else out
+        self.assertIsNotNone(out.grad_fn)
+        for p in m.parameters():
+            p.grad = None
+        out.sum().backward()
+        for name, param in m.named_parameters():
+            self.assertEqual(param.grad, expected[name])
+
+    def test_training_forward_and_backward_do_not_share_names(self):
+        # The two inductor modules are spliced into ONE namespace and both define
+        # call / Runner / their kernels. A module resolves those as late-bound
+        # globals when INVOKED, so without per-module renaming the forward runs
+        # the backward's kernels -- which surfaces as an arity error, or worse.
+        m = torch.nn.Linear(4, 3)
+        x = torch.randn(5, 4)
+        gm = _capture(m, x)
+        with torch.enable_grad():
+            src, _cache = compile_to_python(gm, _flat_inputs(m, x), grad_enabled=True)
+        tree = ast.parse(src)
+        names = [
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.ClassDef))
+        ]
+        self.assertEqual(len(names), len(set(names)), f"duplicate top-level: {names}")
+
     def test_linear_addmm_runs_like_eager(self):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -1226,6 +1226,81 @@ class TestPrecompile(TestCase):
                 x = torch.randn(size, 4)
                 self.assertEqual(loaded(x), _precompile_dynamo_dynamic(x))
 
+    @torch._dynamo.config.patch(
+        automatic_dynamic_shapes=True, assume_static_by_default=True
+    )
+    def test_tracer_dynamo_training_recompiles_to_dynamic_graph(self):
+        examples = [(torch.randn(size, 4, requires_grad=True),) for size in (2, 3, 5)]
+        code, cache = torch.compiler.precompile(
+            _precompile_dynamo_dynamic,
+            example_inputs=examples,
+            tracer="dynamo",
+            training=True,
+        )
+
+        self.assertIn("TRAINING = True", code)
+        self.assertIn("DYNAMIC_GRAPH_COUNT = 1", code)
+        self.assertIn("class _CompiledFunction(torch.autograd.Function):", code)
+        self.assertIn("_inner_call_fw", code)
+        self.assertIn("_inner_call_bw", code)
+        for _, loaded in _default_and_inlined_loaders(code, cache, "inductor"):
+            x = torch.randn(7, 4, requires_grad=True)
+            ref = x.detach().clone().requires_grad_()
+            expected = _precompile_dynamo_dynamic(ref)
+            expected.sum().backward()
+            actual = loaded(x)
+            self.assertTrue(actual.requires_grad)
+            actual.sum().backward()
+            self.assertEqual(actual, expected)
+            self.assertEqual(x.grad, ref.grad)
+
+    def test_tracer_dynamo_training_source_runs_in_fresh_process(self):
+        x = torch.randn(4, requires_grad=True)
+        code, _cache = torch.compiler.precompile(
+            _precompile_dynamo_dynamic,
+            example_inputs=[(x,)],
+            tracer="dynamo",
+            training=True,
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as artifact:
+            artifact.write(code)
+            artifact_path = artifact.name
+        try:
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-c",
+                    textwrap.dedent(
+                        """
+                        import runpy as r
+                        import sys as s
+                        import torch as t
+
+                        namespace = r.run_path(s.argv[1])
+                        x = t.randn(4, requires_grad=True)
+                        out = namespace["forward"](x)
+                        assert out.requires_grad
+                        out.sum().backward()
+                        t.testing.assert_close(x.grad, x.detach().cos())
+                        """
+                    ),
+                    artifact_path,
+                ]
+            )
+        finally:
+            os.unlink(artifact_path)
+
+    def test_training_requires_dynamo_inductor(self):
+        x = torch.randn(4, requires_grad=True)
+        for kwargs in ({}, {"tracer": "dynamo", "backend": "eager"}):
+            with self.assertRaisesRegex(NotImplementedError, "dynamo.*inductor"):
+                torch.compiler.precompile(
+                    _precompile_dynamo_dynamic,
+                    example_inputs=[(x,)],
+                    training=True,
+                    **kwargs,
+                )
+
     def test_dynamo_backend_source_literal_roundtrip(self):
         source = 'slash = "\\\\n"\ntriple = \'"""\'\n'
         namespace = {}
@@ -1276,6 +1351,28 @@ class TestPrecompile(TestCase):
             )
         finally:
             os.unlink(artifact_path)
+
+    def test_tracer_dynamo_training_across_disabled_graph_break(self):
+        x = torch.randn(4, requires_grad=True)
+        code, cache = torch.compiler.precompile(
+            _precompile_dynamo_with_disabled,
+            example_inputs=[(x,)],
+            tracer="dynamo",
+            training=True,
+        )
+
+        self.assertEqual(
+            code.count("class _CompiledFunction(torch.autograd.Function):"), 2
+        )
+        for _, loaded in _default_and_inlined_loaders(code, cache, "inductor"):
+            actual_input = torch.randn(4, requires_grad=True)
+            ref_input = actual_input.detach().clone().requires_grad_()
+            expected = _precompile_dynamo_with_disabled(ref_input)
+            expected.sum().backward()
+            actual = loaded(actual_input)
+            actual.sum().backward()
+            self.assertEqual(actual, expected)
+            self.assertEqual(actual_input.grad, ref_input.grad)
 
     def test_tracer_dynamo_rebinds_imported_graph_break_alias(self):
         x = torch.randn(4)
@@ -2950,6 +3047,44 @@ class TestPrecompileNumerics(TestCase):
             for size in (1, 7):
                 x = make_tensor((size, 4), device=device, dtype=torch.float32)
                 self.assertEqual(loaded(x), _precompile_dynamo_with_disabled(x))
+
+    @onlyCUDA
+    @torch._dynamo.config.patch(
+        automatic_dynamic_shapes=True, assume_static_by_default=True
+    )
+    def test_tracer_dynamo_training_cuda(self, device):
+        from torch._inductor.utils import fresh_cache
+
+        examples = [
+            (
+                make_tensor(
+                    (size, 4), device=device, dtype=torch.float32, requires_grad=True
+                ),
+            )
+            for size in (2, 3, 5)
+        ]
+        with fresh_cache():
+            code, cache = torch.compiler.precompile(
+                _precompile_dynamo_dynamic,
+                example_inputs=examples,
+                tracer="dynamo",
+                training=True,
+            )
+
+        self.assertIn("DYNAMIC_GRAPH_COUNT = 1", code)
+        self.assertIn("_inner_call_bw", code)
+        self.assertIn("@triton.jit", code)
+        for _, loaded in _default_and_inlined_loaders(code, cache, "inductor"):
+            x = make_tensor(
+                (7, 4), device=device, dtype=torch.float32, requires_grad=True
+            )
+            ref = x.detach().clone().requires_grad_()
+            expected = _precompile_dynamo_dynamic(ref)
+            expected.sum().backward()
+            actual = loaded(x)
+            actual.sum().backward()
+            self.assertEqual(actual, expected)
+            self.assertEqual(x.grad, ref.grad)
 
     def test_plain_function(self, device):
         def f(x, y):

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -12,6 +12,7 @@ import copy
 import functools
 import itertools
 import pprint
+import threading
 import typing
 import warnings
 import weakref
@@ -3337,6 +3338,9 @@ class _AOTDispatchAutogradFunctionFactory:
     spec: AOTDispatchAutogradCompileSpec
 
     def build(self) -> type[torch.autograd.Function]:
+        sink = getattr(_aot_dispatch_autograd_capture_tls, "sink", None)
+        if sink is not None:
+            sink.append(self.spec)
         compile_id = CompileContext.current_compile_id()
         compile_id_str = str(compile_id) if compile_id is not None else None
         self.spec.fw_metadata.compile_id_str = compile_id_str
@@ -3618,6 +3622,22 @@ class _AOTDispatchAutogradFunctionFactory:
                 )
 
         return CompiledFunction
+
+
+_aot_dispatch_autograd_capture_tls = threading.local()
+
+
+@contextlib.contextmanager
+def capture_aot_dispatch_autograd_specs(
+    into: list[AOTDispatchAutogradCompileSpec],
+) -> Generator[None, None, None]:
+    """Record autograd-function specs built on this thread within the context."""
+    previous = getattr(_aot_dispatch_autograd_capture_tls, "sink", None)
+    _aot_dispatch_autograd_capture_tls.sink = into
+    try:
+        yield
+    finally:
+        _aot_dispatch_autograd_capture_tls.sink = previous
 
 
 # This is wrapped in a class just for namespacing purposes

--- a/torch/_functorch/_aot_autograd/to_standalone_python.py
+++ b/torch/_functorch/_aot_autograd/to_standalone_python.py
@@ -116,7 +116,8 @@ _COMPILE_LOCK = threading.RLock()
 # We do NOT reimplement any of this. We CAPTURE AOTAutograd's exact codegen'd wrapper
 # source together with the (pre-exec) globals dict each wrapper closed over: a
 # thread-local sink in codegen.py records one GeneratedSource per wrapper.
-# To trigger the capture we run AOTAutograd ourselves (under no_grad, the inference path)
+# To trigger the capture we run AOTAutograd ourselves, using grad mode to select the
+# inference path or a joint forward/backward; see ``compile_to_python.grad_enabled``.
 # with a capture-only inner compiler: it grabs the dense inner graph and returns a
 # placeholder callable, so AOTAutograd still codegen's the runtime-wrapper chain AROUND
 # that placeholder -- which is what the sink records. Inductor does not run in that pass;
@@ -828,7 +829,12 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     strides has static sizes, and treating it as static would silently specialize the
     artifact to the example strides. (Unbacked symints appearing only in intermediates,
     not on any placeholder, are still missed here, but such a graph fails loudly
-    downstream when emit_value rejects the still-symbolic metadata.)"""
+    downstream when emit_value rejects the still-symbolic metadata.)
+
+    Both metadata keys are checked, like ``_resolve_fake_mode``: make_fx stashes the fake
+    under "val", while a Dynamo graph (which torch.compiler.precompile's dynamo tracer
+    feeds here) stashes it under "example_value" -- reading only "val" would call a
+    dynamic Dynamo graph static and silently specialize it to the example sizes."""
     import torch
 
     def _is_symbolic(v: Any) -> bool:
@@ -850,13 +856,346 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     return False
 
 
+def namespace_module_names(sources: Sequence[str]) -> list[str]:
+    """Suffix every top-level name each module DEFINES, per module.
+
+    Splicing several Inductor modules into ONE namespace is only safe if their
+    top-level names are disjoint, because the code inside a module resolves its
+    siblings as late-bound globals: a module's ``call`` looks up its kernels and
+    its ``_runtime_wrapper`` when INVOKED, not when defined. Two modules of the
+    same computation -- a forward and its backward, or two shape variants of one
+    frame -- otherwise define the same names, and the first silently runs the
+    second's code. Snapshotting each module's entry is not enough for the same
+    reason.
+
+    Rewriting is driven by AST positions rather than a text match, which is what
+    keeps three lookalikes out of it: an attribute (``runner.call`` is an
+    ``Attribute``, not a ``Name``), a nested binding (``def call`` inside
+    ``class Runner`` is not module-level), and an import (``async_compile`` is
+    both a local binding and part of ``torch._inductor.async_compile``).
+    """
+    out: list[str] = []
+    for slot, source in enumerate(sources):
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        defined: set[str] = set()
+        headers: list[tuple[int, str]] = []
+        for node in tree.body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    imported.add((alias.asname or alias.name).split(".")[0])
+            elif isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                defined.add(node.name)
+                headers.append((node.lineno, node.name))
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        defined.add(target.id)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                defined.add(node.target.id)
+        targets = defined - imported
+        if not targets:
+            out.append(source)
+            continue
+        suffix = f"_s{slot}"
+        edits: dict[int, list[tuple[int, int, str]]] = {}
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Name)
+                and node.id in targets
+                and node.end_col_offset is not None
+            ):
+                edits.setdefault(node.lineno, []).append(
+                    (node.col_offset, node.end_col_offset, node.id + suffix)
+                )
+        lines = source.split("\n")
+        for lineno, name in headers:
+            if name not in targets:
+                continue
+            found = re.search(rf"\b{re.escape(name)}\b", lines[lineno - 1])
+            if found is not None:
+                edits.setdefault(lineno, []).append(
+                    (found.start(), found.end(), name + suffix)
+                )
+        for lineno, spans in edits.items():
+            line = lines[lineno - 1]
+            for begin, finish, text in sorted(spans, reverse=True):
+                line = line[:begin] + text + line[finish:]
+            lines[lineno - 1] = line
+        out.append("\n".join(lines))
+    return out
+
+
+def _compose_training_module(
+    fw_python: str,
+    bw_python: str,
+    captured: list[GeneratedSource],
+    spec: Any,
+) -> str:
+    """Compose a FORWARD and BACKWARD lowering into one standalone module.
+
+    The inference composer nests wrappers around a single ``call``. Training is a
+    different shape: AOTAutograd's own bridge is a ``torch.autograd.Function``
+    whose ``forward``/``backward`` bodies ARE codegen'd source
+    (``compiled_function_forward`` / ``compiled_function_backward``, with
+    ``backward_prologue`` / ``backward_epilogue`` beside them), but the class
+    holding them is ordinary Python, so the composer emits it.
+
+    Both inductor modules are spliced at module level and each one's entry is
+    snapshotted immediately, because the second block rebinds ``call`` /
+    ``Runner`` / the kernels that the first block's code resolves as late-bound
+    globals.
+    """
+
+    from . import runtime_wrappers as _rw
+
+    if spec.maybe_subclass_meta is not None:
+        raise NotImplementedError(
+            "aot_autograd.compile_to_python cannot compose a training graph with "
+            "tensor subclasses into standalone source yet."
+        )
+    if spec.backward_state_indices:
+        raise NotImplementedError(
+            "aot_autograd.compile_to_python cannot compose a training graph that "
+            "carries a BackwardState into standalone source yet."
+        )
+
+    by_name: dict[str, list[GeneratedSource]] = {}
+    for gen in captured:
+        by_name.setdefault(gen.artifact_name, []).append(gen)
+    missing = [
+        name
+        for name in (
+            "backward_prologue",
+            "backward_epilogue",
+            "compiled_function_forward",
+            "compiled_function_backward",
+            "runtime_wrapper_orchestration",
+        )
+        if name not in by_name
+    ]
+    if missing:
+        raise NotImplementedError(
+            f"aot_autograd.compile_to_python: the training compose expects "
+            f"AOTAutograd to codegen {missing}, which this graph did not produce."
+        )
+
+    imports: set[str] = set()
+    helper_table = _known_helper_table()
+
+    def splice(gen: GeneratedSource) -> str:
+        hoists = []
+        for name, obj in gen.globals_dict.items():
+            if name == "__builtins__":
+                continue
+            expr = _resolve_global(obj, helper_table, None, {}, imports)
+            if name != expr:
+                hoists.append(f"{name} = {expr}")
+        return "\n".join(hoists + [gen.source, ""])
+
+    blocks = [
+        splice(gen)
+        for name in (
+            "backward_prologue",
+            "backward_epilogue",
+            "compiled_fn_wrapper",
+            "compiled_function_forward",
+            "compiled_function_backward",
+        )
+        for gen in by_name.get(name, [])
+    ]
+    orchestration = splice(by_name["runtime_wrapper_orchestration"][0])
+
+    fw_metadata_src = emit_value(spec.fw_metadata, imports)
+    rng_src = emit_value(
+        _rw._AutogradRngStateTracker(
+            num_rng=spec.fw_metadata.num_graphsafe_rng_states,
+            graphsafe_idx=spec.fw_metadata.graphsafe_rng_state_index,
+            device=spec.fw_metadata.graphsafe_rng_device,
+        ),
+        imports,
+    )
+    imports |= {
+        "import contextlib",
+        "import torch",
+        "import weakref",
+        "from torch._functorch._aot_autograd.runtime_wrappers import "
+        "_AutogradSavedState, _snapshot_external_objects, "
+        "index_to_external_object_weakref",
+        "from torch._functorch._aot_autograd.standalone_runtime import "
+        "normalize_as_list",
+    }
+
+    glue = f"""
+_fw_metadata = {fw_metadata_src}
+_saved_state = _AutogradSavedState(metadata=_fw_metadata)
+_rng_state = {rng_src}
+_NUM_FORWARD_RETURNS = {spec.fw_metadata.num_forward_returns}
+_DISABLE_AMP = {spec.disable_amp!r}
+
+
+def _finalize(ctx, fw_outs):
+    raw_returns = list(fw_outs[:_NUM_FORWARD_RETURNS])
+    ctx.mark_non_differentiable(*_transform_raw_returns(raw_returns))
+    ctx._materialize_non_diff_grads = False
+    _snapshot_external_objects(ctx)
+    return tuple(raw_returns)
+
+
+def _backward_impl(ctx, all_args):
+    ctx.maybe_clear_saved_tensors()
+    for idx, obj in getattr(ctx, "_external_objects", {{}}).items():
+        index_to_external_object_weakref[idx] = weakref.ref(obj)
+    amp = torch._C._DisableAutocast if _DISABLE_AMP else contextlib.nullcontext
+    with amp():
+        out = _inner_call_bw(all_args)
+    return normalize_as_list(out)
+
+
+def _double_backward(ctx, impl_fn, all_args):
+    class _DoubleBackward(torch.autograd.Function):
+        @staticmethod
+        def forward(double_ctx, *unused_args):
+            return impl_fn(double_ctx)
+
+        @staticmethod
+        def backward(ctx, *args):
+            raise RuntimeError(
+                "torch.compile with aot_autograd does not currently support "
+                "double backward"
+            )
+
+    if not any(t.requires_grad for t in all_args if isinstance(t, torch.Tensor)):
+        all_args = [torch.empty(0, requires_grad=True)] + all_args
+    return _DoubleBackward.apply(*all_args)
+
+
+class _CompiledFunction(torch.autograd.Function):
+    boxed_grads_call = True
+
+    @staticmethod
+    def forward(ctx, *deduped_flat_tensor_args):
+        return _compiled_forward(
+            ctx,
+            deduped_flat_tensor_args,
+            _rng_state.add_forward_args,
+            _saved_state.save_from_forward,
+            _finalize,
+            _inner_call_fw,
+        )
+
+    @staticmethod
+    def backward(ctx, *flat_args):
+        return _compiled_backward(
+            flat_args,
+            ctx,
+            _backward_prologue,
+            _rng_state.add_backward_args,
+            _backward_impl,
+            _backward_epilogue,
+            _double_backward,
+        )
+
+
+def _boxed_autograd_apply(args):
+    return _CompiledFunction.apply(*args)
+
+
+def call(flat_inputs):  # noqa: F811
+    return _runtime_wrapper(
+        _boxed_autograd_apply, contextlib.nullcontext, lambda: None, list(flat_inputs)
+    )
+"""
+
+    # Both modules land in this one namespace and each defines ``call``,
+    # ``Runner`` and its kernels; without renaming, the forward's ``call``
+    # resolves the BACKWARD's kernels at invocation time.
+    fw_ns, bw_ns = namespace_module_names([fw_python, bw_python])
+    parts = [
+        "# Generated by aot_autograd.compile_to_python (training) -- do not edit.",
+        "",
+        *sorted(imports),
+        "",
+        "# === Inner Inductor output code: FORWARD ===",
+        fw_ns,
+        "_inner_call_fw = call_s0",
+        "",
+        "# === Inner Inductor output code: BACKWARD ===",
+        bw_ns,
+        "_inner_call_bw = call_s1",
+        "",
+        "# === AOTAutograd runtime wrappers ===",
+        *blocks,
+        orchestration,
+        glue,
+    ]
+    return "\n".join(parts)
+
+
+def _restride_backward_placeholders(
+    bw_gm: GraphModule,
+    fwd_output_strides: Sequence[tuple[int, ...] | None],
+    spec: Any,
+) -> None:
+    """Restride the backward's saved-activation inputs to what the forward chose.
+
+    Layout optimization lets the compiled forward hand back e.g. channels-last
+    saved activations, so the backward must be lowered against those strides
+    rather than the eager ones its joint trace carries. torch.compile does this
+    in ``_aot_stage2b_bw_compile`` with strides reported out of the forward's
+    lowering; this is the same restride against the strides
+    ``_inductor_compile_to_python`` now reports.
+
+    The rewrite lands on ``node.meta["val"]``, NOT on an example-inputs list:
+    ``inductor.compile_to_python`` rebuilds its fakes from the placeholders'
+    metadata and ignores the inputs it is handed, so restriding a list is a
+    silent no-op through that entry point.
+    """
+    import torch
+
+    if not fwd_output_strides:
+        return
+    # Which of the forward's outputs are the saved activations, and where they
+    # sit among the backward's inputs, are both recorded -- guessing positionally
+    # restrides the wrong placeholder and asserts (or miscomputes) at runtime.
+    meta = spec.fw_metadata
+    saved = list(fwd_output_strides[meta.tensors_saved_for_backwards_slice])
+    num_symints = spec.num_symints_saved_for_bw
+    placeholders = [n for n in bw_gm.graph.nodes if n.op == "placeholder"]
+    for index, node in enumerate(placeholders):
+        val = node.meta.get("val")
+        if not isinstance(val, torch.Tensor):
+            continue
+        offset = index - num_symints
+        if not (0 <= offset < len(saved)) or not saved[offset]:
+            continue
+        real = tuple(int(s) for s in saved[offset])
+        if len(real) == val.dim() and tuple(val.stride()) != real:
+            node.meta["val"] = val.as_strided(val.size(), real)
+
+
 def compile_to_python(
     gm: GraphModule,
     example_inputs: Sequence[Any],
     *,
     options: dict[str, Any] | None = None,
+    grad_enabled: bool = False,
 ) -> tuple[str, bytes | None]:
     """Compile ``gm`` to ``(python_code, cache)``; see the module docstring.
+
+    ``grad_enabled`` runs the AOTAutograd capture pass under ``enable_grad`` instead of the
+    default ``no_grad``, and covers two different graphs. One performs autograd INTERNALLY
+    -- a Dynamo graph captured with ``trace_autograd_ops``, whose traced
+    ``torch.autograd.grad`` call needs a live autograd graph to differentiate and otherwise
+    fails the capture pass with "element 0 of tensors does not require grad"; that is still
+    an INFERENCE graph at the AOT boundary, since its backward lives inside the traced call.
+    The other has INPUTS that require grad, and AOTAutograd then emits a joint
+    forward+backward: two dense graphs, composed into a module whose ``call`` returns
+    outputs carrying ``grad_fn``, so the caller's ``.backward()`` runs the compiled
+    backward. Leaving it off pins the inference path, which is what you want for a forward
+    you will never differentiate.
 
     THREADING: serialized by a process-global lock (``_COMPILE_LOCK``). The wrapper-source
     capture is thread-local, but the AOTAutograd pass and the inner inductor compile both
@@ -918,21 +1257,33 @@ def compile_to_python(
         # compile-time token and never runs.
         captured: list[GeneratedSource] = []
         dense: dict[str, Any] = {}
+        # The training compose needs AOTAutograd's own spec (fw_metadata, RNG
+        # state, disable_amp, the saved/symint counts). It is built during the
+        # capture pass and not otherwise reachable from out here.
+        from . import runtime_wrappers as _rw
+
+        specs: list[Any] = []
 
         def _capture_inner_compile(dense_gm, dense_inputs, **kwargs):
-            if "gm" in dense:
+            # A training graph reaches this TWICE -- once for the forward, once
+            # for the backward -- and inductor says which via is_backward. Keep
+            # the "only one of each" guard per slot; a third call is still
+            # something this layer does not model.
+            slot = "bw" if kwargs.get("is_backward") else "gm"
+            if slot in dense:
                 raise NotImplementedError(
                     "aot_autograd.compile_to_python does not support a graph whose "
-                    "AOTAutograd lowering emits more than one inner forward graph."
+                    f"AOTAutograd lowering emits more than one inner {slot} graph."
                 )
-            dense["gm"] = dense_gm
+            dense[slot] = dense_gm
             # Retain the placeholder's IDENTITY: it is the authoritative inner call the
             # runtime-wrapper chain closes over. The composer needs it to tell the inner
             # call apart from the orchestration's own outer closure (both surface as a
             # wrapper's inner-ref yet neither is a captured wrapper fn), which is what
             # separates INNER wrappers from the OUTER dedup / synthetic-base wrappers.
             placeholder = make_boxed_func(dense_gm.forward)
-            dense["placeholder"] = placeholder
+            if slot == "gm":
+                dense["placeholder"] = placeholder
             return placeholder
 
         # Drive inductor's own ``compile_fx`` (i.e. its exact AOTAutograd invocation --
@@ -943,14 +1294,12 @@ def compile_to_python(
         # the graph (there is no dynamic_shapes knob): a symbolically-traced graph uses
         # ``"from_graph"`` to stay dynamic, a static one ``"from_example_inputs"`` to
         # specialize -- matching what the composer can bake (symbolic view metadata is
-        # rejected downstream). no_grad pins the inference path (one forward module).
+        # rejected downstream). grad mode selects an inference forward or a joint
+        # forward/backward.
         # Deepcopy first so compile_fx cannot mutate the caller's gm (torchbind
         # ProcessGroups smuggled through as shared references). Note: the raw-collective /
         # torchbind rewrites are inductor-lowering prereqs and belong to the step-2 inductor
-        # compile, which applies them to the dense graph -- not duplicated here. When
-        # called from a Dynamo backend, reuse its active fake mode: the example inputs
-        # are FakeTensors owned by that mode, so creating another one would mix modes.
-        # Outside Dynamo, infer the mode from the graph as before.
+        # compile, which applies them to the dense graph -- not duplicated here.
         shapes_mode = (
             "from_tracing_context"
             if torch._guards.TracingContext.try_get() is not None
@@ -959,17 +1308,19 @@ def compile_to_python(
             )
         )
         with (
-            torch.no_grad(),
+            torch.enable_grad() if grad_enabled else torch.no_grad(),
             _standalone_context(gm, shapes_mode, aot=False),
             capture_generated_sources(captured),
+            _rw.capture_aot_dispatch_autograd_specs(specs),
         ):
             with _share_torchbind_and_process_group_on_deepcopy():
                 gm_owned = copy.deepcopy(gm)
             compile_fx(
                 gm_owned,
                 example_inputs,
-                # Placeholder returns a boxed callable, not a full OutputCode; AOTAutograd
-                # only wraps it (never inductor-post-compiles it), so this is fine at runtime.
+                # Placeholder returns a boxed callable, not a full OutputCode;
+                # AOTAutograd only wraps it (never inductor-post-compiles it), so
+                # this is fine at runtime.
                 inner_compile=_capture_inner_compile,  # pyrefly: ignore[bad-argument-type]
                 ignore_shape_env=_resolve_ignore_shape_env(shapes_mode),
             )
@@ -979,11 +1330,44 @@ def compile_to_python(
                 "forward compiler, so no dense graph was captured."
             )
 
+        # Lower the FORWARD first and take the strides inductor actually chose,
+        # then restride the backward's placeholders to match before lowering it.
+        # This is the fw->bw coupling torch.compile gets from
+        # TracingContext.report_output_strides (graph_compile.py:2841) and feeds
+        # to _aot_stage2b_bw_compile; a capture pass that never lowers cannot
+        # observe it, and two independently-lowered graphs then disagree about
+        # layout -- loudly on a conv net, silently if size asserts are off.
+        training = "bw" in dense
+        fwd_output_strides: list[tuple[int, ...] | None] = []
         inner_python, cache = _inductor_compile_to_python(
-            dense["gm"], example_inputs, options=options
+            dense["gm"],
+            example_inputs,
+            options=options,
+            is_inference=not training,
+            output_strides=fwd_output_strides,
         )
-        source = _compose_standalone_module(
-            inner_python, captured, dense["placeholder"]
+        if not training:
+            source = _compose_standalone_module(
+                inner_python, captured, dense["placeholder"]
+            )
+            return source, cache
+
+        if len(specs) != 1:
+            raise NotImplementedError(
+                "aot_autograd.compile_to_python expected exactly one training "
+                f"autograd-function spec, captured {len(specs)}."
+            )
+        spec = specs[0]
+
+        _restride_backward_placeholders(dense["bw"], fwd_output_strides, spec)
+        bw_python, _ = _inductor_compile_to_python(
+            dense["bw"], [], options=options, is_inference=False
+        )
+        source = _compose_training_module(
+            inner_python,
+            bw_python,
+            captured,
+            spec,
         )
     return source, cache
 

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -698,6 +698,8 @@ def compile_to_python(
     example_inputs: Sequence[InputType],
     *,
     options: dict[str, Any] | None = None,
+    is_inference: bool = True,
+    output_strides: list[tuple[int, ...] | None] | None = None,
 ) -> tuple[str, bytes | None]:
     """Compile ``gm`` and return ``(inner_python, cache)`` -- the INNER half of the
     backend contract behind ``torch.compiler.precompile``.
@@ -715,6 +717,10 @@ def compile_to_python(
     layer -- a companion change in ``torch._functorch.aot_autograd`` wraps this and
     composes AOTAutograd's codegen'd runtime wrappers around the result.
     Callers must run ``call`` under ``torch.no_grad()`` (the kernels use out= ops).
+    ``is_inference`` selects Inductor's inference or training layout heuristics. If
+    ``output_strides`` is provided, it is extended with the layouts selected for the
+    graph outputs so an AOTAutograd backward can be lowered against the forward's actual
+    saved-activation layouts.
 
     Caller preconditions (this layer does not re-derive them):
 
@@ -853,10 +859,17 @@ def compile_to_python(
             fake_inputs,
             static_input_idxs=(),
             cudagraphs=BoxedBool(False),
-            is_inference=True,
+            is_inference=is_inference,
             boxed_forward_device_index=BoxedDeviceIndex(None),
         )
         artifacts = torch.compiler.save_cache_artifacts()
+    if output_strides is not None:
+        # The strides Inductor CHOSE for this graph's outputs, which only exist
+        # once it has lowered. A training backward has to be compiled against
+        # the forward's actual choices -- layout optimization is free to hand
+        # back channels-last saved activations -- and this is the only channel
+        # for that, since the caller cannot see the CompiledFxGraph.
+        output_strides.extend(getattr(compiled_graph, "output_strides", None) or [])
     inner_python = _runnable_source(compiled_graph)
     cache = _acceleration_cache_bytes(artifacts)
     return inner_python, cache

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -23,6 +23,11 @@ call that fails every retained guard set raises. Compiled graphs and kernels rem
 Python source, while guard trees, transformed entry/resume bytecode, and disabled-
 function bytecode are stored as opaque inline data.
 
+With ``tracer="dynamo", training=True`` (inductor backend only), every compiled segment
+contains AOTAutograd's forward and backward as readable Inductor source. The served
+output retains its ``grad_fn`` and a later ``backward()`` executes those captured
+backward kernels, including across captured recompilations and graph breaks.
+
 ``precompile`` returns a self-contained, executable ``python_code`` string plus a
 companion integrity-tagged ``cache``. With ``backend="inductor"`` (the default) the
 captured graph is lowered through the AOT backend contract
@@ -1118,7 +1123,7 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
         "USER_INPUT_DEVICES",
         "USER_INPUT_BOUNDS",
     }
-    wanted = {"BACKEND", "TRACER", *make_fx_metadata}
+    wanted = {"BACKEND", "TRACER", "TRAINING", *make_fx_metadata}
     found: dict[str, object] = {}
     try:
         tree = ast.parse(python_code)
@@ -1363,7 +1368,9 @@ def _build_dynamo_eager_graph_source(gm: torch.fx.GraphModule) -> str:
     return "\n".join(parts)
 
 
-def _dynamo_backend_compiler(backend: str) -> Callable[..., _DynamoPythonBackend]:
+def _dynamo_backend_compiler(
+    backend: str, training: bool
+) -> Callable[..., _DynamoPythonBackend]:
     def compile_graph(
         gm: torch.fx.GraphModule, example_inputs: list[object]
     ) -> _DynamoPythonBackend:
@@ -1388,7 +1395,10 @@ def _dynamo_backend_compiler(backend: str) -> Callable[..., _DynamoPythonBackend
                 if node.op == "placeholder"
             ]
             python_code, cache = aot_autograd.compile_to_python(
-                gm, graph_inputs, options={"size_asserts": True}
+                gm,
+                graph_inputs,
+                options={"size_asserts": True},
+                grad_enabled=training,
             )
             call = aot_autograd.load_from_python(python_code, cache)
         return _DynamoPythonBackend(python_code, cache, is_dynamic, call)
@@ -1554,6 +1564,7 @@ def _dynamo_backend_source_literal(source: str) -> str:
 def _build_dynamo_python_source(
     *,
     backend: str,
+    training: bool,
     state: dict[str, Any],
     backend_ids: list[str],
     compiled_backends: list[_DynamoPythonBackend],
@@ -1587,6 +1598,7 @@ def _build_dynamo_python_source(
         "# " + "=" * 70,
         f"BACKEND = {backend!r}",
         'TRACER = "dynamo"',
+        f"TRAINING = {training!r}",
         f"FRAME_COUNT = {len(state['codes'])}",
         f"VARIANT_COUNT = {variant_count}",
         f"GRAPH_COUNT = {len(compiled_backends)}",
@@ -1645,6 +1657,7 @@ def _precompile_dynamo(
     *,
     backend: str,
     decompositions: dict | None,
+    training: bool,
 ) -> tuple[str, bytes]:
     import dis
     import importlib
@@ -1848,7 +1861,7 @@ def _precompile_dynamo(
             return result
 
         compiled = torch._dynamo.optimize(
-            backend=_dynamo_backend_compiler(backend),
+            backend=_dynamo_backend_compiler(backend, training),
             nopython=False,
             guard_filter_fn=keep_portable_capture_guards,
             package=package,
@@ -1905,8 +1918,13 @@ def _precompile_dynamo(
 
             sys.settrace(trace)
         try:
-            for example in example_inputs:
-                compiled(*example)
+            if training:
+                with torch.enable_grad():
+                    for example in example_inputs:
+                        compiled(*example)
+            else:
+                for example in example_inputs:
+                    compiled(*example)
         finally:
             if use_profile:
                 sys.setprofile(previous_profile)
@@ -2051,6 +2069,7 @@ def _precompile_dynamo(
         }
         python_code = _build_dynamo_python_source(
             backend=backend,
+            training=training,
             state=state,
             backend_ids=[str(backend_id) for backend_id in backend_ids],
             compiled_backends=compiled_backends,
@@ -2407,6 +2426,7 @@ class _PrecompileApi:
         backend: str = "inductor",
         tracer: str = "make_fx",
         decompositions: dict | None = None,
+        training: bool = False,
     ) -> tuple[str, bytes]:
         """Ahead-of-time precompile ``fn`` against ``example_inputs``.
 
@@ -2479,6 +2499,13 @@ class _PrecompileApi:
         ``decomposition_table`` during capture, so you can control how ATen ops are
         broken down in the captured graph. Defaults to ``None`` (make_fx's default) and
         is not yet supported with ``tracer="dynamo"``.
+
+        ``training=True`` is supported with ``tracer="dynamo"`` and
+        ``backend="inductor"``. Capture runs with grad enabled, and each compiled graph
+        carries a readable AOTAutograd forward and backward bridged by an emitted
+        ``torch.autograd.Function``. A served output therefore retains its ``grad_fn``;
+        calling ``backward()`` executes the precompiled backward kernels. The input
+        tensors that require gradients must do so in every example and at runtime.
 
         With ``tracer="dynamo"``, shape variation across ``example_inputs`` uses
         Dynamo's ordinary automatic dynamic-shape policy: for example, a static first
@@ -2562,12 +2589,18 @@ class _PrecompileApi:
             raise ValueError(
                 f"precompile tracer must be 'make_fx' or 'dynamo', got {tracer!r}."
             )
+        if training and (tracer != "dynamo" or backend != "inductor"):
+            raise NotImplementedError(
+                "precompile training=True currently requires tracer='dynamo' and "
+                "backend='inductor'."
+            )
         if tracer == "dynamo":
             return _precompile_dynamo(
                 fn,
                 example_inputs,
                 backend=backend,
                 decompositions=decompositions,
+                training=training,
             )
         compiled = PrecompiledModule(
             fn, backend=backend, tracer=tracer, decompositions=decompositions


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* #194528
* #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* #194468
* #194467
* #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* __->__ #194252
* #194148
* #194113

The Dynamo precompile path lowered every captured graph through an inference-only
AOTAutograd pass. Inputs requiring gradients therefore produced detached served
outputs, and the standalone source composer rejected the forward/backward wrapper
set that AOTAutograd generates for training.

Add a training=True mode for the Dynamo/Inductor path. Capture AOTAutograd's exact
forward and backward wrapper source and autograd metadata, lower the forward first,
and restride the backward placeholders from the layouts Inductor actually selected
for saved activations. Namespace both generated Inductor modules before composing
them with an emitted autograd.Function, keeping kernels and runtime glue readable
while preserving recompilations and graph-break resume frames.

The metadata capture uses a thread-local context rather than replacing a process-
global factory method, so unrelated concurrent AOTAutograd compilations are not
affected. The default remains inference-only.

Test Plan:

```
/home/bobren/local/b/pytorch-env/bin/python agent_space/run_precompile_overlay.py compile_test
```

```
/home/bobren/local/b/pytorch-env/bin/python agent_space/run_precompile_overlay.py test
```

```
/home/bobren/local/b/pytorch-env/bin/python agent_space/run_precompile_overlay.py test TestPrecompileNumericsCUDA.test_tracer_dynamo_training_cuda_cuda
```

```
PATH=/home/bobren/.conda/envs/xlformers_finetune_conda-newest/bin:$PATH TMPDIR=$PWD/agent_space/lintrunner_tmp UV_OFFLINE=1 lintrunner -a
```

Authored with an AI assistant.