### PR TITLE
Fix indefinite article and grammar typos in comments and docstrings

### DIFF
--- a/torch/_functorch/_aot_autograd/aot_autograd_result.py
+++ b/torch/_functorch/_aot_autograd/aot_autograd_result.py
@@ -610,7 +610,7 @@ class GenericAOTAutogradResult(Generic[TForward, TBackward]):
         that AOTAutograd returned the first time it was run. It does this by running the various
         post compile steps that AOTAutograd runs on its compiled artifact after running the fw/bw compilers.
 
-        In the inference path, this consists of the Subclass, FunctionalzedRngRuntime, and RuntimeWrappers.
+        In the inference path, this consists of the Subclass, FunctionalizedRngRuntime, and RuntimeWrappers.
         In the autograd path, this consists of AOTAutogradDispatch.post_compile.
 
         The steps here should match exactly the steps that are run in aot_dispatch_base and aot_dispatch_autograd.

--- a/torch/csrc/distributed/rpc/python_rpc_handler.h
+++ b/torch/csrc/distributed/rpc/python_rpc_handler.h
@@ -42,7 +42,7 @@ class PYBIND11_EXPORT PythonRpcHandler {
   void handleException(const py::object& obj);
   // Alternative if the caller is already holding the GIL.
   void handleExceptionGILHeld(const py::object& obj);
-  // Check if obj is an RemoteException instance.
+  // Check if obj is a RemoteException instance.
   bool isRemoteException(const py::object& obj);
 
   // Explicitly clean up py::objects to avoid segment faults when

--- a/torch/csrc/inductor/aoti_runtime/mini_array_ref.h
+++ b/torch/csrc/inductor/aoti_runtime/mini_array_ref.h
@@ -35,14 +35,14 @@ class MiniArrayRef final {
   /// Construct an empty MiniArrayRef.
   /* implicit */ constexpr MiniArrayRef() : Data(nullptr), Length(0) {}
 
-  /// Construct an MiniArrayRef from a single element.
+  /// Construct a MiniArrayRef from a single element.
   // TODO Make this explicit
   constexpr MiniArrayRef(const T& OneElt) : Data(&OneElt), Length(1) {}
 
-  /// Construct an MiniArrayRef from a pointer and length.
+  /// Construct a MiniArrayRef from a pointer and length.
   constexpr MiniArrayRef(T* data, size_t length) : Data(data), Length(length) {}
 
-  /// Construct an MiniArrayRef from a range.
+  /// Construct a MiniArrayRef from a range.
   constexpr MiniArrayRef(T* begin, T* end) : Data(begin), Length(end - begin) {}
 
   template <
@@ -53,7 +53,7 @@ class MiniArrayRef final {
   /* implicit */ MiniArrayRef(Container& container)
       : Data(container.data()), Length(container.size()) {}
 
-  /// Construct an MiniArrayRef from a std::vector.
+  /// Construct a MiniArrayRef from a std::vector.
   // The enable_if stuff here makes sure that this isn't used for
   // std::vector<bool>, because MiniArrayRef can't work on a std::vector<bool>
   // bitfield.
@@ -65,21 +65,21 @@ class MiniArrayRef final {
         "MiniArrayRef<bool> cannot be constructed from a std::vector<bool> bitfield.");
   }
 
-  /// Construct an MiniArrayRef from a std::array
+  /// Construct a MiniArrayRef from a std::array
   template <size_t N>
   /* implicit */ constexpr MiniArrayRef(std::array<T, N>& Arr)
       : Data(Arr.data()), Length(N) {}
 
-  /// Construct an MiniArrayRef from a C array.
+  /// Construct a MiniArrayRef from a C array.
   template <size_t N>
   // NOLINTNEXTLINE(*c-array*)
   /* implicit */ constexpr MiniArrayRef(T (&Arr)[N]) : Data(Arr), Length(N) {}
 
-  // /// Construct an MiniArrayRef from an empty C array.
+  // /// Construct a MiniArrayRef from an empty C array.
   /* implicit */ constexpr MiniArrayRef(const volatile void* Arr)
       : Data(nullptr), Length(0) {}
 
-  /// Construct an MiniArrayRef from a std::initializer_list.
+  /// Construct a MiniArrayRef from a std::initializer_list.
   /* implicit */ constexpr MiniArrayRef(const std::initializer_list<T>& Vec)
       : Data(
             std::begin(Vec) == std::end(Vec) ? static_cast<T*>(nullptr)

--- a/torch/csrc/jit/codegen/fuser/interface.h
+++ b/torch/csrc/jit/codegen/fuser/interface.h
@@ -31,7 +31,7 @@ TORCH_API bool canFuseOnGPU();
 // flakiness)
 TORCH_API void overrideCanFuseOnCPU(bool value);
 
-// Sets whether fusion on CPU must use LLVM Codegen and not SimplieIREval
+// Sets whether fusion on CPU must use LLVM Codegen and not SimpleIREval
 TORCH_API void overrideMustUseLLVMOnCPU(bool value);
 
 // Sets whether fusion on the GPU is allowed (enabled by default)

--- a/torch/csrc/jit/serialization/export.cpp
+++ b/torch/csrc/jit/serialization/export.cpp
@@ -263,8 +263,8 @@ class GraphEncoder {
  private:
   // Using std::map instead of std::unordered_map for initializers
   // in EncodeGraph constructor so that the order in which initializers
-  // get written to the ONNX graph is always the deterministic and
-  // predictable. While this is not a ONNX requirement, it is needed
+  // get written to the ONNX graph is always deterministic and
+  // predictable. While this is not an ONNX requirement, it is needed
   // for testing purposes in tests that use _export_to_pretty_string()
   // for validating ONNX graphs.
   void EncodeGraph(

--- a/torch/csrc/jit/tensorexpr/loopnest.h
+++ b/torch/csrc/jit/tensorexpr/loopnest.h
@@ -31,7 +31,7 @@ class TORCH_API LoopNest {
   // A convenience constructor for the case when all tensors are output tensors
   LoopNest(const std::vector<Tensor>& output_tensors);
 
-  // A constructor for building a LoopNest from an Stmt and a list of output
+  // A constructor for building a LoopNest from a Stmt and a list of output
   // buffers.
   LoopNest(StmtPtr stmt, std::unordered_set<BufPtr> output_bufs);
 

--- a/torch/csrc/lazy/core/tensor.h
+++ b/torch/csrc/lazy/core/tensor.h
@@ -206,7 +206,7 @@ TORCH_API LazyTensorPtr GetLtcTensorOrCreateForWrappedNumber(
     const BackendDevice& device);
 
 // Section 2: LazyTensor => at::Tensor.
-// Creates an ATen tensor from an LazyTensor.
+// Creates an ATen tensor from a LazyTensor.
 TORCH_API at::Tensor CreateAtenFromLtcTensor(const LazyTensorPtr& ltc_tensor);
 TORCH_API at::Tensor CreateAtenFromLtcTensor(LazyTensor&& ltc_tensor);
 

--- a/torch/csrc/lazy/core/tensor_impl.h
+++ b/torch/csrc/lazy/core/tensor_impl.h
@@ -9,7 +9,7 @@
 namespace torch::lazy {
 
 // Tensor implementation class used to be fed to the at::Tensor.
-// Its scope is just to handle an LazyTensor.
+// Its scope is just to handle a LazyTensor.
 class TORCH_API LTCTensorImpl final : public c10::TensorImpl {
  public:
   explicit LTCTensorImpl(const LazyTensorPtr& tensor);

--- a/torch/csrc/stable/c/shim.h
+++ b/torch/csrc/stable/c/shim.h
@@ -248,13 +248,13 @@ AOTI_TORCH_EXPORT const char* torch_exception_get_what();
 /// thread is shutdown.
 AOTI_TORCH_EXPORT const char* torch_exception_get_what_without_backtrace();
 
-// Allocates an StableIValue on the heap, returns an owning pointer.
+// Allocates a StableIValue on the heap, returns an owning pointer.
 // This allocation must be deleted with torch_delete_stable_ivalue or
 // by passing it to a dispatch call which frees it internally.
 AOTI_TORCH_EXPORT AOTITorchError
 torch_new_stable_ivalue(StableIValue** ret_value);
 
-// Frees an StableIValue that was created by torch_new_stable_ivalue.
+// Frees a StableIValue that was created by torch_new_stable_ivalue.
 // Deleting a nullptr is invalid and returns failure, allocations must
 // only be deleted once.
 AOTI_TORCH_EXPORT AOTITorchError

--- a/torch/distributed/fsdp/_state_dict_utils.py
+++ b/torch/distributed/fsdp/_state_dict_utils.py
@@ -539,7 +539,7 @@ def _sharded_post_state_dict_hook(
 ) -> dict[str, Any]:
     """
     The hook replaces the unflattened, unsharded parameter in the state_dict
-    with a unflattened, sharded parameter (a ShardedTensor).
+    with an unflattened, sharded parameter (a ShardedTensor).
     """
 
     def param_hook(state_dict: dict[str, Any], prefix: str, fqn: str):

--- a/torch/distributed/tensor/experimental/_context_parallel/_attention.py
+++ b/torch/distributed/tensor/experimental/_context_parallel/_attention.py
@@ -909,7 +909,7 @@ def _sdpa_handler(
     args: tuple[object, ...],
     kwargs: dict[str, object],
 ) -> object:
-    # extract local tensor and sharding infos to a OpInfo
+    # extract local tensor and sharding infos to an OpInfo
     op_info = DTensor._op_dispatcher.unwrap_to_op_info(op_call, args, kwargs)
     logger.debug("Dispatching op_call: %s", op_info.schema or op_call)
 

--- a/torch/distributions/relaxed_categorical.py
+++ b/torch/distributions/relaxed_categorical.py
@@ -16,7 +16,7 @@ __all__ = ["ExpRelaxedCategorical", "RelaxedOneHotCategorical"]
 
 class ExpRelaxedCategorical(Distribution):
     r"""
-    Creates a ExpRelaxedCategorical parameterized by
+    Creates an ExpRelaxedCategorical parameterized by
     :attr:`temperature`, and either :attr:`probs` or :attr:`logits` (but not both).
     Returns the log of a point in the simplex. Based on the interface to
     :class:`OneHotCategorical`.

--- a/torch/fx/experimental/unification/utils.py
+++ b/torch/fx/experimental/unification/utils.py
@@ -89,10 +89,10 @@ def reverse_dict(d: dict[_T, Iterable[_T]]) -> dict[_T, tuple[_T, ...]]:
     {1: ('a',), 2: ('a', 'b'), 3: ('b',)}
 
     .. note::
-        dict order are not deterministic. As we iterate on the
-        input dict, it make the output of this function depend on the
+        dict order is not deterministic. As we iterate on the
+        input dict, it makes the output of this function depend on the
         dict order. So this function output order should be considered
-        as undeterministic.
+        as nondeterministic.
     """
     result = {}  # type: ignore[var-annotated]
     for key in d:

--- a/torch/onnx/_internal/exporter/_registration.py
+++ b/torch/onnx/_internal/exporter/_registration.py
@@ -198,7 +198,7 @@ class ONNXRegistry:
         target: TorchOp,
         onnx_decomposition: OnnxDecompMeta,
     ) -> None:
-        """Registers a OnnxDecompMeta to an operator.
+        """Registers an OnnxDecompMeta to an operator.
 
         Args:
             target: The PyTorch node callable target.

--- a/torch/onnx/_internal/torchscript_exporter/_type_utils.py
+++ b/torch/onnx/_internal/torchscript_exporter/_type_utils.py
@@ -160,7 +160,7 @@ class JitScalarType(enum.IntEnum):
     def from_onnx_type(
         cls, onnx_type: int | _C_onnx.TensorProtoDataType | None
     ) -> JitScalarType:
-        """Convert a ONNX data type to JitScalarType.
+        """Convert an ONNX data type to JitScalarType.
 
         Args:
             onnx_type: A torch._C._onnx.TensorProtoDataType to create a JitScalarType from

--- a/torch/utils/data/datapipes/map/utils.py
+++ b/torch/utils/data/datapipes/map/utils.py
@@ -16,7 +16,7 @@ class SequenceWrapperMapDataPipe(MapDataPipe[_T]):
     Wraps a sequence object into a MapDataPipe.
 
     Args:
-        sequence: Sequence object to be wrapped into an MapDataPipe
+        sequence: Sequence object to be wrapped into a MapDataPipe
         deepcopy: Option to deepcopy input sequence object
 
     .. note::


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194254

No functional changes. Corrects "a"/"an" agreement in comments and docstrings across AOTAutograd, RPC, AOTI runtime, JIT, lazy tensors, the stable C shim, FSDP, DTensor context parallel, distributions, FX unification, ONNX export, and datapipes, along with a few misspellings (FunctionalizedRngRuntime, SimpleIREval) and subject-verb agreement in the unification utils note.

Test Plan: comment-only change; no tests run.

Authored with the assistance of an AI coding agent.

cc @EikanWang @jgong5