### PR TITLE
[inductor] AOTI lite mode: support HigherOrderOperators (user-defined Triton kernels) (#194255)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -386,6 +386,40 @@ class AOTInductorTestsTemplate:
         inputs = (torch.randn(4, device=self.device),)
         self.check_model(Model(), inputs)
 
+    def test_triton_kernel_lite_mode(self):
+        # A user-defined Triton kernel (a triton_kernel_wrapper_functional HOP) compiled
+        # under AOTInductor all-fallback / lite mode. Previously the HOP was forced to the
+        # AOT ProxyExecutor -- which only serializes OpOverload targets -- and failed. It
+        # is now decomposed to its mutation form in lite mode (compile_fx runs the
+        # decomposition even with post-grad passes off) and compiled as a
+        # UserDefinedTritonKernel into the AOT artifact.
+        #
+        # use_post_grad_passes=False is as load bearing as fallback_by_default: with
+        # post-grad passes on, post_grad_passes decomposes the functional HOP itself and
+        # the graph takes the same path with or without this change.
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires GPU")
+
+        class Model(torch.nn.Module):
+            def forward(self, x, y):
+                out = torch.zeros_like(x)
+                n_elements = out.numel()
+                add_kernel[(n_elements,)](x, y, out, n_elements, BLOCK_SIZE=16)
+                return out
+
+        inputs = (
+            torch.randn(64, device=self.device),
+            torch.randn(64, device=self.device),
+        )
+        model = Model()
+        with config.patch({"fallback_by_default": True, "use_post_grad_passes": False}):
+            self.check_model(model, inputs)
+
+            # The kernel is compiled into the artifact and launched, rather than
+            # dispatched through the proxy executor.
+            _, code = run_and_get_cpp_code(AOTIRunnerUtil.compile, model, inputs)
+            FileCheck().check("launchKernel(").run(code)
+
     def test_triton_kernel_bool_tensor_arg(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17997,6 +17997,40 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         else:
             FileCheck().check("torch.ops.aten.add").run(code[0])
 
+    def test_lite_mode_sym_stride(self):
+        # aten.sym_stride.int (`x.stride(dim)` under a dynamic shape) returns a SymInt,
+        # like sym_size.int, and cannot be serialized as a generic fallback kernel.
+        # skip_fallback_due_to_dynamic_shape routes it to its symbolic (no-kernel)
+        # handling so lite mode does not hit the "Unsupported return type
+        # torch.SymIntType" wall. Use a 2D tensor with a dynamic inner dim so stride(0)
+        # is symbolic (for a 1D/contiguous tensor stride(0) is the constant 1).
+        def f(x):
+            s = x.stride(0)
+            return x + s
+
+        x = torch.randn(4, 8, device=self.device)
+        torch._dynamo.mark_dynamic(x, 1)
+        opt_f = torch.compile(f, mode="lite")
+
+        # Compiles and matches eager. Without the skip_fallback_due_to_dynamic_shape
+        # entry for sym_stride.int, this raises "Unsupported return type torch.SymIntType"
+        # under the cpp wrapper (AOTI) serialization path.
+        result, code = run_and_get_code(opt_f, x)
+        self.assertEqual(result, f(x))
+
+        # The surrounding elementwise op still falls back (lite mode is active); the
+        # sym_stride.int node did not become a generic fallback kernel. Lite mode sets
+        # use_dce=False, so a fallback kernel would survive into the generated code
+        # even with nothing consuming its buffer.
+        self.assertNotIn("sym_stride", code[0])
+        if config.cpp_wrapper:
+            # Same as test_lite_mode_sym_size: `aten.add.Tensor` is in torchgen's
+            # inductor_fallback_ops, so its fallback goes through the device
+            # c-shim, not the generic aoti_torch_call_dispatcher path.
+            FileCheck().check_regex(r"aoti_torch_\w+_add_Tensor\(").run(code[0])
+        else:
+            FileCheck().check("torch.ops.aten.add").run(code[0])
+
     @lowering.force_fallback(aten.sort.default)
     def test_size_asserts_for_multi_output_fallback(self):
         @torch.compile

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -120,7 +120,11 @@ from .debug import DebugContext
 from .decomposition import select_decomp_table
 from .exc import InductorError
 from .fx_passes.joint_graph import joint_graph_passes
-from .fx_passes.post_grad import post_grad_passes, view_to_reshape
+from .fx_passes.post_grad import (
+    decompose_triton_kernel_wrapper_functional,
+    post_grad_passes,
+    view_to_reshape,
+)
 from .fx_passes.pre_grad import pre_grad_passes
 from .graph import GraphLowering
 from .ir import get_device_type, IRNode
@@ -778,6 +782,23 @@ def _recursive_post_grad_passes(gm: GraphModule, is_inference: bool = False) -> 
         _propagate_invoke_subgraph_nested_region_config(gm)
         with _patch_nested_region_inductor_config(gm):
             if not config.use_post_grad_passes:
+                # triton_kernel_wrapper_functional (a user-defined Triton kernel already
+                # in the model) has no inductor lowering; post_grad_passes normally
+                # decomposes it into its mutation form, which lowers to a
+                # UserDefinedTritonKernel and compiles into the AOT artifact. With
+                # post-grad passes disabled (e.g. lite mode / fallback_by_default), still
+                # run just that decomposition -- it is a correctness pass, not an
+                # optimization -- so such kernels keep compiling instead of hard-erroring
+                # at lowering (the functional HOP is neither an OpOverload with a lowering
+                # nor serializable by the proxy executor). Gated on the graph actually
+                # containing one so a lite-mode graph without user Triton kernels -- the
+                # common case -- pays neither the pattern match nor the recompile.
+                if gm.graph.find_nodes(
+                    op="call_function",
+                    target=torch.ops.higher_order.triton_kernel_wrapper_functional,
+                ):
+                    decompose_triton_kernel_wrapper_functional(gm.graph)
+                    gm.recompile()
                 return
 
             for subgraph_name in _get_subgraph_names(gm):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -7987,8 +7987,14 @@ class ExternKernel(InputsKernel):
         n_args = len(args)
         n_pos_args = len(self.arg_properties)
         # For cpp wrapper, if some positional args are not provided, we need to check
-        # if they're in the kwargs or use their default value
-        if n_args < n_pos_args:
+        # if they're in the kwargs or use their default value. This is schema-based and
+        # only applies to OpOverloads: for HigherOrderOperators (and other non-OpOverload
+        # kernels) collect_arg_kwarg_properties fills arg_properties with empty placeholder
+        # dicts (one per flattened input, not the positional-arg count), so they have no
+        # "name"/"default_value" to fill from and the args/kwargs from unflatten_args are
+        # already complete. e.g. triton_kernel_wrapper_functional passes all its tensors via
+        # kwargs (n_args == 0), which would otherwise index empty dicts here -> KeyError.
+        if n_args < n_pos_args and isinstance(self.op_overload, torch._ops.OpOverload):
             log.debug(
                 "%s has %d unprovided positional arguments. "
                 "Will check if they are in the keyword arguments or will use default values.",

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4760,16 +4760,17 @@ def should_fallback_by_default(node: torch.fx.Node) -> bool:
     if target in skip_fallback_due_to_dynamic_shape:
         return False
 
-    # Most hops have registered lowering. We should follow the lowering and not fallback.
-    # However, in rare cases, hops may not register lowering, such as
-    # torch.ops.higher_order.triton_kernel_wrapper_functional. We should fallback for
-    # these hops.
-    fallback_hops = OrderedSet(
-        [torch.ops.higher_order.triton_kernel_wrapper_functional]
-    )
-
+    # HigherOrderOperators cannot be serialized by the AOT ProxyExecutor, which only
+    # supports OpOverload targets -- e.g. triton_kernel_wrapper_functional (a user-defined
+    # Triton kernel already present in the model) fails ExternKernelNode serialization with
+    # "expected OpOverload or registered extension type". Do not force HOPs to fall back;
+    # let them use their normal inductor codegen so any Triton already in the model is
+    # compiled into the AOT artifact rather than routed through the (unsupported) proxy
+    # executor. (triton_kernel_wrapper_functional has no lowering of its own; it is
+    # decomposed to its mutation form -- see the lite-mode decomposition in
+    # compile_fx._recursive_post_grad_passes -- which lowers to a UserDefinedTritonKernel.)
     if isinstance(target, torch._ops.HigherOrderOperator):
-        return target in fallback_hops
+        return False
 
     return not _needs_inductor_compile(node)
 

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -4752,6 +4752,8 @@ def should_fallback_by_default(node: torch.fx.Node) -> bool:
             # `.item()` returns a Scalar, which cannot be serialized as a generic
             # fallback kernel; route it to its dedicated DynamicScalar lowering.
             torch.ops.aten._local_scalar_dense.default,
+            # `x.stride(dim)` returns a SymInt too; same symbolic handling as sym_size.
+            torch.ops.aten.sym_stride.int,
         ]
     )
 


### PR DESCRIPTION
Summary:

Under AOTInductor all-fallback (lite mode / `fallback_by_default`), a HigherOrderOperator
present in the model -- e.g. `triton_kernel_wrapper_functional`, a user-defined Triton kernel
baked into a recsys model's dense region -- could not be handled and blocked compilation:

- It was forced to fall back (via `fallback_hops`) to the AOT ProxyExecutor, whose
  ExternKernelNode serializer only supports `OpOverload` targets, failing with
  "expected OpOverload or registered extension type, got TritonKernelWrapperFunctional"
  (serialize.py).
- Before that, `fill_non_provided_args` raised `KeyError: 'name'` on it, because
  `collect_arg_kwarg_properties` fills `arg_properties` with empty placeholder dicts for a
  non-OpOverload kernel and the HOP passes all its tensors via kwargs (0 positional args).

Fix (three parts):
1. `compile_fx.py`: run `decompose_triton_kernel_wrapper_functional` even when
   `use_post_grad_passes` is False (lite mode). `triton_kernel_wrapper_functional` has no
   lowering of its own -- only its `mutation` form does (-> `UserDefinedTritonKernel`). That
   functional->mutation decomposition normally runs inside `post_grad_passes`, which lite
   mode skips, so the functional HOP reached lowering un-converted and hard-errored
   ("triton_kernel_wrapper_functional is not an OpOverload"). It is a correctness pass, not
   an optimization; running it lets the Triton kernel compile normally into the AOT artifact
   (UserDefinedTritonKernel codegen is supported under cpp_wrapper/AOTI). No-op when no such
   HOP exists.
2. `utils.py` (`should_fallback_by_default`): return False for all HigherOrderOperators --
   HOPs cannot be serialized by the proxy executor, so never force them to fall back; let
   them use their normal inductor codegen (after part 1's decomposition).
3. `ir.py` (`fill_non_provided_args`): guard the schema-based positional-default fill to
   `OpOverload`s, so non-OpOverload FallbackKernels don't index empty `arg_properties`
   placeholder dicts and KeyError.

Together these let a model that already contains Triton (a user Triton-kernel HOP) compile
that Triton into the AOT artifact under lite mode, rather than routing it through the
(HOP-incapable) proxy executor.

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
New `test_lite_mode_user_triton_kernel` in `caffe2/test/inductor/test_torchinductor.py`
(fbcode + xplat): a user-defined `triton.jit` kernel invoked in a compiled function under
`torch.compile(mode="lite")`; it compiles and matches eager (previously errored at lowering
on the functional HOP).

Also validated end-to-end on the real recsys `merge` net (AMD MI350, gfx950): with these
changes `--mode fallback` gets past the user Triton-kernel HOP and the model fully lowers,
packages, and loads (the Triton kernel is compiled into the .so). Walls beyond this point
are separate issues.

Authored with an AI assistant.

Reviewed By: kqfu

Differential Revision: D114016601


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo