### PR TITLE
[ROCm] Use torch.version.rocm in skip helpers and add skipIfRocmVersionIn

### DIFF
--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -524,11 +524,23 @@ def _get_torch_cuda_version():
     return tuple(int(x) for x in cuda_version.split("."))
 
 def _get_torch_rocm_version():
-    if not TEST_WITH_ROCM or torch.version.hip is None:
+    if not TEST_WITH_ROCM:
         return (0, 0)
-    rocm_version = str(torch.version.hip)
-    rocm_version = rocm_version.split("-", maxsplit=1)[0]    # ignore git sha
-    return tuple(int(x) for x in rocm_version.split("."))
+    rocm_version = getattr(torch.version, "rocm", None) or torch.version.hip
+    if rocm_version is None:
+        return (0, 0)
+    rocm_version = str(rocm_version).split("-", maxsplit=1)[0]    # ignore git sha
+    parts = []
+    for x in rocm_version.split("."):
+        digits = []
+        for c in x:
+            if not c.isdigit():
+                break
+            digits.append(c)
+        if not digits:
+            break
+        parts.append(int("".join(digits)))
+    return tuple(parts) if parts else (0, 0)
 
 def _get_torch_hipblaslt_version():
     if not TEST_WITH_ROCM:

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -530,17 +530,7 @@ def _get_torch_rocm_version():
     if rocm_version is None:
         return (0, 0)
     rocm_version = str(rocm_version).split("-", maxsplit=1)[0]    # ignore git sha
-    parts = []
-    for x in rocm_version.split("."):
-        digits = []
-        for c in x:
-            if not c.isdigit():
-                break
-            digits.append(c)
-        if not digits:
-            break
-        parts.append(int("".join(digits)))
-    return tuple(parts) if parts else (0, 0)
+    return tuple(int(x) for x in rocm_version.split("."))
 
 def _get_torch_hipblaslt_version():
     if not TEST_WITH_ROCM:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -40,6 +40,7 @@ from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import (
     FILE_SCHEMA,
     find_free_port,
+    getRocmVersion,
     IS_SANDCASTLE,
     LazyVal,
     retry_on_connect_failures,
@@ -629,14 +630,8 @@ def skip_if_rocm_ver_lessthan_multiprocess(version=None):
     def decorator(func):
         reason = None
         if TEST_WITH_ROCM:
-            rocm_version = str(torch.version.hip)
-            rocm_version = rocm_version.split("-", maxsplit=1)[0]  # ignore git sha
-            rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
-            if (
-                rocm_version_tuple is None
-                or version is None
-                or rocm_version_tuple < tuple(version)
-            ):
+            rocm_version_tuple = getRocmVersion()
+            if version is None or rocm_version_tuple < tuple(version):
                 reason = f"skip_if_rocm_ver_lessthan_multiprocess: ROCm {rocm_version_tuple} is available but {version} required"
 
         return unittest.skipIf(reason is not None, reason)(func)
@@ -650,9 +645,7 @@ def skip_if_rocm_ver_atleast_multiprocess(version=None):
     def decorator(func):
         reason = None
         if TEST_WITH_ROCM:
-            rocm_version = str(torch.version.hip)
-            rocm_version = rocm_version.split("-", maxsplit=1)[0]  # ignore git sha
-            rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
+            rocm_version_tuple = getRocmVersion()
             if version is not None and rocm_version_tuple >= tuple(version):
                 reason = f"skip_if_rocm_ver_atleast_multiprocess: known failure on ROCm {rocm_version_tuple} (>= {version})"
 

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -654,6 +654,29 @@ def skip_if_rocm_ver_atleast_multiprocess(version=None):
     return decorator
 
 
+def skip_if_rocm_ver_in_multiprocess(versions: list | None = None):
+    """Skips a test for specific ROCm major.minor versions - multiprocess UTs.
+
+    Counterpart of skipIfRocmVersionIn. Use this on MultiProcessTestCase; the
+    single-process decorator is evaluated too late for spawned workers.
+    """
+    normalized = {tuple(v) for v in (versions or [])}
+
+    def decorator(func):
+        reason = None
+        if TEST_WITH_ROCM:
+            rocm_version_tuple = getRocmVersion()
+            if rocm_version_tuple in normalized:
+                reason = (
+                    "skip_if_rocm_ver_in_multiprocess: known failure on ROCm "
+                    f"{rocm_version_tuple} (in {sorted(normalized)})"
+                )
+
+        return unittest.skipIf(reason is not None, reason)(func)
+
+    return decorator
+
+
 def skip_if_win32():
     return skip_but_pass_in_sandcastle_if(
         sys.platform == "win32",

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2587,6 +2587,25 @@ def skipIfRocmVersionAtLeast(version=None):
         )
     return lazy_skip_if(_should_skip, f"ROCm version at least {version}: known failure")
 
+# Skips a test on ROCm for specific major.minor versions, given as a list of
+# tuples/lists. Prefer this over skipIfRocmVersionAtLeast when a failure is
+# confined to known releases (possibly non-contiguous) and later versions may
+# already be fixed, e.g. skipIfRocmVersionIn([(7, 14), (10, 0)]).
+# Mirrors skipCUDAVersionIn. Built on lazy_skip_if for methods and classes.
+# For MultiProcessTestCase use skip_if_rocm_ver_in_multiprocess.
+def skipIfRocmVersionIn(versions: list | None = None):
+    normalized = {tuple(v) for v in (versions or [])}
+
+    def _should_skip():
+        if not TEST_WITH_ROCM:
+            return False
+        rocm_version_tuple = getRocmVersion()
+        return rocm_version_tuple in normalized
+
+    return lazy_skip_if(
+        _should_skip, f"ROCm version in {sorted(normalized)}: known failure"
+    )
+
 def skipIfNotMiopenSuggestNHWC(fn):
     return lazy_skip_if(
         lambda: not TEST_WITH_MIOPEN_SUGGEST_NHWC,


### PR DESCRIPTION
Skip helpers today parse `torch.version.hip`. HIP version and ROCm version are not the same. On ROCm 10.1, HIP is 7.16. A skip of "ROCm < 10.1" against HIP would skip 10.1.Read `torch.version.rocm` when the attribute exists. If it does not exist, keep `torch.version.hip` so older builds still work.

Add `skipIfRocmVersionIn`. It skips a list of `(major.minor)` versions. Use it when a failure is on known releases, not on all versions after a cutoff. Same idea as `skipCUDAVersionIn`.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang