### PR TITLE
[Test] Add hw_classification and enable XPU for test_overrides.py

### DIFF
--- a/test/test_overrides.py
+++ b/test/test_overrides.py
@@ -12,6 +12,7 @@ import unittest
 import os
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     TestCase,
     run_tests,
     TEST_WITH_CROSSREF,
@@ -38,6 +39,8 @@ from torch.overrides import (
 from torch.testing._internal.common_device_type import (
     ops,
     instantiate_device_type_tests,
+    skip,
+    skipOps,
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.opinfo.core import SampleInput
@@ -398,6 +401,8 @@ class TensorLike:
         return HANDLED_FUNCTIONS_TENSOR_LIKE[func](*args, **kwargs)
 
 class TestTorchFunctionOverride(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_dtype_override(self):
         class MyDtype:
             def __torch_function__(self, *args, **kwargs):
@@ -1167,6 +1172,8 @@ def wrap(v):
     return Wrapper(v) if isinstance(v, torch.Tensor) else v
 
 class TestEinsumOverride(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     "Regression test for gh-38479"
     def test_wrapper(self):
         x = Wrapper(torch.randn(5))
@@ -1182,6 +1189,8 @@ class TestEinsumOverride(TestCase):
                          torch.nn.functional.bilinear(a, c, b)._data)
 
 class TestGradCheckOverride(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     "Test that wrappers work with gradcheck."
     def test_gradcheck(self):
         from torch.testing._internal.common_utils import gradcheck, gradgradcheck
@@ -1238,6 +1247,8 @@ class TestGradCheckOverride(TestCase):
         run_test(fast_mode=False)
 
 class TestNamedTuple(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """ Regression test for gh-47090 """
     def test_max(self):
         x = torch.tensor([1, 2])
@@ -1248,6 +1259,8 @@ class TestNamedTuple(TestCase):
         self.assertEqual(r, rs)
 
 class TestGradNewOnesOverride(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """ Regression test for gh-47069 """
     def test_newones(self):
         t = torch.tensor([1, 2]).as_subclass(SubTensor2)
@@ -1255,6 +1268,8 @@ class TestGradNewOnesOverride(TestCase):
         self.assertEqual(type(n), SubTensor2)
 
 class TestPickle(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     "Regression test for gh-47051"
     def test_pickle(self):
         t = torch.tensor([1]).as_subclass(SubTensor2)
@@ -1264,6 +1279,8 @@ class TestPickle(TestCase):
         self.assertEqual(t2.abcd, "e")
 
 class TestBroadcastAllOverride(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """ test for gh-37141 """
     def test_broadcast_all(self):
         from torch.distributions.utils import broadcast_all
@@ -1286,6 +1303,8 @@ class TestBroadcastAllOverride(TestCase):
         self.assertEqual(o_2[1]._data, c)
 
 class TestWrapTorchFunction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_wrap_torch_function(self):
         class A:
             @classmethod
@@ -1302,6 +1321,8 @@ class TestWrapTorchFunction(TestCase):
         self.assertEqual(f(A()), -1)
 
 class TestIndexing(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     """ Regression tests for gh-46277 """
     def test_getitem(self):
         class A:
@@ -1370,6 +1391,8 @@ class TestIndexing(TestCase):
 
 
 class TestIterator(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # Regression test for gh-54457
     def test_iterator(self):
         t = torch.tensor([5, 6, 7]).as_subclass(SubTensor2)
@@ -1380,6 +1403,8 @@ class TestIterator(TestCase):
 
 
 class TestRNN(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # Regression test for gh-55868
     def test_rnn(self):
         model = torch.nn.RNN(10, 20, 2)
@@ -1388,6 +1413,8 @@ class TestRNN(TestCase):
 
 
 class TestDisabledTorchFunction(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # Regression test for gh-64687
     def test_parameter_does_not_prevent_dispatch(self):
         class MyTensor:
@@ -1404,6 +1431,8 @@ class TestDisabledTorchFunction(TestCase):
         self.assertEqual(torch.nn.functional.linear(inp, t2, t1), "called")
 
 class TestResolveName(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_resolve_name(self):
         for cs in get_overridable_functions().values():
             for c in cs:
@@ -1414,6 +1443,8 @@ class TestResolveName(TestCase):
                 )
 
 class TestTorchFunctionWarning(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_torch_function_standalone_class(self):
         class StandaloneTorchFunctionClass:
             @classmethod
@@ -1441,6 +1472,8 @@ class TestTorchFunctionWarning(TestCase):
         self.assertEqual(result2, torch.tensor(99.0))
 
 class TestDisabledUserWarnings(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_no_implicit_user_warning_for_deprecated_functions(self):
         self.assertNotWarn(get_ignored_functions)
         self.assertNotWarn(get_testing_overrides)
@@ -1450,6 +1483,8 @@ class TestDisabledUserWarnings(TestCase):
 
 @unittest.skipIf(TEST_WITH_CROSSREF, "not run with crossref")
 class TestTorchFunctionMode(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         class A(TorchFunctionMode):
             def __torch_function__(self, *args, **kwargs):
@@ -1933,6 +1968,8 @@ class TestTorchFunctionMode(TestCase):
 
 
 class TestTorchFunctionRedispatch(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.assertFalse(
@@ -2022,16 +2059,24 @@ TensorBase.add: (<class 'torch.testing._internal.common_subclass.RedispatchTenso
         self.assertEqual(filtered, ['foo', 'add', 'add'])
 
 
-class TestTorchFunctionRedispatchOps(TestCase):
+class TestTorchFunctionRedispatchOpsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @ops(op_db)
+    @skipOps({
+        # Disabled due to CI failures; see #190241
+        skip("nn.functional.conv_transpose3d", dtypes=(torch.float16, torch.bfloat16, torch.complex32)),
+        # dot_xpu_mkl does not support integer types;
+        # see https://github.com/intel/torch-xpu-ops/issues/5049
+        skip("__rmatmul__", device_type="xpu", dtypes=(torch.int8, torch.uint8)),
+        skip("tensordot", device_type="xpu", dtypes=(torch.int8, torch.uint8)),
+        # Flaky numerical precision failure on XPU with float16;
+        # see https://github.com/intel/torch-xpu-ops/issues/5050
+        skip("nn.functional.linear_cross_entropy", device_type="xpu", dtypes=(torch.float16,)),
+        skip("nn.functional.linear_cross_entropy", "chunked", device_type="xpu", dtypes=(torch.float16,)),
+        skip("nn.functional.linear_cross_entropy", "chunked_none", device_type="xpu", dtypes=(torch.float16,)),
+    })
     def test_redispatch(self, device, dtype, op):
-        if op.name == "nn.functional.conv_transpose3d" and dtype in (
-            torch.float16,
-            torch.bfloat16,
-            torch.complex32,
-        ):
-            # Disabled due to CI failures; see #190241
-            self.skipTest("disabled due to CI failures; see #190241")
         if op.has_nondeterministic_output:
             self.skipTest("output is nondeterministic; not comparable across calls")
 
@@ -2071,7 +2116,7 @@ class TestTorchFunctionRedispatchOps(TestCase):
                 self.assertEqual(expect, actual)
 
 
-instantiate_device_type_tests(TestTorchFunctionRedispatchOps, globals())
+instantiate_device_type_tests(TestTorchFunctionRedispatchOpsDevice, globals(), allow_xpu=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Classify all 18 test classes in `test/test_overrides.py` with `hw_classification`
- Enable XPU testing for `TestTorchFunctionRedispatchOps` via `allow_xpu=True`
- Skip known XPU failures with tracked issues

## Details

**Classification (17 GENERIC, 1 ACCELERATOR):**

The 17 non-device-parameterized classes test `__torch_function__` protocol mechanics (dispatch priority, mode stacking, subclass behavior) using CPU-only tensors — they have no device dependency and are correctly GENERIC per the hw_classification framework.

`TestTorchFunctionRedispatchOps` is the only device-parameterized class (uses `instantiate_device_type_tests` + `@ops(op_db)`). It validates that `__torch_function__` redispatch produces identical results across all ops. Classified as ACCELERATOR.

**XPU enablement:**

Adding `allow_xpu=True` generates ~6000 new XPU test cases. 6 are skipped due to known limitations:

| Tests | Root cause | Issue |
|-------|-----------|-------|
| `__rmatmul__` / `tensordot` with int8/uint8 | `dot_xpu_mkl` only supports float/complex types | intel/torch-xpu-ops#5049 |
| `linear_cross_entropy` variants with float16 | Flaky numerical precision mismatch (~0.002 abs diff) | intel/torch-xpu-ops#5050 |

## Test coverage delta

### Before

| Category | Tests | Devices |
|----------|-------|---------|
| 17 non-device classes (69 methods) | No classification, run unconditionally | CPU only |
| `TestTorchFunctionRedispatchOps` (1 method × ~700 ops × dtypes) | `instantiate_device_type_tests` | CPU, CUDA |
| **Total** | **~7,600** | |

### After

| Category | Tests | Devices |
|----------|-------|---------|
| 17 GENERIC classes (69 methods) | Classified, filterable via `--hw-classification` | CPU only (unchanged) |
| `TestTorchFunctionRedispatchOps` (1 method × ~700 ops × dtypes) | `instantiate_device_type_tests` + `allow_xpu=True` | CPU, CUDA, **XPU** |
| **Total** | **~13,773** | |

### Net new XPU coverage: +6,152 tests (5,962 pass, 190 skipped)

The test wraps each op's input in a `RedispatchTensor` subclass, invokes the op, and asserts the result matches the unwrapped baseline — validating that `__torch_function__` redispatch works correctly on Intel GPU for all registered ops.

## Test plan

```bash
source /opt/intel/oneapi/setvars.sh
python test/test_overrides.py
# Ran 13773 tests in 194s — OK (skipped=345)
python test/test_overrides.py -k "XPU"
# Ran 6152 tests in 118s — OK (skipped=190)
```

Ref: #142029

cc @guangyey @EikanWang

---
PR authored with AI assistant.
