### PR TITLE
Move torchtitan CI to the py3.12 docker image

### DIFF
--- a/.github/workflows/torchtitan.yml
+++ b/.github/workflows/torchtitan.yml
@@ -60,8 +60,8 @@ jobs:
       - get-cuda-version
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
-      build-environment: linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-py3-gcc11
-      docker-image-name: ci-image:pytorch-linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-cudnn9-py3-gcc11
+      build-environment: linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-py3.12-gcc11-torchtitan
+      docker-image-name: ci-image:pytorch-linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-cudnn9-py3.12-gcc11
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       cuda-arch-list: '8.0 8.9 9.0 10.0'
       runner: linux.24xlarge.memory
@@ -72,7 +72,7 @@ jobs:
           { config: "torchtitan_features_integration", shard: 1, num_shards: 1, runner: "linux.g5.48xlarge.nvidia.gpu" },
           { config: "torchtitan_models_integration", shard: 1, num_shards: 1, runner: "linux.g5.48xlarge.nvidia.gpu" }
         ]}
-      python-version: "3.10"
+      python-version: "3.12"
       compiler: gcc11
       cuda-version: ${{ needs.get-cuda-version.outputs.stable-cuda }}
     secrets: inherit
@@ -85,10 +85,10 @@ jobs:
       - get-label-type
       - get-cuda-version
     with:
-      build-environment: linux-jammy-cuda${{ needs.get-cuda-version.outputs.stable-cuda }}-py3-gcc11
+      build-environment: ${{ needs.build.outputs.build-environment }}
       docker-image: ${{ needs.build.outputs.docker-image }}
       test-matrix: ${{ needs.build.outputs.test-matrix }}
-      python-version: "3.10"
+      python-version: "3.12"
       compiler: gcc11
       cuda-version: ${{ needs.get-cuda-version.outputs.stable-cuda }}
     secrets: inherit


### PR DESCRIPTION
**Impact:** `torchtitan-test` workflow build/test legs
**Risk:** low

## What
Switches the torchtitan build and test jobs from the `py3` (3.10) CI image to `py3.12`, updates the `build-environment` name to match (and tags it `-torchtitan`), and has the test job derive `build-environment` from the build job's output instead of hardcoding it.

## Why
torchtitan swapped its stateful dataloader to `grain`, which requires Python >= 3.11 and ships no cp310 wheel. That pushed torchtitan's own `requires-python` to `>=3.11`, so `pip install -e .` refused to run inside the 3.10 container and both legs died within minutes of the daily pin bump. The lever here is the docker image, not the `python-version:` input (that input doesn't select the interpreter); the `python-version` bump is kept for consistency.

# Notes
This only unblocks the interpreter, which restores the `features_integration` leg. `models_integration` is failing on torchtitan's own test assertions independently of the Python version and stays red after this change — it needs a separate owner. Expect runner burn on the models leg to go back up once the install works and it runs the full suite again.