### PR TITLE
[inductor] AOTI: route integer-scalar / integral-tensor ops off the c-shim to the proxy executor (#194262)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5305,6 +5305,56 @@ class AOTInductorTestsTemplate:
         )
         self.check_model(M(), example_args, options={"fallback_by_default": True})
 
+    def test_proxy_executor_integral_add_scalar(self):
+        # The C-shim types alpha as double, so the default alpha=1 would arrive as 1.0,
+        # which ATen rejects for integral tensors. Must route to the proxy executor.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.add.Tensor(x, 1)
+
+        example_args = (torch.randint(0, 10, (64,), device=self.device),)
+        self.check_model(M(), example_args, options={"fallback_by_default": True})
+
+    def test_proxy_executor_integral_pow_scalar(self):
+        # Same rule via an explicit Scalar slot rather than a schema default: through the
+        # c-shim the exponent arrives as a double and promotes the int64 base.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.pow.Tensor_Scalar(x, 2)
+
+        example_args = (
+            torch.randint(0, 10, (64,), dtype=torch.int64, device=self.device),
+        )
+        self.check_model(M(), example_args, options={"fallback_by_default": True})
+
+    def test_proxy_executor_bool_scalar_alpha(self):
+        # alpha=True arrives as 1.0 through the double ABI, which alpha_check rejects for
+        # a Bool result; eager accepts a Boolean alpha. The proxy executor keeps it a bool.
+        class M(torch.nn.Module):
+            def forward(self, x, y):
+                return torch.ops.aten.add.Tensor(x, y, alpha=True)
+
+        example_args = (
+            torch.tensor([True, False, True, False], device=self.device),
+            torch.tensor([True, True, False, False], device=self.device),
+        )
+        self.check_model(M(), example_args, options={"fallback_by_default": True})
+
+    def test_proxy_executor_bool_scalar_infers_dtype(self):
+        # full.default infers its dtype from the fill Scalar (True -> bool, 1.0 -> float)
+        # and has no tensor arg for the integral-tensor gate to see. dtype is deliberately
+        # not passed, so the Scalar drives the output dtype.
+        #
+        # NB forward-looking guard, not a regression test: full.default's c-shim is
+        # version-gated and absent today, so this passes with or without the bool rule.
+        # test_proxy_executor_bool_scalar_alpha is the actual regression test.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.full.default(x.shape, True, device=x.device) & x
+
+        example_args = (torch.tensor([True, False, True], device=self.device),)
+        self.check_model(M(), example_args, options={"fallback_by_default": True})
+
     def test_proxy_executor_error_message_preserved(self):
         @torch.library.custom_op("aoti_test::validate_input", mutates_args=())
         def validate_input(x: torch.Tensor) -> torch.Tensor:

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -9973,36 +9973,19 @@ class FallbackKernel(ExternKernelAlloc):
                 kernel not in config.aot_inductor.custom_ops_to_c_shims
             )
 
-        # Handle the special case where a complex number is input to a C-shim kernel for
-        # a scalar input.  The torchgen'ed shim API will use type "double", which is
-        # incompatible with complex numbers, forcing a fallback to runtime dispatch.
+        # Scalars the C-shim's double ABI cannot represent must use the proxy executor
+        # instead; see _cshim_scalar_abi_forces_proxy.
         if (
             V.graph.cpp_wrapper
             and isinstance(kernel, torch._ops.OpOverload)
             and not self.use_runtime_dispatch
         ):
-
-            def is_number(t: torch.JitType) -> bool:
-                if isinstance(t, torch.OptionalType):
-                    return is_number(t.getElementType())
-                return isinstance(t, torch.NumberType)
-
-            # Using unflatten_args is a bit of a hack, but all the complex arguments we
+            # Using unflatten_args is a bit of a hack, but all the scalar arguments we
             # care about are in self.constant_args, and calling unflatten_args puts them
             # in the correct order without triggering codegen.
             args, kwargs = self.unflatten_args(self.inputs, self.constant_args)
-            # Append kwarg values to args.  ordered_kwargs_for_cpp_kernel is guaranteed
-            # to be set, since this is an OpOverload kernel.
-            args_iter = itertools.chain(
-                args,
-                (
-                    self.get_kwargs_value(k, **kwargs)
-                    for k in self.ordered_kwargs_for_cpp_kernel
-                ),
-            )
-            self.use_runtime_dispatch = any(
-                isinstance(v, complex) and is_number(a.real_type)
-                for v, a in zip(args_iter, kernel._schema.arguments)
+            self.use_runtime_dispatch = self._cshim_scalar_abi_forces_proxy(
+                kernel, args, kwargs
             )
 
         self.codegen_comment(wrapper)
@@ -10116,6 +10099,62 @@ class FallbackKernel(ExternKernelAlloc):
             return False
         return kernel not in config.aot_inductor.custom_ops_to_c_shims
 
+    @staticmethod
+    def _cshim_scalar_abi_forces_proxy(
+        kernel: _OpOverloads, args: Any, kwargs: Any
+    ) -> bool:
+        # Whether a Scalar arg cannot survive the C-shim's `double` Scalar ABI. Complex
+        # does not fit a double at all; bool and int lose their type, which ATen rejects
+        # (`alpha=1` -> `1.0`) or silently mis-promotes. Such ops go to the proxy executor,
+        # which serializes each scalar with its real type. Used by both codegen() and
+        # _materialize_scalar_tensor_args.
+        if not V.graph.cpp_wrapper or not isinstance(kernel, torch._ops.OpOverload):
+            return False
+
+        def is_number(t: torch.JitType) -> bool:
+            if isinstance(t, torch.OptionalType):
+                return is_number(t.getElementType())
+            return isinstance(t, torch.NumberType)
+
+        def is_integral_tensor(v: Any) -> bool:
+            if not isinstance(v, IRNode):
+                return False
+            try:
+                dtype = v.get_dtype()
+            except (AttributeError, NotImplementedError):
+                return False
+            return (
+                dtype is not None
+                and not dtype.is_floating_point
+                and not dtype.is_complex
+            )
+
+        has_integral_tensor = any(
+            is_integral_tensor(v) for v in itertools.chain(args, kwargs.values())
+        )
+
+        for i, arg_info in enumerate(kernel._schema.arguments):
+            if arg_info.name in kwargs:
+                value = kwargs[arg_info.name]
+            elif not arg_info.kwarg_only and i < len(args):
+                value = args[i]
+            else:
+                value = arg_info.default_value
+            if not is_number(arg_info.real_type):
+                continue
+            if isinstance(value, complex):
+                return True
+            # A bool Scalar is its own c10::Scalar kind; the double ABI turns True into
+            # 1.0, which is neither boolean nor integral. Ungated by has_integral_tensor
+            # because it also changes dtype inference on ops with no tensor arg at all
+            # (full(size, True) is bool, full(size, 1.0) is float).
+            if type(value) is bool:
+                return True
+            # `type(...) is int`, not isinstance: bool subclasses int, handled above.
+            if type(value) is int and has_integral_tensor:
+                return True
+        return False
+
     @classmethod
     def _materialize_scalar_tensor_args(
         cls, kernel: _OpOverloads, args: Any, kwargs: Any
@@ -10133,7 +10172,12 @@ class FallbackKernel(ExternKernelAlloc):
         # as *real* tensors (see the V.graph.constants branch there).
         if not isinstance(kernel, torch._ops.OpOverload):
             return args, kwargs, False
-        if not cls._uses_aot_proxy_executor(kernel):
+        # Materialize for anything codegen() will send to the proxy executor: no C-shim,
+        # or a scalar the C-shim's double ABI cannot represent.
+        if not (
+            cls._uses_aot_proxy_executor(kernel)
+            or cls._cshim_scalar_abi_forces_proxy(kernel, args, kwargs)
+        ):
             return args, kwargs, False
 
         tensor_dtypes: list[torch.dtype] = []


### PR DESCRIPTION
Summary:

Under AOTInductor all-fallback (lite mode), an op with an integer Scalar arg on an integral
tensor -- e.g. `aten.add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1)` with an int64
`self` -- fails at RUNTIME through the c-shim:

    RuntimeError: For integral input tensors, argument alpha must not be a floating point number.

Root cause: the torchgen'd AOTI c-shim types every `Scalar` parameter as `double` (to carry
both int and float through one ABI). So the integer `alpha=1` is coerced to `1.0` at the shim
boundary, and ATen's `alpha_check` rejects a floating-point alpha for integral tensors. Normal
lowering never hits this because `add.Tensor` is an inlined pointwise op (no ATen dispatch, no
`c10::Scalar` at runtime); only all-fallback emits the opaque c-shim ATen call.

Fix: generalize the existing "complex scalar can't fit the double shim ABI -> use the proxy
executor" special-case in `FallbackKernel.codegen` into a shared predicate
`_cshim_scalar_abi_forces_proxy`. A scalar bound to a Number/Scalar param must leave the c-shim
when it is:
  - complex -- does not fit in a double at all (the prior special-case, now subsumed);
  - bool    -- see below; or
  - int, and an integral tensor is present -- the `alpha=1` -> `1.0` case above.
Such ops are routed to the proxy executor, which serializes each scalar with its real type, so
ATen reconstructs the right kind of `c10::Scalar` and the checks pass.

Booleans are handled as their own case, and deliberately without the integral-tensor gate. A
bool is a distinct kind of `c10::Scalar` (`Scalar::isBoolean()`), and the double ABI erases
that tag -- `True` arrives as `1.0`, a Double Scalar that is neither boolean nor integral. Two
separate things break, neither covered by the integer rule:
  - `alpha_check` (ATen/native/BinaryOps.h:18-22) rejects it for a Bool result, because a
    Double is not integral -- whereas eager accepts a Boolean alpha, which counts as integral
    under `isIntegral(includeBool=true)`;
  - wherever the scalar feeds dtype inference the result changes: `aten.full.default` infers
    bool from `full(size, True)` but float from `full(size, 1.0)`, so the runtime output stops
    matching the layout inductor inferred from the real bool.
That second case has no tensor argument at all, so `has_integral_tensor` has nothing to gate
on -- hence no gate. It is latent rather than live today, because `full.default`'s c-shim is
version-gated (`"since": TORCH_VERSION_2_10_0`) and currently absent, so the op already reaches
the proxy executor via the no-c-shim rule; the bool rule is what keeps it correct once that
shim lands. Bool scalars are rare, so routing all of them costs effectively nothing, and the
round trip is already exact: `serialize.py` emits `as_bool` (checked ahead of `as_int`, since
`bool` subclasses `int`) and the `NumberType` branch of the proxy executor rebuilds a boolean
IValue. Note `type(value) is int` rather than `isinstance` in the integer rule, so bool does
not fall through to it.

The predicate is wired into BOTH:
- `FallbackKernel.codegen` (sets `use_runtime_dispatch`); and
- `_materialize_scalar_tensor_args` (the Option B materialization gate) -- so a routed op's
  scalar-in-Tensor-slot args (e.g. the `other` in `add.Tensor(x, 1)`) are materialized to real
  constant buffers too; otherwise `fill_args` re-hits "got <class 'int'>" for the scalar in a
  Tensor slot. Both sites must use the same predicate.

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
In `caffe2/test/inductor/test_aot_inductor.py` (fbcode + xplat), all via `check_model` with
`options={"fallback_by_default": True}` -- compile, package, load, run, compare against eager:

- `test_proxy_executor_integral_add_scalar` -- `add.Tensor(int64_tensor, 1)`; previously raised
  the integral-alpha error at runtime.
- `test_proxy_executor_integral_pow_scalar` -- `pow.Tensor_Scalar(int64_tensor, 2)`, the same
  rule via an explicit Scalar slot rather than a schema default.
- `test_proxy_executor_bool_scalar_alpha` -- NEW. `add.Tensor(bool_tensor, bool_tensor,
  alpha=True)`. Verified to be a real regression test: with the bool rule disabled it fails
  with the predicted
      RuntimeError: For integral input tensors, argument alpha must not be a floating point number.
  and passes with it.
- `test_proxy_executor_bool_scalar_infers_dtype` -- NEW. `full.default(x.shape, True,
  device=x.device) & x`, covering the no-tensor-argument dtype-inference case. Labelled in the
  test as a forward-looking guard, NOT a regression test: it passes with and without the bool
  rule today because full.default has no c-shim in this build, and starts exercising the rule
  once that shim lands.

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor \
  -- --regex "proxy_executor|scalar_tensor|integral"
Tests finished: Pass 40. Fail 0. Skip 13.
```

Because the bool rule widens which ops leave the c-shim, the cpp-wrapper suite was re-run as a
regression check:

```
buck2 test @//mode/opt-amd-gpu fbcode//caffe2/test/inductor:test_inductor \
  -- --env TORCHINDUCTOR_CPP_WRAPPER=1
```
No new failures versus the parent commit (the residual failures on this devserver are
pre-existing: hipBLASLt HIPBLAS_STATUS_INVALID_VALUE, FlashAttention dtype, and an undefined
`torch_new_stable_ivalue` symbol).

`lintrunner` clean on both changed files.

Also validated end-to-end on the recsys `merge` net (AMD MI350, gfx950) `--mode fallback`:
with this fix (on top of the walls 1-7 fixes) the model FULLY lowers, packages, loads, and
RUNS -- `max_abs_diff_vs_eager=3.9e-3` (matching the normal-lowering baseline), 52 outputs.

Authored with an AI assistant.

Reviewed By: desertfire

Differential Revision: D114083095




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo