### PR TITLE
[ROCm] Avoid OpenMP capture of structured bindings in SparseCsrTensorMath (#194263)

### DIFF
--- a/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
+++ b/aten/src/ATen/native/sparse/cuda/SparseCsrTensorMath.cu
@@ -488,11 +488,12 @@ Tensor reduce_sparse_csr_dim0_cuda_template(const Tensor& sparse, ReductionOp ro
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto [new_values, new_values_acc] =
-      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-          values.options(), values.scalar_type(), new_nnz);
+  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+      values.options(), values.scalar_type(), new_nnz);
+  Tensor new_values = std::get<0>(acc_buffer);
+  Tensor new_values_acc = std::get<1>(acc_buffer);
   scalar_t* values_ptr = values.data_ptr<scalar_t>();
-  acc_t* new_values_acc_ptr = new_values_acc.template data_ptr<acc_t>();
+  acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
   int64_t THREADS = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
   int64_t BLOCKS = (new_nnz + THREADS) / THREADS;
   at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
@@ -578,9 +579,10 @@ Tensor reduce_sparse_csr_dim1_cuda_template(const Tensor& sparse, ReductionOp ro
   // of float should be float in current scenario. In CUDA, float is the accumulate type
   // of float, while in CPU, double is the accumulate type of float.
   using acc_t = at::acc_type<scalar_t, true>;
-  auto [new_values, new_values_acc] =
-      at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
-          values.options(), values.scalar_type());
+  auto acc_buffer = at::sparse_csr::create_acc_buffer<acc_t, scalar_t>(
+      values.options(), values.scalar_type());
+  Tensor new_values = std::get<0>(acc_buffer);
+  Tensor new_values_acc = std::get<1>(acc_buffer);
 
   at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
   int64_t THREADS = at::cuda::getCurrentDeviceProperties()->maxThreadsPerBlock;
@@ -603,8 +605,7 @@ Tensor reduce_sparse_csr_dim1_cuda_template(const Tensor& sparse, ReductionOp ro
                             new_values_acc.resize_(new_nnz);
 
                             scalar_t* values_ptr = values.data_ptr<scalar_t>();
-                            acc_t* new_values_acc_ptr =
-                                new_values_acc.template data_ptr<acc_t>();
+                            acc_t* new_values_acc_ptr = new_values_acc.data_ptr<acc_t>();
                             reduce_sparse_csr_dim1_cuda_kernel<<<BLOCKS, THREADS, 0, stream>>>(new_values_acc_ptr,
                                                                                                values_ptr,
                                                                                                crow_indices_ptr,


### PR DESCRIPTION
Summary:

D113684917 converted two `std::get` call sites in
`ATen/native/sparse/cuda/SparseCsrTensorMath.cu` to C++17 structured bindings.
Both `new_values` and `new_values_acc` are subsequently captured inside an
OpenMP region, and clang rejects that:

```
SparseCsrTensorMath.hip:604:29: error: capturing a structured binding is not yet
  supported in OpenMP
    new_values_acc.resize_(new_nnz);
SparseCsrTensorMath.hip:582:9: note: 'new_values' declared here
  auto [new_values, new_values_acc] =
```

The hipified `ATen/native/sparse/hip/SparseCsrTensorMath.hip` is compiled by
clang, so `fbcode//caffe2:ATen-hip` fails to build for gfx942. nvcc does not
apply this restriction, which is why the CUDA container manifests stayed green
and only the AMD ones broke.

This restores the explicit `Tensor new_values` / `Tensor new_values_acc` locals
in this one file. The other 30 files touched by D113684917 are unchanged.

Test Plan: `buck2 run fbcode//sigrid/predictor:sigrid.predictor.hip -- --build-remote`

Differential Revision: D116741221




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang