### PR TITLE
[Test] Support `DistMatrixOpsTest.test_grouped_mm` with world size 2

### DIFF
--- a/test/distributed/tensor/test_matrix_ops.py
+++ b/test/distributed/tensor/test_matrix_ops.py
@@ -1036,9 +1036,10 @@ class DistMatrixOpsTest(DTensorTestBase):
             },
             {
                 # Case that would have invalid strides on inp * mat1 when sharded
+                # Keep the local BF16 row stride unaligned on 2- and 4-rank meshes
                 "inp_shape": (64, 16),
-                "w1_shape": (2, 16, 16),
-                "w2_shape": (2, 16, 16),
+                "w1_shape": (2, 16, 8),
+                "w2_shape": (2, 8, 16),
                 "inp_placements": [Replicate()],
                 "w1_placements": [Shard(2)],
                 "w2_placements": [Shard(1)],


### PR DESCRIPTION
`test/distributed/tensor/test_matrix_ops.py DistMatrixOpsTest.test_grouped_mm_backend_cublaslt_kwargs1` is failing on NVIDIA CI machines with 2 GPUs because the `kwargs1` case is intended to have invalid strides when sharded, but strides are still properly aligned if only dividing by 2. (Original dim size = 16, 16/2=8, 8 * 2 bytes for bf16 = 16 bytes, and 16-byte alignment is required) 

This PR halves the inner dimension for the second matmul, making those strides invalid for world size 2 while preserving the existing invalid case for world size 4. With this change, the test now works as expected on 2 or 4 GPUs.

Authored with assistance from Codex

cc @eqy