### PR TITLE
Enable cmake-instrumentation by default for x86_64

### DIFF
--- a/.ci/macwheel/build_all_macos_wheels.sh
+++ b/.ci/macwheel/build_all_macos_wheels.sh
@@ -25,6 +25,9 @@ export BINARY_ENV_FILE="${BINARY_ENV_FILE:-${RUNNER_TEMP}/env}"
 
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+# shellcheck disable=SC1091
+source "${PYTORCH_ROOT}/.ci/pytorch/setup_cmake.sh"
+
 iter=0
 for desired in ${DESIRED_PYTHONS}; do
     # Wrap each iteration in a GHA log group so long logs collapse nicely

--- a/.ci/manywheel/build_all.sh
+++ b/.ci/manywheel/build_all.sh
@@ -28,6 +28,9 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PARENT_OUT_DIR="${PYTORCH_FINAL_PACKAGE_DIR}"
 mkdir -p "${PARENT_OUT_DIR}"
 
+# shellcheck disable=SC1091
+source "${PYTORCH_ROOT}/.ci/pytorch/setup_cmake.sh"
+
 iter=0
 for desired in ${DESIRED_PYTHONS}; do
     echo "::group::Build wheel for Python ${desired}"

--- a/.ci/pytorch/setup_cmake.sh
+++ b/.ci/pytorch/setup_cmake.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+pytorch_cmake_version="4.4.2"
+pytorch_cmake_root="${RUNNER_TEMP:-/tmp}/cmake-${pytorch_cmake_version}"
+pytorch_cmake_bin="${pytorch_cmake_root}/cmake/data/bin"
+
+if [[ ! -x "${pytorch_cmake_bin}/cmake" || ! -x "${pytorch_cmake_bin}/ctest" ]]; then
+    if command -v uv >/dev/null; then
+        uv pip install --no-deps --target "${pytorch_cmake_root}" "cmake==${pytorch_cmake_version}"
+    elif [[ -x /opt/python/cp310-cp310/bin/python ]]; then
+        /opt/python/cp310-cp310/bin/python -m pip install \
+            --disable-pip-version-check \
+            --no-deps \
+            --target "${pytorch_cmake_root}" \
+            "cmake==${pytorch_cmake_version}"
+    else
+        echo "No Python-independent package installer is available for CMake" >&2
+        return 1
+    fi
+fi
+
+export CMAKE_EXECUTABLE="${pytorch_cmake_bin}/cmake"
+export PATH="${pytorch_cmake_bin}:${PATH}"
+
+"${CMAKE_EXECUTABLE}" --version
+"${pytorch_cmake_bin}/ctest" --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,10 +519,16 @@ cmake_dependent_option(
 cmake_dependent_option(BUILD_FUNCTORCH "Build Functorch" ON "BUILD_PYTHON" OFF)
 cmake_dependent_option(BUILD_BUNDLE_PTXAS "Bundle PTX into torch/bin folder"
                        OFF "USE_CUDA" OFF)
+
+# gradual rollout of cmake-instrumentation
+set(USE_CMAKE_INSTRUMENTATION_DEFAULT OFF)
+if(NOT USE_CUDA)
+  set(USE_CMAKE_INSTRUMENTATION_DEFAULT ON)
+endif()
 cmake_dependent_option(
   USE_CMAKE_INSTRUMENTATION
   "Use cmake-instrumentation to collect build metrics"
-  ${CPU_INTEL} # AArch64 CI times out when profiling is enabled
+  ${USE_CMAKE_INSTRUMENTATION_DEFAULT}
   "CMAKE_VERSION VERSION_GREATER_EQUAL 4.3"
   OFF
 )
@@ -535,6 +541,7 @@ if(USE_CMAKE_INSTRUMENTATION)
     CALLBACK "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/build_trace_summary.py" --root "${CMAKE_CURRENT_SOURCE_DIR}" --index
   )
 endif()
+
 cmake_dependent_option(USE_KLEIDIAI "Use KleidiAI for the ARM CPU & AARCH64 architecture." ON
                         "CPU_AARCH64" OFF)
 # prioritized text linker, ON by default for AArch64+Linux, option visible to all AArch64, x86 and ppc64le.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,7 +522,7 @@ cmake_dependent_option(BUILD_BUNDLE_PTXAS "Bundle PTX into torch/bin folder"
 cmake_dependent_option(
   USE_CMAKE_INSTRUMENTATION
   "Use cmake-instrumentation to collect build metrics"
-  OFF # disabled by default because it causes CI timeouts
+  ${CPU_INTEL} # AArch64 CI times out when profiling is enabled
   "CMAKE_VERSION VERSION_GREATER_EQUAL 4.3"
   OFF
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,10 +521,7 @@ cmake_dependent_option(BUILD_BUNDLE_PTXAS "Bundle PTX into torch/bin folder"
                        OFF "USE_CUDA" OFF)
 
 # gradual rollout of cmake-instrumentation
-set(USE_CMAKE_INSTRUMENTATION_DEFAULT OFF)
-if(NOT USE_CUDA)
-  set(USE_CMAKE_INSTRUMENTATION_DEFAULT ON)
-endif()
+set(USE_CMAKE_INSTRUMENTATION_DEFAULT ON)
 cmake_dependent_option(
   USE_CMAKE_INSTRUMENTATION
   "Use cmake-instrumentation to collect build metrics"


### PR DESCRIPTION
AArch64 jobs in CI timeout when instrumentation is enabled.
Enabling it only for x86_64 for now so it can be rolled out
gradually.

Related-to: https://github.com/pytorch/pytorch/issues/189078