### PR TITLE
[nn] Define generic MultiheadAttention and SyncBatchNorm device gates from the dispatcher

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6164,6 +6164,26 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         )
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @unittest.skipIf(not torch.distributed.is_available(), "torch.distributed not available")
+    @unittest.skipIf(not torch.distributed.is_gloo_available(), "gloo not available")
+    def test_sync_batchnorm_unsupported_device(self):
+        # SyncBatchNorm needs aten::batch_norm_stats, which is only registered for
+        # some backends. The gate rejects the rest before the collective runs.
+        from torch.nn.modules.batchnorm import _sync_batch_norm_supported
+
+        self.assertFalse(_sync_batch_norm_supported("cpu"))
+        self.assertEqual(_sync_batch_norm_supported("cuda"), TEST_CUDA)
+
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", "29513")
+        torch.distributed.init_process_group("gloo", rank=0, world_size=1)
+        try:
+            module = torch.nn.SyncBatchNorm(3).train()
+            with self.assertRaisesRegex(ValueError, "batch_norm_stats kernel registered"):
+                module(torch.randn(2, 3, 4))
+        finally:
+            torch.distributed.destroy_process_group()
+
     def test_convert_sync_batchnorm(self):
         module = torch.nn.Sequential(
             torch.nn.BatchNorm1d(100),

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -6163,7 +6163,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             4096,
         )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     @unittest.skipIf(not torch.distributed.is_available(), "torch.distributed not available")
     @unittest.skipIf(not torch.distributed.is_gloo_available(), "gloo not available")
     def test_sync_batchnorm_unsupported_device(self):
@@ -6184,6 +6183,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         finally:
             torch.distributed.destroy_process_group()
 
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
     def test_convert_sync_batchnorm(self):
         module = torch.nn.Sequential(
             torch.nn.BatchNorm1d(100),

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -236,6 +236,8 @@ constant_fold_functions = [
     torch.nn.functional._Reduction.get_enum,  # type: ignore[attr-defined]
     torch.promote_types,
     torch._C._get_privateuse1_backend_name,
+    torch._C._dispatch_key_for_device,
+    torch._C._dispatch_has_kernel_for_dispatch_key,
     torch.autograd._is_checkpoint_valid,
     torch.mps.is_available,
     torch.mtia.is_available,

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -85,7 +85,10 @@ class SyncBatchNorm(Function):
             # world_size * (2C + 1) -> world_size * C, world_size * C, world_size * 1
             mean_all, invstd_all, count_all = torch.split(combined, num_channels, dim=1)
 
-        if not (torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()):
+        _is_capturing = getattr(
+            torch.get_device_module(input.device), "is_current_stream_capturing", None
+        )
+        if _is_capturing is None or not _is_capturing():
             # The lines below force a synchronization between CUDA and CPU, because
             # the shape of the result count_all depends on the values in mask tensor.
             # Such synchronizations break CUDA Graph capturing.

--- a/torch/nn/modules/activation.py
+++ b/torch/nn/modules/activation.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import functools
 import warnings
 
 import torch
@@ -1054,14 +1055,20 @@ class Softshrink(Module):
         return str(self.lambd)
 
 
+@functools.lru_cache
+def _mha_fastpath_supported(device_type: str) -> bool:
+    return torch._C._dispatch_has_kernel_for_dispatch_key(
+        "aten::_native_multi_head_attention",
+        torch._C._dispatch_key_for_device(device_type),
+    )
+
+
 def _check_arg_device(x: torch.Tensor | None) -> bool:
-    if x is not None:
-        return x.device.type in [
-            "cpu",
-            "cuda",
-            torch.utils.backend_registration._privateuse1_backend_name,
-        ]
-    return True
+    if x is None:
+        return True
+    if torch.jit.is_scripting():
+        return False
+    return _mha_fastpath_supported(x.device.type)
 
 
 def _arg_requires_grad(x: torch.Tensor | None) -> bool:
@@ -1412,8 +1419,8 @@ class MultiheadAttention(Module):
                 why_not_fast_path = "some Tensor argument has_torch_function"
             elif not all(_check_arg_device(x) for x in tensor_args):
                 why_not_fast_path = (
-                    "some Tensor argument's device is neither one of "
-                    f"cpu, cuda or {torch.utils.backend_registration._privateuse1_backend_name}"
+                    "some Tensor argument's device has no "
+                    "_native_multi_head_attention kernel registered"
                 )
             elif torch.is_grad_enabled() and any(
                 _arg_requires_grad(x) for x in tensor_args

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -1,4 +1,5 @@
 # mypy: allow-untyped-defs
+import functools
 from typing import Any
 
 import torch
@@ -20,6 +21,18 @@ __all__ = [
     "LazyBatchNorm3d",
     "SyncBatchNorm",
 ]
+
+# SyncBatchNorm is built from batch_norm_stats and friends, which are registered
+# per backend rather than being composite. Ask the dispatcher which devices have
+# them instead of tracking the backend list by hand.
+_SYNC_BATCH_NORM_OP = "aten::batch_norm_stats"
+
+
+@functools.lru_cache
+def _sync_batch_norm_supported(device_type: str) -> bool:
+    return torch._C._dispatch_has_kernel_for_dispatch_key(
+        _SYNC_BATCH_NORM_OP, torch._C._dispatch_key_for_device(device_type)
+    )
 
 
 class _NormBase(Module):
@@ -841,16 +854,11 @@ class SyncBatchNorm(_BatchNorm):
             and torch.distributed.is_initialized()
         )
         if need_sync:
-            # currently only GPU/PrivateUse1 input is supported
-            if input.device.type not in [
-                "cuda",
-                "hpu",
-                "xpu",
-                torch._C._get_privateuse1_backend_name(),
-            ]:
+            if not _sync_batch_norm_supported(input.device.type):
                 raise ValueError(
-                    "SyncBatchNorm expected input tensor to be on GPU or XPU or "
-                    f"{torch._C._get_privateuse1_backend_name()}"
+                    "SyncBatchNorm expected input tensor to be on a device with a "
+                    f"{_SYNC_BATCH_NORM_OP} kernel registered, but got "
+                    f"{input.device.type}"
                 )
 
             process_group = torch.distributed.group.WORLD

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -22,16 +22,11 @@ __all__ = [
     "SyncBatchNorm",
 ]
 
-# SyncBatchNorm is built from batch_norm_stats and friends, which are registered
-# per backend rather than being composite. Ask the dispatcher which devices have
-# them instead of tracking the backend list by hand.
-_SYNC_BATCH_NORM_OP = "aten::batch_norm_stats"
-
 
 @functools.lru_cache
 def _sync_batch_norm_supported(device_type: str) -> bool:
     return torch._C._dispatch_has_kernel_for_dispatch_key(
-        _SYNC_BATCH_NORM_OP, torch._C._dispatch_key_for_device(device_type)
+        "aten::batch_norm_stats", torch._C._dispatch_key_for_device(device_type)
     )
 
 
@@ -857,7 +852,7 @@ class SyncBatchNorm(_BatchNorm):
             if not _sync_batch_norm_supported(input.device.type):
                 raise ValueError(
                     "SyncBatchNorm expected input tensor to be on a device with a "
-                    f"{_SYNC_BATCH_NORM_OP} kernel registered, but got "
+                    f"aten::batch_norm_stats kernel registered, but got "
                     f"{input.device.type}"
                 )
 


### PR DESCRIPTION
## What does this PR solves?

Two `nn` modules (activation.py and batchnorm.py) gate behaviour on a hardcoded list of device-type strings. Both lists are hand-maintained proxies for "does this device have the kernel", replace them with a dispatcher query.

Related to this RFC: #194355

### `MultiheadAttention` (`activation.py`)

`_check_arg_device` decides whether `forward` takes the fused `torch._native_multi_head_attention` fast path, by matching a hardcoded list of device-type strings. The list is a hand-maintained proxy for "does this device have the kernel", and it needs an edit every time a backend lands.

Each vendor that registers the `_native_multi_head_attention` kernel should add their key to the check list in activation.py:1059. Instead, query the disğatcher for `aten::_native_multi_head_attention`, so the gate follows the registrations rather than tracking them by hand. After this change, also XPU can use the fastpath, which is skipped even though it had a registered kernel in native_functions.yaml.

The query also fixes a second problem the list has in the other direction: PrivateUse1 is currently admitted unconditionally, so a backend that has not registered the kernel enters the fast path and hits `NotImplementedError` instead of falling back to `F.multi_head_attention_forward`.

### `SyncBatchNorm` (`batchnorm.py`, `_functions.py`)

The gate matched `["cuda", "hpu", "xpu", privateuse1]`. `hpu` was admitted despite having no in-tree kernel (not in native_functions.yaml), while the error message it raised named only GPU, XPU and privateuse1. Query `aten::batch_norm_stats` instead, so a backend that registers the kernels is accepted and one that does not gets a clear error rather than a `NotImplementedError` from inside the collective.

Separately, the graph-capture check in `_functions.py` was gated on `torch.cuda.is_available()`, which says nothing about where the input lives. On XPU, HPU and PrivateUse1 it was therefore always `False`, so the mask that forces a device-to-host sync ran unconditionally and silently broke graph capture on every non-CUDA accelerator. Key it on the input's own device module instead. There is no device-agnostic capture-state query, `torch.cuda`, `torch.xpu` and `torch_npu` each expose `is_current_stream_capturing` but `torch.accelerator` does not, so this reads it off the device module and treats absence as "not capturing", which is correct for backends without capture support.

### Dynamo

The two `torch._C` dispatcher queries are added to `constant_fold_functions` to prevent graph breaks. `torch._C._get_privateuse1_backend_name` is already in that list for the same reason.

### Behaviour changes

- XPU reaches the MHA fast path. Note the CUDA fused kernel returns `NaN` for fully-masked rows where the SDPA fallback returns `0`, a known divergence (`test_transformers.py:445` works around it with `nan_to_num()`), now inherited by newly admitted backends.
- `meta` tensors pass the MHA gate, where the old list blocked them.
- HPU is no longer accepted by SyncBatchNorm unconditionally; it now needs a registered `batch_norm_stats` kernel like every other backend. This is the point of the change but is the one thing an existing HPU user could notice.

### Test plan

Adds `test_sync_batchnorm_unsupported_device` into `test/test_nn`.

lintrunner -a
python -m pytest test/test_transformers.py -k "TestTransformers" -q
python -m pytest test/test_jit.py -k "multi_head or multihead" -q
python -m pytest test/test_modules.py -k "MultiheadAttention or BatchNorm" -q
python -m pytest test/test_nn.py -q
python -m pytest test/dynamo/test_misc.py -q


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98