### PR TITLE
Fix rpath-link handling of libnuma

### DIFF
--- a/c10/CMakeLists.txt
+++ b/c10/CMakeLists.txt
@@ -110,10 +110,40 @@ if(NOT BUILD_LIBTORCHLESS)
     # rpath-link entry. Wrapped in BUILD_INTERFACE so this build-machine path
     # is not baked into the installed Caffe2Targets.cmake export (it is
     # meaningless to downstream find_package(Torch) consumers). ELF/GNU-ld only.
+    #
+    # Skip the entry entirely when libnuma lives in a directory the toolchain
+    # already searches implicitly (the common distro case,
+    # e.g. /usr/lib/x86_64-linux-gnu). There it buys nothing -- ld falls back to
+    # its default directories for DT_NEEDED resolution anyway -- but it does
+    # real harm: GNU ld probes every -rpath-link directory, in command-line
+    # order, *before* -rpath and before its default directories. Naming a
+    # system directory here therefore hoists it to the front of the dependency
+    # search order, so a stale system copy of some *other* library shadows the
+    # intended one from a self-contained toolchain. Concretely, an apt-installed
+    # /usr/lib/x86_64-linux-gnu/libhsa-runtime64.so.1 would win over the ROCm
+    # SDK's own copy when resolving libamdhip64.so's DT_NEEDED, breaking every
+    # HIP-linking target with undefined hsa_* references. Only the conda-style
+    # narrow-sysroot case (libnuma outside the implicit dirs) needs the flag.
     if(NOT WIN32 AND NOT APPLE)
       get_filename_component(_numa_dir "${Numa_LIBRARIES}" DIRECTORY)
-      target_link_options(
-        c10 INTERFACE "$<BUILD_INTERFACE:LINKER:-rpath-link,${_numa_dir}>")
+      get_filename_component(_numa_dir "${_numa_dir}" REALPATH)
+      set(_numa_dir_is_implicit FALSE)
+      foreach(_implicit_dir IN LISTS CMAKE_C_IMPLICIT_LINK_DIRECTORIES
+                                     CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES)
+        get_filename_component(_implicit_dir "${_implicit_dir}" REALPATH)
+        if(_numa_dir STREQUAL _implicit_dir)
+          set(_numa_dir_is_implicit TRUE)
+          break()
+        endif()
+      endforeach()
+      if(_numa_dir_is_implicit)
+        message(STATUS
+          "Not adding -rpath-link for ${_numa_dir}: already an implicit "
+          "linker search directory")
+      else()
+        target_link_options(
+          c10 INTERFACE "$<BUILD_INTERFACE:LINKER:-rpath-link,${_numa_dir}>")
+      endif()
     endif()
   else()
     message(STATUS "don't use NUMA")

--- a/c10/hip/CMakeLists.txt
+++ b/c10/hip/CMakeLists.txt
@@ -45,22 +45,11 @@ if(NOT BUILD_LIBTORCHLESS)
   endif()
 
   # ---[ Dependency of c10_hip
+  # The -rpath-link fix for hip::amdhip64's own libhsa-runtime64.so lookup
+  # (see cmake/public/LoadHIP.cmake) is attached directly to the hip::amdhip64
+  # imported target, so every consumer -- this one included -- inherits it
+  # regardless of how many levels of target_link_libraries separate them.
   target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::host)
-
-  # hip::host resolves to hip::amdhip64 (libamdhip64.so under $ROCM_PATH/lib),
-  # whose own DT_NEEDED on libhsa-runtime64.so must resolve at link time.
-  # Nothing here propagates $ROCM_PATH/lib as an -rpath-link entry, so if some
-  # OTHER -rpath-link source (e.g. c10's NUMA workaround above, pointing at
-  # libnuma's directory) happens to also contain an unrelated system
-  # libhsa-runtime64.so (a stray apt package sharing that multiarch dir), the
-  # linker's rpath-link search -- which is checked before -rpath -- resolves
-  # against that wrong/incompatible version instead, causing "undefined
-  # reference to hsa_amd_vmem_*"-style failures. Explicitly propagate this
-  # ROCm install's own lib dir first. ELF/GNU-ld only.
-  if(NOT WIN32 AND NOT APPLE AND DEFINED ENV{ROCM_PATH})
-    target_link_options(
-      c10_hip INTERFACE "$<BUILD_INTERFACE:LINKER:-rpath-link,$ENV{ROCM_PATH}/lib>")
-  endif()
 
   target_include_directories(
       c10_hip PUBLIC

--- a/c10/hip/CMakeLists.txt
+++ b/c10/hip/CMakeLists.txt
@@ -47,6 +47,21 @@ if(NOT BUILD_LIBTORCHLESS)
   # ---[ Dependency of c10_hip
   target_link_libraries(c10_hip PUBLIC ${C10_LIB} hip::host)
 
+  # hip::host resolves to hip::amdhip64 (libamdhip64.so under $ROCM_PATH/lib),
+  # whose own DT_NEEDED on libhsa-runtime64.so must resolve at link time.
+  # Nothing here propagates $ROCM_PATH/lib as an -rpath-link entry, so if some
+  # OTHER -rpath-link source (e.g. c10's NUMA workaround above, pointing at
+  # libnuma's directory) happens to also contain an unrelated system
+  # libhsa-runtime64.so (a stray apt package sharing that multiarch dir), the
+  # linker's rpath-link search -- which is checked before -rpath -- resolves
+  # against that wrong/incompatible version instead, causing "undefined
+  # reference to hsa_amd_vmem_*"-style failures. Explicitly propagate this
+  # ROCm install's own lib dir first. ELF/GNU-ld only.
+  if(NOT WIN32 AND NOT APPLE AND DEFINED ENV{ROCM_PATH})
+    target_link_options(
+      c10_hip INTERFACE "$<BUILD_INTERFACE:LINKER:-rpath-link,$ENV{ROCM_PATH}/lib>")
+  endif()
+
   target_include_directories(
       c10_hip PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>

--- a/cmake/public/LoadHIP.cmake
+++ b/cmake/public/LoadHIP.cmake
@@ -220,6 +220,23 @@ list(FILTER CMAKE_MODULE_PATH EXCLUDE REGEX ".*/cmake/hip$")
 set(PYTORCH_FOUND_HIP TRUE)
 find_package_and_print_version(hip REQUIRED CONFIG)
 
+# hip::amdhip64's own DT_NEEDED on libhsa-runtime64.so must resolve at link
+# time. Nothing propagates ${ROCM_PATH}/lib as an -rpath-link entry for it, so
+# if some OTHER -rpath-link source elsewhere in the build (e.g. c10's NUMA
+# workaround, which points at libnuma's directory) happens to also contain an
+# unrelated system libhsa-runtime64.so (a stray distro package sharing that
+# multiarch dir), the linker's rpath-link search -- which is checked before
+# -rpath -- resolves against that wrong/incompatible version instead, causing
+# "undefined reference to hsa_amd_vmem_*"-style failures in ANY target that
+# transitively links hip::amdhip64, however deep. Attach this ROCm install's
+# own lib dir directly to the imported target so every consumer inherits it,
+# regardless of how many levels of target_link_libraries separate them from
+# hip::amdhip64. ELF/GNU-ld only.
+if(NOT WIN32 AND NOT APPLE AND TARGET hip::amdhip64)
+  set_property(TARGET hip::amdhip64 APPEND PROPERTY
+    INTERFACE_LINK_OPTIONS "$<BUILD_INTERFACE:LINKER:-rpath-link,${ROCM_PATH}/lib>")
+endif()
+
 # Map lowercase hip_VERSION vars (from CONFIG mode) to uppercase HIP_VERSION
 # vars that the rest of PyTorch's build expects (previously set by FindHIP MODULE).
 if(hip_VERSION AND NOT HIP_VERSION)


### PR DESCRIPTION
# Motivation

The problem was discovered in a system where ROCM 7.2 was installed as system-wide package, and ROCM 7.14 is installed in VENV. (Note multi-version installation of ROCM is supported.)

However the pytorch mainline failed to build and the error arises during the linking of C++ unit test files due to library incompatibility.

# Inspection

During the linking, the system wide, ROCM 7.2 library `/usr/lib/x86_64-linux-gnu/libhsa-runtime64.so.1` was chosen over the library from ROCM 7.14, even if `ROCM_PATH` is configured. The inspection shows configuration code of `libnuma` incorrectly adds its library path to the `rpath-link` unconditionally, even if it's implicit and should be used as a fallback for system libraries instead. This practice effectively shadows `rpath` supplied by ROCM.

# Solution

Do not add `_numa_dir` to `rpath-link` if it is implicit.

## Minor Changes

`${ROCM_PATH}/lib` is added to `rpath-link` of `hip::amdhip64`, which was the early attempt to fix the problem but also should be kept as defense in depth.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil