### PR TITLE
[torchelastic] Thread entrypoint fn_name through ErrorHandler (#194269)

### DIFF
--- a/test/distributed/elastic/multiprocessing/errors/api_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/api_test.py
@@ -49,6 +49,31 @@ def raise_child_failure_error_fn(name, child_error_file=""):
     raise ChildFailedError(name, {0: pf})
 
 
+def raise_sentinel_error_fn():
+    raise SentinelError("foobar")
+
+
+class FnNameCapturingErrorHandler(ErrorHandler):
+    """Captures the entrypoint fn_name that ``@record`` threads via handler state.
+
+    Deliberately overrides ``initialize``/``record_exception`` with the
+    pre-fn_name signatures to prove that old-style subclasses still receive the
+    entrypoint name (through ``self._fn_name``) and are not broken by ``@record``.
+    """
+
+    def __init__(self) -> None:
+        self.initialize_fn_name: str | None = None
+        self.record_exception_fn_name: str | None = None
+
+    def initialize(self) -> None:
+        self.initialize_fn_name = self._fn_name
+        super().initialize()
+
+    def record_exception(self, e: BaseException) -> None:
+        self.record_exception_fn_name = self._fn_name
+        super().record_exception(e)
+
+
 def read_resource_file(resource_file: str) -> str:
     with open(os.path.join(os.path.dirname(__file__), resource_file)) as fp:
         return "".join(fp.readlines())
@@ -283,3 +308,35 @@ class ApiTest(unittest.TestCase):
         error_msg = str(ex)
         self.assertIn("(SIGSEGV)", error_msg)
         self.assertIn(f"exitcode  : {-signal.SIGSEGV}", error_msg)
+
+    def test_record_passes_fn_name_to_error_handler(self):
+        # a subclass using the pre-fn_name signatures must still receive the
+        # entrypoint name via handler state and must not raise from @record
+        error_handler = FnNameCapturingErrorHandler()
+        wrapped = record(raise_sentinel_error_fn, error_handler=error_handler)
+
+        with mock.patch.dict(
+            os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}
+        ):
+            with self.assertRaises(SentinelError):
+                wrapped()
+
+        self.assertEqual("raise_sentinel_error_fn", error_handler.initialize_fn_name)
+        self.assertEqual(
+            "raise_sentinel_error_fn", error_handler.record_exception_fn_name
+        )
+
+    def test_record_does_not_write_fn_name_to_error_file(self):
+        # extraInfo is a map<string,string> for downstream consumers, so @record
+        # threads fn_name to the handler but the base handler does not persist it
+        wrapped = record(raise_sentinel_error_fn, error_handler=ErrorHandler())
+
+        with mock.patch.dict(
+            os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}
+        ):
+            with self.assertRaises(SentinelError):
+                wrapped()
+
+        with open(self.test_error_file) as fp:
+            err = json.load(fp)
+        self.assertNotIn("fn_name", err["message"]["extraInfo"])

--- a/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
+++ b/test/distributed/elastic/multiprocessing/errors/error_handler_test.py
@@ -9,6 +9,9 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+from torch.distributed.elastic.multiprocessing.errors import (
+    error_handler as error_handler_mod,
+)
 from torch.distributed.elastic.multiprocessing.errors.error_handler import ErrorHandler
 from torch.distributed.elastic.multiprocessing.errors.handlers import get_error_handler
 
@@ -66,6 +69,26 @@ class ErrorHandlerTest(unittest.TestCase):
             self.assertIsNotNone(err["message"]["message"])
             self.assertIsNotNone(err["message"]["extraInfo"]["py_callstack"])
             self.assertIsNotNone(err["message"]["extraInfo"]["timestamp"])
+
+    def test_record_exception_with_fn_name(self):
+        with patch.dict(os.environ, {"TORCHELASTIC_ERROR_FILE": self.test_error_file}):
+            eh = ErrorHandler()
+            eh.set_entrypoint_fn_name("raise_exception_fn")
+            eh.initialize()
+
+            with self.assertLogs(error_handler_mod.logger, level="DEBUG") as logs:
+                try:
+                    raise_exception_fn()
+                except Exception as e:
+                    eh.record_exception(e)
+
+            self.assertTrue(any("raise_exception_fn" in line for line in logs.output))
+
+            # extraInfo is a map<string,string> for downstream consumers, so the
+            # base handler logs fn_name rather than writing it to the error file
+            with open(self.test_error_file) as fp:
+                err = json.load(fp)
+            self.assertNotIn("fn_name", err["message"]["extraInfo"])
 
     def test_record_exception_no_error_file(self):
         # make sure record does not fail when no error file is specified in env vars

--- a/torch/distributed/elastic/multiprocessing/errors/__init__.py
+++ b/torch/distributed/elastic/multiprocessing/errors/__init__.py
@@ -340,6 +340,7 @@ def record(
     ::
 
      error_handler = get_error_handler()
+     error_handler.set_entrypoint_fn_name(foobar.__qualname__)
      error_handler.initialize()
      try:
          foobar()
@@ -375,6 +376,7 @@ def record(
         def wrapper(*args: _P.args, **kwargs: _P.kwargs):
             if error_handler is None:
                 raise AssertionError  # assertion for mypy type checker
+            error_handler.set_entrypoint_fn_name(f.__qualname__)
             error_handler.initialize()
             try:
                 return f(*args, **kwargs)

--- a/torch/distributed/elastic/multiprocessing/errors/error_handler.py
+++ b/torch/distributed/elastic/multiprocessing/errors/error_handler.py
@@ -41,6 +41,23 @@ class ErrorHandler:
         """
         return os.environ.get("TORCHELASTIC_ERROR_FILE", None)
 
+    # Qualified name of the ``@record``-decorated entrypoint function, set via
+    # ``set_entrypoint_fn_name`` before ``initialize``/``record_exception`` run.
+    # Kept as handler state (rather than a method argument) so overriding
+    # ``initialize``/``record_exception`` does not require a signature change,
+    # preserving backward compatibility for this public extension point.
+    _fn_name: str | None = None
+
+    def set_entrypoint_fn_name(self, fn_name: str | None) -> None:
+        """
+        Record the qualified name of the ``@record``-decorated entrypoint fn.
+
+        Called by ``@record`` before ``initialize()`` so subclasses can attribute
+        errors to the originating function via ``self._fn_name`` without changing
+        the ``initialize``/``record_exception`` signatures.
+        """
+        self._fn_name = fn_name
+
     def initialize(self) -> None:
         """
         Call prior to running code that we wish to capture errors/exceptions.
@@ -72,7 +89,14 @@ class ErrorHandler:
 
         If the error file cannot be determined, then logs the content
         that would have been written to the error file.
+
+        ``self._fn_name`` (the qualified name of the ``@record``-decorated
+        entrypoint function, if set via ``set_entrypoint_fn_name``) is logged but
+        not written to the error file; subclasses may override this method to
+        record it in their own format.
         """
+        if self._fn_name:
+            logger.debug("recording exception from entrypoint fn: %s", self._fn_name)
         file = self._get_error_file_path()
         if file:
             data = {


### PR DESCRIPTION
Summary:

Pass the qualified name of the `record`-decorated entrypoint function into
the error handler so failures can be attributed to the originating function.

Test Plan:
unit tests

```
buck2 test //caffe2/test/distributed/elastic/multiprocessing/errors:error_handler_test
```
Tests finished: Pass 8. Fail 0.

https://www.internalfb.com/intern/testinfra/testrun/9570149399716947

```
buck2 test fbcode//caffe2/test/distributed/elastic/multiprocessing/errors:api_test
```
Tests finished: Pass 18. Fail 0.
https://www.internalfb.com/intern/testinfra/testrun/34621422162816549

## Remote fbpkg builds (pinned to this diff, rev 401320860e42)
- training_platform.worker: https://www.internalfb.com/intern/servicelab/build/1063030740
- training_platform.launcher: https://www.internalfb.com/intern/servicelab/build/1063030743

## MAST relaunch (using packages built from this diff)
```
aito_mast_relaunch f1127524915-TrainingApplication \
  --mast_job_version 0 \
  --entitlement dper_int \
  --hpc_identity oncall_pyper_training \
  --skip_clone_model \
  --model_entity_id 1127520403 \
  --package_override training_platform.launcher:4a47a67827af16853ec7a4c46517d481 \
  --package_override training_platform.worker:934746d496acf2db53c56b5ef5830ea0
```
MAST job: https://www.internalfb.com/mlhub/pipelines/runs/mast/f1127524915-TrainingApplication_T7GOZ?job_attempt=0&version=0&tab=execution_details&env=PRODUCTION

Reviewed By: d4l3k

Differential Revision: D116228049


