### PR TITLE
Add shape validation for attn_bias in SDPA meta registration

### DIFF
--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -6467,6 +6467,15 @@ def meta__scaled_dot_product_fused_attention_overrideable(
     S_KV = key.size(-2)
     D_V = value.size(-1)
 
+    if attn_bias is not None:
+        bias_s_kv = attn_bias.size(-1)
+        if bias_s_kv != 1:
+            torch._check(
+                bias_s_kv == S_KV,
+                lambda: f"attn_bias last dimension must match S_KV ({S_KV}) "
+                f"or be 1 for broadcasting, but got {bias_s_kv}",
+            )
+
     # Preserve input dimensionality for the output shape
     out_shape = list(query.shape)
     out_shape[-1] = D_V


### PR DESCRIPTION
### Description
This PR adds validation checks for the `attn_bias` tensor shape during meta-registration tracing of `_scaled_dot_product_fused_attention_overrideable`. 

Specifically, it asserts that the last dimension (index `-1`) of `attn_bias` aligns with the Key/Value sequence length (`S_KV`) or is equal to `1` (permitting standard broadcasting behavior). 