### PR TITLE
Fix typos and grammar in comments and READMEs

### DIFF
--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -885,7 +885,7 @@ def register_bytecode_hook(hook: BytecodeHook) -> RemovableHandle:
 
 
 # TODO - We want to run preserve_node_meta context manager here, but the CI
-# fails (its unclear if the failures were flaky)
+# fails (it's unclear if the failures were flaky)
 # @torch.fx.traceback.preserve_node_meta()
 @preserve_global_state
 def trace_frame(

--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -628,10 +628,10 @@ def unimplemented_with_warning(
 ) -> NoReturn:
     # This function calls unimplemented internally and eventually graph breaks
     # or falls to eager. unimplemented itself does not print any user warnings,
-    # i.e., its very silent. This helper function is intended when an error is
+    # i.e., it's very silent. This helper function is intended when an error is
     # encountered in the torch.compile stack which is worth showing as warning
     # to the user. For example, if AOT Autograd backend fails with a fake tensor
-    # exception, its ok to fallback to eager but not silently. Here, we can use
+    # exception, it's ok to fallback to eager but not silently. Here, we can use
     # this function to log the message and the stack trace.
     graph_break_msg = format_error_msg_verbose(e, code)
     torch._logging.trace_structured(

--- a/torch/_inductor/choices.py
+++ b/torch/_inductor/choices.py
@@ -292,7 +292,7 @@ class InductorChoices:
     ) -> bool:
         """Return True if any active backend requires fixed (non-flexible) tensor layouts."""
         # TODO: debug and fix
-        # NOTE: on mps, we see issues with flexible layouts on baddmm. This check just makes sure
+        # NOTE: on mps, we see issues with flexible layouts on baddbmm. This check just makes sure
         # that for mps, everything stays as it was before this optimization
         if len(adjusted_choices) > 0:
             if adjusted_choices[0].inputs.device_type == "mps" and op_name not in [

--- a/torch/ao/pruning/_experimental/activation_sparsifier/README.md
+++ b/torch/ao/pruning/_experimental/activation_sparsifier/README.md
@@ -66,7 +66,7 @@ def mask_fn(tensor, threshold):  # threshold is the sparse config here
 
 `step`: For each registered layer, applies the `reduce_fn` on aggregated activations and then applies `mask_fn` after reduce operation.
 
-`squash_mask`: Unregisters aggregate hook that was applied earlier and registers sparsification hooks if `attach_sparsify_hook=True`. Sparsification hooks applies the computed mask to the activations before it flows into the registered layer.
+`squash_mask`: Unregisters aggregate hook that was applied earlier and registers sparsification hooks if `attach_sparsify_hook=True`. Sparsification hooks apply the computed mask to the activations before it flows into the registered layer.
 
 ## Example
 

--- a/torch/ao/pruning/_experimental/data_scheduler/README.md
+++ b/torch/ao/pruning/_experimental/data_scheduler/README.md
@@ -14,7 +14,7 @@ the data sparsifier class and varies it across the training process (or across t
 `step`: Applies the `get_schedule_param` logic every epoch/step depending on when it is called. This should always be called after the `sparsifier.step()` has been called.
 
 ## Write your own data scheduler
-The custom data scheduler must be inherit from the `BaseDataScheduler` class and should have the `get_schedule_param()` function implemented. For example, that gradually multiplies the sparsity level by `gamma` every epoch.
+The custom data scheduler must inherit from the `BaseDataScheduler` class and should have the `get_schedule_param()` function implemented. For example, that gradually multiplies the sparsity level by `gamma` every epoch.
 It also takes an argument `threshold_sl` which when reached does not increase further.
 
 ```

--- a/torch/ao/pruning/_experimental/data_sparsifier/README.md
+++ b/torch/ao/pruning/_experimental/data_sparsifier/README.md
@@ -17,7 +17,7 @@ The BaseDataSparsifier handles all the housekeeping while allowing the user to j
 
 `add_data`: Accepts name, data tuple and registers the data as a parametrized buffer inside the container model. Note that the data is always associated to a name. A custom sparse config can be provided along with the name, data pair. If not provided, the default config will be applied while doing the sparsification.
 If the named data already exists, then it is replaced with the new data. The config and mask will be retained for the new data unless not specified to.
-To not the old mask, set `reuse_mask=False`. If the `config` is explicitly passed in, it will be updated.
+To not reuse the old mask, set `reuse_mask=False`. If the `config` is explicitly passed in, it will be updated.
 
 **Note**: name containing '.' is not a valid name for the data sparsifier
 

--- a/torch/ao/quantization/fx/README.md
+++ b/torch/ao/quantization/fx/README.md
@@ -135,7 +135,7 @@ def forward(self, x):
 ```
 
 In this step we swap the fused module to qat module, for example, swap nn.intrinsic.LinearReLU instances to nn.intrinsic.qat.LinearReLU module where we fake quantize the weight of linear.
-For modules that has corresponding QAT modules we’ll call eager mode `convert` function with a mapping from float module to QAT module which will swap all float module (and fused module) with QAT module, this step is exactly the same as eager mode quantization, just called inside the `prepare_fx/prepare_qat_fx` function.
+For modules that have corresponding QAT modules we’ll call eager mode `convert` function with a mapping from float module to QAT module which will swap all float module (and fused module) with QAT module, this step is exactly the same as eager mode quantization, just called inside the `prepare_fx/prepare_qat_fx` function.
 
 `backend_config` configurations relevant in this step are:
 ```

--- a/torch/ao/quantization/fx/_model_report/README.md
+++ b/torch/ao/quantization/fx/_model_report/README.md
@@ -158,7 +158,7 @@ After the `ModelReportObserver` collects the statistics above during the calibra
 
 If you wish to implement your own custom Observer to use with the ModelReport API for your own custom detector, there are a few things to keep in mind.
 - Make sure your detector inherits from [`torch.ao.quantization.observer.ObserverBase`](https://www.internalfb.com/code/fbsource/[20eb160510847bd24bf21a5b95092c160642155f]/fbcode/caffe2/torch/ao/quantization/observer.py?lines=122)
-- In the custom detector class, come up with a descriptive and unique `PRE_OBSERVER_NAME` (and/or `POST_OBSERVER_NAME`) so that you can generate a fully qualified name (fqn) for each observer that acts a key in the returned dictionary described [here](#requirements-to-implement-a-detector)
+- In the custom detector class, come up with a descriptive and unique `PRE_OBSERVER_NAME` (and/or `POST_OBSERVER_NAME`) so that you can generate a fully qualified name (fqn) for each observer that acts as a key in the returned dictionary described [here](#requirements-to-implement-a-detector)
   - [Code Example](https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/fx/_model_report/detector.py#L958)
 - In the `determine_observer_insert_points()` method in your detector, initialize your custom Observer and add it to the returned dictionary described [here](#requirements-to-implement-a-detector)
   - [Code Example](https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/fx/_model_report/detector.py#L1047)

--- a/torch/csrc/distributed/rpc/rref_impl.h
+++ b/torch/csrc/distributed/rpc/rref_impl.h
@@ -115,7 +115,7 @@ struct TORCH_API RRefForkData {
 //
 // G1. The owner will be notified when any UserRRef is deleted.
 //
-// As messages might come delayed or out-of-order, we need more one guarantee to
+// As messages might come delayed or out-of-order, we need one more guarantee to
 // make sure the delete message is not sent out too soon. Let us first introduce
 // a new concept. If A sends an RPC to B that involves an RRef, we call the RRef
 // on A the parent RRef and the RRef on B the child RRef.

--- a/torch/csrc/jit/codegen/fuser/cpu/temp_file.h
+++ b/torch/csrc/jit/codegen/fuser/cpu/temp_file.h
@@ -70,7 +70,7 @@ struct TempFile {
     auto wname = std::wstring(tt.begin(), tt.end() - 1);
     name_ = c10::u16u8(wname);
 #else
-    // mkstemps edits its first argument in places
+    // mkstemps edits its first argument in place
     // so we make a copy of the string here, including null terminator
     std::vector<char> tt(t.c_str(), t.c_str() + t.size() + 1);
     int fd = mkstemps(tt.data(), suffix);

--- a/torch/csrc/jit/passes/dead_code_elimination.h
+++ b/torch/csrc/jit/passes/dead_code_elimination.h
@@ -4,7 +4,7 @@
 
 namespace torch::jit {
 
-// If given a top-level graph, DCE will construct do alias analysis that allows
+// If given a top-level graph, DCE will do alias analysis that allows
 // for "smarter" dead code elimination (we will eliminate mutable ops if we can
 // prove the mutated values are not used). Otherwise, we will not allow DCE to
 // eliminate mutable ops.

--- a/torch/csrc/jit/passes/frozen_concat_linear.cpp
+++ b/torch/csrc/jit/passes/frozen_concat_linear.cpp
@@ -114,7 +114,7 @@ class ConcatLinearLayers {
 
     for (Node* orig_node : compatible_layers) {
       // for each node in the compatible_layers list,
-      // slide the output of the combined linear layer
+      // slice the output of the combined linear layer
       // and use it instead of the output of the original node
 
       Tensor weight_tensor =

--- a/torch/csrc/jit/passes/quantization/finalize.cpp
+++ b/torch/csrc/jit/passes/quantization/finalize.cpp
@@ -264,7 +264,7 @@ Module FinalizeOnDevicePTQ(
   removePackedParamInsertionAndFPWeightsSetAttr(
       quantized_graph, packed_param_attr_names);
   // Removing packed params is not sufficient since that does not do DCE
-  // for observer node's getatts and callmethods because callmethods have side
+  // for observer node's getattrs and callmethods because callmethods have side
   // effects
   removeObserverCallMethods(quantized_graph);
   // This step removed the return output from the graph and subsequent

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -20,7 +20,7 @@ from .optimizer import (
 __all__ = ["Muon"]
 
 # Constants from Keller Jordan's Muon post: https://kellerjordan.github.io/posts/muon/
-# github permlink: https://github.com/KellerJordan/Muon/blob/f90a42b28e00b8d9d2d05865fe90d9f39abcbcbd/muon.py#L16
+# github permalink: https://github.com/KellerJordan/Muon/blob/f90a42b28e00b8d9d2d05865fe90d9f39abcbcbd/muon.py#L16
 EPS = 1e-7
 DEFAULT_A = 3.4445
 DEFAULT_B = -4.7750

--- a/torch/utils/benchmark/README.md
+++ b/torch/utils/benchmark/README.md
@@ -43,7 +43,7 @@ performance differences. Grouping and layout is based on metadata passed to
 table will be generated per unique label.
 
 * `sub_label`: This is the label for a given configuration. Multiple statements
-may be logically equivalent differ in implementation. Assigning separate
+may be logically equivalent but differ in implementation. Assigning separate
 sub_labels will result in a row per sub_label. If a sublabel is not provided,
 `stmt` is used instead. Statistics (such as computing the fastest
 implementation) use all sub_labels.

--- a/torch/utils/data/datapipes/README.md
+++ b/torch/utils/data/datapipes/README.md
@@ -9,7 +9,7 @@ For `MapDataPipe`, please take reference from files in [map](https://github.com/
 ### Naming
 The naming convention for DataPipe is Operation-er and with suffix of `IterDataPipe` because each DataPipe behaves like a container to apply the operation to data yielded from the source DataPipe.
 And, when importing the DataPipe into `iter` module under `datapipes`, each DataPipe will be aliased as Op-er without the suffix of `IterDataPipe`.
-Please check [`__init__.py`](https://github.com/pytorch/pytorch/blob/main/torch/utils/data/datapipes/iter/__init__.py) in `iter` module for how we aliasing each DataPipe class.
+Please check [`__init__.py`](https://github.com/pytorch/pytorch/blob/main/torch/utils/data/datapipes/iter/__init__.py) in `iter` module for how we alias each DataPipe class.
 Like the example of `IterDataPipe` to map a function, we are going to name it as `MapperIterDataPipe` and alias it as `iter.Mapper` under `datapipes`.
 
 ### Constructor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Corrects small wording errors across code comments, documentation, and READMEs
under `torch/`: misspellings (baddmm, permlink, getatts, slide vs slice),
grammatical slips (its vs it's, subject-verb agreement, "we need more one
guarantee"), and a truncated sentence in the data sparsifier README that dropped
the verb ("To not the old mask" -> "To not reuse the old mask").

No functional changes.

Test Plan: no code paths are affected; only comments and Markdown files change.
Verified the tree still lints cleanly.

```
lintrunner -a
```

This change was authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98