### PR TITLE
[inductor] Replace `Any` with `object` on isinstance/getattr-only predicates

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -207,7 +207,7 @@ log = logging.getLogger(__name__)
 AOTAUTOGRAD_CACHE_PREFIX = "a"
 
 
-def _device_constructor_sort_key(target: Any) -> str:
+def _device_constructor_sort_key(target: object) -> str:
     return ".".join(
         x
         for x in (
@@ -934,7 +934,7 @@ class FxGraphCachePickler(pickle.Pickler):
         to a different value than another.
         """
 
-        def get_str(obj: Any) -> str:
+        def get_str(obj: object) -> str:
             if isinstance(obj, torch.Tensor):
                 return str(extract_tensor_metadata_for_cache_key(obj))
             elif isinstance(obj, bytes):
@@ -1227,11 +1227,11 @@ class CacheabilityValidator:
 _warned_pre_grad_pass_missing_uuid: OrderedSet[str] = OrderedSet()
 
 
-def _custom_pass_has_uuid(custom_pass: Any) -> bool:
+def _custom_pass_has_uuid(custom_pass: object) -> bool:
     return isinstance(custom_pass, CustomGraphPass) and custom_pass.uuid() is not None
 
 
-def _custom_pass_name(custom_pass: Any) -> str:
+def _custom_pass_name(custom_pass: object) -> str:
     return getattr(custom_pass, "__qualname__", None) or type(custom_pass).__qualname__
 
 
@@ -1372,7 +1372,7 @@ class FxGraphHashDetails:
     )
 
     @classmethod
-    def _contains_tensor(cls, value: Any) -> bool:
+    def _contains_tensor(cls, value: object) -> bool:
         if isinstance(value, torch.Tensor):
             return True
         if isinstance(value, (list, tuple, OrderedSet, frozenset)):
@@ -1385,7 +1385,7 @@ class FxGraphHashDetails:
         return False
 
     @classmethod
-    def _contains_cpu_tensor(cls, value: Any) -> bool:
+    def _contains_cpu_tensor(cls, value: object) -> bool:
         if isinstance(value, torch.Tensor):
             return value.device.type == "cpu"
         if isinstance(value, (list, tuple, OrderedSet, frozenset)):
@@ -1398,7 +1398,7 @@ class FxGraphHashDetails:
         return False
 
     @staticmethod
-    def _device_type(value: Any) -> str | None:
+    def _device_type(value: object) -> str | None:
         if isinstance(value, torch.device):
             return value.type
         if isinstance(value, str):
@@ -1410,7 +1410,7 @@ class FxGraphHashDetails:
 
     @classmethod
     def _is_factory_target(
-        cls, target: Any, targets: tuple[Any, ...], packets: tuple[Any, ...]
+        cls, target: object, targets: tuple[object, ...], packets: tuple[object, ...]
     ) -> bool:
         if target in targets or target in packets:
             return True

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -1688,7 +1688,7 @@ class KernelArgs:
         )
 
     @staticmethod
-    def _buffer_is_marked_removed(name: Any) -> bool:
+    def _buffer_is_marked_removed(name: object) -> bool:
         # this function is needed by MTIA
         return isinstance(name, RemovedArg)
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -129,8 +129,8 @@ else:
 log = torch._logging.getArtifactLogger(__name__, "cudagraphs")
 
 
-def format_inputs_log(inputs: list[Any]) -> str:
-    def format_item(i: int, inp: Any) -> str:
+def format_inputs_log(inputs: Sequence[object]) -> str:
+    def format_item(i: int, inp: object) -> str:
         if isinstance(inp, torch.Tensor):
             return (
                 f"[{i}]: Tensor(size={list(inp.size())}, stride={inp.stride()}, "
@@ -383,7 +383,7 @@ def reset_cudagraph_trees() -> None:
     MarkStepBox.mark_step_counter = 0
 
 
-def get_obj(local: Any, attr_name: str) -> Any:
+def get_obj(local: threading.local, attr_name: str) -> Any:
     if hasattr(local, attr_name):
         return getattr(local, attr_name)
     if not torch._C._is_key_in_tls(attr_name):
@@ -824,7 +824,7 @@ class CUDAWarmupNode:
             )
 
         # sdpa returns cpu tensors when not recording cuda graph
-        def add_ref(o: Any) -> bool:
+        def add_ref(o: object) -> bool:
             return (
                 isinstance(o, torch.Tensor)
                 and o.is_cuda

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -368,7 +368,7 @@ class UniformValueConstantFolder(ConstantFolder):
             if not isinstance(tensor_val, torch.Tensor):
                 continue
 
-            def is_zero_int(arg: Any) -> bool:
+            def is_zero_int(arg: object) -> bool:
                 return isinstance(arg, int) and arg == 0
 
             if not any(is_zero_int(a) for a in op.args):

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -1644,10 +1644,22 @@ class GraphLowering(torch.fx.Interpreter):
 
         return self.add_tensor_constant(value, target)
 
-    def call_module(self, target: Any, args: Any, kwargs: Any) -> NoReturn:
+    @typing_extensions.override
+    def call_module(
+        self,
+        target: torch.fx.node.Target,
+        args: tuple[torch.fx.node.Argument, ...],
+        kwargs: dict[str, object],
+    ) -> NoReturn:
         raise AssertionError
 
-    def call_method(self, target: Any, args: Any, kwargs: Any) -> NoReturn:
+    @typing_extensions.override
+    def call_method(
+        self,
+        target: torch.fx.node.Target,
+        args: tuple[torch.fx.node.Argument, ...],
+        kwargs: dict[str, object],
+    ) -> NoReturn:
         raise AssertionError
 
     @typing_extensions.override
@@ -1817,7 +1829,7 @@ class GraphLowering(torch.fx.Interpreter):
                 f"old_kwargs length ({len(old_kwargs)}) != new_kwargs length ({len(new_kwargs)})"
             )
 
-        def already_reflected(old_arg: Any, new_arg: Any) -> bool:
+        def already_reflected(old_arg: object, new_arg: object) -> bool:
             # No propagation is needed when new_arg already reflects the
             # mutation of old_arg: either they are the same object, or they are
             # distinct IR nodes aliasing the same buffer (e.g. an in-place op

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -662,7 +662,7 @@ class IRNode:
     def wrap_for_lowering(self) -> IRNode:
         return TensorBox.create(self)
 
-    def _post_init_setattr(self, attr: str, value: Any) -> None:
+    def _post_init_setattr(self, attr: str, value: object) -> None:
         # Intended for use in __post_init__ for enforcing an invariant on a dataclass
         # If you must, can also be used for setting provenance info
         # We would like to try and minimize these usages though
@@ -3842,7 +3842,7 @@ class SqueezeView(BaseView):
 
         return new_size, reindex
 
-    def __init__(self, data: Any) -> None:
+    def __init__(self, data: object) -> None:
         raise AssertionError("use SqueezeView.create()")
 
 
@@ -5210,7 +5210,7 @@ class MutationLayoutSHOULDREMOVE(Layout):
         return self.real_layout().storage_size()
 
     def get_buffer(self) -> Buffer:
-        def unwrap_views(target: Any) -> Any:
+        def unwrap_views(target: object) -> object:
             if isinstance(target, MutationLayoutSHOULDREMOVE):
                 return unwrap_views(target.target)
             if isinstance(target, BaseView):
@@ -7226,7 +7226,7 @@ class ExternKernel(InputsKernel):
     def get_read_writes(self) -> dependencies.ReadWrites:
         read_writes = super().get_read_writes()
 
-        def add_ir_read(value: Any) -> None:
+        def add_ir_read(value: object) -> None:
             if isinstance(value, IRNode):
                 name = value.maybe_get_name()
                 if name is not None:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -290,7 +290,7 @@ def decode_dtype(dtype: int | torch.dtype) -> torch.dtype:
     return dtype
 
 
-def is_integer_type(x: Any) -> TypeGuard[TensorBox | IRNode | sympy.Expr | int]:
+def is_integer_type(x: object) -> TypeGuard[TensorBox | IRNode | sympy.Expr | int]:
     if isinstance(x, (TensorBox, IRNode)):
         return is_integer_dtype(x.get_dtype()) or is_boolean_dtype(x.get_dtype())
     elif isinstance(x, sympy.Expr):
@@ -299,7 +299,7 @@ def is_integer_type(x: Any) -> TypeGuard[TensorBox | IRNode | sympy.Expr | int]:
         return isinstance(x, int)
 
 
-def is_boolean_type(x: Any) -> TypeGuard[TensorBox | IRNode | bool]:
+def is_boolean_type(x: object) -> TypeGuard[TensorBox | IRNode | bool]:
     if isinstance(x, (TensorBox, IRNode)):
         return is_boolean_dtype(x.get_dtype())
     else:

--- a/torch/_inductor/runtime/runtime_utils.py
+++ b/torch/_inductor/runtime/runtime_utils.py
@@ -170,7 +170,7 @@ def blue_text(msg: str) -> str:
     return _color_text(msg, "blue")
 
 
-def get_first_attr(obj: Any, *attrs: str) -> Any:
+def get_first_attr(obj: object, *attrs: str) -> Any:
     """
     Return the first available attribute or throw an exception if none is present.
     """

--- a/torch/_inductor/runtime/static_triton_launcher.py
+++ b/torch/_inductor/runtime/static_triton_launcher.py
@@ -90,7 +90,7 @@ class StaticallyLaunchedTritonKernel:
             launch_enter = triton_knobs.runtime.launch_enter_hook
             launch_exit = triton_knobs.runtime.launch_exit_hook
 
-        def hook_is_empty(hook: Any) -> bool:
+        def hook_is_empty(hook: object) -> bool:
             if hook is None:
                 return True
             if (

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -101,7 +101,7 @@ def get_backend_options():
     return get_backend_options_for_target(target)
 
 
-def _is_concrete_backend_option_value(value: Any) -> bool:
+def _is_concrete_backend_option_value(value: object) -> bool:
     import sympy
 
     import torch

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -759,13 +759,13 @@ def print_performance(
     return took.item()
 
 
-def precompute_method(obj: Any, method: str) -> None:
+def precompute_method(obj: object, method: str) -> None:
     """Replace obj.method() with a new method that returns a precomputed constant."""
     result = getattr(obj, method)()
     setattr(obj, method, lambda: result)
 
 
-def precompute_methods(obj: Any, methods: list[str]) -> None:
+def precompute_methods(obj: object, methods: list[str]) -> None:
     """Replace methods with new methods that returns a precomputed constants."""
     for method in methods:
         precompute_method(obj, method)
@@ -1308,13 +1308,13 @@ def sympy_subs(expr: sympy.Expr, replacements: dict[sympy.Expr, Any]) -> sympy.E
     return _sympy_subs(expr, replacements)
 
 
-def is_symbolic(a: Any) -> TypeGuard[torch.SymInt | torch.Tensor]:
+def is_symbolic(a: object) -> TypeGuard[torch.SymInt | torch.Tensor]:
     return isinstance(a, torch.SymInt) or (
         isinstance(a, torch.Tensor) and a._has_symbolic_sizes_strides
     )
 
 
-def any_is_symbolic(*args: Any) -> bool:
+def any_is_symbolic(*args: object) -> bool:
     return any(is_symbolic(a) for a in args)
 
 
@@ -3134,11 +3134,11 @@ def is_windows() -> bool:
     return sys.platform == "win32"
 
 
-def has_free_symbols(itr: Iterable[Any]) -> bool:
+def has_free_symbols(itr: Iterable[object]) -> bool:
     return any(isinstance(x, sympy.Expr) and not x.is_number for x in itr)
 
 
-def is_dynamic(*args: Any) -> bool:
+def is_dynamic(*args: object) -> bool:
     from . import ir
 
     for t in args:


### PR DESCRIPTION
40 `Any` annotations across 11 inductor files, on functions whose bodies only
classify the value they are handed: `isinstance`, `getattr`-with-default,
`type()`, identity (`is`), `in`, `str()`/f-string, or nothing at all. `object`
is the honest description of that contract, and unlike `Any` it makes the
checker verify the classification logic inside the body.

To be precise about what this buys, since it is easy to overstate: for a
*parameter*, `object` and `Any` accept exactly the same arguments, so nothing
changes for callers and no call site can break. The gain is entirely inside
each body -- the narrowing chain after each `isinstance` is now checked rather
than skipped. It also stops these signatures from silently laundering `Any`
into the rest of the file when someone later widens a body.

Review order, cheapest to most interesting:

The bulk is mechanical and reads in one pass: `utils.py` (`is_symbolic`,
`any_is_symbolic`, `is_dynamic`, `has_free_symbols`), `lowering.py`
(`is_integer_type`, `is_boolean_type`), `codecache.py` (the
`FxGraphHashDetails` recursion helpers plus the three custom-pass/device-key
helpers), and the periphery one-liners in `codegen/common.py`,
`runtime/triton_helpers.py`, `runtime/static_triton_launcher.py`,
`fx_passes/joint_graph.py`, and `cudagraph_trees.py`.

One of those is not a bare `object`: `cudagraph_trees.format_inputs_log` takes
`Sequence[object]` rather than `list[object]`, because `list` is invariant and
its sole caller passes a `list[InputType]`. The body only reads (`len`, a
slice, `enumerate`), so `Sequence` is both accurate and the only spelling that
type-checks without a cast.

Then the four that are not a bare parameter swap:

`ir.py`'s `unwrap_views` is the only site where the *return* type changes too
(`Any -> object`). Leaving the return as `Any` would have made the change
pointless -- the caller immediately does `isinstance(result, Buffer)` and
returns it as `Buffer`, so `Any` in meant `Any` out meant an unchecked return.
With `object` the existing `if not isinstance(result, Buffer): raise` narrows
it properly, and this needed no cast.

`graph.py`'s `call_module`/`call_method` do not become `object` at all. They
are `fx.Interpreter` overrides whose bodies are a bare `raise AssertionError`,
and the base class already declares the exact types (`target: Target, args:
tuple[Argument, ...], kwargs: dict[str, Any]`), so the precise annotation was
available for free and is what they get -- matching `GraphLowering.output`
just below them. Widening to `object` would have been contravariantly sound
but strictly less informative. They also pick up `@typing_extensions.override`
(which `placeholder`, `call_function`, and `output` in this class already
carry), so the override relationship is enforced by the checker on every run
rather than confirmed once by hand.

`cudagraph_trees.py`'s `get_obj` likewise does not become `object`, even
though its body is `hasattr`/`getattr`. It also calls `_initialize_tls(local)`,
which is already annotated `(local: threading.local)`, so `object` would have
required a cast to buy nothing. All six call sites -- `cudagraph_trees.py:370`,
`:371`, `:396`, `:397`, `:417` and `test/inductor/test_cudagraph_trees.py:156`
-- pass the module-level `local = threading.local()`. This is the only
*narrowing* in the PR and therefore the only change that could in principle
reject a caller, hence the exhaustive enumeration.

`utils.py`'s `precompute_method`/`precompute_methods` and
`runtime/runtime_utils.py`'s `get_first_attr` are the honest exception to the
"the gain is checking inside the body" claim above: they reflect over the
object (`getattr(obj, name)()`, `setattr`) with a name that is a runtime
`str`, so `getattr` yields `Any` and `setattr` accepts anything whether the
parameter is `Any` or `object`. No narrowing chain becomes checked. They are
included because `object` is still the accurate contract -- these genuinely do
accept any object -- not because they gain verification.

Two things intentionally left out. `graph.py:837 is_grouped` looks like it
belongs to this cluster but is not a classifier: it does unguarded
`n.args[...]` behind two `# type: ignore[union-attr, operator]`s, and its
sibling `is_in_out_channel` is already `torch.fx.Node`, so it wants that
precise type rather than `object` -- a separate change. And
`runtime/triton_helpers.py` is in `pyrefly.toml`'s `project-excludes`, so its
one line is an annotation improvement the type checker does not currently
verify; it is included for consistency with the rest of the cluster and was
checked by inspection (the body is pure `isinstance` plus recursion over
narrowed `tuple`/`list`/`dict`).

Test Plan:

Type checking is the entire behavioral surface here, so the check that matters
is that the CI type checker reports nothing new. Baseline (at the merge base)
and post-change runs both report 70 errors and 10,964 suppressed, with
byte-identical sorted error lists -- no new errors and no new suppressions,
i.e. this needed zero casts and zero `pyrefly: ignore` comments. In particular
no `bad-override` for the two newly-`@override`-decorated methods:

```
pyrefly check --config=pyrefly.toml --output-format=min-text | sort
```

An empty diff can also mean the checker never looked, so that run was
validated by injecting a deliberate `hook.__probe_bogus_attr__` into the
`hook: object` body in `static_triton_launcher.py` and confirming pyrefly
flags it, then reverting:

```
ERROR torch/_inductor/runtime/static_triton_launcher.py:94:13-38: Object of
class `object` has no attribute `__probe_bogus_attr__` [missing-attribute]
```

Lint is clean on the touched files:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a \
  torch/_inductor/utils.py \
  torch/_inductor/lowering.py \
  torch/_inductor/codecache.py \
  torch/_inductor/ir.py \
  torch/_inductor/graph.py \
  torch/_inductor/codegen/common.py \
  torch/_inductor/runtime/triton_helpers.py \
  torch/_inductor/runtime/static_triton_launcher.py \
  torch/_inductor/runtime/runtime_utils.py \
  torch/_inductor/fx_passes/joint_graph.py \
  torch/_inductor/cudagraph_trees.py
```

Eight of the eleven files carry `from __future__ import annotations`, so their
annotations are never evaluated at all -- they are stored in
`__annotations__` as strings. The three that lack it
(`runtime/triton_helpers.py`, `runtime/static_triton_launcher.py`,
`fx_passes/joint_graph.py`) evaluate eagerly, but each only gained a bare
`object`, which is a builtin. `Sequence` in `cudagraph_trees.py` is a
`TYPE_CHECKING`-only import, which is fine precisely because that file
stringizes. So the one edit with any runtime surface at all is the pair of
`@typing_extensions.override` decorators, which only set `__override__` on the
function object. Verified the modules still byte-compile:

```
python -m py_compile torch/_inductor/*.py torch/_inductor/runtime/*.py
```

This checkout is not built, so the suites covering this code
(`test/inductor/test_torchinductor.py`, `test/inductor/test_codecache.py`,
`test/inductor/test_cudagraph_trees.py`) are left to CI; `ciflow/trunk` is
applied.

This PR was authored with the assistance of an AI coding assistant.



cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo