### PR TITLE
inductor: alias "NVIDIA H100 80GB HBM3" to the H100 datasheet entry

### DIFF
--- a/test/inductor/test_analysis.py
+++ b/test/inductor/test_analysis.py
@@ -282,6 +282,13 @@ class TestUtils(TestCase):
         self.assertEqual(lookup_device_info("AMD Instinct MI300X"), upper)
         self.assertEqual(lookup_device_info("amd instinct mi300x"), upper)
 
+    def test_lookup_device_info_h100_sxm_reported_name(self):
+        # torch.cuda.get_device_name() reports the SXM part as
+        # "NVIDIA H100 80GB HBM3", which the "NVIDIA H100" entry describes.
+        h100 = lookup_device_info("NVIDIA H100")
+        self.assertIsNotNone(h100)
+        self.assertEqual(lookup_device_info("NVIDIA H100 80GB HBM3"), h100)
+
 
 def has_supported_gpu():
     """Check if any GPU platform with Triton support is available."""

--- a/torch/_inductor/analysis/device_info.py
+++ b/torch/_inductor/analysis/device_info.py
@@ -247,6 +247,10 @@ _device_mapping: dict[str, DeviceInfo] = {
         dram_gb=48,
     ),
 }
+# The SXM part reports itself as "NVIDIA H100 80GB HBM3", which does not match
+# the key above; the entry already carries that part's datasheet numbers
+# (80 GB, 3350 GB/s), so alias it rather than duplicating them.
+_device_mapping["NVIDIA H100 80GB HBM3"] = _device_mapping["NVIDIA H100"]
 _device_mapping["AMD INSTINCT MI350X"] = _device_mapping["AMD MI350X"]
 _device_mapping["AMD INSTINCT MI300X"] = _device_mapping["AMD MI300X"]
 _device_mapping["AMD INSTINCT MI210X"] = _device_mapping["AMD MI210X"]


### PR DESCRIPTION
Summary:
`lookup_device_info()` does an exact dict lookup on `torch.cuda.get_device_name()`
after upper-casing it. `_device_mapping` has a single Hopper key, `NVIDIA H100`,
but the SXM part reports itself as `NVIDIA H100 80GB HBM3`. Those hosts miss the
table, so `get_gpu_dram_gbps()` and `get_device_tflops()` in
`torch/_inductor/utils.py` silently fall back to the Triton estimate, and the
cost model then produces a different schedule.

This is visible in production AOTInductor lowering. For one ads ranking model,
holding the input, the package and the RE pool fixed, a worker reporting
`NVIDIA H100 80GB HBM3` emitted a plan with 124 `empty_strided` allocations and
89 `triton_tem_` kernels, while a worker reporting `NVIDIA H100` emitted 65 and
94 -- the latter matching the published artifact. The divergence tracked the
host rather than the binary, and cost roughly 8% latency on the affected model.

The existing entry already carries the SXM part's datasheet numbers (80 GB,
3350 GB/s), so this aliases the reported name onto it instead of duplicating
them, following the existing `AMD INSTINCT ...` and `Intel(R) Arc(TM) ...`
aliases. It is placed before the upper-casing normalization so the new key is
normalized along with the rest of the table.

`NVIDIA GH200 480GB` is missing from the table for the same reason, but every
SM90_ARM lowering misses it uniformly, so there is no A/B showing harm there;
left for a follow-up.

Test Plan:
```
buck test fbcode//caffe2/test/inductor:analysis -- TestUtils
```

End-to-end, on the model above: an ephemeral `ien.lower` package built from this
change plus `6d12e83f6303` (the revision `ien.lower:669` was built from, so the
alias is the only delta) was run through `test_run_client` on the
`gpu-remote-execution` pool with cold caches (`save_remote_cache=false`, a fresh
`TORCHINDUCTOR_CACHE_DIR`). It landed on a worker reporting
`NVIDIA H100 80GB HBM3` and produced 65 `empty_strided` allocations, down from
124 for the unmodified package on the same pool and same reported device.

Written with the help of an AI assistant.

Differential Revision: D116831366




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo