### PR TITLE
Fix gelu returning NaN for infinite inputs on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationGeluKernel.cu
@@ -25,9 +25,13 @@ void GeluCUDAKernelImpl(TensorIteratorBase& it, GeluType approximate) {
         using opmath_t = at::opmath_type<scalar_t>;
         constexpr opmath_t kBeta = M_SQRT2 * M_2_SQRTPI * opmath_t(0.5);
         constexpr opmath_t kKappa = 0.044715;
-        auto x_cube = static_cast<opmath_t>(x) * static_cast<opmath_t>(x) * static_cast<opmath_t>(x);
-        auto inner = kBeta * (static_cast<opmath_t>(x) + kKappa * x_cube);
-        return opmath_t(0.5) * static_cast<opmath_t>(x) * (opmath_t(1) + c10::cuda::compat::tanh(inner));
+        auto x_float = static_cast<opmath_t>(x);
+        if (::isinf(x_float)) {
+          return x_float > opmath_t(0) ? x : scalar_t(0);
+        }
+        auto x_cube = x_float * x_float * x_float;
+        auto inner = kBeta * (x_float + kKappa * x_cube);
+        return opmath_t(0.5) * x_float * (opmath_t(1) + c10::cuda::compat::tanh(inner));
       });
     });
   } else {
@@ -35,7 +39,11 @@ void GeluCUDAKernelImpl(TensorIteratorBase& it, GeluType approximate) {
       gpu_kernel(it, [] GPU_LAMBDA(scalar_t x) -> scalar_t {
         using opmath_t = at::opmath_type<scalar_t>;
         constexpr opmath_t kAlpha = M_SQRT1_2;
-        return static_cast<opmath_t>(x) * opmath_t(0.5) * (opmath_t(1) + ::erf(static_cast<opmath_t>(x) * kAlpha));
+        auto x_float = static_cast<opmath_t>(x);
+        if (::isinf(x_float)) {
+          return x_float > opmath_t(0) ? x : scalar_t(0);
+        }
+        return x_float * opmath_t(0.5) * (opmath_t(1) + ::erf(x_float * kAlpha));
       });
     });
   }

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7681,6 +7681,21 @@ class TestNNDeviceType(NNTestCase):
         self.assertEqual(y_cuda_ch_last, y_cuda_contig)
 
     @onlyCUDA
+    @dtypes(torch.float32, torch.float64, torch.float16, torch.bfloat16)
+    @parametrize_test("approximate", ["none", "tanh"])
+    def test_gelu_infinite_inputs(self, device, dtype, approximate):
+        # https://github.com/pytorch/pytorch/issues/185770
+        x = torch.tensor([float("inf"), -float("inf"), float("nan")],
+                         device=device, dtype=dtype)
+        out = F.gelu(x, approximate=approximate)
+        self.assertTrue(torch.isinf(out[0]) and out[0] > 0)
+        self.assertEqual(out[1].item(), 0.0)
+        self.assertTrue(torch.isnan(out[2]))
+
+        big = torch.full((1024,), -float("inf"), device=device, dtype=dtype)
+        self.assertEqual(F.gelu(big, approximate=approximate).abs().sum().item(), 0.0)
+
+    @onlyCUDA
     def test_large_reflect_pad(self, device):
         # https://github.com/pytorch/pytorch/issues/165861
         for shape in ((2**16, 2), (2**16, 1, 2)):


### PR DESCRIPTION
Fixes the CUDA half of #185770.

`F.gelu(-inf)` returns NaN on CUDA instead of 0. The kernel computes
`x * 0.5 * (1 + erf(x/sqrt(2)))`, and at `-inf` the `erf` term saturates to
-1, so the parenthesised factor is exactly 0 and the product is `-inf * 0`.
The tanh approximation has the same shape via `1 + tanh(-inf)`. `+inf` is
already correct on CUDA, unlike the CPU vectorized path.

This adds infinity guards to both branches of `GeluCUDAKernelImpl`, matching
the approach @agarg0627 used for CPU and MPS in #192318.

Verified on an RTX 4060 (sm_89), both `approximate` modes, float32/float64/
float16/bfloat16:
- `gelu(-inf)` returns 0
- `gelu(+inf)` still returns `inf`
- NaN still propagates
- finite values unchanged (max abs diff vs CPU ~5e-7, same as before)

The regression test is CUDA-only rather than in the OpInfo because CPU still
returns NaN through the oneDNN path (see the discussion in #192318). Moving
it into the OpInfo makes sense once the CPU side lands.