### PR TITLE
[DO NOT LAND] gpu-coverage probe: sm90 gate in a base-class helper, two modules away

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -96,6 +96,8 @@ nn/qat/ @jerryzh168
 
 # Custom Test Infrastructure
 /test/run_test.py @pytorch/pytorch-dev-infra
+/test/test_arch_gate_base.py @pytorch/pytorch-dev-infra
+/test/test_helper_gate_probe.py @pytorch/pytorch-dev-infra
 /torch/testing/_internal/common_device_type.py @mruberry
 /torch/testing/_internal/common_utils.py @pytorch/pytorch-dev-infra
 
@@ -1254,6 +1256,8 @@ torch/backends/cudnn/ @eqy @syed-ahmed @Aidyn-A
 # /test/scripts/
 # /test/spincli/
 # /test/strobelight/
+# /test/test_arch_gate_base.py
+# /test/test_helper_gate_probe.py
 # /test/test_public_bindings.py
 # /test/test_testing.py
 # /test/test_utils.py

--- a/test/test_arch_gate_base.py
+++ b/test/test_arch_gate_base.py
@@ -1,0 +1,15 @@
+# Owner(s): ["module: ci"]
+from torch.testing._internal.common_cuda import SM90OrLater
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+class ArchGatedBase(TestCase):
+    """Shared base whose helper carries the gate, in a different module."""
+
+    def _require_sm90(self):
+        if not SM90OrLater:
+            self.skipTest("needs sm90")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_helper_gate_probe.py
+++ b/test/test_helper_gate_probe.py
@@ -1,0 +1,17 @@
+# Owner(s): ["module: ci"]
+from test_arch_gate_base import ArchGatedBase
+
+from torch.testing._internal.common_utils import run_tests
+
+
+class TestHelperGate(ArchGatedBase):
+    def setUp(self):
+        super().setUp()
+        self._require_sm90()
+
+    def test_gated_via_base_class_helper(self):
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

The hardest shape for the check to see. The gate is neither in `setUp`'s body nor in
the same class:

```
TestHelperGate.setUp  ->  self._require_sm90()      # inherited
ArchGatedBase._require_sm90  ->  if not SM90OrLater: self.skipTest(...)   # another file
```

`setUp` is gutted, so the skip never fires and the test records as running at every
capability. A single-file syntax scan finds nothing, and this used to report clean
with no warning at all.

Expected: `TestHelperGate::setUp` named as unclassifiable. Locally:

```
test/test_helper_gate_probe.py::TestHelperGate::setUp not classified
    why:  its skip is inside setUp or the test body, which is not run here
```

The check now resolves gates through the imported class rather than the file's
syntax tree, so `getattr` finds the helper wherever Python would, and self-calls are
followed transitively. What stays out of reach: dynamic dispatch
(`getattr(self, name)()`), and a gate in a module-level function rather than a
method.