### PR TITLE
[DO NOT LAND] gpu-coverage probe: smoke list names a test file that does not exist

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -440,7 +440,7 @@ test_python_smoke() {
   # Smoke tests for H100/B200
   install_nvmath
   time python test/run_test.py --include inductor/test_flex_attention -k test_tma_with_customer_kernel_options $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
-  time python test/run_test.py --include test_matmul_cuda test_scaled_matmul_cuda inductor/test_fp8 inductor/test_max_autotune inductor/test_cutedsl_grouped_mm $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time python test/run_test.py --include test_matmul_cuda test_removed_last_year test_scaled_matmul_cuda inductor/test_fp8 inductor/test_max_autotune inductor/test_cutedsl_grouped_mm $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_foreach -k TestForeachMM $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   time python test/run_test.py --include test_linalg -k polar $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty


### PR DESCRIPTION
Scratch PR exercising the `gpu-coverage` job. Not for landing.

`run_test.py` ignores an `--include` naming a file that is not there, so an entry
left behind by a deleted test selects nothing and nothing complains. This adds one
directly.

Expected: a stale-entry warning naming `test_removed_last_year`. Locally:

```
live: 17 | stale: ['test_removed_last_year']
```

Adding the check that catches this surfaced a parsing bug it had been hiding: the
trailing `$PYTHON_TEST_EXTRA_OPTION` on each `run_test.py` line was being read as an
`--include` argument, and only went unnoticed because it never resolved to a file.
With that fixed the smoke set is 17 live files and no stale entries on a clean
tree.