### PR TITLE
Fix leaked mkstemp fd in elastic rendezvous _create_file_store

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,10 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            # FileStore opens the path itself; close our copy of the
+            # descriptor so it is not leaked.
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
## Summary

Fixes #191394

`_create_file_store` in `torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py` uses `tempfile.mkstemp()` to create the temporary shared file when no rendezvous endpoint is given. `mkstemp` returns an open file descriptor, but `FileStore` opens the path itself, so the descriptor returned by `mkstemp` was never closed and was leaked for the lifetime of the process (one leaked fd per rendezvous without a user-specified endpoint).

## Changes

- Keep the fd returned by `tempfile.mkstemp` and close it immediately with `os.close(...)`.

No behavior change: `FileStore` opens the path by name and the file itself still exists for the store to use.

## Test plan

```python
python -c "import torch.distributed.elastic.rendezvous.c10d_rendezvous_backend"
```

Existing behavior is covered by the distributed elastic rendezvous tests; this is a leak-only fix with no functional change.