### PR TITLE
[ROCm] Include the hipified generator header in RNN_miopen.cpp

### DIFF
--- a/aten/src/ATen/native/miopen/RNN_miopen.cpp
+++ b/aten/src/ATen/native/miopen/RNN_miopen.cpp
@@ -7,7 +7,6 @@
 #include <ATen/TensorUtils.h>
 
 #include <ATen/cuda/CUDAConfig.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 
@@ -58,6 +57,8 @@ namespace at::native {
 #include <ATen/miopen/Descriptors.h>
 #include <ATen/miopen/Types.h>
 #include <ATen/miopen/Utils.h>
+
+#include <ATen/hip/HIPGeneratorImpl.h>
 
 #include <ATen/TensorUtils.h>
 


### PR DESCRIPTION
## Fix MIOpen RNN build: use the hipified generator header

Follow-up to #189285, which added `#include <ATen/cuda/CUDAGeneratorImpl.h>` to `aten/src/ATen/native/miopen/RNN_miopen.cpp`. Files under `native/miopen/` aren't hipified (they're not in the `includes` list in `tools/amd_build/build_amd.py`), so they must spell ATen headers with their hipified names. Where only the hipified headers are available, the CUDA-spelled path fails to resolve:

```
fatal error: 'ATen/cuda/CUDAGeneratorImpl.h' file not found
```

Switched to `<ATen/hip/HIPGeneratorImpl.h>`, matching the `c10/hip/*` includes the same PR added right below it, and moved it into the `AT_ROCM_ENABLED()` branch since non-ROCm builds don't need it. Hipify renames files, not identifiers, so no call sites change. No functional change.

### Test Plan:

Built ATen for ROCm and confirmed it compiles with this change.

Differential Revision: D116840188




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang