### PR TITLE
[ac_budget_override] Resolve per-module AC budget by module id, not annotation

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3450,6 +3450,49 @@ class AOTAutogradCacheTests(CacheKeyEquivalenceMixin, InductorTestCase):
     @inductor_config.patch("fx_graph_remote_cache", False)
     @inductor_config.patch("fx_graph_cache", True)
     @functorch_config.patch({"enable_autograd_cache": True})
+    def test_module_activation_memory_budget_causes_cache_miss(self):
+        """Changing a per-module budget invalidates the AOTAutograd cache, while
+        the process-local id() keys it is stored under do not."""
+
+        class Mod(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(10, 10)
+
+            def forward(self, x):
+                return self.lin(x).relu()
+
+        def run(budget):
+            mod = Mod()
+            by_module_id = {id(m): budget for m in mod.modules()}
+            with functorch_config.patch(
+                activation_memory_budget_by_module_id=by_module_id
+            ):
+                compiled_fn = torch.compile(mod, backend="inductor")
+                compiled_fn(torch.randn(10, 10, requires_grad=True)).sum().backward()
+
+        with fresh_cache():
+            run(0.3)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 0)
+
+            self._clear_dynamo_and_codecache()
+
+            # A fresh module gives every id() a new value while the budget is
+            # unchanged, so the key must not move.
+            run(0.3)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 1)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+            self._clear_dynamo_and_codecache()
+
+            run(0.8)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_miss"], 2)
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_hit"], 1)
+
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @functorch_config.patch({"enable_autograd_cache": True})
     def test_region_activation_memory_budget_graph_break_cache(self):
         """With graph breaks, changing one graph's budget causes a miss for
         that graph but a hit for the unchanged graph."""

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7359,6 +7359,161 @@ def forward(self, primals_1, tangents_1):
         # so the producer op does not appear in the backward graph.
         self.assertNotIn("topk", bw_graph["gm"].code)
 
+    @staticmethod
+    def _isolate_with_graph_breaks(module):
+        orig_forward = module.forward
+
+        def wrapped_forward(*args, **kwargs):
+            torch._dynamo.graph_break()
+            out = orig_forward(*args, **kwargs)
+            torch._dynamo.graph_break()
+            return out
+
+        module.forward = wrapped_forward
+
+    @staticmethod
+    def _three_leaf_model(break_in_target):
+        class Leaf(torch.nn.Module):
+            def __init__(self, brk):
+                super().__init__()
+                self.brk = brk
+                self.a = torch.nn.Linear(16, 16)
+                self.b = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                x = self.a(x).relu()
+                if self.brk:
+                    torch._dynamo.graph_break()
+                return self.b(x).relu()
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pre = Leaf(False)
+                self.target = Leaf(break_in_target)
+                self.post = Leaf(False)
+
+            def forward(self, x):
+                return self.post(self.target(self.pre(x))).sum()
+
+        return Model()
+
+    def _graph_budgets(self, model, by_module_id):
+        """Memory budget the partitioner chose for each joint graph, in order."""
+        import torch._functorch.config as functorch_config
+        import torch._functorch.partitioners as partitioners
+        from torch._dynamo.backends.common import aot_autograd
+
+        used = []
+        orig_choose = partitioners.choose_saved_values_set
+
+        def spy(joint_graph, node_info, memory_budget=1):
+            used.append(memory_budget)
+            return orig_choose(joint_graph, node_info, memory_budget=memory_budget)
+
+        backend = aot_autograd(
+            fw_compiler=lambda gm, _: gm.forward,
+            bw_compiler=lambda gm, _: gm.forward,
+            partition_fn=min_cut_rematerialization_partition,
+        )
+
+        torch._dynamo.reset()
+        partitioners.choose_saved_values_set = spy
+        try:
+            with functorch_config.patch(
+                activation_memory_budget=0.1,
+                activation_memory_budget_by_module_id=by_module_id,
+            ):
+                model_c = torch.compile(model, backend=backend)
+                model_c(torch.randn(16, 16, requires_grad=True)).backward()
+        finally:
+            partitioners.choose_saved_values_set = orig_choose
+        return used
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_module_memory_budget_survives_internal_graph_break(self):
+        model = self._three_leaf_model(break_in_target=True)
+        # A graph break makes the module's forward its own frame, which drops the
+        # module itself out of nn_module_stack and leaves only its children, so
+        # the whole subtree has to be registered.
+        by_module_id = {id(m): 0.55 for m in model.target.modules()}
+        self._isolate_with_graph_breaks(model.target)
+
+        budgets = self._graph_budgets(model, by_module_id)
+
+        # Both graphs the module was split into carry its budget; the surrounding
+        # modules keep the global one.
+        self.assertEqual(sorted(budgets), [0.1, 0.1, 0.55, 0.55])
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_module_memory_budget_disabled_by_default(self):
+        model = self._three_leaf_model(break_in_target=True)
+        self._isolate_with_graph_breaks(model.target)
+
+        budgets = self._graph_budgets(model, {})
+
+        self.assertEqual(set(budgets), {0.1})
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_module_memory_budget_falls_back_when_graph_spans_modules(self):
+        # Not isolated, so a single graph covers all three leaves. No one module
+        # owns it and the global budget must win.
+        model = self._three_leaf_model(break_in_target=False)
+        by_module_id = {id(m): 0.55 for m in model.target.modules()}
+
+        budgets = self._graph_budgets(model, by_module_id)
+
+        self.assertEqual(set(budgets), {0.1})
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_module_memory_budget_falls_back_on_conflicting_budgets(self):
+        # Every leaf is configured, at a different budget, and none is isolated,
+        # so one graph carries several budgets at once. The partitioner applies a
+        # single budget per graph, so there is no honest choice but the global.
+        model = self._three_leaf_model(break_in_target=False)
+        by_module_id = {}
+        for leaf, budget in ((model.pre, 0.2), (model.target, 0.55), (model.post, 0.8)):
+            by_module_id.update({id(m): budget for m in leaf.modules()})
+
+        budgets = self._graph_budgets(model, by_module_id)
+
+        self.assertEqual(set(budgets), {0.1})
+
+    @unittest.skipIf(not USE_NETWORKX, "networkx not available")
+    def test_module_memory_budget_deepest_module_wins(self):
+        class Child(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = torch.nn.Linear(16, 16)
+
+            def forward(self, x):
+                return self.lin(x).relu().sum()
+
+        class Parent(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.child = Child()
+
+            def forward(self, x):
+                return self.child(x)
+
+        class Root(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.parent = Parent()
+
+            def forward(self, x):
+                return self.parent(x)
+
+        model = Root()
+        # Every op is enclosed by both, so the budget on the deeper module wins.
+        by_module_id = {id(model.parent): 0.5}
+        by_module_id.update({id(m): 0.25 for m in model.parent.child.modules()})
+
+        budgets = self._graph_budgets(model, by_module_id)
+
+        self.assertEqual(set(budgets), {0.25})
+
     def test_disable_functionalization_ignores_effect_token_metadata(self):
         def fn(args):
             (x,) = args

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -533,6 +533,17 @@ class AOTAutogradCacheDetails(FxGraphHashDetails):
             else None
         )
 
+        # activation_memory_budget_by_module_id is in _save_config_ignore, so the
+        # saved config cannot invalidate the cache when a budget changes. Record
+        # the budget values rather than the id() keys, which are process-local and
+        # would miss on every run, and only once the feature is in use so that a
+        # default config leaves the key untouched.
+        module_budgets = tuple(
+            sorted(set(config.activation_memory_budget_by_module_id.values()))
+        )
+        if module_budgets:
+            self.module_activation_memory_budgets: tuple[float, ...] = module_budgets
+
         # Note: We use the live config module, not self.autograd_config (the
         # saved config), because activation_memory_budget_runtime_estimator and
         # activation_memory_budget_solver are excluded from save_config (in

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -25,6 +25,8 @@ _save_config_ignore = [
     # callable configs with uuid() for caching, or raw callables
     "activation_memory_budget_runtime_estimator",
     "activation_memory_budget_solver",
+    # process-local id() keys; serializing them would only poison cache keys
+    "activation_memory_budget_by_module_id",
 ]
 
 
@@ -200,6 +202,29 @@ remat_using_tags_for_fwd_loss_bwd_graph = True
 # the activation memory budget.
 # NOTE: This *cannot* be treated as
 activation_memory_budget = 1.0
+
+# Per-module activation memory budgets, keyed by id() of the nn.Module.
+#
+# A joint graph whose forward lies wholly inside one configured module uses that
+# module's budget instead of activation_memory_budget; every other graph is
+# untouched. Empty (the default) disables the feature entirely.
+#
+# Keyed by id() rather than FQN because that is what survives: node.meta
+# ["nn_module_stack"] maps id(module) -> (source_expression, type), and the
+# source expression degrades to a stack temporary ("L['___stack0']") in frames
+# Dynamo resumes after a graph break, while the id stays exact.
+#
+# Register the target's whole subtree, e.g.
+# {id(sub): 0.5 for sub in target.modules()}, not just the target. Dynamo only
+# records a module in nn_module_stack when it is entered through
+# Module.__call__, so once a graph break turns a module's forward into its own
+# compilation unit the module itself disappears from the stack and only its
+# children remain -- registering just the target would resolve nothing on
+# exactly the graphs this is meant for. Ops written directly in that frame's
+# body carry no nn_module_stack at all and simply follow the rest of the graph.
+#
+# Process-local and meaningless to serialize, hence _save_config_ignore below.
+activation_memory_budget_by_module_id: dict[int, float] = {}
 
 # This controls how we estimate the runtime when deciding what the cheapest
 # operators to recompute are. The 3 options are

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -4140,6 +4140,95 @@ def classify_nodes(
     )
 
 
+def _budget_from_module_config(node: fx.Node) -> float | None:
+    """Budget configured for the innermost module this node came from, if any.
+
+    node.meta["nn_module_stack"] maps id(module) -> (source_expression, type)
+    for every module enclosing the node. Matching on the id keeps this correct
+    in frames Dynamo resumed after a graph break, where the source expression
+    has decayed to a stack temporary.
+    """
+    stack = node.meta.get("nn_module_stack")
+    if not stack:
+        return None
+    by_id = config.activation_memory_budget_by_module_id
+    best_budget: float | None = None
+    best_depth = -1
+    for module_id, entry in stack.items():
+        # Dynamo stores the key as str(id(module)); accept an int-keyed config
+        # too, since that is the natural way to build one from live modules.
+        key = (
+            int(module_id)
+            if isinstance(module_id, str) and module_id.isdigit()
+            else module_id
+        )
+        budget = by_id.get(key, by_id.get(module_id))
+        if budget is None:
+            continue
+        # Deeper module wins, so a budget on a child overrides one on its
+        # parent. Depth is the nesting of the recorded source expression.
+        source = entry[0] if isinstance(entry, (tuple, list)) else ""
+        depth = source.count(".") if isinstance(source, str) else 0
+        if depth > best_depth:
+            best_budget, best_depth = float(budget), depth
+    return best_budget
+
+
+def _resolve_module_memory_budget(
+    joint_graph: fx.Graph, node_info: "NodeInfo", default: float
+) -> float:
+    """Resolve config.activation_memory_budget_by_module_id for this joint graph.
+
+    The partitioner applies one budget per graph, so a configured budget is used
+    only when the graph's whole forward lies inside a single configured module.
+    A graph that straddles a module boundary keeps the default and says so,
+    rather than applying a budget to ops it was not meant for.
+
+    Only ops that carry an nn_module_stack can vote. Ops written directly in the
+    body of the frame Dynamo is compiling have no nn_module_stack at all --
+    Dynamo records a module only when it is entered through Module.__call__, and
+    a frame that a graph break turned into its own compilation unit was not.
+    Those ops therefore can never match anything, and counting them as being
+    outside the module would make this unsatisfiable for precisely the graphs
+    the feature exists to serve. They stay with whatever the rest of the graph
+    resolves to.
+    """
+    budgets: OrderedSet[float] = OrderedSet()
+    outside = 0
+    for node in joint_graph.nodes:
+        if node.op != "call_function" or not node_info.is_required_fw(node):
+            continue
+        if not node.meta.get("nn_module_stack"):
+            continue
+        budget = _budget_from_module_config(node)
+        if budget is None:
+            outside += 1
+        else:
+            budgets.add(budget)
+
+    if not budgets:
+        return default
+    if len(budgets) > 1 or outside:
+        log.warning(
+            "activation_memory_budget_by_module_id: graph spans more than one "
+            "budget (budgets=%s, %d forward op(s) outside any configured "
+            "module), so the global budget %s is used for it. Isolate the "
+            "module into its own graph to have its budget applied.",
+            sorted(budgets),
+            outside,
+            default,
+        )
+        return default
+    resolved = next(iter(budgets))
+    log.info(
+        "activation_memory_budget_by_module_id: using %s for this graph instead "
+        "of the global budget %s.",
+        resolved,
+        default,
+    )
+    return resolved
+
+
 def min_cut_rematerialization_partition(
     joint_module: fx.GraphModule,
     _joint_inputs: Any,
@@ -4309,6 +4398,13 @@ def min_cut_rematerialization_partition(
                 f"Unannotated ops: {[n.name for n in unannotated_fw_ops]}."
             )
         memory_budget = next(iter(all_budgets))
+    elif config.activation_memory_budget_by_module_id:
+        # 4. Per-module budgets keyed by FQN. Resolved from nn_module_stack, so
+        #    it is unaffected by where Dynamo cut frames. Only consulted when no
+        #    region annotation applies, so the two never fight.
+        memory_budget = _resolve_module_memory_budget(
+            joint_graph, node_info, memory_budget
+        )
     saved_values = choose_saved_values_set(
         joint_graph,
         node_info,


### PR DESCRIPTION
Summary:
Applies an `ac_budget_override_config` per-module activation memory budget to
*every* graph a module is split into, instead of failing compilation when the
module contains an internal graph break.

## Problem

The previous implementation wrapped each targeted module's forward in
`torch.autograd.graph.region_activation_memory_budget(budget)`. That annotation
must cover the entire forward of a joint graph, so a graph break inside the
module left part of the forward unannotated and the partitioner raised:

    RuntimeError: ... must cover the entire forward of a graph ...
    6103 forward op(s) are unannotated

The annotation is carried on `node.meta["custom"]`, which only exists on nodes
traced inside the context manager. A graph break splits the forward across
frames, so the resumed frame's nodes have no annotation at all.

## Change

Drop the annotation entirely and resolve the budget from module identity, which
survives graph breaks. `apply_ac_budget_by_module_path` now publishes
`{id(module): budget}` into `torch._functorch.config.
activation_memory_budget_by_module_id`, added by the PyTorch diff below this one
in the stack, and the AOT partitioner resolves one budget per joint graph.

Details:

- The whole subtree of a matched module is registered, not just the module
  itself. Dynamo records a module in `nn_module_stack` only when it is entered
  through `Module.__call__`; once a graph break turns a module's forward into
  its own compilation unit the module drops out of the stack and only its
  children remain, so registering just the target would resolve nothing on
  exactly the graphs this feature exists for.
- Path matching accepts an exact match or a dot-boundary suffix match, since a
  distributed wrapper can prepend to the path the user configured. A path that
  matches nothing is reported as a warning here, against the live model, rather
  than silently doing nothing at compile time.
- `wrap_module_with_memory_budget` is replaced by
  `isolate_module_with_graph_breaks`, which emits a graph break on each side of
  the module's forward. It no longer carries the budget, so the
  `assume_constant_result` / `SymFloat` workaround and the
  `is_compiling()` eager-path guard are both gone.

Also adds the `isolate_with_graph_break` field to `ACBudgetOverrideConfig`. The
partitioner applies one budget per joint graph, so a budget only takes effect on
a graph whose forward lies wholly inside the target module; isolating guarantees
that. Without it the budget applies only when the model happens to be cut that
way already, and is otherwise ignored with a warning.

## Impact

- No behavior change when `module_path_to_budget` is empty: nothing is published
  and every graph keeps the global `activation_memory_budget`.
- Scoped to modules named in `ac_budget_override_config`; no Dynamo change and
  no dependency on `nested_graph_breaks`.
- Since this path no longer calls `region_activation_memory_budget`, the
  "must cover the entire forward" error is structurally unreachable from it.

Test Plan:
End-to-end on MAST -- job `aps-yuqi-648e46ad7d`, OmniFM v5, 8 trainers, global
`activation_memory_budget: 0.1`, with two modules overridden to values *below*
the global so the partitioner runs its knapsack and records the budget in the
`min_cut_information` artifact:

    seq_interaction_layer    0.01   (contains an internal graph break)
    seq_summarization_layer  0.02   (no internal break)

Budget distribution across the 18 partitioned graphs, from tlparse:

    {0.01: 1, 0.02: 3, 0.1: 14}

    -_21_0_0   budget=0.01   torch_dynamo_resume_in_forward_at_1733
    -_19_1_1   budget=0.02   torch_dynamo_resume_in_wrapped_forward_at_193
    -_19_3_1   budget=0.02   torch_dynamo_resume_in_wrapped_forward_at_193
    -_19_5_1   budget=0.02   torch_dynamo_resume_in_wrapped_forward_at_193
    (14 further regions at the global 0.1)

`-_21_0_0` is the resume frame *after the internal graph break inside*
`seq_interaction_layer` -- the graph that previously raised the coverage error --
and it carries the module's budget. `seq_summarization_layer` is split across
three graphs, all three of which carry its budget, demonstrating the
one-module-many-graphs case directly. No `graph spans more than one budget`
fallback warnings and no unmatched module paths were logged.

Note the budgets are deliberately below the global: `choose_saved_values_set`
early-returns without running the knapsack when a budget is already satisfied,
and that path writes no `min_cut_information`, so a budget above the global is
not observable in tlparse.

APS unit tests -- `buck2 test fbcode//mode/dev
fbcode//aps_models/ads/common/utils/tests:apply_full_model_compilation_test`
=> Pass 12, Fail 0. Covers subtree publication, id keying, float coercion,
multiple paths, isolation scope, output equality, and the not-found warning.

Type checking -- `buck2 test fbcode//mode/dev` on
`fbcode//aps_models/ads/common/utils:apply_full_model_compilation-type-checking`,
`fbcode//apf/core:configs-type-checking` and
`fbcode//aps_models/ads/common/utils/tests:apply_full_model_compilation_test-library-type-checking`
=> Pass 3, Fail 0.

Partitioner-side unit tests and the AOTAutograd cache-key tests live on the
PyTorch diff below this one in the stack.

Lint -- `arc f` clean, `arc lint` 0 errors on all changed files. Documenting
`module_path_to_budget` and `isolate_with_graph_break` in the class docstring
also cleared two pre-existing `AllDataclassesHaveClearDocstrings` warnings.

Differential Revision: D116744717




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98