### PR TITLE
[fc_quantization] Fix the problematic weights deletion (#194292)

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -1792,6 +1792,77 @@ class TestQuantizeFx(QuantizationTestCase):
                     m = convert_fn(m)
                     self.checkGraphModuleNodes(m, expected_node_occurrence=node_occurrence)
 
+    @skipIfNoFBGEMM
+    def test_fold_weight_preserves_external_weight_users(self):
+        """fold_weight keeps a weight get_attr alive when a non-prepack user
+        (here x.to(self.weight.dtype)) still consumes it.
+        """
+        with override_quantized_engine('fbgemm'):
+            class Linear(torch.nn.Module):
+                def __init__(self) -> None:
+                    super().__init__()
+                    self.weight = torch.nn.Parameter(torch.rand(10, 5))
+
+                def forward(self, x):
+                    return F.linear(x.to(self.weight.dtype), self.weight)
+
+            inputs = (torch.rand(8, 5, dtype=torch.float64),)
+            model = Linear().eval()
+            expected = model(*inputs)
+            qconfig_mapping = QConfigMapping().set_object_type(
+                F.linear, float16_dynamic_qconfig
+            )
+            prepared = prepare_fx(model, qconfig_mapping, example_inputs=inputs)
+            converted = convert_fx(prepared, keep_original_weights=True)
+
+            actual = converted(*inputs)
+            torch.testing.assert_close(actual, expected, rtol=1e-3, atol=1e-3)
+            self.checkGraphModuleNodes(
+                converted,
+                expected_node_occurrence={
+                    ns.call_function(torch.ops.quantized.linear_dynamic_fp16): 1,
+                    ns.call_function(torch.ops.quantized.linear_prepack_fp16): 0,
+                },
+            )
+            self.assertIn('weight', converted.state_dict())
+            self.assertIn('_packed_weight_0', converted.state_dict())
+
+    @skipIfNoFBGEMM
+    def test_fold_weight_removes_exclusively_used_weight(self):
+        """fold_weight still drops a weight get_attr shared by several linears
+        once every one of its users has been folded into a packed weight.
+        """
+        with override_quantized_engine('fbgemm'):
+            class Linear(torch.nn.Module):
+                def __init__(self) -> None:
+                    super().__init__()
+                    self.weight = torch.nn.Parameter(torch.rand(10, 5))
+
+                def forward(self, x):
+                    return F.linear(x, self.weight) + F.linear(x, self.weight)
+
+            inputs = (torch.rand(8, 5),)
+            model = Linear().eval()
+            qconfig_mapping = QConfigMapping().set_object_type(
+                F.linear, float16_dynamic_qconfig
+            )
+            prepared = prepare_fx(model, qconfig_mapping, example_inputs=inputs)
+            converted = convert_fx(prepared)
+
+            state_dict = converted.state_dict()
+            self.assertNotIn('weight', state_dict)
+            self.assertEqual(
+                2,
+                len([key for key in state_dict if key.startswith('_packed_weight_')]),
+            )
+            self.checkGraphModuleNodes(
+                converted,
+                expected_node_occurrence={
+                    ns.call_function(torch.ops.quantized.linear_dynamic_fp16): 2,
+                    ns.call_function(torch.ops.quantized.linear_prepack_fp16): 0,
+                },
+            )
+
 
 
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")

--- a/torch/ao/quantization/fx/_lower_to_native_backend.py
+++ b/torch/ao/quantization/fx/_lower_to_native_backend.py
@@ -489,6 +489,7 @@ def fold_weight(
     # remove folded nodes and replace the prepacking node with getattr
     folded_graph = Graph()
     env: dict[Any, Any] = {}
+    folded_node_copies: list[Node] = []
 
     def load_arg(a):
         return map_arg(a, lambda node: env[node.name])
@@ -522,12 +523,17 @@ def fold_weight(
                 ]
                 del original_weights_lookup[str(lookup_counter)]
                 lookup_counter += 1
-        elif prepack_node is not None:
-            # remove the fold node
-            continue
         else:
             # copy other nodes
             env[node.name] = folded_graph.node_copy(node, load_arg)
+            if prepack_node is not None:
+                folded_node_copies.append(env[node.name])
+
+    # Preserve folded producers with external users, and remove only the
+    # producer chain made dead by replacing its prepack node.
+    for node in reversed(folded_node_copies):
+        if len(node.users) == 0:
+            folded_graph.erase_node(node)
 
     quantized_model = GraphModule(quantized_model, folded_graph)
     quantized_model._register_state_dict_hook(_save_packed_weight)


### PR DESCRIPTION
Summary:

During FP16/BF16 FX FC quantization, `fold_weight` treated the complete producer chain of a linear prepack node as removable. If a producer such as a weight `get_attr` also had an external user—for example, `weight.dtype` used to cast the activation—the transform skipped that producer and later failed to rebuild the surviving branch with a `KeyError`.

Copy prepack producer candidates into the rebuilt graph, replace the prepack node with the packed-weight attribute, and then erase only candidate copies that have no remaining users. This preserves shared or externally consumed producers while retaining the existing cleanup for exclusively folded weight chains.

Add regression coverage for both an external weight metadata user and a weight shared by multiple folded linear calls.

Test Plan:
- `buck2 test fbcode//caffe2/test:quantization_fx` — Passed
- `arc lint` — Passed
- MAST `aps-StandalonePublish-27e2bf48ed` — COMPLETE on attempt 0 with BF16 FC quantization enabled for `remote_request_only`

Before the fix:
f1123217275
After the fix (together with some other changes):
https://www.internalfb.com/mlhub/pipelines/runs/mast/aps-StandalonePublish-27e2bf48ed?job_attempt=0&version=0&tab=summary

Differential Revision: D116677940
