### PR TITLE
fix-194047-resize-allocation-metadata

### DIFF
--- a/aten/src/ATen/native/Resize.cpp
+++ b/aten/src/ATen/native/Resize.cpp
@@ -15,6 +15,7 @@
 #include <ATen/ops/_resize_output_native.h>
 #endif
 
+#include <c10/util/accumulate.h>
 #include <c10/util/overflows.h>
 
 namespace at::native {
@@ -159,15 +160,7 @@ void resize_bytes_meta(StorageImpl* storage, c10::SymInt size_bytes) {
 }
 
 static void maybe_resize_storage_meta(TensorImpl* self, c10::SymInt new_size_bytes) {
-  // It does not make sense to try to resize a storage
-  // to hold 0 elements, and this can break
-  // if storage_offset is positive but
-  // new_size is 0, so just bail in that case
-  // (same comment is in Resize.h)
-  if (self->sym_numel() == 0) {
-    return;
-  }
-
+  // Caller must skip zero-numel requested shapes (see _resize_impl_).
   const Storage& storage = self->unsafe_storage();
   if (!storage) {
     TORCH_INTERNAL_ASSERT(0, "NYI, this should only be Caffe2");
@@ -199,21 +192,29 @@ static TensorImpl* _resize_impl_(
     return self;
   }
 
+  // Resize storage before updating metadata so allocation failures leave
+  // tensor metadata unchanged.
   const auto itemsize = self->dtype().itemsize();
   const auto storage_offset = self->generic_storage_offset<T>();
-  T storage_size = T(1);
+  T storage_size;
   if (stride) {
-    self->set_sizes_and_strides(size, *stride);
     storage_size = at::detail::computeStorageNbytes(
         size, *stride, itemsize, storage_offset);
   } else {
-    self->generic_set_sizes_contiguous(size);
     storage_size = at::detail::computeStorageNbytesContiguous(
         size, itemsize, storage_offset);
   }
 
-  if (resize_storage) {
+  // Same zero-numel bail as the previous maybe_resize_storage_* helpers, but
+  // based on the *requested* shape because metadata is not updated yet.
+  if (resize_storage && c10::multiply_integers(size) != 0) {
     _maybe_resize_storage(self, std::move(storage_size));
+  }
+
+  if (stride) {
+    self->set_sizes_and_strides(size, *stride);
+  } else {
+    self->generic_set_sizes_contiguous(size);
   }
 
   return self;

--- a/aten/src/ATen/native/Resize.h
+++ b/aten/src/ATen/native/Resize.h
@@ -41,16 +41,9 @@ TORCH_API void resize_bytes_cpu(StorageImpl* storage, size_t size_bytes);
 TORCH_API void resize_bytes_meta(StorageImpl* storage, c10::SymInt size_bytes);
 TORCH_API void resize_bytes_nocuda(const Storage& storage, const c10::SymInt& size_bytes);
 
+// Caller must skip zero-numel requested shapes (see _resize_impl_). Checking
+// self->numel() here is incorrect when storage is resized before metadata.
 inline void maybe_resize_storage_cpu(TensorImpl* self, size_t new_size_bytes) {
-  // It does not make sense to try to resize a storage
-  // to hold 0 elements, and this can break
-  // if storage_offset is positive but
-  // new_size is 0, so just bail in that case
-  // (same comment is in cuda/Resize.h)
-  if (self->numel() == 0) {
-    return;
-  }
-
   const Storage& storage = self->unsafe_storage();
   if (!storage) {
     auto new_storage = c10::make_intrusive<StorageImpl>(

--- a/aten/src/ATen/test/basic.cpp
+++ b/aten/src/ATen/test/basic.cpp
@@ -2,8 +2,10 @@
 
 #include <ATen/ATen.h>
 #include <ATen/core/Reduction.h>
+#include <ATen/native/Resize.h>
 #include <torch/cuda.h>
 #include <ATen/test/test_assert.h>
+#include <c10/core/CPUAllocator.h>
 #include <c10/util/irange.h>
 #include <c10/util/CallOnce.h>
 
@@ -549,4 +551,82 @@ TEST(BasicTest, TestForBlobStridesOverflow) {
   ASSERT_THROWS(
       at::for_blob(storage.data(), {2,}).strides({huge,}).options(c10::TensorOptions(kInt)).make_tensor());
 #endif
+}
+
+namespace {
+
+// Fails allocations above max_nbytes; used only by the StorageImpl under test
+// (no global SetCPUAllocator).
+struct FailLargeCPUAllocator final : at::Allocator {
+  explicit FailLargeCPUAllocator(size_t max_nbytes) : max_nbytes_(max_nbytes) {}
+
+  at::DataPtr allocate(size_t nbytes) override {
+    TORCH_CHECK(
+        nbytes <= max_nbytes_,
+        "Forced CPU allocation failure for testing");
+    return c10::GetDefaultCPUAllocator()->allocate(nbytes);
+  }
+
+  at::DeleterFnPtr raw_deleter() const override {
+    return c10::GetDefaultCPUAllocator()->raw_deleter();
+  }
+
+  void copy_data(void* dest, const void* src, std::size_t count) const override {
+    c10::GetDefaultCPUAllocator()->copy_data(dest, src, count);
+  }
+
+  size_t max_nbytes_;
+};
+
+at::Tensor tensor_with_allocator(FailLargeCPUAllocator& allocator, int64_t value) {
+  auto storage = c10::make_intrusive<c10::StorageImpl>(
+      c10::StorageImpl::use_byte_size_t(),
+      /*size_bytes=*/sizeof(int64_t),
+      &allocator,
+      /*resizable=*/true);
+  auto t = at::empty({0}, at::dtype(at::kLong)).set_(
+      at::Storage(std::move(storage)), /*storage_offset=*/0, /*size=*/{1}, /*stride=*/{1});
+  t.fill_(value);
+  return t;
+}
+
+} // namespace
+
+// Regression for https://github.com/pytorch/pytorch/issues/194047
+TEST(BasicTest, ResizeFailedAllocationPreservesMetadataCPU) {
+  FailLargeCPUAllocator allocator(/*max_nbytes=*/1024);
+  auto t = tensor_with_allocator(allocator, /*value=*/123);
+
+  ASSERT_THROWS(t.resize_({100000}));
+
+  ASSERT_EQ(t.sizes(), IntArrayRef({1}));
+  ASSERT_EQ(t.strides(), IntArrayRef({1}));
+  ASSERT_EQ(t.storage().nbytes(), sizeof(int64_t));
+  ASSERT_EQ(t.item<int64_t>(), 123);
+}
+
+TEST(BasicTest, ResizeFailedStridedAllocationPreservesMetadataCPU) {
+  FailLargeCPUAllocator allocator(/*max_nbytes=*/1024);
+  auto t = tensor_with_allocator(allocator, /*value=*/123);
+  const int64_t stride = 1;
+
+  ASSERT_THROWS(at::native::resize_impl_cpu_(
+      t.unsafeGetTensorImpl(),
+      /*size=*/{100000},
+      /*stride=*/IntArrayRef(&stride, 1),
+      /*resize_storage=*/true));
+
+  ASSERT_EQ(t.sizes(), IntArrayRef({1}));
+  ASSERT_EQ(t.strides(), IntArrayRef({1}));
+  ASSERT_EQ(t.storage().nbytes(), sizeof(int64_t));
+  ASSERT_EQ(t.item<int64_t>(), 123);
+}
+
+TEST(BasicTest, ResizeZeroToNonzeroGrowsStorageCPU) {
+  auto t = at::empty({0}, at::dtype(at::kLong));
+  ASSERT_EQ(t.numel(), 0);
+  t.resize_({10});
+  ASSERT_EQ(t.sizes(), IntArrayRef({10}));
+  ASSERT_EQ(t.numel(), 10);
+  ASSERT_GE(t.storage().nbytes(), 10 * sizeof(int64_t));
 }


### PR DESCRIPTION
## Summary

Fixes #194047.

`resize_` updated tensor sizes and strides before attempting to grow the underlying storage. If the CPU allocation failed, the tensor could retain the requested metadata while still referencing the old, smaller storage.

This changes the resize ordering so that the required storage size is computed and storage growth is attempted before mutating tensor metadata. If allocation fails, the original sizes, strides, and storage remain unchanged.

The zero-numel check now uses the requested shape rather than the tensor's current `numel()`, preserving correct behavior for zero-to-nonzero resizes.

## Test plan

Built the relevant ATen test target incrementally:

```text
ninja -C build -j1 basic
```

Passed new regression tests:

```text
BasicTest.ResizeFailedAllocationPreservesMetadataCPU
BasicTest.ResizeFailedStridedAllocationPreservesMetadataCPU
BasicTest.ResizeZeroToNonzeroGrowsStorageCPU
```

Result:

```text
[  PASSED  ] 3 tests.
```

Also passed existing sanity tests:

```text
BasicTest.BasicTestCPU
BasicTest.TestForBlobResizeCPU
BasicTest.TestForBlobStridesResizeCPU
BasicTest.TestForBlobStridesOverflow
```

Additional check:

```text
git diff --check
```

passed with no issues.

The original ASAN `10**12` allocation reproducer was not run locally because this was tested on Windows. The regression tests use a local failing allocator attached to the test storage to deterministically exercise the allocation-failure path without requiring a very large allocation or modifying the global CPU allocator.
