### PR TITLE
[Inductor][FlyDSL] Add gfx950 MXFP8 Grouped GEMM for F.scaled_grouped_mm

### DIFF
--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 import torch
+import torch.nn.functional as F
 from torch._inductor.codegen.flydsl import flydsl_utils
 from torch._inductor.codegen.flydsl.flydsl_kernel import FlyDSLTemplateKernel
 from torch._inductor.codegen.flydsl.flydsl_scheduling import (
@@ -421,6 +422,21 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(result, fn(a, b), atol=3e-2, rtol=3e-2)
         return code
 
+    def _assert_compiled_grouped_mm(self, a, b, offs, *, expect_flydsl=True):
+        from torch._inductor.utils import run_and_get_code
+
+        def fn(a, b, offs):
+            return F.grouped_mm(a, b, offs=offs)
+
+        torch._dynamo.reset()
+        result, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor"), a, b, offs
+        )
+        assertion = self.assertIn if expect_flydsl else self.assertNotIn
+        assertion("async_compile.flydsl", code)
+        self.assertEqual(result, fn(a, b, offs), atol=3e-2, rtol=3e-2)
+        return code
+
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
     @unittest.skipIf(torch.version.hip is None, "requires ROCm")
     @torch._inductor.config.patch(
@@ -522,6 +538,160 @@ class TestFlyDSLTemplate(TestCase):
                     b = torch.randn(64, k, device="cuda", dtype=torch.bfloat16)
                     self._assert_compiled_mm(a, b)
 
+    @parametrize(
+        "dtype,k,n",
+        [
+            (torch.bfloat16, 128, 128),
+            (torch.bfloat16, 160, 256),
+        ],
+    )
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=False,
+    )
+    def test_flydsl_grouped_mm_e2e(self, dtype, k, n):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        group_sizes = torch.tensor(
+            [0, 1, 67, 0, 130, 3], device="cuda", dtype=torch.int32
+        )
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=dtype)
+        b = torch.randn(group_sizes.numel(), k, n, device="cuda", dtype=dtype)
+        code = self._assert_compiled_grouped_mm(a, b, offs)
+        self.assertIn(".mark_layout_dynamic()", code)
+        self.assertIn("COMPILE_ONLY", code)
+        self.assertIn("_precompile", code)
+
+    @parametrize("k", (96, 192))
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        max_autotune_gemm_search_space="EXHAUSTIVE",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=True,
+    )
+    def test_flydsl_grouped_mm_autotune_e2e(self, k):
+        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        configs = [
+            asdict(config)
+            for config in flydsl_heuristics.get_default_grouped_gemm_configs()
+        ]
+        configs = [
+            next(config for config in configs if not config["USE_HALF_TILE_INTERLEAVED"]),
+            next(config for config in configs if config["USE_HALF_TILE_INTERLEAVED"]),
+        ]
+        group_sizes = torch.tensor(
+            [0, 1, 67, 0, 130, 3], device="cuda", dtype=torch.int32
+        )
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(group_sizes.numel(), k, 128, device="cuda", dtype=torch.bfloat16)
+        with mock.patch.object(
+            flydsl_heuristics,
+            "get_grouped_gemm_configs",
+            return_value=configs,
+        ):
+            self._assert_compiled_grouped_mm(a, b, offs)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=False,
+    )
+    def test_flydsl_grouped_mm_kernel_paths_e2e(self):
+        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        config_fields = (
+            "TILE_M",
+            "TILE_N",
+            "TILE_K",
+            "STAGES",
+            "BLOCK_M_WARPS",
+            "BLOCK_N_WARPS",
+            "GROUP_M",
+            "USE_HALF_TILE_INTERLEAVED",
+        )
+        cases = (
+            ("block_swizzle", 4096, 1024, 128, (128, 128, 64, 2, 1, 4, 4, False)),
+            ("deep_pipeline", 128, 128, 192, (64, 128, 64, 3, 1, 4, 0, False)),
+            ("large_tile", 1024, 256, 128, (256, 256, 64, 2, 2, 4, 0, True)),
+        )
+        configs = [
+            asdict(config)
+            for config in flydsl_heuristics.get_default_grouped_gemm_configs()
+        ]
+
+        for name, m, n, k, expected_values in cases:
+            with self.subTest(name=name):
+                config = next(
+                    config
+                    for config in configs
+                    if tuple(config[field] for field in config_fields)
+                    == expected_values
+                )
+                group_sizes = torch.tensor([m], device="cuda", dtype=torch.int32)
+                offs = group_sizes.cumsum(0).to(torch.int32)
+                a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+                b = torch.randn(1, k, n, device="cuda", dtype=torch.bfloat16)
+                with mock.patch.object(
+                    flydsl_heuristics,
+                    "get_grouped_gemm_configs",
+                    return_value=[config],
+                ):
+                    code = self._assert_compiled_grouped_mm(a, b, offs)
+                self.assertIn("launch_gemm_gfx950_grouped", code)
+                for field, value in zip(config_fields, expected_values):
+                    self.assertIn(f"{field}: fx.Constexpr = {value}", code)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="ATEN,FLYDSL",
+    )
+    def test_flydsl_grouped_mm_fallback_e2e(self):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        group_sizes = torch.tensor([32, 64], device="cuda", dtype=torch.int32)
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        k = 128
+        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        cases = (
+            (
+                "b_transposed",
+                torch.randn(2, 256, k, device="cuda", dtype=torch.bfloat16).transpose(
+                    -1, -2
+                ),
+            ),
+            (
+                "n_not_tile_divisible",
+                torch.randn(2, k, 96, device="cuda", dtype=torch.bfloat16),
+            ),
+        )
+
+        for name, b in cases:
+            with self.subTest(name=name):
+                self._assert_compiled_grouped_mm(a, b, offs, expect_flydsl=False)
+
+instantiate_parametrized_tests(TestFlyDSLTemplate)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -937,9 +937,6 @@ class TestFlyDSLTemplate(TestCase):
     def test_flydsl_mxfp8_grouped_gemm_config_schema(self):
         from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
-        default = flydsl_heuristics.FlyDSLMXFP8GroupedGemmConfig()
-        self.assertEqual(asdict(default), {"BLOCK_R": 256, "BLOCK_C": 256})
-
         # Non-autotuned selection is the tile the kernel's own heuristic picks,
         # not a fixed one -- so it has to be shape-dependent.
         with (
@@ -966,17 +963,6 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(len(exhaustive), 6)
         self.assertIn({"BLOCK_R": 256, "BLOCK_C": 256}, exhaustive)
         self.assertIn({"BLOCK_R": 64, "BLOCK_C": 128}, exhaustive)
-
-    def test_flydsl_mxfp8_scale_block_matches_kernel(self):
-        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
-
-        if not flydsl_utils.runtime_available():
-            self.skipTest("FlyDSL runtime unavailable")
-        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
-            MXFP8_SCALE_BLOCK,
-        )
-
-        self.assertEqual(flydsl_heuristics.MXFP8_SCALE_BLOCK, MXFP8_SCALE_BLOCK)
 
     @parametrize(
         "k,n,g,block_r,block_c,expected",

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -422,7 +422,9 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(result, fn(a, b), atol=3e-2, rtol=3e-2)
         return code
 
-    def _assert_compiled_grouped_mm(self, a, b, offs, *, expect_flydsl=True):
+    def _assert_compiled_grouped_mm(
+        self, a, b, offs, *, expect_flydsl: bool | None = True
+    ):
         from torch._inductor.utils import run_and_get_code
 
         def fn(a, b, offs):
@@ -432,8 +434,9 @@ class TestFlyDSLTemplate(TestCase):
         result, (code,) = run_and_get_code(
             torch.compile(fn, backend="inductor"), a, b, offs
         )
-        assertion = self.assertIn if expect_flydsl else self.assertNotIn
-        assertion("async_compile.flydsl", code)
+        if expect_flydsl is not None:
+            assertion = self.assertIn if expect_flydsl else self.assertNotIn
+            assertion("async_compile.flydsl", code)
         self.assertEqual(result, fn(a, b, offs), atol=3e-2, rtol=3e-2)
         return code
 
@@ -538,11 +541,32 @@ class TestFlyDSLTemplate(TestCase):
                     b = torch.randn(64, k, device="cuda", dtype=torch.bfloat16)
                     self._assert_compiled_mm(a, b)
 
+    def test_flydsl_grouped_gemm_config_schema(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        with mock.patch.object(flydsl_heuristics, "_make_gemm_param"):
+            configs = flydsl_heuristics.get_default_grouped_gemm_configs()
+        self.assertEqual(
+            asdict(configs[0]),
+            {
+                "TILE_M": 16,
+                "TILE_N": 64,
+                "TILE_K": 64,
+                "STAGES": 2,
+                "BLOCK_M_WARPS": 1,
+                "BLOCK_N_WARPS": 2,
+                "GROUP_M": 0,
+                "USE_HALF_TILE_INTERLEAVED": False,
+            },
+        )
+        self.assertTrue(any(config.USE_HALF_TILE_INTERLEAVED for config in configs))
+
     @parametrize(
         "dtype,k,n",
         [
             (torch.bfloat16, 128, 128),
             (torch.bfloat16, 160, 256),
+            (torch.float16, 128, 128),
         ],
     )
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
@@ -564,7 +588,7 @@ class TestFlyDSLTemplate(TestCase):
         b = torch.randn(group_sizes.numel(), k, n, device="cuda", dtype=dtype)
         code = self._assert_compiled_grouped_mm(a, b, offs)
         self.assertIn(".mark_layout_dynamic()", code)
-        self.assertIn("COMPILE_ONLY", code)
+        self.assertIn("FLYDSL_COMPILE_ONLY", code)
         self.assertIn("_precompile", code)
 
     @parametrize("k", (96, 192))
@@ -578,7 +602,7 @@ class TestFlyDSLTemplate(TestCase):
         autotune_in_subproc=True,
     )
     def test_flydsl_grouped_mm_autotune_e2e(self, k):
-        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
         if not flydsl_utils.runtime_available():
             self.skipTest("FlyDSL runtime unavailable")
@@ -588,7 +612,9 @@ class TestFlyDSLTemplate(TestCase):
             for config in flydsl_heuristics.get_default_grouped_gemm_configs()
         ]
         configs = [
-            next(config for config in configs if not config["USE_HALF_TILE_INTERLEAVED"]),
+            next(
+                config for config in configs if not config["USE_HALF_TILE_INTERLEAVED"]
+            ),
             next(config for config in configs if config["USE_HALF_TILE_INTERLEAVED"]),
         ]
         group_sizes = torch.tensor(
@@ -596,7 +622,9 @@ class TestFlyDSLTemplate(TestCase):
         )
         offs = group_sizes.cumsum(0).to(torch.int32)
         a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
-        b = torch.randn(group_sizes.numel(), k, 128, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(
+            group_sizes.numel(), k, 128, device="cuda", dtype=torch.bfloat16
+        )
         with mock.patch.object(
             flydsl_heuristics,
             "get_grouped_gemm_configs",
@@ -613,7 +641,7 @@ class TestFlyDSLTemplate(TestCase):
         autotune_in_subproc=False,
     )
     def test_flydsl_grouped_mm_kernel_paths_e2e(self):
-        from torch._inductor.template_heuristics import flydsl as flydsl_heuristics
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
         if not flydsl_utils.runtime_available():
             self.skipTest("FlyDSL runtime unavailable")
@@ -629,16 +657,53 @@ class TestFlyDSLTemplate(TestCase):
             "USE_HALF_TILE_INTERLEAVED",
         )
         cases = (
-            ("block_swizzle", 4096, 1024, 128, (128, 128, 64, 2, 1, 4, 4, False)),
-            ("deep_pipeline", 128, 128, 192, (64, 128, 64, 3, 1, 4, 0, False)),
-            ("large_tile", 1024, 256, 128, (256, 256, 64, 2, 2, 4, 0, True)),
+            (
+                "block_swizzle",
+                1,
+                4096,
+                1024,
+                128,
+                (128, 128, 64, 2, 1, 4, 4, False),
+            ),
+            (
+                "deep_pipeline",
+                1,
+                128,
+                128,
+                192,
+                (64, 128, 64, 3, 1, 4, 0, False),
+            ),
+            (
+                "large_tile",
+                1,
+                1024,
+                256,
+                128,
+                (256, 256, 64, 2, 2, 4, 0, True),
+            ),
+            (
+                "hti_odd_k_tiles",
+                1,
+                128,
+                128,
+                192,
+                (128, 128, 64, 2, 2, 2, 0, True),
+            ),
+            (
+                "persistent_hti",
+                8,
+                512,
+                4352,
+                128,
+                (256, 256, 64, 2, 2, 4, 0, True),
+            ),
         )
         configs = [
             asdict(config)
             for config in flydsl_heuristics.get_default_grouped_gemm_configs()
         ]
 
-        for name, m, n, k, expected_values in cases:
+        for name, groups, m, n, k, expected_values in cases:
             with self.subTest(name=name):
                 config = next(
                     config
@@ -646,10 +711,10 @@ class TestFlyDSLTemplate(TestCase):
                     if tuple(config[field] for field in config_fields)
                     == expected_values
                 )
-                group_sizes = torch.tensor([m], device="cuda", dtype=torch.int32)
+                group_sizes = torch.full((groups,), m, device="cuda", dtype=torch.int32)
                 offs = group_sizes.cumsum(0).to(torch.int32)
-                a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
-                b = torch.randn(1, k, n, device="cuda", dtype=torch.bfloat16)
+                a = torch.randn(groups * m, k, device="cuda", dtype=torch.bfloat16)
+                b = torch.randn(groups, k, n, device="cuda", dtype=torch.bfloat16)
                 with mock.patch.object(
                     flydsl_heuristics,
                     "get_grouped_gemm_configs",
@@ -673,25 +738,70 @@ class TestFlyDSLTemplate(TestCase):
         group_sizes = torch.tensor([32, 64], device="cuda", dtype=torch.int32)
         offs = group_sizes.cumsum(0).to(torch.int32)
         k = 128
-        a = torch.randn(int(group_sizes.sum()), k, device="cuda", dtype=torch.bfloat16)
+        total_m = int(group_sizes.sum())
+        a = torch.randn(total_m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(2, k, 128, device="cuda", dtype=torch.bfloat16)
+        a_padded = torch.randn(total_m, k + 8, device="cuda", dtype=torch.bfloat16)[
+            :, :k
+        ]
+        a_unaligned = torch.as_strided(
+            torch.randn(
+                total_m * k + 1,
+                device="cuda",
+                dtype=torch.bfloat16,
+            ),
+            (total_m, k),
+            (k, 1),
+            storage_offset=1,
+        )
+        b_padded = torch.randn(2, k, 136, device="cuda", dtype=torch.bfloat16)[
+            ..., :128
+        ]
+        a_aligned = torch.as_strided(
+            torch.randn(total_m * k + 8, device="cuda", dtype=torch.bfloat16),
+            (total_m, k),
+            (k, 1),
+            storage_offset=8,
+        )
+        b_aligned = torch.as_strided(
+            torch.randn(2 * k * 128 + 8, device="cuda", dtype=torch.bfloat16),
+            (2, k, 128),
+            (k * 128, 128, 1),
+            storage_offset=8,
+        )
+        self._assert_compiled_grouped_mm(a_aligned, b_aligned, offs, expect_flydsl=None)
+        with torch._inductor.config.patch(max_autotune_gemm_backends="FLYDSL"):
+            self._assert_compiled_grouped_mm(a_aligned, b_aligned, offs)
+
         cases = (
             (
                 "b_transposed",
+                a,
                 torch.randn(2, 256, k, device="cuda", dtype=torch.bfloat16).transpose(
                     -1, -2
                 ),
             ),
             (
                 "n_not_tile_divisible",
+                a,
                 torch.randn(2, k, 96, device="cuda", dtype=torch.bfloat16),
+            ),
+            ("a_padded_stride", a_padded, b),
+            ("a_unaligned_offset", a_unaligned, b),
+            ("b_padded_stride", a, b_padded),
+            (
+                "k_not_tile_divisible",
+                torch.randn(total_m, 80, device="cuda", dtype=torch.bfloat16),
+                torch.randn(2, 80, 128, device="cuda", dtype=torch.bfloat16),
             ),
         )
 
-        for name, b in cases:
+        for name, case_a, case_b in cases:
             with self.subTest(name=name):
-                self._assert_compiled_grouped_mm(a, b, offs, expect_flydsl=False)
+                self._assert_compiled_grouped_mm(
+                    case_a, case_b, offs, expect_flydsl=False
+                )
 
-instantiate_parametrized_tests(TestFlyDSLTemplate)
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -1144,8 +1144,11 @@ class TestFlyDSLTemplate(TestCase):
 
         code = self._assert_compiled_mxfp8_grouped_mm(group_sizes, k, n)
         self.assertIn(".mark_layout_dynamic()", code)
-        self.assertIn("FLYDSL_COMPILE_ONLY", code)
         self.assertIn("_precompile", code)
+        # Compile-only is an argument, not a process-global env flag: warming
+        # and a real dispatch can share a process.
+        self.assertIn("compile_only=True", code)
+        self.assertNotIn("FLYDSL_COMPILE_ONLY", code)
 
     @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
     @unittest.skipIf(torch.version.hip is None, "requires ROCm")
@@ -1161,6 +1164,76 @@ class TestFlyDSLTemplate(TestCase):
             self.skipTest("FlyDSL runtime unavailable")
 
         self._assert_compiled_mxfp8_grouped_mm([512, 300, 700, 1000], 2048, 2048)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    def test_flydsl_mxfp8_grouped_mm_tile_parity_e2e(self):
+        """Every tile must agree bitwise, on the shapes that once did not.
+
+        The N_ACCUMS=4 tiles (BLOCK_R=64, and 128x128) computed a small
+        fraction of elements wrong until `wait_barrier` was made to wait on
+        lgkmcnt as well as vmcnt: an s2r fragment issued in one cluster and
+        consumed in the next could cross the barrier still outstanding. Only
+        the MFMAs in between covered that gap, so exactly the tiles with four
+        accumulators broke. `pick_block_r` can return those tiles, so this
+        pins the property rather than trusting it.
+        """
+        import importlib
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+        module = importlib.import_module(
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels."
+            "mxfp8_grouped_gemm_gfx950"
+        )
+        import flydsl.compiler as flyc
+
+        group_sizes = [1, 3, 7, 15, 31, 63, 127, 255]
+        k, n, g = 2048, 1408, len(group_sizes)
+        a, b, a_scale, b_scale, offs, reference = self._make_mxfp8_grouped_inputs(
+            group_sizes, k, n
+        )
+        # The kernel wants B as a stack of [N, K] planes, the layout the
+        # lowering hands it after the template's permute.
+        weight = b.permute(0, 2, 1)
+        rows = int(offs[-1])
+        outputs = {}
+        for block_r in (64, 128, 256):
+            for block_c in (128, 256):
+                param = module.make_mxfp8_grouped_gemm_param_and_validate(
+                    k, n, g, block_r, block_c
+                )
+                if param is None:
+                    continue
+                out = torch.zeros(a.shape[0], n, dtype=torch.bfloat16, device=a.device)
+                module.launch_mxfp8_grouped_gemm_gfx950(
+                    out,
+                    a,
+                    weight,
+                    a_scale,
+                    b_scale.reshape(g, n, -1),
+                    offs,
+                    param,
+                    torch.cuda.current_stream(),
+                    tensor_arg=lambda t: flyc.from_torch_tensor(
+                        t
+                    ).mark_layout_dynamic(),
+                )
+                outputs[(block_r, block_c)] = out
+        self.assertGreaterEqual(len(outputs), 4)
+
+        tiles = list(outputs)
+        base = outputs[tiles[0]]
+        for tile in tiles[1:]:
+            differing = int((outputs[tile][:rows] != base[:rows]).sum())
+            self.assertEqual(
+                differing,
+                0,
+                f"tile {tile} disagrees with {tiles[0]} on {differing} elements",
+            )
+        self.assertEqual(
+            base[:rows].float(), reference[:rows].float(), atol=6e-2, rtol=6e-2
+        )
 
     def test_flydsl_mxfp8_grouped_mm_row_windows(self):
         """A token dim past the int32 operand limit is split, not truncated."""

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -546,22 +546,66 @@ class TestFlyDSLTemplate(TestCase):
 
         flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear()
         self.addCleanup(flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear)
-        with mock.patch.object(flydsl_heuristics, "_make_gemm_param"):
+        default_config = flydsl_heuristics.DEFAULT_GROUPED_GEMM_CONFIG
+        with (
+            mock.patch.object(flydsl_heuristics, "_make_gemm_param"),
+            torch._inductor.config.patch(flydsl_enable_autotuning=False),
+        ):
             configs = flydsl_heuristics.get_default_grouped_gemm_configs()
+            selected = flydsl_heuristics.get_grouped_gemm_configs()
         self.assertEqual(
-            asdict(configs[0]),
+            asdict(default_config),
             {
-                "TILE_M": 16,
-                "TILE_N": 64,
+                "TILE_M": 128,
+                "TILE_N": 128,
                 "TILE_K": 64,
                 "STAGES": 2,
                 "BLOCK_M_WARPS": 1,
-                "BLOCK_N_WARPS": 2,
+                "BLOCK_N_WARPS": 4,
                 "GROUP_M": 0,
                 "USE_HALF_TILE_INTERLEAVED": False,
             },
         )
+        # The baseline must stay reachable regardless of candidate ordering.
+        self.assertIn(default_config, configs)
+        self.assertEqual(selected, [asdict(default_config)])
         self.assertTrue(any(config.USE_HALF_TILE_INTERLEAVED for config in configs))
+
+    def test_flydsl_grouped_gemm_exhaustive_layout_filter(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        valid = flydsl_heuristics.DEFAULT_GROUPED_GEMM_CONFIG
+        small_n = flydsl_heuristics.FlyDSLGemmConfig(32, 32, 64, 2, 1, 2, 0)
+        invalid_cshuffle = flydsl_heuristics.FlyDSLGemmConfig(16, 96, 64, 2, 1, 2, 0)
+        with mock.patch.object(
+            flydsl_heuristics,
+            "get_exhaustive_gemm_configs",
+            return_value=[small_n, invalid_cshuffle, valid],
+        ):
+            configs = flydsl_heuristics.get_exhaustive_grouped_gemm_configs()
+        self.assertEqual(configs, [valid])
+
+    @parametrize(
+        "config_args,n,expected",
+        [
+            ((32, 32, 64, 2, 1, 2, 0), 32, False),
+            ((16, 96, 64, 2, 1, 2, 0), 96, False),
+            ((128, 128, 64, 2, 1, 4, 0), 128, True),
+        ],
+    )
+    def test_flydsl_grouped_gemm_layout_validation(self, config_args, n, expected):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        gemm_config = asdict(flydsl_heuristics.FlyDSLGemmConfig(*config_args))
+        with mock.patch.object(
+            flydsl_heuristics,
+            "is_gemm_config_valid_for_shape",
+            return_value=True,
+        ):
+            valid = flydsl_heuristics.is_grouped_gemm_config_valid_for_shape(
+                128, n, 128, 0, gemm_config
+            )
+        self.assertEqual(valid, expected)
 
     @parametrize(
         "dtype,k,n",

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -544,6 +544,8 @@ class TestFlyDSLTemplate(TestCase):
     def test_flydsl_grouped_gemm_config_schema(self):
         from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
+        flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear()
+        self.addCleanup(flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear)
         with mock.patch.object(flydsl_heuristics, "_make_gemm_param"):
             configs = flydsl_heuristics.get_default_grouped_gemm_configs()
         self.assertEqual(

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -22,6 +22,7 @@ from torch._inductor.select_algorithm import PartialRender
 from torch._inductor.test_case import TestCase
 from torch._inductor.utils import OrderedSet
 from torch._inductor.virtualized import V
+from torch.nn.functional import ScalingType, SwizzleType
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -847,6 +848,350 @@ class TestFlyDSLTemplate(TestCase):
                 self._assert_compiled_grouped_mm(
                     case_a, case_b, offs, expect_flydsl=False
                 )
+
+    # ------------------------------------------------------------------
+    # MXFP8 ragged grouped GEMM (aten._scaled_grouped_mm_v2)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _mxfp8_quantize(x, block=32):
+        """Cast the last dim of `x` to MXFP8: e4m3 data + e8m0 block scales.
+
+        Returns (fp8 data, e8m0 scales, f32 scales) -- the f32 scales are the
+        exact values the e8m0 ones encode, so a reference can dequantize
+        without re-deriving the exponent.
+        """
+        k = x.shape[-1]
+        blocks = x.reshape(*x.shape[:-1], k // block, block)
+        amax = blocks.abs().amax(-1)
+        # e4m3 max is 448 = 2**8.8; take the exponent that maps amax below it.
+        exponent = torch.floor(torch.log2(amax.clamp(min=1e-30))).to(torch.int32) - 7
+        exponent = exponent.clamp(-127, 127)
+        scale_f32 = torch.exp2(exponent.float())
+        data = (
+            (blocks / scale_f32.unsqueeze(-1))
+            .clamp(-448, 448)
+            .to(torch.float8_e4m3fn)
+            .reshape(*x.shape[:-1], k)
+        )
+        scale_e8m0 = (exponent + 127).to(torch.uint8).view(torch.float8_e8m0fnu)
+        return data, scale_e8m0, scale_f32
+
+    @classmethod
+    def _mxfp8_grouped_reference(cls, a, a_scale, b, b_scale, offs, block=32):
+        """Dequantize and matmul per group, in f32."""
+        m, k = a.shape
+        g, n = b.shape[0], b.shape[1]
+        a_deq = a.float().reshape(m, k // block, block) * a_scale.unsqueeze(-1)
+        b_deq = b.float().reshape(g, n, k // block, block) * b_scale.unsqueeze(-1)
+        a_deq = a_deq.reshape(m, k)
+        b_deq = b_deq.reshape(g, n, k)
+        out = torch.zeros(m, n, device=a.device, dtype=torch.float32)
+        start = 0
+        for group in range(g):
+            end = int(offs[group])
+            if end > start:
+                out[start:end] = a_deq[start:end] @ b_deq[group].t()
+            start = end
+        return out.to(torch.bfloat16)
+
+    @classmethod
+    def _make_mxfp8_grouped_inputs(cls, group_sizes, k, n, device="cuda"):
+        offs = torch.tensor(group_sizes, device=device, dtype=torch.int32).cumsum(0)
+        offs = offs.to(torch.int32)
+        m = int(sum(group_sizes))
+        g = len(group_sizes)
+        a_hp = torch.randn(m, k, device=device) * 0.5
+        # The weight is generated as [G, N, K] row-major and handed to the op
+        # as the [G, K, N] view of it, which is the layout every scaled GEMM
+        # already requires of mat_b.
+        b_hp = torch.randn(g, n, k, device=device) * 0.5
+        a, a_scale, a_scale_f32 = cls._mxfp8_quantize(a_hp)
+        b, b_scale, b_scale_f32 = cls._mxfp8_quantize(b_hp)
+        reference = cls._mxfp8_grouped_reference(a, a_scale_f32, b, b_scale_f32, offs)
+        return (
+            a,
+            b.transpose(-2, -1),
+            a_scale,
+            b_scale.reshape(g, -1),
+            offs,
+            reference,
+        )
+
+    @staticmethod
+    def _scaled_grouped_mm_mxfp8(a, b, a_scale, b_scale, offs, **kwargs):
+        return F.scaled_grouped_mm(
+            a,
+            b,
+            a_scale,
+            ScalingType.BlockWise1x32,
+            b_scale,
+            ScalingType.BlockWise1x32,
+            swizzle_a=SwizzleType.NO_SWIZZLE,
+            swizzle_b=SwizzleType.NO_SWIZZLE,
+            offs=offs,
+            output_dtype=torch.bfloat16,
+            **kwargs,
+        )
+
+    def test_flydsl_mxfp8_grouped_gemm_config_schema(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        default = flydsl_heuristics.FlyDSLMXFP8GroupedGemmConfig()
+        self.assertEqual(asdict(default), {"BLOCK_R": 256, "BLOCK_C": 256})
+
+        # Non-autotuned selection is the tile the kernel's own heuristic picks,
+        # not a fixed one -- so it has to be shape-dependent.
+        with (
+            mock.patch.object(
+                flydsl_heuristics,
+                "get_default_mxfp8_grouped_gemm_config",
+                return_value=flydsl_heuristics.FlyDSLMXFP8GroupedGemmConfig(64, 128),
+            ),
+            mock.patch.object(flydsl_heuristics, "_make_mxfp8_grouped_gemm_param"),
+            torch._inductor.config.patch(flydsl_enable_autotuning=False),
+        ):
+            selected = flydsl_heuristics.get_mxfp8_grouped_gemm_configs(
+                512, 2048, 2048, 8
+            )
+        self.assertEqual(selected, [{"BLOCK_R": 64, "BLOCK_C": 128}])
+
+        with (
+            mock.patch.object(flydsl_heuristics, "_make_mxfp8_grouped_gemm_param"),
+            torch._inductor.config.patch(flydsl_enable_autotuning=True),
+        ):
+            exhaustive = flydsl_heuristics.get_mxfp8_grouped_gemm_configs(
+                512, 2048, 2048, 8
+            )
+        self.assertEqual(len(exhaustive), 6)
+        self.assertIn({"BLOCK_R": 256, "BLOCK_C": 256}, exhaustive)
+        self.assertIn({"BLOCK_R": 64, "BLOCK_C": 128}, exhaustive)
+
+    def test_flydsl_mxfp8_scale_block_matches_kernel(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+            MXFP8_SCALE_BLOCK,
+        )
+
+        self.assertEqual(flydsl_heuristics.MXFP8_SCALE_BLOCK, MXFP8_SCALE_BLOCK)
+
+    @parametrize(
+        "k,n,g,block_r,block_c,expected",
+        (
+            (2048, 2048, 8, 256, 256, True),
+            (2048, 2048, 8, 64, 128, True),
+            # K must be a whole number of 128-element pipeline steps...
+            (2080, 2048, 8, 256, 256, False),
+            # ...and there must be at least four of them (2 prologue, 2 tails).
+            (384, 2048, 8, 256, 256, False),
+            # A 128-wide tile only pays when it divides N.
+            (2048, 1408, 8, 256, 128, True),
+            (2048, 1344, 8, 256, 128, False),
+            # Tiles the kernel does not implement.
+            (2048, 2048, 8, 32, 256, False),
+            (2048, 2048, 8, 256, 64, False),
+        ),
+    )
+    def test_flydsl_mxfp8_grouped_gemm_shape_validation(
+        self, k, n, g, block_r, block_c, expected
+    ):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        valid = flydsl_heuristics.is_mxfp8_grouped_gemm_config_valid_for_shape(
+            n, k, g, {"BLOCK_R": block_r, "BLOCK_C": block_c}
+        )
+        self.assertEqual(valid, expected)
+
+    @parametrize(
+        "case",
+        (
+            "a_dtype",
+            "out_dtype",
+            "scale_dtype",
+            "b_not_k_major",
+            "a_padded_stride",
+            "scale_a_padded_stride",
+            "scale_b_wrong_shape",
+            "offs_dtype",
+            "k_not_scale_aligned",
+        ),
+    )
+    def test_flydsl_mxfp8_grouped_gate_rejects_invalid_inputs(self, case):
+        """The gate rejects everything the kernel's layout contract excludes.
+
+        Driven through fake IR nodes rather than a compile so it runs without a
+        GPU, and -- more to the point -- without ATen, which has no MXFP8
+        grouped kernel on ROCm to fall back to.
+        """
+        from torch._inductor.kernel import mm_grouped
+
+        m, k, n, g = 512, 2048, 256, 4
+        scale_k = k // 32
+
+        def node(size, stride, dtype, offset=0):
+            return SimpleNamespace(
+                get_size=lambda: size,
+                get_stride=lambda: stride,
+                get_dtype=lambda: dtype,
+                get_layout=lambda: SimpleNamespace(offset=offset),
+            )
+
+        fp8 = torch.float8_e4m3fn
+        e8m0 = torch.float8_e8m0fnu
+        mat_a = node([m, k], [k, 1], fp8)
+        mat_b = node([g, k, n], [k * n, 1, k], fp8)
+        scale_a = node([m, scale_k], [scale_k, 1], e8m0)
+        scale_b = node([g, n * scale_k], [n * scale_k, 1], e8m0)
+        offs = node([g], [1], torch.int32)
+        out_dtype = torch.bfloat16
+
+        if case == "a_dtype":
+            mat_a = node([m, k], [k, 1], torch.float8_e5m2)
+        elif case == "out_dtype":
+            out_dtype = torch.float16
+        elif case == "scale_dtype":
+            scale_a = node([m, scale_k], [scale_k, 1], torch.float32)
+        elif case == "b_not_k_major":
+            mat_b = node([g, k, n], [k * n, n, 1], fp8)
+        elif case == "a_padded_stride":
+            mat_a = node([m, k], [k + 32, 1], fp8)
+        elif case == "scale_a_padded_stride":
+            scale_a = node([m, scale_k], [scale_k + 4, 1], e8m0)
+        elif case == "scale_b_wrong_shape":
+            scale_b = node([g, n, scale_k], [n * scale_k, scale_k, 1], e8m0)
+        elif case == "offs_dtype":
+            offs = node([g], [1], torch.int64)
+        elif case == "k_not_scale_aligned":
+            mat_a = node([m, k + 16], [k + 16, 1], fp8)
+
+        layout = SimpleNamespace(
+            stride=[n, 1],
+            dtype=out_dtype,
+            size=[m, n],
+            device=torch.device("cpu"),
+        )
+        sizevars = SimpleNamespace(
+            statically_known_equals=lambda x, y: x == y,
+            statically_known_multiple_of=lambda x, y: x % y == 0,
+        )
+        with (
+            V.set_graph_handler(SimpleNamespace(sizevars=sizevars)),
+            mock.patch.object(
+                mm_grouped, "use_flydsl_gemm_template", return_value=True
+            ),
+            mock.patch.object(mm_grouped, "is_unaligned", return_value=False),
+        ):
+            result = mm_grouped.get_flydsl_mxfp8_grouped_mm_template_kwargs(
+                mat_a, mat_b, scale_a, scale_b, offs, layout, True
+            )
+        self.assertEqual(result, [])
+
+    def _assert_compiled_mxfp8_grouped_mm(
+        self, group_sizes, k, n, *, expect_flydsl: bool = True
+    ):
+        from torch._inductor.utils import run_and_get_code
+
+        a, b, a_scale, b_scale, offs, reference = self._make_mxfp8_grouped_inputs(
+            group_sizes, k, n
+        )
+
+        def fn(a, b, a_scale, b_scale, offs):
+            return self._scaled_grouped_mm_mxfp8(a, b, a_scale, b_scale, offs)
+
+        torch._dynamo.reset()
+        result, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor"), a, b, a_scale, b_scale, offs
+        )
+        assertion = self.assertIn if expect_flydsl else self.assertNotIn
+        assertion("async_compile.flydsl", code)
+        # Rows past the last group are written by no block and are not part of
+        # the result, so only the grouped region is compared.
+        rows = int(offs[-1])
+        self.assertEqual(
+            result[:rows].float(), reference[:rows].float(), atol=6e-2, rtol=6e-2
+        )
+        return code
+
+    @parametrize(
+        "group_sizes,k,n",
+        (
+            ([512, 300, 700, 1000], 2048, 2048),
+            ([512] * 8, 4096, 4096),
+            # Empty groups, and a group boundary inside a row tile.
+            ([0, 1024, 0, 512, 2048, 128, 0, 896], 2048, 2048),
+            # The minimum K the pipeline supports: 4 steps of 128.
+            ([256] * 4, 512, 2048),
+            # N that only the 128-wide tile divides.
+            ([1, 3, 7, 15, 31, 63, 127, 255], 2048, 1408),
+        ),
+    )
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=False,
+    )
+    def test_flydsl_mxfp8_grouped_mm_e2e(self, group_sizes, k, n):
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        code = self._assert_compiled_mxfp8_grouped_mm(group_sizes, k, n)
+        self.assertIn(".mark_layout_dynamic()", code)
+        self.assertIn("FLYDSL_COMPILE_ONLY", code)
+        self.assertIn("_precompile", code)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=False,
+    )
+    def test_flydsl_mxfp8_grouped_mm_autotune_e2e(self):
+        """Autotuning walks every tile the kernel implements, and each is correct."""
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        self._assert_compiled_mxfp8_grouped_mm([512, 300, 700, 1000], 2048, 2048)
+
+    def test_flydsl_mxfp8_grouped_mm_row_windows(self):
+        """A token dim past the int32 operand limit is split, not truncated."""
+        import importlib
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        module = importlib.import_module(
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels."
+            "mxfp8_grouped_gemm_gfx950"
+        )
+        param = module.make_mxfp8_grouped_gemm_param(2048, 2048, 2, 256, 256)
+        total_m = 1 << 22
+        offs = torch.tensor([total_m // 2, total_m], dtype=torch.int32)
+        windows = list(
+            module._row_windows(total_m, param.k, param.n, offs, param.block_r)
+        )
+        # M * K here is 2**33, so this must split.
+        self.assertGreater(len(windows), 1)
+        covered = 0
+        for row_start, rows, window_offs in windows:
+            # Disjoint, contiguous, and never splitting a row tile.
+            self.assertEqual(row_start, covered)
+            self.assertEqual(rows % param.block_r, 0)
+            # Offsets are rebased into the window and clamped to it, so a group
+            # straddling the boundary ends at `rows` here and starts at 0 next.
+            self.assertEqual(int(window_offs.max()), rows)
+            self.assertGreaterEqual(int(window_offs.min()), 0)
+            covered += rows
+        self.assertEqual(covered, total_m)
 
 
 if __name__ == "__main__":

--- a/test/test_public_bindings.py
+++ b/test/test_public_bindings.py
@@ -369,6 +369,7 @@ class TestPublicBindings(TestCase):
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers",  # depends on cutlass_api
             "torch._inductor.kernel.vendored_templates.cutedsl.wrappers.dense_blockscaled_gemm_kernel",  # depends on cutlass_api
             "torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_gfx950",  # depends on flydsl
+            "torch._inductor.kernel.vendored_templates.flydsl.kernels.grouped_gemm_gfx950",  # depends on flydsl
             "torch._inductor.runtime.triton_helpers",
             "torch.ao.pruning._experimental.data_sparsifier.lightning.callbacks.data_sparsity",
             "torch.backends._coreml.preprocess",

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -234,40 +234,53 @@ def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     config_tuples: list[FlyDSLGemmConfigArgs] = [
         # Small-M grouped/decode configs.  These reduce wasted work when each
         # group has far fewer than 32 rows.
-        (16, 64, 64, 2, 1, 1, 2, 1, 0, True),
-        (16, 128, 64, 2, 1, 1, 2, 1, 0, True),
-        (32, 64, 64, 2, 1, 1, 2, 1, 0, True),
-        (32, 256, 64, 2, 1, 1, 4, 1, 0, True),
-        (32, 128, 64, 2, 1, 1, 4, 1, 0, True),
-        (64, 128, 64, 2, 1, 1, 4, 1, 0, True),
-        (64, 256, 64, 2, 1, 1, 4, 1, 0, True),
-        (128, 128, 64, 2, 1, 1, 4, 1, 0, True),
-        (128, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (16, 64, 64, 2, 1, 2, 0),
+        (16, 128, 64, 2, 1, 2, 0),
+        (32, 64, 64, 2, 1, 2, 0),
+        (32, 256, 64, 2, 1, 4, 0),
+        (32, 128, 64, 2, 1, 4, 0),
+        (64, 128, 64, 2, 1, 4, 0),
+        (64, 256, 64, 2, 1, 4, 0),
+        (128, 128, 64, 2, 1, 4, 0),
+        (128, 256, 64, 2, 1, 4, 0),
         # Deeper pipelines, autotuned for the multi-stage overlap.
-        (64, 128, 64, 3, 1, 1, 4, 1, 0, True),
-        (128, 128, 64, 3, 1, 1, 4, 1, 0, True),
-        (128, 256, 64, 3, 1, 1, 4, 1, 0, True),
+        (64, 128, 64, 3, 1, 4, 0),
+        (128, 128, 64, 3, 1, 4, 0),
+        (128, 256, 64, 3, 1, 4, 0),
         # Swizzled group-M variant remaps sufficiently large per-group tile grids.
-        (128, 128, 64, 2, 1, 1, 4, 1, 4, True),
+        (128, 128, 64, 2, 1, 4, 4),
     ]
     hti_config_tuples: list[FlyDSLHTIGemmConfigArgs] = [
         # 2x2 half-tile-interleaved variant (stages=2 only): four half-block
         # accumulators + per-quadrant cshuffle store for better register tiling
         # and MMA scheduling. Requires m_waves=2, n_waves>=2 and even tiles.
-        (64, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
-        (128, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
-        (128, 128, 64, 2, 1, 2, 2, 1, 4, True, True),
-        (128, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
-        (256, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
-        (256, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+        (64, 128, 64, 2, 2, 2, 0, True),
+        (128, 128, 64, 2, 2, 2, 0, True),
+        (128, 128, 64, 2, 2, 2, 4, True),
+        (128, 256, 64, 2, 2, 4, 0, True),
+        (256, 128, 64, 2, 2, 2, 0, True),
+        (256, 256, 64, 2, 2, 4, 0, True),
     ]
     # Tuple order must match the FlyDSLGemmConfig field declaration order.
     candidates = [FlyDSLGemmConfig(*args) for args in config_tuples]
     candidates.extend(FlyDSLGemmConfig(*args) for args in hti_config_tuples)
-    return candidates
+    valid_configs: list[FlyDSLGemmConfig] = []
+    for gemm_config in candidates:
+        try:
+            _make_gemm_param(asdict(gemm_config))
+            valid_configs.append(gemm_config)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid default FlyDSL grouped config %s: %s",
+                gemm_config,
+                e,
+            )
+    return valid_configs
 
 
-def get_grouped_gemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
+def get_grouped_gemm_configs(
+    m: int, n: int, k: int, dtype_id: int
+) -> list[dict[str, object]]:
     """Return supported configs for the persistent multi-stage grouped kernel."""
     if (
         config.flydsl_enable_autotuning
@@ -289,9 +302,7 @@ def get_grouped_gemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
         if (k // grouped_config.TILE_K) < grouped_config.STAGES:
             continue
         gemm_config = asdict(grouped_config)
-        try:
-            _make_gemm_param(gemm_config)
-        except Exception:
+        if not is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config):
             continue
         configs.append(gemm_config)
     if not configs:

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -372,9 +372,9 @@ def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
     return [asdict(gemm_config) for gemm_config in candidates]
 
 
-# OCP MX: 32 elements share one E8M0 scale. Declared here rather than imported
-# from the vendored kernel so the lowering's shape gate stays importable
-# without the FlyDSL runtime; the two are asserted equal in the tests.
+# OCP MX: 32 elements share one E8M0 scale. Fixed by the spec, so it is declared
+# here rather than imported from the vendored kernel (which pulls in the FlyDSL
+# runtime) and the lowering's shape gate stays importable without it.
 MXFP8_SCALE_BLOCK = 32
 
 

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -218,3 +218,82 @@ def get_gemm_configs() -> list[dict[str, int | bool]]:
         log.warning("No valid FlyDSL GEMM configuration is available")
         return []
     return [asdict(gemm_config) for gemm_config in configs]
+
+
+def get_exhaustive_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
+    """Return exhaustive configs for the gfx950 FlyDSL grouped GEMM kernel."""
+    return get_exhaustive_gemm_configs()
+
+
+def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
+    """Return default configs for the gfx950 FlyDSL grouped GEMM kernel.
+
+    The grouped kernel always stages N-contiguous B vectors into LDS and reads
+    them back transposed.
+    """
+    config_tuples: list[FlyDSLGemmConfigArgs] = [
+        # Small-M grouped/decode configs.  These reduce wasted work when each
+        # group has far fewer than 32 rows.
+        (16, 64, 64, 2, 1, 1, 2, 1, 0, True),
+        (16, 128, 64, 2, 1, 1, 2, 1, 0, True),
+        (32, 64, 64, 2, 1, 1, 2, 1, 0, True),
+        (32, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (32, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (64, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (64, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        (128, 128, 64, 2, 1, 1, 4, 1, 0, True),
+        (128, 256, 64, 2, 1, 1, 4, 1, 0, True),
+        # Deeper pipelines, autotuned for the multi-stage overlap.
+        (64, 128, 64, 3, 1, 1, 4, 1, 0, True),
+        (128, 128, 64, 3, 1, 1, 4, 1, 0, True),
+        (128, 256, 64, 3, 1, 1, 4, 1, 0, True),
+        # Swizzled group-M variant remaps sufficiently large per-group tile grids.
+        (128, 128, 64, 2, 1, 1, 4, 1, 4, True),
+    ]
+    hti_config_tuples: list[FlyDSLHTIGemmConfigArgs] = [
+        # 2x2 half-tile-interleaved variant (stages=2 only): four half-block
+        # accumulators + per-quadrant cshuffle store for better register tiling
+        # and MMA scheduling. Requires m_waves=2, n_waves>=2 and even tiles.
+        (64, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (128, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (128, 128, 64, 2, 1, 2, 2, 1, 4, True, True),
+        (128, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+        (256, 128, 64, 2, 1, 2, 2, 1, 0, True, True),
+        (256, 256, 64, 2, 1, 2, 4, 1, 0, True, True),
+    ]
+    # Tuple order must match the FlyDSLGemmConfig field declaration order.
+    candidates = [FlyDSLGemmConfig(*args) for args in config_tuples]
+    candidates.extend(FlyDSLGemmConfig(*args) for args in hti_config_tuples)
+    return candidates
+
+
+def get_grouped_gemm_configs(m: int, n: int, k: int) -> list[dict[str, object]]:
+    """Return supported configs for the persistent multi-stage grouped kernel."""
+    if (
+        config.flydsl_enable_autotuning
+        and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
+    ):
+        candidates = get_exhaustive_grouped_gemm_configs()
+    elif config.flydsl_enable_autotuning:
+        candidates = get_default_grouped_gemm_configs()
+    else:
+        candidates = get_default_grouped_gemm_configs()
+        candidates = candidates[:1]
+
+    configs: list[dict[str, object]] = []
+    for grouped_config in candidates:
+        if grouped_config.TILE_M > max(128, m):
+            continue
+        if n < grouped_config.TILE_N or n % grouped_config.TILE_N != 0:
+            continue
+        if (k // grouped_config.TILE_K) < grouped_config.STAGES:
+            continue
+        gemm_config = asdict(grouped_config)
+        try:
+            _make_gemm_param(gemm_config)
+        except Exception:
+            continue
+        configs.append(gemm_config)
+    if not configs:
+        log.warning("No valid FlyDSL grouped GEMM configuration is available")
+    return configs

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -225,6 +225,7 @@ def get_exhaustive_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     return get_exhaustive_gemm_configs()
 
 
+@functools.cache
 def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     """Return default configs for the gfx950 FlyDSL grouped GEMM kernel.
 
@@ -278,33 +279,45 @@ def get_default_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     return valid_configs
 
 
-def get_grouped_gemm_configs(
-    m: int, n: int, k: int, dtype_id: int
-) -> list[dict[str, object]]:
-    """Return supported configs for the persistent multi-stage grouped kernel."""
+def is_grouped_gemm_config_valid_for_shape(
+    m: int,
+    n: int,
+    k: int,
+    dtype_id: int,
+    gemm_config: dict[str, int | bool],
+) -> bool:
+    """Return whether a FlyDSL config supports this grouped GEMM shape."""
+    tile_m = int(gemm_config["TILE_M"])
+    tile_n = int(gemm_config["TILE_N"])
+    tile_k = int(gemm_config["TILE_K"])
+    stages = int(gemm_config["STAGES"])
+    use_half_tile_interleaved = bool(gemm_config["USE_HALF_TILE_INTERLEAVED"])
+    has_enough_k = use_half_tile_interleaved or k // tile_k >= stages
+    return (
+        tile_m <= max(128, m)
+        and n >= tile_n
+        and n % tile_n == 0
+        and has_enough_k
+        and is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config)
+    )
+
+
+def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
+    """Return configs for the persistent multi-stage grouped kernel.
+
+    Shape compatibility is checked in the lowering before this function is called.
+    """
     if (
         config.flydsl_enable_autotuning
         and config.max_autotune_gemm_search_space == "EXHAUSTIVE"
     ):
         candidates = get_exhaustive_grouped_gemm_configs()
-    elif config.flydsl_enable_autotuning:
-        candidates = get_default_grouped_gemm_configs()
     else:
         candidates = get_default_grouped_gemm_configs()
-        candidates = candidates[:1]
+        if not config.flydsl_enable_autotuning:
+            candidates = candidates[:1]
 
-    configs: list[dict[str, object]] = []
-    for grouped_config in candidates:
-        if grouped_config.TILE_M > max(128, m):
-            continue
-        if n < grouped_config.TILE_N or n % grouped_config.TILE_N != 0:
-            continue
-        if (k // grouped_config.TILE_K) < grouped_config.STAGES:
-            continue
-        gemm_config = asdict(grouped_config)
-        if not is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config):
-            continue
-        configs.append(gemm_config)
-    if not configs:
+    if not candidates:
         log.warning("No valid FlyDSL grouped GEMM configuration is available")
-    return configs
+        return []
+    return [asdict(gemm_config) for gemm_config in candidates]

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -370,3 +370,144 @@ def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
         log.warning("No valid FlyDSL grouped GEMM configuration is available")
         return []
     return [asdict(gemm_config) for gemm_config in candidates]
+
+
+# OCP MX: 32 elements share one E8M0 scale. Declared here rather than imported
+# from the vendored kernel so the lowering's shape gate stays importable
+# without the FlyDSL runtime; the two are asserted equal in the tests.
+MXFP8_SCALE_BLOCK = 32
+
+
+@dataclass(frozen=True)
+class FlyDSLMXFP8GroupedGemmConfig:
+    """Tile shape of the MXFP8 grouped GEMM kernel.
+
+    The MXFP8 kernel is not a scaled variant of the BF16 grouped kernel and
+    does not share its knobs: its contraction step is fixed at 128 elements
+    (one scaled-MFMA K), its wave split is fixed at 4x4 over one 256-thread
+    block, and its LDS ping-pong depth is fixed at 2. What remains tunable is
+    the output tile, so that is the whole config.
+    """
+
+    BLOCK_R: int = 256
+    BLOCK_C: int = 256
+
+
+class FlyDSLMXFP8GroupedGemmConfigDict(TypedDict):
+    BLOCK_R: int
+    BLOCK_C: int
+
+
+# Every tile the kernel implements. BLOCK_R below 64 puts a wave-dim half under
+# one MFMA tile (16 rows x 2 wave-rows) and the row structure stops holding;
+# BLOCK_C below 128 does the same on the column side.
+_MXFP8_GROUPED_BLOCK_R = (64, 128, 256)
+_MXFP8_GROUPED_BLOCK_C = (128, 256)
+
+
+def _make_mxfp8_grouped_gemm_param(
+    k: int, n: int, group_count: int, gemm_config: dict[str, int]
+):
+    # Keep FlyDSL optional when this heuristics module is imported.
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        make_mxfp8_grouped_gemm_param,
+    )
+
+    return make_mxfp8_grouped_gemm_param(
+        k,
+        n,
+        group_count,
+        block_r=int(gemm_config["BLOCK_R"]),
+        block_c=int(gemm_config["BLOCK_C"]),
+    )
+
+
+def is_mxfp8_grouped_gemm_config_valid_for_shape(
+    n: int,
+    k: int,
+    group_count: int,
+    gemm_config: dict[str, int],
+) -> bool:
+    """Return whether a config supports this MXFP8 grouped GEMM shape.
+
+    M is deliberately not an argument: the per-group row counts live on the
+    device and the kernel is built not to sync on them, so nothing here may
+    depend on them.
+    """
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        make_mxfp8_grouped_gemm_param_and_validate,
+    )
+
+    return (
+        make_mxfp8_grouped_gemm_param_and_validate(
+            k,
+            n,
+            group_count,
+            int(gemm_config["BLOCK_R"]),
+            int(gemm_config["BLOCK_C"]),
+        )
+        is not None
+    )
+
+
+def get_exhaustive_mxfp8_grouped_gemm_configs() -> list[FlyDSLMXFP8GroupedGemmConfig]:
+    """Return every tile the MXFP8 grouped GEMM kernel implements."""
+    return [
+        FlyDSLMXFP8GroupedGemmConfig(BLOCK_R=block_r, BLOCK_C=block_c)
+        for block_r, block_c in product(_MXFP8_GROUPED_BLOCK_R, _MXFP8_GROUPED_BLOCK_C)
+    ]
+
+
+def get_default_mxfp8_grouped_gemm_config(
+    m: int, n: int, group_count: int
+) -> FlyDSLMXFP8GroupedGemmConfig:
+    """The tile the kernel's own measured heuristic picks for this shape.
+
+    Unlike the dense and BF16-grouped defaults, this one is shape-dependent.
+    It has to be: the tile trades per-block MFMA density against how much of
+    a row tile a group actually fills and against how many blocks the grid
+    ends up with, and both terms move with (M/G, N). ``pick_tile`` is the
+    upstream kernel's own measured answer, so the single non-autotuned choice
+    is the one it makes rather than a fixed tile that is wrong at both ends.
+    """
+    from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+        pick_mxfp8_grouped_gemm_tile,
+    )
+
+    block_r, block_c = pick_mxfp8_grouped_gemm_tile(m, group_count, n)
+    return FlyDSLMXFP8GroupedGemmConfig(BLOCK_R=block_r, BLOCK_C=block_c)
+
+
+def get_mxfp8_grouped_gemm_configs(
+    m: int, n: int, k: int, group_count: int
+) -> list[dict[str, int]]:
+    """Return configs for the MXFP8 ragged grouped GEMM kernel.
+
+    Shape compatibility beyond the tile itself is checked in the lowering
+    before this function is called. By default, autotuning is disabled and we
+    return only the tile ``pick_tile`` chooses.
+    """
+    if config.flydsl_enable_autotuning:
+        candidates = get_exhaustive_mxfp8_grouped_gemm_configs()
+    else:
+        candidates = [get_default_mxfp8_grouped_gemm_config(m, n, group_count)]
+
+    valid_configs: list[FlyDSLMXFP8GroupedGemmConfig] = []
+    for gemm_config in candidates:
+        try:
+            _make_mxfp8_grouped_gemm_param(
+                k,
+                n,
+                group_count,
+                cast(dict[str, int], asdict(gemm_config)),
+            )
+            valid_configs.append(gemm_config)
+        except Exception as e:
+            log.debug(
+                "Skipping invalid FlyDSL MXFP8 grouped config %s: %s", gemm_config, e
+            )
+
+    if not valid_configs:
+        log.warning("No valid FlyDSL MXFP8 grouped GEMM configuration is available")
+        return []
+    return [asdict(gemm_config) for gemm_config in valid_configs]

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -220,9 +220,52 @@ def get_gemm_configs() -> list[dict[str, int | bool]]:
     return [asdict(gemm_config) for gemm_config in configs]
 
 
+def _is_grouped_gemm_layout_valid(
+    tile_m: int,
+    tile_n: int,
+    m_waves: int,
+    n_waves: int,
+    use_half_tile_interleaved: bool,
+) -> bool:
+    """Return whether a config satisfies grouped B-LDS and C-shuffle layouts."""
+    divisor = 2 if use_half_tile_interleaved else 1
+    effective_tile_m = tile_m // divisor
+    effective_tile_n = tile_n // divisor
+    if (
+        effective_tile_m <= 0
+        or effective_tile_n < 64
+        or effective_tile_n & (effective_tile_n - 1)
+        or m_waves <= 0
+        or n_waves <= 0
+    ):
+        return False
+
+    cshuffle_x_threads = effective_tile_n // 8
+    block_threads = m_waves * n_waves * 64
+    if block_threads % cshuffle_x_threads != 0:
+        return False
+    return effective_tile_m % (block_threads // cshuffle_x_threads) == 0
+
+
 def get_exhaustive_grouped_gemm_configs() -> list[FlyDSLGemmConfig]:
     """Return exhaustive configs for the gfx950 FlyDSL grouped GEMM kernel."""
-    return get_exhaustive_gemm_configs()
+    return [
+        gemm_config
+        for gemm_config in get_exhaustive_gemm_configs()
+        if _is_grouped_gemm_layout_valid(
+            gemm_config.TILE_M,
+            gemm_config.TILE_N,
+            gemm_config.BLOCK_M_WARPS,
+            gemm_config.BLOCK_N_WARPS,
+            gemm_config.USE_HALF_TILE_INTERLEAVED,
+        )
+    ]
+
+
+# Baseline used when FlyDSL autotuning is disabled. The dataclass defaults
+# describe the dense kernel, whose 4x4 wave split does not apply here, so the
+# grouped baseline is named explicitly; it must stay in the candidate list below.
+DEFAULT_GROUPED_GEMM_CONFIG = FlyDSLGemmConfig(128, 128, 64, 2, 1, 4, 0)
 
 
 @functools.cache
@@ -291,6 +334,8 @@ def is_grouped_gemm_config_valid_for_shape(
     tile_n = int(gemm_config["TILE_N"])
     tile_k = int(gemm_config["TILE_K"])
     stages = int(gemm_config["STAGES"])
+    m_waves = int(gemm_config["BLOCK_M_WARPS"])
+    n_waves = int(gemm_config["BLOCK_N_WARPS"])
     use_half_tile_interleaved = bool(gemm_config["USE_HALF_TILE_INTERLEAVED"])
     has_enough_k = use_half_tile_interleaved or k // tile_k >= stages
     return (
@@ -298,6 +343,9 @@ def is_grouped_gemm_config_valid_for_shape(
         and n >= tile_n
         and n % tile_n == 0
         and has_enough_k
+        and _is_grouped_gemm_layout_valid(
+            tile_m, tile_n, m_waves, n_waves, use_half_tile_interleaved
+        )
         and is_gemm_config_valid_for_shape(m, n, k, dtype_id, gemm_config)
     )
 
@@ -306,6 +354,7 @@ def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
     """Return configs for the persistent multi-stage grouped kernel.
 
     Shape compatibility is checked in the lowering before this function is called.
+    By default, autotuning is disabled and we return only a single baseline config.
     """
     if (
         config.flydsl_enable_autotuning
@@ -315,7 +364,7 @@ def get_grouped_gemm_configs() -> list[dict[str, int | bool]]:
     else:
         candidates = get_default_grouped_gemm_configs()
         if not config.flydsl_enable_autotuning:
-            candidates = candidates[:1]
+            candidates = [c for c in candidates if c == DEFAULT_GROUPED_GEMM_CONFIG]
 
     if not candidates:
         log.warning("No valid FlyDSL grouped GEMM configuration is available")

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -62,6 +62,7 @@ from ..utils import (
     use_triton_tma_template,
 )
 from .mm_common import (
+    _fits_int32_buffer_span,
     _is_static_problem,
     _use_small_mm_pointwise,
     load_kernel_template,
@@ -213,21 +214,6 @@ def check_supported_striding(mat_a, mat_b) -> None:
     torch._check(
         is_col_major(mat_b.get_stride()) or has_zero_dim(mat_b.get_size()),
         lambda: f"mat_b must be col_major, got stride {mat_b.get_stride()}",
-    )
-
-
-def _fits_int32_buffer_span(
-    rows: int, row_stride: int | None, cols: int, itemsize: int
-) -> bool:
-    # Descriptor fields are signed int32, but AMD buffer voffset is an unsigned
-    # 32-bit byte offset.
-    int32_max = (1 << 31) - 1
-    return (
-        0 < rows <= int32_max
-        and 0 < cols <= int32_max
-        and row_stride is not None
-        and 0 <= row_stride <= int32_max
-        and ((rows - 1) * row_stride + cols) * itemsize < 1 << 32
     )
 
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -214,6 +214,21 @@ def _use_small_mm_pointwise(m, k, n, layout) -> bool:
     return skt(m >= 64) and skt(k < 5) and skt(n < 5)
 
 
+def _fits_int32_buffer_span(
+    rows: int, row_stride: int | None, cols: int, itemsize: int
+) -> bool:
+    # Descriptor fields are signed int32, but AMD buffer voffset is an unsigned
+    # 32-bit byte offset.
+    int32_max = (1 << 31) - 1
+    return (
+        0 < rows <= int32_max
+        and 0 < cols <= int32_max
+        and row_stride is not None
+        and 0 <= row_stride <= int32_max
+        and ((rows - 1) * row_stride + cols) * itemsize < 1 << 32
+    )
+
+
 def _is_static_problem(layout: Layout) -> tuple[bool, bool]:
     """
     Check if input tensors and output layout have static shapes and non-zero sizes.

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -6,6 +6,7 @@ from typing import Any
 import torch
 from torch._dynamo.utils import counters
 from torch._inductor.codegen.cutedsl.cutedsl_template import CuteDSLTemplate
+from torch._inductor.codegen.flydsl.flydsl_template import FlyDSLTemplate
 from torch._inductor.heuristics.template.cutedsl import get_groupgemm_configs
 from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
@@ -25,6 +26,7 @@ from ..utils import (
     has_free_symbols,
     use_aten_gemm_kernels,
     use_blackwell_cutedsl_grouped_mm,
+    use_flydsl_gemm_template,
     use_nv_universal_gemm_template,
     use_triton_template,
 )
@@ -141,6 +143,79 @@ cutedsl_grouped_mm_template = CuteDSLTemplate(
     name="grouped_gemm_cutedsl",
     source=load_kernel_template("cutedsl_mm_grouped"),
 )
+
+flydsl_grouped_mm_template = FlyDSLTemplate(
+    name="grouped_gemm_flydsl",
+    source=load_kernel_template("flydsl_grouped_mm"),
+)
+
+
+def get_flydsl_grouped_mm_template_kwargs(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+    layout: Layout,
+    a_is_2d: bool,
+    b_is_2d: bool,
+    offs: TensorBox | None,
+    bias: TensorBox | None,
+    scale_result: TensorBox | None,
+    is_nonzero: bool,
+) -> list[dict[str, object]]:
+    from ..heuristics.template.flydsl import get_grouped_gemm_configs
+
+    if not is_nonzero or not use_flydsl_gemm_template(layout):
+        return []
+    # FlyDSL grouped GEMM only supports a 2D ragged A gathered by group offsets
+    # against a 3D [G, K, N] B; bias/scale fusion is not implemented.
+    if not (a_is_2d and not b_is_2d and offs is not None):
+        return []
+    if bias is not None or scale_result is not None:
+        return []
+    if mat_a.get_dtype() != mat_b.get_dtype() or layout.dtype != mat_a.get_dtype():
+        return []
+
+    sizevars = V.graph.sizevars
+    mat1_stride = mat_a.get_stride()
+    mat2_stride = mat_b.get_stride()
+    out_stride = layout.stride
+    if not sizevars.statically_known_equals(mat1_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-1], 1):
+        return []
+    # The grouped kernel consumes B as [G, K, N] with the N dimension contiguous.
+    if not sizevars.statically_known_equals(mat2_stride[-1], 1):
+        return []
+
+    dtype = mat_a.get_dtype()
+    if dtype not in (torch.float16, torch.bfloat16):
+        return []
+
+    n = mat_b.get_size()[-1]
+    k = mat_a.get_size()[-1]
+    try:
+        n_static = int(n)
+        k_static = int(k)
+        # Total M only prunes configs here; exact per-group sizes remain runtime
+        # values read from offs by the persistent kernel's on-device tile scan.
+        m_static = int(mat_a.get_size()[0])
+    except (TypeError, ValueError):
+        return []
+    if n_static % 32 != 0 or k_static % 32 != 0:
+        return []
+
+    from .vendored_templates.flydsl.kernels import GEMM_DTYPE_BF16, GEMM_DTYPE_FP16
+
+    dtype_id = GEMM_DTYPE_FP16 if dtype == torch.float16 else GEMM_DTYPE_BF16
+    return [
+        {
+            **gemm_config,
+            "GEMM_DTYPE_ID": dtype_id,
+            "GEMM_M": m_static,
+            "GEMM_N": n_static,
+            "GEMM_K": k_static,
+        }
+        for gemm_config in get_grouped_gemm_configs(m_static, n_static, k_static)
+    ]
 
 
 def has_grouped_mm_triton_support() -> bool:
@@ -484,6 +559,16 @@ def _tuned_grouped_mm_common(
                 **kwargs,
                 **asdict(config),
             )
+
+    for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(
+        mat_a, mat_b, layout, a_is_2d, b_is_2d, offs, bias, scale_result, is_nonzero
+    ):
+        flydsl_grouped_mm_template.maybe_append_choice(
+            choices,
+            input_nodes=input_nodes,
+            layout=layout,
+            **flydsl_kwargs,
+        )
 
     if (
         is_nonzero

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -10,11 +10,12 @@ from torch._inductor.codegen.flydsl.flydsl_template import FlyDSLTemplate
 from torch._inductor.heuristics.template.cutedsl import get_groupgemm_configs
 from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
+from torch.nn.functional import ScalingType, SwizzleType
 from torch.utils._triton import has_triton
 
 from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import ChoiceCaller, is_unaligned, Layout, TensorBox
-from ..lowering import register_lowering
+from ..lowering import fallback_handler, register_lowering
 from ..select_algorithm import (
     autotune_select_algorithm,
     ExternKernelChoice,
@@ -231,6 +232,8 @@ def get_flydsl_grouped_mm_template_kwargs(
     k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
     g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
     if m_static is None or n_static is None or k_static is None or g_static is None:
+        return []
+    if not V.graph.sizevars.statically_known_equals(offs.get_size()[0], g):
         return []
     if n_static % 32 != 0 or k_static % 32 != 0:
         return []
@@ -717,4 +720,300 @@ def tuned_scaled_grouped_mm(
         out_dtype,
         use_fast_accum,
         layout,
+    )
+
+
+flydsl_mxfp8_grouped_mm_template = FlyDSLTemplate(
+    name="mxfp8_grouped_gemm_flydsl",
+    source=load_kernel_template("flydsl_mxfp8_grouped_mm"),
+)
+
+
+def get_flydsl_mxfp8_grouped_mm_template_kwargs(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+    scale_a: TensorBox,
+    scale_b: TensorBox,
+    offs: TensorBox | None,
+    layout: Layout,
+    is_nonzero: bool,
+) -> list[dict[str, object]]:
+    """Return supported FlyDSL template configs for an MXFP8 grouped GEMM.
+
+    The recipe/swizzle/bias/multi-level gates are checked by the caller; what
+    is left here is the dtype, shape, stride and alignment contract of the
+    kernel itself.
+    """
+    from ..heuristics.template.flydsl import (
+        get_mxfp8_grouped_gemm_configs,
+        is_mxfp8_grouped_gemm_config_valid_for_shape,
+        MXFP8_SCALE_BLOCK,
+    )
+
+    if not is_nonzero or not use_flydsl_gemm_template(layout):
+        return []
+    if offs is None:
+        return []
+    # 2D ragged A gathered by group offsets against a 3D [G, K, N] B. The
+    # kernel groups the output rows, which is exactly this case and no other.
+    if len(mat_a.get_size()) != 2 or len(mat_b.get_size()) != 3:
+        return []
+    if mat_a.get_dtype() != torch.float8_e4m3fn:
+        return []
+    if mat_b.get_dtype() != torch.float8_e4m3fn:
+        return []
+    if layout.dtype != torch.bfloat16:
+        return []
+    if scale_a.get_dtype() != torch.float8_e8m0fnu:
+        return []
+    if scale_b.get_dtype() != torch.float8_e8m0fnu:
+        return []
+    if offs.get_dtype() != torch.int32:
+        return []
+    # The kernel unrolls one scalar offset load per group at trace time, so the
+    # offsets tensor has to name exactly the groups B stacks.
+    if len(offs.get_size()) != 1:
+        return []
+
+    sizevars = V.graph.sizevars
+    g = mat_b.get_size()[0]
+    k = mat_a.get_size()[-1]
+    n = mat_b.get_size()[-1]
+    m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
+    n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
+    k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
+    g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
+    if m_static is None or n_static is None or k_static is None or g_static is None:
+        return []
+
+    if k_static % MXFP8_SCALE_BLOCK != 0:
+        return []
+    scale_k = k_static // MXFP8_SCALE_BLOCK
+
+    mat_a_stride = mat_a.get_stride()
+    mat_b_stride = mat_b.get_stride()
+    scale_a_stride = scale_a.get_stride()
+    scale_b_stride = scale_b.get_stride()
+    out_stride = layout.stride
+
+    # A is (M, K) row-major and its scales are (M, K // 32) row-major.
+    if not sizevars.statically_known_equals(mat_a_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(mat_a_stride[-2], k):
+        return []
+    # B is presented as [G, K, N] but the kernel reads a stack of [N, K]
+    # row-major weight planes, i.e. exactly the "mat_b is transposed" layout
+    # every scaled GEMM already requires. Anything else would need a copy.
+    if not sizevars.statically_known_equals(mat_b_stride[-2], 1):
+        return []
+    if not sizevars.statically_known_equals(mat_b_stride[-1], k):
+        return []
+    if not sizevars.statically_known_equals(mat_b_stride[0], k * n):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-2], n):
+        return []
+
+    # Scales are the plain unswizzled MX layout the ROCm recipe asks for:
+    # (M, K // 32) for A, and the op's flat per-group stack (G, N * K // 32)
+    # for B, which is a [G, N, K // 32] plane per group.
+    if len(scale_a.get_size()) != 2 or len(scale_b.get_size()) != 2:
+        return []
+    if not sizevars.statically_known_equals(scale_a.get_size()[0], mat_a.get_size()[0]):
+        return []
+    if not sizevars.statically_known_equals(scale_a.get_size()[1], scale_k):
+        return []
+    if not sizevars.statically_known_equals(scale_a_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(scale_a_stride[-2], scale_k):
+        return []
+    if not sizevars.statically_known_equals(scale_b.get_size()[0], g):
+        return []
+    if not sizevars.statically_known_equals(scale_b.get_size()[1], n * scale_k):
+        return []
+    if not sizevars.statically_known_equals(scale_b_stride[-1], 1):
+        return []
+    if not sizevars.statically_known_equals(scale_b_stride[-2], n * scale_k):
+        return []
+
+    # Every operand is read through 16-byte buffer loads, so an operand that
+    # starts mid-vector cannot be served. fp8 and e8m0 are both one byte, so
+    # the element offset is the byte offset.
+    operands = (mat_a, mat_b, scale_a, scale_b)
+    if any(is_unaligned(node) for node in operands):
+        return []
+    if any(
+        not sizevars.statically_known_multiple_of(
+            node.get_layout().offset, GPU_ALIGN_BYTES
+        )
+        for node in operands
+    ):
+        return []
+
+    # The kernel addresses every operand through a 32-bit buffer descriptor.
+    # `_row_windows` splits the token dim so the M-dependent operands always
+    # fit, but the weight and its scales are not split and must fit outright.
+    weight_spans = (
+        (g_static, n_static * k_static, n_static * k_static),
+        (g_static, n_static * scale_k, n_static * scale_k),
+    )
+    if any(
+        not _fits_int32_buffer_span(rows, stride, cols, 1)
+        for rows, stride, cols in weight_spans
+    ):
+        return []
+
+    return [
+        {
+            **gemm_config,
+            "GEMM_G": g_static,
+            "GEMM_N": n_static,
+            "GEMM_K": k_static,
+        }
+        for gemm_config in get_mxfp8_grouped_gemm_configs(
+            m_static, n_static, k_static, g_static
+        )
+        if is_mxfp8_grouped_gemm_config_valid_for_shape(
+            n_static, k_static, g_static, gemm_config
+        )
+    ]
+
+
+# The op takes recipes and swizzles as plain ints, and the pybind enums compare
+# equal to neither ints nor freshly constructed instances of themselves, so the
+# two the lowering can serve are pinned to their integer values here.
+_MXFP8_SCALE_RECIPE = int(ScalingType.BlockWise1x32)
+_NO_SWIZZLE = int(SwizzleType.NO_SWIZZLE)
+
+
+# Inductor has no template or extern choice for most _scaled_grouped_mm_v2
+# recipes; defer those to the eager op exactly as the absence of a lowering
+# used to. add_to_fallback_set is False because this handler is invoked from
+# the lowering below rather than registered as the op's global fallback.
+scaled_grouped_mm_v2_fallback = fallback_handler(
+    aten._scaled_grouped_mm_v2.default, add_to_fallback_set=False
+)
+
+
+@register_lowering(aten._scaled_grouped_mm_v2.default, type_promotion_kind=None)
+def tuned_scaled_grouped_mm_v2(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+    scale_a: list[Any],
+    scale_recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[Any],
+    scale_recipe_b: list[int],
+    swizzle_b: list[int],
+    offs: TensorBox | None = None,
+    bias: TensorBox | None = None,
+    out_dtype: torch.dtype | None = None,
+    contraction_dim: list[int] | None = None,
+    use_fast_accum: bool = False,
+    layout: Layout | None = None,
+) -> TensorBox:
+    """Auto-tuning for the _scaled_grouped_mm_v2() operator.
+
+    Only one combination has a lowering here: MXFP8 x MXFP8 (BlockWise1x32
+    e8m0 scales, NO_SWIZZLE) on gfx950, served by the vendored FlyDSL ragged
+    grouped GEMM. That combination has no ATen kernel on ROCm at all -- the
+    MSLK grouped path is CUDA-only and `_mx8_mx8_bf16_grouped_mm_mslk` raises
+    NOT_IMPLEMENTED there -- so the FlyDSL template is not competing with an
+    extern choice, it is the only one, and no ATen choice is offered for it.
+    Everything else falls back to the eager op, which is what happened before
+    this lowering existed.
+    """
+
+    def _is_mxfp8_recipe(recipe: list[int]) -> bool:
+        return len(recipe) == 1 and int(recipe[0]) == _MXFP8_SCALE_RECIPE
+
+    is_single_level_scale = len(scale_a) == 1 and len(scale_b) == 1
+    is_mxfp8 = (
+        is_single_level_scale
+        and _is_mxfp8_recipe(scale_recipe_a)
+        and _is_mxfp8_recipe(scale_recipe_b)
+        # An empty swizzle list is how F.scaled_grouped_mm spells "none".
+        and not any(int(s) != _NO_SWIZZLE for s in swizzle_a)
+        and not any(int(s) != _NO_SWIZZLE for s in swizzle_b)
+        and bias is None
+        # contraction_dim overrides which dim is K; the kernel only implements
+        # the default (A dim 1, B dim 1 of a [G, K, N] operand).
+        and not contraction_dim
+    )
+
+    if is_mxfp8 and offs is not None:
+        m1_size, m2_size, mm_layout, mat_a, mat_b, offs = grouped_mm_args(
+            mat_a, mat_b, offs, layout=layout, out_dtype=out_dtype or torch.bfloat16
+        )
+        _, is_nonzero = _is_static_problem(mm_layout)
+        scale_a_real, scale_b_real = realize_inputs(scale_a[0], scale_b[0])
+        input_nodes: list[Any] = [
+            mat_a,
+            mat_b,
+            scale_a_real,
+            scale_b_real,
+            realize_inputs(offs),
+        ]
+
+        choices: list[ChoiceCaller] = []
+        for flydsl_kwargs in get_flydsl_mxfp8_grouped_mm_template_kwargs(
+            mat_a,
+            mat_b,
+            scale_a_real,
+            scale_b_real,
+            offs,
+            mm_layout,
+            is_nonzero,
+        ):
+            flydsl_mxfp8_grouped_mm_template.maybe_append_choice(
+                choices,
+                input_nodes=input_nodes,
+                layout=mm_layout,
+                **flydsl_kwargs,
+            )
+
+        if choices:
+            counters["aten_mm_info"]["aten._scaled_grouped_mm_v2.default"] += 1
+            log.info(
+                "Tuned aten._scaled_grouped_mm_v2.default: mat1_shape=%s, "
+                "mat2_shape=%s, mat1_dtype=%s, mat2_dtype=%s, output_layout=%s",
+                m1_size,
+                m2_size,
+                mat_a.get_dtype(),
+                mat_b.get_dtype(),
+                mm_layout,
+            )
+            m, k = m1_size
+            n = m2_size[-1]
+            input_gen_fns = {
+                4: lambda x: create_offsets(
+                    x, True, False, m, n, k, 16 // mat_a.dtype.itemsize
+                )
+            }
+            node, _ = autotune_select_algorithm(
+                "scaled_grouped_mm_v2",
+                choices,
+                input_nodes,
+                mm_layout,
+                input_gen_fns=input_gen_fns,
+            )
+            return node
+
+    # contraction_dim is a non-optional int[] in the schema (default []); this
+    # lowering defaults it to None, so coerce before the eager call.
+    return scaled_grouped_mm_v2_fallback(
+        mat_a,
+        mat_b,
+        scale_a,
+        scale_recipe_a,
+        swizzle_a,
+        scale_b,
+        scale_recipe_b,
+        swizzle_b,
+        offs,
+        bias,
+        out_dtype,
+        [] if contraction_dim is None else contraction_dim,
+        use_fast_accum,
     )

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -12,6 +12,7 @@ from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
 from torch.utils._triton import has_triton
 
+from ..codegen.wrapper import PythonWrapperCodegen
 from ..ir import ChoiceCaller, is_unaligned, Layout, TensorBox
 from ..lowering import register_lowering
 from ..select_algorithm import (
@@ -32,6 +33,7 @@ from ..utils import (
     use_triton_template,
 )
 from .mm_common import (
+    _fits_int32_buffer_span,
     _is_static_problem,
     check_supported_striding,
     load_kernel_template,
@@ -163,7 +165,10 @@ def get_flydsl_grouped_mm_template_kwargs(
     is_nonzero: bool,
 ) -> list[dict[str, object]]:
     """Return supported FlyDSL template configs for grouped matrix multiplication."""
-    from ..heuristics.template.flydsl import get_grouped_gemm_configs
+    from ..heuristics.template.flydsl import (
+        get_grouped_gemm_configs,
+        is_grouped_gemm_config_valid_for_shape,
+    )
 
     if not is_nonzero or not use_flydsl_gemm_template(layout):
         return []
@@ -219,27 +224,25 @@ def get_flydsl_grouped_mm_template_kwargs(
     ):
         return []
 
-    try:
-        n_static = int(n)
-        k_static = int(k)
-        g_static = int(g)
-        # Total M only prunes configs here; exact per-group sizes remain runtime
-        # values read from offs by the persistent kernel's on-device tile scan.
-        m_static = int(mat_a.get_size()[0])
-    except (TypeError, ValueError):
+    # Total M only prunes configs here; exact per-group sizes remain runtime
+    # values read from offs by the persistent kernel's on-device tile scan.
+    m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
+    n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
+    k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
+    g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
+    if m_static is None or n_static is None or k_static is None or g_static is None:
         return []
     if n_static % 32 != 0 or k_static % 32 != 0:
         return []
-    int32_max = (1 << 31) - 1
-    dimensions = (m_static, n_static, k_static, g_static)
-    if any(dim <= 0 or dim > int32_max for dim in dimensions):
-        return []
     tensor_spans = (
-        m_static * k_static,
-        g_static * k_static * n_static,
-        m_static * n_static,
+        (m_static, k_static, k_static),
+        (g_static, k_static * n_static, k_static * n_static),
+        (m_static, n_static, n_static),
     )
-    if any(span * itemsize >= 1 << 32 for span in tensor_spans):
+    if any(
+        not _fits_int32_buffer_span(rows, stride, cols, itemsize)
+        for rows, stride, cols in tensor_spans
+    ):
         return []
 
     from .vendored_templates.flydsl.kernels import GEMM_DTYPE_BF16, GEMM_DTYPE_FP16
@@ -253,8 +256,9 @@ def get_flydsl_grouped_mm_template_kwargs(
             "GEMM_N": n_static,
             "GEMM_K": k_static,
         }
-        for gemm_config in get_grouped_gemm_configs(
-            m_static, n_static, k_static, dtype_id
+        for gemm_config in get_grouped_gemm_configs()
+        if is_grouped_gemm_config_valid_for_shape(
+            m_static, n_static, k_static, dtype_id, gemm_config
         )
     ]
 

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -12,7 +12,7 @@ from torch._inductor.runtime.triton_compat import tl
 from torch._inductor.virtualized import V
 from torch.utils._triton import has_triton
 
-from ..ir import ChoiceCaller, Layout, TensorBox
+from ..ir import ChoiceCaller, is_unaligned, Layout, TensorBox
 from ..lowering import register_lowering
 from ..select_algorithm import (
     autotune_select_algorithm,
@@ -23,6 +23,7 @@ from ..select_algorithm import (
 from ..utils import (
     get_gpu_shared_memory,
     get_num_sms,
+    GPU_ALIGN_BYTES,
     has_free_symbols,
     use_aten_gemm_kernels,
     use_blackwell_cutedsl_grouped_mm,
@@ -161,6 +162,7 @@ def get_flydsl_grouped_mm_template_kwargs(
     scale_result: TensorBox | None,
     is_nonzero: bool,
 ) -> list[dict[str, object]]:
+    """Return supported FlyDSL template configs for grouped matrix multiplication."""
     from ..heuristics.template.flydsl import get_grouped_gemm_configs
 
     if not is_nonzero or not use_flydsl_gemm_template(layout):
@@ -192,15 +194,52 @@ def get_flydsl_grouped_mm_template_kwargs(
 
     n = mat_b.get_size()[-1]
     k = mat_a.get_size()[-1]
+    g = mat_b.get_size()[0]
+    if not sizevars.statically_known_equals(mat1_stride[-2], k):
+        return []
+    if not sizevars.statically_known_equals(mat2_stride[-2], n):
+        return []
+    if not sizevars.statically_known_equals(mat2_stride[-3], k * n):
+        return []
+    if not sizevars.statically_known_equals(out_stride[-2], n):
+        return []
+
+    itemsize = dtype.itemsize
+    aligned_byte_offsets = (
+        mat_a.get_layout().offset * itemsize,
+        mat_b.get_layout().offset * itemsize,
+    )
+    if (
+        is_unaligned(mat_a)
+        or is_unaligned(mat_b)
+        or any(
+            not sizevars.statically_known_multiple_of(offset, GPU_ALIGN_BYTES)
+            for offset in aligned_byte_offsets
+        )
+    ):
+        return []
+
     try:
         n_static = int(n)
         k_static = int(k)
+        g_static = int(g)
         # Total M only prunes configs here; exact per-group sizes remain runtime
         # values read from offs by the persistent kernel's on-device tile scan.
         m_static = int(mat_a.get_size()[0])
     except (TypeError, ValueError):
         return []
     if n_static % 32 != 0 or k_static % 32 != 0:
+        return []
+    int32_max = (1 << 31) - 1
+    dimensions = (m_static, n_static, k_static, g_static)
+    if any(dim <= 0 or dim > int32_max for dim in dimensions):
+        return []
+    tensor_spans = (
+        m_static * k_static,
+        g_static * k_static * n_static,
+        m_static * n_static,
+    )
+    if any(span * itemsize >= 1 << 32 for span in tensor_spans):
         return []
 
     from .vendored_templates.flydsl.kernels import GEMM_DTYPE_BF16, GEMM_DTYPE_FP16
@@ -214,7 +253,9 @@ def get_flydsl_grouped_mm_template_kwargs(
             "GEMM_N": n_static,
             "GEMM_K": k_static,
         }
-        for gemm_config in get_grouped_gemm_configs(m_static, n_static, k_static)
+        for gemm_config in get_grouped_gemm_configs(
+            m_static, n_static, k_static, dtype_id
+        )
     ]
 
 
@@ -560,15 +601,24 @@ def _tuned_grouped_mm_common(
                 **asdict(config),
             )
 
-    for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(
-        mat_a, mat_b, layout, a_is_2d, b_is_2d, offs, bias, scale_result, is_nonzero
-    ):
-        flydsl_grouped_mm_template.maybe_append_choice(
-            choices,
-            input_nodes=input_nodes,
-            layout=layout,
-            **flydsl_kwargs,
-        )
+    if not scaled:
+        for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(
+            mat_a,
+            mat_b,
+            layout,
+            a_is_2d,
+            b_is_2d,
+            offs,
+            bias,
+            scale_result,
+            is_nonzero,
+        ):
+            flydsl_grouped_mm_template.maybe_append_choice(
+                choices,
+                input_nodes=input_nodes,
+                layout=layout,
+                **flydsl_kwargs,
+            )
 
     if (
         is_nonzero

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -154,6 +154,32 @@ flydsl_grouped_mm_template = FlyDSLTemplate(
 )
 
 
+def _flydsl_grouped_static_shape(
+    mat_a: TensorBox, mat_b: TensorBox, offs: TensorBox
+) -> tuple[int, int, int, int] | None:
+    """(M, N, K, G) as ints for a 2D-ragged x 3D grouped GEMM, or None.
+
+    None means one of them is dynamic, or `offs` does not name exactly the
+    groups B stacks. Total M only prunes configs -- the exact per-group sizes
+    stay runtime values that the kernel reads from `offs` on device -- but the
+    other three are compile keys, so a dynamic one has to decline the template.
+    Shared by the BF16 and MXFP8 grouped gates so the two cannot drift.
+    """
+    g = mat_b.get_size()[0]
+    k = mat_a.get_size()[-1]
+    n = mat_b.get_size()[-1]
+    statically_known = PythonWrapperCodegen.statically_known_int_or_none
+    m_static = statically_known(mat_a.get_size()[0])
+    n_static = statically_known(n)
+    k_static = statically_known(k)
+    g_static = statically_known(g)
+    if m_static is None or n_static is None or k_static is None or g_static is None:
+        return None
+    if not V.graph.sizevars.statically_known_equals(offs.get_size()[0], g):
+        return None
+    return m_static, n_static, k_static, g_static
+
+
 def get_flydsl_grouped_mm_template_kwargs(
     mat_a: TensorBox,
     mat_b: TensorBox,
@@ -225,16 +251,10 @@ def get_flydsl_grouped_mm_template_kwargs(
     ):
         return []
 
-    # Total M only prunes configs here; exact per-group sizes remain runtime
-    # values read from offs by the persistent kernel's on-device tile scan.
-    m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
-    n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
-    k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
-    g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
-    if m_static is None or n_static is None or k_static is None or g_static is None:
+    static_shape = _flydsl_grouped_static_shape(mat_a, mat_b, offs)
+    if static_shape is None:
         return []
-    if not V.graph.sizevars.statically_known_equals(offs.get_size()[0], g):
-        return []
+    m_static, n_static, k_static, g_static = static_shape
     if n_static % 32 != 0 or k_static % 32 != 0:
         return []
     tensor_spans = (
@@ -779,12 +799,10 @@ def get_flydsl_mxfp8_grouped_mm_template_kwargs(
     g = mat_b.get_size()[0]
     k = mat_a.get_size()[-1]
     n = mat_b.get_size()[-1]
-    m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
-    n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
-    k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
-    g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
-    if m_static is None or n_static is None or k_static is None or g_static is None:
+    static_shape = _flydsl_grouped_static_shape(mat_a, mat_b, offs)
+    if static_shape is None:
         return []
+    m_static, n_static, k_static, g_static = static_shape
 
     if k_static % MXFP8_SCALE_BLOCK != 0:
         return []

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -1,0 +1,206 @@
+import contextlib
+import os
+import threading
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+    get_grouped_gemm_persistent_grid_size,
+    infer_has_k_tail,
+    launch_gemm_gfx950_grouped,
+    make_gemm_param_and_validate,
+)
+from torch._inductor.runtime.flydsl_cache import (
+    ensure_flydsl_cache_dir,
+    run_cached_flydsl,
+)
+
+{{gen_defines()}}
+
+
+_grouped_param = None
+_grouped_executor = None
+_grouped_init_lock = threading.Lock()
+_grouped_grid_key = None
+_grouped_grid_size = None
+
+
+def _inductor_tensor_arg(tensor):
+    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
+
+
+@contextlib.contextmanager
+def _temporary_env(updates):
+    old_values = {key: os.environ.get(key) for key in updates}
+    os.environ.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    try:
+        yield
+    finally:
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
+    global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
+    group_count, k, n = mat2.shape
+    total_m = mat1.shape[0]
+    if total_m == 0:
+        return output
+
+    executor = _grouped_executor
+    param = _grouped_param
+    if executor is None and param is None:
+        with _grouped_init_lock:
+            param = _grouped_param
+            if param is None:
+                has_k_tail = infer_has_k_tail(GEMM_K, TILE_K, STAGES)
+                param = make_gemm_param_and_validate(
+                    GEMM_M,
+                    GEMM_N,
+                    GEMM_K,
+                    {
+                        "dtype_id": GEMM_DTYPE_ID,
+                        "block_m": TILE_M,
+                        "block_n": TILE_N,
+                        "block_k": TILE_K,
+                        "stages": STAGES,
+                        "m_waves": BLOCK_M_WARPS,
+                        "n_waves": BLOCK_N_WARPS,
+                        "group_m": GROUP_M,
+                        "use_half_tile_interleaved": USE_HALF_TILE_INTERLEAVED,
+                        "has_bias": False,
+                        "has_k_tail": has_k_tail,
+                    },
+                )
+                assert param is not None, "unsupported FlyDSL grouped GEMM shape/config"
+                _grouped_param = param
+                _grouped_grid_key = None
+    assert param is not None
+
+    group_count = int(group_count)
+    total_m = int(total_m)
+    n_int = int(n)
+    k_int = int(k)
+    if os.environ.get("COMPILE_ONLY"):
+        grid_size = 1
+    else:
+        grid_key = (total_m, n_int, group_count, mat1.device)
+        if grid_key != _grouped_grid_key:
+            _grouped_grid_size = get_grouped_gemm_persistent_grid_size(
+                param,
+                total_m,
+                n_int,
+                group_count,
+                torch.cuda.get_device_properties(mat1.device),
+            )
+            _grouped_grid_key = grid_key
+        grid_size = _grouped_grid_size
+    output_mn = output.view(-1, n)
+    mat1_mk = mat1.view(-1, k)
+    compile_args = (
+        _inductor_tensor_arg(output_mn),
+        _inductor_tensor_arg(mat1_mk),
+        _inductor_tensor_arg(mat2),
+        _inductor_tensor_arg(offs),
+        group_count,
+        n_int,
+        k_int,
+        grid_size,
+        param,
+        stream,
+    )
+    dispatch_args = (
+        output_mn,
+        mat1_mk,
+        mat2,
+        offs,
+        group_count,
+        n_int,
+        k_int,
+        grid_size,
+        param,
+        stream,
+    )
+    if executor is not None:
+        executor(*dispatch_args)
+        return output
+
+    with _grouped_init_lock:
+        executor = _grouped_executor
+        if executor is None:
+            ensure_flydsl_cache_dir()
+            if os.environ.get("COMPILE_ONLY"):
+                flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
+            else:
+                executor = run_cached_flydsl(
+                    launch_gemm_gfx950_grouped,
+                    *compile_args,
+                    constexpr_param=param,
+                    compiler=flyc.compile,
+                    dispatch_args=dispatch_args,
+                )
+                _grouped_executor = executor
+            return output
+
+    executor(*dispatch_args)
+    return output
+
+
+{{def_kernel("mat1", "mat2", "offs")}}
+    output = {{get_output()}}
+    return _flydsl_grouped_mm(output, mat1, mat2, offs, stream)
+
+
+def {{kernel_name}}_precompile(
+    precompile_shapes,
+    precompile_strides,
+    precompile_dtypes,
+    device_index=0,
+    device_capability=None,
+    flydsl_gpu_arch=None,
+):
+    """Warm FlyDSL's disk cache using metadata-only fake tensors."""
+    dtype_mat1 = getattr(torch, precompile_dtypes["mat1"])
+    dtype_mat2 = getattr(torch, precompile_dtypes["mat2"])
+    dtype_offs = getattr(torch, precompile_dtypes["offs"])
+    dtype_output = getattr(torch, precompile_dtypes["output"])
+
+    shape_mat1 = tuple(precompile_shapes["mat1"])
+    shape_mat2 = tuple(precompile_shapes["mat2"])
+    shape_offs = tuple(precompile_shapes["offs"])
+    shape_output = tuple(precompile_shapes["output"])
+
+    stride_mat1 = tuple(precompile_strides["mat1"])
+    stride_mat2 = tuple(precompile_strides["mat2"])
+    stride_offs = tuple(precompile_strides["offs"])
+    stride_output = tuple(precompile_strides["output"])
+
+    env_updates = {"COMPILE_ONLY": "1"}
+    if flydsl_gpu_arch is not None:
+        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
+
+    with _temporary_env(env_updates):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+
+            def _fake_proxy(shape, stride, dtype):
+                return torch.empty_strided(shape, stride, dtype=dtype, device="cpu")
+
+            mat1 = _fake_proxy(shape_mat1, stride_mat1, dtype_mat1)
+            mat2 = _fake_proxy(shape_mat2, stride_mat2, dtype_mat2)
+            offs = _fake_proxy(shape_offs, stride_offs, dtype_offs)
+            output = _fake_proxy(shape_output, stride_output, dtype_output)
+
+            try:
+                {{kernel_name}}_main(mat1, mat2, offs, output, stream=0)
+            finally:
+                global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
+                with _grouped_init_lock:
+                    _grouped_executor = None
+                    _grouped_grid_key = None
+                    _grouped_grid_size = None
+                    _grouped_param = None

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -102,25 +102,11 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
             )
             _grouped_grid_key = grid_key
         grid_size = _grouped_grid_size
-    output_mn = output.view(-1, n)
-    mat1_mk = mat1.view(-1, k)
     compile_args = (
-        _inductor_tensor_arg(output_mn),
-        _inductor_tensor_arg(mat1_mk),
+        _inductor_tensor_arg(output),
+        _inductor_tensor_arg(mat1),
         _inductor_tensor_arg(mat2),
         _inductor_tensor_arg(offs),
-        group_count,
-        n_int,
-        k_int,
-        grid_size,
-        param,
-        stream,
-    )
-    dispatch_args = (
-        output_mn,
-        mat1_mk,
-        mat2,
-        offs,
         group_count,
         n_int,
         k_int,
@@ -137,7 +123,18 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
             *compile_args,
             constexpr_param=param,
             compiler=flyc.compile,
-            dispatch_args=dispatch_args,
+            dispatch_args=(
+                output,
+                mat1,
+                mat2,
+                offs,
+                group_count,
+                n_int,
+                k_int,
+                grid_size,
+                param,
+                stream,
+            ),
         )
     return output
 

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -18,8 +18,6 @@ from torch._inductor.runtime.flydsl_cache import (
 
 _grouped_param = None
 _grouped_param_lock = threading.Lock()
-_grouped_grid_key = None
-_grouped_grid_size = None
 
 
 def _inductor_tensor_arg(tensor):
@@ -43,7 +41,7 @@ def _temporary_env(updates):
 
 
 def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
-    global _grouped_grid_key, _grouped_grid_size, _grouped_param
+    global _grouped_param
     group_count, k, n = mat2.shape
     total_m = mat1.shape[0]
     if total_m == 0:
@@ -82,26 +80,25 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
                         f"tile=({TILE_M}, {TILE_N}, {TILE_K}), stages={STAGES}"
                     )
                 _grouped_param = param
-                _grouped_grid_key = None
 
     group_count = int(group_count)
     total_m = int(total_m)
     n_int = int(n)
     k_int = int(k)
-    if os.environ.get("FLYDSL_COMPILE_ONLY"):
+    compile_only = bool(os.environ.get("FLYDSL_COMPILE_ONLY"))
+    if compile_only:
+        # Precompilation runs on fake tensors that have no device to query, and
+        # the persistent kernel reads its grid from gridDim, so the size the disk
+        # cache is warmed with does not have to match the one used at runtime.
         grid_size = 1
     else:
-        grid_key = (total_m, n_int, group_count, mat1.device)
-        if grid_key != _grouped_grid_key:
-            _grouped_grid_size = get_grouped_gemm_persistent_grid_size(
-                param,
-                total_m,
-                n_int,
-                group_count,
-                torch.cuda.get_device_properties(mat1.device),
-            )
-            _grouped_grid_key = grid_key
-        grid_size = _grouped_grid_size
+        grid_size = get_grouped_gemm_persistent_grid_size(
+            param,
+            total_m,
+            n_int,
+            group_count,
+            torch.cuda.get_device_properties(mat1.device),
+        )
     compile_args = (
         _inductor_tensor_arg(output),
         _inductor_tensor_arg(mat1),
@@ -115,7 +112,7 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
         stream,
     )
     ensure_flydsl_cache_dir()
-    if os.environ.get("FLYDSL_COMPILE_ONLY"):
+    if compile_only:
         flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
     else:
         run_cached_flydsl(

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -17,8 +17,7 @@ from torch._inductor.runtime.flydsl_cache import (
 
 
 _grouped_param = None
-_grouped_executor = None
-_grouped_init_lock = threading.Lock()
+_grouped_param_lock = threading.Lock()
 _grouped_grid_key = None
 _grouped_grid_size = None
 
@@ -44,19 +43,20 @@ def _temporary_env(updates):
 
 
 def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
-    global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
+    global _grouped_grid_key, _grouped_grid_size, _grouped_param
     group_count, k, n = mat2.shape
     total_m = mat1.shape[0]
     if total_m == 0:
         return output
 
-    executor = _grouped_executor
     param = _grouped_param
-    if executor is None and param is None:
-        with _grouped_init_lock:
+    if param is None:
+        with _grouped_param_lock:
             param = _grouped_param
             if param is None:
                 has_k_tail = infer_has_k_tail(GEMM_K, TILE_K, STAGES)
+                if USE_HALF_TILE_INTERLEAVED:
+                    has_k_tail = has_k_tail or (((GEMM_K + TILE_K - 1) // TILE_K) % 2 != 0)
                 param = make_gemm_param_and_validate(
                     GEMM_M,
                     GEMM_N,
@@ -75,16 +75,20 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
                         "has_k_tail": has_k_tail,
                     },
                 )
-                assert param is not None, "unsupported FlyDSL grouped GEMM shape/config"
+                if param is None:
+                    raise RuntimeError(
+                        f"unsupported FlyDSL grouped GEMM shape/config: M={GEMM_M}, "
+                        f"N={GEMM_N}, K={GEMM_K}, "
+                        f"tile=({TILE_M}, {TILE_N}, {TILE_K}), stages={STAGES}"
+                    )
                 _grouped_param = param
                 _grouped_grid_key = None
-    assert param is not None
 
     group_count = int(group_count)
     total_m = int(total_m)
     n_int = int(n)
     k_int = int(k)
-    if os.environ.get("COMPILE_ONLY"):
+    if os.environ.get("FLYDSL_COMPILE_ONLY"):
         grid_size = 1
     else:
         grid_key = (total_m, n_int, group_count, mat1.device)
@@ -124,28 +128,17 @@ def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
         param,
         stream,
     )
-    if executor is not None:
-        executor(*dispatch_args)
-        return output
-
-    with _grouped_init_lock:
-        executor = _grouped_executor
-        if executor is None:
-            ensure_flydsl_cache_dir()
-            if os.environ.get("COMPILE_ONLY"):
-                flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
-            else:
-                executor = run_cached_flydsl(
-                    launch_gemm_gfx950_grouped,
-                    *compile_args,
-                    constexpr_param=param,
-                    compiler=flyc.compile,
-                    dispatch_args=dispatch_args,
-                )
-                _grouped_executor = executor
-            return output
-
-    executor(*dispatch_args)
+    ensure_flydsl_cache_dir()
+    if os.environ.get("FLYDSL_COMPILE_ONLY"):
+        flyc.compile(launch_gemm_gfx950_grouped, *compile_args)
+    else:
+        run_cached_flydsl(
+            launch_gemm_gfx950_grouped,
+            *compile_args,
+            constexpr_param=param,
+            compiler=flyc.compile,
+            dispatch_args=dispatch_args,
+        )
     return output
 
 
@@ -178,7 +171,7 @@ def {{kernel_name}}_precompile(
     stride_offs = tuple(precompile_strides["offs"])
     stride_output = tuple(precompile_strides["output"])
 
-    env_updates = {"COMPILE_ONLY": "1"}
+    env_updates = {"FLYDSL_COMPILE_ONLY": "1"}
     if flydsl_gpu_arch is not None:
         env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
 
@@ -194,13 +187,4 @@ def {{kernel_name}}_precompile(
             mat2 = _fake_proxy(shape_mat2, stride_mat2, dtype_mat2)
             offs = _fake_proxy(shape_offs, stride_offs, dtype_offs)
             output = _fake_proxy(shape_output, stride_output, dtype_output)
-
-            try:
-                {{kernel_name}}_main(mat1, mat2, offs, output, stream=0)
-            finally:
-                global _grouped_executor, _grouped_grid_key, _grouped_grid_size, _grouped_param
-                with _grouped_init_lock:
-                    _grouped_executor = None
-                    _grouped_grid_key = None
-                    _grouped_grid_size = None
-                    _grouped_param = None
+            {{kernel_name}}_main(mat1, mat2, offs, output, stream=0)

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
@@ -35,7 +35,9 @@ def _temporary_env(updates):
                 os.environ[key] = old_value
 
 
-def _flydsl_mxfp8_grouped_mm(output, mat1, mat2, scale_a, scale_b, offs, stream):
+def _flydsl_mxfp8_grouped_mm(
+    output, mat1, mat2, scale_a, scale_b, offs, stream, compile_only=False
+):
     global _mxfp8_grouped_param
     if output.shape[0] == 0:
         return output
@@ -70,9 +72,11 @@ def _flydsl_mxfp8_grouped_mm(output, mat1, mat2, scale_a, scale_b, offs, stream)
         param,
         stream,
         tensor_arg=_inductor_tensor_arg,
-        # Precompilation runs on fake tensors, so it may warm the cache but
-        # must not dispatch.
-        compile_only=bool(os.environ.get("FLYDSL_COMPILE_ONLY")),
+        # Passed down rather than read from the environment: cache warming and
+        # a real dispatch can share a process (autotune_in_subproc=False), and
+        # a process-global flag would let a real call skip the GEMM and return
+        # the uninitialised output buffer.
+        compile_only=compile_only,
     )
     return output
 
@@ -95,7 +99,9 @@ def {{kernel_name}}_precompile(
     """Warm FlyDSL's disk cache using metadata-only fake tensors."""
     names = ("mat1", "mat2", "scale_a", "scale_b", "offs", "output")
 
-    env_updates = {"FLYDSL_COMPILE_ONLY": "1"}
+    # FLYDSL_GPU_ARCH is read by FlyDSL itself, so it has to go through the
+    # environment; compile-only is ours and is passed as an argument instead.
+    env_updates = {}
     if flydsl_gpu_arch is not None:
         env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
 
@@ -112,12 +118,13 @@ def {{kernel_name}}_precompile(
                 )
                 for name in names
             }
-            {{kernel_name}}_main(
+            _flydsl_mxfp8_grouped_mm(
+                fakes["output"],
                 fakes["mat1"],
                 fakes["mat2"],
                 fakes["scale_a"],
                 fakes["scale_b"],
                 fakes["offs"],
-                fakes["output"],
                 stream=0,
+                compile_only=True,
             )

--- a/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mxfp8_grouped_mm.py.jinja
@@ -1,0 +1,123 @@
+import contextlib
+import os
+import threading
+
+from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
+    launch_mxfp8_grouped_gemm_gfx950,
+    make_mxfp8_grouped_gemm_param,
+)
+from torch._inductor.runtime.flydsl_cache import ensure_flydsl_cache_dir
+
+{{gen_defines()}}
+
+
+_mxfp8_grouped_param = None
+_mxfp8_grouped_param_lock = threading.Lock()
+
+
+def _inductor_tensor_arg(tensor):
+    return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
+
+
+@contextlib.contextmanager
+def _temporary_env(updates):
+    old_values = {key: os.environ.get(key) for key in updates}
+    os.environ.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    try:
+        yield
+    finally:
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
+
+
+def _flydsl_mxfp8_grouped_mm(output, mat1, mat2, scale_a, scale_b, offs, stream):
+    global _mxfp8_grouped_param
+    if output.shape[0] == 0:
+        return output
+
+    param = _mxfp8_grouped_param
+    if param is None:
+        with _mxfp8_grouped_param_lock:
+            param = _mxfp8_grouped_param
+            if param is None:
+                param = make_mxfp8_grouped_gemm_param(
+                    GEMM_K,
+                    GEMM_N,
+                    GEMM_G,
+                    block_r=BLOCK_R,
+                    block_c=BLOCK_C,
+                )
+                _mxfp8_grouped_param = param
+
+    # The kernel reads B as a stack of [N, K] row-major weight planes. The
+    # lowering already required mat2's K dim to be the contiguous one, so this
+    # permute is a free relabelling of a contiguous buffer, not a copy.
+    weight = mat2.permute(0, 2, 1)
+    # scale_b arrives as the op's flat per-group scale stack, (G, N * K // 32).
+    ensure_flydsl_cache_dir()
+    launch_mxfp8_grouped_gemm_gfx950(
+        output,
+        mat1,
+        weight,
+        scale_a,
+        scale_b,
+        offs,
+        param,
+        stream,
+        tensor_arg=_inductor_tensor_arg,
+        # Precompilation runs on fake tensors, so it may warm the cache but
+        # must not dispatch.
+        compile_only=bool(os.environ.get("FLYDSL_COMPILE_ONLY")),
+    )
+    return output
+
+
+{{def_kernel("mat1", "mat2", "scale_a", "scale_b", "offs")}}
+    output = {{get_output()}}
+    return _flydsl_mxfp8_grouped_mm(
+        output, mat1, mat2, scale_a, scale_b, offs, stream
+    )
+
+
+def {{kernel_name}}_precompile(
+    precompile_shapes,
+    precompile_strides,
+    precompile_dtypes,
+    device_index=0,
+    device_capability=None,
+    flydsl_gpu_arch=None,
+):
+    """Warm FlyDSL's disk cache using metadata-only fake tensors."""
+    names = ("mat1", "mat2", "scale_a", "scale_b", "offs", "output")
+
+    env_updates = {"FLYDSL_COMPILE_ONLY": "1"}
+    if flydsl_gpu_arch is not None:
+        env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
+
+    with _temporary_env(env_updates):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with FakeTensorMode():
+            fakes = {
+                name: torch.empty_strided(
+                    tuple(precompile_shapes[name]),
+                    tuple(precompile_strides[name]),
+                    dtype=getattr(torch, precompile_dtypes[name]),
+                    device="cpu",
+                )
+                for name in names
+            }
+            {{kernel_name}}_main(
+                fakes["mat1"],
+                fakes["mat2"],
+                fakes["scale_a"],
+                fakes["scale_b"],
+                fakes["offs"],
+                fakes["output"],
+                stream=0,
+            )

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -4,20 +4,24 @@ import importlib
 from typing import Any
 
 
-__all__ = [
-    "GEMM_DTYPE_BF16",
-    "GEMM_DTYPE_FP16",
-    "infer_has_k_tail",
-    "make_gemm_gfx950_param",
-    "make_gemm_param_and_validate",
-]
+_EXPORT_MODULES = {
+    "GEMM_DTYPE_BF16": "gemm_gfx950",
+    "GEMM_DTYPE_FP16": "gemm_gfx950",
+    "infer_has_k_tail": "gemm_gfx950",
+    "make_gemm_gfx950_param": "gemm_gfx950",
+    "make_gemm_param_and_validate": "gemm_gfx950",
+    "get_grouped_gemm_persistent_grid_size": "grouped_gemm_gfx950",
+    "launch_gemm_gfx950_grouped": "grouped_gemm_gfx950",
+}
+__all__ = list(_EXPORT_MODULES)
 
 
 def __getattr__(name: str) -> Any:
-    if name not in __all__:
+    submodule = _EXPORT_MODULES.get(name)
+    if submodule is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    module = importlib.import_module(f"{__name__}.gemm_gfx950")
+    module = importlib.import_module(f"{__name__}.{submodule}")
     value = getattr(module, name)
     globals()[name] = value
     return value

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -12,6 +12,12 @@ _EXPORT_MODULES = {
     "make_gemm_param_and_validate": "gemm_gfx950",
     "get_grouped_gemm_persistent_grid_size": "grouped_gemm_gfx950",
     "launch_gemm_gfx950_grouped": "grouped_gemm_gfx950",
+    "get_mxfp8_grouped_gemm_grid_size": "mxfp8_grouped_gemm_gfx950",
+    "launch_mxfp8_grouped_gemm_gfx950": "mxfp8_grouped_gemm_gfx950",
+    "make_mxfp8_grouped_gemm_param": "mxfp8_grouped_gemm_gfx950",
+    "make_mxfp8_grouped_gemm_param_and_validate": "mxfp8_grouped_gemm_gfx950",
+    "pick_mxfp8_grouped_gemm_tile": "mxfp8_grouped_gemm_gfx950",
+    "MXFP8_SCALE_BLOCK": "mxfp8_grouped_gemm_gfx950",
 }
 __all__ = list(_EXPORT_MODULES)
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/__init__.py
@@ -12,12 +12,10 @@ _EXPORT_MODULES = {
     "make_gemm_param_and_validate": "gemm_gfx950",
     "get_grouped_gemm_persistent_grid_size": "grouped_gemm_gfx950",
     "launch_gemm_gfx950_grouped": "grouped_gemm_gfx950",
-    "get_mxfp8_grouped_gemm_grid_size": "mxfp8_grouped_gemm_gfx950",
     "launch_mxfp8_grouped_gemm_gfx950": "mxfp8_grouped_gemm_gfx950",
     "make_mxfp8_grouped_gemm_param": "mxfp8_grouped_gemm_gfx950",
     "make_mxfp8_grouped_gemm_param_and_validate": "mxfp8_grouped_gemm_gfx950",
     "pick_mxfp8_grouped_gemm_tile": "mxfp8_grouped_gemm_gfx950",
-    "MXFP8_SCALE_BLOCK": "mxfp8_grouped_gemm_gfx950",
 }
 __all__ = list(_EXPORT_MODULES)
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -40,18 +40,6 @@ class GemmGfx950Param:
     mma_k: fx.Constexpr[int]
 
 
-def _gemm_gfx950_smem_bytes(
-    block_m: int,
-    block_n: int,
-    block_k: int,
-    stages: int,
-    in_data_bytes: int,
-    out_data_bytes: int,
-) -> int:
-    staged_smem_bytes = stages * (block_m + block_n) * block_k * in_data_bytes
-    return max(staged_smem_bytes, block_m * block_n * out_data_bytes)
-
-
 def make_gemm_gfx950_param(
     dtype_id: int = GEMM_DTYPE_BF16,
     block_m: int = 256,
@@ -114,9 +102,8 @@ def make_gemm_gfx950_param(
     elif block_n % cshuffle_vec_size != 0:
         raise ValueError("block_n must be divisible by the c-shuffle vector size")
 
-    smem_bytes = _gemm_gfx950_smem_bytes(
-        block_m, block_n, block_k, stages, in_dbytes, out_dbytes
-    )
+    smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
+    smem_bytes = max(smem_bytes, block_m * block_n * out_dbytes)
     smem_capacity = {
         "gfx942": 65536,
         "gfx950": 163840,
@@ -1009,8 +996,8 @@ def gemm_gfx950(
     a_row_stride = fx.Int32(fx.get_scalar(a.stride[0]))
     b_row_stride = fx.Int32(fx.get_scalar(b.stride[0]))
     tiled_mma = _make_gemm_gfx950_tiled_mma(param)
-    num_pid_m = (m + param.block_m - 1) // param.block_m
-    num_pid_n = (n + param.block_n - 1) // param.block_n
+    num_pid_m = (m - 1) // param.block_m + 1
+    num_pid_n = (n - 1) // param.block_n + 1
     kernel_impl = (
         gemm_hti_gfx950_kernel
         if param.use_half_tile_interleaved

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/gemm_gfx950.py
@@ -40,6 +40,18 @@ class GemmGfx950Param:
     mma_k: fx.Constexpr[int]
 
 
+def _gemm_gfx950_smem_bytes(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    stages: int,
+    in_data_bytes: int,
+    out_data_bytes: int,
+) -> int:
+    staged_smem_bytes = stages * (block_m + block_n) * block_k * in_data_bytes
+    return max(staged_smem_bytes, block_m * block_n * out_data_bytes)
+
+
 def make_gemm_gfx950_param(
     dtype_id: int = GEMM_DTYPE_BF16,
     block_m: int = 256,
@@ -102,8 +114,9 @@ def make_gemm_gfx950_param(
     elif block_n % cshuffle_vec_size != 0:
         raise ValueError("block_n must be divisible by the c-shuffle vector size")
 
-    smem_bytes = stages * (block_m + block_n) * block_k * in_dbytes
-    smem_bytes = max(smem_bytes, block_m * block_n * out_dbytes)
+    smem_bytes = _gemm_gfx950_smem_bytes(
+        block_m, block_n, block_k, stages, in_dbytes, out_dbytes
+    )
     smem_capacity = {
         "gfx942": 65536,
         "gfx950": 163840,
@@ -281,6 +294,28 @@ def buffer_load_lds_inline(rsrc, lds_ptr, global_offset, dma_bytes):
 
 def _elem_dtype(param: GemmGfx950Param):
     return fx.Float16 if const_expr(param.dtype_id == GEMM_DTYPE_FP16) else fx.BFloat16
+
+
+def _make_gemm_gfx950_tiled_mma(param: GemmGfx950Param):
+    mma_atom = fx.make_mma_atom(
+        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, _elem_dtype(param))
+    )
+    k_per_mfma_group = param.mma_k // 4
+    return fx.make_tiled_mma(
+        mma_atom,
+        fx.make_layout(
+            (param.m_waves, param.n_waves, 1),
+            (param.n_waves, 1, 0),
+        ),
+        fx.make_tile(
+            None,
+            None,
+            fx.make_layout(
+                (k_per_mfma_group, 4),
+                (1, k_per_mfma_group),
+            ),
+        ),
+    )
 
 
 @flyc.kernel
@@ -973,28 +1008,9 @@ def gemm_gfx950(
     k = fx.Int32(fx.get_scalar(a.shape[1]))
     a_row_stride = fx.Int32(fx.get_scalar(a.stride[0]))
     b_row_stride = fx.Int32(fx.get_scalar(b.stride[0]))
-    elem_dtype = _elem_dtype(param)
-    mma_atom = fx.make_mma_atom(
-        fx.rocdl.MFMA(param.mma_m, param.mma_n, param.mma_k, elem_dtype)
-    )
-    k_per_mfma_group = param.mma_k // 4
-    tiled_mma = fx.make_tiled_mma(
-        mma_atom,
-        fx.make_layout(
-            (param.m_waves, param.n_waves, 1),
-            (param.n_waves, 1, 0),
-        ),
-        fx.make_tile(
-            None,
-            None,
-            fx.make_layout(
-                (k_per_mfma_group, 4),
-                (1, k_per_mfma_group),
-            ),
-        ),
-    )
-    num_pid_m = (m - 1) // param.block_m + 1
-    num_pid_n = (n - 1) // param.block_n + 1
+    tiled_mma = _make_gemm_gfx950_tiled_mma(param)
+    num_pid_m = (m + param.block_m - 1) // param.block_m
+    num_pid_n = (n + param.block_n - 1) // param.block_n
     kernel_impl = (
         gemm_hti_gfx950_kernel
         if param.use_half_tile_interleaved

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -1,0 +1,1010 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import const_expr, range_constexpr, rocdl
+
+from .gemm_gfx950 import (
+    __barrier,
+    __waitcnt,
+    _elem_dtype,
+    _gemm_gfx950_smem_bytes,
+    _make_gemm_gfx950_tiled_mma,
+    BlockSwizzle,
+    buffer_load_lds_inline,
+    GEMM_DTYPE_FP16,
+    GemmGfx950Param,
+    GFX950_DMA_BYTES,
+    GFX950_WAVE_SIZE,
+)
+
+
+def _grouped_swizzle_tile(param, num_pid_m, num_pid_n, local_tile):
+    bid_m = local_tile % num_pid_m
+    bid_n = local_tile // num_pid_m
+    if const_expr(param.group_m <= 0):
+        return bid_m, bid_n
+
+    block_swizzle = BlockSwizzle(
+        NUM_XCDS=8, NUM_PIDS_THRESHOLD=256, GROUP_M=param.group_m
+    )
+    swizzled_m, swizzled_n = block_swizzle.swizzle(num_pid_m, num_pid_n, local_tile)
+    num_workgroups = num_pid_m * num_pid_n
+    use_block_swizzle = (num_workgroups >= 256) & ((num_workgroups % 8) == 0)
+    if const_expr(isinstance(use_block_swizzle, bool)):
+        if const_expr(use_block_swizzle):
+            return swizzled_m, swizzled_n
+        return bid_m, bid_n
+    return (
+        use_block_swizzle.select(swizzled_m, bid_m),
+        use_block_swizzle.select(swizzled_n, bid_n),
+    )
+
+
+def get_grouped_gemm_persistent_grid_size(
+    param: GemmGfx950Param,
+    total_m: int,
+    n: int,
+    group_count: int,
+    device_properties,
+) -> int:
+    num_cus = int(getattr(device_properties, "multi_processor_count", 1) or 1)
+    if total_m <= 0 or n <= 0 or group_count <= 0:
+        return 1
+
+    smem_bytes = _gemm_gfx950_smem_bytes(
+        param.block_m,
+        param.block_n,
+        param.block_k,
+        param.stages,
+        param.in_data_bytes,
+        param.out_data_bytes,
+    )
+    shared_memory_per_cu = getattr(
+        device_properties, "shared_memory_per_multiprocessor", None
+    )
+    max_threads_per_cu = getattr(
+        device_properties, "max_threads_per_multi_processor", None
+    )
+    if shared_memory_per_cu is None or max_threads_per_cu is None:
+        resource_blocks_per_cu = 1
+    else:
+        resource_blocks_per_cu = min(
+            max(int(shared_memory_per_cu) // smem_bytes, 1),
+            max(int(max_threads_per_cu) // param.block_threads, 1),
+        )
+
+    light_tile = param.block_m <= 64 and param.block_n <= 128
+    n_tiles = (n + param.block_n - 1) // param.block_n
+    if light_tile:
+        for blocks_per_cu in (8, 4, 2, 1):
+            if blocks_per_cu <= resource_blocks_per_cu:
+                break
+        # The host only knows total M. This lower bound prevents empty CTAs
+        # for uniformly small groups, even though ragged inputs have more work.
+        task_floor = (total_m + param.block_m - 1) // param.block_m * n_tiles
+        return max(1, min(num_cus * blocks_per_cu, task_floor))
+
+    blocks_per_cu = 2 if resource_blocks_per_cu >= 2 else 1
+    nonempty_groups_upper = min(group_count, total_m)
+    m_tiles_upper = (
+        nonempty_groups_upper + (total_m - nonempty_groups_upper) // param.block_m
+    )
+    return max(1, min(num_cus * blocks_per_cu, m_tiles_upper * n_tiles))
+
+
+def make_grouped_gemm_gfx950_kernel_name(param: GemmGfx950Param) -> str:
+    dtype_str = "fp16" if param.dtype_id == GEMM_DTYPE_FP16 else "bf16"
+    name = (
+        f"grouped_gemm_{dtype_str}_"
+        f"t{param.block_m}x{param.block_n}x{param.block_k}x{param.stages}"
+    )
+    name += f"_w{param.m_waves}x{param.n_waves}"
+    name += f"_gm{param.group_m}"
+    name += f"_ktail{int(param.has_k_tail)}"
+    name += "_hti" if param.use_half_tile_interleaved else "_ft"
+    return name
+
+
+class _GroupedGemmGfx950Resources:
+    def __init__(
+        self,
+        a_buf,
+        b_buf,
+        out_buf,
+        offs_buf,
+        a_rsrc,
+        b_rsrc,
+        s2r_copy_atom,
+        r2g_copy_atom,
+        thr_mma,
+        thr_copy_A,
+        b_s2r_copy_atom,
+        thr_copy_B,
+    ):
+        self.a_buf = a_buf
+        self.b_buf = b_buf
+        self.out_buf = out_buf
+        self.offs_buf = offs_buf
+        self.a_rsrc = a_rsrc
+        self.b_rsrc = b_rsrc
+        self.s2r_copy_atom = s2r_copy_atom
+        self.r2g_copy_atom = r2g_copy_atom
+        self.thr_mma = thr_mma
+        self.thr_copy_A = thr_copy_A
+        self.b_s2r_copy_atom = b_s2r_copy_atom
+        self.thr_copy_B = thr_copy_B
+
+
+def _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid):
+    a_buf = fx.rocdl.make_buffer_tensor(a, max_size=True)
+    b_buf = fx.rocdl.make_buffer_tensor(b, max_size=True)
+    out_buf = fx.rocdl.make_buffer_tensor(out, max_size=True)
+    offs_buf = fx.rocdl.make_buffer_tensor(offs, max_size=True)
+    a_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(a_buf))
+    b_rsrc = fx.rocdl.get_buffer_rsrc(fx.get_iter(b_buf))
+    s2r_copy_atom = fx.make_copy_atom(fx.UniversalCopy128b(), elem_dtype)
+    g2r_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    r2g_copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), elem_dtype)
+    thr_mma = tiled_mma.thr_slice(tid)
+    thr_copy_A = fx.make_tiled_copy_A(g2r_copy_atom, tiled_mma).get_slice(tid)
+    b_s2r_copy_atom = fx.make_copy_atom(rocdl.cdna4.LDSReadTrans16_64b(), elem_dtype)
+    thr_copy_B = fx.make_tiled_copy_B(b_s2r_copy_atom, tiled_mma).get_slice(tid)
+    return _GroupedGemmGfx950Resources(
+        a_buf,
+        b_buf,
+        out_buf,
+        offs_buf,
+        a_rsrc,
+        b_rsrc,
+        s2r_copy_atom,
+        r2g_copy_atom,
+        thr_mma,
+        thr_copy_A,
+        b_s2r_copy_atom,
+        thr_copy_B,
+    )
+
+
+def _grouped_gemm_gfx950_allocate_shared_storage(
+    block_m, block_n, block_k, stages, elem_dtype
+):
+    @fx.struct
+    class SharedABStorage:
+        a: fx.Array[elem_dtype, stages * block_m * block_k, 16]
+        b: fx.Array[elem_dtype, stages * block_n * block_k, 16]
+
+    @fx.union
+    class SharedStorage:
+        ab: SharedABStorage
+        c: fx.Array[elem_dtype, block_m * block_n, 16]
+
+    storage = fx.SharedAllocator().allocate(SharedStorage)
+    return storage.ab.a.peek().ptr, storage.ab.b.peek().ptr, storage.c.peek().ptr
+
+
+class _GroupedGemmGfx950Ctx:
+    def __init__(
+        self,
+        param,
+        tid,
+        tiled_mma,
+        thr_mma,
+        smem_a,
+        smem_b,
+        a_rsrc,
+        b_rsrc,
+        a_buf,
+        b_buf,
+        out_buf,
+        offs_buf,
+        s2r_copy_atom,
+        r2g_copy_atom,
+        thr_copy_A,
+        thr_copy_B,
+        a_lds_layout,
+        b_lds_layout,
+        b_lds_s2r_layout,
+        sC,
+        frag_A,
+        frag_B,
+        frag_C,
+        frag_C_out,
+        frag_A_retile,
+        frag_B_retile,
+        thr_mma_cRow,
+        thr_mma_cCol,
+        thr_mma_bK,
+        b_s2r_copy_atom,
+        thr_copy_cshuffle,
+        thr_sC,
+        thr_cRow,
+        thr_cCol,
+        frag_C_cshuffle,
+        pred_C,
+        wave_offset,
+    ):
+        self.param = param
+        self.tid = tid
+        self.tiled_mma = tiled_mma
+        self.thr_mma = thr_mma
+        self.smem_a = smem_a
+        self.smem_b = smem_b
+        self.a_rsrc = a_rsrc
+        self.b_rsrc = b_rsrc
+        self.a_buf = a_buf
+        self.b_buf = b_buf
+        self.out_buf = out_buf
+        self.offs_buf = offs_buf
+        self.s2r_copy_atom = s2r_copy_atom
+        self.r2g_copy_atom = r2g_copy_atom
+        self.thr_copy_A = thr_copy_A
+        self.thr_copy_B = thr_copy_B
+        self.a_lds_layout = a_lds_layout
+        self.b_lds_layout = b_lds_layout
+        self.b_lds_s2r_layout = b_lds_s2r_layout
+        self.sC = sC
+        self.frag_A = frag_A
+        self.frag_B = frag_B
+        self.frag_C = frag_C
+        self.frag_C_out = frag_C_out
+        self.frag_A_retile = frag_A_retile
+        self.frag_B_retile = frag_B_retile
+        self.thr_mma_cRow = thr_mma_cRow
+        self.thr_mma_cCol = thr_mma_cCol
+        self.thr_mma_bK = thr_mma_bK
+        self.b_s2r_copy_atom = b_s2r_copy_atom
+        self.thr_copy_cshuffle = thr_copy_cshuffle
+        self.thr_sC = thr_sC
+        self.thr_cRow = thr_cRow
+        self.thr_cCol = thr_cCol
+        self.frag_C_cshuffle = frag_C_cshuffle
+        self.pred_C = pred_C
+        self.wave_offset = wave_offset
+
+
+def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    stages = param.stages
+    block_threads = param.block_threads
+    elem_dtype = _elem_dtype(param)
+    tid = fx.thread_idx.x
+
+    smem_a, smem_b, smem_c = _grouped_gemm_gfx950_allocate_shared_storage(
+        block_m, block_n, block_k, stages, elem_dtype
+    )
+
+    rs = _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid)
+
+    swizzle = fx.static(fx.SwizzleType.get(3, 3, 3))
+    a_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((block_m, block_k), (1, 0)),
+    )
+    b_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((block_k, block_n), (1, 0)),
+    )
+    b_lds_s2r_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_layout((block_n, block_k), (1, block_n)),
+    )
+    c_lds_layout = fx.make_layout((block_m, block_n), (block_n, 1))
+
+    sA = fx.make_view(smem_a, a_lds_layout)
+    sC = fx.make_view(smem_c, c_lds_layout)
+    frag_A = rs.thr_mma.make_fragment_A(sA)
+    bk_coords = fx.make_view(0, fx.make_layout((block_n, block_k), (0, 1)))
+    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
+    sB = fx.make_view(smem_b, b_lds_s2r_layout)
+    frag_B = rs.thr_mma.make_fragment_B(sB)
+    frag_B_retile = rs.thr_copy_B.retile(frag_B)
+
+    frag_C = rs.thr_mma.make_fragment_C(sC)
+    frag_C_out = fx.make_fragment_like(frag_C, elem_dtype)
+    frag_A_retile = rs.thr_copy_A.retile(frag_A)
+    row_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (1, 0)))
+    col_coords = fx.make_view(0, fx.make_layout((block_m, block_n), (0, 1)))
+    thr_mma_cRow = rs.thr_mma.partition_C(row_coords)
+    thr_mma_cCol = rs.thr_mma.partition_C(col_coords)
+
+    cshuffle_vec_size = GFX950_DMA_BYTES // param.out_data_bytes
+    cshuffle_x_threads = block_n // cshuffle_vec_size
+    cshuffle_thr_layout = fx.make_layout(
+        (block_threads // cshuffle_x_threads, cshuffle_x_threads),
+        (cshuffle_x_threads, 1),
+    )
+    cshuffle_val_layout = fx.make_layout((1, cshuffle_vec_size), (1, 1))
+    cshuffle_tile, cshuffle_tv_layout = fx.make_layout_tv(
+        cshuffle_thr_layout,
+        cshuffle_val_layout,
+    )
+    tiled_copy_cshuffle = fx.make_tiled_copy(
+        rs.r2g_copy_atom,
+        cshuffle_tv_layout,
+        cshuffle_tile,
+    )
+    thr_copy_cshuffle = tiled_copy_cshuffle.get_slice(tid)
+    thr_sC = thr_copy_cshuffle.partition_S(sC)
+    thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
+    thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
+    frag_C_cshuffle = fx.make_fragment_like(thr_sC)
+    pred_C = fx.make_fragment_like(thr_cRow, dtype=fx.Boolean)
+    wave_offset = rocdl.readfirstlane(
+        fx.Int64.ir_type,
+        fx.Int64(tid // GFX950_WAVE_SIZE * GFX950_WAVE_SIZE * param.async_load_bytes),
+    )
+
+    return _GroupedGemmGfx950Ctx(
+        param,
+        tid,
+        tiled_mma,
+        rs.thr_mma,
+        smem_a,
+        smem_b,
+        rs.a_rsrc,
+        rs.b_rsrc,
+        rs.a_buf,
+        rs.b_buf,
+        rs.out_buf,
+        rs.offs_buf,
+        rs.s2r_copy_atom,
+        rs.r2g_copy_atom,
+        rs.thr_copy_A,
+        rs.thr_copy_B,
+        a_lds_layout,
+        b_lds_layout,
+        b_lds_s2r_layout,
+        sC,
+        frag_A,
+        frag_B,
+        frag_C,
+        frag_C_out,
+        frag_A_retile,
+        frag_B_retile,
+        thr_mma_cRow,
+        thr_mma_cCol,
+        thr_mma_bK,
+        rs.b_s2r_copy_atom,
+        thr_copy_cshuffle,
+        thr_sC,
+        thr_cRow,
+        thr_cCol,
+        frag_C_cshuffle,
+        pred_C,
+        wave_offset,
+    )
+
+
+def _grouped_tile_init(ctx, bid_m, bid_n, m, n, row_base):
+    param = ctx.param
+    block_m = param.block_m
+    block_n = param.block_n
+    tile_base = (row_base + bid_m * block_m) * n + bid_n * block_n
+    gC = fx.make_view(
+        fx.add_offset(fx.get_iter(ctx.out_buf), tile_base),
+        fx.make_layout((block_m, block_n), (n, 1)),
+    )
+    thr_gC = ctx.thr_copy_cshuffle.partition_D(gC)
+    ctx.frag_C.fill(0.0)
+
+    for i in range_constexpr(fx.size(ctx.pred_C.shape).unpack()):
+        local_row = fx.get_scalar(ctx.thr_cRow[i])
+        local_col = fx.get_scalar(ctx.thr_cCol[i])
+        row_idx = bid_m * block_m + local_row
+        col_idx = bid_n * block_n + local_col
+        ctx.pred_C[i] = (
+            (local_row < block_m)
+            & (local_col < block_n)
+            & (row_idx < m)
+            & (col_idx < n)
+        )
+    return thr_gC
+
+
+def _grouped_tile_store(ctx, thr_gC):
+    frag_C_out = ctx.frag_C_out
+    frag_C_out.store(ctx.frag_C.load().to(_elem_dtype(ctx.param)))
+
+    fx.gpu.barrier()
+    for i in range_constexpr(fx.size(frag_C_out.shape).unpack()):
+        row = fx.get_scalar(ctx.thr_mma_cRow[i])
+        col = fx.get_scalar(ctx.thr_mma_cCol[i])
+        ctx.sC[row, col] = frag_C_out[i]
+
+    fx.gpu.barrier()
+    fx.copy(ctx.s2r_copy_atom, ctx.thr_sC, ctx.frag_C_cshuffle)
+    fx.copy(ctx.r2g_copy_atom, ctx.frag_C_cshuffle, thr_gC, pred=ctx.pred_C)
+    fx.gpu.barrier()
+
+
+def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
+    param = ctx.param
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    sA_stage = fx.make_view(
+        ctx.smem_a + read_stage * block_m * block_k,
+        ctx.a_lds_layout,
+    )
+    sB_stage = fx.make_view(
+        ctx.smem_b + read_stage * block_n * block_k,
+        ctx.b_lds_s2r_layout,
+    )
+    thr_sA_s2r = ctx.thr_copy_A.partition_S(sA_stage)
+    thr_sB_s2r = ctx.thr_copy_B.partition_S(sB_stage)
+
+    for block_k_iter in range_constexpr(block_k // param.mma_k):
+        fx.copy(
+            ctx.b_s2r_copy_atom,
+            thr_sB_s2r[None, None, block_k_iter],
+            ctx.frag_B_retile[None, None, block_k_iter],
+        )
+        if const_expr(param.has_k_tail):
+            frag_B_chunk = ctx.frag_B[None, None, block_k_iter]
+            bK_chunk = ctx.thr_mma_bK[None, None, block_k_iter]
+            for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
+                in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
+                frag_B_chunk[i] = in_bounds.select(
+                    frag_B_chunk[i], _elem_dtype(param)(0.0)
+                )
+        fx.copy(
+            ctx.s2r_copy_atom,
+            thr_sA_s2r[None, None, block_k_iter],
+            ctx.frag_A_retile[None, None, block_k_iter],
+        )
+        fx.gemm(
+            ctx.tiled_mma,
+            ctx.frag_C,
+            ctx.frag_A[None, None, block_k_iter],
+            ctx.frag_B[None, None, block_k_iter],
+            ctx.frag_C,
+            traversal_order=fx.GemmTraversalOrder.KNM,
+        )
+
+
+def _grouped_load_a_tile_async(ctx, row_base, bid_m, m, k, k_tile, stage):
+    param = ctx.param
+    block_m = param.block_m
+    block_k = param.block_k
+    async_load_bytes = param.async_load_bytes
+    in_data_bytes = param.in_data_bytes
+    async_load_vec_size = async_load_bytes // in_data_bytes
+    ldg_x_threads = param.ldg_x_threads
+    block_threads = param.block_threads
+    ldg_a_iters = param.ldg_a_iters
+    lds_ptr = fx.recast_iter(
+        fx.Int8, ctx.smem_a + stage * block_m * block_k
+    ) + fx.Int32(ctx.wave_offset)
+    for i in range_constexpr(ldg_a_iters):
+        global_tid = block_threads * i + ctx.tid
+        m_local_idx = global_tid // ldg_x_threads
+        k_local_idx = global_tid % ldg_x_threads * async_load_vec_size
+        in_bounds_m = bid_m * block_m + m_local_idx < m
+        global_m_idx = row_base + bid_m * block_m + m_local_idx
+        safe_global_m_idx = in_bounds_m.select(global_m_idx, 0)
+        col = (
+            fx.get_scalar(fx.crd2idx((m_local_idx, k_local_idx), ctx.a_lds_layout))
+            % block_k
+        )
+        global_k_idx = k_tile * block_k + col
+        if const_expr(param.has_k_tail):
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        else:
+            safe_global_k_idx = global_k_idx
+        global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
+        buffer_load_lds_inline(ctx.a_rsrc, lds_ptr, global_offset, async_load_bytes)
+        if i < ldg_a_iters - 1:
+            lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+
+def _grouped_load_b_tile_async(ctx, bid_n, n, k, group_idx, k_tile, stage):
+    param = ctx.param
+    block_n = param.block_n
+    block_k = param.block_k
+    async_load_bytes = param.async_load_bytes
+    in_data_bytes = param.in_data_bytes
+    async_load_vec_size = async_load_bytes // in_data_bytes
+    block_threads = param.block_threads
+    ldg_b_iters = param.ldg_b_iters
+    n_vectors = block_n // async_load_vec_size
+    lds_ptr = fx.recast_iter(
+        fx.Int8, ctx.smem_b + stage * block_n * block_k
+    ) + fx.Int32(ctx.wave_offset)
+
+    for i in range_constexpr(ldg_b_iters):
+        vector_idx = block_threads * i + ctx.tid
+        k_local_idx = vector_idx // n_vectors
+        n_local_idx = vector_idx % n_vectors * async_load_vec_size
+        global_k_idx = k_tile * block_k + k_local_idx
+        swizzled_n_idx = (
+            fx.get_scalar(fx.crd2idx((k_local_idx, n_local_idx), ctx.b_lds_layout))
+            % block_n
+        )
+        global_n_idx = bid_n * block_n + swizzled_n_idx
+        safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        global_offset = (
+            group_idx * k * n + safe_global_k_idx * n + global_n_idx
+        ) * in_data_bytes
+        buffer_load_lds_inline(ctx.b_rsrc, lds_ptr, global_offset, async_load_bytes)
+        if i < ldg_b_iters - 1:
+            lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+
+@flyc.kernel
+def gemm_gfx950_grouped_kernel(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    offs: fx.Tensor,
+    group_count: fx.Int32,
+    n: fx.Int32,
+    k: fx.Int32,
+    tiled_mma: fx.TiledMma,
+    param: GemmGfx950Param,
+):
+    ctx = _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param)
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    stages = param.stages
+    has_k_tail = param.has_k_tail
+    ldg_a_iters = param.ldg_a_iters
+    num_pid_n = (n + block_n - 1) // block_n
+    k_tiles = (k + block_k - 1) // block_k
+    grid = fx.Int32(fx.grid_dim.x)
+    work_idx = fx.Int32(fx.block_idx.x)
+    tiles_before = fx.Int32(0)
+    row_base = fx.Int32(0)
+    for g in range(0, group_count, 1):
+        row_end = fx.get_scalar(ctx.offs_buf[g])
+        m_g = row_end - row_base
+        num_pid_m = (m_g + block_m - 1) // block_m
+        tiles_after = tiles_before + num_pid_m * num_pid_n
+
+        for linear_tile in range(work_idx, tiles_after, grid):
+            local_tile = linear_tile - tiles_before
+            bid_m, bid_n = _grouped_swizzle_tile(
+                param, num_pid_m, num_pid_n, local_tile
+            )
+            thr_gC = _grouped_tile_init(ctx, bid_m, bid_n, m_g, n, row_base)
+            ldg_wait_count = ldg_a_iters + param.ldg_b_iters
+            for stage in range_constexpr(stages - 1):
+                _grouped_load_b_tile_async(ctx, bid_n, n, k, g, stage, stage)
+                _grouped_load_a_tile_async(ctx, row_base, bid_m, m_g, k, stage, stage)
+            rocdl.sched_barrier(0)
+            if const_expr(has_k_tail):
+                main_loop_end = (k_tiles > stages - 1).select(k_tiles - (stages - 1), 0)
+            else:
+                main_loop_end = k_tiles - (stages - 1)
+            for k_tile in range(0, main_loop_end, 1):
+                current_stage = k_tile % stages
+                write_stage = (current_stage + stages - 1) % stages
+                __barrier((stages - 2) * ldg_wait_count)
+                fx.gpu.barrier()
+                _grouped_load_b_tile_async(
+                    ctx, bid_n, n, k, g, k_tile + (stages - 1), write_stage
+                )
+                _grouped_load_a_tile_async(
+                    ctx, row_base, bid_m, m_g, k, k_tile + (stages - 1), write_stage
+                )
+                _grouped_compute_stage_from_lds(ctx, current_stage, k_tile, k)
+            current_stage = main_loop_end % stages
+            for s in range_constexpr(0, stages - 1):
+                __barrier((stages - 2 - s) * ldg_wait_count)
+                fx.gpu.barrier()
+                _grouped_compute_stage_from_lds(
+                    ctx, current_stage, main_loop_end + s, k
+                )
+                current_stage = (current_stage + 1) % stages
+            _grouped_tile_store(ctx, thr_gC)
+
+        remaining = (work_idx < tiles_after).select(tiles_after - work_idx, fx.Int32(0))
+        work_idx = work_idx + (remaining + grid - 1) // grid * grid
+        tiles_before = tiles_after
+        row_base = row_end
+
+
+@flyc.kernel
+def gemm_hti_gfx950_grouped_kernel(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    offs: fx.Tensor,
+    group_count: fx.Int32,
+    n: fx.Int32,
+    k: fx.Int32,
+    tiled_mma: fx.TiledMma,
+    param: GemmGfx950Param,
+):
+    block_m = param.block_m
+    block_n = param.block_n
+    block_k = param.block_k
+    half_block_m = block_m // 2
+    half_block_n = block_n // 2
+    async_load_bytes = param.async_load_bytes
+    in_data_bytes = param.in_data_bytes
+    async_load_vec_size = async_load_bytes // in_data_bytes
+    ldg_x_threads = param.ldg_x_threads
+    block_threads = param.block_threads
+    half_ldg_a_iters = param.ldg_a_iters // 2
+    half_ldg_b_iters = param.ldg_b_iters // 2
+    elem_dtype = _elem_dtype(param)
+
+    tid = fx.thread_idx.x
+    num_pid_n = (n + block_n - 1) // block_n
+    k_tiles = (k + block_k - 1) // block_k
+    has_odd_k_tiles = k_tiles % 2 != 0
+
+    smem_a, smem_b, smem_c = _grouped_gemm_gfx950_allocate_shared_storage(
+        block_m, block_n, block_k, 2, elem_dtype
+    )
+
+    rs = _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid)
+
+    swizzle = fx.static(fx.SwizzleType.get(3, 3, 3))
+    a_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((half_block_m, block_k), (1, 0)),
+    )
+    b_half_lds_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_ordered_layout((block_k, half_block_n), (1, 0)),
+    )
+    b_half_lds_s2r_layout = fx.make_composed_layout(
+        swizzle,
+        fx.make_layout((half_block_n, block_k), (1, half_block_n)),
+    )
+    c_lds_layout = fx.make_layout((half_block_m, half_block_n), (half_block_n, 1))
+    wave_offset = rocdl.readfirstlane(
+        fx.Int64.ir_type,
+        fx.Int64(tid // GFX950_WAVE_SIZE * GFX950_WAVE_SIZE * async_load_bytes),
+    )
+
+    def make_wave_lds_ptr(ptr):
+        return fx.recast_iter(fx.Int8, ptr) + fx.Int32(wave_offset)
+
+    def swizzled_col_idx(row, col):
+        return fx.get_scalar(fx.crd2idx((row, col), a_lds_layout)) % block_k
+
+    def half_a_base(stage, m_part):
+        return smem_a + (stage * block_m + m_part * half_block_m) * block_k
+
+    def half_b_base(stage, n_part):
+        return smem_b + (stage * block_n + n_part * half_block_n) * block_k
+
+    def load_a_half(m_part, k_tile, stage, bid_m, m, row_base):
+        lds_ptr = make_wave_lds_ptr(half_a_base(stage, m_part))
+        for i in range_constexpr(half_ldg_a_iters):
+            global_tid = block_threads * i + tid
+            m_local_idx = global_tid // ldg_x_threads
+            k_local_idx = global_tid % ldg_x_threads * async_load_vec_size
+            m_tile_idx = bid_m * block_m + m_part * half_block_m + m_local_idx
+            in_bounds_m = m_tile_idx < m
+            safe_global_m_idx = in_bounds_m.select(row_base + m_tile_idx, 0)
+            global_k_idx = k_tile * block_k + swizzled_col_idx(m_local_idx, k_local_idx)
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
+            buffer_load_lds_inline(rs.a_rsrc, lds_ptr, global_offset, async_load_bytes)
+            if i < half_ldg_a_iters - 1:
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+    def load_b_half(n_part, k_tile, stage, bid_n, group):
+        lds_ptr = make_wave_lds_ptr(half_b_base(stage, n_part))
+        n_vectors = half_block_n // async_load_vec_size
+        for i in range_constexpr(half_ldg_b_iters):
+            vector_idx = block_threads * i + tid
+            k_local_idx = vector_idx // n_vectors
+            n_local_idx = vector_idx % n_vectors * async_load_vec_size
+            global_k_idx = k_tile * block_k + k_local_idx
+            swizzled_n_idx = (
+                fx.get_scalar(fx.crd2idx((k_local_idx, n_local_idx), b_half_lds_layout))
+                % half_block_n
+            )
+            global_n_idx = bid_n * block_n + n_part * half_block_n + swizzled_n_idx
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            global_offset = (
+                group * k * n + safe_global_k_idx * n + global_n_idx
+            ) * in_data_bytes
+            buffer_load_lds_inline(rs.b_rsrc, lds_ptr, global_offset, async_load_bytes)
+            if i < half_ldg_b_iters - 1:
+                lds_ptr = lds_ptr + block_threads * async_load_bytes
+
+    def load_a_fragment(m_part, read_stage):
+        sA = fx.make_view(half_a_base(read_stage, m_part), a_lds_layout)
+        frag_A = rs.thr_mma.make_fragment_A(sA)
+        frag_A_retile = rs.thr_copy_A.retile(frag_A)
+        thr_sA_s2r = rs.thr_copy_A.partition_S(sA)
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            fx.copy(
+                rs.s2r_copy_atom,
+                thr_sA_s2r[None, None, block_k_iter],
+                frag_A_retile[None, None, block_k_iter],
+            )
+        return frag_A
+
+    def load_b_fragment(n_part, read_stage, k_tile):
+        sB = fx.make_view(
+            half_b_base(read_stage, n_part),
+            b_half_lds_s2r_layout,
+        )
+        frag_B = rs.thr_mma.make_fragment_B(sB)
+        frag_B_retile = rs.thr_copy_B.retile(frag_B)
+        thr_sB_s2r = rs.thr_copy_B.partition_S(sB)
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            fx.copy(
+                rs.b_s2r_copy_atom,
+                thr_sB_s2r[None, None, block_k_iter],
+                frag_B_retile[None, None, block_k_iter],
+            )
+            if const_expr(param.has_k_tail):
+                frag_B_chunk = frag_B[None, None, block_k_iter]
+                bK_chunk = thr_mma_bK[None, None, block_k_iter]
+                for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
+                    in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
+                    frag_B_chunk[i] = in_bounds.select(frag_B_chunk[i], elem_dtype(0.0))
+        return frag_B
+
+    def consume(frag_C, frag_A, frag_B):
+        rocdl.sched_barrier(0)
+        for block_k_iter in range_constexpr(block_k // param.mma_k):
+            fx.gemm(
+                tiled_mma,
+                frag_C,
+                frag_A[None, None, block_k_iter],
+                frag_B[None, None, block_k_iter],
+                frag_C,
+                traversal_order=fx.GemmTraversalOrder.KNM,
+            )
+        rocdl.sched_barrier(0)
+
+    def half_gC(m_part, n_part, bid_m, bid_n, row_base):
+        row = row_base + bid_m * block_m + m_part * half_block_m
+        col = bid_n * block_n + n_part * half_block_n
+        return fx.make_view(
+            fx.add_offset(fx.get_iter(rs.out_buf), row * n + col),
+            fx.make_layout((half_block_m, half_block_n), (n, 1)),
+        )
+
+    cshuffle_vec_size = GFX950_DMA_BYTES // param.out_data_bytes
+    cshuffle_x_threads = half_block_n // cshuffle_vec_size
+    cshuffle_thr_layout = fx.make_layout(
+        (block_threads // cshuffle_x_threads, cshuffle_x_threads),
+        (cshuffle_x_threads, 1),
+    )
+    cshuffle_val_layout = fx.make_layout((1, cshuffle_vec_size), (1, 1))
+    cshuffle_tile, cshuffle_tv_layout = fx.make_layout_tv(
+        cshuffle_thr_layout,
+        cshuffle_val_layout,
+    )
+    tiled_copy_cshuffle = fx.make_tiled_copy(
+        rs.r2g_copy_atom,
+        cshuffle_tv_layout,
+        cshuffle_tile,
+    )
+    thr_copy_cshuffle = tiled_copy_cshuffle.get_slice(tid)
+    row_coords = fx.make_view(0, fx.make_layout((half_block_m, half_block_n), (1, 0)))
+    col_coords = fx.make_view(0, fx.make_layout((half_block_m, half_block_n), (0, 1)))
+    thr_mma_cRow = rs.thr_mma.partition_C(row_coords)
+    thr_mma_cCol = rs.thr_mma.partition_C(col_coords)
+    thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
+    thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
+    bk_coords = fx.make_view(0, fx.make_layout((half_block_n, block_k), (0, 1)))
+    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
+
+    def store_half_tile(m_part, n_part, frag_C, bid_m, bid_n, m, row_base):
+        gC = half_gC(m_part, n_part, bid_m, bid_n, row_base)
+        sC = fx.make_view(smem_c, c_lds_layout)
+        thr_sC = thr_copy_cshuffle.partition_S(sC)
+        thr_gC = thr_copy_cshuffle.partition_D(gC)
+        frag_C_cshuffle = fx.make_fragment_like(thr_sC)
+        pred_C = fx.make_fragment_like(thr_cRow, dtype=fx.Boolean)
+
+        for i in range_constexpr(fx.size(pred_C.shape).unpack()):
+            local_row = fx.get_scalar(thr_cRow[i])
+            local_col = fx.get_scalar(thr_cCol[i])
+            row_idx = bid_m * block_m + m_part * half_block_m + local_row
+            col_idx = bid_n * block_n + n_part * half_block_n + local_col
+            pred_C[i] = (
+                (local_row < half_block_m)
+                & (local_col < half_block_n)
+                & (row_idx < m)
+                & (col_idx < n)
+            )
+
+        frag_C_out = fx.make_fragment_like(frag_C, elem_dtype)
+        for i in range_constexpr(fx.size(frag_C.shape).unpack()):
+            frag_C_out[i] = frag_C[i].to(elem_dtype)
+
+        fx.gpu.barrier()
+        for i in range_constexpr(fx.size(frag_C_out.shape).unpack()):
+            row = fx.get_scalar(thr_mma_cRow[i])
+            col = fx.get_scalar(thr_mma_cCol[i])
+            sC[row, col] = frag_C_out[i]
+
+        fx.gpu.barrier()
+        fx.copy(rs.s2r_copy_atom, thr_sC, frag_C_cshuffle)
+        fx.copy(rs.r2g_copy_atom, frag_C_cshuffle, thr_gC, pred=pred_C)
+        fx.gpu.barrier()
+
+    frag_shape = fx.make_view(
+        fx.get_iter(rs.out_buf),
+        fx.make_layout((half_block_m, half_block_n), (n, 1)),
+    )
+    c00 = rs.thr_mma.make_fragment_C(frag_shape)
+    c01 = rs.thr_mma.make_fragment_C(frag_shape)
+    c10 = rs.thr_mma.make_fragment_C(frag_shape)
+    c11 = rs.thr_mma.make_fragment_C(frag_shape)
+
+    def compute_double_tile(
+        k_tile,
+        prefetch_next,
+        bid_m,
+        bid_n,
+        m,
+        row_base,
+        group,
+    ):
+        next_k_tile = k_tile + 2
+
+        b0 = load_b_fragment(0, 0, k_tile)
+        a0 = load_a_fragment(0, 0)
+        load_a_half(1, k_tile + 1, 1, bid_m, m, row_base)
+        rocdl.s_barrier()
+        consume(c00, a0, b0)
+        rocdl.s_barrier()
+
+        b1 = load_b_fragment(1, 0, k_tile)
+        if const_expr(prefetch_next):
+            load_b_half(0, next_k_tile, 0, bid_n, group)
+            rocdl.s_barrier()
+        consume(c01, a0, b1)
+        rocdl.s_barrier()
+
+        a1 = load_a_fragment(1, 0)
+        if const_expr(prefetch_next):
+            load_a_half(0, next_k_tile, 0, bid_m, m, row_base)
+            rocdl.s_barrier()
+        consume(c10, a1, b0)
+        rocdl.s_barrier()
+
+        b0 = load_b_fragment(0, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            load_b_half(1, next_k_tile, 0, bid_n, group)
+            __barrier(2 * half_ldg_b_iters + half_ldg_a_iters)
+        consume(c11, a1, b1)
+        if const_expr(not prefetch_next):
+            __waitcnt(0)
+        rocdl.s_barrier()
+
+        a0 = load_a_fragment(0, 1)
+        if const_expr(prefetch_next):
+            load_a_half(1, next_k_tile, 0, bid_m, m, row_base)
+            rocdl.s_barrier()
+        consume(c00, a0, b0)
+        rocdl.s_barrier()
+
+        b1 = load_b_fragment(1, 1, k_tile + 1)
+        if const_expr(prefetch_next):
+            load_b_half(0, next_k_tile + 1, 1, bid_n, group)
+            rocdl.s_barrier()
+        consume(c01, a0, b1)
+        rocdl.s_barrier()
+
+        a1 = load_a_fragment(1, 1)
+        if const_expr(prefetch_next):
+            load_a_half(0, next_k_tile + 1, 1, bid_m, m, row_base)
+            rocdl.s_barrier()
+        consume(c10, a1, b0)
+        rocdl.s_barrier()
+
+        if const_expr(prefetch_next):
+            load_b_half(1, next_k_tile + 1, 1, bid_n, group)
+            __barrier(half_ldg_b_iters + half_ldg_a_iters)
+        consume(c11, a1, b1)
+        rocdl.s_barrier()
+
+    def compute_single_tile(k_tile, read_stage):
+        b0 = load_b_fragment(0, read_stage, k_tile)
+        b1 = load_b_fragment(1, read_stage, k_tile)
+        a0 = load_a_fragment(0, read_stage)
+        consume(c00, a0, b0)
+        consume(c01, a0, b1)
+        a1 = load_a_fragment(1, read_stage)
+        consume(c10, a1, b0)
+        consume(c11, a1, b1)
+
+    grid = fx.Int32(fx.grid_dim.x)
+    work_idx = fx.Int32(fx.block_idx.x)
+    tiles_before = fx.Int32(0)
+    row_base = fx.Int32(0)
+    for g in range(0, group_count, 1):
+        row_end = fx.get_scalar(rs.offs_buf[g])
+        m_g = row_end - row_base
+        num_pid_m = (m_g + block_m - 1) // block_m
+        tiles_after = tiles_before + num_pid_m * num_pid_n
+
+        for linear_tile in range(work_idx, tiles_after, grid):
+            local_tile = linear_tile - tiles_before
+            bid_m, bid_n = _grouped_swizzle_tile(
+                param, num_pid_m, num_pid_n, local_tile
+            )
+            c00.fill(0.0)
+            c01.fill(0.0)
+            c10.fill(0.0)
+            c11.fill(0.0)
+
+            load_b_half(0, 0, 0, bid_n, g)
+            load_a_half(0, 0, 0, bid_m, m_g, row_base)
+            load_b_half(1, 0, 0, bid_n, g)
+            load_a_half(1, 0, 0, bid_m, m_g, row_base)
+            rocdl.sched_barrier(0)
+            rocdl.s_barrier()
+            rocdl.sched_barrier(0)
+            load_b_half(0, 1, 1, bid_n, g)
+            load_a_half(0, 1, 1, bid_m, m_g, row_base)
+            load_b_half(1, 1, 1, bid_n, g)
+            __barrier(half_ldg_b_iters + half_ldg_a_iters)
+
+            if has_odd_k_tiles:
+                final_double_tile = k_tiles - 3
+                for k_tile in range(0, final_double_tile, 2):
+                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
+                compute_double_tile(
+                    final_double_tile, False, bid_m, bid_n, m_g, row_base, g
+                )
+                load_b_half(0, k_tiles - 1, 0, bid_n, g)
+                load_a_half(0, k_tiles - 1, 0, bid_m, m_g, row_base)
+                load_b_half(1, k_tiles - 1, 0, bid_n, g)
+                load_a_half(1, k_tiles - 1, 0, bid_m, m_g, row_base)
+                __barrier(0)
+                fx.gpu.barrier()
+                compute_single_tile(k_tiles - 1, 0)
+            else:
+                main_loop_end = (k_tiles > 2).select(k_tiles - 2, 0)
+                for k_tile in range(0, main_loop_end, 2):
+                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
+                compute_double_tile(
+                    main_loop_end, False, bid_m, bid_n, m_g, row_base, g
+                )
+
+            store_half_tile(0, 0, c00, bid_m, bid_n, m_g, row_base)
+            store_half_tile(0, 1, c01, bid_m, bid_n, m_g, row_base)
+            store_half_tile(1, 0, c10, bid_m, bid_n, m_g, row_base)
+            store_half_tile(1, 1, c11, bid_m, bid_n, m_g, row_base)
+
+        remaining = (work_idx < tiles_after).select(tiles_after - work_idx, fx.Int32(0))
+        work_idx = work_idx + (remaining + grid - 1) // grid * grid
+        tiles_before = tiles_after
+        row_base = row_end
+
+
+@flyc.jit
+def launch_gemm_gfx950_grouped(
+    out: fx.Tensor,
+    a: fx.Tensor,
+    b: fx.Tensor,
+    offs: fx.Tensor,
+    group_count: int,
+    n: fx.Int32,
+    k: fx.Int32,
+    grid_size: int,
+    param: GemmGfx950Param,
+    stream: fx.Stream = fx.Stream(None),
+):
+    tiled_mma = _make_gemm_gfx950_tiled_mma(param)
+    kernel_impl = (
+        gemm_hti_gfx950_grouped_kernel
+        if param.use_half_tile_interleaved
+        else gemm_gfx950_grouped_kernel
+    )
+    kernel_impl._known_block_size = [param.block_threads, 1, 1]
+    kernel_impl._func.__name__ = make_grouped_gemm_gfx950_kernel_name(param)
+    kernel_impl(out, a, b, offs, group_count, n, k, tiled_mma, param).launch(
+        grid=(grid_size, 1, 1),
+        block=(param.block_threads, 1, 1),
+        stream=stream,
+    )

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
+from dataclasses import dataclass
+from typing import Any
+
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl.expr import const_expr, range_constexpr, rocdl
@@ -30,7 +33,9 @@ def _grouped_swizzle_tile(param, num_pid_m, num_pid_n, local_tile):
     )
     swizzled_m, swizzled_n = block_swizzle.swizzle(num_pid_m, num_pid_n, local_tile)
     num_workgroups = num_pid_m * num_pid_n
-    use_block_swizzle = (num_workgroups >= 256) & ((num_workgroups % 8) == 0)
+    use_block_swizzle = (num_workgroups >= block_swizzle.NUM_PIDS_THRESHOLD) & (
+        (num_workgroups % block_swizzle.NUM_XCDS) == 0
+    )
     if const_expr(isinstance(use_block_swizzle, bool)):
         if const_expr(use_block_swizzle):
             return swizzled_m, swizzled_n
@@ -105,34 +110,20 @@ def make_grouped_gemm_gfx950_kernel_name(param: GemmGfx950Param) -> str:
     return name
 
 
+@dataclass
 class _GroupedGemmGfx950Resources:
-    def __init__(
-        self,
-        a_buf,
-        b_buf,
-        out_buf,
-        offs_buf,
-        a_rsrc,
-        b_rsrc,
-        s2r_copy_atom,
-        r2g_copy_atom,
-        thr_mma,
-        thr_copy_A,
-        b_s2r_copy_atom,
-        thr_copy_B,
-    ):
-        self.a_buf = a_buf
-        self.b_buf = b_buf
-        self.out_buf = out_buf
-        self.offs_buf = offs_buf
-        self.a_rsrc = a_rsrc
-        self.b_rsrc = b_rsrc
-        self.s2r_copy_atom = s2r_copy_atom
-        self.r2g_copy_atom = r2g_copy_atom
-        self.thr_mma = thr_mma
-        self.thr_copy_A = thr_copy_A
-        self.b_s2r_copy_atom = b_s2r_copy_atom
-        self.thr_copy_B = thr_copy_B
+    """Buffer descriptors, copy atoms and thread slices shared by both kernels."""
+
+    out_buf: Any
+    offs_buf: Any
+    a_rsrc: Any
+    b_rsrc: Any
+    s2r_copy_atom: Any
+    r2g_copy_atom: Any
+    thr_mma: Any
+    thr_copy_A: Any
+    b_s2r_copy_atom: Any
+    thr_copy_B: Any
 
 
 def _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid):
@@ -150,18 +141,16 @@ def _grouped_gemm_gfx950_resources(out, a, b, offs, tiled_mma, elem_dtype, tid):
     b_s2r_copy_atom = fx.make_copy_atom(rocdl.cdna4.LDSReadTrans16_64b(), elem_dtype)
     thr_copy_B = fx.make_tiled_copy_B(b_s2r_copy_atom, tiled_mma).get_slice(tid)
     return _GroupedGemmGfx950Resources(
-        a_buf,
-        b_buf,
-        out_buf,
-        offs_buf,
-        a_rsrc,
-        b_rsrc,
-        s2r_copy_atom,
-        r2g_copy_atom,
-        thr_mma,
-        thr_copy_A,
-        b_s2r_copy_atom,
-        thr_copy_B,
+        out_buf=out_buf,
+        offs_buf=offs_buf,
+        a_rsrc=a_rsrc,
+        b_rsrc=b_rsrc,
+        s2r_copy_atom=s2r_copy_atom,
+        r2g_copy_atom=r2g_copy_atom,
+        thr_mma=thr_mma,
+        thr_copy_A=thr_copy_A,
+        b_s2r_copy_atom=b_s2r_copy_atom,
+        thr_copy_B=thr_copy_B,
     )
 
 
@@ -182,82 +171,48 @@ def _grouped_gemm_gfx950_allocate_shared_storage(
     return storage.ab.a.peek().ptr, storage.ab.b.peek().ptr, storage.c.peek().ptr
 
 
+@dataclass
 class _GroupedGemmGfx950Ctx:
-    def __init__(
-        self,
-        param,
-        tid,
-        tiled_mma,
-        thr_mma,
-        smem_a,
-        smem_b,
-        a_rsrc,
-        b_rsrc,
-        a_buf,
-        b_buf,
-        out_buf,
-        offs_buf,
-        s2r_copy_atom,
-        r2g_copy_atom,
-        thr_copy_A,
-        thr_copy_B,
-        a_lds_layout,
-        b_lds_layout,
-        b_lds_s2r_layout,
-        sC,
-        frag_A,
-        frag_B,
-        frag_C,
-        frag_C_out,
-        frag_A_retile,
-        frag_B_retile,
-        thr_mma_cRow,
-        thr_mma_cCol,
-        b_s2r_copy_atom,
-        thr_copy_cshuffle,
-        thr_sC,
-        thr_cRow,
-        thr_cCol,
-        frag_C_cshuffle,
-        pred_C,
-        wave_offset,
-    ):
-        self.param = param
-        self.tid = tid
-        self.tiled_mma = tiled_mma
-        self.thr_mma = thr_mma
-        self.smem_a = smem_a
-        self.smem_b = smem_b
-        self.a_rsrc = a_rsrc
-        self.b_rsrc = b_rsrc
-        self.a_buf = a_buf
-        self.b_buf = b_buf
-        self.out_buf = out_buf
-        self.offs_buf = offs_buf
-        self.s2r_copy_atom = s2r_copy_atom
-        self.r2g_copy_atom = r2g_copy_atom
-        self.thr_copy_A = thr_copy_A
-        self.thr_copy_B = thr_copy_B
-        self.a_lds_layout = a_lds_layout
-        self.b_lds_layout = b_lds_layout
-        self.b_lds_s2r_layout = b_lds_s2r_layout
-        self.sC = sC
-        self.frag_A = frag_A
-        self.frag_B = frag_B
-        self.frag_C = frag_C
-        self.frag_C_out = frag_C_out
-        self.frag_A_retile = frag_A_retile
-        self.frag_B_retile = frag_B_retile
-        self.thr_mma_cRow = thr_mma_cRow
-        self.thr_mma_cCol = thr_mma_cCol
-        self.b_s2r_copy_atom = b_s2r_copy_atom
-        self.thr_copy_cshuffle = thr_copy_cshuffle
-        self.thr_sC = thr_sC
-        self.thr_cRow = thr_cRow
-        self.thr_cCol = thr_cCol
-        self.frag_C_cshuffle = frag_C_cshuffle
-        self.pred_C = pred_C
-        self.wave_offset = wave_offset
+    """Per-workgroup state of the non-interleaved grouped kernel.
+
+    Everything here is tile-independent, so it is built once before the
+    persistent tile loop and reused by every tile the workgroup claims.
+    """
+
+    param: Any
+    tid: Any
+    tiled_mma: Any
+    thr_mma: Any
+    smem_a: Any
+    smem_b: Any
+    a_rsrc: Any
+    b_rsrc: Any
+    out_buf: Any
+    offs_buf: Any
+    s2r_copy_atom: Any
+    r2g_copy_atom: Any
+    thr_copy_A: Any
+    thr_copy_B: Any
+    a_lds_layout: Any
+    b_lds_layout: Any
+    b_lds_s2r_layout: Any
+    sC: Any
+    frag_A: Any
+    frag_B: Any
+    frag_C: Any
+    frag_C_out: Any
+    frag_A_retile: Any
+    frag_B_retile: Any
+    thr_mma_cRow: Any
+    thr_mma_cCol: Any
+    b_s2r_copy_atom: Any
+    thr_copy_cshuffle: Any
+    thr_sC: Any
+    thr_cRow: Any
+    thr_cCol: Any
+    frag_C_cshuffle: Any
+    pred_C: Any
+    wave_offset: Any
 
 
 def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
@@ -333,42 +288,40 @@ def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
     )
 
     return _GroupedGemmGfx950Ctx(
-        param,
-        tid,
-        tiled_mma,
-        rs.thr_mma,
-        smem_a,
-        smem_b,
-        rs.a_rsrc,
-        rs.b_rsrc,
-        rs.a_buf,
-        rs.b_buf,
-        rs.out_buf,
-        rs.offs_buf,
-        rs.s2r_copy_atom,
-        rs.r2g_copy_atom,
-        rs.thr_copy_A,
-        rs.thr_copy_B,
-        a_lds_layout,
-        b_lds_layout,
-        b_lds_s2r_layout,
-        sC,
-        frag_A,
-        frag_B,
-        frag_C,
-        frag_C_out,
-        frag_A_retile,
-        frag_B_retile,
-        thr_mma_cRow,
-        thr_mma_cCol,
-        rs.b_s2r_copy_atom,
-        thr_copy_cshuffle,
-        thr_sC,
-        thr_cRow,
-        thr_cCol,
-        frag_C_cshuffle,
-        pred_C,
-        wave_offset,
+        param=param,
+        tid=tid,
+        tiled_mma=tiled_mma,
+        thr_mma=rs.thr_mma,
+        smem_a=smem_a,
+        smem_b=smem_b,
+        a_rsrc=rs.a_rsrc,
+        b_rsrc=rs.b_rsrc,
+        out_buf=rs.out_buf,
+        offs_buf=rs.offs_buf,
+        s2r_copy_atom=rs.s2r_copy_atom,
+        r2g_copy_atom=rs.r2g_copy_atom,
+        thr_copy_A=rs.thr_copy_A,
+        thr_copy_B=rs.thr_copy_B,
+        a_lds_layout=a_lds_layout,
+        b_lds_layout=b_lds_layout,
+        b_lds_s2r_layout=b_lds_s2r_layout,
+        sC=sC,
+        frag_A=frag_A,
+        frag_B=frag_B,
+        frag_C=frag_C,
+        frag_C_out=frag_C_out,
+        frag_A_retile=frag_A_retile,
+        frag_B_retile=frag_B_retile,
+        thr_mma_cRow=thr_mma_cRow,
+        thr_mma_cCol=thr_mma_cCol,
+        b_s2r_copy_atom=rs.b_s2r_copy_atom,
+        thr_copy_cshuffle=thr_copy_cshuffle,
+        thr_sC=thr_sC,
+        thr_cRow=thr_cRow,
+        thr_cCol=thr_cCol,
+        frag_C_cshuffle=frag_C_cshuffle,
+        pred_C=pred_C,
+        wave_offset=wave_offset,
     )
 
 
@@ -414,6 +367,7 @@ def _grouped_tile_store(ctx, thr_gC):
     fx.gpu.barrier()
 
 
+@flyc.jit
 def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
     param = ctx.param
     block_m = param.block_m

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -9,7 +9,6 @@ from .gemm_gfx950 import (
     __barrier,
     __waitcnt,
     _elem_dtype,
-    _gemm_gfx950_smem_bytes,
     _make_gemm_gfx950_tiled_mma,
     BlockSwizzle,
     buffer_load_lds_inline,
@@ -53,14 +52,13 @@ def get_grouped_gemm_persistent_grid_size(
     if total_m <= 0 or n <= 0 or group_count <= 0:
         return 1
 
-    smem_bytes = _gemm_gfx950_smem_bytes(
-        param.block_m,
-        param.block_n,
-        param.block_k,
-        param.stages,
-        param.in_data_bytes,
-        param.out_data_bytes,
+    smem_bytes = (
+        param.stages
+        * (param.block_m + param.block_n)
+        * param.block_k
+        * param.in_data_bytes
     )
+    smem_bytes = max(smem_bytes, param.block_m * param.block_n * param.out_data_bytes)
     shared_memory_per_cu = getattr(
         device_properties, "shared_memory_per_multiprocessor", None
     )

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -76,14 +76,14 @@ def get_grouped_gemm_persistent_grid_size(
         )
 
     light_tile = param.block_m <= 64 and param.block_n <= 128
-    n_tiles = (n + param.block_n - 1) // param.block_n
+    n_tiles = (n - 1) // param.block_n + 1
     if light_tile:
         for blocks_per_cu in (8, 4, 2, 1):
             if blocks_per_cu <= resource_blocks_per_cu:
                 break
         # The host only knows total M. This lower bound prevents empty CTAs
         # for uniformly small groups, even though ragged inputs have more work.
-        task_floor = (total_m + param.block_m - 1) // param.block_m * n_tiles
+        task_floor = ((total_m - 1) // param.block_m + 1) * n_tiles
         return max(1, min(num_cus * blocks_per_cu, task_floor))
 
     blocks_per_cu = 2 if resource_blocks_per_cu >= 2 else 1
@@ -215,7 +215,6 @@ class _GroupedGemmGfx950Ctx:
         frag_B_retile,
         thr_mma_cRow,
         thr_mma_cCol,
-        thr_mma_bK,
         b_s2r_copy_atom,
         thr_copy_cshuffle,
         thr_sC,
@@ -253,7 +252,6 @@ class _GroupedGemmGfx950Ctx:
         self.frag_B_retile = frag_B_retile
         self.thr_mma_cRow = thr_mma_cRow
         self.thr_mma_cCol = thr_mma_cCol
-        self.thr_mma_bK = thr_mma_bK
         self.b_s2r_copy_atom = b_s2r_copy_atom
         self.thr_copy_cshuffle = thr_copy_cshuffle
         self.thr_sC = thr_sC
@@ -297,8 +295,6 @@ def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
     sA = fx.make_view(smem_a, a_lds_layout)
     sC = fx.make_view(smem_c, c_lds_layout)
     frag_A = rs.thr_mma.make_fragment_A(sA)
-    bk_coords = fx.make_view(0, fx.make_layout((block_n, block_k), (0, 1)))
-    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
     sB = fx.make_view(smem_b, b_lds_s2r_layout)
     frag_B = rs.thr_mma.make_fragment_B(sB)
     frag_B_retile = rs.thr_copy_B.retile(frag_B)
@@ -367,7 +363,6 @@ def _grouped_gemm_gfx950_setup(out, a, b, offs, tiled_mma, param):
         frag_B_retile,
         thr_mma_cRow,
         thr_mma_cCol,
-        thr_mma_bK,
         rs.b_s2r_copy_atom,
         thr_copy_cshuffle,
         thr_sC,
@@ -437,20 +432,12 @@ def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
     thr_sA_s2r = ctx.thr_copy_A.partition_S(sA_stage)
     thr_sB_s2r = ctx.thr_copy_B.partition_S(sB_stage)
 
-    for block_k_iter in range_constexpr(block_k // param.mma_k):
+    def compute_k_chunk(block_k_iter):
         fx.copy(
             ctx.b_s2r_copy_atom,
             thr_sB_s2r[None, None, block_k_iter],
             ctx.frag_B_retile[None, None, block_k_iter],
         )
-        if const_expr(param.has_k_tail):
-            frag_B_chunk = ctx.frag_B[None, None, block_k_iter]
-            bK_chunk = ctx.thr_mma_bK[None, None, block_k_iter]
-            for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
-                in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
-                frag_B_chunk[i] = in_bounds.select(
-                    frag_B_chunk[i], _elem_dtype(param)(0.0)
-                )
         fx.copy(
             ctx.s2r_copy_atom,
             thr_sA_s2r[None, None, block_k_iter],
@@ -464,6 +451,14 @@ def _grouped_compute_stage_from_lds(ctx, read_stage, k_tile, k):
             ctx.frag_C,
             traversal_order=fx.GemmTraversalOrder.KNM,
         )
+
+    for block_k_iter in range_constexpr(block_k // param.mma_k):
+        if const_expr(param.has_k_tail):
+            global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+            if global_k_iter < k:
+                compute_k_chunk(block_k_iter)
+        else:
+            compute_k_chunk(block_k_iter)
 
 
 def _grouped_load_a_tile_async(ctx, row_base, bid_m, m, k, k_tile, stage):
@@ -525,7 +520,10 @@ def _grouped_load_b_tile_async(ctx, bid_n, n, k, group_idx, k_tile, stage):
             % block_n
         )
         global_n_idx = bid_n * block_n + swizzled_n_idx
-        safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        if const_expr(param.has_k_tail):
+            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+        else:
+            safe_global_k_idx = global_k_idx
         global_offset = (
             group_idx * k * n + safe_global_k_idx * n + global_n_idx
         ) * in_data_bytes
@@ -553,8 +551,8 @@ def gemm_gfx950_grouped_kernel(
     stages = param.stages
     has_k_tail = param.has_k_tail
     ldg_a_iters = param.ldg_a_iters
-    num_pid_n = (n + block_n - 1) // block_n
-    k_tiles = (k + block_k - 1) // block_k
+    num_pid_n = (n - 1) // block_n + 1
+    k_tiles = (k - 1) // block_k + 1
     grid = fx.Int32(fx.grid_dim.x)
     work_idx = fx.Int32(fx.block_idx.x)
     tiles_before = fx.Int32(0)
@@ -584,7 +582,6 @@ def gemm_gfx950_grouped_kernel(
                 current_stage = k_tile % stages
                 write_stage = (current_stage + stages - 1) % stages
                 __barrier((stages - 2) * ldg_wait_count)
-                fx.gpu.barrier()
                 _grouped_load_b_tile_async(
                     ctx, bid_n, n, k, g, k_tile + (stages - 1), write_stage
                 )
@@ -595,7 +592,6 @@ def gemm_gfx950_grouped_kernel(
             current_stage = main_loop_end % stages
             for s in range_constexpr(0, stages - 1):
                 __barrier((stages - 2 - s) * ldg_wait_count)
-                fx.gpu.barrier()
                 _grouped_compute_stage_from_lds(
                     ctx, current_stage, main_loop_end + s, k
                 )
@@ -625,6 +621,7 @@ def gemm_hti_gfx950_grouped_kernel(
     block_k = param.block_k
     half_block_m = block_m // 2
     half_block_n = block_n // 2
+    has_k_tail = param.has_k_tail
     async_load_bytes = param.async_load_bytes
     in_data_bytes = param.in_data_bytes
     async_load_vec_size = async_load_bytes // in_data_bytes
@@ -635,9 +632,8 @@ def gemm_hti_gfx950_grouped_kernel(
     elem_dtype = _elem_dtype(param)
 
     tid = fx.thread_idx.x
-    num_pid_n = (n + block_n - 1) // block_n
-    k_tiles = (k + block_k - 1) // block_k
-    has_odd_k_tiles = k_tiles % 2 != 0
+    num_pid_n = (n - 1) // block_n + 1
+    k_tiles = (k - 1) // block_k + 1
 
     smem_a, smem_b, smem_c = _grouped_gemm_gfx950_allocate_shared_storage(
         block_m, block_n, block_k, 2, elem_dtype
@@ -686,7 +682,10 @@ def gemm_hti_gfx950_grouped_kernel(
             in_bounds_m = m_tile_idx < m
             safe_global_m_idx = in_bounds_m.select(row_base + m_tile_idx, 0)
             global_k_idx = k_tile * block_k + swizzled_col_idx(m_local_idx, k_local_idx)
-            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            if const_expr(has_k_tail):
+                safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            else:
+                safe_global_k_idx = global_k_idx
             global_offset = (safe_global_m_idx * k + safe_global_k_idx) * in_data_bytes
             buffer_load_lds_inline(rs.a_rsrc, lds_ptr, global_offset, async_load_bytes)
             if i < half_ldg_a_iters - 1:
@@ -705,7 +704,10 @@ def gemm_hti_gfx950_grouped_kernel(
                 % half_block_n
             )
             global_n_idx = bid_n * block_n + n_part * half_block_n + swizzled_n_idx
-            safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            if const_expr(has_k_tail):
+                safe_global_k_idx = (global_k_idx < k).select(global_k_idx, 0)
+            else:
+                safe_global_k_idx = global_k_idx
             global_offset = (
                 group * k * n + safe_global_k_idx * n + global_n_idx
             ) * in_data_bytes
@@ -713,17 +715,26 @@ def gemm_hti_gfx950_grouped_kernel(
             if i < half_ldg_b_iters - 1:
                 lds_ptr = lds_ptr + block_threads * async_load_bytes
 
-    def load_a_fragment(m_part, read_stage):
+    def load_a_fragment(m_part, read_stage, k_tile):
         sA = fx.make_view(half_a_base(read_stage, m_part), a_lds_layout)
         frag_A = rs.thr_mma.make_fragment_A(sA)
         frag_A_retile = rs.thr_copy_A.retile(frag_A)
         thr_sA_s2r = rs.thr_copy_A.partition_S(sA)
         for block_k_iter in range_constexpr(block_k // param.mma_k):
-            fx.copy(
-                rs.s2r_copy_atom,
-                thr_sA_s2r[None, None, block_k_iter],
-                frag_A_retile[None, None, block_k_iter],
-            )
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.copy(
+                        rs.s2r_copy_atom,
+                        thr_sA_s2r[None, None, block_k_iter],
+                        frag_A_retile[None, None, block_k_iter],
+                    )
+            else:
+                fx.copy(
+                    rs.s2r_copy_atom,
+                    thr_sA_s2r[None, None, block_k_iter],
+                    frag_A_retile[None, None, block_k_iter],
+                )
         return frag_A
 
     def load_b_fragment(n_part, read_stage, k_tile):
@@ -735,30 +746,45 @@ def gemm_hti_gfx950_grouped_kernel(
         frag_B_retile = rs.thr_copy_B.retile(frag_B)
         thr_sB_s2r = rs.thr_copy_B.partition_S(sB)
         for block_k_iter in range_constexpr(block_k // param.mma_k):
-            fx.copy(
-                rs.b_s2r_copy_atom,
-                thr_sB_s2r[None, None, block_k_iter],
-                frag_B_retile[None, None, block_k_iter],
-            )
-            if const_expr(param.has_k_tail):
-                frag_B_chunk = frag_B[None, None, block_k_iter]
-                bK_chunk = thr_mma_bK[None, None, block_k_iter]
-                for i in range_constexpr(fx.size(frag_B_chunk.shape).unpack()):
-                    in_bounds = k_tile * block_k + fx.get_scalar(bK_chunk[i]) < k
-                    frag_B_chunk[i] = in_bounds.select(frag_B_chunk[i], elem_dtype(0.0))
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.copy(
+                        rs.b_s2r_copy_atom,
+                        thr_sB_s2r[None, None, block_k_iter],
+                        frag_B_retile[None, None, block_k_iter],
+                    )
+            else:
+                fx.copy(
+                    rs.b_s2r_copy_atom,
+                    thr_sB_s2r[None, None, block_k_iter],
+                    frag_B_retile[None, None, block_k_iter],
+                )
         return frag_B
 
-    def consume(frag_C, frag_A, frag_B):
+    def consume(k_tile, frag_C, frag_A, frag_B):
         rocdl.sched_barrier(0)
         for block_k_iter in range_constexpr(block_k // param.mma_k):
-            fx.gemm(
-                tiled_mma,
-                frag_C,
-                frag_A[None, None, block_k_iter],
-                frag_B[None, None, block_k_iter],
-                frag_C,
-                traversal_order=fx.GemmTraversalOrder.KNM,
-            )
+            if const_expr(has_k_tail):
+                global_k_iter = k_tile * block_k + block_k_iter * param.mma_k
+                if global_k_iter < k:
+                    fx.gemm(
+                        tiled_mma,
+                        frag_C,
+                        frag_A[None, None, block_k_iter],
+                        frag_B[None, None, block_k_iter],
+                        frag_C,
+                        traversal_order=fx.GemmTraversalOrder.KNM,
+                    )
+            else:
+                fx.gemm(
+                    tiled_mma,
+                    frag_C,
+                    frag_A[None, None, block_k_iter],
+                    frag_B[None, None, block_k_iter],
+                    frag_C,
+                    traversal_order=fx.GemmTraversalOrder.KNM,
+                )
         rocdl.sched_barrier(0)
 
     def half_gC(m_part, n_part, bid_m, bid_n, row_base):
@@ -792,8 +818,6 @@ def gemm_hti_gfx950_grouped_kernel(
     thr_mma_cCol = rs.thr_mma.partition_C(col_coords)
     thr_cRow = thr_copy_cshuffle.partition_S(row_coords)[(0, None), None, None]
     thr_cCol = thr_copy_cshuffle.partition_S(col_coords)[(0, None), None, None]
-    bk_coords = fx.make_view(0, fx.make_layout((half_block_n, block_k), (0, 1)))
-    thr_mma_bK = rs.thr_mma.partition_B(bk_coords)
 
     def store_half_tile(m_part, n_part, frag_C, bid_m, bid_n, m, row_base):
         gC = half_gC(m_part, n_part, bid_m, bid_n, row_base)
@@ -851,71 +875,61 @@ def gemm_hti_gfx950_grouped_kernel(
         next_k_tile = k_tile + 2
 
         b0 = load_b_fragment(0, 0, k_tile)
-        a0 = load_a_fragment(0, 0)
+        a0 = load_a_fragment(0, 0, k_tile)
         load_a_half(1, k_tile + 1, 1, bid_m, m, row_base)
         rocdl.s_barrier()
-        consume(c00, a0, b0)
+        consume(k_tile, c00, a0, b0)
         rocdl.s_barrier()
 
         b1 = load_b_fragment(1, 0, k_tile)
         if const_expr(prefetch_next):
             load_b_half(0, next_k_tile, 0, bid_n, group)
             rocdl.s_barrier()
-        consume(c01, a0, b1)
+        consume(k_tile, c01, a0, b1)
         rocdl.s_barrier()
 
-        a1 = load_a_fragment(1, 0)
+        a1 = load_a_fragment(1, 0, k_tile)
         if const_expr(prefetch_next):
             load_a_half(0, next_k_tile, 0, bid_m, m, row_base)
             rocdl.s_barrier()
-        consume(c10, a1, b0)
+        consume(k_tile, c10, a1, b0)
         rocdl.s_barrier()
 
         b0 = load_b_fragment(0, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_b_half(1, next_k_tile, 0, bid_n, group)
             __barrier(2 * half_ldg_b_iters + half_ldg_a_iters)
-        consume(c11, a1, b1)
+        consume(k_tile, c11, a1, b1)
         if const_expr(not prefetch_next):
             __waitcnt(0)
         rocdl.s_barrier()
 
-        a0 = load_a_fragment(0, 1)
+        a0 = load_a_fragment(0, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_a_half(1, next_k_tile, 0, bid_m, m, row_base)
             rocdl.s_barrier()
-        consume(c00, a0, b0)
+        consume(k_tile + 1, c00, a0, b0)
         rocdl.s_barrier()
 
         b1 = load_b_fragment(1, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_b_half(0, next_k_tile + 1, 1, bid_n, group)
             rocdl.s_barrier()
-        consume(c01, a0, b1)
+        consume(k_tile + 1, c01, a0, b1)
         rocdl.s_barrier()
 
-        a1 = load_a_fragment(1, 1)
+        a1 = load_a_fragment(1, 1, k_tile + 1)
         if const_expr(prefetch_next):
             load_a_half(0, next_k_tile + 1, 1, bid_m, m, row_base)
             rocdl.s_barrier()
-        consume(c10, a1, b0)
+        consume(k_tile + 1, c10, a1, b0)
         rocdl.s_barrier()
 
         if const_expr(prefetch_next):
             load_b_half(1, next_k_tile + 1, 1, bid_n, group)
             __barrier(half_ldg_b_iters + half_ldg_a_iters)
-        consume(c11, a1, b1)
+        consume(k_tile + 1, c11, a1, b1)
         rocdl.s_barrier()
-
-    def compute_single_tile(k_tile, read_stage):
-        b0 = load_b_fragment(0, read_stage, k_tile)
-        b1 = load_b_fragment(1, read_stage, k_tile)
-        a0 = load_a_fragment(0, read_stage)
-        consume(c00, a0, b0)
-        consume(c01, a0, b1)
-        a1 = load_a_fragment(1, read_stage)
-        consume(c10, a1, b0)
-        consume(c11, a1, b1)
 
     grid = fx.Int32(fx.grid_dim.x)
     work_idx = fx.Int32(fx.block_idx.x)
@@ -949,27 +963,11 @@ def gemm_hti_gfx950_grouped_kernel(
             load_b_half(1, 1, 1, bid_n, g)
             __barrier(half_ldg_b_iters + half_ldg_a_iters)
 
-            if has_odd_k_tiles:
-                final_double_tile = k_tiles - 3
-                for k_tile in range(0, final_double_tile, 2):
-                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
-                compute_double_tile(
-                    final_double_tile, False, bid_m, bid_n, m_g, row_base, g
-                )
-                load_b_half(0, k_tiles - 1, 0, bid_n, g)
-                load_a_half(0, k_tiles - 1, 0, bid_m, m_g, row_base)
-                load_b_half(1, k_tiles - 1, 0, bid_n, g)
-                load_a_half(1, k_tiles - 1, 0, bid_m, m_g, row_base)
-                __barrier(0)
-                fx.gpu.barrier()
-                compute_single_tile(k_tiles - 1, 0)
-            else:
-                main_loop_end = (k_tiles > 2).select(k_tiles - 2, 0)
-                for k_tile in range(0, main_loop_end, 2):
-                    compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
-                compute_double_tile(
-                    main_loop_end, False, bid_m, bid_n, m_g, row_base, g
-                )
+            final_double_tile = ((k_tiles % 2) == 0).select(k_tiles - 2, k_tiles - 1)
+            main_loop_end = (k_tiles > 2).select(final_double_tile, 0)
+            for k_tile in range(0, main_loop_end, 2):
+                compute_double_tile(k_tile, True, bid_m, bid_n, m_g, row_base, g)
+            compute_double_tile(main_loop_end, False, bid_m, bid_n, m_g, row_base, g)
 
             store_half_tile(0, 0, c00, bid_m, bid_n, m_g, row_base)
             store_half_tile(0, 1, c01, bid_m, bid_n, m_g, row_base)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_buffer_ops.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_buffer_ops.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: MIT
+# Vendored from the MXFP8 grouped GEMM
+# package in ROCm/AMD-TorchTitan-Ops (`amd_titan/_ops/fwdgemm/_buffer_ops.py`),
+# whose own upstream is the `flydsl-groupped-gemm` development repo. Kept as a
+# separate file from `gemm_gfx950.py` so it can be re-synced wholesale. The one
+# change is `_aux_is_positional`, which handles the 0.3.1 buffer-op builders.
+"""Buffer-descriptor loads and stores, on ops that exist in flydsl 0.2.4 AND 0.3.0.
+
+WHY THIS FILE EXISTS. These kernels were written against flydsl 0.2.4 and called
+``flydsl.expr.buffer_ops`` and ``flydsl.expr.vector``. 0.3.0 DELETED both
+modules, so the kernels only ran there via a compat shim that grafted the two
+0.2.4 modules back under their old names -- which meant carrying 763 lines of
+someone else's deleted code, on a path outside this repo.
+
+The shim was never the only option: ``rocdl.MakeBufferRsrcOp``,
+``RawPtrBufferLoadOp`` and ``RawPtrBufferStoreOp`` are present in BOTH versions.
+0.2.4's ``buffer_ops`` was a convenience layer over exactly those, and this is
+that layer, re-implemented against the ops directly and kept to what these
+kernels actually use. No shim, no version branch, no ``flydsl.expr.buffer_ops``.
+
+What is deliberately NOT here, because no caller needs it: ``mask=``,
+``cache_modifier``, ``stride``, ``base_byte_offset``, ``offset_is_bytes``, the
+``from_addr`` descriptor constructor, and the memref-derived size fallback (every
+caller passes ``num_records_bytes`` explicitly). Adding one back means porting
+its logic from 0.2.4, not guessing.
+
+THE BOUNDS ARE LOAD-BEARING, not an optimisation. ``num_records`` is what makes
+an out-of-range read return 0 instead of faulting, and this kernel relies on that:
+it over-provisions row-tile slots and lets a surplus block's scale read go past
+the plane, where 0 as an e8m0 is 2**-127 and underflows exactly as the epilogue
+mask intends. Dropping the bound gives ``hipErrorIllegalAddress`` on real
+DSV3-16B shapes -- see the descriptor comments in `_fwd_kernel.py`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Optional, Union
+
+from flydsl._mlir import ir
+from flydsl._mlir.dialects import (
+    arith as std_arith,
+    fly as _fly,
+    llvm,
+    rocdl,
+    vector as _vector,
+)
+from flydsl._mlir.extras import types as T
+from flydsl.expr import arith as _arith_ext
+
+
+# CDNA (gfx9xx) buffer resource flags word, bits 127:96 of the V#:
+#   bits [14:12] DATA_FORMAT = 7 (float), bits [18:15] NUM_FORMAT = 4 (32-bit).
+# Mirrors LLVM's AMDGPUToROCDL makeBufferRsrc(). gfx950 is CDNA, so the RDNA
+# variant (bit 24, OOB_SELECT) is not needed and is not offered -- a kernel that
+# ran on RDNA with this constant would silently lose bounds checking.
+_CDNA_BUFFER_FLAGS = (7 << 12) | (4 << 15)  # 0x20070
+_UNBOUNDED = 0xFFFFFFFF
+
+
+def _aux_is_positional(op) -> bool:
+    """Whether this FlyDSL build still takes ``aux`` as a positional operand.
+
+    flydsl 0.2.4/0.3.0 declare ``RawPtrBuffer{Load,Store}Op(..., soffset, aux)``
+    with ``aux`` a required positional ir.Value; 0.3.1 made it a keyword-only
+    *attribute* defaulting to None. Passing the 0.2.4 form to 0.3.1 raises
+    ``TypeError: __init__() takes 5 positional arguments but 6 were given`` at
+    trace time, so the arity is read off the builder rather than assumed.
+    """
+    parameter = inspect.signature(op.__init__).parameters.get("aux")
+    return (
+        parameter is not None
+        and parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    )
+
+
+_LOAD_AUX_IS_POSITIONAL = _aux_is_positional(rocdl.RawPtrBufferLoadOp)
+_STORE_AUX_IS_POSITIONAL = _aux_is_positional(rocdl.RawPtrBufferStoreOp)
+
+
+def _unwrap(v):
+    """DSL Numeric / OpView / ir.Value -> ir.Value."""
+    if hasattr(v, "ir_value"):
+        v = v.ir_value()
+    if hasattr(v, "result"):
+        v = v.result
+    return v
+
+
+def _const_i32(v: int):
+    return std_arith.ConstantOp(T.i32(), ir.IntegerAttr.get(T.i32(), int(v))).result
+
+
+def _const_i16(v: int):
+    return std_arith.ConstantOp(T.i16(), ir.IntegerAttr.get(T.i16(), int(v))).result
+
+
+def _const_i64(v: int):
+    return std_arith.ConstantOp(T.i64(), ir.IntegerAttr.get(T.i64(), int(v))).result
+
+
+def _as_i32(v):
+    """Coerce an unwrapped value to i32, index-casting or sign-extending as needed."""
+    v = _unwrap(v)
+    if isinstance(v.type, ir.IntegerType) and v.type.width == 32:
+        return v
+    if isinstance(v.type, ir.IndexType):
+        return std_arith.IndexCastOp(T.i32(), v).result
+    return std_arith.ExtSIOp(T.i32(), v).result
+
+
+def _as_i64(v):
+    v = _unwrap(v)
+    if isinstance(v.type, ir.IntegerType) and v.type.width == 64:
+        return v
+    if isinstance(v.type, ir.IndexType):
+        return std_arith.IndexCastOp(T.i64(), v).result
+    return std_arith.ExtSIOp(T.i64(), v).result
+
+
+def create_buffer_resource(
+    memref_val,
+    max_size: bool = True,
+    *,
+    num_records_bytes: Optional[Union[int, ir.Value]] = None,
+):
+    """A buffer resource descriptor (V#, `!llvm.ptr<8>`) over a fly.memref.
+
+    `num_records_bytes` sets the hardware bound and takes precedence over
+    `max_size`. Pass it: an unbounded descriptor turns an out-of-range read from
+    a returned 0 into a fault (see the module docstring).
+    """
+    base_ptr = _fly.extract_aligned_pointer_as_index(
+        ir.Type.parse("!llvm.ptr"), _unwrap(memref_val)
+    )
+    if num_records_bytes is None:
+        num_records = _const_i64(_UNBOUNDED if max_size else 0)
+    elif isinstance(num_records_bytes, int):
+        num_records = _const_i64(max(0, min(int(num_records_bytes), _UNBOUNDED)))
+    else:
+        num_records = _as_i64(num_records_bytes)
+    return rocdl.MakeBufferRsrcOp(
+        ir.Type.parse("!llvm.ptr<8>"),
+        base_ptr,
+        _const_i16(0),
+        num_records,
+        _const_i32(_CDNA_BUFFER_FLAGS),
+    ).result
+
+
+def buffer_load(
+    rsrc,
+    offset,
+    vec_width: int = 4,
+    dtype=None,
+    soffset_bytes: Optional[Union[int, ir.Value]] = None,
+    is_scalar: bool = False,
+):
+    """Load `vec_width` x `dtype` from `rsrc` at an ELEMENT offset.
+
+    `offset` is in elements and is scaled to bytes here -- the hardware wants
+    bytes. `soffset_bytes` rides the instruction's scalar offset field, so a
+    small wave-uniform delta costs no VGPR arithmetic.
+
+    `is_scalar` emits `s.buffer.load` instead: a uniform SMEM load landing in
+    SGPRs, for wave-uniform addresses only. It forces i32 (the intrinsic returns
+    raw dwords) and takes no soffset, matching 0.2.4.
+    """
+    if is_scalar:
+        if vec_width not in (1, 4):
+            raise ValueError(f"buffer_load(is_scalar=True): vec_width={vec_width}")
+        if soffset_bytes is not None:
+            raise ValueError("buffer_load(is_scalar=True) takes no soffset_bytes")
+        dtype = T.i32()
+    elif dtype is None:
+        dtype = T.f32()
+    elif hasattr(dtype, "ir_type"):
+        dtype = dtype.ir_type
+
+    offset = _const_i32(offset) if isinstance(offset, int) else _as_i32(offset)
+    # element offset -> byte offset
+    offset = std_arith.MulIOp(offset, _const_i32(dtype.width // 8)).result
+    result_type = dtype if vec_width == 1 else ir.VectorType.get([vec_width], dtype)
+
+    if is_scalar:
+        # The s.buffer.load intrinsic wants the descriptor as v4i32, not the
+        # opaque ptr<8> the vector path uses. It takes TWO steps: `llvm.bitcast`
+        # only casts pointer-to-pointer, so go through an i128 first. Casting
+        # ptr<8> straight to v4i32 fails to compile with
+        # "'llvm.bitcast' op can only cast pointers from and to pointers".
+        rsrc_v4 = llvm.bitcast(
+            ir.VectorType.get([4], T.i32()),
+            llvm.ptrtoint(ir.IntegerType.get_signless(128), _unwrap(rsrc)),
+        )
+        return llvm.call_intrinsic(
+            result_type,
+            "llvm.amdgcn.s.buffer.load." + ("i32" if vec_width == 1 else "v4i32"),
+            [rsrc_v4, offset, _const_i32(0)],
+            [],
+            [],
+        )
+
+    soffset = (
+        _const_i32(0)
+        if soffset_bytes is None
+        else _const_i32(soffset_bytes)
+        if isinstance(soffset_bytes, int)
+        else _as_i32(soffset_bytes)
+    )
+    load_args = [result_type, _unwrap(rsrc), offset, soffset]
+    if _LOAD_AUX_IS_POSITIONAL:
+        load_args.append(_const_i32(0))
+    return rocdl.RawPtrBufferLoadOp(*load_args).result
+
+
+def buffer_store(data, rsrc, offset):
+    """Store `data` to `rsrc` at an ELEMENT offset (scaled to bytes here)."""
+    data = _unwrap(data)
+    offset = _const_i32(offset) if isinstance(offset, int) else _as_i32(offset)
+    elem_t = data.type.element_type if hasattr(data.type, "element_type") else data.type
+    offset = std_arith.MulIOp(offset, _const_i32(elem_t.width // 8)).result
+    store_args = [data, _unwrap(rsrc), offset, _const_i32(0)]
+    if _STORE_AUX_IS_POSITIONAL:
+        store_args.append(_const_i32(0))
+    rocdl.RawPtrBufferStoreOp(*store_args)
+
+
+def vec_extract(vector, static_position=None, dynamic_position=None):
+    """`vector.extract`, replacing 0.3.0's deleted `flydsl.expr.vector.extract`.
+
+    A dynamic index needs a kDynamic sentinel in the static attribute for the
+    ODS builder to pair the two, so fill those in when only dynamic indices are
+    given.
+    """
+    static_position = list(static_position or [])
+    dynamic_position = [
+        _arith_ext.unwrap(i, index=True) for i in (dynamic_position or [])
+    ]
+    if dynamic_position and len(static_position) < len(dynamic_position):
+        static_position += [ir.ShapedType.get_dynamic_size()] * (
+            len(dynamic_position) - len(static_position)
+        )
+    return _vector.ExtractOp(
+        _arith_ext.unwrap(vector),
+        static_position=static_position,
+        dynamic_position=dynamic_position,
+    ).result

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_gemm_utils.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_gemm_utils.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+# Vendored, unmodified apart from this header, from the MXFP8 grouped GEMM
+# package in ROCm/AMD-TorchTitan-Ops
+# (`amd_titan/_ops/fwdgemm/_fp8_gemm_utils.py`).
+# Copyright (c) 2025 FlyDSL Project Contributors
+#
+# FP8-GEMM data-path helpers for the flydsl_8wave candidate. Self-contained:
+# the only dependency is the `flydsl` pip wheel (flydsl.*).
+
+import flydsl.expr as fx
+from flydsl._mlir.dialects import fly as fly_dialect, llvm as _llvm
+from flydsl._mlir.dialects.fly_rocdl import TargetAddressSpace
+from flydsl.expr import arith, const_expr, range_constexpr
+from flydsl.expr.typing import Vector as Vec
+
+
+def preshuffle_b(b_t):
+    """Permute row-major ``B_T`` ``(N, K)`` for ``b_preshuffled=True``."""
+    n, k = b_t.shape[-2:]
+    assert n % 16 == 0 and k % 64 == 0, f"need N%16==0 and K%64==0, got N={n} K={k}"
+    return b_t.reshape(n // 16, 16, k // 64, 4, 16).permute(0, 2, 3, 1, 4).contiguous()
+
+
+def ceildiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def divmod(a: int, b: int) -> tuple[int, int]:
+    return (a // b, a % b)
+
+
+def make_fp8_buffer_tensor(arg_i8, fp8_ir_t):
+    # max_size=False with no num_records_bytes: cosize(layout) becomes a
+    # runtime expression because TensorAdaptor defaults to layout-dynamic
+    # memref (post #554), so the descriptor adapts to the actual tensor
+    # extent and no longer bakes the first-call's shape into IR.
+    t_i8 = fx.rocdl.make_buffer_tensor(arg_i8, max_size=False)
+    iter_i8 = fx.get_iter(t_i8)
+    f8_buf_ptr_ty = fx.PointerType.get(
+        elem_ty=fp8_ir_t,
+        address_space=TargetAddressSpace.BufferDesc,
+        alignment=fx.PointerType(iter_i8.type).alignment,
+    )
+    iter_f8 = fx.recast_iter(f8_buf_ptr_ty, iter_i8)
+    return fx.Tensor(fx.make_view(iter_f8, fx.get_layout(t_i8)))
+
+
+def swizzle_128(row, col):
+    offset = row * 128 + col
+    swizzle = ((offset % (16 * 128)) >> 8) << 4
+    swizzled_offset = offset ^ swizzle
+    return swizzled_offset // 128, swizzled_offset % 128
+
+
+def compute_global_swizzle(lane_id, wave_id, K, n_rounds, preshuffled):
+    offsets = []
+    n_waves = fx.block_dim.x // 64
+    for round in range_constexpr(n_rounds):
+        if const_expr(preshuffled):
+            row = lane_id % 8 + wave_id * 8 + round * (n_waves * 8)
+            col = (lane_id // 8) * 16
+            offsets.append(
+                (row // 16) * (K * 16)
+                + (row % 16) * 16
+                + (col // 64) * 1024
+                + ((col % 64) // 16) * 256
+                + (col % 16)
+            )
+        else:
+            row = lane_id // 8 + wave_id * 8 + round * (n_waves * 8)
+            col = (lane_id % 8) * 16
+            r, c = swizzle_128(row, col)
+            offsets.append(r * K + c)
+    return offsets
+
+
+class G2SLoader:
+    def __init__(self, gl_src, gl_offsets, n_load_steps, lds_dtype, wave_id):
+        self.g2lds_atom = fx.make_copy_atom(fx.rocdl.BufferCopyLDS128b(), 128)
+        self.LdsPtr_t = fx.PointerType.get(lds_dtype, 2, 512)
+        self.gl_src = gl_src
+        self.gl_offsets = gl_offsets
+        self.n_load_steps = n_load_steps
+        self.wave_id = wave_id
+        self.n_waves = fx.block_dim.x // 64
+
+    def _lds_dst_at(self, lds_dst, step):
+        step_off = self.wave_id * 1024 + step * (self.n_waves * 1024)
+        base_i32 = fx.Int32(fx.ptrtoint(lds_dst.ptr))
+        sum_i32 = base_i32 + fx.Int32(step_off)
+        lds_ptr = fx.inttoptr(self.LdsPtr_t, sum_i32)
+        return fx.make_view(lds_ptr, fx.make_layout(1, 1))
+
+    def load(self, lds_dst, k_offset):
+        for step in range_constexpr(self.n_load_steps):
+            src = fx.slice(self.gl_src, (None, fx.Int32(self.gl_offsets[step])))
+            dst = self._lds_dst_at(lds_dst, step)
+            fx.copy(self.g2lds_atom, src, dst, soffset=fx.Int32(k_offset))
+
+    def load_one(self, lds_dst, k_offset, step):
+        src = fx.slice(self.gl_src, (None, fx.Int32(self.gl_offsets[step])))
+        dst = self._lds_dst_at(lds_dst, step)
+        fx.copy(self.g2lds_atom, src, dst, soffset=fx.Int32(k_offset))
+
+
+def pack_i32x4_i32x8(lo, hi):
+    # Pack two i32x4 as one i32x8
+    return lo.shuffle(hi, list(range(8)))
+
+
+class S2RLoader:
+    def __init__(self, wave_idx, n_tiles):
+        self.lane_id = fx.thread_idx.x % 64
+        self.wave_idx = wave_idx
+        self.n_tiles = n_tiles
+
+    def _vec_load_16xf8(self, lds_src, offset):
+        off_tup = fx.make_int_tuple(offset)
+        ptr_off = fx.add_offset(lds_src.ptr, off_tup)
+        i8_iter = fx.recast_iter(fx.Uint8, ptr_off)
+        view = fx.make_view(i8_iter, fx.make_layout(16, 1))
+        return view.load()
+
+    def load(self, lds_src, preshuffled=False):
+        frag = []
+        for i in range_constexpr(self.n_tiles):
+            halves = []
+            row = self.wave_idx * (self.n_tiles * 16) + i * 16 + self.lane_id % 16
+            for step in range_constexpr(2):
+                col = (self.lane_id // 16) * 16 + step * 64
+                if const_expr(preshuffled):
+                    offset = (row // 8) * 1024 + (row % 8) * 16 + (col // 16) * 128
+                else:
+                    row_swz, col_swz = swizzle_128(row, col)
+                    offset = row_swz * 128 + col_swz
+                v = self._vec_load_16xf8(lds_src, offset)
+                halves.append(v.bitcast(fx.Int32))
+            frag.append(pack_i32x4_i32x8(halves[0], halves[1]))
+        return frag
+
+    def load_one(self, lds_src, lds_offset):
+        v = self._vec_load_16xf8(lds_src, lds_offset)
+        return v.bitcast(fx.Int32)
+
+
+class StoreC:
+    def __init__(
+        self, A_scale, B_scale, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b
+    ):
+        self.c_rows = c_rows
+        self.c_cols = c_cols
+        self.lane_id = fx.thread_idx.x % 64
+        self.c_idx_fn = c_idx_fn
+        self.n_tiles_a = n_tiles_a
+        self.n_tiles_b = n_tiles_b
+        # Exact byte counts from compile-time shape (BF16 C output, FP32 scales).
+        # ``num_records_bytes`` is required when ``max_size=False`` -- see
+        # ``make_buffer_tensor`` docstring for the silent-OOB rationale.
+        c_nbytes = c_rows * c_cols * 2  # BFloat16 = 2 bytes
+        sa_nbytes = c_rows * 4  # Float32 row-wise scale
+        sb_nbytes = c_cols * 4  # Float32 col-wise scale
+        gC = fx.rocdl.make_buffer_tensor(C, max_size=False, num_records_bytes=c_nbytes)
+        gSA = fx.rocdl.make_buffer_tensor(
+            A_scale, max_size=False, num_records_bytes=sa_nbytes
+        )
+        gSB = fx.rocdl.make_buffer_tensor(
+            B_scale, max_size=False, num_records_bytes=sb_nbytes
+        )
+        self.c_div = fx.logical_divide(gC, fx.make_layout(1, 1))
+        self.sa_div = fx.logical_divide(gSA, fx.make_layout(1, 1))
+        self.sb_div = fx.logical_divide(gSB, fx.make_layout(1, 1))
+
+        self.scale_atom_4 = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float32)
+        self.scale_atom_1 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
+        self.out_atom_1 = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), fx.BFloat16)
+        self.reg_f32_4 = fx.make_rmem_tensor(fx.make_layout(4, 1), fx.Float32)
+        self.reg_f32_1 = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Float32)
+        self.reg_bf16_1 = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.BFloat16)
+
+    def _load_scale_vec4(self, row):
+        fx.copy(
+            self.scale_atom_4,
+            fx.slice(self.sa_div, (None, fx.Int32(row))),
+            self.reg_f32_4,
+        )
+        return Vec(fx.memref_load_vec(self.reg_f32_4))
+
+    def _load_scale_scalar(self, col):
+        fx.copy(
+            self.scale_atom_1,
+            fx.slice(self.sb_div, (None, fx.Int32(col))),
+            self.reg_f32_1,
+        )
+        return Vec(fx.memref_load_vec(self.reg_f32_1))[0]
+
+    def _store_bf16(self, value_bf16, c_index):
+        fx.memref_store_vec(Vec.filled(1, value_bf16, fx.BFloat16), self.reg_bf16_1)
+        fx.copy(
+            self.out_atom_1,
+            self.reg_bf16_1,
+            fx.slice(self.c_div, (None, fx.Int32(c_index))),
+        )
+
+    def store(self, c_frag, base_row, base_col):
+        a_scales = [
+            self._load_scale_vec4(base_row + i * 16 + (self.lane_id // 16) * 4)
+            for i in range_constexpr(self.n_tiles_a)
+        ]
+        b_scales = [
+            self._load_scale_scalar(base_col + i * 16 + self.lane_id % 16)
+            for i in range_constexpr(self.n_tiles_b)
+        ]
+        for ti in range_constexpr(self.n_tiles_a):
+            row = base_row + ti * 16 + (self.lane_id // 16) * 4
+            for tj in range_constexpr(self.n_tiles_b):
+                col = base_col + tj * 16 + self.lane_id % 16
+                col_valid = col < self.c_cols
+                oob = fx.Int32(self.c_rows * self.c_cols)
+                vec_f32 = Vec(c_frag[self.c_idx_fn(ti, tj)])
+                for i in range_constexpr(4):
+                    scaled = (vec_f32[i] * (a_scales[ti][i] * b_scales[tj])).to(
+                        fx.BFloat16
+                    )
+                    c_index = (row + i) * self.c_cols + col
+                    self._store_bf16(scaled, arith.select(col_valid, c_index, oob))
+
+
+def wait_barrier(count):
+    """`s_waitcnt vmcnt(count) lgkmcnt(0)` then `s_barrier`.
+
+    THE lgkmcnt(0) IS LOAD-BEARING. This barrier protects LDS buffers that other
+    waves are about to overwrite, and vmcnt alone does not cover the ds_reads
+    this wave still has in flight -- ds_read retires on lgkmcnt. The `s_barrier`
+    lives inside an inline-asm string, so the backend cannot see a barrier here
+    and will not insert the lgkmcnt(0) it normally places ahead of one.
+
+    Without it the kernel is correct only by accident, on instruction distance:
+    an s2r fragment is issued in one cluster and consumed in the NEXT, so it
+    crosses this barrier outstanding, and the buffer it reads (`ac1`) is
+    overwritten two clusters later by another wave that this same barrier just
+    released. What covers the gap is the MFMAs in between -- N_ACCUMS of them.
+    At N_ACCUMS 16 (256x256) and 8 (128x256, 256x128) the read always retires
+    first. At N_ACCUMS 4 it does not, which is exactly the set that failed:
+    (128,128) and BLOCK_R=64, 0.01-0.10% of elements wrong, varying run to run
+    and only after repeated calls. Nothing else distinguished those two tiles --
+    occupancy, the interleave plan and the swizzle round count were each ruled
+    out by experiment first.
+    """
+    _llvm.inline_asm(
+        res=None,
+        operands_=[],
+        asm_string=f"s_waitcnt vmcnt({count}) lgkmcnt(0)\ns_barrier",
+        constraints="",
+        has_side_effects=True,
+    )
+
+
+class Mfma16x16x128:
+    def __init__(self, n_tiles_a, n_tiles_b):
+        self.atom = fx.make_mma_atom(
+            fx.rocdl.cdna4.MFMA_Scale(16, 16, 128, fx.Float8E4M3FN)
+        )
+        self.accum_type = Vec.make_type(4, fx.Float32)
+        self.zero_value = Vec.filled(4, 0.0, fx.Float32)
+        self.n_tiles_a = n_tiles_a
+        self.n_tiles_b = n_tiles_b
+
+    def idx(self, i, j):
+        return i * self.n_tiles_b + j
+
+    def _do_mma(self, a, b, c):
+        return fly_dialect.mma_atom_call_ssa([self.accum_type], self.atom, a, b, c)
+
+    def call(self, a, b, c):
+        assert len(a) == self.n_tiles_a
+        assert len(b) == self.n_tiles_b
+        assert len(c) == self.n_tiles_a * self.n_tiles_b
+
+        for i in range_constexpr(self.n_tiles_a):
+            for j in range_constexpr(self.n_tiles_b):
+                c[self.idx(i, j)] = self._do_mma(a[i], b[j], c[self.idx(i, j)])
+        return c
+
+    def call_one(self, a, b, c, i, j):
+        assert i < self.n_tiles_a and j < self.n_tiles_b
+
+        return self._do_mma(a[i], b[j], c[self.idx(i, j)])

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_gemm_utils.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_gemm_utils.py
@@ -6,27 +6,21 @@
 #
 # FP8-GEMM data-path helpers for the flydsl_8wave candidate. Self-contained:
 # the only dependency is the `flydsl` pip wheel (flydsl.*).
+#
+# TRIMMED TO WHAT `mxfp8_grouped_gemm_gfx950` IMPORTS. Upstream also carries
+# `preshuffle_b`, `ceildiv`, `divmod`, `StoreC` and `Mfma16x16x128`; this
+# kernel imports none of them (it issues its own scaled MFMA through
+# `_mfma_scale_agpr` and stores via `buffer_ops.buffer_store`), so they are
+# dropped rather than vendored unused. `Mfma16x16x128` in particular built an
+# `MFMA_Scale` atom and left its scale operands at the atom default, which is
+# only correct while FlyDSL treats that default as an identity scale -- an
+# assumption no live code here depends on.
 
 import flydsl.expr as fx
 from flydsl._mlir.dialects import fly as fly_dialect, llvm as _llvm
 from flydsl._mlir.dialects.fly_rocdl import TargetAddressSpace
 from flydsl.expr import arith, const_expr, range_constexpr
 from flydsl.expr.typing import Vector as Vec
-
-
-def preshuffle_b(b_t):
-    """Permute row-major ``B_T`` ``(N, K)`` for ``b_preshuffled=True``."""
-    n, k = b_t.shape[-2:]
-    assert n % 16 == 0 and k % 64 == 0, f"need N%16==0 and K%64==0, got N={n} K={k}"
-    return b_t.reshape(n // 16, 16, k // 64, 4, 16).permute(0, 2, 3, 1, 4).contiguous()
-
-
-def ceildiv(a: int, b: int) -> int:
-    return (a + b - 1) // b
-
-
-def divmod(a: int, b: int) -> tuple[int, int]:
-    return (a // b, a % b)
 
 
 def make_fp8_buffer_tensor(arg_i8, fp8_ir_t):
@@ -143,88 +137,6 @@ class S2RLoader:
         return v.bitcast(fx.Int32)
 
 
-class StoreC:
-    def __init__(
-        self, A_scale, B_scale, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b
-    ):
-        self.c_rows = c_rows
-        self.c_cols = c_cols
-        self.lane_id = fx.thread_idx.x % 64
-        self.c_idx_fn = c_idx_fn
-        self.n_tiles_a = n_tiles_a
-        self.n_tiles_b = n_tiles_b
-        # Exact byte counts from compile-time shape (BF16 C output, FP32 scales).
-        # ``num_records_bytes`` is required when ``max_size=False`` -- see
-        # ``make_buffer_tensor`` docstring for the silent-OOB rationale.
-        c_nbytes = c_rows * c_cols * 2  # BFloat16 = 2 bytes
-        sa_nbytes = c_rows * 4  # Float32 row-wise scale
-        sb_nbytes = c_cols * 4  # Float32 col-wise scale
-        gC = fx.rocdl.make_buffer_tensor(C, max_size=False, num_records_bytes=c_nbytes)
-        gSA = fx.rocdl.make_buffer_tensor(
-            A_scale, max_size=False, num_records_bytes=sa_nbytes
-        )
-        gSB = fx.rocdl.make_buffer_tensor(
-            B_scale, max_size=False, num_records_bytes=sb_nbytes
-        )
-        self.c_div = fx.logical_divide(gC, fx.make_layout(1, 1))
-        self.sa_div = fx.logical_divide(gSA, fx.make_layout(1, 1))
-        self.sb_div = fx.logical_divide(gSB, fx.make_layout(1, 1))
-
-        self.scale_atom_4 = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Float32)
-        self.scale_atom_1 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
-        self.out_atom_1 = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), fx.BFloat16)
-        self.reg_f32_4 = fx.make_rmem_tensor(fx.make_layout(4, 1), fx.Float32)
-        self.reg_f32_1 = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Float32)
-        self.reg_bf16_1 = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.BFloat16)
-
-    def _load_scale_vec4(self, row):
-        fx.copy(
-            self.scale_atom_4,
-            fx.slice(self.sa_div, (None, fx.Int32(row))),
-            self.reg_f32_4,
-        )
-        return Vec(fx.memref_load_vec(self.reg_f32_4))
-
-    def _load_scale_scalar(self, col):
-        fx.copy(
-            self.scale_atom_1,
-            fx.slice(self.sb_div, (None, fx.Int32(col))),
-            self.reg_f32_1,
-        )
-        return Vec(fx.memref_load_vec(self.reg_f32_1))[0]
-
-    def _store_bf16(self, value_bf16, c_index):
-        fx.memref_store_vec(Vec.filled(1, value_bf16, fx.BFloat16), self.reg_bf16_1)
-        fx.copy(
-            self.out_atom_1,
-            self.reg_bf16_1,
-            fx.slice(self.c_div, (None, fx.Int32(c_index))),
-        )
-
-    def store(self, c_frag, base_row, base_col):
-        a_scales = [
-            self._load_scale_vec4(base_row + i * 16 + (self.lane_id // 16) * 4)
-            for i in range_constexpr(self.n_tiles_a)
-        ]
-        b_scales = [
-            self._load_scale_scalar(base_col + i * 16 + self.lane_id % 16)
-            for i in range_constexpr(self.n_tiles_b)
-        ]
-        for ti in range_constexpr(self.n_tiles_a):
-            row = base_row + ti * 16 + (self.lane_id // 16) * 4
-            for tj in range_constexpr(self.n_tiles_b):
-                col = base_col + tj * 16 + self.lane_id % 16
-                col_valid = col < self.c_cols
-                oob = fx.Int32(self.c_rows * self.c_cols)
-                vec_f32 = Vec(c_frag[self.c_idx_fn(ti, tj)])
-                for i in range_constexpr(4):
-                    scaled = (vec_f32[i] * (a_scales[ti][i] * b_scales[tj])).to(
-                        fx.BFloat16
-                    )
-                    c_index = (row + i) * self.c_cols + col
-                    self._store_bf16(scaled, arith.select(col_valid, c_index, oob))
-
-
 def wait_barrier(count):
     """`s_waitcnt vmcnt(count) lgkmcnt(0)` then `s_barrier`.
 
@@ -253,35 +165,3 @@ def wait_barrier(count):
         constraints="",
         has_side_effects=True,
     )
-
-
-class Mfma16x16x128:
-    def __init__(self, n_tiles_a, n_tiles_b):
-        self.atom = fx.make_mma_atom(
-            fx.rocdl.cdna4.MFMA_Scale(16, 16, 128, fx.Float8E4M3FN)
-        )
-        self.accum_type = Vec.make_type(4, fx.Float32)
-        self.zero_value = Vec.filled(4, 0.0, fx.Float32)
-        self.n_tiles_a = n_tiles_a
-        self.n_tiles_b = n_tiles_b
-
-    def idx(self, i, j):
-        return i * self.n_tiles_b + j
-
-    def _do_mma(self, a, b, c):
-        return fly_dialect.mma_atom_call_ssa([self.accum_type], self.atom, a, b, c)
-
-    def call(self, a, b, c):
-        assert len(a) == self.n_tiles_a
-        assert len(b) == self.n_tiles_b
-        assert len(c) == self.n_tiles_a * self.n_tiles_b
-
-        for i in range_constexpr(self.n_tiles_a):
-            for j in range_constexpr(self.n_tiles_b):
-                c[self.idx(i, j)] = self._do_mma(a[i], b[j], c[self.idx(i, j)])
-        return c
-
-    def call_one(self, a, b, c, i, j):
-        assert i < self.n_tiles_a and j < self.n_tiles_b
-
-        return self._do_mma(a[i], b[j], c[self.idx(i, j)])

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -78,6 +78,7 @@
 
 import dataclasses
 import functools
+import logging
 import os
 
 import torch
@@ -93,7 +94,7 @@ from torch._inductor.runtime.flydsl_cache import run_cached_flydsl
 SCALE_BLOCK = 32
 
 BLOCK_R = 256  # DEFAULT output rows (tokens) per tile; see pick_block_r
-BLOCK_C_DEFAULT = 256  # output cols (N) per tile; 128 also supported, see pick_block_c
+BLOCK_C_DEFAULT = 256  # output cols (N) per tile; 128 also supported, see pick_tile
 BLOCK_M = 128  # contraction elements per pipeline step (= BLOCK_K)
 
 
@@ -140,14 +141,16 @@ def pick_block_r(m_total: int, e: int) -> int:
 def pick_tile(m_total: int, e: int, n: int) -> tuple:
     """(BLOCK_R, BLOCK_C) for this shape, shrinking both when the grid starves.
 
-    `pick_block_r` and `pick_block_c` each answer a local question and neither
-    looks at how many blocks the pair produces. That is fine everywhere except
+    `pick_block_r` answers a local question and does not look at how many
+    blocks the resulting tile produces. That is fine everywhere except
     small N, where BLOCK_C=256 leaves ONE column tile and the row dim is the
     only parallelism left: K4096 x N256 tiles to 16 blocks on a 256-CU part.
 
     Halving a tile dimension doubles the block count, and at a starved grid that
     trade is strongly positive even though the narrower tile is worse per block.
-    THE THRESHOLD IS ONE FULL WAVE.
+    THE THRESHOLD IS ONE FULL WAVE, and the shrink stops at (128, 128): going on
+    to BLOCK_R=64 measured 2.2% at K4096 x N256 on MI355X, inside the harness
+    run-to-run band, which does not pay for another branch here.
 
     Note for anyone re-deriving this: the original block_c sweep that concluded
     "128 loses on 11 of 12 shapes" predates the surplus-slot guard, when the
@@ -156,7 +159,12 @@ def pick_tile(m_total: int, e: int, n: int) -> tuple:
     Do not resurrect those numbers.
     """
     br = pick_block_r(m_total, e)
-    bc = pick_block_c(n)
+    # BLOCK_C is always 256 to start: a tile that overhangs N is not free, but
+    # the narrow tile is still ~15% slower where it removes the whole overhang,
+    # because per K-step a wave issues 4*NA*NB MFMAs against 4*(NA+NB) LDS reads
+    # -- ratio 2.0 at 4x4 against 1.33 at 4x2. 128 is taken below only when the
+    # grid is starved, where occupancy outweighs that ratio.
+    bc = BLOCK_C_DEFAULT
     if e <= 0 or n <= 0:
         return br, bc
     # Row tiles are per-group, so the average group is what the grid sees.
@@ -179,21 +187,10 @@ def pick_tile(m_total: int, e: int, n: int) -> tuple:
         br = 128
         if tiles_at(br, bc) >= _STARVED_TILES:
             return br, bc
-    # Third step, for the shapes STILL starved after both. K4096 x N256 is the
-    # case: bandwidth-bound with too few concurrent blocks to saturate HBM, so
-    # throughput tracks block count. Split-K is NOT the fix -- the K-walk is
-    # only ~6us of a 25us kernel there, so splitting scales time linearly with
-    # launches; this shape wants more blocks per launch, not more launches.
-    #
-    # HALF the threshold, because the step reverses once bandwidth saturates: a
-    # finer tile re-reads operands more times, so it only pays while there are
-    # too few blocks to use the bus. K4096 x N512 is the far side, where
-    # (64,128) buys more bytes for less work and loses. The gate is therefore
-    # "still under half a wave after both steps".
-    if br == 128 and tiles_at(br, bc) < _STARVED_TILES // 2:
-        br = 64
     return br, bc
 
+
+log = logging.getLogger(__name__)
 
 _STARVED_TILES = 256  # one full wave on MI350X's 256 CUs; see pick_tile
 
@@ -215,10 +212,8 @@ def _warn_guard_fallback(K, N, E, BLOCK_C, BLOCK_R, err) -> None:
     if key in _guard_fallback_warned:
         return
     _guard_fallback_warned.add(key)
-    import logging
-
-    logging.getLogger(__name__).warning(
-        "[amd_titan] fwdgemm: surplus-slot guard failed to compile at "
+    log.warning(
+        "FlyDSL MXFP8 grouped GEMM: surplus-slot guard failed to compile at "
         "K=%d N=%d E=%d BLOCK_C=%d BLOCK_R=%d (%s: %s); falling back to the "
         "unguarded kernel, which is correct but pays for its surplus slots.",
         K,
@@ -231,20 +226,6 @@ def _warn_guard_fallback(K, N, E, BLOCK_C, BLOCK_R, err) -> None:
     )
 
 
-def pick_block_c(N: int) -> int:
-    """Column tile width. Always 256 -- the narrow tile was measured and lost.
-
-    A tile that overhangs N is not free: the MFMAs run on the overhang and the
-    results are discarded at the store. Even so, at the shapes where 128 removes
-    the whole overhang it is still ~15% slower, because per K-step a wave issues
-    4*NA*NB MFMAs against 4*(NA+NB) LDS reads -- ratio 2.0 at 4x4 against 1.33
-    at 4x2. Hardware efficiency drops further than the saved work is worth.
-
-    No better tile is available: the accumulators already fill all 256 AGPRs at
-    NA*NB = 16 per quadrant. Pass ``block_c=128`` explicitly to re-run the
-    comparison; `pick_tile` still takes 128 when the grid is starved.
-    """
-    return BLOCK_C_DEFAULT
 
 
 import flydsl.compiler as flyc
@@ -266,11 +247,9 @@ from .mxfp8_gemm_utils import (
 )
 
 
-# Interleave each quadrant's 16 MFMAs with the g2s/s2r loads of the NEXT
-# fragment so they co-issue in the MFMA execute shadow. Worth +6.6% in wgrad
-# once its scale loads stopped saturating the L1 address path. Set
-# FWDGEMM_INTERLEAVE=0 for the plain cluster.
-_INTERLEAVE = os.environ.get("FLYDSL_MXFP8_GROUPED_INTERLEAVE", "1") != "0"
+# Each quadrant's 16 MFMAs are interleaved with the g2s/s2r loads of the NEXT
+# fragment so they co-issue in the MFMA execute shadow -- worth +6.6% in wgrad
+# once its scale loads stopped saturating the L1 address path.
 
 
 def _mfma_scale_agpr(a, b, sa, sb, acc):
@@ -737,14 +716,7 @@ def _compile(
                     out.append(swz)
                 return out
 
-            def _cluster_plain(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
-                g2s.load(lds_dst, k_off)
-                vm.issue(g2s.n_load_steps)
-                rt = s2r.load(lds_src)
-                c = mma(a, b, c, sa, sb)
-                return c, rt
-
-            def _cluster_il(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+            def _cluster(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
                 # Interleave this quadrant's MFMAs with the g2s and s2r loads of
                 # the NEXT fragment, so the loads co-issue in the MFMA execute
                 # shadow. Mirrors fp8_gemm_4wave's _interleaved_cluster; the MFMA
@@ -774,8 +746,6 @@ def _compile(
 
                 vm.issue(g2s.n_load_steps)
                 return c, rt
-
-            _cluster = _cluster_il if _INTERLEAVE else _cluster_plain
 
             # ── Prologue: pre-fill the 8-buffer LDS pipeline (2 K-steps) ──
             # Chunk 0 goes first so it is the oldest thing in flight and the
@@ -1285,8 +1255,7 @@ def _row_windows(M, K, N, offs, block_r=BLOCK_R):
         yield r0, rows, (offs - r0).clamp_(0, rows)
 
 
-# Names the Inductor lazy-export table in `kernels/__init__.py` binds to.
-# Aliases rather than renames, so the body above stays diffable against the
+# Name the Inductor lazy-export table in `kernels/__init__.py` binds to. An
+# alias rather than a rename, so the body above stays diffable against the
 # upstream AMD-TorchTitan-Ops file.
-MXFP8_SCALE_BLOCK = SCALE_BLOCK
 pick_mxfp8_grouped_gemm_tile = pick_tile

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -26,6 +26,10 @@
 #   * `MXFP8GroupedGemmParam` carries the compile key so the template can hand
 #     it to `run_cached_flydsl` the same way the dense and BF16-grouped
 #     templates hand over their `GemmGfx950Param`.
+#   * `pick_block_r` scores MFMA density against actual overhang instead of
+#     comparing m_avg to a constant. This is the ONE divergence from upstream
+#     in a decision the kernel body relies on; it is measured over 43 shapes in
+#     the comment on that function and should be ported back.
 #
 # Exactly four things differ from the even-groups parent. Everything else --
 # the 8-buffer LDS ping-pong, the AGPR-pinned scaled MFMA, the cooperative
@@ -165,12 +169,40 @@ def pick_block_r(m_total: int, e: int) -> int:
     """
     if e <= 0:
         return 256
-    m_avg = m_total // e
-    if m_avg <= 96:
-        return 64
-    if m_avg <= 320:
-        return 128
-    return 256
+    m_avg = max(m_total // e, 1)
+
+    # OVERHANG, NOT A THRESHOLD ON m_avg. The docstring above says the waste is
+    # (BLOCK_R / m_g), but that only holds while m_g < BLOCK_R; in general a
+    # group of m_avg rows under a BLOCK_R tile is charged
+    # ceildiv(m_avg, BLOCK_R) * BLOCK_R rows. At m_avg = 256 that factor is 1.0
+    # for every legal tile -- a 256-row group fills a 256-row tile exactly -- so
+    # the ladder's "m_avg <= 320 -> 128" narrowed the tile to remove an overhang
+    # that was not there, paying the MFMA-per-ds_read ratio (2.0 at 4x4 against
+    # 1.33 at 2x4) for nothing.
+    #
+    # Scoring density against actual overhang instead. Measured on MI350X over
+    # 43 shapes (the 19 benchmark shapes plus an m_avg ladder of 64..512 at
+    # K=N=4096 and K=N=8192, all six tiles timed interleaved in one process,
+    # median of 3 runs of 21), against the best tile for each shape:
+    #
+    #   rule       geomean loss vs best tile   >2% off
+    #   ladder     1.0271x                     12/43
+    #   this       1.0055x                      4/43
+    #
+    # Biggest single gain 1.158x at m_avg=96, K=N=8192, where the ladder picked
+    # 64 and the right answer is 128. Shapes with m_avg >= 384 -- including the
+    # DSV3 shape this kernel was tuned on, m_g=24576 -- score 256 exactly as the
+    # ladder did, so the original calibration is unchanged.
+    best_block_r, best_score = 256, -1.0
+    for block_r in (64, 128, 256):
+        n_tiles_a = block_r // 64
+        # MFMA-per-ds_read ratio at this tile height, against a 4-wide tile.
+        density = n_tiles_a * 4 / (n_tiles_a + 4)
+        overhang = ceildiv(m_avg, block_r) * block_r / m_avg
+        score = density / overhang
+        if score > best_score:
+            best_block_r, best_score = block_r, score
+    return best_block_r
 
 
 def pick_tile(m_total: int, e: int, n: int) -> tuple:

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -28,8 +28,8 @@
 #     templates hand over their `GemmGfx950Param`.
 #   * `pick_block_r` scores MFMA density against actual overhang instead of
 #     comparing m_avg to a constant. This is the ONE divergence from upstream
-#     in a decision the kernel body relies on; it is measured over 43 shapes in
-#     the comment on that function and should be ported back.
+#     in a decision the kernel body relies on; the 43-shape sweep behind it is
+#     in the PR description, and it should be ported back.
 #
 # Exactly four things differ from the even-groups parent. Everything else --
 # the 8-buffer LDS ping-pong, the AGPR-pinned scaled MFMA, the cooperative
@@ -54,39 +54,25 @@
 # zero-initialised because a masked store no longer covers every row.
 # ---------------------------------------------------------------------------
 #
-# Ported from flydsl-wgrad's `_wgrad_kernel_v3.py` v3.3 (1305 TFLOP/s, 28.3% of
-# MI350X peak). The port is small because the two problems have the SAME operand
-# layout: both are `C = A @ B^T` with A and B row-major and the contraction
-# running along the contiguous axis. What differs is only what the axes mean:
+# Ported from flydsl-wgrad's `_wgrad_kernel_v3.py` v3.3. The port is small
+# because the two problems have the SAME operand layout -- both are
+# `C = A @ B^T` with A and B row-major and the contraction along the contiguous
+# axis. What differs is what the axes mean: wgrad's groups partition the
+# CONTRACTION, these partition the OUTPUT ROWS, so the group index moves from
+# the K-walk into the tile's base addresses.
 #
-#                    wgrad v3.3                      forward (here)
-#   A                go_t   (R=N, M_TOTAL)           X      (M_tok, K)
-#   B                ia_t   (C=K, M_TOTAL)           W[g]   (N, K)
-#   contraction      tokens, length m_g              K, length K (fixed)
-#   groups partition the CONTRACTION                 the OUTPUT ROWS
-#   per-group offset a column offset (m_start)       a row offset on A, a plane on B
-#   output           (E, R, C) f32                   (M_tok, N) bf16
-#
-# So the group index moves from the K-walk into the tile's base addresses, the
-# contraction becomes short and uniform (K/128 = 16 or 11 steps, versus wgrad's
-# 192), and the epilogue writes bf16 into one 2-D matrix instead of f32 into a
-# per-expert stack.
-#
-# Two structural consequences of the short contraction:
-#   * The K-loop is fully unrolled at compile time. wgrad needed `scf.for`
-#     because a 192-step constexpr loop hung the JIT; at 11-16 steps the rolled
-#     form only costs scheduling freedom, and the loop-carried a0/b0 fragments
-#     and scale chunk disappear.
+# Two structural consequences of the short contraction (K/128 = 11-16 steps,
+# against wgrad's 192):
+#   * The K-loop is fully unrolled at compile time; the loop-carried a0/b0
+#     fragments and scale chunk disappear.
 #   * Pipeline fill and drain are a much larger fraction of the kernel (2 of 16
-#     steps are prologue, 2 are tails), so prologue cost matters here in a way it
-#     never did for wgrad.
+#     steps are prologue, 2 are tails), so prologue cost matters here in a way
+#     it never did for wgrad.
 #
-# The vmcnt accounting is derived, not transcribed. wgrad hand-computed four
-# constants (W1A/W2A/W1B/W2B) for its steady state; with the loop unrolled the
-# issue pattern is not perfectly periodic (the last steps stop prefetching
-# scales), so `_VmCounter` tracks issued vector-memory ops and each barrier waits
-# for exactly "everything up to the op I depend on". It reproduces wgrad's
-# constants in the steady state -- see the test in test_correctness.py.
+# The vmcnt accounting is derived, not transcribed: with the loop unrolled the
+# issue pattern is not perfectly periodic, so `_VmCounter` tracks issued
+# vector-memory ops and each barrier waits for exactly "everything up to the op
+# I depend on".
 
 # NOTE: no `from __future__ import annotations` -- fx.struct needs real types.
 
@@ -112,87 +98,33 @@ BLOCK_M = 128  # contraction elements per pipeline step (= BLOCK_K)
 
 
 def pick_block_r(m_total: int, e: int) -> int:
-    """Row tile height, from the AVERAGE group size. 256 unless groups are small.
+    """Row tile height, from the AVERAGE group size.
 
-    A row tile is charged for every row it covers, so a group of 64 tokens under
-    a 256-row tile runs the MFMAs on 256 rows and discards three quarters of the
-    result at the masked store. The waste is (BLOCK_R / m_g) and it is the single
-    largest term at the small-M shapes: measured 4.6% of MXFP8 peak at
-    m_g=64 (g32x64x2048x2048) against 20-25% where m_g >= 512.
-
-    A narrower tile costs per-block efficiency, because the MFMA-per-ds_read
-    ratio is NA*NB/(NA+NB) -- 2.0 at 4x4 (BLOCK_R=256), 1.33 at 2x4 (128), 0.8 at
-    1x4 (64). So this is only worth taking when the overhang it removes is bigger
-    than the ratio it gives up, i.e. when a group does not fill the wider tile.
+    A row tile is charged for every row it covers: a group of m_avg rows under a
+    BLOCK_R tile is charged ceildiv(m_avg, BLOCK_R) * BLOCK_R rows and discards
+    the rest at the masked store. A narrower tile removes that overhang but
+    costs per-block efficiency -- the MFMA-per-ds_read ratio is NA*NB/(NA+NB),
+    2.0 at 4x4 (BLOCK_R=256), 1.33 at 2x4 (128), 0.8 at 1x4 (64) -- so the two
+    are scored against each other below.
 
     AVERAGE, not per-group, and that is forced: the group sizes live on the
-    device and this kernel's whole design is not to sync on them (see
-    `grouped_mm`). m_total and E are host-side shape metadata, so m_total // E
-    costs nothing. Under real MoE routing the groups are within ~2x of the mean,
-    so the average picks the right tile for most of them; a badly skewed batch
-    gets a tile sized for its mean, which is still no worse than the fixed 256.
+    device and this kernel's whole design is not to sync on them. m_total and E
+    are host-side shape metadata, so m_total // E costs nothing. Under real MoE
+    routing the groups are within ~2x of the mean; a skewed batch gets a tile
+    sized for its mean, which is no worse than the fixed 256.
 
-    THE CUTOFF IS MEASURED, NOT DERIVED, and it sits at 320 because that is
-    where the evidence stops being one-sided. Pure overhang arithmetic says 128
-    only pays below m_g=128, but it keeps winning up to a skewed ragged mean of
-    269 (+44%), because the smaller tile also doubles the tile count and fills
-    the machine. At m_avg=512 it is no longer a win in any consistent direction
-    -- the same m_avg goes +5.2%, -2.6% and -14.0% depending only on K, N and E
-    -- so 512 stays on the wide tile. Measured (median of 3, bitwise-identical
-    output, TFLOP/s):
-
-        m_avg  shape                     br=256   br=128   pick
-           62  ragged [1,3,7,15,...]      254.8    366.2    128 (64 would give 430.3)
-           64  g32x64x2048x2048           219.9    298.7    128 (64 would give 375.1)
-          128  g8x128x4096x4096           461.6    595.7    128
-          128  g16x128x4096x4096          408.0    536.9    128
-          256  g16x256x2048x2048          628.5    614.0    128  (-2.3%, the one loss)
-          256  g8x256x8192x8192           806.1    867.3    128
-          269  ragged [100,333,777,...]   571.7    820.6    128
-          512  g8x512x4096x4096           992.0   1044.1    256  (+5.2% forgone)
-          512  g16x512x4096x4096         1036.6   1009.9    256
-          512  g8x512x8192x2048           994.1    854.5    256  (128 costs 14%)
-          696  ragged [813,1200,47,...]  1199.2   1073.7    256
-         1024  g4x1024x2048x2048          771.1    682.4    256
-
-    64 IS RETURNED AGAIN at m_avg <= 96, where it is the fastest tile (1.71x at
-    g32x64, 1.69x at the [1,3,7,...] ragged). It used to compute wrong answers;
-    the cause was `wait_barrier` waiting on vmcnt but never lgkmcnt, so an s2r
-    fragment issued in one cluster and consumed in the next crossed the barrier
-    outstanding while another wave overwrote its LDS buffer. Only the MFMAs in
-    between covered the gap -- N_ACCUMS of them -- so the tiles with N_ACCUMS=4
-    (this one, and BLOCK_C=128 with BLOCK_R=128) were the ones that broke. Fixed
-    in `_fp8_gemm_utils.wait_barrier`; verified clean on all 10 shapes of
-    scratchpad/dbg_br64.py on the development branch, including the K=8192
-    N=8192 case that used to corrupt
-    1510 elements.
+    BLOCK_R=64 computed wrong answers until the `wait_barrier` lgkmcnt fix in
+    `mxfp8_gemm_utils`; verified clean since.
     """
     if e <= 0:
         return 256
     m_avg = max(m_total // e, 1)
 
-    # OVERHANG, NOT A THRESHOLD ON m_avg. The docstring above says the waste is
-    # (BLOCK_R / m_g), but that only holds while m_g < BLOCK_R; in general a
-    # group of m_avg rows under a BLOCK_R tile is charged
-    # ceildiv(m_avg, BLOCK_R) * BLOCK_R rows. At m_avg = 256 that factor is 1.0
-    # for every legal tile -- a 256-row group fills a 256-row tile exactly -- so
-    # the ladder's "m_avg <= 320 -> 128" narrowed the tile to remove an overhang
-    # that was not there, paying the MFMA-per-ds_read ratio (2.0 at 4x4 against
-    # 1.33 at 2x4) for nothing.
-    #
-    # Scoring density against actual overhang instead. Measured on MI350X over
-    # 43 shapes (the 19 benchmark shapes plus an m_avg ladder of 64..512 at
-    # K=N=4096 and K=N=8192, all six tiles timed interleaved in one process,
-    # median of 3 runs of 21), against the best tile for each shape:
-    #
-    #   rule       geomean loss vs best tile   >2% off
-    #   ladder     1.0271x                     12/43
-    #   this       1.0055x                      4/43
-    #
-    # Biggest single gain 1.158x at m_avg=96, K=N=8192, where the ladder picked
-    # 64 and the right answer is 128. Shapes with m_avg >= 384 -- including the
-    # DSV3 shape this kernel was tuned on, m_g=24576 -- score 256 exactly as the
-    # ladder did, so the original calibration is unchanged.
+    # Density against actual overhang, not a threshold on m_avg: at m_avg=256
+    # every legal tile has overhang 1.0, so narrowing there gives up the ratio
+    # for nothing. Measured over 43 shapes, geomean loss against the best tile
+    # is 1.0055x here against 1.0271x for a threshold ladder; shapes with
+    # m_avg >= 384 pick 256 either way. Sweep in the PR description.
     best_block_r, best_score = 256, -1.0
     for block_r in (64, 128, 256):
         n_tiles_a = block_r // 64
@@ -210,28 +142,18 @@ def pick_tile(m_total: int, e: int, n: int) -> tuple:
 
     `pick_block_r` and `pick_block_c` each answer a local question and neither
     looks at how many blocks the pair produces. That is fine everywhere except
-    small N, where BLOCK_C=256 leaves ONE column tile and the row dim is the only
-    parallelism left: K4096 x N256 tiles to 16 blocks on a 256-CU part, 6% of the
-    machine, and it is the one PR shape still under 1x of the bf16 kernel.
+    small N, where BLOCK_C=256 leaves ONE column tile and the row dim is the
+    only parallelism left: K4096 x N256 tiles to 16 blocks on a 256-CU part.
 
     Halving a tile dimension doubles the block count, and at a starved grid that
-    trade is strongly positive even though the narrower tile is worse per block
-    (the MFMA-per-ds_read ratio argument in `pick_block_c`). Measured at
-    K4096 x N256, M=4096 over 8 groups, bitwise-identical output:
+    trade is strongly positive even though the narrower tile is worse per block.
+    THE THRESHOLD IS ONE FULL WAVE.
 
-        br    bc   tiles   TF/s
-        256   256     16   145.4   (1.00x, the shipped pick)
-        256   128     32   215.9   (1.48x)
-        128   256     32   212.6   (1.46x)
-        128   128     64   296.3   (2.04x)
-
-    THE THRESHOLD IS ONE FULL WAVE, and the evidence for it had to be re-taken.
-    The original block_c sweep -- "128 loses on 11 of 12 shapes", including 0.86x
-    at g4x1024x2048x2048 -- was measured BEFORE the surplus-slot guard, when the
+    Note for anyone re-deriving this: the original block_c sweep that concluded
+    "128 loses on 11 of 12 shapes" predates the surplus-slot guard, when the
     launched grid was (ceildiv(M,BLOCK_R) + E) * n_c instead of the tile count,
     so both arms were partial-wave and the comparison never isolated occupancy.
-    Post-guard the grid IS the tile count, the same shape goes +14%, and every
-    partial-wave shape measured gains 11-14%. Do not resurrect the old numbers.
+    Do not resurrect those numbers.
     """
     br = pick_block_r(m_total, e)
     bc = pick_block_c(n)
@@ -242,26 +164,10 @@ def pick_tile(m_total: int, e: int, n: int) -> tuple:
     if tiles >= _STARVED_TILES:
         return br, bc
     # Only a tile that is 256 in BOTH dims can be halved: halving one that is
-    # already 128 lands on (128, 128), which is banned below. Measured on the
-    # partial-wave shapes (TFLOP/s, all bitwise-correct, post-surplus-guard):
-    #
-    #   shape                 pick  (256,256)  (256,128)  (128,256)   taken
-    #   g4x1024x2048x2048  256,256      823.4      938.1      929.9   +14%
-    #   g4x512x4096x4096   256,256     1018.2     1164.8     1156.5   +14%
-    #   g8x512x8192x2048   256,256     1110.8     1231.6     1267.7   +11%
-    #   g8x128x4096x4096   128,256      522.8      618.8      730.1   -> (128,128)
-    #   ragged [1,3,7,...] 128,256      269.4      335.5      386.2   -> narrower
-    #
-    # SHRINK ONE STEP AT A TIME, re-checking. (128,128) and BLOCK_R=64 were
-    # banned until 2026-08-13 for computing wrong answers; the cause was
-    # `wait_barrier` waiting on vmcnt and never lgkmcnt, so an s2r fragment
-    # issued in one cluster and consumed in the next crossed the barrier still
-    # outstanding while another wave overwrote its LDS buffer. The only thing
-    # covering that gap was the MFMAs in between -- N_ACCUMS of them -- so
-    # exactly the tiles with N_ACCUMS=4 broke. Fixed in `_fp8_gemm_utils`, and
-    # both tiles verified clean on the repros that used to fail every time.
-    # At K4096 x N256 the two-step shrink is worth 296.3 TF/s against 215.9 for
-    # stopping at (256,128).
+    # already 128 lands on (128, 128). SHRINK ONE STEP AT A TIME, re-checking;
+    # the partial-wave shapes gain 11-14% from the first step. (128,128) and
+    # BLOCK_R=64 were banned until the `wait_barrier` lgkmcnt fix, which is what
+    # made the N_ACCUMS=4 tiles compute wrong answers.
     tiles_at = lambda r, c: (
         max(1, e * ceildiv(max(m_total // e, 1), r)) * ceildiv(n, c)
     )
@@ -273,36 +179,17 @@ def pick_tile(m_total: int, e: int, n: int) -> tuple:
         br = 128
         if tiles_at(br, bc) >= _STARVED_TILES:
             return br, bc
-    # Third step, for the shapes that are STILL starved after both. K4096 x N256
-    # is the case: it is bandwidth-bound with too few concurrent blocks to
-    # saturate HBM, and throughput tracks achieved bandwidth, which tracks block
-    # count. Measured there (bitwise-identical output):
+    # Third step, for the shapes STILL starved after both. K4096 x N256 is the
+    # case: bandwidth-bound with too few concurrent blocks to saturate HBM, so
+    # throughput tracks block count. Split-K is NOT the fix -- the K-walk is
+    # only ~6us of a 25us kernel there, so splitting scales time linearly with
+    # launches; this shape wants more blocks per launch, not more launches.
     #
-    #   tile      tiles  waves    TF/s   achieved TB/s
-    #   (256,256)    16   0.06   147.4   0.63
-    #   (256,128)    32   0.12   222.4   1.40
-    #   (128,128)    64   0.25   302.8   2.51
-    #   (64,128)    128   0.50   361.1   4.45
-    #
-    # TAKE THE LAST ROW AS +9%, NOT +19%. That 361.1 came from one back-to-back
-    # sweep; an interleaved A/B repeated across three fresh processes puts
-    # (64,128) at 1.073 / 1.095 / 1.110 of (128,128), i.e. ~336 TF/s against
-    # ~305. One shape at +9% is ~+0.4% of the 24-shape geomean, which is inside
-    # that harness's run-to-run band -- so this step is justified by the A/B and
-    # will NOT be visible end to end. Do not go looking for it there.
-    #
-    # Split-K would be the textbook fix and is NOT it: the K-walk is only ~6us
-    # of a 25us kernel there, so splitting K scaled the time LINEARLY with the
-    # number of launches (S=2 -> 0.50x, S=4 -> 0.25x). More blocks per launch is
-    # what this shape wants, not more launches.
-    #
-    # HALF the threshold, because this step reverses once bandwidth saturates.
-    # A finer tile re-reads operands more times, so it only pays while there are
-    # too few blocks to use the bus. K4096 x N512 shows the far side: it reaches
-    # 4.58 TB/s at (128,128) already, and (64,128) buys 4.91 TB/s of MORE bytes
-    # for LESS work -- 551.2 -> 398.6 TF/s. N256 is the near side, 2.51 -> 4.45
-    # TB/s and 302.8 -> 361.1 TF/s. The two differ by whether 128 tiles is
-    # already enough, so the gate is "still under half a wave after both steps".
+    # HALF the threshold, because the step reverses once bandwidth saturates: a
+    # finer tile re-reads operands more times, so it only pays while there are
+    # too few blocks to use the bus. K4096 x N512 is the far side, where
+    # (64,128) buys more bytes for less work and loses. The gate is therefore
+    # "still under half a wave after both steps".
     if br == 128 and tiles_at(br, bc) < _STARVED_TILES // 2:
         br = 64
     return br, bc
@@ -347,31 +234,15 @@ def _warn_guard_fallback(K, N, E, BLOCK_C, BLOCK_R, err) -> None:
 def pick_block_c(N: int) -> int:
     """Column tile width. Always 256 -- the narrow tile was measured and lost.
 
-    The motivation for a narrow tile is real: a tile that overhangs N is not
-    free, because the MFMAs run on the overhang and the results are discarded at
-    the store. At K=2048, M=196608, N=1408 (6x256 = 1536 columns) and N=1536 take
-    the SAME 0.83 ms, so the 9.1% overhang is paid in full, and the kernel's
-    29.8% of peak on useful FLOPs is really 32.3% of the hardware.
+    A tile that overhangs N is not free: the MFMAs run on the overhang and the
+    results are discarded at the store. Even so, at the shapes where 128 removes
+    the whole overhang it is still ~15% slower, because per K-step a wave issues
+    4*NA*NB MFMAs against 4*(NA+NB) LDS reads -- ratio 2.0 at 4x4 against 1.33
+    at 4x2. Hardware efficiency drops further than the saved work is worth.
 
-    1408 = 2^7 x 11 and a legal BLOCK_C is 64 x N_TILES_B, so 128 is the only
-    sane width that divides it. Measured (median of 3, interleaved):
-
-        K=2048 N=1408   256: 0.831 ms 1365 TF/s   128: 0.979 ms 1158   0.849x
-        K=1408 N=2048   256: 0.833 ms 1361 TF/s   128: 1.034 ms 1097   0.806x
-        K=2048 N=2048   256: 1.105 ms 1493 TF/s   128: 1.326 ms 1244   0.833x
-
-    So the narrow tile removes the whole overhang at N=1408 and is still 15%
-    slower. Why: per K-step a wave issues 4*NA*NB MFMAs against 4*(NA+NB) LDS
-    reads, so the MFMA-per-ds_read ratio is NA*NB/(NA+NB) -- 2.0 at 4x4, 1.33 at
-    4x2. Hardware efficiency drops 32.3% -> 25.1%, a 22% loss to save 9% of work.
-
-    There is no better tile available: the accumulators already fill all 256
-    AGPRs at NA*NB = 16 per quadrant, so no shape with a higher ratio fits. The
-    NA=8, NB=2 corner (ratio 1.6, and exactly 160 KB of LDS) interpolates to
-    ~28% hardware, still below the 29.8% useful the wide tile delivers.
-
-    Conclusion: the overhang at N=1408 is not recoverable by retiling. Pass
-    ``block_c=128`` explicitly to re-run the comparison.
+    No better tile is available: the accumulators already fill all 256 AGPRs at
+    NA*NB = 16 per quadrant. Pass ``block_c=128`` explicitly to re-run the
+    comparison; `pick_tile` still takes 128 when the grid is starved.
     """
     return BLOCK_C_DEFAULT
 

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -1,0 +1,1372 @@
+# SPDX-License-Identifier: MIT
+#
+# RAGGED MXFP8 FORWARD grouped GEMM, 4-wave AGPR body.
+#
+#     out[group_g] = X[group_g] @ W[g]^T        X(M,K), W(E,N,K) -> (M,N)
+#
+# ---------------------------------------------------------------------------
+# VENDORED from ROCm/AMD-TorchTitan-Ops `amd_titan/_ops/fwdgemm/_fwd_kernel.py`,
+# which is the upstream source of truth. The kernel body, the interleave plan
+# and the vmcnt accounting are that file unchanged apart from PyTorch's
+# formatter; what changed for Inductor is host-side only and is listed under
+# "INDUCTOR ADAPTATION" below.
+#
+# INDUCTOR ADAPTATION
+#   * `_buffer_ops` / `_fp8_gemm_utils` are vendored beside this file as
+#     `mxfp8_buffer_ops` / `mxfp8_gemm_utils`.
+#   * The `_flydsl_runtime_available()` guard is gone: this module is only ever
+#     reached through the lazy `__getattr__` in `kernels/__init__.py`, which is
+#     itself only consulted once `use_flydsl_gemm_template` has confirmed the
+#     runtime.
+#   * The upstream `grouped_mm` torch wrapper (which allocated, quantised
+#     nothing, and owned its own launch cache) is replaced by
+#     `launch_mxfp8_grouped_gemm_gfx950`, which writes into the output buffer
+#     Inductor already allocated and routes compilation through
+#     `torch._inductor.runtime.flydsl_cache`.
+#   * `MXFP8GroupedGemmParam` carries the compile key so the template can hand
+#     it to `run_cached_flydsl` the same way the dense and BF16-grouped
+#     templates hand over their `GemmGfx950Param`.
+#
+# Exactly four things differ from the even-groups parent. Everything else --
+# the 8-buffer LDS ping-pong, the AGPR-pinned scaled MFMA, the cooperative
+# scale load, the interleave plan, the hand-counted vmcnt barriers -- is
+# untouched, because the ragged axis here is NOT the contraction. K is uniform
+# across experts, so the K-walk never learns the groups are ragged. (That is
+# what made this port small and the wgrad one hard.)
+#
+#   1. `OFFS` is a new kernel argument, and the block -> (group, row tile,
+#      col tile) mapping is resolved ON DEVICE from it. The parent computed it
+#      from a constexpr M_G.
+#   2. `row0 = m_start + r_base` instead of `g * M_G + r_base`.
+#   3. The epilogue store masks on `active & (r_ < m_end)`: a row tile may
+#      overhang its group, and those rows hold this expert's weights applied to
+#      the next group's tokens.
+#   4. The compile key drops M_G and M_TOTAL, keeping only (K, N, E, BLOCK_C).
+#      Both were routing-dependent, so the parent recompiled per token count --
+#      invisible under balanced routing, a per-step JIT under real routing.
+#
+# Host side: `grouped_mm_even` is replaced by `grouped_mm`, the grid is
+# over-provisioned to ceildiv(M, BLOCK_R) + E row tiles, and the output is
+# zero-initialised because a masked store no longer covers every row.
+# ---------------------------------------------------------------------------
+#
+# Ported from flydsl-wgrad's `_wgrad_kernel_v3.py` v3.3 (1305 TFLOP/s, 28.3% of
+# MI350X peak). The port is small because the two problems have the SAME operand
+# layout: both are `C = A @ B^T` with A and B row-major and the contraction
+# running along the contiguous axis. What differs is only what the axes mean:
+#
+#                    wgrad v3.3                      forward (here)
+#   A                go_t   (R=N, M_TOTAL)           X      (M_tok, K)
+#   B                ia_t   (C=K, M_TOTAL)           W[g]   (N, K)
+#   contraction      tokens, length m_g              K, length K (fixed)
+#   groups partition the CONTRACTION                 the OUTPUT ROWS
+#   per-group offset a column offset (m_start)       a row offset on A, a plane on B
+#   output           (E, R, C) f32                   (M_tok, N) bf16
+#
+# So the group index moves from the K-walk into the tile's base addresses, the
+# contraction becomes short and uniform (K/128 = 16 or 11 steps, versus wgrad's
+# 192), and the epilogue writes bf16 into one 2-D matrix instead of f32 into a
+# per-expert stack.
+#
+# Two structural consequences of the short contraction:
+#   * The K-loop is fully unrolled at compile time. wgrad needed `scf.for`
+#     because a 192-step constexpr loop hung the JIT; at 11-16 steps the rolled
+#     form only costs scheduling freedom, and the loop-carried a0/b0 fragments
+#     and scale chunk disappear.
+#   * Pipeline fill and drain are a much larger fraction of the kernel (2 of 16
+#     steps are prologue, 2 are tails), so prologue cost matters here in a way it
+#     never did for wgrad.
+#
+# The vmcnt accounting is derived, not transcribed. wgrad hand-computed four
+# constants (W1A/W2A/W1B/W2B) for its steady state; with the loop unrolled the
+# issue pattern is not perfectly periodic (the last steps stop prefetching
+# scales), so `_VmCounter` tracks issued vector-memory ops and each barrier waits
+# for exactly "everything up to the op I depend on". It reproduces wgrad's
+# constants in the steady state -- see the test in test_correctness.py.
+
+# NOTE: no `from __future__ import annotations` -- fx.struct needs real types.
+
+import dataclasses
+import functools
+import os
+
+import torch
+from torch._inductor.runtime.flydsl_cache import run_cached_flydsl
+
+
+# NOTE: no flydsl_compat. `_buffer_ops` implements the descriptor loads/stores
+# on rocdl ops that exist in BOTH flydsl 0.2.4 and 0.3.0, so this kernel runs on
+# either without the shim that grafted 0.3.0's deleted modules back.
+
+
+# OCP MX: 32 elements share one E8M0 scale.
+SCALE_BLOCK = 32
+
+BLOCK_R = 256  # DEFAULT output rows (tokens) per tile; see pick_block_r
+BLOCK_C_DEFAULT = 256  # output cols (N) per tile; 128 also supported, see pick_block_c
+BLOCK_M = 128  # contraction elements per pipeline step (= BLOCK_K)
+
+
+def pick_block_r(m_total: int, e: int) -> int:
+    """Row tile height, from the AVERAGE group size. 256 unless groups are small.
+
+    A row tile is charged for every row it covers, so a group of 64 tokens under
+    a 256-row tile runs the MFMAs on 256 rows and discards three quarters of the
+    result at the masked store. The waste is (BLOCK_R / m_g) and it is the single
+    largest term at the small-M shapes: measured 4.6% of MXFP8 peak at
+    m_g=64 (g32x64x2048x2048) against 20-25% where m_g >= 512.
+
+    A narrower tile costs per-block efficiency, because the MFMA-per-ds_read
+    ratio is NA*NB/(NA+NB) -- 2.0 at 4x4 (BLOCK_R=256), 1.33 at 2x4 (128), 0.8 at
+    1x4 (64). So this is only worth taking when the overhang it removes is bigger
+    than the ratio it gives up, i.e. when a group does not fill the wider tile.
+
+    AVERAGE, not per-group, and that is forced: the group sizes live on the
+    device and this kernel's whole design is not to sync on them (see
+    `grouped_mm`). m_total and E are host-side shape metadata, so m_total // E
+    costs nothing. Under real MoE routing the groups are within ~2x of the mean,
+    so the average picks the right tile for most of them; a badly skewed batch
+    gets a tile sized for its mean, which is still no worse than the fixed 256.
+
+    THE CUTOFF IS MEASURED, NOT DERIVED, and it sits at 320 because that is
+    where the evidence stops being one-sided. Pure overhang arithmetic says 128
+    only pays below m_g=128, but it keeps winning up to a skewed ragged mean of
+    269 (+44%), because the smaller tile also doubles the tile count and fills
+    the machine. At m_avg=512 it is no longer a win in any consistent direction
+    -- the same m_avg goes +5.2%, -2.6% and -14.0% depending only on K, N and E
+    -- so 512 stays on the wide tile. Measured (median of 3, bitwise-identical
+    output, TFLOP/s):
+
+        m_avg  shape                     br=256   br=128   pick
+           62  ragged [1,3,7,15,...]      254.8    366.2    128 (64 would give 430.3)
+           64  g32x64x2048x2048           219.9    298.7    128 (64 would give 375.1)
+          128  g8x128x4096x4096           461.6    595.7    128
+          128  g16x128x4096x4096          408.0    536.9    128
+          256  g16x256x2048x2048          628.5    614.0    128  (-2.3%, the one loss)
+          256  g8x256x8192x8192           806.1    867.3    128
+          269  ragged [100,333,777,...]   571.7    820.6    128
+          512  g8x512x4096x4096           992.0   1044.1    256  (+5.2% forgone)
+          512  g16x512x4096x4096         1036.6   1009.9    256
+          512  g8x512x8192x2048           994.1    854.5    256  (128 costs 14%)
+          696  ragged [813,1200,47,...]  1199.2   1073.7    256
+         1024  g4x1024x2048x2048          771.1    682.4    256
+
+    64 IS RETURNED AGAIN at m_avg <= 96, where it is the fastest tile (1.71x at
+    g32x64, 1.69x at the [1,3,7,...] ragged). It used to compute wrong answers;
+    the cause was `wait_barrier` waiting on vmcnt but never lgkmcnt, so an s2r
+    fragment issued in one cluster and consumed in the next crossed the barrier
+    outstanding while another wave overwrote its LDS buffer. Only the MFMAs in
+    between covered the gap -- N_ACCUMS of them -- so the tiles with N_ACCUMS=4
+    (this one, and BLOCK_C=128 with BLOCK_R=128) were the ones that broke. Fixed
+    in `_fp8_gemm_utils.wait_barrier`; verified clean on all 10 shapes of
+    scratchpad/dbg_br64.py on the development branch, including the K=8192
+    N=8192 case that used to corrupt
+    1510 elements.
+    """
+    if e <= 0:
+        return 256
+    m_avg = m_total // e
+    if m_avg <= 96:
+        return 64
+    if m_avg <= 320:
+        return 128
+    return 256
+
+
+def pick_tile(m_total: int, e: int, n: int) -> tuple:
+    """(BLOCK_R, BLOCK_C) for this shape, shrinking both when the grid starves.
+
+    `pick_block_r` and `pick_block_c` each answer a local question and neither
+    looks at how many blocks the pair produces. That is fine everywhere except
+    small N, where BLOCK_C=256 leaves ONE column tile and the row dim is the only
+    parallelism left: K4096 x N256 tiles to 16 blocks on a 256-CU part, 6% of the
+    machine, and it is the one PR shape still under 1x of the bf16 kernel.
+
+    Halving a tile dimension doubles the block count, and at a starved grid that
+    trade is strongly positive even though the narrower tile is worse per block
+    (the MFMA-per-ds_read ratio argument in `pick_block_c`). Measured at
+    K4096 x N256, M=4096 over 8 groups, bitwise-identical output:
+
+        br    bc   tiles   TF/s
+        256   256     16   145.4   (1.00x, the shipped pick)
+        256   128     32   215.9   (1.48x)
+        128   256     32   212.6   (1.46x)
+        128   128     64   296.3   (2.04x)
+
+    THE THRESHOLD IS ONE FULL WAVE, and the evidence for it had to be re-taken.
+    The original block_c sweep -- "128 loses on 11 of 12 shapes", including 0.86x
+    at g4x1024x2048x2048 -- was measured BEFORE the surplus-slot guard, when the
+    launched grid was (ceildiv(M,BLOCK_R) + E) * n_c instead of the tile count,
+    so both arms were partial-wave and the comparison never isolated occupancy.
+    Post-guard the grid IS the tile count, the same shape goes +14%, and every
+    partial-wave shape measured gains 11-14%. Do not resurrect the old numbers.
+    """
+    br = pick_block_r(m_total, e)
+    bc = pick_block_c(n)
+    if e <= 0 or n <= 0:
+        return br, bc
+    # Row tiles are per-group, so the average group is what the grid sees.
+    tiles = max(1, e * ceildiv(max(m_total // e, 1), br)) * ceildiv(n, bc)
+    if tiles >= _STARVED_TILES:
+        return br, bc
+    # Only a tile that is 256 in BOTH dims can be halved: halving one that is
+    # already 128 lands on (128, 128), which is banned below. Measured on the
+    # partial-wave shapes (TFLOP/s, all bitwise-correct, post-surplus-guard):
+    #
+    #   shape                 pick  (256,256)  (256,128)  (128,256)   taken
+    #   g4x1024x2048x2048  256,256      823.4      938.1      929.9   +14%
+    #   g4x512x4096x4096   256,256     1018.2     1164.8     1156.5   +14%
+    #   g8x512x8192x2048   256,256     1110.8     1231.6     1267.7   +11%
+    #   g8x128x4096x4096   128,256      522.8      618.8      730.1   -> (128,128)
+    #   ragged [1,3,7,...] 128,256      269.4      335.5      386.2   -> narrower
+    #
+    # SHRINK ONE STEP AT A TIME, re-checking. (128,128) and BLOCK_R=64 were
+    # banned until 2026-08-13 for computing wrong answers; the cause was
+    # `wait_barrier` waiting on vmcnt and never lgkmcnt, so an s2r fragment
+    # issued in one cluster and consumed in the next crossed the barrier still
+    # outstanding while another wave overwrote its LDS buffer. The only thing
+    # covering that gap was the MFMAs in between -- N_ACCUMS of them -- so
+    # exactly the tiles with N_ACCUMS=4 broke. Fixed in `_fp8_gemm_utils`, and
+    # both tiles verified clean on the repros that used to fail every time.
+    # At K4096 x N256 the two-step shrink is worth 296.3 TF/s against 215.9 for
+    # stopping at (256,128).
+    tiles_at = lambda r, c: (
+        max(1, e * ceildiv(max(m_total // e, 1), r)) * ceildiv(n, c)
+    )
+    if bc == 256 and n % 128 == 0:
+        bc = 128
+        if tiles_at(br, bc) >= _STARVED_TILES:
+            return br, bc
+    if br == 256:
+        br = 128
+        if tiles_at(br, bc) >= _STARVED_TILES:
+            return br, bc
+    # Third step, for the shapes that are STILL starved after both. K4096 x N256
+    # is the case: it is bandwidth-bound with too few concurrent blocks to
+    # saturate HBM, and throughput tracks achieved bandwidth, which tracks block
+    # count. Measured there (bitwise-identical output):
+    #
+    #   tile      tiles  waves    TF/s   achieved TB/s
+    #   (256,256)    16   0.06   147.4   0.63
+    #   (256,128)    32   0.12   222.4   1.40
+    #   (128,128)    64   0.25   302.8   2.51
+    #   (64,128)    128   0.50   361.1   4.45
+    #
+    # TAKE THE LAST ROW AS +9%, NOT +19%. That 361.1 came from one back-to-back
+    # sweep; an interleaved A/B repeated across three fresh processes puts
+    # (64,128) at 1.073 / 1.095 / 1.110 of (128,128), i.e. ~336 TF/s against
+    # ~305. One shape at +9% is ~+0.4% of the 24-shape geomean, which is inside
+    # that harness's run-to-run band -- so this step is justified by the A/B and
+    # will NOT be visible end to end. Do not go looking for it there.
+    #
+    # Split-K would be the textbook fix and is NOT it: the K-walk is only ~6us
+    # of a 25us kernel there, so splitting K scaled the time LINEARLY with the
+    # number of launches (S=2 -> 0.50x, S=4 -> 0.25x). More blocks per launch is
+    # what this shape wants, not more launches.
+    #
+    # HALF the threshold, because this step reverses once bandwidth saturates.
+    # A finer tile re-reads operands more times, so it only pays while there are
+    # too few blocks to use the bus. K4096 x N512 shows the far side: it reaches
+    # 4.58 TB/s at (128,128) already, and (64,128) buys 4.91 TB/s of MORE bytes
+    # for LESS work -- 551.2 -> 398.6 TF/s. N256 is the near side, 2.51 -> 4.45
+    # TB/s and 302.8 -> 361.1 TF/s. The two differ by whether 128 tiles is
+    # already enough, so the gate is "still under half a wave after both steps".
+    if br == 128 and tiles_at(br, bc) < _STARVED_TILES // 2:
+        br = 64
+    return br, bc
+
+
+_STARVED_TILES = 256  # one full wave on MI350X's 256 CUs; see pick_tile
+
+_guard_fallback_warned = set()
+
+# (K, N, E, BLOCK_C, BLOCK_R) whose guarded kernel failed to TRACE. FlyDSL
+# traces on first launch, not at compile, so this is discovered at the launch
+# site and remembered here -- see `launch_for` / `launch_guarded`.
+_guard_broken = set()
+
+
+def _warn_guard_fallback(K, N, E, BLOCK_C, BLOCK_R, err) -> None:
+    """Say once, per shape, that the surplus-slot guard did not compile.
+
+    Loud enough to notice (this shape is now paying for its surplus row-tile
+    slots, up to 1.74x) but not per call, and never fatal.
+    """
+    key = (K, N, E, BLOCK_C, BLOCK_R)
+    if key in _guard_fallback_warned:
+        return
+    _guard_fallback_warned.add(key)
+    import logging
+
+    logging.getLogger(__name__).warning(
+        "[amd_titan] fwdgemm: surplus-slot guard failed to compile at "
+        "K=%d N=%d E=%d BLOCK_C=%d BLOCK_R=%d (%s: %s); falling back to the "
+        "unguarded kernel, which is correct but pays for its surplus slots.",
+        K,
+        N,
+        E,
+        BLOCK_C,
+        BLOCK_R,
+        type(err).__name__,
+        str(err).splitlines()[0][:120],
+    )
+
+
+def pick_block_c(N: int) -> int:
+    """Column tile width. Always 256 -- the narrow tile was measured and lost.
+
+    The motivation for a narrow tile is real: a tile that overhangs N is not
+    free, because the MFMAs run on the overhang and the results are discarded at
+    the store. At K=2048, M=196608, N=1408 (6x256 = 1536 columns) and N=1536 take
+    the SAME 0.83 ms, so the 9.1% overhang is paid in full, and the kernel's
+    29.8% of peak on useful FLOPs is really 32.3% of the hardware.
+
+    1408 = 2^7 x 11 and a legal BLOCK_C is 64 x N_TILES_B, so 128 is the only
+    sane width that divides it. Measured (median of 3, interleaved):
+
+        K=2048 N=1408   256: 0.831 ms 1365 TF/s   128: 0.979 ms 1158   0.849x
+        K=1408 N=2048   256: 0.833 ms 1361 TF/s   128: 1.034 ms 1097   0.806x
+        K=2048 N=2048   256: 1.105 ms 1493 TF/s   128: 1.326 ms 1244   0.833x
+
+    So the narrow tile removes the whole overhang at N=1408 and is still 15%
+    slower. Why: per K-step a wave issues 4*NA*NB MFMAs against 4*(NA+NB) LDS
+    reads, so the MFMA-per-ds_read ratio is NA*NB/(NA+NB) -- 2.0 at 4x4, 1.33 at
+    4x2. Hardware efficiency drops 32.3% -> 25.1%, a 22% loss to save 9% of work.
+
+    There is no better tile available: the accumulators already fill all 256
+    AGPRs at NA*NB = 16 per quadrant, so no shape with a higher ratio fits. The
+    NA=8, NB=2 corner (ratio 1.6, and exactly 160 KB of LDS) interpolates to
+    ~28% hardware, still below the 29.8% useful the wide tile delivers.
+
+    Conclusion: the overhang at N=1408 is not recoverable by retiling. Pass
+    ``block_c=128`` explicitly to re-run the comparison.
+    """
+    return BLOCK_C_DEFAULT
+
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.expr import arith, range_constexpr, rocdl
+from flydsl.expr.arith import ArithValue
+from flydsl.expr.typing import T, Vector as Vec
+
+from . import mxfp8_buffer_ops as buffer_ops
+from .mxfp8_gemm_utils import (
+    compute_global_swizzle,
+    G2SLoader,
+    make_fp8_buffer_tensor,
+    pack_i32x4_i32x8,
+    S2RLoader,
+    swizzle_128,
+    wait_barrier,
+)
+
+
+# Interleave each quadrant's 16 MFMAs with the g2s/s2r loads of the NEXT
+# fragment so they co-issue in the MFMA execute shadow. Worth +6.6% in wgrad
+# once its scale loads stopped saturating the L1 address path. Set
+# FWDGEMM_INTERLEAVE=0 for the plain cluster.
+_INTERLEAVE = os.environ.get("FLYDSL_MXFP8_GROUPED_INTERLEAVE", "1") != "0"
+
+
+def _mfma_scale_agpr(a, b, sa, sb, acc):
+    """fp8 16x16x128 scaled MFMA with the accumulator pinned in AGPR (=a,...,0)
+    so the f32x4 accumulates in place and the compiler does not shuffle it
+    between AGPR slots. a/b are i32x8 (K=128 fp8); sa/sb are broadcast-i32
+    E8M0 scales (one e8m0 replicated to 4 bytes). cbsz:0 blgp:0, no op_sel."""
+    asm = "v_mfma_scale_f32_16x16x128_f8f6f4 $0, $1, $2, $0, $3, $4 cbsz:0 blgp:0"
+    return _llvm.inline_asm(
+        Vec.make_type(4, fx.Float32),
+        [
+            arith._to_raw(a),
+            arith._to_raw(b),
+            arith._to_raw(sa),
+            arith._to_raw(sb),
+            arith._to_raw(acc),
+        ],
+        asm,
+        "=a,v,v,v,v,0",
+        has_side_effects=True,
+    )
+
+
+class _VmCounter:
+    """Issue-order bookkeeping for `s_waitcnt vmcnt(n)`.
+
+    vmcnt retires IN ORDER, so "wait until op X has landed" is spelled
+    "allow at most (ops issued after X) to be outstanding". Every vector
+    memory op the kernel issues is counted here; `mark()` records a
+    watermark right after the ops a later barrier will depend on, and
+    `wait(mark)` emits the barrier with the exact count.
+
+    Getting this wrong in the unsafe direction is silent: too LARGE a count
+    under-waits and reads LDS the copy has not filled yet. Deriving it from
+    the issue order removes the chance to mis-transcribe a constant.
+    """
+
+    def __init__(self):
+        self.n = 0
+
+    def issue(self, k):
+        self.n += k
+        return self.n
+
+    def mark(self):
+        return self.n
+
+    def wait(self, mark):
+        wait_barrier(self.n - mark)
+
+
+def _compile(
+    K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int = BLOCK_R, GUARD: bool = True
+):
+    """Compile a RAGGED forward grouped GEMM for one (K, N, E) shape.
+
+    Deliberately absent from the key: the token count and every group size.
+    Both are runtime. Under real MoE routing they change every step, and a
+    shape-keyed compile leaks a JIT compile plus a retained GPU module per
+    step per layer -- the same defect the dim1 cast had, where it cost 618x.
+    The even-groups parent keyed on (K, N, M_G, M_TOTAL, BLOCK_C) and so
+    recompiled per token count; only balanced routing hid it.
+    """
+    assert K % BLOCK_M == 0, f"K ({K}) must be a multiple of {BLOCK_M}"
+    assert BLOCK_C in (128, 256), f"BLOCK_C {BLOCK_C} not supported"
+    # 64/128/256 give N_TILES_A of 1/2/4. Below 64 a half is under one MFMA
+    # tile (16 rows x 2 wave-rows) and the row structure stops holding.
+    assert BLOCK_R in (64, 128, 256), f"BLOCK_R {BLOCK_R} not supported"
+
+    K_ITERS = K // BLOCK_M
+    assert K_ITERS >= 4, (
+        f"K {K} gives {K_ITERS} steps; need >= 4 (2 prologue + 2 tails)"
+    )
+
+    SCALE_I32_ROW = K // 128  # i32 of e8m0 per operand row
+
+    N_TILES_A = BLOCK_R // 4 // 16
+    N_TILES_B = BLOCK_C // 4 // 16
+    N_ACCUMS = N_TILES_A * N_TILES_B
+    N_LDS_ROUNDS = max(N_TILES_A, N_TILES_B)
+
+    # A dwordx2 scale load needs an even element index. The index is
+    # lane*SCALE_I32_ROW + (row_base*SCALE_I32_ROW) + k with k always even
+    # (a chunk starts on an even K-step) and no per-group K offset here, so
+    # the row stride alone decides. K=2048 -> 16 (paired); K=1408 -> 11 (two
+    # dword loads instead; same cache lines, one extra instruction).
+    SC_PAIR = SCALE_I32_ROW % 2 == 0
+    N_SC_OPS = 4 if SC_PAIR else 8  # scale vm ops per chunk (2 K-steps)
+    N_CHUNKS = (K_ITERS + 1) // 2
+
+    LDS_BLOCK_R = BLOCK_R // 2  # each wave-dim half owns BLOCK_R/2 rows
+    LDS_BLOCK_C = BLOCK_C // 2
+
+    def _interleave_plan(n_mfma, n_g2s, n_tiles):
+        """Where to slot each load into the cluster's MFMA stream.
+
+        Returns three lists indexed by MFMA position: the g2s steps, the
+        first-half s2r tiles and the second-half s2r tiles to issue just
+        before that MFMA. Generated rather than written out because the
+        counts move with the tile -- BLOCK_C=256 is 16 MFMAs against 4 g2s
+        steps and 4x2 s2r reads, BLOCK_C=128 is 8 against 4 and 2x2.
+
+        Computed HERE, outside the kernel body, on purpose: FlyDSL's AST
+        rewriter turns an `if` inside a nested kernel-body function into a
+        separate `__then_N` function that cannot see the enclosing closure,
+        so schedule logic has to be plain Python that runs before tracing.
+        The kernel body then walks the plan with no branches at all.
+        """
+        acts = []
+        for r in range(max(n_g2s, n_tiles)):
+            if r < n_g2s:
+                acts.append(("g", r))
+            if r < n_tiles:
+                acts.append(("s0", r))
+                acts.append(("s1", r))
+        g_at = [[] for _ in range(n_mfma)]
+        s0_at = [[] for _ in range(n_mfma)]
+        s1_at = [[] for _ in range(n_mfma)]
+        for n_, act in enumerate(acts):
+            # Spread the loads evenly across the MFMA stream. The clamp is
+            # load-bearing at NA=1 (BLOCK_R=64), where 9 acts share only 4
+            # MFMA slots: the last act lands at round(9*4/10) = round(3.6) =
+            # 4, one past the end. `round` can exceed the floor whenever the
+            # ratio's fraction is >= .5, so the clamp -- not the ratio -- is
+            # what guarantees every load keeps a slot. It is a no-op at the
+            # 4x4/2x4/4x2 tiles, where the ratio never reaches n_mfma - 0.5.
+            pos = min(n_mfma - 1, int(round((n_ + 1) * n_mfma / (len(acts) + 1))))
+            {"g": g_at, "s0": s0_at, "s1": s1_at}[act[0]][pos].append(act[1])
+        return g_at, s0_at, s1_at
+
+    MFMA_SEQ = [(i, j) for i in range(N_TILES_A) for j in range(N_TILES_B)]
+    # Keyed by (g2s steps, s2r tiles): clusters 1 and 4 push A and pull B,
+    # clusters 2 and 3 the other way round. Keys collide harmlessly when the
+    # tile is square.
+    PLANS = {
+        (N_TILES_A, N_TILES_B): _interleave_plan(len(MFMA_SEQ), N_TILES_A, N_TILES_B),
+        (N_TILES_B, N_TILES_A): _interleave_plan(len(MFMA_SEQ), N_TILES_B, N_TILES_A),
+    }
+    a_lds_size = LDS_BLOCK_R * BLOCK_M
+    b_lds_size = LDS_BLOCK_C * BLOCK_M
+
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_fwd(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        OUT: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        OFFS: fx.Tensor,
+        n_c_tiles: fx.Int32,
+        out_m: fx.Int32,
+        out_n: fx.Int32,
+    ):
+        F8_IR_t = fx.Float8E4M3FN.ir_type
+
+        # ── Block -> (group, row tile, col tile), resolved ON DEVICE ──
+        # Groups partition the OUTPUT ROWS here, not the contraction, so
+        # unlike the wgrad kernel nothing about the K-walk changes: K is
+        # uniform across experts. Only this mapping and the epilogue mask
+        # care that the groups are ragged.
+        bid = fx.block_idx.x
+        slot = ArithValue(bid) // n_c_tiles  # which row tile overall
+        c_base = (ArithValue(bid) % n_c_tiles) * fx.Int32(BLOCK_C)
+
+        offs_rsrc = buffer_ops.create_buffer_resource(
+            OFFS, max_size=False, num_records_bytes=E * 4
+        )
+        # Uniform (SGPR) loads: every lane in the block wants the same
+        # boundaries, so this is E scalar loads, not E per-lane loads.
+        ends = [
+            ArithValue(
+                buffer_ops.buffer_load(
+                    offs_rsrc, fx.Int32(i), vec_width=1, dtype=T.i32, is_scalar=True
+                )
+            )
+            for i in range(E)
+        ]
+        starts = [ArithValue(fx.Int32(0))] + ends[:-1]
+
+        # Walk the groups accumulating row tiles until the slot lands in one.
+        # E is constexpr, so this unrolls to E selects on the SALU against a
+        # K-walk of many iterations -- the same O(E) prologue the wgrad
+        # kernel pays. `active` is false for slots past the last group's
+        # tiles, which predicates those blocks off in the epilogue.
+        g = ArithValue(fx.Int32(0))
+        r_base = ArithValue(fx.Int32(0))
+        m_start = ArithValue(fx.Int32(0))
+        m_end = ArithValue(fx.Int32(0))
+        active = fx.Int32(0) > fx.Int32(0)  # false
+        cum = ArithValue(fx.Int32(0))
+        # range_constexpr, not range: the AST rewriter turns a plain `range`
+        # into a device-side scf.for, whose induction variable is an
+        # ArithValue and cannot index the `ends`/`starts` Python lists. This
+        # loop must unroll at trace time.
+        for i in range_constexpr(E):
+            m_i = ends[i] - starts[i]
+            t_i = (m_i + fx.Int32(BLOCK_R - 1)) // fx.Int32(BLOCK_R)
+            hit = (slot >= cum) & (slot < cum + t_i)
+            g = arith.select(hit, fx.Int32(i), g)
+            r_base = arith.select(hit, (slot - cum) * fx.Int32(BLOCK_R), r_base)
+            m_start = arith.select(hit, starts[i], m_start)
+            m_end = arith.select(hit, ends[i], m_end)
+            active = active | hit
+            cum = cum + t_i
+
+        # A is offset by the group's first token row, B by the expert's
+        # weight plane. Both are plain row offsets at the same stride K --
+        # the "dynamic per-group stride" problem the MXFP8-MoE post
+        # describes does not arise on this axis.
+        row0 = m_start + r_base
+        wrow0 = ArithValue(g) * fx.Int32(N) + c_base
+
+        # ── SURPLUS SLOTS EXIT HERE, BEFORE ANY GLOBAL TRAFFIC ──
+        # The host cannot know how many row tiles the groups actually need
+        # -- that is sum_g ceildiv(m_g, BLOCK_R), and the m_g live on the
+        # device -- so it launches the upper bound, ceildiv(M, BLOCK_R) + E.
+        # The slack is real: at g8x512x4096x4096 it is 24 slots launched for
+        # 16 needed, and since n_blocks = n_slots * n_c that is 384 blocks
+        # where 256 would do. On 256 CUs that is the difference between one
+        # wave and two, which is why the surplus cost 1.74x there and
+        # 1.12-1.68x across the shapes -- far more than its 33% share of the
+        # blocks, because it is wave quantization and not just wasted bytes.
+        #
+        # `active` was already computed for the store mask; consulting it
+        # here instead skips the K-walk entirely. It is BLOCK-UNIFORM (it
+        # depends only on block_idx and on scalar loads of OFFS), so every
+        # thread takes the same branch and the barriers inside stay legal.
+        # `GUARD` is a plain Python bool from the compile key, so the tracer
+        # resolves this at TRACE time: True leaves `proceed` dynamic and the
+        # rewriter builds the scf.if; False makes it a Python True and the
+        # body is traced unconditionally, reproducing the pre-guard kernel
+        # byte for byte. One copy of the body, two kernels. The fallback
+        # exists because the guard does not compile everywhere -- see
+        # `cached_launch`.
+        proceed = active if GUARD else True
+        if proceed:
+            lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+            a_cur0, a_cur1 = lds.A_lds_cur_0, lds.A_lds_cur_1
+            a_next0, a_next1 = lds.A_lds_next_0, lds.A_lds_next_1
+            b_cur0, b_cur1 = lds.B_lds_cur_0, lds.B_lds_cur_1
+            b_next0, b_next1 = lds.B_lds_next_0, lds.B_lds_next_1
+
+            lane_id = fx.thread_idx.x % 64
+            wave_id = fx.thread_idx.x // 64
+            wave_i = wave_id // 2
+            wave_j = wave_id % 2
+
+            m_lane = lane_id % fx.Int32(16)
+            k_grp = lane_id // fx.Int32(16)
+            kshift = k_grp * fx.Int32(8)
+            mask_ff = fx.Int32(0xFF)
+            bcast = fx.Int32(0x01010101)
+
+            A0_gl = row0 * fx.Int32(K)
+            A1_gl = (row0 + fx.Int32(LDS_BLOCK_R)) * fx.Int32(K)
+            B0_gl = wrow0 * fx.Int32(K)
+            B1_gl = (wrow0 + fx.Int32(LDS_BLOCK_C)) * fx.Int32(K)
+
+            gA = make_fp8_buffer_tensor(A, F8_IR_t)
+            gB = make_fp8_buffer_tensor(B, F8_IR_t)
+            a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+            b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+
+            # BOUND THE SCALE DESCRIPTORS. `max_size=True` sets num_records to
+            # 0xFFFFFFFF, so an out-of-range e8m0 read is NOT clamped by the
+            # hardware -- it touches unmapped memory and faults. This kernel
+            # over-provisions row tiles (`n_slots = ceildiv(M, BLOCK_R) + E`) and
+            # relies on `active` to predicate the surplus blocks off in the
+            # epilogue, so a scale read issued before that predicate goes past
+            # the plane whenever the group boundaries leave a slot mapping past
+            # the last group.
+            #
+            # Measured, not theorised: with AMD_MXFP8_PAD_MULTIPLE=256 (which
+            # puts every group boundary on a 256 row-tile boundary) DSV3-16B at
+            # lbs4/seq8192 dies with hipErrorIllegalAddress every run, and a
+            # backend bisect pins it here -- AMD_MXFP8_GEMM_BACKEND=triton passes
+            # while quant=triton and wgrad=triton both still fault. At the
+            # default pad multiple of 32 the same fault appears every few runs.
+            #
+            # The wgrad body already carries this fix (_kernel.py); this
+            # kernel was ported from it before the fix landed and never got it.
+            # A bounded descriptor returns 0 for an out-of-range read, and 0 as
+            # an e8m0 is 2**-127, which underflows the product exactly as the
+            # epilogue mask intends.
+            #
+            # A is (M, K/32) with M a runtime value; B is (E, N, K/32), all
+            # constexpr, so its bound folds to a constant.
+            sa_bytes = arith.index_cast(
+                T.i64, arith.index_cast(T.index, out_m * fx.Int32(K // SCALE_BLOCK))
+            )
+            sa_rsrc = buffer_ops.create_buffer_resource(
+                A_scale, max_size=False, num_records_bytes=sa_bytes
+            )
+            sb_rsrc = buffer_ops.create_buffer_resource(
+                B_scale, max_size=False, num_records_bytes=E * N * (K // SCALE_BLOCK)
+            )
+
+            gl_off_a = compute_global_swizzle(
+                lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False
+            )
+            gl_off_b = compute_global_swizzle(
+                lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False
+            )
+
+            a_g2s = G2SLoader(a_div, gl_off_a, N_TILES_A, F8_IR_t, wave_id)
+            b_g2s = G2SLoader(b_div, gl_off_b, N_TILES_B, F8_IR_t, wave_id)
+            a_s2r = S2RLoader(wave_i, N_TILES_A)
+            b_s2r = S2RLoader(wave_j, N_TILES_B)
+
+            vm = _VmCounter()
+
+            # ── MXFP8 scales: cooperative wide load + ds_bpermute (wgrad v3.3) ──
+            # Each operand-half needs the e8m0 byte of 64 consecutive rows (4 MFMA
+            # tiles x 16 rows) at this K-step; one i32 per row covers 128 K, of
+            # which lane group k_grp takes byte k_grp and broadcasts it to 4 bytes.
+            #
+            # The naive form -- one buffer_load per (half, tile) -- issues 16 dword
+            # loads per K-step that touch the SAME 16 cache lines four times over,
+            # because lanes m_lane..m_lane+48 share an address. That is the same L1
+            # request count as all of the step's data traffic, and it, not the
+            # matrix core, sets the pace (measured in wgrad: stubbing the scales
+            # out took it 822 -> 1486 TFLOP/s).
+            #
+            # Instead: ONE cooperative load per half, lane L taking row
+            # (half_base + L), so 64 lanes cover 64 rows with no duplicate address,
+            # widened to a dwordx2 spanning two K-steps. 8x fewer scale L1
+            # requests. Each lane then pulls the tile it actually needs with
+            # ds_bpermute (lane L from lane t*16 + L%16) -- LDS crossbar, not HBM.
+            #
+            # A half spans N_TILES*16 rows, so 64 lanes cover it exactly at
+            # N_TILES=4 and cover it twice over at N_TILES=2 (BLOCK_C=128). The
+            # duplicate half of that load is wasted address bandwidth but stays
+            # ONE instruction, and the rows it touches are the next 32 of the same
+            # weight plane -- already-warm cache lines, or an in-bounds read the
+            # bpermute never selects.
+            assert N_TILES_A <= 4 and N_TILES_B <= 4, "a half must fit in 64 lanes"
+
+            sa0_base = row0 + wave_i * fx.Int32(N_TILES_A * 16)
+            sa1_base = row0 + fx.Int32(LDS_BLOCK_R) + wave_i * fx.Int32(N_TILES_A * 16)
+            sb0_base = wrow0 + wave_j * fx.Int32(N_TILES_B * 16)
+            sb1_base = wrow0 + fx.Int32(LDS_BLOCK_C) + wave_j * fx.Int32(N_TILES_B * 16)
+
+            # Only the row term is per-lane; the half base and the K index are
+            # wave-uniform and ride the buffer instruction's SGPR soffset, so the
+            # address costs no per-step VALU and exactly one VGPR.
+            sc_voff = lane_id * fx.Int32(SCALE_I32_ROW)
+            sc_sbase = [
+                (_rs, _base * fx.Int32(SCALE_I32_ROW * 4))
+                for _rs, _base in (
+                    (sa_rsrc, sa0_base),
+                    (sa_rsrc, sa1_base),
+                    (sb_rsrc, sb0_base),
+                    (sb_rsrc, sb1_base),
+                )
+            ]
+            sc_perm = [
+                fx.Int32(t_ * 64) + m_lane * fx.Int32(4)
+                for t_ in range_constexpr(max(N_TILES_A, N_TILES_B))
+            ]
+            # Tiles per half, in the order the chunk stores them: A0, A1, B0, B1.
+            sc_tiles = (N_TILES_A, N_TILES_A, N_TILES_B, N_TILES_B)
+
+            def issue_chunk(k_i32):
+                """Cooperative scale loads for K-steps (k_i32, k_i32+1).
+
+                Returns 2 raw i32 per operand-half, flat: [a0_lo, a0_hi, a1_lo, ...].
+                A chunk for a K-step past the end reads the next row's scales (or
+                out of bounds, which the buffer resource returns as 0) and is never
+                consumed -- cheaper than predicating the last prefetch.
+                """
+                out = []
+                for _rs, _sb in sc_sbase:
+                    soff = _sb + fx.Int32(k_i32 * 4)
+                    if SC_PAIR:
+                        v = buffer_ops.buffer_load(
+                            _rs, sc_voff, vec_width=2, dtype=T.i32, soffset_bytes=soff
+                        )
+                        out.append(
+                            buffer_ops.vec_extract(
+                                v, static_position=[0], dynamic_position=[]
+                            )
+                        )
+                        out.append(
+                            buffer_ops.vec_extract(
+                                v, static_position=[1], dynamic_position=[]
+                            )
+                        )
+                    else:
+                        out.append(
+                            buffer_ops.buffer_load(
+                                _rs,
+                                sc_voff,
+                                vec_width=1,
+                                dtype=T.i32,
+                                soffset_bytes=soff,
+                            )
+                        )
+                        out.append(
+                            buffer_ops.buffer_load(
+                                _rs,
+                                sc_voff,
+                                vec_width=1,
+                                dtype=T.i32,
+                                soffset_bytes=soff + fx.Int32(4),
+                            )
+                        )
+                vm.issue(N_SC_OPS)
+                return out
+
+            def use_chunk(chunk, p):
+                """Redistribute + consume the chunk's K-step `p` -> (sa0, sa1, sb0, sb1)."""
+                groups = []
+                for h_ in range_constexpr(4):
+                    src = chunk[2 * h_ + p]
+                    grp = []
+                    for t_ in range_constexpr(sc_tiles[h_]):
+                        v = rocdl.ds_bpermute(res=T.i32, index=sc_perm[t_], src=src)
+                        grp.append(((ArithValue(v) >> kshift) & mask_ff) * bcast)
+                    groups.append(grp)
+                return groups
+
+            def mma(a, b, c, sa, sb):
+                for i in range_constexpr(N_TILES_A):
+                    for j in range_constexpr(N_TILES_B):
+                        idx = i * N_TILES_B + j
+                        c[idx] = _mfma_scale_agpr(a[i], b[j], sa[i], sb[j], c[idx])
+                return c
+
+            zero = Vec.filled(4, 0.0, fx.Float32)
+            c00 = [zero] * N_ACCUMS
+            c01 = [zero] * N_ACCUMS
+            c10 = [zero] * N_ACCUMS
+            c11 = [zero] * N_ACCUMS
+
+            def _lds_swizzle(s2r):
+                out = []
+                for row_off in range_constexpr(s2r.n_tiles):
+                    row = (
+                        s2r.wave_idx * fx.Int32(s2r.n_tiles * 16)
+                        + fx.Int32(row_off * 16)
+                        + (lane_id % fx.Int32(16))
+                    )
+                    swz = []
+                    for ii in range_constexpr(2):
+                        col = (lane_id // fx.Int32(16)) * fx.Int32(16) + fx.Int32(
+                            ii * 64
+                        )
+                        r_, c_ = swizzle_128(row, col)
+                        swz.append(r_ * fx.Int32(BLOCK_M) + c_)
+                    out.append(swz)
+                return out
+
+            def _cluster_plain(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+                g2s.load(lds_dst, k_off)
+                vm.issue(g2s.n_load_steps)
+                rt = s2r.load(lds_src)
+                c = mma(a, b, c, sa, sb)
+                return c, rt
+
+            def _cluster_il(lds_dst, g2s, k_off, s2r, lds_src, a, b, c, sa, sb):
+                # Interleave this quadrant's MFMAs with the g2s and s2r loads of
+                # the NEXT fragment, so the loads co-issue in the MFMA execute
+                # shadow. Mirrors fp8_gemm_4wave's _interleaved_cluster; the MFMA
+                # is scaled + AGPR-pinned here. The schedule comes from
+                # `_interleave_plan` (computed before tracing), so this walks it
+                # with no branches -- see that function on why.
+                swz = _lds_swizzle(s2r)
+                rt = [None] * s2r.n_tiles
+                half = [None] * s2r.n_tiles
+                g_at, s0_at, s1_at = PLANS[(g2s.n_load_steps, s2r.n_tiles)]
+
+                for idx in range_constexpr(len(MFMA_SEQ)):
+                    for gi in range_constexpr(len(g_at[idx])):
+                        g2s.load_one(lds_dst, k_off, g_at[idx][gi])
+                    for si in range_constexpr(len(s0_at[idx])):
+                        t_ = s0_at[idx][si]
+                        half[t_] = s2r.load_one(lds_src, swz[t_][0])
+                    for si in range_constexpr(len(s1_at[idx])):
+                        t_ = s1_at[idx][si]
+                        rt[t_] = pack_i32x4_i32x8(
+                            half[t_], s2r.load_one(lds_src, swz[t_][1])
+                        )
+                    i_, j_ = MFMA_SEQ[idx]
+                    c[i_ * N_TILES_B + j_] = _mfma_scale_agpr(
+                        a[i_], b[j_], sa[i_], sb[j_], c[i_ * N_TILES_B + j_]
+                    )
+
+                vm.issue(g2s.n_load_steps)
+                return c, rt
+
+            _cluster = _cluster_il if _INTERLEAVE else _cluster_plain
+
+            # ── Prologue: pre-fill the 8-buffer LDS pipeline (2 K-steps) ──
+            # Chunk 0 goes first so it is the oldest thing in flight and the
+            # prologue barriers retire it for free.
+            chunks = [None] * N_CHUNKS
+            chunks[0] = issue_chunk(0)
+
+            a_g2s.load(a_cur0, A0_gl + 0 * BLOCK_M)
+            mk_ac0 = vm.issue(N_TILES_A)
+            b_g2s.load(b_cur0, B0_gl + 0 * BLOCK_M)
+            mk_bc0 = vm.issue(N_TILES_B)
+            b_g2s.load(b_cur1, B1_gl + 0 * BLOCK_M)
+            vm.issue(N_TILES_B)
+            a_g2s.load(a_cur1, A1_gl + 0 * BLOCK_M)
+            mk_a = vm.issue(N_TILES_A)
+
+            a_g2s.load(a_next0, A0_gl + 1 * BLOCK_M)
+            vm.issue(N_TILES_A)
+            b_g2s.load(b_next0, B0_gl + 1 * BLOCK_M)
+            mk_b = vm.issue(N_TILES_B)
+            b_g2s.load(b_next1, B1_gl + 1 * BLOCK_M)
+            vm.issue(N_TILES_B)
+            a_g2s.load(a_next1, A1_gl + 1 * BLOCK_M)
+            mk_c = vm.issue(N_TILES_A)
+
+            vm.wait(mk_ac0)
+            a0 = a_s2r.load(a_cur0)
+            vm.wait(mk_bc0)
+            b0 = b_s2r.load(b_cur0)
+
+            # ── Main K-steps 0 .. K_ITERS-3, fully unrolled ──
+            # Each step consumes the LDS buffers holding step k, loads step k+2
+            # into them, and reads step k+1's leading fragments. Which watermark
+            # each barrier waits on follows from the ping-pong depth:
+            #   * clusters 1-2 read the halves written by step k-2's SECOND half,
+            #   * clusters 3-4 read the halves written by step k-1's FIRST half.
+            # The two prologue groups stand in for steps -2 and -1: `mk_a` closes
+            # the k=0 group (step 0's second-half operands), `mk_b` sits right
+            # after b_next0 (step 1's leading fragments) and `mk_c` closes the
+            # k=1 group (step 1's second-half operands).
+            bufs = (a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1)
+            sec = {-2: mk_a, -1: mk_c}  # second-half watermark, by step index
+            fst = {-1: mk_b}  # first-half watermark, by step index
+
+            for kk in range_constexpr(K_ITERS - 2):
+                ac0, ac1, an0, an1, bc0, bc1, bn0, bn1 = bufs
+                k2 = (kk + 2) * BLOCK_M
+                p = kk % 2
+
+                # The scales for this step came off HBM a full step-pair ago; the
+                # only HBM touch is the prefetch for the pair two K-steps out --
+                # the same horizon the data ping-pong runs at.
+                vm.wait(sec[kk - 2])
+                if p == 0 and (kk // 2) + 1 < N_CHUNKS:
+                    chunks[(kk // 2) + 1] = issue_chunk(kk + 2)
+                sa0, sa1, sb0, sb1 = use_chunk(chunks[kk // 2], p)
+
+                c00, b1 = _cluster(
+                    ac0, a_g2s, A0_gl + k2, b_s2r, bc1, a0, b0, c00, sa0, sb0
+                )
+                c01, a1 = _cluster(
+                    bc0, b_g2s, B0_gl + k2, a_s2r, ac1, a0, b1, c01, sa0, sb1
+                )
+                fst[kk] = vm.mark()
+
+                vm.wait(fst[kk - 1])
+                c10, a0 = _cluster(
+                    bc1, b_g2s, B1_gl + k2, a_s2r, an0, a1, b0, c10, sa1, sb0
+                )
+                c11, b0 = _cluster(
+                    ac1, a_g2s, A1_gl + k2, b_s2r, bn0, a1, b1, c11, sa1, sb1
+                )
+                sec[kk] = vm.mark()
+
+                bufs = (an0, an1, ac0, ac1, bn0, bn1, bc0, bc1)
+
+            a_cur0, a_cur1, a_next0, a_next1, b_cur0, b_cur1, b_next0, b_next1 = bufs
+
+            # ── Tail step K_ITERS-2: drain, no more g2s ──
+            k_tail0 = K_ITERS - 2
+            vm.wait(sec[k_tail0 - 2])
+            sa0, sa1, sb0, sb1 = use_chunk(chunks[k_tail0 // 2], k_tail0 % 2)
+            b1 = b_s2r.load(b_cur1)
+            c00 = mma(a0, b0, c00, sa0, sb0)
+            a1 = a_s2r.load(a_cur1)
+            c01 = mma(a0, b1, c01, sa0, sb1)
+            vm.wait(fst[k_tail0 - 1])
+            a0 = a_s2r.load(a_next0)
+            c10 = mma(a1, b0, c10, sa1, sb0)
+            b0 = b_s2r.load(b_next0)
+            c11 = mma(a1, b1, c11, sa1, sb1)
+
+            a_cur0, a_next0 = a_next0, a_cur0
+            a_cur1, a_next1 = a_next1, a_cur1
+            b_cur0, b_next0 = b_next0, b_cur0
+            b_cur1, b_next1 = b_next1, b_cur1
+
+            # ── Tail step K_ITERS-1 ──
+            k_tail1 = K_ITERS - 1
+            vm.wait(sec[k_tail1 - 2])
+            sa0, sa1, sb0, sb1 = use_chunk(chunks[k_tail1 // 2], k_tail1 % 2)
+            b1 = b_s2r.load(b_cur1)
+            a1 = a_s2r.load(a_cur1)
+            c00 = mma(a0, b0, c00, sa0, sb0)
+            c01 = mma(a0, b1, c01, sa0, sb1)
+            c10 = mma(a1, b0, c10, sa1, sb0)
+            c11 = mma(a1, b1, c11, sa1, sb1)
+
+            # ── Epilogue: bf16 into out(M, N); the MFMA already applied the scales ──
+            # Storing f32 and converting outside would cost a full extra pass over
+            # M*N (553 MB at the e2e forward shape) -- more than half the kernel.
+            out_m_i = arith.index_cast(T.index, out_m)
+            out_n_i = arith.index_cast(T.index, out_n)
+            nbytes = arith.index_cast(T.i64, out_m_i * out_n_i * fx.Index(2))
+            o_rsrc = buffer_ops.create_buffer_resource(
+                OUT, max_size=False, num_records_bytes=nbytes
+            )
+            base_row = row0 + wave_i * fx.Int32(N_TILES_A * 16)
+            base_col = c_base + wave_j * fx.Int32(N_TILES_B * 16)
+            oob = out_m * out_n
+
+            def store_group(frag, br, bc):
+                for ti in range_constexpr(N_TILES_A):
+                    row = br + fx.Int32(ti * 16) + k_grp * fx.Int32(4)
+                    for tj in range_constexpr(N_TILES_B):
+                        col = bc + fx.Int32(tj * 16) + m_lane
+                        col_ok = col < out_n
+                        vec = Vec(frag[ti * N_TILES_B + tj])
+                        for e in range_constexpr(4):
+                            r_ = row + fx.Int32(e)
+                            # `r_ < m_end` is the ragged part. A row tile may
+                            # overhang its group, in which case the overhanging
+                            # rows hold this expert's weights applied to the
+                            # NEXT group's tokens -- correct arithmetic, wrong
+                            # expert -- so they must not be stored. `active`
+                            # kills whole slots past the last group's tiles.
+                            # Reading those A rows is harmless: each output
+                            # element is one A row dotted with one B column, so
+                            # nothing leaks across rows, and any fp8 NaN in the
+                            # pad region past m_total lands only in rows we drop.
+                            ok = active & (r_ < m_end) & (r_ < out_m) & col_ok
+                            off = arith.select(ok, r_ * out_n + col, oob)
+                            buffer_ops.buffer_store(vec[e].to(fx.BFloat16), o_rsrc, off)
+
+            store_group(c00, base_row, base_col)
+            store_group(c01, base_row, base_col + fx.Int32(LDS_BLOCK_C))
+            store_group(c10, base_row + fx.Int32(LDS_BLOCK_R), base_col)
+            store_group(
+                c11, base_row + fx.Int32(LDS_BLOCK_R), base_col + fx.Int32(LDS_BLOCK_C)
+            )
+
+    @flyc.jit
+    def launch_fwd(
+        A,
+        B,
+        OUT,
+        A_scale,
+        B_scale,
+        OFFS,
+        n_blocks: fx.Int32,
+        n_c_tiles: fx.Int32,
+        out_m: fx.Int32,
+        out_n: fx.Int32,
+        stream: fx.Stream,
+    ):
+        kernel_fwd(
+            A,
+            B,
+            OUT,
+            A_scale,
+            B_scale,
+            OFFS,
+            n_c_tiles,
+            out_m,
+            out_n,
+            value_attrs={
+                "rocdl.waves_per_eu": 1,
+                "rocdl.flat_work_group_size": "256,256",
+            },
+        ).launch(grid=(n_blocks, 1, 1), block=(256, 1, 1), stream=stream)
+
+    return launch_fwd
+
+
+@functools.lru_cache(maxsize=None)
+def cached_launch(
+    K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int = 256, GUARD: bool = True
+):
+    """Build the launcher. GUARD is part of the key -- see `launch_for`.
+
+    NOTE: this does NOT trace. FlyDSL traces lazily, on the first call
+    through `fast_launch`, so a tracer error surfaces at LAUNCH time and
+    cannot be caught here. That is what `launch_for` is for.
+    """
+    return _compile(K, N, E, BLOCK_C, BLOCK_R, GUARD=GUARD)
+
+
+def launch_for(K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int):
+    """The guarded launcher, unless this shape already failed to trace.
+
+    The surplus-slot guard is worth 1.2-1.74x but does not trace on every
+    shape: as a bare `if active:`, K=8192 N=256 BLOCK_R=128 raised "cannot
+    evaluate dynamic 'Boolean' as Python bool", and only when it came after
+    ~10 other kernels in the same process -- which is why the 24-shape sweep
+    and the full test suite both missed it. A pre-guard A/B at the same
+    position in the same sequence traced fine, so it is the guard.
+
+    Routing the condition through `proceed` made every shape tried since
+    trace, but "every shape tried" is exactly the guarantee that failed
+    last time, so the floor stays. It has to live at the LAUNCH site: an
+    untraceable shape would otherwise raise RuntimeError out of the op, and
+    `_flydsl_grouped_mm_impl` only falls back to Triton on
+    NotImplementedError and AssertionError -- so this would take down a
+    training job on a shape that worked yesterday. GUARD=False is verified
+    bitwise-identical to GUARD=True; the floor costs throughput, nothing
+    else.
+    """
+    return cached_launch(
+        K,
+        N,
+        E,
+        BLOCK_C,
+        BLOCK_R,
+        GUARD=(K, N, E, BLOCK_C, BLOCK_R) not in _guard_broken,
+    )
+
+
+def launch_guarded(launch, key, compile_args, dispatch_args, param):
+    """Run `launch`, and on a tracer error retry once unguarded, forever.
+
+    Compilation goes through Inductor's FlyDSL cache so the compiled dispatcher
+    is shared with the rest of the Inductor-generated FlyDSL kernels and is
+    keyed the same way (pid, device, constexpr param).
+    """
+    try:
+        return run_cached_flydsl(
+            launch,
+            *compile_args,
+            constexpr_param=param,
+            compiler=flyc.compile,
+            dispatch_args=dispatch_args,
+        )
+    except Exception as e:
+        if key in _guard_broken:
+            raise
+        _guard_broken.add(key)
+        _warn_guard_fallback(*key, e)
+        return run_cached_flydsl(
+            cached_launch(*key, GUARD=False),
+            *compile_args,
+            constexpr_param=param.unguarded(),
+            compiler=flyc.compile,
+            dispatch_args=dispatch_args,
+        )
+
+
+def ceildiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+@dataclasses.dataclass(frozen=True)
+class MXFP8GroupedGemmParam:
+    """The compile key of one MXFP8 grouped GEMM specialisation.
+
+    Deliberately absent: the token count and every group size. Both are
+    runtime values under real MoE routing, and a shape-keyed compile would
+    leak a JIT compile plus a retained GPU module per step per layer.
+
+    This is a plain dataclass rather than an ``fx.struct``: the kernel body
+    closes over these values at trace time (see ``_compile``) instead of
+    reading them from a device-side struct, so FlyDSL never sees the param.
+    It carries ``__cache_signature__`` only so ``run_cached_flydsl`` can key
+    on it exactly as it keys on the dense ``GemmGfx950Param``.
+    """
+
+    k: int
+    n: int
+    group_count: int
+    block_c: int
+    block_r: int
+    guarded: bool = True
+
+    def key(self) -> tuple[int, int, int, int, int]:
+        """The tuple ``cached_launch`` / ``_guard_broken`` are keyed on."""
+        return (self.k, self.n, self.group_count, self.block_c, self.block_r)
+
+    def unguarded(self) -> "MXFP8GroupedGemmParam":
+        return dataclasses.replace(self, guarded=False)
+
+    def __cache_signature__(self) -> tuple[int, int, int, int, int, bool]:
+        return (*self.key(), self.guarded)
+
+
+def make_mxfp8_grouped_gemm_kernel_name(param: MXFP8GroupedGemmParam) -> str:
+    return (
+        f"mxfp8_grouped_gemm_k{param.k}_n{param.n}_e{param.group_count}"
+        f"_t{param.block_r}x{param.block_c}"
+        f"_guard{int(param.guarded)}"
+    )
+
+
+def make_mxfp8_grouped_gemm_param(
+    k: int,
+    n: int,
+    group_count: int,
+    block_r: int = BLOCK_R,
+    block_c: int = BLOCK_C_DEFAULT,
+) -> MXFP8GroupedGemmParam:
+    """Validate one (K, N, E, BLOCK_R, BLOCK_C) against what `_compile` accepts.
+
+    Raises ``ValueError`` rather than tripping the asserts inside ``_compile``,
+    so the Inductor heuristics can prune a config without catching
+    ``AssertionError``.
+    """
+    if k <= 0 or n <= 0 or group_count <= 0:
+        raise ValueError(f"degenerate shape K={k}, N={n}, E={group_count}")
+    if k % BLOCK_M != 0:
+        raise ValueError(f"K ({k}) must be a multiple of {BLOCK_M}")
+    if k // BLOCK_M < 4:
+        raise ValueError(
+            f"K {k} gives {k // BLOCK_M} pipeline steps; need >= 4 "
+            "(2 prologue + 2 tails)"
+        )
+    if block_c not in (128, 256):
+        raise ValueError(f"BLOCK_C {block_c} not supported")
+    if block_r not in (64, 128, 256):
+        raise ValueError(f"BLOCK_R {block_r} not supported")
+    if block_c == 128 and n % 128 != 0:
+        # A 128-wide tile is only ever chosen to remove overhang; taking it on
+        # an N it does not divide adds overhang instead of removing it.
+        raise ValueError(f"BLOCK_C 128 needs N ({n}) to be a multiple of 128")
+    return MXFP8GroupedGemmParam(
+        k=int(k),
+        n=int(n),
+        group_count=int(group_count),
+        block_c=int(block_c),
+        block_r=int(block_r),
+    )
+
+
+def make_mxfp8_grouped_gemm_param_and_validate(
+    k: int, n: int, group_count: int, block_r: int, block_c: int
+) -> MXFP8GroupedGemmParam | None:
+    """`make_mxfp8_grouped_gemm_param`, returning None instead of raising."""
+    try:
+        return make_mxfp8_grouped_gemm_param(k, n, group_count, block_r, block_c)
+    except ValueError:
+        return None
+
+
+def get_mxfp8_grouped_gemm_grid_size(
+    param: MXFP8GroupedGemmParam, rows: int
+) -> tuple[int, int]:
+    """(n_blocks, n_c_tiles) for a launch covering `rows` tokens.
+
+    The row-tile count is over-provisioned to ``ceildiv(rows, BLOCK_R) + E``:
+    a group boundary that falls inside a tile costs the next group a slot, and
+    E boundaries can each do that. Blocks whose slot lands past the last group
+    resolve to ``active == False`` and are predicated off by the surplus-slot
+    guard, so the surplus is a launch-descriptor cost, not work.
+    """
+    n_c_tiles = ceildiv(param.n, param.block_c)
+    n_slots = ceildiv(rows, param.block_r) + param.group_count
+    return n_slots * n_c_tiles, n_c_tiles
+
+
+def launch_mxfp8_grouped_gemm_gfx950(
+    out,
+    mat_a,
+    mat_b,
+    scale_a,
+    scale_b,
+    offs,
+    param: MXFP8GroupedGemmParam,
+    stream,
+    tensor_arg=None,
+    compile_only=False,
+):
+    """MXFP8 forward grouped GEMM over RAGGED token groups, into `out`.
+
+        out[group_g] = mat_a[group_g] @ mat_b[g]^T
+
+    Groups partition the token (output row) dim with device-resident, unequal
+    sizes. Because the ragged axis is NOT the contraction, the whole pipelined
+    K-walk carries over from the even-groups body untouched -- only the
+    block -> (group, tile) mapping and the epilogue mask change.
+
+        out       (M, N)      bf16, contiguous, allocated by the caller
+        mat_a     (M, K)      fp8 e4m3, row-major
+        mat_b     (E, N, K)   fp8 e4m3, row-major (i.e. a [E, K, N] operand
+                              whose K dim is the contiguous one)
+        scale_a   (M, K//32)  e8m0, contiguous
+        scale_b   (E, N, K//32) e8m0, contiguous
+        offs      (E,) int32  cumulative group ends along M, ON DEVICE.
+                              Read by the block itself -- never synced here.
+
+    ROWS PAST ``offs[-1]`` ARE LEFT ALONE. They are covered by no block, which
+    matches what ATen's own 2d-3d grouped GEMMs do with the same tail; the
+    alternative is a full M*N memset, measured at 9.5% of the kernel.
+
+    `tensor_arg` wraps each tensor for the *compile* call; Inductor passes
+    ``flyc.from_torch_tensor(t).mark_layout_dynamic()`` so one compiled
+    dispatcher serves every M.
+
+    `compile_only` warms the disk cache and returns without dispatching. It is
+    what Inductor's precompile entry point uses, where the tensors are fake and
+    the only thing wanted is the compiled artifact. Only the first window is
+    compiled: every window traces the same kernel, and the layout-dynamic
+    compile args make the window's row count a runtime slot.
+    """
+    if tensor_arg is None:
+
+        def tensor_arg(tensor):
+            return tensor
+
+    total_m = int(out.shape[0])
+    if total_m == 0:
+        return out
+
+    a = mat_a.view(torch.int8)
+    a_sc = scale_a.view(torch.uint8)
+    b = mat_b.view(torch.int8).view(-1)
+    b_sc = scale_b.view(torch.uint8).view(-1)
+    offs_i32 = offs.view(torch.int32)
+
+    key = param.key()
+    for row_start, rows, offs_window in _row_windows(
+        total_m, param.k, param.n, offs_i32, param.block_r
+    ):
+        n_blocks, n_c_tiles = get_mxfp8_grouped_gemm_grid_size(param, rows)
+        dispatch_args = (
+            a.narrow(0, row_start, rows).view(-1),
+            b,
+            out.narrow(0, row_start, rows).view(-1),
+            a_sc.narrow(0, row_start, rows).view(-1),
+            b_sc,
+            offs_window,
+            n_blocks,
+            n_c_tiles,
+            rows,
+            param.n,
+            stream,
+        )
+        compile_args = tuple(
+            tensor_arg(arg) if idx < 6 else arg for idx, arg in enumerate(dispatch_args)
+        )
+        if compile_only:
+            flyc.compile(launch_for(*key), *compile_args)
+            return out
+        # A window that fell back re-resolves, so later windows skip the retry.
+        launch_guarded(launch_for(*key), key, compile_args, dispatch_args, param)
+    return out
+
+
+def _row_windows(M, K, N, offs, block_r=BLOCK_R):
+    """Split the token dim into windows no single launch can overflow int32 on.
+
+    FlyDSL's CABI packs a tensor's shape entries as int32
+    (``jit_argument._LayoutPlan``: ``"i" * len(shape)``), and every operand goes
+    over as a 1-D view, so ``shape[0]`` IS the element count. Past 2**31 the pack
+    raises ``struct.error`` from inside the dispatch -- which kills the training
+    job outright rather than failing one op, and is not one of the exceptions
+    ``_flydsl_grouped_mm_impl`` falls back on. Reached on a real DSV3-16B step at
+    65k tokens/rank: M=1,108,768 x K=2048 = 2,270,756,864.
+
+    Splitting is sound HERE, and only here, because the groups partition the
+    OUTPUT ROWS rather than the contraction: each window owns a disjoint row
+    range, so the windows never share a partial sum and need no accumulation.
+    (The wgrad cannot do this -- there the groups partition the contraction.)
+
+    Yields ``(row_start, n_rows, window_offsets)``. The offsets are rebased and
+    clamped ON DEVICE -- a group that straddles a boundary ends at ``n_rows`` in
+    one window and starts at 0 in the next, and groups wholly outside collapse to
+    size 0. No host sync, which is the property this whole kernel is built around.
+    """
+    # Bound the widest M-dependent operand: A is (M, K), out is (M, N), and A's
+    # scales are (M, K//32).
+    rows_max = (2**31 - 1) // max(K, N)
+    # Align down to the row-tile size so a window boundary never splits a tile;
+    # the tiling inside each window is then identical to the unsplit case.
+    rows_max = (rows_max // block_r) * block_r
+    if rows_max < block_r:
+        raise NotImplementedError(
+            f"a single row tile of {block_r} rows already exceeds the int32 "
+            f"operand limit at K={K} N={N}"
+        )
+
+    if M <= rows_max:
+        yield 0, M, offs  # unsplit: byte-for-byte the previous path
+        return
+    for r0 in range(0, M, rows_max):
+        rows = min(rows_max, M - r0)
+        yield r0, rows, (offs - r0).clamp_(0, rows)
+
+
+# Names the Inductor lazy-export table in `kernels/__init__.py` binds to.
+# Aliases rather than renames, so the body above stays diffable against the
+# upstream AMD-TorchTitan-Ops file.
+MXFP8_SCALE_BLOCK = SCALE_BLOCK
+pick_mxfp8_grouped_gemm_tile = pick_tile

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -463,16 +463,20 @@ def _compile(
     The even-groups parent keyed on (K, N, M_G, M_TOTAL, BLOCK_C) and so
     recompiled per token count; only balanced routing hid it.
     """
-    assert K % BLOCK_M == 0, f"K ({K}) must be a multiple of {BLOCK_M}"
-    assert BLOCK_C in (128, 256), f"BLOCK_C {BLOCK_C} not supported"
+    if K % BLOCK_M != 0:
+        raise ValueError(f"K ({K}) must be a multiple of {BLOCK_M}")
+    if BLOCK_C not in (128, 256):
+        raise ValueError(f"BLOCK_C {BLOCK_C} not supported")
     # 64/128/256 give N_TILES_A of 1/2/4. Below 64 a half is under one MFMA
     # tile (16 rows x 2 wave-rows) and the row structure stops holding.
-    assert BLOCK_R in (64, 128, 256), f"BLOCK_R {BLOCK_R} not supported"
+    if BLOCK_R not in (64, 128, 256):
+        raise ValueError(f"BLOCK_R {BLOCK_R} not supported")
 
     K_ITERS = K // BLOCK_M
-    assert K_ITERS >= 4, (
-        f"K {K} gives {K_ITERS} steps; need >= 4 (2 prologue + 2 tails)"
-    )
+    if K_ITERS < 4:
+        raise ValueError(
+            f"K {K} gives {K_ITERS} steps; need >= 4 (2 prologue + 2 tails)"
+        )
 
     SCALE_I32_ROW = K // 128  # i32 of e8m0 per operand row
 
@@ -746,7 +750,6 @@ def _compile(
             # ONE instruction, and the rows it touches are the next 32 of the same
             # weight plane -- already-warm cache lines, or an in-bounds read the
             # bpermute never selects.
-            assert N_TILES_A <= 4 and N_TILES_B <= 4, "a half must fit in 64 lanes"
 
             sa0_base = row0 + wave_i * fx.Int32(N_TILES_A * 16)
             sa1_base = row0 + fx.Int32(LDS_BLOCK_R) + wave_i * fx.Int32(N_TILES_A * 16)
@@ -1145,7 +1148,11 @@ def launch_guarded(launch, key, compile_args, dispatch_args, param):
             dispatch_args=dispatch_args,
         )
     except Exception as e:
-        if key in _guard_broken:
+        # The guard fallback exists for ONE failure mode: the surplus-slot `if`
+        # not tracing on some shapes. An out-of-memory is not that, and treating
+        # it as such both misreports the cause and permanently pins this shape
+        # to the unguarded kernel (up to 1.74x slower). Re-raise it instead.
+        if isinstance(e, torch.OutOfMemoryError) or key in _guard_broken:
             raise
         _guard_broken.add(key)
         _warn_guard_fallback(*key, e)

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/mxfp8_grouped_gemm_gfx950.py
@@ -1132,7 +1132,7 @@ def launch_for(K: int, N: int, E: int, BLOCK_C: int, BLOCK_R: int):
     )
 
 
-def launch_guarded(launch, key, compile_args, dispatch_args, param):
+def launch_guarded(launch, key, compile_args_factory, dispatch_args, param):
     """Run `launch`, and on a tracer error retry once unguarded, forever.
 
     Compilation goes through Inductor's FlyDSL cache so the compiled dispatcher
@@ -1142,10 +1142,10 @@ def launch_guarded(launch, key, compile_args, dispatch_args, param):
     try:
         return run_cached_flydsl(
             launch,
-            *compile_args,
             constexpr_param=param,
             compiler=flyc.compile,
             dispatch_args=dispatch_args,
+            compile_args_factory=compile_args_factory,
         )
     except Exception as e:
         # The guard fallback exists for ONE failure mode: the surplus-slot `if`
@@ -1158,10 +1158,10 @@ def launch_guarded(launch, key, compile_args, dispatch_args, param):
         _warn_guard_fallback(*key, e)
         return run_cached_flydsl(
             cached_launch(*key, GUARD=False),
-            *compile_args,
             constexpr_param=param.unguarded(),
             compiler=flyc.compile,
             dispatch_args=dispatch_args,
+            compile_args_factory=compile_args_factory,
         )
 
 
@@ -1352,14 +1352,24 @@ def launch_mxfp8_grouped_gemm_gfx950(
             param.n,
             stream,
         )
-        compile_args = tuple(
-            tensor_arg(arg) if idx < 6 else arg for idx, arg in enumerate(dispatch_args)
-        )
+
+        # Deferred: the descriptors are only needed if a compile happens, and
+        # after the first call for a given param it never does. Building them
+        # eagerly cost ~8us of the launcher's ~26us per call, which is dead
+        # weight on shapes whose kernel time is of that order.
+        def compile_args_factory(dispatch_args=dispatch_args):
+            return tuple(
+                tensor_arg(arg) if idx < 6 else arg
+                for idx, arg in enumerate(dispatch_args)
+            )
+
         if compile_only:
-            flyc.compile(launch_for(*key), *compile_args)
+            flyc.compile(launch_for(*key), *compile_args_factory())
             return out
         # A window that fell back re-resolves, so later windows skip the retry.
-        launch_guarded(launch_for(*key), key, compile_args, dispatch_args, param)
+        launch_guarded(
+            launch_for(*key), key, compile_args_factory, dispatch_args, param
+        )
     return out
 
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2819,6 +2819,7 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
                 aten.clone.default,
                 aten._scaled_mm.default,
                 aten._scaled_mm_v2.default,
+                aten._scaled_grouped_mm_v2.default,
                 prims.convert_element_type.default,
             )
             or (isinstance(node.target, torch._ops.OpOverload) and is_view(node.target))
@@ -2839,6 +2840,9 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
             aten.clone.default,
             aten._scaled_mm.default,
             aten._scaled_mm_v2.default,
+            # MXFP8 grouped GEMM: the e8m0 scales are consumed by the kernel,
+            # never read arithmetically by generated Triton.
+            aten._scaled_grouped_mm_v2.default,
         ) or is_view(node.target):
             return False
         if node.target == torch.ops.prims.convert_element_type.default:

--- a/torch/_inductor/runtime/flydsl_cache.py
+++ b/torch/_inductor/runtime/flydsl_cache.py
@@ -23,8 +23,20 @@ def run_cached_flydsl(
     constexpr_param: Any,
     compiler: Callable[..., Any],
     dispatch_args: tuple[Any, ...],
+    compile_args_factory: Callable[[], tuple[Any, ...]] | None = None,
 ) -> Any:
-    """Cache a layout-dynamic FlyDSL dispatcher by constexpr param."""
+    """Cache a layout-dynamic FlyDSL dispatcher by constexpr param.
+
+    `compile_args` are only read on the compile path -- a cache hit dispatches
+    straight through `dispatch_args`. Building them eagerly therefore wastes
+    work on every call after the first for a given param: the FlyDSL argument
+    descriptors (`from_torch_tensor(...).mark_layout_dynamic()`) are
+    constructed and immediately discarded. Callers that can defer the work
+    should pass `compile_args_factory` instead, a zero-argument callable
+    invoked only when a compile is actually needed.
+    """
+    if compile_args_factory is not None and compile_args:
+        raise TypeError("pass compile_args or compile_args_factory, not both")
     device = getattr(dispatch_args[0], "device", None)
     cache_key = (
         os.getpid(),
@@ -47,7 +59,12 @@ def run_cached_flydsl(
 
         compiled = compiled_cache.get(cache_key)
         if compiled is None:
-            compiled = compiler(jit_func, *compile_args)
+            args = (
+                compile_args_factory()
+                if compile_args_factory is not None
+                else compile_args
+            )
+            compiled = compiler(jit_func, *args)
             compiled_cache[cache_key] = compiled
         else:
             dispatch_after_wait = True

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8711,8 +8711,9 @@ def _meta_grouped_mm_common(
 
     if mat_a.dtype == torch.float16:
         torch._check(
-            _grouped_mm_fp16_cublaslt_supported(mat_a, mat_b, offs),
-            lambda: "Float16 grouped_mm requires cuBLASLt grouped GEMM support.",
+            _grouped_mm_fp16_flydsl_supported(mat_a, mat_b, offs)
+            or _grouped_mm_fp16_cublaslt_supported(mat_a, mat_b, offs),
+            lambda: "Float16 grouped_mm requires cuBLASLt grouped GEMM or FlyDSL support.",
         )
 
     torch._check(
@@ -8733,6 +8734,27 @@ def _meta_grouped_mm_common(
         )
 
     return _create_grouped_mm_output_tensor(mat_a, mat_b, offs, out_dtype)
+
+
+def _grouped_mm_fp16_flydsl_supported(
+    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None
+) -> bool:
+    if (
+        not torch.version.hip
+        or not torch.cuda.is_available()
+        or device_hint(mat_a) != "cuda"
+        or device_hint(mat_b) != "cuda"
+        or mat_a.dim() != 2
+        or mat_b.dim() != 3
+        or offs is None
+        or device_hint(offs) != "cuda"
+        or mat_a.device != mat_b.device
+        or mat_a.device != offs.device
+    ):
+        return False
+    device_index = mat_a.device.index if mat_a.device.index is not None else 0
+    arch = torch.cuda.get_device_properties(device_index).gcnArchName.split(":", 1)[0]
+    return arch == "gfx950"
 
 
 def _grouped_mm_fp16_cublaslt_supported(


### PR DESCRIPTION
## Summary
- Add a gfx950 FlyDSL backend for `F.scaled_grouped_mm` with the **MXFP8** recipe: 2D ragged A gathered by group offsets against a 3D `[G, K, N]` B, fp8 e4m3 data with e8m0 block scales, bf16 out.
- Add a lowering for `aten._scaled_grouped_mm_v2.default`, its config schema and shape gate, and let `_scaled_grouped_mm_v2` past the fp8/e8m0 fallback gate in `lowering.py` so a template can serve the node at all.
- Reuse the dense and BF16-grouped FlyDSL configuration, caching, and lazy kernel-export infrastructure.
- Add E2E coverage for the ragged body, the empty-group and minimum-K paths, the int32 row-window split, and an autotuning run over every tile the kernel implements.

Stacked on #191475, which adds the FlyDSL grouped GEMM for `F.grouped_mm`. Since GitHub cannot take another fork's branch as a base, this PR targets `gh/XiaobingSuper/2/head` and therefore also shows #191475's commits; only the four MXFP8 commits are new here.

**There is no ATen or Triton kernel to fall back to on this path.** `_scaled_grouped_mm_v2` routes MXFP8 x MXFP8 to `_mx8_mx8_bf16_grouped_mm_mslk`, which is CUDA/MSLK-only and raises `NOT_IMPLEMENTED` on ROCm. Verified on gfx950: eager, `max_autotune_gemm_backends="TRITON"`, `"ATEN"` and `"TRITON,ATEN"` all raise `NotImplementedError: mxfp8_mxfp8 grouped gemm requires compile with USE_MSLK`. The FlyDSL template is not competing with an extern choice on this op -- it is the only one, which is why no ATen choice is offered on the MXFP8 path.

## Test Plan
- `test/inductor/test_flydsl_template.py`

```
pytest test/inductor/test_flydsl_template.py -k "mxfp8 or cache"
30 passed
```

## Performance

Local `gfx950` MXFP8 `F.scaled_grouped_mm` benchmark. FlyDSL was forced in an isolated process with a fresh cache per shape, non-autotuned (the shipped `flydsl_enable_autotuning=False` path). Outputs were checked against a dequantize-then-f32-matmul oracle. Throughput is steady-state **TFLOPS**, excluding compilation time.

> **The Triton and ATen columns are the BF16 `F.grouped_mm` figures published in #191475, not measurements of this op.** Neither backend implements MXFP8 grouped GEMM on ROCm, so no same-dtype comparison exists; BF16 `torch._grouped_mm` is the only grouped GEMM that runs there today. Those columns were also taken on MI350X while the FlyDSL column here is MI355X. The ratios are therefore cross-dtype and cross-machine, and are offered as a scale reference rather than a like-for-like comparison.

### Standard 14-shape
| Shape | FlyDSL MXFP8 (TFLOPS) | Triton BF16 (TFLOPS) | ATen BF16 (TFLOPS) | Fly/Tri (%) | Fly/ATen (%) |
|---|---:|---:|---:|---:|---:|
| g8x512x2048x8192 | 1615.6 | 737.9 | 530.7 | 218.9% | 304.4% |
| g8x1024x8192x8192 | 2107.8 | 849.0 | 1142.7 | 248.3% | 184.5% |
| g8x512x4096x4096 | 1766.7 | 785.2 | 543.8 | 225.0% | 324.9% |
| g16x512x4096x4096 | 1669.7 | 769.7 | 584.0 | 216.9% | 285.9% |
| g4x2048x8192x8192 | 2135.7 | 898.3 | 1362.6 | 237.8% | 156.7% |
| g2x2048x4096x4096 | 1823.0 | 882.2 | 759.1 | 206.6% | 240.2% |
| g8x256x8192x8192 | 1530.4 | 778.1 | 585.0 | 196.7% | 261.6% |
| g4x1024x2048x2048 | 776.7 | 737.6 | 321.6 | 105.3% | 241.5% |
| g8x512x8192x2048 | 1463.0 | 769.7 | 426.6 | 190.1% | 342.9% |
| g4x512x4096x4096 | 1358.5 | 762.8 | 489.6 | 178.1% | 277.5% |
| g16x256x2048x2048 | 858.3 | 536.6 | 127.4 | 159.9% | 673.7% |
| g8x128x4096x4096 | 782.1 | 392.1 | 150.5 | 199.5% | 519.7% |
| g16x128x4096x4096 | 965.0 | 536.1 | 166.3 | 180.0% | 580.3% |
| g32x64x2048x2048 | 408.3 | 189.2 | 32.6 | 215.8% | 1252.4% |

Geometric mean: **194.8% vs Triton BF16** and **342.1% vs ATen BF16**.

### Dense K/N combinations (G=8, M=512/group)
| K x N | FlyDSL MXFP8 (TFLOPS) | Triton BF16 (TFLOPS) | ATen BF16 (TFLOPS) | Fly/Tri (%) | Fly/ATen (%) |
|---|---:|---:|---:|---:|---:|
| K4096 x N14336 (MoE up) | 1667.5 | 795.5 | 832.8 | 209.6% | 200.2% |
| K4096 x N28672 | 1866.0 | 796.8 | 1119.6 | 234.2% | 166.7% |
| K4096 x N256 (small N) | 204.2 | 302.5 | 54.0 | 67.5% | 378.2% |
| K8192 x N8192 | 1892.4 | 821.4 | 660.8 | 230.4% | 286.4% |
| K14336 x N4096 (MoE down) | 1928.6 | 812.3 | 699.7 | 237.4% | 275.6% |

Geometric mean: **178.5% vs Triton BF16** and **251.0% vs ATen BF16**. `K4096 x N256` is the one shape below the BF16 reference: at N=256 a 256-wide tile leaves a single column tile and the row dim is the only parallelism left, so the grid is 16 blocks on a 256-CU part. None of the six tiles the kernel implements recovers it; a narrower `BLOCK_C` or split-K would be a separate change.

### Ragged M combinations (G=8, K=N=4096)
| Per-group M | FlyDSL MXFP8 (TFLOPS) | Triton BF16 (TFLOPS) | ATen BF16 (TFLOPS) | Fly/Tri (%) | Fly/ATen (%) |
|---|---:|---:|---:|---:|---:|
| [1024,512,256,128,2048,64,512,1024] | 1462.9 | 778.9 | 558.6 | 187.8% | 261.9% |
| [0,1024,0,512,2048,128,0,896] | 1263.6 | 671.3 | 611.8 | 188.2% | 206.5% |
| [100,333,777,1,500,63,129,250] | 1034.5 | 472.4 | 263.9 | 219.0% | 392.0% |
| [1,3,7,15,31,63,127,255] | 403.6 | 160.0 | 74.9 | 252.3% | 538.9% |
| [813,1200,47,999,512,256,88,1600] | 1455.8 | 726.2 | 535.5 | 200.5% | 271.9% |

Geometric mean: **208.2% vs Triton BF16** and **315.1% vs ATen BF16**.

Scales are the plain unswizzled MX layout the ROCm recipe asks for: `(M, K/32)` for A and the op's flat per-group stack `(G, N * K/32)` for B. Rows past `offs[-1]` are covered by no block and left alone, matching what ATen's 2d-3d grouped GEMMs do with the same tail; zeroing them costs a full `M*N` memset, measured at 9.5% of the kernel.

> Authored with assistance from an AI coding agent.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo