### PR TITLE
Fix quantized adaptive average pooling index overflow

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/quantized/cpu/AdaptiveAveragePooling.cpp
@@ -3,6 +3,7 @@
 #include <ATen/Context.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Parallel.h>
+#include <ATen/native/AdaptivePooling.h>
 #include <ATen/native/quantized/cpu/QuantizedOps.h>
 
 #ifndef AT_PER_OPERATOR_HEADERS
@@ -30,28 +31,6 @@ DEFINE_DISPATCH(qadaptive_avg_pool3d_ndhwc_stub);
 
 namespace {
 
-inline int start_index(int out_idx, int out_len, int in_len) {
-  /*
-   * out_idx: the current index of output matrix
-   * out_len: the dimension_size of output matrix
-   * in_len: the dimension_size of input matrix
-   * Basically, in_len / out_len gives the number of
-   * elements in each average computation.
-   * This function computes the start index on input matrix.
-   */
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  return static_cast<int>(std::floor(static_cast<float>(out_idx * in_len) / out_len));
-}
-
-inline int end_index(int out_idx, int out_len, int in_len) {
-  /*
-   * Parameter definition is the same as start_index.
-   * This function computes the end index on input matrix.
-   */
-  // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
-  return static_cast<int>(std::ceil(static_cast<float>((out_idx + 1) * in_len) / out_len));
-}
-
 // adaptive avg pool for 2D and 3D inputs
 template <typename scalar_t>
 void adaptive_avg_pool_single_out_frame(
@@ -72,22 +51,22 @@ void adaptive_avg_pool_single_out_frame(
     for (const auto c : c10::irange(start, end)) {
       /* loop over output */
       for (int64_t od = 0; od < osizeD; od++) {
-        int istartD = start_index(od, osizeD, isizeD);
-        int iendD = end_index(od, osizeD, isizeD);
-        int kD = iendD - istartD;
+        int64_t istartD = start_index(od, osizeD, isizeD);
+        int64_t iendD = end_index(od, osizeD, isizeD);
+        int64_t kD = iendD - istartD;
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
         float kDr = 1.0 / kD;
         for (int64_t oh = 0; oh < osizeH; oh++) {
-          int istartH = start_index(oh, osizeH, isizeH);
-          int iendH = end_index(oh, osizeH, isizeH);
-          int kH = iendH - istartH;
+          int64_t istartH = start_index(oh, osizeH, isizeH);
+          int64_t iendH = end_index(oh, osizeH, isizeH);
+          int64_t kH = iendH - istartH;
           // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
           float kDHr = kDr / kH;
 
           for (int64_t ow = 0; ow < osizeW; ow++) {
-            int istartW = start_index(ow, osizeW, isizeW);
-            int iendW = end_index(ow, osizeW, isizeW);
-            int kW = iendW - istartW;
+            int64_t istartW = start_index(ow, osizeW, isizeW);
+            int64_t iendW = end_index(ow, osizeW, isizeW);
+            int64_t kW = iendW - istartW;
             // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions,bugprone-narrowing-conversions)
             float kDHWr = kDHr / kW;
 
@@ -105,9 +84,9 @@ void adaptive_avg_pool_single_out_frame(
 
             /* compute local average: */
             int64_t sum = 0;
-            for (int id = 0; id < kD; id++) {
-              for (int ih = 0; ih < kH; ih++) {
-                for (int iw = 0; iw < kW; iw++) {
+            for (int64_t id = 0; id < kD; id++) {
+              for (int64_t ih = 0; ih < kH; ih++) {
+                for (int64_t iw = 0; iw < kW; iw++) {
                   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
                   int64_t val = (ip +
                                  id * istrideD +

--- a/test/quantization/core/test_quantized_op.py
+++ b/test/quantization/core/test_quantized_op.py
@@ -2180,6 +2180,21 @@ class TestQuantizedOps(TestCase):
                                  msg=lambda msg: f"{msg}\n" + (error_message.format(name + '.zero_point', scale,
                                  X_hat.q_zero_point())))
 
+    def test_adaptive_avg_pool1d_float_index_boundary(self):
+        # Float32 boundary math gives the wrong pooling window for this size.
+        # Use C > 1 so unsqueeze(-2) is not channels_last (NHWC stub).
+        input_len = 2047
+        output_len = 10413
+        x = torch.zeros(1, 2, input_len)
+        x[0, :, 1770] = 10.0
+        x[0, :, 1771] = 30.0
+        qx = torch.quantize_per_tensor(x, scale=1.0, zero_point=0, dtype=torch.qint8)
+        ref = torch.nn.functional.adaptive_avg_pool1d(
+            qx.int_repr().to(torch.double), output_len).round()
+        qy = torch.nn.functional.adaptive_avg_pool1d(qx, output_len)
+        self.assertEqual(ref, qy.int_repr(), atol=0, rtol=0, exact_dtype=False)
+        self.assertEqual(qy.int_repr()[0, 0, 9008].item(), 10)
+
     @unittest.skip("not currently working and feature isn't used")
     def test_adaptive_avg_pool(self):
 


### PR DESCRIPTION
## Summary

Fixes #194023.

The quantized CPU adaptive average pooling implementation used local
`int`/floating-point helpers to compute pooling boundaries. For sufficiently
large output indices, the intermediate multiplication can overflow `int`
before conversion to floating point, producing invalid pooling bounds and
potentially an out-of-bounds input access.

Reuse the existing `int64_t` adaptive pooling boundary helpers from
`ATen/native/AdaptivePooling.h` instead. The pooling window indices and loop
counters are also kept as `int64_t`.

A regression test covers the quantized `adaptive_avg_pool1d` path with a
small deterministic case where the previous boundary calculation selected
the wrong pooling window.

## Test plan

```text
python test/test_quantization.py TestQuantizedOps.test_adaptive_avg_pool1d_index_boundary -v
PASS: 1 passed, 0 failed, 0 skipped

python test/test_quantization.py -k adaptive_avg_pool -v
PASS: 3 passed, 0 failed, 2 skipped

python -m py_compile test/quantization/core/test_quantized_op.py
PASS

git diff --check
PASS

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01