### PR TITLE
Fix FlyDSL topk CI lint and test import issues.

### DIFF
--- a/test/python_native/test_topk_flydsl.py
+++ b/test/python_native/test_topk_flydsl.py
@@ -10,7 +10,8 @@ from torch._native.ops.topk.flydsl_impl import (
     _SUPPORTED_ARCHES,
 )
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import skipCUDAIf, TEST_CUDA
+from torch.testing._internal.common_cuda import TEST_CUDA
+from torch.testing._internal.common_device_type import skipCUDAIf
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -33,7 +34,8 @@ def _gate_n_bounds(k: int) -> tuple[int, int]:
     if k in _REGISTER_KS:
         return _REGISTER_N_BOUNDS
     n_range = _radix_n_range(k)
-    assert n_range is not None, f"missing radix gate for K={k}"
+    if n_range is None:
+        raise AssertionError(f"missing radix gate for K={k}")
     return n_range
 
 
@@ -53,7 +55,8 @@ def _expected_kernel(k: int, n: int) -> str:
     from torch._native.ops.topk.flydsl_impl import _kernel_for
 
     kernel = _kernel_for(k, n)
-    assert kernel is not None, f"K={k} N={n} is outside the FlyDSL gate"
+    if kernel is None:
+        raise AssertionError(f"K={k} N={n} is outside the FlyDSL gate")
     return kernel
 
 

--- a/torch/_native/ops/topk/flydsl_kernels.py
+++ b/torch/_native/ops/topk/flydsl_kernels.py
@@ -124,8 +124,8 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool, arch: s
     num_warps = block_threads // warp_size
     tile = block_threads * _VEC
     vec_iters = n // tile
-    vec_tail_start = vec_iters * tile
-    scalar_tail_iters = (n - vec_tail_start + block_threads - 1) // block_threads
+    vec_end = vec_iters * tile
+    scalar_tail_iters = (n - vec_end + block_threads - 1) // block_threads
 
     @flyc.kernel(known_block_size=[block_threads, 1, 1])
     def radix_select_topk_kernel(
@@ -253,7 +253,7 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool, arch: s
                         sign_bit_xor_val,
                     )
             for step in range_constexpr(scalar_tail_iters):
-                col = vec_tail_start + step * block_threads + tid
+                col = vec_end + step * block_threads + tid
                 if col < n:
                     accumulate_radix_byte_hist(
                         _f32_to_ord(row_in[col]),
@@ -342,7 +342,7 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool, arch: s
 
             # --- Scalar tail ---
             for step in range_constexpr(scalar_tail_iters):
-                col = vec_tail_start + step * block_threads + tid
+                col = vec_end + step * block_threads + tid
                 valid = col < n
                 packed_local = 0
                 if valid:
@@ -400,7 +400,7 @@ def _build_radix_select_topk_module(n: int, k: int, deterministic: bool, arch: s
                     idx = fx.Int32(base + vi)
                     gather_candidate(rvals[vi], idx, s_vals, s_idxs)
             for step in range_constexpr(scalar_tail_iters):
-                col = vec_tail_start + step * block_threads + tid
+                col = vec_end + step * block_threads + tid
                 if col < n:
                     gather_candidate(row_in[col], fx.Int32(col), s_vals, s_idxs)
 

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -5557,7 +5557,8 @@ def sample_inputs_flydsl_topk(op_info, device, dtype, requires_grad, **kwargs):
     # M=256 covers the gfx950 occupancy gate.
     for K in (64, 256, 257, 383, 384, 831, 832, 1024):
         n_range = _radix_n_range(K)
-        assert n_range is not None, f"missing radix gate for K={K}"
+        if n_range is None:
+            raise AssertionError(f"missing radix gate for K={K}")
         N = n_range[0]
         yield SampleInput(make_arg((256, N)).contiguous(), args=(K,))
         yield SampleInput(make_arg((256, N)).contiguous(), args=(K, -1))


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #193548
* #191447
* __->__ #194315

Correct skipCUDAIf import in test_topk_flydsl, replace assert with
raise AssertionError for S101, and rename vec_tail_start to vec_end per
review.

Test Plan:

```
lintrunner test/python_native/test_topk_flydsl.py torch/_native/ops/topk/flydsl_kernels.py torch/testing/_internal/common_methods_invocations.py
```

Authored with assistance from an AI coding assistant.

Co-authored-by: Cursor <cursoragent@cursor.com>