### PR TITLE
[inductor] AOTI proxy executor: coerce a None empty (Sym)IntList arg to an empty list (#194324)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5355,6 +5355,35 @@ class AOTInductorTestsTemplate:
         example_args = (torch.tensor([True, False, True], device=self.device),)
         self.check_model(M(), example_args, options={"fallback_by_default": True})
 
+    def test_proxy_executor_empty_int_list_arg(self):
+        # An EMPTY (Sym)IntList argument on an op dispatched through the AOT
+        # ProxyExecutor -- e.g. the size/stride of a 0-d aten.empty_strided([], []).
+        # An empty list contributes no runtime ints, so the host's dynamic-arg loop
+        # skipped the slot entirely and the argument reached the op as None, where
+        # toIntList() aborts with "Expected SymIntList or IntList but got None".
+        with torch.library._scoped_library("mylib", "FRAGMENT") as lib:
+            torch.library.define(
+                "mylib::sum_to_shape",
+                "(Tensor a, SymInt[] shape) -> Tensor",
+                tags=torch.Tag.pt2_compliant_tag,
+                lib=lib,
+            )
+
+            @torch.library.impl(
+                "mylib::sum_to_shape", "CompositeExplicitAutograd", lib=lib
+            )
+            @torch.library.register_fake("mylib::sum_to_shape", lib=lib)
+            def sum_to_shape_impl(a: torch.Tensor, shape: list[int]) -> torch.Tensor:
+                return a.sum().expand(shape).clone()
+
+            class M(torch.nn.Module):
+                def forward(self, x):
+                    # An empty shape: reduce all the way down to a 0-d tensor.
+                    return torch.ops.mylib.sum_to_shape(x, []) + 1
+
+            example_args = (torch.randn(8, device=self.device),)
+            self.check_model(M(), example_args, options={"fallback_by_default": True})
+
     def test_proxy_executor_error_message_preserved(self):
         @torch.library.custom_op("aoti_test::validate_input", mutates_args=())
         def validate_input(x: torch.Tensor) -> torch.Tensor:

--- a/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
+++ b/torch/csrc/inductor/aoti_torch/oss_proxy_executor.cpp
@@ -760,6 +760,17 @@ void OSSProxyExecutor::call_function(
     int length = dynamic_arg.length;
 
     if (length == 0) {
+      // An empty (Sym)IntList contributes no runtime ints, so the switch below
+      // never writes its slot and the op would see the default None and abort
+      // in toIntList()/toSymIntList(). An empty list is what the caller meant
+      // -- an empty size/stride is exactly a 0-d tensor. A genuinely-None
+      // optional list does not reach here: the as_none branch above registers a
+      // zero-length ListIntType only for a bare List[SymInt], which an Optional
+      // never is.
+      if (dynamic_arg_type == DynamicArgType::ListIntType &&
+          stack[arg_index].isNone()) {
+        stack[arg_index] = c10::List<int64_t>{};
+      }
       continue;
     }
 


### PR DESCRIPTION
Summary:

Under AOTInductor with the OSS proxy executor, an op with an EMPTY (Sym)IntList argument --
e.g. `aten.empty_strided([], [])` allocating a 0-dim tensor -- can reach
`OSSProxyExecutor::call_function` with that argument left as `None` on the argument stack: an
empty serialized `as_ints` list does not populate a dynamic-arg slot, so the slot keeps its
default (None) `IValue`. When the op then reads the argument via `toIntList()` / `toSymIntList()`
it aborts:

    RuntimeError: isSymIntList() || isIntList() INTERNAL ASSERT FAILED
    ... Expected SymIntList or IntList but got None

Fix: right before invoking the op, scan the schema and coerce any `None`-valued (Sym)IntList
argument to an empty `c10::List<int64_t>{}`. An empty list is the intended value (an empty
size/stride is exactly a 0-dim tensor), so this is semantically identical and only affects the
previously-crashing edge case.

This surfaces under all-fallback (lite mode) lowering, where every op is an opaque ATen call
routed through the proxy executor and 0-dim scalar factory ops such as `empty_strided([], [])`
appear; normal lowering inlines these and never hits the proxy path.

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
Unit test added in this diff: `test_proxy_executor_empty_int_list_arg` (custom op with a
`SymInt[]` parameter called with `[]`, under `fallback_by_default`).

```
buck2 test @//mode/opt -c fbcode.enable_gpu_sections=true \
  fbcode//caffe2/test/inductor:test_aot_inductor -- \
  --regex 'test_proxy_executor_empty_int_list_arg'
```
=> with this diff: Pass 4. Fail 0.
=> with the coercion reverted: **Fail 3** --- `ABICompatibleCpu`, `ABICompatibleGpu` and
   `DualWrapper` all abort with `Expected SymIntList or IntList but got None`. So the test
   is a real regression test for this change, not a smoke test.

Whole proxy-executor family on remote GPU:
```
buck2 test @//mode/opt -c fbcode.enable_gpu_sections=true \
  fbcode//caffe2/test/inductor:test_aot_inductor -- \
  --regex 'test_proxy_executor_|test_triton_kernel_lite_mode'
```
=> Pass 39. Fail 0. Skip 14 (MPS, and the GPU-only tests under the CPU class).

Also reproduced on the recsys `merge` net (AMD MI350) under all-fallback, as before.

`arc f` + `arc lint` clean.

Reviewed By: desertfire

Differential Revision: D114190652




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo