### PR TITLE
[inductor] lite mode: run reinplacing before decomposing the functional Triton HOP (#194325)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -18031,6 +18031,41 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         else:
             FileCheck().check("torch.ops.aten.add").run(code[0])
 
+    @requires_gpu_and_triton
+    @unittest.skipIf(
+        config.cpp_wrapper,
+        "lite mode + user-defined Triton kernel is not supported by the cpp wrapper "
+        "(same reason as test_lite_triton_kernel_wrapper_functional above)",
+    )
+    def test_lite_mode_triton_kernel_no_clone(self):
+        # The decomposition emits "clone(s) + the mutation node" and relies on
+        # reinplacing to mark the unnecessary clones; lite mode used to skip
+        # reinplacing, so every user Triton kernel paid a copy of its output.
+        from torch.testing._internal.triton_utils import add_kernel
+
+        def f(x, y):
+            out = torch.zeros_like(x)
+            n_elements = out.numel()
+            add_kernel[(n_elements,)](x, y, out, n_elements, BLOCK_SIZE=16)
+            return out
+
+        x = torch.randn(64, device=GPU_TYPE)
+        y = torch.randn(64, device=GPU_TYPE)
+
+        opt_f = torch.compile(f, mode="lite")
+        result, code = run_and_get_code(opt_f, x, y)
+        self.assertEqual(result, f(x, y))
+
+        # Anchor: the kernel really made it into the generated code, so the no-clone
+        # assertion below cannot pass vacuously.
+        self.assertIn("add_kernel", code[0])
+        # The buffer the kernel writes is allocated immediately before the call and
+        # never read beforehand, so reinplacing must drop it from `tensors_to_clone`
+        # and the decomposition must emit no copy at all.
+        self.assertNotIn(
+            "aoti_torch_clone" if config.cpp_wrapper else "aten.clone", code[0]
+        )
+
     @lowering.force_fallback(aten.sort.default)
     def test_size_asserts_for_multi_output_fallback(self):
         @torch.compile

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -793,10 +793,18 @@ def _recursive_post_grad_passes(gm: GraphModule, is_inference: bool = False) -> 
                 # nor serializable by the proxy executor). Gated on the graph actually
                 # containing one so a lite-mode graph without user Triton kernels -- the
                 # common case -- pays neither the pattern match nor the recompile.
+                #
+                # Reinplacing must run FIRST: the decomposition emits "clone(s) + the
+                # mutation node" and relies on it to mark which clones are unnecessary,
+                # so without it every user Triton kernel pays a device-to-device copy.
                 if gm.graph.find_nodes(
                     op="call_function",
                     target=torch.ops.higher_order.triton_kernel_wrapper_functional,
                 ):
+                    from .fx_passes.reinplace import reinplace_inplaceable_ops
+                    from .fx_utils import FakeTensorUpdater
+
+                    reinplace_inplaceable_ops(FakeTensorUpdater(gm), gm.graph)
                     decompose_triton_kernel_wrapper_functional(gm.graph)
                     gm.recompile()
                 return


### PR DESCRIPTION
Summary:

decompose_triton_kernel_wrapper_functional lowers the functional HOP to "clone(s) + the
mutation node", and its own docstring states it assumes the reinplacing pass has already
run to mark which of those clones are unnecessary. In lite mode
(use_post_grad_passes=False) only the decomposition ran, so EVERY user-defined Triton
kernel paid a full device-to-device copy of its output.

Measured on a recsys net lowered all-fallback with 352 injected library kernels
(NVIDIA GB200): exactly one extra Memcpy DtoD per injected site, confirmed by isolating
each pattern -- rmsnorm_mul 168 sites/+168 copies, mul_sigmoid 78/+78, layernorm_mul
64/+64, select_sigmoid 40/+40.

    Memcpy DtoD   304 launches / 818us  ->  4 launches / 6us
    total device   10.34 ms             ->  9.44 ms
    total launches  2139                ->  1839
    wall           39.85 ms             ->  28.51 ms
    parity          3.9062e-03          ->  3.9062e-03  (unchanged, strict)

The wall-clock gain is an order of magnitude larger than the device-time gain because
each removed clone was also a proxy-executor dispatch: ~10ms of host time for 300
launches. Gated on the graph actually containing a triton_kernel_wrapper_functional, so
it is a no-op for graphs without user Triton kernels, and it runs last (before the
decomposition) exactly as in the normal post-grad ordering.

Also stride-generalizes kernel_library's rmsnorm_mul so it takes x/w strides instead of
calling .contiguous(). That was a second, independent source of the same copy: x there is
a fallback kernel's output on an unbacked dim, which inductor cannot prove contiguous
when handing it to an opaque custom op. Reinplacing turns out to cover the bulk of the
350 copies on its own, but the kernel is now honest about layout, matching what
select_sigmoid already did and what the module docstring claims.

Test Plan:
Unit test added in this diff: `test_lite_mode_triton_kernel_no_clone` --- compiles a user
Triton kernel with `mode="lite"` and asserts the generated code contains the kernel launch
but no `clone`. Without reinplacing running first, the decomposition emits a
`clone_preserve_strides` of the kernel's freshly allocated output.

Verified on GPU (gfx950) that the diff does what it claims, by running the test body
directly at this commit and at its parent:

    parent      python wrapper: clone-ish symbols in generated code = ['clone']
    this diff   python wrapper: clone-ish symbols in generated code = []   , numerics OK

The new test is skipped under `config.cpp_wrapper`
------------------------------------------------
The first version of this diff added the test without a cpp-wrapper guard, and that broke
all four `inductor_cpp_wrapper` shards (inductor-test and inductor-test-cuda132, shards
1/2 and 2/2). Root cause: lite mode + a user-defined Triton kernel is not supported by the
cpp wrapper at all, so the test could never have passed there. Reproduced on GPU at this
commit AND at its parent -- i.e. the limitation is pre-existing, this diff merely added the
first test that exercises it under cpp_wrapper:

    main.cpp:208:33: error: no matching function for call to 'from'
      std::optional tmp_var_1{torch::stable::detail::from(nullptr, 0)};
      ... all candidates take a single argument

The immediately preceding test in the same file, `test_lite_triton_kernel_wrapper_functional`,
already carries exactly this guard for the same reason
("codegen triton_kernel_wrapper_functional is not implemented for cpp wrapper"). The new
test now carries it too. Making that codegen path work is separate work.

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:test_inductor -- --regex 'lite_mode'
=> Pass 4. Fail 0. Skip 2.

buck2 test @//mode/opt fbcode//caffe2/test/inductor:test_inductor \
  -- --regex 'lite_' --env TORCHINDUCTOR_CPP_WRAPPER=1
=> Pass 5. Fail 0. Skip 6.        # the configuration that was failing
```

```
buck2 test @//mode/opt -c fbcode.enable_gpu_sections=true \
  fbcode//caffe2/test/inductor:test_aot_inductor -- \
  --regex 'test_proxy_executor_|test_triton_kernel_lite_mode'
```
=> Pass 39. Fail 0. Skip 14.

End-to-end perf numbers on the recsys net and the `mini_qkv_split` repro are unchanged
from the previous version of this diff.

`lintrunner` clean.

Reviewed By: desertfire

Differential Revision: D115158279




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo