### PR TITLE
[dynamo] Graph-break Tensor subclasses whose __getattr__ is not the f…

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -2980,6 +2980,68 @@ class GraphModule(torch.nn.Module):
         self.assertIsInstance(result, MyTensor)
         self.assertEqual(result, x)
 
+    def test_bare_subclass_getattr_method_does_not_crash(self):
+        # https://github.com/pytorch/pytorch/issues/194323
+        class CustomTensor(torch.Tensor):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self + x
+
+        def fn():
+            ct = CustomTensor([1, 2, 3])
+            return ct.custom_method(torch.tensor([4, 5, 6]))
+
+        expected = fn()
+        actual = torch.compile(fn, backend="eager")()
+        self.assertEqual(actual, expected)
+
+    def test_bare_subclass_getattr_method_raises_does_not_crash(self):
+        class CustomTensor(torch.Tensor):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self + x
+                raise AttributeError(attr)
+
+        def fn():
+            ct = CustomTensor([1, 2, 3])
+            return ct.custom_method(torch.tensor([4, 5, 6]))
+
+        expected = fn()
+        actual = torch.compile(fn, backend="eager")()
+        self.assertEqual(actual, expected)
+
+    def test_bare_subclass_getattr_method_inside_compiled_fn(self):
+        def fn():
+            class CustomTensor(torch.Tensor):
+                def __getattr__(self, attr):
+                    if attr == "custom_method":
+                        return lambda x: self + x
+
+            ct = CustomTensor([1, 2, 3])
+            return ct.custom_method(torch.tensor([4, 5, 6]))
+
+        expected = fn()
+        actual = torch.compile(fn, backend="eager")()
+        # Nested class objects differ across eager vs compile, compare as Tensor.
+        self.assertEqual(
+            actual.as_subclass(torch.Tensor), expected.as_subclass(torch.Tensor)
+        )
+
+    def test_bare_subclass_getattr_still_traces_tensor_methods(self):
+        class CustomTensor(torch.Tensor):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self + x
+                raise AttributeError(attr)
+
+        def fn(x):
+            return x.sin()
+
+        x = torch.randn(3).as_subclass(CustomTensor)
+        expected = fn(x)
+        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(actual, expected)
+
 
 instantiate_parametrized_tests(SubclassTests)
 

--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -2982,6 +2982,7 @@ class GraphModule(torch.nn.Module):
 
     def test_bare_subclass_getattr_method_does_not_crash(self):
         # https://github.com/pytorch/pytorch/issues/194323
+        # Constructing the subclass inside the compiled region must not crash.
         class CustomTensor(torch.Tensor):
             def __getattr__(self, attr):
                 if attr == "custom_method":
@@ -2994,6 +2995,33 @@ class GraphModule(torch.nn.Module):
         expected = fn()
         actual = torch.compile(fn, backend="eager")()
         self.assertEqual(actual, expected)
+
+        torch._dynamo.reset()
+        # Constructor graph-breaks before wrap_tensor; still must not be an internal error.
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)()
+
+    def test_bare_subclass_getattr_swallows_graph_breaks(self):
+        # wrap_tensor swallow check: sourced tensor, so Dynamo wraps the input.
+        class CustomTensor(torch.Tensor):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self + x
+
+        def fn(x):
+            return x.sin()
+
+        x = torch.randn(3).as_subclass(CustomTensor)
+        expected = fn(x)
+        actual = torch.compile(fn, backend="eager")(x)
+        self.assertEqual(actual, expected)
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "swallows missing attributes",
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
 
     def test_bare_subclass_getattr_method_raises_does_not_crash(self):
         class CustomTensor(torch.Tensor):
@@ -3009,6 +3037,10 @@ class GraphModule(torch.nn.Module):
         expected = fn()
         actual = torch.compile(fn, backend="eager")()
         self.assertEqual(actual, expected)
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)()
 
     def test_bare_subclass_getattr_method_inside_compiled_fn(self):
         def fn():
@@ -3027,6 +3059,10 @@ class GraphModule(torch.nn.Module):
             actual.as_subclass(torch.Tensor), expected.as_subclass(torch.Tensor)
         )
 
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported):
+            torch.compile(fn, backend="eager", fullgraph=True)()
+
     def test_bare_subclass_getattr_still_traces_tensor_methods(self):
         class CustomTensor(torch.Tensor):
             def __getattr__(self, attr):
@@ -3038,6 +3074,50 @@ class GraphModule(torch.nn.Module):
             return x.sin()
 
         x = torch.randn(3).as_subclass(CustomTensor)
+        expected = fn(x)
+        actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(actual, expected)
+
+    def test_bare_subclass_undefined_method_graph_breaks(self):
+        class CustomTensor(torch.Tensor):
+            @classmethod
+            def __torch_function__(cls, func, types, args=(), kwargs=None):
+                if kwargs is None:
+                    kwargs = {}
+                return super().__torch_function__(func, types, args, kwargs)
+
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self + x
+                raise AttributeError(attr)
+
+        def fn(x):
+            return x.custom_method(torch.ones_like(x))
+
+        x = torch.tensor([1.0, 2.0, 3.0]).as_subclass(CustomTensor)
+        expected = fn(x)
+        actual = torch.compile(fn, backend="eager")(x)
+        self.assertEqual(actual, expected)
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "Tensor subclass method not defined on Tensor",
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+
+    def test_wrapper_subclass_with_getattr_still_traces(self):
+        # Swallow check must not preempt a real flatten-protocol wrapper.
+        class TwoTensorGetattr(TwoTensor):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self.a + x
+                raise AttributeError(attr)
+
+        def fn(x):
+            return x.sin()
+
+        x = TwoTensorGetattr(torch.randn(3), torch.randn(3))
         expected = fn(x)
         actual = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(actual, expected)

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1288,6 +1288,31 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
 
         run_checks()
 
+    def test_traceable_wrapper_subclass_protocol_ignores_instance_getattr(
+        self,
+    ) -> None:
+        class BareGetattrTensor(torch.Tensor):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self + x
+
+        class WrapperWithGetattr(_StaticUnflattenWrapper):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self.elem + x
+                raise AttributeError(attr)
+
+        bare = BareGetattrTensor([1.0, 2.0])
+        # __getattr__ returning None makes instance hasattr a false positive.
+        self.assertTrue(hasattr(bare, "__tensor_flatten__"))
+        self.assertIsNone(getattr(bare, "__tensor_flatten__"))
+        self.assertFalse(is_traceable_wrapper_subclass(bare))
+        self.assertFalse(is_traceable_wrapper_subclass_type(BareGetattrTensor))
+
+        wrapped = WrapperWithGetattr(torch.randn(2, 2))
+        self.assertTrue(is_traceable_wrapper_subclass(wrapped))
+        self.assertTrue(is_traceable_wrapper_subclass_type(WrapperWithGetattr))
+
     def test_make_fx_with_subclass(self) -> None:
         def f(x, y):
             # Returns (TwoTensor, Tensor)

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1291,9 +1291,6 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
     def test_traceable_wrapper_subclass_protocol_ignores_instance_getattr(
         self,
     ) -> None:
-        # Keep the assertions out of dynamo_wrapped compilation. The classes
-        # define __getattr__, and tracing construction of the wrapper crashes
-        # with InternalTorchDynamoError (AttributeError: elem).
         @torch._dynamo.disable
         def run_checks() -> None:
             class BareGetattrTensor(torch.Tensor):
@@ -1310,7 +1307,7 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
             bare = BareGetattrTensor([1.0, 2.0])
             # __getattr__ returning None makes instance hasattr a false positive.
             self.assertTrue(hasattr(bare, "__tensor_flatten__"))
-            self.assertIsNone(getattr(bare, "__tensor_flatten__"))
+            self.assertIsNone(bare.__tensor_flatten__)
             self.assertFalse(is_traceable_wrapper_subclass(bare))
             self.assertFalse(is_traceable_wrapper_subclass_type(BareGetattrTensor))
 

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1291,27 +1291,34 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
     def test_traceable_wrapper_subclass_protocol_ignores_instance_getattr(
         self,
     ) -> None:
-        class BareGetattrTensor(torch.Tensor):
-            def __getattr__(self, attr):
-                if attr == "custom_method":
-                    return lambda x: self + x
+        # Keep the assertions out of dynamo_wrapped compilation. The classes
+        # define __getattr__, and tracing construction of the wrapper crashes
+        # with InternalTorchDynamoError (AttributeError: elem).
+        @torch._dynamo.disable
+        def run_checks() -> None:
+            class BareGetattrTensor(torch.Tensor):
+                def __getattr__(self, attr):
+                    if attr == "custom_method":
+                        return lambda x: self + x
 
-        class WrapperWithGetattr(_StaticUnflattenWrapper):
-            def __getattr__(self, attr):
-                if attr == "custom_method":
-                    return lambda x: self.elem + x
-                raise AttributeError(attr)
+            class WrapperWithGetattr(_StaticUnflattenWrapper):
+                def __getattr__(self, attr):
+                    if attr == "custom_method":
+                        return lambda x: self.elem + x
+                    raise AttributeError(attr)
 
-        bare = BareGetattrTensor([1.0, 2.0])
-        # __getattr__ returning None makes instance hasattr a false positive.
-        self.assertTrue(hasattr(bare, "__tensor_flatten__"))
-        self.assertIsNone(getattr(bare, "__tensor_flatten__"))
-        self.assertFalse(is_traceable_wrapper_subclass(bare))
-        self.assertFalse(is_traceable_wrapper_subclass_type(BareGetattrTensor))
+            bare = BareGetattrTensor([1.0, 2.0])
+            # __getattr__ returning None makes instance hasattr a false positive.
+            self.assertTrue(hasattr(bare, "__tensor_flatten__"))
+            self.assertIsNone(getattr(bare, "__tensor_flatten__"))
+            self.assertFalse(is_traceable_wrapper_subclass(bare))
+            self.assertFalse(is_traceable_wrapper_subclass_type(BareGetattrTensor))
 
-        wrapped = WrapperWithGetattr(torch.randn(2, 2))
-        self.assertTrue(is_traceable_wrapper_subclass(wrapped))
-        self.assertTrue(is_traceable_wrapper_subclass_type(WrapperWithGetattr))
+            wrapped = WrapperWithGetattr(torch.randn(2, 2))
+            self.assertTrue(is_traceable_wrapper_subclass(wrapped))
+            self.assertTrue(is_traceable_wrapper_subclass_type(WrapperWithGetattr))
+
+        run_checks()
 
     def test_make_fx_with_subclass(self) -> None:
         def f(x, y):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -5796,6 +5796,29 @@
       "Hints": []
     }
   ],
+  "GB1323": [
+    {
+      "Gb_type": "Tensor subclass __getattr__ swallows missing attributes",
+      "Context": "type(value).__name__",
+      "Explanation": "{type(value).__name__}.__getattr__ returns for missing names instead of raising AttributeError, so Dynamo cannot safely inspect the tensor.",
+      "Hints": [
+        "Raise AttributeError from `__getattr__` for unknown names.",
+        "Prefer an explicit method on the subclass instead of `__getattr__`.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
+  "GB6174": [
+    {
+      "Gb_type": "Tensor subclass method not defined on Tensor",
+      "Context": "{self.class_type.__name__}.{name}",
+      "Explanation": "`torch.compile` cannot trace `{self.class_type.__name__}.{name}` because it is not a torch.Tensor method.",
+      "Hints": [
+        "Avoid calling `{name}` on this tensor subclass inside torch.compile.",
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB0355": [
     {
       "Gb_type": "non-single Tensor return unsupported",

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4572,13 +4572,13 @@ def getattr_swallows_missing_attrs(value: Any) -> bool:
     """True if type(value).__getattr__ returns for names that are not on the object.
 
     Instance hasattr()/getattr(..., default) are unreliable in that case, because a
-    missing name does not raise AttributeError.
+    missing name does not raise AttributeError. A sentinel probe is required to
+    tell a raising __getattr__ from a swallowing one; get_custom_getattr only
+    tells us that __getattr__ exists.
     """
-    if inspect.getattr_static(type(value), "__getattr__", None) is None:
+    if get_custom_getattr(value) is None:
         return False
     sentinel = "__dynamo_missing_attr_probe__"
-    if inspect.getattr_static(value, sentinel, None) is not None:
-        return False
     try:
         object.__getattribute__(value, sentinel)
         return False
@@ -4586,7 +4586,7 @@ def getattr_swallows_missing_attrs(value: Any) -> bool:
         pass
     try:
         getattr(value, sentinel)
-    except Exception:
+    except AttributeError:
         return False
     return True
 

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -4568,6 +4568,29 @@ def get_custom_getattr(
     return getattr_fn
 
 
+def getattr_swallows_missing_attrs(value: Any) -> bool:
+    """True if type(value).__getattr__ returns for names that are not on the object.
+
+    Instance hasattr()/getattr(..., default) are unreliable in that case, because a
+    missing name does not raise AttributeError.
+    """
+    if inspect.getattr_static(type(value), "__getattr__", None) is None:
+        return False
+    sentinel = "__dynamo_missing_attr_probe__"
+    if inspect.getattr_static(value, sentinel, None) is not None:
+        return False
+    try:
+        object.__getattribute__(value, sentinel)
+        return False
+    except AttributeError:
+        pass
+    try:
+        getattr(value, sentinel)
+    except Exception:
+        return False
+    return True
+
+
 class TensorStaticReason(enum.Enum):
     PARAMETER = 2
     NOT_TENSOR = 4

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -177,6 +177,7 @@ from ..utils import (
     get_fake_value,
     get_locals_to_steal,
     get_static_address_type,
+    getattr_swallows_missing_attrs,
     is_frozen_dataclass,
     is_function,
     is_function_or_wrapper,
@@ -2987,6 +2988,22 @@ class VariableBuilder:
 
         # By this point, we should have deduplicated all tensors
         self.assert_not_wrapped_by_this_graph(value)
+
+        if getattr_swallows_missing_attrs(value):
+            unimplemented(
+                gb_type="Tensor subclass __getattr__ swallows missing attributes",
+                context=type(value).__name__,
+                explanation=(
+                    f"{type(value).__name__}.__getattr__ returns for missing names "
+                    "instead of raising AttributeError, so Dynamo cannot safely "
+                    "inspect the tensor."
+                ),
+                hints=[
+                    "Raise AttributeError from `__getattr__` for unknown names.",
+                    "Prefer an explicit method on the subclass instead of `__getattr__`.",
+                    *graph_break_hints.SUPPORTABLE,
+                ],
+            )
 
         if (
             isinstance(value, torch.Tensor)

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -2989,7 +2989,9 @@ class VariableBuilder:
         # By this point, we should have deduplicated all tensors
         self.assert_not_wrapped_by_this_graph(value)
 
-        if getattr_swallows_missing_attrs(value):
+        # Do not graph-break legitimate wrapper subclasses that also define __getattr__.
+        is_wrapper = is_traceable_wrapper_subclass(value)
+        if not is_wrapper and getattr_swallows_missing_attrs(value):
             unimplemented(
                 gb_type="Tensor subclass __getattr__ swallows missing attributes",
                 context=type(value).__name__,

--- a/torch/_dynamo/variables/torch_function.py
+++ b/torch/_dynamo/variables/torch_function.py
@@ -777,12 +777,26 @@ class TensorWithTFOverrideVariable(TensorVariable):
             # we will graph break in other cases this will need a bigger overhaul of extracting methods/comparing them for equality
             # We've established with the above check that the method is not overridden, so we guard that the method is the same
             # as the impl defined on tensor and retrieve it
-            if self.source:
-                source = AttrSource(AttrSource(self.source, "__class__"), name)
-                value = inspect.getattr_static(self.python_type(), name)
-            else:
-                source = None
-                value = getattr(torch.Tensor, name)
+            try:
+                if self.source:
+                    source = AttrSource(AttrSource(self.source, "__class__"), name)
+                    value = inspect.getattr_static(self.python_type(), name)
+                else:
+                    source = None
+                    value = getattr(torch.Tensor, name)
+            except AttributeError:
+                unimplemented(
+                    gb_type="Tensor subclass method not defined on Tensor",
+                    context=f"{self.class_type.__name__}.{name}",
+                    explanation=(
+                        f"`torch.compile` cannot trace `{self.class_type.__name__}.{name}` "
+                        "because it is not a torch.Tensor method."
+                    ),
+                    hints=[
+                        f"Avoid calling `{name}` on this tensor subclass inside torch.compile.",
+                        *graph_break_hints.SUPPORTABLE,
+                    ],
+                )
             func_var = VariableTracker.build(tx, value, source)
             return dispatch_torch_function(tx, func_var, tf_args, kwargs)
         else:

--- a/torch/_subclasses/meta_utils.py
+++ b/torch/_subclasses/meta_utils.py
@@ -394,10 +394,6 @@ class MetaTensorDescriber:
         ctx = None
         type_v = None
         if is_traceable_wrapper_subclass_v:
-            if not hasattr(t, "__tensor_flatten__"):
-                raise AssertionError(
-                    "Traceable wrapper subclass must have __tensor_flatten__ method"
-                )
             raw_attrs, ctx = t.__tensor_flatten__()
             attrs = {}
             opaque_attrs = {}

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -540,7 +540,7 @@ class TraceableWrapperSubclass(Protocol):
 TensorWithFlatten = TraceableWrapperSubclass
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _has_traceable_wrapper_subclass_protocol(cls: type) -> bool:
     # Class lookup so instance __getattr__ cannot fake the flatten protocol.
     # hasattr (not getattr_static) so Dynamo can trace nn.Module._apply.

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import inspect
 import warnings
 from collections import deque
 from dataclasses import dataclass
@@ -541,7 +542,14 @@ TensorWithFlatten = TraceableWrapperSubclass
 
 
 def _has_traceable_wrapper_subclass_protocol(t: object) -> bool:
-    return hasattr(t, "__tensor_flatten__") and hasattr(t, "__tensor_unflatten__")
+    # Look up on the class MRO, never the instance. Instance hasattr() is True
+    # whenever __getattr__ returns without raising, which is not the flatten
+    # protocol. getattr_static also skips metaclass __getattr__.
+    cls = t if isinstance(t, type) else type(t)
+    return (
+        inspect.getattr_static(cls, "__tensor_flatten__", None) is not None
+        and inspect.getattr_static(cls, "__tensor_unflatten__", None) is not None
+    )
 
 
 def is_traceable_wrapper_subclass(t: object) -> TypeIs[TraceableWrapperSubclass]:

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import contextlib
 import functools
-import inspect
 import warnings
 from collections import deque
 from dataclasses import dataclass
@@ -541,15 +540,11 @@ class TraceableWrapperSubclass(Protocol):
 TensorWithFlatten = TraceableWrapperSubclass
 
 
-def _has_traceable_wrapper_subclass_protocol(t: object) -> bool:
-    # Look up on the class MRO, never the instance. Instance hasattr() is True
-    # whenever __getattr__ returns without raising, which is not the flatten
-    # protocol. getattr_static also skips metaclass __getattr__.
-    cls = t if isinstance(t, type) else type(t)
-    return (
-        inspect.getattr_static(cls, "__tensor_flatten__", None) is not None
-        and inspect.getattr_static(cls, "__tensor_unflatten__", None) is not None
-    )
+@functools.lru_cache(maxsize=None)
+def _has_traceable_wrapper_subclass_protocol(cls: type) -> bool:
+    # Class lookup so instance __getattr__ cannot fake the flatten protocol.
+    # hasattr (not getattr_static) so Dynamo can trace nn.Module._apply.
+    return hasattr(cls, "__tensor_flatten__") and hasattr(cls, "__tensor_unflatten__")
 
 
 def is_traceable_wrapper_subclass(t: object) -> TypeIs[TraceableWrapperSubclass]:
@@ -564,7 +559,7 @@ def is_traceable_wrapper_subclass(t: object) -> TypeIs[TraceableWrapperSubclass]
     with ``return_and_correct_aliasing()`` when needed.
     """
     is_subclass = isinstance(t, torch.Tensor) and type(t) is not torch.Tensor
-    return is_subclass and _has_traceable_wrapper_subclass_protocol(t)
+    return is_subclass and _has_traceable_wrapper_subclass_protocol(type(t))
 
 
 def is_traceable_wrapper_subclass_type(


### PR DESCRIPTION
## Summary
Fixes #194323.

`torch.compile` crashed with `InternalTorchDynamoError: type object 'CustomTensor' has no attribute '__tensor_flatten__'` on a bare `torch.Tensor` subclass that defined `__getattr__` and had no flatten protocol. Eager ran.

Instance `hasattr` is true whenever `__getattr__` returns without raising, so Dynamo treated the subclass as a traceable wrapper and called `type(x).__tensor_flatten__`. After that, a missing subclass method still leaked as `AttributeError`, and a `__getattr__` that returns `None` for unknown names also broke dynamo-internal attribute probes (including C++ `DIMENSION_DYNAMIC_MARKING_GUARD`).

The compile path now:
- checks `__tensor_flatten__` / `__tensor_unflatten__` on the class via `inspect.getattr_static` (classmethods/staticmethods still count)
- graph-breaks before wrapping if `__getattr__` swallows missing names
- graph-breaks on subclass methods that are not `torch.Tensor` methods, instead of wrapping the `AttributeError`

This is a graph-break plus eager fallback, not tracing of `__getattr__`. Tensor methods such as `sin()` still compile.

## Test plan
- [x] `python test/test_python_dispatch.py TestPythonDispatch.test_traceable_wrapper_subclass_protocol_runtime_check`
- [x] `python test/test_python_dispatch.py TestPythonDispatch.test_traceable_wrapper_subclass_protocol_ignores_instance_getattr`
- [x] `python test/dynamo/test_subclasses.py -k test_bare_subclass_getattr`
- [x] `python test/dynamo/test_subclasses.py -k test_tensor_subclass_custom_attr`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98