### PR TITLE
[XPU][Aten] Fix memory format detection for conv backward overrideable

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -493,8 +493,6 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
       "so far only support float, bfloat16, half and double convolution backward in XPU backend, your data type is ",
       grad_output.scalar_type());
 
-  bool is_channels_last_suggested = use_channels_last_for_conv(input, weight);
-
   Tensor grad_output_, input_, weight_;
   IntArrayRef stride_, padding_, dilation_, output_padding_;
   bool transposed_ = false;
@@ -528,6 +526,8 @@ std::tuple<Tensor, Tensor, Tensor> convolution_backward_overrideable(
     output_padding_ = output_padding;
     groups_ = groups;
   }
+
+  bool is_channels_last_suggested = use_channels_last_for_conv(input_, weight_);
 
   // ensure the tensors are contiguous
   auto mfmt = is_channels_last_suggested

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -609,6 +609,24 @@ class TestConvolutionNNDeviceType(NNTestCase):
             _test(t, weight_even, mode)
             _test(t, weight_odd, mode)
 
+    @onlyXPU
+    @dtypes(torch.double)
+    def test_conv1d_backward_depthwise(self, device, dtype):
+        batch, channels, width = 2, 4, 2
+        x = make_tensor(
+            (batch, 1, channels), device=device, dtype=dtype, requires_grad=True
+        ).transpose(1, 2)
+        weight = make_tensor(
+            (channels, width), device=device, dtype=dtype, requires_grad=True
+        )
+
+        def conv1d_depthwise(x, weight):
+            return torch.nn.functional.conv1d(
+                x, weight.unsqueeze(1), padding=width - 1, groups=channels
+            )
+
+        gradcheck(conv1d_depthwise, (x, weight))
+
     @unittest.skipIf(not TEST_SCIPY, "Scipy required for the test.")
     @dtypes(torch.float)
     @parametrize_test("mode", ("valid", "same"))

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -609,8 +609,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
             _test(t, weight_even, mode)
             _test(t, weight_odd, mode)
 
-    @onlyXPU
-    @dtypes(torch.double)
+    @dtypes(torch.float, torch.double)
     def test_conv1d_backward_depthwise(self, device, dtype):
         batch, channels, width = 2, 4, 2
         x = make_tensor(

--- a/test/xpu/test_conv.py
+++ b/test/xpu/test_conv.py
@@ -609,7 +609,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
             _test(t, weight_even, mode)
             _test(t, weight_odd, mode)
 
-    @dtypes(torch.float, torch.double)
+    @dtypes(torch.double)
     def test_conv1d_backward_depthwise(self, device, dtype):
         batch, channels, width = 2, 4, 2
         x = make_tensor(


### PR DESCRIPTION
Currently, the XPU implements conv1d through oneDNN conv2d by viewing 3D tensors as 4D tensors. `convolution_backward_overrideable` selected the memory format before applying this viewing and converted all tensors to that format. The detail implementation then re-detected the memory format from the converted 4D tensors when creating memory descriptors.

For some singleton-dimension layouts, 3D and 4D format detection differs, causing oneDNN use mismatched layout tags and produce incorrect backward results.

For example, a 3D input with `shape=[2, 4, 1]` and `stride=[8, 1, 4]` suggests a contiguous layout. After it is viewed as a 4D tensor with `shape=[2, 4, 1, 1]` and `stride=[8, 1, 4, 4]`, it instead suggests a channels-last layout.

This PR fixes the https://github.com/intel/torch-xpu-ops/issues/4906

cc @ptrblck @msaroufim @eqy @tinglvv @nWEIdia @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @gujinghui @EikanWang @fengyuan14 @guangyey