### PR TITLE
Validate MPS device during deserialization

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -705,6 +705,17 @@ class SerializationMixin:
         with self.assertRaisesRegex(RuntimeError, error_msg):
             _ = torch.load(buf)
 
+    @unittest.skipIf(torch.mps.is_available(), "Testing torch.load on a machine without MPS")
+    def test_load_nonexistent_mps_device(self):
+        # Asking for a device the machine does not have must report that, the same
+        # way every other backend does, rather than surfacing an allocator error.
+        with tempfile.NamedTemporaryFile() as f:
+            torch.save(torch.randn(2), f)
+            f.seek(0)
+            error_msg = r'Attempting to deserialize object on a MPS device'
+            with self.assertRaisesRegex(RuntimeError, error_msg):
+                _ = torch.load(f, map_location='mps')
+
     def test_serialization_filelike_api_requirements(self):
         filemock = FilelikeMock(b'', has_readinto=False)
         tensor = torch.randn(3, 5)

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -565,6 +565,14 @@ def _cpu_deserialize(obj, location):
 
 def _mps_deserialize(obj, location):
     if location.startswith("mps"):
+        # MPS predates the shared _backend_tag/_deserialize pair and still moves
+        # storages with obj.mps(): the shared path goes through
+        # torch._utils._to, which needs a torch.<backend>.device context manager
+        # that torch.mps does not provide. Validate through the same helper as
+        # every other backend regardless, so an unavailable device or an
+        # out-of-range index is reported here the way it is reported everywhere
+        # else instead of failing inside the allocator.
+        _validate_device(location, "mps")
         return obj.mps()
 
 


### PR DESCRIPTION
Fixes ##194584

Every accelerator's storage deserializer runs the requested location through _validate_device before moving data, so a checkpoint tagged for a device the machine does not have fails with a message that names the fix (map_location=torch.device('cpu')). MPS is the one exception — _mps_deserialize calls obj.mps() with no validation.

Two user-visible consequences:

On a machine without MPS, obj.mps() reaches torch.UntypedStorage(nbytes, device="mps"), and the at::kMPS arm of the allocator switch in THPStorage_pynew is behind USE_MPS — so on a build without it, kMPS falls through to default: and reports Storage device not recognized: mps. On an Apple build with too old an OS it reports the macOS 14.0+ requirement from ATen/mps/EmptyTensor.cpp. Neither mentions map_location.
map_location="mps:N" for N >= torch.mps.device_count() is not checked at all and silently lands on the default device, where CUDA raises.
This routes _mps_deserialize through the shared _validate_device and keeps obj.mps() for the move.

Why only half the migration. Moving MPS fully onto _deserialize("mps") would be the better end state, but that path calls storage.to(device=...) → torch._utils._to, which does with device_module.device(device). torch.mps exposes no device context manager, while torch.cuda, torch.xpu and torch.mtia all do (all three list "device" in __all__). Adding one is an MPS API change and out of scope here. _mps_tag is left alone for the same reason, so nothing about the bytes on disk changes.

Behavior changes, both narrowing what is accepted:

An unavailable MPS device now raises from _validate_device rather than from the allocator, so the message changes to the shared one.
