### PR TITLE
Validate torch.jit map_location for every backend, not only CUDA

### DIFF
--- a/test/jit/test_save_load.py
+++ b/test/jit/test_save_load.py
@@ -25,6 +25,48 @@ from torch.testing._internal.jit_utils import clear_class_registry, JitTestCase
 
 
 class TestSaveLoad(JitTestCase):
+    def test_validate_map_location_checks_every_backend(self):
+        """
+        validate_map_location used to validate only when the target was CUDA, so
+        an unavailable non-CUDA accelerator passed straight through to the
+        loader. Every accelerator with a registered device module is checked.
+        """
+        from torch.jit._serialization import validate_map_location
+
+        checked = []
+        for device_type in ("cuda", "xpu", "mps", "mtia"):
+            device_module = getattr(torch, device_type, None)
+            if device_module is None or not hasattr(device_module, "is_available"):
+                continue
+            if device_module.is_available():
+                continue
+            checked.append(device_type)
+            with self.assertRaisesRegex(
+                RuntimeError, rf"torch\.{device_type}\.is_available\(\) is False"
+            ):
+                validate_map_location(device_type)
+
+        if not checked:
+            self.skipTest(
+                "every accelerator with a device module is available on this machine"
+            )
+
+    def test_validate_map_location_passes_through_deviceless_targets(self):
+        """
+        A device type with no device module has nothing to validate against and
+        must still round-trip, as must CPU and None.
+        """
+        from torch.jit._serialization import validate_map_location
+
+        self.assertIsNone(validate_map_location(None))
+        self.assertEqual(validate_map_location("cpu"), torch.device("cpu"))
+        self.assertEqual(validate_map_location("meta"), torch.device("meta"))
+        self.assertEqual(
+            validate_map_location(torch.device("cpu")), torch.device("cpu")
+        )
+        with self.assertRaisesRegex(ValueError, "map_location should be either"):
+            validate_map_location(0)
+
     def test_different_modules(self):
         """
         Exercise the situation where we have the same qualified name

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -17,7 +17,7 @@ import torch
 from torch._jit_internal import _get_model_id
 from torch._utils_internal import log_torchscript_usage
 from torch.jit._recursive import wrap_cpp_module
-from torch.serialization import validate_cuda_device
+from torch.serialization import _validate_device
 
 
 def save(m, f, _extra_files=None) -> None:
@@ -222,8 +222,17 @@ def validate_map_location(map_location=None):
             "but got type: " + str(type(map_location))
         )
 
-    if str(map_location).startswith("cuda"):
-        validate_cuda_device(map_location)
+    # Validate against whichever backend registered torch.<device_type>, rather
+    # than only CUDA: _validate_device is already parameterized by backend name
+    # and reports an unavailable device or an out-of-range index the same way for
+    # all of them. Two types are skipped rather than validated -- one with no
+    # device module at all (meta) has nothing to check against and is left to the
+    # loader, and cpu is skipped by name because torch.cpu exists but is never
+    # the absent-runtime case this guards.
+    if map_location is not None:
+        device_type = map_location.type
+        if device_type != "cpu" and hasattr(torch, device_type):
+            _validate_device(map_location, device_type)
 
     return map_location
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -622,14 +622,9 @@ def _validate_device(location, backend_name):
             "to map your storages to the CPU."
         )
     device_module = getattr(torch, backend_name)
-    if hasattr(device_module, "_utils") and hasattr(
-        device_module._utils, "_get_device_index"
-    ):
-        device_index = device_module._utils._get_device_index(location, True)
-        device = torch.device(backend_name, device_index)
-    else:
-        device = torch.device(location)
-        device_index = device.index if device.index else 0
+    # Availability first: resolving the index can itself query the runtime, and a
+    # backend that is not present fails there with its own message instead of the
+    # actionable one below.
     if hasattr(device_module, "is_available") and not device_module.is_available():
         raise RuntimeError(
             f"Attempting to deserialize object on a {backend_name.upper()} "
@@ -638,6 +633,14 @@ def _validate_device(location, backend_name):
             "please use torch.load with map_location=torch.device('cpu') "
             "to map your storages to the CPU."
         )
+    if hasattr(device_module, "_utils") and hasattr(
+        device_module._utils, "_get_device_index"
+    ):
+        device_index = device_module._utils._get_device_index(location, True)
+        device = torch.device(backend_name, device_index)
+    else:
+        device = torch.device(location)
+        device_index = device.index if device.index else 0
     if hasattr(device_module, "device_count"):
         device_count = device_module.device_count()
         if device_index >= device_count:


### PR DESCRIPTION
Related to this RFC: #194355

`validate_map_location` gates its check on a string prefix:

```python
if str(map_location).startswith("cuda"):
    validate_cuda_device(map_location)
```

so `torch.jit.load(map_location="cuda:5")` on a single-GPU machine raises, while
`map_location="xpu:5"` is not checked at all and falls through to the C++ loader.
All three entry points that share the helper inherit the gap — `torch.jit.load`,
the `torch.jit._script` importer path, and
`torch.jit.mobile._load_for_lite_interpreter`. `torch.load` has always validated
every backend, through `_deserialize` → `_validate_device`, so the two loaders
currently disagree about the same `map_location`.

Nothing about the check is CUDA-specific. `validate_cuda_device` is a one-line
wrapper over `_validate_device(location, backend_name)`, which is already
parameterized by backend and derives everything from the device module
(`is_available`, `_utils._get_device_index`, `device_count`). This resolves the
backend from `map_location.type` and calls that helper.

Two device types are skipped rather than validated: one with no device module at
all (`meta`) has nothing to check against and is left to the loader, matching
current behavior; `cpu` is skipped by name, because `torch.cpu` does exist as a
package and a `getattr`-based gate would let it into a check about an absent
runtime that cannot apply to it.

`_validate_device` is also reordered to test `is_available()` before resolving
the device index. The index resolution queries the runtime — for a location with
no index, `_get_device_index(location, optional=True)` reaches
`torch._utils._get_current_device_index` → `_get_device_attr` →
`m.current_device()` — so on a machine without the backend the failure could come
from the runtime rather than from the actionable branch immediately below.
Ordering availability first cannot change a working load, since both orders
execute identically when the backend is present, and it matters more now that the
helper is reached for backends other than CUDA.

**Behavior change, a narrowing.** `torch.jit.load` and
`_load_for_lite_interpreter` with a `map_location` naming an unavailable
accelerator, or an index at or beyond that backend's `device_count`, now raise
where they previously proceeded. CUDA is unaffected — it was already validated.
The message is the shared one, naming `map_location=torch.device('cpu')`.

`validate_cuda_device` and `validate_hpu_device` are left in place. Both are
public (`serialization.__all__`); after this change the former has no in-tree
caller and the latter never had one. Replacing the pair with a single public
`validate_device` would be the consistent end state, but that is new public API
and belongs in its own change.

