### PR TITLE
[Dynamo] derive registered Stream/Event classes from DeviceInterface

### DIFF
--- a/test/dynamo/test_streams.py
+++ b/test/dynamo/test_streams.py
@@ -8,6 +8,11 @@ from unittest.mock import patch
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
+from torch._dynamo.device_interface import (
+    device_interfaces,
+    DeviceInterface,
+    register_interface_for_device,
+)
 from torch._dynamo.graph_bytecode_inputs import (
     CURRENT_STREAM_INDEX,
     index_to_external_object_weakref,
@@ -15,6 +20,7 @@ from torch._dynamo.graph_bytecode_inputs import (
     store_user_object_weakrefs,
 )
 from torch._dynamo.testing import extract_graph, remove_trailing_space
+from torch._dynamo.variables.user_defined import UserDefinedClassVariable
 from torch.testing._internal.common_utils import (
     IS_LINUX,
     IS_MACOS,
@@ -51,6 +57,44 @@ class TestStreams(torch._dynamo.test_case.TestCase):
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
+
+    def test_registered_device_stream_event_in_graph_classes(self):
+        class TestStream(torch.Stream):
+            pass
+
+        class TestEvent(torch.Event):
+            pass
+
+        class TestInterface(DeviceInterface):
+            Stream = TestStream
+            Event = TestEvent
+
+        class PlaceholderInterface(DeviceInterface):
+            pass
+
+        UserDefinedClassVariable._in_graph_classes.cache_clear()
+        self.addCleanup(UserDefinedClassVariable._in_graph_classes.cache_clear)
+        self.assertNotIn(TestStream, UserDefinedClassVariable._in_graph_classes())
+
+        with patch.dict(device_interfaces):
+            register_interface_for_device("test", TestInterface)
+            register_interface_for_device("placeholder", PlaceholderInterface)
+            in_graph_classes = UserDefinedClassVariable._in_graph_classes()
+
+            for device in ("cuda", "xpu"):
+                device_interface = device_interfaces[device]
+                for base, cls in (
+                    (torch.Stream, device_interface.Stream),
+                    (torch.Event, device_interface.Event),
+                ):
+                    if isinstance(cls, type) and issubclass(cls, base):
+                        self.assertIn(cls, in_graph_classes)
+                    else:
+                        self.assertNotIn(cls, in_graph_classes)
+            self.assertIn(TestStream, in_graph_classes)
+            self.assertIn(TestEvent, in_graph_classes)
+            self.assertNotIn(DeviceInterface.Stream, in_graph_classes)
+            self.assertNotIn(DeviceInterface.Event, in_graph_classes)
 
     @requires_cuda
     def test_stream_weakref(self):

--- a/torch/_dynamo/device_interface.py
+++ b/torch/_dynamo/device_interface.py
@@ -642,6 +642,9 @@ def register_interface_for_device(
     if isinstance(device, torch.device):
         device = device.type
     device_interfaces[device] = device_interface
+    from .variables.user_defined import UserDefinedClassVariable
+
+    UserDefinedClassVariable._in_graph_classes.cache_clear()
 
 
 def get_interface_for_device(device: str | torch.device) -> type[DeviceInterface]:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -51,6 +51,7 @@ from torch.utils._pytree import GetAttrKey, is_structseq_class
 from .. import config, graph_break_hints, polyfills, variables
 from ..bytecode_transformation import create_call_function
 from ..create_parameter_op import do_not_convert_to_tracable_parameter
+from ..device_interface import get_registered_device_interfaces
 from ..exc import (
     handle_observed_exception,
     ObservedAttributeError,
@@ -393,10 +394,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
             torch.cuda.LongTensor,  # type: ignore[attr-defined]
             torch.Stream,
             torch.Event,
-            torch.cuda.Stream,
-            torch.cuda.Event,
-            torch.xpu.Stream,
-            torch.xpu.Event,
         }
         if hasattr(torch, "hpu"):
             _in_graph_class_list.update(
@@ -405,6 +402,17 @@ class UserDefinedClassVariable(UserDefinedVariable):
                     torch.hpu.Event,
                 }
             )
+
+        for _, device_interface in get_registered_device_interfaces():
+            stream_class = getattr(device_interface, "Stream", None)
+            if isinstance(stream_class, type) and issubclass(
+                stream_class, torch.Stream
+            ):
+                _in_graph_class_list.add(stream_class)
+
+            event_class = getattr(device_interface, "Event", None)
+            if isinstance(event_class, type) and issubclass(event_class, torch.Event):
+                _in_graph_class_list.add(event_class)
 
         return set(tensortype_to_dtype.keys()) | _in_graph_class_list
 


### PR DESCRIPTION
## Summary

This is a narrower replacement for #192196: it contains only the Stream/Event
part of that proposal and deliberately excludes the separate tensor-type and
autocast changes.

`UserDefinedClassVariable._in_graph_classes()` recognizes built-in Stream and
Event classes, but it does not consume the Stream/Event types already exposed
by registered `DeviceInterface` implementations. Out-of-tree backends therefore
need to patch this cached set themselves.

This change:

- adds valid `torch.Stream` / `torch.Event` subclasses from every registered
  concrete device interface to the existing in-graph class set;
- excludes the placeholder classes inherited from `DeviceInterface` and other
  invalid implementations;
- clears the cached set when an interface is registered, so backends imported
  after the first Dynamo trace are visible; and
- adds a focused regression test for late registration and placeholder
  filtering.

The scope is intentionally limited to Stream/Event discovery. It does not add
new `DeviceInterface` slots, alter autocast or tensor-type routing, or remove the
existing CUDA/XPU/HPU entries.

## Test Plan

```text
python test/dynamo/test_streams.py TestStreams.test_registered_device_stream_event_in_graph_classes -v
# 1 passed

lintrunner --take FLAKE8,NEWLINE,SPACES,TABS,COPYRIGHT \
  test/dynamo/test_streams.py \
  torch/_dynamo/device_interface.py \
  torch/_dynamo/variables/user_defined.py
# No lint issues
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @jansel @albanD @jbschlosser
