### PR TITLE
[dynamo] Split DequeReverseIteratorVariable off DequeIteratorVariable to match CPython

### DIFF
--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -484,7 +484,9 @@ class TestIterators(torch._dynamo.test_case.TestCase):
             DequeReverseIteratorVariable,
         )
 
-        self.assertFalse(issubclass(DequeReverseIteratorVariable, DequeIteratorVariable))
+        self.assertFalse(
+            issubclass(DequeReverseIteratorVariable, DequeIteratorVariable)
+        )
         self.assertIs(
             DequeReverseIteratorVariable._cpython_type,
             type(reversed(collections.deque())),

--- a/test/dynamo/test_iterators.py
+++ b/test/dynamo/test_iterators.py
@@ -471,6 +471,47 @@ class TestIterators(torch._dynamo.test_case.TestCase):
 
         self.assertEqual(list(gen()), [1, 2, 3])
 
+    def test_deque_reverse_iterator_not_a_deque_iterator(self):
+        """reverse deque iterators must not subclass DequeIteratorVariable.
+
+        In CPython, _deque_reverse_iterator is not a subclass of
+        _deque_iterator; the VTs should mirror that.
+        """
+        import collections
+
+        from torch._dynamo.variables.lists import (
+            DequeIteratorVariable,
+            DequeReverseIteratorVariable,
+        )
+
+        self.assertFalse(issubclass(DequeReverseIteratorVariable, DequeIteratorVariable))
+        self.assertIs(
+            DequeReverseIteratorVariable._cpython_type,
+            type(reversed(collections.deque())),
+        )
+        self.assertIs(
+            DequeIteratorVariable._cpython_type, type(iter(collections.deque()))
+        )
+
+    @make_dynamo_test
+    def test_yield_from_deque_reverse_iterator(self):
+        """yield from over a reverse deque iterator still traces after the VT split."""
+        import collections
+
+        def gen():
+            yield from reversed(collections.deque([1, 2, 3]))
+
+        self.assertEqual(list(gen()), [3, 2, 1])
+
+    @make_dynamo_test
+    def test_deque_reverse_iterator_python_type(self):
+        """type(reversed(deque)) inside compile must be _deque_reverse_iterator."""
+        import collections
+
+        it = reversed(collections.deque([1, 2, 3]))
+        self.assertIs(type(it), type(reversed(collections.deque())))
+        self.assertIsNot(type(it), type(iter(collections.deque())))
+
     def test_tuple_iterator_not_a_list_iterator(self):
         """tuple iterators must not subclass ListIteratorVariable (CPython parity).
 

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -183,6 +183,7 @@ from .variables.lazy import LazyVariableTracker
 from .variables.lists import (
     BaseListVariable,
     DequeIteratorVariable,
+    DequeReverseIteratorVariable,
     ListIteratorVariable,
     ListVariable,
     SliceVariable,
@@ -6558,7 +6559,7 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
 
     def GET_YIELD_FROM_ITER(self, inst: Instruction) -> None:
         tos = self.stack[-1]
-        iter_vts = (ListIteratorVariable, TupleIteratorVariable, DequeIteratorVariable)
+        iter_vts = (ListIteratorVariable, TupleIteratorVariable, DequeIteratorVariable, DequeReverseIteratorVariable)
         if not isinstance(tos, iter_vts):
             self.pop()
             res = VariableTracker.build(self, iter).call_function(self, [tos], {})  # type: ignore[arg-type]

--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -6559,7 +6559,12 @@ class InliningGeneratorInstructionTranslator(InliningInstructionTranslator):
 
     def GET_YIELD_FROM_ITER(self, inst: Instruction) -> None:
         tos = self.stack[-1]
-        iter_vts = (ListIteratorVariable, TupleIteratorVariable, DequeIteratorVariable, DequeReverseIteratorVariable)
+        iter_vts = (
+            ListIteratorVariable,
+            TupleIteratorVariable,
+            DequeIteratorVariable,
+            DequeReverseIteratorVariable,
+        )
         if not isinstance(tos, iter_vts):
             self.pop()
             res = VariableTracker.build(self, iter).call_function(self, [tos], {})  # type: ignore[arg-type]

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -1310,6 +1310,7 @@ def _unpack_fast_types() -> tuple[type, ...]:
             variables.ListIteratorVariable,
             variables.TupleIteratorVariable,
             variables.DequeIteratorVariable,
+            variables.DequeReverseIteratorVariable,
             variables.RangeVariable,
             variables.SetVariable,
             variables.FrozensetVariable,

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -122,6 +122,7 @@ from .lazy import LazyConstantVariable, LazyVariableTracker
 from .lists import (
     BaseListVariable,
     DequeIteratorVariable,
+    DequeReverseIteratorVariable,
     DequeVariable,
     ListIteratorVariable,
     ListVariable,

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -2358,9 +2358,9 @@ class SliceVariable(VariableTracker):
 
 
 class BaseListIteratorVariable(IteratorVariable):
-    # In CPython list_iterator, tuple_iterator, and _deque_iterator are siblings,
-    # not subclasses of one another, so the concrete VTs share this base rather
-    # than each other.
+    # In CPython list_iterator, tuple_iterator, _deque_iterator, and
+    # _deque_reverse_iterator are siblings, not subclasses of one another, so
+    # the concrete VTs share this base rather than each other.
 
     _nonvar_fields = {
         "index",
@@ -2485,8 +2485,37 @@ class DequeIteratorVariable(BaseListIteratorVariable):
         return type(iter(collections.deque()))
 
 
-class DequeReverseIteratorVariable(DequeIteratorVariable):
+class DequeReverseIteratorVariable(BaseListIteratorVariable):
+    # Sibling of DequeIteratorVariable. Mutation snapshot is copied, not
+    # inherited, so isinstance(..., DequeIteratorVariable) stays false.
     _cpython_type = type(reversed(collections.deque()))
+
+    _nonvar_fields = {
+        "saved_state",
+        *BaseListIteratorVariable._nonvar_fields,
+    }
+
+    def __init__(
+        self,
+        items: list[VariableTracker],
+        source_deque: "DequeVariable",
+        saved_state: int,
+        index: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(items, index=index, **kwargs)
+        self.source_deque = source_deque
+        self.saved_state = saved_state
+
+    def _check_mutation(self, tx: "InstructionTranslatorBase") -> None:
+        if self.source_deque.state != self.saved_state:
+            raise_observed_exception(
+                RuntimeError, tx, args=["deque mutated during iteration"]
+            )
+
+    def tp_iternext_impl(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        self._check_mutation(tx)
+        return super().tp_iternext_impl(tx)
 
     def python_type(self) -> type:
         return type(reversed(collections.deque()))


### PR DESCRIPTION
## Summary

In CPython, `_deque_reverse_iterator` is not a subclass of `_deque_iterator`:

```
>>> from collections import deque
>>> issubclass(type(reversed(deque())), type(iter(deque())))
False
```

`dir()` on both is the same (`__iter__`, `__next__`, `__length_hint__`). Dynamo still had `DequeReverseIteratorVariable(DequeIteratorVariable)`, so every `isinstance(x, DequeIteratorVariable)` check also matched reverse deque iterators.

This follows the same shape as #193261 (deque forward) and #193717 (tuple): reparent onto the existing `BaseListIteratorVariable` so the two deque iterator VTs are siblings. No new base class.

The deque mutation snapshot (`source_deque` / `saved_state`) cannot be inherited from `DequeIteratorVariable` after the split, or reverse iterators would still type-check as deque iterators. It is copied onto `DequeReverseIteratorVariable` so `reversed(d)` still raises `RuntimeError: deque mutated during iteration`.

### Files touched

| File | What changed |
| --- | --- |
| `torch/_dynamo/variables/lists.py` | `DequeReverseIteratorVariable` now subclasses `BaseListIteratorVariable`. Mutation snapshot copied so reverse iterators stay siblings. |
| `torch/_dynamo/symbolic_convert.py` | `GET_YIELD_FROM_ITER` lists `DequeReverseIteratorVariable` explicitly (same pattern as list/tuple/deque after #193717). |
| `torch/_dynamo/utils.py` | `_unpack_fast_types` adds `DequeReverseIteratorVariable` so reverse deque unpack keeps the fast path. |
| `torch/_dynamo/variables/__init__.py` | Import `DequeReverseIteratorVariable` (not exported in `__all__`, same as `DequeIteratorVariable`). |
| `test/dynamo/test_iterators.py` | Hierarchy, `yield from reversed(deque)`, and `type(reversed(deque))` regression tests. |

Not touched: `side_effects.py`. Deque iterators are built sourceless with `ValueMutationNew` and never hit the list/tuple iterator replay handler (#193261). Reverse is the same.

Part of #192874

## Test plan

```
python test/dynamo/test_iterators.py TestIterators.test_deque_reverse_iterator_not_a_deque_iterator
python test/dynamo/test_iterators.py TestIterators.test_yield_from_deque_reverse_iterator
python test/dynamo/test_iterators.py TestIterators.test_deque_reverse_iterator_python_type
python test/dynamo/test_iterators.py
python test/dynamo/test_sequence_ops.py -k deque_reverse
```


cc @guilhermeleobas @williamwen42 @jansel @Skylion007 @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98