### PR TITLE
Remove unused typelist constructs from TypeList.h

### DIFF
--- a/test/cpp/aoti_abi_check/test_typelist.cpp
+++ b/test/cpp/aoti_abi_check/test_typelist.cpp
@@ -1,6 +1,4 @@
-#include <gtest/gtest.h>
 #include <torch/headeronly/util/TypeList.h>
-#include <memory>
 
 using namespace torch::headeronly::guts::typelist;
 // NOLINTBEGIN(modernize-unary-static-assert)
@@ -65,36 +63,6 @@ static_assert(
     "");
 } // namespace test_concat
 
-namespace test_filter {
-class MyClass {};
-static_assert(
-    std::is_same_v<typelist<>, filter_t<std::is_reference, typelist<>>>,
-    "");
-static_assert(
-    std::is_same_v<
-        typelist<>,
-        filter_t<std::is_reference, typelist<int, float, double, MyClass>>>,
-    "");
-static_assert(
-    std::is_same_v<
-        typelist<float&, const MyClass&&>,
-        filter_t<
-            std::is_reference,
-            typelist<int, float&, double, const MyClass&&>>>,
-    "");
-} // namespace test_filter
-
-namespace test_count_if {
-class MyClass final {};
-static_assert(
-    count_if<
-        std::is_reference,
-        typelist<int, bool&, const MyClass&&, float, double>>::value == 2,
-    "");
-static_assert(count_if<std::is_reference, typelist<int, bool>>::value == 0, "");
-static_assert(count_if<std::is_reference, typelist<>>::value == 0, "");
-} // namespace test_count_if
-
 namespace test_true_for_each_type {
 template <class>
 class Test;
@@ -131,25 +99,6 @@ static_assert(
 static_assert(!true_for_any_type<std::is_reference, typelist<>>::value, "");
 } // namespace test_true_for_any_type
 
-namespace test_map {
-class MyClass {};
-static_assert(
-    std::is_same_v<typelist<>, map_t<std::add_lvalue_reference_t, typelist<>>>,
-    "");
-static_assert(
-    std::is_same_v<
-        typelist<int&>,
-        map_t<std::add_lvalue_reference_t, typelist<int>>>,
-    "");
-static_assert(
-    std::is_same_v<
-        typelist<int&, double&, const MyClass&>,
-        map_t<
-            std::add_lvalue_reference_t,
-            typelist<int, double, const MyClass>>>,
-    "");
-} // namespace test_map
-
 namespace test_head {
 class MyClass {};
 static_assert(std::is_same_v<int, head_t<typelist<int, double>>>, "");
@@ -182,104 +131,6 @@ static_assert(
     "");
 static_assert(std::is_same_v<bool, head_with_default_t<bool, typelist<>>>, "");
 } // namespace test_head_with_default
-
-namespace test_reverse {
-class MyClass {};
-static_assert(
-    std::is_same_v<
-        typelist<int, double, MyClass*, const MyClass&&>,
-        reverse_t<typelist<const MyClass&&, MyClass*, double, int>>>,
-    "");
-static_assert(std::is_same_v<typelist<>, reverse_t<typelist<>>>, "");
-} // namespace test_reverse
-
-namespace test_map_types_to_values {
-struct map_to_size {
-  template <class T>
-  constexpr size_t operator()(T) const {
-    return sizeof(typename T::type);
-  }
-};
-
-TEST(TypeListTest, MapTypesToValues_sametype) {
-  auto sizes =
-      map_types_to_values<typelist<int64_t, bool, uint32_t>>(map_to_size());
-  std::tuple<size_t, size_t, size_t> expected(8, 1, 4);
-  static_assert(std::is_same_v<decltype(expected), decltype(sizes)>, "");
-  EXPECT_EQ(expected, sizes);
-}
-
-struct map_make_shared {
-  template <class T>
-  std::shared_ptr<typename T::type> operator()(T) {
-    return std::make_shared<typename T::type>();
-  }
-};
-
-TEST(TypeListTest, MapTypesToValues_differenttypes) {
-  auto shared_ptrs =
-      map_types_to_values<typelist<int, double>>(map_make_shared());
-  static_assert(
-      std::is_same_v<
-          std::tuple<std::shared_ptr<int>, std::shared_ptr<double>>,
-          decltype(shared_ptrs)>,
-      "");
-}
-
-struct Class1 {
-  static int func() {
-    return 3;
-  }
-};
-struct Class2 {
-  static double func() {
-    return 2.0;
-  }
-};
-
-struct mapper_call_func {
-  template <class T>
-  auto operator()(T) {
-    return T::type::func();
-  }
-};
-
-TEST(TypeListTest, MapTypesToValues_members) {
-  auto result =
-      map_types_to_values<typelist<Class1, Class2>>(mapper_call_func());
-  std::tuple<int, double> expected(3, 2.0);
-  static_assert(std::is_same_v<decltype(expected), decltype(result)>, "");
-  EXPECT_EQ(expected, result);
-}
-
-struct mapper_call_nonexistent_function {
-  template <class T>
-  auto operator()(T) {
-    return T::type::this_doesnt_exist();
-  }
-};
-
-TEST(TypeListTest, MapTypesToValues_empty) {
-  auto result =
-      map_types_to_values<typelist<>>(mapper_call_nonexistent_function());
-  std::tuple<> expected;
-  static_assert(std::is_same_v<decltype(expected), decltype(result)>, "");
-  EXPECT_EQ(expected, result);
-}
-} // namespace test_map_types_to_values
-
-namespace test_find_if {
-static_assert(0 == find_if<typelist<char&>, std::is_reference>::value, "");
-static_assert(
-    0 == find_if<typelist<char&, int, char&, int&>, std::is_reference>::value,
-    "");
-static_assert(
-    2 == find_if<typelist<char, int, char&, int&>, std::is_reference>::value,
-    "");
-static_assert(
-    3 == find_if<typelist<char, int, char, int&>, std::is_reference>::value,
-    "");
-} // namespace test_find_if
 
 namespace test_contains {
 static_assert(contains<typelist<double>, double>::value, "");

--- a/torch/header_only_apis.txt
+++ b/torch/header_only_apis.txt
@@ -81,17 +81,11 @@ tuple_take
 all
 concat_t
 contains
-count_if
 drop_if_nonempty_t
 drop_t
-filter_t
-find_if
 from_tuple_t
 head_t
 head_with_default_t
-map_t
-map_types_to_values
-reverse_t
 size
 take_t
 to_tuple_t

--- a/torch/headeronly/util/TypeList.h
+++ b/torch/headeronly/util/TypeList.h
@@ -12,9 +12,6 @@ namespace c10::guts {
 
 template <class... T>
 struct false_t : std::false_type {};
-template <template <class> class... T>
-struct false_higher_t : std::false_type {};
-
 namespace typelist {
 
 /**
@@ -109,58 +106,6 @@ template <class... TypeLists>
 using concat_t = typename concat<TypeLists...>::type;
 
 /**
- * Filters the types in a type list by a type trait.
- * Examples:
- *   typelist<int&, const string&&>  ==  filter_t<std::is_reference,
- * typelist<void, string, int&, bool, const string&&, int>>
- */
-template <template <class> class Condition, class TypeList>
-struct filter final {
-  static_assert(
-      false_t<TypeList>::value,
-      "In typelist::filter<Condition, TypeList>, the TypeList argument must be typelist<...>.");
-};
-template <template <class> class Condition, class Head, class... Tail>
-struct filter<Condition, typelist<Head, Tail...>> final {
-  static_assert(
-      is_type_condition<Condition>::value,
-      "In typelist::filter<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
-  using type = std::conditional_t<
-      Condition<Head>::value,
-      concat_t<
-          typelist<Head>,
-          typename filter<Condition, typelist<Tail...>>::type>,
-      typename filter<Condition, typelist<Tail...>>::type>;
-};
-template <template <class> class Condition>
-struct filter<Condition, typelist<>> final {
-  static_assert(
-      is_type_condition<Condition>::value,
-      "In typelist::filter<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
-  using type = typelist<>;
-};
-template <template <class> class Condition, class TypeList>
-using filter_t = typename filter<Condition, TypeList>::type;
-
-/**
- * Counts how many types in the list fulfill a type trait
- * Examples:
- *   2  ==  count_if<std::is_reference, typelist<void, string, int&, bool, const
- * string&&, int>>
- */
-template <template <class> class Condition, class TypeList>
-struct count_if final {
-  static_assert(
-      is_type_condition<Condition>::value,
-      "In typelist::count_if<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
-  static_assert(
-      is_instantiation_of<typelist, TypeList>::value,
-      "In typelist::count_if<Condition, TypeList>, the TypeList argument must be typelist<...>.");
-  // TODO Direct implementation might be faster
-  static constexpr size_t value = size<filter_t<Condition, TypeList>>::value;
-};
-
-/**
  * Checks if a typelist contains a certain type.
  * Examples:
  *  contains<typelist<int, string>, string> == true_type
@@ -218,25 +163,6 @@ struct true_for_any_type<Condition, typelist<Types...>> final
       is_type_condition<Condition>::value,
       "In typelist::true_for_any_type<Condition, TypeList>, the Condition argument must be a condition type trait, i.e. have a static constexpr bool ::value member.");
 };
-
-/**
- * Maps types of a type list using a type trait
- * Example:
- *  typelist<int&, double&, string&>  ==  map_t<std::add_lvalue_reference_t,
- * typelist<int, double, string>>
- */
-template <template <class> class Mapper, class TypeList>
-struct map final {
-  static_assert(
-      false_t<TypeList>::value,
-      "In typelist::map<Mapper, TypeList>, the TypeList argument must be typelist<...>.");
-};
-template <template <class> class Mapper, class... Types>
-struct map<Mapper, typelist<Types...>> final {
-  using type = typelist<Mapper<Types>...>;
-};
-template <template <class> class Mapper, class TypeList>
-using map_t = typename map<Mapper, TypeList>::type;
 
 /**
  * Returns the first element of a type list.
@@ -312,29 +238,6 @@ template <size_t Index, class TypeList>
 using element_t = typename element<Index, TypeList>::type;
 
 /**
- * Returns the last element of a type list.
- * Example:
- *   int  ==  last_t<typelist<int, string>>
- */
-template <class TypeList>
-struct last final {
-  static_assert(
-      false_t<TypeList>::value,
-      "In typelist::last<T>, the T argument must be typelist<...>.");
-};
-template <class Head, class... Tail>
-struct last<typelist<Head, Tail...>> final {
-  using type = typename last<typelist<Tail...>>::type;
-};
-template <class Head>
-struct last<typelist<Head>> final {
-  using type = Head;
-};
-template <class TypeList>
-using last_t = typename last<TypeList>::type;
-static_assert(std::is_same_v<int, last_t<typelist<double, float, int>>>);
-
-/**
  * Take/drop a number of arguments from a typelist.
  * Example:
  *   typelist<int, string> == take_t<typelist<int, string, bool>, 2>
@@ -401,100 +304,6 @@ struct drop_if_nonempty final {
 template <class TypeList, size_t num>
 using drop_if_nonempty_t = typename drop_if_nonempty<TypeList, num>::type;
 
-/**
- * Reverses a typelist.
- * Example:
- *   typelist<int, string>  == reverse_t<typelist<string, int>>
- */
-template <class TypeList>
-struct reverse final {
-  static_assert(
-      false_t<TypeList>::value,
-      "In typelist::reverse<T>, the T argument must be typelist<...>.");
-};
-template <class Head, class... Tail>
-struct reverse<typelist<Head, Tail...>> final {
-  using type =
-      concat_t<typename reverse<typelist<Tail...>>::type, typelist<Head>>;
-};
-template <>
-struct reverse<typelist<>> final {
-  using type = typelist<>;
-};
-template <class TypeList>
-using reverse_t = typename reverse<TypeList>::type;
-
-/**
- * Find the index of the first type in a typelist fulfilling a type trait
- * condition. Example:
- *
- * 2 == find_if<typelist<char, int, char&, int&>, std::is_reference>::value
- */
-template <class TypeList, template <class> class Condition, class Enable = void>
-struct find_if final {
-  static_assert(
-      false_t<TypeList>::value,
-      "In typelist::find_if<TypeList, Condition>, the TypeList argument must be typelist<...>.");
-};
-template <template <class> class Condition>
-struct find_if<typelist<>, Condition, void> final {
-  static_assert(
-      false_higher_t<Condition>::value,
-      "In typelist::find_if<Type/List, Condition>, didn't find any type fulfilling the Condition.");
-};
-template <class Head, class... Tail, template <class> class Condition>
-struct find_if<typelist<Head, Tail...>, Condition, void> final {
-  static constexpr size_t value = [] {
-    if constexpr (Condition<Head>::value) {
-      return size_t{0};
-    } else {
-      return size_t{1} + find_if<typelist<Tail...>, Condition>::value;
-    }
-  }();
-};
-
-/**
- * Maps a list of types into a list of values.
- * Examples:
- *   // Example 1
- *   auto sizes =
- *     map_types_to_values<typelist<int64_t, bool, uint32_t>>(
- *       [] (auto t) { return sizeof(decltype(t)::type); }
- *     );
- *   //  sizes  ==  std::tuple<size_t, size_t, size_t>{8, 1, 4}
- *
- *   // Example 2
- *   auto shared_ptrs =
- *     map_types_to_values<typelist<int, double>>(
- *       [] (auto t) { return make_shared<typename decltype(t)::type>(); }
- *     );
- *   // shared_ptrs == std::tuple<shared_ptr<int>, shared_ptr<double>>()
- */
-namespace detail {
-template <class T>
-struct type_ final {
-  using type = T;
-};
-template <class TypeList>
-struct map_types_to_values final {
-  static_assert(
-      false_t<TypeList>::value,
-      "In typelist::map_types_to_values<T>, the T argument must be typelist<...>.");
-};
-template <class... Types>
-struct map_types_to_values<typelist<Types...>> final {
-  template <class Func>
-  static auto call(Func&& func) {
-    return std::tuple{std::forward<Func>(func)(type_<Types>())...};
-  }
-};
-} // namespace detail
-
-template <class TypeList, class Func>
-auto map_types_to_values(Func&& func) {
-  return detail::map_types_to_values<TypeList>::call(std::forward<Func>(func));
-}
-
 } // namespace typelist
 } // namespace c10::guts
 
@@ -507,17 +316,11 @@ namespace typelist {
 using c10::guts::typelist::all;
 using c10::guts::typelist::concat_t;
 using c10::guts::typelist::contains;
-using c10::guts::typelist::count_if;
 using c10::guts::typelist::drop_if_nonempty_t;
 using c10::guts::typelist::drop_t;
-using c10::guts::typelist::filter_t;
-using c10::guts::typelist::find_if;
 using c10::guts::typelist::from_tuple_t;
 using c10::guts::typelist::head_t;
 using c10::guts::typelist::head_with_default_t;
-using c10::guts::typelist::map_t;
-using c10::guts::typelist::map_types_to_values;
-using c10::guts::typelist::reverse_t;
 using c10::guts::typelist::size;
 using c10::guts::typelist::take_t;
 using c10::guts::typelist::to_tuple_t;


### PR DESCRIPTION
These constructs in `torch/headeronly/util/TypeList.h` have zero in-tree
users outside their own unit test: `filter`, `count_if`, `map`, `last`,
`reverse`, `find_if`, `map_types_to_values` (and its `detail::type_`
helper), and `false_higher_t` (only used by `find_if`'s error case).
Removed together with the matching unit-test sections, the
`torch::headeronly` re-export entries, and their `torch/header_only_apis.txt`
entries. `take`/`drop` and `drop_if_nonempty_t` are kept (the former used
by gaudi-pytorch-bridge, the latter by `c10/core/DispatchKeySet.h`).

Test Plan: trimmed `test_typelist.cpp` still runs in CI; grep confirms
zero remaining references to the deleted constructs.
