### PR TITLE
[dynamo] Support modified Triton kernel sources

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -1865,6 +1865,44 @@ def forward(self, x_1, output_1):
 
         self.assertEqual(compiled_out, eager_out)
 
+    @requires_gpu
+    def test_triton_kernel_with_modified_source(self):
+        @triton.jit
+        def kernel_with_modified_source(
+            in_ptr,
+            out_ptr,
+            n_elements,
+            BLOCK_SIZE: "tl.constexpr",
+        ):
+            pid = tl.program_id(axis=0)
+            block_start = pid * BLOCK_SIZE
+            offsets = block_start + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_elements
+            x = tl.load(in_ptr + offsets, mask=mask)
+            output = x
+            tl.store(out_ptr + offsets, output, mask=mask)
+
+        kernel_with_modified_source._unsafe_update_src(
+            kernel_with_modified_source.src.replace(
+                "output = x", "output = fast_dividef(x, 3.14)"
+            )
+        )
+
+        def f(x):
+            out = torch.empty_like(x)
+            n_elements = x.numel()
+            kernel_with_modified_source[(n_elements,)](
+                x, out, n_elements, BLOCK_SIZE=16
+            )
+            return out
+
+        x = torch.randn(4, device=GPU_TYPE)
+        eager_out = f(x)
+        compiled_out, (triton_code,) = run_and_get_code(torch.compile(f), x)
+
+        self.assertIn("import fast_dividef as fast_dividef", triton_code)
+        self.assertEqual(compiled_out, eager_out)
+
     @unittest.skipIf(
         not HAS_GPU or not hasattr(triton, "constexpr_function"),
         "newer triton version required",

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import ast
 import collections
 import contextlib
 import dataclasses
@@ -393,17 +394,26 @@ def user_defined_triton_kernel_transitive_closure_source_code(
     symbols_included = OrderedSet([kernel.__name__])
 
     def traverse(cur_kernel):
+        # Walk the source Triton will compile to find loaded names because
+        # JITFunction.src may differ from the underlying function bytecode.
+        source_loads = OrderedSet(
+            node.id
+            for node in ast.walk(ast.parse(cur_kernel.src))
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load)
+        )
         # here we extract the unqualified names (i.e., not attributes and
-        # without prepended module name) loaded in the kernel code, which
-        # are matched with the co_names and __globals__ below to codegen
-        # the respective imports necessary for the kernel compilation
-        unqualified_loads = OrderedSet(
+        # without prepended module name) loaded in the kernel bytecode and
+        # combine them with names loaded from the source. These are matched with
+        # the co_names and __globals__ below to codegen the respective imports
+        # necessary for the kernel compilation
+        unqualified_loads = source_loads | OrderedSet(
             inst.argval
             for inst in dis.Bytecode(cur_kernel.fn)
             if inst.opname == "LOAD_GLOBAL"
         )
         global_annotations = cur_kernel.fn.__globals__.get("__annotations__", {})
-        for symbol_name in cur_kernel.fn.__code__.co_names:
+        referenced_names = OrderedSet(cur_kernel.fn.__code__.co_names) | source_loads
+        for symbol_name in referenced_names:
             if symbol_name in symbols_included:
                 continue
             if symbol_name in cur_kernel.fn.__globals__:


### PR DESCRIPTION
this mr solves the inductor triton hop reconstruction bug for
- imported variable from other package
- nested jit construction triton kernels

A Triton JITFunction's source can differ from the bytecode of its underlying Python function. Inductor needs to inspected the bytecode when collecting globals variable or functions.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo