### PR TITLE
Promote pytorch-mps-ci to CRCR allowlist L2

### DIFF
--- a/.github/allowlist.yml
+++ b/.github/allowlist.yml
@@ -41,13 +41,13 @@ L1:
   - NVIDIA-dev/pytorch-oot-internal
   - NVIDIA/pytorch-windows-ci
   - google-pytorch/torch_tpu
-  - Isalia20/pytorch-mps-ci
 
 L2:
   - TorchedHat/pytorch-redhat-ci
   - Ascend/pytorch
   - torch-spyre/torch-spyre
   - vllm-project/vllm
+  - Isalia20/pytorch-mps-ci
 
 L3:
   # Canonical test repos for CRCR.


### PR DESCRIPTION
Promote Isalia20/pytorch-mps-ci from L1 to L2 so its results report to the HUD. Repo onboarded at L1 in #194198.
You can see the runs on all merges on this link:
https://github.com/Isalia20/pytorch-mps-ci/actions?query=-is%3Acancelled+-is%3Askipped

<img width="1512" height="739" alt="Screenshot 2026-09-12 at 15 25 28" src="https://github.com/user-attachments/assets/28e853f2-a956-4d8e-a2a4-3c3eefbdd61a" />
