### PR TITLE
[flop_counter] Defer PrivateUse1 triton-missing warning to first FlopCounterMode use

### DIFF
--- a/test/test_flop_counter.py
+++ b/test/test_flop_counter.py
@@ -2,6 +2,7 @@
 # ruff: noqa: F841
 import functools
 import unittest
+from unittest import mock
 
 import torch
 import torch.nn.functional as F
@@ -969,6 +970,70 @@ class TestFlopCounter(TestCase):
         mod = torch.nn.Linear(2, 2)
         with self.assertWarnsRegex(UserWarning, "not needed"):
             FlopCounterMode(mod)
+
+    def _run_with_missing_triton(self, backend_name, is_triton_capable):
+        # Simulates `except ImportError: _JITFunction = NoneType` having
+        # already run, plus a PrivateUse1 backend registered as `backend_name`
+        # whose DeviceInterface.is_triton_capable() returns `is_triton_capable`.
+        # `NotImplementedError` (no DeviceInterface registered at all) is
+        # simulated by passing `is_triton_capable=None`.
+        fake_log = mock.MagicMock()
+        fake_interface = mock.MagicMock()
+        if is_triton_capable is None:
+            fake_get_interface = mock.MagicMock(side_effect=NotImplementedError)
+        else:
+            fake_interface.is_triton_capable.return_value = is_triton_capable
+            fake_get_interface = mock.MagicMock(return_value=fake_interface)
+        with (
+            mock.patch.object(torch.utils.flop_counter, "_JITFunction", type(None)),
+            mock.patch.object(torch.utils.flop_counter, "log", fake_log),
+            mock.patch.object(
+                torch._C, "_get_privateuse1_backend_name", return_value=backend_name
+            ),
+            mock.patch(
+                "torch._dynamo.device_interface.get_interface_for_device",
+                fake_get_interface,
+            ),
+        ):
+            FlopCounterMode()
+        return fake_log, fake_get_interface
+
+    def test_privateuse1_triton_warning_when_capable(self):
+        fake_log, fake_get_interface = self._run_with_missing_triton(
+            "npu", is_triton_capable=True
+        )
+        fake_get_interface.assert_called_once_with("npu")
+        fake_log.warning.assert_called_once_with(
+            "triton not found; flop counting will not work for triton kernels"
+        )
+
+    def test_privateuse1_no_warning_when_not_triton_capable(self):
+        fake_log, fake_get_interface = self._run_with_missing_triton(
+            "npu", is_triton_capable=False
+        )
+        fake_get_interface.assert_called_once_with("npu")
+        fake_log.warning.assert_not_called()
+
+    def test_privateuse1_warns_when_backend_has_no_device_interface(self):
+        # Backend renamed itself but never registered a DeviceInterface:
+        # get_interface_for_device() raises NotImplementedError, and we
+        # conservatively warn since we can't ask the backend directly.
+        fake_log, fake_get_interface = self._run_with_missing_triton(
+            "npu", is_triton_capable=None
+        )
+        fake_get_interface.assert_called_once_with("npu")
+        fake_log.warning.assert_called_once_with(
+            "triton not found; flop counting will not work for triton kernels"
+        )
+
+    def test_no_privateuse1_backend_no_warning(self):
+        # "privateuseone" is the sentinel for "no PrivateUse1 backend
+        # registered" -- must not even consult a DeviceInterface.
+        fake_log, fake_get_interface = self._run_with_missing_triton(
+            "privateuseone", is_triton_capable=True
+        )
+        fake_get_interface.assert_not_called()
+        fake_log.warning.assert_not_called()
 
     def test_custom_op(self):
         from torch.utils.flop_counter import FlopCounterMode, register_flop_formula

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -109,12 +109,40 @@ log = logging.getLogger(__name__)
 try:
     from triton.runtime.jit import JITFunction as _JITFunction
 except ImportError:
-    _has_privateuse1_backend = torch._C._get_privateuse1_backend_name() != "privateuseone"
-    if _has_privateuse1_backend or any(
-        getattr(torch.version, attr, None) is not None for attr in ["cuda", "hip", "xpu"]
-    ):
+    if any(getattr(torch.version, attr, None) is not None for attr in ["cuda", "hip", "xpu"]):
         log.warning("triton not found; flop counting will not work for triton kernels")
     _JITFunction = NoneType
+
+
+def _warn_if_privateuse1_missing_triton() -> None:
+    """Warn (once) if a registered PrivateUse1 backend needs triton for its
+    Inductor codegen but triton isn't importable.
+
+    This is deliberately deferred to first ``FlopCounterMode`` use rather than
+    checked at module import time: a PrivateUse1 backend (e.g. ``torch_npu``)
+    is often registered by an ``import`` that happens after this module is
+    first loaded (directly or transitively, e.g. via
+    ``torch/_inductor/fx_utils.py``), so an import-time check can permanently
+    miss it.
+    """
+    from torch._logging import warning_once
+
+    backend_name = torch._C._get_privateuse1_backend_name()
+    if backend_name == "privateuseone":
+        return
+
+    from torch._dynamo.device_interface import get_interface_for_device
+
+    try:
+        triton_capable = get_interface_for_device(backend_name).is_triton_capable()
+    except NotImplementedError:
+        # Backend renamed itself but never registered a DeviceInterface: we
+        # can't ask it, so warn conservatively (a false positive here is a
+        # harmless log line; a false negative silently breaks flop counting).
+        triton_capable = True
+
+    if triton_capable:
+        warning_once(log, "triton not found; flop counting will not work for triton kernels")
 
 
 aten = torch.ops.aten
@@ -921,6 +949,8 @@ class FlopCounterMode:
             display: bool = True,
             custom_mapping: dict[Any, Any] | None = None) -> None:
         super().__init__()
+        if _JITFunction is NoneType:
+            _warn_if_privateuse1_missing_triton()
         self.flop_counts: dict[str, dict[Any, int]] = defaultdict(lambda: defaultdict(int))
         self.depth = depth
         self.display = display

--- a/torch/utils/flop_counter.py
+++ b/torch/utils/flop_counter.py
@@ -109,7 +109,10 @@ log = logging.getLogger(__name__)
 try:
     from triton.runtime.jit import JITFunction as _JITFunction
 except ImportError:
-    if any(getattr(torch.version, attr, None) is not None for attr in ["cuda", "hip", "xpu"]):
+    _has_privateuse1_backend = torch._C._get_privateuse1_backend_name() != "privateuseone"
+    if _has_privateuse1_backend or any(
+        getattr(torch.version, attr, None) is not None for attr in ["cuda", "hip", "xpu"]
+    ):
         log.warning("triton not found; flop counting will not work for triton kernels")
     _JITFunction = NoneType
 


### PR DESCRIPTION
## Summary

`flop_counter.py`'s missing-triton warning only checked
`torch.version.cuda`/`hip`/`xpu` to decide whether to warn that flop
counting won't work for triton kernels. A PrivateUse1-registered
backend that also relies on triton for its Inductor codegen
would silently get no warning, since it isn't in that literal list and
PrivateUse1 backends don't set any of those `torch.version` attributes.

An earlier version of this PR added a PrivateUse1 check at module
import time, inside the `except ImportError:` block. That's broken for
the case it targets: a PrivateUse1 backend like `torch_npu` is
typically registered by its own `import torch_npu`, which can happen
*after* something else already imported `torch.utils.flop_counter`
(e.g. `torch/_inductor/fx_utils.py` imports it at its own import
time). Since a module's top-level code only ever runs once, that first
snapshot of the backend name is permanent for the process, confirmed
on NPU hardware with `TORCH_DEVICE_BACKEND_AUTOLOAD=0`, forcing this
exact ordering: the old check never warned even after the backend
registered moments later.

This version instead defers the check to first `FlopCounterMode`
construction (gated on triton actually being missing), wrapped in
`torch._logging.warning_once` so it re-evaluates the current backend
state each time rather than trusting a stale import-time snapshot, but
still only logs once per process. The existing
`torch.version.{cuda,hip,xpu}` branch is untouched.

Rather than warning unconditionally for any registered PrivateUse1
backend, it asks the backend directly via
`torch._dynamo.device_interface.get_interface_for_device(name).is_triton_capable()`
, an existing generic, backend-overridable capability query (a backend
registers its own `DeviceInterface` and can answer this itself). This
import is local to the deferred call site, so plain `import
torch.utils.flop_counter` still doesn't pull in `torch._dynamo`. If the
backend renamed itself but never registered a `DeviceInterface`,
`get_interface_for_device()` raises `NotImplementedError`, treated as
"warn" — the same conservative default as before for the
genuinely-unknown case.

`is_triton_capable()` is deliberately not used for the existing
CUDA/hip/xpu branch: for CUDA it resolves to a runtime device probe
(`Worker.get_device_properties(device).major >= 7`) that raises
`RuntimeError` with no GPU visible and leaves
`torch.cuda.is_initialized()` true afterward, unlike the current cheap
build-property check.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Added 4 cases to `test/test_flop_counter.py` covering
`_warn_if_privateuse1_missing_triton()`'s branches (mocking
`_get_privateuse1_backend_name()` and `get_interface_for_device()`):
registered + capable (warns), registered + not capable (silent),
registered with no `DeviceInterface` (warns), no PrivateUse1 backend
(silent, `get_interface_for_device()` never called):

    python test/test_flop_counter.py -k privateuse1 -v

Also manually verified on NPU hardware with
`TORCH_DEVICE_BACKEND_AUTOLOAD=0`: constructing `FlopCounterMode()`
after `import torch_npu` now warns regardless of whether
`flop_counter` or `torch_npu` was imported first, and a construction
before `torch_npu` is imported correctly stays silent.

Ran `lintrunner -a` on both changed files — no issues.