### PR TITLE
Make functorch benchmark utils device-agnostic

### DIFF
--- a/torch/_functorch/benchmark_utils.py
+++ b/torch/_functorch/benchmark_utils.py
@@ -46,7 +46,8 @@ def dump_chrome_trace(
     """
 
     if devices is None:
-        devices = ["cuda"]
+        accelerator = torch.accelerator.current_accelerator(check_available=True)
+        devices = [accelerator.type] if accelerator is not None else ["cpu"]
 
     global synchronize
     if devices != ["cpu"] and torch.accelerator.is_available():
@@ -234,9 +235,8 @@ def benchmark_utilization(
         input_,
         chrome_trace_file_name,
         optimize_ctx,
-        [ProfilerActivity.CUDA],
+        list(torch.profiler.supported_activities()),
         num_runs=num_runs,
-        devices=["cuda"],
     )
     utilization, mm_conv_utilization = compute_utilization(
         chrome_trace_file_name, total_length

--- a/torch/_functorch/benchmark_utils.py
+++ b/torch/_functorch/benchmark_utils.py
@@ -91,10 +91,10 @@ def get_chrome_trace_events(filename: str) -> list[dict[str, Any]]:
 
 
 def is_gpu_compute_event(event: dict[str, Any]) -> bool:
-    global gpu_pids
+    global accelerator_pids
     return (
         "pid" in event
-        and event["pid"] in gpu_pids
+        and event["pid"] in accelerator_pids
         and "ph" in event
         and event["ph"] == "X"
     )
@@ -141,12 +141,12 @@ def get_sorted_gpu_mm_conv_events(events: list[dict[str, Any]]) -> list[dict[str
     return sorted_events
 
 
-gpu_pids: list[Any] = []
+accelerator_pids: list[Any] = []
 
 
 def compute_utilization(filename: str, total_length: float) -> tuple[float, float]:
     """
-    Process the chrome traces outputs by the pytorch profiler to compute GPU Utilization
+    Process the chrome traces outputs by the pytorch profiler to compute accelerator utilization
     and percent of times spent on matmul and convolution
 
     Args:
@@ -155,18 +155,20 @@ def compute_utilization(filename: str, total_length: float) -> tuple[float, floa
         total_length(float): total length of the process without profiler in second
 
     Return:
-        tuple: (GPU Utilization, percent of time spent on matmul and convolution)
+        tuple: (accelerator utilization, percent of time spent on matmul and convolution)
     """
     events = get_chrome_trace_events(filename)
 
-    # get pids of GPU events
-    global gpu_pids
-    gpu_pids = []
+    # get pids of accelerator events: every process_labels event other than the
+    # "CPU" host process is a device process, regardless of vendor label (e.g.
+    # "GPU {n}" for CUDA/ROCm/XPU, "NPU {n}" for torch_npu)
+    global accelerator_pids
+    accelerator_pids = []
     for event in events:
         if "name" not in event:
             continue
-        if event["name"] == "process_labels" and "GPU" in event["args"]["labels"]:
-            gpu_pids.append(event["pid"])
+        if event["name"] == "process_labels" and "CPU" not in event["args"]["labels"]:
+            accelerator_pids.append(event["pid"])
 
     total_length = total_length * 1e6
     sorted_gpu_events = get_sorted_gpu_events(events)
@@ -187,7 +189,7 @@ def benchmark_utilization(
     num_runs: int = 1,
 ) -> tuple[float, float]:
     """
-    Benchmark the GPU Utilization and percent of time spent on matmul and convolution operations of
+    Benchmark the accelerator utilization and percent of time spent on matmul and convolution operations of
     running f(input_, **kwargs_for_f) with [optimize_ctx] [num_runs] times.
     It will produce a chrome trace file in trace_folder/trace_file_name.json
 
@@ -218,7 +220,7 @@ def benchmark_utilization(
         num_runs: number of times to run f, excluding the warm-up runs, default to 1.
 
     Return:
-        tuple: (GPU Utilization, percent of time spent on matmul and convolution)
+        tuple: (accelerator utilization, percent of time spent on matmul and convolution)
 
     """
     isExist = os.path.exists(trace_folder)


### PR DESCRIPTION
## Summary

Removed CUDA-only assumptions from `dump_chrome_trace()` and
`benchmark_utilization()` in `torch/_functorch/benchmark_utils.py`.

`dump_chrome_trace()` now derives its default device from
`torch.accelerator.current_accelerator(check_available=True)`, falling
back to CPU when no accelerator is available. This allows accelerator
synchronization to work correctly for XPU, MTIA, HPU, PrivateUse1/NPU,
and other supported backends, instead of hardcoding `devices=["cuda"]`.

`benchmark_utilization()` now uses
`torch.profiler.supported_activities()` instead of hardcoding
`ProfilerActivity.CUDA`, and relies on `dump_chrome_trace()` to
determine the active device rather than passing `devices=["cuda"]`
itself.

MPS remains unable to report GPU utilization because
`torch.profiler.supported_activities()` exposes only CPU activity on
MPS-only systems — this is a pre-existing limitation, not a
regression introduced here (verified: still returns `0.0` utilization
on MPS after this change, same as before).

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Ran both functions end-to-end:

    python -c "
    import torch, contextlib
    from torch._functorch.benchmark_utils import dump_chrome_trace, benchmark_utilization

    def f(a):
        return a.sum()

    a = torch.rand(1000)
    dump_chrome_trace(f, a, '/tmp/tmp_trace.json', contextlib.nullcontext(),
                       list(torch.profiler.supported_activities()), num_runs=2)

    a_mps = torch.rand(1000, device='mps')
    benchmark_utilization(f, a_mps, '/tmp/trace_dir', num_runs=2)
    "

Both ran without error on CPU and MPS.
Ran `lintrunner -a` on `torch/_functorch/benchmark_utils.py` — no
issues.
