### PR TITLE
Fix pytree treespec serialization round-trip for tuple mapping keys

### DIFF
--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1095,6 +1095,35 @@ if "optree" in sys.modules:
         serialized_spec = python_pytree.treespec_dumps(spec)
         self.assertIsInstance(serialized_spec, str)
 
+    def test_pytree_serialize_tuple_mapping_key(self):
+        # A tuple mapping key is a valid pytree, but JSON has no tuple type, so
+        # naive serialization turns the key into a list, which is unhashable and
+        # breaks the round-trip in tree_unflatten. See #188648.
+        for tree in [
+            {(1, 2): 0},
+            OrderedDict({(1, 2): 0, ("a", "b"): 1}),
+            {(1, (2, 3)): 0},  # nested tuple key
+            {"scalar": 0, (1, 2): 1},  # mix of hashable and tuple keys
+            defaultdict(list, {(1, 2): [0]}),
+        ]:
+            leaves, spec = python_pytree.tree_flatten(tree)
+            roundtrip_spec = python_pytree.treespec_loads(
+                python_pytree.treespec_dumps(spec)
+            )
+            self.assertEqual(spec, roundtrip_spec)
+            # The reconstructed spec must still unflatten (tuple keys stay hashable).
+            self.assertEqual(
+                python_pytree.tree_unflatten(leaves, roundtrip_spec), tree
+            )
+
+    def test_pytree_serialize_tuple_key_is_backward_compatible(self):
+        # Specs that contain no tuple keys must serialize byte-for-byte as before,
+        # so previously serialized specs keep loading.
+        spec = python_pytree.tree_structure({"a": 0, "b": {"c": 1}})
+        serialized_spec = python_pytree.treespec_dumps(spec)
+        self.assertNotIn("__tuple__", serialized_spec)
+        self.assertEqual(spec, python_pytree.treespec_loads(serialized_spec))
+
     def test_pytree_serialize_namedtuple(self):
         Point1 = namedtuple("Point1", ["x", "y"])
         python_pytree._register_namedtuple(

--- a/test/test_pytree.py
+++ b/test/test_pytree.py
@@ -1124,6 +1124,44 @@ if "optree" in sys.modules:
         self.assertNotIn("__tuple__", serialized_spec)
         self.assertEqual(spec, python_pytree.treespec_loads(serialized_spec))
 
+    def test_pytree_serialize_custom_context_with_tuple_marker(self):
+        # The tuple escaping used to fix tuple mapping keys is scoped to the
+        # built-in mapping contexts (dict / OrderedDict / defaultdict) only. A
+        # custom node that uses the generic JSON context path (no custom
+        # to/from_dumpable_context) whose serialized context legitimately IS the
+        # tuple-escape marker dict must round-trip completely UNCHANGED -- the
+        # dict must stay a dict and never be turned into the tuple (1, 2).
+        class DummyType:
+            def __init__(self, x, y):
+                self.x = x
+                self.y = y
+
+        marker_context = {"__tuple__": [1, 2]}
+        python_pytree.register_pytree_node(
+            DummyType,
+            lambda dummy: ([dummy.x, dummy.y], dict(marker_context)),
+            lambda xs, context: DummyType(*xs),
+            serialized_type_name=(
+                "test_pytree.test_pytree_serialize_custom_context_"
+                "with_tuple_marker.DummyType"
+            ),
+        )
+        try:
+            spec = python_pytree.tree_structure(DummyType(1, 2))
+            # Sanity check: the context really is the marker dict.
+            self.assertEqual(spec._context, marker_context)
+
+            roundtrip_spec = python_pytree.treespec_loads(
+                python_pytree.treespec_dumps(spec)
+            )
+            # The generic/custom context path must not apply tuple unescaping, so
+            # the context stays a dict and is not corrupted into a tuple.
+            self.assertIsInstance(roundtrip_spec._context, dict)
+            self.assertEqual(roundtrip_spec._context, marker_context)
+            self.assertEqual(spec, roundtrip_spec)
+        finally:
+            python_pytree._deregister_pytree_node(DummyType)
+
     def test_pytree_serialize_namedtuple(self):
         Point1 = namedtuple("Point1", ["x", "y"])
         python_pytree._register_namedtuple(

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -838,6 +838,56 @@ def _dict_unflatten(values: Iterable[T], context: Context) -> dict[Any, T]:
     return dict(zip(context, values, strict=True))
 
 
+# JSON has no tuple type, so a tuple that appears in a built-in mapping context --
+# the list of dict keys, e.g. the ``(1, 2)`` in ``{(1, 2): ...}`` -- would be
+# written out as an array and read back as a ``list``. A ``list`` is unhashable
+# and cannot be used as a mapping key, so ``tree_unflatten`` would then fail to
+# reconstruct an otherwise valid pytree. We escape tuples with an explicit marker
+# on the way out and restore them on the way in.
+#
+# This escaping is applied ONLY to the built-in mapping contexts (``dict``,
+# ``OrderedDict``, ``defaultdict``) whose context is the list of keys -- never to
+# the generic JSON path used by arbitrary registered nodes. A custom node whose
+# default-serialized context legitimately contains ``{"__tuple__": [...]}`` is
+# therefore passed through untouched. Contexts without tuples serialize
+# byte-for-byte as before, so previously serialized specs are unaffected.
+_TUPLE_MARKER = "__tuple__"
+
+
+def _json_escape_tuples(obj: Any) -> Any:
+    if isinstance(obj, tuple):
+        return {_TUPLE_MARKER: [_json_escape_tuples(item) for item in obj]}
+    if isinstance(obj, list):
+        return [_json_escape_tuples(item) for item in obj]
+    if isinstance(obj, dict):
+        return {key: _json_escape_tuples(value) for key, value in obj.items()}
+    return obj
+
+
+def _json_unescape_tuples(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        if len(obj) == 1 and _TUPLE_MARKER in obj:
+            return tuple(_json_unescape_tuples(item) for item in obj[_TUPLE_MARKER])
+        return {key: _json_unescape_tuples(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_json_unescape_tuples(item) for item in obj]
+    return obj
+
+
+def _mapping_context_serialize(context: Context) -> DumpableContext:
+    # ``dict`` / ``OrderedDict`` have no custom dumpable-context of their own, so
+    # this mirrors the generic JSON path (json string, EnumEncoder) exactly and
+    # only adds tuple escaping. Non-tuple contexts serialize byte-for-byte as
+    # before.
+    return json.dumps(_json_escape_tuples(context), cls=EnumEncoder)
+
+
+def _mapping_context_deserialize(dumpable_context: DumpableContext) -> Context:
+    return _json_unescape_tuples(
+        json.loads(dumpable_context, object_hook=enum_object_hook)
+    )
+
+
 def _namedtuple_flatten(d: NamedTuple) -> tuple[list[Any], Context]:
     return list(d), type(d)
 
@@ -1010,6 +1060,8 @@ _private_register_pytree_node(
     _dict_flatten,
     _dict_unflatten,
     serialized_type_name="builtins.dict",
+    to_dumpable_context=_mapping_context_serialize,
+    from_dumpable_context=_mapping_context_deserialize,
     flatten_with_keys_fn=_dict_flatten_with_keys,
 )
 _private_register_pytree_node(
@@ -1026,6 +1078,8 @@ _private_register_pytree_node(
     _ordereddict_flatten,
     _ordereddict_unflatten,
     serialized_type_name="collections.OrderedDict",
+    to_dumpable_context=_mapping_context_serialize,
+    from_dumpable_context=_mapping_context_deserialize,
     flatten_with_keys_fn=_ordereddict_flatten_with_keys,
 )
 _private_register_pytree_node(
@@ -1982,36 +2036,6 @@ class _ProtocolFn(NamedTuple):
 _SUPPORTED_PROTOCOLS: dict[int, _ProtocolFn] = {}
 
 
-# JSON has no tuple type, so a tuple that appears in a serialized context -- most
-# commonly a tuple mapping key such as ``{(1, 2): ...}`` -- would be written out
-# as an array and read back as a ``list``. A ``list`` is unhashable and cannot be
-# used as a mapping key, so ``tree_unflatten`` would then fail to reconstruct an
-# otherwise valid pytree. We escape tuples with an explicit marker on the way out
-# and restore them on the way in. Contexts without tuples serialize byte-for-byte
-# as before, so previously serialized specs are unaffected.
-_TUPLE_MARKER = "__tuple__"
-
-
-def _json_escape_tuples(obj: Any) -> Any:
-    if isinstance(obj, tuple):
-        return {_TUPLE_MARKER: [_json_escape_tuples(item) for item in obj]}
-    if isinstance(obj, list):
-        return [_json_escape_tuples(item) for item in obj]
-    if isinstance(obj, dict):
-        return {key: _json_escape_tuples(value) for key, value in obj.items()}
-    return obj
-
-
-def _json_unescape_tuples(obj: Any) -> Any:
-    if isinstance(obj, dict):
-        if len(obj) == 1 and _TUPLE_MARKER in obj:
-            return tuple(_json_unescape_tuples(item) for item in obj[_TUPLE_MARKER])
-        return {key: _json_unescape_tuples(value) for key, value in obj.items()}
-    if isinstance(obj, list):
-        return [_json_unescape_tuples(item) for item in obj]
-    return obj
-
-
 def _treespec_to_json(treespec: TreeSpec) -> _TreeSpecSchema:
     if treespec.is_leaf():
         return _TreeSpecSchema(None, None, [])
@@ -2033,9 +2057,7 @@ def _treespec_to_json(treespec: TreeSpec) -> _TreeSpecSchema:
 
     if serialize_node_def.to_dumpable_context is None:
         try:
-            serialized_context = json.dumps(
-                _json_escape_tuples(treespec._context), cls=EnumEncoder
-            )
+            serialized_context = json.dumps(treespec._context, cls=EnumEncoder)
         except TypeError as e:
             raise TypeError(
                 "Unable to serialize context. "
@@ -2081,9 +2103,7 @@ def _json_to_treespec(json_schema: DumpableContext) -> TreeSpec:
 
     if serialize_node_def.from_dumpable_context is None:
         try:
-            context = _json_unescape_tuples(
-                json.loads(json_schema["context"], object_hook=enum_object_hook)
-            )
+            context = json.loads(json_schema["context"], object_hook=enum_object_hook)
         except TypeError as ex:
             raise TypeError(
                 "Unable to deserialize context. "

--- a/torch/utils/_pytree.py
+++ b/torch/utils/_pytree.py
@@ -943,7 +943,7 @@ def _defaultdict_serialize(context: Context) -> DumpableContext:
     json_defaultdict = {
         "default_factory_module": default_factory.__module__,
         "default_factory_name": default_factory.__qualname__,
-        "dict_context": dict_context,
+        "dict_context": _json_escape_tuples(dict_context),
     }
     return json_defaultdict
 
@@ -971,7 +971,7 @@ def _defaultdict_deserialize(dumpable_context: DumpableContext) -> Context:
     module = importlib.import_module(default_factory_module)
     default_factory = getattr(module, default_factory_name)
 
-    dict_context = dumpable_context["dict_context"]
+    dict_context = _json_unescape_tuples(dumpable_context["dict_context"])
     return [default_factory, dict_context]
 
 
@@ -1982,6 +1982,36 @@ class _ProtocolFn(NamedTuple):
 _SUPPORTED_PROTOCOLS: dict[int, _ProtocolFn] = {}
 
 
+# JSON has no tuple type, so a tuple that appears in a serialized context -- most
+# commonly a tuple mapping key such as ``{(1, 2): ...}`` -- would be written out
+# as an array and read back as a ``list``. A ``list`` is unhashable and cannot be
+# used as a mapping key, so ``tree_unflatten`` would then fail to reconstruct an
+# otherwise valid pytree. We escape tuples with an explicit marker on the way out
+# and restore them on the way in. Contexts without tuples serialize byte-for-byte
+# as before, so previously serialized specs are unaffected.
+_TUPLE_MARKER = "__tuple__"
+
+
+def _json_escape_tuples(obj: Any) -> Any:
+    if isinstance(obj, tuple):
+        return {_TUPLE_MARKER: [_json_escape_tuples(item) for item in obj]}
+    if isinstance(obj, list):
+        return [_json_escape_tuples(item) for item in obj]
+    if isinstance(obj, dict):
+        return {key: _json_escape_tuples(value) for key, value in obj.items()}
+    return obj
+
+
+def _json_unescape_tuples(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        if len(obj) == 1 and _TUPLE_MARKER in obj:
+            return tuple(_json_unescape_tuples(item) for item in obj[_TUPLE_MARKER])
+        return {key: _json_unescape_tuples(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_json_unescape_tuples(item) for item in obj]
+    return obj
+
+
 def _treespec_to_json(treespec: TreeSpec) -> _TreeSpecSchema:
     if treespec.is_leaf():
         return _TreeSpecSchema(None, None, [])
@@ -2003,7 +2033,9 @@ def _treespec_to_json(treespec: TreeSpec) -> _TreeSpecSchema:
 
     if serialize_node_def.to_dumpable_context is None:
         try:
-            serialized_context = json.dumps(treespec._context, cls=EnumEncoder)
+            serialized_context = json.dumps(
+                _json_escape_tuples(treespec._context), cls=EnumEncoder
+            )
         except TypeError as e:
             raise TypeError(
                 "Unable to serialize context. "
@@ -2049,7 +2081,9 @@ def _json_to_treespec(json_schema: DumpableContext) -> TreeSpec:
 
     if serialize_node_def.from_dumpable_context is None:
         try:
-            context = json.loads(json_schema["context"], object_hook=enum_object_hook)
+            context = _json_unescape_tuples(
+                json.loads(json_schema["context"], object_hook=enum_object_hook)
+            )
         except TypeError as ex:
             raise TypeError(
                 "Unable to deserialize context. "


### PR DESCRIPTION
Fixes #188648

## Problem
`treespec_dumps` serializes a mapping context (the list of dict keys) via JSON, which has no tuple type. A tuple key such as `(1, 2)` is written as an array and read back by `treespec_loads` as a Python `list`. Lists are unhashable, so the reconstructed spec then fails in `tree_unflatten` with `TypeError: unhashable type: 'list'`, and a valid pytree cannot survive a dump/load round-trip. `dict`, `OrderedDict`, and `defaultdict` are all affected, including nested tuple keys.

```python
import torch.utils._pytree as pytree
tree = {(1, 2): 0}
leaves, spec = pytree.tree_flatten(tree)
spec2 = pytree.treespec_loads(pytree.treespec_dumps(spec))
pytree.tree_unflatten(leaves, spec2)  # TypeError: unhashable type: 'list'
```

## Fix
Escape tuples with an explicit `{"__tuple__": [...]}` marker when serializing a context and restore them on load, mirroring the existing enum-marker mechanism. The transform is a structural no-op when a context contains no tuples, so contexts without tuples serialize byte-for-byte as before and previously serialized specs keep loading — only keys that previously could not round-trip at all (they crashed) are affected.

## Test
`test/test_pytree.py::TestPythonPytree`:
- `test_pytree_serialize_tuple_mapping_key` (dict / OrderedDict / nested tuple / mixed / defaultdict) — fails without this change, passes with it.
- `test_pytree_serialize_tuple_key_is_backward_compatible` — guards that tuple-free specs are unchanged.

## BC
Not BC-breaking. Serialized output for tuple-free contexts is byte-identical to before, and old serialized strings continue to load.