### PR TITLE
Extend accelerator graph-capture health check beyond CUDA/XPU

### DIFF
--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -481,7 +481,7 @@ class Optimizer:
         # Determine available accelerator device
         accelerator = torch.accelerator.current_accelerator(check_available=True)
 
-        if accelerator and accelerator.type in {"cuda", "xpu"}:
+        if accelerator is not None:
             capturing = torch.accelerator.current_stream().is_capturing()
 
             if capturing and not all(


### PR DESCRIPTION
## Summary

`_accelerator_graph_capture_health_check()` gated its whole body
behind `if accelerator and accelerator.type in {"cuda", "xpu"}:`, but
everything inside that block is already backend-agnostic:
`torch.accelerator.current_stream().is_capturing()` and
`accelerator.type.upper()` in the warning/error messages both work
for any accelerator already.

That gate traces back to #180453, which modernized this function's
internals but preserved the previous code's explicit
`torch.cuda.is_available()`/`torch.xpu.is_available()` restriction as
a faithful port rather than a deliberate decision tied to
`is_capturing()`'s semantics.

`c10::Stream::is_capturing()` calls
`DeviceGuardImplInterface::isStreamCapturing()`, whose base
implementation is `return false;` — only `CUDAGuardImpl` and
`XPUGuardImpl` override it with real logic
(`c10/core/impl/DeviceGuardImplInterface.h`). Every other backend
(MPS, MTIA, HPU, PrivateUse1) already safely returns `False` through
the same call, so restricting the check to `{"cuda", "xpu"}` served
no functional purpose — it just meant this health check (and its
`capturable=True`/`False` warnings) silently never ran on any other
backend.

Replaced the gate with `if accelerator is not None:`, which behaves
identically for CUDA/XPU and correctly extends the same already-safe
check to every other accelerator.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Verified using:

    python -c "
    import torch
    import torch.optim as optim
    p = torch.nn.Parameter(torch.randn(3, 3))
    opt = optim.Adam([p], capturable=False)
    opt._accelerator_graph_capture_health_check()
    print('ok')
    "

`is_capturing()` correctly returns `False` on MPS and the health check
runs without error. Ran `lintrunner -a` on `torch/optim/optimizer.py` — no
issues.
