### PR TITLE
Fix autograd Type to capture device index for any accelerator

### DIFF
--- a/torch/autograd/_functions/tensor.py
+++ b/torch/autograd/_functions/tensor.py
@@ -18,7 +18,7 @@ class Type(Function):
     # pyrefly: ignore [bad-override]
     def forward(ctx, i, dest_type):
         ctx.input_type = type(i)
-        ctx.input_device = -1 if not i.is_cuda else i.get_device()
+        ctx.input_device = -1 if i.device.index is None else i.device.index
         return i.type(dest_type)
 
     @staticmethod


### PR DESCRIPTION
## Summary

`Type.forward()` only captured a device index when the input tensor's
`is_cuda` was `True`, forcing `ctx.input_device = -1` for every other
backend.

This was a partial-migration gap, not a deliberate design choice: the
`is_cuda` check was introduced in 2017 (462f95ed6dde), when CUDA was
the only accelerator PyTorch supported. `backward()` was later
rewritten in 2025 (ad81eeb7c7c9 / #148880) to restore the device index
generically via `torch.accelerator.device_index()`, which uses the
accelerator-hooks dispatch shared by CUDA, XPU, MPS, and PrivateUse1.
`forward()` was never updated to match, so it continued to discard
valid device information for every non-CUDA accelerator.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Verified `forward()`'s device-index capture directly (isolated from
the full autograd engine) on both CPU and MPS:

    python -c "
    import warnings, torch
    from torch.autograd._functions.tensor import Type

    class Ctx: pass

    with warnings.catch_warnings():
        warnings.simplefilter('ignore')
        ctx = Ctx()
        Type.forward.__wrapped__(ctx, torch.randn(3), torch.float64)
        print('cpu:', ctx.input_device)  # -1

        ctx2 = Ctx()
        x_mps = torch.randn(3, device='mps')
        Type.forward.__wrapped__(ctx2, x_mps, torch.float32)
        print('mps:', ctx2.input_device)  # 0, matches x_mps.device.index
    "

Also checked whether a pre-existing, unrelated failure I hit while
testing the full `Type.apply(...).backward()` path on MPS
(`RuntimeError: ... expected device mps:0 but got cpu`) was caused by
this change — confirmed via a side-by-side test against the exact
pre-fix code checked out from `main` that it fails identically either
way, so it's out of scope for this PR.

Ran `lintrunner -a` on `torch/autograd/_functions/tensor.py` — no
issues.