### PR TITLE
[inductor] Fix graph ordering and broadcast values in partitioned scatter

### DIFF
--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -341,6 +341,92 @@ class TestPartitionedScatterOpt(TestCase):
 
         self._check_accuracy(f, (out, idx, vals), atol=1.0, rtol=1e-2)
 
+    def test_unsorted_graph_from_earlier_pass(self):
+        """post_grad only sorts the graph after this pass runs, so an earlier pass
+        can leave a node positioned after one of its users. Both stages of this pass
+        read the graph in list order, so it has to sort before it looks."""
+        torch.manual_seed(42)
+        N, n, D = 8192, 8, 4
+
+        def desort(graph):
+            """Stand in for an earlier post_grad pass: clone a node just before its
+            last user and redirect every use to the clone, leaving the first user
+            reading a definition that now comes later in the list."""
+            nodes = list(graph.nodes)
+            position = {node: i for i, node in enumerate(nodes)}
+            for node in nodes:
+                if node.op != "call_function" or "val" not in node.meta:
+                    continue
+                users = sorted(
+                    (u for u in node.users if u.op == "call_function"),
+                    key=position.__getitem__,
+                )
+                if len(users) < 2 or position[users[-1]] - position[users[0]] < 2:
+                    continue
+                with graph.inserting_before(users[-1]):
+                    clone = graph.call_function(node.target, node.args, node.kwargs)
+                clone.meta.update(node.meta)
+                node.replace_all_uses_with(
+                    clone, delete_user_cb=lambda u: u is not clone
+                )
+                return
+
+        def f(out, idx, vals, x):
+            # y has two users far enough apart for desort to have something to move.
+            y = x.permute(1, 0)
+            return (
+                out.index_put([idx], vals, accumulate=True),
+                (y * 2).sum(),
+                torch.relu(y).sum(),
+            )
+
+        out = torch.zeros(n, D, dtype=torch.float32)
+        idx = torch.randint(0, 4, (N,), dtype=torch.int64)
+        vals = torch.randn(N, D, dtype=torch.float32)
+        x = torch.randn(16, 32, dtype=torch.float32)
+
+        with config.patch(
+            post_grad_custom_pre_pass=desort,
+            fx_graph_cache=False,
+            fx_graph_remote_cache=False,
+        ):
+            self._check_accuracy(f, (out, idx, vals, x), atol=1.0, rtol=1e-2)
+
+        self.assertGreater(counters["inductor"]["partitioned_scatter_applied"], 0)
+
+    def test_broadcast_values_multidim_index(self):
+        """A multi-dimensional index makes the replacement flatten values against
+        the index shape. index_put only requires values to broadcast, so operands
+        that are merely broadcastable have to be skipped, not reshaped."""
+        torch.manual_seed(42)
+        rows, D, B, T = 512, 4, 16, 512
+
+        def f(out, idx, vals):
+            return out.index_put([idx], vals, accumulate=True)
+
+        out = torch.zeros(rows, D, dtype=torch.float32)
+        idx = torch.randint(0, 4, (B, T), dtype=torch.int64)
+
+        # Fully materialized values: the flatten is valid, so the pass applies.
+        self._check_accuracy(
+            f, (out, idx, torch.randn(B, T, D, dtype=torch.float32)), atol=1.0
+        )
+        self.assertGreater(counters["inductor"]["partitioned_scatter_applied"], 0)
+
+        for vals in (
+            torch.randn(B, 1, D, dtype=torch.float32),
+            torch.randn(D, dtype=torch.float32),
+        ):
+            counters.clear()
+            torch._dynamo.reset()
+            self._check_accuracy(f, (out, idx, vals), atol=1.0)
+            self.assertEqual(counters["inductor"]["partitioned_scatter_applied"], 0)
+            self.assertGreater(
+                counters["inductor"]["partitioned_scatter_skipped_broadcast_operand"],
+                0,
+                "broadcast values must be rejected by a gate, not reshaped",
+            )
+
     def test_skip_accumulate_false(self):
         """index_put with accumulate=False doesn't match the registered patterns."""
         n = 256

--- a/torch/_inductor/fx_passes/reduced_atomic_contention.py
+++ b/torch/_inductor/fx_passes/reduced_atomic_contention.py
@@ -26,6 +26,7 @@ from torch._inductor.pattern_matcher import (
     Match,
     PatternMatcherPass,
     register_graph_pattern,
+    stable_topological_sort,
 )
 from torch._logging import getArtifactLogger
 from torch.fx.experimental.symbolic_shapes import optimization_hint
@@ -153,6 +154,22 @@ def _evaluate_candidate(
     if scatter_dim >= len(input_meta["shape"]):
         _record_skip(ctx, "dim_out_of_bounds", node_name)
         return None
+
+    # A multi-dimensional index makes the replacement flatten values against the
+    # index shape. index_put only requires those to broadcast, and a broadcast
+    # operand has too few elements to reshape to the flattened length.
+    index_ndim = len(index_meta["shape"])
+    if index_ndim > 1:
+        values_node = output_node.args[2] if len(output_node.args) > 2 else None
+        values_meta = (
+            _get_tensor_meta(values_node) if isinstance(values_node, fx.Node) else None
+        )
+        if (
+            values_meta is None
+            or values_meta["shape"][:index_ndim] != index_meta["shape"]
+        ):
+            _record_skip(ctx, "broadcast_operand", node_name)
+            return None
 
     output_size = _resolve_numel(input_meta["numel"])
     index_size = _resolve_numel(index_meta["numel"])
@@ -634,6 +651,12 @@ def partitioned_scatter_optimization_pass(graph: fx.Graph) -> fx.Graph:
     if not ctx.candidates:
         _log_summary(ctx, 0)
         return graph
+
+    # post_grad only sorts the graph after this pass runs, so a node may still sit
+    # after one of its users here. build_memory_profile raises on the out-of-order
+    # node, and replace_by_example inserts at the match node, so an argument placed
+    # after it would leave the nodes we emit reading a later definition.
+    stable_topological_sort(graph)
 
     # Stage 2: build the memory profile and run the pattern matcher.
     ctx.memory = _build_scatter_memory_state(graph)


### PR DESCRIPTION
Two bugs in the partitioned scatter pass resolved

## 1. The pass assumed a topologically sorted graph
post_grad runs this pass at post_grad.py:256 but doesn't sort the graph until line 310, so an earlier pass can leave a node sitting after one of its users. This pass reads the graph in list order twice before that sort happens: build_memory_profile walks it to build the memory profile, and replace_by_example inserts new nodes at the match node.

Previously, when an out-of-order node was near a match, the nodes emitted by the replacement read a definition that came later in the list, and graph.lint() failed the compile:

RuntimeError: Argument X of Node X was used before it has been defined!
There was a quieter effect too. build_memory_profile raises on the out-of-order node, and that exception is caught and treated as "run without memory gating", so an unsorted graph silently dropped the memory budget even when the compile went on to succeed.

Now stable_topological_sort(graph) runs before both stages. It sits after the cheap pre-scan so graphs with no candidates don't pay for it, and it's a no-op on a graph that is already ordered.

## 2. Broadcast values with a multi-dimensional index

When the index has more than one dimension, the replacement flattens values against the index shape:

flat_values = values.reshape([num_operations] + list(values.shape[values_ndim:]))
But index_put only requires values to be broadcastable to the index shape, not equal to it, and a broadcast operand has too few elements for that reshape.

Previously, out.index_put([idx], vals, accumulate=True) with idx of shape [16, 512] and vals of shape [16, 1, 4] failed while tracing the replacement:

RuntimeError: shape '[8192, 4]' is invalid for input of size 64
Now _evaluate_candidate rejects these candidates under a new broadcast_operand skip reason, so the op compiles unchanged. Values fully materialized to the index shape are still optimized as before.

## Tests

Both added to TestPartitionedScatterOpt in test/inductor/test_scatter_optimization.py:

test_unsorted_graph_from_earlier_pass installs a post_grad_custom_pre_pass that clones a node just before its last user and redirects the uses, standing in for an earlier pass that leaves the graph unsorted. Without the fix it fails with the "used before it has been defined" error.

test_broadcast_values_multidim_index checks that [B, 1, D] and [D] values against a [B, T] index are skipped via the new counter, while a full [B, T, D] operand is still optimized. Without the fix it fails with the reshape error.
All 24 tests in the file pass.

Co-authored by Cursor


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben