### PR TITLE
[distributed][Refactor] Remove hardcoded _PYTORCH_MIN_ALLOCATE, introduce device-agnostic helper get_allocation_granularity()

### DIFF
--- a/test/distributed/_tools/test_mem_tracker.py
+++ b/test/distributed/_tools/test_mem_tracker.py
@@ -4,6 +4,7 @@ import unittest
 
 import torch
 import torch.nn as nn
+from torch.distributed._tools.common_utils import get_allocation_granularity
 from torch.distributed._tools.mem_tracker import MemTracker
 from torch.testing._internal.common_utils import (
     run_tests,
@@ -237,6 +238,53 @@ class TestMemTracker(TestCase):
             optim.zero_grad()
             # After zero_grad: Gradients are deallocated
             test_attribution_equivalence(mt, model, optim)
+
+    def test_tracker_charges_allocator_rounded_size(self):
+        """
+        Tests that the tracker charges the size the allocator actually consumed rather
+        than the raw byte count, on whatever backend the test runs on.
+        """
+        dev = (
+            torch.device(torch.accelerator.current_device_index())
+            if torch.accelerator.is_available()
+            else torch.device("cpu")
+        )
+        granularity = get_allocation_granularity(dev.type)
+        n_tensors, numel, dtype = 8, 100, torch.float32
+        # 400 bytes per tensor, deliberately not a multiple of any plausible
+        # granularity, so a missing round-up changes the expected total.
+        nbytes = numel * torch.empty(0, dtype=dtype).element_size()
+        expected = n_tensors * ((nbytes + granularity - 1) // granularity * granularity)
+        gc.collect(1)
+
+        def stat(key: str) -> int:
+            if not torch.accelerator.is_available():
+                return 0
+            return torch.accelerator.memory_stats().get(key, 0)
+
+        mem_tracker = MemTracker()
+        with mem_tracker as mt:
+            pre_tracked = mt.get_tracker_snapshot().get(dev, {}).get("Total", 0)
+            pre_requested = stat("requested_bytes.all.current")
+            pre_allocated = stat("allocated_bytes.all.current")
+            tensors = [  # noqa: F841
+                torch.empty(numel, dtype=dtype, device=dev) for _ in range(n_tensors)
+            ]
+            tracked = mt.get_tracker_snapshot()[dev]["Total"] - pre_tracked
+            requested = stat("requested_bytes.all.current") - pre_requested
+            consumed = stat("allocated_bytes.all.current") - pre_allocated
+
+        if consumed > 0 and requested == 0:
+            # The allocator rounds but never reports ``requested_bytes``, so the
+            # granularity cannot be measured and the tracker falls back to charging
+            # raw bytes. torch.mps is the in-tree example.
+            self.skipTest(f"torch.{dev.type} does not report requested_bytes")
+
+        self.assertEqual(tracked, expected)
+        # Cross-check against the allocator itself so the assertion above cannot pass
+        # merely because the tracker and the granularity probe agree with each other.
+        if consumed > 0:
+            self.assertEqual(tracked, consumed)
 
 
 if __name__ == "__main__":

--- a/test/distributed/_tools/test_sac_estimator.py
+++ b/test/distributed/_tools/test_sac_estimator.py
@@ -3,6 +3,7 @@ import unittest
 
 import torch
 from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.distributed._tools.common_utils import get_allocation_granularity
 from torch.distributed._tools.sac_estimator import SACEstimator
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import run_tests, TestCase
@@ -81,6 +82,46 @@ class TestSACEstimator(TestCase):
             self.assertEqual(sac_estimator.sac_mod_stats["Foo"].rand_ops, [])
             self.assertEqual(
                 sac_estimator.sac_mod_stats["Foo"].inplace_ops, [(2, 1), (3, 1), (4, 1)]
+            )
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_sac_estimation_charges_rounded_size(self):
+        """
+        Checks that the estimator charges the size the allocator rounds up to. Under
+        ``FakeTensorMode`` the storages live on meta, so this also guards against
+        reading the granularity off the storage instead of the tensor.
+        """
+
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.fc1 = torch.nn.Linear(5, 10)
+                self.fc2 = torch.nn.Linear(10, 10)
+
+            def forward(self, x):
+                return self.fc2(torch.relu(self.fc1(x)))
+
+        dev = torch.cuda.current_device()
+        granularity = get_allocation_granularity(torch.device(dev).type)
+        with FakeTensorMode():
+            with torch.device(dev):
+                model = Foo()
+            # (10, 10) float32 activations are 400 bytes, deliberately not a multiple
+            # of any plausible granularity.
+            x = torch.rand((10, 5), device=dev)
+
+            sac_estimator = SACEstimator()
+            with sac_estimator(estimate_mode_type="operator-level-benchmark"):
+                loss = model(x).sum()
+            loss.backward()
+
+            # View-like ops and the last op are zeroed by design, so only assert on
+            # the ops that actually retain memory.
+            recorded = [m for m in sac_estimator.sac_mod_stats["Foo"].memory if m > 0]
+            self.assertTrue(recorded, "expected some operator to record memory")
+            unrounded = [m for m in recorded if m % granularity != 0]
+            self.assertEqual(
+                unrounded, [], f"operator memory not rounded to {granularity} bytes"
             )
 
 

--- a/torch/distributed/_tools/common_utils.py
+++ b/torch/distributed/_tools/common_utils.py
@@ -1,8 +1,12 @@
+import functools
 import warnings
 
 import torch
 from torch._custom_class_base import CustomClassBase
-from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+from torch.utils._python_dispatch import (
+    _disable_current_modes,
+    is_traceable_wrapper_subclass,
+)
 
 
 def get_untyped_storages(t: torch.Tensor) -> set[torch.UntypedStorage]:
@@ -41,3 +45,38 @@ def get_untyped_storages(t: torch.Tensor) -> set[torch.UntypedStorage]:
             else:
                 flattened_tensor_storages.add(obj.untyped_storage())
     return flattened_tensor_storages
+
+
+@functools.cache
+def get_allocation_granularity(device_type: str) -> int:
+    """
+    Returns the number of bytes that ``device_type``'s allocator rounds an allocation up to.
+
+    The value is measured from the allocator's own statistics rather than hardcoded
+    per backend, so any accelerator reporting ``requested_bytes``/``allocated_bytes``
+    is covered, including out-of-tree PrivateUse1 backends.
+
+    Args:
+        device_type (str): The device type to query, e.g. ``"cuda"``.
+
+    Returns:
+        int: The allocation granularity in bytes. 1 if the allocator returns exactly
+        the requested size, does not report the above statistics, or is bypassed.
+    """
+    acc = torch.accelerator.current_accelerator()
+    if acc is None or acc.type != device_type:
+        return 1
+
+    def stat(key: str) -> int:
+        return torch.accelerator.memory_stats().get(key, 0)
+
+    # Modes must be off: this runs under ``__torch_dispatch__``, and a fake mode
+    # would allocate nothing.
+    with _disable_current_modes():
+        before_req = stat("requested_bytes.all.current")
+        before_alloc = stat("allocated_bytes.all.current")
+        probe = torch.empty(1, dtype=torch.uint8, device=device_type)
+        req = stat("requested_bytes.all.current") - before_req
+        alloc = stat("allocated_bytes.all.current") - before_alloc
+        del probe
+    return alloc if req == 1 and alloc > 0 else 1

--- a/torch/distributed/_tools/mem_tracker.py
+++ b/torch/distributed/_tools/mem_tracker.py
@@ -1,5 +1,3 @@
-import math
-import os
 import re
 import warnings
 from collections.abc import Callable
@@ -13,7 +11,10 @@ import torch
 import torch.distributed._tools.fake_collectives
 from torch import nn, optim
 from torch._guards import active_fake_mode
-from torch.distributed._tools.common_utils import get_untyped_storages
+from torch.distributed._tools.common_utils import (
+    get_allocation_granularity,
+    get_untyped_storages,
+)
 from torch.distributed._tools.mod_tracker import ModTracker
 from torch.distributed.tensor import DTensor
 from torch.optim.optimizer import (
@@ -28,11 +29,6 @@ from torch.utils.weak import WeakIdKeyDictionary, weakref
 if TYPE_CHECKING:
     from torch.utils.hooks import RemovableHandle
 
-# This value is hard-coded here:
-# https://github.com/pytorch/pytorch/blob/5fba5d83f0703ff8077ab65448a998e9ad6598fd/c10/cuda/CUDACachingAllocator.cpp#L117
-_PYTORCH_MIN_ALLOCATE = (
-    2**9 if int(os.environ.get("PYTORCH_NO_CUDA_MEMORY_CACHING", 0)) == 0 else 1
-)
 _TOTAL_KEY = "Total"
 
 __all__ = ["MemTracker"]
@@ -153,9 +149,8 @@ class _WeakRefInfo:
             int: The memory consumed in bytes.
         """
         mem = self.size * self.element_size
-        if self.device.type == "cuda":
-            return math.ceil((mem) / _PYTORCH_MIN_ALLOCATE) * _PYTORCH_MIN_ALLOCATE
-        return mem
+        granularity = get_allocation_granularity(self.device.type)
+        return (mem + granularity - 1) // granularity * granularity
 
     def update_mem_consumed(self, st: torch.UntypedStorage) -> int:
         """

--- a/torch/distributed/_tools/sac_estimator.py
+++ b/torch/distributed/_tools/sac_estimator.py
@@ -1,4 +1,3 @@
-import math
 import os
 import sys
 from collections import OrderedDict
@@ -10,7 +9,10 @@ import torch
 from torch import nan, nn, UntypedStorage
 from torch._guards import active_fake_mode
 from torch._subclasses.fake_tensor import FakeTensorMode
-from torch.distributed._tools.common_utils import get_untyped_storages
+from torch.distributed._tools.common_utils import (
+    get_allocation_granularity,
+    get_untyped_storages,
+)
 from torch.distributed._tools.mod_tracker import ModTracker
 from torch.distributed._tools.runtime_estimator import RuntimeEstimator
 from torch.testing._internal.composite_compliance import (
@@ -32,11 +34,6 @@ _ADDITIONAL_IGNORED_OPS = {
     aten.clone.default,  # type: ignore[attr-defined] # seems needed for torch.compile
 }
 OPS_TO_ALWAYS_SKIP = SAC_IGNORED_OPS | _ADDITIONAL_IGNORED_OPS
-# This value is hard-coded here:
-# https://github.com/pytorch/pytorch/blob/5fba5d83f0703ff8077ab65448a998e9ad6598fd/c10/cuda/CUDACachingAllocator.cpp#L117
-_PYTORCH_MIN_ALLOCATE = (
-    2**9 if int(os.environ.get("PYTORCH_NO_CUDA_MEMORY_CACHING", 0)) == 0 else 1
-)
 
 
 def _display_stats_tabular(headers: list[str], table_data: list[list[Any]]) -> None:
@@ -403,32 +400,36 @@ class SACEstimator(TorchDispatchMode):
         # 1. Get the runtime estimate
         out, op_time = self._estimate_runtime(func, args, kwargs)
         flat_outs, _ = tree_flatten(out)
-        out_storages_cuda: set[UntypedStorage] = set()
+        acc = torch.accelerator.current_accelerator()
+        out_storages_acc: set[UntypedStorage] = set()
         out_storages_cpu: set[UntypedStorage] = set()
-        cuda_devices: set[torch.device] = set()
+        acc_devices: set[torch.device] = set()
         for o in flat_outs:
             if isinstance(o, torch.Tensor):
-                if o.device.type == "cuda":
-                    out_storages_cuda.update(get_untyped_storages(o))
-                    cuda_devices.add(o.device)
+                if acc is not None and o.device.type == acc.type:
+                    out_storages_acc.update(get_untyped_storages(o))
+                    acc_devices.add(o.device)
                 else:
                     out_storages_cpu.update(get_untyped_storages(o))
 
-        # Check if there's more than 1 CUDA device
-        if len(cuda_devices) > 1:
+        # Check if there's more than 1 accelerator device
+        if len(acc_devices) > 1:
             raise AssertionError(
-                f"{func.__name__}'s output has more than 1 CUDA devices {cuda_devices}"
+                f"{func.__name__}'s output has more than 1 accelerator devices {acc_devices}"
             )
 
-        # 2. Get the memory consumed by output
-        nbytes_cuda = sum(
-            math.ceil(st.nbytes() / _PYTORCH_MIN_ALLOCATE) * _PYTORCH_MIN_ALLOCATE
-            for st in out_storages_cuda
+        # 2. Get the memory consumed by output. This mode runs under ``FakeTensorMode``
+        # where the storages live on meta, so the granularity comes from the tensor's
+        # device rather than the storage's.
+        granularity = get_allocation_granularity(acc.type) if acc is not None else 1
+        nbytes_acc = sum(
+            (st.nbytes() + granularity - 1) // granularity * granularity
+            for st in out_storages_acc
         )
         nbytes_cpu = sum(st.nbytes() for st in out_storages_cpu)
-        nbytes = nbytes_cuda + nbytes_cpu
+        nbytes = nbytes_acc + nbytes_cpu
+        out_storages = out_storages_acc | out_storages_cpu
         # 3. Get the current operator index, output storage identifiers and inplace metadata
-        out_storages = out_storages_cuda | out_storages_cpu
         curr_idx, output_ids, mod_inplace_info = self._get_inplace_metadata(
             func, out_storages
         )


### PR DESCRIPTION
## Problem

`mem_tracker.py` and `sac_estimator.py` each carried an identical copy of:

```python
_PYTORCH_MIN_ALLOCATE = (
    2**9 if int(os.environ.get("PYTORCH_NO_CUDA_MEMORY_CACHING", 0)) == 0 else 1
)
```

applied behind a `device.type == "cuda"` gate. Consequences:

- If used, non-CUDA accelerators were charged raw, unrounded bytes. XPU and any PrivateUse1 backend built on c10's caching allocator round to `kMinBlockSize` (512), so their memory was under-reported. In `sac_estimator.py` they were additionally misclassified into the CPU bucket.
- `PYTORCH_NO_<NONCUDA-BACKEND>_MEMORY_CACHING` was ignored, though c10 honours it (`c10/cuda/CUDACachingAllocator.cpp:4479-4484`).
- The value was computed at import, so the runtime toggle `torch.cuda.caching_allocator_enable(False)` was invisible.

Related to this RFC:  #194355

## Approach

Rather than enumerate per-backend constants or env-var names, measure the allocator's behaviour. `get_allocation_granularity()` in `common_utils.py` allocates one byte and compares `requested_bytes` against `allocated_bytes` from `torch.accelerator.memory_stats()`, a device-generic API that reaches any backend implementing `c10::DeviceAllocator::getDeviceStats`, including out-of-tree PrivateUse1 backends. It returns 1 when the allocator hands back exactly what was requested, doesn't report those statistics, or is bypassed.

The durable fix is a `roundedSize(n)` virtual on `c10::DeviceAllocator`, which would also handle `roundup_power2_divisions` and MPS's per-size driver query. That needs an RFC and vendor coordination; this PR is Python-only and self-contained.

## Review order

1. `common_utils.py`, the new helper.
2. `mem_tracker.py`, drops the constant, calls the helper.
3. `sac_estimator.py`, same, plus `== "cuda"` becomes "is on the current accelerator".

## Known limitations

- The probe allocates one block per device type per process, released immediately. It can move `memory_snapshot`/peak by one block.
- The result is cached per device type, so a mid-process `caching_allocator_enable(False)` is not picked up. Previously the value was frozen at import, so this is still an improvement.
- Rounding is sampled at one size, so `roundup_power2_divisions` is not modelled, the same blind spot the hardcoded 512 had.

## Test Plan

Ran on CUDA with no behaviour change:

```bash
lintrunner -a
python test/distributed/_tools/test_mem_tracker.py
python -m pytest -q test/distributed/_tools/test_sac_estimator.py
python -m pytest -q test/distributed/_tools/test_sac_ilp.py
python -m pytest -q test/distributed/_tools/test_runtime_estimator.py
```