### PR TITLE
[Test] Make `functorch/test_ac.py` tests device-generic and enable testing XPU.

### DIFF
--- a/test/functorch/test_ac.py
+++ b/test/functorch/test_ac.py
@@ -5,8 +5,17 @@ from math import prod
 
 import torch
 import torch._functorch.config as config
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_ROCM, TestCase
-from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_ROCM,
+    TestCase,
+)
+from torch.testing._internal.inductor_utils import HAS_GPU_AND_TRITON
 from torch.utils._triton import has_triton
 from torch.utils.checkpoint import checkpoint
 from torch.utils.flop_counter import FlopCounterMode, register_flop_formula
@@ -27,9 +36,9 @@ def compile_with_ac(f, memory_budget):
 def get_act_mem(f):
     out = f()
     out.backward()
-    start_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+    start_mem = torch.accelerator.memory_stats()["requested_bytes.all.current"]
     out = f()
-    cur_mem = torch.cuda.memory_stats()["requested_bytes.all.current"]
+    cur_mem = torch.accelerator.memory_stats()["requested_bytes.all.current"]
     act_mem = (cur_mem - start_mem) / (1024 * 1024)
     out.backward()
     return act_mem
@@ -44,11 +53,11 @@ def get_bw_flops(f):
     return mode.get_total_flops() / (512**3 * 2)
 
 
-def create_pair(B_I, O):
+def create_pair(B_I, O, device):
     # results in B_I * O memory, requires B_I * B_I * O flops
     # arithmetic intensity of B_I
-    x = torch.randn(B_I * 512, B_I * 512, requires_grad=True)
-    w = torch.randn(B_I * 512, O * 512, requires_grad=True)
+    x = torch.randn(B_I * 512, B_I * 512, requires_grad=True, device=device)
+    w = torch.randn(B_I * 512, O * 512, requires_grad=True, device=device)
     return x, w
 
 
@@ -64,23 +73,18 @@ def get_mem_and_flops(f, memory_budget=None):
         return round(get_act_mem(f), 1), get_bw_flops(f)
 
 
-class MemoryBudgetTest(TestCase):
-    def setUp(self):
-        super().setUp()
-        torch.set_default_device("cuda")
+class MemoryBudgetTestDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
 
-    def tearDown(self):
-        torch.set_default_device(None)
-        super().tearDown()
-
-    def test_rematerializes_cheap(self):
+    @onlyAccelerator
+    def test_rematerializes_cheap(self, device):
         def f(x, w):
             x = x.cos()
             x = torch.mm(x, w)
             return x.sum()
 
-        x = torch.randn(512, 512, requires_grad=True)
-        w = torch.randn(512, 512, requires_grad=True)
+        x = torch.randn(512, 512, requires_grad=True, device=device)
+        w = torch.randn(512, 512, requires_grad=True, device=device)
 
         def call():
             return f(x, w)
@@ -96,15 +100,18 @@ class MemoryBudgetTest(TestCase):
         self.assertEqual(mem_5, 0.0)
         self.assertEqual(flops_5, eager_flops)
 
-    def test_matmul_even_chain(self):
+    @onlyAccelerator
+    def test_matmul_even_chain(self, device):
         def f(x, ws):
             x = x.cos()
             for w in ws:
                 x = torch.mm(x, w).cos()
             return x.sum()
 
-        x = torch.randn(512, 512, requires_grad=True)
-        ws = [torch.randn(512, 512, requires_grad=True) for _ in range(5)]
+        x = torch.randn(512, 512, requires_grad=True, device=device)
+        ws = [
+            torch.randn(512, 512, requires_grad=True, device=device) for _ in range(5)
+        ]
 
         def call():
             return f(x, ws)
@@ -124,7 +131,8 @@ class MemoryBudgetTest(TestCase):
                 self.assertEqual(mem, 10.0)
                 self.assertEqual(flops, eager_flops)
 
-    def test_matmul_uneven_chain(self):
+    @onlyAccelerator
+    def test_matmul_uneven_chain(self, device):
         # This function is constructed so that we are saving one input of size
         # [512, in_dim] for each w
         # In addition, every matmul has a same ratio of compute to "memory
@@ -134,12 +142,14 @@ class MemoryBudgetTest(TestCase):
             xs = [torch.mm(x, w).cos() for w in ws]
             return sum(x.sum() for x in xs)
 
-        x = torch.randn(512, 512, requires_grad=True)
+        x = torch.randn(512, 512, requires_grad=True, device=device)
 
         def make_weights(w_shapes):
             ws = []
             for dim in w_shapes:
-                ws.append(torch.randn(512, dim * 512, requires_grad=True))
+                ws.append(
+                    torch.randn(512, dim * 512, requires_grad=True, device=device)
+                )
             return ws
 
         weight_configs = [
@@ -190,9 +200,9 @@ class MemoryBudgetTest(TestCase):
                 mem, _ = get_mem_and_flops(call, memory_budget=mem_achieved / total_mem)
                 self.assertEqual(mem, mem_achieved)
 
-    # needs CUDA, but this test file all needs CUDA.
+    @onlyAccelerator
     @unittest.skipIf(not has_triton(), "test needs triton")
-    def test_custom_triton_kernel(self):
+    def test_custom_triton_kernel(self, device):
         @triton.jit
         def relu_kernel_(inp_ptr, out_ptr, sz, BLOCK_SIZE: tl.constexpr):
             pid = tl.program_id(0)
@@ -246,9 +256,9 @@ class MemoryBudgetTest(TestCase):
                 x = torch.ops.testac.triton_relu(torch.mm(x, w))
             return x.sum()
 
-        x = torch.randn(512, 512, requires_grad=True, device="cuda")
+        x = torch.randn(512, 512, requires_grad=True, device=device)
         ws = [
-            torch.randn(512, 512, requires_grad=True, device="cuda") for _ in range(5)
+            torch.randn(512, 512, requires_grad=True, device=device) for _ in range(5)
         ]
 
         def call():
@@ -266,13 +276,14 @@ class MemoryBudgetTest(TestCase):
 
                 self.assertEqual(expected, f_compile())
 
-    def test_prioritize_cheaper_matmul(self):
+    @onlyAccelerator
+    def test_prioritize_cheaper_matmul(self, device):
         def f(xs, ws):
             xs = [torch.mm(x, w).cos() for x, w in zip(xs, ws)]
             return sum(x.sum() for x in xs)
 
-        x1, w1 = create_pair(1, 4)
-        x2, w2 = create_pair(2, 2)
+        x1, w1 = create_pair(1, 4, device=device)
+        x2, w2 = create_pair(2, 2, device=device)
 
         def call():
             return f([x1, x2], [w1, w2])
@@ -285,16 +296,19 @@ class MemoryBudgetTest(TestCase):
         # We are recomputing x1 @ w1 here!
         self.assertEqual(comp_flops, eager_flops + 4)
 
+    @onlyAccelerator
     @config.patch(activation_memory_budget_runtime_estimator="profile")
-    def test_profile(self):
+    def test_profile(self, device):
         def f(x, ws):
             x = x.cos()
             for w in ws:
                 x = torch.mm(x, w).cos()
             return x.sum()
 
-        x = torch.randn(512, 512, requires_grad=True)
-        ws = [torch.randn(512, 512, requires_grad=True) for _ in range(5)]
+        x = torch.randn(512, 512, requires_grad=True, device=device)
+        ws = [
+            torch.randn(512, 512, requires_grad=True, device=device) for _ in range(5)
+        ]
 
         def call():
             return f(x, ws)
@@ -305,13 +319,14 @@ class MemoryBudgetTest(TestCase):
         self.assertEqual(mem, 2)
         self.assertEqual(flops, eager_flops + 3)
 
-    def test_prioritize_cheaper_matmul2(self):
+    @onlyAccelerator
+    def test_prioritize_cheaper_matmul2(self, device):
         def f(xs, ws):
             xs = [torch.mm(x, w).cos() for x, w in zip(xs, ws)]
             return sum(x.sum() for x in xs)
 
         data = [(4, 4), (6, 2), (2, 6)]
-        xs, ws = zip(*[create_pair(a, b) for a, b in data])
+        xs, ws = zip(*[create_pair(a, b, device=device) for a, b in data])
 
         def call():
             return f(xs, ws)
@@ -330,7 +345,8 @@ class MemoryBudgetTest(TestCase):
         self.assertEqual(mem, 12)
         self.assertEqual(flops - eager_flops, 2 * 2 * 6 + 4 * 4 * 4)
 
-    def test_attention_vs_linear(self):
+    @onlyAccelerator
+    def test_attention_vs_linear(self, device):
         def f(x, w):
             orig_shape = x.shape
             x = x.reshape(1, 1, x.shape[0], x.shape[1])
@@ -343,8 +359,8 @@ class MemoryBudgetTest(TestCase):
             return x.sum()
 
         def try_seq_length(S, D, expected_recompute):
-            x = torch.randn(S * 512, D * 512, requires_grad=True)
-            w = torch.randn(D * 512, D * 512, requires_grad=True)
+            x = torch.randn(S * 512, D * 512, requires_grad=True, device=device)
+            w = torch.randn(D * 512, D * 512, requires_grad=True, device=device)
 
             def call():
                 return f(x, w)
@@ -379,7 +395,8 @@ class MemoryBudgetTest(TestCase):
         try_seq_length(4, 7, "mm")
         try_seq_length(4, 9, "attn")
 
-    def test_manual_ac(self):
+    @onlyAccelerator
+    def test_manual_ac(self, device):
         # test that manual checkpoint boundaries are respected
         # when autoac is set
         def f(x):
@@ -394,7 +411,7 @@ class MemoryBudgetTest(TestCase):
             x = checkpoint(f, x, use_reentrant=False)
             return x
 
-        x = torch.randn(64, 1024, requires_grad=True)
+        x = torch.randn(64, 1024, requires_grad=True, device=device)
 
         def call():
             return g(x).sum()
@@ -407,7 +424,10 @@ class MemoryBudgetTest(TestCase):
         self.assertEqual(flops, eager_flops)
 
 
+instantiate_device_type_tests(MemoryBudgetTestDevice, globals(), only_for=("cuda",))
+
+
 if __name__ == "__main__":
-    # I'm using the cuda memory allocator to verify memory allocations
-    if HAS_CUDA_AND_TRITON and not TEST_WITH_ROCM:
+    # I'm using the accelerator memory allocator to verify memory allocations
+    if HAS_GPU_AND_TRITON and not TEST_WITH_ROCM:
         run_tests()

--- a/test/functorch/test_ac.py
+++ b/test/functorch/test_ac.py
@@ -8,6 +8,7 @@ import torch._functorch.config as config
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyAccelerator,
+    skipXPUIf,
 )
 from torch.testing._internal.common_utils import (
     HardwareClassification,
@@ -346,6 +347,7 @@ class MemoryBudgetTestDevice(TestCase):
         self.assertEqual(flops - eager_flops, 2 * 2 * 6 + 4 * 4 * 4)
 
     @onlyAccelerator
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/4729")
     def test_attention_vs_linear(self, device):
         def f(x, w):
             orig_shape = x.shape
@@ -424,7 +426,9 @@ class MemoryBudgetTestDevice(TestCase):
         self.assertEqual(flops, eager_flops)
 
 
-instantiate_device_type_tests(MemoryBudgetTestDevice, globals(), only_for=("cuda",))
+instantiate_device_type_tests(
+    MemoryBudgetTestDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors `test/functorch/test_ac.py` test file to make the hardcoded `cuda` tests device-generic and enables testing XPU.

### Changes

- Add `Device` suffix to `MemoryBudgetTest` -> `MemoryBudgetTestDevice`.
- Instantiate `MemoryBudgetTestDevice` with `instantiate_device_type_tests()`.
- Use explicit `device` function parameter instead of `torch.set_default_device()` at the setUp stage.
- Add `@onlyAccelerator` decorator for test functions that were so far launched only with cuda device (no cpu).
- Add `HardwareClassification` classification to `MemoryBudgetTestDevice`.
- Remove imports that are redundant after refactor.
- Change `torch.cuda.memory_stats()` calls to `torch.accelerator.memory_stats()`.
- Change `HAS_CUDA_AND_TRITON` to only `HAS_GPU_AND_TRITON` to enable launching those tests with other accelerators.
- Add necessary skip for test that fails on XPU with linked issue.
- Enable testing XPU.