### PR TITLE
[torch] Make singletons immortal (#194371)

### DIFF
--- a/torch/csrc/Dtype.cpp
+++ b/torch/csrc/Dtype.cpp
@@ -6,6 +6,7 @@
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/refcount_contention.h>
 #include <cstring>
 
 PyObject* THPDtype_New(at::ScalarType scalar_type, const std::string& name) {
@@ -16,6 +17,7 @@ PyObject* THPDtype_New(at::ScalarType scalar_type, const std::string& name) {
   auto self_ = reinterpret_cast<THPDtype*>(self.get());
   self_->scalar_type = scalar_type;
   std::strncpy(self_->name, name.c_str(), DTYPE_NAME_LEN);
+  torch::utils::set_immortal_if_possible(self.get());
   return self.release();
 }
 

--- a/torch/csrc/Layout.cpp
+++ b/torch/csrc/Layout.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/refcount_contention.h>
 
 #include <cstring>
 #include <string>
@@ -15,6 +16,7 @@ PyObject* THPLayout_New(at::Layout layout, const std::string& name) {
   self_->layout = layout;
   std::strncpy(self_->name, name.c_str(), LAYOUT_NAME_LEN);
   self_->name[LAYOUT_NAME_LEN] = '\0';
+  torch::utils::set_immortal_if_possible(self.get());
   return self.release();
 }
 

--- a/torch/csrc/MemoryFormat.cpp
+++ b/torch/csrc/MemoryFormat.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/refcount_contention.h>
 
 #include <cstring>
 #include <string>
@@ -17,6 +18,7 @@ PyObject* THPMemoryFormat_New(
   self_->memory_format = memory_format;
   std::strncpy(self_->name, name.c_str(), MEMORY_FORMAT_NAME_LEN);
   self_->name[MEMORY_FORMAT_NAME_LEN] = '\0';
+  torch::utils::set_immortal_if_possible(self.get());
   return self.release();
 }
 

--- a/torch/csrc/QScheme.cpp
+++ b/torch/csrc/QScheme.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/Exceptions.h>
 #include <torch/csrc/utils/object_ptr.h>
 #include <torch/csrc/utils/python_strings.h>
+#include <torch/csrc/utils/refcount_contention.h>
 
 #include <cstring>
 #include <string>
@@ -15,6 +16,7 @@ PyObject* THPQScheme_New(at::QScheme qscheme, const std::string& name) {
   self_->qscheme = qscheme;
   std::strncpy(self_->name, name.c_str(), QSCHEME_NAME_LEN);
   self_->name[QSCHEME_NAME_LEN] = '\0';
+  torch::utils::set_immortal_if_possible(self.get());
   return self.release();
 }
 

--- a/torch/csrc/utils/pythoncapi_compat.h
+++ b/torch/csrc/utils/pythoncapi_compat.h
@@ -1425,6 +1425,11 @@ PyUnicodeWriter_WriteStr(PyUnicodeWriter *writer, PyObject *obj)
 static inline int
 PyUnicodeWriter_WriteRepr(PyUnicodeWriter *writer, PyObject *obj)
 {
+    if (obj == NULL) {
+        return _PyUnicodeWriter_WriteASCIIString((_PyUnicodeWriter*)writer,
+                                                 "<NULL>", 6);
+    }
+
     PyObject *str = PyObject_Repr(obj);
     if (str == NULL) {
         return -1;
@@ -1569,6 +1574,11 @@ static inline int PyLong_IsZero(PyObject *obj)
 
 // gh-124502 added PyUnicode_Equal() to Python 3.14.0a0
 #if PY_VERSION_HEX < 0x030E00A0
+
+#if PY_VERSION_HEX >= 0x030d0000 && !defined(PYPY_VERSION)
+PyAPI_FUNC(int) _PyUnicode_Equal(PyObject *str1, PyObject *str2);
+#endif
+
 static inline int PyUnicode_Equal(PyObject *str1, PyObject *str2)
 {
     if (!PyUnicode_Check(str1)) {
@@ -1583,8 +1593,6 @@ static inline int PyUnicode_Equal(PyObject *str1, PyObject *str2)
     }
 
 #if PY_VERSION_HEX >= 0x030d0000 && !defined(PYPY_VERSION)
-    PyAPI_FUNC(int) _PyUnicode_Equal(PyObject *str1, PyObject *str2);
-
     return _PyUnicode_Equal(str1, str2);
 #elif PY_VERSION_HEX >= 0x03060000 && !defined(PYPY_VERSION)
     return _PyUnicode_EQ(str1, str2);
@@ -1607,11 +1615,14 @@ static inline PyObject* PyBytes_Join(PyObject *sep, PyObject *iterable)
 
 
 #if PY_VERSION_HEX < 0x030E00A0
+
+#if PY_VERSION_HEX >= 0x03000000 && !defined(PYPY_VERSION)
+PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void *src, Py_ssize_t len);
+#endif
+
 static inline Py_hash_t Py_HashBuffer(const void *ptr, Py_ssize_t len)
 {
 #if PY_VERSION_HEX >= 0x03000000 && !defined(PYPY_VERSION)
-    PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void *src, Py_ssize_t len);
-
     return _Py_HashBytes(ptr, len);
 #else
     Py_hash_t hash;
@@ -1743,7 +1754,7 @@ static inline void
 _PyLong_SetSignAndDigitCount(PyLongObject *op, int sign, Py_ssize_t size)
 {
 #if PY_VERSION_HEX >= 0x030C0000
-    op->long_value.lv_tag = (uintptr_t)(1 - sign) | ((uintptr_t)size << 3);
+    op->long_value.lv_tag = (uintptr_t)(1 - sign) | ((uintptr_t)(size) << 3);
 #elif PY_VERSION_HEX >= 0x030900A4
     Py_SET_SIZE(op, sign * size);
 #else
@@ -1948,11 +1959,14 @@ PyLongWriter_Finish(PyLongWriter *writer)
 
 // gh-127350 added Py_fopen() and Py_fclose() to Python 3.14a4
 #if PY_VERSION_HEX < 0x030E00A4
+
+#if 0x030400A2 <= PY_VERSION_HEX && !defined(PYPY_VERSION)
+PyAPI_FUNC(FILE*) _Py_fopen_obj(PyObject *path, const char *mode);
+#endif
+
 static inline FILE* Py_fopen(PyObject *path, const char *mode)
 {
 #if 0x030400A2 <= PY_VERSION_HEX && !defined(PYPY_VERSION)
-    PyAPI_FUNC(FILE*) _Py_fopen_obj(PyObject *path, const char *mode);
-
     return _Py_fopen_obj(path, mode);
 #else
     FILE *f;
@@ -2659,6 +2673,40 @@ PyUnstable_Unicode_GET_CACHED_HASH(PyObject *op)
 }
 #endif
 
+#if 0x030D0000 <= PY_VERSION_HEX && PY_VERSION_HEX < 0x030F00A7 && !defined(PYPY_VERSION)
+// Immortal objects were implemented in Python 3.12, however there is no easy API
+// to make objects immortal until 3.14 which has _Py_SetImmortal(). Since
+// immortal objects are primarily needed for free-threading, this API is implemented
+// for 3.14 using _Py_SetImmortal() and uses private macros on 3.13.
+#if 0x030E0000 <= PY_VERSION_HEX
+PyAPI_FUNC(void) _Py_SetImmortal(PyObject *op);
+#endif
+
+static inline int
+PyUnstable_SetImmortal(PyObject *op)
+{
+    assert(op != NULL);
+    if (!PyUnstable_Object_IsUniquelyReferenced(op) || PyUnicode_Check(op)) {
+        return 0;
+    }
+#if 0x030E0000 <= PY_VERSION_HEX
+    _Py_SetImmortal(op);
+#else
+    // Python 3.13 doesn't export _Py_SetImmortal() function
+    if (PyObject_GC_IsTracked(op)) {
+        PyObject_GC_UnTrack(op);
+    }
+#ifdef Py_GIL_DISABLED
+    op->ob_tid = _Py_UNOWNED_TID;
+    op->ob_ref_local = _Py_IMMORTAL_REFCNT_LOCAL;
+    op->ob_ref_shared = 0;
+#else
+    op->ob_refcnt = _Py_IMMORTAL_REFCNT;
+#endif
+#endif
+    return 1;
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/torch/csrc/utils/refcount_contention.h
+++ b/torch/csrc/utils/refcount_contention.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <torch/csrc/python_headers.h>
+#include <torch/csrc/utils/pythoncapi_compat.h>
+
+namespace torch::utils {
+
+// Set a Python object as immortal, i.e. living for the same lifetime as the
+// entire runtime.
+//
+// Reference counting is expensive on the free-threaded build when threads
+// incref/decref objects that they don't own, there's an atomic
+// read-modify-write that leads to contended cache lines.  This particularly
+// hurts common shared objects like singletons.
+//
+// Return true if the object was successfully immortalized.
+inline bool set_immortal_if_possible([[maybe_unused]] PyObject* obj) {
+  // The unstable API for immortalizing objects is added in Python 3.15, but the
+  // compat header includes support for it starting with Python 3.13.
+#if PY_VERSION_HEX >= 0x030D0000
+  return PyUnstable_SetImmortal(obj) > 0;
+#else
+  return false;
+#endif
+}
+
+} // namespace torch::utils


### PR DESCRIPTION
Summary:

Every value in the `torch` namespace is a process-lifetime singleton, and on a
free-threaded build every one of them is an ordinary mortal `PyObject`.  Loading
a mortal object owned by another thread takes the shared incref path, an atomic
read-modify-write on one cache line, so a `dtype=torch.long` keyword or a
`torch.cat` lookup in a hot loop becomes a point of contention for the whole
process.

Measured across multiple threads, with each thread looping over its own state,
speedup relative to one thread:

                        case      1t ms       8t      32t
            touch local obj         6.1     7.6x    17.9x
          touch py function         6.2     7.0x    24.8x
            touch math.sqrt         6.8     7.0x     6.4x
           touch shared obj         7.4     0.5x     0.6x
           touch torch.long        12.2     0.1x     0.1x
          touch torch.empty        15.2     0.1x     0.0x
      as_tensor(dtype=long)        14.6     0.7x     0.3x
             torch.empty(4)         6.0     0.3x     0.1x
         numel per-thread t         3.0     7.9x    15.1x

A one-line check lines up 1:1 with that table:

  math.sqrt    builtin_function_or_method  __self__=<module math>  immortal=True
  np.zeros     builtin_function_or_method  __self__=<module ...>   immortal=True
  torch.empty  builtin_function_or_method  __self__=None           immortal=False
  torch.cat    builtin_function_or_method  __self__=None           immortal=False
  torch.long   dtype                       __self__=None           immortal=False

Everything immortal scales, everything mortal does not.  The interpreter itself
is fine: pure Python and thread-private objects scale 18-25x on the same box,
and `numel()` on a *per-thread* tensor scales 15x.

This diff adds a `torch::utils::set_immortal_if_possible` helper and applies it
to four singleton types: `torch.dtype`, `torch.layout`, `torch.memory_format`,
and `torch.qscheme`.

The pythoncapi_compat.h header has to be updated to pull in the definition of
PyUnstable_SetImmortal(), it's officially added as part of Python 3.15 but the
compat header supports it starting in Python 3.13.

Test Plan:
All numbers below are from a 144-core aarch64 GB200 host.  The free-threaded
interpreters are CPython built from `third-party/python/{3.14,3.15}/pristine`
with `--disable-gil` (3.14.7+ and 3.15.0rc1+dev, `sys._is_gil_enabled()` false
in both).  The GIL interpreters are a stock 3.14.7 and the platform 3.12.14.

# Version dispatch

`set_immortal_if_possible` compiled against each interpreter's real headers,
checking which undefined symbol the resulting object file actually references:

           config     build    symbol referenced
         GIL 3.12        ok    none, compiles to a no-op
         GIL 3.14        ok    _Py_SetImmortal, via the compat shim
          FT 3.14        ok    _Py_SetImmortal, via the compat shim
          FT 3.15        ok    PyUnstable_SetImmortal, native

# Correctness

The singleton pattern is reproduced in a standalone extension that includes the
real `torch/csrc/utils/refcount_contention.h` and mints two module-level
singletons of one static non-GC type, differing only in the line this diff adds:

  IMMORTAL   `set_immortal_if_possible()` after `tp_alloc`, the post-diff shape
  PLAIN      untouched, the pre-diff shape

The extension declares `Py_MOD_GIL_NOT_USED` as `torch/csrc/Module.cpp` does, so
the interpreter does not quietly re-enable the GIL on import.  Every check below
passes on free-threaded 3.14, free-threaded 3.15 and GIL 3.14:

- `set_immortal_if_possible` returns true, and the refcount reads `0xC0000000`
  on all three.

- The refcount is pinned rather than merely large: identical across 1000 reads,
  and unchanged after 10,000 incref/decref cycles.

- The `test_type_info.py` criterion from `test_to_complex` and `test_to_real`,
  `len(ref_cnt) < 3` over ten reads, holds for both shapes.

- Twenty full collections plus per-generation collections leave the singleton
  intact and identity-stable.

- `copy.copy`, `copy.deepcopy` and `pickle.dumps` give the same outcome for the
  immortalized shape as for the pre-diff shape.

- 64 threads doing 200k lookups each, then 32 readers racing a thread calling
  `gc.collect()` in a loop: no exceptions, no crashes, refcount still pinned.

On 3.12 the helper compiles to a genuine no-op: no immortalization symbol is
referenced at all, `set_immortal_if_possible` returns false, and the refcount
stays ordinary.

# Scaling

1,000,000 module-attribute reads per thread, best of 3, speedup relative to one
thread of the same variant.

3.14.7t:

  threads       IMMORTAL             PLAIN
        1    5.8ms  1.00x    22.8ms  1.00x
        8    6.0ms  7.79x  1057.8ms  0.17x
       32    6.8ms  27.2x  2327.5ms  0.31x
       64    8.1ms  46.1x  4764.2ms  0.31x
      128   10.2ms  73.3x 13824.8ms  0.21x

3.15.0t:

  threads       IMMORTAL             PLAIN
        1    6.1ms  1.00x    22.8ms  1.00x
        8    6.0ms  8.04x   548.3ms  0.33x
       32    6.3ms  30.7x  2449.8ms  0.30x
       64    7.3ms  53.0x  4919.6ms  0.30x
      128   11.4ms  68.1x 14997.7ms  0.20x

The pre-diff shape scales negatively on both interpreters, bottoming out near
0.2x, while the immortalized shape reaches 73.3x on 3.14 and 68.1x on 3.15.
Even single-threaded the immortalized shape is 4x faster, because a worker
thread never owns a singleton the main thread minted, so every read takes the
shared atomic path even with no contention at all.

# GIL builds

4,000,000 single-threaded attribute reads on GIL 3.14 take 20.1ms immortalized
against 23.0ms before, so 1.14x.  The visible consequence is that
`sys.getrefcount` on one of these singletons now returns 3221225472 on an
ordinary GIL build.

Reviewed By: ezyang

Differential Revision: D116032674


