### PR TITLE
[BE] Mark large conv test for MPS as expected failure

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -4021,6 +4021,7 @@ class TestConvolutionNNDeviceType(NNTestCase):
         and _get_cudnn_version() is not None
         and (91000 < _get_cudnn_version() < 91500)
     )
+    @expectedFailureMPS
     def test_depthwise_conv_64bit_indexing(self, device):
         x = torch.randn(1, 2, 32800, 32800, dtype=torch.half).to(
             memory_format=torch.channels_last


### PR DESCRIPTION
After adding large Mac as a testing machine, I encountered an error on CI, which is skippped by usual runners because of large tensor test decorator which exceeds the memory CI. Here is the error:


```
_____________________________________ TestConvolutionNNDeviceTypeMPS.test_depthwise_conv_64bit_indexing_mps ______________________________________
Traceback (most recent call last):
  File "/Users/isalia/.local/share/uv/python/cpython-3.14.5-macos-aarch64-none/lib/python3.14/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/Users/isalia/.local/share/uv/python/cpython-3.14.5-macos-aarch64-none/lib/python3.14/unittest/case.py", line 669, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/isalia/.local/share/uv/python/cpython-3.14.5-macos-aarch64-none/lib/python3.14/unittest/case.py", line 615, in _callTestMethod
    result = method()
  File "/Users/isalia/pytorch/torch/testing/_internal/common_utils.py", line 3831, in wrapper
    method(*args, **kwargs)
    ~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/isalia/pytorch/torch/testing/_internal/common_device_type.py", line 692, in instantiated_test
    raise rte
  File "/Users/isalia/pytorch/torch/testing/_internal/common_device_type.py", line 672, in instantiated_test
    result = test(self, **param_kwargs)
  File "/Users/isalia/pytorch/torch/testing/_internal/common_device_type.py", line 2181, in only_fn
    return fn(self, *args, **kwargs)
  File "/Users/isalia/pytorch/torch/testing/_internal/common_device_type.py", line 1843, in dep_fn
    return fn(self, *args, **kwargs)
  File "/Users/isalia/pytorch/torch/testing/_internal/common_device_type.py", line 1843, in dep_fn
    return fn(self, *args, **kwargs)
  File "/Users/isalia/pytorch/torch/testing/_internal/common_device_type.py", line 1672, in dep_fn
    return fn(slf, *args, **kwargs)
  File "/Users/isalia/pytorch/test/nn/test_convolution.py", line 4032, in test_depthwise_conv_64bit_indexing
    y = c.to(device=device)(x.to(device=device))
  File "/Users/isalia/pytorch/torch/nn/modules/module.py", line 1787, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/isalia/pytorch/torch/nn/modules/module.py", line 1798, in _call_impl
    return forward_call(*args, **kwargs)
  File "/Users/isalia/pytorch/torch/nn/modules/conv.py", line 565, in forward
    return self._conv_forward(input, self.weight, self.bias)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/isalia/pytorch/torch/nn/modules/conv.py", line 560, in _conv_forward
    return F.conv2d(
           ~~~~~~~~^
        input, weight, bias, self.stride, self.padding, self.dilation, self.groups
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
NotImplementedError: convolution_overrideable not implemented. You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN, if this is intended, please use TORCH_LIBRARY_IMPL to override this function 

To execute this test, run the following from the base repo dir:
    PYTORCH_TEST_WITH_SLOW=1 python test/nn/test_convolution.py TestConvolutionNNDeviceTypeMPS.test_depthwise_conv_64bit_indexing_mps

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
============================================================ short test summary info =============================================================
FAILED [21.9268s] test/nn/test_convolution.py::TestConvolutionNNDeviceTypeMPS::test_depthwise_conv_64bit_indexing_mps - NotImplementedError: convolution_overrideable not implemented. You are likely triggering this with tensor backend other than CPU/CUDA/MKLDNN,...
=============================================================== 1 failed in 22.42s ==================================================
```