### PR TITLE
[release/2.14] Remove CUDA 13.4 from the binary build matrix

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -24,11 +24,11 @@ SCRIPT_DIR = Path(__file__).absolute().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent
 
 
-CUDA_ARCHES = ["12.6", "13.0", "13.2", "13.4"]
+CUDA_ARCHES = ["12.6", "13.0", "13.2"]
 CUDA_STABLE = "13.0"
 # Only consumed by generate_docker_release_matrix.py, whose Dockerfile installs
 # an already-published torch nightly. A CUDA version belongs here only once its
-# wheels are on the download.pytorch.org index, so 13.4 is deliberately absent.
+# wheels are on the download.pytorch.org index.
 CUDA_ARCHES_FULL_VERSION = {
     "12.6": "12.6.3",
     "13.0": "13.0.3",
@@ -38,11 +38,10 @@ CUDA_ARCHES_CUDNN_VERSION = {
     "12.6": "9",
     "13.0": "9",
     "13.2": "9",
-    "13.4": "9",
 }
 
 # CUDA versions without a Windows installer on the ossci-windows bucket yet.
-CUDA_ARCHES_NO_WINDOWS = ["13.4"]
+CUDA_ARCHES_NO_WINDOWS: list[str] = []
 
 ROCM_ARCHES = ["7.2", "7.14"]
 
@@ -56,7 +55,6 @@ CUDA_AARCH64_ARCHES = [
     "12.6-aarch64",
     "13.0-aarch64",
     "13.2-aarch64",
-    "13.4-aarch64",
 ]
 
 PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
@@ -81,14 +79,6 @@ PYTORCH_EXTRA_INSTALL_REQUIREMENTS = {
         "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.2.1; platform_system == 'Linux' | "
         "cuda-bindings>=13.0.3,<14; platform_system == 'Linux' and python_version < '3.15' | "
         "nvidia-cudnn-cu13==9.24.0.43; platform_system == 'Linux' | "
-        "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
-        "nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | "
-        "nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
-    ),
-    "13.4": (
-        "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.4.0rc1; platform_system == 'Linux' | "
-        "cuda-bindings>=13.0.3,<14; platform_system == 'Linux' and python_version < '3.15' | "
-        "nvidia-cudnn-cu13==9.25.0.15; platform_system == 'Linux' | "
         "nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | "
         "nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | "
         "nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
@@ -453,7 +443,7 @@ def generate_wheels_matrix(
             # cuda linux wheels require PYTORCH_EXTRA_INSTALL_REQUIREMENTS to install
 
             if (
-                arch_version in ["13.4", "13.2", "13.0", "12.6"]
+                arch_version in ["13.2", "13.0", "12.6"]
                 and os == "linux"
                 or arch_version in CUDA_AARCH64_ARCHES
             ):

--- a/.github/workflows/build-almalinux-images.yml
+++ b/.github/workflows/build-almalinux-images.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 240
     strategy:
       matrix:
-        tag: ["cuda12.6", "cuda13.0", "cuda13.2", "cuda13.4", "rocm7.1", "rocm7.2", "cpu"]
+        tag: ["cuda12.6", "cuda13.0", "cuda13.2", "rocm7.1", "rocm7.2", "cpu"]
     steps:
       - name: Build docker image
         uses: pytorch/pytorch/.github/actions/binary-docker-build@release/2.14

--- a/.github/workflows/build-manywheel-images.yml
+++ b/.github/workflows/build-manywheel-images.yml
@@ -47,11 +47,9 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { name: "manylinux2_28-builder",          tag: "cuda13.4",          runner: "${{ needs.select-runner.outputs.x86 }}" },
           { name: "manylinux2_28-builder",          tag: "cuda13.2",          runner: "${{ needs.select-runner.outputs.x86 }}" },
           { name: "manylinux2_28-builder",          tag: "cuda13.0",          runner: "${{ needs.select-runner.outputs.x86 }}" },
           { name: "manylinux2_28-builder",          tag: "cuda12.6",          runner: "${{ needs.select-runner.outputs.x86 }}" },
-          { name: "manylinuxaarch64-builder",       tag: "cuda13.4",          runner: "${{ needs.select-runner.outputs.arm64 }}" },
           { name: "manylinuxaarch64-builder",       tag: "cuda13.2",          runner: "${{ needs.select-runner.outputs.arm64 }}" },
           { name: "manylinuxaarch64-builder",       tag: "cuda13.0",          runner: "${{ needs.select-runner.outputs.arm64 }}" },
           { name: "manylinuxaarch64-builder",       tag: "cuda12.6",          runner: "${{ needs.select-runner.outputs.arm64 }}" },

--- a/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
@@ -495,99 +495,10 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_2/*
 
-  manywheel-cuda-aarch64-cu134-build:
-    name: manywheel-cuda-aarch64-cu134-build
-    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag]
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/release/2.14' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-arm64g3-44-340' || 'l-arm64g3-61-463' }}"
-    timeout-minutes: 420
-    container:
-      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda13.4${{ needs.get-docker-tag.outputs.docker_image_suffix }}
-    env:
-      PYTORCH_ROOT: ${{ github.workspace }}
-      PACKAGE_TYPE: manywheel
-      DESIRED_CUDA: cu134
-      GPU_ARCH_VERSION: "13.4-aarch64"
-      GPU_ARCH_TYPE: cuda-aarch64
-      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinuxaarch64-builder:cuda13.4${{ needs.get-docker-tag.outputs.docker_image_suffix }}
-      SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
-      BUILD_NAME_PREFIX: "manywheel-py"
-      BUILD_NAME_SUFFIX: "-cuda-aarch64-13_4"
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.4.0rc1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu13==9.25.0.15; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
-    steps:
-      - name: Configure git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Checkout PyTorch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is visible to
-          # `git describe --tags --exact`; nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
-          fetch-tags: ${{ github.ref_type == 'tag' }}
-          submodules: recursive
-          show-progress: false
-      - name: Populate binary env
-        shell: bash
-        run: |
-          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
-          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
-          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
-          bash .ci/pytorch/binary_populate_env.sh
-      - name: Build all wheels
-        shell: bash
-        run: |
-          # shellcheck disable=SC1091
-          source "${BINARY_ENV_FILE}"
-          bash .ci/manywheel/build_all.sh
-      # One artifact per built Python -- names must match what the test/upload
-      # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_10-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_11-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_12-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_13-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_14-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_14t-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_15-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda-aarch64-13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_15t-cuda-aarch64-13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda-aarch64-13_4/*
-
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build, manywheel-cuda-aarch64-cu134-build]
+    needs: [get-label-type, get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -625,14 +536,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.10"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_10-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.11"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -664,14 +567,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda-aarch64-13_2"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.11"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_11-cuda-aarch64-13_4"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.12"
             desired_cuda: "cpu"
@@ -705,14 +600,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_12-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.12"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_12-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.13"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -744,14 +631,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_13-cuda-aarch64-13_2"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.13"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_13-cuda-aarch64-13_4"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14"
             desired_cuda: "cpu"
@@ -785,14 +664,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.14t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -824,14 +695,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
-            runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.14t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14t-cuda-aarch64-13_4"
             runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15"
             desired_cuda: "cpu"
@@ -865,14 +728,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
           - desired_python: "3.15t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -905,14 +760,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
             runs_on: "l-arm64g3-16-62"
-          - desired_python: "3.15t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15t-cuda-aarch64-13_4"
-            runs_on: "l-arm64g3-16-62"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel
@@ -938,7 +785,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build, manywheel-cuda-aarch64-cu134-build, manywheel-test]
+    needs: [get-docker-tag, manywheel-cpu-aarch64-build, manywheel-cuda-aarch64-cu126-build, manywheel-cuda-aarch64-cu130-build, manywheel-cuda-aarch64-cu132-build, manywheel-test]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false
@@ -972,13 +819,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda-aarch64-13_2"
-          - desired_python: "3.10"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_10-cuda-aarch64-13_4"
           - desired_python: "3.11"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1007,13 +847,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda-aarch64-13_2"
-          - desired_python: "3.11"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_11-cuda-aarch64-13_4"
           - desired_python: "3.12"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1042,13 +875,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_12-cuda-aarch64-13_2"
-          - desired_python: "3.12"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_12-cuda-aarch64-13_4"
           - desired_python: "3.13"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1077,13 +903,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_13-cuda-aarch64-13_2"
-          - desired_python: "3.13"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_13-cuda-aarch64-13_4"
           - desired_python: "3.14"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1112,13 +931,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14-cuda-aarch64-13_2"
-          - desired_python: "3.14"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14-cuda-aarch64-13_4"
           - desired_python: "3.14t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1147,13 +959,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda-aarch64-13_2"
-          - desired_python: "3.14t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14t-cuda-aarch64-13_4"
           - desired_python: "3.15"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1182,13 +987,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15-cuda-aarch64-13_2"
-          - desired_python: "3.15"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15-cuda-aarch64-13_4"
           - desired_python: "3.15t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1217,13 +1015,6 @@ jobs:
             docker_image: "manylinuxaarch64-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15t-cuda-aarch64-13_2"
-          - desired_python: "3.15t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4-aarch64"
-            gpu_arch_type: "cuda-aarch64"
-            docker_image: "manylinuxaarch64-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15t-cuda-aarch64-13_4"
     with:
       PYTORCH_ROOT: /pytorch
       PACKAGE_TYPE: manywheel

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -496,95 +496,6 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_2/*
 
-  manywheel-cuda-cu134-build:
-    name: manywheel-cuda-cu134-build
-    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag]
-    runs-on: "${{ needs.get-label-type.outputs.label-type }}${{ (github.ref == 'refs/heads/release/2.14' || github.ref == 'refs/heads/nightly' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v')) && 'rel-l-x86iavx512-44-340' || 'l-x86iavx512-48-384' }}"
-    timeout-minutes: 280
-    container:
-      image: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda13.4${{ needs.get-docker-tag.outputs.docker_image_suffix }}
-    env:
-      PYTORCH_ROOT: ${{ github.workspace }}
-      PACKAGE_TYPE: manywheel
-      DESIRED_CUDA: cu134
-      GPU_ARCH_VERSION: "13.4"
-      GPU_ARCH_TYPE: cuda
-      DOCKER_IMAGE: ${{ needs.get-docker-tag.outputs.docker_registry_host }}pytorch/manylinux2_28-builder:cuda13.4${{ needs.get-docker-tag.outputs.docker_image_suffix }}
-      SKIP_ALL_TESTS: 1
-      DESIRED_PYTHONS: "3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t"
-      BUILD_NAME_PREFIX: "manywheel-py"
-      BUILD_NAME_SUFFIX: "-cuda13_4"
-      PYTORCH_EXTRA_INSTALL_REQUIREMENTS: "cuda-toolkit[nvrtc,cudart,cupti,cufft,curand,cusolver,cusparse,cublas,cufile,nvjitlink,nvtx]==13.4.0rc1; platform_system == 'Linux' | cuda-bindings>=13.0.3,<14; platform_system == 'Linux' and python_version < '3.15' | nvidia-cudnn-cu13==9.25.0.15; platform_system == 'Linux' | nvidia-cusparselt-cu13==0.8.1; platform_system == 'Linux' | nvidia-nccl-cu13==2.30.7; platform_system == 'Linux' | nvidia-nvshmem-cu13==3.4.5; platform_system == 'Linux'"
-    steps:
-      - name: Configure git safe directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Checkout PyTorch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          # Full fetch on tag pushes so the release tag is visible to
-          # `git describe --tags --exact`; nightlies stay shallow for speed.
-          fetch-depth: ${{ github.ref_type != 'tag' && 2 || 0 }}
-          fetch-tags: ${{ github.ref_type == 'tag' }}
-          submodules: recursive
-          show-progress: false
-      - name: Populate binary env
-        shell: bash
-        run: |
-          export PYTORCH_FINAL_PACKAGE_DIR="${RUNNER_TEMP}/artifacts"
-          mkdir -p "${PYTORCH_FINAL_PACKAGE_DIR}"
-          echo "PYTORCH_FINAL_PACKAGE_DIR=${PYTORCH_FINAL_PACKAGE_DIR}" >> "${GITHUB_ENV}"
-          bash .ci/pytorch/binary_populate_env.sh
-      - name: Build all wheels
-        shell: bash
-        run: |
-          # shellcheck disable=SC1091
-          source "${BINARY_ENV_FILE}"
-          bash .ci/manywheel/build_all.sh
-      # One artifact per built Python -- names must match what the test/upload
-      # matrix below downloads.
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_10-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_10-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_11-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_11-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_12-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_12-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_13-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_13-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_14-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_14-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_14t-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_14t-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_15-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_15-cuda13_4/*
-      - uses: actions/upload-artifact@v4.4.0
-        with:
-          name: manywheel-py3_15t-cuda13_4
-          if-no-files-found: error
-          path: ${{ runner.temp }}/artifacts/manywheel-py3_15t-cuda13_4/*
-
   manywheel-build:
     name: ${{ matrix.build_name }}-build
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
@@ -834,7 +745,7 @@ jobs:
   manywheel-test:
     name: ${{ matrix.build_name }}-test
     if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
-    needs: [get-label-type, get-docker-tag, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-cuda-cu134-build]
+    needs: [get-label-type, get-docker-tag, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build]
     uses: ./.github/workflows/_binary-test-linux.yml
     strategy:
       fail-fast: false
@@ -872,14 +783,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda13_2"
             runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.10"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_10-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.11"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -911,14 +814,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.11"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_11-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.12"
             desired_cuda: "cpu"
@@ -952,14 +847,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_12-cuda13_2"
             runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.12"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_12-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.13"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -991,14 +878,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_13-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.13"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_13-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14"
             desired_cuda: "cpu"
@@ -1032,14 +911,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14-cuda13_2"
             runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.14t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1071,14 +942,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.14t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14t-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15"
             desired_cuda: "cpu"
@@ -1112,14 +975,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15-cuda13_2"
             runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15-cuda13_4"
-            runs_on: "l-x86iavx512-29-115-t4"
           - desired_python: "3.15t"
             desired_cuda: "cpu"
             gpu_arch_version: ""
@@ -1151,14 +1006,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15t-cuda13_2"
-            runs_on: "l-x86iavx512-29-115-t4"
-          - desired_python: "3.15t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15t-cuda13_4"
             runs_on: "l-x86iavx512-29-115-t4"
     with:
       PYTORCH_ROOT: /pytorch
@@ -1388,7 +1235,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: [get-docker-tag, manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-cuda-cu134-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
+    needs: [get-docker-tag, manywheel-build, manywheel-cpu-build, manywheel-cuda-cu126-build, manywheel-cuda-cu130-build, manywheel-cuda-cu132-build, manywheel-test, manywheel-test-rocm, manywheel-test-xpu]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false
@@ -1422,13 +1269,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_10-cuda13_2"
-          - desired_python: "3.10"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_10-cuda13_4"
           - desired_python: "3.10"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1479,13 +1319,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_11-cuda13_2"
           - desired_python: "3.11"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_11-cuda13_4"
-          - desired_python: "3.11"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
             gpu_arch_type: "rocm"
@@ -1534,13 +1367,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_12-cuda13_2"
-          - desired_python: "3.12"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_12-cuda13_4"
           - desired_python: "3.12"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1591,13 +1417,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_13-cuda13_2"
           - desired_python: "3.13"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_13-cuda13_4"
-          - desired_python: "3.13"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
             gpu_arch_type: "rocm"
@@ -1646,13 +1465,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14-cuda13_2"
-          - desired_python: "3.14"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14-cuda13_4"
           - desired_python: "3.14"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1703,13 +1515,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_14t-cuda13_2"
           - desired_python: "3.14t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_14t-cuda13_4"
-          - desired_python: "3.14t"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
             gpu_arch_type: "rocm"
@@ -1759,13 +1564,6 @@ jobs:
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15-cuda13_2"
           - desired_python: "3.15"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15-cuda13_4"
-          - desired_python: "3.15"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
             gpu_arch_type: "rocm"
@@ -1814,13 +1612,6 @@ jobs:
             docker_image: "manylinux2_28-builder"
             docker_image_tag_prefix: "cuda13.2"
             build_name: "manywheel-py3_15t-cuda13_2"
-          - desired_python: "3.15t"
-            desired_cuda: "cu134"
-            gpu_arch_version: "13.4"
-            gpu_arch_type: "cuda"
-            docker_image: "manylinux2_28-builder"
-            docker_image_tag_prefix: "cuda13.4"
-            build_name: "manywheel-py3_15t-cuda13_4"
           - desired_python: "3.15t"
             desired_cuda: "rocm7.2"
             gpu_arch_version: "7.2"
@@ -1906,15 +1697,6 @@ jobs:
             build_name: "libtorch-cuda13_2-shared-with-deps-release"
             container_image: "manylinux2_28-builder"
             container_image_tag_prefix: "cuda13.2"
-          - desired_cuda: "cu134"
-            gpu_arch_type: "cuda"
-            gpu_arch_version: "13.4"
-            libtorch_variant: "shared-with-deps"
-            libtorch_config: "release"
-            source_wheel_build_name: "manywheel-py3_10-cuda13_4"
-            build_name: "libtorch-cuda13_4-shared-with-deps-release"
-            container_image: "manylinux2_28-builder"
-            container_image_tag_prefix: "cuda13.4"
           - desired_cuda: "rocm7.2"
             gpu_arch_type: "rocm"
             gpu_arch_version: "7.2"
@@ -2011,12 +1793,6 @@ jobs:
             libtorch_variant: "shared-with-deps"
             libtorch_config: "release"
             build_name: "libtorch-cuda13_2-shared-with-deps-release"
-          - desired_cuda: "cu134"
-            gpu_arch_type: "cuda"
-            gpu_arch_version: "13.4"
-            libtorch_variant: "shared-with-deps"
-            libtorch_config: "release"
-            build_name: "libtorch-cuda13_4-shared-with-deps-release"
           - desired_cuda: "rocm7.2"
             gpu_arch_type: "rocm"
             gpu_arch_version: "7.2"


### PR DESCRIPTION
## Summary

CUDA 13.4 is not shipping in the 2.14 release, so `release/2.14` should not be building it. This removes 13.4 from the binary build matrix and from the builder images that exist only to serve those builds.

**This targets `release/2.14` only.** The companion change is pytorch/test-infra#8601, which drops 13.4 from the test-infra build matrix on the same branch.

## Changes

### `.github/scripts/generate_binary_build_matrix.py`

| Constant | Change |
|---|---|
| `CUDA_ARCHES` | drop `13.4` |
| `CUDA_ARCHES_CUDNN_VERSION` | drop the `13.4` entry |
| `CUDA_AARCH64_ARCHES` | drop `13.4-aarch64` |
| `CUDA_ARCHES_NO_WINDOWS` | now empty — `13.4` was its only member |
| `PYTORCH_EXTRA_INSTALL_REQUIREMENTS` | drop the `13.4` block (pinned `cuda-toolkit==13.4.0rc1`, `nvidia-cudnn-cu13==9.25.0.15`) |
| `generate_wheels_matrix` | drop `13.4` from the `arch_version` list |

Also reworded the `CUDA_ARCHES_FULL_VERSION` comment, which existed to explain why 13.4 was deliberately absent from that dict — no longer meaningful.

### Regenerated workflows (`.github/regenerate.sh`)

Exactly one job removed per file, verified by parsing both versions and diffing the job sets:

| File | Job removed | jobs |
|---|---|---|
| `generated-linux-binary-manywheel-nightly.yml` | `manywheel-cuda-cu134-build` | 14 → 13 |
| `generated-linux-aarch64-binary-manywheel-nightly.yml` | `manywheel-cuda-aarch64-cu134-build` | 9 → 8 |

**Zero non-13.4 job removals, zero job additions.** The only added lines are four `needs:` lists that no longer reference the deleted `cu134` jobs.

### Builder images

These existed only to feed the removed binary builds:

- `build-manywheel-images.yml` — drop the `cuda13.4` rows for `manylinux2_28-builder` and `manylinuxaarch64-builder`
- `build-almalinux-images.yml` — drop `cuda13.4` from the tag matrix

## Deliberately out of scope

`periodic.yml` and `docker-builds.yml` still build and test `linux-jammy-cuda13.4-py3.10-gcc11`. Those are CI test lanes rather than release build artifacts, so I did not touch them — but they are the remaining 13.4 references on this branch, and removing them is a reasonable follow-up if you want the branch fully clear of 13.4. Happy to fold that in here instead if you prefer.

Note `generated-macos-arm64-binary-wheel-nightly.yml` still matches a grep for `13.4` — that is `setup_python_version: "3.13.4"`, unrelated.

## Test Plan

- `python3 .github/scripts/generate_ci_workflows.py` (via `.github/regenerate.sh`) — re-running after the change produces no further diff, so the checked-in generated files are in sync with the generator.
- Parsed the before/after YAML for both regenerated workflows and compared job-key sets to confirm only the `cu134` jobs disappeared.
- `yaml.safe_load` on both hand-edited image workflows to confirm they still parse.

## Test Result

Generator is idempotent; job-set diff is exactly the two `cu134` build jobs; both edited image workflows parse cleanly.
