### PR TITLE
Fix symbolic FakeTensor support for shift out overloads

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_TORCHDYNAMO,
     run_tests,
     parametrize,
+    instantiate_parametrized_tests,
     xfailIfTorchDynamo,
     skipIfXpu,
 )
@@ -2286,7 +2287,45 @@ class TestMetaKernelConv(TestCase):
 
 
 
+@instantiate_parametrized_tests
 class TestMetaKernelRegistrations(TestCase):
+    @parametrize("shift", ["lshift", "rshift"])
+    @parametrize("other_kind", ["Scalar", "Tensor"])
+    def test_shift_out_symbolic_fake_tensor(self, shift, other_kind):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        op_packet = getattr(torch.ops.aten, f"__{shift}__")
+        functional = getattr(op_packet, other_kind)
+        out_op = getattr(op_packet, f"{other_kind}_out")
+        with FakeTensorMode(shape_env=shape_env):
+            size = shape_env.create_unbacked_symint()
+            inp = torch.empty(size, dtype=torch.int32)
+            out = torch.empty(size, dtype=torch.int32)
+            other = 16 if other_kind == "Scalar" else torch.empty(size, dtype=torch.int32)
+            functional_result = functional(inp, other)
+            result = out_op(inp, other, out=out)
+
+        self.assertIs(result, out)
+        self.assertEqual(result.shape, functional_result.shape)
+        self.assertEqual(result.stride(), functional_result.stride())
+        self.assertEqual(result.dtype, functional_result.dtype)
+        self.assertEqual(result.layout, functional_result.layout)
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    @parametrize("shift", ["lshift", "rshift"])
+    @parametrize("other_kind", ["Scalar", "Tensor"])
+    def test_shift_out_dtype_mismatch(self, shift, other_kind):
+        op_packet = getattr(torch.ops.aten, f"__{shift}__")
+        op = getattr(op_packet, f"{other_kind}_out")
+        inp = torch.empty(3, dtype=torch.int32, device="meta")
+        out = torch.empty(0, dtype=torch.float32, device="meta")
+        other = 1 if other_kind == "Scalar" else torch.empty(3, dtype=torch.int32, device="meta")
+
+        with self.assertRaisesRegex(RuntimeError, "Expected out tensor to have dtype"):
+            op(inp, other, out=out)
+
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
     def test_aminmax_out_dtype_mismatch(self):
         inp = torch.rand(10, 10, device="meta")

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -4829,7 +4829,15 @@ def shift_dtype_check(fn_name, self, val):
         )
 
 
-@register_meta([aten.__rshift__.Tensor, aten.__rshift__.Scalar])
+@register_meta(
+    [
+        aten.__rshift__.Tensor,
+        aten.__rshift__.Scalar,
+        aten.__rshift__.Scalar_out,
+        aten.__rshift__.Tensor_out,
+    ]
+)
+@out_wrapper(exact_dtype=True)
 def meta_rshifts(self, other):
     shift_dtype_check("rshift", self, other)
     return elementwise_meta(
@@ -4837,7 +4845,15 @@ def meta_rshifts(self, other):
     )
 
 
-@register_meta([aten.__lshift__.Tensor, aten.__lshift__.Scalar])
+@register_meta(
+    [
+        aten.__lshift__.Tensor,
+        aten.__lshift__.Scalar,
+        aten.__lshift__.Scalar_out,
+        aten.__lshift__.Tensor_out,
+    ]
+)
+@out_wrapper(exact_dtype=True)
 def meta_lshifts(self, other):
     shift_dtype_check("lshift", self, other)
     return elementwise_meta(


### PR DESCRIPTION
## Problem

The functional shift operators had Python Meta implementations, but their autogenerated `out=` overloads did not. This breaks Inductor eager-backend lowering when a functional shift is rewritten to its out= overload: symbolic FakeTensor propagation fails before generated code can run.

The autogenerated composite `out=` kernel in `torchgen/native_function_generation.py` calls `resize_out_helper -> at::native::resize_output(dst, src.sizes())`, and `sizes()` throws when called on a tensor with symbolic sizes.

## Fix

Register Python Meta implementations for the `__lshift__` and `__rshift__` `Scalar_out` and `Tensor_out` overloads, reusing the existing shift metadata logic and out_wrapper(exact_dtype=True). This preserves the native CPU/CUDA implementations while enabling symbolic metadata propagation and matching the native output-dtype contract. Regression tests cover symbolic left/right shifts with scalar and tensor operands, as well as dtype validation.

## Test Plan

```    
    ./.venv/bin/python test/test_meta.py -k shift_out
    ./.venv/bin/python test/test_decomp.py HasDecompTest.test_has_decomposition
```

Both tests passed. `spin quicklint` could not initialize lintrunner because `uvx lintrunner@0.12.7` init failed.

## AI disclosure

This commit was authored with assistance from an AI assistant.