### PR TITLE
Remove NJT (nested jagged tensor) from weights_only safe globals

### DIFF
--- a/test/test_nestedtensor.py
+++ b/test/test_nestedtensor.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: nestedtensor"]
 # ruff: noqa: F841
 import ast
+import contextlib
 import io
 import itertools
 import math
@@ -19,6 +20,7 @@ import torch._dynamo.testing
 import torch.nn
 import torch.nn.functional as F
 from torch.nested._internal.nested_tensor import (
+    _rebuild_njt,
     buffer_from_jagged,
     jagged_from_list,
     nested_view_from_values_offsets,
@@ -957,6 +959,7 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
         self.assertEqual(a.grad, torch.ones(2, 4, device=device, dtype=dtype))
         self.assertEqual(b.grad, torch.ones(5, 4, device=device, dtype=dtype))
 
+    @serialTest()
     @dtypes(torch.float, torch.double, torch.half)
     @parametrize("requires_grad", [False, True])
     @parametrize("weights_only", [False, True])
@@ -969,12 +972,20 @@ class TestNestedTensorDeviceType(NestedTensorTestCase):
                 nt2._nested_tensor_storage_offsets(),
             )
 
+        # Strided nested tensors are not allowlisted for weights_only load by
+        # default and must be opted into via safe_globals.
+        load_ctx = (
+            torch.serialization.safe_globals([torch._utils._rebuild_nested_tensor])
+            if weights_only
+            else contextlib.nullcontext()
+        )
         nt_contiguous, nt_noncontiguous = random_nt_noncontiguous_pair((2, 3, 6, 7))
         for a in [nt_contiguous, nt_noncontiguous]:
             buffer = io.BytesIO()
             serialized = torch.save(a, buffer)
             buffer.seek(0)
-            b = torch.load(buffer, weights_only=weights_only)
+            with load_ctx:
+                b = torch.load(buffer, weights_only=weights_only)
             # should be both conceptually equal and metadata equivalent
             self.assertEqual(a, b)
             compare_metadata(a, b)
@@ -4055,6 +4066,7 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
 
         return example_lists
 
+    @serialTest()
     @dtypes(torch.float32)
     @parametrize(
         "contiguity",
@@ -4096,10 +4108,18 @@ class TestNestedTensorSubclass(NestedTensorTestCase):
         nt.size()
         nt.stride()
 
+        # NJTs are not allowlisted for weights_only load by default and must be
+        # opted into via safe_globals.
+        load_ctx = (
+            torch.serialization.safe_globals([_rebuild_njt, NestedTensor])
+            if weights_only
+            else contextlib.nullcontext()
+        )
         with tempfile.TemporaryFile() as f:
             torch.save(nt, f)
             f.seek(0)
-            nt_loaded = torch.load(f, weights_only=weights_only)
+            with load_ctx:
+                nt_loaded = torch.load(f, weights_only=weights_only)
 
             self.assertIsNot(nt, nt_loaded)
             # we expect a new offsets tensor -> different nested int upon load

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4544,10 +4544,32 @@ class TestSerialization(TestCase, SerializationMixin):
             filename = pathlib.Path(filename)
             import_string = "import torch._dynamo;" if should_import else ""
             err_msg = (
-                "_pickle.UnpicklingError: Weights only load failed. ``torch.nested`` and ``torch._dynamo``"
-                " must be imported to load nested jagged tensors (NJTs)"
-            ) if not should_import else None
+                "Unsupported global: GLOBAL torch.nested._internal.nested_tensor._rebuild_njt"
+                " was not an allowed global by default"
+            )
             self._attempt_load_from_subprocess(filename, import_string, err_msg)
+
+    @serialTest()
+    def test_load_njt_weights_only_safe_globals(self):
+        from torch.nested._internal.nested_tensor import _rebuild_njt, NestedTensor
+        njt = torch.nested.nested_tensor([[1, 2, 3], [4, 5]], layout=torch.jagged)
+        with BytesIOContext() as f:
+            torch.save(njt, f)
+            f.seek(0)
+            with self.assertRaisesRegex(
+                pickle.UnpicklingError,
+                "Unsupported global: GLOBAL torch.nested._internal.nested_tensor._rebuild_njt",
+            ):
+                torch.load(f, weights_only=True)
+            f.seek(0)
+            with torch.serialization.safe_globals([_rebuild_njt, NestedTensor]):
+                loaded = torch.load(f, weights_only=True)
+            self.assertEqual(type(loaded), NestedTensor)
+            self.assertEqual(loaded.values(), njt.values())
+            self.assertEqual(loaded.offsets(), njt.offsets())
+            # safe_globals is a context manager, so the allowlisted globals are removed on exit
+            self.assertNotIn(_rebuild_njt, torch.serialization.get_safe_globals())
+            self.assertNotIn(NestedTensor, torch.serialization.get_safe_globals())
 
     @parametrize("dtype", all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
     @parametrize("weights_only", [True, False])

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -157,7 +157,6 @@ def _tensor_rebuild_functions():
         torch._utils._rebuild_tensor_v3,
         torch._utils._rebuild_sparse_tensor,
         torch._utils._rebuild_meta_tensor_no_storage,
-        torch._utils._rebuild_nested_tensor,
         torch._utils._rebuild_wrapper_subclass,
         # Allowlisting this, but not allowlisting the numpy functions by default
         # Reasoning is that we don't have control over the numpy functions, but
@@ -339,16 +338,6 @@ class Unpickler:
                     self.append(_get_allowed_globals()[full_path])
                 elif full_path in _get_user_allowed_globals():
                     self.append(_get_user_allowed_globals()[full_path])
-                elif full_path in (
-                    [
-                        "torch.nested._internal.nested_tensor.NestedTensor",
-                        "torch.nested._internal.nested_tensor._rebuild_njt",
-                        "torch._dynamo.decorators._DimRange",
-                    ]
-                ):
-                    raise UnpicklingError(
-                        "``torch.nested`` and ``torch._dynamo`` must be imported to load nested jagged tensors (NJTs)"
-                    )
                 elif full_path in (
                     [
                         "torch.distributed.device_mesh.DeviceMesh",

--- a/torch/nested/__init__.py
+++ b/torch/nested/__init__.py
@@ -17,12 +17,6 @@ __all__ = [
     "masked_select",
 ]
 
-# Allowlist these for weights_only load of NJT
-from ._internal.nested_tensor import _rebuild_njt, NestedTensor as _NestedTensor
-
-
-torch.serialization.add_safe_globals([_NestedTensor, _rebuild_njt])
-
 
 def as_nested_tensor(
     ts: Tensor | list[Tensor] | tuple[Tensor, ...],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #194380

NestedTensors are no longer allowlisted by default for `weights_only` loads, and `torch.nested` no longer registers them via `add_safe_globals` on import. Loading a checkpoint containing an NJT now raises the generic unsupported-global error.

NJTs can still be loaded by explicitly opting in with the `safe_globals` context manager:
```python
from torch.nested._internal.nested_tensor import _rebuild_njt, NestedTensor
with torch.serialization.safe_globals([_rebuild_njt, NestedTensor]):
    njt = torch.load(path, weights_only=True)
```

Authored with assistance from Claude (Anthropic AI assistant).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>