### PR TITLE
[CUDA] Remove unused multinomial probability copy

### DIFF
--- a/aten/src/ATen/native/cuda/MultinomialKernel.cu
+++ b/aten/src/ATen/native/cuda/MultinomialKernel.cu
@@ -382,17 +382,6 @@ void multinomial_with_replacement_kernel_impl(
     } else {
       // Generic, slow implementation with memory allocations
 
-      // For sampling without replacement, we modify the distribution
-      // for subsequent samples in this space
-      Tensor origDist = native::empty_like(
-          self_v,
-          std::nullopt /* dtype */,
-          std::nullopt /* layout */,
-          std::nullopt /* device */,
-          std::nullopt /* pin_memory */,
-          LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-      origDist.copy_(self_v);
-
       Tensor normDist = native::empty_like(
           self_v,
           std::nullopt /* dtype */,
@@ -410,7 +399,7 @@ void multinomial_with_replacement_kernel_impl(
           LEGACY_CONTIGUOUS_MEMORY_FORMAT);
 
       // Renorm along rows
-      normDist.copy_(origDist);
+      normDist.copy_(self_v);
       renormRows(normDist);
 
       // Prefix sum along rows


### PR DESCRIPTION
## Issue

Fixes #192594

## Summary

Remove the unused `origDist` allocation and copy in the CUDA multinomial path.

The without-replacement CUDA path was removed previously, but the related
`origDist` handling remained. This change initializes `normDist` directly
from `self_v`, avoiding an unnecessary input-sized allocation and
device-to-device copy.

No sampling behavior is changed.

## Benchmark

Environment:
- GPU: NVIDIA A10
- CUDA: 12.8
- Build: Release
- Architecture: sm_86

Configuration:
- Shape: `[256, 65536]`
- dtype: `float32`
- num_samples: `2`
- replacement: `True`

Before:
- Extra allocated memory: 192.00 MiB
- CUDA time: 1.3274 ms
- Wall time: 1.3277 ms

After:
- Extra allocated memory: 128.00 MiB
- CUDA time: 1.0525 ms
- Wall time: 1.0527 ms

## Test Plan

- `lintrunner -a aten/src/ATen/native/cuda/MultinomialKernel.cu`
- `git diff --check`
- `python test/test_torch.py -k multinomial`
- `python test/test_cuda.py -k multinomial`

## Checklist

- [x] Passes lint
- [x] Existing multinomial tests pass
- [x] Benchmark results included

## BC-breaking?

No.
