### PR TITLE
[MPS] Add regression test for source-offset dtype-converting D2H copy (#194344)

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -8114,6 +8114,24 @@ class TestMPS(TestCaseMPS):
         self.assertEqual(output, input_cpu[src_offset:].to(dst_dtype))
         self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/194344
+    @parametrize("src_dtype,dst_dtype", [
+        (torch.half, torch.float),
+        (torch.bfloat16, torch.float),
+        (torch.float, torch.half),
+        (torch.short, torch.int),
+    ])
+    @parametrize("src_offset", [1, 2, 64, 256, 4096, 65536])
+    def test_cast_mps_to_cpu_source_offset(self, src_dtype, dst_dtype, src_offset):
+        input_cpu = torch.randn(1 << 20).to(src_dtype)
+        input_mps = input_cpu.to("mps")
+        expected = input_cpu[src_offset:src_offset + 64].to(dst_dtype)
+
+        fused = input_mps[src_offset:src_offset + 64].to("cpu", dst_dtype)
+
+        self.assertEqual(fused, expected)
+        self.assertTrue(torch.equal(input_mps.cpu(), input_cpu))
+
     def test_cast_mps_to_cpu_preserves_transposed_layout(self):
         input_cpu = torch.arange(12, dtype=torch.float).reshape(3, 4).t()
         input_mps = input_cpu.to("mps")


### PR DESCRIPTION
Fixes: none (test-only; the bug itself is already fixed on main via #184740/#189572/#189966).

This PR adds a regression test for #194344: a dtype-converting MPS->CPU copy read from the wrong source address when the MPS source view had a nonzero storage_offset(), silently returning garbage (misaligned bit reinterpretations, wrong-offset data, or zeros) with no error raised.

The existing tests added alongside #189572/#189966 cover the destination-offset (test_cast_mps_to_cpu_preserves_source) and equal-strided non-dense (test_copy_equal_strided_non_dense_mps_to_cpu) facets of the D2H copy-cast rework, but neither exercises a *source* offset large enough to hit the zero-fill path described in the issue(>= 256 elements). This test fills that gap using the exact offsets from the issue's repro (1, 2, 64, 256, 4096, 65536) across the dtype
pairs called out as affected (fp16->fp32, bf16->fp32, fp32->fp16, int16->int32).

Test Plan:
python test/test_mps.py TestMPS.test_cast_mps_to_cpu_source_offset

(run on macOS/Apple Silicon; confirmed the test's structure mirrors the adjacent test_cast_mps_to_cpu_preserves_source added for #189563)
