### PR TITLE
Document release gating requirements for accelerator versions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -462,23 +462,18 @@ For accelerator software like CUDA, ROCm and XPU we will typically use the follo
 
 ### Release gating requirements for accelerator versions
 
-These requirements apply to every accelerator we publish binaries for -- CUDA, ROCm, XPU and any backend added later. They generalize the CUDA policy in
-[RFC-0039](https://github.com/pytorch/rfcs/blob/master/RFC-0039-cuda-support.md#release-gating-principles), which also documents the CUDA-specific process.
+These apply to every accelerator we publish binaries for -- CUDA, ROCm, XPU and any backend added later. They generalize the CUDA policy in
+[RFC-0039](https://github.com/pytorch/rfcs/blob/master/RFC-0039-cuda-support.md#release-gating-principles).
 
-1. **We do not release anything that is not tested in CI.** An accelerator version qualifies for a release -- including as an Experimental version -- only once it has
-   build *and* test jobs running in CI, with all failures identified, tracked in issues, and either fixed or explicitly accepted before branch cut. Presence in the
-   nightly build matrix (CD) alone does not qualify a version: CD shows that it builds, CI shows that it works. A version that is only built and never tested is not
-   eligible for the release matrix.
-2. **We do not cut an RC for anything we are not planning to promote.** The release matrix is fixed before the release branch is cut, and only the versions in that
-   matrix are built in the RC. An RC binary is a promise to ship; if we would not promote it to the final release, we do not build it in the RC.
-3. **Promotion from Experimental to Stable requires more than CI passing.** The full CI and CD matrix has to be running on the version and green over a sustained
-   period, benchmarks must show no unresolved regressions against the current Stable version, and the domain libraries and other downstream consumers must have built
-   and tested against it and confirmed they can switch. Promotion is what makes a version the one we publish to PyPI.
-4. **We stop shipping before we stop testing.** When support for a version is removed, CD support is dropped first and CI support second, so a published version is
-   never left without test coverage.
+1. **We do not release anything that is not tested in CI.** A version qualifies for a release, including as Experimental, only once it has build *and* test jobs in CI,
+   with failures tracked and either fixed or explicitly accepted before branch cut. CD shows that a version builds; CI shows that it works. A version present only in
+   the nightly build matrix is not eligible for the release matrix.
+2. **We do not cut an RC for anything we are not planning to promote.** The release matrix is fixed before branch cut, and only those versions are built in the RC.
+3. **Promotion from Experimental to Stable needs more than green CI.** The full CI and CD matrix must be running and stable, benchmarks must show no unresolved
+   regressions against the current Stable version, and downstream consumers must have tested the version and be ready to switch.
+4. **We stop shipping before we stop testing.** On deprecation, CD support is dropped first and CI second.
 
-Enablement of a new version runs CD first and then CI, per platform rather than globally -- for example CD Linux followed by CI Linux, CD Windows followed by CI
-Windows -- with platforms progressing in parallel. A platform whose CD is still broken does not hold back CI enablement on a platform whose CD is already green.
+Enablement runs CD then CI per platform rather than globally, with platforms progressing in parallel.
 
 ### Special support cases
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,6 +36,7 @@
 - [Hardware / Software Support in Binary Build Matrix](#hardware--software-support-in-binary-build-matrix)
   - [Python](#python)
   - [Accelerator Software](#accelerator-software)
+    - [Release gating requirements for accelerator versions](#release-gating-requirements-for-accelerator-versions)
     - [Special support cases](#special-support-cases)
   - [Operating Systems](#operating-systems)
 - [Submitting Tutorials](#submitting-tutorials)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -471,9 +471,6 @@ These apply to every accelerator we publish binaries for -- CUDA, ROCm, XPU and 
 2. **We do not cut an RC for anything we are not planning to promote.** The release matrix is fixed before branch cut, and only those versions are built in the RC.
 3. **Promotion from Experimental to Stable needs more than green CI.** The full CI and CD matrix must be running and stable, benchmarks must show no unresolved
    regressions against the current Stable version, and downstream consumers must have tested the version and be ready to switch.
-4. **We stop shipping before we stop testing.** On deprecation, CD support is dropped first and CI second.
-
-Enablement runs CD then CI per platform rather than globally, with platforms progressing in parallel.
 
 ### Special support cases
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -457,8 +457,28 @@ See https://github.com/pytorch/rfcs/blob/master/RFC-0038-cpython-support.md for 
 
 ## Accelerator Software
 
-For accelerator software like CUDA and ROCm we will typically use the following criteria:
+For accelerator software like CUDA, ROCm and XPU we will typically use the following criteria:
 * Support latest 2 minor versions
+
+### Release gating requirements for accelerator versions
+
+These requirements apply to every accelerator we publish binaries for -- CUDA, ROCm, XPU and any backend added later. They generalize the CUDA policy in
+[RFC-0039](https://github.com/pytorch/rfcs/blob/master/RFC-0039-cuda-support.md#release-gating-principles), which also documents the CUDA-specific process.
+
+1. **We do not release anything that is not tested in CI.** An accelerator version qualifies for a release -- including as an Experimental version -- only once it has
+   build *and* test jobs running in CI, with all failures identified, tracked in issues, and either fixed or explicitly accepted before branch cut. Presence in the
+   nightly build matrix (CD) alone does not qualify a version: CD shows that it builds, CI shows that it works. A version that is only built and never tested is not
+   eligible for the release matrix.
+2. **We do not cut an RC for anything we are not planning to promote.** The release matrix is fixed before the release branch is cut, and only the versions in that
+   matrix are built in the RC. An RC binary is a promise to ship; if we would not promote it to the final release, we do not build it in the RC.
+3. **Promotion from Experimental to Stable requires more than CI passing.** The full CI and CD matrix has to be running on the version and green over a sustained
+   period, benchmarks must show no unresolved regressions against the current Stable version, and the domain libraries and other downstream consumers must have built
+   and tested against it and confirmed they can switch. Promotion is what makes a version the one we publish to PyPI.
+4. **We stop shipping before we stop testing.** When support for a version is removed, CD support is dropped first and CI support second, so a published version is
+   never left without test coverage.
+
+Enablement of a new version runs CD first and then CI, per platform rather than globally -- for example CD Linux followed by CI Linux, CD Windows followed by CI
+Windows -- with platforms progressing in parallel. A platform whose CD is still broken does not hold back CI enablement on a platform whose CD is already green.
 
 ### Special support cases
 


### PR DESCRIPTION
Adds a `Release gating requirements for accelerator versions` subsection under `Hardware / Software Support in Binary Build Matrix` -> `Accelerator Software`.

## Why

[RFC-0039](https://github.com/pytorch/rfcs/blob/master/RFC-0039-cuda-support.md#release-gating-principles) states the release gating principles, but only for CUDA and only in the RFC repo. The same rules apply to every accelerator we publish binaries for, and RELEASE.md is where release mechanics are documented, so the requirements belong here too. This mirrors how the `Python` section links out to RFC-0038 for the CPython policy.

The headline requirement, and the reason for the section: **CI coverage is what qualifies an accelerator version for a release.** Being present in the nightly build matrix is not sufficient. CD shows that a version builds; CI shows that it works. A version that is only ever built and never tested is not eligible for the release matrix, in any accelerator.

## What it says

Four numbered requirements, written for CUDA, ROCm, XPU and any backend added later:

1. We do not release anything that is not tested in CI -- build **and** test jobs, failures tracked and either fixed or explicitly accepted before branch cut.
2. We do not cut an RC for anything we are not planning to promote -- the release matrix is fixed before branch cut and only those versions are built in the RC.
3. Promotion from Experimental to Stable requires more than CI passing -- full CI/CD matrix green over a sustained period, no unresolved benchmark regressions against current Stable, and downstream consumers built, tested and ready to switch.
4. We stop shipping before we stop testing -- on deprecation, CD support is dropped first and CI second, so a published version is never left untested.

Plus a note that enablement is sequenced CD then CI **per platform**, not globally, with platforms progressing in parallel.

The intro line of the section is also updated from "CUDA and ROCm" to "CUDA, ROCm and XPU", since XPU has been in the build matrix for several releases.
