### PR TITLE
Fail binary upload when the artifact is missing on a real publish run

### DIFF
--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -116,9 +116,10 @@ jobs:
 
       - name: Download Build Artifacts
         id: download-artifacts
-        # NB: When the previous build job is skipped, there won't be any artifacts and
-        # this step will fail. Binary build jobs can only be skipped on CI, not nightly
-        continue-on-error: true
+        # A skipped build job on a ciflow run legitimately leaves no artifact, so
+        # tolerate that. On nightly/release-tag pushes the artifact always exists,
+        # and swallowing its absence makes "Upload binaries" a silent no-op.
+        continue-on-error: ${{ !(github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')))) }}
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: ${{ inputs.build_name }}


### PR DESCRIPTION
**Impact:** binary/nightly/release-tag upload jobs
**Risk:** medium

## What
Make the "Download Build Artifacts" step in `_binary-upload.yml` tolerant of a missing artifact only on runs that would never publish (ciflow tags, workflow_dispatch, PRs). On nightly-branch and release-tag pushes the step now fails when the artifact is absent, reusing the exact condition that already gates `DRY_RUN=disabled` further down.

## Why
`continue-on-error: true` was unconditional, and "Upload binaries" is gated on the download step's outcome. When a build job is skipped, the download finds no artifact, the step swallows the failure, and the upload reports success having uploaded nothing. That silent no-op hid a multi-week gap in Linux libtorch nightly publishing without anything going red. Scoping the tolerance to non-publishing runs restores a real failure signal on the runs where the upload is supposed to be real, while ciflow/PR builds keep today's behavior where a build leg can legitimately be skipped.

# Notes
- This does not fix the underlying skipped `libtorch-extract` job; that is a separate change which should land first, otherwise the libtorch upload legs will turn red on the next nightly.
- `continue-on-error` is typed as bool by actionlint, so a mistyped expression fails lint rather than silently evaluating truthy.