### PR TITLE
[Inductor][Triton] Add opt-in auxiliary writes (#194406)

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -11,7 +11,7 @@ import sympy
 
 import torch
 import torch._inductor.config as inductor_config
-from torch._inductor import ir
+from torch._inductor import dependencies, ir
 from torch._inductor.choices import InductorChoices
 from torch._inductor.codegen import triton_utils
 from torch._inductor.codegen.common import ArgName, CSEVariable, SizeArg, TensorArg
@@ -31,6 +31,7 @@ from torch._inductor.codegen.triton import (
 from torch._inductor.codegen.wrapper import _escape_triton_kernel_source_for_wrapper
 from torch._inductor.dtype_propagation import DtypePropagationOpsHandler, promote_types
 from torch._inductor.graph import GraphLowering
+from torch._inductor.loop_body import LoopBody
 from torch._inductor.runtime.hints import DeviceProperties
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import (
@@ -38,7 +39,7 @@ from torch._inductor.utils import (
     run_and_get_code,
     run_and_get_kernels,
 )
-from torch._inductor.virtualized import V
+from torch._inductor.virtualized import ops, V
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,
@@ -152,6 +153,184 @@ class TestCodegenTriton(InductorTestCase):
                 )
             finally:
                 kernel.range_trees = saved_range_trees
+
+    def test_auxiliary_write_region(self):
+        auxiliary_index = sympy.Symbol(
+            "auxiliary_index", integer=True, nonnegative=True
+        )
+        write = ir.AuxiliaryWriteRegion(
+            numel=sympy.Integer(1024),
+            index_var=auxiliary_index,
+            output_index=2 * auxiliary_index,
+            predicate=sympy.And(auxiliary_index >= 512, auxiliary_index < 768),
+            value=127,
+        )
+        or_write = ir.AuxiliaryWriteRegion(
+            numel=sympy.Integer(1024),
+            index_var=auxiliary_index,
+            output_index=2 * auxiliary_index + 1,
+            predicate=sympy.Or(auxiliary_index < 128, auxiliary_index >= 896),
+            value=0,
+        )
+        (iter_vars, reduce_vars), var_ranges = dependencies.index_vars_no_squeeze(
+            [sympy.Integer(4)], [], prefix="d"
+        )
+        body = LoopBody(
+            lambda index: None,
+            (iter_vars,),
+            var_ranges,
+            iter_vars,
+            reduce_vars,
+            auxiliary_writes=(("buf0", write),),
+        )
+        copied_body = LoopBody(
+            body,
+            (iter_vars, reduce_vars),
+            var_ranges,
+            iter_vars,
+            reduce_vars,
+            allow_same_symbol_in_index=True,
+        )
+        self.assertEqual(copied_body.auxiliary_writes, (("buf0", write),))
+
+        with V.set_kernel_handler(SimpleNamespace()):
+            with self.assertRaisesRegex(
+                AssertionError,
+                "backend does not support auxiliary write regions",
+            ):
+                body([sympy.Integer(0)])
+
+        calls = []
+        kernel_handler = SimpleNamespace(
+            codegen_auxiliary_write=lambda output_name, region: calls.append(
+                (output_name, region)
+            )
+        )
+        with (
+            inductor_config.patch("triton.enable_fuse_auxiliary_writes", False),
+            V.set_kernel_handler(kernel_handler),
+        ):
+            body([sympy.Integer(0)])
+        self.assertEqual(calls, [("buf0", write)])
+
+        kernel = TritonKernel(
+            {"x": sympy.Integer(4)},
+            features=SIMDKernelFeatures([], sympy.Integer(4), sympy.Integer(1)),
+            override_persistent_reduction=False,
+            override_cooperative_reduction=False,
+        )
+        self.assertFalse(hasattr(kernel, "auxiliary_store"))
+        with patch.object(
+            kernel.args,
+            "output",
+            side_effect=lambda name: {
+                "buf0": "out_ptr0",
+                "buf1": "out_ptr1",
+            }[name],
+        ):
+            kernel.codegen_auxiliary_write("buf0", write)
+            kernel.codegen_auxiliary_write("buf0", write)
+            kernel.codegen_auxiliary_write("buf1", or_write)
+
+        code = kernel.auxiliary_store.getvalue()
+        self.assertEqual(code.count("for auxiliary_offset_"), 2)
+        self.assertEqual(code.count("tl.store(out_ptr0"), 1)
+        self.assertEqual(code.count("tl.store(out_ptr1"), 1)
+        self.assertIn(" & ", code)
+        self.assertIn(" | ", code)
+        for line in code.splitlines():
+            if "tl.store" in line:
+                self.assertNotIn(" and ", line)
+                self.assertNotIn(" or ", line)
+        self.assertIn("127", code)
+
+    @inductor_config.patch("triton.enable_fuse_auxiliary_writes", True)
+    def test_auxiliary_write_dependencies(self):
+        auxiliary_numel = make_symbol(SymT.UNBACKED_INT, 0)
+        auxiliary_offset = make_symbol(SymT.UNBACKED_INT, 1)
+        auxiliary_limit = make_symbol(SymT.UNBACKED_INT, 2)
+        auxiliary_index = sympy.Symbol(
+            "auxiliary_index", integer=True, nonnegative=True
+        )
+
+        class AuxiliaryPointwise(ir.Pointwise):
+            def get_auxiliary_writes(self, indexer):
+                logical_index = sympy.Mod(auxiliary_index + auxiliary_offset, 4)
+                return (
+                    ir.AuxiliaryWriteRegion(
+                        numel=auxiliary_numel,
+                        index_var=auxiliary_index,
+                        output_index=indexer([logical_index]),
+                        predicate=sympy.And(
+                            auxiliary_index < 4,
+                            auxiliary_index < auxiliary_limit,
+                        ),
+                        value=127,
+                    ),
+                )
+
+        pointwise = AuxiliaryPointwise(
+            device=torch.device(GPU_TYPE),
+            dtype=torch.float32,
+            inner_fn=lambda index: ops.constant(0, torch.float32),
+            ranges=[sympy.Integer(4)],
+        )
+        buffer = ir.ComputedBuffer(
+            name="buf0",
+            layout=ir.FixedLayout(
+                torch.device(GPU_TYPE),
+                torch.float32,
+                [sympy.Integer(4)],
+                [sympy.Integer(1)],
+            ),
+            data=pointwise,
+        )
+
+        self.assertIn(dependencies.StarDep("buf0"), buffer.get_read_writes().writes)
+        symbol_uses = buffer.get_free_symbol_uses(unbacked_only=True)
+        self.assertTrue(
+            {auxiliary_numel, auxiliary_offset, auxiliary_limit}.issubset(symbol_uses)
+        )
+        self.assertNotIn(auxiliary_index, buffer.get_free_symbol_uses())
+
+    @inductor_config.patch("triton.enable_fuse_auxiliary_writes", True)
+    def test_auxiliary_write_rejects_empty_primary_domain(self):
+        class AuxiliaryPointwise(ir.Pointwise):
+            def get_auxiliary_writes(self, indexer):
+                auxiliary_index = sympy.Symbol(
+                    "auxiliary_index", integer=True, nonnegative=True
+                )
+                return (
+                    ir.AuxiliaryWriteRegion(
+                        numel=sympy.Integer(4),
+                        index_var=auxiliary_index,
+                        output_index=indexer([auxiliary_index]),
+                        predicate=sympy.true,
+                        value=127,
+                    ),
+                )
+
+        pointwise = AuxiliaryPointwise(
+            device=torch.device(GPU_TYPE),
+            dtype=torch.float32,
+            inner_fn=lambda index: ops.constant(0, torch.float32),
+            ranges=[sympy.Integer(0)],
+        )
+        buffer = ir.ComputedBuffer(
+            name="buf0",
+            layout=ir.FixedLayout(
+                torch.device(GPU_TYPE),
+                torch.float32,
+                [sympy.Integer(0)],
+                [sympy.Integer(1)],
+            ),
+            data=pointwise,
+        )
+
+        with self.assertRaisesRegex(
+            AssertionError, "statically nonempty primary domain"
+        ):
+            buffer.get_read_writes()
 
     def test_escape_triton_kernel_source_for_wrapper(self):
         source = """\

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -456,6 +456,7 @@ def register_backend_for_device(
 
 
 class BackendFeature(Enum):
+    AUXILIARY_WRITE_REGIONS = auto()
     FOREACH = auto()
     BUCKETIZE = auto()
     INPLACE_BUFFERS = auto()
@@ -1397,9 +1398,9 @@ pointwise_overrides_data: dict[str, OverridesData] = dict(
     mul_rn=OverridesData(
         type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
         cpp=lambda x, y: f"({x}) * ({y})",  # C++ doesn't need special handling
-        triton=lambda x, y: f"({x}) * ({y})"
-        if torch.version.hip
-        else f"libdevice.mul_rn({x}, {y})",
+        triton=lambda x, y: (
+            f"({x}) * ({y})" if torch.version.hip else f"libdevice.mul_rn({x}, {y})"
+        ),
         name="mul_rn",
     ),
     # erfinv, exp2, expit, gammaln
@@ -2074,8 +2075,9 @@ class CSE(Generic[CSEVariableType, AugmentedKeyT]):
         name_prefix: str = "tmp",
         iter_buffers: itertools.count[int] | None = None,
         store_cache: MutableMapping[str, CSEVariableType] | None = None,
-        reduction_cache: MutableMapping[ReductionCacheKey, CSEVariableType]
-        | None = None,
+        reduction_cache: (
+            MutableMapping[ReductionCacheKey, CSEVariableType] | None
+        ) = None,
         varname_map: dict[str, CSEVariableType] | None = None,
     ):
         self.prefix = prefix

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -216,9 +216,11 @@ def _materialize_trunc_to_float_expr(
             return node
 
         new_args = tuple(
-            rewrite_float_subexpr(arg)
-            if isinstance(arg, sympy.Expr) and not is_predicate_expr(arg)
-            else arg
+            (
+                rewrite_float_subexpr(arg)
+                if isinstance(arg, sympy.Expr) and not is_predicate_expr(arg)
+                else arg
+            )
             for arg in node.args
         )
         if new_args == node.args:
@@ -5222,6 +5224,85 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
 
         exit_stack.close()
 
+    def _auxiliary_predicate_to_str(self, predicate: sympy.Expr) -> str:
+        if isinstance(predicate, (sympy.And, sympy.Or, sympy.Xor)):
+            operator = {
+                sympy.And: " & ",
+                sympy.Or: " | ",
+                sympy.Xor: " ^ ",
+            }[type(predicate)]
+            return operator.join(
+                f"({self._auxiliary_predicate_to_str(arg)})" for arg in predicate.args
+            )
+        if isinstance(predicate, sympy.Not):
+            return f"~({self._auxiliary_predicate_to_str(predicate.args[0])})"
+        return self.kexpr(predicate)
+
+    def codegen_auxiliary_write(
+        self, output_name: str, write: ir.AuxiliaryWriteRegion
+    ) -> None:
+        if not hasattr(self, "auxiliary_store"):
+            self.auxiliary_store = IndentedBuffer()
+            self._auxiliary_write_index = itertools.count()
+            self._auxiliary_writes: OrderedSet[tuple[str, ir.AuxiliaryWriteRegion]] = (
+                OrderedSet()
+            )
+        key = (output_name, write)
+        if key in self._auxiliary_writes:
+            return
+        self._auxiliary_writes.add(key)
+        output = self.args.output(output_name)
+        suffix = next(self._auxiliary_write_index)
+        loop_var = sympy.Symbol(
+            f"auxiliary_index_{suffix}", integer=True, nonnegative=True
+        )
+        loop_offset = f"auxiliary_offset_{suffix}"
+        block_size = 256
+        replacements = {write.index_var: loop_var}
+        numel_str = self.index_to_str(self.rename_indexing(write.numel))
+        output_index_str = self.index_to_str(
+            self.rename_indexing(sympy_subs(write.output_index, replacements))
+        )
+        predicate = sympy_subs(write.predicate, replacements)
+        predicate = sympy_subs(
+            predicate,
+            {
+                symbol: self.args.size(symbol)
+                for symbol in sorted(predicate.free_symbols, key=lambda s: s.name)
+                if symbol_is_type(
+                    symbol,
+                    (
+                        SymT.UNBACKED_INT,
+                        SymT.SIZE,
+                        SymT.PRECOMPUTED_SIZE,
+                        SymT.UNBACKED_FLOAT,
+                    ),
+                )
+            },
+        )
+        predicate_str = self._auxiliary_predicate_to_str(predicate)
+        code = IndentedBuffer()
+        code.writeline("if tl.program_id(1) == 0 and tl.program_id(2) == 0:")
+        with code.indent():
+            code.writeline(
+                f"for {loop_offset} in tl.range("
+                f"tl.program_id(0) * {block_size}, {numel_str}, "
+                f"tl.num_programs(0) * {block_size}):"
+            )
+            with code.indent():
+                code.writeline(
+                    f"{loop_var} = {loop_offset} + tl.arange(0, {block_size})"
+                )
+                code.writeline(
+                    DeferredLine(
+                        output_name,
+                        f"tl.store({output} + {output_index_str}, "
+                        f"{constant_repr(write.value)}, "
+                        f"({loop_var} < {numel_str}) & ({predicate_str}))",
+                    )
+                )
+        self.auxiliary_store.splice(code)
+
     def device_assert_async(self, cond, msg) -> None:
         self.compute.writeline(f"tl.device_assert({cond}, {repr(msg)})")
 
@@ -5524,9 +5605,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             index = self.reduction_collapse_dims(
                 buffer,
                 index,
-                cast(torch.dtype, index.dtype)
-                if isinstance(index, CSEVariable)
-                else V.kernel.get_index_dtype_as_torch_dtype(),
+                (
+                    cast(torch.dtype, index.dtype)
+                    if isinstance(index, CSEVariable)
+                    else V.kernel.get_index_dtype_as_torch_dtype()
+                ),
             )
             if result_kind == "value_and_index":
                 result_value, result_index = result_var
@@ -6744,6 +6827,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             or self.compute
             or self.post_loop_combine
             or self.post_loop_store
+            or getattr(self, "auxiliary_store", None)
         ):
             return
 
@@ -6915,12 +6999,16 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.cooperative_reduction_workspace_cache.on_loop_end()
         if not self.mix_order_reduction:
             self.body.splice(self.post_loop_store)
+        if hasattr(self, "auxiliary_store"):
+            self.body.splice(self.auxiliary_store)
         self.indexing_code.clear()
         self.loads.clear()
         self.compute.clear()
         self.stores.clear()
         self.post_loop_combine.clear()
         self.post_loop_store.clear()
+        if hasattr(self, "auxiliary_store"):
+            self.auxiliary_store.clear()
 
     def kernel_benchmark_extra_args(self) -> list[str]:
         args = []
@@ -8276,6 +8364,7 @@ class TritonScheduling(SIMDScheduling):
     kernel_type: type[Any] = TritonKernel
     backend_features = OrderedSet(
         [
+            BackendFeature.AUXILIARY_WRITE_REGIONS,
             BackendFeature.FOREACH,
             BackendFeature.BUCKETIZE,
             BackendFeature.INPLACE_BUFFERS,

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2317,6 +2317,11 @@ class triton:
     # and lane-resolution pointwise epilogues.
     nested_reduction = os.environ.get("TORCHINDUCTOR_NESTED_REDUCTION", "0") == "1"
 
+    # Fuse auxiliary write regions into Triton producer kernels.
+    enable_fuse_auxiliary_writes = (
+        os.environ.get("TORCHINDUCTOR_ENABLE_FUSE_AUXILIARY_WRITES", "0") == "1"
+    )
+
     # Map for storing the amount of kernel runs with dumped input tensors
     # Based on hash of Triton source code to avoid bloating the folder
     debug_dump_kernel_inputs: dict[str, int] = {}

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1101,6 +1101,12 @@ class Loops(IRNode):
     def get_pointwise_size(self) -> Sequence[_IntLike]:
         return self.ranges
 
+    def get_auxiliary_writes(
+        self,
+        indexer: Callable[[Sequence[Expr]], Expr],
+    ) -> tuple[AuxiliaryWriteRegion, ...]:
+        return ()
+
     @classmethod
     def create(cls, *args: Any, **kwargs: Any) -> TensorBox:
         origin_node = kwargs.pop("origin_node", None)
@@ -1208,6 +1214,30 @@ class Loops(IRNode):
         raise NotImplementedError(
             f"constant_to_device() is not implemented by {type(self)}!"
         )
+
+
+@dataclasses.dataclass(frozen=True)
+class AuxiliaryWriteRegion:
+    """A secondary write domain owned by the enclosing computed buffer.
+
+    The selected output indices must be in bounds, injective, and disjoint from
+    the primary store and every other auxiliary write in the same kernel.
+    """
+
+    numel: Expr
+    index_var: Symbol
+    output_index: Expr
+    predicate: Expr
+    value: bool | float | int
+
+    def get_free_symbol_uses(self, unbacked_only: bool = False) -> OrderedSet[Symbol]:
+        result = OrderedSet().union(
+            get_free_symbols(self.numel, unbacked_only),
+            get_free_symbols(self.output_index, unbacked_only),
+            get_free_symbols(self.predicate, unbacked_only),
+        )
+        result.discard(self.index_var)
+        return result
 
 
 def nop_loader_fn(idx: Expr | Sequence[Expr], *, dtype: torch.dtype) -> OpsValue:
@@ -5627,16 +5657,35 @@ class ComputedBuffer(OperationBuffer):
 
         with patch.object(FlexibleLayout, "allow_indexing", True):
             if self.data.get_reduction_type():
-                return extract_read_writes(
+                read_writes = extract_read_writes(
                     self.get_store_function(),
                     self.data.get_pointwise_size(),
                     self.data.get_reduction_size(),
                 )
             else:
-                return extract_read_writes(
+                read_writes = extract_read_writes(
                     self.get_store_function(),
                     self.data.get_size(),
                 )
+
+            if self._get_auxiliary_writes():
+                read_writes.writes.add(dependencies.StarDep(self.get_name()))
+            return read_writes
+
+    def _get_auxiliary_writes(self) -> tuple[AuxiliaryWriteRegion, ...]:
+        if not config.triton.enable_fuse_auxiliary_writes:
+            return ()
+        with patch.object(FlexibleLayout, "allow_indexing", True):
+            writes = self.data.get_auxiliary_writes(
+                self.get_layout().as_fixed().make_indexer()
+            )
+        if writes and not V.graph.sizevars.statically_known_gt(
+            sympy_product(self.data.get_pointwise_size()), sympy.S.Zero
+        ):
+            raise AssertionError(
+                "auxiliary writes require a statically nonempty primary domain"
+            )
+        return writes
 
     @cache_on_self_and_args("ComputedBuffer")
     def get_free_symbol_uses(
@@ -5659,6 +5708,9 @@ class ComputedBuffer(OperationBuffer):
         result = self.layout.get_free_symbol_uses(
             unbacked_only
         ) | self.data.get_free_symbol_uses(unbacked_only)
+
+        for write in self._get_auxiliary_writes():
+            result |= write.get_free_symbol_uses(unbacked_only)
 
         if self.has_store_function():
             result |= self.get_read_writes().get_free_symbol_uses(unbacked_only)
@@ -5754,6 +5806,9 @@ class ComputedBuffer(OperationBuffer):
                 (args if self.get_reduction_type() else args[:1]),
                 var_ranges,
                 *args,
+                auxiliary_writes=tuple(
+                    (self.get_name(), write) for write in self._get_auxiliary_writes()
+                ),
             )
         index_vars = []
         reduce_vars: list[Any] = []
@@ -6203,8 +6258,9 @@ class TemplateBuffer(OperationBuffer):
         structured: object,
         *,
         direct_alias_at_leaf: dict[int, IRNode] | None = None,
-        on_tensor_leaf: Callable[[str, MultiOutput, list[tuple[type, int]], int], None]
-        | None = None,
+        on_tensor_leaf: (
+            Callable[[str, MultiOutput, list[tuple[type, int]], int], None] | None
+        ) = None,
         on_non_tensor_leaf: Callable[[int], None] | None = None,
     ) -> tuple[TensorBox, ...]:
         """Walk a structured output tree, creating MultiOutput nodes for tensor leaves."""
@@ -11461,9 +11517,11 @@ class Switch(ExternKernel):
             MultiOutput(
                 FixedLayout(
                     # pyrefly: ignore [bad-argument-type]
-                    device=output.get_device()
-                    if output.get_device() is not None
-                    else device,  # type: ignore[arg-type]
+                    device=(
+                        output.get_device()
+                        if output.get_device() is not None
+                        else device
+                    ),  # type: ignore[arg-type]
                     dtype=output.get_dtype(),
                     size=[_maybe_expr(sz) for sz in merged_output.size()],
                     stride=[_maybe_expr(sz) for sz in merged_output.stride()],

--- a/torch/_inductor/loop_body.py
+++ b/torch/_inductor/loop_body.py
@@ -105,6 +105,7 @@ class LoopBody:
     root_block: LoopBodyBlock
     memory_usage: dict[MemoryUsageType, list[MemoryEntry]]
     op_counts: collections.Counter[str]
+    auxiliary_writes: tuple[Any, ...]
 
     # defined only temporarily
     indexing_exprs_name: dict[sympy.Expr, str]
@@ -124,6 +125,7 @@ class LoopBody:
         iter_vars,
         reduce_vars,
         allow_same_symbol_in_index=False,
+        auxiliary_writes=(),
     ):
         super().__init__()
 
@@ -136,6 +138,7 @@ class LoopBody:
         self.iter_vars = iter_vars
         self.reduce_vars = reduce_vars
         self.var_ranges = var_ranges
+        self.auxiliary_writes = tuple(auxiliary_writes)
 
         if isinstance(fn, LoopBody):
             self._init_with_copy(fn, args, allow_same_symbol_in_index)
@@ -199,6 +202,7 @@ class LoopBody:
         self.op_counts = other.op_counts
         self.root_block = other.root_block.clone(self)
         self.has_partial_accumulate = other.has_partial_accumulate
+        self.auxiliary_writes = other.auxiliary_writes
 
         submodules = {**other.submodules}
         submodules.pop("get_index")
@@ -576,6 +580,11 @@ class LoopBody:
         self.indexing = self.indexing_from_args(indices, allow_same_symbol_in_index)
         result = self.root_block()
         self.indexing = None
+        if self.auxiliary_writes:
+            if not hasattr(V.kernel, "codegen_auxiliary_write"):
+                raise AssertionError("backend does not support auxiliary write regions")
+            for output_name, write in self.auxiliary_writes:
+                V.kernel.codegen_auxiliary_write(output_name, write)
         return result
 
     def bind_set_indirect_shim(self, var, size, check, wrap_neg):


### PR DESCRIPTION
Summary:

Inductor loop bodies normally write only over their primary iteration domain. Some fused computations also need to initialize or update a separate runtime-sized region of the same output without materializing an intermediate tensor or launching another kernel.

Introduce a generic, opt-in `AuxiliaryWriteRegion` abstraction. The enclosing `ComputedBuffer` binds each region to its own output, records a conservative `StarDep`, and includes the region expressions in symbolic dependency tracking. Regions carry one backend-neutral predicate and require a statically nonempty primary launch domain.

Triton lazily allocates auxiliary state only after a descriptor is present. It emits each region after the primary stores, with only the `program_id(1) == 0` and `program_id(2) == 0` plane participating. X-grid programs cooperatively scan the auxiliary domain with a 256-element grid-stride `tl.range`; boolean predicates are rendered with tensor-safe bitwise operators.

The default-false `triton.enable_fuse_auxiliary_writes` option gates descriptor collection in one place. Kernels without an opting-in producer do not allocate auxiliary buffers or enter auxiliary emission.

Test Plan:
- `buck2 test mode/opt-split-dwarf mode/inplace //caffe2/test/inductor:codegen_triton -- test_auxiliary_write` (4 passed)
- `buck2 run fbcode//triton/tools/triton_lint:triton_lint_cli -- caffe2/torch/_inductor/codegen/triton.py` (0 violations)
- `arc lint -a` on changed files (passed)
- `arc pyre check-owning-targets ...` (no eligible targets)

Reviewed By: yyetim

Differential Revision: D116973153


