### PR TITLE
[precompile] Actually remove a dropped guard from the artifact

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -362,6 +362,21 @@ def _precompile_reads_flag(x):
     return x * getattr(x, "my_flag", 1)
 
 
+def _serialized_guard_names(code):
+    """Every guard name actually present in a shipped artifact's guard state."""
+    from torch._dynamo.package import load_guards_state
+    from torch._precompile import _read_literal
+
+    names = []
+    for frame in pickle.loads(
+        base64.b64decode(_read_literal(ast.parse(code), "_FRAMES"))
+    ):
+        for variant in frame["variants"]:
+            state = load_guards_state(variant["guards_state"])
+            names += [g.name for g in state.output_graph.guards]
+    return " ".join(names)
+
+
 def _read_risky(code):
     from torch._precompile import _read_literal
 
@@ -2866,6 +2881,12 @@ class TestPrecompile(TestCase):
                     example_inputs=[(model, x)],
                 )
             self.assertIn("_cpu_copy", str(_read_risky(code)))
+            # Recorded is not enough: the pickle is what the serving machine
+            # rebuilds from, so a dropped guard still in it fails there exactly
+            # as it failed here.
+            self.assertNotIn("_cpu_copy", _serialized_guard_names(code))
+            torch._dynamo.reset()
+            torch.compiler.precompile.load(code, cache)
             return
         with drop, torch.no_grad():
             session = precompile_capture(_precompile_call_model, backend="eager")

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -5191,13 +5191,23 @@ class CheckFunctionManager:
                     output_graph,
                     False,
                 )
-                if collect_guard_failures:
-                    failed = {id(g) for g, _ in collect_guard_failures}
-                    all_guards = [g for g in all_guards if id(g) not in failed]
+                drop_failed_guards()
                 filter_entries = [
                     make_guard_filter_entry(guard, inspection_builder)
                     for guard in all_guards
                 ]
+
+            def drop_failed_guards() -> None:
+                # A guard the caller could not rebuild must leave the SERIALIZED
+                # set, not merely be reported: the pickle is what the serving
+                # machine rebuilds from, so a guard left in it fails there
+                # exactly as it failed here. Runs after every build that can
+                # collect, because which build that is depends on whether there
+                # is a runtime filter.
+                nonlocal all_guards
+                if collect_guard_failures:
+                    failed = {id(g) for g, _ in collect_guard_failures}
+                    all_guards = [g for g in all_guards if id(g) not in failed]
 
             def apply_filter(
                 filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]],
@@ -5245,6 +5255,7 @@ class CheckFunctionManager:
                 and save_guards
                 and serialization_guard_filter_fn is not None
             ):
+                drop_failed_guards()
                 filter_entries = [
                     make_guard_filter_entry(guard, builder) for guard in all_guards
                 ]

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -1582,9 +1582,20 @@ class CompilePackage:
             target_code = _lookup_code(entry) if entry.code_source else code
             scope = sys.modules[entry.python_module].__dict__
             for index, guarded_code in enumerate(entry.guarded_codes):
-                managers[(target_code, index)] = load_guard_manager(
-                    load_guards_state(guarded_code.guards_state), target_code, scope
-                )
+                try:
+                    managers[(target_code, index)] = load_guard_manager(
+                        load_guards_state(guarded_code.guards_state),
+                        target_code,
+                        scope,
+                    )
+                except Exception as e:
+                    # Name the frame and the variant: several frames can guard
+                    # the same source, so without them a failure here cannot be
+                    # told apart from one the capture reported dropping.
+                    raise RuntimeError(
+                        f"{entry.python_module}.{target_code.co_name} "
+                        f"variant {index}: {type(e).__name__}: {e}"
+                    ) from e
         self._prepared = _PreparedInstall(
             backends=self._deserialize_backends(backends), managers=managers
         )

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -1577,17 +1577,22 @@ class PrecompileSession:
         )
 
     def _record_unrebuildable(
-        self, failures: list[tuple[Guard, Exception]]
+        self, code_entry: Any, failures: list[tuple[Guard, Exception]]
     ) -> set[tuple[str, str]]:
         dropped = set()
         for guard, exc in failures:
             slot = (guard.create_fn_name(), guard.name)
             dropped.add(slot)
+            # Naming the frame matters: several frames can guard the same source
+            # string, so "dropped" and "still failing" are otherwise
+            # indistinguishable between one frame swept and another missed.
             log.warning(
-                "precompile: dropping guard %s on %s -- it cannot be rebuilt from "
-                "the artifact (%s: %s). Nothing checks it at load time.",
+                "precompile: dropping guard %s on %s in %s -- it cannot be "
+                "rebuilt from the artifact (%s: %s). Nothing checks it at load "
+                "time.",
                 slot[0],
                 slot[1],
+                code_entry.python_code.co_name,
                 type(exc).__name__,
                 exc,
             )
@@ -1606,7 +1611,7 @@ class PrecompileSession:
         from torch._dynamo.guards import CheckFunctionManager
         from torch._dynamo.output_graph import OutputGraphCommon
 
-        dropped = self._record_unrebuildable(failures)
+        dropped = self._record_unrebuildable(code_entry, failures)
 
         def without(entries: Sequence[GuardFilterEntry]) -> Sequence[bool]:
             return [(e.guard_type, e.name) not in dropped for e in entries]
@@ -1707,7 +1712,7 @@ class PrecompileSession:
                 except Exception as e:
                     raise _unrebuildable_guards(code_entry, e) from e
                 if failures:
-                    self._record_unrebuildable(failures)
+                    self._record_unrebuildable(code_entry, failures)
                 self._report_guard_drift(code_entry, rebuilt)
                 guarded.guards_state = pruned
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #194407
* #194394
* #194393
* #194390
* #194389
* #194388
* #194387
* #194386
* #194385
* #194384
* #194383
* #194320
* #194319
* #194318
* #194317
* #194316
* #194302
* #194301
* #194300
* #194286
* #194285
* #194284
* #194283
* #194282
* #194250
* #194249
* #194248
* #194158
* #192379
* #193977
* #193976
* #193697
* #192374
* #192866
* #193725

The commit that started dropping unrebuildable guards recorded them and, on the
``torch.compiler.precompile`` path, did not remove them. Capture logged ten
drops and listed them in DROPPED_GUARDS; the pickle still contained all ten, so
``load`` refused the artifact with the same AttributeError the capture had
already reported handling. A reviewer reading the header would believe the guard
was gone.

This is a regression introduced further down this stack, not an original defect.
The pruning lives inside ``build_filter_entries``, which used to run for every
CheckFunctionManager. "Build a precompiled frame's guard tree twice, not three
times" then stopped calling it when there is no RUNTIME filter -- which is
exactly the configuration ``_apply_guard_policy`` uses -- and derived the filter
entries from the runtime builder instead. The failures were still collected, so
the log and the header were right; nothing pruned ``all_guards``, so the
serialized set was not.

Hoist the pruning into its own step and run it after EVERY build that can
collect, rather than inside one of them. The session-API path was unaffected
because it re-serializes through an explicit filter naming the dropped guards.

Both messages now name the frame. Several frames can guard the same source
string -- the model this came from captured ten variants each of two frames that
guard the same weakref -- so without the frame there is no way to tell "recorded
but not applied" from "one frame swept and another missed", and those need
different fixes.

Test Plan:

```
python test/test_precompile.py
python test/dynamo/test_package.py
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_precompile_context.py
```

The existing drop test asserted only that the drop was RECORDED, which is what
let this through. It now decodes the shipped artifact, walks every variant's
guard state, and asserts the dropped source is absent -- then loads it. That
assertion fails without this change and passes with it.

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98