### PR TITLE
Fix grammar and typos in docs and docstrings

### DIFF
--- a/torch/ao/quantization/backend_config/README.md
+++ b/torch/ao/quantization/backend_config/README.md
@@ -178,7 +178,7 @@ During the prepare phase of quantization, we will compare the data types specifi
 
 #### Quantization range
 
-The user's QConfig may specify `quant_min` and `quant_max`, which are min and max restrictions on the quantization values. Here we set the lower bound for the `quant_min` and then upper bound for the `quant_max` to represent the limits of the backend. If a QConfig exceeds these limits in either direction, it will be treated as violating this constraint.
+The user's QConfig may specify `quant_min` and `quant_max`, which are min and max restrictions on the quantization values. Here we set the lower bound for the `quant_min` and the upper bound for the `quant_max` to represent the limits of the backend. If a QConfig exceeds these limits in either direction, it will be treated as violating this constraint.
 
 #### Scale range
 

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -1201,7 +1201,7 @@ class emit_nvtx:
 
 
 def load_nvprof(path):
-    """Open an nvprof trace file and parses autograd annotations.
+    """Open an nvprof trace file and parse autograd annotations.
 
     Args:
         path (str): path to nvprof trace

--- a/torch/csrc/README.md
+++ b/torch/csrc/README.md
@@ -46,7 +46,7 @@ Python interpreter, so that this exception can be propagated
 accordingly; however, because the Python API is C-based, what actually
 will happen is it will return control to whatever C++ code called it.
 Similarly, if we raise a C++ exception, prior to returning to the Python
-interpreter, we must set the Python error flags, so it turns into a C++
+interpreter, we must set the Python error flags, so it turns into a Python
 exception.
 
 Moreover, when using the following macros, the generated warnings

--- a/torch/csrc/jit/JIT-AUTOCAST.md
+++ b/torch/csrc/jit/JIT-AUTOCAST.md
@@ -25,7 +25,7 @@
 ## Overview
 
 [Autocast][2] (aka Automatic Mixed Precision) is an optimization which helps
-taking advantage of the storage and performance benefits of narrow types
+take advantage of the storage and performance benefits of narrow types
 (float16) while preserving the additional range and numerical precision of
 float32.
 

--- a/torch/csrc/jit/api/method.h
+++ b/torch/csrc/jit/api/method.h
@@ -69,7 +69,7 @@ struct TORCH_API Method : public torch::IMethod {
       std::vector<std::string>& /*argumentNames*/ /*argumentNamesOut*/)
       const override;
 
-  // Methods are uniqued owned by a single module. This raw pointer allows
+  // Methods are uniquely owned by a single module. This raw pointer allows
   // looking up the module.
   ObjectPtr owner_;
 

--- a/torch/csrc/jit/codegen/fuser/README.md
+++ b/torch/csrc/jit/codegen/fuser/README.md
@@ -4,7 +4,7 @@ The fuser accepts subgraphs wrapped in "fusion nodes" and tries to execute them 
 
 ## Code Organization
 
-The fuser is designed hierarchically with device-independent logic eventually deferring to device-specific logic and implementation. The device-specific code is (mostly) found in each devices' subdirectory. The device-independent logic has six components:
+The fuser is designed hierarchically with device-independent logic eventually deferring to device-specific logic and implementation. The device-specific code is (mostly) found in each device's subdirectory. The device-independent logic has six components:
 
 * The Interface (interface.h/cpp) has functions to register and run fusions, interrogate fusion functionality, and perform debugging.
 * The Compiler (compiler.h/cpp) performs "upfront" and "runtime" compilation. When fusions are registered, upfront compilation produces fallback code and performs some shape inference. When a fusion is run, runtime compilation invokes code generation and the device-specific compilation logic.

--- a/torch/csrc/jit/codegen/onednn/README.md
+++ b/torch/csrc/jit/codegen/onednn/README.md
@@ -72,7 +72,7 @@ CMake files where bridge code is included:
 caffe2/CMakeLists.txt
 ```
 
-CMake files where oneDNN Graph submodule are included:
+CMake files where the oneDNN Graph submodule is included:
 
 ```bash
 third_party/ideep/mkl-dnn

--- a/torch/csrc/jit/runtime/static/README.md
+++ b/torch/csrc/jit/runtime/static/README.md
@@ -104,7 +104,7 @@ end of the iteration and allocate a buffer that is possibly bigger on the next i
 `StaticRuntime` can optionally manage output tensors via the `manage_output_tensors` option in `StaticModuleOptions`.
 When this flag is turned on, we coalesce allocations for output tensors together. Note that the buffer containing
 output tensors is separated from the one containing intermediate tensors. The former needs to live past the end
-of the inference run, but the latter needs deallocated at the end of the run.
+of the inference run, but the latter needs to be deallocated at the end of the run.
 
 Under the hood, we store a refcounted pointer to the output arena in each returned `Tensor`. The arena is destroyed
 explicitly.
@@ -153,7 +153,7 @@ the result is not `nullptr`, use that op.
 
 The following diagram shows the core data structure. An arrow from `A` to `B` means that
 `A` stores a reference to `B`. If the reference is unowned,
-`A` may not out live `B` or anything that `B` stores a reference to (directly or indirectly).
+`A` may not outlive `B` or anything that `B` stores a reference to (directly or indirectly).
 If the reference is owned, the lifetimes of `A` and `B` are the same.
 ```
 
@@ -187,7 +187,7 @@ forwards to the cached runtime's `StaticRuntime::operator()`. One upshot of this
 
 The way to use static runtime in a multi-threaded context is to give each thread its own `StaticRuntime`
 instance. New runtime instances can be created directly (`StaticRuntime(static_module)`) or `clone()`'d from
-an existing runtimes.
+an existing runtime.
 
 `StaticModule` takes a set of options that control the behavior of the runtime instances that it spawns;
 see `StaticModuleOptions` for more details.

--- a/torch/csrc/lazy/tutorial.md
+++ b/torch/csrc/lazy/tutorial.md
@@ -110,7 +110,7 @@ assert lazy_result.cpu() == add_two_maybe(t, maybe_true)
 Woo-hoo! This works too!
 Unfortunately, this flexibility comes with a few downsides. Remember that backends need to translate aten ops into some much lower-level operations that an accelerator understands. The translation process may be time-consuming. Although, usually, it's well worth it!
 
-However, if a non-trivial model is wildly dynamic and contains loops that always run different number of times or if statements one after another that explode into different traces every time you run the model, the backend will spend non-trivial amount of time compiling each trace even though the latter is used only for a few times.
+However, if a non-trivial model is wildly dynamic and contains loops that always run a different number of times or if statements one after another that explode into different traces every time you run the model, the backend will spend non-trivial amount of time compiling each trace even though the latter is used only for a few times.
 
 Alright, at this point, you should have learned the main ideas behind Lazy Tensor, most common usage patterns and APIs.
 Also, you are hopefully as inspired and motivated about Lazy Tensor as I am.
@@ -272,10 +272,10 @@ print(torch._lazy.metrics.counter_names())
 
 If you are seeing any ops with the prefix: `aten::`
 
-*Sometimes* you could replace such ops with similar that LT does support. More often than not, we will have to just live with it until LT matures.
+*Sometimes* you could replace such ops with similar ones that LT does support. More often than not, we will have to just live with it until LT matures.
 
 Another handy API is `torch._lazy.wait_device_ops()`. Remember, we said that `mark_step()` breaks up the current trace and kicks off a computation asynchronously? If downstream there are no blocking operations such as `print`, `item()`, `to`, LT will happily continue tracing.
-If you would like to time how much exactly time computation and tracing took for some model without including device transfers or printing, you could stick `torch._lazy.wait_device_ops()` and `time.perf_counter()` right after it. Don't forget another `time.perf_counter()` before the trace start!
+If you would like to time exactly how much time computation and tracing took for some model without including device transfers or printing, you could stick `torch._lazy.wait_device_ops()` and `time.perf_counter()` right after it. Don't forget another `time.perf_counter()` before the trace start!
 
 This concludes our brief introduction to LT. Hopefully, you'll remember the main takeaways:
 

--- a/torch/csrc/profiler/README.md
+++ b/torch/csrc/profiler/README.md
@@ -74,7 +74,7 @@ The autograd engine is responsible for automatically computing gradients.
 
 The profiler records two pieces of information from the autograd engine:
 * [Sequence number](../../../aten/src/ATen/SequenceNumber.h): this is a unique-per-thread index assigned to each op call(\*) in the forward pass. When a backward op is triggered, it is also assigned a sequence number matching the sequence number of the forward op that caused that backward op to be executed. Using this information, the profiler is able to match forward and backward ops; in chrome traces, this feature can be enabled with the "fwd_bwd" flow events
-* [Forward thread id](https://github.com/pytorch/pytorch/blob/2e3fce54506ba82eee2c890410bf7a1405a64ec6/aten/src/ATen/record_function.h#L357): Autograd can be used in multi-threaded environments. The forward thread ID indicates the ID of the thread on which the forward op was executed on. This information is needed because the sequence number, mentioned above, is only unique within a thread; the forward thread ID is used for differentiating different ops with the same sequence number.
+* [Forward thread id](https://github.com/pytorch/pytorch/blob/2e3fce54506ba82eee2c890410bf7a1405a64ec6/aten/src/ATen/record_function.h#L357): Autograd can be used in multi-threaded environments. The forward thread ID indicates the ID of the thread on which the forward op was executed. This information is needed because the sequence number, mentioned above, is only unique within a thread; the forward thread ID is used for differentiating different ops with the same sequence number.
 
 (\*) Note that only op invocations whose inputs require gradients are assigned a sequence number
 

--- a/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
+++ b/torch/distributed/algorithms/ddp_comm_hooks/default_hooks.py
@@ -18,7 +18,7 @@ __all__ = [
 def _allreduce_fut(
     process_group: dist.ProcessGroup, tensor: torch.Tensor
 ) -> torch.futures.Future[torch.Tensor]:
-    """Average the input gradient tensor by allreduce and returns a future."""
+    """Average the input gradient tensor by allreduce and return a future."""
     group_to_use = process_group if process_group is not None else dist.group.WORLD
 
     # Apply the division first to avoid overflow, especially for FP16.

--- a/torch/distributed/checkpoint/_traverse.py
+++ b/torch/distributed/checkpoint/_traverse.py
@@ -155,7 +155,7 @@ def get_element(
     path: OBJ_PATH,
     default_value: T | None = None,
 ) -> T | None:
-    """Retrieve the value at ``path``from ``root_dict``, returning ``default_value`` if not found."""
+    """Retrieve the value at ``path`` from ``root_dict``, returning ``default_value`` if not found."""
     cur_value = cast(CONTAINER_TYPE, root_dict)
     for part in path:
         if type(part) is int:

--- a/torch/distributed/optim/zero_redundancy_optimizer.py
+++ b/torch/distributed/optim/zero_redundancy_optimizer.py
@@ -289,7 +289,7 @@ class _OverlapInfo:
 
 class ZeroRedundancyOptimizer(Optimizer, Joinable):
     r"""
-    Wrap an arbitrary :class:`optim.Optimizer <torch.optim.Optimizer>` and shards its states across ranks in the group.
+    Wrap an arbitrary :class:`optim.Optimizer <torch.optim.Optimizer>` and shard its states across ranks in the group.
 
     The sharing is done as described by `ZeRO <https://arxiv.org/abs/1910.02054>`_.
 
@@ -817,7 +817,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
         This rank sends its shard of the parameters to all other ranks and
         receives a shard from each other rank. This is done using
         ``broadcast()``. Parameters are sent bucket-by-bucket if
-        ``parameters_as_bucket_view=True``and sent parameter-by-parameter
+        ``parameters_as_bucket_view=True`` and sent parameter-by-parameter
         otherwise.
         """
         handles = []
@@ -906,9 +906,9 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
         assigned_ranks_per_bucket: list[set[int]],
     ) -> None:
         r"""
-        Assign ``bucket_params`` to the rank with the least size assigned so far and collects relevant information.
+        Assign ``bucket_params`` to the rank with the least size assigned so far and collect relevant information.
 
-        The model parameters given by ``bucket_params`` represents a (possibly non-strict)
+        The model parameters given by ``bucket_params`` represent a (possibly non-strict)
         subset of the parameters corresponding to a :class:`DistributedDataParallel` bucket.
 
         Arguments:
@@ -1127,7 +1127,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
         **kwargs: Any,
     ) -> float | None:
         r"""
-        Perform a single optimizer step and syncs parameters across all ranks.
+        Perform a single optimizer step and sync parameters across all ranks.
 
         Arguments:
             closure (Callable): a closure that re-evaluates the model and
@@ -1423,7 +1423,7 @@ class ZeroRedundancyOptimizer(Optimizer, Joinable):
         params: Any,
     ) -> list[torch.Tensor] | list[dict]:
         r"""
-        Verify the type of ``params`` and initializes ``self._all_params`` as a :class:`list` of all parameters.
+        Verify the type of ``params`` and initialize ``self._all_params`` as a :class:`list` of all parameters.
 
         The initialization will first make sure that provided ``params`` is valid.
 

--- a/torch/distributed/tensor/README.md
+++ b/torch/distributed/tensor/README.md
@@ -14,7 +14,7 @@ from torch.distributed.tensor import init_device_mesh, Shard, distribute_tensor
 
 # Create a mesh topology with the available devices:
 # 1. We can directly create the mesh using elastic launcher, (recommended)
-# 2. If using mp.spawn, one need to initialize the world process_group first and set device
+# 2. If using mp.spawn, one needs to initialize the world process_group first and set device
 #   i.e. torch.distributed.init_process_group(backend="nccl", world_size=world_size)
 
 mesh = init_device_mesh("cuda", (int(os.environ["WORLD_SIZE"]),))
@@ -25,11 +25,11 @@ my_dtensor = distribute_tensor(big_tensor, mesh, [Shard(dim=0)])
 
 ## Motivation
 
-Today there are mainly three ways to scale up distributed training: Data Parallel, Tensor Parallel and Pipeline Parallel. Each of them works on a separate dimension where solutions have been built independently (i.e. PyTorch DDP, FSDP, ShardedTensor, PiPPy, etc.). When training really large models, users would like to use these technologies together (i.e. 3-D Parallelism), while the interoperability of the existing solutions are not great and often hard to use (i.e. users might want arbitrary combinations of the data parallel, tensor parallel and pipeline parallel). This is becoming an issue for users and one of the biggest reasons is that there is no common abstraction that build the bridge between different parallelism strategies.
+Today there are mainly three ways to scale up distributed training: Data Parallel, Tensor Parallel and Pipeline Parallel. Each of them works on a separate dimension where solutions have been built independently (i.e. PyTorch DDP, FSDP, ShardedTensor, PiPPy, etc.). When training really large models, users would like to use these technologies together (i.e. 3-D Parallelism), while the interoperability of the existing solutions is not great and often hard to use (i.e. users might want arbitrary combinations of the data parallel, tensor parallel and pipeline parallel). This is becoming an issue for users and one of the biggest reasons is that there is no common abstraction that builds the bridge between different parallelism strategies.
 
 An ideal scenario is that users could build their distributed program just like authoring in a single node/device, without worrying about how to do distributed training in a cluster, and our solutions could help them run distributed training in an efficient manner. For example, researchers just need to build the big transformer model, and PyTorch Distributed automatically figures out how to split the model and run pipeline parallel across different nodes, how to run data parallel and tensor parallel within each node. In order to achieve this, we need some common abstractions to distribute tensor values and distributed computations accordingly.
 
-There're many recent works that working on tensor level parallelism to provide common abstractions, see the `Related Works` in the last section for more details. Inspired by [GSPMD](https://arxiv.org/pdf/2105.04663.pdf), [Oneflow](https://arxiv.org/pdf/2110.15032.pdf) and [TF’s DTensor](https://www.tensorflow.org/guide/dtensor_overview), we introduce PyTorch DTensor as the next generation of ShardedTensor to provide basic abstractions for distributing storage and computation. It serves as one of the basic building blocks for distributed program translations and describes the layout of a distributed training program. With the DTensor abstraction, we can seamlessly build parallelism strategies such as tensor parallelism, DDP and FSDP.
+There're many recent works that are working on tensor level parallelism to provide common abstractions, see the `Related Works` in the last section for more details. Inspired by [GSPMD](https://arxiv.org/pdf/2105.04663.pdf), [Oneflow](https://arxiv.org/pdf/2110.15032.pdf) and [TF’s DTensor](https://www.tensorflow.org/guide/dtensor_overview), we introduce PyTorch DTensor as the next generation of ShardedTensor to provide basic abstractions for distributing storage and computation. It serves as one of the basic building blocks for distributed program translations and describes the layout of a distributed training program. With the DTensor abstraction, we can seamlessly build parallelism strategies such as tensor parallelism, DDP and FSDP.
 
 ## Value Proposition
 
@@ -168,7 +168,7 @@ This work is mainly inspired by [GSPMD](https://arxiv.org/pdf/2105.04663.pdf), [
 
 GSPMD:
 -   GSPMD is now the fundamental component of JAX/TensorFlow distributed training and enables various optimizations with the XLA compiler to allow users to train their models efficiently in a large scale setting.
--   Fundamentally, GSPMD have three types of sharding strategies within a tensor: “tiled”, “replicated”, “partially tiled” to represent sharding and replication.
+-   Fundamentally, GSPMD has three types of sharding strategies within a tensor: “tiled”, “replicated”, “partially tiled” to represent sharding and replication.
 -   At the core of GSPMD Partitioner, it utilizes the XLA compiler to do advanced optimizations, i.e. sharding propagation and compiler based fusion.
 -   XLA mark_sharding API: PyTorch XLA’s [mark_sharding](https://github.com/pytorch/xla/pull/3476) API uses [XLAShardedTensor](https://github.com/pytorch/xla/issues/3871) abstraction (i.e. sharding specs) in PyTorch/XLA. Under the hood XLAShardedTensor is utilizing the GSPMD partitioner to enable SPMD style training on TPU.
 
@@ -182,10 +182,10 @@ TensorFlow DTensor:
 -   DTensor also allows sharding and replication on an n-d mesh like device network.
 -   DTensor implements MLIR passes to do propagation and operator implementations.
 
-There are also several cutting edge research fields that embeds tensor sharding as part of the system, i.e. [Megatron-LM](https://arxiv.org/pdf/1909.08053.pdf) for tensor parallelism on Transformer based models. [DeepSpeed](https://github.com/deepspeedai/DeepSpeed) for training large scale models with different optimization techniques on top of tensor sharding.
+There are also several cutting edge research fields that embed tensor sharding as part of the system, i.e. [Megatron-LM](https://arxiv.org/pdf/1909.08053.pdf) for tensor parallelism on Transformer based models. [DeepSpeed](https://github.com/deepspeedai/DeepSpeed) for training large scale models with different optimization techniques on top of tensor sharding.
 
 ### Additional context
 
 RFC: https://github.com/pytorch/pytorch/issues/88838
 
-We are gathering early feedbacks about this proposal. We have also posted this [RFC](https://dev-discuss.pytorch.org/t/rfc-pytorch-distributedtensor/740) to the dev-discuss forum, please feel free to comment directly in the above issue or in the forum post. To see a complete design doc with additional details about DTensor, please refer to this [doc](https://docs.google.com/document/d/1nFeJ8NSFNhNlCkNgWK31ZGRqm1L9rd0i_XN_RprphaI/edit#heading=h.6sovjqv9jiqn)
+We are gathering early feedback about this proposal. We have also posted this [RFC](https://dev-discuss.pytorch.org/t/rfc-pytorch-distributedtensor/740) to the dev-discuss forum, please feel free to comment directly in the above issue or in the forum post. To see a complete design doc with additional details about DTensor, please refer to this [doc](https://docs.google.com/document/d/1nFeJ8NSFNhNlCkNgWK31ZGRqm1L9rd0i_XN_RprphaI/edit#heading=h.6sovjqv9jiqn)

--- a/torch/headeronly/README.md
+++ b/torch/headeronly/README.md
@@ -1,6 +1,6 @@
 ## torch/headeronly
 
-The inlined C++ headers in the `torch::headeronly` namespace living this subdirectory are completely decoupled from LibTorch. These APIs are also globally listed in [torch/header_only_apis.txt](https://github.com/pytorch/pytorch/blob/main/torch/header_only_apis.txt).
+The inlined C++ headers in the `torch::headeronly` namespace living in this subdirectory are completely decoupled from LibTorch. These APIs are also globally listed in [torch/header_only_apis.txt](https://github.com/pytorch/pytorch/blob/main/torch/header_only_apis.txt).
 
 There are two types of LibTorch independent header-only headers:
 1. OG header-only. Originally header-only APIs, such as `ScalarType`, `Half`, `BFloat16`, have always been implemented in headers only. For them to move into torch/headeronly only required a code migration, a copy-pasta, if you will.

--- a/torch/multiprocessing/cuda_multiprocessing.md
+++ b/torch/multiprocessing/cuda_multiprocessing.md
@@ -1,6 +1,6 @@
 # CUDA IPC Refcounting implementation explained
 
-Since shared CUDA memory belongs to the producer process, we need to take special precautions to make sure that it is stays allocated for entire shared tensor life-span.
+Since shared CUDA memory belongs to the producer process, we need to take special precautions to make sure that it stays allocated for entire shared tensor life-span.
 
 It could be done manually by syncing on an event:
 
@@ -21,7 +21,7 @@ Instead, we implement cross-process reference counting for shared CUDA (and HIP)
 
 Details of implementation follow.
 
-At the moment of sending tensor, we are wrapping DataPtr of the tensor with additional structure CudaIPCSentData. It still points to the same memory, but have other behavior on destruction.
+At the moment of sending tensor, we are wrapping DataPtr of the tensor with additional structure CudaIPCSentData. It still points to the same memory, but has other behavior on destruction.
 
 Instead of simply removing the allocated block, it checks if there are any active references to this block (references are stored in shared memory files described by CudaIPCRefCountersFile structure). If such exists, instead of deleting blocks DataPtr it is moved to the global state CudaIPCSentDataLimbo.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Sweep of small grammatical corrections across READMEs, tutorials, and
Python docstrings under `torch/`: subject-verb agreement in docstring
summary lines (`Average ... and returns` -> `and return`), possessive and
plural slips (`each devices'` -> `each device's`, `an existing runtimes`
-> `an existing runtime`), missing words (`needs deallocated` -> `needs to
be deallocated`), a missing space in `parameters_as_bucket_view=True``and`,
and one factual mixup in `torch/csrc/README.md` where raising a C++
exception was said to turn into a C++ exception rather than a Python one.

No functional changes; documentation and comments only.

Test Plan: no behavioral change, so no tests were run beyond lint.

```
lintrunner -a
```

This change was authored with the assistance of an AI agent.

cc @gujinghui @PenghuiCheng @XiaobingSuper @jianyuh @jgong5 @mingfeima @sanchitintel @ashokei @jingxu10 @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal