### PR TITLE
Fix quantized_batch_norm schema: make weight and bias non-optional Th…

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1082,7 +1082,7 @@
 - func: batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps, bool cudnn_enabled) -> Tensor
   tags: maybe_aliasing_or_mutating
 
-- func: quantized_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor
+- func: quantized_batch_norm(Tensor input, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor
   dispatch:
     QuantizedCPU: quantized_batch_norm
   autogen: quantized_batch_norm.out

--- a/aten/src/ATen/native/quantized/cpu/Normalization.cpp
+++ b/aten/src/ATen/native/quantized/cpu/Normalization.cpp
@@ -55,18 +55,13 @@ void compute_fused_params(
 template <bool ReluFused>
 Tensor q_batch_norm1d_impl(
     Tensor qx,
-    std::optional<Tensor> mb_weight,
-    std::optional<Tensor> mb_bias,
+    const Tensor& weight,
+    const Tensor& bias,
     Tensor mean,
     Tensor var,
     double eps,
     double output_scale,
     int64_t output_zero_point) {
-
-  TORCH_CHECK(mb_weight.has_value(), "Weight must be provided");
-  TORCH_CHECK(mb_bias.has_value(), "Bias must be provided");
-  const auto& weight = *mb_weight;
-  const auto& bias = *mb_bias;
 
   if (qx.numel() == 0) {
     auto out = qx.clone();
@@ -163,18 +158,13 @@ Tensor q_batch_norm1d_impl(
 template <bool ReluFused>
 Tensor q_batch_norm2d_impl(
     Tensor qx,
-    std::optional<Tensor> mb_weight,
-    std::optional<Tensor> mb_bias,
+    const Tensor& weight,
+    const Tensor& bias,
     Tensor mean,
     Tensor var,
     double eps,
     double output_scale,
     int64_t output_zero_point) {
-
-  TORCH_CHECK(mb_weight.has_value(), "Weight must be provided");
-  TORCH_CHECK(mb_bias.has_value(), "Bias must be provided");
-  const auto& weight = *mb_weight;
-  const auto& bias = *mb_bias;
 
   if (qx.numel() == 0) {
     auto out = qx.clone();
@@ -257,19 +247,13 @@ Tensor q_batch_norm2d_impl(
 template <bool ReluFused>
 Tensor q_batch_norm3d_impl(
     Tensor qx,
-    std::optional<Tensor> mb_weight,
-    std::optional<Tensor> mb_bias,
+    const Tensor& weight,
+    const Tensor& bias,
     Tensor mean,
     Tensor var,
     double eps,
     double output_scale,
     int64_t output_zero_point) {
-
-  TORCH_CHECK(mb_weight.has_value(), "Weight must be provided")
-  TORCH_CHECK(mb_bias.has_value(), "Bias must be provided")
-
-  const auto& weight = *mb_weight;
-  const auto& bias = *mb_bias;
 
   if (qx.numel() == 0) {
     auto out = qx.clone();
@@ -354,8 +338,8 @@ Tensor q_batch_norm3d_impl(
 template <bool ReluFused>
 Tensor q_batch_norm_impl(
     Tensor qx,
-    std::optional<Tensor> mb_weight,
-    std::optional<Tensor> mb_bias,
+    Tensor weight,
+    Tensor bias,
     Tensor mean,
     Tensor var,
     double eps,
@@ -365,13 +349,13 @@ Tensor q_batch_norm_impl(
   int64_t dim = qx.dim();
   if (dim == 2 || dim == 3) {
     qy = q_batch_norm1d_impl<ReluFused>(
-        qx, mb_weight, mb_bias, mean, var, eps, output_scale, output_zero_point);
+        qx, weight, bias, mean, var, eps, output_scale, output_zero_point);
   } else if (dim == 4) {
     qy = q_batch_norm2d_impl<ReluFused>(
-        qx, mb_weight, mb_bias, mean, var, eps, output_scale, output_zero_point);
+        qx, weight, bias, mean, var, eps, output_scale, output_zero_point);
   } else if (dim == 5) {
     qy = q_batch_norm3d_impl<ReluFused>(
-        qx, mb_weight, mb_bias, mean, var, eps, output_scale, output_zero_point);
+        qx, weight, bias, mean, var, eps, output_scale, output_zero_point);
   } else {
     TORCH_CHECK(false, "quantized::batch_norm only support 2d, 3d, 4d or 5d inputs.");
   }
@@ -460,16 +444,16 @@ Tensor int8_batch_norm2d_cpu_impl(
 } // namespace
 
 Tensor quantized_batch_norm(
-    const Tensor& qx, const std::optional<Tensor>& weight_opt /* optional */, const std::optional<Tensor>& bias_opt /* optional */,
-    const Tensor& mean /* optional */,
-    const Tensor& var /* optional */,
+    const Tensor& qx, const Tensor& weight, const Tensor& bias,
+    const Tensor& mean,
+    const Tensor& var,
     double eps,
     double output_scale,
     int64_t output_zero_point) {
   return q_batch_norm_impl<false>(
       qx,
-      weight_opt,
-      bias_opt,
+      weight,
+      bias,
       mean,
       var,
       eps,

--- a/aten/src/ATen/native/quantized/library.cpp
+++ b/aten/src/ATen/native/quantized/library.cpp
@@ -36,14 +36,14 @@ TORCH_LIBRARY(quantized, m) {
   // quantized::batch_norm supports both 2d and 3d batch norm right now
   // it should also support 1d batch_norm after quantized::batch_norm1d is
   // implemented
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm_relu(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm1d(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm1d_relu(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm2d(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm2d_relu(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm3d(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
-  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm3d_relu(Tensor qx, Tensor? weight, Tensor? bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm_relu(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm1d(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm1d_relu(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm2d(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm2d_relu(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm3d(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
+  m.def(TORCH_SELECTIVE_SCHEMA("quantized::batch_norm3d_relu(Tensor qx, Tensor weight, Tensor bias, Tensor mean, Tensor var, float eps, float output_scale, int output_zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::clamp(Tensor qx, Scalar? min=None, Scalar? max=None) -> Tensor qy"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::threshold(Tensor qx, Scalar threshold, Scalar value) -> Tensor qy"), {at::Tag::pt2_compliant_tag});
   m.def(TORCH_SELECTIVE_SCHEMA("quantized::cat(Tensor[] qx, int dim, float? scale, int? zero_point) -> Tensor"), {at::Tag::pt2_compliant_tag});

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -13907,7 +13907,7 @@ Example::
 add_docstr(
     torch.quantized_batch_norm,
     r"""
-quantized_batch_norm(input, weight=None, bias=None, mean, var, eps, output_scale, output_zero_point) -> Tensor
+quantized_batch_norm(input, weight, bias, mean, var, eps, output_scale, output_zero_point) -> Tensor
 
 Applies batch normalization on a 4D (NCHW) quantized tensor.
 


### PR DESCRIPTION
## Summary
The `quantized_batch_norm` schema and docstring declared `weight` and `bias` as optional (`Tensor?` / `=None`), but the C++ kernel always required both and raised `RuntimeError` if `None` was passed. This was misleading.

## Changes
- `native_functions.yaml`: `Tensor? weight, Tensor? bias` → `Tensor weight, Tensor bias`
- `Normalization.cpp`: Removed `std::optional<Tensor>` wrappers and dead `TORCH_CHECK` guards from all 4 functions
- `_torch_docs.py`: Removed `=None` defaults from signature

## Test Plan
- Verified no callers pass `None` for weight/bias
- Existing tests don't call this function directly
- CI quantization suite will validate

Fixes #194351

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01