### PR TITLE
Fix grammar typos in comments and docstrings

### DIFF
--- a/torch/_lazy/closure.py
+++ b/torch/_lazy/closure.py
@@ -107,7 +107,7 @@ def add_step_closure(
 ) -> None:
     """Adds a closure to the list of the ones to be run at the end of the step.
     Many times during model training there is the need to print/report (print to
-    console, post to tensorboard, etc...) information which require the content of
+    console, post to tensorboard, etc...) information which requires the content of
     intermediary tensors to be inspected.
     Inspecting different tensors content in different points of the model code
     requires many executions and typically causes performance issues.

--- a/torch/csrc/autograd/record_function_ops.cpp
+++ b/torch/csrc/autograd/record_function_ops.cpp
@@ -85,7 +85,7 @@ static c10::intrusive_ptr<c10::ivalue::Future> _call_end_callbacks_on_fut(
         auto& rec = get_record();
         rec.end();
         // Note: this future is returned to the user to ensure that a call to
-        // wait() ensures that profiling callbacks have ran. To ensure that this
+        // wait() ensures that profiling callbacks have run. To ensure that this
         // is transparent, we must make this future propagate the value of the
         // RPC future. Use value() here instead of constValue() to ensure we
         // propagate errors.

--- a/torch/csrc/distributed/c10d/HashStore.hpp
+++ b/torch/csrc/distributed/c10d/HashStore.hpp
@@ -49,7 +49,7 @@ class TORCH_API HashStore : public Store {
       const std::vector<std::string>& keys,
       const std::vector<std::vector<uint8_t>>& values) override;
 
-  // Returns true if this store support append, multiGet and multiSet
+  // Returns true if this store supports append, multiGet and multiSet
   bool hasExtendedApi() const override;
 
   void queuePush(const std::string& key, const std::vector<uint8_t>& value)

--- a/torch/csrc/distributed/c10d/PrefixStore.cpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.cpp
@@ -105,7 +105,7 @@ void PrefixStore::multiSet(
   store_->multiSet(prefixed_keys, values);
 }
 
-// Returns true if this store support append, multiGet and multiSet
+// Returns true if this store supports append, multiGet and multiSet
 bool PrefixStore::hasExtendedApi() const {
   return store_->hasExtendedApi();
 }

--- a/torch/csrc/distributed/c10d/PrefixStore.hpp
+++ b/torch/csrc/distributed/c10d/PrefixStore.hpp
@@ -49,7 +49,7 @@ class TORCH_API PrefixStore : public Store {
       const std::vector<std::string>& keys,
       const std::vector<std::vector<uint8_t>>& values) override;
 
-  // Returns true if this store support append, multiGet and multiSet
+  // Returns true if this store supports append, multiGet and multiSet
   bool hasExtendedApi() const override;
 
   void queuePush(const std::string& key, const std::vector<uint8_t>& value)

--- a/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupUCC.hpp
@@ -170,7 +170,7 @@ class TORCH_API ProcessGroupUCC : public Backend {
   // Performs a health check by initializing dummy UCC & UCX communicators and
   // then destroying them. This will help indicate and signal any
   // UCC/UCX-related issues prior to the first collective. The actual
-  // initialization and subsequent destruction is ran on a separate thread and
+  // initialization and subsequent destruction is run on a separate thread and
   // the main thread is signalled about timeouts/errors to report to the
   // application.
   void runHealthCheck();

--- a/torch/csrc/distributed/c10d/Store.hpp
+++ b/torch/csrc/distributed/c10d/Store.hpp
@@ -97,7 +97,7 @@ class TORCH_API Store : public torch::CustomClassHolder {
       const std::vector<std::string>& keys,
       const std::vector<std::vector<uint8_t>>& values);
 
-  // Returns true if this store support append, multiGet and multiSet
+  // Returns true if this store supports append, multiGet and multiSet
   virtual bool hasExtendedApi() const;
 
   virtual void queuePush(

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -364,7 +364,7 @@ AOTI_API AOTIRuntimeError AOTInductorModelRun(
     AtenTensorHandle* output_handles);
 
 // Replace AOTInductorModel's constant map. Note it doesn't handle concurrency
-// so be sure to handle ordering if AOTInductorModelRun is ran concurrently.
+// so be sure to handle ordering if AOTInductorModelRun is run concurrently.
 AOTI_API AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
     AOTInductorConstantMapHandle constant_map_handle);

--- a/torch/csrc/jit/ir/alias_analysis.cpp
+++ b/torch/csrc/jit/ir/alias_analysis.cpp
@@ -809,7 +809,7 @@ void AliasDb::analyzeImpl(Node* node) {
 
   if (analysis == AliasAnalysisKind::CONSERVATIVE) {
     // TODO A previous implementation of alias analysis always accessed
-    // node->schema , which cause the schema caches in the Node class to be
+    // node->schema , which caused the schema caches in the Node class to be
     // filled for the full graph. Unfortunately, our JIT passes started relying
     // on that, so we need to keep doing this. Details: in
     // caffe2/torch/onnx/utils.py, _jit_pass_onnx is called on an invalid JIT

--- a/torch/csrc/jit/mobile/flatbuffer_loader.h
+++ b/torch/csrc/jit/mobile/flatbuffer_loader.h
@@ -109,7 +109,7 @@ TORCH_API uint64_t get_bytecode_version_from_bytes(char* flatbuffer_content);
 TORCH_API mobile::ModuleInfo get_module_info_from_flatbuffer(
     char* flatbuffer_content);
 
-// The methods below are less efficient because it need to read the stream in
+// The methods below are less efficient because it needs to read the stream in
 // its entirety to a buffer
 TORCH_API mobile::Module load_mobile_module_from_stream_with_copy(
     std::istream& in,

--- a/torch/csrc/jit/mobile/import.h
+++ b/torch/csrc/jit/mobile/import.h
@@ -93,7 +93,7 @@ namespace mobile {
 /**
  * Given a torch::jit::mobile::Module, return a set of operator names
  * (with overload name) that are used by any method in this mobile
- * Mobile. This method runs through the bytecode for all methods
+ * Module. This method runs through the bytecode for all methods
  * in the specified model (module), and extracts all the root
  * operator names. Root operators are operators that are called
  * directly by the model (as opposed to non-root operators, which

--- a/torch/nativert/executor/OpKernel.h
+++ b/torch/nativert/executor/OpKernel.h
@@ -35,7 +35,7 @@ class Arguments {
     }
   }
 
-  // Returns a view of pairs consist of the argument index and
+  // Returns a view of pairs consisting of the argument index and
   // the corresponding Value pointer from the graph.
   auto getDynamicArgs() const {
     std::vector<std::pair<size_t, Value*>> ret;

--- a/torch/nn/utils/rnn.py
+++ b/torch/nn/utils/rnn.py
@@ -45,7 +45,7 @@ class PackedSequence(PackedSequence_):
         Instances of this class should never be created manually. They are meant
         to be instantiated by functions like :func:`pack_padded_sequence`.
 
-        Batch sizes represent the number elements at each sequence step in
+        Batch sizes represent the number of elements at each sequence step in
         the batch, not the varying sequence lengths passed to
         :func:`pack_padded_sequence`.  For instance, given data ``abc`` and ``x``
         the :class:`PackedSequence` would contain data ``axbc`` with

--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -2640,7 +2640,7 @@ class RpcTest(RpcAgentTestFixture, RpcTestCommon):
             with self.assertRaisesRegex(ValueError, expected_err):
                 fut.wait()
             # This barrier prevents a race condition where the main thread exits
-            # context manager before the remote function has ran.
+            # context manager before the remote function has run.
             dist.barrier()
 
         # Validate that trainers log errors when running functions.

--- a/torch/utils/data/datapipes/utils/common.py
+++ b/torch/utils/data/datapipes/utils/common.py
@@ -133,7 +133,7 @@ def _is_local_fn(fn):
 
 def _check_unpickable_fn(fn: Callable) -> None:
     """
-    Check function is pickable or not.
+    Check function is picklable or not.
 
     If it is a lambda or local function, a UserWarning will be raised. If it's not a callable function, a TypeError will be raised.
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194417

Corrects subject-verb agreement, past-participle forms ("ran" -> "run"),
and a few wrong words ("Mobile" -> "Module", "pickable" -> "picklable",
"number elements" -> "number of elements") across comments and docstrings.
No functional changes.

Test Plan: comment- and docstring-only changes, so no behavior to test.
Verified nothing outside comments and docstrings was touched.

This change was authored with the help of an AI assistant.