### PR TITLE
Fix grammar and typos in code comments and docstrings

### DIFF
--- a/torch/_inductor/codegen/multi_kernel.py
+++ b/torch/_inductor/codegen/multi_kernel.py
@@ -439,7 +439,7 @@ class MultiKernelCall:
     #
     # An alternative that reused the multi-kernel cache does not work well
     # since during codegen of the second pass, it's very hard to know the
-    # path for the cache file. Also reading the cache file need do some IO
+    # path for the cache file. Also reading the cache file needs to do some IO
     # which can be slower.
     @staticmethod
     def record_choice(multi_kernel_name: str, picked_kernel_name: str):

--- a/torch/csrc/api/include/torch/data/datasets/stateful.h
+++ b/torch/csrc/api/include/torch/data/datasets/stateful.h
@@ -21,7 +21,7 @@ namespace torch::data::datasets {
 /// ended, it should return an empty optional. The dataloader knows to modify
 /// its implementation based on whether the dataset is stateless or stateful.
 ///
-/// Note that when subclassing a from `StatefulDataset<Self, T>`, the return
+/// Note that when subclassing from `StatefulDataset<Self, T>`, the return
 /// type of `get_batch()`, which the subclass must override, will be
 /// `optional<T>` (i.e. the type specified in the `StatefulDataset`
 /// specialization is automatically boxed into an `optional` for the dataset's

--- a/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
+++ b/torch/csrc/distributed/c10d/hooks/FlightRecorderHook.cpp
@@ -556,7 +556,7 @@ void FlightRecorderHook::onPre(const PreHookArgs& args) {
   // entry the ring buffer has already overwritten (retire_completed would no-op
   // on it), so the buffer's own capacity is the bound. Dropping the oldest also
   // releases its Work, so a backend that never finishes an op cannot be pinned
-  // by the recorder for ever.
+  // by the recorder forever.
   while (inflight_.size() > max_inflight_) {
     auto oldest = inflight_.begin();
     if (oldest->second.work) {

--- a/torch/csrc/jit/codegen/fuser/executor.cpp
+++ b/torch/csrc/jit/codegen/fuser/executor.cpp
@@ -340,7 +340,7 @@ bool runFusion(const int64_t key, Stack& stack, std::string* code_out) {
 
   // Determines device to dispatch to.
   at::Device device = inputs.at(0).device();
-  // If there's a device mismatch in the inputs or if one of the input is a
+  // If there's a device mismatch in the inputs or if one of the inputs is a
   // sparse tensor, we use the fallback (which should give a nice error
   // message).
   for (const auto& t : at::TensorList(inputs).slice(1)) {

--- a/torch/csrc/jit/frontend/exit_transforms.cpp
+++ b/torch/csrc/jit/frontend/exit_transforms.cpp
@@ -511,7 +511,7 @@ struct ExitTransformer {
   //   while i < 3:
   //     continue
   //   break
-  // when we transform the for loop block, target_block_ will be set the for
+  // when we transform the for loop block, target_block_ will be set to the for
   // block. then, when we enter the while loop, target_block_ will be the while
   // loop block. when we are done transforming the while it will be set back to
   // the for block.

--- a/torch/csrc/jit/frontend/lexer.h
+++ b/torch/csrc/jit/frontend/lexer.h
@@ -265,7 +265,7 @@ struct TORCH_API SharedParserData {
         *kind = TK_IDENT;
       }
       // check for token second, so that e.g. 'max' matches the token TK_MAX
-      // rather the
+      // rather than the
       // identifier 'max'
       if (cur) {
         const auto begin_it = cur->child_chars.begin();

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -779,7 +779,7 @@ class AttributePropagator {
       }
       TORCH_INTERNAL_ASSERT(node->inputs().size() == 1);
       TORCH_INTERNAL_ASSERT(node->outputs().size() == 1);
-      // If input type is not a from aten::fork call then the
+      // If input type is not from an aten::fork call then the
       // aten::wait operator can be deleted.
       if (node->input()->type()->kind() != TypeKind::FutureType) {
         node->output()->replaceAllUsesWith(node->input());

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -1067,7 +1067,7 @@ class ShapePropagator : public PropertyPropBase {
         }};
 
     // aten::where is special in that its return type is the second argument's
-    // (self) type rather than the that of condition
+    // (self) type rather than that of condition
     static const register_formula_for where_op{
         {
             "aten::where(Tensor condition, Tensor self, Tensor other) -> Tensor",

--- a/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_runtime_fusion.cpp
@@ -524,7 +524,7 @@ static RegisterOperators SRCopyOuts({
 
 // On each invocation of this guard, we need to check all of the static
 // information (dtype/device/requires grad/contiguity/static dims),
-// and also the that the symbolic shape dimensions are observed.
+// and also that the symbolic shape dimensions are observed.
 // For any symbolic dimension we need to set its value on its first
 // use and for all subsequent uses check that the values are equal
 static RegisterOperators reg_guard({

--- a/torch/csrc/jit/runtime/graph_iterator.h
+++ b/torch/csrc/jit/runtime/graph_iterator.h
@@ -93,7 +93,7 @@ class DepthFirstGraphNodeIterator {
     }
   }
 
-  // Moves to the next adjacent node or up in to the parent if that is not
+  // Moves to the next adjacent node or up into the parent if that is not
   // possible.
   void move_next() {
     if (current_ == nullptr) {

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -1272,7 +1272,7 @@ Tensor TensorExprKernel::convertSymbolicOutputToCorrectStrides(
   // [0] [3] [1] [4] [2] [5]
   // When we are doing the re-ordering of values into the output tensor,
   // we are iterating per-element of the input, and we are fixed
-  // in indexing in to the output tensor at [i, j] = val
+  // in indexing into the output tensor at [i, j] = val
   // `val` we want here is equal to the indices for the output
   // tensor that would have given the same position as the output
   // The position is equal to the sum of stride[i] * index[i],

--- a/torch/export/_remove_auto_functionalized_pass.py
+++ b/torch/export/_remove_auto_functionalized_pass.py
@@ -26,7 +26,7 @@ def unsafe_remove_auto_functionalized_pass(
     ep: ExportedProgram,
 ) -> ExportedProgram:
     """
-    This pass removes an instances of the higher order op 'auto_functionalized',
+    This pass removes all instances of the higher order op 'auto_functionalized',
     and modifies the calling EP inplace to have the original mutator op.
     This pass doesn't perform safety checks to make sure that this inplace mutation is safe.
     """

--- a/torch/fx/experimental/unification/multipledispatch/utils.py
+++ b/torch/fx/experimental/unification/multipledispatch/utils.py
@@ -85,8 +85,8 @@ def reverse_dict(
     {1: ('a',), 2: ('a', 'b'), 3: ('b',)}
 
     .. note::
-        dict order are not deterministic. As we iterate on the
-        input dict, it make the output of this function depend on the
+        dict order is not deterministic. As we iterate on the
+        input dict, it makes the output of this function depend on the
         dict order. So this function output order should be considered
         as undeterministic.
     """

--- a/torch/fx/subgraph_rewriter.py
+++ b/torch/fx/subgraph_rewriter.py
@@ -409,7 +409,7 @@ def _replace_pattern(
             v for v in val_map.values() if v not in match.placeholder_nodes
         ]
 
-        # Hook the output Node of the replacement subgraph in to the
+        # Hook the output Node of the replacement subgraph into the
         # original Graph at the correct location
         if len(match.returning_nodes) != len(copied_returning_nodes):  # type: ignore[arg-type]
             raise AssertionError(

--- a/torch/headeronly/util/Float8_e4m3fnuz.h
+++ b/torch/headeronly/util/Float8_e4m3fnuz.h
@@ -71,7 +71,7 @@ namespace detail {
 inline C10_HOST_DEVICE uint8_t fp8e4m3fnuz_from_fp32_value(float f) {
   /*
    * Binary representation of 256.0f, which is the first value not representable
-   * (i.e. the first value which would overflow in to the sign bit, resulting in
+   * (i.e. the first value which would overflow into the sign bit, resulting in
    * a NaN) in fp8e4m3fnuz range:
    * 1 0000 000 - fp8e4m3fnuz
    * 0 10000111 00000000000000000000000 - fp32

--- a/torch/headeronly/util/Float8_e5m2fnuz.h
+++ b/torch/headeronly/util/Float8_e5m2fnuz.h
@@ -70,7 +70,7 @@ namespace detail {
 inline C10_HOST_DEVICE uint8_t fp8e5m2fnuz_from_fp32_value(float f) {
   /*
    * Binary representation of 65536.0f, which is the first value not
-   * representable (i.e. the first value which would overflow in to the sign
+   * representable (i.e. the first value which would overflow into the sign
    * bit, resulting in a NaN) in fp8e4m3fnuz range:
    * 1 00000 00 - fp8e5m2fnuz
    * 0 10001111 00000000000000000000000 - fp32


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Sweep of pre-existing grammatical slips in comments and docstrings across
inductor, the JIT frontend/passes/runtime, the C++ data API, FX, export, and
the headeronly float8 helpers. Most are missing or misplaced articles and
prepositions ("in to" -> "into", "rather the" -> "rather than the", "a from"
-> "from a"), plus subject/verb agreement in the multipledispatch docstring.

No functional changes; comments and docstrings only.

Test Plan: no runtime behavior is touched, so no tests were run.

Authored with the assistance of an AI coding agent.

cc @EikanWang @jgong5 @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo