### PR TITLE
distributed: improve collective fingerprint diagnostics

### DIFF
--- a/test/distributed/test_pg_wrapper.py
+++ b/test/distributed/test_pg_wrapper.py
@@ -1,5 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 
+import gc
 import os
 import sys
 import unittest
@@ -699,6 +700,46 @@ class ProcessGroupGlooWrapperTest(AbstractProcessGroupWrapperTest):
                 end = (r + 1) * in_shapes[i][0]
                 expected[start:end] = torch.ones(in_shapes[i]) * (r + 1)
             self.assertTrue(torch.allclose(output, expected))
+
+    @with_dist_debug_levels(levels=["DETAIL"])
+    def test_collective_fingerprint_advisory_fields_do_not_mismatch(self):
+        # https://github.com/pytorch/pytorch/issues/97469
+        pg = self._create_wrapper_pg(with_new_group=True)
+        gc_was_enabled = gc.isenabled()
+        try:
+            # Create divergent tracked GC state across ranks.
+            if self.rank == 0:
+                gc.disable()
+                before = gc.get_count()
+                self._gc_hold = [[] for _ in range(500)]
+                self.assertNotEqual(before, gc.get_count())
+            else:
+                gc.collect()
+
+            tensor = torch.ones(8) * (self.rank + 1)
+            pg.allreduce([tensor]).wait()
+
+            with self.assertRaisesRegex(RuntimeError, ".*") as cm:
+                if self.rank == 0:
+                    pg.allreduce([tensor])
+                else:
+                    pg.reduce([tensor])
+            self._validate_error(
+                exception=cm.exception,
+                op_type="ALLREDUCE" if self.rank == 0 else "REDUCE",
+                rank=self.rank,
+                tensor=tensor,
+            )
+            err = str(cm.exception)
+            self.assertIn("PythonGcCounts=", err)
+            self.assertIn("SteadyClockTimeMs=", err)
+        finally:
+            if hasattr(self, "_gc_hold"):
+                del self._gc_hold
+            if gc_was_enabled:
+                gc.enable()
+            else:
+                gc.disable()
 
     @with_dist_debug_levels(levels=["DETAIL"])
     def test_allgather_into_tensor_coalesced_op_mismatch_debug_mode(self):

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -7,11 +7,17 @@
 #include <c10/util/Exception.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/irange.h>
+#include <chrono>
 #include <optional>
 #include <stdexcept>
 #include <utility>
 
 namespace c10d {
+
+gc_count_getter_t& get_gc_count_getter() {
+  static gc_count_getter_t getter = nullptr;
+  return getter;
+}
 
 namespace {
 // A container for information about a particular collective, including optype
@@ -28,6 +34,9 @@ struct CollectiveFingerPrint {
   // input tensor sizes
   std::vector<std::vector<int64_t>> tensor_sizes_;
   uint64_t sequence_number_;
+  // Local-only debug context; not included in serialize_fingerprint().
+  std::optional<std::array<int64_t, 3>> python_gc_counts_;
+  std::optional<int64_t> steady_clock_time_ms_;
 
   CollectiveFingerPrint(
       OpType op_type,
@@ -35,7 +44,18 @@ struct CollectiveFingerPrint {
       uint64_t sequence_number)
       : op_type_(op_type),
         num_tensors_(input_tensors.size()),
-        sequence_number_(sequence_number) {
+        sequence_number_(sequence_number),
+        steady_clock_time_ms_(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now().time_since_epoch())
+                .count()) {
+    if (auto getter = get_gc_count_getter()) {
+      try {
+        python_gc_counts_ = (*getter)();
+      } catch (...) {
+        // Optional diagnostics must not fail the collective.
+      }
+    }
     tensor_dtypes_.reserve(num_tensors_);
     tensor_device_types_.reserve(num_tensors_);
     tensor_sizes_.reserve(num_tensors_);
@@ -332,6 +352,18 @@ std::ostream& operator<<(
     const CollectiveFingerPrint& collective_fingerprint) {
   std::string collectiveInfo;
   auto op_type_str = opTypeToString(collective_fingerprint.op_type_);
+  std::string debug_info;
+  if (collective_fingerprint.python_gc_counts_.has_value()) {
+    const auto& gc = *collective_fingerprint.python_gc_counts_;
+    debug_info = c10::str(
+        ", PythonGcCounts=[", gc[0], ", ", gc[1], ", ", gc[2], "]");
+  }
+  if (collective_fingerprint.steady_clock_time_ms_.has_value()) {
+    debug_info = c10::str(
+        debug_info,
+        ", SteadyClockTimeMs=",
+        *collective_fingerprint.steady_clock_time_ms_);
+  }
   if (collective_fingerprint.num_tensors_ != 0) {
     // Convert dtype and device type info to string.
     std::vector<std::string> dtype_strs =
@@ -353,14 +385,16 @@ std::ostream& operator<<(
         dtype_strs,
         ", TensorDeviceTypes=",
         device_type_strs,
+        debug_info,
         ")");
   } else {
     collectiveInfo = c10::str(
         "CollectiveFingerPrint(",
         "SequenceNumber=",
         collective_fingerprint.sequence_number_,
-        "OpType=",
+        ", OpType=",
         op_type_str,
+        debug_info,
         ")");
   }
   return output << collectiveInfo;

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -355,8 +355,8 @@ std::ostream& operator<<(
   std::string debug_info;
   if (collective_fingerprint.python_gc_counts_.has_value()) {
     const auto& gc = *collective_fingerprint.python_gc_counts_;
-    debug_info = c10::str(
-        ", PythonGcCounts=[", gc[0], ", ", gc[1], ", ", gc[2], "]");
+    debug_info =
+        c10::str(", PythonGcCounts=[", gc[0], ", ", gc[1], ", ", gc[2], "]");
   }
   if (collective_fingerprint.steady_clock_time_ms_.has_value()) {
     debug_info = c10::str(

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -8,6 +8,7 @@
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/irange.h>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <chrono>
 #include <optional>
 #include <stdexcept>
@@ -363,12 +364,12 @@ std::ostream& operator<<(
 
     fmt::print(
         output,
-        "CollectiveFingerPrint(SequenceNumber={}, OpType={}, TensorShape=[{}], TensorDtypes={}, TensorDeviceTypes={}",
+        "CollectiveFingerPrint(SequenceNumber={}, OpType={}, TensorShape=[{}], TensorDtypes=[{}], TensorDeviceTypes=[{}]",
         collective_fingerprint.sequence_number_,
         op_type_str,
-        c10::Join(", ", size_strs),
-        fmt::streamed(dtype_strs),
-        fmt::streamed(device_type_strs));
+        fmt::join(size_strs, ", "),
+        fmt::join(dtype_strs, ", "),
+        fmt::join(device_type_strs, ", "));
   } else {
     fmt::print(
         output,
@@ -378,7 +379,7 @@ std::ostream& operator<<(
   }
   if (collective_fingerprint.python_gc_counts_.has_value()) {
     const auto& gc = *collective_fingerprint.python_gc_counts_;
-    fmt::print(output, ", PythonGcCounts=[{}, {}, {}]", gc[0], gc[1], gc[2]);
+    fmt::print(output, ", PythonGcCounts=[{}]", fmt::join(gc, ", "));
   }
   if (collective_fingerprint.steady_clock_time_ms_.has_value()) {
     fmt::print(

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.cpp
@@ -7,6 +7,7 @@
 #include <c10/util/Exception.h>
 #include <c10/util/intrusive_ptr.h>
 #include <c10/util/irange.h>
+#include <fmt/ostream.h>
 #include <chrono>
 #include <optional>
 #include <stdexcept>
@@ -350,20 +351,7 @@ struct CollectiveFingerPrint {
 std::ostream& operator<<(
     std::ostream& output,
     const CollectiveFingerPrint& collective_fingerprint) {
-  std::string collectiveInfo;
   auto op_type_str = opTypeToString(collective_fingerprint.op_type_);
-  std::string debug_info;
-  if (collective_fingerprint.python_gc_counts_.has_value()) {
-    const auto& gc = *collective_fingerprint.python_gc_counts_;
-    debug_info =
-        c10::str(", PythonGcCounts=[", gc[0], ", ", gc[1], ", ", gc[2], "]");
-  }
-  if (collective_fingerprint.steady_clock_time_ms_.has_value()) {
-    debug_info = c10::str(
-        debug_info,
-        ", SteadyClockTimeMs=",
-        *collective_fingerprint.steady_clock_time_ms_);
-  }
   if (collective_fingerprint.num_tensors_ != 0) {
     // Convert dtype and device type info to string.
     std::vector<std::string> dtype_strs =
@@ -373,31 +361,33 @@ std::ostream& operator<<(
     std::vector<std::string> size_strs =
         CollectiveFingerPrint::get_size_strs(collective_fingerprint);
 
-    collectiveInfo = c10::str(
-        "CollectiveFingerPrint(",
-        "SequenceNumber=",
+    fmt::print(
+        output,
+        "CollectiveFingerPrint(SequenceNumber={}, OpType={}, TensorShape=[{}], TensorDtypes={}, TensorDeviceTypes={}",
         collective_fingerprint.sequence_number_,
-        ", OpType=",
         op_type_str,
-        ", TensorShape=[",
         c10::Join(", ", size_strs),
-        "], TensorDtypes=",
-        dtype_strs,
-        ", TensorDeviceTypes=",
-        device_type_strs,
-        debug_info,
-        ")");
+        fmt::streamed(dtype_strs),
+        fmt::streamed(device_type_strs));
   } else {
-    collectiveInfo = c10::str(
-        "CollectiveFingerPrint(",
-        "SequenceNumber=",
+    fmt::print(
+        output,
+        "CollectiveFingerPrint(SequenceNumber={}, OpType={}",
         collective_fingerprint.sequence_number_,
-        ", OpType=",
-        op_type_str,
-        debug_info,
-        ")");
+        op_type_str);
   }
-  return output << collectiveInfo;
+  if (collective_fingerprint.python_gc_counts_.has_value()) {
+    const auto& gc = *collective_fingerprint.python_gc_counts_;
+    fmt::print(output, ", PythonGcCounts=[{}, {}, {}]", gc[0], gc[1], gc[2]);
+  }
+  if (collective_fingerprint.steady_clock_time_ms_.has_value()) {
+    fmt::print(
+        output,
+        ", SteadyClockTimeMs={}",
+        *collective_fingerprint.steady_clock_time_ms_);
+  }
+  fmt::print(output, ")");
+  return output;
 }
 
 bool check_same_size(const std::vector<at::Tensor>& input_tensors) {

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -11,6 +11,8 @@
 
 namespace c10d {
 
+// Returns Python GC counters in generation order:
+// [generation 0, generation 1, generation 2].
 // Registered by the Python bindings when available.
 typedef std::optional<std::array<int64_t, 3>> (*gc_count_getter_t)();
 

--- a/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroupWrapper.hpp
@@ -2,11 +2,19 @@
 
 #ifdef USE_C10D_GLOO
 
+#include <array>
+#include <optional>
+
 #include <torch/csrc/distributed/c10d/ProcessGroupGloo.hpp>
 #include <torch/csrc/distributed/c10d/Types.hpp>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 
 namespace c10d {
+
+// Registered by the Python bindings when available.
+typedef std::optional<std::array<int64_t, 3>> (*gc_count_getter_t)();
+
+TORCH_API gc_count_getter_t& get_gc_count_getter();
 
 // ProcessGroupWrapper wraps a Backend for debugging purposes. It intercepts
 // collective operations to verify consistency across ranks before dispatching

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -107,6 +107,29 @@ bool registerGilChecker() {
 static bool registered = registerGilChecker();
 #endif // USE_C10D_NCCL
 
+#ifdef USE_C10D_GLOO
+
+std::optional<std::array<int64_t, 3>> get_python_gc_counts() {
+  if (!Py_IsInitialized()) {
+    return std::nullopt;
+  }
+  pybind11::gil_scoped_acquire gil;
+  py::tuple counts =
+      py::module_::import("gc").attr("get_count")().cast<py::tuple>();
+  return std::array<int64_t, 3>{
+      counts[0].cast<int64_t>(),
+      counts[1].cast<int64_t>(),
+      counts[2].cast<int64_t>()};
+}
+
+bool registerGcCountGetter() {
+  c10d::get_gc_count_getter() = &get_python_gc_counts;
+  return true;
+}
+
+static bool registered_gc_count_getter = registerGcCountGetter();
+#endif // USE_C10D_GLOO
+
 // Wrapper to ensure GIL is released before destructing ProcessGroupGloo
 // TODO: move this somewhere more generally useful
 template <typename T>


### PR DESCRIPTION
## Summary

Improves collective fingerprint diagnostics used with
`TORCH_DISTRIBUTED_DEBUG=DETAIL`.

This adds:

- Python GC counts for all three generations using `gc.get_count()`
- a C++ monotonic timestamp using `std::chrono::steady_clock`
- the new diagnostic fields to collective fingerprint log/error output

The GC counts are obtained through a callback registered from the Python
bindings so `ProcessGroupWrapper.cpp` remains independent of Python/CPython
headers.

The GC counts and monotonic timestamp are intentionally local-only diagnostic
fields. They are not included in `serialize_fingerprint()` and therefore do
not participate in cross-rank fingerprint equality checks. This avoids false
collective mismatches when ranks naturally have different GC state or local
timestamps.

Also fixes the missing separator between `SequenceNumber` and `OpType` in the
no-tensor fingerprint output.

Fixes #97469

## Testing

Built locally on Windows with:

- `USE_DISTRIBUTED=ON`
- `USE_GLOO=ON`
- `USE_CUDA=OFF`

Native build:

```text
ninja -C build torch_cpu torch_python
```
Passed:

```text
python test/distributed/test_pg_wrapper.py ProcessGroupGlooWrapperTest.test_collective_fingerprint_advisory_fields_do_not_mismatch
python test/distributed/test_pg_wrapper.py ProcessGroupGlooWrapperTest.test_collectives_op_mismatch_debug_mode
python test/distributed/test_pg_wrapper.py ProcessGroupGlooWrapperTest.test_collective_shape_mismatch_debug_mode
```
Additional checks:

```text
git diff --check
python -m py_compile test/distributed/test_pg_wrapper.py
```
