### PR TITLE
Add gradcheck diagnostic for dependent checked inputs

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7329,6 +7329,142 @@ Done""",
         check(fast_mode=True)
         check(fast_mode=False)
 
+    @parametrize("fast_mode", [True, False])
+    def test_gradcheck_dependent_inputs_hint(self, fast_mode):
+        # https://github.com/pytorch/pytorch/issues/121842: when one checked input is
+        # an autograd ancestor of another, the analytical Jacobian wrt the ancestor
+        # picks up chain rule terms that finite differences do not see.
+        hint = "potential dependency from this input to another"
+
+        def mismatch_wrt_first(*args):
+            out = args[0].clone()
+            out.register_hook(lambda grad: grad + 1e-2)
+            return out + sum(args[1:])
+
+        x = torch.ones(1, dtype=torch.double, requires_grad=True)
+        y = 3 * x
+        with self.assertRaisesRegex(RuntimeError, hint):
+            gradcheck(torch.dot, (x, y), fast_mode=fast_mode)
+        self.assertFalse(
+            gradcheck(torch.dot, (x, y), raise_exception=False, fast_mode=fast_mode)
+        )
+
+        # The dependency does not have to be direct.
+        x = torch.randn(3, dtype=torch.double, requires_grad=True)
+        z = x.sin() * 3
+        with self.assertRaisesRegex(RuntimeError, hint):
+            gradcheck(lambda x, z: x * z, (x, z), fast_mode=fast_mode)
+
+        # A shared ancestor is not a dependency between the checked inputs: neither
+        # q nor k is reachable from the other, so gradcheck still passes.
+        h = torch.randn(3, dtype=torch.double, requires_grad=True)
+        q, k = 2 * h, 3 * h
+        self.assertTrue(gradcheck(lambda q, k: q * k, (q, k), fast_mode=fast_mode))
+
+        # A wrong backward for an input that is not an ancestor gets no hint.
+        a = torch.randn(3, dtype=torch.double, requires_grad=True)
+        with self.assertRaises(RuntimeError) as cm:
+            gradcheck(mismatch_wrt_first, (a,), fast_mode=fast_mode)
+        self.assertNotIn(hint, str(cm.exception))
+
+        # The hint is scoped to the input that actually mismatched. Here x is an
+        # ancestor of y, but the mismatch is wrt a, so that dependency cannot
+        # explain it. y is unused so it contributes no chain rule term to x either.
+        x = torch.randn(3, dtype=torch.double, requires_grad=True)
+        y = 3 * x
+        with self.assertRaises(RuntimeError) as cm:
+            gradcheck(
+                lambda a, x, y: mismatch_wrt_first(a, x),
+                (a, x, y),
+                fast_mode=fast_mode,
+            )
+        self.assertIn("with respect to input 0", str(cm.exception))
+        self.assertNotIn(hint, str(cm.exception))
+
+        # Two outputs of the same node are different gradient edges, not an
+        # ancestor-descendant pair, so an unrelated mismatch gets no hint.
+        x = torch.randn(4, dtype=torch.double, requires_grad=True)
+        p, r = (3 * x).split(2)
+        self.assertIs(p.grad_fn, r.grad_fn)
+        self.assertNotEqual(p.output_nr, r.output_nr)
+        with self.assertRaises(RuntimeError) as cm:
+            gradcheck(mismatch_wrt_first, (p, r), fast_mode=fast_mode)
+        self.assertNotIn(hint, str(cm.exception))
+
+        # Forward AD builds its duals from detached inputs, so it is unaffected by
+        # the dependency that makes the backward check above fail.
+        x = torch.ones(1, dtype=torch.double, requires_grad=True)
+        y = 3 * x
+        self.assertTrue(
+            gradcheck(
+                torch.dot,
+                (x, y),
+                fast_mode=fast_mode,
+                check_forward_ad=True,
+                check_backward_ad=False,
+                check_batched_grad=False,
+            )
+        )
+
+        # gradgradcheck delegates to gradcheck, so it inherits the diagnostic.
+        x = torch.randn(3, dtype=torch.double, requires_grad=True)
+        y = 3 * x
+        with self.assertRaisesRegex(RuntimeError, hint):
+            gradgradcheck(lambda p, q: p * q, (x, y), fast_mode=fast_mode)
+        a = torch.randn(3, dtype=torch.double, requires_grad=True)
+        b = torch.randn(3, dtype=torch.double, requires_grad=True)
+        self.assertTrue(gradgradcheck(lambda p, q: p * q, (a, b), fast_mode=fast_mode))
+
+    def test_gradcheck_potential_dependency_predicate(self):
+        from torch.autograd.gradcheck import (
+            _has_potential_dependency_to_other_checked_input as has_dependency,
+        )
+
+        x = torch.randn(4, dtype=torch.double, requires_grad=True)
+        y = 3 * x
+        self.assertTrue(has_dependency((x, y), x))
+        # The relationship is directed: nothing was computed from y.
+        self.assertFalse(has_dependency((x, y), y))
+
+        # Sharing an ancestor is not a dependency between the checked inputs.
+        h = torch.randn(4, dtype=torch.double, requires_grad=True)
+        q, k = 2 * h, 3 * h
+        self.assertFalse(has_dependency((q, k), q))
+
+        # Distinct outputs of one node share a Node but not a gradient edge.
+        p, r = y.split(2)
+        self.assertFalse(has_dependency((p, r), p))
+
+        # An input passed twice resolves to the same gradient edge.
+        self.assertFalse(has_dependency((x, x), x))
+
+        # Nested inputs are flattened the same way the analytical path flattens them.
+        self.assertTrue(has_dependency((x, [y]), x))
+
+        # The predicate reports a potential dependency, not a proven one.
+        # next_functions belongs to a Node rather than to one of its outputs, so the
+        # two outputs below cannot be told apart by their upstream edges even though
+        # each depends on only one input, and u is reported for out_v despite
+        # d(out_v)/du being zero.
+        class SplitDependency(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, a, b):
+                return a.clone(), b.clone()
+
+            @staticmethod
+            def backward(ctx, grad_a, grad_b):
+                return grad_a, grad_b
+
+        u = torch.randn(4, dtype=torch.double, requires_grad=True)
+        v = torch.randn(4, dtype=torch.double, requires_grad=True)
+        out_u, out_v = SplitDependency.apply(u, v)
+        self.assertIs(out_u.grad_fn, out_v.grad_fn)
+        self.assertEqual(
+            torch.autograd.grad(out_v.sum(), u, allow_unused=True)[0],
+            torch.zeros_like(u),
+        )
+        self.assertTrue(has_dependency((u, out_v), u))
+
     def test_gradcheck_dense_and_sparse_inputs(self):
         def check(fast_mode):
             def fn(x, y):

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -11,6 +11,7 @@ import torch.testing
 
 # pyrefly: ignore [deprecated]
 from torch._vmap_internals import _vmap, vmap
+from torch.autograd.graph import get_gradient_edge
 from torch.overrides import is_tensor_like
 from torch.types import _TensorOrOptionalTensors, _TensorOrTensors
 
@@ -1395,6 +1396,68 @@ def _differentiable_outputs(x):
     return tuple(o for o in _as_tuple(x) if o.requires_grad)
 
 
+CHECKED_INPUT_DEPENDENCY_MSG = """
+The autograd graph contains a potential dependency from this input to another
+checked input. Numerical gradcheck perturbs one checked input at a time without
+recomputing the other explicit inputs from it, whereas backward mode autograd can
+additionally propagate through such a dependency and pick up extra chain rule
+terms. That can make the numerical and analytical checks disagree even when the
+backward implementation is correct. To check the composed function, build the
+dependency inside func, for example gradcheck(lambda x: func(x, g(x)), (x,)). To
+check local Jacobians, pass inputs that do not depend on each other, for example
+x.detach().requires_grad_().
+""".strip()
+
+
+def _has_potential_dependency_to_other_checked_input(inputs, candidate) -> bool:
+    # Reachability is over gradient edges rather than nodes alone: two checked inputs
+    # may be distinct outputs of one Node, which is not an ancestor relationship.
+    # Nodes are deduplicated during traversal, but each edge is matched as it is
+    # encountered, so distinct outputs of the same node stay distinguishable.
+    #
+    # This deliberately overapproximates. next_functions is a property of a Node, not
+    # of one of its outputs, so for a multi-output Node every output looks like it
+    # depends on all of the Node's inputs. Reachability also cannot know whether the
+    # resulting chain rule term is nonzero. The hint is worded as a possible cause.
+    candidate_edge = get_gradient_edge(candidate)
+    target = (candidate_edge.node, candidate_edge.output_nr)
+    for t in _iter_tensors(inputs, only_requiring_grad=True):
+        # _iter_tensors admits Tensor-likes that are not Tensor instances.
+        if not isinstance(t, torch.Tensor):
+            continue
+        edge = get_gradient_edge(t)
+        if (edge.node, edge.output_nr) == target:
+            # The same edge, e.g. an input passed twice, is not a dependency.
+            continue
+        seen = {edge.node}
+        queue = collections.deque([edge.node])
+        while queue:
+            for next_node, output_nr in queue.popleft().next_functions:
+                if next_node is None:
+                    continue
+                if (next_node, output_nr) == target:
+                    return True
+                if next_node not in seen:
+                    seen.add(next_node)
+                    queue.append(next_node)
+    return False
+
+
+def _checked_input_dependency_hint(inputs, checked_inputs, input_idx) -> str:
+    # Diagnostic for the input whose Jacobian actually mismatched; a dependency
+    # between two unrelated checked inputs cannot explain this mismatch. This runs
+    # while building a GradcheckError, so it must never raise and hide that error.
+    try:
+        candidate = checked_inputs[input_idx]
+        if not isinstance(candidate, torch.Tensor):
+            return ""
+        if not _has_potential_dependency_to_other_checked_input(inputs, candidate):
+            return ""
+    except Exception:
+        return ""
+    return "\n" + CHECKED_INPUT_DEPENDENCY_MSG
+
+
 def _get_notallclose_msg(
     analytical,
     numerical,
@@ -1655,9 +1718,11 @@ def _slow_gradcheck(
 
             for j, (a, n) in enumerate(zip(analytical, numerical[i])):
                 if not _allclose_with_type_promotion(a, n.to(a.device), rtol, atol):
-                    raise GradcheckError(
-                        _get_notallclose_msg(a, n, i, j, complex_indices, test_imag)
-                    )
+                    # j indexes the flattened list the analytical path used
+                    diff_inputs = list(_iter_tensors(tupled_inputs, True))
+                    msg = _get_notallclose_msg(a, n, i, j, complex_indices, test_imag)
+                    msg += _checked_input_dependency_hint(tupled_inputs, diff_inputs, j)
+                    raise GradcheckError(msg)
 
     return True
 
@@ -1899,12 +1964,17 @@ def _check_analytical_numerical_equal(
                 jacobians_str = _run_slow_mode_and_get_error(
                     func, tupled_inputs, outputs, i, j, rtol, atol, eps, is_forward_ad
                 )
-                raise GradcheckError(
+                msg = (
                     _get_notallclose_msg(
                         a, n, j, i, complex_indices, test_imag, is_forward_ad
                     )
                     + jacobians_str
                 )
+                if not is_forward_ad:
+                    # i indexes the tensors all_u was built from
+                    inp_tensors = _get_inp_tensors(tupled_inputs)[1]
+                    msg += _checked_input_dependency_hint(tupled_inputs, inp_tensors, i)
+                raise GradcheckError(msg)
 
 
 def _fast_gradcheck(
@@ -2047,6 +2117,23 @@ def gradcheck(
        :func:`torch.Tensor.expand`), this check will likely fail because the numerical
        gradients computed by point perturbation at such indices will change
        values at all other indices that share the same memory address.
+
+    .. note::
+       Numerical differentiation perturbs one checked input at a time without
+       recomputing the other explicit inputs from it. Absent storage aliasing, this
+       corresponds to treating the checked inputs as independent coordinates when
+       computing the numerical derivatives. Backward mode autograd instead sees
+       whatever autograd graph already connects the checked inputs, so if one checked
+       input was computed from another (e.g. ``y = 3 * x`` passed as
+       ``gradcheck(func, (x, y))``) it can additionally propagate through that
+       dependency and pick up extra chain rule terms. The numerical and analytical
+       checks can then disagree even when the backward implementation is correct.
+
+       Which behavior is wanted depends on the function being tested. To check the
+       derivative of the composed function, build the dependency inside ``func``, e.g.
+       ``gradcheck(lambda x: func(x, g(x)), (x,))``. To check local Jacobians with
+       respect to independent coordinates, pass inputs that do not depend on each
+       other, e.g. ``x.detach().requires_grad_()``.
 
     Args:
         func (function): a Python function that takes Tensor inputs and returns


### PR DESCRIPTION
# Add gradcheck diagnostic for dependent checked inputs

Fixes #121842.

## Summary

This PR documents and diagnoses a class of `gradcheck` failures that can occur when one checked input is computed from another checked input.

For example:

```python
x = torch.ones(1, dtype=torch.double, requires_grad=True)
y = 3 * x

gradcheck(torch.dot, (x, y))
```

currently reports:

```text
numerical:  3
analytical: 6
```

The backward implementation is not necessarily incorrect in this situation. The two sides of `gradcheck` can be differentiating against different effective input boundaries:

* **Numerical differentiation** perturbs one explicit checked input at a time without recomputing the other checked inputs from it.
* **Backward-mode autograd** follows the pre-existing autograd graph connecting those tensors.

> **Note**  
> This PR does **not** automatically rewrite or detach user inputs.

Instead, it:
1. Documents the distinction in the `gradcheck` API documentation.
2. Adds a targeted diagnostic after a backward-mode numerical/analytical Jacobian mismatch when the mismatched input has a potential graph dependency to another checked input.

## Why the mismatch occurs

Suppose the function being checked is:
$$F(x, y)$$

but the concrete tensors passed to `gradcheck` satisfy:
$$y = g(x)$$

Numerically, `gradcheck` perturbs $x$ while leaving the explicit $y$ argument unchanged. Ignoring storage aliasing, this treats the supplied arguments as independent coordinates.

For the original reproducer,
$$F(x,y)=xy, \qquad y=3x$$

the numerical derivative with respect to $x$ is therefore:
$$\frac{\partial F}{\partial x}=y=3$$

Backward autograd sees the existing graph:

```mermaid
graph LR
    x --> F
    x --> y
    y --> F
```

so the gradient with respect to $x$ can include both paths:

$$ \frac{dF}{dx} = \frac{\partial F}{\partial x} + \frac{\partial F}{\partial y}\frac{dy}{dx} $$

At $x = 1$, $y = 3$:

$$3 + 1 \cdot 3 = 6$$

This is the `3` versus `6` mismatch reported in #121842.

The same issue is transitive. For example, an input relationship such as:

```mermaid
graph LR
    x --> sin --> intermediate --> multiply --> z
```

can produce the same mismatch when both $x$ and $z$ are supplied as checked inputs.

By contrast, a shared ancestor alone is not sufficient:

```mermaid
graph TD
    h --> q
    h --> k
```

Neither $q$ nor $k$ is upstream of the other, so checking a function of $(q, k)$ does not introduce the same additional path into either requested derivative.

## Why this PR does not automatically detach inputs

A possible implementation-level solution is to detach checked inputs before computing the analytical Jacobian.

That would make the explicit arguments independent autograd coordinates, but it would require `gradcheck` to silently choose a mathematical interpretation that it cannot infer from the call.

Given:

```python
gradcheck(F, (x, y))
```

with $y = g(x)$, the caller may intend either of two different tests.

### Local Jacobian

The caller may want to test:
$$F(x,y)$$

as a function of independent coordinates.

In that case, the appropriate setup is to sever the pre-existing dependency before calling `gradcheck`, for example with detached inputs when appropriate.

### Composed function

The caller may instead want to test:
$$x \mapsto F(x,g(x))$$

In that case, the dependency is part of the function being checked and should be reconstructed inside the callable:

```python
gradcheck(lambda x: F(x, g(x)), (x,))
```

Now numerical perturbations of `x` also recompute `g(x)`, so numerical and analytical differentiation operate on the same composition.

`gradcheck(F, (x, y))` does not contain enough information to distinguish these intentions. 

Automatic detachment would therefore silently select the local-Jacobian interpretation. It also changes autograd object semantics: a differentiable non-leaf tensor becomes a leaf after `detach().requires_grad_(True)`. That can affect otherwise valid leaf-sensitive behavior such as custom `autograd.Function`s that legitimately perform in-place operations using `mark_dirty`.

For these reasons, this PR does not mutate checked inputs.

## Why the diagnostic runs only after a mismatch

A graph relationship alone does not prove that it caused a Jacobian mismatch.

For checked inputs $I_i$ and $I_j$, the additional analytical contribution has the form:
$$\frac{\partial F}{\partial I_j} \frac{dI_j}{dI_i}$$

Graph reachability can indicate that the second factor may exist, but it does not prove that the complete term is nonzero.

For example:

```mermaid
graph LR
    x --> y
```

may exist while the tested function does not depend on `y`. In that case, the dependency is harmless for the current derivative.

A preflight rejection or automatic intervention based only on graph topology would therefore affect cases that currently pass.

Instead, the dependency traversal runs only after `gradcheck` has already observed a backward-mode numerical/analytical Jacobian mismatch. The diagnostic is also scoped to the specific input whose Jacobian mismatched, so a dependency between unrelated checked inputs does not decorate an unrelated failure.

Successful `gradcheck` calls remain on their existing execution paths.

## Why the diagnostic says "potential dependency"

The graph traversal deliberately overapproximates mathematical dependence.

`next_functions` belongs to an autograd `Node`, not to an individual output of that node. 

For example, consider a custom multi-output `Function`:

```python
class SplitDependency(torch.autograd.Function):
    @staticmethod
    def forward(ctx, a, b):
        return a.clone(), b.clone()

    @staticmethod
    def backward(ctx, grad_a, grad_b):
        return grad_a, grad_b
```

Mathematically, the second output does not depend on the first input:
$$\frac{\partial\,out_b}{\partial a}=0$$

However, both outputs share the same backward `Node`, whose `next_functions` exposes the upstream edges for the function invocation as a whole. 

A lightweight graph traversal can therefore observe structural reachability from `a` through that node even though the relevant output-specific derivative is zero. This cannot be resolved by replacing BFS with DFS or a topological sort: the missing information is output-specific derivative dependence, not graph-search order.

The diagnostic therefore intentionally says that the graph contains a **potential dependency** and that such a relationship **can** explain the mismatch. It does not claim that reachability proves causation.

## User-facing behavior

For the original #121842 reproducer, the existing error:

```text
Jacobian mismatch for output 0 with respect to input 0,
numerical:tensor([[3.0000]], dtype=torch.float64)
analytical:tensor([[6.]], dtype=torch.float64)
```

is followed by:

```text
The autograd graph contains a potential dependency from this input to another
checked input. Numerical gradcheck perturbs one checked input at a time without
recomputing the other explicit inputs from it, whereas backward mode autograd can
additionally propagate through such a dependency and pick up extra chain rule
terms. That can make the numerical and analytical checks disagree even when the
backward implementation is correct. To check the composed function, build the
dependency inside func, for example gradcheck(lambda x: func(x, g(x)), (x,)). To
check local Jacobians, pass inputs that do not depend on each other, for example
x.detach().requires_grad_().
```

The `gradcheck` documentation contains the corresponding longer explanation of the two possible testing intents.

## Alternatives considered

**Automatically detach checked inputs**  
Rejected as the default behavior because it silently chooses local-Jacobian semantics, changes non-leaf tensors into leaves, and can alter valid autograd behavior unrelated to this issue.

**Reject dependent inputs before running gradcheck**  
Rejected because graph reachability is only a structural risk condition. The relevant chain-rule contribution can be zero, so some such inputs currently pass correctly.

**Documentation only**  
This would address discoverability but would leave users encountering the original failure without context at the point where the ambiguity becomes relevant.

This PR therefore uses documentation plus a post-mismatch diagnostic: the execution semantics remain unchanged, while the failure explains the two possible differentiation boundaries.

## Testing

New coverage includes:
- original #121842 direct dependency;
- transitive dependency;
- shared-ancestor inputs that must continue to pass;
- genuine backward mismatches with no dependency hint;
- dependency relationships unrelated to the mismatched input;
- `(node, output_nr)` gradient-edge identity;
- duplicate checked inputs;
- nested checked inputs;
- documented multi-output overapproximation;
- forward-only AD;
- `gradgradcheck`;
- `raise_exception=False`;
- both `fast_mode=True` and `fast_mode=False`.

Local validation:

```bash
python test/test_autograd.py TestAutograd -k gradcheck -v
```
Result: 32 passed, 4 skipped.

```bash
python test/test_autograd.py
```
Result: 770 passed, 50 skipped, 1 error.


```bash
lintrunner -a
git diff --check
```
Both are clean.

## Backward compatibility

This PR does not change the numerical or analytical computation performed by successful gradchecks and does not mutate user inputs.

The only runtime behavior change is additional explanatory text on an existing backward-mode Jacobian mismatch when the mismatched input has a potential dependency to another checked input.

Because exception text is observable behavior, this is technically a user-visible diagnostic change, but it does not change whether an existing check succeeds or fails.