### PR TITLE
Drop the dead SYSTEM_PROTOBUF guard in ProtoBufPatch.cmake

### DIFF
--- a/cmake/ProtoBufPatch.cmake
+++ b/cmake/ProtoBufPatch.cmake
@@ -1,96 +1,84 @@
-# CMake file to replace the string contents in ONNX, Caffe, and Caffe2 proto.
+# CMake file to patch the generated ONNX proto sources.
 # Usage example:
-#   cmake -DFILENAME=caffe2.pb.h -DLOCAL_PROTOBUF=ON -P ProtoBufPatch.cmake
+#   cmake -DFILENAME=onnx.pb.h -DNAMESPACES=onnx -P ProtoBufPatch.cmake
 
 file(READ ${FILENAME} content)
 
-if(NOT SYSTEM_PROTOBUF)
-  # protobuf-3.6.0 pattern
+string(
+  REPLACE
+  "::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited"
+  "GetEmptyStringAlreadyInited"
+  content
+  "${content}")
+
+string(
+  REPLACE
+  "PROTOBUF_CONSTEXPR"
+  ""
+  content
+  "${content}")
+
+# Stripping PROTOBUF_CONSTEXPR above makes the ConstantInitialized
+# constructors non-constexpr, so the default-instance globals can no longer
+# be constinit. Drop PROTOBUF_CONSTINIT (protobuf 3.21+) so they fall back to
+# dynamic initialization instead of failing to compile.
+string(
+  REPLACE
+  "PROTOBUF_CONSTINIT"
+  ""
+  content
+  "${content}")
+
+# Stripping PROTOBUF_CONSTEXPR above leaves plain constexpr behind, which
+# breaks the MSVC build (see protocolbuffers/protobuf@0400cca).
+if(MSVC)
   string(
-    REPLACE
-    "::google::protobuf::internal::GetEmptyStringAlreadyInited"
-    "GetEmptyStringAlreadyInited"
+    REGEX REPLACE
+    "static constexpr ([^ ]+) ([^ ]+) ="
+    "static \\1 const \\2 ="
     content
     "${content}")
+endif()
 
-  # protobuf-3.8.0+ pattern
-  string(
-    REPLACE
-    "::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited"
-    "GetEmptyStringAlreadyInited"
-    content
-    "${content}")
-
-  string(
-    REPLACE
-    "PROTOBUF_CONSTEXPR"
-    ""
-    content
-    "${content}")
-
-  # Stripping PROTOBUF_CONSTEXPR above makes the ConstantInitialized
-  # constructors non-constexpr, so the default-instance globals can no longer
-  # be constinit. Drop PROTOBUF_CONSTINIT (protobuf 3.21+) so they fall back to
-  # dynamic initialization instead of failing to compile.
-  string(
-    REPLACE
-    "PROTOBUF_CONSTINIT"
-    ""
-    content
-    "${content}")
-
-  # https://github.com/protocolbuffers/protobuf/commit/0400cca3236de1ca303af38bf81eab332d042b7c
-  # changes PROTOBUF_CONSTEXPR to constexpr, which breaks windows
-  # build.
-  if(MSVC)
+foreach(ns ${NAMESPACES})
+  # Insert "const ::std::string& GetEmptyStringAlreadyInited();" within
+  # the namespace and make sure we only do it once in the file. Unfortunately
+  # using string(REPLACE ...) doesn't work because it will replace at all
+  # locations and there might be multiple declarations of the namespace
+  # depending on how the proto is structured.
+  set(search "namespace ${ns} {")
+  string(LENGTH "${search}" search_len)
+  string(FIND "${content}" "${search}" pos)
+  if(${pos} GREATER -1)
+    math(EXPR pos "${pos}+${search_len}")
+    string(SUBSTRING "${content}" 0 ${pos} content_pre)
+    string(SUBSTRING "${content}" ${pos} -1 content_post)
     string(
-      REGEX REPLACE
-      "static constexpr ([^ ]+) ([^ ]+) ="
-      "static \\1 const \\2 ="
+      CONCAT
       content
-      "${content}")
+      "${content_pre}"
+      " const ::std::string& GetEmptyStringAlreadyInited(); "
+      "${content_post}")
   endif()
+endforeach()
 
-  foreach(ns ${NAMESPACES})
-    # Insert "const ::std::string& GetEmptyStringAlreadyInited();" within
-    # the namespace and make sure we only do it once in the file. Unfortunately
-    # using string(REPLACE ...) doesn't work because it will replace at all
-    # locations and there might be multiple declarations of the namespace
-    # depending on how the proto is structured.
-    set(search "namespace ${ns} {")
-    string(LENGTH "${search}" search_len)
-    string(FIND "${content}" "${search}" pos)
-    if(${pos} GREATER -1)
-      math(EXPR pos "${pos}+${search_len}")
-      string(SUBSTRING "${content}" 0 ${pos} content_pre)
-      string(SUBSTRING "${content}" ${pos} -1 content_post)
-      string(
-        CONCAT
-        content
-        "${content_pre}"
-        " const ::std::string& GetEmptyStringAlreadyInited(); "
-        "${content_post}")
-    endif()
-  endforeach()
+# The moving constructor is defined in the header file, which will cause
+# a link error that claims that the vftable is not found. Luckily, we
+# could move the definition into the source file to solve the problem.
+list(LENGTH NAMESPACES ns_count)
+if("${FILENAME}" MATCHES ".pb.h" AND ns_count EQUAL 1)
+  string(REPLACE ".pb.h" ".pb.cc" SOURCE_FILENAME ${FILENAME})
+  file(READ ${SOURCE_FILENAME} content_cc_origin)
 
-  # The moving constructor is defined in the header file, which will cause
-  # a link error that claims that the vftable is not found. Luckily, we
-  # could move the definition into the source file to solve the problem.
-  list(LENGTH NAMESPACES ns_count)
-  if("${FILENAME}" MATCHES ".pb.h" AND ns_count EQUAL 1)
-    string(REPLACE ".pb.h" ".pb.cc" SOURCE_FILENAME ${FILENAME})
-    file(READ ${SOURCE_FILENAME} content_cc_origin)
+  string(REGEX MATCHALL "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept[^}]*}" content_cc "${content}")
+  string(REGEX REPLACE "};" "}\n" content_cc "${content_cc}")
+  string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept" "  \\1::\\1(\\1&& from) noexcept" content_cc "${content_cc}")
+  set(content_cc "${content_cc_origin}\nnamespace ${NAMESPACES} {\n#if LANG_CXX11\n${content_cc}\n#endif\n}")
 
-    string(REGEX MATCHALL "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept[^}]*}" content_cc "${content}")
-    string(REGEX REPLACE "};" "}\n" content_cc "${content_cc}")
-    string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept" "  \\1::\\1(\\1&& from) noexcept" content_cc "${content_cc}")
-    set(content_cc "${content_cc_origin}\nnamespace ${NAMESPACES} {\n#if LANG_CXX11\n${content_cc}\n#endif\n}")
+  string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept([^}]*)}" "\\1(\\1&& from) noexcept;" content "${content}")
 
-    string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept([^}]*)}" "\\1(\\1&& from) noexcept;" content "${content}")
-
-    file(WRITE ${SOURCE_FILENAME} "${content_cc}")
-  endif()
-endif(NOT SYSTEM_PROTOBUF)
+  file(WRITE ${SOURCE_FILENAME} "${content_cc}")
+endif()
 
 # constexpr int TensorBoundShape_DimType_DimType_ARRAYSIZE = TensorBoundShape_DimType_DimType_MAX + 1;
 # throws

--- a/cmake/ProtoBufPatch.cmake
+++ b/cmake/ProtoBufPatch.cmake
@@ -29,17 +29,6 @@ string(
   content
   "${content}")
 
-# Stripping PROTOBUF_CONSTEXPR above leaves plain constexpr behind, which
-# breaks the MSVC build (see protocolbuffers/protobuf@0400cca).
-if(MSVC)
-  string(
-    REGEX REPLACE
-    "static constexpr ([^ ]+) ([^ ]+) ="
-    "static \\1 const \\2 ="
-    content
-    "${content}")
-endif()
-
 foreach(ns ${NAMESPACES})
   # Insert "const ::std::string& GetEmptyStringAlreadyInited();" within
   # the namespace and make sure we only do it once in the file. Unfortunately
@@ -61,39 +50,5 @@ foreach(ns ${NAMESPACES})
       "${content_post}")
   endif()
 endforeach()
-
-# The moving constructor is defined in the header file, which will cause
-# a link error that claims that the vftable is not found. Luckily, we
-# could move the definition into the source file to solve the problem.
-list(LENGTH NAMESPACES ns_count)
-if("${FILENAME}" MATCHES ".pb.h" AND ns_count EQUAL 1)
-  string(REPLACE ".pb.h" ".pb.cc" SOURCE_FILENAME ${FILENAME})
-  file(READ ${SOURCE_FILENAME} content_cc_origin)
-
-  string(REGEX MATCHALL "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept[^}]*}" content_cc "${content}")
-  string(REGEX REPLACE "};" "}\n" content_cc "${content_cc}")
-  string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept" "  \\1::\\1(\\1&& from) noexcept" content_cc "${content_cc}")
-  set(content_cc "${content_cc_origin}\nnamespace ${NAMESPACES} {\n#if LANG_CXX11\n${content_cc}\n#endif\n}")
-
-  string(REGEX REPLACE "([a-zA-Z_]+)\\([a-zA-Z_]+&& from\\) noexcept([^}]*)}" "\\1(\\1&& from) noexcept;" content "${content}")
-
-  file(WRITE ${SOURCE_FILENAME} "${content_cc}")
-endif()
-
-# constexpr int TensorBoundShape_DimType_DimType_ARRAYSIZE = TensorBoundShape_DimType_DimType_MAX + 1;
-# throws
-# error: more than one operator "+" matches these operands:
-#     built-in operator "arithmetic + arithmetic"
-#     function "c10::operator+(int, c10::BFloat16)"
-#     function "c10::operator+(c10::BFloat16, int)"
-#     function "c10::operator+(int, c10::Half)"
-#     function "c10::operator+(c10::Half, int)"
-#   operand types are: const caffe2::ExternalDataProto_SourceType + int
-string(
-  REGEX REPLACE
-  "constexpr ([^ ]+) ([^ ]+_ARRAYSIZE) = ([^ ]+_MAX) \\+ 1;"
-  "constexpr \\1 \\2 = static_cast<\\1>(\\3) + 1;"
-  content
-  "${content}")
 
 file(WRITE ${FILENAME} "${content}")


### PR DESCRIPTION
Summary and diff prepared with the assistance of an AI assistant, reviewed and approved for submission.

## Summary

Two commits cleaning up `ProtoBufPatch.cmake`, whose only remaining caller is the ONNX post-build step (#194231 removed the caffe2/torch proto generation):

1. Flatten the always-true `if(NOT SYSTEM_PROTOBUF)` guard — nothing sets that variable anymore — and drop the dead protobuf-3.6.0 string pattern (the bundled protobuf 3.21.12 protoc only emits the 3.8.0+ `PROTOBUF_NAMESPACE_ID` form, which is kept).
2. Drop the MSVC `static constexpr` regex, the move-ctor-to-.pb.cc block, and the `_ARRAYSIZE` regex. All three predate the 3.21.12 pin and targeted caffe2's own protos, which are no longer generated; the move-ctor block even wraps its output in `#if LANG_CXX11`, which 3.21 generated code never defines.

The four remaining replacements (`GetEmptyStringAlreadyInited` rewrite, `PROTOBUF_CONSTEXPR`/`PROTOBUF_CONSTINIT` strips, namespace declaration insertion) form one interdependent mechanism for hidden-visibility static protobuf and are kept.

`CAFFE2_LINK_LOCAL_PROTOBUF` — the option that gates whether the ONNX post-build step runs the script at all — is unrelated and untouched.

## Test Plan

No behavioral difference expected on Linux/macOS; Windows correctness of commit 2 is validated by CI (`win-vs2022-cpu` etc. compile the patched onnx protos).