### PR TITLE
Fix torch.multiprocessing.pool.Pool

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -636,8 +636,6 @@ coverage_ignore_functions = [
     # torch.masked.maskedtensor.creation
     "as_masked_tensor",
     "masked_tensor",
-    # torch.multiprocessing.pool
-    "clean_worker",
     # torch.multiprocessing.reductions
     "fd_id",
     "init_reductions",

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -586,6 +586,20 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
         if torch.cuda.is_available():
             torch.cuda.ipc_collect()
 
+    def test_pool_module(self):
+        """Regression test for Pool being broken since Python 3.8.
+
+        Previously, Pool.__init__ would raise TypeError because _setup_queues
+        and _repopulate_pool didn't provide the required ctx argument.
+        This test verifies Pool can be instantiated and used.
+        """
+        from torch.multiprocessing.pool import Pool
+
+        with Pool(2) as p:
+            buffers = [torch.zeros(2, 2) for i in range(4)]
+            results = p.map(simple_pool_fill, buffers, 1)
+        self.assertEqual(results, [torch.ones(2, 2) * 5] * 4, atol=0, rtol=0)
+
     def _test_preserve_sharing(self, ctx=mp, repeat=1):
         def do_test():
             x = torch.randn(5, 5)

--- a/torch/multiprocessing/pool.py
+++ b/torch/multiprocessing/pool.py
@@ -1,52 +1,8 @@
-import multiprocessing.pool
-import multiprocessing.util as util
-
-from .queue import SimpleQueue
+from multiprocessing.pool import Pool as _Pool
 
 
-def clean_worker(*args, **kwargs):
-    import gc
-
-    multiprocessing.pool.worker(*args, **kwargs)
-    # Regular multiprocessing workers don't fully clean up after themselves,
-    # so we have to explicitly trigger garbage collection to make sure that all
-    # destructors are called...
-    gc.collect()
+class Pool(_Pool):
+    """Multiprocessing pool that passes tensors through shared memory."""
 
 
-class Pool(multiprocessing.pool.Pool):
-    """Pool implementation which uses our version of SimpleQueue.
-
-    This lets us pass tensors in shared memory across processes instead of
-    serializing the underlying data.
-    """
-
-    def _setup_queues(self):
-        self._inqueue = SimpleQueue()
-        self._outqueue = SimpleQueue()
-        self._quick_put = self._inqueue._writer.send
-        self._quick_get = self._outqueue._reader.recv
-
-    def _repopulate_pool(self):
-        """Increase the number of pool processes to the specified number.
-
-        Bring the number of pool processes up to the specified number, for use after
-        reaping workers which have exited.
-        """
-        for _ in range(self._processes - len(self._pool)):
-            # changed worker -> clean_worker
-            args = (
-                self._inqueue,
-                self._outqueue,
-                self._initializer,
-                self._initargs,
-                self._maxtasksperchild,
-            )
-            if hasattr(self, "_wrap_exception"):
-                args += (self._wrap_exception,)
-            w = self.Process(target=clean_worker, args=args)
-            self._pool.append(w)
-            w.name = w.name.replace("Process", "PoolWorker")
-            w.daemon = True
-            w.start()
-            util.debug("added worker")
+__all__ = ["Pool"]


### PR DESCRIPTION
`torch.multiprocessing.pool.Pool` has never constructed successfully on any supported Python: `_setup_queues` calls `SimpleQueue()` without the required `ctx`, and the inlined `_repopulate_pool` calls `self.Process(...)` without the `ctx` argument `Pool.Process` has required since 3.8. It went unnoticed because `torch.multiprocessing.Pool` is shadowed by the stdlib factory via `from multiprocessing import *`, so it was dead code from every in-repo entry point.

Replace the subclass with an alias of the stdlib `Pool`. The stdlib `Pool` already provides what the subclass wanted: torch registers tensor reducers on `multiprocessing.reduction.ForkingPickler` globally, and stdlib pool queues pickle through `connection.Connection.send` → that same `ForkingPickler`, so tensors move through shared memory without custom hooks.

## Test plan

- Added `test_pool_module` as a regression test.
- Verified against pip torch 2.13.0 (Python 3.14) by copying the new `pool.py` into site-packages: `Pool(2).map` over tensors and worker recycling with `maxtasksperchild=1` both pass.

---

🤖 Root-cause analysis and fix authored with Claude Code per AI policy.
