### PR TITLE
Fix typos in comm mode method name and test comments

### DIFF
--- a/torch/distributed/tensor/debug/_comm_mode.py
+++ b/torch/distributed/tensor/debug/_comm_mode.py
@@ -214,7 +214,7 @@ class _CommModeModuleTracker(ModTracker):
         for handle in self.register_forward_hook_handles.values():
             handle.remove()
 
-    def print_paramater_info(self):
+    def print_parameter_info(self):
         print(self.module_parameters_dict)
 
     def print_sharding_info(self):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -243,7 +243,7 @@ def error_inputs_hsplit(op_info, device, **kwargs):
                 f"is not divisible by the split_size 0!")
     yield ErrorInput(SampleInput(make_arg((S, S, S)), 0), error_regex=err_msg2)
 
-    # Incorrect type for indices_or_section argument
+    # Incorrect type for indices_or_sections argument
     err_msg3 = ("received an invalid combination of arguments.")
     yield ErrorInput(
         SampleInput(make_arg((S, S, S)), "abc"),
@@ -261,7 +261,7 @@ def error_inputs_vsplit(op_info, device, **kwargs):
     yield ErrorInput(SampleInput(make_arg(S, S, S), 0),
                      error_regex=err_msg2)
 
-    # Incorrect type for indices_or_section argument
+    # Incorrect type for indices_or_sections argument
     err_msg3 = ("received an invalid combination of arguments.")
     yield ErrorInput(SampleInput(make_arg(S, S, S), "abc"),
                      error_type=TypeError, error_regex=err_msg3)


### PR DESCRIPTION
### Summary

This PR fixes two typos, one for each of the linked issues:

- Renames the misspelled `print_paramater_info` method to `print_parameter_info` in `torch/distributed/tensor/debug/_comm_mode.py`. The method is private and has no callers in the codebase, so the rename is safe and no other files need to be updated.
- Corrects `indices_or_section` to `indices_or_sections` in two comments in `torch/testing/_internal/common_methods_invocations.py` to match the actual argument name used by `torch.hsplit` / `torch.vsplit`.

### Test Plan

- `python -m py_compile torch/distributed/tensor/debug/_comm_mode.py`
- `grep -rn "paramater" torch/` returns no matches

Fixes #194404
Fixes #194405

> **AI assistance disclosure:** This PR was authored with the assistance of GitHub Copilot. The changes were reviewed by the author before submission.