### PR TITLE
Fix indices_or_section typo in test comments

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -241,7 +241,7 @@ def error_inputs_hsplit(op_info, device, **kwargs):
                 f"is not divisible by the split_size 0!")
     yield ErrorInput(SampleInput(make_arg((S, S, S)), 0), error_regex=err_msg2)
 
-    # Incorrect type for indices_or_section argument
+    # Incorrect type for indices_or_sections argument
     err_msg3 = ("received an invalid combination of arguments.")
     yield ErrorInput(
         SampleInput(make_arg((S, S, S)), "abc"),
@@ -259,7 +259,7 @@ def error_inputs_vsplit(op_info, device, **kwargs):
     yield ErrorInput(SampleInput(make_arg(S, S, S), 0),
                      error_regex=err_msg2)
 
-    # Incorrect type for indices_or_section argument
+    # Incorrect type for indices_or_sections argument
     err_msg3 = ("received an invalid combination of arguments.")
     yield ErrorInput(SampleInput(make_arg(S, S, S), "abc"),
                      error_type=TypeError, error_regex=err_msg3)


### PR DESCRIPTION
Fixes #194405

## Summary
The comments in `torch/testing/_internal/common_methods_invocations.py`
referred to the `indices_or_section` argument,but the actual argument
name is `indices_or_sections`.This PR corrects the typo in two comments.

## Changes
- `error_inputs_hsplit`:fixed comment `indices_or_section` to `indices_or_sections`
- `error_inputs_vsplit`:fixed comment `indices_or_section` to `indices_or_sections`

This is a comment-only change with no functional or behavioral impact.