### PR TITLE
[DO NOT MERGE] Duplicate of #172074 (grad_dtype lost in FSDP), base for a stacked fix

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -10,12 +10,12 @@ import torch
 import torch.distributed as dist
 import torch.distributed._functional_collectives as funcol
 import torch.nn as nn
-from torch.distributed.device_mesh import init_device_mesh
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
 from torch.distributed.fsdp._fully_shard._fsdp_collectives import (
     _get_gradient_divide_factors,
 )
-from torch.distributed.tensor import Shard
+from torch.distributed.tensor import distribute_tensor, Shard
 from torch.testing._internal.common_distributed import (
     requires_nccl_version,
     SaveForwardInputsModel,
@@ -457,6 +457,236 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
         for param in module.parameters():
             if param.grad is not None:
                 param.grad.div_(group.size())
+
+    @skip_if_lt_x_gpu(2)
+    def test_grad_dtype_preserved(self):
+        meshes = [init_device_mesh(device_type.type, (self.world_size,))]
+        if self.world_size == 4:  # test HSDP too if enough GPUs
+            shard_size, replicate_size = 2, self.world_size // 2
+            meshes.append(
+                init_device_mesh(
+                    device_type.type,
+                    (replicate_size, shard_size),
+                    mesh_dim_names=("dp_replicate", "dp_shard"),
+                )
+            )
+        self.run_subtests(
+            {
+                "mesh": meshes,
+                "model_grad_dtypes": [
+                    (torch.bfloat16, torch.float32),
+                    (torch.float32, torch.bfloat16),
+                ],
+                "param_dtype": [None, torch.bfloat16],
+                "reduce_dtype": [torch.bfloat16, torch.float32],
+            },
+            self._test_grad_dtype_preserved,
+        )
+
+    def _test_grad_dtype_preserved(
+        self,
+        mesh: DeviceMesh,
+        model_grad_dtypes: tuple[torch.dtype, torch.dtype],
+        param_dtype: torch.dtype | None,
+        reduce_dtype: torch.dtype,
+    ):
+        model_dtype, grad_dtype = model_grad_dtypes
+
+        torch.manual_seed(42)
+        model = nn.Sequential(*[MLP(16, torch.device("cpu")) for _ in range(3)])
+        model.to(device=device_type, dtype=model_dtype)
+
+        for param in model.parameters():
+            param.grad_dtype = grad_dtype
+
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=param_dtype, reduce_dtype=reduce_dtype
+        )
+        for mlp in model:
+            fully_shard(mlp, mesh=mesh, mp_policy=mp_policy)
+        fully_shard(model, mesh=mesh, mp_policy=mp_policy)
+
+        for param in model.parameters():
+            self.assertEqual(param.grad_dtype, grad_dtype)
+
+        forward_grad_dtype_ok = []
+
+        def check_unsharded_grad_dtype(module, input):
+            for param in module.parameters():
+                forward_grad_dtype_ok.append(param.grad_dtype == grad_dtype)
+
+        hooks = []
+        for mlp in model:
+            hooks.append(mlp.register_forward_pre_hook(check_unsharded_grad_dtype))
+
+        torch.manual_seed(42 + self.rank + 1)
+        inp_dtype = param_dtype or model_dtype
+        inp = torch.randn(2, 16, device=device_type, dtype=inp_dtype)
+        model(inp).sum().backward()
+
+        for hook in hooks:
+            hook.remove()
+        self.assertTrue(len(forward_grad_dtype_ok) > 0)
+        self.assertTrue(all(forward_grad_dtype_ok))
+
+        for param in model.parameters():
+            self.assertIsNotNone(param.grad)
+            self.assertEqual(param.grad.dtype, grad_dtype)
+
+    @skip_if_lt_x_gpu(2)
+    def test_grad_dtype_preserved_grad_acc(self):
+        meshes = [init_device_mesh(device_type.type, (self.world_size,))]
+        if self.world_size == 4:  # test HSDP too if enough GPUs
+            shard_size, replicate_size = 2, self.world_size // 2
+            meshes.append(
+                init_device_mesh(
+                    device_type.type,
+                    (replicate_size, shard_size),
+                    mesh_dim_names=("dp_replicate", "dp_shard"),
+                )
+            )
+        self.run_subtests(
+            {
+                "mesh": meshes,
+                "model_grad_dtypes": [
+                    (torch.bfloat16, torch.float32),
+                    (torch.float32, torch.bfloat16),
+                ],
+                "param_dtype": [None, torch.bfloat16],
+                "reduce_dtype": [torch.bfloat16, torch.float32],
+            },
+            self._test_grad_dtype_preserved_grad_acc,
+        )
+
+    def _test_grad_dtype_preserved_grad_acc(
+        self,
+        mesh: DeviceMesh,
+        model_grad_dtypes: tuple[torch.dtype, torch.dtype],
+        param_dtype: torch.dtype | None,
+        reduce_dtype: torch.dtype,
+    ):
+        model_dtype, grad_dtype = model_grad_dtypes
+        torch.manual_seed(42)
+        model = nn.Sequential(*[MLP(16, torch.device("cpu")) for _ in range(3)])
+        model.to(device=device_type, dtype=model_dtype)
+
+        for param in model.parameters():
+            param.grad_dtype = grad_dtype
+
+        mp_policy = MixedPrecisionPolicy(
+            param_dtype=param_dtype, reduce_dtype=reduce_dtype
+        )
+        for mlp in model:
+            fully_shard(mlp, mesh=mesh, mp_policy=mp_policy)
+        fully_shard(model, mesh=mesh, mp_policy=mp_policy)
+
+        torch.manual_seed(42 + self.rank + 1)
+        inp_dtype = param_dtype or model_dtype
+        num_microbatches = 3
+        inp = torch.randn(2 * num_microbatches, 16, device=device_type, dtype=inp_dtype)
+        microbatch_inps = inp.chunk(num_microbatches)
+
+        for microbatch_idx in range(num_microbatches):
+            is_last_microbatch = microbatch_idx == num_microbatches - 1
+            model.set_requires_gradient_sync(is_last_microbatch)
+            model(microbatch_inps[microbatch_idx]).sum().backward()
+
+        for param in model.parameters():
+            self.assertIsNotNone(param.grad)
+            self.assertEqual(param.grad.dtype, grad_dtype)
+
+    @skip_if_lt_x_gpu(2)
+    def test_grad_dtype_numerics_grad_acc(self):
+        """
+        Tests that FSDP gradient accumulation with grad_dtype matches single-device
+        numerics.
+        """
+        self.run_subtests(
+            {
+                "model_grad_dtypes": [
+                    (torch.float32, torch.bfloat16),
+                    (torch.bfloat16, torch.float32),
+                ],
+                "reduce_dtype": [torch.float32],
+            },
+            self._test_grad_dtype_numerics_grad_acc,
+        )
+
+    def _test_grad_dtype_numerics_grad_acc(
+        self,
+        model_grad_dtypes: tuple[torch.dtype, torch.dtype],
+        reduce_dtype: torch.dtype,
+    ):
+        model_dtype, grad_dtype = model_grad_dtypes
+
+        torch.manual_seed(42)
+        ref_model = nn.Sequential(*[MLP(16, torch.device("cpu")) for _ in range(3)])
+        ref_model.to(device=device_type, dtype=model_dtype)
+        for param in ref_model.parameters():
+            param.grad_dtype = grad_dtype
+
+        torch.manual_seed(42)
+        model = nn.Sequential(*[MLP(16, torch.device("cpu")) for _ in range(3)])
+        model.to(device=device_type, dtype=model_dtype)
+        for param in model.parameters():
+            param.grad_dtype = grad_dtype
+        mp_policy = MixedPrecisionPolicy(reduce_dtype=reduce_dtype)
+        for mlp in model:
+            fully_shard(mlp, mp_policy=mp_policy)
+        fully_shard(model, mp_policy=mp_policy)
+
+        torch.manual_seed(42 + self.rank + 1)
+        num_microbatches = 3
+        inp = torch.randn(
+            2 * num_microbatches, 16, device=device_type, dtype=model_dtype
+        )
+        microbatch_inps = inp.chunk(num_microbatches)
+        for microbatch_idx in range(num_microbatches):
+            is_last = microbatch_idx == num_microbatches - 1
+            model.set_requires_gradient_sync(is_last)
+            fsdp_loss = model(microbatch_inps[microbatch_idx]).sum()
+            ref_loss = ref_model(microbatch_inps[microbatch_idx]).sum()
+            self.assertEqual(fsdp_loss, ref_loss)
+            fsdp_loss.backward()
+            ref_loss.backward()
+
+        # Simulate FSDP's reduce on the single-device reference grads.
+        for param in ref_model.parameters():
+            self.assertEqual(param.grad.dtype, grad_dtype)
+            grad = param.grad.to(reduce_dtype)
+            dist.all_reduce(grad)
+            grad.div_(self.world_size)
+            param.grad = grad.to(grad_dtype)
+
+        for ref_param, fsdp_param in zip(ref_model.parameters(), model.parameters()):
+            self.assertIsNotNone(fsdp_param.grad)
+            sharded_ref_grad = distribute_tensor(
+                ref_param.grad, fsdp_param.device_mesh, fsdp_param.placements
+            )
+            self.assertEqual(
+                fsdp_param.grad.to_local(),
+                sharded_ref_grad.to_local(),
+                atol=1e-4,
+                rtol=8e-3,
+            )
+
+    @skip_if_lt_x_gpu(2)
+    def test_grad_dtype_non_uniform_raises(self):
+        """Tests that non-uniform grad_dtype across params in an FSDP group raises."""
+        torch.manual_seed(42)
+        model = nn.Sequential(*[MLP(16, torch.device("cpu")) for _ in range(3)])
+        model.to(device=device_type, dtype=torch.float32)
+
+        # set different grad_dtype on different params within the same MLP
+        params = list(model[0].parameters())
+        params[0].grad_dtype = torch.bfloat16
+        params[1].grad_dtype = torch.float16
+
+        fully_shard(model[0])
+        fully_shard(model)
+        inp = torch.randn(2, 16, device=device_type)
+        with self.assertRaisesRegex(AssertionError, "uniform grad_dtype"):
+            model(inp).sum().backward()
 
     @skip_if_lt_x_gpu(2)
     def test_structured_input_output(self):

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -600,7 +600,20 @@ def foreach_reduce(
         device=device,
     )
 
-    foreach_reduce_scatter_copy_in(unsharded_grads, reduce_scatter_input, world_size)
+    # _chunk_cat handles widening casts (e.g. bf16 -> fp32) natively but
+    # rejects narrowing casts. Use a temp buffer only for narrowing.
+    if (
+        grad_dtype != reduce_dtype
+        and torch.promote_types(grad_dtype, reduce_dtype) != reduce_dtype
+    ):
+        grad_buffer = torch.empty_like(reduce_scatter_input, dtype=grad_dtype)
+        foreach_reduce_scatter_copy_in(unsharded_grads, grad_buffer, world_size)
+        reduce_scatter_input.copy_(grad_buffer)
+        del grad_buffer
+    else:
+        foreach_reduce_scatter_copy_in(
+            unsharded_grads, reduce_scatter_input, world_size
+        )
 
     # Only after the copy-in finishes can we free the gradients
     unsharded_grads.clear()
@@ -693,7 +706,14 @@ def foreach_reduce(
         # AR to finish. The reduce-dtype buffer is held across layers by
         # FSDPParamGroup._all_reduce_state (captured above) to prevent
         # this. See PR #140044, regression test PR #180900.
-        reduce_output = _to_dtype_if_needed(reduce_output, orig_dtype)
+        # Cast directly to grad_dtype if set, skipping orig_dtype to
+        # avoid a lossy round-trip (e.g. fp32 reduce -> bf16 orig -> fp32).
+        target_dtype = orig_dtype
+        if fsdp_params:
+            param_grad_dtype = fsdp_params[0].sharded_param.grad_dtype
+            if param_grad_dtype != fsdp_params[0].sharded_param.dtype:
+                target_dtype = param_grad_dtype
+        grad_output = _to_dtype_if_needed(reduce_output, target_dtype)
         # View out and accumulate sharded gradients
         flat_grad_offset = 0  # [0, reduce_scatter_output_numel - 1]
         for padded_unsharded_size, fsdp_param in zip(
@@ -702,7 +722,7 @@ def foreach_reduce(
             # Assume even sharding for Shard(i), i > 0; otherwise would require
             # copy-out for contiguous strides
             new_sharded_grad = torch.as_strided(
-                reduce_output,
+                grad_output,
                 size=fsdp_param.sharded_size,
                 stride=fsdp_param.contiguous_sharded_stride,
                 storage_offset=flat_grad_offset,

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -210,6 +210,10 @@ class FSDPParam:
     _unsharded_inner_tensors: list[torch.Tensor]
     _release_all_gather_outputs_after_post_all_gather: bool
     _orig_param_uid: int
+    # User-set Tensor.grad_dtype when it differs from param.dtype. None means
+    # the default (grad_dtype == param.dtype), which must not be copied onto
+    # the unsharded compute param or reduce-scatter would see orig_dtype grads.
+    _explicit_grad_dtype: torch.dtype | None
 
     def __init__(
         self,
@@ -274,6 +278,12 @@ class FSDPParam:
             raise NotImplementedError(
                 f"FSDP does not support non-contiguous parameters yet: {param.shape=} {param.stride()=}"
             )
+        # Snapshot before any rewrite of `param` (e.g. spmd_types -> DTensor).
+        explicit_grad_dtype = (
+            param.grad_dtype
+            if param.requires_grad and param.grad_dtype != param.dtype
+            else None
+        )
         if fsdp_placement is None:
             fsdp_placement = Shard(0)
         elif fsdp_placement.dim < 0:
@@ -360,6 +370,12 @@ class FSDPParam:
             self.to_sharded_dtensor(sharded_param),
             requires_grad=param.requires_grad,
         )
+        # Propagate user-set grad_dtype. grad_dtype returns param.dtype by
+        # default, so this does not detect an explicit setting of
+        # grad_dtype == param.dtype; that case matches the default.
+        self._explicit_grad_dtype = explicit_grad_dtype
+        if explicit_grad_dtype is not None:
+            self.sharded_param.grad_dtype = explicit_grad_dtype
         # Let `param_data` be freed normally when its ref count reaches 0 when
         # the `fully_shard` call returns to allow provided parameters to alias
         self._setattr_on_modules(self.sharded_param)
@@ -930,6 +946,7 @@ class FSDPParam:
         self._unsharded_param = nn.Parameter(
             unsharded_param, requires_grad=self.sharded_param.requires_grad
         )
+        self._maybe_set_explicit_grad_dtype(self._unsharded_param)
         self._release_all_gather_outputs_if_needed()
 
     def _release_all_gather_outputs_if_needed(self) -> None:
@@ -999,6 +1016,7 @@ class FSDPParam:
             self.to_sharded_post_forward_dtensor(sharded_post_forward_tensor),
             requires_grad=self.sharded_param.requires_grad,
         )
+        self._maybe_set_explicit_grad_dtype(self._sharded_post_forward_param)
         self._setattr_on_modules(self._sharded_post_forward_param)
         self.free_unsharded_param()
         self.sharded_state = ShardedState.SHARDED_POST_FORWARD
@@ -1015,6 +1033,10 @@ class FSDPParam:
             self._sharded_post_forward_param = None
             self._sharded_post_forward_param_data = None  # free
         self.sharded_state = ShardedState.UNSHARDED
+
+    def _maybe_set_explicit_grad_dtype(self, param: nn.Parameter) -> None:
+        if self._explicit_grad_dtype is not None:
+            param.grad_dtype = self._explicit_grad_dtype
 
     def _setattr_on_modules(self, param: nn.Parameter) -> None:
         unsafe_setattr_param(
@@ -1283,6 +1305,9 @@ class FSDPParam:
                     f"instead of {self.sharded_param}"
                 )
             self.sharded_param = new_param
+        # _apply may keep the Parameter object but replace storage, dropping
+        # Tensor.grad_dtype. Re-stamp after every reset.
+        self._maybe_set_explicit_grad_dtype(self.sharded_param)
 
         local_tensor = new_param._local_tensor
         if local_tensor.is_meta:

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param_group.py
@@ -302,6 +302,11 @@ class FSDPParamGroup:
         self._reduce_dtype = (
             next(iter(reduce_dtypes)) if dtype_sets_are_uniform else None
         )
+        grad_dtypes = {p.sharded_param.grad_dtype for p in trainable_params}
+        if len(trainable_params) > 0 and len(grad_dtypes) != 1:
+            raise AssertionError(
+                f"FSDP expects uniform grad_dtype but got {grad_dtypes}"
+            )
 
     def lazy_init(self):
         # Lazy init should be idempotent


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194434
* __->__ #194433

DO NOT MERGE. DO NOT REVIEW THIS PR.

This is an unmodified duplicate of
https://github.com/pytorch/pytorch/pull/172074 by arkadip-maitra. It exists
only to give the correction PR stacked on top of it something to diff
against, so that the correction shows up as a self-contained change instead
of being mixed in with the work it builds on.

All credit for the change below belongs to the original author. Please review
and land https://github.com/pytorch/pytorch/pull/172074, not this copy. This
PR will be closed once the original lands or the correction is folded into it.

The original description follows verbatim.

---

Fixes #170648

**Problem**
When `fully_shard()` is applied, it creates new `nn.Parameter` objects to hold the sharded data. The original parameter's `grad_dtype` property was not being copied to these new parameters, so any user-set `grad_dtype` was lost.

**Fix**

1. `_fsdp_param.py`: Before creating the sharded parameter, save the original `grad_dtype`. After creating it, restore that value.
2. `_fsdp_collectives.py`: Before assigning a gradient to a parameter, cast the gradient to match the parameter's grad_dtype if one is set.
3. Added test