### PR TITLE
[Testcase Refactoring][quantization][jit] Add GENERIC hw_classification to test_fusion_passes.py

### DIFF
--- a/test/quantization/jit/test_fusion_passes.py
+++ b/test/quantization/jit/test_fusion_passes.py
@@ -4,10 +4,12 @@
 import torch
 from torch.testing import FileCheck
 from torch.testing._internal.common_quantization import QuantizationTestCase
-from torch.testing._internal.common_utils import raise_on_run_directly
+from torch.testing._internal.common_utils import raise_on_run_directly, HardwareClassification
 
 
 class TestFusionPasses(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_quantized_add_relu_fusion(self):
         class MAdd(torch.nn.Module):
             def forward(self, x, y):


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata so test selection can distinguish device-agnostic framework tests from accelerator-specific tests.

`TestFusionPasses` contains four quantized add + relu fusion test scenarios. The class does not use device-type test instantiation, device parameters, CUDA-only decorators, CUDA APIs, hard-coded device strings, or device-specific assertions. All tensors are intentionally created on the default device via `torch.quantize_per_tensor` and `torch._empty_affine_quantized` to validate shared fusion logic. Therefore, no hardware decoupling or class split is required, and the class is classified as `HardwareClassification.GENERIC`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.GENERIC` to `TestFusionPasses`.
- Keep all four test scenarios, assertions, and collected test names unchanged.

## Self-test

Environment:

- Linux aarch64, Python 3.12.13
- PyTorch 2.7.1+cpu
- Ascend 910B (NPU available, but test runs on CPU)

Commands:

```bash
python -m pytest test/quantization/jit/test_fusion_passes.py -v
python -m pytest --collect-only -q test/quantization/jit/test_fusion_passes.py
```

Results:

- CPU environment: 1 passed; 1 collected.
- `git diff --check` passed.
- All command exit codes were 0, and the collected test set was unchanged.

## Risks

Low. The change only imports the hardware classification enum and adds class-level test metadata; test logic and product code are unchanged.

<details>
<summary>CPU self-test log</summary>

```text
torch: 2.7.1+cpu
============================= test session starts =============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
cachedir: .pytest_cache
rootdir: /opt/setup/npu-pytorch-setup/pytorch
configfile: pyproject.toml
collecting ... collected 1 item

Running 1 item in this shard

opt/setup/npu-pytorch-setup/pytorch/test/quantization/jit/test_fusion_passes.py::TestFusionPasses::test_quantized_add_relu_fusion PASSED [8.26s] [100%]

============================== 1 passed in 8.26s ==============================
1 test collected in 0.02s
CPU exit codes: unfiltered=0 collect=0
```

</details>