### PR TITLE
Replace torch.multiprocessing.queue wrappers with aliases of stdlib queues

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1755,7 +1755,6 @@ coverage_ignore_classes = [
     # torch.multiprocessing.pool
     "Pool",
     # torch.multiprocessing.queue
-    "ConnectionWrapper",
     "Queue",
     "SimpleQueue",
     # torch.multiprocessing.reductions

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -586,6 +586,25 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
         if torch.cuda.is_available():
             torch.cuda.ipc_collect()
 
+    def test_queue_module(self):
+        """Queue and SimpleQueue pass tensors through shared memory."""
+        from torch.multiprocessing.queue import Queue, SimpleQueue
+
+        ctx = mp.get_context()
+        q = SimpleQueue(ctx=ctx)
+        x = torch.zeros(2, 2)
+        q.put(x)
+        y = q.get()
+        self.assertEqual(y, x)
+        y.fill_(7)
+        self.assertEqual(x, torch.full((2, 2), 7))
+
+        q = Queue(ctx=ctx)
+        q.put(torch.ones(2, 2))
+        self.assertEqual(q.get(), torch.ones(2, 2))
+        q.close()
+        q.join_thread()
+
     def _test_preserve_sharing(self, ctx=mp, repeat=1):
         def do_test():
             x = torch.randn(5, 5)

--- a/torch/multiprocessing/queue.py
+++ b/torch/multiprocessing/queue.py
@@ -1,43 +1,12 @@
-# mypy: allow-untyped-defs
-import io
-import multiprocessing.queues
-import pickle
-from multiprocessing.reduction import ForkingPickler
+from multiprocessing.queues import Queue as _Queue, SimpleQueue as _SimpleQueue
 
 
-class ConnectionWrapper:
-    """Proxy class for _multiprocessing.Connection which uses ForkingPickler for object serialization."""
-
-    def __init__(self, conn):
-        self.conn = conn
-
-    def send(self, obj):
-        buf = io.BytesIO()
-        ForkingPickler(buf, pickle.HIGHEST_PROTOCOL).dump(obj)
-        self.send_bytes(buf.getvalue())
-
-    def recv(self):
-        buf = self.recv_bytes()
-        return pickle.loads(buf)
-
-    def __getattr__(self, name):
-        if "conn" in self.__dict__:
-            return getattr(self.conn, name)
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute 'conn'")
+class Queue(_Queue):
+    """Multiprocessing queue that passes tensors through shared memory."""
 
 
-class Queue(multiprocessing.queues.Queue):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._reader: ConnectionWrapper = ConnectionWrapper(self._reader)
-        self._writer: ConnectionWrapper = ConnectionWrapper(self._writer)
-        self._send = self._writer.send
-        self._recv = self._reader.recv
+class SimpleQueue(_SimpleQueue):
+    """Multiprocessing simple queue that passes tensors through shared memory."""
 
 
-class SimpleQueue(multiprocessing.queues.SimpleQueue):
-    def _make_methods(self):
-        if not isinstance(self._reader, ConnectionWrapper):
-            self._reader: ConnectionWrapper = ConnectionWrapper(self._reader)
-            self._writer: ConnectionWrapper = ConnectionWrapper(self._writer)
-        super()._make_methods()  # type: ignore[misc]
+__all__ = ["Queue", "SimpleQueue"]


### PR DESCRIPTION
## Description

`ConnectionWrapper` reimplemented what multiprocessing's `Connection.send/.recv` (and Queue's feeder thread) natively do on every supported Python: serialize with `ForkingPickler`, on which torch registers its tensor reducers. `torch.multiprocessing.Queue`/`SimpleQueue` are already shadowed by the stdlib classes via `from multiprocessing import *`, so the subclasses were only reachable through the `queue` submodule and used nowhere in-tree.

## Test

`test_queue_module` — SimpleQueue roundtrip where mutating the received tensor is visible in the sender's tensor (proves shared storage, not by-value pickle); Queue roundtrip.