### PR TITLE
Simplify torch.multiprocessing._atfork

### DIFF
--- a/torch/multiprocessing/_atfork.py
+++ b/torch/multiprocessing/_atfork.py
@@ -4,32 +4,20 @@ import sys
 
 __all__ = ["register_after_fork"]
 
-if sys.platform == "win32":
-    import multiprocessing.util as _util
-
-    def _register(func):
-        def wrapper(arg):
-            func()
-
-        _util.register_after_fork(_register, wrapper)
-
-else:
-    import os
-
-    def _register(func):
-        os.register_at_fork(after_in_child=func)
-
 
 def register_after_fork(func):
     """Register a callable to be executed in the child process after a fork.
 
-    Note:
-        In python < 3.7 this will only work with processes created using the
-        ``multiprocessing`` module. In python >= 3.7 it also works with
-        ``os.fork()``.
+    Works with processes created using the ``multiprocessing`` module and
+    with ``os.fork()``.
 
     Args:
         func (function): Function taking no arguments to be called in the child after fork
 
     """
-    _register(func)
+    if sys.platform == "win32":
+        import multiprocessing.util as _util
+        _util.register_after_fork(lambda _: func(), None)
+    else:
+        import os
+        os.register_at_fork(after_in_child=func)

--- a/torch/multiprocessing/_atfork.py
+++ b/torch/multiprocessing/_atfork.py
@@ -1,11 +1,11 @@
-# mypy: allow-untyped-defs
 import sys
+from collections.abc import Callable
 
 
 __all__ = ["register_after_fork"]
 
 
-def register_after_fork(func):
+def register_after_fork(func: Callable) -> None:
     """Register a callable to be executed in the child process after a fork.
 
     Works with processes created using the ``multiprocessing`` module and
@@ -17,7 +17,9 @@ def register_after_fork(func):
     """
     if sys.platform == "win32":
         import multiprocessing.util as _util
-        _util.register_after_fork(lambda _: func(), None)
+
+        _util.register_after_fork(register_after_fork, lambda _: func())
     else:
         import os
+
         os.register_at_fork(after_in_child=func)


### PR DESCRIPTION
Simplify _atfork.py docstring and consolidate platform-specific logic into function body.