### PR TITLE
Report a child's KeyboardInterrupt instead of exiting 0 in spawn

### DIFF
--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -89,6 +89,10 @@ def simple_pool_fill(tensor):
     return tensor.add(1)
 
 
+def raise_keyboard_interrupt(i):
+    raise KeyboardInterrupt
+
+
 def send_tensor(queue, event, device, dtype):
     t = torch.ones(5, 5, device=device, dtype=dtype)
     queue.put(t)
@@ -585,6 +589,12 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
     def tearDown(self):
         if torch.cuda.is_available():
             torch.cuda.ipc_collect()
+
+    def test_spawn_child_keyboard_interrupt(self):
+        # A child interrupted while the parent lives must be reported as a
+        # failure, not exit 0 and be mistaken for success.
+        with self.assertRaisesRegex(mp.ProcessRaisedException, "KeyboardInterrupt"):
+            mp.spawn(raise_keyboard_interrupt, nprocs=1, join=True)
 
     def _test_preserve_sharing(self, ctx=mp, repeat=1):
         def do_test():

--- a/torch/distributed/checkpoint/_experimental/checkpoint_process.py
+++ b/torch/distributed/checkpoint/_experimental/checkpoint_process.py
@@ -316,8 +316,10 @@ class CheckpointProcess:
         logger.debug(
             "Closing CheckpointProcess for rank %d", self._rank_info.global_rank
         )
-        self._executor.shutdown(wait=True, cancel_futures=True)
 
+        # Shut down the executor after the subprocess below: its worker thread
+        # is the PR_SET_PDEATHSIG "parent", so killing it first would send the
+        # child a spurious SIGINT before graceful termination.
         if self.process and self.process.processes[0].is_alive():
             subprocess_pid = self.process.processes[0].pid
             # send graceful termination to sub process
@@ -357,5 +359,7 @@ class CheckpointProcess:
             except ProcessExitedException:
                 logger.exception("ProcessExitedException during subprocess termination")
                 raise
+
+        self._executor.shutdown(wait=True, cancel_futures=True)
 
         logger.debug("CheckpointProcess closed successfully")

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -83,10 +83,19 @@ def _wrap(fn, i, args, error_file):
     # terminate if their parent terminates before they do.
     _prctl_pr_set_pdeathsig(signal.SIGINT)
 
+    parent_pid = os.getppid()
+
     try:
         fn(i, *args)
     except KeyboardInterrupt:
-        pass  # SIGINT; Killed by parent, do nothing
+        # Parent died (pdeathsig SIGINT): exit quietly. Otherwise report
+        # it like any other failure instead of faking success.
+        if os.getppid() == parent_pid:
+            import traceback
+
+            with open(error_file, "wb") as fh:
+                pickle.dump(traceback.format_exc(), fh)
+            sys.exit(1)
     except Exception:
         # Propagate exception to parent process, keeping original traceback
         import traceback

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -95,7 +95,7 @@ def _wrap(fn, i, args, error_file):
 
             with open(error_file, "wb") as fh:
                 pickle.dump(traceback.format_exc(), fh)
-            sys.exit(1)
+            sys.exit(128 + signal.SIGINT)
     except Exception:
         # Propagate exception to parent process, keeping original traceback
         import traceback


### PR DESCRIPTION
_wrap_ swallowed every `KeyboardInterrupt` (`pass` -> exit 0). That is only correct for pdeathsig (Linux parent death sends SIGINT); a `KeyboardInterrupt` raised by `fn` or sent to the child alone made a dead child look successful to `join()`. Now the child exits quietly only when the parent is gone (`getppid()` changed); otherwise the traceback goes to the error file like any other failure. Terminal-wide Ctrl+C is unaffected (the parent itself raises from `join()`).

Test: `test_spawn_child_keyboard_interrupt`.