### PR TITLE
Remove deprecated SpawnContext alias

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1765,7 +1765,6 @@ coverage_ignore_classes = [
     "ProcessException",
     "ProcessExitedException",
     "ProcessRaisedException",
-    "SpawnContext",
     # torch.nn.cpp
     "ModuleWrapper",
     "OrderedDictWrapper",

--- a/docs/source/multiprocessing.md
+++ b/docs/source/multiprocessing.md
@@ -194,7 +194,7 @@ terminate processes upon detecting an error in one of them.
 ```
 
 ```{eval-rst}
-.. class:: SpawnContext
+.. class:: ProcessContext
 
    Returned by :func:`~spawn` when called with ``join=False``.
 

--- a/test/allowlist_for_publicAPI.json
+++ b/test/allowlist_for_publicAPI.json
@@ -530,7 +530,6 @@
     "RawValue",
     "Semaphore",
     "SimpleQueue",
-    "SpawnContext",
     "TimeoutError",
     "Value",
     "active_children",

--- a/torch/multiprocessing/__init__.py
+++ b/torch/multiprocessing/__init__.py
@@ -45,7 +45,6 @@ from .spawn import (
     ProcessExitedException,
     ProcessRaisedException,
     spawn,
-    SpawnContext,
     start_processes,
 )
 

--- a/torch/multiprocessing/spawn.py
+++ b/torch/multiprocessing/spawn.py
@@ -24,7 +24,6 @@ __all__ = [
     "ProcessExitedException",
     "ProcessRaisedException",
     "spawn",
-    "SpawnContext",
     "start_processes",
 ]
 
@@ -209,14 +208,6 @@ class ProcessContext:
         msg = f"\n\n-- Process {error_index:d} terminated with the following error:\n"
         msg += original_trace
         raise ProcessRaisedException(msg, error_index, failed_process.pid)
-
-
-class SpawnContext(ProcessContext):
-    def __init__(self, processes, error_files):
-        warnings.warn(
-            "SpawnContext is renamed to ProcessContext since 1.4 release.", stacklevel=2
-        )
-        super().__init__(processes, error_files)
 
 
 # Note: [start_processes]


### PR DESCRIPTION
> `SpawnContext` is the pre-1.4 name of `ProcessContext`, kept as a subclass that only warns. Nothing in tree constructs it and all APIs return `ProcessContext`, so remove the alias and its registration sites. The `multiprocessing.md` class doc, which still documented the old name, now documents `ProcessContext`.
>
> Breaking change for code importing `torch.multiprocessing.SpawnContext`; happy to drop if maintainers prefer keeping the alias.
>
> Test Plan: with the patched files, `SpawnContext` is gone and `mp.spawn` still runs.