### PR TITLE
[TEST] Add hw_classification to test_fsdp_mixed_precision.py

### DIFF
--- a/test/distributed/fsdp/test_fsdp_mixed_precision.py
+++ b/test/distributed/fsdp/test_fsdp_mixed_precision.py
@@ -37,6 +37,7 @@ from torch.testing._internal.common_fsdp import (
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -520,6 +521,8 @@ class TestFSDPMixedPrecision(FSDPTest):
 
 
 class TestFSDPMixedPrecisionSharded(TestFSDPMixedPrecision):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2
@@ -1050,6 +1053,8 @@ class TestFSDPMixedPrecisionUnsharded(TestFSDPMixedPrecision):
     Smaller test suite for unshared param (i.e. world_size == 1) case.
     """
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 1
@@ -1114,6 +1119,8 @@ class ModelWithIgnoredModule(nn.Module):
 
 
 class TestFSDPMixedPrecisionIgnoredModules(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 1
@@ -1135,6 +1142,8 @@ class TestFSDPMixedPrecisionIgnoredModules(FSDPTest):
 
 
 class TestFSDPDifferentSubmodulePrecision(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2
@@ -1290,6 +1299,8 @@ class TestFSDPDifferentSubmodulePrecision(FSDPTest):
 
 
 class TestFSDPTrainEval(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2


### PR DESCRIPTION
## Summary
- Classifies all five `test_*`-bearing classes in `test/distributed/fsdp/test_fsdp_mixed_precision.py` as `HardwareClassification.ACCELERATOR`: `TestFSDPMixedPrecisionSharded`, `TestFSDPMixedPrecisionUnsharded`, `TestFSDPMixedPrecisionIgnoredModules`, `TestFSDPDifferentSubmodulePrecision`, `TestFSDPTrainEval`.
- `TestFSDPMixedPrecision` itself has no `test_*` methods (shared helpers only) and is left unclassified per the base/mixin-class exception.
- No `instantiate_device_type_tests()` added: `FSDPTest` extends `MultiProcessTestCase`, not `DeviceTypeTestBase`, and the test bodies reference the module-level `device_type` global rather than `self.device_type`. Verified empirically that wrapping a class in `instantiate_device_type_tests` doesn't error, but produces `...CPU`/`...CUDA` variants that both actually run on the same accelerator, silently duplicating CI cost with no added coverage.

## Test Plan

```
python test/distributed/fsdp/test_fsdp_mixed_precision.py -v
Ran 66 tests in ~399s - OK (65 passed, 1 skipped)

python test/distributed/fsdp/test_fsdp_mixed_precision.py -v --hw-classification ACCELERATOR
Ran 66 tests in ~398s - OK (skipped=1)
```