### PR TITLE
[docs] Fix Python method notation in set_device_states docstring

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -204,7 +204,7 @@ def set_device_states(devices, states, *, device_type=None) -> None:
         states: States to set.
         device_type: ``device_type`` of the devices to set states for. Default
             is the device returned by a call to ``DefaultDeviceType.get_device_type()``,
-            which is ``cuda`` if not changed by calling ``DefaultDeviceType::set_device_type()``.
+            which is ``cuda`` if not changed by calling ``DefaultDeviceType.set_device_type()``.
     """
     if device_type is None:
         device_type = DefaultDeviceType.get_device_type()


### PR DESCRIPTION
Small documentation fix in `torch/utils/checkpoint.py`.
Replaces C++ style scope operator `DefaultDeviceType::set_device_type()` with Python dot notation `DefaultDeviceType.set_device_type()` in the parameter description for `set_device_states`.