### PR TITLE
[aot_autograd] Make the fallback cache key unique per call

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -13,10 +13,10 @@ import json
 import logging
 import os
 import pickle
-import random
 import shutil
 import time
 import traceback
+import uuid
 from copy import copy
 from typing import Any, TYPE_CHECKING
 from typing_extensions import override
@@ -961,7 +961,13 @@ def autograd_cache_key(
                 "Failed to generate AOTAutograd cache key; falling back to nonce due to enable_aot_compile",
                 exc_info=True,
             )
-            return str(random.random()), []
+            # Unique per CALL, not merely per graph. random.random() is not:
+            # Dynamo save/restores Python random state around every frame it
+            # compiles, so on that path this returned the same value for every
+            # graph in one capture, and the second graph HIT the first's entry
+            # -- the keyed lookup still runs, so a precompile's graphs share a
+            # keyspace even though the artifact is addressed by backend id.
+            return uuid.uuid4().hex, []
         else:
             raise
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195070
* #195014
* #194966
* #194952
* #194951
* #194950
* #194949
* #194948
* #194677
* #194629
* #194622
* #194619
* #194549
* #194542
* #194541
* #194534
* #194488
* #194479
* #194455
* #194454
* #194453
* #194452
* __->__ #194451
* #194450
* #194449
* #194428
* #194427
* #194426
* #194409
* #194394
* #194393
* #194390
* #194389
* #194388
* #194387
* #194386
* #194385
* #194384
* #194383
* #194320
* #194319
* #194318
* #194317
* #194316
* #194302
* #194301
* #194300
* #194286
* #194285
* #194284
* #194283
* #194282
* #194250
* #194249
* #194248
* #194158
* #192379
* #193977
* #193976
* #193697
* #192374
* #192866
* #193725

``autograd_cache_key`` falls back to a nonce when it cannot key a graph and
``bypass_autograd_cache_key`` is set -- the AOT-precompile case, where the
artifact is addressed by backend id and pinned to one torch build, so key
soundness across processes buys nothing.

The nonce was ``str(random.random())``, which is not a nonce on the frame
evaluation path: Dynamo save/restores Python random state around every frame it
compiles, so it returns the same value for every graph in one capture. Two
graphs in one capture, both unkeyable:

    key[0] = 0.6046499405164466
    key[1] = 0.6046499405164466
    key[2] = 0.6046499405164466
    key[3] = 0.5062721227655768
    {'autograd_cache_miss': 2, 'autograd_cache_saved': 1, 'autograd_cache_hit': 2}

Two hits, one save. The keyed lookup runs whether or not the key is meaningful,
so the second graph found the first's entry and got its compiled code. That the
artifact is later addressed by backend id does not help -- the collision has
already happened by then, inside the capture.

``uuid.uuid4().hex`` instead: 4 keys, 4 distinct, 4 misses, 2 saves. The cost is
that two identical graphs in one capture no longer dedup, which is the right
trade for a key that exists precisely because the graph could not be identified.

Latent until now rather than a live bug: the two existing users of this flag,
``torch._dynamo.aot_compile`` and ``aot_compile_joint_with_descriptors``, call
into capture directly and never re-enter frame evaluation, so random state
advances normally for them. The commit above this one puts a precompile capture
on that path, which is what makes it reachable.

Test Plan:

```
python test/dynamo/test_aot_autograd_cache.py
python test/test_precompile.py
python test/dynamo/test_aot_compile.py
```

test_aot_compile.py has 3 pre-existing failures in this environment
(test_aot_compile_with_aoti*, `fatal error: cuda.h`).

Authored with an AI assistant.

Differential Revision: [D117073082](https://our.internmc.facebook.com/intern/diff/D117073082)