### PR TITLE
[aot_autograd] Name the method and the receiver in the call_method cache bypass

### DIFF
--- a/test/dynamo/test_aot_autograd_cache.py
+++ b/test/dynamo/test_aot_autograd_cache.py
@@ -3798,6 +3798,24 @@ class AOTAutogradCachePicklerTests(torch._dynamo.test_case.TestCase):
         ):
             check_cacheable(gm)
 
+    def test_call_method_bypass_names_the_method_and_the_receiver(self):
+        graph = torch.fx.Graph()
+        xs = graph.placeholder("xs")
+        item = graph.call_function(operator.getitem, (xs, 0))
+        graph.output(graph.call_method("size", (item,)))
+        gm = torch.fx.GraphModule({}, graph)
+
+        with self.assertRaises(BypassAOTAutogradCache) as ctx:
+            check_cacheable(gm)
+        message = str(ctx.exception)
+        self.assertIn("'size'", message)
+        self.assertIn("'getitem'", message)
+        self.assertIn("example_value", message)
+        # Read off the Node rather than the receiver's value, these reported
+        # torch.fx.node/None for every graph and named no method at all.
+        self.assertNotIn("torch.fx.node", message)
+        self.assertNotIn("Method name: None", message)
+
     def test_numpy_wrapper_cache_key_does_not_cache_unknown_callable_ids(self):
         torch._dynamo.utils._torch_numpy_callable_cache_key_by_id.cache_clear()
 

--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -262,10 +262,14 @@ def check_node_safe(node: Node) -> None:
                 f"expected method_target to be Node, got {type(method_target)}"
             )
         if not is_tensor(method_target):
-            module = getattr(method_target, "__module__", None)
-            name = getattr(method_target, "__name__", None)
+            # Name the receiver AND the method: the receiver's str() is its node
+            # name, so on its own this read as a rejected function called
+            # "getitem". __module__/__name__ were read off the Node, which
+            # reports torch.fx.node and None for every graph.
             raise BypassAOTAutogradCache(
-                f"Unsupported call_method target {method_target}. \nMethod module: {module}, \nMethod name: {name}"
+                f"Unsupported call_method {method_name!r} on node "
+                f"'{method_target}' ({method_target.op} {method_target.target}), "
+                f"which has no example_value and so is not known to be a Tensor"
             )
         if (
             type(method_name) is not str


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195070
* #195014
* #194966
* #194952
* #194951
* #194950
* #194949
* #194948
* #194677
* #194629
* #194622
* #194619
* #194549
* #194542
* #194541
* #194534
* #194488
* #194479
* #194455
* #194454
* __->__ #194453
* #194452
* #194451
* #194450
* #194449
* #194428
* #194427
* #194426
* #194409
* #194394
* #194393
* #194390
* #194389
* #194388
* #194387
* #194386
* #194385
* #194384
* #194383
* #194320
* #194319
* #194318
* #194317
* #194316
* #194302
* #194301
* #194300
* #194286
* #194285
* #194284
* #194283
* #194282
* #194250
* #194249
* #194248
* #194158
* #192379
* #193977
* #193976
* #193697
* #192374
* #192866
* #193725

The bypass a graph gets when it calls a method on a non-Tensor node reads:

    Unsupported call_method target getitem.
    Method module: torch.fx.node,
    Method name: None

Every part of that after the first four words is wrong. `method_target` is the
RECEIVER node, and a Node's str() is its name, so "target getitem" names the
node the method was called ON, not the method -- it reads as a rejected
function called `getitem`. The module and name are read off that Node too, so
they report `torch.fx.node` and `None` for every graph ever rejected here: a
Node has no `__name__`, and `__module__` resolves to the class attribute. The
one fact worth having, which method was called, is never printed.

A reader who takes the message at face value goes looking for an allowlist gap
on a function named `getitem`. The actual condition is that the receiver
carries no `example_value`, so `is_tensor` cannot conclude it is a Tensor, and
the useful next step is to find out what that node is.

Test Plan:

```
python test/dynamo/test_aot_autograd_cache.py
```

One new test builds the rejecting graph directly -- getitem off a placeholder,
then a method on the result -- and asserts the message names both the method
and the receiver, and that neither of the two constants the old code emitted
survives.

Authored with an AI assistant.

Differential Revision: [D117073078](https://our.internmc.facebook.com/intern/diff/D117073078)