### PR TITLE
[DTensor] Do not flatten all_gather when shard dim is not evenly divisible

### DIFF
--- a/test/distributed/tensor/test_redistribute.py
+++ b/test/distributed/tensor/test_redistribute.py
@@ -3198,6 +3198,41 @@ class UnevenFlattenedReduceScatterTest(DTensorContinuousTestBase):
             )
 
 
+class UnevenFlattenedAllGatherTest(DTensorContinuousTestBase):
+    """Test for correctness of flattened all_gather with uneven tensor dimensions.
+
+    When redistributing Shard(dim),Shard(dim) -> Replicate,Replicate on a 2D
+    mesh, uneven tensor dimensions produce nested chunk boundaries that do not
+    coincide with the chunk boundaries of a single flattened all_gather, so
+    the flattened optimization must not be applied (same rule reduce_scatter
+    already enforces).
+    """
+
+    world_size = 4  # 2 x 2 mesh
+
+    def test_shard_shard_to_replicate_replicate_uneven(self):
+        """Test that Shard(0),Shard(0) -> Replicate,Replicate round-trips uneven dims.
+
+        With mesh [2, 2] and tensor dim 0 size = 5:
+        - Nested chunking: dim split [3, 2] across mesh dim 0, then [2, 1] and
+          [1, 1] across mesh dim 1 -> local sizes (2, 1, 1, 1).
+        - A single flattened all_gather over 4 ranks assumes flat chunk sizes
+          (2, 2, 1, 0), so gathering the nested shards with it reassembles the
+          tensor with rows misplaced and zero padding injected.
+        """
+        mesh = init_device_mesh(self.device_type, (2, 2), mesh_dim_names=("A", "B"))
+        # Create flattened mesh so the flattened optimization is eligible
+        mesh["A", "B"]._flatten("A_B")
+
+        # Tensor size 5 on dim 0 is not divisible by the flattened mesh size 4
+        full_tensor = torch.arange(5 * 3, dtype=torch.float32).reshape(5, 3)
+        dt = distribute_tensor(full_tensor, mesh, (Shard(0), Shard(0)))
+
+        result = dt.redistribute(mesh, (Replicate(), Replicate()))
+
+        self.assertEqual(result.to_local(), full_tensor)
+
+
 RedistributeTestWithLocalTensor = create_local_tensor_test_class(
     RedistributeTest,
     base_class=LocalDTensorContinuousTestBase,

--- a/torch/distributed/tensor/_redistribute.py
+++ b/torch/distributed/tensor/_redistribute.py
@@ -382,7 +382,7 @@ def _warn_flatten_optimization_not_possible(
     elif reason == "uneven_tensor_shape":
         reason_msg = (
             " Unfortunately, because the tensor dimension is not evenly divisible by the product of "
-            "the mesh dim sizes that would need to be flattened for the optimization to work, it can not be optimized.",
+            "the mesh dim sizes that would need to be flattened for the optimization to work, it can not be optimized."
         )
     elif reason == "non_ascending_mesh_dims":
         reason_msg = (
@@ -481,7 +481,7 @@ def _optimize_transform_infos(
         - failure_reason is None if successful, or one of:
           - "too_few_transforms": Less than 2 transforms provided
           - "no_flattened_mesh": No flattened mesh exists for the required dimensions
-          - "uneven_tensor_shape": For reduce_scatter, tensor dim not evenly divisible
+          - "uneven_tensor_shape": For all_gather / reduce_scatter, tensor dim not evenly divisible
         """
         if len(infos) < 2:
             return None, "too_few_transforms"
@@ -524,22 +524,26 @@ def _optimize_transform_infos(
         # The outermost transform has the largest logical_shape on the affected
         # tensor dimension (least divided by prior shards).
         src, dst = first_placements
-        if comm_type == "all_gather":
-            # S->R (all_gather): affected dim is the source shard dim
-            affected_dim = cast(Shard, src).dim
-            outermost_info = max(infos, key=lambda x: x.logical_shape[affected_dim])
-        elif comm_type == "reduce_scatter":
-            affected_dim = cast(Shard, dst).dim
+        if comm_type in ("all_gather", "reduce_scatter"):
+            # all_gather (S->R): affected dim is the source shard dim.
+            # reduce_scatter (P->S): affected dim is the destination shard dim.
+            affected_dim = (
+                cast(Shard, src).dim
+                if comm_type == "all_gather"
+                else cast(Shard, dst).dim
+            )
             outermost_info = max(infos, key=lambda x: x.logical_shape[affected_dim])
             tensor_dim_size = outermost_info.logical_shape[affected_dim]
             effective_shard_mesh_size = math.prod(
                 device_mesh.size(info.mesh_dim) for info in infos
             )
-            # For reduce_scatter (Partial -> Shard), we cannot flatten if the tensor
-            # dimension is not evenly divisible by the flattened mesh size.
-            # The effective size is the product of mesh sizes for dims being transformed
-            # (not all dims with matching placement - intervening shards are already
-            # accounted for in logical_shape).
+            # We cannot flatten if the tensor dimension is not evenly divisible
+            # by the flattened mesh size: nested sharding chunks the dimension
+            # hierarchically, and those chunk boundaries only coincide with the
+            # boundaries of a single flat collective when the split is even.
+            # The effective size is the product of mesh sizes for dims being
+            # transformed (not all dims with matching placement - intervening
+            # shards are already accounted for in logical_shape).
             if tensor_dim_size % effective_shard_mesh_size != 0:
                 return None, "uneven_tensor_shape"
         elif comm_type == "all_reduce":


### PR DESCRIPTION
Fixes a silent data-corruption bug in DTensor's flattened-collective optimization.

## The bug

`try_create_flattened()` rejects **reduce_scatter** when the affected tensor dimension is not evenly divisible by the flattened mesh size (`uneven_tensor_shape`), but the **all_gather** branch has no such guard. The invariant is the same for both: nested sharding chunks a dimension hierarchically, and those chunk boundaries only coincide with the chunk boundaries of a single flat collective when the split is even.

With a 2x2 mesh carrying a flattened submesh, a `(5, 3)` tensor placed `[Shard(0), Shard(0)]` (nested local sizes 2/1/1/1) and redistributed to `[Replicate(), Replicate()]` takes the flattened all_gather path (which assumes flat chunk sizes 2/2/1/0) and returns corrupted data on every rank, with no error:

```
got:                          expected:
tensor([[ 0.,  1.,  2.],      tensor([[ 0.,  1.,  2.],
        [ 3.,  4.,  5.],              [ 3.,  4.,  5.],
        [ 6.,  7.,  8.],              [ 6.,  7.,  8.],
        [ 0.,  0.,  0.],              [ 9., 10., 11.],
        [ 9., 10., 11.]])             [12., 13., 14.]])
```

Row 4 is silently lost and a padding row appears in its place. Reproduces on current main and on v2.13.0 (the branch structure is identical); related to the uneven-sharding corner cases tracked in #103306.

## The fix

Hoist the divisibility guard so it covers both comm types — the uneven case falls back to the correct sequential path, exactly as reduce_scatter does today. Even splits keep the flattened fast path.

Two adjacent nits fixed in the same code path: the docstring said `uneven_tensor_shape` applies "for reduce_scatter" only, and the `uneven_tensor_shape` warning message was accidentally a one-element tuple (trailing comma), rendering as `("Unfortunately, ...",)` in the warning text.

## Test

`UnevenFlattenedAllGatherTest` mirrors the existing `UnevenFlattenedReduceScatterTest`: 2x2 mesh with flattened submesh, dim size 5, asserts the round-trip returns the original tensor. Fails on main with the corruption above, passes with this change.
