### PR TITLE
[MPS] Periodically release the command buffer to bound MPSGraph scratch

### DIFF
--- a/aten/src/ATen/mps/MPSStream.h
+++ b/aten/src/ATen/mps/MPSStream.h
@@ -123,6 +123,8 @@ class TORCH_API MPSStream {
   MPSCommandBuffer_t _commandBuffer = nil;
   MPSCommandBuffer_t _prevCommandBuffer = nil;
   MTLComputeCommandEncoder_t _commandEncoder = nil;
+  // encodes accumulated into _commandBuffer since the last flush()
+  uint64_t _encodesSinceFlush = 0;
   MPSGraphExecutionDescriptor* _executionDescriptor = nil;
   MPSGraphCompilationDescriptor* _compilationDescriptor = nil;
   dispatch_queue_t _serialQueue = nullptr;

--- a/aten/src/ATen/mps/MPSStream.mm
+++ b/aten/src/ATen/mps/MPSStream.mm
@@ -15,6 +15,16 @@
 @end
 
 namespace at::mps {
+
+// Number of MPSGraph encodes to accumulate into one command buffer before
+// committing and releasing it. See executeMPSGraph() for why this is needed.
+// 8 was picked by measurement on an M4: it keeps a 20k iteration LSTM loop
+// flat at ~185 MB where the unbounded version reaches 16 GB, and it is the
+// fastest setting measured on large graphs, where the memory pressure costs
+// more time than the extra command buffers do. Larger values stop bounding
+// memory on big graphs (64 leaves a 1024 hidden, 100 step LSTM at 13 GB).
+constexpr uint64_t kEncodesPerCommandBuffer = 8;
+
 //-----------------------------------------------------------------
 //  MPSStream
 //-----------------------------------------------------------------
@@ -248,6 +258,23 @@ void MPSStream::executeMPSGraph(MPSGraph* mpsGraph, NSDictionary* feeds, NSDicti
       profiler.endProfileKernel(mpsGraph, this, _syncType);
     } else {
       synchronize(_syncType);
+    }
+
+    // MPSGraph allocates scratch buffers for a graph's internal intermediates
+    // straight from the device, so they never pass through MPSAllocator. That
+    // scratch is retained by the command buffer it was encoded into and is only
+    // reclaimed once the buffer completes and is released. With
+    // commitAndContinue enabled, commit() calls commitAndContinue on the same
+    // MPSCommandBuffer and never releases it, so only commitAndWait() ever
+    // drops it. A loop that does not synchronize therefore holds one scratch
+    // allocation per encode for the life of the process (see #145374).
+    // Committing and releasing the command buffer every so often lets the
+    // driver reclaim that memory. flush() does not wait on the GPU and the next
+    // encode creates a fresh command buffer, so this does not stall the
+    // pipeline.
+    if (_enableCommitAndContinue && ++_encodesSinceFlush >= kEncodesPerCommandBuffer) {
+      flush();
+      _encodesSinceFlush = 0;
     }
   });
 }


### PR DESCRIPTION
Fixes #145374.

## What is happening

MPSGraph allocates scratch for a graph's internal intermediates directly from
the device. Those buffers never pass through MPSAllocator, which is why the
issue reports memory climbing while `torch.mps.current_allocated_memory()` and
`memory_reserved()` stay flat and `empty_cache()` does nothing. Only
`driver_allocated_memory()` sees them.

That scratch is retained by the command buffer it was encoded into, and is
released when that buffer completes and is released. With commitAndContinue
enabled, which is the default, `MPSStream::commit()` calls commitAndContinue on
the same MPSCommandBuffer and never releases it. Only `commitAndWait()` drops
it. So a loop that never synchronizes accumulates one scratch allocation per
encode for the life of the process.

## How I got there

On an M4, 24 GB, macOS 26.6.1, torch built from main:

1. Four counters per iteration on the issue's repro. `driver_allocated_memory`
   grows 0.8 MB per iteration, dead linear. `memory_reserved`, current, and
   active never move. Same loop on CPU is flat.
2. `heap` snapshots 1950 iterations apart show `AGXG16GFamilyBuffer` going from
   78 to 2028 live instances. That is exactly one leaked MTLBuffer per LSTM
   execution.
3. `leaks` reports none of them, so they are reachable, held by something live
   rather than lost.
4. The leak scales with T, H and num_layers, so the buffers are sized like the
   graph's intermediates.
5. Timing shows iteration 0 at 45 ms and the rest at 1.1 ms, so the graph cache
   is hitting and exactly one compiled graph exists. The growth happens on cache
   hits, which puts it below RnnOps.mm.
6. `torch.mps.synchronize()` every iteration makes it completely flat, which
   points at the command buffer lifetime rather than the op.

## The fix

Commit and release the command buffer every 8 encodes. `flush()` does not wait
on the GPU and the next encode lazily creates a fresh command buffer, so the
pipeline keeps running.

## Results

| workload | on main | with the fix |
| --- | --- | --- |
| 20k iteration LSTM loop | 16010 MB, still climbing | 185 MB, flat from iteration 2000 |
| 2 layer LSTM training, 500 steps | 4067 MB peak | 131 MB peak |
| hidden 1024, 100 steps, batch 64 | OOM at 29 GB | completes, 6.4 GB |

Time per step is unchanged on the training loop (1.62 vs 1.58 ms median over 4
runs). On the large configs the fix is actually faster, 75 ms vs 114 ms per
iteration, because the memory pressure was costing more than the extra command
buffers do.

## Why 8

I swept the cadence over LSTM inference at three sizes, LSTM training, matmul at
three sizes, a mixed workload, and two threads, 3 repeats each.

- 1 is the worst for small graph ops, +64% on a 32x32 matmul, and it does not
  reduce memory further.
- 64 stops bounding memory once graphs get big. It leaves the 1024 hidden
  config at 13 GB, which is close to the unfixed number.
- 8 is the only setting that is good at both ends. On the large config it is
  both the fastest and the leanest.

## Known cost

On a 32x32 matmul, which is small enough that submission overhead dominates,
this costs about 12% (12.6 to 14.0 us). At 256x256 and above it is gone.
Elementwise ops do not go through `executeMPSGraph` at all so they are
unaffected.

## Testing

Full `test/test_mps.py` with and without the change on the same base: same 3
failures and 15 errors both times, all pre-existing. 14 of the errors are
`compile_shader` include path issues from my local build.

I also wrote a regression test that asserts bounded growth over 500 iterations,
0 MB with the fix and 24 MB without. I left it out because a memory threshold
seems likely to be flaky across the runner fleet, but happy to add it if you
want it.

## Open question

The cadence is a fixed encode count, which means the memory it bounds scales
with how big each graph's scratch is. I tried a byte budget instead, tracking
device allocation growth, but it did worse in practice: once buffers start being
recycled the growth signal stalls and it stops flushing. A cadence gated on
whether device allocation actually grew since the last flush would avoid the
pointless flushes on ops that do not leak, but I have not validated it and did
not want to add a mechanism I cannot back with numbers.