### PR TITLE
[MPS] Raise NotImplementedError for pooling ops that require 64-bit indexing

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -454,6 +454,9 @@ static void fill_pool_size_strides(PoolingParams<5>& params,
                                    const Tensor& output,
                                    const std::optional<Tensor>& indices_opt) {
   const Tensor& indices = *(at::borrow_from_optional_tensor(indices_opt));
+  TORCH_CHECK_NOT_IMPLEMENTED(canUse32BitIndexMath(input) && canUse32BitIndexMath(output) &&
+                                  (!indices.defined() || canUse32BitIndexMath(indices)),
+                              "MPS pooling does not support tensors that require 64-bit indexing");
   for (const auto dim : c10::irange(input.dim())) {
     params.input_sizes[dim] = safe_downcast<int32_t, int64_t>(input.size(dim));
     params.input_strides[dim] = safe_downcast<int32_t, int64_t>(input.stride(dim));
@@ -573,6 +576,10 @@ static void max_pool_backward_out_mps_template(Tensor& grad_input,
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   const auto numThreads = grad_output.numel();
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      canUse32BitIndexMath(grad_input) && canUse32BitIndexMath(grad_output) && canUse32BitIndexMath(indices),
+      op_name,
+      ": MPS does not support tensors that require 64-bit indexing");
   PoolingBackwardParams<5> params;
 
   params.dims = dims;
@@ -848,6 +855,9 @@ static void avg_pool_out_mps_template(const Tensor& output,
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   const auto numThreads = output.numel();
+  TORCH_CHECK_NOT_IMPLEMENTED(canUse32BitIndexMath(input) && canUse32BitIndexMath(output),
+                              op_name,
+                              ": MPS does not support tensors that require 64-bit indexing");
 
   AvgPoolingParams<5> params;
 
@@ -907,6 +917,9 @@ static void avg_pool_backward_out_mps_template(const Tensor& grad_input,
   id<MTLDevice> device = MPSDevice::getInstance()->device();
   MPSStream* mpsStream = getCurrentMPSStream();
   const auto numThreads = grad_output.numel();
+  TORCH_CHECK_NOT_IMPLEMENTED(canUse32BitIndexMath(grad_input) && canUse32BitIndexMath(grad_output),
+                              op_name,
+                              ": MPS does not support tensors that require 64-bit indexing");
 
   AvgPoolingParams<5> params;
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -1794,6 +1794,7 @@ torch.{device_type}.synchronize()
     @onlyAccelerator
     @largeTensorTest("18GB")
     @largeTensorTest("180GB", "cpu")
+    @expectedFailureMPS
     def test_pool3d_large_size_int64(self, device):
         # See https://github.com/pytorch/pytorch/issues/52822
         x = torch.randn(


### PR DESCRIPTION
Continuation of #194373
More errors. Below script causes failures:
```
import torch
import torch.nn.functional as F


def run(name, shape, op, bwd):
    x = torch.randn(shape, dtype=torch.half)
    xm = x.to("mps").requires_grad_(bwd)
    xc = x.float().requires_grad_(bwd)
    try:
        ym, yc = op(xm), op(xc)
        if bwd:
            g = torch.randn_like(yc)
            ym.backward(g.to("mps").half())
            yc.backward(g)
            rm, rc = xm.grad.cpu().float(), xc.grad
        else:
            rm, rc = ym.detach().cpu().float(), yc.detach()
        bad = int(((rm - rc).abs() > 0.1).sum())
        print(f"{name}: {'FAIL' if bad else 'ok'}  mismatched={bad}")
    except NotImplementedError as e:
        print(f"{name}: guarded ({e})")
    torch.mps.empty_cache()


P2 = (34, 1, 8192, 8192)
P3 = (70, 32, 100, 100, 100)

run("max/adaptive fwd template", P2, lambda t: F.max_pool2d(t, 2), False)
run("max bwd template", P2, lambda t: F.adaptive_max_pool2d(t, 128), True)
run("avg fwd template", P2, lambda t: F.avg_pool2d(t, 2, ceil_mode=True), False)
run("avg bwd template", P3, lambda t: F.avg_pool3d(t, 2), True)
```

leads to:
```
max/adaptive fwd template: FAIL  mismatched=32208577
max bwd template: FAIL  mismatched=30132
avg fwd template: FAIL  mismatched=28232769
avg bwd template: FAIL  mismatched=39205174
```