### PR TITLE
[inductor] Replace `Any` with `object` at the serialization / cache-key boundary

### DIFF
--- a/torch/_functorch/_aot_autograd/autograd_cache.py
+++ b/torch/_functorch/_aot_autograd/autograd_cache.py
@@ -607,7 +607,7 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
         return (_ident, (name,))
 
     # pyrefly: ignore [bad-override]
-    def reducer_override(self, obj: Any) -> Any:
+    def reducer_override(self, obj: object) -> Any:
         """
         Override to handle tensor subclasses (like DTensor) that aren't caught
         by the dispatch_table's exact type matching.
@@ -628,7 +628,7 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
         return super().reducer_override(obj)
 
     @staticmethod
-    def _format_global_for_cache_key(name: str, obj: Any) -> str:
+    def _format_global_for_cache_key(name: str, obj: object) -> str:
         if (numpy_key := numpy_wrapper_cache_key(obj)) is not None:
             return f"# cache_key_numpy_wrapper {name}: {numpy_key!r}"
 
@@ -674,10 +674,10 @@ class AOTAutogradCachePickler(FxGraphCachePickler):
     def _hash_bytes_for_cache(self, data: bytes) -> str:
         return hashlib.blake2b(data, digest_size=16).hexdigest()
 
-    def _hash_pickled_value_for_cache(self, value: Any) -> str:
+    def _hash_pickled_value_for_cache(self, value: object) -> str:
         return self._hash_bytes_for_cache(pickle.dumps(value))
 
-    def _stable_hash_for_cache_value(self, obj: Any) -> str:
+    def _stable_hash_for_cache_value(self, obj: object) -> str:
         """Get a stable hash for an object used inside tensor subclass metadata."""
         from torch._custom_class_base import CustomClassBase
         from torch.utils._python_dispatch import is_traceable_wrapper_subclass

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -169,7 +169,9 @@ class TuningProcess:
 
     @staticmethod
     def send(
-        obj: Any, write_pipe: IO[bytes], extra_env: dict[str, str | None] | None = None
+        obj: object,
+        write_pipe: IO[bytes],
+        extra_env: dict[str, str | None] | None = None,
     ) -> None:
         pickle.dump((obj, extra_env), write_pipe)
         write_pipe.flush()
@@ -233,7 +235,7 @@ class TuningProcess:
         """
         return self.running and self.process.poll() is None
 
-    def put(self, req: Any, extra_env: dict[str, str | None] | None = None) -> None:
+    def put(self, req: object, extra_env: dict[str, str | None] | None = None) -> None:
         """
         Push a work item to the child process.
         """

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -733,7 +733,7 @@ class FxGraphCachePickler(pickle.Pickler):
         self.fast = True
 
     # pyrefly: ignore [bad-override]
-    def reducer_override(self, obj: Any) -> Any:
+    def reducer_override(self, obj: object) -> Any:
         """Fallback reducer for objects not registered in dispatch_table.
 
         This handles extension types (e.g. pybind11 enums) that don't support
@@ -769,7 +769,9 @@ class FxGraphCachePickler(pickle.Pickler):
         return result
 
     @staticmethod
-    def _reduce_unpicklable(obj: Any) -> Any:
+    def _reduce_unpicklable(
+        obj: object,
+    ) -> tuple[Callable[[str], NoReturn], tuple[str]]:
         key = _get_stable_obj_key(obj)
         if key is None:
             raise BypassFxGraphCache(
@@ -846,7 +848,7 @@ class FxGraphCachePickler(pickle.Pickler):
         # hashing.  Guards ensure correctness on cache reload.
         return (_ident, (str(s),))
 
-    def _reduce_unsupported(self, s: Any) -> NoReturn:
+    def _reduce_unsupported(self, s: object) -> NoReturn:
         """
         Custom reducer to handle any objects that we don't support and therefore
         raise to bypass caching.
@@ -893,7 +895,7 @@ class FxGraphCachePickler(pickle.Pickler):
                 self.fast = False
         return (_ident, (t.wrapped_obj, t.script_class_name, t.real_obj))
 
-    def dumps(self, obj: Any) -> bytes:
+    def dumps(self, obj: object) -> bytes:
         """
         Pickle an object and return a byte string.
         """
@@ -913,14 +915,14 @@ class FxGraphCachePickler(pickle.Pickler):
             self._stream.seek(0)
             self._stream.truncate(0)
 
-    def get_hash(self, obj: Any) -> str:
+    def get_hash(self, obj: object) -> str:
         """
         Serialize an object and return a hash of the bytes.
         """
         serialized_data = self.dumps(obj)
         return COMPACT_CACHE_KEY_STRATEGY.key(serialized_data)
 
-    def get_key(self, obj: Any) -> str:
+    def get_key(self, obj: object) -> str:
         """
         Serialize an object and return an FX graph cache key.
         """
@@ -934,7 +936,7 @@ class FxGraphCachePickler(pickle.Pickler):
         to a different value than another.
         """
 
-        def get_str(obj: Any) -> str:
+        def get_str(obj: object) -> str:
             if isinstance(obj, torch.Tensor):
                 return str(extract_tensor_metadata_for_cache_key(obj))
             elif isinstance(obj, bytes):
@@ -1199,7 +1201,7 @@ class CacheabilityValidator:
 
     def _check_cache_key_object(
         self,
-        obj: Any,
+        obj: object,
         seen: set[int] | None = None,  # noqa: set_linter
     ) -> None:
         if seen is None:
@@ -1227,11 +1229,11 @@ class CacheabilityValidator:
 _warned_pre_grad_pass_missing_uuid: OrderedSet[str] = OrderedSet()
 
 
-def _custom_pass_has_uuid(custom_pass: Any) -> bool:
+def _custom_pass_has_uuid(custom_pass: object) -> bool:
     return isinstance(custom_pass, CustomGraphPass) and custom_pass.uuid() is not None
 
 
-def _custom_pass_name(custom_pass: Any) -> str:
+def _custom_pass_name(custom_pass: object) -> str:
     return getattr(custom_pass, "__qualname__", None) or type(custom_pass).__qualname__
 
 

--- a/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/kernel_cache.py
@@ -37,7 +37,7 @@ def _device_target(cc: int) -> Any:
     return TargetSm.ensure(f"{cc}a")
 
 
-def _epilogue_args_signature(epilogue_args: Any) -> tuple:
+def _epilogue_args_signature(epilogue_args: object) -> tuple:
     """Extract a hashable signature of epilogue args for cache keying.
 
     Two callers with the same `(efc_kernel_name, epilogue_source)` but
@@ -74,7 +74,7 @@ _cache_lock = threading.RLock()
 _kernel_by_name_cache: dict[str, Any] | None = None
 
 
-def _operand_dtype_str(operand: Any) -> str | None:
+def _operand_dtype_str(operand: object) -> str | None:
     """Best-effort cutlass dtype name for a kernel operand or args operand."""
     dtype = getattr(operand, "dtype", None)
     if dtype is None:
@@ -123,7 +123,7 @@ def _get_kernel_cache() -> dict[str, Any]:
     return cache
 
 
-def _operand_sig(operand: Any) -> tuple | None:
+def _operand_sig(operand: object) -> tuple | None:
     """Hashable (dtype, shape, stride, scale-sig, mode, swizzle) signature."""
     if operand is None:
         return None
@@ -149,7 +149,7 @@ def _operand_sig(operand: Any) -> tuple | None:
     return (dtype, tuple(shape), tuple(stride), scale_sig, mode, swizzle)
 
 
-def _partition_sig(args: Any) -> tuple | None:
+def _partition_sig(args: object) -> tuple | None:
     """Signature capturing everything `supports(args)` depends on, or None if
     it can't be fully determined (falls back to a non-memoized scan)."""
     a = _operand_sig(getattr(args, "A", None))

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -11,7 +11,7 @@ import tempfile
 import warnings
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, TYPE_CHECKING, TypeGuard
+from typing import TYPE_CHECKING, TypeGuard
 from typing_extensions import final, override, Self
 
 import torch._inductor.async_compile
@@ -75,12 +75,12 @@ class _VirtualizedSerializer:
 
     # The values here get serialized. We don't grab everything because some of
     # the fields can't be serialized.
-    aot_compilation: Any = None
-    choices: Any = None
-    local_buffer_context: Any = None
-    ops: Any = None
-    kernel: Any = None
-    current_node: Any = None
+    aot_compilation: object = None
+    choices: object = None
+    local_buffer_context: object = None
+    ops: object = None
+    kernel: object = None
+    current_node: object = None
 
     @classmethod
     def serialize(cls) -> _VirtualizedSerializer:


### PR DESCRIPTION
`Any` disables type checking for every value that flows through it. At the
inductor serialization and cache-key boundary that cost buys nothing: these
parameters are only pickled, hashed, or reduced to a cache signature, and
their bodies never do anything with the value beyond `isinstance`, `type()`,
`hasattr`, `getattr`, or handing it to `pickle`. `object` expresses exactly
that contract and, unlike `Any`, makes the checker reject a caller that
starts reading attributes off one of these values.

The tree already has the anchor for this: `SubprocPickler.dumps` in
`compile_worker/subproc_pool.py` is typed `obj: object`, while the
structurally identical `FxGraphCachePickler.dumps` was `obj: Any`. Likewise
`FxGraphCachePickler._reduce_unpicklable` was `obj: Any` even though its
entire body is a call to `_get_stable_obj_key`, which is already
`obj: object`. This makes those pairs agree.

Sites changed:

- `codecache.py`: `FxGraphCachePickler.{reducer_override, _reduce_unpicklable, _reduce_unsupported, dumps, get_hash, get_key}`, the local `get_str` inside `debug_lines`, `CacheabilityValidator._check_cache_key_object`, and the `_custom_pass_has_uuid` / `_custom_pass_name` helpers below it.
- `autograd_cache.py`: `AOTAutogradCachePickler.{reducer_override, _format_global_for_cache_key, _hash_pickled_value_for_cache, _stable_hash_for_cache_value}`. `reducer_override` is a direct override of the widened `FxGraphCachePickler` method, so leaving it on `Any` would have made this PR itself the source of a base/override disagreement. `_format_global_for_cache_key` is the anchor pattern again: it hands `obj` to `_format_import_statement`, which is already `obj: object`.
- `autotune_process.py`: `TuningProcess.{send, put}` (both pass straight through to `pickle.dump`).
- `compile_fx_ext.py`: the six `_VirtualizedSerializer` fields, which are populated by `getattr(V, f.name)` and only ever pickled and patched back; nothing reads through them. `Any` became unused in that file, so the import is gone too.
- `codegen/nv_universal_gemm/kernel_cache.py`: `_epilogue_args_signature`, `_operand_dtype_str`, `_operand_sig`, `_partition_sig` -- pure `getattr` chains that build a hashable signature.

Two judgment calls worth flagging.

Both `reducer_override` methods already carry a `# pyrefly: ignore
[bad-override]` against `pickle.Pickler`, so widening their parameter risked
churning an override relationship that is already suppressed. I checked
rather than guessed: with the suppression removed, pyrefly reports the same
`bad-override` before and after this change, so the ignore is load-bearing in
both states and the override relationship is untouched.

`_reduce_unpicklable`'s return type was also `Any`; since the body has a
single `return _unpicklable_error, (key,)`, it is now spelled exactly as
`tuple[Callable[[str], NoReturn], tuple[str]]`. Other return types are left
alone -- both `reducer_override`s genuinely return pickle's heterogeneous
reduce-value union.

No `cast` and no new suppression were needed anywhere.

## Test Plan

Type check. Full-project pyrefly was run with the five touched files reverted
to their `origin/viable/strict` contents and then with the patch applied, and
the sorted output diffed. The trailing `N errors (M suppressed)` line is part
of the diff, so a newly *suppressed* error would also surface:

```
git checkout origin/viable/strict -- <the five files>
pyrefly check --output-format=min-text 2>&1 | sort > /tmp/base.txt
git checkout HEAD -- <the five files>
pyrefly check --output-format=min-text 2>&1 | sort > /tmp/after.txt
diff /tmp/base.txt /tmp/after.txt
```

Identical: `65 errors (10,965 suppressed)` on both sides, zero net-new
diagnostics.

Lint, clean on all five touched files:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8,TYPEIGNORE,NOQA,DOCSTRING_LINTER \
  -m origin/viable/strict
```

Tests, against a local CUDA build of this branch:

```
python test/inductor/test_codecache.py
python test/dynamo/test_aot_autograd_cache.py
```

`test_codecache.py` is `OK` (323 run, 181 skipped -- the skips are the
triton/GPU-gated tests; triton 3.8.0 is not on the nightly index for this
box). `test_aot_autograd_cache.py` runs 220 with 4 errors in
`test_saved_tensors_hooks_autograd_cache{,_symbolic}`; those same 4 fail with
the five touched files checked out at `origin/viable/strict`, so they are
pre-existing in this environment and unrelated.

Every widened function was also driven directly -- `TuningProcess.send`/`recv`
round-trip, `FxGraphCachePickler.dumps`/`get_hash`/`get_key`/`debug_lines`,
`_check_cache_key_object`, `_custom_pass_has_uuid`/`_custom_pass_name`,
`_VirtualizedSerializer.serialize` through `pickle`, the four
`AOTAutogradCachePickler` methods, and the four `kernel_cache` signature
helpers -- all producing the expected values.

The change is annotation-only; four of the five files use
`from __future__ import annotations`, and the fifth annotates with the
`object` builtin, so nothing is evaluated differently at runtime.

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo