### PR TITLE
[package] Validate f arg type in PackageExporter before calling C++

### DIFF
--- a/torch/package/package_exporter.py
+++ b/torch/package/package_exporter.py
@@ -224,8 +224,13 @@ class PackageExporter:
         if isinstance(f, (str, os.PathLike)):
             f = os.fspath(f)
             self.buffer: IO[bytes] | None = None
-        else:  # is a byte buffer
+        elif hasattr(f, "write"):
             self.buffer = f
+        else:
+            raise TypeError(
+                "f arg should be a string, PathLike, or binary IO object, "
+                f"got {type(f)} instead."
+            )
 
         self.zip_file = torch._C.PyTorchFileWriter(f)
         self.zip_file.set_min_version(6)


### PR DESCRIPTION
PackageExporter.__init__ accepted any value for f and passed it directly to PyTorchFileWriter (C++), which called .write() on it. When f was a tensor (or any non-IO object), this caused an unrecoverable abort via pybind11.

Add a hasattr(f, "write") check before the C++ call. If f is not a string, PathLike, or binary IO object, raise a clear TypeError instead of crashing.

Fixes pytorch#155321