### PR TITLE
[elastic] Redirect the process std fds, not sys.stdout's fd

### DIFF
--- a/test/distributed/elastic/multiprocessing/redirects_test.py
+++ b/test/distributed/elastic/multiprocessing/redirects_test.py
@@ -7,6 +7,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import ctypes
+import io
 import os
 import shutil
 import sys
@@ -115,6 +116,65 @@ class RedirectsTest(unittest.TestCase):
             self.assertEqual(
                 {"redir stderr from python\n", "redir stderr from c\n"}, lines
             )
+
+    def _assert_all_three_sources(self, stdout_log):
+        with open(stdout_log) as f:
+            self.assertEqual(
+                {"foo from python\n", "foo from c\n", "foo from cmd\n"},
+                set(f.readlines()),
+            )
+
+    def test_redirect_stdout_without_fileno(self):
+        # A test runner may replace sys.stdout with a stream that has no fd at
+        # all (pytest --capture=sys). Deriving the fd from it used to raise
+        # io.UnsupportedOperation.
+        stdout_log = os.path.join(self.test_dir, "stdout.log")
+
+        orig_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            with redirect_stdout(stdout_log):
+                print("foo from python")
+                libc.printf(b"foo from c\n")
+                os.system("echo foo from cmd")
+        finally:
+            sys.stdout = orig_stdout
+
+        self._assert_all_three_sources(stdout_log)
+
+    def test_redirect_stdout_bound_to_other_fd(self):
+        # sys.stdout may instead be backed by an unrelated fd (pytest's default
+        # --capture=fd). Redirecting that fd let C and subprocess output escape.
+        stdout_log = os.path.join(self.test_dir, "stdout.log")
+        other_log = os.path.join(self.test_dir, "other.log")
+
+        orig_stdout = sys.stdout
+        with open(other_log, "w") as other:
+            sys.stdout = other
+            try:
+                with redirect_stdout(stdout_log):
+                    print("foo from python")
+                    libc.printf(b"foo from c\n")
+                    os.system("echo foo from cmd")
+            finally:
+                sys.stdout = orig_stdout
+
+        self._assert_all_three_sources(stdout_log)
+        with open(other_log) as f:
+            self.assertEqual("", f.read())
+
+    def test_redirect_restores_replaced_stdout(self):
+        stdout_log = os.path.join(self.test_dir, "stdout.log")
+
+        orig_stdout = sys.stdout
+        replacement = io.StringIO()
+        sys.stdout = replacement
+        try:
+            with redirect_stdout(stdout_log):
+                pass
+            self.assertIs(replacement, sys.stdout)
+        finally:
+            sys.stdout = orig_stdout
 
     def _redirect_large_buffer(self, print_fn, num_lines=500_000):
         stdout_log = os.path.join(self.test_dir, "stdout.log")

--- a/torch/distributed/elastic/multiprocessing/redirects.py
+++ b/torch/distributed/elastic/multiprocessing/redirects.py
@@ -10,6 +10,7 @@
 # Taken and modified from original source:
 # https://eli.thegreenplace.net/2015/redirecting-all-kinds-of-stdout-in-python/
 import ctypes
+import io
 import logging
 import os
 import sys
@@ -77,6 +78,15 @@ def _c_std(stream: str):
 
 def _python_std(stream: str):
     return {"stdout": sys.stdout, "stderr": sys.stderr}[stream]
+
+
+def _is_backed_by(stream, fd: int) -> bool:
+    """Whether writes to ``stream`` reach file descriptor ``fd``."""
+    try:
+        return stream.fileno() == fd
+    except (AttributeError, OSError, ValueError):
+        # io.UnsupportedOperation derives from both OSError and ValueError.
+        return False
 
 
 _VALID_STD = {"stdout", "stderr"}
@@ -210,7 +220,12 @@ else:
 
         c_std = _c_std(std)
         python_std = _python_std(std)
-        std_fd = python_std.fileno()
+        # C and subprocess output always goes to fds 1 and 2, so those are what
+        # must be redirected, not whatever sys.stdout is currently bound to.
+        # A test runner rebinds it: pytest's fd capture reports a temp file's
+        # fd and its sys capture has no fd at all. Windows uses the same
+        # constants above.
+        std_fd = 1 if std == "stdout" else 2
 
         def _redirect(dst):
             libc.fflush(c_std)
@@ -219,9 +234,23 @@ else:
 
         with os.fdopen(os.dup(std_fd)) as orig_std, open(to_file, mode="w+b") as dst:
             _redirect(dst)
+
+            # A rebound sys.stdout does not write to std_fd, so point it at the
+            # destination too. In the common case nothing is rebound.
+            rebound_std = None
+            if not _is_backed_by(python_std, std_fd):
+                rebound_std = io.TextIOWrapper(
+                    open(std_fd, mode="wb", closefd=False),  # noqa: SIM115
+                    line_buffering=True,
+                )
+                setattr(sys, std, rebound_std)
+
             try:
                 yield
             finally:
+                if rebound_std is not None:
+                    rebound_std.flush()  # before std_fd is pointed back
+                    setattr(sys, std, python_std)
                 _redirect(orig_std)
 
 


### PR DESCRIPTION
Fixes #124906

## Root cause

`redirect()` took the descriptor to `dup2` onto from `sys.stdout.fileno()`, which assumes `sys.stdout` is the process' stdout. Under a test runner it is not, and that produces two different failures:

| `--capture` | `sys.stdout` is | `.fileno()` | result |
| --- | --- | --- | --- |
| `sys` | in-memory `CaptureIO` | raises `io.UnsupportedOperation` | `redirect()` raises before doing anything — the crash in the issue |
| `fd` (pytest default) | `EncodedFile` over a temp file | a real but unrelated fd | destination `dup2`'d onto that fd while libc and subprocesses kept writing to fd 1, so their output silently escaped into pytest's capture |

The second one is worth calling out: on the *default* capture mode there is no exception at all, just a log file missing everything that did not come from Python.

A process' stdout and stderr are fds 1 and 2 — that is what libc writes to, what `os.system()` inherits, and what the `c_std` flush in this same function already targets unconditionally. So deriving the fd from `sys.stdout` also left the two halves of the redirect disagreeing about which descriptor they operated on.

## Fix

Use the constants, as the Windows branch of this file already does (`std_fd = 1 if std == "stdout" else 2`).

That alone is not sufficient: with `sys.stdout` bound elsewhere, python-level writes still bypass fd 1. So when `sys.stdout` is not backed by the descriptor being redirected, it is rebound to the destination for the duration and restored afterwards — again mirroring the Windows branch. When `sys.stdout` is the real stdout nothing is rebound, so there is no behaviour change for existing callers.

## Testing

The three new tests fail on the unfixed code under **every** runner, including plain `unittest`, so they pin the descriptor bug rather than a pytest-specific quirk.

| | `--capture=fd` | `--capture=sys` | `--capture=no` | `unittest` |
| --- | --- | --- | --- | --- |
| before | 7 failed, 2 passed | 8 failed, 1 passed | 3 failed, 6 passed | FAILED (1 failure, 2 errors) |
| after | 9 passed | 9 passed | 9 passed | OK |

Run on linux — the redirect implementation is unsupported on macOS and the test module imports `libc.so.6`:

```
python -m pytest test/distributed/elastic/multiprocessing/redirects_test.py
python -m pytest test/distributed/elastic/multiprocessing/redirects_test.py --capture=sys
python -m pytest test/distributed/elastic/multiprocessing/redirects_test.py --capture=no
python -m unittest redirects_test
```

`spin quicklint` reports no issues.

## Note for reviewers

`redirects_test.py` is not currently collected by CI — its `__main__` raises, and it is linux-only. This change makes it pass under pytest, which is what @H-Huang asked for on the issue, but re-enabling it in `discover_tests.py` is a separate decision and is left alone here.

---

Prepared with AI assistance. I have read and reviewed the analysis and the implementation, and I stand behind both.
