### PR TITLE
[dynamo] preserve guard-visible tensor state

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -216,6 +216,21 @@ class _PrecompileDynamoUnguardedAttribute(torch.nn.Module):
         return self.linear(x).relu().sum()
 
 
+class _PrecompileDynamoReadsTensorAttribute(torch.nn.Module):
+    def forward(self, x):
+        companion = getattr(x, "_cpu_copy", None)
+        return x * 2 if companion is None else x * 2 + companion.to(x.device)
+
+
+def _precompile_dynamo_tensor_attribute_break(module, x):
+    torch._dynamo.graph_break()
+    return module(x).sum()
+
+
+def _precompile_dynamo_reads_tensor_flag(x):
+    return x * getattr(x, "my_flag", 1)
+
+
 class _PrecompileDynamoStepCounter(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -1653,6 +1668,82 @@ class TestPrecompile(TestCase):
         loaded = torch.compiler.precompile.load(code, cache)
         for _, x in examples:
             self.assertEqual(loaded(runtime, x), reference(x))
+
+    @parametrize("graph_break", (False, True))
+    def test_tracer_dynamo_guard_through_tensor_attribute(self, graph_break):
+        model = _PrecompileDynamoReadsTensorAttribute()
+        x = torch.randn(8)
+        x._cpu_copy = torch.randn(8)
+        x.unused = (index for index in range(3))
+        fn = (
+            _precompile_dynamo_tensor_attribute_break
+            if graph_break
+            else _precompile_dynamo_call_module
+        )
+        code, cache = torch.compiler.precompile(
+            fn,
+            example_inputs=[(model, x)],
+            tracer="dynamo",
+            backend="eager",
+            require_no_risky_drops=False,
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(loaded(model, x), fn(model, x))
+        x._cpu_copy = torch.randn(8)
+        self.assertEqual(loaded(model, x), fn(model, x))
+
+    def test_tracer_dynamo_self_referential_tensor_attribute(self):
+        x = torch.randn(4)
+        x.my_flag = x
+        code, cache = torch.compiler.precompile(
+            _precompile_dynamo_reads_tensor_flag,
+            example_inputs=[(x,)],
+            tracer="dynamo",
+            backend="eager",
+            require_no_risky_drops=False,
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(loaded(x), _precompile_dynamo_reads_tensor_flag(x))
+
+    def test_tracer_dynamo_wrapper_subclass_requires_grad(self):
+        from torch.testing._internal.two_tensor import TwoTensor
+
+        x = TwoTensor(torch.randn(3), torch.randn(3)).requires_grad_(True)
+        code, cache = torch.compiler.precompile(
+            _precompile_dynamo_dynamic,
+            example_inputs=[(x,)],
+            tracer="dynamo",
+            backend="eager",
+            training=True,
+            require_no_risky_drops=False,
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(loaded(x), _precompile_dynamo_dynamic(x))
+
+    @parametrize(
+        "marking",
+        ("unbacked", "unbacked_bounds", "unbacked_shape_id", "static", "dynamic"),
+    )
+    def test_tracer_dynamo_marked_artifact_serves_capture_tensor(self, marking):
+        model = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(8, 4)
+        {
+            "unbacked": lambda t: mark_unbacked(t, 0),
+            "unbacked_bounds": lambda t: mark_unbacked(t, 0, min=4, max=16),
+            "unbacked_shape_id": lambda t: mark_unbacked(t, 0, shape_id="batch"),
+            "static": lambda t: torch._dynamo.decorators.mark_static(t, 0),
+            "dynamic": lambda t: mark_dynamic(t, 0),
+        }[marking](x)
+        code, cache = torch.compiler.precompile(
+            _precompile_dynamo_call_module,
+            example_inputs=[(model, x)],
+            tracer="dynamo",
+            backend="eager",
+            training=True,
+            require_no_risky_drops=False,
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(loaded(model, x), model(x))
 
     def test_tracer_dynamo_captures_every_example_past_default_limit(self):
         x = torch.randn(4)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3841,11 +3841,17 @@ class GuardBuilder(GuardBuilderBase):
                 "_dynamo_static_indices",
             )
 
+            def read_marking(attr_name: str) -> Any:
+                marking = getattr(value, attr_name, None)
+                if marking is not None:
+                    self.guard_tree_values[id(marking)] = marking
+                return marking
+
             expected_attrs: dict[str, set[int]] = {}
             absent_attrs: list[str] = []
             for attr_name in dim_marking_attrs:
                 if hasattr(value, attr_name):
-                    expected_attrs[attr_name] = getattr(value, attr_name)
+                    expected_attrs[attr_name] = read_marking(attr_name)
                     code_part = f"((getattr({tensor_name}, '{attr_name}', set()).issubset({getattr(value, attr_name)!r})) if hasattr({tensor_name}, '{attr_name}') else True)"
                     code.append(code_part)
                 else:
@@ -3859,7 +3865,7 @@ class GuardBuilder(GuardBuilderBase):
             gate_attr = "_dynamo_unbacked_indices"
             if hasattr(value, gate_attr):
                 for attr_name in dep_attr_names:
-                    attr_value = getattr(value, attr_name, None)
+                    attr_value = read_marking(attr_name)
                     dependent_attrs[attr_name] = (attr_value, gate_attr)
                     code_part = f"((getattr({tensor_name}, '{attr_name}', None) == {attr_value!r}) if hasattr({tensor_name}, '{gate_attr}') else True)"
                     code.append(code_part)
@@ -4090,12 +4096,44 @@ class _Missing:
         return _Missing()
 
 
+_FAKE_TENSOR_OWNED_ATTRIBUTES = frozenset(
+    {
+        "_fake_device",
+        "fake_mode",
+        "constant",
+        "pytype",
+        "dispatch_keys",
+        "real_tensor",
+        "_nonzero_memo",
+        "_nonzero_memo_vc",
+        "_nonzero_memo_epoch",
+        "_item_memo",
+        "_item_memo_vc",
+        "_item_memo_epoch",
+        "_unique_memo",
+        "_unique_memo_vc",
+        "_unique_memo_epoch",
+        "_unique_consecutive_memo",
+        "_unique_consecutive_memo_vc",
+        "_unique_consecutive_memo_epoch",
+        "_nested_int_memo",
+        "_nested_int_memo_vc",
+        "_nested_int_memo_epoch",
+    }
+)
+
+_FAKE_TENSOR_RESERVED_ATTRIBUTES = frozenset(
+    {"_fake_device", "fake_mode", "pytype", "dispatch_keys"}
+)
+
+
 @functools.cache
 def _get_unsupported_types() -> tuple[type, ...]:
     # We only do ID_MATCH on C objects which is already banned from guards serialization.
     ret: tuple[type, ...] = (
         torch._C.Stream,
         weakref.ReferenceType,
+        torch._C.Generator,
     )
     try:
         ret += (torch._C._distributed_c10d.ProcessGroup,)
@@ -4140,6 +4178,34 @@ class GuardsStatePickler(pickle.Pickler):
         self.guard_tree_values = guard_tree_values
         self.empty_values = empty_values
         self.missing_values = missing_values
+
+    @classmethod
+    def _restore_tensor_attributes(
+        cls, tensor: torch.Tensor, state: dict[str, Any]
+    ) -> None:
+        for name, value in state.items():
+            object.__setattr__(tensor, name, value)
+
+    def _carried_tensor_attributes(self, obj: torch.Tensor) -> dict[str, Any] | None:
+        state = getattr(obj, "__dict__", None)
+        if not state:
+            return None
+        is_fake = isinstance(  # noqa: ISINSTANCE_FAKE_TENSOR
+            obj, torch._subclasses.FakeTensor
+        )
+        carried: dict[str, Any] = {}
+        for name, value in state.items():
+            if is_fake and name in _FAKE_TENSOR_OWNED_ATTRIBUTES:
+                continue
+            if not self._keep(value):
+                continue
+            if name in _FAKE_TENSOR_RESERVED_ATTRIBUTES:
+                raise torch._dynamo.exc.PackageError(
+                    f"a guard reads {name!r} off a tensor, but precompile rebuilds "
+                    "that tensor as a FakeTensor whose own state uses the same name"
+                )
+            carried[name] = value
+        return carried or None
 
     @classmethod
     def _unpickle_module(cls, state: Any) -> torch.nn.Module:
@@ -4189,6 +4255,8 @@ class GuardsStatePickler(pickle.Pickler):
         out = pytype.__tensor_unflatten__(  # type: ignore[attr-defined]
             inner_tensors, ctx, outer_size, outer_stride
         )
+        if out.requires_grad != meta_tensor.requires_grad:
+            out.requires_grad_(meta_tensor.requires_grad)
         out.pytype = pytype
         out.dispatch_keys = torch._C.DispatchKeySet.from_raw_repr(dispatch_keys_raw)
         return out
@@ -4453,13 +4521,25 @@ class GuardsStatePickler(pickle.Pickler):
                         self.guard_tree_values[id(inner)] = inner
                     inner_data.append((attr, inner))
 
-                return type(self)._unpickle_traceable_wrapper_subclass, (
-                    meta_tensor,
-                    obj.device,
-                    type(obj),
-                    dispatch_keys.raw_repr(),
-                    ctx,
-                    inner_data,
+                carried = self._carried_tensor_attributes(obj)
+                if carried is not None:
+                    for attr in attrs:
+                        carried.pop(attr, None)
+                    carried = carried or None
+                return (
+                    type(self)._unpickle_traceable_wrapper_subclass,
+                    (
+                        meta_tensor,
+                        obj.device,
+                        type(obj),
+                        dispatch_keys.raw_repr(),
+                        ctx,
+                        inner_data,
+                    ),
+                    carried,
+                    None,
+                    None,
+                    type(self)._restore_tensor_attributes,
                 )
 
             # For FakeTensors, use pytype if set, otherwise default to
@@ -4473,12 +4553,19 @@ class GuardsStatePickler(pickle.Pickler):
             if pytype.__qualname__ != pytype.__name__:
                 raise_local_type_error(pytype)
 
-            return type(self)._unpickle_tensor, (
-                meta_tensor,
-                obj.device,
-                pytype,
-                dispatch_keys.raw_repr(),
-                obj.grad if obj.is_leaf else None,
+            return (
+                type(self)._unpickle_tensor,
+                (
+                    meta_tensor,
+                    obj.device,
+                    pytype,
+                    dispatch_keys.raw_repr(),
+                    obj.grad if obj.is_leaf else None,
+                ),
+                self._carried_tensor_attributes(obj),
+                None,
+                None,
+                type(self)._restore_tensor_attributes,
             )
 
         elif isinstance(obj, torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* #194528
* #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* #194468
* #194467
* #194466
* __->__ #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

Serialized guards rebuild tensors from metadata, which discarded Python attributes traversed by guards, dimension-marking state, and wrapper-subclass autograd metadata. The rebuilt guards could then fail on the exact input used for capture.

Carry only tensor attributes reached by the guard tree in pickle state, register dimension-marking values when guards read them, and restore the outer requires_grad bit for traceable wrapper subclasses. The state slot preserves self-referential attributes without serializing unrelated tensor state.

Test Plan:

```

TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/test_precompile.py -k tracer_dynamo

TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/dynamo/test_guard_serialization.py

PATH=/home/bobren/local/c/pytorch-env/bin:$PATH lintrunner -a --skip PYREFLY torch/_dynamo/guards.py test/test_precompile.py

```

The full lintrunner invocation is blocked by a Pyrefly dependency-fetch failure in this environment.

Authored with assistance from an AI coding tool.

cc @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98