### PR TITLE
[precompile] make guard reconstruction contract-aware

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -1585,7 +1585,7 @@ class TestPrecompile(TestCase):
         self.assertEqual(len(guard_summaries), 2)
         for guard_types, _, _, has_shape_guards in guard_summaries:
             self.assertIn("TENSOR_MATCH", guard_types)
-            self.assertIn("GLOBAL_STATE", guard_types)
+            self.assertNotIn("GLOBAL_STATE", guard_types)
             self.assertTrue(has_shape_guards)
 
         for _, loaded in _default_and_inlined_loaders(code, cache, "inductor"):
@@ -1704,6 +1704,97 @@ class TestPrecompile(TestCase):
         )
         loaded = torch.compiler.precompile.load(code, cache)
         self.assertEqual(loaded(x), _precompile_dynamo_reads_tensor_flag(x))
+
+    def test_tracer_dynamo_rejects_unrebuildable_input_guard(self):
+        from unittest import mock
+
+        from torch._dynamo.guards import GuardsStatePickler
+
+        carry = GuardsStatePickler._carried_tensor_attributes
+
+        def omit_cpu_copy(self, tensor):
+            state = carry(self, tensor)
+            if state is not None:
+                state.pop("_cpu_copy", None)
+            return state or None
+
+        model = _PrecompileDynamoReadsTensorAttribute()
+        x = torch.randn(8)
+        x._cpu_copy = torch.randn(8)
+        with (
+            mock.patch.object(
+                GuardsStatePickler, "_carried_tensor_attributes", omit_cpu_copy
+            ),
+            self.assertRaisesRegex(PrecompileError, "input-derived guard"),
+        ):
+            torch.compiler.precompile(
+                _precompile_dynamo_call_module,
+                example_inputs=[(model, x)],
+                tracer="dynamo",
+                backend="eager",
+                require_no_risky_drops=False,
+            )
+
+    def test_tracer_dynamo_rejects_drifted_input_guard(self):
+        from unittest import mock
+
+        from torch._dynamo.guards import GuardsStatePickler
+
+        restore = GuardsStatePickler._restore_tensor_attributes.__func__
+
+        def _restore_tensor_attributes(cls, tensor, state):
+            state = dict(state)
+            if "_cpu_copy" in state:
+                state["_cpu_copy"] = torch.randn(2)
+            restore(cls, tensor, state)
+
+        model = _PrecompileDynamoReadsTensorAttribute()
+        x = torch.randn(8)
+        x._cpu_copy = torch.randn(8)
+        with (
+            mock.patch.object(
+                GuardsStatePickler,
+                "_restore_tensor_attributes",
+                classmethod(_restore_tensor_attributes),
+            ),
+            self.assertRaisesRegex(PrecompileError, "input-derived guard.*changed"),
+        ):
+            torch.compiler.precompile(
+                _precompile_dynamo_call_module,
+                example_inputs=[(model, x)],
+                tracer="dynamo",
+                backend="eager",
+                require_no_risky_drops=False,
+            )
+
+    def test_tracer_dynamo_rejects_guard_leaf_drift(self):
+        from unittest import mock
+
+        from torch._dynamo.guards import GuardManagerWrapper
+
+        fingerprint = GuardManagerWrapper.leaf_fingerprint
+        calls = 0
+
+        def drift_after_capture(self):
+            nonlocal calls
+            calls += 1
+            result = fingerprint(self)
+            if calls > 1:
+                return result | {("TEST_GUARD", "changed after serialization")}
+            return result
+
+        with (
+            mock.patch.object(
+                GuardManagerWrapper, "leaf_fingerprint", drift_after_capture
+            ),
+            self.assertRaisesRegex(PrecompileError, "changed input-derived checks"),
+        ):
+            torch.compiler.precompile(
+                _precompile_dynamo_dynamic,
+                example_inputs=[(torch.randn(4),)],
+                tracer="dynamo",
+                backend="eager",
+            )
 
     def test_tracer_dynamo_wrapper_subclass_requires_grad(self):
         from torch.testing._internal.two_tensor import TwoTensor
@@ -3280,7 +3371,7 @@ class TestPrecompile(TestCase):
         )
         for guard_types, _, _, _ in summaries:
             self.assertIn("TENSOR_MATCH", guard_types)
-            self.assertIn("GLOBAL_STATE", guard_types)
+            self.assertNotIn("GLOBAL_STATE", guard_types)
         x = torch.randn(4)
         self.assertEqual(loaded(x, 2), _precompile_dynamo_scalar(x, 2))
         self.assertEqual(loaded(x, 4), _precompile_dynamo_scalar(x, 4))

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -2002,7 +2002,11 @@ def _compile(
         if package is not None:
             if check_fn.guards_state is None:
                 raise AssertionError("check_fn.guards_state must not be None")
-            package.add_guarded_code(check_fn.guards_state, out_code)
+            package.add_guarded_code(
+                check_fn.guards_state,
+                out_code,
+                check_fn.guard_manager.leaf_fingerprint(),
+            )
             package.add_inlined_source(output.tracing_context.traced_code)
             package.update_device_type(output.current_tracer.graph)
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -216,7 +216,7 @@ except ModuleNotFoundError:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, KeysView, Sequence, Sized
+    from collections.abc import Generator, Iterator, KeysView, Sequence, Sized
 
     from sympy import Symbol
 
@@ -723,6 +723,38 @@ class GuardManagerWrapper:
                     self.get_manager_line(child_mgr, f"accessed_by={accessor.repr()}")
                 )
                 self.construct_manager_string(child_mgr, body)
+
+    def leaf_fingerprint(self) -> frozenset[tuple[str, str]]:
+        """Return a stable description of the checks made by this guard tree."""
+        found: set[tuple[str, str]] = set()
+
+        def payload(guard: LeafGuard) -> Iterator[str]:
+            for part in guard.verbose_code_parts():
+                text = part.split("  # ", 1)[0]
+                text = re.sub(r"___check_metadata\S*", "___check_metadata", text)
+                yield re.sub(r"\d{6,}", "N", text)
+
+        def walk(manager: GuardManager) -> None:
+            for guard in manager.get_leaf_guards():
+                if isinstance(guard, RelationalGuard):
+                    continue
+                if type(guard).__name__ == "LAMBDA_GUARD":
+                    continue
+                found.update((type(guard).__name__, part) for part in payload(guard))
+            if isinstance(manager, DictGuardManager):
+                pairs = manager.get_key_value_managers().values()
+                for key_manager, value_manager in pairs:
+                    for child in (key_manager, value_manager):
+                        if child is not None:
+                            walk(child)
+            for child in manager.get_child_managers():
+                walk(child)
+
+        walk(self.root)
+        return frozenset(
+            (guard_type, value.replace(", FakeTensor,", ", Tensor,"))
+            for guard_type, value in found
+        )
 
     def __str__(self) -> str:
         with self._preserve_printed_relational_guards():
@@ -4096,6 +4128,54 @@ class _Missing:
         return _Missing()
 
 
+def _attribute_link(source: Any) -> tuple[str, str] | None:
+    base = getattr(source, "base", None)
+    member = getattr(source, "member", None)
+    if base is None or not isinstance(member, str):
+        return None
+    name = getattr(base, "name", None)
+    try:
+        text = name() if callable(name) else name
+    except Exception:
+        return None
+    return (text, member) if isinstance(text, str) else None
+
+
+def _companion_attribute_guards(
+    guards: Sequence[Guard], failures: Sequence[tuple[Guard, Exception]]
+) -> list[tuple[Guard, Exception]]:
+    links = {
+        link
+        for guard, _ in failures
+        if (link := _attribute_link(guard.originating_source)) is not None
+    }
+    failed = {id(guard) for guard, _ in failures}
+    result = []
+    for guard in guards:
+        if id(guard) in failed:
+            continue
+        keywords = getattr(guard.create_fn, "keywords", None) or {}
+        link = _attribute_link(guard.originating_source)
+        if link in links or (guard.name, keywords.get("attr")) in links:
+            result.append(
+                (
+                    guard,
+                    RuntimeError("a dependent attribute guard could not be rebuilt"),
+                )
+            )
+    return result
+
+
+@contextmanager
+def _quiet_guard_errors() -> Generator[None, None, None]:
+    disabled = torch._guards.log.disabled
+    torch._guards.log.disabled = True
+    try:
+        yield
+    finally:
+        torch._guards.log.disabled = disabled
+
+
 _FAKE_TENSOR_OWNED_ATTRIBUTES = frozenset(
     {
         "_fake_device",
@@ -4232,6 +4312,8 @@ class GuardsStatePickler(pickle.Pickler):
             torch._C.DispatchKeySet.from_raw_repr(dispatch_keys_raw),
         )
         ret.grad = grad if isinstance(grad, torch.Tensor) else None
+        ret.pytype = pytype
+        ret.dispatch_keys = torch._C.DispatchKeySet.from_raw_repr(dispatch_keys_raw)
         return ret
 
     @classmethod
@@ -4889,6 +4971,7 @@ class CheckFunctionManager:
         save_guards: bool = False,
         strict_error: bool = False,
         guard_build_local_state: Any | None = None,
+        collect_guard_failures: list[tuple[Guard, Exception]] | None = None,
     ) -> None:
         guards = output_graph.guards if output_graph else None
         self._weakrefs: dict[int, ReferenceType[object]] = {}
@@ -4913,6 +4996,7 @@ class CheckFunctionManager:
         self.additional_used_global_vars: OrderedSet[str] = OrderedSet()
         self.runtime_global_scope = runtime_global_scope
         self.guard_build_local_state = guard_build_local_state
+        self._collect_guard_failures = collect_guard_failures
         self.global_state: torch._C._dynamo.guards.GlobalStateGuard | None = None
         self.torch_function_mode_stack_check_fn: Callable[[], bool] | None = None
 
@@ -4963,6 +5047,7 @@ class CheckFunctionManager:
 
             def build_filter_entries() -> None:
                 nonlocal filter_entries
+                nonlocal all_guards
                 if filter_entries is not None:
                     return
                 inspection_builder, _ = self.build_guards(
@@ -4972,10 +5057,21 @@ class CheckFunctionManager:
                     output_graph,
                     False,
                 )
+                drop_failed_guards()
                 filter_entries = [
                     make_guard_filter_entry(guard, inspection_builder)
                     for guard in all_guards
                 ]
+
+            def drop_failed_guards() -> None:
+                nonlocal all_guards
+                if not collect_guard_failures:
+                    return
+                collect_guard_failures.extend(
+                    _companion_attribute_guards(all_guards, collect_guard_failures)
+                )
+                failed = {id(guard) for guard, _ in collect_guard_failures}
+                all_guards = [guard for guard in all_guards if id(guard) not in failed]
 
             def apply_filter(
                 filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]],
@@ -4995,9 +5091,7 @@ class CheckFunctionManager:
                     guard for guard, keep in zip(all_guards, filter_results) if keep
                 ]
 
-            if guard_filter_fn is not None or (
-                save_guards and serialization_guard_filter_fn is not None
-            ):
+            if guard_filter_fn is not None:
                 build_filter_entries()
 
             runtime_guards = (
@@ -5012,6 +5106,15 @@ class CheckFunctionManager:
                 runtime_save_guards,
                 guard_filter_fn=guard_filter_fn,
             )
+            if (
+                filter_entries is None
+                and save_guards
+                and serialization_guard_filter_fn is not None
+            ):
+                drop_failed_guards()
+                filter_entries = [
+                    make_guard_filter_entry(guard, builder) for guard in all_guards
+                ]
 
             serialized_guards = runtime_guards
             serialization_builder = builder
@@ -5352,7 +5455,14 @@ class CheckFunctionManager:
             ):
                 continue
 
-            guard.create(builder)
+            if self._collect_guard_failures is None:
+                guard.create(builder)
+            else:
+                try:
+                    with _quiet_guard_errors():
+                        guard.create(builder)
+                except Exception as error:
+                    self._collect_guard_failures.append((guard, error))
         return builder, guard_manager
 
     def compile_check_fn(

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -685,6 +685,7 @@ class CompilePackage:
         self._innermost_fn = None
         self._codes: dict[types.CodeType, _DynamoCodeCacheEntry] = {}
         self._observed_scopes: dict[types.CodeType, list[dict[str, object]]] = {}
+        self._live_guard_leaves: dict[int, list[frozenset[tuple[str, str]]]] = {}
 
         self._current_entry: _DynamoCodeCacheEntry | None = None
         self._installed_globals: dict[types.ModuleType, list[_InstalledGlobal]] = {}
@@ -833,10 +834,16 @@ class CompilePackage:
     def observed_scopes(self) -> list[list[dict[str, object]]]:
         return [self._observed_scopes.get(code, []) for code in self._codes]
 
+    def live_guard_leaves(
+        self, entry: _DynamoCodeCacheEntry
+    ) -> Sequence[frozenset[tuple[str, str]]]:
+        return self._live_guard_leaves.get(id(entry), ())
+
     def add_guarded_code(
         self,
         guards_state: bytes,
         dynamo_code: types.CodeType,
+        live_guard_leaves: frozenset[tuple[str, str]] = frozenset(),
     ) -> None:
         if self._current_entry is None:
             raise AssertionError("_current_entry is not set in add_guarded_code")
@@ -847,6 +854,9 @@ class CompilePackage:
             dynamo_code=SerializedCode.from_code_object(dynamo_code),
         )
         self._current_entry.guarded_codes.append(guarded_code_entry)
+        self._live_guard_leaves.setdefault(id(self._current_entry), []).append(
+            live_guard_leaves
+        )
         for backend_id in _backend_ids_from_code(dynamo_code):
             self._add_backend_id(backend_id)
 

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -1476,6 +1476,16 @@ _DYNAMO_UNMODELLED_GUARD_TYPES = frozenset(
         "TORCH_FUNCTION_STATE",
     }
 )
+_DYNAMO_ENVIRONMENT_GUARD_TYPES = frozenset(
+    {
+        "AUTOGRAD_SAVED_TENSORS_HOOKS",
+        "DEFAULT_DEVICE",
+        "DETERMINISTIC_ALGORITHMS",
+        "GRAD_MODE",
+        "GLOBAL_STATE",
+        "TORCH_FUNCTION_STATE",
+    }
+)
 _DYNAMO_VALUE_GUARD_TYPES = frozenset({"CONSTANT_MATCH", "EQUALS_MATCH"})
 _DYNAMO_OBJ_ID = re.compile(r"(?<=, )\d+(?=\), type=)")
 _DYNAMO_SAVED_HOOK_IDS = re.compile(
@@ -1556,13 +1566,23 @@ def _dynamo_guard_value(entry: Any) -> str:
                 get_tensor_guard_code_part,
             )
 
+            pytype = getattr(value, "pytype", type(value))
+            is_python_fake = isinstance(  # noqa: ISINSTANCE_FAKE_TENSOR
+                value, torch._subclasses.FakeTensor
+            )
+            if is_python_fake and pytype is type(value):
+                pytype = torch.Tensor
+            dispatch_keys = getattr(value, "dispatch_keys", None)
+            if dispatch_keys is None:
+                dispatch_keys = torch._C._dispatch_keys(value)
+
             return get_tensor_guard_code_part(
                 value,
                 "",
                 convert_to_concrete_values(value.size()),
                 convert_to_concrete_values(value.stride()),
-                type(value),
-                torch._C._dispatch_keys(value),
+                pytype,
+                dispatch_keys,
             )
         except Exception:
             return f"type={type(value).__name__}, dtype={value.dtype}, <unrenderable>"
@@ -1612,6 +1632,7 @@ class _DynamoCapturedGuardSet:
     facts: tuple[GuardFact, ...]
     dropped: frozenset[tuple[str, str]]
     risky_dropped: frozenset[tuple[str, str]]
+    environment: frozenset[tuple[str, str]]
 
 
 def _dynamo_frame_invariants(
@@ -1719,12 +1740,18 @@ def _filter_dynamo_guards(
     runtime_global_scope: dict[str, object],
     guarded_codes: Sequence[Any],
     captured: Sequence[_DynamoCapturedGuardSet],
+    live_leaf_sets: Sequence[frozenset[tuple[str, str]]],
 ) -> _DynamoGuardFinalization:
-    """Drop guards proven invariant across the frozen capture variants."""
+    """Rebuild, validate, and minimize guards from frozen capture state."""
     import dataclasses
     import functools
 
-    from torch._dynamo.guards import CheckFunctionManager, GuardBuilder
+    from torch._dynamo.guards import (
+        _companion_attribute_guards,
+        CheckFunctionManager,
+        GuardBuilder,
+        strip_local_scope,
+    )
     from torch._dynamo.output_graph import OutputGraphCommon
     from torch._dynamo.package import load_guard_manager, load_guards_state
     from torch._guards import GuardsSet
@@ -1768,6 +1795,11 @@ def _filter_dynamo_guards(
             "precompile tracer='dynamo' did not record one guard set for every "
             "captured variant."
         )
+    if len(states) != len(live_leaf_sets):
+        raise PrecompileError(
+            "precompile tracer='dynamo' did not record one live guard tree for "
+            "every captured variant."
+        )
     slots = {
         (fact.guard_type, fact.source)
         for record in captured
@@ -1792,15 +1824,29 @@ def _filter_dynamo_guards(
     filtered_states: list[bytes] = []
     kept_slots: list[frozenset[tuple[str, str]]] = []
     policy_dropped: set[tuple[str, str]] = set()
-    for state in states:
+    for state, record, live_leaves in zip(
+        states, captured, live_leaf_sets, strict=True
+    ):
+        live_facts: dict[tuple[str, str], set[GuardFact]] = {}
+        for fact in record.facts:
+            if fact.enforced:
+                live_facts.setdefault((fact.guard_type, fact.source), set()).add(fact)
         kept_guards = [
             guard
             for guard in state.output_graph.guards
-            if required_guard(guard) or _dynamo_guard_slot(guard) in varying_slots
+            if _dynamo_guard_slot(guard) not in record.environment
+            and (required_guard(guard) or _dynamo_guard_slot(guard) in varying_slots)
         ]
         kept_aot_guards = list(state.output_graph.aotautograd_guards)
+        environment_sources = {source for _, source in record.environment}
         kept_key_order = sorted(
-            state.output_graph.guard_on_key_order, key=lambda source: source.name
+            (
+                source
+                for source in state.output_graph.guard_on_key_order
+                if _normalize_dynamo_guard_text(strip_local_scope(source.name))
+                not in environment_sources
+            ),
+            key=lambda source: source.name,
         )
 
         output_graph = dataclasses.replace(
@@ -1816,6 +1862,26 @@ def _filter_dynamo_guards(
             if any(guard.create_fn_name() == "SHAPE_ENV" for guard in kept_guards)
             else None
         )
+        failures: list[tuple[Any, Exception]] = []
+        drifted: list[tuple[Any, GuardFact]] = []
+
+        def keep_unchanged_guards(entries: Sequence[Any]) -> list[bool]:
+            for entry in entries:
+                fact = _dynamo_guard_fact(entry, enforced=True)
+                slot = (fact.guard_type, fact.source)
+                if fact not in live_facts.get(slot, set()):
+                    drifted.append((entry.orig_guard, fact))
+            companions = _companion_attribute_guards(
+                [entry.orig_guard for entry in entries],
+                [
+                    (guard, RuntimeError("the rebuilt guard changed"))
+                    for guard, _ in drifted
+                ],
+            )
+            dropped = {id(guard) for guard, _ in drifted}
+            dropped.update(id(guard) for guard, _ in companions)
+            return [id(entry.orig_guard) not in dropped for entry in entries]
+
         check_fn = CheckFunctionManager(
             target_code,
             OutputGraphCommon(output_graph),
@@ -1824,18 +1890,84 @@ def _filter_dynamo_guards(
             save_guards=True,
             strict_error=True,
             guard_build_local_state=state.local_state,
+            serialization_guard_filter_fn=keep_unchanged_guards,
+            collect_guard_failures=failures,
         )
+        failed_slots = {_dynamo_guard_slot(guard) for guard, _ in failures}
+        input_failures = failed_slots - record.environment
+        if input_failures:
+            guard, error = next(
+                (guard, error)
+                for guard, error in failures
+                if _dynamo_guard_slot(guard) in input_failures
+            )
+            raise PrecompileError(
+                "precompile tracer='dynamo' cannot rebuild input-derived guard "
+                f"{_dynamo_guard_slot(guard)!r}: {type(error).__name__}: {error}"
+            ) from error
+        input_drift = [
+            (guard, fact)
+            for guard, fact in drifted
+            if _dynamo_guard_slot(guard) not in record.environment
+        ]
+        if input_drift:
+            guard, fact = input_drift[0]
+            raise PrecompileError(
+                "precompile tracer='dynamo' rebuilt input-derived guard "
+                f"{_dynamo_guard_slot(guard)!r} with a changed predicate: "
+                f"{fact.render()}"
+            )
         if check_fn.guards_state is None:
             raise AssertionError("guards_state must not be None")
         filtered_state = load_guards_state(check_fn.guards_state)
-        manager_for(filtered_state)
+        rebuilt = manager_for(filtered_state)
+        extra_leaves = rebuilt.leaf_fingerprint() - live_leaves
+        if extra_leaves:
+            examples = ", ".join(
+                f"{guard_type}: {payload}"
+                for guard_type, payload in sorted(extra_leaves)[:3]
+            )
+            raise PrecompileError(
+                "precompile tracer='dynamo' rebuilt a guard tree with changed "
+                f"input-derived checks: {examples}"
+            )
         filtered_states.append(check_fn.guards_state)
-        final_slots = frozenset(_dynamo_guard_slot(guard) for guard in kept_guards)
+        final_slots = frozenset(
+            _dynamo_guard_slot(guard) for guard in filtered_state.output_graph.guards
+        )
         kept_slots.append(final_slots)
         policy_dropped.update(
             {_dynamo_guard_slot(guard) for guard in state.output_graph.guards}
             - final_slots
         )
+
+    facts_by_variant = [
+        {
+            slot: frozenset(
+                dataclasses.replace(fact, enforced=True)
+                for fact in record.facts
+                if (fact.guard_type, fact.source) == slot
+            )
+            for slot in {(fact.guard_type, fact.source) for fact in record.facts}
+        }
+        for record in captured
+    ]
+    for index, facts in enumerate(facts_by_variant):
+        for earlier in range(index):
+            if not any(
+                facts_by_variant[earlier].get(slot) != facts.get(slot)
+                for slot in kept_slots[earlier]
+            ):
+                differing = sorted(
+                    slot
+                    for slot in facts_by_variant[earlier].keys() | facts.keys()
+                    if facts_by_variant[earlier].get(slot) != facts.get(slot)
+                )
+                raise PrecompileError(
+                    "precompile tracer='dynamo' dropped guards that can affect "
+                    f"dispatch between captured variants {earlier} and {index}: "
+                    f"{differing}"
+                )
 
     return _DynamoGuardFinalization(
         states=tuple(filtered_states),
@@ -2169,6 +2301,12 @@ def _dynamo_input_object_ids(
         for example in example_inputs
         for value in (*example.args, *example.kwargs.values())
     ]
+    if isinstance(fn, types.FunctionType):
+        stack.extend(fn.__defaults__ or ())
+        stack.extend((fn.__kwdefaults__ or {}).values())
+    elif isinstance(fn, types.MethodType):
+        stack.extend(fn.__func__.__defaults__ or ())
+        stack.extend((fn.__func__.__kwdefaults__ or {}).values())
     if isinstance(fn, torch.nn.Module):
         stack.append(fn)
 
@@ -2490,17 +2628,17 @@ def _precompile_dynamo(
                 )
                 for guard in guards
             ]
-            # Values reachable from explicit inputs may legitimately vary. An
-            # unsupported value reached only through other state belongs to the
-            # caller-promised invariant environment and must not poison the artifact.
+            # Explicit inputs, defaults, and values derived across graph breaks may
+            # vary. Known process state, globals, and unsupported values outside that
+            # input closure belong to the caller-promised invariant environment.
             environment_assumptions = [
-                guard.source_has_unsupported_value
-                and guard.source_root_id is not None
-                and (
-                    guard.source_root_is_module
-                    or guard.source_root_id not in input_object_ids
+                guard.guard_type in _DYNAMO_ENVIRONMENT_GUARD_TYPES
+                or (
+                    guard.source_root_id is not None
+                    and guard.source_root_id not in input_object_ids
+                    and (not guard.has_value or id(guard.value) not in input_object_ids)
+                    and (guard.is_global or guard.source_has_unsupported_value)
                 )
-                and (not guard.has_value or id(guard.value) not in input_object_ids)
                 for guard in guards
             ]
             chosen = (
@@ -2571,6 +2709,27 @@ def _precompile_dynamo(
                     facts=tuple(facts),
                     dropped=frozenset(dropped),
                     risky_dropped=frozenset(risky),
+                    environment=frozenset(
+                        slot
+                        for slot in {
+                            (
+                                entry.guard_type,
+                                _normalize_dynamo_guard_text(entry.name),
+                            )
+                            for entry in guards
+                        }
+                        if all(
+                            is_environment
+                            for entry, is_environment in zip(
+                                guards, environment_assumptions, strict=True
+                            )
+                            if (
+                                entry.guard_type,
+                                _normalize_dynamo_guard_text(entry.name),
+                            )
+                            == slot
+                        )
+                    ),
                 )
             )
             return decisions
@@ -2715,6 +2874,7 @@ def _precompile_dynamo(
                 runtime_globals,
                 code.guarded_codes,
                 captured_guard_sets.get(id(code), ()),
+                package.live_guard_leaves(code),
             )
             filtered_guard_states = finalized.states
             kept_by_entry[id(code)] = list(finalized.kept_slots)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* #194528
* #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* #194468
* #194467
* __->__ #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

Serialized guard rebuilding previously failed all-or-nothing and could also rebuild a predicate with different semantics. That made environment-only weakref guards poison an otherwise valid artifact, while reconstructed input guards could fail or drift without a precise safety boundary.

Rebuild each serialized guard independently, remove dependent attribute guards, and classify provenance against the explicit input closure. Environment-only guards are omitted under the precompile contract; input-derived and unknown guards fail closed. Record each live guard tree, compare reconstructed leaf predicates, and verify that retained frozen facts still distinguish every captured variant without executing an example again. Preserve FakeTensor guard metadata so faithful reconstructions compare identically.

Test Plan:

```

TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/test_precompile.py -k tracer_dynamo

TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/dynamo/test_guard_serialization.py

TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/dynamo/test_package.py TestPackage.test_guarded_code_records_backend_ids_from_bytecode

PATH=/home/bobren/local/c/pytorch-env/bin:$PATH lintrunner -a --skip PYREFLY torch/_dynamo/convert_frame.py torch/_dynamo/guards.py torch/_dynamo/package.py torch/_precompile.py test/test_precompile.py

```

The required full `lintrunner -a` was also run; Pyrefly could not fetch types-openpyxl because the configured HTTPS tunnel certificate is untrusted.

Authored with an AI assistant.

cc @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98