### PR TITLE
[precompile] serialize eager higher-order graphs without retracing

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -92,6 +92,54 @@ def _precompile_dynamo_dict_order(x, values):
     return x
 
 
+def _precompile_eager_cond(x):
+    return torch.cond(x.sum() > 0, lambda t: t.sin(), lambda t: t.cos(), (x,))
+
+
+def _precompile_eager_while_loop(x):
+    return torch._higher_order_ops.while_loop(
+        lambda i, t: i < 3,
+        lambda i, t: (i + 1, t + 1.0),
+        (torch.tensor(0), x),
+    )[1]
+
+
+def _precompile_eager_checkpoint(x):
+    return torch.utils.checkpoint.checkpoint(
+        lambda t: t.sin().cos(), x, use_reentrant=False
+    )
+
+
+def _precompile_eager_vmap(x):
+    return torch.vmap(lambda t: t * 2.0)(x)
+
+
+def _precompile_eager_autocast(x):
+    with torch.autocast("cpu", dtype=torch.bfloat16):
+        return x @ x
+
+
+def _precompile_eager_no_grad(x):
+    y = x * 2.0
+    with torch.no_grad():
+        return y.sin()
+
+
+_PRECOMPILE_EAGER_ROUND_TRIP = {
+    "autocast": _precompile_eager_autocast,
+    "checkpoint": _precompile_eager_checkpoint,
+    "cond": _precompile_eager_cond,
+    "vmap": _precompile_eager_vmap,
+    "while_loop": _precompile_eager_while_loop,
+}
+
+
+def _precompile_eager_graph_break(key, x):
+    y = x * 2.0
+    torch._dynamo.graph_break()
+    return _PRECOMPILE_EAGER_ROUND_TRIP[key](y)
+
+
 class _PrecompileWeakValue:
     pass
 
@@ -1594,6 +1642,147 @@ class TestPrecompile(TestCase):
                 self.assertEqual(loaded(x), _precompile_dynamo_dynamic(x))
             with self.assertRaisesRegex(PrecompileError, "no captured Dynamo variant"):
                 loaded(torch.randn(1, 4))
+
+    @parametrize("construct", sorted(_PRECOMPILE_EAGER_ROUND_TRIP))
+    @parametrize("graph_break", (False, True))
+    def test_tracer_dynamo_eager_higher_order_graph(self, construct, graph_break):
+        entry = (
+            _precompile_eager_graph_break
+            if graph_break
+            else _PRECOMPILE_EAGER_ROUND_TRIP[construct]
+        )
+        args = (construct,) if graph_break else ()
+        x = torch.randn(4, 4)
+        with torch.no_grad():
+            expected = torch.compile(entry, backend="eager")(*args, x)
+        torch._dynamo.reset()
+        code, cache = torch.compiler.precompile(
+            entry,
+            example_inputs=[(*args, x)],
+            tracer="dynamo",
+            backend="eager",
+            dynamic=False,
+            require_no_risky_drops=False,
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        try:
+            with torch.no_grad():
+                self.assertEqual(loaded(*args, x), expected)
+        finally:
+            if hasattr(loaded, "unload"):
+                loaded.unload()
+
+    def test_tracer_dynamo_eager_preserves_no_grad_region(self):
+        x = torch.randn(4, requires_grad=True)
+        with torch.enable_grad():
+            expected = torch.compile(_precompile_eager_no_grad, backend="eager")(x)
+            code, cache = torch.compiler.precompile(
+                _precompile_eager_no_grad,
+                example_inputs=[(x,)],
+                tracer="dynamo",
+                backend="eager",
+                dynamic=False,
+                training=True,
+            )
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.enable_grad():
+            actual = loaded(x)
+        self.assertFalse(actual.requires_grad)
+        self.assertEqual(actual, expected)
+
+    def test_tracer_dynamo_eager_higher_order_source_runs_in_fresh_process(self):
+        from unittest import mock
+
+        x = torch.ones(4)
+        code, cache = torch.compiler.precompile(
+            _precompile_eager_cond,
+            example_inputs=[(x,)],
+            tracer="dynamo",
+            backend="eager",
+            dynamic=False,
+        )
+        self.assertIn("def _graph_forward", code)
+        self.assertIn("def _eager_subgraph_0", code)
+        self.assertIn("_EAGER_GRAPH_BODY", code)
+        with mock.patch.object(
+            torch.fx.Tracer,
+            "trace",
+            side_effect=AssertionError("load must not symbolically retrace"),
+        ):
+            loaded = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(loaded(x), _precompile_eager_cond(x))
+
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as artifact:
+            artifact.write(code)
+            artifact_path = artifact.name
+        try:
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-c",
+                    textwrap.dedent(
+                        """
+                        import runpy
+                        import sys
+                        import torch
+
+                        forward = runpy.run_path(sys.argv[1])["forward"]
+                        for x in (torch.ones(4), -torch.ones(4)):
+                            expected = x.sin() if x.sum() > 0 else x.cos()
+                            torch.testing.assert_close(forward(x), expected)
+                        """
+                    ),
+                    artifact_path,
+                ]
+            )
+        finally:
+            os.unlink(artifact_path)
+
+    @parametrize("graph_break", (False, True))
+    def test_tracer_dynamo_eager_checkpoint_training(self, graph_break):
+        entry = (
+            _precompile_eager_graph_break
+            if graph_break
+            else _precompile_eager_checkpoint
+        )
+        args = ("checkpoint",) if graph_break else ()
+        x = torch.randn(4, requires_grad=True)
+        reference_input = x.detach().clone().requires_grad_()
+        expected = entry(*args, reference_input)
+        expected.sum().backward()
+        code, cache = torch.compiler.precompile(
+            entry,
+            example_inputs=[(*args, x)],
+            tracer="dynamo",
+            backend="eager",
+            dynamic=False,
+            training=True,
+            require_no_risky_drops=False,
+        )
+        actual_input = x.detach().clone().requires_grad_()
+        loaded = torch.compiler.precompile.load(code, cache)
+        try:
+            actual = loaded(*args, actual_input)
+            actual.sum().backward()
+            self.assertEqual(actual, expected)
+            self.assertEqual(actual_input.grad, reference_input.grad)
+        finally:
+            if hasattr(loaded, "unload"):
+                loaded.unload()
+
+    @torch._dynamo.config.patch(
+        automatic_dynamic_shapes=True, assume_static_by_default=True
+    )
+    def test_tracer_dynamo_eager_higher_order_dynamic_shapes(self):
+        code, cache = torch.compiler.precompile(
+            _precompile_eager_cond,
+            example_inputs=[(torch.ones(2),), (torch.ones(3),)],
+            tracer="dynamo",
+            backend="eager",
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        for x in (torch.ones(5), -torch.ones(7)):
+            self.assertEqual(loaded(x), _precompile_eager_cond(x))
 
     @torch._dynamo.config.patch(
         automatic_dynamic_shapes=True, assume_static_by_default=True

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -1390,28 +1390,124 @@ class _DynamoPythonBackend:
 
 def _build_dynamo_eager_graph_source(gm: torch.fx.GraphModule) -> str:
     """Render one Dynamo FX graph as standalone eager Python source."""
-    get_attrs = list(gm.graph.find_nodes(op="get_attr"))
-    if get_attrs:
-        raise PrecompileError(
-            "precompile tracer='dynamo' with backend='eager' does not yet support "
-            "FX get_attr nodes; use backend='inductor'."
+    import base64
+    import pickle
+
+    from torch.fx._graph_pickler import GraphPickler, Options
+    from torch.fx._lazy_graph_module import _LazyGraphModule
+    from torch.fx.graph_module import _format_import_block
+    from torch.package import sys_importer
+
+    def recompile(module: torch.fx.GraphModule) -> Any:
+        return (
+            module._real_recompile()
+            if isinstance(module, _LazyGraphModule)
+            else module.recompile()
         )
+
+    options = Options(
+        ops_filter=None,
+        node_metadata_key_filter=lambda key: key
+        not in (
+            "example_value",
+            "tensor_dict",
+            "source_fn_stack",
+            "nn_module_stack",
+            "fwd_source_fn_stack",
+        ),
+    )
+    python_code = recompile(gm)
+    readable_subgraphs: list[tuple[str, str, str]] = []
+
+    def collect_subgraphs(module: torch.fx.GraphModule, prefix: str = "") -> None:
+        for name, child in module._modules.items():
+            if not isinstance(child, torch.fx.GraphModule):
+                continue
+            path = f"{prefix}.{name}" if prefix else name
+            child_code = recompile(child)
+            readable_subgraphs.append(
+                (
+                    path,
+                    _format_import_block(child_code.globals, sys_importer),
+                    child.code,
+                )
+            )
+            collect_subgraphs(child, path)
+
+    collect_subgraphs(gm)
+    body = gm.__dict__.copy()
+    body.pop("_graph", None)
+    marker = "torch.compiler.precompile.eager_subgraph"
+    body["_modules"] = {
+        name: (marker, GraphPickler.dumps(module, options))
+        if isinstance(module, torch.fx.GraphModule)
+        else module
+        for name, module in body.get("_modules", {}).items()
+    }
+    encoded_body = base64.b64encode(pickle.dumps(body)).decode("ascii")
+    import_block = _format_import_block(python_code.globals, sys_importer)
 
     from torch.fx.graph import _custom_builtins
 
     parts = [
         "# Dynamo captured graph (eager backend).",
+        "import base64",
+        "import pickle",
+        "import torch",
+        "from torch._subclasses import FakeTensorMode",
+        "from torch.fx._graph_pickler import GraphPickler",
+        "from torch.fx.experimental.symbolic_shapes import ShapeEnv",
         *(_cb.import_str for _cb in _custom_builtins.values()),
-        gm.code.replace("def forward(", "def _graph_forward(", 1),
-        "",
-        "class _GraphSelf:",
-        "    pass",
-        "",
-        "",
-        "def call(args):",
-        "    return _graph_forward(_GraphSelf(), *args)",
-        "",
+        import_block,
     ]
+    for index, (path, imports, source) in enumerate(readable_subgraphs):
+        parts.extend(
+            [
+                f"# Nested FX graph {path!r}; executable structure is restored below.",
+                imports,
+                source.replace("def forward(", f"def _eager_subgraph_{index}(", 1),
+                "",
+            ]
+        )
+    parts.extend(
+        [
+            gm.code.replace("def forward(", "def _graph_forward(", 1),
+            "",
+            "# Opaque FX state: eager HOPs require real Graph objects at runtime.",
+            f"_EAGER_GRAPH_BODY = {encoded_body!r}",
+            f"_EAGER_SUBGRAPH_MARKER = {marker!r}",
+            "",
+            "",
+            "def _load_eager_subgraph(value):",
+            "    if not (isinstance(value, tuple) and len(value) == 2 and",
+            "            value[0] == _EAGER_SUBGRAPH_MARKER):",
+            "        return value",
+            "    graph = GraphPickler.loads(",
+            "        value[1], FakeTensorMode(shape_env=ShapeEnv())",
+            "    )",
+            "    graph.recompile()",
+            "    return graph",
+            "",
+            "",
+            "class _GraphSelf(torch.nn.Module):",
+            "    def __init__(self):",
+            "        super().__init__()",
+            "        body = pickle.loads(base64.b64decode(_EAGER_GRAPH_BODY))",
+            "        body['_modules'] = {",
+            "            name: _load_eager_subgraph(value)",
+            "            for name, value in body.get('_modules', {}).items()",
+            "        }",
+            "        self.__dict__.update(body)",
+            "",
+            "",
+            "_GRAPH_SELF = _GraphSelf()",
+            "",
+            "",
+            "def call(args):",
+            "    return _graph_forward(_GRAPH_SELF, *args)",
+            "",
+        ]
+    )
     return "\n".join(parts)
 
 
@@ -2085,9 +2181,9 @@ def _build_dynamo_python_source(
     parts = [
         '# Generated by torch.compiler.precompile (tracer="dynamo") -- do not edit.',
         "#",
-        "# The compiled graphs and kernels below are ordinary Python source. Dynamo's",
-        "# guard trees and required code objects have no source form, so section 2",
-        "# stores minimized dispatch guards and bytecode as base64-encoded pickle data.",
+        "# Graph entry points and kernels below are ordinary Python source. Nested FX",
+        "# graph structure used by eager higher-order ops, Dynamo guard trees, and",
+        "# required code objects are stored as labelled base64-encoded pickle data.",
         *serving_description,
         "",
         "# " + "=" * 70,
@@ -2633,6 +2729,11 @@ def _precompile_dynamo(
             # input closure belong to the caller-promised invariant environment.
             environment_assumptions = [
                 guard.guard_type in _DYNAMO_ENVIRONMENT_GUARD_TYPES
+                or (
+                    guard.has_value
+                    and id(guard.value) not in input_object_ids
+                    and importable_global(guard.value) is not None
+                )
                 or (
                     guard.source_root_id is not None
                     and guard.source_root_id not in input_object_ids


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* #194528
* #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* #194468
* __->__ #194467
* #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

The Dynamo eager artifact rejected FX get_attr nodes, while directly pickling a GraphModule would reconstruct its Graph by symbolically retracing generated source. Higher-order operators carry nested GraphModules through get_attr, and cond, while_loop, checkpoint, autocast, and grad-mode nodes do not survive that retrace reliably.

Keep the top-level graph and every nested graph body as readable Python. Serialize only the GraphModule state and nested FX Graph structure, restore nested bodies with GraphPickler, and bind the generated top-level forward to the reconstructed module state. This preserves interpreter-visible Graph objects without running symbolic tracing or model code during load. Importable module identity guards are treated as invariant environment state under the precompile contract.

Test Plan:

```

TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/test_precompile.py -k tracer_dynamo

PATH=/home/bobren/local/c/pytorch-env/bin:$PATH lintrunner -a --skip PYREFLY torch/_precompile.py test/test_precompile.py

```

The required full `lintrunner -a` was also run; Pyrefly could not fetch isort because the configured HTTPS tunnel certificate is untrusted.

Authored with an AI assistant.

cc @albanD