### PR TITLE
[precompile] enforce the input-only guard contract

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -81,18 +81,23 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
       With ``tracer="dynamo"``, every tuple or ``ExampleInput`` in ``example_inputs``
       is executed exactly once during capture. Recompilations become guarded variants
       in the artifact, including automatically dynamic graphs produced when dimensions
-      vary across examples. The
-      artifact drops a serialized guard record only when doing so preserves how every
-      example matches the captured variants, or when it only checks process-local state
-      outside the explicit inputs. Globals, context-manager state, and the rest of the
-      Python environment must be semantically unchanged between capture and runtime;
-      guards that only enforce that promise may therefore be omitted. Input-derived
-      guards remain responsible for dispatch. This filtering is at guard-record
-      granularity, so a retained composite record can still contain invariant leaf
-      checks. Breaking an unchecked environment assumption can silently miscompute. A
-      standalone artifact raises when a call fails every retained guard set. An
-      installed artifact may compile an uncovered call with its selected backend.
-      Graph breaks are captured as Dynamo resume frames.
+      vary across examples. Its contract requires that (1) globals, context-manager
+      state, and the rest of the Python environment are semantically identical at
+      capture and runtime, and (2) only explicit inputs vary in ways that would cause a
+      recompile. Guards that only enforce the first promise are omitted. By default,
+      every portable input-derived guard is retained, including invariant guards needed
+      to reject an unseen input variation.
+
+      Each retained guard is rebuilt independently from its frozen capture snapshot.
+      An environment-only guard that cannot be rebuilt is omitted with its dependent
+      attribute checks; an input-derived or unknown-provenance guard instead raises a
+      ``PrecompileError``. Rebuilt guard facts and leaf predicates are compared with the
+      live capture so a changed input predicate cannot silently ship. This filtering is
+      at guard-record granularity, so a retained composite record can still contain
+      invariant leaf checks. Breaking an unchecked environment assumption can silently
+      miscompute. A standalone artifact raises when a call fails every retained guard
+      set. An installed artifact may compile an uncovered call with its selected
+      backend. Graph breaks are captured as Dynamo resume frames.
       Closure-free Python functions wrapped with ``torch._dynamo.disable`` are embedded
       and execute eagerly between compiled graph segments. Global names left in
       standalone transformed bytecode must resolve to recursive literal values or
@@ -100,13 +105,16 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
       their defining modules. Disabled functions cannot assign globals or use
       ``globals()``, ``eval()``, or ``exec()``; their importable module globals are
       rebound at load, while recursive literal globals and defaults are captured by
-      value. Compiled graphs and kernels remain Python source; guard
-      trees, transformed Dynamo entry/resume bytecode, and embedded disabled-function
-      bytecode are stored as opaque inline data because they have no Python-source
-      representation. The top-level function cannot have closure cells or nested
-      functions that capture its locals. ``nn.Module`` arguments are supported and are
-      checked at runtime for type, training mode, parameter/buffer names, aliasing,
-      shapes, strides, dtypes, devices, and ``requires_grad`` state.
+      value. Compiled graph bodies and kernels remain Python source. The eager backend
+      supports higher-order graphs such as ``torch.cond``, ``torch.while_loop``,
+      non-reentrant activation checkpointing, ``vmap``, autocast, and grad-mode regions.
+      Their nested graph bodies are rendered as Python too, while the FX ``Graph``
+      structure required by eager higher-order-op interpreters is stored as opaque
+      inline data. Guard trees, transformed Dynamo entry/resume bytecode, and embedded
+      disabled-function bytecode are also opaque. The top-level function cannot have
+      closure cells or nested functions that capture its locals. ``nn.Module`` arguments
+      are supported and are checked at runtime for type, training mode, parameter/buffer
+      names, aliasing, shapes, strides, dtypes, devices, and ``requires_grad`` state.
 
       Entry and graph-break resume frames are dispatched directly from the generated
       source. If capture also compiles a nested frame reachable only through an ordinary
@@ -145,7 +153,8 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        runtime inputs.
    :param backend: ``"inductor"`` (default) lowers through AOTAutograd + Inductor;
        ``"eager"`` keeps the captured ATen graph (layout-flexible, no kernels; shapes
-       are still specialized to the example).
+       are still specialized to the example). With the Dynamo tracer, eager preserves
+       nested higher-order-op graphs without symbolic retracing at load.
    :param tracer: capture front-end. ``"make_fx"`` (default) is a non-strict make_fx
        trace. ``"dynamo"`` captures guarded specializations and recompilations from a
        Python function, including graph-break resume frames; it does not yet support
@@ -162,9 +171,10 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        ``torch.compile``. ``None`` enables automatic promotion when example shapes vary.
    :param guard_filter_fn: Optional callable returning one boolean per candidate Dynamo
        guard. It may narrow the portable default set but cannot restore unserializable
-       guards. Final minimization preserves the complete dispatch result for every
-       supplied example while omitting guards covered by the invariant-environment
-       contract.
+       guards. Removing an input guard is considered risky and requires
+       ``require_no_risky_drops=False``. Finalization omits guards covered by the
+       invariant-environment contract and verifies that the frozen captured variants
+       remain distinguishable.
    :param invariants: Optional path for a text report classifying captured guards as
        invariant, varying, or undetermined for each frame.
    :param require_complete: Reject bypassed, truncated, uncovered, or failed captures.

--- a/docs/source/user_guide/torch_compiler/torch.compiler.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler.md
@@ -45,23 +45,29 @@ Reload the artifact with `torch.compiler.precompile.load`; since no weights are 
 you pass the model again at runtime. The optional `tracer="dynamo"` path accepts several
 example calls and retains the guarded recompilations they trigger, including
 automatically dynamic graphs. Use `torch.compiler.ExampleInput(args=..., kwargs=...)`
-for a call with keyword arguments. Its serialized guard records are minimized while
-preserving how every example dispatches. The Python environment, including globals and
-context-manager state, must be semantically unchanged at runtime; guards that only check
-that promise may be omitted, while input-derived guards remain part of dispatch. Breaking
-an unchecked environment assumption can silently miscompute. Tensor, scalar,
-Python-container, and `nn.Module` arguments are supported. Graph breaks and
+for a call with keyword arguments. Its serialized guard records are filtered while
+preserving how every example dispatches. The contract requires the Python environment,
+including globals and context-manager state, to remain semantically unchanged and allows
+recompilation-causing variation only through explicit inputs. Environment-only guards may
+therefore be omitted, while every portable input-derived guard is retained by default.
+Explicitly filtering an input guard is a risky drop and requires opting out of the default
+safety gate. Guards are rebuilt from frozen capture state and checked for predicate drift
+before the artifact is emitted. Breaking an unchecked environment assumption can silently
+miscompute. Tensor, scalar, Python-container, and `nn.Module` arguments are supported.
+Graph breaks and
 closure-free `torch._dynamo.disable` functions are preserved; top-level closures and
-nested functions that capture locals are not yet supported. Captured nested frames that
-cannot be reached by a source-only dispatcher use an isolated installed artifact; it
-installs lazily, can be scoped with `with`, exposes `unload()`, and may compile an
-uncovered call. A standalone artifact instead rejects calls outside its captured guard
-sets. With `training=True`, both eager and Inductor artifacts retain autograd history;
-Inductor graphs include readable compiled forward and backward code. This training mode
-works across captured recompilations and graph breaks. `PrecompileSummary` reports
-coverage and dropped guards, while the `require_*` options let callers reject incomplete
-or insufficiently guarded captures. See the
-{ref}`API reference <torch.compiler_api>` for details.
+nested functions that capture locals are not yet supported. The eager backend also
+preserves higher-order graphs such as `torch.cond`, `torch.while_loop`, non-reentrant
+checkpointing, `vmap`, autocast, and grad-mode regions without symbolically retracing
+them at load. Captured nested frames that cannot be reached by a source-only dispatcher
+use an isolated installed artifact; it installs lazily, can be scoped with `with`,
+exposes `unload()`, and may compile an uncovered call. A standalone artifact instead
+rejects calls outside its captured guard sets. With `training=True`, both eager and
+Inductor artifacts retain autograd history; Inductor graphs include readable compiled
+forward and backward code. This training mode works across captured recompilations and
+graph breaks. `PrecompileSummary` reports coverage and dropped guards, while the
+`require_*` options let callers reject incomplete or insufficiently guarded captures.
+See the {ref}`API reference <torch.compiler_api>` for details.
 
 :::{warning}
 `torch.compile` may not support recently released major versions of Python.

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -92,12 +92,30 @@ def _precompile_dynamo_dict_order(x, values):
     return x
 
 
+class _PrecompileDynamoInputAttribute:
+    def __init__(self):
+        self.flag = True
+
+
+def _precompile_dynamo_input_attribute(x, state):
+    return x + (1 if hasattr(state, "flag") else 2)
+
+
+class _PrecompileDynamoCallableAttribute(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.op = torch.sin
+
+    def forward(self, x):
+        return self.op(x)
+
+
 def _precompile_eager_cond(x):
     return torch.cond(x.sum() > 0, lambda t: t.sin(), lambda t: t.cos(), (x,))
 
 
 def _precompile_eager_while_loop(x):
-    return torch._higher_order_ops.while_loop(
+    return torch.while_loop(
         lambda i, t: i < 3,
         lambda i, t: (i + 1, t + 1.0),
         (torch.tensor(0), x),
@@ -129,6 +147,7 @@ _PRECOMPILE_EAGER_ROUND_TRIP = {
     "autocast": _precompile_eager_autocast,
     "checkpoint": _precompile_eager_checkpoint,
     "cond": _precompile_eager_cond,
+    "no_grad": _precompile_eager_no_grad,
     "vmap": _precompile_eager_vmap,
     "while_loop": _precompile_eager_while_loop,
 }
@@ -147,6 +166,17 @@ class _PrecompileWeakValue:
 def _precompile_dynamo_weakref_input(x, values):
     ref = values.data["value"]
     return x + (1 if ref.__callback__ is not None else 2)
+
+
+_PRECOMPILE_DYNAMO_GENERATOR = torch.Generator()
+
+
+def _precompile_dynamo_generator_environment(x):
+    return x + (1 if _PRECOMPILE_DYNAMO_GENERATOR.device.type == "cpu" else 2)
+
+
+def _precompile_dynamo_generator_input(x, generator):
+    return x + (1 if generator.device.type == "cpu" else 2)
 
 
 def _precompile_dynamo_graph_break(x):
@@ -1662,23 +1692,29 @@ class TestPrecompile(TestCase):
             tracer="dynamo",
             backend="eager",
             dynamic=False,
-            require_no_risky_drops=False,
         )
         loaded = torch.compiler.precompile.load(code, cache)
         try:
+            self.assertEqual(loaded.capture_summary.risky_dropped_guards, ())
             with torch.no_grad():
                 self.assertEqual(loaded(*args, x), expected)
         finally:
             if hasattr(loaded, "unload"):
                 loaded.unload()
 
-    def test_tracer_dynamo_eager_preserves_no_grad_region(self):
+    @parametrize("graph_break", (False, True))
+    def test_tracer_dynamo_eager_preserves_no_grad_region(self, graph_break):
+        entry = (
+            _precompile_eager_graph_break if graph_break else _precompile_eager_no_grad
+        )
+        args = ("no_grad",) if graph_break else ()
         x = torch.randn(4, requires_grad=True)
         with torch.enable_grad():
-            expected = torch.compile(_precompile_eager_no_grad, backend="eager")(x)
+            expected = torch.compile(entry, backend="eager")(*args, x)
+            torch._dynamo.reset()
             code, cache = torch.compiler.precompile(
-                _precompile_eager_no_grad,
-                example_inputs=[(x,)],
+                entry,
+                example_inputs=[(*args, x)],
                 tracer="dynamo",
                 backend="eager",
                 dynamic=False,
@@ -1686,9 +1722,23 @@ class TestPrecompile(TestCase):
             )
         loaded = torch.compiler.precompile.load(code, cache)
         with torch.enable_grad():
-            actual = loaded(x)
+            actual = loaded(*args, x)
         self.assertFalse(actual.requires_grad)
         self.assertEqual(actual, expected)
+
+    def test_tracer_dynamo_eager_load_preserves_ambient_grad_mode(self):
+        x = torch.randn(4)
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                _precompile_eager_no_grad,
+                example_inputs=[(x,)],
+                tracer="dynamo",
+                backend="eager",
+                dynamic=False,
+            )
+            self.assertFalse(torch.is_grad_enabled())
+            torch.compiler.precompile.load(code, cache)
+            self.assertFalse(torch.is_grad_enabled())
 
     def test_tracer_dynamo_eager_higher_order_source_runs_in_fresh_process(self):
         from unittest import mock
@@ -1757,7 +1807,6 @@ class TestPrecompile(TestCase):
             backend="eager",
             dynamic=False,
             training=True,
-            require_no_risky_drops=False,
         )
         actual_input = x.detach().clone().requires_grad_()
         loaded = torch.compiler.precompile.load(code, cache)
@@ -1796,6 +1845,31 @@ class TestPrecompile(TestCase):
         loaded = torch.compiler.precompile.load(code, cache)
         with self.assertRaisesRegex(PrecompileError, "dtype"):
             loaded(torch.randn(7, 4, dtype=torch.float64))
+
+    def test_tracer_dynamo_keeps_invariant_input_attribute_guard(self):
+        x = torch.randn(4)
+        state = _PrecompileDynamoInputAttribute()
+        code, cache = torch.compiler.precompile(
+            _precompile_dynamo_input_attribute,
+            example_inputs=[(x, state)],
+            tracer="dynamo",
+            backend="eager",
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(loaded(x, state), _precompile_dynamo_input_attribute(x, state))
+        del state.flag
+        with self.assertRaisesRegex(PrecompileError, "no captured Dynamo variant"):
+            loaded(x, state)
+
+    def test_tracer_dynamo_does_not_treat_module_callable_as_environment(self):
+        model = _PrecompileDynamoCallableAttribute()
+        with self.assertRaisesRegex(PrecompileError, "can affect dispatch"):
+            torch.compiler.precompile(
+                _precompile_dynamo_call_module,
+                example_inputs=[(model, torch.randn(4))],
+                tracer="dynamo",
+                backend="eager",
+            )
 
     @torch._dynamo.config.patch(
         automatic_dynamic_shapes=True, assume_static_by_default=True
@@ -1839,6 +1913,26 @@ class TestPrecompile(TestCase):
         for (example,) in examples:
             self.assertEqual(example, torch.ones_like(example))
 
+    def test_tracer_dynamo_executes_each_backward_once(self):
+        model = torch.nn.Linear(4, 3)
+        calls: list[torch.Tensor] = []
+        handle = model.weight.register_hook(
+            lambda grad: calls.append(grad.detach().clone())
+        )
+        examples = [(model, torch.randn(size, 4)) for size in (2, 3)]
+        try:
+            torch.compiler.precompile(
+                _precompile_dynamo_backward,
+                example_inputs=examples,
+                tracer="dynamo",
+                backend="eager",
+                training=True,
+            )
+        finally:
+            handle.remove()
+        self.assertEqual(len(calls), len(examples))
+        self.assertIsNone(model.weight.grad)
+
     def test_tracer_dynamo_guards_mutating_module_at_capture_state(self):
         torch.manual_seed(0)
         model = _PrecompileDynamoStepCounter()
@@ -1849,6 +1943,7 @@ class TestPrecompile(TestCase):
             tracer="dynamo",
             backend="eager",
         )
+        self.assertEqual(model.step, len(examples))
 
         torch.manual_seed(0)
         runtime = _PrecompileDynamoStepCounter()
@@ -1863,7 +1958,7 @@ class TestPrecompile(TestCase):
         model = _PrecompileDynamoReadsTensorAttribute()
         x = torch.randn(8)
         x._cpu_copy = torch.randn(8)
-        x.unused = (index for index in range(3))
+        x.unused_generator = torch.Generator()
         fn = (
             _precompile_dynamo_tensor_attribute_break
             if graph_break
@@ -1874,7 +1969,6 @@ class TestPrecompile(TestCase):
             example_inputs=[(model, x)],
             tracer="dynamo",
             backend="eager",
-            require_no_risky_drops=False,
         )
         loaded = torch.compiler.precompile.load(code, cache)
         self.assertEqual(loaded(model, x), fn(model, x))
@@ -1889,7 +1983,6 @@ class TestPrecompile(TestCase):
             example_inputs=[(x,)],
             tracer="dynamo",
             backend="eager",
-            require_no_risky_drops=False,
         )
         loaded = torch.compiler.precompile.load(code, cache)
         self.assertEqual(loaded(x), _precompile_dynamo_reads_tensor_flag(x))
@@ -1921,7 +2014,6 @@ class TestPrecompile(TestCase):
                 example_inputs=[(model, x)],
                 tracer="dynamo",
                 backend="eager",
-                require_no_risky_drops=False,
             )
 
     def test_tracer_dynamo_rejects_drifted_input_guard(self):
@@ -1953,10 +2045,10 @@ class TestPrecompile(TestCase):
                 example_inputs=[(model, x)],
                 tracer="dynamo",
                 backend="eager",
-                require_no_risky_drops=False,
             )
 
-    def test_tracer_dynamo_rejects_guard_leaf_drift(self):
+    @parametrize("change", ("add", "remove"))
+    def test_tracer_dynamo_rejects_guard_leaf_drift(self, change):
         from unittest import mock
 
         from torch._dynamo.guards import GuardManagerWrapper
@@ -1969,7 +2061,9 @@ class TestPrecompile(TestCase):
             calls += 1
             result = fingerprint(self)
             if calls > 1:
-                return result | {("TEST_GUARD", "changed after serialization")}
+                if change == "add":
+                    return result | {("x", "TEST_GUARD", "changed after serialization")}
+                return result - {sorted(result)[0]}
             return result
 
         with (
@@ -1995,7 +2089,6 @@ class TestPrecompile(TestCase):
             tracer="dynamo",
             backend="eager",
             training=True,
-            require_no_risky_drops=False,
         )
         loaded = torch.compiler.precompile.load(code, cache)
         self.assertEqual(loaded(x), _precompile_dynamo_dynamic(x))
@@ -2020,7 +2113,6 @@ class TestPrecompile(TestCase):
             tracer="dynamo",
             backend="eager",
             training=True,
-            require_no_risky_drops=False,
         )
         loaded = torch.compiler.precompile.load(code, cache)
         self.assertEqual(loaded(model, x), model(x))
@@ -2335,6 +2427,38 @@ class TestPrecompile(TestCase):
                 backend="eager",
             )
 
+    def test_tracer_dynamo_drops_generator_environment_guard(self):
+        x = torch.randn(4)
+        code, cache = torch.compiler.precompile(
+            _precompile_dynamo_generator_environment,
+            example_inputs=[(x,)],
+            tracer="dynamo",
+            backend="eager",
+        )
+        loaded = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(loaded(x), _precompile_dynamo_generator_environment(x))
+        self.assertEqual(loaded.capture_summary.risky_dropped_guards, ())
+        self.assertTrue(
+            set(loaded.capture_summary.policy_dropped_guards).issubset(
+                loaded.capture_summary.dropped_guards
+            )
+        )
+        self.assertTrue(
+            any(
+                "_PRECOMPILE_DYNAMO_GENERATOR" in source
+                for _, source in loaded.capture_summary.policy_dropped_guards
+            )
+        )
+
+    def test_tracer_dynamo_does_not_drop_generator_input_guard(self):
+        with self.assertRaisesRegex(PrecompileError, "can affect dispatch"):
+            torch.compiler.precompile(
+                _precompile_dynamo_generator_input,
+                example_inputs=[(torch.randn(4), torch.Generator())],
+                tracer="dynamo",
+                backend="eager",
+            )
+
     @parametrize(
         "bad",
         (
@@ -2354,7 +2478,7 @@ class TestPrecompile(TestCase):
 
     def test_tracer_dynamo_require_no_dropped_guards(self):
         x = torch.randn(4)
-        with self.assertRaisesRegex(PrecompileError, "dropped unserializable"):
+        with self.assertRaisesRegex(PrecompileError, "dropped environment-contract"):
             torch.compiler.precompile(
                 _precompile_dynamo_graph_break,
                 example_inputs=[(x,)],
@@ -3542,7 +3666,7 @@ class TestPrecompile(TestCase):
                 backend="eager",
             )
 
-    def test_tracer_dynamo_filters_invariant_scalar_guards(self):
+    def test_tracer_dynamo_retains_scalar_dispatch_guards(self):
         examples = [(torch.randn(4), scale) for scale in (2, 3)]
         code, cache = torch.compiler.precompile(
             _precompile_dynamo_scalar,

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -724,23 +724,30 @@ class GuardManagerWrapper:
                 )
                 self.construct_manager_string(child_mgr, body)
 
-    def leaf_fingerprint(self) -> frozenset[tuple[str, str]]:
+    def leaf_fingerprint(self) -> frozenset[tuple[str, str, str]]:
         """Return a stable description of the checks made by this guard tree."""
-        found: set[tuple[str, str]] = set()
+        found: set[tuple[str, str, str]] = set()
 
         def payload(guard: LeafGuard) -> Iterator[str]:
             for part in guard.verbose_code_parts():
                 text = part.split("  # ", 1)[0]
                 text = re.sub(r"___check_metadata\S*", "___check_metadata", text)
-                yield re.sub(r"\d{6,}", "N", text)
+                text = re.sub(
+                    r"___check_opaque_guard_fn_\S*", "___check_opaque_guard_fn", text
+                )
+                text = re.sub(r"__dtensor_spec_\d+", "__dtensor_spec", text)
+                yield text.strip()
 
         def walk(manager: GuardManager) -> None:
+            source = (
+                ""
+                if isinstance(manager, RootGuardManager)
+                else strip_local_scope(manager.get_source())
+            )
             for guard in manager.get_leaf_guards():
-                if isinstance(guard, RelationalGuard):
-                    continue
-                if type(guard).__name__ == "LAMBDA_GUARD":
-                    continue
-                found.update((type(guard).__name__, part) for part in payload(guard))
+                found.update(
+                    (source, type(guard).__name__, part) for part in payload(guard)
+                )
             if isinstance(manager, DictGuardManager):
                 pairs = manager.get_key_value_managers().values()
                 for key_manager, value_manager in pairs:
@@ -751,9 +758,14 @@ class GuardManagerWrapper:
                 walk(child)
 
         walk(self.root)
+        if hasattr(self.root, "get_epilogue_lambda_guards"):
+            for guard in self.root.get_epilogue_lambda_guards():
+                found.update(
+                    ("", type(guard).__name__, part) for part in payload(guard)
+                )
         return frozenset(
-            (guard_type, value.replace(", FakeTensor,", ", Tensor,"))
-            for guard_type, value in found
+            (source, guard_type, value.replace(", FakeTensor,", ", Tensor,"))
+            for source, guard_type, value in found
         )
 
     def __str__(self) -> str:
@@ -4166,16 +4178,6 @@ def _companion_attribute_guards(
     return result
 
 
-@contextmanager
-def _quiet_guard_errors() -> Generator[None, None, None]:
-    disabled = torch._guards.log.disabled
-    torch._guards.log.disabled = True
-    try:
-        yield
-    finally:
-        torch._guards.log.disabled = disabled
-
-
 _FAKE_TENSOR_OWNED_ATTRIBUTES = frozenset(
     {
         "_fake_device",
@@ -4836,7 +4838,7 @@ def make_guard_filter_entry(guard: Guard, builder: GuardBuilder) -> GuardFilterE
             has_value = False
     source = guard.originating_source
     source_root_id = None
-    source_root_is_module = False
+    source_root_is_import = False
     source_has_unsupported_value = False
     while source is not None:
         try:
@@ -4849,7 +4851,7 @@ def make_guard_filter_entry(guard: Guard, builder: GuardBuilder) -> GuardFilterE
             )
             if not isinstance(source, ChainedSource):
                 source_root_id = id(source_value)
-                source_root_is_module = isinstance(source_value, torch.nn.Module)
+                source_root_is_import = isinstance(source, ImportSource)
         source = source.base if isinstance(source, ChainedSource) else None
     is_global = get_global_source_name(guard.originating_source) is not None
     return GuardFilterEntry(
@@ -4861,7 +4863,7 @@ def make_guard_filter_entry(guard: Guard, builder: GuardBuilder) -> GuardFilterE
         is_global=is_global,
         orig_guard=guard,
         source_root_id=source_root_id,
-        source_root_is_module=source_root_is_module,
+        source_root_is_import=source_root_is_import,
         source_has_unsupported_value=source_has_unsupported_value,
         code=tuple(guard.code_list or ()),
     )
@@ -5459,8 +5461,7 @@ class CheckFunctionManager:
                 guard.create(builder)
             else:
                 try:
-                    with _quiet_guard_errors():
-                        guard.create(builder)
+                    guard.create_fn(builder, guard)
                 except Exception as error:
                     self._collect_guard_failures.append((guard, error))
         return builder, guard_manager

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -685,7 +685,7 @@ class CompilePackage:
         self._innermost_fn = None
         self._codes: dict[types.CodeType, _DynamoCodeCacheEntry] = {}
         self._observed_scopes: dict[types.CodeType, list[dict[str, object]]] = {}
-        self._live_guard_leaves: dict[int, list[frozenset[tuple[str, str]]]] = {}
+        self._live_guard_leaves: dict[int, list[frozenset[tuple[str, str, str]]]] = {}
 
         self._current_entry: _DynamoCodeCacheEntry | None = None
         self._installed_globals: dict[types.ModuleType, list[_InstalledGlobal]] = {}
@@ -836,14 +836,14 @@ class CompilePackage:
 
     def live_guard_leaves(
         self, entry: _DynamoCodeCacheEntry
-    ) -> Sequence[frozenset[tuple[str, str]]]:
+    ) -> Sequence[frozenset[tuple[str, str, str]]]:
         return self._live_guard_leaves.get(id(entry), ())
 
     def add_guarded_code(
         self,
         guards_state: bytes,
         dynamo_code: types.CodeType,
-        live_guard_leaves: frozenset[tuple[str, str]] = frozenset(),
+        live_guard_leaves: frozenset[tuple[str, str, str]] = frozenset(),
     ) -> None:
         if self._current_entry is None:
             raise AssertionError("_current_entry is not set in add_guarded_code")

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -49,7 +49,7 @@ class GuardFilterEntry:
     orig_guard: Guard
     # Capture-only provenance used by precompile's environment contract.
     source_root_id: int | None = None
-    source_root_is_module: bool = False
+    source_root_is_import: bool = False
     source_has_unsupported_value: bool = False
     # Snapshot this when the inspection builder creates the entry. Rebuilding
     # guards appends to Guard.code_list, so reading it later duplicates text.

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -16,16 +16,18 @@ With ``tracer="dynamo"``, precompile executes every tuple in ``example_inputs`` 
 captures the guarded specializations, recompilations, and graph-break resume frames
 Dynamo produces. Closure-free functions wrapped with ``torch._dynamo.disable`` are
 embedded for eager execution between compiled segments. The serialized guard records
-are minimized while preserving how every example dispatches among the captured
-variants. The Python environment, including globals and context-manager state, must be
+are filtered under the input-only recompilation contract while preserving how every
+example dispatches among the captured variants. The Python environment, including
 semantically unchanged at runtime; guards that only enforce that promise may be omitted,
-including guards through process-local values that cannot be reconstructed. Input-derived
-guards remain responsible for dispatch. A standalone artifact raises when no captured
-variant matches. Captured nested frames that are reachable only by an ordinary Python
-call use an isolated installed mode; it installs lazily, may compile an uncovered call
-with the selected backend, and can be removed with ``unload()``. Compiled graphs and
-kernels remain Python source, while guard trees, transformed entry/resume bytecode, and
-disabled-function bytecode are stored as opaque inline data.
+including guards through process-local values that cannot be reconstructed. By default,
+every portable input-derived guard is retained, rebuilt from frozen capture state, and
+checked for predicate drift. A standalone artifact raises when no captured variant matches.
+Captured nested frames that are reachable only by an ordinary Python call use an isolated
+installed mode; it installs lazily, may compile an uncovered call with the selected
+backend, and can be removed with ``unload()``. Compiled graph bodies and kernels remain
+Python source. Eager higher-order ops retain opaque FX structure only where their runtime
+interpreters require a real ``Graph``; guard trees and transformed/disabled bytecode are
+also stored as opaque inline data.
 
 With ``tracer="dynamo", training=True``, captured graphs remain differentiable on both
 backends. Inductor artifacts contain AOTAutograd's forward and backward as readable
@@ -223,9 +225,11 @@ it.
 #
 # tracer: the capture front-end, orthogonal to backend. "make_fx" (default) is a
 # non-strict trace. "dynamo" analyzes Python bytecode, captures one variant per
-# specialization/recompilation exercised by example_inputs, minimizes guard records
-# while preserving dispatch for those calls, and dispatches among the variants at
-# runtime. Graph breaks are reconstructed from their captured resume frames.
+# specialization/recompilation exercised by example_inputs, omits guards for the
+# caller-promised invariant environment, and retains every portable input-derived
+# guard. Graph breaks are reconstructed from their captured resume frames. The eager
+# backend preserves higher-order graph bodies as Python plus the opaque FX structure
+# their runtime interpreters require; it does not symbolically retrace them at load.
 
 from __future__ import annotations
 
@@ -1549,16 +1553,6 @@ def _dynamo_backend_compiler(
     return compile_graph
 
 
-_DYNAMO_REQUIRED_GUARD_TYPES = frozenset(
-    {
-        "CONSTANT_MATCH",
-        "DUPLICATE_INPUT",
-        "EQUALS_MATCH",
-        "SEQUENCE_LENGTH",
-        "SYMBOL_MATCH",
-        "TENSOR_MATCH",
-    }
-)
 _DYNAMO_UNMODELLED_GUARD_TYPES = frozenset(
     {
         "DETERMINISTIC_ALGORITHMS",
@@ -1836,9 +1830,9 @@ def _filter_dynamo_guards(
     runtime_global_scope: dict[str, object],
     guarded_codes: Sequence[Any],
     captured: Sequence[_DynamoCapturedGuardSet],
-    live_leaf_sets: Sequence[frozenset[tuple[str, str]]],
+    live_leaf_sets: Sequence[frozenset[tuple[str, str, str]]],
 ) -> _DynamoGuardFinalization:
-    """Rebuild, validate, and minimize guards from frozen capture state."""
+    """Rebuild and validate guards from frozen capture state."""
     import dataclasses
     import functools
 
@@ -1852,15 +1846,6 @@ def _filter_dynamo_guards(
     from torch._dynamo.package import load_guard_manager, load_guards_state
     from torch._guards import GuardsSet
     from torch.utils._ordered_set import OrderedSet
-
-    def required_guard(guard: Any) -> bool:
-        required = _DYNAMO_REQUIRED_GUARD_TYPES | _DYNAMO_UNMODELLED_GUARD_TYPES
-        return guard.create_fn_name() in required or bool(
-            required.intersection(
-                getattr(guard, "guard_types", ())
-                or getattr(guard, "derived_guard_types", ())
-            )
-        )
 
     def fresh_guard(guard: Any, *, final: bool = False) -> Any:
         create_fn = guard.create_fn
@@ -1896,27 +1881,6 @@ def _filter_dynamo_guards(
             "precompile tracer='dynamo' did not record one live guard tree for "
             "every captured variant."
         )
-    slots = {
-        (fact.guard_type, fact.source)
-        for record in captured
-        for fact in record.facts
-        if fact.enforced
-    }
-    varying_slots = {
-        slot
-        for slot in slots
-        if len(
-            {
-                frozenset(
-                    fact
-                    for fact in record.facts
-                    if fact.enforced and (fact.guard_type, fact.source) == slot
-                )
-                for record in captured
-            }
-        )
-        > 1
-    }
     filtered_states: list[bytes] = []
     kept_slots: list[frozenset[tuple[str, str]]] = []
     policy_dropped: set[tuple[str, str]] = set()
@@ -1931,7 +1895,6 @@ def _filter_dynamo_guards(
             guard
             for guard in state.output_graph.guards
             if _dynamo_guard_slot(guard) not in record.environment
-            and (required_guard(guard) or _dynamo_guard_slot(guard) in varying_slots)
         ]
         kept_aot_guards = list(state.output_graph.aotautograd_guards)
         environment_sources = {source for _, source in record.environment}
@@ -2017,11 +1980,57 @@ def _filter_dynamo_guards(
             raise AssertionError("guards_state must not be None")
         filtered_state = load_guards_state(check_fn.guards_state)
         rebuilt = manager_for(filtered_state)
-        extra_leaves = rebuilt.leaf_fingerprint() - live_leaves
-        if extra_leaves:
+        dropped_sources = {
+            source for _, source in record.environment | record.dropped if source
+        }
+        dropped_root_types = {
+            guard_type
+            for guard_type, source in record.environment | record.dropped
+            if not source
+        }
+        root_environment_types = {
+            "DEFAULT_DEVICE",
+            "GLOBAL_STATE",
+            "TORCH_FUNCTION_MODE_STACK",
+        }
+
+        def normalize_leaf(
+            leaf: tuple[str, str, str],
+        ) -> tuple[str, str, str]:
+            source, guard_type, payload = leaf
+            return (
+                _normalize_dynamo_guard_text(source),
+                guard_type,
+                _normalize_dynamo_guard_text(payload),
+            )
+
+        def is_dropped_leaf(leaf: tuple[str, str, str]) -> bool:
+            source, guard_type, payload = leaf
+            if not source:
+                return guard_type in root_environment_types or (
+                    guard_type == "LAMBDA_GUARD"
+                    and (
+                        "top_saved_tensors_hooks" in payload
+                        or "SHAPE_ENV" in dropped_root_types
+                    )
+                )
+            return any(
+                source == root or source.startswith((f"{root}.", f"{root}["))
+                for root in dropped_sources
+            )
+
+        normalized_live_leaves = map(normalize_leaf, live_leaves)
+        expected_leaves = frozenset(
+            leaf for leaf in normalized_live_leaves if not is_dropped_leaf(leaf)
+        )
+        rebuilt_leaves = frozenset(
+            normalize_leaf(leaf) for leaf in rebuilt.leaf_fingerprint()
+        )
+        changed_leaves = expected_leaves ^ rebuilt_leaves
+        if changed_leaves:
             examples = ", ".join(
-                f"{guard_type}: {payload}"
-                for guard_type, payload in sorted(extra_leaves)[:3]
+                f"{source or '<root>'}: {guard_type}: {payload}"
+                for source, guard_type, payload in sorted(changed_leaves)[:3]
             )
             raise PrecompileError(
                 "precompile tracer='dynamo' rebuilt a guard tree with changed "
@@ -2729,8 +2738,11 @@ def _precompile_dynamo(
             # input closure belong to the caller-promised invariant environment.
             environment_assumptions = [
                 guard.guard_type in _DYNAMO_ENVIRONMENT_GUARD_TYPES
+                or guard.source_root_is_import
                 or (
                     guard.has_value
+                    and guard.source_root_id is not None
+                    and guard.source_root_id not in input_object_ids
                     and id(guard.value) not in input_object_ids
                     and importable_global(guard.value) is not None
                 )
@@ -3047,28 +3059,13 @@ def _precompile_dynamo(
             for record in records
             for slot in record.dropped
         }
+        dropped_guards.update(policy_dropped_guards)
         risky_dropped_guards = {
             slot
             for records in captured_guard_sets.values()
             for record in records
             for slot in record.risky_dropped
         }
-        for entry in code_entries:
-            records = captured_guard_sets.get(id(entry), [])
-            values_by_source: dict[str, set[tuple[tuple[str, ...], str]]] = {}
-            dropped_by_source: dict[str, set[tuple[str, str]]] = {}
-            for record in records:
-                for fact in record.facts:
-                    values_by_source.setdefault(fact.source, set()).add(
-                        (fact.code, fact.value)
-                    )
-                for guard_type, source in record.dropped:
-                    dropped_by_source.setdefault(source, set()).add(
-                        (guard_type, source)
-                    )
-            for source, values in values_by_source.items():
-                if len(values) > 1:
-                    risky_dropped_guards.update(dropped_by_source.get(source, ()))
         kept_guards = {
             slot
             for variants in kept_by_entry.values()
@@ -3105,8 +3102,9 @@ def _precompile_dynamo(
             )
         if require_no_dropped_guards and summary.dropped_guards:
             raise PrecompileError(
-                "precompile tracer='dynamo' dropped unserializable or "
-                f"caller-filtered guards: {list(summary.dropped_guards)}. Pass "
+                "precompile tracer='dynamo' dropped environment-contract, "
+                "unserializable, or caller-filtered guards: "
+                f"{list(summary.dropped_guards)}. Pass "
                 "require_no_dropped_guards=False to accept them."
             )
         if require_no_risky_drops and summary.risky_dropped_guards:
@@ -3594,8 +3592,9 @@ class _PrecompileApi:
         The outer sequence supports capture front-ends that can specialize one artifact
         from multiple calls. The ``make_fx`` tracer accepts exactly one tuple because it
         records only one execution; ``dynamo`` executes every tuple and records the
-        guarded recompilations they trigger. The Dynamo artifact minimizes serialized
-        guard records while preserving how every example dispatches among those variants.
+        guarded recompilations they trigger. The Dynamo artifact filters serialized guard
+        records under its input-only recompilation contract while preserving how every
+        example dispatches among those variants.
 
         THREADING: the inductor lowering step drives process-global compiler state
         and is serialized by an internal lock, so concurrent ``backend="inductor"``
@@ -3612,12 +3611,14 @@ class _PrecompileApi:
           holds the save_cache_artifacts bundle that primes the inductor cache on load.
         - ``"eager"``: do NOT lower -- keep the captured ATen graph and run it as-is
           (analogous to ``torch.compile(backend="eager")``). ``python_code`` inlines
-          the readable captured graph (both the inspectable rendering and the
-          executable artifact); the eager cache carries no compiled artifact
+          the readable captured graph. Higher-order graph bodies are readable Python;
+          their FX structure is also embedded because eager HOP interpreters require a
+          real ``Graph`` at runtime. Loading recompiles that structure to bytecode but
+          never symbolically retraces it. The eager cache carries no compiled artifact
           (artifact=None) but is still a full integrity-tagged envelope -- with no
           kernels there is nothing to accelerate, so ``load`` runs the inlined graph.
-          Useful for
-          inspecting/debugging exactly what was traced without an Inductor dependency.
+          Useful for inspecting/debugging exactly what was traced without an Inductor
+          dependency.
 
         ``tracer`` selects the capture front-end:
 
@@ -3629,13 +3630,17 @@ class _PrecompileApi:
           specialization/recompilation exercised by ``example_inputs``. The emitted
           artifact drops a serialized guard record only when doing so preserves every
           example's variant-match results, or when the guard only checks process-local
-          state outside the explicit inputs. The Python environment -- including globals
-          and context-manager state -- must be semantically identical between capture and
-          runtime, so such environment-only checks are caller assumptions rather than
-          dispatch predicates. Input-derived guards are retained. Filtering is at
-          guard-record granularity, so a retained composite record can still rebuild
-          invariant leaf checks. Breaking an unchecked assumption can silently
-          miscompute.
+          state outside the explicit inputs. The Python environment -- including
+          globals and context-manager state -- must be semantically identical between
+          capture and runtime, and only explicit inputs may vary in a way that causes a
+          recompile. Environment-only checks are therefore caller assumptions rather
+          than dispatch predicates. By default, every portable input-derived guard is
+          retained. Each guard is rebuilt independently from frozen capture state; an
+          input-derived rebuild failure or changed predicate raises, while an
+          environment-only failure is omitted with dependent attribute checks.
+          Filtering is at guard-record granularity, so a retained composite record can
+          still rebuild invariant leaf checks. Breaking an unchecked assumption can
+          silently miscompute.
           A standalone call that fails every retained guard set raises. An installed
           artifact can compile an uncovered call with its selected backend. Graph breaks
           are preserved through their Dynamo resume frames;
@@ -3665,10 +3670,12 @@ class _PrecompileApi:
 
         ``guard_filter_fn`` receives each candidate Dynamo guard sequence and returns
         one bool per guard. It can narrow the portable default set but cannot restore a
-        guard Dynamo cannot serialize. After all examples run, precompile further drops
-        only records whose removal preserves the complete example-to-variant dispatch
-        matrix. ``invariants`` optionally names a text file receiving the resulting
-        invariant, varying, and undetermined guard report.
+        guard Dynamo cannot serialize. Input guards removed by this callback are risky
+        drops and are rejected unless ``require_no_risky_drops=False``. After all examples
+        run, precompile drops guards covered by the invariant-environment contract and
+        verifies that retained frozen facts still distinguish the captured variants.
+        ``invariants`` optionally names a text file receiving the resulting invariant,
+        varying, and undetermined guard report.
 
         ``require_complete`` rejects captures with bypassed, truncated, uncovered, or
         failed frames. ``require_no_risky_drops`` rejects dropped guards that could alter
@@ -3687,8 +3694,8 @@ class _PrecompileApi:
         With ``tracer="dynamo"``, shape variation across ``example_inputs`` uses
         Dynamo's ordinary automatic dynamic-shape policy: for example, a static first
         graph can recompile into a symbolic graph when a later tuple changes a dimension.
-        The symbolic graphs and the minimized dispatch guard records are retained in the
-        artifact.
+        The symbolic graphs and contract-filtered dispatch guard records are retained in
+        the artifact.
 
         With ``tracer="make_fx"``, dynamic shapes are opt-in via
         ``torch._dynamo.decorators.mark_unbacked``


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* #194528
* #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* __->__ #194468
* #194467
* #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

The previous guard finalization policy kept only a hand-picked set of guard types or guards that differed across examples. That could discard invariant predicates rooted in explicit inputs, while imported environment state could be mistaken for an input dependency. The resulting artifact could either reject supported higher-order graphs or accept an unseen input that should have missed every captured variant.

Retain every portable input-derived guard by default and classify only true environment roots as caller assumptions. Unsupported environment guards, including weakref and generator state, are recorded as contract drops; input-derived or unknown guards fail closed. Rebuild from frozen capture facts, compare the complete source-aware leaf predicate set in both directions, and keep dependent guard handling so serialization cannot silently add or remove an input check.

The tests pin invariant input attributes, callable module attributes, unsupported generator provenance, exactly one forward/backward execution per example, higher-order graph behavior across graph breaks, ambient grad-mode preservation, and the public contract documentation.

Test Plan:

```
TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/test_precompile.py
```

```
TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/dynamo/test_guard_serialization.py
```

```
TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/dynamo/test_package.py
```

```
TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/functorch/test_compile_to_python.py
```

```
TORCH_USE_RTLD_GLOBAL=1 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64 python test/test_precompile.py TestPrecompileNumericsCUDA.test_tracer_dynamo_recompiles_to_dynamic_cuda_graph_cuda TestPrecompileNumericsCUDA.test_tracer_dynamo_graph_break_cuda_cuda TestPrecompileNumericsCUDA.test_tracer_dynamo_installed_graph_break_cuda_cuda TestPrecompileNumericsCUDA.test_tracer_dynamo_training_cuda_cuda
```

```
PATH=/home/bobren/local/c/pytorch-env/bin:$PATH lintrunner -a --skip PYREFLY torch/_dynamo/types.py torch/_dynamo/guards.py torch/_dynamo/package.py torch/_precompile.py test/test_precompile.py docs/source/torch.compiler_api.md docs/source/user_guide/torch_compiler/torch.compiler.md
```

The required full `lintrunner -a` was also run; Pyrefly crashed internally while building its export table. All other linters passed on the touched files.

Authored with an AI assistant.

cc @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98