### PR TITLE
[MPS] Ignore bias in complex `[b]add[b]mm` when beta is 0

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -463,8 +463,14 @@ Tensor& do_metal_addmm(const Tensor& self,
                        const Scalar& alpha,
                        const Scalar& beta,
                        const Tensor& bias) {
-  if (beta.isFloatingPoint() && alpha.isFloatingPoint() && beta.toDouble() == 0 && alpha.toDouble() == 1) {
-    return do_metal_mm(self, other, output);
+  // beta == 0 means bias is ignored, so nan/inf in it must not propagate. Lower to a plain
+  // mm (skipping the bias) and scale by alpha in place only for the uncommon alpha != 1.
+  if (beta.toComplexDouble() == 0.0) {
+    do_metal_mm(self, other, output);
+    if (alpha.toComplexDouble() != 1.0) {
+      output.mul_(alpha);
+    }
+    return output;
   }
   // Handle conjugated inputs by creating resolved copies
   auto self_ = self.is_conj() ? self.resolve_conj() : self;
@@ -512,10 +518,22 @@ Tensor& do_metal_addbmm_or_baddbmm(const Tensor& bias,
                                    const Scalar& beta,
                                    Tensor& output,
                                    bool is_baddbmm) {
-  // Handle conjugated inputs by creating resolved copies
+  // beta == 0 means bias is ignored, so nan/inf in it must not propagate. baddbmm then
+  // lowers to a plain bmm (skipping the bias) with an in-place alpha scale for alpha != 1.
+  if (is_baddbmm && beta.toComplexDouble() == 0.0) {
+    do_metal_bmm(batch1, batch2, output);
+    if (alpha.toComplexDouble() != 1.0) {
+      output.mul_(alpha);
+    }
+    return output;
+  }
+
+  // Handle conjugated inputs by creating resolved copies. addbmm still needs its batch
+  // reduction, so when beta == 0 feed the kernel a broadcast scalar zero for the bias.
   auto batch1_ = batch1.is_conj() ? batch1.resolve_conj() : batch1;
   auto batch2_ = batch2.is_conj() ? batch2.resolve_conj() : batch2;
-  auto bias_ = bias.is_conj() ? bias.resolve_conj() : bias;
+  auto bias_src = beta.toComplexDouble() == 0.0 ? at::zeros({}, bias.options()) : bias;
+  auto bias_ = bias_src.is_conj() ? bias_src.resolve_conj() : bias_src;
 
   auto stream = getCurrentMPSStream();
   auto device = MPSDevice::getInstance()->device();
@@ -1312,7 +1330,7 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
   // Inner dimension is 0
   // Early out as some paths in the code below do not handle this case correctly
   if (self.size(1) == 0) {
-    if (beta.toDouble() == 0.0) {
+    if (beta.toComplexDouble() == 0.0) {
       output.zero_();
     } else {
       output.copy_(*bias_);
@@ -1326,7 +1344,10 @@ static Tensor& addmm_out_mps_impl(const Tensor& bias,
     return output;
   }
 
-  if (use_metal_mm(self, other, output)) {
+  // Complex addmm must use the Metal kernel (like bmm/baddbmm): the MPSGraph-based fallback
+  // for real types below encodes alpha/beta as real (double) constants via toDouble(), which
+  // throws for a complex scalar and drops its imaginary part.
+  if (use_metal_mm(self, other, output) || c10::isComplexType(self.scalar_type())) {
     return do_metal_addmm(self, other, output, alpha, beta, *bias_);
   }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -1760,11 +1760,15 @@ class TestMPS(TestCaseMPS):
 
     def test_baddbmm_beta_zero_ignores_input(self):
         # When beta == 0 the input/bias must be ignored entirely. nan/inf in it
-        # must not be propagated. Regression test for: #187521.
-        for dtype in [torch.float32, torch.float16, torch.bfloat16]:
+        # must not be propagated. Regression test for: #187521 and for #194442
+        # also probes the complex path
+        for dtype in [torch.float32, torch.float16, torch.bfloat16, torch.complex64]:
             batch1 = torch.randn(8, 77, 64, dtype=dtype, device="mps")
             batch2 = torch.randn(8, 64, 77, dtype=dtype, device="mps")
-            for bad in [float("nan"), float("inf"), float("-inf")]:
+            bad_values = [float("nan"), float("inf"), float("-inf")]
+            if dtype.is_complex:
+                bad_values = [complex(v, v) for v in bad_values]
+            for bad in bad_values:
                 inp = torch.full((8, 77, 77), bad, dtype=dtype, device="mps")
                 out = torch.baddbmm(inp, batch1, batch2, beta=0, alpha=0.125)
                 self.assertFalse(out.isnan().any() or out.isinf().any(),
@@ -1776,6 +1780,12 @@ class TestMPS(TestCaseMPS):
                 out_a = torch.addbmm(inp_a, batch1, batch2, beta=0, alpha=0.125)
                 self.assertFalse(out_a.isnan().any() or out_a.isinf().any(),
                                  lambda msg: f"{msg}\naddbmm beta=0 propagated {bad} for dtype={dtype}")
+
+                inp_m = torch.full((77, 77), bad, dtype=dtype, device="mps")
+                out_m = torch.addmm(inp_m, batch1[0], batch2[0], beta=0, alpha=0.125)
+                self.assertFalse(out_m.isnan().any() or out_m.isinf().any(),
+                                 lambda msg: f"{msg}\naddmm beta=0 propagated {bad} for dtype={dtype}")
+                self.assertEqual(out_m, torch.mm(batch1[0], batch2[0]) * 0.125)
 
     def test_local_scalar_dense_mps(self):
         x_cpu = torch.randn(1)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -12347,9 +12347,6 @@ op_db: list[OpInfo] = [
                    dtypes=(torch.complex64, torch.complex128)),
                DecorateInfo(toleranceOverride({torch.float16: tol(atol=1e-3, rtol=2e-3)}),
                             "TestConsistency", "test_output_grad_match", device_type="mps"),
-               # RuntimeError: value cannot be converted to type double without overflow
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
            )),
     OpInfo('addmm',
            # When alpha=beta=1 as compile-time constants, JIT will decompose addmm into mm and add.

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -29,6 +29,7 @@ if torch.backends.mps.is_available():
             "abs",
             "add",
             "addbmm",
+            "addmm",
             "alias_copy",
             "argwhere",
             "atleast_1d",


### PR DESCRIPTION
Fixes #194442.

`baddbmm`/`addbmm`/`addmm` [document](https://docs.pytorch.org/docs/stable/generated/torch.addmm.html) that when `beta == 0` the `input`/bias is ignored, so nan/inf in it must not propagate. On MPS, real dtypes already honor this (the MPSGraph path drops the bias node when `beta == 0`, and the bfloat16 case from the issue was already fixed on main after 2.13.0), but complex and integral types take the Metal-kernel path, which unconditionally adds `beta*bias`, so a nan/inf `input` poisons the whole output even though `beta == 0`.

When `beta == 0` the bias must be dropped entirely:
- baddbmm lowers to a plain `bmm` and addmm to a plain `mm`, scaling in place only for the uncommon `alpha != 1`
- addbmm has no bias-free "batched matmul + reduce" kernel, so it stays on its own kernel but is handed a broadcast scalar-zero bias

It also fixes complex `addmm` more broadly: the MPSGraph addmm path applied `alpha`/`beta` via `toDouble()`, which throws for a complex scalar and silently drops the imaginary part (and a pure-imaginary `beta` was mis-detected as zero, wrongly dropping the bias). Complex `addmm` is now routed through the Metal kernel like `bmm`/`baddbmm`. Integral types cannot carry nan, so nothing changes for them.

For complex baddbmm with `beta=0` and a nan `input`, the poisoned-output count goes from `256 / 256` on main to `0 / 256`, matching CPU; same for addbmm/addmm. Complex `alpha`/`beta` addmm now matches CPU instead of raising.

Authored with the assistance of an AI agent (Claude Code).

Co-authored-by: Achraf Bayi <achrafbayi@icloud.com>
