### PR TITLE
[checkpoint] Stash device RNG state without the CUDA-style device-module API

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5131,14 +5131,28 @@ class TestMPS(TestCaseMPS):
     def test_activation_checkpoint_does_not_error(self):
         from torch.utils.checkpoint import checkpoint
 
+        def fn(x):
+            return x.sin().cos().exp()
+
+        # Recompute must replay the RNG state stashed during the forward,
+        # otherwise the gradient below is silently wrong rather than noisy.
+        def dropout_fn(x):
+            return (x * (torch.rand_like(x) > 0.5)).sum()
+
         for use_reentrant in (True, False):
             a = torch.tensor(1., device="mps", requires_grad=True)
-
-            def fn(x):
-                return x.sin().cos().exp()
-
             out = checkpoint(fn, a, use_reentrant=use_reentrant)
             out.backward()
+
+            x = torch.randn(64, device="mps", requires_grad=True)
+            torch.manual_seed(2024)
+            dropout_fn(x).backward()
+            expected_grad = x.grad.clone()
+
+            x.grad = None
+            torch.manual_seed(2024)
+            checkpoint(dropout_fn, x, use_reentrant=use_reentrant).backward()
+            self.assertEqual(x.grad, expected_grad)
 
     def test_as_strided(self):
         values = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]

--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -104,6 +104,20 @@ def _get_device_module(device="cuda"):
     return device_module
 
 
+def _is_device_initialized(device_type: str) -> bool:
+    # Whether stashing this device's RNG state is safe, i.e. the device is
+    # already in use. Backends that initialize lazily (cuda, xpu, mtia) must not
+    # have a context created behind the user's back, so they are asked through
+    # their ``_initialized`` flag. Backends with no lazy initialization step
+    # (e.g. mps) have no context to create and are ready as soon as they are the
+    # current accelerator. Plain cpu is never an accelerator, so it stays False.
+    device_module = _get_device_module(device_type)
+    if (initialized := getattr(device_module, "_initialized", None)) is not None:
+        return initialized
+    acc = torch.accelerator.current_accelerator()
+    return acc is not None and acc.type == device_type
+
+
 class DefaultDeviceType:
     r"""
     A class that manages the default device type for checkpointing.
@@ -187,11 +201,11 @@ def get_device_states(*args) -> Tuple[List[int], List[torch.Tensor]]:
         return arg
     tree_map(add_device_ids, args)
 
-    fwd_device_states = []
     device_module = _get_device_module(_infer_device_type(*args))
-    for device_id in fwd_device_ids:
-        with device_module.device(device_id):
-            fwd_device_states.append(device_module.get_rng_state())
+    # Index the generator directly instead of switching the current device, the
+    # way torch.random.fork_rng does. Backends that never grew a CUDA-style
+    # ``device`` context manager (e.g. MPS) then work here too.
+    fwd_device_states = [device_module.get_rng_state(idx) for idx in fwd_device_ids]
 
     return fwd_device_ids, fwd_device_states
 
@@ -212,8 +226,7 @@ def set_device_states(devices, states, *, device_type=None) -> None:
         return
     device_module = _get_device_module(device_type)
     for device, state in zip(devices, states, strict=False):
-        with device_module.device(device):
-            device_module.set_rng_state(state)
+        device_module.set_rng_state(state, device)
 
 
 def _get_autocast_kwargs(device_type="cuda"):
@@ -254,8 +267,7 @@ class CheckpointFunction(torch.autograd.Function):
             # run_function, we SHOULD actually stash the cuda state here.  Unfortunately,
             # we have no way to anticipate this will happen before we run the function.)
             ctx.had_device_in_fwd = False
-            device_module = _get_device_module(ctx.device_type)
-            if getattr(device_module, "_initialized", False):
+            if _is_device_initialized(ctx.device_type):
                 ctx.had_device_in_fwd = True
                 ctx.fwd_devices, ctx.fwd_device_states = get_device_states(*args)
 
@@ -1899,7 +1911,6 @@ def _checkpoint_without_reentrant_generator_impl(
         )
 
     device_type = _infer_device_type(*args)
-    device_module = _get_device_module(device_type)
     forward_context, recompute_context = context_fn()
     # SAC caches some tensors outside the autograd graph; this tells its caching
     # mode whether to route them through the user's saved_tensors_hooks. Set by
@@ -1927,7 +1938,7 @@ def _checkpoint_without_reentrant_generator_impl(
         # we have no way to anticipate this will happen before we run the function.
         # If they do so, we raise an error.)
         had_device_in_fwd = False
-        if getattr(device_module, "_initialized", False):
+        if _is_device_initialized(device_type):
             had_device_in_fwd = True
             fwd_devices, fwd_device_states = get_device_states(*args)
 
@@ -2021,7 +2032,7 @@ def _checkpoint_without_reentrant_generator_impl(
         )
     new_frame.forward_completed = True
 
-    if getattr(device_module, "_initialized", False) and \
+    if _is_device_initialized(device_type) and \
        preserve_rng_state and not had_device_in_fwd:  # type: ignore[possibly-undefined]
         # Device was not initialized before running the forward, so we didn't
         # stash the device state.


### PR DESCRIPTION
Fixes #127676.

torch.utils.checkpoint saves the device RNG state during the forward and replays it during recompute, so a checkpointed function that draws randomness (dropout, rand_like) recomputes the same values and produces the same gradient. On MPS neither half happened, and the failure was silent. Backward recomputed the forward with a fresh dropout mask, so the gradient was simply wrong.

Two pieces of the legacy CUDA-shaped device-module contract are responsible. The stash is gated on `getattr(device_module, "_initialized", False)`, and torch.mps has no `_initialized`, so the gate was always False. Had it passed, `get_device_states` would have raised `AttributeError` anyway, since it selects the device with `device_module.device(idx)`, a context manager only torch.cuda and torch.xpu provide. Users hit that second one directly through libraries that stash RNG state themselves.

This PR removes checkpoint's dependency on both, instead of adding them to torch.mps (which is what the first version of this PR did).

- `get_device_states`/`set_device_states` now index the generator with `get_rng_state(device)` / `set_rng_state(state, device)`, exactly as `torch.random.fork_rng` (which checkpoint calls a few lines later on the same module) already does. No device context manager is needed here at all.
- The gate moves into `_is_device_initialized`, which reads `_initialized` when a backend has one (cuda/xpu/mtia unchanged, and a lazily initialized device is still never touched behind the user's back) and otherwise asks torch.accelerator whether this device type is the current accelerator. MPS has no lazy init step. cpu is never an accelerator and stays False as before.

I checked that `_is_device_initialized` returns exactly what the old `getattr` returned for cpu, cuda, xpu, mtia and meta, and only flips to True for mps. Public signatures of `get_device_states`/`set_device_states` are unchanged.

I did not route the device selection through `torch.accelerator.device_index`. `_accelerator_exchangeDevice` eagerly calls `maybe_initialize_device` and does not treat a negative index as a no-op the way `torch.cuda.device` does, so CUDA behavior would not have been identical for these public functions.

## Test Plan

The existing `test_activation_checkpoint_does_not_error` in test/test_mps.py now also compares the gradient of a dropout-style function checkpointed vs not, both `use_reentrant` values, fixed seed. On main that assertion fails with 28/64 elements mismatched. With this change it passes.

```
python test/test_mps.py TestMPS -k test_activation_checkpoint_does_not_error
```

On CPU the result set is identical before and after this change.

```
python test/test_utils.py -k checkpoint
python test/test_autograd.py -k checkpoint
```

Authored with AI assistance (Claude). I reviewed and tested the change on real Apple Silicon hardware.
