### PR TITLE
[inductor] Replace `Any` with precise types in symbolic-shape predicates

### DIFF
--- a/torch/_inductor/codegen/simd.py
+++ b/torch/_inductor/codegen/simd.py
@@ -59,6 +59,7 @@ from ..runtime.runtime_utils import (
 )
 from ..scheduler import BaseSchedulerNode, BaseScheduling, WhyNoFuse
 from ..utils import (
+    _IntLike,
     cache_property_on_self,
     decompose_index,
     expr_fits_within_32bit,
@@ -509,8 +510,8 @@ class NodeInfo(NamedTuple):
     node_schedule: list
     tiling: dict
     tiling_scores: dict | None
-    numel: Any
-    rnumel: Any
+    numel: _IntLike
+    rnumel: _IntLike
     features: SIMDKernelFeatures
     is_persistent_reduction: bool
 

--- a/torch/_inductor/codegen/triton_combo_kernel.py
+++ b/torch/_inductor/codegen/triton_combo_kernel.py
@@ -34,6 +34,7 @@ from ..stream_utils import (
     get_raw_stream_name,
 )
 from ..utils import (
+    _IntLike,
     clear_on_fresh_cache,
     DeferredLineBase,
     Placeholder,
@@ -74,7 +75,7 @@ LARGE_NUMELS = 51_200_000
 BLOCK_UTILIZATION = 0.8
 
 
-def _size_hint(expr: Any) -> int:
+def _size_hint(expr: _IntLike) -> int:
     return V.graph.sizevars.optimization_hint(expr, fallback=1)
 
 

--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -49,9 +49,12 @@ from .triton_addmm import AddMMConfigMixin
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator
+    from collections.abc import Callable, Generator, Sequence
 
     from triton import Config as TritonConfig
+
+    from ...ir import IRNode
+    from ...utils import _IntLike
 
 else:
     from torch._inductor.runtime.triton_compat import Config as TritonConfig
@@ -2874,13 +2877,15 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
             # Need to unsqueeze bias from [N] -> [1, N]
             bias = L[aten.unsqueeze](bias, 0)
 
-        def is_tensorwise_scale(scale: Any) -> bool:
+        def is_tensorwise_scale(scale: IRNode) -> bool:
             size = scale.get_size()
             return len(size) == 0 or all(
                 V.graph.sizevars.statically_known_equals(dim, 1) for dim in size
             )
 
-        def normalize_tensorwise_scale(scale: Any, *, allow_high_rank: bool) -> Any:
+        def normalize_tensorwise_scale(
+            scale: IRNode, *, allow_high_rank: bool
+        ) -> IRNode:
             if not is_tensorwise_scale(scale):
                 return scale
             if not allow_high_rank and len(scale.get_size()) > 2:
@@ -2929,7 +2934,9 @@ class BaseScaledMMConfigMixin(MMTemplateConfigMixin):
         scale_b = input_nodes[3]
 
         # Scale compatibility assertion from mm_common.scaled_mm_options
-        def are_compatible_scales(size_a: Any, size_b: Any) -> bool:
+        def are_compatible_scales(
+            size_a: Sequence[_IntLike], size_b: Sequence[_IntLike]
+        ) -> bool:
             # Same sized scales are compatible
             if len(size_a) == len(size_b):
                 return True

--- a/torch/_inductor/kernel/flex_gemm/constraints.py
+++ b/torch/_inductor/kernel/flex_gemm/constraints.py
@@ -14,6 +14,8 @@ from torch._inductor.kernel.gemm_epilogue_utils import (
     statically_known,
     statically_known_shape_equal,
 )
+from torch._inductor.utils import _IntLike
+from torch.types import IntLikeType
 
 
 LOCAL_REDUCE_FEED_MAIN_ARG_NAME: Final = "local_reduce0"
@@ -162,13 +164,18 @@ FLEX_GEMM_MAIN_OUTPUT_SHAPE_ERROR = (
 )
 
 
-def statically_known_multiple(value: Any, divisor: int) -> bool:
-    """Return whether a symbolic shape value is known divisible without guards."""
+def statically_known_multiple(value: _IntLike | IntLikeType, divisor: _IntLike) -> bool:
+    """Return whether a symbolic shape value is known divisible without guards.
+
+    ``value`` spans both worlds: inductor sizes reach it as ``int``/``sympy.Expr``,
+    while the local-reduce validators below pass ``torch.Size``-derived dims whose
+    dynamic entries are ``SymInt``.
+    """
     return statically_known(value % divisor == 0)
 
 
 def is_flex_gemm_partial_reduction_shape(
-    aux_size: Sequence[Any], output_size: Sequence[Any]
+    aux_size: Sequence[_IntLike], output_size: Sequence[_IntLike]
 ) -> bool:
     """Recognize aux shapes that imply a final PyTorch reduction, not local reduce.
 
@@ -223,7 +230,7 @@ def validate_local_reduce_group_axis(group: int, axis: int) -> None:
 
 
 def validate_local_reduce_selected_dim_divisible(
-    shape: Sequence[Any], group: int, axis: int
+    shape: Sequence[IntLikeType], group: int, axis: int
 ) -> None:
     """Reject selected M/N dimensions known not to have an integral compressed shape."""
     validate_local_reduce_group_axis(group, axis)
@@ -301,8 +308,8 @@ def validate_local_reduce_feed_main_capability(axis: int, group: int) -> None:
 
 
 def local_reduce_compressed_shape(
-    shape: Sequence[Any], group: int, axis: int
-) -> tuple[Any, ...]:
+    shape: Sequence[IntLikeType], group: int, axis: int
+) -> tuple[IntLikeType, ...]:
     """Compute the explicit aux shape that mirrors QuACK's grouped store."""
     validate_local_reduce_selected_dim_divisible(shape, group, axis)
     result = list(shape)
@@ -494,7 +501,7 @@ def output_contraction_capture_supported(kind: str, is_boolean: bool) -> bool:
     return kind in ("scalar", "col") and not is_boolean
 
 
-def output_contraction_config_supported(config: Any, n: Any) -> bool:
+def output_contraction_config_supported(config: Any, n: _IntLike) -> bool:
     """Return whether a config has validated output-contraction store ownership.
 
     Keep the physical M/N orientation, one CTA per cluster along N, and require
@@ -519,7 +526,7 @@ FlexGemmLocalReduceGeometry = GemmReductionGeometry
 
 def flex_gemm_output_config_supported(
     config: Any,
-    n: Any,
+    n: _IntLike,
     local_reduce_geometries: Sequence[FlexGemmLocalReduceGeometry],
     output_contraction: FlexGemmOutputContraction | None,
     output_layout: FlexGemmOutputStorageLayout | None,

--- a/torch/_inductor/kernel/flex_gemm/lowering.py
+++ b/torch/_inductor/kernel/flex_gemm/lowering.py
@@ -26,7 +26,7 @@ from torch.utils._ordered_set import OrderedSet
 from ... import ir
 from ...ir import IRNode, TensorBox
 from ...lowering import empty_strided, process_subgraph_nodes, register_lowering
-from ...utils import ceildiv, has_free_symbols
+from ...utils import _IntLike, ceildiv, has_free_symbols
 from ...virtualized import V
 from .constraints import (
     FLEX_GEMM_CHUNKED_CONTIGUOUS_B_ERROR,
@@ -164,7 +164,7 @@ def infer_flex_gemm_epilogue_arg_kinds(
 def validate_flex_gemm_aux_outputs(
     gemm_op: torch._ops.OpOverload,
     aux_outputs: tuple[torch.fx.Node, ...],
-    output_size: list[Any],
+    output_size: Sequence[_IntLike],
 ) -> tuple[Any, ...]:
     """Validate QUACK aux-output support and return fake tensor metadata."""
     if not aux_outputs:
@@ -279,8 +279,8 @@ def filter_gemm_configs(
 
 def flex_gemm_config_keys(
     device,
-    m: int,
-    n: int,
+    m: _IntLike,
+    n: _IntLike,
     local_reduce_geometries: tuple[Any, ...],
     tuned: bool,
     output_contraction: FlexGemmOutputContraction | None = None,

--- a/torch/_inductor/kernel/gemm_epilogue_analysis.py
+++ b/torch/_inductor/kernel/gemm_epilogue_analysis.py
@@ -49,12 +49,12 @@ from torch._inductor.kernel.gemm_epilogue_utils import (
 from torch.utils._ordered_set import OrderedSet
 
 
-def _is_inferred_reshape_dim(value: Any) -> bool:
+def _is_inferred_reshape_dim(value: object) -> bool:
     """Return whether a reshape dimension is the literal inferred-size marker."""
     return isinstance(value, int) and value == -1
 
 
-def _kept_dim_matches_source(kept_size: Any, source_size: Any) -> bool:
+def _kept_dim_matches_source(kept_size: object, source_size: object) -> bool:
     return _is_inferred_reshape_dim(kept_size) or statically_known_equal(
         kept_size, source_size
     )
@@ -145,14 +145,14 @@ def _grouped_layout_matches_source_shape(
 
 
 def grouped_tensor_layout(
-    shape: Any, source_shape: Any | None = None
+    shape: object, source_shape: object | None = None
 ) -> GemmReductionGeometry | None:
     """Recognize grouped M/N geometry, specializing backed group dimensions."""
     shape = normalize_shape(shape)
     if not isinstance(shape, tuple):
         return None
     if len(shape) == 1 and isinstance(shape[0], (list, tuple, torch.Size)):
-        shape = normalize_shape(shape[0])
+        shape = tuple(shape[0])
     if source_shape is not None:
         source_shape = normalize_shape(source_shape)
         if isinstance(source_shape, tuple) and len(source_shape) == 2:

--- a/torch/_inductor/kernel/gemm_epilogue_utils.py
+++ b/torch/_inductor/kernel/gemm_epilogue_utils.py
@@ -2,7 +2,6 @@
 """Symbolic shape helpers shared by GEMM epilogue frontends."""
 
 from collections.abc import Sequence
-from typing import Any
 
 import sympy
 
@@ -15,12 +14,12 @@ from torch.fx.experimental.symbolic_shapes import (
 )
 
 
-def normalize_shape(shape: Any) -> Any:
+def normalize_shape(shape: object) -> object:
     """Canonicalize sequence-like shapes to tuples."""
     return tuple(shape) if isinstance(shape, (list, tuple, torch.Size)) else shape
 
 
-def guarded_int(value: Any) -> int | None:
+def guarded_int(value: object) -> int | None:
     """Return an integer after guarding backed symbolic values."""
     if isinstance(value, torch.fx.Node):
         value = value.meta.get("val")
@@ -33,22 +32,24 @@ def guarded_int(value: Any) -> int | None:
     return value if isinstance(value, int) else None
 
 
-def statically_known(expr: Any) -> bool:
+def statically_known(expr: object) -> bool:
     """Return whether a symbolic predicate is known true without adding guards."""
     if isinstance(expr, bool):
         return expr
     if isinstance(expr, sympy.Basic):
         return V.graph.sizevars.statically_known_true(expr)
+    if not isinstance(expr, torch.SymBool):
+        raise AssertionError(f"expected a boolean predicate, got {type(expr)}")
     return fx_statically_known_true(expr)
 
 
-def statically_known_equal(lhs: Any, rhs: Any) -> bool:
+def statically_known_equal(lhs: object, rhs: object) -> bool:
     """Return whether symbolic shape values are known equal without adding guards."""
     return statically_known(lhs == rhs)
 
 
 def statically_known_shape_equal(
-    actual_shape: Sequence[Any], expected_shape: Sequence[Any]
+    actual_shape: Sequence[object], expected_shape: Sequence[object]
 ) -> bool:
     """Compare possibly symbolic shape tuples without adding guards."""
     return len(actual_shape) == len(expected_shape) and all(

--- a/torch/_inductor/kernel/mm.py
+++ b/torch/_inductor/kernel/mm.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 import functools
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 import torch
@@ -25,7 +26,7 @@ from ..codegen.cutlass.gemm_template import CUTLASS2xGemmTemplate, CUTLASS3xGemm
 from ..codegen.rocm.ck_tile_universal_gemm_template import CKTileGemmTemplate
 from ..codegen.rocm.ck_universal_gemm_template import CKGemmTemplate
 from ..codegen.subgraph import SubgraphChoiceCaller, SubgraphTemplate
-from ..ir import Buffer, ChoiceCaller, is_triton, Layout
+from ..ir import Buffer, ChoiceCaller, IRNode, is_triton, Layout
 from ..kernel_inputs import MMKernelInputs
 from ..lowering import (
     fallback_handler,
@@ -43,6 +44,7 @@ from ..select_algorithm import (
     TritonTemplate,
 )
 from ..utils import (
+    _IntLike,
     _use_cutlass_for_op,
     ceildiv,
     use_aten_gemm_kernels,
@@ -862,19 +864,22 @@ epilogue_scaling_types = [ScalingType.TensorWise, ScalingType.RowWise]
 main_loop_scaling_types = [ScalingType.BlockWise1x128, ScalingType.BlockWise128x128]
 
 
-def _is_tensorwise_scaling(sz: Any) -> bool:
+def _is_tensorwise_scaling(sz: Sequence[_IntLike]) -> bool:
     return (len(sz) == 0) or all(
         V.graph.sizevars.statically_known_equals(d, 1) for d in sz
     )
 
 
-def _is_rowwise_scaling(sz: Any, transpose: bool) -> bool:
+def _is_rowwise_scaling(sz: Sequence[_IntLike], transpose: bool) -> bool:
     idx = 0 if transpose else -1
     return V.graph.sizevars.statically_known_equals(sz[idx], 1)
 
 
 def _is_blockwise1xTILESIZE_scaling(
-    sz: Any, tensor_sz: Any, tile_size: int, transpose: bool
+    sz: Sequence[_IntLike],
+    tensor_sz: Sequence[_IntLike],
+    tile_size: int,
+    transpose: bool,
 ) -> bool:
     lhs = 1 if transpose else 0
     rhs = 0 if transpose else 1
@@ -885,15 +890,17 @@ def _is_blockwise1xTILESIZE_scaling(
     )
 
 
-def _is_blockwise128x128_scaling(sz: Any, tensor_sz: Any) -> bool:
+def _is_blockwise128x128_scaling(
+    sz: Sequence[_IntLike], tensor_sz: Sequence[_IntLike]
+) -> bool:
     return V.graph.sizevars.statically_known_equals(
         sz[0], ceildiv(tensor_sz[0], 128)
     ) and V.graph.sizevars.statically_known_equals(sz[1], ceildiv(tensor_sz[1], 128))
 
 
 def is_desired_scaling(
-    t: Any,
-    scale_size: torch.Tensor,
+    t: IRNode,
+    scale_size: Sequence[_IntLike],
     scaling_type: ScalingType,
     transpose: bool = False,
 ) -> bool:
@@ -912,7 +919,7 @@ def is_desired_scaling(
             raise AssertionError(f"Unsupported scaling type {scaling_type}")
 
 
-def get_tile_size(scale_option) -> int:
+def get_tile_size(scale_option: ScalingType) -> int:
     match scale_option:
         case ScalingType.BlockWise128x128:
             return 128
@@ -925,10 +932,10 @@ def get_tile_size(scale_option) -> int:
 
 
 def get_scaling_options(
-    mat_a: Any,
-    mat_b: Any,
-    scale_a_size: torch.Tensor,
-    scale_b_size: torch.Tensor,
+    mat_a: IRNode,
+    mat_b: IRNode,
+    scale_a_size: Sequence[_IntLike],
+    scale_b_size: Sequence[_IntLike],
 ) -> tuple[ScalingType, ScalingType]:
     for scale_option_a, scale_option_b in scaling_pairs:
         if is_desired_scaling(

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -13,7 +13,7 @@ from .loop_body import LoopBody
 from .utils import dominated_nodes
 
 
-def val_expressable_in_32_bits(val: Any) -> bool:
+def val_expressable_in_32_bits(val: object) -> bool:
     if getattr(val, "is_Boolean", False):
         return True
 


### PR DESCRIPTION
Inductor threads a heterogeneous "maybe-symbolic scalar" through its shape
reasoning -- a dimension that may be a plain `int`, a `sympy.Expr`, a `SymInt`,
or an `fx.Node` carrying one of those in `meta["val"]`. The small predicate
helpers that consume it were all annotated `Any`, so none of their call sites
were checked at all.

Reading them, they are not all the same shape, and this PR gives each the type
that actually fits rather than applying one blanket replacement:

- Helpers whose body `isinstance`-branches over every case take `object`. That
  matches the four helpers of exactly this shape that already use `object`:
  `ir._is_static`, `codegen/cutlass/utils.is_static_int`,
  `codegen/triton.is_sympy_integer_like`, and
  `codegen/cutedsl/cutedsl_kernel._static_integer_expr`.
- Helpers whose body does arithmetic or ordering on the value take `_IntLike`
  (`int | sympy.Expr`). `object` would be wrong there: `%`, `*`, and `<=` are
  not defined on `object`, and reaching for a `cast` to keep the `object`
  annotation would have thrown away the checking the annotation is there to buy.
- Helpers whose body indexes and iterates a size take `Sequence[_IntLike]`, and
  the scaled-mm heuristic's scale arguments -- on which the body calls
  `get_size()` -- take `IRNode`. The one exception is
  `statically_known_shape_equal`, which is handed `FakeTensor.shape` and
  `.stride()`, so its elements can be `SymInt` rather than `sympy.Expr`; since
  it only forwards them to `statically_known_equal`, its element type is
  `object`.

Narrowing a predicate buys nothing if its own caller still launders the value
through `Any` first, so the callers are narrowed up to the frame where the value
enters: `is_flex_gemm_partial_reduction_shape` and
`flex_gemm_output_config_supported` in `kernel/flex_gemm/constraints.py`,
`validate_flex_gemm_aux_outputs` and `flex_gemm_config_keys` in
`kernel/flex_gemm/lowering.py`, and the `NodeInfo` fields that
`codegen/triton_combo_kernel._size_hint` reads (`codegen/simd.py`).

Doing that surfaced several annotations that were already wrong, not merely
loose:

- `statically_known_multiple`'s `divisor` was `int`, but both worlds reach it:
  a plain `int` from `group` and `swap_ab_alignment`, and a `sympy.Expr` from
  `aux_m` / `aux_n`, which originate in `ir.convert_shape_to_inductor`
  (`-> list[sympy.Expr]`). `_IntLike` is the only type covering all four call
  sites.
- `flex_gemm_config_keys` declared `m: int, n: int`. Its production caller
  passes `TensorBox.get_size()` elements, and `test_flex_gemm.py:1169` already
  passes a `sympy.Symbol` for `n`. The function's own `has_free_symbols((n,))`
  guard and the `guard_or_false(sympy.Eq(n % swap_ab_alignment, 0))` branch
  below it would both be dead code if `n` really were an `int`.

`kernel/flex_gemm/constraints.py` needs two unions rather than one, neither of
which is `_IntLike` alone:

- Its local-reduce validators
  (`validate_local_reduce_selected_dim_divisible`,
  `local_reduce_compressed_shape`) are reached only with `torch.Size`-derived
  tuples -- from real tensors at `runtime.py:306, 363, 520`, and from
  `tuple(FakeTensor.shape)` at `fx_cutedsl_codegen.py:271` ->
  `quack_reductions.py:246`. So they take `Sequence[IntLikeType]`
  (`int | SymInt`). Keeping `sympy.Expr` out of them is not cosmetic: sympy's
  `==`/`!=` are structural, so `Mod(s0, 8) != 0` is Python `True`, and a
  merely-unknown dimension would raise `LOCAL_REDUCE_DIVISIBLE_SHAPE_ERROR`
  rather than fall through the way `constraints.py:239-242` intends.
- `statically_known_multiple` sits below both those validators and the
  inductor-lowering callers, so it takes `_IntLike | IntLikeType`. `object` is
  not available for either, since the bodies need `%` and `//`.

`NodeInfo.numel` / `rnumel` become `_IntLike`, but both tiling dicts in the same
NamedTuple are deliberately left as they were, for two different reasons.

For `tiling_scores` the accurate value type is `int`
(`_SubSplit.split_scores: list[int]`, forced through `int(...)` at
`simd.py:5128`, zipped in by `create_tiling` without sympifying). `dict` is
invariant, so correcting it without also moving `SIMDKernel.__init__`,
`SIMDKernelFeatures`, `CandidateTiling`, `create_tiling`,
`ComboKernel.create_triton_kernel`, `FusedUserDefinedTritonKernel`, and
`BaseSchedulerNode.get_tiling` would leave that chain's declarations
contradicting each other -- a coherent follow-up, not this PR.

`tiling` is a tighter bind rather than the same one. Its producer and consumer
both already declare `dict[str, sympy.Expr]`, so matching them would cost
nothing and would make the third `_size_hint` call site checked -- but it would
not be true, since `create_tiling` also receives `tiling_factor` and the
`prod = 1` initializer, both plain `int`. The accurate `dict[str, _IntLike]` is
the one that collides with the chain. Since this PR's whole argument is that
these annotations should mean something, asserting an element type its own
evidence contradicts is the wrong trade, so `tiling` stays bare too.

Flagging the consequence rather than leaving it silent: `_size_hint`'s
narrowing is load-bearing as documentation at two of its three call sites, not
three.

Suggested reading order: `kernel/gemm_epilogue_utils.py` first, since it holds
the base predicates the rest call; then its callers in
`kernel/gemm_epilogue_analysis.py`, `kernel/flex_gemm/constraints.py`, and
`kernel/flex_gemm/lowering.py`; then the independent files (`kernel/mm.py`,
`heuristics/template/triton.py`, `optimize_indexing.py`, and
`codegen/triton_combo_kernel.py` together with the `codegen/simd.py` field
types it reads).

Three changes are not purely annotations.

`statically_known` used to fall through to
`symbolic_shapes.statically_known_true`, which accepts `bool | SymBool` and
raises `AssertionError` on anything else. With the parameter narrowed to
`object` that call no longer type checks. Rather than a `cast`, the fallthrough
now checks `isinstance(expr, torch.SymBool)` and raises `AssertionError` itself
-- the same outcome the callee already produced for the same inputs, but it
states the helper's real contract (`bool | sympy.Basic | SymBool`) in the code.
In practice the new branch is unreachable: every caller passes a comparison
result, which is a `bool` for concrete operands and for `sympy.Expr` `==`
(`Expr.__eq__` is structural), a `sympy` relational for `sympy.Expr` `<`/`<=`
and friends, and a `SymBool` for `SymInt` operands.

`grouped_tensor_layout` called `normalize_shape(shape[0])` inside a branch that
had already established `shape[0]` is a `list | tuple | torch.Size`, so
`normalize_shape` could only ever return `tuple(shape[0])` there. Calling
`tuple` directly keeps `shape` narrowed to a tuple for the rest of the function,
which is what the functions it is then handed to
(`_guard_grouped_reshape_group`, `_syntactic_grouped_tensor_layout`) already
declare they want.

`is_desired_scaling` and `get_scaling_options` in `kernel/mm.py` declared
`scale_size: torch.Tensor`, which was simply wrong -- every caller passes a size
(`scale_a_real.shape`, `scale_a.get_size()`) and the body indexes it and takes
its `len`. Those are now `Sequence[_IntLike]`.

One alternative considered and rejected: a single repo-wide alias for the
"maybe-symbolic scalar" union. These helpers do not agree on the union -- the
`isinstance`-branching ones genuinely accept `fx.Node`, the flex_gemm
local-reduce validators see only `int | SymInt`, and the rest see
`int | sympy.Expr` -- so one alias would have had to be the widest of the three
and would have re-hidden the distinction that motivated the change.

No `cast` and no new type-checker suppression were needed anywhere.

## Test Plan

No behavior change is intended, so the primary check is that the type checker
sees no new errors anywhere in the repo -- not just in the touched files, since
these are signature changes that propagate to callers:

```
pyrefly check   # with the patch, and again with the nine files reverted
```

Both runs report `65 errors (10,965 suppressed)`, and the sorted diagnostic
lists diff clean: zero net-new. Because the trailing count line is part of the
comparison, a newly *suppressed* error would also have shown up. Coverage of the
touched files was confirmed rather than assumed, by appending a deliberately
ill-typed function to `kernel/gemm_epilogue_utils.py` and checking the
whole-repo run reports it.

One caveat on how much that proves, since it cuts against this PR's own
motivation and is worth stating plainly. `pyrefly.toml:134` sets
`replace-imports-with-any = ["sympy.*", ...]`, so `sympy.Expr` resolves to `Any`
and `_IntLike` is effectively `int | Any`. I probed it directly -- a throwaway
`def f(x: _IntLike)` called with a `str` -- and it produces no diagnostic, while
the same probe against `IntLikeType` does. So the `_IntLike` annotations here
are accurate documentation that will begin checking if sympy stubs are ever
enabled, not checking today. The `object`, `IRNode`, `Sequence[object]`, and
`Sequence[IntLikeType]` narrowings are enforced now. `statically_known_multiple`'s
`_IntLike | IntLikeType` is the one exception on that side: the `_IntLike`
member absorbs everything, so the union documents rather than checks.

Lint, clean on all nine touched files:

```
lintrunner --take PYFMT,RUFF,PYREFLY,CODESPELL,FLAKE8 -a \
  torch/_inductor/codegen/simd.py \
  torch/_inductor/codegen/triton_combo_kernel.py \
  torch/_inductor/heuristics/template/triton.py \
  torch/_inductor/kernel/flex_gemm/constraints.py \
  torch/_inductor/kernel/flex_gemm/lowering.py \
  torch/_inductor/kernel/gemm_epilogue_analysis.py \
  torch/_inductor/kernel/gemm_epilogue_utils.py \
  torch/_inductor/kernel/mm.py \
  torch/_inductor/optimize_indexing.py
```

Tests, on a local build of this branch:

```
python test/inductor/test_optimize_indexing.py
python test/inductor/test_indexing.py
python test/inductor/test_flex_gemm.py
python test/inductor/test_torchinductor.py -k cpu
```

`test_optimize_indexing.py` is `OK` (15 run), `test_indexing.py` is `OK` (93
run, 22 skipped), and `test_flex_gemm.py` is `OK` (437 run, 369 GPU-skipped) --
the last includes `test_swap_ab_alignment_filters_tuned_and_explicit_configs`,
which is the test that pushes a `sympy.Symbol` through the corrected
`flex_gemm_config_keys` signature. The CPU inductor suite runs 1493 with 4
errors, all four `TritonMissing` from this box having no Triton install rather
than anything in the diff. The GPU-only suites that cover the rest of the touched code
(`test_flex_gemm.py`, `test_combo_kernels.py`, and the scaled-mm paths) are left
to CI.

This PR was authored with the assistance of an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo