### PR TITLE
[inductor] Fix flex flash captured-float test expectation

### DIFF
--- a/test/inductor/test_flex_flash.py
+++ b/test/inductor/test_flex_flash.py
@@ -2757,7 +2757,7 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
             self._flash_triton_dynamic(q, k, v)
 
     def test_captured_float_fails_with_dynamic(self):
-        """Test that captured Python float still fails as a CPU scalar tensor."""
+        """Test that a captured Python float is rejected under dynamic shapes."""
         val = 2.0
 
         def score_mod(score, _b, _h, _q, _k):
@@ -2766,7 +2766,14 @@ class TestFlexFlashDynamicShapes(InductorTestCase):
         compiled_fn = torch.compile(flex_attention, dynamic=True)
         q, k, v = create_test_tensors(seq_len=256, device="cuda", dtype=torch.float16)
 
-        with self.assertRaisesRegex(RuntimeError, r"captures a 0-dim CPU tensor"):
+        # The unspecialized float reaches the HOP either as a 0-dim CPU scalar
+        # tensor, rejected by the FLASH lowering, or as a SymFloat, rejected by
+        # the flex_attention operand check, depending on which tracer owns its
+        # `.item()` proxy. Both are valid rejections.
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"captures a 0-dim CPU tensor|can only be of.*but got.*SymFloat",
+        ):
             compiled_fn(
                 q, k, v, score_mod=score_mod, kernel_options={"BACKEND": "FLASH"}
             )


### PR DESCRIPTION
**Impact:** CI only (single flex_attention FLASH test)
**Risk:** low

## What
Broaden the `assertRaisesRegex` in `test_captured_float_fails_with_dynamic` to accept either of the two valid rejection messages a captured Python float can trigger under `dynamic=True`.

## Why
The test asserted only the "captures a 0-dim CPU tensor" error. Depending on which tracer owns the unspecialized float's `.item()` proxy, the value can instead reach the HOP as a `SymFloat` and get rejected by the flex_attention operand check ("can only be of ... but got ... SymFloat"). Both outcomes are correct rejections, so the test was flaky on the message text. The regex now matches either, and the docstring/comment explain the two paths.

Differential Revision: D117100365

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo