### PR TITLE
Fix stale dim=None docs for median/nanmedian

### DIFF
--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -2668,6 +2668,16 @@ class TestReductions(TestCase):
         self.assertEqual(a[:, ::2, :].median(-1)[0], torch.tensor([[0, 4], [6, 10]], device=device))
         self.assertEqual(a[:, ::2, :].nanmedian(-1)[0], torch.tensor([[0, 4], [6, 10]], device=device))
 
+    def test_median_dim_none_invalid_arguments(self, device):
+        # median.dim/nanmedian.dim only have an int dim overload (the Dimname
+        # overload was removed), so dim=None doesn't match any overload and
+        # should raise a plain argument-parsing error, not a Dimname-lookup
+        # RuntimeError.
+        t = torch.randn(2, 3, device=device)
+        for op in (torch.median, torch.nanmedian):
+            with self.assertRaisesRegex(TypeError, "argument 'dim' must be int, not NoneType"):
+                op(t, dim=None)
+
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/pull/138657 discovers a latent bug")
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -7360,7 +7360,7 @@ the outputs tensor having 1 fewer dimension than :attr:`input`.
 
 Args:
     {input}
-    {opt_dim_all_reduce}
+    {opt_dim_without_none}
     {opt_keepdim}
 
 Keyword args:
@@ -7417,7 +7417,7 @@ median of the non-``NaN`` elements. If all the elements in a reduced row are ``N
 
 Args:
     {input}
-    {opt_dim_all_reduce}
+    {opt_dim_without_none}
     {opt_keepdim}
 
 Keyword args:


### PR DESCRIPTION
torch.median(x, dim=None) and torch.nanmedian(x, dim=None) already raise a
clean TypeError ("argument 'dim' must be int, not NoneType") since the
Dimname overloads for median.dim/nanmedian.dim were removed by an earlier
"Remove named tensor" change. The originally reported RuntimeError
("Please look up dimensions by name, got: name = None.") no longer occurs
anywhere in the codebase.

What remained broken was the docs: torch/_torch_docs.py still used the
{opt_dim_all_reduce} template ("If None, all dimensions are reduced") for
the (values, indices)-returning dim overload of median/nanmedian, which is
false for an overload that requires an int dim and rejects None. Switch to
{opt_dim_without_none}, the template already used for the identical
overload shape in torch.max/torch.min (#156153).

Add a regression test asserting median/nanmedian raise TypeError for
dim=None.

Fixes #188087

Test Plan:

    python -m pytest test/test_reductions.py -k test_median_dim_none_invalid_arguments -v

