### PR TITLE
[CI] Read re-enabled issues with git log, not git cherry

### DIFF
--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -480,8 +480,13 @@ def parse_reenabled_issues(s: str | None) -> list[str]:
 def get_reenabled_issues(pr_body: str = "") -> list[str]:
     default_branch = f"origin/{os.environ.get('GIT_DEFAULT_BRANCH', 'main')}"
     try:
+        # Read commit subjects with git log instead of git cherry. CI checks out
+        # treeless (--filter=tree:0), and git cherry computes patch-ids, which
+        # may require multiple round-trip fetches.
         commit_messages = subprocess.check_output(
-            f"git cherry -v {default_branch}".split(" ")
+            ["git", "log", "--format=%s", f"{default_branch}..HEAD"],
+            env={**os.environ, "GIT_NO_LAZY_FETCH": "1"},
+            timeout=60,
         ).decode("utf-8")
     except Exception as e:
         warnings.warn(f"failed to get commit messages: {e}")

--- a/.github/scripts/test_filter_test_configs.py
+++ b/.github/scripts/test_filter_test_configs.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 import tempfile
 from typing import Any
 from unittest import main, mock, TestCase
@@ -12,6 +13,7 @@ from filter_test_configs import (
     filter_selected_test_configs,
     get_ghstack_below_count,
     get_labels,
+    get_reenabled_issues,
     mark_unstable_jobs,
     parse_reenabled_issues,
     perform_misc_tasks,
@@ -832,6 +834,31 @@ class TestConfigFilter(TestCase):
 
         pr_body = None
         self.assertEqual(parse_reenabled_issues(pr_body), [])
+
+    @mock.patch("subprocess.check_output")
+    def test_get_reenabled_issues(self, mocked_subprocess: Any) -> None:
+        mocked_subprocess.return_value = b"Fixes #123\nUnrelated commit\nCloses #456\n"
+        self.assertEqual(
+            get_reenabled_issues(pr_body="Resolves #789"), ["789", "123", "456"]
+        )
+
+        # Must stay on a command that reads commit objects only: git cherry
+        # computes patch-ids, which makes a treeless CI checkout (--filter=tree:0)
+        # lazily fetch every tree off the default branch.
+        args, kwargs = mocked_subprocess.call_args
+        self.assertEqual(args[0][:3], ["git", "log", "--format=%s"])
+        self.assertTrue(args[0][3].endswith("..HEAD"))
+        self.assertIsNotNone(kwargs.get("timeout"))
+
+    @mock.patch("subprocess.check_output")
+    def test_get_reenabled_issues_when_git_fails(self, mocked_subprocess: Any) -> None:
+        # A broken git lookup must not lose the issues named in the PR body.
+        for err in (
+            subprocess.CalledProcessError(128, "git"),
+            subprocess.TimeoutExpired("git", 60),
+        ):
+            mocked_subprocess.side_effect = err
+            self.assertEqual(get_reenabled_issues(pr_body="Fixes #123"), ["123"])
 
     def test_get_ghstack_below_count(self) -> None:
         # Not a ghstack body.


### PR DESCRIPTION
The *Check for keep-going label and re-enabled test issues* step intermittently stalls for tens of minutes. 
- [Example run, release branches are the worst-affected cohort](https://github.com/pytorch/pytorch/actions/runs/32523305318/job/96933135846)

It is not confined to release branches. Healthy p50 is ~0.5–2 min depending on cohort, but 19.2% of `pull` invocations exceed 10 minutes, additionally observed ghstack also heavily hit, with 1/4 of jobs 10+ minutes. The step then fails open: the exception is swallowed and `reenabled-issues` returns empty. The stall produces no result.

get_reenabled_issues scrapes commit subjects for "Fixes #NNNNN". It used `git cherry -v origin/main`, which computes patch-ids and so needs the trees of every commit off main. CI checks out treeless (--filter=tree:0), so each of those is lazily fetched from the promisor remote one round trip at a time -- observed stalling this step for 102 minutes before erroring and discarding the result anyway.

`git log --format=%s` reads commit objects only, which the clone always has. This is behavior-preserving, not just faster: git cherry -v prints subject lines, and prints both "+" and "-" entries, so the commits reaching the regex are exactly origin/main..HEAD. The patch-id work only selects the prefix character, which REENABLE_TEST_REGEX never reads. %B was rejected -- feeding commit bodies to the regex is a behavior change, not a fix.

Git command output test:
```
# git log --format=%s <upstream>..HEAD feeds the re-enable regex the same text
# git cherry -v <upstream> did -- including commits whose patch is already
# upstream, which is what people assume git cherry filters out.
rm -rf /tmp/rB && git init -q /tmp/rB && cd /tmp/rB

# upstream = stand-in for origin/main; the "PR" line is built on the default branch
echo a > f && git add f && git commit -qm "base" && git branch upstream
echo b > f && git add f && git commit -qm "Fixes #12345" && git branch feat

# upstream moves on, then the same patch lands there: same patch-id, new sha, so
# feat's commit is still inside upstream..feat
git checkout -q upstream && echo z > g && git add g && git commit -qm "upstream moved on"
git cherry-pick feat >/dev/null

echo "OLD: git cherry -v upstream feat"; git cherry -v upstream feat
echo "NEW: git log --format=%s upstream..feat"; git log --format=%s upstream..feat

# "-" = patch already upstream, printed anyway. Same commit set both ways; the
# patch-id work only picks the +/- prefix, which the regex never reads.
```

Authored with assistance from Claude.