### PR TITLE
[docs][xpu] Note that mem_get_info is unavailable on integrated GPUs

### DIFF
--- a/torch/xpu/memory.py
+++ b/torch/xpu/memory.py
@@ -206,6 +206,13 @@ def mem_get_info(device: Device = None) -> tuple[int, int]:
         tuple[int, int]: a tuple of two integers (free_memory, total_memory) in bytes.
             The first value is the free memory on the device (available across all processes and applications),
             The second value is the device's total hardware memory capacity.
+
+    .. note::
+        This query relies on the SYCL ``ext_intel_free_memory`` aspect. Devices
+        that do not expose it, integrated Intel GPUs in particular, raise a
+        :class:`RuntimeError` here. Check
+        ``torch.xpu.get_device_properties(device).is_integrated_gpu`` or guard
+        the call if your code must run on both integrated and discrete devices.
     """
     _lazy_init()
     device = _get_device_index(device, optional=True)


### PR DESCRIPTION
torch.xpu.mem_get_info() raises on integrated Intel GPUs. The underlying TORCH_CHECK in c10/xpu/XPUCachingAllocator.cpp requires the SYCL ext_intel_free_memory aspect, which integrated devices do not expose. The docstring that generates the public docs page said nothing about this, so users hit the RuntimeError with no explanation and no documented way to guard against it. The same investigation has been repeated across several issues (pytorch#164429, pytorch#162909, pytorch#159728, pytorch#164057, pytorch#159027, intel/torch-xpu-ops#1352, intel/torch-xpu-ops#1384).

This adds a note naming the aspect requirement and pointing at get_device_properties(device).is_integrated_gpu as a pre-check. The note also mentions guarding the call directly: is_integrated_gpu is backed by a different aspect (ext_oneapi_is_integrated_gpu), so it is a reliable proxy rather than the exact predicate, and a try/except is the precise alternative for code that must run on both device classes.

Docs only; no behaviour change.

Test Plan:

Docstring-only change, so it was verified by reading the docstring back out of the source rather than by importing torch (this checkout is unbuilt, and importing would read the installed wheel instead of the edited source):

```
python3 -c "
import ast
for n in ast.parse(open('torch/xpu/memory.py').read()).body:
    if isinstance(n, ast.FunctionDef) and n.name == 'mem_get_info':
        print(ast.get_docstring(n))
"
```

Lint:

```
lintrunner -a torch/xpu/memory.py
```

Applied no patches. It exits non-zero in an unbuilt tree because every finding is PYREFLY missing-attribute on torch._C.* (torch/_C/__init__.pyi is build-generated); the finding set is identical with and without this change, verified by re-running against a stashed working tree.

The documented behaviour was reproduced on the hardware, using the released 2.13.0+xpu wheel:

```
python -c "
import torch
p = torch.xpu.get_device_properties(0)
print(p.name, p.is_integrated_gpu)
torch.xpu.mem_get_info(0)
"
Intel(R) Graphics [0xb080] True
RuntimeError: The device (Intel(R) Graphics [0xb080]) doesn't support querying
the available free memory. You can file an issue at
https://github.com/pytorch/pytorch/issues to help us prioritize its
implementation.
```

Intel Arc B390 (Panther Lake Xe3, integrated), torch 2.13.0+xpu.

This change was prepared with the assistance of an AI coding assistant; the wording and the reproduction were reviewed by a human.
