### PR TITLE
Pre-reserve lastUsedBy map in nativert deallocation planning

### DIFF
--- a/torch/nativert/executor/ExecutionPlanner.cpp
+++ b/torch/nativert/executor/ExecutionPlanner.cpp
@@ -67,6 +67,7 @@ void ExecutionPlanner::generateDeallocationPlan(ExecutionPlan& plan) {
   size_t numNodes = nodes.size();
 
   std::unordered_map<ValueId, NodeIndex> lastUsedBy;
+  lastUsedBy.reserve(graph_.numValues());
 
   // Traverse from the last node to the first node
   // For each Value, find out which is the last node that uses it


### PR DESCRIPTION
**Impact:** nativert executor (`ExecutionPlanner::generateDeallocationPlan`)
**Risk:** low

## What
Reserve capacity for the `lastUsedBy` hash map up front using `graph_.numValues()`, so it doesn't rehash repeatedly as node inputs are inserted.

## Why
The map is built incrementally inside a nested loop over all nodes and their inputs, growing one entry at a time and rehashing as it goes. Its final size is bounded by the number of values in the graph, and since nearly every value is consumed as some node's input, `numValues()` is a tight (well within 2x) upper bound. Pre-allocating buckets removes the rehash churn during the insertion loop. Behavior is unchanged.