### PR TITLE
Fix grammar and typos in code comments and docstrings

### DIFF
--- a/torch/CMakeLists.txt
+++ b/torch/CMakeLists.txt
@@ -438,7 +438,7 @@ if(BUILD_ONEDNN_GRAPH)
 endif()
 
 if(${CMAKE_BUILD_TYPE} STREQUAL "RelWithAssert")
-   # Workaround numerous decret-without-a-gil warnings from JIT
+   # Workaround numerous decref-without-a-gil warnings from JIT
    # see https://github.com/pytorch/pytorch/issues/130073
    target_compile_definitions(torch_python PRIVATE "-DPYBIND11_NO_ASSERT_GIL_HELD_INCREF_DECREF")
 endif()

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1329,7 +1329,7 @@ def enable_activation_quantization(
                 continue
             node.meta["saved_for_quantization"] = True
             node.meta["dequant_type"] = node.meta["val"].dtype
-            # some of the fwd outputs and bwd inputs are not share the same object
+            # some of the fwd outputs and bwd inputs do not share the same object
             bwd_module_inputs[node.name].meta["saved_for_quantization"] = True
             bwd_module_inputs[node.name].meta["dequant_type"] = node.meta["val"].dtype
             should_perform_fp8_quant = True

--- a/torch/_guards.py
+++ b/torch/_guards.py
@@ -699,7 +699,7 @@ class GuardsSet:
         return list(self.source_to_guards[source])
 
     def remove_guards_with_source(self, source: Source) -> None:
-        """Delete all guards that contains a given source"""
+        """Delete all guards that contain a given source"""
         from ._dynamo.source import is_from_source
 
         self.inner = OrderedSet(
@@ -1228,7 +1228,7 @@ class TracingContext:
             except Exception as e:
                 # Prevent real_stack from getting attached
                 #
-                # The invariant is that if an Exception as real_stack, we've
+                # The invariant is that if an Exception has real_stack, we've
                 # appropriately attached a user stack and we no longer need to
                 # attach anything. Because we cannot conveniently interpose
                 # when an exception is thrown, we instead interpose everywhere

--- a/torch/_inductor/async_compile.py
+++ b/torch/_inductor/async_compile.py
@@ -459,7 +459,7 @@ class AsyncCompile:
           cases, like coordesc tuning and dynamic_scale_rblock, require us to reload the function
           in the parent lazily when we require it.
         - The AutotuneCache, if enabled, is constructed on each worker per triton config
-          and pickled by to us via `CachingAutotuner.save_cache_hook`.
+          and pickled to us via `CachingAutotuner.save_cache_hook`.
         """
         load_kernel = functools.partial(
             _load_triton_kernel_from_source, kernel_name, source_code

--- a/torch/_numpy/_ndarray.py
+++ b/torch/_numpy/_ndarray.py
@@ -543,7 +543,7 @@ class ndarray:
 
     @normalizer
     def fill(self, value: ArrayLike) -> None:
-        # Both Pytorch and NumPy accept 0D arrays/tensors and scalars, and
+        # Both PyTorch and NumPy accept 0D arrays/tensors and scalars, and
         # error out on D > 0 arrays
         self.tensor.fill_(value)
 

--- a/torch/autograd/graph.py
+++ b/torch/autograd/graph.py
@@ -255,7 +255,7 @@ def increment_version(tensor: torch.Tensor | Iterable[torch.Tensor]) -> None:
     This is to enable more accurate error checking within the autograd engine.
     It is already done automatically by PyTorch functions and within custom Function
     when mark_dirty() is called appropriately so you only need to call this explicitly
-    if you are doing inplace operation on the Tensor data in a way that Pytorch doesn't
+    if you are doing inplace operation on the Tensor data in a way that PyTorch doesn't
     know about. For example a custom kernel that reads the Tensor data_ptr and modifies
     the memory inplace based on this pointer. Can accept either a tensor, or a list of tensors.
 

--- a/torch/csrc/dynamo/eval_frame.c
+++ b/torch/csrc/dynamo/eval_frame.c
@@ -372,7 +372,7 @@ static PyObject* dynamo_eval_custom_code_impl(
   //  variables into frame and initializing cell variables
   //  3. CPython interpreter executes the code object
   //
-  // Dynamo hooks the 3th step: before executing the code object, Dynamo
+  // Dynamo hooks the 3rd step: before executing the code object, Dynamo
   // transforms the code object into a new code object. Then, the old frame is
   // not suitable for executing the new code. Therefore, Dynamo needs to
   // manually create and initialize a new frame to execute the new code. The

--- a/torch/csrc/jit/serialization/import_source.cpp
+++ b/torch/csrc/jit/serialization/import_source.cpp
@@ -53,7 +53,7 @@ struct TORCH_API ClassNamespaceValue : public SugaredValue {
 };
 
 // This value maps attributes CONSTANTS.c0 CONSTANTS.c1 to entries
-// in the 'constants' vector. This table is will be stored in a container format
+// in the 'constants' vector. This table will be stored in a container format
 // and given to the import_method when restoring the code.
 struct ConstantTableValue : public SugaredValue {
   explicit ConstantTableValue(const std::vector<at::IValue>* constants)

--- a/torch/csrc/jit/serialization/mobile_bytecode.fbs
+++ b/torch/csrc/jit/serialization/mobile_bytecode.fbs
@@ -216,7 +216,7 @@ table Module {
   operator_version:uint;
 
   // Size of ivalue that comes from the mobile module.
-  // Because the ivalues array above can also have ivalues that cames from
+  // Because the ivalues array above can also have ivalues that came from
   // the jit::Module that got its source attached to flatbuffer file.
   // this should be smaller than ivalues.size()
   mobile_ivalue_size:uint;

--- a/torch/csrc/jit/tensorexpr/ir_simplifier.h
+++ b/torch/csrc/jit/tensorexpr/ir_simplifier.h
@@ -516,7 +516,7 @@ class TORCH_API TermExpander : public PolynomialBase {
   // Expand MinTerms to a series of Min ops.
   ExprPtr mutate(const MinTermPtr& v) override;
 
-  // Expand RoundOff to it's component: Mul(Div(lhs, rhs), rhs).
+  // Expand RoundOff to its component: Mul(Div(lhs, rhs), rhs).
   ExprPtr mutate(const RoundOffPtr& v) override;
 
   // Eliminate zero length allocations.

--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -2764,7 +2764,7 @@ def _convert_to_params(
 
 
 def _is_truly_contiguous(x: Tensor) -> bool:
-    # Special case: Pytorch thinks that 1x1 channels_last convolution weights are
+    # Special case: PyTorch thinks that 1x1 channels_last convolution weights are
     # both contiguous and channels_last contiguous at the same time.
     # CuDNN does not agree though and refuses to select faster kernels.
     # It is the reason of having the extra check here.

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_param.py
@@ -685,7 +685,7 @@ class FSDPParam:
                 if isinstance(self.mesh_info, HSDPMeshInfo):
                     spec_placements.append(Replicate())
                 # Reuse the placement already computed for this DP shard dim
-                # so that we don't loss _StridedShard.
+                # so that we don't lose _StridedShard.
                 spec_placements.append(spmd_placements[i])
                 skip = len(dp_dim_names.shard_names) - 1
             elif name in replicate_names_set and isinstance(

--- a/torch/onnx/_internal/exporter/_building.py
+++ b/torch/onnx/_internal/exporter/_building.py
@@ -165,7 +165,7 @@ def _resolve_parameter_dtypes(
     #   b. Iterate over all named_inputs
     #   b0. Find the corresponding parameter in the signature
     #   b1. If the argument is a Python constant, skip.
-    #   b2. If the argument is a ir.Value, Bind {constraint: arg.type}.
+    #   b2. If the argument is an ir.Value, Bind {constraint: arg.type}.
     type_binding = {}
     for name, arg in named_inputs.items():
         param = signature.params_map[name]

--- a/torch/profiler/_cupti/monitor.py
+++ b/torch/profiler/_cupti/monitor.py
@@ -342,7 +342,7 @@ class CuptiMonitor:
         self._subscriber: int | None = None
         self._latency_enabled = False
         self._device_ts_enabled = False
-        # Layout state -- a function of registration, recomputed only when the
+        # Layout state -- a function of registration.
         # The fields enabled per kind on the subscriber (a function of the observer
         # field union, recomputed only on register/deregister, never per buffer). The
         # record byte layout is NOT tracked here -- each completed buffer carries


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Follow-up to the recent typo-fix passes, covering comments and docstrings under
torch/ that were missed: subject-verb agreement, misspellings such as
"decret"/"cames"/"3th", its/it's and lose/loss confusions, "Pytorch" capitalized
as "PyTorch", and an article fix. Also completes a truncated sentence in the
CUPTI monitor comment.

No functional changes; only comments, docstrings, and a FlatBuffers schema
comment are touched.

Test Plan: No code changes, so no tests were run beyond lint.

```
lintrunner -a
```

This change was authored with the assistance of an AI coding agent.

cc @EikanWang @jgong5 @voznesenskym @penguinwu @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98