### PR TITLE
Fix typos and grammar in comments and docstrings

### DIFF
--- a/torch/csrc/api/include/torch/data/datasets/shared.h
+++ b/torch/csrc/api/include/torch/data/datasets/shared.h
@@ -70,7 +70,7 @@ class SharedBatchDataset : public BatchDataset<
 };
 
 /// Constructs a new `SharedBatchDataset` by creating a
-/// `shared_ptr<UnderlyingDatase>`. All arguments are forwarded to
+/// `shared_ptr<UnderlyingDataset>`. All arguments are forwarded to
 /// `make_shared<UnderlyingDataset>`.
 template <typename UnderlyingDataset, typename... Args>
 SharedBatchDataset<UnderlyingDataset> make_shared_dataset(Args&&... args) {

--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -802,7 +802,7 @@ static PyObject* c_call_callback(
     PyObject* const* args,
     size_t nargsf,
     PyObject* kwnames) {
-  // The logic of this function is based on sys_defile_call_or_return defined
+  // The logic of this function is based on sys_profile_call_or_return defined
   // in https://github.com/python/cpython/blob/v3.12.5/Python/legacy_tracing.c
 
   PyThreadState* tstate = PyThreadState_GET();

--- a/torch/csrc/distributed/c10d/NCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/NCCLUtils.cpp
@@ -247,7 +247,7 @@ std::shared_ptr<NCCLComm> NCCLComm::split(
   if (color_id >= 0) {
     // Waiting for parent comm above still does not seem to guarantee the child
     // comm ptr is valid. Therefore we add a manual wait here for safety.
-    // TODO: remove this wait after NCCL fix the semantics.
+    // TODO: remove this wait after NCCL fixes the semantics.
     auto startTime = std::chrono::steady_clock::now();
     auto timeout = nccl_nonblocking_timeout();
     while (!comm->ncclComm_) {

--- a/torch/csrc/jit/passes/autocast.cpp
+++ b/torch/csrc/jit/passes/autocast.cpp
@@ -258,9 +258,9 @@ void updateAutocastEnabledCheck(Node* node, bool is_jit_enabled) {
 // scalar_type in forward graph. So inputs with mismatched scalar_type would
 // get the different dgrad.
 // While in JIT, autodiff doesn't do this, so implicit cast is not visible to
-// autodiff and backward dgrad for mismatched inputs would ended up with dgrads
+// autodiff and backward dgrad for mismatched inputs would end up with dgrads
 // in the same scalar_type. This has caused downstream operations, which
-// expects dgrad to be the same scalar type to throw mismatch error.
+// expect dgrad to be the same scalar type to throw mismatch error.
 //
 // TODO: Use the list from AMP eager directly
 void handleBlock(Block* block, AutocastContext initial_state) {

--- a/torch/csrc/jit/passes/onnx/peephole.cpp
+++ b/torch/csrc/jit/passes/onnx/peephole.cpp
@@ -378,10 +378,10 @@ static void pushPackingPastRnn(Block* b) {
       new_sizes.push_back(*oldType->sizes()[0]);
       new_sizes.push_back(*oldType->sizes()[1]);
       if (next->kind() == onnx::Reshape) {
-        // bidirection
+        // bidirectional
         new_sizes.push_back(rnn->i(attr::hidden_size) * 2);
       } else {
-        // unidirection
+        // unidirectional
         new_sizes.push_back(rnn->i(attr::hidden_size));
       }
       TensorTypePtr newType = TensorType::createContiguous(

--- a/torch/csrc/jit/serialization/unpickler.cpp
+++ b/torch/csrc/jit/serialization/unpickler.cpp
@@ -1089,7 +1089,7 @@ void Unpickler::rebuildTensorFromTypeV2() {
     }
     // This calls the function to rebuild the
     // base tensor.
-    // Eg. `rebuildTensor`, `rebuildSpareTensor`.
+    // Eg. `rebuildTensor`, `rebuildSparseTensor`.
     stack_.emplace_back(base_tensor_args);
     globals_[curr_globals_idx + 1]();
     stack_.emplace_back(pop(stack_));

--- a/torch/csrc/lazy/core/metrics.h
+++ b/torch/csrc/lazy/core/metrics.h
@@ -33,8 +33,8 @@ using MetricReprFn = std::function<std::string(double)>;
 class TORCH_API MetricData {
  public:
   // Creates a new MetricData object with the internal circular buffer storing
-  // max_samples samples. The repr_fn argument allow to specify a function which
-  // pretty-prints a sample value.
+  // max_samples samples. The repr_fn argument allows specifying a function
+  // which pretty-prints a sample value.
   MetricData(MetricReprFn repr_fn, size_t max_samples);
 
   // Returns the total values of all the samples being posted to this metric.

--- a/torch/csrc/utils/throughput_benchmark.h
+++ b/torch/csrc/utils/throughput_benchmark.h
@@ -91,7 +91,7 @@ class BenchmarkHelper {
   }
 
   // Destructor doesn't require the GIL because it is going to be executed on
-  // the PyThon thread
+  // the Python thread
   std::vector<Input> inputs_;
   Model model_;
   bool initialized_{false};
@@ -184,7 +184,7 @@ class C10_HIDDEN ThroughputBenchmark {
   // Equivalent to just running the model directly on the given input
   py::object runOnce(const py::args& args, const py::kwargs& kwargs);
 
-  // The main method of the class allows to perform a multi-threaded benchmark
+  // The main method of the class allows performing a multi-threaded benchmark
   // It returns BenchmarkExecutionStats object with a lot of useful statistics
   // about runtime execution. We can enhance this class in the future to provide
   // more information to the user

--- a/torch/distributed/_composable_state.py
+++ b/torch/distributed/_composable_state.py
@@ -26,7 +26,7 @@ def _get_module_state(module: nn.Module) -> _State | None:
 
     Given a ``module``, this API finds out if the module is also a ``_State``
     instance or if the module is managed by a composable API. If the module
-    is also a ``_State``, ``module`` will be casted to ``_State` and returned.
+    is also a ``_State``, ``module`` will be casted to ``_State`` and returned.
     If it is managed by a composable API, the corresponding ``_State`` will
     be returned.
     """

--- a/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
+++ b/torch/distributed/algorithms/_checkpoint/checkpoint_wrapper.py
@@ -94,7 +94,7 @@ class ActivationWrapper(torch.nn.Module, ABC):
         *args: Any,
     ) -> None:
         """
-        ``_pre_state_dict_hook` is called before ``self._load_from_state_dict()`` is called.
+        ``_pre_state_dict_hook`` is called before ``self._load_from_state_dict()`` is called.
 
         For ``checkpoint_wrapper``, it will add back the module
         prefix so that non-checkpointed modules can be loaded into
@@ -217,7 +217,7 @@ def checkpoint_wrapper(
             implementation, and is ignored if a custom ``checkpoint_fn`` is
             specified. Note that for implementations using reentrant checkpoint
             from ``torch.utils.checkpoint``, keyword arguments will only be
-            supported if ``checkpoint_impl`` is passed as ``CheckpointImpl.REENTRANT`.
+            supported if ``checkpoint_impl`` is passed as ``CheckpointImpl.REENTRANT``.
         checkpoint_fn (Optional[Callable]):
             Functional checkpoint implementation to use. If this is specified,
             it will be used over the default ``torch.utils.checkpoint.checkpoint``

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -326,7 +326,7 @@ def _get_module_fsdp_state_if_fully_sharded_module(
 
 class TrainingState(Enum):
     """
-    An enum that indicates the state of a ``FullyShardedDataParallel` instance.
+    An enum that indicates the state of a ``FullyShardedDataParallel`` instance.
     """
 
     IDLE = auto()
@@ -336,7 +336,7 @@ class TrainingState(Enum):
 
 class HandleTrainingState(Enum):
     """
-    An enum that indicates the state of a ``FlatParamHandle`.
+    An enum that indicates the state of a ``FlatParamHandle``.
     """
 
     IDLE = auto()

--- a/torch/distributed/fsdp/api.py
+++ b/torch/distributed/fsdp/api.py
@@ -249,7 +249,7 @@ class StateDictType(Enum):
 
     .. note::
         FSDP currently supports three types of ``state_dict``:
-            1. ``state_dict/load_state_dict`: this pair of APIs return and load
+            1. ``state_dict/load_state_dict``: this pair of APIs return and load
                the non-sharded, unflattened parameters. The semantics is the
                same as using DDP.
             2. ``_local_state_dict/_load_local_state_dict``: this pair of APIs return

--- a/torch/distributed/fsdp/fully_sharded_data_parallel.py
+++ b/torch/distributed/fsdp/fully_sharded_data_parallel.py
@@ -382,7 +382,7 @@ class FullyShardedDataParallel(nn.Module, _FSDPState):
             gradients are not reduced across ranks. This argument unifies with
             the existing ``ignored_modules`` argument, and we may deprecate
             ``ignored_modules`` soon. For backward compatibility, we keep both
-            ``ignored_states`` and `ignored_modules``, but FSDP only allows one
+            ``ignored_states`` and ``ignored_modules``, but FSDP only allows one
             of them to be specified as not ``None``.
         device_mesh (Optional[DeviceMesh]): DeviceMesh can be used as an alternative to
             process_group. When device_mesh is passed, FSDP will use the underlying process

--- a/torch/distributed/fsdp/wrap.py
+++ b/torch/distributed/fsdp/wrap.py
@@ -272,7 +272,7 @@ def lambda_auto_wrap_policy(
 ) -> bool:
     """
     A convenient auto wrap policy to wrap submodules based on an arbitrary user
-    function. If `lambda_fn(submodule) == True``, the submodule will be wrapped as
+    function. If ``lambda_fn(submodule) == True``, the submodule will be wrapped as
     a `wrapper_cls` unit.
 
     Return if a module should be wrapped during auto wrapping.

--- a/torch/distributed/nn/functional.py
+++ b/torch/distributed/nn/functional.py
@@ -81,7 +81,7 @@ def scatter(tensors, src=0, group=group.WORLD):
 
     Arguments:
         tensors (list[Tensor]): List of tensors to scatter on the source rank.
-            Receivers must pass ``None`.
+            Receivers must pass ``None``.
         src (int, optional): Source rank (default is 0).
         group (ProcessGroup, optional): The process group to work on.
 
@@ -415,7 +415,7 @@ class _AllGather(Function):
             gx = torch.empty_like(grad_outputs[rank])
             gx = _Reduce_Scatter.apply(ReduceOp.SUM, ctx.group, gx, *grad_outputs)
         else:
-            # As many backends doesn't support ReduceScatter, we use AlltoAll with .sum()
+            # As many backends don't support ReduceScatter, we use AlltoAll with .sum()
             # to emulate the ReduceScatter behavior
             tensor_list = [torch.empty_like(tensor) for tensor in grad_outputs]
             gxs = _AlltoAll.apply(ctx.group, tensor_list, *grad_outputs)

--- a/torch/optim/swa_utils.py
+++ b/torch/optim/swa_utils.py
@@ -174,7 +174,7 @@ class AveragedModel(Module):
     but using exponential weights instead of equal weights across iterations.
 
     AveragedModel class creates a copy of the provided module :attr:`model`
-    on the device :attr:`device` and allows to compute running averages of the
+    on the device :attr:`device` and allows computing running averages of the
     parameters of the :attr:`model`.
 
     Args:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Corrects misspellings, malformed RST inline-literal markers (single
closing backtick instead of double), and a few grammatical slips in
comments and docstrings across torch/csrc and torch/distributed.

No functional changes.

cc @mcarilli @ptrblck @leslie-fang-intel @jgong5