### PR TITLE
Fix grammar and typos in code comments and docstrings

### DIFF
--- a/torch/_inductor/bounds.py
+++ b/torch/_inductor/bounds.py
@@ -31,7 +31,7 @@ class BoundVars:
     It exposes the ranges of the nodes in the `bounds` variable
 
     Note. A current limitation of this analysis is that it just works on a per-loop basis.
-    We should be able to propagate the bounds between across the whole graph. This may benefit
+    We should be able to propagate the bounds across the whole graph. This may benefit
     the case a bounded variable is returned by a kernel and fed into another.
     """
 

--- a/torch/ao/quantization/qconfig.py
+++ b/torch/ao/quantization/qconfig.py
@@ -334,7 +334,7 @@ qconfig.
     * This qconfig uses signed activations and weights. Weights have added
     restrictions such as zero point is forced to be 0, making the weights
     symmetric, hence the name. And the 8-bit quantized values are
-    restricting to [-127, +127], excluding -128.
+    restricted to [-127, +127], excluding -128.
 
     * xnnpack has a requantization scale value restriction, 0x1p-32 <=
     requantization_scale < 256.0 where, `requantization_scale = (input_scale
@@ -518,7 +518,7 @@ _default_fp32_placeholder_qconfig = QConfig(
 
 _default_quint8_placeholder_qconfig = QConfig(
     activation=PlaceholderObserver.with_args(dtype=torch.quint8),
-    # operators using this qconfig doesn't have weights
+    # operators using this qconfig don't have weights
     weight=None,
 )
 

--- a/torch/distributed/_shard/api.py
+++ b/torch/distributed/_shard/api.py
@@ -296,7 +296,7 @@ def shard_module(module: nn.Module, plan: ShardingPlan, src_rank=0, process_grou
                 raise TypeError(
                     f"Only `ShardingSpec` is supported as output_plan for '{module_path}'"
                 )
-    # convert the output back to data parallel for the modules appears in
+    # convert the output back to data parallel for the modules that appear in
     # `return_local_tensor` of the plan, we will call `_collect_local_shard`
     # to collect the local tensor for output of modules
     if plan.return_local_tensor is not None:

--- a/torch/distributed/checkpoint/_experimental/checkpointer.py
+++ b/torch/distributed/checkpoint/_experimental/checkpointer.py
@@ -20,7 +20,7 @@ T = TypeVar("T")
 class Checkpointer(abc.ABC):
     """
     WARNING: This class is experimental, and is created to validate certain ideas,
-    and is subjected to change or deprecation and we strong discourage any usages at
+    and is subjected to change or deprecation and we strongly discourage any usages at
     this time.
 
     Abstract base class that defines the API for checkpointing.

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -308,7 +308,7 @@ def _check_cpu_rng_sync(
     state_ranks = defaultdict(set)
     for rank, state_tensor in enumerate(all_state_tensors):
         # Summarize the state vector of the CPU rng.
-        # The properties that matter most are (1) its different if there is a state difference, (2) its printable
+        # The properties that matter most are (1) it's different if there is a state difference, (2) it's printable
         # (see desync table- not viable to print whole state vector of size 5k)
         state_ranks[torch.hash_tensor(state_tensor).item()].add(rank)
     return state_ranks, "Generator state hash"

--- a/torch/distributed/elastic/timer/file_based_local_timer.py
+++ b/torch/distributed/elastic/timer/file_based_local_timer.py
@@ -134,7 +134,7 @@ class FileTimerClient(TimerClient):
 
     @_retry(max_retries=10, sleep_time=0.1)
     def _open_non_blocking(self) -> io.TextIOWrapper | None:
-        # The server may have crashed or may haven't started yet.
+        # The server may have crashed or may not have started yet.
         # In such case, calling open() in blocking model blocks the client.
         # To avoid such issue, open it in non-blocking mode, and an OSError will
         # be raised if the server is not there.
@@ -150,7 +150,7 @@ class FileTimerClient(TimerClient):
             ) from e
         with file:
             json_request = request.to_json()
-            # Write request with no greater than select.PIPE_BUF is guarantee to be atomic.
+            # Write request with no greater than select.PIPE_BUF is guaranteed to be atomic.
             if len(json_request) > select.PIPE_BUF:
                 raise RuntimeError(
                     f"FileTimerRequest larger than {select.PIPE_BUF} bytes "

--- a/torch/distributed/fsdp/_exec_order_utils.py
+++ b/torch/distributed/fsdp/_exec_order_utils.py
@@ -25,7 +25,7 @@ class _ExecOrderData:
     the pre-forward order on the *first* iteration for forward prefetching
     (which thus assumes static graph) and the post-forward order on *every*
     iteration for backward prefetching (which thus does not assume static
-    graph but may be provide an incorrect order).
+    graph but may provide an incorrect order).
     """
 
     def __init__(

--- a/torch/distributed/launch.py
+++ b/torch/distributed/launch.py
@@ -103,7 +103,7 @@ or
 
 .. versionchanged:: 2.0.0
 
-    The launcher will passes the ``--local-rank=<rank>`` argument to your script.
+    The launcher will pass the ``--local-rank=<rank>`` argument to your script.
     From PyTorch 2.0.0 onwards, the dashed ``--local-rank`` is preferred over the
     previously used underscored ``--local_rank``.
 

--- a/torch/distributed/pipelining/_backward.py
+++ b/torch/distributed/pipelining/_backward.py
@@ -19,7 +19,7 @@ def _get_grad_fn_or_grad_acc(t: torch.Tensor) -> Node | None:
     """
     Get the grad function or grad accumulator for a tensor.
 
-    Accumulate grad nodes are lazily created, so we need to a
+    Accumulate grad nodes are lazily created, so we need to create a
     dummy view in order to trigger its creation.
     """
     if t.requires_grad and t.grad_fn is None:

--- a/torch/distributed/rpc/backend_registry.py
+++ b/torch/distributed/rpc/backend_registry.py
@@ -181,7 +181,7 @@ def _tensorpipe_exchange_and_check_all_device_maps(
 
     _validate_device_maps(all_names, all_device_counts, all_device_maps, all_devices)
 
-    # passed all checked, construct reverse mapping and get list of devices handled by this agent
+    # passed all checks, construct reverse mapping and get list of devices handled by this agent
     reverse_device_maps = _create_reverse_mapping(my_name, all_names, all_device_maps)
     my_devices = _create_device_list(my_devices, my_device_maps, reverse_device_maps)
     return reverse_device_maps, my_devices

--- a/torch/distributed/rpc/functions.py
+++ b/torch/distributed/rpc/functions.py
@@ -24,7 +24,7 @@ def async_execution(fn):
         However, this does not mean this decorator has to be outmost one when
         defining a function. For example, when combined with ``@staticmethod``
         or ``@classmethod``, ``@rpc.functions.async_execution`` needs to be the
-        inner decorator to allow the target function be recognized as a static
+        inner decorator to allow the target function to be recognized as a static
         or class function. This target function can still execute asynchronously
         because, when accessed, the static or class method preserves attributes
         installed by ``@rpc.functions.async_execution``.

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -100,7 +100,7 @@ def freeze(
     Note:
         Because freezing makes weights constants and removes module hierarchy, `to` and other
         nn.Module methods to manipulate device or dtype no longer work. As a workaround,
-        You can remap devices by specifying `map_location` in `torch.jit.load`, however
+        you can remap devices by specifying `map_location` in `torch.jit.load`, however
         device-specific logic may have been baked into the model.
     """
     warnings.warn(

--- a/torch/nn/modules/adaptive.py
+++ b/torch/nn/modules/adaptive.py
@@ -34,7 +34,7 @@ class AdaptiveLogSoftmaxWithLoss(Module):
     frequency distribution approximately follows the `Zipf's law`_.
 
     Adaptive softmax partitions the labels into several clusters, according to
-    their frequency. These clusters may contain different number of targets
+    their frequency. These clusters may contain a different number of targets
     each.
     Additionally, clusters containing less frequent labels assign lower
     dimensional embeddings to those labels, which speeds up the computation.

--- a/torch/nn/utils/memory_format.py
+++ b/torch/nn/utils/memory_format.py
@@ -14,7 +14,7 @@ def convert_conv2d_weight_memory_format(
     r"""Convert ``memory_format`` of ``nn.Conv2d.weight`` to ``memory_format``.
 
     The conversion recursively applies to nested ``nn.Module``, including ``module``.
-    Note that it only changes the memory_format, but not the semantics of each dimensions.
+    Note that it only changes the memory_format, but not the semantics of each dimension.
     This function is used to facilitate the computation to adopt NHWC kernels, which
     provides considerable speed up for fp16 data on CUDA devices with compute capability >= 7.0
 
@@ -93,7 +93,7 @@ def convert_conv3d_weight_memory_format(
 ) -> _M:
     r"""Convert ``memory_format`` of ``nn.Conv3d.weight`` to ``memory_format``
     The conversion recursively applies to nested ``nn.Module``, including ``module``.
-    Note that it only changes the memory_format, but not the semantics of each dimensions.
+    Note that it only changes the memory_format, but not the semantics of each dimension.
     This function is used to facilitate the computation to adopt NHWC kernels, which
     provides considerable speed up for fp16 data on CUDA devices with compute capability >= 7.0
 

--- a/torch/onnx/_internal/exporter/_torchlib/ops/hop.py
+++ b/torch/onnx/_internal/exporter/_torchlib/ops/hop.py
@@ -76,7 +76,7 @@ def higher_order_cond(
     )
 
     # ONNX Runtime complains about duplicate output names if we don't rename them.
-    # But the doesn't seem to be an actual violation of SSA form without renaming.
+    # But there doesn't seem to be an actual violation of SSA form without renaming.
     for func_out, out in zip(true_func.outputs, then_node.outputs):
         out.name = f"{func_out.name}_{true_func.name}"
     for func_out, out in zip(false_func.outputs, else_node.outputs):
@@ -136,7 +136,7 @@ def higher_order_scan(
     )
 
     # ONNX Runtime complains about duplicate output names if we don't rename them.
-    # But the doesn't seem to be an actual violation of SSA form without renaming.
+    # But there doesn't seem to be an actual violation of SSA form without renaming.
     for func_out, out in zip(body_func.outputs, body_node.outputs):
         out.name = f"{func_out.name}_{body_func.name}"
 

--- a/torch/utils/_content_store.py
+++ b/torch/utils/_content_store.py
@@ -89,7 +89,7 @@ def hash_storage_kernel(x):
 
 
 # Returns a hex digest of the data in the storage.  Guaranteed to be
-# SHA-1 if stable_hash=True, otherwise it will consistent for a single
+# SHA-1 if stable_hash=True, otherwise it will be consistent for a single
 # process run but not necessarily across processes.
 def hash_storage(storage: torch.UntypedStorage, *, stable_hash: bool = False) -> str:
     import torch._dynamo


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Follow-up to the recent typo-fix passes, covering another set of
grammatical slips in comments and docstrings across inductor, ao
quantization, distributed, jit, nn, onnx, and torch/utils. All changes
are comment/docstring text only; no code or behavior is affected.

Test Plan: no functional change, so no tests were run beyond lint.

```
lintrunner -a
```

This PR was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo