### PR TITLE
Fix grammar and typos in code comments and docstrings

### DIFF
--- a/torch/_dynamo/repro/aoti.py
+++ b/torch/_dynamo/repro/aoti.py
@@ -558,7 +558,7 @@ p-value, which we leave for future work.
             default=accuracy,
             help="""\
 by default, when doing accuracy minification we will reject reductions which
-change the divergence from a floating point divergence to a integral/boolean
+change the divergence from a floating point divergence to an integral/boolean
 divergence.  This is because some operations like ReLU involve temporarily
 sharp boundaries that smooth out again afterwards; without requiring
 divergence on floating point, the minifier will often fixate on divergent

--- a/torch/_functorch/apis.py
+++ b/torch/_functorch/apis.py
@@ -182,7 +182,7 @@ def vmap(
         >>> batched_dot(x, y)  # tensor of size [2, 3]
 
     If the inputs are not batched along the first dimension, ``in_dims`` specifies
-    the dimension that each inputs are batched along as
+    the dimension that each input is batched along as
 
         >>> torch.dot  # [N], [N] -> []
         >>> batched_dot = torch.vmap(torch.dot, in_dims=1)  # [N, D], [N, D] -> [D]

--- a/torch/ao/nn/quantizable/modules/activation.py
+++ b/torch/ao/nn/quantizable/modules/activation.py
@@ -333,9 +333,9 @@ class MultiheadAttention(nn.MultiheadAttention):
               value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
             - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
               3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
-              S is the source sequence length. attn_mask ensure that position i is allowed to attend the unmasked
+              S is the source sequence length. attn_mask ensures that position i is allowed to attend the unmasked
               positions. If a BoolTensor is provided, positions with ``True``
-              is not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+              are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
               is provided, it will be added to the attention weight.
             - is_causal: If specified, applies a causal mask as attention mask. Mutually exclusive with providing attn_mask.
               Default: ``False``.

--- a/torch/csrc/api/include/torch/nn/utils/rnn.h
+++ b/torch/csrc/api/include/torch/nn/utils/rnn.h
@@ -28,7 +28,7 @@ inline Tensor invert_permutation(const Tensor& permutation) {
 ///     Instances of this class should never be created manually. They are meant
 ///     to be instantiated by functions like `pack_padded_sequence`.
 ///
-///     Batch sizes represent the number elements at each sequence step in
+///     Batch sizes represent the number of elements at each sequence step in
 ///     the batch, not the varying sequence lengths passed to
 ///     `pack_padded_sequence`.  For instance, given data ``abc`` and ``x``
 ///     the :class:`PackedSequence` would contain data ``axbc`` with

--- a/torch/csrc/autograd/profiler_kineto.cpp
+++ b/torch/csrc/autograd/profiler_kineto.cpp
@@ -563,7 +563,7 @@ void pushGlobalProfilingCallbacks(
           .scopes(scopes);
 
   // Arm the drain gate before the global callback and fire on any thread. If
-  // this a new profiling session, also bump the session generation.
+  // this is a new profiling session, also bump the session generation.
   // disableProfiler() relies on this to know it must drain in-flight callbacks.
   global_callback_session.activate(new_session);
 

--- a/torch/csrc/jit/api/module.h
+++ b/torch/csrc/jit/api/module.h
@@ -365,7 +365,7 @@ In both cases, we also recompile on new striding behavior, device, or dtype.
 
 Behavior - fallback functions & depth:
     When an input doesn't match the format required by the specialized compiled op, it will run
-    a fallback function. Fallback functions are recursively be compiled and specialized based
+    a fallback function. Fallback functions are recursively compiled and specialized based
     on the observed tensor shapes. Since compilation can be slow, the "depth" parameter is provided to
     limit the number of specializations that can be compiled, before giving up on recompiling and
     falling back to a completely un-fused, un-specialized implementation.

--- a/torch/csrc/jit/passes/specialize_autogradzero.cpp
+++ b/torch/csrc/jit/passes/specialize_autogradzero.cpp
@@ -361,7 +361,7 @@ struct AutogradZeroSpecializer {
           state_[n->output()] = State::Zero;
         } break;
         case prim::profile: {
-          // this a profile node on a tensor use
+          // this is a profile node on a tensor use
           // if we decided to specialize this graph
           // its input may have undefinedness info
           // otherwise it should be Unknown

--- a/torch/distributed/checkpoint/hf_storage.py
+++ b/torch/distributed/checkpoint/hf_storage.py
@@ -210,7 +210,7 @@ class HuggingFaceStorageReader(FileSystemReader):
 
         Args:
             path: directory where the checkpoint will be read from.
-            thread_count: Number of threads to use to read distributed checkpoint. Default to 1.
+            thread_count: Number of threads to use to read distributed checkpoint. Defaults to 1.
         """
 
         super().__init__(path=path)

--- a/torch/distributions/constraint_registry.py
+++ b/torch/distributions/constraint_registry.py
@@ -45,7 +45,7 @@ invariant.::
     coordinate-wise operation appropriate for algorithms like SVI. In
     contrast, ``biject_to(constraints.simplex)`` returns a
     :class:`~torch.distributions.transforms.StickBreakingTransform` that
-    bijects its input down to a one-fewer-dimensional space; this a more
+    bijects its input down to a one-fewer-dimensional space; this is a more
     expensive less numerically stable transform but is needed for algorithms
     like HMC.
 

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -186,7 +186,7 @@ def _register_stack_trace_anchor(fn: Callable[..., Any]) -> None:
 class TracerBase:
     graph: Graph
     record_stack_traces: bool = False
-    # When record_stack_traces is True, only reocrd stack traces
+    # When record_stack_traces is True, only record stack traces
     # with forward function names.
     # This helps when we want stack trace back to model code
     _record_forward_stack_traces_only: bool = False

--- a/torch/xpu/graphs.py
+++ b/torch/xpu/graphs.py
@@ -59,7 +59,7 @@ class XPUGraph(_XPUGraph):
             ``capture_end`` and the underlying modifiable command graph will be
             destroyed. Note that the executable command graph will not be
             instantiated at the end of ``capture_end`` in this
-            case. Instead, it will be instantiated via an explicit called
+            case. Instead, it will be instantiated via an explicit call
             to ``instantiate`` or automatically on the first call to
             ``replay`` if ``instantiate`` was not already called. Calling
             ``instantiate`` manually before ``replay`` is recommended to


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Corrects small grammatical errors and typos across a handful of comments
and docstrings: missing articles and verbs ("this a" -> "this is a", "the
number elements" -> "the number of elements"), subject-verb agreement in
the quantizable MultiheadAttention attn_mask description, "a integral" ->
"an integral", "reocrd" -> "record", and a few awkward phrasings such as
"recursively be compiled" and "an explicit called to".

No functional changes; documentation and comments only.

Test Plan: no code paths are affected, so no tests were run beyond lint.

```
lintrunner -a
```

This change was authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98