### PR TITLE
Fall back to unfused addmm when the cuBLASLt bias is under-aligned

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1608,6 +1608,13 @@ bool gemm_and_bias(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_EPILOGUE, epilogue);
 
   if (bias) {
+#ifndef USE_ROCM
+    // cuBLASLt has no alignment preference for the bias pointer (unlike A/B/C/D),
+    // so an under-aligned bias can pick a kernel that faults on it.
+    if (detail::getAlignment(reinterpret_cast<uintptr_t>(bias)) < 16) {
+      return false;
+    }
+#endif
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_BIAS_POINTER, bias);
   }
 


### PR DESCRIPTION
cuBLASLt's alignment preferences cover A, B, C, D but not the epilogue
bias pointer, so the heuristic can pick a kernel that assumes 16-byte
bias alignment. A bias that's a slice of a larger buffer need not be,
and the kernel then faults with "misaligned address". Check the bias
alignment and fall back to the unfused path (as gemm_and_bias already
does for other failure cases) when it's under 16 bytes.

Reproduced on a GTX 1660 Ti with CUDA 13.3.

Test Plan:
python test/test_matmul_cuda.py TestMatmulCudaCUDA.test_cublas_addmm_alignment_cuda_float16