### PR TITLE
[Testcase Refactoring][Quantization] Add hw_classification to test_top_level_apis.py

### DIFF
--- a/test/quantization/core/test_top_level_apis.py
+++ b/test/quantization/core/test_top_level_apis.py
@@ -2,10 +2,11 @@
 
 import torch
 import torch.ao.quantization
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class TestDefaultObservers(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     observers = [
         "default_affine_fixed_qparams_observer",
         "default_debug_observer",
@@ -62,6 +63,8 @@ class TestDefaultObservers(TestCase):
 
 
 class TestQConfig(TestCase):
+
+    hw_classification = HardwareClassification.GENERIC
 
     REDUCE_RANGE_DICT = {
         'fbgemm': (True, False),


### PR DESCRIPTION
## Change Background
As part of the hardware classification (hw_classification) initiative, test classes should be labeled with a HardwareClassification so that CI / OOT backends can filter test suites per hardware type via `--hw-classification`. This PR adds the `hw_classification` class attribute to the test classes in `test/quantization/core/test_top_level_apis.py`.

## Changes
1. Import `HardwareClassification` from `torch.testing._internal.common_utils`.
2. Add `hw_classification = HardwareClassification.GENERIC` to `TestDefaultObservers` and `TestQConfig`.

## Why no device decoupling / test class refactoring is needed
- The file has no hardcoded "cuda" string or CUDA device instances, no CUDA-specific decorators (e.g. `@onlyCUDA`), no device-branching logic, and only creates default CPU tensors (`torch.rand(...)` without a device argument). It has no accelerator dependency, so device decoupling is not required.
- Both test classes belong entirely to the same hardware category: pure CPU / device-agnostic logic without `instantiate_device_type_tests`. Per the GENERIC / ACCELERATOR / device-specific refactoring rules, an entire test class belonging to a single hardware category needs no split or rename. Both classes are labeled GENERIC directly.

## Self-test Verification
- Local build: N/A (Python-only change)
- Unit tests (CPU): PASSED - `python -m unittest test_top_level_apis.py -v` -> Ran 4 tests, OK (test_observers, test_fake_quants, test_reduce_range, test_reduce_range_qat)
- CUDA: not applicable - the tests contain no CUDA-specific code paths (pure CPU / GENERIC logic)
- Collected tests are unchanged: only class-level metadata is added; runtime behavior is identical when `--hw-classification` is not passed

## Risk
- No compatibility, data, or deployment risk. Only class-level metadata attributes are added; no runtime behavior changes.

## Labels
@pytorchbot label "module: tests/others"