### PR TITLE
Disable USE_FLASH_ATTENTION when no CUDA arch supports it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1060,6 +1060,22 @@ cmake_dependent_option(
   "(USE_CUDA AND NOT MSVC) OR USE_ROCM"
   OFF)
 
+# Flash Attention needs sm80+; disable it if no resolved arch reaches that.
+if(USE_FLASH_ATTENTION AND USE_CUDA AND NOT USE_ROCM)
+  string(REPLACE " " ";" _flash_attn_archs "${NVCC_FLAGS_EXTRA_readable}")
+  set(_flash_attn_has_sm80 OFF)
+  foreach(_arch IN LISTS _flash_attn_archs)
+    if(_arch MATCHES "^(sm|compute)_([0-9]+)" AND CMAKE_MATCH_2 GREATER_EQUAL 80)
+      set(_flash_attn_has_sm80 ON)
+    endif()
+  endforeach()
+  if(_flash_attn_archs AND NOT _flash_attn_has_sm80)
+    message(STATUS
+      "Disabling USE_FLASH_ATTENTION: it needs a CUDA architecture >= 8.0, "
+      "but the resolved CUDA architectures are '${_flash_attn_archs}'")
+    set(USE_FLASH_ATTENTION OFF)
+  endif()
+endif()
 
 IF(USE_ROCM AND ("gfx942" IN_LIST PYTORCH_ROCM_ARCH OR "gfx950" IN_LIST PYTORCH_ROCM_ARCH))
   message(WARNING "Setting USE_MSLK for gfx942/gfx950 to ON by default, doing ROCM build")


### PR DESCRIPTION
USE_FLASH_ATTENTION stays ON for any CUDA build regardless of target
architecture, even though the kernels need sm80+ and
can_use_flash_attention() rejects anything below that at runtime. A
build pinned to older hardware compiles the whole kernel set (the
largest source tree under third_party) into a binary that can never
use it.

Disable the option when none of the resolved CUDA architectures reach
sm80. Reuses NVCC_FLAGS_EXTRA_readable, which torch_cuda_get_nvcc_gencode_flag
already sets from TORCH_CUDA_ARCH_LIST earlier in configure - symbolic
names (Auto, Ampere, Hopper, ...) are already resolved to concrete
sm_NN/compute_NN entries there, so there's no need to re-parse
TORCH_CUDA_ARCH_LIST or special-case symbolic names.

Test Plan:
cmake -P checks against every resolved form NVCC_FLAGS_EXTRA_readable
takes (plain sm_NN, PTX compute_NN, arch-specific sm_90a, pre-sm80-only,
mixed, empty). Verified can_use_flash_attention() returns False on a
GTX 1660 Ti (sm75) build under the old behavior.
