### PR TITLE
[Inductor] Add shared FlyDSL scaled GEMM infrastructure

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -18,6 +18,7 @@ exclude_patterns = [
     'torch/_inductor/autoheuristic/artifacts/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/_vendor/**',
     'scripts/**',
     'test/generated_type_hints_smoketest.py',
@@ -134,6 +135,7 @@ include_patterns = [
 exclude_patterns = [
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/_vendor/**',
 ]
 command = [
@@ -1257,6 +1259,7 @@ exclude_patterns = [
     'torch/_inductor/autoheuristic/artifacts/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/utils/model_dump/preact.mjs',
     # Generated: mirrors the label names on GitHub verbatim
     'tools/linter/adapters/pytorch_labels.json',
@@ -1640,6 +1643,7 @@ exclude_patterns = [
     'torch/_inductor/autoheuristic/artifacts/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
     'torch/_vendor/**',
     'test/cpython/**',
     'test/test_torchfuzz_repros.py',
@@ -1854,6 +1858,7 @@ include_patterns = [
 exclude_patterns = [
     'torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**',
     'torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py',
+    'torch/_inductor/kernel/vendored_templates/flydsl/kernels/**',
 ]
 is_formatter = false
 

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -43,6 +43,7 @@ project-excludes = [
   "*/.*",
   "torch/_inductor/kernel/vendored_templates/cutedsl/kernels/**",
   "torch/_inductor/kernel/vendored_templates/cutedsl/dense_blockscaled_gemm_persistent.py",
+  "torch/_inductor/kernel/vendored_templates/flydsl/kernels/**",
   "torch/_vendor/quack/**",
 ]
 ignore-missing-imports = [

--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -295,6 +295,85 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(metadata["precompile_strides"], {"output": [1]})
         self.assertEqual(metadata["precompile_dtypes"], {"output": "float32"})
 
+    def test_precompile_metadata_preserves_four_input_layouts(self):
+        def fake_node(size, stride, dtype):
+            return SimpleNamespace(
+                get_size=lambda: list(size),
+                get_stride=lambda: list(stride),
+                get_dtype=lambda: dtype,
+            )
+
+        kernel = SimpleNamespace(
+            _template_signature_defined=True,
+            _template_input_args=[
+                (
+                    "arg_mat1",
+                    fake_node((64, 256), (256, 1), torch.float8_e4m3fn),
+                ),
+                (
+                    "arg_mat2",
+                    fake_node((256, 96), (1, 256), torch.float8_e4m3fn),
+                ),
+                (
+                    "arg_scale_a",
+                    fake_node((64, 8), (8, 1), torch.float8_e8m0fnu),
+                ),
+                (
+                    "arg_scale_b",
+                    fake_node((96, 8), (8, 1), torch.float8_e8m0fnu),
+                ),
+            ],
+        )
+        buffer = SimpleNamespace(
+            layout=SimpleNamespace(
+                size=[64, 96],
+                stride=[96, 1],
+                dtype=torch.bfloat16,
+                device=torch.device("cuda", 0),
+            )
+        )
+        scheduling = FlyDSLScheduling.__new__(FlyDSLScheduling)
+
+        with (
+            mock.patch("torch.cuda.is_available", return_value=False),
+            mock.patch.object(
+                FlyDSLScheduling,
+                "_build_flydsl_gpu_arch",
+                return_value="gfx950",
+            ),
+        ):
+            metadata = scheduling._build_precompile_metadata(kernel, buffer)
+
+        self.assertEqual(
+            metadata,
+            {
+                "precompile_shapes": {
+                    "mat1": [64, 256],
+                    "mat2": [256, 96],
+                    "scale_a": [64, 8],
+                    "scale_b": [96, 8],
+                    "output": [64, 96],
+                },
+                "precompile_strides": {
+                    "mat1": [256, 1],
+                    "mat2": [1, 256],
+                    "scale_a": [8, 1],
+                    "scale_b": [8, 1],
+                    "output": [96, 1],
+                },
+                "precompile_dtypes": {
+                    "mat1": "float8_e4m3fn",
+                    "mat2": "float8_e4m3fn",
+                    "scale_a": "float8_e8m0fnu",
+                    "scale_b": "float8_e8m0fnu",
+                    "output": "bfloat16",
+                },
+                "device_index": 0,
+                "device_capability": None,
+                "flydsl_gpu_arch": "gfx950",
+            },
+        )
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2660,6 +2660,7 @@ class TestImports(TestCase):
                            "torch.csrc",  # files here are devtools, not part of torch
                            "torch.include",  # torch include files after install
                            "torch._inductor.kernel.vendored_templates.cutedsl",  # depends on cutlass
+                           "torch._inductor.kernel.vendored_templates.flydsl",  # depends on flydsl
                            "torch._vendor.quack",  # depends on cutlass / cuda-python
                            "torch.profiler._cupti",  # depends on cupti-python
                            ]

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -635,11 +635,13 @@ multi_kernel_hints: list[int] = []
 
 
 # Specify candidate backends for gemm autotune.
-# Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, NVGEMM, CK, CKTILE, CPP.
+# Possible choices are combinations of: ATen, Triton, CUTLASS, CUTEDSL, FLYDSL,
+# NVGEMM, CK, CKTILE, CPP.
 # ATen: default Pytorch ATen kernels.
 # Triton: Triton templates defined in torch inductor (AMD and NVidia GPUs).
 # CUTLASS: Cutlass templates and kernels (NVidia GPUs only).
 # CUTEDSL: CuteDSL templates for Blackwell GPUs (NVidia SM100-SM109 only).
+# FLYDSL: FlyDSL templates for ROCm GPUs (experimental).
 # NVGEMM: NVIDIA Universal GEMM via cutlass.operators (NVidia GPUs only).
 # CK: Composable Kernel templates and kernels (AMD Instinct GPUs only).
 # CKTILE: Composable Kernel templates and kernels, new API (AMD Instinct GPUs only).
@@ -761,6 +763,8 @@ use_post_grad_passes: bool = True
 cutedsl_enable_autotuning: bool = (
     os.environ.get("CUTEDSL_ENABLE_AUTOTUNING", "0") == "1"
 )
+
+flydsl_enable_autotuning: bool = os.environ.get("FLYDSL_ENABLE_AUTOTUNING", "0") == "1"
 
 # DEPRECATED. This setting is ignored.
 autotune_fallback_to_aten = False

--- a/torch/_inductor/kernel/vendored_templates/flydsl/__init__.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored FlyDSL kernels used by TorchInductor templates."""

--- a/torch/_inductor/runtime/flydsl_cache.py
+++ b/torch/_inductor/runtime/flydsl_cache.py
@@ -1,0 +1,64 @@
+"""Helpers for routing FlyDSL JIT artifacts through TorchInductor's cache."""
+
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from torch._inductor.runtime.cache_dir_utils import cache_dir
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+_compiled_cache_lock = threading.Lock()
+
+
+def run_cached_flydsl(
+    jit_func: Any,
+    *compile_args: Any,
+    constexpr_param: Any,
+    compiler: Callable[..., Any],
+    dispatch_args: tuple[Any, ...],
+) -> Any:
+    """Cache a layout-dynamic FlyDSL dispatcher by constexpr param."""
+    cache_key = constexpr_param.__cache_signature__()
+    with _compiled_cache_lock:
+        compiled_cache = getattr(jit_func, "_compiled_cache", None)
+        if compiled_cache is None:
+            compiled_cache = {}
+            jit_func._compiled_cache = compiled_cache
+        compile_locks = getattr(jit_func, "_compiled_cache_locks", None)
+        if compile_locks is None:
+            compile_locks = {}
+            jit_func._compiled_cache_locks = compile_locks
+        compile_lock = compile_locks.setdefault(cache_key, threading.Lock())
+
+    with compile_lock:
+        compiled = compiled_cache.get(cache_key)
+        if compiled is None:
+            # FlyDSL compilation executes the first invocation using compile_args.
+            compiled = compiler(jit_func, *compile_args)
+            compiled_cache[cache_key] = compiled
+            return compiled
+
+    # Keep steady-state kernel launches outside all compilation locks.
+    compiled(*dispatch_args)
+    return compiled
+
+
+def _cache_dir() -> Path:
+    return Path(cache_dir()) / "flydsl_compile_cache"
+
+
+def ensure_flydsl_cache_dir() -> str:
+    """Put FlyDSL artifacts under the Inductor cache unless explicitly set."""
+    existing = os.environ.get("FLYDSL_RUNTIME_CACHE_DIR")
+    if existing:
+        return existing
+    resolved = str(_cache_dir())
+    os.environ["FLYDSL_RUNTIME_CACHE_DIR"] = resolved
+    return resolved

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -2244,6 +2244,38 @@ def ensure_nvmatmul_heuristics_available() -> bool:
         return False
 
 
+def use_flydsl_scaled_mm_template(layout: Layout) -> bool:
+    """Return whether a gfx950 FlyDSL scaled_mm template may be selected.
+
+    Shared by the MXFP8 and MXFP4 lowerings: nothing here depends on the input
+    dtype, only on the backend list, the runtime being importable, and the arch.
+    """
+    if not _use_autotune_backend("FLYDSL"):
+        return False
+    if torch.version.hip is None:
+        return False
+    if not (config.max_autotune or config.max_autotune_gemm):
+        return False
+    if not _use_template_for_gpu(layout, [torch.float16, torch.bfloat16]):
+        return False
+
+    from .codegen.flydsl import flydsl_utils
+
+    if not flydsl_utils.runtime_available():
+        return False
+
+    try:
+        device_index = layout.device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        props = torch.cuda.get_device_properties(device_index)
+        gcn_arch = getattr(props, "gcnArchName", "") or ""
+    except Exception:
+        log.debug("Could not determine ROCm arch for FlyDSL gate", exc_info=True)
+        return False
+    return gcn_arch.split(":", 1)[0] == "gfx950"
+
+
 def use_blackwell_cutedsl_grouped_mm(
     mat_a: Any,
     mat_b: Any,


### PR DESCRIPTION
## Series

Part 1 of 2.

- **This PR:** shared FlyDSL scaled GEMM infrastructure.
- **Follow-up:** https://github.com/pytorch/pytorch/pull/194506

This PR introduces the shared FlyDSL runtime cache, configuration,
availability helpers, vendored-template package support, and template
test coverage.
