### PR TITLE
[TestCase Refactoring] Refactor test_experimental.py. Move complex GPU tests to TestExperimentDevice

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -951,69 +951,6 @@ def forward(self, args_0):
         self.assertEqual(gm_results, foo(*test_inputs))
         self.assertEqual(len(GLOBAL_LIST), 1)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_dynamo_graph_capture_fx_graph_annotate_overlap_pass(self):
-        class DummyOp(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, x, scalar):
-                ctx.save_for_backward(x)
-                return x + scalar
-
-            @staticmethod
-            def backward(ctx, grad_out):
-                return grad_out, None
-
-        def mock_fw_compute(x):
-            with fx_traceback.annotate({"compute": 0}):
-                return DummyOp.apply(x, 10)
-
-        def mock_bw_comm(x):
-            with fx_traceback.annotate({"comm": 0}):
-                return DummyOp.apply(x, 20)
-
-        def mock_bw_compute(x):
-            return DummyOp.apply(x, 30)
-
-        class Model(torch.nn.Module):
-            def forward(self, fw_in, bw_in):
-                fw_out = mock_fw_compute(fw_in)
-                # bw_in blocks bw_out
-                bw_in = mock_bw_comm(bw_in)
-                bw_out = mock_bw_compute(bw_in)
-                return fw_out, bw_out
-
-        def input_fn():
-            inputs = (torch.rand(2, 128, device="cuda", requires_grad=True),)
-            grad_ins = (torch.rand(2, 128, device="cuda"),)
-            return (
-                *inputs,
-                *grad_ins,
-            )
-
-        with torch.device("meta"):
-            model = Model()
-
-        import torch.fx.traceback as fx_traceback
-
-        with fx_traceback.preserve_node_meta():
-            gm = dynamo_graph_capture_for_export(model)(*input_fn())
-
-        """
-        def forward(self, args_0, args_1):
-            _tree_leaf_0, _tree_leaf_1, _tree_leaf_2, = pytree.tree_leaves((self, args_0, args_1,))
-            L_fw_in_ , L_bw_in_ , = self._in_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2)
-            l_fw_in_ = L_fw_in_
-            l_bw_in_ = L_bw_in_
-            fwd_body_0 = self.fwd_body_0
-            bwd_body_0 = self.bwd_body_0
-            fw_out = torch.ops.higher_order.autograd_function_apply(fwd_body_0, bwd_body_0, l_fw_in_, args_tensor_mask = [True, False], non_differentiable_idx = []);  fwd_body_0 = bwd_body_0 = l_fw_in_ = None
-            bw_in = l_bw_in_ + 20;  l_bw_in_ = None
-            bw_out = bw_in + 30;  bw_in = None
-            return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2, fw_out, bw_out), self._out_spec)
-        """
-        test_inputs = input_fn()
-        self.assertEqual(gm(*test_inputs), model(*test_inputs))
-
     def test_dynamo_graph_capture_default_args(self):
         class Module(torch.nn.Module):
             def forward(self, x, y=1):
@@ -1141,194 +1078,6 @@ def forward(self, args_0):
         # Should raise TypeError when given a non-module, non-bound-method
         with self.assertRaises(TypeError):
             _restore_state_dict(lambda x: x, gm)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_aot_export_blockmask_with_new_closure(self):
-        import contextlib
-
-        from torch._export.utils import _compiling_state_context
-        from torch._functorch.aot_autograd import (
-            aot_compile_joint_with_descriptors,
-            aot_export_joint_with_descriptors,
-        )
-        from torch._guards import tracing as torch_tracing, TracingContext
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            res = 4
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        args = (torch.randn(2, 128, device="cuda"),)
-        gm = dynamo_graph_capture_for_export(Model())(*args)
-
-        fake_mode = gm.meta["fake_mode"]
-        with contextlib.ExitStack() as stack:
-            stack.enter_context(torch_tracing(TracingContext(fake_mode)))
-            stack.enter_context(_compiling_state_context())
-            stack.enter_context(fake_mode)
-
-            joint_with_descriptors = aot_export_joint_with_descriptors(
-                stack,
-                gm,
-                args=args,
-                kwargs={},
-                keep_inference_input_mutations=True,
-            )
-            self.assertExpectedInline(
-                str(joint_with_descriptors.graph_module.code).strip(),
-                """\
-def forward(self, arg0_1):
-    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
-    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
-    add = torch.ops.aten.add.Tensor(arange_3, 4);  arange_3 = None
-    view = torch.ops.aten.view.default(arange_2, [64, 1]);  arange_2 = None
-    ge = torch.ops.aten.ge.Tensor(view, add);  view = add = None
-    unsqueeze = torch.ops.aten.unsqueeze.default(ge, 0);  ge = None
-    expand = torch.ops.aten.expand.default(unsqueeze, [1, 64, 64]);  unsqueeze = None
-    unsqueeze_1 = torch.ops.aten.unsqueeze.default(expand, 0);  expand = None
-    expand_1 = torch.ops.aten.expand.default(unsqueeze_1, [1, 1, 64, 64]);  unsqueeze_1 = None
-    constant_pad_nd = torch.ops.aten.constant_pad_nd.default(expand_1, [0, 64, 0, 64], 0.0);  expand_1 = None
-    view_1 = torch.ops.aten.view.default(constant_pad_nd, [1, 1, 1, 128, 1, 128]);  constant_pad_nd = None
-    permute = torch.ops.aten.permute.default(view_1, [0, 1, 2, 4, 3, 5]);  view_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(permute, [-2, -1]);  permute = None
-    eq = torch.ops.aten.eq.Scalar(sum_1, 16384)
-    gt = torch.ops.aten.gt.Scalar(sum_1, 0)
-    lt = torch.ops.aten.lt.Scalar(sum_1, 16384);  sum_1 = None
-    bitwise_and = torch.ops.aten.bitwise_and.Tensor(gt, lt);  gt = lt = None
-    _to_copy = torch.ops.aten._to_copy.default(bitwise_and, dtype = torch.int8);  bitwise_and = None
-    _to_copy_1 = torch.ops.aten._to_copy.default(eq, dtype = torch.int8);  eq = None
-    _to_copy_2 = torch.ops.aten._to_copy.default(_to_copy, dtype = torch.int32);  _to_copy = None
-    sum_2 = torch.ops.aten.sum.dim_IntList(_to_copy_2, [-1])
-    sort = torch.ops.aten.sort.stable(_to_copy_2, stable = True, descending = True);  _to_copy_2 = None
-    getitem_1 = sort[1];  sort = None
-    _to_copy_3 = torch.ops.aten._to_copy.default(sum_2, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_2 = None
-    _to_copy_4 = torch.ops.aten._to_copy.default(getitem_1, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_1 = None
-    _to_copy_5 = torch.ops.aten._to_copy.default(_to_copy_1, dtype = torch.int32);  _to_copy_1 = None
-    sum_3 = torch.ops.aten.sum.dim_IntList(_to_copy_5, [-1])
-    sort_1 = torch.ops.aten.sort.stable(_to_copy_5, stable = True, descending = True);  _to_copy_5 = None
-    getitem_3 = sort_1[1];  sort_1 = None
-    _to_copy_6 = torch.ops.aten._to_copy.default(sum_3, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_3 = None
-    _to_copy_7 = torch.ops.aten._to_copy.default(getitem_3, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_3 = None
-    new_zeros = torch.ops.aten.new_zeros.default(_to_copy_4, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_2 = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
-    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_3 = torch.ops.aten.unsqueeze.default(_to_copy_3, 3)
-    lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_3);  arange_5 = unsqueeze_3 = None
-    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
-    where = torch.ops.aten.where.self(lt_1, _to_copy_4, scalar_tensor);  lt_1 = scalar_tensor = None
-    new_ones = torch.ops.aten.new_ones.default(new_zeros, [1, 1], pin_memory = False)
-    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_4 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
-    unsqueeze_5 = torch.ops.aten.unsqueeze.default(unsqueeze_4, -1);  unsqueeze_4 = None
-    view_2 = torch.ops.aten.view.default(new_ones, [1, 1, 1, 1]);  new_ones = None
-    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_6 = torch.ops.aten.unsqueeze.default(arange_7, -1);  arange_7 = None
-    unsqueeze_7 = torch.ops.aten.unsqueeze.default(unsqueeze_6, -1);  unsqueeze_6 = None
-    unsqueeze_8 = torch.ops.aten.unsqueeze.default(unsqueeze_7, -1);  unsqueeze_7 = None
-    index_put = torch.ops.aten.index_put.default(new_zeros, [unsqueeze_8, unsqueeze_5, unsqueeze_2, where], view_2);  new_zeros = unsqueeze_8 = unsqueeze_5 = unsqueeze_2 = where = view_2 = None
-    slice_3 = torch.ops.aten.slice.Tensor(index_put, 3, 0, 1);  index_put = None
-    transpose_1 = torch.ops.aten.transpose.int(slice_3, -2, -1);  slice_3 = None
-    sum_4 = torch.ops.aten.sum.dim_IntList(transpose_1, [-1])
-    sort_2 = torch.ops.aten.sort.stable(transpose_1, stable = True, descending = True);  transpose_1 = None
-    getitem_5 = sort_2[1];  sort_2 = None
-    _to_copy_8 = torch.ops.aten._to_copy.default(sum_4, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_4 = None
-    _to_copy_9 = torch.ops.aten._to_copy.default(getitem_5, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_5 = None
-    new_zeros_1 = torch.ops.aten.new_zeros.default(_to_copy_7, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_9 = torch.ops.aten.unsqueeze.default(arange_8, -1);  arange_8 = None
-    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_10 = torch.ops.aten.unsqueeze.default(_to_copy_6, 3)
-    lt_2 = torch.ops.aten.lt.Tensor(arange_9, unsqueeze_10);  arange_9 = unsqueeze_10 = None
-    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
-    where_1 = torch.ops.aten.where.self(lt_2, _to_copy_7, scalar_tensor_1);  lt_2 = scalar_tensor_1 = None
-    new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [1, 1], pin_memory = False)
-    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_11 = torch.ops.aten.unsqueeze.default(arange_10, -1);  arange_10 = None
-    unsqueeze_12 = torch.ops.aten.unsqueeze.default(unsqueeze_11, -1);  unsqueeze_11 = None
-    view_3 = torch.ops.aten.view.default(new_ones_1, [1, 1, 1, 1]);  new_ones_1 = None
-    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_13 = torch.ops.aten.unsqueeze.default(arange_11, -1);  arange_11 = None
-    unsqueeze_14 = torch.ops.aten.unsqueeze.default(unsqueeze_13, -1);  unsqueeze_13 = None
-    unsqueeze_15 = torch.ops.aten.unsqueeze.default(unsqueeze_14, -1);  unsqueeze_14 = None
-    index_put_1 = torch.ops.aten.index_put.default(new_zeros_1, [unsqueeze_15, unsqueeze_12, unsqueeze_9, where_1], view_3);  new_zeros_1 = unsqueeze_15 = unsqueeze_12 = unsqueeze_9 = where_1 = view_3 = None
-    slice_6 = torch.ops.aten.slice.Tensor(index_put_1, 3, 0, 1);  index_put_1 = None
-    transpose_3 = torch.ops.aten.transpose.int(slice_6, -2, -1);  slice_6 = None
-    sum_5 = torch.ops.aten.sum.dim_IntList(transpose_3, [-1])
-    sort_3 = torch.ops.aten.sort.stable(transpose_3, stable = True, descending = True);  transpose_3 = None
-    getitem_7 = sort_3[1];  sort_3 = None
-    _to_copy_10 = torch.ops.aten._to_copy.default(sum_5, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_5 = None
-    _to_copy_11 = torch.ops.aten._to_copy.default(getitem_7, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_7 = None
-    return (arg0_1, _to_copy_3, _to_copy_4, _to_copy_6, _to_copy_7, _to_copy_8, _to_copy_9, _to_copy_10, _to_copy_11)""",
-            )
-
-            compiled_fn = aot_compile_joint_with_descriptors(joint_with_descriptors)
-            # Shouldn't crash
-            self.assertIsNotNone(compiled_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_aot_export_blockmask_closure_spec_mismatch(self):
-        """BlockMasks with same closure structure produce equal TreeSpecs.
-
-        Closure values are extracted into pytree leaves, so two BlockMasks
-        whose mask_mod closures have the same code + structure but different
-        captured values have the same spec (values differ in the leaves, not
-        the context).  BlockMasks with different closure *structure* (e.g.
-        different code) must still produce different specs.
-        """
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn(offset):
-            def fn(b, h, q, k):
-                return q >= k + offset
-
-            return fn
-
-        mask_a = create_block_mask(
-            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-        mask_b = create_block_mask(
-            make_mask_fn(8), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-        mask_a_same = create_block_mask(
-            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-
-        _, spec_a = pytree.tree_flatten(mask_a)
-        _, spec_b = pytree.tree_flatten(mask_b)
-        _, spec_a_same = pytree.tree_flatten(mask_a_same)
-
-        # Same closure code + same captured value -> same spec
-        self.assertEqual(spec_a, spec_a_same)
-        # Same closure code + different captured value -> same spec
-        # (values are in the leaves, not the context)
-        self.assertEqual(spec_a, spec_b)
-
-        # Different closure *code* -> different spec
-        def different_mask(b, h, q, k):
-            return q > k
-
-        mask_c = create_block_mask(
-            different_mask, B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-        _, spec_c = pytree.tree_flatten(mask_c)
-        self.assertNotEqual(spec_a, spec_c)
 
     def _assert_blockmask_partial_replays_bound_tensors(self, make_mask_mod):
         from torch.fx.experimental.proxy_tensor import make_fx
@@ -1519,58 +1268,6 @@ def forward(self, arg0_1):
                 ),
             )
         )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_blockmask_and_masks_closure_extraction(self):
-        """and_masks closure tensors are recursively extracted into pytree leaves.
-
-        and_masks(fn1, fn2) returns a closure capturing a tuple of functions.
-        _extract_callable_pytree must recursively process these functions
-        (extracting their closure tensors) rather than emitting the functions
-        themselves as leaves, since functions are not supported export input
-        types.
-        """
-        from torch.nn.attention.flex_attention import (
-            and_masks,
-            BlockMask,
-            create_block_mask,
-        )
-
-        _register_blockmask_pytree()
-
-        def causal(b, h, q_idx, kv_idx):
-            return q_idx >= kv_idx
-
-        offset = torch.tensor(3, device="cuda")
-
-        def offset_mask(b, h, q_idx, kv_idx):
-            return q_idx >= kv_idx + offset
-
-        mask_mod = and_masks(causal, offset_mask)
-        block_mask = create_block_mask(
-            mask_mod, B=1, H=None, Q_LEN=128, KV_LEN=128, device="cuda"
-        )
-
-        leaves, spec = pytree.tree_flatten(block_mask)
-
-        # Present BlockMask tensor attrs + offset extracted from
-        # offset_mask's closure
-        n_regular = sum(
-            getattr(block_mask, attr) is not None for attr in BlockMask._TENSOR_ATTRS
-        )
-        self.assertEqual(len(leaves), n_regular + 1)
-        self.assertTrue(all(isinstance(l, torch.Tensor) for l in leaves))
-        self.assertIs(leaves[n_regular], offset)
-
-        # Leaves must all pass check_user_input_output
-        from torch._dynamo.eval_frame import check_user_input_output
-        from torch._dynamo.exc import UserErrorType
-
-        check_user_input_output(leaves, UserErrorType.INVALID_INPUT)
-
-        # Round-trip: unflatten should reconstruct a working mask_mod
-        restored = pytree.tree_unflatten(leaves, spec)
-        self.assertTrue(callable(restored.mask_mod))
 
     def test_aot_export_closure_buffer_mutation(self):
         class Mod(torch.nn.Module):
@@ -1885,6 +1582,305 @@ class TestExperimentDevice(TestCase):
         ):
             _dynamo_graph_capture_for_export(module)(x)
 
+
+    def test_dynamo_graph_capture_fx_graph_annotate_overlap_pass(self, device):
+        class DummyOp(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, scalar):
+                ctx.save_for_backward(x)
+                return x + scalar
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                return grad_out, None
+
+        def mock_fw_compute(x):
+            with fx_traceback.annotate({"compute": 0}):
+                return DummyOp.apply(x, 10)
+
+        def mock_bw_comm(x):
+            with fx_traceback.annotate({"comm": 0}):
+                return DummyOp.apply(x, 20)
+
+        def mock_bw_compute(x):
+            return DummyOp.apply(x, 30)
+
+        class Model(torch.nn.Module):
+            def forward(self, fw_in, bw_in):
+                fw_out = mock_fw_compute(fw_in)
+                # bw_in blocks bw_out
+                bw_in = mock_bw_comm(bw_in)
+                bw_out = mock_bw_compute(bw_in)
+                return fw_out, bw_out
+
+        def input_fn():
+            inputs = (torch.rand(2, 128, device=device, requires_grad=True),)
+            grad_ins = (torch.rand(2, 128, device=device),)
+            return (
+                *inputs,
+                *grad_ins,
+            )
+
+        with torch.device("meta"):
+            model = Model()
+
+        import torch.fx.traceback as fx_traceback
+
+        with fx_traceback.preserve_node_meta():
+            gm = dynamo_graph_capture_for_export(model)(*input_fn())
+
+        """
+        def forward(self, args_0, args_1):
+            _tree_leaf_0, _tree_leaf_1, _tree_leaf_2, = pytree.tree_leaves((self, args_0, args_1,))
+            L_fw_in_ , L_bw_in_ , = self._in_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2)
+            l_fw_in_ = L_fw_in_
+            l_bw_in_ = L_bw_in_
+            fwd_body_0 = self.fwd_body_0
+            bwd_body_0 = self.bwd_body_0
+            fw_out = torch.ops.higher_order.autograd_function_apply(fwd_body_0, bwd_body_0, l_fw_in_, args_tensor_mask = [True, False], non_differentiable_idx = []);  fwd_body_0 = bwd_body_0 = l_fw_in_ = None
+            bw_in = l_bw_in_ + 20;  l_bw_in_ = None
+            bw_out = bw_in + 30;  bw_in = None
+            return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2, fw_out, bw_out), self._out_spec)
+        """
+        test_inputs = input_fn()
+        self.assertEqual(gm(*test_inputs), model(*test_inputs))
+
+    def test_aot_export_blockmask_with_new_closure(self, device):
+        import contextlib
+
+        from torch._export.utils import _compiling_state_context
+        from torch._functorch.aot_autograd import (
+            aot_compile_joint_with_descriptors,
+            aot_export_joint_with_descriptors,
+        )
+        from torch._guards import tracing as torch_tracing, TracingContext
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            res = 4
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        args = (torch.randn(2, 128, device=device),)
+        gm = dynamo_graph_capture_for_export(Model())(*args)
+
+        fake_mode = gm.meta["fake_mode"]
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(torch_tracing(TracingContext(fake_mode)))
+            stack.enter_context(_compiling_state_context())
+            stack.enter_context(fake_mode)
+
+            joint_with_descriptors = aot_export_joint_with_descriptors(
+                stack,
+                gm,
+                args=args,
+                kwargs={},
+                keep_inference_input_mutations=True,
+            )
+            self.assertExpectedInline(
+                str(joint_with_descriptors.graph_module.code).strip(),
+                f"""\
+def forward(self, arg0_1):
+    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='{torch.device(device).type}', index=0), pin_memory = False)
+    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='{torch.device(device).type}', index=0), pin_memory = False)
+    add = torch.ops.aten.add.Tensor(arange_3, 4);  arange_3 = None
+    view = torch.ops.aten.view.default(arange_2, [64, 1]);  arange_2 = None
+    ge = torch.ops.aten.ge.Tensor(view, add);  view = add = None
+    unsqueeze = torch.ops.aten.unsqueeze.default(ge, 0);  ge = None
+    expand = torch.ops.aten.expand.default(unsqueeze, [1, 64, 64]);  unsqueeze = None
+    unsqueeze_1 = torch.ops.aten.unsqueeze.default(expand, 0);  expand = None
+    expand_1 = torch.ops.aten.expand.default(unsqueeze_1, [1, 1, 64, 64]);  unsqueeze_1 = None
+    constant_pad_nd = torch.ops.aten.constant_pad_nd.default(expand_1, [0, 64, 0, 64], 0.0);  expand_1 = None
+    view_1 = torch.ops.aten.view.default(constant_pad_nd, [1, 1, 1, 128, 1, 128]);  constant_pad_nd = None
+    permute = torch.ops.aten.permute.default(view_1, [0, 1, 2, 4, 3, 5]);  view_1 = None
+    sum_1 = torch.ops.aten.sum.dim_IntList(permute, [-2, -1]);  permute = None
+    eq = torch.ops.aten.eq.Scalar(sum_1, 16384)
+    gt = torch.ops.aten.gt.Scalar(sum_1, 0)
+    lt = torch.ops.aten.lt.Scalar(sum_1, 16384);  sum_1 = None
+    bitwise_and = torch.ops.aten.bitwise_and.Tensor(gt, lt);  gt = lt = None
+    _to_copy = torch.ops.aten._to_copy.default(bitwise_and, dtype = torch.int8);  bitwise_and = None
+    _to_copy_1 = torch.ops.aten._to_copy.default(eq, dtype = torch.int8);  eq = None
+    _to_copy_2 = torch.ops.aten._to_copy.default(_to_copy, dtype = torch.int32);  _to_copy = None
+    sum_2 = torch.ops.aten.sum.dim_IntList(_to_copy_2, [-1])
+    sort = torch.ops.aten.sort.stable(_to_copy_2, stable = True, descending = True);  _to_copy_2 = None
+    getitem_1 = sort[1];  sort = None
+    _to_copy_3 = torch.ops.aten._to_copy.default(sum_2, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_2 = None
+    _to_copy_4 = torch.ops.aten._to_copy.default(getitem_1, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_1 = None
+    _to_copy_5 = torch.ops.aten._to_copy.default(_to_copy_1, dtype = torch.int32);  _to_copy_1 = None
+    sum_3 = torch.ops.aten.sum.dim_IntList(_to_copy_5, [-1])
+    sort_1 = torch.ops.aten.sort.stable(_to_copy_5, stable = True, descending = True);  _to_copy_5 = None
+    getitem_3 = sort_1[1];  sort_1 = None
+    _to_copy_6 = torch.ops.aten._to_copy.default(sum_3, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_3 = None
+    _to_copy_7 = torch.ops.aten._to_copy.default(getitem_3, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_3 = None
+    new_zeros = torch.ops.aten.new_zeros.default(_to_copy_4, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
+    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{torch.device(device).type}', index=0), pin_memory = False)
+    unsqueeze_2 = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
+    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{torch.device(device).type}', index=0), pin_memory = False)
+    unsqueeze_3 = torch.ops.aten.unsqueeze.default(_to_copy_3, 3)
+    lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_3);  arange_5 = unsqueeze_3 = None
+    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{torch.device(device).type}', index=0))
+    where = torch.ops.aten.where.self(lt_1, _to_copy_4, scalar_tensor);  lt_1 = scalar_tensor = None
+    new_ones = torch.ops.aten.new_ones.default(new_zeros, [1, 1], pin_memory = False)
+    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{torch.device(device).type}', index=0))
+    unsqueeze_4 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
+    unsqueeze_5 = torch.ops.aten.unsqueeze.default(unsqueeze_4, -1);  unsqueeze_4 = None
+    view_2 = torch.ops.aten.view.default(new_ones, [1, 1, 1, 1]);  new_ones = None
+    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{torch.device(device).type}', index=0))
+    unsqueeze_6 = torch.ops.aten.unsqueeze.default(arange_7, -1);  arange_7 = None
+    unsqueeze_7 = torch.ops.aten.unsqueeze.default(unsqueeze_6, -1);  unsqueeze_6 = None
+    unsqueeze_8 = torch.ops.aten.unsqueeze.default(unsqueeze_7, -1);  unsqueeze_7 = None
+    index_put = torch.ops.aten.index_put.default(new_zeros, [unsqueeze_8, unsqueeze_5, unsqueeze_2, where], view_2);  new_zeros = unsqueeze_8 = unsqueeze_5 = unsqueeze_2 = where = view_2 = None
+    slice_3 = torch.ops.aten.slice.Tensor(index_put, 3, 0, 1);  index_put = None
+    transpose_1 = torch.ops.aten.transpose.int(slice_3, -2, -1);  slice_3 = None
+    sum_4 = torch.ops.aten.sum.dim_IntList(transpose_1, [-1])
+    sort_2 = torch.ops.aten.sort.stable(transpose_1, stable = True, descending = True);  transpose_1 = None
+    getitem_5 = sort_2[1];  sort_2 = None
+    _to_copy_8 = torch.ops.aten._to_copy.default(sum_4, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_4 = None
+    _to_copy_9 = torch.ops.aten._to_copy.default(getitem_5, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_5 = None
+    new_zeros_1 = torch.ops.aten.new_zeros.default(_to_copy_7, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
+    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{torch.device(device).type}', index=0), pin_memory = False)
+    unsqueeze_9 = torch.ops.aten.unsqueeze.default(arange_8, -1);  arange_8 = None
+    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{torch.device(device).type}', index=0), pin_memory = False)
+    unsqueeze_10 = torch.ops.aten.unsqueeze.default(_to_copy_6, 3)
+    lt_2 = torch.ops.aten.lt.Tensor(arange_9, unsqueeze_10);  arange_9 = unsqueeze_10 = None
+    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{torch.device(device).type}', index=0))
+    where_1 = torch.ops.aten.where.self(lt_2, _to_copy_7, scalar_tensor_1);  lt_2 = scalar_tensor_1 = None
+    new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [1, 1], pin_memory = False)
+    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{torch.device(device).type}', index=0))
+    unsqueeze_11 = torch.ops.aten.unsqueeze.default(arange_10, -1);  arange_10 = None
+    unsqueeze_12 = torch.ops.aten.unsqueeze.default(unsqueeze_11, -1);  unsqueeze_11 = None
+    view_3 = torch.ops.aten.view.default(new_ones_1, [1, 1, 1, 1]);  new_ones_1 = None
+    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{torch.device(device).type}', index=0))
+    unsqueeze_13 = torch.ops.aten.unsqueeze.default(arange_11, -1);  arange_11 = None
+    unsqueeze_14 = torch.ops.aten.unsqueeze.default(unsqueeze_13, -1);  unsqueeze_13 = None
+    unsqueeze_15 = torch.ops.aten.unsqueeze.default(unsqueeze_14, -1);  unsqueeze_14 = None
+    index_put_1 = torch.ops.aten.index_put.default(new_zeros_1, [unsqueeze_15, unsqueeze_12, unsqueeze_9, where_1], view_3);  new_zeros_1 = unsqueeze_15 = unsqueeze_12 = unsqueeze_9 = where_1 = view_3 = None
+    slice_6 = torch.ops.aten.slice.Tensor(index_put_1, 3, 0, 1);  index_put_1 = None
+    transpose_3 = torch.ops.aten.transpose.int(slice_6, -2, -1);  slice_6 = None
+    sum_5 = torch.ops.aten.sum.dim_IntList(transpose_3, [-1])
+    sort_3 = torch.ops.aten.sort.stable(transpose_3, stable = True, descending = True);  transpose_3 = None
+    getitem_7 = sort_3[1];  sort_3 = None
+    _to_copy_10 = torch.ops.aten._to_copy.default(sum_5, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_5 = None
+    _to_copy_11 = torch.ops.aten._to_copy.default(getitem_7, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_7 = None
+    return (arg0_1, _to_copy_3, _to_copy_4, _to_copy_6, _to_copy_7, _to_copy_8, _to_copy_9, _to_copy_10, _to_copy_11)""",
+            )
+
+            compiled_fn = aot_compile_joint_with_descriptors(joint_with_descriptors)
+            # Shouldn't crash
+            self.assertIsNotNone(compiled_fn)
+
+    def test_aot_export_blockmask_closure_spec_mismatch(self, device):
+        """BlockMasks with same closure structure produce equal TreeSpecs.
+
+        Closure values are extracted into pytree leaves, so two BlockMasks
+        whose mask_mod closures have the same code + structure but different
+        captured values have the same spec (values differ in the leaves, not
+        the context).  BlockMasks with different closure *structure* (e.g.
+        different code) must still produce different specs.
+        """
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn(offset):
+            def fn(b, h, q, k):
+                return q >= k + offset
+
+            return fn
+
+        mask_a = create_block_mask(
+            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
+        )
+        mask_b = create_block_mask(
+            make_mask_fn(8), B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
+        )
+        mask_a_same = create_block_mask(
+            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
+        )
+
+        _, spec_a = pytree.tree_flatten(mask_a)
+        _, spec_b = pytree.tree_flatten(mask_b)
+        _, spec_a_same = pytree.tree_flatten(mask_a_same)
+
+        # Same closure code + same captured value -> same spec
+        self.assertEqual(spec_a, spec_a_same)
+        # Same closure code + different captured value -> same spec
+        # (values are in the leaves, not the context)
+        self.assertEqual(spec_a, spec_b)
+
+        # Different closure *code* -> different spec
+        def different_mask(b, h, q, k):
+            return q > k
+
+        mask_c = create_block_mask(
+            different_mask, B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
+        )
+        _, spec_c = pytree.tree_flatten(mask_c)
+        self.assertNotEqual(spec_a, spec_c)
+
+    def test_blockmask_and_masks_closure_extraction(self, device):
+        """and_masks closure tensors are recursively extracted into pytree leaves.
+
+        and_masks(fn1, fn2) returns a closure capturing a tuple of functions.
+        _extract_callable_pytree must recursively process these functions
+        (extracting their closure tensors) rather than emitting the functions
+        themselves as leaves, since functions are not supported export input
+        types.
+        """
+        from torch.nn.attention.flex_attention import (
+            and_masks,
+            BlockMask,
+            create_block_mask,
+        )
+
+        _register_blockmask_pytree()
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        offset = torch.tensor(3, device=device)
+
+        def offset_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx + offset
+
+        mask_mod = and_masks(causal, offset_mask)
+        block_mask = create_block_mask(
+            mask_mod, B=1, H=None, Q_LEN=128, KV_LEN=128, device=device
+        )
+
+        leaves, spec = pytree.tree_flatten(block_mask)
+
+        # Present BlockMask tensor attrs + offset extracted from
+        # offset_mask's closure
+        n_regular = sum(
+            getattr(block_mask, attr) is not None for attr in BlockMask._TENSOR_ATTRS
+        )
+        self.assertEqual(len(leaves), n_regular + 1)
+        self.assertTrue(all(isinstance(l, torch.Tensor) for l in leaves))
+        self.assertIs(leaves[n_regular], offset)
+
+        # Leaves must all pass check_user_input_output
+        from torch._dynamo.eval_frame import check_user_input_output
+        from torch._dynamo.exc import UserErrorType
+
+        check_user_input_output(leaves, UserErrorType.INVALID_INPUT)
+
+        # Round-trip: unflatten should reconstruct a working mask_mod
+        restored = pytree.tree_unflatten(leaves, spec)
+        self.assertTrue(callable(restored.mask_mod))
 
 instantiate_device_type_tests(TestExperimentDevice, globals(), except_for="cpu")
 

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -28,8 +28,9 @@ from torch.export.graph_signature import OutputKind
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import (
     IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED,
+    instantiate_device_type_tests,
 )
-from torch.testing._internal.common_utils import TEST_CUDA
+from torch.testing._internal.common_utils import HardwareClassification, TEST_CUDA
 from torch.utils import _pytree as pytree
 
 
@@ -91,6 +92,8 @@ class GlobalContext:
 
 @unittest.skipIf(not torch._dynamo.is_dynamo_supported(), "dynamo isn't supported")
 class TestExperiment(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_joint_basic(self) -> None:
         class Module(torch.nn.Module):
             def __init__(self) -> None:
@@ -193,48 +196,6 @@ def forward(self, p_linear_weight, p_linear_bias, c_lifted_tensor_0, x):
     return (div, permute_3, view_3)""",
         )
 
-    def _test_export_blockmask_with_mask_fn(self, make_mask_fn):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        class Model(torch.nn.Module):
-            def __init__(self, mask_fn_factory):
-                super().__init__()
-                self.mask_fn_factory = mask_fn_factory
-
-            def forward(self, x):
-                mask_fn = self.mask_fn_factory()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model(make_mask_fn)
-
-        out_eager, mask_eager = module(x)
-
-        compiled = _dynamo_graph_capture_for_export(module)(x)
-        out_compiled, mask_compiled = compiled(x)
-
-        self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(
-            mask_eager.mask_mod(1, 1, 64, 64),
-            mask_compiled.mask_mod(1, 1, 64, 64),
-        )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask(self):
-        def make_mask_fn():
-            res = 4
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
 
     def test_export_with_default_kwargs(self):
         class FunctionalWrapper(torch.nn.Module):
@@ -270,188 +231,6 @@ def forward(self, args_0):
     out = torch._C._nn.linear(l_args_0_, l_self_modules_module_parameters_weight_, l_self_modules_module_parameters_bias_);  l_args_0_ = l_self_modules_module_parameters_weight_ = l_self_modules_module_parameters_bias_ = None
     return self._dynamo_bytecode_unflatten((out,), _fn_args)""",
         )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_mutated_closure(self):
-        def make_mask_fn():
-            res = 1
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            res = 4  # mutation after function definition
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_with_containers(self):
-        def make_mask_fn():
-            offsets = [1, 2, 3]
-            config = {"base": 4, "nested": {"scale": 2}}
-
-            def fn(b, h, q, k):
-                return q >= k + config["base"] + sum(offsets)
-
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_triple_nested(self):
-        def make_mask_fn():
-            a = 1
-
-            def level1():
-                b = 2
-
-                def level2():
-                    c = 3
-
-                    def fn(bx, h, q, k):
-                        return q >= k + a + b + c
-
-                    return fn
-
-                return level2()
-
-            return level1()
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_self_recursive(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            # Self-referential: fn captures itself through the closure
-            def fn(b, h, q, k):
-                _ = fn  # self-reference
-                return q >= k + 4
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_tensor(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            tensor = torch.ones(2, 2)
-
-            def fn(b, h, q, k):
-                _ = fn
-                return q >= k + 4 + tensor.sum()
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_unsupported_class_instance(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        class MaskConfig:
-            def __init__(self, offset):
-                self.offset = offset
-
-        def make_mask_fn():
-            cfg = MaskConfig(offset=5)
-
-            def fn(b, h, q, k):
-                return q >= k + cfg.offset
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_mutually_recursive(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            # Create mutually recursive closures: fn_a references fn_b, fn_b references fn_a
-            # This is non-constructible because we cannot serialize mutually recursive closures
-            def fn_a(b, h, q, k):
-                _ = fn_b  # reference to fn_b
-                return q >= k
-
-            def fn_b(b, h, q, k):
-                _ = fn_a  # reference to fn_a
-                return q >= k + 1
-
-            return fn_a
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
 
     @unittest.skipUnless(
         IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
@@ -1883,6 +1662,231 @@ def forward(self, arg0_1):
                 eager_buf,
                 msg=lambda msg: f"{msg}\n{label}: buffer mutation mismatch",
             )
+
+
+@unittest.skipIf(not torch._dynamo.is_dynamo_supported(), "dynamo isn't supported")
+class TestExperimentDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def _test_export_blockmask_with_mask_fn(self, make_mask_fn, device):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        class Model(torch.nn.Module):
+            def __init__(self, mask_fn_factory):
+                super().__init__()
+                self.mask_fn_factory = mask_fn_factory
+
+            def forward(self, x):
+                mask_fn = self.mask_fn_factory()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device=device)
+        module = Model(make_mask_fn)
+
+        out_eager, mask_eager = module(x)
+
+        compiled = _dynamo_graph_capture_for_export(module)(x)
+        out_compiled, mask_compiled = compiled(x)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(
+            mask_eager.mask_mod(1, 1, 64, 64),
+            mask_compiled.mask_mod(1, 1, 64, 64),
+        )
+
+    def test_export_blockmask(self, device):
+        def make_mask_fn():
+            res = 4
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+    def test_export_blockmask_mutated_closure(self, device):
+        def make_mask_fn():
+            res = 1
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            res = 4  # mutation after function definition
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+    def test_export_blockmask_closure_with_containers(self, device):
+        def make_mask_fn():
+            offsets = [1, 2, 3]
+            config = {"base": 4, "nested": {"scale": 2}}
+
+            def fn(b, h, q, k):
+                return q >= k + config["base"] + sum(offsets)
+
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+    def test_export_blockmask_closure_triple_nested(self, device):
+        def make_mask_fn():
+            a = 1
+
+            def level1():
+                b = 2
+
+                def level2():
+                    c = 3
+
+                    def fn(bx, h, q, k):
+                        return q >= k + a + b + c
+
+                    return fn
+
+                return level2()
+
+            return level1()
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+    def test_export_blockmask_closure_self_recursive(self, device):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            # Self-referential: fn captures itself through the closure
+            def fn(b, h, q, k):
+                _ = fn  # self-reference
+                return q >= k + 4
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device=device)
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+    def test_export_blockmask_closure_tensor(self, device):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            tensor = torch.ones(2, 2)
+
+            def fn(b, h, q, k):
+                _ = fn
+                return q >= k + 4 + tensor.sum()
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device=device)
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+    def test_export_blockmask_closure_unsupported_class_instance(self, device):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        class MaskConfig:
+            def __init__(self, offset):
+                self.offset = offset
+
+        def make_mask_fn():
+            cfg = MaskConfig(offset=5)
+
+            def fn(b, h, q, k):
+                return q >= k + cfg.offset
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device=device)
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+    def test_export_blockmask_closure_mutually_recursive(self, device):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            # Create mutually recursive closures: fn_a references fn_b, fn_b references fn_a
+            # This is non-constructible because we cannot serialize mutually recursive closures
+            def fn_a(b, h, q, k):
+                _ = fn_b  # reference to fn_b
+                return q >= k
+
+            def fn_b(b, h, q, k):
+                _ = fn_a  # reference to fn_a
+                return q >= k + 1
+
+            return fn_a
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device=device)
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+
+instantiate_device_type_tests(TestExperimentDevice, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
---
***Refactoring test_experimental.py across 3 PRs. This is the second PR.***

Move complex GPU tests to TestExperimentDevice

Changes
---
- Move 4 GPU-dependent tests from TestExperiment to TestExperimentDevice:
   - test_dynamo_graph_capture_fx_graph_annotate_overlap_pass
   - test_aot_export_blockmask_with_new_closure
   - test_aot_export_blockmask_closure_spec_mismatch
   - test_blockmask_and_masks_closure_extraction
- Replace hardcoded device="cuda" with device parameter; 
- remove @skipIf(not TEST_CUDA) decorators.

> **Refactored into 3 PRs. This is the second PR, which moves 4 complex GPU-dependent tests from TestExperiment to TestExperimentDevice.
Dependency Chain:**
- #194514 depends on #194513 and #194512
- #194513 (this PR) depends on #194512

Test Plan
---
```Bash
python -c "import ast; ast.parse(open('test_experimental.py').read())"
python -m pytest -rA -v test_experimental.py
python test_experimental.py -v -k TestExperimentDevice
python test_experimental.py --hw-classification GENERIC -v -k TestExperiment
```
