### PR TITLE
Bypass the FakeTensor dispatch cache for ScriptObject arguments

### DIFF
--- a/test/test_fake_tensor.py
+++ b/test/test_fake_tensor.py
@@ -2,6 +2,7 @@
 # ruff: noqa: F841
 
 
+import operator
 import contextlib
 import copy
 import dataclasses
@@ -4265,6 +4266,53 @@ class FakeTensorDispatchCache(TestCase):
         FakeTensorMode.cache_clear()
         ep.run_decompositions({})
         self.assertBypasses("unrepresented symbol in output", 2)
+
+
+
+    def test_cache_key_rejects_uncomparable_member(self):
+        """_DispatchCacheKey compares key tuples, so an un-comparable member breaks lookup.
+
+        Building and hashing the key succeed -- objects that hash by identity are accepted
+        -- and the failure surfaces only when two keys land in the same bucket and __eq__
+        compares their contents. Hence the symptom is a confusing intermittent error deep
+        inside dispatch rather than a clear one at insertion.
+        """
+        from torch._subclasses.fake_tensor import _DispatchCacheKey
+
+        class _NoEq:
+            __hash__ = object.__hash__
+
+            def __eq__(self, other):
+                raise NotImplementedError("'__eq__' is not implemented for _NoEq")
+
+        key_a = _DispatchCacheKey((_NoEq(),))
+        key_b = _DispatchCacheKey((_NoEq(),))
+        hash(key_a)
+        with self.assertRaises(NotImplementedError):
+            operator.eq(key_a, key_b)
+
+    def test_cache_bypasses_script_object(self):
+        """A ScriptObject argument must bypass the cache rather than enter a key.
+
+        Custom classes registered through the legacy ``torch::class_`` C++ API are not
+        required to bind ``__eq__``, unlike ``register_custom_class``, which enforces it
+        for constant types. A ScriptObject in a cache key therefore risks
+        NotImplementedError on any bucket collision, so it is refused up front, as the
+        surrounding branches already do for non-fake tensors and function arguments.
+        """
+        from torch._subclasses.fake_tensor import (
+            _BypassDispatchCache,
+            _CacheKeyState,
+        )
+        from torch.testing._internal.torchbind_impls import load_torchbind_test_lib
+
+        load_torchbind_test_lib()
+        script_obj = torch.classes._TorchScriptTesting._Foo(10, 20)
+        self.assertIsInstance(script_obj, torch.ScriptObject)
+
+        mode = FakeTensorMode()
+        with self.assertRaisesRegex(_BypassDispatchCache, "script object"):
+            mode._prep_args_for_hash([], [script_obj], _CacheKeyState(), [])
 
 
 class FakeTensorPreferDeviceType(TestCase):

--- a/torch/_subclasses/fake_tensor.py
+++ b/torch/_subclasses/fake_tensor.py
@@ -2054,6 +2054,12 @@ class FakeTensorMode(TorchDispatchMode):
                 self._prep_args_for_hash(result, arg, state, id_hashed_objects)
             elif isinstance(arg, types.FunctionType):
                 raise _BypassDispatchCache("function argument")
+            elif isinstance(arg, torch.ScriptObject):
+                # TorchScript custom classes are opaque to the cache: they expose no
+                # metadata it can reason about, and __eq__ is optional for them, so a
+                # key holding one raises NotImplementedError when two keys collide in
+                # the same bucket and __eq__ compares the key tuples.
+                raise _BypassDispatchCache("script object")
             elif isinstance(arg, torch.fx.GraphModule):
                 # This is used for invoke_subgraph where id(graph_module) allows
                 # us to cache fake outputs


### PR DESCRIPTION
### Summary

`FakeTensorMode._prep_args_for_hash` ends in a catch-all `else` that appends `(type(arg), arg)` for any unrecognised argument, so a `torch.ScriptObject` becomes part of the dispatch cache key. `ScriptObject` hashes by identity, so the key is built and inserted without complaint — the failure appears later, when two keys land in the same bucket and `_DispatchCacheKey.__eq__` compares the key tuples element-wise:

```
NotImplementedError: '__eq__' is not implemented for __torch__.torch.classes.tensorrt.Engine
  torch/_subclasses/fake_tensor.py:1433 in _DispatchCacheKey.__eq__
  while executing torch.ops.tensorrt.execute_engine.default
```

Because it only fires on a hash-bucket collision, it surfaces as a confusing intermittent error deep inside dispatch rather than a clear one at insertion.

Custom classes registered through the legacy `torch::class_` C++ API are not required to bind `__eq__`. `register_custom_class` *does* enforce it for `typ="constant"` — [`opaque_object.py`](https://github.com/pytorch/pytorch/blob/main/torch/_library/opaque_object.py) raises `TypeError: ... expected to have a non-default __eq__ implementation as we will use this in torch.compile to guard on the equality of objects` — but legacy registrations never pass through that check, so the cache cannot assume the operator exists. `torch-tensorrt`'s `TRTEngine` is registered the legacy way ([`register_jit_hooks.cpp`](https://github.com/pytorch/TensorRT/blob/main/core/runtime/register_jit_hooks.cpp)) and binds `__str__`, `__repr__`, `__obj_flatten__`, `__getstate__`/`__setstate__` — but no `__eq__`.

### Fix

Treat `ScriptObject` as uncacheable, matching the surrounding branches that already refuse non-fake tensors, function arguments and mkldnn tensors. A `ScriptObject` carries no metadata the cache can reason about, so there is nothing to gain by keying on it.

Keying by `type` + `id`, as is done a few lines below for `torch.fx.GraphModule`, would preserve caching — but it would also make the cache retain the object through `id_hashed_objects`, which for something like a TensorRT engine means pinning GPU memory to a cache entry. Bypassing seemed the safer default; happy to switch if you prefer the identity-keyed form.

### Repro

With `torch-tensorrt` installed:

```python
ep = torch.export.export(module, inputs, strict=False)
trt = torch_tensorrt.dynamo.compile(ep, inputs=inputs, min_block_size=1)
torch_tensorrt.save(trt, "out.pt2", inputs=inputs,
                    output_format="aot_inductor", retrace=True)
```

### Verification

Measured on an H100 with `torch 2.14.0.dev20260811+cu130` / `torch_tensorrt 2.14.0.dev20260823+cu130`, applying exactly the six lines in this PR to the installed `fake_tensor.py`:

| | result |
|---|---|
| without the patch | `NotImplementedError: '__eq__' is not implemented for ...tensorrt.Engine` |
| with the patch | save + reload OK, reloaded output matches pre-save `cos=1.000000`, `max_abs=0.000e+00` |

Reverting the patch in the same environment brings the failure straight back.

No effect on ordinary caching — FakeTensor dispatch cache counters over a mixed matmul/softmax/elementwise workload are identical before and after (**1795 hits / 8 misses** both ways), which is expected since `ScriptObject`s do not appear in hot dispatch paths.

`test_fake_tensor.py -k "cache or Cache"` passes (34 passed). `test_cache_bypasses_script_object` needs `libtorchbind_test.so`, which a wheel install does not ship, so I could not execute that one locally — it uses the same `load_torchbind_test_lib()` helper as `test/test_weak.py` and should run in CI. Flagging it explicitly rather than claiming a green run I did not see.

### Tests

- `test_cache_key_rejects_uncomparable_member` — the mechanism: the key builds and hashes fine, and only comparison raises.
- `test_cache_bypasses_script_object` — the fix: a real legacy `torch::class_` `ScriptObject` is refused when the key is built.

cc @eellison @zou3519 @bdhirsh
