### PR TITLE
[Distributed][ROCm] Fix FSDP incorrectly drops and reuses memory when using both NO_SHARD and CPU offload

### DIFF
--- a/torch/distributed/fsdp/_flat_param.py
+++ b/torch/distributed/fsdp/_flat_param.py
@@ -1851,6 +1851,14 @@ class FlatParamHandle:
                 device == torch.device("cpu"),
                 f"Expects the local shard to be on CPU but got {device}",
             )
+            # For `NO_SHARD`, this drops the only FSDP reference to the H2D
+            # copy that `pre_unshard()` allocated on the pre-unshard stream,
+            # and no all-gather ran to record it. Hand it to the consuming
+            # stream so the allocator does not reuse it under running kernels.
+            if not self.uses_sharded_strategy:
+                _no_dispatch_record_stream(
+                    flat_param.data, self._device_handle.current_stream()
+                )
         flat_param.data = flat_param._local_shard  # type: ignore[attr-defined]
         if self._use_orig_params:
             if skip_use_sharded_views:  # type: ignore[possibly-undefined]


### PR DESCRIPTION
### Root cause

With `ShardingStrategy.NO_SHARD` + `CPUOffload(offload_params=True)`, `pre_unshard()` allocates a fresh device copy of the flat parameter via `flat_param_to(self.device, non_blocking=True)`. That copy is allocated on the pre-unshard stream but consumed on the computation stream, and nothing records the consuming stream on it.

The existing `record_stream` call that protects this buffer lives in `_all_gather_flat_param()`, which `NO_SHARD` never enters: `needs_unshard()` returns `False` unconditionally, so `unshard()` returns early. The other two records are likewise out of reach — `_free_unsharded_flat_param()` is guarded by `_check_sharded_strategy()`, and the `_mp_shard` record requires parameter mixed precision.

So when `_use_sharded_flat_param()` assigns `flat_param.data = flat_param._local_shard`, FSDP drops its reference to a device buffer that has an empty `stream_uses` set. With `use_orig_params=True` autograd holds the last reference and frees it after the backward node returns on the CPU, while that node's kernels are still running. The caching allocator takes the immediate `free_block()` path, and since `get_free_block()` only reuses blocks whose allocation stream matches, the block goes straight back to the next handle's H2D copy on the pre-unshard stream. Two modules then share one buffer, and gradients are silently wrong from the second optimizer step onward.

### The fix

Record the consuming stream on the device buffer immediately before the assignment that releases it. `current_stream()` there is the computation stream on both the forward and backward paths: `reshard()` is the only caller, and no `_reshard()` entry point runs inside a `device_handle.stream(...)` context.

Gated on `not self.uses_sharded_strategy` because every sharded strategy already records the same block on the same stream in `_free_unsharded_flat_param()` a few lines later.

Fixes #190166

Authored with AI assistance

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang