### PR TITLE
Fix CPython version check in cpython_defs.c that could never fire

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -64,9 +64,9 @@ void init_THPCaches() {}
 #undef _PyOpcode_Caches
 
 // As a simple way to reduce the impact of ABI changes on the CPython side, this
-// check forces us to manually re-check that the function didn't change on the
-// next major version
-#if IS_PYTHON_3_16_PLUS
+// check forces us to manually re-check that the functions below didn't change
+// on the next release.
+#if PY_MINOR_VERSION > 15
 #error \
     "Please ensure that the functions below still match the CPython implementation for 3.15"
 #endif


### PR DESCRIPTION
`cpython_defs.c` hand-copies a few CPython internal functions. There's a
compile-time check meant to force a manual re-verification whenever the code
starts compiling against a newer, unverified CPython version.

That check was broken: it tested the exact same condition that had already
put us in this branch of the file, so it could never be true and the error
could never fire, no matter how new the Python version was. Verified this
in isolation with `gcc -E`: even simulating Python 3.20, no error is raised.

Fix: compare the Python minor version against the last-verified version
directly, instead of reusing the same macro. Now the check fires correctly
when someone raises that macro's version cutoff without redoing the
verification.

## Test Plan

Checked with `gcc -E` across version combinations.

---
This PR description was drafted with AI assistance and reviewed by the author.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98