### PR TITLE
Fix ONNX type promotion for scalar-first tensor operations

### DIFF
--- a/test/onnx/test_fx_type_promotion.py
+++ b/test/onnx/test_fx_type_promotion.py
@@ -39,6 +39,25 @@ class TestFindCompatibleOpOverload(common_utils.TestCase):
 
 
 class TestTypePromotionONNXExport(common_utils.TestCase):
+    def test_scalar_minus_int_tensor_exports(self):
+        class Model(torch.nn.Module):
+            def forward(self, x, mask):
+                return (1.0 - mask) * x
+
+        model = Model().eval()
+        x = torch.randn(2, 3)
+        mask = torch.ones(2, 3, dtype=torch.int64)
+        exported_program = torch.export.export(model, (x, mask))
+
+        onnx_program = torch.onnx.export(
+            exported_program,
+            (x, mask),
+            dynamo=True,
+            verbose=False,
+        )
+
+        self.assertIsNotNone(onnx_program)
+
     def test_where_with_bool_tensor_and_mixed_scalars_exports(self):
         class WhereModel(torch.nn.Module):
             def forward(self, condition):

--- a/torch/onnx/_internal/fx/passes/type_promotion.py
+++ b/torch/onnx/_internal/fx/passes/type_promotion.py
@@ -1440,6 +1440,7 @@ class _TypePromotionInterpreter(torch.fx.Interpreter):
         node: torch.fx.Node,
         fx_arg: torch.fx.node.Argument,
         dtype: torch.dtype | None,
+        force_tensor: bool = False,
     ) -> torch.fx.node.Argument:
         """Promote fx_arg to dtype if necessary."""
         if dtype is None:
@@ -1478,7 +1479,7 @@ class _TypePromotionInterpreter(torch.fx.Interpreter):
                 )
                 if equivalent_dtype is None:
                     raise AssertionError(f"Unexpected arg_type: {arg_type}")
-                if equivalent_dtype != dtype:
+                if force_tensor or equivalent_dtype != dtype:
                     # Promote Sym number to tensor of dtype.
                     graph = node.graph
                     with graph.inserting_before(node):
@@ -1503,7 +1504,7 @@ class _TypePromotionInterpreter(torch.fx.Interpreter):
                 type(fx_arg)
             )
         ) is not None:
-            if equivalent_dtype != dtype:
+            if force_tensor or equivalent_dtype != dtype:
                 # Promote number to tensor of dtype.
                 # The op should have overload that supports tensor for this arg, otherwise
                 # the type promotion rule should not suggest promoting this arg.
@@ -1542,18 +1543,31 @@ class _TypePromotionInterpreter(torch.fx.Interpreter):
         """Promote node inputs and outputs according to type promotion rule."""
         args, kwargs = self.fetch_args_kwargs_from_env(node)
         type_promotion_info = rule.preview_type_promotion(args, kwargs)
+        target = node.target
+        if not isinstance(target, torch._ops.OpOverload):
+            raise AssertionError(f"Expected OpOverload, got {type(target)}")
+        schema_args = target._schema.arguments
+        schema_kwargs = {arg.name: arg for arg in schema_args}
         new_args = []
         new_kwargs = {}
         for i, arg in enumerate(node.args):
             new_args.append(
                 self._maybe_promote_arg(
-                    node, arg, type_promotion_info.args_dtypes.get(i, None)
+                    node,
+                    arg,
+                    type_promotion_info.args_dtypes.get(i, None),
+                    i < len(schema_args)
+                    and isinstance(schema_args[i].type, torch.TensorType),
                 )
             )
 
         for name, arg in node.kwargs.items():
             new_kwargs[name] = self._maybe_promote_arg(
-                node, arg, type_promotion_info.kwargs_dtypes.get(name, None)
+                node,
+                arg,
+                type_promotion_info.kwargs_dtypes.get(name, None),
+                name in schema_kwargs
+                and isinstance(schema_kwargs[name].type, torch.TensorType),
             )
         new_args = tuple(new_args)
 


### PR DESCRIPTION
## Summary

ONNX export failed when type promotion left a scalar in a Tensor-typed schema position, such as `1.0 - int_tensor`.

- **Type promotion:** Materialize scalars as rank-zero tensors when the selected operator schema requires a Tensor, while preserving scalar-compatible overloads.
- **Regression coverage:** Add an export test for the scalar-minus-integer-mask pattern.

Fixes https://github.com/pytorch/pytorch/issues/194381
