### PR TITLE
[precompile] capture input-driven backward tangent variants

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -132,8 +132,13 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
       ``torch.autograd.Function``; eager segments retain differentiable ATen operations.
       Outputs retain their ``grad_fn``, so a later ``backward()`` runs the captured
       backward. Training works across captured recompilations and graph breaks. Only
-      first-order backward is supported; tensor-subclass and ``BackwardState`` training
-      graphs are rejected.
+      first-order backward is supported; training graphs carrying ``BackwardState`` are
+      rejected. Each example's actual backward determines an integer bitmask whose set
+      bits identify undefined output tangents and compiles that pattern during the
+      example call. Inductor serializes every observed backward variant and rejects an
+      unseen pattern at runtime; ``None`` is never passed to a compiled Tensor input. If
+      the examples only run forwards, the ordinary all-tangents-present backward is the
+      sole covered pattern.
 
    With ``tracer="make_fx"``, if ``fn`` runs a backward, the artifact re-runs the whole
    forward and backward and scatters the resulting parameter gradients onto the runtime

--- a/docs/source/user_guide/torch_compiler/torch.compiler.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler.md
@@ -66,9 +66,13 @@ An uncovered call compiles with a warning and increments `serve_time_compiles()`
 standalone artifact instead rejects calls outside its captured guard sets. With
 `training=True`, both eager and Inductor artifacts retain autograd history; Inductor
 graphs include readable compiled forward and backward code. This training mode works
-across captured recompilations and graph breaks. `PrecompileSummary` reports coverage
-and dropped guards, while the `require_*` options let callers reject incomplete or
-insufficiently guarded captures.
+across captured recompilations, graph breaks, and supported tensor subclasses. Each
+example's real backward compiles and records an integer bitmask whose set bits identify
+undefined output tangents, and Inductor serializes the matching backward variants
+without passing `None` to a kernel Tensor input. A pattern absent from the examples is
+rejected at runtime. If the examples only run forwards, only the all-tangents-present
+backward is covered. `PrecompileSummary` reports coverage and dropped guards, while the
+`require_*` options let callers reject incomplete or insufficiently guarded captures.
 See the {ref}`API reference <torch.compiler_api>` for details.
 
 :::{warning}

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -21,6 +21,7 @@ import torch.utils._pytree as _pytree
 from torch._dynamo import graph_break as _precompile_dynamo_break_here
 from torch._dynamo.decorators import mark_dynamic, mark_unbacked
 from torch._precompile import PrecompileError
+from torch.distributed._functional_collectives import AsyncCollectiveTensor
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_device_type import (
@@ -399,6 +400,37 @@ def _precompile_dynamo_wrong_call_module(module, x):
 
 def _precompile_dynamo_backward(module, x):
     module(x).sum().backward()
+
+
+class _PrecompileDynamoIndependentOutputs(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.left = torch.nn.Linear(4, 3)
+        self.right = torch.nn.Linear(4, 3)
+
+    def forward(self, x):
+        return self.left(x).sin(), self.right(x).cos()
+
+
+@torch._dynamo.disable
+def _precompile_dynamo_backward_one(first, second, use_first):
+    (first if use_first else second).sum().backward()
+
+
+def _precompile_dynamo_undefined_tangent_step(module, x, use_first):
+    first, second = module(x)
+    _precompile_dynamo_backward_one(first, second, use_first)
+
+
+def _precompile_dynamo_optional_tangent_step(x, y, use_first):
+    first, second = torch.ops.precompile_optional_tangents.split.default(x, y)
+    _precompile_dynamo_backward_one(first, second, use_first)
+
+
+def _precompile_dynamo_async_collective_tangent_step(x, y):
+    first = x.sin()
+    second = AsyncCollectiveTensor(y.cos())
+    _precompile_dynamo_backward_one(first, second, True)
 
 
 def _precompile_dynamo_autograd_grad(module, x, target):
@@ -5175,6 +5207,235 @@ class TestPrecompile(TestCase):
 class TestPrecompileNumerics(TestCase):
     # Numeric-correctness tests run device-generically so the same coverage
     # exercises the CUDA lowering, not just CPU.
+
+    def test_torch_compile_training_preserves_undefined_tangent(self, device):
+        model = _PrecompileDynamoIndependentOutputs().to(device)
+        x = make_tensor((2, 4), device=device, dtype=torch.float32)
+        compiled = torch.compile(model, backend="inductor", fullgraph=True)
+        compiled(x)[0].sum().backward()
+
+        self.assertIsNotNone(model.left.weight.grad)
+        self.assertIsNone(model.right.weight.grad)
+
+    def test_torch_compile_training_async_collective_undefined_tangent(self, device):
+        @torch.compile(backend="inductor", fullgraph=True)
+        def compiled(x, y):
+            return x.sin(), AsyncCollectiveTensor(y.cos())
+
+        x = make_tensor((4,), device=device, dtype=torch.float32, requires_grad=True)
+        y = make_tensor((4,), device=device, dtype=torch.float32, requires_grad=True)
+        compiled(x, y)[0].sum().backward()
+
+        self.assertEqual(x.grad, x.cos())
+        self.assertIsNone(y.grad)
+
+    def test_dynamo_training_serializes_tangent_masks(self, device):
+        from torch._dynamo.utils import counters
+        from torch._inductor.utils import fresh_cache
+
+        torch.manual_seed(0)
+        model = _PrecompileDynamoIndependentOutputs().to(device)
+        x = make_tensor((2, 4), device=device, dtype=torch.float32)
+        backward_calls: list[torch.Tensor | None] = []
+        handles = [
+            layer.weight.register_hook(lambda grad: backward_calls.append(grad))
+            for layer in (model.left, model.right)
+        ]
+        counters.clear()
+        try:
+            with fresh_cache():
+                code, cache = torch.compiler.precompile(
+                    _precompile_dynamo_undefined_tangent_step,
+                    example_inputs=[(model, x, True), (model, x, False)],
+                    tracer="dynamo",
+                    backend="inductor",
+                    training=True,
+                )
+        finally:
+            for handle in handles:
+                handle.remove()
+
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+        self.assertEqual(len(backward_calls), 4)
+        self.assertEqual(sum(grad is None for grad in backward_calls), 2)
+        self.assertIn("1: (_inner_call_bw_0", code)
+        self.assertIn("2: (_inner_call_bw_1", code)
+        self.assertIn("_AOT_DEFAULT_BACKWARD_VARIANT_s0 = None", code)
+        self.assertEqual(code.count("Inner Inductor output code: BACKWARD variant"), 2)
+
+        for _, loaded in _default_and_inlined_loaders(code, cache, "inductor"):
+            for use_first in (True, False):
+                run = copy.deepcopy(model)
+                ref = copy.deepcopy(model)
+                loaded(run, x, use_first)
+                _precompile_dynamo_undefined_tangent_step(ref, x, use_first)
+                for actual, expected in zip(run.parameters(), ref.parameters()):
+                    self.assertEqual(actual.grad, expected.grad)
+
+    @torch._dynamo.config.patch(
+        automatic_dynamic_shapes=True, assume_static_by_default=True
+    )
+    def test_dynamo_training_custom_backward_observes_none_tangent(self, device):
+        from torch._dynamo.utils import counters
+        from torch._inductor.utils import fresh_cache
+        from torch.library import _scoped_library
+
+        with _scoped_library("precompile_optional_tangents", "FRAGMENT") as lib:
+            lib.define("split(Tensor x, Tensor y) -> (Tensor, Tensor)")
+            lib.impl(
+                "split",
+                lambda x, y: (x * 2, y * 3),
+                "CompositeExplicitAutograd",
+            )
+            lib.impl(
+                "split",
+                lambda x, y: (torch.empty_like(x), torch.empty_like(y)),
+                "Meta",
+            )
+
+            def setup_context(ctx, inputs, output):
+                ctx.set_materialize_grads(False)
+                ctx.save_for_backward(*inputs)
+
+            def backward(ctx, grad_x, grad_y):
+                x, y = ctx.saved_tensors
+                if grad_x is None:
+                    return y * 5, grad_y * y
+                if grad_y is None:
+                    return grad_x * x, x * 7
+                return grad_x * x, grad_y * y
+
+            torch.library.register_autograd(
+                "precompile_optional_tangents::split",
+                backward,
+                setup_context=setup_context,
+                lib=lib,
+            )
+            examples = []
+            for size, use_first in ((2, True), (3, False), (5, True)):
+                x = make_tensor(
+                    (size,), device=device, dtype=torch.float32, requires_grad=True
+                )
+                y = make_tensor(
+                    (size,), device=device, dtype=torch.float32, requires_grad=True
+                )
+                examples.append((x, y, use_first))
+            counters.clear()
+            with fresh_cache():
+                code, cache = torch.compiler.precompile(
+                    _precompile_dynamo_optional_tangent_step,
+                    example_inputs=examples,
+                    tracer="dynamo",
+                    backend="inductor",
+                    training=True,
+                )
+
+            self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+            self.assertIn("DYNAMIC_GRAPH_COUNT = 1", code)
+            self.assertIn("1: (_inner_call_bw_0", code)
+            self.assertIn("2: (_inner_call_bw_1", code)
+            caches = (cache, _strip_artifact(cache))
+            for artifact_cache in caches:
+                with fresh_cache():
+                    loaded = torch.compiler.precompile.load(code, artifact_cache)
+                    for use_first in (True, False):
+                        x = make_tensor(
+                            (7,),
+                            device=device,
+                            dtype=torch.float32,
+                            requires_grad=True,
+                        )
+                        y = make_tensor(
+                            (7,),
+                            device=device,
+                            dtype=torch.float32,
+                            requires_grad=True,
+                        )
+                        actual_x = x.detach().clone().requires_grad_()
+                        actual_y = y.detach().clone().requires_grad_()
+                        expected_x = x.detach().clone().requires_grad_()
+                        expected_y = y.detach().clone().requires_grad_()
+                        loaded(actual_x, actual_y, use_first)
+                        _precompile_dynamo_optional_tangent_step(
+                            expected_x, expected_y, use_first
+                        )
+                        self.assertEqual(actual_x.grad, expected_x.grad)
+                        self.assertEqual(actual_y.grad, expected_y.grad)
+
+    @torch._dynamo.config.patch(
+        automatic_dynamic_shapes=True, assume_static_by_default=True
+    )
+    def test_dynamo_training_async_collective_tensor_undefined_tangent(self, device):
+        from torch._dynamo.utils import counters
+        from torch._inductor.utils import fresh_cache
+
+        examples = []
+        for size in (2, 3, 5):
+            x = make_tensor(
+                (size,), device=device, dtype=torch.float32, requires_grad=True
+            )
+            y = make_tensor(
+                (size,), device=device, dtype=torch.float32, requires_grad=True
+            )
+            examples.append((x, y))
+        counters.clear()
+        with fresh_cache():
+            code, cache = torch.compiler.precompile(
+                _precompile_dynamo_async_collective_tangent_step,
+                example_inputs=examples,
+                tracer="dynamo",
+                backend="inductor",
+                training=True,
+            )
+
+        self.assertEqual(counters["aot_autograd"]["autograd_cache_bypass"], 0)
+        self.assertIn("DYNAMIC_GRAPH_COUNT = 1", code)
+        self.assertIn("2: (_inner_call_bw_0", code)
+        self.assertNotIn("tangents_2", code)
+        for artifact_cache in (cache, _strip_artifact(cache)):
+            with fresh_cache():
+                loaded = torch.compiler.precompile.load(code, artifact_cache)
+                x = make_tensor(
+                    (7,), device=device, dtype=torch.float32, requires_grad=True
+                )
+                y = make_tensor(
+                    (7,), device=device, dtype=torch.float32, requires_grad=True
+                )
+                loaded(x, y)
+                self.assertEqual(x.grad, x.cos())
+                self.assertIsNone(y.grad)
+
+        if device == "cpu":
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".py", delete=False
+            ) as artifact:
+                artifact.write(code)
+                artifact_path = artifact.name
+            try:
+                subprocess.check_call(
+                    [
+                        sys.executable,
+                        "-c",
+                        textwrap.dedent(
+                            """
+                            import runpy
+                            import sys
+                            import torch
+
+                            namespace = runpy.run_path(sys.argv[1])
+                            x = torch.randn(7, requires_grad=True)
+                            y = torch.randn(7, requires_grad=True)
+                            namespace["forward"](x, y)
+                            torch.testing.assert_close(x.grad, x.cos())
+                            if y.grad is not None:
+                                raise AssertionError(f"expected no y.grad, got {y.grad}")
+                            """
+                        ),
+                        artifact_path,
+                    ]
+                )
+            finally:
+                os.unlink(artifact_path)
 
     @onlyCUDA
     def test_make_fx_autocast_tracks_graph_devices(self, device):

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -33,7 +33,11 @@ also stored as opaque inline data.
 With ``tracer="dynamo", training=True``, captured graphs remain differentiable on both
 backends. Inductor artifacts contain AOTAutograd's forward and backward as readable
 source. The served output retains its ``grad_fn`` and a later ``backward()`` executes
-the captured backward, including across captured recompilations and graph breaks.
+the captured backward, including across captured recompilations and graph breaks. Each
+example's real backward records which differentiable outputs have undefined tangents;
+the artifact contains one backward specialization per observed pattern and rejects an
+unseen pattern instead of passing ``None`` to an Inductor tensor input. If the examples
+only run forwards, only the all-tangents-present backward is covered.
 
 ``precompile`` returns an executable ``python_code`` string plus a companion
 integrity-tagged ``cache``. Make-fx artifacts are self-contained. Dynamo artifacts may
@@ -1384,14 +1388,35 @@ class _DynamoPythonBackend:
         cache: bytes | None,
         is_dynamic: bool,
         call: Callable[[list[object]], object],
+        compile_state: Any | None = None,
     ) -> None:
         self.python_code = python_code
         self.cache = cache
         self.is_dynamic = is_dynamic
         self._call = call
+        self._compile_state = compile_state
+        if compile_state is not None:
+            globals_dict = getattr(call, "__globals__", None)
+            if not isinstance(globals_dict, dict):
+                raise AssertionError("training backend call must have Python globals")
+            compile_state.install_capture(globals_dict)
 
     def __call__(self, *args: object) -> object:
         return self._call(list(args))
+
+    def finalize_training(self) -> None:
+        if self._compile_state is None:
+            return
+        globals_dict = getattr(self._call, "__globals__", {})
+        masks = globals_dict.get("_AOT_OBSERVED_UNDEFINED_TANGENT_MASKS", ())
+        try:
+            self.python_code, self.cache = self._compile_state.finalize(tuple(masks))
+        finally:
+            globals_dict["_AOT_BACKWARD_VARIANT_COMPILER"] = None
+            variants = globals_dict.get("_AOT_BACKWARD_VARIANTS")
+            if isinstance(variants, dict):
+                variants.clear()
+            self._compile_state = None
 
 
 def _build_dynamo_eager_graph_source(gm: torch.fx.GraphModule) -> str:
@@ -1525,6 +1550,7 @@ def _dynamo_backend_compiler(
     ) -> _DynamoPythonBackend:
         from torch._functorch import aot_autograd
         from torch._functorch._aot_autograd.to_standalone_python import (
+            _compile_to_python_with_state,
             _graph_has_dynamic_shapes,
         )
 
@@ -1535,6 +1561,7 @@ def _dynamo_backend_compiler(
             namespace: dict[str, object] = {"__name__": "_dynamo_eager_graph"}
             exec(compile(python_code, "<dynamo-eager-graph>", "exec"), namespace)
             call = cast("Callable[[list[object]], object]", namespace["call"])
+            compile_state = None
         else:
             # Dynamo's runtime examples may have concrete tensor sizes while the graph
             # metadata carries the symbolic sizes and sources selected for this variant.
@@ -1543,14 +1570,14 @@ def _dynamo_backend_compiler(
                 for node in gm.graph.nodes
                 if node.op == "placeholder"
             ]
-            python_code, cache = aot_autograd.compile_to_python(
+            python_code, cache, compile_state = _compile_to_python_with_state(
                 gm,
                 graph_inputs,
                 options={"size_asserts": True},
                 grad_enabled=training,
             )
             call = aot_autograd.load_from_python(python_code, cache)
-        return _DynamoPythonBackend(python_code, cache, is_dynamic, call)
+        return _DynamoPythonBackend(python_code, cache, is_dynamic, call, compile_state)
 
     return compile_graph
 
@@ -2741,7 +2768,10 @@ def _precompile_dynamo(
                 trace_autograd_ops=training,
             )
         )
-        functorch_options = {"bundled_autograd_cache": True}
+        functorch_options = {
+            "bundled_autograd_cache": True,
+            "bypass_autograd_cache_key": True,
+        }
         if training:
             functorch_options["force_non_lazy_backward_lowering"] = True
         capture_stack.enter_context(functorch_config.patch(**functorch_options))
@@ -2955,6 +2985,7 @@ def _precompile_dynamo(
                     "precompile tracer='dynamo' encountered a graph that could not be "
                     "represented as standalone Python source."
                 )
+            compiled_backend.finalize_training()
             compiled_backends.append(compiled_backend)
 
         code_states: list[_DynamoCodeState] = []
@@ -3707,7 +3738,12 @@ class _PrecompileApi:
         Inductor graphs carry readable AOTAutograd forward and backward source bridged
         by an emitted ``torch.autograd.Function``; eager graphs replay their captured
         differentiable operations. The input tensors that require gradients must do so
-        in every example and at runtime.
+        in every example and at runtime. Each example's actual backward also records its
+        output-tangent presence pattern. Inductor compiles and serializes one backward
+        variant per observed pattern, preserving undefined gradients without presenting
+        ``None`` as a kernel tensor input. A runtime pattern not covered by the examples
+        raises :class:`PrecompileError` rather than compiling at serve time. If the
+        examples only run forwards, only the all-tangents-present backward is covered.
 
         With ``tracer="dynamo"``, shape variation across ``example_inputs`` uses
         Dynamo's ordinary automatic dynamic-shape policy: for example, a static first


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* #194528
* #194527
* #194526
* __->__ #194525
* #194524
* #194523
* #194470
* #194468
* #194467
* #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

Dynamo precompile examples could exercise different output-tangent patterns,
but the artifact retained only the initial AOTAutograd backward. In training
this surfaced as a None value at an Inductor Tensor input for models with unused
outputs, including AsyncCollectiveTensor-shaped graph-break cases.

Connect each Inductor backend to the standalone backward capture state while
the real examples run, then finalize the graph with exactly the observed masks.
Use nonce AOTAutograd cache keys only when a graph cannot be hashed so every
backend is recorded without reporting a cache bypass. The generated artifact
contains all matching kernels, rejects uncovered masks, and documents the
input-driven specialization contract.

Test Plan:

```
/home/bobren/local/e/pytorch-env/bin/python test/test_precompile.py
```

```
/home/bobren/local/e/pytorch-env/bin/python test/test_precompile.py -k async_collective_undefined_tangent
```

```
UV_OFFLINE=1 /home/bobren/local/c/pytorch-env/bin/spin quicklint -- --skip PYREFLY
```

The required full `spin lint -a` was also run. Pyrefly crashed on the pre-existing
duplicate `prepare_qat` binding; the remaining linters and changed-file lint passed.

Authored with an AI assistant.

cc @albanD