### PR TITLE
[aot_autograd] preserve fallback for unsafe tangent retraces

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -7317,12 +7317,9 @@ def forward(self, primals_1, tangents_1):
         # - 5 original outputs (sb is a tuple, gets expanded to 2 symints)
         # - 8 saved outputs for backward: 5 tensors, 3 symints
         self.assertEqual(get_num_ins_outs(fw_graph), (4, 13))
-        # in the bwd graph, 10 inputs (grad outs) because:
-        # - The fwd graph had 13 outputs
-        # - 1 was a view of an input, which gets regenerated outside of the graph
-        #   and doesn't participate in the backward
-        # - 2 user outs were symints (b.size()), which don't get tangents in the backward
-        self.assertEqual(get_num_ins_outs(bw_graph), (10, 4))
+        # The real backward does not use mm2, so its tangent and the saved values used
+        # only by that branch are pruned from the specialized backward.
+        self.assertEqual(get_num_ins_outs(bw_graph), (5, 4))
         _, fw_graph_out_nodes = get_ins_outs(fw_graph)
         self.assertEqual(
             # fw outputs include b.size() which expands to 2 symints,
@@ -7380,7 +7377,9 @@ def forward(self, primals_1, tangents_1):
         bw_graph = bw_graph_cell[0]
 
         self.assertEqual(get_num_ins_outs(fw_graph), (4, 12))
-        self.assertEqual(get_num_ins_outs(bw_graph), (9, 4))
+        # The real backward does not use mm2, so its tangent and the saved values used
+        # only by that branch are pruned from the specialized backward.
+        self.assertEqual(get_num_ins_outs(bw_graph), (4, 4))
         _, fw_graph_out_nodes = get_ins_outs(fw_graph)
         self.assertEqual(
             # fw outputs include b.size() which expands to 2 symints,

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -95,7 +95,10 @@ from .schemas import (
     SubclassMeta,
     ViewAndMutationMeta,
 )
-from .subclass_utils import compute_inner_mutated_inp_indices_from_subclass_meta
+from .subclass_utils import (
+    compute_inner_mutated_inp_indices_from_subclass_meta,
+    requires_subclass_dispatch,
+)
 from .utils import (
     contain_metadata_mutation_ops,
     get_default_generator,
@@ -288,13 +291,20 @@ def aot_stage1_graph_capture(
         if isinstance(module, torch.fx.GraphModule)
         for node in module.graph.nodes
     )
-    # Synthetic-base wrappers close over real example views, and Dynamo has already
-    # specialized Python autograd.Function backward subgraphs. Neither can be replayed
-    # with literal None tangents; use the structural backward specializer instead.
+    # Synthetic-base wrappers close over real example views, effect tokens contain
+    # trace-local tensors, tensor subclasses require their original dispatch setup,
+    # and Dynamo has already specialized Python autograd.Function backward subgraphs.
+    # These cases must use structural specialization or the existing materialization
+    # fallback because the forward cannot safely be rerun to retrace the joint graph.
     can_retrace_backward = (
         not any(
             isinstance(wrapper, AOTSyntheticBaseWrapper) and wrapper.needs_post_compile
             for wrapper in wrappers
+        )
+        and not aot_state.fw_metadata.tokens
+        and not requires_subclass_dispatch(  # type: ignore[arg-type]
+            aot_state.flat_args,
+            aot_state.fw_metadata,
         )
         and not has_dynamo_autograd_function
     )

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -4142,9 +4142,9 @@ class _AutogradBackwardCompiler:
                         bw_module,
                         placeholder_list,
                     )
-                if specialized is None and not any(
-                    isinstance(meta, SubclassCreationMeta)
-                    for meta in self.fw_metadata.subclass_tangent_meta
+                if (
+                    specialized is None
+                    and self.aot_config.precompile_backend_id is not None
                 ):
                     raise RuntimeError(
                         "AOTAutograd could not compile the observed undefined-output "
@@ -4160,6 +4160,11 @@ class _AutogradBackwardCompiler:
                     all_args,
                 )
             if specialized is None:
+                if self.aot_config.precompile_backend_id is not None:
+                    raise RuntimeError(
+                        "AOTAutograd could not compile the observed undefined-output "
+                        "tangent pattern."
+                    )
                 _materialize_missing_tangent_args(
                     all_args,
                     bw_module,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* #194528
* __->__ #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* #194468
* #194467
* #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

Undefined-output tangent specialization retraced wrapped forwards that cannot safely be replayed, including effect-token and tensor-subclass graphs. A forward ABI mismatch also raised unconditionally, regressing ordinary torch.compile cases that previously materialized missing tangents.

Avoid joint retracing for effectful and subclass-dispatched graphs, then use structural specialization or the established materialization fallback. Keep precompile strict: when neither specialization path can preserve the observed tangent semantics, capture still fails instead of emitting a silently incorrect artifact. Update partitioner expectations to reflect the intentionally pruned tangent branch and its private saved inputs.

Test Plan:

~~~
PYTHONPATH="$PWD/test/functorch" /home/bobren/local/e/pytorch-env/bin/python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_aotdispatch.py", "TestAOTAutogradWithCache", "TestAOTModuleSimplified", "TestPartitioning"]; runpy.run_path("test/functorch/test_aotdispatch.py",run_name="__main__")'
PYTHONPATH="$PWD/test/functorch" /home/bobren/local/e/pytorch-env/bin/python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_aotdispatch.py"]; runpy.run_path("test/functorch/test_aotdispatch.py",run_name="__main__")'
PYTHONPATH="$PWD/test/functorch" /home/bobren/local/e/pytorch-env/bin/python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_compile_to_python.py"]; runpy.run_path("test/functorch/test_compile_to_python.py",run_name="__main__")'
/home/bobren/local/e/pytorch-env/bin/python -W ignore test/test_precompile.py
UV_OFFLINE=1 /home/bobren/local/c/pytorch-env/bin/spin quicklint -- --skip PYREFLY
git diff --check
~~~

Full Pyrefly lint was attempted but hit its pre-existing duplicate prepare_qat binding panic. All remaining changed-file linters passed.

Authored with an AI assistant.

cc @albanD