### PR TITLE
[aot_autograd] diagnose unresolved output tangents

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -1041,6 +1041,186 @@ def forward(self, primals_1):
             1,
         )
 
+    def test_unresolved_none_tangent_names_the_forward_output(self):
+        import torch._functorch._aot_autograd.graph_compile as graph_compile
+        import torch._functorch._aot_autograd.runtime_wrappers as runtime_wrappers
+
+        def fn(x):
+            y = torch.sin(x)
+            return y[0:4], y[4:8], y.detach(), x * 3
+
+        torch._dynamo.reset()
+        x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        with (
+            patch.object(
+                runtime_wrappers, "_dealias_marked_returns", lambda raw, marked: None
+            ),
+            patch.object(
+                graph_compile,
+                "_retrace_backward_for_undefined_grad_outputs",
+                lambda *args: None,
+            ),
+            patch.object(
+                runtime_wrappers,
+                "_specialize_bw_module_for_undefined_grad_outputs",
+                lambda *args: None,
+            ),
+            patch.object(
+                runtime_wrappers, "_grad_output_prototype", lambda *args: None
+            ),
+        ):
+            outputs = torch.compile(fn, backend="inductor")(x)
+            with self.assertRaisesRegex(
+                RuntimeError, "handed a non-Tensor for a tangent it requires"
+            ) as cm:
+                outputs[3].sum().backward()
+
+        msg = str(cm.exception)
+        self.assertIn("tangent index         : 1", msg)
+        self.assertIn("received              : None (type NoneType", msg)
+        self.assertIn("IntermediateBaseAOTOutput(base_of=PlainAOTOutput(idx=0))", msg)
+        self.assertIn("that slot holds       : intermediate base 0", msg)
+        self.assertIn("user output index     : 0", msg)
+        self.assertIn("OutputType.alias_of_intermediate_save_as_output", msg)
+        self.assertIn("its requires_grad     : True", msg)
+        self.assertIn("its dtype             : torch.float32", msg)
+        self.assertIn("This slot is case (2) or (3)", msg)
+
+    @parametrize("fallback", ("retrace", "structural", "materialize"))
+    def test_none_tangent_resolution_precedes_diagnostic(self, fallback):
+        import torch._functorch._aot_autograd.graph_compile as graph_compile
+        import torch._functorch._aot_autograd.runtime_wrappers as runtime_wrappers
+
+        def fn(x):
+            y = torch.sin(x)
+            return y[0:4], y[4:8], y.detach(), x * 3
+
+        def unexpected_fallback(*args):
+            self.fail(f"unexpected fallback for {fallback}")
+
+        torch._dynamo.reset()
+        x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    runtime_wrappers,
+                    "_dealias_marked_returns",
+                    lambda raw, marked: None,
+                )
+            )
+            if fallback == "retrace":
+                stack.enter_context(
+                    patch.object(
+                        runtime_wrappers,
+                        "_specialize_bw_module_for_undefined_grad_outputs",
+                        unexpected_fallback,
+                    )
+                )
+                stack.enter_context(
+                    patch.object(
+                        runtime_wrappers,
+                        "_materialize_missing_tangent_args",
+                        unexpected_fallback,
+                    )
+                )
+            else:
+                stack.enter_context(
+                    patch.object(
+                        graph_compile,
+                        "_retrace_backward_for_undefined_grad_outputs",
+                        lambda *args: None,
+                    )
+                )
+            if fallback == "structural":
+                stack.enter_context(
+                    patch.object(
+                        runtime_wrappers,
+                        "_materialize_missing_tangent_args",
+                        unexpected_fallback,
+                    )
+                )
+            elif fallback == "materialize":
+                stack.enter_context(
+                    patch.object(
+                        runtime_wrappers,
+                        "_specialize_bw_module_for_undefined_grad_outputs",
+                        lambda *args: None,
+                    )
+                )
+            torch.compile(fn, backend="inductor")(x)[3].sum().backward()
+
+        self.assertEqual(x.grad, torch.full_like(x, 3))
+
+    def test_none_tangent_error_reports_non_differentiable_dtype(self):
+        # Integer outputs are normally pruned before tangent processing, so drive
+        # this diagnostic classification directly.
+        from torch._functorch._aot_autograd.descriptors import (
+            PlainAOTOutput,
+            TangentAOTInput,
+        )
+        from torch._functorch._aot_autograd.runtime_wrappers import (
+            _non_tensor_tangent_error,
+            KeptTangentInfo,
+        )
+
+        info = KeptTangentInfo(
+            grad_out_idx=(0, 2),
+            dtype=(torch.float32, torch.int64),
+            num_mutated_inputs=0,
+            num_outputs=3,
+            num_intermediate_bases=0,
+            output_type=("non_alias",) * 3,
+            output_requires_grad=(True, False, True),
+            output_requires_grad_for_backward=(True, False, True),
+        )
+        msg = str(
+            _non_tensor_tangent_error(
+                None, 1, TangentAOTInput(PlainAOTOutput(idx=2)), "1/0", "here\n", info
+            )
+        )
+        self.assertIn("user output index     : 2", msg)
+        self.assertIn("its dtype             : torch.int64", msg)
+        self.assertIn("torch.int64 is not a differentiable dtype", msg)
+        self.assertIn("This error occurred in compiled graph [1/0].", msg)
+        self.assertIn("The forward output was created here:\nhere", msg)
+
+    def test_none_tangent_subclass_attribute_without_kept_slot_is_accepted(self):
+        from torch._functorch._aot_autograd.runtime_wrappers import AOTDispatchAutograd
+        from torch._functorch._aot_autograd.schemas import PlainTensorMeta
+
+        # Recursive subclass attributes do not identify a top-level tangent slot.
+        tangent, flat = AOTDispatchAutograd.process_runtime_tangent(
+            None, PlainTensorMeta(0)
+        )
+        self.assertIsNone(tangent)
+        self.assertEqual(flat, [None])
+
+    def test_none_tangent_for_a_dropped_slot_still_passes_through(self):
+        def fn(x, lengths):
+            y = torch.sin(x)
+            return (
+                y[0:4],
+                y[4:8],
+                lengths * 2,
+                lengths > 1,
+                (x * 2).detach(),
+                x[0:2],
+                x * 3,
+            )
+
+        def run(fn, x, lengths):
+            outputs = fn(x, lengths)
+            (outputs[0].sum() + outputs[1].sum() + outputs[6].sum()).backward()
+            return x.grad
+
+        torch._dynamo.reset()
+        lengths = torch.arange(4)
+        x_ref = torch.randn(8, requires_grad=True)
+        expected = run(fn, x_ref, lengths)
+        x = x_ref.detach().clone().requires_grad_(True)
+        actual = run(torch.compile(fn, backend="inductor"), x, lengths)
+        self.assertEqual(actual, expected)
+
     @torch._functorch.config.patch(aot_autograd_prune_unused_outputs=False)
     def test_unused_differentiable_outputs_pruning_kill_switch(self):
         bw_graphs = []
@@ -9954,6 +10134,46 @@ def forward(self, primals_1, tangents_1):
             torch.ops.aten.sum.dim_IntList,
             [node.target for node in compiled_autograd_graphs[0].graph.nodes],
         )
+
+    def test_compiled_autograd_unresolved_none_tangent_diagnostic(self):
+        import torch._dynamo.compiled_autograd as compiled_autograd_impl
+        import torch._functorch._aot_autograd.graph_compile as graph_compile
+        import torch._functorch._aot_autograd.runtime_wrappers as runtime_wrappers
+        from torch._dynamo import compiled_autograd
+
+        def fn(x):
+            y = torch.sin(x)
+            return y[0:4], y[4:8], y.detach(), x * 3
+
+        torch._dynamo.reset()
+        x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        with (
+            patch.object(
+                runtime_wrappers, "_dealias_marked_returns", lambda raw, marked: None
+            ),
+            patch.object(
+                graph_compile,
+                "_retrace_backward_for_undefined_grad_outputs",
+                lambda *args: None,
+            ),
+            patch.object(
+                compiled_autograd_impl,
+                "_specialize_bw_module_for_undefined_grad_outputs",
+                lambda *args: None,
+            ),
+            patch.object(
+                runtime_wrappers, "_grad_output_prototype", lambda *args: None
+            ),
+        ):
+            outputs = torch.compile(fn, backend="aot_eager")(x)
+            with (
+                compiled_autograd._enable(lambda gm: gm),
+                torch.autograd.set_multithreading_enabled(False),
+                self.assertRaisesRegex(
+                    RuntimeError, "handed a non-Tensor for a tangent it requires"
+                ),
+            ):
+                outputs[3].sum().backward()
 
     def test_backward_epilogue_compiled_autograd_subclass(self):
         from torch.testing._internal.two_tensor import TwoTensor

--- a/test/functorch/test_compile_to_python.py
+++ b/test/functorch/test_compile_to_python.py
@@ -280,6 +280,7 @@ class TestAOTCompileToPython(TestCase):
         source, final_cache = state.finalize(tuple(masks))
         self.assertIn("2: (_inner_call_bw_0", source)
         self.assertIn("_AOT_DEFAULT_BACKWARD_VARIANT = None", source)
+        self.assertIn("KeptTangentInfo", source)
         loaded = load_from_python(source, final_cache)
         run_x = x.detach().clone().requires_grad_()
         run_y = y.detach().clone().requires_grad_()

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -5277,6 +5277,7 @@ class TestPrecompileNumerics(TestCase):
         self.assertIn("1: (_inner_call_bw_0", code)
         self.assertIn("2: (_inner_call_bw_1", code)
         self.assertIn("_AOT_DEFAULT_BACKWARD_VARIANT_s0 = None", code)
+        self.assertIn("KeptTangentInfo", code)
         self.assertEqual(code.count("Inner Inductor output code: BACKWARD variant"), 2)
 
         for _, loaded in _default_and_inlined_loaders(code, cache, "inductor"):

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2758,9 +2758,152 @@ _GradOutputPrototypeType = (
 )
 
 
+class KeptTangentInfo(typing.NamedTuple):
+    """Runtime-safe metadata for tangent slots retained by the backward prologue."""
+
+    grad_out_idx: tuple[int, ...]
+    dtype: tuple[torch.dtype | None, ...]
+    num_mutated_inputs: int
+    num_outputs: int
+    num_intermediate_bases: int
+    output_type: tuple[str, ...]
+    output_requires_grad: tuple[bool, ...]
+    output_requires_grad_for_backward: tuple[bool, ...]
+
+
+def _kept_tangent_info(fw_metadata: ViewAndMutationMeta) -> KeptTangentInfo:
+    grad_out_idx = tuple(_grad_output_surviving_indices(fw_metadata))
+    tangent_dtypes = getattr(fw_metadata, "traced_tangent_dtypes", None) or []
+    if len(tangent_dtypes) != len(grad_out_idx):
+        tangent_dtypes = [None] * len(grad_out_idx)
+    return KeptTangentInfo(
+        grad_out_idx=grad_out_idx,
+        dtype=tuple(tangent_dtypes),
+        num_mutated_inputs=fw_metadata.num_mutated_inp_runtime_indices,
+        num_outputs=fw_metadata.num_outputs,
+        num_intermediate_bases=fw_metadata.num_intermediate_bases,
+        output_type=tuple(info.output_type.name for info in fw_metadata.output_info),
+        output_requires_grad=tuple(
+            info.requires_grad for info in fw_metadata.output_info
+        ),
+        output_requires_grad_for_backward=tuple(
+            info.requires_grad_for_backward for info in fw_metadata.output_info
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class _MaterializedFlatTangent:
     values: tuple[torch.Tensor | CustomClassBase, ...]
+
+
+def _non_tensor_tangent_error(
+    x: Any,
+    tangent_idx: int,
+    tangent_desc: Any | None,
+    compile_id_str: str | None,
+    tangent_stack_trace: str | None,
+    kept_tangent_info: KeptTangentInfo,
+) -> RuntimeError:
+    from .descriptors import IntermediateBaseAOTOutput, PlainAOTOutput, TangentAOTInput
+
+    out_idx: int | None = None
+    via_base = False
+    if isinstance(tangent_desc, TangentAOTInput):
+        out = tangent_desc.output
+        if isinstance(out, IntermediateBaseAOTOutput):
+            via_base = True
+            out = out.base_of
+        if isinstance(out, PlainAOTOutput):
+            out_idx = out.idx
+
+    lines = [
+        f"  tangent index         : {tangent_idx}",
+        f"  received              : {x!r:.200} (type {type(x).__name__}, expected a Tensor)",
+        f"  tangent descriptor    : {tangent_desc!r}",
+    ]
+    if isinstance(tangent_desc, TangentAOTInput):
+        lines.append(f"  descriptor expression : {tangent_desc.expr()}")
+
+    dtype: torch.dtype | None = None
+    if tangent_idx < len(kept_tangent_info.grad_out_idx):
+        info = kept_tangent_info
+        dtype = info.dtype[tangent_idx]
+        grad_out_idx = info.grad_out_idx[tangent_idx]
+        total = info.num_mutated_inputs + info.num_outputs + info.num_intermediate_bases
+        if grad_out_idx < info.num_mutated_inputs:
+            what = "the updated value of a mutated forward input"
+        elif grad_out_idx < info.num_mutated_inputs + info.num_outputs:
+            what = f"user forward output {grad_out_idx - info.num_mutated_inputs}"
+        else:
+            nth = grad_out_idx - info.num_mutated_inputs - info.num_outputs
+            what = f"intermediate base {nth} (not a user output)"
+        lines.append(
+            f"  grad_output slot      : {grad_out_idx} of {total} slots returned "
+            "by the compiled autograd.Function"
+        )
+        lines.append(f"  that slot holds       : {what}")
+        if out_idx is not None and out_idx < len(info.output_type):
+            suffix = " (the output this intermediate base backs)" if via_base else ""
+            lines.append(f"  user output index     : {out_idx}{suffix}")
+            lines.append(
+                f"  its OutputType        : OutputType.{info.output_type[out_idx]}"
+            )
+            lines.append(
+                f"  its requires_grad     : {info.output_requires_grad[out_idx]} "
+                f"(requires_grad_for_backward="
+                f"{info.output_requires_grad_for_backward[out_idx]})"
+            )
+        if dtype is not None:
+            lines.append(f"  its dtype             : {dtype}")
+    elif out_idx is not None:
+        lines.append(f"  user output index     : {out_idx}")
+
+    if dtype is None:
+        reason = "any of (1), (2) or (3): no dtype was recorded for this slot."
+    elif not (dtype.is_floating_point or dtype.is_complex):
+        reason = f"""(1).
+{dtype} is not a differentiable dtype, so autograd never recorded gradient
+metadata for this output, yet AOTAutograd recorded that same output as needing a
+tangent."""
+    else:
+        reason = """(2) or (3), since the dtype above is differentiable.
+AOTAutograd marks every returned slot whose recorded requires_grad is False, and
+marking is keyed on TensorImpl, so a backend returning the same tensor object in
+two returned slots marks both. Inductor lowers aten.detach to a no-op and folds
+h * 1 / h + 0 away, which is how one object can end up in two slots."""
+
+    graph_hint = (
+        f"\nThis error occurred in compiled graph [{compile_id_str}]."
+        if compile_id_str is not None
+        else ""
+    )
+    stack_hint = (
+        f"\nThe forward output was created here:\n{tangent_stack_trace}"
+        if tangent_stack_trace is not None
+        else ""
+    )
+    body = "\n".join(lines)
+    return RuntimeError(
+        f"""
+The compiled backward was handed a non-Tensor for a tangent it requires.
+
+{body}
+
+Autograd hands back None rather than a zero tangent only for a returned slot it
+recorded no gradient metadata for, which is exactly three cases: (1) the output
+has a non-differentiable dtype, (2) the output was marked via
+ctx.mark_non_differentiable, or (3) the forward returned a non-Tensor in that
+slot. AOTAutograd's forward epilogue sets ctx._materialize_non_diff_grads =
+False, so nothing fills the slot back in.
+
+This slot is case {reason}
+
+The backward requires this tangent, so none of the three is something your model
+can ask for: this is a bug in AOTAutograd or in the backend. Please report it
+with this message.
+{graph_hint}{stack_hint}"""
+    )
 
 
 def _grad_output_tensor_prototype(
@@ -3130,6 +3273,7 @@ def _process_runtime_or_materialized_tangent(
     tangent_desc: Any,
     compile_id_str: str | None,
     tangent_stack_trace: str | None,
+    kept_tangent_info: KeptTangentInfo | None = None,
 ) -> list[Any]:
     if isinstance(tangent, _MaterializedFlatTangent):
         return list(tangent.values)
@@ -3140,6 +3284,7 @@ def _process_runtime_or_materialized_tangent(
         tangent_desc,
         compile_id_str,
         tangent_stack_trace,
+        kept_tangent_info,
     )[1]
 
 
@@ -3188,6 +3333,8 @@ def _materialize_missing_tangent_args(
     if not undefined_grad_out_indices_set:
         return
 
+    kept_tangent_info = _kept_tangent_info(fw_metadata)
+
     placeholders = bw_module.graph.find_nodes(op="placeholder")
     tangent_placeholders = [node for node in placeholders if _is_grad_tangent(node)]
     placeholder_positions = {node: i for i, node in enumerate(placeholders)}
@@ -3212,20 +3359,26 @@ def _materialize_missing_tangent_args(
         if grad_out_idx not in undefined_grad_out_indices_set:
             curr_flat_idx += arg_count
             continue
-        if grad_out_idx >= len(grad_output_prototypes):
-            curr_flat_idx += arg_count
-            continue
-
-        prototype = grad_output_prototypes[grad_out_idx]
-        if prototype is None:
-            curr_flat_idx += arg_count
-            continue
-
         tangent_stack_trace = (
             fw_metadata.tangent_source_stack_traces[tangent_idx]
             if fw_metadata.tangent_source_stack_traces
             else None
         )
+        prototype = (
+            grad_output_prototypes[grad_out_idx]
+            if grad_out_idx < len(grad_output_prototypes)
+            else None
+        )
+        if prototype is None:
+            raise _non_tensor_tangent_error(
+                None,
+                tangent_idx,
+                fw_metadata.traced_tangents_descs[tangent_idx],
+                fw_metadata.compile_id_str,
+                tangent_stack_trace,
+                kept_tangent_info,
+            )
+
         if isinstance(tangent_meta, SubclassCreationMeta):
             flat_tangents = list(
                 _flat_zeros_like_tangent_prototype(
@@ -3243,6 +3396,7 @@ def _materialize_missing_tangent_args(
                 fw_metadata.traced_tangents_descs[tangent_idx],
                 fw_metadata.compile_id_str,
                 tangent_stack_trace,
+                kept_tangent_info,
             )
         if len(flat_tangents) != arg_count:
             raise AssertionError(
@@ -4319,6 +4473,7 @@ def _codegen_backward_prologue(
     )
     all_surviving = _grad_output_surviving_indices(fw_metadata)
     num_flat_bw_args_with_grads = len(all_surviving)
+    kept_tangent_info = _kept_tangent_info(fw_metadata)
 
     buf = PySourceBuilder(
         "_backward_prologue",
@@ -4410,6 +4565,7 @@ def _codegen_backward_prologue(
             _tangent_descs_=fw_metadata.traced_tangents_descs,
             _compile_id_=fw_metadata.compile_id_str,
             _stack_traces_=fw_metadata.tangent_source_stack_traces or (),
+            _kept_tangent_info_=kept_tangent_info,
         )
 
         if has_subclass:
@@ -4432,9 +4588,12 @@ def _codegen_backward_prologue(
             buf.writeline(
                 "_fpt = list(_chain_("
                 "_process_materialized_tangent_(t, m, idx, desc, _compile_id_, "
-                "_stack_traces_[idx] if _stack_traces_ else None) "
-                "for idx, (t, m, desc) in enumerate("
-                "zip(_tangents, _tangent_metas_, _tangent_descs_))))"
+                "_stack_traces_[idx] if _stack_traces_ else None, "
+                "_kept_tangent_info_ if grad_idx not in "
+                "skip_materialize_grad_output_indices else None) "
+                "for idx, (t, m, desc, grad_idx) in enumerate("
+                "zip(_tangents, _tangent_metas_, _tangent_descs_, "
+                "_materialize_grad_output_indices_))))"
             )
 
             if codegen_unwrap_fn is not None:
@@ -4451,7 +4610,10 @@ def _codegen_backward_prologue(
                 buf.writeline(
                     "all_args[_i] = _process_tangent_(all_args[_i], "
                     "_tangent_metas_[j], j, _tangent_descs_[j], _compile_id_, "
-                    "_stack_traces_[j] if _stack_traces_ else None)[0]"
+                    "_stack_traces_[j] if _stack_traces_ else None, "
+                    "_kept_tangent_info_ if "
+                    "_materialize_grad_output_indices_[j] not in "
+                    "skip_materialize_grad_output_indices else None)[0]"
                 )
 
         if has_mutations_in_bw:
@@ -5100,7 +5262,22 @@ Your tensor subclass must implement __coerce_same_metadata_as_tangent__."""
         tangent_desc: Any | None = None,
         compile_id_str: str | None = None,
         tangent_stack_trace: str | None = None,
+        kept_tangent_info: KeptTangentInfo | None = None,
     ) -> tuple[Any, list[Any]]:
+        if (
+            not isinstance(x, torch.Tensor)
+            and tangent_idx is not None
+            and kept_tangent_info is not None
+        ):
+            raise _non_tensor_tangent_error(
+                x,
+                tangent_idx,
+                tangent_desc,
+                compile_id_str,
+                tangent_stack_trace,
+                kept_tangent_info,
+            )
+
         if x is None:
             return x, [None] * _tangent_meta_arg_count(meta)
 

--- a/torch/_functorch/_aot_autograd/schemas.py
+++ b/torch/_functorch/_aot_autograd/schemas.py
@@ -512,6 +512,10 @@ class ViewAndMutationMeta:
     # This list is generated after calling make_runtime_safe().
     traced_tangent_metas: list[Any] | None = None
 
+    # Same length and order as traced_tangents. Retained for runtime diagnostics
+    # after the fake traced tangents themselves are discarded.
+    traced_tangent_dtypes: list[torch.dtype | None] | None = None
+
     num_symints_saved_for_bw: int | None = None
 
     # See Note [Activations with no version counter checks in eager]
@@ -741,7 +745,8 @@ class ViewAndMutationMeta:
         There are various fields in ViewAndMutationMeta that aren't serializable. This function is called after all tracing
         is completed to simplify certain fields in the metadata so that they can be safely cached.
 
-        Doing so may lose information (in the case of traced_tangents), but none of the information is needed at runtime.
+        Doing so may lose information from traced_tangents while retaining the
+        runtime-safe summaries needed by the wrappers.
         """
         # TODO: This function is only a best effort: there are other fields that may not be cache safe
         # (i.e., there's no guarantee that tensor_flatten() returns a serializable result), or that
@@ -749,6 +754,10 @@ class ViewAndMutationMeta:
         if self.traced_tangent_metas is not None:
             raise AssertionError(
                 "traced_tangent_metas should be None before calling make_runtime_safe"
+            )
+        if self.traced_tangent_dtypes is not None:
+            raise AssertionError(
+                "traced_tangent_dtypes should be None before calling make_runtime_safe"
             )
 
         def extract_metadata(t: object) -> tuple[Sequence[str], object] | None:
@@ -764,6 +773,10 @@ class ViewAndMutationMeta:
                 return None
 
         self.traced_tangent_metas = [extract_metadata(t) for t in self.traced_tangents]
+        self.traced_tangent_dtypes = [
+            t.dtype if isinstance(t, torch.Tensor) else None
+            for t in self.traced_tangents
+        ]
         # Clear traced tangents at runtime
         self.traced_tangents = []
         for inp_meta in self.subclass_inp_meta:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194543
* __->__ #194528
* #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* #194468
* #194467
* #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

AOTAutograd intentionally lets undefined output tangents reach the lazy
backward compiler so it can specialize those inputs away or materialize zero
tangents. When neither path could resolve a slot, the remaining None previously
reached the backend and surfaced as an opaque expected-Tensor error.

Retain a runtime-safe mapping from kept tangent slots to their forward outputs
and report the output type, dtype, grad flags, descriptor, compile id, and source
stack only after specialization and materialization have both failed. An early
check in the common tangent processor would reject legal None values that an
observed backward variant intentionally removes, so generated prologues pass the
metadata only for slots the selected variant still requires. Keep the extended
helper signature backward compatible with older generated source.

Test Plan:

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 PYTHONPATH="$PWD/test/functorch" python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_aotdispatch.py"]; runpy.run_path("test/functorch/test_aotdispatch.py",run_name="__main__")'
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 PYTHONPATH="$PWD/test/functorch" python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_aotdispatch.py", "-k", "none_tangent"]; runpy.run_path("test/functorch/test_aotdispatch.py",run_name="__main__")'
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 python test/functorch/test_compile_to_python.py
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 python test/test_precompile.py
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 python test/dynamo/test_aot_autograd_cache.py
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 python test/dynamo/test_package.py
```

```
UV_OFFLINE=1 /home/bobren/local/c/pytorch-env/bin/spin lint
```

```
UV_OFFLINE=1 /home/bobren/local/c/pytorch-env/bin/spin quicklint -- --skip PYREFLY
```

The full lint command could not complete because Pyrefly crashes on the
pre-existing duplicate `prepare_qat` binding and the full-tree Ruff invocation
reports a missing path in this checkout. All changed-file linters other than
Pyrefly passed.

Authored with an AI assistant.

cc @albanD