### PR TITLE
Strict pyrefly checking: type torch/_numpy/_funcs_impl.py

### DIFF
--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -492,3 +492,13 @@ bad-param-name-override = false
 unannotated-return = true
 unannotated-parameter = true
 unannotated-attribute = true
+
+[[sub-config]]
+matches = "torch/_numpy/_funcs_impl.py"
+[sub-config.errors]
+implicit-import = false
+implicit-any = true
+bad-param-name-override = false
+unannotated-return = true
+unannotated-parameter = true
+unannotated-attribute = true

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -1,5 +1,3 @@
-# mypy: ignore-errors
-
 """A thin pytorch / numpy compat layer.
 
 Things imported from here have numpy-compatible signatures but operate on
@@ -23,6 +21,8 @@ from . import _dtypes_impl, _util
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from ._dtypes import DType
+    from ._ndarray import ndarray
     from ._normalizations import (
         ArrayLike,
         ArrayLikeOrScalar,
@@ -36,21 +36,21 @@ if TYPE_CHECKING:
 
 def copy(
     a: ArrayLike, order: NotImplementedType = "K", subok: NotImplementedType = False
-):
+) -> torch.Tensor:
     return a.clone()
 
 
 def copyto(
     dst: NDArray,
     src: ArrayLike,
-    casting: CastingModes | None = "same_kind",
+    casting: CastingModes = "same_kind",
     where: NotImplementedType = None,
-):
+) -> None:
     (src,) = _util.typecast_tensors((src,), dst.dtype, casting=casting)
     dst.copy_(src)
 
 
-def atleast_1d(*arys: ArrayLike):
+def atleast_1d(*arys: ArrayLike) -> torch.Tensor | list[torch.Tensor]:
     res = torch.atleast_1d(*arys)
     if isinstance(res, tuple):
         return list(res)
@@ -58,7 +58,7 @@ def atleast_1d(*arys: ArrayLike):
         return res
 
 
-def atleast_2d(*arys: ArrayLike):
+def atleast_2d(*arys: ArrayLike) -> torch.Tensor | list[torch.Tensor]:
     res = torch.atleast_2d(*arys)
     if isinstance(res, tuple):
         return list(res)
@@ -66,7 +66,7 @@ def atleast_2d(*arys: ArrayLike):
         return res
 
 
-def atleast_3d(*arys: ArrayLike):
+def atleast_3d(*arys: ArrayLike) -> torch.Tensor | list[torch.Tensor]:
     res = torch.atleast_3d(*arys)
     if isinstance(res, tuple):
         return list(res)
@@ -74,7 +74,9 @@ def atleast_3d(*arys: ArrayLike):
         return res
 
 
-def _concat_check(tup, dtype, out):
+def _concat_check(
+    tup: Sequence[torch.Tensor], dtype: torch.dtype | None, out: object
+) -> None:
     if tup == ():
         raise ValueError("need at least one array to concatenate")
 
@@ -87,24 +89,33 @@ def _concat_check(tup, dtype, out):
         )
 
 
-def _concat_cast_helper(tensors, out=None, dtype=None, casting="same_kind"):
+def _concat_cast_helper(
+    tensors: Sequence[torch.Tensor],
+    out: ndarray | None = None,
+    dtype: torch.dtype | None = None,
+    casting: str = "same_kind",
+) -> tuple[torch.Tensor, ...]:
     """Figure out dtypes, cast if necessary."""
 
-    if out is not None or dtype is not None:
+    if out is not None:
         # figure out the type of the inputs and outputs
         out_dtype = out.dtype.torch_dtype if dtype is None else dtype
+    elif dtype is not None:
+        out_dtype = dtype
     else:
         out_dtype = _dtypes_impl.result_type_impl(*tensors)
 
     # cast input arrays if necessary; do not broadcast them against `out`
-    tensors = _util.typecast_tensors(tensors, out_dtype, casting)
-
-    return tensors
+    return _util.typecast_tensors(tensors, out_dtype, casting)
 
 
 def _concatenate(
-    tensors, axis=0, out=None, dtype=None, casting: CastingModes | None = "same_kind"
-):
+    tensors: Sequence[torch.Tensor],
+    axis: int | None = 0,
+    out: ndarray | None = None,
+    dtype: torch.dtype | None = None,
+    casting: CastingModes = "same_kind",
+) -> torch.Tensor:
     # pure torch implementation, used below and in cov/corrcoef below
     tensors, axis = _util.axis_none_flatten(*tensors, axis=axis)
     tensors = _concat_cast_helper(tensors, out, dtype, casting)
@@ -113,11 +124,11 @@ def _concatenate(
 
 def concatenate(
     ar_tuple: Sequence[ArrayLike],
-    axis=0,
+    axis: int | None = 0,
     out: OutArray | None = None,
     dtype: DTypeLike | None = None,
-    casting: CastingModes | None = "same_kind",
-):
+    casting: CastingModes = "same_kind",
+) -> torch.Tensor:
     _concat_check(ar_tuple, dtype, out=out)
     result = _concatenate(ar_tuple, axis=axis, out=out, dtype=dtype, casting=casting)
     return result
@@ -127,8 +138,8 @@ def vstack(
     tup: Sequence[ArrayLike],
     *,
     dtype: DTypeLike | None = None,
-    casting: CastingModes | None = "same_kind",
-):
+    casting: CastingModes = "same_kind",
+) -> torch.Tensor:
     _concat_check(tup, dtype, out=None)
     tensors = _concat_cast_helper(tup, dtype=dtype, casting=casting)
     return torch.vstack(tensors)
@@ -141,8 +152,8 @@ def hstack(
     tup: Sequence[ArrayLike],
     *,
     dtype: DTypeLike | None = None,
-    casting: CastingModes | None = "same_kind",
-):
+    casting: CastingModes = "same_kind",
+) -> torch.Tensor:
     _concat_check(tup, dtype, out=None)
     tensors = _concat_cast_helper(tup, dtype=dtype, casting=casting)
     return torch.hstack(tensors)
@@ -152,8 +163,8 @@ def dstack(
     tup: Sequence[ArrayLike],
     *,
     dtype: DTypeLike | None = None,
-    casting: CastingModes | None = "same_kind",
-):
+    casting: CastingModes = "same_kind",
+) -> torch.Tensor:
     # XXX: in numpy 1.24 dstack does not have dtype and casting keywords
     # but {h,v}stack do.  Hence add them here for consistency.
     _concat_check(tup, dtype, out=None)
@@ -165,8 +176,8 @@ def column_stack(
     tup: Sequence[ArrayLike],
     *,
     dtype: DTypeLike | None = None,
-    casting: CastingModes | None = "same_kind",
-):
+    casting: CastingModes = "same_kind",
+) -> torch.Tensor:
     # XXX: in numpy 1.24 column_stack does not have dtype and casting keywords
     # but row_stack does. (because row_stack is an alias for vstack, really).
     # Hence add these keywords here for consistency.
@@ -177,21 +188,22 @@ def column_stack(
 
 def stack(
     arrays: Sequence[ArrayLike],
-    axis=0,
+    axis: int = 0,
     out: OutArray | None = None,
     *,
     dtype: DTypeLike | None = None,
-    casting: CastingModes | None = "same_kind",
-):
+    casting: CastingModes = "same_kind",
+) -> torch.Tensor:
     _concat_check(arrays, dtype, out=out)
 
     tensors = _concat_cast_helper(arrays, dtype=dtype, casting=casting)
     result_ndim = tensors[0].ndim + 1
     axis = _util.normalize_axis_index(axis, result_ndim)
-    return torch.stack(tensors, axis=axis)
+    # torch.stack accepts `axis` as an alias for `dim` at runtime.
+    return torch.stack(tensors, axis=axis)  # pyrefly: ignore[unexpected-keyword]
 
 
-def append(arr: ArrayLike, values: ArrayLike, axis=None):
+def append(arr: ArrayLike, values: ArrayLike, axis: int | None = None) -> torch.Tensor:
     if axis is None:
         if arr.ndim != 1:
             arr = arr.flatten()
@@ -203,7 +215,12 @@ def append(arr: ArrayLike, values: ArrayLike, axis=None):
 # ### split ###
 
 
-def _split_helper(tensor, indices_or_sections, axis, strict=False):
+def _split_helper(
+    tensor: torch.Tensor,
+    indices_or_sections: int | Sequence[int],
+    axis: int,
+    strict: bool = False,
+) -> tuple[torch.Tensor, ...]:
     if isinstance(indices_or_sections, int):
         return _split_helper_int(tensor, indices_or_sections, axis, strict)
     elif isinstance(indices_or_sections, (list, tuple)):
@@ -213,7 +230,9 @@ def _split_helper(tensor, indices_or_sections, axis, strict=False):
         raise TypeError(f"split_helper: {type(indices_or_sections)}")
 
 
-def _split_helper_int(tensor, indices_or_sections, axis, strict=False):
+def _split_helper_int(
+    tensor: torch.Tensor, indices_or_sections: int, axis: int, strict: bool = False
+) -> tuple[torch.Tensor, ...]:
     if not isinstance(indices_or_sections, int):
         raise NotImplementedError("split: indices_or_sections")
 
@@ -240,7 +259,9 @@ def _split_helper_int(tensor, indices_or_sections, axis, strict=False):
     return torch.split(tensor, lst, axis)
 
 
-def _split_helper_list(tensor, indices_or_sections, axis):
+def _split_helper_list(
+    tensor: torch.Tensor, indices_or_sections: list[int], axis: int
+) -> tuple[torch.Tensor, ...]:
     if not isinstance(indices_or_sections, list):
         raise NotImplementedError("split: indices_or_sections: list")
     # numpy expects indices, while torch expects lengths of sections
@@ -257,38 +278,50 @@ def _split_helper_list(tensor, indices_or_sections, axis):
     return torch.split(tensor, lst, axis)
 
 
-def array_split(ary: ArrayLike, indices_or_sections, axis=0):
+def array_split(
+    ary: ArrayLike, indices_or_sections: int | Sequence[int], axis: int = 0
+) -> tuple[torch.Tensor, ...]:
     return _split_helper(ary, indices_or_sections, axis)
 
 
-def split(ary: ArrayLike, indices_or_sections, axis=0):
+def split(
+    ary: ArrayLike, indices_or_sections: int | Sequence[int], axis: int = 0
+) -> tuple[torch.Tensor, ...]:
     return _split_helper(ary, indices_or_sections, axis, strict=True)
 
 
-def hsplit(ary: ArrayLike, indices_or_sections):
+def hsplit(
+    ary: ArrayLike, indices_or_sections: int | Sequence[int]
+) -> tuple[torch.Tensor, ...]:
     if ary.ndim == 0:
         raise ValueError("hsplit only works on arrays of 1 or more dimensions")
     axis = 1 if ary.ndim > 1 else 0
     return _split_helper(ary, indices_or_sections, axis, strict=True)
 
 
-def vsplit(ary: ArrayLike, indices_or_sections):
+def vsplit(
+    ary: ArrayLike, indices_or_sections: int | Sequence[int]
+) -> tuple[torch.Tensor, ...]:
     if ary.ndim < 2:
         raise ValueError("vsplit only works on arrays of 2 or more dimensions")
     return _split_helper(ary, indices_or_sections, 0, strict=True)
 
 
-def dsplit(ary: ArrayLike, indices_or_sections):
+def dsplit(
+    ary: ArrayLike, indices_or_sections: int | Sequence[int]
+) -> tuple[torch.Tensor, ...]:
     if ary.ndim < 3:
         raise ValueError("dsplit only works on arrays of 3 or more dimensions")
     return _split_helper(ary, indices_or_sections, 2, strict=True)
 
 
-def kron(a: ArrayLike, b: ArrayLike):
+def kron(a: ArrayLike, b: ArrayLike) -> torch.Tensor:
     return torch.kron(a, b)
 
 
-def vander(x: ArrayLike, N=None, increasing=False):
+def vander(
+    x: ArrayLike, N: int | None = None, increasing: bool = False
+) -> torch.Tensor:
     return torch.vander(x, N, increasing)
 
 
@@ -298,12 +331,12 @@ def vander(x: ArrayLike, N=None, increasing=False):
 def linspace(
     start: ArrayLike,
     stop: ArrayLike,
-    num=50,
-    endpoint=True,
-    retstep=False,
+    num: int = 50,
+    endpoint: bool = True,
+    retstep: bool = False,
     dtype: DTypeLike | None = None,
-    axis=0,
-):
+    axis: int = 0,
+) -> torch.Tensor:
     if axis != 0 or retstep or not endpoint:
         raise NotImplementedError
     if dtype is None:
@@ -315,16 +348,17 @@ def linspace(
 def geomspace(
     start: ArrayLike,
     stop: ArrayLike,
-    num=50,
-    endpoint=True,
+    num: int = 50,
+    endpoint: bool = True,
     dtype: DTypeLike | None = None,
-    axis=0,
-):
+    axis: int = 0,
+) -> torch.Tensor:
     if axis != 0 or not endpoint:
         raise NotImplementedError
     base = torch.pow(stop / start, 1.0 / (num - 1))
     logbase = torch.log(base)
-    return torch.logspace(
+    # torch.logspace accepts tensor start/end/base at runtime.
+    return torch.logspace(  # pyrefly: ignore[no-matching-overload]
         torch.log(start) / logbase,
         torch.log(stop) / logbase,
         num,
@@ -333,14 +367,14 @@ def geomspace(
 
 
 def logspace(
-    start,
-    stop,
-    num=50,
-    endpoint=True,
-    base=10.0,
+    start: float,
+    stop: float,
+    num: int = 50,
+    endpoint: bool = True,
+    base: float = 10.0,
     dtype: DTypeLike | None = None,
-    axis=0,
-):
+    axis: int = 0,
+) -> torch.Tensor:
     if axis != 0 or not endpoint:
         raise NotImplementedError
     return torch.logspace(start, stop, num, base=base, dtype=dtype)
@@ -353,12 +387,12 @@ def arange(
     dtype: DTypeLike | None = None,
     *,
     like: NotImplementedType = None,
-):
+) -> torch.Tensor:
     if step == 0:
         raise ZeroDivisionError
-    if stop is None and start is None:
-        raise TypeError
     if stop is None:
+        if start is None:
+            raise TypeError
         # XXX: this breaks if start is passed as a kwarg:
         # arange(start=4) should raise (no stop) but doesn't
         start, stop = 0, start
@@ -366,22 +400,30 @@ def arange(
         start = 0
 
     # the dtype of the result
+    # NB: a None step is not handled here (numpy would treat it as 1); passing
+    # step=None reaches these helpers and raises, matching prior behavior.
     if dtype is None:
         dtype = (
             _dtypes_impl.default_dtypes().float_dtype
+            # pyrefly: ignore[bad-argument-type]
             if any(_dtypes_impl.is_float_or_fp_tensor(x) for x in (start, stop, step))
             else _dtypes_impl.default_dtypes().int_dtype
         )
     work_dtype = torch.float64 if dtype.is_complex else dtype
 
     # RuntimeError: "lt_cpu" not implemented for 'ComplexFloat'. Fall back to eager.
+    # pyrefly: ignore[bad-argument-type]
     if any(_dtypes_impl.is_complex_or_complex_tensor(x) for x in (start, stop, step)):
         raise NotImplementedError
 
+    # The complex check above guarantees start/stop/step are real and orderable.
+    # pyrefly: ignore[unsupported-operation]
     if (step > 0 and start > stop) or (step < 0 and start < stop):
         # empty range
         return torch.empty(0, dtype=dtype)
 
+    # torch.arange accepts scalar tensors as bounds at runtime.
+    # pyrefly: ignore[no-matching-overload]
     result = torch.arange(start, stop, step, dtype=work_dtype)
     result = _util.cast_if_needed(result, dtype)
     return result
@@ -391,12 +433,12 @@ def arange(
 
 
 def empty(
-    shape,
+    shape: int | Sequence[int],
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "C",
     *,
     like: NotImplementedType = None,
-):
+) -> torch.Tensor:
     if dtype is None:
         dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.empty(shape, dtype=dtype)
@@ -411,8 +453,8 @@ def empty_like(
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "K",
     subok: NotImplementedType = False,
-    shape=None,
-):
+    shape: int | Sequence[int] | None = None,
+) -> torch.Tensor:
     result = torch.empty_like(prototype, dtype=dtype)
     if shape is not None:
         result = result.reshape(shape)
@@ -420,30 +462,34 @@ def empty_like(
 
 
 def full(
-    shape,
+    shape: int | Sequence[int],
     fill_value: ArrayLike,
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "C",
     *,
     like: NotImplementedType = None,
-):
+) -> torch.Tensor:
     if isinstance(shape, int):
         shape = (shape,)
     if dtype is None:
         dtype = fill_value.dtype
     if not isinstance(shape, (tuple, list)):
-        shape = (shape,)
+        # defensive wrap for non-int scalar shapes (e.g. numpy scalars) that
+        # fall outside the annotated int | Sequence[int] domain
+        shape = (shape,)  # pyrefly: ignore[bad-assignment]
+    # torch.full accepts a tensor fill_value at runtime.
+    # pyrefly: ignore[no-matching-overload]
     return torch.full(shape, fill_value, dtype=dtype)
 
 
 def full_like(
     a: ArrayLike,
-    fill_value,
+    fill_value: int | float | complex | bool,
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "K",
     subok: NotImplementedType = False,
-    shape=None,
-):
+    shape: int | Sequence[int] | None = None,
+) -> torch.Tensor:
     # XXX: fill_value broadcasts
     result = torch.full_like(a, fill_value, dtype=dtype)
     if shape is not None:
@@ -452,12 +498,12 @@ def full_like(
 
 
 def ones(
-    shape,
+    shape: int | Sequence[int],
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "C",
     *,
     like: NotImplementedType = None,
-):
+) -> torch.Tensor:
     if dtype is None:
         dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.ones(shape, dtype=dtype)
@@ -468,8 +514,8 @@ def ones_like(
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "K",
     subok: NotImplementedType = False,
-    shape=None,
-):
+    shape: int | Sequence[int] | None = None,
+) -> torch.Tensor:
     result = torch.ones_like(a, dtype=dtype)
     if shape is not None:
         result = result.reshape(shape)
@@ -477,12 +523,12 @@ def ones_like(
 
 
 def zeros(
-    shape,
+    shape: int | Sequence[int],
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "C",
     *,
     like: NotImplementedType = None,
-):
+) -> torch.Tensor:
     if dtype is None:
         dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.zeros(shape, dtype=dtype)
@@ -493,8 +539,8 @@ def zeros_like(
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "K",
     subok: NotImplementedType = False,
-    shape=None,
-):
+    shape: int | Sequence[int] | None = None,
+) -> torch.Tensor:
     result = torch.zeros_like(a, dtype=dtype)
     if shape is not None:
         result = result.reshape(shape)
@@ -504,7 +550,9 @@ def zeros_like(
 # ### cov & corrcoef ###
 
 
-def _xy_helper_corrcoef(x_tensor, y_tensor=None, rowvar=True):
+def _xy_helper_corrcoef(
+    x_tensor: torch.Tensor, y_tensor: torch.Tensor | None = None, rowvar: bool = True
+) -> torch.Tensor:
     """Prepare inputs for cov and corrcoef."""
 
     # https://github.com/numpy/numpy/blob/v1.24.0/numpy/lib/function_base.py#L2636
@@ -532,12 +580,12 @@ def _xy_helper_corrcoef(x_tensor, y_tensor=None, rowvar=True):
 def corrcoef(
     x: ArrayLike,
     y: ArrayLike | None = None,
-    rowvar=True,
-    bias=None,
-    ddof=None,
+    rowvar: bool = True,
+    bias: int | None = None,
+    ddof: int | None = None,
     *,
     dtype: DTypeLike | None = None,
-):
+) -> torch.Tensor:
     if bias is not None or ddof is not None:
         # deprecated in NumPy
         raise NotImplementedError
@@ -560,14 +608,14 @@ def corrcoef(
 def cov(
     m: ArrayLike,
     y: ArrayLike | None = None,
-    rowvar=True,
-    bias=False,
-    ddof=None,
+    rowvar: bool = True,
+    bias: bool = False,
+    ddof: int | None = None,
     fweights: ArrayLike | None = None,
     aweights: ArrayLike | None = None,
     *,
     dtype: DTypeLike | None = None,
-):
+) -> torch.Tensor:
     m = _xy_helper_corrcoef(m, y, rowvar)
 
     if ddof is None:
@@ -587,7 +635,7 @@ def cov(
     return result
 
 
-def _conv_corr_impl(a, v, mode):
+def _conv_corr_impl(a: torch.Tensor, v: torch.Tensor, mode: str) -> torch.Tensor:
     dt = _dtypes_impl.result_type_impl(a, v)
     a = _util.cast_if_needed(a, dt)
     v = _util.cast_if_needed(v, dt)
@@ -610,7 +658,7 @@ def _conv_corr_impl(a, v, mode):
     return result[0, :]
 
 
-def convolve(a: ArrayLike, v: ArrayLike, mode="full"):
+def convolve(a: ArrayLike, v: ArrayLike, mode: str = "full") -> torch.Tensor:
     # NumPy: if v is longer than a, the arrays are swapped before computation
     if a.shape[0] < v.shape[0]:
         a, v = v, a
@@ -621,7 +669,7 @@ def convolve(a: ArrayLike, v: ArrayLike, mode="full"):
     return _conv_corr_impl(a, v, mode)
 
 
-def correlate(a: ArrayLike, v: ArrayLike, mode="valid"):
+def correlate(a: ArrayLike, v: ArrayLike, mode: str = "valid") -> torch.Tensor:
     v = torch.conj_physical(v)
     return _conv_corr_impl(a, v, mode)
 
@@ -629,10 +677,12 @@ def correlate(a: ArrayLike, v: ArrayLike, mode="valid"):
 # ### logic & element selection ###
 
 
-def bincount(x: ArrayLike, /, weights: ArrayLike | None = None, minlength=0):
+def bincount(
+    x: ArrayLike, /, weights: ArrayLike | None = None, minlength: int = 0
+) -> torch.Tensor:
     if x.numel() == 0:
-        # edge case allowed by numpy
-        x = x.new_empty(0, dtype=int)
+        # edge case allowed by numpy; torch accepts the python `int` type as dtype
+        x = x.new_empty(0, dtype=int)  # pyrefly: ignore[no-matching-overload]
 
     int_dtype = _dtypes_impl.default_dtypes().int_dtype
     (x,) = _util.typecast_tensors((x,), int_dtype, casting="safe")
@@ -645,14 +695,15 @@ def where(
     x: ArrayLikeOrScalar | None = None,
     y: ArrayLikeOrScalar | None = None,
     /,
-):
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
     if (x is None) != (y is None):
         raise ValueError("either both or neither of x and y should be given")
 
     if condition.dtype != torch.bool:
         condition = condition.to(torch.bool)
 
-    if x is None and y is None:
+    # the guard above guarantees x and y are either both None or both non-None
+    if x is None or y is None:
         result = torch.where(condition)
     else:
         result = torch.where(condition, x, y)
@@ -662,15 +713,15 @@ def where(
 # ###### module-level queries of object properties
 
 
-def ndim(a: ArrayLike):
+def ndim(a: ArrayLike) -> int:
     return a.ndim
 
 
-def shape(a: ArrayLike):
+def shape(a: ArrayLike) -> tuple[int, ...]:
     return tuple(a.shape)
 
 
-def size(a: ArrayLike, axis=None):
+def size(a: ArrayLike, axis: int | None = None) -> int:
     if axis is None:
         return a.numel()
     else:
@@ -680,12 +731,12 @@ def size(a: ArrayLike, axis=None):
 # ###### shape manipulations and indexing
 
 
-def expand_dims(a: ArrayLike, axis):
+def expand_dims(a: ArrayLike, axis: int | tuple[int, ...]) -> torch.Tensor:
     shape = _util.expand_shape(a.shape, axis)
     return a.view(shape)  # never copies
 
 
-def flip(m: ArrayLike, axis=None):
+def flip(m: ArrayLike, axis: int | tuple[int, ...] | None = None) -> torch.Tensor:
     # XXX: semantic difference: np.flip returns a view, torch.flip copies
     if axis is None:
         axis = tuple(range(m.ndim))
@@ -694,15 +745,15 @@ def flip(m: ArrayLike, axis=None):
     return torch.flip(m, axis)
 
 
-def flipud(m: ArrayLike):
+def flipud(m: ArrayLike) -> torch.Tensor:
     return torch.flipud(m)
 
 
-def fliplr(m: ArrayLike):
+def fliplr(m: ArrayLike) -> torch.Tensor:
     return torch.fliplr(m)
 
 
-def rot90(m: ArrayLike, k=1, axes=(0, 1)):
+def rot90(m: ArrayLike, k: int = 1, axes: tuple[int, ...] = (0, 1)) -> torch.Tensor:
     axes = _util.normalize_axis_tuple(axes, m.ndim)
     return torch.rot90(m, k, axes)
 
@@ -710,21 +761,32 @@ def rot90(m: ArrayLike, k=1, axes=(0, 1)):
 # ### broadcasting and indices ###
 
 
-def broadcast_to(array: ArrayLike, shape, subok: NotImplementedType = False):
+def broadcast_to(
+    array: ArrayLike, shape: int | Sequence[int], subok: NotImplementedType = False
+) -> torch.Tensor:
+    if isinstance(shape, int):
+        shape = (shape,)
     return torch.broadcast_to(array, size=shape)
 
 
 # This is a function from tuples to tuples, so we just reuse it.  However,
 # dynamo expects its __module__ to be torch._numpy
-def broadcast_shapes(*args):
+def broadcast_shapes(*args: int | Sequence[int]) -> torch.Size:
     return torch.broadcast_shapes(*args)
 
 
-def broadcast_arrays(*args: ArrayLike, subok: NotImplementedType = False):
+def broadcast_arrays(
+    *args: ArrayLike, subok: NotImplementedType = False
+) -> list[torch.Tensor]:
     return torch.broadcast_tensors(*args)
 
 
-def meshgrid(*xi: ArrayLike, copy=True, sparse=False, indexing="xy"):
+def meshgrid(
+    *xi: ArrayLike,
+    copy: bool = True,
+    sparse: bool = False,
+    indexing: str = "xy",
+) -> list[torch.Tensor]:
     ndim = len(xi)
 
     if indexing not in ["xy", "ij"]:
@@ -748,57 +810,58 @@ def meshgrid(*xi: ArrayLike, copy=True, sparse=False, indexing="xy"):
     return list(output)  # match numpy, return a list
 
 
-def indices(dimensions, dtype: DTypeLike | None = int, sparse=False):
+def indices(
+    dimensions: Sequence[int],
+    dtype: DTypeLike | None = torch.int64,
+    sparse: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
     # https://github.com/numpy/numpy/blob/v1.24.0/numpy/core/numeric.py#L1691-L1791
     dimensions = tuple(dimensions)
     N = len(dimensions)
     shape = (1,) * N
+    idxs = [
+        torch.arange(dim, dtype=dtype).reshape(shape[:i] + (dim,) + shape[i + 1 :])
+        for i, dim in enumerate(dimensions)
+    ]
     if sparse:
-        res = ()
-    else:
-        res = torch.empty((N,) + dimensions, dtype=dtype)
-    for i, dim in enumerate(dimensions):
-        idx = torch.arange(dim, dtype=dtype).reshape(
-            shape[:i] + (dim,) + shape[i + 1 :]
-        )
-        if sparse:
-            res = res + (idx,)
-        else:
-            res[i] = idx
+        return tuple(idxs)
+    res = torch.empty((N,) + dimensions, dtype=dtype)
+    for i, idx in enumerate(idxs):
+        res[i] = idx
     return res
 
 
 # ### tri*-something ###
 
 
-def tril(m: ArrayLike, k=0):
+def tril(m: ArrayLike, k: int = 0) -> torch.Tensor:
     return torch.tril(m, k)
 
 
-def triu(m: ArrayLike, k=0):
+def triu(m: ArrayLike, k: int = 0) -> torch.Tensor:
     return torch.triu(m, k)
 
 
-def tril_indices(n, k=0, m=None):
+def tril_indices(n: int, k: int = 0, m: int | None = None) -> torch.Tensor:
     if m is None:
         m = n
     return torch.tril_indices(n, m, offset=k)
 
 
-def triu_indices(n, k=0, m=None):
+def triu_indices(n: int, k: int = 0, m: int | None = None) -> torch.Tensor:
     if m is None:
         m = n
     return torch.triu_indices(n, m, offset=k)
 
 
-def tril_indices_from(arr: ArrayLike, k=0):
+def tril_indices_from(arr: ArrayLike, k: int = 0) -> torch.Tensor:
     if arr.ndim != 2:
         raise ValueError("input array must be 2-d")
     # Return a tensor rather than a tuple to avoid a graphbreak
     return torch.tril_indices(arr.shape[0], arr.shape[1], offset=k)
 
 
-def triu_indices_from(arr: ArrayLike, k=0):
+def triu_indices_from(arr: ArrayLike, k: int = 0) -> torch.Tensor:
     if arr.ndim != 2:
         raise ValueError("input array must be 2-d")
     # Return a tensor rather than a tuple to avoid a graphbreak
@@ -806,13 +869,13 @@ def triu_indices_from(arr: ArrayLike, k=0):
 
 
 def tri(
-    N,
-    M=None,
-    k=0,
+    N: int,
+    M: int | None = None,
+    k: int = 0,
     dtype: DTypeLike | None = None,
     *,
     like: NotImplementedType = None,
-):
+) -> torch.Tensor:
     if M is None:
         M = N
     tensor = torch.ones((N, M), dtype=dtype)
@@ -822,35 +885,47 @@ def tri(
 # ### equality, equivalence, allclose ###
 
 
-def isclose(a: ArrayLike, b: ArrayLike, rtol=1.0e-5, atol=1.0e-8, equal_nan=False):
+def isclose(
+    a: ArrayLike,
+    b: ArrayLike,
+    rtol: float = 1.0e-5,
+    atol: float = 1.0e-8,
+    equal_nan: bool = False,
+) -> torch.Tensor:
     dtype = _dtypes_impl.result_type_impl(a, b)
     a = _util.cast_if_needed(a, dtype)
     b = _util.cast_if_needed(b, dtype)
     return torch.isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
-def allclose(a: ArrayLike, b: ArrayLike, rtol=1e-05, atol=1e-08, equal_nan=False):
+def allclose(
+    a: ArrayLike,
+    b: ArrayLike,
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+    equal_nan: bool = False,
+) -> bool:
     dtype = _dtypes_impl.result_type_impl(a, b)
     a = _util.cast_if_needed(a, dtype)
     b = _util.cast_if_needed(b, dtype)
     return torch.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
 
 
-def _tensor_equal(a1, a2, equal_nan=False):
+def _tensor_equal(a1: torch.Tensor, a2: torch.Tensor, equal_nan: bool = False) -> bool:
     # Implementation of array_equal/array_equiv.
     if a1.shape != a2.shape:
         return False
     cond = a1 == a2
     if equal_nan:
         cond = cond | (torch.isnan(a1) & torch.isnan(a2))
-    return cond.all().item()
+    return bool(cond.all().item())
 
 
-def array_equal(a1: ArrayLike, a2: ArrayLike, equal_nan=False):
+def array_equal(a1: ArrayLike, a2: ArrayLike, equal_nan: bool = False) -> bool:
     return _tensor_equal(a1, a2, equal_nan=equal_nan)
 
 
-def array_equiv(a1: ArrayLike, a2: ArrayLike):
+def array_equiv(a1: ArrayLike, a2: ArrayLike) -> bool:
     # *almost* the same as array_equal: _equiv tries to broadcast, _equal does not
     try:
         a1_t, a2_t = torch.broadcast_tensors(a1, a2)
@@ -861,8 +936,12 @@ def array_equiv(a1: ArrayLike, a2: ArrayLike):
 
 
 def nan_to_num(
-    x: ArrayLike, copy: NotImplementedType = True, nan=0.0, posinf=None, neginf=None
-):
+    x: ArrayLike,
+    copy: NotImplementedType = True,
+    nan: float = 0.0,
+    posinf: float | None = None,
+    neginf: float | None = None,
+) -> torch.Tensor:
     # work around RuntimeError: "nan_to_num" not implemented for 'ComplexDouble'
     if x.is_complex():
         re = torch.nan_to_num(x.real, nan=nan, posinf=posinf, neginf=neginf)
@@ -878,10 +957,10 @@ def nan_to_num(
 def take(
     a: ArrayLike,
     indices: ArrayLike,
-    axis=None,
+    axis: int | None = None,
     out: OutArray | None = None,
     mode: NotImplementedType = "raise",
-):
+) -> torch.Tensor:
     (a,), axis = _util.axis_none_flatten(a, axis=axis)
     axis = _util.normalize_axis_index(axis, a.ndim)
     idx = (slice(None),) * axis + (indices, ...)
@@ -889,7 +968,9 @@ def take(
     return result
 
 
-def take_along_axis(arr: ArrayLike, indices: ArrayLike, axis):
+def take_along_axis(
+    arr: ArrayLike, indices: ArrayLike, axis: int | None
+) -> torch.Tensor:
     (arr,), axis = _util.axis_none_flatten(arr, axis=axis)
     axis = _util.normalize_axis_index(axis, arr.ndim)
     return torch.take_along_dim(arr, indices, axis)
@@ -900,7 +981,7 @@ def put(
     indices: ArrayLike,
     values: ArrayLike,
     mode: NotImplementedType = "raise",
-):
+) -> None:
     v = values.type(a.dtype)
     # If indices is larger than v, expand v to at least the size of indices. Any
     # unnecessary trailing elements are then trimmed.
@@ -916,7 +997,9 @@ def put(
     return None
 
 
-def put_along_axis(arr: ArrayLike, indices: ArrayLike, values: ArrayLike, axis):
+def put_along_axis(
+    arr: ArrayLike, indices: ArrayLike, values: ArrayLike, axis: int | None
+) -> None:
     (arr,), axis = _util.axis_none_flatten(arr, axis=axis)
     axis = _util.normalize_axis_index(axis, arr.ndim)
 
@@ -932,19 +1015,19 @@ def choose(
     choices: Sequence[ArrayLike],
     out: OutArray | None = None,
     mode: NotImplementedType = "raise",
-):
+) -> torch.Tensor:
     # First, broadcast elements of `choices`
-    choices = torch.stack(torch.broadcast_tensors(*choices))
+    choices_t = torch.stack(torch.broadcast_tensors(*choices))
 
     # Use an analog of `gather(choices, 0, a)` which broadcasts `choices` vs `a`:
     # (taken from https://github.com/pytorch/pytorch/issues/9407#issuecomment-1427907939)
-    idx_list = [
-        torch.arange(dim).view((1,) * i + (dim,) + (1,) * (choices.ndim - i - 1))
-        for i, dim in enumerate(choices.shape)
+    idx_list: list[torch.Tensor] = [
+        torch.arange(dim).view((1,) * i + (dim,) + (1,) * (choices_t.ndim - i - 1))
+        for i, dim in enumerate(choices_t.shape)
     ]
 
     idx_list[0] = a
-    return choices[tuple(idx_list)].squeeze(0)
+    return choices_t[tuple(idx_list)].squeeze(0)
 
 
 # ### unique et al. ###
@@ -953,12 +1036,12 @@ def choose(
 def unique(
     ar: ArrayLike,
     return_index: NotImplementedType = False,
-    return_inverse=False,
-    return_counts=False,
-    axis=None,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    axis: int | None = None,
     *,
     equal_nan: NotImplementedType = True,
-):
+) -> torch.Tensor | tuple[torch.Tensor, ...]:
     (ar,), axis = _util.axis_none_flatten(ar, axis=axis)
     axis = _util.normalize_axis_index(axis, ar.ndim)
 
@@ -969,15 +1052,15 @@ def unique(
     return result
 
 
-def nonzero(a: ArrayLike):
+def nonzero(a: ArrayLike) -> tuple[torch.Tensor, ...]:
     return torch.nonzero(a, as_tuple=True)
 
 
-def argwhere(a: ArrayLike):
+def argwhere(a: ArrayLike) -> torch.Tensor:
     return torch.argwhere(a)
 
 
-def flatnonzero(a: ArrayLike):
+def flatnonzero(a: ArrayLike) -> torch.Tensor:
     return torch.flatten(a).nonzero(as_tuple=True)[0]
 
 
@@ -986,21 +1069,25 @@ def clip(
     min: ArrayLike | None = None,
     max: ArrayLike | None = None,
     out: OutArray | None = None,
-):
+) -> torch.Tensor:
     return torch.clamp(a, min, max)
 
 
-def repeat(a: ArrayLike, repeats: ArrayLikeOrScalar, axis=None):
+def repeat(
+    a: ArrayLike, repeats: ArrayLikeOrScalar, axis: int | None = None
+) -> torch.Tensor:
+    # torch.repeat_interleave accepts a tensor/int repeats and optional axis.
+    # pyrefly: ignore[no-matching-overload]
     return torch.repeat_interleave(a, repeats, axis)
 
 
-def tile(A: ArrayLike, reps):
+def tile(A: ArrayLike, reps: int | Sequence[int]) -> torch.Tensor:
     if isinstance(reps, int):
         reps = (reps,)
     return torch.tile(A, reps)
 
 
-def resize(a: ArrayLike, new_shape=None):
+def resize(a: ArrayLike, new_shape: int | Sequence[int] | None = None) -> torch.Tensor:
     # implementation vendored from
     # https://github.com/numpy/numpy/blob/v1.24.0/numpy/core/fromnumeric.py#L1420-L1497
     if new_shape is None:
@@ -1030,7 +1117,9 @@ def resize(a: ArrayLike, new_shape=None):
 # ### diag et al. ###
 
 
-def diagonal(a: ArrayLike, offset=0, axis1=0, axis2=1):
+def diagonal(
+    a: ArrayLike, offset: int = 0, axis1: int = 0, axis2: int = 1
+) -> torch.Tensor:
     axis1 = _util.normalize_axis_index(axis1, a.ndim)
     axis2 = _util.normalize_axis_index(axis2, a.ndim)
     return torch.diagonal(a, offset, axis1, axis2)
@@ -1038,25 +1127,25 @@ def diagonal(a: ArrayLike, offset=0, axis1=0, axis2=1):
 
 def trace(
     a: ArrayLike,
-    offset=0,
-    axis1=0,
-    axis2=1,
+    offset: int = 0,
+    axis1: int = 0,
+    axis2: int = 1,
     dtype: DTypeLike | None = None,
     out: OutArray | None = None,
-):
+) -> torch.Tensor:
     result = torch.diagonal(a, offset, dim1=axis1, dim2=axis2).sum(-1, dtype=dtype)
     return result
 
 
 def eye(
-    N,
-    M=None,
-    k=0,
+    N: int,
+    M: int | None = None,
+    k: int = 0,
     dtype: DTypeLike | None = None,
     order: NotImplementedType = "C",
     *,
     like: NotImplementedType = None,
-):
+) -> torch.Tensor:
     if dtype is None:
         dtype = _dtypes_impl.default_dtypes().float_dtype
     if M is None:
@@ -1066,24 +1155,26 @@ def eye(
     return z
 
 
-def identity(n, dtype: DTypeLike | None = None, *, like: NotImplementedType = None):
+def identity(
+    n: int, dtype: DTypeLike | None = None, *, like: NotImplementedType = None
+) -> torch.Tensor:
     return torch.eye(n, dtype=dtype)
 
 
-def diag(v: ArrayLike, k=0):
+def diag(v: ArrayLike, k: int = 0) -> torch.Tensor:
     return torch.diag(v, k)
 
 
-def diagflat(v: ArrayLike, k=0):
+def diagflat(v: ArrayLike, k: int = 0) -> torch.Tensor:
     return torch.diagflat(v, k)
 
 
-def diag_indices(n, ndim=2):
+def diag_indices(n: int, ndim: int = 2) -> tuple[torch.Tensor, ...]:
     idx = torch.arange(n)
     return (idx,) * ndim
 
 
-def diag_indices_from(arr: ArrayLike):
+def diag_indices_from(arr: ArrayLike) -> tuple[torch.Tensor, ...]:
     if not arr.ndim >= 2:
         raise ValueError("input array must be at least 2-d")
     # For more than d=2, the strided formula is only valid for arrays with
@@ -1094,11 +1185,13 @@ def diag_indices_from(arr: ArrayLike):
     return diag_indices(s[0], arr.ndim)
 
 
-def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap=False):
+def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap: bool = False) -> torch.Tensor:
     if a.ndim < 2:
         raise ValueError("array must be at least 2-d")
     if val.numel() == 0 and not wrap:
-        a.fill_diagonal_(val)
+        # NB: latent bug -- Tensor.fill_diagonal_ requires a scalar, so this
+        # path raises at runtime for a tensor `val` (numpy treats it as a no-op).
+        a.fill_diagonal_(val)  # pyrefly: ignore[bad-argument-type]
         return a
 
     if val.ndim == 0:
@@ -1128,7 +1221,7 @@ def fill_diagonal(a: ArrayLike, val: ArrayLike, wrap=False):
     return a
 
 
-def vdot(a: ArrayLike, b: ArrayLike, /):
+def vdot(a: ArrayLike, b: ArrayLike, /) -> torch.Tensor:
     # 1. torch only accepts 1D arrays, numpy flattens
     # 2. torch requires matching dtype, while numpy casts (?)
     t_a, t_b = torch.atleast_1d(a, b)
@@ -1160,7 +1253,11 @@ def vdot(a: ArrayLike, b: ArrayLike, /):
     return result
 
 
-def tensordot(a: ArrayLike, b: ArrayLike, axes=2):
+def tensordot(
+    a: ArrayLike,
+    b: ArrayLike,
+    axes: int | Sequence[int] | Sequence[Sequence[int]] = 2,
+) -> torch.Tensor:
     if isinstance(axes, (list, tuple)):
         axes = [[ax] if isinstance(ax, int) else ax for ax in axes]
 
@@ -1171,7 +1268,7 @@ def tensordot(a: ArrayLike, b: ArrayLike, axes=2):
     return torch.tensordot(a, b, dims=axes)
 
 
-def dot(a: ArrayLike, b: ArrayLike, out: OutArray | None = None):
+def dot(a: ArrayLike, b: ArrayLike, out: OutArray | None = None) -> torch.Tensor:
     dtype = _dtypes_impl.result_type_impl(a, b)
     is_bool = dtype == torch.bool
     if is_bool:
@@ -1191,7 +1288,7 @@ def dot(a: ArrayLike, b: ArrayLike, out: OutArray | None = None):
     return result
 
 
-def inner(a: ArrayLike, b: ArrayLike, /):
+def inner(a: ArrayLike, b: ArrayLike, /) -> torch.Tensor:
     dtype = _dtypes_impl.result_type_impl(a, b)
     is_half = dtype == torch.float16 and (a.is_cpu or b.is_cpu)
     is_bool = dtype == torch.bool
@@ -1214,11 +1311,18 @@ def inner(a: ArrayLike, b: ArrayLike, /):
     return result
 
 
-def outer(a: ArrayLike, b: ArrayLike, out: OutArray | None = None):
+def outer(a: ArrayLike, b: ArrayLike, out: OutArray | None = None) -> torch.Tensor:
     return torch.outer(a, b)
 
 
-def cross(a: ArrayLike, b: ArrayLike, axisa=-1, axisb=-1, axisc=-1, axis=None):
+def cross(
+    a: ArrayLike,
+    b: ArrayLike,
+    axisa: int = -1,
+    axisb: int = -1,
+    axisc: int = -1,
+    axis: int | None = None,
+) -> torch.Tensor:
     # implementation vendored from
     # https://github.com/numpy/numpy/blob/v1.24.0/numpy/core/numeric.py#L1486-L1685
     if axis is not None:
@@ -1251,35 +1355,37 @@ def cross(a: ArrayLike, b: ArrayLike, axisa=-1, axisb=-1, axisc=-1, axis=None):
     # create local aliases for readability
     a0 = a[..., 0]
     a1 = a[..., 1]
-    if a.shape[-1] == 3:
-        a2 = a[..., 2]
     b0 = b[..., 0]
     b1 = b[..., 1]
-    if b.shape[-1] == 3:
-        b2 = b[..., 2]
-    if cp.ndim != 0 and cp.shape[-1] == 3:
-        cp0 = cp[..., 0]
-        cp1 = cp[..., 1]
-        cp2 = cp[..., 2]
 
     if a.shape[-1] == 2:
         if b.shape[-1] == 2:
             # a0 * b1 - a1 * b0
             cp[...] = a0 * b1 - a1 * b0
             return cp
-        else:
-            if b.shape[-1] != 3:
-                raise AssertionError(f"b.shape[-1] must be 3, got {b.shape[-1]}")
-            # cp0 = a1 * b2 - 0  (a2 = 0)
-            # cp1 = 0 - a0 * b2  (a2 = 0)
-            # cp2 = a0 * b1 - a1 * b0
-            cp0[...] = a1 * b2
-            cp1[...] = -a0 * b2
-            cp2[...] = a0 * b1 - a1 * b0
+        # from here the output is 3D, so cp.shape[-1] == 3
+        cp0 = cp[..., 0]
+        cp1 = cp[..., 1]
+        cp2 = cp[..., 2]
+        if b.shape[-1] != 3:
+            raise AssertionError(f"b.shape[-1] must be 3, got {b.shape[-1]}")
+        b2 = b[..., 2]
+        # cp0 = a1 * b2 - 0  (a2 = 0)
+        # cp1 = 0 - a0 * b2  (a2 = 0)
+        # cp2 = a0 * b1 - a1 * b0
+        cp0[...] = a1 * b2
+        cp1[...] = -a0 * b2
+        cp2[...] = a0 * b1 - a1 * b0
     else:
         if a.shape[-1] != 3:
             raise AssertionError(f"a.shape[-1] must be 3, got {a.shape[-1]}")
+        # from here the output is 3D, so cp.shape[-1] == 3
+        cp0 = cp[..., 0]
+        cp1 = cp[..., 1]
+        cp2 = cp[..., 2]
+        a2 = a[..., 2]
         if b.shape[-1] == 3:
+            b2 = b[..., 2]
             cp0[...] = a1 * b2 - a2 * b1
             cp1[...] = a2 * b0 - a0 * b2
             cp2[...] = a0 * b1 - a1 * b0
@@ -1293,7 +1399,14 @@ def cross(a: ArrayLike, b: ArrayLike, axisa=-1, axisb=-1, axisc=-1, axis=None):
     return torch.moveaxis(cp, -1, axisc)
 
 
-def einsum(*operands, out=None, dtype=None, order="K", casting="safe", optimize=False):
+def einsum(
+    *operands: object,
+    out: object = None,
+    dtype: object = None,
+    order: str = "K",
+    casting: str = "safe",
+    optimize: bool | str = False,
+) -> object:
     # Have to manually normalize *operands and **kwargs, following the NumPy signature
     # We have a local import to avoid polluting the global space, as it will be then
     # exported in funcs.py
@@ -1314,6 +1427,7 @@ def einsum(*operands, out=None, dtype=None, order="K", casting="safe", optimize=
         raise NotImplementedError("'order' parameter is not supported.")
 
     # parse arrays and normalize them
+    subscripts: object = None
     sublist_format = not isinstance(operands[0], str)
     if sublist_format:
         # op, str, op, str ... [sublistout] format: normalize every other argument
@@ -1344,12 +1458,14 @@ def einsum(*operands, out=None, dtype=None, order="K", casting="safe", optimize=
 
     from torch.backends import opt_einsum
 
+    # Read current state unconditionally so it is always bound for the finally
+    # block below (only actually restored when opt_einsum is available).
+    old_strategy = torch.backends.opt_einsum.strategy
+    old_enabled = torch.backends.opt_einsum.enabled
+
     try:
         # set the global state to handle the optimize=... argument, restore on exit
         if opt_einsum.is_available():
-            old_strategy = torch.backends.opt_einsum.strategy
-            old_enabled = torch.backends.opt_einsum.enabled
-
             # torch.einsum calls opt_einsum.contract_path, which runs into
             # https://github.com/dgasmith/opt_einsum/issues/219
             # for strategy={True, False}
@@ -1358,19 +1474,24 @@ def einsum(*operands, out=None, dtype=None, order="K", casting="safe", optimize=
             elif optimize is False:
                 torch.backends.opt_einsum.enabled = False
 
-            torch.backends.opt_einsum.strategy = optimize
+            # `optimize` may be False here, which the setter ignores while
+            # opt_einsum is disabled.
+            torch.backends.opt_einsum.strategy = (
+                optimize  # pyrefly: ignore[bad-assignment]
+            )
 
         if sublist_format:
             # recombine operands
             sublists = operands[1::2]
             has_sublistout = len(operands) % 2 == 1
+            sublistout = operands[-1] if has_sublistout else None
+            einsum_operands = list(
+                itertools.chain.from_iterable(zip(tensors, sublists))
+            )
             if has_sublistout:
-                sublistout = operands[-1]
-            operands = list(itertools.chain.from_iterable(zip(tensors, sublists)))
-            if has_sublistout:
-                operands.append(sublistout)
+                einsum_operands.append(sublistout)
 
-            result = torch.einsum(*operands)
+            result = torch.einsum(*einsum_operands)
         else:
             result = torch.einsum(subscripts, *tensors)
 
@@ -1386,7 +1507,9 @@ def einsum(*operands, out=None, dtype=None, order="K", casting="safe", optimize=
 # ### sort and partition ###
 
 
-def _sort_helper(tensor, axis, kind, order):
+def _sort_helper(
+    tensor: torch.Tensor, axis: int | None, kind: str | None, order: object
+) -> tuple[torch.Tensor, int, bool]:
     if tensor.dtype.is_complex:
         raise NotImplementedError(f"sorting {tensor.dtype} is not supported")
     (tensor,), axis = _util.axis_none_flatten(tensor, axis=axis)
@@ -1397,21 +1520,31 @@ def _sort_helper(tensor, axis, kind, order):
     return tensor, axis, stable
 
 
-def sort(a: ArrayLike, axis=-1, kind=None, order: NotImplementedType = None):
+def sort(
+    a: ArrayLike,
+    axis: int = -1,
+    kind: str | None = None,
+    order: NotImplementedType = None,
+) -> torch.Tensor:
     # `order` keyword arg is only relevant for structured dtypes; so not supported here.
     a, axis, stable = _sort_helper(a, axis, kind, order)
     result = torch.sort(a, dim=axis, stable=stable)
     return result.values
 
 
-def argsort(a: ArrayLike, axis=-1, kind=None, order: NotImplementedType = None):
+def argsort(
+    a: ArrayLike,
+    axis: int = -1,
+    kind: str | None = None,
+    order: NotImplementedType = None,
+) -> torch.Tensor:
     a, axis, stable = _sort_helper(a, axis, kind, order)
     return torch.argsort(a, dim=axis, stable=stable)
 
 
 def searchsorted(
-    a: ArrayLike, v: ArrayLike, side="left", sorter: ArrayLike | None = None
-):
+    a: ArrayLike, v: ArrayLike, side: str = "left", sorter: ArrayLike | None = None
+) -> torch.Tensor:
     if a.dtype.is_complex:
         raise NotImplementedError(f"searchsorted with dtype={a.dtype}")
 
@@ -1421,19 +1554,21 @@ def searchsorted(
 # ### swap/move/roll axis ###
 
 
-def moveaxis(a: ArrayLike, source, destination):
+def moveaxis(
+    a: ArrayLike, source: int | Sequence[int], destination: int | Sequence[int]
+) -> torch.Tensor:
     source = _util.normalize_axis_tuple(source, a.ndim, "source")
     destination = _util.normalize_axis_tuple(destination, a.ndim, "destination")
     return torch.moveaxis(a, source, destination)
 
 
-def swapaxes(a: ArrayLike, axis1, axis2):
+def swapaxes(a: ArrayLike, axis1: int, axis2: int) -> torch.Tensor:
     axis1 = _util.normalize_axis_index(axis1, a.ndim)
     axis2 = _util.normalize_axis_index(axis2, a.ndim)
     return torch.swapaxes(a, axis1, axis2)
 
 
-def rollaxis(a: ArrayLike, axis, start=0):
+def rollaxis(a: ArrayLike, axis: int, start: int = 0) -> torch.Tensor:
     # Straight vendor from:
     # https://github.com/numpy/numpy/blob/v1.24.0/numpy/core/numeric.py#L1259
     #
@@ -1460,18 +1595,23 @@ def rollaxis(a: ArrayLike, axis, start=0):
     return a.view(axes)
 
 
-def roll(a: ArrayLike, shift, axis=None):
+def roll(
+    a: ArrayLike,
+    shift: int | tuple[int, ...],
+    axis: int | Sequence[int] | None = None,
+) -> torch.Tensor:
     if axis is not None:
         axis = _util.normalize_axis_tuple(axis, a.ndim, allow_duplicate=True)
         if not isinstance(shift, tuple):
             shift = (shift,) * len(axis)
-    return torch.roll(a, shift, axis)
+    # torch.roll accepts axis=None (rolls the flattened tensor) at runtime.
+    return torch.roll(a, shift, axis)  # pyrefly: ignore[bad-argument-type]
 
 
 # ### shape manipulations ###
 
 
-def squeeze(a: ArrayLike, axis=None):
+def squeeze(a: ArrayLike, axis: int | tuple[int, ...] | None = None) -> torch.Tensor:
     if axis == ():
         result = a
     elif axis is None:
@@ -1486,10 +1626,12 @@ def squeeze(a: ArrayLike, axis=None):
     return result
 
 
-def reshape(a: ArrayLike, newshape, order: NotImplementedType = "C"):
+def reshape(
+    a: ArrayLike, newshape: Sequence[int], order: NotImplementedType = "C"
+) -> torch.Tensor:
     # if sh = (1, 2, 3), numpy allows both .reshape(sh) and .reshape(*sh)
-    newshape = newshape[0] if len(newshape) == 1 else newshape
-    return a.reshape(newshape)
+    shape = newshape[0] if len(newshape) == 1 else newshape
+    return a.reshape(shape)
 
 
 # NB: cannot use torch.reshape(a, newshape) above, because of
@@ -1497,27 +1639,28 @@ def reshape(a: ArrayLike, newshape, order: NotImplementedType = "C"):
 # *** TypeError: reshape(): argument 'shape' (position 2) must be tuple of SymInts, not int
 
 
-def transpose(a: ArrayLike, axes=None):
+def transpose(a: ArrayLike, axes: int | Sequence[int] | None = None) -> torch.Tensor:
     # numpy allows both .transpose(sh) and .transpose(*sh)
     # also older code uses axes being a list
     if axes in [(), None, (None,)]:
         axes = tuple(reversed(range(a.ndim)))
-    elif len(axes) == 1:
+    elif isinstance(axes, (tuple, list)) and len(axes) == 1:
         axes = axes[0]
-    return a.permute(axes)
+    # axes is never None here (the membership check above replaces it).
+    return a.permute(axes)  # pyrefly: ignore[no-matching-overload]
 
 
-def ravel(a: ArrayLike, order: NotImplementedType = "C"):
+def ravel(a: ArrayLike, order: NotImplementedType = "C") -> torch.Tensor:
     return torch.flatten(a)
 
 
 def diff(
     a: ArrayLike,
-    n=1,
-    axis=-1,
+    n: int = 1,
+    axis: int = -1,
     prepend: ArrayLike | None = None,
     append: ArrayLike | None = None,
-):
+) -> torch.Tensor:
     axis = _util.normalize_axis_index(axis, a.ndim)
 
     if n < 0:
@@ -1537,28 +1680,39 @@ def diff(
         shape[axis] = append.shape[axis] if append.ndim > 0 else 1
         append = torch.broadcast_to(append, shape)
 
+    # torch.diff accepts `axis` as an alias for `dim` at runtime.
+    # pyrefly: ignore[unexpected-keyword]
     return torch.diff(a, n, axis=axis, prepend=prepend, append=append)
 
 
 # ### math functions ###
 
 
-def angle(z: ArrayLike, deg=False):
+def angle(z: ArrayLike, deg: bool = False) -> torch.Tensor:
     result = torch.angle(z)
     if deg:
         result = result * (180 / torch.pi)
     return result
 
 
-def sinc(x: ArrayLike):
+def sinc(x: ArrayLike) -> torch.Tensor:
     return torch.sinc(x)
 
 
 # NB: have to normalize *varargs manually
-def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
+def gradient(
+    f: ArrayLike,
+    *varargs: object,
+    axis: int | tuple[int, ...] | None = None,
+    edge_order: int = 1,
+) -> torch.Tensor | list[torch.Tensor]:
     N = f.ndim  # number of dimensions
 
-    varargs = _util.ndarrays_to_tensors(varargs)
+    # ndarrays_to_tensors preserves the tuple structure, converting any ndarray
+    # spacing arguments to tensors and leaving scalars intact.
+    spacing = _util.ndarrays_to_tensors(varargs)
+    if not isinstance(spacing, tuple):
+        raise AssertionError
 
     if axis is None:
         axes = tuple(range(N))
@@ -1566,16 +1720,19 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
         axes = _util.normalize_axis_tuple(axis, N)
 
     len_axes = len(axes)
-    n = len(varargs)
+    n = len(spacing)
     if n == 0:
         # no spacing argument - use 1 in all axes
         dx = [1.0] * len_axes
-    elif n == 1 and (_dtypes_impl.is_scalar(varargs[0]) or varargs[0].ndim == 0):
-        # single scalar or 0D tensor for all axes (np.ndim(varargs[0]) == 0)
-        dx = varargs * len_axes
+    elif n == 1 and (
+        _dtypes_impl.is_scalar(spacing[0])
+        or (isinstance(spacing[0], torch.Tensor) and spacing[0].ndim == 0)
+    ):
+        # single scalar or 0D tensor for all axes (np.ndim(spacing[0]) == 0)
+        dx = spacing * len_axes
     elif n == len_axes:
         # scalar or 1d array for each axis
-        dx = list(varargs)
+        dx = list(spacing)
         for i, distances in enumerate(dx):
             distances = torch.as_tensor(distances)
             if distances.ndim == 0:
@@ -1608,10 +1765,10 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
     outvals = []
 
     # create slice objects --- initially all are [:, :, ..., :]
-    slice1 = [slice(None)] * N
-    slice2 = [slice(None)] * N
-    slice3 = [slice(None)] * N
-    slice4 = [slice(None)] * N
+    slice1: list[slice | int] = [slice(None)] * N
+    slice2: list[slice | int] = [slice(None)] * N
+    slice3: list[slice | int] = [slice(None)] * N
+    slice4: list[slice | int] = [slice(None)] * N
 
     otype = f.dtype
     if _dtypes_impl.python_type_for_torch(otype) in (int, bool):
@@ -1631,7 +1788,9 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
         out = torch.empty_like(f, dtype=otype)
 
         # spacing for the current axis (NB: np.ndim(ax_dx) == 0)
-        uniform_spacing = _dtypes_impl.is_scalar(ax_dx) or ax_dx.ndim == 0
+        uniform_spacing = _dtypes_impl.is_scalar(ax_dx) or (
+            isinstance(ax_dx, torch.Tensor) and ax_dx.ndim == 0
+        )
 
         # Numerical differentiation: 2nd order interior
         slice1[axis] = slice(1, -1)
@@ -1642,6 +1801,8 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
         if uniform_spacing:
             out[tuple(slice1)] = (f[tuple(slice4)] - f[tuple(slice2)]) / (2.0 * ax_dx)
         else:
+            # non-uniform spacing is always a 1d tensor (as_tensor is a no-op)
+            ax_dx = torch.as_tensor(ax_dx)
             dx1 = ax_dx[0:-1]
             dx2 = ax_dx[1:]
             a = -(dx2) / (dx1 * (dx1 + dx2))
@@ -1663,14 +1824,22 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
             slice1[axis] = 0
             slice2[axis] = 1
             slice3[axis] = 0
-            dx_0 = ax_dx if uniform_spacing else ax_dx[0]
+            if uniform_spacing:
+                dx_0 = ax_dx
+            else:
+                ax_dx = torch.as_tensor(ax_dx)
+                dx_0 = ax_dx[0]
             # 1D equivalent -- out[0] = (f[1] - f[0]) / (x[1] - x[0])
             out[tuple(slice1)] = (f[tuple(slice2)] - f[tuple(slice3)]) / dx_0
 
             slice1[axis] = -1
             slice2[axis] = -1
             slice3[axis] = -2
-            dx_n = ax_dx if uniform_spacing else ax_dx[-1]
+            if uniform_spacing:
+                dx_n = ax_dx
+            else:
+                ax_dx = torch.as_tensor(ax_dx)
+                dx_n = ax_dx[-1]
             # 1D equivalent -- out[-1] = (f[-1] - f[-2]) / (x[-1] - x[-2])
             out[tuple(slice1)] = (f[tuple(slice2)] - f[tuple(slice3)]) / dx_n
 
@@ -1685,6 +1854,7 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
                 b = 2.0 / ax_dx
                 c = -0.5 / ax_dx
             else:
+                ax_dx = torch.as_tensor(ax_dx)
                 dx1 = ax_dx[0]
                 dx2 = ax_dx[1]
                 a = -(2.0 * dx1 + dx2) / (dx1 * (dx1 + dx2))
@@ -1704,6 +1874,7 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
                 b = -2.0 / ax_dx
                 c = 1.5 / ax_dx
             else:
+                ax_dx = torch.as_tensor(ax_dx)
                 dx1 = ax_dx[-2]
                 dx2 = ax_dx[-1]
                 a = (dx2) / (dx1 * (dx1 + dx2))
@@ -1731,7 +1902,7 @@ def gradient(f: ArrayLike, *varargs, axis=None, edge_order=1):
 # ### Type/shape etc queries ###
 
 
-def round(a: ArrayLike, decimals=0, out: OutArray | None = None):
+def round(a: ArrayLike, decimals: int = 0, out: OutArray | None = None) -> torch.Tensor:
     if a.is_floating_point():
         result = torch.round(a, decimals=decimals)
     elif a.is_complex():
@@ -1750,7 +1921,7 @@ around = round
 round_ = round
 
 
-def real_if_close(a: ArrayLike, tol=100):
+def real_if_close(a: ArrayLike, tol: float = 100) -> torch.Tensor:
     if not torch.is_complex(a):
         return a
     if tol > 1:
@@ -1763,49 +1934,49 @@ def real_if_close(a: ArrayLike, tol=100):
     return a.real if mask.all() else a
 
 
-def real(a: ArrayLike):
+def real(a: ArrayLike) -> torch.Tensor:
     return torch.real(a)
 
 
-def imag(a: ArrayLike):
+def imag(a: ArrayLike) -> torch.Tensor:
     if a.is_complex():
         return a.imag
     return torch.zeros_like(a)
 
 
-def iscomplex(x: ArrayLike):
+def iscomplex(x: ArrayLike) -> torch.Tensor:
     if torch.is_complex(x):
         return x.imag != 0
     return torch.zeros_like(x, dtype=torch.bool)
 
 
-def isreal(x: ArrayLike):
+def isreal(x: ArrayLike) -> torch.Tensor:
     if torch.is_complex(x):
         return x.imag == 0
     return torch.ones_like(x, dtype=torch.bool)
 
 
-def iscomplexobj(x: ArrayLike):
+def iscomplexobj(x: ArrayLike) -> bool:
     return torch.is_complex(x)
 
 
-def isrealobj(x: ArrayLike):
+def isrealobj(x: ArrayLike) -> bool:
     return not torch.is_complex(x)
 
 
-def isneginf(x: ArrayLike, out: OutArray | None = None):
+def isneginf(x: ArrayLike, out: OutArray | None = None) -> torch.Tensor:
     return torch.isneginf(x)
 
 
-def isposinf(x: ArrayLike, out: OutArray | None = None):
+def isposinf(x: ArrayLike, out: OutArray | None = None) -> torch.Tensor:
     return torch.isposinf(x)
 
 
-def i0(x: ArrayLike):
+def i0(x: ArrayLike) -> torch.Tensor:
     return torch.special.i0(x)
 
 
-def isscalar(a):
+def isscalar(a: object) -> bool:
     # We need to use normalize_array_like, but we don't want to export it in funcs.py
     from ._normalizations import normalize_array_like
 
@@ -1819,27 +1990,27 @@ def isscalar(a):
 # ### Filter windows ###
 
 
-def hamming(M):
+def hamming(M: int) -> torch.Tensor:
     dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.hamming_window(M, periodic=False, dtype=dtype)
 
 
-def hanning(M):
+def hanning(M: int) -> torch.Tensor:
     dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.hann_window(M, periodic=False, dtype=dtype)
 
 
-def kaiser(M, beta):
+def kaiser(M: int, beta: float) -> torch.Tensor:
     dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.kaiser_window(M, beta=beta, periodic=False, dtype=dtype)
 
 
-def blackman(M):
+def blackman(M: int) -> torch.Tensor:
     dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.blackman_window(M, periodic=False, dtype=dtype)
 
 
-def bartlett(M):
+def bartlett(M: int) -> torch.Tensor:
     dtype = _dtypes_impl.default_dtypes().float_dtype
     return torch.bartlett_window(M, periodic=False, dtype=dtype)
 
@@ -1862,7 +2033,7 @@ array_precision = {
 }
 
 
-def common_type(*tensors: ArrayLike):
+def common_type(*tensors: ArrayLike) -> torch.dtype | None:
     is_complex = False
     precision = 0
     for a in tensors:
@@ -1887,12 +2058,13 @@ def common_type(*tensors: ArrayLike):
 
 def histogram(
     a: ArrayLike,
-    bins: ArrayLike = 10,
-    range=None,
-    normed=None,
+    # the `10` default is normalized to a tensor only when passed explicitly
+    bins: ArrayLike = 10,  # pyrefly: ignore[bad-function-definition]
+    range: tuple[float, float] | None = None,
+    normed: bool | None = None,
     weights: ArrayLike | None = None,
-    density=None,
-):
+    density: bool | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
     if normed is not None:
         raise ValueError("normed argument is deprecated, use density= instead")
 
@@ -1907,18 +2079,22 @@ def histogram(
     if weights is not None:
         weights = _util.cast_if_needed(weights, a.dtype)
 
-    if isinstance(bins, torch.Tensor):
-        if bins.ndim == 0:
+    n_bins: torch.Tensor | int = bins
+    if isinstance(n_bins, torch.Tensor):
+        if n_bins.ndim == 0:
             # bins was a single int
-            bins = operator.index(bins)
+            n_bins = operator.index(n_bins)
         else:
-            bins = _util.cast_if_needed(bins, a.dtype)
+            n_bins = _util.cast_if_needed(n_bins, a.dtype)
 
+    # torch.histogram accepts either a tensor of edges or an int count of bins.
     if range is None:
-        h, b = torch.histogram(a, bins, weight=weights, density=bool(density))
+        h, b = torch.histogram(  # pyrefly: ignore[no-matching-overload]
+            a, n_bins, weight=weights, density=bool(density)
+        )
     else:
-        h, b = torch.histogram(
-            a, bins, range=range, weight=weights, density=bool(density)
+        h, b = torch.histogram(  # pyrefly: ignore[no-matching-overload]
+            a, n_bins, range=range, weight=weights, density=bool(density)
         )
 
     if not density and is_w_int:
@@ -1930,39 +2106,41 @@ def histogram(
 
 
 def histogram2d(
-    x,
-    y,
-    bins=10,
+    x: torch.Tensor | Sequence[float],
+    y: torch.Tensor | Sequence[float],
+    bins: int | Sequence[int] = 10,
     range: ArrayLike | None = None,
-    normed=None,
+    normed: bool | None = None,
     weights: ArrayLike | None = None,
-    density=None,
-):
+    density: bool | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # vendored from https://github.com/numpy/numpy/blob/v1.24.0/numpy/lib/twodim_base.py#L655-L821
     if len(x) != len(y):
         raise ValueError("x and y must have the same length.")
 
     try:
-        N = len(bins)
+        # a scalar `bins` raises TypeError from len(), handled below
+        N = len(bins)  # pyrefly: ignore[bad-argument-type]
     except TypeError:
         N = 1
 
+    hist_bins: int | Sequence[object] = bins
     if N != 1 and N != 2:
-        bins = [bins, bins]
+        hist_bins = [bins, bins]
 
-    h, e = histogramdd((x, y), bins, range, normed, weights, density)
+    h, e = histogramdd((x, y), hist_bins, range, normed, weights, density)
 
     return h, e[0], e[1]
 
 
 def histogramdd(
-    sample,
-    bins=10,
+    sample: object,
+    bins: int | Sequence[object] = 10,
     range: ArrayLike | None = None,
-    normed=None,
+    normed: bool | None = None,
     weights: ArrayLike | None = None,
-    density=None,
-):
+    density: bool | None = None,
+) -> tuple[torch.Tensor, list[torch.Tensor]]:
     # have to normalize manually because `sample` interpretation differs
     # for a list of lists and a 2D array
     if normed is not None:
@@ -1981,28 +2159,34 @@ def histogramdd(
         sample = sample.double()
 
     # bins is either an int, or a sequence of ints or a sequence of arrays
-    bins_is_array = not (
-        isinstance(bins, int) or builtins.all(isinstance(b, int) for b in bins)
-    )
-    if bins_is_array:
-        bins = normalize_seq_array_like(bins)
-        bins_dtypes = [b.dtype for b in bins]
-        bins = [_util.cast_if_needed(b, sample.dtype) for b in bins]
+    bins_dtypes: list[torch.dtype] = []
+    bins_seq: int | Sequence[object]
+    if isinstance(bins, int) or builtins.all(isinstance(b, int) for b in bins):
+        bins_is_array = False
+        bins_seq = bins
+    else:
+        bins_is_array = True
+        bins_tensors = normalize_seq_array_like(bins)
+        bins_dtypes = [b.dtype for b in bins_tensors]
+        bins_seq = [_util.cast_if_needed(b, sample.dtype) for b in bins_tensors]
 
-    if range is not None:
-        range = range.flatten().tolist()
-
+    dd_range: list[float] | tuple[float, ...] | None
+    w_kwd: dict[str, torch.Tensor]
     if weights is not None:
         # range=... is required : interleave min and max values per dimension
         mm = sample.aminmax(dim=0)
-        range = torch.cat(mm).reshape(2, -1).T.flatten()
-        range = tuple(range.tolist())
+        edges = torch.cat(mm).reshape(2, -1).T.flatten()
+        dd_range = tuple(edges.tolist())
         weights = _util.cast_if_needed(weights, sample.dtype)
         w_kwd = {"weight": weights}
     else:
+        dd_range = range.flatten().tolist() if range is not None else None
         w_kwd = {}
 
-    h, b = torch.histogramdd(sample, bins, range, density=bool(density), **w_kwd)
+    # torch.histogramdd accepts an int/sequence of bins and an optional range.
+    h, b = torch.histogramdd(  # pyrefly: ignore[no-matching-overload]
+        sample, bins_seq, dd_range, density=bool(density), **w_kwd
+    )
 
     if bins_is_array:
         b = [_util.cast_if_needed(bb, dtyp) for bb, dtyp in zip(b, bins_dtypes)]
@@ -2013,7 +2197,7 @@ def histogramdd(
 # ### odds and ends
 
 
-def min_scalar_type(a: ArrayLike, /):
+def min_scalar_type(a: ArrayLike, /) -> DType:
     # https://github.com/numpy/numpy/blob/maintenance/1.24.x/numpy/core/src/multiarray/convert_datatype.c#L1288
 
     from ._dtypes import DType
@@ -2022,6 +2206,8 @@ def min_scalar_type(a: ArrayLike, /):
         # numpy docs: "For non-scalar array a, returns the vector's dtype unmodified."
         return DType(a.dtype)
 
+    # fallback dtype; the branches below always find a fit for a 1-element array
+    dtype: torch.dtype = a.dtype
     if a.dtype == torch.bool:
         dtype = torch.bool
 
@@ -2050,15 +2236,24 @@ def min_scalar_type(a: ArrayLike, /):
     return DType(dtype)
 
 
-def pad(array: ArrayLike, pad_width: ArrayLike, mode="constant", **kwargs):
+def pad(
+    array: ArrayLike, pad_width: ArrayLike, mode: str = "constant", **kwargs: object
+) -> torch.Tensor:
     if mode != "constant":
         raise NotImplementedError
     value = kwargs.get("constant_values", 0)
-    # `value` must be a python scalar for torch.nn.functional.pad
+    # `value` must be a python scalar for torch.nn.functional.pad; `typ` is the
+    # array's python scalar type, chosen dynamically so the constructor call is
+    # opaque to the type checker.
     typ = _dtypes_impl.python_type_for_torch(array.dtype)
-    value = typ(value)
+    value = typ(value)  # pyrefly: ignore[no-matching-overload, bad-argument-type]
 
     pad_width = torch.broadcast_to(pad_width, (array.ndim, 2))
     pad_width = torch.flip(pad_width, (0,)).flatten()
 
-    return torch.nn.functional.pad(array, tuple(pad_width), value=value)
+    # `value` is a python scalar accepted by pad even when not a plain float.
+    return torch.nn.functional.pad(
+        array,
+        tuple(pad_width),
+        value=value,  # pyrefly: ignore[bad-argument-type]
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #194529

Removes `# mypy: ignore-errors` from torch/_numpy/_funcs_impl.py and enables strict
pyrefly checking via a per-file sub-config, with no net-new pyrefly errors.

_funcs_impl.py is the numpy-compat function layer; its functions are decorated by
`@normalizer` (in _funcs.py), which dispatches on the string form of each
parameter annotation. Existing marker annotations (ArrayLike, OutArray, etc.) are
preserved unchanged; only return types and previously-unannotated parameters were
added. The one sanctioned marker change is `casting: CastingModes | None` ->
`casting: CastingModes` (the `| None` is spurious -- the casting normalizer raises
on None), which lets casting flow into _util's str-typed helpers cleanly.

Several torch ops accept arguments at runtime that their stubs do not model
(scalar/tensor bounds, `axis=` aliases, python-type dtypes); those calls carry
targeted `# pyrefly: ignore` comments. Two latent bugs surfaced and are preserved
here (not fixed, since a fix needs a failing test first) with comments flagging
them: arange(step=None) raises rather than treating None as 1, and fill_diagonal's
empty-val branch passes a tensor to Tensor.fill_diagonal_ (which requires a
scalar).

Test Plan:

No net-new pyrefly errors (156 before and after):

    pyrefly check

Behavior unchanged:

    python -m pytest test/torch_np/ -q

Lint clean:

    lintrunner -a torch/_numpy/_funcs_impl.py

Authored with Claude.