### PR TITLE
Fix libtorch nightly upload skipping and gate publish on wheel tests

### DIFF
--- a/.github/templates/linux_binary_build_workflow.yml.j2
+++ b/.github/templates/linux_binary_build_workflow.yml.j2
@@ -600,7 +600,7 @@ jobs:
 
   libtorch-extract:
     name: ${{ matrix.build_name }}-extract
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: !{{ owner_if }}
     needs: [manywheel-build]
     runs-on: "mt-l-x86iavx512-16-128"
     container:
@@ -666,6 +666,15 @@ jobs:
           path: "${{ github.workspace }}/libtorch_output/"
 
 {%- if branches == "nightly" %}
+{#- Every libtorch tarball is cut out of a wheel, so its upload must also wait
+    on that wheel's test job: a red wheel test has to withhold the tarball taken
+    from the same build. -#}
+{%- set source_wheels = libtorch_extraction_configs | map(attribute='source_wheel_build_name') | list %}
+{%- set wheel_test_jobs = standard_test_jobs + [{'name': 'manywheel-test-rocm', 'configs': rocm_configs}, {'name': 'manywheel-test-xpu', 'configs': xpu_configs}] %}
+{%- set libtorch_upload_needs = ['libtorch-extract'] %}
+{%- for t in wheel_test_jobs if t['configs'] | selectattr('build_name', 'in', source_wheels) | list %}
+  {%- set _ = libtorch_upload_needs.append(t['name']) %}
+{%- endfor %}
 
   libtorch-upload:
     name: ${{ matrix.build_name }}-upload
@@ -673,7 +682,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: libtorch-extract
+    needs: [!{{ libtorch_upload_needs | join(', ') }}]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/generated-linux-binary-manywheel-nightly.yml
+++ b/.github/workflows/generated-linux-binary-manywheel-nightly.yml
@@ -2140,7 +2140,7 @@ jobs:
 
   libtorch-extract:
     name: ${{ matrix.build_name }}-extract
-    if: ${{ github.repository_owner == 'pytorch' }}
+    if: ${{ !failure() && !cancelled() && github.repository_owner == 'pytorch' }}
     needs: [manywheel-build]
     runs-on: "mt-l-x86iavx512-16-128"
     container:
@@ -2261,7 +2261,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    needs: libtorch-extract
+    needs: [libtorch-extract, manywheel-cpu-test, manywheel-cuda-cu126-test, manywheel-cuda-cu130-test, manywheel-cuda-cu132-test, manywheel-cuda-cu134-test, manywheel-test-rocm]
     uses: ./.github/workflows/_binary-upload.yml
     strategy:
       fail-fast: false


### PR DESCRIPTION
**Impact:** CI only — `linux-binary-manywheel` nightly libtorch legs
**Risk:** low

## What
Gives `libtorch-extract` its own `owner_if` guard so a deliberately-skipped `get-docker-tag` no longer transitively skips it, and gates `libtorch-upload` on the wheel test jobs whose builds each libtorch tarball is carved from. Both edits are in the `.j2` template; the generated manywheel-nightly workflow is regenerated to match.

## Why
Since #187174 introduced `get-docker-tag` (tag-only), the nightly branch pushes left `libtorch-extract` with a bare `if:` — an implicit `success()` over the transitive ancestry meant one skipped ancestor skipped extract, so nothing was produced and the uploads found no artifacts. This was masked until #194401 tightened `continue-on-error` in `_binary-upload.yml`, turning the seven libtorch upload legs red on 2026-08-22. Linux libtorch nightlies had in fact published nothing since 2026-06-30. `owner_if` replaces the implicit check with `!failure() && !cancelled()`, matching the other 21 jobs, so a skipped ancestor no longer skips extract while a failed/cancelled one still does.

Since each libtorch tarball is extracted from a wheel, its upload should follow the same rule as the wheels themselves. `libtorch-upload` previously depended only on `libtorch-extract` (ancestry with zero test jobs), so it could publish C++ binaries from a build whose wheel tests failed while the wheels from that same build were withheld. The new `needs` derives the exact set of wheel test jobs backing the libtorch source wheels — cpu, cu126/130/132/134, rocm; xpu is correctly excluded since no libtorch config sources an xpu wheel.

# Notes
- This cannot be validated pre-merge on the path it fixes: `ciflow/binaries` runs are tag pushes where `get-docker-tag` already succeeds. Confidence rests on static analysis plus an 8/8 tag-vs-branch historical correlation. Only a nightly-branch push or a branch `workflow_dispatch` reproduces the broken state.
- The upload gate is intentionally coarser than the per-arch wheel gating: `libtorch-upload` is a single matrix job, so any one gating test failure withholds all seven tarballs, and it adds some release-day latency (waits for the slowest wheel test). This fails closed on purpose — publishing test-rejected public binaries is the more expensive mistake.