### PR TITLE
Fix gaussian_nll_loss data-dependent guard under torch.compile(fullgraph=True)

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2755,6 +2755,17 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         self.assertEqual(F.gaussian_nll_loss(input, target, var_tensor, reduction='none'),
                          F.gaussian_nll_loss(input, target, var, reduction='none'))
 
+    def test_gaussian_nll_loss_compile_fullgraph(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/194503
+        # torch.any(var < 0) used to force a data-dependent guard under
+        # fullgraph=True even for valid, non-negative var.
+        input = torch.zeros(2, 3)
+        target = torch.ones(2, 3)
+        var = torch.ones(2, 3)
+        eager_out = F.gaussian_nll_loss(input, target, var)
+        compiled_out = torch.compile(F.gaussian_nll_loss, fullgraph=True)(input, target, var)
+        self.assertEqual(eager_out, compiled_out)
+
     def test_KLDivLoss_batch_mean(self):
         input_shape = (2, 5)
         log_prob1 = F.log_softmax(torch.randn(input_shape), 1)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2766,6 +2766,16 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         compiled_out = torch.compile(F.gaussian_nll_loss, fullgraph=True)(input, target, var)
         self.assertEqual(eager_out, compiled_out)
 
+    def test_gaussian_nll_loss_compile_fullgraph_negative_var(self):
+        input = torch.zeros(2, 3)
+        target = torch.ones(2, 3)
+        var = -torch.ones(2, 3)
+
+        compiled = torch.compile(F.gaussian_nll_loss, fullgraph=True)
+
+        with self.assertRaisesRegex(RuntimeError, "var has negative"):
+            compiled(input, target, var)
+
     def test_KLDivLoss_batch_mean(self):
         input_shape = (2, 5)
         log_prob1 = F.log_softmax(torch.randn(input_shape), 1)

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3347,8 +3347,12 @@ def gaussian_nll_loss(
         if var < 0:
             raise ValueError("var has negative entry/entries")
         var = var * torch.ones_like(input)
-    elif torch.any(var < 0):
-        raise ValueError("var has negative entry/entries")
+    else:
+        from torch.fx.experimental.symbolic_shapes import guard_or_false
+
+        # pyrefly: ignore [bad-argument-type]
+        if guard_or_false(torch.any(var < 0).item()):
+            raise ValueError("var has negative entry/entries")
 
     # Check var size
     # If var.size == input.size, the case is heteroscedastic and no further checks are needed.

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3347,12 +3347,10 @@ def gaussian_nll_loss(
         if var < 0:
             raise ValueError("var has negative entry/entries")
         var = var * torch.ones_like(input)
-    else:
-        from torch.fx.experimental.symbolic_shapes import guard_or_false
-
-        # pyrefly: ignore [bad-argument-type]
-        if guard_or_false(torch.any(var < 0).item()):
-            raise ValueError("var has negative entry/entries")
+    elif torch.compiler.is_compiling():
+        torch._assert_async(~torch.any(var < 0), "var has negative entry/entries")
+    elif torch.any(var < 0):
+        raise ValueError("var has negative entry/entries")
 
     # Check var size
     # If var.size == input.size, the case is heteroscedastic and no further checks are needed.


### PR DESCRIPTION
Fixes #194503.

`F.gaussian_nll_loss`'s `elif torch.any(var < 0):` implicitly converts a tensor to a Python bool. Under Dynamo/`fullgraph=True` tracing `var` is a `FakeTensor`, so that conversion allocates an unbacked `SymBool` instead of a concrete value, and Dynamo raises `GuardOnDataDependentSymNode` on an otherwise-valid call.

Fix: gate on `torch.compiler.is_compiling()` (same pattern already used elsewhere in this file, e.g. `pad()`) and replace the Python-level branch with `torch._assert_async(~torch.any(var < 0), msg)` under compile. This keeps the check as an in-graph runtime assertion — Dynamo never needs to resolve the value at trace time, but invalid `var` still fails at actual runtime, just as `RuntimeError` rather than eager's `ValueError`. Eager execution is unchanged.

## Test plan
```
python test/test_nn.py -k gaussian_nll_loss -v
```
Two new tests: `test_gaussian_nll_loss_compile_fullgraph` (valid `var` compiles and matches eager) and `test_gaussian_nll_loss_compile_fullgraph_negative_var` (invalid `var` still raises under compile). `lintrunner` passes.

Authored with the assistance of Claude Code (Claude Sonnet 5); reviewed end-to-end.