### PR TITLE
Give the conv and avg_pool functional docs their parameter types

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -71,12 +71,12 @@ Note:
     + r"""
 
 Args:
-    input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
-    weight: filters of shape :math:`(\text{out\_channels} , \frac{\text{in\_channels}}{\text{groups}} , kW)`
-    bias: optional bias of shape :math:`(\text{out\_channels})`. Default: ``None``
-    stride: the stride of the convolving kernel. Can be a single number or
+    input (Tensor): input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
+    weight (Tensor): filters of shape :math:`(\text{out\_channels} , \frac{\text{in\_channels}}{\text{groups}} , kW)`
+    bias (Tensor, optional): optional bias of shape :math:`(\text{out\_channels})`. Default: ``None``
+    stride (int or tuple, optional): the stride of the convolving kernel. Can be a single number or
       a one-element tuple `(sW,)`. Default: 1
-    padding: implicit paddings on both sides of the input. Can be a string {'valid', 'same'},
+    padding (int, tuple or str, optional): implicit paddings on both sides of the input. Can be a string {'valid', 'same'},
       single number or a one-element tuple `(padW,)`. Default: 0
       ``padding='valid'`` is the same as no padding. ``padding='same'`` pads
       the input so the output has the same shape as the input. However, this mode
@@ -86,9 +86,9 @@ Args:
           For ``padding='same'``, if the ``weight`` is even-length and
           ``dilation`` is odd in any dimension, a full :func:`pad` operation
           may be needed internally. Lowering performance.
-    dilation: the spacing between kernel elements. Can be a single number or
+    dilation (int or tuple, optional): the spacing between kernel elements. Can be a single number or
       a one-element tuple `(dW,)`. Default: 1
-    groups: split input into groups, :math:`\text{in\_channels}` should be divisible by
+    groups (int, optional): split input into groups, :math:`\text{in\_channels}` should be divisible by
       the number of groups. Default: 1
 
 Examples::
@@ -120,12 +120,12 @@ Note:
     + r"""
 
 Args:
-    input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
-    weight: filters of shape :math:`(\text{out\_channels} , \frac{\text{in\_channels}}{\text{groups}} , kH , kW)`
-    bias: optional bias tensor of shape :math:`(\text{out\_channels})`. Default: ``None``
-    stride: the stride of the convolving kernel. Can be a single number or a
+    input (Tensor): input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
+    weight (Tensor): filters of shape :math:`(\text{out\_channels} , \frac{\text{in\_channels}}{\text{groups}} , kH , kW)`
+    bias (Tensor, optional): optional bias tensor of shape :math:`(\text{out\_channels})`. Default: ``None``
+    stride (int or tuple, optional): the stride of the convolving kernel. Can be a single number or a
       tuple `(sH, sW)`. Default: 1
-    padding: implicit paddings on both sides of the input. Can be a string {'valid', 'same'},
+    padding (int, tuple or str, optional): implicit paddings on both sides of the input. Can be a string {'valid', 'same'},
       single number or a tuple `(padH, padW)`. Default: 0
       ``padding='valid'`` is the same as no padding. ``padding='same'`` pads
       the input so the output has the same shape as the input. However, this mode
@@ -136,9 +136,9 @@ Args:
           ``dilation`` is odd in any dimension, a full :func:`pad` operation
           may be needed internally. Lowering performance.
 
-    dilation: the spacing between kernel elements. Can be a single number or
+    dilation (int or tuple, optional): the spacing between kernel elements. Can be a single number or
       a tuple `(dH, dW)`. Default: 1
-    groups: split input into groups, both :math:`\text{in\_channels}` and :math:`\text{out\_channels}`
+    groups (int, optional): split input into groups, both :math:`\text{in\_channels}` and :math:`\text{out\_channels}`
       should be divisible by the number of groups. Default: 1
 
 Examples::
@@ -171,12 +171,12 @@ Note:
     + r"""
 
 Args:
-    input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iT , iH , iW)`
-    weight: filters of shape :math:`(\text{out\_channels} , \frac{\text{in\_channels}}{\text{groups}} , kT , kH , kW)`
-    bias: optional bias tensor of shape :math:`(\text{out\_channels})`. Default: None
-    stride: the stride of the convolving kernel. Can be a single number or a
+    input (Tensor): input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iT , iH , iW)`
+    weight (Tensor): filters of shape :math:`(\text{out\_channels} , \frac{\text{in\_channels}}{\text{groups}} , kT , kH , kW)`
+    bias (Tensor, optional): optional bias tensor of shape :math:`(\text{out\_channels})`. Default: None
+    stride (int or tuple, optional): the stride of the convolving kernel. Can be a single number or a
       tuple `(sT, sH, sW)`. Default: 1
-    padding: implicit paddings on both sides of the input. Can be a string {'valid', 'same'},
+    padding (int, tuple or str, optional): implicit paddings on both sides of the input. Can be a string {'valid', 'same'},
       single number or a tuple `(padT, padH, padW)`. Default: 0
       ``padding='valid'`` is the same as no padding. ``padding='same'`` pads
       the input so the output has the same shape as the input. However, this mode
@@ -187,9 +187,9 @@ Args:
           ``dilation`` is odd in any dimension, a full :func:`pad` operation
           may be needed internally. Lowering performance.
 
-    dilation: the spacing between kernel elements. Can be a single number or
+    dilation (int or tuple, optional): the spacing between kernel elements. Can be a single number or
       a tuple `(dT, dH, dW)`. Default: 1
-    groups: split input into groups, :math:`\text{in\_channels}` should be divisible by
+    groups (int, optional): split input into groups, :math:`\text{in\_channels}` should be divisible by
       the number of groups. Default: 1
 
 Examples::
@@ -218,19 +218,19 @@ Note:
     + r"""
 
 Args:
-    input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
-    weight: filters of shape :math:`(\text{in\_channels} , \frac{\text{out\_channels}}{\text{groups}} , kW)`
-    bias: optional bias of shape :math:`(\text{out\_channels})`. Default: None
-    stride: the stride of the convolving kernel. Can be a single number or a
+    input (Tensor): input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
+    weight (Tensor): filters of shape :math:`(\text{in\_channels} , \frac{\text{out\_channels}}{\text{groups}} , kW)`
+    bias (Tensor, optional): optional bias of shape :math:`(\text{out\_channels})`. Default: None
+    stride (int or tuple, optional): the stride of the convolving kernel. Can be a single number or a
       tuple ``(sW,)``. Default: 1
-    padding: ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
+    padding (int or tuple, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
       sides of each dimension in the input. Can be a single number or a tuple
       ``(padW,)``. Default: 0
-    output_padding: additional size added to one side of each dimension in the
+    output_padding (int or tuple, optional): additional size added to one side of each dimension in the
       output shape. Can be a single number or a tuple ``(out_padW)``. Default: 0
-    groups: split input into groups, :math:`\text{in\_channels}` should be divisible by the
+    groups (int, optional): split input into groups, :math:`\text{in\_channels}` should be divisible by the
       number of groups. Default: 1
-    dilation: the spacing between kernel elements. Can be a single number or
+    dilation (int or tuple, optional): the spacing between kernel elements. Can be a single number or
       a tuple ``(dW,)``. Default: 1
 
 Examples::
@@ -259,20 +259,20 @@ Note:
     + r"""
 
 Args:
-    input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
-    weight: filters of shape :math:`(\text{in\_channels} , \frac{\text{out\_channels}}{\text{groups}} , kH , kW)`
-    bias: optional bias of shape :math:`(\text{out\_channels})`. Default: None
-    stride: the stride of the convolving kernel. Can be a single number or a
+    input (Tensor): input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
+    weight (Tensor): filters of shape :math:`(\text{in\_channels} , \frac{\text{out\_channels}}{\text{groups}} , kH , kW)`
+    bias (Tensor, optional): optional bias of shape :math:`(\text{out\_channels})`. Default: None
+    stride (int or tuple, optional): the stride of the convolving kernel. Can be a single number or a
       tuple ``(sH, sW)``. Default: 1
-    padding: ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
+    padding (int or tuple, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
       sides of each dimension in the input. Can be a single number or a tuple
       ``(padH, padW)``. Default: 0
-    output_padding: additional size added to one side of each dimension in the
+    output_padding (int or tuple, optional): additional size added to one side of each dimension in the
       output shape. Can be a single number or a tuple ``(out_padH, out_padW)``.
       Default: 0
-    groups: split input into groups, :math:`\text{in\_channels}` should be divisible by the
+    groups (int, optional): split input into groups, :math:`\text{in\_channels}` should be divisible by the
       number of groups. Default: 1
-    dilation: the spacing between kernel elements. Can be a single number or
+    dilation (int or tuple, optional): the spacing between kernel elements. Can be a single number or
       a tuple ``(dH, dW)``. Default: 1
 
 Examples::
@@ -302,20 +302,20 @@ Note:
     + r"""
 
 Args:
-    input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iT , iH , iW)`
-    weight: filters of shape :math:`(\text{in\_channels} , \frac{\text{out\_channels}}{\text{groups}} , kT , kH , kW)`
-    bias: optional bias of shape :math:`(\text{out\_channels})`. Default: None
-    stride: the stride of the convolving kernel. Can be a single number or a
+    input (Tensor): input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iT , iH , iW)`
+    weight (Tensor): filters of shape :math:`(\text{in\_channels} , \frac{\text{out\_channels}}{\text{groups}} , kT , kH , kW)`
+    bias (Tensor, optional): optional bias of shape :math:`(\text{out\_channels})`. Default: None
+    stride (int or tuple, optional): the stride of the convolving kernel. Can be a single number or a
       tuple ``(sT, sH, sW)``. Default: 1
-    padding: ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
+    padding (int or tuple, optional): ``dilation * (kernel_size - 1) - padding`` zero-padding will be added to both
       sides of each dimension in the input. Can be a single number or a tuple
       ``(padT, padH, padW)``. Default: 0
-    output_padding: additional size added to one side of each dimension in the
+    output_padding (int or tuple, optional): additional size added to one side of each dimension in the
       output shape. Can be a single number or a tuple
       ``(out_padT, out_padH, out_padW)``. Default: 0
-    groups: split input into groups, :math:`\text{in\_channels}` should be divisible by the
+    groups (int, optional): split input into groups, :math:`\text{in\_channels}` should be divisible by the
       number of groups. Default: 1
-    dilation: the spacing between kernel elements. Can be a single number or
+    dilation (int or tuple, optional): the spacing between kernel elements. Can be a single number or
       a tuple `(dT, dH, dW)`. Default: 1
 
 Examples::
@@ -353,17 +353,17 @@ input planes.
 See :class:`~torch.nn.AvgPool1d` for details and output shape.
 
 Args:
-    input: input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
-    kernel_size: the size of the window. Can be a single number or a
+    input (Tensor): input tensor of shape :math:`(\text{minibatch} , \text{in\_channels} , iW)`
+    kernel_size (int or tuple): the size of the window. Can be a single number or a
       tuple `(kW,)`
-    stride: the stride of the window. Can be a single number or a tuple
+    stride (int or tuple, optional): the stride of the window. Can be a single number or a tuple
       `(sW,)`. Default: :attr:`kernel_size`
-    padding: implicit zero paddings on both sides of the input. Can be a single
+    padding (int or tuple, optional): implicit zero paddings on both sides of the input. Can be a single
       number or a tuple `(padW,)`. Should be at most half of effective kernel
       size, that is :math:`((kernelSize - 1) * dilation + 1) / 2`. Default: 0
-    ceil_mode: when True, will use `ceil` instead of `floor` to compute the
+    ceil_mode (bool, optional): when True, will use `ceil` instead of `floor` to compute the
         output shape. Default: ``False``
-    count_include_pad: when True, will include the zero-padding in the
+    count_include_pad (bool, optional): when True, will include the zero-padding in the
         averaging calculation. Default: ``True``
 
 Examples::
@@ -389,20 +389,20 @@ input planes.
 See :class:`~torch.nn.AvgPool2d` for details and output shape.
 
 Args:
-    input: input tensor :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
-    kernel_size: size of the pooling region. Can be a single number, a single-element tuple or a
+    input (Tensor): input tensor :math:`(\text{minibatch} , \text{in\_channels} , iH , iW)`
+    kernel_size (int or tuple): size of the pooling region. Can be a single number, a single-element tuple or a
       tuple `(kH, kW)`
-    stride: stride of the pooling operation. Can be a single number, a single-element tuple or a
+    stride (int or tuple, optional): stride of the pooling operation. Can be a single number, a single-element tuple or a
       tuple `(sH, sW)`. Default: :attr:`kernel_size`
-    padding: implicit zero paddings on both sides of the input. Can be a
+    padding (int or tuple, optional): implicit zero paddings on both sides of the input. Can be a
       single number, a single-element tuple or a tuple `(padH, padW)`.
       Should be at most half of effective kernel size, that
       is :math:`((kernelSize - 1) * dilation + 1) / 2`. Default: 0
-    ceil_mode: when True, will use `ceil` instead of `floor` in the formula
+    ceil_mode (bool, optional): when True, will use `ceil` instead of `floor` in the formula
         to compute the output shape. Default: ``False``
-    count_include_pad: when True, will include the zero-padding in the
+    count_include_pad (bool, optional): when True, will include the zero-padding in the
         averaging calculation. Default: ``True``
-    divisor_override: if specified, it will be used as divisor, otherwise
+    divisor_override (int, optional): if specified, it will be used as divisor, otherwise
          size of the pooling region will be used. Default: None
 """,
 )
@@ -419,20 +419,20 @@ size :math:`sT \times sH \times sW` steps. The number of output features is equa
 See :class:`~torch.nn.AvgPool3d` for details and output shape.
 
 Args:
-    input: input tensor :math:`(\text{minibatch} , \text{in\_channels} , iT \times iH , iW)`
-    kernel_size: size of the pooling region. Can be a single number or a
+    input (Tensor): input tensor :math:`(\text{minibatch} , \text{in\_channels} , iT \times iH , iW)`
+    kernel_size (int or tuple): size of the pooling region. Can be a single number or a
       tuple `(kT, kH, kW)`
-    stride: stride of the pooling operation. Can be a single number or a
+    stride (int or tuple, optional): stride of the pooling operation. Can be a single number or a
       tuple `(sT, sH, sW)`. Default: :attr:`kernel_size`
-    padding: implicit zero paddings on both sides of the input. Can be a
+    padding (int or tuple, optional): implicit zero paddings on both sides of the input. Can be a
       single number or a tuple `(padT, padH, padW)`. Should be at most half
       of effective kernel size, that is :math:`((kernelSize - 1) * dilation + 1) / 2`.
       Default: 0
-    ceil_mode: when True, will use `ceil` instead of `floor` in the formula
+    ceil_mode (bool, optional): when True, will use `ceil` instead of `floor` in the formula
         to compute the output shape
-    count_include_pad: when True, will include the zero-padding in the
+    count_include_pad (bool, optional): when True, will include the zero-padding in the
         averaging calculation
-    divisor_override: if specified, it will be used as divisor, otherwise
+    divisor_override (int, optional): if specified, it will be used as divisor, otherwise
         size of the pooling region will be used. Default: None
 """,
 )


### PR DESCRIPTION
Fixes #103846.

## The issue

The Args entries for `torch.nn.functional`'s conv and average-pooling functions carry no type annotation at all:

```
Args:
    input: input tensor of shape ...
    weight: filters of shape ...
    stride: the stride of the convolving kernel. Can be a single number or ...
```

so the rendered page shows a bare parameter name where every other PyTorch page shows `name (type)`. That is what the screenshots on the issue are pointing at.

The matching `nn.Module` classes already document the same parameters with types, so the functional pages are the odd ones out rather than the docs having no convention:

```
# torch.nn.Conv1d
    stride (int or tuple, optional): Stride of the convolution. Default: 1
    padding (int, tuple or str, optional): Padding added to both sides of ...
```

## Changes

Types added to 65 Args entries across nine functions: `conv1d`, `conv2d`, `conv3d`, `conv_transpose1d`, `conv_transpose2d`, `conv_transpose3d`, `avg_pool1d`, `avg_pool2d`, `avg_pool3d`.

The wording is taken from the corresponding `nn.Module` docstrings rather than invented, so the two sets of pages agree: `Conv*d` for the conv arguments and `ConvTranspose*d` for `output_padding`.

One distinction worth checking in review, because it is the one place the two families genuinely differ: only `conv{1,2,3}d` accept the `'valid'` / `'same'` strings for `padding`, which their own prose already says, so only those three get `int, tuple or str`. The transposed variants take `int or tuple`.

Counts, as a sanity check on the mapping:

| annotation | times | expected |
|---|---|---|
| `input (Tensor)` | 9 | all nine functions |
| `stride (int or tuple, optional)` | 9 | all nine |
| `weight (Tensor)`, `bias (Tensor, optional)`, `dilation`, `groups` | 6 each | the six conv functions |
| `padding (int, tuple or str, optional)` | 3 | conv1d/2d/3d only |
| `padding (int or tuple, optional)` | 6 | conv_transpose*d and avg_pool*d |
| `output_padding (int or tuple, optional)` | 3 | the transposed convs |
| `kernel_size`, `ceil_mode`, `count_include_pad` | 3 each | the avg_pools |
| `divisor_override (int, optional)` | 2 | avg_pool2d and avg_pool3d only, avg_pool1d has no such argument |

Text only: no signature, default or behaviour change, and the diff is 65 changed lines with no additions or deletions of content.

## Scope

The issue also names `linear`, `bilinear`, `max_pool1d/2d/3d`, `max_unpool3d` and `nn.MultiheadAttention`. I left those out on purpose rather than silently: `linear` and `bilinear` have no `Args:` block at all (they describe their arguments in prose, so giving them types is a rewrite, not an annotation), the `max_pool*` and `max_unpool*` docstrings are built differently and are worth their own pass, and `MultiheadAttention` is a class in `torch/nn/modules/activation.py` whose docstring already carries types for its constructor. Happy to follow up on any of them, but they are separate edits and mixing them in would make this harder to review, not easier.

## Test plan

Documentation only, so there is no runtime behaviour to test. What I checked:

- `torch/nn/functional.py` still parses (`ast.parse`).
- Every one of the 65 changed lines was diffed and grouped by annotation to produce the table above, so no entry got a type that belongs to a different parameter.
- The type strings match the `nn.Module` class docstrings for the same parameters, checked against `torch.nn.Conv1d`, `torch.nn.ConvTranspose1d` and `torch.nn.AvgPool2d` on 2.11.0.
