### PR TITLE
[distributed] fix fd leak in _create_file_store

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -274,9 +274,7 @@ class CreateBackendTest(TestCase):
         ):
             create_backend(self._params_filestore)
 
-    @mock.patch(
-        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
-    )
+    @mock.patch("torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore")
     def test_create_backend_raises_error_if_file_path_is_invalid(
         self, filestore_mock
     ) -> None:
@@ -288,3 +286,24 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch("torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore")
+    @mock.patch("tempfile.mkstemp")
+    @mock.patch("os.close")
+    def test_create_file_store_closes_mkstemp_fd(
+        self, mock_os_close, mock_mkstemp, mock_filestore
+    ) -> None:
+        """mkstemp() returns an fd that must be closed; FileStore opens the path itself."""
+        mock_mkstemp.return_value = (42, "/tmp/test_rdzv_path")
+        mock_filestore.side_effect = RuntimeError("store init fails")
+
+        self._params_filestore.endpoint = ""
+        with self.assertRaisesRegex(
+            RendezvousConnectionError,
+            r"^The connection to the C10d store has failed. See inner exception for "
+            r"details.$",
+        ):
+            create_backend(self._params_filestore)
+
+        mock_mkstemp.assert_called_once()
+        mock_os_close.assert_called_once_with(42)

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -191,8 +191,10 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
     else:
         try:
             # The temporary file is readable and writable only by the user of
-            # this process.
-            _, path = tempfile.mkstemp()
+            # this process. FileStore opens the path independently, so we must
+            # close the fd returned by mkstemp() to avoid leaking it.
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
## 变更内容

`torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py` 中，`_create_file_store()` 在未指定 endpoint 时调用 `tempfile.mkstemp()` 创建临时文件，但丢弃了返回的文件描述符（fd），导致 fd 泄漏。

**修复**：捕获 fd 并立即调用 `os.close(fd)`，因为 FileStore 会自行打开路径，不需要保留该 fd。

## 测试方法

新增单元测试 `test_create_file_store_closes_mkstemp_fd`：
- mock `tempfile.mkstemp()` 返回已知 fd=42
- mock `os.close()` 记录调用
- 验证 `os.close(42)` 被调用恰好一次，即使在 FileStore 初始化失败时

**本地复现命令**：
```bash
python -m unittest test.distributed.elastic.rendezvous.c10d_rendezvous_backend_test.CreateBackendTest.test_create_file_store_closes_mkstemp_fd
```

Fixes #191394

---
Generated with assistance from an AI coding agent.