### PR TITLE
[c10d] Add an opt-in uniform-rank simulation contract to FakeProcessGroup

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1026,6 +1026,185 @@ class TestFakePG(TestCase):
         self.assertEqual(pg_name, expected)
 
 
+class TestFakePGUniformRanks(TestCase):
+    """Tests for Options.simulate_uniform_ranks.
+
+    See NOTE [FakeProcessGroup uniform-rank simulation]. The contract is that
+    the group behaves as if every rank held data identical to this one, which
+    makes every collective well defined from local inputs alone.
+    """
+
+    def tearDown(self):
+        super().tearDown()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _init(self, rank, world_size):
+        opts = FakeProcessGroup.Options()
+        opts.simulate_uniform_ranks = True
+        backend = FakeProcessGroup._create_internal(
+            rank, world_size=world_size, options=opts
+        )
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake", rank=rank, world_size=world_size, store=store
+        )
+        return backend
+
+    def test_option_defaults_to_off(self):
+        """Existing behavior must be untouched unless the flag is set."""
+        self.assertFalse(FakeProcessGroup.Options().simulate_uniform_ranks)
+
+    def test_allreduce_sum_scales_by_world_size(self):
+        """Summing world_size identical tensors multiplies by world_size."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.ones(3)
+
+        pg.allreduce([tensor]).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 4.0))
+
+    def test_allreduce_avg_is_identity(self):
+        """Averaging identical values leaves them unchanged."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.full((3,), 7.0)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.AVG
+
+        pg.allreduce([tensor], opts).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 7.0))
+
+    def test_allreduce_product_raises_to_the_world_size(self):
+        """Multiplying world_size identical tensors is exponentiation."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.full((3,), 2.0)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.PRODUCT
+
+        pg.allreduce([tensor], opts).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 16.0))
+
+    def test_allreduce_premul_sum_applies_factor_then_scales(self):
+        """PREMUL_SUM sums factor * x over every rank."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.full((3,), 3.0)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.PREMUL_SUM(0.5)
+
+        pg.allreduce([tensor], opts).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 6.0))
+
+    def test_allreduce_bitwise_and_or_are_identity(self):
+        """AND and OR are idempotent, so equal operands reduce to themselves."""
+        for op in (dist.ReduceOp.BAND, dist.ReduceOp.BOR):
+            with self.subTest(op=op):
+                pg = self._init(rank=0, world_size=4)
+                try:
+                    tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+                    opts = dist.AllreduceOptions()
+                    opts.reduceOp = op
+
+                    pg.allreduce([tensor], opts).wait()
+
+                    self.assertEqual(
+                        tensor, torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+                    )
+                finally:
+                    # Without this, a failed assertion leaves the group up and
+                    # the next iteration's _init raises "already initialized",
+                    # masking the real diagnostic.
+                    dist.destroy_process_group()
+
+    def test_allreduce_bitwise_xor_cancels_in_pairs(self):
+        """XOR over equal operands depends only on the parity of world_size."""
+        for world_size, expected in ((4, [0, 0]), (3, [0b1100, 0b1010])):
+            with self.subTest(world_size=world_size):
+                pg = self._init(rank=0, world_size=world_size)
+                try:
+                    tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+                    opts = dist.AllreduceOptions()
+                    opts.reduceOp = dist.ReduceOp.BXOR
+
+                    pg.allreduce([tensor], opts).wait()
+
+                    self.assertEqual(tensor, torch.tensor(expected, dtype=torch.int32))
+                finally:
+                    dist.destroy_process_group()
+
+    def test_reduce_scatter_sum_scales_the_local_chunk(self):
+        """Each rank keeps its own chunk, scaled by the number of ranks."""
+        pg = self._init(rank=2, world_size=4)
+        output = torch.empty(1)
+
+        pg.reduce_scatter_single(output, torch.tensor([1.0, 2.0, 3.0, 4.0])).wait()
+
+        # chunk[2] is 3.0, summed across 4 identical ranks.
+        self.assertEqual(output.item(), 12.0)
+
+    def test_all_gather_replicates_local_input(self):
+        """Unchanged by the flag: every slot already held the local value."""
+        pg = self._init(rank=1, world_size=3)
+        output = torch.empty(6)
+
+        pg.all_gather_single(output, torch.tensor([5.0, 6.0])).wait()
+
+        for chunk in output.chunk(3):
+            self.assertEqual(chunk, torch.tensor([5.0, 6.0]))
+
+    def test_all_to_all_single_preserves_split_structure(self):
+        """The regression that motivated the flag.
+
+        A caller that reshapes all-to-all output by [world_size, per_rank]
+        needs every slot filled with a full-size segment. The default
+        approximation copies a prefix and zeroes the rest, which yields the
+        wrong element count once splits are uneven.
+        """
+        world_size = 4
+        pg = self._init(rank=1, world_size=world_size)
+        # Each rank sends 2 elements to every peer, so it receives 2 from each.
+        send = torch.tensor([10.0, 11.0, 20.0, 21.0, 30.0, 31.0, 40.0, 41.0])
+        recv = torch.empty(8)
+
+        pg.all_to_all_single(recv, send, [2] * world_size, [2] * world_size).wait()
+
+        # Every peer sends us the segment it would send to rank 1, and under
+        # the uniform contract that is our own split at index 1.
+        for slot in recv.chunk(world_size):
+            self.assertEqual(slot, torch.tensor([20.0, 21.0]))
+
+    def test_all_to_all_single_reshapes_like_torchrec(self):
+        """Output must survive a [world_size, per_rank] view."""
+        world_size = 16
+        per_rank = 8
+        pg = self._init(rank=0, world_size=world_size)
+        send = torch.arange(world_size * per_rank, dtype=torch.float)
+        recv = torch.empty(world_size * per_rank)
+
+        pg.all_to_all_single(
+            recv, send, [per_rank] * world_size, [per_rank] * world_size
+        ).wait()
+
+        # This view is what KeyedJaggedTensor.dist_init performs; under the
+        # default approximation the element count does not line up.
+        self.assertEqual(recv.view(world_size, per_rank).shape, (world_size, per_rank))
+
+    def test_alltoall_list_form_uses_our_own_entry(self):
+        """Every peer sends what it would send to our position."""
+        pg = self._init(rank=2, world_size=3)
+        inputs = [torch.full((2,), float(i)) for i in range(3)]
+        outputs = [torch.empty(2) for _ in range(3)]
+
+        pg.alltoall(outputs, inputs).wait()
+
+        for output in outputs:
+            self.assertEqual(output, torch.full((2,), 2.0))
+
+
+instantiate_parametrized_tests(TestFakePGUniformRanks)
+
 instantiate_parametrized_tests(TestFakePG)
 
 if __name__ == "__main__":

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -480,6 +480,9 @@ class ProcessGroup:
         XCCL = ...
         CUSTOM = ...
 
+    @overload
+    def __init__(self, rank: int, size: int) -> None: ...
+    @overload
     def __init__(
         self,
         store: Store,
@@ -816,8 +819,21 @@ class ProcessGroup:
     def group_desc(self) -> str: ...
 
 class FakeProcessGroup(Backend):
+    class Options(Backend.Options):
+        fake_option: int
+        error_on_collective: bool
+        simulate_uniform_ranks: bool
+
+        def __init__(self) -> None: ...
+
     @staticmethod
-    def _create_internal(rank: int, world_size: int) -> FakeProcessGroup: ...
+    def _create_internal(
+        rank: int,
+        world_size: int,
+        options: FakeProcessGroup.Options = ...,
+    ) -> FakeProcessGroup: ...
+    @property
+    def options(self) -> FakeProcessGroup.Options: ...
 
 class FakeWork(Work):
     seq_id: int

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -13,6 +13,14 @@ namespace c10d {
 class FakeWork : public Work {
  public:
   int seq_id = -1;
+
+  // `result` is the tensors the collective produced. Real backends resolve
+  // their future to those tensors; callers using async_op=True read them via
+  // get_future().value(). Defaulted so existing no-arg construction is
+  // unchanged and keeps returning a valueless future.
+  explicit FakeWork(std::vector<at::Tensor> result = {})
+      : result_(std::move(result)) {}
+
   bool wait(std::chrono::milliseconds timeout = kNoTimeout) override {
     return true;
   }
@@ -26,10 +34,19 @@ class FakeWork : public Work {
   }
 
   c10::intrusive_ptr<c10::ivalue::Future> getFuture() override {
-    auto fut = c10::make_intrusive<c10::ivalue::Future>(c10::NoneType::get());
-    fut->markCompleted();
+    if (result_.empty()) {
+      auto fut = c10::make_intrusive<c10::ivalue::Future>(c10::NoneType::get());
+      fut->markCompleted();
+      return fut;
+    }
+    auto fut = c10::make_intrusive<c10::ivalue::Future>(
+        c10::ListType::create(c10::TensorType::get()));
+    fut->markCompleted(result_);
     return fut;
   }
+
+ private:
+  std::vector<at::Tensor> result_;
 };
 
 class FakeProcessGroup : public Backend {
@@ -43,6 +60,8 @@ class FakeProcessGroup : public Backend {
 
     int fake_option = 0;
     bool error_on_collective = false;
+    // See NOTE [FakeProcessGroup uniform-rank simulation]
+    bool simulate_uniform_ranks = false;
   };
 
   // Static factory method for official APIs
@@ -106,17 +125,140 @@ class FakeProcessGroup : public Backend {
         groupRank, static_cast<int>(ranks.size()), std::move(fakeOpts));
   }
 
+  // NOTE [FakeProcessGroup uniform-rank simulation]
+  // With Options::simulate_uniform_ranks the group models a world in which
+  // every rank holds data identical to this one. That single assumption makes
+  // every collective well defined from local inputs alone, which the default
+  // approximations are not: they ignore the reduce op entirely and fill
+  // all-to-all outputs without regard to the split structure, so a caller that
+  // reshapes collective output (TorchRec's KeyedJaggedTensor does) gets a
+  // wrongly sized tensor.
+  //
+  // The modeling cost is that ranks cannot diverge, so this cannot surface
+  // rank-divergence bugs. It is off by default; existing behavior is untouched.
+  bool uniformRanks() const {
+    return options_ != nullptr && options_->simulate_uniform_ranks;
+  }
+
+  // Combine `size_` identical contributions in place. Every reduce op has a
+  // closed form once the contributions are known to be equal, so the contract
+  // is total: no op falls back to a silently wrong approximation.
+  void applyUniformReduction(const at::Tensor& tensor, const ReduceOp& reduceOp)
+      const {
+    switch (reduceOp.op_) {
+      case ReduceOp::SUM:
+        tensor.mul_(size_);
+        return;
+      case ReduceOp::AVG:
+      case ReduceOp::MIN:
+      case ReduceOp::MAX:
+      case ReduceOp::BAND:
+      case ReduceOp::BOR:
+        // Averaging, taking an extremum, and bitwise AND/OR are all idempotent
+        // on equal operands, so each leaves the local value unchanged.
+        return;
+      case ReduceOp::PRODUCT:
+        tensor.pow_(size_);
+        return;
+      case ReduceOp::BXOR:
+        // x ^ x == 0, so an even number of equal contributions cancels out
+        // entirely and an odd number leaves one behind.
+        if (size_ % 2 == 0) {
+          tensor.zero_();
+        }
+        return;
+      case ReduceOp::PREMUL_SUM: {
+        // Summing `factor * x` over `size_` equal ranks scales the local
+        // value by `size_ * factor`.
+        auto supplement =
+            c10::dynamic_intrusive_pointer_cast<PreMulSumSupplement>(
+                reduceOp.supplement_);
+        TORCH_CHECK(
+            supplement != nullptr,
+            "FakeProcessGroup: PREMUL_SUM was given without its scaling "
+            "factor. Build it with torch.distributed._make_nccl_premul_sum.");
+        if (supplement->tensor_factor.defined()) {
+          tensor.mul_(supplement->tensor_factor);
+        } else {
+          tensor.mul_(supplement->double_factor);
+        }
+        tensor.mul_(size_);
+        return;
+      }
+      default:
+        TORCH_CHECK(
+            false,
+            "FakeProcessGroup: unrecognized reduce op ",
+            static_cast<int>(reduceOp.op_),
+            " under simulate_uniform_ranks.");
+    }
+  }
+
+  // Fill `dst` by repeating `src`. Real backends write the whole slot;
+  // truncating would leave the tail uninitialized, and a caller that reshapes
+  // the output would then read garbage.
+  static void fillByTiling(const at::Tensor& dst, const at::Tensor& src) {
+    const auto dstNumel = dst.numel();
+    const auto srcNumel = src.numel();
+    if (dstNumel == 0) {
+      return;
+    }
+    if (srcNumel == 0) {
+      // This peer contributes nothing, so the slot receives nothing. Zero it
+      // rather than leaving whatever the caller's buffer happened to hold.
+      dst.zero_();
+      return;
+    }
+    int64_t written = 0;
+    while (written < dstNumel) {
+      const auto n = std::min(srcNumel, dstNumel - written);
+      dst.narrow(0, written, n).copy_(src.narrow(0, 0, n));
+      written += n;
+    }
+  }
+
+  // A flat 1-D view over `t`'s storage, for element-wise segment copies.
+  static at::Tensor flatView(const at::Tensor& t) {
+    return t.as_strided({t.numel()}, {1}, t.storage_offset());
+  }
+
+  // The contiguous segment of `flat` belonging to peer `index`, honoring the
+  // c10d convention that an empty split list means an equal division.
+  static at::Tensor splitSegment(
+      const at::Tensor& flat,
+      const std::vector<int64_t>& splitSizes,
+      int index,
+      int worldSize) {
+    if (splitSizes.empty()) {
+      const auto chunk = flat.numel() / worldSize;
+      return flat.narrow(0, chunk * index, chunk);
+    }
+    int64_t offset = 0;
+    for (int i = 0; i < index; ++i) {
+      offset += splitSizes[i];
+    }
+    return flat.narrow(0, offset, splitSizes[index]);
+  }
+
   c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& /* tensors */,
       const BroadcastOptions& /* opts */ = BroadcastOptions()) override {
     checkCollectiveError();
+    // Identity under either contract: every rank already holds the value.
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
+    if (uniformRanks()) {
+      at::AutoDispatchBelowAutograd guard;
+      for (auto& tensor : tensors) {
+        applyUniformReduction(tensor, opts.reduceOp);
+      }
+      return c10::make_intrusive<FakeWork>(tensors);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
@@ -128,17 +270,31 @@ class FakeProcessGroup : public Backend {
   }
 
   c10::intrusive_ptr<Work> allreduce_coalesced(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceCoalescedOptions& /* opts */ =
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override {
     checkCollectiveError();
+    if (uniformRanks()) {
+      at::AutoDispatchBelowAutograd guard;
+      for (auto& tensor : tensors) {
+        applyUniformReduction(tensor, opts.reduceOp);
+      }
+      return c10::make_intrusive<FakeWork>(tensors);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const ReduceOptions& /* opts */ = ReduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override {
     checkCollectiveError();
+    if (uniformRanks()) {
+      at::AutoDispatchBelowAutograd guard;
+      for (auto& tensor : tensors) {
+        applyUniformReduction(tensor, opts.reduceOp);
+      }
+      return c10::make_intrusive<FakeWork>(tensors);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
@@ -285,8 +441,7 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     TORCH_CHECK(
         inputBuffer.numel() == outputBuffer.numel() * size_,
@@ -295,14 +450,18 @@ class FakeProcessGroup : public Backend {
     at::AutoDispatchBelowAutograd guard;
     auto chunks = inputBuffer.chunk(size_);
     outputBuffer.copy_(chunks[rank_]);
+    if (uniformRanks()) {
+      applyUniformReduction(outputBuffer, opts.reduceOp);
+      return c10::make_intrusive<FakeWork>(
+          std::vector<at::Tensor>{outputBuffer});
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(
@@ -318,8 +477,12 @@ class FakeProcessGroup : public Backend {
           "input tensor must be the same size as output size times world size");
       auto chunks = inputs[i].chunk(size_);
       outputs[i].copy_(chunks[rank_]);
+      if (uniformRanks()) {
+        applyUniformReduction(outputs[i], opts.reduceOp);
+      }
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks() ? c10::make_intrusive<FakeWork>(outputs)
+                          : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> all_to_all_single(
@@ -348,6 +511,19 @@ class FakeProcessGroup : public Backend {
             .as_strided(
                 {outputBuffer.numel()}, {1}, outputBuffer.storage_offset())
             .zero_();
+    if (uniformRanks()) {
+      // Every peer holds what we hold, so the segment peer j sends to us is
+      // the segment we would send to a peer in our own position: our input
+      // split at index rank_. Fill each output slot from it, which keeps the
+      // split structure self-consistent and lets callers reshape the result.
+      auto mine = splitSegment(flat_input, inputSplitSizes, rank_, size_);
+      for (int j = 0; j < size_; ++j) {
+        auto slot = splitSegment(flat_output, outputSplitSizes, j, size_);
+        fillByTiling(slot, mine);
+      }
+      return c10::make_intrusive<FakeWork>(
+          std::vector<at::Tensor>{outputBuffer});
+    }
     auto copy_size = std::min(flat_input.numel(), flat_output.numel());
     if (copy_size > 0) {
       flat_output.narrow(0, 0, copy_size)
@@ -369,9 +545,27 @@ class FakeProcessGroup : public Backend {
     // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
     for (size_t i = 0; i < outputTensors.size(); ++i) {
-      outputTensors[i].copy_(inputTensors[i]);
+      if (uniformRanks()) {
+        // Every peer sends us what it would send to our position, which is our
+        // own entry at index rank_. Shapes need not match, so tile.
+        // flatView walks storage linearly, so a non-contiguous tensor would
+        // read or write the wrong elements. all_to_all_single rejects those
+        // outright; do the same here rather than corrupt them silently.
+        TORCH_CHECK(
+            outputTensors[i].is_contiguous(),
+            "FakeProcessGroup::alltoall: output tensor must be contiguous "
+            "under simulate_uniform_ranks");
+        TORCH_CHECK(
+            inputTensors[rank_].is_contiguous(),
+            "FakeProcessGroup::alltoall: input tensor must be contiguous "
+            "under simulate_uniform_ranks");
+        fillByTiling(flatView(outputTensors[i]), flatView(inputTensors[rank_]));
+      } else {
+        outputTensors[i].copy_(inputTensors[i]);
+      }
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks() ? c10::make_intrusive<FakeWork>(outputTensors)
+                          : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> send(

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -158,6 +158,10 @@ class FakeProcessGroup : public Backend {
         // on equal operands, so each leaves the local value unchanged.
         return;
       case ReduceOp::PRODUCT:
+        // Overflows silently for integer dtypes once the world is more than a
+        // few ranks wide, and saturates to inf for floats. That matches what a
+        // real backend would produce for the same inputs, so it is left alone
+        // rather than clamped.
         tensor.pow_(size_);
         return;
       case ReduceOp::BXOR:
@@ -227,14 +231,14 @@ class FakeProcessGroup : public Backend {
   static at::Tensor splitSegment(
       const at::Tensor& flat,
       const std::vector<int64_t>& splitSizes,
-      int index,
-      int worldSize) {
+      int64_t index,
+      int64_t worldSize) {
     if (splitSizes.empty()) {
       const auto chunk = flat.numel() / worldSize;
       return flat.narrow(0, chunk * index, chunk);
     }
     int64_t offset = 0;
-    for (int i = 0; i < index; ++i) {
+    for (int64_t i = 0; i < index; ++i) {
       offset += splitSizes[i];
     }
     return flat.narrow(0, offset, splitSizes[index]);
@@ -506,24 +510,24 @@ class FakeProcessGroup : public Backend {
     // much of the local input as fits and zero the remainder.
     auto flat_input = inputBuffer.as_strided(
         {inputBuffer.numel()}, {1}, inputBuffer.storage_offset());
-    auto flat_output =
-        outputBuffer
-            .as_strided(
-                {outputBuffer.numel()}, {1}, outputBuffer.storage_offset())
-            .zero_();
+    auto flat_output = outputBuffer.as_strided(
+        {outputBuffer.numel()}, {1}, outputBuffer.storage_offset());
     if (uniformRanks()) {
       // Every peer holds what we hold, so the segment peer j sends to us is
       // the segment we would send to a peer in our own position: our input
       // split at index rank_. Fill each output slot from it, which keeps the
       // split structure self-consistent and lets callers reshape the result.
+      // The splits cover the whole buffer, so every element is written here
+      // and the approximation's pre-zeroing below would be wasted work.
       auto mine = splitSegment(flat_input, inputSplitSizes, rank_, size_);
-      for (int j = 0; j < size_; ++j) {
+      for (int64_t j = 0; j < size_; ++j) {
         auto slot = splitSegment(flat_output, outputSplitSizes, j, size_);
         fillByTiling(slot, mine);
       }
       return c10::make_intrusive<FakeWork>(
           std::vector<at::Tensor>{outputBuffer});
     }
+    flat_output.zero_();
     auto copy_size = std::min(flat_input.numel(), flat_output.numel());
     if (copy_size > 0) {
       flat_output.narrow(0, 0, copy_size)
@@ -544,28 +548,31 @@ class FakeProcessGroup : public Backend {
         invalidArgument, outputTensors.size(), inputTensors.size(), size_);
     // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
-    for (size_t i = 0; i < outputTensors.size(); ++i) {
-      if (uniformRanks()) {
-        // Every peer sends us what it would send to our position, which is our
-        // own entry at index rank_. Shapes need not match, so tile.
-        // flatView walks storage linearly, so a non-contiguous tensor would
-        // read or write the wrong elements. all_to_all_single rejects those
-        // outright; do the same here rather than corrupt them silently.
+    if (uniformRanks()) {
+      // Every peer sends us what it would send to our position, which is our
+      // own entry at index rank_, so it is the same source for every slot.
+      // flatView walks storage linearly, so a non-contiguous tensor would read
+      // or write the wrong elements. all_to_all_single rejects those outright;
+      // do the same here rather than corrupt them silently.
+      TORCH_CHECK(
+          inputTensors[rank_].is_contiguous(),
+          "FakeProcessGroup::alltoall: input tensor must be contiguous "
+          "under simulate_uniform_ranks");
+      auto mine = flatView(inputTensors[rank_]);
+      for (auto& output : outputTensors) {
         TORCH_CHECK(
-            outputTensors[i].is_contiguous(),
+            output.is_contiguous(),
             "FakeProcessGroup::alltoall: output tensor must be contiguous "
             "under simulate_uniform_ranks");
-        TORCH_CHECK(
-            inputTensors[rank_].is_contiguous(),
-            "FakeProcessGroup::alltoall: input tensor must be contiguous "
-            "under simulate_uniform_ranks");
-        fillByTiling(flatView(outputTensors[i]), flatView(inputTensors[rank_]));
-      } else {
-        outputTensors[i].copy_(inputTensors[i]);
+        // Shapes need not match, so tile.
+        fillByTiling(flatView(output), mine);
       }
+      return c10::make_intrusive<FakeWork>(outputTensors);
     }
-    return uniformRanks() ? c10::make_intrusive<FakeWork>(outputTensors)
-                          : c10::make_intrusive<FakeWork>();
+    for (size_t i = 0; i < outputTensors.size(); ++i) {
+      outputTensors[i].copy_(inputTensors[i]);
+    }
+    return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> send(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4658,6 +4658,9 @@ such as `dist.all_reduce(tensor, async_op=True)`.
       .def_readwrite(
           "error_on_collective",
           &::c10d::FakeProcessGroup::Options::error_on_collective)
+      .def_readwrite(
+          "simulate_uniform_ranks",
+          &::c10d::FakeProcessGroup::Options::simulate_uniform_ranks)
       .def(
           "__copy__",
           [](const ::c10d::FakeProcessGroup::Options& self) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194539

`FakeProcessGroup` documents its collectives as "deterministic single-process approximations" whose "values are arbitrary; do not assert on them". That is unusable for any caller that reshapes collective output, and it is silently wrong for any caller that cares about the reduce op:

- `allreduce` / `reduce` / `allreduce_coalesced` ignore `ReduceOp` entirely and are pure no-ops, so a SUM comes back unscaled
- `reduce_scatter*` return the local chunk without applying the op
- `all_to_all_single` fills the output with a prefix of the local input and zeros the remainder, disregarding the split structure

The third one is not hypothetical. Running an internal TorchRec model against the stock backend fails in the first forward:

```
RuntimeError: shape '[16, 8]' is invalid for input of size 114
  torchrec/sparse/jagged_tensor.py in KeyedJaggedTensor.dist_init
    stride_per_key_per_rank = stride_per_rank_per_key.view(...)
```

With a fake world of 16, TorchRec exchanges per-rank stride metadata over all-to-all and reshapes the result. The approximation does not preserve the split structure, so the element count does not line up.

## The contract

`Options::simulate_uniform_ranks` (default `false`) makes the group model a world in which **every rank holds data identical to this one**. That single assumption makes every collective well defined from local inputs alone:

| collective | under the contract |
| --- | --- |
| `broadcast` | identity, every rank already holds the value |
| `all_gather*` | replicate the local input, unchanged from today |
| `allreduce` / `reduce` | see the reduce-op table below |
| `reduce_scatter*` | the local chunk, then the same op scaling |
| `all_to_all_single` / `alltoall` | each output slot is filled from the segment this rank would send to its own position, tiled to fill the slot |

The contract is **total** over reduce ops. Once the contributions are known to be equal, every op has a closed form, so none of them falls back to a silently wrong approximation:

| op | result |
| --- | --- |
| `SUM` | `x * world_size` |
| `AVG`, `MIN`, `MAX`, `BAND`, `BOR` | identity, all are idempotent on equal operands |
| `PRODUCT` | `x ** world_size` |
| `PREMUL_SUM(f)` | `x * f * world_size` |
| `BXOR` | `x` for odd `world_size`, `0` for even, since `x ^ x == 0` |

`FakeWork` now also resolves its future to the produced tensors, so `async_op=True` callers reading `get_future().value()` see the result instead of `None`. Default-constructed `FakeWork` is unchanged and still returns a valueless future.

## Type stubs

`torch/_C/_distributed_c10d.pyi` did not declare `FakeProcessGroup.Options` at all, nor `_create_internal`'s `options` argument, so every Python caller of this flag was a type error. It also declared only the `(store, rank, size)` `ProcessGroup` constructor, though `init.cpp` has exposed a `(rank, size)` overload for as long as the store-less form has existed. Both are added here, which lets the callers in the diffs above drop their `cast(Any, ...)` workarounds.

## Scope

Off by default: with the flag unset every code path and every existing test behaves exactly as before. The modeling cost when it is on is that ranks cannot diverge, so it cannot surface rank-divergence bugs; that is documented on the class in NOTE [FakeProcessGroup uniform-rank simulation].

Differential Revision: [D117087581](https://our.internmc.facebook.com/intern/diff/D117087581/)