### PR TITLE
[aot_autograd] replay opaque input mutations on restricted views

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -2443,6 +2443,57 @@ def forward(self, primals_1):
     return (add,)""",
         )
 
+    @parametrize("backend", ("aot_eager", "inductor"))
+    def test_input_mutation_replayed_onto_restricted_view(self, backend):
+        from torch._dynamo.testing import CompileCounterWithBackend
+
+        class Scale(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, tensor):
+                return tensor
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad * 3
+
+        def opaque_add_(weight, value):
+            weight.data.add_(value)
+
+        with torch.library._scoped_library("aotmut", "FRAGMENT") as lib:
+            lib.define("opaque_add_(Tensor(a!) weight, Tensor value) -> ()")
+            lib.impl("opaque_add_", opaque_add_, "CompositeExplicitAutograd")
+            lib.impl("opaque_add_", lambda weight, value: None, "Meta")
+
+            def body(weight, value):
+                torch.ops.aotmut.opaque_add_(weight, value)
+                return (weight * value).sum()
+
+            def run(fn, restricted):
+                torch.manual_seed(0)
+                base = torch.randn(4, requires_grad=True)
+                value = torch.randn(4, requires_grad=True)
+                weight = base * 1.0
+                if restricted:
+                    weight = Scale.apply(weight)
+                version = weight._version
+                fn(weight, value).backward()
+                result = base.grad, value.grad, weight.detach().clone()
+                return result, weight._version - version
+
+            reference = run(body, True)
+            torch._dynamo.reset()
+            self.assertEqual(run(torch.compile(body, backend=backend), True), reference)
+
+            torch._dynamo.reset()
+            counter = CompileCounterWithBackend(backend)
+            compiled = torch.compile(body, backend=counter, fullgraph=True)
+            ordinary, ordinary_version = run(compiled, False)
+            ordinary_ref, _ = run(body, False)
+            self.assertEqual(ordinary, ordinary_ref)
+            self.assertEqual(ordinary_version, 1)
+            self.assertEqual(run(compiled, True), reference)
+            self.assertEqual(counter.frame_count, 1)
+
     def test_input_mutation_requires_grad_no_grad(self):
         def f(a):
             with torch.no_grad():

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -449,6 +449,16 @@ def _precompile_dynamo_dealias_marked_returns_step(x):
     )
 
 
+@torch._dynamo.disable
+def _precompile_mutation_replay_backward(output):
+    output.backward()
+
+
+def _precompile_mutation_replay_step(weight, value):
+    torch.ops.precompile_mutation_replay.opaque_add_(weight, value)
+    _precompile_mutation_replay_backward((weight * value).sum())
+
+
 def _precompile_dynamo_autograd_grad(module, x, target):
     loss = torch.nn.functional.mse_loss(module(x), target)
     return torch.autograd.grad(loss, tuple(module.parameters()))
@@ -5223,6 +5233,77 @@ class TestPrecompile(TestCase):
 class TestPrecompileNumerics(TestCase):
     # Numeric-correctness tests run device-generically so the same coverage
     # exercises the CUDA lowering, not just CPU.
+
+    def test_dynamo_training_replays_mutation_onto_restricted_view(self, device):
+        class Scale(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, tensor):
+                return tensor
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad * 3
+
+        def opaque_add_(weight, value):
+            weight.data.add_(value)
+
+        with torch.library._scoped_library(
+            "precompile_mutation_replay", "FRAGMENT"
+        ) as lib:
+            lib.define("opaque_add_(Tensor(a!) weight, Tensor value) -> ()")
+            lib.impl("opaque_add_", opaque_add_, "CompositeExplicitAutograd")
+            lib.impl("opaque_add_", lambda weight, value: None, "Meta")
+
+            example_base = make_tensor(
+                (4,), device=device, dtype=torch.float32, requires_grad=True
+            )
+            example_weight = example_base * 1.0
+            example_value = make_tensor(
+                (4,), device=device, dtype=torch.float32, requires_grad=True
+            )
+            code, cache = torch.compiler.precompile(
+                _precompile_mutation_replay_step,
+                example_inputs=[(example_weight, example_value)],
+                tracer="dynamo",
+                backend="inductor",
+                training=True,
+            )
+            self.assertIn(
+                "from torch._functorch._aot_autograd.standalone_runtime import "
+                "_replay_input_mutation",
+                code,
+            )
+            self.assertNotIn(
+                "runtime_wrappers import _replay_input_mutation",
+                code,
+            )
+
+            for _, loaded in _default_and_inlined_loaders(code, cache, "inductor"):
+                ref_base = make_tensor(
+                    (4,), device=device, dtype=torch.float32, requires_grad=True
+                )
+                actual_base = ref_base.detach().clone().requires_grad_()
+                ref_value = make_tensor(
+                    (4,), device=device, dtype=torch.float32, requires_grad=True
+                )
+                actual_value = ref_value.detach().clone().requires_grad_()
+                ref_weight = Scale.apply(ref_base * 1.0)
+                actual_weight = Scale.apply(actual_base * 1.0)
+                ref_version = ref_weight._version
+                actual_version = actual_weight._version
+
+                _precompile_mutation_replay_step(ref_weight, ref_value)
+                with loaded:
+                    loaded(actual_weight, actual_value)
+                    self.assertEqual(loaded.serve_time_compiles(), 0)
+
+                self.assertEqual(actual_base.grad, ref_base.grad)
+                self.assertEqual(actual_value.grad, ref_value.grad)
+                self.assertEqual(actual_weight, ref_weight)
+                self.assertEqual(
+                    actual_weight._version - actual_version,
+                    ref_weight._version - ref_version,
+                )
 
     def test_torch_compile_training_preserves_undefined_tangent(self, device):
         model = _PrecompileDynamoIndependentOutputs().to(device)

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4167,7 +4167,7 @@ def _companion_attribute_guards(
         if (link := _attribute_link(guard.originating_source)) is not None
     }
     failed = {id(guard) for guard, _ in failures}
-    result = []
+    result: list[tuple[Guard, Exception]] = []
     for guard in guards:
         if id(guard) in failed:
             continue

--- a/torch/_functorch/_aot_autograd/graph_compile.py
+++ b/torch/_functorch/_aot_autograd/graph_compile.py
@@ -302,8 +302,8 @@ def aot_stage1_graph_capture(
             for wrapper in wrappers
         )
         and not aot_state.fw_metadata.tokens
-        and not requires_subclass_dispatch(  # type: ignore[arg-type]
-            aot_state.flat_args,
+        and not requires_subclass_dispatch(
+            aot_state.flat_args,  # type: ignore[arg-type]
             aot_state.fw_metadata,
         )
         and not has_dynamo_autograd_function

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -237,6 +237,25 @@ def _identity(x: Any) -> Any:
     return x
 
 
+def _replay_input_mutation(orig: torch.Tensor, updated: torch.Tensor) -> None:
+    """Replay a functionalized input mutation onto the caller's tensor.
+
+    Opaque ops can mutate storage without participating in autograd or bumping the
+    version counter. Replaying that write with a tracked ``copy_`` rejects views
+    returned by custom autograd Functions, while changing their creation metadata
+    would alter backward semantics. Detect this unguarded property per runtime call.
+    """
+    if (
+        orig._is_view()
+        and torch._C._autograd._get_creation_meta(orig)
+        != torch._C._autograd.CreationMeta.DEFAULT
+    ):
+        with torch.no_grad(), torch.autograd._unsafe_preserve_version_counter(orig):
+            orig.copy_(updated)
+    else:
+        orig.copy_(updated)
+
+
 class AliasOfInputHandler:
     def __init__(
         self,
@@ -1080,7 +1099,11 @@ def _create_runtime_wrapper(
             args="orig_inputs, updated_inputs",
             artifact_name="mutation_epilogue",
         )
-        buf.bind(torch=torch, _unwrap_tensoralias=_unwrap_tensoralias)
+        buf.bind(
+            torch=torch,
+            _replay_input_mutation=_replay_input_mutation,
+            _unwrap_tensoralias=_unwrap_tensoralias,
+        )
         wrote_body = False
         with buf.indent():
             for i, inpt_idx in enumerate(runtime_metadata.mutated_inp_runtime_indices):
@@ -1136,7 +1159,7 @@ def _create_runtime_wrapper(
                             )
                             buf.writeline(f"raise RuntimeError({msg_name})")
                         else:
-                            buf.writeline(f"{oi}.copy_({ui})")
+                            buf.writeline(f"_replay_input_mutation({oi}, {ui})")
             if not wrote_body:
                 buf.writeline("pass")
 

--- a/torch/_functorch/_aot_autograd/standalone_runtime.py
+++ b/torch/_functorch/_aot_autograd/standalone_runtime.py
@@ -29,6 +29,7 @@ from torch._prims_common import CUDARngStateHelper
 from .functional_utils import gen_alias_from_base
 from .runtime_wrappers import (
     _dealias_marked_returns,
+    _replay_input_mutation,
     _unwrap_tensoralias,
     mark_dynamo_propagated_dynamic_indices,
 )
@@ -38,6 +39,7 @@ from .utils import normalize_as_list
 __all__ = [
     "gen_alias_from_base",
     "_dealias_marked_returns",
+    "_replay_input_mutation",
     "_unwrap_tensoralias",
     "mark_dynamo_propagated_dynamic_indices",
     "normalize_as_list",

--- a/torch/_functorch/_aot_autograd/to_standalone_python.py
+++ b/torch/_functorch/_aot_autograd/to_standalone_python.py
@@ -193,6 +193,10 @@ def _known_helper_table() -> dict[int, tuple[str, str]]:
             f"{_RT} _dealias_marked_returns",
             "_dealias_marked_returns",
         ),
+        id(rt._replay_input_mutation): (
+            f"{_RT} _replay_input_mutation",
+            "_replay_input_mutation",
+        ),
         id(rt.mark_dynamo_propagated_dynamic_indices): (
             f"{_RT} mark_dynamo_propagated_dynamic_indices",
             "mark_dynamo_propagated_dynamic_indices",

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -2316,7 +2316,7 @@ def _dynamo_input_contract(
     example_inputs: Sequence[ExampleInput],
 ) -> _DynamoInputContract | None:
     def module_signature(module: torch.nn.Module) -> tuple[object, ...]:
-        tensors = [
+        tensors: list[tuple[str, str, torch.Tensor]] = [
             ("parameter", name, tensor)
             for name, tensor in module.named_parameters(remove_duplicate=False)
         ]
@@ -2916,7 +2916,7 @@ def _precompile_dynamo(
             recompile_limit=recompile_limit,
             isolate_recompiles=True,
         )
-        region = context._isolate_recompiles_id
+        region = context._isolate_recompiles_id  # type: ignore[attr-defined]
         compiled = context(fn)
         saved_grads = _dynamo_example_grads(fn, examples)
         try:

--- a/torch/_precompile_driver.py
+++ b/torch/_precompile_driver.py
@@ -407,6 +407,7 @@ def _build_dynamo_forward():
     import pickle
     import sys
     import types
+    from typing import cast
 
     import torch
     import torch.utils._pytree as _pytree
@@ -447,7 +448,7 @@ def _build_dynamo_forward():
         if not state.mutates_input_grads:
             return function(*args, **kwargs)
 
-        tensors = {}
+        tensors: dict[int, torch.Tensor] = {}
         leaves, _ = _pytree.tree_flatten((args, kwargs))
         for value in leaves:
             if isinstance(value, torch.nn.Module):
@@ -455,7 +456,9 @@ def _build_dynamo_forward():
                     tensors[id(parameter)] = parameter
             elif isinstance(value, torch.Tensor) and value.is_leaf:
                 tensors[id(value)] = value
-        saved = [(tensor, tensor.grad) for tensor in tensors.values()]
+        saved: list[tuple[torch.Tensor, torch.Tensor | None]] = [
+            (tensor, tensor.grad) for tensor in tensors.values()
+        ]
         with torch.no_grad():
             for tensor, _ in saved:
                 tensor.grad = None
@@ -467,6 +470,7 @@ def _build_dynamo_forward():
                     current = tensor.grad
                     if previous is None:
                         continue
+                    previous = cast(torch.Tensor, previous)
                     if current is None:
                         tensor.grad = previous
                     elif previous.is_sparse and not current.is_sparse:
@@ -790,7 +794,7 @@ def _build_dynamo_forward():
                         serialization_guard_filter_fn=keep_serializable_guards,
                     )
                     try:
-                        package.prepare(backends)
+                        package.prepare(backends)  # type: ignore[arg-type]
                     except Exception as error:
                         from torch._precompile import PrecompileError
 
@@ -822,7 +826,7 @@ def _build_dynamo_forward():
                         isolate_recompiles=True,
                     )
                     compiled = context(fn)
-                    region = context._isolate_recompiles_id
+                    region = context._isolate_recompiles_id  # type: ignore[attr-defined]
                     try:
                         package.install(backends, isolate_recompiles_id=region)
                     except BaseException:
@@ -842,7 +846,10 @@ def _build_dynamo_forward():
                 with self.state:
                     if self.compiled is None or self.unloading:
                         raise RuntimeError("precompile artifact has been unloaded")
-                    if self.package.installed_entries_dropped():
+                    package = self.package
+                    if package is None:
+                        raise AssertionError("installed artifact was not prepared")
+                    if package.installed_entries_dropped():
                         from torch._precompile import PrecompileError
 
                         raise PrecompileError(
@@ -985,6 +992,6 @@ def _build_dynamo_forward():
         with torch.set_grad_enabled(TRAINING):
             return run_entry(entry, args, kwargs)
 
-    forward.capture_summary = state.summary
+    forward.capture_summary = state.summary  # type: ignore[attr-defined]
 
     return forward


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194543
* #194528
* #194527
* #194526
* #194525
* #194524
* #194523
* #194470
* #194468
* #194467
* #194466
* #194465
* #194464
* #194413
* #194295
* #194294
* #194293
* #194148
* #194643
* #194113

Functionalization replays lifted input mutations with a tracked copy_. That replay is stricter than opaque mutations performed through .data or raw pointers: a tensor returned unchanged from a custom autograd.Function is a restricted view, so the synthetic tracked write raises even though eager accepts the original mutation.

Choose the replay at runtime because view creation metadata is not part of the compiled calling convention. Restricted views are updated under no_grad while preserving their version counter, which matches the opaque write without changing their autograd history. Ordinary tensors retain the existing tracked copy behavior. Re-export the helper through the standalone runtime so generated precompile artifacts remain portable.

Always replaying invisibly was rejected because ordinary mutations must keep their existing version behavior. Clearing creation metadata was rejected because it can reroute history and drop the custom Function backward.

Test Plan:

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 PYTHONPATH="$PWD/test/functorch" /home/bobren/local/e/pytorch-env/bin/python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_aotdispatch.py", "-k", "input_mutation_replayed_onto_restricted_view", "--verbose"]; runpy.run_path("test/functorch/test_aotdispatch.py",run_name="__main__")'
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 PYTHONPATH="$PWD/test/functorch" /home/bobren/local/e/pytorch-env/bin/python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_aotdispatch.py", "-k", "input_mutation", "--verbose"]; runpy.run_path("test/functorch/test_aotdispatch.py",run_name="__main__")'
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 PYTHONPATH="$PWD/test/functorch" /home/bobren/local/e/pytorch-env/bin/python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_aotdispatch.py"]; runpy.run_path("test/functorch/test_aotdispatch.py",run_name="__main__")'
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 PYTHONPATH="$PWD/test/functorch" /home/bobren/local/e/pytorch-env/bin/python -W ignore -c 'import runpy,sys; sys.modules["torchvision"]=None; sys.argv=["test/functorch/test_compile_to_python.py"]; runpy.run_path("test/functorch/test_compile_to_python.py",run_name="__main__")'
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 /home/bobren/local/e/pytorch-env/bin/python test/test_precompile.py
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 /home/bobren/local/e/pytorch-env/bin/python test/dynamo/test_aot_autograd_cache.py
```

```
LD_LIBRARY_PATH=/home/bobren/local/e/pytorch-env/lib:/usr/local/fbcode/platform010/lib/cudnn-no-rpath-9.14/cuda12 /home/bobren/local/e/pytorch-env/bin/python test/dynamo/test_package.py
```

```
UV_OFFLINE=1 /home/bobren/local/c/pytorch-env/bin/spin lint
```

```
UV_OFFLINE=1 /home/bobren/local/c/pytorch-env/bin/spin quicklint -- --skip PYREFLY
```

The full lint entry point hit the pre-existing full-tree missing-path failure, and changed-file Pyrefly hit the pre-existing duplicate prepare_qat panic. All other changed-file linters passed.

Authored with an AI assistant.

cc @albanD @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98