### PR TITLE
[c10d] Add an opt-in uniform-rank simulation contract to FakeProcessGroup

### DIFF
--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1042,35 +1042,51 @@ class TestFakePGUniformRanks(TestCase):
     def _init(self, rank, world_size):
         opts = FakeProcessGroup.Options()
         opts.simulate_uniform_ranks = True
-        backend = FakeProcessGroup._create_internal(
-            rank, world_size=world_size, options=opts
-        )
-        store = FakeStore()
-        # This default group does NOT carry simulate_uniform_ranks; it exists
-        # only so tearDown has something to destroy. Every test below drives
-        # the returned backend directly -- routing through dist.* here would
-        # silently exercise the non-uniform path.
         dist.init_process_group(
-            backend="fake", rank=rank, world_size=world_size, store=store
+            backend="fake",
+            rank=rank,
+            world_size=world_size,
+            store=FakeStore(),
+            pg_options=opts,
         )
-        return backend
+        return dist.distributed_c10d._get_default_group()._get_backend(
+            torch.device("cpu")
+        )
 
     def test_option_defaults_to_off(self):
         """Existing behavior must be untouched unless the flag is set."""
         self.assertFalse(FakeProcessGroup.Options().simulate_uniform_ranks)
 
+    def test_create_internal_uses_fresh_default_options(self):
+        first = FakeProcessGroup._create_internal(0, world_size=2)
+        second = FakeProcessGroup._create_internal(0, world_size=2)
+
+        self.assertIsNot(first.options, second.options)
+        first.options.simulate_uniform_ranks = True
+        self.assertFalse(second.options.simulate_uniform_ranks)
+
+    def test_create_internal_preserves_explicit_none_options(self):
+        backend = FakeProcessGroup._create_internal(0, world_size=2, options=None)
+
+        self.assertIsNone(backend.options)
+
     def test_new_group_inherits_uniform_rank_simulation(self):
-        opts = FakeProcessGroup.Options()
-        opts.simulate_uniform_ranks = True
-        dist.init_process_group(
-            backend="fake",
-            rank=0,
-            world_size=2,
-            store=FakeStore(),
-            pg_options=opts,
-        )
+        self._init(rank=0, world_size=2)
 
         process_group = dist.new_group(ranks=[0, 1])
+        self.assertIsInstance(process_group, dist.ProcessGroup)
+        backend = process_group._get_backend(torch.device("cpu"))
+        self.assertIsInstance(backend, FakeProcessGroup)
+        self.assertTrue(backend.options.simulate_uniform_ranks)
+
+    def test_split_group_inherits_uniform_rank_simulation(self):
+        self._init(rank=0, world_size=2)
+        parent = dist.distributed_c10d._get_default_group()
+
+        process_group = parent.split_group(
+            [0, 1], device_types=[torch.device("cpu")]
+        )
+
         self.assertIsInstance(process_group, dist.ProcessGroup)
         backend = process_group._get_backend(torch.device("cpu"))
         self.assertIsInstance(backend, FakeProcessGroup)
@@ -1146,42 +1162,63 @@ class TestFakePGUniformRanks(TestCase):
 
         self.assertEqual(tensor, torch.full((3,), 6.0))
 
-    def test_allreduce_bitwise_and_or_are_identity(self):
+    def test_allreduce_premul_sum_accepts_a_tensor_factor(self):
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.full((3,), 3.0)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.PREMUL_SUM(torch.tensor(0.5))
+
+        pg.allreduce([tensor], opts).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 6.0))
+
+    def test_allreduce_premul_sum_rejects_integral_tensors(self):
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.ones(3, dtype=torch.int64)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.PREMUL_SUM(0.5)
+
+        with self.assertRaisesRegex(
+            RuntimeError, "requires a floating point or complex tensor"
+        ):
+            pg.allreduce([tensor], opts)
+
+    def test_allreduce_premul_sum_requires_a_factor(self):
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.ones(3)
+        opts = dist.AllreduceOptions()
+        reduce_op = dist.ReduceOp(dist.ReduceOp.SUM)
+        reduce_op.op = dist.ReduceOp.PREMUL_SUM
+        opts.reduceOp = reduce_op
+
+        with self.assertRaisesRegex(RuntimeError, "without its scaling factor"):
+            pg.allreduce([tensor], opts)
+
+    @parametrize("op", [dist.ReduceOp.BAND, dist.ReduceOp.BOR])
+    def test_allreduce_bitwise_and_or_are_identity(self, op):
         """AND and OR are idempotent, so equal operands reduce to themselves."""
-        for op in (dist.ReduceOp.BAND, dist.ReduceOp.BOR):
-            with self.subTest(op=op):
-                pg = self._init(rank=0, world_size=4)
-                try:
-                    tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
-                    opts = dist.AllreduceOptions()
-                    opts.reduceOp = op
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = op
 
-                    pg.allreduce([tensor], opts).wait()
+        pg.allreduce([tensor], opts).wait()
 
-                    self.assertEqual(
-                        tensor, torch.tensor([0b1100, 0b1010], dtype=torch.int32)
-                    )
-                finally:
-                    # Without this, a failed assertion leaves the group up and
-                    # the next iteration's _init raises "already initialized",
-                    # masking the real diagnostic.
-                    dist.destroy_process_group()
+        self.assertEqual(tensor, torch.tensor([0b1100, 0b1010], dtype=torch.int32))
 
-    def test_allreduce_bitwise_xor_cancels_in_pairs(self):
+    @parametrize(
+        "world_size,expected", [(4, [0, 0]), (3, [0b1100, 0b1010])]
+    )
+    def test_allreduce_bitwise_xor_cancels_in_pairs(self, world_size, expected):
         """XOR over equal operands depends only on the parity of world_size."""
-        for world_size, expected in ((4, [0, 0]), (3, [0b1100, 0b1010])):
-            with self.subTest(world_size=world_size):
-                pg = self._init(rank=0, world_size=world_size)
-                try:
-                    tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
-                    opts = dist.AllreduceOptions()
-                    opts.reduceOp = dist.ReduceOp.BXOR
+        pg = self._init(rank=0, world_size=world_size)
+        tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.BXOR
 
-                    pg.allreduce([tensor], opts).wait()
+        pg.allreduce([tensor], opts).wait()
 
-                    self.assertEqual(tensor, torch.tensor(expected, dtype=torch.int32))
-                finally:
-                    dist.destroy_process_group()
+        self.assertEqual(tensor, torch.tensor(expected, dtype=torch.int32))
 
     def test_reduce_scatter_sum_scales_the_local_chunk(self):
         """Each rank keeps its own chunk, scaled by the number of ranks."""
@@ -1223,6 +1260,15 @@ class TestFakePGUniformRanks(TestCase):
         # the uniform contract that is our own split at index 1.
         for slot in recv.chunk(world_size):
             self.assertEqual(slot, torch.tensor([20.0, 21.0]))
+
+    def test_all_to_all_single_uses_equal_default_splits(self):
+        self._init(rank=1, world_size=2)
+        send = torch.tensor([10.0, 11.0, 20.0, 21.0])
+        recv = torch.empty_like(send)
+
+        dist.all_to_all_single(recv, send)
+
+        self.assertEqual(recv, torch.tensor([20.0, 21.0, 20.0, 21.0]))
 
     def test_all_to_all_single_fills_a_2d_buffer(self):
         """Split sizes count rows along dim 0, not elements.
@@ -1304,21 +1350,46 @@ class TestFakePGUniformRanks(TestCase):
 
         self.assertEqual(recv, torch.tensor([1.0, 2.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]))
 
-    def test_reduce_writes_only_the_root(self):
+    def test_all_to_all_single_zero_fills_a_receive_only_rank(self):
+        self._init(rank=0, world_size=2)
+        send = torch.tensor([7.0])
+        recv = torch.full((2,), -1.0)
+
+        dist.all_to_all_single(
+            recv,
+            send,
+            output_split_sizes=[1, 1],
+            input_split_sizes=[0, 1],
+        )
+
+        self.assertEqual(recv, torch.zeros(2))
+
+    @parametrize("noncontiguous_buffer", ["input", "output"])
+    def test_alltoall_rejects_noncontiguous_tensors(self, noncontiguous_buffer):
+        pg = self._init(rank=0, world_size=1)
+        inputs = [torch.arange(4.0).reshape(2, 2)]
+        outputs = [torch.empty(2, 2)]
+        if noncontiguous_buffer == "input":
+            inputs[0] = inputs[0].t()
+        else:
+            outputs[0] = outputs[0].t()
+
+        with self.assertRaisesRegex(
+            RuntimeError, f"{noncontiguous_buffer} tensor must be contiguous"
+        ):
+            pg.alltoall(outputs, inputs)
+
+    @parametrize("rank,expected", [(0, 4.0), (1, 1.0)])
+    def test_reduce_writes_only_the_root(self, rank, expected):
         """Real backends leave every non-root tensor unspecified."""
-        for rank, expected in ((0, 4.0), (1, 1.0)):
-            with self.subTest(rank=rank):
-                pg = self._init(rank=rank, world_size=4)
-                try:
-                    tensor = torch.ones(3)
-                    opts = dist.ReduceOptions()
-                    opts.rootRank = 0
+        pg = self._init(rank=rank, world_size=4)
+        tensor = torch.ones(3)
+        opts = dist.ReduceOptions()
+        opts.rootRank = 0
 
-                    pg.reduce([tensor], opts).wait()
+        pg.reduce([tensor], opts).wait()
 
-                    self.assertEqual(tensor, torch.full((3,), expected))
-                finally:
-                    dist.destroy_process_group()
+        self.assertEqual(tensor, torch.full((3,), expected))
 
     def test_allreduce_coalesced_scales_every_tensor(self):
         """Each tensor in the batch is reduced independently."""
@@ -1351,26 +1422,22 @@ class TestFakePGUniformRanks(TestCase):
         self.assertEqual(outputs[0], torch.tensor([6.0, 8.0]))
         self.assertEqual(outputs[1], torch.tensor([12.0]))
 
-    def test_bool_sum_and_product_are_identity(self):
+    @parametrize("op", [dist.ReduceOp.SUM, dist.ReduceOp.PRODUCT])
+    def test_bool_sum_and_product_are_identity(self, op):
         """Bool has no in-place form of the scaling the other dtypes use.
 
         Under c10d's nonzero-is-true convention both reductions leave equal
         bools alone, so take that branch rather than raise where a real
         backend succeeds.
         """
-        for op in (dist.ReduceOp.SUM, dist.ReduceOp.PRODUCT):
-            with self.subTest(op=op):
-                pg = self._init(rank=0, world_size=4)
-                try:
-                    tensor = torch.tensor([True, False])
-                    opts = dist.AllreduceOptions()
-                    opts.reduceOp = op
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.tensor([True, False])
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = op
 
-                    pg.allreduce([tensor], opts).wait()
+        pg.allreduce([tensor], opts).wait()
 
-                    self.assertEqual(tensor, torch.tensor([True, False]))
-                finally:
-                    dist.destroy_process_group()
+        self.assertEqual(tensor, torch.tensor([True, False]))
 
     def test_result_carries_the_reduced_tensor(self):
         """async_op callers read the output through Work.result()."""
@@ -1381,6 +1448,16 @@ class TestFakePGUniformRanks(TestCase):
         work.wait()
 
         self.assertEqual(work.result()[0], torch.full((2,), 2.0))
+
+    def test_get_future_carries_collective_output(self):
+        pg = self._init(rank=0, world_size=2)
+        output = torch.empty(4)
+
+        work = pg.all_gather_single(output, torch.tensor([3.0, 4.0]))
+
+        self.assertEqual(
+            work.get_future().value()[0], torch.tensor([3.0, 4.0, 3.0, 4.0])
+        )
 
     def test_result_still_raises_without_the_flag(self):
         """Work::result() errors by default and must keep doing so.
@@ -1397,6 +1474,7 @@ class TestFakePGUniformRanks(TestCase):
 
 
 instantiate_parametrized_tests(TestFakePG)
+instantiate_parametrized_tests(TestFakePGUniformRanks)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1071,13 +1071,26 @@ class TestFakePGUniformRanks(TestCase):
         self.assertIsNone(backend.options)
 
     def test_new_group_inherits_uniform_rank_simulation(self):
-        self._init(rank=0, world_size=2)
+        opts = FakeProcessGroup.Options()
+        opts.fake_option = 17
+        opts.simulate_uniform_ranks = True
+        dist.init_process_group(
+            backend="cuda:fake",
+            rank=0,
+            world_size=2,
+            store=FakeStore(),
+            pg_options=opts,
+        )
 
-        process_group = dist.new_group(ranks=[0, 1])
+        process_group = dist.new_group(ranks=[0, 1], backend="fake")
         self.assertIsInstance(process_group, dist.ProcessGroup)
         backend = process_group._get_backend(torch.device("cpu"))
         self.assertIsInstance(backend, FakeProcessGroup)
         self.assertTrue(backend.options.simulate_uniform_ranks)
+        self.assertEqual(backend.options.fake_option, 0)
+
+        backend.options.simulate_uniform_ranks = False
+        self.assertTrue(opts.simulate_uniform_ranks)
 
     def test_split_group_inherits_uniform_rank_simulation(self):
         self._init(rank=0, world_size=2)

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1059,6 +1059,23 @@ class TestFakePGUniformRanks(TestCase):
         """Existing behavior must be untouched unless the flag is set."""
         self.assertFalse(FakeProcessGroup.Options().simulate_uniform_ranks)
 
+    def test_new_group_inherits_uniform_rank_simulation(self):
+        opts = FakeProcessGroup.Options()
+        opts.simulate_uniform_ranks = True
+        dist.init_process_group(
+            backend="fake",
+            rank=0,
+            world_size=2,
+            store=FakeStore(),
+            pg_options=opts,
+        )
+
+        process_group = dist.new_group(ranks=[0, 1])
+        self.assertIsInstance(process_group, dist.ProcessGroup)
+        backend = process_group._get_backend(torch.device("cpu"))
+        self.assertIsInstance(backend, FakeProcessGroup)
+        self.assertTrue(backend.options.simulate_uniform_ranks)
+
     def test_allreduce_sum_scales_by_world_size(self):
         """Summing world_size identical tensors multiplies by world_size."""
         pg = self._init(rank=0, world_size=4)

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1083,9 +1083,7 @@ class TestFakePGUniformRanks(TestCase):
         self._init(rank=0, world_size=2)
         parent = dist.distributed_c10d._get_default_group()
 
-        process_group = parent.split_group(
-            [0, 1], device_types=[torch.device("cpu")]
-        )
+        process_group = parent.split_group([0, 1], device_types=[torch.device("cpu")])
 
         self.assertIsInstance(process_group, dist.ProcessGroup)
         backend = process_group._get_backend(torch.device("cpu"))
@@ -1206,9 +1204,7 @@ class TestFakePGUniformRanks(TestCase):
 
         self.assertEqual(tensor, torch.tensor([0b1100, 0b1010], dtype=torch.int32))
 
-    @parametrize(
-        "world_size,expected", [(4, [0, 0]), (3, [0b1100, 0b1010])]
-    )
+    @parametrize("world_size,expected", [(4, [0, 0]), (3, [0b1100, 0b1010])])
     def test_allreduce_bitwise_xor_cancels_in_pairs(self, world_size, expected):
         """XOR over equal operands depends only on the parity of world_size."""
         pg = self._init(rank=0, world_size=world_size)

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1090,6 +1090,34 @@ class TestFakePGUniformRanks(TestCase):
 
         self.assertEqual(tensor, torch.full((3,), 16.0))
 
+    def test_sparse_allreduce_sum_scales_values(self):
+        """Sparse SUM scales the stored values without changing sparsity."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.sparse_coo_tensor(
+            torch.tensor([[0, 2]]), torch.tensor([2.0, 3.0]), size=(4,)
+        ).coalesce()
+
+        work = pg.allreduce_sparse([tensor])
+        work.wait()
+
+        expected = torch.tensor([8.0, 0.0, 12.0, 0.0])
+        self.assertEqual(tensor.to_dense(), expected)
+        self.assertEqual(work.result()[0].to_dense(), expected)
+
+    def test_sparse_allreduce_product_raises(self):
+        """Sparse PRODUCT remains unsupported under uniform-rank simulation."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.sparse_coo_tensor(
+            torch.tensor([[0, 2]]), torch.tensor([2.0, 3.0]), size=(4,)
+        ).coalesce()
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.PRODUCT
+
+        with self.assertRaisesRegex(
+            RuntimeError, "allreduce_sparse does not support PRODUCT"
+        ):
+            pg.allreduce_sparse([tensor], opts)
+
     def test_allreduce_premul_sum_applies_factor_then_scales(self):
         """PREMUL_SUM sums factor * x over every rank."""
         pg = self._init(rank=0, world_size=4)

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1175,6 +1175,24 @@ class TestFakePGUniformRanks(TestCase):
         for slot in recv.chunk(world_size):
             self.assertEqual(slot, torch.tensor([20.0, 21.0]))
 
+    def test_all_to_all_single_fills_a_2d_buffer(self):
+        """Split sizes count rows along dim 0, not elements.
+
+        A 2-D buffer with explicit splits has to be written in full: narrowing
+        the flat view by the raw split value would write one element per slot
+        instead of one row, leaving the rest of the buffer untouched.
+        """
+        pg = self._init(rank=1, world_size=4)
+        output = torch.empty(4, 8)
+        input_tensor = torch.arange(32.0).reshape(4, 8)
+
+        pg.all_to_all_single(output, input_tensor, [1] * 4, [1] * 4).wait()
+
+        # Row 1 is what this rank would send to a peer in its own position, so
+        # under the uniform contract every slot receives it.
+        expected = input_tensor[1].expand(4, 8)
+        self.assertEqual(output, expected)
+
     def test_all_to_all_single_reshapes_like_torchrec(self):
         """Output must survive a [world_size, per_rank] view."""
         world_size = 16

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1224,6 +1224,129 @@ class TestFakePGUniformRanks(TestCase):
         for output in outputs:
             self.assertEqual(output, torch.full((2,), 2.0))
 
+    def test_alltoall_tiles_and_truncates_mismatched_slots(self):
+        """The list form lets each slot have its own shape.
+
+        Unlike all_to_all_single there is no size equality to lean on, so a
+        slot wider than our contribution is tiled and a narrower one is cut
+        short. Both must be written in full; a partial write would leave the
+        tail holding whatever the caller's buffer already contained.
+        """
+        pg = self._init(rank=0, world_size=2)
+        inputs = [torch.tensor([1.0, 2.0, 3.0]), torch.tensor([7.0, 8.0, 9.0])]
+        wide = torch.full((7,), -1.0)
+        narrow = torch.full((2,), -1.0)
+
+        pg.alltoall([wide, narrow], inputs).wait()
+
+        self.assertEqual(wide, torch.tensor([1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0]))
+        self.assertEqual(narrow, torch.tensor([1.0, 2.0]))
+
+    def test_all_to_all_single_rejects_inconsistent_splits(self):
+        """Uniformity forces every peer to send us what we send it.
+
+        Splits that disagree mean the caller's world is not uniform after all.
+        Padding or tiling the gap would hand back plausible-looking numbers
+        that no real backend would produce, so it has to raise instead.
+        """
+        pg = self._init(rank=0, world_size=2)
+        send = torch.arange(4.0)
+        recv = torch.empty(4)
+
+        with self.assertRaisesRegex(RuntimeError, "every rank sends the same amount"):
+            pg.all_to_all_single(recv, send, [1, 3], [2, 2]).wait()
+
+    def test_reduce_writes_only_the_root(self):
+        """Real backends leave every non-root tensor unspecified."""
+        for rank, expected in ((0, 4.0), (1, 1.0)):
+            with self.subTest(rank=rank):
+                pg = self._init(rank=rank, world_size=4)
+                try:
+                    tensor = torch.ones(3)
+                    opts = dist.ReduceOptions()
+                    opts.rootRank = 0
+
+                    pg.reduce([tensor], opts).wait()
+
+                    self.assertEqual(tensor, torch.full((3,), expected))
+                finally:
+                    dist.destroy_process_group()
+
+    def test_allreduce_coalesced_scales_every_tensor(self):
+        """Each tensor in the batch is reduced independently."""
+        pg = self._init(rank=0, world_size=3)
+        tensors = [torch.ones(2), torch.full((3,), 2.0)]
+
+        pg.allreduce_coalesced(tensors).wait()
+
+        self.assertEqual(tensors[0], torch.full((2,), 3.0))
+        self.assertEqual(tensors[1], torch.full((3,), 6.0))
+
+    def test_reduce_scatter_list_form_scales_our_entry(self):
+        """We keep the input at our own index, summed over the world."""
+        pg = self._init(rank=2, world_size=4)
+        output = torch.empty(2)
+        inputs = [[torch.full((2,), float(r)) for r in range(4)]]
+
+        pg.reduce_scatter([output], inputs).wait()
+
+        self.assertEqual(output, torch.full((2,), 8.0))
+
+    def test_reduce_scatter_single_coalesced_scales_each_output(self):
+        """Every buffer in the batch keeps its own chunk, scaled."""
+        pg = self._init(rank=1, world_size=2)
+        outputs = [torch.empty(2), torch.empty(1)]
+        inputs = [torch.tensor([1.0, 2.0, 3.0, 4.0]), torch.tensor([5.0, 6.0])]
+
+        pg.reduce_scatter_single_coalesced(outputs, inputs).wait()
+
+        self.assertEqual(outputs[0], torch.tensor([6.0, 8.0]))
+        self.assertEqual(outputs[1], torch.tensor([12.0]))
+
+    def test_bool_sum_and_product_are_identity(self):
+        """Bool has no in-place form of the scaling the other dtypes use.
+
+        Under c10d's nonzero-is-true convention both reductions leave equal
+        bools alone, so take that branch rather than raise where a real
+        backend succeeds.
+        """
+        for op in (dist.ReduceOp.SUM, dist.ReduceOp.PRODUCT):
+            with self.subTest(op=op):
+                pg = self._init(rank=0, world_size=4)
+                try:
+                    tensor = torch.tensor([True, False])
+                    opts = dist.AllreduceOptions()
+                    opts.reduceOp = op
+
+                    pg.allreduce([tensor], opts).wait()
+
+                    self.assertEqual(tensor, torch.tensor([True, False]))
+                finally:
+                    dist.destroy_process_group()
+
+    def test_result_carries_the_reduced_tensor(self):
+        """async_op callers read the output through Work.result()."""
+        pg = self._init(rank=0, world_size=2)
+        tensor = torch.ones(2)
+
+        work = pg.allreduce([tensor])
+        work.wait()
+
+        self.assertEqual(work.result()[0], torch.full((2,), 2.0))
+
+    def test_result_still_raises_without_the_flag(self):
+        """Work::result() errors by default and must keep doing so.
+
+        Nothing outside simulate_uniform_ranks records an output, so returning
+        an empty list here would turn a diagnosable failure into a silent one.
+        """
+        pg = FakeProcessGroup._create_internal(0, world_size=2)
+
+        work = pg.allreduce([torch.ones(2)])
+
+        with self.assertRaisesRegex(RuntimeError, "recorded no output"):
+            work.result()
+
 
 instantiate_parametrized_tests(TestFakePG)
 

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1026,6 +1026,185 @@ class TestFakePG(TestCase):
         self.assertEqual(pg_name, expected)
 
 
+class TestFakePGUniformRanks(TestCase):
+    """Tests for Options.simulate_uniform_ranks.
+
+    See NOTE [FakeProcessGroup uniform-rank simulation]. The contract is that
+    the group behaves as if every rank held data identical to this one, which
+    makes every collective well defined from local inputs alone.
+    """
+
+    def tearDown(self):
+        super().tearDown()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+    def _init(self, rank, world_size):
+        opts = FakeProcessGroup.Options()
+        opts.simulate_uniform_ranks = True
+        backend = FakeProcessGroup._create_internal(
+            rank, world_size=world_size, options=opts
+        )
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake", rank=rank, world_size=world_size, store=store
+        )
+        return backend
+
+    def test_option_defaults_to_off(self):
+        """Existing behavior must be untouched unless the flag is set."""
+        self.assertFalse(FakeProcessGroup.Options().simulate_uniform_ranks)
+
+    def test_allreduce_sum_scales_by_world_size(self):
+        """Summing world_size identical tensors multiplies by world_size."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.ones(3)
+
+        pg.allreduce([tensor]).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 4.0))
+
+    def test_allreduce_avg_is_identity(self):
+        """Averaging identical values leaves them unchanged."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.full((3,), 7.0)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.AVG
+
+        pg.allreduce([tensor], opts).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 7.0))
+
+    def test_allreduce_product_raises_to_the_world_size(self):
+        """Multiplying world_size identical tensors is exponentiation."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.full((3,), 2.0)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.PRODUCT
+
+        pg.allreduce([tensor], opts).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 16.0))
+
+    def test_allreduce_premul_sum_applies_factor_then_scales(self):
+        """PREMUL_SUM sums factor * x over every rank."""
+        pg = self._init(rank=0, world_size=4)
+        tensor = torch.full((3,), 3.0)
+        opts = dist.AllreduceOptions()
+        opts.reduceOp = dist.ReduceOp.PREMUL_SUM(0.5)
+
+        pg.allreduce([tensor], opts).wait()
+
+        self.assertEqual(tensor, torch.full((3,), 6.0))
+
+    def test_allreduce_bitwise_and_or_are_identity(self):
+        """AND and OR are idempotent, so equal operands reduce to themselves."""
+        for op in (dist.ReduceOp.BAND, dist.ReduceOp.BOR):
+            with self.subTest(op=op):
+                pg = self._init(rank=0, world_size=4)
+                try:
+                    tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+                    opts = dist.AllreduceOptions()
+                    opts.reduceOp = op
+
+                    pg.allreduce([tensor], opts).wait()
+
+                    self.assertEqual(
+                        tensor, torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+                    )
+                finally:
+                    # Without this, a failed assertion leaves the group up and
+                    # the next iteration's _init raises "already initialized",
+                    # masking the real diagnostic.
+                    dist.destroy_process_group()
+
+    def test_allreduce_bitwise_xor_cancels_in_pairs(self):
+        """XOR over equal operands depends only on the parity of world_size."""
+        for world_size, expected in ((4, [0, 0]), (3, [0b1100, 0b1010])):
+            with self.subTest(world_size=world_size):
+                pg = self._init(rank=0, world_size=world_size)
+                try:
+                    tensor = torch.tensor([0b1100, 0b1010], dtype=torch.int32)
+                    opts = dist.AllreduceOptions()
+                    opts.reduceOp = dist.ReduceOp.BXOR
+
+                    pg.allreduce([tensor], opts).wait()
+
+                    self.assertEqual(tensor, torch.tensor(expected, dtype=torch.int32))
+                finally:
+                    dist.destroy_process_group()
+
+    def test_reduce_scatter_sum_scales_the_local_chunk(self):
+        """Each rank keeps its own chunk, scaled by the number of ranks."""
+        pg = self._init(rank=2, world_size=4)
+        output = torch.empty(1)
+
+        pg.reduce_scatter_single(output, torch.tensor([1.0, 2.0, 3.0, 4.0])).wait()
+
+        # chunk[2] is 3.0, summed across 4 identical ranks.
+        self.assertEqual(output.item(), 12.0)
+
+    def test_all_gather_replicates_local_input(self):
+        """Unchanged by the flag: every slot already held the local value."""
+        pg = self._init(rank=1, world_size=3)
+        output = torch.empty(6)
+
+        pg.all_gather_single(output, torch.tensor([5.0, 6.0])).wait()
+
+        for chunk in output.chunk(3):
+            self.assertEqual(chunk, torch.tensor([5.0, 6.0]))
+
+    def test_all_to_all_single_preserves_split_structure(self):
+        """The regression that motivated the flag.
+
+        A caller that reshapes all-to-all output by [world_size, per_rank]
+        needs every slot filled with a full-size segment. The default
+        approximation copies a prefix and zeroes the rest, which yields the
+        wrong element count once splits are uneven.
+        """
+        world_size = 4
+        pg = self._init(rank=1, world_size=world_size)
+        # Each rank sends 2 elements to every peer, so it receives 2 from each.
+        send = torch.tensor([10.0, 11.0, 20.0, 21.0, 30.0, 31.0, 40.0, 41.0])
+        recv = torch.empty(8)
+
+        pg.all_to_all_single(recv, send, [2] * world_size, [2] * world_size).wait()
+
+        # Every peer sends us the segment it would send to rank 1, and under
+        # the uniform contract that is our own split at index 1.
+        for slot in recv.chunk(world_size):
+            self.assertEqual(slot, torch.tensor([20.0, 21.0]))
+
+    def test_all_to_all_single_reshapes_like_torchrec(self):
+        """Output must survive a [world_size, per_rank] view."""
+        world_size = 16
+        per_rank = 8
+        pg = self._init(rank=0, world_size=world_size)
+        send = torch.arange(world_size * per_rank, dtype=torch.float)
+        recv = torch.empty(world_size * per_rank)
+
+        pg.all_to_all_single(
+            recv, send, [per_rank] * world_size, [per_rank] * world_size
+        ).wait()
+
+        # This view is what KeyedJaggedTensor.dist_init performs; under the
+        # default approximation the element count does not line up.
+        self.assertEqual(recv.view(world_size, per_rank).shape, (world_size, per_rank))
+
+    def test_alltoall_list_form_uses_our_own_entry(self):
+        """Every peer sends what it would send to our position."""
+        pg = self._init(rank=2, world_size=3)
+        inputs = [torch.full((2,), float(i)) for i in range(3)]
+        outputs = [torch.empty(2) for _ in range(3)]
+
+        pg.alltoall(outputs, inputs).wait()
+
+        for output in outputs:
+            self.assertEqual(output, torch.full((2,), 2.0))
+
+
+instantiate_parametrized_tests(TestFakePGUniformRanks)
+
 instantiate_parametrized_tests(TestFakePG)
 
 if __name__ == "__main__":

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1046,6 +1046,10 @@ class TestFakePGUniformRanks(TestCase):
             rank, world_size=world_size, options=opts
         )
         store = FakeStore()
+        # This default group does NOT carry simulate_uniform_ranks; it exists
+        # only so tearDown has something to destroy. Every test below drives
+        # the returned backend directly -- routing through dist.* here would
+        # silently exercise the non-uniform path.
         dist.init_process_group(
             backend="fake", rank=rank, world_size=world_size, store=store
         )
@@ -1220,8 +1224,6 @@ class TestFakePGUniformRanks(TestCase):
         for output in outputs:
             self.assertEqual(output, torch.full((2,), 2.0))
 
-
-instantiate_parametrized_tests(TestFakePGUniformRanks)
 
 instantiate_parametrized_tests(TestFakePG)
 

--- a/test/distributed/test_fake_pg.py
+++ b/test/distributed/test_fake_pg.py
@@ -1242,19 +1242,22 @@ class TestFakePGUniformRanks(TestCase):
         self.assertEqual(wide, torch.tensor([1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0]))
         self.assertEqual(narrow, torch.tensor([1.0, 2.0]))
 
-    def test_all_to_all_single_rejects_inconsistent_splits(self):
-        """Uniformity forces every peer to send us what we send it.
+    def test_all_to_all_single_fills_asymmetric_slots(self):
+        """The output shape the caller declared is the one it gets.
 
-        Splits that disagree mean the caller's world is not uniform after all.
-        Padding or tiling the gap would hand back plausible-looking numbers
-        that no real backend would produce, so it has to raise instead.
+        Strict uniformity would force every output split to equal the input
+        split at our own index, and rejecting anything else was tried: it
+        breaks callers that declare asymmetric splits or a receive-only rank.
+        Each slot is tiled or truncated to the width it asked for instead.
         """
-        pg = self._init(rank=0, world_size=2)
+        pg = self._init(rank=1, world_size=2)
+        # Input split 1 is our segment, so every slot is filled from [1, 2, 3].
         send = torch.arange(4.0)
-        recv = torch.empty(4)
+        recv = torch.empty(8)
 
-        with self.assertRaisesRegex(RuntimeError, "every rank sends the same amount"):
-            pg.all_to_all_single(recv, send, [1, 3], [2, 2]).wait()
+        pg.all_to_all_single(recv, send, [2, 6], [1, 3]).wait()
+
+        self.assertEqual(recv, torch.tensor([1.0, 2.0, 1.0, 2.0, 3.0, 1.0, 2.0, 3.0]))
 
     def test_reduce_writes_only_the_root(self):
         """Real backends leave every non-root tensor unspecified."""

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -830,7 +830,7 @@ class FakeProcessGroup(Backend):
     def _create_internal(
         rank: int,
         world_size: int,
-        options: FakeProcessGroup.Options = ...,
+        options: FakeProcessGroup.Options | None = ...,
     ) -> FakeProcessGroup: ...
     # getOptions() returns null when the group was built without options, and
     # callers (test_device_mesh) branch on that, so this must stay optional.

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -480,6 +480,9 @@ class ProcessGroup:
         XCCL = ...
         CUSTOM = ...
 
+    @overload
+    def __init__(self, rank: int, size: int) -> None: ...
+    @overload
     def __init__(
         self,
         store: Store,
@@ -816,8 +819,21 @@ class ProcessGroup:
     def group_desc(self) -> str: ...
 
 class FakeProcessGroup(Backend):
+    class Options(Backend.Options):
+        fake_option: int
+        error_on_collective: bool
+        simulate_uniform_ranks: bool
+
+        def __init__(self) -> None: ...
+
     @staticmethod
-    def _create_internal(rank: int, world_size: int) -> FakeProcessGroup: ...
+    def _create_internal(
+        rank: int,
+        world_size: int,
+        options: FakeProcessGroup.Options = ...,
+    ) -> FakeProcessGroup: ...
+    @property
+    def options(self) -> FakeProcessGroup.Options: ...
 
 class FakeWork(Work):
     seq_id: int

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -832,8 +832,10 @@ class FakeProcessGroup(Backend):
         world_size: int,
         options: FakeProcessGroup.Options = ...,
     ) -> FakeProcessGroup: ...
+    # getOptions() returns null when the group was built without options, and
+    # callers (test_device_mesh) branch on that, so this must stay optional.
     @property
-    def options(self) -> FakeProcessGroup.Options: ...
+    def options(self) -> FakeProcessGroup.Options | None: ...
 
 class FakeWork(Work):
     seq_id: int

--- a/torch/_C/_distributed_c10d.pyi
+++ b/torch/_C/_distributed_c10d.pyi
@@ -834,7 +834,12 @@ class FakeProcessGroup(Backend):
     ) -> FakeProcessGroup: ...
     # getOptions() returns null when the group was built without options, and
     # callers (test_device_mesh) branch on that, so this must stay optional.
+    # Backend.options is not, which makes the narrowing a real LSP violation
+    # rather than a stub inaccuracy: this property is bound to a different C++
+    # method than the base one, and widening it to match would misdescribe
+    # behavior three assertIsNone checks already pin.
     @property
+    # pyrefly: ignore  # bad-override
     def options(self) -> FakeProcessGroup.Options | None: ...
 
 class FakeWork(Work):

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -432,9 +432,9 @@ class FakeProcessGroup : public Backend {
       // A slot need not be the size of that segment. Strict uniformity would
       // force the two to match, and rejecting the mismatch was tried: it
       // breaks callers that declare asymmetric splits or a receive-only rank,
-      // which the ads_fake_process_group tests cover and which the shapes here
-      // are meant to serve. The output shape the caller asked for is what it
-      // gets, so tile or truncate to fill it.
+      // which the direct fake-process-group tests cover and which the shapes
+      // here are meant to serve. The output shape the caller asked for is what
+      // it gets, so tile or truncate to fill it.
       //
       // Zero first: the slots should tile over the whole buffer, but a caller
       // that reshapes the output must never read uninitialized memory if they

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -196,9 +196,8 @@ class FakeProcessGroup : public Backend {
     for (auto& tensor : outputTensors[0]) {
       tensor.copy_(inputTensors[0]);
     }
-    return uniformRanks()
-        ? c10::make_intrusive<FakeWork>(outputTensors[0])
-        : c10::make_intrusive<FakeWork>();
+    return uniformRanks() ? c10::make_intrusive<FakeWork>(outputTensors[0])
+                          : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> all_gather_single(
@@ -216,8 +215,7 @@ class FakeProcessGroup : public Backend {
       tensor.copy_(inputBuffer);
     }
     return uniformRanks()
-        ? c10::make_intrusive<FakeWork>(
-              std::vector<at::Tensor>{outputBuffer})
+        ? c10::make_intrusive<FakeWork>(std::vector<at::Tensor>{outputBuffer})
         : c10::make_intrusive<FakeWork>();
   }
 

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -16,8 +16,7 @@ class FakeWork : public Work {
 
   // `result` is the tensors the collective produced. Real backends resolve
   // their future to those tensors; callers using async_op=True read them via
-  // get_future().value(). An empty list means the collective recorded no
-  // output, which is the case for every path outside simulate_uniform_ranks.
+  // get_future().value().
   explicit FakeWork(std::vector<at::Tensor> result = {})
       : result_(std::move(result)) {}
 
@@ -33,15 +32,8 @@ class FakeWork : public Work {
     return true;
   }
 
-  // Real backends expose the output through both result() and getFuture();
-  // a caller using the former should not silently get nothing. Work::result()
-  // errors by default, so keep erring when nothing was recorded rather than
-  // turning a diagnosable failure into an empty list.
   std::vector<at::Tensor> result() override {
-    TORCH_CHECK(
-        !result_.empty(),
-        "FakeProcessGroup: this work recorded no output. result() is only "
-        "populated under simulate_uniform_ranks.");
+    TORCH_CHECK(!result_.empty(), "FakeWork: this work recorded no output.");
     return result_;
   }
 
@@ -138,25 +130,19 @@ class FakeProcessGroup : public Backend {
   }
 
   c10::intrusive_ptr<Work> broadcast(
-      std::vector<at::Tensor>& /* tensors */,
+      std::vector<at::Tensor>& tensors,
       const BroadcastOptions& /* opts */ = BroadcastOptions()) override {
     checkCollectiveError();
     // Identity under either contract: every rank already holds the value.
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks() ? c10::make_intrusive<FakeWork>(tensors)
+                          : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
-    if (uniformRanks()) {
-      at::AutoDispatchBelowAutograd guard;
-      for (auto& tensor : tensors) {
-        applyUniformReduction(tensor, opts.reduceOp);
-      }
-      return c10::make_intrusive<FakeWork>(tensors);
-    }
-    return c10::make_intrusive<FakeWork>();
+    return uniformReduceAll(tensors, opts.reduceOp);
   }
 
   c10::intrusive_ptr<Work> allreduce_sparse(
@@ -168,13 +154,8 @@ class FakeProcessGroup : public Backend {
           opts.reduceOp.op_ != ReduceOp::PRODUCT,
           "FakeProcessGroup: allreduce_sparse does not support PRODUCT under "
           "simulate_uniform_ranks.");
-      at::AutoDispatchBelowAutograd guard;
-      for (auto& tensor : tensors) {
-        applyUniformReduction(tensor, opts.reduceOp);
-      }
-      return c10::make_intrusive<FakeWork>(tensors);
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformReduceAll(tensors, opts.reduceOp);
   }
 
   c10::intrusive_ptr<Work> allreduce_coalesced(
@@ -182,14 +163,7 @@ class FakeProcessGroup : public Backend {
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override {
     checkCollectiveError();
-    if (uniformRanks()) {
-      at::AutoDispatchBelowAutograd guard;
-      for (auto& tensor : tensors) {
-        applyUniformReduction(tensor, opts.reduceOp);
-      }
-      return c10::make_intrusive<FakeWork>(tensors);
-    }
-    return c10::make_intrusive<FakeWork>();
+    return uniformReduceAll(tensors, opts.reduceOp);
   }
 
   c10::intrusive_ptr<Work> reduce(
@@ -200,14 +174,10 @@ class FakeProcessGroup : public Backend {
     // leave every other rank's unspecified. Mirror that, so a caller that
     // wrongly reads a non-root result sees the same thing it would in
     // production instead of a value only this backend would produce.
-    if (uniformRanks() && rank_ == opts.rootRank) {
-      at::AutoDispatchBelowAutograd guard;
-      for (auto& tensor : tensors) {
-        applyUniformReduction(tensor, opts.reduceOp);
-      }
-      return c10::make_intrusive<FakeWork>(tensors);
+    if (rank_ != opts.rootRank) {
+      return c10::make_intrusive<FakeWork>();
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformReduceAll(tensors, opts.reduceOp);
   }
 
   // NOTE [FakeProcessGroup collective semantics]
@@ -226,7 +196,9 @@ class FakeProcessGroup : public Backend {
     for (auto& tensor : outputTensors[0]) {
       tensor.copy_(inputTensors[0]);
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks()
+        ? c10::make_intrusive<FakeWork>(outputTensors[0])
+        : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> all_gather_single(
@@ -243,7 +215,10 @@ class FakeProcessGroup : public Backend {
     for (auto& tensor : chunks) {
       tensor.copy_(inputBuffer);
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks()
+        ? c10::make_intrusive<FakeWork>(
+              std::vector<at::Tensor>{outputBuffer})
+        : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allgather_coalesced(
@@ -264,6 +239,14 @@ class FakeProcessGroup : public Backend {
         outputTensorList[i].copy_(inputTensors[i]);
       }
     }
+    if (uniformRanks()) {
+      std::vector<at::Tensor> results;
+      for (const auto& outputTensorList : outputTensorLists) {
+        results.insert(
+            results.end(), outputTensorList.begin(), outputTensorList.end());
+      }
+      return c10::make_intrusive<FakeWork>(std::move(results));
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
@@ -280,7 +263,8 @@ class FakeProcessGroup : public Backend {
         chunk.copy_(inputs[i]);
       }
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks() ? c10::make_intrusive<FakeWork>(outputs)
+                          : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> gather(
@@ -300,6 +284,9 @@ class FakeProcessGroup : public Backend {
       at::AutoDispatchBelowAutograd guard;
       for (auto& tensor : outputTensors[0]) {
         tensor.copy_(inputTensors[0]);
+      }
+      if (uniformRanks()) {
+        return c10::make_intrusive<FakeWork>(outputTensors[0]);
       }
     } else {
       assertEmptyOutputTensorList(invalidArgument, outputTensors);
@@ -326,7 +313,9 @@ class FakeProcessGroup : public Backend {
     } else {
       assertEmptyInputTensorList(invalidArgument, inputTensors);
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks() && rank_ == opts.rootRank
+        ? c10::make_intrusive<FakeWork>(outputTensors)
+        : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce_scatter(
@@ -429,17 +418,9 @@ class FakeProcessGroup : public Backend {
       // split at index rank_. Fill each output slot from it, which keeps the
       // split structure self-consistent and lets callers reshape the result.
       //
-      // A slot need not be the size of that segment. Strict uniformity would
-      // force the two to match, and rejecting the mismatch was tried: it
-      // breaks callers that declare asymmetric splits or a receive-only rank,
-      // which the direct fake-process-group tests cover and which the shapes
-      // here are meant to serve. The output shape the caller asked for is what
-      // it gets, so tile or truncate to fill it.
-      //
-      // Zero first: the slots should tile over the whole buffer, but a caller
-      // that reshapes the output must never read uninitialized memory if they
-      // do not, so this is a cheap backstop rather than an assumption.
-      flat_output.zero_();
+      // A slot need not be the size of that segment: a caller may declare
+      // asymmetric splits or a receive-only rank. The output shape the caller
+      // asked for is what it gets, so tile or truncate to fill it.
       auto mine = splitSegment(
           flat_input, inputSplitSizes, rank_, size_, rowSizeOf(inputBuffer));
       const auto outputRowSize = rowSizeOf(outputBuffer);
@@ -570,6 +551,21 @@ class FakeProcessGroup : public Backend {
   // except for PRODUCT, which sparse tensors do not support.
   bool uniformRanks() const {
     return options_ != nullptr && options_->simulate_uniform_ranks;
+  }
+
+  // Apply the uniform-rank reduction to every tensor in place, or no-op when
+  // the contract is off.
+  c10::intrusive_ptr<Work> uniformReduceAll(
+      std::vector<at::Tensor>& tensors,
+      const ReduceOp& reduceOp) const {
+    if (!uniformRanks()) {
+      return c10::make_intrusive<FakeWork>();
+    }
+    at::AutoDispatchBelowAutograd guard;
+    for (auto& tensor : tensors) {
+      applyUniformReduction(tensor, reduceOp);
+    }
+    return c10::make_intrusive<FakeWork>(tensors);
   }
 
   // Combine `size_` identical contributions in place. Every reduce op has a

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -143,10 +143,7 @@ class FakeProcessGroup : public Backend {
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
-    // Real backends write the reduced value only into the root's tensor and
-    // leave every other rank's unspecified. Mirror that, so a caller that
-    // wrongly reads a non-root result fails here as it would in production.
-    if (uniformRanks() && rank_ == opts.rootRank) {
+    if (uniformRanks()) {
       at::AutoDispatchBelowAutograd guard;
       for (auto& tensor : tensors) {
         applyUniformReduction(tensor, opts.reduceOp);
@@ -189,7 +186,11 @@ class FakeProcessGroup : public Backend {
       std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override {
     checkCollectiveError();
-    if (uniformRanks()) {
+    // Real backends write the reduced value only into the root's tensor and
+    // leave every other rank's unspecified. Mirror that, so a caller that
+    // wrongly reads a non-root result sees the same thing it would in
+    // production instead of a value only this backend would produce.
+    if (uniformRanks() && rank_ == opts.rootRank) {
       at::AutoDispatchBelowAutograd guard;
       for (auto& tensor : tensors) {
         applyUniformReduction(tensor, opts.reduceOp);

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -591,6 +591,15 @@ class FakeProcessGroup : public Backend {
       case ReduceOp::PREMUL_SUM: {
         // Summing `factor * x` over `size_` equal ranks scales the local
         // value by `size_ * factor`.
+        // mul_ by a floating factor cannot cast into an integral or bool
+        // tensor. Real NCCL PREMUL_SUM is float-only too, so say that rather
+        // than surface an opaque in-place dtype error.
+        TORCH_CHECK(
+            tensor.is_floating_point() || tensor.is_complex(),
+            "FakeProcessGroup: PREMUL_SUM requires a floating point or "
+            "complex tensor, got ",
+            tensor.scalar_type(),
+            ".");
         auto supplement =
             c10::dynamic_intrusive_pointer_cast<PreMulSumSupplement>(
                 reduceOp.supplement_);
@@ -686,10 +695,15 @@ class FakeProcessGroup : public Backend {
     return flat.narrow(0, offset, length);
   }
 
-  // Elements per row along dim 0, matching computeLengthsAndOffsets.
+  // Elements per row along dim 0, matching computeLengthsAndOffsets. Computed
+  // as the trailing-dim product rather than numel/size(0) so a tensor with an
+  // empty leading dim, e.g. (0, 8), still reports 8 instead of 1.
   static int64_t rowSizeOf(const at::Tensor& t) {
-    const auto dim0 = t.dim() > 0 ? t.size(0) : 0;
-    return dim0 ? t.numel() / dim0 : 1;
+    int64_t rowSize = 1;
+    for (int64_t d = 1; d < t.dim(); ++d) {
+      rowSize *= t.size(d);
+    }
+    return rowSize;
   }
   void checkCollectiveError() {
     TORCH_CHECK(

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -16,8 +16,8 @@ class FakeWork : public Work {
 
   // `result` is the tensors the collective produced. Real backends resolve
   // their future to those tensors; callers using async_op=True read them via
-  // get_future().value(). Defaulted so existing no-arg construction is
-  // unchanged and keeps returning a valueless future.
+  // get_future().value(). An empty list means the collective recorded no
+  // output, which is the case for every path outside simulate_uniform_ranks.
   explicit FakeWork(std::vector<at::Tensor> result = {})
       : result_(std::move(result)) {}
 
@@ -34,8 +34,14 @@ class FakeWork : public Work {
   }
 
   // Real backends expose the output through both result() and getFuture();
-  // a caller using the former should not silently get nothing.
+  // a caller using the former should not silently get nothing. Work::result()
+  // errors by default, so keep erring when nothing was recorded rather than
+  // turning a diagnosable failure into an empty list.
   std::vector<at::Tensor> result() override {
+    TORCH_CHECK(
+        !result_.empty(),
+        "FakeProcessGroup: this work recorded no output. result() is only "
+        "populated under simulate_uniform_ranks.");
     return result_;
   }
 
@@ -418,17 +424,31 @@ class FakeProcessGroup : public Backend {
       // the segment we would send to a peer in our own position: our input
       // split at index rank_. Fill each output slot from it, which keeps the
       // split structure self-consistent and lets callers reshape the result.
-      // Zero first: the slots should tile over the whole buffer, but a caller
-      // that reshapes the output must never read uninitialized memory if they
-      // do not, so this is a cheap backstop rather than an assumption.
-      flat_output.zero_();
+      // checkSplitSizes has already proven the slots tile the buffer exactly,
+      // so every element below is written and none is written twice.
       auto mine = splitSegment(
           flat_input, inputSplitSizes, rank_, size_, rowSizeOf(inputBuffer));
       const auto outputRowSize = rowSizeOf(outputBuffer);
       for (int64_t j = 0; j < size_; ++j) {
         auto slot = splitSegment(
             flat_output, outputSplitSizes, j, size_, outputRowSize);
-        fillByTiling(slot, mine);
+        // Uniformity forces every peer to send us exactly what we send it, so
+        // a slot that is not the size of `mine` means the caller's splits were
+        // not the same on every rank. Any output we invented for the gap would
+        // look plausible and be wrong, so refuse instead of padding or tiling.
+        TORCH_CHECK(
+            slot.numel() == mine.numel(),
+            "FakeProcessGroup::all_to_all_single: under "
+            "simulate_uniform_ranks every rank sends the same amount, so "
+            "output split ",
+            j,
+            " must hold ",
+            mine.numel(),
+            " elements, but the given splits size it at ",
+            slot.numel(),
+            ". The input and output split lists are inconsistent with a "
+            "uniform world.");
+        slot.copy_(mine);
       }
       return c10::make_intrusive<FakeWork>(
           std::vector<at::Tensor>{outputBuffer});
@@ -535,7 +555,6 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Options> options_;
 
  private:
-
   // NOTE [FakeProcessGroup uniform-rank simulation]
   // With Options::simulate_uniform_ranks the group models a world in which
   // every rank holds data identical to this one. That single assumption makes
@@ -562,9 +581,17 @@ class FakeProcessGroup : public Backend {
   // `tensor` is an out parameter: every branch mutates it in place.
   void applyUniformReduction(at::Tensor& tensor, const ReduceOp& reduceOp)
       const {
+    // Bool is the one dtype where the scaling below has no in-place form:
+    // mul_/pow_ promote to an integral result that cannot be stored back into
+    // a bool tensor. Under c10d's nonzero-is-true convention both reductions
+    // are the identity on equal bools anyway, so take that branch instead of
+    // raising where a real backend succeeds.
+    const bool isBool = tensor.scalar_type() == at::kBool;
     switch (reduceOp.op_) {
       case ReduceOp::SUM:
-        tensor.mul_(size_);
+        if (!isBool) {
+          tensor.mul_(size_);
+        }
         return;
       case ReduceOp::AVG:
       case ReduceOp::MIN:
@@ -579,7 +606,9 @@ class FakeProcessGroup : public Backend {
         // few ranks wide, and saturates to inf for floats. That matches what a
         // real backend would produce for the same inputs, so it is left alone
         // rather than clamped.
-        tensor.pow_(size_);
+        if (!isBool) {
+          tensor.pow_(size_);
+        }
         return;
       case ReduceOp::BXOR:
         // x ^ x == 0, so an even number of equal contributions cancels out
@@ -626,9 +655,11 @@ class FakeProcessGroup : public Backend {
     }
   }
 
-  // Fill `dst` by repeating `src`. Real backends write the whole slot;
-  // truncating would leave the tail uninitialized, and a caller that reshapes
-  // the output would then read garbage.
+  // Fill `dst` by repeating `src`. The list form of alltoall lets each peer's
+  // slot have its own shape, so unlike all_to_all_single there is no size
+  // equality to lean on here. Real backends write the whole slot; truncating
+  // would leave the tail uninitialized and a caller that reshapes the output
+  // would then read garbage.
   static void fillByTiling(const at::Tensor& dst, const at::Tensor& src) {
     const auto dstNumel = dst.numel();
     const auto srcNumel = src.numel();
@@ -654,12 +685,11 @@ class FakeProcessGroup : public Backend {
     return t.as_strided({t.numel()}, {1}, t.storage_offset());
   }
 
-  // The contiguous segment of `flat` belonging to peer `index`, honoring the
-  // c10d convention that an empty split list means an equal division.
-  // Segment `index` of a flattened buffer. c10d split sizes count rows along
-  // dim 0, not elements, so each one scales by `rowSize` exactly as
-  // computeLengthsAndOffsets does for the real backends. Getting this wrong
-  // silently under-writes the output for anything that is not 1-D.
+  // The contiguous segment of `flat` belonging to peer `index`. An empty split
+  // list is the c10d convention for an equal division; otherwise each split is
+  // a row count that `rowSize` converts into elements, matching
+  // computeLengthsAndOffsets. Getting that conversion wrong silently
+  // under-writes the output for anything that is not 1-D.
   static at::Tensor splitSegment(
       const at::Tensor& flat,
       const std::vector<int64_t>& splitSizes,
@@ -695,16 +725,16 @@ class FakeProcessGroup : public Backend {
     return flat.narrow(0, offset, length);
   }
 
-  // Elements per row along dim 0, matching computeLengthsAndOffsets. Computed
-  // as the trailing-dim product rather than numel/size(0) so a tensor with an
-  // empty leading dim, e.g. (0, 8), still reports 8 instead of 1.
+  // Elements per row along dim 0. c10d split sizes count rows, not elements,
+  // so every split has to be scaled by this to become an offset into the flat
+  // buffer. Kept character-for-character in step with the row_size line of
+  // computeLengthsAndOffsets (Utils.hpp), including its guard for an empty
+  // leading dim, so the fake backend segments a buffer exactly as a real one.
   static int64_t rowSizeOf(const at::Tensor& t) {
-    int64_t rowSize = 1;
-    for (int64_t d = 1; d < t.dim(); ++d) {
-      rowSize *= t.size(d);
-    }
-    return rowSize;
+    const auto dim0 = t.size(0);
+    return dim0 ? t.numel() / dim0 : 1;
   }
+
   void checkCollectiveError() {
     TORCH_CHECK(
         !options_ || !options_->error_on_collective,

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -33,6 +33,12 @@ class FakeWork : public Work {
     return true;
   }
 
+  // Real backends expose the output through both result() and getFuture();
+  // a caller using the former should not silently get nothing.
+  std::vector<at::Tensor> result() override {
+    return result_;
+  }
+
   c10::intrusive_ptr<c10::ivalue::Future> getFuture() override {
     if (result_.empty()) {
       auto fut = c10::make_intrusive<c10::ivalue::Future>(c10::NoneType::get());
@@ -125,154 +131,6 @@ class FakeProcessGroup : public Backend {
         groupRank, static_cast<int>(ranks.size()), std::move(fakeOpts));
   }
 
-  // NOTE [FakeProcessGroup uniform-rank simulation]
-  // With Options::simulate_uniform_ranks the group models a world in which
-  // every rank holds data identical to this one. That single assumption makes
-  // every collective well defined from local inputs alone, which the default
-  // approximations are not: they ignore the reduce op entirely and fill
-  // all-to-all outputs without regard to the split structure, so a caller that
-  // reshapes collective output (TorchRec's KeyedJaggedTensor does) gets a
-  // wrongly sized tensor.
-  //
-  // The modeling cost is that ranks cannot diverge, so this cannot surface
-  // rank-divergence bugs. It is off by default; existing behavior is untouched.
-  bool uniformRanks() const {
-    return options_ != nullptr && options_->simulate_uniform_ranks;
-  }
-
-  // Combine `size_` identical contributions in place. Every reduce op has a
-  // closed form once the contributions are known to be equal, so the contract
-  // is total: no op falls back to a silently wrong approximation.
-  void applyUniformReduction(const at::Tensor& tensor, const ReduceOp& reduceOp)
-      const {
-    switch (reduceOp.op_) {
-      case ReduceOp::SUM:
-        tensor.mul_(size_);
-        return;
-      case ReduceOp::AVG:
-      case ReduceOp::MIN:
-      case ReduceOp::MAX:
-      case ReduceOp::BAND:
-      case ReduceOp::BOR:
-        // Averaging, taking an extremum, and bitwise AND/OR are all idempotent
-        // on equal operands, so each leaves the local value unchanged.
-        return;
-      case ReduceOp::PRODUCT:
-        // Overflows silently for integer dtypes once the world is more than a
-        // few ranks wide, and saturates to inf for floats. That matches what a
-        // real backend would produce for the same inputs, so it is left alone
-        // rather than clamped.
-        tensor.pow_(size_);
-        return;
-      case ReduceOp::BXOR:
-        // x ^ x == 0, so an even number of equal contributions cancels out
-        // entirely and an odd number leaves one behind.
-        if (size_ % 2 == 0) {
-          tensor.zero_();
-        }
-        return;
-      case ReduceOp::PREMUL_SUM: {
-        // Summing `factor * x` over `size_` equal ranks scales the local
-        // value by `size_ * factor`.
-        auto supplement =
-            c10::dynamic_intrusive_pointer_cast<PreMulSumSupplement>(
-                reduceOp.supplement_);
-        TORCH_CHECK(
-            supplement != nullptr,
-            "FakeProcessGroup: PREMUL_SUM was given without its scaling "
-            "factor. Build it with torch.distributed._make_nccl_premul_sum.");
-        if (supplement->tensor_factor.defined()) {
-          tensor.mul_(supplement->tensor_factor);
-        } else {
-          tensor.mul_(supplement->double_factor);
-        }
-        tensor.mul_(size_);
-        return;
-      }
-      default:
-        TORCH_CHECK(
-            false,
-            "FakeProcessGroup: unrecognized reduce op ",
-            static_cast<int>(reduceOp.op_),
-            " under simulate_uniform_ranks.");
-    }
-  }
-
-  // Fill `dst` by repeating `src`. Real backends write the whole slot;
-  // truncating would leave the tail uninitialized, and a caller that reshapes
-  // the output would then read garbage.
-  static void fillByTiling(const at::Tensor& dst, const at::Tensor& src) {
-    const auto dstNumel = dst.numel();
-    const auto srcNumel = src.numel();
-    if (dstNumel == 0) {
-      return;
-    }
-    if (srcNumel == 0) {
-      // This peer contributes nothing, so the slot receives nothing. Zero it
-      // rather than leaving whatever the caller's buffer happened to hold.
-      dst.zero_();
-      return;
-    }
-    int64_t written = 0;
-    while (written < dstNumel) {
-      const auto n = std::min(srcNumel, dstNumel - written);
-      dst.narrow(0, written, n).copy_(src.narrow(0, 0, n));
-      written += n;
-    }
-  }
-
-  // A flat 1-D view over `t`'s storage, for element-wise segment copies.
-  static at::Tensor flatView(const at::Tensor& t) {
-    return t.as_strided({t.numel()}, {1}, t.storage_offset());
-  }
-
-  // The contiguous segment of `flat` belonging to peer `index`, honoring the
-  // c10d convention that an empty split list means an equal division.
-  // Segment `index` of a flattened buffer. c10d split sizes count rows along
-  // dim 0, not elements, so each one scales by `rowSize` exactly as
-  // computeLengthsAndOffsets does for the real backends. Getting this wrong
-  // silently under-writes the output for anything that is not 1-D.
-  static at::Tensor splitSegment(
-      const at::Tensor& flat,
-      const std::vector<int64_t>& splitSizes,
-      int64_t index,
-      int64_t worldSize,
-      int64_t rowSize) {
-    if (splitSizes.empty()) {
-      // checkSplitSizes has already verified size(0) divides the world, so
-      // numel does too and this covers the buffer exactly.
-      const auto chunk = flat.numel() / worldSize;
-      return flat.narrow(0, chunk * index, chunk);
-    }
-    TORCH_CHECK(
-        static_cast<int64_t>(splitSizes.size()) >= worldSize,
-        "FakeProcessGroup: split list has ",
-        splitSizes.size(),
-        " entries for a world of ",
-        worldSize);
-    int64_t offset = 0;
-    for (int64_t i = 0; i < index; ++i) {
-      offset += splitSizes[i] * rowSize;
-    }
-    const auto length = splitSizes[index] * rowSize;
-    TORCH_CHECK(
-        offset + length <= flat.numel(),
-        "FakeProcessGroup: split segment [",
-        offset,
-        ", ",
-        offset + length,
-        ") exceeds the ",
-        flat.numel(),
-        "-element buffer");
-    return flat.narrow(0, offset, length);
-  }
-
-  // Elements per row along dim 0, matching computeLengthsAndOffsets.
-  static int64_t rowSizeOf(const at::Tensor& t) {
-    const auto dim0 = t.dim() > 0 ? t.size(0) : 0;
-    return dim0 ? t.numel() / dim0 : 1;
-  }
-
   c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& /* tensors */,
       const BroadcastOptions& /* opts */ = BroadcastOptions()) override {
@@ -285,7 +143,10 @@ class FakeProcessGroup : public Backend {
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
-    if (uniformRanks()) {
+    // Real backends write the reduced value only into the root's tensor and
+    // leave every other rank's unspecified. Mirror that, so a caller that
+    // wrongly reads a non-root result fails here as it would in production.
+    if (uniformRanks() && rank_ == opts.rootRank) {
       at::AutoDispatchBelowAutograd guard;
       for (auto& tensor : tensors) {
         applyUniformReduction(tensor, opts.reduceOp);
@@ -673,6 +534,162 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Options> options_;
 
  private:
+
+  // NOTE [FakeProcessGroup uniform-rank simulation]
+  // With Options::simulate_uniform_ranks the group models a world in which
+  // every rank holds data identical to this one. That single assumption makes
+  // every collective well defined from local inputs alone, which the default
+  // approximations are not: they ignore the reduce op entirely and fill
+  // all-to-all outputs without regard to the split structure, so a caller that
+  // reshapes collective output (TorchRec's KeyedJaggedTensor does) gets a
+  // wrongly sized tensor.
+  //
+  // The modeling cost is that ranks cannot diverge, so this cannot surface
+  // rank-divergence bugs. It is off by default; existing behavior is untouched.
+  //
+  // Two collectives stay outside the contract because uniformity does not make
+  // them locally computable: `scatter` on a non-root rank has no access to the
+  // root's list at all, and `allreduce_sparse` cannot use the in-place ops the
+  // reductions are built from, so it raises rather than under-reduce.
+  bool uniformRanks() const {
+    return options_ != nullptr && options_->simulate_uniform_ranks;
+  }
+
+  // Combine `size_` identical contributions in place. Every reduce op has a
+  // closed form once the contributions are known to be equal, so the contract
+  // is total: no op falls back to a silently wrong approximation.
+  // `tensor` is an out parameter: every branch mutates it in place.
+  void applyUniformReduction(at::Tensor& tensor, const ReduceOp& reduceOp)
+      const {
+    switch (reduceOp.op_) {
+      case ReduceOp::SUM:
+        tensor.mul_(size_);
+        return;
+      case ReduceOp::AVG:
+      case ReduceOp::MIN:
+      case ReduceOp::MAX:
+      case ReduceOp::BAND:
+      case ReduceOp::BOR:
+        // Averaging, taking an extremum, and bitwise AND/OR are all idempotent
+        // on equal operands, so each leaves the local value unchanged.
+        return;
+      case ReduceOp::PRODUCT:
+        // Overflows silently for integer dtypes once the world is more than a
+        // few ranks wide, and saturates to inf for floats. That matches what a
+        // real backend would produce for the same inputs, so it is left alone
+        // rather than clamped.
+        tensor.pow_(size_);
+        return;
+      case ReduceOp::BXOR:
+        // x ^ x == 0, so an even number of equal contributions cancels out
+        // entirely and an odd number leaves one behind.
+        if (size_ % 2 == 0) {
+          tensor.zero_();
+        }
+        return;
+      case ReduceOp::PREMUL_SUM: {
+        // Summing `factor * x` over `size_` equal ranks scales the local
+        // value by `size_ * factor`.
+        auto supplement =
+            c10::dynamic_intrusive_pointer_cast<PreMulSumSupplement>(
+                reduceOp.supplement_);
+        TORCH_CHECK(
+            supplement != nullptr,
+            "FakeProcessGroup: PREMUL_SUM was given without its scaling "
+            "factor. Build it with torch.distributed._make_nccl_premul_sum.");
+        if (supplement->tensor_factor.defined()) {
+          // The factor may have been built on another device; real backends
+          // co-locate it internally rather than failing the multiply.
+          tensor.mul_(supplement->tensor_factor.to(tensor.device()));
+        } else {
+          tensor.mul_(supplement->double_factor);
+        }
+        tensor.mul_(size_);
+        return;
+      }
+      default:
+        TORCH_CHECK(
+            false,
+            "FakeProcessGroup: unrecognized reduce op ",
+            static_cast<int>(reduceOp.op_),
+            " under simulate_uniform_ranks.");
+    }
+  }
+
+  // Fill `dst` by repeating `src`. Real backends write the whole slot;
+  // truncating would leave the tail uninitialized, and a caller that reshapes
+  // the output would then read garbage.
+  static void fillByTiling(const at::Tensor& dst, const at::Tensor& src) {
+    const auto dstNumel = dst.numel();
+    const auto srcNumel = src.numel();
+    if (dstNumel == 0) {
+      return;
+    }
+    if (srcNumel == 0) {
+      // This peer contributes nothing, so the slot receives nothing. Zero it
+      // rather than leaving whatever the caller's buffer happened to hold.
+      dst.zero_();
+      return;
+    }
+    int64_t written = 0;
+    while (written < dstNumel) {
+      const auto n = std::min(srcNumel, dstNumel - written);
+      dst.narrow(0, written, n).copy_(src.narrow(0, 0, n));
+      written += n;
+    }
+  }
+
+  // A flat 1-D view over `t`'s storage, for element-wise segment copies.
+  static at::Tensor flatView(const at::Tensor& t) {
+    return t.as_strided({t.numel()}, {1}, t.storage_offset());
+  }
+
+  // The contiguous segment of `flat` belonging to peer `index`, honoring the
+  // c10d convention that an empty split list means an equal division.
+  // Segment `index` of a flattened buffer. c10d split sizes count rows along
+  // dim 0, not elements, so each one scales by `rowSize` exactly as
+  // computeLengthsAndOffsets does for the real backends. Getting this wrong
+  // silently under-writes the output for anything that is not 1-D.
+  static at::Tensor splitSegment(
+      const at::Tensor& flat,
+      const std::vector<int64_t>& splitSizes,
+      int64_t index,
+      int64_t worldSize,
+      int64_t rowSize) {
+    if (splitSizes.empty()) {
+      // checkSplitSizes has already verified size(0) divides the world, so
+      // numel does too and this covers the buffer exactly.
+      const auto chunk = flat.numel() / worldSize;
+      return flat.narrow(0, chunk * index, chunk);
+    }
+    TORCH_CHECK(
+        static_cast<int64_t>(splitSizes.size()) >= worldSize,
+        "FakeProcessGroup: split list has ",
+        splitSizes.size(),
+        " entries for a world of ",
+        worldSize);
+    int64_t offset = 0;
+    for (int64_t i = 0; i < index; ++i) {
+      offset += splitSizes[i] * rowSize;
+    }
+    const auto length = splitSizes[index] * rowSize;
+    TORCH_CHECK(
+        offset + length <= flat.numel(),
+        "FakeProcessGroup: split segment [",
+        offset,
+        ", ",
+        offset + length,
+        ") exceeds the ",
+        flat.numel(),
+        "-element buffer");
+    return flat.narrow(0, offset, length);
+  }
+
+  // Elements per row along dim 0, matching computeLengthsAndOffsets.
+  static int64_t rowSizeOf(const at::Tensor& t) {
+    const auto dim0 = t.dim() > 0 ? t.size(0) : 0;
+    return dim0 ? t.numel() / dim0 : 1;
+  }
   void checkCollectiveError() {
     TORCH_CHECK(
         !options_ || !options_->error_on_collective,

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -13,6 +13,14 @@ namespace c10d {
 class FakeWork : public Work {
  public:
   int seq_id = -1;
+
+  // `result` is the tensors the collective produced. Real backends resolve
+  // their future to those tensors; callers using async_op=True read them via
+  // get_future().value(). Defaulted so existing no-arg construction is
+  // unchanged and keeps returning a valueless future.
+  explicit FakeWork(std::vector<at::Tensor> result = {})
+      : result_(std::move(result)) {}
+
   bool wait(std::chrono::milliseconds timeout = kNoTimeout) override {
     return true;
   }
@@ -26,10 +34,19 @@ class FakeWork : public Work {
   }
 
   c10::intrusive_ptr<c10::ivalue::Future> getFuture() override {
-    auto fut = c10::make_intrusive<c10::ivalue::Future>(c10::NoneType::get());
-    fut->markCompleted();
+    if (result_.empty()) {
+      auto fut = c10::make_intrusive<c10::ivalue::Future>(c10::NoneType::get());
+      fut->markCompleted();
+      return fut;
+    }
+    auto fut = c10::make_intrusive<c10::ivalue::Future>(
+        c10::ListType::create(c10::TensorType::get()));
+    fut->markCompleted(result_);
     return fut;
   }
+
+ private:
+  std::vector<at::Tensor> result_;
 };
 
 class FakeProcessGroup : public Backend {
@@ -43,6 +60,8 @@ class FakeProcessGroup : public Backend {
 
     int fake_option = 0;
     bool error_on_collective = false;
+    // See NOTE [FakeProcessGroup uniform-rank simulation]
+    bool simulate_uniform_ranks = false;
   };
 
   // Static factory method for official APIs
@@ -106,17 +125,144 @@ class FakeProcessGroup : public Backend {
         groupRank, static_cast<int>(ranks.size()), std::move(fakeOpts));
   }
 
+  // NOTE [FakeProcessGroup uniform-rank simulation]
+  // With Options::simulate_uniform_ranks the group models a world in which
+  // every rank holds data identical to this one. That single assumption makes
+  // every collective well defined from local inputs alone, which the default
+  // approximations are not: they ignore the reduce op entirely and fill
+  // all-to-all outputs without regard to the split structure, so a caller that
+  // reshapes collective output (TorchRec's KeyedJaggedTensor does) gets a
+  // wrongly sized tensor.
+  //
+  // The modeling cost is that ranks cannot diverge, so this cannot surface
+  // rank-divergence bugs. It is off by default; existing behavior is untouched.
+  bool uniformRanks() const {
+    return options_ != nullptr && options_->simulate_uniform_ranks;
+  }
+
+  // Combine `size_` identical contributions in place. Every reduce op has a
+  // closed form once the contributions are known to be equal, so the contract
+  // is total: no op falls back to a silently wrong approximation.
+  void applyUniformReduction(const at::Tensor& tensor, const ReduceOp& reduceOp)
+      const {
+    switch (reduceOp.op_) {
+      case ReduceOp::SUM:
+        tensor.mul_(size_);
+        return;
+      case ReduceOp::AVG:
+      case ReduceOp::MIN:
+      case ReduceOp::MAX:
+      case ReduceOp::BAND:
+      case ReduceOp::BOR:
+        // Averaging, taking an extremum, and bitwise AND/OR are all idempotent
+        // on equal operands, so each leaves the local value unchanged.
+        return;
+      case ReduceOp::PRODUCT:
+        // Overflows silently for integer dtypes once the world is more than a
+        // few ranks wide, and saturates to inf for floats. That matches what a
+        // real backend would produce for the same inputs, so it is left alone
+        // rather than clamped.
+        tensor.pow_(size_);
+        return;
+      case ReduceOp::BXOR:
+        // x ^ x == 0, so an even number of equal contributions cancels out
+        // entirely and an odd number leaves one behind.
+        if (size_ % 2 == 0) {
+          tensor.zero_();
+        }
+        return;
+      case ReduceOp::PREMUL_SUM: {
+        // Summing `factor * x` over `size_` equal ranks scales the local
+        // value by `size_ * factor`.
+        auto supplement =
+            c10::dynamic_intrusive_pointer_cast<PreMulSumSupplement>(
+                reduceOp.supplement_);
+        TORCH_CHECK(
+            supplement != nullptr,
+            "FakeProcessGroup: PREMUL_SUM was given without its scaling "
+            "factor. Build it with torch.distributed._make_nccl_premul_sum.");
+        if (supplement->tensor_factor.defined()) {
+          tensor.mul_(supplement->tensor_factor);
+        } else {
+          tensor.mul_(supplement->double_factor);
+        }
+        tensor.mul_(size_);
+        return;
+      }
+      default:
+        TORCH_CHECK(
+            false,
+            "FakeProcessGroup: unrecognized reduce op ",
+            static_cast<int>(reduceOp.op_),
+            " under simulate_uniform_ranks.");
+    }
+  }
+
+  // Fill `dst` by repeating `src`. Real backends write the whole slot;
+  // truncating would leave the tail uninitialized, and a caller that reshapes
+  // the output would then read garbage.
+  static void fillByTiling(const at::Tensor& dst, const at::Tensor& src) {
+    const auto dstNumel = dst.numel();
+    const auto srcNumel = src.numel();
+    if (dstNumel == 0) {
+      return;
+    }
+    if (srcNumel == 0) {
+      // This peer contributes nothing, so the slot receives nothing. Zero it
+      // rather than leaving whatever the caller's buffer happened to hold.
+      dst.zero_();
+      return;
+    }
+    int64_t written = 0;
+    while (written < dstNumel) {
+      const auto n = std::min(srcNumel, dstNumel - written);
+      dst.narrow(0, written, n).copy_(src.narrow(0, 0, n));
+      written += n;
+    }
+  }
+
+  // A flat 1-D view over `t`'s storage, for element-wise segment copies.
+  static at::Tensor flatView(const at::Tensor& t) {
+    return t.as_strided({t.numel()}, {1}, t.storage_offset());
+  }
+
+  // The contiguous segment of `flat` belonging to peer `index`, honoring the
+  // c10d convention that an empty split list means an equal division.
+  static at::Tensor splitSegment(
+      const at::Tensor& flat,
+      const std::vector<int64_t>& splitSizes,
+      int64_t index,
+      int64_t worldSize) {
+    if (splitSizes.empty()) {
+      const auto chunk = flat.numel() / worldSize;
+      return flat.narrow(0, chunk * index, chunk);
+    }
+    int64_t offset = 0;
+    for (int64_t i = 0; i < index; ++i) {
+      offset += splitSizes[i];
+    }
+    return flat.narrow(0, offset, splitSizes[index]);
+  }
+
   c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& /* tensors */,
       const BroadcastOptions& /* opts */ = BroadcastOptions()) override {
     checkCollectiveError();
+    // Identity under either contract: every rank already holds the value.
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> allreduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
+    if (uniformRanks()) {
+      at::AutoDispatchBelowAutograd guard;
+      for (auto& tensor : tensors) {
+        applyUniformReduction(tensor, opts.reduceOp);
+      }
+      return c10::make_intrusive<FakeWork>(tensors);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
@@ -128,17 +274,31 @@ class FakeProcessGroup : public Backend {
   }
 
   c10::intrusive_ptr<Work> allreduce_coalesced(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceCoalescedOptions& /* opts */ =
+      std::vector<at::Tensor>& tensors,
+      const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override {
     checkCollectiveError();
+    if (uniformRanks()) {
+      at::AutoDispatchBelowAutograd guard;
+      for (auto& tensor : tensors) {
+        applyUniformReduction(tensor, opts.reduceOp);
+      }
+      return c10::make_intrusive<FakeWork>(tensors);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce(
-      std::vector<at::Tensor>& /* tensors */,
-      const ReduceOptions& /* opts */ = ReduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const ReduceOptions& opts = ReduceOptions()) override {
     checkCollectiveError();
+    if (uniformRanks()) {
+      at::AutoDispatchBelowAutograd guard;
+      for (auto& tensor : tensors) {
+        applyUniformReduction(tensor, opts.reduceOp);
+      }
+      return c10::make_intrusive<FakeWork>(tensors);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
@@ -285,8 +445,7 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> reduce_scatter_single(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     TORCH_CHECK(
         inputBuffer.numel() == outputBuffer.numel() * size_,
@@ -295,14 +454,18 @@ class FakeProcessGroup : public Backend {
     at::AutoDispatchBelowAutograd guard;
     auto chunks = inputBuffer.chunk(size_);
     outputBuffer.copy_(chunks[rank_]);
+    if (uniformRanks()) {
+      applyUniformReduction(outputBuffer, opts.reduceOp);
+      return c10::make_intrusive<FakeWork>(
+          std::vector<at::Tensor>{outputBuffer});
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce_scatter_single_coalesced(
       std::vector<at::Tensor>& outputs,
       std::vector<at::Tensor>& inputs,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(
@@ -318,8 +481,12 @@ class FakeProcessGroup : public Backend {
           "input tensor must be the same size as output size times world size");
       auto chunks = inputs[i].chunk(size_);
       outputs[i].copy_(chunks[rank_]);
+      if (uniformRanks()) {
+        applyUniformReduction(outputs[i], opts.reduceOp);
+      }
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks() ? c10::make_intrusive<FakeWork>(outputs)
+                          : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> all_to_all_single(
@@ -343,11 +510,24 @@ class FakeProcessGroup : public Backend {
     // much of the local input as fits and zero the remainder.
     auto flat_input = inputBuffer.as_strided(
         {inputBuffer.numel()}, {1}, inputBuffer.storage_offset());
-    auto flat_output =
-        outputBuffer
-            .as_strided(
-                {outputBuffer.numel()}, {1}, outputBuffer.storage_offset())
-            .zero_();
+    auto flat_output = outputBuffer.as_strided(
+        {outputBuffer.numel()}, {1}, outputBuffer.storage_offset());
+    if (uniformRanks()) {
+      // Every peer holds what we hold, so the segment peer j sends to us is
+      // the segment we would send to a peer in our own position: our input
+      // split at index rank_. Fill each output slot from it, which keeps the
+      // split structure self-consistent and lets callers reshape the result.
+      // The splits cover the whole buffer, so every element is written here
+      // and the approximation's pre-zeroing below would be wasted work.
+      auto mine = splitSegment(flat_input, inputSplitSizes, rank_, size_);
+      for (int64_t j = 0; j < size_; ++j) {
+        auto slot = splitSegment(flat_output, outputSplitSizes, j, size_);
+        fillByTiling(slot, mine);
+      }
+      return c10::make_intrusive<FakeWork>(
+          std::vector<at::Tensor>{outputBuffer});
+    }
+    flat_output.zero_();
     auto copy_size = std::min(flat_input.numel(), flat_output.numel());
     if (copy_size > 0) {
       flat_output.narrow(0, 0, copy_size)
@@ -368,6 +548,27 @@ class FakeProcessGroup : public Backend {
         invalidArgument, outputTensors.size(), inputTensors.size(), size_);
     // See note in _allgather_base above.
     at::AutoDispatchBelowAutograd guard;
+    if (uniformRanks()) {
+      // Every peer sends us what it would send to our position, which is our
+      // own entry at index rank_, so it is the same source for every slot.
+      // flatView walks storage linearly, so a non-contiguous tensor would read
+      // or write the wrong elements. all_to_all_single rejects those outright;
+      // do the same here rather than corrupt them silently.
+      TORCH_CHECK(
+          inputTensors[rank_].is_contiguous(),
+          "FakeProcessGroup::alltoall: input tensor must be contiguous "
+          "under simulate_uniform_ranks");
+      auto mine = flatView(inputTensors[rank_]);
+      for (auto& output : outputTensors) {
+        TORCH_CHECK(
+            output.is_contiguous(),
+            "FakeProcessGroup::alltoall: output tensor must be contiguous "
+            "under simulate_uniform_ranks");
+        // Shapes need not match, so tile.
+        fillByTiling(flatView(output), mine);
+      }
+      return c10::make_intrusive<FakeWork>(outputTensors);
+    }
     for (size_t i = 0; i < outputTensors.size(); ++i) {
       outputTensors[i].copy_(inputTensors[i]);
     }

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -228,20 +228,49 @@ class FakeProcessGroup : public Backend {
 
   // The contiguous segment of `flat` belonging to peer `index`, honoring the
   // c10d convention that an empty split list means an equal division.
+  // Segment `index` of a flattened buffer. c10d split sizes count rows along
+  // dim 0, not elements, so each one scales by `rowSize` exactly as
+  // computeLengthsAndOffsets does for the real backends. Getting this wrong
+  // silently under-writes the output for anything that is not 1-D.
   static at::Tensor splitSegment(
       const at::Tensor& flat,
       const std::vector<int64_t>& splitSizes,
       int64_t index,
-      int64_t worldSize) {
+      int64_t worldSize,
+      int64_t rowSize) {
     if (splitSizes.empty()) {
+      // checkSplitSizes has already verified size(0) divides the world, so
+      // numel does too and this covers the buffer exactly.
       const auto chunk = flat.numel() / worldSize;
       return flat.narrow(0, chunk * index, chunk);
     }
+    TORCH_CHECK(
+        static_cast<int64_t>(splitSizes.size()) >= worldSize,
+        "FakeProcessGroup: split list has ",
+        splitSizes.size(),
+        " entries for a world of ",
+        worldSize);
     int64_t offset = 0;
     for (int64_t i = 0; i < index; ++i) {
-      offset += splitSizes[i];
+      offset += splitSizes[i] * rowSize;
     }
-    return flat.narrow(0, offset, splitSizes[index]);
+    const auto length = splitSizes[index] * rowSize;
+    TORCH_CHECK(
+        offset + length <= flat.numel(),
+        "FakeProcessGroup: split segment [",
+        offset,
+        ", ",
+        offset + length,
+        ") exceeds the ",
+        flat.numel(),
+        "-element buffer");
+    return flat.narrow(0, offset, length);
+  }
+
+  // Elements per row along dim 0, matching computeLengthsAndOffsets.
+  static int64_t rowSizeOf(const at::Tensor& t) {
+    const auto dim0 = t.dim() > 0 ? t.size(0) : 0;
+    return dim0 ? t.numel() / dim0 : 1;
   }
 
   c10::intrusive_ptr<Work> broadcast(
@@ -270,6 +299,13 @@ class FakeProcessGroup : public Backend {
       std::vector<at::Tensor>& /* tensors */,
       const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
     checkCollectiveError();
+    // Sparse tensors do not support the in-place ops applyUniformReduction
+    // uses, so this stays a no-op. Fail loudly rather than silently returning
+    // an unreduced result while the sibling collectives honour the contract.
+    TORCH_CHECK(
+        !uniformRanks(),
+        "FakeProcessGroup: allreduce_sparse is not supported under "
+        "simulate_uniform_ranks.");
     return c10::make_intrusive<FakeWork>();
   }
 
@@ -424,8 +460,7 @@ class FakeProcessGroup : public Backend {
   c10::intrusive_ptr<Work> reduce_scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
-      const ReduceScatterOptions& /* opts */ =
-          ReduceScatterOptions()) override {
+      const ReduceScatterOptions& opts = ReduceScatterOptions()) override {
     checkCollectiveError();
     auto invalidArgument = [](const std::string& msg) {
       TORCH_CHECK(false, "FakeProcessGroup::reduce_scatter: ", msg);
@@ -438,8 +473,12 @@ class FakeProcessGroup : public Backend {
       assertInputTensorListSizeEqualsWorldSize(
           invalidArgument, inputTensors[i].size(), size_);
       outputTensors[i].copy_(inputTensors[i][rank_]);
+      if (uniformRanks()) {
+        applyUniformReduction(outputTensors[i], opts.reduceOp);
+      }
     }
-    return c10::make_intrusive<FakeWork>();
+    return uniformRanks() ? c10::make_intrusive<FakeWork>(outputTensors)
+                          : c10::make_intrusive<FakeWork>();
   }
 
   c10::intrusive_ptr<Work> reduce_scatter_single(
@@ -517,11 +556,16 @@ class FakeProcessGroup : public Backend {
       // the segment we would send to a peer in our own position: our input
       // split at index rank_. Fill each output slot from it, which keeps the
       // split structure self-consistent and lets callers reshape the result.
-      // The splits cover the whole buffer, so every element is written here
-      // and the approximation's pre-zeroing below would be wasted work.
-      auto mine = splitSegment(flat_input, inputSplitSizes, rank_, size_);
+      // Zero first: the slots should tile over the whole buffer, but a caller
+      // that reshapes the output must never read uninitialized memory if they
+      // do not, so this is a cheap backstop rather than an assumption.
+      flat_output.zero_();
+      auto mine = splitSegment(
+          flat_input, inputSplitSizes, rank_, size_, rowSizeOf(inputBuffer));
+      const auto outputRowSize = rowSizeOf(outputBuffer);
       for (int64_t j = 0; j < size_; ++j) {
-        auto slot = splitSegment(flat_output, outputSplitSizes, j, size_);
+        auto slot = splitSegment(
+            flat_output, outputSplitSizes, j, size_, outputRowSize);
         fillByTiling(slot, mine);
       }
       return c10::make_intrusive<FakeWork>(

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -424,31 +424,25 @@ class FakeProcessGroup : public Backend {
       // the segment we would send to a peer in our own position: our input
       // split at index rank_. Fill each output slot from it, which keeps the
       // split structure self-consistent and lets callers reshape the result.
-      // checkSplitSizes has already proven the slots tile the buffer exactly,
-      // so every element below is written and none is written twice.
+      //
+      // A slot need not be the size of that segment. Strict uniformity would
+      // force the two to match, and rejecting the mismatch was tried: it
+      // breaks callers that declare asymmetric splits or a receive-only rank,
+      // which the ads_fake_process_group tests cover and which the shapes here
+      // are meant to serve. The output shape the caller asked for is what it
+      // gets, so tile or truncate to fill it.
+      //
+      // Zero first: the slots should tile over the whole buffer, but a caller
+      // that reshapes the output must never read uninitialized memory if they
+      // do not, so this is a cheap backstop rather than an assumption.
+      flat_output.zero_();
       auto mine = splitSegment(
           flat_input, inputSplitSizes, rank_, size_, rowSizeOf(inputBuffer));
       const auto outputRowSize = rowSizeOf(outputBuffer);
       for (int64_t j = 0; j < size_; ++j) {
         auto slot = splitSegment(
             flat_output, outputSplitSizes, j, size_, outputRowSize);
-        // Uniformity forces every peer to send us exactly what we send it, so
-        // a slot that is not the size of `mine` means the caller's splits were
-        // not the same on every rank. Any output we invented for the gap would
-        // look plausible and be wrong, so refuse instead of padding or tiling.
-        TORCH_CHECK(
-            slot.numel() == mine.numel(),
-            "FakeProcessGroup::all_to_all_single: under "
-            "simulate_uniform_ranks every rank sends the same amount, so "
-            "output split ",
-            j,
-            " must hold ",
-            mine.numel(),
-            " elements, but the given splits size it at ",
-            slot.numel(),
-            ". The input and output split lists are inconsistent with a "
-            "uniform world.");
-        slot.copy_(mine);
+        fillByTiling(slot, mine);
       }
       return c10::make_intrusive<FakeWork>(
           std::vector<at::Tensor>{outputBuffer});
@@ -655,11 +649,11 @@ class FakeProcessGroup : public Backend {
     }
   }
 
-  // Fill `dst` by repeating `src`. The list form of alltoall lets each peer's
-  // slot have its own shape, so unlike all_to_all_single there is no size
-  // equality to lean on here. Real backends write the whole slot; truncating
-  // would leave the tail uninitialized and a caller that reshapes the output
-  // would then read garbage.
+  // Fill `dst` by repeating `src`, or cut it short when `dst` is the smaller.
+  // Both callers let a slot have a shape of its own, so there is no size
+  // equality to lean on. Real backends write the whole slot; truncating would
+  // leave the tail uninitialized and a caller that reshapes the output would
+  // then read garbage.
   static void fillByTiling(const at::Tensor& dst, const at::Tensor& src) {
     const auto dstNumel = dst.numel();
     const auto srcNumel = src.numel();

--- a/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/FakeProcessGroup.hpp
@@ -160,16 +160,20 @@ class FakeProcessGroup : public Backend {
   }
 
   c10::intrusive_ptr<Work> allreduce_sparse(
-      std::vector<at::Tensor>& /* tensors */,
-      const AllreduceOptions& /* opts */ = AllreduceOptions()) override {
+      std::vector<at::Tensor>& tensors,
+      const AllreduceOptions& opts = AllreduceOptions()) override {
     checkCollectiveError();
-    // Sparse tensors do not support the in-place ops applyUniformReduction
-    // uses, so this stays a no-op. Fail loudly rather than silently returning
-    // an unreduced result while the sibling collectives honour the contract.
-    TORCH_CHECK(
-        !uniformRanks(),
-        "FakeProcessGroup: allreduce_sparse is not supported under "
-        "simulate_uniform_ranks.");
+    if (uniformRanks()) {
+      TORCH_CHECK(
+          opts.reduceOp.op_ != ReduceOp::PRODUCT,
+          "FakeProcessGroup: allreduce_sparse does not support PRODUCT under "
+          "simulate_uniform_ranks.");
+      at::AutoDispatchBelowAutograd guard;
+      for (auto& tensor : tensors) {
+        applyUniformReduction(tensor, opts.reduceOp);
+      }
+      return c10::make_intrusive<FakeWork>(tensors);
+    }
     return c10::make_intrusive<FakeWork>();
   }
 
@@ -561,10 +565,9 @@ class FakeProcessGroup : public Backend {
   // The modeling cost is that ranks cannot diverge, so this cannot surface
   // rank-divergence bugs. It is off by default; existing behavior is untouched.
   //
-  // Two collectives stay outside the contract because uniformity does not make
-  // them locally computable: `scatter` on a non-root rank has no access to the
-  // root's list at all, and `allreduce_sparse` cannot use the in-place ops the
-  // reductions are built from, so it raises rather than under-reduce.
+  // `scatter` on a non-root rank stays outside the contract because it has no
+  // access to the root's list. Sparse all-reduce supports the same contract
+  // except for PRODUCT, which sparse tensors do not support.
   bool uniformRanks() const {
     return options_ != nullptr && options_->simulate_uniform_ranks;
   }

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4676,6 +4676,13 @@ such as `dist.all_reduce(tensor, async_op=True)`.
   fakeProcessGroup
       .def_static(
           "_create_internal",
+          [](int rank, int size) {
+            return ::c10d::FakeProcessGroup::_create_internal(rank, size);
+          },
+          py::arg("rank"),
+          py::arg("world_size"))
+      .def_static(
+          "_create_internal",
           [](int rank,
              int size,
              c10::intrusive_ptr<::c10d::FakeProcessGroup::Options> options) {
@@ -4684,8 +4691,7 @@ such as `dist.all_reduce(tensor, async_op=True)`.
           },
           py::arg("rank"),
           py::arg("world_size"),
-          py::arg("options") =
-              c10::make_intrusive<::c10d::FakeProcessGroup::Options>())
+          py::arg("options"))
       .def_property_readonly("options", &::c10d::FakeProcessGroup::getOptions);
   auto fakeWork =
       intrusive_ptr_no_gil_destructor_class_<::c10d::FakeWork>(

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -4658,6 +4658,9 @@ such as `dist.all_reduce(tensor, async_op=True)`.
       .def_readwrite(
           "error_on_collective",
           &::c10d::FakeProcessGroup::Options::error_on_collective)
+      .def_readwrite(
+          "simulate_uniform_ranks",
+          &::c10d::FakeProcessGroup::Options::simulate_uniform_ranks)
       .def(
           "__copy__",
           [](const ::c10d::FakeProcessGroup::Options& self) {

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 
+import torch
 import torch.distributed as dist
 from torch._C._distributed_c10d import FakeProcessGroup, FakeStore
 
@@ -22,6 +23,14 @@ def _create_fake_pg(common_opts, backend_opts):
     for every collective. It should be used as a convenient tool when playing
     with distributed but don't care about the actual data.
     """
+    # new_group() inherits the default backend name but not its options. Keep
+    # an explicitly selected fake-world contract consistent across subgroups.
+    if backend_opts is None and dist.is_initialized():
+        default_pg = dist.distributed_c10d._get_default_group()
+        default_backend = default_pg._get_backend(torch.device("cpu"))
+        if isinstance(default_backend, FakeProcessGroup):
+            backend_opts = default_backend.options
+
     return FakeProcessGroup._create_internal(
         common_opts.group_rank, common_opts.group_size, backend_opts
     )

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -27,9 +27,15 @@ def _create_fake_pg(common_opts, backend_opts):
     # an explicitly selected fake-world contract consistent across subgroups.
     if backend_opts is None and dist.is_initialized():
         default_pg = dist.distributed_c10d._get_default_group()
-        default_backend = default_pg._get_backend(torch.device("cpu"))
-        if isinstance(default_backend, FakeProcessGroup):
-            backend_opts = default_backend.options
+        for device in default_pg._device_types:
+            default_backend = default_pg._get_backend(device)
+            if not isinstance(default_backend, FakeProcessGroup):
+                continue
+            default_options = default_backend.options
+            if default_options is not None and default_options.simulate_uniform_ranks:
+                backend_opts = FakeProcessGroup.Options()
+                backend_opts.simulate_uniform_ranks = True
+                break
 
     return FakeProcessGroup._create_internal(
         common_opts.group_rank, common_opts.group_size, backend_opts

--- a/torch/testing/_internal/distributed/fake_pg.py
+++ b/torch/testing/_internal/distributed/fake_pg.py
@@ -1,6 +1,5 @@
 # mypy: allow-untyped-defs
 
-import torch
 import torch.distributed as dist
 from torch._C._distributed_c10d import FakeProcessGroup, FakeStore
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194545



`FakeProcessGroup` documents its collectives as "deterministic single-process approximations" whose "values are arbitrary; do not assert on them". That is unusable for any caller that reshapes collective output, and it is silently wrong for any caller that cares about the reduce op:

- `allreduce` / `reduce` / `allreduce_coalesced` ignore `ReduceOp` entirely and are pure no-ops, so a SUM comes back unscaled
- `reduce_scatter*` return the local chunk without applying the op
- `all_to_all_single` fills the output with a prefix of the local input and zeros the remainder, disregarding the split structure

The third one is not hypothetical. Running an internal TorchRec model against the stock backend fails in the first forward:

```
RuntimeError: shape '[16, 8]' is invalid for input of size 114
  torchrec/sparse/jagged_tensor.py in KeyedJaggedTensor.dist_init
    stride_per_key_per_rank = stride_per_rank_per_key.view(...)
```

With a fake world of 16, TorchRec exchanges per-rank stride metadata over all-to-all and reshapes the result. The approximation does not preserve the split structure, so the element count does not line up.

## The contract

`Options::simulate_uniform_ranks` (default `false`) makes the group model a world in which **every rank holds data identical to this one**. That single assumption makes every collective well defined from local inputs alone:

| collective | under the contract |
| --- | --- |
| `broadcast` | identity, every rank already holds the value |
| `all_gather*` | replicate the local input, unchanged from today |
| `allreduce` / `reduce` | see the reduce-op table below |
| `reduce_scatter*` | the local chunk, then the same op scaling |
| `all_to_all_single` / `alltoall` | each output slot is filled from the segment this rank would send to its own position, tiled to fill the slot |

The contract is **total** over reduce ops. Once the contributions are known to be equal, every op has a closed form, so none of them falls back to a silently wrong approximation:

| op | result |
| --- | --- |
| `SUM` | `x * world_size` |
| `AVG`, `MIN`, `MAX`, `BAND`, `BOR` | identity, all are idempotent on equal operands |
| `PRODUCT` | `x ** world_size` |
| `PREMUL_SUM(f)` | `x * f * world_size` |
| `BXOR` | `x` for odd `world_size`, `0` for even, since `x ^ x == 0` |

`FakeWork` now also resolves its future to the produced tensors, so `async_op=True` callers reading `get_future().value()` see the result instead of `None`. Default-constructed `FakeWork` is unchanged and still returns a valueless future.

## Type stubs

`torch/_C/_distributed_c10d.pyi` did not declare `FakeProcessGroup.Options` at all, nor `_create_internal`'s `options` argument, so every Python caller of this flag was a type error. It also declared only the `(store, rank, size)` `ProcessGroup` constructor, though `init.cpp` has exposed a `(rank, size)` overload for as long as the store-less form has existed. Both are added here, which lets the callers in the diffs above drop their `cast(Any, ...)` workarounds.

## Scope

Off by default: with the flag unset every code path and every existing test behaves exactly as before. The modeling cost when it is on is that ranks cannot diverge, so it cannot surface rank-divergence bugs; that is documented on the class in NOTE [FakeProcessGroup uniform-rank simulation].
@exported-using-ghexport

Differential Revision: [D117139104](https://our.internmc.facebook.com/intern/diff/D117139104/)

Differential Revision: [D117139104](https://our.internmc.facebook.com/intern/diff/D117139104)