### PR TITLE
Fix torch.compile silently promoting dtype in torch.normal(Tensor, Tensor)

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2793,6 +2793,24 @@ class TestDistributions(DistributionsTestCase):
         self._check_forward_ad(lambda x: torch.normal(x, x))
         self._check_forward_ad(lambda x: x.normal_())
 
+    def test_normal_sample_dtype_compile_matches_eager(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/194547:
+        # torch.compile silently promoted the output dtype instead of
+        # preserving loc's dtype like eager does when loc/scale differ.
+        torch._dynamo.reset()
+        loc = torch.zeros(8, dtype=torch.float16)
+        scale = torch.ones(8)  # float32
+
+        eager = Normal(loc, scale).sample()
+        self.assertEqual(eager.dtype, torch.float16)
+        compiled = torch.compile(lambda l, s: Normal(l, s).sample())(loc, scale)
+        self.assertEqual(compiled.dtype, eager.dtype)
+
+        eager = torch.normal(loc, scale)
+        self.assertEqual(eager.dtype, torch.float16)
+        compiled = torch.compile(torch.normal)(loc, scale)
+        self.assertEqual(compiled.dtype, eager.dtype)
+
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_normal_sample(self):
         set_rng_seed(0)  # see Note [Randomized statistical tests]

--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -2796,20 +2796,63 @@ class TestDistributions(DistributionsTestCase):
     def test_normal_sample_dtype_compile_matches_eager(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/194547:
         # torch.compile silently promoted the output dtype instead of
-        # preserving loc's dtype like eager does when loc/scale differ.
-        torch._dynamo.reset()
-        loc = torch.zeros(8, dtype=torch.float16)
-        scale = torch.ones(8)  # float32
+        # preserving the "first tensor arg wins" dtype eager uses when
+        # loc/scale differ. Covers both dtype directions and the
+        # scalar/tensor combinations, since dtype = tensors[0].dtype means
+        # "first tensor wins", not universally "mean wins".
+        cases = [
+            (torch.zeros(8, dtype=torch.float16), torch.ones(8, dtype=torch.float32)),
+            (0.0, torch.ones(8, dtype=torch.float32)),  # scalar mean, tensor std
+            (torch.zeros(8, dtype=torch.float16), 1.0),  # tensor mean, scalar std
+        ]
+        if torch.get_default_device().type != "mps":  # MPS has no float64 support
+            cases.append(
+                (
+                    torch.zeros(8, dtype=torch.float32),
+                    torch.ones(8, dtype=torch.float64),
+                )
+            )
+            cases.append(
+                (
+                    torch.zeros(8, dtype=torch.float64),
+                    torch.ones(8, dtype=torch.float32),
+                )
+            )
+        for loc, scale in cases:
+            eager = Normal(loc, scale).sample()
+            expected_dtype = loc.dtype if isinstance(loc, torch.Tensor) else scale.dtype
+            self.assertEqual(eager.dtype, expected_dtype)
+            compiled = torch.compile(lambda l, s: Normal(l, s).sample())(loc, scale)
+            self.assertEqual(compiled.dtype, eager.dtype)
 
-        eager = Normal(loc, scale).sample()
-        self.assertEqual(eager.dtype, torch.float16)
-        compiled = torch.compile(lambda l, s: Normal(l, s).sample())(loc, scale)
-        self.assertEqual(compiled.dtype, eager.dtype)
+            if isinstance(loc, torch.Tensor) and isinstance(scale, torch.Tensor):
+                eager = torch.normal(loc, scale)
+                self.assertEqual(eager.dtype, expected_dtype)
+                compiled = torch.compile(torch.normal)(loc, scale)
+                self.assertEqual(compiled.dtype, eager.dtype)
 
-        eager = torch.normal(loc, scale)
-        self.assertEqual(eager.dtype, torch.float16)
-        compiled = torch.compile(torch.normal)(loc, scale)
-        self.assertEqual(compiled.dtype, eager.dtype)
+    def test_normal_decomp_narrowing_matches_eager_inplace_semantics(self):
+        # The aten::normal(Tensor, Tensor) eager kernel computes
+        # ret = raw_samples (in mean's dtype); ret.mul_(std); ret.add_(mean),
+        # narrowing to mean's dtype after each in-place op. The
+        # torch._refs.normal decomposition must reproduce that rounding
+        # order, not just the final dtype: narrowing only once, after
+        # computing std * samples + mean in a promoted precision, can
+        # produce different values. See https://github.com/pytorch/pytorch/pull/194550.
+        from unittest.mock import patch
+
+        mean = torch.tensor([-5.9662e-03, 1.8203e00], dtype=torch.float16)
+        std = torch.tensor([10.8452, 0.1399], dtype=torch.float32)
+        raw_samples = torch.tensor([1.5410, -0.2935], dtype=torch.float16)
+
+        expected = raw_samples.clone()
+        expected.mul_(std)
+        expected.add_(mean)
+
+        with patch("torch._refs.prims.normal", return_value=raw_samples.clone()):
+            actual = torch._refs.normal(mean, std, generator=None)
+
+        self.assertEqual(actual, expected, atol=0, rtol=0)
 
     @unittest.skipIf(not TEST_NUMPY, "NumPy not found")
     def test_normal_sample(self):

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6602,15 +6602,11 @@ def log_normal(self, mean=1, std=2, generator=None):
 
 # TODO: add support for functionalization aten.normal_functional
 # NOTE: the device and dtype will be ignored when shape is None
+# NOTE: no @elementwise_type_promotion_wrapper on (mean, std): eager's
+# normal(Tensor, Tensor) always returns mean's dtype rather than promoting,
+# and the wrapper's pre-cast of mean would corrupt that below (#194547).
 @register_decomposition(aten.normal)
 @out_wrapper()
-@elementwise_type_promotion_wrapper(
-    type_promoting_args=(
-        "mean",
-        "std",
-    ),
-    type_promotion_kind=ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
-)
 def normal(
     mean=0,
     std=1,
@@ -6661,11 +6657,15 @@ def normal(
         requires_grad=False,
         generator=generator,
     )
-    return std * normal_samples + mean
+    # std * normal_samples + mean promotes dtype through ordinary elementwise
+    # op rules when mean/std differ, so narrow back to the resolved dtype to
+    # match eager's in-place (non-promoting) accumulation.
+    return (std * normal_samples + mean).to(dtype)
 
 
 @register_decomposition(aten.normal_)
 def normal_(self, mean=0, std=1, *, generator=None):
+    # pyrefly: ignore [unexpected-keyword]
     return normal(mean, std, self.shape, out=self, generator=generator)
 
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -6657,10 +6657,11 @@ def normal(
         requires_grad=False,
         generator=generator,
     )
-    # std * normal_samples + mean promotes dtype through ordinary elementwise
-    # op rules when mean/std differ, so narrow back to the resolved dtype to
-    # match eager's in-place (non-promoting) accumulation.
-    return (std * normal_samples + mean).to(dtype)
+    # Eager computes this as two in-place ops, narrowing to `dtype` after
+    # each one (ret.mul_(std).add_(mean)); narrowing only once at the end
+    # here would round differently when mean/std differ in dtype.
+    result = (std * normal_samples).to(dtype)
+    return (result + mean).to(dtype)
 
 
 @register_decomposition(aten.normal_)


### PR DESCRIPTION
Fixes #194547

## The bug

`Normal(loc, scale).sample()` calls `torch.normal(loc, scale)`. When both are tensors, eager returns `loc`'s dtype rather than promoting them (the std gets narrowed into the output via in-place ops). Under `torch.compile` it silently returned the promoted dtype instead — e.g. `loc=float16, scale=float32` gives `float16` in eager but `float32` when compiled, with no warning.

## Root cause

The `torch._refs.normal` decomposition (used by AOTAutograd/Inductor) was wrapped in `@elementwise_type_promotion_wrapper`, which promotes `mean`/`std` to a common dtype *before* the function body runs. The function already resolves dtype itself (`dtype = tensors[0].dtype` — first tensor arg wins, matching eager's "mean wins when both are tensors"), but by the time that line ran, `mean` had already been silently cast to the promoted dtype by the wrapper.

## Fix

- Drop the wrapper so `mean`/`std` keep their original dtypes.
- Eager computes this as two in-place ops, `ret.mul_(std); ret.add_(mean)`, narrowing to the output dtype after each one. Narrowing only once at the very end gives different values when mean/std differ in dtype, since the rounding happens at a different point — so the decomposition now narrows after the multiply and again after the add, matching eager exactly.
- Added a `pyrefly: ignore` at the one spot this now surfaces (`normal_`'s call to `normal(..., out=self, ...)`). It's a decorator-composition artifact, not a real bug: `out_wrapper` injects `out` dynamically at runtime regardless of the static signature it exposes, and removing the type-erasing wrapper let pyrefly check that signature for the first time.

## Tests

- `test_normal_sample_dtype_compile_matches_eager`: eager/compiled dtype parity across both promotion directions (fp16/fp32, fp32/fp64, fp64/fp32) and scalar/tensor combinations, since "first tensor wins" isn't the same as "mean always wins."
- `test_normal_decomp_narrowing_matches_eager_inplace_semantics`: mocks the random sample so eager and the decomposition see the same values, then checks the decomposition's arithmetic matches eager's in-place rounding bit-for-bit. Fails against a single-narrow implementation, passes with this fix.

Ran:
```
python test/distributions/test_distributions.py -k test_normal_sample_dtype_compile_matches_eager -k test_normal_decomp_narrowing_matches_eager_inplace_semantics -v
# 4 tests (CPU + MPS) — OK

python test/distributions/test_distributions.py
# 372 tests — OK (skipped=9)

lintrunner on torch/_refs/__init__.py and test/distributions/test_distributions.py
# clean
```

## Not a duplicate

Checked open PRs for #194547 and related keywords — none found. #112449 is a related-looking but different bug: an explicit `dtype=` kwarg on the functional `torch.normal` API being ignored under compile. This one is about the `Normal.sample()` path, where dtype is inferred from `loc` rather than passed explicitly.

## For maintainers

This probably wants `release notes: composability` rather than the auto-applied `topic: not user facing` — I don't have label permissions on this repo, so I asked pytorchbot to set it.

---
Built with Claude Code assistance (investigation, patch, tests). I reviewed the change and ran the tests/lint above myself.
