### PR TITLE
Drop the unreachable version branches in THP_PyFrame_New_NoTrack

### DIFF
--- a/torch/csrc/dynamo/cpython_defs.c
+++ b/torch/csrc/dynamo/cpython_defs.c
@@ -136,16 +136,8 @@ PyFrameObject* THP_PyFrame_New_NoTrack(const PyCodeObject* code) {
   f->f_trace = NULL;
   f->f_trace_lines = 1;
   f->f_trace_opcodes = 0;
-#if IS_PYTHON_3_13_PLUS
-  f->f_extra_locals = NULL;
-#else
   f->f_fast_as_locals = 0;
-#endif
   f->f_lineno = 0;
-#if IS_PYTHON_3_14_PLUS
-  f->f_locals_cache = NULL;
-  f->f_overwritten_fast_locals = NULL;
-#endif
   return f;
 }
 


### PR DESCRIPTION
The function compiles only under `#if !IS_PYTHON_3_13_PLUS`, so its inner `IS_PYTHON_3_13_PLUS` and `IS_PYTHON_3_14_PLUS` arms contradict that guard and have never been compiled; they went dead when #194116 widened the outer guard. Only `f_fast_as_locals` stays reachable. No functional change.

Test plan: evaluated every preprocessor condition in the file against Python 3.9 through 3.21, with and without `_WIN32`; no unsatisfiable branch remains. No build was run, as the removed lines never compiled.

This PR was prepared with the assistance of an AI coding tool (Claude Code); I reviewed the diff and confirmed the removed branches are unreachable before submitting.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98