### PR TITLE
[dynamo] Preserve binding for nonstandard C method descriptors

### DIFF
--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -586,14 +586,24 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
             descriptor, types.MethodDescriptorType
         ):
             self.skipTest("requires a nonstandard C method descriptor")
+        descriptor_type = type(descriptor)
+        bound_method_type = type(builder.get_loc)
 
         def fn(x):
+            builder.set_loc("dynamo-test")
             builder.get_loc()
-            return x + 1
+            return (
+                x + 1,
+                isinstance(builder.get_loc, descriptor_type),
+                isinstance(builder.get_loc, bound_method_type),
+            )
 
         x = torch.ones(1)
-        result = torch.compile(fn, backend="eager")(x)
+        result, is_descriptor, is_bound_method = torch.compile(fn, backend="eager")(x)
         self.assertEqual(result, x + 1)
+        self.assertFalse(is_descriptor)
+        self.assertTrue(is_bound_method)
+        self.assertEqual(builder.get_loc().get_name(), "dynamo-test")
 
     def test_classmethod_descriptor_dict_fromkeys(self):
         """dict.fromkeys is a classmethod_descriptor."""

--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -1,10 +1,16 @@
 # Owner(s): ["module: dynamo"]
 """Tests for tp_getattro_impl: unified attribute access protocol in Dynamo."""
 
+import inspect
+import types
+import unittest
+
 import torch
+
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch.testing._internal.common_utils import HardwareClassification
+from torch.utils._triton import has_triton_package
 
 
 class TpGetattroTests(torch._dynamo.test_case.TestCase):
@@ -567,6 +573,27 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
 
         result = torch.compile(fn, backend="eager", fullgraph=True)()
         self.assertEqual(sorted(result), ["a", "b"])
+
+    @unittest.skipUnless(has_triton_package(), "requires Triton package")
+    def test_nonstandard_c_method_descriptor_graph_break_binding(self):
+        from triton._C.libtriton import ir
+
+        context = ir.context()
+        ir.load_dialects(context)
+        builder = ir.builder(context)
+        descriptor = inspect.getattr_static(type(builder), "get_loc")
+        if not inspect.ismethoddescriptor(descriptor) or isinstance(
+            descriptor, types.MethodDescriptorType
+        ):
+            self.skipTest("requires a nonstandard C method descriptor")
+
+        def fn(x):
+            builder.get_loc()
+            return x + 1
+
+        x = torch.ones(1)
+        result = torch.compile(fn, backend="eager")(x)
+        self.assertEqual(result, x + 1)
 
     def test_classmethod_descriptor_dict_fromkeys(self):
         """dict.fromkeys is a classmethod_descriptor."""

--- a/test/dynamo/test_tp_getattro.py
+++ b/test/dynamo/test_tp_getattro.py
@@ -3,10 +3,8 @@
 
 import inspect
 import types
-import unittest
 
 import torch
-
 import torch._dynamo.test_case
 import torch._dynamo.testing
 from torch.testing._internal.common_utils import HardwareClassification
@@ -574,8 +572,10 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
         result = torch.compile(fn, backend="eager", fullgraph=True)()
         self.assertEqual(sorted(result), ["a", "b"])
 
-    @unittest.skipUnless(has_triton_package(), "requires Triton package")
     def test_nonstandard_c_method_descriptor_graph_break_binding(self):
+        if not has_triton_package():
+            self.skipTest("requires Triton package")
+
         from triton._C.libtriton import ir
 
         context = ir.context()
@@ -586,24 +586,13 @@ class TpGetattroTests(torch._dynamo.test_case.TestCase):
             descriptor, types.MethodDescriptorType
         ):
             self.skipTest("requires a nonstandard C method descriptor")
-        descriptor_type = type(descriptor)
         bound_method_type = type(builder.get_loc)
 
-        def fn(x):
-            builder.set_loc("dynamo-test")
+        def fn():
             builder.get_loc()
-            return (
-                x + 1,
-                isinstance(builder.get_loc, descriptor_type),
-                isinstance(builder.get_loc, bound_method_type),
-            )
+            return isinstance(builder.get_loc, bound_method_type)
 
-        x = torch.ones(1)
-        result, is_descriptor, is_bound_method = torch.compile(fn, backend="eager")(x)
-        self.assertEqual(result, x + 1)
-        self.assertFalse(is_descriptor)
-        self.assertTrue(is_bound_method)
-        self.assertEqual(builder.get_loc().get_name(), "dynamo-test")
+        self.assertTrue(torch.compile(fn, backend="eager")())
 
     def test_classmethod_descriptor_dict_fromkeys(self):
         """dict.fromkeys is a classmethod_descriptor."""

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -182,6 +182,7 @@ if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.side_effects import SideEffects
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
+
     from torch._dynamo.variables.constant import ConstantVariable
 
     from .lists import ListVariable, TupleVariable
@@ -3630,7 +3631,8 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         # TODO(tp_descr_get) - Investigate if we need a separate descriptor
         # VT for instancemethod and cython functions.
         if (
-            torch._C._dynamo.utils.is_instancemethod(type_attr)  # type: ignore[attr-defined]
+            inspect.ismethoddescriptor(type_attr)
+            or torch._C._dynamo.utils.is_instancemethod(type_attr)  # type: ignore[attr-defined]
             or is_cython_function(type_attr)
         ):
             return variables.GetAttrVariable(self, name, type(type_attr), source=source)

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -3629,14 +3629,14 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         # TODO(tp_descr_get) - Investigate if we need a separate descriptor
         # VT for instancemethod and cython functions.
-        if inspect.ismethoddescriptor(type_attr):
-            return variables.GetAttrVariable(self, name, source=source)
-
         if (
             torch._C._dynamo.utils.is_instancemethod(type_attr)  # type: ignore[attr-defined]
             or is_cython_function(type_attr)
         ):
             return variables.GetAttrVariable(self, name, type(type_attr), source=source)
+
+        if inspect.ismethoddescriptor(type_attr):
+            return variables.GetAttrVariable(self, name, source=source)
 
         # Plain class variable (or MethodType, C-level non-data descriptor
         # without __get__, etc.).

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -182,7 +182,6 @@ if TYPE_CHECKING:
     from torch._dynamo.codegen import PyCodegen
     from torch._dynamo.side_effects import SideEffects
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
-
     from torch._dynamo.variables.constant import ConstantVariable
 
     from .lists import ListVariable, TupleVariable

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -3630,9 +3630,11 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         # TODO(tp_descr_get) - Investigate if we need a separate descriptor
         # VT for instancemethod and cython functions.
+        if inspect.ismethoddescriptor(type_attr):
+            return variables.GetAttrVariable(self, name, source=source)
+
         if (
-            inspect.ismethoddescriptor(type_attr)
-            or torch._C._dynamo.utils.is_instancemethod(type_attr)  # type: ignore[attr-defined]
+            torch._C._dynamo.utils.is_instancemethod(type_attr)  # type: ignore[attr-defined]
             or is_cython_function(type_attr)
         ):
             return variables.GetAttrVariable(self, name, type(type_attr), source=source)


### PR DESCRIPTION
# Problem

In the next Triton release for 3.9, migration from pybind11 to nanobind in https://github.com/triton-lang/triton/pull/10283 will change how C++ methods such as `ir.builder.set_loc` are represented in Python. With nanobind, the following program works eagerly but fails under `torch.compile`:

```python
import torch
from triton._C.libtriton import ir

context = ir.context()
ir.load_dialects(context)
builder = ir.builder(context)


def fn(x):
    builder.set_loc("repro")
    builder.get_loc()
    return x + 1


fn(torch.ones(1))  # Works
torch.compile(fn, backend="eager")(torch.ones(1))  # Missing `self`
```

This was exposed while testing the Triton pin in [pytorch/pytorch#190440](https://github.com/pytorch/pytorch/pull/190440).

# Root Cause

Nanobind represents the class attribute and the instance attribute using different objects:

```python
type(builder).__dict__["set_loc"]  # Unbound `nanobind.nb_method`
builder.set_loc                    # Bound `nanobind.nb_bound_method`
```

Access through the instance applies Python's descriptor protocol and binds `builder` as `self`.

Dynamo handles standard CPython method descriptors and pybind instancemethods, but previously treated other C method descriptors as ordinary class attributes. Across a graph break, it could therefore reconstruct the unbound descriptor rather than performing the instance attribute lookup. Invoking that descriptor without the builder receiver produces the missing-`self` failure.

The unbound descriptor and bound method can also have different Python types. Recording the descriptor's type as the runtime result type could cause Dynamo to incorrectly specialize `type` or `isinstance` expressions.

# This Diff

Recognize remaining C method descriptors using `inspect.ismethoddescriptor` and represent their instance access with `GetAttrVariable`.

This preserves a runtime operation equivalent to:

```python
getattr(builder, "set_loc")
```

Python can then apply the descriptor protocol and bind the receiver normally.

The result's `py_type` is intentionally left unspecified because the type of the class descriptor is not necessarily the type returned by instance attribute access.

A regression test calls `get_loc` through compiled code and verifies that instance access produces the bound-method type rather than the unbound descriptor type.

# Test Plan

- Five targeted descriptor tests pass with candidate nanobind Triton `b5d2959a7397d1f56eda229eb870d72f88763455`.
- The same targeted suite passes with previous pybind Triton `df3f91dd2da984f9b64b3f7a0f9d0e612427ca3a`.
- The original `FxGraphRunnableTest.test_user_defined_triton_kernel_autotune` reproducer passes with the candidate pin.
- Without the fix, the minimal `get_loc` reproducer fails because the receiver is missing.
- Without the type correction, the descriptor-versus-bound-method assertion fails.
- `python -m py_compile` and `git diff --check` pass.

Prepared with assistance from Codex.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98