### PR TITLE
Resolve device_hint's fallback through the accelerator API

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -19,6 +19,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_utils import unMarkDynamoStrictTest
 from torch.testing._internal.common_utils import (
     TestCase,
+    HardwareClassification,
     skipIfCrossRef,
     skipIfTorchDynamo,
     suppress_warnings,
@@ -60,6 +61,7 @@ import re
 from collections import defaultdict
 from collections.abc import Iterable
 import unittest
+from unittest.mock import patch
 import warnings
 import weakref
 from functools import partial, wraps
@@ -2698,7 +2700,84 @@ class TestMetaKernelRegistrations(TestCase):
         self.assertEqual(diff_b2.shape, expected_bias_shape)
 
 
+class TestDeviceHint(TestCase):
+    # device_hint decides which backend the ~27 branches in _meta_registrations
+    # model, so its fallback needs coverage on every backend rather than on
+    # whichever one the author had.
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skipIfTorchDynamo("tests device_hint directly, not through dynamo")
+    def test_device_hint_reports_tensor_device(self, device):
+        from torch._meta_registrations import device_hint
+
+        self.assertEqual(
+            device_hint(torch.empty(3, device=device)), torch.device(device).type
+        )
+
+    @skipIfTorchDynamo("tests device_hint directly, not through dynamo")
+    def test_device_hint_device_less_tensor_is_the_accelerator(self, device):
+        from torch._meta_registrations import device_hint
+
+        device_type = torch.device(device).type
+        acc = torch.accelerator.current_accelerator()
+        if acc is None or acc.type != device_type:
+            self.skipTest(f"{device} is not the accelerator in use")
+
+        self.assertEqual(device_hint(torch.empty(3, device="meta")), device_type)
+
+
+class TestDeviceHintFallback(TestCase):
+    # The cases no real machine can produce on demand: an accelerator other than
+    # the one this process has, and a build with no accelerator at all.
+    hw_classification = HardwareClassification.GENERIC
+
+    @skipIfTorchDynamo("tests device_hint directly, not through dynamo")
+    def test_device_hint_follows_current_accelerator(self):
+        from torch._meta_registrations import device_hint
+
+        for device_type in ("cuda", "xpu", "mps", "hpu", "privateuseone"):
+            with patch(
+                "torch.accelerator.current_accelerator",
+                return_value=torch.device(device_type),
+            ):
+                self.assertEqual(
+                    device_hint(torch.empty(3, device="meta")), device_type
+                )
+
+    @skipIfTorchDynamo("tests device_hint directly, not through dynamo")
+    def test_device_hint_without_accelerator_falls_back_to_cuda(self):
+        from torch._meta_registrations import device_hint
+
+        with patch("torch.accelerator.current_accelerator", return_value=None):
+            self.assertEqual(device_hint(torch.empty(3, device="meta")), "cuda")
+
+    @skipIfTorchDynamo("tests device_hint directly, not through dynamo")
+    def test_device_hint_prefers_the_tensor_over_the_accelerator(self):
+        from torch._meta_registrations import device_hint
+
+        with patch(
+            "torch.accelerator.current_accelerator",
+            return_value=torch.device("xpu"),
+        ):
+            self.assertEqual(device_hint(torch.empty(3)), "cpu")
+
+    @skipIfTorchDynamo("tests device_hint directly, not through dynamo")
+    def test_device_hint_prefers_the_fake_device_over_the_accelerator(self):
+        from torch._meta_registrations import device_hint
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        with patch(
+            "torch.accelerator.current_accelerator",
+            return_value=torch.device("xpu"),
+        ):
+            with FakeTensorMode():
+                self.assertEqual(device_hint(torch.empty(3, device="cpu")), "cpu")
+
+
 instantiate_device_type_tests(TestMeta, globals())
+instantiate_device_type_tests(
+    TestDeviceHint, globals(), allow_mps=True, allow_xpu=True
+)
 
 
 def print_op_str_if_not_supported(op_str):

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -1773,8 +1773,8 @@ def _linalg_svd_meta(
         V = A.new_empty(V_shape)
         # NB: This checks for CUDA since there is no way to check for cuSolver.
         # Also, this might not work correctly on CPU when fake_device is not
-        # available as device_hint just defaults to CUDA in that case. See
-        # _linalg_svd meta in core.
+        # available: device_hint then reports the accelerator the process is
+        # using, or "cuda" when there is none. See _linalg_svd meta in core.
         is_cuda = device_hint(A) == "cuda"
         V.as_strided_(V_shape, make_contiguous_strides_for(V_shape, row_major=is_cuda))  # type: ignore[arg-type]
     else:
@@ -2623,7 +2623,8 @@ def device_hint(tensor) -> "str":
     ):
         return tensor.device.type
     else:
-        return "cuda"  # default to cuda
+        acc = torch.accelerator.current_accelerator()
+        return acc.type if acc is not None else "cuda"
 
 
 def calc_conv_nd_return_shape(


### PR DESCRIPTION
Related to this RFC: #194355

`device_hint` tells a meta kernel which device it is modelling. When a tensor
carries no usable device — a plain meta tensor with no fake device attached — it
fell back to the literal `"cuda"`.

That fallback is the root of the CUDA bias in this file. Around 27 call sites
branch on `device_hint`, so on any machine whose accelerator is not CUDA every
one of them silently modelled the CUDA path for device-less tensors, and the only
way for another backend to be modelled correctly was to patch each branch
individually.

`torch.accelerator.current_accelerator()` already answers this question
backend-neutrally. `getAccelerator()` in
`aten/src/ATen/DeviceAccelerator.cpp` returns `kPrivateUse1` ahead of the
compile-time backends whenever a PrivateUse1 backend is registered, so a
registered out-of-tree accelerator resolves to its own device type with no
further framework change. The literal is kept only as the last-resort answer for
builds with no accelerator at all, preserving today's behavior on CPU-only
machines. That priority order also means a CUDA build keeps resolving to
`"cuda"` only while no PrivateUse1 backend is registered in the process; where
both are present — a CUDA build with an openreg-style module registered — the
fallback now names the PrivateUse1 backend. That is the mechanism's own
deliberate choice rather than something introduced here, but it is the one case
where a CUDA build moves, so I would rather flag it than claim nothing changes.
ROCm is unaffected: no `HIPHooks` implementation overrides `isBuilt()`, so a ROCm
build resolves through the hipified CUDA hooks to `"cuda"` as before.

**This is a behavior change rather than a pure refactor.** On machines whose
accelerator is XPU, MPS, HPU or a PrivateUse1 backend, device-less meta tensors
now resolve to that device instead of `"cuda"`, and meta kernels branching on
`device_hint` will take a different path there. That is the intended correction —
those are the machines where `"cuda"` was the wrong answer — but any test that
implicitly relied on the old default will move, and I would rather flag that for
maintainer review than assert it is safe. It does not touch tensors carrying a
real or fake device, which is the overwhelming majority of meta kernel calls.

The trailing comment on the old line described the literal and is dropped rather
than reworded, since the call now names the mechanism itself. The `NB` comment in
`meta__linalg_svd` said `device_hint` "just defaults to CUDA in that case", which
the change makes false, so it now describes the accelerator fallback while
keeping its warning about the CPU path.

`test_meta.py` gains two classes, split by what hardware can produce.
`TestDeviceHint` is instantiated per device type — so it also covers an
out-of-tree PrivateUse1 backend with no entry in the file — and checks that a
tensor's own device still wins and that a device-less meta tensor resolves to the
accelerator in use, skipping instances that are not the current accelerator. The
cases no single machine can produce, an accelerator other than this process's and
a build with none, stay behind mocks in the `GENERIC` class
`TestDeviceHintFallback`, which also pins that a real device and a fake device
both outrank the accelerator.
