### PR TITLE
Speed up bmm/baddbmm on Windows ARM64

### DIFF
--- a/aten/src/ATen/native/LinearAlgebra.cpp
+++ b/aten/src/ATen/native/LinearAlgebra.cpp
@@ -1729,6 +1729,52 @@ static void baddbmm_with_gemm_(const Tensor &result, const Tensor &mat1, const T
 // optimization, it likely depends on the characteristics of the CPU, MKL will be different from non-MKL etc.,
 // but this seems to be a first starting point.
 
+#if defined(_M_ARM64)
+static void bf16_bmm_with_gemm_parallel_(const Tensor& result, const Tensor& mat1, const Tensor& mat2, const Scalar& beta_, const Scalar& alpha_) {
+  TORCH_INTERNAL_ASSERT(result.is_contiguous());
+
+  const auto result_sizes = result.sizes();
+  const auto result_strides = result.strides();
+  const auto mat1_strides = mat1.strides();
+  const auto mat2_strides = mat2.strides();
+  const auto mat1_sizes = mat1.sizes();
+  const auto mat2_sizes = mat2.sizes();
+
+  auto is_transposed = [](const c10::IntArrayRef& strides, const c10::IntArrayRef& sizes) {
+    return strides[1] == 1 && strides[2] >= sizes[1];
+  };
+
+  const auto transa = is_transposed(mat2_strides, mat2_sizes) ? TransposeType::Transpose : TransposeType::NoTranspose;
+  const auto transb = is_transposed(mat1_strides, mat1_sizes) ? TransposeType::Transpose : TransposeType::NoTranspose;
+
+  const int64_t batch_size = mat1_sizes[0];
+  const int64_t m = result_sizes[2];
+  const int64_t n = result_sizes[1];
+  const int64_t k = mat2_sizes[1];
+
+  const int64_t lda = mat2_strides[transa == TransposeType::Transpose ? 2 : 1];
+  const int64_t ldb = mat1_strides[transb == TransposeType::Transpose ? 2 : 1];
+  const int64_t ldc = result_strides[1];
+
+  const auto alpha = alpha_.to<float>();
+  const auto beta = beta_.to<float>();
+  const auto* a = mat2.const_data_ptr<at::BFloat16>();
+  const auto* b = mat1.const_data_ptr<at::BFloat16>();
+  auto* c = result.data_ptr<at::BFloat16>();
+
+  at::parallel_for(0, batch_size, 1, [&](int64_t begin, int64_t end) {
+    for (const auto batch : c10::irange(begin, end)) {
+      at::native::cpublas::gemm(
+          transa, transb, m, n, k, alpha,
+          a + mat2_strides[0] * batch, lda,
+          b + mat1_strides[0] * batch, ldb,
+          beta,
+          c + result_strides[0] * batch, ldc);
+    }
+  });
+}
+#endif // defined(_M_ARM64)
+
 static inline void bmm_out_or_baddbmm_(const Tensor& self_or_result_, const Tensor& batch1, const Tensor& batch2, const Scalar& beta, const Scalar& alpha, bool is_bmm_out) {
   // is_bmm_out: true for bmm_out, false for baddbmm_
   // self_or_result is "self" for baddbmm_ and "result" for bmm_out
@@ -1773,6 +1819,14 @@ static inline void bmm_out_or_baddbmm_(const Tensor& self_or_result_, const Tens
       TORCH_WARN("mkldnn_matmul failed, switching to baddbmm:", e.what());
       at::globalContext().setUserEnabledMkldnn(false);
     }
+  }
+#endif
+#if defined(_M_ARM64)
+  if (contraction_size * res_rows * res_cols >= 400 && self_or_result.scalar_type() == kBFloat16 &&
+      batch_items_contiguous_or_transposed(batch1) &&  batch_items_contiguous_or_transposed(batch2) &&
+      self_or_result.is_contiguous()) {
+    bf16_bmm_with_gemm_parallel_(self_or_result, batch1, batch2, beta, alpha);
+    return;
   }
 #endif
   if (contraction_size * res_rows * res_cols < 400) {

--- a/aten/src/ATen/native/cpu/BlasKernel.cpp
+++ b/aten/src/ATen/native/cpu/BlasKernel.cpp
@@ -6,6 +6,7 @@
 #include <ATen/native/cpu/ReducedPrecisionFloatGemvFastPathKernel.h>
 #include <c10/util/irange.h>
 #include <c10/util/Unroll.h>
+#include <algorithm>
 
 #if !defined(C10_MOBILE)
 namespace at::native::blas_impl {
@@ -49,6 +50,12 @@ void fp16_gemv_notrans(
     const int incy);
 } // namespace at::native::blas_impl
 #endif
+#if (defined(__aarch64__) || defined(_M_ARM64)) && !defined(C10_MOBILE)
+#define AT_BLASKERNEL_ARM_NEON 1
+#if !defined(__aarch64__)
+#include <arm_neon.h>
+#endif
+#endif
 
 namespace at::native {
 namespace cpublas {
@@ -78,7 +85,11 @@ void scale_(int64_t m, int64_t n, opmath_t alpha, scalar_t *a, int64_t lda) {
 
 template <typename Func>
 auto sum(int64_t N, Func f) {
+#if defined(__aarch64__) || defined(_M_ARM64)
+  constexpr int ilp_factor = 8;
+#else
   constexpr int ilp_factor = 4;
+#endif
   using acc_t = decltype(f(0));
 
   // Calculate independent partial sums then add together at the end
@@ -136,6 +147,131 @@ gemm_notrans_(
   }
 }
 
+#if defined(AT_BLASKERNEL_ARM_NEON)
+constexpr int64_t kNeonGemmMinWorkPerChunk = 32768;
+
+C10_ALWAYS_INLINE float32x4_t load_bf16_as_f32(const at::BFloat16* p) {
+  const uint16x4_t bits = vld1_u16(reinterpret_cast<const uint16_t*>(p));
+#if defined(_MSC_VER) && !defined(__clang__)
+  return vreinterpretq_f32_u32(vshlq_n_u32(vmovl_u16(bits), 16));
+#else
+  return vreinterpretq_f32_u32(vshll_n_u16(bits, 16));
+#endif
+}
+
+template <typename out_t>
+C10_ALWAYS_INLINE void store_f32x4(float32x4_t acc, float beta, out_t* dst) {
+  float tmp[4];
+  vst1q_f32(tmp, acc);
+  for (const auto t : c10::irange(4)) {
+    dst[t] = static_cast<out_t>(
+        beta == 0.0f ? tmp[t] : beta * static_cast<float>(dst[t]) + tmp[t]);
+  }
+}
+
+template <int NRC, typename out_t>
+void gemm_notrans_bf16_neon_panel(
+    int64_t m,
+    int64_t k,
+    float alpha,
+    const at::BFloat16* a,
+    int64_t lda,
+    const at::BFloat16* b,
+    int64_t ldb,
+    float beta,
+    out_t* c,
+    int64_t ldc) {
+  int64_t i = 0;
+  for (; i + 16 <= m; i += 16) {
+    float32x4_t acc[NRC][4];
+    c10::ForcedUnroll<NRC>{}([&](auto jj) {
+      acc[jj][0] = vdupq_n_f32(0.0f);
+      acc[jj][1] = vdupq_n_f32(0.0f);
+      acc[jj][2] = vdupq_n_f32(0.0f);
+      acc[jj][3] = vdupq_n_f32(0.0f);
+    });
+    for (const auto l : c10::irange(k)) {
+      const at::BFloat16* a_col = a + l * lda + i;
+      const float32x4_t a0 = load_bf16_as_f32(a_col);
+      const float32x4_t a1 = load_bf16_as_f32(a_col + 4);
+      const float32x4_t a2 = load_bf16_as_f32(a_col + 8);
+      const float32x4_t a3 = load_bf16_as_f32(a_col + 12);
+      c10::ForcedUnroll<NRC>{}([&](auto jj) {
+        const float32x4_t bv = vdupq_n_f32(static_cast<float>(b[jj * ldb + l]) * alpha);
+        acc[jj][0] = vfmaq_f32(acc[jj][0], a0, bv);
+        acc[jj][1] = vfmaq_f32(acc[jj][1], a1, bv);
+        acc[jj][2] = vfmaq_f32(acc[jj][2], a2, bv);
+        acc[jj][3] = vfmaq_f32(acc[jj][3], a3, bv);
+      });
+    }
+    c10::ForcedUnroll<NRC>{}([&](auto jj) {
+      out_t* c_col = c + jj * ldc + i;
+      store_f32x4(acc[jj][0], beta, c_col);
+      store_f32x4(acc[jj][1], beta, c_col + 4);
+      store_f32x4(acc[jj][2], beta, c_col + 8);
+      store_f32x4(acc[jj][3], beta, c_col + 12);
+    });
+  }
+  for (; i + 4 <= m; i += 4) {
+    float32x4_t acc[NRC];
+    c10::ForcedUnroll<NRC>{}([&](auto jj) { acc[jj] = vdupq_n_f32(0.0f); });
+    for (const auto l : c10::irange(k)) {
+      const float32x4_t av = load_bf16_as_f32(a + l * lda + i);
+      c10::ForcedUnroll<NRC>{}([&](auto jj) {
+        const float32x4_t bv = vdupq_n_f32(static_cast<float>(b[jj * ldb + l]) * alpha);
+        acc[jj] = vfmaq_f32(acc[jj], av, bv);
+      });
+    }
+    c10::ForcedUnroll<NRC>{}([&](auto jj) { store_f32x4(acc[jj], beta, c + jj * ldc + i); });
+  }
+  for (; i < m; ++i) {
+    float acc[NRC] = {};
+    for (const auto l : c10::irange(k)) {
+      const float av = static_cast<float>(a[l * lda + i]);
+      c10::ForcedUnroll<NRC>{}([&](auto jj) {
+        acc[jj] += av * (static_cast<float>(b[jj * ldb + l]) * alpha);
+      });
+    }
+    c10::ForcedUnroll<NRC>{}([&](auto jj) {
+      out_t* dst = c + jj * ldc + i;
+      *dst = static_cast<out_t>(
+          beta == 0.0f ? acc[jj] : beta * static_cast<float>(*dst) + acc[jj]);
+    });
+  }
+}
+
+template <typename out_t>
+void gemm_notrans_bf16_neon(
+    int64_t m,
+    int64_t n,
+    int64_t k,
+    float alpha,
+    const at::BFloat16* a,
+    int64_t lda,
+    const at::BFloat16* b,
+    int64_t ldb,
+    float beta,
+    out_t* c,
+    int64_t ldc) {
+  constexpr int NR = 4;
+  const int64_t num_blocks = (n + NR - 1) / NR;
+  const int64_t work_per_block = std::max<int64_t>(1, NR * m * k);
+  const int64_t grain = std::max<int64_t>(1, kNeonGemmMinWorkPerChunk / work_per_block);
+  parallel_for(0, num_blocks, grain, [&](int64_t begin, int64_t end) {
+    for (const auto block : c10::irange(begin, end)) {
+      const int64_t j = block * NR;
+      if (j + NR <= n) {
+        gemm_notrans_bf16_neon_panel<NR>(m, k, alpha, a, lda, b + j * ldb, ldb, beta, c + j * ldc, ldc);
+      } else {
+        for (const auto jt : c10::irange(j, n)) {
+          gemm_notrans_bf16_neon_panel<1>(m, k, alpha, a, lda, b + jt * ldb, ldb, beta, c + jt * ldc, ldc);
+        }
+      }
+    }
+  });
+}
+#endif // defined(AT_BLASKERNEL_ARM_NEON)
+
 // std::is_same<scalar_t, at::BFloat16> || std::is_same<scalar_t, at::Half>
 template <typename scalar_t, typename opmath_t, typename out_t>
 std::enable_if_t<!std::is_same_v<scalar_t, opmath_t>, void>
@@ -151,18 +287,38 @@ gemm_notrans_(
     opmath_t beta,
     out_t* c,
     int64_t ldc) {
-  // c += alpha * (a @ b)
-  for (const auto i : c10::irange(m)) {
+#if defined(AT_BLASKERNEL_ARM_NEON)
+  if constexpr (std::is_same_v<scalar_t, at::BFloat16> && std::is_same_v<opmath_t, float>) {
+    gemm_notrans_bf16_neon(m, n, k, alpha, a, lda, b, ldb, beta, c, ldc);
+    return;
+  }
+#endif
+  const auto c_size = m * n;
+  auto c_accum = std::make_unique<opmath_t[]>(c_size);
+  if (beta == opmath_t(0)) {
+    std::fill_n(c_accum.get(), c_size, opmath_t(0));
+  } else {
     for (const auto j : c10::irange(n)) {
-      const auto dot = sum(k, [&](int64_t l) -> opmath_t {
-        return static_cast<opmath_t>(a[l * lda + i]) *
-            static_cast<opmath_t>(b[j * ldb + l]);
-      });
-      if (beta == opmath_t(0)) {
-        c[j * ldc + i] = alpha * dot;
-      } else {
-        c[j * ldc + i] = beta * c[j * ldc + i] + alpha * dot;
+      for (const auto i : c10::irange(m)) {
+        c_accum[j * m + i] = beta * static_cast<opmath_t>(c[j * ldc + i]);
       }
+    }
+  }
+
+  for (const auto l : c10::irange(k)) {
+    for (const auto j : c10::irange(n)) {
+      const opmath_t val = static_cast<opmath_t>(b[j * ldb + l]) * alpha;
+      opmath_t* c_col = c_accum.get() + j * m;
+      const scalar_t* a_col = a + l * lda;
+      for (const auto i : c10::irange(m)) {
+        c_col[i] += static_cast<opmath_t>(a_col[i]) * val;
+      }
+    }
+  }
+
+  for (const auto j : c10::irange(n)) {
+    for (const auto i : c10::irange(m)) {
+      c[j * ldc + i] = c_accum[j * m + i];
     }
   }
 }


### PR DESCRIPTION
## Summary
 
On Windows ARM64, `bmm`/`baddbmm` fell through to the generic scalar `gemm_notrans_` path in `BlasKernel.cpp`. 
As a result, bf16 batched matmul ran single-threaded through a dot-product-per-element inner loop, measured at up to ~80x lower than the equivalent x64.
 
## Changes
 
- Add a NEON bf16 GEMM kernel (`gemm_notrans_bf16_neon`) that widens bf16 to fp32 and accumulates with  `vfmaq_f32`, blocked 16 rows x 4 columns with scalar tails for remainders. 
- Parallelize `bmm`/`baddbmm` over the batch dimension via `at::parallel_for` for contiguous or transposed bf16 inputs on   Windows ARM64.
## Performance Benchmarks
 
| Operation | Shape                      | x64 (ms) | ARM64 before (ms) | ARM64 after (ms) |
|-----------|-----------------------------|---------:|-------------------:|-------------------:|
| bmm       | B128 M64 N32 K64 float32     |   0.096  |              1.302 |              0.599 |
| bmm       | B128 M64 N32 K64 bfloat16    |   0.182  |             15.213 |              0.209 |
| baddbmm   | B128 M64 N32 K64 bfloat16    |   0.226  |             17.920 |              0.219 |
 
All `bmm`/`baddbmm`/`mm`/`addmm` tests pass, including every stride permutation exercised by `test_bmm` and `test_baddbmm`.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01