### PR TITLE
Fix grammatical errors in comments and docstrings

### DIFF
--- a/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/README.md
+++ b/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/README.md
@@ -44,7 +44,7 @@ The benchmark codes depend on the [DLRM codebase](https://github.com/facebookres
 # This should also dump kaggleAdDisplayChallenge_processed.npz in the path where data is present
 ```
 
-4. Copy the scripts data sparsifier benchmark scripts into to the dlrm directory.
+4. Copy the scripts data sparsifier benchmark scripts into the dlrm directory.
 
 ## Scripts to run each experiment.
 
@@ -92,6 +92,6 @@ GPU: A100
 
 
 ## Future work
-1. **Evaluate memory savings**: The idea is to use torch.sparse tensors to store weights of the embedding bags so that the model memory consumption improves. This will be possible once the embedding bags starts supporting torch.sparse backend.
+1. **Evaluate memory savings**: The idea is to use torch.sparse tensors to store weights of the embedding bags so that the model memory consumption improves. This will be possible once the embedding bags start supporting torch.sparse backend.
 
 2. **Sparsifying activations**: Use activation sparsifier to sparsify the activations of the dlrm model. The idea is to sparsify the features before feeding to the top dense layer (sparsify ```z``` [here](https://github.com/facebookresearch/dlrm/blob/11afc52120c5baaf0bfe418c610bc5cccb9c5777/dlrm_s_pytorch.py#L595)).

--- a/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/evaluate_disk_savings.py
+++ b/torch/ao/pruning/_experimental/data_sparsifier/benchmarks/evaluate_disk_savings.py
@@ -14,7 +14,7 @@ from torch.ao.pruning._experimental.data_sparsifier import DataNormSparsifier
 
 
 def create_attach_sparsifier(model, **sparse_config):
-    """Create a DataNormSparsifier and the attach it to the model embedding layers
+    """Create a DataNormSparsifier and attach it to the model embedding layers
 
     Args:
         model (nn.Module)

--- a/torch/ao/quantization/_correct_bias.py
+++ b/torch/ao/quantization/_correct_bias.py
@@ -109,7 +109,7 @@ def bias_correction(
 
     Args:
         float_model: a trained model that serves as a reference to what bias correction should aim for
-        quantized_model: quantized form of float_model that bias correction is to applied to
+        quantized_model: quantized form of float_model that bias correction is to be applied to
         img_data: calibration data to estimate the expected output (used to find quantization error)
         target_modules: specifies what submodules in quantized_model need bias correction (can be extended to
                 unquantized submodules)

--- a/torch/ao/quantization/_equalize.py
+++ b/torch/ao/quantization/_equalize.py
@@ -144,7 +144,7 @@ def cross_layer_equalization(module1, module2, output_axis=0, input_axis=1):
     weight1_range = channel_range(weight1, output_axis)
     weight2_range = channel_range(weight2, input_axis)
 
-    # producing scaling factors to applied
+    # producing scaling factors to be applied
     weight2_range += 1e-9
     scaling_factors = torch.sqrt(weight1_range / weight2_range)
     inverse_scaling_factors = torch.reciprocal(scaling_factors)
@@ -202,7 +202,7 @@ def equalize(model, paired_modules_list, threshold=1e-4, inplace=True):
     """Equalize modules until convergence is achieved.
 
     Given a list of adjacent modules within a model, equalization will
-    be applied between each pair, this will repeated until convergence is achieved
+    be applied between each pair, this will be repeated until convergence is achieved
 
     Keeps a copy of the changing modules from the previous iteration, if the copies
     are not that different than the current modules (determined by converged_test),

--- a/torch/ao/quantization/quantize_jit.py
+++ b/torch/ao/quantization/quantize_jit.py
@@ -386,7 +386,7 @@ def _quantize_ondevice_dynamic_jit(
         - observe_<method_name> is added that observe the values to be quantized.
         - reset_observers_<method_name> to reset observers.
         - quantize_<method_name> is added to the model.
-          - This method extract scale, zero points.
+          - This method extracts scale, zero points.
           - Quantizes observed weights.
           - Creates packed params from it and update the attribute of the model with the new values
             for the packed params.

--- a/torch/ao/quantization/stubs.py
+++ b/torch/ao/quantization/stubs.py
@@ -46,7 +46,7 @@ class DeQuantStub(nn.Module):
 
 class QuantWrapper(nn.Module):
     r"""A wrapper class that wraps the input module, adds QuantStub and
-    DeQuantStub and surround the call to module with call to quant and dequant
+    DeQuantStub and surrounds the call to module with call to quant and dequant
     modules.
 
     This is used by the `quantization` utility functions to add the quant and

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -325,7 +325,7 @@ static bool treatSequenceAsTuple(PyObject* index) {
   if (!PySequence_Check(index)) {
     return false;
   }
-  // This uses a heuristics from NumPy for determining whether to treat
+  // This uses a heuristic from NumPy for determining whether to treat
   // non-tuple sequences as if they were a tuple. From the NumPy code comments:
   //
   // "At this point, we're left with a non-tuple, non-array, sequence:

--- a/torch/csrc/distributed/autograd/engine/dist_engine.h
+++ b/torch/csrc/distributed/autograd/engine/dist_engine.h
@@ -21,7 +21,7 @@ class BackwardPassCleanupGuard;
 
 // Unlike the vanilla autograd engine, the distributed autograd engine
 // accumulates the gradients in the appropriate DistAutogradContext. This avoids
-// multiple trainer nodes stomping on each others gradients.
+// multiple trainer nodes stomping on each other's gradients.
 class TORCH_API DistEngine {
  public:
   // Retrieve the singleton instance.

--- a/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
+++ b/torch/csrc/distributed/rpc/tensorpipe_agent.cpp
@@ -281,7 +281,7 @@ std::unique_ptr<ChannelRegistration> makeMultiplexedUvChannel() {
 // The multiplexed UV channel encapsulates multiple UV transports (each with its
 // own event loop thread). Each channel will, in turn, contain multiple UV
 // connections, one for each of those contexts. When sending a tensor, its data
-// is split in equal chunks and each chunks is sent on a different connection
+// is split in equal chunks and each chunk is sent on a different connection
 // and thus driven by a different thread. This is needed to reach very high
 // bandwidths.
 C10_REGISTER_CREATOR(

--- a/torch/csrc/jit/backends/backend_exception.h
+++ b/torch/csrc/jit/backends/backend_exception.h
@@ -16,14 +16,14 @@ class TORCH_API BackendRuntimeException : public c10::Error {
     debug_handles.push_back(debug_handle);
   }
   // If rethrowing, can push another debug_handle
-  // This is useful in couple of scenarios.
+  // This is useful in a couple of scenarios.
   // 1. A submodule is lowered and lite interpreter has CallMethod
   //    to lowered module's method. In this case lowered module will throw with
   //    a handle, plus there will be another debug handle corresponding
   //    to the CallMethod node in lite interpreter. Both together give complete
   //    trace. This function allows lite interpreter to rethrow with debug
   //    handle it has for CallMethod.
-  // 2. Another scenarios is when lite interpreter can make function calls or
+  // 2. Another scenario is when lite interpreter can make function calls or
   //    the lowered backend also has function call ability. Thus we have
   //    multiple function frames. Now we need a stack of handles to symbolicate
   //    entire stack trace.

--- a/torch/csrc/jit/frontend/function_schema_parser.cpp
+++ b/torch/csrc/jit/frontend/function_schema_parser.cpp
@@ -35,7 +35,7 @@ struct SchemaParser {
   std::variant<OperatorName, FunctionSchema> parseDeclaration() {
     OperatorName name = parseName();
 
-    // If there is no parentheses coming, then this is just the operator name
+    // If there are no parentheses coming, then this is just the operator name
     // without an argument list
     if (L.cur().kind != '(') {
       return OperatorName(std::move(name));

--- a/torch/csrc/jit/jit_log.h
+++ b/torch/csrc/jit/jit_log.h
@@ -6,8 +6,8 @@
 #include <string>
 #include <unordered_map>
 
-// `TorchScript` offers a simple logging facility that can enabled by setting an
-// environment variable `PYTORCH_JIT_LOG_LEVEL`.
+// `TorchScript` offers a simple logging facility that can be enabled by setting
+// an environment variable `PYTORCH_JIT_LOG_LEVEL`.
 
 // Logging is enabled on a per file basis. To enable logging in
 // `dead_code_elimination.cpp`, `PYTORCH_JIT_LOG_LEVEL` should be

--- a/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py
+++ b/torch/distributed/_shard/sharding_spec/chunk_sharding_spec_ops/embedding.py
@@ -59,7 +59,7 @@ def sharded_embedding(types, args, kwargs, pg):
        The reason of having an extra row (aka, number 4 in the example) is
        because when max_norm is specified only weight which has looked will
        be re-normed so mask IDs whose embeddings are not stored in current
-       rank will to an extra row will ensure max_norm still works as expected.
+       rank to an extra row will ensure max_norm still works as expected.
     3. If max_norm is specified, the extra row guarantees that the mask ID will
        not affect the behavior of weight re-norm.
 

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -601,7 +601,7 @@ class SimpleElasticAgent(ElasticAgent):
         1. Each agent writes its configuration(group_rank, group_world_size
            , num_workers) to the common store.
         2. The rank 0 agent reads all the role_info from the store and
-           determines each agents worker ranks.
+           determines each agent's worker ranks.
         3. Determine the global rank: the global rank of the workers is computed
            by cumulative sum of the local_world_size for all workers in front of it.
            For efficiency reasons each worker is assigned a base global rank

--- a/torch/distributed/optim/named_optimizer.py
+++ b/torch/distributed/optim/named_optimizer.py
@@ -23,7 +23,7 @@ class _NamedOptimizer(optim.Optimizer):
     We replace the original key (number) in an optim to the
     fully qualified name (FQN) string. User can initialize the optim as they
     initialize a PyTorch optim, the only difference is that they also need to
-    pass in the FQN of each parameters.
+    pass in the FQN of each parameter.
 
     Args:
         named_parameters (Mapping[str, Union[torch.Tensor, ShardedTensor]]):

--- a/torch/nativert/executor/DelegateExecutor.h
+++ b/torch/nativert/executor/DelegateExecutor.h
@@ -26,13 +26,13 @@ class DelegateExecutor {
 
   // Runtime calls processWeights() to pass the weights to the delegate backend.
   // Typically, a backend would perform some form of validation and processing,
-  // such as constant folding. The processed weights stays in the deactivate
+  // such as constant folding. The processed weights stay in the deactivate
   // state until commitWeights() is called.
   //
   // Weights tensors are co-owned by the runtime and the delegate backend.
   // In the regular inference run() path, neither Runtime or Delegate backend
   // can modify the weights tensor.
-  // To support inplace weight update, weight tensors are be exposed by
+  // To support inplace weight update, weight tensors are exposed by
   // ModelRunner::getWeights() to an external caller. The external caller can
   // then modify the weight tensors in-place. Such mutation would instantly
   // affect the weight tensors in the delegate backend.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194565

Fixes subject-verb agreement, missing articles, missing possessive
apostrophes, and a few dropped or duplicated words across comments and
docstrings in torch/. No functional changes.

One fix is more than a pure wording change: the embedding sharding
docstring in chunk_sharding_spec_ops/embedding.py contained a garbled
sentence ("mask IDs whose embeddings are not stored in current rank will
to an extra row will ensure ..."). The stray "will" is dropped so the
sentence parses; the intended meaning is preserved.

Test Plan: comment-only change, no tests run. Lint via:

```
lintrunner -a
```

Authored with the assistance of an AI agent.