### PR TITLE
[inductor] Loosen fp16 grad tolerance for special.i1/i1e on XPU (mirr…

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -596,6 +596,10 @@ inductor_override_kwargs["xpu"] = {
     "randn": {"assert_equal": False},
     "nn.functional.rrelu": {"check_gradient": False},
     # XPU
+    # Mirrors the CUDA override from #189872; the fp16 backward gap is the
+    # same eager-vs-inductor intermediate-precision difference on XPU.
+    ("special.i1", f16): {"grad_atol": 1e-5, "grad_rtol": 1e-2},
+    ("special.i1e", f16): {"grad_atol": 1e-5, "grad_rtol": 1e-2},
     ("cross", f16): {"reference_in_float": True},
     ("addr", f16): {"reference_in_float": True},
     ("baddbmm", f16): {"atol": 2e-3, "rtol": 0.002},  # decomp affects accuracy


### PR DESCRIPTION
…or CUDA)

#189872 added the fp16 grad-tolerance override for special.i1/special.i1e under inductor_override_kwargs["cuda"], which makes the newly enabled fp16 gradient checks pass on CUDA. The same eager-vs-inductor intermediate-precision gap exists on XPU, but the xpu dict was missed, so test_comprehensive_special_i1_xpu_float16 and test_comprehensive_special_i1e_xpu_float16 fail on main.

This change mirrors the CUDA entries in the XPU dict with the same grad_atol=1e-5 and grad_rtol=1e-2 values.

Test Plan:

lintrunner -a test/inductor/test_torchinductor_opinfo.py

I authored this with the assistance of an AI coding assistant.,

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo