### PR TITLE
Fix typos and grammar in comments and docstrings

### DIFF
--- a/torch/_inductor/memory.py
+++ b/torch/_inductor/memory.py
@@ -641,7 +641,7 @@ def topological_sort_lpmf(
     https://www.cs.york.ac.uk/rts/docs/DAC-1964-2006/PAPERS/2006/DAC06/PDFFILES/P0689.PDF
 
     The algorithm maintains the max memory so far.
-    At every iteration, for each scheduleable node, it computes:
+    At every iteration, for each schedulable node, it computes:
         - how much memory needs to be allocated for the output buffers of this node;
         - how much memory can be freed as a result of executing this node.
     This gives us two values for each node:

--- a/torch/csrc/api/include/torch/nn/modules/loss.h
+++ b/torch/csrc/api/include/torch/nn/modules/loss.h
@@ -17,7 +17,7 @@ namespace torch::nn {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ L1Loss ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 /// Creates a criterion that measures the mean absolute error (MAE) between each
-/// element in the input : math :`x` and target : `y`.
+/// element in the input :math:`x` and target :math:`y`.
 /// See https://pytorch.org/docs/main/nn.html#torch.nn.L1Loss to learn
 /// about the exact behavior of this module.
 ///

--- a/torch/csrc/jit/runtime/vararg_functions.cpp
+++ b/torch/csrc/jit/runtime/vararg_functions.cpp
@@ -113,7 +113,7 @@ void format(Stack& stack, size_t num_inputs) {
 
   // static const std::regex unsupported_options("\\{(.*?)\\}");
   auto format = peek(stack, 0, num_inputs).toStringRef();
-  // // Temporally comment out the warning message because of
+  // // Temporarily comment out the warning message because of
   // // "StdRegexIsAwful" internal Lint error, to prevent sev
   // // of std::regex from PT mobile.
   // if (std::regex_search(format, unsupported_options)) {

--- a/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/dynamic_rendezvous.py
@@ -907,7 +907,7 @@ class _RendezvousJoinOp:
             rollback_period = 5  # 5 seconds
 
             # If we still have time to rollback (a short period on top of the
-            # operation deadline), try to remove ourself from the rendezvous.
+            # operation deadline), try to remove ourselves from the rendezvous.
             # It is okay if we can't though as our keep-alive will eventually
             # expire.
             if now <= deadline + rollback_period:
@@ -924,7 +924,7 @@ class _RendezvousJoinOp:
         if state.complete:
             # If we are here, it means we are not part of the rendezvous. In
             # case the rendezvous has capacity for additional participants add
-            # ourself to the wait list for the next round.
+            # ourselves to the wait list for the next round.
             if len(state.participants) < ctx.settings.max_nodes:
                 if ctx.node not in state.wait_list:
                     return _Action.ADD_TO_WAIT_LIST

--- a/torch/distributions/utils.py
+++ b/torch/distributions/utils.py
@@ -187,7 +187,7 @@ class _lazy_property_and_property(lazy_property[T, R], property):
 def tril_matrix_to_vec(mat: Tensor, diag: int = 0) -> Tensor:
     r"""
     Convert a `D x D` matrix or a batch of matrices into a (batched) vector
-    which comprises of lower triangular elements from the matrix in row order.
+    which comprises lower triangular elements from the matrix in row order.
     """
     n = mat.shape[-1]
     if not torch._C._get_tracing_state() and (diag < -n or diag >= n):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194567

Corrects small wording and formatting mistakes across several unrelated files:
"scheduleable" -> "schedulable", a malformed Sphinx `:math:` role in the
L1Loss doc comment, "Temporally" -> "Temporarily", "ourself" -> "ourselves",
and "comprises of" -> "comprises".

Comment-only changes; no functional impact.

Test Plan: No behavior change, so no tests were run. The edits touch only
comments and docstrings, and the C++ changes are inside comment blocks, so
compilation is unaffected.

This commit message was authored with the help of an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo