### PR TITLE
[multiprocessing] Add backend-agnostic IPC reducer registration hooks

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -653,6 +653,7 @@ coverage_ignore_functions = [
     "rebuild_tensor",
     "rebuild_typed_storage",
     "rebuild_typed_storage_child",
+    "reduce_cuda_tensor",
     "reduce_storage",
     "reduce_tensor",
     "reduce_typed_storage",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -657,6 +657,8 @@ coverage_ignore_functions = [
     "reduce_tensor",
     "reduce_typed_storage",
     "reduce_typed_storage_child",
+    "register_ipc_storage_check",
+    "register_ipc_tensor_reducer",
     "storage_from_cache",
     # torch.multiprocessing.spawn
     "start_processes",

--- a/docs/source/multiprocessing.md
+++ b/docs/source/multiprocessing.md
@@ -223,3 +223,13 @@ terminate processes upon detecting an error in one of them.
 ```{eval-rst}
 .. py:module:: torch.multiprocessing.reductions
 ```
+
+## IPC reduction registration
+
+Accelerator backends can register tensor reducers and prevent their storages
+from being pickled directly without replacing the reducers provided by PyTorch.
+
+```{eval-rst}
+.. autofunction:: register_ipc_tensor_reducer
+.. autofunction:: register_ipc_storage_check
+```

--- a/docs/source/multiprocessing.md
+++ b/docs/source/multiprocessing.md
@@ -223,13 +223,3 @@ terminate processes upon detecting an error in one of them.
 ```{eval-rst}
 .. py:module:: torch.multiprocessing.reductions
 ```
-
-## IPC reduction registration
-
-Accelerator backends can register tensor reducers and prevent their storages
-from being pickled directly without replacing the reducers provided by PyTorch.
-
-```{eval-rst}
-.. autofunction:: register_ipc_tensor_reducer
-.. autofunction:: register_ipc_storage_check
-```

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -129,7 +129,7 @@ def send_tensor_with_untyped_storage(queue, event):
             ref_counter_offset,
             event_handle,
             event_sync_required,
-        ) = storage._share_cuda_()
+        ) = storage._share_ipc_()
         specs.append(
             {
                 "tensor_cls": type(tensor),
@@ -772,6 +772,7 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
 
         for p in processes.values():
             self.assertFalse(p.is_alive())
+            self.assertEqual(p.exitcode, 0)
 
     @slowTest
     @unittest.skipIf(not TEST_CUDA_IPC, "CUDA IPC not available")
@@ -889,6 +890,10 @@ if __name__ == "__main__":
 
     @unittest.skipIf(not TEST_CUDA_IPC, "CUDA IPC not available")
     def test_rebuild_cuda_tensor(self):
+        reduce_fn, rebuild_fn = mp.reductions._ipc_tensor_reduce_registry["cuda"]
+        self.assertIs(reduce_fn, mp.reductions.reduce_cuda_tensor)
+        self.assertIs(rebuild_fn, mp.reductions.rebuild_cuda_tensor)
+
         ctx = mp.get_context("spawn")
         queue = ctx.Queue()
         event = ctx.Event()
@@ -902,7 +907,7 @@ if __name__ == "__main__":
         specs = queue.get()
         tensors = []
         for spec in specs:
-            tensors.append(mp.reductions.rebuild_cuda_tensor(**spec))
+            tensors.append(rebuild_fn(**spec))
         self.assertEqual(tensors, [1, 1])
 
         del tensors, spec

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -7,7 +7,6 @@ import sys
 import time
 import unittest
 from sys import platform
-from unittest import mock
 
 import torch
 import torch.cuda
@@ -92,18 +91,6 @@ def simple_pool_fill(tensor):
 
 def raise_keyboard_interrupt(i):
     raise KeyboardInterrupt
-
-
-def _rebuild_registered_tensor(value):
-    return value
-
-
-def _reduce_registered_tensor(tensor):
-    return (_rebuild_registered_tensor, (tensor.numel(),))
-
-
-def _reduce_replacement_tensor(tensor):
-    return (_rebuild_registered_tensor, (tensor.numel() + 1,))
 
 
 def send_tensor(queue, event, device, dtype):
@@ -599,49 +586,6 @@ instantiate_device_type_tests(TestMultiprocessingDeviceType, globals())
     "TSAN is not fork-safe since we're forking in a multi-threaded environment",
 )
 class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
-    def test_register_ipc_tensor_reducer(self):
-        registry = mp.reductions._ipc_tensor_reduce_registry
-        with mock.patch.dict(registry, clear=True):
-            mp.reductions.register_ipc_tensor_reducer(
-                "cpu", _reduce_registered_tensor
-            )
-
-            self.assertEqual(
-                mp.reductions.reduction.ForkingPickler.loads(
-                    mp.reductions.reduction.ForkingPickler.dumps(torch.ones(3))
-                ),
-                3,
-            )
-            with self.assertWarnsRegex(UserWarning, "already registered"):
-                mp.reductions.register_ipc_tensor_reducer(
-                    "cpu:0", _reduce_replacement_tensor
-                )
-            self.assertEqual(
-                mp.reductions.reduction.ForkingPickler.loads(
-                    mp.reductions.reduction.ForkingPickler.dumps(torch.ones(3))
-                ),
-                4,
-            )
-
-    def test_register_ipc_storage_check(self):
-        storage = torch.ones(1).untyped_storage()
-        check_fn = mock.Mock(return_value=True)
-        registry = mp.reductions._ipc_storage_reduce_check_registry
-
-        with mock.patch.dict(registry, clear=True):
-            mp.reductions.register_ipc_storage_check("cpu", check_fn)
-
-            with self.assertRaisesRegex(RuntimeError, "Cannot pickle cpu storage"):
-                mp.reductions.reduction.ForkingPickler.dumps(storage)
-            check_fn.assert_called_once_with(storage)
-            replacement_check = mock.Mock(return_value=False)
-            with self.assertWarnsRegex(UserWarning, "already registered"):
-                mp.reductions.register_ipc_storage_check(
-                    "cpu:0", replacement_check
-                )
-            mp.reductions.reduction.ForkingPickler.dumps(storage)
-            replacement_check.assert_called_once_with(storage)
-
     def tearDown(self):
         if torch.cuda.is_available():
             torch.cuda.ipc_collect()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -7,6 +7,7 @@ import sys
 import time
 import unittest
 from sys import platform
+from unittest import mock
 
 import torch
 import torch.cuda
@@ -91,6 +92,14 @@ def simple_pool_fill(tensor):
 
 def raise_keyboard_interrupt(i):
     raise KeyboardInterrupt
+
+
+def _rebuild_registered_tensor(value):
+    return value
+
+
+def _reduce_registered_tensor(tensor):
+    return (_rebuild_registered_tensor, (tensor.numel(),))
 
 
 def send_tensor(queue, event, device, dtype):
@@ -586,6 +595,38 @@ instantiate_device_type_tests(TestMultiprocessingDeviceType, globals())
     "TSAN is not fork-safe since we're forking in a multi-threaded environment",
 )
 class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
+    def test_register_ipc_tensor_reducer(self):
+        registry = mp.reductions._ipc_tensor_reduce_registry
+        with mock.patch.dict(registry, clear=True):
+            mp.reductions.register_ipc_tensor_reducer(
+                "cpu", _reduce_registered_tensor
+            )
+
+            self.assertEqual(
+                mp.reductions.reduction.ForkingPickler.loads(
+                    mp.reductions.reduction.ForkingPickler.dumps(torch.ones(3))
+                ),
+                3,
+            )
+            with self.assertRaisesRegex(RuntimeError, "already been registered"):
+                mp.reductions.register_ipc_tensor_reducer(
+                    "cpu", _reduce_registered_tensor
+                )
+
+    def test_register_ipc_storage_check(self):
+        storage = torch.ones(1).untyped_storage()
+        check_fn = mock.Mock(return_value=True)
+        registry = mp.reductions._ipc_storage_reduce_check_registry
+
+        with mock.patch.dict(registry, clear=True):
+            mp.reductions.register_ipc_storage_check("cpu", check_fn)
+
+            with self.assertRaisesRegex(RuntimeError, "Cannot pickle cpu storage"):
+                mp.reductions.reduction.ForkingPickler.dumps(storage)
+            check_fn.assert_called_once_with(storage)
+            with self.assertRaisesRegex(RuntimeError, "already been registered"):
+                mp.reductions.register_ipc_storage_check("cpu", check_fn)
+
     def tearDown(self):
         if torch.cuda.is_available():
             torch.cuda.ipc_collect()

--- a/test/test_multiprocessing.py
+++ b/test/test_multiprocessing.py
@@ -102,6 +102,10 @@ def _reduce_registered_tensor(tensor):
     return (_rebuild_registered_tensor, (tensor.numel(),))
 
 
+def _reduce_replacement_tensor(tensor):
+    return (_rebuild_registered_tensor, (tensor.numel() + 1,))
+
+
 def send_tensor(queue, event, device, dtype):
     t = torch.ones(5, 5, device=device, dtype=dtype)
     queue.put(t)
@@ -608,10 +612,16 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
                 ),
                 3,
             )
-            with self.assertRaisesRegex(RuntimeError, "already been registered"):
+            with self.assertWarnsRegex(UserWarning, "already registered"):
                 mp.reductions.register_ipc_tensor_reducer(
-                    "cpu", _reduce_registered_tensor
+                    "cpu:0", _reduce_replacement_tensor
                 )
+            self.assertEqual(
+                mp.reductions.reduction.ForkingPickler.loads(
+                    mp.reductions.reduction.ForkingPickler.dumps(torch.ones(3))
+                ),
+                4,
+            )
 
     def test_register_ipc_storage_check(self):
         storage = torch.ones(1).untyped_storage()
@@ -624,8 +634,13 @@ class TestMultiprocessing(_MultiprocessingTestMixin, TestCase):
             with self.assertRaisesRegex(RuntimeError, "Cannot pickle cpu storage"):
                 mp.reductions.reduction.ForkingPickler.dumps(storage)
             check_fn.assert_called_once_with(storage)
-            with self.assertRaisesRegex(RuntimeError, "already been registered"):
-                mp.reductions.register_ipc_storage_check("cpu", check_fn)
+            replacement_check = mock.Mock(return_value=False)
+            with self.assertWarnsRegex(UserWarning, "already registered"):
+                mp.reductions.register_ipc_storage_check(
+                    "cpu:0", replacement_check
+                )
+            mp.reductions.reduction.ForkingPickler.dumps(storage)
+            replacement_check.assert_called_once_with(storage)
 
     def tearDown(self):
         if torch.cuda.is_available():

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -103,11 +103,6 @@ _ipc_storage_reduce_check_registry: dict[str, _Callable] = {}
 
 
 def register_ipc_tensor_reducer(device_type: str, reduce_fn: _Callable) -> None:
-    r"""Register an IPC tensor reducer for a device type.
-
-    The reducer must follow the :mod:`multiprocessing` reducer contract and
-    return a callable plus the arguments used to rebuild the tensor.
-    """
     device_type = torch.device(device_type).type
     if device_type in _ipc_tensor_reduce_registry:
         raise RuntimeError(
@@ -117,10 +112,6 @@ def register_ipc_tensor_reducer(device_type: str, reduce_fn: _Callable) -> None:
 
 
 def register_ipc_storage_check(device_type: str, check_fn: _Callable) -> None:
-    r"""Register a direct storage pickling check for a device type.
-
-    The check must return ``True`` when the storage must not be pickled directly.
-    """
     device_type = torch.device(device_type).type
     if device_type in _ipc_storage_reduce_check_registry:
         raise RuntimeError(

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -98,12 +98,13 @@ class SharedCache(dict):
 shared_cache = SharedCache()
 
 
-# Kept for BC only.
-_ipc_tensor_reduce_registry: dict[str, _Callable] = {}
+_ipc_tensor_reduce_registry: dict[str, tuple[_Callable, _Callable]] = {}
 _ipc_storage_reduce_check_registry: dict[str, _Callable] = {}
 
 
-def register_ipc_tensor_reducer(device_type: str, reduce_fn: _Callable) -> None:
+def register_ipc_tensor_reducer(
+    device_type: str, reduce_fn: _Callable, rebuild_fn: _Callable
+) -> None:
     device_type = torch.device(device_type).type
     if device_type in _ipc_tensor_reduce_registry:
         warnings.warn(
@@ -112,7 +113,7 @@ def register_ipc_tensor_reducer(device_type: str, reduce_fn: _Callable) -> None:
             UserWarning,
             stacklevel=2,
         )
-    _ipc_tensor_reduce_registry[device_type] = reduce_fn
+    _ipc_tensor_reduce_registry[device_type] = (reduce_fn, rebuild_fn)
 
 
 def register_ipc_storage_check(device_type: str, check_fn: _Callable) -> None:
@@ -126,6 +127,7 @@ def register_ipc_storage_check(device_type: str, check_fn: _Callable) -> None:
         )
     _ipc_storage_reduce_check_registry[device_type] = check_fn
 
+# Kept for BC only.
 def rebuild_event(device, handle):
     return torch.cuda.Event.from_ipc_handle(device, handle)
 
@@ -225,8 +227,8 @@ def rebuild_cuda_tensor(
             )
         else:
             # We already ref counting this Storage, but producer needs new ref-counters to be released.
-            storage_cls._release_ipc_counter(
-                ref_counter_handle, ref_counter_offset, device=storage_device
+            storage_cls._release_ipc_counter_cuda(
+                ref_counter_handle, ref_counter_offset
             )
 
     _storage = (
@@ -250,6 +252,44 @@ def rebuild_cuda_tensor(
         t.requires_grad = requires_grad
 
     return t
+
+
+def reduce_cuda_tensor(tensor):
+    storage = tensor._typed_storage()
+    (
+        device,
+        handle,
+        storage_size_bytes,
+        storage_offset_bytes,
+        ref_counter_handle,
+        ref_counter_offset,
+        event_handle,
+        event_sync_required,
+    ) = storage._share_cuda_()
+    tensor_offset = tensor.storage_offset()
+    shared_cache[handle] = StorageWeakRef(storage)
+    # _backward_hooks purposely omitted here, see
+    # Note [Don't serialize hooks]
+    return (
+        rebuild_cuda_tensor,
+        (
+            type(tensor),
+            tensor.size(),
+            tensor.stride(),
+            tensor_offset,  # tensor offset in its storage
+            type(storage),
+            tensor.dtype,
+            device,
+            handle,  # identifier which CUDA allocation is the storage in.
+            storage_size_bytes,  # size(in bytes) of the storage
+            storage_offset_bytes,  # offset(in bytes) of the storage in the CUDA allocation
+            tensor.requires_grad,
+            ref_counter_handle,
+            ref_counter_offset,
+            event_handle,
+            event_sync_required,
+        ),
+    )
 
 
 def reduce_tensor(tensor):
@@ -373,46 +413,12 @@ def reduce_tensor(tensor):
     storage = tensor._typed_storage()
 
     device_type = storage._untyped_storage.device.type
-    reduce_fn = _ipc_tensor_reduce_registry.get(device_type)
-    if reduce_fn is not None:
+    reducer = _ipc_tensor_reduce_registry.get(device_type)
+    if reducer is not None:
+        reduce_fn, _ = reducer
         return reduce_fn(tensor)
 
-    if device_type == "cuda":
-        (
-            device,
-            handle,
-            storage_size_bytes,
-            storage_offset_bytes,
-            ref_counter_handle,
-            ref_counter_offset,
-            event_handle,
-            event_sync_required,
-        ) = storage._share_cuda_()
-        tensor_offset = tensor.storage_offset()
-        shared_cache[handle] = StorageWeakRef(storage)
-        # _backward_hooks purposely omitted here, see
-        # Note [Don't serialize hooks]
-        return (
-            rebuild_cuda_tensor,
-            (
-                type(tensor),
-                tensor.size(),
-                tensor.stride(),
-                tensor_offset,  # tensor offset in its storage
-                type(storage),
-                tensor.dtype,
-                device,
-                handle,  # identifier which CUDA allocation is the storage in.
-                storage_size_bytes,  # size(in bytes) of the storage
-                storage_offset_bytes,  # offset(in bytes) of the storage in the CUDA allocation
-                tensor.requires_grad,
-                ref_counter_handle,
-                ref_counter_offset,
-                event_handle,
-                event_sync_required,
-            ),
-        )
-    elif device_type == "meta":
+    if device_type == "meta":
         return (
             rebuild_meta_tensor,
             (
@@ -637,11 +643,7 @@ def reduce_storage(storage):
             f"try pickling a {device_type} tensor instead"
         )
 
-    if storage.is_cuda:
-        raise RuntimeError(
-            "Cannot pickle CUDA storage; try pickling a CUDA tensor instead"
-        )
-    elif storage.device.type == "meta":
+    if storage.device.type == "meta":
         raise RuntimeError(
             "Cannot pickle meta storage; try pickling a meta tensor instead"
         )
@@ -668,6 +670,12 @@ def reduce_storage(storage):
 
 
 def init_reductions():
+    torch.UntypedStorage._share_ipc_ = torch.UntypedStorage._share_cuda_
+    torch.UntypedStorage._new_shared_ipc = torch.UntypedStorage._new_shared_cuda
+    torch.UntypedStorage._release_ipc_counter = torch.UntypedStorage._release_ipc_counter_cuda
+    register_ipc_tensor_reducer("cuda", reduce_cuda_tensor, rebuild_cuda_tensor)
+    register_ipc_storage_check("cuda", lambda storage: storage.is_cuda)
+
     ipc_event_classes = [torch.cuda.Event, torch.xpu.Event]
     for event_cls in ipc_event_classes:
         reduction.register(event_cls, _reduce_event)

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -127,6 +127,7 @@ def register_ipc_storage_check(device_type: str, check_fn: _Callable) -> None:
         )
     _ipc_storage_reduce_check_registry[device_type] = check_fn
 
+
 # Kept for BC only.
 def rebuild_event(device, handle):
     return torch.cuda.Event.from_ipc_handle(device, handle)
@@ -212,7 +213,7 @@ def rebuild_cuda_tensor(
         )
         if storage is None:
             torch.cuda._lazy_init()
-            storage = storage_cls._new_shared_cuda(
+            storage = storage_cls._new_shared_ipc(
                 storage_device,
                 storage_handle,
                 storage_size_bytes,
@@ -227,9 +228,7 @@ def rebuild_cuda_tensor(
             )
         else:
             # We already ref counting this Storage, but producer needs new ref-counters to be released.
-            storage_cls._release_ipc_counter_cuda(
-                ref_counter_handle, ref_counter_offset
-            )
+            storage_cls._release_ipc_counter(ref_counter_handle, ref_counter_offset)
 
     _storage = (
         storage
@@ -265,7 +264,7 @@ def reduce_cuda_tensor(tensor):
         ref_counter_offset,
         event_handle,
         event_sync_required,
-    ) = storage._share_cuda_()
+    ) = storage._share_ipc_()
     tensor_offset = tensor.storage_offset()
     shared_cache[handle] = StorageWeakRef(storage)
     # _backward_hooks purposely omitted here, see
@@ -672,7 +671,9 @@ def reduce_storage(storage):
 def init_reductions():
     torch.UntypedStorage._share_ipc_ = torch.UntypedStorage._share_cuda_
     torch.UntypedStorage._new_shared_ipc = torch.UntypedStorage._new_shared_cuda
-    torch.UntypedStorage._release_ipc_counter = torch.UntypedStorage._release_ipc_counter_cuda
+    torch.UntypedStorage._release_ipc_counter = (
+        torch.UntypedStorage._release_ipc_counter_cuda
+    )
     register_ipc_tensor_reducer("cuda", reduce_cuda_tensor, rebuild_cuda_tensor)
     register_ipc_storage_check("cuda", lambda storage: storage.is_cuda)
 

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -2,6 +2,7 @@
 import multiprocessing
 import os
 import threading
+import warnings
 from collections.abc import Callable as _Callable
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
@@ -105,8 +106,11 @@ _ipc_storage_reduce_check_registry: dict[str, _Callable] = {}
 def register_ipc_tensor_reducer(device_type: str, reduce_fn: _Callable) -> None:
     device_type = torch.device(device_type).type
     if device_type in _ipc_tensor_reduce_registry:
-        raise RuntimeError(
-            f"An IPC tensor reducer for '{device_type}' has already been registered"
+        warnings.warn(
+            f"An IPC tensor reducer for '{device_type}' is already registered. "
+            "Overwriting it with the new reducer.",
+            UserWarning,
+            stacklevel=2,
         )
     _ipc_tensor_reduce_registry[device_type] = reduce_fn
 
@@ -114,8 +118,11 @@ def register_ipc_tensor_reducer(device_type: str, reduce_fn: _Callable) -> None:
 def register_ipc_storage_check(device_type: str, check_fn: _Callable) -> None:
     device_type = torch.device(device_type).type
     if device_type in _ipc_storage_reduce_check_registry:
-        raise RuntimeError(
-            f"An IPC storage check for '{device_type}' has already been registered"
+        warnings.warn(
+            f"An IPC storage check for '{device_type}' is already registered. "
+            "Overwriting it with the new check.",
+            UserWarning,
+            stacklevel=2,
         )
     _ipc_storage_reduce_check_registry[device_type] = check_fn
 

--- a/torch/multiprocessing/reductions.py
+++ b/torch/multiprocessing/reductions.py
@@ -2,6 +2,7 @@
 import multiprocessing
 import os
 import threading
+from collections.abc import Callable as _Callable
 from multiprocessing import reduction
 from multiprocessing.util import register_after_fork
 
@@ -97,6 +98,36 @@ shared_cache = SharedCache()
 
 
 # Kept for BC only.
+_ipc_tensor_reduce_registry: dict[str, _Callable] = {}
+_ipc_storage_reduce_check_registry: dict[str, _Callable] = {}
+
+
+def register_ipc_tensor_reducer(device_type: str, reduce_fn: _Callable) -> None:
+    r"""Register an IPC tensor reducer for a device type.
+
+    The reducer must follow the :mod:`multiprocessing` reducer contract and
+    return a callable plus the arguments used to rebuild the tensor.
+    """
+    device_type = torch.device(device_type).type
+    if device_type in _ipc_tensor_reduce_registry:
+        raise RuntimeError(
+            f"An IPC tensor reducer for '{device_type}' has already been registered"
+        )
+    _ipc_tensor_reduce_registry[device_type] = reduce_fn
+
+
+def register_ipc_storage_check(device_type: str, check_fn: _Callable) -> None:
+    r"""Register a direct storage pickling check for a device type.
+
+    The check must return ``True`` when the storage must not be pickled directly.
+    """
+    device_type = torch.device(device_type).type
+    if device_type in _ipc_storage_reduce_check_registry:
+        raise RuntimeError(
+            f"An IPC storage check for '{device_type}' has already been registered"
+        )
+    _ipc_storage_reduce_check_registry[device_type] = check_fn
+
 def rebuild_event(device, handle):
     return torch.cuda.Event.from_ipc_handle(device, handle)
 
@@ -343,7 +374,12 @@ def reduce_tensor(tensor):
 
     storage = tensor._typed_storage()
 
-    if storage._untyped_storage.device.type == "cuda":
+    device_type = storage._untyped_storage.device.type
+    reduce_fn = _ipc_tensor_reduce_registry.get(device_type)
+    if reduce_fn is not None:
+        return reduce_fn(tensor)
+
+    if device_type == "cuda":
         (
             device,
             handle,
@@ -378,7 +414,7 @@ def reduce_tensor(tensor):
                 event_sync_required,
             ),
         )
-    elif storage._untyped_storage.device.type == "meta":
+    elif device_type == "meta":
         return (
             rebuild_meta_tensor,
             (
@@ -594,6 +630,14 @@ def reduce_typed_storage_child(storage):
 
 def reduce_storage(storage):
     from . import get_sharing_strategy
+
+    device_type = storage.device.type
+    check_fn = _ipc_storage_reduce_check_registry.get(device_type)
+    if check_fn is not None and check_fn(storage):
+        raise RuntimeError(
+            f"Cannot pickle {device_type} storage; "
+            f"try pickling a {device_type} tensor instead"
+        )
 
     if storage.is_cuda:
         raise RuntimeError(

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -137,6 +137,9 @@ class _StorageBase:
     def _share_fd_cpu_(self, *args, **kwargs):
         raise NotImplementedError
 
+    def _share_ipc_(self, *args, **kwargs):
+        raise NotImplementedError
+
     @classmethod
     def _new_using_filename_cpu(cls, size: _int) -> Self:
         raise NotImplementedError
@@ -162,8 +165,8 @@ class _StorageBase:
         raise NotImplementedError
 
     @classmethod
-    def _release_ipc_counter(cls, *args, device=None, **kwargs):
-        return cls._release_ipc_counter_cuda(*args, **kwargs)
+    def _release_ipc_counter(cls, *args, **kwargs) -> Self:
+        raise NotImplementedError
 
     @classmethod
     def _release_ipc_counter_cuda(cls, *args, **kwargs) -> Self:
@@ -199,6 +202,10 @@ class _StorageBase:
 
     @classmethod
     def _new_shared_cuda(cls, *args, **kwargs) -> Self:
+        raise NotImplementedError
+
+    @classmethod
+    def _new_shared_ipc(cls, *args, **kwargs) -> Self:
         raise NotImplementedError
 
     def _shared_incref(self, *args, **kwargs):
@@ -1461,6 +1468,9 @@ class TypedStorage:
     def _share_cuda_(self, *args, **kwargs):
         return self._untyped_storage._share_cuda_(*args, **kwargs)
 
+    def _share_ipc_(self, *args, **kwargs):
+        return self._untyped_storage._share_ipc_(*args, **kwargs)
+
     def is_shared(self):
         _warn_typed_storage_removal()
         return self._is_shared()
@@ -1472,6 +1482,10 @@ class TypedStorage:
     @classmethod
     def _new_shared_cuda(cls, *args, **kwargs):
         return torch.UntypedStorage._new_shared_cuda(*args, **kwargs)
+
+    @classmethod
+    def _new_shared_ipc(cls, *args, **kwargs):
+        return torch.UntypedStorage._new_shared_ipc(*args, **kwargs)
 
     def _share_filename_cpu_(self, *args, **kwargs):
         (
@@ -1486,8 +1500,8 @@ class TypedStorage:
         return self
 
     @classmethod
-    def _release_ipc_counter(cls, *args, device=None, **kwargs):
-        return torch.UntypedStorage._release_ipc_counter_cuda(*args, **kwargs)
+    def _release_ipc_counter(cls, *args, **kwargs):
+        return torch.UntypedStorage._release_ipc_counter(*args, **kwargs)
 
     def _shared_incref(self, *args, **kwargs):
         return self._untyped_storage._shared_incref(*args, **kwargs)
@@ -1547,7 +1561,7 @@ class _LegacyStorage(TypedStorage, metaclass=_LegacyStorageMeta):
 
     @classmethod
     def _release_ipc_counter(cls, *args, **kwargs):
-        return torch.UntypedStorage._release_ipc_counter_cuda(*args, **kwargs)
+        return torch.UntypedStorage._release_ipc_counter(*args, **kwargs)
 
     @classmethod
     def _new_shared_filename(cls, manager, obj, size):


### PR DESCRIPTION
## Summary

- Add registration APIs for device-specific IPC tensor reducers and storage checks.
- Route CUDA tensor and storage IPC through the registry instead of hardcoded branches.
- Add unified storage IPC methods while keeping the existing CUDA methods available.
- Keep existing CPU and meta behavior unchanged.

Related RFC: https://github.com/pytorch/pytorch/issues/195964

## Testing

- `PYTORCH_TEST_WITH_SLOW=1 python test/test_multiprocessing.py -v` on Linux with PyTorch `2.15.0.dev20260828+cu132`, CUDA 13.2, and NVIDIA A100 GPUs: 50 tests run, 48 passed, 2 expected skips.
- `python -m compileall -q torch/multiprocessing/reductions.py torch/storage.py test/test_multiprocessing.py`
- `git diff --check upstream/main...HEAD`
- Validated the corresponding torch_npu registration path on Linux AArch64 with eight NPUs, including Tensor, Storage, Event, Queue/Pool, DataLoader, and two-device DDP.



cc @VitalyFedyunin @albanD @pragupta @ppwwyyxx