### PR TITLE
[checkpoint] Fix order-dependent CUDA-only tie-break in _infer_device_type

### DIFF
--- a/torch/utils/checkpoint.py
+++ b/torch/utils/checkpoint.py
@@ -152,14 +152,16 @@ def _infer_device_type(*args):
             "Tensor arguments, excluding CPU tensors, are detected on at least two types of devices. "
             "Device state will only be saved for devices of a single device type, and the remaining "
             "devices will be ignored. Consequently, if any checkpointed functions involve randomness, "
-            "this may result in incorrect gradients. (Note that if CUDA devices are among the devices "
-            "detected, it will be prioritized; otherwise, the first device encountered will be selected.)"
+            "this may result in incorrect gradients. (Note that if the current accelerator's device type "
+            "is among the devices detected, it will be prioritized; otherwise, the first device encountered "
+            "will be selected.)"
             f"\nDevice types: {sorted(device_types_set)} first device type: {device_types[0]}", stacklevel=2
         )
     if len(device_types) == 0:
         return DefaultDeviceType.get_device_type()
-    elif "cuda" in device_types_set:
-        return "cuda"
+    acc_type = torch._C._get_accelerator(False).type
+    if acc_type in device_types_set:
+        return acc_type
     else:
         return device_types[0]
 


### PR DESCRIPTION
## Summary

`_infer_device_type` in `torch/utils/checkpoint.py` decides which
device's RNG state `checkpoint()` should save/restore for recomputation
when a checkpointed region's inputs span more than one non-CPU device
type. It hardcoded a tie-break of `"cuda"`, so any other accelerator
(XPU, NPU, MPS, ...) only got picked correctly by the accident of
appearing first in pytree traversal order.

This isn't just a coupling cleanup: the "multiple device types" case
doesn't require two real accelerators (PyTorch enforces that only one
can be compiled into a build at a time) -- it also fires whenever an
accelerator tensor is mixed with a `meta` tensor, which is common (shape
inference, fake tensors). On any non-CUDA accelerator, the old fallback
to `device_types[0]` made the result depend on argument order:

    mps_t, meta_t = torch.rand(4, device="mps"), torch.rand(4, device="meta")
    old_infer_device_type(mps_t, meta_t)   # -> "mps"  (correct, by luck)
    old_infer_device_type(meta_t, mps_t)   # -> "meta" (wrong)

When the non-accelerator tensor came first, `_infer_device_type`
returned `"meta"`, and `get_device_states`/`set_device_states` would
save/restore RNG state for a device that isn't real -- silently
defeating the RNG preservation the function exists for, i.e. exactly the
"incorrect gradients" failure mode its own warning describes.

This replaces the hardcoded `"cuda"` check with
`torch._C._get_accelerator(False)`, the existing generic primitive for
"which accelerator is registered in this build." The new tie-break is
order-independent and correct for every accelerator, not just CUDA.

Separately, in the narrow PrivateUse1-alongside-a-built-in-accelerator
testing configuration (explicitly supported at the ATen level), the
tie-break now matches `at::getAccelerator`'s own priority (PrivateUse1
first) instead of always picking CUDA; no test in this repo currently
exercises that combination.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Reconstructed the old logic locally (macOS, MPS) and confirmed the
order-dependent bug and its fix:

    python3 -c "
    import torch
    from torch.utils.checkpoint import _infer_device_type
    mps_t = torch.rand(4, device='mps')
    meta_t = torch.rand(4, device='meta')
    print(_infer_device_type(mps_t, meta_t))   # mps
    print(_infer_device_type(meta_t, mps_t))   # mps (was 'meta' before this fix)
    "

Verified on real NPU hardware with a standalone comparison script that runs the old and
new logic side by side plus an end-to-end `checkpoint()` + dropout RNG
round trip; confirmed `torch._C._get_accelerator(False)` resolves to
`npu` and `grad_with_checkpointing == grad_no_checkpointing`.

`lintrunner -a torch/utils/checkpoint.py` reports no lint issues.

Existing `test/test_utils.py::TestCheckpointDeviceType` tests
(`test_infer_device_state_recursive_multi_device`,
`test_get_device_states_recursive`), which are `@onlyAccelerator`,
exercise this same code path for whatever accelerator the CI machine has
and were not modified.
