### PR TITLE
[dynamo][fx] Support SwizzleType/ScalingType (pybind11 enums) as tensor subclass constructor args in torch.compile

### DIFF
--- a/test/dynamo/test_enum.py
+++ b/test/dynamo/test_enum.py
@@ -693,6 +693,89 @@ class EnumTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(ref, res)
 
 
+    def test_pybind11_enum_swizzle_type_as_tensor_subclass_arg(self):
+        """Test pybind11 enum passed as arg to tensor subclass constructor under torch.compile."""
+        from torch.nn.functional import SwizzleType
+
+        class EnumSubclass(torch.Tensor):
+            @staticmethod
+            def __new__(cls, data, enum_val):
+                return torch.Tensor._make_wrapper_subclass(
+                    cls, data.shape, dtype=data.dtype, device=data.device
+                )
+
+            def __init__(self, data, enum_val):
+                self._data = data
+                self._enum_val = enum_val
+
+            def __tensor_flatten__(self):
+                return ["_data"], {"enum_val": self._enum_val}
+
+            @classmethod
+            def __tensor_unflatten__(cls, tensor_dict, metadata, outer_size, outer_stride):
+                return cls(tensor_dict["_data"], metadata["enum_val"])
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args, kwargs):
+                def unwrap(a):
+                    return a._data if isinstance(a, cls) else a
+                return func(
+                    *torch.utils._pytree.tree_map(unwrap, args),
+                    **torch.utils._pytree.tree_map(unwrap, kwargs or {}),
+                )
+
+        def fn(x):
+            return EnumSubclass(x * 2, SwizzleType.NO_SWIZZLE)
+
+        x = torch.randn(4, 4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        result = compiled(x)
+        self.assertIsInstance(result, EnumSubclass)
+        self.assertEqual(result._enum_val, SwizzleType.NO_SWIZZLE)
+        self.assertEqual(result._data, x * 2)
+
+    def test_pybind11_enum_scaling_type_as_tensor_subclass_arg(self):
+        """Test ScalingType pybind11 enum as tensor subclass constructor arg under torch.compile."""
+        from torch.nn.functional import ScalingType
+
+        class EnumSubclass(torch.Tensor):
+            @staticmethod
+            def __new__(cls, data, enum_val):
+                return torch.Tensor._make_wrapper_subclass(
+                    cls, data.shape, dtype=data.dtype, device=data.device
+                )
+
+            def __init__(self, data, enum_val):
+                self._data = data
+                self._enum_val = enum_val
+
+            def __tensor_flatten__(self):
+                return ["_data"], {"enum_val": self._enum_val}
+
+            @classmethod
+            def __tensor_unflatten__(cls, tensor_dict, metadata, outer_size, outer_stride):
+                return cls(tensor_dict["_data"], metadata["enum_val"])
+
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args, kwargs):
+                def unwrap(a):
+                    return a._data if isinstance(a, cls) else a
+                return func(
+                    *torch.utils._pytree.tree_map(unwrap, args),
+                    **torch.utils._pytree.tree_map(unwrap, kwargs or {}),
+                )
+
+        def fn(x):
+            return EnumSubclass(x * 2, ScalingType.TensorWise)
+
+        x = torch.randn(4, 4)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        result = compiled(x)
+        self.assertIsInstance(result, EnumSubclass)
+        self.assertEqual(result._enum_val, ScalingType.TensorWise)
+        self.assertEqual(result._data, x * 2)
+
+
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests
 

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1881,9 +1881,13 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         return super().as_python_constant()
 
     def as_proxy(self) -> object:
+        from ..utils import is_pybind11_enum_member
+
         if isinstance(self.value, enum.Enum):
             if isinstance(self.value, int):
                 return int(self.value)
+            return self.value
+        if is_pybind11_enum_member(self.value):
             return self.value
         return super().as_proxy()
 

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -34,6 +34,7 @@ from .immutable_collections import immutable_dict
 from .node import (
     _device_annotation,
     _get_qualified_name,
+    _is_pybind11_enum_member,
     _type_repr,
     Argument,
     Node,
@@ -625,6 +626,10 @@ class CodeGen:
                 cls = arg.__class__
                 clsname = add_global(cls.__name__, cls)
                 return f"{clsname}.{arg.name}"
+            elif _is_pybind11_enum_member(arg):
+                cls = arg.__class__
+                clsname = add_global(cls.__name__, cls)
+                return f"{clsname}.{arg.name}"  # pyrefly: ignore[missing-attribute]
             elif isinstance(arg, complex):
                 if (
                     arg.real == 0.0

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -47,6 +47,17 @@ BaseArgumentTypes = Union[  # noqa: UP007
 ]
 base_types = typing.get_args(BaseArgumentTypes)
 
+
+def _is_pybind11_enum_member(value: object) -> bool:
+    """Check if value is a pybind11 enum member (not a Python enum.Enum)."""
+    t = type(value)
+    members = getattr(t, "__members__", None)
+    if members is None:
+        return False
+    name = getattr(value, "name", None)
+    return name is not None and name in members
+
+
 Target: TypeAlias = Callable[..., Any] | str
 
 Argument = Optional[  # noqa: UP045

--- a/torch/fx/proxy.py
+++ b/torch/fx/proxy.py
@@ -25,7 +25,7 @@ from torch.utils._traceback import CapturedTraceback
 from ._compatibility import compatibility
 from .graph import Graph, magic_methods, reflectable_magic_methods
 from .immutable_collections import immutable_dict, immutable_list
-from .node import Argument, base_types, Node, Target
+from .node import Argument, base_types, Node, Target, _is_pybind11_enum_member
 from .operator_schemas import check_for_mutable_operation
 
 
@@ -478,6 +478,9 @@ class TracerBase:
             return self.create_node("call_function", a.__class__, (), kwargs)
 
         elif isinstance(a, (*base_types, enum.Enum)) or a is None or a is ...:
+            return a  # pyrefly: ignore[bad-return]
+
+        elif _is_pybind11_enum_member(a):
             return a  # pyrefly: ignore[bad-return]
 
         raise NotImplementedError(f"argument of type: {type(a)}")


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/194569

## Problem

When a pybind11 enum (e.g. `SwizzleType`, `ScalingType`) is passed as an
argument to a traceable tensor subclass constructor during `torch.compile`
tracing, three things fail because all existing checks use
`isinstance(value, enum.Enum)`, and pybind11 enums are **not** Python
`enum.Enum` subclasses:

1. `UserDefinedObjectVariable.as_proxy()` raises `NotImplementedError` →
   graph break.
2. `Tracer.create_arg()` in `torch/fx/proxy.py` rejects the enum as an
   unknown argument type.
3. `Graph._get_repr()` in `torch/fx/graph.py` falls back to `repr()`,
   producing `<_SwizzleType.NO_SWIZZLE: 0>` — invalid Python syntax that
   causes a `SyntaxError` when the generated FX graph code is compiled.

## Solution

Add pybind11 enum handling at each of the three failure points, using a shared
`_is_pybind11_enum_member()` helper placed in `torch/fx/node.py` (to avoid
circular imports between `proxy.py` and `graph.py`). The helper detects
pybind11 enums by checking for the `__members__` dict on the type — the same
approach used by `torch._dynamo.utils.is_pybind11_enum_member()`.

**Changes:**

- **`torch/fx/node.py`** — Add `_is_pybind11_enum_member()` helper.
- **`torch/_dynamo/variables/user_defined.py`** — `as_proxy()` now returns
  the raw value for pybind11 enums, matching the existing `enum.Enum` branch.
- **`torch/fx/proxy.py`** — `create_arg()` accepts pybind11 enums as valid
  constant arguments.
- **`torch/fx/graph.py`** — `_get_repr()` generates `ClassName.member_name`
  for pybind11 enums instead of falling back to invalid `repr()`.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98