### PR TITLE
Don't keep a second copy of the model in the performance path

### DIFF
--- a/benchmarks/dynamo/common.py
+++ b/benchmarks/dynamo/common.py
@@ -2814,7 +2814,8 @@ class BenchmarkRunner:
         model, example_inputs = self.maybe_cast(model, example_inputs)
 
         # Use distributed wrapping as necessary
-        model = self.deepcopy_and_maybe_parallelize(model)
+        if self.args.ddp or self.args.fsdp:
+            model = self.deepcopy_and_maybe_parallelize(model)
 
         if not hasattr(model, name):
             model.name = name
@@ -2995,7 +2996,8 @@ class BenchmarkRunner:
         model, example_inputs = self.maybe_cast(model, example_inputs)
 
         # Use distributed wrapping as necessary
-        model = self.deepcopy_and_maybe_parallelize(model)
+        if self.args.ddp or self.args.fsdp:
+            model = self.deepcopy_and_maybe_parallelize(model)
 
         if not hasattr(model, name):
             model.name = name


### PR DESCRIPTION
Don't keep a second copy of the model in the performance path

Problem: https://github.com/intel/torch-xpu-ops/issues/4928 - huggingface DebertaV2ForQuestionAnswering, inference, amp fp16, batch size 2 regressed by +10898% on the eager iteration on an Arc B580 (11876 MB), while inductor stayed flat. More generally, every performance run of the dynamo benchmarks holds two full copies of the model resident.

Root cause: run_performance_test() and run_performance_test_non_alternate() begin with 'model = self.deepcopy_and_maybe_parallelize(model)', which rebinds a local while run_one_model() and run()'s model loop still hold the original, so both copies stay live for the whole measurement - 2 x 3347MB for this model.
That leaves the caching allocator no headroom: it reservers ~12GB on a 11876MB card, and Windows satisfies allocations beyond device capacity from host memory instead of failing, so buffers that land there are read over the host bus at ~4-7GB/s instead of ~370GB/s. The copy serves no purpose on that path: deepcopy_and_maybe_parallelize() only deepcopies unless --ddp/--fsdp is given; it cannot isolate the caller, because maybe_cast() has already covered the module in place before the copy is taken.

Fix: take the copy only when there is something to wrap

Validation: Arc B580, Windows 11, pytorch https://github.com/pytorch/pytorch/commit/d864943a877d29ac551ac02bab5db080a551bb7f; python benchmarks/dynamo/huggingface.py --performance --amp -d xpu -n10 --amp-dtype float16 --inference --backend=<eager/inductor> --cold-start-latency --disable-cudagraphs --batch size 2 --only <model>:
speedup ratio - eager / inductor
* DebertaV2ForQuestionAnswering: speedup 33.18 -> 1.48 (ratio collapses by 22x). Allocated 6695 -> 3347MB, reserved 11956 -> 8510 MB, device free 2 -> 2849 MB, with per-iteration traffic unchanged (1088 allocations, 7.06 GB)
* other models are unaffected: BertForMaskedLM 1.46, DistilBertForMaskedLM 1.37, GoogleFnet 1.41
* --accuracy unaffected: DebertaV2ForQuestionAnswering pass, BertForMaskedLM pass
* --training works, where the optimizer attaches to the model DistilBertForMaskedLM speedup ratio 1.28
* the second call site was exercised via 'python -m benchmarks.dynamo.huggingface --optimus vertical_opt ... --only DistilBertForMaskedLM', which routes to run_performance_test_non_alternate(): exit 0, speedup 0.93

Fixes: https://github.com/intel/torch-xpu-ops/issues/4928