### PR TITLE
Address FlyDSL grouped MM review feedback

### DIFF
--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -40,6 +40,69 @@ class _CacheParam:
 
 @instantiate_parametrized_tests
 class TestFlyDSLTemplate(TestCase):
+    def _grouped_gemm_grid_param_stub(self, **overrides):
+        defaults = {
+            "stages": 2,
+            "block_m": 64,
+            "block_n": 128,
+            "block_k": 64,
+            "in_data_bytes": 2,
+            "out_data_bytes": 2,
+            "block_threads": 256,
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _gfx950_device_stub(self, **overrides):
+        defaults = {
+            "multi_processor_count": 304,
+            "shared_memory_per_multiprocessor": 163840,
+            "max_threads_per_multi_processor": 2048,
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def _expected_grouped_gemm_persistent_grid_size(
+        self, param, total_m, n, group_count, device_properties
+    ):
+        if total_m <= 0 or n <= 0 or group_count <= 0:
+            return 1
+
+        smem_bytes = (
+            param.stages
+            * (param.block_m + param.block_n)
+            * param.block_k
+            * param.in_data_bytes
+        )
+        smem_bytes = max(
+            smem_bytes, param.block_m * param.block_n * param.out_data_bytes
+        )
+        resource_blocks_per_cu = min(
+            max(device_properties.shared_memory_per_multiprocessor // smem_bytes, 1),
+            max(
+                device_properties.max_threads_per_multi_processor
+                // param.block_threads,
+                1,
+            ),
+        )
+        light_tile = param.block_m <= 64 and param.block_n <= 128
+        n_tiles = (n - 1) // param.block_n + 1
+        if light_tile:
+            blocks_per_cu = min(1 << (resource_blocks_per_cu.bit_length() - 1), 8)
+        else:
+            blocks_per_cu = 2 if resource_blocks_per_cu >= 2 else 1
+        nonempty_groups_upper = min(group_count, total_m)
+        m_tiles_upper = (
+            nonempty_groups_upper + (total_m - nonempty_groups_upper) // param.block_m
+        )
+        return max(
+            1,
+            min(
+                device_properties.multi_processor_count * blocks_per_cu,
+                m_tiles_upper * n_tiles,
+            ),
+        )
+
     def setUp(self):
         super().setUp()
         flydsl_utils._check_runtime_available.cache_clear()
@@ -376,7 +439,7 @@ class TestFlyDSLTemplate(TestCase):
             ),
             mock.patch.object(mm_grouped, "is_unaligned", return_value=False),
         ):
-            flydsl_configs = mm_grouped.get_flydsl_grouped_mm_template_kwargs(
+            supported = mm_grouped.use_flydsl_grouped_mm_template(
                 mat_a,
                 mat_b,
                 layout,
@@ -385,8 +448,9 @@ class TestFlyDSLTemplate(TestCase):
                 offs=object(),
                 bias=None,
                 is_nonzero=True,
+                scaled=False,
             )
-        self.assertFalse(flydsl_configs)
+        self.assertFalse(supported)
 
     def test_compiled_cache_keys_on_device_and_param(self):
         jit_func = SimpleNamespace()
@@ -696,6 +760,98 @@ class TestFlyDSLTemplate(TestCase):
         self.assertEqual(valid, expected)
 
     @parametrize(
+        "total_m,n,group_count,param_overrides,device_overrides,expected",
+        [
+            (0, 128, 6, {}, {}, 1),
+            (201, 0, 6, {}, {}, 1),
+            (201, 128, 0, {}, {}, 1),
+            (
+                201,
+                128,
+                6,
+                {},
+                {},
+                9,
+            ),
+            (
+                201,
+                128,
+                6,
+                {"block_m": 128, "block_n": 128, "block_threads": 256},
+                {},
+                7,
+            ),
+            (
+                32,
+                128,
+                1,
+                {},
+                {},
+                1,
+            ),
+            (
+                10000,
+                256,
+                100,
+                {},
+                {"multi_processor_count": 10},
+                20,
+            ),
+            (
+                201,
+                128,
+                6,
+                {},
+                {
+                    "shared_memory_per_multiprocessor": 327680,
+                    "max_threads_per_multi_processor": 4096,
+                },
+                9,
+            ),
+        ],
+    )
+    def test_flydsl_grouped_gemm_persistent_grid_size(
+        self,
+        total_m,
+        n,
+        group_count,
+        param_overrides,
+        device_overrides,
+        expected,
+    ):
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels.grouped_gemm_gfx950 import (
+            get_grouped_gemm_persistent_grid_size,
+        )
+
+        param = self._grouped_gemm_grid_param_stub(**param_overrides)
+        device = self._gfx950_device_stub(**device_overrides)
+        grid_size = get_grouped_gemm_persistent_grid_size(
+            param, total_m, n, group_count, device
+        )
+        self.assertEqual(grid_size, expected)
+        self.assertEqual(
+            grid_size,
+            self._expected_grouped_gemm_persistent_grid_size(
+                param, total_m, n, group_count, device
+            ),
+        )
+
+    def _meta_fp16_grouped_mm_inputs(self, n: int = 128):
+        mat_a = torch.empty(96, 128, device="meta", dtype=torch.float16)
+        mat_b = torch.empty(2, 128, n, device="meta", dtype=torch.float16)
+        offs = torch.empty(2, device="meta", dtype=torch.int32)
+        return mat_a, mat_b, offs
+
+    @parametrize("n", (96, 128))
+    def test_grouped_mm_fp16_meta_shape_inference(self, n):
+        from torch._meta_registrations import meta_grouped_mm
+
+        mat_a, mat_b, offs = self._meta_fp16_grouped_mm_inputs(n=n)
+        out = meta_grouped_mm(mat_a, mat_b, offs)
+        self.assertEqual(out.dtype, torch.float16)
+        self.assertEqual(out.shape, (96, n))
+
+    @parametrize(
         "dtype,k,n",
         [
             (torch.bfloat16, 128, 128),
@@ -873,6 +1029,95 @@ class TestFlyDSLTemplate(TestCase):
     @unittest.skipIf(torch.version.hip is None, "requires ROCm")
     @torch._inductor.config.patch(
         max_autotune_gemm=True,
+        max_autotune_gemm_backends="FLYDSL",
+        flydsl_enable_autotuning=True,
+        autotune_in_subproc=False,
+    )
+    def test_flydsl_grouped_mm_persistent_grid_stride_e2e(self):
+        from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_gfx950 import (
+            make_gemm_gfx950_param,
+        )
+        from torch._inductor.kernel.vendored_templates.flydsl.kernels.grouped_gemm_gfx950 import (
+            get_grouped_gemm_persistent_grid_size,
+        )
+
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
+        config_fields = (
+            "TILE_M",
+            "TILE_N",
+            "TILE_K",
+            "STAGES",
+            "BLOCK_M_WARPS",
+            "BLOCK_N_WARPS",
+            "GROUP_M",
+            "USE_HALF_TILE_INTERLEAVED",
+        )
+        expected_values = (64, 128, 64, 2, 2, 2, 0, True)
+        configs = [
+            asdict(config)
+            for config in flydsl_heuristics.get_default_grouped_gemm_configs()
+        ]
+        configs_by_values = {
+            tuple(config[field] for field in config_fields): config
+            for config in configs
+        }
+        self.assertIn(
+            expected_values,
+            configs_by_values,
+            f"missing grouped GEMM config {expected_values}; "
+            f"available configs: {tuple(configs_by_values)}",
+        )
+        config = configs_by_values[expected_values]
+
+        groups = 32
+        m_per_group = 512
+        n = 2048
+        k = 128
+        total_m = groups * m_per_group
+        group_sizes = torch.full(
+            (groups,), m_per_group, device="cuda", dtype=torch.int32
+        )
+        offs = group_sizes.cumsum(0).to(torch.int32)
+        a = torch.randn(total_m, k, device="cuda", dtype=torch.bfloat16)
+        b = torch.randn(groups, k, n, device="cuda", dtype=torch.bfloat16)
+
+        param = make_gemm_gfx950_param(
+            block_m=config["TILE_M"],
+            block_n=config["TILE_N"],
+            block_k=config["TILE_K"],
+            stages=config["STAGES"],
+            m_waves=config["BLOCK_M_WARPS"],
+            n_waves=config["BLOCK_N_WARPS"],
+            group_m=config["GROUP_M"],
+            use_half_tile_interleaved=config["USE_HALF_TILE_INTERLEAVED"],
+        )
+        device = torch.cuda.get_device_properties(a.device)
+        grid_size = get_grouped_gemm_persistent_grid_size(
+            param, total_m, n, groups, device
+        )
+        n_tiles = (n - 1) // config["TILE_N"] + 1
+        m_tiles_upper = groups + (total_m - groups) // config["TILE_M"]
+        total_tiles = m_tiles_upper * n_tiles
+        self.assertGreater(
+            total_tiles,
+            grid_size,
+            "expected enough tiles to exercise persistent grid-stride loops",
+        )
+
+        with mock.patch.object(
+            flydsl_heuristics,
+            "get_grouped_gemm_configs",
+            return_value=[config],
+        ):
+            self._assert_compiled_grouped_mm(a, b, offs)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA/ROCm not available")
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    @torch._inductor.config.patch(
+        max_autotune_gemm=True,
         max_autotune_gemm_backends="ATEN,FLYDSL",
     )
     def test_flydsl_grouped_mm_fallback_e2e(self):
@@ -929,6 +1174,25 @@ class TestFlyDSLTemplate(TestCase):
         )
 
         for name, case_a, case_b in cases:
+            with self.subTest(name=name):
+                self._assert_compiled_grouped_mm(
+                    case_a, case_b, offs, expect_flydsl=False
+                )
+
+        fp16_a = torch.randn(total_m, k, device="cuda", dtype=torch.float16)
+        fp16_cases = (
+            (
+                "fp16_n_not_tile_divisible",
+                fp16_a,
+                torch.randn(2, k, 96, device="cuda", dtype=torch.float16),
+            ),
+            (
+                "fp16_b_padded_stride",
+                fp16_a,
+                torch.randn(2, k, 136, device="cuda", dtype=torch.float16)[..., :128],
+            ),
+        )
+        for name, case_a, case_b in fp16_cases:
             with self.subTest(name=name):
                 self._assert_compiled_grouped_mm(
                     case_a, case_b, offs, expect_flydsl=False

--- a/torch/_inductor/heuristics/template/flydsl.py
+++ b/torch/_inductor/heuristics/template/flydsl.py
@@ -345,7 +345,9 @@ def is_grouped_gemm_config_valid_for_shape(
     m_waves = int(gemm_config["BLOCK_M_WARPS"])
     n_waves = int(gemm_config["BLOCK_N_WARPS"])
     use_half_tile_interleaved = bool(gemm_config["USE_HALF_TILE_INTERLEAVED"])
-    has_enough_k = use_half_tile_interleaved or k // tile_k >= stages
+    k_tiles = (k + tile_k - 1) // tile_k
+    # The staged kernel prefetches stages-1 K tiles before the main loop.
+    has_enough_k = use_half_tile_interleaved or k_tiles >= stages - 1
     # Partial N tiles issue unguarded vector B loads past row boundaries.
     return (
         tile_m <= max(128, m)

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -226,12 +226,13 @@ def _fits_int32_buffer_span(
     # Descriptor fields are signed int32, but AMD buffer voffset is an unsigned
     # 32-bit byte offset.
     int32_max = (1 << 31) - 1
+    uint32_max = (1 << 32) - 1
     return (
         0 < rows <= int32_max
         and 0 < cols <= int32_max
         and row_stride is not None
         and 0 <= row_stride <= int32_max
-        and ((rows - 1) * row_stride + cols) * itemsize < 1 << 32
+        and ((rows - 1) * row_stride + cols) * itemsize <= uint32_max
     )
 
 

--- a/torch/_inductor/kernel/mm_grouped.py
+++ b/torch/_inductor/kernel/mm_grouped.py
@@ -153,7 +153,7 @@ flydsl_grouped_mm_template = FlyDSLTemplate(
 )
 
 
-def get_flydsl_grouped_mm_template_kwargs(
+def use_flydsl_grouped_mm_template(
     mat_a: TensorBox,
     mat_b: TensorBox,
     layout: Layout,
@@ -162,51 +162,46 @@ def get_flydsl_grouped_mm_template_kwargs(
     offs: TensorBox | None,
     bias: TensorBox | None,
     is_nonzero: bool,
-) -> list[dict[str, object]]:
-    """Return supported FlyDSL template configs for grouped matrix multiplication."""
-    from ..heuristics.template.flydsl import (
-        get_grouped_gemm_configs,
-        is_grouped_gemm_config_valid_for_shape,
-    )
-
+    scaled: bool,
+) -> bool:
+    """Return whether grouped MM can use the FlyDSL gfx950 template."""
+    if scaled:
+        return False
     if not is_nonzero or not use_flydsl_gemm_template(layout):
-        return []
-    # FlyDSL grouped GEMM only supports a 2D ragged A gathered by group offsets
-    # against a 3D [G, K, N] B; bias fusion is not implemented.
+        return False
     if not (a_is_2d and not b_is_2d and offs is not None):
-        return []
+        return False
     if bias is not None:
-        return []
+        return False
     if mat_a.get_dtype() != mat_b.get_dtype() or layout.dtype != mat_a.get_dtype():
-        return []
+        return False
 
     sizevars = V.graph.sizevars
     mat1_stride = mat_a.get_stride()
     mat2_stride = mat_b.get_stride()
     out_stride = layout.stride
     if not sizevars.statically_known_equals(mat1_stride[-1], 1):
-        return []
+        return False
     if not sizevars.statically_known_equals(out_stride[-1], 1):
-        return []
-    # The grouped kernel consumes B as [G, K, N] with the N dimension contiguous.
+        return False
     if not sizevars.statically_known_equals(mat2_stride[-1], 1):
-        return []
+        return False
 
     dtype = mat_a.get_dtype()
     if dtype not in (torch.float16, torch.bfloat16):
-        return []
+        return False
 
     n = mat_b.get_size()[-1]
     k = mat_a.get_size()[-1]
     g = mat_b.get_size()[0]
     if not sizevars.statically_known_equals(mat1_stride[-2], k):
-        return []
+        return False
     if not sizevars.statically_known_equals(mat2_stride[-2], n):
-        return []
+        return False
     if not sizevars.statically_known_equals(mat2_stride[-3], k * n):
-        return []
+        return False
     if not sizevars.statically_known_equals(out_stride[-2], n):
-        return []
+        return False
 
     itemsize = dtype.itemsize
     aligned_byte_offsets = (
@@ -221,27 +216,43 @@ def get_flydsl_grouped_mm_template_kwargs(
             for offset in aligned_byte_offsets
         )
     ):
-        return []
+        return False
 
-    # Total M only prunes configs here; exact per-group sizes remain runtime
-    # values read from offs by the persistent kernel's on-device tile scan.
     m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
     n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
     k_static = PythonWrapperCodegen.statically_known_int_or_none(k)
     g_static = PythonWrapperCodegen.statically_known_int_or_none(g)
     if m_static is None or n_static is None or k_static is None or g_static is None:
-        return []
+        return False
     if n_static % 32 != 0 or k_static % 32 != 0:
-        return []
+        return False
     tensor_spans = (
         (m_static, k_static, k_static),
         (g_static, k_static * n_static, k_static * n_static),
         (m_static, n_static, n_static),
     )
-    if any(
+    return not any(
         not _fits_int32_buffer_span(rows, stride, cols, itemsize)
         for rows, stride, cols in tensor_spans
-    ):
+    )
+
+
+def get_flydsl_grouped_mm_template_kwargs(
+    mat_a: TensorBox,
+    mat_b: TensorBox,
+) -> list[dict[str, object]]:
+    """Return supported FlyDSL template configs for grouped matrix multiplication."""
+    from ..heuristics.template.flydsl import (
+        get_grouped_gemm_configs,
+        is_grouped_gemm_config_valid_for_shape,
+    )
+
+    dtype = mat_a.get_dtype()
+    n = mat_b.get_size()[-1]
+    m_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[0])
+    n_static = PythonWrapperCodegen.statically_known_int_or_none(n)
+    k_static = PythonWrapperCodegen.statically_known_int_or_none(mat_a.get_size()[-1])
+    if m_static is None or n_static is None or k_static is None:
         return []
 
     from .vendored_templates.flydsl.kernels import GEMM_DTYPE_BF16, GEMM_DTYPE_FP16
@@ -604,17 +615,18 @@ def _tuned_grouped_mm_common(
                 **asdict(config),
             )
 
-    if not scaled:
-        for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(
-            mat_a,
-            mat_b,
-            layout,
-            a_is_2d,
-            b_is_2d,
-            offs,
-            bias,
-            is_nonzero,
-        ):
+    if use_flydsl_grouped_mm_template(
+        mat_a,
+        mat_b,
+        layout,
+        a_is_2d,
+        b_is_2d,
+        offs,
+        bias,
+        is_nonzero,
+        scaled,
+    ):
+        for flydsl_kwargs in get_flydsl_grouped_mm_template_kwargs(mat_a, mat_b):
             flydsl_grouped_mm_template.maybe_append_choice(
                 choices,
                 input_nodes=input_nodes,

--- a/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_grouped_mm.py.jinja
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import threading
 
@@ -11,6 +10,7 @@ from torch._inductor.kernel.vendored_templates.flydsl.kernels import (
 from torch._inductor.runtime.flydsl_cache import (
     configure_flydsl_cache_dir,
     run_cached_flydsl,
+    temporary_env,
 )
 
 {{gen_defines()}}
@@ -22,22 +22,6 @@ _grouped_param_lock = threading.Lock()
 
 def _inductor_tensor_arg(tensor):
     return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
-
-
-@contextlib.contextmanager
-def _temporary_env(updates):
-    old_values = {key: os.environ.get(key) for key in updates}
-    os.environ.update(
-        {key: value for key, value in updates.items() if value is not None}
-    )
-    try:
-        yield
-    finally:
-        for key, old_value in old_values.items():
-            if old_value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = old_value
 
 
 def _flydsl_grouped_mm(output, mat1, mat2, offs, stream):
@@ -182,7 +166,7 @@ def {{kernel_name}}_precompile(
     if flydsl_gpu_arch is not None:
         env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
 
-    with _temporary_env(env_updates):
+    with temporary_env(env_updates):
         from torch._subclasses.fake_tensor import FakeTensorMode
 
         with FakeTensorMode():

--- a/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
+++ b/torch/_inductor/kernel/templates/flydsl_mm.py.jinja
@@ -1,4 +1,3 @@
-import contextlib
 import os
 import threading
 
@@ -12,6 +11,7 @@ from torch._inductor.kernel.vendored_templates.flydsl.kernels.gemm_gfx950 import
 from torch._inductor.runtime.flydsl_cache import (
     configure_flydsl_cache_dir,
     run_cached_flydsl,
+    temporary_env,
 )
 
 {{gen_defines()}}
@@ -23,22 +23,6 @@ _gemm_param_lock = threading.Lock()
 
 def _inductor_tensor_arg(tensor):
     return flyc.from_torch_tensor(tensor).mark_layout_dynamic()
-
-
-@contextlib.contextmanager
-def _temporary_env(updates):
-    old_values = {key: os.environ.get(key) for key in updates}
-    os.environ.update(
-        {key: value for key, value in updates.items() if value is not None}
-    )
-    try:
-        yield
-    finally:
-        for key, old_value in old_values.items():
-            if old_value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = old_value
 
 
 {{def_kernel("mat1", "mat2")}}
@@ -132,7 +116,7 @@ def {{kernel_name}}_precompile(
     if flydsl_gpu_arch is not None:
         env_updates["FLYDSL_GPU_ARCH"] = flydsl_gpu_arch
 
-    with _temporary_env(env_updates):
+    with temporary_env(env_updates):
         from torch._subclasses.fake_tensor import FakeTensorMode
 
         with FakeTensorMode():

--- a/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
+++ b/torch/_inductor/kernel/vendored_templates/flydsl/kernels/grouped_gemm_gfx950.py
@@ -22,24 +22,39 @@ from .gemm_gfx950 import (
 )
 
 
-def _grouped_swizzle_tile(param, num_pid_m, num_pid_n, local_tile):
+def _grouped_swizzle_tile(param, num_pid_m, num_pid_n, local_tile, grid, tiles_before):
     bid_m = local_tile % num_pid_m
     bid_n = local_tile // num_pid_m
     if const_expr(param.group_m <= 0):
         return bid_m, bid_n
 
-    block_swizzle = BlockSwizzle(
-        NUM_XCDS=8, NUM_PIDS_THRESHOLD=256, GROUP_M=param.group_m
-    )
-    swizzled_m, swizzled_n = block_swizzle.swizzle(num_pid_m, num_pid_n, local_tile)
+    num_xcds = 8
+    swizzle_threshold = 256
     num_workgroups = num_pid_m * num_pid_n
-    use_block_swizzle = (num_workgroups >= block_swizzle.NUM_PIDS_THRESHOLD) & (
-        (num_workgroups % block_swizzle.NUM_XCDS) == 0
+    # BlockSwizzle maps pid % NUM_XCDS to hardware XCD assignment. In the
+    # persistent grouped loop local_tile = blockIdx.x + j * grid - tiles_before,
+    # so local_tile % NUM_XCDS tracks blockIdx.x only when both grid and
+    # tiles_before are NUM_XCDS-aligned. Otherwise fall back to M-major tile
+    # order so concurrent CTAs share bid_n and reuse the same B tile.
+    use_block_swizzle = (
+        (num_workgroups >= swizzle_threshold)
+        & ((num_workgroups % num_xcds) == 0)
+        & ((grid % num_xcds) == 0)
+        & ((tiles_before % num_xcds) == 0)
     )
     if const_expr(isinstance(use_block_swizzle, bool)):
-        if const_expr(use_block_swizzle):
-            return swizzled_m, swizzled_n
-        return bid_m, bid_n
+        if not use_block_swizzle:
+            return bid_m, bid_n
+        block_swizzle = BlockSwizzle(
+            NUM_XCDS=num_xcds,
+            NUM_PIDS_THRESHOLD=swizzle_threshold,
+            GROUP_M=param.group_m,
+        )
+        return block_swizzle.swizzle(num_pid_m, num_pid_n, local_tile)
+    block_swizzle = BlockSwizzle(
+        NUM_XCDS=num_xcds, NUM_PIDS_THRESHOLD=swizzle_threshold, GROUP_M=param.group_m
+    )
+    swizzled_m, swizzled_n = block_swizzle.swizzle(num_pid_m, num_pid_n, local_tile)
     return (
         use_block_swizzle.select(swizzled_m, bid_m),
         use_block_swizzle.select(swizzled_n, bid_n),
@@ -75,12 +90,8 @@ def get_grouped_gemm_persistent_grid_size(
     n_tiles = (n - 1) // param.block_n + 1
     if light_tile:
         blocks_per_cu = min(1 << (resource_blocks_per_cu.bit_length() - 1), 8)
-        # The host only knows total M. This lower bound prevents empty CTAs
-        # for uniformly small groups, even though ragged inputs have more work.
-        task_floor = ((total_m - 1) // param.block_m + 1) * n_tiles
-        return max(1, min(num_cus * blocks_per_cu, task_floor))
-
-    blocks_per_cu = 2 if resource_blocks_per_cu >= 2 else 1
+    else:
+        blocks_per_cu = 2 if resource_blocks_per_cu >= 2 else 1
     nonempty_groups_upper = min(group_count, total_m)
     m_tiles_upper = (
         nonempty_groups_upper + (total_m - nonempty_groups_upper) // param.block_m
@@ -474,7 +485,7 @@ def _for_each_grouped_tile(offs_buf, group_count, n, param, tile_body):
         for linear_tile in range(work_idx, tiles_after, grid):
             local_tile = linear_tile - tiles_before
             bid_m, bid_n = _grouped_swizzle_tile(
-                param, num_pid_m, num_pid_n, local_tile
+                param, num_pid_m, num_pid_n, local_tile, grid, tiles_before
             )
             tile_body(g, bid_m, bid_n, m_g, row_base)
 

--- a/torch/_inductor/runtime/flydsl_cache.py
+++ b/torch/_inductor/runtime/flydsl_cache.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import threading
 from pathlib import Path
@@ -16,6 +17,23 @@ if TYPE_CHECKING:
 
 # Serialize cold compiles process-wide; warm cache hits bypass this lock.
 _compiled_cache_lock = threading.Lock()
+
+
+@contextlib.contextmanager
+def temporary_env(updates: dict[str, str | None]):
+    """Temporarily override process environment variables."""
+    old_values = {key: os.environ.get(key) for key in updates}
+    os.environ.update(
+        {key: value for key, value in updates.items() if value is not None}
+    )
+    try:
+        yield
+    finally:
+        for key, old_value in old_values.items():
+            if old_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old_value
 
 
 def run_cached_flydsl(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8731,13 +8731,6 @@ def _meta_grouped_mm_common(
             lambda: "Offsets tensor provided, but is not needed for 3D/3D multiplicand layouts.",
         )
 
-    if mat_a.dtype == torch.float16:
-        torch._check(
-            _grouped_mm_fp16_rocm_supported(mat_a, mat_b, offs)
-            or _grouped_mm_fp16_cublaslt_supported(mat_a, mat_b, offs),
-            lambda: "Float16 grouped_mm requires cuBLASLt grouped GEMM or ROCm support.",
-        )
-
     torch._check(
         bias is None,
         lambda: "Bias tensor provided, but it is not supported yet.",
@@ -8756,50 +8749,6 @@ def _meta_grouped_mm_common(
         )
 
     return _create_grouped_mm_output_tensor(mat_a, mat_b, offs, out_dtype)
-
-
-def _grouped_mm_fp16_rocm_supported(
-    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None
-) -> bool:
-    # ROCm ATen implements FP16 grouped_mm via per-group mm_out fallback (and
-    # optional CK fast paths). This is unrelated to Inductor FlyDSL templates.
-    if not torch.version.hip or not torch.cuda.is_available():
-        return False
-    if device_hint(mat_a) != "cuda" or device_hint(mat_b) != "cuda":
-        return False
-    if mat_a.device != mat_b.device:
-        return False
-    if offs is not None and (
-        device_hint(offs) != "cuda" or mat_a.device != offs.device
-    ):
-        return False
-    return True
-
-
-def _grouped_mm_fp16_cublaslt_supported(
-    mat_a: Tensor, mat_b: Tensor, offs: Tensor | None
-) -> bool:
-    if device_hint(mat_a) != "cuda" or device_hint(mat_b) != "cuda":
-        return False
-    if not torch.cuda.is_available():
-        return False
-    mat_a_is_2d = mat_a.dim() == 2
-    mat_b_is_2d = mat_b.dim() == 2
-    batch_count = (
-        offs.size(0)
-        if offs is not None and (mat_a_is_2d or mat_b_is_2d)
-        else mat_a.size(0)
-    )
-    if batch_count < 1 or batch_count > 1024:
-        return False
-    device_capability = torch.cuda.get_device_capability()
-    cuda_version: tuple[int, int] = (0, 0)
-    if torch.version.cuda:
-        parts = torch.version.cuda.split(".")
-        cuda_version = (int(parts[0]), int(parts[1]))
-    return cuda_version >= (13, 3) and (
-        device_capability[0] >= 9 and device_capability[0] <= 11
-    )
 
 
 @register_meta(aten._grouped_mm)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Fix grouped GEMM persistent grid sizing to use the upper-bound tile count
for both light and non-light configs, and only enable BlockSwizzle when
grid and tiles_before are XCD-aligned so persistent grid-stride loops
preserve correct B-tile reuse. Use ceiling K-tile counts for staged-kernel
eligibility, split FlyDSL grouped-MM gating from config enumeration, fix
uint32 buffer-span checks, share temporary_env in flydsl_cache, and keep
meta grouped_mm backend-agnostic for fp16.

Test Plan:
```
docker exec lirui-vllm-latest-0708 bash -lc 'cd /shared/amdgpu/home/xiaobing_zhang_qle/lirui/code/pytorch && /opt/venv/bin/python3 test/inductor/test_flydsl_template.py TestFlyDSLTemplate'
```

Authored with assistance from an AI coding agent.

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo