### PR TITLE
[Testcase Refactoring] Add hw-classification in launcher_launch_test

### DIFF
--- a/test/distributed/launcher/launch_test.py
+++ b/test/distributed/launcher/launch_test.py
@@ -15,6 +15,7 @@ from contextlib import closing
 import torch.distributed.launch as launch
 from torch.distributed.elastic.utils import get_socket_with_port
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     skip_but_pass_in_sandcastle_if,
     TEST_WITH_DEV_DBG_ASAN,
 )
@@ -25,6 +26,8 @@ def path(script):
 
 
 class LaunchTest(unittest.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.test_dir = tempfile.mkdtemp()


### PR DESCRIPTION
## Summary

Tags `LaunchTest` in `test/distributed/launcher/launch_test.py` with
`hw_classification = HardwareClassification.GENERIC` so the class can be
selected by the `--hw-classification` test filter. The class subclasses
`unittest.TestCase` and exercises CPU-only `torch.distributed.launch.main(args)`
CLI behavior, with no device parameter and no
`instantiate_device_type_tests`, so `GENERIC` is the correct category.


## Changes

- `test/distributed/launcher/launch_test.py`: added `HardwareClassification`
  to the existing `torch.testing._internal.common_utils` multi-line import
  block, in alphabetical position before `skip_but_pass_in_sandcastle_if`
  and `TEST_WITH_DEV_DBG_ASAN`.
- `test/distributed/launcher/launch_test.py`: declared
  `hw_classification = HardwareClassification.GENERIC` as a class attribute
  on `LaunchTest`, placed immediately after the class header and before
  `setUp`.


## Motivation

PyTorch's test suite recently introduced the `HardwareClassification`
mechanism (see `torch/testing/_internal/common_utils.py`), which allows
filtering test classes by hardware category (`GENERIC`, `ACCELERATOR`,
`CPU`, `CUDA`, `MPS`, `XPU`) via the `--hw-classification` CLI flag. Test
classes that do not declare a `hw_classification` attribute are excluded
when the filter is used, so they cannot run in hardware-partitioned CI
workflows.

`LaunchTest` fits the `GENERIC` definition ("tests that exercise shared,
device-agnostic logic ... typically do not use
`instantiate_device_type_tests`"): its two test methods
(`test_launch_without_env` and `test_launch_with_env`) build CLI args lists
(`--nnodes`, `--nproc-per-node`, `--master-addr`, `--master-port`,
`--node-rank`, `--use-env`, etc.) and invoke
`torch.distributed.launch.main(args)` to spawn workers running
`bin/test_script_local_rank.py` and `bin/test_script.py` — pure launcher/CLI
wiring with no tensor or device code. Tagging it `GENERIC` brings it into the
new filtering workflow without altering test behavior.


## Test plan

- Run the test file:
 python test/distributed/launcher/launch_test.py , 2 testcases pass
