### PR TITLE
Skip grouped GEMM config schema test without FlyDSL runtime

### DIFF
--- a/test/inductor/test_flydsl_template.py
+++ b/test/inductor/test_flydsl_template.py
@@ -608,6 +608,9 @@ class TestFlyDSLTemplate(TestCase):
     def test_flydsl_grouped_gemm_config_schema(self):
         from torch._inductor.heuristics.template import flydsl as flydsl_heuristics
 
+        if not flydsl_utils.runtime_available():
+            self.skipTest("FlyDSL runtime unavailable")
+
         flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear()
         self.addCleanup(flydsl_heuristics.get_default_grouped_gemm_configs.cache_clear)
         default_config = flydsl_heuristics.DEFAULT_GROUPED_GEMM_CONFIG


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

test_flydsl_grouped_gemm_config_schema calls _make_gemm_param, which
imports the optional flydsl package. Default CI shards do not install
FlyDSL, so skip the test when runtime_available() is false.

Test plan:
- python test/inductor/test_flydsl_template.py TestFlyDSLTemplate.test_flydsl_grouped_gemm_config_schema

Co-authored-by: Cursor <cursoragent@cursor.com>

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo