### PR TITLE
[Elastic] Fix UnboundLocalError in find_free_port when socket creation fails

### DIFF
--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -9,9 +9,11 @@ import os
 import sys
 import unittest
 
+from unittest.mock import MagicMock, patch
+
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +60,34 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+    @patch("socket.getaddrinfo")
+    @patch("socket.socket")
+    def test_find_free_port_retries_on_socket_creation_error(
+        self, mock_socket, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 0)),
+            (10, 1, 6, "", ("::1", 0)),
+        ]
+        mock_sock = MagicMock()
+        mock_socket.side_effect = [OSError("socket creation failed"), mock_sock]
+
+        sock = find_free_port()
+        self.assertEqual(sock, mock_sock)
+
+    @patch("socket.getaddrinfo")
+    @patch("socket.socket")
+    def test_find_free_port_raises_runtime_error_when_all_fail(
+        self, mock_socket, mock_getaddrinfo
+    ):
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("127.0.0.1", 0))]
+        mock_socket.side_effect = OSError("socket creation failed")
+
+        with self.assertRaises(RuntimeError):
+            find_free_port()
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,14 +53,16 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
-            print(f"Socket creation attempt failed: {e}")
+            if s is not None:
+                s.close()
+            logger.warning("Socket creation attempt failed: %s", e)
     raise RuntimeError("Failed to create a socket")
 
 


### PR DESCRIPTION
Fixes #191395

### Description
In `torch.distributed.elastic.rendezvous.etcd_server.find_free_port()`, the socket variable `s` was assigned inside the `try` block while `s.close()` was unconditionally called inside `except OSError:`.

If `socket.socket()` raises an `OSError` (e.g., unsupported address family or socket exhaustion), `s` was never bound, causing `s.close()` to throw an `UnboundLocalError` and aborting the loop prematurely.

This PR:
1. Initializes `s = None` before the `try` block.
2. Only calls `s.close()` if `s is not None`.
3. Replaces `print()` with standard `logger.warning()`.
4. Removes the `# type: ignore[possibly-undefined]` comment.
5. Adds regression tests in `test/distributed/elastic/rendezvous/etcd_server_test.py`.

### Test Plan
Ran unittest suite:
```bash
python test/distributed/elastic/rendezvous/etcd_server_test.py


test_find_free_port_retries_on_socket_creation_error ... ok
test_find_free_port_raises_runtime_error_when_all_fail ... ok
Ran 2 tests in 0.002s
OK
