### PR TITLE
[Docs] Remove non-existent out argument from torch.linalg._powsum docstring

### DIFF
--- a/torch/linalg/__init__.py
+++ b/torch/linalg/__init__.py
@@ -3129,7 +3129,7 @@ Examples::
 _powsum = _add_docstr(
     _linalg.linalg__powsum,
     r"""
-linalg._powsum(x, ord, dim=None, keepdim=False, *, dtype=None, out=None) -> Tensor
+linalg._powsum(x, ord, dim=None, keepdim=False, *, dtype=None) -> Tensor
 
 Computes the sum of the absolute values raised to the power ``ord``.
 
@@ -3151,7 +3151,6 @@ Keyword args:
     dtype (:class:`torch.dtype`, optional): the desired data type of returned tensor.
           If specified, the input tensor is cast to :attr:`dtype` before the operation
           is performed. Default: ``None``.
-    out (Tensor, optional): output tensor. Ignored if ``None``. Default: ``None``.
 
 Returns:
     A real-valued tensor, even when :attr:`x` is complex.


### PR DESCRIPTION
Fixes #180649

### Description
The docstring for `torch.linalg._powsum` currently documents `out=None` in its signature and `Keyword args` section. However, the ATen operator `aten::linalg__powsum` does not support an `out=` parameter (`TypeError: linalg__powsum() got an unexpected keyword argument 'out'`).

This PR updates the docstring in `torch/linalg/__init__.py` to remove `out=None` and align with the actual operator signature.

### Test Plan
Docstring fix only. Verified schema with:
```python
import torch
schema = torch._C._jit_get_schemas_for_operator("aten::linalg__powsum")
print(schema)
