### PR TITLE
[arm]Port AOR sin and cos to SVE128 and SVE256 on aarch64

### DIFF
--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -11,6 +11,12 @@
 #define USE_SLEEF(sleef_code, non_sleef_code) non_sleef_code
 #endif
 
+#if defined(__aarch64__)
+#define USE_AOR(aor_code, non_aor_code) aor_code
+#else
+#define USE_AOR(aor_code, non_aor_code) non_aor_code
+#endif
+
 namespace at::vec {
 // Note [CPU_CAPABILITY namespace]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -104,10 +110,393 @@ static inline svfloat32_t fexp_u20(svfloat32_t values) {
       y);
   return y;
 }
+
+// sin and cos implementation adapted from AOR:
+// https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/sinf.c
+// https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/cosf.c
+// https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/sv_trigf_fallback.h
+static const struct SinData {
+  float neg_pio2_1, neg_pio2_2, neg_pio2_3, inv_pio2, shift, range_val;
+} sin_data = {
+    /* Polynomial coefficients are hard-wired in FTMAD instructions.  */
+    .neg_pio2_1 = -0x1.921fb6p+0f,
+    .neg_pio2_2 = 0x1.777a5cp-25f,
+    .neg_pio2_3 = 0x1.ee59dap-50f,
+    .inv_pio2 = 0x1.45f306p-1f,
+    /* Original shift used in AdvSIMD cosf,
+       plus a contribution to set the bit #0 of q
+       as expected by trigonometric instructions.  */
+    .shift = 0x1.8p+23f,
+    .range_val = 0x1p20f,
+};
+
+static const struct CosData {
+  float neg_pio2_1, neg_pio2_2, neg_pio2_3, inv_pio2, shift, range_val;
+} cos_data = {
+    /* Polynomial coefficients are hard-wired in FTMAD instructions.  */
+    .neg_pio2_1 = -0x1.921fb6p+0f,
+    .neg_pio2_2 = 0x1.777a5cp-25f,
+    .neg_pio2_3 = 0x1.ee59dap-50f,
+    .inv_pio2 = 0x1.45f306p-1f,
+    /* Original shift used in AdvSIMD cosf,
+        plus a contribution to set the bit #0 of q
+       as expected by trigonometric instructions.  */
+    .shift = 0x1.800002p+23f,
+    .range_val = 0x1p20f,
+};
+
+struct TrigfFallbackData {
+  float d0[16];
+  float d1[16];
+  float d2[16];
+  float d3[16];
+  float pio2;
+};
+
+alignas(16) inline constexpr TrigfFallbackData trigf_fallback_data = {
+    .d0 =
+        {
+            0x1p0f,
+            0x1.0000a2p0f,
+            0x1.00a2fap0f,
+            0x1.45f306p-1f,
+            0x1.f306dcp-1f,
+            0x1.06dc9cp-1f,
+            0x1.6e4e44p0f,
+            0x1.4e4416p0f,
+            0x1.44152ap0f,
+            0x1.1529fcp0f,
+            0x1.29fc28p0f,
+            0x1.f84ebp-1f,
+            0x1.2757d2p0f,
+            0x1.57d1f6p0f,
+            0x1.a3ea6ap-1f,
+            0x1.ea69bcp-1f,
+        },
+    .d1 =
+        {
+            0x1.45f306p-25f,
+            0x1.f306dcp-25f,
+            -0x1.f246c6p-26f,
+            0x1.b9391p-26f,
+            0x1.391054p-26f,
+            0x1.1054a8p-26f,
+            0x1.529fc2p-28f,
+            -0x1.ac07b2p-25f,
+            -0x1.ec5418p-31f,
+            0x1.3abe9p-27f,
+            -0x1.505c16p-25f,
+            -0x1.70565ap-27f,
+            -0x1.596448p-29f,
+            -0x1.96447ep-25f,
+            -0x1.11f924p-27f,
+            -0x1.f924ecp-27f,
+        },
+    .d2 =
+        {
+            0x1.b9391p-50f,
+            0x1.391054p-50f,
+            -0x1.df56bp-51f,
+            0x1.529fc2p-52f,
+            0x1.4fe13ap-51f,
+            -0x1.ec5418p-55f,
+            0x1.d5f47ep-54f,
+            0x1.5f47d4p-50f,
+            0x1.f534dep-56f,
+            -0x1.596448p-53f,
+            0x1.a6ee06p-51f,
+            0x1.dc0db6p-52f,
+            0x1.b6c52cp-57f,
+            -0x1.24eb54p-51f,
+            -0x1.d6a66cp-52f,
+            0x1.5993c4p-52f,
+        },
+    .d3 =
+        {
+            0x1.529fc2p-76f,
+            0x1.4fe13ap-75f,
+            -0x1.ec5418p-79f,
+            0x1.d5f47ep-78f,
+            0x1.7d1f54p-76f,
+            0x1.f534dep-80f,
+            -0x1.65912p-79f,
+            0x1.a6ee06p-75f,
+            -0x1.f924ecp-83f,
+            0x1.b6c52cp-81f,
+            0x1.b6295ap-76f,
+            0x1.4acc9ep-79f,
+            -0x1.9b0ef2p-82f,
+            0x1.93c43ap-76f,
+            -0x1.de37ep-79f,
+            0x1.c821p-79f,
+        },
+    .pio2 = 0x1.921fb6p+0f,
+};
+
+/* Return ptr but hide its value from the compiler so accesses through it
+   cannot be optimized based on the contents.  */
+#define ptr_barrier(ptr)         \
+  ({                             \
+    __typeof(ptr) __ptr = (ptr); \
+    __asm("" : "+r"(__ptr));     \
+    __ptr;                       \
+  })
+
+static inline svfloat32x2_t two_prod(
+    svbool_t pg,
+    svfloat32_t a,
+    svfloat32_t b) {
+  svfloat32_t hi = svmul_x(pg, a, b);
+  svfloat32_t lo = svnmls_x(pg, hi, a, b);
+  return svcreate2(hi, lo);
+}
+
+static inline svfloat32x2_t fast_two_sum(
+    svbool_t pg,
+    svfloat32_t a,
+    svfloat32_t b) {
+  svfloat32_t hi = svadd_x(pg, a, b);
+  svfloat32_t t = svsub_x(pg, hi, a);
+  svfloat32_t lo = svsub_x(pg, b, t);
+  return svcreate2(hi, lo);
+}
+
+static inline svfloat32x4_t load_datablock(
+    svbool_t pg,
+    svuint32_t idx,
+    const struct TrigfFallbackData* d) {
+  idx = svand_x(pg, idx, 15);
+
+  svfloat32_t d0 = svld1_gather_index(pg, d->d0, idx);
+  svfloat32_t d1 = svld1_gather_index(pg, d->d1, idx);
+  svfloat32_t d2 = svld1_gather_index(pg, d->d2, idx);
+  svfloat32_t d3 = svld1_gather_index(pg, d->d3, idx);
+
+  return svcreate4(d0, d1, d2, d3);
+}
+
+/* Reduce x for |x| > 0x1p8 inputs, such that:
+x = (q + y) * (pi / 2), with y in [-1/2, 1/2]
+
+Returns a svfloat32x2_t struct containing:
+remainder: The remainder after reduction
+quadrant: Quadrant of x as an integer reinterpreted as a float for packing.
+
+Designed to be used with the SVE trig instructions.  */
+static inline svfloat32x2_t large_range_reduction(svbool_t pg, svfloat32_t x) {
+  const struct TrigfFallbackData* d = ptr_barrier(&trigf_fallback_data);
+
+  /* First, x is reduced into the range of [2^32, 2^40), by directly adjusting
+    the exponent. This ensures the leading product contribute only multiples
+    of 2^8, so the useful bits of q mod 4 are entirely contained within the
+    lower product terms.  */
+  svuint32_t ix = svreinterpret_u32(x);
+  svint32_t x_e_m32 =
+      svsub_x(pg, svreinterpret_s32(svlsr_x(pg, ix, 23)), 127 + 32);
+
+  /* We can then use the new exponent as an index for the 2/pi table.  */
+  svuint32_t idx = svreinterpret_u32(svadd_x(pg, svasr_x(pg, x_e_m32, 3), 3));
+  svfloat32x4_t datablock = load_datablock(pg, idx, d);
+
+  /* x_e_m32 has already been split into:
+      x_e_m32 = 8 * ROW + offset
+    where ROW selected the 2/pi row above.
+
+    We want to keep the offset (x_e_m32 mod 8), and use it to produce a new
+    exponent (32 + offset) so that x_reduced is within our intended [32, 39]
+    window.  */
+  svint32_t masked =
+      svreinterpret_s32(svand_x(pg, svreinterpret_u32(x_e_m32), 7));
+  svuint32_t new_exponent =
+      svreinterpret_u32(svlsl_x(pg, svadd_x(pg, masked, 127 + 32), 23));
+
+  /* Finally, we get our reduced x value, by reinserting the new exponent into
+    the original input mantissa.  */
+  svuint32_t signed_mantissa = svand_x(pg, ix, 0x807fffff);
+  svfloat32_t x_reduced =
+      svreinterpret_f32(svorr_x(pg, new_exponent, signed_mantissa));
+
+  /* We now use the reduced x to calculate x ~= (q + y) * (pi / 2).
+    First, we multiply x_reduced by the first three chunks of the 2/pi
+    table, using double-single arithmetic to maintain a high precision
+    intermediate.  */
+  svfloat32x2_t ph = two_prod(pg, x_reduced, svget4(datablock, 0));
+  svfloat32x2_t pm = two_prod(pg, x_reduced, svget4(datablock, 1));
+  svfloat32x2_t pl = two_prod(pg, x_reduced, svget4(datablock, 2));
+
+  svfloat32_t ph_lo = svget2(ph, 1);
+  svfloat32_t pm_hi = svget2(pm, 0);
+  svfloat32_t pm_lo = svget2(pm, 1);
+  svfloat32_t pl_hi = svget2(pl, 0);
+  svfloat32_t pl_lo = svget2(pl, 1);
+
+  /* Next, we need to accumulate the results together to get an integer k for
+    our quadrant. However, ph.hi will always be a multiple of 2^8, so it
+    cannot affect k mod 4. pm.lo and pl will always be sufficiently small
+    that they cannot affect the integer portion of the result. Therefore we
+    only need to sum ph.lo and pm.hi when computing k mod 4. Rounding sum_hi
+    chooses the nearest quadrant in pi/2 units, which is the control value
+    expected by the trig instructions.  */
+  svfloat32_t sum_hi = svadd_x(pg, ph_lo, pm_hi);
+  svfloat32_t kd = svrinta_x(pg, sum_hi);
+
+  /* To compute the remainder, we need to remove k from the pi/2-scaled
+    value and accumulate the remaining terms as a double-single remainder.  */
+  svfloat32_t y_hi = svadd_x(pg, svsub_x(pg, ph_lo, kd), pm_hi);
+  svfloat32x2_t y_mid = fast_two_sum(pg, pm_lo, pl_hi);
+
+  /* The low portion of x_reduced * D3 has no meaningful contribution to the
+    result, so a simple FMA is sufficient.  */
+  svfloat32_t y_lo = svmla_x(pg, pl_lo, x_reduced, svget4(datablock, 3));
+
+  /* We then accumulate the final hi/lo remainders.  */
+  y_hi = svadd_x(pg, y_hi, svget2(y_mid, 0));
+  y_lo = svadd_x(pg, y_lo, svget2(y_mid, 1));
+
+  /* Multiply the accumulated remainders by pi/2, and adding gives a single
+    final remainder.  */
+  svfloat32_t remainder = svmla_x(
+      pg, svmul_x(pg, y_lo, svdup_n_f32(d->pio2)), y_hi, svdup_n_f32(d->pio2));
+  svint32_t quadrant = svcvt_s32_x(pg, kd);
+  /* Reinterpret quadrant into a float to pack into struct for return.  */
+  return svcreate2(remainder, svreinterpret_f32(quadrant));
+}
+
+__attribute__((noinline)) static svfloat32_t sin_special_case(
+    svfloat32_t x,
+    svfloat32_t y,
+    svbool_t special) {
+  const svbool_t pg_all = svptrue_b32();
+  special = svaclt(special, x, svdup_n_f32(INFINITY));
+
+  svfloat32x2_t reduction = large_range_reduction(pg_all, x);
+  svuint32_t quadrant = svreinterpret_u32(svget2(reduction, 1));
+  svfloat32_t r = svget2(reduction, 0);
+
+  svfloat32_t f = svtssel(r, quadrant);
+  svfloat32_t r2 = svtsmul(r, quadrant);
+  svfloat32_t sin = svdup_n_f32(0.0f);
+  sin = svtmad(sin, r2, 4);
+  sin = svtmad(sin, r2, 3);
+  sin = svtmad(sin, r2, 2);
+  sin = svtmad(sin, r2, 1);
+  sin = svtmad(sin, r2, 0);
+  sin = svmul_x(pg_all, f, sin);
+
+  return svsel_f32(special, sin, y);
+}
+
+__attribute__((noinline)) static svfloat32_t cos_special_case(
+    svfloat32_t x,
+    svfloat32_t y,
+    svbool_t special) {
+  special = svaclt(special, x, svdup_n_f32(INFINITY));
+
+  svfloat32x2_t reduction = large_range_reduction(svptrue_b32(), x);
+
+  /* Unpack the quadrant from the return struct.  */
+  svuint32_t quadrant = svreinterpret_u32(svget2(reduction, 1));
+  svfloat32_t r = svget2(reduction, 0);
+
+  /* Adjust quadrant to select cosine polynomial.  */
+  quadrant = svadd_x(svptrue_b32(), quadrant, 1);
+
+  svfloat32_t f = svtssel(r, quadrant);
+  svfloat32_t r2 = svtsmul(r, quadrant);
+  svfloat32_t cos = svdup_n_f32(0.0f);
+  cos = svtmad(cos, r2, 4);
+  cos = svtmad(cos, r2, 3);
+  cos = svtmad(cos, r2, 2);
+  cos = svtmad(cos, r2, 1);
+  cos = svtmad(cos, r2, 0);
+  cos = svmul_x(svptrue_b32(), f, cos);
+
+  return svsel(special, cos, y);
+}
+
+static inline svfloat32_t sinf(svfloat32_t x, svbool_t pg) {
+  const struct SinData* d = ptr_barrier(&sin_data);
+  const svbool_t pg_all = svptrue_b32();
+
+  svfloat32_t negpio2_and_invpio2 = svld1rq(pg_all, &d->neg_pio2_1);
+
+  svfloat32_t q = svmla_lane(svdup_n_f32(d->shift), x, negpio2_and_invpio2, 3);
+  svfloat32_t n = svsub_x(pg_all, q, d->shift);
+
+  svfloat32_t r = x;
+  r = svmla_lane(r, n, negpio2_and_invpio2, 0);
+  r = svmla_lane(r, n, negpio2_and_invpio2, 1);
+  r = svmla_lane(r, n, negpio2_and_invpio2, 2);
+
+  svuint32_t q_u = svreinterpret_u32(q);
+  svfloat32_t f = svtssel(r, q_u);
+  svfloat32_t r2 = svtsmul(r, q_u);
+  svfloat32_t y = svdup_n_f32(0.0f);
+  y = svtmad(y, r2, 4);
+  y = svtmad(y, r2, 3);
+  y = svtmad(y, r2, 2);
+  y = svtmad(y, r2, 1);
+  y = svtmad(y, r2, 0);
+
+  svfloat32_t fast_result = svmul_x(pg_all, f, y);
+  svbool_t is_zero = svcmpeq(pg, x, svdup_n_f32(0.0f));
+  fast_result = svsel(is_zero, x, fast_result);
+  svbool_t special = svacge(pg, x, svdup_n_f32(d->range_val));
+  if (C10_UNLIKELY(svptest_any(pg, special))) {
+    return sin_special_case(x, fast_result, special);
+  }
+  return fast_result;
+}
+
+/* Vector version of cosf.
+  The maximum observed error is 1.56 + 0.5 ULP if |x| < 0x1p20.
+  _ZGVsMxv_cosf (0x1.dea2f2p+19)
+  got 0x1.fffe7ap-6
+  want 0x1.fffe76p-6
+  The special domain has a higher maximum error than the fast path:
+  Maximum observed error is 2.65 + 0.5ULP
+  _ZGVsMxv_cosf (0x1.ff3afcp+53)
+  got -0x1.ffe74p-3
+  want -0x1.ffe73ap-3.  */
+static inline svfloat32_t cosf(svfloat32_t x, const svbool_t pg) {
+  const struct CosData* d = ptr_barrier(&cos_data);
+  const svbool_t pg_all = svptrue_b32();
+
+  /* Load some constants in quad-word chunks to minimise memory access.  */
+  svfloat32_t negpio2_and_invpio2 = svld1rq(pg_all, &d->neg_pio2_1);
+
+  /* n = rint(x/(pi/2)).  */
+  svfloat32_t q = svmla_lane(svdup_n_f32(d->shift), x, negpio2_and_invpio2, 3);
+  svfloat32_t n = svsub_x(pg_all, q, d->shift);
+
+  /* r = x - n*(pi/2)  (range reduction into -pi/4 .. pi/4).  */
+  svfloat32_t r = x;
+  r = svmla_lane(r, n, negpio2_and_invpio2, 0);
+  r = svmla_lane(r, n, negpio2_and_invpio2, 1);
+  r = svmla_lane(r, n, negpio2_and_invpio2, 2);
+
+  /* Final multiplicative factor: 1.0 or x depending on bit #0 of q.  */
+  svuint32_t q_u = svreinterpret_u32(q);
+  svfloat32_t f = svtssel(r, q_u);
+
+  /* cos(r) poly approx.  */
+  svfloat32_t r2 = svtsmul(r, q_u);
+  svfloat32_t y = svdup_n_f32(0.0f);
+  y = svtmad(y, r2, 4);
+  y = svtmad(y, r2, 3);
+  y = svtmad(y, r2, 2);
+  y = svtmad(y, r2, 1);
+  y = svtmad(y, r2, 0);
+
+  svbool_t cmp = svacge(pg, x, svdup_n_f32(d->range_val));
+  if (C10_UNLIKELY(svptest_any(pg, cmp)))
+    return cos_special_case(x, svmul_x(pg_all, f, y), cmp);
+  /* Apply factor.  */
+  return svmul_x(pg_all, f, y);
+}
 #endif
 
 #if defined(CPU_CAPABILITY_SVE256)
-
 template <>
 struct is_vec_specialized_for<float> : std::bool_constant<true> {};
 
@@ -439,8 +828,10 @@ class Vectorized<float> {
   }
   Vectorized<float> frac() const;
   Vectorized<float> sin() const {
-    return USE_SLEEF(
-        Vectorized<float>(Sleef_sinfx_u10sve(values)), map(std::sin));
+    return USE_AOR(
+        Vectorized<float>(sinf(values, ptrue)),
+        USE_SLEEF(
+            Vectorized<float>(Sleef_sinfx_u10sve(values)), map(std::sin)));
   }
   // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
   // return finite results, because Sleef uses float-range intermediates
@@ -449,8 +840,10 @@ class Vectorized<float> {
     return map(std::sinh);
   }
   Vectorized<float> cos() const {
-    return USE_SLEEF(
-        Vectorized<float>(Sleef_cosfx_u10sve(values)), map(std::cos));
+    return USE_AOR(
+        Vectorized<float>(cosf(values, svptrue_b32())),
+        USE_SLEEF(
+            Vectorized<float>(Sleef_cosfx_u10sve(values)), map(std::cos)));
   }
   Vectorized<float> cosh() const {
     return map(std::cosh);

--- a/aten/src/ATen/cpu/vec/sve/vec_float.h
+++ b/aten/src/ATen/cpu/vec/sve/vec_float.h
@@ -11,12 +11,6 @@
 #define USE_SLEEF(sleef_code, non_sleef_code) non_sleef_code
 #endif
 
-#if defined(__aarch64__)
-#define USE_AOR(aor_code, non_aor_code) aor_code
-#else
-#define USE_AOR(aor_code, non_aor_code) non_aor_code
-#endif
-
 namespace at::vec {
 // Note [CPU_CAPABILITY namespace]
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -111,311 +105,32 @@ static inline svfloat32_t fexp_u20(svfloat32_t values) {
   return y;
 }
 
-// sin and cos implementation adapted from AOR:
+// Fast-path sin and cos implementations adapted from AOR:
 // https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/sinf.c
 // https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/cosf.c
-// https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/sv_trigf_fallback.h
-static const struct SinData {
-  float neg_pio2_1, neg_pio2_2, neg_pio2_3, inv_pio2, shift, range_val;
-} sin_data = {
-    /* Polynomial coefficients are hard-wired in FTMAD instructions.  */
-    .neg_pio2_1 = -0x1.921fb6p+0f,
-    .neg_pio2_2 = 0x1.777a5cp-25f,
-    .neg_pio2_3 = 0x1.ee59dap-50f,
-    .inv_pio2 = 0x1.45f306p-1f,
-    /* Original shift used in AdvSIMD cosf,
-       plus a contribution to set the bit #0 of q
-       as expected by trigonometric instructions.  */
+struct TrigData {
+  float neg_pio2_1 = -0x1.921fb6p+0f;
+  float neg_pio2_2 = 0x1.777a5cp-25f;
+  float neg_pio2_3 = 0x1.ee59dap-50f;
+  float inv_pio2 = 0x1.45f306p-1f;
+  float shift;
+};
+
+inline constexpr TrigData sin_data{
     .shift = 0x1.8p+23f,
-    .range_val = 0x1p20f,
 };
 
-static const struct CosData {
-  float neg_pio2_1, neg_pio2_2, neg_pio2_3, inv_pio2, shift, range_val;
-} cos_data = {
-    /* Polynomial coefficients are hard-wired in FTMAD instructions.  */
-    .neg_pio2_1 = -0x1.921fb6p+0f,
-    .neg_pio2_2 = 0x1.777a5cp-25f,
-    .neg_pio2_3 = 0x1.ee59dap-50f,
-    .inv_pio2 = 0x1.45f306p-1f,
-    /* Original shift used in AdvSIMD cosf,
-        plus a contribution to set the bit #0 of q
-       as expected by trigonometric instructions.  */
+inline constexpr TrigData cos_data{
     .shift = 0x1.800002p+23f,
-    .range_val = 0x1p20f,
 };
 
-struct TrigfFallbackData {
-  float d0[16];
-  float d1[16];
-  float d2[16];
-  float d3[16];
-  float pio2;
-};
-
-alignas(16) inline constexpr TrigfFallbackData trigf_fallback_data = {
-    .d0 =
-        {
-            0x1p0f,
-            0x1.0000a2p0f,
-            0x1.00a2fap0f,
-            0x1.45f306p-1f,
-            0x1.f306dcp-1f,
-            0x1.06dc9cp-1f,
-            0x1.6e4e44p0f,
-            0x1.4e4416p0f,
-            0x1.44152ap0f,
-            0x1.1529fcp0f,
-            0x1.29fc28p0f,
-            0x1.f84ebp-1f,
-            0x1.2757d2p0f,
-            0x1.57d1f6p0f,
-            0x1.a3ea6ap-1f,
-            0x1.ea69bcp-1f,
-        },
-    .d1 =
-        {
-            0x1.45f306p-25f,
-            0x1.f306dcp-25f,
-            -0x1.f246c6p-26f,
-            0x1.b9391p-26f,
-            0x1.391054p-26f,
-            0x1.1054a8p-26f,
-            0x1.529fc2p-28f,
-            -0x1.ac07b2p-25f,
-            -0x1.ec5418p-31f,
-            0x1.3abe9p-27f,
-            -0x1.505c16p-25f,
-            -0x1.70565ap-27f,
-            -0x1.596448p-29f,
-            -0x1.96447ep-25f,
-            -0x1.11f924p-27f,
-            -0x1.f924ecp-27f,
-        },
-    .d2 =
-        {
-            0x1.b9391p-50f,
-            0x1.391054p-50f,
-            -0x1.df56bp-51f,
-            0x1.529fc2p-52f,
-            0x1.4fe13ap-51f,
-            -0x1.ec5418p-55f,
-            0x1.d5f47ep-54f,
-            0x1.5f47d4p-50f,
-            0x1.f534dep-56f,
-            -0x1.596448p-53f,
-            0x1.a6ee06p-51f,
-            0x1.dc0db6p-52f,
-            0x1.b6c52cp-57f,
-            -0x1.24eb54p-51f,
-            -0x1.d6a66cp-52f,
-            0x1.5993c4p-52f,
-        },
-    .d3 =
-        {
-            0x1.529fc2p-76f,
-            0x1.4fe13ap-75f,
-            -0x1.ec5418p-79f,
-            0x1.d5f47ep-78f,
-            0x1.7d1f54p-76f,
-            0x1.f534dep-80f,
-            -0x1.65912p-79f,
-            0x1.a6ee06p-75f,
-            -0x1.f924ecp-83f,
-            0x1.b6c52cp-81f,
-            0x1.b6295ap-76f,
-            0x1.4acc9ep-79f,
-            -0x1.9b0ef2p-82f,
-            0x1.93c43ap-76f,
-            -0x1.de37ep-79f,
-            0x1.c821p-79f,
-        },
-    .pio2 = 0x1.921fb6p+0f,
-};
-
-/* Return ptr but hide its value from the compiler so accesses through it
-   cannot be optimized based on the contents.  */
-#define ptr_barrier(ptr)         \
-  ({                             \
-    __typeof(ptr) __ptr = (ptr); \
-    __asm("" : "+r"(__ptr));     \
-    __ptr;                       \
-  })
-
-static inline svfloat32x2_t two_prod(
-    svbool_t pg,
-    svfloat32_t a,
-    svfloat32_t b) {
-  svfloat32_t hi = svmul_x(pg, a, b);
-  svfloat32_t lo = svnmls_x(pg, hi, a, b);
-  return svcreate2(hi, lo);
-}
-
-static inline svfloat32x2_t fast_two_sum(
-    svbool_t pg,
-    svfloat32_t a,
-    svfloat32_t b) {
-  svfloat32_t hi = svadd_x(pg, a, b);
-  svfloat32_t t = svsub_x(pg, hi, a);
-  svfloat32_t lo = svsub_x(pg, b, t);
-  return svcreate2(hi, lo);
-}
-
-static inline svfloat32x4_t load_datablock(
-    svbool_t pg,
-    svuint32_t idx,
-    const struct TrigfFallbackData* d) {
-  idx = svand_x(pg, idx, 15);
-
-  svfloat32_t d0 = svld1_gather_index(pg, d->d0, idx);
-  svfloat32_t d1 = svld1_gather_index(pg, d->d1, idx);
-  svfloat32_t d2 = svld1_gather_index(pg, d->d2, idx);
-  svfloat32_t d3 = svld1_gather_index(pg, d->d3, idx);
-
-  return svcreate4(d0, d1, d2, d3);
-}
-
-/* Reduce x for |x| > 0x1p8 inputs, such that:
-x = (q + y) * (pi / 2), with y in [-1/2, 1/2]
-
-Returns a svfloat32x2_t struct containing:
-remainder: The remainder after reduction
-quadrant: Quadrant of x as an integer reinterpreted as a float for packing.
-
-Designed to be used with the SVE trig instructions.  */
-static inline svfloat32x2_t large_range_reduction(svbool_t pg, svfloat32_t x) {
-  const struct TrigfFallbackData* d = ptr_barrier(&trigf_fallback_data);
-
-  /* First, x is reduced into the range of [2^32, 2^40), by directly adjusting
-    the exponent. This ensures the leading product contribute only multiples
-    of 2^8, so the useful bits of q mod 4 are entirely contained within the
-    lower product terms.  */
-  svuint32_t ix = svreinterpret_u32(x);
-  svint32_t x_e_m32 =
-      svsub_x(pg, svreinterpret_s32(svlsr_x(pg, ix, 23)), 127 + 32);
-
-  /* We can then use the new exponent as an index for the 2/pi table.  */
-  svuint32_t idx = svreinterpret_u32(svadd_x(pg, svasr_x(pg, x_e_m32, 3), 3));
-  svfloat32x4_t datablock = load_datablock(pg, idx, d);
-
-  /* x_e_m32 has already been split into:
-      x_e_m32 = 8 * ROW + offset
-    where ROW selected the 2/pi row above.
-
-    We want to keep the offset (x_e_m32 mod 8), and use it to produce a new
-    exponent (32 + offset) so that x_reduced is within our intended [32, 39]
-    window.  */
-  svint32_t masked =
-      svreinterpret_s32(svand_x(pg, svreinterpret_u32(x_e_m32), 7));
-  svuint32_t new_exponent =
-      svreinterpret_u32(svlsl_x(pg, svadd_x(pg, masked, 127 + 32), 23));
-
-  /* Finally, we get our reduced x value, by reinserting the new exponent into
-    the original input mantissa.  */
-  svuint32_t signed_mantissa = svand_x(pg, ix, 0x807fffff);
-  svfloat32_t x_reduced =
-      svreinterpret_f32(svorr_x(pg, new_exponent, signed_mantissa));
-
-  /* We now use the reduced x to calculate x ~= (q + y) * (pi / 2).
-    First, we multiply x_reduced by the first three chunks of the 2/pi
-    table, using double-single arithmetic to maintain a high precision
-    intermediate.  */
-  svfloat32x2_t ph = two_prod(pg, x_reduced, svget4(datablock, 0));
-  svfloat32x2_t pm = two_prod(pg, x_reduced, svget4(datablock, 1));
-  svfloat32x2_t pl = two_prod(pg, x_reduced, svget4(datablock, 2));
-
-  svfloat32_t ph_lo = svget2(ph, 1);
-  svfloat32_t pm_hi = svget2(pm, 0);
-  svfloat32_t pm_lo = svget2(pm, 1);
-  svfloat32_t pl_hi = svget2(pl, 0);
-  svfloat32_t pl_lo = svget2(pl, 1);
-
-  /* Next, we need to accumulate the results together to get an integer k for
-    our quadrant. However, ph.hi will always be a multiple of 2^8, so it
-    cannot affect k mod 4. pm.lo and pl will always be sufficiently small
-    that they cannot affect the integer portion of the result. Therefore we
-    only need to sum ph.lo and pm.hi when computing k mod 4. Rounding sum_hi
-    chooses the nearest quadrant in pi/2 units, which is the control value
-    expected by the trig instructions.  */
-  svfloat32_t sum_hi = svadd_x(pg, ph_lo, pm_hi);
-  svfloat32_t kd = svrinta_x(pg, sum_hi);
-
-  /* To compute the remainder, we need to remove k from the pi/2-scaled
-    value and accumulate the remaining terms as a double-single remainder.  */
-  svfloat32_t y_hi = svadd_x(pg, svsub_x(pg, ph_lo, kd), pm_hi);
-  svfloat32x2_t y_mid = fast_two_sum(pg, pm_lo, pl_hi);
-
-  /* The low portion of x_reduced * D3 has no meaningful contribution to the
-    result, so a simple FMA is sufficient.  */
-  svfloat32_t y_lo = svmla_x(pg, pl_lo, x_reduced, svget4(datablock, 3));
-
-  /* We then accumulate the final hi/lo remainders.  */
-  y_hi = svadd_x(pg, y_hi, svget2(y_mid, 0));
-  y_lo = svadd_x(pg, y_lo, svget2(y_mid, 1));
-
-  /* Multiply the accumulated remainders by pi/2, and adding gives a single
-    final remainder.  */
-  svfloat32_t remainder = svmla_x(
-      pg, svmul_x(pg, y_lo, svdup_n_f32(d->pio2)), y_hi, svdup_n_f32(d->pio2));
-  svint32_t quadrant = svcvt_s32_x(pg, kd);
-  /* Reinterpret quadrant into a float to pack into struct for return.  */
-  return svcreate2(remainder, svreinterpret_f32(quadrant));
-}
-
-__attribute__((noinline)) static svfloat32_t sin_special_case(
-    svfloat32_t x,
-    svfloat32_t y,
-    svbool_t special) {
-  const svbool_t pg_all = svptrue_b32();
-  special = svaclt(special, x, svdup_n_f32(INFINITY));
-
-  svfloat32x2_t reduction = large_range_reduction(pg_all, x);
-  svuint32_t quadrant = svreinterpret_u32(svget2(reduction, 1));
-  svfloat32_t r = svget2(reduction, 0);
-
-  svfloat32_t f = svtssel(r, quadrant);
-  svfloat32_t r2 = svtsmul(r, quadrant);
-  svfloat32_t sin = svdup_n_f32(0.0f);
-  sin = svtmad(sin, r2, 4);
-  sin = svtmad(sin, r2, 3);
-  sin = svtmad(sin, r2, 2);
-  sin = svtmad(sin, r2, 1);
-  sin = svtmad(sin, r2, 0);
-  sin = svmul_x(pg_all, f, sin);
-
-  return svsel_f32(special, sin, y);
-}
-
-__attribute__((noinline)) static svfloat32_t cos_special_case(
-    svfloat32_t x,
-    svfloat32_t y,
-    svbool_t special) {
-  special = svaclt(special, x, svdup_n_f32(INFINITY));
-
-  svfloat32x2_t reduction = large_range_reduction(svptrue_b32(), x);
-
-  /* Unpack the quadrant from the return struct.  */
-  svuint32_t quadrant = svreinterpret_u32(svget2(reduction, 1));
-  svfloat32_t r = svget2(reduction, 0);
-
-  /* Adjust quadrant to select cosine polynomial.  */
-  quadrant = svadd_x(svptrue_b32(), quadrant, 1);
-
-  svfloat32_t f = svtssel(r, quadrant);
-  svfloat32_t r2 = svtsmul(r, quadrant);
-  svfloat32_t cos = svdup_n_f32(0.0f);
-  cos = svtmad(cos, r2, 4);
-  cos = svtmad(cos, r2, 3);
-  cos = svtmad(cos, r2, 2);
-  cos = svtmad(cos, r2, 1);
-  cos = svtmad(cos, r2, 0);
-  cos = svmul_x(svptrue_b32(), f, cos);
-
-  return svsel(special, cos, y);
-}
-
-static inline svfloat32_t sinf(svfloat32_t x, svbool_t pg) {
-  const struct SinData* d = ptr_barrier(&sin_data);
+/* Vector version of sinf.
+   The maximum observed error is 1.44 + 0.5 ULP when |x| < 0x1p20.
+   _ZGVsMxv_sinf(0x1.4b0d9cp+13)
+    got 0x1.fc28cep-3
+   want 0x1.fc28d2p-3.  */
+static inline svfloat32_t sinf_fast_path(svfloat32_t x) {
+  const TrigData* d = &sin_data;
   const svbool_t pg_all = svptrue_b32();
 
   svfloat32_t negpio2_and_invpio2 = svld1rq(pg_all, &d->neg_pio2_1);
@@ -439,27 +154,18 @@ static inline svfloat32_t sinf(svfloat32_t x, svbool_t pg) {
   y = svtmad(y, r2, 0);
 
   svfloat32_t fast_result = svmul_x(pg_all, f, y);
-  svbool_t is_zero = svcmpeq(pg, x, svdup_n_f32(0.0f));
+  svbool_t is_zero = svcmpeq(pg_all, x, svdup_n_f32(0.0f));
   fast_result = svsel(is_zero, x, fast_result);
-  svbool_t special = svacge(pg, x, svdup_n_f32(d->range_val));
-  if (C10_UNLIKELY(svptest_any(pg, special))) {
-    return sin_special_case(x, fast_result, special);
-  }
   return fast_result;
 }
 
 /* Vector version of cosf.
-  The maximum observed error is 1.56 + 0.5 ULP if |x| < 0x1p20.
-  _ZGVsMxv_cosf (0x1.dea2f2p+19)
-  got 0x1.fffe7ap-6
-  want 0x1.fffe76p-6
-  The special domain has a higher maximum error than the fast path:
-  Maximum observed error is 2.65 + 0.5ULP
-  _ZGVsMxv_cosf (0x1.ff3afcp+53)
-  got -0x1.ffe74p-3
-  want -0x1.ffe73ap-3.  */
-static inline svfloat32_t cosf(svfloat32_t x, const svbool_t pg) {
-  const struct CosData* d = ptr_barrier(&cos_data);
+   The maximum observed error is 1.56 + 0.5 ULP if |x| < 0x1p20.
+   _ZGVsMxv_cosf (0x1.dea2f2p+19)
+    got 0x1.fffe7ap-6
+   want 0x1.fffe76p-6  */
+static inline svfloat32_t cosf_fast_path(svfloat32_t x) {
+  const TrigData* d = &cos_data;
   const svbool_t pg_all = svptrue_b32();
 
   /* Load some constants in quad-word chunks to minimise memory access.  */
@@ -488,9 +194,6 @@ static inline svfloat32_t cosf(svfloat32_t x, const svbool_t pg) {
   y = svtmad(y, r2, 1);
   y = svtmad(y, r2, 0);
 
-  svbool_t cmp = svacge(pg, x, svdup_n_f32(d->range_val));
-  if (C10_UNLIKELY(svptest_any(pg, cmp)))
-    return cos_special_case(x, svmul_x(pg_all, f, y), cmp);
   /* Apply factor.  */
   return svmul_x(pg_all, f, y);
 }
@@ -827,11 +530,19 @@ class Vectorized<float> {
         Vectorized<float>(Sleef_log1pfx_u10sve(values)), map(std::log1p));
   }
   Vectorized<float> frac() const;
+  // Uses the AOR fast path when every lane satisfies |x| < 0x1p20f. AOR
+  // sinf.c reports a maximum observed error of 1.44 + 0.5 ULP in this range.
+  // If any lane is outside this range, the entire vector uses the existing
+  // SLEEF u10 implementation instead of duplicating AOR's separate large-range
+  // reduction. SLEEF documents an error bound of 1.0 ULP for this path.
   Vectorized<float> sin() const {
-    return USE_AOR(
-        Vectorized<float>(sinf(values, ptrue)),
-        USE_SLEEF(
-            Vectorized<float>(Sleef_sinfx_u10sve(values)), map(std::sin)));
+    const svbool_t pg = svptrue_b32();
+    const svbool_t large = svacge(pg, values, svdup_n_f32(0x1p20f));
+    if (C10_UNLIKELY(svptest_any(pg, large))) {
+      return USE_SLEEF(
+          Vectorized<float>(Sleef_sinfx_u10sve(values)), map(std::sin));
+    }
+    return Vectorized<float>(sinf_fast_path(values));
   }
   // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
   // return finite results, because Sleef uses float-range intermediates
@@ -839,11 +550,19 @@ class Vectorized<float> {
   Vectorized<float> sinh() const {
     return map(std::sinh);
   }
+  // Uses the AOR fast path when every lane satisfies |x| < 0x1p20f. AOR
+  // cosf.c reports a maximum observed error of 1.56 + 0.5 ULP in this range.
+  // If any lane is outside this range, the entire vector uses the existing
+  // SLEEF u10 implementation instead of duplicating AOR's separate large-range
+  // reduction. SLEEF documents an error bound of 1.0 ULP for this path.
   Vectorized<float> cos() const {
-    return USE_AOR(
-        Vectorized<float>(cosf(values, svptrue_b32())),
-        USE_SLEEF(
-            Vectorized<float>(Sleef_cosfx_u10sve(values)), map(std::cos)));
+    const svbool_t pg = svptrue_b32();
+    const svbool_t large = svacge(pg, values, svdup_n_f32(0x1p20f));
+    if (C10_UNLIKELY(svptest_any(pg, large))) {
+      return USE_SLEEF(
+          Vectorized<float>(Sleef_cosfx_u10sve(values)), map(std::cos));
+    }
+    return Vectorized<float>(cosf_fast_path(values));
   }
   Vectorized<float> cosh() const {
     return map(std::cosh);

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -495,8 +495,13 @@ class Vectorized<float> {
 #if defined(CPU_CAPABILITY_SVE128)
   Vectorized<float> sin() const {
     svfloat32_t sve_input = neon_to_sve(values);
-
-    svfloat32_t sve_result = sinf(sve_input, svptrue_b32());
+    const svbool_t pg = svptrue_b32();
+    const svbool_t large = svacge(pg, sve_input, svdup_n_f32(0x1p20f));
+    if (C10_UNLIKELY(svptest_any(pg, large))) {
+      return USE_SLEEF(
+          Vectorized<float>(Sleef_sinf4_u10(values)), map(std::sin));
+    }
+    svfloat32_t sve_result = sinf_fast_path(sve_input);
 
     return Vectorized<float>(sve_to_neon(sve_result));
   }
@@ -507,8 +512,13 @@ class Vectorized<float> {
 #if defined(CPU_CAPABILITY_SVE128)
   Vectorized<float> cos() const {
     svfloat32_t sve_input = neon_to_sve(values);
-
-    svfloat32_t sve_result = cosf(sve_input, svptrue_b32());
+    const svbool_t pg = svptrue_b32();
+    const svbool_t large = svacge(pg, sve_input, svdup_n_f32(0x1p20f));
+    if (C10_UNLIKELY(svptest_any(pg, large))) {
+      return USE_SLEEF(
+          Vectorized<float>(Sleef_cosf4_u10(values)), map(std::cos));
+    }
+    svfloat32_t sve_result = cosf_fast_path(sve_input);
 
     return Vectorized<float>(sve_to_neon(sve_result));
   }

--- a/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
+++ b/aten/src/ATen/cpu/vec/vec128/vec128_float_neon.h
@@ -492,14 +492,35 @@ class Vectorized<float> {
       nextafter,
       Sleef_nextafterf4)
   Vectorized<float> frac() const;
+#if defined(CPU_CAPABILITY_SVE128)
+  Vectorized<float> sin() const {
+    svfloat32_t sve_input = neon_to_sve(values);
+
+    svfloat32_t sve_result = sinf(sve_input, svptrue_b32());
+
+    return Vectorized<float>(sve_to_neon(sve_result));
+  }
+#else
   DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(sin)
+#endif
+
+#if defined(CPU_CAPABILITY_SVE128)
+  Vectorized<float> cos() const {
+    svfloat32_t sve_input = neon_to_sve(values);
+
+    svfloat32_t sve_result = cosf(sve_input, svptrue_b32());
+
+    return Vectorized<float>(sve_to_neon(sve_result));
+  }
+#else
+  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(cos)
+#endif
   // Sleef sinhf/coshf overflow for large float inputs where std::sinh/cosh
   // return finite results, because Sleef uses float-range intermediates
   // internally while the scalar C library uses double precision.
   Vectorized<float> sinh() const {
     return map(std::sinh);
   }
-  DEFINE_SLEEF_COMPATIBLE_UNARY_ELEMENTWISE_FUNC(cos)
   Vectorized<float> cosh() const {
     return map(std::cosh);
   }

--- a/aten/src/ATen/test/vec_test_all_types.cpp
+++ b/aten/src/ATen/test/vec_test_all_types.cpp
@@ -370,6 +370,106 @@ namespace {
             [](vec v) { return v.cos(); },
             test_case);
     }
+    TEST(TrigonometricFloat, SinPreservesSignedZero) {
+      constexpr int size = vfloat::size();
+      constexpr int zero_count = size > 1 ? size - 1 : size;
+      CACHE_ALIGN float input[size];
+      CACHE_ALIGN float output[size];
+
+      for (const auto i : c10::irange(size)) {
+        input[i] = i % 2 == 0 ? -0.0f : 0.0f;
+      }
+      if constexpr (size > 1) {
+        input[size - 1] = 0x1.be07aap+77f;
+      }
+
+      vfloat::loadu(input).sin().store(output);
+      for (const auto i : c10::irange(zero_count)) {
+        EXPECT_EQ(
+            c10::bit_cast<uint32_t>(input[i]),
+            c10::bit_cast<uint32_t>(output[i]));
+      }
+    }
+    TEST(TrigonometricFloat, SinLargeRangeAndSpecialValues) {
+      const float range_below = 0x1.fffffep+19f;
+      const float range_boundary = 0x1p20f;
+      const float range_above = 0x1.000002p+20f;
+      const float fast_case = 0x1.4b0d9cp+13f;
+      const float large_case = 0x1.be07aap+77f;
+      const float inf = std::numeric_limits<float>::infinity();
+      const float nan = std::numeric_limits<float>::quiet_NaN();
+      auto test_case =
+          TestingCase<vfloat>::getBuilder()
+              .addDomain(CheckWithinDomains<float>{
+                  {{-0x1p80f, -0x1p20f}}, true, 4.0e-7f})
+              .addDomain(CheckWithinDomains<float>{
+                  {{0x1p20f, 0x1p80f}}, true, 4.0e-7f})
+              .addDomain(CheckWithinDomains<float>{
+                  {{range_below, range_above}}, true, 4.0e-7f})
+              .addDomain(CheckWithinDomains<float>{
+                  {{-range_above, -range_below}}, true, 4.0e-7f})
+              .addCustom({{range_below}, std::sin(range_below)})
+              .addCustom({{-range_below}, std::sin(-range_below)})
+              .addCustom({{range_boundary}, std::sin(range_boundary)})
+              .addCustom({{-range_boundary}, std::sin(-range_boundary)})
+              .addCustom({{range_above}, std::sin(range_above)})
+              .addCustom({{-range_above}, std::sin(-range_above)})
+              .addCustom({{fast_case}, std::sin(fast_case)})
+              .addCustom({{-fast_case}, std::sin(-fast_case)})
+              .addCustom({{large_case}, std::sin(large_case)})
+              .addCustom({{-large_case}, std::sin(-large_case)})
+              .addCustom({{inf}, nan})
+              .addCustom({{-inf}, nan})
+              .addCustom({{nan}, nan})
+              .setTrialCount(16000)
+              .setTestSeed(TestSeed());
+      test_unary<vfloat>(
+          NAME_INFO(sin_large_range_and_special_values),
+          RESOLVE_OVERLOAD(std::sin),
+          [](vfloat v) { return v.sin(); },
+          test_case);
+    }
+    TEST(TrigonometricFloat, CosLargeRangeAndSpecialValues) {
+      const float range_below = 0x1.fffffep+19f;
+      const float range_boundary = 0x1p20f;
+      const float range_above = 0x1.000002p+20f;
+      const float fast_case = 0x1.dea2f2p+19f;
+      const float large_case = 0x1.ff3afcp+53f;
+      const float inf = std::numeric_limits<float>::infinity();
+      const float nan = std::numeric_limits<float>::quiet_NaN();
+      auto test_case =
+          TestingCase<vfloat>::getBuilder()
+              .addDomain(CheckWithinDomains<float>{
+                  {{-0x1p80f, -0x1p20f}}, true, 4.0e-7f})
+              .addDomain(CheckWithinDomains<float>{
+                  {{0x1p20f, 0x1p80f}}, true, 4.0e-7f})
+              .addDomain(CheckWithinDomains<float>{
+                  {{range_below, range_above}}, true, 4.0e-7f})
+              .addDomain(CheckWithinDomains<float>{
+                  {{-range_above, -range_below}}, true, 4.0e-7f})
+              .addCustom({{range_below}, std::cos(range_below)})
+              .addCustom({{-range_below}, std::cos(-range_below)})
+              .addCustom({{range_boundary}, std::cos(range_boundary)})
+              .addCustom({{-range_boundary}, std::cos(-range_boundary)})
+              .addCustom({{range_above}, std::cos(range_above)})
+              .addCustom({{-range_above}, std::cos(-range_above)})
+              .addCustom({{fast_case}, std::cos(fast_case)})
+              .addCustom({{-fast_case}, std::cos(-fast_case)})
+              .addCustom({{large_case}, std::cos(large_case)})
+              .addCustom({{-large_case}, std::cos(-large_case)})
+              .addCustom({{0.0f}, 1.0f})
+              .addCustom({{-0.0f}, 1.0f})
+              .addCustom({{inf}, nan})
+              .addCustom({{-inf}, nan})
+              .addCustom({{nan}, nan})
+              .setTrialCount(16000)
+              .setTestSeed(TestSeed());
+      test_unary<vfloat>(
+          NAME_INFO(cos_large_range_and_special_values),
+          RESOLVE_OVERLOAD(std::cos),
+          [](vfloat v) { return v.cos(); },
+          test_case);
+    }
     TYPED_TEST(Trigonometric, Tan) {
         using vec = TypeParam;
         test_unary<vec>(


### PR DESCRIPTION
Add AOR-based float32 SVE implementations for sin and cos and use them in the PyTorch SVE128 and SVE256 vector paths for aarch64 platform.
Support float32 directly, while float16 and bfloat16 use PyTorch's existing conversion through the float32 vector path.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01


### Performance
Benchmarked performance using  a single core of @malfet 's script from https://github.com/pytorch/pytorch/pull/176256#:~:text=slower-,Benchmark%20script,-import%20torch%0Aimport

### Perf vs main (SLEEF) on a single Neoverse-V1 core (SVE256 Vectorizer)

```lua
+-------+------------+----------+---------+
| op    | SLEEF (us) | AOR (us) | Speedup |
+-------+------------+----------+---------+
| sin   |      205.0 |     62.1 |   3.30x |
| cos   |      256.8 |     55.6 |   4.62x |
+-------+------------+----------+---------+
```
### Perf vs main (SLEEF) on a single Neoverse-V2 core (SVE128 Vectorizer)

```lua
+-------+------------+----------+---------+
| op    | SLEEF (us) | AOR (us) | Speedup |
+-------+------------+----------+---------+
| sin   |      243.7 |     77.0 |   3.17x |
| cos   |      312.4 |     69.4 |   4.50x |
+-------+------------+----------+---------+
```

### Accuracy 

The same selected-value tests were run on c8g/SVE128 and c7g/SVE256.

### c8g / Neoverse-V2 / SVE128

#### Zero handling

```text
+------+----------+-------+--------+-----------+--------+
| op   | dtype    | input | actual | reference | status |
+------+----------+-------+--------+-----------+--------+
| sin  | float16  | +0    | +0     | +0        | OK     |
| sin  | float16  | -0    | -0     | -0        | OK     |
+------+----------+-------+--------+-----------+--------+
| sin  | bfloat16 | +0    | +0     | +0        | OK     |
| sin  | bfloat16 | -0    | -0     | -0        | OK     |
+------+----------+-------+--------+-----------+--------+
| sin  | float32  | +0    | +0     | +0        | OK     |
| sin  | float32  | -0    | -0     | -0        | OK     |
+------+----------+-------+--------+-----------+--------+
| cos  | float16  | +0    | 1      | 1         | OK     |
| cos  | float16  | -0    | 1      | 1         | OK     |
+------+----------+-------+--------+-----------+--------+
| cos  | bfloat16 | +0    | 1      | 1         | OK     |
| cos  | bfloat16 | -0    | 1      | 1         | OK     |
+------+----------+-------+--------+-----------+--------+
| cos  | float32  | +0    | 1      | 1         | OK     |
| cos  | float32  | -0    | 1      | 1         | OK     |
+------+----------+-------+--------+-----------+--------+
```

#### AOR documented cases

```text
+------+----------+-------+----------------------+------------------+------------------+--------------+
| op   | dtype    | path  | input                | actual           | reference        | status       |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| sin  | bfloat16 | fast  | 10624 (*)            | -0.7617188       | -0.7617188       | OK           |
| sin  | bfloat16 | large | 2.632719e+23 (**)    | 0.6289062        | 0.6289062        | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| sin  | float32  | fast  | 0x1.4b0d9cp+13       | 0x1.fc28cep-3    | 0x1.fc28d2p-3    | DIFF (2 ULP) |
| sin  | float32  | large | 0x1.be07aap+77       | 0x1.ffe058p-5    | 0x1.ffe058p-5    | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| cos  | bfloat16 | fast  | 978944 (***)         | 0.1660156        | 0.1660156        | OK           |
| cos  | bfloat16 | large | 1.80144e+16 (****)   | -0.4414062       | -0.4414062       | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| cos  | float32  | fast  | 0x1.dea2f2p+19       | 0x1.fffe7ap-6    | 0x1.fffe76p-6    | DIFF (2 ULP) |
| cos  | float32  | large | 0x1.ff3afcp+53       | -0x1.ffe73ap-3   | -0x1.ffe73ap-3   | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
```

```text
(*)    rounded from 0x1.4b0d9cp+13
(**)   rounded from 0x1.be07aap+77
(***)  rounded from 0x1.dea2f2p+19
(****) rounded from 0x1.ff3afcp+53
```

### c7g / Neoverse-V1 / SVE256

#### Zero handling

```text
+------+----------+-------+--------+-----------+--------+
| op   | dtype    | input | actual | reference | status |
+------+----------+-------+--------+-----------+--------+
| sin  | float16  | +0    | +0     | +0        | OK     |
| sin  | float16  | -0    | -0     | -0        | OK     |
+------+----------+-------+--------+-----------+--------+
| sin  | bfloat16 | +0    | +0     | +0        | OK     |
| sin  | bfloat16 | -0    | -0     | -0        | OK     |
+------+----------+-------+--------+-----------+--------+
| sin  | float32  | +0    | +0     | +0        | OK     |
| sin  | float32  | -0    | -0     | -0        | OK     |
+------+----------+-------+--------+-----------+--------+
| cos  | float16  | +0    | 1      | 1         | OK     |
| cos  | float16  | -0    | 1      | 1         | OK     |
+------+----------+-------+--------+-----------+--------+
| cos  | bfloat16 | +0    | 1      | 1         | OK     |
| cos  | bfloat16 | -0    | 1      | 1         | OK     |
+------+----------+-------+--------+-----------+--------+
| cos  | float32  | +0    | 1      | 1         | OK     |
| cos  | float32  | -0    | 1      | 1         | OK     |
+------+----------+-------+--------+-----------+--------+
```

#### AOR documented cases

```text
+------+----------+-------+----------------------+------------------+------------------+--------------+
| op   | dtype    | path  | input                | actual           | reference        | status       |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| sin  | bfloat16 | fast  | 10624 (*)            | -0.7617188       | -0.7617188       | OK           |
| sin  | bfloat16 | large | 2.632719e+23 (**)    | 0.6289062        | 0.6289062        | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| sin  | float32  | fast  | 0x1.4b0d9cp+13       | 0x1.fc28cep-3    | 0x1.fc28d2p-3    | DIFF (2 ULP) |
| sin  | float32  | large | 0x1.be07aap+77       | 0x1.ffe058p-5    | 0x1.ffe058p-5    | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| cos  | bfloat16 | fast  | 978944 (***)         | 0.1660156        | 0.1660156        | OK           |
| cos  | bfloat16 | large | 1.80144e+16 (****)   | -0.4414062       | -0.4414062       | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
| cos  | float32  | fast  | 0x1.dea2f2p+19       | 0x1.fffe7ap-6    | 0x1.fffe76p-6    | DIFF (2 ULP) |
| cos  | float32  | large | 0x1.ff3afcp+53       | -0x1.ffe73ap-3   | -0x1.ffe73ap-3   | OK           |
+------+----------+-------+----------------------+------------------+------------------+--------------+
```

```text
(*)    rounded from 0x1.4b0d9cp+13
(**)   rounded from 0x1.be07aap+77
(***)  rounded from 0x1.dea2f2p+19
(****) rounded from 0x1.ff3afcp+53
```

The FP32 hexadecimal inputs and expected results use the exact representations
documented in the AOR source comments:

- [`sinf.c`](https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/sinf.c)
- [`cosf.c`](https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/cosf.c)

#### Comparison with the x86 AVX2 implementation 

PyTorch's current x86 AVX2 float32 implementation uses
[SLEEF `sinf8_u35` and `cosf8_u35`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/cpu/vec/vec256/vec256_float.h#L400-L411),
which have a documented
[3.5-ULP error bound](https://github.com/shibatch/sleef/blob/master/docs/x86.xhtml#L271-L296).

For vectors where every lane satisfies `|x| < 0x1p20`, AOR reports maximum observed errors of
[`1.44 + 0.5 ULP` for `sinf`](https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/sinf.c#L53-L57)
and
[`1.56 + 0.5 ULP` for `cosf`](https://github.com/ARM-software/optimized-routines/blob/master/math/aarch64/sve/cosf.c#L56-L60).

If any lane satisfies `|x| >= 0x1p20`, the entire vector continues to use the existing SLEEF `u10` implementation. Therefore, large-range behavior and accuracy remain unchanged by this PR.