### PR TITLE
Assign the tensor type prototype instead of memcpy 

### DIFF
--- a/torch/csrc/tensor/python_tensor.cpp
+++ b/torch/csrc/tensor/python_tensor.cpp
@@ -200,7 +200,7 @@ static void py_initialize_tensor_type(
   // we need to initialize as many types as there are VariableType instances.
   // We copy the basic object fields from a prototype definition and initialize
   // the remaining fields below.
-  memcpy(&type, &tensor_type_prototype, sizeof(PyTypeObject));
+  type = tensor_type_prototype;
   // Subclassing from torch.<ScalarType>Tensor isn't supported.
   // (Py_TPFLAGS_BASETYPE omitted). Subclassing torch.Tensor still allowed.
   type.tp_flags = Py_TPFLAGS_DEFAULT;


### PR DESCRIPTION
py_initialize_tensor_type() copies a prototype PyTypeObject into the type it is initializing. Both sides are PyTypeObject, so this is a plain copy, not type punning, and assignment expresses it directly. It also drops the hand-written `sizeof`: with memcpy, changing the parameter's type would silently copy the wrong number of bytes, while assignment is a compile error.

PyTypeObject is trivially copyable and copy-assignable, so the generated code is the same.

Test Plan:

```
static_assert(std::is_copy_assignable_v<PyTypeObject>);
static_assert(std::is_trivially_copyable_v<PyTypeObject>);
```

both hold, and the file compiles with -fsyntax-only against the CPython headers.

This PR description was drafted with AI assistance.