### PR TITLE
Resolve legacy storage classes from the device's own module instead of a hardcoded device list

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -44,7 +44,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     bytes_to_scalar, parametrize, noncontiguous_like,
     AlwaysWarnTypedStorageRemoval, TEST_WITH_TORCHDYNAMO, xfailIfTorchDynamo,
     xfailIfS390X, set_warn_always_context, decorateIf, isRocmArchAnyOf,
-    IS_MACOS,
+    IS_MACOS, NATIVE_DEVICES,
 )
 from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import (
@@ -7964,10 +7964,13 @@ class TestTorch(TestCase):
         self.assertEqual(get_device('not_a_module'), 'cpu')
         self.assertEqual(get_device(''), 'cpu')
 
-        # a device type needs no entry here to be recognised, including the
-        # PrivateUse1 name an out-of-tree accelerator registers
-        for device_type in ('hpu', 'xpu', 'mps', 'mtia',
-                            torch._C._get_privateuse1_backend_name()):
+        # A device type needs no entry here to be recognised. Derived from
+        # NATIVE_DEVICES so this widens on its own when a native device is added,
+        # and it already ends with the PrivateUse1 name an out-of-tree
+        # accelerator registers. 'hpu' is added back because NATIVE_DEVICES does
+        # not carry it and it was one of the three entries in the whitelist this
+        # replaces, so deriving alone would drop that regression.
+        for device_type in sorted((set(NATIVE_DEVICES) | {'hpu'}) - {'cpu'}):
             self.assertEqual(get_device(f'torch.{device_type}'), device_type)
             self.assertEqual(get_device(f'some_package.{device_type}'), device_type)
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -262,10 +262,38 @@ class TestTorchDeviceType(TestCase):
     def test_tensor_storage_type(self, device, dtype):
         a = make_tensor((10,), dtype=dtype, device=device, low=-9, high=9)
 
-        module = torch.cuda if (torch.device(device).type == 'cuda') else torch
+        device_type = torch.device(device).type
+        module = torch if device_type == 'cpu' else getattr(torch, device_type)
         expected_storage_type = getattr(module, torch.storage._dtype_to_storage_type_map()[dtype])
 
         self.assertEqual(a.storage_type(), expected_storage_type)
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float, torch.uint8)
+    def test_legacy_storage_class_from_device_module(self, device, dtype):
+        # A backend owns its legacy storage classes by defining them on its own
+        # device module, so the lookup must follow the module rather than a
+        # whitelist of device types.
+        device_type = torch.device(device).type
+        storage_name = torch.storage._dtype_to_storage_type_map()[dtype]
+        module = torch if device_type == 'cpu' else getattr(torch, device_type, None)
+        expected = getattr(module, storage_name, None)
+
+        storage = torch.empty(4, dtype=dtype, device=device)._typed_storage()
+        self.assertIs(storage._get_legacy_storage_class(), expected)
+
+        if expected is None:
+            # no legacy class for this device/dtype: fall back to TypedStorage
+            self.assertEqual(storage.type(), 'torch.storage.TypedStorage')
+        else:
+            # the class round-trips -- its module resolves back to this device,
+            # which is what makes isinstance() and type() agree with the storage
+            self.assertEqual(
+                torch.storage._get_device_from_module(expected.__module__),
+                device_type)
+            self.assertIsInstance(storage, expected)
+            self.assertEqual(
+                storage.type(), f'{expected.__module__}.{expected.__name__}')
 
     @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bool, torch.bfloat16, torch.uint16, torch.uint32, torch.uint64))
@@ -7924,6 +7952,24 @@ class TestTorch(TestCase):
 
             with self.assertRaisesRegex(RuntimeError, r'Not available for CUDA storage'):
                 storage_class._new_shared_filename(0, 0, 0)
+
+    def test_get_device_from_module(self):
+        # Legacy storage classes live on the device's own module, so the trailing
+        # component of the module name has to resolve to a device type. Anything
+        # that does not is CPU, whose classes live in ``torch`` itself.
+        get_device = torch.storage._get_device_from_module
+        self.assertEqual(get_device('torch'), 'cpu')
+        self.assertEqual(get_device('torch.cuda'), 'cuda')
+        self.assertEqual(get_device('torch.storage'), 'cpu')
+        self.assertEqual(get_device('not_a_module'), 'cpu')
+        self.assertEqual(get_device(''), 'cpu')
+
+        # a device type needs no entry here to be recognised, including the
+        # PrivateUse1 name an out-of-tree accelerator registers
+        for device_type in ('hpu', 'xpu', 'mps', 'mtia',
+                            torch._C._get_privateuse1_backend_name()):
+            self.assertEqual(get_device(f'torch.{device_type}'), device_type)
+            self.assertEqual(get_device(f'some_package.{device_type}'), device_type)
 
     def test_storage_casts(self):
         storage = torch.IntStorage([-1, 0, 1, 2, 3, 4])

--- a/torch/storage.py
+++ b/torch/storage.py
@@ -674,11 +674,21 @@ def _reset_warn_typed_storage_removal():
     _warn_typed_storage_removal.__dict__["has_warned"] = False
 
 
-def _get_device_from_module(module: str):
+def _get_device_from_module(module: str) -> str:
+    """Return the device type whose legacy storage classes live in ``module``.
+
+    A backend puts its legacy storage classes in its own device module --
+    ``torch.cuda``, ``torch.hpu``, out-of-tree ``torch.npu`` -- so the trailing
+    component of the module name is the device type. CPU is the exception: its
+    classes live in ``torch`` itself, which is why an unrecognised name maps to
+    ``"cpu"``. Ask the device-type parser rather than keeping a whitelist of
+    accelerator module names here; this is the same probe
+    :func:`torch._register_device_module` uses to accept a device module.
+    """
     last_part = module.rsplit(".", 1)[-1]
-    if last_part in ["cuda", torch._C._get_privateuse1_backend_name(), "hpu"]:
-        return last_part
-    else:
+    try:
+        return torch.device(last_part).type
+    except RuntimeError:
         return "cpu"
 
 
@@ -1502,22 +1512,16 @@ class TypedStorage:
 
         storage_name = _dtype_to_storage_type_map()[self.dtype]
 
-        if self.device.type not in [
-            "cpu",
-            "cuda",
-            "hpu",
-            torch._C._get_privateuse1_backend_name(),
-        ]:
-            return None
-
+        # A backend owns its legacy storage classes by defining them on its
+        # device module; CPU's live on ``torch`` itself. A missing module or a
+        # missing class means this device has no legacy class for this dtype,
+        # which is exactly what a whitelist of device types used to encode.
         module = (
-            torch if self.device.type == "cpu" else getattr(torch, self.device.type)
+            torch
+            if self.device.type == "cpu"
+            else getattr(torch, self.device.type, None)
         )
-
-        try:
-            return getattr(module, storage_name)
-        except AttributeError:
-            return None
+        return getattr(module, storage_name, None)
 
 
 TypedStorage.type.__doc__ = _type.__doc__


### PR DESCRIPTION
Related to this RFC: #194355

`_get_device_from_module` and `TypedStorage._get_legacy_storage_class` in
`torch/storage.py` each carried a hardcoded list of device types. Both encode the
same fact — a backend owns its legacy storage classes by defining them on the
device module it registers through `torch._register_device_module`, with CPU as
the exception whose classes live on `torch` itself — so both can ask instead of
listing.

`_get_device_from_module` now resolves the trailing module component with
`torch.device(last_part).type`, the same probe `_register_device_module` uses to
accept a device module, falling back to `"cpu"` when the parser rejects it.
`_get_legacy_storage_class` drops its whitelist entirely; it already resolved the
module and caught `AttributeError` for a missing class, which answers the same
question.

No behavior change for any backend that works today. In-tree, only `torch` and
`torch.cuda` define legacy storage classes — `torch.cpu`, `torch.xpu`,
`torch.mps` and `torch.mtia` define none, so the lookup returns `None` for them
exactly as the whitelist did. Verified on a CPU-only build for `float32`,
`bfloat16`, `qint8` and `float8_e4m3fn`, and for the `meta` device.

Two differences I want to flag rather than have a reviewer find:

- A device type outside the old whitelist that *does* define legacy storage
  classes now resolves to its own module instead of silently falling back to
  `"cpu"`. That is the intent of the change, and it is unreachable in-tree today.
- After `rename_privateuse1_backend("npu")`, a module literally named
  `*.privateuseone` resolves to `"npu"` rather than `"cpu"`, because
  `torch.device` normalizes the generic spelling to the registered backend name. A
  backend names its module after the registered name, so this is not reachable
  either, but it is a real difference from a string compare against
  `_get_privateuse1_backend_name()`.

Also fixes an existing test that hardcoded the same chain.
`test_tensor_storage_type` computed its expected class as "`torch.cuda` if CUDA
else `torch`", and it is decorated `@onlyNativeDeviceTypes` where `NATIVE_DEVICES`
includes the PrivateUse1 backend name — so on an out-of-tree accelerator it
asserted the CPU storage class against that backend's own, since
`Tensor.storage_type()` is `_get_legacy_storage_class()`. It now derives the
expectation the way the production code does.

Two tests added: a device-parameterized one asserting the class comes from the
device's module and round-trips back to that device through
`_get_device_from_module`, `isinstance` and `TypedStorage.type()`; and a generic
one covering the module-name-to-device-type mapping, which is pure string handling
and needs no accelerator. The device-parameterized test covers PrivateUse1 with no
entry in the test file, since `instantiate_device_type_tests` adds that base
whenever the backend is available.

**Testing.** On CPU: `test_torch.TestTorch` (229) and the storage subset of
`TestTorchDeviceTypeCPU` (121) pass, both new tests pass, and
`test_get_device_from_module` fails against the old implementation, so it is not
vacuous. On CUDA (Tesla T4): `TestTorchDeviceTypeCUDA -k storage` 121 pass,
`-k tensor_storage_type` 12 pass, `-k legacy_storage_class` 2 pass —
`Tensor.storage_type()`, `_get_legacy_storage_class()` and `TypedStorage.type()`
all still resolve to `torch.cuda.FloatStorage` / `'torch.cuda.FloatStorage'`.
`lintrunner` clean on both files.

To be precise about what the CUDA run shows: it is a no-regression result, not a
discriminating one, because `cuda` is in the whitelist being removed and old and
new code are expected to agree there. The same holds for PrivateUse1 in
`_get_legacy_storage_class`. The behavior that actually differs is
`_get_device_from_module` for a device type outside the old list, covered by the
new generic test. I have **not** run the PrivateUse1 instantiation, so the claim
that `test_tensor_storage_type` currently fails on an out-of-tree backend and
passes after this change is reasoned from `NATIVE_DEVICES` and
`Tensor.storage_type()`, not measured.


