### PR TITLE
Include x86gprintrin.h rather than x86intrin.h for __rdtsc

### DIFF
--- a/c10/util/ApproximateClock.h
+++ b/c10/util/ApproximateClock.h
@@ -25,7 +25,11 @@
 // `__rdtsc` is available by default.
 // NB: This has to be first, because Clang will also define `__GNUC__`
 #elif defined(__GNUC__)
-#include <x86intrin.h>
+// x86gprintrin.h is the general-purpose subset that declares __rdtsc. Including
+// x86intrin.h instead pulls in every vector intrinsic header, which costs tens
+// of thousands of preprocessed lines in each of the ~850 targets that reach
+// this header.
+#include <x86gprintrin.h>
 #else
 #undef C10_RDTSC
 #endif


### PR DESCRIPTION
x86intrin.h pulls in the whole vector-intrinsic tree (avx512f, avx512vl, avx512fp16, ...) just to get __rdtsc, and those headers get preprocessed regardless of target flags. x86gprintrin.h declares __rdtsc on its own without the vector headers, cutting preprocessed lines for ApproximateClock.h from 148055 to 96146 across ~850 CUDA build targets. Available since GCC 11, below our GCC 11.3 floor.

Test Plan:
```
g++-15 -std=c++20 -E -I. clk.cpp | wc -l    # 148055 -> 96146
g++-15 -std=c++20 -I. -o clk clk.cpp && ./clk   # getApproximateTime() nonzero
```

> Drafted with Claude Code assistance; reviewed by me before opening.