### PR TITLE
[dynamo] Fix FP64 softmax repro arguments

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import ast
+import itertools
 import math
 import os
 from unittest.mock import patch
@@ -173,6 +174,44 @@ def forward(self, x_1):
     return (convert_element_type, _to_copy, full, empty)
     """,
         )
+
+    def test_cast_model_to_fp64_disables_half_to_float(self):
+        for op_name, overload, use_kwargs in itertools.product(
+            ("_softmax", "_log_softmax"),
+            ("default", "out"),
+            (False, True),
+        ):
+            with self.subTest(
+                op_name=op_name, overload=overload, use_kwargs=use_kwargs
+            ):
+                graph = torch.fx.Graph()
+                x = graph.placeholder("x")
+                op = getattr(getattr(torch.ops.aten, op_name), overload)
+                kwargs = {}
+                inputs = [torch.randn(2, 4, dtype=torch.float16)]
+                if overload == "out":
+                    kwargs["out"] = graph.placeholder("out")
+                    inputs.append(torch.empty(2, 4, dtype=torch.float16))
+                if use_kwargs:
+                    kwargs["half_to_float"] = True
+                    output = graph.call_function(op, args=(x, 1), kwargs=kwargs)
+                else:
+                    output = graph.call_function(op, args=(x, 1, True), kwargs=kwargs)
+                graph.output(output)
+                model = torch.fx.GraphModule({}, graph)
+
+                fp64_model, fp64_inputs = debug_utils.cast_to_fp64(model, inputs)
+                softmax = next(
+                    node
+                    for node in fp64_model.graph.nodes
+                    if node.op == "call_function"
+                )
+                half_to_float = (
+                    softmax.kwargs["half_to_float"] if use_kwargs else softmax.args[2]
+                )
+
+                self.assertFalse(half_to_float)
+                self.assertEqual(fp64_model(*fp64_inputs).dtype, torch.float64)
 
     @patch.dict(
         os.environ,

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -687,6 +687,12 @@ def same_two_models(
 
 
 def cast_dtype_args_to_fp64(model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    half_to_float_ops = (
+        torch.ops.aten._softmax.default,
+        torch.ops.aten._softmax.out,
+        torch.ops.aten._log_softmax.default,
+        torch.ops.aten._log_softmax.out,
+    )
     for node in model.graph.nodes:
         if (
             node.op == "call_function"
@@ -704,6 +710,14 @@ def cast_dtype_args_to_fp64(model: torch.fx.GraphModule) -> torch.fx.GraphModule
                 new_kwargs = dict(node.kwargs)
                 new_kwargs["dtype"] = torch.float64
                 node.kwargs = new_kwargs
+        if node.op == "call_function" and node.target in half_to_float_ops:
+            # FP64 inputs are incompatible with half_to_float=True.
+            if bool(node.kwargs.get("half_to_float", False)):
+                new_kwargs = dict(node.kwargs)
+                new_kwargs["half_to_float"] = False
+                node.kwargs = new_kwargs
+            elif len(node.args) >= 3 and bool(node.args[2]):
+                node.args = (*node.args[:2], False, *node.args[3:])
 
     model.graph.lint()
     model.recompile()


### PR DESCRIPTION
## Issue

Fixes #194594

## Summary

Update `cast_dtype_args_to_fp64` to disable `half_to_float` after softmax and log-softmax inputs are promoted to FP64. Cover the default and out overloads with positional and keyword arguments using a device-independent CPU regression test.

## Testing

- `python -m py_compile test/dynamo/test_debug_utils.py torch/_dynamo/debug_utils.py`
- `lintrunner --take PYFMT,FLAKE8,RUFF,TYPEIGNORE,TYPENOSKIP,NOQA,TESTOWNERS,TEST_HAS_MAIN,CODESPELL,NEWLINE,SPACES,TABS test/dynamo/test_debug_utils.py torch/_dynamo/debug_utils.py`
- The targeted runtime test was not run locally because this checkout does not have a built PyTorch `_C` extension; it is covered by the upstream test suite.

## Checklist

- [x] Passes targeted lint
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results (not applicable; no performance impact)

## BC-breaking?

No. This only changes the generated FP64 debugging/reference graph.

## AI assistance disclosure

> Codex helped adapt my downstream fix to the upstream tree, draft the CPU-only regression coverage, and prepare this PR description.

I previously investigated this failure downstream and reviewed the same core transformation across `_softmax`/`_log_softmax`, default/out overloads, and positional/keyword forms. The upstream patch intentionally contains no accelerator-specific behavior. This PR is a draft so the exact upstream diff can receive a final human review before being marked ready.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98