### PR TITLE
[Test] Support any-match capability gating and callable arg_values in parametrize

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -307,7 +307,7 @@ with _temp_test_configs(
 class TestCapabilityGating(TestCase):
     """Verify that @requires_capabilities gates tests on PrivateUse1 backends."""
 
-    executed_count = 0
+    _executed: dict = defaultdict(int)
 
     @classmethod
     def setUpClass(cls):
@@ -318,44 +318,56 @@ class TestCapabilityGating(TestCase):
             lambda cls: {
                 Capability.dtype.fp8: lambda: True,
                 Capability.dtype.bf16: lambda: False,
+                Capability.attention.flash_attention: lambda: True,
+                Capability.attention.mem_efficient_attention: lambda: False,
             }
         )
 
     @classmethod
     def tearDownClass(cls):
         PrivateUse1TestBase._capabilities = cls._saved_capabilities
-        expected_runs = 3
-        if cls.executed_count != expected_runs:
-            raise AssertionError(
-                f"Capability gating failed! "
-                f"Expected {expected_runs} tests to run, "
-                f"but {cls.executed_count} tests executed."
-            )
+        expected = {
+            "test_capability_supported": 1,
+            "test_capability_unsupported": 0,
+            "test_capability_missing": 1,
+            "test_capability_combined": 1,
+            "test_any_supported": 1,
+            "test_any_unsupported": 0,
+            "test_any_missing": 1,
+            "test_any_partially_missing": 1,
+        }
+        for name, count in expected.items():
+            if cls._executed[name] != count:
+                raise AssertionError(
+                    f"{name} ran {cls._executed[name]} times, expected {count}"
+                )
         super().tearDownClass()
+
+    # AND semantics (default).
 
     @requires_capabilities(Capability.dtype.fp8)
     def test_capability_supported(self, device):
-        type(self).executed_count += 1
+        type(self)._executed["test_capability_supported"] += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
     @requires_capabilities(Capability.dtype.bf16)
     def test_capability_unsupported(self, device):
-        type(self).executed_count += 1
+        type(self)._executed["test_capability_unsupported"] += 1
         self.fail("Expected skip: dtype.bf16 is unsupported on this device")
 
     def test_capability_missing(self, device):
         """@requires_capabilities raises AssertionError for undeclared capabilities."""
 
-        @requires_capabilities(Capability.attention.flash_attention)
+        @requires_capabilities(Capability.attention.cudnn_attention)
         def dummy(self):
             self.fail("should not execute")
 
         with self.assertRaisesRegex(
             AssertionError,
-            r"has not declared capabilities: attention\.flash_attention",
+            r"has not declared capabilities: attention\.cudnn_attention",
         ):
             dummy(self)
-        type(self).executed_count += 1
+        type(self)._executed["test_capability_missing"] += 1
 
     def test_capability_combined(self, device):
         """@requires_capabilities raises AssertionError when a combined set
@@ -363,18 +375,66 @@ class TestCapabilityGating(TestCase):
 
         @requires_capabilities(
             Capability.dtype.fp8,
-            Capability.dtype.bf16,
-            Capability.attention.flash_attention,
+            Capability.attention.cudnn_attention,
         )
         def dummy(self):
             self.fail("should not execute")
 
         with self.assertRaisesRegex(
             AssertionError,
-            r"has not declared capabilities: attention\.flash_attention",
+            r"has not declared capabilities: attention\.cudnn_attention",
         ):
             dummy(self)
-        type(self).executed_count += 1
+        type(self)._executed["test_capability_combined"] += 1
+
+    # OR semantics (any=True).
+
+    @requires_capabilities(
+        Capability.attention.flash_attention,
+        Capability.attention.mem_efficient_attention,
+        any=True,
+    )
+    def test_any_supported(self, device):
+        type(self)._executed["test_any_supported"] += 1
+        self.assertEqual(torch.device(device).type, "openreg")
+
+    @requires_capabilities(Capability.attention.mem_efficient_attention, any=True)
+    def test_any_unsupported(self, device):
+        type(self)._executed["test_any_unsupported"] += 1
+        self.fail("Expected skip: mem_efficient_attention is unsupported")
+
+    def test_any_missing(self, device):
+        """any=True asserts when none of the capabilities are declared."""
+
+        @requires_capabilities(Capability.attention.cudnn_attention, any=True)
+        def dummy(self):
+            self.fail("should not execute")
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"has not declared any of the required capabilities: attention\.cudnn_attention",
+        ):
+            dummy(self)
+        type(self)._executed["test_any_missing"] += 1
+
+    def test_any_partially_missing(self, device):
+        """any=True skips (not asserts) when some capabilities are declared but
+        none are supported, even if others are undeclared."""
+
+        @requires_capabilities(
+            Capability.attention.mem_efficient_attention,  # declared, unsupported
+            Capability.attention.cudnn_attention,  # undeclared
+            any=True,
+        )
+        def dummy(self):
+            self.fail("should not execute")
+
+        with self.assertRaisesRegex(
+            unittest.SkipTest,
+            r"does not satisfy any of the required capabilities",
+        ):
+            dummy(self)
+        type(self)._executed["test_any_partially_missing"] += 1
 
 
 instantiate_device_type_tests(TestCapabilityGating, globals(), only_for="openreg")

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_testing.py
@@ -319,7 +319,6 @@ class TestCapabilityGating(TestCase):
                 Capability.dtype.fp8: lambda: True,
                 Capability.dtype.bf16: lambda: False,
                 Capability.attention.flash_attention: lambda: True,
-                Capability.attention.mem_efficient_attention: lambda: False,
             }
         )
 
@@ -398,21 +397,26 @@ class TestCapabilityGating(TestCase):
         type(self)._executed["test_any_supported"] += 1
         self.assertEqual(torch.device(device).type, "openreg")
 
-    @requires_capabilities(Capability.attention.mem_efficient_attention, any=True)
+    @requires_capabilities(Capability.dtype.bf16, any=True)
     def test_any_unsupported(self, device):
         type(self)._executed["test_any_unsupported"] += 1
-        self.fail("Expected skip: mem_efficient_attention is unsupported")
+        self.fail("Expected skip: dtype.bf16 is unsupported under any=True")
 
     def test_any_missing(self, device):
         """any=True asserts when none of the capabilities are declared."""
 
-        @requires_capabilities(Capability.attention.cudnn_attention, any=True)
+        @requires_capabilities(
+            Capability.attention.cudnn_attention,
+            Capability.attention.mem_efficient_attention,
+            any=True,
+        )
         def dummy(self):
             self.fail("should not execute")
 
         with self.assertRaisesRegex(
             AssertionError,
-            r"has not declared any of the required capabilities: attention\.cudnn_attention",
+            r"has not declared any of the required capabilities: "
+            r"attention\.cudnn_attention, attention\.mem_efficient_attention",
         ):
             dummy(self)
         type(self)._executed["test_any_missing"] += 1
@@ -422,8 +426,8 @@ class TestCapabilityGating(TestCase):
         none are supported, even if others are undeclared."""
 
         @requires_capabilities(
-            Capability.attention.mem_efficient_attention,  # declared, unsupported
-            Capability.attention.cudnn_attention,  # undeclared
+            Capability.dtype.bf16,
+            Capability.attention.cudnn_attention,
             any=True,
         )
         def dummy(self):
@@ -431,7 +435,9 @@ class TestCapabilityGating(TestCase):
 
         with self.assertRaisesRegex(
             unittest.SkipTest,
-            r"does not satisfy any of the required capabilities",
+            r"does not satisfy any of the required capabilities: "
+            r"unsupported capabilities: dtype\.bf16; "
+            r"missing capabilities: attention\.cudnn_attention",
         ):
             dummy(self)
         type(self)._executed["test_any_partially_missing"] += 1

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -2614,6 +2614,36 @@ class TestTestParametrizationDeviceType(TestCase):
         if x == 1 or y == 6:
             raise RuntimeError('Boom')
 
+    def test_parametrize_callable_fixed(self, device):
+
+        class TestParametrized(TestCase):
+            @parametrize("arg_name", lambda _: ["a", "b", "c"])
+            def test_foo(self, device, arg_name):
+                pass
+
+        locals_dict = dict(locals())
+        instantiate_device_type_tests(
+            TestParametrized,
+            locals_dict,
+            only_for=device,
+        )
+
+        device_cls = locals_dict[f"TestParametrized{self.device_type.upper()}"]
+
+        self.assertEqual(
+            _get_test_names_for_test_class(device_cls),
+            [
+                f"{device_cls.__name__}.test_foo_arg_name_a_{self.device_type}",
+                f"{device_cls.__name__}.test_foo_arg_name_b_{self.device_type}",
+                f"{device_cls.__name__}.test_foo_arg_name_c_{self.device_type}",
+            ],
+        )
+
+
+    @parametrize("backend", lambda device_cls: [device_cls.device_type])
+    def test_parametrize_callable_backend(self, device, backend):
+        self.assertEqual(torch.device(device).type, backend)
+
 
 instantiate_parametrized_tests(TestTestParametrization)
 instantiate_device_type_tests(TestTestParametrizationDeviceType, globals())

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -348,6 +348,7 @@ class Capability:
 
         flash_attention = "attention.flash_attention"
         mem_efficient_attention = "attention.mem_efficient_attention"
+        cudnn_attention = "attention.cudnn_attention"
 
 
 class DeviceTypeTestBase(TestCase):
@@ -793,6 +794,7 @@ class CPUTestBase(DeviceTypeTestBase):
             Capability.dtype.bf16: lambda: True,
             Capability.attention.flash_attention: lambda: True,
             Capability.attention.mem_efficient_attention: lambda: False,
+            Capability.attention.cudnn_attention: lambda: False,
         }
 
 
@@ -811,6 +813,7 @@ class CUDATestBase(DeviceTypeTestBase):
     @classmethod
     def _capabilities(cls):
         from torch.testing._internal.common_cuda import (
+            PLATFORM_SUPPORTS_CUDNN_ATTENTION,
             PLATFORM_SUPPORTS_FLASH_ATTENTION,
             PLATFORM_SUPPORTS_FP8,
             PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
@@ -822,6 +825,7 @@ class CUDATestBase(DeviceTypeTestBase):
             Capability.dtype.bf16: lambda: SM80OrLater,
             Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION,
             Capability.attention.mem_efficient_attention: lambda: PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+            Capability.attention.cudnn_attention: lambda: PLATFORM_SUPPORTS_CUDNN_ATTENTION,
         }
 
     @classmethod
@@ -907,6 +911,7 @@ class MPSTestBase(DeviceTypeTestBase):
             Capability.dtype.bf16: lambda: True,
             Capability.attention.flash_attention: lambda: False,
             Capability.attention.mem_efficient_attention: lambda: False,
+            Capability.attention.cudnn_attention: lambda: False,
         }
 
 
@@ -925,6 +930,7 @@ class XPUTestBase(DeviceTypeTestBase):
             Capability.dtype.bf16: lambda: True,
             Capability.attention.flash_attention: lambda: PLATFORM_SUPPORTS_FLASH_ATTENTION_XPU,
             Capability.attention.mem_efficient_attention: lambda: True,
+            Capability.attention.cudnn_attention: lambda: False,
         }
 
     @classmethod
@@ -1179,13 +1185,18 @@ def get_desired_device_type_test_bases(
     )
 
 
-def requires_capabilities(*caps: str):
+def requires_capabilities(*caps: str, any: bool = False):
     """Declare that a test method requires device capabilities.
 
     Wraps the test to call ``type(self).get_capabilities()`` at runtime
-    and skip if any required capability is unsupported by the device.
+    and skip if the device does not satisfy the requirement.
 
-    Raises AssertionError if a capability is not declared in the
+    By default, all capabilities must be supported (AND semantics). Pass
+    ``any=True`` to require only one of them (OR semantics). With
+    ``any=True``, undeclared capabilities are tolerated unless none of the
+    required capabilities are declared.
+
+    Raises AssertionError if a required capability is not declared in the
     device's ``_capabilities()`` map.
     """
     caps_set = set(caps)
@@ -1195,14 +1206,33 @@ def requires_capabilities(*caps: str):
         def wrapper(self, *args, **kwargs):
             device_caps = type(self).get_capabilities()
 
-            unsupported = set()
-            missing = set()
-            for c in caps_set:
-                if c in device_caps:
-                    if not device_caps[c]:
-                        unsupported.add(c)
-                else:
-                    missing.add(c)
+            missing = {c for c in caps_set if c not in device_caps}
+            unsupported = {c for c in caps_set - missing if not device_caps[c]}
+
+            if any:
+                if missing == caps_set:
+                    raise AssertionError(
+                        f"Device '{type(self).device_type}' has not declared any of the "
+                        f"required capabilities: {', '.join(sorted(caps_set))}. "
+                        f"Add them to {type(self).__name__}._capabilities()."
+                    )
+
+                supported = caps_set - missing - unsupported
+                if supported:
+                    return fn(self, *args, **kwargs)
+
+                parts = []
+                if unsupported:
+                    parts.append(
+                        f"unsupported capabilities: {', '.join(sorted(unsupported))}"
+                    )
+                if missing:
+                    parts.append(f"missing capabilities: {', '.join(sorted(missing))}")
+
+                raise unittest.SkipTest(
+                    f"Device '{type(self).device_type}' does not satisfy any of the "
+                    f"required capabilities: {'; '.join(parts)}"
+                )
 
             if missing:
                 raise AssertionError(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -835,6 +835,9 @@ class parametrize(_TestParametrizer):
         arg_str (str): String of arg names separate by commas (e.g. "x,y").
         arg_values (iterable): Iterable of arg values (e.g. range(10)) or
             tuples of arg values (e.g. [(1, 2), (3, 4)]).
+            May also be a callable that returns such an iterable. For device-type tests,
+            the callable receives the instantiated device test class, allowing the
+            parameter values to depend on device-specific properties.
         name_fn (Callable): Optional function that takes in parameters and returns subtest name.
     """
     def __init__(self, arg_str, arg_values, name_fn=None):
@@ -878,7 +881,10 @@ class parametrize(_TestParametrizer):
             # * A tuple of values with one for each arg. For a single arg, a single item is expected.
             # * A subtest instance with arg_values matching the previous.
             values = check_exhausted_iterator = object()
-            for idx, values in enumerate(self.arg_values):
+            arg_values = self.arg_values
+            if callable(arg_values):
+                arg_values = arg_values(device_cls)
+            for idx, values in enumerate(arg_values):
                 maybe_name = None
 
                 decorators: list[Any] = []


### PR DESCRIPTION
## Summary

Adds two extensions to the device-type test infrastructure:

- `@requires_capabilities(..., any=True)` for OR-style capability gating.
- Callable `arg_values` for `@parametrize`, allowing parameters to depend on the instantiated device test class.



## Motivation

These changes help migrate SDPA tests away from static `PLATFORM_SUPPORTS_*` flags toward device capabilities.

Some attention tests need:

- any one of several backends to be supported;
- parameter lists derived from the backends supported by the current device.



## Changes

- Add `any=True` to `requires_capabilities`

  - Runs when any requested capability is supported.
  - Skips when capabilities are declared but none are supported.
  - Raises when none of the requested capabilities are declared.

- Add `Capability.attention.cudnn_attention`.

- Allow `@parametrize` `arg_values` to be callable and receive the instantiated device test class.

- Add tests for `any=True` capability gating and callable `arg_values`.

  

## Test Plan

- Capability gating (OpenReg) :  `pytest tests/test_testing.py -vvv -k 'capability'`   
  - ` 6 passed, 2 skipped, 22 deselected in 0.94s `
- Callable parametrization (CPU/CUDA): `pytest test/test_testing.py -vvv -k "test_parametrize_callable" `
  - `4 passed, 4089 deselected in 3.34s `

