### PR TITLE
[Elastic] Close mkstemp file descriptor in _create_file_store to prevent descriptor leak

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,22 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
+    )
+    def test_create_file_store_closes_mkstemp_fd(
+        self, filestore_mock, mkstemp_mock, close_mock
+    ) -> None:
+        fake_fd = 42
+        fake_path = "/tmp/fake_rendezvous_file"
+        mkstemp_mock.return_value = (fake_fd, fake_path)
+        self._params_filestore.endpoint = ""
+
+        create_backend(self._params_filestore)
+
+        mkstemp_mock.assert_called_once()
+        close_mock.assert_called_once_with(fake_fd)
+        filestore_mock.assert_called_once_with(fake_path)

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,8 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
Fixes #191394

### Description
In `torch.distributed.elastic.rendezvous.c10d_rendezvous_backend._create_file_store()`, `tempfile.mkstemp()` is called when no endpoint is supplied. Previously, the returned file descriptor was discarded (`_, path = tempfile.mkstemp()`) without being closed.

Since `FileStore(path)` opens the path independently, the OS file descriptor allocated by `mkstemp()` was leaked in the Python process on every temporary FileStore creation.

This PR:
1. Captures `fd, path = tempfile.mkstemp()` and immediately closes `os.close(fd)`.
2. Adds a regression test in `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py` to verify that `os.close(fd)` is called on the created file descriptor.

### Test Plan
Ran unittest:
```bash
python test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py

test_create_file_store_closes_mkstemp_fd ... ok
Ran 1 test in 0.001s
OK
