### PR TITLE
Clamp default num_threads to cpuset/affinity mask

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -447,6 +447,21 @@ test_python() {
   assert_git_not_dirty
 }
 
+test_cpuset_num_threads() {
+  # Regression test for https://github.com/pytorch/pytorch/issues/193859
+  # When the process is restricted to a single CPU via a cpuset/affinity mask,
+  # the default intraop thread count must respect that limit rather than the
+  # host's physical core count. Clear the *_NUM_THREADS env vars so the count
+  # is derived from the affinity mask instead of an explicit override.
+  if ! command -v taskset >/dev/null; then
+    echo "taskset not available, skipping cpuset num_threads test"
+    return
+  fi
+  env -u OMP_NUM_THREADS -u MKL_NUM_THREADS taskset -c 0 python -c \
+    'import torch; n = torch.get_num_threads(); print("num_threads =", n); assert n == 1, n'
+  assert_git_not_dirty
+}
+
 test_python_smoke() {
   # Smoke tests for H100/B200
   install_nvmath
@@ -2595,6 +2610,7 @@ elif [[ "${TEST_CONFIG}" == "tsan" ]]; then
 else
   install_torchvision
   install_monkeytype
+  test_cpuset_num_threads
   test_python
   test_aten
   test_vec256

--- a/c10/core/thread_pool.cpp
+++ b/c10/core/thread_pool.cpp
@@ -5,7 +5,28 @@
 #include <cpuinfo.h>
 #endif
 
+#if defined(__linux__)
+#include <sched.h>
+#endif
+
 namespace c10 {
+
+namespace {
+// Number of CPUs the current process is allowed to run on. On Linux this
+// respects the process' CPU affinity mask (i.e. a cpuset/taskset
+// restriction), which cpuinfo does not account for. Returns 0 if the limit
+// is unknown, in which case callers should ignore it.
+size_t get_cpuset_num_threads() {
+#if defined(__linux__)
+  cpu_set_t cpu_set;
+  CPU_ZERO(&cpu_set);
+  if (sched_getaffinity(0, sizeof(cpu_set), &cpu_set) == 0) {
+    return CPU_COUNT(&cpu_set);
+  }
+#endif
+  return 0;
+}
+} // namespace
 
 size_t TaskThreadPoolBase::defaultNumThreads() {
   size_t num_threads = 0;
@@ -16,14 +37,26 @@ size_t TaskThreadPoolBase::defaultNumThreads() {
     size_t num_cores = cpuinfo_get_cores_count();
     num_threads = cpuinfo_get_processors_count();
     if (num_cores > 0 && num_cores < num_threads) {
-      return num_cores;
+      num_threads = num_cores;
     }
     if (num_threads > 0) {
+      // cpuinfo reports the host topology and ignores any cpuset/affinity
+      // restriction on the current process, so clamp to the number of CPUs
+      // this process is actually allowed to run on.
+      size_t cpuset_threads = get_cpuset_num_threads();
+      if (cpuset_threads > 0 && cpuset_threads < num_threads) {
+        num_threads = cpuset_threads;
+      }
       return num_threads;
     }
   }
 #endif
   num_threads = std::thread::hardware_concurrency();
+  size_t cpuset_threads = get_cpuset_num_threads();
+  if (cpuset_threads > 0 &&
+      (num_threads == 0 || cpuset_threads < num_threads)) {
+    num_threads = cpuset_threads;
+  }
   if (num_threads == 0) {
     num_threads = 1;
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #194605

When no explicit thread count is given, TaskThreadPoolBase::defaultNumThreads() derived the default from cpuinfo, which reports the host's topology (physical cores / processors) and ignores the calling process' CPU affinity mask. In a cpuset/taskset-restricted environment (e.g. a Kubernetes pod pinned to a subset
of cores) this makes PyTorch spawn as many threads as the host has cores, which is inefficient and under a tight ulimit on processes this fails at import with:
```
    libgomp: Thread creation failed: Resource temporarily unavailable
```

Fixes #193859

Test Plan:
Added test_cpuset_num_threads() to .ci/pytorch/test.sh (wired into the default
Linux test branch), which pins the process to a single CPU and asserts the
default thread count collapses to 1:

```
env -u OMP_NUM_THREADS -u MKL_NUM_THREADS taskset -c 0 python -c \
  'import torch; n = torch.get_num_threads(); assert n == 1, n'
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>