### PR TITLE
[Test] Gate FP8 row-wise sample on device support in sample_inputs_scaled_mm_v2

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9433,31 +9433,42 @@ def sample_inputs_scaled_mm_v2(op_info, device, dtype, requires_grad, **kwargs):
             torch.bfloat16,  # out_dtype
         )
     )
-    # two e4m3 rowwise
-    mat1 = make_mat_e4m3((M, K))
-    mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
-    scale1 = make_scale((M, 1))
-    scale2 = make_scale((1, N))
-    samples.append(
-        SampleInput(
-            mat1,
-            mat2,
-            [scale1, ],
-            [ScalingType.RowWise, ],
-            [SwizzleType.NO_SWIZZLE, ],
-            [scale2, ],
-            [ScalingType.RowWise, ],
-            [SwizzleType.NO_SWIZZLE, ],
-            None,  # bias
-            torch.bfloat16,  # out_dtype
+    rowwise_supported = True
+    if torch.device(device).type == "cuda" and not torch.version.hip:
+        dmajor, dminor = torch.cuda.get_device_capability(torch.device(device))
+        cuda_version = _get_torch_cuda_version()
+        # Gate samples as the CUTLASS kernel in RowwiseScaledMM.cu isn't built on Windows
+        # (BUILD_ROWWISE_FP8_KERNEL is gated on !defined(_WIN32)). Mirrors the CUTLASS vs cuBLAS
+        # dispatch in _scaled_rowwise_rowwise() (aten/src/ATen/native/cuda/ScaledBlas.cpp); the
+        # scales below are 2-D so the !sizes().empty() check is omitted here.
+        is_cutlass_path = dmajor < 9 or cuda_version < (12, 9) or dmajor >= 10
+        rowwise_supported = not (is_cutlass_path and IS_WINDOWS)
+    if rowwise_supported:
+        # two e4m3 rowwise
+        mat1 = make_mat_e4m3((M, K))
+        mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
+        scale1 = make_scale((M, 1))
+        scale2 = make_scale((1, N))
+        samples.append(
+            SampleInput(
+                mat1,
+                mat2,
+                [scale1, ],
+                [ScalingType.RowWise, ],
+                [SwizzleType.NO_SWIZZLE, ],
+                [scale2, ],
+                [ScalingType.RowWise, ],
+                [SwizzleType.NO_SWIZZLE, ],
+                None,  # bias
+                torch.bfloat16,  # out_dtype
+            )
         )
-    )
     M, K, N = 256, 512, 768
     mat1 = make_mat_e4m3((M, K))
     mat2 = make_mat_e4m3((K, N)).t().contiguous().t()
 
     if torch.device(device).type == "cuda":
-        dmajor, dminor = torch.cuda.get_device_capability()
+        dmajor, dminor = torch.cuda.get_device_capability(torch.device(device))
 
         # Blockwise scaling requires cublasLt >= 12.9 (CUDA 12.9+)
         # See: https://github.com/pytorch/pytorch/issues/172227


### PR DESCRIPTION

### Summary

Row-wise FP8 dispatches to the CUTLASS kernel in RowwiseScaledMM.cu, which is not built on Windows (BUILD_ROWWISE_FP8_KERNEL is gated on !defined(_WIN32)). The RowWise sample is generated unconditionally, so op_db tests running it fail with 'Rowwise scaling is not currently supported on your device'. Gate the sample on device support, mirroring the dispatch condition in _scaled_rowwise_rowwise().

Also pass the test device explicitly to get_device_capability() at both the row-wise and blockwise sites.

### Fixes

This PR fixes following sample failure. 

```
$ pytest test/test_overrides.py -k scaled_mm_v2 -v

FAILED test_overrides.py::TestTorchFunctionRedispatchOpsCUDA::test_redispatch_torch__scaled_mm_v2_cuda_float8_e4m3fn
RuntimeError: Rowwise scaling is not currently supported on your device
```

