### PR TITLE
[XPU] Fix double submission in XPUEvent::record()

### DIFF
--- a/c10/xpu/XPUEvent.h
+++ b/c10/xpu/XPUEvent.h
@@ -107,15 +107,9 @@ struct XPUEvent {
   void record(const XPUStream& stream) {
     namespace syclex = sycl::ext::oneapi::experimental;
     const c10::impl::PyInterpreter* interp = c10::impl::GPUTrace::get_trace();
-    if (!isCreated()) {
+    const bool first_record = !isCreated();
+    if (first_record) {
       createEvent(stream.device_index());
-      if (!reusable_) {
-        assignEvent(stream.queue());
-      }
-      if (C10_UNLIKELY(interp)) {
-        (*interp)->trace_gpu_event_creation(
-            c10::kXPU, reinterpret_cast<uintptr_t>(event_.get()));
-      }
     }
     TORCH_CHECK(
         device_index_ == stream.device_index(),
@@ -129,11 +123,17 @@ struct XPUEvent {
 #if SYCL_COMPILER_VERSION >= 20260200
       syclex::enqueue_signal_event(stream.queue(), *event_);
 #endif
+    } else if (first_record) {
+      assignEvent(stream.queue());
     } else {
       reassignEvent(stream.queue());
     }
 
     if (C10_UNLIKELY(interp)) {
+      if (first_record) {
+        (*interp)->trace_gpu_event_creation(
+            c10::kXPU, reinterpret_cast<uintptr_t>(event_.get()));
+      }
       (*interp)->trace_gpu_event_record(
           c10::kXPU,
           reinterpret_cast<uintptr_t>(event_.get()),


### PR DESCRIPTION
Fix for #194608.

The first `record()` on a non-reusable XPUEvent enqueued two commands: the `if (!isCreated())` branch called assignEvent(), then the `!reusable_` path fell through to reassignEvent(), which resets the event and submits again.

`reassignEvent()` destroys the `sycl::event` of the first, still in-flight submission. 
The backend event object is returned to its cache and the very next `submit_profiling_tag()` gets the same object back, so two enqueued commands share one event and one kernel timestamp slot. 

The host-side reset and re-arm then races the device writing the first timestamp, and the event can end up signaled but without profiling data:

```
  RuntimeError: level_zero backend failed with error: 17
  (UR_RESULT_ERROR_PROFILING_INFO_NOT_AVAILABLE)
```

This surfaces as intermittent failures in Inductor autotuning, the main consumer of `torch.xpu.Event(enable_timing=True).elapsed_time()`. A UR trace shows 2 `urEnqueueTimestampRecordingExp` calls per timed event, with the same `ur_event_handle_t` released and re-acquired in between.

The fix is to enqueue exactly one command per `record()`. 

Additionally, emit `trace_gpu_event_creation()` with the event that is actually kept, instead of the discarded first one.