### PR TITLE
Fix torch.compile(dynamic=True) crash for scatter/scatter_add out variants

### DIFF
--- a/aten/src/ATen/native/NonEmptyUtils.h
+++ b/aten/src/ATen/native/NonEmptyUtils.h
@@ -12,6 +12,10 @@ inline int64_t ensure_nonempty_size(const TensorBase &t, int64_t dim) {
   return t.dim() == 0 ? 1 : t.size(dim);
 }
 
+inline c10::SymInt ensure_nonempty_sym_size(const TensorBase &t, int64_t dim) {
+  return t.dim() == 0 ? c10::SymInt(1) : t.sym_size(dim);
+}
+
 inline int64_t ensure_nonempty_stride(const TensorBase &t, int64_t dim) {
   return t.dim() == 0 ? 1 : t.stride(dim);
 }

--- a/aten/src/ATen/native/ScatterGatherChecks.h
+++ b/aten/src/ATen/native/ScatterGatherChecks.h
@@ -17,7 +17,7 @@ inline void scatter_gather_dtype_check(
   const Tensor& index,
   const std::optional<Tensor>& src_opt = std::nullopt
 ) {
-  if (index.numel() != 0) {
+  if (index.sym_numel() != 0) {
     TORCH_CHECK(
       index.scalar_type() == at::ScalarType::Long || index.scalar_type() == at::ScalarType::Int,
       method_name, "(): Expected dtype int32/int64 for index"
@@ -68,7 +68,7 @@ inline void scatter_shape_check(
   const Tensor& self, int64_t dim, const Tensor& index,
   const std::optional<Tensor>& src_opt = std::nullopt
 ) {
-  if (index.numel() == 0) return;
+  if (index.sym_numel() == 0) return;
   TORCH_CHECK(
     ensure_nonempty_dim(self.dim()) == ensure_nonempty_dim(index.dim()),
     "Index tensor must have the same number of dimensions as self tensor"
@@ -79,9 +79,9 @@ inline void scatter_shape_check(
 
   //  Check: index.size(d) <= self.size(d) for all d != dim
   for (const auto d : c10::irange(self_dims)) {
-    int64_t index_d_size = ensure_nonempty_size(index, d);
+    c10::SymInt index_d_size = ensure_nonempty_sym_size(index, d);
     if (d == dim) continue;
-    if (index_d_size > ensure_nonempty_size(self, d)) {
+    if (index_d_size > ensure_nonempty_sym_size(self, d)) {
       is_wrong_shape = true;
       break;
     }
@@ -91,8 +91,8 @@ inline void scatter_shape_check(
   if (!is_wrong_shape && src_opt.has_value()) {
     const auto& src = src_opt.value();
     for (const auto d : c10::irange(self_dims)) {
-      int64_t index_d_size = ensure_nonempty_size(index, d);
-      if (index_d_size > ensure_nonempty_size(src, d)) {
+      c10::SymInt index_d_size = ensure_nonempty_sym_size(index, d);
+      if (index_d_size > ensure_nonempty_sym_size(src, d)) {
         is_wrong_shape = true;
         break;
       }
@@ -108,16 +108,16 @@ inline void scatter_shape_check(
     );
 
     TORCH_CHECK(!is_wrong_shape,
-      "Expected index ", index.sizes(),
-      " to be no larger than self ", self.sizes(),
+      "Expected index ", index.sym_sizes(),
+      " to be no larger than self ", self.sym_sizes(),
       " apart from dimension ", dim,
-      " and to be no larger size than src ", src.sizes()
+      " and to be no larger size than src ", src.sym_sizes()
     );
   }
   else {
     TORCH_CHECK(!is_wrong_shape,
-      "Expected index ", index.sizes(),
-      " to be no larger than self ", self.sizes(),
+      "Expected index ", index.sym_sizes(),
+      " to be no larger than self ", self.sym_sizes(),
       " apart from dimension ", dim
     );
   }

--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2288,6 +2288,44 @@ class TestMetaKernelConv(TestCase):
 
 class TestMetaKernelRegistrations(TestCase):
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_scatter_add_out_index_dtype_mismatch(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/194103.
+        self_tensor = torch.zeros(2, 3, device="meta")
+        index = torch.zeros(2, 3, dtype=torch.float32, device="meta")
+        src = torch.ones(2, 3, device="meta")
+        out = torch.empty_like(self_tensor)
+
+        with self.assertRaisesRegex(RuntimeError, "Expected dtype int32/int64 for index"):
+            torch.ops.aten.scatter_add.out(self_tensor, 1, index, src, out=out)
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_scatter_add_out_shape_mismatch(self):
+        self_tensor = torch.zeros(2, 3, device="meta")
+        index = torch.zeros(2, 4, dtype=torch.long, device="meta")
+        src = torch.ones(2, 4, device="meta")
+        out = torch.empty_like(self_tensor)
+
+        with self.assertRaisesRegex(RuntimeError, "Expected index"):
+            torch.ops.aten.scatter_add.out(self_tensor, 0, index, src, out=out)
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_scatter_add_out_shape_mismatch_symbolic_index(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        with FakeTensorMode(shape_env=shape_env):
+            size = shape_env.create_unbacked_symint()
+            torch._check(size >= 1)
+            self_tensor = torch.zeros(2, 3)
+            index = torch.zeros(size, 4, dtype=torch.long)
+            src = torch.ones(size, 4)
+            out = torch.empty_like(self_tensor)
+
+            with self.assertRaisesRegex(RuntimeError, "Expected index"):
+                torch.ops.aten.scatter_add.out(self_tensor, 0, index, src, out=out)
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
     def test_aminmax_out_dtype_mismatch(self):
         inp = torch.rand(10, 10, device="meta")
         out_min = torch.empty(10, dtype=torch.float64, device="meta")

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -2250,8 +2250,6 @@ out_symbolic_tensor_failures = {
     xfail('argmax', ''),
     xfail('argmin', ''),
     xfail('gather', ''),
-    xfail('scatter_add', ''),
-    xfail('scatter', ''),
     xfail('take_along_dim', ''),
 
     # SymIntArrayRef expected to contain only concrete

--- a/test/test_scatter_gather_ops.py
+++ b/test/test_scatter_gather_ops.py
@@ -508,6 +508,57 @@ class TestScatterGather(TestCase):
                 res = inp.clone().scatter_add_(d, idx, src)
             self.assertEqual(res, ref)
 
+    @onlyCPU
+    @dtypes(torch.float32)
+    def test_scatter_out_variant_dynamic_shapes(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/194103
+
+        def scatter_src(x, index, src, out):
+            return torch.scatter(x, 1, index, src, out=out)
+
+        def scatter_add(x, index, src, out):
+            return torch.scatter_add(x, 1, index, src, out=out)
+
+        def scatter_value(x, index, out):
+            return torch.scatter(x, 1, index, 1.0, out=out)
+
+        for fn, needs_src in (
+            (scatter_src, True),
+            (scatter_add, True),
+            (scatter_value, False),
+        ):
+            compiled = torch.compile(fn, backend="eager", fullgraph=True, dynamic=True)
+            for width in (2, 3, 5):
+                x = torch.zeros(1, width, device=device, dtype=dtype)
+                index = torch.arange(width, device=device).unsqueeze(0)
+                src = torch.ones(1, width, device=device, dtype=dtype)
+                eager_out = torch.empty_like(x)
+                compiled_out = torch.empty_like(x)
+                args = (x, index, src, eager_out) if needs_src else (x, index, eager_out)
+                compiled_args = (
+                    (x, index, src, compiled_out) if needs_src else (x, index, compiled_out)
+                )
+                fn(*args)
+                compiled(*compiled_args)
+                self.assertEqual(eager_out, compiled_out)
+
+    @onlyCPU
+    @dtypes(torch.float32)
+    def test_scatter_add_out_dynamic_shapes_empty_index(self, device, dtype):
+        # Regression test for https://github.com/pytorch/pytorch/issues/194103.
+        def scatter_add(x, index, src, out):
+            return torch.scatter_add(x, 1, index, src, out=out)
+
+        compiled = torch.compile(scatter_add, backend="eager", fullgraph=True, dynamic=True)
+        for width in (2, 3, 0, 5):
+            x = torch.zeros(1, width, device=device, dtype=dtype)
+            index = torch.arange(width, device=device).unsqueeze(0)
+            src = torch.ones(1, width, device=device, dtype=dtype)
+            eager_out = torch.empty_like(x)
+            compiled_out = torch.empty_like(x)
+            scatter_add(x, index, src, eager_out)
+            compiled(x, index, src, compiled_out)
+            self.assertEqual(eager_out, compiled_out)
 
     @onlyCPU
     @dtypes(torch.float32, torch.float64, torch.bfloat16)


### PR DESCRIPTION
Fixes #194103

scatter/scatter_add out-variant metas call `scatter_gather_dtype_check` and `scatter_shape_check` in `ScatterGatherChecks.h`, which read `index.numel()/index.size(d)` as plain `int64_t`. `TensorImpl::numel_default()/size()` unconditionally throw "`Cannot call numel() on tensor with symbolic sizes/strides"` once a tensor carries symbolic sizes -- exactly the case for FakeTensors under `torch.compile(dynamic=True)`. Eager mode never hits this since indices there are always concrete.

Switches both checks to SymInt-safe accessors (`sym_numel()`, new `ensure_nonempty_sym_size() `helper, `sym_sizes()` in error messages).

Test plan: 
added `test_scatter_out_variant_dynamic_shapes`; 
ran `test/test_scatter_gather_ops.py` (261 pass), 
`test/test_fake_tensor.py` (460 pass), 
`test_dynamic_shapes.py -k scatter` (1 pass).