### PR TITLE
[aoti] Prevent exceptions from crossing the AOTI C ABI (#194613)

### DIFF
--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/inductor/aoti_runtime/interface.h>
 #include <torch/csrc/inductor/aoti_runtime/model_container.h>
 
+#include <exception>
 #include <iostream>
 #include <string>
 #include <unordered_map>
@@ -12,23 +13,48 @@
 // callers on the other side of the C ABI boundary can retrieve it via
 // AOTInductorGetLastError(). Without this, exception messages (e.g.
 // "CUDA error: an illegal memory access was encountered") are lost when
-// CONVERT_EXCEPTION_TO_ERROR_CODE catches them and returns an error code.
+// the runtime boundary catches them and returns an error code.
 static thread_local std::string g_aoti_last_error;
 
-#define CONVERT_EXCEPTION_TO_ERROR_CODE(...)      \
-  try {                                           \
-    g_aoti_last_error.clear();                    \
-    __VA_ARGS__                                   \
-  } catch (const std::exception& e) {             \
-    g_aoti_last_error = e.what();                 \
-    std::cerr << "Error: " << e.what() << '\n';   \
-    return AOTI_RUNTIME_FAILURE;                  \
-  } catch (...) {                                 \
-    g_aoti_last_error = "Unknown exception";      \
-    std::cerr << "Unknown exception occurred.\n"; \
-    return AOTI_RUNTIME_FAILURE;                  \
-  }                                               \
-  return AOTI_RUNTIME_SUCCESS;
+namespace {
+
+// Error reporting must not let a secondary exception cross the C ABI.
+AOTIRuntimeError record_aoti_runtime_exception(
+    const std::exception& e) noexcept {
+  try {
+    g_aoti_last_error = e.what();
+  } catch (...) {
+  }
+  try {
+    std::cerr << "Error: " << e.what() << '\n';
+  } catch (...) {
+  }
+  return AOTI_RUNTIME_FAILURE;
+}
+
+AOTIRuntimeError record_unknown_aoti_runtime_exception() noexcept {
+  try {
+    g_aoti_last_error = "Unknown exception";
+  } catch (...) {
+  }
+  try {
+    std::cerr << "Unknown exception occurred.\n";
+  } catch (...) {
+  }
+  return AOTI_RUNTIME_FAILURE;
+}
+
+} // namespace
+
+#define AOTI_RUNTIME_TRY(...)                       \
+  try {                                             \
+    g_aoti_last_error.clear();                      \
+    __VA_ARGS__                                     \
+  } catch (const std::exception& e) {               \
+    return record_aoti_runtime_exception(e);        \
+  } catch (...) {                                   \
+    return record_unknown_aoti_runtime_exception(); \
+  }
 
 #define AOTI_VECTOR_SIZE_CHECK(actual_size, expected_size, name)  \
   do {                                                            \
@@ -80,23 +106,22 @@ AOTIRuntimeError createModelImpl(
     AOTInductorModelHandle* model_handle,
     bool load_constants_from_blob,
     Populate&& populate) {
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
-    auto constant_array = std::make_shared<
-        std::vector<torch::aot_inductor::ConstantHandle>>();
-    auto* model = new torch::aot_inductor::AOTInductorModel(
-        constant_map,
-        constant_array,
-        // device_str is hardcoded, as AOTInductorModelCreate is only used
-        // for CPU models.
-        "cpu",
-        "");
-    populate(*constant_map);
-    if (load_constants_from_blob) {
-      model->load_constants();
-    }
-    *model_handle = reinterpret_cast<AOTInductorModelHandle>(model);
-  })
+  auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
+  auto constant_array = std::make_shared<
+      std::vector<torch::aot_inductor::ConstantHandle>>();
+  auto model = std::make_unique<torch::aot_inductor::AOTInductorModel>(
+      constant_map,
+      constant_array,
+      // device_str is hardcoded, as AOTInductorModelCreate is only used
+      // for CPU models.
+      "cpu",
+      "");
+  populate(*constant_map);
+  if (load_constants_from_blob) {
+    model->load_constants();
+  }
+  *model_handle = reinterpret_cast<AOTInductorModelHandle>(model.release());
+  return AOTI_RUNTIME_SUCCESS;
 }
 
 } // namespace
@@ -107,35 +132,33 @@ AOTIRuntimeError AOTInductorModelContainerCreate(
     AOTInductorModelContainerHandle* container_handle,
     size_t num_models,
     bool is_cpu,
-    const char* cubin_dir) {
+    const char* cubin_dir) AOTI_RUNTIME_TRY({
       return AOTInductorModelContainerCreateWithDevice(
         container_handle,
         num_models,
         is_cpu ? "cpu" : "cuda",
         cubin_dir);
-}
+})
 
 AOTIRuntimeError AOTInductorModelContainerCreateWithDevice(
     AOTInductorModelContainerHandle* container_handle,
     size_t num_models,
     const char* device_str,
-    const char* cubin_dir) {
-
+    const char* cubin_dir) AOTI_RUNTIME_TRY({
   if (num_models == 0) {
     std::cerr << "Error: num_models must be positive, but got 0\n";
     return AOTI_RUNTIME_FAILURE;
   }
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    std::optional<std::string> cubin_dir_opt;
-    if (cubin_dir != nullptr) {
-      cubin_dir_opt.emplace(cubin_dir);
-    }
-    auto* container = new torch::aot_inductor::AOTInductorModelContainer(
-        num_models, std::string(device_str), cubin_dir_opt);
-    *container_handle =
-        reinterpret_cast<AOTInductorModelContainerHandle>(container);
-  })
-}
+  std::optional<std::string> cubin_dir_opt;
+  if (cubin_dir != nullptr) {
+    cubin_dir_opt.emplace(cubin_dir);
+  }
+  auto* container = new torch::aot_inductor::AOTInductorModelContainer(
+      num_models, std::string(device_str), cubin_dir_opt);
+  *container_handle =
+      reinterpret_cast<AOTInductorModelContainerHandle>(container);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 
 AOTIRuntimeError AOTInductorModelContainerCreateWithExternalConstants(
@@ -144,7 +167,7 @@ AOTIRuntimeError AOTInductorModelContainerCreateWithExternalConstants(
     const char* device_str,
     const char* cubin_dir,
     const AOTInductorConstantMapEntry* constant_entries,
-    size_t num_constant_entries) {
+    size_t num_constant_entries) AOTI_RUNTIME_TRY({
   if (num_models == 0) {
     std::cerr << "Error: num_models must be positive, but got 0\n";
     return AOTI_RUNTIME_FAILURE;
@@ -154,37 +177,35 @@ AOTIRuntimeError AOTInductorModelContainerCreateWithExternalConstants(
               << num_constant_entries << "\n";
     return AOTI_RUNTIME_FAILURE;
   }
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    std::optional<std::string> cubin_dir_opt;
-    if (cubin_dir != nullptr) {
-      cubin_dir_opt.emplace(cubin_dir);
-    }
-    // Rebuild the std map on the DSO side of the boundary so no std container
-    // crosses the ABI; the entries are C-compatible (name + AtenTensorHandle).
-    std::unordered_map<std::string, AtenTensorHandle> constants;
-    constants.reserve(num_constant_entries);
-    for (size_t i = 0; i < num_constant_entries; ++i) {
-      constants.emplace(constant_entries[i].name, constant_entries[i].handle);
-    }
-    auto* container = new torch::aot_inductor::AOTInductorModelContainer(
-        num_models,
-        std::string(device_str),
-        constants,
-        cubin_dir_opt);
-    *container_handle =
-        reinterpret_cast<AOTInductorModelContainerHandle>(container);
-  })
-}
+  std::optional<std::string> cubin_dir_opt;
+  if (cubin_dir != nullptr) {
+    cubin_dir_opt.emplace(cubin_dir);
+  }
+  // Rebuild the std map on the DSO side of the boundary so no std container
+  // crosses the ABI; the entries are C-compatible (name + AtenTensorHandle).
+  std::unordered_map<std::string, AtenTensorHandle> constants;
+  constants.reserve(num_constant_entries);
+  for (size_t i = 0; i < num_constant_entries; ++i) {
+    constants.emplace(constant_entries[i].name, constant_entries[i].handle);
+  }
+  auto* container = new torch::aot_inductor::AOTInductorModelContainer(
+      num_models,
+      std::string(device_str),
+      constants,
+      cubin_dir_opt);
+  *container_handle =
+      reinterpret_cast<AOTInductorModelContainerHandle>(container);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerDelete(
-    AOTInductorModelContainerHandle container_handle) {
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    auto* container =
-        reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
-            container_handle);
-    delete container;
-  });
-}
+    AOTInductorModelContainerHandle container_handle) AOTI_RUNTIME_TRY({
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  delete container;
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerRun(
     AOTInductorModelContainerHandle container_handle,
@@ -197,7 +218,7 @@ AOTIRuntimeError AOTInductorModelContainerRun(
                         // borrowed
     size_t num_outputs,
     AOTInductorStreamHandle stream_handle,
-    AOTIProxyExecutorHandle proxy_executor_handle) {
+    AOTIProxyExecutorHandle proxy_executor_handle) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
@@ -206,12 +227,11 @@ AOTIRuntimeError AOTInductorModelContainerRun(
 
   auto stream =
       reinterpret_cast<torch::aot_inductor::DeviceStreamType>(stream_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    AOTINoGradGuard guard;
-    container->run(
-        input_handles, output_handles, stream, proxy_executor_handle);
-  })
-}
+  AOTINoGradGuard guard;
+  container->run(
+      input_handles, output_handles, stream, proxy_executor_handle);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
     AOTInductorModelContainerHandle container_handle,
@@ -224,7 +244,7 @@ AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
                         // borrowed
     size_t num_outputs,
     AOTInductorStreamHandle stream_handle,
-    AOTIProxyExecutorHandle proxy_executor_handle) {
+    AOTIProxyExecutorHandle proxy_executor_handle) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
@@ -233,341 +253,344 @@ AOTIRuntimeError AOTInductorModelContainerRunSingleThreaded(
 
   auto stream =
       reinterpret_cast<torch::aot_inductor::DeviceStreamType>(stream_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    AOTINoGradGuard guard;
-    container->run_single_threaded(
-        input_handles, output_handles, stream, proxy_executor_handle);
-  })
-}
+  AOTINoGradGuard guard;
+  container->run_single_threaded(
+      input_handles, output_handles, stream, proxy_executor_handle);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetNumConstants(
     AOTInductorModelContainerHandle container_handle,
-    size_t* num_constants) {
+    size_t* num_constants) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-    { *num_constants = container->num_constants(); })
-}
+  *num_constants = container->num_constants();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetConstantName(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
-    const char** name) {
+    const char** name) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-    { *name = container->constant_name(idx); })
-}
+  *name = container->constant_name(idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetConstantOriginalFQN(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
-    const char** original_fqn) {
+    const char** original_fqn) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-    { *original_fqn = container->constant_original_fqn(idx); })
-}
+  *original_fqn = container->constant_original_fqn(idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetConstantFromFolded(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
-    bool* from_folded) {
+    bool* from_folded) AOTI_RUNTIME_TRY({
   auto* container =
-      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({ *from_folded = container->constant_from_folded(idx); })
-}
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  *from_folded = container->constant_from_folded(idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetConstantType(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
-    int32_t* type) {
+    int32_t* type) AOTI_RUNTIME_TRY({
   auto* container =
-      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({ *type = container->constant_type(idx); })
-}
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  *type = container->constant_type(idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetConstantDtype(
     AOTInductorModelContainerHandle container_handle,
     size_t idx,
-    int32_t* dtype) {
+    int32_t* dtype) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-    { *dtype = container->constant_dtype(idx); })
-}
+  *dtype = container->constant_dtype(idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetConstantDataSize(
-  AOTInductorModelContainerHandle container_handle,
-  size_t idx,
-  size_t* data_size) {
+    AOTInductorModelContainerHandle container_handle,
+    size_t idx,
+    size_t* data_size) AOTI_RUNTIME_TRY({
   auto* container =
-    reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
-        container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-    { *data_size = container->constant_data_size(idx); })
-}
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  *data_size = container->constant_data_size(idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerExtractConstantsMap(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
-    bool use_inactive) {
+    bool use_inactive) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  auto constants_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-    { const auto ret = container->extract_constants_map(use_inactive);
-      for (const auto& pair: ret) {
-        constants_map->emplace(pair.first, pair.second);
-      }
-    })
-}
+  auto constants_map =
+      reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(
+          constant_map_handle);
+  const auto ret = container->extract_constants_map(use_inactive);
+  for (const auto& pair : ret) {
+    constants_map->emplace(pair.first, pair.second);
+  }
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerExtractConstantsMapEntries(
     AOTInductorModelContainerHandle container_handle,
     const AOTInductorConstantMapEntry** entries,
     size_t* num_entries,
-    bool use_inactive) {
+    bool use_inactive) AOTI_RUNTIME_TRY({
   if (!entries || !num_entries) {
     return AOTI_RUNTIME_FAILURE;
   }
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    const auto& extracted =
-        container->extract_constants_map_entries(use_inactive);
-    *entries = extracted.empty() ? nullptr : extracted.data();
-    *num_entries = extracted.size();
-  })
-}
+  const auto& extracted =
+      container->extract_constants_map_entries(use_inactive);
+  *entries = extracted.empty() ? nullptr : extracted.data();
+  *num_entries = extracted.size();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateUserManagedConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive,
-    bool validate_full_update) {
+    bool validate_full_update) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->update_constant_buffer(
-        *input_map, use_inactive, validate_full_update, /* user_managed = */ true);
-  })
-}
+  auto input_map =
+      reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(
+          constant_map_handle);
+  container->update_constant_buffer(
+      *input_map,
+      use_inactive,
+      validate_full_update,
+      /* user_managed = */ true);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateUserManagedConstantBufferPairs(
     AOTInductorModelContainerHandle container_handle,
     const AOTInductorConstantMapEntry* pairs,
     size_t num_pairs,
     bool use_inactive,
-    bool validate_full_update) {
+    bool validate_full_update) AOTI_RUNTIME_TRY({
   auto* container =
-      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(container_handle);
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
   // Build a local unordered_map inside
   std::unordered_map<std::string, AtenTensorHandle> input_map;
   input_map.reserve(num_pairs);
   for (size_t i = 0; i < num_pairs; ++i) {
-      input_map.emplace(pairs[i].name, pairs[i].handle);
+    input_map.emplace(pairs[i].name, pairs[i].handle);
   }
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->update_constant_buffer(
-        input_map, use_inactive, validate_full_update, /*user_managed=*/true);
-  })
-}
+  container->update_constant_buffer(
+      input_map, use_inactive, validate_full_update, /*user_managed=*/true);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive,
-    bool validate_full_update) {
+    bool validate_full_update) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->update_constant_buffer(
-        *input_map, use_inactive, validate_full_update);
-  })
-}
+  auto input_map =
+      reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(
+          constant_map_handle);
+  container->update_constant_buffer(
+      *input_map, use_inactive, validate_full_update);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateConstantBufferPairs(
     AOTInductorModelContainerHandle container_handle,
     const AOTInductorConstantMapEntry* pairs,
     size_t num_pairs,
     bool use_inactive,
-    bool validate_full_update) {
+    bool validate_full_update) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
   auto input_map = constant_map_from_pairs(pairs, num_pairs);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->update_constant_buffer(
-        input_map, use_inactive, validate_full_update);
-  })
-}
+  container->update_constant_buffer(
+      input_map, use_inactive, validate_full_update);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateConstantBufferFromCpu(
     AOTInductorModelContainerHandle container_handle,
     AOTInductorConstantMapHandle constant_map_handle,
     bool use_inactive,
-    bool validate_full_update) {
+    bool validate_full_update) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  auto input_map = reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(constant_map_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->update_constant_buffer(
-        *input_map,
-        use_inactive,
-        validate_full_update,
-        /*user_managed=*/false,
-        /*allow_h2d_copy=*/true);
-  })
-}
+  auto input_map =
+      reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(
+          constant_map_handle);
+  container->update_constant_buffer(
+      *input_map,
+      use_inactive,
+      validate_full_update,
+      /*user_managed=*/false,
+      /*allow_h2d_copy=*/true);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateConstantBufferFromCpuPairs(
     AOTInductorModelContainerHandle container_handle,
     const AOTInductorConstantMapEntry* pairs,
     size_t num_pairs,
     bool use_inactive,
-    bool validate_full_update) {
+    bool validate_full_update) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
   auto input_map = constant_map_from_pairs(pairs, num_pairs);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->update_constant_buffer(
-        input_map,
-        use_inactive,
-        validate_full_update,
-        /*user_managed=*/false,
-        /*allow_h2d_copy=*/true);
-  })
-}
+  container->update_constant_buffer(
+      input_map,
+      use_inactive,
+      validate_full_update,
+      /*user_managed=*/false,
+      /*allow_h2d_copy=*/true);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBuffer(
     AOTInductorModelContainerHandle container_handle,
-    AOTInductorConstantMapHandle constant_map_handle) {
+    AOTInductorConstantMapHandle constant_map_handle) AOTI_RUNTIME_TRY({
   return AOTInductorModelContainerUpdateConstantBuffer(
       container_handle,
       constant_map_handle,
       /*use_inactive=*/true,
       /*validate_full_update=*/true);
-}
+})
 
 AOTIRuntimeError AOTInductorModelContainerUpdateInactiveConstantBufferPairs(
     AOTInductorModelContainerHandle container_handle,
     const AOTInductorConstantMapEntry* pairs,
-    size_t num_pairs) {
+    size_t num_pairs) AOTI_RUNTIME_TRY({
   return AOTInductorModelContainerUpdateConstantBufferPairs(
       container_handle,
       pairs,
       num_pairs,
       /*use_inactive=*/true,
       /*validate_full_update=*/true);
-}
+})
 
 AOTIRuntimeError AOTInductorModelContainerFreeInactiveConstantBuffer(
-    AOTInductorModelContainerHandle container_handle) {
+    AOTInductorModelContainerHandle container_handle) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->free_inactive_constant_buffer();
-  })
-}
+  container->free_inactive_constant_buffer();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerRunConstantFolding(
     AOTInductorModelContainerHandle container_handle,
     bool use_inactive,
     AOTInductorStreamHandle stream_handle,
-    AOTIProxyExecutorHandle proxy_executor_handle) {
+    AOTIProxyExecutorHandle proxy_executor_handle) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
   auto stream =
       reinterpret_cast<torch::aot_inductor::DeviceStreamType>(stream_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    AOTINoGradGuard guard;
-    container->run_const_fold(use_inactive, stream, proxy_executor_handle);
-  })
-}
+  AOTINoGradGuard guard;
+  container->run_const_fold(use_inactive, stream, proxy_executor_handle);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerSwapConstantBuffer(
-    AOTInductorModelContainerHandle container_handle) {
+    AOTInductorModelContainerHandle container_handle) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    container->swap_constant_buffer();
-  })
-}
+  container->swap_constant_buffer();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetNumInputs(
     AOTInductorModelContainerHandle container_handle,
-    size_t* ret_num_inputs) {
+    size_t* ret_num_inputs) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_num_inputs = container->num_inputs(); })
-}
+  *ret_num_inputs = container->num_inputs();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetInputName(
     AOTInductorModelContainerHandle container_handle,
     size_t input_idx,
-    const char** ret_input_names) {
+    const char** ret_input_names) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_input_names = container->input_name(input_idx); })
-}
+  *ret_input_names = container->input_name(input_idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetNumOutputs(
     AOTInductorModelContainerHandle container_handle,
-    size_t* ret_num_outputs) {
+    size_t* ret_num_outputs) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_num_outputs = container->num_outputs(); })
-}
+  *ret_num_outputs = container->num_outputs();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetOutputName(
     AOTInductorModelContainerHandle container_handle,
     size_t output_idx,
-    const char** ret_output_names) {
+    const char** ret_output_names) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_output_names = container->output_name(output_idx); })
-}
+  *ret_output_names = container->output_name(output_idx);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetCallSpec(
     AOTInductorModelContainerHandle container_handle,
     const char** in_spec,
-    const char** out_spec) {
+    const char** out_spec) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    *in_spec = container->get_in_spec();
-    *out_spec = container->get_out_spec();
-  })
-}
+  *in_spec = container->get_in_spec();
+  *out_spec = container->get_out_spec();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelCreate(
     AOTInductorModelHandle* model_handle,
-    AOTInductorConstantMapHandle constant_map_handle) {
+    AOTInductorConstantMapHandle constant_map_handle) AOTI_RUNTIME_TRY({
   return createModelImpl(
       model_handle, constant_map_handle == nullptr, [=](auto& constant_map) {
         auto* input_map = reinterpret_cast<
@@ -579,12 +602,12 @@ AOTIRuntimeError AOTInductorModelCreate(
           }
         }
       });
-}
+})
 
 AOTIRuntimeError AOTInductorModelCreateV2(
     AOTInductorModelHandle* model_handle,
     const AOTInductorConstantMapEntry* pairs,
-    size_t num_pairs) {
+    size_t num_pairs) AOTI_RUNTIME_TRY({
   return createModelImpl(
       model_handle, pairs == nullptr || num_pairs == 0, [=](auto& constant_map) {
         if (pairs && num_pairs > 0) {
@@ -594,57 +617,56 @@ AOTIRuntimeError AOTInductorModelCreateV2(
           }
         }
       });
-}
+})
 
 AOTIRuntimeError AOTInductorModelRun(
     AOTInductorModelHandle model_handle,
     AtenTensorHandle* input_handles,
-    AtenTensorHandle* output_handles) {
+    AtenTensorHandle* output_handles) AOTI_RUNTIME_TRY({
   auto model =
       reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    AOTINoGradGuard guard;
-    model->run_impl(
-        input_handles,
-        output_handles,
-        (torch::aot_inductor::DeviceStreamType) nullptr,
-        nullptr);
-  })
-}
+  AOTINoGradGuard guard;
+  model->run_impl(
+      input_handles,
+      output_handles,
+      (torch::aot_inductor::DeviceStreamType) nullptr,
+      nullptr);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
-AOTIRuntimeError AOTInductorModelDelete(AOTInductorModelHandle model_handle){
-    CONVERT_EXCEPTION_TO_ERROR_CODE({
-      auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(
-          model_handle);
-      delete model;
-    })}
+AOTIRuntimeError AOTInductorModelDelete(
+    AOTInductorModelHandle model_handle) AOTI_RUNTIME_TRY({
+  auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(
+      model_handle);
+  delete model;
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelGetNumOutputs(
     AOTInductorModelHandle model_handle,
-    size_t* ret_num_outputs) {
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-      auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
-      *ret_num_outputs = model->num_outputs();
-  })
-}
+    size_t* ret_num_outputs) AOTI_RUNTIME_TRY({
+  auto model =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
+  *ret_num_outputs = model->num_outputs();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
     AOTInductorModelHandle model_handle,
-    AOTInductorConstantMapHandle constant_map_handle) {
+    AOTInductorConstantMapHandle constant_map_handle) AOTI_RUNTIME_TRY({
   auto model =
       reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
-    auto input_map =
-        reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(
-            constant_map_handle);
+  auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
+  auto input_map =
+      reinterpret_cast<std::unordered_map<std::string, AtenTensorHandle>*>(
+          constant_map_handle);
 
-    for (auto const& kv : *input_map) {
-      constant_map->emplace(kv.first, kv.second);
-    }
-    model->update_constants_map(std::move(constant_map));
-  })
-}
+  for (auto const& kv : *input_map) {
+    constant_map->emplace(kv.first, kv.second);
+  }
+  model->update_constants_map(std::move(constant_map));
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 // C-ABI-safe variant: uses an array of (name, handle) pairs instead of an
 // opaque pointer to std::unordered_map, so the host and DSO can use
@@ -652,63 +674,61 @@ AOTIRuntimeError AOTInductorModelUpdateConstantsMap(
 AOTIRuntimeError AOTInductorModelUpdateConstantsMapV2(
     AOTInductorModelHandle model_handle,
     const AOTInductorConstantMapEntry* pairs,
-    int32_t num_pairs) {
+    int32_t num_pairs) AOTI_RUNTIME_TRY({
   auto model =
       reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
-    constant_map->reserve(num_pairs);
-    for (int32_t i = 0; i < num_pairs; ++i) {
-      constant_map->emplace(pairs[i].name, pairs[i].handle);
-    }
-    model->update_constants_map(std::move(constant_map));
-  })
-}
+  auto constant_map = std::make_shared<torch::aot_inductor::ConstantMap>();
+  constant_map->reserve(num_pairs);
+  for (int32_t i = 0; i < num_pairs; ++i) {
+    constant_map->emplace(pairs[i].name, pairs[i].handle);
+  }
+  model->update_constants_map(std::move(constant_map));
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerGetConstantsBlobSize(
     AOTInductorModelContainerHandle container_handle,
-    uint64_t* ret_size) {
+    uint64_t* ret_size) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *ret_size = container->constant_blob_size(); })
-}
+  *ret_size = container->constant_blob_size();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorModelContainerDidCallLoadConstants(
     AOTInductorModelContainerHandle container_handle,
-    bool* did_call_load_constants) {
+    bool* did_call_load_constants) AOTI_RUNTIME_TRY({
   auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      { *did_call_load_constants = container->did_call_load_constants(); })
-}
+  *did_call_load_constants = container->did_call_load_constants();
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 
 // Load weights from a single blob in weight_blob_ptr
 AOTIRuntimeError AOTInductorModelUpdateConstantsFromBlob(
     AOTInductorModelContainerHandle container_handle,
-    const uint8_t* weight_blob_ptr){
-    auto* container =
+    const uint8_t* weight_blob_ptr) AOTI_RUNTIME_TRY({
+  auto* container =
       reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
           container_handle);
-  CONVERT_EXCEPTION_TO_ERROR_CODE(
-      {container->update_constants_from_blob(weight_blob_ptr); })
-    }
+  container->update_constants_from_blob(weight_blob_ptr);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
-AOTIRuntimeError AOTInductorSetUsePinnedAsyncConstantsCopy(bool enabled) {
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    torch::aot_inductor::setUsePinnedAsyncConstantsCopy(enabled);
-  })
-}
+AOTIRuntimeError AOTInductorSetUsePinnedAsyncConstantsCopy(
+    bool enabled) AOTI_RUNTIME_TRY({
+  torch::aot_inductor::setUsePinnedAsyncConstantsCopy(enabled);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorSetPinnedAsyncConstantsCopyStageBufferBytes(
-    size_t bytes) {
-  CONVERT_EXCEPTION_TO_ERROR_CODE({
-    torch::aot_inductor::setPinnedAsyncConstantsCopyStageBufferBytes(bytes);
-  })
-}
+    size_t bytes) AOTI_RUNTIME_TRY({
+  torch::aot_inductor::setPinnedAsyncConstantsCopyStageBufferBytes(bytes);
+  return AOTI_RUNTIME_SUCCESS;
+})
 
 AOTIRuntimeError AOTInductorGetLastError(
     const char** error_msg) {

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -459,15 +459,14 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                         extern "C" AOTIRuntimeError AOTInductorModelRunMinimalArrayrefInterface(
                             AOTInductorModelHandle model_handle,
                             const AOTInductorModelInputs& inputs,
-                            AOTInductorModelOutputs& outputs) {
+                            AOTInductorModelOutputs& outputs) AOTI_RUNTIME_TRY({
                           auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
-                          CONVERT_EXCEPTION_TO_ERROR_CODE({
-                              outputs = model->run_impl_minimal_arrayref_interface<AOTInductorModelInputs, AOTInductorModelOutputs>(
-                                  inputs,
-                                  (torch::aot_inductor::DeviceStreamType)nullptr,
-                                  nullptr);
-                          })
-                        }
+                          outputs = model->run_impl_minimal_arrayref_interface<AOTInductorModelInputs, AOTInductorModelOutputs>(
+                              inputs,
+                              (torch::aot_inductor::DeviceStreamType)nullptr,
+                              nullptr);
+                          return AOTI_RUNTIME_SUCCESS;
+                        })
                     """
                     )
 
@@ -482,40 +481,39 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
                             int32_t num_inputs,
                             const AOTInductorArrayRefTensor* c_inputs,
                             int32_t num_outputs,
-                            AOTInductorArrayRefTensor* c_outputs) {{
+                            AOTInductorArrayRefTensor* c_outputs) AOTI_RUNTIME_TRY({{
                           constexpr int32_t expected_num_inputs = {len(V.graph.graph_inputs)};
                           constexpr int32_t expected_num_outputs = {len(V.graph.graph_outputs)};
                           auto model = reinterpret_cast<torch::aot_inductor::AOTInductorModel*>(model_handle);
-                          CONVERT_EXCEPTION_TO_ERROR_CODE({{
-                              if (num_inputs != expected_num_inputs) {{
-                                throw std::runtime_error(
-                                    std::string("AOTInductorModelRunMinimalArrayrefInterfaceV2 expected ")
-                                    + std::to_string(expected_num_inputs)
-                                    + " inputs but got "
-                                    + std::to_string(num_inputs));
-                              }}
-                              if (num_outputs != expected_num_outputs) {{
-                                throw std::runtime_error(
-                                    std::string("AOTInductorModelRunMinimalArrayrefInterfaceV2 expected ")
-                                    + std::to_string(expected_num_outputs)
-                                    + " outputs but got "
-                                    + std::to_string(num_outputs));
-                              }}
-                              if (num_inputs > 0 && c_inputs == nullptr) {{
-                                throw std::runtime_error(
-                                    "AOTInductorModelRunMinimalArrayrefInterfaceV2 received null input descriptors");
-                              }}
-                              if (num_outputs > 0 && c_outputs == nullptr) {{
-                                throw std::runtime_error(
-                                    "AOTInductorModelRunMinimalArrayrefInterfaceV2 received null output descriptors");
-                              }}
-                              model->run_impl_minimal_arrayref_interface_v2_raw(
-                                  c_inputs,
-                                  c_outputs,
-                                  (torch::aot_inductor::DeviceStreamType)nullptr,
-                                  nullptr);
-                          }})
-                        }}
+                          if (num_inputs != expected_num_inputs) {{
+                            throw std::runtime_error(
+                                std::string("AOTInductorModelRunMinimalArrayrefInterfaceV2 expected ")
+                                + std::to_string(expected_num_inputs)
+                                + " inputs but got "
+                                + std::to_string(num_inputs));
+                          }}
+                          if (num_outputs != expected_num_outputs) {{
+                            throw std::runtime_error(
+                                std::string("AOTInductorModelRunMinimalArrayrefInterfaceV2 expected ")
+                                + std::to_string(expected_num_outputs)
+                                + " outputs but got "
+                                + std::to_string(num_outputs));
+                          }}
+                          if (num_inputs > 0 && c_inputs == nullptr) {{
+                            throw std::runtime_error(
+                                "AOTInductorModelRunMinimalArrayrefInterfaceV2 received null input descriptors");
+                          }}
+                          if (num_outputs > 0 && c_outputs == nullptr) {{
+                            throw std::runtime_error(
+                                "AOTInductorModelRunMinimalArrayrefInterfaceV2 received null output descriptors");
+                          }}
+                          model->run_impl_minimal_arrayref_interface_v2_raw(
+                              c_inputs,
+                              c_outputs,
+                              (torch::aot_inductor::DeviceStreamType)nullptr,
+                              nullptr);
+                          return AOTI_RUNTIME_SUCCESS;
+                        }})
                     """
                     )
                 else:


### PR DESCRIPTION
Summary:

Prevent exceptions from unwinding out of generated AOTI DSOs without changing the public C API function types. Each exported runtime entrypoint uses a function-try-block that records an escaping exception and returns `AOTI_RUNTIME_FAILURE`; secondary failures while recording the error are contained. Consumers retain potentially throwing function pointers for compatibility with older artifacts.

Test Plan:
`buck2 build fbcode//caffe2/test/inductor/fb:test_aot_inductor_model_runner_pybind fbcode//sigmoid/core/executor:aoti_model_impl_cpu`

`buck2 run fbcode//caffe2/test/inductor:aot_inductor_arrayref_cpu -- caffe2.test.inductor.test_aot_inductor_arrayref.AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface.test_runtime_input_count_error_does_not_cross_c_abi_cpu_with_stack_allocation_and_minimal_arrayref_interface`

`buck2 run fbcode//caffe2/test/inductor:aot_inductor_arrayref_cpu_local -- caffe2.test.inductor.test_aot_inductor_arrayref.AOTInductorTestABICompatibleCpuWithStackAllocationAndMinimalArrayRefInterface.test_runtime_input_count_error_does_not_cross_c_abi_cpu_with_stack_allocation_and_minimal_arrayref_interface`

Reviewed By: desertfire

Differential Revision: D116951104




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo