### PR TITLE
Fix post-local SGD checkpoint reload race

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 
 import copy
+import io
 import itertools
 import json
 import math
@@ -482,23 +483,6 @@ def _lock():
             else:
                 fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
             lf.close()
-
-
-@contextmanager
-def _rank_temp_file():
-    if dist.get_rank() == 0:
-        fd, name = tempfile.mkstemp()
-        os.close(fd)
-    else:
-        name = None
-    object_list = [name]
-    dist.broadcast_object_list(object_list)
-    name = object_list[0]
-    try:
-        yield name
-    finally:
-        if dist.get_rank() == 0:
-            os.remove(name)
 
 
 def _build_tensor(size, value=None, dtype=torch.float, device_id=None):
@@ -5740,9 +5724,7 @@ class DistributedTest:
             loss.backward()
             optimizer.step()
 
-        def _test_post_localSGD_optimizer_step_reload(
-            self, create_averager, chkpt_file
-        ):
+        def _test_post_localSGD_optimizer_step_reload(self, create_averager):
             learning_rate = 0.03
 
             net_using_post_localSGD_opt = torch.nn.parallel.DistributedDataParallel(
@@ -5772,14 +5754,22 @@ class DistributedTest:
                     target,
                 )
 
+            # Broadcast the serialized checkpoint instead of sharing a file, so
+            # that no rank owns a resource whose lifetime the other ranks depend on.
             if self.rank == 0:
+                buffer = io.BytesIO()
                 torch.save(
-                    {"optimizer_state_dict": post_localSGD_opt.state_dict()}, chkpt_file
+                    {"optimizer_state_dict": post_localSGD_opt.state_dict()}, buffer
                 )
+                object_list = [buffer.getvalue()]
+            else:
+                object_list = [None]
+            dist.broadcast_object_list(object_list)
 
-            dist.barrier()
             map_location = {"cuda:0": f"cuda:{self.rank:d}"}
-            checkpoint = torch.load(chkpt_file, map_location=map_location)
+            checkpoint = torch.load(
+                io.BytesIO(object_list[0]), map_location=map_location
+            )
             dummy_post_localSGD_opt.load_state_dict(checkpoint["optimizer_state_dict"])
 
             # Check that we didn't hit the trivial case
@@ -5869,10 +5859,9 @@ class DistributedTest:
         )
         def test_post_localSGD_optimizer_step_reload(self):
             torch.cuda.set_device(self.rank)
-            with _rank_temp_file() as tmp_file:
-                self._test_post_localSGD_optimizer_step_reload(
-                    self._create_periodic_model_averager, tmp_file
-                )
+            self._test_post_localSGD_optimizer_step_reload(
+                self._create_periodic_model_averager
+            )
 
         @skip_but_pass_in_sandcastle_if(
             BACKEND not in DistTestCases.backend_feature["ddp"],
@@ -10386,7 +10375,6 @@ class DistributedTest:
         def _test_hook_pickling(self, hook, hook_state):
             torch.manual_seed(0)
             learning_rate = 0.01
-            chkpt_file = tempfile.gettempdir() + "/checkpoint.pt"
             rank = self.rank
 
             input = torch.randn(7, 1, device=rank)
@@ -10413,9 +10401,12 @@ class DistributedTest:
                 "comm_hook_state": hook_state,
             }
 
+            # Broadcast the serialized checkpoint instead of sharing a file, so
+            # that no rank owns a resource whose lifetime the other ranks depend on.
             if rank == 0:
+                buffer = io.BytesIO()
                 with self.assertLogs("torch.distributed") as captured:
-                    torch.save(state, chkpt_file)
+                    torch.save(state, buffer)
 
                 # Check that the logger has only one entry
                 self.assertEqual(len(captured.records), 1)
@@ -10424,11 +10415,23 @@ class DistributedTest:
                     captured.records[0].getMessage(),
                     "NOTE: Process group is not serializable and excluded from a saved state.",
                 )
+                object_list = [buffer.getvalue()]
+            else:
+                object_list = [None]
+            # This test never calls set_device, so the collective device has to be
+            # named explicitly or every rank would broadcast on cuda:0.
+            coll_device = torch.device(f"cuda:{rank:d}")
+            dist.broadcast_object_list(object_list, device=coll_device)
 
-            dist.barrier()
             map_location = {"cuda:0": f"cuda:{rank:d}"}
             with self.assertLogs("torch.distributed") as captured:
-                checkpoint = torch.load(chkpt_file, map_location=map_location)
+                # The checkpoint holds the hook function and its state, not just
+                # tensors, so it cannot be loaded with weights_only.
+                checkpoint = torch.load(
+                    io.BytesIO(object_list[0]),
+                    map_location=map_location,
+                    weights_only=False,
+                )
 
             # Check that the logger has only one entry
             self.assertEqual(len(captured.records), 1)
@@ -10500,16 +10503,11 @@ class DistributedTest:
             ):
                 self.assertEqual(orig_param.grad, dummy_param.grad)
 
-            dist.barrier()
-            if rank == 0:
-                os.remove(chkpt_file)
-
         @skip_but_pass_in_sandcastle_if(
             BACKEND not in DistTestCases.backend_feature["cuda"],
             f"The {BACKEND} backend does not support DDP communication hook on CUDA devices",
         )
         @skip_if_lt_x_gpu(int(os.environ["WORLD_SIZE"]))
-        @skip_but_pass_in_sandcastle_if(True, "Skipped due to flakiness")
         def test_ddp_hook_pickling_powerSGD(self):
             hook = powerSGD.powerSGD_hook
             powersgd_state = powerSGD.PowerSGDState(


### PR DESCRIPTION
## Summary

Fixes #84886.

There was a race in the post-local SGD checkpoint reload test. Rank 0 created the temporary checkpoint and all ranks synchronized after it was written. However, there was no synchronization after loading. Rank 0 could complete the test first, leave the temporary-file context, and delete the checkpoint before another rank opened it, causing FileNotFoundError.

Serialize the checkpoint into an in-memory buffer on rank 0 and broadcast the bytes through the process group. Each rank then loads from its own BytesIO buffer.

This removes the rank-0-owned file and its lifetime race instead of adding another barrier around temporary-file cleanup. It also removes the unnecessary shared-filesystem dependency while preserving coverage of serialization, device remapping, optimizer state restoration, and the missing-step fallback.

The same changes applied to test_ddp_hook_pickling_powerSGD and unskipped the test. 

## Reproduction
On `main`, add a 3s delay on non-zero ranks between the post-save `dist.barrier()` and `torch.load` in `_test_post_localSGD_optimizer_step_reload`:
```python
            dist.barrier()
            if self.rank != 0:
                time.sleep(3)
            map_location = {"cuda:0": f"cuda:{self.rank:d}"}
            checkpoint = torch.load(chkpt_file, map_location=map_location)
```
And then execute the test:
```
BACKEND=nccl WORLD_SIZE=2 TEMP_DIR=/tmp/dist python test/distributed/test_distributed_spawn.py -v \
  TestDistBackendWithSpawn.test_post_localSGD_optimizer_step_reload
```
Without the changes, the test returns:
```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmptsfocehr'
```