### PR TITLE
Preserve channels_last in InstanceNorm and fix the channels-last group norm reductions at D == 1

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/batch_norm.h>
 #include <ATen/native/Normalization.h>
+#include <ATen/native/group_norm.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/cpu/mixed_data_type.h>
 #include <c10/util/irange.h>
@@ -52,6 +53,7 @@
 #include <ATen/ops/native_batch_norm_backward.h>
 #include <ATen/ops/native_batch_norm_backward_native.h>
 #include <ATen/ops/native_batch_norm_native.h>
+#include <ATen/ops/native_group_norm.h>
 #include <ATen/ops/_native_batch_norm_legit.h>
 #include <ATen/ops/renorm_native.h>
 #include <ATen/ops/sum.h>
@@ -740,9 +742,47 @@ Tensor instance_norm(
 
  TORCH_CHECK(use_input_stats || (running_mean.defined() && running_var.defined()),
            "Expected running_mean and running_var to be defined when use_input_stats is false");
-  std::vector<SymInt> shape = input.sym_sizes().vec();
   SymInt b = input.sym_size(0);
   SymInt c = input.sym_size(1);
+
+  // Instance norm is group norm with one group per channel. The batch_norm path
+  // below folds N into C, which is not expressible as a view of a channels_last
+  // tensor, so it copies the input to contiguous and returns a contiguous
+  // output, forcing a layout conversion around every InstanceNorm of a
+  // channels_last model. native_group_norm has channels_last kernels, so prefer
+  // it when there are no running stats to update. Undefined running stats
+  // already imply use_input_stats via the TORCH_CHECK above, so it is not
+  // retested here.
+  const auto memory_format = group_norm_memory_format(input);
+  // native_group_norm takes the group count as a plain int, so a symbolic
+  // channel count (e.g. under torch.compile with dynamic shapes) deliberately
+  // opts out of this fast path and falls back to the batch_norm path below.
+  // A dynamic channel count therefore returns a contiguous output where eager
+  // returns a channels_last one, so the layout is not stable across the two.
+  // Specializing on the channel count would trade that for a guard on a
+  // dimension that is almost always static; the fallback is kept because it is
+  // what this op did before and is still correct.
+  const auto num_groups = c.maybe_as_int();
+  if ((memory_format == MemoryFormat::ChannelsLast ||
+       memory_format == MemoryFormat::ChannelsLast3d) &&
+      !running_mean.defined() && !running_var.defined() &&
+      num_groups.has_value()) {
+    // native_group_norm keeps the affine params and the saved mean/rstd in
+    // their own dtype (fp32) over a reduced-precision input, e.g. the fp32
+    // weight/bias of an nn.InstanceNorm*d module under autocast, so pass
+    // weight/bias through unchanged rather than downcasting to the input dtype.
+    return std::get<0>(at::native_group_norm_symint(
+        input,
+        weight,
+        bias,
+        b,
+        c,
+        c10::multiply_integers(input.sym_sizes().slice(2)),
+        *num_groups,
+        eps));
+  }
+
+  std::vector<SymInt> shape = input.sym_sizes().vec();
   shape[1] = b * c;
   shape[0] = SymInt(1);
 

--- a/aten/src/ATen/native/cuda/Normalization.cuh
+++ b/aten/src/ATen/native/cuda/Normalization.cuh
@@ -7,6 +7,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/DeviceUtils.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
+#include <ATen/native/cuda/channels_last_reduce.cuh>
 #include <ATen/native/cuda/DeviceSqrt.cuh>
 #include <ATen/native/cuda/KernelUtils.cuh>
 #include <ATen/native/cuda/LaunchUtils.h>
@@ -22,13 +23,6 @@
 #endif
 
 namespace at::native {
-
-// The maximum number of threads in a block
-#if defined(USE_ROCM)
-constexpr int MAX_BLOCK_SIZE = 1024;
-#else
-constexpr int MAX_BLOCK_SIZE = 512;
-#endif
 
 constexpr unsigned MAX_GRID_SIZE = 65535u;
 
@@ -144,84 +138,6 @@ __device__ scalar_t reduce(Op op, PTA tensor, int plane) {
   __syncthreads();
   // Everyone picks it up, should be broadcast into the whole grad_input
   return shared[0];
-}
-
-constexpr int ELEMENTS_PER_ITER = 4; // enables concurrency within each thread to hide latency
-constexpr int ELEMENTS_PER_THREAD = 16;
-constexpr int OPTIMAL_TILE_W = 32;
-constexpr int MAX_H_BLOCK = 128;
-
-__host__ void flexible_launch_configs(
-      const int reduction,
-      const int stride,
-      dim3 &block,
-      dim3 &grid,
-      const bool coop_flag = false) {
-  int block_x = std::min(lastPow2(stride), OPTIMAL_TILE_W);
-  int block_y = std::min(lastPow2(at::ceil_div(reduction , ELEMENTS_PER_THREAD)),
-                         MAX_BLOCK_SIZE / block_x);
-  if (block_x * block_y != MAX_BLOCK_SIZE) {
-    block_x = std::min(lastPow2(stride), MAX_BLOCK_SIZE / block_y);
-  }
-
-  int grid_x = at::ceil_div(stride, block_x);
-  int grid_y = std::min(at::ceil_div(reduction, block_y * ELEMENTS_PER_THREAD), MAX_H_BLOCK);
-  if (coop_flag) {
-    // it's not worth having a grid reduction if the reduction dimension is not big enough
-    grid_y = grid_y < 8 ? 1 : grid_y;
-  }
-
-  block.x = block_x;
-  block.y = block_y;
-  block.z = 1;
-  grid.x = grid_x;
-  grid.y = grid_y;
-  grid.z = 1;
-}
-
-template<typename T, typename C>
-__device__ __forceinline__ void welford_merge_element(C& count,
-                                                      T& mean,
-                                                      T& m2n,
-                                                      const C& count_new,
-                                                      const T& mean_new,
-                                                      const T& m2n_new) {
-      T factor = T(1.0) / ::max(1, (count + count_new));
-      T delta0 = mean - mean_new;
-      mean = (mean_new * count_new + mean * count) * factor;
-      m2n += m2n_new + delta0 * delta0 * count_new * count * factor;
-      count += count_new;
-}
-
-// merge mean/m2n among threadIdx.y within block
-template<typename T, typename C>
-__device__ __forceinline__ void welford_merge_block_vertical(C& count,
-                                                             T& mean,
-                                                             T& m2n,
-                                                             C* shmem_count,
-                                                             T* shmem_mean,
-                                                             T* shmem_m2n) {
-  // write to shared memory
-  auto address_base = threadIdx.x + threadIdx.y * blockDim.x;
-
-#pragma unroll
-  for (int offset = blockDim.y/2; offset > 0; offset >>= 1) {
-    if (threadIdx.y < offset*2) {
-      shmem_mean[address_base] = mean;
-      shmem_m2n[address_base] = m2n;
-      shmem_count[address_base] = count;
-    }
-    __syncthreads();
-    if (threadIdx.y < offset && threadIdx.y + offset < blockDim.y) {
-      auto address = address_base + offset * blockDim.x;
-      // read shared memory back to register for reduction
-      auto count_new = shmem_count[address];
-      auto mean_new = shmem_mean[address];
-      auto m2n_new = shmem_m2n[address];
-
-      welford_merge_element(count, mean, m2n, count_new, mean_new, m2n_new);
-    }
-  }
 }
 
 template <typename input_scalar_t, typename stat_scalar_t, typename stat_accscalar_t, bool train, typename index_t>
@@ -1177,30 +1093,6 @@ __global__ void batch_norm_transform_input_channels_last_kernel(
       }
       m_offset += inner_loop_stride;
       address_base += address_increment;
-    }
-  }
-}
-
-template<typename T>
-__device__ __forceinline__ void merge_block_vertical_backward(T& sum_dy,
-    T& sum_dy_xmu,
-    T* shmem_sum_dy,
-    T* shmem_sum_dy_xmu) {
-  // write to shared memory
-  auto address_base = threadIdx.x + threadIdx.y * blockDim.x;
-
-#pragma unroll
-  for (int offset = blockDim.y/2; offset > 0; offset >>= 1) {
-    if (threadIdx.y < offset*2) {
-      shmem_sum_dy[address_base] = sum_dy;
-      shmem_sum_dy_xmu[address_base] = sum_dy_xmu;
-    }
-    __syncthreads();
-    if (threadIdx.y < offset && threadIdx.y + offset < blockDim.y) {
-      auto address = address_base + offset * blockDim.x;
-
-      sum_dy += shmem_sum_dy[address];
-      sum_dy_xmu += shmem_sum_dy_xmu[address];
     }
   }
 }

--- a/aten/src/ATen/native/cuda/channels_last_reduce.cuh
+++ b/aten/src/ATen/native/cuda/channels_last_reduce.cuh
@@ -1,0 +1,141 @@
+#pragma once
+
+// Shared building blocks for reductions over a channels-last tensor viewed as
+// [reduction, stride], where the reduced axis is the outer one. blockDim.x
+// spans the stride (channels) so a warp's global reads stay contiguous, while
+// blockDim.y and gridDim.y split the reduced axis, keeping the grid wide even
+// when the stride is small. Blocks in a gridDim.y slice stage their partial
+// results and the last one to arrive combines them.
+//
+// Used by the batch norm and group norm channels-last kernels.
+
+#include <ATen/ceil_div.h>
+#include <ATen/native/cuda/LaunchUtils.h>
+#include <c10/macros/Macros.h>
+
+#include <algorithm>
+
+namespace at::native {
+
+// The maximum number of threads in a block.
+// Note SortingCommon.cuh separately defines an at::native::MAX_BLOCK_SIZE with a
+// different value; no translation unit includes both today, but a future one
+// would have to reconcile them.
+#if defined(USE_ROCM)
+constexpr int MAX_BLOCK_SIZE = 1024;
+#else
+constexpr int MAX_BLOCK_SIZE = 512;
+#endif
+
+constexpr int ELEMENTS_PER_ITER =
+    4; // enables concurrency within each thread to hide latency
+constexpr int ELEMENTS_PER_THREAD = 16;
+constexpr int OPTIMAL_TILE_W = 32;
+constexpr int MAX_H_BLOCK = 128;
+
+__host__ inline void flexible_launch_configs(
+    const int reduction,
+    const int stride,
+    dim3& block,
+    dim3& grid,
+    const bool coop_flag = false) {
+  int block_x = std::min(lastPow2(stride), OPTIMAL_TILE_W);
+  int block_y = std::min(
+      lastPow2(at::ceil_div(reduction, ELEMENTS_PER_THREAD)),
+      MAX_BLOCK_SIZE / block_x);
+  if (block_x * block_y != MAX_BLOCK_SIZE) {
+    block_x = std::min(lastPow2(stride), MAX_BLOCK_SIZE / block_y);
+  }
+
+  int grid_x = at::ceil_div(stride, block_x);
+  int grid_y =
+      std::min(at::ceil_div(reduction, block_y * ELEMENTS_PER_THREAD),
+               MAX_H_BLOCK);
+  if (coop_flag) {
+    // it's not worth having a grid reduction if the reduction dimension is not
+    // big enough
+    grid_y = grid_y < 8 ? 1 : grid_y;
+  }
+
+  block.x = block_x;
+  block.y = block_y;
+  block.z = 1;
+  grid.x = grid_x;
+  grid.y = grid_y;
+  grid.z = 1;
+}
+
+template <typename T, typename C>
+__device__ __forceinline__ void welford_merge_element(
+    C& count,
+    T& mean,
+    T& m2n,
+    const C& count_new,
+    const T& mean_new,
+    const T& m2n_new) {
+  T factor = T(1.0) / ::max(C(1), (count + count_new));
+  T delta0 = mean - mean_new;
+  mean = (mean_new * count_new + mean * count) * factor;
+  m2n += m2n_new + delta0 * delta0 * count_new * count * factor;
+  count += count_new;
+}
+
+// merge mean/m2n among threadIdx.y within block
+template <typename T, typename C>
+__device__ __forceinline__ void welford_merge_block_vertical(
+    C& count,
+    T& mean,
+    T& m2n,
+    C* shmem_count,
+    T* shmem_mean,
+    T* shmem_m2n) {
+  // write to shared memory
+  auto address_base = threadIdx.x + threadIdx.y * blockDim.x;
+
+#pragma unroll
+  for (int offset = blockDim.y / 2; offset > 0; offset >>= 1) {
+    if (threadIdx.y < offset * 2) {
+      shmem_mean[address_base] = mean;
+      shmem_m2n[address_base] = m2n;
+      shmem_count[address_base] = count;
+    }
+    __syncthreads();
+    if (threadIdx.y < offset && threadIdx.y + offset < blockDim.y) {
+      auto address = address_base + offset * blockDim.x;
+      // read shared memory back to register for reduction
+      auto count_new = shmem_count[address];
+      auto mean_new = shmem_mean[address];
+      auto m2n_new = shmem_m2n[address];
+
+      welford_merge_element(count, mean, m2n, count_new, mean_new, m2n_new);
+    }
+  }
+}
+
+// merge a pair of sums among threadIdx.y within block
+template <typename T>
+__device__ __forceinline__ void merge_block_vertical_backward(
+    T& sum_dy,
+    T& sum_dy_xmu,
+    T* shmem_sum_dy,
+    T* shmem_sum_dy_xmu) {
+  // write to shared memory
+  auto address_base = threadIdx.x + threadIdx.y * blockDim.x;
+
+#pragma unroll
+  for (int offset = blockDim.y / 2; offset > 0; offset >>= 1) {
+    if (threadIdx.y < offset * 2) {
+      shmem_sum_dy[address_base] = sum_dy;
+      shmem_sum_dy_xmu[address_base] = sum_dy_xmu;
+    }
+    __syncthreads();
+    if (threadIdx.y < offset && threadIdx.y + offset < blockDim.y) {
+      auto address = address_base + offset * blockDim.x;
+
+      sum_dy += shmem_sum_dy[address];
+      sum_dy_xmu += shmem_sum_dy_xmu[address];
+    }
+  }
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/group_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/group_norm_kernel.cu
@@ -1,12 +1,14 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/group_norm.h>
 
+#include <limits>
 #include <type_traits>
 #include <utility>
 
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/core/Tensor.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <ATen/native/SharedReduceOps.h>
 #include <ATen/native/TensorIterator.h>
 #include <c10/cuda/CUDAMathCompat.h>
@@ -15,11 +17,13 @@
 #include <ATen/native/cuda/Loops.cuh>
 #include <ATen/native/cuda/MemoryAccess.cuh>
 #include <ATen/native/cuda/block_reduce.cuh>
+#include <ATen/native/cuda/channels_last_reduce.cuh>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #else
 #include <ATen/ops/empty.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 namespace at::native {
@@ -27,6 +31,22 @@ namespace at::native {
 namespace {
 
 constexpr int kCUDANumThreads = 256;
+// CUDA caps the z extent of a grid; the channels-last reduction kernels walk
+// the batch when N is larger.
+constexpr int64_t kMaxGridZ = 65535;
+// flexible_launch_configs takes int and runs ceil_div on its arguments, so both
+// have to stay far enough below INT_MAX that the intermediate cannot overflow.
+// The reduction extent only feeds grid.y, which saturates at MAX_H_BLOCK long
+// before this bound, so clamping it is purely conservative and the kernels
+// stride over whatever is left.
+constexpr int64_t kMaxReductionExtent =
+    std::numeric_limits<int>::max() / (MAX_BLOCK_SIZE * ELEMENTS_PER_THREAD);
+// The stride extent is different: grid.x is the coverage of the channel axis,
+// so clamping it would leave the channels past the clamp unwritten rather than
+// merely under-parallelized. Only keep ceil_div from overflowing; no real
+// tensor comes near this.
+constexpr int64_t kMaxStrideExtent =
+    std::numeric_limits<int>::max() - MAX_BLOCK_SIZE;
 constexpr int kReduceTileSize = 32;
 
 // Reduce across exactly 32 lanes (offsets 16, 8, 4, 2, 1).
@@ -42,13 +62,37 @@ __inline__ __device__ T ReduceSum32(T val) {
   return val;
 }
 
-template <int VecSize, typename T, typename T_ACC>
+template <typename T, typename PT, typename T_ACC>
+__device__ __forceinline__ void WriteMomentsUnitD(
+    int64_t ng,
+    T_ACC mean_th,
+    T_ACC m2n_th,
+    int64_t count_th,
+    T_ACC eps,
+    PT* __restrict__ mean,
+    PT* __restrict__ rstd,
+    T_ACC* __restrict__ mean_acc,
+    T_ACC* __restrict__ rstd_acc) {
+  const T_ACC rstd_val =
+      c10::cuda::compat::rsqrt(m2n_th / static_cast<T_ACC>(count_th) + eps);
+  mean[ng] = mean_th;
+  rstd[ng] = rstd_val;
+  // The accelerated-precision copies are separate tensors exactly when the
+  // input is reduced precision, which is not the same as PT != T_ACC: under
+  // autocast PT and T_ACC are both float over a half input.
+  if constexpr (!std::is_same_v<T, T_ACC>) {
+    mean_acc[ng] = mean_th;
+    rstd_acc[ng] = rstd_val;
+  }
+}
+
+template <int VecSize, typename T, typename PT, typename T_ACC>
 __global__ void RowwiseMomentsContiguousCUDAKernel(
     int64_t N,
-    T eps,
+    T_ACC eps,
     const T* __restrict__ X,
-    T* __restrict__ mean,
-    T* __restrict__ rstd,
+    PT* __restrict__ mean,
+    PT* __restrict__ rstd,
     T_ACC* __restrict__ mean_acc,
     T_ACC* __restrict__ rstd_acc) {
   using WelfordType = WelfordData<T_ACC, int64_t>;
@@ -86,7 +130,7 @@ __global__ void RowwiseMomentsContiguousCUDAKernel(
   }
   if (threadIdx.x == 0) {
     auto [m2, m1] = welford_op.project(val);
-    T_ACC rstd_val = c10::cuda::compat::rsqrt(m2 + static_cast<T_ACC>(eps));
+    T_ACC rstd_val = c10::cuda::compat::rsqrt(m2 + eps);
     mean[i] = m1;
     rstd[i] = rstd_val;
     // save off the accelerated-precision output, if different
@@ -97,16 +141,16 @@ __global__ void RowwiseMomentsContiguousCUDAKernel(
   }
 }
 
-template <int GroupsPerBlock, typename T, typename T_ACC>
+template <int GroupsPerBlock, typename T, typename PT, typename T_ACC>
 __global__ void RowwiseMomentsChannelsLastSmallDCUDAKernel(
     int64_t C,
     int64_t HxW,
     int64_t D,
     int64_t G,
-    T eps,
+    T_ACC eps,
     const T* __restrict__ X,
-    T* __restrict__ mean,
-    T* __restrict__ rstd,
+    PT* __restrict__ mean,
+    PT* __restrict__ rstd,
     T_ACC* __restrict__ mean_acc,
     T_ACC* __restrict__ rstd_acc) {
   using WelfordType = WelfordData<T_ACC, int64_t>;
@@ -147,8 +191,7 @@ __global__ void RowwiseMomentsChannelsLastSmallDCUDAKernel(
     }
     const int64_t ng = n * G + first_group + threadIdx.x;
     auto [m2, m1] = welford_op.project(val);
-    const T_ACC rstd_val =
-        c10::cuda::compat::rsqrt(m2 + static_cast<T_ACC>(eps));
+    const T_ACC rstd_val = c10::cuda::compat::rsqrt(m2 + eps);
     mean[ng] = m1;
     rstd[ng] = rstd_val;
     if constexpr (!std::is_same_v<T, T_ACC>) {
@@ -158,16 +201,16 @@ __global__ void RowwiseMomentsChannelsLastSmallDCUDAKernel(
   }
 }
 
-template <typename T, typename T_ACC>
+template <typename T, typename PT, typename T_ACC>
 __global__ void RowwiseMomentsChannelsLastCUDAKernel(
     int64_t N,
     int64_t C,
     int64_t HxW,
     int64_t D,
-    T eps,
+    T_ACC eps,
     const T* X,
-    T* mean,
-    T* rstd,
+    PT* mean,
+    PT* rstd,
     T_ACC* mean_acc,
     T_ACC* rstd_acc) {
   using WelfordType = WelfordData<T_ACC, int64_t>;
@@ -207,7 +250,7 @@ __global__ void RowwiseMomentsChannelsLastCUDAKernel(
   }
   if (threadIdx.x == 0) {
     auto [m2, m1] = welford_op.project(val);
-    T_ACC rstd_val = c10::cuda::compat::rsqrt(m2 + static_cast<T_ACC>(eps));
+    T_ACC rstd_val = c10::cuda::compat::rsqrt(m2 + eps);
     mean[ng] = m1;
     rstd[ng] = rstd_val;
     if constexpr (!std::is_same_v<T, T_ACC>) {
@@ -217,7 +260,128 @@ __global__ void RowwiseMomentsChannelsLastCUDAKernel(
   }
 }
 
-template <typename index_t, typename T, typename T_ACC>
+// Group norm with one group per channel, which is what instance norm lowers to,
+// has D == 1, so the moments of a group are the moments of a single channel.
+// The kernels above parallelize over groups and reduce HxW inside a block,
+// which leaves almost the whole device idle at that shape: with G == C the
+// SmallD grid is only N * ceil(C / GroupsPerBlock). This one reduces the same
+// data with blockDim.x spanning channels, so a warp's reads stay contiguous,
+// and with blockDim.y and gridDim.y splitting HxW so the grid stays wide
+// regardless of C. Partial results are staged and combined by the last block
+// to arrive, following batch_norm's channels-last statistics kernel.
+template <typename T, typename PT, typename T_ACC>
+__global__ void RowwiseMomentsChannelsLastUnitDCUDAKernel(
+    int64_t N,
+    int64_t C,
+    int64_t HxW,
+    T_ACC eps,
+    const T* __restrict__ X,
+    PT* __restrict__ mean,
+    PT* __restrict__ rstd,
+    T_ACC* __restrict__ mean_acc,
+    T_ACC* __restrict__ rstd_acc,
+    volatile T_ACC* staging_data,
+    int* semaphores) {
+  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t hw_stride = blockDim.y * gridDim.y;
+  static __shared__ T_ACC shmem_mean[MAX_BLOCK_SIZE];
+  static __shared__ T_ACC shmem_m2n[MAX_BLOCK_SIZE];
+  static __shared__ int64_t shmem_count[MAX_BLOCK_SIZE];
+  __shared__ bool is_last_block_done;
+
+  // gridDim.z is capped at 65535, so walk the batch instead of mapping it one
+  // to one onto blockIdx.z. Every block steps through the same n values, so the
+  // barriers below stay uniform across the block.
+  for (int64_t n = blockIdx.z; n < N; n += gridDim.z) {
+    T_ACC mean_th = 0;
+    T_ACC m2n_th = 0;
+    // int64_t because the merged count reaches HxW, which overflows int for
+    // large volumes.
+    int64_t count_th = 0;
+    if (c < C) {
+      for (int64_t hw = blockIdx.y * blockDim.y + threadIdx.y; hw < HxW;
+           hw += hw_stride) {
+        const T_ACC x = static_cast<T_ACC>(X[(n * HxW + hw) * C + c]);
+        welford_merge_element(
+            count_th, mean_th, m2n_th, int64_t{1}, x, T_ACC(0));
+      }
+    }
+    welford_merge_block_vertical(
+        count_th, mean_th, m2n_th, shmem_count, shmem_mean, shmem_m2n);
+
+    if (gridDim.y == 1) {
+      if (threadIdx.y == 0 && c < C) {
+        WriteMomentsUnitD<T, PT, T_ACC>(
+            n * C + c,
+            mean_th,
+            m2n_th,
+            count_th,
+            eps,
+            mean,
+            rstd,
+            mean_acc,
+            rstd_acc);
+      }
+      // Fall through to the barrier below rather than continuing: shmem is
+      // reused by the next batch element and the vertical merge ends on a read.
+      __syncthreads();
+      continue;
+    }
+
+    volatile T_ACC* staging_mean = staging_data;
+    volatile T_ACC* staging_m2n = &staging_data[C * gridDim.y * N];
+    // The count region is int64_t, hence twice the stride of the two T_ACC
+    // regions ahead of it; the workspace is sized to match.
+    volatile int64_t* staging_count =
+        reinterpret_cast<volatile int64_t*>(&staging_m2n[C * gridDim.y * N]);
+    const int64_t staging_index = (n * gridDim.y + blockIdx.y) * C + c;
+    if (threadIdx.y == 0 && c < C) {
+      staging_mean[staging_index] = mean_th;
+      staging_m2n[staging_index] = m2n_th;
+      staging_count[staging_index] = count_th;
+    }
+    __threadfence();
+    __syncthreads();
+
+    if (threadIdx.x == 0 && threadIdx.y == 0) {
+      const int old = atomicAdd(&semaphores[n * gridDim.x + blockIdx.x], 1);
+      is_last_block_done = (old == (gridDim.y - 1));
+    }
+    __syncthreads();
+
+    if (is_last_block_done) {
+      count_th = 0;
+      mean_th = 0;
+      m2n_th = 0;
+      for (int64_t y = threadIdx.y; y < gridDim.y; y += blockDim.y) {
+        const int64_t index = (n * gridDim.y + y) * C + c;
+        const int64_t count_new = c < C ? staging_count[index] : 0;
+        const T_ACC mean_new = c < C ? staging_mean[index] : T_ACC(0);
+        const T_ACC m2n_new = c < C ? staging_m2n[index] : T_ACC(0);
+        welford_merge_element(
+            count_th, mean_th, m2n_th, count_new, mean_new, m2n_new);
+      }
+      welford_merge_block_vertical(
+          count_th, mean_th, m2n_th, shmem_count, shmem_mean, shmem_m2n);
+      if (threadIdx.y == 0 && c < C) {
+        WriteMomentsUnitD<T, PT, T_ACC>(
+            n * C + c,
+            mean_th,
+            m2n_th,
+            count_th,
+            eps,
+            mean,
+            rstd,
+            mean_acc,
+            rstd_acc);
+      }
+    }
+    // shmem and is_last_block_done are reused by the next batch element
+    __syncthreads();
+  }
+}
+
+template <typename index_t, typename T, typename PT, typename T_ACC>
 __global__ void GroupNormBackwardChannelsLastCUDAKernel(
     index_t numel,
     index_t G,
@@ -226,8 +390,8 @@ __global__ void GroupNormBackwardChannelsLastCUDAKernel(
     at::cuda::detail::IntDivider<index_t> D_divider,
     const T* __restrict__ dY,
     const T* __restrict__ X,
-    const T* __restrict__ rstd,
-    const T* __restrict__ gamma,
+    const PT* __restrict__ rstd,
+    const PT* __restrict__ gamma,
     const T_ACC* __restrict__ c2,
     const T_ACC* __restrict__ c3,
     T* __restrict__ dX) {
@@ -247,15 +411,15 @@ __global__ void GroupNormBackwardChannelsLastCUDAKernel(
   }
 }
 
-template <typename T, typename T_ACC>
+template <typename PT, typename T_ACC>
 __global__ void ComputeFusedParamsCUDAKernel(
     int64_t N,
     int64_t C,
     int64_t group,
     const T_ACC* mean,
     const T_ACC* rstd,
-    const T* gamma,
-    const T* beta,
+    const PT* gamma,
+    const PT* beta,
     T_ACC* a,
     T_ACC* b) {
   const int64_t index = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
@@ -269,15 +433,15 @@ __global__ void ComputeFusedParamsCUDAKernel(
   }
 }
 
-template <typename T>
+template <typename T, typename PT>
 __global__ void Compute1dBackwardFusedParamsCUDAKernel(
     int64_t C,
     int64_t group,
     const T* dY,
     const T* X,
-    const T* mean,
-    const T* rstd,
-    const T* gamma,
+    const PT* mean,
+    const PT* rstd,
+    const PT* gamma,
     acc_type<T, true>* c2,
     acc_type<T, true>* c3) {
   using T_ACC = acc_type<T, true>;
@@ -316,17 +480,17 @@ __global__ void Compute1dBackwardFusedParamsCUDAKernel(
   }
 }
 
-template <typename T>
+template <typename T, typename PT>
 __global__ void GammaBeta1dBackwardCUDAKernel1(
     int64_t N,
     int64_t C,
     int64_t group,
     const T* dY,
     const T* X,
-    const T* mean,
-    const T* rstd,
-    T* dgamma,
-    T* dbeta) {
+    const PT* mean,
+    const PT* rstd,
+    PT* dgamma,
+    PT* dbeta) {
   using T_ACC = acc_type<T, true>;
   const int64_t c = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
   if (c < C) {
@@ -354,17 +518,17 @@ __global__ void GammaBeta1dBackwardCUDAKernel1(
   }
 }
 
-template <typename T>
+template <typename T, typename PT>
 __global__ void GammaBeta1dBackwardCUDAKernel2(
     int64_t N,
     int64_t C,
     int64_t group,
     const T* dY,
     const T* X,
-    const T* mean,
-    const T* rstd,
-    T* dgamma,
-    T* dbeta) {
+    const PT* mean,
+    const PT* rstd,
+    PT* dgamma,
+    PT* dbeta) {
   using T_ACC = acc_type<T, true>;
   __shared__ T_ACC g_shared[kReduceTileSize][kReduceTileSize + 1];
   __shared__ T_ACC b_shared[kReduceTileSize][kReduceTileSize + 1];
@@ -490,101 +654,103 @@ __global__ void ComputeInternalGradientsContiguousCUDAKernel(
   }
 }
 
-template <int ChannelsPerBlock, typename T>
+// ds/db are per (n, c) reductions over HxW of a channels-last [N, HxW, C]
+// tensor. blockDim.x spans channels so the global reads of a warp are
+// contiguous, while blockDim.y/gridDim.y split the HxW reduction, which keeps
+// the grid wide even when C is small. Group norm with one group per channel
+// (i.e. instance norm) is exactly that case: it has D == 1, so a kernel
+// parallelized over channels alone would launch only a handful of blocks.
+// The cross-block combine follows batch_norm's channels-last reduction: each
+// gridDim.y slice stages its partial sums and the last slice to arrive
+// accumulates them.
+template <typename T>
 __global__ void ComputeInternalGradientsChannelsLastCUDAKernel(
+    int64_t N,
     int64_t C,
     int64_t HxW,
     const T* __restrict__ dY,
     const T* __restrict__ X,
     acc_type<T, true>* __restrict__ ds,
-    acc_type<T, true>* __restrict__ db) {
+    acc_type<T, true>* __restrict__ db,
+    volatile acc_type<T, true>* staging_data,
+    int* semaphores) {
   using T_ACC = acc_type<T, true>;
-  const int64_t channel_blocks = (C + ChannelsPerBlock - 1) / ChannelsPerBlock;
-  const int64_t n = blockIdx.x / channel_blocks;
-  const int64_t first_channel =
-      (blockIdx.x % channel_blocks) * ChannelsPerBlock;
-  const int64_t local_channel = threadIdx.x % ChannelsPerBlock;
-  const int64_t hw_lane = threadIdx.x / ChannelsPerBlock;
-  const int64_t hw_step = blockDim.x / ChannelsPerBlock;
-  const int64_t c = first_channel + local_channel;
-  T_ACC sum1 = 0;
-  T_ACC sum2 = 0;
-  if (c < C) {
-    for (int64_t hw = hw_lane; hw < HxW; hw += hw_step) {
-      const int64_t index = (n * HxW + hw) * C + c;
-      const T_ACC dy = static_cast<T_ACC>(dY[index]);
-      sum1 += dy * static_cast<T_ACC>(X[index]);
-      sum2 += dy;
-    }
-  }
+  const int64_t c = blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t hw_stride = blockDim.y * gridDim.y;
+  static __shared__ T_ACC shmem_ds[MAX_BLOCK_SIZE];
+  static __shared__ T_ACC shmem_db[MAX_BLOCK_SIZE];
+  __shared__ bool is_last_block_done;
 
-  __shared__ T_ACC ds_shared[kCUDANumThreads];
-  __shared__ T_ACC db_shared[kCUDANumThreads];
-  ds_shared[threadIdx.x] = sum1;
-  db_shared[threadIdx.x] = sum2;
-  __syncthreads();
-  if (threadIdx.x < ChannelsPerBlock && first_channel + threadIdx.x < C) {
-    sum1 = 0;
-    sum2 = 0;
-    for (int64_t i = 0; i < hw_step; ++i) {
-      const int64_t index = i * ChannelsPerBlock + threadIdx.x;
-      sum1 += ds_shared[index];
-      sum2 += db_shared[index];
+  for (int64_t n = blockIdx.z; n < N; n += gridDim.z) {
+    T_ACC sum1 = 0;
+    T_ACC sum2 = 0;
+    if (c < C) {
+      for (int64_t hw = blockIdx.y * blockDim.y + threadIdx.y; hw < HxW;
+           hw += hw_stride) {
+        const int64_t index = (n * HxW + hw) * C + c;
+        const T_ACC dy = static_cast<T_ACC>(dY[index]);
+        sum1 += dy * static_cast<T_ACC>(X[index]);
+        sum2 += dy;
+      }
     }
-    const int64_t nc = n * C + first_channel + threadIdx.x;
-    ds[nc] = sum1;
-    db[nc] = sum2;
+    merge_block_vertical_backward(sum1, sum2, shmem_ds, shmem_db);
+
+    if (gridDim.y == 1) {
+      if (threadIdx.y == 0 && c < C) {
+        ds[n * C + c] = sum1;
+        db[n * C + c] = sum2;
+      }
+      // See the matching comment in RowwiseMomentsChannelsLastUnitDCUDAKernel.
+      __syncthreads();
+      continue;
+    }
+
+    volatile T_ACC* staging_ds = staging_data;
+    volatile T_ACC* staging_db = &staging_data[C * gridDim.y * N];
+    const int64_t staging_index = (n * gridDim.y + blockIdx.y) * C + c;
+    if (threadIdx.y == 0 && c < C) {
+      staging_ds[staging_index] = sum1;
+      staging_db[staging_index] = sum2;
+    }
+    __threadfence();
+    __syncthreads();
+
+    if (threadIdx.x == 0 && threadIdx.y == 0) {
+      const int old = atomicAdd(&semaphores[n * gridDim.x + blockIdx.x], 1);
+      is_last_block_done = (old == (gridDim.y - 1));
+    }
+    __syncthreads();
+
+    if (is_last_block_done) {
+      sum1 = 0;
+      sum2 = 0;
+      for (int64_t y = threadIdx.y; y < gridDim.y; y += blockDim.y) {
+        const int64_t index = (n * gridDim.y + y) * C + c;
+        sum1 += c < C ? staging_ds[index] : T_ACC(0);
+        sum2 += c < C ? staging_db[index] : T_ACC(0);
+      }
+      merge_block_vertical_backward(sum1, sum2, shmem_ds, shmem_db);
+      if (threadIdx.y == 0 && c < C) {
+        ds[n * C + c] = sum1;
+        db[n * C + c] = sum2;
+      }
+    }
+    __syncthreads();
   }
 }
 
-template <typename T>
-__global__ void ComputeInternalGradientsChannelsLastFallbackCUDAKernel(
-    int64_t C,
-    int64_t HxW,
-    const T* __restrict__ dY,
-    const T* __restrict__ X,
-    acc_type<T, true>* __restrict__ ds,
-    acc_type<T, true>* __restrict__ db) {
-  using T_ACC = acc_type<T, true>;
-  const int64_t nc = blockIdx.x;
-  const int64_t n = nc / C;
-  const int64_t c = nc % C;
-  T_ACC sum1 = 0;
-  T_ACC sum2 = 0;
-  for (int64_t hw = threadIdx.x; hw < HxW; hw += blockDim.x) {
-    const int64_t index = (n * HxW + hw) * C + c;
-    const T_ACC dy = static_cast<T_ACC>(dY[index]);
-    sum1 += dy * static_cast<T_ACC>(X[index]);
-    sum2 += dy;
-  }
-  if (blockDim.x <= C10_WARP_SIZE) {
-    sum1 = cuda_utils::WarpReduceSum<T_ACC>(sum1);
-    sum2 = cuda_utils::WarpReduceSum<T_ACC>(sum2);
-  } else {
-    __shared__ T_ACC ds_shared[C10_WARP_SIZE_UPPER_BOUND];
-    __shared__ T_ACC db_shared[C10_WARP_SIZE_UPPER_BOUND];
-    sum1 = cuda_utils::BlockReduceSum<T_ACC>(sum1, ds_shared);
-    sum2 = cuda_utils::BlockReduceSum<T_ACC>(sum2, db_shared);
-  }
-  if (threadIdx.x == 0) {
-    ds[nc] = sum1;
-    db[nc] = sum2;
-  }
-}
-
-template <typename T>
+template <typename PT, typename T_ACC>
 __global__ void ComputeBackwardFusedParamsCUDAKernel(
     int64_t C,
     int64_t HxW,
     int64_t group,
-    const T* mean,
-    const T* rstd,
-    const T* gamma,
-    const acc_type<T, true>* ds,
-    const acc_type<T, true>* db,
-    acc_type<T, true>* c2,
-    acc_type<T, true>* c3) {
-  using T_ACC = acc_type<T, true>;
+    const PT* mean,
+    const PT* rstd,
+    const PT* gamma,
+    const T_ACC* ds,
+    const T_ACC* db,
+    T_ACC* c2,
+    T_ACC* c3) {
   const int64_t G = group;
   const int64_t D = C / G;
   const int64_t n = blockIdx.x;
@@ -619,18 +785,17 @@ __global__ void ComputeBackwardFusedParamsCUDAKernel(
   }
 }
 
-template <typename T>
+template <typename PT, typename T_ACC>
 __global__ void GammaBetaBackwardCUDAKernel1(
     int64_t N,
     int64_t C,
     int64_t group,
-    const T* mean,
-    const T* rstd,
-    const acc_type<T, true>* ds,
-    const acc_type<T, true>* db,
-    T* dgamma,
-    T* dbeta) {
-  using T_ACC = acc_type<T, true>;
+    const PT* mean,
+    const PT* rstd,
+    const T_ACC* ds,
+    const T_ACC* db,
+    PT* dgamma,
+    PT* dbeta) {
   const int64_t c = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
   if (c < C) {
     const int64_t G = group;
@@ -654,18 +819,17 @@ __global__ void GammaBetaBackwardCUDAKernel1(
   }
 }
 
-template <typename T>
+template <typename PT, typename T_ACC>
 __global__ void GammaBetaBackwardCUDAKernel2(
     int64_t N,
     int64_t C,
     int64_t group,
-    const T* mean,
-    const T* rstd,
-    const acc_type<T, true>* ds,
-    const acc_type<T, true>* db,
-    T* dgamma,
-    T* dbeta) {
-  using T_ACC = acc_type<T, true>;
+    const PT* mean,
+    const PT* rstd,
+    const T_ACC* ds,
+    const T_ACC* db,
+    PT* dgamma,
+    PT* dbeta) {
   __shared__ T_ACC g_shared[kReduceTileSize][kReduceTileSize + 1];
   __shared__ T_ACC b_shared[kReduceTileSize][kReduceTileSize + 1];
   const int64_t c = ((int64_t)blockIdx.x) * blockDim.x + threadIdx.x;
@@ -743,7 +907,7 @@ __global__ void GammaBetaBackwardCUDAKernel2(
   }
 }
 
-template <typename T, typename T_ACC>
+template <typename T, typename PT, typename T_ACC>
 void GroupNorm1dForward(
     const Tensor& X,
     const Tensor& mean_acc,
@@ -768,7 +932,8 @@ void GroupNorm1dForward(
                     .add_owned_const_input(beta.view({1, G, D}))
                     .build();
     gpu_kernel(
-        iter, [] GPU_LAMBDA(T x, T_ACC mean, T_ACC rstd, T gamma, T beta) -> T {
+        iter,
+        [] GPU_LAMBDA(T x, T_ACC mean, T_ACC rstd, PT gamma, PT beta) -> T {
           return (static_cast<T_ACC>(x) - mean) * rstd *
               static_cast<T_ACC>(gamma) +
               static_cast<T_ACC>(beta);
@@ -783,7 +948,7 @@ void GroupNorm1dForward(
                     .add_owned_input(rstd_acc.view({N, G, 1}))
                     .add_owned_const_input(gamma.view({1, G, D}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC mean, T_ACC rstd, T gamma) -> T {
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC mean, T_ACC rstd, PT gamma) -> T {
       return (static_cast<T_ACC>(x) - mean) * rstd * static_cast<T_ACC>(gamma);
     });
   } else if (beta.defined()) {
@@ -796,7 +961,7 @@ void GroupNorm1dForward(
                     .add_owned_input(rstd_acc.view({N, G, 1}))
                     .add_owned_const_input(beta.view({1, G, D}))
                     .build();
-    gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC mean, T_ACC rstd, T beta) -> T {
+    gpu_kernel(iter, [] GPU_LAMBDA(T x, T_ACC mean, T_ACC rstd, PT beta) -> T {
       return (static_cast<T_ACC>(x) - mean) * rstd + static_cast<T_ACC>(beta);
     });
   } else {
@@ -815,7 +980,7 @@ void GroupNorm1dForward(
   AT_CUDA_CHECK(cudaGetLastError());
 }
 
-template <typename T, typename T_ACC = acc_type<T, true>>
+template <typename T, typename PT, typename T_ACC = acc_type<T, true>>
 void GroupNormKernelImplInternal(
     const Tensor& X,
     const Tensor& gamma,
@@ -824,7 +989,7 @@ void GroupNormKernelImplInternal(
     int64_t C,
     int64_t HxW,
     int64_t group,
-    T eps,
+    double eps,
     Tensor& Y,
     Tensor& mean,
     Tensor& rstd) {
@@ -841,8 +1006,8 @@ void GroupNormKernelImplInternal(
   const auto kAccTypeOpts{
       X.options().dtype(needMeanAcc ? kFloat : X.scalar_type())};
 
-  T* mean_data = mean.mutable_data_ptr<T>();
-  T* rstd_data = rstd.mutable_data_ptr<T>();
+  PT* mean_data = mean.mutable_data_ptr<PT>();
+  PT* rstd_data = rstd.mutable_data_ptr<PT>();
   Tensor mean_acc = needMeanAcc ? at::empty(mean.sizes(), kAccTypeOpts) : mean;
   Tensor rstd_acc = needMeanAcc ? at::empty(rstd.sizes(), kAccTypeOpts) : rstd;
   T_ACC* mean_acc_data = mean_acc.mutable_data_ptr<T_ACC>();
@@ -855,30 +1020,69 @@ void GroupNormKernelImplInternal(
       ? at::cuda::warp_size()
       : cuda_utils::kCUDABlockReduceNumThreads;
   if (channels_last) {
-    if ((D == 1 || D == 2) && G >= 4 &&
-        D * HxW >= cuda_utils::kCUDABlockReduceNumThreads) {
+    if (D == 1) {
+      // One group per channel: the split reduction below writes the group
+      // statistics directly, so no per-channel merge pass is needed.
+      TORCH_CHECK(
+          C <= kMaxStrideExtent,
+          "group_norm: too many channels for the channels_last kernels, got ",
+          C);
+      dim3 block;
+      dim3 grid;
+      flexible_launch_configs(
+          std::min<int64_t>(HxW, kMaxReductionExtent),
+          std::min<int64_t>(C, kMaxStrideExtent),
+          block,
+          grid,
+          /*coop_flag=*/true);
+      grid.z = std::min<int64_t>(N, kMaxGridZ);
+      // mean and m2n as T_ACC, then the counts as int64_t. Two T_ACC slots
+      // per count is tight for float and generous for double.
+      Tensor staging_data;
+      Tensor semaphores;
+      if (grid.y > 1) {
+        staging_data =
+            at::empty({4 * static_cast<int64_t>(grid.y) * N * C}, kAccTypeOpts);
+        semaphores = at::zeros(
+            {static_cast<int64_t>(grid.x) * N}, X.options().dtype(kInt));
+      }
+      RowwiseMomentsChannelsLastUnitDCUDAKernel<T, PT, T_ACC>
+          <<<grid, block, 0, cuda_stream>>>(
+              N,
+              C,
+              HxW,
+              static_cast<T_ACC>(eps),
+              X_data,
+              mean_data,
+              rstd_data,
+              mean_acc_data,
+              rstd_acc_data,
+              grid.y > 1 ? staging_data.mutable_data_ptr<T_ACC>() : nullptr,
+              grid.y > 1 ? semaphores.mutable_data_ptr<int>() : nullptr);
+    } else if (
+        D == 2 && G >= 4 && D * HxW >= cuda_utils::kCUDABlockReduceNumThreads) {
       constexpr int kGroupsPerBlock = 4;
       const int64_t group_blocks = (G + kGroupsPerBlock - 1) / kGroupsPerBlock;
-      RowwiseMomentsChannelsLastSmallDCUDAKernel<kGroupsPerBlock, T, T_ACC>
+      RowwiseMomentsChannelsLastSmallDCUDAKernel<kGroupsPerBlock, T, PT, T_ACC>
           <<<N * group_blocks, kCUDANumThreads, 0, cuda_stream>>>(
               C,
               HxW,
               D,
               G,
-              eps,
+              static_cast<T_ACC>(eps),
               X_data,
               mean_data,
               rstd_data,
               mean_acc_data,
               rstd_acc_data);
     } else {
-      RowwiseMomentsChannelsLastCUDAKernel<T, T_ACC>
+      RowwiseMomentsChannelsLastCUDAKernel<T, PT, T_ACC>
           <<<N * G, num_threads, 0, cuda_stream>>>(
               N,
               C,
               HxW,
               D,
-              eps,
+              static_cast<T_ACC>(eps),
               X_data,
               mean_data,
               rstd_data,
@@ -889,15 +1093,15 @@ void GroupNormKernelImplInternal(
     Tensor a = at::empty({N, C}, kAccTypeOpts);
     Tensor b = at::empty({N, C}, kAccTypeOpts);
     const int64_t B = (N * C + kCUDANumThreads - 1) / kCUDANumThreads;
-    ComputeFusedParamsCUDAKernel<T, T_ACC>
+    ComputeFusedParamsCUDAKernel<PT, T_ACC>
         <<<B, kCUDANumThreads, 0, cuda_stream>>>(
             N,
             C,
             G,
             mean_acc_data,
             rstd_acc_data,
-            gamma.defined() ? gamma.const_data_ptr<T>() : nullptr,
-            beta.defined() ? beta.const_data_ptr<T>() : nullptr,
+            gamma.defined() ? gamma.const_data_ptr<PT>() : nullptr,
+            beta.defined() ? beta.const_data_ptr<PT>() : nullptr,
             a.mutable_data_ptr<T_ACC>(),
             b.mutable_data_ptr<T_ACC>());
     C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -919,20 +1123,20 @@ void GroupNormKernelImplInternal(
   if (D * HxW % kVecSize == 0 &&
       memory::can_vectorize_up_to<T>(reinterpret_cast<const char*>(X_data)) >=
           kVecSize) {
-    RowwiseMomentsContiguousCUDAKernel<kVecSize, T, T_ACC>
+    RowwiseMomentsContiguousCUDAKernel<kVecSize, T, PT, T_ACC>
         <<<N * G, num_threads, 0, cuda_stream>>>(
             D * HxW,
-            eps,
+            static_cast<T_ACC>(eps),
             X_data,
             mean_data,
             rstd_data,
             mean_acc_data,
             rstd_acc_data);
   } else {
-    RowwiseMomentsContiguousCUDAKernel<1, T, T_ACC>
+    RowwiseMomentsContiguousCUDAKernel<1, T, PT, T_ACC>
         <<<N * G, num_threads, 0, cuda_stream>>>(
             D * HxW,
-            eps,
+            static_cast<T_ACC>(eps),
             X_data,
             mean_data,
             rstd_data,
@@ -942,7 +1146,7 @@ void GroupNormKernelImplInternal(
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
   if (HxW == 1) {
-    GroupNorm1dForward<T, T_ACC>(
+    GroupNorm1dForward<T, PT, T_ACC>(
         X, mean_acc, rstd_acc, gamma, beta, N, C, G, Y);
   } else if (!gamma.defined() && !beta.defined()) {
     auto iter = TensorIteratorConfig()
@@ -959,8 +1163,9 @@ void GroupNormKernelImplInternal(
   } else {
     Tensor a = at::empty({N, C}, kAccTypeOpts);
     Tensor b = at::empty({N, C}, kAccTypeOpts);
-    const T* gamma_data = gamma.defined() ? gamma.const_data_ptr<T>() : nullptr;
-    const T* beta_data = beta.defined() ? beta.const_data_ptr<T>() : nullptr;
+    const PT* gamma_data =
+        gamma.defined() ? gamma.const_data_ptr<PT>() : nullptr;
+    const PT* beta_data = beta.defined() ? beta.const_data_ptr<PT>() : nullptr;
     T_ACC* a_data = a.mutable_data_ptr<T_ACC>();
     T_ACC* b_data = b.mutable_data_ptr<T_ACC>();
 
@@ -968,7 +1173,7 @@ void GroupNormKernelImplInternal(
     // using manual kernel here. Make it using gpu_kernel_multiple_outputs once
     // the issue fixed.
     const int64_t B = (N * C + kCUDANumThreads - 1) / kCUDANumThreads;
-    ComputeFusedParamsCUDAKernel<T, T_ACC>
+    ComputeFusedParamsCUDAKernel<PT, T_ACC>
         <<<B, kCUDANumThreads, 0, cuda_stream>>>(
             N,
             C,
@@ -1008,28 +1213,29 @@ void GroupNormKernelImpl(
     Tensor& Y,
     Tensor& mean,
     Tensor& rstd) {
+  // The stat tensors are allocated in the param dtype (see param_scalar_type in
+  // group_norm.cpp), so a param dtype wider than the input is the mixed-dtype
+  // case (fp32 affine params over a reduced-precision input, e.g. autocast).
+  // Keep gamma/beta/stats in that dtype instead of reading them as the input
+  // dtype, which would downcast fp32 params to fp16/bf16.
+  const bool mixed_type = mean.scalar_type() != X.scalar_type();
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
       X.scalar_type(),
       "GroupNormKernelImpl",
       [&]() {
-        GroupNormKernelImplInternal<scalar_t>(
-            X,
-            gamma,
-            beta,
-            N,
-            C,
-            HxW,
-            group,
-            static_cast<scalar_t>(eps),
-            Y,
-            mean,
-            rstd);
+        if (mixed_type) {
+          GroupNormKernelImplInternal<scalar_t, acc_type<scalar_t, true>>(
+              X, gamma, beta, N, C, HxW, group, eps, Y, mean, rstd);
+        } else {
+          GroupNormKernelImplInternal<scalar_t, scalar_t>(
+              X, gamma, beta, N, C, HxW, group, eps, Y, mean, rstd);
+        }
       });
 }
 
-template <typename T>
+template <typename T, typename PT>
 void GroupNorm1dBackward(
     const Tensor& dY,
     const Tensor& X,
@@ -1047,12 +1253,13 @@ void GroupNorm1dBackward(
   const int64_t D = C / G;
   const T* dY_data = dY.const_data_ptr<T>();
   const T* X_data = X.const_data_ptr<T>();
-  const T* mean_data = mean.const_data_ptr<T>();
-  const T* rstd_data = rstd.const_data_ptr<T>();
+  const PT* mean_data = mean.const_data_ptr<PT>();
+  const PT* rstd_data = rstd.const_data_ptr<PT>();
 
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
   if (dX.defined()) {
-    const T* gamma_data = gamma.defined() ? gamma.const_data_ptr<T>() : nullptr;
+    const PT* gamma_data =
+        gamma.defined() ? gamma.const_data_ptr<PT>() : nullptr;
     const auto kAccType =
         (X.scalar_type() == kHalf || X.scalar_type() == kBFloat16)
         ? kFloat
@@ -1064,7 +1271,7 @@ void GroupNorm1dBackward(
     const int64_t num_threads = (C / G) < cuda_utils::kCUDABlockReduceNumThreads
         ? at::cuda::warp_size()
         : cuda_utils::kCUDABlockReduceNumThreads;
-    Compute1dBackwardFusedParamsCUDAKernel<T>
+    Compute1dBackwardFusedParamsCUDAKernel<T, PT>
         <<<dim3(N, G), num_threads, 0, cuda_stream>>>(
             C,
             G,
@@ -1091,7 +1298,7 @@ void GroupNorm1dBackward(
                       .build();
       gpu_kernel(
           iter,
-          [] GPU_LAMBDA(T dy, T x, T rstd, T gamma, T_ACC c2, T_ACC c3) -> T {
+          [] GPU_LAMBDA(T dy, T x, PT rstd, PT gamma, T_ACC c2, T_ACC c3) -> T {
             const T_ACC c1 =
                 static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
             return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
@@ -1109,7 +1316,7 @@ void GroupNorm1dBackward(
                       .add_owned_const_input(c3.view({N * G, 1}))
                       .build();
       gpu_kernel(
-          iter, [] GPU_LAMBDA(T dy, T x, T rstd, T_ACC c2, T_ACC c3) -> T {
+          iter, [] GPU_LAMBDA(T dy, T x, PT rstd, T_ACC c2, T_ACC c3) -> T {
             const T_ACC c1 = static_cast<T_ACC>(rstd);
             return c1 * static_cast<T_ACC>(dy) + c2 * static_cast<T_ACC>(x) +
                 c3;
@@ -1117,20 +1324,22 @@ void GroupNorm1dBackward(
     }
   }
   if (dgamma.defined() || dbeta.defined()) {
-    T* dgamma_data = dgamma.defined() ? dgamma.mutable_data_ptr<T>() : nullptr;
-    T* dbeta_data = dbeta.defined() ? dbeta.mutable_data_ptr<T>() : nullptr;
+    PT* dgamma_data =
+        dgamma.defined() ? dgamma.mutable_data_ptr<PT>() : nullptr;
+    PT* dbeta_data = dbeta.defined() ? dbeta.mutable_data_ptr<PT>() : nullptr;
     if (N <= 128) {
       const int64_t B = (C + kCUDANumThreads - 1) / kCUDANumThreads;
-      GammaBeta1dBackwardCUDAKernel1<T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
-          N,
-          C,
-          G,
-          dY_data,
-          X_data,
-          mean_data,
-          rstd_data,
-          dgamma_data,
-          dbeta_data);
+      GammaBeta1dBackwardCUDAKernel1<T, PT>
+          <<<B, kCUDANumThreads, 0, cuda_stream>>>(
+              N,
+              C,
+              G,
+              dY_data,
+              X_data,
+              mean_data,
+              rstd_data,
+              dgamma_data,
+              dbeta_data);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       const int64_t B = (C + kReduceTileSize - 1) / kReduceTileSize;
@@ -1139,7 +1348,7 @@ void GroupNorm1dBackward(
       // reduce for each col in the tile. So here the blockDim must be (32, 16).
       constexpr int kThreadX = kReduceTileSize;
       constexpr int kThreadY = kReduceTileSize / 2;
-      GammaBeta1dBackwardCUDAKernel2<T>
+      GammaBeta1dBackwardCUDAKernel2<T, PT>
           <<<B, dim3(kThreadX, kThreadY), 0, cuda_stream>>>(
               N,
               C,
@@ -1155,7 +1364,7 @@ void GroupNorm1dBackward(
   }
 }
 
-template <typename T>
+template <typename T, typename PT>
 void GroupNormBackwardKernelImplInternal(
     const Tensor& dY,
     const Tensor& X,
@@ -1181,14 +1390,14 @@ void GroupNormBackwardKernelImplInternal(
 
   const T* dY_data = dY.const_data_ptr<T>();
   const T* X_data = X.const_data_ptr<T>();
-  const T* mean_data = mean.const_data_ptr<T>();
-  const T* rstd_data = rstd.const_data_ptr<T>();
-  const T* gamma_data = gamma.defined() ? gamma.const_data_ptr<T>() : nullptr;
+  const PT* mean_data = mean.const_data_ptr<PT>();
+  const PT* rstd_data = rstd.const_data_ptr<PT>();
+  const PT* gamma_data = gamma.defined() ? gamma.const_data_ptr<PT>() : nullptr;
   const bool channels_last = X.is_contiguous(at::MemoryFormat::ChannelsLast) ||
       X.is_contiguous(at::MemoryFormat::ChannelsLast3d);
 
   if (HxW == 1 && !channels_last) {
-    GroupNorm1dBackward<T>(
+    GroupNorm1dBackward<T, PT>(
         dY, X, mean, rstd, gamma, N, C, G, dX, dgamma, dbeta);
     return;
   }
@@ -1207,19 +1416,39 @@ void GroupNormBackwardKernelImplInternal(
       ? warp_size
       : cuda_utils::kCUDABlockReduceNumThreads;
   if (channels_last) {
-    constexpr int kChannelsPerBlock = 16;
-    if (C >= kChannelsPerBlock &&
-        HxW >= cuda_utils::kCUDABlockReduceNumThreads) {
-      const int64_t channel_blocks =
-          (C + kChannelsPerBlock - 1) / kChannelsPerBlock;
-      ComputeInternalGradientsChannelsLastCUDAKernel<kChannelsPerBlock, T>
-          <<<N * channel_blocks, kCUDANumThreads, 0, cuda_stream>>>(
-              C, HxW, dY_data, X_data, ds_data, db_data);
-    } else {
-      ComputeInternalGradientsChannelsLastFallbackCUDAKernel<T>
-          <<<N * C, num_threads, 0, cuda_stream>>>(
-              C, HxW, dY_data, X_data, ds_data, db_data);
+    TORCH_CHECK(
+        C <= kMaxStrideExtent,
+        "group_norm backward: too many channels for the channels_last kernels, got ",
+        C);
+    dim3 block;
+    dim3 grid;
+    flexible_launch_configs(
+        std::min<int64_t>(HxW, kMaxReductionExtent),
+        std::min<int64_t>(C, kMaxStrideExtent),
+        block,
+        grid,
+        /*coop_flag=*/true);
+    grid.z = std::min<int64_t>(N, kMaxGridZ);
+    // Only the multi-slice path needs to stage partial sums across blocks.
+    Tensor staging_data;
+    Tensor semaphores;
+    if (grid.y > 1) {
+      staging_data =
+          at::empty({2 * static_cast<int64_t>(grid.y) * N * C}, ds.options());
+      semaphores = at::zeros(
+          {static_cast<int64_t>(grid.x) * N}, X.options().dtype(kInt));
     }
+    ComputeInternalGradientsChannelsLastCUDAKernel<T>
+        <<<grid, block, 0, cuda_stream>>>(
+            N,
+            C,
+            HxW,
+            dY_data,
+            X_data,
+            ds_data,
+            db_data,
+            grid.y > 1 ? staging_data.mutable_data_ptr<T_ACC>() : nullptr,
+            grid.y > 1 ? semaphores.mutable_data_ptr<int>() : nullptr);
   } else {
     constexpr int kVecSize = 16 / sizeof(T);
     if (HxW % kVecSize == 0 &&
@@ -1252,7 +1481,7 @@ void GroupNormBackwardKernelImplInternal(
                       .add_owned_const_input(rstd.view({N, G, 1}))
                       .add_owned_const_input(gamma.view({1, G, D}))
                       .build();
-      gpu_kernel(iter, [] GPU_LAMBDA(T rstd, T gamma) -> T_ACC {
+      gpu_kernel(iter, [] GPU_LAMBDA(PT rstd, PT gamma) -> T_ACC {
         return static_cast<T_ACC>(rstd) * static_cast<T_ACC>(gamma);
       });
     }
@@ -1260,7 +1489,7 @@ void GroupNormBackwardKernelImplInternal(
     num_threads = (C / G) < cuda_utils::kCUDABlockReduceNumThreads
         ? warp_size
         : cuda_utils::kCUDABlockReduceNumThreads;
-    ComputeBackwardFusedParamsCUDAKernel<T>
+    ComputeBackwardFusedParamsCUDAKernel<PT, T_ACC>
         <<<dim3(N, G), num_threads, 0, cuda_stream>>>(
             C,
             HxW,
@@ -1279,7 +1508,7 @@ void GroupNormBackwardKernelImplInternal(
       const int64_t blocks = (numel + kCUDANumThreads - 1) / kCUDANumThreads;
       if (at::cuda::detail::canUse32BitIndexMath(X)) {
         using index_t = uint32_t;
-        GroupNormBackwardChannelsLastCUDAKernel<index_t, T, T_ACC>
+        GroupNormBackwardChannelsLastCUDAKernel<index_t, T, PT, T_ACC>
             <<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
                 static_cast<index_t>(numel),
                 static_cast<index_t>(G),
@@ -1295,7 +1524,7 @@ void GroupNormBackwardKernelImplInternal(
                 dX.mutable_data_ptr<T>());
       } else {
         using index_t = int64_t;
-        GroupNormBackwardChannelsLastCUDAKernel<index_t, T, T_ACC>
+        GroupNormBackwardChannelsLastCUDAKernel<index_t, T, PT, T_ACC>
             <<<blocks, kCUDANumThreads, 0, cuda_stream>>>(
                 numel,
                 G,
@@ -1346,21 +1575,23 @@ void GroupNormBackwardKernelImplInternal(
     }
   }
   if (dgamma.defined() || dbeta.defined()) {
-    T* dgamma_data = dgamma.defined() ? dgamma.mutable_data_ptr<T>() : nullptr;
-    T* dbeta_data = dbeta.defined() ? dbeta.mutable_data_ptr<T>() : nullptr;
+    PT* dgamma_data =
+        dgamma.defined() ? dgamma.mutable_data_ptr<PT>() : nullptr;
+    PT* dbeta_data = dbeta.defined() ? dbeta.mutable_data_ptr<PT>() : nullptr;
     if (N <= 128) {
       // For small batch size, do colwise reduce directly.
       const int64_t B = (C + kCUDANumThreads - 1) / kCUDANumThreads;
-      GammaBetaBackwardCUDAKernel1<T><<<B, kCUDANumThreads, 0, cuda_stream>>>(
-          N,
-          C,
-          G,
-          mean_data,
-          rstd_data,
-          ds_data,
-          db_data,
-          dgamma_data,
-          dbeta_data);
+      GammaBetaBackwardCUDAKernel1<PT, T_ACC>
+          <<<B, kCUDANumThreads, 0, cuda_stream>>>(
+              N,
+              C,
+              G,
+              mean_data,
+              rstd_data,
+              ds_data,
+              db_data,
+              dgamma_data,
+              dbeta_data);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
       const int64_t B = (C + kReduceTileSize - 1) / kReduceTileSize;
@@ -1369,7 +1600,7 @@ void GroupNormBackwardKernelImplInternal(
       // reduce for each col in the tile. So here the blockDim must be (32, 16).
       constexpr int kThreadX = kReduceTileSize;
       constexpr int kThreadY = kReduceTileSize / 2;
-      GammaBetaBackwardCUDAKernel2<T>
+      GammaBetaBackwardCUDAKernel2<PT, T_ACC>
           <<<B, dim3(kThreadX, kThreadY), 0, cuda_stream>>>(
               N,
               C,
@@ -1398,14 +1629,25 @@ void GroupNormBackwardKernelImpl(
     Tensor& dX,
     Tensor& dgamma,
     Tensor& dbeta) {
+  // Mixed dtype (fp32 stats/affine params over a reduced-precision input, e.g.
+  // autocast): keep the params in their own dtype instead of the input's. See
+  // the matching comment in GroupNormKernelImpl.
+  const bool mixed_type = mean.scalar_type() != X.scalar_type();
   AT_DISPATCH_FLOATING_TYPES_AND2(
       at::ScalarType::Half,
       at::ScalarType::BFloat16,
       X.scalar_type(),
       "GroupNormBackwardKernelImpl",
       [&]() {
-        GroupNormBackwardKernelImplInternal<scalar_t>(
-            dY, X, mean, rstd, gamma, N, C, HxW, group, dX, dgamma, dbeta);
+        if (mixed_type) {
+          GroupNormBackwardKernelImplInternal<
+              scalar_t,
+              acc_type<scalar_t, true>>(
+              dY, X, mean, rstd, gamma, N, C, HxW, group, dX, dgamma, dbeta);
+        } else {
+          GroupNormBackwardKernelImplInternal<scalar_t, scalar_t>(
+              dY, X, mean, rstd, gamma, N, C, HxW, group, dX, dgamma, dbeta);
+        }
       });
 }
 

--- a/aten/src/ATen/native/group_norm.cpp
+++ b/aten/src/ATen/native/group_norm.cpp
@@ -27,7 +27,7 @@
 
 namespace at::native {
 
-static MemoryFormat group_norm_memory_format(const Tensor& input) {
+MemoryFormat group_norm_memory_format(const Tensor& input) {
   return (input.device().is_cpu() || input.device().is_cuda() ||
           input.device().is_privateuseone())
       ? input.suggest_memory_format()
@@ -157,7 +157,12 @@ std::tuple<Tensor, Tensor, Tensor> native_group_norm_backward(
   }
 
   auto memory_format = group_norm_memory_format(X);
+  // dgamma/dbeta are written with the same param type the kernels read the
+  // stats with, so derive their dtype from the stats rather than from gamma
+  // alone: with gamma undefined and a fp32 beta over a reduced-precision input,
+  // gamma.options() would fall back to X's dtype and disagree.
   auto dparam_options{(gamma.defined() ? gamma.options() : X.options())
+                          .dtype(param_scalar_type(X, mixed_type))
                           .memory_format(MemoryFormat::Contiguous)};
 
   if (!N) {

--- a/aten/src/ATen/native/group_norm.h
+++ b/aten/src/ATen/native/group_norm.h
@@ -1,12 +1,17 @@
 #pragma once
 
 #include <ATen/native/DispatchStub.h>
+#include <c10/core/MemoryFormat.h>
 #include <cstdint>
 
 namespace at {
 class Tensor;
 
 namespace native {
+
+// The memory format group_norm computes in: channels_last is only
+// preserved on backends that have channels_last group norm kernels.
+TORCH_API c10::MemoryFormat group_norm_memory_format(const Tensor& input);
 
 using forward_fn = void (*)(
     const Tensor& /* X */,

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8035,6 +8035,193 @@ class TestNNDeviceType(NNTestCase):
         if self.device_type == 'cuda':
             self._test_InstanceNorm_cuda_half(nn.InstanceNorm3d, input, device)
 
+    @skipMPS  # InstanceNorm3d is not supported on MPS
+    @dtypes(torch.float)
+    @dtypesIfCUDA(torch.float, torch.half)
+    def test_instancenorm_channels_last(self, device, dtype):
+        # channels_last inputs must not be converted to contiguous, see
+        # https://github.com/pytorch/pytorch/issues/59168
+        tol = {torch.float: 1e-5, torch.half: 1e-2}[dtype]
+        # group_norm_memory_format (aten/src/ATen/native/group_norm.cpp) keeps
+        # the layout on every backend except those without channels_last group
+        # norm kernels, so exclude only those rather than allow-listing, letting
+        # a new backend fail loudly here instead of silently skipping the check.
+        preserves_format = self.device_type not in ('mps', 'xpu')
+
+        def helper(cls, shape, memory_format, affine, track_running_stats):
+            mod = cls(shape[1], affine=affine, track_running_stats=track_running_stats).to(device)
+            ref_mod = deepcopy(mod)
+
+            input = torch.randn(shape, device=device, dtype=dtype)
+            input = input.contiguous(memory_format=memory_format).requires_grad_()
+            ref_input = input.detach().clone().contiguous().requires_grad_()
+            grad = torch.randn(shape, device=device, dtype=dtype).contiguous(memory_format=memory_format)
+
+            out = mod(input)
+            out.backward(grad)
+            ref_out = ref_mod(ref_input)
+            ref_out.backward(grad.contiguous())
+
+            if preserves_format and not track_running_stats:
+                self.assertTrue(out.is_contiguous(memory_format=memory_format))
+                self.assertTrue(input.grad.is_contiguous(memory_format=memory_format))
+            self.assertEqual(out, ref_out, atol=tol, rtol=tol)
+            self.assertEqual(input.grad, ref_input.grad, atol=tol, rtol=tol)
+            if affine:
+                self.assertEqual(mod.weight.grad, ref_mod.weight.grad, atol=tol, rtol=tol)
+                self.assertEqual(mod.bias.grad, ref_mod.bias.grad, atol=tol, rtol=tol)
+            if track_running_stats:
+                self.assertEqual(mod.running_mean, ref_mod.running_mean, atol=tol, rtol=tol)
+                self.assertEqual(mod.running_var, ref_mod.running_var, atol=tol, rtol=tol)
+
+        cases = [
+            (nn.InstanceNorm2d, (4, 8, 6, 7), torch.channels_last),
+            (nn.InstanceNorm2d, (4, 1, 6, 7), torch.channels_last),
+            (nn.InstanceNorm3d, (4, 8, 3, 6, 7), torch.channels_last_3d),
+            (nn.InstanceNorm3d, (4, 1, 3, 6, 7), torch.channels_last_3d),
+        ]
+        for (cls, shape, memory_format), affine, track_running_stats in product(cases, [True, False], [True, False]):
+            helper(cls, shape, memory_format, affine, track_running_stats)
+
+    @onlyCUDA
+    @dtypes(torch.half, torch.bfloat16)
+    def test_instancenorm_channels_last_mixed_dtype(self, device, dtype):
+        # Under autocast the nn.InstanceNorm*d affine params stay fp32 while the
+        # input is reduced precision. The channels_last fast path routes through
+        # native_group_norm, whose CUDA kernels must keep the fp32 params and the
+        # fp32 saved mean/rstd and affine grads rather than downcasting them to
+        # the input dtype (https://github.com/pytorch/pytorch/pull/194616).
+        # Assert the stat/param dtypes directly: a differentiable downcast would
+        # still surface an fp32 leaf .grad and hide the regression.
+        N, C, D, H, W = 2, 8, 3, 6, 7
+        x = torch.randn(N, C, D, H, W, device=device, dtype=dtype)
+        x = x.contiguous(memory_format=torch.channels_last_3d).requires_grad_()
+        weight = torch.randn(C, device=device, dtype=torch.float, requires_grad=True)
+        bias = torch.randn(C, device=device, dtype=torch.float, requires_grad=True)
+
+        # native_group_norm with one group per channel is the kernel the fast
+        # path dispatches to; check it keeps fp32 stats over the fp16/bf16 input.
+        out, mean, rstd = torch.native_group_norm(x, weight, bias, N, C, D * H * W, C, 1e-5)
+        self.assertEqual(out.dtype, dtype)
+        self.assertTrue(out.is_contiguous(memory_format=torch.channels_last_3d))
+        self.assertEqual(mean.dtype, torch.float)
+        self.assertEqual(rstd.dtype, torch.float)
+        out.sum().backward()
+        self.assertEqual(weight.grad.dtype, torch.float)
+        self.assertEqual(bias.grad.dtype, torch.float)
+
+        # instance_norm must pass the fp32 params through unchanged (no downcast)
+        # and match the group_norm reference.
+        io = F.instance_norm(x.detach(), None, None, weight.detach(), bias.detach(), True, 0.0, 1e-5)
+        self.assertEqual(io.dtype, dtype)
+        self.assertTrue(io.is_contiguous(memory_format=torch.channels_last_3d))
+        self.assertEqual(io, out, atol=1e-2, rtol=1e-2)
+
+    @dtypes(torch.float)
+    def test_group_norm_channels_last_staged_reduction(self, device, dtype):
+        # Same backend caveat as test_instancenorm_channels_last above.
+        preserves_format = self.device_type not in ('mps', 'xpu')
+        # The channels_last group norm kernels split the spatial reduction over
+        # several blocks and combine the partial results through a staging
+        # buffer, a path only taken once HxW is large. Every other norm test
+        # here uses a small spatial extent and so only covers the single block
+        # case, including the instance norm shapes above.
+        for C, G in ((32, 32), (64, 8)):
+            shape = (2, C, 8, 16, 16)
+            mod = nn.GroupNorm(G, C).to(device=device, dtype=dtype)
+            ref_mod = deepcopy(mod)
+            input = torch.randn(shape, device=device, dtype=dtype)
+            input = input.contiguous(memory_format=torch.channels_last_3d).requires_grad_()
+            ref_input = input.detach().clone().contiguous().requires_grad_()
+            grad = torch.randn(shape, device=device, dtype=dtype)
+
+            out = mod(input)
+            out.backward(grad.contiguous(memory_format=torch.channels_last_3d))
+            ref_out = ref_mod(ref_input)
+            ref_out.backward(grad.contiguous())
+
+            # The two layouts accumulate the reduction in a different order, so
+            # compare against the float32 error of a few thousand element sum
+            # rather than the default tolerance.
+            tol = {"atol": 1e-4, "rtol": 1e-4}
+            if preserves_format:
+                self.assertTrue(out.is_contiguous(memory_format=torch.channels_last_3d))
+            self.assertEqual(out, ref_out, **tol)
+            self.assertEqual(input.grad, ref_input.grad, **tol)
+            self.assertEqual(mod.weight.grad, ref_mod.weight.grad, **tol)
+            self.assertEqual(mod.bias.grad, ref_mod.bias.grad, **tol)
+
+    @onlyCUDA
+    @dtypes(torch.float)
+    def test_group_norm_channels_last_large_batch(self, device, dtype):
+        # The channels_last kernels walk the batch along gridDim.z, which CUDA
+        # caps at 65535, so a larger batch must still launch.
+        tol = {"atol": 1e-4, "rtol": 1e-4}
+        # These cover the batch walk itself. Reaching it together with a split
+        # HxW reduction would take more than 4e9 elements, so the n factors in
+        # the staging and semaphore indices are only checked by inspection.
+        for C, H, W in ((4, 4, 4), (8, 4, 8)):
+            N = 70000
+            mod = nn.GroupNorm(C, C).to(device=device, dtype=dtype)
+            ref_mod = deepcopy(mod)
+            input = torch.randn(N, C, H, W, device=device, dtype=dtype)
+            input = input.contiguous(memory_format=torch.channels_last).requires_grad_()
+            ref_input = input.detach().clone().contiguous().requires_grad_()
+
+            out = mod(input)
+            out.sum().backward()
+            ref_out = ref_mod(ref_input)
+            ref_out.sum().backward()
+
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+            self.assertEqual(out, ref_out, **tol)
+            self.assertEqual(input.grad, ref_input.grad, **tol)
+
+    @onlyCUDA
+    @dtypes(torch.float)
+    def test_group_norm_channels_last_many_channels(self, device, dtype):
+        # The channels_last kernels size their grid from the channel count, so a
+        # channel count past the point where that sizing saturates must still be
+        # covered rather than silently left unwritten.
+        C = 262145
+        x = torch.randn(1, C, 2, 2, device=device, dtype=dtype)
+        x = x.contiguous(memory_format=torch.channels_last)
+        w = torch.ones(C, device=device, dtype=dtype)
+        b = torch.zeros(C, device=device, dtype=dtype)
+
+        # One group per channel exercises the forward reduction. Backward is not
+        # run here: it launches a grid of G blocks in its y extent, which is a
+        # separate pre-existing limit above 65535 groups.
+        with torch.no_grad():
+            out, mean, rstd = torch.native_group_norm(x, w, b, 1, C, 4, C, 1e-5)
+            ref = torch.native_group_norm(x.contiguous(), w, b, 1, C, 4, C, 1e-5)
+        self.assertEqual(mean, ref[1])
+        self.assertEqual(rstd, ref[2])
+        self.assertEqual(out, ref[0])
+
+        # Several channels per group exercises the backward reduction, which
+        # uses the same grid sizing for every group count.
+        G = 5
+        xg = x.detach().clone().requires_grad_()
+        xc = x.detach().clone().contiguous().requires_grad_()
+        F.group_norm(xg, G).sum().backward()
+        F.group_norm(xc, G).sum().backward()
+        self.assertEqual(xg.grad, xc.grad)
+
+    @dtypes(torch.half, torch.bfloat16)
+    def test_group_norm_mixed_dtype_bias_only(self, device, dtype):
+        # dgamma/dbeta take the param dtype the kernels read the stats with, so a
+        # fp32 bias with no weight must not fall back to the input's dtype.
+        C = 8
+        for memory_format in (torch.channels_last, torch.contiguous_format):
+            x = torch.randn(2, C, 6, 7, device=device, dtype=dtype)
+            x = x.contiguous(memory_format=memory_format).requires_grad_()
+            bias = torch.randn(C, device=device, dtype=torch.float, requires_grad=True)
+            out = F.group_norm(x, C, None, bias)
+            out.sum().backward()
+            self.assertEqual(out.dtype, dtype)
+            self.assertEqual(bias.grad.dtype, torch.float)
+
     @parametrize_test("instance_norm_cls", [nn.InstanceNorm1d, nn.InstanceNorm2d, nn.InstanceNorm3d], name_fn=lambda c: c.__name__)
     @parametrize_test("no_batch_dim", [True, False])
     @parametrize_test("affine", [True, False])

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -4821,7 +4821,11 @@ module_db: list[ModuleInfo] = [
                module_inputs_func=partial(module_inputs_torch_nn_InstanceNormNd, N=2),
                train_and_eval_differ=True,
                skips=(
-                   # No channels_last support for InstanceNorm2d currently.
+                   # These module inputs mix track_running_stats True and False, and
+                   # only the False (fast path) ones preserve channels_last, so the
+                   # per-module test_memory_format cannot pass for all of them. The
+                   # layout preservation is covered by
+                   # test_nn.py::test_instancenorm_channels_last instead.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),)
                ),
     ModuleInfo(torch.nn.InstanceNorm3d,
@@ -4834,7 +4838,11 @@ module_db: list[ModuleInfo] = [
                    DecorateInfo(expectedFailureMPS, 'TestModuleMPS', 'test_forward'),
                    DecorateInfo(expectedFailureMPS, 'TestModuleMPS', 'test_non_contiguous'),
                    DecorateInfo(expectedFailureMPS, 'TestModuleMPS', 'test_save_load'),
-                   # No channels_last support for InstanceNorm3d currently.
+                   # These module inputs mix track_running_stats True and False, and
+                   # only the False (fast path) ones preserve channels_last_3d, so the
+                   # per-module test_memory_format cannot pass for all of them. The
+                   # layout preservation is covered by
+                   # test_nn.py::test_instancenorm_channels_last instead.
                    DecorateInfo(unittest.skip("Skipped!"), 'TestModule', 'test_memory_format'),)
                ),
     ModuleInfo(torch.nn.LocalResponseNorm,


### PR DESCRIPTION
Addresses the `InstanceNorm3d` item of #59168. Deliberately not a `Fixes:` — the other items in that issue stay open.

## The layout problem

`instance_norm` folds `N` into `C` and calls `batch_norm` on a `(1, N*C, ...)` view. That view cannot exist for a channels_last tensor: memory ordered `N,D,H,W,C` cannot be reindexed so `N*C` is innermost. The `input.contiguous()` that follows means every `InstanceNorm` in a channels_last model converts its input and returns a contiguous output the next convolution converts back. The cost of this was measured on nnU-Net in https://github.com/pytorch/pytorch/issues/59168#issuecomment-5339628979.

Instance norm is group norm with one group per channel, and `native_group_norm` already has channels_last kernels, so this dispatches there when the input is channels_last and there are no running stats to update — the default for the `nn.InstanceNorm*d` modules. `group_norm_memory_format` is shared out of `group_norm.cpp` so the fast path triggers exactly on the backends whose group norm kernels keep the layout.

## Dispatching alone made it slower

This is the first caller to reach the channels-last group norm kernels with one group per channel. Those kernels parallelize over groups and reduce `HxW` inside a block — fine for group norm's usual `G=32` over many channels, degenerate when `G == C` and so `D == 1`. At the reported shape the moments kernel launched 16 blocks and `ComputeInternalGradientsChannelsLast` launched **4**, the latter sustaining 21.6 GB/s on a card that does 561 GB/s.

The fix is a reduction that keeps `blockDim.x` on the channel axis, so a warp's reads stay contiguous, while `blockDim.y`/`gridDim.y` split `HxW` so the grid stays wide regardless of `C`. Partials are staged in global memory and combined by the last block to arrive. That is the strategy `batch_norm`'s channels-last statistics kernels already use — and the reason the *contiguous* instance norm path is fast today. The generic parts move out of `Normalization.cuh` into a new `channels_last_reduce.cuh` so `group_norm_kernel.cu` can use them without pulling in the batch norm kernels.

Where it is used differs by direction, because the two produce different quantities:

- **Backward** already reduces to per-`(n, c)` sums, so the new kernel replaces both channels-last variants outright; the fallback kernel and the heuristic choosing between them are deleted.
- **Forward** reduces to per-`(n, g)` moments. At `D == 1` those are the same thing, so it writes group statistics directly. At `D > 1` it would have to compute `C` moments and merge down to `G` — redundant work, and measured slower on `2,640,32,32,32` (`D=20`) even before counting the merge pass. So `D > 1` keeps the existing kernels unchanged, and only the `D == 1` arm of the old `(D == 1 || D == 2)` condition moves.

Two alternatives were tried and rejected. An occupancy threshold steering the existing kernels recovered the reported shape but regressed `N=8` by 1.5x and `N=16` by 1.9x, because the two old kernels differ in coalescing as well as grid width and no threshold separates those cases. Using the new reduction for every `D` regressed ordinary GroupNorm forward by up to 26%, for the redundancy above.

## Mixed dtype

The CUDA kernels read affine params and wrote saved stats and `dgamma`/`dbeta` in the input's scalar type, so fp32 params over a reduced-precision input (autocast) were downcast. The CPU kernel already used a separate param type; the same `PT` is now threaded through the CUDA kernels, and `dgamma`/`dbeta` are allocated from that param type rather than from `gamma.options()` — those disagree when `gamma` is undefined and only `beta` is fp32, which previously threw from the kernel on both CUDA and CPU.

## Behaviour change worth flagging

`eps` used to be cast to the input dtype. `1e-5` is below half's smallest normal, so **fp16 GroupNorm was effectively running with a subnormal or zero epsilon**. It is now kept at accumulation precision. That is a fix, but it changes fp16 `GroupNorm` results for existing callers on the *contiguous* path too, not only `InstanceNorm`.

## Numbers

TITAN RTX (sm_75, 72 SMs), measured as CUDA kernel time rather than wall clock, with the contiguous path measured alongside as a control that the two builds are comparable (it matches within 0.5% on every row).

`InstanceNorm3d` at the reported shape `(2, 32, 64, 64, 64)`, channels_last_3d:

| | before | after |
|---|---|---|
| moments | 1.640 ms | 0.171 ms |
| internal gradients | 6.208 ms | 0.241 ms |
| whole layer | 7.393 ms | **1.598 ms** (contiguous: 1.685 ms) |

Ordinary GroupNorm, channels-last, forward+backward:

| shape | before | after |
|---|---|---|
| `(16,256,32,32)` G=32 | 0.449 | 0.450 |
| `(8,512,16,16)` G=32 | 0.163 | 0.131 |
| `(2,128,64,64)` G=32 | 0.220 | 0.133 |
| `(32,64,56,56)` G=32 | 0.661 | 0.642 |
| `(1,320,64,64)` G=32 | 0.276 | 0.187 |
| `(2,128,16,32,32)` G=32 | 0.803 | 0.463 |
| `(4,256,8,32,32)` G=32 | 0.979 | 0.832 |

Forward and backward separately on five further configurations, since a backward win hides a forward regression in the combined number:

| shape | fwd | fwd+bwd |
|---|---|---|
| `8,64,64,56,56` fp16 | 0.0481 → 0.0481 | 0.1847 → 0.1412 |
| `2,640,32,32,32` fp32 | 0.0518 → 0.0518 | 0.1785 → 0.1616 |
| `8,32,8,64,64` fp16 | 0.0284 → 0.0282 | 0.1396 → 0.0918 |
| `8,256,256,28,28` fp16 | 0.0539 → 0.0441 | 0.1469 → 0.1419 |
| `4,128,32,112,112` fp16 | 0.1353 → 0.1352 | 0.6618 → 0.4352 |

**The end-to-end script is not conclusive on this card.** With the norm layer, channels_last_3d goes from +26.5% to +2.4% against contiguous — but the same script with `nn.Identity` in place of the norm still shows +7.7%, because Turing has no NHWC 3D convolution path and cuDNN falls back to `volta_scudnn` NCHW kernels. The norm layer's own contribution moves from roughly +19 points to roughly −5. Re-running that script on Ampere or newer would give the number this actually needs.

## Review order

`channels_last_reduce.cuh` (code motion) → the matching deletions in `Normalization.cuh` → `group_norm_kernel.cu`, where `RowwiseMomentsChannelsLastUnitDCUDAKernel` and `ComputeInternalGradientsChannelsLastCUDAKernel` are the new reductions and the rest is `PT` threading → `Normalization.cpp` with `group_norm.{cpp,h}` → tests.

## Testing

```
python test/test_nn.py -k instancenorm
python test/test_nn.py -k InstanceNorm
python test/test_nn.py -k GroupNorm
python test/test_nn.py -k group_norm
python test/test_modules.py -k InstanceNorm
python test/test_modules.py -k GroupNorm
python test/test_ops.py -k native_group_norm
```

The pre-existing norm tests all reduce a small `HxW`, which keeps the new kernels on their single-block path, so four tests cover what they miss:

- `test_group_norm_channels_last_staged_reduction` — an `HxW` large enough to split the reduction across blocks and exercise the staging and semaphore combine.
- `test_group_norm_channels_last_large_batch` — `N` above 65535, the `gridDim.z` limit the kernels walk the batch to stay under.
- `test_group_norm_channels_last_many_channels` — a channel count past the point the launch sizing saturates.
- `test_group_norm_mixed_dtype_bias_only` — a fp32 bias with no weight.

## Known limits

- **ROCm is untested.** This uses `__threadfence()` where `batch_norm`'s channels-last kernels deliberately use committed stores instead; correct but possibly slower there.
- Measured on sm_75 only.
- A **dynamic channel count** (`torch.compile(dynamic=True)`, `mark_dynamic` on the channel dim, or export) keeps the batch_norm path and so returns a contiguous output where eager returns channels_last. The comment at the guard records this. Specializing instead would trade the layout difference for a guard on a dimension that is almost always static.
- Routing channels_last instance norm through group norm means argument checking is group norm's, so a few malformed calls report a different message than the contiguous path does, and a degenerate `HxW == 1` lands within rounding of zero rather than exactly zero.

---

Authored with the assistance of Claude Code. The CUDA here deserves close reading rather than trust.
