### PR TITLE
Fix Windows py3.15 builds: constrain Cython < 3.3.0 and bump the cp315 numpy pin

### DIFF
--- a/.ci/pytorch/windows/build_install_deps.py
+++ b/.ci/pytorch/windows/build_install_deps.py
@@ -106,35 +106,10 @@ def install_libuv(workdir: Path, python_prefix: Path) -> Path:
 
 
 def preinstall_cp315_build_deps() -> list[str]:
-    """Pin Cython for the cp315 sdist builds and return the pip flags to use.
-
-    Cython 3.3.0 (released 2026-08-22 05:16 UTC) crashes with
-    STATUS_ACCESS_VIOLATION (0xC0000005, decimal 3221225477) under the
-    GIL-enabled CPython 3.15 build on Windows, so every package pip has to
-    build from an sdist dies in its PEP 517 hook. meson projects surface it as
-    the misleading "Unknown compiler(s): [['cython'], ['cython3']]"; setuptools
-    ones just exit 3221225477 with no output at all.
-
-    The Windows nightly passed on 2026-08-21 and has failed every run since
-    2026-08-22, the first after that release, with no PyTorch-side change and
-    no setuptools/wheel/packaging release in the window. cp315t is unaffected,
-    so the crash is specific to the GIL-enabled build.
-
-    PIP_CONSTRAINT does not work here: pip does not apply it to the isolated
-    build environments, which is where the crashing Cython is installed. That
-    was verified directly with pip 26.2.1 -- building pyyaml from its sdist
-    installs Cython 3.3.0 into the build env whether or not PIP_CONSTRAINT
-    pins it lower. So instead pin Cython in the outer environment and turn
-    build isolation off, which makes sdist builds use the pinned copy.
-
-    Remove once Cython ships a fix.
-    """
+    """Pin Cython < 3.3.0 for cp315 sdist builds. See pytorch/pytorch#194618."""
     if sys.version_info[:2] != (3, 15):
         return []
-    # setuptools/wheel must be present too: without isolation pip will not
-    # provide them to the sdist builds.
     pip_install("-q", "cython<3.3.0", "setuptools", "wheel")
-    print("Pinned cython<3.3.0 for cp315 sdist builds; disabling build isolation")
     return ["--no-build-isolation"]
 
 

--- a/.ci/pytorch/windows/build_install_deps.py
+++ b/.ci/pytorch/windows/build_install_deps.py
@@ -31,7 +31,7 @@ from _common import download, write_env_exports
 
 # Pin numpy by Python version. Matches the legacy table in setup_build.bat.
 NUMPY_PINS: list[tuple[str, str]] = [
-    ("cp315", "2.5.1"),
+    ("cp315", "2.5.2"),
     ("cp314", "2.3.2"),
     ("cp313", "2.1.2"),
 ]
@@ -105,42 +105,11 @@ def install_libuv(workdir: Path, python_prefix: Path) -> Path:
     return libuv_root
 
 
-def provide_stdalign_shim() -> None:
-    """Work around a missing C11 <stdalign.h> for the cp315 numpy source build.
-
-    numpy has no cp315 wheel on any index, so it is built from source, and
-    numpy/_core/src/common/simd/simd.h includes <stdalign.h>. The Windows CI
-    UCRT (Windows SDK 10.0.19041) predates that header (added ~10.0.20348), so
-    MSVC fails with "C1083: Cannot open include file: 'stdalign.h'". Drop a
-    minimal C11-compliant shim on INCLUDE for the cp315-only source build; in C,
-    alignas/alignof are macros for the _Alignas/_Alignof operators. Remove once
-    numpy ships cp315 Windows wheels or the runner SDK is >= 10.0.20348.
-    """
-    if sys.version_info[:2] != (3, 15):
-        return
-    shim_dir = WIN_CI_DIR / "stdalign_shim"
-    shim_dir.mkdir(exist_ok=True)
-    (shim_dir / "stdalign.h").write_text(
-        "#ifndef _STDALIGN_H\n"
-        "#define _STDALIGN_H\n"
-        "#ifndef __cplusplus\n"
-        "#define alignas _Alignas\n"
-        "#define alignof _Alignof\n"
-        "#endif\n"
-        "#define __alignas_is_defined 1\n"
-        "#define __alignof_is_defined 1\n"
-        "#endif\n"
-    )
-    os.environ["INCLUDE"] = f"{shim_dir}{os.pathsep}{os.environ.get('INCLUDE', '')}"
-    print(f"Added <stdalign.h> shim for cp315 numpy source build: {shim_dir}")
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--env-out", type=Path)
     args = parser.parse_args()
 
-    provide_stdalign_shim()
     pip_install("-q", f"numpy=={numpy_pin()}")
     pip_install("-q", *PIP_PACKAGES)
 

--- a/.ci/pytorch/windows/build_install_deps.py
+++ b/.ci/pytorch/windows/build_install_deps.py
@@ -105,38 +105,37 @@ def install_libuv(workdir: Path, python_prefix: Path) -> Path:
     return libuv_root
 
 
-def constrain_cython_for_cp315() -> None:
-    """Hold Cython below 3.3.0 for the cp315 Windows builds.
+def preinstall_cp315_build_deps() -> list[str]:
+    """Pin Cython for the cp315 sdist builds and return the pip flags to use.
 
-    Cython 3.3.0 (released 2026-08-22) crashes with STATUS_ACCESS_VIOLATION
-    (0xC0000005) when merely asked for its version under the GIL-enabled
-    CPython 3.15 build on Windows, so any package pip has to build from an
-    sdist dies in its PEP 517 hook. meson-backed projects report this as the
-    misleading "Unknown compiler(s): [['cython'], ['cython3']]"; setuptools
-    ones just exit 3221225477 with no output.
+    Cython 3.3.0 (released 2026-08-22 05:16 UTC) crashes with
+    STATUS_ACCESS_VIOLATION (0xC0000005, decimal 3221225477) under the
+    GIL-enabled CPython 3.15 build on Windows, so every package pip has to
+    build from an sdist dies in its PEP 517 hook. meson projects surface it as
+    the misleading "Unknown compiler(s): [['cython'], ['cython3']]"; setuptools
+    ones just exit 3221225477 with no output at all.
 
-    The Windows nightly went red on 2026-08-22, the first run after that
-    release, having passed on 2026-08-21 with Cython 3.2.9. The freethreaded
-    cp315t builds are unaffected, so this is specific to the GIL-enabled 3.15
-    build; the condition still covers both, because 3.15t gains nothing from
-    3.3.0 and one version check is easier to delete later.
+    The Windows nightly passed on 2026-08-21 and has failed every run since
+    2026-08-22, the first after that release, with no PyTorch-side change and
+    no setuptools/wheel/packaging release in the window. cp315t is unaffected,
+    so the crash is specific to the GIL-enabled build.
 
-    PIP_CONSTRAINT is used rather than installing Cython here because pip
-    propagates it into the isolated build environments where the crashing
-    Cython actually gets installed. Remove once Cython ships a fix.
+    PIP_CONSTRAINT does not work here: pip does not apply it to the isolated
+    build environments, which is where the crashing Cython is installed. That
+    was verified directly with pip 26.2.1 -- building pyyaml from its sdist
+    installs Cython 3.3.0 into the build env whether or not PIP_CONSTRAINT
+    pins it lower. So instead pin Cython in the outer environment and turn
+    build isolation off, which makes sdist builds use the pinned copy.
+
+    Remove once Cython ships a fix.
     """
     if sys.version_info[:2] != (3, 15):
-        return
-    if os.environ.get("PIP_CONSTRAINT"):
-        print(
-            "PIP_CONSTRAINT already set, not overriding; "
-            "cp315 builds may pick up the crashing Cython 3.3.0"
-        )
-        return
-    constraints = WIN_CI_DIR / "cp315-constraints.txt"
-    constraints.write_text("cython<3.3.0\n")
-    os.environ["PIP_CONSTRAINT"] = str(constraints)
-    print(f"Constrained Cython for cp315 source builds: {constraints}")
+        return []
+    # setuptools/wheel must be present too: without isolation pip will not
+    # provide them to the sdist builds.
+    pip_install("-q", "cython<3.3.0", "setuptools", "wheel")
+    print("Pinned cython<3.3.0 for cp315 sdist builds; disabling build isolation")
+    return ["--no-build-isolation"]
 
 
 def main() -> None:
@@ -144,9 +143,9 @@ def main() -> None:
     parser.add_argument("--env-out", type=Path)
     args = parser.parse_args()
 
-    constrain_cython_for_cp315()
-    pip_install("-q", f"numpy=={numpy_pin()}")
-    pip_install("-q", *PIP_PACKAGES)
+    build_flags = preinstall_cp315_build_deps()
+    pip_install("-q", *build_flags, f"numpy=={numpy_pin()}")
+    pip_install("-q", *build_flags, *PIP_PACKAGES)
 
     if not os.environ.get("SKIP_SETUP_CLEAN"):
         subprocess.run(

--- a/.ci/pytorch/windows/build_install_deps.py
+++ b/.ci/pytorch/windows/build_install_deps.py
@@ -105,11 +105,46 @@ def install_libuv(workdir: Path, python_prefix: Path) -> Path:
     return libuv_root
 
 
+def constrain_cython_for_cp315() -> None:
+    """Hold Cython below 3.3.0 for the cp315 Windows builds.
+
+    Cython 3.3.0 (released 2026-08-22) crashes with STATUS_ACCESS_VIOLATION
+    (0xC0000005) when merely asked for its version under the GIL-enabled
+    CPython 3.15 build on Windows, so any package pip has to build from an
+    sdist dies in its PEP 517 hook. meson-backed projects report this as the
+    misleading "Unknown compiler(s): [['cython'], ['cython3']]"; setuptools
+    ones just exit 3221225477 with no output.
+
+    The Windows nightly went red on 2026-08-22, the first run after that
+    release, having passed on 2026-08-21 with Cython 3.2.9. The freethreaded
+    cp315t builds are unaffected, so this is specific to the GIL-enabled 3.15
+    build; the condition still covers both, because 3.15t gains nothing from
+    3.3.0 and one version check is easier to delete later.
+
+    PIP_CONSTRAINT is used rather than installing Cython here because pip
+    propagates it into the isolated build environments where the crashing
+    Cython actually gets installed. Remove once Cython ships a fix.
+    """
+    if sys.version_info[:2] != (3, 15):
+        return
+    if os.environ.get("PIP_CONSTRAINT"):
+        print(
+            "PIP_CONSTRAINT already set, not overriding; "
+            "cp315 builds may pick up the crashing Cython 3.3.0"
+        )
+        return
+    constraints = WIN_CI_DIR / "cp315-constraints.txt"
+    constraints.write_text("cython<3.3.0\n")
+    os.environ["PIP_CONSTRAINT"] = str(constraints)
+    print(f"Constrained Cython for cp315 source builds: {constraints}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--env-out", type=Path)
     args = parser.parse_args()
 
+    constrain_cython_for_cp315()
     pip_install("-q", f"numpy=={numpy_pin()}")
     pip_install("-q", *PIP_PACKAGES)
 


### PR DESCRIPTION
Fixes all five Windows `py3_15` binary builds.

## Root cause: Cython 3.3.0

**Cython 3.3.0 was released 2026-08-22 05:16 UTC.** It crashes with `STATUS_ACCESS_VIOLATION` (`0xC0000005`, decimal `3221225477`) under the **GIL-enabled** CPython 3.15 build on Windows, so every package pip has to build from an sdist dies in its PEP 517 hook.

The nightly history matches exactly:

| Nightly | py3.15 | py3.15t |
|---|---|---|
| 08-20 | ✅ | ✅ |
| 08-21 | ✅ | ✅ |
| **08-22** (first run after the release) | ❌ | ✅ |
| 08-23 | ❌ | ✅ |
| 08-24 | ❌ | ✅ |

Nothing changed on the PyTorch side. The 08-21 passing log and the 08-24 failing log both use `python-3.15.0b3-amd64.exe`, pip 26.2.1 and setuptools 84.0.0, and there was **no setuptools/wheel/packaging release** in the window — Cython is the only build-time dependency that moved. py3.15**t** passes throughout, which pins the crash to the GIL-enabled build.

The error is easy to misread. meson projects report it as `Unknown compiler(s): [['cython'], ['cython3']]`, which looks like Cython is missing; meson's own detection output shows `cython -V -> 3221225477`. setuptools projects are quieter still: `exit code: 3221225477` with `[0 lines of output]`.

## The fix

**1. Pin `cython<3.3.0` in the outer env and pass `--no-build-isolation` for cp315.**

An earlier revision of this PR used `PIP_CONSTRAINT`. **That does not work**, and CI proved it — the constraint printed, and pyyaml still crashed. pip does not apply `PIP_CONSTRAINT` to its isolated build environments, which is exactly where the crashing Cython gets installed. Verified directly with pip 26.2.1, building pyyaml from its sdist:

```
no constraint                -> Successfully installed Cython-3.3.0 setuptools-84.0.0
PIP_CONSTRAINT=cython<3.3.0  -> Successfully installed Cython-3.3.0 setuptools-84.0.0
```

Identical. So the pin now goes in the outer environment (along with `setuptools` and `wheel`, which pip would otherwise have supplied to the isolated env itself) and isolation is turned off so sdist builds use it.

**2. Bump the cp315 numpy pin 2.5.1 → 2.5.2.** 2.5.1 has no cp315 Windows wheel and so was built from source; 2.5.2 ships `cp315-cp315` and `cp315-cp315t` win_amd64 wheels. Worth keeping regardless — avoiding a source build is faster and removes one exposure.

**3. Remove `provide_stdalign_shim()`.** It existed only for the cp315 numpy source build, and its docstring set exactly this exit condition: *"Remove once numpy ships cp315 Windows wheels or the runner SDK is >= 10.0.20348."*

## Why the numpy bump alone was not enough

CI confirmed it: with numpy resolving to a wheel, `pyyaml` failed next with the identical `3221225477`. PyYAML has **never** shipped a cp315 wheel (checked every release; 6.0.3 added cp314 and stops), and its `pyproject.toml` requires `Cython>=3.0` for py≥3.13, so it lands 3.3.0 in its build env. Pinning per package would be endless; pinning Cython covers numpy, pyyaml and anything else in `PIP_PACKAGES`.

## Test plan

Verified locally with pip 26.2.1:

```
pip install 'cython<3.3.0' setuptools wheel
pip install --no-cache-dir --no-build-isolation --no-binary=:all: pyyaml
# -> builds against Cython 3.2.9, no 3.3.0 fetched, PyYAML 6.0.3 installed
```

- `--no-build-isolation` is a no-op for the packages that resolve to wheels — confirmed for numpy 2.5.2, cmake, ninja, requests, typing_extensions.
- PyPI checks: Cython 3.3.0 uploaded 2026-08-22 05:16 (prior release 3.2.9 on 07-24); numpy 2.5.2 is the first release with a cp315 win_amd64 wheel; no PyYAML release has one; no setuptools/wheel/packaging release since 08-15.
- `ruff check` clean.

Windows confirmation needs a `ciflow/binaries` run on this PR.

## Risk

`--no-build-isolation` is scoped to cp315 only, but within that it applies to every install in `build_install_deps.py`. Any sdist build whose build requirements are not pre-installed will now fail loudly rather than silently provisioning them. Today only pyyaml builds from source on cp315, and `setuptools`/`wheel`/`cython` cover it — but that is the behaviour change to watch in the ciflow run.

## Upstream

The Cython crash is a genuine upstream bug affecting anyone doing a source build on Windows + CPython 3.15 (GIL-enabled). This routes around it and deserves a Cython report if one isn't already open.
