### PR TITLE
[Elastic] Fix mkstemp file descriptor leak in FileStore rendezvous

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,18 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    def test_create_backend_closes_mkstemp_fd(
+        self, tempfile_mock, close_mock
+    ) -> None:
+        fake_fd = 999
+        _, real_path = tempfile.mkstemp()
+        self.addCleanup(os.remove, real_path)
+        tempfile_mock.return_value = (fake_fd, real_path)
+
+        self._params_filestore.endpoint = ""
+        create_backend(self._params_filestore)
+
+        close_mock.assert_called_once_with(fake_fd)

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,8 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
[Elastic] Fix mkstemp file descriptor leak in FileStore rendezvous

Fixes #191394

### Root Cause
In `torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py`, `_create_file_store()` calls `tempfile.mkstemp()` when no endpoint is supplied. `tempfile.mkstemp()` opens the temporary file and returns a tuple `(fd, path)`. The function discards `fd`, leaving an open OS file descriptor leaked by the Python process.

### Fix
Captured the file descriptor returned by `tempfile.mkstemp()` and immediately closed it with `os.close(fd)` after retrieving the file path. `FileStore` opens the file path independently.

### Test Plan
Added `test_create_backend_closes_mkstemp_fd` in `test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py` which mocks `tempfile.mkstemp()` and asserts `os.close(fd)` is called with the exact file descriptor.
