### PR TITLE
Fix grammar in comments and docstrings

### DIFF
--- a/torch/_dynamo/backends/common.py
+++ b/torch/_dynamo/backends/common.py
@@ -108,7 +108,7 @@ class AotAutograd:
                 # Note [Wrapping bw_compiler in disable]
                 # The two disables here:
                 # - stop TorchDynamo from trying to compile the bw_compiler function itself
-                # - stop TorchDynamo from trying to compile our the generated backwards pass bw_compiler produces
+                # - stop TorchDynamo from trying to compile the generated backwards pass bw_compiler produces
 
                 return disable(
                     disable(

--- a/torch/_dynamo/backends/debugging.py
+++ b/torch/_dynamo/backends/debugging.py
@@ -481,8 +481,8 @@ register_backend(
 )
 
 
-# aot_eager_decomp_partition_with_mode is similar as aot_eager_decomp_partition,
-# except that it takes a TorchDispatchMode mode and run the fw/bw in the mode
+# aot_eager_decomp_partition_with_mode is similar to aot_eager_decomp_partition,
+# except that it takes a TorchDispatchMode mode and runs the fw/bw in the mode
 def aot_eager_decomp_partition_with_mode(
     gm: torch.fx.GraphModule,
     fake_tensor_inputs: list[torch.Tensor],

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -992,7 +992,7 @@ def substitute_in_graph(
                 f"already handled by {polyfill_handlers[original_fn]}"
             )
 
-        # Need to wrap the function because we may cannot assign __torch_dynamo_polyfill__ to a
+        # Need to wrap the function because we may not be able to assign __torch_dynamo_polyfill__ to a
         # C++ function.
         @functools.wraps(traceable_fn)
         def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -180,7 +180,7 @@ class ContextWrappingVariable(VariableTracker):
 
 
 class GenericContextWrappingVariable(UserDefinedObjectVariable):
-    # Some methods in ContextWrappingVariable assumes the arguments are
+    # Some methods in ContextWrappingVariable assume the arguments are
     # python constants. Which might not always be the case here.
     def __init__(self, cm_obj: AbstractContextManager[Any], **kwargs: Any) -> None:
         if cm_obj is None:

--- a/torch/_dynamo/variables/nn_module.py
+++ b/torch/_dynamo/variables/nn_module.py
@@ -171,7 +171,7 @@ def guard_to_detect_forward_monkeypatching(
 ) -> None:
     # Users sometimes patch the forward method of a nn module instance to
     # perform optimizations like quantization. Though this is not a good
-    # software practice, but python allows this and Dynamo needs to detect
+    # software practice, python allows this and Dynamo needs to detect
     # this patching.
     #
     # One way to do this is to add an ID_MATCH guard on every function
@@ -587,7 +587,7 @@ class NNModuleVariable(VariableTracker):
                 if nnmodule_has_hooks(mod):
                     # We do not want to unroll sequential if it has hooks, since evaporating it
                     # will cause hooks to not fire!
-                    # This terminates and restart the tracing process
+                    # This terminates and restarts the tracing process
                     self.convert_to_unspecialized(tx)
 
                 # Unroll sequential

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1389,7 +1389,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
             # graph break on any contextlib.* that it is not contextlib.contextmanager
             # Some of the APIs below are not supported because they rely on features
-            # that Dynamo doesn't play well today (i.e. contextlib.suppress)
+            # that Dynamo doesn't play well with today (i.e. contextlib.suppress)
             if self.value in (
                 contextlib._AsyncGeneratorContextManager,
                 contextlib.closing,
@@ -2235,7 +2235,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        # Mirror's CPython variant of vectorcall_method.
+        # Mirrors CPython variant of vectorcall_method.
         # NOTE: Dynamo does not IMPLEMENT the vectorcall protocol, but we keep
         # the name for consistency with CPython's typeobject.c
         m = self._lookup_method(tx, name)
@@ -2247,7 +2247,7 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         name: str,
         args: list[VariableTracker],
     ) -> VariableTracker | None:
-        # Mirror's CPython variants of maybe_call_special_no_args and maybe_call_special_one_arg
+        # Mirrors CPython variants of maybe_call_special_no_args and maybe_call_special_one_arg
         m = self._maybe_lookup_method(tx, name)
         if m is None:
             return None
@@ -4857,7 +4857,7 @@ class DefaultDictVariable(UserDefinedDictVariable):
     ) -> VariableTracker:
         # ref: https://github.com/python/cpython/blob/v3.13.0/Modules/_collectionsmodule.c#L2356-L2395
         # The C impl uses a naming convention of left/right for the two operands
-        # and swap self/other depending on some conditions. For simplicity, we
+        # and swaps self/other depending on some conditions. For simplicity, we
         # will suffix the var names with "_"
 
         # new_defdict(self, left) calls type(self)(self.default_factory, left),

--- a/torch/_inductor/fx_passes/bucketing.py
+++ b/torch/_inductor/fx_passes/bucketing.py
@@ -683,7 +683,7 @@ def bucket_all_gather_by_mb(
         gm (torch.fx.GraphModule): GraphModule where to bucket all_gathers.
         bucket_cap_mb_by_bucket_idx (Callable[[int], float]): Callable to specify cap of the bucket
             in megabytes by bucket idx.  The idea of `bucket_cap_mb_by_bucket_idx` is to allow
-            to specify different sizes of the buckets at the start,
+            specifying different sizes of the buckets at the start,
             as first all_gather is usually exposed.  Interface of bucket_cap_mb_by_bucket_idx
             is `bucket_cap_mb_by_bucket_idx_default` function that is default value for `bucket_cap_mb_by_bucket_idx`.
         filter_wait_node (Callable[[torch.fx.Node], bool] | None): If specified,
@@ -721,7 +721,7 @@ def bucket_reduce_scatter_by_mb(
         gm (torch.fx.GraphModule): GraphModule where to bucket reduce_scatters.
         bucket_cap_mb_by_bucket_idx (Callable[[int], float]): Callable to specify cap of the bucket
             in megabytes by bucket idx.  The idea of `bucket_cap_mb_by_bucket_idx` is to allow
-            to specify different sizes of the buckets.
+            specifying different sizes of the buckets.
         filter_wait_node (Callable[[torch.fx.Node], bool] | None): If specified,
             only reduce_scatter nodes with wait_node that satisfy `filter_wait_node` will be bucketed.
 

--- a/torch/_inductor/fx_passes/mkldnn_fusion.py
+++ b/torch/_inductor/fx_passes/mkldnn_fusion.py
@@ -187,7 +187,7 @@ if torch._C._has_mkldnn:
     def _is_valid_grouped_gemm_fusion(computation_nodes):
         """
         Here we check:
-        1. More than 1 GEMM nodes has been found.
+        1. More than 1 GEMM nodes have been found.
         2. All the GEMM nodes share the same activation.
         3. All the GEMM nodes have same weight size but different wgt node.
         """

--- a/torch/_inductor/wrapper_benchmark.py
+++ b/torch/_inductor/wrapper_benchmark.py
@@ -31,7 +31,7 @@ _kernel_category_choices = [
 def get_kernel_category_by_source_code(src_code: str) -> str:
     """
     Similar to get_kernel_category but use the source code. Call this API
-    if we have not compile the src_code to module yet.
+    if we have not compiled the src_code to module yet.
     """
     choices = [
         ch for ch in _kernel_category_choices if f"@triton_heuristics.{ch}" in src_code

--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -520,7 +520,7 @@ struct GenericViewFunc : public ViewFunc {
         aliased_input_idx_val_(aliased_input_idx_val),
         op_(op) {
     // This should report saved Tensors and SymInts.
-    // We already have an assert that ensure there are no Tensors here
+    // We already have an assert that ensures there are no Tensors here
     // by making sure there is only one Tensor input.
     // We also verify there are no SymInt here for now.
     // Both can be lifted if the visit and clone logic get updated.

--- a/torch/csrc/autograd/forward_grad.h
+++ b/torch/csrc/autograd/forward_grad.h
@@ -44,7 +44,7 @@ struct ForwardGrad;
 // and to un-register itself from this same level if that tangent is removed via
 // ForwardGrad::reset. The ForwardADLevel is created when a new level is entered
 // via ForwardADLevel::get_next_idx. A reference to the new ForwardADLevel is
-// stored into a global (for the whole process) vector that ensure it can be
+// stored into a global (for the whole process) vector that ensures it can be
 // accessed via ForwardADLevel::get_by_idx. This reference is deleted when the
 // index is released by the user when calling ForwardADLevel::release_idx. When
 // it is destructed, the ForwardADLevel is responsible for clearing all the

--- a/torch/csrc/autograd/python_cpp_function.cpp
+++ b/torch/csrc/autograd/python_cpp_function.cpp
@@ -33,7 +33,7 @@ int traverse_node(
   }
   auto& fn = *fn_ptr;
   // The fields traversed below are owned by the cpp grad_fn, which we own a
-  // reference to. We should only them traverse however if we are the only
+  // reference to. We should only traverse them however if we are the only
   // owner of the grad_fn, otherwise we risk prematurely gc'ing the grad_fn.
   //
   // See: https://github.com/pytorch/pytorch/issues/102174

--- a/torch/csrc/jit/backends/backend_detail.cpp
+++ b/torch/csrc/jit/backends/backend_detail.cpp
@@ -197,7 +197,7 @@ Module codegen_backend_module(
   // Whereas this information is not serialized as part of the lowered
   // module, we still need to provide a valid instance of the
   // BackendDebugInfo class when the lowered module is deserialized.
-  // Since the deserialized modules does not need this information,
+  // Since the deserialized modules do not need this information,
   // we create a "dummy" instance with no extra code dependencies (to avoid
   // overhead) when the backend is created in __setstate__.
   c10::intrusive_ptr<torch::CustomClassHolder> backend_debug_info_class;

--- a/torch/csrc/lazy/core/multi_wait.h
+++ b/torch/csrc/lazy/core/multi_wait.h
@@ -41,7 +41,7 @@ class TORCH_API MultiWait {
   // the whole lifetime of the returned function.
   std::function<void()> Completer(std::function<void()> func);
 
-  // Similar as the above API, but with explicit capture of the MultiWait shared
+  // Similar to the above API, but with explicit capture of the MultiWait shared
   // pointer.
   static std::function<void()> Completer(
       std::shared_ptr<MultiWait> mwait,

--- a/torch/headeronly/util/complex.h
+++ b/torch/headeronly/util/complex.h
@@ -161,7 +161,7 @@ struct alignas(sizeof(T) * 2) complex {
   template <typename U>
   explicit C10_HOST_DEVICE complex(const thrust::complex<U>& other)
       : real_(other.real()), imag_(other.imag()) {}
-// NOTE can not be implemented as follow due to ROCm bug:
+// NOTE can not be implemented as follows due to ROCm bug:
 //   explicit C10_HOST_DEVICE complex(const thrust::complex<U> &other):
 //   complex(other.real(), other.imag()) {}
 #endif

--- a/torch/nn/modules/upsampling.py
+++ b/torch/nn/modules/upsampling.py
@@ -113,7 +113,7 @@ class Upsample(Module):
 
         >>> # xdoctest: +IGNORE_WANT("seems to fail when other tests are run in the same session")
         >>> m = nn.Upsample(scale_factor=2, mode='bilinear')  # align_corners=False
-        >>> # Notice that values in top left corner are the same with the small input (except at boundary)
+        >>> # Notice that values in top left corner are the same as the small input (except at boundary)
         >>> m(input_3x3)
         tensor([[[[1.0000, 1.2500, 1.7500, 1.5000, 0.5000, 0.0000],
                   [1.5000, 1.7500, 2.2500, 1.8750, 0.6250, 0.0000],


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Sweep of grammar and typo fixes in comments, docstrings, and doctest
annotations across Dynamo, Inductor, autograd, JIT backends, lazy core,
headeronly complex, and nn.Upsample. Fixes subject-verb agreement,
missing words, misplaced words, and stray possessive apostrophes
("Mirror's" -> "Mirrors", "similar as" -> "similar to").

No functional changes: every edit is inside a comment, docstring, or a
doctest comment line. Behavior, APIs, and generated code are untouched.

Test Plan: comment-only change, so no runtime behavior to exercise. Verified
nothing outside comments changed and that lint passes:

```
git diff -U0 | grep '^[+-]' | grep -vE '^(\+\+\+|---)'
lintrunner -a
```

Authored with the assistance of an AI coding agent (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98