### PR TITLE
reland support min, max in maybe mark dynamic (#194091) (#194625)

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -46,6 +46,7 @@ from torch import Tensor
 from torch._C import FileCheck
 from torch._dynamo import allow_in_graph
 from torch._dynamo.comptime import comptime
+from torch._dynamo.decorators import _DimRange
 from torch._dynamo.eval_frame import _debug_get_cache_entry_list
 from torch._dynamo.exc import Unsupported
 from torch._dynamo.source import ConstantSource, GetItemSource, LocalSource
@@ -108,6 +109,7 @@ from torch.testing._internal.common_utils import (
     wrapDeterministicFlagAPITest,
 )
 from torch.testing._internal.jit_utils import JitTestCase
+from torch.utils._sympy.numbers import int_oo
 
 
 pytree_modules = {
@@ -10996,6 +10998,21 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         res = f(torch.tensor([20, 21]))
         self.assertEqual(torch.tensor(True), res)
 
+    def _range_recording_backend(self, compiled_ranges):
+        """Records the range of the single dynamic dim of each compiled graph."""
+
+        def backend(gm, example_inputs):
+            symints = [arg for arg in example_inputs if isinstance(arg, torch.SymInt)]
+            if not symints:
+                compiled_ranges.append("static")
+                return gm.forward
+            (symint,) = symints
+            vr = symint.node.shape_env.var_to_range[symint.node.expr]
+            compiled_ranges.append((vr.lower, vr.upper))
+            return gm.forward
+
+        return backend
+
     # Translation validation changes the exception type, don't run with it
     @torch.fx.experimental._config.patch(translation_validation=False)
     def test_mark_dynamic_with_ranges(self):
@@ -11009,6 +11026,387 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         torch._dynamo.mark_dynamic(y, 0, min=2, max=5)
         with self.assertRaises(ConstraintViolationError):
             torch.compile(my_dyn_fn, backend="eager")(y)
+
+    def test_maybe_mark_dynamic_with_ranges(self):
+        compiled_ranges = []
+
+        def fn(x):
+            if x.shape[0] == 3:
+                return x.sin()
+            return x.cos() * x.shape[0]
+
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+
+        # min/max do not prevent specialization, the shape[0] == 3 branch
+        # specializes the dim instead of raising a constraint violation.
+        x = torch.randn(3)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static"])
+
+        # The user provided range is used for the dynamic dim.
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static", (2, 5)])
+
+        # 5 is within [2, 5], the graph above is reused.
+        x = torch.randn(5)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static", (2, 5)])
+
+        # 6 is outside [2, 5] and unmarked, recompile with automatic dynamic.
+        x = torch.randn(6)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static", (2, 5), (2, int_oo)])
+
+        # A different range is a different request, it recompiles even though the
+        # size fits the graphs compiled above.
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=3, max=5)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static", (2, 5), (2, int_oo), (3, 5)])
+
+        # Declaring the same range again reuses the graph compiled for it.
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=3, max=5)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static", (2, 5), (2, int_oo), (3, 5)])
+
+        # Re-marking the same tensor object also recompiles. The guard holds a snapshot
+        # of the declared ranges, so mutating the tensor it was compiled with cannot make
+        # the stale graph look like a match.
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=3, max=4)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(
+            compiled_ranges, ["static", (2, 5), (2, int_oo), (3, 5), (3, 4)]
+        )
+
+    # Translation validation changes the exception type, don't run with it: the
+    # constraint violation is raised by create_symbol, nested inside the recorded
+    # top level _create_symbolic_sizes_strides_storage_offset event. recording.py pops
+    # that failed event from the log while the mutations it already made to the
+    # ShapeEnv stay, so the replayed ShapeEnv differs and NotEqualError surfaces.
+    @torch.fx.experimental._config.patch(translation_validation=False)
+    def test_maybe_mark_dynamic_range_narrow_and_extend(self):
+        compiled_ranges = []
+
+        def fn(x):
+            if x.shape[0] < 5:
+                return x.sin()
+            return x.cos() * x.shape[0]
+
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+
+        # Guards may narrow the requested range, [2, 5] becomes [2, 4].
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(2, 4)])
+
+        # The range is never extended to fit the input, a hint outside of it is an
+        # error even though a graph compiled for a wider range is cached.
+        x = torch.randn(6)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        with self.assertRaisesRegex(
+            ConstraintViolationError, r"6 not in range \[2, 5\]"
+        ):
+            opt_fn(x)
+
+    def test_maybe_mark_dynamic_half_open_range_small_hint(self):
+        compiled_ranges = []
+
+        def fn(x):
+            return x.cos() * x.shape[0]
+
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+
+        # A half open range must not imply a lower bound the user never declared: a size
+        # 1 input satisfies max=8 and specializes, which this API allows, rather than
+        # raising "1 not in range [2, 8]".
+        x = torch.randn(1)
+        torch._dynamo.maybe_mark_dynamic(x, 0, max=8)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static"])
+
+        # For a hint that does not specialize, the shape env still narrows the lower
+        # bound to 2 on its own, since 0 and 1 are specialized for backed sizes.
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, max=8)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, ["static", (2, 8)])
+
+    # Translation validation changes the exception type, don't run with it
+    @torch.fx.experimental._config.patch(translation_validation=False)
+    def test_mark_dynamic_half_open_range_small_hint(self):
+        compiled_ranges = []
+
+        def fn(x):
+            return x.cos() * x.shape[0]
+
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+
+        # Same rule as maybe_mark_dynamic: max=8 declares no lower bound, the shape env
+        # narrows it to 2 on its own for a backed size.
+        x = torch.randn(4)
+        torch._dynamo.mark_dynamic(x, 0, max=8)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(2, 8)])
+
+        # min alone leaves the upper bound open.
+        x = torch.randn(4)
+        torch._dynamo.mark_dynamic(x, 0, min=3)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(2, 8), (3, int_oo)])
+
+        # Where maybe_mark_dynamic accepts a size 1 hint by specializing, mark_dynamic
+        # errors, since it does not allow the dim to specialize.
+        x = torch.randn(1)
+        torch._dynamo.mark_dynamic(x, 0, max=8)
+        with self.assertRaises(ConstraintViolationError):
+            opt_fn(x)
+
+    @torch.fx.experimental._config.patch(backed_size_oblivious=True)
+    def test_maybe_mark_dynamic_half_open_range_shape_env_lower_bound(self):
+        compiled_ranges = []
+
+        def fn(x):
+            return x.cos() * x.shape[0]
+
+        # The bound the user left out comes from the shape env, not from the declared
+        # range, so with 0 and 1 no longer specialized the dim starts at 0 instead of 2.
+        x = torch.randn(1)
+        torch._dynamo.maybe_mark_dynamic(x, 0, max=8)
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(0, 8)])
+
+    def test_maybe_mark_dynamic_with_partial_range(self):
+        for kwargs, expected in (
+            ({"min": 3}, (3, int_oo)),
+            ({"max": 8}, (2, 8)),
+            ({}, (2, int_oo)),
+        ):
+            with self.subTest(kwargs=kwargs):
+                torch._dynamo.reset()
+                compiled_ranges = []
+
+                def fn(x):
+                    return x.cos() * x.shape[0]
+
+                x = torch.randn(4)
+                torch._dynamo.maybe_mark_dynamic(x, 0, **kwargs)
+                opt_fn = torch.compile(
+                    fn, backend=self._range_recording_backend(compiled_ranges)
+                )
+                self.assertEqual(opt_fn(x), fn(x))
+                self.assertEqual(compiled_ranges, [expected])
+
+    def test_maybe_mark_dynamic_range_override(self):
+        compiled_ranges = []
+
+        def fn(x):
+            return x.cos() * x.shape[0]
+
+        # A second call for the same dim overrides the range of the first one.
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=3, max=4)
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(3, 4)])
+
+    def test_mark_dynamic_range_cleared_by_bare_remark(self):
+        # Last call wins: a call without min/max declares no range for the dim, which
+        # drops a range an earlier call declared. The attribute goes away with the last
+        # entry, so "no range declared" has a single representation.
+        for mark in (torch._dynamo.mark_dynamic, torch._dynamo.maybe_mark_dynamic):
+            with self.subTest(mark=mark.__name__):
+                x = torch.randn(4)
+                mark(x, 0, min=2, max=5)
+                mark(x, 0)
+                self.assertFalse(hasattr(x, "_dynamo_dynamic_range"))
+
+    def test_maybe_mark_dynamic_range_with_index_list(self):
+        # The list form applies the same range to every listed dim.
+        x = torch.randn(4, 6)
+        torch._dynamo.maybe_mark_dynamic(x, [0, 1], min=2, max=8)
+        self.assertEqual(x._dynamo_weak_dynamic_indices, {0, 1})
+        self.assertEqual(
+            x._dynamo_dynamic_range, {_DimRange(0, 2, 8), _DimRange(1, 2, 8)}
+        )
+
+    def test_maybe_mark_dynamic_range_mirrored_to_subclass_inner_tensors(self):
+        from torch.testing._internal.two_tensor import TwoTensor
+
+        # Marking a traceable wrapper subclass mirrors onto the inner tensors of the
+        # same dim, bounds included.
+        x = TwoTensor(torch.randn(4, 6), torch.randn(4, 6))
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        for inner in (x.a, x.b):
+            self.assertEqual(inner._dynamo_weak_dynamic_indices, {0})
+            self.assertEqual(inner._dynamo_dynamic_range, {_DimRange(0, 2, 5)})
+
+    def test_mark_dynamic_range_copied_with_tensor_attributes(self):
+        from torch._dynamo.utils import copy_dynamo_tensor_attributes
+
+        # A clone keeps the marking and its declared range, otherwise it would
+        # compile under different constraints than the tensor it came from.
+        src = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(src, 0, min=2, max=5)
+        dst = torch.randn(4)
+        copy_dynamo_tensor_attributes(src, dst)
+        self.assertEqual(dst._dynamo_weak_dynamic_indices, {0})
+        self.assertEqual(dst._dynamo_dynamic_range, {_DimRange(0, 2, 5)})
+        # The copy must not alias the source, mutating one must not touch the other.
+        torch._dynamo.maybe_mark_dynamic(dst, 0, min=3, max=4)
+        self.assertEqual(src._dynamo_dynamic_range, {_DimRange(0, 2, 5)})
+
+    # Translation validation changes the exception type, don't run with it
+    @torch.fx.experimental._config.patch(translation_validation=False)
+    def test_mark_dynamic_takes_precedence_over_maybe_mark_dynamic(self):
+        compiled_ranges = []
+
+        def fn(x):
+            return x.cos() * x.shape[0]
+
+        # A dim may carry both markings, marked_dynamic is tested first in
+        # _automatic_dynamic so mark_dynamic wins, and the range is the one the last
+        # call to declare bounds left behind.
+        x = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        torch._dynamo.mark_dynamic(x, 0, min=3, max=6)
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(3, 6)])
+
+        # Enforcement follows mark_dynamic too: specializing the dim is an error rather
+        # than the warning maybe_mark_dynamic alone would give.
+        def specializing_fn(x):
+            if x.shape[0] == 4:
+                return x.sin()
+            return x.cos()
+
+        y = torch.randn(4)
+        torch._dynamo.maybe_mark_dynamic(y, 0)
+        torch._dynamo.mark_dynamic(y, 0)
+        with self.assertRaises(ConstraintViolationError):
+            torch.compile(specializing_fn, backend="eager")(y)
+
+        # mark_dynamic drops the dim from the weak set, so every consumer agrees on the
+        # semantics rather than depending on which index set it tests first. Non strict
+        # export tests the weak set first, and must enforce the dim like dynamo does.
+        class Specializing(torch.nn.Module):
+            def forward(self, x):
+                return specializing_fn(x)
+
+        for strict in (True, False):
+            with self.subTest(strict=strict):
+                e = torch.randn(4)
+                torch._dynamo.maybe_mark_dynamic(e, 0, min=2, max=5)
+                torch._dynamo.mark_dynamic(e, 0)
+                self.assertEqual(e._dynamo_dynamic_indices, {0})
+                self.assertEqual(e._dynamo_weak_dynamic_indices, set())
+                with self.assertRaises(
+                    (
+                        torch._dynamo.exc.UserError,
+                        ConstraintViolationError,
+                    )
+                ):
+                    torch.export.export(Specializing(), (e,), strict=strict)
+
+        # Different dims of the same tensor may use different APIs.
+        z = torch.randn(4, 4)
+        torch._dynamo.mark_dynamic(z, 0)
+        torch._dynamo.maybe_mark_dynamic(z, 1, min=2, max=5)
+        self.assertEqual(z._dynamo_dynamic_range, {_DimRange(1, 2, 5)})
+
+        # A weak marking of a dim mark_dynamic already covers is ignored, its bounds
+        # included: they would otherwise be enforced by the mark_dynamic path.
+        w = torch.randn(4)
+        torch._dynamo.mark_dynamic(w, 0)
+        torch._dynamo.maybe_mark_dynamic(w, 0, min=2, max=5)
+        self.assertFalse(hasattr(w, "_dynamo_weak_dynamic_indices"))
+        self.assertFalse(hasattr(w, "_dynamo_dynamic_range"))
+
+        # so narrowing the dim stays allowed, RelaxedUnspecConstraint only forbids
+        # collapsing it to a single value.
+        def narrowing_fn(x):
+            if x.shape[0] < 5:
+                return x.sin()
+            return x.cos()
+
+        self.assertEqual(
+            torch.compile(narrowing_fn, backend="eager")(w), narrowing_fn(w)
+        )
+
+    def test_mark_dynamic_range_change_recompiles(self):
+        compiled_ranges = []
+
+        def fn(x):
+            return x.cos() * x.shape[0]
+
+        opt_fn = torch.compile(
+            fn, backend=self._range_recording_backend(compiled_ranges)
+        )
+
+        # mark_dynamic shares the range attribute with maybe_mark_dynamic, so a
+        # changed range recompiles here as well. A range the user left half open is
+        # completed with the bounds a backed size already has.
+        x = torch.randn(4)
+        torch._dynamo.mark_dynamic(x, 0, min=2, max=5)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(2, 5)])
+
+        x = torch.randn(4)
+        torch._dynamo.mark_dynamic(x, 0, min=3)
+        self.assertEqual(opt_fn(x), fn(x))
+        self.assertEqual(compiled_ranges, [(2, 5), (3, int_oo)])
+
+    def test_maybe_mark_dynamic_range_with_propagated_dynamic_dim(self):
+        def fn(x):
+            return x.cos() * x.shape[0] * x.shape[1]
+
+        x = torch.randn(4, 4)
+        torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+        # dim 1 is weakly dynamic without a declared range, this used to raise
+        # IndexError while looking up its range.
+        x._dynamo_propagated_dynamic_indices = {1}
+        self.assertEqual(torch.compile(fn, backend="eager")(x), fn(x))
+
+    def test_dim_marking_skipped_under_fx_tracing(self):
+        # FX tracers ignore @forbid_in_graph and pass a Proxy. Reading a marking
+        # attribute off one used to raise TraceError: Proxy.__getattr__ answers every
+        # name, so `in` fell through to iterating the Proxy.
+        class M(torch.nn.Module):
+            def forward(self, x):
+                torch._dynamo.maybe_mark_dynamic(x, 0)
+                torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+                torch._dynamo.mark_dynamic(x, 1)
+                torch._dynamo.mark_dynamic(x, 1, min=2, max=5)
+                return x.cos()
+
+        gm = torch.fx.symbolic_trace(M())
+        # The marking is dropped, not recorded as graph nodes.
+        self.assertEqual(
+            [n.op for n in gm.graph.nodes], ["placeholder", "call_method", "output"]
+        )
+        x = torch.randn(4, 4)
+        self.assertEqual(gm(x), x.cos())
 
     def test_mark_static(self):
         counter = CompileCounter()

--- a/test/export/test_export.py
+++ b/test/export/test_export.py
@@ -10234,6 +10234,44 @@ def forward(self, x):
             ]:
                 self.assertFalse(hasattr(tensor, attr))
 
+    def test_maybe_mark_dynamic_ranges(self) -> None:
+        class Foo(torch.nn.Module):
+            def forward(self, x):
+                return x.cos() * x.shape[0]
+
+        class Narrowing(torch.nn.Module):
+            def forward(self, x):
+                if x.shape[0] < 5:
+                    return x.sin()
+                return x.cos() * x.shape[0]
+
+        def exported_dim_range(mod, size, strict):
+            x = torch.randn(size)
+            torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
+            ep = torch.export.export(mod, (x,), strict=strict)
+            placeholder = next(n for n in ep.graph.nodes if n.op == "placeholder")
+            sym_size = placeholder.meta["val"].shape[0]
+            vr = sym_size.node.shape_env.var_to_range[sym_size.node.expr]
+            return (vr.lower, vr.upper)
+
+        # Strict and non strict export raise different exception types.
+        range_errors = (
+            torch._dynamo.exc.UserError,
+            torch.fx.experimental.symbolic_shapes.ConstraintViolationError,
+        )
+
+        for strict in (True, False):
+            with self.subTest(strict=strict):
+                # The declared range is honored.
+                self.assertEqual(exported_dim_range(Foo(), 4, strict), (2, 5))
+
+                # A guard may narrow the declared range.
+                self.assertEqual(exported_dim_range(Narrowing(), 4, strict), (2, 4))
+
+                # The range is never extended to fit the input.
+                with self.assertRaisesRegex(range_errors, r"6 not in range \[2, 5\]"):
+                    exported_dim_range(Foo(), 6, strict)
+
     @testing.expectedFailureCppRuntime
     def test_while_loop_index_assertions(self):
         from torch._higher_order_ops import while_loop

--- a/test/test_dynamic_shapes.py
+++ b/test/test_dynamic_shapes.py
@@ -76,6 +76,7 @@ from torch.utils._sympy.functions import (
     Min,
     Mod,
 )
+from torch.utils._sympy.numbers import int_oo
 from torch.utils._sympy.value_ranges import ValueRangeError
 
 
@@ -5853,6 +5854,34 @@ def forward(self, arg0_1: "i64[1][1]cpu", arg1_1: "Sym(u1)", arg2_1: "i64[u1][1]
         torch._dynamo.decorators.mark_unbacked(x2, 0, shape_id="other")
         compiled_func(x2)
         self.assertEqual(counter.frame_count, 2)
+
+    @skipIfTorchDynamo("mark_unbacked is not traceable")
+    def test_unbacked_bounds_partially_specified(self):
+        """
+        Unbacked sizes are size oblivious, an unspecified min stays 0.
+        """
+        ranges = []
+
+        def backend(gm, example_inputs):
+            for arg in example_inputs:
+                if isinstance(arg, torch.SymInt):
+                    vr = arg.node.shape_env.var_to_range[arg.node.expr]
+                    ranges.append((vr.lower, vr.upper))
+            return gm.forward
+
+        for kwargs, expected in (
+            ({"max": 10}, (0, 10)),
+            ({"min": 3}, (3, int_oo)),
+            ({"min": 3, "max": 10}, (3, 10)),
+            ({}, (0, int_oo)),
+        ):
+            with self.subTest(kwargs=kwargs):
+                torch._dynamo.reset()
+                ranges.clear()
+                x = torch.randn(4)
+                torch._dynamo.decorators.mark_unbacked(x, 0, **kwargs)
+                torch.compile(lambda t: t.cos() * t.shape[0], backend=backend)(x)
+                self.assertEqual(ranges, [expected])
 
     @skipIfTorchDynamo("mark_unbacked is not traceable")
     def test_unbacked_bounds_recompilation(self):

--- a/torch/_dynamo/decorators.py
+++ b/torch/_dynamo/decorators.py
@@ -52,6 +52,8 @@ justknobs_check._dynamo_marked_constant = True  # type: ignore[attr-defined]
 if TYPE_CHECKING:
     from types import FunctionType
 
+    import sympy
+
     from torch._C._dynamo.eval_frame import (  # noqa: F401
         reset_code,
         set_eval_frame,
@@ -59,6 +61,7 @@ if TYPE_CHECKING:
         set_guard_error_hook,
         unsupported,
     )
+    from torch.utils._sympy.value_ranges import ValueRanges
 
     from .variables import VariableTracker
 else:
@@ -1065,8 +1068,60 @@ class _DimRange:
     """
 
     dim: int
-    min: int
-    max: int
+    min: int | None
+    max: int | None
+
+
+def _set_dim_range(t: Any, dim: int, min: int | None, max: int | None) -> None:
+    """
+    Records the range declared for ``dim`` by mark_dynamic or maybe_mark_dynamic,
+    replacing any range an earlier call declared for that dim. Dims without a
+    declared range get no entry, and the attribute is removed once no dim has one, so
+    that "no range declared" has a single representation.
+
+    The set is rebound rather than mutated: guards hold a reference to it, so mutating
+    in place would let a re-marked tensor compare equal to the graph it was compiled for.
+    """
+    if min is None and max is None and not hasattr(t, "_dynamo_dynamic_range"):
+        return
+
+    ranges = {dr for dr in getattr(t, "_dynamo_dynamic_range", ()) if dr.dim != dim}
+    if min is not None or max is not None:
+        ranges.add(_DimRange(dim, min, max))
+
+    if ranges:
+        t._dynamo_dynamic_range = ranges
+    elif hasattr(t, "_dynamo_dynamic_range"):
+        del t._dynamo_dynamic_range
+
+
+def _get_dim_range(t: Any, dim: int) -> _DimRange | None:
+    """
+    Returns the range declared for ``dim`` by mark_dynamic or maybe_mark_dynamic, or
+    None. A dim can be dynamic without a declared range, for example when dynamism
+    was propagated by AOTAutograd instead of a marking API.
+    """
+    return next(
+        (dr for dr in getattr(t, "_dynamo_dynamic_range", ()) if dr.dim == dim), None
+    )
+
+
+def _dim_range_to_value_ranges(dim_range: _DimRange) -> "ValueRanges[sympy.Expr]":
+    """
+    Converts a _DimRange to a ValueRanges, filling in a bound the user left out with the
+    widest one, since ValueRanges rejects None. The lower default is 0 rather than the 2
+    a backed size ends up with: the constraint must not add a bound the user never
+    declared, otherwise a half open range like max=8 would reject a size 1 input. The
+    shape env still narrows the range to [2, ...] on its own for sizes that specialize
+    0 and 1.
+    """
+    from torch.utils._sympy.numbers import int_oo
+    from torch.utils._sympy.value_ranges import ValueRanges
+
+    return ValueRanges(
+        lower=0 if dim_range.min is None else dim_range.min,
+        upper=int_oo if dim_range.max is None else dim_range.max,
+    )
 
 
 @forbid_in_graph
@@ -1225,7 +1280,20 @@ def mark_dynamic(
     This approach results in one Dynamo trace and two backend compilations. When the input dimension equals 8 or 16
     at runtime, execution will be directed to the specialized compiled region. Performance measurements indicate
     2-8x speedups depending on the specific specialization and model architecture.
+
+    7) Where min or max are given, a later call replaces the range declared by an earlier
+    one, and a call that gives neither declares no range for that dim. This API overrides
+    maybe_mark_dynamic on the same dim: marking a dim that maybe_mark_dynamic already
+    marked takes over, and a later maybe_mark_dynamic on that dim is ignored, so the dim
+    is always enforced with the stronger mark_dynamic semantics.
     """
+    if isinstance(t, torch.fx.Proxy):
+        # FX tracers ignore @forbid_in_graph and pass a Proxy in place of the tensor.
+        # Proxy.__getattr__ answers every name with an Attribute, so the marking
+        # attributes can neither be read (getattr defaults and hasattr are both useless)
+        # nor usefully written: the Proxy is discarded once tracing ends.
+        return
+
     if is_traceable_wrapper_subclass(t):
         # default behavior: mirror mark_dynamic() on all inner tensors with same dim as t
         # TODO: Make this configurable via a supported public API
@@ -1236,8 +1304,6 @@ def mark_dynamic(
     if isinstance(index, int):
         if not hasattr(t, "_dynamo_dynamic_indices"):
             t._dynamo_dynamic_indices = set()
-
-            t._dynamo_dynamic_range = set()
 
             # pyrefly: ignore [implicit-any]
             t._dynamo_hint_overrides = {}
@@ -1250,8 +1316,16 @@ def mark_dynamic(
             t._dynamo_hint_overrides[index] = hint_override
         # TODO(voz): Should we bounds check?
 
+        weak_indices = getattr(t, "_dynamo_weak_dynamic_indices", None)
+        if weak_indices is not None and index in weak_indices:
+            # This API overrides maybe_mark_dynamic, so drop the dim from the weak set:
+            # a dim in both sets would let consumers disagree on which semantics apply,
+            # _automatic_dynamic tests mark_dynamic first while non strict export tests
+            # the weak indices first. Rebound rather than mutated, guards hold a
+            # reference to this set.
+            t._dynamo_weak_dynamic_indices = weak_indices - {index}
         t._dynamo_dynamic_indices.add(index)
-        t._dynamo_dynamic_range.add(_DimRange(index, min, max))  # type: ignore[arg-type]
+        _set_dim_range(t, index, min, max)
         t._has_dynamo_dim_marking = True  # type: ignore[attr-defined]
 
         # FX tracers don't respect @forbid_in_graph and choke on the following error since it passes in proxies:
@@ -1271,22 +1345,59 @@ def mark_dynamic(
 
 
 @forbid_in_graph
-def maybe_mark_dynamic(t: Any, index: int | list[Any] | tuple[Any]) -> None:
+def maybe_mark_dynamic(
+    t: Any,
+    index: int | list[Any] | tuple[Any],
+    *,
+    min: int | None = None,
+    max: int | None = None,
+) -> None:
     """
-    Mark a tensor as having a dynamic dim, but don't enforce it (i.e., if this
-    dimension ends up getting specialized, don't error).
+    Mark a tensor as having a dynamic dim, but do not enforce it (i.e., if this
+    dimension ends up getting specialized, do not error).
+
+    If min or max are specified, they are used as the initial range for the
+    dimension. The compiler may still narrow this range or specialize the
+    dimension.
+
+    Args:
+        t: The tensor, or traceable wrapper subclass, to mark. Marking a subclass
+            mirrors the marking, bounds included, onto its inner tensors of the same dim.
+        index: The dim to mark, or a list or tuple of dims. Every dim in a list gets the
+            same min and max.
+        min: Lower bound to start the dim at, if any. The hint must satisfy it, an input
+            outside the declared range raises ConstraintViolationError at compile time.
+        max: Upper bound to start the dim at, if any.
+
+    A later call that specifies min or max replaces the range declared by an earlier one,
+    and a call that specifies neither declares no range for that dim. If the dim is
+    already marked with mark_dynamic, this call is ignored: that marking has stronger
+    semantics and a weak one cannot weaken it.
     """
+    if isinstance(t, torch.fx.Proxy):
+        # See the matching guard in mark_dynamic: a Proxy cannot carry dim marking.
+        return
+
     if is_traceable_wrapper_subclass(t):
         # default behavior: mirror maybe_mark_dynamic() on all inner tensors with same dim as t
         # TODO: Make this configurable via a supported public API
-        _apply_func_to_inner_tensors_of_same_dim(maybe_mark_dynamic, t, index)
+        _apply_func_to_inner_tensors_of_same_dim(
+            maybe_mark_dynamic, t, index, min=min, max=max
+        )
 
     if isinstance(index, int):
+        if index in getattr(t, "_dynamo_dynamic_indices", ()):
+            # mark_dynamic already covers this dim with stronger semantics. Ignore the
+            # call rather than recording anything: a weak marking cannot weaken it, and
+            # bounds passed here would otherwise end up enforced by the mark_dynamic
+            # path, which is not what this API promises.
+            return
         if not hasattr(t, "_dynamo_weak_dynamic_indices"):
             t._dynamo_weak_dynamic_indices = set()
         # TODO(voz): Should we bounds check?
 
         t._dynamo_weak_dynamic_indices.add(index)
+        _set_dim_range(t, index, min, max)
         t._has_dynamo_dim_marking = True  # type: ignore[attr-defined]
         return
 
@@ -1295,7 +1406,7 @@ def maybe_mark_dynamic(t: Any, index: int | list[Any] | tuple[Any]) -> None:
             f"Expected index to be int, list, or tuple, got {type(index)}"
         )
     for i in index:
-        maybe_mark_dynamic(t, i)
+        maybe_mark_dynamic(t, i, min=min, max=max)
 
 
 def mark_static(t: Any, index: int | list[Any] | tuple[Any] | None = None) -> None:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -3854,6 +3854,14 @@ class GuardBuilder(GuardBuilderBase):
             #   _dynamo_weak_dynamic_indices is the user-facing attribute, set via
             #   maybe_mark_dynamic(), and guarded on like the other dimension marking
             #   attributes above.
+            #   _dynamo_dynamic_range holds the min/max declared through
+            #   mark_dynamic() or maybe_mark_dynamic(). It is compared by VALUE, as one
+            #   set, so declaring a different range for a dim recompiles instead of
+            #   silently reusing a graph built for another range. Comparing the set as a
+            #   whole also means a graph compiled from {dim 0: [2, 5], dim 1: [3, 7]} is
+            #   not reused by a tensor declaring only {dim 0: [2, 5]}, even though the
+            #   marking indices of that tensor would match. TODO we can optimize that
+            #   recompilation by comparing value per dim.
             #   _dynamo_propagated_dynamic_indices is a compiler-internal attribute set by
             #   AOTAutograd's mark_dynamo_propagated_dynamic_indices() to propagate dynamism across
             #   graph breaks. It is NOT guarded on. When AOTAutograd discovers that an
@@ -3884,11 +3892,19 @@ class GuardBuilder(GuardBuilderBase):
                     code_part = f"hasattr({tensor_name}, '{attr_name}') == False"
                     code.append(code_part)
 
-            # Dependent attributes: checked only when _dynamo_unbacked_indices is present.
-            dependent_attrs: dict[str, tuple[dict[int, Any] | None, str]] = {}
-            dep_attr_names = ("_dynamo_shape_ids", "_dynamo_unbacked_bounds")
-            gate_attr = "_dynamo_unbacked_indices"
-            if hasattr(value, gate_attr):
+            # Dependent attributes: compared by value, and only when their gate
+            # attribute is present.
+            dependent_attrs: dict[str, tuple[Any, str]] = {}
+            gated_attrs = (
+                (
+                    "_dynamo_unbacked_indices",
+                    ("_dynamo_shape_ids", "_dynamo_unbacked_bounds"),
+                ),
+                ("_has_dynamo_dim_marking", ("_dynamo_dynamic_range",)),
+            )
+            for gate_attr, dep_attr_names in gated_attrs:
+                if not hasattr(value, gate_attr):
+                    continue
                 for attr_name in dep_attr_names:
                     attr_value = getattr(value, attr_name, None)
                     dependent_attrs[attr_name] = (attr_value, gate_attr)

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -2573,6 +2573,7 @@ def copy_dynamo_tensor_attributes(src: torch.Tensor, dst: torch.Tensor) -> None:
     _copy_dynamo_attr(src, dst, "_dynamo_shape_ids")
     _copy_dynamo_attr(src, dst, "_dynamo_strict_unbacked_indices")
     _copy_dynamo_attr(src, dst, "_dynamo_weak_dynamic_indices")
+    _copy_dynamo_attr(src, dst, "_dynamo_dynamic_range")
     _copy_dynamo_attr(src, dst, "_dynamo_propagated_dynamic_indices")
     _copy_dynamo_attr(src, dst, "_has_dynamo_dim_marking")
 

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -115,7 +115,6 @@ from torch.utils._python_dispatch import (
     is_traceable_wrapper_subclass,
     is_traceable_wrapper_subclass_type,
 )
-from torch.utils._sympy.value_ranges import ValueRanges
 from torch.utils.weak import TensorWeakRef
 
 from .. import config, graph_break_hints, mutation_guard, replay_record, trace_rules
@@ -4684,6 +4683,8 @@ def _automatic_dynamic(
     outer_only: bool = False,
     tensor_spec: TensorSpec | None = None,
 ) -> SymbolicContext:
+    from ..decorators import _dim_range_to_value_ranges, _get_dim_range
+
     # strided NT not supported
     if e.is_nested and not isinstance(
         e, torch.nested._internal.nested_tensor.NestedTensor
@@ -4922,6 +4923,50 @@ def _automatic_dynamic(
 
         automatic_dynamic = automatic_dynamic_size or automatic_dynamic_stride
 
+        # Constraint policy has two independent axes, do not conflate them:
+        #
+        #   kind                        what it requires
+        #   --------------------------  ------------------------------------------------
+        #   None                        nothing, the dim may be narrowed or even fully
+        #                               specialized, silently
+        #   RelaxedUnspecConstraint     weak, the dim must not collapse to a single
+        #                               value, any further narrowing by guards is fine
+        #   StrictMinMaxConstraint(vr)  strong, no guard is allowed unless vr already
+        #                               implies it, so narrowing below vr violates it
+        #
+        #   warn_only                   reaction when the requirement is violated
+        #   --------------------------  ------------------------------------------------
+        #   False                       raise ConstraintViolationError
+        #   True                        log a warning and keep compiling
+        #
+        # The two axes are orthogonal: RelaxedUnspecConstraint(warn_only=False), what
+        # mark_dynamic uses without min/max, is a loose requirement that is strictly
+        # enforced, while StrictMinMaxConstraint(vr, warn_only=True) is a tight
+        # requirement that is only advisory.
+        #
+        # A constraint only controls enforcement. Whether the dim is symbolic at all is
+        # decided further down from marked_dynamic / marked_weak_dynamic, and
+        # constraint_stride is what picks DimDynamic.DYNAMIC for a stride (its own
+        # symbol) over DimDynamic.INFER_STRIDE (stride derived from the sizes).
+        #
+        # TODO: the chain below leans on the automatic dynamic fall-through for dims that
+        # do not match any branch, which is fragile: that branch also decides
+        # constraint_stride and records automatic_dynamic_shapes feature usage for dims
+        # that are dynamic because the user marked them. Refactor to handle every case
+        # explicitly, each with its own constraint_size/constraint_stride, and document
+        # the resulting DimDynamic per case in a table here:
+        #   mark_dynamic, with and without a range
+        #   mark_dynamic under config.allow_ignore_mark_dynamic, which today drops a
+        #     declared range entirely instead of degrading it to warn_only
+        #   maybe_mark_dynamic, with and without a range
+        #   dims that are only _dynamo_propagated_dynamic_indices, which should keep
+        #     plain automatic dynamic behavior and no user constraint
+        #   pure automatic dynamic, and no marking at all
+        # Until then the automatic_dynamic_shapes feature usage recorded below is skewed:
+        # a weakly marked dim with a declared range takes its own branch and records
+        # nothing, while the same dim without a range falls through and records usage,
+        # even though neither is dynamic because of automatic dynamic shapes.
+        #
         # We will process constraints first, as they will imply that we
         # have a dynamic dimension
         # Precedence: export constraints > eager constraints
@@ -4932,27 +4977,47 @@ def _automatic_dynamic(
             if marked_dynamic and not config.allow_ignore_mark_dynamic:
                 # constraint_stride is deliberaly kept None because no easy way to provide value ranges for mark dynamic
                 constraint_stride = None
-                if hasattr(e, "_dynamo_dynamic_range"):
-                    dim_range = [
-                        dr for dr in e._dynamo_dynamic_range if dr.dim == i
-                    ].pop()
-                    if dim_range.min is None and dim_range.max is None:
-                        constraint_size = RelaxedUnspecConstraint(warn_only=False)
-                    else:
-                        from torch.fx.experimental.symbolic_shapes import (
-                            StrictMinMaxConstraint,
-                        )
-
-                        constraint_size = StrictMinMaxConstraint(
-                            vr=ValueRanges(lower=dim_range.min, upper=dim_range.max),
-                            warn_only=False,
-                        )
-                else:
+                dim_range = _get_dim_range(e, i)
+                if dim_range is None:
                     constraint_size = RelaxedUnspecConstraint(warn_only=False)
+                else:
+                    from torch.fx.experimental.symbolic_shapes import (
+                        StrictMinMaxConstraint,
+                    )
+
+                    constraint_size = StrictMinMaxConstraint(
+                        vr=_dim_range_to_value_ranges(dim_range),
+                        warn_only=False,
+                    )
+            elif (
+                marked_weak_dynamic and (dim_range := _get_dim_range(e, i)) is not None
+            ):
+                # Only dims with a declared range are handled here. A weakly dynamic dim
+                # without one, which includes every dim that is weakly dynamic only
+                # because of _dynamo_propagated_dynamic_indices, keeps taking the
+                # automatic dynamic branch below as it did before ranges existed.
+                from torch.fx.experimental.symbolic_shapes import StrictMinMaxConstraint
+
+                constraint_size = StrictMinMaxConstraint(
+                    vr=_dim_range_to_value_ranges(dim_range),
+                    warn_only=True,
+                )
+                # Strides are unrelated to the declared range, so decide them exactly as
+                # they would be for this dim if no range had been declared.
+                # TODO this is hazy, marked_static loses to a weak marking for the size
+                # yet still suppresses the stride constraint here. Maintaining existing
+                # behavior for now, the refactor above should settle it.
+                if not marked_static and automatic_dynamic_stride:
+                    constraint_stride = RelaxedUnspecConstraint(warn_only=True)
             elif marked_strict_unbacked:
                 constraint_size = RelaxedUnspecConstraint(warn_only=False)
             elif not marked_static and automatic_dynamic:
-                set_feature_use("dynamo.automatic_dynamic_shapes", True)
+                if not marked_weak_dynamic:
+                    # A weakly marked dim is dynamic because it was marked, automatic
+                    # dynamic shapes only supplies its constraints, so its usage is not
+                    # recorded. Keeps the reporting independent of whether the marking
+                    # declared a range.
+                    set_feature_use("dynamo.automatic_dynamic_shapes", True)
                 if automatic_dynamic_size:
                     constraint_size = RelaxedUnspecConstraint(warn_only=True)
                 if automatic_dynamic_stride:

--- a/torch/_export/non_strict_utils.py
+++ b/torch/_export/non_strict_utils.py
@@ -262,10 +262,12 @@ def _create_symbolic_context_for_tensor(
     mode: FakeTensorMode,
 ) -> "SymbolicContext":
     """Helper function to create symbolic context for a tensor."""
+    from torch._dynamo.decorators import _dim_range_to_value_ranges, _get_dim_range
     from torch._dynamo.source import AttrSource
     from torch.fx.experimental.symbolic_shapes import (
         DimDynamic,
         RelaxedUnspecConstraint,
+        StrictMinMaxConstraint,
         SubclassSymbolicContext,
     )
     from torch.utils._python_dispatch import is_traceable_wrapper_subclass
@@ -278,12 +280,27 @@ def _create_symbolic_context_for_tensor(
     for i in range(n_dims):
         if i in getattr(t, "_dynamo_weak_dynamic_indices", {}):
             dynamic_sizes.append(DimDynamic.DYNAMIC)
+            # maybe_mark_dynamic ranges are advisory, the dim may still be
+            # specialized or narrowed, hence warn_only.
+            dim_range = _get_dim_range(t, i)
+            if dim_range is not None:
+                constraint_sizes[i] = StrictMinMaxConstraint(  # type: ignore[call-overload]
+                    vr=_dim_range_to_value_ranges(dim_range),
+                    warn_only=True,
+                )
         elif i in getattr(t, "_dynamo_dynamic_indices", {}):
             # bit annoying, but we need to replicate process in _dynamo/variables/builder.py
             # where a RelaxedUnspecConstraint is created for Dim.DYNAMIC, so constraint violations
             # are raised when specializing.
             dynamic_sizes.append(DimDynamic.DYNAMIC)
-            constraint_sizes[i] = RelaxedUnspecConstraint(warn_only=False)  # type: ignore[call-overload]
+            dim_range = _get_dim_range(t, i)
+            if dim_range is None:
+                constraint_sizes[i] = RelaxedUnspecConstraint(warn_only=False)  # type: ignore[call-overload]
+            else:
+                constraint_sizes[i] = StrictMinMaxConstraint(  # type: ignore[call-overload]
+                    vr=_dim_range_to_value_ranges(dim_range),
+                    warn_only=False,
+                )
         else:
             dynamic_sizes.append(DimDynamic.STATIC)
 

--- a/torch/export/dynamic_shapes.py
+++ b/torch/export/dynamic_shapes.py
@@ -1431,7 +1431,10 @@ def _process_dynamic_shapes(
         # we also delete these attributes in non_strict_utils.py/make_constraints()
         tensor._dynamo_weak_dynamic_indices = set()
         tensor._dynamo_dynamic_indices = set()
-        tensor._dynamo_dynamic_range = set()
+        if hasattr(tensor, "_dynamo_dynamic_range"):
+            # Removed rather than emptied, an empty set is a different value to the
+            # guards than an absent attribute. See _clean_dynamic_markers.
+            del tensor._dynamo_dynamic_range
         tensor._dynamo_static_indices = set()
         tensor._dynamo_unbacked_indices = set()
 

--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -181,12 +181,18 @@ class NestedTensor(torch.Tensor):
         self._dynamo_propagated_dynamic_indices = {self._ragged_idx}  # type: ignore[attr-defined]
         self._values._dynamo_propagated_dynamic_indices = {self._ragged_idx - 1}  # type: ignore[attr-defined]
 
-        # min / max sequence length should be dynamic if present
+        # min / max sequence length should be dynamic if present. The metadata cache is
+        # shared across constructions, so skip a tensor whose dim 0 mark_dynamic already
+        # set: re-marking would drop a min/max range declared on it.
         max_seqlen_tensor = self._metadata_cache.get("max_seqlen", None)
-        if max_seqlen_tensor is not None:
+        if max_seqlen_tensor is not None and 0 not in getattr(
+            max_seqlen_tensor, "_dynamo_dynamic_indices", ()
+        ):
             torch._dynamo.mark_dynamic(max_seqlen_tensor, 0)
         min_seqlen_tensor = self._metadata_cache.get("min_seqlen", None)
-        if min_seqlen_tensor is not None:
+        if min_seqlen_tensor is not None and 0 not in getattr(
+            min_seqlen_tensor, "_dynamo_dynamic_indices", ()
+        ):
             torch._dynamo.mark_dynamic(min_seqlen_tensor, 0)
 
     def values(self):


### PR DESCRIPTION
Summary:

internal ref for why its needed https://fb.workplace.com/groups/1075192433118967/permalink/2031263990845135/
Adds `min` / `max` kwargs to `torch._dynamo.maybe_mark_dynamic`, so a dim can be marked
dynamic *and* given an initial range without enforcing that the dim stays dynamic:

```python
torch._dynamo.maybe_mark_dynamic(x, 0, min=2, max=5)
```
The range is a starting point: guards may narrow it ([2, 5] + a x.shape[0] < 5 guard compiles with (2, 4)), and the dim may still specialize instead of raising, unlike mark_dynamic.

A hint outside the declared range is still an error (ConstraintViolationError: 6 not in range [2, 5]) — the range is never widened to fit the input.

Bugs fixed along the way
- min or max alone crashed with AssertionError: not simple sympy type NoneType (ValueRanges rejects None). The missing bound now defaults to 2 / int_oo, the bounds a backed size already has. This also fixes mark_dynamic(x, 0, min=2).
- A dim made dynamic by AOTAutograd's _dynamo_propagated_dynamic_indices, on a tensor carrying a range for another dim, raised IndexError: pop from empty list.

- changing min/max between calls now recompiles rather than reusing the cached graph, and partial ranges no longer crash.
- Marking one dim with both mark_dynamic and maybe_mark_dynamic now raises; different dims of the same tensor may still use different APIs.

Reland of D117045746, which was backed out because it broke FX symbolic tracing. The
new early return in `maybe_mark_dynamic` read `_dynamo_dynamic_indices` off its
argument, but FX tracers ignore `forbid_in_graph` and pass a `Proxy`, whose
`__getattr__` answers every name with an `Attribute`. The `in` test therefore fell
through to iterating the Proxy and raised `TraceError: Proxy object cannot be
iterated`, breaking minimal_viable_ai/models/ifr_prospector/gpu_tests via
hammer/v2/modules/group_hstu_transducer.py. The same hazard applied to
`_set_dim_range` and to the weak-index lookup added to `mark_dynamic`.

Fixed by returning early from `mark_dynamic` / `maybe_mark_dynamic` when handed a
`Proxy`. A Proxy has no dims to annotate and is discarded when tracing ends; the
pre-revert code only escaped the crash because it never read an attribute to make a
decision, and what it did emit was dead graph nodes. Covered by the new
test_dim_marking_skipped_under_fx_tracing.

Test Plan: contbuild & OSS CI, see https://hud.pytorch.org/commit/pytorch/pytorch/f7dfbdd7e57230ed792c4d30b955d125436a2ab8

Differential Revision: D117221892




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98