### PR TITLE
Fix ambiguous reshape in _IndependentConstraint.check for zero-batch inputs

### DIFF
--- a/test/distributions/test_constraints.py
+++ b/test/distributions/test_constraints.py
@@ -107,6 +107,18 @@ def test_constraint(constraint_fn, result, value, is_cuda):
         )
 
 
+def test_independent_constraint_zero_batch():
+    # Regression test for https://github.com/pytorch/pytorch/issues/194548
+    # `_IndependentConstraint.check` used to flatten the reinterpreted dims
+    # via `result.reshape(result.shape[:-ndims] + (-1,))`, which is ambiguous
+    # (and raises) when both the tensor's numel and the un-flattened prefix
+    # are zero, e.g. shape (0, 2) -> reshape(0, -1).
+    value = torch.zeros(0, 2)
+    result = constraints.real_vector.check(value)
+    if result.shape != (0,):
+        raise AssertionError(f"Expected shape (0,), got {result.shape}")
+
+
 @pytest.mark.parametrize(
     ("constraint_fn", "args"), [(c[0], c[1:]) for c in CONSTRAINTS]
 )

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9380,6 +9380,23 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         x = torch.rand([4, 4])
         self.assertEqual(opt_fn(x), fn(x))
 
+    def test_torch_distributions_categorical_zero_batch_size(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/194548
+        # A zero-batch input used to raise in eager (see gh-71689) but
+        # silently succeed under torch.compile, since the underlying
+        # arg-validation bug (an ambiguous reshape for zero-sized batches)
+        # was only reachable through eager's `validate_args` check.
+        # validate_args is forced explicitly since merely constructing
+        # `opt_fn` flips `Distribution._validate_args` off process-wide.
+        def fn(logits):
+            return torch.distributions.Categorical(
+                logits=logits, validate_args=True
+            ).sample()
+
+        opt_fn = torch.compile(fn, backend="eager")
+        x = torch.randn(0, 2)
+        self.assertEqual(opt_fn(x), fn(x))
+
     def test_torch_distributions_gamma_dynamic(self):
         def fn(n: int):
             distribution = torch.distributions.Gamma(

--- a/torch/distributions/constraints.py
+++ b/torch/distributions/constraints.py
@@ -267,10 +267,7 @@ class _IndependentConstraint(Constraint):
             raise ValueError(
                 f"Expected value.dim() >= {expected} but got {value.dim()}"
             )
-        result = result.reshape(
-            result.shape[: result.dim() - self.reinterpreted_batch_ndims] + (-1,)
-        )
-        result = result.all(-1)
+        result = result.all(dim=tuple(range(-self.reinterpreted_batch_ndims, 0)))
         return result
 
     def __repr__(self):


### PR DESCRIPTION
Fixes #194548

## The issue

```python
import torch

def fn(logits):
    d = torch.distributions.Categorical(logits=logits)
    return d.sample()

x = torch.randn(0, 2)

fn(x)
# eager: RuntimeError: cannot reshape tensor of 0 elements into shape [0, -1]
# because the unspecified dimension size -1 can be any value and is ambiguous

torch.compile(fn, backend="inductor")(x)
# compiled: succeeds silently, returns a shape-[0] tensor
```

Eager and compiled disagree about whether a zero-batch `Categorical` input is valid.

## Root cause

The `RuntimeError` isn't raised inside `.sample()` — it's raised during
`Categorical.__init__`'s argument validation
(`Distribution.__init__`'s `validate_args` check calls
`constraints.real_vector.check(logits)`, which goes through
`_IndependentConstraint.check`).

That method flattened the trailing `reinterpreted_batch_ndims` dims with:

```python
result = result.reshape(result.shape[: result.dim() - self.reinterpreted_batch_ndims] + (-1,))
result = result.all(-1)
```

For a `logits` tensor of shape `(0, 2)`, this reshapes a 0-element tensor to
`(0, -1)`. Since both the tensor's numel and the product of the known
(non-inferred) dims are 0, the `-1` dimension is genuinely ambiguous — ATen's
`infer_size_impl` correctly rejects it with the observed error. This is a bug
in `_IndependentConstraint.check`'s own implementation (it doesn't need to
reshape at all to compute this), not a fundamental limitation, and it's the
same underlying mechanism behind the eager-mode limitation tracked in #71689.

It only shows up in eager because `torch.compile` disables
`Distribution.validate_args` process-wide while tracing
(`torch/_dynamo/eval_frame.py`'s `TorchPatcher.patch`, a deliberate,
long-standing Dynamo design decision to avoid data-dependent graph breaks from
distribution argument validation) — so the compiled path skips the buggy
check entirely and never reaches the crash. I confirmed that a bare
`.reshape((0, 2)-shaped tensor, (-1,))` raises the identical error under
FakeTensor propagation during Dynamo tracing, so the reshape mechanics
themselves behave identically in eager and compile; the divergence is purely
about whether that check runs at all.

## The fix

`_IndependentConstraint.check` now reduces directly over the trailing dims
using `Tensor.all(dim=<tuple of dims>)` (a native ATen overload) instead of
reshaping first:

```python
result = result.all(dim=tuple(range(-self.reinterpreted_batch_ndims, 0)))
```

This is behavior-identical to the old code for every non-degenerate shape,
and returns a well-defined empty result for zero-sized batches instead of
raising — fixing eager's own bug, which in turn restores eager/compiled
parity (both now succeed and return the same shape).

I considered instead scoping `torch.compile`'s validate_args-disabling to
only the tracing window, so eager could keep raising unaffected of
`torch.compile` ever having been invoked in the process. That's a much
larger, riskier change to shared Dynamo global-state plumbing for a
comparatively small payoff, so I went with fixing the actual reshape bug,
which is self-contained and doesn't touch Dynamo at all.

Two other constraints in the same file (`MixtureSameFamilyConstraint.check`,
`_LowerTriangular.check`) use the same reshape-then-flatten pattern and have
the same latent zero-batch bug; left untouched to keep this fix minimal and
scoped to the reported issue — worth a follow-up.

## Testing

Added:
- `test/distributions/test_constraints.py::test_independent_constraint_zero_batch` —
  direct unit test that `constraints.real_vector.check(torch.zeros(0, 2))`
  returns shape `(0,)` instead of raising.
- `test/dynamo/test_misc.py::test_torch_distributions_categorical_zero_batch_size` —
  exercises the same fix through `torch.compile` tracing, checking eager and
  compiled results match. `validate_args=True` is passed explicitly, since
  merely constructing the compiled function flips
  `Distribution._validate_args` off process-wide, which would otherwise let
  the test pass trivially regardless of the fix.

```
python test/distributions/test_constraints.py -k test_independent_constraint_zero_batch
python test/dynamo/test_misc.py -k test_torch_distributions_categorical_zero_batch_size
```

I was not able to build PyTorch from this checkout in my sandbox (no working
`cmake`, no pre-existing `.venv`/build), so I could not run these through the
project's actual test runner. I verified the fix and both new tests'
before/after behavior by monkeypatching the equivalent code into an
installed torch 2.5.1 wheel and exercising: the issue's exact repro (eager
and compiled), a normal non-degenerate-shape sanity check, and a genuinely
invalid (NaN) logits input to confirm real validation errors are still
correctly raised. `lintrunner` (RUFF, FLAKE8, PYFMT, CODESPELL, NEWLINE,
SPACES, TABS, NOQA, TYPEIGNORE, TYPENOSKIP) reports no issues on the diff.
A human reviewer should re-run the new tests against a proper build before
merging.

---

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98