### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/torch/ao/nn/quantized/functional.py
+++ b/torch/ao/nn/quantized/functional.py
@@ -96,7 +96,7 @@ def avg_pool3d(
     divisor_override=None,
 ):
     r"""
-    Applies 3D average-pooling operation in :math:`kD \ times kH \times kW` regions by step size
+    Applies 3D average-pooling operation in :math:`kD \times kH \times kW` regions by step size
     :math:`sD \times sH \times sW` steps. The number of output features is equal to the number of
     input planes.
 

--- a/torch/csrc/jit/python/python_sugared_value.h
+++ b/torch/csrc/jit/python/python_sugared_value.h
@@ -232,7 +232,7 @@ struct VISIBILITY_HIDDEN ModuleValue : public SugaredValue {
  private:
   // Check that the type of all submodules is a subtype of ty. If the function
   // returns false, more information about why it returns false (e.g. which
-  // submodule's type is not a subtype of ty) is printed it why_not if it is not
+  // submodule's type is not a subtype of ty) is printed to why_not if it is not
   // null.
   bool areAllSubmodulesSubtypeOf(
       const TypePtr& ty,

--- a/torch/csrc/jit/python/script_init.cpp
+++ b/torch/csrc/jit/python/script_init.cpp
@@ -238,7 +238,7 @@ struct PythonResolver : public Resolver {
 
   /**
    * While compiling classes, the class type we're compiling will not be
-   * available in Python, since we haven't fowner_ defining the class yet. So
+   * available in Python, since we haven't finished defining the class yet. So
    * in order to make the class type available to its own methods, we need to
    * explicitly resolve it.
    *

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -430,7 +430,7 @@ void toggleCollectionDynamic(const bool enable) {
 #ifdef USE_KINETO
   // TODO: We may want to consider adding another input arg for this function
   // if we want to support turning off certain devices and keeping others on.
-  // For now, we can keep it simple at have it turn off all tracing of "CUDA"
+  // For now, we can keep it simple and have it turn off all tracing of "CUDA"
   // devices
   libkineto::api().activityProfiler().toggleCollectionDynamic(enable);
 #endif // USE_KINETO

--- a/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
+++ b/torch/distributed/elastic/rendezvous/etcd_rendezvous.py
@@ -83,7 +83,7 @@ CONST_WORKER_KEEPALIVE_TTL = 10
 # TTL for the ephemeral run_id-specific directory. All rendezvous state data
 # for a specific run_id (job instance) is contained within directory.
 # Its only role is to clean-up rendezvous data from old runs (for the case when
-# etcd server is persistent), and has no affect on correctness, but should be
+# etcd server is persistent), and has no effect on correctness, but should be
 # larger than any timeouts that a worker process is expected to survive:
 CONST_RUNID_SUBROOT_TTL = 7200  # 2 hours
 
@@ -895,7 +895,7 @@ class EtcdRendezvous:
                     break
                 except ConnectionRefusedError:
                     # This error usually occurs during test when the server already got terminated but the
-                    # python garbage collector have not yet invoked the __del__ method.
+                    # python garbage collector has not yet invoked the __del__ method.
                     break
 
                 if stop_event.wait(timeout=ttl / 2):
@@ -963,7 +963,7 @@ class EtcdRendezvous:
                 if key in extra_data_dict:
                     return extra_data_dict[key]
 
-            # The 'extra_data' node doesn't exist, or they key isn't published yet.
+            # The 'extra_data' node doesn't exist, or the key isn't published yet.
             # Wait for interesting events on the extra_data node and retry.
             try:
                 self.client.watch(node, index=root.etcd_index + 1)
@@ -1045,7 +1045,7 @@ def create_rdzv_handler(params: RendezvousParameters) -> RendezvousHandler:
         run_id - unique id for this training job instance,
         min_nodes - min number of workers expected to join the rendezvous,
         max_nodes - max number of workers allowed to join the rendezvous,
-                        defaults to min_workers is not specified.
+                        defaults to min_workers if not specified.
         timeout - total timeout within which next_rendezvous is expected to
                       succeed; a RendezvousTimeoutError is raised otherwise;
                       Defaults is 600 (10 minutes).

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -210,7 +210,7 @@ log = logging.getLogger(__name__)
 #
 # The first instantiated test calls the original test_car() with the OpInfo
 #   for torch.add as its "op" argument, the string 'cpu' for its "device" argument,
-#   and the dtype torch.float32 for is "dtype" argument. The second instantiated
+#   and the dtype torch.float32 for its "dtype" argument. The second instantiated
 #   test calls the test_car() with the OpInfo for torch.sub, a CUDA device string
 #   like 'cuda:0' or 'cuda:1' for its "device" argument, and the dtype
 #   torch.int64 for its "dtype argument."

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -556,7 +556,7 @@ def no_batch_dim_reference_fn(m, p, *args, **kwargs):
     Currently it only supports modules which return a single Tensor as output.
     You can bind the following kwargs.
     Kwargs:
-        batch_first[bool] : If True, all the Tensors in `args` while be unsqueezed at dim `0` .
+        batch_first[bool] : If True, all the Tensors in `args` will be unsqueezed at dim `0` .
                         and output will be squeezed at dim `0` else dim `1` for both.
         kwargs_to_batchify[dict] : Dictionary specifying the name of the argument and dimension to unsqueeze.
                                Useful if there are few arguments whose batch dimension are different


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194627

Corrects a handful of typographical errors in comments and documentation
strings across quantized functional ops, the JIT Python bindings, the
profiler Kineto shim, the etcd rendezvous handler, and the internal
testing helpers. One of these also repairs a malformed `\times` in the
`avg_pool3d` docstring math, which previously rendered incorrectly in the
generated docs.

No functional changes.

Test Plan: No behavior is affected; existing CI coverage suffices. Docs
rendering for the `avg_pool3d` math expression was checked by inspection
of the corrected RST math directive.

This change was authored with the assistance of an AI coding assistant.