### PR TITLE
[FSDP2] Hold HSDP microbatch partial sums at grad_dtype

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py
@@ -561,6 +561,54 @@ class TestFullyShardMixedPrecisionTraining(FSDPTest):
         for param in model.parameters():
             self.assertEqual(param.grad_dtype, torch.float32)
 
+    @skip_if_lt_x_gpu(4)
+    def test_hsdp_partial_reduce_dtype(self):
+        """With a deferred all-reduce the microbatch partial sums are held
+        across backward calls. At reduce_dtype they round once per microbatch,
+        so an explicit wider grad_dtype widens the buffer."""
+        mesh = init_device_mesh(
+            device_type.type,
+            (2, self.world_size // 2),
+            mesh_dim_names=("dp_replicate", "dp_shard"),
+        )
+        torch.manual_seed(42)
+        model = nn.Sequential(*[MLP(16, torch.device("cpu")) for _ in range(3)])
+        model.to(device=device_type, dtype=torch.bfloat16)
+        # Leave the first parameter of each group at the default so the group is
+        # non-uniform: the shared buffer must widen to what any parameter needs,
+        # not to whatever the first one happens to be.
+        for mlp in model:
+            for idx, param in enumerate(mlp.parameters()):
+                if idx > 0:
+                    param.grad_dtype = torch.float32
+        mp_policy = MixedPrecisionPolicy(reduce_dtype=torch.bfloat16)
+        for mlp in model:
+            fully_shard(mlp, mesh=mesh, mp_policy=mp_policy)
+        fully_shard(model, mesh=mesh, mp_policy=mp_policy)
+
+        torch.manual_seed(42 + self.rank + 1)
+        num_microbatches = 3
+        microbatch_inps = torch.randn(
+            2 * num_microbatches, 16, device=device_type, dtype=torch.bfloat16
+        ).chunk(num_microbatches)
+        partial_dtypes = set()
+        for microbatch_idx in range(num_microbatches):
+            model.set_requires_all_reduce(microbatch_idx == num_microbatches - 1)
+            model(microbatch_inps[microbatch_idx]).sum().backward()
+            for module in model.modules():
+                state = _get_module_fsdp_state(module)
+                if state is None or state._fsdp_param_group is None:
+                    continue
+                partial = state._fsdp_param_group._partial_reduce_output
+                if partial is not None:
+                    partial_dtypes.add(partial.dtype)
+
+        self.assertEqual(partial_dtypes, {torch.float32})
+        for mlp in model:
+            for idx, param in enumerate(mlp.parameters()):
+                expected = torch.bfloat16 if idx == 0 else torch.float32
+                self.assertEqual(param.grad.dtype, expected)
+
     @skip_if_lt_x_gpu(2)
     def test_structured_input_output(self):
         """

--- a/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
+++ b/torch/distributed/fsdp/_fully_shard/_fsdp_collectives.py
@@ -646,7 +646,13 @@ def foreach_reduce(
                 if partial_reduce_output is not None:
                     partial_reduce_output += reduce_output
                 else:
-                    partial_reduce_output = reduce_output
+                    # Holding the partial sum at `reduce_dtype` rounds once per
+                    # microbatch, and that error compounds with the microbatch
+                    # count. Widen it the same way the no-collectives no-sync
+                    # path widens its accumulator, so the two cannot diverge.
+                    partial_reduce_output = _to_dtype_if_needed(
+                        reduce_output, _partial_reduce_dtype(fsdp_params)
+                    )
                 return (
                     reduce_scatter_input,
                     reduce_scatter_event,
@@ -801,6 +807,21 @@ def foreach_reduce(
         all_reduce_event,
         None,
     )
+
+
+def _partial_reduce_dtype(fsdp_params: list[FSDPParam]) -> torch.dtype | None:
+    """Widest accumulation dtype any parameter in the group needs.
+
+    The buffer is shared by the whole group and a group may carry different
+    grad_dtype, so `fsdp_params[0]` is not representative. `itemsize` rather
+    than `torch.promote_types`, which raises for float8.
+    """
+    widest: torch.dtype | None = None
+    for fsdp_param in fsdp_params:
+        dtype = fsdp_param._accumulate_grad_dtype
+        if dtype is not None and (widest is None or dtype.itemsize > widest.itemsize):
+            widest = dtype
+    return widest
 
 
 def foreach_reduce_scatter_copy_in(


### PR DESCRIPTION
Stacked on the previous two PRs. With HSDP and set_requires_all_reduce(False),
the reduce-scatter still runs every microbatch and the partial sums are held in
partial_reduce_output across backward calls until the deferred all-reduce. That
buffer is allocated at reduce_dtype, so each microbatch's contribution is
rounded into it and the error compounds with the microbatch count, even when
the user asked for a wider grad_dtype.

This is a different path from the accumulation fix in the previous PR, which
covers set_requires_gradient_sync(False) -- the mode that runs no collectives.
The two no-sync modes take different code paths and only the first was covered.

It reuses FSDPParam._accumulate_grad_dtype, the same rule the no-collectives
path uses, so the two accumulators cannot drift apart. The buffer is shared by
the whole group and the previous PR allows a group to carry different
grad_dtype, so it widens to whatever any parameter needs rather than reading
fsdp_params[0], which is not representative. Beyond that: the buffer is never
narrowed below reduce_dtype, which would make accumulation worse than ignoring
grad_dtype entirely. When grad_dtype is unset or is not wider than
reduce_dtype this is a no-op, so nobody who did not ask for the precision pays
the extra memory -- the buffer is sharded-gradient sized and held for the whole
accumulation window, so widening it is not free.

The all-reduce still runs at reduce_dtype, so one rounding remains by design;
widening it would contradict an explicit reduce_dtype.

Test Plan:

```
python -m pytest test/distributed/_composable/fsdp/test_fully_shard_mixed_precision.py -q
# 18 passed in 105.07s
```

The new test fails against the previous PR's source (`git stash push -- torch/`):

```
1 failed, 17 deselected
```

Measured on 4xH100, 2x2 mesh, bf16 parameters, grad_dtype=fp32,
reduce_dtype=bf16, against a reference that mirrors the reduce pipeline but
accumulates in fp32:

    microbatches    before        after
     8              7.143e-03     5.814e-03
    32              1.143e-02     5.714e-03

The point is not the ratio but the shape: after the change the error no longer
grows with the microbatch count. The residual ~5.7e-3 is the per-microbatch
reduce-scatter rounding, inherent to reduce_dtype=bf16. Peak memory on that
config goes from 224.2 MiB to 232.2 MiB.

Authored with assistance from Claude Code (Anthropic).
