### PR TITLE
[inductor] Update dynamic vision_maskrcnn graph break baselines

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_inference.csv
@@ -266,7 +266,7 @@ vgg16,pass,0
 
 
 
-vision_maskrcnn,fail_to_run,18
+vision_maskrcnn,fail_to_run,15
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_torchbench_training.csv
@@ -190,7 +190,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,fail_to_run,38
+vision_maskrcnn,fail_to_run,33
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_inference.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_inference.csv
@@ -269,7 +269,7 @@ vgg16,eager_two_runs_differ,0
 
 
 
-vision_maskrcnn,fail_to_run,18
+vision_maskrcnn,fail_to_run,15
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_training.csv
@@ -193,7 +193,7 @@ vgg16,pass,6
 
 
 
-vision_maskrcnn,fail_to_run,38
+vision_maskrcnn,fail_to_run,33
 
 
 


### PR DESCRIPTION
Human Context: fixing inductor periodic

## Summary

`Fix Dynamo tracing of compile support checks` (#185528) reduced
`vision_maskrcnn` graph breaks from 18 to 15 for inference and from 38 to 33
for training. It updated the regular TorchBench baselines but missed their
dynamic CUDA and ROCm counterparts.

Because `check_graph_breaks.py` intentionally rejects improvements until the
baseline is updated, this has caused repeated Inductor periodic failures. This
PR aligns all four dynamic baselines with the observed counts.

## Test Plan

```text
python benchmarks/dynamo/check_graph_breaks.py --actual /tmp/pytorch-work/agent_space/pt2-oncall/run-32730575308/rocm-reports/test-reports/inference_torchbench.csv --expected benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_torchbench_inference.csv
spin quicklint
lintrunner -a
```

The checker reports `vision_maskrcnn PASS` against the failed ROCm periodic
artifact.

This PR was authored with assistance from an AI coding assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98