### PR TITLE
[inductor] Honor assume_32bit_indexing in _decide_tl_dtype

### DIFF
--- a/torch/_inductor/codegen/triton_utils.py
+++ b/torch/_inductor/codegen/triton_utils.py
@@ -237,9 +237,13 @@ def signature_to_meta(
         # tl.int32 whenever the (deprecated) block-pointer path is actually
         # active. Templates like flex attention/decoding likewise use
         # hand-written block pointers, so they also stay on 32-bit ks indexing.
+        #
+        # assume_32bit_indexing already asserts (and guards) that every ks* symbol
+        # fits in int32.
         if (
             not is_template
             and not use_block_ptr_enabled()
+            and not config.assume_32bit_indexing
             and isinstance(arg, SizeArg)
             and arg.name.startswith("ks")
         ):


### PR DESCRIPTION

Summary:
When block pointers are disabled, `_decide_tl_dtype` widens dynamic-shape size
arguments (`ks*`) to `tl.int64` to guard against overflow in products such as
`ks0 * ks1` in the kernel's index arithmetic.

`assume_32bit_indexing` is the user asserting that every index fits in int32.
The assertion is enforced rather than merely trusted: `expr_fits_within_32bit`
emits a `check_leq` against `INT32_MAX` and throws if the example inputs
contradict it. A backend that sets the flag may have no 64-bit indexing at all,
so the widening must not silently override the guarantee. Further, since block
access is gated by a check for tl.int32 dtype for dynamic shape-size args,
honoring the assume_32bit_indexing flag enables block access for backends
setting the flag.

This adds `and not config.assume_32bit_indexing` to the condition. The flag is
`False` by default, so codegen is unchanged unless it is explicitly set.

Test Plan:
`buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:codegen_triton`
Pass 33. Fail 0. (2 skipped, HIP-only.)

`buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:config`
Pass 26. Fail 0.

Differential Revision: D116687730


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo