### PR TITLE
[AOTI][FlyDSL] Wrap launchers for export

### DIFF
--- a/docs/source/library.md
+++ b/docs/source/library.md
@@ -167,6 +167,7 @@ relationships.
 .. autofunction:: custom_op
 .. autofunction:: triton_op
 .. autofunction:: wrap_triton
+.. autofunction:: wrap_flydsl
 ```
 
 ## Extending custom ops (created from Python or C++)

--- a/test/inductor/flydsl_aot/test_flydsl_aot_compiler.py
+++ b/test/inductor/flydsl_aot/test_flydsl_aot_compiler.py
@@ -1,0 +1,326 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import ctypes
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, cast
+from unittest import mock
+
+import torch
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch.testing._internal.common_utils import TestCase
+
+
+HAS_FLYDSL = runtime_available()
+if HAS_FLYDSL:
+    import flydsl.compiler as flyc
+    import flydsl.expr as fx
+    from flydsl._mlir import execution_engine, ir
+    from flydsl.compiler import backends, jit_executor, jit_function, protocol
+    from flydsl.compiler.jit_argument import PointerJitArg, TorchTensorJitArg
+
+if HAS_FLYDSL:
+    from torch._inductor.codegen.flydsl.aot_compile import (
+        _argument_abi,
+        _bundle_runtime_libraries,
+        _publish_runtime_library,
+        compile_aot,
+        CompiledAOTLauncher,
+    )
+
+
+class _FakeExecutionEngine:
+    module_text = ""
+    enable_pic = False
+
+    def __init__(self, module, *, opt_level, shared_libs, enable_pic=False):
+        self.__class__.module_text = str(module)
+        self.__class__.enable_pic = enable_pic
+
+    def dump_to_object_file(self, path):
+        Path(path).write_bytes(b"flydsl-object")
+
+
+@unittest.skipUnless(HAS_FLYDSL, "FlyDSL is not available")
+class FlyDSLAOTCompilerTest(TestCase):
+    def _compiled_launcher(self):
+        with ir.Context() as ctx:
+            ctx.load_all_available_dialects()
+            module = ir.Module.parse(
+                """
+                module {
+                  llvm.func @launcher() {
+                    llvm.return
+                  }
+                }
+                """
+            )
+            return CompiledAOTLauncher(
+                module,
+                "launcher",
+                (
+                    {
+                        "arg_index": 0,
+                        "arg_name": "out",
+                        "kind": "tensor_data",
+                        "ctype": "pointer",
+                        "size": 8,
+                        "alignment": 8,
+                    },
+                ),
+            )
+
+    def test_export_uses_packed_entry_and_explicit_module_symbols(self):
+        _FakeExecutionEngine.enable_pic = False
+        compiled = self._compiled_launcher()
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch.object(
+                execution_engine,
+                "ExecutionEngine",
+                _FakeExecutionEngine,
+            ),
+            mock.patch.object(
+                jit_executor,
+                "_resolve_runtime_libs",
+                return_value=["/runtime/libfly_jit_runtime.so"],
+            ),
+            mock.patch(
+                "torch._inductor.codegen.flydsl.aot_compile._rename_loader_symbols",
+                return_value=("launcher__init", "launcher__load"),
+            ) as rename_loader_symbols,
+            mock.patch(
+                "torch._inductor.codegen.flydsl.aot_compile._bundle_runtime_libraries",
+                return_value=["/runtime/libfly_jit_runtime.so"],
+            ),
+        ):
+            output = Path(tmpdir) / "kernel.o"
+            metadata = compiled.export_to_c(str(output), "flydsl_test_launcher")
+
+            self.assertEqual(b"flydsl-object", output.read_bytes())
+            self.assertEqual("_mlir_flydsl_test_launcher", metadata["symbol"])
+            self.assertEqual("launcher__init", metadata["module_init_symbol"])
+            self.assertEqual("launcher__load", metadata["module_load_symbol"])
+            self.assertTrue(_FakeExecutionEngine.enable_pic)
+            self.assertIn("@flydsl_test_launcher", _FakeExecutionEngine.module_text)
+            self.assertNotIn("@launcher", _FakeExecutionEngine.module_text)
+            rename_loader_symbols.assert_called_once_with(
+                output,
+                "flydsl_test_launcher",
+            )
+
+    def test_runtime_bundle_includes_sonames_and_flydsl_dependencies(self):
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            tempfile.TemporaryDirectory() as system_tmpdir,
+        ):
+            root = Path(tmpdir)
+            mlir_libs = root / "flydsl" / "_mlir" / "_mlir_libs"
+            wheel_libs = root / "flydsl.libs"
+            output_dir = root / "output"
+            mlir_libs.mkdir(parents=True)
+            wheel_libs.mkdir()
+            output_dir.mkdir()
+            runtime = mlir_libs / "libmlir_c_runner_utils.so"
+            float16 = mlir_libs / "libmlir_float16_utils.so.23"
+            apfloat = wheel_libs / "libmlir_apfloat.so.23"
+            system = Path(system_tmpdir) / "libc.so.6"
+            for path in (runtime, float16, apfloat, system):
+                path.write_bytes(path.name.encode())
+
+            with (
+                mock.patch(
+                    "torch._inductor.codegen.flydsl.aot_compile._elf_soname",
+                    return_value="libmlir_c_runner_utils.so.23",
+                ),
+                mock.patch(
+                    "torch._inductor.codegen.flydsl.aot_compile._runtime_library_dependencies",
+                    return_value={
+                        float16.name: float16,
+                        apfloat.name: apfloat,
+                        system.name: system,
+                    },
+                ),
+            ):
+                bundled = _bundle_runtime_libraries([str(runtime)], output_dir)
+
+            self.assertCountEqual(
+                [
+                    str(output_dir / "libmlir_c_runner_utils.so.23"),
+                    str(output_dir / float16.name),
+                    str(output_dir / apfloat.name),
+                ],
+                bundled,
+            )
+            self.assertFalse((output_dir / system.name).exists())
+
+    def test_runtime_library_publication_is_atomic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            first = root / "first.so"
+            second = root / "second.so"
+            destination = root / "runtime.so"
+            first.write_bytes(b"first runtime")
+            second.write_bytes(b"second runtime")
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [
+                    executor.submit(_publish_runtime_library, source, destination)
+                    for source in (first, second)
+                ]
+                errors = [future.exception() for future in futures]
+
+            self.assertEqual(1, sum(error is None for error in errors))
+            self.assertEqual(
+                1, sum(isinstance(error, RuntimeError) for error in errors)
+            )
+            self.assertIn(
+                destination.read_bytes(), (first.read_bytes(), second.read_bytes())
+            )
+
+    def test_export_rejects_invalid_symbol(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "invalid C function name"):
+                self._compiled_launcher().export_to_c(
+                    str(Path(tmpdir) / "kernel.o"),
+                    "not-a-c-symbol",
+                )
+
+    def test_tensor_abi_describes_dynamic_layout(self):
+        tensor = cast(Any, torch).empty_strided((2, 3), (5, 1))
+
+        slots = _argument_abi(TorchTensorJitArg(tensor))
+
+        self.assertEqual("tensor_data", slots[0]["kind"])
+        self.assertEqual("tensor_layout", slots[1]["kind"])
+        self.assertEqual([0, 1], slots[1]["shape_dims"])
+        self.assertEqual([0], slots[1]["stride_dims"])
+        self.assertEqual(64, slots[1]["stride_bits"])
+
+    def test_integer_abi_uses_fixed_width_names(self):
+        self.assertEqual("bool", _argument_abi(fx.Boolean(True))[0]["ctype"])
+        self.assertEqual("int32", _argument_abi(fx.Int32(1))[0]["ctype"])
+        self.assertEqual("uint64", _argument_abi(fx.Uint64(1))[0]["ctype"])
+
+    def test_pointer_and_floating_point_abi(self):
+        pointer = object.__new__(PointerJitArg)
+
+        self.assertEqual(
+            [{"kind": "pointer", "ctype": "pointer", "size": 8, "alignment": 8}],
+            _argument_abi(pointer),
+        )
+        self.assertEqual(
+            "float16_bits",
+            _argument_abi(fx.Float16(1.0))[0]["encoding"],
+        )
+        self.assertEqual(
+            "bfloat16_bits",
+            _argument_abi(fx.BFloat16(1.0))[0]["encoding"],
+        )
+        self.assertEqual("float", _argument_abi(fx.Float32(1.0))[0]["ctype"])
+        self.assertEqual("double", _argument_abi(fx.Float64(1.0))[0]["ctype"])
+
+    def test_abi_rejects_unsupported_and_multi_slot_arguments(self):
+        with self.assertRaisesRegex(NotImplementedError, "unsupported JIT argument"):
+            _argument_abi(object())
+
+        with (
+            mock.patch.object(
+                protocol,
+                "c_abi_spec",
+                return_value=[
+                    (ctypes.c_int32, mock.Mock()),
+                    (ctypes.c_int32, mock.Mock()),
+                ],
+            ),
+            self.assertRaisesRegex(NotImplementedError, "exactly one C ABI slot"),
+        ):
+            _argument_abi(fx.Int32(1))
+
+    def test_compile_aot_does_not_dispatch_launcher(self):
+        @flyc.jit
+        def launcher(
+            inp: fx.Tensor,
+            block_dim: fx.Constexpr[int],
+            *,
+            rows: fx.Int32,
+        ):
+            pass
+
+        backend = mock.Mock()
+        backend.target.arch = "gfx950"
+        backend.gpu_module_targets.return_value = []
+        with (
+            mock.patch.object(
+                type(launcher),
+                "__call__",
+                side_effect=AssertionError("AOT compilation dispatched the launcher"),
+            ),
+            mock.patch.object(
+                backends,
+                "get_backend",
+                return_value=backend,
+            ),
+            mock.patch.object(
+                jit_function.MlirCompiler,
+                "compile",
+                side_effect=lambda module, **_kwargs: module,
+            ),
+        ):
+            compiled = compile_aot(
+                launcher,
+                cast(Any, torch).empty(8, device="meta"),
+                256,
+                rows=8,
+            )
+
+        self.assertIsInstance(compiled, CompiledAOTLauncher)
+        self.assertEqual(
+            ["tensor_data", "tensor_layout", "scalar", "stream"],
+            [slot["kind"] for slot in compiled.abi],
+        )
+        self.assertNotIn("block_dim", {slot["arg_name"] for slot in compiled.abi})
+
+    def test_compile_aot_traces_multiple_kernel_launches(self):
+        @flyc.kernel
+        def first_kernel():
+            pass
+
+        @flyc.kernel
+        def second_kernel():
+            pass
+
+        @flyc.jit
+        def launcher():
+            first_kernel().launch(grid=(1, 1, 1), block=(1, 1, 1))
+            second_kernel().launch(grid=(1, 1, 1), block=(1, 1, 1))
+
+        backend = mock.Mock()
+        backend.target.arch = "gfx950"
+        backend.gpu_module_targets.return_value = []
+        with (
+            mock.patch.object(
+                backends,
+                "get_backend",
+                return_value=backend,
+            ),
+            mock.patch.object(
+                jit_function.MlirCompiler,
+                "compile",
+                side_effect=lambda module, **_kwargs: module,
+            ),
+        ):
+            compiled = compile_aot(launcher)
+
+        self.assertEqual(2, compiled._ir_text.count("gpu.launch_func"))
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/test/inductor/flydsl_aot/test_flydsl_capture.py
+++ b/test/inductor/flydsl_aot/test_flydsl_capture.py
@@ -1,0 +1,480 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import inspect
+import unittest
+from collections.abc import Callable
+from unittest import mock
+
+import torch
+from torch._higher_order_ops.flydsl_kernel_wrap import (
+    flydsl_kernel_wrapper_functional,
+    flydsl_kernel_wrapper_mutation,
+    flydsl_launcher_side_table,
+    invoke_flydsl_launcher,
+    restore_flydsl_launcher_arguments,
+    split_flydsl_launcher_arguments,
+    TraceableFlyDSLLauncher,
+)
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch.testing._internal.common_utils import TestCase
+
+
+HAS_FLYDSL = runtime_available()
+if HAS_FLYDSL:
+    import flydsl.compiler as flyc
+    import flydsl.expr as fx
+    from flydsl.compiler.jit_argument import PointerJitArg
+    from flydsl.expr.typing import Stream
+
+
+if HAS_FLYDSL:
+
+    @flyc.jit
+    def _launcher(out: fx.Tensor, inp: fx.Tensor, rows: fx.Int32):
+        pass
+
+else:
+    _launcher = None
+
+
+class _EagerLauncher:
+    def __init__(self) -> None:
+        self.func = self.launch
+
+    def launch(
+        self,
+        out: torch.Tensor,
+        workspace: torch.Tensor,
+        inp: torch.Tensor,
+    ) -> None:
+        out.copy_(inp)
+        workspace.fill_(7)
+
+    def __call__(
+        self,
+        out: torch.Tensor,
+        workspace: torch.Tensor,
+        inp: torch.Tensor,
+    ) -> None:
+        self.launch(out, workspace, inp)
+
+
+@unittest.skipUnless(HAS_FLYDSL, "FlyDSL is not available")
+class FlyDSLCaptureTest(TestCase):
+    def setUp(self):
+        flydsl_launcher_side_table.reset_table()
+        torch._dynamo.reset()
+
+    def test_export_captures_explicit_launcher(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured_launcher(out=out, inp=inp, rows=inp.numel())
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+        self.assertEqual(1, len(nodes))
+        self.assertEqual((0,), nodes[0].kwargs["mutated_arg_indices"])
+
+    def test_mutations_must_be_explicit(self):
+        with self.assertRaisesRegex(TypeError, "mutates_args"):
+            torch.library.wrap_flydsl(_launcher)
+
+    def test_repeated_wrap_reuses_registration(self):
+        first = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+        second = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+        different_mutations = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out", "inp"},
+        )
+
+        self.assertEqual(first.launcher_idx, second.launcher_idx)
+        self.assertNotEqual(first.launcher_idx, different_mutations.launcher_idx)
+
+    def test_capture_rejects_unknown_mutated_argument(self):
+        with self.assertRaisesRegex(ValueError, "not launcher parameters"):
+            torch.library.wrap_flydsl(
+                _launcher,
+                mutates_args={"missing"},
+            )
+
+    def test_wrap_rejects_non_jit_function(self):
+        with self.assertRaisesRegex(RuntimeError, "annotated with flydsl.compiler.jit"):
+            torch.library.wrap_flydsl(lambda: None, mutates_args=())
+
+    def test_wrap_reports_missing_optional_runtime(self):
+        with (
+            mock.patch(
+                "torch._inductor.codegen.flydsl.flydsl_utils.runtime_available",
+                return_value=False,
+            ) as available,
+            self.assertRaisesRegex(RuntimeError, "optional `flydsl` runtime"),
+        ):
+            torch.library.wrap_flydsl(object(), mutates_args=())
+
+        available.assert_called_once_with()
+
+    def test_wrap_rejects_explicit_stream(self):
+        @flyc.jit
+        def launcher(out: fx.Tensor, stream: Stream):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "current device stream"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+    def test_split_launcher_arguments_preserves_parameter_kinds(self):
+        def launcher(out, /, inp, *, rows):
+            pass
+
+        positional, keyword = split_flydsl_launcher_arguments(
+            inspect.signature(launcher),
+            ("out", "inp", 8),
+        )
+
+        self.assertEqual(("out", "inp"), positional)
+        self.assertEqual({"rows": 8}, keyword)
+
+    def test_split_launcher_arguments_rejects_variadic_parameters(self):
+        @flyc.jit
+        def launcher(out: fx.Tensor, *inputs: fx.Tensor):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "variadic parameters cannot be wrapped"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+    def test_export_captures_dynamic_dimension(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured_launcher(out, inp, inp.numel())
+                return out
+
+        batch = torch.export.Dim("batch", min=1, max=32)
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(4, 8),),
+            dynamic_shapes=({0: batch},),
+        )
+
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+        self.assertEqual(1, len(nodes))
+        self.assertTrue(exported.range_constraints)
+        rows = nodes[0].kwargs["args"][2]
+        self.assertIsInstance(rows, torch.fx.Node)
+        self.assertIsInstance(rows.meta["val"], torch.SymInt)
+
+    def test_export_keeps_compile_time_arguments_out_of_fx(self):
+        callback = lambda value: value  # noqa: E731
+
+        @flyc.jit
+        def launcher(
+            out: fx.Tensor,
+            inp: fx.Tensor,
+            transform: fx.Constexpr[Callable],
+            element_type: type[fx.Float32],
+            block_dim: fx.Constexpr[int],
+        ):
+            pass
+
+        captured = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured(out, inp, callback, fx.Float32, 256)
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        (node,) = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        runtime_args = node.kwargs["args"]
+        self.assertEqual((None, None, None), runtime_args[2:])
+        restored = restore_flydsl_launcher_arguments(
+            runtime_args,
+            node.kwargs["call_spec_idx"],
+        )
+        self.assertIs(callback, restored[2])
+        self.assertIs(fx.Float32, restored[3])
+        self.assertEqual(256, restored[4])
+
+    def test_constexpr_call_specs_use_flydsl_value_identity(self):
+        @flyc.jit
+        def launcher(out: fx.Tensor, config: fx.Constexpr[tuple]):
+            pass
+
+        captured = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                first = torch.empty_like(inp)
+                second = torch.empty_like(inp)
+                captured(first, (True,))
+                captured(second, (1,))
+                return first, second
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        self.assertEqual(2, len(nodes))
+        self.assertEqual(
+            [(True,), (1,)],
+            [
+                restore_flydsl_launcher_arguments(
+                    node.kwargs["args"],
+                    node.kwargs["call_spec_idx"],
+                )[1]
+                for node in nodes
+            ],
+        )
+        self.assertNotEqual(
+            nodes[0].kwargs["call_spec_idx"],
+            nodes[1].kwargs["call_spec_idx"],
+        )
+
+    def test_wrap_rejects_preconstructed_runtime_jit_arguments(self):
+        captured = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+        out = torch.empty(4)
+        inp = torch.empty(4)
+
+        for value in (fx.Int32(4), object.__new__(PointerJitArg)):
+            with self.assertRaisesRegex(TypeError, "graphable PyTorch values"):
+                captured(out, inp, value)
+
+    def test_wrap_rejects_non_tensor_mutation(self):
+        @flyc.jit
+        def launcher(value: fx.Int32):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "flydsl.expr.Tensor annotation"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"value"})
+
+    def test_wrap_rejects_unannotated_mutation(self):
+        @flyc.jit
+        def launcher(value):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "flydsl.expr.Tensor annotation"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"value"})
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a GPU")
+    def test_eager_wrap_rejects_non_default_stream(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+        out = torch.empty(4, device="cuda")
+        workspace = torch.empty(4, device="cuda")
+        inp = torch.empty(4, device="cuda")
+
+        with (
+            torch.cuda.stream(torch.cuda.Stream()),
+            self.assertRaisesRegex(RuntimeError, "default device stream"),
+        ):
+            flydsl_kernel_wrapper_mutation(
+                registration.launcher_idx,
+                call_spec_idx,
+                (out, workspace, inp),
+                (0, 1),
+            )
+
+    def test_export_registers_and_deduplicates_compile_time_call_specs(self):
+        @flyc.jit
+        def launcher(
+            out: fx.Tensor,
+            inp: fx.Tensor,
+            block_dim: fx.Constexpr[int],
+        ):
+            pass
+
+        captured = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                first = torch.empty_like(inp)
+                second = torch.empty_like(inp)
+                third = torch.empty_like(inp)
+                captured(first, inp, 64)
+                captured(second, inp, 128)
+                captured(third, inp, 64)
+                return first, second, third
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        self.assertEqual(3, len(nodes))
+        self.assertEqual(
+            [64, 128, 64],
+            [
+                restore_flydsl_launcher_arguments(
+                    node.kwargs["args"],
+                    node.kwargs["call_spec_idx"],
+                )[2]
+                for node in nodes
+            ],
+        )
+        self.assertEqual(
+            nodes[0].kwargs["call_spec_idx"],
+            nodes[2].kwargs["call_spec_idx"],
+        )
+        self.assertNotEqual(
+            nodes[0].kwargs["call_spec_idx"],
+            nodes[1].kwargs["call_spec_idx"],
+        )
+
+    def test_export_captures_bound_jit_method_without_self_operand(self):
+        class LauncherOwner:
+            @flyc.jit
+            def launch(self, out: fx.Tensor, inp: fx.Tensor, rows: fx.Int32):
+                pass
+
+        owner = LauncherOwner()
+        captured = torch.library.wrap_flydsl(owner.launch, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured(out, inp, inp.numel())
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        (node,) = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        registration = flydsl_launcher_side_table.get_registration(
+            node.kwargs["launcher_idx"]
+        )
+        self.assertIs(owner, registration.bound_self)
+        self.assertEqual(3, len(node.kwargs["args"]))
+        with mock.patch.object(
+            type(registration.launcher),
+            "__call__",
+            autospec=True,
+        ) as launch:
+            invoke_flydsl_launcher(registration, ("out", "inp", 8))
+        launch.assert_called_once_with(
+            registration.launcher,
+            owner,
+            "out",
+            "inp",
+            8,
+        )
+
+    def test_hop_reports_tensor_subclass_once(self):
+        class TensorSubclass(torch.Tensor):
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                return NotImplemented
+
+        tensor = TensorSubclass._make_subclass(
+            TensorSubclass,
+            torch.ones(4),
+            False,
+        )
+        self.assertTrue(torch._C._dispatch_keys(tensor).has("Python"))
+
+        overloaded = flydsl_kernel_wrapper_mutation._get_overloaded_args(
+            (),
+            {"args": (tensor,)},
+        )
+
+        self.assertEqual(1, len(overloaded))
+        self.assertIs(tensor, overloaded[0])
+
+    def test_functional_wrapper_clones_only_requested_outputs(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        out = torch.empty(4)
+        workspace = torch.zeros(4)
+        inp = torch.arange(4, dtype=torch.float32)
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+
+        actual_out, actual_workspace = flydsl_kernel_wrapper_functional(
+            registration.launcher_idx,
+            call_spec_idx,
+            (out, workspace, inp),
+            (0, 1),
+            (1,),
+        )
+
+        torch.testing.assert_close(out, inp)
+        self.assertEqual(actual_out.data_ptr(), out.data_ptr())
+        torch.testing.assert_close(workspace, torch.zeros_like(workspace))
+        torch.testing.assert_close(actual_workspace, torch.full_like(workspace, 7))
+        self.assertNotEqual(actual_workspace.data_ptr(), workspace.data_ptr())
+
+    def test_functional_wrapper_rejects_identical_aliased_arguments(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        tensor = torch.zeros(4)
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+
+        with self.assertRaisesRegex(RuntimeError, "aliased launcher arguments"):
+            flydsl_kernel_wrapper_functional(
+                registration.launcher_idx,
+                call_spec_idx,
+                (tensor, tensor, tensor),
+                (0, 1),
+                (0, 1),
+            )
+
+    def test_functional_wrapper_rejects_view_alias(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        base = torch.zeros(8)
+        out = base[:4]
+        workspace = torch.zeros(4)
+        inp = base[2:6]
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+
+        with self.assertRaisesRegex(RuntimeError, "aliased launcher arguments"):
+            flydsl_kernel_wrapper_functional(
+                registration.launcher_idx,
+                call_spec_idx,
+                (out, workspace, inp),
+                (0, 1),
+                (0,),
+            )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torch/_higher_order_ops/flydsl_kernel_wrap.py
+++ b/torch/_higher_order_ops/flydsl_kernel_wrap.py
@@ -1,0 +1,594 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+import inspect
+import threading
+from dataclasses import dataclass
+from typing import Any, cast, TYPE_CHECKING
+
+import torch
+import torch.utils._pytree as pytree
+from torch import Tensor
+from torch._higher_order_ops.utils import register_fake
+from torch._ops import HigherOrderOperator
+from torch._prims_common import clone_preserve_strides
+from torch.fx.experimental.proxy_tensor import (
+    disable_proxy_modes_tracing,
+    ProxyTorchDispatchMode,
+    track_tensor_tree,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch._subclasses.functional_tensor import BaseFunctionalizeAPI
+
+
+DispatchKey = cast(Any, torch._C).DispatchKey
+
+
+@dataclass(frozen=True)
+class FlyDSLLauncherRegistration:
+    launcher: Any
+    bound_self: Any
+    signature: inspect.Signature
+    mutated_arg_indices: tuple[int, ...]
+    compile_time_arg_indices: frozenset[int]
+    constexpr_arg_indices: frozenset[int]
+    constexpr_value_signature: Callable[[Any], Any] | None
+    stream_type: type[Any] | None
+    jit_argument_type: type[Any] | None
+
+
+class TraceableFlyDSLLauncher:
+    def __init__(
+        self,
+        launcher: Any,
+        mutated_arg_indices: tuple[int, ...],
+        *,
+        bound_self: Any = None,
+        signature: inspect.Signature | None = None,
+        compile_time_arg_indices: frozenset[int] = frozenset(),
+        constexpr_arg_indices: frozenset[int] = frozenset(),
+        constexpr_value_signature: Callable[[Any], Any] | None = None,
+        stream_type: type[Any] | None = None,
+        jit_argument_type: type[Any] | None = None,
+    ) -> None:
+        if signature is None:
+            signature = inspect.signature(launcher.func)
+        registration = FlyDSLLauncherRegistration(
+            launcher,
+            bound_self,
+            signature,
+            mutated_arg_indices,
+            compile_time_arg_indices,
+            constexpr_arg_indices,
+            constexpr_value_signature,
+            stream_type,
+            jit_argument_type,
+        )
+        self.launcher_idx = flydsl_launcher_side_table.add_launcher(registration)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        registration = flydsl_launcher_side_table.get_registration(self.launcher_idx)
+        bound = registration.signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        runtime_args, call_spec_idx = partition_flydsl_launcher_arguments(
+            registration,
+            tuple(bound.arguments.values()),
+        )
+        flydsl_kernel_wrapper_mutation(
+            self.launcher_idx,
+            call_spec_idx,
+            runtime_args,
+            registration.mutated_arg_indices,
+        )
+
+
+class FlyDSLLauncherSideTable:
+    def __init__(self) -> None:
+        self.id_to_launcher: dict[int, FlyDSLLauncherRegistration] = {}
+        self.launcher_to_id: dict[tuple[int, int | None, tuple[int, ...]], int] = {}
+        self.id_to_call_spec: dict[int, dict[int, Any]] = {}
+        self.call_spec_to_id: dict[tuple[Any, ...], int] = {}
+        self.lock = threading.Lock()
+
+    def add_launcher(self, registration: FlyDSLLauncherRegistration) -> int:
+        key = (
+            id(registration.launcher),
+            (
+                id(registration.bound_self)
+                if registration.bound_self is not None
+                else None
+            ),
+            registration.mutated_arg_indices,
+        )
+        with self.lock:
+            if key in self.launcher_to_id:
+                return self.launcher_to_id[key]
+            idx = len(self.id_to_launcher)
+            self.id_to_launcher[idx] = registration
+            self.launcher_to_id[key] = idx
+            return idx
+
+    def get_registration(self, idx: int) -> FlyDSLLauncherRegistration:
+        if idx not in self.id_to_launcher:
+            raise AssertionError(f"FlyDSL launcher index {idx} was not registered")
+        return self.id_to_launcher[idx]
+
+    def get_launcher(self, idx: int) -> Any:
+        return self.get_registration(idx).launcher
+
+    def add_call_spec(
+        self,
+        constant_args: dict[int, Any],
+        key: tuple[Any, ...] | None = None,
+    ) -> int:
+        if key is None:
+            key = tuple(
+                (idx, _constant_key(value)) for idx, value in constant_args.items()
+            )
+        with self.lock:
+            if key in self.call_spec_to_id:
+                return self.call_spec_to_id[key]
+            idx = len(self.id_to_call_spec)
+            self.id_to_call_spec[idx] = constant_args
+            self.call_spec_to_id[key] = idx
+            return idx
+
+    def get_call_spec(self, idx: int) -> dict[int, Any]:
+        if idx not in self.id_to_call_spec:
+            raise AssertionError(f"FlyDSL call spec index {idx} was not registered")
+        return self.id_to_call_spec[idx]
+
+    def reset_table(self) -> None:
+        with self.lock:
+            self.id_to_launcher = {}
+            self.launcher_to_id = {}
+            self.id_to_call_spec = {}
+            self.call_spec_to_id = {}
+
+
+flydsl_launcher_side_table = FlyDSLLauncherSideTable()
+
+
+def _constant_key(value: Any) -> tuple[Any, ...]:
+    try:
+        hash(value)
+    except TypeError:
+        return ("identity", type(value), id(value))
+    return ("value", type(value), value)
+
+
+def _register_flydsl_call_spec(
+    constant_args: dict[int, Any],
+    constexpr_indices: tuple[int, ...],
+    constexpr_value_signature: Callable[[Any], Any] | None,
+) -> int:
+    constexpr_indices_set = set(constexpr_indices)
+    key = tuple(
+        (
+            idx,
+            (
+                (
+                    "constexpr",
+                    (
+                        constexpr_value_signature(value)
+                        if constexpr_value_signature is not None
+                        else _constant_key(value)
+                    ),
+                )
+                if idx in constexpr_indices_set
+                else ("type_parameter", value)
+            ),
+        )
+        for idx, value in constant_args.items()
+    )
+    return flydsl_launcher_side_table.add_call_spec(constant_args, key)
+
+
+def _validate_runtime_arguments(
+    registration: FlyDSLLauncherRegistration,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    for idx, (parameter, value) in enumerate(
+        zip(registration.signature.parameters.values(), args)
+    ):
+        if idx in registration.compile_time_arg_indices:
+            continue
+        if registration.stream_type is not None and isinstance(
+            value, registration.stream_type
+        ):
+            raise TypeError(
+                "wrap_flydsl does not accept explicit stream arguments; "
+                "AOT launchers use PyTorch's current device stream"
+            )
+        if registration.jit_argument_type is not None and isinstance(
+            value, registration.jit_argument_type
+        ):
+            raise TypeError(
+                "wrap_flydsl runtime arguments must be graphable PyTorch values; "
+                f"preconstructed FlyDSL JitArgument {type(value).__name__} is unsupported"
+            )
+
+    parameters = tuple(registration.signature.parameters.values())
+    for idx in mutated_arg_indices:
+        if not isinstance(args[idx], Tensor):
+            raise TypeError(
+                "wrap_flydsl mutated arguments must be tensors; "
+                f"{parameters[idx].name!r} received {type(args[idx]).__name__}"
+            )
+
+
+def partition_flydsl_launcher_arguments(
+    registration: FlyDSLLauncherRegistration,
+    args: tuple[Any, ...],
+) -> tuple[tuple[Any, ...], int]:
+    signature = registration.signature
+    parameters = tuple(signature.parameters.values())
+    if len(args) != len(parameters):
+        raise TypeError(
+            f"FlyDSL launcher expected {len(parameters)} arguments, got {len(args)}"
+        )
+    runtime_args = list(args)
+    constant_args = {}
+    constexpr_indices = []
+    for idx, value in enumerate(args):
+        if idx in registration.constexpr_arg_indices:
+            constexpr_indices.append(idx)
+            constant_args[idx] = value
+            runtime_args[idx] = None
+        elif idx in registration.compile_time_arg_indices:
+            constant_args[idx] = value
+            runtime_args[idx] = None
+    return tuple(runtime_args), _register_flydsl_call_spec(
+        constant_args,
+        tuple(constexpr_indices),
+        registration.constexpr_value_signature,
+    )
+
+
+def restore_flydsl_launcher_arguments(
+    args: tuple[Any, ...],
+    call_spec_idx: int,
+) -> tuple[Any, ...]:
+    restored_args = list(args)
+    for idx, value in flydsl_launcher_side_table.get_call_spec(call_spec_idx).items():
+        restored_args[idx] = value
+    return tuple(restored_args)
+
+
+def split_flydsl_launcher_arguments(
+    signature: inspect.Signature,
+    args: tuple[Any, ...],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    parameters = tuple(signature.parameters.values())
+    if len(args) != len(parameters):
+        raise TypeError(
+            f"FlyDSL launcher expected {len(parameters)} arguments, got {len(args)}"
+        )
+    positional_args = []
+    keyword_args = {}
+    for parameter, value in zip(parameters, args):
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional_args.append(value)
+        elif parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+            keyword_args[parameter.name] = value
+        else:
+            raise TypeError(
+                "FlyDSL launchers with variadic parameters cannot be captured"
+            )
+    return tuple(positional_args), keyword_args
+
+
+def invoke_flydsl_launcher(
+    registration: FlyDSLLauncherRegistration,
+    args: tuple[Any, ...],
+) -> None:
+    positional_args, keyword_args = split_flydsl_launcher_arguments(
+        registration.signature,
+        args,
+    )
+    if registration.bound_self is not None:
+        positional_args = (registration.bound_self, *positional_args)
+    registration.launcher(*positional_args, **keyword_args)
+
+
+class FlyDSLKernelWrapperMutation(HigherOrderOperator):
+    def __init__(self) -> None:
+        super().__init__("flydsl_kernel_wrapper_mutation", cacheable=True)
+
+    def __call__(
+        self,
+        launcher_idx: int,
+        call_spec_idx: int,
+        args: tuple[Any, ...],
+        mutated_arg_indices: tuple[int, ...],
+    ) -> None:
+        return super().__call__(
+            launcher_idx=launcher_idx,
+            call_spec_idx=call_spec_idx,
+            args=args,
+            mutated_arg_indices=mutated_arg_indices,
+        )
+
+
+class FlyDSLKernelWrapperFunctional(HigherOrderOperator):
+    def __init__(self) -> None:
+        super().__init__("flydsl_kernel_wrapper_functional", cacheable=True)
+
+    def __call__(
+        self,
+        launcher_idx: int,
+        call_spec_idx: int,
+        args: tuple[Any, ...],
+        mutated_arg_indices: tuple[int, ...],
+        tensors_to_clone: tuple[int, ...],
+    ) -> tuple[Tensor, ...]:
+        return super().__call__(
+            launcher_idx=launcher_idx,
+            call_spec_idx=call_spec_idx,
+            args=args,
+            mutated_arg_indices=mutated_arg_indices,
+            tensors_to_clone=tensors_to_clone,
+        )
+
+
+flydsl_kernel_wrapper_mutation = FlyDSLKernelWrapperMutation()
+flydsl_kernel_wrapper_functional = FlyDSLKernelWrapperFunctional()
+
+
+@flydsl_kernel_wrapper_mutation.py_impl(DispatchKey.CompositeExplicitAutograd)
+def flydsl_kernel_wrapper_mutation_dense(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    registration = flydsl_launcher_side_table.get_registration(launcher_idx)
+    full_args = restore_flydsl_launcher_arguments(args, call_spec_idx)
+    _validate_runtime_arguments(registration, full_args, mutated_arg_indices)
+    cuda_devices = {
+        arg.device
+        for arg in full_args
+        if isinstance(arg, Tensor) and arg.device.type == "cuda"
+    }
+    for device in cuda_devices:
+        if torch.cuda.current_stream(device) != torch.cuda.default_stream(device):
+            raise RuntimeError(
+                "eager wrap_flydsl launches require the default device stream; "
+                "AOTInductor launchers use PyTorch's current device stream"
+            )
+    invoke_flydsl_launcher(
+        registration,
+        full_args,
+    )
+
+
+@register_fake(flydsl_kernel_wrapper_mutation, skip_cache=True)
+def flydsl_kernel_wrapper_mutation_fake(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    return None
+
+
+@flydsl_kernel_wrapper_mutation.py_impl(DispatchKey.Meta)
+def flydsl_kernel_wrapper_mutation_meta(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    return None
+
+
+def _trace_flydsl_wrapper(
+    mode: ProxyTorchDispatchMode,
+    op: HigherOrderOperator,
+    node_args: dict[str, Any],
+) -> Any:
+    with disable_proxy_modes_tracing():
+        output = op(**node_args)
+    proxy_args = pytree.tree_map(cast(Any, mode.tracer).unwrap_proxy, node_args)
+    output_proxy = mode.tracer.create_proxy(
+        "call_function",
+        op,
+        (),
+        proxy_args,
+        name=op.__name__ + "_proxy",
+    )
+    return track_tensor_tree(
+        output,
+        output_proxy,
+        constant=None,
+        tracer=mode.tracer,
+    )
+
+
+@flydsl_kernel_wrapper_mutation.py_impl(ProxyTorchDispatchMode)
+def flydsl_kernel_wrapper_mutation_proxy(
+    mode: ProxyTorchDispatchMode,
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    _trace_flydsl_wrapper(
+        mode,
+        flydsl_kernel_wrapper_mutation,
+        {
+            "launcher_idx": launcher_idx,
+            "call_spec_idx": call_spec_idx,
+            "args": args,
+            "mutated_arg_indices": mutated_arg_indices,
+        },
+    )
+    return None
+
+
+@flydsl_kernel_wrapper_mutation.py_functionalize_impl
+def flydsl_kernel_wrapper_mutation_functionalize(
+    ctx: BaseFunctionalizeAPI,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    unwrapped_args = tuple(ctx.unwrap_tensors(args))
+    with ctx.redispatch_to_next():
+        outputs = flydsl_kernel_wrapper_functional(
+            launcher_idx,
+            call_spec_idx,
+            unwrapped_args,
+            mutated_arg_indices,
+            tuple(range(len(mutated_arg_indices))),
+        )
+
+    for arg_idx, output in zip(mutated_arg_indices, outputs):
+        input_arg = args[arg_idx]
+        if not isinstance(input_arg, Tensor):
+            raise AssertionError(
+                f"Expected FlyDSL mutated argument {arg_idx} to be a Tensor"
+            )
+        ctx.replace(input_arg, output)
+        ctx.mark_mutation_hidden_from_autograd(input_arg)
+        ctx.commit_update(input_arg)
+        ctx.sync(input_arg)
+
+
+@flydsl_kernel_wrapper_functional.py_impl(DispatchKey.CompositeExplicitAutograd)
+def flydsl_kernel_wrapper_functional_dense(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    _validate_clone_aliases(args, mutated_arg_indices, tensors_to_clone)
+    cloned_args = list(args)
+    for output_idx in tensors_to_clone:
+        arg_idx = mutated_arg_indices[output_idx]
+        arg = cloned_args[arg_idx]
+        if not isinstance(arg, Tensor):
+            raise AssertionError(
+                f"Expected FlyDSL mutated argument {arg_idx} to be a Tensor"
+            )
+        cloned_args[arg_idx] = clone_preserve_strides(arg)
+    flydsl_kernel_wrapper_mutation(
+        launcher_idx,
+        call_spec_idx,
+        tuple(cloned_args),
+        mutated_arg_indices,
+    )
+    return tuple(cloned_args[idx] for idx in mutated_arg_indices)
+
+
+@register_fake(flydsl_kernel_wrapper_functional, skip_cache=True)
+def flydsl_kernel_wrapper_functional_fake(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    _validate_clone_aliases(args, mutated_arg_indices, tensors_to_clone)
+    clone_indices = set(tensors_to_clone)
+    return tuple(
+        (
+            clone_preserve_strides(args[arg_idx])
+            if output_idx in clone_indices
+            else args[arg_idx]
+        )
+        for output_idx, arg_idx in enumerate(mutated_arg_indices)
+    )
+
+
+@flydsl_kernel_wrapper_functional.py_impl(ProxyTorchDispatchMode)
+def flydsl_kernel_wrapper_functional_proxy(
+    mode: ProxyTorchDispatchMode,
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    return _trace_flydsl_wrapper(
+        mode,
+        flydsl_kernel_wrapper_functional,
+        {
+            "launcher_idx": launcher_idx,
+            "call_spec_idx": call_spec_idx,
+            "args": args,
+            "mutated_arg_indices": mutated_arg_indices,
+            "tensors_to_clone": tensors_to_clone,
+        },
+    )
+
+
+@flydsl_kernel_wrapper_functional.py_functionalize_impl
+def flydsl_kernel_wrapper_functional_functionalize(
+    ctx: BaseFunctionalizeAPI,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    unwrapped_args = tuple(ctx.unwrap_tensors(args))
+    with ctx.redispatch_to_next():
+        outputs = flydsl_kernel_wrapper_functional(
+            launcher_idx,
+            call_spec_idx,
+            unwrapped_args,
+            mutated_arg_indices,
+            tensors_to_clone,
+        )
+    return tuple(ctx.wrap_tensors(outputs))
+
+
+def _validate_clone_aliases(
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> None:
+    cloned_arg_indices = {
+        mutated_arg_indices[output_idx] for output_idx in tensors_to_clone
+    }
+    tensor_args = [
+        (idx, arg) for idx, arg in enumerate(args) if isinstance(arg, Tensor)
+    ]
+    for position, (arg_idx, arg) in enumerate(tensor_args):
+        for other_idx, other in tensor_args[position + 1 :]:
+            if (
+                arg_idx in cloned_arg_indices or other_idx in cloned_arg_indices
+            ) and cast(Any, torch._C)._is_alias_of(arg, other):
+                raise RuntimeError(
+                    "FlyDSL functionalization does not support cloning aliased "
+                    f"launcher arguments {arg_idx} and {other_idx}"
+                )
+
+
+for op in (flydsl_kernel_wrapper_mutation, flydsl_kernel_wrapper_functional):
+    op.fallthrough(DispatchKey.PythonDispatcher)
+    op.fallthrough(DispatchKey.PythonTLSSnapshot)
+    op.fallthrough(DispatchKey.ADInplaceOrView)
+    op.fallthrough(DispatchKey.BackendSelect)
+    op.fallthrough(DispatchKey.AutocastCPU)
+    op.fallthrough(DispatchKey.AutocastCUDA)
+    op.fallthrough(DispatchKey.AutogradCPU)
+    op.fallthrough(DispatchKey.AutogradCUDA)

--- a/torch/_inductor/codegen/flydsl/aot_compile.py
+++ b/torch/_inductor/codegen/flydsl/aot_compile.py
@@ -1,0 +1,503 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+import ctypes
+import filecmp
+import inspect
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch.utils._ordered_set import OrderedSet
+
+
+HAS_FLYDSL = runtime_available()
+if TYPE_CHECKING or HAS_FLYDSL:
+    import flydsl.utils as flydsl_utils
+    from flydsl._mlir import execution_engine, ir
+    from flydsl._mlir.dialects import func
+    from flydsl.compiler import (
+        backends,
+        jit_argument,
+        jit_executor,
+        jit_function,
+        kernel_function,
+        protocol,
+    )
+    from flydsl.expr import meta, numeric, typing as flydsl_typing
+    from flydsl.expr.utils import arith
+
+
+_C_SYMBOL = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_GPU_MODULE_INIT = "flydsl_gpu_module_init"
+_GPU_MODULE_LOAD_TO_DEVICE = "flydsl_gpu_module_load_to_device"
+_ELF_SONAME = re.compile(r"\(SONAME\).*\[([^]]+)\]")
+_LDD_LIBRARY = re.compile(r"^\s*(\S+)\s+=>\s+(\S+)\s+\(")
+
+
+def _ctype_metadata(ctype: type, *, name: str | None = None) -> dict[str, Any]:
+    if name is None:
+        if ctype is ctypes.c_void_p:
+            name = "pointer"
+        elif issubclass(ctype, ctypes.Array):
+            name = "bytes"
+        elif ctype is ctypes.c_float:
+            name = "float"
+        elif ctype is ctypes.c_double:
+            name = "double"
+        elif ctype is ctypes.c_bool:
+            name = "bool"
+        else:
+            name = ctype.__name__.removeprefix("c_")
+    return {
+        "ctype": name,
+        "size": ctypes.sizeof(ctype),
+        "alignment": ctypes.alignment(ctype),
+    }
+
+
+def _numeric_ctype_name(value: Any, ctype: type) -> str:
+    if value.signed is not None:
+        if value.width == 1:
+            return "bool"
+        return f"{'int' if value.signed else 'uint'}{value.width}"
+    if isinstance(value, (numeric.Float16, numeric.BFloat16)):
+        return "uint16"
+    if isinstance(value, numeric.Float32):
+        return "float"
+    if isinstance(value, numeric.Float64):
+        return "double"
+    return ctype.__name__.removeprefix("c_")
+
+
+def _argument_abi(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, jit_argument.MemRefJitArg):
+        slots = [
+            {
+                "kind": "tensor_data",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        ]
+        if value.is_layout_dynamic:
+            shape_dims = list(value.shape_dyn_indices)
+            stride_dims = list(value.stride_dyn_indices)
+            stride_ctype = ctypes.c_int32 if value.use_32bit_stride else ctypes.c_int64
+            layout_ctype = ctypes.c_byte * (
+                len(shape_dims) * ctypes.sizeof(ctypes.c_int32)
+                + len(stride_dims) * ctypes.sizeof(stride_ctype)
+            )
+            slots.append(
+                {
+                    "kind": "tensor_layout",
+                    **_ctype_metadata(layout_ctype, name="bytes"),
+                    "shape_dims": shape_dims,
+                    "stride_dims": stride_dims,
+                    "stride_bits": 32 if value.use_32bit_stride else 64,
+                }
+            )
+        return slots
+
+    if isinstance(value, flydsl_typing.Stream):
+        return [
+            {
+                "kind": "stream",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        ]
+
+    if isinstance(value, jit_argument.PointerJitArg):
+        return [
+            {
+                "kind": "pointer",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        ]
+
+    if not isinstance(value, numeric.Numeric):
+        raise NotImplementedError(
+            "FlyDSL AOT supports tensor, pointer, scalar, and implicit stream "
+            f"arguments; unsupported JIT argument type: {type(value).__name__}"
+        )
+    if value.signed is not None and value.width not in (1, 8, 16, 32, 64):
+        raise NotImplementedError(
+            f"FlyDSL AOT does not support {type(value).__name__} scalar arguments"
+        )
+    if value.signed is None and not isinstance(
+        value,
+        (
+            numeric.Float16,
+            numeric.BFloat16,
+            numeric.Float32,
+            numeric.Float64,
+        ),
+    ):
+        raise NotImplementedError(
+            f"FlyDSL AOT does not support {type(value).__name__} scalar arguments"
+        )
+    abi_spec = protocol.c_abi_spec(value)
+    if len(abi_spec) != 1:
+        raise NotImplementedError(
+            "FlyDSL AOT scalar arguments must have exactly one C ABI slot"
+        )
+    ctype, _fill = abi_spec[0]
+    slot = {
+        "kind": "scalar",
+        **_ctype_metadata(ctype, name=_numeric_ctype_name(value, ctype)),
+    }
+    if isinstance(value, numeric.Float16):
+        slot["encoding"] = "float16_bits"
+    elif isinstance(value, numeric.BFloat16):
+        slot["encoding"] = "bfloat16_bits"
+    return [slot]
+
+
+def _launcher_abi(
+    sig, bound, jit_args: list[Any], has_user_stream: bool
+) -> tuple[dict[str, Any], ...]:
+    abi = []
+    jit_arg_index = 0
+    for arg_index, (param_name, value) in enumerate(bound.arguments.items()):
+        annotation = sig.parameters[param_name].annotation
+        if annotation is not inspect.Parameter.empty and (
+            flydsl_typing.Constexpr.is_constexpr_annotation(annotation)
+            or jit_argument.is_type_param_annotation(annotation)
+        ):
+            continue
+        jit_arg = jit_args[jit_arg_index]
+        jit_arg_index += 1
+        abi.extend(
+            {"arg_index": arg_index, "arg_name": param_name, **slot}
+            for slot in _argument_abi(jit_arg)
+        )
+    if not has_user_stream:
+        abi.append(
+            {
+                "arg_index": None,
+                "arg_name": None,
+                "kind": "stream",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        )
+    return tuple(abi)
+
+
+def _rename_symbol_ref(attr, symbol_map):
+    components = list(ir.SymbolRefAttr(attr).value)
+    if not components or components[0] not in symbol_map:
+        return attr
+    components[0] = symbol_map[components[0]]
+    return ir.SymbolRefAttr.get(components)
+
+
+def _rename_export_symbols(module: Any, entry: str, symbol: str) -> None:
+    symbol_map = {}
+
+    def collect(op):
+        attrs = op.attributes
+        if "sym_name" not in attrs:
+            return ir.WalkResult.ADVANCE
+        is_definition = op.name in ("llvm.mlir.global", "gpu.binary")
+        if op.name == "llvm.func":
+            is_definition = bool(op.opview.operation.regions)
+        if not is_definition:
+            return ir.WalkResult.ADVANCE
+        old_name = attrs["sym_name"].value
+        new_name = symbol if old_name == entry else f"{symbol}__{old_name}"
+        symbol_map[old_name] = new_name
+        attrs["sym_name"] = ir.StringAttr.get(new_name)
+        return ir.WalkResult.ADVANCE
+
+    def update_refs(op):
+        attrs = op.attributes
+        if op.name == "llvm.call" and "callee" in attrs:
+            old_name = attrs["callee"].value
+            if old_name in symbol_map:
+                attrs["callee"] = ir.FlatSymbolRefAttr.get(symbol_map[old_name])
+        elif op.name == "llvm.mlir.addressof" and "global_name" in attrs:
+            old_name = attrs["global_name"].value
+            if old_name in symbol_map:
+                attrs["global_name"] = ir.FlatSymbolRefAttr.get(symbol_map[old_name])
+        elif op.name in ("llvm.mlir.global_ctors", "llvm.mlir.global_dtors"):
+            key = "ctors" if op.name.endswith("ctors") else "dtors"
+            if key in attrs:
+                attrs[key] = ir.ArrayAttr.get(
+                    [
+                        ir.FlatSymbolRefAttr.get(symbol_map.get(ref.value, ref.value))
+                        for ref in attrs[key]
+                    ]
+                )
+        elif op.name == "gpu.launch_func" and "kernel" in attrs:
+            attrs["kernel"] = _rename_symbol_ref(attrs["kernel"], symbol_map)
+        return ir.WalkResult.ADVANCE
+
+    module.operation.walk(collect)
+    if entry not in symbol_map:
+        raise RuntimeError(f"FlyDSL AOT export could not find entry symbol {entry!r}")
+    module.operation.walk(update_refs)
+
+
+def _rename_loader_symbols(object_path: Path, symbol: str) -> tuple[str, str]:
+    objcopy = shutil.which("llvm-objcopy") or shutil.which("objcopy")
+    if objcopy is None:
+        raise RuntimeError("FlyDSL AOT export requires llvm-objcopy or objcopy")
+
+    init_symbol = f"{symbol}__{_GPU_MODULE_INIT}"
+    load_symbol = f"{symbol}__{_GPU_MODULE_LOAD_TO_DEVICE}"
+    symbol_map = {
+        _GPU_MODULE_INIT: init_symbol,
+        _GPU_MODULE_LOAD_TO_DEVICE: load_symbol,
+        f"_mlir_{_GPU_MODULE_INIT}": f"_mlir_{init_symbol}",
+        f"_mlir_{_GPU_MODULE_LOAD_TO_DEVICE}": f"_mlir_{load_symbol}",
+    }
+    file_descriptor, renamed_path = tempfile.mkstemp(
+        prefix=f".{object_path.name}.",
+        dir=object_path.parent,
+    )
+    os.close(file_descriptor)
+    try:
+        command = [objcopy]
+        for old_name, new_name in symbol_map.items():
+            command.extend(["--redefine-sym", f"{old_name}={new_name}"])
+        command.extend(["--", str(object_path), renamed_path])
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        Path(renamed_path).replace(object_path)
+    finally:
+        Path(renamed_path).unlink(missing_ok=True)
+    return init_symbol, load_symbol
+
+
+def _elf_soname(path: Path) -> str | None:
+    readelf = shutil.which("llvm-readelf") or shutil.which("readelf")
+    if readelf is None:
+        raise RuntimeError("FlyDSL AOT export requires llvm-readelf or readelf")
+    result = subprocess.run(
+        [readelf, "-d", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    match = _ELF_SONAME.search(result.stdout)
+    return match.group(1) if match is not None else None
+
+
+def _runtime_library_dependencies(path: Path) -> dict[str, Path]:
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        raise RuntimeError("FlyDSL AOT export requires ldd")
+    result = subprocess.run(
+        [ldd, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    dependencies = {}
+    for line in result.stdout.splitlines():
+        match = _LDD_LIBRARY.match(line)
+        if match is not None and match.group(2) != "not":
+            dependencies[match.group(1)] = Path(match.group(2)).resolve()
+    return dependencies
+
+
+def _flydsl_distribution_root(runtime_library: Path) -> Path:
+    for parent in runtime_library.resolve().parents:
+        if (parent / "flydsl").is_dir():
+            return parent
+    raise RuntimeError(
+        f"could not locate the FlyDSL distribution for runtime library {runtime_library}"
+    )
+
+
+def _publish_runtime_library(source: Path, destination: Path) -> None:
+    file_descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        dir=destination.parent,
+    )
+    os.close(file_descriptor)
+    temporary = Path(temporary_path)
+    try:
+        shutil.copy2(source, temporary)
+        try:
+            os.link(temporary, destination)
+        except FileExistsError:
+            if not filecmp.cmp(temporary, destination, shallow=False):
+                raise RuntimeError(
+                    "FlyDSL runtime library collision for "
+                    f"{destination.name}: {source} differs from the cached file"
+                ) from None
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _bundle_runtime_libraries(
+    runtime_libraries: list[str],
+    output_dir: Path,
+) -> list[str]:
+    libraries: dict[str, Path] = {}
+    distribution_roots = OrderedSet(
+        _flydsl_distribution_root(Path(path)) for path in runtime_libraries
+    )
+    for path_string in runtime_libraries:
+        path = Path(path_string).resolve()
+        libraries[_elf_soname(path) or path.name] = path
+        libraries.update(
+            {
+                name: dependency
+                for name, dependency in _runtime_library_dependencies(path).items()
+                if any(dependency.is_relative_to(root) for root in distribution_roots)
+            }
+        )
+
+    bundled = []
+    for name, source in libraries.items():
+        destination = output_dir / name
+        if source != destination:
+            _publish_runtime_library(source, destination)
+        bundled.append(str(destination))
+    return bundled
+
+
+class CompiledAOTLauncher:
+    def __init__(self, module: Any, entry: str, abi: tuple[dict[str, Any], ...]):
+        self._ir_text = str(module)
+        self._entry = entry
+        self.abi = abi
+
+    def export_to_c(self, object_file_path: str, function_name: str) -> dict[str, Any]:
+        if not _C_SYMBOL.fullmatch(function_name):
+            raise ValueError(f"invalid C function name: {function_name!r}")
+        object_path = Path(object_file_path)
+        if not object_path.parent.exists():
+            raise FileNotFoundError(
+                f"object output directory does not exist: {object_path.parent}"
+            )
+
+        runtime_libraries = jit_executor._resolve_runtime_libs()
+        ctx = jit_function._create_mlir_context()
+        with ctx:
+            module = ir.Module.parse(self._ir_text)
+            _rename_export_symbols(module, self._entry, function_name)
+            engine = execution_engine.ExecutionEngine(
+                module,
+                opt_level=3,
+                shared_libs=runtime_libraries,
+                enable_pic=True,
+            )
+            engine.dump_to_object_file(str(object_path))
+
+        init_symbol, load_symbol = _rename_loader_symbols(object_path, function_name)
+        bundled_runtime_libraries = _bundle_runtime_libraries(
+            runtime_libraries,
+            object_path.parent,
+        )
+        return {
+            "object_file_path": str(object_path),
+            "symbol": f"_mlir_{function_name}",
+            "runtime_libraries": bundled_runtime_libraries,
+            "abi": list(self.abi),
+            "module_init_symbol": init_symbol,
+            "module_load_symbol": load_symbol,
+        }
+
+
+def compile_aot(launcher: Any, *args, **kwargs) -> CompiledAOTLauncher:
+    """Compile a specialized FlyDSL launcher into an AOT object and ABI."""
+    if not HAS_FLYDSL:
+        raise RuntimeError("FlyDSL AOT compilation requires the FlyDSL runtime")
+    if not isinstance(launcher, jit_function.JitFunction):
+        raise TypeError(
+            f"flyc.compile_aot() expects a @flyc.jit function, got {type(launcher).__name__}"
+        )
+
+    launcher._ensure_sig()
+    bound_self = None
+    if launcher._has_self_param:
+        if not args:
+            raise TypeError(f"{launcher.func.__name__}() missing 'self' argument")
+        bound_self, args = args[0], args[1:]
+    sig = launcher._sig
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+
+    hints = (
+        kernel_function.CompilationContext.compile_hints(launcher.compile_hints)
+        if launcher.compile_hints
+        else nullcontext()
+    )
+    with jit_function._create_mlir_context() as ctx, hints:
+        param_names, jit_args, dsl_types, constexpr_values = (
+            jit_argument.convert_to_jit_arguments(sig, bound)
+        )
+        has_user_stream = jit_function._ensure_stream_arg(jit_args)
+        ir_types = protocol.get_ir_types(jit_args)
+        loc = kernel_function.func_def_location(launcher.func, ctx)
+        module = ir.Module.create(loc=loc)
+        module.operation.attributes["gpu.container_module"] = ir.UnitAttr.get()
+
+        with ir.InsertionPoint(module.body), loc:
+            backend = backends.get_backend()
+            gpu_module = kernel_function.create_gpu_module(
+                "kernels",
+                targets=backend.gpu_module_targets(),
+                use_explicit_module=True,
+            )
+            func_op = func.FuncOp(launcher.func.__name__, (ir_types, []))
+            func_op.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
+            entry_block = func_op.add_entry_block()
+
+            with kernel_function.CompilationContext.create() as comp_ctx:
+                comp_ctx.gpu_module_op = gpu_module
+                comp_ctx.gpu_module_body = kernel_function.get_gpu_module_body(
+                    gpu_module
+                )
+                with ir.InsertionPoint(entry_block):
+                    ir_args = list(func_op.regions[0].blocks[0].arguments)
+                    if not has_user_stream:
+                        comp_ctx.stream_arg = ir_args[-1]
+                    user_jit_args = jit_args[: len(param_names)]
+                    dsl_args = protocol.construct_from_ir_values(
+                        dsl_types, user_jit_args, ir_args
+                    )
+                    named_args = dict(zip(param_names, dsl_args))
+                    named_args.update(constexpr_values)
+                    fastmath_flag = kernel_function.effective_fastmath_hint(
+                        kernel_function.CompilationContext.get_compile_hints()
+                    )
+                    fastmath_scope = (
+                        arith.fastmath(fastmath_flag)
+                        if fastmath_flag is not None
+                        else nullcontext()
+                    )
+                    with meta.tracing_context(launcher.func), fastmath_scope:
+                        if bound_self is not None:
+                            launcher.func(bound_self, **named_args)
+                        else:
+                            launcher.func(**named_args)
+                    func.ReturnOp([])
+
+        link_libs = list(comp_ctx.link_libs) if comp_ctx.link_libs else None
+        if comp_ctx.post_load_processors:
+            raise RuntimeError(
+                "FlyDSL AOT export does not support Python post-load processors"
+            )
+        if link_libs and jit_function._use_external_binary_codegen():
+            raise RuntimeError(
+                "FlyDSL external codegen does not support extern-linked AOT launchers"
+            )
+        if link_libs and "targets" in gpu_module.operation.attributes:
+            del gpu_module.operation.attributes["targets"]
+
+        flydsl_utils.log().info(f"FlyDSL AOT jit_args={jit_args}")
+        compiled_module = jit_function.MlirCompiler.compile(
+            module,
+            arch=backend.target.arch,
+            func_name=launcher.func.__name__,
+            link_libs=link_libs,
+        )
+        abi = _launcher_abi(sig, bound, jit_args, has_user_stream)
+        return CompiledAOTLauncher(compiled_module, launcher.func.__name__, abi)

--- a/torch/_library/__init__.py
+++ b/torch/_library/__init__.py
@@ -3,4 +3,5 @@ import torch._library.fake_impl
 import torch._library.simple_registry
 import torch._library.utils
 from torch._library.fake_class_registry import register_fake_class
+from torch._library.flydsl import wrap_flydsl
 from torch._library.triton import capture_triton, triton_op, wrap_triton

--- a/torch/_library/flydsl.py
+++ b/torch/_library/flydsl.py
@@ -1,0 +1,147 @@
+import inspect
+from collections.abc import Callable, Iterable
+from functools import partial
+from typing import Any
+
+from torch.utils._exposed_in import exposed_in
+
+
+@exposed_in("torch.library")
+def wrap_flydsl(
+    launcher: Callable[..., Any],
+    /,
+    *,
+    mutates_args: Iterable[str],
+) -> Any:
+    """Wrap a FlyDSL ``@jit`` launcher for dispatcher-based tracing.
+
+    The launcher must write results into explicit tensor arguments and return
+    ``None``. AOTInductor executes a wrapped launcher on PyTorch's current
+    device stream. Direct eager calls require the default device stream;
+    launchers with an explicit FlyDSL ``Stream`` parameter are unsupported.
+    ``mutates_args`` names the tensor arguments written by the launcher.
+    Runtime arguments must be graphable PyTorch values rather than
+    preconstructed FlyDSL ``JitArgument`` objects.
+
+    Variadic launcher parameters are not supported.
+    """
+    from torch._dynamo.decorators import allow_in_graph, assume_constant_result
+    from torch._higher_order_ops.flydsl_kernel_wrap import (
+        _register_flydsl_call_spec,
+        flydsl_kernel_wrapper_mutation,
+        TraceableFlyDSLLauncher,
+    )
+    from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+
+    if not runtime_available():
+        raise RuntimeError(
+            "wrap_flydsl requires a supported optional `flydsl` runtime "
+            "on a ROCm-enabled build"
+        )
+
+    from flydsl.compiler import jit_argument, jit_function, protocol
+    from flydsl.expr import typing as flydsl_typing
+
+    JitFunction = jit_function.JitFunction
+    bound_self = None
+    jit_launcher = launcher
+    if isinstance(launcher, partial):
+        bound_call = launcher.func
+        candidate = getattr(bound_call, "__self__", None)
+        if (
+            isinstance(candidate, JitFunction)
+            and getattr(bound_call, "__func__", None) is JitFunction.__call__
+            and len(launcher.args) == 1
+            and not launcher.keywords
+        ):
+            jit_launcher = candidate
+            bound_self = launcher.args[0]
+
+    if not isinstance(jit_launcher, JitFunction):
+        raise RuntimeError(
+            "wrap_flydsl only works on functions annotated with flydsl.compiler.jit"
+        )
+    signature = jit_argument.resolve_signature(jit_launcher.func)
+    parameters = tuple(signature.parameters.values())
+    has_self = bool(parameters) and parameters[0].name == "self"
+    if has_self:
+        if bound_self is None:
+            raise TypeError("FlyDSL JIT methods must be wrapped from a bound instance")
+        signature = signature.replace(parameters=parameters[1:])
+    if any(
+        parameter.kind
+        in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        for parameter in signature.parameters.values()
+    ):
+        raise TypeError("FlyDSL launchers with variadic parameters cannot be wrapped")
+    if any(
+        getattr(parameter.annotation, "_is_stream_param", False)
+        for parameter in signature.parameters.values()
+    ):
+        raise TypeError(
+            "FlyDSL launchers with explicit Stream parameters cannot be wrapped; "
+            "AOT launchers use PyTorch's current device stream"
+        )
+
+    compile_time_arg_indices = frozenset(
+        idx
+        for idx, parameter in enumerate(signature.parameters.values())
+        if parameter.annotation is not inspect.Parameter.empty
+        and (
+            flydsl_typing.Constexpr.is_constexpr_annotation(parameter.annotation)
+            or jit_argument.is_type_param_annotation(parameter.annotation)
+        )
+    )
+    constexpr_arg_indices = frozenset(
+        idx
+        for idx, parameter in enumerate(signature.parameters.values())
+        if parameter.annotation is not inspect.Parameter.empty
+        and flydsl_typing.Constexpr.is_constexpr_annotation(parameter.annotation)
+    )
+
+    mutations = frozenset(mutates_args)
+    unknown = mutations.difference(signature.parameters)
+    if unknown:
+        raise ValueError(
+            f"FlyDSL mutated arguments are not launcher parameters: {sorted(unknown)}"
+        )
+    parameter_names = tuple(signature.parameters)
+    compile_time_parameters = {parameter_names[idx] for idx in compile_time_arg_indices}
+    invalid_mutations = mutations.intersection(compile_time_parameters)
+    if invalid_mutations:
+        raise ValueError(
+            "FlyDSL compile-time arguments cannot be mutated: "
+            f"{sorted(invalid_mutations)}"
+        )
+    non_tensor_mutations = {
+        name
+        for name in mutations
+        if not (
+            isinstance(signature.parameters[name].annotation, type)
+            and issubclass(
+                signature.parameters[name].annotation,
+                flydsl_typing.Tensor,
+            )
+        )
+    }
+    if non_tensor_mutations:
+        raise TypeError(
+            "FlyDSL mutated arguments must have the flydsl.expr.Tensor "
+            f"annotation: {sorted(non_tensor_mutations)}"
+        )
+    mutated_arg_indices = tuple(
+        idx for idx, name in enumerate(parameter_names) if name in mutations
+    )
+    assume_constant_result(_register_flydsl_call_spec)
+    allow_in_graph(flydsl_kernel_wrapper_mutation)
+    return TraceableFlyDSLLauncher(
+        jit_launcher,
+        mutated_arg_indices,
+        bound_self=bound_self,
+        signature=signature,
+        compile_time_arg_indices=compile_time_arg_indices,
+        constexpr_arg_indices=constexpr_arg_indices,
+        constexpr_value_signature=flydsl_typing.Constexpr.value_signature,
+        stream_type=flydsl_typing.Stream,
+        jit_argument_type=protocol.JitArgument,
+    )

--- a/torch/library.py
+++ b/torch/library.py
@@ -19,6 +19,7 @@ from torch._library.custom_ops import (
     device_types_t,
 )
 from torch._library.effects import EffectType
+from torch._library.flydsl import wrap_flydsl
 from torch._library.infer_schema import infer_schema
 from torch._library.triton import triton_op, wrap_triton
 from torch._ops import OpOverload
@@ -38,6 +39,7 @@ __all__ = [
     "get_ctx",
     "get_kernel",
     "custom_op",
+    "wrap_flydsl",
     "triton_op",
     "wrap_triton",
     "infer_schema",


### PR DESCRIPTION
Summary:
Add `torch.library.wrap_flydsl` and FlyDSL higher-order operators for Dynamo/export capture. Callers must declare `mutates_args` explicitly; the wrapper validates the names once, records their ordered runtime-argument indices, and carries those indices directly on the HOP. Do not teach Dynamo to intercept direct `flyc.jit` calls or modify FlyDSL JIT behavior.

Keep the commonly imported HOP module independent of the optional FlyDSL runtime. The explicit entry point checks the existing 0.3.x `runtime_available()` policy, imports FlyDSL locally, and records only generic signature metadata needed by capture.

Keep compile-time values out of FX operands through a call-spec side table, deduplicate launcher registrations, support bound JIT methods without exposing `self`, and preserve tensor-subclass dispatch. Launcher invocation uses the normalized registration signature rather than reconstructing the original signature, so bound methods partition their self-stripped runtime arguments correctly before reattaching `self`. Reject explicit stream parameters because AOT launchers use the current device stream, and reject aliased functionalized mutations whose view semantics cannot be preserved by independent cloning.

Document the explicit-output and mutation contract and cover dynamic dimensions, positional and keyword-only arguments, constexpr omission from the runtime ABI, bound-method capture and invocation, registration reuse, tensor subclasses, scalar and pointer arguments, alias rejection, rejected streams and variadic signatures, invalid launchers, and an unavailable FlyDSL runtime.

Test Plan:
- `ROCM_VISIBLE_DEVICES=6 buck2 test mode/opt-split-dwarf mode/inplace mode/amd-gpu -c fbcode.triton_backend=amd -m rocm70 -c fbcode.enable_gpu_sections=true -c fbcode.rocm_arch=mi350 fbcode//caffe2/test/inductor/flydsl_aot:test_flydsl_capture` (22 passed)
- `arc lint -a` on changed files
- `arc lint -a --engine extra --take CITRINEAGENT` on changed ML Python files (no applicable linters)
- `arc pyre check-owning-targets` on changed Python files (no type-enabled owning targets)
- `python3 -m py_compile` on changed Python files

Differential Revision: D116840788


