### PR TITLE
[AOTI][FlyDSL] Test composed packaged launchers

### DIFF
--- a/docs/source/library.md
+++ b/docs/source/library.md
@@ -167,6 +167,7 @@ relationships.
 .. autofunction:: custom_op
 .. autofunction:: triton_op
 .. autofunction:: wrap_triton
+.. autofunction:: wrap_flydsl
 ```
 
 ## Extending custom ops (created from Python or C++)

--- a/docs/source/library.md
+++ b/docs/source/library.md
@@ -165,6 +165,7 @@ relationships.
 
 ```{eval-rst}
 .. autofunction:: custom_op
+.. autofunction:: flydsl_op
 .. autofunction:: triton_op
 .. autofunction:: wrap_triton
 .. autofunction:: wrap_flydsl

--- a/test/inductor/flydsl_aot/flydsl_aoti_test_models.py
+++ b/test/inductor/flydsl_aot/flydsl_aoti_test_models.py
@@ -1,0 +1,245 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+
+import torch
+from caffe2.test.inductor.flydsl_aot.flydsl_test_kernels import (
+    _relu_kernel,
+    ELEMENTWISE_BLOCK,
+    gemm_launcher,
+    GEMM_M,
+    GEMM_N,
+    relu_launcher,
+    RMS_N,
+    rms_norm_launcher,
+)
+
+
+RELU_SCALE = 0.75
+
+
+@flyc.kernel
+def _vector_add_kernel(
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    out: fx.Tensor,
+    block_dim: fx.Constexpr[int],
+):
+    block = fx.block_idx.x
+    thread = fx.thread_idx.x
+
+    lhs = fx.rocdl.make_buffer_tensor(lhs)
+    rhs = fx.rocdl.make_buffer_tensor(rhs)
+    out = fx.rocdl.make_buffer_tensor(out)
+    tiled_lhs = fx.slice(
+        fx.logical_divide(lhs, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    tiled_rhs = fx.slice(
+        fx.logical_divide(rhs, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    tiled_out = fx.slice(
+        fx.logical_divide(out, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    tiled_lhs = fx.logical_divide(tiled_lhs, fx.make_layout(1, 1))
+    tiled_rhs = fx.logical_divide(tiled_rhs, fx.make_layout(1, 1))
+    tiled_out = fx.logical_divide(tiled_out, fx.make_layout(1, 1))
+
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Float32)
+    lhs_register = fx.make_rmem_tensor(1, fx.Float32)
+    rhs_register = fx.make_rmem_tensor(1, fx.Float32)
+    out_register = fx.make_rmem_tensor(1, fx.Float32)
+    fx.copy_atom_call(copy_atom, fx.slice(tiled_lhs, (None, thread)), lhs_register)
+    fx.copy_atom_call(copy_atom, fx.slice(tiled_rhs, (None, thread)), rhs_register)
+    value = fx.arith.addf(
+        fx.memref_load_vec(lhs_register),
+        fx.memref_load_vec(rhs_register),
+    )
+    fx.memref_store_vec(value, out_register)
+    fx.copy_atom_call(copy_atom, out_register, fx.slice(tiled_out, (None, thread)))
+
+
+@flyc.jit
+def _vector_add_launcher(
+    out: fx.Tensor,
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    elements: fx.Int32,
+    block_dim: fx.Constexpr[int],
+):
+    grid = (elements + block_dim - 1) // block_dim
+    _vector_add_kernel(lhs, rhs, out, block_dim).launch(
+        grid=(grid, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+
+
+@flyc.jit
+def _two_stage_add_launcher(
+    out: fx.Tensor,
+    workspace: fx.Tensor,
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    elements: fx.Int32,
+    block_dim: fx.Constexpr[int],
+):
+    grid = (elements + block_dim - 1) // block_dim
+    _vector_add_kernel(lhs, rhs, workspace, block_dim).launch(
+        grid=(grid, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+    _vector_add_kernel(workspace, rhs, out, block_dim).launch(
+        grid=(grid, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+
+
+class _BoundReluLauncher:
+    @flyc.jit
+    def launch(
+        self,
+        inp: fx.Tensor,
+        out: fx.Tensor,
+        elements: fx.Int32,
+        block_dim: fx.Constexpr[int],
+        *,
+        scale: fx.Float32,
+    ):
+        blocks = (elements + block_dim - 1) // block_dim
+        _relu_kernel(inp, out, scale, block_dim).launch(
+            grid=(blocks, 1, 1),
+            block=(block_dim, 1, 1),
+        )
+
+
+_bound_relu_launcher = _BoundReluLauncher()
+_captured_vector_add = torch.library.wrap_flydsl(
+    _vector_add_launcher,
+    mutates_args={"out"},
+)
+_captured_two_stage_add = torch.library.wrap_flydsl(
+    _two_stage_add_launcher,
+    mutates_args={"out", "workspace"},
+)
+_captured_gemm = torch.library.wrap_flydsl(
+    gemm_launcher,
+    mutates_args={"out"},
+)
+_captured_relu = torch.library.wrap_flydsl(
+    relu_launcher,
+    mutates_args={"out"},
+)
+_captured_rms_norm = torch.library.wrap_flydsl(
+    rms_norm_launcher,
+    mutates_args={"out"},
+)
+_captured_bound_relu = torch.library.wrap_flydsl(
+    _bound_relu_launcher.launch,
+    mutates_args={"out"},
+)
+
+
+def _two_stage_add(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    workspace = torch.empty_like(lhs)
+    out = torch.empty_like(lhs)
+    _captured_two_stage_add(
+        out,
+        workspace,
+        lhs,
+        rhs,
+        lhs.numel(),
+        ELEMENTWISE_BLOCK,
+    )
+    return out
+
+
+class VectorAddModel(torch.nn.Module):
+    def forward(self, lhs, rhs):
+        out = torch.empty_like(lhs)
+        _captured_vector_add(
+            out,
+            lhs,
+            rhs,
+            lhs.numel(),
+            256,
+        )
+        return out
+
+
+class TwoStageAddModel(torch.nn.Module):
+    def forward(self, lhs, rhs):
+        return torch.sin(_two_stage_add(lhs, rhs))
+
+
+class BoundReluModel(torch.nn.Module):
+    def forward(self, inp):
+        out = torch.empty_like(inp)
+        _captured_bound_relu(
+            inp,
+            out,
+            inp.numel(),
+            ELEMENTWISE_BLOCK,
+            scale=RELU_SCALE,
+        )
+        return out
+
+
+def _composed(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    bias: torch.Tensor,
+    weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    gemm_out = torch.empty(
+        (GEMM_M, GEMM_N),
+        device=lhs.device,
+        dtype=lhs.dtype,
+    )
+    _captured_gemm(lhs, rhs, gemm_out)
+
+    biased = gemm_out + bias
+    flat_biased = biased.flatten()
+    flat_activated = torch.empty_like(flat_biased)
+    _captured_relu(
+        flat_biased,
+        flat_activated,
+        flat_biased.numel(),
+        RELU_SCALE,
+        ELEMENTWISE_BLOCK,
+    )
+    activated = flat_activated.view(GEMM_M, GEMM_N)
+
+    mixed = activated + torch.sin(activated) * 0.25
+    normalized = torch.empty_like(mixed)
+    _captured_rms_norm(
+        mixed,
+        weight,
+        normalized,
+        GEMM_M,
+        RMS_N,
+    )
+    final = normalized * 1.5 - 0.5
+    return final, gemm_out, activated, normalized
+
+
+class ComposedModel(torch.nn.Module):
+    def forward(self, lhs, rhs, bias, weight):
+        return _composed(lhs, rhs, bias, weight)
+
+
+class DynamicRMSNormModel(torch.nn.Module):
+    def forward(self, inp, weight):
+        out = torch.empty_like(inp)
+        _captured_rms_norm(
+            inp,
+            weight,
+            out,
+            inp.shape[0],
+            RMS_N,
+        )
+        return out

--- a/test/inductor/flydsl_aot/flydsl_test_kernels.py
+++ b/test/inductor/flydsl_aot/flydsl_test_kernels.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 FlyDSL Project Contributors
+
+"""Small kernels adapted from the upstream FlyDSL examples."""
+
+import flydsl.compiler as flyc
+import flydsl.expr as fx
+from flydsl.expr import math as fmath
+from flydsl.expr.typing import full
+
+
+GEMM_M = 64
+GEMM_N = 64
+GEMM_K = 8
+ELEMENTWISE_BLOCK = 256
+RMS_N = 64
+RMS_EPS = 1e-5
+
+
+@flyc.kernel
+def _gemm_kernel(
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    out: fx.Tensor,
+):
+    thread = fx.thread_idx.x
+    block = fx.block_idx.x
+
+    lhs = fx.rocdl.make_buffer_tensor(lhs)
+    rhs = fx.rocdl.make_buffer_tensor(rhs)
+    out = fx.rocdl.make_buffer_tensor(out)
+
+    block_lhs = fx.slice(
+        fx.zipped_divide(lhs, (GEMM_M, GEMM_K)),
+        (None, block),
+    )
+    block_rhs = fx.slice(
+        fx.zipped_divide(rhs, (GEMM_N, GEMM_K)),
+        (None, block),
+    )
+    block_out = fx.slice(
+        fx.zipped_divide(out, (GEMM_M, GEMM_N)),
+        (None, block),
+    )
+
+    mma_atom = fx.make_mma_atom(fx.rocdl.MFMA(16, 16, 4, fx.Float32))
+    tiled_mma = fx.make_tiled_mma(
+        mma_atom,
+        fx.make_layout((2, 2, 1), (1, 2, 0)),
+    )
+    thread_mma = tiled_mma.thr_slice(thread)
+
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
+    thread_copy_lhs = fx.make_tiled_copy_A(copy_atom, tiled_mma).get_slice(thread)
+    thread_copy_rhs = fx.make_tiled_copy_B(copy_atom, tiled_mma).get_slice(thread)
+    thread_copy_out = fx.make_tiled_copy_C(copy_atom, tiled_mma).get_slice(thread)
+
+    lhs_fragment = thread_mma.make_fragment_A(block_lhs)
+    rhs_fragment = thread_mma.make_fragment_B(block_rhs)
+    out_fragment = thread_mma.make_fragment_C(block_out)
+
+    fx.copy(
+        copy_atom,
+        thread_copy_lhs.partition_S(block_lhs),
+        thread_copy_lhs.retile(lhs_fragment),
+        pred=None,
+    )
+    fx.copy(
+        copy_atom,
+        thread_copy_rhs.partition_S(block_rhs),
+        thread_copy_rhs.retile(rhs_fragment),
+        pred=None,
+    )
+    out_fragment.fill(0)
+    fx.gemm(mma_atom, out_fragment, lhs_fragment, rhs_fragment, out_fragment)
+    fx.copy(
+        copy_atom,
+        thread_copy_out.retile(out_fragment),
+        thread_copy_out.partition_S(block_out),
+        pred=None,
+    )
+
+
+@flyc.jit
+def gemm_launcher(
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    out: fx.Tensor,
+):
+    _gemm_kernel(lhs, rhs, out).launch(
+        grid=(1, 1, 1),
+        block=(256, 1, 1),
+    )
+
+
+@flyc.kernel
+def _relu_kernel(
+    inp: fx.Tensor,
+    out: fx.Tensor,
+    scale: fx.Float32,
+    block_dim: fx.Constexpr[int],
+):
+    block = fx.block_idx.x
+    thread = fx.thread_idx.x
+    inp = fx.rocdl.make_buffer_tensor(inp)
+    out = fx.rocdl.make_buffer_tensor(out)
+    block_inp = fx.slice(
+        fx.logical_divide(inp, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    block_out = fx.slice(
+        fx.logical_divide(out, fx.make_layout(block_dim, 1)),
+        (None, block),
+    )
+    block_inp = fx.logical_divide(block_inp, fx.make_layout(1, 1))
+    block_out = fx.logical_divide(block_out, fx.make_layout(1, 1))
+
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Float32)
+    register = fx.make_rmem_tensor(1, fx.Float32)
+    fx.copy_atom_call(copy_atom, fx.slice(block_inp, (None, thread)), register)
+    value = fx.memref_load_vec(register)[0]
+    activated = value.maximumf(fx.Float32(0.0)) * scale
+    fx.memref_store_vec(full(1, activated, fx.Float32), register)
+    fx.copy_atom_call(copy_atom, register, fx.slice(block_out, (None, thread)))
+
+
+@flyc.jit
+def relu_launcher(
+    inp: fx.Tensor,
+    out: fx.Tensor,
+    elements: fx.Int32,
+    scale: fx.Float32,
+    block_dim: fx.Constexpr[int],
+):
+    blocks = (elements + block_dim - 1) // block_dim
+    _relu_kernel(inp, out, scale, block_dim).launch(
+        grid=(blocks, 1, 1),
+        block=(block_dim, 1, 1),
+    )
+
+
+@flyc.kernel
+def _rms_norm_kernel(
+    inp: fx.Tensor,
+    weight: fx.Tensor,
+    out: fx.Tensor,
+    columns: fx.Constexpr[int],
+):
+    row = fx.block_idx.x
+    thread = fx.thread_idx.x
+    inp = fx.rocdl.make_buffer_tensor(inp)
+    weight = fx.rocdl.make_buffer_tensor(weight)
+    out = fx.rocdl.make_buffer_tensor(out)
+
+    row_inp = fx.logical_divide(
+        fx.slice(inp, (row, None)),
+        fx.make_layout(1, 1),
+    )
+    row_out = fx.logical_divide(
+        fx.slice(out, (row, None)),
+        fx.make_layout(1, 1),
+    )
+    divided_weight = fx.logical_divide(weight, fx.make_layout(1, 1))
+    copy_atom = fx.make_copy_atom(fx.rocdl.BufferCopy(32), fx.Float32)
+
+    inp_register = fx.make_rmem_tensor(1, fx.Float32)
+    weight_register = fx.make_rmem_tensor(1, fx.Float32)
+    out_register = fx.make_rmem_tensor(1, fx.Float32)
+    fx.copy_atom_call(copy_atom, fx.slice(row_inp, (None, thread)), inp_register)
+    fx.copy_atom_call(
+        copy_atom,
+        fx.slice(divided_weight, (None, thread)),
+        weight_register,
+    )
+    value = fx.memref_load_vec(inp_register)[0]
+    weight_value = fx.memref_load_vec(weight_register)[0]
+
+    sum_of_squares = value * value
+    for offset in (32, 16, 8, 4, 2, 1):
+        sum_of_squares = sum_of_squares + sum_of_squares.shuffle_xor(
+            offset,
+            columns,
+        )
+    inverse_rms = fmath.rsqrt(
+        sum_of_squares / fx.Float32(float(columns)) + fx.Float32(RMS_EPS)
+    )
+    normalized = value * inverse_rms * weight_value
+    fx.memref_store_vec(full(1, normalized, fx.Float32), out_register)
+    fx.copy_atom_call(
+        copy_atom,
+        out_register,
+        fx.slice(row_out, (None, thread)),
+    )
+
+
+@flyc.jit
+def rms_norm_launcher(
+    inp: fx.Tensor,
+    weight: fx.Tensor,
+    out: fx.Tensor,
+    rows: fx.Int32,
+    columns: fx.Constexpr[int],
+):
+    _rms_norm_kernel(inp, weight, out, columns).launch(
+        grid=(rows, 1, 1),
+        block=(columns, 1, 1),
+    )

--- a/test/inductor/flydsl_aot/test_flydsl_aot_compiler.py
+++ b/test/inductor/flydsl_aot/test_flydsl_aot_compiler.py
@@ -1,0 +1,326 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import ctypes
+import tempfile
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, cast
+from unittest import mock
+
+import torch
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch.testing._internal.common_utils import TestCase
+
+
+HAS_FLYDSL = runtime_available()
+if HAS_FLYDSL:
+    import flydsl.compiler as flyc
+    import flydsl.expr as fx
+    from flydsl._mlir import execution_engine, ir
+    from flydsl.compiler import backends, jit_executor, jit_function, protocol
+    from flydsl.compiler.jit_argument import PointerJitArg, TorchTensorJitArg
+
+if HAS_FLYDSL:
+    from torch._inductor.codegen.flydsl.aot_compile import (
+        _argument_abi,
+        _bundle_runtime_libraries,
+        _publish_runtime_library,
+        compile_aot,
+        CompiledAOTLauncher,
+    )
+
+
+class _FakeExecutionEngine:
+    module_text = ""
+    enable_pic = False
+
+    def __init__(self, module, *, opt_level, shared_libs, enable_pic=False):
+        self.__class__.module_text = str(module)
+        self.__class__.enable_pic = enable_pic
+
+    def dump_to_object_file(self, path):
+        Path(path).write_bytes(b"flydsl-object")
+
+
+@unittest.skipUnless(HAS_FLYDSL, "FlyDSL is not available")
+class FlyDSLAOTCompilerTest(TestCase):
+    def _compiled_launcher(self):
+        with ir.Context() as ctx:
+            ctx.load_all_available_dialects()
+            module = ir.Module.parse(
+                """
+                module {
+                  llvm.func @launcher() {
+                    llvm.return
+                  }
+                }
+                """
+            )
+            return CompiledAOTLauncher(
+                module,
+                "launcher",
+                (
+                    {
+                        "arg_index": 0,
+                        "arg_name": "out",
+                        "kind": "tensor_data",
+                        "ctype": "pointer",
+                        "size": 8,
+                        "alignment": 8,
+                    },
+                ),
+            )
+
+    def test_export_uses_packed_entry_and_explicit_module_symbols(self):
+        _FakeExecutionEngine.enable_pic = False
+        compiled = self._compiled_launcher()
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch.object(
+                execution_engine,
+                "ExecutionEngine",
+                _FakeExecutionEngine,
+            ),
+            mock.patch.object(
+                jit_executor,
+                "_resolve_runtime_libs",
+                return_value=["/runtime/libfly_jit_runtime.so"],
+            ),
+            mock.patch(
+                "torch._inductor.codegen.flydsl.aot_compile._rename_loader_symbols",
+                return_value=("launcher__init", "launcher__load"),
+            ) as rename_loader_symbols,
+            mock.patch(
+                "torch._inductor.codegen.flydsl.aot_compile._bundle_runtime_libraries",
+                return_value=["/runtime/libfly_jit_runtime.so"],
+            ),
+        ):
+            output = Path(tmpdir) / "kernel.o"
+            metadata = compiled.export_to_c(str(output), "flydsl_test_launcher")
+
+            self.assertEqual(b"flydsl-object", output.read_bytes())
+            self.assertEqual("_mlir_flydsl_test_launcher", metadata["symbol"])
+            self.assertEqual("launcher__init", metadata["module_init_symbol"])
+            self.assertEqual("launcher__load", metadata["module_load_symbol"])
+            self.assertTrue(_FakeExecutionEngine.enable_pic)
+            self.assertIn("@flydsl_test_launcher", _FakeExecutionEngine.module_text)
+            self.assertNotIn("@launcher", _FakeExecutionEngine.module_text)
+            rename_loader_symbols.assert_called_once_with(
+                output,
+                "flydsl_test_launcher",
+            )
+
+    def test_runtime_bundle_includes_sonames_and_flydsl_dependencies(self):
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            tempfile.TemporaryDirectory() as system_tmpdir,
+        ):
+            root = Path(tmpdir)
+            mlir_libs = root / "flydsl" / "_mlir" / "_mlir_libs"
+            wheel_libs = root / "flydsl.libs"
+            output_dir = root / "output"
+            mlir_libs.mkdir(parents=True)
+            wheel_libs.mkdir()
+            output_dir.mkdir()
+            runtime = mlir_libs / "libmlir_c_runner_utils.so"
+            float16 = mlir_libs / "libmlir_float16_utils.so.23"
+            apfloat = wheel_libs / "libmlir_apfloat.so.23"
+            system = Path(system_tmpdir) / "libc.so.6"
+            for path in (runtime, float16, apfloat, system):
+                path.write_bytes(path.name.encode())
+
+            with (
+                mock.patch(
+                    "torch._inductor.codegen.flydsl.aot_compile._elf_soname",
+                    return_value="libmlir_c_runner_utils.so.23",
+                ),
+                mock.patch(
+                    "torch._inductor.codegen.flydsl.aot_compile._runtime_library_dependencies",
+                    return_value={
+                        float16.name: float16,
+                        apfloat.name: apfloat,
+                        system.name: system,
+                    },
+                ),
+            ):
+                bundled = _bundle_runtime_libraries([str(runtime)], output_dir)
+
+            self.assertCountEqual(
+                [
+                    str(output_dir / "libmlir_c_runner_utils.so.23"),
+                    str(output_dir / float16.name),
+                    str(output_dir / apfloat.name),
+                ],
+                bundled,
+            )
+            self.assertFalse((output_dir / system.name).exists())
+
+    def test_runtime_library_publication_is_atomic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            first = root / "first.so"
+            second = root / "second.so"
+            destination = root / "runtime.so"
+            first.write_bytes(b"first runtime")
+            second.write_bytes(b"second runtime")
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [
+                    executor.submit(_publish_runtime_library, source, destination)
+                    for source in (first, second)
+                ]
+                errors = [future.exception() for future in futures]
+
+            self.assertEqual(1, sum(error is None for error in errors))
+            self.assertEqual(
+                1, sum(isinstance(error, RuntimeError) for error in errors)
+            )
+            self.assertIn(
+                destination.read_bytes(), (first.read_bytes(), second.read_bytes())
+            )
+
+    def test_export_rejects_invalid_symbol(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaisesRegex(ValueError, "invalid C function name"):
+                self._compiled_launcher().export_to_c(
+                    str(Path(tmpdir) / "kernel.o"),
+                    "not-a-c-symbol",
+                )
+
+    def test_tensor_abi_describes_dynamic_layout(self):
+        tensor = cast(Any, torch).empty_strided((2, 3), (5, 1))
+
+        slots = _argument_abi(TorchTensorJitArg(tensor))
+
+        self.assertEqual("tensor_data", slots[0]["kind"])
+        self.assertEqual("tensor_layout", slots[1]["kind"])
+        self.assertEqual([0, 1], slots[1]["shape_dims"])
+        self.assertEqual([0], slots[1]["stride_dims"])
+        self.assertEqual(64, slots[1]["stride_bits"])
+
+    def test_integer_abi_uses_fixed_width_names(self):
+        self.assertEqual("bool", _argument_abi(fx.Boolean(True))[0]["ctype"])
+        self.assertEqual("int32", _argument_abi(fx.Int32(1))[0]["ctype"])
+        self.assertEqual("uint64", _argument_abi(fx.Uint64(1))[0]["ctype"])
+
+    def test_pointer_and_floating_point_abi(self):
+        pointer = object.__new__(PointerJitArg)
+
+        self.assertEqual(
+            [{"kind": "pointer", "ctype": "pointer", "size": 8, "alignment": 8}],
+            _argument_abi(pointer),
+        )
+        self.assertEqual(
+            "float16_bits",
+            _argument_abi(fx.Float16(1.0))[0]["encoding"],
+        )
+        self.assertEqual(
+            "bfloat16_bits",
+            _argument_abi(fx.BFloat16(1.0))[0]["encoding"],
+        )
+        self.assertEqual("float", _argument_abi(fx.Float32(1.0))[0]["ctype"])
+        self.assertEqual("double", _argument_abi(fx.Float64(1.0))[0]["ctype"])
+
+    def test_abi_rejects_unsupported_and_multi_slot_arguments(self):
+        with self.assertRaisesRegex(NotImplementedError, "unsupported JIT argument"):
+            _argument_abi(object())
+
+        with (
+            mock.patch.object(
+                protocol,
+                "c_abi_spec",
+                return_value=[
+                    (ctypes.c_int32, mock.Mock()),
+                    (ctypes.c_int32, mock.Mock()),
+                ],
+            ),
+            self.assertRaisesRegex(NotImplementedError, "exactly one C ABI slot"),
+        ):
+            _argument_abi(fx.Int32(1))
+
+    def test_compile_aot_does_not_dispatch_launcher(self):
+        @flyc.jit
+        def launcher(
+            inp: fx.Tensor,
+            block_dim: fx.Constexpr[int],
+            *,
+            rows: fx.Int32,
+        ):
+            pass
+
+        backend = mock.Mock()
+        backend.target.arch = "gfx950"
+        backend.gpu_module_targets.return_value = []
+        with (
+            mock.patch.object(
+                type(launcher),
+                "__call__",
+                side_effect=AssertionError("AOT compilation dispatched the launcher"),
+            ),
+            mock.patch.object(
+                backends,
+                "get_backend",
+                return_value=backend,
+            ),
+            mock.patch.object(
+                jit_function.MlirCompiler,
+                "compile",
+                side_effect=lambda module, **_kwargs: module,
+            ),
+        ):
+            compiled = compile_aot(
+                launcher,
+                cast(Any, torch).empty(8, device="meta"),
+                256,
+                rows=8,
+            )
+
+        self.assertIsInstance(compiled, CompiledAOTLauncher)
+        self.assertEqual(
+            ["tensor_data", "tensor_layout", "scalar", "stream"],
+            [slot["kind"] for slot in compiled.abi],
+        )
+        self.assertNotIn("block_dim", {slot["arg_name"] for slot in compiled.abi})
+
+    def test_compile_aot_traces_multiple_kernel_launches(self):
+        @flyc.kernel
+        def first_kernel():
+            pass
+
+        @flyc.kernel
+        def second_kernel():
+            pass
+
+        @flyc.jit
+        def launcher():
+            first_kernel().launch(grid=(1, 1, 1), block=(1, 1, 1))
+            second_kernel().launch(grid=(1, 1, 1), block=(1, 1, 1))
+
+        backend = mock.Mock()
+        backend.target.arch = "gfx950"
+        backend.gpu_module_targets.return_value = []
+        with (
+            mock.patch.object(
+                backends,
+                "get_backend",
+                return_value=backend,
+            ),
+            mock.patch.object(
+                jit_function.MlirCompiler,
+                "compile",
+                side_effect=lambda module, **_kwargs: module,
+            ),
+        ):
+            compiled = compile_aot(launcher)
+
+        self.assertEqual(2, compiled._ir_text.count("gpu.launch_func"))
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/test/inductor/flydsl_aot/test_flydsl_aot_compiler.py
+++ b/test/inductor/flydsl_aot/test_flydsl_aot_compiler.py
@@ -214,14 +214,12 @@ class FlyDSLAOTCompilerTest(TestCase):
             [{"kind": "pointer", "ctype": "pointer", "size": 8, "alignment": 8}],
             _argument_abi(pointer),
         )
-        self.assertEqual(
-            "float16_bits",
-            _argument_abi(fx.Float16(1.0))[0]["encoding"],
-        )
-        self.assertEqual(
-            "bfloat16_bits",
-            _argument_abi(fx.BFloat16(1.0))[0]["encoding"],
-        )
+        float16 = _argument_abi(fx.Float16(1.0))[0]
+        bfloat16 = _argument_abi(fx.BFloat16(1.0))[0]
+        self.assertEqual("uint16", float16["ctype"])
+        self.assertEqual("float16_bits", float16["encoding"])
+        self.assertEqual("uint16", bfloat16["ctype"])
+        self.assertEqual("bfloat16_bits", bfloat16["encoding"])
         self.assertEqual("float", _argument_abi(fx.Float32(1.0))[0]["ctype"])
         self.assertEqual("double", _argument_abi(fx.Float64(1.0))[0]["ctype"])
 
@@ -242,11 +240,20 @@ class FlyDSLAOTCompilerTest(TestCase):
         ):
             _argument_abi(fx.Int32(1))
 
-    def test_compile_aot_does_not_dispatch_launcher(self):
+    def test_unsupported_custom_jit_argument_is_rejected(self):
+        class CustomJitArgument:
+            def __c_abi_spec__(self):
+                return []
+
+        with self.assertRaisesRegex(NotImplementedError, "unsupported JIT argument"):
+            _argument_abi(CustomJitArgument())
+
+    def test_compile_aot_supports_positional_only_and_constexpr_arguments(self):
         @flyc.jit
         def launcher(
             inp: fx.Tensor,
             block_dim: fx.Constexpr[int],
+            /,
             *,
             rows: fx.Int32,
         ):

--- a/test/inductor/flydsl_aot/test_flydsl_aoti_e2e.py
+++ b/test/inductor/flydsl_aot/test_flydsl_aoti_e2e.py
@@ -1,0 +1,376 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+import torch
+from torch._higher_order_ops.flydsl_kernel_wrap import flydsl_kernel_wrapper_mutation
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch._inductor.utils import fresh_cache, run_and_get_cpp_code
+from torch.autograd import DeviceType
+from torch.testing._internal.common_utils import TestCase
+
+
+HAS_FLYDSL = torch.cuda.is_available() and runtime_available()
+if HAS_FLYDSL:
+    from caffe2.test.inductor.flydsl_aot.flydsl_aoti_test_models import (
+        BoundReluModel,
+        ComposedModel,
+        DynamicRMSNormModel,
+        RELU_SCALE,
+        TwoStageAddModel,
+        VectorAddModel,
+    )
+    from caffe2.test.inductor.flydsl_aot.flydsl_test_kernels import (
+        GEMM_K,
+        GEMM_M,
+        GEMM_N,
+        RMS_EPS,
+        RMS_N,
+    )
+
+RELOCATED_PACKAGE_LOADER_SCRIPT = """
+import sys
+
+import torch
+
+package_path = sys.argv[1]
+lhs = torch.arange(1024, device="cuda", dtype=torch.float32)
+rhs = torch.arange(1024, device="cuda", dtype=torch.float32).flip(0)
+loader = torch._C._aoti.AOTIModelPackageLoader(
+    package_path,
+    "model",
+    False,
+    1,
+    -1,
+)
+actual = loader.run([lhs, rhs])[0]
+torch.cuda.synchronize()
+torch.testing.assert_close(actual, lhs + rhs)
+"""
+
+
+@unittest.skipUnless(HAS_FLYDSL, "FlyDSL is not available")
+class FlyDSLAOTIEndToEndTest(TestCase):
+    def _assert_package_runs_after_relocation(
+        self,
+        package_path: str,
+        root: Path,
+    ) -> None:
+        relocated_dir = root / "relocated"
+        relocated_dir.mkdir()
+        relocated_package = relocated_dir / "renamed_model.pt2"
+        shutil.move(package_path, relocated_package)
+        Path(package_path).parent.rmdir()
+
+        child_cache = root / "child_cache"
+        child_cache.mkdir()
+        env = os.environ.copy()
+        env["TORCHINDUCTOR_CACHE_DIR"] = str(child_cache)
+        env["TRITON_CACHE_DIR"] = str(child_cache / "triton")
+        env["PYTHONPATH"] = os.pathsep.join(path for path in sys.path if path)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                RELOCATED_PACKAGE_LOADER_SCRIPT,
+                str(relocated_package),
+            ],
+            cwd=relocated_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        self.assertEqual(
+            0,
+            result.returncode,
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+    def test_vector_add_runs_from_package(self):
+        lhs = torch.randn(1024, device="cuda", dtype=torch.float32)
+        rhs = torch.randn_like(lhs)
+        exported = torch.export.export(VectorAddModel(), (lhs, rhs), strict=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            producer_dir = root / "producer"
+            producer_dir.mkdir()
+            with fresh_cache(dir=tmpdir):
+                producer_cache = Path(os.environ["TORCHINDUCTOR_CACHE_DIR"])
+                package_path, generated_code = run_and_get_cpp_code(
+                    torch._inductor.aoti_compile_and_package,
+                    exported,
+                    package_path=str(producer_dir / "flydsl_vector_add.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+            self.assertFalse(producer_cache.exists())
+            self.assertNotIn("aoti_torch_clone", generated_code)
+            self.assertNotIn("aoti_torch_copy_", generated_code)
+            self.assertNotIn("triton_poi", generated_code)
+            with zipfile.ZipFile(package_path) as package:
+                packaged_files = package.namelist()
+            self.assertTrue(
+                any(path.endswith("/libfly_jit_runtime.so") for path in packaged_files),
+                packaged_files,
+            )
+            self.assertTrue(
+                any(
+                    Path(path).name.startswith("libmlir_c_runner_utils.so")
+                    for path in packaged_files
+                ),
+                packaged_files,
+            )
+            loader = torch._C._aoti.AOTIModelPackageLoader(
+                package_path,
+                "model",
+                False,
+                1,
+                -1,
+            )
+            actual = loader.run([lhs, rhs])[0]
+            torch.testing.assert_close(actual, lhs + rhs)
+
+            stream = torch.cuda.Stream()
+            self.assertNotEqual(
+                stream.cuda_stream,
+                torch.cuda.default_stream().cuda_stream,
+            )
+            marker = torch.empty_like(lhs)
+            with torch.cuda.stream(stream):
+                torch.add(lhs, rhs, out=marker)
+                loader.run([lhs, rhs])
+            torch.cuda.synchronize()
+
+            with torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CUDA],
+            ) as prof:
+                with torch.cuda.stream(stream):
+                    torch.add(lhs, rhs, out=marker)
+                    stream_actual = loader.run([lhs, rhs])[0]
+                torch.cuda.synchronize()
+            gpu_events = [
+                event for event in prof.events() if event.device_type == DeviceType.CUDA
+            ]
+            self.assertGreaterEqual(len(gpu_events), 2)
+            self.assertEqual(
+                1,
+                len({event.device_resource_id for event in gpu_events}),
+                [(event.name, event.device_resource_id) for event in gpu_events],
+            )
+            torch.testing.assert_close(stream_actual, lhs + rhs)
+
+            del loader
+            self._assert_package_runs_after_relocation(package_path, root)
+
+    def test_multi_kernel_launcher_runs_from_package(self):
+        lhs = torch.randn(1024, device="cuda", dtype=torch.float32)
+        rhs = torch.randn_like(lhs)
+        exported = torch.export.export(TwoStageAddModel(), (lhs, rhs), strict=True)
+        self.assertEqual(
+            1,
+            len(
+                exported.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=flydsl_kernel_wrapper_mutation,
+                )
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_two_stage_add.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                actual = compiled(lhs, rhs)
+
+        torch.testing.assert_close(actual, torch.sin(lhs + rhs + rhs))
+
+    def test_bound_launcher_runs_eager_and_from_package(self):
+        inp = torch.randn(1024, device="cuda", dtype=torch.float32)
+        model = BoundReluModel()
+        expected = torch.relu(inp) * RELU_SCALE
+
+        eager_actual = model(inp)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(eager_actual, expected)
+
+        exported = torch.export.export(model, (inp,), strict=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_bound_relu.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                aoti_actual = compiled(inp)
+
+        torch.testing.assert_close(aoti_actual, expected)
+
+    def test_dynamic_rms_norm_runs_multiple_row_counts(self):
+        inp = torch.randn(4, RMS_N, device="cuda", dtype=torch.float32)
+        weight = torch.randn(RMS_N, device="cuda", dtype=torch.float32)
+        rows = torch.export.Dim("rows", min=1, max=32)
+        exported = torch.export.export(
+            DynamicRMSNormModel(),
+            (inp, weight),
+            dynamic_shapes=({0: rows}, None),
+            strict=True,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_dynamic_rms_norm.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                loader = torch._C._aoti.AOTIModelPackageLoader(
+                    package_path,
+                    "model",
+                    False,
+                    1,
+                    -1,
+                )
+                for row_count in (1, 4, 17, 32):
+                    test_inp = torch.randn(
+                        row_count,
+                        RMS_N,
+                        device="cuda",
+                        dtype=torch.float32,
+                    )
+                    actual = loader.run([test_inp, weight])[0]
+                    expected = (
+                        test_inp
+                        * torch.rsqrt(
+                            test_inp.square().mean(dim=-1, keepdim=True) + RMS_EPS
+                        )
+                        * weight
+                    )
+                    torch.testing.assert_close(
+                        actual,
+                        expected,
+                        atol=2e-4,
+                        rtol=2e-4,
+                    )
+
+    def test_non_contiguous_rms_norm_runs_from_package(self):
+        rows = 4
+        inp = (
+            torch.arange(
+                rows * RMS_N,
+                device="cuda",
+                dtype=torch.float32,
+            )
+            .reshape(RMS_N, rows)
+            .transpose(0, 1)
+        )
+        weight = torch.randn(RMS_N, device="cuda", dtype=torch.float32)
+        self.assertFalse(inp.is_contiguous())
+        self.assertEqual((1, rows), inp.stride())
+        exported = torch.export.export(
+            DynamicRMSNormModel(),
+            (inp, weight),
+            strict=True,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(
+                        Path(tmpdir) / "flydsl_non_contiguous_rms_norm.pt2"
+                    ),
+                    inductor_configs={"compile_threads": 1},
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                runtime_inp = torch.randn(
+                    RMS_N,
+                    rows,
+                    device="cuda",
+                    dtype=torch.float32,
+                ).transpose(0, 1)
+                self.assertEqual(inp.stride(), runtime_inp.stride())
+                actual = compiled(runtime_inp, weight)
+
+        expected = (
+            runtime_inp
+            * torch.rsqrt(runtime_inp.square().mean(dim=-1, keepdim=True) + RMS_EPS)
+            * weight
+        )
+        torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-4)
+
+    def test_composes_multiple_flydsl_and_pytorch_ops(self):
+        torch.manual_seed(0)
+        lhs = torch.randn(GEMM_M, GEMM_K, device="cuda", dtype=torch.float32)
+        rhs = torch.randn(GEMM_N, GEMM_K, device="cuda", dtype=torch.float32)
+        bias = torch.randn(GEMM_N, device="cuda", dtype=torch.float32)
+        weight = torch.randn(RMS_N, device="cuda", dtype=torch.float32)
+        inputs = (lhs, rhs, bias, weight)
+        exported = torch.export.export(ComposedModel(), inputs, strict=True)
+        flydsl_nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+        self.assertEqual(3, len(flydsl_nodes))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with fresh_cache(dir=tmpdir):
+                package_path = torch._inductor.aoti_compile_and_package(
+                    exported,
+                    package_path=str(Path(tmpdir) / "flydsl_composed.pt2"),
+                    inductor_configs={"compile_threads": 1},
+                )
+                with zipfile.ZipFile(package_path) as package:
+                    packaged_files = package.namelist()
+                self.assertEqual(
+                    1,
+                    sum(
+                        path.endswith("/libfly_jit_runtime.so")
+                        for path in packaged_files
+                    ),
+                )
+                compiled = torch._inductor.aoti_load_package(package_path)
+                actual = compiled(*inputs)
+
+        expected_gemm = lhs @ rhs.T
+        expected_activation = torch.relu(expected_gemm + bias) * RELU_SCALE
+        mixed = expected_activation + torch.sin(expected_activation) * 0.25
+        expected_normalized = (
+            mixed
+            * torch.rsqrt(mixed.square().mean(dim=-1, keepdim=True) + RMS_EPS)
+            * weight
+        )
+        expected = (
+            expected_normalized * 1.5 - 0.5,
+            expected_gemm,
+            expected_activation,
+            expected_normalized,
+        )
+        for actual_value, expected_value in zip(actual, expected):
+            torch.testing.assert_close(
+                actual_value,
+                expected_value,
+                atol=2e-4,
+                rtol=2e-4,
+            )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/test/inductor/flydsl_aot/test_flydsl_capture.py
+++ b/test/inductor/flydsl_aot/test_flydsl_capture.py
@@ -1,0 +1,480 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import inspect
+import unittest
+from collections.abc import Callable
+from unittest import mock
+
+import torch
+from torch._higher_order_ops.flydsl_kernel_wrap import (
+    flydsl_kernel_wrapper_functional,
+    flydsl_kernel_wrapper_mutation,
+    flydsl_launcher_side_table,
+    invoke_flydsl_launcher,
+    restore_flydsl_launcher_arguments,
+    split_flydsl_launcher_arguments,
+    TraceableFlyDSLLauncher,
+)
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch.testing._internal.common_utils import TestCase
+
+
+HAS_FLYDSL = runtime_available()
+if HAS_FLYDSL:
+    import flydsl.compiler as flyc
+    import flydsl.expr as fx
+    from flydsl.compiler.jit_argument import PointerJitArg
+    from flydsl.expr.typing import Stream
+
+
+if HAS_FLYDSL:
+
+    @flyc.jit
+    def _launcher(out: fx.Tensor, inp: fx.Tensor, rows: fx.Int32):
+        pass
+
+else:
+    _launcher = None
+
+
+class _EagerLauncher:
+    def __init__(self) -> None:
+        self.func = self.launch
+
+    def launch(
+        self,
+        out: torch.Tensor,
+        workspace: torch.Tensor,
+        inp: torch.Tensor,
+    ) -> None:
+        out.copy_(inp)
+        workspace.fill_(7)
+
+    def __call__(
+        self,
+        out: torch.Tensor,
+        workspace: torch.Tensor,
+        inp: torch.Tensor,
+    ) -> None:
+        self.launch(out, workspace, inp)
+
+
+@unittest.skipUnless(HAS_FLYDSL, "FlyDSL is not available")
+class FlyDSLCaptureTest(TestCase):
+    def setUp(self):
+        flydsl_launcher_side_table.reset_table()
+        torch._dynamo.reset()
+
+    def test_export_captures_explicit_launcher(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured_launcher(out=out, inp=inp, rows=inp.numel())
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+        self.assertEqual(1, len(nodes))
+        self.assertEqual((0,), nodes[0].kwargs["mutated_arg_indices"])
+
+    def test_mutations_must_be_explicit(self):
+        with self.assertRaisesRegex(TypeError, "mutates_args"):
+            torch.library.wrap_flydsl(_launcher)
+
+    def test_repeated_wrap_reuses_registration(self):
+        first = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+        second = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+        different_mutations = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out", "inp"},
+        )
+
+        self.assertEqual(first.launcher_idx, second.launcher_idx)
+        self.assertNotEqual(first.launcher_idx, different_mutations.launcher_idx)
+
+    def test_capture_rejects_unknown_mutated_argument(self):
+        with self.assertRaisesRegex(ValueError, "not launcher parameters"):
+            torch.library.wrap_flydsl(
+                _launcher,
+                mutates_args={"missing"},
+            )
+
+    def test_wrap_rejects_non_jit_function(self):
+        with self.assertRaisesRegex(RuntimeError, "annotated with flydsl.compiler.jit"):
+            torch.library.wrap_flydsl(lambda: None, mutates_args=())
+
+    def test_wrap_reports_missing_optional_runtime(self):
+        with (
+            mock.patch(
+                "torch._inductor.codegen.flydsl.flydsl_utils.runtime_available",
+                return_value=False,
+            ) as available,
+            self.assertRaisesRegex(RuntimeError, "optional `flydsl` runtime"),
+        ):
+            torch.library.wrap_flydsl(object(), mutates_args=())
+
+        available.assert_called_once_with()
+
+    def test_wrap_rejects_explicit_stream(self):
+        @flyc.jit
+        def launcher(out: fx.Tensor, stream: Stream):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "current device stream"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+    def test_split_launcher_arguments_preserves_parameter_kinds(self):
+        def launcher(out, /, inp, *, rows):
+            pass
+
+        positional, keyword = split_flydsl_launcher_arguments(
+            inspect.signature(launcher),
+            ("out", "inp", 8),
+        )
+
+        self.assertEqual(("out", "inp"), positional)
+        self.assertEqual({"rows": 8}, keyword)
+
+    def test_split_launcher_arguments_rejects_variadic_parameters(self):
+        @flyc.jit
+        def launcher(out: fx.Tensor, *inputs: fx.Tensor):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "variadic parameters cannot be wrapped"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+    def test_export_captures_dynamic_dimension(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured_launcher(out, inp, inp.numel())
+                return out
+
+        batch = torch.export.Dim("batch", min=1, max=32)
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(4, 8),),
+            dynamic_shapes=({0: batch},),
+        )
+
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+        self.assertEqual(1, len(nodes))
+        self.assertTrue(exported.range_constraints)
+        rows = nodes[0].kwargs["args"][2]
+        self.assertIsInstance(rows, torch.fx.Node)
+        self.assertIsInstance(rows.meta["val"], torch.SymInt)
+
+    def test_export_keeps_compile_time_arguments_out_of_fx(self):
+        callback = lambda value: value  # noqa: E731
+
+        @flyc.jit
+        def launcher(
+            out: fx.Tensor,
+            inp: fx.Tensor,
+            transform: fx.Constexpr[Callable],
+            element_type: type[fx.Float32],
+            block_dim: fx.Constexpr[int],
+        ):
+            pass
+
+        captured = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured(out, inp, callback, fx.Float32, 256)
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        (node,) = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        runtime_args = node.kwargs["args"]
+        self.assertEqual((None, None, None), runtime_args[2:])
+        restored = restore_flydsl_launcher_arguments(
+            runtime_args,
+            node.kwargs["call_spec_idx"],
+        )
+        self.assertIs(callback, restored[2])
+        self.assertIs(fx.Float32, restored[3])
+        self.assertEqual(256, restored[4])
+
+    def test_constexpr_call_specs_use_flydsl_value_identity(self):
+        @flyc.jit
+        def launcher(out: fx.Tensor, config: fx.Constexpr[tuple]):
+            pass
+
+        captured = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                first = torch.empty_like(inp)
+                second = torch.empty_like(inp)
+                captured(first, (True,))
+                captured(second, (1,))
+                return first, second
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        self.assertEqual(2, len(nodes))
+        self.assertEqual(
+            [(True,), (1,)],
+            [
+                restore_flydsl_launcher_arguments(
+                    node.kwargs["args"],
+                    node.kwargs["call_spec_idx"],
+                )[1]
+                for node in nodes
+            ],
+        )
+        self.assertNotEqual(
+            nodes[0].kwargs["call_spec_idx"],
+            nodes[1].kwargs["call_spec_idx"],
+        )
+
+    def test_wrap_rejects_preconstructed_runtime_jit_arguments(self):
+        captured = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+        out = torch.empty(4)
+        inp = torch.empty(4)
+
+        for value in (fx.Int32(4), object.__new__(PointerJitArg)):
+            with self.assertRaisesRegex(TypeError, "graphable PyTorch values"):
+                captured(out, inp, value)
+
+    def test_wrap_rejects_non_tensor_mutation(self):
+        @flyc.jit
+        def launcher(value: fx.Int32):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "flydsl.expr.Tensor annotation"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"value"})
+
+    def test_wrap_rejects_unannotated_mutation(self):
+        @flyc.jit
+        def launcher(value):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "flydsl.expr.Tensor annotation"):
+            torch.library.wrap_flydsl(launcher, mutates_args={"value"})
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires a GPU")
+    def test_eager_wrap_rejects_non_default_stream(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+        out = torch.empty(4, device="cuda")
+        workspace = torch.empty(4, device="cuda")
+        inp = torch.empty(4, device="cuda")
+
+        with (
+            torch.cuda.stream(torch.cuda.Stream()),
+            self.assertRaisesRegex(RuntimeError, "default device stream"),
+        ):
+            flydsl_kernel_wrapper_mutation(
+                registration.launcher_idx,
+                call_spec_idx,
+                (out, workspace, inp),
+                (0, 1),
+            )
+
+    def test_export_registers_and_deduplicates_compile_time_call_specs(self):
+        @flyc.jit
+        def launcher(
+            out: fx.Tensor,
+            inp: fx.Tensor,
+            block_dim: fx.Constexpr[int],
+        ):
+            pass
+
+        captured = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                first = torch.empty_like(inp)
+                second = torch.empty_like(inp)
+                third = torch.empty_like(inp)
+                captured(first, inp, 64)
+                captured(second, inp, 128)
+                captured(third, inp, 64)
+                return first, second, third
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        self.assertEqual(3, len(nodes))
+        self.assertEqual(
+            [64, 128, 64],
+            [
+                restore_flydsl_launcher_arguments(
+                    node.kwargs["args"],
+                    node.kwargs["call_spec_idx"],
+                )[2]
+                for node in nodes
+            ],
+        )
+        self.assertEqual(
+            nodes[0].kwargs["call_spec_idx"],
+            nodes[2].kwargs["call_spec_idx"],
+        )
+        self.assertNotEqual(
+            nodes[0].kwargs["call_spec_idx"],
+            nodes[1].kwargs["call_spec_idx"],
+        )
+
+    def test_export_captures_bound_jit_method_without_self_operand(self):
+        class LauncherOwner:
+            @flyc.jit
+            def launch(self, out: fx.Tensor, inp: fx.Tensor, rows: fx.Int32):
+                pass
+
+        owner = LauncherOwner()
+        captured = torch.library.wrap_flydsl(owner.launch, mutates_args={"out"})
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                captured(out, inp, inp.numel())
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        (node,) = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_mutation,
+        )
+
+        registration = flydsl_launcher_side_table.get_registration(
+            node.kwargs["launcher_idx"]
+        )
+        self.assertIs(owner, registration.bound_self)
+        self.assertEqual(3, len(node.kwargs["args"]))
+        with mock.patch.object(
+            type(registration.launcher),
+            "__call__",
+            autospec=True,
+        ) as launch:
+            invoke_flydsl_launcher(registration, ("out", "inp", 8))
+        launch.assert_called_once_with(
+            registration.launcher,
+            owner,
+            "out",
+            "inp",
+            8,
+        )
+
+    def test_hop_reports_tensor_subclass_once(self):
+        class TensorSubclass(torch.Tensor):
+            @classmethod
+            def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+                return NotImplemented
+
+        tensor = TensorSubclass._make_subclass(
+            TensorSubclass,
+            torch.ones(4),
+            False,
+        )
+        self.assertTrue(torch._C._dispatch_keys(tensor).has("Python"))
+
+        overloaded = flydsl_kernel_wrapper_mutation._get_overloaded_args(
+            (),
+            {"args": (tensor,)},
+        )
+
+        self.assertEqual(1, len(overloaded))
+        self.assertIs(tensor, overloaded[0])
+
+    def test_functional_wrapper_clones_only_requested_outputs(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        out = torch.empty(4)
+        workspace = torch.zeros(4)
+        inp = torch.arange(4, dtype=torch.float32)
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+
+        actual_out, actual_workspace = flydsl_kernel_wrapper_functional(
+            registration.launcher_idx,
+            call_spec_idx,
+            (out, workspace, inp),
+            (0, 1),
+            (1,),
+        )
+
+        torch.testing.assert_close(out, inp)
+        self.assertEqual(actual_out.data_ptr(), out.data_ptr())
+        torch.testing.assert_close(workspace, torch.zeros_like(workspace))
+        torch.testing.assert_close(actual_workspace, torch.full_like(workspace, 7))
+        self.assertNotEqual(actual_workspace.data_ptr(), workspace.data_ptr())
+
+    def test_functional_wrapper_rejects_identical_aliased_arguments(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        tensor = torch.zeros(4)
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+
+        with self.assertRaisesRegex(RuntimeError, "aliased launcher arguments"):
+            flydsl_kernel_wrapper_functional(
+                registration.launcher_idx,
+                call_spec_idx,
+                (tensor, tensor, tensor),
+                (0, 1),
+                (0, 1),
+            )
+
+    def test_functional_wrapper_rejects_view_alias(self):
+        registration = TraceableFlyDSLLauncher(
+            _EagerLauncher(),
+            (0, 1),
+        )
+        base = torch.zeros(8)
+        out = base[:4]
+        workspace = torch.zeros(4)
+        inp = base[2:6]
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+
+        with self.assertRaisesRegex(RuntimeError, "aliased launcher arguments"):
+            flydsl_kernel_wrapper_functional(
+                registration.launcher_idx,
+                call_spec_idx,
+                (out, workspace, inp),
+                (0, 1),
+                (0,),
+            )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/test/inductor/flydsl_aot/test_flydsl_capture.py
+++ b/test/inductor/flydsl_aot/test_flydsl_capture.py
@@ -18,6 +18,7 @@ from torch._higher_order_ops.flydsl_kernel_wrap import (
     TraceableFlyDSLLauncher,
 )
 from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch._library.utils import get_layout_constraint_tag
 from torch.testing._internal.common_utils import TestCase
 
 
@@ -472,6 +473,196 @@ class FlyDSLCaptureTest(TestCase):
                 (0, 1),
                 (0,),
             )
+
+    def test_flydsl_op_is_opaque_to_symbolic_trace(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::symbolic_trace",
+            mutates_args=(),
+        )
+        def flydsl_add(inp: torch.Tensor) -> torch.Tensor:
+            if inp.shape[1] != 8:
+                raise ValueError("expected width eight")
+            out = torch.empty_like(inp)
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_add(inp)
+
+        traced = torch.fx.symbolic_trace(Model())
+
+        nodes = traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.test_flydsl_capture.symbolic_trace.default,
+        )
+        self.assertEqual(1, len(nodes))
+
+    def test_flydsl_op_preserves_exact_strides_by_default(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::exact_strides",
+            mutates_args=(),
+        )
+        def flydsl_add(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+
+        self.assertEqual(
+            torch._C.Tag.needs_exact_strides,
+            get_layout_constraint_tag(
+                torch.ops.test_flydsl_capture.exact_strides.default
+            ),
+        )
+
+        example = torch.randn(8, 4).t()
+        self.assertEqual((1, 4), example.stride())
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_add(inp)
+
+        exported = torch.export.export(Model(), (example,))
+        custom_op_node = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.test_flydsl_capture.exact_strides.default,
+        )[0]
+        input_node = custom_op_node.args[0]
+        self.assertIsInstance(input_node, torch.fx.Node)
+        self.assertEqual(example.stride(), input_node.meta["val"].stride())
+
+    def test_flydsl_op_decomposes_for_export(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::export",
+            mutates_args=(),
+        )
+        def flydsl_add(inp: torch.Tensor) -> torch.Tensor:
+            if inp.shape[1] != 8:
+                raise ValueError("expected width eight")
+            out = torch.empty_like(inp)
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_add(inp)
+
+        batch = torch.export.Dim("batch", min=1, max=32)
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(4, 8),),
+            dynamic_shapes=({0: batch},),
+        )
+
+        custom_op_nodes = exported.graph_module.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.test_flydsl_capture.export.default,
+        )
+        self.assertEqual(1, len(custom_op_nodes))
+
+        decomposed = exported.run_decompositions()
+        flydsl_nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        self.assertEqual(1, len(flydsl_nodes))
+
+    def test_flydsl_op_preserves_mutation_when_decomposed(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::mutation",
+            mutates_args={"out"},
+        )
+        def flydsl_copy(out: torch.Tensor, inp: torch.Tensor) -> None:
+            captured_launcher(out=out, inp=inp, rows=inp.numel())
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                out = torch.empty_like(inp)
+                flydsl_copy(out, inp)
+                return out
+
+        exported = torch.export.export(Model(), (torch.randn(8),))
+        decomposed = exported.run_decompositions()
+
+        nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        self.assertEqual(1, len(nodes))
+        self.assertEqual((0,), nodes[0].kwargs["mutated_arg_indices"])
+
+    def test_flydsl_op_decomposes_multiple_launchers_and_aten(self):
+        captured_launcher = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::composed",
+            mutates_args=(),
+        )
+        def composed(inp: torch.Tensor) -> torch.Tensor:
+            intermediate = torch.empty_like(inp)
+            captured_launcher(
+                out=intermediate,
+                inp=inp,
+                rows=inp.numel(),
+            )
+            shifted = intermediate + 1
+            out = torch.empty_like(inp)
+            captured_launcher(
+                out=out,
+                inp=shifted,
+                rows=shifted.numel(),
+            )
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return composed(inp)
+
+        batch = torch.export.Dim("batch", min=1, max=32)
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(4, 8),),
+            dynamic_shapes=({0: batch},),
+        )
+        decomposed = exported.run_decompositions()
+
+        flydsl_nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        aten_nodes = decomposed.graph_module.graph.find_nodes(
+            op="call_function",
+            target=torch.ops.aten.add.Tensor,
+        )
+        self.assertEqual(2, len(flydsl_nodes))
+        self.assertEqual(1, len(aten_nodes))
+        for node in flydsl_nodes:
+            rows = node.kwargs["args"][2]
+            self.assertIsInstance(rows, torch.fx.Node)
+            self.assertIsInstance(rows.meta["val"], torch.SymInt)
 
 
 if __name__ == "__main__":

--- a/test/inductor/flydsl_aot/test_flydsl_capture.py
+++ b/test/inductor/flydsl_aot/test_flydsl_capture.py
@@ -575,12 +575,159 @@ class FlyDSLCaptureTest(TestCase):
         )
         self.assertEqual(1, len(custom_op_nodes))
 
-        decomposed = exported.run_decompositions()
+        preserved = exported.run_decompositions(
+            decomp_table={},
+            decompose_custom_triton_ops=True,
+        )
+        self.assertEqual(
+            1,
+            len(
+                preserved.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=torch.ops.test_flydsl_capture.export.default,
+                )
+            ),
+        )
+        self.assertEqual(
+            [],
+            preserved.graph_module.graph.find_nodes(
+                op="call_function",
+                target=flydsl_kernel_wrapper_functional,
+            ),
+        )
+
+        with torch._functorch.config.patch(decompose_custom_flydsl_ops=False):
+            decomposed = exported.run_decompositions(
+                decomp_table={},
+                decompose_custom_triton_ops=False,
+                decompose_custom_flydsl_ops=True,
+            )
         flydsl_nodes = decomposed.graph_module.graph.find_nodes(
             op="call_function",
             target=flydsl_kernel_wrapper_functional,
         )
         self.assertEqual(1, len(flydsl_nodes))
+
+    def test_flydsl_op_decomposes_for_torch_compile_by_default(self):
+        from torch._dynamo.testing import AotEagerAndRecordGraphs
+
+        captured = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::compile_default",
+            mutates_args=(),
+        )
+        def flydsl_copy(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            captured(out, inp, inp.numel())
+            return out
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_copy(inp)
+
+        backend = AotEagerAndRecordGraphs()
+        inp = torch.randn(8)
+
+        def invoke(_, args):
+            args[0].copy_(args[1])
+
+        with mock.patch(
+            "torch._higher_order_ops.flydsl_kernel_wrap.invoke_flydsl_launcher",
+            side_effect=invoke,
+        ):
+            actual = torch.compile(
+                Model(),
+                backend=backend,
+                fullgraph=True,
+            )(inp)
+
+        torch.testing.assert_close(actual, inp)
+        self.assertEqual(1, len(backend.fw_graphs))
+        graph = backend.fw_graphs[0].graph
+        self.assertEqual(
+            1,
+            len(
+                graph.find_nodes(
+                    op="call_function",
+                    target=flydsl_kernel_wrapper_functional,
+                )
+            ),
+        )
+        self.assertEqual(
+            [],
+            graph.find_nodes(
+                op="call_function",
+                target=torch.ops.test_flydsl_capture.compile_default.default,
+            ),
+        )
+
+    def test_flydsl_op_preserved_in_joint_export(self):
+        from torch.export.experimental import _export_forward_backward
+
+        captured = torch.library.wrap_flydsl(_launcher, mutates_args={"out"})
+
+        @torch.library.flydsl_op(
+            "test_flydsl_capture::joint_export",
+            mutates_args=(),
+        )
+        def flydsl_copy(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            captured(out, inp, inp.numel())
+            return out
+
+        def backward(ctx, grad):
+            return grad
+
+        flydsl_copy.register_autograd(backward)
+
+        class Model(torch.nn.Module):
+            def forward(self, inp):
+                return flydsl_copy(inp).sum()
+
+        exported = torch.export.export(
+            Model(),
+            (torch.randn(8, requires_grad=True),),
+        )
+        joint = _export_forward_backward(exported)
+
+        self.assertEqual(
+            1,
+            len(
+                joint.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=torch.ops.test_flydsl_capture.joint_export.default,
+                )
+            ),
+        )
+        self.assertEqual(
+            [],
+            joint.graph_module.graph.find_nodes(
+                op="call_function",
+                target=flydsl_kernel_wrapper_functional,
+            ),
+        )
+
+        decomposed = joint.run_decompositions(
+            decomp_table={},
+            decompose_custom_flydsl_ops=True,
+        )
+        self.assertEqual(
+            [],
+            decomposed.graph_module.graph.find_nodes(
+                op="call_function",
+                target=torch.ops.test_flydsl_capture.joint_export.default,
+            ),
+        )
+        self.assertEqual(
+            1,
+            len(
+                decomposed.graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=flydsl_kernel_wrapper_functional,
+                )
+            ),
+        )
 
     def test_flydsl_op_preserves_mutation_when_decomposed(self):
         captured_launcher = torch.library.wrap_flydsl(
@@ -602,7 +749,7 @@ class FlyDSLCaptureTest(TestCase):
                 return out
 
         exported = torch.export.export(Model(), (torch.randn(8),))
-        decomposed = exported.run_decompositions()
+        decomposed = exported.run_decompositions(decompose_custom_flydsl_ops=True)
 
         nodes = decomposed.graph_module.graph.find_nodes(
             op="call_function",
@@ -647,7 +794,7 @@ class FlyDSLCaptureTest(TestCase):
             (torch.randn(4, 8),),
             dynamic_shapes=({0: batch},),
         )
-        decomposed = exported.run_decompositions()
+        decomposed = exported.run_decompositions(decompose_custom_flydsl_ops=True)
 
         flydsl_nodes = decomposed.graph_module.graph.find_nodes(
             op="call_function",

--- a/test/inductor/flydsl_aot/test_flydsl_inductor.py
+++ b/test/inductor/flydsl_aot/test_flydsl_inductor.py
@@ -1,0 +1,721 @@
+# Owner(s): ["module: inductor"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+from torch._higher_order_ops.flydsl_kernel_wrap import (
+    flydsl_kernel_wrapper_functional,
+    flydsl_kernel_wrapper_mutation,
+    flydsl_launcher_side_table,
+    FlyDSLPythonLauncher,
+    TraceableFlyDSLLauncher,
+)
+from torch._inductor import config, ir
+from torch._inductor.codecache import (
+    BypassFxGraphCache,
+    CacheabilityValidator,
+    ROCmCodeCache,
+)
+from torch._inductor.codegen.cpp_wrapper_gpu import CppWrapperGpu
+from torch._inductor.codegen.flydsl.flydsl_aot import (
+    compile_launcher,
+    define_aot_kernel,
+    FlyDSLAOTArtifact,
+    generate_aot_kernel_call,
+)
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch._inductor.codegen.flydsl.user_defined_kernel import (
+    decompose_functional_wrapper,
+    lower_flydsl_kernel,
+)
+from torch._inductor.fx_passes.post_grad import _has_flydsl_kernel_wrapper
+from torch._inductor.fx_passes.reinplace import reinplace_inplaceable_ops_core
+from torch._inductor.utils import IndentedBuffer
+from torch._inductor.virtualized import V
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_utils import TestCase
+
+
+HAS_FLYDSL = runtime_available()
+if HAS_FLYDSL:
+    import flydsl.compiler as flyc
+    import flydsl.expr as fx
+
+    @flyc.jit
+    def _launcher(out: fx.Tensor, inp: fx.Tensor, *, rows: fx.Int32):
+        pass
+
+else:
+    _launcher = None
+
+
+@unittest.skipUnless(HAS_FLYDSL, "FlyDSL is not available")
+class FlyDSLInductorTest(TestCase):
+    def setUp(self):
+        flydsl_launcher_side_table.reset_table()
+
+    def test_lowering_preserves_arguments_and_mutations(self):
+        captured = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+        launcher_idx = captured.launcher_idx
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+        out = mock.create_autospec(ir.TensorBox, instance=True)
+        inp = mock.create_autospec(ir.TensorBox, instance=True)
+        for tensor in (out, inp):
+            tensor.get_size.return_value = (8,)
+            tensor.get_stride.return_value = (1,)
+            tensor.get_dtype.return_value = torch.float32
+        graph = mock.Mock()
+        graph.sizevars.optimization_hints.side_effect = lambda values: tuple(
+            int(value) for value in values
+        )
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch(
+                "torch._inductor.codegen.flydsl.user_defined_kernel.UserDefinedFlyDSLKernel"
+            ) as kernel,
+        ):
+            lower_flydsl_kernel(
+                launcher_idx=launcher_idx,
+                call_spec_idx=call_spec_idx,
+                args=(out, inp, 8),
+                mutated_arg_indices=(0,),
+            )
+
+        kernel.assert_called_once_with(
+            launcher_idx=launcher_idx,
+            call_spec_idx=call_spec_idx,
+            kernel_args=(out, inp, 8),
+            mutated_arg_indices=(0,),
+        )
+
+    def test_flydsl_hops_bypass_persistent_fx_graph_cache(self):
+        for target, kwargs in (
+            (
+                flydsl_kernel_wrapper_mutation,
+                {
+                    "launcher_idx": 0,
+                    "call_spec_idx": 0,
+                    "args": (),
+                    "mutated_arg_indices": (),
+                },
+            ),
+            (
+                flydsl_kernel_wrapper_functional,
+                {
+                    "launcher_idx": 0,
+                    "call_spec_idx": 0,
+                    "args": (),
+                    "mutated_arg_indices": (),
+                    "tensors_to_clone": (),
+                },
+            ),
+        ):
+            with self.subTest(target=target):
+                graph = torch.fx.Graph()
+                result = graph.call_function(target, kwargs=kwargs)
+                graph.output(result)
+                graph_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+                with self.assertRaisesRegex(
+                    BypassFxGraphCache,
+                    f"Can't cache HigherOrderOperator: {target.name()}",
+                ):
+                    CacheabilityValidator(
+                        graph_module,
+                        require_shape_env=False,
+                    ).validate()
+
+    def test_aot_kernel_rejects_cpp_only_packaging(self):
+        captured = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+        wrapper = SimpleNamespace(user_defined_kernel_cache={})
+        graph = SimpleNamespace(aot_mode=True)
+
+        with (
+            V.set_graph_handler(graph),
+            config.patch({"aot_inductor.package_cpp_only": True}),
+            mock.patch(
+                "torch._inductor.codegen.flydsl.flydsl_aot.compile_launcher"
+            ) as compile_launcher_mock,
+            self.assertRaisesRegex(NotImplementedError, "package_cpp_only"),
+        ):
+            define_aot_kernel(
+                wrapper,
+                captured.launcher_idx,
+                flydsl_launcher_side_table.add_call_spec({}),
+                (),
+            )
+
+        compile_launcher_mock.assert_not_called()
+
+    def test_post_grad_decomposes_functional_wrapper(self):
+        captured = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+        launcher_idx = captured.launcher_idx
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+        fake_mode = FakeTensorMode()
+        graph = torch.fx.Graph()
+        out = graph.placeholder("out")
+        inp = graph.placeholder("inp")
+        out.meta["val"] = fake_mode.from_tensor(torch.empty(8))
+        inp.meta["val"] = fake_mode.from_tensor(torch.empty(8))
+        functional = graph.call_function(
+            flydsl_kernel_wrapper_functional,
+            kwargs={
+                "launcher_idx": launcher_idx,
+                "call_spec_idx": call_spec_idx,
+                "args": (out, inp, 8),
+                "mutated_arg_indices": (0,),
+                "tensors_to_clone": (0,),
+            },
+        )
+        functional.meta["val"] = (fake_mode.from_tensor(torch.empty(8)),)
+        graph.output(functional)
+        graph_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        decompose_functional_wrapper(graph_module.graph)
+        graph_module.graph.lint()
+
+        self.assertEqual(
+            [],
+            graph_module.graph.find_nodes(
+                op="call_function",
+                target=flydsl_kernel_wrapper_functional,
+            ),
+        )
+        self.assertEqual(
+            1,
+            len(
+                graph_module.graph.find_nodes(
+                    op="call_function",
+                    target=flydsl_kernel_wrapper_mutation,
+                )
+            ),
+        )
+
+    def test_post_grad_skips_graphs_without_flydsl(self):
+        graph = torch.fx.Graph()
+        inp = graph.placeholder("inp")
+        graph.output(inp)
+        graph_module = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+        self.assertFalse(_has_flydsl_kernel_wrapper(graph_module.graph))
+        with mock.patch(
+            "torch._inductor.codegen.flydsl.user_defined_kernel.PatternMatcherPass",
+            side_effect=AssertionError("unneeded FlyDSL pattern pass"),
+        ):
+            decompose_functional_wrapper(graph_module.graph)
+
+    def test_post_grad_guard_finds_nested_flydsl(self):
+        child_graph = torch.fx.Graph()
+        child_graph.call_function(
+            flydsl_kernel_wrapper_functional,
+            kwargs={
+                "launcher_idx": 0,
+                "call_spec_idx": 0,
+                "args": (),
+                "mutated_arg_indices": (),
+                "tensors_to_clone": (),
+            },
+        )
+        child_graph.output(None)
+        child = torch.fx.GraphModule(torch.nn.Module(), child_graph)
+        root = torch.nn.Module()
+        root.add_module("child", child)
+        graph = torch.fx.Graph()
+        child_attr = graph.get_attr("child")
+        graph.output(child_attr)
+        graph_module = torch.fx.GraphModule(root, graph)
+
+        self.assertTrue(_has_flydsl_kernel_wrapper(graph_module.graph))
+
+    def test_python_launcher_restores_compile_time_arguments(self):
+        class EagerLauncher:
+            def __init__(self) -> None:
+                self.func = self.launch
+
+            def launch(self, out, factor, inp) -> None:
+                out.copy_(inp * factor)
+
+            def __call__(self, out, factor, inp) -> None:
+                self.launch(out, factor, inp)
+
+        captured = TraceableFlyDSLLauncher(
+            EagerLauncher(),
+            (0,),
+        )
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({1: 3})
+        launcher = FlyDSLPythonLauncher(captured.launcher_idx, call_spec_idx)
+        inp = torch.arange(4, dtype=torch.float32)
+        out = torch.empty_like(inp)
+
+        launcher.run(out, inp)
+
+        torch.testing.assert_close(out, inp * 3)
+
+    def _functional_graph(self, *, keep_original: bool) -> torch.fx.GraphModule:
+        captured = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({})
+
+        def f(inp):
+            out = torch.empty_like(inp)
+            (result,) = flydsl_kernel_wrapper_functional(
+                captured.launcher_idx,
+                call_spec_idx,
+                (out, inp, inp.numel()),
+                (0,),
+                (0,),
+            )
+            return (result, out) if keep_original else result
+
+        return make_fx(f, tracing_mode="fake")(torch.randn(8))
+
+    def test_reinplace_removes_clone_for_fresh_output(self):
+        graph_module = self._functional_graph(keep_original=False)
+
+        reinplace_inplaceable_ops_core(graph_module.graph)
+        graph_module.graph.lint()
+
+        (functional,) = graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        self.assertEqual((), functional.kwargs["tensors_to_clone"])
+
+        decompose_functional_wrapper(graph_module.graph)
+        graph_module.graph.lint()
+        self.assertEqual(
+            [],
+            graph_module.graph.find_nodes(
+                op="call_function",
+                target=torch.ops.aten.clone.default,
+            ),
+        )
+
+    def test_reinplace_keeps_clone_for_live_original(self):
+        graph_module = self._functional_graph(keep_original=True)
+
+        reinplace_inplaceable_ops_core(graph_module.graph)
+        graph_module.graph.lint()
+
+        (functional,) = graph_module.graph.find_nodes(
+            op="call_function",
+            target=flydsl_kernel_wrapper_functional,
+        )
+        self.assertEqual((0,), functional.kwargs["tensors_to_clone"])
+
+    def test_inductor_compiler_exports_flydsl_object(self):
+        captured = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+        registration = flydsl_launcher_side_table.get_registration(
+            captured.launcher_idx
+        )
+        compiled = mock.Mock()
+        compiled.export_to_c.return_value = {
+            "object_file_path": "/cache/launcher.o",
+            "symbol": "_mlir_flydsl_launcher_test",
+            "runtime_libraries": ["/runtime/libfly.so"],
+            "abi": [{"kind": "stream", "arg_index": None}],
+            "module_init_symbol": "flydsl_launcher_test__init",
+            "module_load_symbol": "flydsl_launcher_test__load",
+        }
+        with (
+            tempfile.TemporaryDirectory() as output_dir,
+            mock.patch(
+                "torch._inductor.codegen.flydsl.aot_compile.compile_aot",
+                return_value=compiled,
+            ) as compile_aot,
+            mock.patch(
+                "torch._inductor.codegen.flydsl.flydsl_aot.cache_dir",
+                return_value=output_dir,
+            ),
+        ):
+            artifact = compile_launcher(
+                registration.launcher,
+                ("out", "inp", 8),
+                signature=registration.signature,
+            )
+
+        compile_aot.assert_called_once_with(_launcher, "out", "inp", rows=8)
+        compiled.export_to_c.assert_called_once()
+        self.assertEqual("_mlir_flydsl_launcher_test", artifact.symbol)
+        self.assertEqual("flydsl_launcher_test__load", artifact.module_load_symbol)
+
+    def test_inductor_compiler_exports_bound_flydsl_object(self):
+        class Owner:
+            @flyc.jit
+            def launcher(
+                self,
+                out: fx.Tensor,
+                block_size: fx.Constexpr[int],
+                *,
+                rows: fx.Int32,
+            ):
+                pass
+
+        owner = Owner()
+        captured = torch.library.wrap_flydsl(
+            owner.launcher,
+            mutates_args={"out"},
+        )
+        registration = flydsl_launcher_side_table.get_registration(
+            captured.launcher_idx
+        )
+        compiled = mock.Mock()
+        compiled.export_to_c.return_value = {
+            "object_file_path": "/cache/launcher.o",
+            "symbol": "_mlir_flydsl_bound_launcher_test",
+            "runtime_libraries": [],
+            "abi": [{"kind": "stream", "arg_index": None}],
+            "module_init_symbol": "flydsl_bound_launcher_test__init",
+            "module_load_symbol": "flydsl_bound_launcher_test__load",
+        }
+        with (
+            tempfile.TemporaryDirectory() as output_dir,
+            mock.patch(
+                "torch._inductor.codegen.flydsl.aot_compile.compile_aot",
+                return_value=compiled,
+            ) as compile_aot,
+            mock.patch(
+                "torch._inductor.codegen.flydsl.flydsl_aot.cache_dir",
+                return_value=output_dir,
+            ),
+        ):
+            artifact = compile_launcher(
+                registration.launcher,
+                ("out", 256, 8),
+                signature=registration.signature,
+                bound_self=registration.bound_self,
+            )
+
+        compile_aot.assert_called_once_with(
+            Owner.launcher,
+            owner,
+            "out",
+            256,
+            rows=8,
+        )
+        self.assertEqual("_mlir_flydsl_bound_launcher_test", artifact.symbol)
+
+    def test_aot_kernel_registers_runtime_libraries_separately(self):
+        captured = torch.library.wrap_flydsl(
+            _launcher,
+            mutates_args={"out"},
+        )
+        artifact = FlyDSLAOTArtifact(
+            object_file_path="/cache/launcher.o",
+            symbol="_mlir_flydsl_launcher_test",
+            runtime_libraries=("/runtime/libfly.so",),
+            abi=(),
+            module_init_symbol="flydsl_launcher_test__init",
+            module_load_symbol="flydsl_launcher_test__load",
+        )
+        wrapper = SimpleNamespace(
+            additional_files=[],
+            external_kernel_libs=set(),
+            header=IndentedBuffer(),
+            user_defined_kernel_cache={},
+        )
+        graph = SimpleNamespace(aot_mode=True)
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch(
+                "torch._inductor.codegen.flydsl.flydsl_aot.compile_launcher",
+                return_value=artifact,
+            ),
+            mock.patch.object(ROCmCodeCache, "aot_kernels_o", []),
+        ):
+            result = define_aot_kernel(
+                wrapper,
+                captured.launcher_idx,
+                flydsl_launcher_side_table.add_call_spec({}),
+                (),
+            )
+
+            self.assertIs(artifact, result)
+            self.assertEqual([artifact.object_file_path], ROCmCodeCache.aot_kernels_o)
+            self.assertEqual(
+                {
+                    "-L/runtime",
+                    "-l:libfly.so",
+                    "-Wl,-rpath,$ORIGIN",
+                },
+                wrapper.external_kernel_libs,
+            )
+            self.assertEqual(
+                list(artifact.runtime_libraries),
+                wrapper.additional_files,
+            )
+            generated_header = wrapper.header.getvalue()
+            self.assertIn("cuModuleUnload", generated_header)
+            self.assertIn("cudaGetDevice", generated_header)
+            self.assertIn("hipModuleUnload", generated_header)
+            self.assertIn("hipGetDevice", generated_header)
+            self.assertIn("cannot be shared across GPU devices", generated_header)
+
+    def test_aot_kernel_restores_call_spec_and_bound_self(self):
+        class Owner:
+            @flyc.jit
+            def launcher(
+                self,
+                out: fx.Tensor,
+                block_size: fx.Constexpr[int],
+                *,
+                rows: fx.Int32,
+            ):
+                pass
+
+        owner = Owner()
+        captured = torch.library.wrap_flydsl(
+            owner.launcher,
+            mutates_args={"out"},
+        )
+        registration = flydsl_launcher_side_table.get_registration(
+            captured.launcher_idx
+        )
+        call_spec_idx = flydsl_launcher_side_table.add_call_spec({1: 256})
+        other_call_spec_idx = flydsl_launcher_side_table.add_call_spec({1: 512})
+        artifact = FlyDSLAOTArtifact(
+            object_file_path="/cache/launcher.o",
+            symbol="_mlir_flydsl_launcher_test",
+            runtime_libraries=(),
+            abi=(),
+            module_init_symbol="flydsl_launcher_test__init",
+            module_load_symbol="flydsl_launcher_test__load",
+        )
+        wrapper = SimpleNamespace(
+            additional_files=[],
+            external_kernel_libs=set(),
+            header=IndentedBuffer(),
+            user_defined_kernel_cache={},
+        )
+        graph = SimpleNamespace(aot_mode=True)
+
+        with (
+            V.set_graph_handler(graph),
+            mock.patch(
+                "torch._inductor.codegen.flydsl.flydsl_aot.compile_launcher",
+                return_value=artifact,
+            ) as compile_launcher_mock,
+            mock.patch.object(ROCmCodeCache, "aot_kernels_o", []),
+        ):
+            define_aot_kernel(
+                wrapper,
+                captured.launcher_idx,
+                call_spec_idx,
+                ("out", None, 8),
+            )
+            define_aot_kernel(
+                wrapper,
+                captured.launcher_idx,
+                other_call_spec_idx,
+                ("out", None, 8),
+            )
+
+        compile_launcher_mock.assert_has_calls(
+            [
+                mock.call(
+                    Owner.launcher,
+                    ("out", 256, 8),
+                    signature=registration.signature,
+                    bound_self=owner,
+                ),
+                mock.call(
+                    Owner.launcher,
+                    ("out", 512, 8),
+                    signature=registration.signature,
+                    bound_self=owner,
+                ),
+            ],
+        )
+        self.assertEqual(2, compile_launcher_mock.call_count)
+        self.assertEqual(2, len(wrapper.user_defined_kernel_cache))
+
+    def test_cpp_emitter_loads_module_and_packs_runtime_stream(self):
+        wrapper = object.__new__(CppWrapperGpu)
+        wrapper.header = IndentedBuffer()
+        wrapper.lines = []
+        wrapper.write_get_raw_stream = mock.Mock(return_value="stream")
+        graph = mock.Mock()
+        graph.aot_mode = True
+        graph.name = "graph"
+        graph.sizevars.simplify.side_effect = lambda value: value
+        artifact = FlyDSLAOTArtifact(
+            object_file_path="/cache/launcher.o",
+            symbol="_mlir_flydsl_launcher_test",
+            runtime_libraries=("/runtime/libfly.so",),
+            abi=(
+                {
+                    "kind": "scalar",
+                    "arg_index": 0,
+                    "ctype": "int32",
+                },
+                {
+                    "kind": "stream",
+                    "arg_index": None,
+                    "ctype": "pointer",
+                },
+            ),
+            module_init_symbol="flydsl_launcher_test__init",
+            module_load_symbol="flydsl_launcher_test__load",
+        )
+
+        with V.set_graph_handler(graph):
+            generate_aot_kernel_call(
+                wrapper,
+                artifact,
+                (8,),
+                device=torch.device("cuda", 0),
+                current_stream_idx=0,
+            )
+        generated = "\n".join(wrapper.lines)
+        self.assertIn("__ensure_module_loaded", generated)
+        self.assertIn("int32_t flydsl_0_0", generated)
+        self.assertIn("reinterpret_cast<void*>(stream)", generated)
+        self.assertIn(
+            "_mlir_flydsl_launcher_test(flydsl_packed_0)",
+            generated,
+        )
+        wrapper.write_get_raw_stream.assert_called_once_with(0, "graph")
+
+    def test_cpp_emitter_packs_float_bits_and_pointer(self):
+        wrapper = object.__new__(CppWrapperGpu)
+        wrapper.header = IndentedBuffer()
+        wrapper.lines = []
+        wrapper.write_get_raw_stream = mock.Mock(return_value="stream")
+        graph = mock.Mock()
+        graph.aot_mode = True
+        graph.name = "graph"
+        graph.sizevars.simplify.side_effect = lambda value: value
+        artifact = FlyDSLAOTArtifact(
+            object_file_path="/cache/launcher.o",
+            symbol="_mlir_flydsl_launcher_test",
+            runtime_libraries=(),
+            abi=(
+                {
+                    "kind": "scalar",
+                    "arg_index": 0,
+                    "ctype": "uint16",
+                    "encoding": "float16_bits",
+                },
+                {
+                    "kind": "scalar",
+                    "arg_index": 1,
+                    "ctype": "uint16",
+                    "encoding": "bfloat16_bits",
+                },
+                {
+                    "kind": "pointer",
+                    "arg_index": 2,
+                    "ctype": "pointer",
+                },
+            ),
+            module_init_symbol="flydsl_launcher_test__init",
+            module_load_symbol="flydsl_launcher_test__load",
+        )
+
+        with V.set_graph_handler(graph):
+            generate_aot_kernel_call(
+                wrapper,
+                artifact,
+                (1.5, 2.25, 4096),
+                device=torch.device("cuda", 0),
+                current_stream_idx=0,
+            )
+
+        generated = "\n".join(wrapper.lines)
+        self.assertIn("fp16_ieee_from_fp32_value", generated)
+        self.assertIn("bits_from_f32", generated)
+        self.assertIn("reinterpret_cast<void*>(4096)", generated)
+        self.assertIn("#include <c10/util/Half.h>", wrapper.header.getvalue())
+        self.assertIn("#include <c10/util/BFloat16.h>", wrapper.header.getvalue())
+
+    def test_cpp_emitter_uses_scheduler_auxiliary_stream(self):
+        wrapper = object.__new__(CppWrapperGpu)
+        wrapper.header = IndentedBuffer()
+        wrapper.lines = []
+        wrapper.write_get_raw_stream = mock.Mock(return_value="stream")
+        graph = mock.Mock()
+        graph.aot_mode = True
+        graph.name = "graph"
+        artifact = FlyDSLAOTArtifact(
+            object_file_path="/cache/launcher.o",
+            symbol="_mlir_flydsl_launcher_test",
+            runtime_libraries=(),
+            abi=({"kind": "stream", "arg_index": None},),
+            module_init_symbol="flydsl_launcher_test__init",
+            module_load_symbol="flydsl_launcher_test__load",
+        )
+
+        with V.set_graph_handler(graph):
+            generate_aot_kernel_call(
+                wrapper,
+                artifact,
+                (),
+                device=torch.device("cuda", 0),
+                current_stream_idx=1,
+            )
+
+        self.assertIn(
+            "reinterpret_cast<void*>(stream1)",
+            "\n".join(wrapper.lines),
+        )
+        wrapper.write_get_raw_stream.assert_not_called()
+
+    def test_cpp_emitter_rejects_explicit_stream_argument(self):
+        wrapper = object.__new__(CppWrapperGpu)
+        wrapper.header = IndentedBuffer()
+        wrapper.lines = []
+        wrapper.write_get_raw_stream = mock.Mock(return_value="stream")
+        graph = mock.Mock()
+        graph.aot_mode = True
+        graph.name = "graph"
+        artifact = FlyDSLAOTArtifact(
+            object_file_path="/cache/launcher.o",
+            symbol="_mlir_flydsl_launcher_test",
+            runtime_libraries=(),
+            abi=({"kind": "stream", "arg_index": 0},),
+            module_init_symbol="flydsl_launcher_test__init",
+            module_load_symbol="flydsl_launcher_test__load",
+        )
+
+        with (
+            V.set_graph_handler(graph),
+            self.assertRaisesRegex(
+                AssertionError,
+                "explicit stream",
+            ),
+        ):
+            generate_aot_kernel_call(
+                wrapper,
+                artifact,
+                (1234,),
+                device=torch.device("cuda", 0),
+                current_stream_idx=0,
+            )
+
+
+if __name__ == "__main__":
+    from torch.testing._internal.common_utils import run_tests
+
+    run_tests()

--- a/torch/_dynamo/utils.py
+++ b/torch/_dynamo/utils.py
@@ -199,6 +199,7 @@ class ReInplaceTrigger(enum.Enum):
     AUTO_FUNC_V1 = 1
     AUTO_FUNC_V2 = 2
     TRITON_OPS = 3
+    FLYDSL_OPS = 4
 
 
 class ReinplaceCounters:

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -46,6 +46,9 @@ debug_partitioner = os.environ.get("AOT_PARTITIONER_DEBUG", "0") != "0"
 # See # NOTE [Export custom triton op]
 decompose_custom_triton_ops = True
 
+# Controls functional decomposition for torch.library.flydsl_op.
+decompose_custom_flydsl_ops: bool = True
+
 static_weight_shapes = True
 
 # See https://github.com/pytorch/pytorch/issues/141881

--- a/torch/_higher_order_ops/flydsl_kernel_wrap.py
+++ b/torch/_higher_order_ops/flydsl_kernel_wrap.py
@@ -1,0 +1,594 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+import inspect
+import threading
+from dataclasses import dataclass
+from typing import Any, cast, TYPE_CHECKING
+
+import torch
+import torch.utils._pytree as pytree
+from torch import Tensor
+from torch._higher_order_ops.utils import register_fake
+from torch._ops import HigherOrderOperator
+from torch._prims_common import clone_preserve_strides
+from torch.fx.experimental.proxy_tensor import (
+    disable_proxy_modes_tracing,
+    ProxyTorchDispatchMode,
+    track_tensor_tree,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torch._subclasses.functional_tensor import BaseFunctionalizeAPI
+
+
+DispatchKey = cast(Any, torch._C).DispatchKey
+
+
+@dataclass(frozen=True)
+class FlyDSLLauncherRegistration:
+    launcher: Any
+    bound_self: Any
+    signature: inspect.Signature
+    mutated_arg_indices: tuple[int, ...]
+    compile_time_arg_indices: frozenset[int]
+    constexpr_arg_indices: frozenset[int]
+    constexpr_value_signature: Callable[[Any], Any] | None
+    stream_type: type[Any] | None
+    jit_argument_type: type[Any] | None
+
+
+class TraceableFlyDSLLauncher:
+    def __init__(
+        self,
+        launcher: Any,
+        mutated_arg_indices: tuple[int, ...],
+        *,
+        bound_self: Any = None,
+        signature: inspect.Signature | None = None,
+        compile_time_arg_indices: frozenset[int] = frozenset(),
+        constexpr_arg_indices: frozenset[int] = frozenset(),
+        constexpr_value_signature: Callable[[Any], Any] | None = None,
+        stream_type: type[Any] | None = None,
+        jit_argument_type: type[Any] | None = None,
+    ) -> None:
+        if signature is None:
+            signature = inspect.signature(launcher.func)
+        registration = FlyDSLLauncherRegistration(
+            launcher,
+            bound_self,
+            signature,
+            mutated_arg_indices,
+            compile_time_arg_indices,
+            constexpr_arg_indices,
+            constexpr_value_signature,
+            stream_type,
+            jit_argument_type,
+        )
+        self.launcher_idx = flydsl_launcher_side_table.add_launcher(registration)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        registration = flydsl_launcher_side_table.get_registration(self.launcher_idx)
+        bound = registration.signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        runtime_args, call_spec_idx = partition_flydsl_launcher_arguments(
+            registration,
+            tuple(bound.arguments.values()),
+        )
+        flydsl_kernel_wrapper_mutation(
+            self.launcher_idx,
+            call_spec_idx,
+            runtime_args,
+            registration.mutated_arg_indices,
+        )
+
+
+class FlyDSLLauncherSideTable:
+    def __init__(self) -> None:
+        self.id_to_launcher: dict[int, FlyDSLLauncherRegistration] = {}
+        self.launcher_to_id: dict[tuple[int, int | None, tuple[int, ...]], int] = {}
+        self.id_to_call_spec: dict[int, dict[int, Any]] = {}
+        self.call_spec_to_id: dict[tuple[Any, ...], int] = {}
+        self.lock = threading.Lock()
+
+    def add_launcher(self, registration: FlyDSLLauncherRegistration) -> int:
+        key = (
+            id(registration.launcher),
+            (
+                id(registration.bound_self)
+                if registration.bound_self is not None
+                else None
+            ),
+            registration.mutated_arg_indices,
+        )
+        with self.lock:
+            if key in self.launcher_to_id:
+                return self.launcher_to_id[key]
+            idx = len(self.id_to_launcher)
+            self.id_to_launcher[idx] = registration
+            self.launcher_to_id[key] = idx
+            return idx
+
+    def get_registration(self, idx: int) -> FlyDSLLauncherRegistration:
+        if idx not in self.id_to_launcher:
+            raise AssertionError(f"FlyDSL launcher index {idx} was not registered")
+        return self.id_to_launcher[idx]
+
+    def get_launcher(self, idx: int) -> Any:
+        return self.get_registration(idx).launcher
+
+    def add_call_spec(
+        self,
+        constant_args: dict[int, Any],
+        key: tuple[Any, ...] | None = None,
+    ) -> int:
+        if key is None:
+            key = tuple(
+                (idx, _constant_key(value)) for idx, value in constant_args.items()
+            )
+        with self.lock:
+            if key in self.call_spec_to_id:
+                return self.call_spec_to_id[key]
+            idx = len(self.id_to_call_spec)
+            self.id_to_call_spec[idx] = constant_args
+            self.call_spec_to_id[key] = idx
+            return idx
+
+    def get_call_spec(self, idx: int) -> dict[int, Any]:
+        if idx not in self.id_to_call_spec:
+            raise AssertionError(f"FlyDSL call spec index {idx} was not registered")
+        return self.id_to_call_spec[idx]
+
+    def reset_table(self) -> None:
+        with self.lock:
+            self.id_to_launcher = {}
+            self.launcher_to_id = {}
+            self.id_to_call_spec = {}
+            self.call_spec_to_id = {}
+
+
+flydsl_launcher_side_table = FlyDSLLauncherSideTable()
+
+
+def _constant_key(value: Any) -> tuple[Any, ...]:
+    try:
+        hash(value)
+    except TypeError:
+        return ("identity", type(value), id(value))
+    return ("value", type(value), value)
+
+
+def _register_flydsl_call_spec(
+    constant_args: dict[int, Any],
+    constexpr_indices: tuple[int, ...],
+    constexpr_value_signature: Callable[[Any], Any] | None,
+) -> int:
+    constexpr_indices_set = set(constexpr_indices)
+    key = tuple(
+        (
+            idx,
+            (
+                (
+                    "constexpr",
+                    (
+                        constexpr_value_signature(value)
+                        if constexpr_value_signature is not None
+                        else _constant_key(value)
+                    ),
+                )
+                if idx in constexpr_indices_set
+                else ("type_parameter", value)
+            ),
+        )
+        for idx, value in constant_args.items()
+    )
+    return flydsl_launcher_side_table.add_call_spec(constant_args, key)
+
+
+def _validate_runtime_arguments(
+    registration: FlyDSLLauncherRegistration,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    for idx, (parameter, value) in enumerate(
+        zip(registration.signature.parameters.values(), args)
+    ):
+        if idx in registration.compile_time_arg_indices:
+            continue
+        if registration.stream_type is not None and isinstance(
+            value, registration.stream_type
+        ):
+            raise TypeError(
+                "wrap_flydsl does not accept explicit stream arguments; "
+                "AOT launchers use PyTorch's current device stream"
+            )
+        if registration.jit_argument_type is not None and isinstance(
+            value, registration.jit_argument_type
+        ):
+            raise TypeError(
+                "wrap_flydsl runtime arguments must be graphable PyTorch values; "
+                f"preconstructed FlyDSL JitArgument {type(value).__name__} is unsupported"
+            )
+
+    parameters = tuple(registration.signature.parameters.values())
+    for idx in mutated_arg_indices:
+        if not isinstance(args[idx], Tensor):
+            raise TypeError(
+                "wrap_flydsl mutated arguments must be tensors; "
+                f"{parameters[idx].name!r} received {type(args[idx]).__name__}"
+            )
+
+
+def partition_flydsl_launcher_arguments(
+    registration: FlyDSLLauncherRegistration,
+    args: tuple[Any, ...],
+) -> tuple[tuple[Any, ...], int]:
+    signature = registration.signature
+    parameters = tuple(signature.parameters.values())
+    if len(args) != len(parameters):
+        raise TypeError(
+            f"FlyDSL launcher expected {len(parameters)} arguments, got {len(args)}"
+        )
+    runtime_args = list(args)
+    constant_args = {}
+    constexpr_indices = []
+    for idx, value in enumerate(args):
+        if idx in registration.constexpr_arg_indices:
+            constexpr_indices.append(idx)
+            constant_args[idx] = value
+            runtime_args[idx] = None
+        elif idx in registration.compile_time_arg_indices:
+            constant_args[idx] = value
+            runtime_args[idx] = None
+    return tuple(runtime_args), _register_flydsl_call_spec(
+        constant_args,
+        tuple(constexpr_indices),
+        registration.constexpr_value_signature,
+    )
+
+
+def restore_flydsl_launcher_arguments(
+    args: tuple[Any, ...],
+    call_spec_idx: int,
+) -> tuple[Any, ...]:
+    restored_args = list(args)
+    for idx, value in flydsl_launcher_side_table.get_call_spec(call_spec_idx).items():
+        restored_args[idx] = value
+    return tuple(restored_args)
+
+
+def split_flydsl_launcher_arguments(
+    signature: inspect.Signature,
+    args: tuple[Any, ...],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    parameters = tuple(signature.parameters.values())
+    if len(args) != len(parameters):
+        raise TypeError(
+            f"FlyDSL launcher expected {len(parameters)} arguments, got {len(args)}"
+        )
+    positional_args = []
+    keyword_args = {}
+    for parameter, value in zip(parameters, args):
+        if parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional_args.append(value)
+        elif parameter.kind is inspect.Parameter.KEYWORD_ONLY:
+            keyword_args[parameter.name] = value
+        else:
+            raise TypeError(
+                "FlyDSL launchers with variadic parameters cannot be captured"
+            )
+    return tuple(positional_args), keyword_args
+
+
+def invoke_flydsl_launcher(
+    registration: FlyDSLLauncherRegistration,
+    args: tuple[Any, ...],
+) -> None:
+    positional_args, keyword_args = split_flydsl_launcher_arguments(
+        registration.signature,
+        args,
+    )
+    if registration.bound_self is not None:
+        positional_args = (registration.bound_self, *positional_args)
+    registration.launcher(*positional_args, **keyword_args)
+
+
+class FlyDSLKernelWrapperMutation(HigherOrderOperator):
+    def __init__(self) -> None:
+        super().__init__("flydsl_kernel_wrapper_mutation", cacheable=True)
+
+    def __call__(
+        self,
+        launcher_idx: int,
+        call_spec_idx: int,
+        args: tuple[Any, ...],
+        mutated_arg_indices: tuple[int, ...],
+    ) -> None:
+        return super().__call__(
+            launcher_idx=launcher_idx,
+            call_spec_idx=call_spec_idx,
+            args=args,
+            mutated_arg_indices=mutated_arg_indices,
+        )
+
+
+class FlyDSLKernelWrapperFunctional(HigherOrderOperator):
+    def __init__(self) -> None:
+        super().__init__("flydsl_kernel_wrapper_functional", cacheable=True)
+
+    def __call__(
+        self,
+        launcher_idx: int,
+        call_spec_idx: int,
+        args: tuple[Any, ...],
+        mutated_arg_indices: tuple[int, ...],
+        tensors_to_clone: tuple[int, ...],
+    ) -> tuple[Tensor, ...]:
+        return super().__call__(
+            launcher_idx=launcher_idx,
+            call_spec_idx=call_spec_idx,
+            args=args,
+            mutated_arg_indices=mutated_arg_indices,
+            tensors_to_clone=tensors_to_clone,
+        )
+
+
+flydsl_kernel_wrapper_mutation = FlyDSLKernelWrapperMutation()
+flydsl_kernel_wrapper_functional = FlyDSLKernelWrapperFunctional()
+
+
+@flydsl_kernel_wrapper_mutation.py_impl(DispatchKey.CompositeExplicitAutograd)
+def flydsl_kernel_wrapper_mutation_dense(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    registration = flydsl_launcher_side_table.get_registration(launcher_idx)
+    full_args = restore_flydsl_launcher_arguments(args, call_spec_idx)
+    _validate_runtime_arguments(registration, full_args, mutated_arg_indices)
+    cuda_devices = {
+        arg.device
+        for arg in full_args
+        if isinstance(arg, Tensor) and arg.device.type == "cuda"
+    }
+    for device in cuda_devices:
+        if torch.cuda.current_stream(device) != torch.cuda.default_stream(device):
+            raise RuntimeError(
+                "eager wrap_flydsl launches require the default device stream; "
+                "AOTInductor launchers use PyTorch's current device stream"
+            )
+    invoke_flydsl_launcher(
+        registration,
+        full_args,
+    )
+
+
+@register_fake(flydsl_kernel_wrapper_mutation, skip_cache=True)
+def flydsl_kernel_wrapper_mutation_fake(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    return None
+
+
+@flydsl_kernel_wrapper_mutation.py_impl(DispatchKey.Meta)
+def flydsl_kernel_wrapper_mutation_meta(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    return None
+
+
+def _trace_flydsl_wrapper(
+    mode: ProxyTorchDispatchMode,
+    op: HigherOrderOperator,
+    node_args: dict[str, Any],
+) -> Any:
+    with disable_proxy_modes_tracing():
+        output = op(**node_args)
+    proxy_args = pytree.tree_map(cast(Any, mode.tracer).unwrap_proxy, node_args)
+    output_proxy = mode.tracer.create_proxy(
+        "call_function",
+        op,
+        (),
+        proxy_args,
+        name=op.__name__ + "_proxy",
+    )
+    return track_tensor_tree(
+        output,
+        output_proxy,
+        constant=None,
+        tracer=mode.tracer,
+    )
+
+
+@flydsl_kernel_wrapper_mutation.py_impl(ProxyTorchDispatchMode)
+def flydsl_kernel_wrapper_mutation_proxy(
+    mode: ProxyTorchDispatchMode,
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    _trace_flydsl_wrapper(
+        mode,
+        flydsl_kernel_wrapper_mutation,
+        {
+            "launcher_idx": launcher_idx,
+            "call_spec_idx": call_spec_idx,
+            "args": args,
+            "mutated_arg_indices": mutated_arg_indices,
+        },
+    )
+    return None
+
+
+@flydsl_kernel_wrapper_mutation.py_functionalize_impl
+def flydsl_kernel_wrapper_mutation_functionalize(
+    ctx: BaseFunctionalizeAPI,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    unwrapped_args = tuple(ctx.unwrap_tensors(args))
+    with ctx.redispatch_to_next():
+        outputs = flydsl_kernel_wrapper_functional(
+            launcher_idx,
+            call_spec_idx,
+            unwrapped_args,
+            mutated_arg_indices,
+            tuple(range(len(mutated_arg_indices))),
+        )
+
+    for arg_idx, output in zip(mutated_arg_indices, outputs):
+        input_arg = args[arg_idx]
+        if not isinstance(input_arg, Tensor):
+            raise AssertionError(
+                f"Expected FlyDSL mutated argument {arg_idx} to be a Tensor"
+            )
+        ctx.replace(input_arg, output)
+        ctx.mark_mutation_hidden_from_autograd(input_arg)
+        ctx.commit_update(input_arg)
+        ctx.sync(input_arg)
+
+
+@flydsl_kernel_wrapper_functional.py_impl(DispatchKey.CompositeExplicitAutograd)
+def flydsl_kernel_wrapper_functional_dense(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    _validate_clone_aliases(args, mutated_arg_indices, tensors_to_clone)
+    cloned_args = list(args)
+    for output_idx in tensors_to_clone:
+        arg_idx = mutated_arg_indices[output_idx]
+        arg = cloned_args[arg_idx]
+        if not isinstance(arg, Tensor):
+            raise AssertionError(
+                f"Expected FlyDSL mutated argument {arg_idx} to be a Tensor"
+            )
+        cloned_args[arg_idx] = clone_preserve_strides(arg)
+    flydsl_kernel_wrapper_mutation(
+        launcher_idx,
+        call_spec_idx,
+        tuple(cloned_args),
+        mutated_arg_indices,
+    )
+    return tuple(cloned_args[idx] for idx in mutated_arg_indices)
+
+
+@register_fake(flydsl_kernel_wrapper_functional, skip_cache=True)
+def flydsl_kernel_wrapper_functional_fake(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    _validate_clone_aliases(args, mutated_arg_indices, tensors_to_clone)
+    clone_indices = set(tensors_to_clone)
+    return tuple(
+        (
+            clone_preserve_strides(args[arg_idx])
+            if output_idx in clone_indices
+            else args[arg_idx]
+        )
+        for output_idx, arg_idx in enumerate(mutated_arg_indices)
+    )
+
+
+@flydsl_kernel_wrapper_functional.py_impl(ProxyTorchDispatchMode)
+def flydsl_kernel_wrapper_functional_proxy(
+    mode: ProxyTorchDispatchMode,
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    return _trace_flydsl_wrapper(
+        mode,
+        flydsl_kernel_wrapper_functional,
+        {
+            "launcher_idx": launcher_idx,
+            "call_spec_idx": call_spec_idx,
+            "args": args,
+            "mutated_arg_indices": mutated_arg_indices,
+            "tensors_to_clone": tensors_to_clone,
+        },
+    )
+
+
+@flydsl_kernel_wrapper_functional.py_functionalize_impl
+def flydsl_kernel_wrapper_functional_functionalize(
+    ctx: BaseFunctionalizeAPI,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> tuple[Tensor, ...]:
+    unwrapped_args = tuple(ctx.unwrap_tensors(args))
+    with ctx.redispatch_to_next():
+        outputs = flydsl_kernel_wrapper_functional(
+            launcher_idx,
+            call_spec_idx,
+            unwrapped_args,
+            mutated_arg_indices,
+            tensors_to_clone,
+        )
+    return tuple(ctx.wrap_tensors(outputs))
+
+
+def _validate_clone_aliases(
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+    tensors_to_clone: tuple[int, ...],
+) -> None:
+    cloned_arg_indices = {
+        mutated_arg_indices[output_idx] for output_idx in tensors_to_clone
+    }
+    tensor_args = [
+        (idx, arg) for idx, arg in enumerate(args) if isinstance(arg, Tensor)
+    ]
+    for position, (arg_idx, arg) in enumerate(tensor_args):
+        for other_idx, other in tensor_args[position + 1 :]:
+            if (
+                arg_idx in cloned_arg_indices or other_idx in cloned_arg_indices
+            ) and cast(Any, torch._C)._is_alias_of(arg, other):
+                raise RuntimeError(
+                    "FlyDSL functionalization does not support cloning aliased "
+                    f"launcher arguments {arg_idx} and {other_idx}"
+                )
+
+
+for op in (flydsl_kernel_wrapper_mutation, flydsl_kernel_wrapper_functional):
+    op.fallthrough(DispatchKey.PythonDispatcher)
+    op.fallthrough(DispatchKey.PythonTLSSnapshot)
+    op.fallthrough(DispatchKey.ADInplaceOrView)
+    op.fallthrough(DispatchKey.BackendSelect)
+    op.fallthrough(DispatchKey.AutocastCPU)
+    op.fallthrough(DispatchKey.AutocastCUDA)
+    op.fallthrough(DispatchKey.AutogradCPU)
+    op.fallthrough(DispatchKey.AutogradCUDA)

--- a/torch/_higher_order_ops/flydsl_kernel_wrap.py
+++ b/torch/_higher_order_ops/flydsl_kernel_wrap.py
@@ -299,9 +299,43 @@ def invoke_flydsl_launcher(
     registration.launcher(*positional_args, **keyword_args)
 
 
+class FlyDSLPythonLauncher:
+    def __init__(self, launcher_idx: int, call_spec_idx: int) -> None:
+        self.launcher_idx = launcher_idx
+        self.call_spec_idx = call_spec_idx
+
+    def run(self, *runtime_args: Any, stream: int | None = None) -> None:
+        registration = flydsl_launcher_side_table.get_registration(self.launcher_idx)
+        constant_args = flydsl_launcher_side_table.get_call_spec(self.call_spec_idx)
+        runtime_args_iter = iter(runtime_args)
+        args = []
+        for idx in range(len(registration.signature.parameters)):
+            if idx in constant_args:
+                args.append(constant_args[idx])
+                continue
+            try:
+                args.append(next(runtime_args_iter))
+            except StopIteration as exc:
+                raise TypeError(
+                    "not enough runtime arguments for FlyDSL launcher"
+                ) from exc
+        try:
+            next(runtime_args_iter)
+        except StopIteration:
+            pass
+        else:
+            raise TypeError("too many runtime arguments for FlyDSL launcher")
+
+        if stream is None:
+            invoke_flydsl_launcher(registration, tuple(args))
+            return
+        with torch.cuda.stream(torch.cuda.ExternalStream(stream)):
+            invoke_flydsl_launcher(registration, tuple(args))
+
+
 class FlyDSLKernelWrapperMutation(HigherOrderOperator):
     def __init__(self) -> None:
-        super().__init__("flydsl_kernel_wrapper_mutation", cacheable=True)
+        super().__init__("flydsl_kernel_wrapper_mutation", cacheable=False)
 
     def __call__(
         self,
@@ -320,7 +354,7 @@ class FlyDSLKernelWrapperMutation(HigherOrderOperator):
 
 class FlyDSLKernelWrapperFunctional(HigherOrderOperator):
     def __init__(self) -> None:
-        super().__init__("flydsl_kernel_wrapper_functional", cacheable=True)
+        super().__init__("flydsl_kernel_wrapper_functional", cacheable=False)
 
     def __call__(
         self,

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -3556,6 +3556,7 @@ end
                 device_type=device_type,
                 aot_mode=graph.aot_mode,
                 use_relative_path=use_relative_path,
+                extra_flags=tuple(graph.wrapper_code.external_kernel_libs),
             )
 
             if gpu_kernels_o and device_type == "xpu":

--- a/torch/_inductor/codegen/flydsl/README.md
+++ b/torch/_inductor/codegen/flydsl/README.md
@@ -1,0 +1,265 @@
+# FlyDSL launchers in AOTInductor
+
+This document describes how to use a user-authored FlyDSL launcher with
+AOTInductor (AOTI), and how PyTorch captures, compiles, packages, and invokes
+that launcher. This is the FlyDSL counterpart of wrapping a user-defined Triton
+kernel: the user writes FlyDSL Python and a Python call site, while Inductor
+generates the C++ invocation and packages the compiled artifacts.
+
+## User contract
+
+A user defines one or more `@flyc.kernel` device kernels and calls them from an
+`@flyc.jit` launcher. The launcher can contain any launch logic that FlyDSL can
+trace successfully, including multiple kernel launches such as a split-K GEMM
+followed by a workspace reduction.
+
+For capture and AOTI packaging:
+
+- The launcher returns `None` and writes results to explicit tensor arguments.
+- Output and workspace tensors are allocated by PyTorch code and passed to the
+  launcher. This lets Export and Inductor model their lifetimes and mutations.
+- Mutated tensors are declared through `mutates_args`. If it is omitted, every
+  runtime tensor argument is conservatively treated as mutated.
+- `Constexpr` and FlyDSL type parameters are normal launcher arguments, but are
+  captured as specialization values and omitted from the runtime ABI.
+- Runtime arguments must be graphable PyTorch values. The supported AOT ABI
+  covers tensors, pointers, numeric scalars, and an implicit stream.
+- The launcher must not declare a FlyDSL `Stream` parameter. AOTI supplies the
+  scheduler's current stream when invoking the compiled launcher.
+
+`torch.library.wrap_flydsl()` creates a traceable launcher:
+
+```python
+@flyc.jit
+def split_k_launcher(
+    out: fx.Tensor,
+    workspace: fx.Tensor,
+    lhs: fx.Tensor,
+    rhs: fx.Tensor,
+    rows: fx.Int32,
+    block_size: fx.Constexpr[int],
+):
+    split_k_kernel(...).launch(...)
+    reduce_workspace_kernel(...).launch(...)
+
+
+captured_split_k = torch.library.wrap_flydsl(
+    split_k_launcher,
+    mutates_args={"out", "workspace"},
+)
+```
+
+The model allocates the mutated tensors and invokes the captured launcher:
+
+```python
+def split_k(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    out = torch.empty((lhs.shape[0], rhs.shape[0]), device=lhs.device)
+    workspace = torch.empty(..., device=lhs.device)
+    captured_split_k(out, workspace, lhs, rhs, lhs.shape[0], 256)
+    return out
+```
+
+## End-to-end flow
+
+```mermaid
+flowchart TD
+    subgraph User["User Python"]
+        K["@flyc.kernel device kernels"]
+        L["@flyc.jit launcher<br/>one or multiple launches"]
+        W["torch.library.wrap_flydsl<br/>mutation and signature contract"]
+        K --> L --> W
+    end
+
+    subgraph Export["Export and functionalization"]
+        S["launcher and call-spec side tables"]
+        MH["flydsl_kernel_wrapper_mutation HOP"]
+        FH["flydsl_kernel_wrapper_functional HOP"]
+        S --> MH --> FH
+    end
+
+    subgraph Inductor["Inductor"]
+        D["post-grad functional-HOP decomposition"]
+        I["UserDefinedFlyDSLKernel"]
+        A["restore compile-time arguments<br/>and construct example arguments"]
+        D --> I --> A
+    end
+
+    subgraph Compiler["FlyDSL AOT compiler"]
+        M["trace complete launcher into MLIR"]
+        C["compile embedded GPU device code"]
+        P["emit PIC host object and ABI metadata"]
+        M --> C --> P
+    end
+
+    subgraph Package["AOTI package"]
+        G["generated C++ call site"]
+        R["FlyDSL runtime shared libraries"]
+        SO["linked model shared object"]
+        G --> SO
+        P --> SO
+        R --> SO
+    end
+
+    O --> S
+    W --> S
+    FH --> D
+    A --> M
+```
+
+## Capture and graph representation
+
+`wrap_flydsl()` validates that the input is a FlyDSL `JitFunction`, resolves
+its signature, and records:
+
+- The launcher and an optional bound `self` object.
+- Which tensor arguments may be mutated.
+- Which argument positions are `Constexpr` or type parameters.
+- The FlyDSL helpers used to identify streams and preconstructed JIT arguments.
+
+Runtime tensor and scalar values become FX operands. Compile-time values are
+stored in a call-spec side table and represented in the graph by an integer ID.
+Registrations and equivalent call specifications are deduplicated within the
+process.
+
+The FX graph contains `flydsl_kernel_wrapper_mutation`. Functionalization
+rewrites it to `flydsl_kernel_wrapper_functional`, cloning only the mutated
+tensors that require functional outputs. Aliased arguments that would make
+independent cloning incorrect are rejected. Inductor's post-grad pass later
+decomposes the functional form back into a mutation-aware node for lowering.
+
+The two FlyDSL higher-order operators are deliberately non-cacheable. Their
+launcher and call-spec IDs refer to process-local side tables, so persistent FX
+or AOTAutograd cache reuse would otherwise restore invalid IDs.
+
+## Inductor lowering
+
+`lower_flydsl_kernel()` creates a `UserDefinedFlyDSLKernel`, an Inductor
+`ExternKernel` that owns:
+
+- Realized tensor inputs and runtime scalar or symbolic arguments.
+- Mutation outputs for the declared mutated tensors.
+- The launcher ID and compile-time call-spec ID.
+- Representative meta-tensor arguments used to specialize compilation.
+- The selected device and scheduler stream.
+
+The same IR node supports two wrapper modes:
+
+- A Python wrapper creates a cached `FlyDSLPythonLauncher`, restores the
+  compile-time arguments, and invokes FlyDSL through Python.
+- An AOTI C++ wrapper compiles the launcher to an object, registers it with the
+  AOT link, and emits a packed C ABI call.
+
+The post-grad detection and decomposition pass is guarded by the presence of a
+FlyDSL HOP, including HOPs in nested subgraphs. Graphs without captured FlyDSL
+launchers do not construct or run the FlyDSL-specific pass.
+
+## FlyDSL AOT compilation
+
+`compile_aot()` follows FlyDSL's normal JIT argument conversion instead of
+reimplementing kernel semantics in PyTorch:
+
+1. Bind positional, keyword-only, bound-method, `Constexpr`, and type
+   arguments using the FlyDSL launcher signature.
+2. Convert runtime values through FlyDSL's JIT argument protocol.
+3. Add an implicit stream argument when the launcher does not declare one.
+4. Construct the MLIR function arguments and invoke the original launcher body
+   under FlyDSL's tracing context.
+5. Compile the resulting MLIR module using FlyDSL's configured backend.
+6. Derive declarative ABI metadata from the converted JIT arguments.
+
+The complete `@flyc.jit` body is traced into one exported C entry point. A
+launcher containing multiple device launches therefore remains one Inductor
+external-kernel node and one AOTI call, while the generated launcher performs
+the individual device launches internally.
+
+`CompiledAOTLauncher.export_to_c()` then:
+
+- Gives every exported definition and GPU module loader a unique symbol.
+- Emits a position-independent object through FlyDSL's MLIR execution engine.
+- Renames the generic module initialization and load symbols with `objcopy`.
+- Discovers and copies FlyDSL-owned runtime-library dependencies.
+
+This resembles Triton's packaged-kernel flow at the user and Inductor levels,
+but the artifact is different. The current FlyDSL backend produces a
+relocatable host object containing the C launcher and GPU module-loading
+interface, with the compiled device image embedded in that object; it is not
+only a standalone cubin or HSACO file.
+
+## Runtime ABI and invocation
+
+```mermaid
+sequenceDiagram
+    participant S as Inductor scheduler
+    participant W as Generated AOTI C++ wrapper
+    participant H as Per-artifact module holder
+    participant L as FlyDSL C launcher
+    participant G as GPU runtime
+
+    S->>W: execute external-kernel node
+    W->>H: ensure module loaded on current device
+    alt first invocation
+        H->>G: initialize and load embedded GPU module
+        G-->>H: module handle
+    end
+    W->>W: pack tensor, layout, scalar, and pointer slots
+    W->>W: append scheduler current stream
+    W->>L: launcher(void** packed_args)
+    L->>G: issue one or more device launches
+```
+
+The generated wrapper packs slots in FlyDSL's declared C ABI order:
+
+| FlyDSL argument | Runtime ABI |
+| --- | --- |
+| Tensor or memref | Data pointer, followed by dynamic shape and stride bytes when required |
+| Pointer | `void*` |
+| Integer or Boolean scalar | Fixed-width signed or unsigned value |
+| FP16 or BF16 scalar | Raw 16-bit representation |
+| FP32 or FP64 scalar | `float` or `double` |
+| `Constexpr` or type parameter | No runtime slot; restored from the call spec before compilation |
+| Stream | One implicit current-stream pointer |
+
+For a scheduled auxiliary stream, the generated call uses that scheduler
+stream. Otherwise it queries the current PyTorch device stream. No Python
+stream object crosses Export or the packaged-model boundary.
+
+Each compiled launcher has a DSO-static module holder guarded by
+`std::once_flag`. The holder loads the embedded GPU module once, remembers the
+device that owns it, and unloads it when the model shared object is destroyed.
+An invocation on another device is rejected rather than silently using a
+module loaded for the wrong GPU.
+
+## Linking and package relocation
+
+The generated object is registered in `ROCmCodeCache.aot_kernels_o` for the
+normal AOTI link. FlyDSL runtime libraries are added through the wrapper's
+graph-local `external_kernel_libs` and `additional_files` collections. The
+package uses an `$ORIGIN` runtime search path so the copied libraries remain
+loadable after moving the `.pt2` package away from the compilation cache.
+
+Runtime-library publication is atomic and rejects a same-name collision when
+the existing file has different contents. Dependencies are limited to shared
+libraries located within the FlyDSL distribution instead of copying arbitrary
+system libraries.
+
+## Current limitations
+
+- FlyDSL is an optional dependency. Common PyTorch and Inductor imports do not
+  import it; availability is checked only when FlyDSL is selected or wrapped.
+- Captured-launcher AOT requires FlyDSL 0.2.3 or newer, a ROCm-enabled PyTorch
+  build, and at least one tensor launcher argument.
+- The launcher must return `None`; outputs and workspaces must be explicit
+  tensor arguments.
+- Explicit FlyDSL stream parameters are unsupported. Eager calls through a
+  wrapped launcher currently require the default stream, while AOTI calls use
+  the scheduler's current stream.
+- Mutated tensor aliases that require independent functionalization clones are
+  unsupported.
+- Custom or composite FlyDSL JIT arguments without a declarative ABI are
+  unsupported.
+- Python post-load processors and extern-linked launchers combined with
+  FlyDSL's external binary codegen are unsupported.
+- `aot_inductor.package_cpp_only=True` is unsupported because the generated
+  object and runtime libraries must be linked and packaged.
+- A loaded artifact is owned by one GPU device for the lifetime of its AOTI
+  model instance.

--- a/torch/_inductor/codegen/flydsl/aot_compile.py
+++ b/torch/_inductor/codegen/flydsl/aot_compile.py
@@ -1,0 +1,503 @@
+# mypy: allow-untyped-defs
+from __future__ import annotations
+
+import ctypes
+import filecmp
+import inspect
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+from torch.utils._ordered_set import OrderedSet
+
+
+HAS_FLYDSL = runtime_available()
+if TYPE_CHECKING or HAS_FLYDSL:
+    import flydsl.utils as flydsl_utils
+    from flydsl._mlir import execution_engine, ir
+    from flydsl._mlir.dialects import func
+    from flydsl.compiler import (
+        backends,
+        jit_argument,
+        jit_executor,
+        jit_function,
+        kernel_function,
+        protocol,
+    )
+    from flydsl.expr import meta, numeric, typing as flydsl_typing
+    from flydsl.expr.utils import arith
+
+
+_C_SYMBOL = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_GPU_MODULE_INIT = "flydsl_gpu_module_init"
+_GPU_MODULE_LOAD_TO_DEVICE = "flydsl_gpu_module_load_to_device"
+_ELF_SONAME = re.compile(r"\(SONAME\).*\[([^]]+)\]")
+_LDD_LIBRARY = re.compile(r"^\s*(\S+)\s+=>\s+(\S+)\s+\(")
+
+
+def _ctype_metadata(ctype: type, *, name: str | None = None) -> dict[str, Any]:
+    if name is None:
+        if ctype is ctypes.c_void_p:
+            name = "pointer"
+        elif issubclass(ctype, ctypes.Array):
+            name = "bytes"
+        elif ctype is ctypes.c_float:
+            name = "float"
+        elif ctype is ctypes.c_double:
+            name = "double"
+        elif ctype is ctypes.c_bool:
+            name = "bool"
+        else:
+            name = ctype.__name__.removeprefix("c_")
+    return {
+        "ctype": name,
+        "size": ctypes.sizeof(ctype),
+        "alignment": ctypes.alignment(ctype),
+    }
+
+
+def _numeric_ctype_name(value: Any, ctype: type) -> str:
+    if value.signed is not None:
+        if value.width == 1:
+            return "bool"
+        return f"{'int' if value.signed else 'uint'}{value.width}"
+    if isinstance(value, (numeric.Float16, numeric.BFloat16)):
+        return "uint16"
+    if isinstance(value, numeric.Float32):
+        return "float"
+    if isinstance(value, numeric.Float64):
+        return "double"
+    return ctype.__name__.removeprefix("c_")
+
+
+def _argument_abi(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, jit_argument.MemRefJitArg):
+        slots = [
+            {
+                "kind": "tensor_data",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        ]
+        if value.is_layout_dynamic:
+            shape_dims = list(value.shape_dyn_indices)
+            stride_dims = list(value.stride_dyn_indices)
+            stride_ctype = ctypes.c_int32 if value.use_32bit_stride else ctypes.c_int64
+            layout_ctype = ctypes.c_byte * (
+                len(shape_dims) * ctypes.sizeof(ctypes.c_int32)
+                + len(stride_dims) * ctypes.sizeof(stride_ctype)
+            )
+            slots.append(
+                {
+                    "kind": "tensor_layout",
+                    **_ctype_metadata(layout_ctype, name="bytes"),
+                    "shape_dims": shape_dims,
+                    "stride_dims": stride_dims,
+                    "stride_bits": 32 if value.use_32bit_stride else 64,
+                }
+            )
+        return slots
+
+    if isinstance(value, flydsl_typing.Stream):
+        return [
+            {
+                "kind": "stream",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        ]
+
+    if isinstance(value, jit_argument.PointerJitArg):
+        return [
+            {
+                "kind": "pointer",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        ]
+
+    if not isinstance(value, numeric.Numeric):
+        raise NotImplementedError(
+            "FlyDSL AOT supports tensor, pointer, scalar, and implicit stream "
+            f"arguments; unsupported JIT argument type: {type(value).__name__}"
+        )
+    if value.signed is not None and value.width not in (1, 8, 16, 32, 64):
+        raise NotImplementedError(
+            f"FlyDSL AOT does not support {type(value).__name__} scalar arguments"
+        )
+    if value.signed is None and not isinstance(
+        value,
+        (
+            numeric.Float16,
+            numeric.BFloat16,
+            numeric.Float32,
+            numeric.Float64,
+        ),
+    ):
+        raise NotImplementedError(
+            f"FlyDSL AOT does not support {type(value).__name__} scalar arguments"
+        )
+    abi_spec = protocol.c_abi_spec(value)
+    if len(abi_spec) != 1:
+        raise NotImplementedError(
+            "FlyDSL AOT scalar arguments must have exactly one C ABI slot"
+        )
+    ctype, _fill = abi_spec[0]
+    slot = {
+        "kind": "scalar",
+        **_ctype_metadata(ctype, name=_numeric_ctype_name(value, ctype)),
+    }
+    if isinstance(value, numeric.Float16):
+        slot["encoding"] = "float16_bits"
+    elif isinstance(value, numeric.BFloat16):
+        slot["encoding"] = "bfloat16_bits"
+    return [slot]
+
+
+def _launcher_abi(
+    sig, bound, jit_args: list[Any], has_user_stream: bool
+) -> tuple[dict[str, Any], ...]:
+    abi = []
+    jit_arg_index = 0
+    for arg_index, (param_name, value) in enumerate(bound.arguments.items()):
+        annotation = sig.parameters[param_name].annotation
+        if annotation is not inspect.Parameter.empty and (
+            flydsl_typing.Constexpr.is_constexpr_annotation(annotation)
+            or jit_argument.is_type_param_annotation(annotation)
+        ):
+            continue
+        jit_arg = jit_args[jit_arg_index]
+        jit_arg_index += 1
+        abi.extend(
+            {"arg_index": arg_index, "arg_name": param_name, **slot}
+            for slot in _argument_abi(jit_arg)
+        )
+    if not has_user_stream:
+        abi.append(
+            {
+                "arg_index": None,
+                "arg_name": None,
+                "kind": "stream",
+                **_ctype_metadata(ctypes.c_void_p, name="pointer"),
+            }
+        )
+    return tuple(abi)
+
+
+def _rename_symbol_ref(attr, symbol_map):
+    components = list(ir.SymbolRefAttr(attr).value)
+    if not components or components[0] not in symbol_map:
+        return attr
+    components[0] = symbol_map[components[0]]
+    return ir.SymbolRefAttr.get(components)
+
+
+def _rename_export_symbols(module: Any, entry: str, symbol: str) -> None:
+    symbol_map = {}
+
+    def collect(op):
+        attrs = op.attributes
+        if "sym_name" not in attrs:
+            return ir.WalkResult.ADVANCE
+        is_definition = op.name in ("llvm.mlir.global", "gpu.binary")
+        if op.name == "llvm.func":
+            is_definition = bool(op.opview.operation.regions)
+        if not is_definition:
+            return ir.WalkResult.ADVANCE
+        old_name = attrs["sym_name"].value
+        new_name = symbol if old_name == entry else f"{symbol}__{old_name}"
+        symbol_map[old_name] = new_name
+        attrs["sym_name"] = ir.StringAttr.get(new_name)
+        return ir.WalkResult.ADVANCE
+
+    def update_refs(op):
+        attrs = op.attributes
+        if op.name == "llvm.call" and "callee" in attrs:
+            old_name = attrs["callee"].value
+            if old_name in symbol_map:
+                attrs["callee"] = ir.FlatSymbolRefAttr.get(symbol_map[old_name])
+        elif op.name == "llvm.mlir.addressof" and "global_name" in attrs:
+            old_name = attrs["global_name"].value
+            if old_name in symbol_map:
+                attrs["global_name"] = ir.FlatSymbolRefAttr.get(symbol_map[old_name])
+        elif op.name in ("llvm.mlir.global_ctors", "llvm.mlir.global_dtors"):
+            key = "ctors" if op.name.endswith("ctors") else "dtors"
+            if key in attrs:
+                attrs[key] = ir.ArrayAttr.get(
+                    [
+                        ir.FlatSymbolRefAttr.get(symbol_map.get(ref.value, ref.value))
+                        for ref in attrs[key]
+                    ]
+                )
+        elif op.name == "gpu.launch_func" and "kernel" in attrs:
+            attrs["kernel"] = _rename_symbol_ref(attrs["kernel"], symbol_map)
+        return ir.WalkResult.ADVANCE
+
+    module.operation.walk(collect)
+    if entry not in symbol_map:
+        raise RuntimeError(f"FlyDSL AOT export could not find entry symbol {entry!r}")
+    module.operation.walk(update_refs)
+
+
+def _rename_loader_symbols(object_path: Path, symbol: str) -> tuple[str, str]:
+    objcopy = shutil.which("llvm-objcopy") or shutil.which("objcopy")
+    if objcopy is None:
+        raise RuntimeError("FlyDSL AOT export requires llvm-objcopy or objcopy")
+
+    init_symbol = f"{symbol}__{_GPU_MODULE_INIT}"
+    load_symbol = f"{symbol}__{_GPU_MODULE_LOAD_TO_DEVICE}"
+    symbol_map = {
+        _GPU_MODULE_INIT: init_symbol,
+        _GPU_MODULE_LOAD_TO_DEVICE: load_symbol,
+        f"_mlir_{_GPU_MODULE_INIT}": f"_mlir_{init_symbol}",
+        f"_mlir_{_GPU_MODULE_LOAD_TO_DEVICE}": f"_mlir_{load_symbol}",
+    }
+    file_descriptor, renamed_path = tempfile.mkstemp(
+        prefix=f".{object_path.name}.",
+        dir=object_path.parent,
+    )
+    os.close(file_descriptor)
+    try:
+        command = [objcopy]
+        for old_name, new_name in symbol_map.items():
+            command.extend(["--redefine-sym", f"{old_name}={new_name}"])
+        command.extend(["--", str(object_path), renamed_path])
+        subprocess.run(command, check=True, capture_output=True, text=True)
+        Path(renamed_path).replace(object_path)
+    finally:
+        Path(renamed_path).unlink(missing_ok=True)
+    return init_symbol, load_symbol
+
+
+def _elf_soname(path: Path) -> str | None:
+    readelf = shutil.which("llvm-readelf") or shutil.which("readelf")
+    if readelf is None:
+        raise RuntimeError("FlyDSL AOT export requires llvm-readelf or readelf")
+    result = subprocess.run(
+        [readelf, "-d", str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    match = _ELF_SONAME.search(result.stdout)
+    return match.group(1) if match is not None else None
+
+
+def _runtime_library_dependencies(path: Path) -> dict[str, Path]:
+    ldd = shutil.which("ldd")
+    if ldd is None:
+        raise RuntimeError("FlyDSL AOT export requires ldd")
+    result = subprocess.run(
+        [ldd, str(path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    dependencies = {}
+    for line in result.stdout.splitlines():
+        match = _LDD_LIBRARY.match(line)
+        if match is not None and match.group(2) != "not":
+            dependencies[match.group(1)] = Path(match.group(2)).resolve()
+    return dependencies
+
+
+def _flydsl_distribution_root(runtime_library: Path) -> Path:
+    for parent in runtime_library.resolve().parents:
+        if (parent / "flydsl").is_dir():
+            return parent
+    raise RuntimeError(
+        f"could not locate the FlyDSL distribution for runtime library {runtime_library}"
+    )
+
+
+def _publish_runtime_library(source: Path, destination: Path) -> None:
+    file_descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        dir=destination.parent,
+    )
+    os.close(file_descriptor)
+    temporary = Path(temporary_path)
+    try:
+        shutil.copy2(source, temporary)
+        try:
+            os.link(temporary, destination)
+        except FileExistsError:
+            if not filecmp.cmp(temporary, destination, shallow=False):
+                raise RuntimeError(
+                    "FlyDSL runtime library collision for "
+                    f"{destination.name}: {source} differs from the cached file"
+                ) from None
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _bundle_runtime_libraries(
+    runtime_libraries: list[str],
+    output_dir: Path,
+) -> list[str]:
+    libraries: dict[str, Path] = {}
+    distribution_roots = OrderedSet(
+        _flydsl_distribution_root(Path(path)) for path in runtime_libraries
+    )
+    for path_string in runtime_libraries:
+        path = Path(path_string).resolve()
+        libraries[_elf_soname(path) or path.name] = path
+        libraries.update(
+            {
+                name: dependency
+                for name, dependency in _runtime_library_dependencies(path).items()
+                if any(dependency.is_relative_to(root) for root in distribution_roots)
+            }
+        )
+
+    bundled = []
+    for name, source in libraries.items():
+        destination = output_dir / name
+        if source != destination:
+            _publish_runtime_library(source, destination)
+        bundled.append(str(destination))
+    return bundled
+
+
+class CompiledAOTLauncher:
+    def __init__(self, module: Any, entry: str, abi: tuple[dict[str, Any], ...]):
+        self._ir_text = str(module)
+        self._entry = entry
+        self.abi = abi
+
+    def export_to_c(self, object_file_path: str, function_name: str) -> dict[str, Any]:
+        if not _C_SYMBOL.fullmatch(function_name):
+            raise ValueError(f"invalid C function name: {function_name!r}")
+        object_path = Path(object_file_path)
+        if not object_path.parent.exists():
+            raise FileNotFoundError(
+                f"object output directory does not exist: {object_path.parent}"
+            )
+
+        runtime_libraries = jit_executor._resolve_runtime_libs()
+        ctx = jit_function._create_mlir_context()
+        with ctx:
+            module = ir.Module.parse(self._ir_text)
+            _rename_export_symbols(module, self._entry, function_name)
+            engine = execution_engine.ExecutionEngine(
+                module,
+                opt_level=3,
+                shared_libs=runtime_libraries,
+                enable_pic=True,
+            )
+            engine.dump_to_object_file(str(object_path))
+
+        init_symbol, load_symbol = _rename_loader_symbols(object_path, function_name)
+        bundled_runtime_libraries = _bundle_runtime_libraries(
+            runtime_libraries,
+            object_path.parent,
+        )
+        return {
+            "object_file_path": str(object_path),
+            "symbol": f"_mlir_{function_name}",
+            "runtime_libraries": bundled_runtime_libraries,
+            "abi": list(self.abi),
+            "module_init_symbol": init_symbol,
+            "module_load_symbol": load_symbol,
+        }
+
+
+def compile_aot(launcher: Any, *args, **kwargs) -> CompiledAOTLauncher:
+    """Compile a specialized FlyDSL launcher into an AOT object and ABI."""
+    if not HAS_FLYDSL:
+        raise RuntimeError("FlyDSL AOT compilation requires the FlyDSL runtime")
+    if not isinstance(launcher, jit_function.JitFunction):
+        raise TypeError(
+            f"flyc.compile_aot() expects a @flyc.jit function, got {type(launcher).__name__}"
+        )
+
+    launcher._ensure_sig()
+    bound_self = None
+    if launcher._has_self_param:
+        if not args:
+            raise TypeError(f"{launcher.func.__name__}() missing 'self' argument")
+        bound_self, args = args[0], args[1:]
+    sig = launcher._sig
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+
+    hints = (
+        kernel_function.CompilationContext.compile_hints(launcher.compile_hints)
+        if launcher.compile_hints
+        else nullcontext()
+    )
+    with jit_function._create_mlir_context() as ctx, hints:
+        param_names, jit_args, dsl_types, constexpr_values = (
+            jit_argument.convert_to_jit_arguments(sig, bound)
+        )
+        has_user_stream = jit_function._ensure_stream_arg(jit_args)
+        ir_types = protocol.get_ir_types(jit_args)
+        loc = kernel_function.func_def_location(launcher.func, ctx)
+        module = ir.Module.create(loc=loc)
+        module.operation.attributes["gpu.container_module"] = ir.UnitAttr.get()
+
+        with ir.InsertionPoint(module.body), loc:
+            backend = backends.get_backend()
+            gpu_module = kernel_function.create_gpu_module(
+                "kernels",
+                targets=backend.gpu_module_targets(),
+                use_explicit_module=True,
+            )
+            func_op = func.FuncOp(launcher.func.__name__, (ir_types, []))
+            func_op.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get()
+            entry_block = func_op.add_entry_block()
+
+            with kernel_function.CompilationContext.create() as comp_ctx:
+                comp_ctx.gpu_module_op = gpu_module
+                comp_ctx.gpu_module_body = kernel_function.get_gpu_module_body(
+                    gpu_module
+                )
+                with ir.InsertionPoint(entry_block):
+                    ir_args = list(func_op.regions[0].blocks[0].arguments)
+                    if not has_user_stream:
+                        comp_ctx.stream_arg = ir_args[-1]
+                    user_jit_args = jit_args[: len(param_names)]
+                    dsl_args = protocol.construct_from_ir_values(
+                        dsl_types, user_jit_args, ir_args
+                    )
+                    named_args = dict(zip(param_names, dsl_args))
+                    named_args.update(constexpr_values)
+                    fastmath_flag = kernel_function.effective_fastmath_hint(
+                        kernel_function.CompilationContext.get_compile_hints()
+                    )
+                    fastmath_scope = (
+                        arith.fastmath(fastmath_flag)
+                        if fastmath_flag is not None
+                        else nullcontext()
+                    )
+                    with meta.tracing_context(launcher.func), fastmath_scope:
+                        if bound_self is not None:
+                            launcher.func(bound_self, **named_args)
+                        else:
+                            launcher.func(**named_args)
+                    func.ReturnOp([])
+
+        link_libs = list(comp_ctx.link_libs) if comp_ctx.link_libs else None
+        if comp_ctx.post_load_processors:
+            raise RuntimeError(
+                "FlyDSL AOT export does not support Python post-load processors"
+            )
+        if link_libs and jit_function._use_external_binary_codegen():
+            raise RuntimeError(
+                "FlyDSL external codegen does not support extern-linked AOT launchers"
+            )
+        if link_libs and "targets" in gpu_module.operation.attributes:
+            del gpu_module.operation.attributes["targets"]
+
+        flydsl_utils.log().info(f"FlyDSL AOT jit_args={jit_args}")
+        compiled_module = jit_function.MlirCompiler.compile(
+            module,
+            arch=backend.target.arch,
+            func_name=launcher.func.__name__,
+            link_libs=link_libs,
+        )
+        abi = _launcher_abi(sig, bound, jit_args, has_user_stream)
+        return CompiledAOTLauncher(compiled_module, launcher.func.__name__, abi)

--- a/torch/_inductor/codegen/flydsl/aot_compile.py
+++ b/torch/_inductor/codegen/flydsl/aot_compile.py
@@ -463,8 +463,23 @@ def compile_aot(launcher: Any, *args, **kwargs) -> CompiledAOTLauncher:
                     dsl_args = protocol.construct_from_ir_values(
                         dsl_types, user_jit_args, ir_args
                     )
-                    named_args = dict(zip(param_names, dsl_args))
-                    named_args.update(constexpr_values)
+                    resolved_args = dict(zip(param_names, dsl_args))
+                    resolved_args.update(constexpr_values)
+                    positional_args = []
+                    keyword_args = {}
+                    for parameter in sig.parameters.values():
+                        value = resolved_args[parameter.name]
+                        if parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
+                            positional_args.append(value)
+                        elif parameter.kind in (
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                            inspect.Parameter.KEYWORD_ONLY,
+                        ):
+                            keyword_args[parameter.name] = value
+                        else:
+                            raise TypeError(
+                                "FlyDSL AOT does not support variadic launcher parameters"
+                            )
                     fastmath_flag = kernel_function.effective_fastmath_hint(
                         kernel_function.CompilationContext.get_compile_hints()
                     )
@@ -475,9 +490,9 @@ def compile_aot(launcher: Any, *args, **kwargs) -> CompiledAOTLauncher:
                     )
                     with meta.tracing_context(launcher.func), fastmath_scope:
                         if bound_self is not None:
-                            launcher.func(bound_self, **named_args)
+                            launcher.func(bound_self, *positional_args, **keyword_args)
                         else:
-                            launcher.func(**named_args)
+                            launcher.func(*positional_args, **keyword_args)
                     func.ReturnOp([])
 
         link_libs = list(comp_ctx.link_libs) if comp_ctx.link_libs else None

--- a/torch/_inductor/codegen/flydsl/flydsl_aot.py
+++ b/torch/_inductor/codegen/flydsl/flydsl_aot.py
@@ -1,0 +1,345 @@
+# mypy: allow-untyped-defs
+
+from __future__ import annotations
+
+import os
+import secrets
+import shlex
+import tempfile
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+from torch._inductor import config
+from torch._inductor.codegen.cpp_utils import cexpr
+from torch._inductor.runtime.runtime_utils import cache_dir
+from torch._inductor.virtualized import V
+
+
+if TYPE_CHECKING:
+    import inspect
+
+
+@dataclass(frozen=True)
+class FlyDSLAOTArtifact:
+    object_file_path: str
+    symbol: str
+    runtime_libraries: tuple[str, ...]
+    abi: tuple[dict[str, Any], ...]
+    module_init_symbol: str
+    module_load_symbol: str
+
+
+def argument_signature(arguments: tuple[Any, ...]) -> tuple[Any, ...]:
+    signature: list[tuple[Any, ...]] = []
+    for argument in arguments:
+        if hasattr(argument, "shape") and hasattr(argument, "stride"):
+            signature.append(
+                (
+                    "tensor",
+                    str(argument.dtype),
+                    tuple(argument.shape),
+                    tuple(argument.stride()),
+                )
+            )
+        else:
+            signature.append((type(argument).__qualname__, repr(argument)))
+    return tuple(signature)
+
+
+def compile_launcher(
+    launcher: Any,
+    arguments: tuple[Any, ...],
+    *,
+    signature: inspect.Signature,
+    bound_self: Any = None,
+) -> FlyDSLAOTArtifact:
+    from torch._higher_order_ops.flydsl_kernel_wrap import (
+        split_flydsl_launcher_arguments,
+    )
+    from torch._inductor.codegen.flydsl.aot_compile import compile_aot
+
+    positional_args, keyword_args = split_flydsl_launcher_arguments(
+        signature, arguments
+    )
+    if bound_self is not None:
+        positional_args = (bound_self, *positional_args)
+    compiled = compile_aot(launcher, *positional_args, **keyword_args)
+    output_dir = cache_dir()
+    os.makedirs(output_dir, exist_ok=True)
+    file_descriptor, object_path = tempfile.mkstemp(
+        prefix="flydsl_launcher_",
+        suffix=".o",
+        dir=output_dir,
+    )
+    os.close(file_descriptor)
+    symbol = f"flydsl_launcher_{secrets.token_hex(12)}"
+    try:
+        metadata = compiled.export_to_c(object_path, symbol)
+    except Exception:
+        os.unlink(object_path)
+        raise
+    return FlyDSLAOTArtifact(
+        object_file_path=metadata["object_file_path"],
+        symbol=metadata["symbol"],
+        runtime_libraries=tuple(metadata["runtime_libraries"]),
+        abi=tuple(metadata["abi"]),
+        module_init_symbol=metadata["module_init_symbol"],
+        module_load_symbol=metadata["module_load_symbol"],
+    )
+
+
+def _define_module_loader(wrapper, artifact: FlyDSLAOTArtifact) -> None:
+    if not hasattr(wrapper, "_flydsl_module_loader_header_emitted"):
+        wrapper._flydsl_module_loader_header_emitted = True
+        wrapper.header.writeline("#include <cstdint>")
+        wrapper.header.writeline("#include <mutex>")
+        wrapper.header.writeline("#include <stdexcept>")
+        wrapper.header.splice(
+            """
+            static bool flydsl_gpu_get_device(int* device_index) {
+            #ifdef USE_ROCM
+              return hipGetDevice(device_index) == hipSuccess;
+            #else
+              return cudaGetDevice(device_index) == cudaSuccess;
+            #endif
+            }
+
+            static void flydsl_gpu_module_unload(void* module) noexcept {
+            #ifdef USE_ROCM
+              (void)hipModuleUnload(reinterpret_cast<hipModule_t>(module));
+            #else
+              (void)cuModuleUnload(reinterpret_cast<CUmodule>(module));
+            #endif
+            }
+            """
+        )
+    ensure_symbol = f"{artifact.symbol}__ensure_module_loaded"
+    holder_symbol = f"{artifact.symbol}__module_holder"
+    wrapper.header.writeline(
+        f'extern "C" void {artifact.module_init_symbol}(void**, int32_t*);'
+    )
+    wrapper.header.writeline(
+        f'extern "C" void {artifact.module_load_symbol}(void**, int32_t*);'
+    )
+    wrapper.header.splice(
+        f"""
+        struct {holder_symbol} {{
+          std::once_flag once;
+          void* module = nullptr;
+          int device_index = -1;
+
+          ~{holder_symbol}() noexcept {{
+            if (module != nullptr) {{
+              flydsl_gpu_module_unload(module);
+            }}
+          }}
+        }};
+
+        static {holder_symbol} {holder_symbol}_instance;
+
+        static void {ensure_symbol}() {{
+          int device_index = -1;
+          if (!flydsl_gpu_get_device(&device_index)) {{
+            throw std::runtime_error("FlyDSL could not query the current GPU device");
+          }}
+          std::call_once({holder_symbol}_instance.once, [device_index]() {{
+            int32_t error = 0;
+            {artifact.module_init_symbol}(
+                &{holder_symbol}_instance.module, &error);
+            if (error != 0) {{
+              throw std::runtime_error("FlyDSL GPU module initialization failed");
+            }}
+            {artifact.module_load_symbol}(
+                &{holder_symbol}_instance.module, &error);
+            if (error != 0 || {holder_symbol}_instance.module == nullptr) {{
+              if ({holder_symbol}_instance.module != nullptr) {{
+                flydsl_gpu_module_unload({holder_symbol}_instance.module);
+                {holder_symbol}_instance.module = nullptr;
+              }}
+              throw std::runtime_error("FlyDSL GPU module load failed");
+            }}
+            {holder_symbol}_instance.device_index = device_index;
+          }});
+          if ({holder_symbol}_instance.device_index != device_index) {{
+            throw std::runtime_error(
+                "FlyDSL AOT modules cannot be shared across GPU devices");
+          }}
+        }}
+        """
+    )
+
+
+def define_aot_kernel(wrapper, launcher_idx: int, call_spec_idx: int, example_args):
+    from torch._higher_order_ops.flydsl_kernel_wrap import (
+        flydsl_launcher_side_table,
+        restore_flydsl_launcher_arguments,
+    )
+    from torch._inductor.codecache import ROCmCodeCache
+
+    if not V.graph.aot_mode:
+        raise NotImplementedError(
+            "FlyDSL C++ wrapper launchers are currently supported in AOT mode"
+        )
+    if config.aot_inductor.package_cpp_only:
+        raise NotImplementedError(
+            "FlyDSL AOT launchers do not support aot_inductor.package_cpp_only; "
+            "the packaged runtime libraries require linking before relocation"
+        )
+    full_example_args = restore_flydsl_launcher_arguments(
+        example_args,
+        call_spec_idx,
+    )
+    cache_key = (
+        "flydsl_aot",
+        launcher_idx,
+        call_spec_idx,
+        argument_signature(full_example_args),
+    )
+    cached = wrapper.user_defined_kernel_cache.get(cache_key)
+    if cached is not None:
+        return cached[2]["artifact"]
+
+    registration = flydsl_launcher_side_table.get_registration(launcher_idx)
+    artifact = compile_launcher(
+        registration.launcher,
+        full_example_args,
+        signature=registration.signature,
+        bound_self=registration.bound_self,
+    )
+    if artifact.object_file_path not in ROCmCodeCache.aot_kernels_o:
+        ROCmCodeCache.aot_kernels_o.append(artifact.object_file_path)
+    for path in artifact.runtime_libraries:
+        wrapper.external_kernel_libs.add(f"-L{shlex.quote(os.path.dirname(path))}")
+        wrapper.external_kernel_libs.add(f"-l:{shlex.quote(os.path.basename(path))}")
+        if path not in wrapper.additional_files:
+            wrapper.additional_files.append(path)
+    if artifact.runtime_libraries:
+        wrapper.external_kernel_libs.add("-Wl,-rpath,$ORIGIN")
+    wrapper.header.writeline(f'extern "C" void {artifact.symbol}(void**);')
+    _define_module_loader(wrapper, artifact)
+    wrapper.user_defined_kernel_cache[cache_key] = (
+        artifact.symbol,
+        None,
+        {"artifact": artifact},
+    )
+    return artifact
+
+
+def generate_aot_kernel_call(
+    wrapper,
+    artifact,
+    kernel_args,
+    *,
+    device,
+    current_stream_idx,
+) -> None:
+    """Pack a FlyDSL ABI call and emit its AOTI launch on the scheduler stream."""
+    from torch._inductor.ir import IRNode
+    from torch._inductor.stream_utils import DEFAULT_STREAM_IDX, get_stream_name
+
+    if not hasattr(wrapper, "_flydsl_call_counter"):
+        wrapper._flydsl_call_counter = 0
+        wrapper.header.writeline("#include <cstring>")
+    call_index = wrapper._flydsl_call_counter
+    wrapper._flydsl_call_counter += 1
+    wrapper.writeline(f"{artifact.symbol}__ensure_module_loaded();")
+    stream = (
+        get_stream_name(current_stream_idx)
+        if V.graph.aot_mode
+        and current_stream_idx is not None
+        and current_stream_idx != DEFAULT_STREAM_IDX
+        else wrapper.write_get_raw_stream(device.index, V.graph.name)
+    )
+    if any(slot.get("encoding") == "float16_bits" for slot in artifact.abi):
+        wrapper.header.writeline("#include <c10/util/Half.h>")
+    if any(slot.get("encoding") == "bfloat16_bits" for slot in artifact.abi):
+        wrapper.header.writeline("#include <c10/util/BFloat16.h>")
+    packed_entries = []
+    for slot_index, slot in enumerate(artifact.abi):
+        slot_name = f"flydsl_{call_index}_{slot_index}"
+        kind = slot["kind"]
+        arg_index = slot["arg_index"]
+        arg = kernel_args[arg_index] if arg_index is not None else None
+        if kind == "tensor_data":
+            if not isinstance(arg, IRNode):
+                raise AssertionError("FlyDSL tensor ABI slot requires an IR node")
+            wrapper.writeline(
+                f"void* {slot_name} = {arg.codegen_reference()}.data_ptr();"
+            )
+            packed_entries.append(f"&{slot_name}")
+        elif kind == "tensor_layout":
+            if not isinstance(arg, IRNode):
+                raise AssertionError("FlyDSL layout ABI slot requires an IR node")
+            wrapper.writeline(
+                f"alignas({slot['alignment']}) unsigned char "
+                f"{slot_name}[{slot['size']}] = {{}};"
+            )
+            offset = 0
+            for dim in slot["shape_dims"]:
+                value_name = f"{slot_name}_shape_{dim}"
+                value = cexpr(V.graph.sizevars.simplify(arg.get_size()[dim]))
+                wrapper.writeline(
+                    f"int32_t {value_name} = static_cast<int32_t>({value});"
+                )
+                wrapper.writeline(
+                    f"std::memcpy({slot_name} + {offset}, &{value_name}, "
+                    f"sizeof({value_name}));"
+                )
+                offset += 4
+            stride_type = "int32_t" if slot["stride_bits"] == 32 else "int64_t"
+            stride_size = 4 if slot["stride_bits"] == 32 else 8
+            for dim in slot["stride_dims"]:
+                value_name = f"{slot_name}_stride_{dim}"
+                value = cexpr(V.graph.sizevars.simplify(arg.get_stride()[dim]))
+                wrapper.writeline(
+                    f"{stride_type} {value_name} = static_cast<{stride_type}>({value});"
+                )
+                wrapper.writeline(
+                    f"std::memcpy({slot_name} + {offset}, &{value_name}, "
+                    f"sizeof({value_name}));"
+                )
+                offset += stride_size
+            packed_entries.append(slot_name)
+        elif kind == "scalar":
+            encoding = slot.get("encoding")
+            value = cexpr(V.graph.sizevars.simplify(arg))
+            if encoding == "float16_bits":
+                wrapper.writeline(
+                    f"uint16_t {slot_name} = "
+                    "c10::detail::fp16_ieee_from_fp32_value("
+                    f"static_cast<float>({value}));"
+                )
+                packed_entries.append(f"&{slot_name}")
+                continue
+            if encoding == "bfloat16_bits":
+                wrapper.writeline(
+                    f"uint16_t {slot_name} = c10::detail::bits_from_f32("
+                    f"static_cast<float>({value}));"
+                )
+                packed_entries.append(f"&{slot_name}")
+                continue
+            scalar_types = {
+                "bool": "bool",
+                "float": "float",
+                "double": "double",
+                **{f"int{bits}": f"int{bits}_t" for bits in (8, 16, 32, 64)},
+                **{f"uint{bits}": f"uint{bits}_t" for bits in (8, 16, 32, 64)},
+            }
+            scalar_type = scalar_types[slot["ctype"]]
+            wrapper.writeline(
+                f"{scalar_type} {slot_name} = static_cast<{scalar_type}>({value});"
+            )
+            packed_entries.append(f"&{slot_name}")
+        elif kind in ("pointer", "stream"):
+            if kind == "stream" and arg_index is not None:
+                raise AssertionError(
+                    "FlyDSL AOT launchers do not accept explicit stream arguments"
+                )
+            value = stream if kind == "stream" else cexpr(arg)
+            wrapper.writeline(f"void* {slot_name} = reinterpret_cast<void*>({value});")
+            packed_entries.append(f"&{slot_name}")
+        else:
+            raise NotImplementedError(f"Unsupported FlyDSL ABI slot kind: {kind}")
+    packed_name = f"flydsl_packed_{call_index}"
+    wrapper.writeline(f"void* {packed_name}[] = {{{', '.join(packed_entries)}}};")
+    wrapper.writeline(f"{artifact.symbol}({packed_name});")

--- a/torch/_inductor/codegen/flydsl/user_defined_kernel.py
+++ b/torch/_inductor/codegen/flydsl/user_defined_kernel.py
@@ -1,0 +1,222 @@
+# mypy: allow-untyped-defs
+
+from __future__ import annotations
+
+from typing import Any, cast
+from typing_extensions import override
+
+import sympy
+
+import torch
+from torch._inductor import ir
+from torch._inductor.pattern_matcher import (
+    CallFunctionVarArgs,
+    Match,
+    PatternMatcherPass,
+    register_graph_pattern,
+)
+from torch._inductor.virtualized import V
+
+
+class UserDefinedFlyDSLKernel(ir.ExternKernel):
+    """Lower a captured FlyDSL launcher through Python or AOTI codegen."""
+
+    @override
+    def codegen(self, wrapper) -> None:
+        if V.graph.cpp_wrapper:
+            from .flydsl_aot import define_aot_kernel, generate_aot_kernel_call
+
+            artifact = define_aot_kernel(
+                wrapper,
+                self.launcher_idx,
+                self.call_spec_idx,
+                self.example_args,
+            )
+            generate_aot_kernel_call(
+                wrapper,
+                artifact,
+                self.kernel_args,
+                device=self.device,
+                current_stream_idx=V.graph.scheduler.current_stream_idx,
+            )
+            return
+
+        kernel_name = define_python_launcher(
+            wrapper,
+            self.launcher_idx,
+            self.call_spec_idx,
+        )
+        from torch._higher_order_ops.flydsl_kernel_wrap import (
+            flydsl_launcher_side_table,
+        )
+
+        constant_arg_indices = flydsl_launcher_side_table.get_call_spec(
+            self.call_spec_idx
+        )
+        call_args: list[Any] = []
+        arg_types: list[Any] = []
+        for arg_idx, arg in enumerate(self.kernel_args):
+            if arg_idx in constant_arg_indices:
+                continue
+            if isinstance(arg, ir.IRNode):
+                call_args.append(arg.codegen_reference())
+                arg_types.append(arg.get_dtype())
+            elif isinstance(arg, (int, float, bool, sympy.Expr)):
+                call_args.append(arg)
+                arg_types.append(type(arg))
+            else:
+                raise NotImplementedError(
+                    f"Unsupported FlyDSL launcher argument: {type(arg)}: {arg}"
+                )
+
+        self.codegen_comment(wrapper, kernel_name)
+        wrapper.generate_kernel_call(
+            kernel_name,
+            call_args,
+            arg_types=arg_types,
+            triton=True,
+            device=self.device,
+            original_fxnode_name=self.fx_node.name,
+        )
+
+    def __init__(
+        self,
+        *,
+        launcher_idx: int,
+        call_spec_idx: int,
+        kernel_args: tuple[Any, ...],
+        mutated_arg_indices: tuple[int, ...],
+    ) -> None:
+        inputs: list[ir.IRNode] = []
+        lowered_args: list[Any] = []
+        input_by_arg_index: dict[int, ir.IRNode] = {}
+        for idx, arg in enumerate(kernel_args):
+            if isinstance(arg, ir.TensorBox):
+                realized = ir.InputsKernel.unwrap_storage_for_input(
+                    self.realize_input(arg)
+                )
+                inputs.append(realized)
+                lowered_args.append(realized)
+                input_by_arg_index[idx] = realized
+            else:
+                lowered_args.append(arg)
+
+        if not inputs:
+            raise AssertionError(
+                "FlyDSL launcher must have at least one tensor argument"
+            )
+        self.device = inputs[0].get_device()
+        super().__init__(
+            None,
+            ir.NoneLayout(device=self.device),
+            inputs,
+            tuple(arg for arg in lowered_args if not isinstance(arg, ir.IRNode)),
+        )
+        self.launcher_idx = launcher_idx
+        self.call_spec_idx = call_spec_idx
+        self.kernel_args = tuple(lowered_args)
+        self.example_args = _example_args(self.kernel_args)
+        self.mutation_outputs = [
+            ir.MutationOutput(
+                ir.NoneLayout(device=self.device),
+                input_by_arg_index[idx],
+                self,
+            )
+            for idx in mutated_arg_indices
+        ]
+        V.graph.register_operation(self)
+
+    def get_outputs(self) -> list[ir.Buffer]:
+        return list(self.mutation_outputs)
+
+    def get_device(self):
+        return self.device
+
+
+def _example_args(args: tuple[Any, ...]) -> tuple[Any, ...]:
+    examples = []
+    for arg in args:
+        if isinstance(arg, ir.IRNode):
+            examples.append(
+                cast(Any, torch).empty_strided(
+                    V.graph.sizevars.optimization_hints(arg.get_size()),
+                    V.graph.sizevars.optimization_hints(arg.get_stride()),
+                    dtype=arg.get_dtype(),
+                    device="meta",
+                )
+            )
+        elif isinstance(arg, sympy.Expr):
+            examples.append(V.graph.sizevars.optimization_hint(arg))
+        else:
+            examples.append(arg)
+    return tuple(examples)
+
+
+def lower_flydsl_kernel(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    UserDefinedFlyDSLKernel(
+        launcher_idx=launcher_idx,
+        call_spec_idx=call_spec_idx,
+        kernel_args=args,
+        mutated_arg_indices=mutated_arg_indices,
+    )
+
+
+def define_python_launcher(wrapper, launcher_idx: int, call_spec_idx: int) -> str:
+    cache_key = ("flydsl", launcher_idx, call_spec_idx)
+    cached = wrapper.user_defined_kernel_cache.get(cache_key)
+    if cached is not None:
+        return cached[0]
+
+    name = f"flydsl_user_kernel_{len(wrapper.user_defined_kernel_cache)}"
+    wrapper.add_import_once(
+        "from torch._higher_order_ops.flydsl_kernel_wrap import FlyDSLPythonLauncher"
+    )
+    wrapper.header.writeline(
+        f"{name} = FlyDSLPythonLauncher({launcher_idx}, {call_spec_idx})"
+    )
+    wrapper.user_defined_kernel_cache[cache_key] = (name, None, {})
+    return name
+
+
+def decompose_functional_wrapper(graph) -> None:
+    from torch._higher_order_ops.flydsl_kernel_wrap import (
+        flydsl_kernel_wrapper_functional,
+        flydsl_kernel_wrapper_functional_dense,
+    )
+    from torch._inductor.fx_passes.post_grad import apply_pass_to_subgraphs
+
+    apply_pass_to_subgraphs(decompose_functional_wrapper, graph)
+    if not graph.find_nodes(
+        op="call_function",
+        target=flydsl_kernel_wrapper_functional,
+    ):
+        return
+    graph_pass = PatternMatcherPass()
+
+    @register_graph_pattern(
+        CallFunctionVarArgs(flydsl_kernel_wrapper_functional),
+        # pyrefly: ignore [bad-argument-type]
+        pass_dict=graph_pass,
+    )
+    def _(match: Match, *args, **kwargs):
+        flat_args, spec = torch.utils._pytree.tree_flatten((args, kwargs))
+
+        def decomp(*flat_args):
+            args, kwargs = torch.utils._pytree.tree_unflatten(flat_args, spec)
+            return (flydsl_kernel_wrapper_functional_dense(*args, **kwargs),)
+
+        # pyrefly: ignore [bad-argument-type]
+        match.replace_by_example(decomp, flat_args, run_functional_passes=False)
+
+    graph_pass.apply(graph)
+    for _ in graph.find_nodes(
+        op="call_function",
+        target=flydsl_kernel_wrapper_functional,
+    ):
+        raise AssertionError("flydsl_kernel_wrapper_functional was not removed")

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -471,6 +471,15 @@ def post_grad_passes(gm: torch.fx.GraphModule, is_inference: bool):
         fix_auto_functionalized_dtype_views
     )
 
+    if _has_flydsl_kernel_wrapper(gm.graph):
+        from torch._inductor.codegen.flydsl.user_defined_kernel import (
+            decompose_functional_wrapper,
+        )
+
+        GraphTransformObserver(
+            gm,
+            "decompose_flydsl_kernel_wrapper_functional",
+        ).apply_graph_pass(decompose_functional_wrapper)
     GraphTransformObserver(
         gm, "decompose_triton_kernel_wrapper_functional"
     ).apply_graph_pass(decompose_triton_kernel_wrapper_functional)
@@ -900,6 +909,7 @@ def reorder_for_locality(graph: torch.fx.Graph):
                 torch.ops._c10d_functional.wait_tensor.default,
                 torch.ops._c10d_functional.wait_tensors.default,
             )
+
     else:
 
         def check():
@@ -1444,6 +1454,29 @@ def apply_pass_to_subgraphs(pass_fn: Callable[[fx.Graph], None], graph: fx.Graph
     for child_name, child_mod in gm.named_children():
         if child_name in subgraph_names and isinstance(child_mod, torch.fx.GraphModule):
             pass_fn(child_mod.graph)
+
+
+def _has_flydsl_kernel_wrapper(graph: fx.Graph) -> bool:
+    from torch._higher_order_ops.flydsl_kernel_wrap import (
+        flydsl_kernel_wrapper_functional,
+    )
+
+    if graph.find_nodes(
+        op="call_function",
+        target=flydsl_kernel_wrapper_functional,
+    ):
+        return True
+    gm = graph.owning_module
+    if gm is None:
+        return False
+    subgraph_names: OrderedSet[str] = OrderedSet(
+        node.target for node in graph.find_nodes(op="get_attr")
+    )
+    return any(
+        _has_flydsl_kernel_wrapper(child.graph)
+        for name, child in gm.named_children()
+        if name in subgraph_names and isinstance(child, torch.fx.GraphModule)
+    )
 
 
 def apply_pass_to_control_deps_subgraphs(

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -14,6 +14,7 @@ from torch._C._dynamo.guards import compute_overlapping_tensors
 from torch._dispatch.python import enable_python_dispatcher
 from torch._dynamo.utils import ReinplaceCounters, ReInplaceTrigger
 from torch._guards import detect_fake_mode
+from torch._higher_order_ops.flydsl_kernel_wrap import flydsl_kernel_wrapper_functional
 from torch._higher_order_ops.triton_kernel_wrap import (
     kernel_side_table,
     triton_kernel_wrapper_functional,
@@ -999,6 +1000,31 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                             continue
                         replacement = output_idx_to_replacement[idx]
                         replace_and_collect(user, replacement)
+        elif node.target is flydsl_kernel_wrapper_functional:
+            mutated_arg_indices = node.kwargs["mutated_arg_indices"]
+            flydsl_args = node.kwargs["args"]
+            output_tensors = {
+                output_idx: flydsl_args[arg_idx]
+                for output_idx, arg_idx in enumerate(mutated_arg_indices)
+            }
+            tensors_to_clone = reinplace_and_refine_tensors_to_clone(
+                node.kwargs["tensors_to_clone"],
+                output_tensors,
+                f"flydsl_launcher_{node.kwargs['launcher_idx']}",
+                ReInplaceTrigger.FLYDSL_OPS,
+            )
+
+            kwargs = dict(node.kwargs)
+            kwargs["tensors_to_clone"] = tuple(tensors_to_clone)
+            node.kwargs = immutable_dict(kwargs)
+            if "eager_input_vals" in node.meta:
+                args, kwargs = node.meta["eager_input_vals"]
+                new_kwargs = {**kwargs}
+                new_kwargs["tensors_to_clone"] = tuple(tensors_to_clone)
+                node.meta["eager_input_vals"] = (
+                    args,
+                    immutable_dict(new_kwargs),
+                )
         elif node.target in inplaceable_triton_ops:
             kernel_idx = node.kwargs["kernel_idx"]
             kernel = kernel_side_table.get_kernel(kernel_idx)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -28,6 +28,7 @@ from torch._functorch._aot_autograd.descriptors import (
     SavedForBackwardsNoVcCheckAOTOutput,
 )
 from torch._higher_order_ops.associative_scan import associative_scan_op
+from torch._higher_order_ops.flydsl_kernel_wrap import flydsl_kernel_wrapper_mutation
 from torch._higher_order_ops.triton_kernel_wrap import triton_kernel_wrapper_mutation
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_custom_class_obj
@@ -9178,6 +9179,24 @@ from torch._higher_order_ops.auto_functionalize import auto_functionalized
 
 
 make_fallback(auto_functionalized)
+
+
+@register_lowering(flydsl_kernel_wrapper_mutation)
+def flydsl_kernel_wrap_(
+    *,
+    launcher_idx: int,
+    call_spec_idx: int,
+    args: tuple[Any, ...],
+    mutated_arg_indices: tuple[int, ...],
+) -> None:
+    from torch._inductor.codegen.flydsl.user_defined_kernel import lower_flydsl_kernel
+
+    lower_flydsl_kernel(
+        launcher_idx=launcher_idx,
+        call_spec_idx=call_spec_idx,
+        args=args,
+        mutated_arg_indices=mutated_arg_indices,
+    )
 
 
 @register_lowering(triton_kernel_wrapper_mutation)

--- a/torch/_library/__init__.py
+++ b/torch/_library/__init__.py
@@ -3,4 +3,5 @@ import torch._library.fake_impl
 import torch._library.simple_registry
 import torch._library.utils
 from torch._library.fake_class_registry import register_fake_class
+from torch._library.flydsl import wrap_flydsl
 from torch._library.triton import capture_triton, triton_op, wrap_triton

--- a/torch/_library/__init__.py
+++ b/torch/_library/__init__.py
@@ -3,5 +3,5 @@ import torch._library.fake_impl
 import torch._library.simple_registry
 import torch._library.utils
 from torch._library.fake_class_registry import register_fake_class
-from torch._library.flydsl import wrap_flydsl
+from torch._library.flydsl import flydsl_op, wrap_flydsl
 from torch._library.triton import capture_triton, triton_op, wrap_triton

--- a/torch/_library/flydsl.py
+++ b/torch/_library/flydsl.py
@@ -1,0 +1,147 @@
+import inspect
+from collections.abc import Callable, Iterable
+from functools import partial
+from typing import Any
+
+from torch.utils._exposed_in import exposed_in
+
+
+@exposed_in("torch.library")
+def wrap_flydsl(
+    launcher: Callable[..., Any],
+    /,
+    *,
+    mutates_args: Iterable[str],
+) -> Any:
+    """Wrap a FlyDSL ``@jit`` launcher for dispatcher-based tracing.
+
+    The launcher must write results into explicit tensor arguments and return
+    ``None``. AOTInductor executes a wrapped launcher on PyTorch's current
+    device stream. Direct eager calls require the default device stream;
+    launchers with an explicit FlyDSL ``Stream`` parameter are unsupported.
+    ``mutates_args`` names the tensor arguments written by the launcher.
+    Runtime arguments must be graphable PyTorch values rather than
+    preconstructed FlyDSL ``JitArgument`` objects.
+
+    Variadic launcher parameters are not supported.
+    """
+    from torch._dynamo.decorators import allow_in_graph, assume_constant_result
+    from torch._higher_order_ops.flydsl_kernel_wrap import (
+        _register_flydsl_call_spec,
+        flydsl_kernel_wrapper_mutation,
+        TraceableFlyDSLLauncher,
+    )
+    from torch._inductor.codegen.flydsl.flydsl_utils import runtime_available
+
+    if not runtime_available():
+        raise RuntimeError(
+            "wrap_flydsl requires a supported optional `flydsl` runtime "
+            "on a ROCm-enabled build"
+        )
+
+    from flydsl.compiler import jit_argument, jit_function, protocol
+    from flydsl.expr import typing as flydsl_typing
+
+    JitFunction = jit_function.JitFunction
+    bound_self = None
+    jit_launcher = launcher
+    if isinstance(launcher, partial):
+        bound_call = launcher.func
+        candidate = getattr(bound_call, "__self__", None)
+        if (
+            isinstance(candidate, JitFunction)
+            and getattr(bound_call, "__func__", None) is JitFunction.__call__
+            and len(launcher.args) == 1
+            and not launcher.keywords
+        ):
+            jit_launcher = candidate
+            bound_self = launcher.args[0]
+
+    if not isinstance(jit_launcher, JitFunction):
+        raise RuntimeError(
+            "wrap_flydsl only works on functions annotated with flydsl.compiler.jit"
+        )
+    signature = jit_argument.resolve_signature(jit_launcher.func)
+    parameters = tuple(signature.parameters.values())
+    has_self = bool(parameters) and parameters[0].name == "self"
+    if has_self:
+        if bound_self is None:
+            raise TypeError("FlyDSL JIT methods must be wrapped from a bound instance")
+        signature = signature.replace(parameters=parameters[1:])
+    if any(
+        parameter.kind
+        in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        for parameter in signature.parameters.values()
+    ):
+        raise TypeError("FlyDSL launchers with variadic parameters cannot be wrapped")
+    if any(
+        getattr(parameter.annotation, "_is_stream_param", False)
+        for parameter in signature.parameters.values()
+    ):
+        raise TypeError(
+            "FlyDSL launchers with explicit Stream parameters cannot be wrapped; "
+            "AOT launchers use PyTorch's current device stream"
+        )
+
+    compile_time_arg_indices = frozenset(
+        idx
+        for idx, parameter in enumerate(signature.parameters.values())
+        if parameter.annotation is not inspect.Parameter.empty
+        and (
+            flydsl_typing.Constexpr.is_constexpr_annotation(parameter.annotation)
+            or jit_argument.is_type_param_annotation(parameter.annotation)
+        )
+    )
+    constexpr_arg_indices = frozenset(
+        idx
+        for idx, parameter in enumerate(signature.parameters.values())
+        if parameter.annotation is not inspect.Parameter.empty
+        and flydsl_typing.Constexpr.is_constexpr_annotation(parameter.annotation)
+    )
+
+    mutations = frozenset(mutates_args)
+    unknown = mutations.difference(signature.parameters)
+    if unknown:
+        raise ValueError(
+            f"FlyDSL mutated arguments are not launcher parameters: {sorted(unknown)}"
+        )
+    parameter_names = tuple(signature.parameters)
+    compile_time_parameters = {parameter_names[idx] for idx in compile_time_arg_indices}
+    invalid_mutations = mutations.intersection(compile_time_parameters)
+    if invalid_mutations:
+        raise ValueError(
+            "FlyDSL compile-time arguments cannot be mutated: "
+            f"{sorted(invalid_mutations)}"
+        )
+    non_tensor_mutations = {
+        name
+        for name in mutations
+        if not (
+            isinstance(signature.parameters[name].annotation, type)
+            and issubclass(
+                signature.parameters[name].annotation,
+                flydsl_typing.Tensor,
+            )
+        )
+    }
+    if non_tensor_mutations:
+        raise TypeError(
+            "FlyDSL mutated arguments must have the flydsl.expr.Tensor "
+            f"annotation: {sorted(non_tensor_mutations)}"
+        )
+    mutated_arg_indices = tuple(
+        idx for idx, name in enumerate(parameter_names) if name in mutations
+    )
+    assume_constant_result(_register_flydsl_call_spec)
+    allow_in_graph(flydsl_kernel_wrapper_mutation)
+    return TraceableFlyDSLLauncher(
+        jit_launcher,
+        mutated_arg_indices,
+        bound_self=bound_self,
+        signature=signature,
+        compile_time_arg_indices=compile_time_arg_indices,
+        constexpr_arg_indices=constexpr_arg_indices,
+        constexpr_value_signature=flydsl_typing.Constexpr.value_signature,
+        stream_type=flydsl_typing.Stream,
+        jit_argument_type=protocol.JitArgument,
+    )

--- a/torch/_library/flydsl.py
+++ b/torch/_library/flydsl.py
@@ -5,6 +5,86 @@ from typing import Any
 
 from torch.utils._exposed_in import exposed_in
 
+from .custom_ops import custom_op, CustomOpDef
+from .infer_schema import infer_schema
+
+
+@exposed_in("torch.library")
+def flydsl_op(
+    name: str,
+    fn: Callable | None = None,
+    /,
+    *,
+    mutates_args: str | Iterable[str],
+    schema: str | None = None,
+) -> Callable:
+    """Create a custom operator backed by one or more wrapped FlyDSL launchers.
+
+    Use this boundary when a FlyDSL-backed operation contains Python control flow
+    that should remain opaque to frontend tracing. The function body may contain
+    PyTorch-understood operations and launchers returned by :func:`wrap_flydsl`.
+    It must otherwise remain traceable when its implementation is decomposed for
+    compilation and must not rely on unsupported external Python side effects.
+
+    Args:
+        name: A stable operator name in ``"namespace::name"`` form.
+        mutates_args: Names of arguments mutated by the outer operator, or
+            ``"unknown"`` to conservatively mark all inputs as mutated.
+        schema: An optional operator schema. By default it is inferred from the
+            function annotations.
+
+    Example::
+
+        wrapped_launcher = torch.library.wrap_flydsl(launcher, mutates_args={"out"})
+
+
+        @torch.library.flydsl_op("mylib::add_one", mutates_args=())
+        def add_one(inp: torch.Tensor) -> torch.Tensor:
+            out = torch.empty_like(inp)
+            wrapped_launcher(out=out, inp=inp, rows=inp.numel())
+            return out
+    """
+
+    def dec(fn: Callable[..., object]) -> CustomOpDef:
+        result = custom_op(
+            name,
+            fn,
+            mutates_args=mutates_args,
+            schema=(
+                schema
+                if schema is not None
+                else infer_schema(fn, mutates_args=mutates_args)
+            ),
+        )
+        result.register_fake(fn)
+
+        from .._subclasses.functional_tensor import FunctionalTensorMode
+
+        def functional_decomp(mode, op, types, args, kwargs):
+            import torch._subclasses
+
+            unrecognized_types = [
+                typ
+                for typ in types
+                if not issubclass(typ, torch._subclasses.FakeTensor)
+                and typ
+                not in (
+                    torch.Tensor,
+                    torch._subclasses.functional_tensor.FunctionalTensor,
+                )
+            ]
+            if unrecognized_types:
+                return NotImplemented
+            with mode:
+                return fn(*args, **kwargs)
+
+        result.register_torch_dispatch(FunctionalTensorMode, functional_decomp)
+        return result
+
+    if fn is None:
+        return dec
+    return dec(fn)
+
 
 @exposed_in("torch.library")
 def wrap_flydsl(

--- a/torch/_library/flydsl.py
+++ b/torch/_library/flydsl.py
@@ -107,6 +107,9 @@ def wrap_flydsl(
     ``mutates_args`` names the tensor arguments written by the launcher.
     Runtime arguments must be graphable PyTorch values rather than
     preconstructed FlyDSL ``JitArgument`` objects.
+    AOT compilation supports tensor, pointer, numeric scalar, and implicit
+    current-stream arguments. Custom or composite FlyDSL JIT arguments require
+    a declarative AOT ABI and are not supported yet.
 
     Variadic launcher parameters are not supported.
     """

--- a/torch/_library/flydsl.py
+++ b/torch/_library/flydsl.py
@@ -61,6 +61,11 @@ def flydsl_op(
         from .._subclasses.functional_tensor import FunctionalTensorMode
 
         def functional_decomp(mode, op, types, args, kwargs):
+            from torch.export._trace import custom_flydsl_ops_decomposition_disabled
+
+            if custom_flydsl_ops_decomposition_disabled():
+                return mode.__torch_dispatch__(op, types, args, kwargs)
+
             import torch._subclasses
 
             unrecognized_types = [

--- a/torch/export/_trace.py
+++ b/torch/export/_trace.py
@@ -223,6 +223,26 @@ def custom_triton_ops_decomposition_disabled():
     return not torch._functorch.config.decompose_custom_triton_ops
 
 
+@contextmanager
+def _set_custom_flydsl_op_functional_decomposition(enabled: bool):
+    old = torch._functorch.config.decompose_custom_flydsl_ops
+    try:
+        torch._functorch.config.decompose_custom_flydsl_ops = enabled
+        yield torch._functorch.config.decompose_custom_flydsl_ops
+    finally:
+        torch._functorch.config.decompose_custom_flydsl_ops = old
+
+
+@contextmanager
+def _disable_custom_flydsl_op_functional_decomposition():
+    with _set_custom_flydsl_op_functional_decomposition(False) as enabled:
+        yield enabled
+
+
+def custom_flydsl_ops_decomposition_disabled():
+    return not torch._functorch.config.decompose_custom_flydsl_ops
+
+
 def _fixup_key(x):
     return "L__self__" + _strip_root(x)
 
@@ -1020,9 +1040,9 @@ def _export_to_torch_ir(
     # them here.
     args, kwargs = pytree.tree_map_only(
         _IntWrapper,
-        lambda a: a.val
-        if a.dynamism is None or a.dynamism.type == _DimHintType.STATIC
-        else a,
+        lambda a: (
+            a.val if a.dynamism is None or a.dynamism.type == _DimHintType.STATIC else a
+        ),
         (args, kwargs),
     )
 
@@ -1177,6 +1197,7 @@ def _export_to_aten_ir(
     decomp_table=None,
     _prettify_placeholder_names: bool = True,
     decompose_custom_triton_ops: bool = False,
+    decompose_custom_flydsl_ops: bool = False,
 ) -> ATenExportArtifact:
     custom_triton_ops_decomposition_ctx = (
         nullcontext
@@ -1199,6 +1220,9 @@ def _export_to_aten_ir(
         stack.enter_context(_ignore_backend_decomps())
         stack.enter_context(_compiling_state_context())
         stack.enter_context(custom_triton_ops_decomposition_ctx())
+        stack.enter_context(
+            _set_custom_flydsl_op_functional_decomposition(decompose_custom_flydsl_ops)
+        )
         stack.enter_context(torch.no_grad())
 
         gm, graph_signature = transform(_aot_export_joint_with_descriptors)(
@@ -1562,9 +1586,11 @@ def _process_export_inputs(
     mod: torch.nn.Module,
     args: tuple[object, ...],
     kwargs: dict[str, object] | None,
-    dynamic_shapes: _DynamicShapesInput
-    | torch.export.AdditionalInputs
-    | torch.export.ShapesCollection,
+    dynamic_shapes: (
+        _DynamicShapesInput
+        | torch.export.AdditionalInputs
+        | torch.export.ShapesCollection
+    ),
 ) -> tuple[
     tuple[object, ...],
     dict[str, object],

--- a/torch/export/experimental/__init__.py
+++ b/torch/export/experimental/__init__.py
@@ -78,10 +78,10 @@ def _export_forward_backward(
         cia_to_decomp={},
         python_decomp_table=core_aten_decompositions(),
         joint_loss_index=joint_loss_index,
-        # For serialization purpose, we don't want to decompose custom triton ops.
-        # If users would like to decompose custom triton ops, they could do it
-        # with run_decompositions() API.
+        # Preserve custom kernel ops for serialization. Users can opt into
+        # decomposition with run_decompositions().
         decompose_custom_triton_ops=False,
+        decompose_custom_flydsl_ops=False,
     )
     gm, new_graph_signature = _copy_graph_module_and_signature(ep)
     _remove_detach_pass(gm, new_graph_signature)

--- a/torch/export/exported_program.py
+++ b/torch/export/exported_program.py
@@ -335,6 +335,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
     python_decomp_table: dict[torch._ops.OperatorBase, Callable],
     joint_loss_index: int | None,
     decompose_custom_triton_ops,
+    decompose_custom_flydsl_ops=False,
 ):
     from torch._export.passes.lift_constants_pass import _materialize_and_lift_constants
     from torch._functorch.aot_autograd import aot_export_module
@@ -342,6 +343,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
         _disable_custom_triton_op_functional_decomposition,
         _export_to_aten_ir,
         _ignore_backend_decomps,
+        _set_custom_flydsl_op_functional_decomposition,
         _verify_nn_module_stack,
         _verify_placeholder_names,
         _verify_stack_trace,
@@ -489,6 +491,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
                     decomp_table=python_decomp_table,
                     _prettify_placeholder_names=False,
                     decompose_custom_triton_ops=decompose_custom_triton_ops,
+                    decompose_custom_flydsl_ops=decompose_custom_flydsl_ops,
                 )
 
                 # aten_export_artifact.constants contains only fake script objects, we need to map them back
@@ -601,6 +604,7 @@ def _decompose_and_get_gm_with_new_signature_constants(
         fake_mode_ctx,
         _override_composite_implicit_decomp(cia_to_decomp),
         custom_triton_ops_decomposition_ctx(),
+        _set_custom_flydsl_op_functional_decomposition(decompose_custom_flydsl_ops),
     ):
         gm, graph_signature = aot_export_module(
             ep.graph_module,
@@ -1018,6 +1022,7 @@ def _decompose_exported_program(
     python_decomp_table: dict[torch._ops.OperatorBase, Callable],
     joint_loss_index: int | None,
     decompose_custom_triton_ops: bool,
+    decompose_custom_flydsl_ops: bool = False,
 ):
     (
         gm,
@@ -1030,6 +1035,7 @@ def _decompose_exported_program(
         python_decomp_table=python_decomp_table,
         joint_loss_index=joint_loss_index,
         decompose_custom_triton_ops=decompose_custom_triton_ops,
+        decompose_custom_flydsl_ops=decompose_custom_flydsl_ops,
     )
 
     # The signatures of ep.module_call_graph refer to input / output nodes of
@@ -1516,6 +1522,7 @@ class ExportedProgram:
         self,
         decomp_table: dict[torch._ops.OperatorBase, Callable] | None = None,
         decompose_custom_triton_ops: bool = False,
+        decompose_custom_flydsl_ops: bool = False,
     ) -> "ExportedProgram":
         """
         Run a set of decompositions on the exported program and returns a new
@@ -1530,6 +1537,10 @@ class ExportedProgram:
              An optional argument that specifies decomp behaviour for Aten ops
              (1) If None, we decompose to core aten decompositions
              (2) If empty, we don't decompose any operator
+            decompose_custom_flydsl_ops:
+             Whether to decompose :func:`torch.library.flydsl_op` operators into
+             their wrapped FlyDSL launchers. Defaults to ``False`` independently
+             of ``decompose_custom_triton_ops``.
 
 
         Some examples:
@@ -1580,6 +1591,7 @@ class ExportedProgram:
             python_decomp_table=python_decomp_table,
             joint_loss_index=None,
             decompose_custom_triton_ops=decompose_custom_triton_ops,
+            decompose_custom_flydsl_ops=decompose_custom_flydsl_ops,
         )
 
     def _transform_do_not_use(self, *passes: PassType) -> "ExportedProgram":

--- a/torch/library.py
+++ b/torch/library.py
@@ -19,6 +19,7 @@ from torch._library.custom_ops import (
     device_types_t,
 )
 from torch._library.effects import EffectType
+from torch._library.flydsl import wrap_flydsl
 from torch._library.infer_schema import infer_schema
 from torch._library.triton import triton_op, wrap_triton
 from torch._ops import OpOverload
@@ -38,6 +39,7 @@ __all__ = [
     "get_ctx",
     "get_kernel",
     "custom_op",
+    "wrap_flydsl",
     "triton_op",
     "wrap_triton",
     "infer_schema",

--- a/torch/library.py
+++ b/torch/library.py
@@ -19,7 +19,7 @@ from torch._library.custom_ops import (
     device_types_t,
 )
 from torch._library.effects import EffectType
-from torch._library.flydsl import wrap_flydsl
+from torch._library.flydsl import flydsl_op, wrap_flydsl
 from torch._library.infer_schema import infer_schema
 from torch._library.triton import triton_op, wrap_triton
 from torch._ops import OpOverload
@@ -39,6 +39,7 @@ __all__ = [
     "get_ctx",
     "get_kernel",
     "custom_op",
+    "flydsl_op",
     "wrap_flydsl",
     "triton_op",
     "wrap_triton",


### PR DESCRIPTION
Summary:
Add MI350 end-to-end coverage for packaged FlyDSL launchers through the native AOTI package loader. Verify vector add packages the FlyDSL and MLIR runtime libraries, avoids clone/copy and Triton fallback code, and executes correctly on both the default and a non-default current stream.

Cover a launcher that emits two device kernels with an explicit workspace, a dynamically exported RMSNorm package that runs multiple row counts through one native loader, and a composed model containing FlyDSL GEMM, ReLU, RMSNorm, and intervening PyTorch operations. Add a packaged RMSNorm case using different transposed tensors for export and execution to verify that the decomposed `wrap_flydsl` path carries non-contiguous strides through the AOTI memref ABI. These tests use `wrap_flydsl` directly and verify the exported FlyDSL HOPs without requiring an outer custom-op boundary.

Test Plan:
- `ROCM_VISIBLE_DEVICES=6 buck2 test mode/opt-split-dwarf mode/inplace mode/amd-gpu -c fbcode.triton_backend=amd -m rocm70 -c fbcode.enable_gpu_sections=true -c fbcode.rocm_arch=mi350 caffe2/test/inductor/flydsl_aot:test_flydsl_aoti_e2e` (5 passed)
- `arc lint -a` on changed files
- `arc lint -a --engine extra --take CITRINEAGENT` on changed ML Python files (no applicable findings)
- `arc pyre check-owning-targets` on changed Python files (no type-enabled owning targets)
- `python3 -m py_compile` on changed Python files

Differential Revision: D116840784
