### PR TITLE
[ROCm] Fix hipify skipping sources under Windows subst drives/symlinks in CUDAExtension

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -678,6 +678,58 @@ class TestHipify(TestCase):
     def test_import_hipify(self):
         from torch.utils.hipify import hipify_python  # noqa: F401
 
+    @unittest.skipIf(IS_WINDOWS, "Creating symlinks may require privileges on Windows")
+    def test_hipify_keeps_symlinked_source_under_build_dir(self):
+        # A .cu source symlinked into the build dir must be hipified *in place*
+        # under the build dir. Resolving the symlink (e.g. realpath-ing sources)
+        # relocates the generated .hip into the real source tree, which then
+        # yields a "../real/foo.hip" path relative to the build dir and breaks the
+        # "paths relative to the setup.py directory" invariant in CUDAExtension.
+        # This reproduces on any platform; no ROCm hardware is required.
+        from torch.utils.hipify import hipify_python
+
+        with tempfile.TemporaryDirectory() as tmp:
+            build_dir = os.path.join(tmp, "build")
+            real_dir = os.path.join(tmp, "real")
+            os.makedirs(build_dir)
+            os.makedirs(real_dir)
+
+            real_source = os.path.join(real_dir, "kernel.cu")
+            with open(real_source, "w") as f:
+                f.write(
+                    "#include <cuda_runtime.h>\n"
+                    "__global__ void my_kernel() {}\n"
+                    "void launch() { cudaDeviceSynchronize(); }\n"
+                )
+
+            linked_source = os.path.join(build_dir, "kernel.cu")
+            os.symlink(real_source, linked_source)
+
+            result = hipify_python.hipify(
+                project_directory=build_dir,
+                output_directory=build_dir,
+                includes=[os.path.join(build_dir, "*")],
+                extra_files=[linked_source],
+                hipify_extra_files_only=True,
+                is_pytorch_extension=True,
+            )
+
+            key = os.path.abspath(linked_source)
+            self.assertIn(key, result)
+            hipified_path = result[key].hipified_path
+            self.assertIsNotNone(
+                hipified_path,
+                "symlinked .cu source under the build dir was silently skipped by hipify",
+            )
+            # The generated file must stay under the build dir rather than follow
+            # the symlink into the real source tree.
+            self.assertEqual(
+                os.path.commonpath([os.path.abspath(hipified_path), build_dir]),
+                build_dir,
+            )
+            self.assertTrue(hipified_path.endswith(".hip"))
+            self.assertFalse(os.path.exists(os.path.join(real_dir, "kernel.hip")))
+
 
 class TestHipifyTrie(TestCase):
     def setUp(self):

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1599,13 +1599,19 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
     if IS_HIP_EXTENSION:
         from .hipify import hipify_python
-        build_dir = os.getcwd()
+        # Resolve symlinks/junctions and Windows `subst` drive aliases so the
+        # build directory and the source paths use the same canonical form. On
+        # Windows CI the build runs under a `subst` drive (e.g. B:) while source
+        # paths may resolve to the real drive (e.g. C:); without this the
+        # `includes` scope below matches nothing and hipify silently skips the
+        # sources, leaving CUDA headers unhipified.
+        build_dir = os.path.realpath(os.getcwd())
         hipify_result = hipify_python.hipify(
             project_directory=build_dir,
             output_directory=build_dir,
             header_include_dirs=include_dirs,
             includes=[os.path.join(build_dir, '*')],  # limit scope to build_dir only
-            extra_files=[os.path.abspath(s) for s in sources],
+            extra_files=[os.path.realpath(s) for s in sources],
             show_detailed=True,
             is_pytorch_extension=True,
             hipify_extra_files_only=True,  # don't hipify everything in includes path
@@ -1613,7 +1619,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
         hipified_sources = set()
         for source in sources:
-            s_abs = os.path.abspath(source)
+            s_abs = os.path.realpath(source)
             hipified_s_abs = (hipify_result[s_abs].hipified_path if (s_abs in hipify_result and
                               hipify_result[s_abs].hipified_path is not None) else s_abs)
             # setup() arguments must *always* be /-separated paths relative to the setup.py directory,

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1599,19 +1599,34 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
     if IS_HIP_EXTENSION:
         from .hipify import hipify_python
-        # Resolve symlinks/junctions and Windows `subst` drive aliases so the
-        # build directory and the source paths use the same canonical form. On
-        # Windows CI the build runs under a `subst` drive (e.g. B:) while source
-        # paths may resolve to the real drive (e.g. C:); without this the
-        # `includes` scope below matches nothing and hipify silently skips the
-        # sources, leaving CUDA headers unhipified.
+        # Resolve symlinks/junctions and Windows `subst` drive aliases on the
+        # build directory so it and the source paths can be compared in a single
+        # canonical form. On Windows CI the build runs under a `subst` drive
+        # (e.g. B:) while source paths may resolve to the real drive (e.g. C:);
+        # without this the `includes` scope below matches nothing and hipify
+        # silently skips the sources, leaving CUDA headers unhipified. On POSIX
+        # `os.getcwd()` is already fully resolved, so this is a no-op there.
         build_dir = os.path.realpath(os.getcwd())
+
+        def _canonical_source(s):
+            # Only canonicalize sources that don't already live under `build_dir`.
+            # Realpath-ing every source would relocate a source that is legitimately
+            # symlinked *into* the build dir to its real location outside it, which
+            # then pushes the generated `.hip` file out of `build_dir` and breaks the
+            # "paths relative to the setup.py directory" invariant below. Restricting
+            # realpath to sources outside `build_dir` still fixes the subst-drive case
+            # (source resolves to a different spelling than `build_dir`).
+            s_abs = os.path.abspath(s)
+            if s_abs.startswith(build_dir + os.sep):
+                return s_abs
+            return os.path.realpath(s)
+
         hipify_result = hipify_python.hipify(
             project_directory=build_dir,
             output_directory=build_dir,
             header_include_dirs=include_dirs,
             includes=[os.path.join(build_dir, '*')],  # limit scope to build_dir only
-            extra_files=[os.path.realpath(s) for s in sources],
+            extra_files=[_canonical_source(s) for s in sources],
             show_detailed=True,
             is_pytorch_extension=True,
             hipify_extra_files_only=True,  # don't hipify everything in includes path
@@ -1619,9 +1634,19 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
         hipified_sources = set()
         for source in sources:
-            s_abs = os.path.realpath(source)
-            hipified_s_abs = (hipify_result[s_abs].hipified_path if (s_abs in hipify_result and
-                              hipify_result[s_abs].hipified_path is not None) else s_abs)
+            s_abs = _canonical_source(source)
+            if s_abs in hipify_result and hipify_result[s_abs].hipified_path is not None:
+                hipified_s_abs = hipify_result[s_abs].hipified_path
+            else:
+                # A CUDA source that hipify didn't process is left as raw CUDA and
+                # fails to compile with hipcc (e.g. missing 'cuda_runtime_api.h').
+                # Warn loudly instead of silently skipping (the historical failure mode).
+                if source.endswith(('.cu', '.cuh')):
+                    logger.warning(
+                        "hipify did not process CUDA source '%s'; it will be built as-is, "
+                        "which typically fails under ROCm. This can happen when the source "
+                        "resolves outside the build directory '%s'.", source, build_dir)
+                hipified_s_abs = s_abs
             # setup() arguments must *always* be /-separated paths relative to the setup.py directory,
             # *never* absolute paths
             try:
@@ -2384,11 +2409,24 @@ def _jit_compile(name,
                 if IS_HIP_EXTENSION and (with_cuda or with_cudnn):
                     if hipify_python is None:
                         raise AssertionError("expected hipify_python to be not None")
+                    # Canonicalize sources that don't already live under the build
+                    # directory (same reasoning as `CUDAExtension`): this fixes the
+                    # Windows `subst` drive / symlinked-path case where a caller-supplied
+                    # source resolves to a different spelling than `build_directory`,
+                    # without relocating sources symlinked into the build directory.
+                    build_dir_real = os.path.realpath(build_directory)
+
+                    def _canonical_source(s):
+                        s_abs = os.path.abspath(s)
+                        if s_abs.startswith(build_dir_real + os.sep):
+                            return s_abs
+                        return os.path.realpath(s)
+
                     hipify_result = hipify_python.hipify(
                         project_directory=build_directory,
                         output_directory=build_directory,
                         header_include_dirs=(extra_include_paths if extra_include_paths is not None else []),
-                        extra_files=[os.path.abspath(s) for s in sources],
+                        extra_files=[_canonical_source(s) for s in sources],
                         ignores=[_join_rocm_home('*'), os.path.join(_TORCH_PATH, '*')],  # no need to hipify ROCm or PyTorch headers
                         show_detailed=verbose,
                         show_progress=verbose,
@@ -2398,10 +2436,17 @@ def _jit_compile(name,
 
                     hipified_sources = set()
                     for source in sources:
-                        s_abs = os.path.abspath(source)
+                        s_abs = _canonical_source(source)
                         if s_abs in hipify_result and hipify_result[s_abs].hipified_path is not None:
                             hipified_s_abs = hipify_result[s_abs].hipified_path
                         else:
+                            # A CUDA source that hipify didn't process is left as raw CUDA
+                            # and fails to compile with hipcc. Warn loudly instead of
+                            # silently skipping (the historical failure mode).
+                            if source.endswith(('.cu', '.cuh')):
+                                logger.warning(
+                                    "hipify did not process CUDA source '%s'; it will be built "
+                                    "as-is, which typically fails under ROCm.", source)
                             hipified_s_abs = s_abs
                         hipified_sources.add(hipified_s_abs)
                     sources = list(hipified_sources)

--- a/torch/utils/hipify/hipify_python.py
+++ b/torch/utils/hipify/hipify_python.py
@@ -1139,8 +1139,16 @@ def hipify(
     for f in extra_files:
         if not os.path.isabs(f):
             f = os.path.join(output_directory, f)
+        # `preprocessor` normalizes each path with `_to_unix_path` before testing
+        # membership in `all_files`, and `matched_files_iter` already yields
+        # `_to_unix_path`-normalized entries. Normalize here too so the two forms
+        # can match; otherwise on Windows the backslash spelling appended here never
+        # equals the forward-slash form tested later, the `extra_files` escape hatch
+        # is effectively dead, and the source is silently skipped (never hipified).
+        f = _to_unix_path(f)
         if f not in all_files_set:
             all_files.append(f)
+            all_files_set.add(f)
 
     # List all files in header_include_paths to ensure they are hipified
     from pathlib import Path


### PR DESCRIPTION
﻿## Summary

`CUDAExtension` scopes hipify to `os.getcwd()` and filters sources with `includes=[build_dir/*]`, comparing against `os.path.abspath(...)` source paths. When a build passes source paths that resolve through symlinks/junctions or Windows `subst` drive aliases, the two sides end up with different spellings of the same location, the `includes` filter matches nothing, and hipify **silently skips** the GPU sources leaving raw CUDA headers (e.g. `cuda_runtime_api.h`) for `hipcc`, which then fails with `fatal error: 'cuda_runtime_api.h' file not found`.

This reproduces on Windows ROCm CI, where the build runs under a `subst` drive (e.g. `B:`) while a dependency such as torchaudio computes its source directory with `Path(...).resolve()` and lands on the real drive (e.g. `C:`). `build_dir` (`B:\...`) and the source paths (`C:\...`) then disagree.

## Fix

The root cause is in `torch/utils/hipify/hipify_python.py`: `hipify()` appended `extra_files` to `all_files` verbatim, while `preprocessor()` tests `_to_unix_path(filepath)` against `all_files`. On Windows the appended backslash spelling never equals the forward-slash form being tested, so the `extra_files` escape hatch was effectively dead and hipification depended entirely on the `includes=[build_dir/*]` directory walk — which the subst-drive mismatch defeats. `extra_files` entries are now normalized with `_to_unix_path` on append (and added to `all_files_set`), fixing the silent skip at the source in a platform-independent, unit-testable way.

In `CUDAExtension` (and the matching `load()` / `_jit_compile` path), each source is canonicalized only when its plain `os.path.abspath` isn't already under `build_dir`. This fixes the subst-drive case without `realpath`-ing sources that are legitimately symlinked *into* the build dir — doing so would relocate the generated `.hip` outside `build_dir` and break the "paths relative to the setup.py directory" invariant. The build directory itself is still `realpath`'d (a no-op on POSIX).

Finally, when a `.cu`/`.cuh` source comes back unhipified, we now log a warning so this failure mode is self-diagnosing instead of surfacing later as a missing `cuda_runtime_api.h`.

The only Linux-visible behavior change is the guarded source canonicalization; the build-dir `realpath` and the `extra_files` normalization are no-ops on POSIX.

## Test plan

- New unit test `test/test_utils.py::TestHipify::test_hipify_keeps_symlinked_source_under_build_dir` (runs on Linux, no ROCm hardware): a `.cu` symlinked into the build dir is hipified in place, with the generated `.hip` staying under the build dir and not following the symlink into the real source tree.
- Windows ROCm extension build (e.g. torchaudio) hipifies and compiles GPU sources: the hipify pass reports kernel replacements > 0 and produces `.hip` sources instead of leaving `.cu`.
- Trunk CI green on this PR head (all checks passed): [trunk run](https://github.com/pytorch/pytorch/actions/runs/32807838458) · [HUD](https://hud.pytorch.org/pr/194641)

Cherry-pick of ROCm/pytorch#3561 (ROCM-29365), validated end-to-end there with a full Windows ROCm multi-arch wheel build (torch + torchaudio + torchvision).


cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
