### PR TITLE
[AOTInductor] Support nested custom-op outputs in AOTI C++ wrappers (#194644)

### DIFF
--- a/test/inductor/test_aot_inductor_custom_ops.py
+++ b/test/inductor/test_aot_inductor_custom_ops.py
@@ -95,6 +95,29 @@ def _(x):
     return [torch.randn(i0)]
 
 
+@torch.library.custom_op("aoti_custom_ops::fn_ret_nested_tensor_lists", mutates_args={})
+def fn_ret_nested_tensor_lists(
+    x: torch.Tensor,
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    return (
+        [x.new_ones(x.numel()), x.new_full((x.numel() + 1,), 2)],
+        [x.new_zeros(x.numel() + 2), x.new_full((x.numel() + 3,), 3)],
+    )
+
+
+@fn_ret_nested_tensor_lists.register_fake
+def _(x):
+    ctx = torch._custom_op.impl.get_ctx()
+    i0 = ctx.new_dynamic_size()
+    i1 = ctx.new_dynamic_size()
+    i2 = ctx.new_dynamic_size()
+    i3 = ctx.new_dynamic_size()
+    return (
+        [x.new_empty(i0), x.new_empty(i1)],
+        [x.new_empty(i2), x.new_empty(i3)],
+    )
+
+
 @torch.library.custom_op("aoti_custom_ops::fn_ret_single_tensor", mutates_args={})
 def fn_ret_single_tensor(x: torch.Tensor) -> torch.Tensor:
     s = x.sum().to(torch.int64)
@@ -402,6 +425,23 @@ class AOTInductorTestsTemplate:
 
         m = Model().to(device=self.device)
         args = (torch.randn(3, 4),)
+        self.check_model(m, args)
+
+    def test_custom_op_return_nested_tensor_lists(self) -> None:
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                values, lengths = torch.ops.aoti_custom_ops.fn_ret_nested_tensor_lists(
+                    x
+                )
+                return (
+                    values[0] + 1,
+                    values[1] + 2,
+                    lengths[0] + 3,
+                    lengths[1] + 4,
+                )
+
+        m = Model().to(device=self.device)
+        args = (torch.randn(3, 4, device=self.device),)
         self.check_model(m, args)
 
     def test_custom_op_return_single_tensor(self) -> None:

--- a/test/inductor/test_wrapper_codegen.py
+++ b/test/inductor/test_wrapper_codegen.py
@@ -1,21 +1,30 @@
 # Owner(s): ["module: inductor"]
 
+import types
 from itertools import count
 from types import SimpleNamespace
 
 import sympy
 
 import torch
+import torch.utils._pytree as pytree
 from torch._inductor import ir
 from torch._inductor.codegen.cpp_wrapper_cpu import CppWrapperCpu
 from torch._inductor.codegen.wrapper import PythonWrapperCodegen
+from torch._inductor.graph import GraphLowering
 from torch._inductor.lowering import _record_symbolic_input_source
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import IndentedBuffer
 from torch._inductor.virtualized import V
+from torch.fx.experimental.symbolic_shapes import CallMethodKey
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 from torch.utils._ordered_set import OrderedSet
 
 
+@instantiate_parametrized_tests
 class TestPythonWrapperCodegen(TestCase):
     def _new_wrapper(self):
         wrapper = PythonWrapperCodegen.__new__(PythonWrapperCodegen)
@@ -35,6 +44,86 @@ class TestPythonWrapperCodegen(TestCase):
         wrapper = CppWrapperCpu.__new__(CppWrapperCpu)
         wrapper.prefix = IndentedBuffer()
         return wrapper
+
+    def _codegen_output_symbol(self, outputs, keypath):
+        wrapper = self._new_cpp_wrapper()
+        wrapper.lines = []
+        wrapper.unbacked_symbol_decls = OrderedSet()
+        wrapper.declare = "auto "
+        wrapper.ending = ";"
+        graph = self._graph_with_sizevars(cpp_wrapper=True)
+        graph.sizevars.shape_env = SimpleNamespace(unbacked_renamings={})
+        symbol = sympy.Symbol("u0", integer=True)
+
+        with V.set_graph_handler(graph):
+            wrapper.codegen_unbacked_symbol_defs_for_outputs(
+                "output", outputs, {symbol: keypath}
+            )
+            wrapper.lines.pop().codegen(IndentedBuffer())
+
+        return wrapper.lines.pop()
+
+    def _new_multi_output(self, *, indices=((list, 0),)):
+        # Build a real MultiOutput. Its constructor self-registers with the
+        # active graph, so bind the graph's register helpers onto a minimal
+        # namespace instead of white-box constructing via object.__new__.
+        device = torch.device("cpu")
+        graph = self._graph_with_sizevars(
+            name=None,
+            cpp_wrapper=False,
+            buffers=[],
+            operations=[],
+            name_to_buffer={},
+            name_to_op={},
+            current_node=None,
+            add_device_info=lambda _device: None,
+        )
+        graph.qualify_name = types.MethodType(GraphLowering.qualify_name, graph)
+        graph.register_buffer = types.MethodType(GraphLowering.register_buffer, graph)
+        graph.register_operation = types.MethodType(
+            GraphLowering.register_operation, graph
+        )
+        with V.set_graph_handler(graph):
+            packed = ir.InputBuffer(name="packed", layout=ir.NoneLayout(device=device))
+            return ir.MultiOutput(ir.NoneLayout(device=device), packed, list(indices))
+
+    def test_cpp_output_symbol_traverses_nested_multi_output_with_indices(self):
+        output = self._new_multi_output(indices=((list, 0), (list, 0)))
+        keypath = (
+            pytree.SequenceKey(0),
+            pytree.SequenceKey(0),
+            CallMethodKey("size"),
+            pytree.SequenceKey(0),
+        )
+
+        self.assertEqual(
+            self._codegen_output_symbol([[output]], keypath),
+            f"auto u0 = {output.get_name()}.size(0);",
+        )
+
+    def test_cpp_output_symbol_preserves_single_multi_output_behavior(self):
+        output = self._new_multi_output(indices=((list, 0),))
+        keypath = (
+            pytree.SequenceKey(7),
+            CallMethodKey("size"),
+            pytree.SequenceKey(0),
+        )
+
+        self.assertEqual(
+            self._codegen_output_symbol([output], keypath),
+            f"auto u0 = {output.get_name()}.size(0);",
+        )
+
+    @parametrize("bad_idx", [1, -1])
+    def test_cpp_output_symbol_rejects_out_of_range_nested_index(self, bad_idx):
+        output = self._new_multi_output()
+        keypath = (pytree.SequenceKey(0), pytree.SequenceKey(bad_idx))
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            f"output index {bad_idx} is out of range for list with 1 elements",
+        ):
+            self._codegen_output_symbol([[output]], keypath)
 
     def test_explicit_symbol_input_assignment_uses_canonical_symbol(self):
         wrapper = self._new_wrapper()

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1451,6 +1451,50 @@ BufferName = str
 Line = MemoryPlanningLine | LineContext
 
 
+def _resolve_nested_output(
+    outputs: Any, keypath: pytree.KeyPath
+) -> tuple[ir.IRNode, pytree.KeyPath]:
+    """Follow ``SequenceKey`` entries into (possibly nested) custom-op outputs
+    until reaching the IR node an unbacked symbol is bound to, returning that
+    node together with the keypath entries that still apply to it.
+    """
+    # Fast path for a single output. When a fallback kernel returns a list
+    # consisting of a single tensor, the output is a MultiOutput with non-empty
+    # indices, and we strip the leading keypath entry.
+    if len(outputs) == 1 and isinstance(outputs[0], ir.IRNode):
+        single_output = outputs[0]
+        remaining = (
+            keypath[1:]
+            if isinstance(single_output, ir.MultiOutput) and single_output.indices
+            else keypath
+        )
+        return single_output, remaining
+
+    # Otherwise descend through nested list/tuple containers via SequenceKeys.
+    current_output = outputs
+    remaining_keypath = keypath
+    while isinstance(current_output, (list, tuple)):
+        if not remaining_keypath or not isinstance(
+            remaining_keypath[0], pytree.SequenceKey
+        ):
+            raise AssertionError(
+                "expected SequenceKey while traversing nested "
+                f"outputs, got {remaining_keypath}"
+            )
+        key = remaining_keypath[0]
+        if not 0 <= key.idx < len(current_output):
+            raise AssertionError(
+                f"output index {key.idx} is out of range for "
+                f"{type(current_output).__name__} with "
+                f"{len(current_output)} elements"
+            )
+        current_output = current_output[key.idx]
+        remaining_keypath = remaining_keypath[1:]
+    if not isinstance(current_output, ir.IRNode):
+        raise AssertionError(f"expected IRNode output, got {type(current_output)}")
+    return current_output, remaining_keypath
+
+
 class PythonWrapperCodegen(CodeGen):
     """
     Generate outer wrapper in Python that calls the kernels.
@@ -4686,23 +4730,8 @@ class PythonWrapperCodegen(CodeGen):
                     # because self.get_name() is actually never bound; the
                     # individual output arguments are bound by
                     # generate_c_shim_fallback_kernel
-                    if len(outputs) == 1:
-                        out = outputs[0]
-                        # When fallback kernel returns a list consisting of a single tensor,
-                        # the output is represented as a MultiOutput with non empty indices.
-                        # In this case, we strip the first key path away.
-                        return go(
-                            outputs[0].get_name(),
-                            keypath[1:]
-                            if isinstance(out, ir.MultiOutput) and len(out.indices) != 0
-                            else keypath,
-                        )
-                    else:
-                        if not isinstance(keypath[0], pytree.SequenceKey):
-                            raise AssertionError(
-                                f"expected SequenceKey, got {type(keypath[0])}"
-                            )
-                        return go(outputs[keypath[0].idx].get_name(), keypath[1:])
+                    node, remaining_keypath = _resolve_nested_output(outputs, keypath)
+                    return go(node.get_name(), remaining_keypath)
                 else:
                     return go(output_name, keypath)
 


### PR DESCRIPTION
Summary:

AOTI C++ wrapper codegen resolves unbacked symbols by following pytree keypaths into custom-op outputs. The existing implementation assumed these outputs were flat, so a custom op returning nested Tensor lists could select an inner Python container and call `get_name()` on it, failing during lowering.

Traverse nested list and tuple outputs using their `SequenceKey` entries until reaching the corresponding IR node. Preserve the existing fast path for ordinary single outputs and the established single-`MultiOutput` behavior, including consuming its leading keypath entry. Validate nested indices explicitly so malformed keypaths produce descriptive assertion errors instead of a bare `IndexError`.

Add AOTI round-trip coverage for `tuple[list[Tensor], list[Tensor]]` with four independent dynamic output sizes. Add focused wrapper-codegen tests for singleton nested containers, compatibility with the existing single-`MultiOutput` path, and out-of-range diagnostics.

Error stack trace: P2474137512

Test Plan:
- `arc lint -a caffe2/torch/_inductor/codegen/wrapper.py caffe2/test/inductor/test_aot_inductor_custom_ops.py ../xplat/caffe2/torch/_inductor/codegen/wrapper.py ../xplat/caffe2/test/inductor/test_aot_inductor_custom_ops.py`
- `buck2 test fbcode//caffe2/test/inductor:test_aot_inductor_custom_ops -- test_custom_op_return_nested_tensor_lists_cpu --print-passing-details`
- `arc lint -a caffe2/test/inductor/test_wrapper_codegen.py ../xplat/caffe2/test/inductor/test_wrapper_codegen.py`
- `buck2 test fbcode//caffe2/test/inductor:wrapper_codegen`
  - Covers nested `MultiOutput` traversal, preservation of the existing singleton `MultiOutput` behavior, and parameterized positive/negative out-of-range diagnostics using real `ir.MultiOutput` instances.

Differential Revision: D117224034




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo