### PR TITLE
[Build] Mark CUTLASS include dirs SYSTEM on torch_cuda

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -835,8 +835,8 @@ if(USE_CUDA AND NOT USE_ROCM)
   add_definitions(-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1)
   add_definitions(-DCUTLASS_ENABLE_SM90_EXTENDED_MMA_SHAPES=1)
   add_definitions(-DCUTE_SM90_EXTENDED_MMA_SHAPES_ENABLED)
-  list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/cutlass/include)
-  list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/cutlass/tools/util/include)
+  # CUTLASS include dirs are attached SYSTEM to torch_cuda in caffe2/CMakeLists.txt;
+  # routing them through ATen_CUDA_INCLUDE would emit -I, not -isystem.
 
   if($ENV{ATEN_STATIC_CUDA})
     if(CUDA_VERSION VERSION_LESS_EQUAL 12.9)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1834,6 +1834,10 @@ if(USE_CUDA)
       torch_cuda INTERFACE $<INSTALL_INTERFACE:include>)
   target_include_directories(
       torch_cuda PRIVATE ${Caffe2_GPU_INCLUDE})
+  # SYSTEM so CUTLASS's own warnings do not trip -Werror.
+  target_include_directories(torch_cuda SYSTEM PRIVATE
+      ${PROJECT_SOURCE_DIR}/third_party/cutlass/include
+      ${PROJECT_SOURCE_DIR}/third_party/cutlass/tools/util/include)
   target_link_libraries(
       torch_cuda PRIVATE ${Caffe2_CUDA_DEPENDENCY_LIBS})
 


### PR DESCRIPTION
Observing failures on main of the form:
```
/__w/pytorch/pytorch/aten/src/ATen/../../../third_party/cutlass/include/cute/arch/copy.hpp:100:1: error: unused function 'prefetch' [-Werror,-Wunused-function]
```
Happening to the following builds:
- [pull / linux-jammy-cuda13.0-cudnn9-py3.10-clang20 / build](https://github.com/pytorch/pytorch/actions/runs/32784345760/job/97613504638)
- [pull / linux-jammy-cuda13.2-cudnn9-py3.10-clang20 / build](https://github.com/pytorch/pytorch/actions/runs/32784345760/job/97613504906)

Potential cause:
- FA was previously pulling cutlass under `SYSTEM` which has looser usage requirements (no unused error). This was recently updated, FA is disabled in certain builds, causing cache misses to fail: https://github.com/pytorch/pytorch/blob/866415f3f311/caffe2/CMakeLists.txt#L1132-L1148

Apply the above loosening of restrictions to cutlass in the build. 

**Test Plan:**
- Observe successful build on recent (head of main) changes for cudnn build: https://github.com/pytorch/pytorch/actions/runs/32777657414/job/97593459046?pr=194645, not entirely from cache.

Authored with assistance from Claude (Claude Code).