### PR TITLE
[BE] Pass masked_fill_inplace_if_safe tensor argument by const reference

### DIFF
--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -849,7 +849,7 @@ Tensor masked_fill_backward(const Tensor& grad, const Tensor& mask) {
 }
 
 Tensor masked_fill_inplace_if_safe(
-    Tensor tensor,
+    const Tensor& tensor,
     const Tensor& mask,
     const Scalar& value) {
   return areAnyTensorSubclassLike({tensor, mask})

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -382,7 +382,7 @@ at::Tensor evenly_distribute_backward(
 Tensor sgn_backward(const Tensor& x, const Tensor& gx, const Tensor& sgn);
 Tensor masked_fill_backward(const Tensor& grad, const Tensor& mask);
 Tensor masked_fill_inplace_if_safe(
-    Tensor tensor,
+    const Tensor& tensor,
     const Tensor& mask,
     const Scalar& value);
 at::Tensor var_backward(


### PR DESCRIPTION
Fixes pre-existing clang-tidy `performance-unnecessary-value-param` error, which fails lint for any PR touching `FunctionsManual.cpp`. Discovered while working on grouped_mm for MPS.