### PR TITLE
Fix weights-only NEWOBJ handling for pybind11 types

### DIFF
--- a/test/distributed/tensor/test_placement_types.py
+++ b/test/distributed/tensor/test_placement_types.py
@@ -1,10 +1,6 @@
 # Owner(s): ["oncall: distributed"]
 import copy
-import io
 import itertools
-import pickle
-import sys
-import zipfile
 
 import sympy
 
@@ -33,39 +29,6 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 # Basic functionality test for Placement types.
 class PlacementTypesTestCase(TestCase):
-    # SECURITY: This prevents malformed pickles from exposing uninitialized
-    # pybind11 objects. Do not remove this regression test.
-    def test_weights_only_newobj_requires_build(self):
-        malformed_pickle = (
-            pickle.PROTO
-            + b"\x02"
-            + pickle.GLOBAL
-            + Shard.__module__.encode()
-            + b"\n"
-            + Shard.__name__.encode()
-            + b"\n"
-            + pickle.EMPTY_TUPLE
-            + pickle.NEWOBJ
-            + pickle.STOP
-        )
-
-        checkpoint = io.BytesIO()
-        with zipfile.ZipFile(checkpoint, "w") as archive:
-            archive.writestr("archive/data.pkl", malformed_pickle)
-            archive.writestr("archive/version", "3\n")
-            archive.writestr("archive/byteorder", sys.byteorder)
-        checkpoint.seek(0)
-
-        with self.assertRaisesRegex(
-            pickle.UnpicklingError, "pickle data is likely corrupt or malicious"
-        ):
-            torch.load(checkpoint, weights_only=True)
-
-        buffer = io.BytesIO()
-        torch.save(Shard(2), buffer)
-        buffer.seek(0)
-        self.assertEqual(torch.load(buffer, weights_only=True), Shard(2))
-
     def test_type_identification(self):
         shard = Shard(3)
         strided_shard = _StridedShard(dim=3, split_factor=7)

--- a/test/distributed/tensor/test_placement_types.py
+++ b/test/distributed/tensor/test_placement_types.py
@@ -33,6 +33,8 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 # Basic functionality test for Placement types.
 class PlacementTypesTestCase(TestCase):
+    # SECURITY: This prevents malformed pickles from exposing uninitialized
+    # pybind11 objects. Do not remove this regression test.
     def test_weights_only_newobj_requires_build(self):
         malformed_pickle = (
             pickle.PROTO

--- a/test/distributed/tensor/test_placement_types.py
+++ b/test/distributed/tensor/test_placement_types.py
@@ -1,6 +1,10 @@
 # Owner(s): ["oncall: distributed"]
 import copy
+import io
 import itertools
+import pickle
+import sys
+import zipfile
 
 import sympy
 
@@ -29,6 +33,37 @@ from torch.testing._internal.common_utils import run_tests, TestCase
 
 # Basic functionality test for Placement types.
 class PlacementTypesTestCase(TestCase):
+    def test_weights_only_newobj_requires_build(self):
+        malformed_pickle = (
+            pickle.PROTO
+            + b"\x02"
+            + pickle.GLOBAL
+            + Shard.__module__.encode()
+            + b"\n"
+            + Shard.__name__.encode()
+            + b"\n"
+            + pickle.EMPTY_TUPLE
+            + pickle.NEWOBJ
+            + pickle.STOP
+        )
+
+        checkpoint = io.BytesIO()
+        with zipfile.ZipFile(checkpoint, "w") as archive:
+            archive.writestr("archive/data.pkl", malformed_pickle)
+            archive.writestr("archive/version", "3\n")
+            archive.writestr("archive/byteorder", sys.byteorder)
+        checkpoint.seek(0)
+
+        with self.assertRaisesRegex(
+            pickle.UnpicklingError, "pickle data is likely corrupt or malicious"
+        ):
+            torch.load(checkpoint, weights_only=True)
+
+        buffer = io.BytesIO()
+        torch.save(Shard(2), buffer)
+        buffer.seek(0)
+        self.assertEqual(torch.load(buffer, weights_only=True), Shard(2))
+
     def test_type_identification(self):
         shard = Shard(3)
         strided_shard = _StridedShard(dim=3, split_factor=7)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1266,6 +1266,9 @@ class TestSerialization(TestCase, SerializationMixin):
 
     # SECURITY: This prevents malformed pickles from exposing uninitialized
     # pybind11 objects. Do not remove this regression test.
+    @unittest.skipIf(
+        not torch.distributed.is_available(), "torch.distributed not available"
+    )
     def test_weights_only_newobj_requires_build(self):
         from torch.distributed.tensor import Shard
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1264,6 +1264,41 @@ class TestSerialization(TestCase, SerializationMixin):
                 loaded_p = torch.load(f, weights_only=True)
                 self.assertEqual(loaded_p, p)
 
+    # SECURITY: This prevents malformed pickles from exposing uninitialized
+    # pybind11 objects. Do not remove this regression test.
+    def test_weights_only_newobj_requires_build(self):
+        from torch.distributed.tensor import Shard
+
+        malformed_pickle = (
+            pickle.PROTO
+            + b"\x02"
+            + pickle.GLOBAL
+            + Shard.__module__.encode()
+            + b"\n"
+            + Shard.__name__.encode()
+            + b"\n"
+            + pickle.EMPTY_TUPLE
+            + pickle.NEWOBJ
+            + pickle.STOP
+        )
+
+        checkpoint = io.BytesIO()
+        with zipfile.ZipFile(checkpoint, "w") as archive:
+            archive.writestr("archive/data.pkl", malformed_pickle)
+            archive.writestr("archive/version", "3\n")
+            archive.writestr("archive/byteorder", sys.byteorder)
+        checkpoint.seek(0)
+
+        with self.assertRaisesRegex(
+            pickle.UnpicklingError, "pickle data is likely corrupt or malicious"
+        ):
+            torch.load(checkpoint, weights_only=True)
+
+        buffer = io.BytesIO()
+        torch.save(Shard(2), buffer)
+        buffer.seek(0)
+        self.assertEqual(torch.load(buffer, weights_only=True), Shard(2))
+
     def test_weights_only_safe_globals_build(self):
         counter = 0
 

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1408,6 +1408,7 @@ def _log_api_usage_metadata(
     metadata_map: dict[str, str],
 ) -> None: ...  # LogAPIUsageMetadataFromPython
 def _demangle(str) -> str: ...  # c10::demangle
+def _is_pybind11_type(cls: type) -> bool: ...
 def _getenv(name: str) -> str | None: ...  # c10::utils::get_env
 def _setenv(name: str, value: str, overwrite: _bool = True) -> None: ...  # c10::utils::set_env
 def _unsetenv(name: str) -> None: ...  # c10::utils::unset_env

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -120,6 +120,12 @@ class _safe_globals:
         _remove_safe_globals(self.safe_globals)
 
 
+class _PendingNewobj:
+    def __init__(self, cls, args):
+        self.cls = cls
+        self.args = args
+
+
 # Separate from _get_allowed_globals because of the lru_cache on _get_allowed_globals
 # For example if user had a script like
 #   torch.load(file_a)
@@ -318,6 +324,7 @@ class Unpickler:
         """
         self.metastack = []
         self.stack: list[Any] = []
+        pending_newobjs: set[_PendingNewobj] = set()
         self.append = self.stack.append
         read = self.read
         while True:
@@ -379,7 +386,12 @@ class Unpickler:
                     cls in _get_user_allowed_globals().values()
                     or cls in _get_allowed_globals().values()
                 ):
-                    result = cls.__new__(cls, *args)
+                    result: Any
+                    if torch._C._is_pybind11_type(cls):
+                        result = _PendingNewobj(cls, args)
+                        pending_newobjs.add(result)
+                    else:
+                        result = cls.__new__(cls, *args)
                     if cls in torch._tensor_classes and "sparse" in cls.__module__:
                         _sparse_tensors_to_validate.append(result)
                     self.append(result)
@@ -408,6 +420,14 @@ class Unpickler:
             elif key[0] == BUILD[0]:
                 state = self.stack.pop()
                 inst = self.stack[-1]
+                if isinstance(inst, _PendingNewobj):
+                    pending = inst
+                    inst = pending.cls.__new__(pending.cls, *pending.args)
+                    self.stack[-1] = inst
+                    for memo_id, memo_value in self.memo.items():
+                        if memo_value is pending:
+                            self.memo[memo_id] = inst
+                    pending_newobjs.remove(pending)
                 if type(inst) is torch.Tensor:
                     # Legacy unpickling
 
@@ -546,6 +566,11 @@ class Unpickler:
                         stacklevel=2,
                     )
             elif key[0] == STOP[0]:
+                if pending_newobjs:
+                    raise UnpicklingError(
+                        "Object created by NEWOBJ was not initialized by BUILD; "
+                        "the pickle data is likely corrupt or malicious"
+                    )
                 rc = self.stack.pop()
                 return rc
             else:

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -2721,6 +2721,13 @@ PyObject* initModule() {
   auto py_module = py::reinterpret_borrow<py::module>(module);
   py_module.def("_initCrashHandler", &_initCrashHandler);
   py_module.def("_demangle", &c10::demangle);
+  py_module.def("_is_pybind11_type", [](py::handle cls) {
+    if (!PyType_Check(cls.ptr())) {
+      return false;
+    }
+    auto* type = reinterpret_cast<PyTypeObject*>(cls.ptr());
+    return !py::detail::all_type_info(type).empty();
+  });
 
   // Serialized access to the process environment. Prefer these over Python's
   // os.environ/os.getenv when torch is loaded: they share c10's env mutex, so


### PR DESCRIPTION
## Description
Prevent `weights_only` from exposing uninitialized pybind11 objects when `NEWOBJ` lacks `BUILD`. Detect pybind11 types in C++, defer construction until `BUILD`, and reject pending objects at `STOP` as corrupt or malicious.

Related to #193984

Upstream issue https://github.com/pybind/pybind11/issues/6153

## Test plan
- CPU-only editable build
- `test/test_serialization.py TestSerialization.test_weights_only_newobj_requires_build`
- `test/distributed/tensor/test_placement_types.py`
- `spin lint`