### PR TITLE
Reject re-running `import torch` after a failed import

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import sys
+import textwrap
 import unittest.mock
 from typing import Any
 from collections.abc import Callable
@@ -2738,6 +2739,63 @@ class TestImports(TestCase):
         ]
         out = self._check_python_output("; ".join(commands))
         self.assertEqual(out.strip(), expected)
+
+    def test_reimport_after_failed_import(self) -> None:
+        # A failed `import torch` leaves its submodules and C++ global state behind,
+        # so retrying used to re-run one-time initialization and segfault at
+        # interpreter shutdown. See https://github.com/pytorch/pytorch/issues/194172
+        program = textwrap.dedent(
+            '''\
+            import importlib.metadata
+
+            class _FailingEntryPoint:
+                name = "injected_backend"
+
+                def load(self):
+                    raise ImportError("injected backend failure")
+
+            _real_entry_points = importlib.metadata.entry_points
+
+            def _entry_points(**kwargs):
+                if kwargs.get("group") == "torch.backends":
+                    return [_FailingEntryPoint()]
+                return _real_entry_points(**kwargs)
+
+            importlib.metadata.entry_points = _entry_points
+
+            for _ in range(3):
+                try:
+                    import torch
+                except Exception as e:
+                    print(f"{type(e).__name__}: {e}")
+            '''
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", program],
+            capture_output=True,
+            text=True,
+            # On Windows, opening the subprocess with the default CWD makes `import torch`
+            # fail, so just set CWD to this script's directory
+            cwd=os.path.dirname(os.path.realpath(__file__)),
+            # The test relies on the autoload running, so don't inherit a disabling value
+            env={**os.environ, "TORCH_DEVICE_BACKEND_AUTOLOAD": "1"},
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        lines = proc.stdout.splitlines()
+        self.assertEqual(len(lines), 3, msg=proc.stdout)
+        self.assertTrue(lines[0].startswith("RuntimeError: "), msg=lines[0])
+        self.assertIn("Failed to load the backend extension: injected_backend", lines[0])
+        for line in lines[1:]:
+            self.assertTrue(line.startswith("ImportError: "), msg=line)
+            self.assertIn("can only be initialized once per process", line)
+
+    def test_reload_is_rejected(self) -> None:
+        # Reloading re-executes the module body against live C++ state just like a
+        # retry does, so it is refused; torch must stay usable afterwards.
+        with self.assertRaisesRegex(ImportError, "can only be initialized once"):
+            importlib.reload(torch)
+        self.assertEqual(torch.tensor([1, 2]).sum().item(), 3)
 
 class TestOpInfos(TestCase):
     def test_sample_input(self) -> None:

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -44,6 +44,16 @@ from typing_extensions import (
 )
 
 
+# Re-executing this file (retrying a failed import, or `reload`) would corrupt the C++ global state the first run set up.
+if getattr(sys, "_torch_import_started", False):
+    raise ImportError(
+        "`torch` can only be initialized once per process, so this module cannot "
+        "be imported again: neither via `importlib.reload(torch)`, nor by "
+        "re-importing after a failed `import torch`."
+    )
+sys._torch_import_started = True  # type: ignore[attr-defined]
+
+
 # As a bunch of torch.packages internally still have this check
 # we need to keep this. @todo: Remove tests that rely on this check as
 # they are likely stale.

--- a/torch/utils/data/dataframes_pipes.ipynb
+++ b/torch/utils/data/dataframes_pipes.ipynb
@@ -13,9 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from importlib import reload\n",
-    "import torch\n",
-    "reload(torch)\n",
     "from torch.utils.data import IterDataPipe"
    ]
   },


### PR DESCRIPTION
## Author Notes

Simplest fix I can think for https://github.com/pytorch/pytorch/issues/194172
Also forbids reload(torch), which today will do weird things the first time then and then segfault from the second call onwards!

technically bc-breaking because one reload(torch) used to pass but now fails. But it was a precarious state primed for segfault at any moment.
Generally don't reload(torch) or open an issue if you want to discuss what the semantic for reload should be here.

## Agent Notes

The section below was written by an AI agent (Claude Code) that reproduced the
issue and wrote the patch. I reviewed the diff and the analysis; I'm including
it because the refcount/finalization mechanics are the non-obvious part of why
this one-liner is the right layer to fix it at.

> **Root cause**
>
> A failed `import torch` is not retryable. When the module body raises, the import
> machinery evicts `torch` from `sys.modules` but leaves every already-imported
> submodule behind — 724 `torch.*` entries in practice, including `torch._C`. A second
> `import torch` therefore re-executes `torch/__init__.py` in full against C++ global
> state that is already live.
>
> That re-execution corrupts memory. `_initFunctionPyTypeObject` assigns
> `type.ob_base = {PyObject_HEAD_INIT(nullptr) 0}` over static `PyTypeObject`s, resetting
> `ob_refcnt` to 1 and clearing `Py_TPFLAGS_READY` while the previous generation's holders
> (the old `torch._C._functions` module dict, `cpp_function_types_map`, and the descriptors
> built by the earlier `PyType_Ready`) still reference them. Those references are now
> uncounted, so when `Py_FinalizeEx` clears the module dicts their decrefs drive the
> refcount to zero and CPython calls `type_dealloc` on a static, never-GC-tracked type;
> `_PyObject_GC_UNTRACK` then dereferences its NULL `gc_prev`/`gc_next` and the process
> dies with SIGSEGV at interpreter shutdown.
>
> Measured `AccumulateGrad` refcount across retries: 19 → 16 → 2. This is not limited to
> `AccumulateGrad` — the same function initializes every generated autograd node type, so
> hundreds of static types are clobbered per re-execution. Before the segfault, users also
> saw a misleading `Only a single TORCH_LIBRARY can be used to register the namespace triton`
> error from the second pass.
>
> **Why here and not in C++**
>
> Guarding `THPModule_initExtension` with `call_once` (as the issue suggests) was considered
> and rejected: re-initialization is inherently unsafe, and a flag at any one layer just
> relocates the failure to whatever the layer below re-runs. The flag is set at the top of
> `torch/__init__.py` rather than keyed off `torch._C` being loaded, so a failure before the
> extension loads is caught too — stricter than strictly necessary, but it keeps the
> invariant simple: this file runs at most once per process. `sys` holds the flag because it
> has to outlive the eviction of `torch` from `sys.modules`.
>
> **BC-breaking**
>
> `importlib.reload(torch)` and `del sys.modules["torch"]` + re-import now raise. Re-running
> the module body was already unsafe in exactly the same way as the retry path, so the guard
> does not distinguish the two. The only in-tree user was the `dataframes_pipes.ipynb` RFC
> notebook, whose `reload(torch)` preamble is dropped here. Normal use is unaffected: a
> successful import leaves `torch` in `sys.modules` so the body never re-runs, and re-entrant
> imports from a backend extension during autoload still short-circuit on `sys.modules`
> without reaching the guard.
>
> **Testing**
>
> `test_reimport_after_failed_import` patches `importlib.metadata.entry_points` in a
> subprocess so the device-backend autoload fails, imports torch three times, and asserts the
> child exits 0, reports the real backend error first, and the guard `ImportError` on the
> retries. It has to be out-of-process because the failure is a segfault. With the guard
> removed the same test fails, with the subprocess exiting 139. `test_reload_is_rejected`
> pins the reload behavior and that `torch` stays usable afterwards.
>
> Also verified against the reporter's scenario using the in-tree openreg backend with its
> runtime library made unloadable: reproduced the crash at N>=3 before the fix, exits 0 after.

Fixes #194172


cc @ezyang @gchanan