### PR TITLE
Exclude meta tensors from check_leaked_tensors

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6439,7 +6439,12 @@ def check_leaked_tensors(limit=1, matched_type=torch.Tensor):
     limit specifies how many tensors to dump debug graphs for (default=1)
     """
     def match_obj(obj):
-        return isinstance(obj, matched_type)
+        if not isinstance(obj, matched_type):
+            return False
+        # Meta tensors are excluded: they own no storage, so cannot leak memory.
+        # Counting them makes this report count reference-cycle hygiene rather
+        # than leaked memory, and produces failures that depend on when the collector happens to run.
+        return not (isinstance(obj, torch.Tensor) and obj.device.type == "meta")
 
     try:
         gc.collect()
@@ -6469,6 +6474,9 @@ def check_leaked_tensors(limit=1, matched_type=torch.Tensor):
 
     finally:
         gc.set_debug(0)
+        # gc.garbage is module-global and gc.set_debug(0) does not empty it, so
+        # entries saved here would otherwise outlive this block.
+        del gc.garbage[:]
 
 
 def _win_rmtree_onerror(func, path, exc_info):


### PR DESCRIPTION
## Issue

check_leaked_tensors installs gc.DEBUG_SAVEALL so that everything the collector
reclaims is appended to the module-global gc.garbage rather than freed, then
filters gc.garbage by isinstance(obj, matched_type) to report tensors kept alive
by reference cycles. Two properties of that implementation produce failures that
are unrelated to leaked memory.

First, meta tensors are counted. A meta tensor carries shape, dtype and stride
metadata and owns no storage, so it cannot hold tensor memory alive no matter how
many cycles reference it. The docstring is explicit that the check exists to find
cycles holding a Tensor alive precisely because that is more serious than the
ordinary Python refcycles it intends to ignore - counting meta tensors turns the
report back into exactly the refcycle-hygiene signal it says it ignores.

Second, gc.garbage is module-global and gc.set_debug(0) does not empty it, so
objects saved by one check_leaked_tensors block remain there after the block
exits. The next block's garbage_objs.extend(filter(match_obj, gc.garbage)) then
re-counts them. The warning consequently depends on how many earlier blocks ran
in the same process and on when the collector happened to run, making it
order-dependent across tests sharing an interpreter.

## Summary

Exclude meta tensors from check_leaked_tensors and clear gc.garbage per block.

This filters meta tensors out of match_obj and empties gc.garbage in the `finally`.
Callers that inspect the yielded garbage_objs list are unaffected: it is a
separate list holding its own references, populated before the finally runs, and
it is the documented way to examine results after the block exits. A caller
reading gc.garbage directly afterwards now sees it empty, which is the intended
change - those entries are this block's own DEBUG_SAVEALL byproduct.

Clearing unconditionally rather than snapshotting and restoring prior entries
does mean a nested check_leaked_tensors would lose the outer block's entries.
Nesting is already unsupported, since the inner block's gc.set_debug(0) disables
SAVEALL for the outer one, so this does not regress anything.


## Checklist

- [ ] Passes lint (`spin fixlint`)
- [ ] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

<!-- If this change breaks backward compatibility, describe the impact and migration path. Otherwise, write "No". -->
