### PR TITLE
[serialization] Fix torch.save/torch.load for SwizzleType/ScalingType (pybind11 enums)

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4912,6 +4912,22 @@ class TestSerialization(TestCase, SerializationMixin):
             with self.assertRaisesRegex(RuntimeError, "size is inconsistent with indices"):
                 torch.load(bad_buf, weights_only=False)
 
+    def test_pybind11_enum_swizzle_type_save_load(self):
+        from torch.nn.functional import SwizzleType
+
+        buf = io.BytesIO()
+        torch.save(SwizzleType.NO_SWIZZLE, buf)
+        buf.seek(0)
+        self.assertEqual(torch.load(buf, weights_only=True), SwizzleType.NO_SWIZZLE)
+
+    def test_pybind11_enum_scaling_type_save_load(self):
+        from torch.nn.functional import ScalingType
+
+        buf = io.BytesIO()
+        torch.save(ScalingType.TensorWise, buf)
+        buf.seek(0)
+        self.assertEqual(torch.load(buf, weights_only=True), ScalingType.TensorWise)
+
     def run(self, *args, **kwargs):
         with serialization_method(use_zip=True):
             return super().run(*args, **kwargs)
@@ -5540,6 +5556,7 @@ instantiate_device_type_tests(TestSerializationAccelerator, globals(), allow_xpu
 instantiate_parametrized_tests(TestSubclassSerialization)
 instantiate_parametrized_tests(TestOldSerialization)
 instantiate_parametrized_tests(TestSerialization)
+
 
 if __name__ == '__main__':
     run_tests()

--- a/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_utils.py
+++ b/torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_utils.py
@@ -6,38 +6,14 @@ Utility functions for NVIDIA Universal GEMM.
 import copyreg
 from typing import Any
 
-from torch.nn.functional import ScalingType, SwizzleType
-
-
-def _rebuild_scaling_type(name: str) -> Any:
-    return getattr(ScalingType, name)
-
-
-def _rebuild_swizzle_type(name: str) -> Any:
-    return getattr(SwizzleType, name)
-
-
-def _register_enum_pickling() -> None:
-    """Make torch.nn.functional ScalingType/SwizzleType picklable.
-
-    They are pybind11 C++ enums whose class __qualname__ is `_ScalingType` /
-    `_SwizzleType`, but torch.nn.functional only binds the public names
-    `ScalingType` / `SwizzleType`. Pickle's default reduction reconstructs by
-    the private qualname and fails, which blocks shipping a scaled-GEMM
-    benchmark request to the autotuning subprocess pool. Reduce by `.name`
-    string via the public alias instead (no class object in the pickle).
-    """
-    copyreg.pickle(
-        type(ScalingType.BlockWise1x16),
-        lambda v: (_rebuild_scaling_type, (v.name,)),
-    )
-    copyreg.pickle(
-        type(SwizzleType.NO_SWIZZLE),
-        lambda v: (_rebuild_swizzle_type, (v.name,)),
-    )
-
-
-_register_enum_pickling()
+# Backward compatibility: copyreg and rebuild functions have moved to
+# torch.nn.functional. Old pickle streams may reference these names.
+from torch.nn.functional import (  # noqa: F401
+    _rebuild_scaling_type,  # pyrefly: ignore[missing-module-attribute]
+    _rebuild_swizzle_type,  # pyrefly: ignore[missing-module-attribute]
+    ScalingType,
+    SwizzleType,
+)
 
 
 def _rebuild_scaled_operand_constraints(

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -223,6 +223,22 @@ def _get_allowed_globals():
     # Handles Tensor Subclasses, Tensor's with attributes.
     # NOTE: It calls into above rebuild functions for regular Tensor types.
     rc["torch._tensor._rebuild_from_type_v2"] = torch._tensor._rebuild_from_type_v2
+
+    # Pybind11 enum rebuild functions (ScalingType / SwizzleType)
+    from torch.nn.functional import (  # pyrefly: ignore[missing-module-attribute]
+        _rebuild_scaling_type,
+        _rebuild_swizzle_type,
+    )
+
+    rc["torch.nn.functional._rebuild_scaling_type"] = _rebuild_scaling_type
+    rc["torch.nn.functional._rebuild_swizzle_type"] = _rebuild_swizzle_type
+    # Backward compat: old checkpoints reference the inductor path
+    rc[
+        "torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils._rebuild_scaling_type"
+    ] = _rebuild_scaling_type
+    rc[
+        "torch._inductor.codegen.nv_universal_gemm.nv_universal_gemm_utils._rebuild_swizzle_type"
+    ] = _rebuild_swizzle_type
     return rc
 
 

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -1,5 +1,6 @@
 """Functional interface."""
 
+import copyreg
 import dataclasses
 import importlib
 import math
@@ -36,6 +37,28 @@ from torch.overrides import (
 # Set visibility of the bound enums to this module
 ScalingType.__module__ = "torch.nn.functional"
 SwizzleType.__module__ = "torch.nn.functional"
+
+
+# Pickle support for pybind11 enums.
+# pybind11 enums have __qualname__ = "_ScalingType" / "_SwizzleType" but are
+# exported as ScalingType / SwizzleType, so default pickle reduction fails.
+# Reduce by name string through the public alias instead.
+def _rebuild_scaling_type(name: str) -> _Any:
+    return getattr(ScalingType, name)
+
+
+def _rebuild_swizzle_type(name: str) -> _Any:
+    return getattr(SwizzleType, name)
+
+
+copyreg.pickle(
+    type(ScalingType.TensorWise),
+    lambda v: (_rebuild_scaling_type, (v.name,)),
+)
+copyreg.pickle(
+    type(SwizzleType.NO_SWIZZLE),
+    lambda v: (_rebuild_swizzle_type, (v.name,)),
+)
 
 if TYPE_CHECKING:
     from torch.nn.modules.linear_cross_entropy_options import LinearCrossEntropyOptions


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/194571

## Problem

`torch.save` / `torch.load(weights_only=True)` fails for pybind11 enums
`SwizzleType` and `ScalingType` due to:

1. pybind11 `__qualname__` (`_ScalingType` / `_SwizzleType`) doesn't match the
   public attribute name (`ScalingType` / `SwizzleType`), so default pickle
   reduction fails.
2. A `copyreg` workaround exists in `nv_universal_gemm_utils.py` but only fires
   when the inductor autotuning path is active, not during normal
   `torch.save`.
3. Even when the copyreg workaround fires, `torch.load(weights_only=True)`
   rejects the rebuild function as an unallowed global.
## Solution

- **Move `copyreg` registration to `torch/nn/functional.py`** — this module is
  always imported, so the pickle reduction is always available regardless of
  which code path triggers the save.
- **Add rebuild functions to `_weights_only_unpickler.py` allowed globals** —
  both the new canonical path (`torch.nn.functional._rebuild_*`) and the old
  inductor path (for backward compatibility with existing checkpoints).
- **Keep backward-compat re-exports in `nv_universal_gemm_utils.py`** — old
  pickle streams that reference `torch._inductor.codegen.nv_universal_gemm.
  nv_universal_gemm_utils._rebuild_swizzle_type` will still work.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo