### PR TITLE
[AOTInductor] Make the unsupported-device path in aoti_inference tests fail

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -141,7 +141,7 @@ void test_aoti(const std::string& device, bool use_runtime_constant_folding) {
         model_so_path);
 #endif
   } else {
-    testing::AssertionFailure() << "unsupported device: " << device;
+    FAIL() << "unsupported device: " << device;
   }
   auto actual_output_tensors =
       runner->run(data_loader.attr(inputs_attr.c_str()).toTensorList().vec());
@@ -287,7 +287,7 @@ void test_aoti_constants_update(
         model_so_path);
 #endif
   } else {
-    testing::AssertionFailure() << "unsupported device: " << device;
+    FAIL() << "unsupported device: " << device;
   }
   // By default, buffer #1 get loaded with burned in weights. Correct results.
   auto actual_output_tensors = runner->run(input_tensors);
@@ -384,7 +384,7 @@ void test_aoti_extract_constants_map(const std::string& device) {
         model_so_path);
 #endif
   } else {
-    testing::AssertionFailure() << "unsupported device: " << device;
+    FAIL() << "unsupported device: " << device;
   }
 
   // By default, buffer #1 get loaded with burned in weights. Correct results.
@@ -465,7 +465,7 @@ void test_aoti_double_buffering(
         model_so_path);
 #endif
   } else {
-    testing::AssertionFailure() << "unsupported device: " << device;
+    FAIL() << "unsupported device: " << device;
   }
   // By default, buffer #1 get loaded with burned in weights. Correct results.
   auto actual_output_tensors = runner->run(input_tensors);


### PR DESCRIPTION
Summary:
`testing::AssertionFailure()` returns an `AssertionResult`. Streaming into it and discarding the temporary registers nothing -- a failure is only recorded when the result is passed to `EXPECT_TRUE`/`ASSERT_TRUE` or returned from a predicate. So the `else` arm of the device dispatch in these tests is a silent no-op today.

That matters beyond the missing message: each of these functions leaves `runner` as a default-constructed `std::unique_ptr` and dereferences it immediately after the dispatch. An unsupported device value -- or `"cuda"` in a build where neither `USE_CUDA` nor `USE_ROCM` is defined, which compiles the `cuda` arm out -- falls straight through to a null dereference instead of a test failure. The current test registrations guard the `cuda` cases behind the same `#if`, so this is latent rather than live, but it depends on the registrations and the dispatch staying in sync.

`FAIL()` both records the failure and returns, so the null dereference cannot follow. It is already the idiom used at one site in this same file (`test_multi_cuda_streams`); this makes the other four consistent with it. All four enclosing functions return `void`, which `FAIL()` requires.

Differential Revision: D117248586


