### PR TITLE
[caffe2] Unblock caffe2_gpu under CUDA 13.3 (cudafe++ alias-decl reprint bug)

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1686,9 +1686,16 @@ namespace detail {
 struct _guarded_unsigned_long_unique_dummy final {
   _guarded_unsigned_long_unique_dummy(int64_t /*unused*/){}
 };
-using _guarded_unsigned_long = std::conditional_t<
+// The comparisons are hoisted out of the alias-declaration below on purpose.
+// CUDA 13.3's cudafe++ re-prints a namespace-scope alias-declaration from its
+// own AST, and for size_t-canonical types it may pick a spelling that is not
+// in scope (e.g. one naming a function-local visitor class), emitting host
+// code that does not compile.
+inline constexpr bool _guarded_unsigned_long_is_duplicate =
     std::is_same_v<unsigned long, uint32_t> ||
-        std::is_same_v<unsigned long, uint64_t>,
+    std::is_same_v<unsigned long, uint64_t>;
+using _guarded_unsigned_long = std::conditional_t<
+    _guarded_unsigned_long_is_duplicate,
     _guarded_unsigned_long_unique_dummy,
     unsigned long>;
 


### PR DESCRIPTION
Summary:
A CUDA 13.3 NVCC front-end regression causes cudafe++ to mis‑print a namespace‑scope type alias in ATen, turning a size_t-like type into a reference to an out‑of‑scope symbol (BufferSizeVisitor), which then fails to compile.
The workaround is to move the unsigned long vs uint32_t/uint64_t comparisons into an inline constexpr bool and use that in the alias, so cudafe++ no longer reconstructs the problematic type inside the alias declaration. This preserves behavior while avoiding the CUDA 13.3 re‑printer bug and restores successful builds under that CUDA version.

Test Plan: Verified the generated `.cudafe1.cpp` now contains the correct condition rather than merely compiling, and confirmed with a `static_assert` that the alias still resolves to `_guarded_unsigned_long_unique_dummy` on LP64.

Differential Revision: D117248107


