### PR TITLE
Enable hw-agnostic distributed tests, update PP tests

### DIFF
--- a/test/distributed/pipelining/test_dtensor_pp_integration.py
+++ b/test/distributed/pipelining/test_dtensor_pp_integration.py
@@ -137,10 +137,10 @@ def _loss_fn(output: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
 
 
 def _requires_multi_gpu(func):
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
         torch.accelerator.device_count() < 4,
-        f"{backend} test requires 4+ GPUs",
+        f"{backend} test requires 4+ devices",
     )
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -165,8 +165,8 @@ class DTensorPPIntegrationBase(MultiProcContinuousTest):
         return torch.device(device_type, self.rank)
 
     def init_pg(self) -> None:
-        if device_type == "cuda":
-            torch.cuda.set_device(self.device)
+        if device_type != "cpu":
+            torch.get_device_module(device_type).set_device(self.device)
 
     def _make_mesh(self) -> DeviceMesh:
         return init_device_mesh(device_type, (2, 2), mesh_dim_names=("pp", "tp"))

--- a/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
+++ b/test/distributed/pipelining/test_dtensor_pp_unit_tests.py
@@ -66,9 +66,9 @@ backend = dist.get_default_backend_for_device(device_type)
 
 
 def _requires_multi_gpu(fn):
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 4+ devices"
     )
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -102,8 +102,8 @@ class TestDTensorPPUnitTests(MultiProcContinuousTest):
         return torch.device(device_type, self.rank)
 
     def init_pg(self):
-        if device_type == "cuda":
-            torch.cuda.set_device(self.device)
+        if device_type != "cpu":
+            torch.get_device_module(device_type).set_device(self.device)
 
     # -----------------------------------------------------------------
     # Shared helpers

--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -339,9 +339,9 @@ class ScheduleTest(MultiProcContinuousTest):
             world_size=self.world_size, device=self.device, rank=self.rank
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [_ScheduleForwardOnly])
     @skip_if_lt_x_gpu(4)
@@ -374,9 +374,9 @@ class ScheduleTest(MultiProcContinuousTest):
                 x_clone = mod_ref(x_clone)
             torch.testing.assert_close(x_clone, out)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize(
         "ScheduleClass",
@@ -452,9 +452,9 @@ class ScheduleTest(MultiProcContinuousTest):
         if self.rank == self.world_size - 1:
             self.assertTrue(len(losses) > 0, "Losses should be computed during eval()")
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize(
         "ScheduleClass",
@@ -517,9 +517,9 @@ class ScheduleTest(MultiProcContinuousTest):
         if self.rank == self.world_size - 1:
             self.assertTrue(output is None, "Output should be None")
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     @skip_if_lt_x_gpu(4)
@@ -541,9 +541,9 @@ class ScheduleTest(MultiProcContinuousTest):
 
         dist.barrier(device_ids=[self.rank])
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     @parametrize("pre_split", [False, True])
@@ -611,9 +611,9 @@ class ScheduleTest(MultiProcContinuousTest):
             torch.testing.assert_close(out, ref_out, rtol=1e-2, atol=5e-3)
             torch.testing.assert_close(pipe_loss, ref_loss)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     @parametrize("pre_split", [False, True])
@@ -669,9 +669,9 @@ class ScheduleTest(MultiProcContinuousTest):
         # Check gradients using helper method
         check_gradients(self.config, stage_module, ref_mod)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     @parametrize("shape_inference", [True, False])
@@ -731,9 +731,9 @@ class ScheduleTest(MultiProcContinuousTest):
         # Check gradients using helper method
         check_gradients(self.config, stage_module, ref_mod)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize(
         "ScheduleClass",
@@ -952,9 +952,9 @@ class ScheduleTest(MultiProcContinuousTest):
         check_gradients(self.config, auto_stage_modules, ref_mod, submod_names)
         check_gradients(self.config, pre_split_stage_modules, ref_mod, submod_names)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleInterleavedZeroBubble])
     @skip_if_lt_x_gpu(4)
@@ -1036,9 +1036,9 @@ class ScheduleTest(MultiProcContinuousTest):
         # Check gradients using helper method
         check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize(
         "schedule_class",
@@ -1085,9 +1085,9 @@ class ScheduleTest(MultiProcContinuousTest):
         # Check gradients using helper method
         check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @skip_if_lt_x_gpu(4)
     def test_custom_function_callback(self):
@@ -1288,7 +1288,7 @@ class ScheduleTest(MultiProcContinuousTest):
         check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, "NCCL test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize(
         "ScheduleClass",
@@ -1402,9 +1402,9 @@ class ScheduleTest(MultiProcContinuousTest):
             self.config, stage_modules, ref_mod, submod_names, rtol=1e-5, atol=1e-5
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize(
         "ScheduleClass",
@@ -1443,9 +1443,9 @@ class CustomSchedulesTest(MultiProcContinuousTest):
             world_size=self.world_size, device=self.device, rank=self.rank
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize(
         "schedule_class",
@@ -1496,9 +1496,9 @@ class CustomSchedulesTest(MultiProcContinuousTest):
         # Check gradients using helper method
         check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleWithReorderedB])
     @skip_if_lt_x_gpu(4)
@@ -1560,9 +1560,9 @@ class CustomSchedulesTest(MultiProcContinuousTest):
         # Check gradients using helper method
         check_gradients(self.config, stage_modules, ref_mod, submod_names)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleWithW])
     @skip_if_lt_x_gpu(4)
@@ -1674,9 +1674,9 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
             world_size=self.world_size, device=self.device, rank=self.rank
         )
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @skip_if_lt_x_gpu(4)
     def test_creates_distinct_direction_groups(self):
@@ -1693,9 +1693,9 @@ class PerDirectionScheduleTest(MultiProcContinuousTest):
             self.assertIsNot(stage._upstream_group, dist.group.WORLD)
             self.assertIsNot(stage._downstream_group, stage._upstream_group)
 
-    @requires_accelerator_dist_backend(["nccl", "xccl"])
+    @requires_accelerator_dist_backend([backend])
     @skip_but_pass_in_sandcastle_if(
-        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ GPUs"
+        not TEST_MULTIACCELERATOR, f"{backend} test requires 2+ devices"
     )
     @parametrize("ScheduleClass", [ScheduleGPipe, Schedule1F1B])
     @skip_if_lt_x_gpu(4)

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -540,6 +540,8 @@ def requires_accelerator_dist_backend(backends=None):
     Args:
         backends (Optional[List[str]]): Specific accelerator backends to check (e.g., ["nccl", "xccl", "hccl"]).
                                        If None, checks all supported accelerator backends (NCCL, XCCL, HCCL).
+                                       Names outside that set are resolved through the c10d registry,
+                                       so PrivateUse1 backends are supported.
 
     Returns:
         callable: A decorator that skips the test if no specified accelerator backend is available.
@@ -547,12 +549,20 @@ def requires_accelerator_dist_backend(backends=None):
     if backends is None:
         backends = ACCELERATOR_DIST_BACKENDS
 
+    # In-tree backends need an explicit check because being registered does not
+    # mean the build supports them. Any other name resolves through the c10d
+    # registry, enabling PrivateUse1 backends. Requires an accelerator to be
+    # present, so a CPU-only host is not mistaken for having one.
+    checks = {
+        "nccl": c10d.is_nccl_available,
+        "xccl": c10d.is_xccl_available,
+        "hccl": lambda: TEST_HPU,
+    }
+    has_accelerator = torch.accelerator.current_accelerator() is not None
     backend_available = any(
-        {
-            "nccl": c10d.is_nccl_available,
-            "xccl": c10d.is_xccl_available,
-            "hccl": lambda: TEST_HPU,
-        }.get(backend, lambda: False)()
+        checks[backend]()
+        if backend in checks
+        else has_accelerator and c10d.is_backend_available(backend)
         for backend in backends
     )
 


### PR DESCRIPTION
## Issue

test_schedule_multiproc, test_dtensor_pp_integration and
test_dtensor_pp_unit_tests cannot run on an out-of-tree PrivateUse1 accelerator,
for two independent reasons that have to be fixed together.

requires_accelerator_dist_backend resolves availability from a default ACCELERATOR_DIST_BACKENDS - a hardcoded three-entry allowlist of nccl/xccl/hccl - and returns False for every other name, so a PrivateUse1
communication backend can never satisfy it. Independently, every call site in
these files passes a hardcoded ["nccl", "xccl"], so even a corrected decorator
would never be handed the PrivateUse1 name.

## Summary

The decorator now resolves any name outside its table through
c10d.is_backend_available, which consults the registry that
Backend.register_backend populates, and the call sites pass the backend they will
actually use: the module-level dist.get_default_backend_for_device(device_type)
that all three files already compute.

That registry fallback is gated on an accelerator actually being present. On a
CPU-only host device_type is "cpu" and the default backend is gloo, which is both
registered and available, so an ungated fallback would report gloo as an
available accelerator backend and stop skipping these tests. The sibling
TEST_MULTIACCELERATOR guards happen to mask that today, but the decorator's own
contract should hold without depending on them.

Separately, init_pg in both DTensor files guarded device selection on
device_type == "cuda" and then called torch.cuda.set_device. On any other
accelerator that guard is false and no device is ever selected, so every rank
falls back to device 0, which for a multi-rank pipeline test silently collapses
the entire world onto a single device. Routing through
torch.get_device_module(device_type) selects the correct device on any backend
and leaves CUDA behavior identical.

Finally, the skip messages claimed "requires N+ GPUs" while gating on accelerator
device count, and now say "devices". The flex attention skip in
test_schedule_multiproc keeps "GPUs" because it is gated on device_type != "cuda"
alongside requires_accelerator_dist_backend(["nccl"]) and is genuinely CUDA-only.

Behavior changes:
CUDA is unaffected: backend resolves to "nccl", and is_xccl_available() was
already False there, so the old disjunction was a no-op. XPU tightens, because an
NCCL-enabled build previously satisfied the gate on XPU without XCCL present, and
now XCCL is required. HPU moves from depending on NCCL or XCCL being built to
TEST_HPU, since these call sites never listed hccl. CPU-only hosts still skip.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.
