### PR TITLE
[optim][muon] fix momentum buffer aliasing in Newton-Schulz

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2726,7 +2726,7 @@ class TestMuon(TestCase):
 
 instantiate_device_type_tests(TestOptimRenewed, globals(), allow_mps=True)
 instantiate_device_type_tests(TestSWAUtils, globals(), allow_mps=True)
-instantiate_device_type_tests(TestMuon, globals())
+instantiate_device_type_tests(TestMuon, globals(), allow_mps=True)
 
 
 if __name__ == "__main__":

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2701,8 +2701,28 @@ class TestOptimRenewed(TestCase):
         self.assertEqual(counter, 6)
 
 
+class TestMuon(TestCase):
+    def test_muon_does_not_alias_momentum_buffer(self, device):
+        # With nesterov=False the momentum buffer is handed straight to
+        # Newton-Schulz, which normalizes in place, so a bf16 param must not
+        # end up aliasing it.
+        momentum = 0.9
+        param = Parameter(torch.randn(4, 6, device=device, dtype=torch.bfloat16))
+        grad = torch.randn(4, 6, device=device, dtype=torch.bfloat16)
+        param.grad = grad.clone()
+        optimizer = torch.optim.Muon([param], momentum=momentum, nesterov=False)
+
+        optimizer.step()
+
+        self.assertEqual(
+            optimizer.state[param]["momentum_buffer"],
+            torch.zeros_like(grad).lerp_(grad, 1 - momentum),
+        )
+
+
 instantiate_device_type_tests(TestOptimRenewed, globals(), allow_mps=True)
 instantiate_device_type_tests(TestSWAUtils, globals(), allow_mps=True)
+instantiate_device_type_tests(TestMuon, globals())
 
 
 if __name__ == "__main__":

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -22,6 +22,7 @@ from torch.optim.optimizer import (
 )
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
+    dtypes,
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
@@ -2700,33 +2701,32 @@ class TestOptimRenewed(TestCase):
         optimizer.step(functools.partial(fwd_bwd, optimizer, model, input))
         self.assertEqual(counter, 6)
 
-
-class TestMuon(TestCase):
-    def test_muon_does_not_alias_momentum_buffer(self, device):
-        # With nesterov=False the momentum buffer is handed straight to
-        # Newton-Schulz, which normalizes in place, so a bf16 param must not
-        # end up aliasing it. Check the whole trajectory, not just one step:
-        # Newton-Schulz renormalizes its input, so an aliased buffer only shows
-        # up in the parameters from the second step onwards.
-        torch.manual_seed(7)
+    @dtypes(torch.float32, torch.bfloat16)
+    @parametrize("nesterov", [False, True])
+    def test_muon_orthogonalization_does_not_alias_momentum_buffer(
+        self, device, dtype, nesterov
+    ):
         momentum = 0.9
-        param = Parameter(torch.randn(8, 5, device=device, dtype=torch.bfloat16))
-        optimizer = torch.optim.Muon([param], momentum=momentum, nesterov=False)
+        param = Parameter(torch.zeros(8, 5, device=device, dtype=dtype))
+        param.grad = torch.ones_like(param)
+        optimizer = torch.optim.Muon(
+            [param],
+            lr=0,
+            weight_decay=0,
+            momentum=momentum,
+            nesterov=nesterov,
+        )
         expected = torch.zeros_like(param)
-
-        for _ in range(4):
-            grad = torch.randn(8, 5, device=device, dtype=torch.bfloat16)
-            param.grad = grad.clone()
-            expected.lerp_(grad, 1 - momentum)
-
-            optimizer.step()
-
-            self.assertEqual(optimizer.state[param]["momentum_buffer"], expected)
+        expected.lerp_(param.grad, 1 - momentum)
+        optimizer.step()
+        self.assertEqual(
+            optimizer.state[param]["momentum_buffer"],
+            expected,
+        )
 
 
 instantiate_device_type_tests(TestOptimRenewed, globals(), allow_mps=True)
 instantiate_device_type_tests(TestSWAUtils, globals(), allow_mps=True)
-instantiate_device_type_tests(TestMuon, globals(), allow_mps=True)
 
 
 if __name__ == "__main__":

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -2705,19 +2705,23 @@ class TestMuon(TestCase):
     def test_muon_does_not_alias_momentum_buffer(self, device):
         # With nesterov=False the momentum buffer is handed straight to
         # Newton-Schulz, which normalizes in place, so a bf16 param must not
-        # end up aliasing it.
+        # end up aliasing it. Check the whole trajectory, not just one step:
+        # Newton-Schulz renormalizes its input, so an aliased buffer only shows
+        # up in the parameters from the second step onwards.
+        torch.manual_seed(7)
         momentum = 0.9
-        param = Parameter(torch.randn(4, 6, device=device, dtype=torch.bfloat16))
-        grad = torch.randn(4, 6, device=device, dtype=torch.bfloat16)
-        param.grad = grad.clone()
+        param = Parameter(torch.randn(8, 5, device=device, dtype=torch.bfloat16))
         optimizer = torch.optim.Muon([param], momentum=momentum, nesterov=False)
+        expected = torch.zeros_like(param)
 
-        optimizer.step()
+        for _ in range(4):
+            grad = torch.randn(8, 5, device=device, dtype=torch.bfloat16)
+            param.grad = grad.clone()
+            expected.lerp_(grad, 1 - momentum)
 
-        self.assertEqual(
-            optimizer.state[param]["momentum_buffer"],
-            torch.zeros_like(grad).lerp_(grad, 1 - momentum),
-        )
+            optimizer.step()
+
+            self.assertEqual(optimizer.state[param]["momentum_buffer"], expected)
 
 
 instantiate_device_type_tests(TestOptimRenewed, globals(), allow_mps=True)

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -52,7 +52,8 @@ def _zeropower_via_newtonschulz(
     if len(ns_coefficients) != 3:
         raise ValueError("Coefficients must be a tuple of exactly 3 values")
     a, b, c = ns_coefficients
-    ortho_grad = grad.bfloat16()
+    # NS normalizes in place, so never alias the momentum buffer.
+    ortho_grad = grad.to(dtype=torch.bfloat16, copy=True)
     if grad.size(0) > grad.size(1):
         ortho_grad = ortho_grad.T
     # Ensure spectral norm is at most 1

--- a/torch/optim/_muon.py
+++ b/torch/optim/_muon.py
@@ -52,7 +52,6 @@ def _zeropower_via_newtonschulz(
     if len(ns_coefficients) != 3:
         raise ValueError("Coefficients must be a tuple of exactly 3 values")
     a, b, c = ns_coefficients
-    # NS normalizes in place, so never alias the momentum buffer.
     ortho_grad = grad.to(dtype=torch.bfloat16, copy=True)
     if grad.size(0) > grad.size(1):
         ortho_grad = ortho_grad.T


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #190597
* __->__ #194664

`_zeropower_via_newtonschulz` happens in-place. 
* before: `grad.bfloat16()` returns itself when already bfloat16, and then normalized it in place
via `div_`
* after: use `grad.to(dtype=torch.bfloat16, copy=True)` so the input is never aliased
