### PR TITLE
[AOTI] Mark and free fold-input-only constants (codegen + config)

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -337,6 +337,415 @@ void test_aoti_constants_update(
   }
 }
 
+// Exercises the free_fold_input_only_constants release/re-arm cycle end to end
+// through the C++ runtime: load, predict, update the released fold inputs,
+// re-fold, predict again. Without the re-arm in update_constant_buffer, the
+// second run_const_fold() either throws (inputs released) or silently returns,
+// leaving the stale folded constant and an unchanged output.
+#if defined(USE_CUDA) || defined(USE_ROCM)
+// Live allocator bytes, the C++ equivalent of torch.cuda.memory_allocated().
+// reserved_bytes (used elsewhere in this file) does not shrink on free, so it
+// cannot show a release.
+size_t cudaAllocatedBytes() {
+  int device_idx = -1;
+  if (cudaGetDevice(&device_idx) != cudaSuccess || device_idx == -1) {
+    throw std::runtime_error("cudaGetDevice failed!");
+  }
+  return c10::cuda::CUDACachingAllocator::getDeviceStats(device_idx)
+      .allocated_bytes[0]
+      .current;
+}
+
+// Runs once and reports how many bytes the run gave back, which for this model
+// is dominated by the fold input released after folding.
+size_t runAndMeasureFreed(
+    torch::inductor::AOTIModelContainerRunner* runner,
+    const std::vector<at::Tensor>& inputs,
+    std::vector<at::Tensor>& out) {
+  if (cudaDeviceSynchronize() != cudaSuccess) {
+    throw std::runtime_error("cudaDeviceSynchronize failed!");
+  }
+  size_t before = cudaAllocatedBytes();
+  out = runner->run(inputs);
+  if (cudaDeviceSynchronize() != cudaSuccess) {
+    throw std::runtime_error("cudaDeviceSynchronize failed!");
+  }
+  size_t after = cudaAllocatedBytes();
+  return before > after ? before - after : 0;
+}
+
+void test_aoti_free_fold_constants_update() {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+
+  const auto& model_so_path =
+      data_loader.attr("model_so_path_free_fold").toStringRef();
+  auto input_tensors =
+      data_loader.attr("inputs_free_fold").toTensorList().vec();
+  const auto& ref_output_tensors =
+      data_loader.attr("outputs_free_fold").toTensorList().vec();
+  const auto& ref_updated_output_tensors =
+      data_loader.attr("outputs_updated_free_fold").toTensorList().vec();
+  const auto& w_pre_updated =
+      data_loader.attr("w_pre_updated_free_fold").toTensor();
+  const auto& b_updated = data_loader.attr("b_updated_free_fold").toTensor();
+  size_t fold_input_bytes = static_cast<size_t>(
+      data_loader.attr("fold_input_bytes_free_fold").toInt());
+
+  auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path);
+
+  // First run folds the const graph, then releases w_pre/b.
+  std::vector<at::Tensor> actual_output_tensors;
+  size_t freed =
+      runAndMeasureFreed(runner.get(), input_tensors, actual_output_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+  // Numerics alone cannot tell a release from a constant left resident, so
+  // pin the release itself.
+  ASSERT_GT(freed, fold_input_bytes * 9 / 10);
+
+  // Folding is idempotent: a second fold on an already-folded buffer must be a
+  // no-op rather than tripping the released-inputs assertion.
+  runner->run_const_fold(/* use_inactive = */ false);
+  actual_output_tensors = runner->run(input_tensors);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+
+  // Supplying the released constants again must restore them and re-arm the
+  // buffer so the next fold actually recomputes.
+  torch::inductor::TensorConstantMap updated_map;
+  updated_map.emplace("L__self___w_pre", new at::Tensor(w_pre_updated));
+  updated_map.emplace("L__self___b", new at::Tensor(b_updated));
+  runner->update_constant_buffer(updated_map, false, false);
+
+  // The re-fold has to release again, not just recompute.
+  freed =
+      runAndMeasureFreed(runner.get(), input_tensors, actual_output_tensors);
+  ASSERT_TRUE(
+      torch::allclose(ref_updated_output_tensors[0], actual_output_tensors[0]));
+  // The perturbed weights must actually move the output; an unchanged result
+  // means the re-fold was skipped and the stale folded constant survived.
+  ASSERT_FALSE(
+      torch::allclose(ref_output_tensors[0], actual_output_tensors[0]));
+  ASSERT_GT(freed, fold_input_bytes * 9 / 10);
+
+  for (auto& pair : updated_map) {
+    delete pair.second;
+  }
+}
+
+// A weight update has to re-fold correctly in every update flavor. Each one
+// restores the released fold inputs by a different route: an owning clone
+// (default), the caller's own pointer (user_managed), or a CPU tensor copied
+// H2D into fresh owned storage (allow_h2d_copy, which the runtime reaches
+// through update_constant_buffer_from_cpu). user_managed and allow_h2d_copy
+// are mutually exclusive, so there is no fourth combination to cover.
+enum class FoldInputUpdateMode { kDefault, kUserManaged, kAllowH2DCopy };
+
+void test_aoti_free_fold_constants_update_mode(FoldInputUpdateMode mode) {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+
+  const auto& model_so_path =
+      data_loader.attr("model_so_path_free_fold").toStringRef();
+  auto input_tensors =
+      data_loader.attr("inputs_free_fold").toTensorList().vec();
+  const auto& ref_output_tensors =
+      data_loader.attr("outputs_free_fold").toTensorList().vec();
+  size_t fold_input_bytes = static_cast<size_t>(
+      data_loader.attr("fold_input_bytes_free_fold").toInt());
+
+  // Mirrors FoldInputHeavyNet.forward in test.py, so the reference tracks
+  // whatever weights each round supplies rather than a value from data.pt.
+  auto eager_forward =
+      [](const at::Tensor& x, const at::Tensor& w_pre, const at::Tensor& b) {
+        return x * (at::relu(w_pre).sum(0) + b);
+      };
+
+  auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path);
+
+  // First run folds the const graph, then releases w_pre/b. This always goes
+  // through the load-time owned-storage path, whatever the update mode is.
+  std::vector<at::Tensor> outputs;
+  size_t freed = runAndMeasureFreed(runner.get(), input_tensors, outputs);
+  at::Tensor previous = outputs[0];
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], previous));
+  ASSERT_GT(freed, fold_input_bytes * 9 / 10);
+
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA);
+  // Twice, so the release/re-arm cycle is exercised past the first update.
+  for (int round = 0; round < 2; round++) {
+    at::Tensor w_pre =
+        at::randn({static_cast<int64_t>(fold_input_bytes / 16), 4}, options);
+    at::Tensor b = at::randn({4}, options);
+    at::Tensor expected = eager_forward(input_tensors[0], w_pre, b);
+
+    bool from_cpu = mode == FoldInputUpdateMode::kAllowH2DCopy;
+    // Must outlive the update call; under user_managed the container keeps no
+    // copy of them. The H2D source is deliberately non-contiguous (transposed
+    // twice around a contiguous copy, so the values match but the strides do
+    // not): the runtime has to copy it element-wise, where a raw byte copy off
+    // data_ptr() would silently produce garbage.
+    at::Tensor w_pre_arg = from_cpu ? w_pre.cpu().t().contiguous().t() : w_pre;
+    at::Tensor b_arg = from_cpu ? b.cpu() : b;
+    if (from_cpu) {
+      ASSERT_FALSE(w_pre_arg.is_contiguous());
+    }
+
+    torch::inductor::TensorConstantMap update_map;
+    update_map.emplace("L__self___w_pre", &w_pre_arg);
+    update_map.emplace("L__self___b", &b_arg);
+
+    if (from_cpu) {
+      runner->update_constant_buffer_from_cpu(
+          update_map,
+          /* use_inactive = */ false,
+          /* validate_full_update = */ false);
+    } else {
+      runner->update_constant_buffer(
+          update_map,
+          /* use_inactive = */ false,
+          /* validate_full_update = */ false,
+          /* user_managed = */ mode == FoldInputUpdateMode::kUserManaged);
+    }
+
+    freed = runAndMeasureFreed(runner.get(), input_tensors, outputs);
+    at::Tensor actual = outputs[0];
+    ASSERT_TRUE(torch::allclose(expected, actual));
+    // An unchanged result would mean the re-fold was skipped and the stale
+    // folded constant survived.
+    ASSERT_FALSE(torch::allclose(previous, actual));
+
+    if (mode == FoldInputUpdateMode::kUserManaged) {
+      // The container never copied, so there is nothing of its own to reclaim;
+      // w_pre above is still held by this scope. Asserting the release frees
+      // (almost) nothing is what pins that user_managed forgoes the saving.
+      ASSERT_LT(freed, fold_input_bytes / 2);
+    } else {
+      // default clones and allow_h2d_copy allocates owned device storage, so
+      // both must hand that storage back at the next fold.
+      ASSERT_GT(freed, fold_input_bytes * 9 / 10);
+    }
+    previous = actual;
+  }
+}
+
+// The sequence production serving actually runs, from nativert's
+// AOTIDelegateExecutor: publish new weights into the inactive buffer, fold it
+// there while the active buffer keeps serving, then swap. This is the only
+// coverage of run_const_fold(use_inactive = true) -- a shared lock, the
+// temporary swap of the model's constants map, and
+// inactive().drop_fold_input_only() -- none of which the active-buffer tests
+// reach. update_inactive_constant_buffer also forces validate_full_update, so
+// it doubles as the check that the released fold inputs are always re-supplied
+// on the path that matters.
+void test_aoti_free_fold_inactive_update_fold_swap() {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& model_so_path =
+      data_loader.attr("model_so_path_free_fold").toStringRef();
+  auto input_tensors =
+      data_loader.attr("inputs_free_fold").toTensorList().vec();
+  const auto& ref_output_tensors =
+      data_loader.attr("outputs_free_fold").toTensorList().vec();
+  size_t fold_input_bytes = static_cast<size_t>(
+      data_loader.attr("fold_input_bytes_free_fold").toInt());
+  int64_t fold_rows = static_cast<int64_t>(fold_input_bytes / 16);
+
+  auto eager_forward =
+      [](const at::Tensor& x, const at::Tensor& w_pre, const at::Tensor& b) {
+        return x * (at::relu(w_pre).sum(0) + b);
+      };
+
+  auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path);
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA);
+
+  // Load-time fold of the active buffer, which releases its fold inputs.
+  at::Tensor previous = runner->run(input_tensors)[0];
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], previous));
+
+  // Twice, so the second round updates a buffer whose fold inputs were
+  // released by the first round's fold rather than at load.
+  for (int round = 0; round < 2; round++) {
+    at::Tensor w_pre = at::randn({fold_rows, 4}, options);
+    at::Tensor b = at::randn({4}, options);
+    at::Tensor expected = eager_forward(input_tensors[0], w_pre, b);
+
+    torch::inductor::TensorConstantMap weight_map;
+    weight_map.emplace("L__self___w_pre", &w_pre);
+    weight_map.emplace("L__self___b", &b);
+    runner->update_inactive_constant_buffer(weight_map);
+
+    // Folding the inactive buffer must release its fold inputs too, not just
+    // the active buffer's.
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+      throw std::runtime_error("cudaDeviceSynchronize failed!");
+    }
+    size_t before = cudaAllocatedBytes();
+    runner->run_const_fold(/* use_inactive = */ true);
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+      throw std::runtime_error("cudaDeviceSynchronize failed!");
+    }
+    size_t after = cudaAllocatedBytes();
+    ASSERT_GT(before > after ? before - after : 0, fold_input_bytes * 9 / 10);
+
+    // Still unswapped: the active buffer keeps serving the old weights.
+    ASSERT_TRUE(torch::allclose(previous, runner->run(input_tensors)[0]));
+
+    runner->swap_constant_buffer();
+    at::Tensor actual = runner->run(input_tensors)[0];
+    ASSERT_TRUE(torch::allclose(expected, actual));
+    ASSERT_FALSE(torch::allclose(previous, actual));
+    previous = actual;
+  }
+}
+
+// Folding the same weights repeatedly must be discarded, not repeated. Once
+// the first fold has released the fold inputs there is nothing left to fold
+// from, so every later call has to return without touching them and without
+// disturbing the folded result. A weight update is the only thing that re-arms
+// the buffer.
+void test_aoti_free_fold_repeated_const_fold() {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& model_so_path =
+      data_loader.attr("model_so_path_free_fold").toStringRef();
+  auto input_tensors =
+      data_loader.attr("inputs_free_fold").toTensorList().vec();
+  const auto& ref_output_tensors =
+      data_loader.attr("outputs_free_fold").toTensorList().vec();
+  size_t fold_input_bytes = static_cast<size_t>(
+      data_loader.attr("fold_input_bytes_free_fold").toInt());
+  int64_t fold_rows = static_cast<int64_t>(fold_input_bytes / 16);
+
+  auto eager_forward =
+      [](const at::Tensor& x, const at::Tensor& w_pre, const at::Tensor& b) {
+        return x * (at::relu(w_pre).sum(0) + b);
+      };
+
+  auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path);
+
+  // First run folds and releases the fold inputs.
+  std::vector<at::Tensor> outputs;
+  size_t freed = runAndMeasureFreed(runner.get(), input_tensors, outputs);
+  ASSERT_TRUE(torch::allclose(ref_output_tensors[0], outputs[0]));
+  ASSERT_GT(freed, fold_input_bytes * 9 / 10);
+
+  // Every subsequent fold of the same weights is discarded. None may throw on
+  // the released inputs, and the prediction may not drift.
+  for (int i = 0; i < 5; i++) {
+    runner->run_const_fold(/* use_inactive = */ false);
+    ASSERT_TRUE(
+        torch::allclose(ref_output_tensors[0], runner->run(input_tensors)[0]));
+  }
+
+  // A weight update re-arms, so the next fold is honoured rather than
+  // discarded -- and the extra folds after it are discarded again.
+  at::Tensor w_pre = at::randn(
+      {fold_rows, 4}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+  at::Tensor b =
+      at::randn({4}, at::TensorOptions().dtype(at::kFloat).device(at::kCUDA));
+  torch::inductor::TensorConstantMap update_map;
+  update_map.emplace("L__self___w_pre", &w_pre);
+  update_map.emplace("L__self___b", &b);
+  runner->update_constant_buffer(update_map, false, false);
+
+  at::Tensor expected = eager_forward(input_tensors[0], w_pre, b);
+  for (int i = 0; i < 3; i++) {
+    runner->run_const_fold(/* use_inactive = */ false);
+    ASSERT_TRUE(torch::allclose(expected, runner->run(input_tensors)[0]));
+  }
+  ASSERT_FALSE(torch::allclose(ref_output_tensors[0], expected));
+}
+
+// Back-to-back weight updates, in the two shapes serving can produce: update
+// then predict (each update arms a fold that releases again), and several
+// updates with no fold in between (only the last one's values may survive).
+// The prediction after each has to match eager.
+void test_aoti_free_fold_repeated_updates() {
+  torch::NoGradGuard no_grad;
+
+  std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& model_so_path =
+      data_loader.attr("model_so_path_free_fold").toStringRef();
+  auto input_tensors =
+      data_loader.attr("inputs_free_fold").toTensorList().vec();
+  size_t fold_input_bytes = static_cast<size_t>(
+      data_loader.attr("fold_input_bytes_free_fold").toInt());
+  int64_t fold_rows = static_cast<int64_t>(fold_input_bytes / 16);
+
+  auto eager_forward =
+      [](const at::Tensor& x, const at::Tensor& w_pre, const at::Tensor& b) {
+        return x * (at::relu(w_pre).sum(0) + b);
+      };
+
+  auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
+      model_so_path);
+  auto options = at::TensorOptions().dtype(at::kFloat).device(at::kCUDA);
+
+  auto update = [&](const at::Tensor& w_pre, const at::Tensor& b) {
+    torch::inductor::TensorConstantMap map;
+    // TensorConstantMap borrows, so these must outlive the call; they do,
+    // since the caller's tensors are alive for the whole round.
+    map.emplace("L__self___w_pre", const_cast<at::Tensor*>(&w_pre));
+    map.emplace("L__self___b", const_cast<at::Tensor*>(&b));
+    runner->update_constant_buffer(
+        map,
+        /* use_inactive = */ false,
+        /* validate_full_update = */ false);
+  };
+
+  // First run folds and releases.
+  runner->run(input_tensors);
+
+  // Phase 1: update, predict, repeat. Every round re-arms, re-folds and
+  // releases again.
+  for (int round = 0; round < 4; round++) {
+    at::Tensor w_pre = at::randn({fold_rows, 4}, options);
+    at::Tensor b = at::randn({4}, options);
+    update(w_pre, b);
+    ASSERT_TRUE(torch::allclose(
+        eager_forward(input_tensors[0], w_pre, b),
+        runner->run(input_tensors)[0]));
+  }
+
+  // Phase 2: several updates with no fold in between. Each one overwrites the
+  // previous, still-unfolded values, so the single fold at the end must use
+  // the last ones.
+  std::vector<at::Tensor> w_pres;
+  std::vector<at::Tensor> bs;
+  for (int round = 0; round < 4; round++) {
+    w_pres.push_back(at::randn({fold_rows, 4}, options));
+    bs.push_back(at::randn({4}, options));
+    update(w_pres.back(), bs.back());
+  }
+  ASSERT_TRUE(torch::allclose(
+      eager_forward(input_tensors[0], w_pres.back(), bs.back()),
+      runner->run(input_tensors)[0]));
+}
+#endif
+
 void test_aoti_extract_constants_map(const std::string& device) {
   torch::NoGradGuard no_grad;
 
@@ -1280,6 +1689,34 @@ TEST_F(AotInductorTest, RuntimeUpdateConstantsCuda) {
 
 TEST_F(AotInductorTest, UpdateConstantsCuda) {
   test_aoti_constants_update("cuda", false);
+}
+
+TEST_F(AotInductorTest, FreeFoldInputOnlyConstantsUpdateCuda) {
+  test_aoti_free_fold_constants_update();
+}
+
+TEST_F(AotInductorTest, FreeFoldInputOnlyConstantsUpdateDefaultCuda) {
+  test_aoti_free_fold_constants_update_mode(FoldInputUpdateMode::kDefault);
+}
+
+TEST_F(AotInductorTest, FreeFoldInputOnlyConstantsUpdateUserManagedCuda) {
+  test_aoti_free_fold_constants_update_mode(FoldInputUpdateMode::kUserManaged);
+}
+
+TEST_F(AotInductorTest, FreeFoldInputOnlyConstantsUpdateAllowH2DCopyCuda) {
+  test_aoti_free_fold_constants_update_mode(FoldInputUpdateMode::kAllowH2DCopy);
+}
+
+TEST_F(AotInductorTest, FreeFoldInputOnlyConstantsInactiveUpdateFoldSwapCuda) {
+  test_aoti_free_fold_inactive_update_fold_swap();
+}
+
+TEST_F(AotInductorTest, FreeFoldInputOnlyConstantsRepeatedConstFoldCuda) {
+  test_aoti_free_fold_repeated_const_fold();
+}
+
+TEST_F(AotInductorTest, FreeFoldInputOnlyConstantsRepeatedUpdatesCuda) {
+  test_aoti_free_fold_repeated_updates();
 }
 
 TEST_F(AotInductorTest, ExtractConstantsMapCuda) {

--- a/test/cpp/aoti_inference/test.py
+++ b/test/cpp/aoti_inference/test.py
@@ -166,6 +166,69 @@ def generate_cuda_alloc_test():
     )
 
 
+# Sized so the released fold input dominates the allocator delta across a run,
+# which is what lets the C++ side assert the post-fold release rather than just
+# the numerics. The folded output is 4 elements.
+FOLD_INPUT_ROWS = 1 << 20
+
+
+class FoldInputHeavyNet(torch.nn.Module):
+    def __init__(self, device):
+        super().__init__()
+        self.w_pre = torch.randn(FOLD_INPUT_ROWS, 4, device=device)
+        self.b = torch.randn(4, device=device)
+
+    def forward(self, x):
+        return x * (torch.nn.functional.relu(self.w_pre).sum(dim=0) + self.b)
+
+
+# AOTI model compiled with free_fold_input_only_constants, where w_pre/b feed
+# only the const graph and are therefore released after the first fold. The C++
+# side updates them and re-folds, which only works if the update re-arms the
+# buffer.
+def generate_free_fold_tests():
+    if not torch.cuda.is_available():
+        return
+
+    device = "cuda"
+    model = FoldInputHeavyNet(device)
+    x = torch.randn(4, device=device)
+    with torch.no_grad():
+        ref_output = model(x)
+
+    # Perturb both fold inputs so the post-update output must differ.
+    w_pre_updated = model.w_pre + 0.5
+    b_updated = model.b + 0.5
+    updated_model = FoldInputHeavyNet(device)
+    updated_model.w_pre = w_pre_updated
+    updated_model.b = b_updated
+    with torch.no_grad():
+        ref_output_updated = updated_model(x)
+
+    torch._dynamo.reset()
+    with torch.no_grad():
+        model_so_path = aot_compile(
+            model,
+            (x,),
+            options={
+                "aot_inductor.use_runtime_constant_folding": True,
+                "aot_inductor.free_fold_input_only_constants": True,
+            },
+        )
+
+    data.update(
+        {
+            "model_so_path_free_fold": model_so_path,
+            "inputs_free_fold": [x],
+            "outputs_free_fold": [ref_output],
+            "outputs_updated_free_fold": [ref_output_updated],
+            "w_pre_updated_free_fold": w_pre_updated,
+            "b_updated_free_fold": b_updated,
+            "fold_input_bytes_free_fold": FOLD_INPUT_ROWS * 4 * 4,
+        }
+    )
+
+
 # AOTI model which will create additional tensors during autograd.
 def generate_test_with_additional_tensors():
     if not torch.cuda.is_available():
@@ -199,6 +262,7 @@ def generate_test_with_additional_tensors():
 generate_basic_tests()
 generate_basic_tests_consts_cpp()
 generate_large_tests()
+generate_free_fold_tests()
 generate_test_with_additional_tensors()
 generate_cuda_alloc_test()
 

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -295,6 +295,29 @@ def _record_bmm_shared_a_choices(example_inputs, model=None, **config_overrides)
     return offered
 
 
+def compile_with_fold_input_only_freeing(model, example_inputs):
+    with (
+        torch.no_grad(),
+        config.patch(
+            {
+                "always_keep_tensor_constants": True,
+                "aot_inductor.use_runtime_constant_folding": True,
+                "aot_inductor.free_fold_input_only_constants": True,
+            }
+        ),
+    ):
+        return run_and_get_cpp_code(
+            AOTIRunnerUtil.legacy_compile, model, example_inputs
+        )
+
+
+def fold_input_only_names(code):
+    """Names of the constants codegen marked as fold-input-only."""
+    names = dict(re.findall(r'constants_info_\[(\d+)\]\.name = "([^"]+)";', code))
+    marked = re.findall(r"constants_info_\[(\d+)\]\.fold_input_only = true;", code)
+    return {names[idx] for idx in marked}
+
+
 class AOTInductorTestsTemplate:
     @common_utils.parametrize("embed_kernel_binary", [False, True])
     @common_utils.parametrize("max_autotune", [False, True])
@@ -700,6 +723,314 @@ class AOTInductorTestsTemplate:
         new_output = runner_call(test_inputs)
         self.assertEqual(expected, new_output)
 
+    def test_free_fold_input_only_constants_marks_dead_constants(self):
+        # w_pre and b feed only the folded subgraph. direct_w is read by the
+        # main graph as well, so it has to stay resident.
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w_pre = torch.randn(4, 4, device=device)
+                self.b = torch.randn(4, device=device)
+                self.direct_w = torch.randn(4, 4, device=device)
+
+            def forward(self, x):
+                w_relu = torch.nn.functional.relu(torch.transpose(self.w_pre, 0, 1))
+                return torch.matmul(x, w_relu + self.b) + torch.matmul(x, self.direct_w)
+
+        example_inputs = (torch.randn(4, 4, device=self.device),)
+        _, code = compile_with_fold_input_only_freeing(
+            Model(self.device), example_inputs
+        )
+
+        marked = fold_input_only_names(code)
+        self.assertTrue(any(name.endswith("w_pre") for name in marked), marked)
+        self.assertTrue(any(name.endswith("_b") for name in marked), marked)
+        self.assertFalse(any("direct_w" in name for name in marked), marked)
+        self.assertEqual(len(marked), 2, marked)
+
+    def test_free_fold_input_only_constants_constant_shared_with_main_graph(self):
+        # w feeds the fold and is also read elementwise against x. split_const_gm
+        # emits w as a const-graph output as well, so the main graph reads a
+        # folded copy rather than the original, which is what makes releasing
+        # the original safe. Pin that structure and the resulting numerics.
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w = torch.randn(4, 4, device=device)
+
+            def forward(self, x):
+                folded = torch.nn.functional.relu(torch.transpose(self.w, 0, 1))
+                return torch.matmul(x, folded) + self.w * x
+
+        model = Model(self.device)
+        example_inputs = (torch.randn(4, 4, device=self.device),)
+        so_path, code = compile_with_fold_input_only_freeing(model, example_inputs)
+
+        all_names = re.findall(r'constants_info_\[\d+\]\.name = "([^"]+)";', code)
+        self.assertTrue(
+            any(
+                name.startswith("_FOLDED_CONST_") and "w" in name for name in all_names
+            ),
+            f"expected a folded copy of w; all constants: {all_names}",
+        )
+        marked = fold_input_only_names(code)
+        self.assertFalse(
+            any(name.startswith("_FOLDED_CONST_") for name in marked),
+            f"folded outputs must never be released: {marked}",
+        )
+
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
+        test_inputs = torch.randn(4, 4, device=self.device)
+        self.assertEqual(model(test_inputs), runner.run([test_inputs])[0])
+
+    def test_free_fold_input_only_constants_releases_memory(self):
+        """A/B the feature: identical outputs, and only the enabled build gives
+        the fold inputs back across the first run."""
+        if self.device != "cuda":
+            raise unittest.SkipTest("memory accounting check is CUDA-specific")
+
+        # A large fold-only input reducing to a tiny folded output, so the
+        # allocator delta across the first run isolates the released input.
+        fold_rows = 1 << 20
+        fold_input_bytes = fold_rows * 4 * 4
+
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w_pre = torch.randn(fold_rows, 4, device=device)
+                self.b = torch.randn(4, device=device)
+
+            def forward(self, x):
+                return x * (torch.nn.functional.relu(self.w_pre).sum(dim=0) + self.b)
+
+        model = Model(self.device)
+        example_inputs = (torch.randn(4, device=self.device),)
+        test_inputs = torch.randn(4, device=self.device)
+        eager = model(test_inputs)
+
+        outputs = {}
+        freed = {}
+        for enabled in (False, True):
+            with (
+                torch.no_grad(),
+                config.patch(
+                    {
+                        "always_keep_tensor_constants": True,
+                        "aot_inductor.use_runtime_constant_folding": True,
+                        "aot_inductor.free_fold_input_only_constants": enabled,
+                    }
+                ),
+            ):
+                so_path = AOTIRunnerUtil.legacy_compile(
+                    model=model, example_inputs=example_inputs
+                )
+            runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
+            torch.cuda.synchronize()
+            after_load = torch.cuda.memory_allocated(self.device)
+            # The first run triggers constant folding.
+            outputs[enabled] = runner.run([test_inputs])[0]
+            torch.cuda.synchronize()
+            freed[enabled] = after_load - torch.cuda.memory_allocated(self.device)
+            del runner
+
+        # Accuracy: releasing the fold inputs must not change results.
+        self.assertEqual(eager, outputs[False])
+        self.assertEqual(outputs[False], outputs[True])
+        # Memory: only the enabled build reclaims w_pre. With the feature off the
+        # fold inputs sit in the raw-cudaMalloc blob, which the caching allocator
+        # never sees, so its delta is dominated by the (tiny) folded output.
+        self.assertGreater(
+            freed[True] - freed[False],
+            fold_input_bytes * 0.9,
+            f"expected ~{fold_input_bytes} bytes reclaimed; freed={freed}",
+        )
+
+    def test_free_fold_input_only_constants_disabled_by_default(self):
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w_pre = torch.randn(4, 4, device=device)
+                self.b = torch.randn(4, device=device)
+
+            def forward(self, x):
+                w_relu = torch.nn.functional.relu(torch.transpose(self.w_pre, 0, 1))
+                return torch.matmul(x, w_relu + self.b)
+
+        example_inputs = (torch.randn(4, 4, device=self.device),)
+        with (
+            torch.no_grad(),
+            config.patch(
+                {
+                    "always_keep_tensor_constants": True,
+                    "aot_inductor.use_runtime_constant_folding": True,
+                }
+            ),
+        ):
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.legacy_compile, Model(self.device), example_inputs
+            )
+        self.assertEqual(len(fold_input_only_names(code)), 0)
+
+    def test_free_fold_input_only_constants_update_after_release(self):
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w_pre = torch.randn(4, 4, device=device)
+                self.b = torch.randn(4, device=device)
+
+            def forward(self, x):
+                w_relu = torch.nn.functional.relu(torch.transpose(self.w_pre, 0, 1))
+                return torch.matmul(x, w_relu + self.b)
+
+        model = Model(self.device)
+        example_inputs = (torch.randn(4, 4, device=self.device),)
+        so_path, code = compile_with_fold_input_only_freeing(model, example_inputs)
+        marked = fold_input_only_names(code)
+        self.assertEqual(len(marked), 2, marked)
+
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
+        test_inputs = torch.randn(4, 4, device=self.device)
+
+        # First run folds, then releases w_pre and b.
+        self.assertEqual(model(test_inputs), runner.run([test_inputs])[0])
+
+        # A full update restores the released constants, so the re-fold works.
+        new_weights = {
+            "L__self___b": torch.randn(4, device=self.device),
+            "L__self___w_pre": torch.randn(4, 4, device=self.device),
+        }
+        model.w_pre = new_weights["L__self___w_pre"]
+        model.b = new_weights["L__self___b"]
+        runner.update_constant_buffer(new_weights, False, False)
+        self.assertEqual(model(test_inputs), runner.run([test_inputs])[0])
+
+        # A partial update cannot re-fold, since the missing constant was
+        # released rather than left stale. It has to fail rather than fold
+        # against freed memory. (The fbcode runner surfaces the C ABI failure
+        # without the underlying message, so only the raise is asserted.)
+        runner.update_constant_buffer(
+            {"L__self___b": torch.randn(4, device=self.device)}, False, False
+        )
+        with self.assertRaises(Exception):
+            runner.run([test_inputs])
+
+    @common_utils.parametrize(
+        "update_mode", ["default", "user_managed", "allow_h2d_copy"]
+    )
+    def test_free_fold_input_only_constants_update_modes(self, update_mode):
+        """A weight update must re-fold correctly in every update flavor.
+
+        The fold inputs are released after the first fold, so each mode has to
+        restore them by a different route: an owning clone (default), the
+        caller's own pointer (user_managed), or a CPU tensor copied H2D into
+        fresh owned storage (allow_h2d_copy). user_managed and allow_h2d_copy
+        are mutually exclusive, so there is no fourth combination.
+
+        Also asserts the release actually happens, which numerics alone cannot
+        show: default and allow_h2d_copy hand the container owned storage, so
+        the re-fold must reclaim it, while user_managed hands it the caller's
+        pointer, so the release must reclaim nothing.
+        """
+        if update_mode == "allow_h2d_copy" and self.device != GPU_TYPE:
+            raise unittest.SkipTest("allow_h2d_copy only applies to device models")
+        check_memory = self.device == "cuda"
+
+        # Large enough that the released fold input dominates the allocator
+        # delta across a run; the folded output is 4 elements.
+        fold_rows = 1 << 20
+        fold_input_bytes = fold_rows * 4 * 4
+
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w_pre = torch.nn.Parameter(
+                    torch.randn(fold_rows, 4, device=device)
+                )
+                self.b = torch.nn.Parameter(torch.randn(4, device=device))
+
+            def forward(self, x):
+                return x * (torch.nn.functional.relu(self.w_pre).sum(dim=0) + self.b)
+
+        model = Model(self.device)
+        example_inputs = (torch.randn(4, device=self.device),)
+        # The package loader is what exposes user_managed and allow_h2d_copy;
+        # the fbcode legacy runner has no update_constant_buffer_from_cpu.
+        with torch.no_grad():
+            package_path, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile,
+                model,
+                example_inputs,
+                {
+                    "always_keep_tensor_constants": True,
+                    "aot_inductor.use_runtime_constant_folding": True,
+                    "aot_inductor.free_fold_input_only_constants": True,
+                },
+            )
+        self.assertEqual(len(fold_input_only_names(code)), 2)
+
+        compiled = torch._inductor.aoti_load_package(package_path)
+        # get_constant_fqns also reports the folded output, which no update may
+        # supply; only the two fold inputs are ours to restore.
+        self.assertTrue({"w_pre", "b"}.issubset(compiled.get_constant_fqns()))
+        test_inputs = torch.randn(4, device=self.device)
+        from_cpu = update_mode == "allow_h2d_copy"
+
+        def run_and_measure_freed():
+            """Run once and return (output, bytes the run gave back)."""
+            if not check_memory:
+                return compiled(test_inputs), None
+            torch.cuda.synchronize()
+            before = torch.cuda.memory_allocated(self.device)
+            out = compiled(test_inputs)
+            torch.cuda.synchronize()
+            return out, before - torch.cuda.memory_allocated(self.device)
+
+        with torch.no_grad():
+            # First run folds, then releases w_pre and b. This always goes
+            # through the load-time owned-storage path, whatever the mode is.
+            previous, freed = run_and_measure_freed()
+            self.assertEqual(model(test_inputs), previous)
+            if check_memory:
+                self.assertGreater(freed, fold_input_bytes * 0.9)
+
+            # Twice, so the release/re-arm cycle runs past the first update.
+            for _ in range(2):
+                new_values = {
+                    "w_pre": torch.randn(fold_rows, 4, device=self.device),
+                    "b": torch.randn(4, device=self.device),
+                }
+                # Also keeps the tensors alive past the fold, which user_managed
+                # needs since the container holds no copy of them.
+                model.w_pre = torch.nn.Parameter(new_values["w_pre"])
+                model.b = torch.nn.Parameter(new_values["b"])
+                expected = model(test_inputs)
+
+                compiled.load_constants(
+                    {
+                        fqn: value.cpu() if from_cpu else value
+                        for fqn, value in new_values.items()
+                    },
+                    check_full_update=False,
+                    user_managed=update_mode == "user_managed",
+                    allow_h2d_copy=from_cpu,
+                )
+
+                actual, freed = run_and_measure_freed()
+                self.assertEqual(expected, actual)
+                # An unchanged result would mean the re-fold was skipped and the
+                # stale folded constant survived.
+                self.assertFalse(torch.allclose(previous, actual))
+                if check_memory and update_mode == "user_managed":
+                    # The container never copied, so it has nothing of its own
+                    # to reclaim and new_values still holds the tensor. Pinning
+                    # this documents that user_managed forgoes the saving.
+                    self.assertLess(freed, fold_input_bytes * 0.5)
+                elif check_memory:
+                    # default clones and allow_h2d_copy allocates owned device
+                    # storage, so both must hand it back at the next fold.
+                    self.assertGreater(freed, fold_input_bytes * 0.9)
+                previous = actual
+
     def test_update_inactive_constant_buffer_with_interleaved_folded_constants(self):
         if self.device == "mps":
             raise unittest.SkipTest("MPS baseline mismatch")
@@ -916,6 +1247,102 @@ class AOTInductorTestsTemplate:
             )
 
     @requires_gpu
+    def test_constant_folding_with_update_free_fold_inputs(self):
+        """test_constant_folding_with_update with fold-input-only release on.
+
+        This is the path that broke on a real model: the buffer folds, releases
+        the constants only the const graph reads, and must still re-fold
+        correctly when a weight update restores them -- once on the active
+        buffer and once on the inactive buffer followed by a swap. Also asserts
+        the release actually frees device memory, on the first fold and again
+        after the update-driven re-fold.
+        """
+        if self.device != "cuda":
+            raise unittest.SkipTest("memory accounting check is CUDA-specific")
+
+        # Large enough that the released fold input dominates the allocator
+        # delta across a run; the folded output is 4 elements.
+        fold_rows = 1 << 20
+        fold_input_bytes = fold_rows * 4 * 4
+
+        class Model(torch.nn.Module):
+            def __init__(self, device):
+                super().__init__()
+                self.w_pre = torch.randn(fold_rows, 4, device=device)
+                self.b = torch.randn(4, device=device)
+
+            def forward(self, x):
+                return x * (torch.nn.functional.relu(self.w_pre).sum(dim=0) + self.b)
+
+        example_inputs = (torch.randn(4, device=self.device),)
+        with (
+            torch.no_grad(),
+            config.patch(
+                {
+                    "always_keep_tensor_constants": True,
+                    "aot_inductor.use_runtime_constant_folding": True,
+                    "aot_inductor.free_fold_input_only_constants": True,
+                }
+            ),
+        ):
+            model = Model(self.device)
+            so_path = AOTIRunnerUtil.legacy_compile(
+                model=model, example_inputs=example_inputs
+            )
+
+        runner = AOTIRunnerUtil.legacy_load_runner(self.device, so_path)
+        test_inputs = torch.randn(4, device=self.device)
+
+        def run_and_measure_freed():
+            """Run once (which folds) and return (output, bytes freed)."""
+            torch.cuda.synchronize()
+            before = torch.cuda.memory_allocated(self.device)
+            out = runner.run([test_inputs])[0]
+            torch.cuda.synchronize()
+            return out, before - torch.cuda.memory_allocated(self.device)
+
+        # First fold: releases w_pre.
+        expected = model(test_inputs)
+        output, freed = run_and_measure_freed()
+        self.assertEqual(expected, output)
+        self.assertGreater(
+            freed,
+            fold_input_bytes * 0.9,
+            f"first fold should release ~{fold_input_bytes} bytes, freed={freed}",
+        )
+
+        # Active-buffer update. The update restores every fold input, so the
+        # buffer re-arms and must fold again rather than serving stale values.
+        new_weights = {
+            "L__self___b": torch.randn(4, device=self.device),
+            "L__self___w_pre": torch.randn(fold_rows, 4, device=self.device),
+        }
+        model.w_pre = new_weights["L__self___w_pre"]
+        model.b = new_weights["L__self___b"]
+        expected = model(test_inputs)
+        runner.update_constant_buffer(new_weights, False, False)
+        output, freed = run_and_measure_freed()
+        self.assertEqual(expected, output)
+        self.assertGreater(
+            freed,
+            fold_input_bytes * 0.9,
+            f"re-fold should release again, freed={freed}",
+        )
+
+        # Inactive-buffer update, then swap.
+        new_weights = {
+            "L__self___b": torch.randn(4, device=self.device),
+            "L__self___w_pre": torch.randn(fold_rows, 4, device=self.device),
+        }
+        model.w_pre = new_weights["L__self___w_pre"]
+        model.b = new_weights["L__self___b"]
+        expected = model(test_inputs)
+        runner.update_constant_buffer(new_weights, True, False)
+        # Not swapped yet: still the previous weights' result.
+        self.assertEqual(output, runner.run([test_inputs])[0])
+        runner.swap_constant_buffer()
+        self.assertEqual(expected, runner.run([test_inputs])[0])
+
     def test_duplicate_constant_folding(self):
         class Model(torch.nn.Module):
             def __init__(self, device):

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1343,6 +1343,7 @@ class AOTInductorTestsTemplate:
         runner.swap_constant_buffer()
         self.assertEqual(expected, runner.run([test_inputs])[0])
 
+    @requires_gpu
     def test_duplicate_constant_folding(self):
         class Model(torch.nn.Module):
             def __init__(self, device):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -1266,6 +1266,7 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 for name in V.graph.constants
                 if name not in V.graph.folded_constants
             )
+            fold_input_only = V.graph.get_fold_input_only_constants()
             for idx, name in enumerate(V.graph.constants.keys()):
                 tensor = V.graph.get_original_value_of_constant(name)
                 if not isinstance(tensor, torch.Tensor):
@@ -1307,6 +1308,11 @@ class CppWrapperCpu(PythonWrapperCodegen):
                 from_folded = "true" if name in V.graph.folded_constants else "false"
                 self.prefix.writeline(
                     f"constants_info_[{idx}].from_folded = {from_folded};"
+                )
+
+                self.prefix.writeline(
+                    f"constants_info_[{idx}].fold_input_only = "
+                    f"{'true' if name in fold_input_only else 'false'};"
                 )
 
                 if name in V.graph.folded_constants:

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2411,6 +2411,20 @@ class aot_inductor:
     # flag to decide whether to create a submodule for constant graph.
     use_runtime_constant_folding: bool = False
 
+    # Requires use_runtime_constant_folding. Constants that only the const graph
+    # reads are dead once folding has run, but the runtime keeps them resident
+    # forever. When set, those constants are kept outside the shared constant
+    # blob and released after the first successful fold.
+    # Opt-in: default off. Enable per model via aot_inductor_config.
+    # Trade-off: the model can no longer re-fold from its own weights, so a later
+    # update_constant_buffer must supply every released constant. The delta-update
+    # path does supply them all, since it refuses to run in place unless every
+    # non-empty constant is available. The runtime raises if one is missing rather
+    # than silently folding stale values.
+    free_fold_input_only_constants: bool = (
+        os.environ.get("AOT_INDUCTOR_FREE_FOLD_INPUT_ONLY_CONSTANTS", "0") == "1"
+    )
+
     # flag to force weight to be appended to the shared library and mapped by the runtime
     # rather than embedded into the data section. Needed to support 1B+ parameter models
     force_mmap_weights: bool = False

--- a/torch/_inductor/graph.py
+++ b/torch/_inductor/graph.py
@@ -11,7 +11,7 @@ import sys
 import textwrap
 import time
 import typing_extensions
-from collections import defaultdict
+from collections import Counter, defaultdict
 from contextlib import contextmanager
 from typing import Any, cast, Literal, NoReturn, TYPE_CHECKING
 
@@ -594,6 +594,11 @@ class GraphLowering(torch.fx.Interpreter):
         self.allocated_constant_name: dict[str, str] = (
             const_module.allocated_constant_name if const_module is not None else {}
         )
+        # Unlike constants/allocated_constant_name, this is NOT inherited from
+        # const_module: it records only the constants this graph's own lowering
+        # allocated, which is how the main graph tells its reads apart from the
+        # const graph's. See get_fold_input_only_constants().
+        self.locally_allocated_constant_names: OrderedSet[str] = OrderedSet()
         init_backend_registration()
         self.get_backend_features = functools.lru_cache(None)(get_backend_features)
 
@@ -1211,6 +1216,75 @@ class GraphLowering(torch.fx.Interpreter):
             else self.constants[name]
         )
 
+    def get_fold_input_only_constants(self) -> OrderedSet[str]:
+        """
+        Names of constants that only the constant-folding graph reads, and which
+        are therefore dead once folding has run.
+
+        Two independent signals have to agree, and anything they disagree on --
+        or that cannot be attributed to exactly one graph -- is kept live:
+
+        1. Lowering. locally_allocated_constant_names records the constants each
+           graph's own lowering reached for, so a constant the main graph never
+           touched is a candidate.
+        2. FX. split_const_gm() erases from the main graph every get_attr whose
+           users were all folded away and keeps the ones a main-graph node still
+           reads, so the two graphs' get_attr targets separate them as well.
+
+        The aliasing guard matters: use_runtime_constant_folding disables
+        dedup in allocate_non_dup_const_name, so a tensor read by both graphs
+        gets two entries (L__self___w and L__self___w_0) that share one
+        original_fqn. Neither is safe to release, because the const graph's copy
+        looks fold-only in isolation while the storage behind it is the weight
+        the main graph still reads.
+        """
+        if not (
+            config.aot_inductor.free_fold_input_only_constants
+            and config.aot_inductor.use_runtime_constant_folding
+            and self.const_module is not None
+        ):
+            return OrderedSet()
+
+        # The runtime gives these constants their own storage, which the MPS
+        # path (one shared buffer addressed by offset) cannot express.
+        if "mps" in self.device_types:
+            return OrderedSet()
+
+        def attr_targets(graph_lowering: GraphLowering) -> OrderedSet[str]:
+            return OrderedSet(
+                node.target
+                for node in graph_lowering.module.graph.nodes  # type: ignore[union-attr]
+                if node.op == "get_attr" and isinstance(node.target, str)
+            )
+
+        # const_module.module is the const graph; self.module is the main graph
+        # after split_const_gm has rewritten it in place.
+        const_targets = attr_targets(self.const_module)
+        main_targets = attr_targets(self)
+
+        orig_fqn_counts: Counter[str] = Counter(
+            self.allocated_constant_name.get(name, name) for name in self.constants
+        )
+
+        def is_fold_input_only(name: str) -> bool:
+            if name in self.folded_constants:
+                return False
+            if name in self.locally_allocated_constant_names:
+                return False
+            if name not in self.const_module.locally_allocated_constant_names:  # type: ignore[union-attr]
+                return False
+            orig = self.allocated_constant_name.get(name, name)
+            if orig_fqn_counts[orig] != 1:
+                return False
+            if orig not in const_targets or orig in main_targets:
+                return False
+            # mkldnn constants carry opaque metadata and a data_size that is not
+            # derived from dtype/shape, so they cannot be re-materialized into
+            # standalone storage.
+            return not self.constants[name].is_mkldnn
+
+        return OrderedSet(name for name in self.constants if is_fold_input_only(name))
+
     def allocate_non_dup_const_name(self, name: str | None, data: Tensor) -> str:
         if not config.aot_inductor.use_runtime_constant_folding:
             for constant_name, value in self.constants.items():
@@ -1238,6 +1312,9 @@ class GraphLowering(torch.fx.Interpreter):
             f"{hash(data):x}"
         )
         self.allocated_constant_name[name] = orig_name  # type: ignore[assignment]
+        # constants is shared with const_module, but this set is per-graph: it
+        # records the constants *this* graph's lowering actually reached for.
+        self.locally_allocated_constant_names.add(name)
         return name
 
     def add_tensor_constant(self, data: Tensor, name: str | None = None) -> TensorBox:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194675
* #194674

Codegen half, on top of the runtime diff. This is what turns the feature on.

Under `aot_inductor.use_runtime_constant_folding`, AOTI splits the graph into a
const graph that runs once at load and a main graph that runs per request. Some
constants are read *only* by the const graph. Once folding has produced the
folded outputs those inputs are dead, but the runtime keeps them resident in the
shared constant blob for the lifetime of the process.

This adds `aot_inductor.free_fold_input_only_constants` (**default off**, opt in
per model via `aot_inductor_config`) which gives those constants their own
storage instead of a shared-blob alias, and releases them after the first
successful fold.

Trade-off: the model can no longer re-fold from its own weights, so a later
`update_constant_buffer` must supply every released constant. The delta-update
path already does, since it refuses to run in place unless every non-empty
constant is available. `assert_fold_inputs_available()` raises an actionable
error rather than silently folding against freed memory.

Review in this order:

- `graph.py` -- `get_fold_input_only_constants()` decides which constants
  qualify. Two independent signals must agree (per-graph
  `locally_allocated_constant_names` from lowering, and `get_attr` targets from
  the FX split); anything they disagree on is kept live. Also declines on the
  aliasing case where `use_runtime_constant_folding` disables dedup and one
  `original_fqn` maps to two entries, and on mkldnn and MPS.
- `cpp_wrapper_cpu.py` -- emits `constants_info_[i].fold_input_only`.
- `config.py` -- the opt-in flag.

Design note: an alternative is a second raw-malloc'd blob for these constants.
It was not taken because it does not replace the standalone-constant machinery,
it stacks on it -- `update_constant_buffer` after release still needs somewhere
to put re-supplied constants, and it cannot be a freed blob. Both serving stacks
(`PyTorchDeferredTensorLoader` and nativert `Weights`) already allocate GPU
weights through the caching allocator, so per-constant owned storage is
consistent with the surrounding system.

Differential Revision: [D116886785](https://our.internmc.facebook.com/intern/diff/D116886785/)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo