### PR TITLE
[TEST][Inductor] Update `recover_orig_fp32_precision` to use new TF32 APIs

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -25,7 +25,12 @@ from torch.testing._internal.common_utils import (
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
     TEST_WITH_ROCM, decorateIf, recover_orig_fp32_precision, skipIfXpu
 )
-from torch.testing._internal.common_cuda import has_device_side_assert
+from torch.testing._internal.common_cuda import (
+    has_device_side_assert,
+    tf32_enabled,
+    tf32_off,
+    tf32_on,
+)
 from torch.testing._internal.common_device_type import \
     (PYTORCH_TESTING_DEVICE_EXCEPT_FOR_KEY, PYTORCH_TESTING_DEVICE_ONLY_FOR_KEY, dtypes,
      get_device_type_test_bases, instantiate_device_type_tests, onlyCPU, onlyCUDA, onlyNativeDeviceTypes,
@@ -50,8 +55,38 @@ class TestTesting(TestCase):
             torch.set_float32_matmul_precision("high")
 
         set_tf32()
-        self.assertEqual(torch.get_float32_matmul_precision(), "highest")
         self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
+        self.assertEqual(torch.get_float32_matmul_precision(), "highest")
+
+    @onlyCPU
+    @parametrize("context_name", ("tf32_on", "tf32_enabled"))
+    @recover_orig_fp32_precision
+    def test_tf32_on_contexts_keep_precision_state_in_sync(self, context_name):
+        torch.set_float32_matmul_precision("highest")
+        context = tf32_on(self) if context_name == "tf32_on" else tf32_enabled()
+
+        with context:
+            self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
+            self.assertEqual(torch.get_float32_matmul_precision(), "high")
+            self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "tf32")
+
+        self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
+        self.assertEqual(torch.get_float32_matmul_precision(), "highest")
+        self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
+
+    @onlyCPU
+    @recover_orig_fp32_precision
+    def test_tf32_off_keeps_precision_state_in_sync(self):
+        torch.set_float32_matmul_precision("high")
+
+        with tf32_off():
+            self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
+            self.assertEqual(torch.get_float32_matmul_precision(), "highest")
+            self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "ieee")
+
+        self.assertTrue(torch.backends.cuda.matmul.allow_tf32)
+        self.assertEqual(torch.get_float32_matmul_precision(), "high")
+        self.assertEqual(torch.backends.cuda.matmul.fp32_precision, "tf32")
 
     # Ensure that assertEqual handles numpy arrays properly
     @dtypes(*all_types_and_complex_and(torch.bool, torch.half))

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -23,7 +23,7 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_utils import (
     IS_FBCODE, IS_JETSON, IS_MACOS, IS_SANDCASTLE, IS_WINDOWS, TestCase, run_tests, slowTest,
     parametrize, reparametrize, subtest, instantiate_parametrized_tests, dtype_name,
-    TEST_WITH_ROCM, decorateIf, skipIfXpu
+    TEST_WITH_ROCM, decorateIf, recover_orig_fp32_precision, skipIfXpu
 )
 from torch.testing._internal.common_cuda import has_device_side_assert
 from torch.testing._internal.common_device_type import \
@@ -40,6 +40,19 @@ import string
 
 # For testing TestCase methods and torch.testing functions
 class TestTesting(TestCase):
+    @onlyCPU
+    @recover_orig_fp32_precision
+    def test_recover_orig_fp32_precision_restores_legacy_state(self):
+        torch.set_float32_matmul_precision("highest")
+
+        @recover_orig_fp32_precision
+        def set_tf32():
+            torch.set_float32_matmul_precision("high")
+
+        set_tf32()
+        self.assertEqual(torch.get_float32_matmul_precision(), "highest")
+        self.assertFalse(torch.backends.cuda.matmul.allow_tf32)
+
     # Ensure that assertEqual handles numpy arrays properly
     @dtypes(*all_types_and_complex_and(torch.bool, torch.half))
     def test_assertEqual_numpy(self, device, dtype):

--- a/torch/_inductor/codegen/rocm/ck_template.py
+++ b/torch/_inductor/codegen/rocm/ck_template.py
@@ -34,7 +34,7 @@ class CKTemplate(ROCmTemplate):
         CK exposes this via {a,b}_compute_dtype on op (None == strict compute
         matching the element type). Some F32 instances ship with `TF32` here.
         """
-        if torch.backends.cuda.matmul.allow_tf32:
+        if torch.backends.cuda.matmul.fp32_precision == "tf32":
             return False
         return (
             getattr(op, "a_compute_dtype", None) == "TF32"

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -103,7 +103,7 @@ def _use_bmm_shared_a(mat1, mat2, layout) -> bool:
     return True
 
 
-def _bmm_shared_a_configs(dtype):
+def _bmm_shared_a_configs(dtype, device_type):
     """Hand-tuned config space for the shared-A template.
 
     BLOCK_Q batches share one A tile and are laid side by side in the dot, so
@@ -111,7 +111,12 @@ def _bmm_shared_a_configs(dtype):
     BLOCK_M x BLOCK_N x BLOCK_Q floats; the bound below keeps that in registers.
     """
     acc = acc_type(dtype)
-    allow_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
+    if device_type == "cuda":
+        allow_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
+    elif device_type == "xpu":
+        allow_tf32 = torch.backends.mkldnn.matmul.fp32_precision == "tf32"
+    else:
+        raise AssertionError(f"unsupported device type: {device_type}")
 
     for block_m, block_n, block_k, block_q, warps, stages in itertools.product(
         (64, 128), (32, 64), (32, 64), (2, 4, 8), (4, 8), (1, 2, 3)
@@ -322,7 +327,9 @@ def tuned_bmm(mat1, mat2, out_dtype=None, *, layout=None):
             n,
             k,
         )
-        for config in _bmm_shared_a_configs(mat1.get_dtype()):
+        for config in _bmm_shared_a_configs(
+            mat1.get_dtype(), mat1.get_device().type
+        ):
             bmm_shared_a_template.maybe_append_choice(
                 choices,
                 input_nodes=(mat1, mat2),

--- a/torch/_inductor/kernel/bmm.py
+++ b/torch/_inductor/kernel/bmm.py
@@ -111,7 +111,7 @@ def _bmm_shared_a_configs(dtype):
     BLOCK_M x BLOCK_N x BLOCK_Q floats; the bound below keeps that in registers.
     """
     acc = acc_type(dtype)
-    allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+    allow_tf32 = torch.backends.cuda.matmul.fp32_precision == "tf32"
 
     for block_m, block_n, block_k, block_q, warps, stages in itertools.product(
         (64, 128), (32, 64), (32, 64), (2, 4, 8), (4, 8), (1, 2, 3)

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -374,8 +374,34 @@ def initialize_cuda_context_rng():
 
 _tf32_off_lock = threading.Lock()
 _tf32_off_depth = 0
-_tf32_off_saved_precision = None
+_tf32_off_cublas_ctx = None
 _tf32_off_cudnn_ctx = None
+
+
+@contextlib.contextmanager
+def _tf32_cublas(enabled):
+    old_matmul_precision = torch.get_float32_matmul_precision()
+    # The legacy setter cannot reproduce exact per-backend values such as
+    # "none", so preserve those independently.
+    old_cuda_precision = torch.backends.cuda.matmul.fp32_precision
+    old_mkldnn_precision = torch.backends.mkldnn.matmul.fp32_precision
+    try:
+        if enabled:
+            if old_matmul_precision == "highest":
+                torch.set_float32_matmul_precision("high")
+                torch.backends.mkldnn.matmul.fp32_precision = old_mkldnn_precision
+            torch.backends.cuda.matmul.fp32_precision = "tf32"
+        elif old_matmul_precision == "highest":
+            torch.backends.cuda.matmul.fp32_precision = "ieee"
+        else:
+            torch.set_float32_matmul_precision("highest")
+        yield
+    finally:
+        # Restore the legacy value first because its setter overwrites both
+        # per-backend matmul precision values.
+        torch.set_float32_matmul_precision(old_matmul_precision)
+        torch.backends.cuda.matmul.fp32_precision = old_cuda_precision
+        torch.backends.mkldnn.matmul.fp32_precision = old_mkldnn_precision
 
 
 @contextlib.contextmanager
@@ -385,11 +411,11 @@ def tf32_off():
     # rank thread over the same process-global flags, so per-entry
     # save/restore can interleave and leak a modified state past the last
     # exit, which the TestCase fp32 precision leak detector then flags.
-    global _tf32_off_depth, _tf32_off_saved_precision, _tf32_off_cudnn_ctx
+    global _tf32_off_depth, _tf32_off_cublas_ctx, _tf32_off_cudnn_ctx
     with _tf32_off_lock:
         if _tf32_off_depth == 0:
-            _tf32_off_saved_precision = torch.backends.cuda.matmul.fp32_precision
-            torch.backends.cuda.matmul.fp32_precision = "ieee"
+            _tf32_off_cublas_ctx = _tf32_cublas(False)
+            _tf32_off_cublas_ctx.__enter__()
             _tf32_off_cudnn_ctx = torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=False)
             _tf32_off_cudnn_ctx.__enter__()
         _tf32_off_depth += 1
@@ -401,21 +427,21 @@ def tf32_off():
             if _tf32_off_depth == 0:
                 _tf32_off_cudnn_ctx.__exit__(None, None, None)
                 _tf32_off_cudnn_ctx = None
-                torch.backends.cuda.matmul.fp32_precision = _tf32_off_saved_precision
-                _tf32_off_saved_precision = None
+                _tf32_off_cublas_ctx.__exit__(None, None, None)
+                _tf32_off_cublas_ctx = None
 
 
 @contextlib.contextmanager
 def tf32_on(self, tf32_precision=1e-5):
-    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
     old_precision = self.precision
     try:
-        torch.backends.cuda.matmul.fp32_precision = "tf32"
         self.precision = tf32_precision
-        with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=True):
-            yield
+        with _tf32_cublas(True):
+            with torch.backends.cudnn.flags(
+                enabled=None, benchmark=None, deterministic=None, allow_tf32=True
+            ):
+                yield
     finally:
-        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
         self.precision = old_precision
 
 
@@ -425,15 +451,10 @@ def tf32_enabled():
     Context manager to temporarily enable TF32 for CUDA operations.
     Restores the previous TF32 state after exiting the context.
     """
-    old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
-    try:
-        torch.backends.cuda.matmul.fp32_precision = "tf32"
-        with torch.backends.cudnn.flags(
-            enabled=None, benchmark=None, deterministic=None, allow_tf32=True
-        ):
-            yield
-    finally:
-        torch.backends.cuda.matmul.fp32_precision = old_fp32_precision
+    with _tf32_cublas(True), torch.backends.cudnn.flags(
+        enabled=None, benchmark=None, deterministic=None, allow_tf32=True
+    ):
+        yield
 
 
 # This is a wrapper that wraps a test to run this test twice, one with

--- a/torch/testing/_internal/common_cuda.py
+++ b/torch/testing/_internal/common_cuda.py
@@ -388,11 +388,8 @@ def tf32_off():
     global _tf32_off_depth, _tf32_off_saved_precision, _tf32_off_cudnn_ctx
     with _tf32_off_lock:
         if _tf32_off_depth == 0:
-            # Snapshot fp32_precision (a string), not allow_tf32 (a bool):
-            # writing allow_tf32 back can't reproduce the "none" default (it
-            # yields "ieee"), which the leak detector would flag on ROCm.
             _tf32_off_saved_precision = torch.backends.cuda.matmul.fp32_precision
-            torch.backends.cuda.matmul.allow_tf32 = False
+            torch.backends.cuda.matmul.fp32_precision = "ieee"
             _tf32_off_cudnn_ctx = torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=False)
             _tf32_off_cudnn_ctx.__enter__()
         _tf32_off_depth += 1
@@ -413,7 +410,7 @@ def tf32_on(self, tf32_precision=1e-5):
     old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
     old_precision = self.precision
     try:
-        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cuda.matmul.fp32_precision = "tf32"
         self.precision = tf32_precision
         with torch.backends.cudnn.flags(enabled=None, benchmark=None, deterministic=None, allow_tf32=True):
             yield
@@ -430,7 +427,7 @@ def tf32_enabled():
     """
     old_fp32_precision = torch.backends.cuda.matmul.fp32_precision
     try:
-        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cuda.matmul.fp32_precision = "tf32"
         with torch.backends.cudnn.flags(
             enabled=None, benchmark=None, deterministic=None, allow_tf32=True
         ):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -4093,7 +4093,7 @@ class TestCase(expecttest.TestCase):
                 f"changed from {self._prev_torch_function_state} to {tf_state}"
             )
 
-        # Detect leaked mutations to the six fp32 precision flags. Tests that
+        # Detect leaked mutations to fp32 precision state. Tests that
         # legitimately mutate these globals must restore them themselves (e.g.
         # via recover_orig_fp32_precision or setUpClass/tearDownClass).
         # Escape hatch: PYTORCH_DISABLE_FP32_PRECISION_LEAK_CHECK=1 disables
@@ -4102,7 +4102,14 @@ class TestCase(expecttest.TestCase):
             hasattr(self, '_prev_fp32_precision')
             and os.environ.get('PYTORCH_DISABLE_FP32_PRECISION_LEAK_CHECK') != '1'
         ):
-            current = _snapshot_fp32_precision()
+            try:
+                current = _snapshot_fp32_precision()
+            except RuntimeError as exc:
+                _restore_fp32_precision(self._prev_fp32_precision)
+                raise AssertionError(
+                    "fp32 precision flag leak detected: legacy and new API "
+                    "state became inconsistent"
+                ) from exc
             if current != self._prev_fp32_precision:
                 _restore_fp32_precision(self._prev_fp32_precision)
                 specs = _fp32_precision_flag_specs()
@@ -6547,6 +6554,11 @@ def scoped_load_inline(func):
 # leak detector pick it up automatically.
 def _fp32_precision_flag_specs():
     return (
+        # This must be restored first because its setter also updates the CUDA
+        # and MKLDNN matmul precision values.
+        ("torch.get_float32_matmul_precision()",
+            torch.get_float32_matmul_precision,
+            torch.set_float32_matmul_precision),
         ("torch.backends.cuda.matmul.fp32_precision",
             lambda: torch.backends.cuda.matmul.fp32_precision,
             lambda v: setattr(torch.backends.cuda.matmul, "fp32_precision", v)),
@@ -6590,12 +6602,10 @@ def _restore_fp32_precision(snapshot):
 def recover_orig_fp32_precision(fn):
     @contextlib.contextmanager
     def recover():
-        old_matmul_precision = torch.get_float32_matmul_precision()
         snap = _snapshot_fp32_precision()
         try:
             yield
         finally:
-            torch.set_float32_matmul_precision(old_matmul_precision)
             _restore_fp32_precision(snap)
 
     return recover()(fn)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -6590,10 +6590,12 @@ def _restore_fp32_precision(snapshot):
 def recover_orig_fp32_precision(fn):
     @contextlib.contextmanager
     def recover():
+        old_matmul_precision = torch.get_float32_matmul_precision()
         snap = _snapshot_fp32_precision()
         try:
             yield
         finally:
+            torch.set_float32_matmul_precision(old_matmul_precision)
             _restore_fp32_precision(snap)
 
     return recover()(fn)


### PR DESCRIPTION
otherwise we see runtime errors for API deprecation e.g., 
```
torch._inductor.exc.InductorError: LoweringException: RuntimeError: PyTorch is checking whether allow_tf32_new is enabled for cuBlas matmul,Current status indicate that you have used mix of the legacy and new APIs to set the TF32 status for cublas matmul. We suggest only using the new API to set the TF32 flag. See also: https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices
```

authored with codex

cc @mruberry @zasdfgbnm @ptrblck @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo