### PR TITLE
Run the release runner-group reconcile in pytorch/pytorch

### DIFF
--- a/.github/workflows/release-runner-groups-refresh.yml
+++ b/.github/workflows/release-runner-groups-refresh.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-runner-groups-refresh
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name == 'workflow_dispatch' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-runner-groups-refresh.yml
+++ b/.github/workflows/release-runner-groups-refresh.yml
@@ -5,26 +5,48 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
       - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Apply changes (otherwise dry-run)"
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - .github/workflows/release-runner-groups-refresh.yml
 
 permissions:
   contents: read
 
+concurrency:
+  group: release-runner-groups-refresh
+  cancel-in-progress: true
+
 jobs:
-  dispatch:
+  reconcile:
     if: github.repository_owner == 'pytorch'
-    environment: pytorchbot-env
     runs-on: ubuntu-latest
+    environment: ${{ github.event_name != 'pull_request' && 'runner-group' || '' }}
     steps:
-      - name: Dispatch test-infra reconcile
+      - name: Checkout test-infra
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: pytorch/test-infra
+          ref: main
+          path: test-infra
+
+      - name: Install dependencies
+        run: python3 -m pip install requests==2.32.3 PyYAML==6.0.2
+
+      - name: Reconcile release runner groups
         env:
-          GH_TOKEN: ${{ secrets.GH_PYTORCHBOT_TOKEN }}
+          RUNNER_GROUP_TOKEN: ${{ secrets.RUNNER_GROUP_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          SHOULD_APPLY: ${{ github.event_name == 'push' || inputs.apply }}
         run: |
-          set -euo pipefail
-          gh workflow run release-manage-runner-groups.yml \
-            --repo pytorch/test-infra \
-            --ref main \
-            --field apply=true
-          echo "Dispatched runner-group reconcile for ${GITHUB_REF}." \
-            >> "${GITHUB_STEP_SUMMARY}"
-          echo "Runs: https://github.com/pytorch/test-infra/actions/workflows/release-manage-runner-groups.yml" \
-            >> "${GITHUB_STEP_SUMMARY}"
+          SCRIPT=test-infra/tools/scripts/release_manage_runner_groups.py
+          if [ "${SHOULD_APPLY}" = "true" ]; then
+            python3 "${SCRIPT}" --apply
+          else
+            python3 "${SCRIPT}"
+          fi


### PR DESCRIPTION
Replaces the cross-repo dispatch in `release-runner-groups-refresh.yml` with running the reconcile directly here, so an RC/GA tag push reconciles the release runner groups without needing any permission on pytorch/test-infra.

## Why the dispatch approach did not work

The workflow currently does `gh workflow run ... --repo pytorch/test-infra`, which fails on every tag:

```
could not create workflow dispatch event: HTTP 403: Must have admin rights to Repository.
```

`workflow_dispatch` requires **write** on the target repo, and `pytorchbot` has only `read` on pytorch/test-infra:

```
GET /repos/pytorch/test-infra/collaborators/pytorchbot/permission -> {"permission": "read"}
```

(GitHub's "admin rights" wording is misleading — the endpoint needs write.) No token scope fixes this, so the job has failed on v2.14.0-rc4 and would fail on every future tag.

## What this does instead

The job checks out test-infra and runs the existing script in place:

```yaml
- uses: actions/checkout@... 
  with:
    repository: pytorch/test-infra
    ref: main
    path: test-infra
...
    SCRIPT=test-infra/tools/scripts/release_manage_runner_groups.py
```

No code is copied. The script and `generate_binary_build_matrix.py` stay in test-infra as the single source of truth; only the trigger moves here, which is the part that has to live where the tags are pushed.

`import generate_binary_build_matrix as gbm` resolves without changes because invoking `python3 test-infra/tools/scripts/release_manage_runner_groups.py` puts that directory on `sys.path[0]`. Verified locally against test-infra main: `gbm.CURRENT_CANDIDATE_VERSION == "2.14.0"`.

## Guards

- `environment: ${{ github.event_name != 'pull_request' && 'runner-group' || '' }}` — the token is only selected for tag pushes and dispatches, mirroring the test-infra workflow's `main`-only guard. PRs get no environment, so `RUNNER_GROUP_TOKEN` is empty and the script runs discovery-only.
- `pull_request` on this file so changes to it are exercised as a dry-run.
- `SHOULD_APPLY` is true for tag pushes and for an explicit `apply=true` dispatch; everything else is a dry-run.
- `if: github.repository_owner == 'pytorch'` so forks never run it.

## Required before this can work

1. **Create a `runner-group` environment in pytorch/pytorch** holding `RUNNER_GROUP_TOKEN` (the same token the test-infra `runner-group` environment uses). pytorch/pytorch has no such environment today.
2. **Set its deployment tag policy to allow `v*` and `v*-rc*`** — otherwise a tag push cannot select the environment and the secret resolves empty, which would silently produce a dry-run instead of applying.

Until both are done this job is a no-op dry-run on tags, which is a safe failure mode.

## Note on the alternative

pytorch/test-infra#8510 adds an hourly cron to the test-infra workflow, which would also pick up new RC tags with no cross-repo permissions and no token relocation. This PR is the lower-latency option and is what was asked for; the two are mutually redundant, so if this lands, #8510 can be closed.