### PR TITLE
Fix _int_mm CPU corner case

### DIFF
--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -605,8 +605,12 @@ static void _mkldnn_gemm_i8i8i32_with_blas(
 
     TORCH_CHECK(
       status == dnnl::status::success,
-      "oneDNN i8i8i32 gemm failed with status ",
-      static_cast<int>(status));
+      "oneDNN i8i8i32 gemm failed, dnnl_status_t=", static_cast<int>(status),
+      ", transa=", transa, ", transb=", transb,
+      ", m=", m, ", n=", n, ", k=", k,
+      ", lda=", lda, ", ldb=", ldb, ", ldc=", ldc,
+      ", self sizes=", self.sizes(), " strides=", self.strides(),
+      ", mat2 sizes=", mat2.sizes(), " strides=", mat2.strides());
   }
 
 void mkldnn_matmul_i8i8i32(

--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
@@ -576,8 +576,8 @@ static void _mkldnn_gemm_i8i8i32_with_blas(
     const char transb = mat2.strides()[1] == 1 ? 'N' : 'T';
     const char offsetc = 'F';
 
-    const int lda = transa == 'T' ? self.stride(1) : self.stride(0);
-    const int ldb = transb == 'T' ? mat2.stride(1) : mat2.stride(0);
+    const int lda = transa == 'T' ? (k > 1 ? self.stride(1) : m) : (m > 1 ? self.stride(0) : k);
+    const int ldb = transb == 'T' ? (n > 1 ? mat2.stride(1) : k) : (k > 1 ? mat2.stride(0) : n);
     const int ldc = n;
 
     const float alpha = 1;
@@ -596,11 +596,17 @@ static void _mkldnn_gemm_i8i8i32_with_blas(
         beta,                                                 \
         static_cast<int32_t*>(result.data_ptr()), ldc, &co)
 
+    dnnl::status status;
     if (self.scalar_type() == at::kByte) { //uint8
-      CALL_DNNL_GEMM(dnnl::gemm_u8s8s32, uint8_t*, self.data_ptr());
+      status = CALL_DNNL_GEMM(dnnl::gemm_u8s8s32, uint8_t*, self.data_ptr());
     } else { //int8
-      CALL_DNNL_GEMM(dnnl::gemm_s8s8s32, int8_t*, self.data_ptr());
+      status = CALL_DNNL_GEMM(dnnl::gemm_s8s8s32, int8_t*, self.data_ptr());
     }
+
+    TORCH_CHECK(
+      status == dnnl::status::success,
+      "oneDNN i8i8i32 gemm failed with status ",
+      static_cast<int>(status));
   }
 
 void mkldnn_matmul_i8i8i32(

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -6978,6 +6978,31 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
         self.assertEqual(c_int32_result.float(), torch.mm(a_float, b_float))
 
     @onlyCPU
+    @parametrize("k", [16, 32])
+    @parametrize("n", [16, 32])
+    @parametrize("x_dtype", [torch.int8, torch.uint8])
+    def test__int_mm_cpu_size1_dim_stride(self, device, k, n, x_dtype):
+        # https://github.com/pytorch/pytorch/issues/195066
+        def genf(rows, cols, dtype):
+            info = torch.iinfo(dtype)
+            return torch.randint(
+                info.min, info.max, (rows, cols), dtype=dtype, device=device
+            )
+
+        def check(a, b):
+            ref = torch.mm(a.float(), b.float())
+            self.assertEqual(torch._int_mm(a, b).float(), ref)
+            out = a.new_full((a.size(0), b.size(1)), 42, dtype=torch.int32)
+            torch._int_mm(a, b, out=out)
+            self.assertEqual(out.float(), ref)
+
+        a, b = genf(1, k, x_dtype), genf(k, n, torch.int8)
+        for a_stride in ((0, 1), (1, 1)):
+            check(a.as_strided((1, k), a_stride), b)
+        # with a size-1 contraction dim it is the other stride that is arbitrary
+        check(genf(n, 1, x_dtype).as_strided((n, 1), (1, 0)), genf(1, n, torch.int8))
+
+    @onlyCPU
     @dtypes(torch.bfloat16, torch.float32, torch.float16)
     def test_grouped_mm_cpu_unaligned(self, device, dtype):
         m, n, k, n_groups = 16, 32, 64, 4


### PR DESCRIPTION
This is to fix https://github.com/pytorch/pytorch/issues/195066 _mkldnn_gemm_i8i8i32_with_blas took leading dimensions from the input strides, but the stride of a size-1 dim is arbitrary and inductor emits 0 for it in some cases. On the other hand, oneDNN's row-major gemm requires lda >= K so it will silently reject the call, causing accuracy failures in workloads like int8 quantized LLM decoding.

The PR fixes this corner case and also check this oneDNN gemm status so that exception can be raised. Authored with the assistance of Claude Code.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01