### PR TITLE
[CI] Add td-holdout to replay a PR's first commit without TD

### DIFF
--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -182,6 +182,12 @@ jobs:
           compiler: ${{ inputs.compiler }}
           cuda-version: ${{ inputs.cuda-version }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # The default treeless clone (--filter=tree:0) makes checking out a
+          # different commit fetch trees one round trip at a time -- tree
+          # discovery is recursive, so it cannot batch. That stalled for 8h in
+          # #194683. Blobless keeps trees local; only blobs lazy-load, and those
+          # do batch. Unchanged for every caller that does not pass a ref.
+          checkout-mode: ${{ inputs.ref != '' && 'blobless' || 'treeless' }}
 
       - name: Check if can use old whl build
         id: use-old-whl
@@ -236,17 +242,25 @@ jobs:
       # and the sources it compiles, should come from the target commit.
       - name: Check out target ref
         if: inputs.ref != ''
+        # A stalled checkout must not silently eat the job's 480min budget.
+        timeout-minutes: 30
         shell: bash
         env:
           TARGET_REF: ${{ inputs.ref }}
         run: |
           set -eux
-          git fetch --no-tags --force origin "${TARGET_REF}"
+          echo "::group::fetch ${TARGET_REF}"
+          git fetch --no-tags --force --progress origin "${TARGET_REF}"
+          echo "::endgroup::"
+          echo "::group::checkout"
           git checkout --force --detach "${TARGET_REF}"
+          echo "::endgroup::"
           # Pins move constantly (~55 bumps/60d), so C++ builds need these
           # resynced to the target or they compile against the wrong headers.
+          echo "::group::submodules"
           git submodule sync --recursive
           git submodule update --init --recursive --force
+          echo "::endgroup::"
           git rev-parse HEAD
 
       - name: Build

--- a/.github/workflows/_linux-build.yml
+++ b/.github/workflows/_linux-build.yml
@@ -131,6 +131,13 @@ on:
         type: string
         default: ""
         description: CUDA version to use for the OSDC build.
+      ref:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Git SHA to build instead of the ref the workflow was triggered on.
+          Used by td-holdout to rebuild a historical commit.
 
     secrets:
       HUGGING_FACE_HUB_TOKEN:
@@ -222,6 +229,26 @@ jobs:
           # The max duration enforced by the server side
           role-duration-seconds: 18000
 
+      # Deliberately last: everything above is CI harness that must reflect the
+      # current fleet and tooling, not the commit under test. map_ec2_to_arc.py
+      # in particular runs from the working tree, so swapping the ref earlier
+      # would route runners using a months-old label map. Only build.sh below,
+      # and the sources it compiles, should come from the target commit.
+      - name: Check out target ref
+        if: inputs.ref != ''
+        shell: bash
+        env:
+          TARGET_REF: ${{ inputs.ref }}
+        run: |
+          set -eux
+          git fetch --no-tags --force origin "${TARGET_REF}"
+          git checkout --force --detach "${TARGET_REF}"
+          # Pins move constantly (~55 bumps/60d), so C++ builds need these
+          # resynced to the target or they compile against the wrong headers.
+          git submodule sync --recursive
+          git submodule update --init --recursive --force
+          git rev-parse HEAD
+
       - name: Build
         if: (steps.filter.outputs.is-test-matrix-empty == 'False' || inputs.test-matrix == '') && steps.use-old-whl.outputs.reuse != 'true'
         id: build
@@ -229,7 +256,7 @@ jobs:
           BUILD_ENVIRONMENT: ${{ inputs.build-environment }}
           BRANCH: ${{ steps.setup-linux.outputs.branch }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          SHA1: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1
           SCCACHE_S3_NO_CREDENTIALS: ${{ steps.aws-creds.outcome != 'success' && 'true' || 'false' }}

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -165,18 +165,23 @@ jobs:
           cuda-version: ${{ inputs.cuda-version }}
           submodules: 'false'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # See _linux-build.yml: a treeless clone stalls `git checkout <sha>`
+          # on recursive tree discovery (#194683). Unchanged without a ref.
+          checkout-mode: ${{ inputs.ref != '' && 'blobless' || 'treeless' }}
 
       # Must match the ref the build job used, or the test scripts and the built
       # wheel come from different commits.
       - name: Check out target ref
         if: inputs.ref != ''
+        timeout-minutes: 30
         shell: bash
         env:
           TARGET_REF: ${{ inputs.ref }}
         run: |
           set -eux
-          git fetch --no-tags --force origin "${TARGET_REF}"
+          git fetch --no-tags --force --progress origin "${TARGET_REF}"
           git checkout --force --detach "${TARGET_REF}"
+          git rev-parse HEAD
 
       - name: Configure AWS credentials
         id: aws-creds

--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -105,6 +105,21 @@ on:
         required: false
         type: string
         default: ""
+      ref:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Git SHA to test instead of the ref the workflow was triggered on.
+          Used by td-holdout to test a historical commit.
+      no-td:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          Force NO_TD=1. Callers that exist to measure the unfiltered suite
+          should set this rather than relying on run_test.py's enable-td gate
+          happening to be false for them.
     secrets:
       HUGGING_FACE_HUB_TOKEN:
         required: false
@@ -150,6 +165,18 @@ jobs:
           cuda-version: ${{ inputs.cuda-version }}
           submodules: 'false'
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Must match the ref the build job used, or the test scripts and the built
+      # wheel come from different commits.
+      - name: Check out target ref
+        if: inputs.ref != ''
+        shell: bash
+        env:
+          TARGET_REF: ${{ inputs.ref }}
+        run: |
+          set -eux
+          git fetch --no-tags --force origin "${TARGET_REF}"
+          git checkout --force --detach "${TARGET_REF}"
 
       - name: Configure AWS credentials
         id: aws-creds
@@ -274,7 +301,7 @@ jobs:
           JOB_ID: ${{ steps.setup-linux.outputs.job-id }}
           JOB_NAME: ${{ steps.setup-linux.outputs.job-name }}
           BRANCH: ${{ steps.setup-linux.outputs.branch }}
-          SHA1: ${{ github.event.pull_request.head.sha || github.sha }}
+          SHA1: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
           TEST_CONFIG: ${{ matrix.config }}
           SHARD_NUMBER: ${{ matrix.shard }}
@@ -286,7 +313,7 @@ jobs:
           VERBOSE_TEST_LOGS: ${{ steps.keep-going.outputs.ci-verbose-test-logs }}
           TEST_SHOWLOCALS: ${{ steps.keep-going.outputs.ci-test-showlocals }}
           NO_TEST_TIMEOUT: ${{ steps.keep-going.outputs.ci-no-test-timeout }}
-          NO_TD: ${{ steps.keep-going.outputs.ci-no-td }}
+          NO_TD: ${{ inputs.no-td && '1' || steps.keep-going.outputs.ci-no-td }}
           TD_DISTRIBUTED: ${{ steps.keep-going.outputs.ci-td-distributed }}
           SCCACHE_BUCKET: ossci-compiler-cache-circleci-v2
           SCCACHE_REGION: us-east-1

--- a/.github/workflows/td-holdout.yml
+++ b/.github/workflows/td-holdout.yml
@@ -1,0 +1,181 @@
+# Owner(s): ["module: ci"]
+#
+# Replays a PR's first commit with target determination off.
+#
+# TD only ever reports on the tests it chose to run, so its own misses are
+# invisible in normal CI. Rebuilding the first commit of a PR -- before the
+# author iterated, and before TD's PreviouslyFailedInPR heuristic has any
+# history to feed on -- and running the full suite gives the unfiltered result
+# TD would have been graded against.
+#
+# Results land in ClickHouse through the usual path: `td-holdout` is registered
+# in upload-test-stats.yml, and `run-name` carries the PR number into
+# workflow_run.display_title so runs are joinable back to their source PR.
+name: td-holdout
+
+run-name: td-holdout-prototype pr-${{ inputs.pr-number }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "PR whose first commit to replay"
+        required: true
+        type: string
+      selected-test-configs:
+        description: "Narrow the matrix, e.g. 'default'. Empty runs pull's full matrix."
+        required: false
+        type: string
+        default: ""
+      tests-to-include:
+        description: "Narrow to these test files, e.g. 'test_autograd'. Empty runs everything."
+        required: false
+        type: string
+        default: ""
+
+  # ─── TEMPORARY: DELETE BEFORE MERGE ──────────────────────────────────────
+  # workflow_dispatch resolves only against the default branch, so this file
+  # cannot be exercised until it lands. A pull_request trigger runs the PR's
+  # own copy, including the local-path _linux-build/_linux-test changes.
+  # Scoped to this one path so it cannot fire on unrelated PRs.
+  pull_request:
+    paths:
+      - .github/workflows/td-holdout.yml
+  # ─────────────────────────────────────────────────────────────────────────
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr-number || github.event.pull_request.number }}
+  # Holdout runs are the product, so never cancel one. PR test runs are throwaway.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  get-label-type:
+    name: get-label-type
+    uses: pytorch/pytorch/.github/workflows/_runner-determinator.yml@main
+    if: github.repository_owner == 'pytorch'
+    with:
+      triggering_actor: ${{ github.triggering_actor }}
+      issue_owner: ${{ github.event.pull_request.user.login || github.event.issue.user.login }}
+      curr_branch: ${{ github.head_ref || github.ref_name }}
+      curr_ref_type: ${{ github.ref_type }}
+
+  resolve:
+    name: resolve pr-${{ inputs.pr-number }}
+    if: github.repository_owner == 'pytorch'
+    runs-on: ubuntu-24.04
+    outputs:
+      sha: ${{ steps.first-commit.outputs.sha }}
+      ci-docker-hash: ${{ steps.first-commit.outputs.ci-docker-hash }}
+    steps:
+      - name: Find the PR's first commit
+        id: first-commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+          # TEMPORARY: inputs are empty on pull_request, so pin a target here to
+          # exercise the workflow from the PR. DELETE BEFORE MERGE.
+          #
+          # Chosen as a positive control: this commit edits TensorImpl.cpp and
+          # AutogradComposite.cpp, and 4 of its third_party pins differ from
+          # main -- so it exercises the C++ build and the submodule resync, not
+          # just the dispatch path. It has known deterministic failures (see
+          # tests-to-include below), so a green run means the ref swap silently
+          # built the wrong tree.
+          PINNED_SHA: "57fa17402dc01448d9ab593cb69f1d14779602ad"
+        run: |
+          set -euo pipefail
+          if [ -z "${PR_NUMBER}" ]; then
+            PR_NUMBER="(pinned)"
+            SHA="${PINNED_SHA}"
+          else
+            # Commits come back oldest-first, so [0] is the bottom of the branch.
+            SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/commits" --jq '.[0].sha')
+          fi
+          # Docker tags are the .ci/docker tree hash, so an old commit needs the
+          # image that was current when it was written. Same value as
+          # `git rev-parse ${SHA}:.ci/docker`, without cloning.
+          CI_TREE=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees/${SHA}" --jq '.tree[]|select(.path==".ci")|.sha')
+          HASH=$(gh api "repos/${GITHUB_REPOSITORY}/git/trees/${CI_TREE}" --jq '.tree[]|select(.path=="docker")|.sha')
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "ci-docker-hash=${HASH}" >> "$GITHUB_OUTPUT"
+          echo "PR #${PR_NUMBER} first commit: \`${SHA}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # Matrix is copied verbatim from pull.yml's linux-jammy-py3.10-gcc11 build.
+  # TD filters every one of these configs in pull, so a holdout that runs only
+  # `default` would leave most of what TD drops unmeasured. Keep the two in sync.
+  build:
+    name: linux-jammy-py3.10-gcc11
+    uses: ./.github/workflows/_linux-build.yml
+    needs: [resolve, get-label-type]
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      ci-docker-hash: ${{ needs.resolve.outputs.ci-docker-hash }}
+      # TEMPORARY: 'default' on PR runs trims 24 jobs to 10. DELETE BEFORE MERGE.
+      selected-test-configs: ${{ inputs.selected-test-configs || (github.event_name == 'pull_request' && 'default' || '') }}
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-py3.10-gcc11
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang21
+      test-matrix: |
+        { include: [
+          { config: "default", shard: 1, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 2, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 3, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 4, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 5, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 6, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 7, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 8, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 9, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "default", shard: 10, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.4xlarge" },
+          { config: "docs_test", shard: 1, num_shards: 1,  runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+          { config: "jit_legacy", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+          { config: "backwards_compat", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
+          # Use m7i instead of m7a to match the existing (Intel Xeon) numerics. DTensor crossref tests like linalg.multi_dot have tight
+          # float32 tolerances sensitive to different FMA/reduction order across CPU vendors.
+          { config: "distributed", shard: 1, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 2, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 3, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 4, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 5, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 6, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 7, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "distributed", shard: 8, num_shards: 8, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge.amx" },
+          { config: "numpy_2_x", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.c7i.2xlarge" },
+          { config: "libtorch_agnostic_targetting", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+          { config: "openreg", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+        ]}
+      python-version: "3.10"
+      compiler: gcc11
+      # Not a correctness call -- the graft would be sound, since it only fires
+      # for Python-only diffs. It simply can never hit: reuse_old_whl.py looks
+      # for runs of *this* workflow on main at the merge base, and td-holdout is
+      # dispatch-only. Leaving it on would just cost a doomed lookup, and the
+      # build is under 2% of a run anyway.
+      allow-reuse-old-whl: false
+    secrets: inherit
+
+  test:
+    name: linux-jammy-py3.10-gcc11
+    uses: ./.github/workflows/_linux-test.yml
+    needs: [build, resolve]
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      # Redundant today -- run_test.py's gate already fails on both the missing
+      # PR number and the workflow name. Set anyway: "no TD" is the entire point
+      # of this job, so it should not depend on what the workflow is called.
+      no-td: true
+      build-environment: ${{ needs.build.outputs.build-environment }}
+      docker-image: ${{ needs.build.outputs.docker-image }}
+      test-matrix: ${{ needs.build.outputs.test-matrix }}
+      # TEMPORARY: the two files that PINNED_SHA is known to break, so the PR
+      # run is both cheap and a positive control. Expect red. DELETE BEFORE MERGE.
+      tests-to-include: ${{ inputs.tests-to-include || (github.event_name == 'pull_request' && 'dynamo/test_subclasses dynamo/test_repros' || '') }}
+      tests-to-exclude: "inductor/test_torchinductor_opinfo"
+      python-version: "3.10"
+      compiler: gcc11
+    secrets: inherit

--- a/.github/workflows/upload-test-stats.yml
+++ b/.github/workflows/upload-test-stats.yml
@@ -31,6 +31,7 @@ on:
       - inductor-perf-nightly-rocm-mi300
       - inductor-perf-nightly-rocm-mi350
       - mac-mps
+      - td-holdout
     types:
       - completed
 


### PR DESCRIPTION
Dispatch-only workflow that rebuilds the first commit of a given PR and runs pull's full linux-jammy-py3.10-gcc11 matrix with TD disabled, to measure what TD drops. Adds a 'ref' input to the reusable linux build and test workflows (no-op when empty) and registers td-holdout for test-stats upload so results reach ClickHouse.

Includes a temporary pull_request trigger for validation; see PR body.