### PR TITLE
[CI] Add sm80 to the clang20 CUDA pull builds' arch list

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -475,6 +475,7 @@ jobs:
       build-environment: linux-jammy-cuda13.0-cudnn9-py3.10-clang20
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.0-cudnn9-py3.10-clang20
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      cuda-arch-list: '7.5 8.0'
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1 },
@@ -500,6 +501,7 @@ jobs:
       build-environment: linux-jammy-cuda13.2-cudnn9-py3.10-clang20
       docker-image-name: ci-image:pytorch-linux-jammy-cuda13.2-cudnn9-py3.10-clang20
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      cuda-arch-list: '7.5 8.0'
       test-matrix: |
         { include: [
           { config: "default", shard: 1, num_shards: 1 },


### PR DESCRIPTION
The two `linux-jammy-cuda13.{0,2}-cudnn9-py3.10-clang20` build jobs never set `cuda-arch-list`, so they inherit `_linux-build.yml`'s default of `7.5`. Since #194502 disables `USE_FLASH_ATTENTION` when no resolved arch reaches sm80, they lost the SYSTEM marking that `caffe2/CMakeLists.txt` puts on `third_party/cutlass/include`, and clang-20 started promoting `-Wunused-function` in cutlass headers to errors.

Requesting `8.0` restores the SYSTEM include; `7.5` stays so these builds still cover Turing.

Related: #194645 also touches how the cutlass include dirs are marked.

Authored with assistance from Claude (Claude Code).
