### PR TITLE
[Inductor] stabilize mutation handling during Triton autotuning

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -2227,6 +2227,82 @@ class ComboKernelCompileTimeAutotuneTests(TestCase):
                 counters["inductor"]["combo_subkernel_autotune_fallback"], 0
             )
 
+    @requires_cuda_and_triton
+    def test_compile_time_autotune_mutation_policy_is_stable(self):
+        from torch._inductor.runtime.triton_heuristics import CachingAutotuner
+
+        def fn(a, b, c, d):
+            a.add_(1)
+            b.sigmoid_()
+            c = c + 5
+            d.tanh_()
+            return a, b, c, d
+
+        inputs = [
+            torch.randn(1 << 12, device=GPU_TYPE),
+            torch.randn(1 << 13, device=GPU_TYPE),
+            torch.randn(128, device=GPU_TYPE),
+            torch.randn(1 << 11, device=GPU_TYPE),
+        ]
+        expected = fn(*(x.clone() for x in inputs))
+        actual_inputs = tuple(x.clone() for x in inputs)
+        policies = {}
+        copy_calls = {}
+        available_memory = 0
+        original = CachingAutotuner.copy_args_to_cpu_if_needed
+
+        def record_policy(autotuner, *args, **kwargs):
+            nonlocal available_memory
+            copy_calls[autotuner] = copy_calls.get(autotuner, 0) + 1
+            available_memory = 0 if copy_calls[autotuner] % 2 else 1 << 40
+            copies = original(autotuner, *args, **kwargs)
+            if autotuner.mutated_arg_names and not autotuner.inductor_meta.get(
+                "combo_grid_meta"
+            ):
+                policies.setdefault(autotuner, set()).add(frozenset(copies))
+            return copies
+
+        def max_memory_allocated(*args, **kwargs):
+            return available_memory
+
+        counters.clear()
+        with (
+            fresh_cache(),
+            torch._inductor.config.patch(
+                {
+                    "compile_threads": 1,
+                    "fx_graph_cache": False,
+                    "fx_graph_remote_cache": False,
+                    "autotune_remote_cache": False,
+                    "bundled_autotune_remote_cache": False,
+                }
+            ),
+            patch.object(
+                CachingAutotuner,
+                "copy_args_to_cpu_if_needed",
+                record_policy,
+            ),
+            patch.object(
+                torch.accelerator,
+                "max_memory_allocated",
+                max_memory_allocated,
+            ),
+            patch.object(torch.accelerator, "memory_allocated", return_value=0),
+        ):
+            actual, code = run_and_get_code(torch.compile(fn), *actual_inputs)
+
+        self.assertEqual(actual, expected)
+        self.assertIn("SequentialFlattenComboKernelGrid", " ".join(code))
+        self.assertGreater(counters["inductor"]["combo_subkernel_autotune"], 0)
+        self.assertEqual(counters["inductor"]["combo_subkernel_autotune_fallback"], 0)
+        multi_config_policies = [
+            values for key, values in policies.items() if copy_calls[key] > 1
+        ]
+        self.assertGreater(len(multi_config_policies), 0)
+        self.assertTrue(any(next(iter(values)) for values in multi_config_policies))
+        for values in multi_config_policies:
+            self.assertEqual(len(values), 1)
+
     @requires_gpu_and_triton
     def test_compile_time_autotune_looped_reduction(self):
         # rnumel above the persistent threshold but below the split-reduction

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -831,6 +831,84 @@ class TestArgumentCloneAndRestore(TestCase):
             out = out[:, 1:]
         return out
 
+    def test_benchmark_mutation_policy_is_stable_and_snapshots_are_fresh(self):
+        autotuner = object.__new__(CachingAutotuner)
+        autotuner.optimize_mem = False
+        policy = frozenset({"in_ptr0"})
+        snapshots = [{"in_ptr0": object()}, {"in_ptr0": object()}]
+        autotuner._get_args_to_copy_to_cpu = MagicMock(return_value=policy)
+        autotuner._copy_args_to_cpu = MagicMock(side_effect=snapshots)
+        arg = object()
+
+        with autotuner._mutation_benchmarking():
+            first = autotuner.copy_args_to_cpu_if_needed(arg)
+            second = autotuner.copy_args_to_cpu_if_needed(arg)
+
+        autotuner._get_args_to_copy_to_cpu.assert_called_once_with(arg)
+        self.assertEqual(autotuner._copy_args_to_cpu.call_count, 2)
+        for call in autotuner._copy_args_to_cpu.call_args_list:
+            self.assertIs(call.args[0], policy)
+        self.assertIs(first, snapshots[0])
+        self.assertIs(second, snapshots[1])
+
+    def test_run_reuses_mutation_policy_across_tuning_phases(self):
+        autotuner = object.__new__(CachingAutotuner)
+        autotuner._cached_launcher = None
+        autotuner._cache_eligible = False
+        autotuner._plugins = []
+        autotuner.compile_id = None
+        autotuner.is_backward = False
+        autotuner.optimize_mem = False
+        autotuner.triton_interpret = False
+        autotuner.triton_meta = {}
+        autotuner.inductor_meta = {
+            "combo_tuning_groups": [object()],
+            "coordinate_descent_tuning": True,
+        }
+
+        winner = MagicMock(store_cubin=False)
+        winner.cache_hash = "winner"
+        winner.config = types.SimpleNamespace()
+        winner.return_value = "result"
+        autotuner.launchers = [MagicMock(), MagicMock()]
+
+        policy = frozenset({"in_ptr0"})
+        autotuner._get_args_to_copy_to_cpu = MagicMock(return_value=policy)
+        autotuner._copy_args_to_cpu = MagicMock(return_value={})
+
+        def autotune_to_one_config(*args, **kwargs):
+            autotuner.copy_args_to_cpu_if_needed(*args, **kwargs)
+            autotuner.launchers = [winner]
+
+        def tune_combo(launcher, *args, **kwargs):
+            autotuner.copy_args_to_cpu_if_needed(*args, **kwargs)
+            return launcher
+
+        def coordinate_descent(launcher, *args, **kwargs):
+            autotuner.copy_args_to_cpu_if_needed(*args, **kwargs)
+            return launcher
+
+        autotuner.autotune_to_one_config = MagicMock(side_effect=autotune_to_one_config)
+        autotuner._combo_sequential_autotune = MagicMock(side_effect=tune_combo)
+        autotuner.coordinate_descent_tuning = MagicMock(side_effect=coordinate_descent)
+        autotuner._pre_launch = MagicMock()
+        autotuner._post_launch = MagicMock()
+        arg = object()
+
+        with patch(
+            "torch._inductor.runtime.triton_heuristics.TritonBundler.put_winner"
+        ):
+            result = autotuner.run(arg, stream=0)
+
+        self.assertEqual(result, "result")
+        autotuner.autotune_to_one_config.assert_called_once_with(arg)
+        autotuner._combo_sequential_autotune.assert_called_once_with(winner, arg)
+        autotuner.coordinate_descent_tuning.assert_called_once_with(winner, arg)
+        autotuner._get_args_to_copy_to_cpu.assert_called_once_with(arg)
+        self.assertEqual(autotuner._copy_args_to_cpu.call_count, 3)
+        for call in autotuner._copy_args_to_cpu.call_args_list:
+            self.assertIs(call.args[0], policy)
+
     def _do_test(self, gpu_tensor):
         torch.get_device_module(GPU_TYPE).reset_peak_memory_stats()
         autotuner = self._create_caching_autotuner()

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -19,6 +19,8 @@ import sys
 import threading
 import time
 from collections import namedtuple
+from contextlib import contextmanager, nullcontext
+from contextvars import ContextVar
 from typing import (
     Any,
     cast,
@@ -541,6 +543,19 @@ def _resolve_load_device(device: int | None, device_type: str) -> int | None:
     from torch._dynamo.device_interface import get_interface_for_device
 
     return get_interface_for_device(device_type.replace("hip", "cuda")).current_device()
+
+
+@dataclasses.dataclass
+class _MutationBenchmarkContext:
+    """Mutation restoration policy for one nested autotuning transaction."""
+
+    autotuner: CachingAutotuner
+    cpu_copy_arg_names: OrderedSet[str] | None = None
+
+
+_mutation_benchmark_context: ContextVar[_MutationBenchmarkContext | None] = ContextVar(
+    "_mutation_benchmark_context", default=None
+)
 
 
 class CachingAutotuner(KernelInterface):
@@ -1577,61 +1592,98 @@ class CachingAutotuner(KernelInterface):
             )
         return result
 
-    def copy_args_to_cpu_if_needed(self, *args, **kwargs):
+    @contextmanager
+    def _mutation_benchmarking(self):
+        """Reuse the restore policy while taking a fresh snapshot per benchmark."""
+        active = _mutation_benchmark_context.get()
+        if active is not None and active.autotuner is self:
+            yield
+            return
+
+        token = _mutation_benchmark_context.set(_MutationBenchmarkContext(self))
+        try:
+            yield
+        finally:
+            _mutation_benchmark_context.reset(token)
+
+    def _get_args_to_copy_to_cpu(self, *args, **kwargs) -> OrderedSet[str]:
         """
-        To support benchmarking in the presence of mutated args, we need to avoid
-        autotuning contaminating them. We try to pass cloned args to the kernel.
-        If those clones would increase the peak memory usage, however, we instead
-        copy to cpu and restore them after each iteration. Figure out the args
-        to be copied and do the copying.
+        Choose which mutated args should be restored from CPU during benchmarking.
+        Args not selected here are cloned on the accelerator instead.
         """
         if not self.optimize_mem:
-            return {}
+            return OrderedSet()
 
-        copies = {}
         try:
             if torch.accelerator.current_accelerator() is None:
                 # No initialized accelerator; skip memory-optimized path
-                return {}
+                return OrderedSet()
             budget = (
                 torch.accelerator.max_memory_allocated()
                 - torch.accelerator.memory_allocated()
             )
         except RuntimeError:
             # Possibly a custom CUDA allocator, see https://github.com/pytorch/pytorch/issues/163257
-            return {}
+            return OrderedSet()
+
+        names: OrderedSet[str] = OrderedSet()
+
+        def maybe_select(name, arg):
+            nonlocal budget
+            if name not in self.mutated_arg_names:
+                return
+            if not isinstance(arg, torch.Tensor):
+                raise AssertionError(
+                    f"Expected torch.Tensor for mutated arg, got {type(arg)}"
+                )
+            if arg.device.type not in ("cuda", "xpu"):
+                return
+            required_storage_length = compute_required_storage_length(
+                arg.size(),
+                arg.stride(),
+                0,
+            )
+            size = required_storage_length * arg.element_size()
+            if size > budget:
+                names.add(name)
+            else:
+                budget -= size
+
+        for name, arg in zip(self.fn.arg_names, args):
+            maybe_select(name, arg)
+
+        for name, arg in kwargs.items():
+            maybe_select(name, arg)
+
+        return names
+
+    def _copy_args_to_cpu(self, names: Container[str], *args, **kwargs):
+        copies = {}
 
         def maybe_copy(name, arg):
-            if name in self.mutated_arg_names and arg.device.type in (
-                "cuda",
-                "xpu",
-            ):
-                nonlocal budget
-                if not isinstance(arg, torch.Tensor):
-                    raise AssertionError(
-                        f"Expected torch.Tensor for mutated arg, got {type(arg)}"
-                    )
-                required_storage_length = compute_required_storage_length(
-                    arg.size(),
-                    arg.stride(),
-                    0,
+            if name not in names:
+                return
+            if not isinstance(arg, torch.Tensor):
+                raise AssertionError(
+                    f"Expected torch.Tensor for mutated arg, got {type(arg)}"
                 )
-                size = required_storage_length * arg.element_size()
-                if size > budget:
-                    cpu_arg = torch.empty_strided(
-                        (required_storage_length,),
-                        (1,),
-                        dtype=arg.dtype,
-                        device="cpu",
-                        pin_memory=True,
-                    )
-                    cpu_arg.copy_(
-                        arg.as_strided((required_storage_length,), (1,)),
-                        non_blocking=True,
-                    )
-                    copies[name] = (arg, cpu_arg)
-                else:
-                    budget -= size
+            required_storage_length = compute_required_storage_length(
+                arg.size(),
+                arg.stride(),
+                0,
+            )
+            cpu_arg = torch.empty_strided(
+                (required_storage_length,),
+                (1,),
+                dtype=arg.dtype,
+                device="cpu",
+                pin_memory=True,
+            )
+            cpu_arg.copy_(
+                arg.as_strided((required_storage_length,), (1,)),
+                non_blocking=True,
+            )
+            copies[name] = (arg, cpu_arg)
 
         for name, arg in zip(self.fn.arg_names, args):
             maybe_copy(name, arg)
@@ -1640,6 +1692,19 @@ class CachingAutotuner(KernelInterface):
             maybe_copy(name, arg)
 
         return copies
+
+    def copy_args_to_cpu_if_needed(self, *args, **kwargs):
+        """Copy mutated args selected for CPU restoration during benchmarking."""
+        context = _mutation_benchmark_context.get()
+        if context is not None and context.autotuner is self:
+            if context.cpu_copy_arg_names is None:
+                context.cpu_copy_arg_names = self._get_args_to_copy_to_cpu(
+                    *args, **kwargs
+                )
+            names = context.cpu_copy_arg_names
+        else:
+            names = self._get_args_to_copy_to_cpu(*args, **kwargs)
+        return self._copy_args_to_cpu(names, *args, **kwargs)
 
     def restore_args_from_cpu(self, cpu_copies):
         for pair in cpu_copies.values():
@@ -1813,6 +1878,7 @@ class CachingAutotuner(KernelInterface):
 
     def benchmark_all_configs(self, *args, **kwargs):
         with (
+            self._mutation_benchmarking(),
             dynamo_timed(
                 "CachingAutotuner.benchmark_all_configs",
                 log_pt2_compile_event=True,
@@ -2306,16 +2372,19 @@ class CachingAutotuner(KernelInterface):
         if not self._should_coordesc_tune:
             return launcher
 
-        with dynamo_timed(
-            "CachingAutotuner.coordinate_descent_tuning",
-            # These generate too many pt2_compile_event logs:
-            log_pt2_compile_event=False,
-            metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
-            dynamo_compile_column_us="runtime_triton_autotune_time_us",
-            compile_id=self.compile_id,
-            is_backward=self.is_backward,
-            log_waitcounter=True,
-            waitcounter_name_override="triton_autotuner",
+        with (
+            self._mutation_benchmarking(),
+            dynamo_timed(
+                "CachingAutotuner.coordinate_descent_tuning",
+                # These generate too many pt2_compile_event logs:
+                log_pt2_compile_event=False,
+                metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
+                dynamo_compile_column_us="runtime_triton_autotune_time_us",
+                compile_id=self.compile_id,
+                is_backward=self.is_backward,
+                log_waitcounter=True,
+                waitcounter_name_override="triton_autotuner",
+            ),
         ):
             return self._coordinate_descent_tuning(launcher, *args, **kwargs)
 
@@ -2498,46 +2567,66 @@ class CachingAutotuner(KernelInterface):
             ) is not DEFER:
                 return result
 
-        if len(self.launchers) != 1:
-            if len(self.launchers) == 0:
-                start_time = time.time_ns()
-                self.precompile()
-                self.precompile_time_taken_ns = time.time_ns() - start_time
-            if len(self.launchers) > 1:
-                for plugin in self._plugins:
-                    if (
-                        result := plugin.pre_autotune(
-                            self, *args, stream=stream, **kwargs
-                        )
-                    ) is not DEFER:
-                        return result
-                # Re-check: a plugin may have mutated launchers down to one.
+        config = self.launchers[0].config if len(self.launchers) == 1 else None
+        needs_mutation_benchmarking = (
+            len(self.launchers) != 1
+            or (
+                bool(self.inductor_meta.get("combo_tuning_groups"))
+                and not getattr(config, "found_by_combo_autotune", False)
+            )
+            or (
+                bool(self.inductor_meta.get("coordinate_descent_tuning", False))
+                and not getattr(config, "found_by_coordesc", False)
+            )
+        )
+        mutation_benchmarking = (
+            self._mutation_benchmarking()
+            if needs_mutation_benchmarking
+            else nullcontext()
+        )
+        with mutation_benchmarking:
+            if len(self.launchers) != 1:
+                if len(self.launchers) == 0:
+                    start_time = time.time_ns()
+                    self.precompile()
+                    self.precompile_time_taken_ns = time.time_ns() - start_time
                 if len(self.launchers) > 1:
-                    self.autotune_to_one_config(*args, **kwargs)
+                    for plugin in self._plugins:
+                        if (
+                            result := plugin.pre_autotune(
+                                self, *args, stream=stream, **kwargs
+                            )
+                        ) is not DEFER:
+                            return result
+                    # Re-check: a plugin may have mutated launchers down to one.
+                    if len(self.launchers) > 1:
+                        self.autotune_to_one_config(*args, **kwargs)
 
-        if self.inductor_meta.get("combo_tuning_groups") and not getattr(
-            self.launchers[0].config, "found_by_combo_autotune", False
-        ):
-            with dynamo_timed(
-                "CachingAutotuner.combo_sequential_autotune",
-                log_pt2_compile_event=False,
-                metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
-                dynamo_compile_column_us="runtime_triton_autotune_time_us",
-                compile_id=self.compile_id,
-                is_backward=self.is_backward,
-                log_waitcounter=True,
-                waitcounter_name_override="triton_autotuner",
+            if self.inductor_meta.get("combo_tuning_groups") and not getattr(
+                self.launchers[0].config, "found_by_combo_autotune", False
             ):
-                self.launchers = [
-                    self._combo_sequential_autotune(self.launchers[0], *args, **kwargs)
-                ]
+                with dynamo_timed(
+                    "CachingAutotuner.combo_sequential_autotune",
+                    log_pt2_compile_event=False,
+                    metadata={"kernel_name": self.inductor_meta.get("kernel_name")},
+                    dynamo_compile_column_us="runtime_triton_autotune_time_us",
+                    compile_id=self.compile_id,
+                    is_backward=self.is_backward,
+                    log_waitcounter=True,
+                    waitcounter_name_override="triton_autotuner",
+                ):
+                    self.launchers = [
+                        self._combo_sequential_autotune(
+                            self.launchers[0], *args, **kwargs
+                        )
+                    ]
 
-        if not getattr(
-            self.launchers[0].config, "found_by_coordesc", False
-        ) and self.inductor_meta.get("coordinate_descent_tuning", False):
-            self.launchers = [
-                self.coordinate_descent_tuning(self.launchers[0], *args, **kwargs)
-            ]
+            if not getattr(
+                self.launchers[0].config, "found_by_coordesc", False
+            ) and self.inductor_meta.get("coordinate_descent_tuning", False):
+                self.launchers = [
+                    self.coordinate_descent_tuning(self.launchers[0], *args, **kwargs)
+                ]
 
         (launcher,) = self.launchers
         # Ensure the final launcher is marked as a winner for bundle filtering.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194686

## Summary

Triton autotuning protects mutated arguments by either cloning them on the
accelerator or restoring them from CPU. This choice was recalculated for every
candidate using:

```python
max_memory_allocated() - memory_allocated()
```

Benchmark allocations can increase the recorded peak while current allocation
returns to its previous value. Consequently, later candidates can observe more
apparent headroom and use a different mutation-preservation strategy.

This change:

- selects the restoration policy once per autotuning transaction;
- shares it across initial, combo-sequential, and coordinate-descent tuning;
- creates fresh CPU snapshots for every benchmark;
- preserves existing CachingAutotuner override points and method signatures.


This fixes inconsistent mutation handling between candidates in the shared
CachingAutotuner path.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo