### PR TITLE
[XPU][Inductor] Revert eager fallback for max_pool2d_backward

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -1179,12 +1179,6 @@ def assertGeneratedKernelCountEqual(self: TestCase, expected: int):
     self.assertEqual(torch._inductor.metrics.generated_kernel_count, expected)
 
 
-def assertGeneratedKernelCountGreater(self: TestCase, expected: int):
-    if config.triton.multi_kernel:
-        return
-    self.assertGreater(torch._inductor.metrics.generated_kernel_count, expected)
-
-
 class SweepInputs2:
     input_gen_types1 = [
         "dense",
@@ -13036,9 +13030,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         )
         # Note: Kernel count varies by backend (CUDA ~3, ROCm ~2) due to fusion.
         # Correctness is validated by self.common() above.
-        # XPU: decomposition falls back to native kernel, so no inductor kernels generated
-        if self.device != "xpu":
-            self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
+        self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
 
     def test_max_pool2d_with_indices_backward5(self):
         # Large window size - decomposition handles via scatter_add
@@ -13102,35 +13094,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         # MPS: decomposition falls back to native kernel, so no inductor kernels generated
         if self.device != "mps" and self.device != "xpu":
             self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
-
-    def test_max_pool2d_with_indices_backward_fallback(self):
-        def fn(a, b, c):
-            return aten.max_pool2d_with_indices_backward(
-                a, b, [2, 2], [2, 2], [0, 0], [1, 1], False, c
-            )
-
-        torch._inductor.metrics.generated_kernel_count = 0
-        x = torch.randn([2, 4, 18, 14])
-        result, indices = aten.max_pool2d_with_indices(
-            x,
-            [2, 2],
-            [2, 2],
-            [0, 0],
-            [1, 1],
-            False,
-        )
-        self.common(
-            fn,
-            [
-                torch.randn_like(result),
-                x,
-                indices,
-            ],
-        )
-        if self.device == "xpu":
-            assertGeneratedKernelCountEqual(self, 0)
-        else:
-            assertGeneratedKernelCountGreater(self, 0)
 
     def test_issue102546(self):
         def fn(x):

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -227,15 +227,8 @@ test_failures = {
     "test_adaptive_max_pool2d2_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     # XPU falls back max_pool2d_with_indices_backward to ATen eager (see
     # torch/_decomp/decompositions.py), so no Triton kernel is generated.
-    "test_max_pool2d_with_indices_backward_dynamic_shapes": TestFailure(("xpu",)),
-    "test_max_pool2d_with_indices_backward2_dynamic_shapes": TestFailure(("xpu",)),
-    "test_max_pool2d_with_indices_backward3_dynamic_shapes": TestFailure(("xpu",)),
-    "test_max_pool2d_with_indices_backward4_dynamic_shapes": TestFailure(("xpu",)),
     "test_max_pool2d_with_indices_backward5_dynamic_shapes": TestFailure(("xpu",)),
     "test_max_pool2d_with_indices_backward6_dynamic_shapes": TestFailure(("xpu",)),
-    "test_max_pool2d_with_indices_backward_fallback_dynamic_shapes": TestFailure(
-        ("xpu",)
-    ),
     "test_argmax_to_float_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_avg_pool2d7_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_avg_pool2d_backward4_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -6019,11 +6019,6 @@ fallback_max_pool2d_with_indices_backward = fallback_handler(
 def max_pool2d_with_indices_backward(
     grad_output, x, kernel_size, stride, padding, dilation, ceil_mode, indices
 ):
-    if x.get_device().type == "xpu":
-        return fallback_max_pool2d_with_indices_backward(
-            grad_output, x, kernel_size, stride, padding, dilation, ceil_mode, indices
-        )
-
     if padding == 0:
         padding = [0, 0]
     if dilation == 1:


### PR DESCRIPTION
This PR reverts #187940.

#187940 changed the behavior of max_pool2d_backward on XPU to fall back to the eager implementation instead of being decomposed and lowered to a Triton kernel.

However, with the recent Inductor improvements, the Inductor-generated implementation now outperforms the eager fallback. Therefore, keeping this fallback is no longer beneficial and instead causes a performance regression in workloads such as VGG16  training.

VGG16 training on Intel Client GPU: ~1.2x speedup
VGG16 training on Intel Data Center GPU: ~1.1x speedup

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey