### PR TITLE
Add per-operator headers to XPU sources

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -917,6 +917,10 @@ if(USE_CUDA)
   list(APPEND ATen_CUDA_DEPENDENCY_LIBS ATEN_CUDA_FILES_GEN_LIB)
 endif()
 
+if(USE_XPU)
+  list(APPEND ATen_XPU_DEPENDENCY_LIBS ATEN_XPU_FILES_GEN_LIB)
+endif()
+
 if(USE_MPS)
     include(../../../cmake/Metal.cmake)
 

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -1,5 +1,4 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/WrapDimUtilsMulti.h>
 #include <ATen/native/LinearAlgebraUtils.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNN.h>

--- a/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Blas.cpp
@@ -16,7 +16,13 @@
 #include <ATen/ops/baddbmm_native.h>
 #include <ATen/ops/bmm_native.h>
 #include <ATen/ops/empty.h>
+#include <ATen/ops/gelu.h>
 #include <ATen/ops/mm_native.h>
+#include <ATen/ops/mul.h>
+#include <ATen/ops/ones.h>
+#include <ATen/ops/relu.h>
+#include <ATen/ops/scalar_tensor_native.h>
+#include <ATen/ops/tensordot.h>
 #endif
 
 namespace at::native {

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -1,16 +1,11 @@
 #include <vector>
 
 #include <ATen/core/ATen_fwd.h>
-#include <ATen/core/interned_strings.h>
-#include <ATen/native/ConvUtils.h>
 #include <ATen/native/mkldnn/xpu/Conv.h>
 #include <ATen/native/mkldnn/xpu/FusionUtils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNN.h>
 #include <ATen/native/utils/ParamUtils.h>
 #include <ATen/ops/empty.h>
-#include <ATen/ops/full.h>
-#include <ATen/ops/neg.h>
-#include <c10/core/Scalar.h>
 #include <c10/util/Exception.h>
 #include <torch/library.h>
 #include <optional>

--- a/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/Conv.cpp
@@ -7,6 +7,7 @@
 #include <ATen/native/mkldnn/xpu/FusionUtils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNN.h>
 #include <ATen/native/utils/ParamUtils.h>
+#include <ATen/ops/empty.h>
 #include <ATen/ops/full.h>
 #include <ATen/ops/neg.h>
 #include <c10/core/Scalar.h>

--- a/aten/src/ATen/native/mkldnn/xpu/RNN.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/RNN.cpp
@@ -7,7 +7,6 @@
 #include <ATen/ops/empty.h>
 #include <ATen/ops/stack.h>
 #include <ATen/ops/zeros.h>
-#include <c10/core/Scalar.h>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_sycl.hpp>
 

--- a/aten/src/ATen/native/mkldnn/xpu/RNN.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/RNN.cpp
@@ -1,7 +1,13 @@
-#include <ATen/ATen.h>
+#include <ATen/TensorOperators.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/native/RNN.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
+#include <ATen/ops/cat.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/stack.h>
+#include <ATen/ops/zeros.h>
+#include <c10/core/Scalar.h>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_sycl.hpp>
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -2,6 +2,9 @@
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNN.h>
+#include <ATen/ops/ones.h>
+#include <ATen/ops/scalar_tensor.h>
+#include <ATen/ops/where.h>
 #include <oneapi/dnnl/dnnl.hpp>
 
 namespace {

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
+#include <c10/core/Scalar.h>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_types.h>
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attr.h
@@ -3,6 +3,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
+#include <ATen/ops/dequantize.h>
 #include <c10/core/Scalar.h>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_types.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -1,9 +1,11 @@
 #include <c10/xpu/XPUFunctions.h>
 
-#include <ATen/ATen.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/core/grad_mode.h>
+#include <ATen/ops/empty.h>
 #include <ATen/record_function.h>
 #include <c10/core/MemoryFormat.h>
+#include <c10/core/Scalar.h>
 
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Conv.cpp
@@ -1,11 +1,6 @@
-#include <c10/xpu/XPUFunctions.h>
 
 #include <ATen/core/Tensor.h>
-#include <ATen/core/grad_mode.h>
 #include <ATen/ops/empty.h>
-#include <ATen/record_function.h>
-#include <c10/core/MemoryFormat.h>
-#include <c10/core/Scalar.h>
 
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -1,4 +1,6 @@
-#include <ATen/ATen.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/empty.h>
+#include <c10/core/Scalar.h>
 #include <c10/xpu/XPUFunctions.h>
 
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Deconv.cpp
@@ -1,7 +1,5 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/ops/empty.h>
-#include <c10/core/Scalar.h>
-#include <c10/xpu/XPUFunctions.h>
 
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/DnnlExt.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/DnnlExt.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <ATen/ATen.h>
+#include <ATen/core/Tensor.h>
+#include <c10/core/Scalar.h>
 
 #include <ATen/native/mkldnn/xpu/detail/LRUCache.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -1,11 +1,8 @@
 
-#include <c10/xpu/XPUFunctions.h>
 
 #include <ATen/ExpandUtils.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/ops/empty.h>
-#include <ATen/record_function.h>
-#include <c10/core/Scalar.h>
 
 #include <Attr.h>
 #include <Utils.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Matmul.cpp
@@ -1,8 +1,11 @@
 
 #include <c10/xpu/XPUFunctions.h>
 
-#include <ATen/ATen.h>
+#include <ATen/ExpandUtils.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/ops/empty.h>
 #include <ATen/record_function.h>
+#include <c10/core/Scalar.h>
 
 #include <Attr.h>
 #include <Utils.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/QMatmul.cpp
@@ -1,4 +1,5 @@
 #include <ATen/BlasBackend.h>
+#include <ATen/ExpandUtils.h>
 #include <ATen/Tensor.h>
 #include <ATen/ceil_div.h>
 #include <ATen/core/Tensor.h>

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -1,4 +1,5 @@
 #include <ATen/Context.h>
+#include <ATen/ExpandUtils.h>
 #include <ATen/native/ConvUtils.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <ATen/ATen.h>
 #include <ATen/Tensor.h>
 #include <ATen/core/Tensor.h>
+#include <c10/core/Scalar.h>
 #include <iostream>
 #include <optional>
 
@@ -14,6 +14,7 @@
 #include <oneapi/dnnl/dnnl_version.h>
 
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
+#include <ATen/ops/empty.h>
 
 #define ONEDNN_SUPPORT_DETERMINISTIC \
   (DNNL_VERSION_MAJOR >= 3 && DNNL_VERSION_MINOR >= 4)

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <ATen/ATen.h>
 #include <ATen/BlasBackend.h>
+#include <ATen/core/Tensor.h>
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
+#include <c10/core/Scalar.h>
 
 namespace at::native::onednn {
 


### PR DESCRIPTION
AT_PER_OPERATOR_HEADERS was already configured for XPU in cmake/Codegen.cmake
but never actually linked in, so native/mkldnn/xpu always compiled with the
full ATen umbrella headers. This links it in and fixes the fallout (a few
missing includes, a few files pulling in `<ATen/ATen.h>` unconditionally).

Drafted with AI assistance (Claude Code); reviewed and tested by me before
opening.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01