### PR TITLE
[TEST] Refactor fsdp optim_state and multiple_wrapping with hw_classification

### DIFF
--- a/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
+++ b/test/distributed/fsdp/test_fsdp_multiple_wrapping.py
@@ -9,7 +9,11 @@ from torch.optim import SGD
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_fsdp import FSDPTestContinuous, get_devtype
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 
 
 device_type = torch.device(get_devtype())
@@ -35,6 +39,8 @@ class InnerModel(Module):
 
 
 class TestMultipleWrapping(FSDPTestContinuous):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @skip_if_lt_x_gpu(2)
     def test_multiple_wrapping(self, device):
         """

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -37,6 +37,7 @@ from torch.testing._internal.common_fsdp import (
     TransformerWithSharedParams,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
@@ -322,6 +323,8 @@ class TestDummyModel(torch.nn.Module):
 
 
 class TestFSDPOptimState(FSDPTest):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._model_class = {


### PR DESCRIPTION
## Summary

Apply hardware classification following [#186918](https://github.com/pytorch/pytorch/pull/186918) guidelines across two FSDP test files.

**`test/distributed/fsdp/test_fsdp_optim_state.py`**
- **TestFSDPOptimState**: `ACCELERATOR` — FSDP optimizer state management tests, uses multi-device distributed setup

**`test/distributed/fsdp/test_fsdp_multiple_wrapping.py`**
- **TestMultipleWrapping**: `ACCELERATOR` — FSDP multiple wrapping tests, uses multi-device distributed setup

No structural changes — annotation only.

cc @mansiag05 @RiyaP2508

## Test Plan
```
lintrunner -a test/distributed/fsdp/test_fsdp_optim_state.py
test/distributed/fsdp/test_fsdp_multiple_wrapping.py

ok No lint issues.
python test/distributed/fsdp/test_fsdp_optim_state.py -v python test/distributed/fsdp/test_fsdp_optim_state.py --hw-classification ACCELERATOR -v

python test/distributed/fsdp/test_fsdp_multiple_wrapping.py -v python test/distributed/fsdp/test_fsdp_multiple_wrapping.py --hw-classification ACCELERATOR -v
```
Authored with an AI assistant.