### PR TITLE
Fix the version gate on the free-threaded profiler warning

### DIFF
--- a/torch/csrc/autograd/profiler_python.cpp
+++ b/torch/csrc/autograd/profiler_python.cpp
@@ -1033,7 +1033,7 @@ PythonTracer::PythonTracer(torch::profiler::impl::RecordQueue* queue)
     return;
   }
 
-#if defined(Py_GIL_DISABLED) && !defined(IS_PYTHON_3_14_PLUS)
+#if defined(Py_GIL_DISABLED) && !IS_PYTHON_3_14_PLUS
   TORCH_WARN(
       "The PyTorch profiler is not thread-safe on Python 3.13t. "
       "Please use Python 3.14t or later.");


### PR DESCRIPTION
> IS_PYTHON_3_14_PLUS is always defined (as `PY_VERSION_HEX >= 0x030E0000`), so `!defined(IS_PYTHON_3_14_PLUS)` was always false and the warning never fired on 3.13t. Introduced in #178551, which almost certainly meant to check the macro's boolean value, not whether it's defined. Fix uses the macro's value instead.
>
> Test plan: compiled a probe with the guard against free-threaded 3.14 headers; old form is unreachable on every version, new form is reachable only when pinned to a 3.13 `PY_VERSION_HEX`.
