### PR TITLE
[inductor] AOTI cpp wrapper: pass a missing Optional[Device]/list/tuple as nullopt in the StableIValue path (#194700)

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17833,10 +17833,28 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         _, codes = run_fw_bw_and_get_code(lambda: opt_fn(x))
         self.assertEqual(len(codes), 2)
 
-    @unittest.skipIf(
-        config.cpp_wrapper,
-        "codegen triton_kernel_wrapper_functional is not implemented for cpp wrapper",
-    )
+    def test_lite_mode_cpp_wrapper_optional_device_arg(self):
+        # Lite mode makes `aten::zeros_like` (a `Device? device=None` op with no
+        # c-shim) a StableIValue-path fallback: the shortest repro for the missing
+        # optional being emitted as the uncompilable `from(nullptr, 0)`.
+        if self.device != GPU_TYPE:
+            raise unittest.SkipTest("requires GPU")
+
+        def f(x):
+            return torch.zeros_like(x) + x
+
+        x = torch.randn(64, device=self.device)
+
+        with config.patch(cpp_wrapper=True):
+            opt_f = torch.compile(f, mode="lite")
+            result, code = run_and_get_code(opt_f, x)
+
+        self.assertEqual(result, f(x))
+        # The optional device must be passed as nullopt, not as a (pointer, index)
+        # pair spliced into a single conversion.
+        self.assertIn("aten::zeros_like", code[0])
+        self.assertNotIn("from(nullptr, 0)", code[0])
+
     def test_lite_triton_kernel_wrapper_functional(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")
@@ -18032,11 +18050,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             FileCheck().check("torch.ops.aten.add").run(code[0])
 
     @requires_gpu_and_triton
-    @unittest.skipIf(
-        config.cpp_wrapper,
-        "lite mode + user-defined Triton kernel is not supported by the cpp wrapper "
-        "(same reason as test_lite_triton_kernel_wrapper_functional above)",
-    )
     def test_lite_mode_triton_kernel_no_clone(self):
         # The decomposition emits "clone(s) + the mutation node" and relies on
         # reinplacing to mark the unnecessary clones; lite mode used to skip
@@ -18056,15 +18069,19 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         result, code = run_and_get_code(opt_f, x, y)
         self.assertEqual(result, f(x, y))
 
-        # Anchor: the kernel really made it into the generated code, so the no-clone
-        # assertion below cannot pass vacuously.
-        self.assertIn("add_kernel", code[0])
+        # Anchor so the no-clone assertion cannot pass vacuously. Under the cpp
+        # wrapper the bare name also appears in the embedded Triton source, so match
+        # the generated launch wrapper `call_<kernel>` instead.
+        self.assertIn(
+            "call_add_kernel" if config.cpp_wrapper else "add_kernel", code[0]
+        )
         # The buffer the kernel writes is allocated immediately before the call and
         # never read beforehand, so reinplacing must drop it from `tensors_to_clone`
-        # and the decomposition must emit no copy at all.
-        self.assertNotIn(
-            "aoti_torch_clone" if config.cpp_wrapper else "aten.clone", code[0]
-        )
+        # and the decomposition must emit no copy at all. Under the cpp wrapper the
+        # needle is `aten::clone` (aten.clone has no c-shim, so it goes through
+        # aoti_torch_call_dispatcher), not `aoti_torch_clone`, which is only emitted
+        # for constant buffers and so would pass even if a clone were generated.
+        self.assertNotIn("aten::clone" if config.cpp_wrapper else "aten.clone", code[0])
 
     @lowering.force_fallback(aten.sort.default)
     def test_size_asserts_for_multi_output_fallback(self):

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3698,8 +3698,26 @@ if (!custom_op_wrapper) {
                     # from<std::optional> handle any internal pointers.
                     codegen_arg = codegen_arg.removeprefix("&")
 
-                    if codegen_arg == "nullptr":
+                    # val_to_arg_str spells a missing Optional[Device]/List/Tuple as
+                    # the c-shim's two-token "nullptr, 0" rather than a bare nullptr;
+                    # both mean nullopt here, and there is no two-argument `from`.
+                    if codegen_arg in ("nullptr", "nullptr, 0"):
                         return "torch::stable::detail::from(std::nullopt)"
+
+                    element_type = arg_type.getElementType()
+                    if isinstance(
+                        element_type,
+                        (torch.DeviceObjType, torch.ListType, torch.TupleType),
+                    ):
+                        # A *present* value is two tokens too, which this path cannot
+                        # pack into one StableIValue yet; fail here rather than emit
+                        # C++ that will not compile.
+                        raise NotImplementedError(
+                            "aoti_torch_call_dispatcher: a non-null "
+                            f"Optional[{element_type}] argument is not yet supported "
+                            "by the StableIValue fallback path "
+                            f"(codegen produced {codegen_arg!r})"
+                        )
 
                     var_name = f"tmp_var_{next(tmp_var_number)}"
                     dispatch_lines.writeline(


### PR DESCRIPTION
Summary:

A fallback op with a `Device? device=None` argument produced C++ that does not compile
when it went through the StableIValue dispatcher (`aoti_torch_call_dispatcher`, used for
ops that have no c-shim):

```
main.cpp:211:33: error: no matching function for call to 'from'
  211 | std::optional tmp_var_1{torch::stable::detail::from(nullptr, 0)};
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  note: candidate template ignored: requires single argument 'val', but 2 were provided
```

Root cause is a mismatch between two conventions inside `CppWrapperCpu`:

* `val_to_arg_str` renders a *missing* `Optional[Device]`, `Optional[List]` and
  `Optional[Tuple]` as the c-shim's TWO-token form `"nullptr, 0"` -- a
  (pointer, length) / (type, index) pair -- rather than a bare `"nullptr"`. Every other
  optional renders as one token.
* `parse_arg`, inside `generate_fallback_kernel_with_runtime_lookup_nopython`, detects a
  missing optional by exact string comparison against `"nullptr"`. `"nullptr, 0"` misses
  that check, falls through to the generic path, and both tokens get spliced into one
  `from(...)` call. There is no two-argument `from`.

The StableIValue path does not need the aux token at all -- a list's length travels inside
the value -- so both spellings simply mean `std::nullopt` here.

Fix: accept `"nullptr, 0"` alongside `"nullptr"`.

A *present* value of those three types is rendered as two tokens too
(`"&temporary_reference(arr), 3"`, `"&var_1, 0"`), and this path still cannot pack that
into a single StableIValue. That case now raises `NotImplementedError` from Python naming
the argument type, instead of silently emitting C++ that fails to compile several minutes
later in the build. Supporting it is separate work.

Who hits this: any fallback op with a missing optional device/list/tuple that lacks a
c-shim. `aten::zeros_like` (`Device? device=None`) is the shortest example, and inductor
lite mode makes it a fallback, so lite mode + the cpp wrapper hit it immediately.

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
New `test_lite_mode_cpp_wrapper_optional_device_arg` in test_torchinductor.py. Verified to
be a real regression test, not a smoke test -- run on GPU with and without the code change:

```
buck2 test @//mode/opt -c fbcode.enable_gpu_sections=true \
  fbcode//caffe2/test/inductor:test_inductor_cuda -- \
  --regex 'test_lite_mode_cpp_wrapper_optional_device_arg'

with this fix     => Pass 2. Fail 0.
fix reverted      => Fail 1, with exactly
                     main.cpp:110:33: error: no matching function for call to 'from'
                       std::optional tmp_var_1{torch::stable::detail::from(nullptr, 0)};
```

Also re-enables `test_lite_triton_kernel_wrapper_functional` under the cpp wrapper by
dropping its `unittest.skipIf(config.cpp_wrapper, ...)`. Being precise about this one: it
passes with AND without the code change above, i.e. that skip was simply stale rather than
blocked on this bug. It is re-enabled here because it is the lite-mode Triton cpp-wrapper
test and it now runs clean.

Also re-enables `test_lite_mode_triton_kernel_no_clone` under the cpp wrapper. That test
comes from D115158279, which this diff now sits directly on top of, and its
`unittest.skipIf(config.cpp_wrapper, ...)` is the one skip that genuinely depended on
this fix: its `f` calls `torch.zeros_like`, so under the cpp wrapper it hit exactly the
`from(nullptr, 0)` compile error above. Its skip message blamed "lite mode +
user-defined Triton kernel ... same reason as test_lite_triton_kernel_wrapper_functional
above" -- both halves of that were wrong. The user Triton kernel is a bystander, and that
neighbour's skip was stale.

Two of its assertions are corrected at the same time. Without this, re-enabling the test
would produce something green under the cpp wrapper that checks nothing:

* `assertNotIn("aoti_torch_clone", ...)` -> `assertNotIn("aten::clone", ...)`. This is the
  load-bearing assertion. `aten.clone` has no entry in `inductor_fallback_ops`, so in lite
  mode it becomes a FallbackKernel emitting `aoti_torch_call_dispatcher("aten::clone",
  ...)`. `aoti_torch_clone` is only ever emitted for returning constant buffers, so the old
  needle would have passed even if a clone *were* generated.
* `assertIn("add_kernel", ...)` -> `assertIn("call_add_kernel", ...)` under the cpp
  wrapper. The bare name also occurs inside the embedded Triton source string, making it a
  weak anchor there; `call_<kernel>` is the generated launch wrapper and is the only
  spelling that means the kernel was actually called.

Full runs, all on real GPU:

```
# every lite_ test, cpp wrapper
buck2 test @//mode/opt -c fbcode.enable_gpu_sections=true \
  fbcode//caffe2/test/inductor:test_inductor_cuda -- --regex 'lite_' \
  --env TORCHINDUCTOR_CPP_WRAPPER=1
=> Pass 10. Fail 0. Skip 2.

# every lite_ test, default python wrapper (no regression)
buck2 test @//mode/opt -c fbcode.enable_gpu_sections=true \
  fbcode//caffe2/test/inductor:test_inductor_cuda -- --regex 'lite_'
=> Pass 12. Fail 0. Skip 0.

# the AOTI suites that share this codegen path
buck2 test @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor -- \
  --regex 'proxy_executor|triton_kernel|lite_'
=> Pass 136. Fail 0. Skip 165.
```

`lintrunner` clean on both changed files.

Status of the GPU runs quoted above: they were made on 2026-08-23 against the standalone
version of this diff (on master, no descendants). THIS version differs -- it is rebased
into the stack on top of D115158279 and adds the test re-enable described above -- and
those runs have not been repeated, because `:test_inductor_cuda` currently cannot even be
listed from this devserver: the target is pinned to `gpu-remote-execution` / `H100`, so
`--local-only` is rejected outright, and the inplace par it ships has an unmaterialized
`#link-tree`, so the RE worker fails to bootstrap it (exit 127, `_bootstrap.sh: No such
file or directory`). Sandcastle CI on this version is therefore the authority for the two
corrected assertions.

NOT re-enabled, deliberately: `test_lite_mode_item` keeps its
`unittest.skipIf(config.cpp_wrapper, "lite-mode _to_copy fallback unsupported under
cpp_wrapper")`. With this fix it now gets past codegen and fails only on its own
python-wrapper-specific assertion (`Expected to find ".item()"`), so making it
wrapper-aware is a separate change rather than something this diff should smuggle in.

Authored with an AI assistant.

Reviewed By: jijunyan

Differential Revision: D117143922




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo