### PR TITLE
[CI] Install torchvision for the torchtitan integration tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2239,6 +2239,9 @@ test_executorch() {
 test_torchtitan() {
   install_torchao
   install_torchcomms
+  # muse_glimmer and kimi_k2_7 import torchvision at model-build time. Build it
+  # from the pinned commit rather than PyPI so it links the CI-built torch.
+  install_torchvision
 
   local torchtitan_commit
   torchtitan_commit=$(get_pinned_commit torchtitan)


### PR DESCRIPTION
The torchtitan model integration job has been failing for every PR, not just
one. Two of the three failing flavors die at model-build time:

    muse_glimmer_mm_fsdp+tp+sp    ModuleNotFoundError: No module named 'torchvision'
    kimi_k2_5_muon_pp+fsdp+ep     ModuleNotFoundError: No module named 'torchvision'

test_torchtitan installs torchao, torchcomms and helion, but not torchvision,
and torchtitan's muse_glimmer and kimi_k2_7 models import it while building.
Use the existing install_torchvision helper, which builds from the pinned
vision commit against the CI-built torch rather than pulling a PyPI wheel that
would drag in its own torch -- the same reason the function already guards
against helion and torchtitan overwriting the CI-built packages.

The third failing flavor, qwen3_5_fsdp+tp+varlen_attn+per_op_sac, is a separate
problem and is not addressed here: it needs flash_attn_interface (FA3), which
torchtitan's own tests/integration_tests/features.py already notes "the core
integration CI does not install", and the job runs on A10G (sm86) where FA3 is
unavailable regardless. That belongs in torchtitan.

Test Plan:

Reproduced against the pinned torchtitan commit
(87eca1ac050e88143bbd61e0f123ed976c4e67c9) on 4 GPUs. With torchvision present,
both flavors that fail in CI pass:

```
muse_glimmer_debugmodel_mm_fsdp2_tp2       exit=0 PASS
kimi_k2_5_debugmodel_muon_fsdp2_pp2_ep2    exit=0 PASS
```

Without it they reproduce the CI failure exactly.

Authored with assistance from Claude Code (Anthropic).
