### PR TITLE
[inductor] AOTI cpp wrapper: support invoke_subgraph (#194703)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -362,6 +362,34 @@ class AOTInductorTestsTemplate:
                 model, example_inputs, "AOTInductorModelRunMinimalArrayrefInterface(", 1
             )
 
+    def test_invoke_subgraph_nested_region(self):
+        # Two call sites, so the region is not single-use: it has to be emitted twice
+        # and each copy scoped, and it survives inlining on its own merits rather than
+        # only because of the config patch below.
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.cos(gn(x * 2)) + gn(x * 3)
+
+        with torch._dynamo.config.patch(
+            enable_invoke_subgraph_regional_compile=True,
+            inline_single_use_invoke_subgraph=False,
+        ):
+
+            @torch.compiler.nested_compile_region
+            def gn(x):
+                return torch.sin(x) + 1
+
+            example_inputs = (torch.randn(8, 8, device=self.device),)
+            model = Model()
+            # check_model covers the round trip including dlopen; the FileCheck pins
+            # that the region reached codegen_invoke_subgraph, which a correctness-only
+            # assertion would keep passing without.
+            self.check_model(model, example_inputs)
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile, model, example_inputs
+            )
+            FileCheck().check_count("// subgraph: ", 2).run(code)
+
     @common_utils.parametrize("embed_kernel_binary", [False, True])
     def test_loaded_modules_tracking(self, embed_kernel_binary):
         # Verify that AOTI codegen on CUDA/HIP passes &kernels_.loaded_modules_

--- a/test/inductor/test_control_flow.py
+++ b/test/inductor/test_control_flow.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: inductor"]
 
+import functools
 import itertools
 import unittest
 import uuid
@@ -2717,6 +2718,58 @@ instantiate_parametrized_tests(AssociativeScanTests)
 instantiate_parametrized_tests(ScanTests)
 instantiate_parametrized_tests(MapTests)
 instantiate_parametrized_tests(SwitchTests)
+
+
+# CondTests cases that fail under the cpp wrapper: both declare an unbacked SymInt
+# inside a branch, which the inlined C++ does not bind correctly.
+_CPP_WRAPPER_XFAIL = frozenset(
+    f"test_cond_unbacked_symint_inner{variant}_device_{device}"
+    for variant in ("", "_to_outer")
+    for device in ("cpu", GPU_TYPE)
+)
+
+
+# Re-runs a control-flow suite under config.cpp_wrapper=True; these HOPs reach
+# CppWrapperCpu.codegen_subgraph, which the default python wrapper never exercises.
+# WhileLoopTests and ScanTests are not re-run yet: a branch subgraph declares its
+# buffers in the parent's C++ scope, so two branches reusing a name collide
+# (`redefinition of 'true_graph_0_bufN'`), and while_loop_stack_output is NYI here.
+class _CppWrapperMixin:
+    def setUp(self):
+        super().setUp()
+        patcher = torch._inductor.config.patch(cpp_wrapper=True)
+        patcher.__enter__()
+        self.addCleanup(patcher.__exit__, None, None, None)
+
+
+class CondTestsCppWrapper(_CppWrapperMixin, CondTests):
+    pass
+
+
+class AssociativeScanTestsCppWrapper(_CppWrapperMixin, AssociativeScanTests):
+    pass
+
+
+class MapTestsCppWrapper(_CppWrapperMixin, MapTests):
+    pass
+
+
+class SwitchTestsCppWrapper(_CppWrapperMixin, SwitchTests):
+    pass
+
+
+# instantiate_parametrized_tests expanded CondTests in place, so the subclass inherits
+# concrete methods. Rebind each through a fresh function before marking it:
+# unittest.expectedFailure mutates and returns its argument, so marking the inherited
+# method would mark CondTests' own copy too.
+for _name in _CPP_WRAPPER_XFAIL:
+    _inherited = getattr(CondTests, _name)
+
+    @functools.wraps(_inherited)
+    def _xfail(self, _inherited=_inherited):
+        return _inherited(self)
+
+    setattr(CondTestsCppWrapper, _name, unittest.expectedFailure(_xfail))
 
 
 if __name__ == "__main__":

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17895,10 +17895,6 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         _, codes = run_fw_bw_and_get_code(lambda: opt_fn(x))
         self.assertEqual(len(codes), 2)
 
-    @unittest.skipIf(
-        config.cpp_wrapper,
-        "codegen invoke_subgraph is not implemented for cpp wrapper",
-    )
     def test_lite_regional_compile_invoke_subgraph(self):
         # Checks that get_attr nodes custom metadata is propagated
         @torch.compiler.nested_compile_region

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -2930,9 +2930,36 @@ class CppWrapperCpu(PythonWrapperCodegen):
         return output_names
 
     def codegen_invoke_subgraph(self, invoke_subgraph):
-        raise NotImplementedError(
-            "codegen invoke_subgraph is not implemented for cpp wrapper"
-        )
+        """Emit ABI-compatible C++ for an invoke_subgraph (nested compile region).
+
+        Same shape as codegen_switch / codegen_while_loop: pre-declare an owning
+        handle per output, then inline the region body via codegen_subgraph.
+        """
+        outer_inputs = [buf.codegen_reference() for buf in invoke_subgraph.inputs]
+
+        outer_outputs = []
+        for out in invoke_subgraph.outputs:
+            if isinstance(out, (ir.ShapeAsConstantBuffer, ir.NoneAsConstantBuffer)):
+                # codegen_subgraph_suffix assigns into outer_outputs unconditionally,
+                # so a non-tensor output would need a differently-typed variable.
+                # Reject explicitly rather than emitting C++ that will not compile.
+                raise NotImplementedError(
+                    "cpp wrapper invoke_subgraph: non-tensor region output "
+                    f"({type(out).__name__}) is not supported"
+                )
+            # in ABI-compatible mode, ir.MultiOutput is not codegened,
+            # hence pre-declare output variables directly and separately
+            self.writeline(f"RAIIAtenTensorHandle {out.get_name()};")
+            outer_outputs.append(out.get_name())
+
+        # The region runs its own Scheduler, which re-emits per-device state such as
+        # `<stream_t> stream0;`; unscoped that redefines the parent's declaration.
+        self.writeline("{")
+        with self._preserve_device_guard_state():
+            self.writeline(EnterSubgraphLine(self, invoke_subgraph.subgraph.graph))
+            self.codegen_subgraph(invoke_subgraph.subgraph, outer_inputs, outer_outputs)
+            self.writeline(ExitSubgraphLine(self))
+        self.writeline("}")
 
     def codegen_switch(self, node) -> None:
         """Emit ABI-compatible C++ for a higher-order cond/switch."""

--- a/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu_array_ref.py
@@ -993,6 +993,17 @@ class CppWrapperCpuArrayRef(CppWrapperCpu):
             )
             self.writeline(f"RAIIAtenTensorHandle {inner_input}({inner_input}_handle);")
 
+    def codegen_invoke_subgraph(self, invoke_subgraph):
+        # The region's outputs are pre-declared as RAIIAtenTensorHandle and
+        # codegen_subgraph_suffix std::moves the region's output buffer into
+        # them. A stack-allocated buffer is an ArrayRefTensor<T>, which has no
+        # conversion to RAIIAtenTensorHandle, so that assignment would not
+        # compile -- the same clash cond and while_loop hit. Turn stack
+        # allocation off for the graph, as the extern-kernel paths below do,
+        # rather than emitting C++ that fails to build.
+        self.allow_stack_allocation = False
+        return super().codegen_invoke_subgraph(invoke_subgraph)
+
     def codegen_while_loop(self, while_loop, stack_output=False):
         if stack_output:
             raise NotImplementedError("NYI cpp wrapper for while_loop_stack_output")

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1140,6 +1140,10 @@ class AllocateLine(MemoryPlanningLine):
     def __post_init__(self):
         if V.graph.scheduler.current_node is None:
             raise AssertionError("expected scheduler.current_node to be set")
+        # The index is only meaningful within this scheduler's node list: an inlined
+        # subgraph emits its lines into the parent's list while V.graph is the
+        # SUBGRAPH. See should_reuse_buffer.
+        self.scheduler = V.graph.scheduler
         self.scheduler_node_index = V.graph.scheduler.nodes.index(
             V.graph.scheduler.current_node
         )
@@ -1147,6 +1151,21 @@ class AllocateLine(MemoryPlanningLine):
     def should_reuse_buffer(self, free_line: FreeIfNotReusedLine, size: int) -> bool:
         if self.comm_buffer:
             return True
+        if free_line.scheduler is not self.scheduler:
+            # A parent free paired with an allocation from an inlined invoke_subgraph
+            # region. codegen_invoke_subgraph inlines without the EnterSubgraphLine /
+            # ExitSubgraphLine bracket codegen_switch and codegen_while_loop wrap their
+            # branches in, and only that bracket makes memory_plan_reuse push a fresh
+            # MemoryPlanningState and swap estimate_peak. So the region's lines land in
+            # the parent's pool, scored against the parent's tree, and the two
+            # scheduler_node_index values index different node lists: the adjacency
+            # test below is meaningless and summarize_range raises on the inverted
+            # range. Bailing out costs regions the cross-boundary reuse that cond and
+            # while_loop keep.
+            # TODO: bracket the region instead. EnterSubgraphLine.codegen calls
+            # code.do_indent(), which needs an enclosing Python block statement -- an
+            # if/while branch emits one, a region does not.
+            return False
         if free_line.scheduler_node_index + 1 == self.scheduler_node_index:
             return True
         overall_peak_memory = self.wrapper.estimate_peak.overall_peak_memory
@@ -1264,6 +1283,9 @@ class FreeIfNotReusedLine(MemoryPlanningLine):
     def __post_init__(self):
         if V.graph.scheduler.current_node is None:
             raise AssertionError("expected scheduler.current_node to be set")
+        # See AllocateLine.__post_init__ -- the index is only meaningful
+        # relative to this scheduler's node list.
+        self.scheduler = V.graph.scheduler
         self.scheduler_node_index = V.graph.scheduler.nodes.index(
             V.graph.scheduler.current_node
         )


### PR DESCRIPTION
Summary:

`CppWrapperCpu.codegen_invoke_subgraph` was a bare `raise NotImplementedError`, so any
`torch.compiler.nested_compile_region` under AOTInductor died at codegen:

```
torch._inductor.exc.InductorError: NotImplementedError:
    codegen invoke_subgraph is not implemented for cpp wrapper
  cpp_wrapper_cpu.py:2813
```

Two parts.

**1. Implement `CppWrapperCpu.codegen_invoke_subgraph`.** The class already has a complete
subgraph-inlining implementation, `codegen_subgraph`, used by cond/switch/while_loop;
invoke_subgraph was the only HOP left raising. Declare one owning `RAIIAtenTensorHandle`
per output -- the same shape as `codegen_switch`, because in ABI-compatible mode
`ir.MultiOutput` is not codegened -- and delegate. A non-tensor region output raises
explicitly rather than emitting C++ that will not compile.

The region body is emitted inside its own C++ block. The region has its own `Scheduler`,
which re-emits per-device state -- notably `<stream_t> stream0;` from
`write_get_raw_stream` -- and in the parent's scope that is a redefinition
(`error: redefinition of 'stream0'`). The outputs are declared *outside* the block so
`codegen_subgraph_suffix` can still assign into them, and `_preserve_device_guard_state`
keeps the region's device-guard bookkeeping from leaking out.

**2. Fix a cross-graph index bug in wrapper-IR memory planning** that (1) exposes.
`AllocateLine`/`FreeIfNotReusedLine` record
`scheduler_node_index = V.graph.scheduler.nodes.index(...)`, but an inlined subgraph emits
its lines into the *parent's* line list while `V.graph` is the *subgraph*. Pairing a parent
free with a region allocation then compares indices into two different node lists:

```
ValueError: Start index must be less than or equal to end index
  segmented_tree.py:234, via should_reuse_buffer -> peak_between
```

Record the scheduler alongside the index and refuse reuse across schedulers. This is a
latent pre-existing bug for cond/while_loop too -- inlining is what makes it reachable --
but it is only reproducible once (1) lands.

Per-region Inductor config under the cpp wrapper is the next diff in the stack.

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
`test_lite_regional_compile_invoke_subgraph` was skipped under `config.cpp_wrapper` with
the very message this diff deletes; the skip is removed.

New `test_invoke_subgraph_nested_region` in test_aot_inductor.py -- a full AOTI round trip
through `check_model`: compile, package, dlopen, run and compare against eager. That is
what a generated-C++ assertion cannot cover.

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor \
  -- --regex "invoke_subgraph"
=> Pass 4. Fail 0. Skip 1.

buck2 test @//mode/opt-amd-gpu fbcode//caffe2/test/inductor:test_inductor \
  -- --regex "regional|lite_"
=> Pass 8. Fail 0. Skip 3.
```

**cpp wrapper coverage for the other subgraph HOPs.** `test_control_flow.py` had none: every
case ran only under the default python wrapper, even though cond/while_loop/scan/map/switch
all reach `CppWrapperCpu.codegen_subgraph` and part (2) above touches every inlined
subgraph. This diff adds a `_CppWrapperMixin` that re-runs a suite with
`config.cpp_wrapper=True`, and turns it on for the four suites that pass:
`CondTestsCppWrapper`, `AssociativeScanTestsCppWrapper`, `MapTestsCppWrapper`,
`SwitchTestsCppWrapper`.

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:control_flow -- --regex "CppWrapper"
=> Pass 122. Fail 0. Skip 6.

buck2 test @//mode/opt fbcode//caffe2/test/inductor:control_flow
=> Pass 799. Fail 0. Skip 104.
```
(799 = the suite's previous 677 plus these 122; no existing case changed.)

Not everything could be turned on, and the reasons are pre-existing rather than caused by
this diff. Measured under `TORCHINDUCTOR_CPP_WRAPPER=1` on the parent commit and again on
this one -- identical both times, Pass 341 / Fail 337:
  - `ScanTests` (264 cases) and `WhileLoopTests` (69) still fail. Pinning that many names
    would rot on the next parametrization, so those two suites are left off with the
    reasons recorded in the file.
  - `CondTests` needed only four exclusions, listed in `_CPP_WRAPPER_XFAIL`
    (`test_cond_unbacked_symint_inner*`).
Two distinct causes, each worth its own diff:
  - `error: redefinition of 'true_graph_0_bufN'` -- a branch subgraph declares its buffers
    in the parent's C++ scope, so two branches reusing a name collide. Same class of bug as
    the region `stream0` collision fixed above, but for buffers rather than per-device
    state.
  - `NotImplementedError: NYI cpp wrapper for while_loop_stack_output`.

Authored with an AI assistant.

Reviewed By: desertfire

Differential Revision: D115659603




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo