### PR TITLE
[inductor] AOTI cpp wrapper: keep a nested region's Inductor config (#194704)

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -390,6 +390,34 @@ class AOTInductorTestsTemplate:
             )
             FileCheck().check_count("// subgraph: ", 2).run(code)
 
+    def test_invoke_subgraph_nested_region_config(self):
+        # Same, but the region carries a per-region Inductor config patch, so
+        # the config.patch in CppWrapperCpu.codegen_subgraph is on the path too.
+        # fallback_by_default routes the region's ops to the proxy executor
+        # while the parent keeps its normal lowering.
+        from torch._higher_order_ops.invoke_subgraph import (
+            get_invoke_subgraph_compile_options,
+        )
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return torch.cos(gn(x * 2))
+
+        with torch._dynamo.config.patch(
+            enable_invoke_subgraph_regional_compile=True,
+            inline_single_use_invoke_subgraph=False,
+        ):
+            opts = get_invoke_subgraph_compile_options(
+                fw_inductor_config_patches={"fallback_by_default": True}
+            )
+
+            @torch.compiler.nested_compile_region(options=opts)
+            def gn(x):
+                return torch.sin(x) + 1
+
+            example_inputs = (torch.randn(8, 8, device=self.device),)
+            self.check_model(Model(), example_inputs)
+
     @common_utils.parametrize("embed_kernel_binary", [False, True])
     def test_loaded_modules_tracking(self, embed_kernel_binary):
         # Verify that AOTI codegen on CUDA/HIP passes &kernels_.loaded_modules_

--- a/test/inductor/test_compile_subprocess.py
+++ b/test/inductor/test_compile_subprocess.py
@@ -75,6 +75,19 @@ test_failures = {
     "test_remove_noop_view_dtype": TestFailure(("xpu"), is_skip=True),
     # can not pickle ParametrizedConv2d
     "test_weight_norm_conv2d": TestFailure(("cpu", "cuda"), is_skip=True),
+    # TypeError: cannot pickle '_thread._local' object.
+    # nested_compile_region(options=...) hangs compiler callables off
+    # NestedCompileRegionOptions. dill cannot resolve a module reference for that
+    # class, falls back to pickling the callables by value, and walking their
+    # globals reaches a thread-local. is_skip rather than xfail because the
+    # by-value fallback is dill-specific, so the test still passes where the
+    # graph pickler does not go through dill.
+    "test_regional_fallback_by_default_invoke_subgraph": TestFailure(
+        ("cpu", "cuda"), is_skip=True
+    ),
+    "test_regional_codegen_only_config_cpp_wrapper": TestFailure(
+        ("cpu", "cuda"), is_skip=True
+    ),
     # This manually constructs an FX graph with an OpOverloadPacket target to
     # cover a legacy lowering table entry, which is outside the subprocess
     # compile serialization path this file exercises.

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -17935,6 +17935,104 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertIn("aten::zeros_like", code[0])
         self.assertNotIn("from(nullptr, 0)", code[0])
 
+    def test_regional_fallback_by_default_invoke_subgraph(self):
+        # A nested region carrying inductor_config_patches={"fallback_by_default": True}
+        # must fall back *only inside the region*: the region's ops become
+        # FallbackKernels while the surrounding graph keeps its normal lowering.
+        # This is the complement of lite mode (which falls back everywhere and
+        # compiles the annotated islands).
+        from torch._higher_order_ops.invoke_subgraph import (
+            get_invoke_subgraph_compile_options,
+        )
+
+        # `options=` is gated by enable_invoke_subgraph_regional_compile, and the
+        # gate is checked when the DECORATOR runs -- so the whole body, not just
+        # the torch.compile call, has to be inside the config patch.
+        with torch._dynamo.config.patch(
+            enable_invoke_subgraph_regional_compile=True,
+            inline_single_use_invoke_subgraph=False,
+        ):
+            opts = get_invoke_subgraph_compile_options(
+                fw_inductor_config_patches={"fallback_by_default": True}
+            )
+
+            @torch.compiler.nested_compile_region(options=opts)
+            def gn(x):
+                return torch.sin(x) + 1
+
+            def fn(x):
+                return torch.cos(gn(x * 2))
+
+            opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+            x = torch.randn(64, 64, device=self.device)
+            result, codes = run_and_get_code(lambda: opt_fn(x))
+
+        self.assertEqual(result, fn(x))
+        self.assertEqual(len(codes), 1)
+        # Match against code, not comments. Inductor tags every kernel with an
+        # `Original ATen: [aten.foo]` provenance comment naming the op it was
+        # lowered from, whether or not that op fell back -- so searching the
+        # raw text makes the sin check pass vacuously and the cos check
+        # impossible to satisfy (the parent's Triton cos kernel still carries
+        # an `aten.cos` comment).
+        body = "\n".join(
+            line
+            for line in codes[0].splitlines()
+            if not line.lstrip().startswith(("#", "//"))
+        )
+        # The region's sin went to a fallback kernel; the parent's cos did not.
+        # Spelling differs by wrapper: `aten.sin` for the python wrapper,
+        # `aoti_torch_*_sin` for cpp.
+        self.assertTrue(
+            "aten.sin" in body or "_sin(" in body,
+            f"region did not fall back:\n{codes[0]}",
+        )
+        self.assertNotIn("aten.cos", body)
+
+    def test_regional_codegen_only_config_cpp_wrapper(self):
+        # A codegen-TIME knob on the region must reach the cpp wrapper.
+        # `triton.persistent_reductions` is consulted while the region's kernels
+        # are built (choices.py should_use_persistent_reduction), i.e. after the
+        # lowering-time config.patch in ir.InvokeSubgraph.create has already
+        # closed. Only the patch inside CppWrapperCpu.codegen_subgraph can carry
+        # it. Both halves compute the same softmax: with the region patched, its
+        # reduction must be emitted looped (triton_red_*) while the parent's
+        # stays persistent (triton_per_*).
+        # mps is a GPU_TYPE but has no Triton and no cpp-wrapper backend, so the
+        # persistent-vs-looped contrast this test checks does not exist there.
+        if self.device != GPU_TYPE or self.device == "mps":
+            raise unittest.SkipTest("requires a Triton GPU for reduction kernels")
+
+        from torch._higher_order_ops.invoke_subgraph import (
+            get_invoke_subgraph_compile_options,
+        )
+
+        with torch._dynamo.config.patch(
+            enable_invoke_subgraph_regional_compile=True,
+            inline_single_use_invoke_subgraph=False,
+        ):
+            opts = get_invoke_subgraph_compile_options(
+                fw_inductor_config_patches={"triton.persistent_reductions": False}
+            )
+
+            @torch.compiler.nested_compile_region(options=opts)
+            def gn(x):
+                return torch.softmax(x, dim=-1) + 1
+
+            def fn(x):
+                return gn(torch.softmax(x, dim=-1) * 2)
+
+            with config.patch(cpp_wrapper=True):
+                opt_fn = torch.compile(fn, backend="inductor", fullgraph=True)
+                x = torch.randn(1024, 256, device=self.device)
+                result, codes = run_and_get_code(lambda: opt_fn(x))
+
+        self.assertEqual(result, fn(x), atol=2e-3, rtol=2e-3)
+        code = "\n".join(codes)
+        # the region's kernel is looped, the parent's is persistent
+        self.assertIn("triton_red_", code)
+        self.assertIn("triton_per_", code)
+
     def test_lite_triton_kernel_wrapper_functional(self):
         if self.device != GPU_TYPE or self.device == "mps":
             raise unittest.SkipTest("requires GPU")

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -118,6 +118,14 @@ test_failures = {
     "test_pdl_mutation_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_pdl_template_and_delay_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     #
+    # A symbolic rnumel defeats should_use_persistent_reduction for BOTH halves
+    # of the model, so the parent stops emitting triton_per_ and the
+    # persistent-vs-looped contrast the test asserts no longer exists.
+    #
+    "test_regional_codegen_only_config_cpp_wrapper_dynamic_shapes": TestFailure(
+        ("cuda", "xpu"), is_skip=True
+    ),
+    #
     # Failed to find dynamic for loop variable (no kernels generated)
     #
     "test_fft_real_input_dynamic_shapes": TestFailure(

--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -62,6 +62,12 @@ importlib.import_module("filelock")
 # xfail by default, set is_skip=True to skip
 test_failures = {
     "test_kwargs_dynamic_shapes": TestFailure(("cpu",)),
+    # A symbolic rnumel defeats should_use_persistent_reduction for BOTH halves
+    # of the model, so the parent stops emitting triton_per_ and the
+    # persistent-vs-looped contrast the test asserts no longer exists.
+    "test_regional_codegen_only_config_cpp_wrapper_dynamic_shapes": TestFailure(
+        ("cuda", "xpu"), is_skip=True
+    ),
     # PDL tests are CUDA SM90+ only, skip on CPU
     "test_pdl_mutation_dynamic_shapes": TestFailure(("cpu",), is_skip=True),
     "test_pdl_template_and_delay_dynamic_shapes": TestFailure(("cpu",), is_skip=True),

--- a/torch/_inductor/codegen/cpp_wrapper_cpu.py
+++ b/torch/_inductor/codegen/cpp_wrapper_cpu.py
@@ -3040,16 +3040,30 @@ class CppWrapperCpu(PythonWrapperCodegen):
         # wrapper, we have moved to lifting subgraphs as functions, supported by
         # PythonWrapperCode `codegen_subgraph` function. We should perhaps
         # support lifting of subgraphs as functions for cpp wrapper as well.
+        # Only invoke_subgraph regions have nested config patches set. The
+        # cond/while_loop branch subgraphs are ir.Subgraph too, but leave the
+        # field at None; getattr additionally keeps this robust to non-ir.Subgraph
+        # adapters (e.g. the CodegenGraph used for decompose_k) that reach the
+        # base-class subgraph codegen paths. Mirrors
+        # PythonWrapperCodegen.codegen_subgraph_by_inlining so a nested region is
+        # codegened under its own Inductor config here too.
+        inductor_config_patches = getattr(subgraph, "inductor_config_patches", None)
+        ctx = (
+            config.patch(inductor_config_patches)
+            if inductor_config_patches
+            else contextlib.nullcontext()
+        )
         try:
             self.push_codegened_graph(subgraph.graph)
-            self.writeline(f"// subgraph: {subgraph.name}")
-            self.codegen_subgraph_prefix(subgraph, outer_inputs, outer_outputs)
-            parent_graph = V.graph
-            with V.set_graph_handler(subgraph.graph):
-                subgraph.graph.codegen_subgraph(
-                    parent_graph=parent_graph,
-                )
-            self.codegen_subgraph_suffix(subgraph, outer_inputs, outer_outputs)
+            with ctx:
+                self.writeline(f"// subgraph: {subgraph.name}")
+                self.codegen_subgraph_prefix(subgraph, outer_inputs, outer_outputs)
+                parent_graph = V.graph
+                with V.set_graph_handler(subgraph.graph):
+                    subgraph.graph.codegen_subgraph(
+                        parent_graph=parent_graph,
+                    )
+                self.codegen_subgraph_suffix(subgraph, outer_inputs, outer_outputs)
         finally:
             self.pop_codegened_graph()
 


### PR DESCRIPTION
Summary:

The previous diff makes `invoke_subgraph` codegen at all under the cpp wrapper. It inlines
the region, but codegens it under the PARENT's Inductor config, so a codegen-time
per-region config (D111943224, `nested_compile_region(options=...)`) is silently dropped
for AOTI.

Fix: apply the region's `inductor_config_patches` in `CppWrapperCpu.codegen_subgraph`,
mirroring `PythonWrapperCodegen.codegen_subgraph_by_inlining` (wrapper.py:4623).

Why it has to be here: `ir.InvokeSubgraph.create` already patches config while the region
is LOWERED, so lowering-time knobs (e.g. `fallback_by_default`) are carried without this
diff. But that context has closed by the time the region's kernels are built, so a
CODEGEN-time knob -- `triton.persistent_reductions`, read in
`choices.should_use_persistent_reduction` -- is only carried by a patch at this site. That
is the gap this diff closes.

The `getattr(subgraph, "inductor_config_patches", None)` guard matters: cond/while_loop
branch subgraphs are `ir.Subgraph` too but leave the field `None`, and non-`ir.Subgraph`
adapters (e.g. the `CodegenGraph` used for decompose_k) also reach this base-class path.

Note: `caffe2/...` and `xplat/caffe2/...` are separate synced copies; both are edited.

Test Plan:
`test_regional_codegen_only_config_cpp_wrapper` (test_torchinductor.py) is the test that
targets this change. Both halves of the model compute the same softmax; the region is
patched with `triton.persistent_reductions: False`. Since that knob is read while the
region's kernels are built -- after the lowering-time patch has closed -- only the patch
added here can carry it: the region's reduction must be emitted looped (`triton_red_`)
while the parent's stays persistent (`triton_per_`).

CAVEAT: that test is GPU-gated (`requires GPU for triton reduction kernels`) and every
test_torchinductor.py target available on my devserver materializes CpuTests only, so it
SKIPS locally -- `:test_inductor` runs no GPUTests here, `:test_inductor_cuda` matches
nothing, and `:gpu_cpp_wrapper` does not build (pre-existing hipify errors in
c10/cuda/CUDAFunctions.h). Its verification is therefore deferred to a GPU CI shard.

Two further tests cover the region-config path end to end:
- `test_regional_fallback_by_default_invoke_subgraph` (test_torchinductor.py)
- `test_invoke_subgraph_nested_region_config` (test_aot_inductor.py, full AOTI round trip
  via `check_model`)

Both use `fallback_by_default`, which is a LOWERING-time knob, so -- measured, not assumed
-- they pass with *and* without this diff. They are coverage for regional config under the
cpp wrapper, not regression tests for this particular line.

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:test_aot_inductor \
  -- --regex "invoke_subgraph"
=> Pass 7. Fail 0. Skip 2.   (parent diff alone: Pass 4)

buck2 test @//mode/opt-amd-gpu fbcode//caffe2/test/inductor:test_inductor \
  -- --regex "regional|lite_"
=> Pass 9. Fail 0. Skip 4.   (parent diff alone: Pass 8)
```

`codegen_subgraph` is shared with cond/while_loop, so the subgraph suite was run too:

```
buck2 test @//mode/opt fbcode//caffe2/test/inductor:control_flow \
  -- --env TORCHINDUCTOR_CPP_WRAPPER=1
=> Pass 341. Fail 337.
```
Identical to the parent diff and to the commit below it, i.e. no regression. (See the
parent diff for why control_flow does not pass under the cpp wrapper today -- pre-existing
and unrelated to invoke_subgraph.)

Measured end to end on a 4-block transformer-ish net (gfx950) with one attention region
annotated `{"fallback_by_default": True}`, via
`scripts/zhuoran/inductor_examples:region_fallback_toy`:

| path | region | parent |
|---|---|---|
| python wrapper | 0 triton, 17 aten fallbacks | 6 triton |
| AOTI cpp wrapper | 44 proxy-executor calls, 0 triton | 0 fallbacks, 7 triton |

Authored with an AI assistant.

Reviewed By: kqfu

Differential Revision: D116905778




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo