### PR TITLE
[Testcase Refactoring][Bugfix] SACEstimator: add missing clear_user_hooks in __exit__

### DIFF
--- a/torch/distributed/_tools/sac_estimator.py
+++ b/torch/distributed/_tools/sac_estimator.py
@@ -969,5 +969,6 @@ class SACEstimator(TorchDispatchMode):
 
     def __exit__(self, *args: Any) -> None:  # type: ignore[no-untyped-def]
         self._saved_tensor_hook_ctx.__exit__()
+        self._mod_tracker.clear_user_hooks()
         self._mod_tracker.__exit__(*args)
         super().__exit__(*args)


### PR DESCRIPTION
## Summary

`SACEstimator.__exit__` was missing a `clear_user_hooks()` call that the
similar `RuntimeEstimator.__exit__` already has. Without it, creating a
second `SACEstimator` instance and calling `__enter__` raises
`AssertionError: Only one pre_fw_hook can be registered at a time`.

This is a pre-existing bug that was never exposed because the original
test (`test_sac_estimator.py`) only called `SACEstimator` once per test
method. The decoupled version of the test calls it twice (once with
`operator-level-benchmark`, once with `operator-level-cost-model`),
exposing the missing cleanup.

## Changes

- Added `self._mod_tracker.clear_user_hooks()` in `SACEstimator.__exit__`,
  matching the pattern already used in `RuntimeEstimator.__exit__`.

## Test plan

- `python test/distributed/_tools/test_sac_estimator.py` on CUDA (A100):
  both tests pass — the test calls `_sac_estimation` twice per method,
  which would fail without this fix.
- `python test/distributed/_tools/test_sac_estimator.py` on NPU (Ascend
  910B3): `test_simple_model` passes (calls SACEstimator once, but
  verified no regression); `test_transformer` uses `expectedFailure`
  for a separate FakeTensorMode issue.