### PR TITLE
[Elastic] Return a RunResult when the rendezvous exits gracefully

### DIFF
--- a/test/distributed/elastic/agent/server/test/api_test.py
+++ b/test/distributed/elastic/agent/server/test/api_test.py
@@ -956,7 +956,11 @@ class SimpleElasticAgentTest(unittest.TestCase):
         agent = TestAgent(spec)
         invoke_run.side_effect = RendezvousGracefulExitError()
         with patch.object(agent, "_shutdown"):
-            agent.run()
+            result = agent.run()
+        self.assertIsNotNone(result)
+        self.assertEqual(WorkerState.SUCCEEDED, result.state)
+        self.assertEqual({}, result.return_values)
+        self.assertFalse(result.is_failed())
 
 
 if __name__ == "__main__":

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -749,6 +749,7 @@ class SimpleElasticAgent(ElasticAgent):
             return result
         except RendezvousGracefulExitError as e:
             logger.info("Rendezvous gracefully exited: %s", e)
+            return RunResult(state=WorkerState.SUCCEEDED)
         except SignalException as e:
             logger.warning("Received %s death signal, shutting down workers", e.sigval)
             self._shutdown(e.sigval, timeout=self._shutdown_timeout)


### PR DESCRIPTION
## Description

`SimpleElasticAgent.run()` catches `RendezvousGracefulExitError`, logs it, and then falls off the end of the function, returning `None`. The only production caller, `launch_agent()`, immediately calls `result.is_failed()` on that `None`, so a node that lands in the rendezvous redundancy list and hits a closed rendezvous dies with:

```text
AttributeError: 'NoneType' object has no attribute 'is_failed'
```

instead of exiting cleanly as a warm spare.

This returns `RunResult(state=WorkerState.SUCCEEDED)` on that path. Notes on intent, all verified against callers:

- Metrics and per-worker events stay skipped on this path (they run inside the `try` after `_invoke_run`); no workers ran on a node that never joined.
- `launch_agent()` now records its normal succeeded event, returns empty return values, shuts down the rendezvous handler in its `finally`, and exits 0 - matching the redundancy-list design where the spare terminates gracefully.
- Behavior change worth flagging for anyone scripting around it: such a node previously exited nonzero with an `AttributeError` traceback; it now exits 0.
- A second consideration: in the mid-run re-rendezvous variant the node may have completed workers whose return values are dropped. That path previously crashed too, so this is strictly better, but reviewers may prefer a different state than `SUCCEEDED`; happy to adjust.

The existing unit test is strengthened to pin the returned state and values; its new assertions fail on the old code with "unexpectedly None".

Draft until #194710 gets triaged (understood new-contribution PRs need an `actionable`-labeled issue).

Fixes #194710

## AI assistance disclosure

This change was authored with the help of an AI coding assistant. The assistant found the bug by code audit, wrote the fix and test, ran the verification below, and drafted this description; the author reviewed the diff and conventions before submission.

## Test Plan

Unit test executed against installed torch binaries with the repo module loaded under its canonical name:

```text
python qa_elastic_apitest.py
-> test_agent_process_handler_graceful_exception ... ok
```

With only the api.py fix stashed, the same strengthened test fails, proving regression coverage:

```text
AssertionError: unexpectedly None
FAILED (failures=1)
```

Lint:

```text
python -m ruff check torch/distributed/elastic/agent/server/api.py \
  test/distributed/elastic/agent/server/test/api_test.py
# All checks passed!
```

Full distributed elastic CI coverage runs on Linux shards (`api_test.py` sits in the Windows blocklist).
