### PR TITLE
[optim] Reject ConstantLR factor of 0 at construction

### DIFF
--- a/test/optim/test_lrscheduler.py
+++ b/test/optim/test_lrscheduler.py
@@ -487,6 +487,18 @@ class TestLRScheduler(TestCase):
         scheduler = ConstantLR(self.opt, factor=1.0 / 2, total_iters=5)
         self._test_with_epoch(scheduler, targets, epochs)
 
+    def test_constantlr_factor_limits1(self):
+        factor = 0.0
+        iters = 4
+        with self.assertRaises(ValueError):
+            ConstantLR(self.opt, factor=factor, total_iters=iters)
+
+    def test_constantlr_factor_limits2(self):
+        factor = 1.1
+        iters = 4
+        with self.assertRaises(ValueError):
+            ConstantLR(self.opt, factor=factor, total_iters=iters)
+
     def test_linearlr_with_epoch(self):
         # lr = 0.025     if epoch == 0
         # lr = 0.03125   if epoch == 1

--- a/torch/optim/lr_scheduler.py
+++ b/torch/optim/lr_scheduler.py
@@ -810,9 +810,9 @@ class ConstantLR(LRScheduler):
         total_iters: int = 5,
         last_epoch: int = -1,
     ) -> None:
-        if factor > 1.0 or factor < 0:
+        if factor > 1.0 or factor <= 0:
             raise ValueError(
-                "Constant multiplicative factor expected to be between 0 and 1."
+                "Constant multiplicative factor expected to be greater than 0 and less or equal to 1."
             )
 
         self.factor = factor


### PR DESCRIPTION
## Description

`ConstantLR` accepted `factor=0.0` because the constructor validated with `factor < 0`. The value then survived every step until `last_epoch == total_iters`, where `get_lr()` evaluates `group["lr"] * (1.0 / self.factor)` and raises `ZeroDivisionError` in the middle of a schedule - far from the argument that caused it.

This tightens the check to `factor <= 0` so the invalid input is rejected at construction, mirroring `LinearLR.start_factor`, which was made to reject non-positive values for exactly this division-by-zero reason (#86695), and reuses its message wording.

Scope notes:

- Standalone `factor=0.0` always crashed before reaching the undo step, so this only rejects broken input; no working standalone configuration is removed.
- One composition does change: `SequentialLR(ConstantLR(factor=0.0), ...)` whose boundary step goes through `_get_closed_form_lr()` avoided the division and ran cleanly. That path now raises at construction instead. Flagged in #194712; if maintainers prefer keeping that composition alive, an alternative is guarding the division in `get_lr()` instead.
- `-0.0` also passed the old check (`-0.0 < 0` is false) and is rejected now.
- The two new unit tests mirror the existing `test_linearlr_start_factor_limits1/2` pair; the `factor=0.0` one fails on unpatched code since construction used to succeed.

Draft until #194712 gets triaged (understood new-contribution PRs need an `actionable`-labeled issue).

Fixes #194712

## AI assistance disclosure

This change was authored with the help of an AI coding assistant. The assistant found the bug by code audit, reproduced it, wrote the fix and tests, ran the verification below, and drafted this description; the author reviewed the diff and conventions before submission.

## Test Plan

Repo scheduler module loaded under its canonical module name against installed torch binaries:

```text
python qa_constantrl.py
-> ok   factor=0.0 rejected: Constant multiplicative factor expected to be greater than 0 and less or equal to 1.
-> ok   factor=-0.5 rejected
-> ok   factor=1.0 full schedule ran, last lr=[0.1]
-> ok   factor=0.3333333333333333 full schedule ran, last lr=[0.1]
-> ok   factor=0.5 full schedule ran, last lr=[0.1]
```

Pre-fix behavior demonstrated on the unfixed binary: constructor accepted `factor=0.0`, `ZeroDivisionError` at step == total_iters.

Lint:

```text
python -m ruff check torch/optim/lr_scheduler.py test/optim/test_lrscheduler.py
# All checks passed!
```
