### PR TITLE
[XPU][TEST] Make cases device agnostic in 3 test files and port to Intel GPU

### DIFF
--- a/test/fx/test_common_passes.py
+++ b/test/fx/test_common_passes.py
@@ -78,6 +78,8 @@ Factory_Test_Cases = [FactoryFunctionCall, MutationFactory]
 Devices = ["cpu"]
 if torch.cuda.is_available():
     Devices.append("cuda")
+if torch.xpu.is_available():
+    Devices.append("xpu")
 
 
 def name_fn(common_pass, f, device):

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -3925,7 +3925,7 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         )
         self.assertEqual(finalized_end, 8)
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_schedule_first_compiles_across_kahn_layers(self):
         from torch._inductor.scheduler import ForeachKernelSchedulerNode, Scheduler
 
@@ -3981,7 +3981,7 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         self.assertEqual(observed_combo_layers, [{0, 1}])
         FileCheck().check("'num_kernels': 2").run(code[0])
 
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     @parametrize("gate_enabled", [True, False])
     def test_peak_memory_reorder_order(self, gate_enabled):
         from torch._inductor import memory
@@ -4252,7 +4252,7 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         self.assertIsNone(run(100))
 
     @skipIfRocm  # https://github.com/pytorch/pytorch/issues/182444
-    @requires_cuda_and_triton
+    @requires_gpu_and_triton
     def test_combo_kernel_peak_memory_wide_resnet(self):
         """A tight peak-memory threshold must measurably reduce the
         runtime CUDA peak memory of the compiled forward pass compared
@@ -4265,9 +4265,9 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
         def compile_and_measure_peak(**cfg):
             torch._dynamo.reset()
             torch._inductor.metrics.reset()
-            torch.cuda.synchronize()
-            torch.cuda.empty_cache()
-            torch.cuda.reset_peak_memory_stats()
+            torch.accelerator.synchronize()
+            torch.accelerator.empty_cache()
+            torch.accelerator.reset_peak_memory_stats()
             with (
                 fresh_cache(),
                 torch._inductor.config.patch(
@@ -4277,13 +4277,13 @@ class ComboKernelPeakMemoryTests(InductorTestCase):
                 compiled = torch.compile(model)
                 with torch.no_grad():
                     compiled(x)
-                torch.cuda.synchronize()
-                torch.cuda.empty_cache()
-                torch.cuda.reset_peak_memory_stats()
+                torch.accelerator.synchronize()
+                torch.accelerator.empty_cache()
+                torch.accelerator.reset_peak_memory_stats()
                 with torch.no_grad():
                     compiled(x)
-                torch.cuda.synchronize()
-            return torch.cuda.max_memory_allocated()
+                torch.accelerator.synchronize()
+            return torch.accelerator.max_memory_allocated()
 
         # Permissive gate: schedule-first combos can co-allocate freely.
         peak_permissive = compile_and_measure_peak(

--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -1,6 +1,5 @@
 # Owner(s): ["module: inductor"]
 
-import unittest
 
 import torch
 from torch._inductor import config
@@ -10,13 +9,9 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_utils import IS_LINUX
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
-    HAS_CUDA_AND_TRITON,
     HAS_GPU_AND_TRITON,
     requires_gpu,
 )
-
-
-requires_cuda_triton = unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA")
 
 
 class TestControlDeps(InductorTestCase):
@@ -652,7 +647,7 @@ class TestControlDeps(InductorTestCase):
                 "OrderingBarrier is_no_op() must be True",
             )
 
-    @requires_cuda_triton
+    @requires_gpu()
     def test_bidirectional_stream_sync_correctness(self):
         """Regression: passthrough OrderingBarrier must be ordered after all subgraph ops.
 
@@ -665,25 +660,25 @@ class TestControlDeps(InductorTestCase):
         from torch._inductor.utils import run_and_get_code
 
         def fn(x):
-            s1 = torch.cuda.Stream()
-            s2 = torch.cuda.Stream()
-            event_s1 = torch.cuda.Event()
-            event_s2 = torch.cuda.Event()
-            with torch.cuda.stream(s1):
+            s1 = torch.Stream()
+            s2 = torch.Stream()
+            event_s1 = torch.Event()
+            event_s2 = torch.Event()
+            with s1:
                 a = x * 2
                 event_s1.record(s1)
-            with torch.cuda.stream(s2):
+            with s2:
                 event_s1.wait(s2)
                 b = a + 1
                 event_s2.record(s2)
-            with torch.cuda.stream(s1):
+            with s1:
                 event_s2.wait(s1)
                 c = b * 2
             s1.synchronize()
             s2.synchronize()
             return c
 
-        x = torch.randn(1024, device="cuda")
+        x = torch.randn(1024, device=GPU_TYPE)
         expected = fn(x)
         result, _ = run_and_get_code(torch.compile(fn), x)
         self.assertEqual(result, expected)
@@ -756,7 +751,7 @@ class TestControlDeps(InductorTestCase):
             result = torch.compile(fn)(a, b)
             torch.testing.assert_close(result, fn(a, b))
 
-    @requires_cuda_triton
+    @requires_gpu()
     def test_host_to_device_transfer_between_sync_passthroughs(self):
         """The interleaving above, arrived at without touching the graph.
 
@@ -769,19 +764,19 @@ class TestControlDeps(InductorTestCase):
         def fn(x, w):
             meta = torch.tensor(x.shape[-2], dtype=torch.long)
             residual = x.sin()
-            s = torch.cuda.Stream()
-            with torch.cuda.stream(s):
+            s = torch.Stream()
+            with s:
                 out = x @ w
             s.synchronize()
             extra = meta.to(device=out.device, dtype=out.dtype)
             return torch.cat((out, extra.expand(*out.shape[:-1], 1), residual), dim=-1)
 
-        x = torch.randn(8, 128, device="cuda", dtype=torch.bfloat16)
-        w = torch.randn(128, 128, device="cuda", dtype=torch.bfloat16)
+        x = torch.randn(8, 128, device=GPU_TYPE, dtype=torch.bfloat16)
+        w = torch.randn(128, 128, device=GPU_TYPE, dtype=torch.bfloat16)
         expected = fn(x, w)
         with torch.no_grad():
             result = torch.compile(fn, mode="reduce-overhead")(x, w)
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         torch.testing.assert_close(result, expected)
 
 


### PR DESCRIPTION
For https://github.com/pytorch/pytorch/issues/114850, we will make cases device agnostic in 3 test files. We could enable Intel GPU with following methods and try the best to keep the original code styles:

- replace `requires_cuda_and_triton` with `requires_gpu_and_triton` for applicable cases
- using `torch.Stream()` and `torch.accelerator` to generalize the code
- Enabled XPU for some test path

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo