### PR TITLE
[assoc_scan] SplitScan support for the 2-lane backward scan

### DIFF
--- a/torch/_inductor/codegen/triton_split_scan.py
+++ b/torch/_inductor/codegen/triton_split_scan.py
@@ -88,21 +88,31 @@ class TritonSplitScanKernel(TritonKernel):
     def scan(self, dtypes, combine_fn, values):
         """
         Perform an associative scan on 'values'.
+
+        Supports one or two carried states.
+        *) single lane: value+flag in one <=32-bit word, or 3 u64 slots for 64-bit)
+        *) two lanes: 5-u64-slot layout ([flag, bv0, bv1, ip0, ip1])
         """
         import triton.language as tl
 
-        (dtype,) = dtypes
-        (value,) = values
+        num_lanes = len(values)
+        if num_lanes not in (1, 2):
+            raise AssertionError(
+                f"TritonSplitScanKernel supports 1 or 2 lanes, got {num_lanes}"
+            )
 
-        dtype = upcast_compute_type(dtype)
-        compute_type = triton_compute_type(dtype)
-        compute_type_triton = getattr(tl, compute_type[3:])
+        dtypes = tuple(upcast_compute_type(dtype) for dtype in dtypes)
+        compute_types = [triton_compute_type(dtype) for dtype in dtypes]
+        element_nbits = [getattr(tl, ct[3:]).primitive_bitwidth for ct in compute_types]
 
-        element_nbits = compute_type_triton.primitive_bitwidth
-
-        scratch_type = "tl.uint32" if element_nbits <= 16 else "tl.uint64"
+        if num_lanes == 1:
+            nbits = element_nbits[0]
+            scratch_type = "tl.uint32" if nbits <= 16 else "tl.uint64"
+            scratch_elems_per_block = 3 if nbits == 64 else 1
+        else:
+            scratch_type = "tl.uint64"
+            scratch_elems_per_block = 5
         scratch_type_triton = getattr(tl, scratch_type[3:])
-        scratch_elems_per_block = 3 if element_nbits == 64 else 1
         scratch_nbytes_per_block = scratch_elems_per_block * (
             scratch_type_triton.primitive_bitwidth // 8
         )
@@ -139,62 +149,98 @@ class TritonSplitScanKernel(TritonKernel):
         if self._load_mask:
             raise AssertionError("ops.scan not supported inside ops.masked")
 
-        value = cse_compute(
-            f"{value}.to({compute_type})",
-            dtype=dtype,
-            shape=value.shape,
-        )
-        value = cse_compute(
-            f"tl.broadcast_to({value}, {self.dense_size_str()})",
-            dtype=dtype,
-            shape=self.dense_size_list(),
-        )
+        broadcast_values = []
+        for value, dtype, compute_type in zip(values, dtypes, compute_types):
+            value = cse_compute(
+                f"{value}.to({compute_type})",
+                dtype=dtype,
+                shape=value.shape,
+            )
+            value = cse_compute(
+                f"tl.broadcast_to({value}, {self.dense_size_str()})",
+                dtype=dtype,
+                shape=self.dense_size_list(),
+            )
+            broadcast_values.append(value)
 
-        combine_helper_fn = self._lift_helper(combine_fn, (value,), (dtype,))
+        combine_helper_fn = self._lift_helper(
+            combine_fn, tuple(broadcast_values), dtypes
+        )
         dim = self.triton_tensor_ndim() - 1
         if dim != 0:
             raise AssertionError(f"expected scan dim == 0, got {dim}")
-        scan_shape = value.shape
+        scan_shape = broadcast_values[0].shape
         if scan_shape is None:
             raise AssertionError("expected value.shape to be set")
         reduced_shape = list(scan_shape)
         del reduced_shape[dim]
 
-        block_sum = cse_compute(
-            f"tl.reduce({value}, {dim}, {combine_helper_fn})",
-            dtype=dtype,
-            shape=reduced_shape,
+        def newvars(shape):
+            return [self.cse.newvar(dtype=dtype, shape=shape) for dtype in dtypes]
+
+        def csv(vars_):
+            # trailing-comma form so a single lane still reads as a 1-tuple
+            return "".join(f"{v}, " for v in vars_)
+
+        # block_scan is the in-order inclusive scan of this block; its last
+        # element is the block reduction. Deriving the block sum from it (via
+        # select_one, as the non-split scan does) preserves operand order, which
+        # is required for non-commutative combines -- tl.reduce may reorder
+        # operands across lanes.
+        block_scan = newvars(scan_shape)
+        self.compute.writeline(
+            f"{csv(block_scan)}= tl.associative_scan("
+            f"({csv(broadcast_values)}), {dim}, {combine_helper_fn})"
         )
-        exclusive_prefix = self.cse.newvar(
-            dtype=dtype,
-            shape=reduced_shape,
-        )
-        if element_nbits == 64:
+        block_sum = [
+            cse_compute(
+                f"triton_helpers.select_one({bscan}, "
+                f"tl.arange(0, RBLOCK) == RBLOCK - 1, {dim}, keep_dims=False)",
+                dtype=dtype,
+                shape=reduced_shape,
+            )
+            for dtype, bscan in zip(dtypes, block_scan)
+        ]
+
+        exclusive_prefix = newvars(reduced_shape)
+        pid = self.iteration_ranges_get_pid(self.range_trees[-1])
+        if num_lanes == 2:
             self.compute.splice(
                 f"""
-                {exclusive_prefix} = triton_helpers.exclusive_scan_decoupled_lookback_64(
+                {exclusive_prefix[0]}, {exclusive_prefix[1]} = triton_helpers.exclusive_scan_decoupled_lookback_2(
                     {scratch_base},
-                    {block_sum},
-                    {self.iteration_ranges_get_pid(self.range_trees[-1])},
+                    {block_sum[0]},
+                    {block_sum[1]},
+                    {pid},
                     {combine_helper_fn},
                 )
                 """,
                 strip=True,
             )
-
-        else:
-            if element_nbits > 32:
-                raise AssertionError(
-                    f"expected element_nbits <= 32, got {element_nbits}"
-                )
-            value_as_uint_dtype = f"tl.uint{element_nbits}"
-
+        elif element_nbits[0] == 64:
             self.compute.splice(
                 f"""
-                {exclusive_prefix} = triton_helpers.exclusive_scan_decoupled_lookback(
+                {exclusive_prefix[0]} = triton_helpers.exclusive_scan_decoupled_lookback_64(
                     {scratch_base},
-                    {block_sum},
-                    {self.iteration_ranges_get_pid(self.range_trees[-1])},
+                    {block_sum[0]},
+                    {pid},
+                    {combine_helper_fn},
+                )
+                """,
+                strip=True,
+            )
+        else:
+            if element_nbits[0] > 32:
+                raise AssertionError(
+                    f"expected element_nbits <= 32, got {element_nbits[0]}"
+                )
+            value_as_uint_dtype = f"tl.uint{element_nbits[0]}"
+            self.compute.splice(
+                f"""
+                {exclusive_prefix[0]} = triton_helpers.exclusive_scan_decoupled_lookback(
+                    {scratch_base},
+                    {block_sum[0]},
+                    {pid},
                     {combine_helper_fn},
                     DTYPE_VALUE_AS_UINT={value_as_uint_dtype},
                     DTYPE_PACK={scratch_type},
@@ -202,23 +248,20 @@ class TritonSplitScanKernel(TritonKernel):
                 """,
                 strip=True,
             )
-        # Compute final cumsum
-        block_scan = cse_compute(
-            f"tl.associative_scan({value}, {dim}, {combine_helper_fn})",
-            dtype=dtype,
-            shape=scan_shape,
-        )
-        combined_result = cse_compute(
-            f"{combine_helper_fn}({exclusive_prefix}, {block_scan})",
-            dtype=dtype,
-            shape=scan_shape,
-        )
-        return (
+
+        # combine_helper_fn returns a bare scalar for one lane and a tuple for
+        # two, so the assignment target matches num_lanes.
+        combined = newvars(scan_shape)
+        combine_lhs = ", ".join(str(v) for v in combined)
+        combine_args = ", ".join(str(v) for v in (*exclusive_prefix, *block_scan))
+        self.compute.writeline(f"{combine_lhs} = {combine_helper_fn}({combine_args})")
+        return tuple(
             cse_compute(
-                f"tl.where(roffset == 0, {block_scan}, {combined_result})",
+                f"tl.where(roffset == 0, {bscan}, {comb})",
                 dtype=dtype,
                 shape=scan_shape,
-            ),
+            )
+            for dtype, bscan, comb in zip(dtypes, block_scan, combined)
         )
 
     def _get_heuristic(self):

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -3128,7 +3128,7 @@ class Scan(Loops):
             )
             supports_split = (
                 triton_supports_split
-                and len(dtypes) == 1
+                and len(dtypes) <= 2
                 and not torch.are_deterministic_algorithms_enabled()
             )
             if not supports_split:
@@ -3185,11 +3185,14 @@ class Scan(Loops):
         combine_fn: Callable[[tuple[Any, ...], tuple[Any, ...]], tuple[Any, ...]],
         scan_numel: Expr,
     ) -> tuple[ReductionHint, _IntLike]:
-        # TODO: custom splitting heuristic for scan
         def wrapper_fn(idx: Sequence[Expr], reduction_idx: Sequence[Expr]) -> OpsValue:
             return inner_fn([*idx[:axis], *reduction_idx, *idx[axis:]])
 
-        return Reduction.num_splits(
+        # Reuse the reduction analysis for the ReductionHint (drives INNER/OUTER
+        # tiling in codegen), but override the split count below: the reduction
+        # heuristic assumes split pieces are independent partials, which is wrong
+        # for a scan.
+        hint, reduction_splits = Reduction.num_splits(
             device=device,
             dst_dtype=dtype,
             src_dtype=dtype,
@@ -3199,6 +3202,30 @@ class Scan(Loops):
             reduction_type="scan",
             reduction_numel=scan_numel,
         )
+
+        # A scan split is a serial decoupled-look-back chain, not free parallel
+        # work: split i waits on splits 0..i-1 through global memory. The only
+        # payoff is filling otherwise-idle SMs. But the unsplit scan already
+        # saturates DRAM bandwidth once its rows cover roughly half the SMs (long
+        # streams give high memory-level parallelism per block), and past that
+        # point the look-back overhead makes a split scan a net loss regardless
+        # of scan length. Empirically the split only wins across all lengths when
+        # rows leave well over half of that saturation point idle, i.e. cover
+        # less than about a quarter of the SMs; beyond that, keep the unsplit
+        # scan. When splitting, cover the machine once -- more splits only
+        # lengthen the serial chain.
+        numel = sympy_product(pointwise_ranges)
+        if not V.graph.sizevars.all_unbacked_explicitly_hinted([scan_numel, numel]):
+            return hint, reduction_splits
+        num_rows = V.graph.sizevars.optimization_hint(numel)
+        scan_len = V.graph.sizevars.optimization_hint(scan_numel)
+        num_sm = DeviceProperties.create(device).multi_processor_count
+        min_rblock = config.triton.min_split_scan_rblock
+        if num_rows * 4 >= num_sm or scan_len < 2 * min_rblock:
+            return hint, 1
+        fill = max(1, round(num_sm / num_rows))
+        work_cap = max(1, scan_len // min_rblock)
+        return hint, max(1, min(fill, work_cap))
 
 
 # This signifies a scan op that should go through TritonSplitScanKernel codegen on CUDA.

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -791,6 +791,99 @@ def exclusive_scan_decoupled_lookback_64(scratch_base, block_value, index, combi
 
 
 @triton.jit
+def exclusive_scan_decoupled_lookback_2(
+    scratch_base, block_value0, block_value1, index, combine_fn
+):
+    """Two-lane variant of exclusive_scan_decoupled_lookback_64.
+
+    Computes the exclusive scan of a 2-tuple carried value between blocks.
+    Uses the separate-slot scheme of the 64-bit variant (value stored apart
+    from the flag, ordered by debug_barrier + release/acquire) generalized to
+    two lanes, so it is width-uniform: each lane is bitcast to a same-width
+    unsigned int and zero-extended into its own u64 slot, regardless of the
+    lane's element width.
+
+    scratch_base: Pointer to scratch space in global memory (tl.uint64)
+    block_value0, block_value1: This block's block-sum for each lane
+    index: Scalar index of this block relative to the current scan
+    combine_fn: Function ``(v0, v1, v0, v1) -> (v0, v1)`` scanned over
+
+    Slot layout per block (5 x u64): [flag, bv0, bv1, ip0, ip1]
+    """
+    dtype0 = block_value0.dtype
+    dtype1 = block_value1.dtype
+    uint0 = tl.core.get_int_dtype(dtype0.primitive_bitwidth, signed=False)
+    uint1 = tl.core.get_int_dtype(dtype1.primitive_bitwidth, signed=False)
+
+    # Publish block sums so subsequent blocks don't get stuck waiting for us
+    if index > 0:
+        tl.store(
+            scratch_base + 5 * index + 1,
+            block_value0.to(uint0, bitcast=True).to(tl.uint64),
+        )
+        tl.store(
+            scratch_base + 5 * index + 2,
+            block_value1.to(uint1, bitcast=True).to(tl.uint64),
+        )
+        tl.debug_barrier()
+        flag_one = tl.full([], 1, tl.uint64)
+        tl.atomic_xchg(scratch_base + 5 * index + 0, flag_one, sem="release")
+
+    # Calculate exclusive prefix scan
+    exclusive_prefix0 = tl.zeros([], dtype0)
+    exclusive_prefix1 = tl.zeros([], dtype1)
+    prefix_valid = False
+    test_target = index - 1
+    while test_target >= 0:
+        flag = tl.full([], 0, tl.uint64)
+        while flag == 0:
+            flag = tl.atomic_add(scratch_base + 5 * test_target + 0, 0, sem="acquire")
+
+        # flag == 1 -> block sums at slots (1, 2); flag == 2 -> inclusive prefixes
+        # at slots (3, 4). Offsets are (2 * flag - 1) and (2 * flag).
+        base = scratch_base + 5 * test_target
+        raw0 = tl.load(base + (2 * flag - 1).to(tl.int32))
+        raw1 = tl.load(base + (2 * flag).to(tl.int32))
+        value0 = raw0.to(uint0).to(dtype0, bitcast=True)
+        value1 = raw1.to(uint1).to(dtype1, bitcast=True)
+        if prefix_valid:
+            exclusive_prefix0, exclusive_prefix1 = combine_fn(
+                value0, value1, exclusive_prefix0, exclusive_prefix1
+            )
+        else:
+            exclusive_prefix0 = value0
+            exclusive_prefix1 = value1
+            prefix_valid = True
+
+        if flag == 2:
+            test_target = tl.full([], -1, index.dtype)  # Match the original type
+        else:
+            test_target = test_target - 1
+
+    # Make inclusive block sums visible to other blocks
+    if prefix_valid:
+        inclusive_prefix0, inclusive_prefix1 = combine_fn(
+            exclusive_prefix0, exclusive_prefix1, block_value0, block_value1
+        )
+    else:
+        inclusive_prefix0 = block_value0
+        inclusive_prefix1 = block_value1
+    tl.store(
+        scratch_base + 5 * index + 3,
+        inclusive_prefix0.to(uint0, bitcast=True).to(tl.uint64),
+    )
+    tl.store(
+        scratch_base + 5 * index + 4,
+        inclusive_prefix1.to(uint1, bitcast=True).to(tl.uint64),
+    )
+    tl.debug_barrier()
+    flag_two = tl.full([], 2, tl.uint64)
+    tl.atomic_xchg(scratch_base + 5 * index + 0, flag_two, sem="release")
+
+    return exclusive_prefix0, exclusive_prefix1
+
+
+@triton.jit
 def frexp(x):
     # TODO(isuruf): use inline_asm_elementwise here
     zero = x == 0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #192971
* __->__ #194722
* #192762
* #192654
* #192389
* #192388
* #192761
The associative_scan backward computes g_ys as a 2-output associative
scan. Inductor's SplitScan is gated to a single output, so this scan
is forced onto a single-block Triton Scan with no aten fallback, which
under-parallelizes the compiled backward.

This PR aims to extend SplitScan to exactly two carried states,
so the g_ys scan can take the parallel single-pass path.

This change was developed with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo