### PR TITLE
make sure `stream` is `torch.cuda.ExternalStream` or `torch.cuda.Stream`

### DIFF
--- a/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
+++ b/torch/_inductor/kernel/vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py
@@ -344,9 +344,11 @@ class VendoredDenseBlockScaledGemmKernel(CuteDslOperator):
         stream = to_cuda_stream(stream)
         compiled_gemm = compiled_artifact.compiled_obj
 
-        # TVM FFI needs a torch.cuda.Stream, not a raw int handle
-        if isinstance(stream, int):
-            stream = torch.cuda.ExternalStream(stream)
+        # TVM FFI needs a torch.cuda.Stream, not a raw int handle.
+        # to_cuda_stream() returns cuda.bindings.driver.CUstream, which is not
+        # an int and has no .device; torch.cuda.stream() requires that.
+        if not isinstance(stream, torch.cuda.Stream):
+            stream = torch.cuda.ExternalStream(int(stream))
 
         # Runtime arg list must match _compile: alpha always trails stream.
         alpha = getattr(args, "alpha", None)


### PR DESCRIPTION
To fix `AttributeError: 'cuda.bindings.driver.CUstream' object has no attribute 'device'` in some nv universal gemm tests.

ref: https://hud.pytorch.org/pr/pytorch/pytorch/194364#96790367885
```
TestNVUniversalGemm.test_scaled_gemm_mxfp8_layout_a_aligned_offset_m_128_n_256_k_512:

  File "/opt/pytorch/pytorch/test/inductor/test_nv_universal_gemm.py", line 428, in test_scaled_gemm_mxfp8
      result = compiled_fn(a_fp8, b_fp8, scale_a, scale_b)
  ...
  File ".../torch/_inductor/codegen/nv_universal_gemm/nv_universal_gemm_kernel.py", line 869, in _nvgemm_run
      kernel.run(
  File ".../cutlass/operators/base.py", line 193, in run
      return self._run(args, compiled_artifact, stream, workspace)
  File ".../vendored_templates/cutedsl/wrappers/dense_blockscaled_gemm_kernel.py", line 355, in _run
      with torch.cuda.stream(stream):
  File ".../torch/cuda/__init__.py", line 869, in __enter__
      if self.src_prev_stream.device != cur_stream.device:
  AttributeError: 'cuda.bindings.driver.CUstream' object has no attribute 'device'
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo