### PR TITLE
[profiler] Fix silent zero-byte memory timeline on MPS

### DIFF
--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -683,7 +683,8 @@ class _KinetoProfile:
             if self.use_device and self.use_device != "cuda":
                 device = self.use_device + ":0"
             else:
-                device = "cuda:0" if torch.cuda.is_available() else "cpu"
+                acc = torch.accelerator.current_accelerator(check_available=True)
+                device = f"{acc.type}:0" if acc is not None else "cpu"
 
         # Construct the memory timeline plot data
         self.mem_tl = MemoryProfileTimeline(self._memory_profile())


### PR DESCRIPTION
## Summary

`_KinetoProfile.export_memory_timeline()` picks a default device (when
the caller doesn't pass one) from `self.use_device`, which is only ever
set from `ProfilerActivity.{CUDA,XPU,MTIA,HPU,PrivateUse1}`. There is
no `ProfilerActivity.MPS`, so `self.use_device` stays `None` for any
MPS-only profiling session. The fallback for that case hardcoded
`"cuda:0" if torch.cuda.is_available() else "cpu"`, so on any Mac (no
CUDA) it silently picked `"cpu"` even though the profiled tensors were
actually on `"mps"`. This isn't a crash: `MemoryProfileTimeline` filters
events by the device string it's given, so passing the wrong one just
produces a plausible-looking timeline reporting zero bytes, with no
error or warning.

This exact fallback has been touched by three separate PRs without
anyone generalizing it: #120185 added (then reverted, for an unrelated
perf reason in `_parse_kineto_events`) an XPU-specific availability
check here; #144237 restructured the surrounding if/else but kept the
CUDA-hardcoded fallback untouched.
`torch.accelerator.current_accelerator()` already exists as the generic
"which accelerator is actually active" primitive (same idiom used in
`torch/utils/checkpoint.py`'s `DefaultDeviceType.get_device_type()`),
and correctly resolves to `"mps"` here, unlike `ProfilerActivity`.

Reproduced with real MPS tensors before/after: before the fix, an
`x @ x` matmul on 1000x1000 MPS tensors produced a memory timeline with
`0` total bytes recorded when `device` was left unset (same wrong
result as explicitly passing `device="cpu"`); passing `device="mps:0"`
explicitly (a manual workaround) correctly recorded `8000004` bytes
across 5 events. After the fix, leaving `device` unset produces the
same correct result without needing the workaround.

Note: `export_memory_timeline()` is already deprecated in favor of
`torch.cuda.memory._record_memory_history`/`_export_memory_snapshot`,
so this fixes a real but narrowing-relevance bug rather than a
load-bearing code path; there is no existing test coverage for
`export_memory_timeline()` in this repo to extend.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Reproduced the bug and the fix on real MPS hardware:

    python3 -c "
    import torch, json, gzip, tempfile, os
    from torch.profiler import profile, ProfilerActivity
    with profile(activities=[ProfilerActivity.CPU], profile_memory=True, record_shapes=True, with_stack=True) as prof:
        x = torch.randn(1000, 1000, device='mps')
        y = x @ x
        y.sum().item()
        del x, y
    tmp = tempfile.mktemp(suffix='.raw.json.gz')
    prof.export_memory_timeline(tmp)  # device left unset
    with gzip.open(tmp, 'rt') as f:
        data = json.load(f)
    print(len(data), sum(r[2] for r in data))
    os.remove(tmp)
    "

Before this fix: `2 0` (zero bytes recorded). After this fix: `5
8000004`, matching the result of explicitly passing `device="mps:0"`.

Verified the no-accelerator/CPU-only fallback still works by mocking
`torch.accelerator.current_accelerator` to return `None` and confirming
`export_memory_timeline` still writes a valid file.

`lintrunner -a torch/profiler/profiler.py` reports no lint issues.
