### PR TITLE
Initialize Adagrad parameter state lazily in the C++ optimizer

### DIFF
--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -473,16 +473,15 @@ TEST(OptimTest, AddParameter_LBFGS) {
 TEST(OptimTest, AddParameter_Adagrad) {
   torch::manual_seed(0);
 
-  // Adagrad used to create its state only in the constructor, so a parameter
-  // that reached the optimizer later - appended to an existing group, or in a
-  // group added afterwards - tripped an internal assert in step().
+  // Adagrad used to build state only in its constructor, so a parameter added
+  // later tripped an internal assert in step().
   auto parameter = torch::randn({5, 5});
   auto appended = parameter.clone();
   auto in_new_group = parameter.clone();
 
-  // The group overrides initial_accumulator_value, so the test pins down which
-  // value the state created on first use is seeded from. Its lr is set
-  // explicitly so the comparison below does not depend on option inheritance.
+  // The group's initial_accumulator_value differs from the defaults, so the
+  // assertions below pin which of the two a late-added parameter is seeded
+  // from. lr is set explicitly so they do not also depend on option merging.
   std::vector<OptimizerParamGroup> param_groups;
   param_groups.emplace_back(
       std::vector<torch::Tensor>{parameter},
@@ -504,15 +503,9 @@ TEST(OptimTest, AddParameter_Adagrad) {
   ASSERT_TRUE(parameter.allclose(appended));
   ASSERT_TRUE(parameter.allclose(in_new_group));
 
-  // Both late arrivals are seeded from the optimizer defaults rather than from
-  // the group's initial_accumulator_value, matching the constructor and
-  // torch/optim/adagrad.py, which reads self.defaults in _init_group. This
-  // pins the current semantics; it is not a claim that they are the desirable
-  // ones.
   for (const auto& late : {appended, in_new_group}) {
-    // at() rather than operator[]: a missing key means the lazy init
-    // regressed, and operator[] would default-insert null and segfault here
-    // instead of reporting a failure.
+    // at(), not operator[]: on a missing key the latter default-inserts null
+    // and this would segfault rather than report a failure.
     auto& state = static_cast<AdagradParamState&>(
         *optimizer.state().at(late.unsafeGetTensorImpl()));
     ASSERT_EQ(state.step(), 1);

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -510,8 +510,11 @@ TEST(OptimTest, AddParameter_Adagrad) {
   // pins the current semantics; it is not a claim that they are the desirable
   // ones.
   for (const auto& late : {appended, in_new_group}) {
+    // at() rather than operator[]: a missing key means the lazy init
+    // regressed, and operator[] would default-insert null and segfault here
+    // instead of reporting a failure.
     auto& state = static_cast<AdagradParamState&>(
-        *optimizer.state()[late.unsafeGetTensorImpl()]);
+        *optimizer.state().at(late.unsafeGetTensorImpl()));
     ASSERT_EQ(state.step(), 1);
     // sum starts at initial_accumulator_value and accumulates grad * grad.
     ASSERT_TRUE(state.sum().allclose(torch::full_like(late, 1.5)));

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -470,6 +470,47 @@ TEST(OptimTest, AddParameter_LBFGS) {
   // REQUIRE this doesn't throw
 }
 
+TEST(OptimTest, AddParameter_Adagrad) {
+  torch::manual_seed(0);
+
+  // Adagrad used to create its state only in the constructor, so a parameter
+  // that reached the optimizer later - appended to an existing group, or in a
+  // group added afterwards - tripped an internal assert in step().
+  auto parameter = torch::randn({5, 5});
+  auto appended = parameter.clone();
+  auto in_new_group = parameter.clone();
+
+  // The group overrides initial_accumulator_value, so the test pins down which
+  // value the state created on first use is seeded from. Its lr is set
+  // explicitly so the comparison below does not depend on option inheritance.
+  std::vector<OptimizerParamGroup> param_groups;
+  param_groups.emplace_back(
+      std::vector<torch::Tensor>{parameter},
+      std::make_unique<AdagradOptions>(
+          AdagradOptions(1.0).initial_accumulator_value(0.9)));
+  Adagrad optimizer(
+      param_groups, AdagradOptions(1.0).initial_accumulator_value(0.5));
+
+  optimizer.param_groups()[0].params().push_back(appended);
+  optimizer.add_param_group(OptimizerParamGroup({in_new_group}));
+
+  parameter.mutable_grad() = torch::ones_like(parameter);
+  appended.mutable_grad() = torch::ones_like(appended);
+  in_new_group.mutable_grad() = torch::ones_like(in_new_group);
+
+  ASSERT_NO_THROW(optimizer.step());
+
+  // All three start equal and are seeded identically, so they stay equal.
+  ASSERT_TRUE(parameter.allclose(appended));
+  ASSERT_TRUE(parameter.allclose(in_new_group));
+
+  auto& state = static_cast<AdagradParamState&>(
+      *optimizer.state()[appended.unsafeGetTensorImpl()]);
+  ASSERT_EQ(state.step(), 1);
+  // sum starts at initial_accumulator_value and accumulates grad * grad.
+  ASSERT_TRUE(state.sum().allclose(torch::full_like(appended, 1.5)));
+}
+
 // Check whether the learning rate of the parameter groups in the optimizer are
 // the same as the expected learning rates given in the epoch:learning rate map
 static void check_lr_change(

--- a/test/cpp/api/optim.cpp
+++ b/test/cpp/api/optim.cpp
@@ -504,11 +504,18 @@ TEST(OptimTest, AddParameter_Adagrad) {
   ASSERT_TRUE(parameter.allclose(appended));
   ASSERT_TRUE(parameter.allclose(in_new_group));
 
-  auto& state = static_cast<AdagradParamState&>(
-      *optimizer.state()[appended.unsafeGetTensorImpl()]);
-  ASSERT_EQ(state.step(), 1);
-  // sum starts at initial_accumulator_value and accumulates grad * grad.
-  ASSERT_TRUE(state.sum().allclose(torch::full_like(appended, 1.5)));
+  // Both late arrivals are seeded from the optimizer defaults rather than from
+  // the group's initial_accumulator_value, matching the constructor and
+  // torch/optim/adagrad.py, which reads self.defaults in _init_group. This
+  // pins the current semantics; it is not a claim that they are the desirable
+  // ones.
+  for (const auto& late : {appended, in_new_group}) {
+    auto& state = static_cast<AdagradParamState&>(
+        *optimizer.state()[late.unsafeGetTensorImpl()]);
+    ASSERT_EQ(state.step(), 1);
+    // sum starts at initial_accumulator_value and accumulates grad * grad.
+    ASSERT_TRUE(state.sum().allclose(torch::full_like(late, 1.5)));
+  }
 }
 
 // Check whether the learning rate of the parameter groups in the optimizer are

--- a/torch/csrc/api/include/torch/optim/adagrad.h
+++ b/torch/csrc/api/include/torch/optim/adagrad.h
@@ -71,13 +71,8 @@ class TORCH_API Adagrad : public Optimizer {
 
     for (const auto& group : param_groups_) {
       for (const auto& p : group.params()) {
-        auto state = std::make_unique<AdagradParamState>();
-        state->step(0);
-        state->sum(torch::full_like(
-            p.data(),
-            defaults.initial_accumulator_value(),
-            at::MemoryFormat::Preserve));
-        state_[p.unsafeGetTensorImpl()] = std::move(state);
+        state_[p.unsafeGetTensorImpl()] =
+            make_param_state(p, defaults.initial_accumulator_value());
       }
     }
   }
@@ -91,6 +86,12 @@ class TORCH_API Adagrad : public Optimizer {
   void load(serialize::InputArchive& archive) override;
 
  private:
+  // Shared by the constructor and by the on-first-use path in step(), so the
+  // two can never seed a parameter differently.
+  static std::unique_ptr<AdagradParamState> make_param_state(
+      const Tensor& param,
+      double initial_accumulator_value);
+
   template <typename Self, typename Archive>
   static void serialize(Self& self, Archive& archive) {
     _TORCH_OPTIM_SERIALIZE_WITH_TEMPLATE_ARG(Adagrad);

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -57,8 +57,6 @@ void AdagradParamState::serialize(torch::serialize::InputArchive& archive) {
   _TORCH_OPTIM_DESERIALIZE_TORCH_ARG(Tensor, sum);
 }
 
-/// Adapted from
-/// https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py
 std::unique_ptr<AdagradParamState> Adagrad::make_param_state(
     const Tensor& param,
     double initial_accumulator_value) {
@@ -69,6 +67,8 @@ std::unique_ptr<AdagradParamState> Adagrad::make_param_state(
   return state;
 }
 
+/// Adapted from
+/// https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py
 Tensor Adagrad::step(LossClosure closure) {
   NoGradGuard no_grad;
   Tensor loss = {};
@@ -83,10 +83,10 @@ Tensor Adagrad::step(LossClosure closure) {
       }
       auto grad = p.grad();
       auto param_state = state_.find(p.unsafeGetTensorImpl());
-      auto& defaults = static_cast<AdagradOptions&>(*defaults_);
 
       // State initialization
       if (param_state == state_.end()) {
+        auto& defaults = static_cast<AdagradOptions&>(*defaults_);
         auto new_state =
             make_param_state(p, defaults.initial_accumulator_value());
         param_state =

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -72,10 +72,18 @@ Tensor Adagrad::step(LossClosure closure) {
         continue;
       }
       auto grad = p.grad();
-      TORCH_INTERNAL_ASSERT(
-          state_[p.unsafeGetTensorImpl()] != nullptr,
-          "state found NULL for the Tensor ",
-          p);
+      // A parameter added to the optimizer after construction has no state
+      // yet; create it here exactly as the constructor does.
+      if (state_.find(p.unsafeGetTensorImpl()) == state_.end()) {
+        auto& defaults = static_cast<AdagradOptions&>(*defaults_);
+        auto state = std::make_unique<AdagradParamState>();
+        state->step(0);
+        state->sum(torch::full_like(
+            p.data(),
+            defaults.initial_accumulator_value(),
+            at::MemoryFormat::Preserve));
+        state_[p.unsafeGetTensorImpl()] = std::move(state);
+      }
       auto& state =
           static_cast<AdagradParamState&>(*state_[p.unsafeGetTensorImpl()]);
       auto& options = static_cast<AdagradOptions&>(group.options());

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -59,6 +59,16 @@ void AdagradParamState::serialize(torch::serialize::InputArchive& archive) {
 
 /// Adapted from
 /// https://github.com/pytorch/pytorch/blob/master/torch/optim/adagrad.py
+std::unique_ptr<AdagradParamState> Adagrad::make_param_state(
+    const Tensor& param,
+    double initial_accumulator_value) {
+  auto state = std::make_unique<AdagradParamState>();
+  state->step(0);
+  state->sum(torch::full_like(
+      param, initial_accumulator_value, MemoryFormat::Preserve));
+  return state;
+}
+
 Tensor Adagrad::step(LossClosure closure) {
   NoGradGuard no_grad;
   Tensor loss = {};
@@ -72,17 +82,13 @@ Tensor Adagrad::step(LossClosure closure) {
         continue;
       }
       auto grad = p.grad();
-      // A parameter added to the optimizer after construction has no state
-      // yet; create it here exactly as the constructor does.
-      if (state_.find(p.unsafeGetTensorImpl()) == state_.end()) {
-        auto& defaults = static_cast<AdagradOptions&>(*defaults_);
-        auto state = std::make_unique<AdagradParamState>();
-        state->step(0);
-        state->sum(torch::full_like(
-            p.data(),
-            defaults.initial_accumulator_value(),
-            at::MemoryFormat::Preserve));
-        state_[p.unsafeGetTensorImpl()] = std::move(state);
+      auto param_state = state_.find(p.unsafeGetTensorImpl());
+      auto& defaults = static_cast<AdagradOptions&>(*defaults_);
+
+      // State initialization
+      if (param_state == state_.end()) {
+        state_[p.unsafeGetTensorImpl()] =
+            make_param_state(p, defaults.initial_accumulator_value());
       }
       auto& state =
           static_cast<AdagradParamState&>(*state_[p.unsafeGetTensorImpl()]);

--- a/torch/csrc/api/src/optim/adagrad.cpp
+++ b/torch/csrc/api/src/optim/adagrad.cpp
@@ -87,11 +87,12 @@ Tensor Adagrad::step(LossClosure closure) {
 
       // State initialization
       if (param_state == state_.end()) {
-        state_[p.unsafeGetTensorImpl()] =
+        auto new_state =
             make_param_state(p, defaults.initial_accumulator_value());
+        param_state =
+            state_.emplace(p.unsafeGetTensorImpl(), std::move(new_state)).first;
       }
-      auto& state =
-          static_cast<AdagradParamState&>(*state_[p.unsafeGetTensorImpl()]);
+      auto& state = static_cast<AdagradParamState&>(*param_state->second);
       auto& options = static_cast<AdagradOptions&>(group.options());
 
       state.step(state.step() + 1);


### PR DESCRIPTION
Fixes #87706.

`torch::optim::Adagrad` created per-parameter state only in its constructor, so a
parameter added afterwards — via `add_param_group`, or by pushing onto an existing
group's `params()` as in the issue — reached `step()` with no state and tripped
`TORCH_INTERNAL_ASSERT(... "state found NULL for the Tensor ")`.

Adagrad was the only C++ optimizer doing this; `sgd.cpp:82`, `adam.cpp:82`,
`adamw.cpp:82`, `rmsprop.cpp:84` and `lbfgs.cpp:422` all create state on first use inline
in `step()`. There is no `_init_group` equivalent on the C++ side, so this adds the same
inline branch rather than a new pattern.

The constructor's eager loop stays. `adagrad.py` initializes both eagerly in `__init__`
and lazily in `_init_group`, and `OptimTest.OptimizerAccessors` depends on the eager half
twice: it reads `optimizer.state()` without calling `step()`, and it expects
`add_param_group` to reject a duplicate parameter — a check implemented as
`state_.count(...) == 0` (`optimizer.cpp:300-304`), which silently accepts duplicates if
state only appears after the first `step()`. #106896 deleted that loop and went red on ten
jobs. Both sites now share `Adagrad::make_param_state`, seeded from the optimizer defaults
to match the constructor and `adagrad.py:172`.

Complex is out of scope: `Adagrad::step` has no `view_as_real` path, so C++ Adagrad is
already wrong for complex regardless of state init. Same for Adam/AdamW/RMSprop.

### Test

`OptimTest.AddParameter_Adagrad` covers both late-arrival paths and gives the first group
an `initial_accumulator_value` differing from the defaults, so it pins which one the lazy
path reads.

I can now run the gtest binaries locally, so here is the test run against both versions of
the library in one CPU-only Windows build tree. First with `adagrad.cpp` and `adagrad.h`
reverted to their state on this PR's merge base (`7744b78e00e`) and `test_api` rebuilt —
that is, the test against unmodified main. Absolute paths are shortened in both blocks:

```
$ ./test_api.exe --gtest_filter=OptimTest.*Adagrad*:OptimTest.OptimizerAccessors

[ RUN      ] OptimTest.AddParameter_Adagrad
test/cpp/api/optim.cpp(500): error: Expected: optimizer.step() doesn't throw an exception.
  Actual: it throws c10::Error with description "state_[p.unsafeGetTensorImpl()] != nullptr
  INTERNAL ASSERT FAILED at "torch/csrc/api/src/optim/adagrad.cpp":78, please report a bug
  to PyTorch. state found NULL for the Tensor ...
[  FAILED  ] OptimTest.AddParameter_Adagrad (607 ms)

[==========] 7 tests from 1 test suite ran. (3295 ms total)
[  PASSED  ] 6 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] OptimTest.AddParameter_Adagrad
```

The other six stay green, `OptimTest.OptimizerAccessors` among them — that is the test the
constructor's eager loop exists for, so this also shows the revert isolates the new
behaviour rather than disturbing the old one.

With the fix restored and `test_api` rebuilt from the same tree:

```
$ ./test_api.exe --gtest_filter=OptimTest.*Adagrad*:OptimTest.OptimizerAccessors

[       OK ] OptimTest.OptimizerAccessors (2 ms)
[       OK ] OptimTest.XORConvergence_Adagrad (1964 ms)
[       OK ] OptimTest.ProducesPyTorchValues_Adagrad (502 ms)
[       OK ] OptimTest.ProducesPyTorchValues_AdagradWithWeightDecay (501 ms)
[       OK ] OptimTest.ProducesPyTorchValues_AdagradWithWeightDecayAndLRDecay (581 ms)
[       OK ] OptimTest.AddParameter_Adagrad (0 ms)
[       OK ] OptimTest.MergeWithDefaultOptions_Adagrad (0 ms)
[  PASSED  ] 7 tests.
```

It also passed in CI on `74042392cc4`, the last commit CI has been approved for on this
PR; the current head `9131265e04a` only trims comments in the test body and its runs are
still awaiting fork approval. From
`test-reports/cpp-unittest/test_libtorch/test_api.xml` in
`linux-jammy-py3.10-clang21-asan / test (default, 1, 18)`:

```
AllTests:  tests=1023  failures=0  errors=0
OptimTest: tests=45    failures=0  errors=0
  AddParameter_Adagrad   status=run result=completed failures=0
  OptimizerAccessors     status=run result=completed failures=0
```

Developed with AI assistance (Claude); I reviewed the change and the reasoning above.
