### PR TITLE
Fix macOS py3.15 wheel builds: pin Cython < 3.3.0 and bump the cp315 numpy pin

### DIFF
--- a/.ci/macwheel/build_install_deps.py
+++ b/.ci/macwheel/build_install_deps.py
@@ -29,7 +29,7 @@ NUMPY_PINS: dict[str, str] = {
     "3.12": "2.0.2",
     "3.13": "2.1.0",
     "3.14": "2.3.4",
-    "3.15": "2.5.1",
+    "3.15": "2.5.2",
 }
 
 OMP_PREFIX = Path("/opt/llvm-openmp")
@@ -63,6 +63,14 @@ def numpy_pin() -> str:
     return pin
 
 
+def preinstall_cp315_build_deps() -> list[str]:
+    """Pin Cython < 3.3.0 for cp315 sdist builds. See pytorch/pytorch#194618."""
+    if sys.version_info[:2] != (3, 15):
+        return []
+    pip_install("-q", "cython<3.3.0", "setuptools>=77.0.0,<82", "wheel")
+    return ["--no-build-isolation"]
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("package_dir", type=Path)
@@ -71,9 +79,10 @@ def main() -> None:
     os.chdir(args.package_dir)
     # requirements-build.txt supplies the build backend for `python -m build
     # --no-isolation` (the previous shell build relied on it being preinstalled).
-    pip_install("-qU", "-r", "requirements-build.txt")
-    pip_install("-q", "-r", "requirements.txt")
-    pip_install("-q", f"numpy=={numpy_pin()}")
+    build_flags = preinstall_cp315_build_deps()
+    pip_install("-qU", *build_flags, "-r", "requirements-build.txt")
+    pip_install("-q", *build_flags, "-r", "requirements.txt")
+    pip_install("-q", *build_flags, f"numpy=={numpy_pin()}")
     # Skip when sharing build/ across Pythons in the per-host loop -- the
     # per-Python bits (libtorch_python, _C.so) are invalidated by
     # tools/setup_helpers/cmake.py, so libtorch_cpu is reused. spin (from


### PR DESCRIPTION
Fixes the macOS arm64 nightly, where `py3_15` and `py3_15t` fail to build: [run 32823323968](https://github.com/pytorch/pytorch/actions/runs/32823323968/job/97725935556) (2026-08-25 nightly). 3.10 through 3.14t build and upload fine.

## What's failing

In `.ci/macwheel/build_install_deps.py`, on the very first install (`-r requirements-build.txt`):

```
× Getting requirements to build wheel did not run successfully.
│ exit code: -11
╰─> [0 lines of output]
ERROR: Failed to build 'pyyaml' when getting requirements to build wheel
```

`exit code: -11` is **SIGSEGV** — the POSIX equivalent of the `3221225477` (`0xC0000005`) access violation seen on Windows in #194618. Same signature: a crash inside pyyaml's PEP 517 `get_requires_for_build_wheel`, with no output because the process dies before printing.

The `No files were found with the provided path: …/wheel-py3_15-cpu` upload errors are downstream — no wheel was produced.

## Root cause: Cython 3.3.0

**Cython 3.3.0 was released 2026-08-22** and crashes under CPython 3.15, so every package pip must build from an sdist dies. `pyyaml` is in `requirements-build.txt`, has **never** shipped a cp315 wheel on any platform, and its `pyproject.toml` requires `Cython>=3.0` for py≥3.13 — so 3.3.0 lands in its isolated build env.

Unlike Windows, macOS loses **both** 3.15 and 3.15t.

## The fix

**1. Pin `cython<3.3.0` in the outer env and pass `--no-build-isolation`.**

`PIP_CONSTRAINT` is not usable here — pip does not apply it to isolated build environments, which is exactly where the crashing Cython gets installed. Verified with pip 26.2.1:

```
no constraint                -> Successfully installed Cython-3.3.0 setuptools-84.0.0
PIP_CONSTRAINT=cython<3.3.0  -> Successfully installed Cython-3.3.0 setuptools-84.0.0
```

`setuptools` is pinned to the same `>=77.0.0,<82` bound `requirements-build.txt` uses, so the preinstall doesn't smuggle in a newer build backend; `wheel` is added because pip no longer supplies it once isolation is off.

**2. Bump the cp315 numpy pin 2.5.1 → 2.5.2.** 2.5.1 has **no** cp315 macOS arm64 wheel, so numpy would have been built from source too and hit the same crash. 2.5.2 publishes `cp315`/`cp315t` wheels for both `macosx_11_0_arm64` and `macosx_14_0_arm64`. numpy is only installed *after* `requirements-build.txt`, which is why pyyaml failed first and this hadn't surfaced yet.

## Relationship to #194618

Same root cause, different script — that PR patches `.ci/pytorch/windows/build_install_deps.py`, this one `.ci/macwheel/build_install_deps.py`. Kept separate deliberately so the macOS fix isn't blocked on the Windows one, which is still awaiting a `ciflow/binaries` confirmation.

## Test plan

Verified locally with pip 26.2.1, reproducing the script's install order:

```
pip install 'cython<3.3.0' 'setuptools>=77.0.0,<82' wheel
pip install -qU --no-build-isolation -r requirements-build.txt
```

- Exits 0. All 14 entries install with isolation off, so the pre-installed build deps are sufficient for the whole file — that was the main risk of this approach.
- Cython stays at **3.2.9**; setuptools stays at **81.0.0**, inside the `<82` bound; PyYAML 6.0.3 installs.
- Separately confirmed a forced sdist build uses the pin: `pip install --no-cache-dir --no-build-isolation --no-binary=:all: pyyaml` builds against Cython 3.2.9 and fetches no 3.3.0.
- `preinstall_cp315_build_deps()` returns `['--no-build-isolation']` and preinstalls only on 3.15; returns `[]` and installs nothing on 3.14/3.12. `numpy_pin()` gives 2.5.2 / 2.3.4 / 2.0.2 for 3.15 / 3.14 / 3.12.
- PyPI checks: Cython 3.3.0 uploaded 2026-08-22 (prior release 3.2.9 on 07-24); numpy 2.5.2 is the first release with cp315 macOS arm64 wheels; no PyYAML release has a cp315 wheel.
- `ruff check` clean.

Real confirmation needs a macOS binary run — `ciflow/binaries` on this PR, or the next nightly.

## Risk

`--no-build-isolation` is scoped to 3.15, but within that it applies to all three installs in this script. Any sdist build whose build requirements aren't pre-installed will now fail loudly rather than pip provisioning them. The local run above shows `requirements-build.txt` is fine; `requirements.txt` is larger and only exercised on a real 3.15 macOS runner, so that's the thing to watch in CI.

## Upstream

The Cython crash is a genuine upstream bug — it now has confirmed reproductions on Windows (`0xC0000005`) and macOS arm64 (`SIGSEGV`) under CPython 3.15. This routes around it and deserves a Cython report if one isn't already open.
