### PR TITLE
Fix `torch.nn.functional.normalize` typing on `dim`

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -6108,7 +6108,7 @@ def triplet_margin_with_distance_loss(
 def normalize(
     input: Tensor,
     p: float = 2.0,
-    dim: int = 1,
+    dim: int | list[int] = 1,
     eps: float = 1e-12,
     out: Tensor | None = None,
 ) -> Tensor:
@@ -6125,7 +6125,7 @@ def normalize(
     Args:
         input: input tensor of any shape
         p (float): the exponent value in the norm formulation. Default: 2
-        dim (int or tuple of ints): the dimension to reduce. Default: 1
+        dim (int or tuple of int): the dimension to reduce. Default: 1
         eps (float): small value to avoid division by zero. Default: 1e-12
         out (Tensor, optional): the output tensor. If :attr:`out` is used, this
                                 operation won't be differentiable.


### PR DESCRIPTION
Docstring and functionality states `dim (int or tuple of ints): the dimension to reduce. Default: 1` but type signature still had `dim: int = 1`, which would be wrong.