### PR TITLE
Add `TORCHINDUCTOR_REDIS_EXPIRE` and set "ex" arg in Redis cache

### DIFF
--- a/torch/_inductor/remote_cache.py
+++ b/torch/_inductor/remote_cache.py
@@ -289,6 +289,9 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
                 port=int(os.environ.get("TORCHINDUCTOR_REDIS_PORT", 6379)),
             )
 
+        ttl_str = os.environ.get("TORCHINDUCTOR_REDIS_EXPIRE")
+        self._ttl = int(ttl_str) if ttl_str is not None else None
+
     @override
     def _get(self, key: str) -> bytes | None:
         if not self._redis:
@@ -318,7 +321,7 @@ class RedisRemoteCacheBackend(RemoteCacheBackend[bytes]):
 
         try:
             # pyrefly: ignore [missing-attribute]
-            self._redis.set(key, data)
+            self._redis.set(key, data, ex=self._ttl)
         # pyrefly: ignore [missing-attribute]
         except redis.exceptions.ConnectionError:
             # Redis is lazy and doesn't actually attempt to connect until the


### PR DESCRIPTION
Currently, inductor redis cache assume the server side is configured to evict entries on its own, and we put key-value pairs without any TTL.
This PR add a new env variable option, `TORCHINDUCTOR_REDIS_EXPIRE`, and pass it as `ex` (expire) argument to `redis.Redit.put(..)`. This will give more control to the user, determining for how long (seconds) the cache should persist in Redis.
Thanks in advance! ❤️ 

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo