### PR TITLE
Preserve FakeTensor metadata through as_strided views

### DIFF
--- a/aten/src/ATen/ConjugateFallback.cpp
+++ b/aten/src/ATen/ConjugateFallback.cpp
@@ -18,6 +18,10 @@ TORCH_LIBRARY_IMPL(_, Conjugate, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&conjugateFallback>());
 }
 
+TORCH_LIBRARY_IMPL(prims, Conjugate, m) {
+  m.impl("as_strided", torch::CppFunction::makeFallthrough());
+}
+
 TORCH_LIBRARY_IMPL(aten, Conjugate, m) {
   m.impl("set_.source_Storage_storage_offset", torch::CppFunction::makeFallthrough());
   m.impl("set_.source_Tensor", torch::CppFunction::makeFallthrough());

--- a/aten/src/ATen/native/AutogradComposite.cpp
+++ b/aten/src/ATen/native/AutogradComposite.cpp
@@ -45,7 +45,7 @@ Tensor _new_zeros_with_same_feature_meta(
     int64_t self_num_batch_dims) {
   auto other_sizes = other.sym_sizes();
   auto other_strides = other.sym_strides();
-  auto other_storage_offset = other.storage_offset();
+  auto other_storage_offset = other.sym_storage_offset();
   auto other_storage_numel = other.storage().sym_nbytes() / c10::SymInt(other.itemsize());
 
   if (self_num_batch_dims == 0) {

--- a/aten/src/ATen/native/NegateFallback.cpp
+++ b/aten/src/ATen/native/NegateFallback.cpp
@@ -19,6 +19,10 @@ TORCH_LIBRARY_IMPL(_, Negative, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&negationFallback>());
 }
 
+TORCH_LIBRARY_IMPL(prims, Negative, m) {
+  m.impl("as_strided", torch::CppFunction::makeFallthrough());
+}
+
 TORCH_LIBRARY_IMPL(aten, Negative, m) {
   m.impl("set_.source_Storage_storage_offset", torch::CppFunction::makeFallthrough());
   m.impl("set_.source_Tensor", torch::CppFunction::makeFallthrough());

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1358,6 +1358,19 @@ static Tensor make_qtensor(
   return result;
 }
 
+static void copy_fake_tensor_metadata(
+    const Tensor& self,
+    TensorImpl* result_impl) {
+  if (!self.is_fake()) {
+    return;
+  }
+  if (auto fake_device = self.unsafeGetTensorImpl()->fake_device()) {
+    result_impl->set_and_normalize_fake_device(*fake_device);
+  }
+  result_impl->set_fake_tensor_mode(
+      self.unsafeGetTensorImpl()->fake_tensor_mode());
+}
+
 Tensor as_strided_tensorimpl(
     const Tensor& self,
     IntArrayRef size,
@@ -1370,6 +1383,7 @@ Tensor as_strided_tensorimpl(
       self.key_set(),
       self.dtype());
   setStrided(result, size, stride, storage_offset);
+  copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
   return result;
 }
 
@@ -1404,6 +1418,7 @@ Tensor as_strided_tensorimpl_meta_symint(
   // bases / storage size.
   setStridedUnchecked(
       result, sym_size, sym_stride, std::move(sym_storage_offset));
+  copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
   return result;
 }
 
@@ -1970,6 +1985,7 @@ static Tensor alias_with_sizes_and_strides(
   } else {
     self_tmp_->set_sizes_and_strides(sizes, strides, self.storage_offset());
   }
+  copy_fake_tensor_metadata(self, self_tmp_);
   return self_;
 }
 

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -237,8 +237,10 @@ void AutogradMeta::set_fw_grad(
             if (view_info.has_view_fn()) {
               new_fw_grad_value = view_info.view_fn()(new_base_fw_grad);
             } else {
-              new_fw_grad_value = new_base_fw_grad.as_strided(
-                  self.sizes(), self.strides(), self.storage_offset());
+              new_fw_grad_value = new_base_fw_grad.as_strided_symint(
+                  self.sym_sizes(),
+                  self.sym_strides(),
+                  self.sym_storage_offset());
             }
 
             new_fw_grad_value.copy_(new_grad);
@@ -304,8 +306,8 @@ const Variable& AutogradMeta::fw_grad(
         if (view_info.has_view_fn()) {
           new_val = view_info.view_fn()(base_val);
         } else {
-          new_val = base_val.as_strided(
-              self.sizes(), self.strides(), self.storage_offset());
+          new_val = base_val.as_strided_symint(
+              self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
         }
 
         const_view_meta->fw_grad_->set_value(std::move(new_val), level);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -551,8 +551,8 @@ static PyObject* view_func_impl(
           out = view_func(new_base);
         }
       } else {
-        out = new_base.as_strided(
-            self.sizes(), self.strides(), self.storage_offset());
+        out = new_base.as_strided_symint(
+            self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
       }
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193750
* #192856
* #191798
* #190248
* __->__ #194742
* #190247

Low-level as_strided view construction copied the Fake dispatch key without preserving the fake mode and logical device. Preserve that metadata and symbolic storage offsets through view reconstruction, and let prims::as_strided retain conjugate and negative bits.

Test Plan:

```bash
python -c "import torch; x=torch.randn(4,dtype=torch.cfloat).conj(); y=torch.ops.prims.as_strided(x,(2,2),(2,1),0); torch.testing.assert_close(y,x.view(2,2)); assert y.is_conj(); x=torch._neg_view(torch.arange(4,dtype=torch.float)); y=torch.ops.prims.as_strided(x,(2,2),(2,1),0); torch.testing.assert_close(y,x.view(2,2)); assert y.is_neg()"
```

Authored with an AI assistant.