### PR TITLE
[CPP FakeTensor] Preserve FakeTensor metadata through as_strided views

### DIFF
--- a/aten/src/ATen/ConjugateFallback.cpp
+++ b/aten/src/ATen/ConjugateFallback.cpp
@@ -18,6 +18,10 @@ TORCH_LIBRARY_IMPL(_, Conjugate, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&conjugateFallback>());
 }
 
+TORCH_LIBRARY_IMPL(prims, Conjugate, m) {
+  m.impl("as_strided", torch::CppFunction::makeFallthrough());
+}
+
 TORCH_LIBRARY_IMPL(aten, Conjugate, m) {
   m.impl("set_.source_Storage_storage_offset", torch::CppFunction::makeFallthrough());
   m.impl("set_.source_Tensor", torch::CppFunction::makeFallthrough());

--- a/aten/src/ATen/native/AutogradComposite.cpp
+++ b/aten/src/ATen/native/AutogradComposite.cpp
@@ -45,7 +45,7 @@ Tensor _new_zeros_with_same_feature_meta(
     int64_t self_num_batch_dims) {
   auto other_sizes = other.sym_sizes();
   auto other_strides = other.sym_strides();
-  auto other_storage_offset = other.storage_offset();
+  auto other_storage_offset = other.sym_storage_offset();
   auto other_storage_numel = other.storage().sym_nbytes() / c10::SymInt(other.itemsize());
 
   if (self_num_batch_dims == 0) {

--- a/aten/src/ATen/native/NegateFallback.cpp
+++ b/aten/src/ATen/native/NegateFallback.cpp
@@ -19,6 +19,10 @@ TORCH_LIBRARY_IMPL(_, Negative, m) {
   m.fallback(torch::CppFunction::makeFromBoxedFunction<&negationFallback>());
 }
 
+TORCH_LIBRARY_IMPL(prims, Negative, m) {
+  m.impl("as_strided", torch::CppFunction::makeFallthrough());
+}
+
 TORCH_LIBRARY_IMPL(aten, Negative, m) {
   m.impl("set_.source_Storage_storage_offset", torch::CppFunction::makeFallthrough());
   m.impl("set_.source_Tensor", torch::CppFunction::makeFallthrough());

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1358,6 +1358,19 @@ static Tensor make_qtensor(
   return result;
 }
 
+static void copy_fake_tensor_metadata(
+    const Tensor& self,
+    TensorImpl* result_impl) {
+  if (!self.is_fake()) {
+    return;
+  }
+  if (auto fake_device = self.unsafeGetTensorImpl()->fake_device()) {
+    result_impl->set_and_normalize_fake_device(*fake_device);
+  }
+  result_impl->set_fake_tensor_mode(
+      self.unsafeGetTensorImpl()->fake_tensor_mode());
+}
+
 Tensor as_strided_tensorimpl(
     const Tensor& self,
     IntArrayRef size,
@@ -1370,6 +1383,7 @@ Tensor as_strided_tensorimpl(
       self.key_set(),
       self.dtype());
   setStrided(result, size, stride, storage_offset);
+  copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
   return result;
 }
 
@@ -1404,6 +1418,7 @@ Tensor as_strided_tensorimpl_meta_symint(
   // bases / storage size.
   setStridedUnchecked(
       result, sym_size, sym_stride, std::move(sym_storage_offset));
+  copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
   return result;
 }
 
@@ -1970,6 +1985,7 @@ static Tensor alias_with_sizes_and_strides(
   } else {
     self_tmp_->set_sizes_and_strides(sizes, strides, self.storage_offset());
   }
+  copy_fake_tensor_metadata(self, self_tmp_);
   return self_;
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1361,7 +1361,9 @@ static Tensor make_qtensor(
 // as_strided creates a new TensorImpl but shares the storage so for faketensor
 // we need to copy over the metadata like the device and also the faketensormode
 // pointer
-static void copy_fake_tensor_metadata(const Tensor& self, TensorImpl* result) {
+static void maybe_copy_fake_tensor_metadata(
+    const Tensor& self,
+    TensorImpl* result) {
   if (!self.is_fake()) {
     return;
   }
@@ -1383,7 +1385,7 @@ Tensor as_strided_tensorimpl(
       self.key_set(),
       self.dtype());
   setStrided(result, size, stride, storage_offset);
-  copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
+  maybe_copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
   return result;
 }
 
@@ -1418,7 +1420,7 @@ Tensor as_strided_tensorimpl_meta_symint(
   // bases / storage size.
   setStridedUnchecked(
       result, sym_size, sym_stride, std::move(sym_storage_offset));
-  copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
+  maybe_copy_fake_tensor_metadata(self, result.unsafeGetTensorImpl());
   return result;
 }
 
@@ -1985,7 +1987,7 @@ static Tensor alias_with_sizes_and_strides(
   } else {
     self_tmp_->set_sizes_and_strides(sizes, strides, self.storage_offset());
   }
-  copy_fake_tensor_metadata(self, self_tmp_);
+  maybe_copy_fake_tensor_metadata(self, self_tmp_);
   return self_;
 }
 

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1358,6 +1358,9 @@ static Tensor make_qtensor(
   return result;
 }
 
+// as_strided creates a new TensorImpl but shares the storage so for faketensor
+// we need to copy over the metadata like the device and also the faketensormode
+// pointer
 static void copy_fake_tensor_metadata(const Tensor& self, TensorImpl* result) {
   if (!self.is_fake()) {
     return;

--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1358,17 +1358,14 @@ static Tensor make_qtensor(
   return result;
 }
 
-static void copy_fake_tensor_metadata(
-    const Tensor& self,
-    TensorImpl* result_impl) {
+static void copy_fake_tensor_metadata(const Tensor& self, TensorImpl* result) {
   if (!self.is_fake()) {
     return;
   }
-  if (auto fake_device = self.unsafeGetTensorImpl()->fake_device()) {
-    result_impl->set_and_normalize_fake_device(*fake_device);
-  }
-  result_impl->set_fake_tensor_mode(
-      self.unsafeGetTensorImpl()->fake_tensor_mode());
+  auto fake_device = self.unsafeGetTensorImpl()->fake_device();
+  TORCH_INTERNAL_ASSERT(fake_device.has_value());
+  result->set_and_normalize_fake_device(*fake_device);
+  result->set_fake_tensor_mode(self.unsafeGetTensorImpl()->fake_tensor_mode());
 }
 
 Tensor as_strided_tensorimpl(

--- a/aten/src/ATen/test/native_test.cpp
+++ b/aten/src/ATen/test/native_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <ATen/ATen.h>
+#include <ATen/ops/as_strided_native.h>
 #include <c10/util/irange.h>
 
 using namespace at;
@@ -260,6 +261,22 @@ TEST(TestNative, NativeTestCPU) {
 
   test(at::device(kCPU).dtype(kFloat),
        at::device(kCPU).dtype(kDouble));
+}
+
+TEST(TestNative, AsStridedPreservesFakeTensorMetadata) {
+  auto input = at::empty({4}, at::device(at::kMeta));
+  auto mode = std::make_shared<c10::FakeTensorMode>(nullptr, nullptr);
+  auto* input_impl = input.unsafeGetTensorImpl();
+  input_impl->set_and_normalize_fake_device(c10::Device(c10::kCPU));
+  input_impl->set_fake_tensor_mode(mode);
+
+  auto result = at::native::as_strided_tensorimpl(input, {2, 2}, {2, 1}, 0);
+  auto* result_impl = result.unsafeGetTensorImpl();
+  auto fake_device = result_impl->fake_device();
+
+  ASSERT_TRUE(fake_device.has_value());
+  EXPECT_EQ(*fake_device, c10::Device(c10::kCPU));
+  EXPECT_EQ(result_impl->fake_tensor_mode(), mode);
 }
 
 TEST(TestNative, NativeTestGPU) {

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1449,6 +1449,13 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // use when the device might lack an index ("cuda" vs "cuda:0").
   void set_and_normalize_fake_device(c10::Device fake_device);
 
+  std::optional<c10::Device> fake_device() const {
+    if (!extra_meta_) {
+      return std::nullopt;
+    }
+    return extra_meta_->fake_device_;
+  }
+
   void set_fake_tensor_mode(std::shared_ptr<FakeTensorMode> mode) {
     get_extra_meta().fake_tensor_mode_ = std::move(mode);
   }

--- a/c10/core/TensorImpl.h
+++ b/c10/core/TensorImpl.h
@@ -1449,6 +1449,7 @@ struct C10_API TensorImpl : public c10::intrusive_ptr_target {
   // use when the device might lack an index ("cuda" vs "cuda:0").
   void set_and_normalize_fake_device(c10::Device fake_device);
 
+  // the fake device recorded for this tensor, or nullopt if none
   std::optional<c10::Device> fake_device() const {
     if (!extra_meta_) {
       return std::nullopt;

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2275,6 +2275,22 @@ class TestCompositeCompliance(TestCase):
 class TestMathBits(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
+    @onlyCPU
+    def test_prims_as_strided_conjugate(self, device):
+        x = torch.randn(4, dtype=torch.cfloat, device=device).conj()
+        result = torch.ops.prims.as_strided(x, (2, 2), (2, 1), 0)
+
+        self.assertTrue(result.is_conj())
+        self.assertEqual(result, x.view(2, 2))
+
+    @onlyCPU
+    def test_prims_as_strided_negative(self, device):
+        x = torch._neg_view(torch.arange(4, dtype=torch.float, device=device))
+        result = torch.ops.prims.as_strided(x, (2, 2), (2, 1), 0)
+
+        self.assertTrue(result.is_neg())
+        self.assertEqual(result, x.view(2, 2))
+
     # Tests that
     # 1. The operator's output for physically conjugated/negated tensors and conjugate/negative view tensors
     # produces the same value

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -19,6 +19,10 @@ from torch._prims.context import TorchRefsMode
 from torch._prims_common.wrappers import _maybe_remove_out_wrapper
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch._subclasses.fake_utils import outputs_alias_inputs
+from torch.fx.experimental.symbolic_shapes import (
+    constrain_range,
+    ShapeEnv as SymbolicShapeEnv,
+)
 from torch.testing import make_tensor
 from torch.testing._internal import composite_compliance, opinfo
 from torch.testing._internal.common_cuda import with_tf32_off
@@ -2275,6 +2279,14 @@ class TestCompositeCompliance(TestCase):
 class TestMathBits(TestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
+    def _symbolic_meta(self, dtype):
+        shape_env = SymbolicShapeEnv()
+        size = shape_env.create_unbacked_symint()
+        constrain_range(size, min=1, max=10)
+        result = torch.empty_strided((size, 7), (7, 1), dtype=dtype, device="meta")
+        self.assertIsInstance(result.shape[0], torch.SymInt)
+        return result
+
     @onlyCPU
     def test_prims_as_strided_conjugate(self, device):
         x = torch.randn(4, dtype=torch.cfloat, device=device).conj()
@@ -2283,6 +2295,22 @@ class TestMathBits(TestCase):
         self.assertTrue(result.is_conj())
         self.assertEqual(result, x.view(2, 2))
 
+        base = self._symbolic_meta(torch.cfloat)
+        torch._C._set_conj(base, True)
+        view = torch.ops.prims.as_strided(
+            base,
+            (base.shape[1], base.shape[0]),
+            (1, base.stride(0)),
+            0,
+        )
+        with torch.autograd.forward_ad.dual_level():
+            dual = torch.autograd.forward_ad.make_dual(view.clone(), view.clone())
+            view.copy_(dual)
+            tangent = torch.autograd.forward_ad.unpack_dual(view).tangent
+
+        self.assertTrue(tangent.is_conj())
+        self.assertEqual(tangent.shape, view.shape)
+
     @onlyCPU
     def test_prims_as_strided_negative(self, device):
         x = torch._neg_view(torch.arange(4, dtype=torch.float, device=device))
@@ -2290,6 +2318,22 @@ class TestMathBits(TestCase):
 
         self.assertTrue(result.is_neg())
         self.assertEqual(result, x.view(2, 2))
+
+        base = self._symbolic_meta(torch.float)
+        torch._C._set_neg(base, True)
+        view = torch.ops.prims.as_strided(
+            base,
+            (base.shape[1], base.shape[0]),
+            (1, base.stride(0)),
+            0,
+        )
+        with torch.autograd.forward_ad.dual_level():
+            dual = torch.autograd.forward_ad.make_dual(base.clone(), base.clone())
+            base.copy_(dual)
+            tangent = torch.autograd.forward_ad.unpack_dual(view).tangent
+
+        self.assertTrue(tangent.is_neg())
+        self.assertEqual(tangent.shape, view.shape)
 
     # Tests that
     # 1. The operator's output for physically conjugated/negated tensors and conjugate/negative view tensors

--- a/torch/csrc/autograd/autograd_meta.cpp
+++ b/torch/csrc/autograd/autograd_meta.cpp
@@ -237,8 +237,10 @@ void AutogradMeta::set_fw_grad(
             if (view_info.has_view_fn()) {
               new_fw_grad_value = view_info.view_fn()(new_base_fw_grad);
             } else {
-              new_fw_grad_value = new_base_fw_grad.as_strided(
-                  self.sizes(), self.strides(), self.storage_offset());
+              new_fw_grad_value = new_base_fw_grad.as_strided_symint(
+                  self.sym_sizes(),
+                  self.sym_strides(),
+                  self.sym_storage_offset());
             }
 
             new_fw_grad_value.copy_(new_grad);
@@ -304,8 +306,8 @@ const Variable& AutogradMeta::fw_grad(
         if (view_info.has_view_fn()) {
           new_val = view_info.view_fn()(base_val);
         } else {
-          new_val = base_val.as_strided(
-              self.sizes(), self.strides(), self.storage_offset());
+          new_val = base_val.as_strided_symint(
+              self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
         }
 
         const_view_meta->fw_grad_->set_value(std::move(new_val), level);

--- a/torch/csrc/autograd/python_variable.cpp
+++ b/torch/csrc/autograd/python_variable.cpp
@@ -551,8 +551,8 @@ static PyObject* view_func_impl(
           out = view_func(new_base);
         }
       } else {
-        out = new_base.as_strided(
-            self.sizes(), self.strides(), self.storage_offset());
+        out = new_base.as_strided_symint(
+            self.sym_sizes(), self.sym_strides(), self.sym_storage_offset());
       }
     }
   }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193750
* #192856
* #191798
* #190248
* #197173
* #197172
* #197175
* #197168
* #197167
* #194780
* #194758
* __->__ #194744

Low-level as_strided view construction copied the Fake dispatch key without preserving the fake mode and logical device. Preserve that metadata and symbolic storage offsets through view reconstruction, and let prims::as_strided retain conjugate and negative bits.

Test Plan:

```bash
python -c "import torch; x=torch.randn(4,dtype=torch.cfloat).conj(); y=torch.ops.prims.as_strided(x,(2,2),(2,1),0); torch.testing.assert_close(y,x.view(2,2)); assert y.is_conj(); x=torch._neg_view(torch.arange(4,dtype=torch.float)); y=torch.ops.prims.as_strided(x,(2,2),(2,1),0); torch.testing.assert_close(y,x.view(2,2)); assert y.is_neg()"
```

Authored with an AI assistant.