### PR TITLE
[BE] MacOS CD: Update `actions/` to latest majors

### DIFF
--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -182,7 +182,7 @@ jobs:
         with:
           python-version: "3.10.4"
           freethreaded: false
-      - uses: actions/download-artifact@v6.0.0
+      - uses: actions/download-artifact@v7.0.0
         name: Download Wheel Artifact
         with:
           name: !{{ lt_config["source_wheel_build_name"] }}

--- a/.github/templates/macos_binary_build_workflow.yml.j2
+++ b/.github/templates/macos_binary_build_workflow.yml.j2
@@ -74,7 +74,7 @@ jobs:
         run: |
           echo "BINARY_ENV_FILE=${RUNNER_TEMP}/env" >> "${GITHUB_ENV}"
       - name: Checkout PyTorch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.1.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           # Full fetch on tag pushes so the release tag is visible to
@@ -110,7 +110,7 @@ jobs:
       # Upload phase: each wheel becomes its own artifact (one call per name).
 {%- for config in build_configs %}
       - name: Upload !{{ config["build_name"] }}
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: !{{ config["build_name"] }}
@@ -172,7 +172,7 @@ jobs:
       LIBTORCH_VARIANT: !{{ lt_config["libtorch_variant"] }}
     steps:
       - name: Checkout PyTorch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.1.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           sparse-checkout: .ci/libtorch/
@@ -182,7 +182,7 @@ jobs:
         with:
           python-version: "3.10.4"
           freethreaded: false
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v6.0.0
         name: Download Wheel Artifact
         with:
           name: !{{ lt_config["source_wheel_build_name"] }}
@@ -197,7 +197,7 @@ jobs:
             --platform macos \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: !{{ lt_config["build_name"] }}

--- a/.github/workflows/_binary-test-macos.yml
+++ b/.github/workflows/_binary-test-macos.yml
@@ -71,7 +71,7 @@ jobs:
           # setup-python needs this to resolve the latest 3.15 beta. No-op for
           # the exact stable versions the other Pythons pass.
           allow-prereleases: true
-      - uses: actions/download-artifact@v6.0.0
+      - uses: actions/download-artifact@v7.0.0
         with:
           name: ${{ inputs.build_name }}
           path: ${{ runner.temp }}/artifacts

--- a/.github/workflows/_binary-test-macos.yml
+++ b/.github/workflows/_binary-test-macos.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout smoke-test script
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.1.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           sparse-checkout: .ci/pytorch/smoke_test/
@@ -71,7 +71,7 @@ jobs:
           # setup-python needs this to resolve the latest 3.15 beta. No-op for
           # the exact stable versions the other Pythons pass.
           allow-prereleases: true
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v6.0.0
         with:
           name: ${{ inputs.build_name }}
           path: ${{ runner.temp }}/artifacts

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -120,7 +120,7 @@ jobs:
         # tolerate that. On nightly/release-tag pushes the artifact always exists,
         # and swallowing its absence makes "Upload binaries" a silent no-op.
         continue-on-error: ${{ !(github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')))) }}
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: ${{ inputs.build_name }}
           path: "${{ runner.temp }}/artifacts/"

--- a/.github/workflows/_binary-upload.yml
+++ b/.github/workflows/_binary-upload.yml
@@ -120,7 +120,7 @@ jobs:
         # tolerate that. On nightly/release-tag pushes the artifact always exists,
         # and swallowing its absence makes "Upload binaries" a silent no-op.
         continue-on-error: ${{ !(github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || (startsWith(github.event.ref, 'refs/tags/') && !startsWith(github.event.ref, 'refs/tags/ciflow/')))) }}
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ inputs.build_name }}
           path: "${{ runner.temp }}/artifacts/"

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -241,7 +241,7 @@ jobs:
         with:
           python-version: "3.10.4"
           freethreaded: false
-      - uses: actions/download-artifact@v6.0.0
+      - uses: actions/download-artifact@v7.0.0
         name: Download Wheel Artifact
         with:
           name: wheel-py3_10-cpu

--- a/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
+++ b/.github/workflows/generated-macos-arm64-binary-wheel-nightly.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo "BINARY_ENV_FILE=${RUNNER_TEMP}/env" >> "${GITHUB_ENV}"
       - name: Checkout PyTorch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.1.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           # Full fetch on tag pushes so the release tag is visible to
@@ -94,7 +94,7 @@ jobs:
           "${PYTORCH_ROOT}/.ci/macwheel/build_all_macos_wheels.sh"
       # Upload phase: each wheel becomes its own artifact (one call per name).
       - name: Upload wheel-py3_10-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_10-cpu
@@ -102,7 +102,7 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_10-cpu
       - name: Upload wheel-py3_11-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_11-cpu
@@ -110,7 +110,7 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_11-cpu
       - name: Upload wheel-py3_12-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_12-cpu
@@ -118,7 +118,7 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_12-cpu
       - name: Upload wheel-py3_13-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_13-cpu
@@ -126,7 +126,7 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_13-cpu
       - name: Upload wheel-py3_14-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_14-cpu
@@ -134,7 +134,7 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_14-cpu
       - name: Upload wheel-py3_14t-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_14t-cpu
@@ -142,7 +142,7 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_14t-cpu
       - name: Upload wheel-py3_15-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_15-cpu
@@ -150,7 +150,7 @@ jobs:
           if-no-files-found: error
           path: ${{ runner.temp }}/artifacts/wheel-py3_15-cpu
       - name: Upload wheel-py3_15t-cpu
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: wheel-py3_15t-cpu
@@ -231,7 +231,7 @@ jobs:
       LIBTORCH_VARIANT: shared-with-deps
     steps:
       - name: Checkout PyTorch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5.1.0
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           sparse-checkout: .ci/libtorch/
@@ -241,7 +241,7 @@ jobs:
         with:
           python-version: "3.10.4"
           freethreaded: false
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v6.0.0
         name: Download Wheel Artifact
         with:
           name: wheel-py3_10-cpu
@@ -256,7 +256,7 @@ jobs:
             --platform macos \
             --desired-cuda "$DESIRED_CUDA" \
             --libtorch-variant "$LIBTORCH_VARIANT"
-      - uses: actions/upload-artifact@v4.4.0
+      - uses: actions/upload-artifact@v6.0.0
         if: always()
         with:
           name: libtorch-cpu-shared-with-deps-release


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #194748

This would suppress gazillion warnings that Node-20 is deprecated which
one can observe for example in https://github.com/pytorch/pytorch/actions/runs/32851904205

Written with assistance of Codex regex prowess