### PR TITLE
[dynamo] Stop writing a source onto the interned ConstantVariable(None)

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -4575,6 +4575,37 @@ class ReproTests(torch._dynamo.test_case.TestCase):
             if isinstance(backend, CompileCounter):
                 self.assertEqual(backend.frame_count, 2)  # graph breaks
 
+    def test_grad_attr_does_not_poison_the_interned_none(self):
+        # Reading a tensor's .grad labels the RESULT with an AttrSource, and when
+        # there is a pending `p.grad = None` store that result is the
+        # VariableTracker side_effects is holding -- which for None is a
+        # process-wide interned ConstantVariable. Writing a source onto it left
+        # every LATER compile in the process reconstructing a local from THIS
+        # frame, and dying in create_load with "self missing".
+        class Holder:
+            def __init__(self, model):
+                self.model = model
+
+            def step(self, x, t):
+                for p in self.model.parameters():
+                    p.grad = None
+                torch.nn.functional.mse_loss(self.model(x), t).backward()
+
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+        with torch._dynamo.config.patch(trace_autograd_ops=True):
+            step = Holder(torch.nn.Linear(4, 3)).step
+            torch.compile(step, backend="eager", fullgraph=True)(x, t)
+
+        none_vt = torch._dynamo.variables.ConstantVariable.create(None)
+        self.addCleanup(setattr, none_vt, "source", None)
+        self.assertIsNone(none_vt.source)
+
+        def later(m, xx):
+            return m(xx), None
+
+        opt = torch.compile(later, backend="eager", fullgraph=True)
+        self.assertIsNone(opt(torch.nn.Linear(4, 3), x)[1])
+
     def test_dynamic_shapes_double_not_equal(self):
         # https://github.com/pytorch/pytorch/issues/113393
         def fn(x):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -769,7 +769,17 @@ class TensorVariable(VariableTracker):
             )
         ):
             install_guard(self.make_guard(GuardBuilder.TYPE_MATCH))
-            result.source = AttrSource(self.source, name)
+            if result.is_python_constant():
+                # ConstantVariable.create(None) is a process-wide singleton, and
+                # method_attr_grad hands it back for a pending `p.grad = None`; a
+                # source written onto it leaks into every later compile. Non-constants
+                # keep the in-place write: .data's tracker is AttributeMutationNew,
+                # which __init__ rejects a source for.
+                result = result.clone(
+                    source=AttrSource(self.source, name), source_location=None
+                )
+            else:
+                result.source = AttrSource(self.source, name)
 
         # It's hard to get inplace view (metadata mutation) on graph input work properly across
         # dynamo/aot/inductor, just fall back.


### PR DESCRIPTION
First of six fixes this stack needs before torch.compiler.precompile at the
top of it can capture anything.

Background, because the bug is only obvious once two facts sit next to each
other. Dynamo never handles real values while tracing; every value is wrapped
in a VariableTracker, and `ConstantVariable` is the wrapper for the ones it can
treat as compile-time constants. `ConstantVariable.create(None)` therefore does
not make a None -- it asks for the tracker that DESCRIBES None. And because
every None is indistinguishable, `create` is a cache: with no kwargs it returns
`CONSTANT_VARIABLE_NONE`, one object allocated at import and handed to every
caller in the process. The second fact is that a tracker's `source` records how
to rebuild the value, in bytecode, from the frame currently being compiled --
`LOAD_FAST x; LOAD_ATTR grad`. It is meaningful only inside that frame.

Reading a tensor attribute labels the result with an AttrSource so downstream
code can reconstruct it. `getattro_impl` did that by assignment, which is safe
only when the result is a tracker it just built. For `.grad` and
`requires_grad` it is not: the value is the shared singleton, so the assignment
stamps a name from THIS frame onto the object every later compile in the
process will also be handed. The next unrelated function to touch a None gets a
tracker claiming it can be rebuilt as `x.grad`, tries it, and dies in
`create_load` with "<name> missing" -- in code with no connection to the
culprit. The cache is fine; mutating a cached object is not, for the same
reason you do not mutate a default argument.

Clone before labelling, but only for constants. A blanket clone breaks `.data`:
the tracker it hands back is freshly created, and `VariableTracker.__init__`
rejects a source on one of those ("source must be None for
ValueMutationNew/AttributeMutationNew"), so only the in-place write gets
through. The guard above the branch already restricts constants to
grad/requires_grad, so the clone arm is exactly the singleton case.

Why the top of the stack needs it: a precompile training capture pins
`trace_autograd_ops` and seeds a zero `.grad` on every autograd target before
re-capturing, which is exactly the shape that poisons the singleton. With this
hunk reverted, 32 tests in test/test_precompile.py fail.

Test Plan:

The regression test turns on `trace_autograd_ops`, compiles a step that nulls
`.grad` before calling `backward()`, then compiles an unrelated function. The
second compile raises without the fix.

```
python test/dynamo/test_repros.py
python test/dynamo/test_misc.py
```

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
