### PR TITLE
Make sparse tensor validation state thread-local

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import sys
 import tempfile
+import threading
 import unittest
 import warnings
 import zipfile
@@ -4911,6 +4912,67 @@ class TestSerialization(TestCase, SerializationMixin):
         with torch.sparse.check_sparse_tensor_invariants(True):
             with self.assertRaisesRegex(RuntimeError, "size is inconsistent with indices"):
                 torch.load(bad_buf, weights_only=False)
+
+    def test_weights_only_sparse_validation_is_thread_local(self):
+        bad = torch.sparse_coo_tensor(
+            torch.tensor([[0, 999]]),
+            torch.tensor([1.0, 2.0]),
+            (2,),
+            check_invariants=False,
+        )
+        bad_buffer = io.BytesIO()
+        torch.save({"s": bad}, bad_buffer)
+        good_buffer = io.BytesIO()
+        torch.save({"t": torch.ones(1)}, good_buffer)
+
+        bad_validation_started = threading.Event()
+        resume_bad_validation = threading.Event()
+        original_validate = torch._utils._validate_loaded_sparse_tensors
+        errors = {}
+        results = {}
+
+        def synchronized_validate(weights_only=False):
+            if threading.current_thread() is bad_thread:
+                bad_validation_started.set()
+                if not resume_bad_validation.wait(timeout=5):
+                    raise RuntimeError("timed out waiting to resume validation")
+            return original_validate(weights_only=weights_only)
+
+        def load_bad():
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    results["bad"] = torch.load(
+                        io.BytesIO(bad_buffer.getvalue()), weights_only=True
+                    )
+            except Exception as error:
+                errors["bad"] = error
+
+        bad_thread = threading.Thread(target=load_bad)
+        with patch.object(
+            torch._utils,
+            "_validate_loaded_sparse_tensors",
+            synchronized_validate,
+        ):
+            bad_thread.start()
+            try:
+                self.assertTrue(bad_validation_started.wait(timeout=5))
+                try:
+                    results["good"] = torch.load(
+                        io.BytesIO(good_buffer.getvalue()), weights_only=True
+                    )
+                except Exception as error:
+                    errors["good"] = error
+            finally:
+                resume_bad_validation.set()
+                bad_thread.join(timeout=5)
+
+        self.assertFalse(bad_thread.is_alive())
+        self.assertNotIn("good", errors)
+        self.assertEqual(results["good"]["t"], torch.ones(1))
+        self.assertNotIn("bad", results)
+        self.assertIn("bad", errors)
+        self.assertRegex(str(errors["bad"]), "size is inconsistent with indices")
 
     def run(self, *args, **kwargs):
         with serialization_method(use_zip=True):

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -274,7 +274,8 @@ def _rebuild_tensor_v3(
     return t
 
 
-_sparse_tensors_to_validate: list["torch.Tensor"] = []
+def _get_sparse_tensors_to_validate() -> list["torch.Tensor"]:
+    return torch.serialization._serialization_tls.sparse_tensors_to_validate
 
 
 # In _legacy_load() in serialization.py we unpickle storages after the sparse
@@ -292,8 +293,9 @@ def _validate_loaded_sparse_tensors(weights_only=False):
     # cause out-of-bounds reads later (e.g. in to_dense()), and an untrusted
     # checkpoint must not be able to slip those through. Otherwise we fall back
     # to the global check_sparse_tensor_invariants setting.
+    sparse_tensors_to_validate = _get_sparse_tensors_to_validate()
     try:
-        if not _sparse_tensors_to_validate:
+        if not sparse_tensors_to_validate:
             return
         if weights_only:
             warnings.warn(
@@ -307,7 +309,7 @@ def _validate_loaded_sparse_tensors(weights_only=False):
         # We disable pinning check (see check_pinning=False below) to
         # avoid gh-153143. In fact, pinning check is unnecessary
         # anyway when loading sparse data from external sources.
-        for t in _sparse_tensors_to_validate:
+        for t in sparse_tensors_to_validate:
             if t.layout is torch.sparse_coo:
                 torch._validate_sparse_coo_tensor_args(
                     t._indices(),
@@ -348,7 +350,7 @@ def _validate_loaded_sparse_tensors(weights_only=False):
                 )
 
     finally:
-        _sparse_tensors_to_validate.clear()
+        sparse_tensors_to_validate.clear()
 
 
 def _rebuild_sparse_tensor(layout, data):
@@ -369,7 +371,7 @@ def _rebuild_sparse_tensor(layout, data):
         result = torch.sparse_coo_tensor(
             indices, values, size, check_invariants=False, is_coalesced=is_coalesced
         )
-        _sparse_tensors_to_validate.append(result)
+        _get_sparse_tensors_to_validate().append(result)
         return result
 
     elif layout in {
@@ -387,7 +389,7 @@ def _rebuild_sparse_tensor(layout, data):
             layout=layout,
             check_invariants=False,
         )
-        _sparse_tensors_to_validate.append(result)
+        _get_sparse_tensors_to_validate().append(result)
         return result
 
     raise NotImplementedError(f"rebuilding sparse tensor for layout {layout}")

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -72,7 +72,7 @@ from sys import maxsize
 from typing import Any
 
 import torch
-from torch._utils import _sparse_tensors_to_validate, IMPORT_MAPPING, NAME_MAPPING
+from torch._utils import _get_sparse_tensors_to_validate, IMPORT_MAPPING, NAME_MAPPING
 
 
 # modules in this list are never allowed, even if the user attempts to allowlist
@@ -381,7 +381,7 @@ class Unpickler:
                 ):
                     result = cls.__new__(cls, *args)
                     if cls in torch._tensor_classes and "sparse" in cls.__module__:
-                        _sparse_tensors_to_validate.append(result)
+                        _get_sparse_tensors_to_validate().append(result)
                     self.append(result)
                 else:
                     raise UnpicklingError(
@@ -403,7 +403,7 @@ class Unpickler:
                     raise UnpicklingError(error_msg)
                 result = func(*args)
                 if func in torch._tensor_classes and "sparse" in func.__module__:
-                    _sparse_tensors_to_validate.append(result)
+                    _get_sparse_tensors_to_validate().append(result)
                 self.stack[-1] = result
             elif key[0] == BUILD[0]:
                 state = self.stack.pop()

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -102,6 +102,7 @@ class _SerializationLocal(threading.local):
         self.map_location: MAP_LOCATION | None = None
         self.skip_data: bool = False
         self.materialize_fake_tensors: bool = False
+        self.sparse_tensors_to_validate: list[torch.Tensor] = []
 
 
 _serialization_tls = _SerializationLocal()


### PR DESCRIPTION
# Fixing an Issue

## Issue

Fixes #194750

## Summary

QED Audit is proposing the thread-local fix requested by @malfet for #194750.

> AI-assisted content (Codex): Move the deferred sparse-validation collector
> onto PyTorch's existing `_SerializationLocal` state so concurrent
> `torch.load` calls cannot validate or clear one another's tensors. Add a
> deterministic integration test that pauses a malformed weights-only load at
> validation while an independent valid load completes. The test fails against
> the unpatched nightly and passes with this change. Codex assisted with the
> implementation, test, and PR wording; QED Audit directed and reviewed the
> contribution scope.

## Checklist

- [x] Passes targeted Ruff/PyFmt lint and `git diff --check`
- [x] Added/updated tests
- [x] Updated documentation (not applicable; no public API or behavior change)
- [x] Included benchmark results (not applicable; no performance-sensitive path change)

## BC-breaking?

No.
