### PR TITLE
[dynamo] Guard autocast objects by value rather than identity

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -1,5 +1,6 @@
 # Owner(s): ["module: dynamo"]
 import contextlib
+import inspect
 import sys
 import unittest
 from collections import defaultdict
@@ -322,6 +323,15 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(compiled.device.index, 0)
         self.assertEqual(compiled.dtype, torch.float32)
 
+    def test_autocast_ctor_signature_is_pinned(self):
+        # builder.py and ctx_manager.py each hard-code this parameter list, in
+        # attribute-name and parameter-name form respectively; a new or reordered
+        # constructor parameter has to be reflected in both.
+        self.assertEqual(
+            list(inspect.signature(torch.amp.autocast_mode.autocast).parameters),
+            ["device_type", "dtype", "enabled", "cache_enabled"],
+        )
+
     def test_autocast_object_guarded_by_value_not_identity(self):
         # A user-held autocast object reaches the trace as four specialized
         # values (device, dtype, enabled, cache_enabled), so those are what the
@@ -333,6 +343,8 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             def __init__(self, ctx):
                 super().__init__()
                 self.ctx = ctx
+                # Unlike an nn.Linear weight, this tensor does not require grad, so
+                # the autocast cache cannot retain a stale bf16 cast across tests.
                 self.w = torch.randn(4, 4)
 
             def forward(self, x):
@@ -786,6 +798,8 @@ class GraphModule(torch.nn.Module):
         prev_enabled = torch.is_autocast_enabled("cpu")
         prev_dtype = torch.get_autocast_dtype("cpu")
         prev_cache = torch.is_autocast_cache_enabled()
+        nesting_before = torch.autocast_increment_nesting() - 1
+        torch.autocast_decrement_nesting()
 
         try:
             opt_f = torch.compile(f, backend="eager", fullgraph=True)
@@ -796,6 +810,9 @@ class GraphModule(torch.nn.Module):
             self.assertEqual(out, opt_out)
             self.assertEqual(out.dtype, opt_out.dtype)
             self.assertFalse(torch.is_autocast_enabled("cpu"))
+            nesting_after = torch.autocast_increment_nesting() - 1
+            torch.autocast_decrement_nesting()
+            self.assertEqual(nesting_after, nesting_before)
         finally:
             torch.set_autocast_enabled("cpu", prev_enabled)
             torch.set_autocast_dtype("cpu", prev_dtype)

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -776,6 +776,7 @@ class GraphModule(torch.nn.Module):
             torch.set_autocast_enabled("cpu", True)
             torch.set_autocast_dtype("cpu", torch.bfloat16)
             torch.set_autocast_cache_enabled(True)
+            torch.autocast_increment_nesting()
             x = x @ y
             torch.autocast_decrement_nesting()
             torch.clear_autocast_cache()
@@ -799,12 +800,6 @@ class GraphModule(torch.nn.Module):
             torch.set_autocast_enabled("cpu", prev_enabled)
             torch.set_autocast_dtype("cpu", prev_dtype)
             torch.set_autocast_cache_enabled(prev_cache)
-            # f() decrements the nesting counter with no matching increment and
-            # runs twice above, so the counter is left at -2. A negative counter
-            # stops autocast.__exit__ from ever reaching 0, so it never clears
-            # the weight cache, and later tests in this file see stale casts.
-            torch.autocast_increment_nesting()
-            torch.autocast_increment_nesting()
 
     def test__enter__exit_autocast_function_mode(self):
         class FunctionCount(torch.overrides.TorchFunctionMode):

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -322,6 +322,60 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertEqual(compiled.device.index, 0)
         self.assertEqual(compiled.dtype, torch.float32)
 
+    def test_autocast_object_guarded_by_value_not_identity(self):
+        # A user-held autocast object reaches the trace as four specialized
+        # values (device, dtype, enabled, cache_enabled), so those are what the
+        # graph depends on. Guarding the object by id() instead is both too
+        # strong -- a second object configured identically cannot reuse the
+        # graph -- and unserializable, which is what makes a precompiled
+        # artifact drop the guard entirely.
+        class MyModule(torch.nn.Module):
+            def __init__(self, ctx):
+                super().__init__()
+                self.ctx = ctx
+                self.w = torch.randn(4, 4)
+
+            def forward(self, x):
+                with self.ctx:
+                    return x @ self.w
+
+        module = MyModule(torch.amp.autocast("cpu", dtype=torch.bfloat16))
+        cnts = torch._dynamo.testing.CompileCounter()
+        compiled = torch.compile(module, backend=cnts)
+        x = torch.randn(4, 4)
+        self.assertEqual(compiled(x).dtype, torch.bfloat16)
+        self.assertEqual(cnts.frame_count, 1)
+
+        # A DIFFERENT object with the same settings: same graph, no recompile.
+        # An id() guard would miss here and recompile.
+        module.ctx = torch.amp.autocast("cpu", dtype=torch.bfloat16)
+        self.assertEqual(compiled(x).dtype, torch.bfloat16)
+        self.assertEqual(cnts.frame_count, 1)
+
+        # A different setting is a different graph.
+        module.ctx = torch.amp.autocast("cpu", dtype=torch.float16)
+        self.assertEqual(compiled(x).dtype, torch.float16)
+        self.assertEqual(cnts.frame_count, 2)
+
+        # Mutating in place must also invalidate the graph.
+        module.ctx._enabled = False
+        self.assertEqual(compiled(x).dtype, torch.float32)
+        self.assertEqual(cnts.frame_count, 3)
+
+    def test_autocast_object_from_constant_source(self):
+        @torch._dynamo.assume_constant_result
+        def get_ctx():
+            return torch.amp.autocast("cpu", dtype=torch.bfloat16)
+
+        weight = torch.randn(4, 4)
+
+        @torch.compile(backend="eager")
+        def fn(x):
+            with get_ctx():
+                return x @ weight
+
+        self.assertEqual(fn(torch.randn(4, 4)).dtype, torch.bfloat16)
+
     def test_autocast_cpu(self):
         class MyModule(torch.nn.Module):
             def forward(self, x):
@@ -745,6 +799,12 @@ class GraphModule(torch.nn.Module):
             torch.set_autocast_enabled("cpu", prev_enabled)
             torch.set_autocast_dtype("cpu", prev_dtype)
             torch.set_autocast_cache_enabled(prev_cache)
+            # f() decrements the nesting counter with no matching increment and
+            # runs twice above, so the counter is left at -2. A negative counter
+            # stops autocast.__exit__ from ever reaching 0, so it never clears
+            # the weight cache, and later tests in this file see stale casts.
+            torch.autocast_increment_nesting()
+            torch.autocast_increment_nesting()
 
     def test__enter__exit_autocast_function_mode(self):
         class FunctionCount(torch.overrides.TorchFunctionMode):

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -776,6 +776,27 @@ class TestGuardSerialization(TestGuardSerializationBase):
             False,
         )
 
+    def test_autocast_equals_match(self):
+        class Module(torch.nn.Module):
+            def __init__(self, ctx):
+                super().__init__()
+                self.ctx = ctx
+
+            def forward(self, x):
+                with self.ctx:
+                    return x @ x
+
+        module = Module(torch.amp.autocast("cpu", dtype=torch.bfloat16))
+        x = torch.randn(4, 4)
+        ref, loaded = self._test_serialization("EQUALS_MATCH", module, x)
+        self._test_check_fn(ref, loaded, {"self": module, "x": x}, True)
+
+        module.ctx = torch.amp.autocast("cpu", dtype=torch.bfloat16)
+        self._test_check_fn(ref, loaded, {"self": module, "x": x}, True)
+
+        module.ctx = torch.amp.autocast("cpu", dtype=torch.float16)
+        self._test_check_fn(ref, loaded, {"self": module, "x": x}, False)
+
     def test_constant_match(self):
         # === bool constant ===
         def fn(x, y):

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1826,14 +1826,22 @@ class VariableBuilder:
             if isinstance(value, torch.amp.autocast_mode._UnmanagedAutocast):
                 return self.wrap_user_defined(value)
             else:
-                self.install_guards(GuardBuilder.ID_MATCH)
+                # Guard the four fields the trace specializes on rather than the
+                # object's address. An ID_MATCH here cannot be serialized, so a
+                # precompile drops it and a sibling instance holding a DIFFERENT
+                # autocast object silently selects this variant; these guards
+                # also catch the object being mutated in place, which id() misses.
+                self.install_guards(GuardBuilder.TYPE_MATCH)
+                fields = ("device", "fast_dtype", "_enabled", "_cache_enabled")
+                if not is_constant_source(self.source):
+                    for field in fields:
+                        install_guard(
+                            AttrSource(self.source, field).make_guard(
+                                GuardBuilder.EQUALS_MATCH
+                            )
+                        )
                 return AutocastModeVariable(
-                    target_values=[
-                        value.device,
-                        value.fast_dtype,
-                        value._enabled,
-                        value._cache_enabled,
-                    ],
+                    target_values=[getattr(value, field) for field in fields],
                     source=self.source,
                 )
         elif TorchCtxManagerClassVariable.is_matching_cls(value):


### PR DESCRIPTION
Autocast objects are decomposed into device, dtype, enabled, and cache settings during tracing, but `VariableBuilder` guarded the object itself with `ID_MATCH`. Replacing an autocast object with an equivalent instance therefore caused an unnecessary recompile, while mutating the same object could reuse a stale graph. Identity guards also cannot be serialized for precompilation.

This installs a type guard plus equality guards on the four values consumed by the trace, and derives the specialized values from that same field list. The attribute guards are skipped for `ConstantSource` objects, whose source cannot construct guards, matching `VariableBuilder.install_guards` behavior.

Regression coverage is added for equivalent replacement, changed settings, in-place mutation, autocast objects returned by `assume_constant_result`, and serialization of the new equality guards.

### A pre-existing autocast state leak this PR exposed

The new value-guard test failed in CI and came back green only because of `--reruns=2`. Root cause, confirmed locally and unrelated to the guard change (it reproduces in pure eager):

`test_autocast_low_level_api` calls `torch.autocast_decrement_nesting()` with no matching increment, once in eager and once in the compiled callable, and its `finally` block restores enabled/dtype/cache but not the nesting counter, leaving it at -2. `autocast.__exit__` then never sees the counter reach 0, so `clear_autocast_cache()` never runs and a weight cached in bfloat16 survives into a later float16 region as `mat1 and mat2 must have the same dtype, but got Half and BFloat16`. Each rerun leaks +1 back into the counter (-2 -> -1 -> 0), which is why the third attempt passed.

Pairing the low-level decrement with an increment inside the callable fixes the leak at its source. The new test additionally uses a plain tensor rather than `nn.Linear`, so it holds no cacheable leaf Parameter and does not depend on cross-test cleanup. Either change alone is sufficient; both are kept because the leak is real and the test should be self-contained.

Two related problems are left as follow-ups: `torch._dynamo.test_case.TestCase` restores grad mode between tests but not autocast state, and Dynamo lowers `with autocast(...)` into straight-line enter/exit nodes with no `try`/`finally`, so an exception between them permanently leaks the nesting counter and dtype.

### Test Plan

Whole files, not a `-k` filter. The earlier filtered run is what hid the ordering-dependent failure above, since `-k autocast_object` deselects `test_autocast_low_level_api`.

```
python test/dynamo/test_ctx_manager.py
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_ctx_manager.py \
  CtxManagerTests.test_autocast_low_level_api \
  CtxManagerTests.test_autocast_object_guarded_by_value_not_identity
lintrunner --take PYFMT,RUFF,CODESPELL,FLAKE8 -a test/dynamo/test_ctx_manager.py
```

`test_ctx_manager.py`: 161 tests, only `test_autocast_sdpa` fails, which also fails on an unmodified `main` in this environment because Triton is not installed. `test_guard_serialization.py`: 61 tests, OK. Reverting the builder change to `ID_MATCH` makes the new test fail, so it is not vacuous.

This PR was authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
