### PR TITLE
[dynamo] Stop shipping every inlined module's whole source in the package

### DIFF
--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -170,12 +170,9 @@ class InlinedSource:
     firstlineno: int
     lastlineno: int
     checksum: str
-    content: str
-
-
-@functools.cache
-def _get_module_content(module: types.ModuleType) -> str:
-    return inspect.getsource(module)
+    # The whole module's source, kept for a reader that never arrived. Retained
+    # as a field so an old pickle still loads; never populated.
+    content: str = ""
 
 
 @dataclasses.dataclass
@@ -200,7 +197,6 @@ class SourceInfo:
                 firstlineno=firstlineno,
                 lastlineno=lastlineno,
                 checksum=_hash_source(source),
-                content=_get_module_content(module),
             )
         )
 


### PR DESCRIPTION
`InlinedSource` records the module, line range and checksum of each function
Dynamo inlined, so a load can tell whether the source has drifted. It also
carried `content`: the entire source text of the defining module, for every
module involved.

Nothing reads it. `grep` over torch and test finds one writer and no reader --
the drift check uses `checksum` and re-reads the live module. It is
deadweight, and it scales with the size of the modules the model happens to
touch rather than with the model.

Measured on an installed artifact for a graph-breaking TransformerEncoderLayer:
796,497 bytes to 91,105, an 88.6% reduction. The field stays on the dataclass
with a default so an artifact pickled before this still loads; it is simply
never populated, and `_get_module_content` goes with it.

Test Plan:

```
python test/dynamo/test_package.py
python test/test_precompile.py
python test/dynamo/test_precompile_context.py
```

No new test: there is nothing to assert beyond the absence of a field nothing
reads, and the drift check that does use these records is covered by
`test_package.py`'s existing `test_file_change`.

Authored with an AI assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98