### PR TITLE
[inductor] Write tl.constexpr values the generated kernel can actually evaluate

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -259,6 +259,101 @@ class KernelTests(torch._inductor.test_case.TestCase):
         # not crash
 
     @requires_gpu
+    def test_triton_kernel_intenum_constexpr(self):
+        # triton_meta is emitted with repr(), so an enum-valued tl.constexpr
+        # renders as "<RoundingMode.even: 2>" -- a SyntaxError that makes the
+        # generated file unimportable, losing the kernel and every frame above
+        # it to an eager fallback. fbgemm's MX4 quantize kernels take a
+        # RoundingMode this way.
+        import enum
+
+        class RoundingMode(enum.IntEnum):
+            even = 2
+            stochastic = 3
+
+        @triton.jit
+        def rounding_kernel(out_ptr, n, MODE: tl.constexpr, BLOCK: tl.constexpr):
+            offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+            # Compare against a plain int, as the fbgemm kernels do.
+            val = tl.where(MODE == 3, 1.0, 2.0)
+            tl.store(out_ptr + offs, val, mask=offs < n)
+
+        def f(x):
+            out = torch.empty_like(x)
+            rounding_kernel[(1,)](out, x.numel(), MODE=RoundingMode.even, BLOCK=64)
+            return out + 1
+
+        x = torch.rand(64, device=GPU_TYPE)
+        eager = f(x)
+        compiled = torch.compile(f, backend="inductor")(x)
+        # An IntEnum equals and hashes as its int, so substituting the int
+        # leaves the kernel Triton builds unchanged -- the branch above must
+        # still take the MODE != 3 arm.
+        self.assertEqual(compiled, eager)
+        self.assertTrue(torch.all(compiled == 3.0))
+
+    def test_constexpr_source_reconstructs_or_declines(self):
+        # repr() is not an expression for every constexpr a user can pass, and
+        # the value is written into generated source AND exec'd into the
+        # launcher, so an unspellable one is a SyntaxError in both rather than
+        # a bad launch. Reconstruct what can be reconstructed; decline clearly
+        # for the rest.
+        import enum
+        import plistlib
+
+        from torch._inductor.codegen.wrapper import (
+            _constexpr_constant,
+            _constexpr_source,
+        )
+
+        # A plain Enum from a real module: named, with the import it needs.
+        self.assertEqual(
+            _constexpr_source(plistlib.FMT_XML),
+            ("PlistFormat.FMT_XML", "from plistlib import PlistFormat"),
+        )
+
+        # An IntEnum equals and hashes as its int, so it becomes one -- which
+        # keeps the kernel Triton builds and its cache key unchanged.
+        class Mode(enum.IntEnum):
+            even = 2
+
+        self.assertEqual(_constexpr_constant(Mode.even), 2)
+
+        # Defined in a function body: not importable in the compile worker, so
+        # emitting an import would resolve to something else or nothing.
+        class Local(enum.Enum):
+            a = 1
+
+        self.assertIsNone(_constexpr_source(Local.a))
+
+        # Ordinary values are untouched.
+        self.assertEqual(_constexpr_source(64), ("64", None))
+
+    @requires_gpu
+    def test_triton_kernel_unspellable_constexpr_errors_clearly(self):
+        # Declining has to say why. Before, the value went into the generated
+        # file verbatim and surfaced as "SyntaxError: invalid syntax" against a
+        # temp path, with the kernel and every frame above it lost to eager.
+        import enum
+
+        class LocalMode(enum.Enum):
+            even = 2
+
+        @triton.jit
+        def local_mode_kernel(out_ptr, n, MODE: tl.constexpr, BLOCK: tl.constexpr):
+            offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+            tl.store(out_ptr + offs, tl.where(MODE == 3, 1.0, 2.0), mask=offs < n)
+
+        def f(x):
+            out = torch.empty_like(x)
+            local_mode_kernel[(1,)](out, x.numel(), MODE=LocalMode.even, BLOCK=64)
+            return out + 1
+
+        x = torch.rand(64, device=GPU_TYPE)
+        with self.assertRaisesRegex(Exception, "cannot be written into"):
+            torch.compile(f, backend="inductor")(x)
+
+    @requires_gpu
     def test_triton_kernel_dunder_name_no_name_mangling(self):
         # Regression test for https://github.com/pytorch/pytorch/issues/170398
         # Triton kernels whose names start with ``__`` must not trigger

--- a/torch/_inductor/codegen/wrapper.py
+++ b/torch/_inductor/codegen/wrapper.py
@@ -1,10 +1,12 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import ast
 import collections
 import contextlib
 import dataclasses
 import dis
+import enum
 import functools
 import inspect
 import logging
@@ -12,6 +14,7 @@ import operator
 import os
 import re
 import secrets
+import sys
 import tempfile
 from collections.abc import Callable
 from enum import Enum
@@ -366,6 +369,100 @@ def user_defined_kernel_grid_fn_code(
                 writeline(statement, f"if {guards}: return {example_grid}")
 
     return fn_name, output.getvalue()
+
+
+def _constexpr_constant(value: Any) -> Any:
+    """A ``tl.constexpr`` value in a form the generated kernel can be parsed with.
+
+    ``triton_meta`` is emitted with ``repr()``, so a value whose repr is not an
+    expression makes the generated file unimportable and loses the kernel --
+    ``'ROUNDING_MODE': <RoundingMode.even: 2>`` is a ``SyntaxError``, and every
+    frame above it silently falls back to eager.
+
+    Only ``IntEnum`` is rewritten, and only to its int. That is safe because the
+    value reaches ``ASTSource`` as a Triton specialisation input: an ``IntEnum``
+    compares and hashes equal to that int, so the kernel Triton builds and the
+    key it is cached under are unchanged. A plain ``Enum`` is NOT equal to its
+    value, so rewriting one would change what a kernel comparing against it
+    computes; ``_constexpr_source`` reconstructs those by name instead.
+    """
+    if isinstance(value, enum.IntEnum):
+        return int(value)
+    return value
+
+
+def _constexpr_source(value: Any) -> tuple[str, str | None] | None:
+    """Source for a ``tl.constexpr`` value, plus any import it needs.
+
+    Returns None when the value cannot be written as an expression the
+    generated file could evaluate back to the same object.
+
+    A plain ``Enum`` cannot be replaced by its value -- it does not compare
+    equal to one -- so it is emitted as ``Cls.member`` with an import for the
+    class. The import must work in the compile worker, a different process, so
+    the class has to be reachable from a real module: anything defined in
+    ``__main__`` or inside a function body is not, and is reported rather than
+    emitted as something that would import the worker's own ``__main__``.
+    """
+    if isinstance(value, enum.Enum):
+        cls = type(value)
+        module, qualname = cls.__module__, cls.__qualname__
+        root = qualname.split(".")[0]
+        if module and module != "__main__" and "<locals>" not in qualname:
+            owner = sys.modules.get(module)
+            if owner is not None and getattr(owner, root, None) is not None:
+                expr = f"{qualname}.{value.name}"
+                try:
+                    if eval(expr, {root: getattr(owner, root)}) is value:
+                        return expr, f"from {module} import {root}"
+                except Exception:
+                    pass
+        return None
+    text = repr(value)
+    try:
+        ast.parse(text, mode="eval")
+    except SyntaxError:
+        return None
+    return text, None
+
+
+def _render_constexpr_constants(
+    constants: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Constants with unreprable values replaced by source, plus their imports.
+
+    The substitutes carry their own ``__repr__`` so the caller can keep
+    formatting ``triton_meta`` with ``!r``; the dict handed to Triton in this
+    process is untouched.
+    """
+    rendered: dict[str, Any] = {}
+    imports: list[str] = []
+    for name, value in constants.items():
+        source = _constexpr_source(value)
+        if source is None:
+            raise RuntimeError(
+                f"Triton kernel constexpr argument {name!r} has value {value!r} "
+                f"of type {type(value).__name__}, which cannot be written into "
+                f"the generated kernel: its repr is not an expression and it "
+                f"cannot be reconstructed by name. Pass an int, an IntEnum, or "
+                f"a value whose type is defined in an importable module (not "
+                f"__main__ and not inside a function)."
+            )
+        expr, import_line = source
+        rendered[name] = _SourceLiteral(expr) if expr != repr(value) else value
+        if import_line is not None and import_line not in imports:
+            imports.append(import_line)
+    return rendered, imports
+
+
+class _SourceLiteral:
+    """Reprs as the source it was built from, so ``{d!r}`` emits an expression."""
+
+    def __init__(self, source: str) -> None:
+        self.source = source
+
+    def __repr__(self) -> str:
+        return self.source
 
 
 def user_defined_triton_kernel_transitive_closure_source_code(
@@ -3529,7 +3626,7 @@ class PythonWrapperCodegen(CodeGen):
                 if arg.name in kwargs:
                     # the arg may not appear in kwargs if it is an autotuned arg.
                     # in this case, it will be added in triton_heuristics after autotuning.
-                    constants[arg.name] = kwargs[arg.name]
+                    constants[arg.name] = _constexpr_constant(kwargs[arg.name])
 
             else:
                 # the only case where arg name isn't in kwargs, should be
@@ -3776,6 +3873,14 @@ class PythonWrapperCodegen(CodeGen):
         inductor_meta.update(triton_info_kernel_cls.inductor_meta_common())
 
         compile_wrapper.splice(triton_info_kernel_cls.gen_common_triton_imports())
+        # A constexpr the generated file cannot spell -- a plain Enum -- needs
+        # its class imported before the decorator that mentions it.
+        constexpr_constants, constexpr_imports = _render_constexpr_constants(
+            triton_meta.get("constants", {})
+        )
+        triton_meta = {**triton_meta, "constants": constexpr_constants}
+        for import_line in constexpr_imports:
+            compile_wrapper.writeline(import_line)
         if config.triton.proton_profiling:
             compile_wrapper.writeline('pl.enable_semantic("triton")')
 

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1,6 +1,7 @@
 # mypy: allow-untyped-defs
 from __future__ import annotations
 
+import ast
 import builtins
 import copy
 import dataclasses
@@ -2843,10 +2844,10 @@ class CompileResult(Generic[_T]):
 
     def _get_arg_lists(
         self, arg_names, constexprs
-    ) -> tuple[list[str], list[str], OrderedSet[str]]:
+    ) -> tuple[list[str], list[str], OrderedSet[str], dict[str, Any]]:
         """
         Return a bunch of intermediate lists of args needed for generating
-        launcher code.
+        launcher code, plus any objects the generated code names directly.
         """
         compile_meta = self.compile_meta
         cfg = self.config
@@ -2875,11 +2876,23 @@ class CompileResult(Generic[_T]):
         )
         none_args = none_args.difference(OrderedSet(compile_meta["signature"].keys()))
 
+        # Values the launcher source names instead of spelling. repr() is not
+        # an expression for every constexpr a user can pass -- a plain Enum
+        # reprs as "<Mode.even: 2>" -- and the launcher is exec'd, so an
+        # unspellable value is a SyntaxError rather than a bad launch.
+        constant_scope: dict[str, Any] = {}
+
         def _convert_constant(constant):
             if isinstance(constant, str):
                 return "r'" + constant + "'"
-            else:
-                return repr(constant)
+            text = repr(constant)
+            try:
+                ast.parse(text, mode="eval")
+            except SyntaxError:
+                name = f"_constexpr_{len(constant_scope)}"
+                constant_scope[name] = constant
+                return name
+            return text
 
         if triton_version_uses_attrs_dict():
             call_args = arg_names
@@ -2917,7 +2930,7 @@ class CompileResult(Generic[_T]):
         if "extra_launcher_args" in self.inductor_meta:
             def_args = [*def_args, *self.inductor_meta["extra_launcher_args"]]
 
-        return call_args, def_args, none_args
+        return call_args, def_args, none_args, constant_scope
 
 
 _KernelCompileResult: TypeAlias = (
@@ -3082,7 +3095,7 @@ class StaticTritonCompileResult(CompileResult[_T]):
         # want only a subset of the arguments passed to triton.
         # Here, arg_names is exactly fn.src.arg_names and declared_constexprs is exactly fn.src.constexprs,
         # which matches behavior with regular TritonCompileResult
-        _, def_args, none_args = self._get_arg_lists(
+        _, def_args, none_args, constant_scope = self._get_arg_lists(
             self.kernel.arg_names, self.kernel.declared_constexprs
         )
 
@@ -3103,6 +3116,7 @@ class StaticTritonCompileResult(CompileResult[_T]):
 
             scope["_host_tma_aligned"] = _host_tma_aligned
             scope["TensorDescriptor"] = TensorDescriptor
+        scope.update(constant_scope)
         launcher = self._gen_launcher_code(
             scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
         )
@@ -3206,7 +3220,7 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
         binary = self.kernel
         fn = binary.src.fn
         binary._init_handles()
-        (call_args, def_args, none_args) = self._get_arg_lists(
+        (call_args, def_args, none_args, constant_scope) = self._get_arg_lists(
             fn.arg_names, get_constexprs(fn)
         )
         binary_shared = (
@@ -3313,6 +3327,7 @@ class TritonCompileResult(CompileResult[CompiledKernel]):
             scope["_host_tma_aligned"] = _host_tma_aligned
             scope["TensorDescriptor"] = TensorDescriptor
 
+        scope.update(constant_scope)
         launcher = self._gen_launcher_code(
             scope, def_args, runner_args, pre_runner_lines=pre_runner_lines
         )


### PR DESCRIPTION
A value passed to a `tl.constexpr` parameter reaches two generated-Python
sites. The user-kernel decorator must contain valid source, while the launcher
is executed with an explicit scope. Using an enum's `repr()` can produce syntax
such as `<RoundingMode.even: 2>`. Converting every enum to its underlying value
is also not generally safe because a plain `Enum` does not compare equal to
that value.

This change handles the cases according to their semantics. An `IntEnum`
becomes its integer because it compares and hashes identically. A plain
`Enum` is emitted by qualified member name with an import when its class is
available from a real module. Values that cannot be reconstructed are rejected
with an actionable error. Launcher constants whose `repr()` is not an
expression are bound through the launcher's execution scope.

Test Plan:

```text
PYTHONPATH="$PWD" python test/inductor/test_triton_kernels.py -k constexpr
PYTHONPATH="$PWD" python test/inductor/test_codegen_triton.py -k sanitize_for_repr
python -m py_compile test/inductor/test_triton_kernels.py torch/_inductor/codegen/wrapper.py torch/_inductor/runtime/triton_heuristics.py
lintrunner -a --skip PYREFLY test/inductor/test_triton_kernels.py torch/_inductor/codegen/wrapper.py torch/_inductor/runtime/triton_heuristics.py
```

Authored with an AI assistant.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo