### PR TITLE
[aot_autograd] Don't let a non-differentiable output mark its aliases

### DIFF
--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -5258,6 +5258,79 @@ def forward(self, tangents_1):
 
         self._assert_no_extra_refs(refcount_box)
 
+    def test_detach_output_aliasing_intermediate_base(self):
+        # mark_non_differentiable is keyed on TensorImpl, and a backend is free
+        # to lower aten.detach to a no-op -- inductor does -- so y.detach() and
+        # y's intermediate base can be the same object. Marking the detach
+        # output then marks the base, which is a slot the backward requires a
+        # tangent for, and autograd hands it None because
+        # _materialize_non_diff_grads is False. Depending on whether that
+        # backward has any compute this either silently drops the gradient or
+        # dies inside the compiled backward.
+        def f(x):
+            y = torch.sin(x)
+            return y[0:4], y[4:8], y.detach(), x * 3
+
+        def run(fn, x):
+            outs = fn(x)
+            (outs[0].sum() + outs[1].sum() + outs[3].sum()).backward()
+            return (
+                [o.requires_grad for o in outs],
+                [o.grad_fn is not None for o in outs],
+                x.grad,
+            )
+
+        x_ref = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        rg_ref, gf_ref, grad_ref = run(f, x_ref)
+        self.assertIsNotNone(grad_ref)
+
+        for backend in ("aot_eager", "inductor"):
+            torch._dynamo.reset()
+            x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+            rg, gf, grad = run(torch.compile(f, backend=backend), x)
+            self.assertEqual(rg, rg_ref, f"requires_grad diverged on {backend}")
+            self.assertEqual(gf, gf_ref, f"grad_fn diverged on {backend}")
+            self.assertEqual(grad, grad_ref, f"gradient diverged on {backend}")
+
+        # The detach output must stay a leaf: sparing the base must not be
+        # done by declining to mark the output that aliases it.
+        torch._dynamo.reset()
+        x = torch.arange(8, dtype=torch.float32).requires_grad_(True)
+        detached = torch.compile(f, backend="inductor")(x)[2]
+        self.assertFalse(detached.requires_grad)
+        self.assertIsNone(detached.grad_fn)
+
+    def test_detach_output_aliasing_sibling_output(self):
+        # No intermediate base here: h * 1 folds to h and detach() no-ops, so
+        # two OUTPUT slots hold one object and marking the second marks the
+        # first, dropping the only gradient in the model.
+        class Net(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.l = torch.nn.Linear(3, 3)
+
+            def forward(self, x):
+                h = torch.relu(self.l(x))
+                return h * 1.0, h.detach()
+
+        torch.manual_seed(0)
+        ref = Net()
+        x_ref = torch.randn(3, requires_grad=True)
+        out_ref = ref(x_ref)
+        out_ref[0].sum().backward()
+
+        torch._dynamo.reset()
+        torch.manual_seed(0)
+        mod = Net()
+        x = torch.randn(3, requires_grad=True)
+        outs = torch.compile(mod, backend="inductor")(x)
+        self.assertEqual(
+            [(o.requires_grad, o.grad_fn is not None) for o in outs],
+            [(o.requires_grad, o.grad_fn is not None) for o in out_ref],
+        )
+        outs[0].sum().backward()
+        self.assertEqual(x.grad, x_ref.grad)
+
 
 def extract_graph(fx_g, _, graph_cell):
     graph_cell[0] = fx_g

--- a/torch/_functorch/_aot_autograd/runtime_wrappers.py
+++ b/torch/_functorch/_aot_autograd/runtime_wrappers.py
@@ -2684,6 +2684,45 @@ class _AutogradSavedState:
         ctx.opaque_objects = opaque_object_outs
 
 
+def _dealias_marked_returns(raw_returns: list[Any], marked: Sequence[int]) -> None:
+    """Give each slot about to be marked non-differentiable its own TensorImpl.
+
+    mark_non_differentiable is keyed on TensorImpl, so marking one slot marks
+    EVERY returned slot holding that same object, and with
+    ctx._materialize_non_diff_grads = False a slot marked this way is handed a
+    None instead of zeros. Backends are free to return one object in two slots
+    -- inductor lowers aten.detach to a no-op, and h*1 / h+0 fold away -- so
+    `return h * 1, h.detach()` marks the differentiable output too and drops
+    the gradient, and `return y[:2], y[2:], y.detach()` marks y's intermediate
+    base, which the backward requires a tangent for.
+
+    Substituting an alias is only correct because the slot is one we are about
+    to declare non-differentiable anyway; slots that stay differentiable keep
+    their identity.
+    """
+    if not marked:
+        return
+    # This runs on every forward of every compiled autograd function and almost
+    # never fires, so index the marked slots -- usually one or two -- and probe
+    # the rest against them, rather than indexing all of raw_returns.
+    marked_positions: dict[int, list[int]] = {}
+    for i in marked:
+        x = raw_returns[i]
+        if isinstance(x, torch.Tensor):
+            marked_positions.setdefault(id(x), []).append(i)
+    if not marked_positions:
+        return
+    marked_set = set(marked)
+    collide: set[int] = set()
+    for j, o in enumerate(raw_returns):
+        if j not in marked_set:
+            hits = marked_positions.get(id(o))
+            if hits is not None:
+                collide.update(hits)
+    for i in collide:
+        raw_returns[i] = raw_returns[i].detach()
+
+
 @dataclass
 class _AutogradForwardEpilogue:
     metadata: ViewAndMutationMeta
@@ -2748,12 +2787,13 @@ class _AutogradForwardEpilogue:
             if x.mutation_type == MutationType.MUTATED_OUT_GRAPH
         ] + self.metadata.output_info
 
-        fw_outs_not_requiring_grad = [
-            x
+        non_diff_indices = [
+            i
             for (i, x) in enumerate(raw_returns_not_including_intermediate_bases)
             if isinstance(x, torch.Tensor) and not raw_returns_meta[i].requires_grad
         ]
-        ctx.mark_non_differentiable(*fw_outs_not_requiring_grad)
+        _dealias_marked_returns(raw_returns, non_diff_indices)
+        ctx.mark_non_differentiable(*(raw_returns[i] for i in non_diff_indices))
         ctx._materialize_non_diff_grads = False
         _snapshot_external_objects(ctx)
 
@@ -3416,7 +3456,12 @@ class _AOTDispatchAutogradFunctionFactory:
             args="raw_returns",
             artifact_name="compiled_fn_wrapper",
         )
-        buf.bind(TensorAlias=TensorAlias, torch=torch, Tensor=Tensor)
+        buf.bind(
+            TensorAlias=TensorAlias,
+            torch=torch,
+            Tensor=Tensor,
+            _dealias_marked_returns=_dealias_marked_returns,
+        )
 
         with buf.indent():
             for i, idx in enumerate(fw_metadata.mutated_inp_runtime_indices):
@@ -3451,6 +3496,13 @@ class _AOTDispatchAutogradFunctionFactory:
                     and not meta.requires_grad
                 ):
                     _non_diff_indices.append(i)
+            if _non_diff_indices:
+                # See _dealias_marked_returns: marking is keyed on TensorImpl,
+                # so a slot sharing an object with another returned slot marks
+                # that one too.
+                buf.writeline(
+                    f"_dealias_marked_returns(raw_returns, {_non_diff_indices!r})"
+                )
             if _non_diff_indices:
                 checks = " + ".join(
                     f"([raw_returns[{i}]] if isinstance(raw_returns[{i}], Tensor) else [])"


### PR DESCRIPTION
`torch.compile(backend="inductor")` can silently return no gradient for a
function that returns differentiable views alongside a detached alias of
their intermediate base. A similar collision between sibling outputs can
either drop the only valid gradient or fail in the compiled backward.

`ctx.mark_non_differentiable` is keyed on `TensorImpl`, so marking one output
slot also marks every returned slot holding that same object. Backends are
allowed to create this identity collision because Inductor can lower
`aten.detach` to a no-op and fold expressions such as `h * 1` or `h + 0`.

Give each colliding non-differentiable output slot its own detached
`TensorImpl` immediately before marking it. Differentiable slots retain their
identity, while detached outputs remain non-differentiable. Skipping the mark
for colliding slots was rejected because it would incorrectly make detached
outputs require gradients and allow backward to flow through them.

The regression tests cover both collision shapes: a detached output aliasing
an intermediate base and a detached output aliasing a differentiable sibling.

Test Plan:

```
python test/functorch/test_aotdispatch.py TestAOTAutograd.test_detach_output_aliasing_intermediate_base TestAOTAutograd.test_detach_output_aliasing_sibling_output
spin quicklint
lintrunner -a
```