### PR TITLE
[fx] Clear fake_mode on a view's base in GraphPickler (#194771)

### DIFF
--- a/test/fx/test_graph_pickler.py
+++ b/test/fx/test_graph_pickler.py
@@ -1095,6 +1095,84 @@ class TestWeakrefPickle(TestCase):
         self.assertIs(restored_weak(), restored_strong)
 
 
+@unittest.skipUnless(HAS_DILL, "dill not available")
+class TestViewTensorPickle(TestCase):
+    """Tests that a view FakeTensor in node metadata is serializable.
+
+    A view's MetaTensorDesc carries a `base` descriptor with its own
+    `fake_mode`. Left set, it drags the whole FakeTensorMode ->
+    FakeTensorConverter -> MetaConverter.storage_memo graph into the pickle,
+    which dies on a meta storage's data_ptr().
+    """
+
+    def setUp(self):
+        super().setUp()
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx._graph_pickler import GraphPickler, Options
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        self.GraphPickler = GraphPickler
+        self.Options = Options
+        self.fake_mode = FakeTensorMode(shape_env=ShapeEnv())
+
+    def _make_graph_with_view_val(self):
+        """Graph whose call node holds a view FakeTensor in meta['val']."""
+
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.ops.aten.permute.default(x, [0, 2, 1])
+
+        gm = torch.fx.symbolic_trace(M())
+        # from_tensor populates the mode's MetaConverter.storage_memo; that memo
+        # is what a leaked base.fake_mode drags into the pickle.
+        view = self.fake_mode.from_tensor(torch.randn(2, 3, 4).permute(0, 2, 1))
+
+        self.assertIsNotNone(view._base, "expected a view tensor")
+        self.assertTrue(
+            len(self.fake_mode.fake_tensor_converter.meta_converter.storage_memo) > 0,
+            "storage_memo empty -- would not exercise the leak",
+        )
+        call_node = next(n for n in gm.graph.nodes if n.op == "call_function")
+        call_node.meta["val"] = view
+        return gm, call_node
+
+    def test_base_fake_mode_is_cleared(self):
+        """_TensorPickleData must clear fake_mode on a view's base."""
+        from torch._subclasses.meta_utils import MetaTensorDescriber
+        from torch.fx._graph_pickler import _TensorPickleData
+
+        _, call_node = self._make_graph_with_view_val()
+        data = _TensorPickleData(
+            MetaTensorDescriber(copy_data=False), call_node.meta["val"]
+        )
+
+        self.assertIsNone(data.metadata.fake_mode)
+        self.assertIsNotNone(data.metadata.base, "expected a base descriptor")
+        self.assertIsNone(data.metadata.base.fake_mode)
+
+    def test_view_val_roundtrips(self):
+        """A view FakeTensor in node meta survives dumps/loads intact."""
+        gm, _ = self._make_graph_with_view_val()
+        # node_metadata_key_filter=None keeps every meta key, matching callers
+        # that opt out of the default filter.
+        options = self.Options(node_metadata_key_filter=None)
+
+        restored = self.GraphPickler.loads(
+            self.GraphPickler.dumps(gm, options), self.fake_mode
+        )
+
+        self.assertIsInstance(restored, torch.fx.GraphModule)
+        new_node = next(n for n in restored.graph.nodes if n.op == "call_function")
+        old_node = next(n for n in gm.graph.nodes if n.op == "call_function")
+        restored_val = new_node.meta["val"]
+        original_val = old_node.meta["val"]
+
+        self.assertIsNotNone(restored_val._base, "view-ness was lost")
+        self.assertEqual(restored_val.shape, original_val.shape)
+        self.assertEqual(restored_val.stride(), original_val.stride())
+        self.assertEqual(restored_val.dtype, original_val.dtype)
+
+
 if __name__ == "__main__":
     from torch.testing._internal.common_utils import run_tests
 

--- a/torch/fx/_graph_pickler.py
+++ b/torch/fx/_graph_pickler.py
@@ -541,6 +541,16 @@ class _TensorPickleData:
             )
         self.metadata = dataclasses.replace(metadata, fake_mode=None)
 
+        # A view's base carries its own fake_mode, which drags in the whole
+        # FakeTensorMode -> FakeTensorConverter -> MetaConverter.storage_memo
+        # graph and dies on a meta storage's data_ptr(). unpickle() restores
+        # fake_mode on the base, so clearing it here keeps the two symmetric.
+        if self.metadata.is_view and self.metadata.base is not None:
+            self.metadata = dataclasses.replace(
+                self.metadata,
+                base=dataclasses.replace(self.metadata.base, fake_mode=None),
+            )
+
         # Some debugging/verification
         for k in MetaTensorDesc._UNSERIALIZABLE:
             if k in ("fake_mode", "view_func"):


### PR DESCRIPTION
Summary:

`_TensorPickleData.__init__` clears `fake_mode` on the top-level `MetaTensorDesc` but not on `metadata.base`. For a **view** tensor the base descriptor carries its own live `fake_mode`, so pickling reaches `FakeTensorMode` -> `FakeTensorConverter` -> `MetaConverter.storage_memo` and dies on a memoized storage.

The asymmetry is the bug: `unpickle` already restores `fake_mode` on *both* the descriptor and its base, so the dump side clearing only one level was an oversight rather than a deliberate choice. This clears the base too, gated on the same `is_view and base is not None` condition `unpickle` uses, so a non-view carrying a base can never be dumped cleared and left unrestored.

Found via a graph whose `aten.permute` nodes survive into the collected FX graph; `GraphPickler.debug_dumps` reported the leaf as:

```
...nodes[5].meta['val'].metadata.base.fake_mode
   .fake_tensor_converter.meta_converter.storage_memo._remove
```

The concrete symptom was `RuntimeError: Cannot access data pointer of Tensor (e.g. FakeTensor, FunctionalTensor)`, though the exact failing leaf varies with what the mode's converter has memoized.

This change was authored with assistance from Claude Code. The root cause analysis, fix, and tests were reviewed by the author.

Test Plan:
Added `TestViewTensorPickle` to `test/fx/test_graph_pickler.py` with two tests: `test_base_fake_mode_is_cleared` pins the descriptor invariant directly, and `test_view_val_roundtrips` pins that a view `FakeTensor` in `node.meta['val']` survives `dumps`/`loads` with its view-ness, shape, stride and dtype intact. The round-trip test builds its fake tensor via `fake_mode.from_tensor` so the mode's `storage_memo` is populated, and asserts that precondition -- without it the leak has nothing to drag in and the test passes vacuously.

Both tests fail without the fix and pass with it. Note `test/fx/test_graph_pickler.py` is excluded from the fbcode build at `caffe2/test/BUCK:203`, so they were verified by temporarily hosting the two test classes in `caffe2/test/inductor:compiled_fx_graph_serialization`:

```bash
buck2 run fbcode//caffe2/test/inductor:compiled_fx_graph_serialization
```

Without the fix: `FAILED (failures=1, errors=1)` -- `test_base_fake_mode_is_cleared` fails on `FakeTensorMode ... is not None`, `test_view_val_roundtrips` errors inside `GraphPickler.dumps`. With the fix: `Ran 5 tests ... OK`.

Existing GraphPickler coverage, unaffected:

```bash
buck2 run fbcode//caffe2/test/inductor:compiled_fx_graph_serialization   # 3/3 OK
buck2 run fbcode//mtia/accuracy/training/tests:test_graph_serialize      # 9/9 OK
```

`caffe2/test/dynamo:test_dynamo` fails at collection with `ModuleNotFoundError: test_functions` in `test_ctx_manager.py` and `test_nested_graph_breaks_wrapped.py`. That reproduces without this change and is unrelated to it.

Differential Revision: D117389490


