### PR TITLE
[ROCm][c10d] Enable NCCL2 reconfigure on ROCm

### DIFF
--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -21,8 +21,8 @@ from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     run_tests,
-    skipIfRocm,
     TEST_CUDA,
+    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -354,13 +354,11 @@ class AbstractFaultToleranceTest:
         self._store_barrier("ft_reused_uuid_rejected")
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
-    @skipIfRocm(
-        msg="RCCL 2.30.4 blocks in ncclCommInitRankConfig(blocking=0) when a rank "
-        "is missing, so timeout-retry reconfigure hangs",
-    )
     def test_reconfigure_timeout_is_retryable(self):
         if self.backend_name != "nccl2":
             self.skipTest("nonblocking NCCL initialization behavior")
+        if TEST_WITH_ROCM:
+            self.skipTest("RCCL issue being investigated")
         self._init_reconfigurable_pg()
         handles = self._collect_handles("ft_timeout_retry_initial")
 

--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -22,7 +22,6 @@ from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     run_tests,
     TEST_CUDA,
-    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -357,8 +356,6 @@ class AbstractFaultToleranceTest:
     def test_reconfigure_timeout_is_retryable(self):
         if self.backend_name != "nccl2":
             self.skipTest("nonblocking NCCL initialization behavior")
-        if TEST_WITH_ROCM:
-            self.skipTest("RCCL issue being investigated")
         self._init_reconfigurable_pg()
         handles = self._collect_handles("ft_timeout_retry_initial")
 

--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -21,8 +21,8 @@ from torch.testing._internal.common_distributed import MultiProcessTestCase
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     run_tests,
+    skipIfRocm,
     TEST_CUDA,
-    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -354,9 +354,8 @@ class AbstractFaultToleranceTest:
         self._store_barrier("ft_reused_uuid_rejected")
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
-    @unittest.skipIf(
-        TEST_WITH_ROCM,
-        "RCCL 2.30.4 blocks in ncclCommInitRankConfig(blocking=0) when a rank "
+    @skipIfRocm(
+        msg="RCCL 2.30.4 blocks in ncclCommInitRankConfig(blocking=0) when a rank "
         "is missing, so timeout-retry reconfigure hangs",
     )
     def test_reconfigure_timeout_is_retryable(self):

--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -354,6 +354,11 @@ class AbstractFaultToleranceTest:
         self._store_barrier("ft_reused_uuid_rejected")
         self._assert_all_reduce_sum(sum(range(1, self.world_size + 1)))
 
+    @unittest.skipIf(
+        TEST_WITH_ROCM,
+        "RCCL 2.30.4 blocks in ncclCommInitRankConfig(blocking=0) when a rank "
+        "is missing, so timeout-retry reconfigure hangs",
+    )
     def test_reconfigure_timeout_is_retryable(self):
         if self.backend_name != "nccl2":
             self.skipTest("nonblocking NCCL initialization behavior")
@@ -391,11 +396,6 @@ def _make_fault_tolerance_test_class(backend):
         cls = unittest.skipIf(
             not TEST_CUDA or torch.cuda.device_count() < 3,
             "fault tolerance CUDA tests require at least 3 GPUs",
-        )(cls)
-    if backend.name == "nccl2":
-        cls = unittest.skipIf(
-            TEST_WITH_ROCM,
-            "nccl2 reconfigure is not supported with RCCL",
         )(cls)
     return cls
 

--- a/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
@@ -64,9 +64,7 @@ ncclResult_t DefaultNcclApi::commAbort(ncclComm_t comm) {
 
 ncclResult_t DefaultNcclApi::commRevoke(ncclComm_t comm) {
   std::lock_guard<std::mutex> lock(api_mutex_);
-// RCCL advertises NCCL_VERSION_CODE >= 2.28 but does not provide
-// ncclCommRevoke; on ROCm fall through to the unsupported path.
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0) && !defined(USE_ROCM)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
   return ncclCommRevoke(comm, 0);
 #else
   std::ignore = comm;

--- a/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/NcclApi.cpp
@@ -64,7 +64,10 @@ ncclResult_t DefaultNcclApi::commAbort(ncclComm_t comm) {
 
 ncclResult_t DefaultNcclApi::commRevoke(ncclComm_t comm) {
   std::lock_guard<std::mutex> lock(api_mutex_);
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+  // RCCL first shipped ncclCommRevoke in 2.30.4 (ROCm 7.14). Keep the CUDA
+  // NCCL 2.28.0 gate unchanged.
+#if (defined(USE_ROCM) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 4)) || \
+    (!defined(USE_ROCM) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0))
   return ncclCommRevoke(comm, 0);
 #else
   std::ignore = comm;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -300,7 +300,9 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // over the surviving/new members. Implemented in
   // ReconfigureNCCL.cpp.
   bool supportsReconfigure() const override {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+    // Same revoke availability gate as DefaultNcclApi::commRevoke.
+#if (defined(USE_ROCM) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 30, 4)) || \
+    (!defined(USE_ROCM) && NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0))
     return true;
 #else
     return false;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -300,7 +300,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // over the surviving/new members. Implemented in
   // ReconfigureNCCL.cpp.
   bool supportsReconfigure() const override {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0) && !defined(USE_ROCM)
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
     return true;
 #else
     return false;

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -136,10 +136,18 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     auto nonblocking = c10::utils::check_env("TORCH_NCCL_USE_COMM_NONBLOCKING");
     options_c10d_->config.blocking = nonblocking.value_or(false) ? 0 : 1;
   }
+#if defined(USE_ROCM)
+#if NCCL_VERSION_CODE < NCCL_VERSION(2, 30, 4)
+  TORCH_CHECK(
+      !options_c10d_->enable_reconfigure,
+      "nccl2 reconfigure requires RCCL 2.30.4 or later");
+#endif
+#else
 #if NCCL_VERSION_CODE < NCCL_VERSION(2, 28, 0)
   TORCH_CHECK(
       !options_c10d_->enable_reconfigure,
       "nccl2 reconfigure requires NCCL 2.28 or later");
+#endif
 #endif
 }
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -136,11 +136,10 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     auto nonblocking = c10::utils::check_env("TORCH_NCCL_USE_COMM_NONBLOCKING");
     options_c10d_->config.blocking = nonblocking.value_or(false) ? 0 : 1;
   }
-#if NCCL_VERSION_CODE < NCCL_VERSION(2, 28, 0) || defined(USE_ROCM)
+#if NCCL_VERSION_CODE < NCCL_VERSION(2, 28, 0)
   TORCH_CHECK(
       !options_c10d_->enable_reconfigure,
-      "nccl2 reconfigure requires NCCL 2.28 or later and is not supported "
-      "with RCCL");
+      "nccl2 reconfigure requires NCCL 2.28 or later");
 #endif
 }
 


### PR DESCRIPTION
## Summary

Enable nccl2 communicator reconfigure on ROCm by dropping the `USE_ROCM` compile-time exclusion around `ncclCommRevoke` and `supportsReconfigure()`.

Version gates:

- CUDA: unchanged, NCCL 2.28.0
- ROCm: RCCL 2.30.4 (first released RCCL with `ncclCommRevoke`, ROCm 7.14)

This does **not** enable NCCL windows / allocator provenance (see #193282).

## Timeout-retry / RCCL hang

`test_reconfigure_timeout_is_retryable` now runs on ROCm. There is no ROCm skip left on `Nccl2FaultToleranceTest`.

Stock RCCL 2.30.4 hangs on the missing-rank nonblocking init path used by that test (`ncclGroupEndInternal` still inspects emptied `ncclAsyncJobs` after jobs were moved to `groupJob->asyncJobs`). The RCCL fix is in [ROCm/rocm-systems#10796](https://github.com/ROCm/rocm-systems/pull/10796) (`7621e6c`, 2026-08-28). It is **not** in ROCm 10.0 / RCCL 2.30.4. The first 10.1 nightly that includes it is `10.1.0a20260901`; this PR was checked against `10.1.0a20260902`.

These tests use `world_size = 3` and skip unless `torch.cuda.device_count() >= 3`. Typical 2-GPU ROCm distributed jobs never enter this class, so default 10.0 CI is not a hang coverage path.

## Temporary CI commit (revert before merge)

`[ROCm][CI] Temporary preview pin to 10.1.0a20260902` is **not** product code. It pins preview docker to a 10.1 nightly that contains the RCCL fix (`https://nightly.repo.amd.com/rocm/core/whl-next/`), plus the `liblzma-dev` and `katex@0.16.22` preview-build fixes from #194924. Revert that commit before landing.

## Test plan

- [x] Local 3-GPU MI355X (`gfx950`) against `rocm==10.1.0a20260902` / RCCL 2.30.7 at `ccbac3faaec`
  - `Nccl2FaultToleranceTest.test_reconfigure_timeout_is_retryable`: ok in 4.647s (previously hung on RCCL 2.30.4 until OS timeout)
  - `test/distributed/test_c10d_fault_tolerance.py`: 34 tests, OK, 3 expected Gloo skips
- [ ] Preview CI with the temporary pin
- [ ] Revert the preview pin before merge

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang
