### PR TITLE
Fix shrink_group(SHRINK_ABORT) hang by aborting the parent group instead of destroying it

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2088,7 +2088,9 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
             dist.destroy_process_group()
         else:
             log_test_info(self.rank, "Excluded from shrink test - exiting immediately")
-            dist.destroy_process_group()
+            # Survivors shrink with NCCL_SHRINK_ABORT and abort the parent, so
+            # the excluded rank must abort too; destroy here would hang.
+            pg1._get_backend(torch.device(device)).abort()
             return
 
         # Performance analysis (only for participating ranks)

--- a/torch/distributed/distributed_c10d.py
+++ b/torch/distributed/distributed_c10d.py
@@ -7564,6 +7564,14 @@ def shrink_group(
     Notes:
         - Only non-excluded ranks should call this function; excluded ranks
           must not participate in the shrink operation.
+        - With ``SHRINK_ABORT``, the parent group is aborted rather than
+          destroyed for the surviving ranks: destroying a NCCL communicator is
+          a collective that every rank of the communicator must join, and the
+          excluded ranks abort it instead. For the same reason, excluded ranks
+          must abort the parent group on their side (e.g. via
+          ``_abort_process_group``) and must never call
+          ``destroy_process_group`` on it; mixing abort and destroy on the
+          same communicator can hang with NCCL >= 2.31.2.
         - Shrinking the default group destroys all other process groups since
           rank reassignment makes them inconsistent.
     """
@@ -7590,7 +7598,9 @@ def shrink_group(
 
     # Step 6: Handle cleanup and creation of new process group
     target_group_info["pg_options_override"] = pg_options
-    return _finalize_shrunk_group(target_group_info, excluded_ranks_set, new_backend)
+    return _finalize_shrunk_group(
+        target_group_info, excluded_ranks_set, new_backend, shrink_flags
+    )
 
 
 def _validate_shrink_inputs(ranks_to_exclude: list[int], shrink_flags: int) -> None:
@@ -7736,6 +7746,7 @@ def _finalize_shrunk_group(
     group_info: _ShrinkGroupInfo,
     excluded_ranks_set: set[int],
     new_backend: C10DBackend,
+    shrink_flags: int,
 ) -> ProcessGroup:
     """Clean up old group and create new shrunk process group."""
     target_pg = group_info["process_group"]
@@ -7754,8 +7765,13 @@ def _finalize_shrunk_group(
         rank for rank in original_ranks if rank not in excluded_ranks_set
     ]
 
-    # Clean up the original group
-    _cleanup_original_group(target_pg, is_default_group)
+    # Clean up the original group. With SHRINK_ABORT the excluded ranks abort
+    # the parent comm instead of destroying it, so survivors must abort too:
+    # NCCL forbids mixing abort and destroy on the same communicator, and
+    # destroy is an intra-node collective (hangs on NCCL >= 2.31.2 otherwise).
+    _cleanup_original_group(
+        target_pg, is_default_group, use_abort=bool(shrink_flags & SHRINK_ABORT)
+    )
 
     # Create and configure the new process group
     new_pg = _create_shrunk_process_group(
@@ -7808,17 +7824,23 @@ def _extract_group_metadata(target_pg: ProcessGroup) -> _GroupMetadata:
     }
 
 
-def _cleanup_original_group(target_pg: ProcessGroup, is_default_group: bool) -> None:
+def _cleanup_original_group(
+    target_pg: ProcessGroup, is_default_group: bool, use_abort: bool
+) -> None:
     """Clean up the original process group safely."""
     try:
-        destroy_process_group(target_pg)
+        if use_abort:
+            _abort_process_group(target_pg)
+        else:
+            destroy_process_group(target_pg)
     except Exception:
+        action = "abort" if use_abort else "destroy"
         group_type = "default" if is_default_group else "non-default"
         logger.warning(
-            "Failed to destroy %s group during shrinking", group_type, exc_info=True
+            "Failed to %s %s group during shrinking", action, group_type, exc_info=True
         )
 
-    # Ensure global state cleanup even if destroy_process_group fails
+    # Ensure global state cleanup even if the destroy/abort above fails
     _cleanup_process_group_global_state(target_pg)
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #194775

shrink_group consumed shrink_flags only for the backend shrink call; the
teardown always released the parent via destroy_process_group. With
SHRINK_ABORT the excluded ranks release the parent with ncclCommAbort, while
the survivors' destroy goes through ncclCommFinalize/ncclCommDestroy. Since
NCCL 2.31.2 (commit 08016686e) commDestroySync contains an untimed intra-node
bootstrap barrier gated only on `*comm->abortFlag == 0`, and ncclCommAbort
skips it. ncclCommShrink(NCCL_SHRINK_ABORT) sets the parent's abort flags but
resets them to 0 before returning, so the surviving ranks look healthy, enter
the barrier, wait for the excluded ranks (which never arrive), and block
forever in socketAccept.

Fix: thread shrink_flags into the teardown and release the parent with
_abort_process_group when SHRINK_ABORT was used. This matches the NCCL
contract (once any rank aborts a communicator, all ranks must release it with
abort; NCCL's own ft_test.cu has survivors abort the parent after an abortive
shrink) and is the same treatment _destroy_all_other_groups already applies to
sibling groups in this flow. test_shrink_group_vs_abort_reinit_performance had
the inverted mismatch (excluded rank destroyed the parent while survivors
shrank with SHRINK_ABORT); it was accidentally symmetric before this change
and would hang after it, so its excluded rank now aborts as well.

Alternative considered: marking the parent NCCLComm aborted in C++
(ProcessGroupNCCL::shrink) so a later destroy no-ops even for direct
Backend.shrink callers; rejected to keep the change minimal since shrink_group
is the supported API and direct backend users own the comm lifetime.

Test Plan:

On a 4-GPU node with torch source-built against NCCL 2.31 (contains the
destroy barrier):

```
python test/distributed/test_c10d_nccl.py -v -k test_shrink_group_flags
python test/distributed/test_c10d_nccl.py -v -k test_shrink_group_vs_abort_reinit_performance
python test/distributed/test_c10d_nccl.py -v -k test_shrink_group
```

Before the fix test_shrink_group_flags times out after 300 s (survivor stuck
in the destroy barrier); with the fix it passes in ~5 s and the full 10-test
shrink sweep passes. `lintrunner -a --skip CLANGTIDY` is clean.

This PR was authored with the help of an AI assistant (Claude Code).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>