### PR TITLE
[inductor] Prevent CSE reuse of loop-local loads after reductions

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -253,6 +253,19 @@ def helper(x):
             )
             self.assertTrue(predicate_options.reduction_axes_omitted)
 
+    @unittest.skipUnless(HAS_GPU_AND_TRITON, "requires GPU and Triton")
+    def test_indirect_load_cse_across_reduction_loop(self):
+        def fn(x, buf, idx):
+            selected = torch.gather(buf, -2, idx)
+            value = selected + x.sum(dim=-1, keepdim=True)
+            return x + value, buf.scatter(-2, idx, value)
+
+        x = torch.ones(2, 2, 1025, device=GPU_TYPE)
+        buf = torch.ones(2, 8, 1, device=GPU_TYPE)
+        idx = torch.arange(4, device=GPU_TYPE).reshape(2, 2, 1)
+        compiled = torch.compile(fn, fullgraph=True, dynamic=True)
+        self.assertEqual(compiled(x, buf, idx), fn(x, buf, idx))
+
     def test_reduction_invariant_load_indexing_extents(self):
         self._stack.enter_context(self._graph.set_current_device(torch.device("cuda")))
         xnumel = sympy.Integer(65)

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5112,6 +5112,7 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if not self.inside_reduction or (
             not indexing.has_rmask()
             and not has_rindex
+            and load_buffer is self.body
             # The address and predicate producers for a narrowed load live in
             # the loop-local compute buffer, so re-emit it for each loop chunk.
             and not reduction_axes_omitted


### PR DESCRIPTION
# Problem

[`torch.compile` issue #194490](https://github.com/pytorch/pytorch/issues/194490) fails when a dynamic `gather` is used inside a kernel containing a non-persistent reduction and the gathered value is reused after the reduction loop. Inductor generates Triton code that uses `tmp17` after the loop even though it is defined only inside the loop.

The failure begins in PyTorch 2.13 and reproduces with Triton 3.7.1 and 3.8.

# Root Cause

Inductor emits some loads outside the reduction loop and others inside it. `TritonKernel.load()` decided whether a value could survive the loop using properties of its index rather than where the load was actually emitted. This allowed a loop-local gather load to remain cached, so the epilogue reused an invalid temporary.

PyTorch PR [#184287](https://github.com/pytorch/pytorch/pull/184287) exposed this existing lifetime bug by making the loop and epilogue index expressions identical.

# This Diff

- Preserve a load across the reduction-loop boundary only when it was emitted in `self.body`, outside the loop.
- Add a minimal dynamic `gather`/`sum`/`scatter` regression test.
- Preserve the negative-index bounds behavior introduced by #184287.

Validation:
- The minimal regression fails before this change with `NameError('tmp7 is not defined')` and passes afterward.
- The original reproducer passes for both reported shapes on H100 with PyTorch nightly and Triton 3.8.

Fixes #194490

Drafted with Codex


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
