### PR TITLE
[AOTI] Add opt-in stream-to-runtime affinity (#194783)

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -19,10 +19,10 @@
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_cpu.h>
 #if defined(USE_CUDA)
 #include <c10/cuda/CUDACachingAllocator.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <cuda_runtime.h>
 #endif
 #if defined(USE_CUDA) || defined(USE_ROCM)
+#include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
 #include <torch/csrc/inductor/aoti_runner/model_container_runner_cuda.h>
 #endif
@@ -1102,6 +1102,217 @@ void test_multi_cuda_streams(const std::string& device) {
 }
 #endif // USE_CUDA
 
+void test_cuda_stream_affinity_bindings(const std::string& device) {
+  c10::InferenceMode mode;
+  const std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& pt2_package_path =
+      data_loader.attr(("pt2_package_path_" + device).c_str()).toStringRef();
+  const auto ref_output =
+      data_loader.attr(("outputs_" + device).c_str()).toTensorList().get(0);
+  const auto inputs =
+      data_loader.attr(("inputs_" + device).c_str()).toTensorList().vec();
+  const auto first_stream = c10::cuda::getStreamFromPool();
+  const auto second_stream = c10::cuda::getStreamFromPool();
+  ASSERT_NE(first_stream.stream(), second_stream.stream());
+
+  auto run_on_stream = [&](torch::inductor::AOTIModelPackageLoader& loader,
+                           const c10::cuda::CUDAStream& stream) {
+    c10::cuda::CUDAStreamGuard stream_guard(stream);
+    const auto outputs = loader.run(inputs, stream.stream());
+    stream.synchronize();
+    ASSERT_TRUE(torch::allclose(ref_output, outputs[0]));
+  };
+
+  torch::inductor::AOTIModelPackageLoader default_loader(
+      pt2_package_path, "model", false, 2);
+  run_on_stream(default_loader, first_stream);
+  EXPECT_EQ(
+      AOTI_STREAM_AFFINITY_DISABLED,
+      default_loader.get_runner()->get_stream_affinity_model_index_for_testing(
+          first_stream.stream()));
+
+  torch::inductor::AOTIModelPackageLoader affinity_loader(
+      pt2_package_path,
+      "model",
+      false,
+      2,
+      -1,
+      /*use_stream_affinity=*/true);
+  EXPECT_EQ(
+      AOTI_STREAM_AFFINITY_UNBOUND,
+      affinity_loader.get_runner()->get_stream_affinity_model_index_for_testing(
+          first_stream.stream()));
+
+  run_on_stream(affinity_loader, first_stream);
+  const auto first_model =
+      affinity_loader.get_runner()->get_stream_affinity_model_index_for_testing(
+          first_stream.stream());
+  ASSERT_GE(first_model, 0);
+  try {
+    affinity_loader.get_runner()->set_use_stream_affinity(true);
+    FAIL() << "Expected affinity reconfiguration after a run to be rejected";
+  } catch (const c10::Error& error) {
+    EXPECT_THAT(
+        error.what(),
+        ::testing::HasSubstr(
+            "Stream affinity can only be reconfigured while the model pool is "
+            "quiescent"));
+  }
+  run_on_stream(affinity_loader, first_stream);
+  EXPECT_EQ(
+      first_model,
+      affinity_loader.get_runner()->get_stream_affinity_model_index_for_testing(
+          first_stream.stream()));
+
+  run_on_stream(affinity_loader, second_stream);
+  const auto second_model =
+      affinity_loader.get_runner()->get_stream_affinity_model_index_for_testing(
+          second_stream.stream());
+  ASSERT_GE(second_model, 0);
+  EXPECT_NE(first_model, second_model);
+
+  torch::inductor::AOTIModelPackageLoader oversubscribed_loader(
+      pt2_package_path,
+      "model",
+      false,
+      1,
+      -1,
+      /*use_stream_affinity=*/true);
+  run_on_stream(oversubscribed_loader, first_stream);
+  const auto only_model =
+      oversubscribed_loader.get_runner()
+          ->get_stream_affinity_model_index_for_testing(first_stream.stream());
+  ASSERT_GE(only_model, 0);
+  run_on_stream(oversubscribed_loader, second_stream);
+  EXPECT_EQ(
+      AOTI_STREAM_AFFINITY_UNBOUND,
+      oversubscribed_loader.get_runner()
+          ->get_stream_affinity_model_index_for_testing(first_stream.stream()));
+  EXPECT_EQ(
+      only_model,
+      oversubscribed_loader.get_runner()
+          ->get_stream_affinity_model_index_for_testing(
+              second_stream.stream()));
+}
+
+void test_concurrent_same_cuda_stream_affinity(const std::string& device) {
+  c10::InferenceMode mode;
+  const std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& pt2_package_path =
+      data_loader.attr(("pt2_package_path_" + device).c_str()).toStringRef();
+  const auto ref_output =
+      data_loader.attr(("outputs_" + device).c_str()).toTensorList().get(0);
+  const auto inputs =
+      data_loader.attr(("inputs_" + device).c_str()).toTensorList().vec();
+
+  constexpr int num_threads = 2;
+  torch::inductor::AOTIModelPackageLoader loader(
+      pt2_package_path,
+      "model",
+      false,
+      num_threads,
+      -1,
+      /*use_stream_affinity=*/true);
+  const auto stream = c10::cuda::getStreamFromPool();
+  std::atomic<int> ready{0};
+  std::vector<std::vector<torch::Tensor>> all_outputs(num_threads);
+  std::vector<std::thread> threads;
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&, i]() {
+      c10::cuda::CUDAStreamGuard stream_guard(stream);
+      ready.fetch_add(1);
+      while (ready.load() < num_threads) {
+        std::this_thread::yield();
+      }
+      all_outputs[i] = loader.run(inputs, stream.stream());
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  stream.synchronize();
+
+  for (const auto& outputs : all_outputs) {
+    ASSERT_TRUE(torch::allclose(ref_output, outputs[0]));
+  }
+  EXPECT_GE(
+      loader.get_runner()->get_stream_affinity_model_index_for_testing(
+          stream.stream()),
+      0);
+}
+#endif // USE_CUDA || USE_ROCM
+
+void test_stream_affinity_rejected_for_cpu() {
+  const std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& pt2_package_path =
+      data_loader.attr("pt2_package_path_cpu").toStringRef();
+
+  try {
+    torch::inductor::AOTIModelPackageLoader loader(
+        pt2_package_path,
+        "model",
+        false,
+        1,
+        -1,
+        /*use_stream_affinity=*/true);
+    FAIL() << "Expected CPU stream affinity to be rejected";
+  } catch (const c10::Error& error) {
+    EXPECT_THAT(
+        error.what(),
+        ::testing::HasSubstr(
+            "Stream affinity is only supported for device runtimes"));
+  }
+}
+
+void test_stream_affinity_rejected_with_single_threaded() {
+  try {
+    torch::inductor::AOTIModelPackageLoader loader(
+        "does_not_exist.pt2",
+        "model",
+        true,
+        1,
+        -1,
+        /*use_stream_affinity=*/true);
+    FAIL() << "Expected single-threaded stream affinity to be rejected";
+  } catch (const c10::Error& error) {
+    EXPECT_THAT(
+        error.what(),
+        ::testing::HasSubstr("use_stream_affinity cannot be enabled when "
+                             "run_single_threaded is true"));
+  }
+}
+
+void test_stream_affinity_rejected_by_single_threaded_runner() {
+  const std::string data_path =
+      (std::filesystem::path(STRINGIZE(CMAKE_CURRENT_BINARY_DIR)) / "data.pt")
+           .string();
+  torch::jit::script::Module data_loader = torch::jit::load(data_path);
+  const auto& pt2_package_path =
+      data_loader.attr("pt2_package_path_cpu").toStringRef();
+
+  try {
+    torch::inductor::AOTIModelPackageLoader loader(
+        pt2_package_path, "model", true, 1, -1);
+    loader.get_runner()->set_use_stream_affinity(true);
+    FAIL() << "Expected the single-threaded runner to reject stream affinity";
+  } catch (const c10::Error& error) {
+    EXPECT_THAT(
+        error.what(),
+        ::testing::HasSubstr("use_stream_affinity cannot be enabled when "
+                             "run_single_threaded is true"));
+  }
+}
+
+#if defined(USE_CUDA) || defined(USE_ROCM)
 void test_concurrent_run_with_const_fold(const std::string& device) {
   torch::NoGradGuard no_grad;
 
@@ -1168,7 +1379,9 @@ void test_concurrent_run_with_const_fold(const std::string& device) {
 // run depends on the cudaStreamSynchronize(0) at the end of
 // update_constant_buffer (model_container.h). On NVIDIA the legacy default
 // stream implicitly serializes, so this passes regardless.
-void test_aoti_const_fold_separate_stream() {
+void test_aoti_const_fold_separate_stream(
+    bool use_stream_affinity,
+    int num_iters) {
   torch::NoGradGuard no_grad;
 
   // Use the large (size=4096) model so the per-weight D2D copy is big enough to
@@ -1186,14 +1399,16 @@ void test_aoti_const_fold_separate_stream() {
   const int64_t size = x.size(1);
 
   auto runner = std::make_unique<torch::inductor::AOTIModelContainerRunnerCuda>(
-      model_so_path);
+      model_so_path, use_stream_affinity ? 2 : 1);
+  if (use_stream_affinity) {
+    runner->set_use_stream_affinity(true);
+  }
 
   // Dedicated non-blocking pool stream for folding, distinct from the default
   // stream that update_constant_buffer copies the weights on.
   c10::cuda::CUDAStream fold_stream = c10::cuda::getStreamFromPool();
 
-  constexpr int kIters = 100;
-  for (int i = 0; i < kIters; ++i) {
+  for (int i = 0; i < num_iters; ++i) {
     at::Tensor w_pre = at::randn({size, size}, x.options());
     at::Tensor w_add = at::randn({size, size}, x.options());
     // Independent reference, mirroring Net.forward in test.py.
@@ -1211,12 +1426,24 @@ void test_aoti_const_fold_separate_stream() {
     runner->run_const_fold(
         /* use_inactive = */ true,
         reinterpret_cast<AOTInductorStreamHandle>(fold_stream.stream()));
+    if (use_stream_affinity) {
+      ASSERT_GE(
+          runner->get_stream_affinity_model_index_for_testing(
+              fold_stream.stream()),
+          0);
+    }
     // Isolate the copy->fold edge (under test) from the fold->inference edge by
     // finishing the fold before swapping the freshly folded buffer in.
     fold_stream.synchronize();
     runner->swap_constant_buffer();
 
-    auto actual = runner->run(input_tensors);
+    std::vector<at::Tensor> actual;
+    if (use_stream_affinity) {
+      actual = runner->run(input_tensors, fold_stream.stream());
+      fold_stream.synchronize();
+    } else {
+      actual = runner->run(input_tensors);
+    }
     ASSERT_TRUE(torch::allclose(
         expected, actual[0], /* rtol = */ 1e-2, /* atol = */ 1e-2))
         << "iter " << i
@@ -1454,6 +1681,18 @@ TEST_F(AotInductorTest, BasicPackageLoaderTestCpu) {
   test_aoti_package_loader("cpu", false);
 }
 
+TEST_F(AotInductorTest, StreamAffinityRejectedForCpu) {
+  test_stream_affinity_rejected_for_cpu();
+}
+
+TEST_F(AotInductorTest, StreamAffinityRejectedWithSingleThreaded) {
+  test_stream_affinity_rejected_with_single_threaded();
+}
+
+TEST_F(AotInductorTest, StreamAffinityRejectedBySingleThreadedRunner) {
+  test_stream_affinity_rejected_by_single_threaded_runner();
+}
+
 TEST_F(AotInductorTest, ExtractConstantsMapCpu) {
   test_aoti_extract_constants_map("cpu");
 }
@@ -1528,8 +1767,20 @@ TEST_F(AotInductorTest, ConcurrentRunConstFoldCuda) {
 // Registered for ROCm as well as CUDA: the S638065 race only manifests on AMD
 // (on NVIDIA the legacy default stream implicitly orders with the fold stream).
 #if defined(USE_CUDA) || defined(USE_ROCM)
+TEST_F(AotInductorTest, MultiStreamAffinityTestCuda) {
+  test_cuda_stream_affinity_bindings("cuda");
+}
+
+TEST_F(AotInductorTest, ConcurrentSameStreamAffinityTestCuda) {
+  test_concurrent_same_cuda_stream_affinity("cuda");
+}
+
 TEST_F(AotInductorTest, ConstFoldSeparateStreamCuda) {
-  test_aoti_const_fold_separate_stream();
+  test_aoti_const_fold_separate_stream(false, 100);
+}
+
+TEST_F(AotInductorTest, ConstFoldSeparateStreamWithAffinityCuda) {
+  test_aoti_const_fold_separate_stream(true, 100);
 }
 #endif // USE_CUDA || USE_ROCM
 

--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -97,6 +97,55 @@ class TestPackage(TestCase):
         self.assertEqual(len(package.methods["fn"].overloads), 3)
 
 
+class TestAOTIPackageStreamAffinity(TestCase):
+    def test_aoti_load_package_forwards_stream_affinity_options(self):
+        compiled_model = object()
+        with mock.patch(
+            "torch._inductor.package.load_package", return_value=compiled_model
+        ) as load_package_mock:
+            result = torch._inductor.aoti_load_package(
+                "model.pt2",
+                run_single_threaded=False,
+                device_index=2,
+                num_runners=4,
+                use_stream_affinity=True,
+            )
+
+        self.assertIs(result, compiled_model)
+        load_package_mock.assert_called_once_with(
+            "model.pt2",
+            run_single_threaded=False,
+            num_runners=4,
+            device_index=2,
+            use_stream_affinity=True,
+        )
+
+    def test_load_aoti_forwards_stream_affinity_to_cpp_loader(self):
+        loader_type = mock.MagicMock()
+        loader_type.load_metadata_from_package.return_value = {
+            "AOTI_DEVICE_KEY": "cuda"
+        }
+        loader = loader_type.return_value
+
+        with (
+            mock.patch.object(torch._C._aoti, "AOTIModelPackageLoader", loader_type),
+            mock.patch(
+                "torch._inductor.codecache.get_device_information", return_value={}
+            ),
+        ):
+            compiled_model = _load_aoti(
+                "model.pt2",
+                "model",
+                False,
+                4,
+                2,
+                use_stream_affinity=True,
+            )
+
+        self.assertIs(compiled_model.loader, loader)
+        loader_type.assert_called_once_with("model.pt2", "model", False, 4, 2, True)
+
+
 class TestAOTIPackageDeviceValidation(TestCase):
     def test_aoti_load_uses_cpp_device_validation_before_device_info(self):
         class FakeAOTIModelPackageLoader:

--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -338,6 +338,32 @@ model(torch.ones(2))
 
             self.assertEqual(actual, expected)
 
+    def test_load_package_with_stream_affinity(self):
+        if self.device == "cpu":
+            self.skipTest("stream affinity requires an accelerator")
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        model = Model().to(self.device)
+        example_inputs = (torch.randn(10, 10, device=self.device),)
+        expected = model(*example_inputs)
+        ep = torch.export.export(model, example_inputs, strict=True)
+        package_path = torch._inductor.aoti_compile_and_package(
+            ep,
+            inductor_configs={
+                "aot_inductor.package_cpp_only": self.package_cpp_only,
+            },
+        )
+        loaded = torch._inductor.aoti_load_package(
+            package_path,
+            num_runners=2,
+            use_stream_affinity=True,
+        )
+
+        self.assertEqual(loaded(*example_inputs), expected)
+
     def test_load_package_from_directory(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/torch/_C/_aoti.pyi
+++ b/torch/_C/_aoti.pyi
@@ -152,10 +152,11 @@ class AOTIModelPackageLoader:
     def __init__(
         self,
         model_package_path: str,
-        model_name: str,
-        run_single_threaded: bool,
-        num_runners: int,
-        device_index: int,
+        model_name: str = ...,
+        run_single_threaded: bool = ...,
+        num_runners: int = ...,
+        device_index: int = ...,
+        use_stream_affinity: bool = ...,
     ) -> None: ...
     def get_metadata(self) -> dict[str, str]: ...
     def run(

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -255,7 +255,12 @@ def _aoti_compile_and_package_inner(
 
 
 def aoti_load_package(
-    path: FileLike, run_single_threaded: bool = False, device_index: int = -1
+    path: FileLike,
+    run_single_threaded: bool = False,
+    device_index: int = -1,
+    *,
+    num_runners: int = 1,
+    use_stream_affinity: bool = False,
 ) -> AOTICompiledModel:
     """
     Loads a model from a PT2 package or an extracted PT2 package directory.
@@ -279,11 +284,20 @@ def aoti_load_package(
             to be loaded. By default, `device_index=-1` is used, which corresponds
             to the device `cuda` when using CUDA. Passing `device_index=1` would
             load the package to `cuda:1`, for example.
+        num_runners (int): Number of model instances available for concurrent
+            execution.
+        use_stream_affinity (bool): Whether each non-null device stream should
+            retain a stable model instance. Intended for controlled
+            multi-stream benchmarking; this may reduce host-side pipelining.
     """
     from torch._inductor.package import load_package
 
     return load_package(
-        path, run_single_threaded=run_single_threaded, device_index=device_index
+        path,
+        run_single_threaded=run_single_threaded,
+        num_runners=num_runners,
+        device_index=device_index,
+        use_stream_affinity=use_stream_affinity,
     )
 
 

--- a/torch/_inductor/codegen/aoti_runtime/interface.cpp
+++ b/torch/_inductor/codegen/aoti_runtime/interface.cpp
@@ -198,6 +198,32 @@ AOTIRuntimeError AOTInductorModelContainerCreateWithExternalConstants(
   return AOTI_RUNTIME_SUCCESS;
 })
 
+AOTIRuntimeError AOTInductorModelContainerSetUseStreamAffinity(
+    AOTInductorModelContainerHandle container_handle,
+    bool use_stream_affinity) AOTI_RUNTIME_TRY({
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  container->set_use_stream_affinity(use_stream_affinity);
+  return AOTI_RUNTIME_SUCCESS;
+})
+
+AOTIRuntimeError AOTInductorModelContainerGetStreamAffinityModelIndexForTesting(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorStreamHandle stream_handle,
+    int64_t* model_index) AOTI_RUNTIME_TRY({
+  if (model_index == nullptr) {
+    return AOTI_RUNTIME_FAILURE;
+  }
+  auto* container =
+      reinterpret_cast<torch::aot_inductor::AOTInductorModelContainer*>(
+          container_handle);
+  auto stream =
+      reinterpret_cast<torch::aot_inductor::DeviceStreamType>(stream_handle);
+  *model_index = container->get_stream_affinity_model_index(stream);
+  return AOTI_RUNTIME_SUCCESS;
+})
+
 AOTIRuntimeError AOTInductorModelContainerDelete(
     AOTInductorModelContainerHandle container_handle) AOTI_RUNTIME_TRY({
   auto* container =

--- a/torch/_inductor/package/package.py
+++ b/torch/_inductor/package/package.py
@@ -106,6 +106,7 @@ def load_package(
     run_single_threaded: bool = False,
     num_runners: int = 1,
     device_index: int = -1,
+    use_stream_affinity: bool = False,
 ) -> AOTICompiledModel:
     """Load an AOTI model from a PT2 package or an extracted package directory."""
     is_directory = isinstance(path, (str, os.PathLike)) and os.path.isdir(path)
@@ -116,6 +117,7 @@ def load_package(
                 run_single_threaded=run_single_threaded,
                 num_runners=num_runners,
                 device_index=device_index,
+                use_stream_affinity=use_stream_affinity,
             )
             if model_name not in pt2_contents.aoti_runners:
                 raise RuntimeError(f"Model {model_name} not found in package")
@@ -133,12 +135,22 @@ def load_package(
             f.write(path.read())
             log.debug("Writing buffer to tmp file located at %s.", f.name)
             loader = torch._C._aoti.AOTIModelPackageLoader(
-                f.name, model_name, run_single_threaded, num_runners, device_index
+                f.name,
+                model_name,
+                run_single_threaded,
+                num_runners,
+                device_index,
+                use_stream_affinity,
             )
             return AOTICompiledModel(loader)
 
     path = os.fspath(path)  # AOTIModelPackageLoader expects (str, str)
     loader = torch._C._aoti.AOTIModelPackageLoader(
-        path, model_name, run_single_threaded, num_runners, device_index
+        path,
+        model_name,
+        run_single_threaded,
+        num_runners,
+        device_index,
+        use_stream_affinity,
     )
     return AOTICompiledModel(loader)

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -26,6 +26,14 @@ namespace {
 
 const std::string k_separator = "/";
 
+void validate_stream_affinity_configuration(
+    bool run_single_threaded,
+    bool use_stream_affinity) {
+  TORCH_CHECK(
+      !use_stream_affinity || !run_single_threaded,
+      "use_stream_affinity cannot be enabled when run_single_threaded is true");
+}
+
 bool is_windows_drive_root(const std::string& path) {
   return path.size() == 3 &&
       std::isalpha(static_cast<unsigned char>(path[0])) && path[1] == ':' &&
@@ -726,8 +734,11 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
     const std::string& model_name,
     const bool run_single_threaded,
     const size_t num_runners,
-    const c10::DeviceIndex device_index)
+    const c10::DeviceIndex device_index,
+    const bool use_stream_affinity)
     : runner_(nullptr), metadata_{} {
+  validate_stream_affinity_configuration(
+      run_single_threaded, use_stream_affinity);
   if (run_single_threaded) {
     TORCH_CHECK(
         num_runners == 1,
@@ -945,6 +956,12 @@ AOTIModelPackageLoader::AOTIModelPackageLoader(
 
   if (!weight_blob_filename.empty()) {
     runner_->update_constant_buffer_from_blob(weight_blob_filename);
+  }
+
+  // Keep old model packages loadable unless the caller explicitly requests
+  // the optional runtime symbol introduced with stream affinity.
+  if (use_stream_affinity) {
+    runner_->set_use_stream_affinity(true);
   }
 }
 

--- a/torch/csrc/inductor/aoti_package/model_package_loader.h
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.h
@@ -13,7 +13,8 @@ class TORCH_API AOTIModelPackageLoader {
       const std::string& model_name = "model",
       const bool run_single_threaded = false,
       const size_t num_runners = 1,
-      const c10::DeviceIndex device_index = -1);
+      const c10::DeviceIndex device_index = -1,
+      const bool use_stream_affinity = false);
   ~AOTIModelPackageLoader();
 
   AOTIModelContainerRunner* get_runner();

--- a/torch/csrc/inductor/aoti_package/pybind.cpp
+++ b/torch/csrc/inductor/aoti_package/pybind.cpp
@@ -17,13 +17,15 @@ class AOTIModelPackageLoaderPybind : public AOTIModelPackageLoader {
       const std::string& model_name,
       const bool run_single_threaded,
       const size_t num_runners,
-      const c10::DeviceIndex device_index)
+      const c10::DeviceIndex device_index,
+      const bool use_stream_affinity)
       : AOTIModelPackageLoader(
             model_package_path,
             model_name,
             run_single_threaded,
             num_runners,
-            device_index) {}
+            device_index,
+            use_stream_affinity) {}
 
   py::list boxed_run(py::list& inputs, void* stream_handle = nullptr) {
     std::vector<at::Tensor> input_tensors;
@@ -50,12 +52,20 @@ void initAOTIPackageBindings(PyObject* module) {
   auto rootModule = py::handle(module).cast<py::module>();
   auto m = rootModule.def_submodule("_aoti");
   py::class_<AOTIModelPackageLoaderPybind>(m, "AOTIModelPackageLoader")
-      .def(py::init<
-           const std::string&,
-           const std::string&,
-           const bool,
-           const size_t,
-           const c10::DeviceIndex>())
+      .def(
+          py::init<
+              const std::string&,
+              const std::string&,
+              const bool,
+              const size_t,
+              const c10::DeviceIndex,
+              const bool>(),
+          py::arg("model_package_path"),
+          py::arg("model_name") = "model",
+          py::arg("run_single_threaded") = false,
+          py::arg("num_runners") = 1,
+          py::arg("device_index") = -1,
+          py::arg("use_stream_affinity") = false)
       .def("get_metadata", &AOTIModelPackageLoaderPybind::get_metadata)
       .def(
           "run",

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.cpp
@@ -94,7 +94,8 @@ AOTIModelContainerRunner::AOTIModelContainerRunner(
     size_t num_models,
     const std::string& device_str,
     const std::string& cubin_dir,
-    const bool run_single_threaded) {
+    const bool run_single_threaded)
+    : run_single_threaded_(run_single_threaded) {
   if (run_single_threaded) {
     TORCH_CHECK(
         num_models == 1,
@@ -252,6 +253,78 @@ AOTIModelContainerRunner::~AOTIModelContainerRunner() {
   }
 }
 
+const char* AOTIModelContainerRunner::get_aoti_runtime_error() const {
+  const char* error = torch::aot_inductor::get_last_error();
+  if (error) {
+    return error;
+  }
+  if (get_last_error_func_ &&
+      get_last_error_func_(&error) == AOTI_RUNTIME_SUCCESS && error &&
+      error[0]) {
+    return error;
+  }
+  return nullptr;
+}
+
+void AOTIModelContainerRunner::set_use_stream_affinity(
+    bool use_stream_affinity) {
+  TORCH_CHECK(
+      !use_stream_affinity || !run_single_threaded_,
+      "use_stream_affinity cannot be enabled when run_single_threaded is true");
+  TORCH_CHECK(
+      model_so_ != nullptr,
+      "Stream affinity is unavailable for custom AOTI device runners");
+  decltype(&AOTInductorModelContainerSetUseStreamAffinity) set_affinity_func =
+      nullptr;
+  try {
+    set_affinity_func = reinterpret_cast<decltype(set_affinity_func)>(
+        model_so_->sym("AOTInductorModelContainerSetUseStreamAffinity"));
+  } catch (const at::DynamicLibraryError&) {
+    // Report the missing optional symbol below with upgrade guidance.
+  }
+  TORCH_CHECK(
+      set_affinity_func != nullptr,
+      "AOTInductorModelContainerSetUseStreamAffinity is unavailable. "
+      "Rebuild the model with the latest AOTInductor.");
+  torch::aot_inductor::set_last_error(nullptr);
+  const auto result = set_affinity_func(container_handle_, use_stream_affinity);
+  if (result != AOTI_RUNTIME_SUCCESS) {
+    if (const char* error = get_aoti_runtime_error()) {
+      TORCH_CHECK(false, error);
+    }
+    torch::headeronly::detail::throw_exception(
+        "set_affinity_func(...)", __FILE__, __LINE__);
+  }
+}
+
+int64_t AOTIModelContainerRunner::get_stream_affinity_model_index_for_testing(
+    void* stream_handle) {
+  TORCH_CHECK(
+      model_so_ != nullptr,
+      "Stream affinity diagnostics are unavailable for custom AOTI device "
+      "runners");
+  decltype(&AOTInductorModelContainerGetStreamAffinityModelIndexForTesting)
+      get_binding_func = nullptr;
+  try {
+    get_binding_func =
+        reinterpret_cast<decltype(get_binding_func)>(model_so_->sym(
+            "AOTInductorModelContainerGetStreamAffinityModelIndexForTesting"));
+  } catch (const at::DynamicLibraryError&) {
+    // Report the missing optional symbol below with upgrade guidance.
+  }
+  TORCH_CHECK(
+      get_binding_func != nullptr,
+      "AOTInductorModelContainerGetStreamAffinityModelIndexForTesting is "
+      "unavailable. "
+      "Rebuild the model with the latest AOTInductor.");
+  int64_t model_index = -1;
+  AOTI_RUNTIME_ERROR_CODE_CHECK(get_binding_func(
+      container_handle_,
+      reinterpret_cast<AOTInductorStreamHandle>(stream_handle),
+      &model_index));
+  return model_index;
+}
+
 std::vector<at::Tensor> AOTIModelContainerRunner::run_impl(
     std::vector<AtenTensorHandle>& input_handles,
     void* stream_handle) {
@@ -281,16 +354,8 @@ std::vector<at::Tensor> AOTIModelContainerRunner::run_impl(
       reinterpret_cast<AOTInductorStreamHandle>(stream_handle),
       proxy_executor_handle_);
   if (run_result != AOTI_RUNTIME_SUCCESS) {
-    const char* err = torch::aot_inductor::get_last_error();
-    if (err) {
-      TORCH_CHECK(false, err);
-    }
-    if (get_last_error_func_) {
-      const char* aoti_err = nullptr;
-      if (get_last_error_func_(&aoti_err) == AOTI_RUNTIME_SUCCESS && aoti_err &&
-          aoti_err[0]) {
-        TORCH_CHECK(false, aoti_err);
-      }
+    if (const char* error = get_aoti_runtime_error()) {
+      TORCH_CHECK(false, error);
     }
     torch::headeronly::detail::throw_exception(
         "run_func_(...)", __FILE__, __LINE__);

--- a/torch/csrc/inductor/aoti_runner/model_container_runner.h
+++ b/torch/csrc/inductor/aoti_runner/model_container_runner.h
@@ -70,6 +70,8 @@ class TORCH_API AOTIModelContainerRunner {
   void free_inactive_constant_buffer();
   void update_constant_buffer_from_blob(const std::string& weights_path);
   bool did_call_load_constants() const;
+  void set_use_stream_affinity(bool use_stream_affinity);
+  int64_t get_stream_affinity_model_index_for_testing(void* stream_handle);
 
   std::vector<std::string> get_call_spec();
 
@@ -189,11 +191,13 @@ class TORCH_API AOTIModelContainerRunner {
   }
 
  private:
+  const char* get_aoti_runtime_error() const;
   void load_aoti_symbols(
       const std::string& model_so_path,
       const std::string& device_str,
       bool run_single_threaded);
 
+  bool run_single_threaded_{false};
   std::unique_ptr<torch::aot_inductor::ProxyExecutor> proxy_executor_;
 
   // Private, not protected: the lifetime argument in set_observer() only holds

--- a/torch/csrc/inductor/aoti_runtime/interface.h
+++ b/torch/csrc/inductor/aoti_runtime/interface.h
@@ -17,6 +17,9 @@ the import case.
 #define AOTI_API __attribute__((__visibility__("default")))
 #endif
 
+inline constexpr int64_t AOTI_STREAM_AFFINITY_DISABLED = -2;
+inline constexpr int64_t AOTI_STREAM_AFFINITY_UNBOUND = -1;
+
 extern "C" {
 struct AOTInductorModelOpaque;
 using AOTInductorModelHandle = AOTInductorModelOpaque*;
@@ -117,6 +120,23 @@ AOTI_API AOTIRuntimeError AOTInductorModelContainerCreateWithExternalConstants(
     const char* cubin_dir,
     const AOTInductorConstantMapEntry* constant_entries,
     size_t num_constant_entries);
+
+// Enables or disables stable device-stream-to-model assignment. This may only
+// be reconfigured while all model instances are idle. A null stream handle
+// continues to use the default model-pool scheduling policy.
+AOTI_API AOTIRuntimeError AOTInductorModelContainerSetUseStreamAffinity(
+    AOTInductorModelContainerHandle container_handle,
+    bool use_stream_affinity);
+
+// Returns the model index currently bound to a stream,
+// AOTI_STREAM_AFFINITY_UNBOUND when no binding exists, or
+// AOTI_STREAM_AFFINITY_DISABLED when affinity is disabled. This is intended for
+// diagnostics and testing of affinity policies.
+AOTI_API AOTIRuntimeError
+AOTInductorModelContainerGetStreamAffinityModelIndexForTesting(
+    AOTInductorModelContainerHandle container_handle,
+    AOTInductorStreamHandle stream_handle,
+    int64_t* model_index);
 
 // Deletes the AOTInductor model container.
 AOTI_API AOTIRuntimeError AOTInductorModelContainerDelete(

--- a/torch/csrc/inductor/aoti_runtime/model_container.h
+++ b/torch/csrc/inductor/aoti_runtime/model_container.h
@@ -5,8 +5,11 @@
 #include <chrono>
 #include <condition_variable>
 #include <deque>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <unordered_map>
+#include <unordered_set>
 
 // WARNING: Be careful when adding new includes here. This header will be used
 // in model.so, and should not refer to any aten/c10 headers except the stable
@@ -92,6 +95,16 @@ struct ConstantBufferSet {
 };
 
 class AOTInductorModelContainer {
+ private:
+  struct StreamLock {
+    StreamLock() = default;
+    explicit StreamLock(const std::shared_ptr<std::mutex>& stream_mutex)
+        : stream_mutex_(stream_mutex), lock_(*stream_mutex_) {}
+
+    std::shared_ptr<std::mutex> stream_mutex_;
+    std::unique_lock<std::mutex> lock_;
+  };
+
  public:
   AOTInductorModelContainer(
       size_t num_models,
@@ -222,6 +235,46 @@ class AOTInductorModelContainer {
     out_spec_ = model->get_out_spec();
   }
 
+  // Stream affinity is intended for controlled multi-stream benchmarking with
+  // one model instance per long-lived stream. It deliberately waits for a
+  // stream's bound model instead of using another instance, trading host-side
+  // pipelining for stable stream-to-model assignment.
+  void set_use_stream_affinity(bool use_stream_affinity) {
+    std::lock_guard lk(models_mutex_);
+    AOTI_RUNTIME_CHECK(
+        available_models_.size() == models_.size() && pending_models_.empty() &&
+            checked_out_models_.empty(),
+        "Stream affinity can only be reconfigured while the model pool is "
+        "quiescent");
+#if defined(USE_CUDA) || defined(USE_XPU)
+    use_stream_affinity_ = use_stream_affinity;
+#else
+    AOTI_RUNTIME_CHECK(
+        !use_stream_affinity,
+        "Stream affinity is only supported for device runtimes");
+#endif
+    stream_models_.clear();
+    model_streams_.clear();
+    reclaim_unused_stream_mutexes();
+  }
+
+  int64_t get_stream_affinity_model_index(DeviceStreamType stream) {
+    std::lock_guard lk(models_mutex_);
+    if (!use_stream_affinity_) {
+      return AOTI_STREAM_AFFINITY_DISABLED;
+    }
+    const auto stream_it = stream_models_.find(stream);
+    if (stream == nullptr || stream_it == stream_models_.end()) {
+      return AOTI_STREAM_AFFINITY_UNBOUND;
+    }
+    for (size_t i = 0; i < models_.size(); ++i) {
+      if (models_[i].get() == stream_it->second) {
+        return static_cast<int64_t>(i);
+      }
+    }
+    AOTI_RUNTIME_CHECK(false, "Stream affinity refers to an unknown model");
+  }
+
   void run(
       AtenTensorHandle*
           input_handles, // array of input AtenTensorHandle; handles
@@ -244,19 +297,19 @@ class AOTInductorModelContainer {
       // Double locking to make sure constant folding is only ran once.
       if (const_folded == ConstantState::INITIALIZED) {
         auto* model = get_available_model();
-        // TODO: add try catch block to handle exception.
-        auto folded_const_map = model->run_const_fold(
-            stream, proxy_executor, /* initialization = */ true);
-        update_constant_buffer(
-            std::move(folded_const_map),
-            /* use_inactive = */ false,
-            /* validate_full_update = */ false);
-        const_folded = ConstantState::FOLDED;
-        {
-          std::lock_guard lk(models_mutex_);
-          pending_models_.push_back(model);
+        try {
+          auto folded_const_map = model->run_const_fold(
+              stream, proxy_executor, /* initialization = */ true);
+          update_constant_buffer(
+              std::move(folded_const_map),
+              /* use_inactive = */ false,
+              /* validate_full_update = */ false);
+          const_folded = ConstantState::FOLDED;
+        } catch (...) {
+          return_model_to_available(model);
+          throw;
         }
-        pending_models_available_.notify_one();
+        return_model_to_pending(model);
       }
       constants_folding_lk.unlock();
       model_lk.lock();
@@ -266,21 +319,17 @@ class AOTInductorModelContainer {
           "Unknown constant state: " + toStringConstantState(const_folded));
     }
 
-    auto* model = get_available_model();
+    [[maybe_unused]] auto stream_lock = acquire_stream_lock(stream);
+    auto* model = get_available_model(stream);
 
     try {
       model->run(input_handles, output_handles, stream, proxy_executor);
     } catch (...) {
-      std::lock_guard lk(models_mutex_);
-      available_models_.push_back(model);
+      return_model_to_available(model);
       throw;
     }
 
-    {
-      std::lock_guard lk(models_mutex_);
-      pending_models_.push_back(model);
-    }
-    pending_models_available_.notify_one();
+    return_model_to_pending(model);
   }
 
   // Non-thread-aware variant of run(). Obviously unsafe to use in a threaded
@@ -295,6 +344,9 @@ class AOTInductorModelContainer {
                           // borrowed
       DeviceStreamType stream,
       AOTIProxyExecutorHandle proxy_executor) {
+    AOTI_RUNTIME_CHECK(
+        !use_stream_affinity_,
+        "Stream affinity cannot be used with single-threaded execution");
     auto* model = available_models_[0];
 
     auto& const_folded = active().fold_state;
@@ -449,13 +501,14 @@ class AOTInductorModelContainer {
             /* validate_full_update = */ false);
         const_folded = ConstantState::FOLDED;
       } catch (...) {
-        std::lock_guard lk(models_mutex_);
-        available_models_.push_back(model);
+        return_model_to_available(model);
         throw;
       }
+      return_model_to_pending(model);
     } else {
       std::shared_lock model_lk(model_exec_mutex_);
-      model = get_available_model();
+      [[maybe_unused]] auto stream_lock = acquire_stream_lock(stream);
+      model = get_available_model(stream);
 
       // We swap the constant mapping to the inactive buffer in the model to run
       // const run.
@@ -481,17 +534,12 @@ class AOTInductorModelContainer {
         model->update_constants_array(active_array);
         const_folded = ConstantState::FOLDED;
       } catch (...) {
-        std::lock_guard lk(models_mutex_);
-        available_models_.push_back(model);
+        return_model_to_available(model);
         throw;
       }
-    }
 
-    {
-      std::lock_guard lk(models_mutex_);
-      pending_models_.push_back(model);
+      return_model_to_pending(model);
     }
-    pending_models_available_.notify_one();
   }
 
   bool _is_tensor_constant_type(const size_t idx) const {
@@ -938,7 +986,13 @@ class AOTInductorModelContainer {
   // Holds all the AOTInductorModel instances owned by this container.
   std::vector<std::unique_ptr<AOTInductorModel>> models_;
 
-  // Holds the AOTInductorModel instances available for inference.
+  // Holds the AOTInductorModel instances available for inference. When stream
+  // affinity is enabled, each model is in exactly one execution state under
+  // models_mutex_: available here, pending device completion below, or checked
+  // out by a host thread. Stream bindings are persistent preferences
+  // independent of those states; borrowing a bound model preserves its
+  // binding, while a failed run clears it so the next call may choose another
+  // model.
   std::vector<AOTInductorModel*> available_models_;
 
   // Holds the AOTInductorModel instances that have started running
@@ -946,11 +1000,20 @@ class AOTInductorModelContainer {
   // completion.
   std::deque<AOTInductorModel*> pending_models_;
 
-  // Protects available_models_ and pending_models_.
+  bool use_stream_affinity_{false};
+  // Callers enabling affinity must keep bound streams alive to avoid a reused
+  // device handle inheriting an old binding. Unbound mutexes are reclaimed
+  // once no in-flight StreamLock shares ownership.
+  std::unordered_map<DeviceStreamType, AOTInductorModel*> stream_models_;
+  std::unordered_map<AOTInductorModel*, DeviceStreamType> model_streams_;
+  std::unordered_map<DeviceStreamType, std::shared_ptr<std::mutex>>
+      stream_mutexes_;
+  std::unordered_set<AOTInductorModel*> checked_out_models_;
+
+  // Protects the model-state collections and affinity mappings.
   std::mutex models_mutex_;
 
-  // Notified whenever a model is placed onto pending_models_.
-  std::condition_variable pending_models_available_;
+  std::condition_variable model_state_changed_;
 
   std::vector<std::string> extracted_constant_map_entry_names_;
   std::vector<AOTInductorConstantMapEntry> extracted_constant_map_entries_;
@@ -970,12 +1033,173 @@ class AOTInductorModelContainer {
 
   AOTInductorModel* get_available_model() {
     std::unique_lock lk(models_mutex_);
-    if (available_models_.empty()) {
+    return checkout_available_model(lk);
+  }
+
+  AOTInductorModel* checkout_available_model(std::unique_lock<std::mutex>& lk) {
+    return take_available_model(lk, /*prefer_unbound=*/use_stream_affinity_);
+  }
+
+  AOTInductorModel* take_available_model(
+      std::unique_lock<std::mutex>& lk,
+      bool prefer_unbound) {
+    while (available_models_.empty()) {
       reclaim_finished_models(lk);
     }
-    auto* result = available_models_.back();
-    available_models_.pop_back();
+    auto result_it = available_models_.end() - 1;
+    if (prefer_unbound) {
+      // Preserve existing bindings when possible. If every available model is
+      // bound, the caller borrows one while its owning stream waits.
+      for (auto it = available_models_.end();
+           it != available_models_.begin();) {
+        --it;
+        if (model_streams_.find(*it) == model_streams_.end()) {
+          result_it = it;
+          break;
+        }
+      }
+    }
+    auto* result = *result_it;
+    available_models_.erase(result_it);
+    if (use_stream_affinity_) {
+      checked_out_models_.insert(result);
+    }
     return result;
+  }
+
+  AOTInductorModel* get_available_model(DeviceStreamType stream) {
+    std::unique_lock lk(models_mutex_);
+#if defined(USE_CUDA) || defined(USE_XPU)
+    if (use_stream_affinity_ && stream != nullptr) {
+      return get_stream_affine_model(stream, lk);
+    }
+#else
+    (void)stream;
+#endif
+    return checkout_available_model(lk);
+  }
+
+  AOTInductorModel* get_stream_affine_model(
+      DeviceStreamType stream,
+      std::unique_lock<std::mutex>& lk) {
+    while (true) {
+      const auto stream_it = stream_models_.find(stream);
+      if (stream_it == stream_models_.end()) {
+        break;
+      }
+
+      auto* model = stream_it->second;
+      const auto available_it =
+          std::find(available_models_.begin(), available_models_.end(), model);
+      if (available_it != available_models_.end()) {
+        available_models_.erase(available_it);
+        checked_out_models_.insert(model);
+        return model;
+      }
+
+      const auto pending_it =
+          std::find(pending_models_.begin(), pending_models_.end(), model);
+      if (pending_it != pending_models_.end()) {
+        pending_models_.erase(pending_it);
+        checked_out_models_.insert(model);
+        lk.unlock();
+        try {
+          model->wait_for_completion();
+        } catch (...) {
+          return_model_to_available(model);
+          throw;
+        }
+        return model;
+      }
+
+      // A null-stream checkout or pool reclamation can temporarily borrow a
+      // bound model. Same non-null stream calls serialize before this point.
+      model_state_changed_.wait(lk, [this, model]() {
+        return checked_out_models_.find(model) == checked_out_models_.end();
+      });
+    }
+
+    // Bind an unbound model on a stream's first use. If all model instances are
+    // already bound, reclaim and rebind one for an oversubscribed stream.
+    auto* model = take_available_model(lk, /*prefer_unbound=*/true);
+    bind_model_to_stream(model, stream);
+    return model;
+  }
+
+  StreamLock acquire_stream_lock(DeviceStreamType stream) {
+#if defined(USE_CUDA) || defined(USE_XPU)
+    std::shared_ptr<std::mutex> stream_mutex;
+    {
+      std::lock_guard lk(models_mutex_);
+      if (!use_stream_affinity_ || stream == nullptr) {
+        return {};
+      }
+      reclaim_unused_stream_mutexes();
+      auto [it, inserted] = stream_mutexes_.try_emplace(stream, nullptr);
+      if (inserted) {
+        it->second = std::make_shared<std::mutex>();
+      }
+      stream_mutex = it->second;
+    }
+    return StreamLock(stream_mutex);
+#else
+    (void)stream;
+    return {};
+#endif
+  }
+
+  void reclaim_unused_stream_mutexes() {
+    for (auto it = stream_mutexes_.begin(); it != stream_mutexes_.end();) {
+      if (stream_models_.find(it->first) == stream_models_.end() &&
+          it->second.use_count() == 1) {
+        it = stream_mutexes_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  void unbind_model_from_stream(AOTInductorModel* model) {
+    const auto model_it = model_streams_.find(model);
+    if (model_it == model_streams_.end()) {
+      return;
+    }
+    stream_models_.erase(model_it->second);
+    model_streams_.erase(model_it);
+  }
+
+  void bind_model_to_stream(AOTInductorModel* model, DeviceStreamType stream) {
+    unbind_model_from_stream(model);
+
+    const auto stream_it = stream_models_.find(stream);
+    if (stream_it != stream_models_.end()) {
+      model_streams_.erase(stream_it->second);
+      stream_models_.erase(stream_it);
+    }
+
+    stream_models_.emplace(stream, model);
+    model_streams_.emplace(model, stream);
+  }
+
+  void return_model_to_available(AOTInductorModel* model) {
+    {
+      std::lock_guard lk(models_mutex_);
+      // A failed execution invalidates its affinity so a subsequent call can
+      // select another model instance.
+      unbind_model_from_stream(model);
+      checked_out_models_.erase(model);
+      available_models_.push_back(model);
+    }
+    model_state_changed_.notify_all();
+  }
+
+  void return_model_to_pending(AOTInductorModel* model) {
+    {
+      std::lock_guard lk(models_mutex_);
+      checked_out_models_.erase(model);
+      pending_models_.push_back(model);
+    }
+    model_state_changed_.notify_all();
   }
 
   // This mutex is used to protect execution of model.
@@ -1002,30 +1226,43 @@ class AOTInductorModelContainer {
 
     if (it != pending_models_.end()) {
       // We have finished model instances that can be pushed into
-      // available_models_ so that we don't have to be blocked on waiting
-      // the pending_models_available_ condition.
+      // available_models_ so that we don't have to block waiting on
+      // model_state_changed_.
       available_models_.insert(
           available_models_.end(), it, pending_models_.end());
       pending_models_.erase(it, pending_models_.end());
+      model_state_changed_.notify_all();
       return;
     }
 
-    pending_models_available_.wait(
-        lk, [this]() { return !pending_models_.empty(); });
+    model_state_changed_.wait(lk, [this]() {
+      return !available_models_.empty() || !pending_models_.empty();
+    });
+    if (!available_models_.empty()) {
+      return;
+    }
     // Let's make the schedule simple first. We always wait on the first
     // pending_models_ to be complete.
     auto* model = pending_models_.front();
     pending_models_.pop_front();
+    if (use_stream_affinity_) {
+      checked_out_models_.insert(model);
+    }
     lk.unlock();
     try {
       model->wait_for_completion();
     } catch (...) {
       lk.lock();
+      unbind_model_from_stream(model);
+      checked_out_models_.erase(model);
       available_models_.push_back(model);
+      model_state_changed_.notify_all();
       throw;
     }
     lk.lock();
+    checked_out_models_.erase(model);
     available_models_.push_back(model);
+    model_state_changed_.notify_all();
   }
 };
 

--- a/torch/export/pt2_archive/_package.py
+++ b/torch/export/pt2_archive/_package.py
@@ -1045,6 +1045,7 @@ def _load_aoti(
     run_single_threaded: bool,
     num_runners: int,
     device_idx: int,
+    use_stream_affinity: bool = False,
 ) -> AOTICompiledModel:
     loaded_metadata = torch._C._aoti.AOTIModelPackageLoader.load_metadata_from_package(  # type: ignore[attr-defined]
         file, model_name
@@ -1057,6 +1058,7 @@ def _load_aoti(
             run_single_threaded,
             num_runners,
             device_idx,
+            use_stream_affinity,
         )
     )
 
@@ -1087,6 +1089,7 @@ def load_pt2(
     num_runners: int = 1,
     device_index: int = -1,
     load_weights_from_disk: bool = False,
+    use_stream_affinity: bool = False,
 ) -> PT2ArchiveContents:  # type: ignore[type-arg]
     """
     Loads all the artifacts previously saved with ``package_pt2``.
@@ -1108,6 +1111,10 @@ def load_pt2(
             to be loaded. By default, `device_index=-1` is used, which corresponds
             to the device `cuda` when using CUDA. Passing `device_index=1` would
             load the package to `cuda:1`, for example.
+
+        use_stream_affinity (bool): Whether each non-null device stream should
+            retain a stable model instance. This is intended for controlled
+            multi-stream benchmarking and can reduce host-side pipelining.
 
     Returns:
         A ``PT2ArchiveContents`` object which contains all the objects in the PT2.
@@ -1188,6 +1195,7 @@ def load_pt2(
                         run_single_threaded,
                         num_runners,
                         device_index,
+                        use_stream_affinity,
                     )
                     for model_name in aoti_model_names
                 }
@@ -1201,6 +1209,7 @@ def load_pt2(
                 run_single_threaded,
                 num_runners,
                 device_index,
+                use_stream_affinity,
             )
             for model_name in aoti_model_names
         }


### PR DESCRIPTION
Summary:

Add an opt-in per-container AOTI scheduling policy for controlled multi-stream benchmarking. The public runtime and package-loader APIs now configure affinity per container instead of reading process-global configuration. When enabled, each non-null CUDA or XPU stream retains a stable model instance, calls sharing a stream serialize, and a bound stream waits for its prior model execution to complete. Null streams and non-device runtimes retain the default model-pool behavior. Bindings persist for the container lifetime and therefore assume long-lived streams; oversubscribed streams rebind models. This deliberately trades host/device pipelining for stable stream-to-model assignment. The internal Model Analyzer path keeps a compatibility bridge from its existing benchmark-only environment switch to the new per-container setter.

Test Plan: PyTorch pinned `clang-format` 19.1.4 via `tools/linter/adapters/clangformat_linter.py` passed with no findings for all nine changed upstream C++ paths. `arc f` and `arc lint -a` passed. `arc lint -e extra` produced only xplat compilation-database advice and no actionable findings. `buck2 build fbcode//caffe2:_libtorch fbcode//sigmoid/core/executor:aoti_model_impl_cuda fbcode//sigmoid/core/executor:aoti_model_impl_gpu_hipify_gen` passed (https://www.internalfb.com/buck2/9e7571c2-f2a2-4679-94e9-fe1bc267be95). `buck2 test fbcode//mode/opt fbcode//caffe2/test/inductor:aot_inductor_package` previously passed 50 tests with 26 skipped. Added upstream C++ integration cases covering affinity disabled, repeated calls across persistent distinct streams, and concurrent calls sharing one stream; that CMake-only test source has no fbcode Buck owner.

Reviewed By: desertfire

Differential Revision: D117399496




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo