### PR TITLE
[ROCm] Fixed test_cuda preferred_blas_library_settings for gfx1250

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -870,6 +870,8 @@ print(t.is_pinned())
                     archs.append("gfx950")
                 if ROCM_VERSION >= (7, 13):
                     archs.extend(["gfx1100", "gfx1101", "gfx1151"])
+                if ROCM_VERSION >= (7, 14):
+                    archs.extend(["gfx1250"])
                 gcn_arch_name = torch.cuda.get_device_properties(0).gcnArchName
                 hipblaslt_preferred = any(arch in gcn_arch_name for arch in archs)
                 if hipblaslt_preferred:


### PR DESCRIPTION
Fixed test_cuda.py::TestCuda::test_preferred_blas_library_settings

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang