### PR TITLE
[inductor] Fix loop-local load CSE lifetime

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -1410,6 +1410,41 @@ class ReductionInvariantIndexingTests(InductorTestCase):
     @config.patch(
         {
             "force_disable_caches": True,
+            "triton.persistent_reductions": False,
+        }
+    )
+    def test_loop_epilogue_indirect_load_scope(self):
+        def fn(x, source, index):
+            index = index.unsqueeze(-1)
+            selected = torch.gather(source, -2, index)
+            updated = selected + x.mean(dim=-1, keepdim=True)
+            return x / updated, source.scatter(-2, index, updated)
+
+        x = torch.ones(2, 2, 8, device=GPU_TYPE)
+        source = torch.arange(1, 17, device=GPU_TYPE, dtype=torch.float32).reshape(
+            2, 8, 1
+        )
+        index = torch.arange(2, device=GPU_TYPE).repeat(2, 1)
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True, dynamic=True),
+            x,
+            source,
+            index,
+            remove_quote=True,
+        )
+
+        self.assertEqual(fn(x, source, index), actual)
+        reduction_kernels = [kernel for kernel in kernels if "tl.sum(" in kernel]
+        self.assertEqual(1, len(reduction_kernels))
+        indirect_load = r"tl\.load\([^\n]*\+ \(tmp\d+"
+        FileCheck().check("for r0_offset in tl.range").check_regex(indirect_load).check(
+            "tl.store"
+        ).check_regex(indirect_load).run(reduction_kernels[0])
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "force_disable_caches": True,
             "triton.prefer_nd_tiling": True,
             "triton.tile_reductions": True,
         }
@@ -1724,13 +1759,14 @@ class ReductionInvariantIndexingTests(InductorTestCase):
         FileCheck().check_regex(DENSE_X_INDEX_LOAD).run(kernels[0])
 
     @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @parametrize("dense_indexing", [False, True])
     @config.patch(
         {
             "force_disable_caches": True,
             "triton.persistent_reductions": False,
         }
     )
-    def test_loop_epilogue_masked_index_load_scope(self):
+    def test_loop_epilogue_masked_index_load_scope(self, dense_indexing):
         def fn(index, mask, value):
             positions = torch.arange(index.numel(), device=index.device)
             masked_index = torch.ops.aten._unsafe_masked_index(
@@ -1744,16 +1780,20 @@ class ReductionInvariantIndexingTests(InductorTestCase):
             torch.tensor([True, False] * 8, device=GPU_TYPE),
             torch.randn(16, 64, device=GPU_TYPE),
         )
-        actual, kernels = run_and_get_kernels(
-            torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
-        )
+        with config.patch("triton.dense_indexing", dense_indexing):
+            actual, kernels = run_and_get_kernels(
+                torch.compile(fn, fullgraph=True), *inputs, remove_quote=True
+            )
 
         self.assertEqual(fn(*inputs), actual)
         self.assertEqual(1, len(kernels))
         kernel = kernels[0]
-        FileCheck().check("for r0_offset in tl.range").check_regex(
-            REDUCTION_INVARIANT_X_LOAD
-        ).check("tl.sum").check_regex(r"tl\.load\(").run(kernel)
+        check = FileCheck().check("for r0_offset in tl.range")
+        if dense_indexing:
+            check.check_regex(DENSE_X_INDEX_LOAD)
+        else:
+            check.check_regex(REDUCTION_INVARIANT_X_LOAD)
+        check.check("tl.sum").check_regex(r"tl\.load\(").run(kernel)
 
 
 class TestOptimizationHintIdentityExpansion(InductorTestCase):

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4537,9 +4537,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.inside_reduction
             and self.range_trees[-1].is_loop
             and not indexing.has_rindex()
+            and not indexing.has_rmask()
         ):
-            # can lift a common load outside of reduction loop
-            # One exception is when this is an indirect_load.
+            # Lift loads whose address and mask are available outside the loop.
             return self.body
         else:
             return self.loads
@@ -4917,9 +4917,6 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
         if isinstance(indexing, IndexingOptions):
             if self._has_stride1_on_rdim(indexing.index):
                 self.has_load_with_contiguous_rdim = True
-            reduction_axes_omitted = indexing.reduction_axes_omitted
-        else:
-            reduction_axes_omitted = False
 
         has_rindex = indexing.has_rindex()
         has_tmpmask = indexing.has_tmpmask()
@@ -5106,13 +5103,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     ),
                 )
 
-        if not self.inside_reduction or (
-            not indexing.has_rmask()
-            and not has_rindex
-            # The address and predicate producers for a narrowed load live in
-            # the loop-local compute buffer, so re-emit it for each loop chunk.
-            and not reduction_axes_omitted
-        ):
+        # Only CSE values emitted outside the loop remain valid after it closes.
+        if not self.inside_reduction or load_buffer is self.body:
             self.outside_loop_vars.add(result_var)
 
         return result_var


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Human context: fix for https://github.com/pytorch/pytorch/issues/194490) exposed by https://github.com/pytorch/pytorch/pull/184287 although the underlying cause was prior CSE / loop hoisting logic (and ultimately the fact that this is all tied to one very complicated file)..

Triton load placement and CSE lifetime used separate heuristics. An indirect load emitted inside a loop could consequently remain cached after loop closure and be reused by an epilogue even though its temporary did not dominate that use.

Use the selected load buffer as the source of truth for whether a CSE value survives loop closure. Also prevent loads carrying reduction masks from being hoisted before those masks are defined.

Test Plan:

```
python test/inductor/test_indexing.py ReductionInvariantIndexingTests
python test/inductor/test_codegen_triton.py -k reduction_invariant_load_indexing
git diff --check
lintrunner -a test/inductor/test_indexing.py torch/_inductor/codegen/triton.py
```

The two test commands and git diff check pass. Lintrunner was invoked, but Pyrefly failed on unrelated repository-wide missing-attribute errors because this detached worktree has no initialized lintrunner data.

AI-Assisted: Author reviewed and validated all AI-generated content.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo