### PR TITLE
grid_sample: support mode='bicubic' with 5-D input, including its double backward

### DIFF
--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -38,13 +38,13 @@ using at::native::detail::GridSamplerPadding;
 
 namespace {
 
-  // Resolves the four cubic taps one axis contributes to a sample at `coord`: the Keys
-  // coefficients of its fractional part, the index each tap reads at, whether it reads at all, and,
-  // when `coeffs_grad` is given, the derivative of each coefficient, which the grid gradient needs.
-  // The taps sit around the UNCLIPPED index, since a clipped one would place them around the wrong
-  // voxel. A tap the padding drops is marked with a negative index and contributes a zero value,
-  // which is what get_value_bounded does in 4-D: its coefficient still reaches the sum, so a
-  // coefficient that is not finite propagates the same way at both ranks.
+  // The four cubic taps one axis contributes at `coord`: the Keys coefficients of its fractional
+  // part, the index each tap reads at, and, when `coeffs_grad` is given, the derivative the grid
+  // gradient needs. The taps sit around the UNCLIPPED index; a clipped one would place them around
+  // the wrong voxel. A tap the padding drops takes a negative index and contributes a zero value
+  // while keeping its coefficient, which is what get_value_bounded does in 4-D. The bounds are
+  // taken on the coordinate where 4-D takes them on the truncated index; the two agree because
+  // compute_coordinates sends an integer to an integer in every padding mode.
   template <typename scalar_t, typename index_t>
   static inline void resolve_cubic_taps(
       scalar_t coord,
@@ -61,8 +61,7 @@ namespace {
     }
     for (const auto i : c10::irange(4)) {
       const scalar_t tap = compute_coordinates(base - 1 + i, size, padding_mode, align_corners);
-      // the comparison decides, not the cast: a coordinate that is not finite fails both sides,
-      // where converting it to an integer is undefined
+      // the comparison, not the cast: a coordinate that is not finite fails both sides
       indices[i] = (tap >= 0 && tap < static_cast<scalar_t>(size))
           ? static_cast<index_t>(tap)
           : static_cast<index_t>(-1);
@@ -262,8 +261,6 @@ namespace {
                             ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
                             : inp_ptr_NC;
                         for (const auto i : c10::irange(4)) {
-                          // a dropped tap contributes a zero value and keeps its coefficient,
-                          // which is what get_value_bounded does in 4-D
                           const opmath_t sample = plane_reads && x_taps[i] >= 0
                               ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
                               : static_cast<opmath_t>(0);

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -61,13 +61,13 @@ namespace {
     }
     for (const auto i : c10::irange(4)) {
       const scalar_t tap = compute_coordinates(base - 1 + i, size, padding_mode, align_corners);
-      // the comparison, not the cast: a coordinate that is not finite fails both sides
+      // the comparison decides, not the cast: a coordinate that is not finite fails
+      // both sides, where converting it is undefined
       indices[i] = (tap >= 0 && tap < static_cast<scalar_t>(size))
           ? static_cast<index_t>(tap)
           : static_cast<index_t>(-1);
     }
   }
-
 
   template<typename scalar_t>
   Tensor grid_sampler_3d_cpu_impl(const Tensor& input, const Tensor& grid,
@@ -225,7 +225,9 @@ namespace {
                 }
               } else if (interpolation_mode == GridSamplerInterpolation::Bicubic) {
                 // The taps are placed around the unclipped index, so this branch samples at the
-                // raw x, y, z rather than at the clipped ix, iy, iz above.
+                // raw x, y, z rather than at the clipped ix, iy, iz above. It works in the
+                // accumulate type: the coefficients and the reflection arithmetic need more
+                // precision than a half carries, and CUDA computes every mode in it.
                 opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
                 int64_t x_taps[4], y_taps[4], z_taps[4];
                 resolve_cubic_taps(grid_sampler_unnormalize(static_cast<opmath_t>(x), inp_W, align_corners),

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -39,11 +39,12 @@ using at::native::detail::GridSamplerPadding;
 namespace {
 
   // Resolves the four cubic taps one axis contributes to a sample at `coord`: the Keys
-  // coefficients of its fractional part, the index each tap reads at, and, when `coeffs_grad` is
-  // given, the derivative of each coefficient, which the grid gradient needs. The taps sit around
-  // the UNCLIPPED index, since a clipped one would place them around the wrong voxel; a tap the
-  // padding drops gets a zero coefficient, a zero derivative and index 0, so summing over the taps
-  // needs no bounds test.
+  // coefficients of its fractional part, the index each tap reads at, whether it reads at all, and,
+  // when `coeffs_grad` is given, the derivative of each coefficient, which the grid gradient needs.
+  // The taps sit around the UNCLIPPED index, since a clipped one would place them around the wrong
+  // voxel. A tap the padding drops is marked with a negative index and contributes a zero value,
+  // which is what get_value_bounded does in 4-D: its coefficient still reaches the sum, so a
+  // coefficient that is not finite propagates the same way at both ranks.
   template <typename scalar_t, typename index_t>
   static inline void resolve_cubic_taps(
       scalar_t coord,
@@ -60,16 +61,11 @@ namespace {
     }
     for (const auto i : c10::irange(4)) {
       const scalar_t tap = compute_coordinates(base - 1 + i, size, padding_mode, align_corners);
-      const index_t index = static_cast<index_t>(tap);
-      if (index >= 0 && index < size) {
-        indices[i] = index;
-      } else {
-        coeffs[i] = static_cast<scalar_t>(0);
-        if (coeffs_grad != nullptr) {
-          coeffs_grad[i] = static_cast<scalar_t>(0);
-        }
-        indices[i] = static_cast<index_t>(0);
-      }
+      // the comparison decides, not the cast: a coordinate that is not finite fails both sides,
+      // where converting it to an integer is undefined
+      indices[i] = (tap >= 0 && tap < static_cast<scalar_t>(size))
+          ? static_cast<index_t>(tap)
+          : static_cast<index_t>(-1);
     }
   }
 
@@ -240,16 +236,39 @@ namespace {
                 resolve_cubic_taps(grid_sampler_unnormalize(static_cast<opmath_t>(z), inp_D, align_corners),
                                    inp_D, padding_mode, align_corners, z_coeffs, static_cast<opmath_t*>(nullptr), z_taps);
 
+                // Only zero padding drops a tap, and only near the rim, so the sum splits: the
+                // common case reads all 64 taps and the test would only stop the vectoriser. A
+                // negative index marks a dropped tap; the OR is negative when any of them is.
+                const bool every_tap_reads =
+                    (x_taps[0] | x_taps[1] | x_taps[2] | x_taps[3] |
+                     y_taps[0] | y_taps[1] | y_taps[2] | y_taps[3] |
+                     z_taps[0] | z_taps[1] | z_taps[2] | z_taps[3]) >= 0;
+
                 scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
                 const scalar_t *inp_ptr_NC = inp_ptr_N;
                 for (int64_t c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
                   opmath_t value = static_cast<opmath_t>(0);
                   for (const auto k : c10::irange(4)) {
                     for (const auto j : c10::irange(4)) {
-                      const scalar_t *row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
                       const opmath_t weight_zy = z_coeffs[k] * y_coeffs[j];
-                      for (const auto i : c10::irange(4)) {
-                        value += static_cast<opmath_t>(row[x_taps[i] * inp_sW]) * weight_zy * x_coeffs[i];
+                      if (every_tap_reads) {
+                        const scalar_t *row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
+                        for (const auto i : c10::irange(4)) {
+                          value += static_cast<opmath_t>(row[x_taps[i] * inp_sW]) * weight_zy * x_coeffs[i];
+                        }
+                      } else {
+                        const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
+                        const scalar_t *row = plane_reads
+                            ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
+                            : inp_ptr_NC;
+                        for (const auto i : c10::irange(4)) {
+                          // a dropped tap contributes a zero value and keeps its coefficient,
+                          // which is what get_value_bounded does in 4-D
+                          const opmath_t sample = plane_reads && x_taps[i] >= 0
+                              ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
+                              : static_cast<opmath_t>(0);
+                          value += sample * weight_zy * x_coeffs[i];
+                        }
                       }
                     }
                   }
@@ -523,14 +542,22 @@ namespace {
                   const opmath_t gOut = *gOut_ptr_NCDHW;
                   for (const auto k : c10::irange(4)) {
                     for (const auto j : c10::irange(4)) {
-                      const scalar_t *row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
-                      const int64_t grad_row = gInp_offset_NC + z_taps[k] * gInp_sD + y_taps[j] * gInp_sH;
+                      const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
+                      const scalar_t *row = plane_reads
+                          ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
+                          : inp_ptr_NC;
+                      const int64_t grad_row = plane_reads
+                          ? gInp_offset_NC + z_taps[k] * gInp_sD + y_taps[j] * gInp_sH
+                          : gInp_offset_NC;
                       for (const auto i : c10::irange(4)) {
-                        if (input_requires_grad) {
+                        const bool reads = plane_reads && x_taps[i] >= 0;
+                        if (input_requires_grad && reads) {
                           gInp_ptr[grad_row + x_taps[i] * gInp_sW] += static_cast<scalar_t>(
                               gOut * x_coeffs[i] * y_coeffs[j] * z_coeffs[k]);
                         }
-                        const opmath_t value = static_cast<opmath_t>(row[x_taps[i] * inp_sW]);
+                        const opmath_t value = reads
+                            ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
+                            : static_cast<opmath_t>(0);
                         gix -= value * x_coeffs_grad[i] * y_coeffs[j] * z_coeffs[k] * gOut;
                         giy -= value * x_coeffs[i] * y_coeffs_grad[j] * z_coeffs[k] * gOut;
                         giz -= value * x_coeffs[i] * y_coeffs[j] * z_coeffs_grad[k] * gOut;

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -3,6 +3,7 @@
 #include <ATen/native/GridSamplerUtils.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
+#include <ATen/OpMathType.h>
 #include <ATen/Parallel.h>
 #include <ATen/native/UpSample.h>
 #include <ATen/native/cpu/GridSamplerKernel.h>
@@ -37,6 +38,42 @@ using at::native::detail::GridSamplerPadding;
 
 namespace {
 
+  // Resolves the four cubic taps one axis contributes to a sample at `coord`: the Keys
+  // coefficients of its fractional part, the index each tap reads at, and, when `coeffs_grad` is
+  // given, the derivative of each coefficient, which the grid gradient needs. The taps sit around
+  // the UNCLIPPED index, since a clipped one would place them around the wrong voxel; a tap the
+  // padding drops gets a zero coefficient, a zero derivative and index 0, so summing over the taps
+  // needs no bounds test.
+  template <typename scalar_t, typename index_t>
+  static inline void resolve_cubic_taps(
+      scalar_t coord,
+      index_t size,
+      GridSamplerPadding padding_mode,
+      bool align_corners,
+      scalar_t coeffs[4],
+      scalar_t* coeffs_grad,
+      index_t indices[4]) {
+    const scalar_t base = std::floor(coord);
+    get_cubic_upsample_coefficients<scalar_t>(coeffs, coord - base);
+    if (coeffs_grad != nullptr) {
+      get_cubic_coefficients_grad<scalar_t>(coeffs_grad, coord - base);
+    }
+    for (const auto i : c10::irange(4)) {
+      const scalar_t tap = compute_coordinates(base - 1 + i, size, padding_mode, align_corners);
+      const index_t index = static_cast<index_t>(tap);
+      if (index >= 0 && index < size) {
+        indices[i] = index;
+      } else {
+        coeffs[i] = static_cast<scalar_t>(0);
+        if (coeffs_grad != nullptr) {
+          coeffs_grad[i] = static_cast<scalar_t>(0);
+        }
+        indices[i] = static_cast<index_t>(0);
+      }
+    }
+  }
+
+
   template<typename scalar_t>
   Tensor grid_sampler_3d_cpu_impl(const Tensor& input, const Tensor& grid,
                                   GridSamplerInterpolation interpolation_mode,
@@ -44,9 +81,9 @@ namespace {
                                   bool align_corners) {
     // See NOTE [ grid_sampler Native Functions ].
     // Add checks here in case this is called instead of grid_sampler.
+    using opmath_t = at::opmath_type<scalar_t>;
     check_grid_sampler_common(input, grid);
-    check_grid_sampler_3d(
-      input, grid, static_cast<int64_t>(interpolation_mode));
+    check_grid_sampler_3d(input, grid);
 
     int64_t N = input.size(0);
     int64_t C = input.size(1);
@@ -88,13 +125,13 @@ namespace {
             for (const auto w : c10::irange(out_W)) {
               // get the corresponding input x, y, z coordinates from grid
               const scalar_t *grid_ptr_NDHW = grid_ptr_N + d * grid_sD + h * grid_sH + w * grid_sW;
-              scalar_t ix = *grid_ptr_NDHW;
-              scalar_t iy = grid_ptr_NDHW[grid_sCoor];
-              scalar_t iz = grid_ptr_NDHW[2 * grid_sCoor];
+              scalar_t x = *grid_ptr_NDHW;
+              scalar_t y = grid_ptr_NDHW[grid_sCoor];
+              scalar_t z = grid_ptr_NDHW[2 * grid_sCoor];
 
-              ix = grid_sampler_compute_source_index(ix, inp_W, padding_mode, align_corners);
-              iy = grid_sampler_compute_source_index(iy, inp_H, padding_mode, align_corners);
-              iz = grid_sampler_compute_source_index(iz, inp_D, padding_mode, align_corners);
+              scalar_t ix = grid_sampler_compute_source_index(x, inp_W, padding_mode, align_corners);
+              scalar_t iy = grid_sampler_compute_source_index(y, inp_H, padding_mode, align_corners);
+              scalar_t iz = grid_sampler_compute_source_index(z, inp_D, padding_mode, align_corners);
 
               if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
                 // get corner pixel values from (x, y, z)
@@ -191,6 +228,33 @@ namespace {
                     *out_ptr_NCDHW = static_cast<scalar_t>(0);
                   }
                 }
+              } else if (interpolation_mode == GridSamplerInterpolation::Bicubic) {
+                // The taps are placed around the unclipped index, so this branch samples at the
+                // raw x, y, z rather than at the clipped ix, iy, iz above.
+                opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
+                int64_t x_taps[4], y_taps[4], z_taps[4];
+                resolve_cubic_taps(grid_sampler_unnormalize(static_cast<opmath_t>(x), inp_W, align_corners),
+                                   inp_W, padding_mode, align_corners, x_coeffs, static_cast<opmath_t*>(nullptr), x_taps);
+                resolve_cubic_taps(grid_sampler_unnormalize(static_cast<opmath_t>(y), inp_H, align_corners),
+                                   inp_H, padding_mode, align_corners, y_coeffs, static_cast<opmath_t*>(nullptr), y_taps);
+                resolve_cubic_taps(grid_sampler_unnormalize(static_cast<opmath_t>(z), inp_D, align_corners),
+                                   inp_D, padding_mode, align_corners, z_coeffs, static_cast<opmath_t*>(nullptr), z_taps);
+
+                scalar_t *out_ptr_NCDHW = out_ptr + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
+                const scalar_t *inp_ptr_NC = inp_ptr_N;
+                for (int64_t c = 0; c < C; ++c, out_ptr_NCDHW += out_sC, inp_ptr_NC += inp_sC) {
+                  opmath_t value = static_cast<opmath_t>(0);
+                  for (const auto k : c10::irange(4)) {
+                    for (const auto j : c10::irange(4)) {
+                      const scalar_t *row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
+                      const opmath_t weight_zy = z_coeffs[k] * y_coeffs[j];
+                      for (const auto i : c10::irange(4)) {
+                        value += static_cast<opmath_t>(row[x_taps[i] * inp_sW]) * weight_zy * x_coeffs[i];
+                      }
+                    }
+                  }
+                  *out_ptr_NCDHW = static_cast<scalar_t>(value);
+                }
               }
             }
           }
@@ -209,9 +273,9 @@ namespace {
                                     bool align_corners, std::array<bool,2> output_mask) {
     // See NOTE [ grid_sampler Native Functions ].
     // Add checks here in case this is called instead of grid_sampler.
+    using opmath_t = at::opmath_type<scalar_t>;
     check_grid_sampler_common(input, grid);
-    check_grid_sampler_3d(
-      input, grid, static_cast<int64_t>(interpolation_mode));
+    check_grid_sampler_3d(input, grid);
 
     auto input_requires_grad = output_mask[0];
     Tensor grad_input = ([&]() {
@@ -287,15 +351,15 @@ namespace {
             for (int64_t w = 0; w < out_W; ++w, gGrid_ptr_NDHW += gGrid_sW /* grad_grid is contiguous */ ) {
               // get the corresponding input x, y, z coordinates from grid
               const scalar_t *grid_ptr_NDHW = grid_ptr_N + d * grid_sD + h * grid_sH + w * grid_sW;
-              scalar_t ix = *grid_ptr_NDHW;
-              scalar_t iy = grid_ptr_NDHW[grid_sCoor];
-              scalar_t iz = grid_ptr_NDHW[2 * grid_sCoor];
+              scalar_t x = *grid_ptr_NDHW;
+              scalar_t y = grid_ptr_NDHW[grid_sCoor];
+              scalar_t z = grid_ptr_NDHW[2 * grid_sCoor];
 
               // multipliers for gradients on ix, iy, and iz
               scalar_t gix_mult, giy_mult, giz_mult;
-              ix = grid_sampler_compute_source_index_set_grad(ix, inp_W, padding_mode, align_corners, &gix_mult);
-              iy = grid_sampler_compute_source_index_set_grad(iy, inp_H, padding_mode, align_corners, &giy_mult);
-              iz = grid_sampler_compute_source_index_set_grad(iz, inp_D, padding_mode, align_corners, &giz_mult);
+              scalar_t ix = grid_sampler_compute_source_index_set_grad(x, inp_W, padding_mode, align_corners, &gix_mult);
+              scalar_t iy = grid_sampler_compute_source_index_set_grad(y, inp_H, padding_mode, align_corners, &giy_mult);
+              scalar_t iz = grid_sampler_compute_source_index_set_grad(z, inp_D, padding_mode, align_corners, &giz_mult);
 
               if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
                 // get corner pixel values from (x, y, z)
@@ -432,6 +496,52 @@ namespace {
                                 gInp_sD, gInp_sH, gInp_sW, inp_D, inp_H, inp_W, *gOut_ptr_NCDHW);
                   }
                 }
+              } else if (interpolation_mode == GridSamplerInterpolation::Bicubic) {
+                // The taps are placed around the unclipped index, so the clipping ix, iy, iz went
+                // through above is undone here; their multipliers are the unnormalize ones.
+                opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
+                opmath_t x_coeffs_grad[4], y_coeffs_grad[4], z_coeffs_grad[4];
+                int64_t x_taps[4], y_taps[4], z_taps[4];
+                opmath_t x_mult, y_mult, z_mult;
+                resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(x), inp_W, align_corners, &x_mult),
+                                   inp_W, padding_mode, align_corners, x_coeffs, x_coeffs_grad, x_taps);
+                resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(y), inp_H, align_corners, &y_mult),
+                                   inp_H, padding_mode, align_corners, y_coeffs, y_coeffs_grad, y_taps);
+                resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(z), inp_D, align_corners, &z_mult),
+                                   inp_D, padding_mode, align_corners, z_coeffs, z_coeffs_grad, z_taps);
+
+                opmath_t gix = static_cast<opmath_t>(0);
+                opmath_t giy = static_cast<opmath_t>(0);
+                opmath_t giz = static_cast<opmath_t>(0);
+
+                const scalar_t *gOut_ptr_NCDHW = gOut_ptr + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
+                const scalar_t *inp_ptr_NC = inp_ptr_N;
+                // an offset rather than a pointer, since grad_input is undefined when it is not asked for
+                int64_t gInp_offset_NC = n * gInp_sN;
+                for (int64_t c = 0; c < C;
+                     ++c, gOut_ptr_NCDHW += gOut_sC, gInp_offset_NC += gInp_sC, inp_ptr_NC += inp_sC) {
+                  const opmath_t gOut = *gOut_ptr_NCDHW;
+                  for (const auto k : c10::irange(4)) {
+                    for (const auto j : c10::irange(4)) {
+                      const scalar_t *row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
+                      const int64_t grad_row = gInp_offset_NC + z_taps[k] * gInp_sD + y_taps[j] * gInp_sH;
+                      for (const auto i : c10::irange(4)) {
+                        if (input_requires_grad) {
+                          gInp_ptr[grad_row + x_taps[i] * gInp_sW] += static_cast<scalar_t>(
+                              gOut * x_coeffs[i] * y_coeffs[j] * z_coeffs[k]);
+                        }
+                        const opmath_t value = static_cast<opmath_t>(row[x_taps[i] * inp_sW]);
+                        gix -= value * x_coeffs_grad[i] * y_coeffs[j] * z_coeffs[k] * gOut;
+                        giy -= value * x_coeffs[i] * y_coeffs_grad[j] * z_coeffs[k] * gOut;
+                        giz -= value * x_coeffs[i] * y_coeffs[j] * z_coeffs_grad[k] * gOut;
+                      }
+                    }
+                  }
+                }
+                // assuming grad_grid is contiguous
+                gGrid_ptr_NDHW[0] = static_cast<scalar_t>(x_mult * gix);
+                gGrid_ptr_NDHW[1] = static_cast<scalar_t>(y_mult * giy);
+                gGrid_ptr_NDHW[2] = static_cast<scalar_t>(z_mult * giz);
               }
             }
           }
@@ -962,7 +1072,7 @@ Tensor grid_sampler_3d_cpu(const Tensor& input, const Tensor& grid,
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_common(input, grid);
-  check_grid_sampler_3d(input, grid, interpolation_mode);
+  check_grid_sampler_3d(input, grid);
 
   return AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "grid_sampler3d_cpu", [&] {
     return grid_sampler_3d_cpu_impl<scalar_t>(
@@ -1023,7 +1133,7 @@ grid_sampler_3d_backward_cpu(const Tensor& grad_output, const Tensor& input, con
                              std::array<bool,2> output_mask) {
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
-  check_grid_sampler_3d_backward(input, grid, grad_output, interpolation_mode);
+  check_grid_sampler_3d_backward(input, grid, grad_output);
 
   return AT_DISPATCH_FLOATING_TYPES_AND2(kHalf, kBFloat16, input.scalar_type(), "grid_sampler_3d_backward_cpu", [&] {
     return grid_sampler_3d_backward_cpu_impl<scalar_t>(

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -44,7 +44,9 @@ namespace {
   // the wrong voxel. A tap the padding drops takes a negative index and contributes a zero value
   // while keeping its coefficient, which is what get_value_bounded does in 4-D. The bounds are
   // taken on the coordinate where 4-D takes them on the truncated index; the two agree because
-  // compute_coordinates sends an integer to an integer in every padding mode.
+  // compute_coordinates sends an integer to an integer in every padding mode. Where a scalar_t
+  // runs out of integers the bound stays conservative: it drops taps at the top of an extent
+  // rather than admitting one past the end.
   template <typename scalar_t, typename index_t>
   static inline void resolve_cubic_taps(
       scalar_t coord,

--- a/aten/src/ATen/native/GridSampler.cpp
+++ b/aten/src/ATen/native/GridSampler.cpp
@@ -38,6 +38,37 @@ using at::native::detail::GridSamplerPadding;
 
 namespace {
 
+  // compute_coordinates with the reflection parity taken by fmod rather than
+  // through an int, which is undefined once the fold count passes INT_MAX. It
+  // forms the same bounds as compute_coordinates and clips the same way, so the
+  // two answer alike wherever the merged helper is defined, and the CUDA twin
+  // reaches the same voxel where it is not.
+  template <typename scalar_t, typename index_t>
+  static inline scalar_t compute_coordinates_sized(scalar_t coord, index_t size,
+                                                   GridSamplerPadding padding_mode,
+                                                   bool align_corners) {
+    if (padding_mode == GridSamplerPadding::Border) {
+      coord = clip_coordinates(coord, size);
+    } else if (padding_mode == GridSamplerPadding::Reflection) {
+      // the bounds reflect_coordinates halves, reached without doubling an extent
+      // the type may not represent
+      const scalar_t low =
+          align_corners ? static_cast<scalar_t>(0) : static_cast<scalar_t>(-0.5);
+      const scalar_t span = static_cast<scalar_t>(align_corners ? size - 1 : size);
+      if (span == 0) {
+        coord = 0;
+      } else {
+        const scalar_t in = std::fabs(coord - low);
+        const scalar_t extra = std::fmod(in, span);
+        const bool odd =
+            std::fmod(std::floor(in / span), static_cast<scalar_t>(2)) != 0;
+        coord = odd ? span - extra + low : extra + low;
+      }
+      coord = clip_coordinates(coord, size);
+    }
+    return coord;
+  }
+
   // The four cubic taps one axis contributes at `coord`: the Keys coefficients of its fractional
   // part, the index each tap reads at, and, when `coeffs_grad` is given, the derivative the grid
   // gradient needs. The taps sit around the UNCLIPPED index; a clipped one would place them around
@@ -62,7 +93,8 @@ namespace {
       get_cubic_coefficients_grad<scalar_t>(coeffs_grad, coord - base);
     }
     for (const auto i : c10::irange(4)) {
-      const scalar_t tap = compute_coordinates(base - 1 + i, size, padding_mode, align_corners);
+      const scalar_t tap =
+          compute_coordinates_sized(base - 1 + i, size, padding_mode, align_corners);
       // the comparison decides, not the cast: a coordinate that is not finite fails
       // both sides, where converting it is undefined
       indices[i] = (tap >= 0 && tap < static_cast<scalar_t>(size))

--- a/aten/src/ATen/native/GridSamplerUtils.h
+++ b/aten/src/ATen/native/GridSamplerUtils.h
@@ -73,19 +73,27 @@ inline void check_grid_sampler_2d(
 // See NOTE [ grid_sampler Native Functions ].
 inline void check_grid_sampler_3d(
   const TensorBase& input,
-  const TensorBase& grid,
-  int64_t interpolation_mode
+  const TensorBase& grid
 ) {
   TORCH_CHECK(
     input.dim() == 5 && input.dim() == grid.dim(),
     "grid_sampler(): expected 5D input and grid with same number of "
     "dimensions, but got input with sizes ", input.sizes(),
     " and grid with sizes ", grid.sizes());
+}
+
+// Overload for a backend whose 5D sampler implements bilinear and nearest only.
+// See NOTE [ grid_sampler Native Functions ].
+inline void check_grid_sampler_3d(
+  const TensorBase& input,
+  const TensorBase& grid,
+  int64_t interpolation_mode
+) {
+  check_grid_sampler_3d(input, grid);
   TORCH_CHECK(
-    !(input.dim() == 5 &&
-      static_cast<GridSamplerInterpolation>(interpolation_mode) ==
-        GridSamplerInterpolation::Bicubic),
-    "grid_sampler(): bicubic interpolation only supports 4D input");
+    static_cast<GridSamplerInterpolation>(interpolation_mode) !=
+      GridSamplerInterpolation::Bicubic,
+    "grid_sampler(): bicubic interpolation with 5D input is not supported by this backend");
 }
 
 // See NOTE [ grid_sampler Native Functions ].
@@ -122,12 +130,22 @@ inline void check_grid_sampler_2d_backward(
 inline void check_grid_sampler_3d_backward(
   const TensorBase& input,
   const TensorBase& grid,
+  const TensorBase& grad_output
+) {
+  check_grid_sampler_common(input, grid);
+  check_grid_sampler_3d(input, grid);
+  check_grid_sampler_backward(input, grid, grad_output);
+}
+
+// See NOTE [ grid_sampler Native Functions ].
+inline void check_grid_sampler_3d_backward(
+  const TensorBase& input,
+  const TensorBase& grid,
   const TensorBase& grad_output,
   int64_t interpolation_mode
 ) {
-  check_grid_sampler_common(input, grid);
+  check_grid_sampler_3d_backward(input, grid, grad_output);
   check_grid_sampler_3d(input, grid, interpolation_mode);
-  check_grid_sampler_backward(input, grid, grad_output);
 }
 
 // See NOTE [ grid_sampler Native Functions ].

--- a/aten/src/ATen/native/GridSamplerUtils.h
+++ b/aten/src/ATen/native/GridSamplerUtils.h
@@ -82,9 +82,9 @@ inline void check_grid_sampler_3d(
     " and grid with sizes ", grid.sizes());
 }
 
-// The overload a backend whose 5D sampler has bilinear and nearest only calls.
-// torch-xpu-ops calls it at the commit third_party/xpu.txt pins; drop it once
-// that call site moves to the two argument form.
+// TODO: drop this overload once torch-xpu-ops stops calling it. In-tree backends
+// call the one above and refuse bicubic themselves; torch-xpu-ops still passes
+// the mode here, at the commit third_party/xpu.txt pins.
 // See NOTE [ grid_sampler Native Functions ].
 inline void check_grid_sampler_3d(
   const TensorBase& input,
@@ -140,16 +140,6 @@ inline void check_grid_sampler_3d_backward(
   check_grid_sampler_backward(input, grid, grad_output);
 }
 
-// See NOTE [ grid_sampler Native Functions ].
-inline void check_grid_sampler_3d_backward(
-  const TensorBase& input,
-  const TensorBase& grid,
-  const TensorBase& grad_output,
-  int64_t interpolation_mode
-) {
-  check_grid_sampler_3d_backward(input, grid, grad_output);
-  check_grid_sampler_3d(input, grid, interpolation_mode);
-}
 
 // See NOTE [ grid_sampler Native Functions ].
 // cudnn does not support inputs larger than 1024.

--- a/aten/src/ATen/native/GridSamplerUtils.h
+++ b/aten/src/ATen/native/GridSamplerUtils.h
@@ -82,7 +82,9 @@ inline void check_grid_sampler_3d(
     " and grid with sizes ", grid.sizes());
 }
 
-// Overload for a backend whose 5D sampler implements bilinear and nearest only.
+// The overload a backend whose 5D sampler has bilinear and nearest only calls.
+// torch-xpu-ops calls it at the commit third_party/xpu.txt pins; drop it once
+// that call site moves to the two argument form.
 // See NOTE [ grid_sampler Native Functions ].
 inline void check_grid_sampler_3d(
   const TensorBase& input,
@@ -90,10 +92,11 @@ inline void check_grid_sampler_3d(
   int64_t interpolation_mode
 ) {
   check_grid_sampler_3d(input, grid);
-  TORCH_CHECK(
+  TORCH_CHECK_NOT_IMPLEMENTED(
     static_cast<GridSamplerInterpolation>(interpolation_mode) !=
       GridSamplerInterpolation::Bicubic,
-    "grid_sampler(): bicubic interpolation with 5D input is not supported by this backend");
+    "grid_sampler(): bicubic interpolation with 5D input is not "
+    "implemented for ", input.device().type());
 }
 
 // See NOTE [ grid_sampler Native Functions ].

--- a/aten/src/ATen/native/GridSamplerUtils.h
+++ b/aten/src/ATen/native/GridSamplerUtils.h
@@ -140,7 +140,6 @@ inline void check_grid_sampler_3d_backward(
   check_grid_sampler_backward(input, grid, grad_output);
 }
 
-
 // See NOTE [ grid_sampler Native Functions ].
 // cudnn does not support inputs larger than 1024.
 inline bool cond_cudnn_grid_sampler(

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -801,12 +801,15 @@ namespace {
             #pragma unroll
             for (int j = 0; j < 4; ++j) {
               auto row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
-              const index_t grad_row = NC_offset + z_taps[k] * gInp_sD + y_taps[j] * gInp_sH;
+              // the grad_input strides are int64_t whatever index_t is, so the offset is narrowed
+              // back to index_t, which is what fastAtomicAdd measures its span in
+              const index_t grad_row = NC_offset + static_cast<index_t>(z_taps[k] * gInp_sD + y_taps[j] * gInp_sH);
               #pragma unroll
               for (int i = 0; i < 4; ++i) {
                 if (input_requires_grad) {
                   // See Note [Passing pointer and offset to fastAtomicAdd].
-                  fastAtomicAdd(grad_input.data, grad_row + x_taps[i] * gInp_sW, grad_input_memory_span,
+                  fastAtomicAdd(grad_input.data, grad_row + static_cast<index_t>(x_taps[i] * gInp_sW),
+                                grad_input_memory_span,
                                 static_cast<scalar_t>(gOut * x_coeffs[i] * y_coeffs[j] * z_coeffs[k]), true);
                 }
                 const opmath_t value = static_cast<opmath_t>(row[x_taps[i] * inp_sW]);

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -297,6 +297,36 @@ namespace {
             *out_ptr_NCDHW = static_cast<scalar_t>(0);
           }
         }
+      } else if (interpolation_mode == GridSamplerInterpolation::Bicubic) {
+        // The taps are placed around the unclipped index, so this branch samples at the raw
+        // x, y, z rather than at the clipped ix, iy, iz above.
+        opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
+        index_t x_taps[4], y_taps[4], z_taps[4];
+        resolve_cubic_taps(grid_sampler_unnormalize(x, inp_W, align_corners), inp_W, padding_mode,
+                           align_corners, x_coeffs, static_cast<opmath_t*>(nullptr), x_taps);
+        resolve_cubic_taps(grid_sampler_unnormalize(y, inp_H, align_corners), inp_H, padding_mode,
+                           align_corners, y_coeffs, static_cast<opmath_t*>(nullptr), y_taps);
+        resolve_cubic_taps(grid_sampler_unnormalize(z, inp_D, align_corners), inp_D, padding_mode,
+                           align_corners, z_coeffs, static_cast<opmath_t*>(nullptr), z_taps);
+
+        auto inp_ptr_NC = input.data + n * inp_sN;
+        auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
+        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
+          opmath_t value = static_cast<opmath_t>(0);
+          #pragma unroll
+          for (int k = 0; k < 4; ++k) {
+            #pragma unroll
+            for (int j = 0; j < 4; ++j) {
+              auto row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
+              const opmath_t weight_zy = z_coeffs[k] * y_coeffs[j];
+              #pragma unroll
+              for (int i = 0; i < 4; ++i) {
+                value += static_cast<opmath_t>(row[x_taps[i] * inp_sW]) * weight_zy * x_coeffs[i];
+              }
+            }
+          }
+          *out_ptr_NCDHW = static_cast<scalar_t>(value);
+        }
       }
     }
   }
@@ -573,15 +603,15 @@ namespace {
       const auto grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
 
       // get the corresponding input x, y, z coordinates from grid
-      scalar_t ix = grid.data[grid_offset];
-      scalar_t iy = grid.data[grid_offset + grid_sCoor];
-      scalar_t iz = grid.data[grid_offset + 2 * grid_sCoor];
+      scalar_t x = grid.data[grid_offset];
+      scalar_t y = grid.data[grid_offset + grid_sCoor];
+      scalar_t z = grid.data[grid_offset + 2 * grid_sCoor];
 
       // multipliers for gradients on ix, iy, and iz
       scalar_t gix_mult, giy_mult, giz_mult;
-      ix = grid_sampler_compute_source_index_set_grad(ix, inp_W, padding_mode, align_corners, &gix_mult);
-      iy = grid_sampler_compute_source_index_set_grad(iy, inp_H, padding_mode, align_corners, &giy_mult);
-      iz = grid_sampler_compute_source_index_set_grad(iz, inp_D, padding_mode, align_corners, &giz_mult);
+      scalar_t ix = grid_sampler_compute_source_index_set_grad(x, inp_W, padding_mode, align_corners, &gix_mult);
+      scalar_t iy = grid_sampler_compute_source_index_set_grad(y, inp_H, padding_mode, align_corners, &giy_mult);
+      scalar_t iz = grid_sampler_compute_source_index_set_grad(z, inp_D, padding_mode, align_corners, &giz_mult);
 
       if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
         // get corner pixel values from (x, y, z)
@@ -742,6 +772,55 @@ namespace {
         gGrid_ptr_NDHW[0] = static_cast<scalar_t>(0);
         gGrid_ptr_NDHW[1] = static_cast<scalar_t>(0);
         gGrid_ptr_NDHW[2] = static_cast<scalar_t>(0);
+      } else if (interpolation_mode == GridSamplerInterpolation::Bicubic) {
+        using opmath_t = at::opmath_type<scalar_t>;
+        // The taps are placed around the unclipped index, so the clipping ix, iy, iz went through
+        // above is undone here; their multipliers are the unnormalize ones.
+        opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
+        opmath_t x_coeffs_grad[4], y_coeffs_grad[4], z_coeffs_grad[4];
+        index_t x_taps[4], y_taps[4], z_taps[4];
+        opmath_t x_mult, y_mult, z_mult;
+        resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(x), inp_W, align_corners, &x_mult),
+                           inp_W, padding_mode, align_corners, x_coeffs, x_coeffs_grad, x_taps);
+        resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(y), inp_H, align_corners, &y_mult),
+                           inp_H, padding_mode, align_corners, y_coeffs, y_coeffs_grad, y_taps);
+        resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(z), inp_D, align_corners, &z_mult),
+                           inp_D, padding_mode, align_corners, z_coeffs, z_coeffs_grad, z_taps);
+
+        opmath_t gix = static_cast<opmath_t>(0);
+        opmath_t giy = static_cast<opmath_t>(0);
+        opmath_t giz = static_cast<opmath_t>(0);
+
+        const scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
+        index_t NC_offset = n * gInp_sN;
+        auto inp_ptr_NC = input.data + n * inp_sN;
+        for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, NC_offset += gInp_sC, inp_ptr_NC += inp_sC) {
+          const opmath_t gOut = *gOut_ptr_NCDHW;
+          #pragma unroll
+          for (int k = 0; k < 4; ++k) {
+            #pragma unroll
+            for (int j = 0; j < 4; ++j) {
+              auto row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
+              const index_t grad_row = NC_offset + z_taps[k] * gInp_sD + y_taps[j] * gInp_sH;
+              #pragma unroll
+              for (int i = 0; i < 4; ++i) {
+                if (input_requires_grad) {
+                  // See Note [Passing pointer and offset to fastAtomicAdd].
+                  fastAtomicAdd(grad_input.data, grad_row + x_taps[i] * gInp_sW, grad_input_memory_span,
+                                static_cast<scalar_t>(gOut * x_coeffs[i] * y_coeffs[j] * z_coeffs[k]), true);
+                }
+                const opmath_t value = static_cast<opmath_t>(row[x_taps[i] * inp_sW]);
+                gix -= value * x_coeffs_grad[i] * y_coeffs[j] * z_coeffs[k] * gOut;
+                giy -= value * x_coeffs[i] * y_coeffs_grad[j] * z_coeffs[k] * gOut;
+                giz -= value * x_coeffs[i] * y_coeffs[j] * z_coeffs_grad[k] * gOut;
+              }
+            }
+          }
+        }
+        scalar_t *gGrid_ptr_NDHW = grad_grid.data + index * gGrid_sW;
+        gGrid_ptr_NDHW[0] = static_cast<scalar_t>(x_mult * gix);
+        gGrid_ptr_NDHW[1] = static_cast<scalar_t>(y_mult * giy);
+        gGrid_ptr_NDHW[2] = static_cast<scalar_t>(z_mult * giz);
       }
     }
   }
@@ -797,7 +876,7 @@ void launch_grid_sampler_3d_forward_kernel(
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
   check_grid_sampler_common(input, grid);
-  check_grid_sampler_3d(input, grid, interpolation_mode);
+  check_grid_sampler_3d(input, grid);
 
   auto N = input.size(0);
   auto D = grid.size(1);
@@ -905,7 +984,7 @@ void launch_grid_sampler_3d_backward_kernel(
     bool align_corners, std::array<bool,2> output_mask) {
   // See NOTE [ grid_sampler Native Functions ].
   // Add checks here in case this is called instead of grid_sampler.
-  check_grid_sampler_3d_backward(input, grid, grad_output, interpolation_mode);
+  check_grid_sampler_3d_backward(input, grid, grad_output);
 
   // See Note [Writing Nondeterministic Operations]
   // Nondeterministic because of atomicAdd usage

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -317,11 +317,16 @@ namespace {
           for (int k = 0; k < 4; ++k) {
             #pragma unroll
             for (int j = 0; j < 4; ++j) {
-              auto row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
+              const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
+              auto row = plane_reads ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
+                                     : inp_ptr_NC;
               const opmath_t weight_zy = z_coeffs[k] * y_coeffs[j];
               #pragma unroll
               for (int i = 0; i < 4; ++i) {
-                value += static_cast<opmath_t>(row[x_taps[i] * inp_sW]) * weight_zy * x_coeffs[i];
+                const opmath_t sample = plane_reads && x_taps[i] >= 0
+                    ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
+                    : static_cast<opmath_t>(0);
+                value += sample * weight_zy * x_coeffs[i];
               }
             }
           }
@@ -800,19 +805,26 @@ namespace {
           for (int k = 0; k < 4; ++k) {
             #pragma unroll
             for (int j = 0; j < 4; ++j) {
-              auto row = inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH;
+              const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
+              auto row = plane_reads ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
+                                     : inp_ptr_NC;
               // the grad_input strides are int64_t whatever index_t is, so the offset is narrowed
               // back to index_t, which is what fastAtomicAdd measures its span in
-              const index_t grad_row = NC_offset + static_cast<index_t>(z_taps[k] * gInp_sD + y_taps[j] * gInp_sH);
+              const index_t grad_row = plane_reads
+                  ? NC_offset + static_cast<index_t>(z_taps[k] * gInp_sD + y_taps[j] * gInp_sH)
+                  : NC_offset;
               #pragma unroll
               for (int i = 0; i < 4; ++i) {
-                if (input_requires_grad) {
+                const bool reads = plane_reads && x_taps[i] >= 0;
+                if (input_requires_grad && reads) {
                   // See Note [Passing pointer and offset to fastAtomicAdd].
                   fastAtomicAdd(grad_input.data, grad_row + static_cast<index_t>(x_taps[i] * gInp_sW),
                                 grad_input_memory_span,
                                 static_cast<scalar_t>(gOut * x_coeffs[i] * y_coeffs[j] * z_coeffs[k]), true);
                 }
-                const opmath_t value = static_cast<opmath_t>(row[x_taps[i] * inp_sW]);
+                const opmath_t value = reads
+                    ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
+                    : static_cast<opmath_t>(0);
                 gix -= value * x_coeffs_grad[i] * y_coeffs[j] * z_coeffs[k] * gOut;
                 giy -= value * x_coeffs[i] * y_coeffs_grad[j] * z_coeffs[k] * gOut;
                 giz -= value * x_coeffs[i] * y_coeffs[j] * z_coeffs_grad[k] * gOut;

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -297,41 +297,91 @@ namespace {
             *out_ptr_NCDHW = static_cast<scalar_t>(0);
           }
         }
-      } else if (interpolation_mode == GridSamplerInterpolation::Bicubic) {
-        // The taps are placed around the unclipped index, so this branch samples at the raw
-        // x, y, z rather than at the clipped ix, iy, iz above.
-        opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
-        index_t x_taps[4], y_taps[4], z_taps[4];
-        resolve_cubic_taps(grid_sampler_unnormalize(x, inp_W, align_corners), inp_W, padding_mode,
-                           align_corners, x_coeffs, static_cast<opmath_t*>(nullptr), x_taps);
-        resolve_cubic_taps(grid_sampler_unnormalize(y, inp_H, align_corners), inp_H, padding_mode,
-                           align_corners, y_coeffs, static_cast<opmath_t*>(nullptr), y_taps);
-        resolve_cubic_taps(grid_sampler_unnormalize(z, inp_D, align_corners), inp_D, padding_mode,
-                           align_corners, z_coeffs, static_cast<opmath_t*>(nullptr), z_taps);
+      }
+    }
+  }
 
-        auto inp_ptr_NC = input.data + n * inp_sN;
-        auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
-        for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
-          opmath_t value = static_cast<opmath_t>(0);
-          #pragma unroll
-          for (int k = 0; k < 4; ++k) {
-            #pragma unroll
-            for (int j = 0; j < 4; ++j) {
-              const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
-              auto row = plane_reads ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
-                                     : inp_ptr_NC;
-              const opmath_t weight_zy = z_coeffs[k] * y_coeffs[j];
-              #pragma unroll
-              for (int i = 0; i < 4; ++i) {
-                const opmath_t sample = plane_reads && x_taps[i] >= 0
-                    ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
-                    : static_cast<opmath_t>(0);
-                value += sample * weight_zy * x_coeffs[i];
-              }
+  // Bicubic gets its own kernel rather than a branch in the one above: the 64 taps need twice
+  // the registers of a trilinear sample, and a shared kernel is allocated for its worst branch,
+  // which would cost bilinear and nearest the occupancy of a mode they never take.
+  template <typename scalar_t, typename index_t>
+  C10_LAUNCH_BOUNDS_1(512)
+  __global__ void grid_sampler_3d_bicubic_kernel(
+      const index_t nthreads,
+      TensorInfo<const scalar_t, index_t> input,
+      TensorInfo<const scalar_t, index_t> grid,
+      TensorInfo<scalar_t, index_t> output,
+      const GridSamplerPadding padding_mode,
+      bool align_corners) {
+
+    using opmath_t = at::opmath_type<scalar_t>;
+    index_t C = input.sizes[1];
+    index_t inp_D = input.sizes[2];
+    index_t inp_H = input.sizes[3];
+    index_t inp_W = input.sizes[4];
+    index_t out_D = grid.sizes[1];
+    index_t out_H = grid.sizes[2];
+    index_t out_W = grid.sizes[3];
+    index_t inp_sN = input.strides[0];
+    index_t inp_sC = input.strides[1];
+    index_t inp_sD = input.strides[2];
+    index_t inp_sH = input.strides[3];
+    index_t inp_sW = input.strides[4];
+    index_t grid_sN = grid.strides[0];
+    index_t grid_sD = grid.strides[1];
+    index_t grid_sH = grid.strides[2];
+    index_t grid_sW = grid.strides[3];
+    index_t grid_sCoor = grid.strides[4];
+    index_t out_sN = output.strides[0];
+    index_t out_sC = output.strides[1];
+    index_t out_sD = output.strides[2];
+    index_t out_sH = output.strides[3];
+    index_t out_sW = output.strides[4];
+
+    CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
+      const index_t w = index % out_W;
+      const index_t h = (index / out_W) % out_H;
+      const index_t d = (index / (out_H * out_W)) % out_D;
+      const index_t n = index / (out_D * out_H * out_W);
+      const index_t grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
+
+      opmath_t x = grid.data[grid_offset];
+      opmath_t y = grid.data[grid_offset + grid_sCoor];
+      opmath_t z = grid.data[grid_offset + 2 * grid_sCoor];
+
+      // The taps are placed around the unclipped index, so this branch samples at the raw
+      // x, y, z rather than at the clipped ix, iy, iz above.
+      opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
+      index_t x_taps[4], y_taps[4], z_taps[4];
+      resolve_cubic_taps(grid_sampler_unnormalize(x, inp_W, align_corners), inp_W, padding_mode,
+                         align_corners, x_coeffs, static_cast<opmath_t*>(nullptr), x_taps);
+      resolve_cubic_taps(grid_sampler_unnormalize(y, inp_H, align_corners), inp_H, padding_mode,
+                         align_corners, y_coeffs, static_cast<opmath_t*>(nullptr), y_taps);
+      resolve_cubic_taps(grid_sampler_unnormalize(z, inp_D, align_corners), inp_D, padding_mode,
+                         align_corners, z_coeffs, static_cast<opmath_t*>(nullptr), z_taps);
+
+      auto inp_ptr_NC = input.data + n * inp_sN;
+      auto out_ptr_NCDHW = output.data + n * out_sN + d * out_sD + h * out_sH + w * out_sW;
+      for (index_t c = 0; c < C; ++c, inp_ptr_NC += inp_sC, out_ptr_NCDHW += out_sC) {
+        opmath_t value = static_cast<opmath_t>(0);
+        #pragma unroll 4
+        for (index_t k = 0; k < 4; ++k) {
+          #pragma unroll 4
+          for (index_t j = 0; j < 4; ++j) {
+            const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
+            auto row = plane_reads ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
+                                   : inp_ptr_NC;
+            const opmath_t weight_zy = z_coeffs[k] * y_coeffs[j];
+            #pragma unroll 4
+            for (index_t i = 0; i < 4; ++i) {
+              const opmath_t sample = plane_reads && x_taps[i] >= 0
+                  ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
+                  : static_cast<opmath_t>(0);
+              value += sample * weight_zy * x_coeffs[i];
             }
           }
-          *out_ptr_NCDHW = static_cast<scalar_t>(value);
         }
+        *out_ptr_NCDHW = static_cast<scalar_t>(value);
       }
     }
   }
@@ -341,6 +391,131 @@ namespace {
 // For its internal bounds checking, fastAtomicAdd needs to know where the destination address
 // lies relative to the entire tensor, so we pass the base grad_input.data and full offset information,
 // including batch * channel offset (NC_offset).
+
+  // Bicubic's own backward kernel, for the reason its forward has one: 64 taps hold twice the
+  // registers of the trilinear sample the shared kernel is otherwise allocated for.
+  template <typename scalar_t, typename index_t>
+  C10_LAUNCH_BOUNDS_1(256)
+  __global__ void grid_sampler_3d_bicubic_backward_kernel(
+      const index_t nthreads,
+      TensorInfo<const scalar_t, index_t> grad_output,
+      TensorInfo<const scalar_t, index_t> input,
+      TensorInfo<const scalar_t, index_t> grid,
+      TensorInfo<scalar_t, index_t> grad_input,  // initialized to zeros (or unused if input_requires_grad is false)
+      TensorInfo<scalar_t, index_t> grad_grid,   // initialized to empty
+      const GridSamplerPadding padding_mode,
+      bool align_corners,
+      const index_t grad_input_memory_span,
+      const bool input_requires_grad) {
+
+    index_t C = input.sizes[1];
+    index_t inp_D = input.sizes[2];
+    index_t inp_H = input.sizes[3];
+    index_t inp_W = input.sizes[4];
+    index_t out_D = grid.sizes[1];
+    index_t out_H = grid.sizes[2];
+    index_t out_W = grid.sizes[3];
+    index_t inp_sN = input.strides[0];
+    index_t inp_sC = input.strides[1];
+    index_t inp_sD = input.strides[2];
+    index_t inp_sH = input.strides[3];
+    index_t inp_sW = input.strides[4];
+    index_t grid_sN = grid.strides[0];
+    index_t grid_sD = grid.strides[1];
+    index_t grid_sH = grid.strides[2];
+    index_t grid_sW = grid.strides[3];
+    index_t grid_sCoor = grid.strides[4];
+    index_t gOut_sN = grad_output.strides[0];
+    index_t gOut_sC = grad_output.strides[1];
+    index_t gOut_sD = grad_output.strides[2];
+    index_t gOut_sH = grad_output.strides[3];
+    index_t gOut_sW = grad_output.strides[4];
+    // gInp_* (and NC_offset below) are not really needed if input_requires_grad is false.
+    int64_t gInp_sN = 0;
+    int64_t gInp_sC = 0;
+    int64_t gInp_sD = 0;
+    int64_t gInp_sH = 0;
+    int64_t gInp_sW = 0;
+    if (input_requires_grad) {
+      gInp_sN = grad_input.strides[0];
+      gInp_sC = grad_input.strides[1];
+      gInp_sD = grad_input.strides[2];
+      gInp_sH = grad_input.strides[3];
+      gInp_sW = grad_input.strides[4];
+    }
+    index_t gGrid_sW = grad_grid.strides[3];
+
+    CUDA_KERNEL_LOOP_TYPE(index, nthreads, index_t) {
+      const index_t w = index % out_W;
+      const index_t h = (index / out_W) % out_H;
+      const index_t d = (index / (out_H * out_W)) % out_D;
+      const index_t n = index / (out_D * out_H * out_W);
+      const auto grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
+
+      scalar_t x = grid.data[grid_offset];
+      scalar_t y = grid.data[grid_offset + grid_sCoor];
+      scalar_t z = grid.data[grid_offset + 2 * grid_sCoor];
+
+      using opmath_t = at::opmath_type<scalar_t>;
+      // The taps are placed around the unclipped index, so the clipping ix, iy, iz went through
+      // above is undone here; their multipliers are the unnormalize ones.
+      opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
+      opmath_t x_coeffs_grad[4], y_coeffs_grad[4], z_coeffs_grad[4];
+      index_t x_taps[4], y_taps[4], z_taps[4];
+      opmath_t x_mult, y_mult, z_mult;
+      resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(x), inp_W, align_corners, &x_mult),
+                         inp_W, padding_mode, align_corners, x_coeffs, x_coeffs_grad, x_taps);
+      resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(y), inp_H, align_corners, &y_mult),
+                         inp_H, padding_mode, align_corners, y_coeffs, y_coeffs_grad, y_taps);
+      resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(z), inp_D, align_corners, &z_mult),
+                         inp_D, padding_mode, align_corners, z_coeffs, z_coeffs_grad, z_taps);
+
+      opmath_t gix = static_cast<opmath_t>(0);
+      opmath_t giy = static_cast<opmath_t>(0);
+      opmath_t giz = static_cast<opmath_t>(0);
+
+      const scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
+      index_t NC_offset = n * gInp_sN;
+      auto inp_ptr_NC = input.data + n * inp_sN;
+      for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, NC_offset += gInp_sC, inp_ptr_NC += inp_sC) {
+        const opmath_t gOut = *gOut_ptr_NCDHW;
+        #pragma unroll 4
+        for (index_t k = 0; k < 4; ++k) {
+          #pragma unroll 4
+          for (index_t j = 0; j < 4; ++j) {
+            const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
+            auto row = plane_reads ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
+                                   : inp_ptr_NC;
+            // the grad_input strides are int64_t whatever index_t is, so the offset is narrowed
+            // back to index_t, which is what fastAtomicAdd measures its span in
+            const index_t grad_row = plane_reads
+                ? NC_offset + static_cast<index_t>(z_taps[k] * gInp_sD + y_taps[j] * gInp_sH)
+                : NC_offset;
+            #pragma unroll 4
+            for (index_t i = 0; i < 4; ++i) {
+              const bool reads = plane_reads && x_taps[i] >= 0;
+              if (input_requires_grad && reads) {
+                // See Note [Passing pointer and offset to fastAtomicAdd].
+                fastAtomicAdd(grad_input.data, grad_row + static_cast<index_t>(x_taps[i] * gInp_sW),
+                              grad_input_memory_span,
+                              static_cast<scalar_t>(gOut * x_coeffs[i] * y_coeffs[j] * z_coeffs[k]), true);
+              }
+              const opmath_t value = reads
+                  ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
+                  : static_cast<opmath_t>(0);
+              gix -= value * x_coeffs_grad[i] * y_coeffs[j] * z_coeffs[k] * gOut;
+              giy -= value * x_coeffs[i] * y_coeffs_grad[j] * z_coeffs[k] * gOut;
+              giz -= value * x_coeffs[i] * y_coeffs[j] * z_coeffs_grad[k] * gOut;
+            }
+          }
+        }
+      }
+      scalar_t *gGrid_ptr_NDHW = grad_grid.data + index * gGrid_sW;
+      gGrid_ptr_NDHW[0] = static_cast<scalar_t>(x_mult * gix);
+      gGrid_ptr_NDHW[1] = static_cast<scalar_t>(y_mult * giy);
+      gGrid_ptr_NDHW[2] = static_cast<scalar_t>(z_mult * giz);
+    }
+  }
 
   template <typename scalar_t, typename index_t>
   C10_LAUNCH_BOUNDS_1(256)
@@ -608,15 +783,15 @@ namespace {
       const auto grid_offset = n * grid_sN + d * grid_sD + h * grid_sH + w * grid_sW;
 
       // get the corresponding input x, y, z coordinates from grid
-      scalar_t x = grid.data[grid_offset];
-      scalar_t y = grid.data[grid_offset + grid_sCoor];
-      scalar_t z = grid.data[grid_offset + 2 * grid_sCoor];
+      scalar_t ix = grid.data[grid_offset];
+      scalar_t iy = grid.data[grid_offset + grid_sCoor];
+      scalar_t iz = grid.data[grid_offset + 2 * grid_sCoor];
 
       // multipliers for gradients on ix, iy, and iz
       scalar_t gix_mult, giy_mult, giz_mult;
-      scalar_t ix = grid_sampler_compute_source_index_set_grad(x, inp_W, padding_mode, align_corners, &gix_mult);
-      scalar_t iy = grid_sampler_compute_source_index_set_grad(y, inp_H, padding_mode, align_corners, &giy_mult);
-      scalar_t iz = grid_sampler_compute_source_index_set_grad(z, inp_D, padding_mode, align_corners, &giz_mult);
+      ix = grid_sampler_compute_source_index_set_grad(ix, inp_W, padding_mode, align_corners, &gix_mult);
+      iy = grid_sampler_compute_source_index_set_grad(iy, inp_H, padding_mode, align_corners, &giy_mult);
+      iz = grid_sampler_compute_source_index_set_grad(iz, inp_D, padding_mode, align_corners, &giz_mult);
 
       if (interpolation_mode == GridSamplerInterpolation::Bilinear) {
         // get corner pixel values from (x, y, z)
@@ -777,65 +952,6 @@ namespace {
         gGrid_ptr_NDHW[0] = static_cast<scalar_t>(0);
         gGrid_ptr_NDHW[1] = static_cast<scalar_t>(0);
         gGrid_ptr_NDHW[2] = static_cast<scalar_t>(0);
-      } else if (interpolation_mode == GridSamplerInterpolation::Bicubic) {
-        using opmath_t = at::opmath_type<scalar_t>;
-        // The taps are placed around the unclipped index, so the clipping ix, iy, iz went through
-        // above is undone here; their multipliers are the unnormalize ones.
-        opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
-        opmath_t x_coeffs_grad[4], y_coeffs_grad[4], z_coeffs_grad[4];
-        index_t x_taps[4], y_taps[4], z_taps[4];
-        opmath_t x_mult, y_mult, z_mult;
-        resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(x), inp_W, align_corners, &x_mult),
-                           inp_W, padding_mode, align_corners, x_coeffs, x_coeffs_grad, x_taps);
-        resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(y), inp_H, align_corners, &y_mult),
-                           inp_H, padding_mode, align_corners, y_coeffs, y_coeffs_grad, y_taps);
-        resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(z), inp_D, align_corners, &z_mult),
-                           inp_D, padding_mode, align_corners, z_coeffs, z_coeffs_grad, z_taps);
-
-        opmath_t gix = static_cast<opmath_t>(0);
-        opmath_t giy = static_cast<opmath_t>(0);
-        opmath_t giz = static_cast<opmath_t>(0);
-
-        const scalar_t *gOut_ptr_NCDHW = grad_output.data + n * gOut_sN + d * gOut_sD + h * gOut_sH + w * gOut_sW;
-        index_t NC_offset = n * gInp_sN;
-        auto inp_ptr_NC = input.data + n * inp_sN;
-        for (index_t c = 0; c < C; ++c, gOut_ptr_NCDHW += gOut_sC, NC_offset += gInp_sC, inp_ptr_NC += inp_sC) {
-          const opmath_t gOut = *gOut_ptr_NCDHW;
-          #pragma unroll
-          for (int k = 0; k < 4; ++k) {
-            #pragma unroll
-            for (int j = 0; j < 4; ++j) {
-              const bool plane_reads = z_taps[k] >= 0 && y_taps[j] >= 0;
-              auto row = plane_reads ? inp_ptr_NC + z_taps[k] * inp_sD + y_taps[j] * inp_sH
-                                     : inp_ptr_NC;
-              // the grad_input strides are int64_t whatever index_t is, so the offset is narrowed
-              // back to index_t, which is what fastAtomicAdd measures its span in
-              const index_t grad_row = plane_reads
-                  ? NC_offset + static_cast<index_t>(z_taps[k] * gInp_sD + y_taps[j] * gInp_sH)
-                  : NC_offset;
-              #pragma unroll
-              for (int i = 0; i < 4; ++i) {
-                const bool reads = plane_reads && x_taps[i] >= 0;
-                if (input_requires_grad && reads) {
-                  // See Note [Passing pointer and offset to fastAtomicAdd].
-                  fastAtomicAdd(grad_input.data, grad_row + static_cast<index_t>(x_taps[i] * gInp_sW),
-                                grad_input_memory_span,
-                                static_cast<scalar_t>(gOut * x_coeffs[i] * y_coeffs[j] * z_coeffs[k]), true);
-                }
-                const opmath_t value = reads
-                    ? static_cast<opmath_t>(row[x_taps[i] * inp_sW])
-                    : static_cast<opmath_t>(0);
-                gix -= value * x_coeffs_grad[i] * y_coeffs[j] * z_coeffs[k] * gOut;
-                giy -= value * x_coeffs[i] * y_coeffs_grad[j] * z_coeffs[k] * gOut;
-                giz -= value * x_coeffs[i] * y_coeffs[j] * z_coeffs_grad[k] * gOut;
-              }
-            }
-          }
-        }
-        scalar_t *gGrid_ptr_NDHW = grad_grid.data + index * gGrid_sW;
-        gGrid_ptr_NDHW[0] = static_cast<scalar_t>(x_mult * gix);
-        gGrid_ptr_NDHW[1] = static_cast<scalar_t>(y_mult * giy);
-        gGrid_ptr_NDHW[2] = static_cast<scalar_t>(z_mult * giz);
       }
     }
   }
@@ -899,31 +1015,55 @@ void launch_grid_sampler_3d_forward_kernel(
   auto W = grid.size(3);
   int64_t count = N * D * H * W;
   if (count > 0) {
+    const bool bicubic = static_cast<GridSamplerInterpolation>(interpolation_mode) ==
+        GridSamplerInterpolation::Bicubic;
     AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half, ScalarType::BFloat16,
       input.scalar_type(), "grid_sampler_3d_cuda", [&] {
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(output)) {
-        grid_sampler_3d_kernel<scalar_t>
-          <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
-            static_cast<int>(count),
-            getTensorInfo<const scalar_t, int>(input),
-            getTensorInfo<const scalar_t, int>(grid),
-            getTensorInfo<scalar_t, int>(output),
-            static_cast<GridSamplerInterpolation>(interpolation_mode),
-            static_cast<GridSamplerPadding>(padding_mode),
-            align_corners);
+        if (bicubic) {
+          grid_sampler_3d_bicubic_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
+              static_cast<int>(count),
+              getTensorInfo<const scalar_t, int>(input),
+              getTensorInfo<const scalar_t, int>(grid),
+              getTensorInfo<scalar_t, int>(output),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners);
+        } else {
+          grid_sampler_3d_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
+              static_cast<int>(count),
+              getTensorInfo<const scalar_t, int>(input),
+              getTensorInfo<const scalar_t, int>(grid),
+              getTensorInfo<scalar_t, int>(output),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners);
+        }
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
-        grid_sampler_3d_kernel<scalar_t>
-          <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
-            count,
-            getTensorInfo<const scalar_t, int64_t>(input),
-            getTensorInfo<const scalar_t, int64_t>(grid),
-            getTensorInfo<scalar_t, int64_t>(output),
-            static_cast<GridSamplerInterpolation>(interpolation_mode),
-            static_cast<GridSamplerPadding>(padding_mode),
-            align_corners);
+        if (bicubic) {
+          grid_sampler_3d_bicubic_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+              getTensorInfo<const scalar_t, int64_t>(input),
+              getTensorInfo<const scalar_t, int64_t>(grid),
+              getTensorInfo<scalar_t, int64_t>(output),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners);
+        } else {
+          grid_sampler_3d_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 512), 512, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+              getTensorInfo<const scalar_t, int64_t>(input),
+              getTensorInfo<const scalar_t, int64_t>(grid),
+              getTensorInfo<scalar_t, int64_t>(output),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners);
+        }
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });
@@ -1010,40 +1150,72 @@ void launch_grid_sampler_3d_backward_kernel(
   auto W = grid.size(3);
   int64_t count = N * D * H * W;
   auto input_requires_grad = output_mask[0];
+  const bool bicubic = static_cast<GridSamplerInterpolation>(interpolation_mode) ==
+      GridSamplerInterpolation::Bicubic;
   if (count > 0) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
       ScalarType::Half, ScalarType::BFloat16,
       input.scalar_type(), "grid_sampler_3d_backward_cuda", [&] {
       if (canUse32BitIndexMath(input) && canUse32BitIndexMath(grid) &&
           canUse32BitIndexMath(grad_output)) {
-        grid_sampler_3d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
-            static_cast<int>(count),
-            getTensorInfo<const scalar_t, int>(grad_output),
-            getTensorInfo<const scalar_t, int>(input),
-            getTensorInfo<const scalar_t, int>(grid),
-            input_requires_grad ? getTensorInfo<scalar_t, int>(grad_input) : TensorInfo<scalar_t, int>(),
-            getTensorInfo<scalar_t, int>(grad_grid),
-            static_cast<GridSamplerInterpolation>(interpolation_mode),
-            static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/input_requires_grad ? static_cast<int>(grad_input.numel()) : 0,
-            input_requires_grad);
+        if (bicubic) {
+          grid_sampler_3d_bicubic_backward_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              static_cast<int>(count),
+              getTensorInfo<const scalar_t, int>(grad_output),
+              getTensorInfo<const scalar_t, int>(input),
+              getTensorInfo<const scalar_t, int>(grid),
+              input_requires_grad ? getTensorInfo<scalar_t, int>(grad_input) : TensorInfo<scalar_t, int>(),
+              getTensorInfo<scalar_t, int>(grad_grid),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/input_requires_grad ? static_cast<int>(grad_input.numel()) : 0,
+              input_requires_grad);
+        } else {
+          grid_sampler_3d_backward_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              static_cast<int>(count),
+              getTensorInfo<const scalar_t, int>(grad_output),
+              getTensorInfo<const scalar_t, int>(input),
+              getTensorInfo<const scalar_t, int>(grid),
+              input_requires_grad ? getTensorInfo<scalar_t, int>(grad_input) : TensorInfo<scalar_t, int>(),
+              getTensorInfo<scalar_t, int>(grad_grid),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/input_requires_grad ? static_cast<int>(grad_input.numel()) : 0,
+              input_requires_grad);
+        }
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       } else {
-        grid_sampler_3d_backward_kernel<scalar_t>
-          <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
-            count,
-            getTensorInfo<const scalar_t, int64_t>(grad_output),
-            getTensorInfo<const scalar_t, int64_t>(input),
-            getTensorInfo<const scalar_t, int64_t>(grid),
-            input_requires_grad ? getTensorInfo<scalar_t, int64_t>(grad_input) : TensorInfo<scalar_t, int64_t>(),
-            getTensorInfo<scalar_t, int64_t>(grad_grid),
-            static_cast<GridSamplerInterpolation>(interpolation_mode),
-            static_cast<GridSamplerPadding>(padding_mode),
-            align_corners,
-            /*grad_input_memory_span =*/input_requires_grad ? grad_input.numel() : 0,
-            input_requires_grad);
+        if (bicubic) {
+          grid_sampler_3d_bicubic_backward_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+              getTensorInfo<const scalar_t, int64_t>(grad_output),
+              getTensorInfo<const scalar_t, int64_t>(input),
+              getTensorInfo<const scalar_t, int64_t>(grid),
+              input_requires_grad ? getTensorInfo<scalar_t, int64_t>(grad_input) : TensorInfo<scalar_t, int64_t>(),
+              getTensorInfo<scalar_t, int64_t>(grad_grid),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/input_requires_grad ? grad_input.numel() : 0,
+              input_requires_grad);
+        } else {
+          grid_sampler_3d_backward_kernel<scalar_t>
+            <<<GET_BLOCKS(count, 256), 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+              count,
+              getTensorInfo<const scalar_t, int64_t>(grad_output),
+              getTensorInfo<const scalar_t, int64_t>(input),
+              getTensorInfo<const scalar_t, int64_t>(grid),
+              input_requires_grad ? getTensorInfo<scalar_t, int64_t>(grad_input) : TensorInfo<scalar_t, int64_t>(),
+              getTensorInfo<scalar_t, int64_t>(grad_grid),
+              static_cast<GridSamplerInterpolation>(interpolation_mode),
+              static_cast<GridSamplerPadding>(padding_mode),
+              align_corners,
+              /*grad_input_memory_span =*/input_requires_grad ? grad_input.numel() : 0,
+              input_requires_grad);
+        }
         C10_CUDA_KERNEL_LAUNCH_CHECK();
       }
     });

--- a/aten/src/ATen/native/cuda/GridSampler.cu
+++ b/aten/src/ATen/native/cuda/GridSampler.cu
@@ -353,11 +353,11 @@ namespace {
       // x, y, z rather than at the clipped ix, iy, iz above.
       opmath_t x_coeffs[4], y_coeffs[4], z_coeffs[4];
       index_t x_taps[4], y_taps[4], z_taps[4];
-      resolve_cubic_taps(grid_sampler_unnormalize(x, inp_W, align_corners), inp_W, padding_mode,
+      resolve_cubic_taps(grid_sampler_unnormalize_sized(x, inp_W, align_corners), inp_W, padding_mode,
                          align_corners, x_coeffs, static_cast<opmath_t*>(nullptr), x_taps);
-      resolve_cubic_taps(grid_sampler_unnormalize(y, inp_H, align_corners), inp_H, padding_mode,
+      resolve_cubic_taps(grid_sampler_unnormalize_sized(y, inp_H, align_corners), inp_H, padding_mode,
                          align_corners, y_coeffs, static_cast<opmath_t*>(nullptr), y_taps);
-      resolve_cubic_taps(grid_sampler_unnormalize(z, inp_D, align_corners), inp_D, padding_mode,
+      resolve_cubic_taps(grid_sampler_unnormalize_sized(z, inp_D, align_corners), inp_D, padding_mode,
                          align_corners, z_coeffs, static_cast<opmath_t*>(nullptr), z_taps);
 
       auto inp_ptr_NC = input.data + n * inp_sN;
@@ -463,11 +463,11 @@ namespace {
       opmath_t x_coeffs_grad[4], y_coeffs_grad[4], z_coeffs_grad[4];
       index_t x_taps[4], y_taps[4], z_taps[4];
       opmath_t x_mult, y_mult, z_mult;
-      resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(x), inp_W, align_corners, &x_mult),
+      resolve_cubic_taps(grid_sampler_unnormalize_set_grad_sized(static_cast<opmath_t>(x), inp_W, align_corners, &x_mult),
                          inp_W, padding_mode, align_corners, x_coeffs, x_coeffs_grad, x_taps);
-      resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(y), inp_H, align_corners, &y_mult),
+      resolve_cubic_taps(grid_sampler_unnormalize_set_grad_sized(static_cast<opmath_t>(y), inp_H, align_corners, &y_mult),
                          inp_H, padding_mode, align_corners, y_coeffs, y_coeffs_grad, y_taps);
-      resolve_cubic_taps(grid_sampler_unnormalize_set_grad(static_cast<opmath_t>(z), inp_D, align_corners, &z_mult),
+      resolve_cubic_taps(grid_sampler_unnormalize_set_grad_sized(static_cast<opmath_t>(z), inp_D, align_corners, &z_mult),
                          inp_D, padding_mode, align_corners, z_coeffs, z_coeffs_grad, z_taps);
 
       opmath_t gix = static_cast<opmath_t>(0);

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -335,11 +335,12 @@ void resolve_cubic_taps(
   if (coeffs_grad != nullptr) {
     get_cubic_coefficients_grad<scalar_t>(coeffs_grad, coord - base);
   }
-  #pragma unroll
+  #pragma unroll 4
   for (int i = 0; i < 4; ++i) {
-    const scalar_t tap = compute_coordinates(base - 1 + i, static_cast<int>(size), padding_mode, align_corners);
-    // the comparison decides, not the cast: a coordinate that is not finite fails both sides,
-    // where converting it to an integer is undefined
+    // the comparison decides, not the cast: a coordinate that is not
+    // finite fails both sides, where converting it is undefined
+    const scalar_t tap = compute_coordinates(
+        base - 1 + i, static_cast<int>(size), padding_mode, align_corners);
     indices[i] = (tap >= 0 && tap < static_cast<scalar_t>(size))
         ? static_cast<index_t>(tap)
         : static_cast<index_t>(-1);

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -338,16 +338,11 @@ void resolve_cubic_taps(
   #pragma unroll
   for (int i = 0; i < 4; ++i) {
     const scalar_t tap = compute_coordinates(base - 1 + i, static_cast<int>(size), padding_mode, align_corners);
-    const index_t index = static_cast<index_t>(tap);
-    if (index >= 0 && index < size) {
-      indices[i] = index;
-    } else {
-      coeffs[i] = static_cast<scalar_t>(0);
-      if (coeffs_grad != nullptr) {
-        coeffs_grad[i] = static_cast<scalar_t>(0);
-      }
-      indices[i] = static_cast<index_t>(0);
-    }
+    // the comparison decides, not the cast: a coordinate that is not finite fails both sides,
+    // where converting it to an integer is undefined
+    indices[i] = (tap >= 0 && tap < static_cast<scalar_t>(size))
+        ? static_cast<index_t>(tap)
+        : static_cast<index_t>(-1);
   }
 }
 

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -1,5 +1,6 @@
 #pragma once
 #include <ATen/native/cuda/KernelUtils.cuh>
+#include <ATen/native/cuda/UpSample.cuh>
 #include <ATen/native/GridSamplerUtils.h>
 
 namespace at::native {
@@ -317,5 +318,37 @@ void get_cubic_coefficients_grad(
   coeffs[3] = (3 * A * x - 10 * A) * x + 8 * A;
 }
 
+
+// The device twin of resolve_cubic_taps in ATen/native/GridSampler.cpp.
+template<typename scalar_t, typename index_t>
+__forceinline__ __device__
+void resolve_cubic_taps(
+    scalar_t coord,
+    index_t size,
+    GridSamplerPadding padding_mode,
+    bool align_corners,
+    scalar_t coeffs[4],
+    scalar_t* coeffs_grad,
+    index_t indices[4]) {
+  const scalar_t base = ::floor(coord);
+  get_cubic_upsampling_coefficients<scalar_t>(coeffs, coord - base);
+  if (coeffs_grad != nullptr) {
+    get_cubic_coefficients_grad<scalar_t>(coeffs_grad, coord - base);
+  }
+  #pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    const scalar_t tap = compute_coordinates(base - 1 + i, static_cast<int>(size), padding_mode, align_corners);
+    const index_t index = static_cast<index_t>(tap);
+    if (index >= 0 && index < size) {
+      indices[i] = index;
+    } else {
+      coeffs[i] = static_cast<scalar_t>(0);
+      if (coeffs_grad != nullptr) {
+        coeffs_grad[i] = static_cast<scalar_t>(0);
+      }
+      indices[i] = static_cast<index_t>(0);
+    }
+  }
+}
 
 }  // namespace at::native

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -319,18 +319,17 @@ void get_cubic_coefficients_grad(
 }
 
 
-// grid_sampler_unnormalize with the extent kept in index_t, for the kernels
-// that index with int64_t; bit-identical to the int-taking one for every
-// extent an int can carry.
+// grid_sampler_unnormalize with the extent in index_t, for the kernels that
+// index with int64_t. It converts where the int-taking helper converts, so the
+// two agree for any extent. Separate copies keep the shared kernels unchanged.
 template <typename scalar_t, typename index_t>
 __forceinline__ __device__
 scalar_t grid_sampler_unnormalize_sized(scalar_t coord, index_t size,
                                         bool align_corners) {
-  const scalar_t extent = static_cast<scalar_t>(size);
   if (align_corners) {
-    return ((coord + 1) / 2) * (extent - 1);
+    return ((coord + 1) / 2) * static_cast<scalar_t>(size - 1);
   } else {
-    return ((coord + 1) * extent - 1) / 2;
+    return ((coord + 1) * static_cast<scalar_t>(size) - 1) / 2;
   }
 }
 
@@ -339,23 +338,19 @@ __forceinline__ __device__
 scalar_t grid_sampler_unnormalize_set_grad_sized(scalar_t coord, index_t size,
                                                  bool align_corners,
                                                  scalar_t* grad_in) {
-  const scalar_t extent = static_cast<scalar_t>(size);
   if (align_corners) {
-    *grad_in = (extent - 1) / 2;
-    return ((coord + 1) / 2) * (extent - 1);
+    *grad_in = static_cast<scalar_t>(size - 1) / 2;
+    return ((coord + 1) / 2) * static_cast<scalar_t>(size - 1);
   } else {
-    *grad_in = extent / 2;
-    return ((coord + 1) * extent - 1) / 2;
+    *grad_in = static_cast<scalar_t>(size) / 2;
+    return ((coord + 1) * static_cast<scalar_t>(size) - 1) / 2;
   }
 }
 
-// compute_coordinates with the extent kept in index_t: the tricubic kernels
-// index with index_t, and narrowing the extent to int before the padding would
-// fold a dimension past INT_MAX onto the wrong voxel. The reflection parity is
-// taken with fmod so no float ever converts to an integer type, and no
-// downgrade clips a valid position past INT_MAX: the caller's comparison gate
-// decides before any cast. For every extent an int can carry the arithmetic
-// matches compute_coordinates exactly.
+// compute_coordinates with the extent in index_t: narrowing it to int would
+// fold a dimension past INT_MAX onto the wrong voxel. It forms the same bounds,
+// but takes the reflection parity with fmod and skips the downgrade, so no float
+// converts to an integer and no valid position past INT_MAX is clipped.
 template <typename scalar_t, typename index_t>
 __forceinline__ __device__
 scalar_t compute_coordinates_sized(scalar_t coord, index_t size,
@@ -365,15 +360,14 @@ scalar_t compute_coordinates_sized(scalar_t coord, index_t size,
     coord = ::min(static_cast<scalar_t>(size - 1),
                   ::max(coord, static_cast<scalar_t>(0)));
   } else if (padding_mode == GridSamplerPadding::Reflection) {
-    const scalar_t twice_low = align_corners ? 0 : -1;
-    const scalar_t twice_high =
-        static_cast<scalar_t>(2) * static_cast<scalar_t>(size) -
-        (align_corners ? 2 : 1);
-    if (twice_low == twice_high) {
+    // reflect_coordinates halves the difference of two integer bounds. Halving
+    // what it doubles reaches them with one exact conversion of the extent.
+    const scalar_t low =
+        align_corners ? static_cast<scalar_t>(0) : static_cast<scalar_t>(-0.5);
+    const scalar_t span = static_cast<scalar_t>(align_corners ? size - 1 : size);
+    if (span == 0) {
       coord = 0;
     } else {
-      const scalar_t low = twice_low / 2;
-      const scalar_t span = (twice_high - twice_low) / 2;
       const scalar_t in = ::fabs(coord - low);
       const scalar_t extra = ::fmod(in, span);
       const bool odd = ::fmod(::floor(in / span), static_cast<scalar_t>(2)) != 0;

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -319,11 +319,43 @@ void get_cubic_coefficients_grad(
 }
 
 
+// grid_sampler_unnormalize with the extent kept in index_t, for the kernels
+// that index with int64_t; bit-identical to the int-taking one for every
+// extent an int can carry.
+template <typename scalar_t, typename index_t>
+__forceinline__ __device__
+scalar_t grid_sampler_unnormalize_sized(scalar_t coord, index_t size,
+                                        bool align_corners) {
+  const scalar_t extent = static_cast<scalar_t>(size);
+  if (align_corners) {
+    return ((coord + 1) / 2) * (extent - 1);
+  } else {
+    return ((coord + 1) * extent - 1) / 2;
+  }
+}
+
+template <typename scalar_t, typename index_t>
+__forceinline__ __device__
+scalar_t grid_sampler_unnormalize_set_grad_sized(scalar_t coord, index_t size,
+                                                 bool align_corners,
+                                                 scalar_t* grad_in) {
+  const scalar_t extent = static_cast<scalar_t>(size);
+  if (align_corners) {
+    *grad_in = (extent - 1) / 2;
+    return ((coord + 1) / 2) * (extent - 1);
+  } else {
+    *grad_in = extent / 2;
+    return ((coord + 1) * extent - 1) / 2;
+  }
+}
+
 // compute_coordinates with the extent kept in index_t: the tricubic kernels
 // index with index_t, and narrowing the extent to int before the padding would
 // fold a dimension past INT_MAX onto the wrong voxel. The reflection parity is
-// taken with fmod so no float ever converts to an integer type; for every
-// extent an int can carry the arithmetic matches compute_coordinates exactly.
+// taken with fmod so no float ever converts to an integer type, and no
+// downgrade clips a valid position past INT_MAX: the caller's comparison gate
+// decides before any cast. For every extent an int can carry the arithmetic
+// matches compute_coordinates exactly.
 template <typename scalar_t, typename index_t>
 __forceinline__ __device__
 scalar_t compute_coordinates_sized(scalar_t coord, index_t size,
@@ -350,7 +382,6 @@ scalar_t compute_coordinates_sized(scalar_t coord, index_t size,
     coord = ::min(static_cast<scalar_t>(size - 1),
                   ::max(coord, static_cast<scalar_t>(0)));
   }
-  coord = safe_downgrade_to_int_range(coord);
   return coord;
 }
 

--- a/aten/src/ATen/native/cuda/GridSampler.cuh
+++ b/aten/src/ATen/native/cuda/GridSampler.cuh
@@ -319,6 +319,41 @@ void get_cubic_coefficients_grad(
 }
 
 
+// compute_coordinates with the extent kept in index_t: the tricubic kernels
+// index with index_t, and narrowing the extent to int before the padding would
+// fold a dimension past INT_MAX onto the wrong voxel. The reflection parity is
+// taken with fmod so no float ever converts to an integer type; for every
+// extent an int can carry the arithmetic matches compute_coordinates exactly.
+template <typename scalar_t, typename index_t>
+__forceinline__ __device__
+scalar_t compute_coordinates_sized(scalar_t coord, index_t size,
+                                   GridSamplerPadding padding_mode,
+                                   bool align_corners) {
+  if (padding_mode == GridSamplerPadding::Border) {
+    coord = ::min(static_cast<scalar_t>(size - 1),
+                  ::max(coord, static_cast<scalar_t>(0)));
+  } else if (padding_mode == GridSamplerPadding::Reflection) {
+    const scalar_t twice_low = align_corners ? 0 : -1;
+    const scalar_t twice_high =
+        static_cast<scalar_t>(2) * static_cast<scalar_t>(size) -
+        (align_corners ? 2 : 1);
+    if (twice_low == twice_high) {
+      coord = 0;
+    } else {
+      const scalar_t low = twice_low / 2;
+      const scalar_t span = (twice_high - twice_low) / 2;
+      const scalar_t in = ::fabs(coord - low);
+      const scalar_t extra = ::fmod(in, span);
+      const bool odd = ::fmod(::floor(in / span), static_cast<scalar_t>(2)) != 0;
+      coord = odd ? span - extra + low : extra + low;
+    }
+    coord = ::min(static_cast<scalar_t>(size - 1),
+                  ::max(coord, static_cast<scalar_t>(0)));
+  }
+  coord = safe_downgrade_to_int_range(coord);
+  return coord;
+}
+
 // The device twin of resolve_cubic_taps in ATen/native/GridSampler.cpp.
 template<typename scalar_t, typename index_t>
 __forceinline__ __device__
@@ -339,8 +374,8 @@ void resolve_cubic_taps(
   for (int i = 0; i < 4; ++i) {
     // the comparison decides, not the cast: a coordinate that is not
     // finite fails both sides, where converting it is undefined
-    const scalar_t tap = compute_coordinates(
-        base - 1 + i, static_cast<int>(size), padding_mode, align_corners);
+    const scalar_t tap = compute_coordinates_sized(
+        base - 1 + i, size, padding_mode, align_corners);
     indices[i] = (tap >= 0 && tap < static_cast<scalar_t>(size))
         ? static_cast<index_t>(tap)
         : static_cast<index_t>(-1);

--- a/aten/src/ATen/native/mps/operations/GridSampler.mm
+++ b/aten/src/ATen/native/mps/operations/GridSampler.mm
@@ -130,7 +130,7 @@ static void grid_sampler_3d_mps_impl(Tensor& output,
       check_grid_sampler_2d(input, grid);
       break;
     case 3:
-      check_grid_sampler_3d(input, grid, _interpolation_mode);
+      check_grid_sampler_3d(input, grid);
       break;
     default:
       TORCH_INTERNAL_ASSERT(false, "Only 2D and 3D sampling are supported, but got: ", sampler_dims);
@@ -339,7 +339,7 @@ std::tuple<Tensor, Tensor> grid_sampler_3d_backward_mps(const Tensor& grad_outpu
   // Nondeterministic due to atomic_add
   at::globalContext().alertNotDeterministic("grid_sampler_3d_backward_mps");
 
-  check_grid_sampler_3d_backward(input, grid, grad_output, interpolation_mode);
+  check_grid_sampler_3d_backward(input, grid, grad_output);
 
   TORCH_CHECK_NOT_IMPLEMENTED(interpolation_mode == 0 || interpolation_mode == 1,
                               "grid_sampler_3d backward on MPS only supports bilinear and nearest interpolation");

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4339,6 +4339,12 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, "expected input to have non-empty spatial dimensions"):
             F.grid_sample(torch.empty(1, 1, 0, 2), grid, align_corners=False)
 
+        if torch.backends.mps.is_available():
+            # a backend whose 5-D sampler implements bilinear and nearest only refuses bicubic
+            with self.assertRaisesRegex(RuntimeError, "bicubic interpolation with 5D input"):
+                F.grid_sample(torch.empty(1, 1, 2, 2, 2, device='mps'),
+                              torch.empty(1, 1, 1, 1, 3, device='mps'), mode='bicubic')
+
         if TEST_CUDA:
             with self.assertRaisesRegex(RuntimeError, "Expected all tensors to be on the same device"):
                 F.grid_sample(input.cuda(), grid, align_corners=False)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11020,7 +11020,9 @@ class TestNNDeviceType(NNTestCase):
             sum(i * s for i, s in zip(large_view.size(), large_view.stride())) >= 2 ** 31,
             msg="View must use 64-bit indexing")
         for mode, padding_mode, align_corners in itertools.product(
-                ('nearest', 'bilinear'), ('zeros', 'border', 'reflection'), (True, False)):
+                ('nearest', 'bilinear', 'bicubic'), ('zeros', 'border', 'reflection'), (True, False)):
+            if mode == 'bicubic' and torch.device(device).type == 'mps':
+                continue  # MPS has no 5-D bicubic sampler
             a = F.grid_sample(
                 small_image, coords, mode=mode,
                 padding_mode=padding_mode, align_corners=align_corners)
@@ -11041,8 +11043,6 @@ class TestNNDeviceType(NNTestCase):
     def test_grid_sample_half_precision(self):
         def helper(shape_in, shape_out, align_corners):
             for mode in ('bilinear', 'nearest', 'bicubic'):
-                if len(shape_in) != 4 and mode == 'bicubic':
-                    continue
                 data = torch.randn(shape_in, device='cuda', dtype=torch.half)
                 grid = torch.rand(shape_out, device='cuda', dtype=torch.half) * 2.0 - 1.0
 
@@ -11061,8 +11061,6 @@ class TestNNDeviceType(NNTestCase):
     def test_grid_sample_bfloat16_precision(self):
         def helper(shape_in, shape_out, align_corners):
             for mode in ('bilinear', 'nearest', 'bicubic'):
-                if len(shape_in) != 4 and mode == 'bicubic':
-                    continue
                 data = torch.randn(shape_in, device='cuda', dtype=torch.bfloat16)
                 grid = torch.rand(shape_out, device='cuda', dtype=torch.bfloat16) * 2.0 - 1.0
 
@@ -11884,6 +11882,23 @@ class TestNNDeviceType(NNTestCase):
         # stages in the scalar type, so single precision needs a tolerance
         tolerance = {} if dtype == torch.double else {"atol": 1e-4, "rtol": 1e-4}
         self.assertEqual(out_3d.squeeze(2), out_2d, **tolerance)
+
+    @parametrize_test("wrt", ["input", "grid"])
+    @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64
+    @onlyNativeDeviceTypes
+    @dtypes(torch.double)
+    def test_grid_sample_3d_bicubic_one_sided_grad(self, device, dtype, wrt):
+        # The double backward builds the tap gather and the coefficient derivatives only for
+        # the outputs asked of it, and the OpInfo samples ask for both at once.
+        volume = torch.randn(1, 2, 4, 5, 5, device=device, dtype=dtype)
+        grid = torch.rand(1, 2, 3, 3, 3, device=device, dtype=dtype) * 2 - 1
+
+        def fn(t):
+            args = (t, grid) if wrt == "input" else (volume, t)
+            return F.grid_sample(*args, mode='bicubic', padding_mode='border', align_corners=False)
+
+        wrt_tensor = (volume if wrt == "input" else grid).clone().requires_grad_(True)
+        self.assertTrue(gradgradcheck(fn, (wrt_tensor,)))
 
     @parametrize_test("padding_mode", ["zeros", "border", "reflection"])
     @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11021,8 +11021,11 @@ class TestNNDeviceType(NNTestCase):
             msg="View must use 64-bit indexing")
         for mode, padding_mode, align_corners in itertools.product(
                 ('nearest', 'bilinear', 'bicubic'), ('zeros', 'border', 'reflection'), (True, False)):
-            if mode == 'bicubic' and torch.device(device).type == 'mps':
-                continue  # MPS has no 5-D bicubic sampler
+            # Neither MPS nor XPU has a 5-D bicubic sampler. XPU never reaches this today,
+            # since instantiate_device_type_tests below passes allow_xpu=False, and its eager
+            # refusal cannot be tested in tree at all: the kernel lives in torch-xpu-ops.
+            if mode == 'bicubic' and torch.device(device).type in ('mps', 'xpu'):
+                continue
             a = F.grid_sample(
                 small_image, coords, mode=mode,
                 padding_mode=padding_mode, align_corners=align_corners)
@@ -11883,22 +11886,25 @@ class TestNNDeviceType(NNTestCase):
         tolerance = {} if dtype == torch.double else {"atol": 1e-4, "rtol": 1e-4}
         self.assertEqual(out_3d.squeeze(2), out_2d, **tolerance)
 
+    @parametrize_test("padding_mode", ["zeros", "border", "reflection"])
     @parametrize_test("wrt", ["input", "grid"])
     @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64
     @onlyNativeDeviceTypes
     @dtypes(torch.double)
-    def test_grid_sample_3d_bicubic_one_sided_grad(self, device, dtype, wrt):
+    def test_grid_sample_3d_bicubic_one_sided_grad(self, device, dtype, wrt, padding_mode):
         # The double backward builds the tap gather and the coefficient derivatives only for
         # the outputs asked of it, and the OpInfo samples ask for both at once.
         volume = torch.randn(1, 2, 4, 5, 5, device=device, dtype=dtype)
-        grid = torch.rand(1, 2, 3, 3, 3, device=device, dtype=dtype) * 2 - 1
+        # far enough inside that every tap stays in bounds: under zeros padding a tap the
+        # rim drops takes the value away with it, a step gradcheck cannot difference through
+        grid = torch.rand(1, 2, 3, 3, 3, device=device, dtype=dtype) * 0.5 - 0.25
 
         def fn(t):
             args = (t, grid) if wrt == "input" else (volume, t)
-            return F.grid_sample(*args, mode='bicubic', padding_mode='border', align_corners=False)
+            return F.grid_sample(*args, mode='bicubic', padding_mode=padding_mode, align_corners=False)
 
         wrt_tensor = (volume if wrt == "input" else grid).clone().requires_grad_(True)
-        self.assertTrue(gradgradcheck(fn, (wrt_tensor,)))
+        gradgradcheck(fn, (wrt_tensor,))
 
     @parametrize_test("padding_mode", ["zeros", "border", "reflection"])
     @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -35,7 +35,7 @@ from torch.nn import Buffer, Parameter
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_math_dtypes, floating_types
 from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, run_tests, TestCase, \
-    skipIfNoLapack, skipIfRocm, skipIfRocmVersionLessThan, getRocmVersion, TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, TEST_MULTIACCELERATOR, \
+    skipIfNoLapack, skipIfRocm, skipIfRocmVersionLessThan, getRocmVersion, TEST_MPS, TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, TEST_MULTIACCELERATOR, \
     download_file, get_function_arglist, load_tests, skipIfMPS, MACOS_VERSION, \
     IS_PPC, IS_ARM64, IS_MACOS, IS_WINDOWS, IS_CPU_CAPABILITY_SVE, IS_CPU_EXT_SVE_SUPPORTED, xfailIf, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
@@ -4339,7 +4339,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, "expected input to have non-empty spatial dimensions"):
             F.grid_sample(torch.empty(1, 1, 0, 2), grid, align_corners=False)
 
-        if torch.backends.mps.is_available():
+        if TEST_MPS:
             # a backend whose 5-D sampler implements bilinear and nearest only refuses bicubic
             with self.assertRaisesRegex(RuntimeError, "bicubic interpolation with 5D input"):
                 F.grid_sample(torch.empty(1, 1, 2, 2, 2, device='mps'),
@@ -11853,9 +11853,12 @@ class TestNNDeviceType(NNTestCase):
             out2 = model(inp2)
             self.assertTrue(torch.equal(out1, out2))
 
+    @parametrize_test("padding_mode", ["zeros", "border", "reflection"])
+    @parametrize_test("align_corners", [True, False])
+    @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64
     @onlyNativeDeviceTypes
-    @dtypes(torch.double)
-    def test_grid_sample_3d_bicubic_matches_2d(self, device, dtype):
+    @dtypes(torch.double, torch.float)
+    def test_grid_sample_3d_bicubic_matches_2d(self, device, dtype, padding_mode, align_corners):
         # A volume that does not vary along z is sampled by the same separable kernel the 4-D
         # sampler applies, since the four cubic weights of the z axis sum to one.
         image = torch.randn(2, 3, 7, 8, device=device, dtype=dtype)
@@ -11864,13 +11867,37 @@ class TestNNDeviceType(NNTestCase):
         # a z away from a voxel centre gives the four z taps a real weight each, and one
         # that far inside a 5-deep axis keeps every tap in bounds, so no padding drops one
         grid_3d = torch.cat([grid_2d, torch.full_like(grid_2d[..., :1], 0.1)], dim=-1).unsqueeze(1)
-        for padding_mode in ('zeros', 'border', 'reflection'):
-            for align_corners in (True, False):
-                out_2d = F.grid_sample(image, grid_2d, mode='bicubic',
-                                       padding_mode=padding_mode, align_corners=align_corners)
-                out_3d = F.grid_sample(volume, grid_3d, mode='bicubic',
-                                       padding_mode=padding_mode, align_corners=align_corners)
-                self.assertEqual(out_3d.squeeze(2), out_2d)
+        out_2d = F.grid_sample(image, grid_2d, mode='bicubic',
+                               padding_mode=padding_mode, align_corners=align_corners)
+        out_3d = F.grid_sample(volume, grid_3d, mode='bicubic',
+                               padding_mode=padding_mode, align_corners=align_corners)
+        # 5-D sums the 64 taps flat in the accumulate type where 4-D nests two cubic_interp1d
+        # stages in the scalar type, so single precision needs a tolerance
+        tolerance = {} if dtype == torch.double else {"atol": 1e-4, "rtol": 1e-4}
+        self.assertEqual(out_3d.squeeze(2), out_2d, **tolerance)
+
+    @parametrize_test("padding_mode", ["zeros", "border", "reflection"])
+    @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64
+    @onlyNativeDeviceTypes
+    @dtypes(torch.double)
+    def test_grid_sample_3d_bicubic_non_finite(self, device, dtype, padding_mode):
+        # A tap the padding drops contributes a zero value and keeps its coefficient, which is
+        # what get_value_bounded does in 4-D. So a coordinate or a voxel that is not finite has
+        # to reach the same answer at both ranks: neither the dropped tap's own value nor the
+        # voxel it would otherwise alias may enter the sum.
+        image = torch.randn(1, 1, 5, 5, device=device, dtype=dtype)
+        image[0, 0, 0, 0] = float('inf')
+        volume = image.unsqueeze(2).expand(1, 1, 5, 5, 5).contiguous()
+        for coordinate in (float('nan'), float('inf'), -float('inf'), 50.0):
+            grid_2d = torch.full((1, 1, 2, 2), coordinate, device=device, dtype=dtype)
+            grid_2d[0, 0, 1] = 0.1  # a sane sample beside the bad one
+            grid_3d = torch.cat(
+                [grid_2d, torch.full_like(grid_2d[..., :1], 0.1)], dim=-1).unsqueeze(1)
+            out_2d = F.grid_sample(image, grid_2d, mode='bicubic',
+                                   padding_mode=padding_mode, align_corners=False)
+            out_3d = F.grid_sample(volume, grid_3d, mode='bicubic',
+                                   padding_mode=padding_mode, align_corners=False)
+            self.assertEqual(out_3d.squeeze(2), out_2d)
 
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4940,24 +4940,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                     for input_requires_grad in [False, True]:
                         test(N, C, D, H, W, mode, padding_mode, align_corners, input_requires_grad)
 
-    def test_grid_sample_3d_bicubic_matches_2d(self):
-        # A volume that does not vary along z is sampled by the same separable kernel the 4-D
-        # sampler applies, since the four cubic weights of the z axis sum to one.
-        for device in ['cpu'] + (['cuda'] if TEST_CUDA else []):
-            image = torch.randn(2, 3, 7, 8, device=device, dtype=torch.double)
-            volume = image.unsqueeze(2).expand(2, 3, 5, 7, 8).contiguous()
-            grid_2d = torch.randn(2, 4, 6, 2, device=device, dtype=torch.double).clamp(-1.2, 1.2)
-            # a z away from a voxel centre gives the four z taps a real weight each, and one
-            # that far inside a 5-deep axis keeps every tap in bounds, so no padding drops one
-            grid_3d = torch.cat([grid_2d, torch.full_like(grid_2d[..., :1], 0.1)], dim=-1).unsqueeze(1)
-            for padding_mode in ('zeros', 'border', 'reflection'):
-                for align_corners in (True, False):
-                    out_2d = F.grid_sample(image, grid_2d, mode='bicubic',
-                                           padding_mode=padding_mode, align_corners=align_corners)
-                    out_3d = F.grid_sample(volume, grid_3d, mode='bicubic',
-                                           padding_mode=padding_mode, align_corners=align_corners)
-                    self.assertEqual(out_3d.squeeze(2), out_2d)
-
     def test_grid_sample_nearest_neighbor_rounding_mode_consistency(self):
 
         device_list = ['cpu']
@@ -11870,6 +11852,25 @@ class TestNNDeviceType(NNTestCase):
             out1 = model(inp1)
             out2 = model(inp2)
             self.assertTrue(torch.equal(out1, out2))
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.double)
+    def test_grid_sample_3d_bicubic_matches_2d(self, device, dtype):
+        # A volume that does not vary along z is sampled by the same separable kernel the 4-D
+        # sampler applies, since the four cubic weights of the z axis sum to one.
+        image = torch.randn(2, 3, 7, 8, device=device, dtype=dtype)
+        volume = image.unsqueeze(2).expand(2, 3, 5, 7, 8).contiguous()
+        grid_2d = torch.randn(2, 4, 6, 2, device=device, dtype=dtype).clamp(-1.2, 1.2)
+        # a z away from a voxel centre gives the four z taps a real weight each, and one
+        # that far inside a 5-deep axis keeps every tap in bounds, so no padding drops one
+        grid_3d = torch.cat([grid_2d, torch.full_like(grid_2d[..., :1], 0.1)], dim=-1).unsqueeze(1)
+        for padding_mode in ('zeros', 'border', 'reflection'):
+            for align_corners in (True, False):
+                out_2d = F.grid_sample(image, grid_2d, mode='bicubic',
+                                       padding_mode=padding_mode, align_corners=align_corners)
+                out_3d = F.grid_sample(volume, grid_3d, mode='bicubic',
+                                       padding_mode=padding_mode, align_corners=align_corners)
+                self.assertEqual(out_3d.squeeze(2), out_2d)
 
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11934,6 +11934,24 @@ class TestNNDeviceType(NNTestCase):
                                    padding_mode=padding_mode, align_corners=False)
             self.assertEqual(out_3d.squeeze(2), out_2d)
 
+        # The double backward gathers dropped taps from their clamped voxels, so
+        # the mask has to be applied with where(): multiplying after the gather
+        # turns an aliased Inf into NaN. One axis fully out of the volume keeps
+        # the forward a clean zero while every tap aliases onto the Inf plane.
+        if padding_mode == 'zeros' and dtype is torch.double:
+            poisoned = torch.randn(1, 1, 5, 6, 7, device=device, dtype=dtype)
+            poisoned[0, 0, :, 0, :] = float('inf')
+            poisoned.requires_grad_()
+            grid = torch.tensor([[[[[0.1, -2.0, 0.1]]]]], device=device, dtype=dtype,
+                                requires_grad=True)
+            out = F.grid_sample(poisoned, grid, mode='bicubic', padding_mode='zeros',
+                                align_corners=False)
+            gg = torch.autograd.grad(out.sum(), grid, create_graph=True)[0]
+            d_input = torch.autograd.grad(gg.sum(), poisoned, retain_graph=True)[0]
+            d_grid = torch.autograd.grad(gg.sum(), grid)[0]
+            self.assertTrue(bool(d_input.isfinite().all()))
+            self.assertTrue(bool(d_grid.isfinite().all()))
+
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)
     @dtypesIfMPS(torch.float, torch.half, torch.bfloat16)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4341,7 +4341,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
         if TEST_MPS:
             # a backend whose 5-D sampler implements bilinear and nearest only refuses bicubic
-            with self.assertRaisesRegex(RuntimeError, "bicubic interpolation with 5D input"):
+            with self.assertRaisesRegex(RuntimeError, "Unsupported Bicubic interpolation"):
                 F.grid_sample(torch.empty(1, 1, 2, 2, 2, device='mps'),
                               torch.empty(1, 1, 1, 1, 3, device='mps'), mode='bicubic')
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -22,6 +22,7 @@ from unittest import mock, SkipTest
 
 import torch
 from torch import inf, nan
+from torch._subclasses.fake_tensor import FakeTensorMode
 import torch.autograd.forward_ad as fwAD
 import torch.backends.cudnn as cudnn
 import torch.nn as nn
@@ -4342,6 +4343,14 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         if TEST_MPS:
             # a backend whose 5-D sampler implements bilinear and nearest only refuses bicubic
             with self.assertRaisesRegex(RuntimeError, "Unsupported Bicubic interpolation"):
+                F.grid_sample(torch.empty(1, 1, 2, 2, 2, device='mps'),
+                              torch.empty(1, 1, 1, 1, 3, device='mps'), mode='bicubic')
+
+        # The same call has to be refused in a trace, where the meta kernel answers rather
+        # than the backend, hence the other message. A fake tensor gets there with no MPS
+        # present, so this runs everywhere.
+        with FakeTensorMode():
+            with self.assertRaisesRegex(RuntimeError, "bicubic interpolation with 5D input"):
                 F.grid_sample(torch.empty(1, 1, 2, 2, 2, device='mps'),
                               torch.empty(1, 1, 1, 1, 3, device='mps'), mode='bicubic')
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11895,9 +11895,14 @@ class TestNNDeviceType(NNTestCase):
         # The double backward builds the tap gather and the coefficient derivatives only for
         # the outputs asked of it, and the OpInfo samples ask for both at once.
         volume = torch.randn(1, 2, 4, 5, 5, device=device, dtype=dtype)
-        # far enough inside that every tap stays in bounds: under zeros padding a tap the
-        # rim drops takes the value away with it, a step gradcheck cannot difference through
-        grid = torch.rand(1, 2, 3, 3, 3, device=device, dtype=dtype) * 0.5 - 0.25
+        # Two bands. The first stays far enough inside that every tap is in bounds. The
+        # second sits STABLY outside, around -1.5 in source units: a dropped tap is only a
+        # step for gradcheck when the perturbation crosses the boundary, and there the tap
+        # set is locally constant, so the dropped-tap arithmetic is differenced for real,
+        # with this single-sided mask.
+        inside = torch.rand(1, 2, 3, 3, 3, device=device, dtype=dtype) * 0.5 - 0.25
+        outside = torch.rand(1, 2, 3, 3, 3, device=device, dtype=dtype) * 0.04 - 1.42
+        grid = torch.cat([inside, outside], dim=1)
 
         def fn(t):
             args = (t, grid) if wrt == "input" else (volume, t)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11934,23 +11934,53 @@ class TestNNDeviceType(NNTestCase):
                                    padding_mode=padding_mode, align_corners=False)
             self.assertEqual(out_3d.squeeze(2), out_2d)
 
-        # The double backward gathers dropped taps from their clamped voxels, so
-        # the mask has to be applied with where(): multiplying after the gather
-        # turns an aliased Inf into NaN. One axis fully out of the volume keeps
-        # the forward a clean zero while every tap aliases onto the Inf plane.
-        if padding_mode == 'zeros' and dtype is torch.double:
-            poisoned = torch.randn(1, 1, 5, 6, 7, device=device, dtype=dtype)
-            poisoned[0, 0, :, 0, :] = float('inf')
-            poisoned.requires_grad_()
-            grid = torch.tensor([[[[[0.1, -2.0, 0.1]]]]], device=device, dtype=dtype,
-                                requires_grad=True)
-            out = F.grid_sample(poisoned, grid, mode='bicubic', padding_mode='zeros',
+    @parametrize_test("mode", ["bilinear", "bicubic"])
+    @expectedFailureMPS  # TypeError: the MPS framework doesn't support float64
+    @onlyNativeDeviceTypes
+    @dtypes(torch.double)
+    def test_grid_sample_double_backward_drops_masked_taps(self, device, dtype, mode):
+        # A dropped tap is gathered from the voxel it clamps onto and its cotangent is
+        # scattered there, so both need where(): multiplying after the gather turns an
+        # aliased Inf into NaN. Poisoning plane 0, where dropped taps clamp, and asking
+        # for the same gradients with a finite value there is what says it never enters.
+        def second_order(dim, plane_value, cotangent):
+            # squared, so the mixed second difference is not zero: on a ramp the grid
+            # gradient below vanishes and the equality has nothing to compare
+            ramp = torch.arange(1., 43. if dim == 2 else 211., device=device, dtype=dtype)
+            input = (ramp * ramp).reshape((1, 1, 6, 7) if dim == 2 else (1, 1, 5, 6, 7))
+            if dim == 2:
+                input[0, 0, 0, :] = plane_value
+                # one sample an axis fully outside, one well inside and off the voxel
+                # centre, where the cubic takes its general branch
+                grid = torch.tensor([[[[0.1, -2.0], [0.1, 0.3]]]], device=device, dtype=dtype)
+            else:
+                input[0, 0, :, 0, :] = plane_value
+                grid = torch.tensor([[[[[0.1, -2.0, 0.1], [0.1, 0.3, 0.1]]]]],
+                                    device=device, dtype=dtype)
+            input.requires_grad_()
+            grid.requires_grad_()
+            out = F.grid_sample(input, grid, mode=mode, padding_mode='zeros',
                                 align_corners=False)
-            gg = torch.autograd.grad(out.sum(), grid, create_graph=True)[0]
-            d_input = torch.autograd.grad(gg.sum(), poisoned, retain_graph=True)[0]
-            d_grid = torch.autograd.grad(gg.sum(), grid)[0]
-            self.assertTrue(bool(d_input.isfinite().all()))
-            self.assertTrue(bool(d_grid.isfinite().all()))
+            grad_output = torch.ones_like(out)
+            grad_output.view(-1)[0] = cotangent  # carried by the dropped taps alone
+            d_grid = torch.autograd.grad(out, grid, grad_outputs=grad_output,
+                                         create_graph=True)[0]
+            # a finite seed, so only the masking may put a non-finite number in
+            return torch.autograd.grad(d_grid.sum(), [input, grid])
+
+        for dim in (2, 3):
+            reference = second_order(dim, 1.0, 1.0)
+            for bad in (float('inf'), -float('inf'), float('nan')):
+                # the voxel a dropped tap aliases reaches neither gradient
+                for got, expected in zip(second_order(dim, bad, 1.0), reference):
+                    self.assertTrue(bool(got.isfinite().all()))
+                    self.assertEqual(got, expected)
+                # nor does the cotangent it carries reach the scattered one. The grid
+                # gradient is exempt: it already holds what the first-order kernel makes
+                # of a non-finite cotangent on a dropped sample, which predates this.
+                d_input = second_order(dim, 1.0, bad)[0]
+                self.assertTrue(bool(d_input.isfinite().all()))
+                self.assertEqual(d_input, reference[0])
 
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4339,9 +4339,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         with self.assertRaisesRegex(RuntimeError, "expected input to have non-empty spatial dimensions"):
             F.grid_sample(torch.empty(1, 1, 0, 2), grid, align_corners=False)
 
-        with self.assertRaisesRegex(RuntimeError, "bicubic interpolation only supports 4D input"):
-            F.grid_sample(torch.empty(1, 1, 2, 2, 2), torch.empty(1, 1, 1, 1, 3), mode='bicubic')
-
         if TEST_CUDA:
             with self.assertRaisesRegex(RuntimeError, "Expected all tensors to be on the same device"):
                 F.grid_sample(input.cuda(), grid, align_corners=False)
@@ -4913,7 +4910,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             W = random.randint(3, IW + 2)
             test_shape(0, C, ID, IH, IW, D, H, W, mode, padding_mode, align_corners)
 
-        for mode in ('bilinear', 'nearest'):
+        for mode in ('bilinear', 'nearest', 'bicubic'):
             for padding_mode in ('zeros', 'border', 'reflection'):
                 for align_corners in (True, False):
                     # do gradcheck
@@ -4936,6 +4933,24 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
                     for input_requires_grad in [False, True]:
                         test(N, C, D, H, W, mode, padding_mode, align_corners, input_requires_grad)
+
+    def test_grid_sample_3d_bicubic_matches_2d(self):
+        # A volume that does not vary along z is sampled by the same separable kernel the 4-D
+        # sampler applies, since the four cubic weights of the z axis sum to one.
+        for device in ['cpu'] + (['cuda'] if TEST_CUDA else []):
+            image = torch.randn(2, 3, 7, 8, device=device, dtype=torch.double)
+            volume = image.unsqueeze(2).expand(2, 3, 5, 7, 8).contiguous()
+            grid_2d = torch.randn(2, 4, 6, 2, device=device, dtype=torch.double).clamp(-1.2, 1.2)
+            # a z away from a voxel centre gives the four z taps a real weight each, and one
+            # that far inside a 5-deep axis keeps every tap in bounds, so no padding drops one
+            grid_3d = torch.cat([grid_2d, torch.full_like(grid_2d[..., :1], 0.1)], dim=-1).unsqueeze(1)
+            for padding_mode in ('zeros', 'border', 'reflection'):
+                for align_corners in (True, False):
+                    out_2d = F.grid_sample(image, grid_2d, mode='bicubic',
+                                           padding_mode=padding_mode, align_corners=align_corners)
+                    out_3d = F.grid_sample(volume, grid_3d, mode='bicubic',
+                                           padding_mode=padding_mode, align_corners=align_corners)
+                    self.assertEqual(out_3d.squeeze(2), out_2d)
 
     def test_grid_sample_nearest_neighbor_rounding_mode_consistency(self):
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5912,8 +5912,8 @@ def check_grid_sampler_3d(input: Tensor, grid: Tensor, interpolation_mode: int):
             f" and grid with sizes {grid.shape}"
         ),
     )
-    # CPU and CUDA sample 5D bicubic; the backends that do not reject it in eager, so the
-    # trace has to reject it too rather than succeed and fail at run time.
+    # CPU and CUDA sample 5D bicubic, mps and xpu reject it in eager, so the trace
+    # rejects it too instead of succeeding and failing at run time.
     torch._check(
         input.device.type not in ("mps", "xpu")
         or interpolation_mode != GridSamplerInterpolation.BICUBIC.value,

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5903,7 +5903,7 @@ def check_grid_sampler_2d(input: Tensor, grid: Tensor):
     )
 
 
-def check_grid_sampler_3d(input: Tensor, grid: Tensor):
+def check_grid_sampler_3d(input: Tensor, grid: Tensor, interpolation_mode: int):
     torch._check(
         input.ndim == 5 and input.ndim == grid.ndim,
         lambda: (
@@ -5911,6 +5911,14 @@ def check_grid_sampler_3d(input: Tensor, grid: Tensor):
             f"dimensions, but got input with sizes {input.shape}"
             f" and grid with sizes {grid.shape}"
         ),
+    )
+    # CPU and CUDA sample 5D bicubic; the backends that do not reject it in eager, so the
+    # trace has to reject it too rather than succeed and fail at run time.
+    torch._check(
+        input.device.type not in ("mps", "xpu")
+        or interpolation_mode != GridSamplerInterpolation.BICUBIC.value,
+        lambda: "grid_sampler(): bicubic interpolation with 5D input is not supported "
+        f"on {input.device.type}",
     )
 
 
@@ -5984,7 +5992,7 @@ def grid_sampler_3d(
     align_corners,
 ):
     check_grid_sampler_common(input, grid)
-    check_grid_sampler_3d(input, grid)
+    check_grid_sampler_3d(input, grid, interpolation_mode)
     N = input.shape[0]
     C = input.shape[1]
     out_D = grid.shape[1]
@@ -6005,7 +6013,7 @@ def grid_sampler_3d_backward(
     output_mask,
 ):
     check_grid_sampler_common(input, grid)
-    check_grid_sampler_3d(input, grid)
+    check_grid_sampler_3d(input, grid, interpolation_mode)
     input_requires_grad = output_mask[0]
     if input_requires_grad:
         grad_input = torch.zeros_like(

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5912,13 +5912,14 @@ def check_grid_sampler_3d(input: Tensor, grid: Tensor, interpolation_mode: int):
             f" and grid with sizes {grid.shape}"
         ),
     )
-    # CPU and CUDA sample 5D bicubic, mps and xpu reject it in eager, so the trace
-    # rejects it too instead of succeeding and failing at run time.
+    # CPU and CUDA sample 5D bicubic, the other backends reject it in eager, so the
+    # trace rejects it too instead of succeeding and failing at run time. A FakeTensor
+    # reports its device as meta while a meta kernel runs, hence device_hint.
     torch._check(
-        input.device.type not in ("mps", "xpu")
-        or interpolation_mode != GridSamplerInterpolation.BICUBIC.value,
+        interpolation_mode != GridSamplerInterpolation.BICUBIC.value
+        or device_hint(input) in ("cpu", "cuda"),
         lambda: "grid_sampler(): bicubic interpolation with 5D input is not supported "
-        f"on {input.device.type}",
+        f"on {device_hint(input)}",
     )
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -5903,7 +5903,7 @@ def check_grid_sampler_2d(input: Tensor, grid: Tensor):
     )
 
 
-def check_grid_sampler_3d(input: Tensor, grid: Tensor, interpolation_mode: int):
+def check_grid_sampler_3d(input: Tensor, grid: Tensor):
     torch._check(
         input.ndim == 5 and input.ndim == grid.ndim,
         lambda: (
@@ -5911,13 +5911,6 @@ def check_grid_sampler_3d(input: Tensor, grid: Tensor, interpolation_mode: int):
             f"dimensions, but got input with sizes {input.shape}"
             f" and grid with sizes {grid.shape}"
         ),
-    )
-    torch._check(
-        not (
-            input.ndim == 5
-            and interpolation_mode == GridSamplerInterpolation.BICUBIC.value
-        ),
-        lambda: "grid_sampler(): bicubic interpolation only supports 4D input",
     )
 
 
@@ -5991,7 +5984,7 @@ def grid_sampler_3d(
     align_corners,
 ):
     check_grid_sampler_common(input, grid)
-    check_grid_sampler_3d(input, grid, interpolation_mode)
+    check_grid_sampler_3d(input, grid)
     N = input.shape[0]
     C = input.shape[1]
     out_D = grid.shape[1]
@@ -6012,7 +6005,7 @@ def grid_sampler_3d_backward(
     output_mask,
 ):
     check_grid_sampler_common(input, grid)
-    check_grid_sampler_3d(input, grid, interpolation_mode)
+    check_grid_sampler_3d(input, grid)
     input_requires_grad = output_mask[0]
     if input_requires_grad:
         grad_input = torch.zeros_like(

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -8172,7 +8172,8 @@ static Tensor gs_gather2d_multi(
                     .reshape({N, C, out_H, out_W, K});
   if (zeros_oob) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result =
+        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8195,7 +8196,8 @@ static Tensor gs_scatter2d_multi(
   auto weighted = values.unsqueeze(-1) * weights.unsqueeze(1);
   if (zeros_oob) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(
+        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_H * out_W * K}))
@@ -8222,7 +8224,8 @@ static Tensor gs_gather2d_bc_multi(
                     .reshape({N, C, out_H, out_W, K});
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result =
+        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8248,7 +8251,8 @@ static Tensor gs_scatter2d_bc_multi(
   auto weighted = values.unsqueeze(-1) * weights.unsqueeze(1);
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(
+        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_H * out_W * K}))
@@ -8281,7 +8285,8 @@ static Tensor gs_gather3d_bc_multi(
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result =
+        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8312,7 +8317,8 @@ static Tensor gs_scatter3d_bc_multi(
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(
+        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, D * H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_D * out_H * out_W * K}))
@@ -8341,7 +8347,8 @@ static Tensor gs_gather3d_multi(
   if (zeros_oob) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result =
+        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8369,7 +8376,8 @@ static Tensor gs_scatter3d_multi(
   if (zeros_oob) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(
+        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, D * H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_D * out_H * out_W * K}))

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -8172,8 +8172,7 @@ static Tensor gs_gather2d_multi(
                     .reshape({N, C, out_H, out_W, K});
   if (zeros_oob) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    result =
-        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result = at::where(mask.unsqueeze(1), result, 0);
   }
   return result;
 }
@@ -8196,8 +8195,7 @@ static Tensor gs_scatter2d_multi(
   auto weighted = values.unsqueeze(-1) * weights.unsqueeze(1);
   if (zeros_oob) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(
-        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(mask.unsqueeze(1), weighted, 0);
   }
   return at::zeros({N, C, H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_H * out_W * K}))
@@ -8224,8 +8222,7 @@ static Tensor gs_gather2d_bc_multi(
                     .reshape({N, C, out_H, out_W, K});
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    result =
-        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result = at::where(mask.unsqueeze(1), result, 0);
   }
   return result;
 }
@@ -8251,8 +8248,7 @@ static Tensor gs_scatter2d_bc_multi(
   auto weighted = values.unsqueeze(-1) * weights.unsqueeze(1);
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(
-        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(mask.unsqueeze(1), weighted, 0);
   }
   return at::zeros({N, C, H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_H * out_W * K}))
@@ -8285,8 +8281,7 @@ static Tensor gs_gather3d_bc_multi(
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    result =
-        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result = at::where(mask.unsqueeze(1), result, 0);
   }
   return result;
 }
@@ -8317,8 +8312,7 @@ static Tensor gs_scatter3d_bc_multi(
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(
-        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(mask.unsqueeze(1), weighted, 0);
   }
   return at::zeros({N, C, D * H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_D * out_H * out_W * K}))
@@ -8347,8 +8341,7 @@ static Tensor gs_gather3d_multi(
   if (zeros_oob) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    result =
-        at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
+    result = at::where(mask.unsqueeze(1), result, 0);
   }
   return result;
 }
@@ -8376,8 +8369,7 @@ static Tensor gs_scatter3d_multi(
   if (zeros_oob) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    weighted = at::where(
-        mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
+    weighted = at::where(mask.unsqueeze(1), weighted, 0);
   }
   return at::zeros({N, C, D * H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_D * out_H * out_W * K}))

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -8708,89 +8708,104 @@ std::tuple<Tensor, Tensor, Tensor> grid_sampler_3d_double_backward(
            -((((3 * (A + 2)) * t2) - (2 * (A + 3))) * t2),
            (((-3 * A) * t3) + (10 * A)) * t3 - (8 * A)},
           -1);
-      auto d2c = at::stack(
+      return std::make_pair(c, dc);
+    };
+    // only the ggGrid half needs the second derivative, so it is built there
+    auto second = [](const Tensor& t) {
+      auto t1 = t + 1.0, t2 = 1.0 - t, t3 = 2.0 - t;
+      return at::stack(
           {((6 * A) * t1) - (10 * A),
            ((6 * (A + 2)) * t) - (2 * (A + 3)),
            ((6 * (A + 2)) * t2) - (2 * (A + 3)),
            ((6 * A) * t3) - (10 * A)},
           -1);
-      return std::make_tuple(c, dc, d2c);
     };
-    auto [cx, dcx, d2cx] = coeffs(fx);
-    auto [cy, dcy, d2cy] = coeffs(fy);
-    auto [cz, dcz, d2cz] = coeffs(fz);
+    auto [cx, dcx] = coeffs(fx);
+    auto [cy, dcy] = coeffs(fy);
+    auto [cz, dcz] = coeffs(fz);
 
-    // The 64 taps, flattened as k = kz * 16 + jy * 4 + ix, which is the order
-    // the outer product below builds its weights in.
+    // Walk the 64 taps four at a time, one (z, y) pair per step. Materialising
+    // them together would hold three [N, Do, Ho, Wo, 64] index tensors and a
+    // gather of the same width times the channels, which is gigabytes at a
+    // realistic volume size.
     auto offs = at::arange(-1, 3, x0.options());
-    auto shape = std::vector<int64_t>(
-        {x0.size(0), x0.size(1), x0.size(2), x0.size(3), 64});
-    auto taps = [&](const Tensor& base, int64_t axis) {
-      // the axis owns one of the three tap dimensions and broadcasts over the
-      // other two, so that flattening them gives k = kz * 16 + jy * 4 + ix
-      auto dims = std::vector<int64_t>(
-          {x0.size(0), x0.size(1), x0.size(2), x0.size(3), 1, 1, 1});
-      dims[4 + axis] = 4;
-      return (base.unsqueeze(-1) + offs)
-          .reshape(dims)
-          .expand({-1, -1, -1, -1, 4, 4, 4})
-          .reshape(shape);
-    };
-    auto z_idx = taps(z0, 0), y_idx = taps(y0, 1), x_idx = taps(x0, 2);
+    auto x_idx = x0.unsqueeze(-1) + offs;
 
-    auto I_all = gs_gather3d_bc_multi(
-        input, z_idx, y_idx, x_idx, padding_mode_enum, align_corners);
-
-    // The weight of tap k in d output / d coordinate, one tensor per axis.
-    auto outer3 = [](const Tensor& a, const Tensor& b, const Tensor& c) {
-      return gs_outer_last(gs_outer_last(a, b), c);
-    };
-    Tensor B_dx, B_dy, B_dz;
-    if (output_mask[0] || output_mask[1]) {
-      B_dx = outer3(dcx, cy, cz);
-      B_dy = outer3(cx, dcy, cz);
-      B_dz = outer3(cx, cy, dcz);
-    }
-
-    if (output_mask[0]) {
-      auto contrib = gs_accum_sumprod_k(I_all, B_dx) * ggG_x.unsqueeze(1);
-      contrib.addcmul_(gs_accum_sumprod_k(I_all, B_dy), ggG_y.unsqueeze(1));
-      contrib.addcmul_(gs_accum_sumprod_k(I_all, B_dz), ggG_z.unsqueeze(1));
-      d_grad_output = d_grad_output.defined() ? d_grad_output + contrib
-                                              : std::move(contrib);
-    }
-
-    if (output_mask[1]) {
-      auto w_in = ggG_x.unsqueeze(-1) * B_dx;
-      w_in.addcmul_(ggG_y.unsqueeze(-1), B_dy);
-      w_in.addcmul_(ggG_z.unsqueeze(-1), B_dz);
-      d_input = gs_scatter3d_bc_multi(
-          grad_output,
-          w_in,
-          z_idx,
-          y_idx,
-          x_idx,
-          D,
-          H,
-          W,
-          padding_mode_enum,
-          align_corners);
-    }
-
-    // ggGrid -> d_grid: the second derivatives of the sampled value in the
-    // coordinate, which for a separable cubic is the symmetric 3x3 of the
-    // taps weighted by two derivative factors.
+    Tensor d2cx, d2cy, d2cz, dx2, dy2, dz2, dxdy, dxdz, dydz;
     if (output_mask[2]) {
-      auto tap_dot = (grad_output.unsqueeze(-1) * I_all).sum(1);
-      auto dot = [&](const Tensor& a, const Tensor& b, const Tensor& c) {
-        return (tap_dot * outer3(a, b, c)).sum(-1);
-      };
-      auto dx2 = dot(d2cx, cy, cz);
-      auto dy2 = dot(cx, d2cy, cz);
-      auto dz2 = dot(cx, cy, d2cz);
-      auto dxdy = dot(dcx, dcy, cz);
-      auto dxdz = dot(dcx, cy, dcz);
-      auto dydz = dot(cx, dcy, dcz);
+      d2cx = second(fx);
+      d2cy = second(fy);
+      d2cz = second(fz);
+    }
+
+    for (const auto kz : c10::irange(4)) {
+      for (const auto jy : c10::irange(4)) {
+        auto y_idx = (y0 + (jy - 1)).unsqueeze(-1).expand_as(x_idx);
+        auto z_idx = (z0 + (kz - 1)).unsqueeze(-1).expand_as(x_idx);
+        auto taps = gs_gather3d_bc_multi(
+            input, z_idx, y_idx, x_idx, padding_mode_enum, align_corners);
+
+        auto cy_j = cy.select(-1, jy), dcy_j = dcy.select(-1, jy);
+        auto cz_k = cz.select(-1, kz), dcz_k = dcz.select(-1, kz);
+        auto weight = [](const Tensor& along_x, const Tensor& other) {
+          return along_x * other.unsqueeze(-1);
+        };
+
+        Tensor B_dx, B_dy, B_dz;
+        if (output_mask[0] || output_mask[1]) {
+          B_dx = weight(dcx, cy_j * cz_k);
+          B_dy = weight(cx, dcy_j * cz_k);
+          B_dz = weight(cx, cy_j * dcz_k);
+        }
+
+        if (output_mask[0]) {
+          auto contrib = gs_accum_sumprod_k(taps, B_dx) * ggG_x.unsqueeze(1);
+          contrib.addcmul_(gs_accum_sumprod_k(taps, B_dy), ggG_y.unsqueeze(1));
+          contrib.addcmul_(gs_accum_sumprod_k(taps, B_dz), ggG_z.unsqueeze(1));
+          d_grad_output = d_grad_output.defined() ? d_grad_output + contrib
+                                                  : std::move(contrib);
+        }
+
+        if (output_mask[1]) {
+          auto w_in = ggG_x.unsqueeze(-1) * B_dx;
+          w_in.addcmul_(ggG_y.unsqueeze(-1), B_dy);
+          w_in.addcmul_(ggG_z.unsqueeze(-1), B_dz);
+          auto contrib = gs_scatter3d_bc_multi(
+              grad_output,
+              w_in,
+              z_idx,
+              y_idx,
+              x_idx,
+              D,
+              H,
+              W,
+              padding_mode_enum,
+              align_corners);
+          d_input = d_input.defined() ? d_input + contrib : std::move(contrib);
+        }
+
+        // The second derivatives of the sampled value in the coordinate, which
+        // for a separable cubic is the symmetric 3x3 of the taps weighted by
+        // two derivative factors.
+        if (output_mask[2]) {
+          auto tap_dot = (grad_output.unsqueeze(-1) * taps).sum(1);
+          auto dot = [&](const Tensor& along_x, const Tensor& other) {
+            return (tap_dot * weight(along_x, other)).sum(-1);
+          };
+          auto accumulate = [](Tensor& total, Tensor part) {
+            total = total.defined() ? total + part : std::move(part);
+          };
+          accumulate(dx2, dot(d2cx, cy_j * cz_k));
+          accumulate(dy2, dot(cx, d2cy.select(-1, jy) * cz_k));
+          accumulate(dz2, dot(cx, cy_j * d2cz.select(-1, kz)));
+          accumulate(dxdy, dot(dcx, dcy_j * cz_k));
+          accumulate(dxdz, dot(dcx, cy_j * dcz_k));
+          accumulate(dydz, dot(cx, dcy_j * dcz_k));
+        }
+      }
+    }
+
+    if (output_mask[2]) {
       auto row = [&](const Tensor& to_x,
                      const Tensor& to_y,
                      const Tensor& to_z,
@@ -8808,6 +8823,7 @@ std::tuple<Tensor, Tensor, Tensor> grid_sampler_3d_double_backward(
       d_grid =
           d_grid.defined() ? d_grid + ggrid_d_grid : std::move(ggrid_d_grid);
     }
+
     return {std::move(d_grad_output), std::move(d_input), std::move(d_grid)};
   }
 

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -8255,6 +8255,69 @@ static Tensor gs_scatter2d_bc_multi(
       .reshape({N, C, H, W});
 }
 
+// Multi-tap bounded gather for bicubic 3D: the padding maps every tap, as it
+// does in the kernel, instead of the caller having mapped the coordinate once.
+static Tensor gs_gather3d_bc_multi(
+    const Tensor& input,
+    const Tensor& d_idx,
+    const Tensor& h_idx,
+    const Tensor& w_idx,
+    GridSamplerPadding padding_mode,
+    bool align_corners) {
+  auto N = input.size(0), C = input.size(1);
+  auto D = input.size(2), H = input.size(3), W = input.size(4);
+  auto out_D = d_idx.size(1), out_H = d_idx.size(2), out_W = d_idx.size(3),
+       K = d_idx.size(4);
+  auto flat = ((gs_bound_coord(d_idx, D, padding_mode, align_corners) * H +
+                gs_bound_coord(h_idx, H, padding_mode, align_corners)) *
+                   W +
+               gs_bound_coord(w_idx, W, padding_mode, align_corners))
+                  .reshape({N, 1, out_D * out_H * out_W * K})
+                  .expand({N, C, out_D * out_H * out_W * K});
+  auto result = input.reshape({N, C, D * H * W})
+                    .gather(2, flat)
+                    .reshape({N, C, out_D, out_H, out_W, K});
+  if (padding_mode == GridSamplerPadding::Zeros) {
+    auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
+        (w_idx >= 0) & (w_idx < W);
+    result = result * mask.unsqueeze(1).to(result.dtype());
+  }
+  return result;
+}
+
+// Multi-tap bounded scatter for bicubic 3D: values [N,C,Do,Ho,Wo], weights
+// [N,Do,Ho,Wo,K] → [N,C,D,H,W]
+static Tensor gs_scatter3d_bc_multi(
+    const Tensor& values,
+    const Tensor& weights,
+    const Tensor& d_idx,
+    const Tensor& h_idx,
+    const Tensor& w_idx,
+    int64_t D,
+    int64_t H,
+    int64_t W,
+    GridSamplerPadding padding_mode,
+    bool align_corners) {
+  auto N = values.size(0), C = values.size(1);
+  auto out_D = values.size(2), out_H = values.size(3), out_W = values.size(4);
+  auto K = d_idx.size(4);
+  auto flat = ((gs_bound_coord(d_idx, D, padding_mode, align_corners) * H +
+                gs_bound_coord(h_idx, H, padding_mode, align_corners)) *
+                   W +
+               gs_bound_coord(w_idx, W, padding_mode, align_corners))
+                  .reshape({N, 1, out_D * out_H * out_W * K})
+                  .expand({N, C, out_D * out_H * out_W * K});
+  auto weighted = values.unsqueeze(-1) * weights.unsqueeze(1);
+  if (padding_mode == GridSamplerPadding::Zeros) {
+    auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
+        (w_idx >= 0) & (w_idx < W);
+    weighted = weighted * mask.unsqueeze(1).to(weighted.dtype());
+  }
+  return at::zeros({N, C, D * H * W}, values.options())
+      .scatter_add(2, flat, weighted.reshape({N, C, out_D * out_H * out_W * K}))
+      .reshape({N, C, D, H, W});
+}
+
 // Multi-tap gather for 3D: d_idx/h_idx/w_idx [N, Do, Ho, Wo, K] → [N, C, Do,
 // Ho, Wo, K]
 static Tensor gs_gather3d_multi(
@@ -8602,6 +8665,152 @@ std::tuple<Tensor, Tensor, Tensor> grid_sampler_3d_double_backward(
   if (!ggGrid.defined() || interpolation == GridSamplerInterpolation::Nearest) {
     return {std::move(d_grad_output), std::move(d_input), std::move(d_grid)};
   }
+
+  if (interpolation == GridSamplerInterpolation::Bicubic) {
+    // As in 2D: the bicubic backward differentiates the UNNORMALIZED coordinate
+    // and applies the padding tap by tap, so the multiplier is the unnormalize
+    // scale alone. gs_compute_coords would zero it at a border and lose a
+    // sensitivity the kernel still has.
+    auto D = input.size(2), H = input.size(3), W = input.size(4);
+    auto x_scale = static_cast<double>(align_corners ? W - 1 : W) / 2.0;
+    auto y_scale = static_cast<double>(align_corners ? H - 1 : H) / 2.0;
+    auto z_scale = static_cast<double>(align_corners ? D - 1 : D) / 2.0;
+    auto raw = [&](int64_t axis, double scale) {
+      auto coord = (grid.select(-1, axis) + 1) * scale;
+      return align_corners ? coord : coord - 0.5;
+    };
+    auto x_raw = raw(0, x_scale), y_raw = raw(1, y_scale),
+         z_raw = raw(2, z_scale);
+    auto x0 = at::floor(x_raw).to(at::kLong);
+    auto y0 = at::floor(y_raw).to(at::kLong);
+    auto z0 = at::floor(z_raw).to(at::kLong);
+    auto fx = x_raw - x0.to(x_raw.dtype());
+    auto fy = y_raw - y0.to(y_raw.dtype());
+    auto fz = z_raw - z0.to(z_raw.dtype());
+    auto ggG_x = ggGrid.select(-1, 0) * x_scale;
+    auto ggG_y = ggGrid.select(-1, 1) * y_scale;
+    auto ggG_z = ggGrid.select(-1, 2) * z_scale;
+
+    // Keys' coefficients and their first two derivatives in the fractional
+    // offset, for the four taps at {-1, 0, 1, 2} from the base voxel.
+    constexpr double A = -0.75;
+    auto coeffs = [](const Tensor& t) {
+      auto t1 = t + 1.0, t2 = 1.0 - t, t3 = 2.0 - t;
+      auto c = at::stack(
+          {(((A * t1) - (5 * A)) * t1 + (8 * A)) * t1 - (4 * A),
+           (((A + 2) * t) - (A + 3)) * t.square() + 1,
+           (((A + 2) * t2) - (A + 3)) * t2.square() + 1,
+           (((A * t3) - (5 * A)) * t3 + (8 * A)) * t3 - (4 * A)},
+          -1);
+      auto dc = at::stack(
+          {(((3 * A) * t1) - (10 * A)) * t1 + (8 * A),
+           (((3 * (A + 2)) * t) - (2 * (A + 3))) * t,
+           -((((3 * (A + 2)) * t2) - (2 * (A + 3))) * t2),
+           (((-3 * A) * t3) + (10 * A)) * t3 - (8 * A)},
+          -1);
+      auto d2c = at::stack(
+          {((6 * A) * t1) - (10 * A),
+           ((6 * (A + 2)) * t) - (2 * (A + 3)),
+           ((6 * (A + 2)) * t2) - (2 * (A + 3)),
+           ((6 * A) * t3) - (10 * A)},
+          -1);
+      return std::make_tuple(c, dc, d2c);
+    };
+    auto [cx, dcx, d2cx] = coeffs(fx);
+    auto [cy, dcy, d2cy] = coeffs(fy);
+    auto [cz, dcz, d2cz] = coeffs(fz);
+
+    // The 64 taps, flattened as k = kz * 16 + jy * 4 + ix, which is the order
+    // the outer product below builds its weights in.
+    auto offs = at::arange(-1, 3, x0.options());
+    auto shape = std::vector<int64_t>(
+        {x0.size(0), x0.size(1), x0.size(2), x0.size(3), 64});
+    auto taps = [&](const Tensor& base, int64_t axis) {
+      // the axis owns one of the three tap dimensions and broadcasts over the
+      // other two, so that flattening them gives k = kz * 16 + jy * 4 + ix
+      auto dims = std::vector<int64_t>(
+          {x0.size(0), x0.size(1), x0.size(2), x0.size(3), 1, 1, 1});
+      dims[4 + axis] = 4;
+      return (base.unsqueeze(-1) + offs)
+          .reshape(dims)
+          .expand({-1, -1, -1, -1, 4, 4, 4})
+          .reshape(shape);
+    };
+    auto z_idx = taps(z0, 0), y_idx = taps(y0, 1), x_idx = taps(x0, 2);
+
+    auto I_all = gs_gather3d_bc_multi(
+        input, z_idx, y_idx, x_idx, padding_mode_enum, align_corners);
+
+    // The weight of tap k in d output / d coordinate, one tensor per axis.
+    auto outer3 = [](const Tensor& a, const Tensor& b, const Tensor& c) {
+      return gs_outer_last(gs_outer_last(a, b), c);
+    };
+    Tensor B_dx, B_dy, B_dz;
+    if (output_mask[0] || output_mask[1]) {
+      B_dx = outer3(dcx, cy, cz);
+      B_dy = outer3(cx, dcy, cz);
+      B_dz = outer3(cx, cy, dcz);
+    }
+
+    if (output_mask[0]) {
+      auto contrib = gs_accum_sumprod_k(I_all, B_dx) * ggG_x.unsqueeze(1);
+      contrib.addcmul_(gs_accum_sumprod_k(I_all, B_dy), ggG_y.unsqueeze(1));
+      contrib.addcmul_(gs_accum_sumprod_k(I_all, B_dz), ggG_z.unsqueeze(1));
+      d_grad_output = d_grad_output.defined() ? d_grad_output + contrib
+                                              : std::move(contrib);
+    }
+
+    if (output_mask[1]) {
+      auto w_in = ggG_x.unsqueeze(-1) * B_dx;
+      w_in.addcmul_(ggG_y.unsqueeze(-1), B_dy);
+      w_in.addcmul_(ggG_z.unsqueeze(-1), B_dz);
+      d_input = gs_scatter3d_bc_multi(
+          grad_output,
+          w_in,
+          z_idx,
+          y_idx,
+          x_idx,
+          D,
+          H,
+          W,
+          padding_mode_enum,
+          align_corners);
+    }
+
+    // ggGrid -> d_grid: the second derivatives of the sampled value in the
+    // coordinate, which for a separable cubic is the symmetric 3x3 of the
+    // taps weighted by two derivative factors.
+    if (output_mask[2]) {
+      auto tap_dot = (grad_output.unsqueeze(-1) * I_all).sum(1);
+      auto dot = [&](const Tensor& a, const Tensor& b, const Tensor& c) {
+        return (tap_dot * outer3(a, b, c)).sum(-1);
+      };
+      auto dx2 = dot(d2cx, cy, cz);
+      auto dy2 = dot(cx, d2cy, cz);
+      auto dz2 = dot(cx, cy, d2cz);
+      auto dxdy = dot(dcx, dcy, cz);
+      auto dxdz = dot(dcx, cy, dcz);
+      auto dydz = dot(cx, dcy, dcz);
+      auto row = [&](const Tensor& to_x,
+                     const Tensor& to_y,
+                     const Tensor& to_z,
+                     double scale) {
+        auto value = ggG_x * to_x;
+        value.addcmul_(ggG_y, to_y);
+        value.addcmul_(ggG_z, to_z);
+        return value.mul_(scale);
+      };
+      auto ggrid_d_grid = at::stack(
+          {row(dx2, dxdy, dxdz, x_scale),
+           row(dxdy, dy2, dydz, y_scale),
+           row(dxdz, dydz, dz2, z_scale)},
+          -1);
+      d_grid =
+          d_grid.defined() ? d_grid + ggrid_d_grid : std::move(ggrid_d_grid);
+    }
+    return {std::move(d_grad_output), std::move(d_input), std::move(d_grid)};
+  }
+
   TORCH_CHECK_NOT_IMPLEMENTED(
       interpolation == GridSamplerInterpolation::Bilinear,
       "grid_sampler_3d double backward not implemented for interpolation_mode=",

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -8172,7 +8172,7 @@ static Tensor gs_gather2d_multi(
                     .reshape({N, C, out_H, out_W, K});
   if (zeros_oob) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    result = result * mask.unsqueeze(1).to(result.dtype());
+    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8195,7 +8195,7 @@ static Tensor gs_scatter2d_multi(
   auto weighted = values.unsqueeze(-1) * weights.unsqueeze(1);
   if (zeros_oob) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    weighted = weighted * mask.unsqueeze(1).to(weighted.dtype());
+    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_H * out_W * K}))
@@ -8222,7 +8222,7 @@ static Tensor gs_gather2d_bc_multi(
                     .reshape({N, C, out_H, out_W, K});
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    result = result * mask.unsqueeze(1).to(result.dtype());
+    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8248,7 +8248,7 @@ static Tensor gs_scatter2d_bc_multi(
   auto weighted = values.unsqueeze(-1) * weights.unsqueeze(1);
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (h_idx >= 0) & (h_idx < H) & (w_idx >= 0) & (w_idx < W);
-    weighted = weighted * mask.unsqueeze(1).to(weighted.dtype());
+    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_H * out_W * K}))
@@ -8281,7 +8281,7 @@ static Tensor gs_gather3d_bc_multi(
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    result = result * mask.unsqueeze(1).to(result.dtype());
+    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8312,7 +8312,7 @@ static Tensor gs_scatter3d_bc_multi(
   if (padding_mode == GridSamplerPadding::Zeros) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    weighted = weighted * mask.unsqueeze(1).to(weighted.dtype());
+    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, D * H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_D * out_H * out_W * K}))
@@ -8341,7 +8341,7 @@ static Tensor gs_gather3d_multi(
   if (zeros_oob) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    result = result * mask.unsqueeze(1).to(result.dtype());
+    result = at::where(mask.unsqueeze(1), result, at::zeros({}, result.options()));
   }
   return result;
 }
@@ -8369,7 +8369,7 @@ static Tensor gs_scatter3d_multi(
   if (zeros_oob) {
     auto mask = (d_idx >= 0) & (d_idx < D) & (h_idx >= 0) & (h_idx < H) &
         (w_idx >= 0) & (w_idx < W);
-    weighted = weighted * mask.unsqueeze(1).to(weighted.dtype());
+    weighted = at::where(mask.unsqueeze(1), weighted, at::zeros({}, weighted.options()));
   }
   return at::zeros({N, C, D * H * W}, values.options())
       .scatter_add(2, flat, weighted.reshape({N, C, out_D * out_H * out_W * K}))

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -8255,8 +8255,9 @@ static Tensor gs_scatter2d_bc_multi(
       .reshape({N, C, H, W});
 }
 
-// Multi-tap bounded gather for bicubic 3D: the padding maps every tap, as it
-// does in the kernel, instead of the caller having mapped the coordinate once.
+// Multi-tap bounded gather for bicubic 3D: d/h/w_idx [N, Do, Ho, Wo, K] -> [N,
+// C, Do, Ho, Wo, K]. The padding maps every tap, as it does in the kernel,
+// instead of the caller having mapped the coordinate once.
 static Tensor gs_gather3d_bc_multi(
     const Tensor& input,
     const Tensor& d_idx,
@@ -8286,7 +8287,7 @@ static Tensor gs_gather3d_bc_multi(
 }
 
 // Multi-tap bounded scatter for bicubic 3D: values [N,C,Do,Ho,Wo], weights
-// [N,Do,Ho,Wo,K] → [N,C,D,H,W]
+// [N,Do,Ho,Wo,K] -> [N,C,D,H,W]
 static Tensor gs_scatter3d_bc_multi(
     const Tensor& values,
     const Tensor& weights,
@@ -8708,7 +8709,7 @@ std::tuple<Tensor, Tensor, Tensor> grid_sampler_3d_double_backward(
            -((((3 * (A + 2)) * t2) - (2 * (A + 3))) * t2),
            (((-3 * A) * t3) + (10 * A)) * t3 - (8 * A)},
           -1);
-      return std::make_pair(c, dc);
+      return std::make_pair(std::move(c), std::move(dc));
     };
     // only the ggGrid half needs the second derivative, so it is built there
     auto second = [](const Tensor& t) {
@@ -8742,8 +8743,12 @@ std::tuple<Tensor, Tensor, Tensor> grid_sampler_3d_double_backward(
       for (const auto jy : c10::irange(4)) {
         auto y_idx = (y0 + (jy - 1)).unsqueeze(-1).expand_as(x_idx);
         auto z_idx = (z0 + (kz - 1)).unsqueeze(-1).expand_as(x_idx);
-        auto taps = gs_gather3d_bc_multi(
-            input, z_idx, y_idx, x_idx, padding_mode_enum, align_corners);
+        // d_input needs the weights and grad_output, not the input values
+        Tensor taps;
+        if (output_mask[0] || output_mask[2]) {
+          taps = gs_gather3d_bc_multi(
+              input, z_idx, y_idx, x_idx, padding_mode_enum, align_corners);
+        }
 
         auto cy_j = cy.select(-1, jy), dcy_j = dcy.select(-1, jy);
         auto cz_k = cz.select(-1, kz), dcz_k = dcz.select(-1, kz);
@@ -8762,6 +8767,8 @@ std::tuple<Tensor, Tensor, Tensor> grid_sampler_3d_double_backward(
           auto contrib = gs_accum_sumprod_k(taps, B_dx) * ggG_x.unsqueeze(1);
           contrib.addcmul_(gs_accum_sumprod_k(taps, B_dy), ggG_y.unsqueeze(1));
           contrib.addcmul_(gs_accum_sumprod_k(taps, B_dz), ggG_z.unsqueeze(1));
+          // out of place: vmap refuses an in-place accumulation whose
+          // destination is not batched while the chunk's contribution is
           d_grad_output = d_grad_output.defined() ? d_grad_output + contrib
                                                   : std::move(contrib);
         }

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5571,10 +5571,11 @@ def grid_sample(
                        or :math:`(N, D_\text{out}, H_\text{out}, W_\text{out}, 3)` (5-D case)
         mode (str): interpolation mode to calculate output values
             ``'bilinear'`` | ``'nearest'`` | ``'bicubic'``. Default: ``'bilinear'``
-            Note: ``mode='bicubic'`` supports only 4-D input.
             When ``mode='bilinear'`` and the input is 5-D, the interpolation mode
             used internally will actually be trilinear. However, when the input is 4-D,
-            the interpolation mode will legitimately be bilinear.
+            the interpolation mode will legitimately be bilinear. The same holds for
+            ``mode='bicubic'``, which is tricubic on a 5-D input: the same separable
+            cubic kernel over the third axis.
         padding_mode (str): padding mode for outside grid values
             ``'zeros'`` | ``'border'`` | ``'reflection'``. Default: ``'zeros'``
         align_corners (bool, optional): Geometrically, we consider the pixels of the

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5575,7 +5575,7 @@ def grid_sample(
             used internally will actually be trilinear. However, when the input is 4-D,
             the interpolation mode will legitimately be bilinear. Likewise
             ``mode='bicubic'`` is tricubic on a 5-D input, the separable cubic kernel
-            extended over the third axis.
+            extended over the third axis; CPU and CUDA implement the 5-D case.
         padding_mode (str): padding mode for outside grid values
             ``'zeros'`` | ``'border'`` | ``'reflection'``. Default: ``'zeros'``
         align_corners (bool, optional): Geometrically, we consider the pixels of the

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5575,7 +5575,7 @@ def grid_sample(
             used internally will actually be trilinear. However, when the input is 4-D,
             the interpolation mode will legitimately be bilinear. Likewise
             ``mode='bicubic'`` is tricubic on a 5-D input, the separable cubic kernel
-            extended over the third axis; CPU and CUDA implement the 5-D case.
+            extended over the third axis; CPU and CUDA, ROCm included, implement the 5-D case.
         padding_mode (str): padding mode for outside grid values
             ``'zeros'`` | ``'border'`` | ``'reflection'``. Default: ``'zeros'``
         align_corners (bool, optional): Geometrically, we consider the pixels of the

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -5531,8 +5531,8 @@ def grid_sample(
     which are used to interpolate the output value ``output[n, :, h, w]``.
     In the case of 5D inputs, ``grid[n, d, h, w]`` specifies the
     ``x``, ``y``, ``z`` pixel locations for interpolating
-    ``output[n, :, d, h, w]``. :attr:`mode` argument specifies ``nearest`` or
-    ``bilinear`` interpolation method to sample the input pixels.
+    ``output[n, :, d, h, w]``. :attr:`mode` argument specifies ``nearest``,
+    ``bilinear`` or ``bicubic`` interpolation method to sample the input pixels.
 
     :attr:`grid` specifies the sampling pixel locations normalized by the
     :attr:`input` spatial dimensions. Therefore, it should have most values in
@@ -5573,9 +5573,9 @@ def grid_sample(
             ``'bilinear'`` | ``'nearest'`` | ``'bicubic'``. Default: ``'bilinear'``
             When ``mode='bilinear'`` and the input is 5-D, the interpolation mode
             used internally will actually be trilinear. However, when the input is 4-D,
-            the interpolation mode will legitimately be bilinear. The same holds for
-            ``mode='bicubic'``, which is tricubic on a 5-D input: the same separable
-            cubic kernel over the third axis.
+            the interpolation mode will legitimately be bilinear. Likewise
+            ``mode='bicubic'`` is tricubic on a 5-D input, the separable cubic kernel
+            extended over the third axis.
         padding_mode (str): padding mode for outside grid values
             ``'zeros'`` | ``'border'`` | ``'reflection'``. Default: ``'zeros'``
         align_corners (bool, optional): Geometrically, we consider the pixels of the

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21985,6 +21985,11 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             # Only CPU and CUDA sample 5-D bicubic; mps and xpu refuse it in eager, so the
             # 5-D bicubic samples fail every test that runs the op on all of them. The
             # xfails are strict: each flips to a failure once a backend gains the mode.
+            # test_dtypes stays unmarked on purpose: a raising sample only makes a dtype
+            # "partially supported", which is a printed warning, so it keeps passing there
+            # (vacuously, on those two backends). test_out_warning stays unmarked because
+            # the supports_out=False path returns inside its first iteration, and the
+            # first sample is 4-D bilinear.
             # TODO: drop these when mps / xpu implement 5-D bicubic.
             # MPS TestConsistency carries its own entry in common_mps.py.
             DecorateInfo(unittest.expectedFailure, "TestCommon",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8966,9 +8966,13 @@ def sample_inputs_grid_sample(op_info, device, dtype, requires_grad, **kwargs):
     align_cornerss = (False, True)
     padding_modes = ("zeros", "border", "reflection")
 
+    # 5-D bicubic is implemented for CPU and CUDA; the other backends refuse it, and
+    # check_grid_sampler_3d is where they say so.
+    bicubic_dims = (2, 3) if torch.device(device).type in ("cpu", "cuda") else (2,)
+
     for dim in (2, 3):
 
-        modes_ = (*modes, "bicubic") if dim == 2 else modes
+        modes_ = (*modes, "bicubic") if dim in bicubic_dims else modes
 
         for mode, padding_mode, align_corners in itertools.product(modes_, padding_modes, align_cornerss):
             yield SampleInput(

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8968,6 +8968,7 @@ def sample_inputs_grid_sample(op_info, device, dtype, requires_grad, **kwargs):
 
     # 5-D bicubic is implemented for CPU and CUDA; the other backends refuse it, and
     # check_grid_sampler_3d is where they say so.
+    # TODO: yield it for mps, xpu, mtia and privateuse1 too once their 5-D sampler has the mode.
     bicubic_dims = (2, 3) if torch.device(device).type in ("cpu", "cuda") else (2,)
 
     for dim in (2, 3):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -8966,14 +8966,9 @@ def sample_inputs_grid_sample(op_info, device, dtype, requires_grad, **kwargs):
     align_cornerss = (False, True)
     padding_modes = ("zeros", "border", "reflection")
 
-    # 5-D bicubic is implemented for CPU and CUDA; the other backends refuse it, and
-    # check_grid_sampler_3d is where they say so.
-    # TODO: yield it for mps, xpu, mtia and privateuse1 too once their 5-D sampler has the mode.
-    bicubic_dims = (2, 3) if torch.device(device).type in ("cpu", "cuda") else (2,)
-
     for dim in (2, 3):
 
-        modes_ = (*modes, "bicubic") if dim in bicubic_dims else modes
+        modes_ = (*modes, "bicubic")
 
         for mode, padding_mode, align_corners in itertools.product(modes_, padding_modes, align_cornerss):
             yield SampleInput(
@@ -21985,7 +21980,40 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
         sample_inputs_func=sample_inputs_grid_sample,
         reference_inputs_func=reference_inputs_grid_sample,
         supports_gradgrad=True,
-        gradcheck_nondet_tol=1e-15),
+        gradcheck_nondet_tol=1e-15,
+        skips=(
+            # Only CPU and CUDA sample 5-D bicubic; mps and xpu refuse it in eager, so the
+            # 5-D bicubic samples fail every test that runs the op on all of them. The
+            # xfails are strict: each flips to a failure once a backend gains the mode.
+            # TODO: drop these when mps / xpu implement 5-D bicubic.
+            # MPS TestConsistency carries its own entry in common_mps.py.
+            DecorateInfo(unittest.expectedFailure, "TestCommon",
+                         "test_noncontiguous_samples", device_type="mps"),
+            DecorateInfo(unittest.expectedFailure, "TestCommon",
+                         "test_noncontiguous_samples", device_type="xpu"),
+            DecorateInfo(unittest.expectedFailure, "TestCommon",
+                         "test_variant_consistency_eager", device_type="mps"),
+            DecorateInfo(unittest.expectedFailure, "TestCommon",
+                         "test_variant_consistency_eager", device_type="xpu"),
+            # The remaining classes are not instantiated on mps at all.
+            DecorateInfo(unittest.expectedFailure, "TestCompositeCompliance",
+                         "test_operator", device_type="xpu"),
+            DecorateInfo(unittest.expectedFailure, "TestCompositeCompliance",
+                         "test_backward", device_type="xpu"),
+            DecorateInfo(unittest.expectedFailure, "TestCompositeCompliance",
+                         "test_view_replay", device_type="xpu"),
+            DecorateInfo(unittest.expectedFailure, "TestMathBits",
+                         "test_neg_view", device_type="xpu"),
+            DecorateInfo(unittest.expectedFailure, "TestFakeTensor",
+                         "test_fake_crossref_backward_no_amp", device_type="xpu"),
+            DecorateInfo(unittest.expectedFailure, "TestFakeTensor",
+                         "test_fake_crossref_backward_amp", device_type="xpu"),
+            # float64 is claimed on xpu, so the gradient suites reach the samples there.
+            DecorateInfo(unittest.expectedFailure, "TestBwdGradients",
+                         "test_fn_grad", device_type="xpu"),
+            DecorateInfo(unittest.expectedFailure, "TestBwdGradients",
+                         "test_fn_gradgrad", device_type="xpu"),
+        )),
     # TODO: delete this OpInfo once we add meta support for grid_sampler_3d
     OpInfo(
         "grid_sampler_2d",

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -539,6 +539,13 @@ if torch.backends.mps.is_available():
     def mps_ops_grad_modifier(ops: Sequence[OpInfo]) -> Sequence[OpInfo]:
         XFAILLIST_GRAD = {
             # Unimplemented ops
+            # No 5-D bicubic sampler on MPS, so the grad leg fails in its forward
+            # call. The forward entry in UNIMPLEMENTED_XFAILLIST also reaches this
+            # test today, but only because mps_ops_modifier mutates the shared
+            # test_consistency_op_db before the grad db is deep-copied; this line
+            # makes the coverage explicit instead of an ordering accident.
+            # TODO: drop this when MPS has 5-D bicubic.
+            "nn.functional.grid_sample": [torch.float32],
             "sparse.mmreduce": [torch.float32],  # csr not supported
             "linalg.householder_product": None,
             "linalg.lstsq": [torch.float32],

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -62,6 +62,11 @@ if torch.backends.mps.is_available():
         # Those ops are not expected to work
         UNIMPLEMENTED_XFAILLIST: dict[str, list | None] = {
             # Failures due to lack of op implementation on MPS backend
+            # No 5-D bicubic sampler on MPS: the 5-D bicubic samples are yielded on every
+            # backend and GridSampler.mm refuses the mode, so the whole op xfails until MPS
+            # implements it. The f16/bf16 SKIPLIST entry below still intercepts those dtypes.
+            # TODO: drop this when MPS has 5-D bicubic.
+            "nn.functional.grid_sample": None,
             "linalg.eig": None,
             "linalg.eigvals": None,
             "hash_tensor": None,

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -63,10 +63,11 @@ if torch.backends.mps.is_available():
         UNIMPLEMENTED_XFAILLIST: dict[str, list | None] = {
             # Failures due to lack of op implementation on MPS backend
             # No 5-D bicubic sampler on MPS: the 5-D bicubic samples are yielded on every
-            # backend and GridSampler.mm refuses the mode, so the whole op xfails until MPS
-            # implements it. The f16/bf16 SKIPLIST entry below still intercepts those dtypes.
+            # backend and GridSampler.mm refuses the mode, so the op xfails until MPS
+            # implements it. float32 only: the SKIPLIST entry below already skips f16/bf16,
+            # and a skip beats an xfail, so listing them here would be dead weight.
             # TODO: drop this when MPS has 5-D bicubic.
-            "nn.functional.grid_sample": None,
+            "nn.functional.grid_sample": [torch.float32],
             "linalg.eig": None,
             "linalg.eigvals": None,
             "hash_tensor": None,


### PR DESCRIPTION
## Issue

Fixes #194738

## Summary

`grid_sample` accepts 4-D and 5-D input, but `mode='bicubic'` only worked for 4-D. This adds the 5-D
case: the same separable Keys kernel (A = -3/4) applied over the third axis, with forward, backward
and double backward on CPU and CUDA.

The motivation is in the issue. Medical volumes are resampled through a stored transform or a
displacement field, which is exactly what `grid_sample` does, and cubic is the usual interpolation
order for intensity data (ITK uses `BSplineInterpolateImageFunction`, SimpleITK `sitkBSpline`).
Until now a 3-D warp had to fall back to trilinear or gather the 64 neighbours by hand. This came up
in [KonfAI](https://github.com/fideus-labs/KonfAI), a deep-learning framework for medical imaging,
where that hand-written gather lives in `konfai/data/sampling.py`.

#194776 adds the same feature. I had this ready before I saw it, and it differs in three ways that
may be worth picking up either way:

- **The double backward is implemented.** `grid_sampler_3d_double_backward` only handled bilinear,
  so second-order tests raise `NotImplemented` on the new mode. Here it handles bicubic like the 2-D
  version does, with 64 taps instead of 16. That keeps the new OpInfo samples in the autograd
  suites: `test_fn_gradgrad` and functorch's `vjpvjp` and `vmapvjpvjp` pass instead of being skipped.
- **The forward resolves each axis's four taps once per output voxel**, instead of nesting
  `cubic_interp1d` over `get_value_bounded`. On one RTX PRO 5000, a 128^3 volume on a 64^3 grid,
  float32, best of five: 0.23 ms vs 0.43 ms for the nested form, which maps the padding per tap per
  channel instead of once per axis per voxel.
- **`check_grid_sampler_3d` gains a form that only checks the rank.** CPU, CUDA and MPS call it; MPS
  still refuses bicubic in its own wrapper. The form that takes the mode stays for `torch-xpu-ops`,
  which calls it at the commit `third_party/xpu.txt` pins and whose 5-D sampler has bilinear and
  nearest only, with a TODO to drop it.

All four kernels share one new helper, `resolve_cubic_taps`. It returns the four taps of one axis:
their coefficients, the index each one reads, and (for the backward) each coefficient's derivative.
A tap dropped by the padding carries a negative index, contributes zero and keeps its coefficient,
so the 64-tap sum needs no per-tap bounds check.

## Testing

`sample_inputs_grid_sample` now yields the mode for 5-D input on every backend, six samples. On mps
and xpu, where eager refuses the mode, the tests those samples fail carry strict `expectedFailure`
entries (plus one in `common_mps.py` for MPS `TestConsistency`), so each flips to a failure the
moment a backend implements it. The set was derived per test: one that consumes only the first
sample, swallows the raise, or folds a raising sample into "partially supported" keeps passing and
is not marked, since a strict xfail on a passing test is itself a failure. Every suite that reads
`sample_inputs` picks the samples up: `test_ops`, `test_ops_gradients` including
`gradgrad`, `test_meta`, `test_proxy_tensor`, `test_decomp`, `test_autograd`, and functorch's
`vjp`, `vjpvjp` and `vmapvjpvjp`. All pass locally.

Three suites do not see them, none of it new to this mode. Anything reading `reference_inputs` gets
the reference generator instead of the samples, since defining `reference_inputs_func` replaces the
set rather than extending it: that is `test_vmap`'s batch-rule test, and `test_compare_cpu`, which
carries `@skipCUDAIfNotRocm` and so does not run on CUDA for any op. Forward AD is not implemented
for `grid_sampler_3d` at all, so the OpInfo leaves `supports_forward_ad` false and
`test_ops_fwd_gradients` skips the op. And `nn.functional.grid_sample` is in `inductor_one_sample`,
where only the first sample runs.

`bicubic` also joins the mode loop in `test_grid_sample_3d`, which checks values, CPU/CUDA agreement,
`gradcheck` on input and grid, and the empty and 1-voxel shapes. Two new `TestNNDeviceType` tests,
parametrized over padding mode and `align_corners`, compare the 5-D kernel against the 4-D one on a
volume that is constant along the third axis: `test_grid_sample_3d_bicubic_matches_2d` in float64 and
float32, and `test_grid_sample_3d_bicubic_non_finite` on NaN, infinite and far coordinates. The error check that asserted the old refusal now asserts the one MPS raises itself.

Outside the test suite, the forward matches an independent 64-tap reference to 1e-15 in double for
all three padding modes and both `align_corners` settings, and agrees with a hand-written separable
Keys A=-3/4 tricubic to 1.2e-13.

## Benchmarks

float32, best of five, on one RTX PRO 5000 Blackwell and a 24-core host. The last column is a plain
hand-written walk over the 64 neighbours, which is what a 3-D cubic warp needs today.

Forward (ms):

| case | bicubic | bilinear | 64-tap gather |
|---|---|---|---|
| CUDA 128^3 -> 64^3, 1 channel | 0.21 | 0.04 | 11.72 |
| CUDA 128^3 -> 64^3, 3 channels | 0.55 | 0.08 | 10.13 |
| CUDA 256^3 -> 128^3, 1 channel | 1.48 | 0.39 | 55.06 |
| CPU 128^3 -> 64^3, 1 channel | 17.35 | 5.86 | 300.18 |
| CPU 256^3 -> 128^3, 1 channel | 503.00 | 175.00 | 4058.43 |

Backward, input and grid (ms):

| case | bicubic | bilinear |
|---|---|---|
| CUDA 128^3 -> 64^3, 1 channel | 0.95 | 0.36 |
| CUDA 256^3 -> 128^3, 1 channel | 17.15 | 4.09 |
| CPU 128^3 -> 64^3, 1 channel | 75.70 | 18.11 |
| CPU 256^3 -> 128^3, 1 channel | 2258.45 | 562.57 |

## Review follow-ups

- A tap dropped by zero padding carries index -1 and contributes a zero value with its coefficient kept, matching the 4-D convention; the double backward masks dropped taps with `where()` before any product, so an aliased `Inf` can no longer turn into `NaN`, and it walks the taps four at a time instead of materialising 64 index tensors.
- The CUDA mode keeps its own forward and backward kernels: sharing them cost the existing modes their registers (64 to 128, measured slowdowns on bilinear and nearest); split, `grid_sampler_3d_kernel` and its backward disassemble to the same SASS as main.
- The tap extent stays in `index_t` through the padding on the 64-bit kernels and the reflection parity is taken with `fmod`, so no float reaches an integer conversion.
- The meta gate keys on `device_hint`, so an mps or xpu fake tensor fails closed at trace time; single-sided `output_mask`, half/bfloat16 5-D bicubic, the `int64` kernel and non-finite inputs each have targeted tests.
- Known and deferred: the double backward accumulates out of place for vmap and allocates per chunk (follow-up), and the three not-implemented wordings differ per backend.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [x] Updated documentation (if applicable)
- [x] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No. A 5-D input with `mode='bicubic'` used to raise an error and now returns a sample. Backends that
do not implement it still raise, in three wordings that predate this PR except the last:

- `grid_sampler_3d: Unsupported Bicubic interpolation`, MPS forward, a `TORCH_CHECK`
- `grid_sampler(): bicubic interpolation with 5D input is not implemented for <device>`, the MPS
  backward and the overload torch-xpu-ops calls, both `TORCH_CHECK_NOT_IMPLEMENTED`
- `grid_sampler(): bicubic interpolation with 5D input is not supported on <device>`, the meta kernel

The exception types differ where it matters: `TORCH_CHECK_NOT_IMPLEMENTED` reaches the fake-tensor
fallback, a plain `TORCH_CHECK` propagates.

Two behaviour changes outside the new mode:

- The 4-D double backward masks dropped taps with `where()` instead of multiplying by 0, so an `Inf` or `NaN` at a dropped tap no longer turns the gradient into `NaN`.
- Under reflection padding, far outside the grid (past 2^31 folds, around 1e9 in normalized coordinates), 5-D bicubic takes the fold parity with `fmod` while the 4-D helpers count folds in an int, so the two ranks can return different values there.
