### PR TITLE
Fix docker-release validate job to use the channel matching the pushed image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -180,5 +180,8 @@ jobs:
     if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/nightly' || startsWith(github.event.ref, 'refs/tags/v')) }}
     uses: pytorch/test-infra/.github/workflows/validate-docker-images.yml@main
     with:
-      channel: nightly
+      # Must match what `build` above actually pushed, otherwise validate pulls a
+      # tag that was never built: RC tags publish pytorch-test, final release tags
+      # pytorch, and the nightly branch pytorch-nightly.
+      channel: ${{ contains(github.event.ref, '-rc') && 'test' || (startsWith(github.event.ref, 'refs/tags/v') && 'release' || 'nightly') }}
       ref: main


### PR DESCRIPTION
## Summary

The `validate` job in `docker-release.yml` hardcoded `channel: nightly`. On a release-tag push that makes test-infra's `generate_docker_release_matrix.py` take its nightly branch and emit

```
ghcr.io/pytorch/pytorch-nightly:<version>.dev<today>-cuda<x>-cudnn<y>-devel
```

which is only ever built from the `nightly` branch. Every `validate` leg on `v2.14.0-rc7` failed at "Pull docker image" with `manifest unknown`:

```
+ docker pull ghcr.io/pytorch/pytorch-nightly:2.14.0.dev20260824-cuda13.0-cudnn9-devel
Error response from daemon: manifest unknown
```

Failing run: https://github.com/pytorch/pytorch/actions/runs/32788665482/job/97632261400

The `build` job in the same workflow already selects the correct image per trigger — RC tags set `DOCKER_IMAGE=pytorch-test` / `INSTALL_CHANNEL=whl/test`, the nightly branch sets `pytorch-nightly` / `whl/nightly`, and a final release tag falls through to `docker.Makefile`'s default of `pytorch`. Only `validate` was out of sync, so it validated an image nobody had pushed.

## Fix

Derive `channel` from the same ref `build` keys off:

| ref | channel | image looked up |
| --- | --- | --- |
| `refs/tags/v2.14.0-rc7` | `test` | `pytorch-test:2.14.0` |
| `refs/tags/v2.14.0` | `release` | `pytorch:<CURRENT_STABLE_VERSION>` |
| `refs/heads/nightly` | `nightly` | `pytorch-nightly:<version>.dev<today>` |

## Verification

Against GHCR, for the RC7 run that failed:

| image | HTTP |
| --- | --- |
| `pytorch-test:2.14.0-cuda13.0-cudnn9-devel` | **200** — what `build` pushed |
| `pytorch-test:2.14.0-cuda13.0-cudnn9-runtime` | **200** |
| `pytorch-nightly:2.14.0.dev20260824-cuda13.0-cudnn9-devel` | **404** — what `validate` pulled |

The expression was evaluated against all four trigger refs the workflow accepts (`-rc` tag, final tag, `refs/heads/nightly`, `ciflow/nightly/*`) and produces the mapping in the table above. The file parses under `yaml.safe_load`.

## Notes

- **Follow-up needed before GA:** `channel: release` resolves through `CURRENT_STABLE_VERSION` in test-infra's `generate_binary_build_matrix.py`, which is `2.13.0` on both `main` and `release/2.14`. That must be bumped to `2.14.0` before a final `v2.14.0` tag is pushed, or the release leg will look for `pytorch:2.13.0`. Not changed here.
- The `ref: main` input just below is currently a no-op: `validate-docker-images.yml` declares a `ref` input but never uses it (`run-gpu-tests` hardcodes its own `ref`). Left alone to keep this diff to the bug.
- This is intended for cherry-pick to `release/2.14` to unblock RC validation.

---

Filed with the help of Claude Code.
