### PR TITLE
Avoid selective-build dispatch for clamp bound metadata

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -349,7 +349,9 @@ static std::optional<Scalar> prepare_clamp_bound(
   if (!isIntegralType(dtype, /*includeBool=*/false)) {
     return scalar;
   }
-  const auto [below, above] = AT_DISPATCH_V2(
+  // This dispatch only reads dtype metadata, so it must not become a
+  // selective-build kernel tag.
+  const auto [below, above] = THO_DISPATCH_V2(
       dtype,
       "prepare_clamp_bound",
       AT_WRAP([&] { return clamp_bound_range<scalar_t>(scalar); }),


### PR DESCRIPTION
Summary:
D116736970 added prepare_clamp_bound with AT_DISPATCH_V2. In mobile selective builds, that creates a new kernel tag which is absent from existing model YAML files, so models that clamp integral tensors fail with "dtype 'Long' not selected for kernel tag prepare_clamp_bound".

Use THO_DISPATCH_V2 for this metadata-only dtype dispatch. It preserves the same scalar_t specializations while avoiding selective-build gating and kernel-dtype recording. Apply the change to both the fbcode and xplat mirrors.

This consolidates the root-cause fixes proposed in D117095602 and D117096132 into the smaller header-only dispatch implementation.

Authored with assistance from Codex, an AI coding assistant.

Test Plan:
```
buck2 test fbsource//xplat/pytorch_models/build/face_parsing_int8/v1006:e2e_fp_fd_resize_real_bundle_300_nhwc_img_test fbsource//xplat/pytorch_models/build/speech_asr_ig_voice_memo-en_US/v6:pytorchmodel.pt_test fbsource//xplat/pytorch_models/build/oacr_milan_on_wearable_native_en_US_capture_asr_map_pytorchmodel.pt/v873:model_test
```
Passed: 3 tests, 0 failures.

```
buck2 test fbcode//caffe2/test:torch -- --regex 'test_clamp'
```
Passed: 16 tests, 0 failures.

Android variants for the three sampled model tests were also attempted together, but all three were blocked before execution by the same test-environment error: "Unable to set up adb". Test session: https://www.internalfb.com/intern/testinfra/testrun/1125900429709767

The successful CXX model test session is https://www.internalfb.com/intern/testinfra/testrun/29273397606559493 and the clamp regression session is https://www.internalfb.com/intern/testinfra/testrun/9288674424274607.

Differential Revision: D117393201


