### PR TITLE
[Inductor] Add a Gluon template frontend, first used by flex_attention on gfx950

### DIFF
--- a/test/inductor/test_flex_attention.py
+++ b/test/inductor/test_flex_attention.py
@@ -192,6 +192,27 @@ def skip_on_xpu(test_func):
 skip_on_mps = skipMPSIf(True, "Not supported on MPS")
 
 
+@functools.lru_cache
+def _is_gfx950() -> bool:
+    """True on the AMD target the Gluon flex-attention template targets.
+
+    Matches the hook's own test (an exact target, not the gfx95 family), so this
+    cannot enable the tests on a part where the hook declines to offer a body.
+    """
+    if not (torch.cuda.is_available() and torch.version.hip):
+        return False
+    try:
+        arch = torch.cuda.get_device_properties(0).gcnArchName
+    except Exception:
+        return False
+    return arch.split(":", 1)[0].startswith("gfx950")
+
+
+# Not bound as skipUnless(_is_gfx950(), ...) here: that evaluates at module scope
+# and so initializes CUDA during collection on every platform. The class below
+# checks it in setUpClass instead, which runs only if its tests are selected.
+
+
 def _is_not_implemented_exc(exc):
     """True if `exc` is or wraps a NotImplementedError (Dynamo/Inductor wrap it)."""
     seen = set()
@@ -10528,6 +10549,366 @@ class TestLearnableBiases(InductorTestCase):
                 lambda msg: f"{msg}\n{name} -> Ref error: {ref_error}, Flex eager Error: {flex_error}",
             )
 
+
+class TestGluonFlexAttention(InductorTestCase):
+    """The Gluon (Triton low-level frontend) flex-attention template on gfx950.
+
+    The template is an extra autotuning candidate, so these tests force it with
+    ``autotune_choice_name_regex`` and assert a Gluon kernel was really emitted --
+    without that check a green test would only prove the Triton template is correct.
+    """
+
+    B, H, S = 2, 4, 512
+    TOL = {torch.float16: 2e-2, torch.bfloat16: 3e-2}
+
+    @classmethod
+    def setUpClass(cls):
+        if not _is_gfx950():
+            raise unittest.SkipTest(
+                "Gluon flex-attention is only offered on AMD gfx950"
+            )
+        super().setUpClass()
+
+    def _inputs(self, dtype, head_dim, seq_len=None):
+        torch.manual_seed(0)
+        return [
+            torch.randn(
+                self.B,
+                self.H,
+                seq_len or self.S,
+                head_dim,
+                device="cuda",
+                dtype=dtype,
+            )
+            for _ in range(3)
+        ]
+
+    @staticmethod
+    def _src(code):
+        return "\n".join(code) if isinstance(code, (list, tuple)) else str(code)
+
+    @classmethod
+    def _emitted_gluon(cls, code):
+        return "@gluon.jit" in cls._src(code)
+
+    @classmethod
+    def _emitted_async(cls, code):
+        # only the async body stages through the DMA intrinsic
+        return "buffer_load_to_shared" in cls._src(code)
+
+    def _patches(self, *, enabled=True, force="gluon_flex_attention"):
+        # Just the one config value, which is what a caller sets: the handler that
+        # reads it is installed on import. Every forced test below emitting a Gluon
+        # kernel is what proves that install is still happening.
+        return config.patch(
+            {
+                "max_autotune": True,
+                "force_disable_caches": True,
+                "gluon_flex_attention": enabled,
+                "test_configs.autotune_choice_name_regex": force or None,
+            }
+        )
+
+    def _compile(self, fn, args, *, enabled=True, force="gluon_flex_attention"):
+        torch._dynamo.reset()
+        with self._patches(enabled=enabled, force=force):
+            out, code = run_and_get_code(torch.compile(fn, fullgraph=True), *args)
+        torch.cuda.synchronize()
+        return out, code
+
+    def _check(
+        self,
+        *,
+        dtype,
+        head_dim,
+        mask_fn=None,
+        score_mod=None,
+        seq_len=None,
+        sparse_block_size=None,
+        force="gluon_flex_attention",
+    ):
+        seq_len = seq_len or self.S
+        q, k, v = self._inputs(dtype, head_dim, seq_len)
+        scale = head_dim**-0.5
+        mask_kwargs = (
+            {} if sparse_block_size is None else {"BLOCK_SIZE": sparse_block_size}
+        )
+        block_mask = (
+            create_block_mask(
+                mask_fn, self.B, self.H, seq_len, seq_len, device="cuda", **mask_kwargs
+            )
+            if mask_fn is not None
+            else None
+        )
+
+        def fn(q, k, v):
+            return flex_attention(
+                q, k, v, score_mod=score_mod, block_mask=block_mask, scale=scale
+            )
+
+        expected = fn(q, k, v)
+        actual, code = self._compile(fn, (q, k, v), force=force)
+        if force:
+            self.assertTrue(self._emitted_gluon(code), "no Gluon kernel was emitted")
+        tol = self.TOL[dtype]
+        self.assertEqual(actual.float(), expected.float(), atol=tol, rtol=tol)
+        return code
+
+    # (mask_fn, score_mod) for each branch the template specializes on.
+    MODS = {
+        "identity": (None, None),
+        "causal": (lambda b, h, m, n: m >= n, None),
+        "softcap": (None, lambda s, b, h, m, n: 20.0 * torch.tanh(s / 20.0)),
+        "head_bias": (None, lambda s, b, h, m, n: s - 0.125 * h),
+    }
+
+    @common_utils.parametrize("case", list(MODS))
+    def test_score_and_mask_mods(self, case):
+        """Identity, mask_mod-only, and both score_mod flavours the template branches on."""
+        mask_fn, score_mod = self.MODS[case]
+        self._check(
+            dtype=torch.float16,
+            head_dim=64,
+            mask_fn=mask_fn,
+            score_mod=score_mod,
+        )
+
+    @common_utils.parametrize(
+        "dtype,head_dim,masked",
+        [
+            common_utils.subtest((torch.bfloat16, 64, True), name="bf16_64_causal"),
+            common_utils.subtest((torch.float16, 128, True), name="fp16_128_causal"),
+            common_utils.subtest((torch.bfloat16, 128, False), name="bf16_128_dense"),
+        ],
+    )
+    def test_dtypes_and_head_dims(self, dtype, head_dim, masked):
+        """Both supported head dims, since each selects a different DMA staging layout."""
+        mask_fn = (lambda b, h, m, n: m >= n) if masked else None
+        self._check(dtype=dtype, head_dim=head_dim, mask_fn=mask_fn)
+
+    @common_utils.parametrize(
+        "dtype,masked",
+        [
+            common_utils.subtest((torch.float16, False), name="fp16_dense"),
+            common_utils.subtest((torch.bfloat16, True), name="bf16_causal"),
+        ],
+    )
+    def test_logsumexp(self, dtype, masked):
+        """LSE feeds the backward pass, so a wrong one is invisible in the output."""
+        q, k, v = self._inputs(dtype, 64)
+        block_mask = (
+            create_block_mask(
+                lambda b, h, m, n: m >= n,
+                self.B,
+                self.H,
+                self.S,
+                self.S,
+                device="cuda",
+            )
+            if masked
+            else None
+        )
+
+        def fn(q, k, v):
+            return flex_attention(
+                q, k, v, block_mask=block_mask, scale=0.125, return_lse=True
+            )
+
+        ref_out, ref_lse = fn(q, k, v)
+        (out, lse), code = self._compile(fn, (q, k, v))
+        self.assertTrue(self._emitted_gluon(code))
+        tol = self.TOL[dtype]
+        self.assertEqual(out.float(), ref_out.float(), atol=tol, rtol=tol)
+        self.assertEqual(lse.float(), ref_lse.float(), atol=tol, rtol=tol)
+
+    def test_fully_masked_rows(self):
+        """Rows with no legal key: the -inf row max must not become NaN."""
+        q, k, v = self._inputs(torch.float16, 64)
+        block_mask = create_block_mask(
+            lambda b, h, m, n: m < 0, self.B, self.H, self.S, self.S, device="cuda"
+        )
+
+        def fn(q, k, v):
+            return flex_attention(q, k, v, block_mask=block_mask, scale=0.125)
+
+        expected = fn(q, k, v)
+        actual, _ = self._compile(fn, (q, k, v))
+        self.assertTrue(
+            torch.isfinite(actual).all(), "masked-out rows produced NaN/inf"
+        )
+        self.assertEqual(float(actual.abs().max()), 0.0)
+        tol = self.TOL[torch.float16]
+        self.assertEqual(actual.float(), expected.float(), atol=tol, rtol=tol)
+
+    def test_unforced_autotune_winner_is_correct(self):
+        """How a user actually runs it: the Gluon body only competes, and may lose."""
+        q, k, v = self._inputs(torch.float16, 64)
+
+        def fn(q, k, v):
+            return flex_attention(q, k, v, scale=0.125)
+
+        expected = fn(q, k, v)
+        actual, _ = self._compile(fn, (q, k, v), force=False)
+        tol = self.TOL[torch.float16]
+        self.assertEqual(actual.float(), expected.float(), atol=tol, rtol=tol)
+
+    @common_utils.parametrize("seq_len", [500, 4000])
+    def test_non_divisible_kv_len(self, seq_len):
+        """A KV_LEN that BLOCK_N does not divide must not reach the async body.
+
+        That body stages K/V by unmasked DMA and clamps a prefetch which would
+        overrun to KV_LEN - BLOCK_N, which is a block start only when BLOCK_N
+        divides KV_LEN. Offered anyway, the final block scores staged rows against
+        the column indices of a different block: 33% relative error at S=4000,
+        picked by ordinary autotuning rather than needing to be forced.
+        """
+        # forced, so the sync body still has to be correct here
+        code = self._check(dtype=torch.float16, head_dim=64, seq_len=seq_len)
+        self.assertFalse(
+            self._emitted_async(code),
+            "async body offered at a KV_LEN it cannot stage correctly",
+        )
+        # and again as a user would run it, with the body only competing
+        self._check(dtype=torch.float16, head_dim=64, seq_len=seq_len, force=False)
+
+    def test_sparse_block_hanging_off_the_end(self):
+        """BLOCK_N | KV_LEN is the async gate even though sparse blocks can overhang.
+
+        KV_LEN=320 with the default 128 sparse block passes the gate (320 % 64 == 0)
+        while sparse block 2 spans [256, 384), so it hangs off the end -- and this
+        mask leaves a row whose *only* block is that one, which is the case where the
+        prefetch clamp could bite. It is nonetheless safe, and not by luck:
+        IS_DIVISIBLE is ``KV_LEN % 128 == 0 and (KV_LEN % SPARSE_KV == 0 or
+        SPARSE_KV >= KV_LEN)``, so an overhanging block forces it False and the body
+        takes its masked path. When it is True no block can overhang. Gating on
+        SPARSE_KV instead would cost the async body every unmasked shape, since
+        SPARSE_KV is 2**30 there.
+        """
+        sparse = 128
+        seq_len = 320
+        code = self._check(
+            dtype=torch.float16,
+            head_dim=64,
+            mask_fn=lambda b, h, m, n: n >= 2 * sparse,
+            seq_len=seq_len,
+            sparse_block_size=sparse,
+            force="gluon_flex_attention_async",
+        )
+        self.assertTrue(
+            self._emitted_async(code),
+            "async body did not run, so this asserts nothing about it",
+        )
+
+    @common_utils.parametrize("head_dim", [64, 128])
+    def test_irregularly_gapped_mask(self, head_dim):
+        """The async prefetch must track the block it is actually filling.
+
+        The slot refilled at iteration i is next read at i + NUM_BUF, so the
+        prefetch advances by that iteration's delta. Advancing by iteration i's
+        delta instead only agrees when the scheduled block starts are evenly
+        spaced, which dense and causal both are -- so this needs a mask whose
+        kv_indices has *irregular* gaps. Uniform gaps do not reach it: with
+        SPARSE_KV_MULTIPLE=2 the deltas alternate and every jump is equal.
+
+        Unfixed this gave 183% relative error at head_dim 64 and 109% at 128, and
+        the async body won ordinary autotuning at both.
+        """
+        legal = (0, 5, 6, 9)
+
+        def mask_mod(b, h, m, n):
+            blk = n // 128
+            keep = blk == legal[0]
+            for idx in legal[1:]:
+                keep = keep | (blk == idx)
+            return keep
+
+        code = self._check(
+            dtype=torch.float16,
+            head_dim=head_dim,
+            mask_fn=mask_mod,
+            seq_len=2048,
+            force="gluon_flex_attention_async",
+        )
+        self.assertTrue(
+            self._emitted_async(code),
+            "async body did not run, so this asserts nothing about it",
+        )
+
+    @common_utils.parametrize(
+        "dtype,head_dim",
+        [
+            common_utils.subtest((torch.float16, 64), name="fp16_64"),
+            common_utils.subtest((torch.bfloat16, 128), name="bf16_128"),
+        ],
+    )
+    def test_tall_query_tile(self, dtype, head_dim):
+        """BLOCK_M=256 is offered only without a block mask, so cover that path.
+
+        create_block_mask defaults to a 128 sparse Q block and 128 % 256 != 0, so a
+        masked run filters these configs out and with them the num_warps=8 rows of
+        the DMA ladder.
+        """
+        self._check(dtype=dtype, head_dim=head_dim, mask_fn=None)
+
+    def test_negative_scale(self):
+        """A negative scale must not take the identity fold.
+
+        The fold subtracts ``max(qk) * QK_SCALE`` instead of the row max of the
+        scaled scores, which is the row *min* once QK_SCALE is negative. Softmax is
+        invariant to what constant it subtracts, so this only costs stability -- but
+        it costs all of it: the exp2 arguments become ``|QK_SCALE|`` times the score
+        span, and once that passes fp32's exp2 range the output is NaN. scale=-1.0
+        at head_dim 128 puts it near 160, where it does.
+        """
+        head_dim = 128
+        q, k, v = self._inputs(torch.float16, head_dim)
+
+        def fn(q, k, v):
+            return flex_attention(q, k, v, scale=-1.0)
+
+        expected = fn(q, k, v)
+        actual, _ = self._compile(fn, (q, k, v))
+        self.assertTrue(torch.isfinite(actual).all(), "negative scale overflowed")
+        tol = self.TOL[torch.float16]
+        self.assertEqual(actual.float(), expected.float(), atol=tol, rtol=tol)
+
+    def test_single_switch(self):
+        """The config flag is the whole interface; nothing else has to be set.
+
+        ``heuristics/template/gluon.py`` installs the choices handler when
+        ``torch._inductor`` is imported, which is what lets the flag mean anything.
+        The forced tests above would all stop emitting a Gluon kernel if that
+        regressed; this names the reason so the failure is not a mystery.
+        """
+        from torch._inductor.kernel.flex.gluon_flex import (
+            enable_gluon_flex_attention,
+            GluonInductorChoices,
+        )
+
+        factory = config.inductor_choices_class
+        self.assertIsNotNone(factory, "no choices factory was installed on import")
+        self.assertIsInstance(factory(), GluonInductorChoices)
+        with config.patch({}):
+            enable_gluon_flex_attention()
+            self.assertTrue(config.gluon_flex_attention)
+
+    def test_disabled_is_a_no_op(self):
+        """With the config flag off, no Gluon kernel may be emitted."""
+        q, k, v = self._inputs(torch.float16, 64)
+
+        def fn(q, k, v):
+            return flex_attention(q, k, v, scale=0.125)
+
+        expected = fn(q, k, v)
+        actual, code = self._compile(fn, (q, k, v), enabled=False, force=False)
+        self.assertFalse(
+            self._emitted_gluon(code), "Gluon kernel emitted while the flag was off"
+        )
+        tol = self.TOL[torch.float16]
+        self.assertEqual(actual.float(), expected.float(), atol=tol, rtol=tol)
+
+
+common_utils.instantiate_parametrized_tests(TestGluonFlexAttention)
 
 instantiate_device_type_tests(
     TestFlexAttention,

--- a/torch/_inductor/codegen/gluon/__init__.py
+++ b/torch/_inductor/codegen/gluon/__init__.py
@@ -1,0 +1,15 @@
+"""Gluon (Triton's low-level frontend) template support for Inductor.
+
+``gluon_template`` holds the target-neutral frontend: ``@gluon.jit`` codegen and
+the op lowerings Gluon's explicit layouts force. Every other module here binds
+one Gluon target namespace and takes its name -- ``cdna4`` wraps
+``gluon.language.amd.cdna4``. That split follows the frontend itself, which is
+namespaced per target (``gluon.language.amd`` has cdna3, cdna4, gfx1250, rdna3
+and rdna4; ``gluon.language.nvidia`` has ampere through rubin) because the
+families share no matmul or async-copy primitives.
+
+A target module carries only the imports its kernel bodies need. The geometry
+those bodies are written against -- matmul tile, wavefront width, staging
+layouts -- stays with the kernel that offers them, as in
+``inductor/kernel/flex/gluon_flex.py``.
+"""

--- a/torch/_inductor/codegen/gluon/cdna4.py
+++ b/torch/_inductor/codegen/gluon/cdna4.py
@@ -1,0 +1,24 @@
+# mypy: allow-untyped-defs
+"""CDNA4 (AMD gfx950) target bindings for Gluon templates.
+
+The intrinsics a CDNA4 kernel body uses: the MFMA layout and matmul, and the
+``buffer_load_to_shared`` async-copy namespace. See ``GLUON_BASE_IMPORTS`` in
+gluon_template.py for what belongs here versus in the shared layer.
+"""
+
+from .gluon_template import GluonTemplate, GluonTemplateKernel
+
+
+CDNA4_IMPORTS = """
+from triton.experimental.gluon.language.amd import AMDMFMALayout
+from triton.experimental.gluon.language.amd.cdna4 import mfma as mfma_cdna4
+from triton.experimental.gluon.language.amd.cdna4 import async_copy as cdna4_async
+"""
+
+
+class Cdna4GluonTemplateKernel(GluonTemplateKernel):
+    target_imports = CDNA4_IMPORTS
+
+
+class Cdna4GluonTemplate(GluonTemplate):
+    kernel_type = Cdna4GluonTemplateKernel

--- a/torch/_inductor/codegen/gluon/gluon_template.py
+++ b/torch/_inductor/codegen/gluon/gluon_template.py
@@ -1,0 +1,120 @@
+# mypy: allow-untyped-defs
+"""Gluon (Triton's low-level frontend) template support for Inductor.
+
+Gluon kernels are ``@gluon.jit`` functions that expose explicit tile layouts,
+shared-memory descriptors and target intrinsics (CDNA4 ``mfma``, TMA/MMA), which
+lets an expert hand-tune past what Triton's automatic codegen achieves.
+
+``GluonJITFunction`` subclasses ``triton.runtime.jit.JITFunction`` and launches
+identically to a Triton kernel, and ``tl.*`` pointwise ops are valid inside a
+``@gluon.jit`` body (layouts are inferred from the operands). So a Gluon
+template can reuse the entire Triton template path -- ``TritonTemplateKernel``
+codegen (``def_kernel``/``modification``/``store_output``), ``TritonScheduling``
+and ``async_compile.triton`` -- and only the emitted imports and the jit
+decorator differ.
+"""
+
+import math
+from functools import lru_cache
+
+import torch
+from torch._inductor.codegen.simd import constant_repr
+from torch._inductor.codegen.triton import triton_compute_type, TritonKernelOverrides
+from torch._inductor.select_algorithm import TritonTemplate, TritonTemplateKernel
+
+
+# Imports every generated Gluon kernel needs, regardless of target: the frontend
+# plus the target-neutral layout classes from ``gluon.language._layouts``.
+#
+# Anything under ``gluon.language.amd.*`` or ``gluon.language.nvidia.*`` is a
+# target intrinsic and belongs in a target's ``target_imports`` instead -- the
+# families do not share primitives (CDNA4 has mfma + buffer_load_to_shared,
+# gfx1250 has wmma + tensor descriptors + mbarrier, NVIDIA has mma + TMA), so a
+# kernel body is written per target and only the scaffolding is shared.
+GLUON_BASE_IMPORTS = """
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language._layouts import (
+    DistributedLinearLayout,
+    DotOperandLayout,
+    PaddedSharedLayout,
+)
+"""
+
+
+class GluonKernelOverrides(TritonKernelOverrides):
+    """Triton op lowerings adjusted for Gluon's explicit-layout tensors.
+
+    Gluon tensor constructors (``gl.full``/``gl.zeros``) require an explicit
+    layout, which generated subgraph code has no way to pick: the right layout
+    depends on the tile the constant is combined with. Emit *typed scalars*
+    instead -- they broadcast against a tile of any layout.
+
+    This mirrors ``TritonOverrides._shaped_constant``, including its ``-0.0``
+    bit-pattern round-trip, so a fix to either belongs in both. The divergence is
+    forced rather than chosen: the base materializes scalars as ``tl.full([], v,
+    t)``, and that does not compile inside a ``@gluon.jit`` body even though an
+    empty shape needs no layout. ``tl.cast`` is what does. The base's note about
+    ``tl.full`` being what stops subnormal fp32 from promoting to fp64 does not
+    reproduce on Triton 3.8 -- ``tl.full``, ``tl.cast`` and a bare literal all
+    give bit-identical fp32 results there -- so there is no known cost to it.
+    """
+
+    @classmethod
+    def constant(cls, value, dtype):
+        type_ = torch._prims_common.dtype_to_type(dtype)
+        triton_type = triton_compute_type(dtype)
+
+        if value == 0 and math.copysign(1.0, value) < 0:
+            # -0.0 does not survive a scalar literal (-0.0 == 0 in Python), so
+            # round-trip the IEEE 754 bit pattern.
+            if triton_type == "tl.float32":
+                return f"tl.cast(0x80000000, tl.uint32).to({triton_type}, bitcast=True)"
+            if triton_type == "tl.float64":
+                return (
+                    f"tl.cast(0x8000000000000000, tl.uint64)"
+                    f".to({triton_type}, bitcast=True)"
+                )
+
+        triton_val = constant_repr(type_(value))
+        if value < 0 and not dtype.is_signed:
+            signed_type = f"tl.{triton_type[4:]}"
+            return f"tl.cast({triton_val}, {signed_type}).to({triton_type})"
+        return f"tl.cast({triton_val}, {triton_type})"
+
+
+class GluonTemplateKernel(TritonTemplateKernel):
+    """TritonTemplateKernel that emits a ``@gluon.jit`` kernel.
+
+    Target-neutral: subclass and set ``target_imports`` to the intrinsics a
+    target's kernel bodies use. ``gen_common_triton_imports`` is cached per
+    ``cls``, so each target subclass gets its own cache entry.
+
+    Everything else (signature generation, subgraph ``modification()`` rendering
+    for score_mod/mask_mod, ``store_output``, argument plumbing and the kernel
+    call) is inherited unchanged.
+    """
+
+    overrides = GluonKernelOverrides  # type: ignore[assignment]
+
+    # Set by target subclasses; see GLUON_BASE_IMPORTS.
+    target_imports: str = ""
+
+    @classmethod
+    @lru_cache(None)
+    def gen_common_triton_imports(cls) -> str:
+        return (
+            super().gen_common_triton_imports()
+            + GLUON_BASE_IMPORTS
+            + cls.target_imports
+        )
+
+    def jit_lines(self) -> str:
+        # Keep @triton_heuristics.template(...) -- the autotuner drives a
+        # GluonJITFunction the same way it drives a JITFunction -- and swap only
+        # the frontend decorator.
+        return super().jit_lines().replace("@triton.jit", "@gluon.jit")
+
+
+class GluonTemplate(TritonTemplate):
+    kernel_type = GluonTemplateKernel

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -3097,6 +3097,13 @@ _cache_config_serializer = _serialize_inductor_choices
 # External callable for matmul tuning candidates
 external_matmul: list[Callable[[torch.Tensor, torch.Tensor, torch.Tensor], None]] = []
 
+# Experimental: offer a hand-tuned Gluon (Triton's low-level frontend) template
+# as a flex-attention autotuning candidate, which autotuning then picks or drops
+# on measured time. This is the only switch -- the handler that reads it is
+# installed on import -- but it still applies on ROCm gfx950 alone, and is a no-op
+# anywhere else.
+gluon_flex_attention: bool = False
+
 write_are_deterministic_algorithms_enabled = (
     os.getenv("TORCHINDUCTOR_WRITE_ARE_DETERMINISTIC_ALGORITHMS_ENABLED", "1") == "1"
 )

--- a/torch/_inductor/heuristics/template/__init__.py
+++ b/torch/_inductor/heuristics/template/__init__.py
@@ -16,6 +16,7 @@ from . import (
     base,
     contiguous_mm,
     decompose_k,
+    gluon,
     nv_universal_gemm,
     registry,
     tlx,

--- a/torch/_inductor/heuristics/template/gluon.py
+++ b/torch/_inductor/heuristics/template/gluon.py
@@ -1,0 +1,41 @@
+# Installs the choices handler that reads config.gluon_flex_attention, on import,
+# the way TLX does -- so that config is the single switch and a caller does not
+# also have to know which choices class implements the seam.
+#
+# The factory has to be lazy: this module is imported during choices.py's own
+# import (via heuristics/template/__init__), so InductorChoices does not exist yet
+# and GluonInductorChoices cannot be constructed until later.
+#
+# ROCm-only because installing a factory is what gives the handler a uuid() in the
+# cache key, and a build with no Gluon body should not pay a key change for it.
+# Gluon itself need not be present in the installed Triton: the frontend emits its
+# gluon imports into generated kernels as text, so a ROCm build on trunk Triton
+# loads this and simply offers no candidate.
+import logging
+
+import torch
+
+from torch._inductor import config
+
+
+log = logging.getLogger(__name__)
+
+
+def _gluon_inductor_choices():
+    from torch._inductor.kernel.flex.gluon_flex import GluonInductorChoices
+
+    return GluonInductorChoices()
+
+
+if torch.version.hip:
+    if config.inductor_choices_class is None:
+        config.inductor_choices_class = _gluon_inductor_choices
+    else:
+        # Someone else owns the seam; theirs wins. Gluon then offers nothing even
+        # with the config on, so say so rather than fail silently.
+        log.debug(
+            "config.inductor_choices_class is already set to %s, so the Gluon "
+            "flex-attention choices were not installed; subclass "
+            "GluonInductorChoices to offer both.",
+            config.inductor_choices_class,
+        )

--- a/torch/_inductor/kernel/flex/gluon_dma_layouts.py
+++ b/torch/_inductor/kernel/flex/gluon_dma_layouts.py
@@ -1,0 +1,113 @@
+# mypy: allow-untyped-defs
+"""DMA staging layouts for the Gluon flex-attention templates.
+
+``buffer_load_to_shared`` writes LDS directly and needs exact register/lane/warp
+bases saying which lane of which wave moves which element. These cannot be
+improvised -- the plain Blocked/Swizzled layouts fail to lower -- so these tables
+are the ones taken from the hand-tuned gfx950 kernel.
+
+They are data rather than a branch chain in the template so that the hook and the
+body cannot disagree: the hook offers the async body exactly when a key is
+present, and the body renders its layouts from the value. Adding a combination
+(BLOCK_N=32 and 128 are the unexplored ones) is a new entry and nothing else.
+"""
+
+from typing import NamedTuple
+
+
+class DmaLayouts(NamedTuple):
+    """Linear-layout bases for staging one K^T tile and one V tile into LDS.
+
+    ``*_offset_bases`` map a shared-memory offset to tile coordinates; the
+    ``reg``/``lane``/``warp`` bases say how far along each tile dimension to move
+    when the corresponding bit of the register / lane / warp index flips.
+    """
+
+    kt_offset_bases: list[list[int]]
+    kt_reg_bases: list[list[int]]
+    kt_lane_bases: list[list[int]]
+    kt_warp_bases: list[list[int]]
+    v_offset_bases: list[list[int]]
+    v_reg_bases: list[list[int]]
+    v_lane_bases: list[list[int]]
+    v_warp_bases: list[list[int]]
+
+
+# K^T is staged [head_dim, BLOCK_N] and V is staged [BLOCK_N, head_dim], so their
+# bases are mirror images of each other. The offset bases depend only on the tile
+# shape; the reg/lane/warp split depends on how many waves share the transfer.
+_KT_OFFSETS_128 = [
+    [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0], [64, 0],
+    [0, 16], [0, 32], [0, 1], [0, 2], [0, 4], [0, 8],
+]  # fmt: skip
+_V_OFFSETS_128 = [
+    [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32], [0, 64],
+    [16, 0], [32, 0], [1, 0], [2, 0], [4, 0], [8, 0],
+]  # fmt: skip
+_KT_OFFSETS_64 = [
+    [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [32, 0],
+    [0, 16], [0, 32], [0, 1], [0, 2], [0, 4], [0, 8],
+]  # fmt: skip
+_V_OFFSETS_64 = [
+    [0, 1], [0, 2], [0, 4], [0, 8], [0, 16], [0, 32],
+    [16, 0], [32, 0], [1, 0], [2, 0], [4, 0], [8, 0],
+]  # fmt: skip
+
+
+# (QK_HEAD_DIM_ROUNDED, BLOCK_N, num_warps) -> layouts
+CDNA4_DMA_LADDER: dict[tuple[int, int, int], DmaLayouts] = {
+    (128, 64, 8): DmaLayouts(
+        kt_offset_bases=_KT_OFFSETS_128,
+        kt_reg_bases=[[1, 0], [2, 0], [4, 0], [0, 8]],
+        kt_lane_bases=[[8, 0], [16, 0], [32, 0], [64, 0], [0, 16], [0, 32]],
+        kt_warp_bases=[[0, 1], [0, 2], [0, 4]],
+        v_offset_bases=_V_OFFSETS_128,
+        v_reg_bases=[[0, 1], [0, 2], [0, 4], [8, 0]],
+        v_lane_bases=[[0, 8], [0, 16], [0, 32], [0, 64], [16, 0], [32, 0]],
+        v_warp_bases=[[1, 0], [2, 0], [4, 0]],
+    ),
+    (128, 64, 4): DmaLayouts(
+        kt_offset_bases=_KT_OFFSETS_128,
+        kt_reg_bases=[[1, 0], [2, 0], [4, 0], [0, 8], [0, 4]],
+        kt_lane_bases=[[8, 0], [16, 0], [32, 0], [64, 0], [0, 16], [0, 32]],
+        kt_warp_bases=[[0, 1], [0, 2]],
+        v_offset_bases=_V_OFFSETS_128,
+        v_reg_bases=[[0, 1], [0, 2], [0, 4], [8, 0], [4, 0]],
+        v_lane_bases=[[0, 8], [0, 16], [0, 32], [0, 64], [16, 0], [32, 0]],
+        v_warp_bases=[[1, 0], [2, 0]],
+    ),
+    (64, 64, 8): DmaLayouts(
+        kt_offset_bases=_KT_OFFSETS_64,
+        kt_reg_bases=[[1, 0], [2, 0], [4, 0]],
+        kt_lane_bases=[[8, 0], [16, 0], [32, 0], [0, 16], [0, 32], [0, 1]],
+        kt_warp_bases=[[0, 2], [0, 4], [0, 8]],
+        v_offset_bases=_V_OFFSETS_64,
+        v_reg_bases=[[0, 1], [0, 2], [0, 4]],
+        v_lane_bases=[[0, 8], [0, 16], [0, 32], [16, 0], [32, 0], [1, 0]],
+        v_warp_bases=[[2, 0], [4, 0], [8, 0]],
+    ),
+    (64, 64, 4): DmaLayouts(
+        kt_offset_bases=_KT_OFFSETS_64,
+        kt_reg_bases=[[1, 0], [2, 0], [4, 0], [0, 8]],
+        kt_lane_bases=[[8, 0], [16, 0], [32, 0], [0, 16], [0, 32], [0, 1]],
+        kt_warp_bases=[[0, 2], [0, 4]],
+        v_offset_bases=_V_OFFSETS_64,
+        v_reg_bases=[[0, 1], [0, 2], [0, 4], [8, 0]],
+        v_lane_bases=[[0, 8], [0, 16], [0, 32], [16, 0], [32, 0], [1, 0]],
+        v_warp_bases=[[2, 0], [4, 0]],
+    ),
+}
+
+
+def as_template_options(layouts: DmaLayouts) -> dict[str, list[list[int]]]:
+    """Template options the async body renders its layout declarations from."""
+    return {
+        "GLUON_KT_OFFSET_BASES": layouts.kt_offset_bases,
+        "GLUON_KT_REG_BASES": layouts.kt_reg_bases,
+        "GLUON_KT_LANE_BASES": layouts.kt_lane_bases,
+        "GLUON_KT_WARP_BASES": layouts.kt_warp_bases,
+        "GLUON_V_OFFSET_BASES": layouts.v_offset_bases,
+        "GLUON_V_REG_BASES": layouts.v_reg_bases,
+        "GLUON_V_LANE_BASES": layouts.v_lane_bases,
+        "GLUON_V_WARP_BASES": layouts.v_warp_bases,
+    }

--- a/torch/_inductor/kernel/flex/gluon_flex.py
+++ b/torch/_inductor/kernel/flex/gluon_flex.py
@@ -1,0 +1,367 @@
+# mypy: allow-untyped-defs
+"""Gluon FlexAttention templates for Inductor.
+
+Offers hand-tuned Gluon flash-attention forward kernels as flex-attention
+autotuning candidates through ``InductorChoices.append_flex_attention_choices``
+(the extension seam TLX uses). ``heuristics/template/gluon.py`` installs the
+handler on import, so ``config.gluon_flex_attention`` is the only switch.
+
+A template is a ``GluonTemplate`` -- a ``TritonTemplate`` that emits a
+``@gluon.jit`` body -- so ``score_mod``/``mask_mod`` are rendered by Inductor's
+existing ``modification()`` machinery and the kernel runs through the standard
+Triton scheduling/compile path.
+
+Targets are described by ``GluonFlexTarget``: matmul tile geometry, which
+template bodies exist, and the DMA staging ladder. Kernel *bodies* are per target
+because Gluon's primitives differ by family, but everything here -- config
+filtering, subgraph rendering, autotuning -- is shared. Adding a target is a new
+descriptor plus its template files.
+"""
+
+import dataclasses
+import functools
+import hashlib
+import logging
+from typing import Any, NamedTuple
+from typing_extensions import override
+
+import torch
+from torch._inductor import config
+from torch._inductor.choices import InductorChoices
+from torch._inductor.codegen.gluon.cdna4 import Cdna4GluonTemplate
+from torch._inductor.codegen.gluon.gluon_template import GluonTemplate
+
+from .common import load_flex_template
+from .gluon_dma_layouts import as_template_options, CDNA4_DMA_LADDER, DmaLayouts
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True, eq=False)
+class GluonFlexTarget:
+    """Everything target-specific about offering a Gluon flex-attention body.
+
+    ``eq=False`` keeps the default identity hash, so a target can be used as a
+    cache key. Field-based equality would hash ``dma_ladder`` and fail, which is
+    also why this is not a NamedTuple -- being a tuple implies hashability that a
+    mapping field does not provide.
+    """
+
+    name: str
+    # gfx target this descriptor's bodies were written and measured against,
+    # matched exactly rather than as a family prefix
+    arch_prefix: str
+    template_cls: type[GluonTemplate]
+    sync_template: str
+    # None when the target has no async body yet; only the sync one is offered.
+    async_template: str | None
+    # Matmul instruction tile (MFMA on CDNA, WMMA on RDNA/gfx1250, MMA on NVIDIA).
+    mma_m: int
+    mma_n: int
+    max_warps: int
+    # Wavefront width the template's layouts are declared against. GluonASTSource
+    # stamps ttg.threads-per-warp from this, so a wave32 target that inherited 64
+    # would fail layout verification rather than run slowly.
+    threads_per_warp: int
+    # (head_dim, block_n, num_warps) -> staging layouts for the async body.
+    dma_ladder: dict[tuple[int, int, int], DmaLayouts]
+
+    def warps_for(self, block_m: int) -> int:
+        """The matmul layout splits BLOCK_M across waves."""
+        return min(self.max_warps, max(1, block_m // self.mma_m))
+
+    def tiles_evenly(self, block_m: int, block_n: int) -> bool:
+        """Blocks smaller than one matmul tile give a degenerate layout."""
+        return block_m % self.mma_m == 0 and block_n % self.mma_n == 0
+
+
+CDNA4_TARGET = GluonFlexTarget(
+    name="cdna4",
+    arch_prefix="gfx950",
+    template_cls=Cdna4GluonTemplate,
+    sync_template="gluon_flex_attention",
+    async_template="gluon_flex_attention_async",
+    mma_m=32,
+    mma_n=32,
+    max_warps=8,
+    threads_per_warp=64,
+    dma_ladder=CDNA4_DMA_LADDER,
+)
+
+# Every target the module knows about. Both the arch lookup and the template
+# digest iterate this, so adding one cannot leave either behind.
+TARGETS: tuple[GluonFlexTarget, ...] = (CDNA4_TARGET,)
+
+
+@functools.cache
+def _target_for_arch(arch: str) -> GluonFlexTarget | None:
+    """The descriptor for a bare gfx target name, or None.
+
+    Matched exactly rather than as a gfx95 family prefix: the bodies below are
+    written against CDNA4's matmul geometry and wavefront width, so a later gfx95*
+    part should fall back to Triton until someone measures it, not inherit layouts
+    silently.
+    """
+    for target in TARGETS:
+        if arch.startswith(target.arch_prefix):
+            return target
+    return None
+
+
+def _active_target(device: Any = None) -> GluonFlexTarget | None:
+    """The descriptor for this device, or None if no Gluon body targets it."""
+    if not torch.version.hip:
+        return None
+    try:
+        # The compiling device, not device 0: a host can mix architectures, and
+        # Inductor compiles for wherever the inputs live.
+        index = device.index if getattr(device, "index", None) is not None else None
+        arch = torch.cuda.get_device_properties(index).gcnArchName
+    except Exception:
+        return None
+    return _target_for_arch(arch.split(":", 1)[0])
+
+
+@functools.cache
+def _get_gluon_flex_template(target: GluonFlexTarget, name: str) -> GluonTemplate:
+    from .flex_attention import flex_attention_grid
+
+    return target.template_cls(
+        name=name,
+        grid=flex_attention_grid,
+        source=load_flex_template(name) + load_flex_template("utilities"),
+        always_freeze_layout=True,
+    )
+
+
+def _async_body(
+    target: GluonFlexTarget, conf: Any, kernel_options: dict[str, Any], kv_len: Any
+) -> tuple[str, DmaLayouts] | None:
+    """This config's async body and its staging layouts, or None if unsupported.
+
+    This *is* the gate: the async body renders its layout declarations from these
+    values, so a config is offered exactly when the ladder has an entry for it.
+    """
+    from torch._inductor.virtualized import V
+
+    name = target.async_template
+    if name is None:
+        return None
+    qk_rounded = kernel_options.get("QK_HEAD_DIM_ROUNDED")
+    v_rounded = kernel_options.get("V_HEAD_DIM_ROUNDED")
+    # The ladder is keyed on one head dim; K^T and V are staged with the same one.
+    if qk_rounded is None or qk_rounded != v_rounded:
+        return None
+    # The DMA spans the rounded head dim with no mask, so a head dim that had to be
+    # rounded up would stage past the end of K/V. The sync body masks and handles it.
+    if not kernel_options.get("SAFE_HEAD_DIM"):
+        return None
+    # The async body stages K/V by unmasked DMA, so it clamps a prefetch that would
+    # run past the end of the tensor to KV_LEN - BLOCK_N. That is a block start only
+    # when BLOCK_N divides KV_LEN; otherwise the final block stages rows other than
+    # the ones mask_mod/score_mod are told it staged, and the results are wrong
+    # rather than imprecise. A dynamic KV_LEN cannot prove the property, so it also
+    # takes the sync body.
+    #
+    # BLOCK_N is the right quantity even though a *sparse* block can overhang KV_LEN
+    # (KV_LEN=320 with the default 128 leaves block 2 spanning [256, 384)). The clamp
+    # only matters on an unmasked block, and IS_DIVISIBLE -- KV_LEN % 128 == 0 and
+    # (KV_LEN % SPARSE_KV == 0 or SPARSE_KV >= KV_LEN) -- is necessarily False
+    # whenever a block overhangs, so the body masks in exactly those cases and no
+    # block overhangs when it is True. Gating on SPARSE_KV instead would drop the
+    # async body on every unmasked shape, where it is 2**30.
+    if not V.graph.sizevars.statically_known_multiple_of(kv_len, conf.block_n):
+        return None
+    key = (qk_rounded, conf.block_n, kernel_options["num_warps"])
+    layouts = target.dma_ladder.get(key)
+    return None if layouts is None else (name, layouts)
+
+
+@functools.cache
+def _template_digest() -> str:
+    """Short digest of every Gluon template body, for cache keying."""
+    h = hashlib.sha256()
+    for target in TARGETS:
+        for name in (target.sync_template, target.async_template):
+            if name is not None:
+                h.update(load_flex_template(name).encode())
+    return h.hexdigest()[:16]
+
+
+class _ExtraConfig(NamedTuple):
+    """A block shape offered on top of the ones flex proposes."""
+
+    block_m: int
+    block_n: int
+
+
+# flex's own config list stops at BLOCK_M=128, but a taller query tile is what the
+# hand-tuned gfx950 kernel runs: one K/V block then serves twice the query rows, so
+# the DMA traffic per unit of math halves. Only usable when the sparse Q block is a
+# multiple of it, which the loop below already checks.
+EXTRA_CONFIGS = (_ExtraConfig(256, 64), _ExtraConfig(256, 32))
+
+
+def _score_mod_is_identity(subgraphs, sm_scale: Any) -> bool:
+    """True when score_mod passes the score through unchanged.
+
+    Inductor lowers an identity score_mod to a buffer that just reads the
+    ``score`` input, so the template can then fold sm_scale into the same FMA
+    that does the exp2 change of base instead of scaling the tile separately.
+
+    Two invariants this depends on. The detection reads Inductor's lowering of an
+    identity subgraph, so a *false* answer only costs the fold while a *true* one
+    makes the template skip score_mod entirely -- if that lowering ever stops
+    producing an InputBuffer for the identity, this has to fail closed. And the
+    fold scales the row max instead of the tile, which reorders max and multiply,
+    so it holds only for a positive scale; a negative one would turn the row max
+    into a row min and overflow the exp2. The Triton template scales the tile
+    first and so does not care about the sign.
+    """
+    from torch._inductor import ir
+
+    if not subgraphs:
+        return False
+    if not isinstance(sm_scale, (int, float)) or sm_scale <= 0:
+        return False
+    return isinstance(getattr(subgraphs[0], "data", None), ir.InputBuffer)
+
+
+class GluonInductorChoices(InductorChoices):
+    """InductorChoices that offers the Gluon flash-attention templates."""
+
+    def uuid(self) -> str:
+        # This handler is installed on every ROCm build (see
+        # heuristics/template/gluon.py), so keep the digest out of the key until
+        # the flag is on: otherwise editing a template body would invalidate
+        # cached choices for callers who never offer a Gluon candidate.
+        if not config.gluon_flex_attention:
+            return "gluon-flex-attention-disabled"
+        # Derived from the template sources so editing a body invalidates cached
+        # choices without anyone remembering to bump a version string.
+        return f"gluon-flex-attention-{_template_digest()}"
+
+    @override
+    def append_flex_attention_choices(
+        self,
+        choices: list[Any],
+        configs: list[Any],
+        input_nodes: list[Any],
+        subgraphs: list[Any],
+        layout: Any,
+        kernel_options: dict[str, Any],
+        sparse_q_block_size: int,
+        sparse_kv_block_size: int,
+    ) -> list[Any]:
+        query, _key, _value, logsumexp, max_scores = input_nodes[:5]
+        target = _active_target(query.get_device())
+        if not config.gluon_flex_attention or target is None:
+            return choices
+
+        if query.get_dtype() not in (torch.float16, torch.bfloat16):
+            return choices
+
+        # These bodies pick their own block shape and schedule, so offering one
+        # would quietly hand back a kernel built with something other than what
+        # the caller pinned. Leave the Triton candidates to honour it instead.
+        if any(
+            k in kernel_options
+            for k in ("num_warps", "num_stages", "fwd_num_warps", "fwd_num_stages")
+        ):
+            return choices
+
+        # None of this depends on the block shape, so build it once rather than
+        # per config.
+        base_opts = kernel_options.copy()
+        for k in list(base_opts.keys()):
+            if k.startswith("fwd_"):
+                base_opts[k[4:]] = base_opts.pop(k)
+            elif k.startswith("bwd_"):
+                base_opts.pop(k)
+        base_opts["USE_TMA"] = False
+        base_opts["GLUON_THREADS_PER_WARP"] = target.threads_per_warp
+        score_mod_is_identity = _score_mod_is_identity(
+            subgraphs, base_opts.get("SM_SCALE")
+        )
+        # The Gluon body schedules its own loop; keep Triton's software pipeliner
+        # out of it.
+        base_opts["num_stages"] = 1
+        base_opts.setdefault("SPARSE_Q_BLOCK_SIZE", sparse_q_block_size)
+        base_opts.setdefault("SPARSE_KV_BLOCK_SIZE", sparse_kv_block_size)
+        # Validate against the effective sizes rather than the arguments: the
+        # setdefaults above leave a caller-pinned value in place, and that is what
+        # the kernel is built with. Same reasoning as the Triton path.
+        sparse_q = base_opts["SPARSE_Q_BLOCK_SIZE"]
+        sparse_kv = base_opts["SPARSE_KV_BLOCK_SIZE"]
+
+        kv_len = _key.get_size()[2]
+        for conf in tuple(configs) + EXTRA_CONFIGS:
+            if not target.tiles_evenly(conf.block_m, conf.block_n):
+                continue
+            if sparse_kv % conf.block_n != 0 or sparse_q % conf.block_m != 0:
+                continue
+
+            opts = dict(base_opts)
+            opts["BLOCK_M"] = conf.block_m
+            opts["BLOCK_N"] = conf.block_n
+            opts["num_warps"] = target.warps_for(conf.block_m)
+
+            # Offer the synchronous body always, and the async one wherever the
+            # ladder has staging layouts, so autotuning picks between them.
+            bodies: list[tuple[str, DmaLayouts | None]] = [(target.sync_template, None)]
+            async_body = _async_body(target, conf, opts, kv_len)
+            if async_body is not None:
+                bodies.append(async_body)
+
+            for template_name, dma_layouts in bodies:
+                body_opts = dict(opts)
+                # The async body is exactly the one carrying staging layouts, so
+                # test for those rather than compare template names: the same
+                # invariant, but one a type checker can follow.
+                if dma_layouts is not None:
+                    body_opts.update(as_template_options(dma_layouts))
+                    # LDS ring depth: measured 2 > 3 > 4 on gfx950 (deeper rings
+                    # cost more occupancy at D=128 than the extra overlap buys:
+                    # 608 -> 559 TFLOPS non-causal).
+                    body_opts["GLUON_NUM_BUF"] = 2
+                    body_opts["SCORE_MOD_IS_IDENTITY"] = score_mod_is_identity
+                # Unrolling the KV loop pays off on some shapes and costs on
+                # others (it helps D=64 causal, hurts D=128), so offer both and
+                # let autotuning decide per shape. Only the async body reads it.
+                for unroll in (1, 2) if dma_layouts is not None else (None,):
+                    if unroll is not None:
+                        body_opts["GLUON_UNROLL"] = unroll
+                    error = _get_gluon_flex_template(
+                        target, template_name
+                    ).maybe_append_choice(
+                        choices=choices,
+                        input_nodes=input_nodes,
+                        layout=layout,
+                        subgraphs=subgraphs,
+                        mutated_inputs=[logsumexp, max_scores],
+                        call_sizes=query.get_size(),
+                        **body_opts,
+                    )
+                    if error is not None:
+                        log.debug(
+                            "gluon flex choice skipped: target=%s body=%s "
+                            "BLOCK_M=%s BLOCK_N=%s unroll=%s: %s: %s",
+                            target.name,
+                            template_name,
+                            conf.block_m,
+                            conf.block_n,
+                            unroll,
+                            type(error).__name__,
+                            error,
+                        )
+        return choices
+
+
+def enable_gluon_flex_attention() -> None:
+    """Turn on the Gluon flex-attention choices (currently AMD gfx950 only).
+
+    The choices handler is installed on import (heuristics/template/gluon.py), so
+    this is only the config flag and is equivalent to setting it directly.
+    """
+    config.gluon_flex_attention = True

--- a/torch/_inductor/kernel/flex/templates/gluon_flex_attention.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/gluon_flex_attention.py.jinja
@@ -1,0 +1,288 @@
+{#- One KV loop over the block-sparse column list, staged through gl.load.
+    full=false walks the partially-masked blocks and applies mask_mod;
+    full=true walks the fully-unmasked ones and skips it. Emitted twice by
+    the two call sites below -- a macro rather than a @gluon.jit helper so
+    the generated code is unchanged and the hot loop keeps its register
+    allocation. -#}
+{%- macro kv_loop(full) %}
+{%- set kv_idx_name = "FULL_KV_IDX" if full else "KV_IDX" %}
+{%- set kv_nblk_name = "FULL_KV_NUM_BLKS" if full else "KV_NUM_BLKS" %}
+    kv_indices = {{ kv_idx_name }} + sparse_kv_idx_offset
+    kv_start = tl.load(kv_indices) * SPARSE_KV_BLOCK_SIZE
+    kv_num_blocks = tl.load({{ kv_nblk_name }} + sparse_kv_num_blks_offset)
+    block_n_end = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+    offs_n_base = kv_start
+    # Build the K/V pointer tiles once and advance them by the block stride each
+    # iteration: rebuilding them from offs_n_base costs a multiply-add per
+    # element per block, which dominates the vector-ALU count in this loop.
+    kt_ptrs = (k_base + kt_offs_d[:, None].to(INDEX_DTYPE) * stride_kk
+               + (offs_n_base + kt_offs_n)[None, :].to(INDEX_DTYPE) * stride_kn)
+    v_ptrs = (v_base + (offs_n_base + v_offs_n)[:, None].to(INDEX_DTYPE) * stride_vn
+              + offs_vd[None, :].to(INDEX_DTYPE) * stride_vk)
+    for start_n in range(0, block_n_end):
+        offs_n_mma = offs_n_base + gl.arange(0, BLOCK_N, layout=mma_offs_n_col)
+
+        # -- V tile: V depends on neither the QK MFMA nor the softmax, so issue
+        #    its global load up front and overlap that latency with both.
+        {%- if IS_DIVISIBLE and SAFE_HEAD_DIM %}
+        v = gl.load(v_ptrs)
+        {%- else %}
+        v = gl.load(v_ptrs, mask=((offs_n_base + v_offs_n)[:, None] < KV_LEN)
+                    & (offs_vd[None, :] < V_HEAD_DIM), other=0.0)
+        {%- endif %}
+
+        # -- K^T tile: global -> LDS -> MFMA operand --
+        {%- if IS_DIVISIBLE and SAFE_HEAD_DIM %}
+        kt = gl.load(kt_ptrs)
+        {%- else %}
+        kt = gl.load(kt_ptrs, mask=((offs_n_base + kt_offs_n)[None, :] < KV_LEN)
+                     & (kt_offs_d[:, None] < QK_HEAD_DIM), other=0.0)
+        {%- endif %}
+        kt_smem.store(kt)
+        # Read the MFMA operand straight out of LDS rather than going back through
+        # registers and converting layout there.
+        kt_dot = kt_smem.load(kt_dot_layout)
+
+        qk = gl.zeros([BLOCK_M, BLOCK_N], dtype=gl.float32, layout=mma_layout)
+        qk = mfma_cdna4(q_dot, kt_dot, qk)
+        qk = qk * SM_SCALE
+
+        # -- score_mod / mask_mod on the score tile --
+        # IS_DIVISIBLE means the sparse blocks tile Q/KV exactly, so no index can
+        # run past the end and the wrap is dead work. Same skip the async body and
+        # the Triton flex templates make.
+        {%- if IS_DIVISIBLE %}
+        m = offs_m_mma[:, None]
+        n = offs_n_mma[None, :]
+        {%- else %}
+        m = get_bounded_indices(offs_m_mma[:, None], Q_LEN)
+        n = get_bounded_indices(offs_n_mma[None, :], KV_LEN)
+        {%- endif %}
+
+        {{ modification(
+            subgraph_number=0,
+            output_name="post_mod_scores",
+            score="qk",
+            b="off_zq",
+            h="off_hq",
+            m="m",
+            n="n",
+            out="qk",
+            input_shapes={
+                "score": ("BLOCK_M", "BLOCK_N"),
+                "m": ("BLOCK_M", "1"),
+                "n": ("1", "BLOCK_N"),
+            },
+            input_dtypes={"b": "index", "h": "index", "m": "index", "n": "index"},
+        ) | indent_except_first(2) }}
+
+{%- if not full %}
+        {{ modification(
+            subgraph_number=1,
+            output_name="mask_mod_output",
+            score="qk",
+            b="off_zq",
+            h="off_hq",
+            m="m",
+            n="n",
+            input_shapes={
+                "score": ("BLOCK_M", "BLOCK_N"),
+                "m": ("BLOCK_M", "1"),
+                "n": ("1", "BLOCK_N"),
+            },
+            input_dtypes={"b": "index", "h": "index", "m": "index", "n": "index"},
+        ) | indent_except_first(2) }}
+
+        # Out-of-range keys are masked out regardless of mask_mod. Gluon keeps
+        # layouts explicit: the masked-off value is a materialized tile in the
+        # score layout, not a bare scalar (which would leave the result's layout
+        # unconstrained and break the row reduction below).
+        mask_mod_output = mask_mod_output & (offs_n_mma[None, :] < KV_LEN)
+        post_mod_scores = gl.where(mask_mod_output, post_mod_scores, neg_inf_tile)
+{%- else %}
+        post_mod_scores = gl.where(offs_n_mma[None, :] < KV_LEN, post_mod_scores, neg_inf_tile)
+{%- endif %}
+        post_mod_scores = post_mod_scores * RCP_LN2
+
+        # -- online softmax --
+        m_ij = gl.maximum(m_i, gl.max(post_mod_scores, axis=1))
+        m_ij_safe = gl.where(m_ij == float("-inf"), zero_row, m_ij)
+        alpha = gl.exp2(m_i - m_ij_safe)
+        p = gl.exp2(post_mod_scores - m_ij_safe[:, None])
+        l_i = l_i * alpha + gl.sum(p, axis=1)
+        acc = acc * alpha[:, None]
+
+        # -- V tile: global -> LDS -> MFMA operand; acc += P @ V --
+        v_smem.store(v)
+        v_dot = v_smem.load(v_dot_layout)
+        p_dot = gl.convert_layout(p.to(MATMUL_PRECISION), p_dot_layout)
+        acc = mfma_cdna4(p_dot, v_dot, acc)
+        m_i = m_ij
+
+        block_off = get_offset_for_next_block(
+            start_n, kv_indices, kv_num_blocks,
+            SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+        )
+        offs_n_base = offs_n_base + block_off
+        kt_ptrs = kt_ptrs + block_off.to(INDEX_DTYPE) * stride_kn
+        v_ptrs = v_ptrs + block_off.to(INDEX_DTYPE) * stride_vn
+{%- endmacro %}
+{{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX")}}
+    # Gluon FlexAttention forward (AMD CDNA4 / gfx950).
+    #
+    # Same FlexAttention scaffolding as the Triton template -- block-sparse KV
+    # iteration, score_mod/mask_mod rendered by modification(), logsumexp/max --
+    # with the compute body written in Gluon: explicit MFMA/dot-operand layouts,
+    # LDS staging through shared-memory descriptors, and CDNA4 mfma.
+    #
+    # tl.* pointwise ops (what modification()/store_output emit) are valid inside
+    # a @gluon.jit body; layouts are inferred from the operands.
+
+    tl.static_assert(SPARSE_Q_BLOCK_SIZE >= BLOCK_M and SPARSE_Q_BLOCK_SIZE % BLOCK_M == 0)
+    tl.static_assert(SPARSE_KV_BLOCK_SIZE >= BLOCK_N and SPARSE_KV_BLOCK_SIZE % BLOCK_N == 0)
+
+    stride_qz, stride_qh, stride_qm, stride_qk = {{stride("Q")}}
+    stride_kz, stride_kh, stride_kn, stride_kk = {{stride("K")}}
+    stride_vz, stride_vh, stride_vn, stride_vk = {{stride("V")}}
+
+    ZQ = {{size("Q", 0)}}
+    HQ = {{size("Q", 1)}}
+    Q_LEN = {{size("Q", 2)}}
+    ZKV = {{size("K", 0)}}
+    KV_LEN = {{size("K", 2)}}
+
+    MATMUL_PRECISION = Q.dtype.element_ty
+    RCP_LN2: tl.constexpr = 1.44269504
+
+    # ---------------- Gluon layouts ----------------
+    num_warps: gl.constexpr = gl.num_warps()
+    threads_per_warp: gl.constexpr = GLUON_THREADS_PER_WARP
+    k_width: gl.constexpr = 8
+    pv_k_width: gl.constexpr = 4
+
+    mma_layout: gl.constexpr = AMDMFMALayout(version=4, instr_shape=[32, 32, 16],
+                                             transposed=True, warps_per_cta=[num_warps, 1])
+    q_dot_layout: gl.constexpr = DotOperandLayout(operand_index=0, parent=mma_layout, k_width=k_width)
+    kt_dot_layout: gl.constexpr = DotOperandLayout(operand_index=1, parent=mma_layout, k_width=k_width)
+    p_dot_layout: gl.constexpr = DotOperandLayout(operand_index=0, parent=mma_layout, k_width=pv_k_width)
+    v_dot_layout: gl.constexpr = DotOperandLayout(operand_index=1, parent=mma_layout, k_width=pv_k_width)
+
+    # Row-major blocked layout for global loads/stores of [*, HEAD_DIM] tiles.
+    blocked_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 8], threads_per_warp=[threads_per_warp // 4, 4],
+        warps_per_cta=[num_warps, 1], order=[1, 0])
+    # K is consumed transposed: [HEAD_DIM, BLOCK_N].
+    kt_blocked_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 1], threads_per_warp=[1, threads_per_warp],
+        warps_per_cta=[1, num_warps], order=[0, 1])
+
+    offs_m_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked_layout)
+    offs_d_layout: gl.constexpr = gl.SliceLayout(dim=0, parent=blocked_layout)
+    offs_n_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked_layout)
+    kt_offs_d_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=kt_blocked_layout)
+    kt_offs_n_layout: gl.constexpr = gl.SliceLayout(dim=0, parent=kt_blocked_layout)
+    # Slices of the MFMA layout: the score tile lives in mma_layout, so the m/n
+    # index tensors handed to score_mod/mask_mod must be slices of it.
+    mma_offs_m_row: gl.constexpr = gl.SliceLayout(dim=1, parent=mma_layout)
+    mma_offs_n_col: gl.constexpr = gl.SliceLayout(dim=0, parent=mma_layout)
+    mma_m_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=mma_layout)
+
+    # ---------------- program ids ----------------
+    q_start = gl.program_id(0)
+    off_zq = gl.program_id(1)
+    off_hq = gl.program_id(2)
+
+    # KV may be broadcast along batch (ZKV == 1) and shared across query heads (GQA).
+    off_zkv = off_zq % ZKV
+    off_hkv = off_hq // GQA_SHARED_HEADS
+
+    q_base = Q + off_zq * stride_qz + off_hq * stride_qh
+    k_base = K + off_zkv * stride_kz + off_hkv * stride_kh
+    v_base = V + off_zkv * stride_vz + off_hkv * stride_vh
+
+    # ---------------- block-sparse bookkeeping ----------------
+    SPARSE_Z = {{size("KV_NUM_BLKS", 0)}}
+    SPARSE_HQ = {{size("KV_NUM_BLKS", 1)}}
+    sparse_idx_z = off_zq % SPARSE_Z
+    sparse_idx_hq = off_hq % SPARSE_HQ
+    SPARSE_Q_MULTIPLE: tl.constexpr = (SPARSE_Q_BLOCK_SIZE // BLOCK_M)
+    SPARSE_KV_MULTIPLE: tl.constexpr = (SPARSE_KV_BLOCK_SIZE // BLOCK_N)
+    stride_kv_num_blks_h = {{stride("KV_NUM_BLKS", 1)}}
+    stride_kv_idx_h = {{stride("KV_IDX", 1)}}
+    stride_kv_idx_m = {{stride("KV_IDX", 2)}}
+    sparse_hz_offset = sparse_idx_z * SPARSE_HQ + sparse_idx_hq
+    sparse_kv_num_blks_offset = sparse_hz_offset * stride_kv_num_blks_h + q_start // SPARSE_Q_MULTIPLE
+    sparse_kv_idx_offset = sparse_hz_offset * stride_kv_idx_h + (q_start // SPARSE_Q_MULTIPLE) * stride_kv_idx_m  # noqa: B950
+
+    # ---------------- offsets ----------------
+    # Two flavors of the m/d offsets: blocked (global loads + epilogue stores)
+    # and mma-slice (score tile masking + the mod subgraphs).
+    offs_m = q_start * BLOCK_M + gl.arange(0, BLOCK_M, layout=offs_m_layout)
+    offs_d = gl.arange(0, QK_HEAD_DIM_ROUNDED, layout=offs_d_layout)
+    offs_vd = gl.arange(0, V_HEAD_DIM_ROUNDED, layout=offs_d_layout)
+    offs_m_mma = q_start * BLOCK_M + gl.arange(0, BLOCK_M, layout=mma_offs_m_row)
+    kt_offs_d = gl.arange(0, QK_HEAD_DIM_ROUNDED, layout=kt_offs_d_layout)
+    kt_offs_n = gl.arange(0, BLOCK_N, layout=kt_offs_n_layout)
+    v_offs_n = gl.arange(0, BLOCK_N, layout=offs_n_layout)
+
+    # ---------------- load Q into registers (dot operand layout) ----------------
+    q_smem = gl.allocate_shared_memory(
+        Q.dtype.element_ty, [BLOCK_M, QK_HEAD_DIM_ROUNDED],
+        layout=gl.SwizzledSharedLayout(vec=8, per_phase=1, max_phase=16, order=[1, 0]))
+    q_ptrs = q_base + offs_m[:, None].to(INDEX_DTYPE) * stride_qm + offs_d[None, :].to(INDEX_DTYPE) * stride_qk
+    q = gl.load(q_ptrs, mask=(offs_m[:, None] < Q_LEN) & (offs_d[None, :] < QK_HEAD_DIM), other=0.0)
+    q_smem.store(q)
+    q_dot = q_smem.load(q_dot_layout)
+
+    # ---------------- LDS staging for K^T / V ----------------
+    kt_smem = gl.allocate_shared_memory(
+        Q.dtype.element_ty, [QK_HEAD_DIM_ROUNDED, BLOCK_N],
+        layout=gl.SwizzledSharedLayout(vec=8, per_phase=1, max_phase=16, order=[0, 1]))
+    v_smem = gl.allocate_shared_memory(
+        Q.dtype.element_ty, [BLOCK_N, V_HEAD_DIM_ROUNDED],
+        layout=gl.SwizzledSharedLayout(vec=8, per_phase=1, max_phase=16, order=[1, 0]))
+
+    # ---------------- accumulators ----------------
+    m_i = gl.full([BLOCK_M], float("-inf"), dtype=gl.float32, layout=mma_m_layout)
+    l_i = gl.zeros([BLOCK_M], dtype=gl.float32, layout=mma_m_layout)
+    acc = gl.zeros([BLOCK_M, V_HEAD_DIM_ROUNDED], dtype=gl.float32, layout=mma_layout)
+
+    # Constants used as gl.where arms must carry the layout of the tile they
+    # select into, so materialize them once here.
+    neg_inf_tile = gl.full([BLOCK_M, BLOCK_N], float("-inf"), dtype=gl.float32, layout=mma_layout)
+    zero_row = gl.zeros([BLOCK_M], dtype=gl.float32, layout=mma_m_layout)
+    one_row = gl.full([BLOCK_M], 1.0, dtype=gl.float32, layout=mma_m_layout)
+
+    # ==================== partial blocks: score_mod AND mask_mod ====================
+{{ kv_loop(false) }}
+
+    # ==================== full blocks: score_mod only ====================
+    if HAS_FULL_BLOCKS:
+{{ kv_loop(true) | indent(4) }}
+
+    # ==================== epilogue ====================
+    # Fully-masked rows have l_i == 0 and m_i == -inf; normalize by 1 so
+    # out/lse come out as 0 (matching the Triton template).
+    l_i = gl.where(l_i == 0.0, one_row, l_i)
+    acc = acc / l_i[:, None]
+
+    idx_zq = off_zq
+    idx_hq = off_hq
+    idx_m = offs_m[:, None].to(INDEX_DTYPE)
+    idx_d = offs_vd[None, :].to(INDEX_DTYPE)
+    mask = (idx_m < Q_LEN) & (idx_d < V_HEAD_DIM)
+    acc_out = gl.convert_layout(acc, blocked_layout)
+
+    {{store_output(("idx_zq", "idx_hq", "idx_m", "idx_d"), "acc_out", "mask", val_shape=("BLOCK_M", "V_HEAD_DIM_ROUNDED"))}}
+
+    if OUTPUT_LOGSUMEXP:
+        off_hz = off_zq * HQ + off_hq
+        lse = m_i + gl.log2(l_i)
+        lse_blk = gl.convert_layout(lse, offs_m_layout)
+        gl.store(LSE + off_hz * Q_LEN + offs_m, lse_blk, mask=offs_m < Q_LEN)
+
+    if OUTPUT_MAX:
+        off_hz = off_zq * HQ + off_hq
+        m_blk = gl.convert_layout(m_i, offs_m_layout)
+        gl.store(MAX + off_hz * Q_LEN + offs_m, m_blk, mask=offs_m < Q_LEN)

--- a/torch/_inductor/kernel/flex/templates/gluon_flex_attention_async.py.jinja
+++ b/torch/_inductor/kernel/flex/templates/gluon_flex_attention_async.py.jinja
@@ -1,0 +1,343 @@
+{#- One KV loop over the block-sparse column list, staged by async DMA.
+    full=false walks the partially-masked blocks and applies mask_mod;
+    full=true walks the fully-unmasked ones and skips it. Emitted twice by
+    the two call sites below -- a macro rather than a @gluon.jit helper so
+    the generated code is unchanged and the hot loop keeps its register
+    allocation. -#}
+{%- macro kv_loop(full) %}
+{%- set kv_idx_name = "FULL_KV_IDX" if full else "KV_IDX" %}
+{%- set kv_nblk_name = "FULL_KV_NUM_BLKS" if full else "KV_NUM_BLKS" %}
+    kv_indices = {{ kv_idx_name }} + sparse_kv_idx_offset
+    # Clamped because this index is read whatever kv_num_blocks says, and a
+    # BlockMask that has been _adjust()ed keeps cropped-out indices in place -- so
+    # for a row left with no blocks it can still name one past KV_LEN. The
+    # prologue below issues its DMAs before block_n_end is consulted. Buffer loads
+    # bounds-check on CDNA, so an unclamped address reads zeros rather than
+    # faulting, but nothing here should rest on that.
+    kv_start = tl.minimum(tl.load(kv_indices) * SPARSE_KV_BLOCK_SIZE, last_start)
+    kv_num_blocks = tl.load({{ kv_nblk_name }} + sparse_kv_num_blks_offset)
+    block_n_end = tl.minimum(kv_num_blocks * SPARSE_KV_MULTIPLE, tl.maximum(tl.cdiv(KV_LEN, BLOCK_N), 1))
+
+{%- if full %}
+    gl.barrier()
+{%- endif %}
+    # Prime the pipeline: start the DMA for the first NUM_BUF blocks.
+    n_ahead = kv_start
+    for stage in gl.static_range(NUM_BUF):
+        cdna4_async.buffer_load_to_shared(kt_smem.index(stage), k_base,
+                                          kt_dma_off + n_ahead.to(INDEX_DTYPE) * stride_kn)
+        cdna4_async.buffer_load_to_shared(v_smem.index(stage), v_base,
+                                          v_dma_off + n_ahead.to(INDEX_DTYPE) * stride_vn)
+        cdna4_async.commit_group()
+        n_ahead = tl.minimum(n_ahead + get_offset_for_next_block(
+            stage, kv_indices, kv_num_blocks,
+            SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS), last_start)
+
+    offs_n_base = kv_start
+    for start_n in tl.range(0, block_n_end, loop_unroll_factor=GLUON_UNROLL):
+        cur = start_n % NUM_BUF
+        offs_n_mma = offs_n_base + gl.arange(0, BLOCK_N, layout=mma_offs_n_col)
+
+        # Wait for this block's transfer, leaving the next one in flight.
+        cdna4_async.wait_group(NUM_BUF - 1)
+        kt_dot = cdna4_async.load_shared_relaxed(kt_smem.index(cur), kt_dot_layout)
+
+        qk = gl.zeros([BLOCK_M, BLOCK_N], dtype=gl.float32, layout=mma_layout)
+        qk = mfma_cdna4(q_dot, kt_dot, qk)
+{%- if not SCORE_MOD_IS_IDENTITY %}
+        qk = qk * SM_SCALE
+{%- endif %}
+
+{%- if IS_DIVISIBLE %}
+        m = offs_m_mma[:, None]
+        n = offs_n_mma[None, :]
+{%- else %}
+        m = get_bounded_indices(offs_m_mma[:, None], Q_LEN)
+        n = get_bounded_indices(offs_n_mma[None, :], KV_LEN)
+{%- endif %}
+
+{%- if SCORE_MOD_IS_IDENTITY %}
+        post_mod_scores = qk
+{%- else %}
+        {{ modification(
+            subgraph_number=0,
+            output_name="post_mod_scores",
+            score="qk",
+            b="off_zq",
+            h="off_hq",
+            m="m",
+            n="n",
+            out="qk",
+            input_shapes={
+                "score": ("BLOCK_M", "BLOCK_N"),
+                "m": ("BLOCK_M", "1"),
+                "n": ("1", "BLOCK_N"),
+            },
+            input_dtypes={"b": "index", "h": "index", "m": "index", "n": "index"},
+        ) | indent_except_first(2) }}
+{%- endif %}
+
+{%- if not full %}
+        {{ modification(
+            subgraph_number=1,
+            output_name="mask_mod_output",
+            score="qk",
+            b="off_zq",
+            h="off_hq",
+            m="m",
+            n="n",
+            input_shapes={
+                "score": ("BLOCK_M", "BLOCK_N"),
+                "m": ("BLOCK_M", "1"),
+                "n": ("1", "BLOCK_N"),
+            },
+            input_dtypes={"b": "index", "h": "index", "m": "index", "n": "index"},
+        ) | indent_except_first(2) }}
+
+{%- if not IS_DIVISIBLE %}
+        mask_mod_output = mask_mod_output & (offs_n_mma[None, :] < KV_LEN)
+{%- endif %}
+        post_mod_scores = gl.where(mask_mod_output, post_mod_scores, neg_inf_tile)
+{%- elif not IS_DIVISIBLE %}
+        post_mod_scores = gl.where(offs_n_mma[None, :] < KV_LEN, post_mod_scores, neg_inf_tile)
+{%- endif %}
+        # Change of base for exp2: scale the row max (BLOCK_M values) rather than
+        # the whole score tile, and fold the tile's scale into the exp2 argument so
+        # it costs one FMA instead of a multiply plus a subtract.
+        m_ij = gl.maximum(m_i, gl.max(post_mod_scores, axis=1) * QK_SCALE)
+        m_ij_safe = gl.where(m_ij == float("-inf"), zero_row, m_ij)
+        alpha = gl.exp2(m_i - m_ij_safe)
+        p = gl.exp2(post_mod_scores * QK_SCALE - m_ij_safe[:, None])
+        l_i = l_i * alpha + gl.sum(p, axis=1)
+        acc = acc * alpha[:, None]
+
+        v_dot = cdna4_async.load_shared_relaxed(v_smem.index(cur), v_dot_layout)
+        p_dot = gl.convert_layout(p.to(MATMUL_PRECISION), p_dot_layout)
+        acc = mfma_cdna4(p_dot, v_dot, acc)
+        m_i = m_ij
+
+        # This buffer is free now; start the block NUM_BUF ahead into it. The
+        # barrier is the WAR guard: the reads above must finish everywhere before
+        # the DMA overwrites the slot.
+        block_off = get_offset_for_next_block(
+            start_n, kv_indices, kv_num_blocks,
+            SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+        )
+        offs_n_base = offs_n_base + block_off
+        # The slot refilled below is next read NUM_BUF iterations from here, so the
+        # prefetch has to advance by *that* iteration's delta, not this one's. They
+        # differ whenever the scheduled block starts are unevenly spaced, which is
+        # any mask whose kv_indices has irregular gaps -- dense and causal both give
+        # evenly spaced starts, which is why the difference is invisible on them.
+        # The index is clamped because a prefetch past the last block is never
+        # consumed, and get_offset_for_next_block would read past kv_indices.
+        produce_off = get_offset_for_next_block(
+            tl.minimum(start_n + NUM_BUF, block_n_end - 1), kv_indices, kv_num_blocks,
+            SPARSE_KV_BLOCK_SIZE, SPARSE_KV_MULTIPLE, BLOCK_N, BLOCKS_ARE_CONTIGUOUS
+        )
+        gl.barrier()
+        cdna4_async.buffer_load_to_shared(kt_smem.index(cur), k_base,
+                                          kt_dma_off + n_ahead.to(INDEX_DTYPE) * stride_kn)
+        cdna4_async.buffer_load_to_shared(v_smem.index(cur), v_base,
+                                          v_dma_off + n_ahead.to(INDEX_DTYPE) * stride_vn)
+        cdna4_async.commit_group()
+        n_ahead = tl.maximum(tl.minimum(n_ahead + produce_off, last_start), 0)
+
+    # Drain the transfers still in flight from the loop's lookahead.
+    cdna4_async.wait_group(0)
+{%- endmacro %}
+{{def_kernel("Q", "K", "V", "LSE", "MAX", "KV_NUM_BLKS", "KV_IDX", "FULL_KV_NUM_BLKS", "FULL_KV_IDX")}}
+    # Gluon FlexAttention forward, async-DMA variant (AMD CDNA4 / gfx950).
+    #
+    # Same FlexAttention scaffolding and score_mod/mask_mod rendering as the
+    # synchronous template, but K/V are staged global -> LDS by the CDNA4 DMA
+    # (buffer_load_to_shared) into double-buffered shared memory, so the transfer
+    # for the next KV block overlaps this block's MFMAs and softmax.
+    #
+    # The DMA requires exact register/lane/warp bases for the offsets and a
+    # padded shared layout; those cannot be improvised (the plain Blocked /
+    # Swizzled layouts fail to lower). The combinations below are the ones taken
+    # from the hand-tuned gfx950 kernel; the choices hook only offers this
+    # template for those, and everything else uses the synchronous template.
+
+    tl.static_assert(SPARSE_Q_BLOCK_SIZE >= BLOCK_M and SPARSE_Q_BLOCK_SIZE % BLOCK_M == 0)
+    tl.static_assert(SPARSE_KV_BLOCK_SIZE >= BLOCK_N and SPARSE_KV_BLOCK_SIZE % BLOCK_N == 0)
+
+    stride_qz, stride_qh, stride_qm, stride_qk = {{stride("Q")}}
+    stride_kz, stride_kh, stride_kn, stride_kk = {{stride("K")}}
+    stride_vz, stride_vh, stride_vn, stride_vk = {{stride("V")}}
+
+    ZQ = {{size("Q", 0)}}
+    HQ = {{size("Q", 1)}}
+    Q_LEN = {{size("Q", 2)}}
+    ZKV = {{size("K", 0)}}
+    KV_LEN = {{size("K", 2)}}
+
+    MATMUL_PRECISION = Q.dtype.element_ty
+    RCP_LN2: tl.constexpr = 1.44269504
+{%- if SCORE_MOD_IS_IDENTITY %}
+    # score_mod is the identity, so sm_scale has not been applied to the tile
+    # yet: fold it into the same FMA that does the change of base.
+    QK_SCALE: tl.constexpr = SM_SCALE * RCP_LN2
+{%- else %}
+    QK_SCALE: tl.constexpr = RCP_LN2
+{%- endif %}
+    NUM_BUF: tl.constexpr = GLUON_NUM_BUF
+
+    # ---------------- Gluon layouts ----------------
+    num_warps: gl.constexpr = gl.num_warps()
+    threads_per_warp: gl.constexpr = GLUON_THREADS_PER_WARP
+    k_width: gl.constexpr = 8
+    pv_k_width: gl.constexpr = 4
+
+    mma_layout: gl.constexpr = AMDMFMALayout(version=4, instr_shape=[32, 32, 16],
+                                             transposed=True, warps_per_cta=[num_warps, 1])
+    q_dot_layout: gl.constexpr = DotOperandLayout(operand_index=0, parent=mma_layout, k_width=k_width)
+    kt_dot_layout: gl.constexpr = DotOperandLayout(operand_index=1, parent=mma_layout, k_width=k_width)
+    p_dot_layout: gl.constexpr = DotOperandLayout(operand_index=0, parent=mma_layout, k_width=pv_k_width)
+    v_dot_layout: gl.constexpr = DotOperandLayout(operand_index=1, parent=mma_layout, k_width=pv_k_width)
+
+    blocked_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 8], threads_per_warp=[threads_per_warp // 4, 4],
+        warps_per_cta=[num_warps, 1], order=[1, 0])
+
+    offs_m_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked_layout)
+    offs_d_layout: gl.constexpr = gl.SliceLayout(dim=0, parent=blocked_layout)
+    mma_offs_m_row: gl.constexpr = gl.SliceLayout(dim=1, parent=mma_layout)
+    mma_offs_n_col: gl.constexpr = gl.SliceLayout(dim=0, parent=mma_layout)
+    mma_m_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=mma_layout)
+
+    # ---- DMA staging layouts ----
+    # Selected in Python from the target's ladder (gluon_dma_layouts.py) and
+    # rendered here, so the choices hook cannot offer a config whose bases are
+    # missing: it offers this body exactly when the lookup succeeds.
+    kt_offset_bases: gl.constexpr = {{GLUON_KT_OFFSET_BASES}}
+    v_offset_bases: gl.constexpr = {{GLUON_V_OFFSET_BASES}}
+    kt_async_layout: gl.constexpr = DistributedLinearLayout(
+        reg_bases={{GLUON_KT_REG_BASES}},
+        lane_bases={{GLUON_KT_LANE_BASES}},
+        warp_bases={{GLUON_KT_WARP_BASES}}, block_bases=[],
+        shape=[QK_HEAD_DIM_ROUNDED, BLOCK_N])
+    v_async_layout: gl.constexpr = DistributedLinearLayout(
+        reg_bases={{GLUON_V_REG_BASES}},
+        lane_bases={{GLUON_V_LANE_BASES}},
+        warp_bases={{GLUON_V_WARP_BASES}}, block_bases=[],
+        shape=[BLOCK_N, V_HEAD_DIM_ROUNDED])
+
+    kt_smem_layout: gl.constexpr = PaddedSharedLayout(
+        interval_padding_pairs=[[512, 8]], offset_bases=kt_offset_bases, cga_layout=[],
+        shape=[QK_HEAD_DIM_ROUNDED, BLOCK_N])
+    v_smem_layout: gl.constexpr = PaddedSharedLayout(
+        interval_padding_pairs=[[512, 32]], offset_bases=v_offset_bases, cga_layout=[],
+        shape=[BLOCK_N, V_HEAD_DIM_ROUNDED])
+
+    # offset index tensors must be slices of the DMA layouts
+    kt_dma_d: gl.constexpr = gl.SliceLayout(dim=1, parent=kt_async_layout)
+    kt_dma_n: gl.constexpr = gl.SliceLayout(dim=0, parent=kt_async_layout)
+    v_dma_n: gl.constexpr = gl.SliceLayout(dim=1, parent=v_async_layout)
+    v_dma_d: gl.constexpr = gl.SliceLayout(dim=0, parent=v_async_layout)
+
+    # ---------------- program ids ----------------
+    q_start = gl.program_id(0)
+    off_zq = gl.program_id(1)
+    off_hq = gl.program_id(2)
+    off_zkv = off_zq % ZKV
+    off_hkv = off_hq // GQA_SHARED_HEADS
+
+    q_base = Q + off_zq * stride_qz + off_hq * stride_qh
+    k_base = K + off_zkv * stride_kz + off_hkv * stride_kh
+    v_base = V + off_zkv * stride_vz + off_hkv * stride_vh
+
+    # ---------------- block-sparse bookkeeping ----------------
+    SPARSE_Z = {{size("KV_NUM_BLKS", 0)}}
+    SPARSE_HQ = {{size("KV_NUM_BLKS", 1)}}
+    sparse_idx_z = off_zq % SPARSE_Z
+    sparse_idx_hq = off_hq % SPARSE_HQ
+    SPARSE_Q_MULTIPLE: tl.constexpr = (SPARSE_Q_BLOCK_SIZE // BLOCK_M)
+    SPARSE_KV_MULTIPLE: tl.constexpr = (SPARSE_KV_BLOCK_SIZE // BLOCK_N)
+    stride_kv_num_blks_h = {{stride("KV_NUM_BLKS", 1)}}
+    stride_kv_idx_h = {{stride("KV_IDX", 1)}}
+    stride_kv_idx_m = {{stride("KV_IDX", 2)}}
+    sparse_hz_offset = sparse_idx_z * SPARSE_HQ + sparse_idx_hq
+    sparse_kv_num_blks_offset = sparse_hz_offset * stride_kv_num_blks_h + q_start // SPARSE_Q_MULTIPLE
+    sparse_kv_idx_offset = sparse_hz_offset * stride_kv_idx_h + (q_start // SPARSE_Q_MULTIPLE) * stride_kv_idx_m  # noqa: B950
+
+    # ---------------- offsets ----------------
+    offs_m = q_start * BLOCK_M + gl.arange(0, BLOCK_M, layout=offs_m_layout)
+    offs_d = gl.arange(0, QK_HEAD_DIM_ROUNDED, layout=offs_d_layout)
+    offs_vd = gl.arange(0, V_HEAD_DIM_ROUNDED, layout=offs_d_layout)
+    offs_m_mma = q_start * BLOCK_M + gl.arange(0, BLOCK_M, layout=mma_offs_m_row)
+
+    kt_d = gl.arange(0, QK_HEAD_DIM_ROUNDED, layout=kt_dma_d)
+    kt_n = gl.arange(0, BLOCK_N, layout=kt_dma_n)
+    v_n = gl.arange(0, BLOCK_N, layout=v_dma_n)
+    v_d = gl.arange(0, V_HEAD_DIM_ROUNDED, layout=v_dma_d)
+    # Element offsets within K / V for one block, minus the block's own start.
+    kt_dma_off = kt_d[:, None].to(INDEX_DTYPE) * stride_kk + kt_n[None, :].to(INDEX_DTYPE) * stride_kn
+    v_dma_off = v_n[:, None].to(INDEX_DTYPE) * stride_vn + v_d[None, :].to(INDEX_DTYPE) * stride_vk
+
+    # ---------------- Q ----------------
+    q_smem = gl.allocate_shared_memory(
+        Q.dtype.element_ty, [BLOCK_M, QK_HEAD_DIM_ROUNDED],
+        layout=gl.SwizzledSharedLayout(vec=8, per_phase=1, max_phase=16, order=[1, 0]))
+    q_ptrs = q_base + offs_m[:, None].to(INDEX_DTYPE) * stride_qm + offs_d[None, :].to(INDEX_DTYPE) * stride_qk
+    q = gl.load(q_ptrs, mask=(offs_m[:, None] < Q_LEN) & (offs_d[None, :] < QK_HEAD_DIM), other=0.0)
+    q_smem.store(q)
+    q_dot = q_smem.load(q_dot_layout)
+
+    # ---------------- double-buffered LDS for the DMA ----------------
+    kt_smem = gl.allocate_shared_memory(
+        Q.dtype.element_ty, [NUM_BUF, QK_HEAD_DIM_ROUNDED, BLOCK_N], layout=kt_smem_layout)
+    v_smem = gl.allocate_shared_memory(
+        Q.dtype.element_ty, [NUM_BUF, BLOCK_N, V_HEAD_DIM_ROUNDED], layout=v_smem_layout)
+
+    # ---------------- accumulators ----------------
+    m_i = gl.full([BLOCK_M], float("-inf"), dtype=gl.float32, layout=mma_m_layout)
+    l_i = gl.zeros([BLOCK_M], dtype=gl.float32, layout=mma_m_layout)
+    acc = gl.zeros([BLOCK_M, V_HEAD_DIM_ROUNDED], dtype=gl.float32, layout=mma_layout)
+    neg_inf_tile = gl.full([BLOCK_M, BLOCK_N], float("-inf"), dtype=gl.float32, layout=mma_layout)
+    zero_row = gl.zeros([BLOCK_M], dtype=gl.float32, layout=mma_m_layout)
+    one_row = gl.full([BLOCK_M], 1.0, dtype=gl.float32, layout=mma_m_layout)
+
+    # Largest in-range block start, so a prefetch past the end re-reads the last
+    # block instead of running off the tensor (cheaper than a per-element mask).
+    #
+    # This is only a block start when BLOCK_N divides KV_LEN, and this body is
+    # offered on exactly that condition -- gluon_flex.py::_async_body gates on it.
+    # Without the gate the clamp fires on a block that is actually read, and the
+    # rows staged here are not the rows offs_n_base tells mask_mod/score_mod they
+    # are, so the output is wrong rather than imprecise. Same reason the DMA
+    # staging ladder lives in the hook: a precondition of the body belongs
+    # wherever the body is chosen.
+    last_start = tl.maximum(KV_LEN - BLOCK_N, 0)
+
+    # ==================== partial blocks: score_mod AND mask_mod ====================
+{{ kv_loop(false) }}
+
+    # ==================== full blocks: score_mod only ====================
+    if HAS_FULL_BLOCKS:
+{{ kv_loop(true) | indent(4) }}
+
+    # ==================== epilogue ====================
+    l_i = gl.where(l_i == 0.0, one_row, l_i)
+    acc = acc / l_i[:, None]
+
+    idx_zq = off_zq
+    idx_hq = off_hq
+    idx_m = offs_m[:, None].to(INDEX_DTYPE)
+    idx_d = offs_vd[None, :].to(INDEX_DTYPE)
+    mask = (idx_m < Q_LEN) & (idx_d < V_HEAD_DIM)
+    acc_out = gl.convert_layout(acc, blocked_layout)
+
+    {{store_output(("idx_zq", "idx_hq", "idx_m", "idx_d"), "acc_out", "mask", val_shape=("BLOCK_M", "V_HEAD_DIM_ROUNDED"))}}
+
+    if OUTPUT_LOGSUMEXP:
+        off_hz = off_zq * HQ + off_hq
+        lse = m_i + gl.log2(l_i)
+        lse_blk = gl.convert_layout(lse, offs_m_layout)
+        gl.store(LSE + off_hz * Q_LEN + offs_m, lse_blk, mask=offs_m < Q_LEN)
+
+    if OUTPUT_MAX:
+        off_hz = off_zq * HQ + off_hq
+        m_blk = gl.convert_layout(m_i, offs_m_layout)
+        gl.store(MAX + off_hz * Q_LEN + offs_m, m_blk, mask=offs_m < Q_LEN)

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1382,8 +1382,22 @@ class CachingAutotuner(KernelInterface):
         if not ASTSource:
             raise RuntimeError("Installed triton version too old, please upgrade")
 
+        # Pick the ASTSource for the kernel's language. A JITFunction only
+        # publishes self.ASTSource lazily (in create_binder, on first launch), so
+        # compiling ahead of time has to ask the function what it is. Gluon needs
+        # GluonASTSource, which stamps ttg.threads-per-warp from options.warp_size
+        # onto the module before codegen; with the plain ASTSource the module
+        # keeps the default and Gluon's explicit wave64 layouts fail verification.
+        ast_source_cls = getattr(self.fn, "ASTSource", None)
+        is_gluon = getattr(self.fn, "is_gluon", None)
+        if ast_source_cls is None and is_gluon is not None and is_gluon():
+            from triton.experimental.gluon._runtime import GluonASTSource
+
+            ast_source_cls = GluonASTSource
+        if ast_source_cls is None:
+            ast_source_cls = ASTSource
         compile_args = (
-            ASTSource(
+            ast_source_cls(
                 self.fn,
                 compile_meta["signature"],
                 compile_meta["constants"],

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1391,8 +1391,15 @@ class CachingAutotuner(KernelInterface):
         ast_source_cls = getattr(self.fn, "ASTSource", None)
         is_gluon = getattr(self.fn, "is_gluon", None)
         if ast_source_cls is None and is_gluon is not None and is_gluon():
-            from triton.experimental.gluon._runtime import GluonASTSource
-
+            try:
+                from triton.experimental.gluon._runtime import GluonASTSource
+            except ImportError as e:
+                # The function says it is Gluon, so falling back to the plain
+                # ASTSource would fail later and less legibly.
+                raise RuntimeError(
+                    "kernel is a Gluon function but this Triton has no "
+                    "triton.experimental.gluon runtime; please upgrade"
+                ) from e
             ast_source_cls = GluonASTSource
         if ast_source_cls is None:
             ast_source_cls = ASTSource


### PR DESCRIPTION
Following up on RFC (https://github.com/pytorch/pytorch/issues/188212) 

Adds Gluon — Triton's low-level frontend — as a template frontend for Inductor, and uses it to offer a hand-tuned flash-attention forward kernel as an extra `flex_attention` autotuning candidate on gfx950. Gluon exposes explicit tile layouts and target intrinsics, so the kernel can stage K/V from global to LDS by DMA and keep that transfer in flight across the MFMAs — an overlap Inductor's Triton codegen cannot currently express. Worth 1.08x to 1.12x on the forward pass, and the frontend is reusable by anything else that wants a hand-written body.

MI350X, ROCm 7.2.1, fp16, forward only, TFLOPS:

| shape | mask | triton | gluon | ratio |
|---|---|---:|---:|---:|
| B1 H16 N4096 D64 | none | 514.0 | 574.0 | 1.117x |
| B1 H16 N4096 D64 | causal | 316.3 | 348.7 | 1.102x |
| B1 H16 N4096 D128 | none | 620.6 | 687.3 | 1.107x |
| B1 H16 N4096 D128 | causal | 398.2 | 434.5 | 1.091x |
| B1 H32 N8192 D128 | none | 640.6 | 713.6 | 1.114x |
| B1 H32 N8192 D128 | causal | 469.3 | 509.7 | 1.086x |

Geomean 1.103x, against a worst-case measurement drift of 0.4%.

This also lays the groundwork for the next generation (gfx1250 / CDNA5), where the gap Gluon can close tends to be widest: each generation adds mechanisms a codegen has to learn to model — async copy here, warp specialization and TMA/mbarrier there — and Gluon exposes them immediately. A body that does not win the autotune never runs, so offering one costs nothing where Triton is already at the ceiling.

<details>
<summary>How the numbers were taken</summary>

Both arms are compiled in one process and timed A/B/A, so drift within the run shows up as a difference between the two Triton measurements rather than as a Gluon effect; the worst such drift was 0.3% and the Gluon spread 0.1% to 0.6%. Each point is the median of five `do_bench` medians after a clock ramp, and each figure above is the median of three such runs on a device checked idle before each. This is a shared host: one of the three runs picked up a transient co-tenant that cost the first shape 3.5% before it recovered on repeat, which is what taking medians across runs is for.

The baseline has to remove the Gluon choices from the pool rather than merely stop forcing them. Leave them in and Gluon wins the baseline autotune too, and the comparison reads 1.00x.

</details>

### The frontend

`torch/_inductor/codegen/gluon` is target-neutral and knows nothing about attention.

`GluonTemplate` / `GluonTemplateKernel` subclass `TritonTemplate` / `TritonTemplateKernel` and override only the emitted imports and the jit decorator. Signature generation, `modification()` subgraph rendering, `store_output`, argument plumbing and the kernel call are all inherited, and `TritonScheduling` and `async_compile.triton` are reused as they are. That works because `GluonJITFunction` subclasses `triton.runtime.jit.JITFunction` and launches identically, and because `tl.*` pointwise ops are valid inside a `@gluon.jit` body with layouts inferred from the operands.

This is deliberately not a backend in the shape of the landed CuteDSL one, which brings its own `BaseScheduling`, `Kernel` and modification wrapper. CuteDSL needs that because it is a different language; Gluon is not, so reusing Triton's path is what makes `score_mod`/`mask_mod` work here for free rather than needing to be reimplemented.

`GluonKernelOverrides` is the one codegen adjustment. Gluon's `gl.full` / `gl.zeros` need an explicit layout that generated subgraph code has no way to pick, since the right layout depends on the tile the constant is combined with, so constants become typed scalars that broadcast against any layout while keeping the dtype pinned.

A target contributes only its intrinsics and its wavefront width — `codegen/gluon/cdna4.py` is 24 lines. Gluon's primitives differ by family (CDNA4 has mfma and `buffer_load_to_shared`, gfx1250 has wmma and mbarrier, NVIDIA has mma and TMA), so bodies are per target while everything above them is shared. And because `score_mod`/`mask_mod` go through the inherited `modification()` machinery, arbitrary user mods work in a Gluon body with no extra support code.

### The first consumer

The flex pieces plug in through the existing `InductorChoices.append_flex_attention_choices` seam, so Gluon kernels are appended alongside the Triton candidates and the autotuner picks the winner; where the Gluon body is slower it loses and never runs. Two bodies are offered per config and autotuned against each other: a synchronous one, and an async one that stages K/V through `buffer_load_to_shared` into a double-buffered LDS ring, waiting with `wait_group(NUM_BUF - 1)` so the next block's transfer stays in flight during this block's math. The async body wins on all six shapes above.

A `GluonFlexTarget` descriptor carries the matmul tile geometry, the wavefront width and the DMA staging ladder, and the staging layouts are a table keyed by `(head_dim, BLOCK_N, num_warps)` rather than a branch chain in the template, so the choices hook and the body cannot disagree.

Off by default behind `config.gluon_flex_attention`, and gated to gfx950 on top of that.

### Preconditions the hook enforces

**`BLOCK_N` must divide `KV_LEN`.** Staging by unmasked DMA means a prefetch that would overrun the tensor is clamped to `KV_LEN - BLOCK_N`, which is a block start only under that condition. Otherwise the clamp fires on a block that is actually read, and the final block scores staged rows against another block's column indices — wrong rather than imprecise, 33% relative error at S=4000, and selected by ordinary autotuning rather than needing to be forced.

The existing `IS_DIVISIBLE` cannot express this. It is computed against `SPARSE_KV_BLOCK_SIZE`, which is `1073741824` on the unmasked path, so it is `False` both where the async body is correct and where it is not. Anything the gate rejects, including a dynamic `KV_LEN`, takes the sync body or Triton.

**The scale must be positive** for the identity `score_mod` fold, which subtracts `max(qk) * QK_SCALE` rather than the row max of the scaled scores. A negative scale makes those the row min; softmax is invariant to the constant it subtracts, but the exp2 arguments then grow with the score span and overflow to NaN past fp32's range of 128, which `scale=-1.0` at head dim 128 reaches at 145. The Triton template scales the tile first and so is sign-agnostic.

**A caller-pinned `num_warps` or `num_stages`** suppresses the Gluon offer rather than being silently rewritten, since these bodies choose their own.

### Coverage

`TestGluonFlexAttention` is skipped unless running on gfx950. The forcing tests assert a Gluon kernel was actually emitted, since otherwise a green test would only prove the Triton template still works. Correctness was additionally validated out of tree across 120 combinations of shape, `score_mod` and dtype at sequence lengths to 8192, and the sync body at head dims 16 through 256.

Forward only; the backward pass keeps using the Triton template. The async body needs `BLOCK_N=64`, head dim 64 or 128, and a `KV_LEN` that `BLOCK_N` divides, with everything else falling back to the sync body or Triton.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo