### PR TITLE
[ROCm][CI] Upgrade trunk to ROCm 10.0

### DIFF
--- a/.ci/docker/build.sh
+++ b/.ci/docker/build.sh
@@ -204,8 +204,8 @@ case "$tag" in
       ANACONDA_PYTHON_VERSION=3.12
     fi
     GCC_VERSION=13
-    ROCM_VERSION=7.14
-    THEROCK_INDEX_URL="https://repo.amd.com/rocm/whl-multi-arch/"
+    ROCM_VERSION=10.0
+    THEROCK_INDEX_URL="https://stable.repo.amd.com/rocm/whl-next/"
     TRITON=yes
     KATEX=yes
     PYTORCH_ROCM_ARCH="gfx90a;gfx942;gfx950;gfx1100"

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1552,14 +1552,7 @@ if(USE_ROCM)
       foreach(_arch ${PYTORCH_ROCM_ARCH})
         list(FIND ROCSHMEM_SUPPORTED_ARCH "${_arch}" _rocsmem_supported_idx)
         if(NOT _rocsmem_supported_idx EQUAL -1)
-          # rocSHMEM device archives are commonly built for gfx90a xnack variants,
-          # so map plain gfx90a to gfx90a:xnack-/gfx90a:xnack+ to match device
-          # symbols during HIP RDC link.
-          if(_arch STREQUAL "gfx90a")
-            list(APPEND _torch_rocshmem_build_arches "gfx90a:xnack-" "gfx90a:xnack+")
-          else()
-            list(APPEND _torch_rocshmem_build_arches "${_arch}")
-          endif()
+          list(APPEND _torch_rocshmem_build_arches "${_arch}")
         endif()
       endforeach()
       if(_torch_rocshmem_build_arches)


### PR DESCRIPTION
## Problem
- PyTorch trunk ROCm CI still builds against ROCm 7.14.
- ROCm 10.0 packages are published from the new `whl-next` index.
- rocSHMEM must build for the requested gfx target instead of substituting gfx90a XNACK variants.

## Changes
- Upgrade the shared `rocm-n` trunk image from ROCm 7.14 to 10.0.
- Install ROCm 10.0 from `https://stable.repo.amd.com/rocm/whl-next/`.
- Cherry-pick the rocSHMEM target fix from https://github.com/ROCm/pytorch/pull/3583.
- Keep wheel, builder, and nightly changes independent in https://github.com/pytorch/pytorch/pull/194919.

## Validation
- Bash syntax and stubbed trunk Docker argument routing pass.
- The trunk image selects ROCm 10.0 and the `whl-next` index; the preview image retains its nightly index.
- `git diff --check` and targeted IDE lint checks pass for the Docker and CMake changes.
- Full image and rocSHMEM builds were not run locally; CI provides end-to-end validation.
- [trunk workflow](https://github.com/pytorch/pytorch/actions/runs/33000092249/job/98385742860) ran successfully with ROCm10.0
- [rocm-mi200](https://github.com/pytorch/pytorch/actions/runs/33002840829/job/98340667528) ran successfully with ROCm10.0

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang