### PR TITLE
fix(aten): deduplicate isin after dtype promotion

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -602,17 +602,26 @@ static void isin_sorting(
     bool assume_unique,
     bool invert,
     const Tensor& out) {
+  // Fix false positives when dtype promotion introduces duplicates.
+  // Deduplicate after casting to the common dtype.
+  auto common_dtype = at::native::result_type(elements, test_elements);
+  Tensor elements_common = elements.scalar_type() == common_dtype
+      ? elements
+      : elements.to(common_dtype);
+  Tensor test_elements_common = test_elements.scalar_type() == common_dtype
+      ? test_elements
+      : test_elements.to(common_dtype);
   // 1. Concatenate unique elements with unique test elements in 1D form. If
   //    assume_unique is true, skip calls to unique().
   Tensor elements_flat, test_elements_flat, unique_order;
   if (assume_unique) {
-    elements_flat = elements.ravel();
-    test_elements_flat = test_elements.ravel();
+    elements_flat = elements_common.ravel();
+    test_elements_flat = test_elements_common.ravel();
   } else {
     std::tie(elements_flat, unique_order) =
-        at::_unique(elements, /*sorted=*/false, /*return_inverse=*/true);
+        at::_unique(elements_common, /*sorted=*/false, /*return_inverse=*/true);
     std::tie(test_elements_flat, std::ignore) =
-        at::_unique(test_elements, /*sorted=*/false);
+        at::_unique(test_elements_common, /*sorted=*/false);
   }
 
   // 2. Stable sort all elements, maintaining order indices to reverse the


### PR DESCRIPTION
Bug: torch.isin produces false positives on CPU when dtype promotion introduces duplicate values. The sorting path deduplicates via _unique before promotion, so values distinct in their original dtypes but equal after casting to the common dtype are missed, corrupting the duplicate mask.

Fix: compute common dtype via result_type before deduplication and cast elements and test_elements to that dtype before _unique and ravel in isin_sorting. This ensures deduplication sees the same values that sorting and comparison use.

Evidence: verified RED to GREEN via git stash keep-index workflow. Diff is 13 lines in aten/src/ATen/native/TensorCompare.cpp around line 599, formatter blast radius limited to that file.