### PR TITLE
[RAWTHROW][3a] Use TORCH_CHECK_VALUE for the two registry lookups

### DIFF
--- a/torch/csrc/utils/tensor_memoryformats.cpp
+++ b/torch/csrc/utils/tensor_memoryformats.cpp
@@ -17,7 +17,7 @@ std::array<PyObject*, static_cast<int>(at::MemoryFormat::NumOptions)>
 PyObject* getTHPMemoryFormat(at::MemoryFormat memory_format) {
   auto py_memory_format =
       memory_format_registry[static_cast<int>(memory_format)];
-  TORCH_CHECK(py_memory_format, "unsupported memory_format");
+  TORCH_CHECK_VALUE(py_memory_format, "unsupported memory_format");
   return py_memory_format;
 }
 

--- a/torch/csrc/utils/tensor_qschemes.cpp
+++ b/torch/csrc/utils/tensor_qschemes.cpp
@@ -28,7 +28,7 @@ void initializeQSchemes() {
 
 PyObject* getTHPQScheme(at::QScheme qscheme) {
   auto qscheme_ = thp_qscheme_array[static_cast<int>(qscheme)];
-  TORCH_CHECK(qscheme_, "unsupported QScheme");
+  TORCH_CHECK_VALUE(qscheme_, "unsupported QScheme");
   return qscheme_;
 }
 } // namespace torch::utils


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194778
* __->__ #194797
* #194773
* #194772
* #194379
* #194378

## Author Notes

PLACEHOLDER

## Agent Notes

Written by Claude Code:

> Follow-up to the serialization-codegen PR, taking Skylion007's suggestion on
> `getTHPMemoryFormat` and `getTHPQScheme`: TORCH_CHECK_VALUE rather than plain
> TORCH_CHECK, since the throws being replaced were `std::invalid_argument`.
>
> His question was whether pybind11's translator is missing something. It is not -
> `detail/internals.h` maps `std::invalid_argument` to ValueError correctly. What
> made the original behaviour non-uniform is on our side. `HANDLE_TH_ERRORS` opens
> a try block; the matching `END_HANDLE_TH_ERRORS_RET` catches
> `const std::exception&` and calls `torch::translate_exception_to_python`, which
> is where `CATCH_ALL_ERRORS` lives (torch/csrc/Exceptions.cpp). Its trailing
> `catch (const std::exception&)` arm flattens *every* std:: exception to
> RuntimeError before pybind ever sees it.
> So the same throw surfaced two different ways depending on the caller:
>
>     getTHPQScheme        one caller, wrap_outputs.h, under HANDLE_TH_ERRORS
>                          -> invalid_argument flattened to RuntimeError
>     getTHPMemoryFormat   three callers: the autograd template is under
>                          HANDLE_TH_ERRORS (RuntimeError); the at::MemoryFormat
>                          type_caster in utils/pybind.h runs inside pybind's own
>                          dispatcher frame (ValueError); and dynamo/guards.cpp is
>                          called as a raw function pointer from Inductor-generated
>                          C++, whose `inductor_entry_cpp` wrapper catches
>                          std::exception and sets RuntimeError.
>
> So neither macro reproduces the old behaviour everywhere: TORCH_CHECK gives
> RuntimeError and matches three of the four paths, TORCH_CHECK_VALUE gives
> ValueError and matches the pybind one. (Three, not two - the inductor path
> flattens to RuntimeError in its own wrapper regardless of what we throw.) TORCH_CHECK_VALUE is the
> better of the two - it is what the message says ("unsupported memory_format" is
> a value error), it is what a user on the pybind path already saw, and it makes
> the two functions agree with each other.
>
> Uniformly on the paths we control, because the typed arm wins: TORCH_CHECK_VALUE
> throws `c10::ValueError`
> and `CATCH_TH_ERRORS` has an explicit `_CATCH_GENERIC_ERROR(ValueError,
> PyExc_ValueError)` that `CATCH_ALL_ERRORS` runs before its generic
> `std::exception` arm, so the flattening that hit `std::invalid_argument` does not
> apply here. Two exceptions to "uniformly": the inductor wrapper above, and
> `STRIP_ERROR_MESSAGES` builds, where TORCH_CHECK_WITH_MSG discards `error_t` and
> hardcodes `C10_THROW_ERROR(Error, ...)`, degrading to RuntimeError.
>
> None of which is observable, and that is why this is a small follow-up rather
> than a correction. Both branches are dead: `memory_format_registry` gets all four
> `at::MemoryFormat` values from `initializeMemoryFormats`, and
> `thp_qscheme_array` is filled by a loop over `COMPILE_TIME_NUM_QSCHEMES` (5), so
> neither lookup can return null. The checks are defensive.
>
> Test Plan:
>
> ```
> bash -ic 'BUILD_CONFIG spin develop'
> python -c "import torch; [str(m) for m in (torch.contiguous_format,
>     torch.channels_last, torch.channels_last_3d, torch.preserve_format)]"
> python -c "import torch; [str(q) for q in (torch.per_tensor_affine,
>     torch.per_channel_affine, torch.per_tensor_symmetric,
>     torch.per_channel_symmetric, torch.per_channel_affine_float_qparams)]"
> ```
>
> All 4 memory formats and all 5 qschemes resolve. That evidences the registries
> being *full*; unreachability rests on the separate and stronger fact that the
> enums are exhaustive - `MemoryFormat` has exactly 4 real enumerators and
> `initializeMemoryFormats` registers all 4, and `thp_qscheme_array` is sized
> `COMPILE_TIME_NUM_QSCHEMES` and filled by an `irange` over the same bound. (Both
> registries are null before `_initExtension` runs, but nothing calls these two
> functions during that window.)
>
> TORCH_INTERNAL_ASSERT would arguably be the more honest macro for a branch this
> dead, but TORCH_CHECK_VALUE is what was asked for, it matches what the pybind
> path already produced, and it keeps the two functions agreeing with each other.
>
> ```
> lintrunner --take RAWTHROW --all-files
> spin lint
> ```
>
> Clean.
>
> Not verified locally: nothing exercises the null branches, by construction. The
> ValueError mapping is established by the macro chain above rather than by a
> runtime probe, since there is no way to reach these two sites.