### PR TITLE
[trymerge] Verify greenlight approved the exact commit being landed

### DIFF
--- a/.github/scripts/greenlight_guard.py
+++ b/.github/scripts/greenlight_guard.py
@@ -1,0 +1,319 @@
+"""Land-time verification that greenlight reviewed the commit that is about to land.
+
+`merge_rules.yaml`'s "Greenlight Review Bot" rule lets a single `pytorchgreenlight`
+approval authorize a merge of any path, and pytorch/pytorch has no GitHub-native
+required reviews, so that approval is never dismissed when the author pushes more
+commits. This module compares the PR's head commit against the head SHA greenlight
+recorded in its ledger and refuses the merge when they disagree, waiting instead when
+greenlight simply has not answered yet.
+
+It must not import `trymerge`: `trymerge` imports this module, and the cycle would
+break both. Everything it needs about a PR arrives as plain data or callables, and it
+returns a verdict rather than raising trymerge's exception types.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from greenlight_identity import GREENLIGHT_LOGIN, is_greenlight
+from greenlight_ledger import (
+    fetch_ledger_states,
+    GreenlightLedgerError,
+    IN_FLIGHT_STATUSES,
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_LAND,
+    STATUS_NO_LAND,
+)
+from greenlight_messages import (
+    describe_ledger,
+    FIX_HUMAN,
+    FIX_RETRIGGER,
+    FIX_TRANSPORT,
+    FIX_UNSETTLED,
+    FORCE_SUFFIX,
+    LEDGER_UNREADABLE,
+    render_announcement,
+    render_refusal,
+    render_wait,
+    timeout_suffix,
+)
+from greenlight_preflight import cannot_review
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from greenlight_ledger import LedgerState
+
+
+MAX_WAIT = timedelta(minutes=60)
+MAX_WAIT_MINUTES = int(MAX_WAIT.total_seconds() // 60)
+
+# greenlight re-dispatches a review that has outlived its own timeout and writes a fresh
+# row when it does, so an older in-flight row is proof that no verdict is coming for this
+# commit. The 5 minutes on top of greenlight's DEFAULT_TIMEOUT_MINUTES of 45 are slack for
+# the gap between that timeout expiring and the next scan acting on it. greenlight's CLI
+# takes the 45 as --timeout-minutes, so an override there silently skews this check.
+DEAD_REVIEW_AGE = timedelta(minutes=50)
+
+# Not one of greenlight's groupings: upstream splits NO_LAND (terminal) from CANCELLED
+# and FAILED (retry-eligible). At land time all three mean the same thing, namely that
+# greenlight did not say LAND for the commit in front of us.
+NEGATIVE_STATUSES = frozenset({STATUS_NO_LAND, STATUS_CANCELLED, STATUS_FAILED})
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+class GuardVerdict(enum.Enum):
+    ALLOW = "ALLOW"
+    WAIT = "WAIT"
+    DENY = "DENY"
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    verdict: GuardVerdict
+    message: str = ""
+    comment: str = ""
+
+
+@dataclass(frozen=True)
+class PRUnderMerge:
+    """One PR a merge is about to land, plus the facts the guard needs about it.
+
+    ``head_sha`` is the PR's GitHub head, which is what greenlight records even on the
+    ghstack path, where the commit git actually cherry-picks is a different revision
+    carrying the same content. The callables are callables because each costs a request
+    and only the minority of PRs that greenlight alone authorizes ever need them.
+
+    ``get_bot_reviewers`` returns None when GitHub could not be asked which reviewers are
+    App accounts, which is different from a PR that has none.
+    """
+
+    pr_num: int
+    head_sha: str
+    approved_by: Sequence[str]
+    changes_requested_by: Sequence[str]
+    labels: Sequence[str]
+    get_updated_at: Callable[[], str | None]
+    get_bot_reviewers: Callable[[], frozenset[str] | None]
+    get_merge_authorized_logins: Callable[[], frozenset[str]]
+    is_authorized_without_greenlight: Callable[[], bool]
+
+
+@dataclass(frozen=True)
+class Outcome:
+    verdict: GuardVerdict
+    kind: str
+    detail: str
+    pr_num: int
+    head_sha: str
+    ledger: str
+    fix: str = ""
+
+
+@dataclass
+class GreenlightWaitWindow:
+    """The wait budget for one merge command, carried across ``merge_into`` re-entries.
+
+    The budget opens at the first wait rather than when the merge command was issued:
+    `merge_into` is reached only once CI is green, and pytorch CI routinely runs for
+    hours, so a budget anchored at the command would already be spent before the guard
+    ever ran once.
+    """
+
+    opened_at: datetime | None = None
+    announced: bool = False
+
+    def register_wait(self, now: datetime) -> bool:
+        """Record that the guard is waiting. True once the budget is spent."""
+        if self.opened_at is None:
+            self.opened_at = now
+        return now - self.opened_at >= MAX_WAIT
+
+    def claim_announcement(self) -> bool:
+        """True for the first wait of this merge command only, and never again."""
+        if self.announced:
+            return False
+        self.announced = True
+        return True
+
+
+def _same_commit(left: str, right: str) -> bool:
+    """Whether two shas name the same commit.
+
+    Both sides have to be full 40-hex shas. The entire gate is this one equality, and a
+    pair of empty strings -- an unreadable PR head, a ledger row written without one --
+    would otherwise compare equal and wave the merge through.
+    """
+    normalized = left.strip().lower()
+    if not _SHA_RE.fullmatch(normalized):
+        return False
+    return normalized == right.strip().lower()
+
+
+def _settled_outcome(pr: PRUnderMerge, state: LedgerState, now: datetime) -> Outcome:
+    ledger = describe_ledger(state)
+    if state.status in IN_FLIGHT_STATUSES:
+        if now - state.version >= DEAD_REVIEW_AGE:
+            return Outcome(
+                GuardVerdict.DENY,
+                "DEAD_REVIEW",
+                "greenlight's review of this commit has been running far longer than "
+                "a review takes, so no verdict is coming",
+                pr.pr_num,
+                pr.head_sha,
+                ledger,
+                FIX_RETRIGGER,
+            )
+        return Outcome(
+            GuardVerdict.WAIT,
+            "IN_FLIGHT",
+            "greenlight is still reviewing this commit",
+            pr.pr_num,
+            pr.head_sha,
+            ledger,
+            FIX_UNSETTLED,
+        )
+    if state.status == STATUS_LAND:
+        return Outcome(GuardVerdict.ALLOW, "LAND", "", pr.pr_num, pr.head_sha, ledger)
+    if state.status in NEGATIVE_STATUSES:
+        detail = f"greenlight recorded {state.status} for this exact commit"
+        kind = "NEGATIVE_VERDICT"
+    else:
+        detail = f"greenlight recorded the unrecognized status {state.status} for this commit"
+        kind = "UNKNOWN_STATUS"
+    return Outcome(
+        GuardVerdict.DENY, kind, detail, pr.pr_num, pr.head_sha, ledger, FIX_HUMAN
+    )
+
+
+def _evaluate_pr(pr: PRUnderMerge, state: LedgerState | None, now: datetime) -> Outcome:
+    if state is not None and _same_commit(state.head_sha, pr.head_sha):
+        return _settled_outcome(pr, state, now)
+
+    ledger = describe_ledger(state)
+    # Nothing settled for this commit, so landing it depends on greenlight dispatching a
+    # fresh review. Refuse now rather than after a full wait when it structurally cannot.
+    blocked = cannot_review(pr, state.status if state is not None else None, now)
+    if blocked is not None:
+        if blocked.retryable:
+            return Outcome(
+                GuardVerdict.WAIT,
+                "UNCLASSIFIED_REVIEWER",
+                "greenlight may not produce a verdict for this commit because "
+                f"{blocked.cause}",
+                pr.pr_num,
+                pr.head_sha,
+                ledger,
+                blocked.fix,
+            )
+        return Outcome(
+            GuardVerdict.DENY,
+            "CANNOT_REVIEW",
+            "greenlight cannot produce a verdict for this commit because "
+            f"{blocked.cause}",
+            pr.pr_num,
+            pr.head_sha,
+            ledger,
+            blocked.fix,
+        )
+    if state is None:
+        return Outcome(
+            GuardVerdict.WAIT,
+            "NO_ROW",
+            "greenlight has not reviewed this PR yet",
+            pr.pr_num,
+            pr.head_sha,
+            ledger,
+            FIX_UNSETTLED,
+        )
+    return Outcome(
+        GuardVerdict.WAIT,
+        "SHA_MISMATCH",
+        "greenlight's latest verdict is for a different commit",
+        pr.pr_num,
+        pr.head_sha,
+        ledger,
+        FIX_UNSETTLED,
+    )
+
+
+def _transport_outcome(pr: PRUnderMerge, error: Exception) -> Outcome:
+    return Outcome(
+        GuardVerdict.WAIT,
+        "TRANSPORT",
+        f"greenlight's ledger could not be read: {error}",
+        pr.pr_num,
+        pr.head_sha,
+        LEDGER_UNREADABLE,
+        FIX_TRANSPORT,
+    )
+
+
+def _needs_greenlight(pr: PRUnderMerge) -> bool:
+    if not any(is_greenlight(login) for login in pr.approved_by):
+        return False
+    return not pr.is_authorized_without_greenlight()
+
+
+def evaluate_greenlight_guard(
+    repo_full_name: str,
+    prs: Sequence[PRUnderMerge],
+    *,
+    wait_window: GreenlightWaitWindow | None,
+    now: datetime | None = None,
+    fetch_states: Callable[[str, Sequence[int]], dict[int, LedgerState]] | None = None,
+) -> GuardResult:
+    """Decide whether the PRs a single merge will land may proceed.
+
+    ``wait_window`` is the merge command's wait budget, shared across every re-entry.
+    None means the caller (a force merge) has no retry loop to wait in, so nothing waits.
+
+    ``fetch_states`` is resolved here rather than bound as a default argument, so that
+    patching the ledger reader in a test actually takes effect.
+    """
+    moment = now if now is not None else datetime.now(timezone.utc)
+    fetch = fetch_states if fetch_states is not None else fetch_ledger_states
+    guarded = [pr for pr in prs if _needs_greenlight(pr)]
+    if not guarded:
+        return GuardResult(GuardVerdict.ALLOW)
+
+    try:
+        states = fetch(repo_full_name, [pr.pr_num for pr in guarded])
+    except GreenlightLedgerError as e:
+        # A sustained outage still ends in a refusal once the budget runs out, but a
+        # brief HUD blip must not kill a merge that is otherwise ready to land.
+        outcomes = [_transport_outcome(pr, e) for pr in guarded]
+    else:
+        outcomes = [_evaluate_pr(pr, states.get(pr.pr_num), moment) for pr in guarded]
+
+    unresolved = [o for o in outcomes if o.verdict is not GuardVerdict.ALLOW]
+    if not unresolved:
+        return GuardResult(GuardVerdict.ALLOW)
+    if any(o.verdict is GuardVerdict.DENY for o in unresolved):
+        # Every unresolved PR in the stack is reported, waits included: the merge is
+        # over either way, and fixing only the refusal would just hit the wait next.
+        # Refusals lead, because they are the ones the reader has to act on.
+        ordered = sorted(unresolved, key=lambda o: o.verdict is not GuardVerdict.DENY)
+        return GuardResult(GuardVerdict.DENY, render_refusal(ordered))
+
+    waits = unresolved
+    if wait_window is None:
+        return GuardResult(GuardVerdict.DENY, render_refusal(waits, FORCE_SUFFIX))
+    if wait_window.register_wait(moment):
+        return GuardResult(
+            GuardVerdict.DENY, render_refusal(waits, timeout_suffix(MAX_WAIT_MINUTES))
+        )
+    comment = (
+        render_announcement(waits, MAX_WAIT_MINUTES, GREENLIGHT_LOGIN)
+        if wait_window.claim_announcement()
+        else ""
+    )
+    return GuardResult(GuardVerdict.WAIT, render_wait(waits), comment)

--- a/.github/scripts/greenlight_identity.py
+++ b/.github/scripts/greenlight_identity.py
@@ -1,0 +1,51 @@
+"""One way to compare GitHub logins across the greenlight guard, and who greenlight is.
+
+The guard reads logins from two GitHub APIs that spell the same account differently:
+GraphQL renders a GitHub App's login bare while REST appends `[bot]`. Every comparison
+has to go through ``normalize_login`` or the two spellings silently fail to match, which
+here means either the guard switches itself off or it refuses a merge it should allow.
+"""
+
+from __future__ import annotations
+
+
+GREENLIGHT_LOGIN = "pytorchgreenlight"
+
+# A GitHub App acts through an account whose REST login is `<app-slug>[bot]`; mirrors
+# greenlight's constants.BOT_LOGIN_SUFFIX in pytorch/test-infra under
+# `greenlight/src/greenlight/`.
+BOT_LOGIN_SUFFIX = "[bot]"
+
+# Mirrors greenlight's pr_hash.BOT_LOGINS, which is what decides whose review counts as
+# a human's. The `[bot]` suffix alone does not identify a bot, because GraphQL strips it.
+BOT_LOGINS = frozenset(
+    {
+        "codecov",
+        "codecov-commenter",
+        "dependabot",
+        "facebook-github-bot",
+        "facebook-github-tools",
+        "github-actions",
+        "linux-foundation-easycla",
+        "meta-codesync",
+        "pytorch-bot",
+        "pytorchbot",
+        "pytorchmergebot",
+        "pytorchupdatebot",
+    }
+)
+
+
+def normalize_login(login: str) -> str:
+    """A login in the single form every comparison in the guard uses."""
+    return login.strip().lower().removesuffix(BOT_LOGIN_SUFFIX)
+
+
+def is_greenlight(login: str) -> bool:
+    return normalize_login(login) == GREENLIGHT_LOGIN
+
+
+def is_known_bot(login: str) -> bool:
+    """Whether this login belongs to a bot, by the same test greenlight applies."""
+    normalized = login.strip().lower()
+    return normalized.endswith(BOT_LOGIN_SUFFIX) or normalized in BOT_LOGINS

--- a/.github/scripts/greenlight_ledger.py
+++ b/.github/scripts/greenlight_ledger.py
@@ -1,0 +1,139 @@
+"""Client for greenlight's authoritative per-PR verdict ledger.
+
+Greenlight records one row per review run in ClickHouse's `misc.greenlight_pr_state`,
+naming the head SHA that run evaluated. This module reads the latest row per PR through
+the HUD route that fronts that table, so the merge path can tell whether greenlight has
+approved the exact commit about to land.
+
+Row selection lives server-side and mirrors greenlight's own reader: writer and reader
+have to agree on which row is authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import traceback
+import urllib.parse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, TYPE_CHECKING
+
+from github_utils import gh_fetch_url
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+
+STATUS_LAND = "LAND"
+STATUS_NO_LAND = "NO_LAND"
+STATUS_CANCELLED = "CANCELLED"
+STATUS_FAILED = "FAILED"
+STATUS_AI_REVIEW_STARTED = "AI_REVIEW_STARTED"
+STATUS_AI_REVIEW_DISPATCHED = "AI_REVIEW_DISPATCHED"
+
+IN_FLIGHT_STATUSES = frozenset({STATUS_AI_REVIEW_STARTED, STATUS_AI_REVIEW_DISPATCHED})
+# greenlight's own split, from greenlight/src/greenlight/constants.py. A terminal status
+# is one its scan will never revisit; CANCELLED and FAILED are retry-eligible there, so a
+# PR carrying one can still be picked up again.
+TERMINAL_STATUSES = frozenset({STATUS_LAND, STATUS_NO_LAND})
+
+LEDGER_URL = "https://hud.pytorch.org/api/greenlight/pr_state"
+
+# The route rejects longer batches. ghstack stacks never come close, but a rejected
+# batch fails closed and would block a merge that nobody can unblock.
+_MAX_PRS_PER_REQUEST = 50
+_NUM_RETRIES = 3
+_RETRY_BACKOFF_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class LedgerState:
+    pr_number: int
+    status: str
+    head_sha: str
+    run_id: int
+    version: datetime
+
+
+class GreenlightLedgerError(RuntimeError):
+    pass
+
+
+def parse_utc_timestamp(raw: str) -> datetime:
+    text = raw.strip()
+    # trymerge runs on Python 3.10, whose fromisoformat rejects the trailing Z that
+    # both this route and the GitHub REST API emit.
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_states(payload: Any) -> dict[int, LedgerState]:
+    states: dict[int, LedgerState] = {}
+    for row in payload["states"]:
+        state = LedgerState(
+            pr_number=int(row["pr_number"]),
+            status=str(row["status"]),
+            head_sha=str(row["head_sha"]),
+            run_id=int(row["run_id"]),
+            version=parse_utc_timestamp(str(row["version"])),
+        )
+        states[state.pr_number] = state
+    return states
+
+
+def _fetch_batch(
+    repo_full_name: str, pr_numbers: list[int], sleep: Callable[[float], None]
+) -> dict[int, LedgerState]:
+    query = urllib.parse.urlencode(
+        {"repo": repo_full_name, "prNumbers": ",".join(str(n) for n in pr_numbers)}
+    )
+    last_error: Exception | None = None
+    for attempt in range(_NUM_RETRIES):
+        try:
+            return _parse_states(
+                gh_fetch_url(
+                    f"{LEDGER_URL}?{query}",
+                    headers={"x-hud-internal-bot": os.getenv("HUD_API_TOKEN", "")},
+                    reader=json.load,
+                )
+            )
+        except Exception as e:
+            last_error = e
+            print(
+                f"Greenlight ledger read {attempt + 1}/{_NUM_RETRIES} for "
+                f"{repo_full_name} PRs {pr_numbers} failed: {type(e).__name__}: {e}",
+                flush=True,
+            )
+            if attempt + 1 < _NUM_RETRIES:
+                sleep(_RETRY_BACKOFF_SECONDS * 2**attempt)
+            else:
+                # The guard turns the raised error into a one-line message for the PR,
+                # so this is the only place the stack of the real failure is visible.
+                traceback.print_exc()
+    raise GreenlightLedgerError(
+        f"could not read the greenlight ledger for {repo_full_name} PRs {pr_numbers} "
+        f"after {_NUM_RETRIES} attempts: {type(last_error).__name__}: {last_error}"
+    ) from last_error
+
+
+def fetch_ledger_states(
+    repo_full_name: str,
+    pr_numbers: Sequence[int],
+    *,
+    sleep: Callable[[float], None] | None = None,
+) -> dict[int, LedgerState]:
+    """Latest ledger row per PR. PRs with no row are absent from the result."""
+    wait = sleep if sleep is not None else time.sleep
+    states: dict[int, LedgerState] = {}
+    ordered = list(pr_numbers)
+    for start in range(0, len(ordered), _MAX_PRS_PER_REQUEST):
+        batch = ordered[start : start + _MAX_PRS_PER_REQUEST]
+        states.update(_fetch_batch(repo_full_name, batch, wait))
+    return states

--- a/.github/scripts/greenlight_messages.py
+++ b/.github/scripts/greenlight_messages.py
@@ -1,0 +1,139 @@
+"""Render greenlight guard outcomes as the text a user reads.
+
+Three surfaces share one set of outcomes: the refusal that ends a merge, the line the
+merge command's retry loop logs while it waits, and the single comment posted to the PR
+the first time a merge waits on greenlight. The fix line for a PR greenlight structurally
+cannot review belongs to `greenlight_preflight` instead, next to the check that raises it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from greenlight_ledger import LEDGER_URL
+from greenlight_preflight import EXCLUDED_LABELS_PHRASE
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from greenlight_guard import Outcome
+    from greenlight_ledger import LedgerState
+
+
+GREENLIGHT_JOB_URL = (
+    "https://github.com/pytorch/test-infra/actions/workflows/greenlight-pr-review.yml"
+)
+
+_REVIEWS_RUN_AT = f"Greenlight reviews run at {GREENLIGHT_JOB_URL}"
+
+_ONLY_AUTHORITY = (
+    "Greenlight's approval is the only one authorizing this merge, so it cannot land "
+    "until greenlight records a verdict for the exact commit being landed."
+)
+
+FIX_HUMAN = (
+    "To land this now, get an approval from a human reviewer with merge rights for "
+    "these files, or push a commit so greenlight reviews the new content."
+)
+FIX_RETRIGGER = (
+    "Push a commit to trigger a fresh greenlight review, or get an approval from a "
+    "human reviewer with merge rights."
+)
+FIX_UNSETTLED = (
+    "To land without greenlight, get an approval from a human reviewer with merge "
+    "rights for these files. To get a greenlight verdict instead, push a commit, "
+    f"remove the {EXCLUDED_LABELS_PHRASE} if it is set, and resolve any requested "
+    "changes."
+)
+FIX_TRANSPORT = (
+    "Re-issue the merge command; if it keeps failing, ask Dev Infra to check the HUD "
+    f"greenlight route at {LEDGER_URL}."
+)
+
+# The same escape hatches, worded for a merge that is still running: `merge` aborts the
+# moment a new commit appears on the PR, so pushing one here is not a free retrigger.
+_WAIT_OPTIONS = (
+    "To land without waiting, get an approval from a human reviewer with merge rights "
+    f"for these files, or remove the {EXCLUDED_LABELS_PHRASE} and resolve any requested "
+    "changes so greenlight picks the PR up. Pushing a commit gets greenlight to review "
+    "the new content but ends this merge command, so re-issue the merge afterwards."
+)
+
+FORCE_SUFFIX = "A force merge does not wait for greenlight."
+
+LEDGER_UNREADABLE = "Greenlight ledger: could not be read"
+
+
+def describe_ledger(state: LedgerState | None) -> str:
+    if state is None:
+        return "Greenlight ledger: no row for this PR"
+    return (
+        f"Greenlight ledger: {state.status} at {state.head_sha} "
+        f"(run {state.run_id}, recorded {state.version.isoformat()})"
+    )
+
+
+def timeout_suffix(minutes: int) -> str:
+    return f"Greenlight did not answer after {minutes} minutes of waiting."
+
+
+def _sentence(text: str) -> str:
+    return f"{text[:1].upper()}{text[1:]}."
+
+
+def _bullet(outcome: Outcome, *, with_fix: bool) -> str:
+    lines = [
+        f"- PR #{outcome.pr_num} ({outcome.kind}): {outcome.detail}.",
+        f"  - Head commit: `{outcome.head_sha}`.",
+        f"  - {outcome.ledger}.",
+    ]
+    if with_fix and outcome.fix:
+        lines.append(f"  - {outcome.fix}")
+    return "\n".join(lines)
+
+
+def render_refusal(outcomes: Sequence[Outcome], suffix: str = "") -> str:
+    """The refusal that ends a merge, leading with what actually went wrong.
+
+    ``outcomes`` is ordered by the caller so that the PR the user has to act on comes
+    first; its detail becomes the headline, because that is the sentence people read.
+    """
+    parts = [_sentence(outcomes[0].detail)]
+    if suffix:
+        parts.append(suffix)
+    parts.append(_ONLY_AUTHORITY)
+    parts.append("\n".join(_bullet(outcome, with_fix=True) for outcome in outcomes))
+    parts.append(_REVIEWS_RUN_AT)
+    return "\n\n".join(parts)
+
+
+def render_wait(outcomes: Sequence[Outcome]) -> str:
+    parts = [
+        "Waiting on greenlight before merging.",
+        *(
+            f"PR #{o.pr_num} ({o.kind}): {o.detail}. Head commit: {o.head_sha}. "
+            f"{o.ledger}."
+            for o in outcomes
+        ),
+        _REVIEWS_RUN_AT,
+    ]
+    return " ".join(parts)
+
+
+def render_announcement(outcomes: Sequence[Outcome], minutes: int, login: str) -> str:
+    """The one comment a merge posts to the PR when it starts waiting on greenlight."""
+    listed = "\n".join(
+        f"- PR #{outcome.pr_num}: {outcome.detail} (head commit `{outcome.head_sha}`)."
+        for outcome in outcomes
+    )
+    return "\n\n".join(
+        (
+            f"This merge is waiting for `{login}` to review the commit it will land.",
+            _ONLY_AUTHORITY,
+            listed,
+            f"The merge command keeps retrying for up to {minutes} minutes. "
+            f"{_WAIT_OPTIONS}",
+            _REVIEWS_RUN_AT,
+        )
+    )

--- a/.github/scripts/greenlight_preflight.py
+++ b/.github/scripts/greenlight_preflight.py
@@ -1,0 +1,242 @@
+"""Detect PRs greenlight will never produce a verdict for, so a merge can refuse early.
+
+Mirrors the upstream filters that drop a PR before it is ever fingerprinted, both in
+pytorch/test-infra under `greenlight/src/greenlight/`: `review._recency_filter` (the
+excluded labels and the review window, each with an escape for a PR whose recorded status
+is non-terminal) and both arms of `review_gate.human_review_skip_reason` (changes
+requested by a non-bot, and an approval from the merge-authorized set). Drift from those
+costs a merge an hour of waiting for a verdict that was never coming, or refuses a PR
+greenlight would in fact have reviewed.
+
+What it does not mirror is the `--pr` recheck path, on which upstream passes
+`skip_on_approval=False` and so reviews an approved PR anyway. pytorch/pytorch has no way
+to reach that path, so an approval is terminal here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import NamedTuple, TYPE_CHECKING
+
+from greenlight_identity import is_greenlight, is_known_bot, normalize_login
+from greenlight_ledger import parse_utc_timestamp, TERMINAL_STATUSES
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from datetime import datetime
+
+    from greenlight_guard import PRUnderMerge
+
+
+# greenlight's EXCLUDED_LABELS and its STALE_LABEL member, from its constants.py. The set
+# is mirrored rather than the member so that a label added upstream lands here too. GitHub
+# labels are case-sensitive and the pytorch stale bot applies this exact name.
+STALE_LABEL = "Stale"
+EXCLUDED_LABELS = frozenset({STALE_LABEL})
+
+# greenlight's review_window_hours default. Outside it the scan drops the PR before
+# fingerprinting, so no verdict will ever arrive. Upstream reads it from
+# PYTORCH_GREENLIGHT_REVIEW_WINDOW_HOURS, so an override there silently skews this check.
+REVIEW_WINDOW = timedelta(hours=24)
+
+
+def _label_phrase(labels: Sequence[str]) -> str:
+    names = ", ".join(f"`{label}`" for label in labels)
+    return f"{names} label" if len(labels) == 1 else f"{names} labels"
+
+
+EXCLUDED_LABELS_PHRASE = _label_phrase(sorted(EXCLUDED_LABELS))
+
+FIX_CHANGES_REQUESTED = (
+    "Resolve or dismiss that review, or get an approval from a human reviewer with "
+    "merge rights."
+)
+FIX_UNCLASSIFIED_REVIEWER = (
+    "Re-issue the merge command. If that review is from a person, resolve or dismiss "
+    "it, or get an approval from a human reviewer with merge rights."
+)
+FIX_HUMAN_APPROVED = (
+    "Dismiss that approval, or get an approval from a reviewer the merge rule for "
+    "these files accepts."
+)
+FIX_STALE_LABEL = (
+    f"Remove the {EXCLUDED_LABELS_PHRASE}, or get an approval from a human reviewer "
+    "with merge rights."
+)
+FIX_OUT_OF_WINDOW = (
+    "Push a commit to bring it back into range, or get an approval from a human "
+    "reviewer with merge rights."
+)
+
+
+@dataclass(frozen=True)
+class CannotReview:
+    """Why greenlight will not produce a verdict for this PR, and how to fix it.
+
+    ``retryable`` marks a cause the guard could not confirm because a GitHub lookup
+    failed. A transport failure must not harden into a permanent merge refusal, so those
+    are reported as something to wait on rather than something settled.
+    """
+
+    cause: str
+    fix: str
+    retryable: bool = False
+
+
+class ReviewerScan(NamedTuple):
+    """Logins that read as people, and whether GitHub answered which ones are Apps."""
+
+    humans: list[str]
+    classified: bool
+
+
+class _AppReviewers:
+    """The PR's App-account reviewers, fetched at most once per evaluation."""
+
+    def __init__(self, pr: PRUnderMerge) -> None:
+        self._pr = pr
+        self._loaded = False
+        self._logins: frozenset[str] | None = None
+
+    def logins(self) -> frozenset[str] | None:
+        """Normalized App logins, or None when the lookup failed."""
+        if not self._loaded:
+            reported = self._pr.get_bot_reviewers()
+            self._logins = (
+                None
+                if reported is None
+                else frozenset(normalize_login(login) for login in reported)
+            )
+            self._loaded = True
+        return self._logins
+
+
+def _named_bots_removed(logins: Iterable[str]) -> list[str]:
+    return sorted(
+        {
+            login
+            for login in logins
+            if not is_known_bot(login) and not is_greenlight(login)
+        }
+    )
+
+
+def _apps_removed(candidates: list[str], apps: _AppReviewers) -> ReviewerScan:
+    """Drop the candidates GitHub reports as App accounts.
+
+    GraphQL gives no account type, so an App whose login is neither suffixed nor listed
+    in greenlight's own bot set is indistinguishable from a person until REST answers.
+    """
+    if not candidates:
+        return ReviewerScan([], True)
+    known_apps = apps.logins()
+    if known_apps is None:
+        return ReviewerScan(candidates, False)
+    return ReviewerScan(
+        [login for login in candidates if normalize_login(login) not in known_apps],
+        True,
+    )
+
+
+def blocking_reviewers(
+    pr: PRUnderMerge, apps: _AppReviewers | None = None
+) -> ReviewerScan:
+    """The non-bot logins whose requested changes stop greenlight reviewing this PR."""
+    return _apps_removed(
+        _named_bots_removed(pr.changes_requested_by), apps or _AppReviewers(pr)
+    )
+
+
+def _merge_authorized_approvers(pr: PRUnderMerge, apps: _AppReviewers) -> ReviewerScan:
+    """The PR's approvers that greenlight counts as a human merge authority.
+
+    Membership is the flat lowercased union of every `approved_by` entry in
+    merge_rules.yaml, ignoring file patterns, because that is what upstream's
+    `merge_authz.resolve_authorized_logins` builds and what the scan compares against.
+    """
+    candidates = _named_bots_removed(pr.approved_by)
+    if not candidates:
+        return ReviewerScan([], True)
+    authorized = pr.get_merge_authorized_logins()
+    listed = [login for login in candidates if normalize_login(login) in authorized]
+    return _apps_removed(listed, apps)
+
+
+def _outside_review_window(pr: PRUnderMerge, now: datetime) -> str | None:
+    updated_at = pr.get_updated_at()
+    if updated_at is None:
+        return None
+    try:
+        updated = parse_utc_timestamp(updated_at)
+    except ValueError as e:
+        print(
+            f"Unparsable updated_at {updated_at!r} for PR #{pr.pr_num}, skipping the "
+            f"greenlight review-window check: {e}",
+            flush=True,
+        )
+        return None
+    if updated >= now - REVIEW_WINDOW:
+        return None
+    return updated_at
+
+
+def cannot_review(
+    pr: PRUnderMerge, ledger_status: str | None, now: datetime
+) -> CannotReview | None:
+    """Why greenlight will never dispatch a review for this PR, and how to fix it."""
+    apps = _AppReviewers(pr)
+    blocking = blocking_reviewers(pr, apps)
+    if blocking.humans:
+        listed = ", ".join(blocking.humans)
+        if not blocking.classified:
+            return CannotReview(
+                f"GitHub did not say whether {listed} is a person or an app, and "
+                "greenlight skips any PR whose requested changes a person left "
+                "unresolved",
+                FIX_UNCLASSIFIED_REVIEWER,
+                retryable=True,
+            )
+        return CannotReview(
+            f"{listed} requested changes, and greenlight skips any PR with unresolved "
+            "requested changes",
+            FIX_CHANGES_REQUESTED,
+        )
+    approved = _merge_authorized_approvers(pr, apps)
+    if approved.humans:
+        listed = ", ".join(approved.humans)
+        if not approved.classified:
+            return CannotReview(
+                f"GitHub did not say whether {listed} is a person or an app, and "
+                "greenlight skips any PR a person listed in merge_rules.yaml has "
+                "approved",
+                FIX_UNCLASSIFIED_REVIEWER,
+                retryable=True,
+            )
+        return CannotReview(
+            f"{listed} already approved it, and greenlight skips any PR approved by a "
+            "login listed anywhere in merge_rules.yaml, even when that approval does "
+            "not satisfy the merge rule for the files this PR changes",
+            FIX_HUMAN_APPROVED,
+        )
+    # A non-terminal status is upstream's escape from the recency filter: its scan keeps
+    # a labelled or out-of-window PR whose last review is in flight, cancelled, or
+    # failed, because it can still re-dispatch that one.
+    if ledger_status is not None and ledger_status not in TERMINAL_STATUSES:
+        return None
+    present = sorted(EXCLUDED_LABELS.intersection(pr.labels))
+    if present:
+        return CannotReview(
+            f"it carries the {_label_phrase(present)}, and greenlight skips labelled PRs",
+            FIX_STALE_LABEL,
+        )
+    stale_since = _outside_review_window(pr, now)
+    if stale_since is not None:
+        hours = int(REVIEW_WINDOW.total_seconds() // 3600)
+        return CannotReview(
+            f"the PR was last updated at {stale_since}, outside greenlight's {hours}h "
+            "review window",
+            FIX_OUT_OF_WINDOW,
+        )
+    return None

--- a/.github/scripts/test_greenlight_guard.py
+++ b/.github/scripts/test_greenlight_guard.py
@@ -1,0 +1,740 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest import main, mock, TestCase
+
+import greenlight_guard
+from greenlight_guard import (
+    DEAD_REVIEW_AGE,
+    evaluate_greenlight_guard,
+    GREENLIGHT_LOGIN,
+    GreenlightWaitWindow,
+    GuardVerdict,
+    MAX_WAIT,
+    PRUnderMerge,
+)
+from greenlight_ledger import (
+    LedgerState,
+    STATUS_AI_REVIEW_DISPATCHED,
+    STATUS_AI_REVIEW_STARTED,
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_LAND,
+    STATUS_NO_LAND,
+)
+from greenlight_messages import GREENLIGHT_JOB_URL
+from greenlight_preflight import REVIEW_WINDOW, STALE_LABEL
+
+
+NOW = datetime(2026, 8, 25, 12, 0, 0, tzinfo=timezone.utc)
+MERGE_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+REPO = "pytorch/pytorch"
+
+
+def make_pr(
+    pr_num: int = 1,
+    head_sha: str = MERGE_SHA,
+    approved_by: tuple[str, ...] = (GREENLIGHT_LOGIN,),
+    changes_requested_by: tuple[str, ...] = (),
+    labels: tuple[str, ...] = (),
+    updated_at: str | None = None,
+    bot_reviewers: tuple[str, ...] | None = (),
+    merge_authorized: tuple[str, ...] = (),
+    authorized_without_greenlight: bool = False,
+) -> PRUnderMerge:
+    """A PR under merge. ``bot_reviewers=None`` is a failed reviewer-type lookup."""
+    return PRUnderMerge(
+        pr_num=pr_num,
+        head_sha=head_sha,
+        approved_by=list(approved_by),
+        changes_requested_by=list(changes_requested_by),
+        labels=list(labels),
+        get_updated_at=lambda: updated_at,
+        get_bot_reviewers=lambda: (
+            None if bot_reviewers is None else frozenset(bot_reviewers)
+        ),
+        get_merge_authorized_logins=lambda: frozenset(merge_authorized),
+        is_authorized_without_greenlight=lambda: authorized_without_greenlight,
+    )
+
+
+def make_state(
+    status: str = STATUS_LAND,
+    head_sha: str = MERGE_SHA,
+    pr_number: int = 1,
+    run_id: int = 7,
+    age: timedelta = timedelta(minutes=1),
+) -> LedgerState:
+    return LedgerState(
+        pr_number=pr_number,
+        status=status,
+        head_sha=head_sha,
+        run_id=run_id,
+        version=NOW - age,
+    )
+
+
+def evaluate(
+    prs: list[PRUnderMerge],
+    states: dict[int, LedgerState],
+    *,
+    wait_window: GreenlightWaitWindow | None = None,
+    now: datetime = NOW,
+) -> greenlight_guard.GuardResult:
+    """Evaluate with a wait budget, a fresh one unless the caller brings their own."""
+    return evaluate_greenlight_guard(
+        REPO,
+        prs,
+        wait_window=wait_window if wait_window is not None else GreenlightWaitWindow(),
+        now=now,
+        fetch_states=lambda _repo, _nums: states,
+    )
+
+
+def evaluate_force(
+    prs: list[PRUnderMerge],
+    states: dict[int, LedgerState],
+    *,
+    now: datetime = NOW,
+) -> greenlight_guard.GuardResult:
+    """Evaluate as a force merge: no retry loop to wait in."""
+    return evaluate_greenlight_guard(
+        REPO,
+        prs,
+        wait_window=None,
+        now=now,
+        fetch_states=lambda _repo, _nums: states,
+    )
+
+
+class TestPredicate(TestCase):
+    def test_skips_pr_greenlight_did_not_approve(self) -> None:
+        fetch = mock.MagicMock()
+        result = evaluate_greenlight_guard(
+            REPO,
+            [make_pr(approved_by=("malfet",))],
+            wait_window=GreenlightWaitWindow(),
+            now=NOW,
+            fetch_states=fetch,
+        )
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+        fetch.assert_not_called()
+
+    def test_skips_when_another_approver_carries_a_merge_rule(self) -> None:
+        fetch = mock.MagicMock()
+        result = evaluate_greenlight_guard(
+            REPO,
+            [
+                make_pr(
+                    approved_by=(GREENLIGHT_LOGIN, "malfet"),
+                    authorized_without_greenlight=True,
+                )
+            ],
+            wait_window=GreenlightWaitWindow(),
+            now=NOW,
+            fetch_states=fetch,
+        )
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+        fetch.assert_not_called()
+
+    def test_drive_by_approver_does_not_disable_the_guard(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "a-random-stranger"),
+            authorized_without_greenlight=False,
+        )
+        result = evaluate([pr], {1: make_state(status=STATUS_NO_LAND)})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+
+    def test_greenlight_login_is_matched_case_insensitively(self) -> None:
+        pr = make_pr(approved_by=("PyTorchGreenlight",))
+        result = evaluate([pr], {1: make_state(status=STATUS_NO_LAND)})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+
+    def test_a_bot_suffixed_greenlight_login_still_triggers_the_guard(self) -> None:
+        pr = make_pr(approved_by=(f"{GREENLIGHT_LOGIN}[bot]",))
+        result = evaluate([pr], {1: make_state(status=STATUS_NO_LAND)})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+
+
+class TestLaziness(TestCase):
+    """Every callable on PRUnderMerge costs a request, so none may fire needlessly."""
+
+    def _instrumented(self, **kwargs: Any) -> tuple[PRUnderMerge, dict[str, Any]]:
+        calls = {
+            "get_updated_at": mock.MagicMock(return_value=None),
+            "get_bot_reviewers": mock.MagicMock(return_value=frozenset()),
+            "get_merge_authorized_logins": mock.MagicMock(return_value=frozenset()),
+            "is_authorized_without_greenlight": mock.MagicMock(return_value=False),
+        }
+        base = make_pr(**kwargs)
+        return (
+            PRUnderMerge(
+                pr_num=base.pr_num,
+                head_sha=base.head_sha,
+                approved_by=base.approved_by,
+                changes_requested_by=base.changes_requested_by,
+                labels=base.labels,
+                get_updated_at=calls["get_updated_at"],
+                get_bot_reviewers=calls["get_bot_reviewers"],
+                get_merge_authorized_logins=calls["get_merge_authorized_logins"],
+                is_authorized_without_greenlight=calls[
+                    "is_authorized_without_greenlight"
+                ],
+            ),
+            calls,
+        )
+
+    def test_nothing_is_queried_when_greenlight_did_not_approve(self) -> None:
+        pr, calls = self._instrumented(approved_by=("malfet",))
+        self.assertEqual(evaluate([pr], {}).verdict, GuardVerdict.ALLOW)
+        for name, call in calls.items():
+            with self.subTest(callable=name):
+                call.assert_not_called()
+
+    def test_preflight_facts_are_untouched_when_the_verdict_already_matches(
+        self,
+    ) -> None:
+        pr, calls = self._instrumented(labels=(STALE_LABEL,))
+        self.assertEqual(
+            evaluate([pr], {1: make_state(status=STATUS_LAND)}).verdict,
+            GuardVerdict.ALLOW,
+        )
+        calls["is_authorized_without_greenlight"].assert_called_once()
+        calls["get_updated_at"].assert_not_called()
+        calls["get_bot_reviewers"].assert_not_called()
+        calls["get_merge_authorized_logins"].assert_not_called()
+
+    def test_reviewer_types_are_only_read_for_an_unrecognized_blocker(self) -> None:
+        pr, calls = self._instrumented(changes_requested_by=("pytorch-bot",))
+        self.assertEqual(evaluate([pr], {}).verdict, GuardVerdict.WAIT)
+        calls["get_bot_reviewers"].assert_not_called()
+
+    def test_merge_rules_are_only_read_when_a_person_approved(self) -> None:
+        pr, calls = self._instrumented(approved_by=(GREENLIGHT_LOGIN, "pytorchbot"))
+        self.assertEqual(evaluate([pr], {}).verdict, GuardVerdict.WAIT)
+        calls["get_merge_authorized_logins"].assert_not_called()
+        calls["get_bot_reviewers"].assert_not_called()
+
+    def test_reviewer_types_are_not_read_for_an_unlisted_approver(self) -> None:
+        pr, calls = self._instrumented(
+            approved_by=(GREENLIGHT_LOGIN, "a-random-stranger")
+        )
+        self.assertEqual(evaluate([pr], {}).verdict, GuardVerdict.WAIT)
+        calls["get_merge_authorized_logins"].assert_called_once()
+        calls["get_bot_reviewers"].assert_not_called()
+
+
+class TestDecisionTable(TestCase):
+    def test_land_at_head_sha_allows(self) -> None:
+        result = evaluate([make_pr()], {1: make_state(status=STATUS_LAND)})
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+        self.assertEqual(result.message, "")
+
+    def test_negative_verdict_at_head_sha_denies(self) -> None:
+        for status in (STATUS_NO_LAND, STATUS_CANCELLED, STATUS_FAILED):
+            with self.subTest(status=status):
+                result = evaluate([make_pr()], {1: make_state(status=status)})
+                self.assertEqual(result.verdict, GuardVerdict.DENY)
+                self.assertIn("NEGATIVE_VERDICT", result.message)
+                self.assertIn(status, result.message)
+                self.assertIn(MERGE_SHA, result.message)
+
+    def test_in_flight_at_head_sha_waits(self) -> None:
+        for status in (STATUS_AI_REVIEW_STARTED, STATUS_AI_REVIEW_DISPATCHED):
+            with self.subTest(status=status):
+                result = evaluate([make_pr()], {1: make_state(status=status)})
+                self.assertEqual(result.verdict, GuardVerdict.WAIT)
+                self.assertIn("IN_FLIGHT", result.message)
+
+    def test_different_head_sha_waits(self) -> None:
+        for status in (STATUS_LAND, STATUS_NO_LAND, STATUS_AI_REVIEW_STARTED):
+            with self.subTest(status=status):
+                result = evaluate(
+                    [make_pr()], {1: make_state(status=status, head_sha=OTHER_SHA)}
+                )
+                self.assertEqual(result.verdict, GuardVerdict.WAIT)
+                self.assertIn("SHA_MISMATCH", result.message)
+                self.assertIn(OTHER_SHA, result.message)
+                self.assertIn(MERGE_SHA, result.message)
+
+    def test_the_sha_mismatch_kind_does_not_collide_with_the_stale_label(self) -> None:
+        """`Stale` is a GitHub label the refusal also talks about; the kind is not it."""
+        result = evaluate([make_pr()], {1: make_state(head_sha=OTHER_SHA)})
+        self.assertNotIn("(STALE)", result.message)
+
+    def test_missing_row_waits(self) -> None:
+        result = evaluate([make_pr()], {})
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+        self.assertIn("NO_ROW", result.message)
+        self.assertIn("no row for this PR", result.message)
+
+    def test_dead_in_flight_review_denies(self) -> None:
+        result = evaluate(
+            [make_pr()],
+            {1: make_state(status=STATUS_AI_REVIEW_STARTED, age=DEAD_REVIEW_AGE)},
+        )
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("DEAD_REVIEW", result.message)
+
+    def test_in_flight_review_just_under_the_age_limit_waits(self) -> None:
+        result = evaluate(
+            [make_pr()],
+            {
+                1: make_state(
+                    status=STATUS_AI_REVIEW_STARTED,
+                    age=DEAD_REVIEW_AGE - timedelta(seconds=1),
+                )
+            },
+        )
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+    def test_unrecognized_status_denies(self) -> None:
+        result = evaluate([make_pr()], {1: make_state(status="WAT")})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("UNKNOWN_STATUS", result.message)
+
+    def test_message_names_the_run_id_and_ledger_sha(self) -> None:
+        result = evaluate(
+            [make_pr()], {1: make_state(status=STATUS_NO_LAND, run_id=4242)}
+        )
+        self.assertIn("run 4242", result.message)
+        self.assertIn(GREENLIGHT_JOB_URL, result.message)
+
+
+class TestShaComparison(TestCase):
+    def test_case_differences_do_not_break_the_match(self) -> None:
+        pr = make_pr(head_sha=MERGE_SHA.upper())
+        result = evaluate([pr], {1: make_state(head_sha=MERGE_SHA)})
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+
+    def test_surrounding_whitespace_does_not_break_the_match(self) -> None:
+        pr = make_pr(head_sha=f" {MERGE_SHA}\n")
+        result = evaluate([pr], {1: make_state(head_sha=MERGE_SHA)})
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+
+    def test_two_equal_non_shas_never_allow(self) -> None:
+        for sha in ("", "unknown", MERGE_SHA[:39], f"{MERGE_SHA}0", "z" * 40):
+            with self.subTest(sha=sha):
+                result = evaluate(
+                    [make_pr(head_sha=sha)], {1: make_state(head_sha=sha)}
+                )
+                self.assertNotEqual(result.verdict, GuardVerdict.ALLOW)
+
+
+class TestStack(TestCase):
+    def test_denial_anywhere_in_the_stack_wins_over_a_wait(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha=MERGE_SHA),
+            make_pr(pr_num=2, head_sha=OTHER_SHA),
+        ]
+        states = {2: make_state(pr_number=2, status=STATUS_NO_LAND, head_sha=OTHER_SHA)}
+        result = evaluate(prs, states)
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("PR #2", result.message)
+
+    def test_a_refusal_also_reports_the_prs_still_unsettled(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha="1" * 40),
+            make_pr(pr_num=2, head_sha="2" * 40),
+        ]
+        states = {2: make_state(pr_number=2, status=STATUS_NO_LAND, head_sha="2" * 40)}
+        result = evaluate(prs, states)
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("PR #1 (NO_ROW)", result.message)
+        self.assertIn("PR #2 (NEGATIVE_VERDICT)", result.message)
+
+    def test_every_denial_in_the_stack_is_reported(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha="1" * 40),
+            make_pr(pr_num=2, head_sha="2" * 40),
+        ]
+        states = {
+            1: make_state(pr_number=1, status=STATUS_NO_LAND, head_sha="1" * 40),
+            2: make_state(pr_number=2, status="WAT", head_sha="2" * 40),
+        }
+        result = evaluate(prs, states)
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("PR #1 (NEGATIVE_VERDICT)", result.message)
+        self.assertIn("PR #2 (UNKNOWN_STATUS)", result.message)
+
+    def test_every_wait_in_the_stack_is_reported(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha="1" * 40),
+            make_pr(pr_num=2, head_sha="2" * 40),
+        ]
+        states = {
+            2: make_state(
+                pr_number=2, status=STATUS_AI_REVIEW_STARTED, head_sha="2" * 40
+            )
+        }
+        result = evaluate(prs, states)
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+        self.assertIn("PR #1 (NO_ROW)", result.message)
+        self.assertIn("PR #2 (IN_FLIGHT)", result.message)
+
+    def test_mixed_stack_only_queries_the_greenlight_only_prs(self) -> None:
+        human_approved = make_pr(pr_num=1, approved_by=("malfet",), head_sha="1" * 40)
+        greenlight_a = make_pr(pr_num=2, head_sha="2" * 40)
+        greenlight_b = make_pr(pr_num=3, head_sha="3" * 40)
+        seen: list[Any] = []
+
+        def fetch(repo: str, numbers: Any) -> dict[int, LedgerState]:
+            seen.append((repo, list(numbers)))
+            return {
+                2: make_state(pr_number=2, head_sha="2" * 40),
+                3: make_state(pr_number=3, head_sha="3" * 40),
+            }
+
+        result = evaluate_greenlight_guard(
+            REPO,
+            [human_approved, greenlight_a, greenlight_b],
+            wait_window=GreenlightWaitWindow(),
+            now=NOW,
+            fetch_states=fetch,
+        )
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+        self.assertEqual(seen, [(REPO, [2, 3])])
+
+    def test_stack_is_checked_against_each_prs_own_head_sha(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha="1" * 40),
+            make_pr(pr_num=2, head_sha="2" * 40),
+        ]
+        states = {
+            1: make_state(pr_number=1, head_sha="1" * 40),
+            2: make_state(pr_number=2, head_sha="1" * 40),
+        }
+        result = evaluate(prs, states)
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+        self.assertIn("PR #2", result.message)
+
+
+class TestPreflight(TestCase):
+    def test_changes_requested_by_a_human_denies_instead_of_waiting(self) -> None:
+        result = evaluate([make_pr(changes_requested_by=("some-reviewer",))], {})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("CANNOT_REVIEW", result.message)
+        self.assertIn("some-reviewer", result.message)
+        self.assertIn("Resolve or dismiss", result.message)
+
+    def test_changes_requested_by_a_bot_still_waits(self) -> None:
+        for login in ("pytorch-bot", "facebook-github-tools[bot]", "PyTorchBot"):
+            with self.subTest(login=login):
+                result = evaluate([make_pr(changes_requested_by=(login,))], {})
+                self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+    def test_changes_requested_by_an_unlisted_app_still_waits(self) -> None:
+        pr = make_pr(
+            changes_requested_by=("some-new-app",), bot_reviewers=("Some-New-App",)
+        )
+        self.assertEqual(evaluate([pr], {}).verdict, GuardVerdict.WAIT)
+
+    def test_stale_label_denies_instead_of_waiting(self) -> None:
+        result = evaluate([make_pr(labels=(STALE_LABEL,))], {})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("CANNOT_REVIEW", result.message)
+        self.assertIn(f"`{STALE_LABEL}` label", result.message)
+
+    def test_pr_outside_the_review_window_denies_instead_of_waiting(self) -> None:
+        stale = (NOW - REVIEW_WINDOW - timedelta(minutes=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        result = evaluate([make_pr(updated_at=stale)], {})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("CANNOT_REVIEW", result.message)
+        self.assertIn("review window", result.message)
+        self.assertIn(stale, result.message)
+
+    def test_pr_inside_the_review_window_waits(self) -> None:
+        recent = (NOW - REVIEW_WINDOW + timedelta(minutes=1)).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        result = evaluate([make_pr(updated_at=recent)], {})
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+    def test_unreadable_updated_at_falls_back_to_waiting(self) -> None:
+        self.assertEqual(
+            evaluate([make_pr(updated_at=None)], {}).verdict, GuardVerdict.WAIT
+        )
+        self.assertEqual(
+            evaluate([make_pr(updated_at="not a timestamp")], {}).verdict,
+            GuardVerdict.WAIT,
+        )
+
+    def test_a_redispatchable_review_survives_the_stale_label(self) -> None:
+        for status in (STATUS_CANCELLED, STATUS_FAILED, STATUS_AI_REVIEW_STARTED):
+            with self.subTest(status=status):
+                result = evaluate(
+                    [make_pr(labels=(STALE_LABEL,))],
+                    {1: make_state(status=status, head_sha=OTHER_SHA)},
+                )
+                self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+    def test_a_terminal_verdict_does_not_survive_the_stale_label(self) -> None:
+        for status in (STATUS_LAND, STATUS_NO_LAND):
+            with self.subTest(status=status):
+                result = evaluate(
+                    [make_pr(labels=(STALE_LABEL,))],
+                    {1: make_state(status=status, head_sha=OTHER_SHA)},
+                )
+                self.assertEqual(result.verdict, GuardVerdict.DENY)
+                self.assertIn("CANNOT_REVIEW", result.message)
+
+    def test_a_redispatchable_review_survives_the_review_window(self) -> None:
+        stale = (NOW - REVIEW_WINDOW - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = evaluate(
+            [make_pr(updated_at=stale)],
+            {1: make_state(status=STATUS_CANCELLED, head_sha=OTHER_SHA)},
+        )
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+    def test_changes_requested_denies_even_for_a_redispatchable_review(self) -> None:
+        result = evaluate(
+            [make_pr(changes_requested_by=("some-reviewer",))],
+            {1: make_state(status=STATUS_CANCELLED, head_sha=OTHER_SHA)},
+        )
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("CANNOT_REVIEW", result.message)
+
+    def test_preflight_does_not_override_a_settled_verdict_at_the_head_sha(
+        self,
+    ) -> None:
+        stale = (NOW - REVIEW_WINDOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        pr = make_pr(
+            changes_requested_by=("some-reviewer",),
+            labels=(STALE_LABEL,),
+            updated_at=stale,
+        )
+        result = evaluate([pr], {1: make_state(status=STATUS_LAND)})
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+
+    def test_preflight_does_not_interrupt_a_review_of_the_head_sha(self) -> None:
+        pr = make_pr(changes_requested_by=("some-reviewer",), labels=(STALE_LABEL,))
+        result = evaluate([pr], {1: make_state(status=STATUS_AI_REVIEW_STARTED)})
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+    def test_preflight_applies_when_the_ledger_row_is_for_another_commit(self) -> None:
+        pr = make_pr(labels=(STALE_LABEL,))
+        result = evaluate([pr], {1: make_state(head_sha=OTHER_SHA)})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("CANNOT_REVIEW", result.message)
+
+
+class TestWaiting(TestCase):
+    def test_the_budget_opens_at_the_first_wait_not_at_the_merge_command(self) -> None:
+        window = GreenlightWaitWindow()
+        much_later = NOW + timedelta(hours=4)
+
+        first = evaluate([make_pr()], {}, wait_window=window, now=much_later)
+        self.assertEqual(first.verdict, GuardVerdict.WAIT)
+        self.assertEqual(window.opened_at, much_later)
+
+        still_waiting = evaluate(
+            [make_pr()],
+            {},
+            wait_window=window,
+            now=much_later + MAX_WAIT - timedelta(seconds=1),
+        )
+        self.assertEqual(still_waiting.verdict, GuardVerdict.WAIT)
+
+        expired = evaluate(
+            [make_pr()], {}, wait_window=window, now=much_later + MAX_WAIT
+        )
+        self.assertEqual(expired.verdict, GuardVerdict.DENY)
+        self.assertIn("did not answer after 60 minutes of waiting", expired.message)
+        self.assertIn("NO_ROW", expired.message)
+
+    def test_an_allow_never_opens_the_budget(self) -> None:
+        window = GreenlightWaitWindow()
+        result = evaluate([make_pr()], {1: make_state()}, wait_window=window)
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+        self.assertIsNone(window.opened_at)
+
+    def test_a_caller_that_cannot_retry_denies_instead_of_waiting(self) -> None:
+        result = evaluate_force([make_pr()], {})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("force merge does not wait", result.message)
+
+    def test_a_caller_that_cannot_retry_still_allows_a_matching_land(self) -> None:
+        result = evaluate_force([make_pr()], {1: make_state()})
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+
+    def test_the_two_refusals_that_follow_a_wait_name_a_next_step(self) -> None:
+        window = GreenlightWaitWindow()
+        evaluate([make_pr()], {}, wait_window=window)
+        refusals = (
+            evaluate([make_pr()], {}, wait_window=window, now=NOW + MAX_WAIT).message,
+            evaluate_force([make_pr()], {}).message,
+        )
+        for message in refusals:
+            with self.subTest(message=message):
+                self.assertIn("human reviewer with merge rights", message)
+                self.assertIn("push a commit", message)
+                self.assertIn(f"`{STALE_LABEL}` label", message)
+                self.assertIn("resolve any requested changes", message)
+
+
+class TestAnnouncement(TestCase):
+    def test_the_first_wait_carries_one_comment(self) -> None:
+        window = GreenlightWaitWindow()
+        first = evaluate([make_pr()], {}, wait_window=window)
+        self.assertEqual(first.verdict, GuardVerdict.WAIT)
+        self.assertIn(GREENLIGHT_LOGIN, first.comment)
+        self.assertIn(f"head commit `{MERGE_SHA}`", first.comment)
+        self.assertIn("up to 60 minutes", first.comment)
+        self.assertNotIn("more minutes", first.comment)
+        self.assertIn("human reviewer with merge rights", first.comment)
+        # merge() aborts on a new commit, so the comment must not sell a push as a
+        # free retrigger of the merge that is currently running.
+        self.assertIn("re-issue the merge", first.comment)
+
+    def test_later_waits_carry_no_comment(self) -> None:
+        window = GreenlightWaitWindow()
+        evaluate([make_pr()], {}, wait_window=window)
+        later = evaluate(
+            [make_pr()], {}, wait_window=window, now=NOW + timedelta(minutes=5)
+        )
+        self.assertEqual(later.verdict, GuardVerdict.WAIT)
+        self.assertEqual(later.comment, "")
+
+    def test_an_allow_or_a_denial_carries_no_comment(self) -> None:
+        self.assertEqual(evaluate([make_pr()], {1: make_state()}).comment, "")
+        self.assertEqual(
+            evaluate([make_pr()], {1: make_state(status=STATUS_NO_LAND)}).comment, ""
+        )
+        self.assertEqual(evaluate_force([make_pr()], {}).comment, "")
+
+    def test_the_comment_lists_every_waiting_pr_in_the_stack(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha="1" * 40),
+            make_pr(pr_num=2, head_sha="2" * 40),
+        ]
+        result = evaluate(prs, {})
+        self.assertIn("PR #1", result.comment)
+        self.assertIn("PR #2", result.comment)
+
+    def test_a_timeout_refusal_carries_no_comment(self) -> None:
+        """The wait was already announced; the refusal is delivered by the merge itself."""
+        window = GreenlightWaitWindow()
+        first = evaluate([make_pr()], {}, wait_window=window)
+        self.assertNotEqual(first.comment, "")
+        expired = evaluate([make_pr()], {}, wait_window=window, now=NOW + MAX_WAIT)
+        self.assertEqual(expired.verdict, GuardVerdict.DENY)
+        self.assertEqual(expired.comment, "")
+
+    def test_a_timeout_on_the_very_first_evaluation_carries_no_comment(self) -> None:
+        """A budget already spent when it opens still must not announce a wait."""
+        window = GreenlightWaitWindow(opened_at=NOW - MAX_WAIT)
+        expired = evaluate([make_pr()], {}, wait_window=window)
+        self.assertEqual(expired.verdict, GuardVerdict.DENY)
+        self.assertEqual(expired.comment, "")
+        self.assertFalse(window.announced)
+
+
+class TestRefusalLayout(TestCase):
+    def test_the_refusal_opens_with_the_cause_not_the_precondition(self) -> None:
+        result = evaluate([make_pr()], {1: make_state(status=STATUS_NO_LAND)})
+        headline = result.message.split("\n", 1)[0]
+        self.assertEqual(
+            headline, f"Greenlight recorded {STATUS_NO_LAND} for this exact commit."
+        )
+
+    def test_the_refusal_is_paragraphs_and_bullets_not_one_run_on(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha="1" * 40),
+            make_pr(pr_num=2, head_sha="2" * 40),
+        ]
+        states = {2: make_state(pr_number=2, status=STATUS_NO_LAND, head_sha="2" * 40)}
+        result = evaluate(prs, states)
+        self.assertIn("\n\n", result.message)
+        self.assertIn("- PR #1 (NO_ROW):", result.message)
+        self.assertIn("- PR #2 (NEGATIVE_VERDICT):", result.message)
+        longest = max(len(line) for line in result.message.splitlines())
+        self.assertLess(longest, 300)
+
+    def test_the_pr_to_act_on_is_listed_before_the_ones_merely_waiting(self) -> None:
+        prs = [
+            make_pr(pr_num=1, head_sha="1" * 40),
+            make_pr(pr_num=2, head_sha="2" * 40),
+        ]
+        states = {2: make_state(pr_number=2, status=STATUS_NO_LAND, head_sha="2" * 40)}
+        message = evaluate(prs, states).message
+        self.assertLess(message.index("PR #2"), message.index("PR #1 ("))
+
+    def test_a_timeout_refusal_still_opens_with_the_cause(self) -> None:
+        window = GreenlightWaitWindow()
+        evaluate([make_pr()], {}, wait_window=window)
+        expired = evaluate([make_pr()], {}, wait_window=window, now=NOW + MAX_WAIT)
+        lines = expired.message.split("\n\n")
+        self.assertEqual(lines[0], "Greenlight has not reviewed this PR yet.")
+        self.assertIn("60 minutes", lines[1])
+
+
+class TestMergeAuthorizedApproval(TestCase):
+    """A PR greenlight's own scan drops because a merge_rules approver handled it."""
+
+    def _pr(self, **kwargs: Any) -> PRUnderMerge:
+        return make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "malfet"),
+            merge_authorized=("malfet",),
+            **kwargs,
+        )
+
+    def test_it_refuses_now_rather_than_waiting_an_hour(self) -> None:
+        result = evaluate([self._pr()], {})
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("CANNOT_REVIEW", result.message)
+        self.assertIn("malfet", result.message)
+        self.assertIn("merge_rules.yaml", result.message)
+        self.assertIn("Dismiss that approval", result.message)
+
+    def test_the_advice_does_not_send_the_author_after_a_new_commit(self) -> None:
+        """Pushing cannot help: the scan drops the PR again at any head."""
+        result = evaluate([self._pr()], {})
+        headline, *rest = result.message.split("\n\n")
+        self.assertNotIn("push a commit", headline.lower())
+        self.assertNotIn("@greenlight", result.message)
+
+    def test_an_unreadable_reviewer_type_waits_instead_of_refusing(self) -> None:
+        result = evaluate([self._pr(bot_reviewers=None)], {})
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+        self.assertIn("UNCLASSIFIED_REVIEWER", result.message)
+
+    def test_an_approval_at_the_head_sha_is_still_honoured(self) -> None:
+        result = evaluate([self._pr()], {1: make_state(status=STATUS_LAND)})
+        self.assertEqual(result.verdict, GuardVerdict.ALLOW)
+
+
+class TestUnclassifiedReviewer(TestCase):
+    """A failed reviewer-type lookup must stay retryable, never a terminal refusal."""
+
+    def test_an_unrecognized_blocker_waits_when_the_lookup_failed(self) -> None:
+        pr = make_pr(changes_requested_by=("some-new-app",), bot_reviewers=None)
+        result = evaluate([pr], {})
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+        self.assertIn("UNCLASSIFIED_REVIEWER", result.message)
+        self.assertIn("some-new-app", result.message)
+
+    def test_a_known_bot_blocker_never_needs_the_lookup(self) -> None:
+        pr = make_pr(changes_requested_by=("pytorch-bot",), bot_reviewers=None)
+        self.assertEqual(evaluate([pr], {}).verdict, GuardVerdict.WAIT)
+        self.assertNotIn("UNCLASSIFIED_REVIEWER", evaluate([pr], {}).message)
+
+    def test_a_sustained_lookup_failure_still_refuses_once_the_budget_is_spent(
+        self,
+    ) -> None:
+        pr = make_pr(changes_requested_by=("some-new-app",), bot_reviewers=None)
+        window = GreenlightWaitWindow()
+        self.assertEqual(
+            evaluate([pr], {}, wait_window=window).verdict, GuardVerdict.WAIT
+        )
+        expired = evaluate([pr], {}, wait_window=window, now=NOW + MAX_WAIT)
+        self.assertEqual(expired.verdict, GuardVerdict.DENY)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_greenlight_ledger.py
+++ b/.github/scripts/test_greenlight_ledger.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from unittest import main, mock, TestCase
+from urllib.error import HTTPError, URLError
+
+import greenlight_ledger
+from greenlight_guard import (
+    evaluate_greenlight_guard,
+    GreenlightWaitWindow,
+    GuardVerdict,
+    MAX_WAIT,
+)
+from greenlight_ledger import (
+    fetch_ledger_states,
+    GreenlightLedgerError,
+    STATUS_AI_REVIEW_STARTED,
+    STATUS_LAND,
+)
+from test_greenlight_guard import make_pr, MERGE_SHA, NOW, REPO
+
+
+# A run_id as production emits it: an unquoted JSON number far past 32 bits.
+LARGE_RUN_ID = 32747018107
+
+
+def evaluate(
+    *, wait_window: GreenlightWaitWindow | None = None, now: datetime = NOW
+) -> Any:
+    return evaluate_greenlight_guard(
+        REPO,
+        [make_pr()],
+        wait_window=wait_window if wait_window is not None else GreenlightWaitWindow(),
+        now=now,
+    )
+
+
+class TestLedgerTransport(TestCase):
+    def _http_error(self, code: int = 500, reason: str = "boom") -> HTTPError:
+        return HTTPError(greenlight_ledger.LEDGER_URL, code, reason, {}, None)  # type: ignore[arg-type]
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_reads_all_prs_in_one_request(self, fetch_url: mock.MagicMock) -> None:
+        fetch_url.return_value = {
+            "states": [
+                {
+                    "pr_number": 5,
+                    "status": STATUS_LAND,
+                    "head_sha": MERGE_SHA,
+                    "run_id": 3,
+                    "version": "2026-08-25T11:59:00.000Z",
+                }
+            ]
+        }
+        with mock.patch.dict("os.environ", {"HUD_API_TOKEN": "token"}):
+            states = fetch_ledger_states(REPO, [5, 6])
+
+        fetch_url.assert_called_once()
+        url = fetch_url.call_args.args[0]
+        self.assertIn("repo=pytorch%2Fpytorch", url)
+        self.assertIn("prNumbers=5%2C6", url)
+        self.assertEqual(
+            fetch_url.call_args.kwargs["headers"], {"x-hud-internal-bot": "token"}
+        )
+        self.assertEqual(set(states), {5})
+        self.assertEqual(states[5].run_id, 3)
+        self.assertEqual(
+            states[5].version, datetime(2026, 8, 25, 11, 59, tzinfo=timezone.utc)
+        )
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_unknown_response_fields_are_ignored(
+        self, fetch_url: mock.MagicMock
+    ) -> None:
+        """The route is free to grow fields without breaking a deployed trymerge."""
+        fetch_url.return_value = {
+            "states": [
+                {
+                    "pr_number": 5,
+                    "status": STATUS_LAND,
+                    "head_sha": MERGE_SHA,
+                    "run_id": 3,
+                    "version": "2026-08-25T11:59:00.000Z",
+                    "a_field_added_later": {"nested": True},
+                }
+            ],
+            "an_envelope_field_added_later": 1,
+        }
+        states = fetch_ledger_states(REPO, [5])
+        self.assertEqual(states[5].head_sha, MERGE_SHA)
+        self.assertEqual(states[5].status, STATUS_LAND)
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_every_route_error_response_is_transport_class(
+        self, fetch_url: mock.MagicMock
+    ) -> None:
+        for code, reason in (
+            (400, "repo must be owner/name"),
+            (400, "repo and prNumbers are required"),
+            (400, "prNumbers must be positive integers"),
+            (400, "at most 50 prNumbers"),
+            (401, "unauthorized"),
+            (405, "method not allowed"),
+            (500, "internal error"),
+        ):
+            with self.subTest(code=code, reason=reason):
+                fetch_url.side_effect = self._http_error(code, reason)
+                with self.assertRaises(GreenlightLedgerError) as cm:
+                    fetch_ledger_states(REPO, [5], sleep=lambda _s: None)
+                self.assertIn(str(code), str(cm.exception))
+                self.assertIn(reason, str(cm.exception))
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_batches_are_capped_at_the_route_limit(
+        self, fetch_url: mock.MagicMock
+    ) -> None:
+        fetch_url.return_value = {"states": []}
+        limit = greenlight_ledger._MAX_PRS_PER_REQUEST
+        fetch_ledger_states(REPO, list(range(1, limit + 2)))
+        self.assertEqual(fetch_url.call_count, 2)
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_retries_then_raises_on_persistent_http_errors(
+        self, fetch_url: mock.MagicMock
+    ) -> None:
+        fetch_url.side_effect = self._http_error()
+        sleeps: list[float] = []
+        with self.assertRaises(GreenlightLedgerError):
+            fetch_ledger_states(REPO, [5], sleep=sleeps.append)
+        self.assertEqual(fetch_url.call_count, 3)
+        self.assertEqual(sleeps, [2.0, 4.0])
+
+    @mock.patch("greenlight_ledger.time.sleep")
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_the_backoff_sleep_is_patchable(
+        self, fetch_url: mock.MagicMock, sleep: mock.MagicMock
+    ) -> None:
+        fetch_url.side_effect = self._http_error()
+        with self.assertRaises(GreenlightLedgerError):
+            fetch_ledger_states(REPO, [5])
+        self.assertEqual(sleep.call_args_list, [mock.call(2.0), mock.call(4.0)])
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_recovers_when_a_retry_succeeds(self, fetch_url: mock.MagicMock) -> None:
+        fetch_url.side_effect = [self._http_error(), {"states": []}]
+        self.assertEqual(fetch_ledger_states(REPO, [5], sleep=lambda _s: None), {})
+        self.assertEqual(fetch_url.call_count, 2)
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_timeouts_and_malformed_payloads_raise(
+        self, fetch_url: mock.MagicMock
+    ) -> None:
+        failures = [
+            URLError("timed out"),
+            json.JSONDecodeError("bad", "", 0),
+            KeyError("states"),
+        ]
+        payloads: list[Any] = [
+            {"unexpected": []},
+            {"states": [{"pr_number": 5}]},
+            {
+                "states": [
+                    {
+                        "pr_number": 5,
+                        "status": STATUS_LAND,
+                        "head_sha": MERGE_SHA,
+                        "run_id": 1,
+                        "version": "nope",
+                    }
+                ]
+            },
+        ]
+        for failure in failures:
+            with self.subTest(failure=type(failure).__name__):
+                fetch_url.side_effect = failure
+                with self.assertRaises(GreenlightLedgerError):
+                    fetch_ledger_states(REPO, [5], sleep=lambda _s: None)
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                fetch_url.side_effect = None
+                fetch_url.return_value = payload
+                with self.assertRaises(GreenlightLedgerError):
+                    fetch_ledger_states(REPO, [5], sleep=lambda _s: None)
+
+    def test_version_timestamps_are_normalized_to_aware_utc(self) -> None:
+        cases = {
+            "2026-08-25T11:59:00.048Z": datetime(
+                2026, 8, 25, 11, 59, 0, 48000, tzinfo=timezone.utc
+            ),
+            "2026-08-25T13:59:00.000+02:00": datetime(
+                2026, 8, 25, 11, 59, tzinfo=timezone.utc
+            ),
+            "2026-08-25 11:59:00.000": datetime(
+                2026, 8, 25, 11, 59, tzinfo=timezone.utc
+            ),
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                parsed = greenlight_ledger.parse_utc_timestamp(raw)
+                # Everything downstream subtracts these from an aware `now`; a naive
+                # result would raise TypeError inside the age-out check instead.
+                self.assertIsNotNone(parsed.tzinfo)
+                self.assertEqual(parsed, expected)
+
+
+@mock.patch("greenlight_ledger.time.sleep")
+@mock.patch("greenlight_ledger.gh_fetch_url")
+class TestUnreadableLedger(TestCase):
+    """A HUD blip must not kill a merge, but a sustained outage still refuses it."""
+
+    def _http_error(self) -> HTTPError:
+        return HTTPError(greenlight_ledger.LEDGER_URL, 500, "boom", {}, None)  # type: ignore[arg-type]
+
+    def test_transport_failure_waits(self, fetch_url: Any, _sleep: Any) -> None:
+        fetch_url.side_effect = self._http_error()
+        result = evaluate()
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+        self.assertIn("TRANSPORT", result.message)
+        self.assertIn("#1", result.message)
+
+    def test_a_sustained_outage_denies_once_the_budget_is_spent(
+        self, fetch_url: Any, _sleep: Any
+    ) -> None:
+        fetch_url.side_effect = self._http_error()
+        window = GreenlightWaitWindow()
+        self.assertEqual(
+            evaluate(wait_window=window).verdict,
+            GuardVerdict.WAIT,
+        )
+        expired = evaluate(wait_window=window, now=NOW + MAX_WAIT)
+        self.assertEqual(expired.verdict, GuardVerdict.DENY)
+        self.assertIn("TRANSPORT", expired.message)
+        self.assertIn("did not answer after 60 minutes of waiting", expired.message)
+        self.assertIn(greenlight_ledger.LEDGER_URL, expired.message)
+
+    def test_a_force_merge_refuses_immediately(
+        self, fetch_url: Any, _sleep: Any
+    ) -> None:
+        fetch_url.side_effect = self._http_error()
+        result = evaluate_greenlight_guard(REPO, [make_pr()], wait_window=None, now=NOW)
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("TRANSPORT", result.message)
+
+
+class TestParsedTimestampsReachTheAgeOutCheck(TestCase):
+    """The route's timestamps must survive parsing into the dead-review arithmetic."""
+
+    def _payload(self, version: str) -> dict[str, Any]:
+        return {
+            "states": [
+                {
+                    "pr_number": 1,
+                    "status": STATUS_AI_REVIEW_STARTED,
+                    "head_sha": MERGE_SHA,
+                    "run_id": LARGE_RUN_ID,
+                    "version": version,
+                }
+            ]
+        }
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def _verdict_for(self, version: str, fetch_url: mock.MagicMock) -> Any:
+        fetch_url.return_value = self._payload(version)
+        return evaluate()
+
+    def test_a_fresh_route_timestamp_waits(self) -> None:
+        result = self._verdict_for("2026-08-25T11:59:00.048Z")
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+    def test_an_aged_out_route_timestamp_denies(self) -> None:
+        result = self._verdict_for("2026-08-25T11:00:00.048Z")
+        self.assertEqual(result.verdict, GuardVerdict.DENY)
+        self.assertIn("DEAD_REVIEW", result.message)
+
+    def test_a_large_run_id_survives_parsing_and_reaches_the_message(self) -> None:
+        result = self._verdict_for("2026-08-25T11:00:00.048Z")
+        self.assertIn(f"run {LARGE_RUN_ID}", result.message)
+
+
+class TestLedgerReaderIsPatchable(TestCase):
+    @mock.patch("greenlight_guard.fetch_ledger_states")
+    def test_patching_the_reader_keeps_the_guard_off_the_network(
+        self, fetch_states: mock.MagicMock
+    ) -> None:
+        fetch_states.return_value = {}
+        with mock.patch("greenlight_ledger.gh_fetch_url") as fetch_url:
+            result = evaluate()
+        fetch_states.assert_called_once_with(REPO, [1])
+        fetch_url.assert_not_called()
+        self.assertEqual(result.verdict, GuardVerdict.WAIT)
+
+
+class TestStatusGroupings(TestCase):
+    def test_terminal_statuses_match_greenlights_own_split(self) -> None:
+        self.assertEqual(
+            greenlight_ledger.TERMINAL_STATUSES,
+            frozenset(
+                {greenlight_ledger.STATUS_LAND, greenlight_ledger.STATUS_NO_LAND}
+            ),
+        )
+        self.assertTrue(
+            greenlight_ledger.TERMINAL_STATUSES.isdisjoint(
+                greenlight_ledger.IN_FLIGHT_STATUSES
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_greenlight_preflight.py
+++ b/.github/scripts/test_greenlight_preflight.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import main, TestCase
+
+from greenlight_identity import GREENLIGHT_LOGIN
+from greenlight_ledger import (
+    STATUS_AI_REVIEW_DISPATCHED,
+    STATUS_AI_REVIEW_STARTED,
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_LAND,
+    STATUS_NO_LAND,
+)
+from greenlight_preflight import (
+    blocking_reviewers,
+    cannot_review,
+    EXCLUDED_LABELS,
+    REVIEW_WINDOW,
+    STALE_LABEL,
+)
+from test_greenlight_guard import make_pr, NOW
+
+
+IN_WINDOW = (NOW - REVIEW_WINDOW + timedelta(minutes=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+OUT_OF_WINDOW = (NOW - REVIEW_WINDOW - timedelta(minutes=1)).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)
+
+# greenlight's review._recency_filter keeps a PR whose recorded status is not terminal,
+# because its scan can still re-dispatch that review; TERMINAL_STATUSES upstream is
+# exactly {LAND, NO_LAND}.
+REDISPATCHABLE = (
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_AI_REVIEW_STARTED,
+    STATUS_AI_REVIEW_DISPATCHED,
+)
+SETTLED = (STATUS_LAND, STATUS_NO_LAND)
+
+
+class TestBlockingReviewers(TestCase):
+    def test_a_human_blocks(self) -> None:
+        pr = make_pr(changes_requested_by=("some-reviewer",))
+        self.assertEqual(blocking_reviewers(pr).humans, ["some-reviewer"])
+
+    def test_a_listed_bot_does_not_block(self) -> None:
+        pr = make_pr(changes_requested_by=("pytorchbot", "PyTorch-Bot"))
+        self.assertEqual(blocking_reviewers(pr).humans, [])
+
+    def test_a_bot_suffixed_login_does_not_block(self) -> None:
+        pr = make_pr(changes_requested_by=("some-app[bot]",))
+        self.assertEqual(blocking_reviewers(pr).humans, [])
+
+    def test_greenlight_itself_does_not_block(self) -> None:
+        pr = make_pr(changes_requested_by=(GREENLIGHT_LOGIN,))
+        self.assertEqual(blocking_reviewers(pr).humans, [])
+
+    def test_an_app_github_reports_as_a_bot_does_not_block(self) -> None:
+        """REST names an App `slug[bot]`; GraphQL names the same App bare."""
+        pr = make_pr(
+            changes_requested_by=("some-new-app", "a-human"),
+            bot_reviewers=("Some-New-App[bot]",),
+        )
+        self.assertEqual(blocking_reviewers(pr).humans, ["a-human"])
+
+    def test_a_failed_reviewer_type_lookup_is_reported_as_unclassified(self) -> None:
+        pr = make_pr(changes_requested_by=("some-new-app",), bot_reviewers=None)
+        scan = blocking_reviewers(pr)
+        self.assertEqual(scan.humans, ["some-new-app"])
+        self.assertFalse(scan.classified)
+
+    def test_a_failed_lookup_with_nothing_to_classify_is_still_classified(self) -> None:
+        pr = make_pr(changes_requested_by=("pytorchbot",), bot_reviewers=None)
+        scan = blocking_reviewers(pr)
+        self.assertEqual(scan.humans, [])
+        self.assertTrue(scan.classified)
+
+
+class TestHumanApproval(TestCase):
+    """greenlight's review_gate.human_review_skip_reason HUMAN_APPROVED arm."""
+
+    def test_an_approver_listed_in_merge_rules_blocks(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "malfet"), merge_authorized=("malfet",)
+        )
+        blocked = cannot_review(pr, None, NOW)
+        if blocked is None:
+            self.fail("expected the merge-authorized approval to block a review")
+        self.assertIn("malfet", blocked.cause)
+        self.assertIn("merge_rules.yaml", blocked.cause)
+        self.assertIn("Dismiss that approval", blocked.fix)
+        self.assertFalse(blocked.retryable)
+
+    def test_membership_ignores_case(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "Malfet"), merge_authorized=("malfet",)
+        )
+        self.assertIsNotNone(cannot_review(pr, None, NOW))
+
+    def test_an_approver_absent_from_merge_rules_does_not_block(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "a-random-stranger"),
+            merge_authorized=("malfet",),
+        )
+        self.assertIsNone(cannot_review(pr, None, NOW))
+
+    def test_greenlight_is_listed_in_merge_rules_but_is_not_a_human(self) -> None:
+        for login in (GREENLIGHT_LOGIN, f"{GREENLIGHT_LOGIN}[bot]"):
+            with self.subTest(login=login):
+                pr = make_pr(
+                    approved_by=(login,), merge_authorized=(GREENLIGHT_LOGIN, "malfet")
+                )
+                self.assertIsNone(cannot_review(pr, None, NOW))
+
+    def test_a_named_bot_in_merge_rules_is_not_a_human(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "pytorchbot"),
+            merge_authorized=("pytorchbot",),
+        )
+        self.assertIsNone(cannot_review(pr, None, NOW))
+
+    def test_an_app_github_reports_as_a_bot_is_not_a_human(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "some-new-app"),
+            merge_authorized=("some-new-app",),
+            bot_reviewers=("some-new-app[bot]",),
+        )
+        self.assertIsNone(cannot_review(pr, None, NOW))
+
+    def test_a_failed_reviewer_type_lookup_is_retryable(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "some-new-app"),
+            merge_authorized=("some-new-app",),
+            bot_reviewers=None,
+        )
+        blocked = cannot_review(pr, None, NOW)
+        if blocked is None:
+            self.fail("expected the unclassified approver to block a review")
+        self.assertTrue(blocked.retryable)
+
+    def test_an_approval_blocks_regardless_of_the_recorded_status(self) -> None:
+        """The approval skip is applied at fingerprint time, past the recency escape."""
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "malfet"),
+            merge_authorized=("malfet",),
+            updated_at=IN_WINDOW,
+        )
+        for status in (*REDISPATCHABLE, *SETTLED, None):
+            with self.subTest(status=status):
+                self.assertIsNotNone(cannot_review(pr, status, NOW))
+
+    def test_requested_changes_are_reported_ahead_of_an_approval(self) -> None:
+        pr = make_pr(
+            approved_by=(GREENLIGHT_LOGIN, "malfet"),
+            changes_requested_by=("some-reviewer",),
+            merge_authorized=("malfet",),
+        )
+        blocked = cannot_review(pr, None, NOW)
+        if blocked is None:
+            self.fail("expected the requested changes to block a review")
+        self.assertIn("some-reviewer", blocked.cause)
+
+
+class TestRecencyFilterMirror(TestCase):
+    """Pins this module's mirror of greenlight review._recency_filter's shape.
+
+    It checks the escape this module implements, not upstream's source: nothing here
+    would notice if upstream changed, which is what the citations in the module under
+    test are for.
+    """
+
+    def test_stale_label_blocks_only_a_settled_or_absent_review(self) -> None:
+        pr = make_pr(labels=(STALE_LABEL,))
+        for status in REDISPATCHABLE:
+            with self.subTest(status=status):
+                self.assertIsNone(cannot_review(pr, status, NOW))
+        for status in SETTLED:
+            with self.subTest(status=status):
+                self.assertIsNotNone(cannot_review(pr, status, NOW))
+        self.assertIsNotNone(cannot_review(pr, None, NOW))
+
+    def test_every_excluded_label_blocks(self) -> None:
+        for label in EXCLUDED_LABELS:
+            with self.subTest(label=label):
+                blocked = cannot_review(make_pr(labels=(label,)), None, NOW)
+                if blocked is None:
+                    self.fail(f"expected the {label} label to block a review")
+                self.assertIn(f"`{label}`", blocked.cause)
+
+    def test_out_of_window_blocks_only_a_settled_or_absent_review(self) -> None:
+        pr = make_pr(updated_at=OUT_OF_WINDOW)
+        for status in REDISPATCHABLE:
+            with self.subTest(status=status):
+                self.assertIsNone(cannot_review(pr, status, NOW))
+        for status in SETTLED:
+            with self.subTest(status=status):
+                self.assertIsNotNone(cannot_review(pr, status, NOW))
+        self.assertIsNotNone(cannot_review(pr, None, NOW))
+
+    def test_a_recent_unlabelled_pr_is_never_blocked(self) -> None:
+        pr = make_pr(updated_at=IN_WINDOW)
+        for status in (*REDISPATCHABLE, *SETTLED, None):
+            with self.subTest(status=status):
+                self.assertIsNone(cannot_review(pr, status, NOW))
+
+    def test_requested_changes_block_regardless_of_the_recorded_status(self) -> None:
+        pr = make_pr(changes_requested_by=("some-reviewer",), updated_at=IN_WINDOW)
+        for status in (*REDISPATCHABLE, *SETTLED, None):
+            with self.subTest(status=status):
+                blocked = cannot_review(pr, status, NOW)
+                if blocked is None:
+                    self.fail("expected the requested changes to block a review")
+                self.assertIn("some-reviewer", blocked.cause)
+
+    def test_every_block_names_a_way_out(self) -> None:
+        cases = (
+            make_pr(changes_requested_by=("some-reviewer",)),
+            make_pr(changes_requested_by=("some-new-app",), bot_reviewers=None),
+            make_pr(labels=(STALE_LABEL,)),
+            make_pr(updated_at=OUT_OF_WINDOW),
+            make_pr(
+                approved_by=(GREENLIGHT_LOGIN, "malfet"), merge_authorized=("malfet",)
+            ),
+        )
+        for pr in cases:
+            with self.subTest(
+                pr=pr.labels or pr.changes_requested_by or pr.approved_by
+            ):
+                blocked = cannot_review(pr, None, NOW)
+                if blocked is None:
+                    self.fail("expected this PR to be unreviewable")
+                self.assertTrue(blocked.fix.endswith("."))
+                self.assertTrue(blocked.fix[:1].isupper())
+                self.assertIn("approval", blocked.fix)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_trymerge.py
+++ b/.github/scripts/test_trymerge.py
@@ -21,11 +21,20 @@ from urllib.error import HTTPError
 
 from github_utils import gh_graphql
 from gitutils import get_git_remote_name, get_git_repo_dir, GitRepo
+from greenlight_guard import (
+    GREENLIGHT_LOGIN,
+    GreenlightWaitWindow,
+    GuardResult,
+    GuardVerdict,
+)
+from greenlight_identity import normalize_login
 from trymerge import (
+    _AUTHORIZED_WITHOUT_GREENLIGHT,
     _find_non_matching_files,
     _revlist_to_prs,
     can_skip_internal_checks,
     categorize_checks,
+    check_greenlight_reviewed_head_sha,
     DRCI_CHECKRUN_NAME,
     ensure_mergeable_labels,
     find_matching_merge_rule,
@@ -35,18 +44,23 @@ from trymerge import (
     get_topmost_docker_pr,
     gh_get_team_members,
     GitHubPR,
+    is_authorized_without_greenlight,
     is_bot_initiated_codev_merge,
     is_docker_affecting_files,
     iter_issue_timeline_until_comment,
     JobCheckState,
     main as trymerge_main,
     MandatoryChecksMissingError,
+    merge,
+    merge_authorized_logins,
     MergeRule,
     MergeRuleFailedError,
     PostCommentError,
     RE_GHSTACK_DESC,
     read_merge_rules,
     remove_job_name_suffix,
+    REVIEW_PAGE_LIMIT,
+    REVIEWS_PER_PAGE,
     sha_from_committed_event,
     sha_from_force_push_after,
     validate_revert,
@@ -58,6 +72,8 @@ if "GIT_REMOTE_URL" not in os.environ:
 
 GQL_MOCKS = "gql_mocks.json.gz"
 DRCI_MOCKS = "drci_mocks.json.gz"
+
+MALFORMED_TEAM_REF = "pytorch/pytorch-dev-infra/extra"
 
 
 def mock_query(
@@ -253,6 +269,38 @@ def mocked_read_merge_rules_approvers(
     ]
 
 
+def mocked_read_merge_rules_greenlight(
+    repo: Any, org: str, project: str
+) -> list[MergeRule]:
+    return [
+        MergeRule(
+            name="Greenlight Review Bot",
+            patterns=["*"],
+            approved_by=[GREENLIGHT_LOGIN],
+            mandatory_checks_name=["Lint", "pull"],
+        ),
+        MergeRule(
+            name="Core Maintainers",
+            patterns=["*"],
+            approved_by=["malfet"],
+            mandatory_checks_name=["Lint", "pull"],
+        ),
+    ]
+
+
+def mocked_read_merge_rules_malformed_team(
+    repo: Any, org: str, project: str
+) -> list[MergeRule]:
+    return [
+        MergeRule(
+            name="Malformed Team",
+            patterns=["*"],
+            approved_by=[MALFORMED_TEAM_REF],
+            mandatory_checks_name=["Lint", "pull"],
+        ),
+    ]
+
+
 def mocked_read_merge_rules_raise(repo: Any, org: str, project: str) -> list[MergeRule]:
     raise RuntimeError("testing")
 
@@ -296,6 +344,24 @@ class TestTryMerge(TestCase):
         repo = DummyGitRepo()
         merge_rules = read_merge_rules(repo, "pytorch", "pytorch")
         self.assertGreater(len(merge_rules), 1)
+
+    def test_merge_rules_still_grant_greenlight_merge_authority(
+        self, *args: Any
+    ) -> None:
+        """GREENLIGHT_LOGIN is a copy of a login in merge_rules.yaml.
+
+        Renaming it there and not here would leave the guard watching for an approval
+        nobody can give, which silently switches the guard off.
+        """
+        merge_rules = read_merge_rules(DummyGitRepo(), "pytorch", "pytorch")
+        self.assertTrue(
+            any(
+                normalize_login(login) == GREENLIGHT_LOGIN
+                for rule in merge_rules
+                for login in rule.approved_by
+            ),
+            f"no merge rule lists {GREENLIGHT_LOGIN} in approved_by",
+        )
 
     def test_negative_pattern_excludes_subpath(self, *args: Any) -> None:
         "Patterns prefixed with '-' exclude matching files from a rule."
@@ -506,6 +572,25 @@ class TestTryMerge(TestCase):
         pr = GitHubPR("pytorch", "pytorch", 115495)
         # Test that PR with the correct approvers doesn't raise any exception
         self.assertTrue(find_matching_merge_rule(pr, repo) is not None)
+
+    @mock.patch(
+        "trymerge.read_merge_rules",
+        side_effect=mocked_read_merge_rules_malformed_team,
+    )
+    def test_match_rules_malformed_team_ref(self, *args: Any) -> None:
+        "Tests that a multi-slash approved_by entry aborts instead of matching any approval"
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        repo = DummyGitRepo()
+
+        with mock.patch(
+            "trymerge.gh_get_team_members", return_value=[]
+        ) as mock_members:
+            self.assertRaisesRegex(
+                ValueError,
+                MALFORMED_TEAM_REF,
+                lambda: find_matching_merge_rule(pr, repo),
+            )
+        mock_members.assert_not_called()
 
     @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules)
     def test_lint_fails(self, *args: Any) -> None:
@@ -1676,9 +1761,13 @@ class TestDockerCiGates(TestCase):
         mock_check_docker_builds_ready: mock.MagicMock,
     ) -> None:
         lower_pr = mock.MagicMock(spec=GitHubPR)
+        lower_pr.pr_num = 1000
         lower_pr.is_closed.return_value = False
         lower_pr.is_docker_affecting.return_value = True
         top_pr = mock.MagicMock(spec=GitHubPR)
+        top_pr.org = "pytorch"
+        top_pr.project = "pytorch"
+        top_pr.pr_num = 1001
         top_pr.is_ghstack_pr.return_value = True
         top_pr.is_closed.return_value = False
         top_pr.is_docker_affecting.return_value = False
@@ -1696,6 +1785,658 @@ class TestDockerCiGates(TestCase):
         mock_check_docker_builds_ready.assert_called_once_with(lower_pr)
         top_pr.merge_changes_locally.assert_called_once_with(
             repo, False, 1, ghstack_prs=ghstack_prs
+        )
+
+
+@mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+@mock.patch(
+    "trymerge.get_drci_classifications", side_effect=mocked_drci_classifications
+)
+@mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules_greenlight)
+class TestAuthorizedWithoutGreenlight(TestCase):
+    def setUp(self) -> None:
+        # The answer is memoized for the lifetime of a merge command's process; each
+        # test is a different command.
+        _AUTHORIZED_WITHOUT_GREENLIGHT.clear()
+
+    def _pr_approved_by(self, *logins: str) -> GitHubPR:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        pr._reviews = [(login, "APPROVED") for login in logins]
+        return pr
+
+    def test_greenlight_alone_is_required(self, *args: Any) -> None:
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN)
+        self.assertFalse(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+    def test_drive_by_approver_does_not_authorize_the_pr(self, *args: Any) -> None:
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN, "a-random-stranger")
+        self.assertFalse(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+    def test_a_real_rule_approver_makes_greenlight_unnecessary(
+        self, *args: Any
+    ) -> None:
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN, "malfet")
+        self.assertTrue(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+    def test_greenlight_is_stripped_case_insensitively(self, *args: Any) -> None:
+        pr = self._pr_approved_by("PyTorchGreenlight")
+        self.assertFalse(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+    def test_dismissed_greenlight_approval_is_not_an_approval(self, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        pr._reviews = [(GREENLIGHT_LOGIN, "DISMISSED"), ("malfet", "APPROVED")]
+        self.assertEqual(pr.get_approved_by(), ["malfet"])
+        self.assertTrue(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+    def test_a_bot_suffixed_greenlight_approval_is_still_greenlights(
+        self, *args: Any
+    ) -> None:
+        """REST spells the App `pytorchgreenlight[bot]`; dropping it must still work."""
+        pr = self._pr_approved_by(f"{GREENLIGHT_LOGIN}[bot]")
+        self.assertFalse(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+    def test_the_reject_reason_is_logged(self, *args: Any) -> None:
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN, "a-random-stranger")
+        with mock.patch("builtins.print") as mock_print:
+            self.assertFalse(is_authorized_without_greenlight(pr, DummyGitRepo()))
+        logged = " ".join(str(call.args[0]) for call in mock_print.call_args_list)
+        self.assertIn("#115495", logged)
+        self.assertIn("Core Maintainers", logged)
+
+    def test_the_answer_is_computed_once_per_approver_set(self, *args: Any) -> None:
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN)
+        repo = DummyGitRepo()
+        with mock.patch(
+            "trymerge.find_matching_merge_rule",
+            side_effect=MergeRuleFailedError("no rule"),
+        ) as mock_rule:
+            self.assertFalse(is_authorized_without_greenlight(pr, repo))
+            self.assertFalse(is_authorized_without_greenlight(pr, repo))
+        mock_rule.assert_called_once()
+
+    def test_an_approval_arriving_mid_merge_is_not_masked_by_the_cache(
+        self, *args: Any
+    ) -> None:
+        repo = DummyGitRepo()
+        self.assertFalse(
+            is_authorized_without_greenlight(
+                self._pr_approved_by(GREENLIGHT_LOGIN), repo
+            )
+        )
+        self.assertTrue(
+            is_authorized_without_greenlight(
+                self._pr_approved_by(GREENLIGHT_LOGIN, "malfet"), repo
+            )
+        )
+
+    def test_the_real_gates_arguments_are_used_verbatim(self, *args: Any) -> None:
+        """A rule the real gate would skip must not answer this question instead."""
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN, "malfet")
+        repo = DummyGitRepo()
+        with mock.patch("trymerge.find_matching_merge_rule") as mock_rule:
+            is_authorized_without_greenlight(
+                pr,
+                repo,
+                skip_mandatory_checks=True,
+                skip_internal_checks=True,
+                ignore_current_checks=["some-check"],
+            )
+        self.assertEqual(
+            mock_rule.call_args.kwargs,
+            {
+                "skip_mandatory_checks": True,
+                "skip_internal_checks": True,
+                "ignore_current_checks": ["some-check"],
+                "approved_by_override": {"malfet"},
+            },
+        )
+
+    def test_pending_mandatory_checks_keep_the_guard_on(self, *args: Any) -> None:
+        """The real gate skips such a rule and falls through to the Greenlight rule."""
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN, "malfet")
+        with mock.patch(
+            "trymerge.find_matching_merge_rule",
+            side_effect=MandatoryChecksMissingError("Lint is pending"),
+        ):
+            self.assertFalse(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+    def test_an_unusable_rule_set_keeps_the_guard_on(self, *args: Any) -> None:
+        pr = self._pr_approved_by(GREENLIGHT_LOGIN, "malfet")
+        with mock.patch(
+            "trymerge.find_matching_merge_rule",
+            side_effect=RuntimeError("This PR has internal changes"),
+        ):
+            self.assertFalse(is_authorized_without_greenlight(pr, DummyGitRepo()))
+
+
+@mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+class TestMergeAuthorizedLogins(TestCase):
+    """greenlight's merge_authz.resolve_authorized_logins, mirrored for the guard."""
+
+    @mock.patch(
+        "trymerge.read_merge_rules", side_effect=mocked_read_merge_rules_greenlight
+    )
+    def test_every_rules_approvers_are_unioned_and_lowercased(self, *args: Any) -> None:
+        self.assertEqual(
+            merge_authorized_logins(DummyGitRepo(), "pytorch", "pytorch"),
+            frozenset({GREENLIGHT_LOGIN, "malfet"}),
+        )
+
+    @mock.patch("trymerge.read_merge_rules")
+    def test_team_refs_are_expanded_to_members(
+        self, mock_rules: Any, *args: Any
+    ) -> None:
+        mock_rules.return_value = [
+            MergeRule(
+                name="Some Team",
+                patterns=["*"],
+                approved_by=["pytorch/some-team", "Malfet"],
+                mandatory_checks_name=None,
+            )
+        ]
+        with mock.patch(
+            "trymerge.gh_get_team_members", return_value=["Alice", "bob"]
+        ) as mock_members:
+            self.assertEqual(
+                merge_authorized_logins(DummyGitRepo(), "pytorch", "pytorch"),
+                frozenset({"alice", "bob", "malfet"}),
+            )
+        mock_members.assert_called_once_with("pytorch", "some-team")
+
+    @mock.patch("trymerge.read_merge_rules", side_effect=mocked_read_merge_rules_raise)
+    def test_an_unreadable_rules_file_yields_an_empty_set(self, *args: Any) -> None:
+        self.assertEqual(
+            merge_authorized_logins(DummyGitRepo(), "pytorch", "pytorch"), frozenset()
+        )
+
+    @mock.patch(
+        "trymerge.get_drci_classifications", side_effect=mocked_drci_classifications
+    )
+    @mock.patch("trymerge.read_merge_rules")
+    def test_a_malformed_team_ref_in_an_unmatched_rule_still_raises(
+        self, mock_rules: Any, *args: Any
+    ) -> None:
+        """Refusing a mis-typed team ref is deliberate: it must never resolve to nobody.
+
+        find_matching_merge_rule drops a rule whose patterns miss the PR before it
+        expands that rule's approvers, so the ref below never reaches it. This set
+        spans every rule in the file regardless of patterns, and the empty set it
+        would otherwise produce is what the guard reads as "no human authorized this".
+        """
+        mock_rules.return_value = [
+            MergeRule(
+                name="Malformed Team",
+                patterns=["some/path/that/no/pr/touches/**"],
+                approved_by=[MALFORMED_TEAM_REF],
+                mandatory_checks_name=None,
+            )
+        ]
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+
+        with mock.patch(
+            "trymerge.gh_get_team_members", return_value=[]
+        ) as mock_members:
+            self.assertRaisesRegex(
+                MergeRuleFailedError,
+                "No rule found to match PR",
+                lambda: find_matching_merge_rule(pr, DummyGitRepo()),
+            )
+            self.assertRaisesRegex(
+                ValueError,
+                MALFORMED_TEAM_REF,
+                lambda: merge_authorized_logins(DummyGitRepo(), "pytorch", "pytorch"),
+            )
+        mock_members.assert_not_called()
+
+
+@mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+@mock.patch(
+    "trymerge.get_drci_classifications", side_effect=mocked_drci_classifications
+)
+class TestApprovedByOverride(TestCase):
+    @mock.patch(
+        "trymerge.read_merge_rules", side_effect=mocked_read_merge_rules_approvers
+    )
+    def test_override_replaces_the_prs_real_approvers(self, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        repo = DummyGitRepo()
+
+        self.assertIsNotNone(find_matching_merge_rule(pr, repo))
+        self.assertIsNotNone(
+            find_matching_merge_rule(pr, repo, approved_by_override={"malfet"})
+        )
+        self.assertRaisesRegex(
+            MergeRuleFailedError,
+            "has not been reviewed yet",
+            lambda: find_matching_merge_rule(pr, repo, approved_by_override=set()),
+        )
+        self.assertRaisesRegex(
+            MergeRuleFailedError,
+            "Core Maintainers",
+            lambda: find_matching_merge_rule(
+                pr, repo, approved_by_override={"a-random-stranger"}
+            ),
+        )
+
+
+@mock.patch("trymerge.gh_graphql", side_effect=mocked_gh_graphql)
+class TestReviewAccessors(TestCase):
+    def test_get_changes_requested_by(self, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        pr._reviews = [
+            ("malfet", "APPROVED"),
+            ("some-reviewer", "CHANGES_REQUESTED"),
+            ("a-commenter", "COMMENTED"),
+        ]
+        self.assertEqual(pr.get_changes_requested_by(), ["some-reviewer"])
+        self.assertEqual(pr.get_approved_by(), ["malfet"])
+
+    @mock.patch("trymerge.gh_fetch_json_dict")
+    def test_get_updated_at(self, mock_fetch: Any, *args: Any) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        mock_fetch.return_value = {"updated_at": "2026-08-25T11:00:00Z"}
+        self.assertEqual(pr.get_updated_at(), "2026-08-25T11:00:00Z")
+        self.assertIn(
+            "/repos/pytorch/pytorch/pulls/115495", mock_fetch.call_args.args[0]
+        )
+
+    @mock.patch("trymerge.gh_fetch_json_dict")
+    def test_get_updated_at_returns_none_when_unavailable(
+        self, mock_fetch: Any, *args: Any
+    ) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        mock_fetch.return_value = {}
+        self.assertIsNone(pr.get_updated_at())
+        mock_fetch.side_effect = HTTPError(
+            "https://api.github.com",
+            500,
+            "boom",
+            {},  # type: ignore[arg-type]
+            None,
+        )
+        self.assertIsNone(pr.get_updated_at())
+
+    @mock.patch("trymerge.gh_fetch_json_list")
+    def test_get_bot_reviewers(self, mock_fetch: Any, *args: Any) -> None:
+        """REST names an App `slug[bot]`, and that is the login callers get back."""
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        mock_fetch.return_value = [
+            {"user": {"login": "some-app[bot]", "type": "Bot"}},
+            {"user": {"login": "malfet", "type": "User"}},
+            {"user": None},
+            {},
+        ]
+        self.assertEqual(pr.get_bot_reviewers(), frozenset({"some-app[bot]"}))
+        self.assertIn(
+            "/repos/pytorch/pytorch/pulls/115495/reviews", mock_fetch.call_args.args[0]
+        )
+
+    @mock.patch("trymerge.gh_fetch_json_list")
+    def test_get_bot_reviewers_walks_every_page(
+        self, mock_fetch: Any, *args: Any
+    ) -> None:
+        """GitHub returns reviews oldest first, so the last page holds the recent ones."""
+        full_page = [{"user": {"login": "malfet", "type": "User"}}] * REVIEWS_PER_PAGE
+        mock_fetch.side_effect = [
+            full_page,
+            [{"user": {"login": "late-app[bot]", "type": "Bot"}}],
+        ]
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        self.assertEqual(pr.get_bot_reviewers(), frozenset({"late-app[bot]"}))
+        self.assertEqual(
+            [call.kwargs["params"]["page"] for call in mock_fetch.call_args_list],
+            [1, 2],
+        )
+
+    @mock.patch("trymerge.gh_fetch_json_list")
+    def test_get_bot_reviewers_stops_at_the_page_limit(
+        self, mock_fetch: Any, *args: Any
+    ) -> None:
+        mock_fetch.return_value = [
+            {"user": {"login": "some-app[bot]", "type": "Bot"}}
+        ] * REVIEWS_PER_PAGE
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        self.assertEqual(pr.get_bot_reviewers(), frozenset({"some-app[bot]"}))
+        self.assertEqual(mock_fetch.call_count, REVIEW_PAGE_LIMIT)
+
+    @mock.patch("trymerge.gh_fetch_json_list")
+    def test_get_bot_reviewers_is_none_when_unavailable(
+        self, mock_fetch: Any, *args: Any
+    ) -> None:
+        """None, not an empty set: an outage must not read as "this PR has no Apps"."""
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        mock_fetch.side_effect = HTTPError(
+            "https://api.github.com",
+            500,
+            "boom",
+            {},  # type: ignore[arg-type]
+            None,
+        )
+        self.assertIsNone(pr.get_bot_reviewers())
+
+    @mock.patch("trymerge.gh_fetch_json_list")
+    def test_get_bot_reviewers_is_none_for_a_malformed_payload(
+        self, mock_fetch: Any, *args: Any
+    ) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        mock_fetch.return_value = {"message": "Not Found"}
+        self.assertIsNone(pr.get_bot_reviewers())
+
+    @mock.patch("trymerge.gh_fetch_json_dict")
+    def test_get_updated_at_is_none_for_a_malformed_payload(
+        self, mock_fetch: Any, *args: Any
+    ) -> None:
+        pr = GitHubPR("pytorch", "pytorch", 115495)
+        mock_fetch.return_value = ["not", "a", "dict"]
+        self.assertIsNone(pr.get_updated_at())
+
+
+class TestGreenlightGuardCallSite(TestCase):
+    def setUp(self) -> None:
+        for patcher in (
+            mock.patch("trymerge.check_docker_builds_ready"),
+            mock.patch("trymerge.can_skip_internal_checks", return_value=False),
+            mock.patch(
+                "trymerge.find_matching_merge_rule", return_value=(None, [], [], {})
+            ),
+        ):
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _pr(self, pr_num: int, ghstack: bool = False) -> Any:
+        pr = mock.MagicMock(spec=GitHubPR)
+        pr.org = "pytorch"
+        pr.project = "pytorch"
+        pr.pr_num = pr_num
+        pr.is_ghstack_pr.return_value = ghstack
+        pr.is_closed.return_value = False
+        pr.is_docker_affecting.return_value = False
+        pr.is_dependabot_pr.return_value = False
+        pr.get_approved_by.return_value = [GREENLIGHT_LOGIN]
+        pr.get_changes_requested_by.return_value = []
+        pr.get_labels.return_value = []
+        pr.merge_changes_locally.side_effect = RuntimeError("stop after gates")
+        return pr
+
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_non_ghstack_pr_is_checked_at_its_head(self, mock_evaluate: Any) -> None:
+        pr = self._pr(1)
+        pr.last_commit_sha.return_value = "head-sha"
+        mock_evaluate.return_value = GuardResult(GuardVerdict.ALLOW)
+
+        with self.assertRaisesRegex(RuntimeError, "stop after gates"):
+            GitHubPR.merge_into(pr, mock.MagicMock(spec=GitRepo), comment_id=1)
+
+        repo_full_name, prs = mock_evaluate.call_args.args
+        self.assertEqual(repo_full_name, "pytorch/pytorch")
+        self.assertEqual([(p.pr_num, p.head_sha) for p in prs], [(1, "head-sha")])
+
+    @mock.patch("trymerge.get_ghstack_prs")
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_ghstack_stack_is_checked_at_the_github_heads(
+        self, mock_evaluate: Any, mock_get_ghstack_prs: Any
+    ) -> None:
+        """greenlight records `gh/USER/N/head`, never the `/orig` rev git cherry-picks."""
+        lower_pr = self._pr(1)
+        lower_pr.last_commit_sha.return_value = "lower-github-head"
+        closed_pr = self._pr(2)
+        closed_pr.is_closed.return_value = True
+        top_pr = self._pr(3, ghstack=True)
+        top_pr.last_commit_sha.return_value = "top-github-head"
+        mock_get_ghstack_prs.return_value = [
+            (lower_pr, "lower_rev"),
+            (closed_pr, "closed_rev"),
+            (top_pr, "top_rev"),
+        ]
+        mock_evaluate.return_value = GuardResult(GuardVerdict.ALLOW)
+
+        with self.assertRaisesRegex(RuntimeError, "stop after gates"):
+            GitHubPR.merge_into(top_pr, mock.MagicMock(spec=GitRepo), comment_id=1)
+
+        _, prs = mock_evaluate.call_args.args
+        self.assertEqual(
+            [(p.pr_num, p.head_sha) for p in prs],
+            [(1, "lower-github-head"), (3, "top-github-head")],
+        )
+
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_wait_raises_the_retryable_error(self, mock_evaluate: Any) -> None:
+        pr = self._pr(1)
+        pr.last_commit_sha.return_value = "head-sha"
+        mock_evaluate.return_value = GuardResult(GuardVerdict.WAIT, "still reviewing")
+
+        with self.assertRaisesRegex(MandatoryChecksMissingError, "still reviewing"):
+            GitHubPR.merge_into(pr, mock.MagicMock(spec=GitRepo), comment_id=1)
+        pr.merge_changes_locally.assert_not_called()
+
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_deny_raises_a_non_retryable_error(self, mock_evaluate: Any) -> None:
+        pr = self._pr(1)
+        pr.last_commit_sha.return_value = "head-sha"
+        mock_evaluate.return_value = GuardResult(GuardVerdict.DENY, "refusing")
+
+        with self.assertRaisesRegex(MergeRuleFailedError, "refusing") as cm:
+            GitHubPR.merge_into(pr, mock.MagicMock(spec=GitRepo), comment_id=1)
+        self.assertNotIsInstance(cm.exception, MandatoryChecksMissingError)
+        pr.merge_changes_locally.assert_not_called()
+
+    @mock.patch("trymerge.gh_post_pr_comment")
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_a_returned_comment_is_posted_to_the_pr_being_merged(
+        self, mock_evaluate: Any, mock_post: Any
+    ) -> None:
+        pr = self._pr(1)
+        pr.last_commit_sha.return_value = "head-sha"
+        mock_evaluate.return_value = GuardResult(
+            GuardVerdict.WAIT, "still reviewing", "hold tight"
+        )
+
+        with self.assertRaises(MandatoryChecksMissingError):
+            GitHubPR.merge_into(
+                pr, mock.MagicMock(spec=GitRepo), comment_id=1, dry_run=True
+            )
+        mock_post.assert_called_once_with("pytorch", "pytorch", 1, "hold tight", True)
+
+    @mock.patch("trymerge.gh_post_pr_comment")
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_no_comment_is_posted_when_the_guard_returns_none(
+        self, mock_evaluate: Any, mock_post: Any
+    ) -> None:
+        pr = self._pr(1)
+        pr.last_commit_sha.return_value = "head-sha"
+        mock_evaluate.return_value = GuardResult(GuardVerdict.WAIT, "still reviewing")
+
+        with self.assertRaises(MandatoryChecksMissingError):
+            GitHubPR.merge_into(pr, mock.MagicMock(spec=GitRepo), comment_id=1)
+        mock_post.assert_not_called()
+
+    @mock.patch("trymerge.gh_post_pr_comment")
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_a_failed_comment_does_not_end_the_merge(
+        self, mock_evaluate: Any, mock_post: Any
+    ) -> None:
+        pr = self._pr(1)
+        pr.last_commit_sha.return_value = "head-sha"
+        mock_post.side_effect = RuntimeError("github is down")
+        mock_evaluate.return_value = GuardResult(
+            GuardVerdict.WAIT, "still reviewing", "hold tight"
+        )
+
+        with self.assertRaisesRegex(MandatoryChecksMissingError, "still reviewing"):
+            GitHubPR.merge_into(pr, mock.MagicMock(spec=GitRepo), comment_id=1)
+
+    @mock.patch("greenlight_ledger.gh_fetch_url")
+    def test_the_guard_is_skipped_when_greenlight_did_not_approve(
+        self, mock_fetch_url: Any
+    ) -> None:
+        pr = self._pr(1)
+        pr.last_commit_sha.return_value = "head-sha"
+        pr.get_approved_by.return_value = ["malfet"]
+
+        with self.assertRaisesRegex(RuntimeError, "stop after gates"):
+            GitHubPR.merge_into(pr, mock.MagicMock(spec=GitRepo), comment_id=1)
+        mock_fetch_url.assert_not_called()
+
+
+@mock.patch("trymerge.gh_add_labels")
+@mock.patch("trymerge.check_for_sev")
+@mock.patch("trymerge.post_starting_merge_comment")
+@mock.patch("trymerge.ensure_mergeable_labels")
+@mock.patch("trymerge.find_matching_merge_rule")
+@mock.patch("trymerge.get_classifications", return_value={})
+class TestGreenlightWaitPlumbing(TestCase):
+    def _pr(self) -> Any:
+        pr = mock.MagicMock(spec=GitHubPR)
+        pr.org = "pytorch"
+        pr.project = "pytorch"
+        pr.pr_num = 1
+        pr.last_commit_sha.return_value = "head-sha"
+        pr.get_labels.return_value = []
+        pr.is_ghstack_pr.return_value = False
+        pr.get_checkrun_conclusions.return_value = {}
+        return pr
+
+    @mock.patch("trymerge.GitHubPR")
+    def test_normal_merge_gets_a_wait_window(
+        self, mock_pr_cls: Any, *args: Any
+    ) -> None:
+        pr = self._pr()
+        mock_pr_cls.return_value = pr
+        merge(pr, mock.MagicMock(spec=GitRepo), comment_id=1, dry_run=True)
+        self.assertIsInstance(
+            pr.merge_into.call_args.kwargs["greenlight_wait"], GreenlightWaitWindow
+        )
+
+    @mock.patch("trymerge.time.sleep")
+    @mock.patch("trymerge.GitHubPR")
+    def test_every_retry_shares_one_wait_window(
+        self, mock_pr_cls: Any, _mock_sleep: Any, *args: Any
+    ) -> None:
+        pr = self._pr()
+        mock_pr_cls.return_value = pr
+        pr.merge_into.side_effect = [
+            MandatoryChecksMissingError("waiting on greenlight"),
+            None,
+        ]
+        merge(pr, mock.MagicMock(spec=GitRepo), comment_id=1, dry_run=True)
+        windows = [
+            call.kwargs["greenlight_wait"] for call in pr.merge_into.call_args_list
+        ]
+        self.assertEqual(len(windows), 2)
+        self.assertIs(windows[0], windows[1])
+
+    def test_force_merge_gets_no_window_so_it_cannot_wait(self, *args: Any) -> None:
+        pr = self._pr()
+        merge(
+            pr,
+            mock.MagicMock(spec=GitRepo),
+            comment_id=1,
+            dry_run=True,
+            skip_mandatory_checks=True,
+        )
+        self.assertIsNone(pr.merge_into.call_args.kwargs["greenlight_wait"])
+
+
+class TestGreenlightGuardWiring(TestCase):
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_pr_facts_are_forwarded_to_the_guard(self, mock_evaluate: Any) -> None:
+        pr = mock.MagicMock(spec=GitHubPR)
+        pr.org = "pytorch"
+        pr.project = "pytorch"
+        pr.pr_num = 7
+        pr.last_commit_sha.return_value = "head-sha"
+        pr.get_approved_by.return_value = [GREENLIGHT_LOGIN]
+        pr.get_changes_requested_by.return_value = ["some-reviewer"]
+        pr.get_labels.return_value = ["Stale"]
+        pr.get_updated_at.return_value = "2026-08-25T11:00:00Z"
+        pr.get_bot_reviewers.return_value = frozenset({"some-app[bot]"})
+        mock_evaluate.return_value = GuardResult(GuardVerdict.ALLOW)
+
+        with mock.patch(
+            "trymerge.merge_authorized_logins", return_value=frozenset({"malfet"})
+        ) as mock_logins:
+            check_greenlight_reviewed_head_sha(pr, None, [pr], wait_window=None)
+
+        repo_full_name, prs = mock_evaluate.call_args.args
+        self.assertEqual(repo_full_name, "pytorch/pytorch")
+        self.assertEqual(len(prs), 1)
+        forwarded = prs[0]
+        self.assertEqual(forwarded.pr_num, 7)
+        self.assertEqual(forwarded.head_sha, "head-sha")
+        self.assertEqual(forwarded.approved_by, [GREENLIGHT_LOGIN])
+        self.assertEqual(forwarded.changes_requested_by, ["some-reviewer"])
+        self.assertEqual(forwarded.labels, ["Stale"])
+        self.assertEqual(forwarded.get_updated_at(), "2026-08-25T11:00:00Z")
+        self.assertEqual(forwarded.get_bot_reviewers(), frozenset({"some-app[bot]"}))
+        self.assertEqual(forwarded.get_merge_authorized_logins(), frozenset({"malfet"}))
+        mock_logins.assert_called_once_with(None, "pytorch", "pytorch")
+        self.assertIsNone(mock_evaluate.call_args.kwargs["wait_window"])
+
+    @mock.patch("trymerge.evaluate_greenlight_guard")
+    def test_the_real_gates_arguments_reach_the_authorization_question(
+        self, mock_evaluate: Any
+    ) -> None:
+        pr = mock.MagicMock(spec=GitHubPR)
+        pr.org = "pytorch"
+        pr.project = "pytorch"
+        pr.pr_num = 7
+        pr.last_commit_sha.return_value = "head-sha"
+        pr.get_approved_by.return_value = [GREENLIGHT_LOGIN]
+        pr.get_changes_requested_by.return_value = []
+        pr.get_labels.return_value = []
+        pr.get_bot_reviewers.return_value = frozenset()
+        mock_evaluate.return_value = GuardResult(GuardVerdict.ALLOW)
+
+        with mock.patch("trymerge.is_authorized_without_greenlight") as mock_authz:
+            check_greenlight_reviewed_head_sha(
+                pr,
+                None,
+                [pr],
+                wait_window=None,
+                skip_mandatory_checks=True,
+                skip_internal_checks=True,
+                ignore_current_checks=["some-check"],
+            )
+            _, prs = mock_evaluate.call_args.args
+            prs[0].is_authorized_without_greenlight()
+        self.assertEqual(
+            mock_authz.call_args.kwargs,
+            {
+                "skip_mandatory_checks": True,
+                "skip_internal_checks": True,
+                "ignore_current_checks": ["some-check"],
+            },
+        )
+
+    @mock.patch("trymerge.check_greenlight_reviewed_head_sha")
+    @mock.patch("trymerge.check_docker_builds_ready")
+    @mock.patch("trymerge.can_skip_internal_checks", return_value=True)
+    @mock.patch("trymerge.find_matching_merge_rule", return_value=(None, [], [], {}))
+    def test_merge_into_hands_the_guard_the_gate_it_just_ran(
+        self, _rule: Any, _skip: Any, _docker: Any, mock_check: Any
+    ) -> None:
+        pr = mock.MagicMock(spec=GitHubPR)
+        pr.org = "pytorch"
+        pr.project = "pytorch"
+        pr.pr_num = 1
+        pr.is_ghstack_pr.return_value = False
+        pr.is_dependabot_pr.return_value = False
+        pr.is_docker_affecting.return_value = False
+        pr.merge_changes_locally.side_effect = RuntimeError("stop after gates")
+
+        with self.assertRaisesRegex(RuntimeError, "stop after gates"):
+            GitHubPR.merge_into(
+                pr,
+                mock.MagicMock(spec=GitRepo),
+                comment_id=1,
+                skip_mandatory_checks=True,
+                ignore_current_checks=["some-check"],
+            )
+
+        self.assertEqual(mock_check.call_args.kwargs["skip_mandatory_checks"], True)
+        self.assertEqual(mock_check.call_args.kwargs["skip_internal_checks"], True)
+        self.assertEqual(
+            mock_check.call_args.kwargs["ignore_current_checks"], ["some-check"]
         )
 
 

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -7,10 +7,11 @@ import json
 import os
 import re
 import time
+import traceback
 import urllib.parse
 from collections import defaultdict
 from dataclasses import dataclass
-from functools import cache
+from functools import cache, partial
 from pathlib import Path
 from re import Pattern
 from typing import Any, cast, NamedTuple, TYPE_CHECKING
@@ -19,6 +20,7 @@ from warnings import warn
 import yaml
 from github_utils import (
     gh_close_pr,
+    gh_fetch_json_dict,
     gh_fetch_json_list,
     gh_fetch_merge_base,
     gh_fetch_url,
@@ -27,6 +29,7 @@ from github_utils import (
     gh_post_commit_comment,
     gh_post_pr_comment,
     gh_update_pr_state,
+    GITHUB_API_URL,
     GitHubComment,
 )
 from gitutils import (
@@ -37,6 +40,13 @@ from gitutils import (
     patterns_to_regex,
     retries_decorator,
 )
+from greenlight_guard import (
+    evaluate_greenlight_guard,
+    GreenlightWaitWindow,
+    GuardVerdict,
+    PRUnderMerge,
+)
+from greenlight_identity import is_greenlight, normalize_login
 from label_utils import (
     gh_add_labels,
     gh_remove_label,
@@ -446,6 +456,9 @@ HAS_NO_CONNECTED_DIFF_TITLE = (
 # This could be set to -1 to ignore all flaky and broken trunk failures. On the
 # other hand, using a large value like 10 here might be useful in sev situation
 IGNORABLE_FAILED_CHECKS_THESHOLD = 10
+
+REVIEWS_PER_PAGE = 100
+REVIEW_PAGE_LIMIT = 10
 
 # CI docker images are keyed by the git tree hash of the .ci/docker directory
 # (see .github/workflows/docker-builds.yml, which tags the images it builds with
@@ -1035,6 +1048,65 @@ class GitHubPR:
     def get_approved_by(self) -> list[str]:
         return [login for (login, state) in self._get_reviews() if state == "APPROVED"]
 
+    def get_changes_requested_by(self) -> list[str]:
+        return [
+            login
+            for (login, state) in self._get_reviews()
+            if state == "CHANGES_REQUESTED"
+        ]
+
+    def get_updated_at(self) -> str | None:
+        """The PR's `updated_at` timestamp, or None if it could not be read.
+
+        Read over REST rather than added to GH_GET_PR_INFO_QUERY because that query's
+        text is the cache key for test_trymerge.py's recorded GraphQL fixtures, so
+        adding a field to it invalidates every one of them.
+        """
+        try:
+            info = gh_fetch_json_dict(
+                f"{GITHUB_API_URL}/repos/{self.org}/{self.project}/pulls/{self.pr_num}"
+            )
+            updated_at = info.get("updated_at")
+            return str(updated_at) if updated_at else None
+        except Exception as e:
+            print(f"Warning: failed to read updated_at for PR #{self.pr_num}: {e}")
+            traceback.print_exc()
+            return None
+
+    def get_bot_reviewers(self) -> frozenset[str] | None:
+        """Logins of this PR's reviewers that GitHub reports as Bot accounts, or None.
+
+        GraphQL renders an App's login bare, so `_get_reviews` cannot tell a GitHub App
+        apart from a human; only the REST reviews payload carries `user.type`. GitHub
+        returns reviews oldest first, so every page has to be walked to see the recent
+        ones; a PR with more than `REVIEW_PAGE_LIMIT` pages of reviews leaves the tail
+        unclassified.
+
+        None means GitHub could not be asked, which callers must not read as "this PR
+        has no App reviewers": that would turn a transient GitHub failure into a
+        permanent merge refusal.
+        """
+        bots = set()
+        try:
+            for page in range(1, REVIEW_PAGE_LIMIT + 1):
+                reviews = gh_fetch_json_list(
+                    f"{GITHUB_API_URL}/repos/{self.org}/{self.project}/pulls/{self.pr_num}/reviews",
+                    params={"per_page": REVIEWS_PER_PAGE, "page": page},
+                )
+                for review in reviews:
+                    user = review.get("user")
+                    if not isinstance(user, dict):
+                        continue
+                    if str(user.get("type", "")).lower() == "bot" and user.get("login"):
+                        bots.add(str(user["login"]))
+                if len(reviews) < REVIEWS_PER_PAGE:
+                    break
+        except Exception as e:
+            print(f"Warning: failed to read reviewer types for PR #{self.pr_num}: {e}")
+            traceback.print_exc()
+            return None
+        return frozenset(bots)
+
     def get_commit_count(self) -> int:
         return int(self.info["commits_with_authors"]["totalCount"])
 
@@ -1407,7 +1479,9 @@ class GitHubPR:
         dry_run: bool = False,
         comment_id: int,
         ignore_current_checks: list[str] | None = None,
+        greenlight_wait: GreenlightWaitWindow | None = None,
     ) -> None:
+        skip_internal_checks = can_skip_internal_checks(self, comment_id)
         # Raises exception if matching rule is not found
         (
             merge_rule,
@@ -1418,7 +1492,7 @@ class GitHubPR:
             self,
             repo,
             skip_mandatory_checks=skip_mandatory_checks,
-            skip_internal_checks=can_skip_internal_checks(self, comment_id),
+            skip_internal_checks=skip_internal_checks,
             ignore_current_checks=ignore_current_checks,
         )
         ghstack_prs: list[tuple[GitHubPR, str]] | None = None
@@ -1426,6 +1500,17 @@ class GitHubPR:
         if self.is_ghstack_pr():
             ghstack_prs = get_ghstack_prs(repo, self, open_only=False)
             prs_to_merge = [pr for pr, _ in ghstack_prs if not pr.is_closed()]
+
+        check_greenlight_reviewed_head_sha(
+            self,
+            repo,
+            prs_to_merge,
+            wait_window=greenlight_wait,
+            dry_run=dry_run,
+            skip_mandatory_checks=skip_mandatory_checks,
+            skip_internal_checks=skip_internal_checks,
+            ignore_current_checks=ignore_current_checks,
+        )
 
         # A ghstack merge lands all open PRs below this one. Use the topmost
         # docker-affecting PR because its cumulative head has the final docker
@@ -1643,6 +1728,52 @@ def read_merge_rules(repo: GitRepo | None, org: str, project: str) -> list[Merge
         return [MergeRule(**x) for x in rc]
 
 
+def rule_approvers(rule: MergeRule) -> set[str]:
+    """The logins one rule accepts, with its `org/team-slug` refs expanded to members."""
+    approvers: set[str] = set()
+    for approver in rule.approved_by:
+        if "/" in approver:
+            team_org, _, team_name = approver.partition("/")
+            if "/" in team_name:
+                # gh_get_team_members warns and returns [] for a team that does not
+                # exist, and find_matching_merge_rule skips its approver check when a
+                # rule resolves to no approvers: a mis-typed ref would match anything.
+                raise ValueError(
+                    f"approved_by team ref must be 'org/team-slug', got {approver!r}"
+                )
+            approvers.update(gh_get_team_members(team_org, team_name))
+        else:
+            approvers.add(approver)
+    return approvers
+
+
+def merge_authorized_logins(
+    repo: GitRepo | None, org: str, project: str
+) -> frozenset[str]:
+    """Every login that authorizes a merge under some rule, lowercased, patterns ignored.
+
+    This is deliberately coarser than `find_matching_merge_rule`, which is case-sensitive
+    and only consults the rules whose file patterns cover a PR. It mirrors greenlight's
+    `merge_authz.resolve_authorized_logins` (pytorch/test-infra, under
+    `greenlight/src/greenlight/`), which is the set greenlight itself tests an approver
+    against before deciding a human has already handled a PR. Answering that question
+    with a different set would have the guard wait for a review that never comes.
+
+    An unreadable rules file yields the empty set rather than an error: the guard would
+    otherwise invent a refusal out of a failure to read a file the real merge gate reads
+    on the same pass, and would blame the wrong thing when it did.
+    """
+    try:
+        rules = read_merge_rules(repo, org, project)
+    except Exception as e:
+        print(f"Warning: failed to read {MERGE_RULE_PATH} for {org}/{project}: {e}")
+        traceback.print_exc()
+        return frozenset()
+    return frozenset(
+        normalize_login(login) for rule in rules for login in rule_approvers(rule)
+    )
+
+
 def _find_non_matching_files(patterns: list[str], files: list[str]) -> list[str]:
     """Return files that do not match the given patterns.
 
@@ -1666,6 +1797,7 @@ def find_matching_merge_rule(
     skip_mandatory_checks: bool = False,
     skip_internal_checks: bool = False,
     ignore_current_checks: list[str] | None = None,
+    approved_by_override: set[str] | None = None,
 ) -> tuple[
     MergeRule,
     list[tuple[str, str | None, int | None]],
@@ -1676,11 +1808,18 @@ def find_matching_merge_rule(
     Returns merge rule matching to this pr together with the list of associated pending
     and failing jobs OR raises an exception.
 
+    approved_by_override replaces the PR's real approver set, so a caller can ask what
+    would happen if a given approval were absent. None keeps the PR's real approvers.
+
     NB: this function is used in Meta-internal workflows, see the comment at the top of
     this file for details.
     """
     changed_files = pr.get_changed_files()
-    approved_by = set(pr.get_approved_by())
+    approved_by = (
+        set(pr.get_approved_by())
+        if approved_by_override is None
+        else set(approved_by_override)
+    )
 
     issue_link = gen_new_issue_link(
         org=pr.org,
@@ -1742,16 +1881,10 @@ def find_matching_merge_rule(
             continue
 
         # Does the PR have the required approvals for this rule?
-        rule_approvers = set()
-        for approver in rule.approved_by:
-            if "/" in approver:
-                org, name = approver.split("/")
-                rule_approvers.update(gh_get_team_members(org, name))
-            else:
-                rule_approvers.add(approver)
-        approvers_intersection = approved_by.intersection(rule_approvers)
+        this_rule_approvers = rule_approvers(rule)
+        approvers_intersection = approved_by.intersection(this_rule_approvers)
         # If rule requires approvers but they aren't the ones that reviewed PR
-        if len(approvers_intersection) == 0 and len(rule_approvers) > 0:
+        if len(approvers_intersection) == 0 and len(this_rule_approvers) > 0:
             # Less than or equal is intentionally used here to gather all potential
             # approvers
             if reject_reason_score <= 10000:
@@ -1849,6 +1982,146 @@ def find_matching_merge_rule(
     if reject_reason_score == 20000:
         raise MandatoryChecksMissingError(reject_reason, rule)
     raise MergeRuleFailedError(reject_reason, rule)
+
+
+# One merge command runs as one process, and its retry loop re-asks this question every
+# five minutes with the same answer. The repeated call is not free: find_matching_merge_rule
+# posts to Dr.CI, which rewrites the PR's Dr.CI comment as a side effect.
+_AUTHORIZED_WITHOUT_GREENLIGHT: dict[tuple[Any, ...], bool] = {}
+
+
+def is_authorized_without_greenlight(
+    pr: GitHubPR,
+    repo: GitRepo | None,
+    *,
+    skip_mandatory_checks: bool = False,
+    skip_internal_checks: bool = False,
+    ignore_current_checks: list[str] | None = None,
+) -> bool:
+    """Whether some merge rule still matches once greenlight's approval is dropped.
+
+    Asking "is greenlight the only approver" instead would be unsound: pytorch/pytorch
+    is public, so any stranger can approve a PR, and that would switch the land-time
+    greenlight check off without contributing anything to the merge's authorization.
+
+    The caller passes the same gate arguments `merge_into` gives the real
+    `find_matching_merge_rule`. Relaxing any of them here would let a rule that the real
+    gate rejects answer this question, and the real gate would then fall through to the
+    Greenlight rule -- leaving greenlight the sole authority with the guard switched off.
+
+    An answer is cached per approver set and head commit. Both are re-read from GitHub on
+    every retry, so an approval added mid-merge still takes effect; what the cache drops
+    is the identical re-run, and with it a redundant Dr.CI comment rewrite.
+    """
+    approvers = pr.get_approved_by()
+    key = (
+        pr.org,
+        pr.project,
+        pr.pr_num,
+        pr.last_commit_sha(default=""),
+        frozenset(approvers),
+        skip_mandatory_checks,
+        skip_internal_checks,
+        tuple(ignore_current_checks or ()),
+    )
+    if key in _AUTHORIZED_WITHOUT_GREENLIGHT:
+        return _AUTHORIZED_WITHOUT_GREENLIGHT[key]
+    remaining = {login for login in approvers if not is_greenlight(login)}
+    try:
+        find_matching_merge_rule(
+            pr,
+            repo,
+            skip_mandatory_checks=skip_mandatory_checks,
+            skip_internal_checks=skip_internal_checks,
+            ignore_current_checks=ignore_current_checks,
+            approved_by_override=remaining,
+        )
+        authorized = True
+    except MergeRuleFailedError as e:
+        print(
+            f"PR #{pr.pr_num} has no merge rule without greenlight's approval, so the "
+            f"greenlight land-time check applies: {e}"
+        )
+        authorized = False
+    except RuntimeError as e:
+        # An unusable rule set or an internal-changes PR: the real gate would refuse the
+        # merge outright, so this hypothetical proves nothing about greenlight's role.
+        print(
+            f"PR #{pr.pr_num} could not be evaluated without greenlight's approval, so "
+            f"the greenlight land-time check applies: {e}"
+        )
+        traceback.print_exc()
+        authorized = False
+    _AUTHORIZED_WITHOUT_GREENLIGHT[key] = authorized
+    return authorized
+
+
+def check_greenlight_reviewed_head_sha(
+    pr: GitHubPR,
+    repo: GitRepo | None,
+    prs_to_merge: list[GitHubPR],
+    *,
+    wait_window: GreenlightWaitWindow | None,
+    dry_run: bool = False,
+    skip_mandatory_checks: bool = False,
+    skip_internal_checks: bool = False,
+    ignore_current_checks: list[str] | None = None,
+) -> None:
+    """Block a merge that only greenlight authorizes and that greenlight has not
+    approved at the head commit being landed.
+
+    Raises MandatoryChecksMissingError to wait, because merge()'s retry loop catches
+    exactly that type and re-enters merge_into five minutes later. wait_window is what
+    bounds that waiting across those re-entries; None means the caller cannot retry.
+
+    The gate arguments are the ones `merge_into` gave the real `find_matching_merge_rule`,
+    so that asking whether greenlight's approval is load-bearing asks it of the same gate.
+
+    The ghstack path lands a cherry-pick of each PR's head rather than the head itself,
+    but get_ghstack_prs has already proven the two carry identical content, and the head
+    is what greenlight records, so the head is what gets compared.
+    """
+    # One rules file governs the whole stack, so every PR asks the same question of it.
+    authorized_logins = partial(merge_authorized_logins, repo, pr.org, pr.project)
+    result = evaluate_greenlight_guard(
+        f"{pr.org}/{pr.project}",
+        [
+            PRUnderMerge(
+                pr_num=stacked.pr_num,
+                head_sha=stacked.last_commit_sha(default=""),
+                approved_by=stacked.get_approved_by(),
+                changes_requested_by=stacked.get_changes_requested_by(),
+                labels=stacked.get_labels(),
+                get_updated_at=stacked.get_updated_at,
+                get_bot_reviewers=stacked.get_bot_reviewers,
+                get_merge_authorized_logins=authorized_logins,
+                is_authorized_without_greenlight=partial(
+                    is_authorized_without_greenlight,
+                    stacked,
+                    repo,
+                    skip_mandatory_checks=skip_mandatory_checks,
+                    skip_internal_checks=skip_internal_checks,
+                    ignore_current_checks=ignore_current_checks,
+                ),
+            )
+            for stacked in prs_to_merge
+        ],
+        wait_window=wait_window,
+    )
+    if result.comment:
+        try:
+            gh_post_pr_comment(pr.org, pr.project, pr.pr_num, result.comment, dry_run)
+        except Exception as e:
+            # The comment is a courtesy; failing to post it must not end a merge that
+            # the guard itself is willing to keep waiting on.
+            print(
+                f"Warning: failed to comment the greenlight wait on PR #{pr.pr_num}: {e}"
+            )
+            traceback.print_exc()
+    if result.verdict is GuardVerdict.WAIT:
+        raise MandatoryChecksMissingError(result.message)
+    if result.verdict is GuardVerdict.DENY:
+        raise MergeRuleFailedError(result.message)
 
 
 def get_topmost_docker_pr(prs: list[GitHubPR]) -> GitHubPR | None:
@@ -2681,11 +2954,14 @@ def merge(
 
     if skip_mandatory_checks:
         post_starting_merge_comment(repo, pr, explainer, dry_run)
+        # This return is outside the retry loop below, so there is no iteration for
+        # the greenlight check to wait in: it has to decide now or refuse.
         return pr.merge_into(
             repo,
             dry_run=dry_run,
             skip_mandatory_checks=skip_mandatory_checks,
             comment_id=comment_id,
+            greenlight_wait=None,
         )
 
     # Check for approvals
@@ -2713,6 +2989,9 @@ def merge(
     start_time = time.time()
     last_exception = ""
     elapsed_time = 0.0
+    # Owned out here so the greenlight wait budget spans every iteration below rather
+    # than restarting each time merge_into is re-entered.
+    greenlight_wait = GreenlightWaitWindow()
     ignore_current_checks = [
         x[0] for x in ignore_current_checks_info
     ]  # convert to List[str] for convenience
@@ -2788,6 +3067,7 @@ def merge(
                 skip_mandatory_checks=skip_mandatory_checks,
                 comment_id=comment_id,
                 ignore_current_checks=ignore_current_checks,
+                greenlight_wait=greenlight_wait,
             )
         except MandatoryChecksMissingError as ex:
             last_exception = str(ex)
@@ -2834,8 +3114,6 @@ def main() -> None:
         msg = "\n".join((f"## {title}", f"{exception}", "", f"{internal_debugging}"))
 
         gh_post_pr_comment(org, project, args.pr_num, msg, dry_run=args.dry_run)
-        import traceback
-
         traceback.print_exc()
 
     if args.revert:


### PR DESCRIPTION
**Impact:** try-merge and mergebot
**Risk:** medium

## What
Adds a land-time gate to `merge_into`: when greenlight's approval is the only one that
satisfies a merge rule, trymerge reads greenlight's verdict ledger over the HUD
`/api/greenlight/pr_state` route and refuses to land unless greenlight recorded `LAND`
for the head commit actually being merged. The decision logic lives in new
`greenlight_*.py` modules next to trymerge (guard, ledger client, preflight mirror,
login normalization, message rendering); `trymerge.py` only feeds PR facts in and turns
the verdict into an exception the existing merge loop already understands.

Three smaller `trymerge.py` changes worth reading on their own:

- `find_matching_merge_rule` gains an `approved_by_override` kwarg so the guard can ask
  "would any rule still match if greenlight had not approved?" without duplicating rule
  evaluation. Default behaviour is unchanged.
- The inline approver expansion is extracted to `rule_approvers`, and a malformed team
  ref (`org/team/extra`) now raises instead of expanding to nobody. Previously
  `gh_get_team_members` warned, returned `[]`, and the rule then matched *any* approver.
- Two REST accessors on `GitHubPR` (`get_updated_at`, `get_bot_reviewers`). REST rather
  than new fields on `GH_GET_PR_INFO_QUERY`, because that query text is the cache key for
  the recorded GraphQL fixtures and extending it invalidates all of them.

## Why
The "Greenlight Review Bot" rule in `merge_rules.yaml` lets a single `pytorchgreenlight`
approval authorize a merge of any path, and pytorch/pytorch has no GitHub-native required
reviews, so that approval is never dismissed when the author pushes more commits. Today an
author can get greenlight's approval on a benign commit, push anything on top, and
`@pytorchbot merge` lands unreviewed content.

# Notes
Review the modules commit first, then the wiring commit — the second is mostly call-site
plumbing once the guard's contract is clear.

Behaviour worth sanity-checking:

- **Scope.** The guard is skipped entirely when greenlight did not approve, and when any
  other merge rule still matches after dropping greenlight's approval. A drive-by approval
  from a random GitHub user does *not* switch it off.
- **Waiting vs refusing.** Anything merely unknown (no ledger row, a verdict for an older
  commit, a review still in flight, an unreadable HUD) waits; anything settled against the
  head being landed (`NO_LAND`/`CANCELLED`/`FAILED`, unknown status, a review past
  greenlight's own timeout) refuses immediately. Waits raise
  `MandatoryChecksMissingError`, so the existing 5-minute retry loop handles them. The
  60-minute budget is owned by `merge()`, shared across re-entries, and opens at the first
  wait rather than at command time (`merge_into` is only reached once CI is green). One
  comment is posted to the PR the first time it waits.
- **Force merge.** `-f` gets no wait window and so never waits; it refuses instead if
  greenlight is the only authority and hasn't verified the head.
- **ghstack.** Checked against each open PR's GitHub head, which is what greenlight
  records, not the `/orig` revision git cherry-picks.
- **Fail direction.** An unreadable `merge_rules.yaml` or an unclassifiable reviewer
  leaves the guard on rather than inventing an authorization.

Depends on the `/api/greenlight/pr_state` route in pytorch/test-infra; `HUD_API_TOKEN` is
already plumbed into `trymerge.yml`.

Several preflight constants mirror greenlight's own (review window, excluded labels,
review timeout, the authorized-login set). Drift on either side makes this wait for a
verdict that is never coming, or refuse a PR greenlight would have reviewed — each
mirrored value is commented with its upstream source, and one test asserts
`merge_rules.yaml` still grants `pytorchgreenlight` merge authority so a rename there
can't silently disable the guard.