### PR TITLE
fix(elastic): close mkstemp fd in _create_file_store; guard s.close() in find_free_port

### DIFF
--- a/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
+++ b/test/distributed/elastic/rendezvous/c10d_rendezvous_backend_test.py
@@ -288,3 +288,54 @@ class CreateBackendTest(TestCase):
             r"details.$",
         ):
             create_backend(self._params_filestore)
+
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    def test_create_file_store_closes_mkstemp_fd(
+        self, mkstemp_mock, os_close_mock
+    ) -> None:
+        """mkstemp() fd must be closed after _create_file_store(), even on success."""
+        import tempfile as _tempfile
+
+        real_fd, real_path = _tempfile.mkstemp()
+        try:
+            mkstemp_mock.return_value = (real_fd, real_path)
+            self._params_filestore.endpoint = ""
+            # Should succeed; the real fd gets closed via our patched os.close
+            create_backend(self._params_filestore)
+            os_close_mock.assert_called_once_with(real_fd)
+        finally:
+            import os as _os
+            # Ensure cleanup even if os.close was mocked and did not close the fd
+            try:
+                _os.close(real_fd)
+            except OSError:
+                pass
+            _os.remove(real_path)
+
+    @mock.patch(
+        "torch.distributed.elastic.rendezvous.c10d_rendezvous_backend.FileStore"
+    )
+    @mock.patch("os.close")
+    @mock.patch("tempfile.mkstemp")
+    def test_create_file_store_closes_mkstemp_fd_on_filestore_failure(
+        self, mkstemp_mock, os_close_mock, filestore_mock
+    ) -> None:
+        """mkstemp() fd must be closed even when FileStore construction fails."""
+        import tempfile as _tempfile
+        import os as _os
+
+        real_fd, real_path = _tempfile.mkstemp()
+        try:
+            mkstemp_mock.return_value = (real_fd, real_path)
+            filestore_mock.side_effect = RuntimeError("store construction failed")
+            self._params_filestore.endpoint = ""
+            with self.assertRaises(RendezvousConnectionError):
+                create_backend(self._params_filestore)
+            os_close_mock.assert_called_once_with(real_fd)
+        finally:
+            try:
+                _os.close(real_fd)
+            except OSError:
+                pass
+            _os.remove(real_path)

--- a/test/distributed/elastic/rendezvous/etcd_server_test.py
+++ b/test/distributed/elastic/rendezvous/etcd_server_test.py
@@ -6,12 +6,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 import os
+import socket
 import sys
 import unittest
+from unittest import mock
 
 from torch.distributed.elastic.rendezvous import RendezvousParameters
 from torch.distributed.elastic.rendezvous.etcd_rendezvous import create_rdzv_handler
-from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer
+from torch.distributed.elastic.rendezvous.etcd_server import EtcdServer, find_free_port
 
 
 if os.getenv("CIRCLECI"):
@@ -58,3 +60,42 @@ class EtcdServerTest(unittest.TestCase):
             self.assertEqual(1, rdzv_info.world_size)
         finally:
             server.stop()
+
+
+class FindFreePortTest(unittest.TestCase):
+    def test_find_free_port_returns_socket(self):
+        """find_free_port should succeed under normal conditions."""
+        s = find_free_port()
+        try:
+            self.assertGreater(s.getsockname()[1], 0)
+        finally:
+            s.close()
+
+    def test_find_free_port_socket_constructor_failure_no_unbound_local_error(self):
+        """If socket() raises on the first address, no UnboundLocalError should escape."""
+        addr_ipv4 = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+        # Provide two addresses: the first socket() call fails, the second succeeds
+        real_socket = socket.socket
+
+        call_count = 0
+
+        def socket_side_effect(family, type, proto):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise OSError("simulated socket creation failure")
+            return real_socket(family, type, proto)
+
+        with mock.patch("socket.getaddrinfo", return_value=[addr_ipv4, addr_ipv4]), \
+             mock.patch("socket.socket", side_effect=socket_side_effect):
+            s = find_free_port()
+            s.close()
+
+    def test_find_free_port_all_addresses_fail_raises_runtime_error(self):
+        """When all addresses fail, RuntimeError (not UnboundLocalError) should be raised."""
+        addr_ipv4 = (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+
+        with mock.patch("socket.getaddrinfo", return_value=[addr_ipv4]), \
+             mock.patch("socket.socket", side_effect=OSError("socket failed")):
+            with self.assertRaises(RuntimeError):
+                find_free_port()

--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,11 +192,14 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."
             ) from exc
+        # FileStore opens the path independently; close the descriptor returned
+        # by mkstemp() to avoid leaking it.
+        os.close(fd)
 
     try:
         store = FileStore(path)

--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
Fixes two related resource-management bugs in `torch.distributed.elastic.rendezvous`:

### 1. FileStore fd leak (fixes #191394)

`_create_file_store()` in `c10d_rendezvous_backend.py` called `tempfile.mkstemp()` but discarded the returned file descriptor without closing it. `FileStore` opens the path independently, so the descriptor remained open for the lifetime of the process. With repeated rendezvous creation this could exhaust the process's open-FD limit.

**Fix:** Call `os.close(fd)` immediately after `mkstemp()` succeeds, before constructing the `FileStore`.

### 2. UnboundLocalError in find_free_port (fixes #191395)

`find_free_port()` in `etcd_server.py` referenced loop variable `s` inside the `except OSError` block without guarding against the case where `socket.socket()` itself raised on the first iteration (before `s` was ever assigned). This produced an `UnboundLocalError` that masked the real socket-creation error.

**Fix:** Initialise `s = None` before the `try` block and guard with `if s is not None: s.close()`.

### Tests added
- `test_create_file_store_closes_mkstemp_fd` — verifies fd is closed on success path
- `test_create_file_store_closes_mkstemp_fd_on_filestore_failure` — verifies fd is closed even when `FileStore` construction fails
- `FindFreePortTest.test_find_free_port_returns_socket` — basic happy path
- `FindFreePortTest.test_find_free_port_socket_constructor_failure_no_unbound_local_error` — first addr fails, second succeeds, no `UnboundLocalError`
- `FindFreePortTest.test_find_free_port_all_addresses_fail_raises_runtime_error` — all fail → clean `RuntimeError`