### PR TITLE
Skip the data-dependent Binomial KL check under torch.compile

### DIFF
--- a/test/distributions/test_distributions.py
+++ b/test/distributions/test_distributions.py
@@ -6144,6 +6144,30 @@ class TestKL(DistributionsTestCase):
                 lambda msg: f"{msg}\nIncorrect KL({type(p).__name__}, {type(q).__name__})",
             )
 
+    def test_kl_binomial_binomial_compile_fullgraph(self):
+        # Regression test for https://github.com/pytorch/pytorch/issues/194593
+        # The p.total_count < q.total_count guard in _kl_binomial_binomial is
+        # data-dependent, which used to break torch.compile(fullgraph=True).
+        def fn(p_count, p_prob, q_count, q_prob):
+            return kl_divergence(
+                Binomial(total_count=p_count, probs=p_prob),
+                Binomial(total_count=q_count, probs=q_prob),
+            )
+
+        p_count = torch.tensor([5.0])
+        p_prob = torch.tensor([0.2])
+        q_count = torch.tensor([3.0])
+        q_prob = torch.tensor([0.4])
+
+        expected = fn(p_count, p_prob, q_count, q_prob)
+        compiled_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        actual = compiled_fn(p_count, p_prob, q_count, q_prob)
+        self.assertEqual(actual, expected)
+
+        # Preserved eager behavior: q.total_count > p.total_count still raises.
+        with self.assertRaises(NotImplementedError):
+            fn(q_count, q_prob, p_count, p_prob)
+
     def test_kl_edgecases(self):
         self.assertEqual(kl_divergence(Bernoulli(0), Bernoulli(0)), 0)
         self.assertEqual(kl_divergence(Bernoulli(1), Bernoulli(1)), 0)

--- a/torch/distributions/kl.py
+++ b/torch/distributions/kl.py
@@ -232,7 +232,11 @@ def _kl_beta_beta(p, q):
 def _kl_binomial_binomial(p, q):
     # from https://math.stackexchange.com/questions/2214993/
     # kullback-leibler-divergence-for-binomial-distributions-p-and-q
-    if (p.total_count < q.total_count).any():
+    # This data-dependent check is skipped under torch.compile (dynamo already
+    # disables distribution argument validation during compilation); when
+    # q.total_count > p.total_count is traced, the p >= q formula below is
+    # silently evaluated on that unsupported input instead of raising.
+    if not torch.compiler.is_compiling() and (p.total_count < q.total_count).any():
         raise NotImplementedError(
             "KL between Binomials where q.total_count > p.total_count is not implemented"
         )


### PR DESCRIPTION
Fixes #194593

`_kl_binomial_binomial` guards its formula with `if (p.total_count < q.total_count).any(): raise NotImplementedError`. That branch is data-dependent, so `kl_divergence(Binomial, Binomial)` with a tensor `total_count` fails under `torch.compile(fullgraph=True)` with "Data-dependent branching", while eager works fine.

The fix skips the check when compiling (`torch.compiler.is_compiling()`), the same way dynamo already skips distribution argument validation during compilation. One honest note: under compile, the `q.total_count > p.total_count` case is no longer rejected and the p >= q formula gets evaluated on it — this is documented in a comment at the check. Same failure class as #194596 (Wishart) and #194764 (VonMises).

Added a regression test: the compiled fullgraph result equals eager, and eager still raises `NotImplementedError` for the unsupported case.

Test plan:

```
python test/distributions/test_distributions.py TestKL.test_kl_binomial_binomial_compile_fullgraph
python test/distributions/test_distributions.py -k kl
```

Both green (12/12 on the kl sweep). Also verified independently on a second machine (aarch64, nightly wheel): stock fails at kl.py:235, fixed matches eager, eager error behavior unchanged.

P.S: Fable-Assisted, all changes reviewed and tested by me.


cc @fritzo @neerajprad @alicanb @nikitaved