### PR TITLE
Fix `fused_moving_avg_obs_fake_quant` stale qparams when observing

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
@@ -57,8 +57,11 @@ void calculate_moving_average(
   return;
 }
 
-std::tuple<at::Tensor, at::Tensor> choose_qparams_fake_quant(
-    const at::Tensor& x,
+// Compute the quantization parameters from the running min/max and write them
+// into `scale` and `zero_point` in place. This is kept separate from the
+// fake quantize below so that the qparams can be refreshed even when fake
+// quant is disabled.
+void choose_qparams(
     const at::Tensor& inp_running_min,
     const at::Tensor& inp_running_max,
     at::Tensor& scale,
@@ -66,10 +69,7 @@ std::tuple<at::Tensor, at::Tensor> choose_qparams_fake_quant(
     bool per_row_fake_quant,
     bool symmetric_quant,
     int qmin,
-    int qmax,
-    int ch_axis) {
-  std::tuple<at::Tensor, at::Tensor> fake_quant_out;
-  at::Tensor x_min, x_max;
+    int qmax) {
   if (per_row_fake_quant) {
     const float* x_min_data = inp_running_min.const_data_ptr<float>();
     const float* x_max_data = inp_running_max.const_data_ptr<float>();
@@ -98,8 +98,6 @@ std::tuple<at::Tensor, at::Tensor> choose_qparams_fake_quant(
       zero_point[i] = x_qparams.zero_point;
 #endif
     }
-    fake_quant_out = at::fake_quantize_per_channel_affine_cachemask(
-        x, scale, zero_point, ch_axis, qmin, qmax);
   } else {
 #ifdef USE_FBGEMM
     fbgemm::TensorQuantizationParams x_qparams{};
@@ -129,12 +127,25 @@ std::tuple<at::Tensor, at::Tensor> choose_qparams_fake_quant(
     scale[0] = x_qparams.scale;
     zero_point[0] = x_qparams.zero_point;
 #endif
-    auto fake_quant_enabled = at::ones(1, x.options().dtype(at::kLong));
-    fake_quant_out =
-        at::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
-            x, scale, zero_point, fake_quant_enabled, qmin, qmax);
   }
-  return fake_quant_out;
+}
+
+// Fake quantize `x` using the qparams already computed by `choose_qparams`.
+std::tuple<at::Tensor, at::Tensor> fake_quant_with_qparams(
+    const at::Tensor& x,
+    at::Tensor& scale,
+    at::Tensor& zero_point,
+    bool per_row_fake_quant,
+    int qmin,
+    int qmax,
+    int ch_axis) {
+  if (per_row_fake_quant) {
+    return at::fake_quantize_per_channel_affine_cachemask(
+        x, scale, zero_point, ch_axis, qmin, qmax);
+  }
+  auto fake_quant_enabled = at::ones(1, x.options().dtype(at::kLong));
+  return at::_fake_quantize_per_tensor_affine_cachemask_tensor_qparams(
+      x, scale, zero_point, fake_quant_enabled, qmin, qmax);
 }
 } // namespace
 
@@ -199,17 +210,28 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cpu(
           ch_axis);
     }
   }
-  // Calculate qparams and fake_quantize
+  // Calculate qparams whenever the running min/max are valid, so that
+  // `scale` and `zero_point` stay in sync with them even if fake quant is
+  // disabled. Skip this if we never observed, since the running min/max are
+  // still +/-inf in that case.
   auto fake_quant = fake_quant_on.item().toInt();
-  if (fake_quant) {
-    return choose_qparams_fake_quant(
-        self,
+  if (observe || fake_quant) {
+    choose_qparams(
         running_min,
         running_max,
         scale,
         zero_point,
         per_row_fake_quant,
         symmetric_quant,
+        quant_min,
+        quant_max);
+  }
+  if (fake_quant) {
+    return fake_quant_with_qparams(
+        self,
+        scale,
+        zero_point,
+        per_row_fake_quant,
         quant_min,
         quant_max,
         ch_axis);

--- a/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
@@ -210,10 +210,9 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cpu(
           ch_axis);
     }
   }
-  // Calculate qparams whenever the running min/max are valid, so that
-  // `scale` and `zero_point` stay in sync with them even if fake quant is
-  // disabled. Skip this if we never observed, since the running min/max are
-  // still +/-inf in that case.
+  // Refresh the qparams if the observer ran this step, so that `scale` and
+  // `zero_point` track the running min/max even when fake quant is disabled.
+  // Keep computing them when fake quant is on to preserve existing behavior.
   auto fake_quant = fake_quant_on.item().toInt();
   if (observe || fake_quant) {
     choose_qparams(

--- a/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
+++ b/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
@@ -25,6 +25,7 @@ namespace at::native {
 namespace {
 template <typename T>
 __global__ void ChooseQuantizationParamsKernelImpl(
+    const int64_t* observer_on,
     const int64_t* fake_quant_on,
     const T* x_min,
     const T* x_max,
@@ -35,7 +36,10 @@ __global__ void ChooseQuantizationParamsKernelImpl(
     float* scale,
     int32_t* zero_point) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < size && *fake_quant_on == 1) {
+  // Recompute the qparams whenever we observed this step, so that scale and
+  // zero_point stay in sync with the running min/max even if fake quant is
+  // disabled.
+  if (i < size && (*observer_on == 1 || *fake_quant_on == 1)) {
     float min_val = x_min[i];
     float max_val = x_max[i];
 
@@ -209,6 +213,7 @@ void _calculate_moving_average(
 
 void _calc_moving_avg_qparams_helper(
     const at::Tensor& x,
+    const at::Tensor observer_on,
     const at::Tensor fake_quant_on,
     at::Tensor& running_min,
     at::Tensor& running_max,
@@ -223,6 +228,7 @@ void _calc_moving_avg_qparams_helper(
   device_guard.set_index(x.get_device());
 
   cudaStream_t cuda_stream = at::cuda::getCurrentCUDAStream();
+  int64_t* observer_on_data = observer_on.data_ptr<int64_t>();
   int64_t* fake_quant_on_data = fake_quant_on.data_ptr<int64_t>();
   if (per_row_fq) {
     AT_DISPATCH_FLOATING_TYPES_AND2(
@@ -236,6 +242,7 @@ void _calc_moving_avg_qparams_helper(
               num_threads,
               0,
               cuda_stream>>>(
+              observer_on_data,
               fake_quant_on_data,
               running_min_data,
               running_max_data,
@@ -253,6 +260,7 @@ void _calc_moving_avg_qparams_helper(
           scalar_t* running_min_data = running_min.data_ptr<scalar_t>();
           scalar_t* running_max_data = running_max.data_ptr<scalar_t>();
           ChooseQuantizationParamsKernelImpl<<<1, 1, 0, cuda_stream>>>(
+              observer_on_data,
               fake_quant_on_data,
               running_min_data,
               running_max_data,
@@ -332,6 +340,7 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
 
   _calc_moving_avg_qparams_helper(
       x_contig,
+      observer_on.to(at::kLong),
       fake_quant_on.to(at::kLong),
       running_min,
       running_max,

--- a/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
+++ b/aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
@@ -293,6 +293,7 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
     bool symmetric_quant) {
   TORCH_CHECK(ch_axis < x.dim(), "Error in fused_moving_avg_obs_fake_quant_cpu: ch_axis must be < self.dim()");
   const auto x_contig = x.contiguous();
+  const auto observer_on_long = observer_on.to(at::kLong);
   // Calculate the size of the dimension we need to quantize over,
   // For per-channel quant we default to axis 0, since it is only for
   // weight quantization currently.
@@ -318,7 +319,7 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
     }
     _calculate_moving_average(
         y,
-        observer_on.to(at::kLong),
+        observer_on_long,
         running_min,
         running_max,
         averaging_const,
@@ -327,7 +328,7 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
   } else {
     _calculate_moving_average(
         x_contig,
-        observer_on.to(at::kLong),
+        observer_on_long,
         running_min,
         running_max,
         averaging_const,
@@ -340,7 +341,7 @@ std::tuple<at::Tensor, at::Tensor> fused_moving_avg_obs_fake_quant_cuda(
 
   _calc_moving_avg_qparams_helper(
       x_contig,
-      observer_on.to(at::kLong),
+      observer_on_long,
       fake_quant_on.to(at::kLong),
       running_min,
       running_max,

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1269,6 +1269,81 @@ class TestFusedObsFakeQuant(TestCase):
                 self.assertEqual(in_running_max_ref, in_running_max_op)
                 torch.testing.assert_close(out, x_in)
 
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
+           symmetric_quant=st.booleans())
+    @settings(deadline=None)
+    def test_fused_obs_fake_quant_qparams_without_fake_quant(self, device, symmetric_quant) -> None:
+        """
+        Tests that scale and zero_point are updated whenever the observer is
+        enabled, even if fake quant is disabled, and that they are left alone
+        once the observer is disabled too.
+        """
+        in_running_min_ref = torch.tensor(float("inf"))
+        in_running_max_ref = torch.tensor(float("-inf"))
+        in_running_min_op = torch.tensor(float("inf"), device=device)
+        in_running_max_op = torch.tensor(float("-inf"), device=device)
+        avg_const = 0.01
+        scale = torch.tensor([1.0], device=device)
+        zero_point = torch.tensor([0], dtype=torch.int, device=device)
+
+        pt_op = torch.fused_moving_avg_obs_fake_quant
+
+        # Observer on, fake quant off: qparams track the running min/max
+        for _ in range(5):
+            x = torch.randn(5, 5, device=device)
+            out = pt_op(
+                x,
+                torch.tensor(1, device=device),  # observer on
+                torch.tensor(0, device=device),  # fake quant off
+                in_running_min_op,
+                in_running_max_op,
+                scale,
+                zero_point,
+                avg_const,
+                0,
+                255,
+                0,
+                False,
+                symmetric_quant,
+            )
+            in_running_min_ref, in_running_max_ref = _get_tensor_min_max(
+                x,
+                running_min=in_running_min_ref,
+                running_max=in_running_max_ref,
+                averaging_const=avg_const,
+            )
+            x_scale, x_zero_point = _get_scale_zp(
+                in_running_min_ref,
+                in_running_max_ref,
+                torch.quint8,
+                preserve_sparsity=symmetric_quant,
+            )
+            self.assertEqual(scale, x_scale)
+            self.assertEqual(zero_point, x_zero_point)
+            # the output is not fake quantized
+            torch.testing.assert_close(out, x)
+
+        # Observer off, fake quant off: qparams are left alone
+        prev_scale = scale.clone()
+        prev_zero_point = zero_point.clone()
+        pt_op(
+            torch.randn(5, 5, device=device) * 100,
+            torch.tensor(0, device=device),  # observer off
+            torch.tensor(0, device=device),  # fake quant off
+            in_running_min_op,
+            in_running_max_op,
+            scale,
+            zero_point,
+            avg_const,
+            0,
+            255,
+            0,
+            False,
+            symmetric_quant,
+        )
+        self.assertEqual(scale, prev_scale)
+        self.assertEqual(zero_point, prev_zero_point)
+
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),)
     @settings(deadline=None)
     def test_fused_obs_fake_quant_backward_op(self, device) -> None:

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1344,6 +1344,60 @@ class TestFusedObsFakeQuant(TestCase):
         self.assertEqual(scale, prev_scale)
         self.assertEqual(zero_point, prev_zero_point)
 
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
+           symmetric_quant=st.booleans())
+    @settings(deadline=None)
+    def test_fused_obs_fake_quant_qparams_without_fake_quant_per_channel(self, device, symmetric_quant) -> None:
+        """
+        Same as `test_fused_obs_fake_quant_qparams_without_fake_quant`, but for
+        the per channel path.
+        """
+        m = 5
+        in_running_min_ref = torch.empty(m, device=device).fill_(float("inf"))
+        in_running_max_ref = torch.empty(m, device=device).fill_(float("-inf"))
+        in_running_min_op = torch.empty(m, device=device).fill_(float("inf"))
+        in_running_max_op = torch.empty(m, device=device).fill_(float("-inf"))
+        avg_const = 0.01
+        scale = torch.empty(m, device=device).fill_(0.1)
+        zero_point = torch.empty(m, dtype=torch.int, device=device).fill_(0)
+
+        pt_op = torch.fused_moving_avg_obs_fake_quant
+
+        # Observer on, fake quant off: qparams track the running min/max
+        for _ in range(5):
+            x = torch.randn(m, 5, device=device)
+            out = pt_op(
+                x,
+                torch.tensor(1, device=device),  # observer on
+                torch.tensor(0, device=device),  # fake quant off
+                in_running_min_op,
+                in_running_max_op,
+                scale,
+                zero_point,
+                avg_const,
+                0,
+                255,
+                0,
+                True,  # per_channel_enabled
+                symmetric_quant,
+            )
+            in_running_min_ref, in_running_max_ref = _get_per_row_min_max(
+                x, in_running_min_ref, in_running_max_ref
+            )
+            x_scale = torch.empty(m, device=device)
+            x_zero_point = torch.empty(m, dtype=torch.int, device=device)
+            for i in range(x_scale.numel()):
+                x_scale[i], x_zero_point[i] = _get_scale_zp(
+                    in_running_min_ref[i].item(),
+                    in_running_max_ref[i].item(),
+                    torch.quint8,
+                    preserve_sparsity=symmetric_quant,
+                )
+            self.assertEqual(scale, x_scale)
+            self.assertEqual(zero_point, x_zero_point)
+            # the output is not fake quantized
+            torch.testing.assert_close(out, x)
+
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),)
     @settings(deadline=None)
     def test_fused_obs_fake_quant_backward_op(self, device) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194816
* __->__ #194815

**Summary:** `torch.fused_moving_avg_obs_fake_quant` only wrote `scale`
and `zero_point` when fake quant was enabled. After an observe-only
phase, these buffers become stale even though the running min/max had
been updated, and callers have no way to read the latest qparams.

This commit fixes this by also setting the qparams when the observer is
enabled but fake quant is not, so `scale` and `zero_point` stay in sync with
the running min/max. Behavior is unchanged when fake quant is enabled.

- On CPU, we need to split `choose_qparams_fake_quant`, which bundled
  setting qparams and applying fake quant in the same function
- On CUDA, these are already separate, so the change is minimal

**Test Plan:**

```
pytest test/quantization/core/test_workflow_ops.py -k TestFusedObsFakeQuant
```

Differential Revision: [D117426200](https://our.internmc.facebook.com/intern/diff/D117426200)

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01