### PR TITLE
Fix qparams mismatch in FusedMovingAvgObsFakeQuantize

### DIFF
--- a/test/quantization/core/test_workflow_module.py
+++ b/test/quantization/core/test_workflow_module.py
@@ -1395,6 +1395,57 @@ class TestFusedObsFakeQuantModule(TestCase):
             torch.testing.assert_close(mod.state_dict()['activation_post_process.min_val'], running_min_op)
             torch.testing.assert_close(mod.state_dict()['activation_post_process.max_val'], running_max_op)
 
+    @given(
+        device=st.sampled_from(
+            ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+        )
+    )
+    @settings(deadline=None)
+    def test_fused_obs_fq_module_calculate_qparams(self, device):
+        """
+        Tests that calculate_qparams returns the qparams the fused op used,
+        and not the inner observer's, which computes symmetric qparams using
+        a different formula.
+        """
+        mod = FusedMovingAvgObsFakeQuantize(
+            observer=MovingAverageMinMaxObserver,
+            quant_min=-127,
+            quant_max=127,
+            dtype=torch.qint8,
+            qscheme=torch.per_tensor_symmetric,
+        )
+        mod.to(device)
+        x = torch.randn(5, 5, device=device)
+        mod(x)
+        scale, zero_point = mod.calculate_qparams()
+
+        # Run the operator directly to get the reference qparams, with the
+        # observer frozen so the running min/max are not updated again
+        obs = mod.activation_post_process
+        ref_scale = torch.ones_like(mod.scale)
+        ref_zero_point = torch.zeros_like(mod.zero_point)
+        torch.fused_moving_avg_obs_fake_quant(
+            x,
+            torch.zeros_like(mod.observer_enabled),
+            torch.ones_like(mod.fake_quant_enabled),
+            obs.min_val.clone(),
+            obs.max_val.clone(),
+            ref_scale,
+            ref_zero_point,
+            obs.averaging_constant,
+            obs.quant_min,
+            obs.quant_max,
+            mod.ch_axis,
+            mod.is_per_channel,
+            mod.is_symmetric_quant,
+        )
+        torch.testing.assert_close(scale, ref_scale, atol=0, rtol=0)
+        torch.testing.assert_close(zero_point, ref_zero_point, atol=0, rtol=0)
+
+        # The observer uses a different symmetric formula and should not match
+        obs_scale, _ = obs.calculate_qparams()
+        self.assertFalse(torch.equal(scale, obs_scale))
+
     def test_fused_mod_reduce_range(self):
         obs = FusedMovingAvgObsFakeQuantize(quant_min=0, quant_max=255, dtype=torch.quint8, reduce_range=True)
         self.assertEqual(obs.activation_post_process.quant_min, 0)

--- a/torch/ao/quantization/fake_quantize.py
+++ b/torch/ao/quantization/fake_quantize.py
@@ -409,7 +409,7 @@ class FusedMovingAvgObsFakeQuantize(FakeQuantize):
 
     @torch.jit.export
     def calculate_qparams(self) -> tuple[torch.Tensor, torch.Tensor]:  # type: ignore[override]
-        return self.activation_post_process.calculate_qparams()
+        return self.scale, self.zero_point
 
     @torch.jit.export
     def extra_repr(self) -> str:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194816
* #194815

**Summary:** `FusedMovingAvgObsFakeQuantize` offers two different
qparams calculations with slightly differing numerics:

(1) `torch.fused_moving_avg_obs_fake_quant`

```
\# aten/src/ATen/native/quantized/cuda/FusedObsFakeQuant.cu
int symmetric_qmin = -((qmax - qmin) / 2 + 1);
int symmetric_qmax = (qmax - qmin) / 2;
double max_scale = std::max(
    fabs(min_val / symmetric_qmin), fabs(max_val / symmetric_qmax));
min_val = max_scale * symmetric_qmin;
max_val = max_scale * symmetric_qmax;
min_val = std::min(min_val, 0.f);
max_val = std::max(max_val, 0.f);
scale[i] = (static_cast<double>(max_val) - min_val) / (qmax - qmin);
```

(2) `MovingAverageMinMaxObserver.calculate_qparams`

```
max_val_pos = torch.max(-min_val_neg, max_val_pos)
scale = max_val_pos / (float(quant_max - quant_min) / 2)
scale = torch.max(scale, self.eps)
```

E.g. for [-8, 7], (1) divides by 8 or 7 while (2) divides by 7.5,
so e.g. min=-1.149422, max=2.533506 gives 0.361929 vs 0.337801.

This commit fixes this by always reading the qparams from (1) the
c++/cuda kernel directly, ignoring the inner observer (2)
hiding in the fake quant entirely. This resolves the duplicate
observer semantics in `FusedMovingAvgObsFakeQuantize`, which
was the root cause of the numerical divergence.

**Test Plan:**

```
pytest test/quantization/core/test_workflow_module.py -k test_fused_obs_fq_module_calculate_qparams
```