### PR TITLE
[varlen] Fix cuDNN backend bugs found by fuzz testing

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -2058,9 +2058,11 @@ void run_cudnn_SDP_bprop_nestedtensor(
     Tensor& dV,
     const Tensor& dropoutseed,
     const Tensor& dropoutoffset) {
-  // do nothing if we got 0-element tensors
   if (!q.numel() || !k.numel() || !v.numel() || !o.numel() || !dO.numel() ||
       !softmaxstats.numel()) {
+    dQ.zero_();
+    dK.zero_();
+    dV.zero_();
     return;
   }
   TORCH_CHECK(

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -1,5 +1,4 @@
 #include <limits>
-#include <numeric>
 
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
@@ -607,32 +606,6 @@ enum UIDS {
 std::vector<int64_t> thd_to_bhsd_strides(const Tensor& tensor) {
   TORCH_INTERNAL_ASSERT(tensor.dim() == 3);
   return {INT_MAX, tensor.stride(1), tensor.stride(0), tensor.stride(2)};
-}
-
-// Allocate a dense output in the query's dimension order, mirroring
-// _empty_with_matching_layout in torch/nn/attention/_utils.py (used by the
-// varlen custom-op fake) and the Flash varlen forward's empty_like(q).
-Tensor empty_with_matching_layout(const Tensor& tensor, IntArrayRef shape) {
-  if (tensor.sizes().equals(shape)) {
-    return at::empty_like(tensor);
-  }
-  const int64_t dims = tensor.dim();
-  std::vector<int64_t> order(dims);
-  std::iota(order.begin(), order.end(), 0);
-  std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
-    const auto stride_key = [&](int64_t dim) {
-      const auto stride = tensor.stride(dim);
-      return stride ? stride : std::numeric_limits<int64_t>::max();
-    };
-    return stride_key(a) < stride_key(b);
-  });
-  std::vector<int64_t> strides(dims);
-  int64_t stride = 1;
-  for (const auto dim : order) {
-    strides[dim] = stride;
-    stride *= shape[dim];
-  }
-  return at::empty_strided(shape, strides, tensor.options());
 }
 
 // Ragged offsets are declared int32 to cuDNN, so the largest offset
@@ -1723,7 +1696,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
   // tensors; empty KV attends to nothing, so o is zero and the LSE is -inf.
   if (!q.numel() || !k.numel() || !v.numel()) {
     if (!o.defined()) {
-      o = empty_with_matching_layout(q, {q.size(0), h_q, d_v});
+      alloc_with_matching_layout(q, o, {q.size(0), h_q, d_v});
       o.zero_();
     }
     if (return_softmaxstats && !softmaxstats.defined()) {
@@ -1746,7 +1719,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
   }
 
   if (!o.defined()) {
-    o = empty_with_matching_layout(q, {q.size(0), h_q, d_v});
+    alloc_with_matching_layout(q, o, {q.size(0), h_q, d_v});
   }
 
   if (return_softmaxstats && !softmaxstats.defined()) {

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -1,3 +1,5 @@
+#include <limits>
+
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
 #include <ATen/cuda/CUDAConfig.h>
@@ -8,6 +10,31 @@
 #include <cudnn_frontend_version.h>
 #endif
 #endif
+
+namespace at::native {
+
+// Check the pointer and stride alignment cuDNN requires for varlen tensors.
+bool has_aligned_varlen_layout(const Tensor& tensor) {
+  constexpr int64_t alignment_bytes = 16;
+  if (!tensor.numel()) {
+    return true;
+  }
+  if (tensor.dim() == 0 || tensor.stride(-1) != 1 ||
+      reinterpret_cast<uintptr_t>(tensor.const_data_ptr()) % alignment_bytes !=
+          0) {
+    return false;
+  }
+  const int64_t alignment = alignment_bytes / tensor.element_size();
+  for (int64_t dim = 0; dim < tensor.dim() - 1; ++dim) {
+    if (tensor.size(dim) > 1 &&
+        (tensor.stride(dim) <= 0 || tensor.stride(dim) % alignment != 0)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace at::native
 
 #if defined(USE_ROCM) || !AT_CUDNN_ENABLED() || !defined(CUDNN_VERSION) || \
     (defined(CUDNN_VERSION) && CUDNN_VERSION < 8900) ||                    \
@@ -579,6 +606,17 @@ enum UIDS {
 std::vector<int64_t> thd_to_bhsd_strides(const Tensor& tensor) {
   TORCH_INTERNAL_ASSERT(tensor.dim() == 3);
   return {INT_MAX, tensor.stride(1), tensor.stride(0), tensor.stride(2)};
+}
+
+// Ragged offsets are declared int32 to cuDNN, so the largest offset
+// (packed extent * token stride) must not wrap.
+void check_ragged_offset_capacity(const Tensor& tensor, const char* name) {
+  TORCH_CHECK(
+      tensor.size(-3) * tensor.stride(-3) <= std::numeric_limits<int>::max(),
+      "cuDNN varlen attention requires the packed extent of ",
+      name,
+      " times its token stride to fit in int32, got ",
+      tensor.size(-3) * tensor.stride(-3));
 }
 
 // A ragged offset is cum_seqlen * token_stride, so equal token strides can
@@ -1654,8 +1692,18 @@ void run_cudnn_SDP_fprop_nestedtensor(
     Tensor& dropoutseed,
     Tensor& dropoutoffset) {
   cudnnHandle_t handle = getCudnnHandle();
-  // do nothing if we got 0-element tensors
+  // Return well-formed outputs for 0-element inputs instead of undefined
+  // tensors; empty KV attends to nothing, so o is zero and the LSE is -inf.
   if (!q.numel() || !k.numel() || !v.numel()) {
+    if (!o.defined()) {
+      o = at::zeros({q.size(0), h_q, d_v}, q.options());
+    }
+    if (return_softmaxstats && !softmaxstats.defined()) {
+      softmaxstats = at::full(
+          {h_q, q.size(0)},
+          -std::numeric_limits<float>::infinity(),
+          q.options().dtype(kFloat));
+    }
     return;
   }
   const bool is_paged = page_table.has_value();
@@ -1739,6 +1787,12 @@ void run_cudnn_SDP_fprop_nestedtensor(
   auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
   auto seqlen_kv =
       seqused_k.has_value() ? seqused_k.value() : at::diff(cum_seqlen_kv, 1, 0);
+  check_ragged_offset_capacity(q, "query");
+  check_ragged_offset_capacity(o, "out");
+  if (!is_paged) {
+    check_ragged_offset_capacity(k, "key");
+    check_ragged_offset_capacity(v, "value");
+  }
   auto rag_q_off = cum_seqlen_q.mul(q.stride(-3));
   auto rag_o_off =
       ragged_offset(cum_seqlen_q, o.stride(-3), rag_q_off, q.stride(-3));
@@ -1985,20 +2039,26 @@ void run_cudnn_SDP_bprop_nestedtensor(
       softmaxstats.dim() == 2, "cuDNN SDPA expected a 2D (H, T) softmax_lse");
   auto softmaxstats_ = softmaxstats.unsqueeze(-1).transpose(0, 1);
 
-  // Alignment is not part of the cache key, and cuDNN requires a unit
-  // embedding stride. Preserve all other dO strides when those hold.
+  // Alignment is not part of the cache key, and cuDNN requires 16-byte
+  // pointer/stride alignment. Preserve dO strides when those hold.
   Tensor dO_ = dO;
-  if (dO.stride(-1) != 1 ||
-      reinterpret_cast<uintptr_t>(dO.const_data_ptr()) % 16 != 0) {
+  if (!has_aligned_varlen_layout(dO)) {
     dO_ = dO.clone(at::MemoryFormat::Contiguous);
   }
   TORCH_INTERNAL_ASSERT(
-      dO_.stride(-1) == 1 &&
-          reinterpret_cast<uintptr_t>(dO_.const_data_ptr()) % 16 == 0,
+      has_aligned_varlen_layout(dO_),
       "cuDNN SDPA expected an aligned grad_output with unit embedding stride");
 
   auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
   auto seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
+  check_ragged_offset_capacity(q, "query");
+  check_ragged_offset_capacity(k, "key");
+  check_ragged_offset_capacity(v, "value");
+  check_ragged_offset_capacity(o, "out");
+  check_ragged_offset_capacity(dO_, "grad_out");
+  check_ragged_offset_capacity(dQ, "grad_query");
+  check_ragged_offset_capacity(dK, "grad_key");
+  check_ragged_offset_capacity(dV, "grad_value");
   const int64_t q_token_stride = q.stride(-3);
   const int64_t kv_token_stride = k.stride(-3);
   auto rag_q_off = cum_seqlen_q.mul(q_token_stride);

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -2050,7 +2050,8 @@ void run_cudnn_SDP_bprop_nestedtensor(
   }
   TORCH_INTERNAL_ASSERT(
       has_aligned_varlen_layout(dO_),
-      "cuDNN SDPA expected an aligned grad_output with unit embedding stride");
+      "cuDNN SDPA expected grad_output to have 16-byte-aligned storage and "
+      "non-broadcast strides, with a contiguous last dimension");
 
   auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
   auto seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -1,4 +1,5 @@
 #include <limits>
+#include <numeric>
 
 #include <ATen/ATen.h>
 #include <ATen/Config.h>
@@ -606,6 +607,32 @@ enum UIDS {
 std::vector<int64_t> thd_to_bhsd_strides(const Tensor& tensor) {
   TORCH_INTERNAL_ASSERT(tensor.dim() == 3);
   return {INT_MAX, tensor.stride(1), tensor.stride(0), tensor.stride(2)};
+}
+
+// Allocate a dense output in the query's dimension order, mirroring
+// _empty_with_matching_layout in torch/nn/attention/_utils.py (used by the
+// varlen custom-op fake) and the Flash varlen forward's empty_like(q).
+Tensor empty_with_matching_layout(const Tensor& tensor, IntArrayRef shape) {
+  if (tensor.sizes().equals(shape)) {
+    return at::empty_like(tensor);
+  }
+  const int64_t dims = tensor.dim();
+  std::vector<int64_t> order(dims);
+  std::iota(order.begin(), order.end(), 0);
+  std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+    const auto stride_key = [&](int64_t dim) {
+      const auto stride = tensor.stride(dim);
+      return stride ? stride : std::numeric_limits<int64_t>::max();
+    };
+    return stride_key(a) < stride_key(b);
+  });
+  std::vector<int64_t> strides(dims);
+  int64_t stride = 1;
+  for (const auto dim : order) {
+    strides[dim] = stride;
+    stride *= shape[dim];
+  }
+  return at::empty_strided(shape, strides, tensor.options());
 }
 
 // Ragged offsets are declared int32 to cuDNN, so the largest offset
@@ -1696,7 +1723,8 @@ void run_cudnn_SDP_fprop_nestedtensor(
   // tensors; empty KV attends to nothing, so o is zero and the LSE is -inf.
   if (!q.numel() || !k.numel() || !v.numel()) {
     if (!o.defined()) {
-      o = at::zeros({q.size(0), h_q, d_v}, q.options());
+      o = empty_with_matching_layout(q, {q.size(0), h_q, d_v});
+      o.zero_();
     }
     if (return_softmaxstats && !softmaxstats.defined()) {
       softmaxstats = at::full(
@@ -1718,7 +1746,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
   }
 
   if (!o.defined()) {
-    o = at::empty({q.size(0), h_q, d_v}, q.options());
+    o = empty_with_matching_layout(q, {q.size(0), h_q, d_v});
   }
 
   if (return_softmaxstats && !softmaxstats.defined()) {

--- a/aten/src/ATen/native/cudnn/MHA.h
+++ b/aten/src/ATen/native/cudnn/MHA.h
@@ -3,6 +3,9 @@
 
 namespace at::native {
 
+// Check the pointer and stride alignment cuDNN requires for varlen tensors.
+bool has_aligned_varlen_layout(const Tensor& tensor);
+
 void run_cudnn_SDP_fprop(
     int64_t b,
     int64_t h,

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -986,31 +986,6 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
   return std::make_tuple(Tensor(), Tensor(), Tensor(), Tensor(), c10::SymInt(0), c10::SymInt(0), Tensor(), Tensor(), Tensor());
 }
 
-namespace {
-
-// Check the pointer and stride alignment required by cuDNN varlen SDPA.
-bool has_aligned_varlen_layout(const Tensor& tensor) {
-  constexpr int64_t alignment_bytes = 16;
-  if (!tensor.numel()) {
-    return true;
-  }
-  if (tensor.dim() == 0 || tensor.stride(-1) != 1 ||
-      reinterpret_cast<uintptr_t>(tensor.const_data_ptr()) % alignment_bytes !=
-          0) {
-    return false;
-  }
-  const int64_t alignment = alignment_bytes / tensor.element_size();
-  for (int64_t dim = 0; dim < tensor.dim() - 1; ++dim) {
-    if (tensor.size(dim) > 1 &&
-        (tensor.stride(dim) <= 0 || tensor.stride(dim) % alignment != 0)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-} // namespace
-
 std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Tensor, Tensor> _cudnn_attention_forward(
     const Tensor& query,
     const Tensor& key,
@@ -1043,11 +1018,11 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
       "cuDNN attention expects query, key and value to have the same dtype, got ",
       query.scalar_type(), ", ", key.scalar_type(), " and ", value.scalar_type());
   TORCH_CHECK(
-      !has_kv_cache ||
+      !is_nested ||
           (has_aligned_varlen_layout(query) &&
            has_aligned_varlen_layout(key) &&
            has_aligned_varlen_layout(value)),
-      "cuDNN KV-cache attention requires query, key and value to have "
+      "cuDNN varlen attention requires query, key and value to have "
       "16-byte-aligned storage and non-broadcast strides, with a contiguous "
       "last dimension.");
   TORCH_CHECK(
@@ -1139,6 +1114,10 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
     const int64_t num_heads_v = value.size(-2);
     const int64_t head_dim_qk = query.size(-1);
     const int64_t head_dim_v = value.size(-1);
+    TORCH_CHECK(
+        block_table.has_value() || key.size(-1) == query.size(-1),
+        "cuDNN varlen attention requires key head dimension to match query, got ",
+        key.size(-1), " and ", query.size(-1));
     TORCH_CHECK(
         block_table.has_value() || cumulative_sequence_length_kv.has_value(),
         "cuDNN varlen attention requires cum_seq_k unless a block_table is given.");

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1103,11 +1103,44 @@ class TestVarlenAttention(NNTestCase):
         self.assertEqual(lse.shape, torch.Size([num_heads, 0]))
 
     @skipIfRocm
+    def test_cudnn_varlen_empty_kv(self, device):
+        """Empty KV returns constant outputs and zero gradients."""
+        _check_cudnn_varlen_supported(device)
+        num_heads, head_dim = 2, 64
+        q = torch.randn(
+            256, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_()
+        k = torch.randn(
+            0, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_()
+        v = torch.randn_like(k, requires_grad=True)
+        cu_seq_q = torch.tensor([0, 256], device=device, dtype=torch.int32)
+        cu_seq_k = torch.tensor([0, 0], device=device, dtype=torch.int32)
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out, lse = varlen_attn(
+                q,
+                k,
+                v,
+                cu_seq_q,
+                cu_seq_k,
+                256,
+                0,
+                return_aux=AuxRequest(lse=True),
+            )
+            grads = torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
+
+        self.assertEqual(out, torch.zeros_like(out))
+        self.assertEqual(lse, torch.full_like(lse, -torch.inf))
+        for grad in grads:
+            self.assertEqual(grad, torch.zeros_like(grad))
+
+    @skipIfRocm
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
     def test_cudnn_varlen_compile_noncontiguous_query(self, device):
-        """The fake op must mirror cuDNN's contiguous output for compile."""
+        """The real and fake ops preserve the query's dimension order."""
         _check_cudnn_varlen_supported(device)
         torch.manual_seed(42)
         seq_len, num_heads, head_dim = 256, 4, 64

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1009,6 +1009,7 @@ class TestVarlenAttention(NNTestCase):
     @parametrize("dtype", [torch.bfloat16, torch.float16])
     def test_cudnn_varlen_unaligned_grad_out(self, device, dtype):
         """Unaligned grad_output row strides are contiguified, not crashed on."""
+        _check_cudnn_varlen_supported(device)
         torch.manual_seed(42)
         seq_len, num_heads, head_dim = 256, 2, 8
         tensors = [

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1127,6 +1127,8 @@ class TestVarlenAttention(NNTestCase):
         with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
             eager = fn(q, k, v)
             compiled = torch.compile(fn, fullgraph=True)(q, k, v)
+        # The real output matches the query's layout, like Flash and the fake.
+        self.assertEqual(eager.stride(), q.stride())
         self.assertEqual(compiled, eager)
 
     @skipIfRocm

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -975,6 +975,161 @@ class TestVarlenAttention(NNTestCase):
         self.assertEqual(cudnn_backward.call_count, 0)
 
     @skipIfRocm
+    @parametrize("tensor_idx", [0, 1, 2])
+    def test_cudnn_varlen_unaligned_input_raises(self, device, tensor_idx):
+        """Reject varlen inputs whose row strides are not 16-byte aligned.
+
+        cuDNN's varlen kernels silently produce wrong results (forward) or
+        fault (backward) on such layouts.
+        """
+        _check_cudnn_varlen_supported(device)
+        seq_len, num_heads, head_dim = 256, 2, 8
+
+        def make(unaligned):
+            if unaligned:
+                # Row stride (head_dim + 3) * 2 bytes is not 16-byte aligned.
+                storage = torch.randn(
+                    seq_len, num_heads, head_dim + 3, device=device, dtype=torch.float16
+                )
+                return storage[..., :head_dim]
+            return torch.randn(
+                seq_len, num_heads, head_dim, device=device, dtype=torch.float16
+            )
+
+        q, k, v = (make(i == tensor_idx) for i in range(3))
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaisesRegex(RuntimeError, "16-byte-aligned"):
+                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    def test_cudnn_varlen_unaligned_grad_out(self, device, dtype):
+        """Unaligned grad_output row strides are contiguified, not crashed on."""
+        torch.manual_seed(42)
+        seq_len, num_heads, head_dim = 256, 2, 8
+        tensors = [
+            torch.randn(
+                seq_len, num_heads, head_dim, device=device, dtype=dtype
+            ).requires_grad_()
+            for _ in range(3)
+        ]
+        q, k, v = tensors
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        def grads(grad_out, use_cudnn):
+            with _use_cudnn_varlen(use_cudnn, device):
+                out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+                return torch.autograd.grad(out, tensors, grad_out)
+
+        # Row stride (head_dim + 3) * itemsize is not 16-byte aligned.
+        storage = torch.randn(
+            seq_len, num_heads, head_dim + 3, device=device, dtype=dtype
+        )
+        unaligned = storage[..., :head_dim]
+        self.assertNotEqual(unaligned.stride(-2) * unaligned.element_size() % 16, 0)
+        expected = grads(unaligned.clone(), use_cudnn=False)
+        actual = grads(unaligned, use_cudnn=True)
+        for got, want in zip(actual, expected):
+            self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
+    def test_cudnn_varlen_rejects_large_head_dim(self, device):
+        """Head dims above 128 must fall back to Flash instead of failing in cuDNN."""
+        _check_cudnn_varlen_supported(device)
+        seq_len, num_heads, head_dim = 256, 2, 192
+        q = torch.randn(
+            seq_len, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        )
+        k, v = torch.randn_like(q), torch.randn_like(q)
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        with (
+            patch.object(
+                torch.ops.aten,
+                "_flash_attention_forward",
+                wraps=torch.ops.aten._flash_attention_forward,
+            ) as flash_forward,
+            patch.object(
+                torch.ops.aten,
+                "_cudnn_attention_forward",
+                wraps=torch.ops.aten._cudnn_attention_forward,
+            ) as cudnn_forward,
+        ):
+            varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+        self.assertEqual(flash_forward.call_count, 1)
+        self.assertEqual(cudnn_forward.call_count, 0)
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaisesRegex(
+                RuntimeError, "head dimensions must be at most 128"
+            ):
+                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+    @skipIfRocm
+    def test_cudnn_varlen_key_head_dim_mismatch_raises(self, device):
+        """A mismatched key head dim must raise instead of overreading K."""
+        _check_cudnn_varlen_supported(device)
+        seq_len, num_heads = 256, 2
+        q = torch.randn(seq_len, num_heads, 64, device=device, dtype=torch.bfloat16)
+        k = torch.randn(seq_len, num_heads, 32, device=device, dtype=torch.bfloat16)
+        v = torch.randn(seq_len, num_heads, 64, device=device, dtype=torch.bfloat16)
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            with self.assertRaisesRegex(
+                RuntimeError, "key head dimension to match query"
+            ):
+                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+    @skipIfRocm
+    def test_cudnn_varlen_empty_batch(self, device):
+        """Zero-token batches return well-formed empties, matching Flash."""
+        _check_cudnn_varlen_supported(device)
+        num_heads, head_dim = 2, 64
+        q = torch.randn(0, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+        k, v = torch.randn_like(q), torch.randn_like(q)
+        cu_seq = torch.tensor([0, 0], device=device, dtype=torch.int32)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out, lse = varlen_attn(
+                q, k, v, cu_seq, cu_seq, 256, 256, return_aux=AuxRequest(lse=True)
+            )
+        self.assertEqual(out.shape, torch.Size([0, num_heads, head_dim]))
+        self.assertEqual(lse.shape, torch.Size([num_heads, 0]))
+
+    @skipIfRocm
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    )
+    def test_cudnn_varlen_compile_noncontiguous_query(self, device):
+        """The fake op must mirror cuDNN's contiguous output for compile."""
+        _check_cudnn_varlen_supported(device)
+        torch.manual_seed(42)
+        seq_len, num_heads, head_dim = 256, 4, 64
+
+        def make():
+            # Head-major storage: strides (head_dim, seq_len * head_dim, 1).
+            return torch.randn(
+                num_heads, seq_len, head_dim, device=device, dtype=torch.bfloat16
+            ).permute(1, 0, 2)
+
+        q, k, v = make(), make(), make()
+        cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
+
+        def fn(q, k, v):
+            return varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            eager = fn(q, k, v)
+            compiled = torch.compile(fn, fullgraph=True)(q, k, v)
+        self.assertEqual(compiled, eager)
+
+    @skipIfRocm
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -89,6 +89,8 @@ def _cudnn_rejection_reasons(
         reasons.append("query dtype must be float16 or bfloat16")
     if query.shape[-1] % 8 != 0 or value.shape[-1] % 8 != 0:
         reasons.append("query and value head dimensions must be divisible by 8")
+    if query.shape[-1] > 128 or value.shape[-1] > 128:
+        reasons.append("head dimensions must be at most 128")
     if window_size == [-1, 0]:
         if cu_seq_q is not cu_seq_k:
             reasons.append(
@@ -270,7 +272,16 @@ def _varlen_attn_fake(
     """
     window_size = _normalize_window_size(window_size)
 
-    output = _empty_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
+    if backend == _CUDNN_ATTENTION_BACKEND:
+        # The cuDNN varlen forward always allocates a contiguous output
+        # (aten/src/ATen/native/cudnn/MHA.cpp), regardless of query layout.
+        output = torch.empty(
+            (*query.shape[:-1], value.size(-1)),
+            dtype=query.dtype,
+            device=query.device,
+        )
+    else:
+        output = _empty_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
 
     # For varlen path: logsumexp shape is (num_heads, total_q)
     total_q = query.size(0)

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -272,16 +272,7 @@ def _varlen_attn_fake(
     """
     window_size = _normalize_window_size(window_size)
 
-    if backend == _CUDNN_ATTENTION_BACKEND:
-        # The cuDNN varlen forward always allocates a contiguous output
-        # (aten/src/ATen/native/cudnn/MHA.cpp), regardless of query layout.
-        output = torch.empty(
-            (*query.shape[:-1], value.size(-1)),
-            dtype=query.dtype,
-            device=query.device,
-        )
-    else:
-        output = _empty_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
+    output = _empty_with_matching_layout(query, (*query.shape[:-1], value.size(-1)))
 
     # For varlen path: logsumexp shape is (num_heads, total_q)
     total_q = query.size(0)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #194834
* __->__ #194818

This commit was authored with an AI assistant.

An adversarial fuzzing campaign against the public varlen_attn cuDNN backend (GB200, cuDNN 9.24.0)
found six reachable defects. Review the kernel-facing fixes in MHA.cpp/attention.cu first, then the Python
selector fix in varlen.py; every fix has a regression test. All new validation is host-side tensor metadata
only: no fix introduces a device-to-host or host-to-device sync.

cuDNN's varlen kernels require 16-byte-aligned base pointers and row strides, but the alignment check only
guarded the KV-cache path. Unaligned q/k/v silently produced wrong results (compute-sanitizer memcheck-clean,
so wrong address arithmetic rather than out-of-bounds access), a 16B-misaligned base pointer raised a sticky
misaligned-address fault, and a padded grad_out crashed backward with CUDNN_BACKEND_API_FAILED err 716. The
forward now enforces has_aligned_varlen_layout for all varlen calls, and backward contiguifies grad_out under
the same predicate. Automatic fallback on this rejection is intentionally not added: the same fuzzing found
Flash varlen can fault on these unaligned layouts, so fallback is not currently a safe recovery path.

The ragged path also trusted more metadata than it checked: a key head dim different from query silently
overread K (proven with a canary allocation), ragged offsets (cum_seqlen * token stride, declared INT32 to
cuDNN) could silently wrap at about 1M packed tokens for H=16/d=128, and empty inputs returned undefined
outputs. These now raise clean errors or return well-defined zero output, -inf LSE, and zero gradients. The
zero-gradient handling covers mixed empty inputs such as nonempty Q with empty KV, where returning from
backward without initializing dQ would otherwise expose allocator contents.

The real cuDNN forward also always allocated a contiguous output, while the fake and Flash forward match the
query's dimension order, so torch.compile with a non-contiguous query failed assert_size_stride. The cuDNN
forward now allocates output in the query's dimension order, restoring parity with Flash and the fake; a
multi-document head-major probe verified this layout in causal/full forward and backward. Finally, head dims
192/256 were incorrectly routed to cuDNN and failed in the frontend, so dimensions above 128 are rejected.

This PR does not claim a performance change. The plot gives backend context on one GB200 by holding the packed
token budget at exactly 16,384 and moving those tokens among six document-length distributions. It uses BF16
causal varlen_attn with H=16, exact triangular matmul FLOPs, and five interleaved timing rounds with
per-case profiler routing checks. PyTorch's registered SDPA FLOP formula is not used because it explicitly
counts the full LxL matrix even for causal attention.

![varlen_attn throughput by token-length distribution](https://gist.githubusercontent.com/drisspg/914f2970e21a7661e508184d9fa35426/raw/42b9b61303c807a1e75a3cac100cff2330cccab3/varlen_distribution_tflops.png)

FA2 leads when nearly all tokens are in short documents. FA4 takes over as token mass moves into medium/long,
multi-scale, or long-tail distributions; cuDNN generally follows FA4 but loses more on heterogeneous backward
workloads. At d128 uniform-long, median TFLOP/s is 316/685/573 forward and 298/730/660 backward for
FA2/FA4/cuDNN. Raw samples, routing proof, and the benchmark script are in the
[benchmark gist](https://gist.github.com/drisspg/914f2970e21a7661e508184d9fa35426).

```bash
gpu-run auto -- env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/pytest -q test/test_varlen_attention.py -n 8
lintrunner -a

gpu-run auto -- env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/python agent_space/varlen_cudnn_audit/round2/perf_distributions/benchmark.py
```

382 passed / 72 skipped / 8 xfailed on GB200 with cuDNN 9.24.0 (baseline before this change: 372 passed);
the ten new tests cover each fix and fail or expose undefined behavior without it.

cc @liangel-02 @howardzhang-cv