### PR TITLE
[inductor] Eagerly load codegen heuristic modules (#194822)

### DIFF
--- a/test/inductor/test_codegen_heuristics_registry_lazy_imports.py
+++ b/test/inductor/test_codegen_heuristics_registry_lazy_imports.py
@@ -1,0 +1,131 @@
+# Owner(s): ["module: inductor"]
+
+import importlib
+import subprocess
+import sys
+
+from torch._inductor.test_case import run_tests, TestCase
+
+
+_TEST_SCRIPT = """\
+import importlib
+import sys
+
+from torch._inductor.heuristics.registry import clear_registry, get_codegen_heuristic
+
+if not getattr(importlib, "is_lazy_imports_enabled", lambda: False)():
+    raise AssertionError("Cinder lazy imports are not enabled")
+
+package_name = "torch._inductor.heuristics.triton_codegen"
+expected_types = {
+    "pointwise": (
+        "torch._inductor.heuristics.triton_codegen.pointwise",
+        "PointwiseHeuristic",
+    ),
+    "reduction": (
+        "torch._inductor.heuristics.triton_codegen.reduction",
+        "ReductionHeuristic",
+    ),
+}
+
+def check_heuristics() -> None:
+    for name, expected_type in expected_types.items():
+        heuristic_type = type(get_codegen_heuristic(name, "cpu"))
+        actual_type = (heuristic_type.__module__, heuristic_type.__name__)
+        if actual_type != expected_type:
+            raise AssertionError(f"{name}: expected {expected_type}, got {actual_type}")
+
+print("PHASE: cold lookup", flush=True)
+if package_name in sys.modules:
+    raise AssertionError(f"{package_name} was loaded before the cold lookup")
+
+check_heuristics()
+
+parent = sys.modules[package_name]
+module_names = {module_name for module_name, _ in expected_types.values()}
+
+for module_name in module_names:
+    if module_name not in sys.modules:
+        raise AssertionError(f"{module_name} was not loaded by the cold lookup")
+
+print("PHASE: cached-parent recovery", flush=True)
+for module_name in module_names:
+    sys.modules.pop(module_name)
+    parent.__dict__.pop(module_name.rsplit(".", 1)[1], None)
+
+clear_registry()
+
+if package_name not in sys.modules:
+    raise AssertionError(f"{package_name} is not cached")
+for module_name in module_names:
+    if module_name in sys.modules:
+        raise AssertionError(f"{module_name} is still loaded")
+
+check_heuristics()
+for module_name in module_names:
+    if module_name not in sys.modules:
+        raise AssertionError(f"{module_name} was not loaded by the cached lookup")
+
+print("PHASE: unknown-name fallback", flush=True)
+for module_name in module_names:
+    sys.modules.pop(module_name)
+    parent.__dict__.pop(module_name.rsplit(".", 1)[1], None)
+
+clear_registry()
+
+if package_name not in sys.modules:
+    raise AssertionError(f"{package_name} is not cached before the unknown lookup")
+for module_name in module_names:
+    if module_name in sys.modules:
+        raise AssertionError(f"{module_name} is still loaded before the unknown lookup")
+
+try:
+    get_codegen_heuristic("unknown", "cpu")
+except ValueError:
+    pass
+else:
+    raise AssertionError("unknown heuristic did not raise ValueError")
+
+for module_name in module_names:
+    if module_name not in sys.modules:
+        raise AssertionError(f"{module_name} was not loaded by the unknown lookup")
+"""
+
+
+class CodegenHeuristicsRegistryLazyImportsTest(TestCase):
+    def test_codegen_heuristics_are_registered_on_demand(self) -> None:
+        lazy_import_capability = getattr(importlib, "is_lazy_imports_enabled", None)
+        if not callable(lazy_import_capability) or not lazy_import_capability():
+            self.skipTest("Cinder lazy imports are unavailable or disabled")
+
+        result = subprocess.run(
+            [sys.executable, "-L", "-c", _TEST_SCRIPT],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"subprocess failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+        phases = [
+            line for line in result.stdout.splitlines() if line.startswith("PHASE: ")
+        ]
+        self.assertEqual(
+            phases,
+            [
+                "PHASE: cold lookup",
+                "PHASE: cached-parent recovery",
+                "PHASE: unknown-name fallback",
+            ],
+            "unexpected subprocess phases:\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/heuristics/registry.py
+++ b/torch/_inductor/heuristics/registry.py
@@ -11,6 +11,7 @@ Both share one underlying registry dict and cascading fallback lookup.
 from __future__ import annotations
 
 import contextlib
+import importlib
 import logging
 from typing import Any, TYPE_CHECKING
 
@@ -26,6 +27,8 @@ _HEURISTIC_REGISTRY: dict[tuple[str | None, ...], Any] = {}
 # This intentionally covers both template and codegen entries.
 _TEMPLATE_HEURISTIC_REGISTRY = _HEURISTIC_REGISTRY
 _HEURISTIC_CACHE: dict[tuple[str | None, ...], Any] = {}
+_CODEGEN_HEURISTICS_PACKAGE = "torch._inductor.heuristics.triton_codegen"
+
 
 log = logging.getLogger(__name__)
 
@@ -54,6 +57,12 @@ def _lookup(name: str, device_type: str, op_name: str | None) -> Any | None:
         if key in _HEURISTIC_REGISTRY:
             return _HEURISTIC_REGISTRY[key]
     return None
+
+
+def _import_codegen_heuristic_modules() -> None:
+    # Registrations for one name may be spread across multiple required providers.
+    importlib.import_module(f"{_CODEGEN_HEURISTICS_PACKAGE}.pointwise")
+    importlib.import_module(f"{_CODEGEN_HEURISTICS_PACKAGE}.reduction")
 
 
 # -----------------------------------------------------------------
@@ -201,9 +210,7 @@ def get_codegen_heuristic(name: str, device_type: str) -> CodegenConfigHeuristic
     heuristic_class = _lookup(name, device_type, None)
 
     if heuristic_class is None:
-        # Lazily import codegen heuristics to trigger registration
-        import torch._inductor.heuristics.triton_codegen  # noqa: F401
-
+        _import_codegen_heuristic_modules()
         heuristic_class = _lookup(name, device_type, None)
 
     if heuristic_class is None:
@@ -223,7 +230,11 @@ def get_codegen_heuristic(name: str, device_type: str) -> CodegenConfigHeuristic
 
 
 def clear_registry() -> None:
-    """Clear all registered heuristics. Primarily for testing."""
+    """Clear registered heuristic classes and cached instances.
+
+    Imported modules are not unloaded, so tests that need registration side effects
+    to run again must evict those modules before importing them again.
+    """
     _HEURISTIC_REGISTRY.clear()
     _HEURISTIC_CACHE.clear()
 

--- a/torch/_inductor/heuristics/triton_codegen/__init__.py
+++ b/torch/_inductor/heuristics/triton_codegen/__init__.py
@@ -16,7 +16,8 @@ from torch._inductor.heuristics.registry import (
     register_codegen_heuristic,
 )
 
-# Import submodules to trigger registration
+# Keep explicit re-exports for packaging and type checkers. Registry lookup
+# performs eager runtime imports when registration is needed.
 from . import pointwise as pointwise, reduction as reduction
 
 


### PR DESCRIPTION
Summary:

Force `get_codegen_heuristic` to import the concrete `pointwise` and `reduction` modules. This avoids relying on package import side effects that Cinder lazy imports can defer during packaged MTIA lowering.

Add a Cinder-enabled regression test covering both heuristic lookups after the parent package has been cached.

Test Plan: `buck2 test fbcode//caffe2/test/inductor:codegen_heuristics_registry_lazy_imports`

Reviewed By: jansel

Differential Revision: D117434043




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo