### PR TITLE
Fix grammar typos in comments and docstrings

### DIFF
--- a/torch/_dynamo/graph_utils.py
+++ b/torch/_dynamo/graph_utils.py
@@ -8,7 +8,7 @@ from torch.utils._pytree import tree_flatten
 
 # flattens with support for slices
 # Note: a better way to do this would
-# be register/unregister slices as pytree nodes
+# be to register/unregister slices as pytree nodes
 # but there is no unregister API in the pytorch
 # pytree impl
 def _get_flat_args(

--- a/torch/_export/db/examples/autograd_function.py
+++ b/torch/_export/db/examples/autograd_function.py
@@ -14,8 +14,8 @@ class MyAutogradFunction(torch.autograd.Function):
 
 class AutogradFunction(torch.nn.Module):
     """
-    TorchDynamo does not keep track of backward() on autograd functions. We recommend to
-    use `allow_in_graph` to mitigate this problem.
+    TorchDynamo does not keep track of backward() on autograd functions. We recommend
+    using `allow_in_graph` to mitigate this problem.
     """
 
     def forward(self, x):

--- a/torch/_tensor_docs.py
+++ b/torch/_tensor_docs.py
@@ -6618,7 +6618,7 @@ Is ``True`` if gradients need to be computed for this Tensor, ``False`` otherwis
 
 .. note::
 
-    The fact that gradients need to be computed for a Tensor do not mean that the :attr:`grad`
+    The fact that gradients need to be computed for a Tensor does not mean that the :attr:`grad`
     attribute will be populated, see :attr:`is_leaf` for more details.
 
 """,

--- a/torch/csrc/api/include/torch/nn/modules/container/moduledict.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/moduledict.h
@@ -162,7 +162,7 @@ class ModuleDictImpl : public Cloneable<ModuleDictImpl> {
     stream << "torch::nn::ModuleDict";
   }
 
-  /// Attempts to returns the `Module` associated with the given `key`. Throws
+  /// Attempts to return the `Module` associated with the given `key`. Throws
   /// an exception if no such `key` is stored in the `ModuleDict`. Check
   /// contains(key) before for a non-throwing way of access.
   std::shared_ptr<Module> operator[](const std::string& key) const {

--- a/torch/csrc/autograd/autograd.cpp
+++ b/torch/csrc/autograd/autograd.cpp
@@ -144,7 +144,7 @@ static variable_list run_backward(
       create_graph,
       accumulate_grad,
       output_edges);
-  // check if grad_inputs contains None or not base on the allow_unused flag
+  // check if grad_inputs contains None or not based on the allow_unused flag
   if (!inputs.empty() && !allow_unused) {
     size_t num_inputs = inputs.size();
     for (const auto i : c10::irange(num_inputs)) {

--- a/torch/csrc/distributed/c10d/init.cpp
+++ b/torch/csrc/distributed/c10d/init.cpp
@@ -90,7 +90,7 @@ bool acquire_gil() {
     return true;
   }
 
-  // If we end up here, its probably still a "pass" from the perspective of
+  // If we end up here, it's probably still a "pass" from the perspective of
   // checking whether python is stuck. but currently we don't check the return
   // value of this function anyway, just check whether it returned quickly vs
   // timing out.  Taking a long time is the main sign of trouble.  Fast return

--- a/torch/csrc/distributed/c10d/socket.cpp
+++ b/torch/csrc/distributed/c10d/socket.cpp
@@ -191,7 +191,7 @@ class SocketImpl {
 };
 
 std::string formatSockAddr(const struct ::sockaddr* addr, socklen_t len) {
-  // It can be very slow to repeatedly hit DNS resolution failure, but its
+  // It can be very slow to repeatedly hit DNS resolution failure, but it's
   // very helpful to have DNS names in logs by default. So we try to use DNS but
   // if we hit a transient failure we just disable it for the remainder of the
   // job, logging IP addresses instead. See

--- a/torch/csrc/jit/passes/quantization/insert_observers.h
+++ b/torch/csrc/jit/passes/quantization/insert_observers.h
@@ -46,7 +46,7 @@ TORCH_API Module InsertObservers(
  *
  * For each Tensor that needs to be observed in the method, insert observer
  * module to the input module and observe_<method-name> methods to the module.
- * This method is clone of method_name with forward calls of observer added.
+ * This method is a clone of method_name with forward calls of observer added.
  *
  * \param module the input module
  * \param method_name the method we want to insert observers for

--- a/torch/distributed/_shard/sharder.py
+++ b/torch/distributed/_shard/sharder.py
@@ -17,7 +17,7 @@ class Sharder(abc.ABC):
     @abc.abstractmethod
     def shard(self, module: nn.Module) -> nn.Module:
         """
-        Shard a module base on the implementation of this method, and
+        Shard a module based on the implementation of this method, and
         return the sharded version of the module.
 
         Args:

--- a/torch/distributed/tensor/_ops/_tensor_ops.py
+++ b/torch/distributed/tensor/_ops/_tensor_ops.py
@@ -772,7 +772,7 @@ def stack_strategy(op_schema: OpSchema) -> StrategyType:
         op_schema.op, input_tuple_strategy
     )
 
-    # create op strategy base on the follow placements
+    # create op strategy based on the follow placements
     op_strategy = OpStrategy([])
 
     input_specs = tuple(

--- a/torch/distributed/tensor/_tp_conv.py
+++ b/torch/distributed/tensor/_tp_conv.py
@@ -12,7 +12,7 @@ aten = torch.ops.aten
 
 
 def _requires_data_exchange(padding, dim_map) -> bool:
-    # Data exchange is not need if only sharded across batch dim
+    # Data exchange is not needed if only sharded across batch dim
     if all(x == -1 for x in dim_map[1:]):
         return False
     # TODO: whether there requires data exchange is currently determined by padding

--- a/torch/fx/passes/dialect/common/cse_pass.py
+++ b/torch/fx/passes/dialect/common/cse_pass.py
@@ -58,7 +58,7 @@ class CSEPass(PassBase):
         For functional dialects, user would only need to specify the random ops in ban list.
 
         Warning: CSE Pass cannot be safely applied on a FX graph in non-functional dialects.
-        If your dialect contains stateful operators, please customized the banned_ops.
+        If your dialect contains stateful operators, please customize the banned_ops.
 
         """
         if banned_ops is None:

--- a/torch/nested/_internal/nested_tensor.py
+++ b/torch/nested/_internal/nested_tensor.py
@@ -74,7 +74,7 @@ class NestedTensor(torch.Tensor):
     _lengths: Optional[torch.Tensor]
     # NOTE [ Nested ints for ragged sizes and strides ]
     #
-    # Jagged layout tensors are tensors that represent a n-dim tensor with a
+    # Jagged layout tensors are tensors that represent an n-dim tensor with a
     # ragged dimension, but are backed by an (n-1)-dim tensor underneath, e.g.,
     # a jagged tensor with outer shape [B, x, D] is represented internally by a
     # tensor with shape [sum(x), D] where we introduce what we call a nested int

--- a/torch/nn/modules/batchnorm.py
+++ b/torch/nn/modules/batchnorm.py
@@ -648,7 +648,7 @@ class LazyBatchNorm3d(_LazyNormBase, _BatchNorm):
 
 
 class SyncBatchNorm(_BatchNorm):
-    r"""Applies Batch Normalization over a N-Dimensional input.
+    r"""Applies Batch Normalization over an N-Dimensional input.
 
     The N-D input is a mini-batch of [N-2]D inputs with additional channel dimension as described in the paper
     `Batch Normalization: Accelerating Deep Network Training by Reducing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

Corrects small grammatical errors in comments, doc comments, and docstrings across dynamo, export, autograd, distributed, JIT, FX, nested tensor, and nn modules. Changes are documentation-only; no functional code is touched.

Test Plan: No behavior change, so no new tests. Verified the edits only affect comments and docstrings.

This change was authored with the assistance of an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98