### PR TITLE
Emit Python, not sympy, for symbolic tensor shape/stride in repros (#194827)

### DIFF
--- a/test/dynamo/test_debug_utils.py
+++ b/test/dynamo/test_debug_utils.py
@@ -10,7 +10,7 @@ import torch._dynamo
 import torch._dynamo.config
 from torch._dynamo import debug_utils
 from torch._dynamo.debug_utils import (
-    _serialize_storage_nbytes,
+    _serialize_sym_expr,
     aot_graph_input_parser,
     generate_env_vars_string,
     NNModuleToString,
@@ -39,7 +39,7 @@ class TestDebugUtils(TestCase):
         symbol = shape_env.create_symbol(4, ConstantSource("storage_size"))
         expr = 4 * symbol + 18428 * Max(1, symbol)
         nbytes = torch.SymInt(SymNode(expr, shape_env, int, hint=73728))
-        source = _serialize_storage_nbytes(nbytes)
+        source = _serialize_sym_expr(nbytes)
 
         self.assertNotIn("Max", source)
         for value in (0, 1, 4):
@@ -50,11 +50,57 @@ class TestDebugUtils(TestCase):
 
         floor_expr = floor(symbol / 2)
         floor_nbytes = torch.SymInt(SymNode(floor_expr, shape_env, int, hint=2))
-        floor_source = _serialize_storage_nbytes(floor_nbytes)
+        floor_source = _serialize_sym_expr(floor_nbytes)
         self.assertIn("math.floor", floor_source)
         self.assertEqual(
             eval(floor_source, {"math": math}, {str(symbol): 4}),
             2,
+        )
+
+    def test_input_writer_symbolic_tensor_metadata_is_python(self):
+        from torch._dynamo.debug_utils import InputWriter
+        from torch._dynamo.source import ConstantSource
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.fx.experimental.sym_node import SymNode
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+        from torch.utils._sympy.functions import CeilToInt, IntTrueDiv
+
+        shape_env = ShapeEnv()
+        symbol = shape_env.create_symbol(64, ConstantSource("s33"))
+        # 32*ceil(s33/32) reprs as 32*CeilToInt(IntTrueDiv(s33, 32)) under sympy
+        expr = 32 * CeilToInt(IntTrueDiv(symbol, 32))
+        dim = torch.SymInt(SymNode(expr, shape_env, int, hint=64))
+
+        writer = InputWriter(None)
+        with FakeTensorMode(shape_env=shape_env):
+            base = torch.empty(4, dim, device="cpu")
+            writer.tensor("shape_arg", base)
+            writer.tensor("stride_arg", base.transpose(0, 1))
+            writer.tensor("offset_arg", base[1])
+
+        source = "\n".join(writer.lines())
+        self.assertIn("math.ceil", source)
+        self.assertNotIn("CeilToInt", source)
+        self.assertNotIn("IntTrueDiv", source)
+
+        class Reader:
+            def __init__(self):
+                self.tensors = []
+
+            def storage(self, storage_hash, nbytes, **kwargs):
+                return nbytes
+
+            def tensor(self, buf, shape, stride=None, *, storage_offset=0, **kwargs):
+                self.tensors.append((shape, stride, storage_offset))
+
+        # The generated preamble provides math; the symbol is bound by the caller.
+        namespace = {"math": math, str(symbol): 64}
+        exec(source, namespace)
+        reader = Reader()
+        namespace["load_args"](reader)
+        self.assertEqual(
+            reader.tensors,
+            [((4, 64), None, 0), ((64, 4), (1, 64), 0), ((64,), None, 64)],
         )
 
     def test_repro_templates_import_symexpr_dependencies(self):

--- a/torch/_dynamo/debug_utils.py
+++ b/torch/_dynamo/debug_utils.py
@@ -947,12 +947,22 @@ class InputReader:
 #     works too" but this is delicate so we don't do it
 
 
-def _serialize_storage_nbytes(nbytes: int | torch.SymInt) -> str:
-    if isinstance(nbytes, torch.SymInt):
+def _serialize_sym_expr(val: int | torch.SymInt) -> str:
+    # str()/repr() of a SymInt gives the sympy repr (e.g. CeilToInt(IntTrueDiv(s0, 32))),
+    # which is not valid Python.  SymExprPrinter emits evaluable Python instead; the
+    # repro preamble imports math so math.ceil/math.floor etc. are in scope.
+    if isinstance(val, torch.SymInt):
         from torch.fx.experimental.symbolic_shapes import SymExprPrinter
 
-        return SymExprPrinter().doprint(nbytes.node.expr)
-    return repr(nbytes)
+        return SymExprPrinter().doprint(val.node.expr)
+    return repr(val)
+
+
+def _serialize_sym_tuple(vals: Sequence[int | torch.SymInt]) -> str:
+    inner = ", ".join(_serialize_sym_expr(v) for v in vals)
+    if len(vals) == 1:
+        inner += ","
+    return f"({inner})"
 
 
 class InputWriter:
@@ -1011,7 +1021,7 @@ class InputWriter:
         if _device_or_default(None) != device:
             maybe_device = f", device={device!r}"
         nbytes = untyped_storage.nbytes()
-        nbytes_source = _serialize_storage_nbytes(nbytes)
+        nbytes_source = _serialize_sym_expr(nbytes)
         storage_hash = None
         if self.store is not None and untyped_storage.device.type != "meta":
             storage_hash = self.store.write_storage(untyped_storage)
@@ -1032,13 +1042,13 @@ class InputWriter:
         if not statically_known_true(
             sym_eq(_stride_or_default(None, shape=t.shape), t.stride())
         ):
-            args.append(str(tuple(t.stride())))
+            args.append(_serialize_sym_tuple(t.stride()))
         if _dtype_or_default(None) != t.dtype:
             args.append(f"dtype={t.dtype!r}")
         if not statically_known_true(
             _storage_offset_or_default(None) == t.storage_offset()
         ):
-            args.append(f"storage_offset={t.storage_offset()!r}")
+            args.append(f"storage_offset={_serialize_sym_expr(t.storage_offset())}")
         tensor_metadata = torch._utils.get_tensor_metadata(t)
         if tensor_metadata:
             args.extend(f"{k}={v!r}" for k, v in tensor_metadata.items())
@@ -1049,7 +1059,7 @@ class InputWriter:
             args.append(f"is_leaf={is_leaf!r}")
         self._lines.append(
             "reader.tensor("
-            + ", ".join([storage, str(tuple(t.shape)), *args])
+            + ", ".join([storage, _serialize_sym_tuple(t.shape), *args])
             + f")  # {name}"
         )
 


### PR DESCRIPTION
Summary:

`InputWriter` stringified symbolic values two different ways.
`InputWriter.storage()` routed the storage `nbytes` through
`_serialize_storage_nbytes`, which uses `SymExprPrinter` and therefore emits
evaluable Python (`math.ceil(s33 / 32)`). `InputWriter.tensor()` instead used
plain `str()`/`repr()` on `t.shape`, `t.stride()` and `t.storage_offset()`,
which for a `SymInt` yields the raw sympy repr
(`CeilToInt(IntTrueDiv(s33, 32))`, `Max(1, ...)`). Those names are never
imported by the generated repro, so replaying an after-AOT repro of a
dynamic-shape graph died with `NameError: name 'CeilToInt' is not defined`
inside `load_args`. The two behaviours were visible on adjacent lines of the
same generated file.

The fix renames `_serialize_storage_nbytes` to `_serialize_sym_expr` (it is no
longer nbytes-specific), adds `_serialize_sym_tuple` for tuples of
`int | SymInt` (handling the 1-element trailing-comma case), and routes shape,
stride and storage offset through them. For non-symbolic inputs the helpers are
exactly `repr()` and Python tuple repr, so the emitted text for concrete
tensors is byte-for-byte unchanged; the existing
`test_after_aot.py::TestAfterAot::test_dump_tensor` expect-test is untouched
and still passes.

Test Plan:
New regression test builds a fake tensor whose shape/stride/storage-offset all
contain `32*CeilToInt(IntTrueDiv(s, 32))`, asserts the emitted `load_args`
contains `math.ceil` and no sympy names, and `exec`s it with only `math` and
the symbol in scope:

```
buck2 run @//mode/dev-nosan //caffe2/test/dynamo:test_debug_utils -- \
    -r test_input_writer_symbolic_tensor_metadata_is_python
```

Expected: `Ran 1 test ... OK`. Reverting the three `tensor()` hunks makes it
fail with `AssertionError: 'CeilToInt' unexpectedly found in ...`.

The `load_args` that test generates for its three tensors, with the three
`tensor()` hunks reverted:

```
def load_args(reader):
    buf0 = reader.storage(None, 512*math.ceil(s69 / 32))
    reader.tensor(buf0, (4, 32*CeilToInt(IntTrueDiv(s69, 32))), is_leaf=True)  # shape_arg
    reader.tensor(buf0, (32*CeilToInt(IntTrueDiv(s69, 32)), 4), (1, Max(1, 32*CeilToInt(IntTrueDiv(s69, 32)))), is_leaf=True)  # stride_arg
    reader.tensor(buf0, (32*CeilToInt(IntTrueDiv(s69, 32)),), storage_offset=Max(1, 32*CeilToInt(IntTrueDiv(s69, 32))), is_leaf=True)  # offset_arg
load_args._version = 0
```

and with this diff applied:

```
def load_args(reader):
    buf0 = reader.storage(None, 512*math.ceil(s69 / 32))
    reader.tensor(buf0, (4, 32*math.ceil(s69 / 32)), is_leaf=True)  # shape_arg
    reader.tensor(buf0, (32*math.ceil(s69 / 32), 4), (1, max(1, 32*math.ceil(s69 / 32))), is_leaf=True)  # stride_arg
    reader.tensor(buf0, (32*math.ceil(s69 / 32),), storage_offset=max(1, 32*math.ceil(s69 / 32)), is_leaf=True)  # offset_arg
load_args._version = 0
```

`CeilToInt`/`IntTrueDiv` become `math.ceil`, and sympy's `Max` -- an undefined
name in the generated file -- becomes the `max` builtin. The
`reader.storage(...)` line is byte-identical in both: that path already routed
through `SymExprPrinter`, and the adjacent-line inconsistency between it and
the `reader.tensor(...)` lines is exactly what this diff removes.

Whole file:

```
buck2 run @//mode/dev-nosan //caffe2/test/dynamo:test_debug_utils
```

Expected: `Ran 42 tests ... OK`.

Non-symbolic output unchanged (byte-for-byte expect-test):

```
cd fbcode && PYTEST_ADDOPTS="-k test_dump_tensor" \
    buck2 run @//mode/dev-nosan //caffe2/test/dynamo:test_dynamo
```

Expected: `1 passed, 7490 deselected`.

Differential Revision: D117383581




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98