### PR TITLE
Fix typos and grammar in comments and docstrings

### DIFF
--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -535,7 +535,7 @@ at::vec::VecMask<int64_t, NI> inline get_mask_for_argmin_argmax(
   using i_t = at::vec::VecMask<int64_t, NI>;
   i_t vmask_itype = vmask.template cast<int64_t, NI>();
   // use itype here since there is vec impl for operator~ for itype
-  // while there may not vec impl for vtype
+  // while there may not be vec impl for vtype
   v_t isnan_a = a.value.isnan();
   i_t isnan_a_itype = isnan_a.template cast<int64_t, NI>();
   v_t isnan_b = value.isnan();

--- a/torch/csrc/jit/api/object.h
+++ b/torch/csrc/jit/api/object.h
@@ -188,7 +188,7 @@ struct TORCH_API Object {
   Object deepcopy() const;
 
  private:
-  // mutable be we lazily initialize in module_object.
+  // mutable because we lazily initialize in module_object.
   mutable ObjectPtr _ivalue_;
 };
 

--- a/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
@@ -246,7 +246,7 @@ constexpr auto half_support_literal =
     // MSVC's preprocessor (but not the standard compiler) has a bug
     // where it incorrectly tokenizes raw string literals, ending when it sees a
     // " this causes the #endif in this string literal to be treated as a
-    // preprocessor token which, in turn, cause sccache on windows CI to fail.
+    // preprocessor token which, in turn, causes sccache on windows CI to fail.
     // See https://godbolt.org/z/eVTIJq as an example.
     // This workaround uses string-pasting to separate the " and the #endif into
     // different strings

--- a/torch/csrc/jit/frontend/concrete_module_type.h
+++ b/torch/csrc/jit/frontend/concrete_module_type.h
@@ -52,7 +52,7 @@ class ConcreteModuleType;
 // 2. Querying: We use ConcreteModuleType as a source of truth for
 // ModuleValue::attr calls during method compilation.
 
-// Represents a concrete type during in the process for construction. We use
+// Represents a concrete type during the process for construction. We use
 // this to decide whether we can share types between modules.
 class VISIBILITY_HIDDEN ConcreteModuleTypeBuilder {
  public:

--- a/torch/csrc/jit/frontend/name_mangler.h
+++ b/torch/csrc/jit/frontend/name_mangler.h
@@ -9,7 +9,7 @@ namespace torch::jit {
  * class NameMangler
  *
  * Utility to mangle qualified names in order to make them unique. We use this
- * in various places where we to de-duplicate qualified names.
+ * in various places where we need to de-duplicate qualified names.
  */
 class TORCH_API NameMangler {
  public:

--- a/torch/csrc/jit/mobile/parse_bytecode.cpp
+++ b/torch/csrc/jit/mobile/parse_bytecode.cpp
@@ -90,7 +90,7 @@ void applyUpgrader(mobile::Function* function, uint64_t operator_version) {
               static_cast<int>(operator_version) >= upgrader.min_version) {
             // If there exists a valid upgrader, change the instruction OP to
             // CALL, and the index will point to the according upgrader
-            // function. All upgrader function are available in
+            // function. All upgrader functions are available in
             // function->get_code().functions_. It's a vector of function
             // pointer and they are initialized in the same order as the global
             // vector kUpgraderBytecode.

--- a/torch/csrc/jit/passes/lower_graph.h
+++ b/torch/csrc/jit/passes/lower_graph.h
@@ -6,7 +6,7 @@ namespace torch::jit {
 
 using ModulePtr = c10::intrusive_ptr<c10::ivalue::Object>;
 
-// Given a graph with of a method which first argument is %self, lower it to a
+// Given a graph of a method which first argument is %self, lower it to a
 // graph where all attributes accesses are replaced with explicit inputs of the
 // graph (rather than results of prim::GetAttr executed on %self).
 //

--- a/torch/distributed/flight_recorder/components/types.py
+++ b/torch/distributed/flight_recorder/components/types.py
@@ -68,7 +68,7 @@ class MatchState(Enum):
     - COLLECTIVE_TYPE_MISMATCH: The types of the collective operations differ.
     - SIZE_OR_SYNTAX_MISMATCH: There is a mismatch in input/output sizes or violation of collective syntax.
     - COLLECTIVE_STATE_MISMATCH:
-        The states of the collective not same, such as one finished while another just started or scheduled.
+        The states of the collective are not the same, such as one finished while another just started or scheduled.
     - COLLECTIVE_DTYPE_MISMATCH: The data types of the collective input/output differ.
     - UNDECIDED:
         The match status is ambiguous or cannot be determined, e.g., we might need to check all ranks for alltoall_base.

--- a/torch/distributed/optim/functional_adagrad.py
+++ b/torch/distributed/optim/functional_adagrad.py
@@ -61,7 +61,7 @@ class _FunctionalAdagrad:
         self.param_group = {"params": params}
 
         # TODO: no union or any types in TorchScript, make step a scalar tensor instead
-        # This is also needed by if we want to share_memory on the step across processes
+        # This is also needed if we want to share_memory on the step across processes
         for p in self.param_group["params"]:
             self.state[p] = {
                 "sum": torch.full_like(p.data, initial_accumulator_value),

--- a/torch/nn/modules/linear_cross_entropy.py
+++ b/torch/nn/modules/linear_cross_entropy.py
@@ -188,7 +188,7 @@ class _ChunkContext:
     """Per-call state for the chunked loop, built once via ``build``.
     Methods hide dtype/device/acc_policy dispatch behind single math ops;
     dispatch-free per-iter math is inlined into the loop body. Buffers
-    dispatch decided are not needed are rank-matching empty tensors
+    that dispatch decided are not needed are rank-matching empty tensors
     (``when=False`` in ``_make_*``) so the dataclass surface stays uniform.
     """
 

--- a/torch/package/importer.py
+++ b/torch/package/importer.py
@@ -28,7 +28,7 @@ class ObjMismatchError(Exception):
 class Importer(ABC):
     """Represents an environment to import modules from.
 
-    By default, you can figure out what module an object belongs by checking
+    By default, you can figure out what module an object belongs to by checking
     __module__ and importing the result using __import__ or importlib.import_module.
 
     torch.package introduces module importers other than the default one.

--- a/torch/profiler/_cupti/monitor_trace.py
+++ b/torch/profiler/_cupti/monitor_trace.py
@@ -287,8 +287,7 @@ def _graph_dependency_flow_events(
 
 # Eager kernel/transfer launches (NOT cudaGraphLaunch). These 1:1 correlate to an eager GPU
 # op, so they drive the host-launch -> render-stage gpu_correlation link (event_id == corr).
-# Syncs are excluded -- they correlate to no kernel, so a link on them would point nowhere
-# pointing nowhere.
+# Syncs are excluded -- they correlate to no kernel, so a link on them would point nowhere.
 _RUNTIME_LAUNCH_NAMES = {
     "cudaLaunchKernel",
     "cudaLaunchCooperativeKernel",

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_ops_common.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/_test_ops_common.py
@@ -84,7 +84,7 @@ def generate_local_weight_sharding_params_for_test(
     local_weight, sharded_dim, gpu_num, spec, rank
 ):
     """
-    Shard the local weight based the given spec, so we can compare against
+    Shard the local weight based on the given spec, so we can compare against
     the one from sharded tensor.
 
     Args:

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -5235,7 +5235,7 @@ class DistributedTest:
                 num_validated_iters=start_localSGD_iter,
             )
 
-            # When `subgroup` is None, it is equivalent to the subgroup on the each node.
+            # When `subgroup` is None, it is equivalent to the subgroup on each node.
             # For this single-node test environment, the intra-node process group is equivalent to
             # the global process group.
             if self.world_size == dist.get_world_size():

--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -518,7 +518,7 @@ class ThreeWorkersRemoteModuleTest(CommonRemoteModuleTest):
             self.assertFalse(attrs["is_device_map_set"])
             self.assertFalse(attrs["is_scriptable"])
 
-            # Test the installed methods on worker1's can be initiated by worker2 over RPC layer.
+            # Test the installed methods on worker1 can be initiated by worker2 over RPC layer.
             # NOTE: In practice a remote module should be directly stored on the worker that runs ``forward``` or ``forward_async``,
             # not have another worker to initiate forward over the RPC layer.
             args = (torch.ones(1), 2, "3")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194829

Pure comment/docstring cleanup across a handful of C++ headers and Python
modules: missing words, subject-verb agreement, and one duplicated phrase
fragment in the CUPTI monitor trace comment. No functional changes.

Test Plan: no code changes, so no tests were run; the modified lines are all
comments or docstrings.

This change was authored with the assistance of an AI assistant.