### PR TITLE
[Cherry-pick][release/2.14] [inductor] Fix loop-local load CSE lifetime (#194786)

### DIFF
--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -9,6 +9,7 @@ import sympy
 
 import torch
 from torch._dynamo.source import ConstantSource
+from torch._inductor import config
 from torch._inductor.codegen.cpp import cexpr
 from torch._inductor.codegen.simd_kernel_features import SIMDKernelFeatures
 from torch._inductor.codegen.triton import texpr
@@ -20,16 +21,15 @@ from torch._inductor.sizevars import (
     SizeVarAllocator,
     stride_at_vec_range,
 )
-from torch._inductor import config
 from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import run_and_get_kernels, run_and_get_triton_code
+from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_MACOS,
     IS_WINDOWS,
     parametrize,
 )
-from torch.testing import FileCheck
 from torch.testing._internal.inductor_utils import (
     GPU_TYPE,
     HAS_CPU,

--- a/test/inductor/test_indexing.py
+++ b/test/inductor/test_indexing.py
@@ -20,15 +20,22 @@ from torch._inductor.sizevars import (
     SizeVarAllocator,
     stride_at_vec_range,
 )
+from torch._inductor import config
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch._inductor.utils import run_and_get_triton_code
+from torch._inductor.utils import run_and_get_kernels, run_and_get_triton_code
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_MACOS,
     IS_WINDOWS,
     parametrize,
 )
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CPU, HAS_GPU
+from torch.testing import FileCheck
+from torch.testing._internal.inductor_utils import (
+    GPU_TYPE,
+    HAS_CPU,
+    HAS_CUDA_AND_TRITON,
+    HAS_GPU,
+)
 from torch.utils._sympy.functions import (
     FloorDiv,
     Identity,
@@ -1249,6 +1256,43 @@ class TestOptimizationHintIdentityExpansion(InductorTestCase):
         expr = -u0 * (-Identity(sympy.Integer(1)) + Identity(sympy.Integer(0)))
         hint = sizevars.optimization_hint(expr, fallback=42)
         self.assertEqual(hint, 42)
+
+
+class TestLoopLocalLoadCSELifetime(InductorTestCase):
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "requires CUDA and Triton")
+    @config.patch(
+        {
+            "force_disable_caches": True,
+            "triton.persistent_reductions": False,
+        }
+    )
+    def test_loop_epilogue_indirect_load_scope(self):
+        def fn(x, source, index):
+            index = index.unsqueeze(-1)
+            selected = torch.gather(source, -2, index)
+            updated = selected + x.mean(dim=-1, keepdim=True)
+            return x / updated, source.scatter(-2, index, updated)
+
+        x = torch.ones(2, 2, 8, device=GPU_TYPE)
+        source = torch.arange(1, 17, device=GPU_TYPE, dtype=torch.float32).reshape(
+            2, 8, 1
+        )
+        index = torch.arange(2, device=GPU_TYPE).repeat(2, 1)
+        actual, kernels = run_and_get_kernels(
+            torch.compile(fn, fullgraph=True, dynamic=True),
+            x,
+            source,
+            index,
+            remove_quote=True,
+        )
+
+        self.assertEqual(fn(x, source, index), actual)
+        reduction_kernels = [kernel for kernel in kernels if "tl.sum(" in kernel]
+        self.assertEqual(1, len(reduction_kernels))
+        indirect_load = r"tl\.load\([^\n]*\+ \(tmp\d+"
+        FileCheck().check("for r0_offset in tl.range").check_regex(indirect_load).check(
+            "tl.store"
+        ).check_regex(indirect_load).run(reduction_kernels[0])
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -4513,9 +4513,9 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             self.inside_reduction
             and self.range_trees[-1].is_loop
             and not indexing.has_rindex()
+            and not indexing.has_rmask()
         ):
-            # can lift a common load outside of reduction loop
-            # One exception is when this is an indirect_load.
+            # Lift loads whose address and mask are available outside the loop.
             return self.body
         else:
             return self.loads
@@ -5000,7 +5000,8 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                     ),
                 )
 
-        if not self.inside_reduction or (not indexing.has_rmask() and not has_rindex):
+        # Only CSE values emitted outside the loop remain valid after it closes.
+        if not self.inside_reduction or load_buffer is self.body:
             self.outside_loop_vars.add(result_var)
 
         return result_var


### PR DESCRIPTION
Manual cherry-pick of #194786 (`60598ed3c877`) onto `release/2.14`. Fixes #194490 on the release branch.

## What the fix does

Triton load placement and CSE lifetime used separate heuristics. An indirect load emitted inside a reduction loop could stay in the CSE cache after the loop closed and be reused by an epilogue, even though its temporary did not dominate that use. Two changes:

* `get_load_buffer` no longer lifts a load out of the loop when its indexing carries a reduction mask, since the mask is not defined outside the loop.
* `load` now uses the selected load buffer as the source of truth for CSE lifetime: `load_buffer is self.body`, rather than re-deriving it from `has_rmask()` / `has_rindex()`.

```diff
             self.inside_reduction
             and self.range_trees[-1].is_loop
             and not indexing.has_rindex()
+            and not indexing.has_rmask()
         ):
-            # can lift a common load outside of reduction loop
-            # One exception is when this is an indirect_load.
+            # Lift loads whose address and mask are available outside the loop.
             return self.body

-        if not self.inside_reduction or (not indexing.has_rmask() and not has_rindex):
+        # Only CSE values emitted outside the loop remain valid after it closes.
+        if not self.inside_reduction or load_buffer is self.body:
             self.outside_loop_vars.add(result_var)
```

## Why it needed manual resolution

Both files conflicted, because `release/2.14` predates #184287 — the PR whose narrowed-load work exposed this bug.

**`torch/_inductor/codegen/triton.py`** — upstream also deletes the `reduction_axes_omitted` bookkeeping that #184287 introduced. That code is not on this branch, so the deletion is already satisfied and the surrounding lines are left as they are. Both substantive changes apply unchanged, and `load_buffer` is already in scope at the fix site (assigned from `get_load_buffer` earlier in `load`).

**`test/inductor/test_indexing.py`** — upstream adds the regression test to `ReductionInvariantIndexingTests`, a class #184287 introduced that does not exist here. Rather than importing that whole class (whose other tests cover a feature this branch does not have), the regression test `test_loop_epilogue_indirect_load_scope` is ported verbatim into a new `TestLoopLocalLoadCSELifetime` class. Its helpers all exist on this branch: `run_and_get_kernels` (including the `remove_quote` kwarg), `FileCheck`, `HAS_CUDA_AND_TRITON` and `torch._inductor.config`, added to the imports. The unrelated `@parametrize("dense_indexing")` hunk in the same upstream diff is dropped, since it parametrizes a #184287 test.

Net result against `release/2.14`: `triton.py` +4/-3, `test_indexing.py` +48/-2.

## Test plan

```
python test/inductor/test_indexing.py TestLoopLocalLoadCSELifetime
```

I could not execute it here — this checkout has no built PyTorch and the test requires CUDA and Triton — so it needs a run on CI or a GPU host before merge. Both files were syntax-checked, and the ported test is byte-identical to the upstream one apart from the class it lives in.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

---

AI-Assisted: the conflict resolution and the test port were done with Claude Code. Author reviewed and validated all AI-generated content, per [AI_POLICY.md](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md).
