### PR TITLE
[varlen] Reuse shared cuDNN sequence metadata

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -1812,9 +1812,16 @@ void run_cudnn_SDP_fprop_nestedtensor(
   }
   const fe::graph::Graph& mha_graph = *cache_it->second;
 
+  const bool shared_cum_seqlen = cum_seqlen_q.is_same(cum_seqlen_kv);
   auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
-  auto seqlen_kv =
-      seqused_k.has_value() ? seqused_k.value() : at::diff(cum_seqlen_kv, 1, 0);
+  Tensor seqlen_kv;
+  if (seqused_k.has_value()) {
+    seqlen_kv = seqused_k.value();
+  } else if (shared_cum_seqlen) {
+    seqlen_kv = seqlen_q;
+  } else {
+    seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
+  }
   check_ragged_offset_capacity(q, "query");
   check_ragged_offset_capacity(o, "out");
   if (!is_paged) {
@@ -1826,7 +1833,9 @@ void run_cudnn_SDP_fprop_nestedtensor(
       ragged_offset(cum_seqlen_q, o.stride(-3), rag_q_off, q.stride(-3));
   Tensor rag_k_off, rag_v_off;
   if (!is_paged) {
-    rag_k_off = cum_seqlen_kv.mul(k.stride(-3));
+    rag_k_off = shared_cum_seqlen && k.stride(-3) == q.stride(-3)
+        ? rag_q_off
+        : cum_seqlen_kv.mul(k.stride(-3));
     rag_v_off =
         ragged_offset(cum_seqlen_kv, v.stride(-3), rag_k_off, k.stride(-3));
   }
@@ -2079,8 +2088,9 @@ void run_cudnn_SDP_bprop_nestedtensor(
       has_aligned_varlen_layout(dO_),
       "cuDNN SDPA expected an aligned grad_output with unit embedding stride");
 
+  const bool shared_cum_seqlen = cum_seqlen_q.is_same(cum_seqlen_kv);
   auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
-  auto seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
+  auto seqlen_kv = shared_cum_seqlen ? seqlen_q : at::diff(cum_seqlen_kv, 1, 0);
   check_ragged_offset_capacity(q, "query");
   check_ragged_offset_capacity(k, "key");
   check_ragged_offset_capacity(v, "value");
@@ -2092,7 +2102,9 @@ void run_cudnn_SDP_bprop_nestedtensor(
   const int64_t q_token_stride = q.stride(-3);
   const int64_t kv_token_stride = k.stride(-3);
   auto rag_q_off = cum_seqlen_q.mul(q_token_stride);
-  auto rag_k_off = cum_seqlen_kv.mul(kv_token_stride);
+  auto rag_k_off = shared_cum_seqlen && kv_token_stride == q_token_stride
+      ? rag_q_off
+      : cum_seqlen_kv.mul(kv_token_stride);
   auto rag_v_off =
       ragged_offset(cum_seqlen_kv, v.stride(-3), rag_k_off, kv_token_stride);
   auto rag_o_off =

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -975,6 +975,35 @@ class TestVarlenAttention(NNTestCase):
         self.assertEqual(cudnn_backward.call_count, 0)
 
     @skipIfRocm
+    @parametrize("different_kv_stride", [False, True])
+    def test_cudnn_varlen_shared_cu_seq(self, device, different_kv_stride):
+        """Reusing shared Q/K metadata preserves forward and backward results."""
+        _check_cudnn_varlen_supported(device)
+        torch.manual_seed(42)
+        total, num_heads, head_dim = 512, 4, 64
+        q = torch.randn(
+            total, num_heads, head_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_()
+
+        def make_kv():
+            shape = (total, num_heads, head_dim + 8) if different_kv_stride else q.shape
+            tensor = torch.randn(shape, device=device, dtype=torch.bfloat16)
+            return tensor[..., :head_dim].requires_grad_()
+
+        k, v = make_kv(), make_kv()
+        cu_seq = torch.tensor([0, 192, total], device=device, dtype=torch.int32)
+        grad_out = torch.randn_like(q)
+
+        def run(cu_seq_k):
+            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                out = varlen_attn(q, k, v, cu_seq, cu_seq_k, 320, 320)
+                return (out, *torch.autograd.grad(out, (q, k, v), grad_out))
+
+        expected = run(cu_seq.clone())
+        actual = run(cu_seq)
+        self.assertEqual(actual, expected)
+
+    @skipIfRocm
     @parametrize("tensor_idx", [0, 1, 2])
     def test_cudnn_varlen_unaligned_input_raises(self, device, tensor_idx):
         """Reject varlen inputs whose row strides are not 16-byte aligned.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194834
* #194818

This commit was authored with an AI assistant.

Causal varlen attention requires Q and K to share the same cumulative sequence-length tensor, but the cuDNN
path independently launched `diff` and ragged-offset multiplication kernels for Q and K. Reuse Q's derived
sequence lengths when the cumulative tensors have the same TensorImpl, and reuse its ragged offsets only when
the token strides also match. Equal-valued clones and storage-sharing views remain on the independent path;
`seqused_k` continues to override KV sequence lengths, and paged KV remains unchanged.

The cuDNN frontend receives the reused buffers as two distinct read-only input UIDs. A regression compares the
shared path directly against the independent cuDNN path for both matching and different aligned KV strides,
covering forward and backward. Additional stress testing covered FP16/BF16, d64/d128, causal/full attention,
equal clones, storage-sharing views, different Q/K distributions, and CUDA graph replay after mutating the
shared cumulative tensor. Compute Sanitizer memcheck reported no errors.

On one GB200 with BF16 causal varlen attention, H=16 and 16,384 packed tokens, this removes two launches from
both directions: cuDNN forward drops from 6 to 4 kernels and backward from 10 to 8. Representative medians:

| d128 workload | eager fwd | graph fwd | eager bwd | graph bwd |
| --- | ---: | ---: | ---: | ---: |
| uniform short, before | 354.2 us | 85.8 us | 560.7 us | 239.9 us |
| uniform short, after | 318.7 us | 82.9 us | 522.9 us | 236.0 us |
| multi-scale, before | 384.8 us | 197.0 us | 1120.2 us | 768.8 us |
| multi-scale, after | 348.7 us | 194.2 us | 1060.5 us | 763.6 us |

CUDA graph timings use Transformer Nuggets'
`benchmark_cuda_function_in_microseconds(..., USE_CUDA_GRAPHS=True)` with fixed pointers, 20 warmups, 100
replays, and five outer medians. The larger eager improvement comes from removing host-separated launches;
the graph improvement reflects the roughly 3-5 us of removed GPU work. TFLOP/s counts exact causal triangular
matmul work rather than PyTorch's registered full-matrix SDPA estimate. A matched three-call graph comparison
rotating 288 MiB (d64) or 576 MiB (d128) of Q/K/V against the 129 MiB L2 changed cuDNN forward throughput by
at most 0.64%, ruling out warm L2 residency as the explanation. Full results and scripts are in the
[benchmark gist](https://gist.github.com/drisspg/914f2970e21a7661e508184d9fa35426).

![CUDA graph varlen throughput](https://gist.githubusercontent.com/drisspg/914f2970e21a7661e508184d9fa35426/raw/42b9b61303c807a1e75a3cac100cff2330cccab3/varlen_distribution_cuda_graph_tflops.png)

The forward-only cache control below captures three calls in both arms, so graph-launch amortization is
identical. The rotating arm uses three independent Q/K/V sets totaling more than twice the device L2.

![Fixed versus rotating CUDA graph forward](https://gist.githubusercontent.com/drisspg/914f2970e21a7661e508184d9fa35426/raw/7a6d1a322e1dc8cb627175cc23818463b404aaa3/varlen_distribution_fixed_vs_rotating_forward.png)

```bash
gpu-run auto -- env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/pytest -q test/test_varlen_attention.py -n 8
lintrunner -a

gpu-run auto -- env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/python agent_space/varlen_cudnn_audit/round2/perf_cuda_graphs/stress_alias_reuse.py
gpu-run auto -- zsh -ic 'cd /home/drisspg/meta/pytorch && sanitize env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/python agent_space/varlen_cudnn_audit/round2/perf_cuda_graphs/sanitize_alias_reuse.py'
gpu-run auto -- env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/python agent_space/varlen_cudnn_audit/round2/perf_distributions_cuda_graph/benchmark.py
```

384 passed / 72 skipped / 8 xfailed; Compute Sanitizer memcheck reported zero errors.

cc @liangel-02 @howardzhang-cv