### PR TITLE
Drop the dead force_schema_registration flag from generate_code.py

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -363,7 +363,6 @@ add_custom_command(
     --tags-path "aten/src/ATen/native/tags.yaml"
     $<$<BOOL:${INTERN_DISABLE_AUTOGRAD}>:--disable-autograd>
     $<$<BOOL:${SELECTED_OP_LIST}>:--selected-op-list-path="${SELECTED_OP_LIST}">
-    --force_schema_registration
     --gen_lazy_ts_backend
     ${GEN_PER_OPERATOR_FLAG}
   DEPENDS

--- a/tools/setup_helpers/generate_code.py
+++ b/tools/setup_helpers/generate_code.py
@@ -27,7 +27,6 @@ def generate_code(
     install_dir: str | None = None,
     subset: str | None = None,
     disable_autograd: bool = False,
-    force_schema_registration: bool = False,
     operator_selector: Any = None,
 ) -> None:
     from tools.autograd.gen_annotated_fn_args import gen_annotated
@@ -168,13 +167,6 @@ def main() -> None:
         help="Path to the model YAML file that contains the list of operators to include for custom build.",
     )
     parser.add_argument(
-        "--force-schema-registration",
-        "--force_schema_registration",
-        action="store_true",
-        help="force it to generate schema-only registrations for ops that are not"
-        "listed on --selected-op-list",
-    )
-    parser.add_argument(
         "--gen-lazy-ts-backend",
         "--gen_lazy_ts_backend",
         action="store_true",
@@ -201,7 +193,6 @@ def main() -> None:
         options.install_dir,
         options.subset,
         options.disable_autograd,
-        options.force_schema_registration,
         # options.selected_op_list
         operator_selector=operator_selector,
     )


### PR DESCRIPTION
## Summary
- `generate_code()` in `tools/setup_helpers/generate_code.py` has accepted a `force_schema_registration` parameter but never used it in its body since #49251 (2021) deleted the `gen_unboxing_wrappers()` call that was its only consumer here.
- `caffe2/CMakeLists.txt` has been passing `--force_schema_registration` to this script ever since with no effect.
- `torchgen/gen.py` has its own separate, still-functional `force_schema_registration` (used by Buck's internal build via `torchgen:gen`) and is untouched by this PR.

## Test plan
- [ ] `python -m tools.setup_helpers.generate_code --help` still runs and no longer lists `--force-schema-registration`/`--force_schema_registration`
- [ ] `.ci/pytorch/codegen-test.sh` (or the equivalent CMake codegen step) still completes successfully without the flag

This PR description was drafted with an AI assistant (Claude Code); I've reviewed the change.