### PR TITLE
Drop the gcc 4.8 era addition of gcc and gcc_s to the link line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1212,15 +1212,6 @@ endif()
 # ---[ Allowlist file if allowlist is specified
 include(cmake/Allowlist.cmake)
 
-# ---[ Set link flag, handle additional deps for gcc 4.8 and above
-if(CMAKE_COMPILER_IS_GNUCXX AND NOT ANDROID)
-  message(
-    STATUS
-      "GCC ${CMAKE_CXX_COMPILER_VERSION}: Adding gcc and gcc_s libs to link line"
-  )
-  list(APPEND Caffe2_DEPENDENCY_LIBS gcc_s gcc)
-endif()
-
 # ---[ Build flags Re-include to override append_cxx_flag_if_supported from
 # third_party/FBGEMM
 include(cmake/public/utils.cmake)


### PR DESCRIPTION
## Summary
- `Caffe2_DEPENDENCY_LIBS` has appended `gcc_s gcc` since 2016 as a gcc 4.8 workaround. CMakeLists.txt now requires gcc >= 11.3, and `g++ -shared` already adds `-lgcc_s` (not `-lgcc`) by default via `-shared-libgcc`.
- The entries were inert, not harmful: ordered `gcc_s gcc`, so the shared archive resolved first and no static `libgcc.a` member was ever pulled in.

## Test plan
```
g++ -### -shared empty.cpp        # driver already adds -lgcc_s, not -lgcc
readelf -d build/lib/libtorch_cpu.so | grep NEEDED
```

This PR description was drafted with an AI assistant (Claude Code); I've reviewed the change.