### PR TITLE
Don't mutate the caller's annotation dict in mark_stream

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -499,6 +499,34 @@ class TestMarkKernels(TestCase):
 
         self.assertAnnotations({"name": "aux_branch", "stream": expected_stream_id})
 
+    def test_mark_stream_does_not_mutate_caller_annotation(self):
+        """The stream id goes onto a copy. The annotation is stored by reference, so
+        writing it through would leak back to the caller and, for a dict reused across
+        lanes, retag the regions already recorded with it to the last lane."""
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+        capture_stream = torch.cuda.Stream()
+        lane_a = torch.cuda.Stream()
+        lane_b = torch.cuda.Stream()
+        id_a, id_b = _get_stream_id(lane_a), _get_stream_id(lane_b)
+        shared = {"name": "comm"}
+
+        capture_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.graph(graph, stream=capture_stream, enable_annotations=True):
+            for lane in (lane_a, lane_b):
+                lane_ready = capture_stream.record_event()
+                lane_done = torch.cuda.Event()
+                with mark_stream(lane, shared):
+                    lane.wait_event(lane_ready)
+                    _ = x * 2
+                    lane.record_event(lane_done)
+                capture_stream.wait_event(lane_done)
+
+        self.assertNotIn("stream", shared)
+        self.assertAnnotations(
+            {"name": "comm", "stream": id_a}, {"name": "comm", "stream": id_b}
+        )
+
     def _exec_graph_id(self, graph):
         from cuda.bindings import runtime as cuda_runtime
 

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -1075,7 +1075,11 @@ def mark_stream(stream: torch.cuda.Stream, annotation: str | dict[str, Any]):
         if isinstance(annotation, str):
             annotation = {"name": annotation}
         if isinstance(annotation, dict):
-            annotation["stream"] = _get_stream_id(stream)
+            # Copy rather than write through: the annotation is stored by reference, so an
+            # in-place "stream" would leak back to the caller and, when one dict is reused
+            # across mark_stream calls (a comms wrapper marking a lane per process group),
+            # retag every region already recorded with it to the last lane written.
+            annotation = {**annotation, "stream": _get_stream_id(stream)}
         with mark_kernels(annotation):
             with torch.cuda.stream(stream):
                 yield


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #194848
* #194847
* __->__ #194846

Human note:

`mark_stream` modified annotation in-place, if multiple mark_streams were handed the same annotation dict
only the last modification survived, that's a bug 

Claude:
mark_stream wrote the resolved stream id into the annotation dict it was
handed. The annotation is then stored by reference in the kernel annotation
registry, so the write had two effects the caller never asked for: the dict
gained a "stream" key that outlived the call, and a dict reused across several
mark_stream calls (a comms wrapper marking one lane per process group is the
motivating case) ended up shared by every region recorded with it, so the
last lane written overwrote all the earlier ones and every marked region
rendered on a single lane.

Build the tagged annotation as a copy instead, which is what the string input
path already effectively did.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda_graph_utils.py -k mark_stream
```

The new test marks two lanes with one shared dict; it fails on the parent
commit (the caller's dict gains "stream", and both regions resolve to the
second lane) and passes here.

Authored with assistance from Claude Code.