### PR TITLE
Store one merged annotation per CUDA graph node

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -1210,7 +1210,7 @@ class TestMarkKernels(TestCase):
         y.backward()
         torch.cuda.synchronize()
         resolve_pending_annotations()
-        self.assertEqual(get_kernel_annotations(), before)
+        self.assertEqual(dict(get_kernel_annotations()), before)
 
     def test_eager_forward_backward_noop(self):
         x = torch.randn(8, device="cuda", requires_grad=True)
@@ -1703,25 +1703,58 @@ class TestRemoveKernelAnnotations(TestCase):
 
         exec_a, exec_b = 1, 2
         ga.clear_kernel_annotations()
-        ann = ga.get_kernel_annotations()
-        ann[self._tools_id(exec_a, 10)] = ["a"]
-        ann[self._tools_id(exec_b, 10)] = ["b"]
+        ga.record_node_annotation(self._tools_id(exec_a, 10), {"name": "a"})
+        ga.record_node_annotation(self._tools_id(exec_b, 10), {"name": "b"})
 
         ga.remove_kernel_annotations([exec_a])
 
         self.assertEqual(
-            ga.get_kernel_annotations(), {self._tools_id(exec_b, 10): ["b"]}
+            dict(ga.get_kernel_annotations()),
+            {self._tools_id(exec_b, 10): [{"name": "b"}]},
         )
 
     def test_missing_and_empty_ids_are_noops(self):
         import torch.cuda._graph_annotations as ga
 
         ga.clear_kernel_annotations()
-        ann = ga.get_kernel_annotations()
-        ann[self._tools_id(2, 10)] = ["b"]
+        ga.record_node_annotation(self._tools_id(2, 10), {"name": "b"})
         ga.remove_kernel_annotations([])  # empty: no-op
         ga.remove_kernel_annotations([99])  # unknown exec id: no-op
-        self.assertEqual(ga.get_kernel_annotations(), {self._tools_id(2, 10): ["b"]})
+        self.assertEqual(
+            dict(ga.get_kernel_annotations()), {self._tools_id(2, 10): [{"name": "b"}]}
+        )
+
+
+# Pure registry logic, no CUDA needed: the store keeps one merged annotation per node,
+# which the public mapping wraps in a one-element list.
+class TestAnnotationStore(TestCase):
+    def tearDown(self):
+        import torch.cuda._graph_annotations as ga
+
+        ga.clear_kernel_annotations()
+        super().tearDown()
+
+    def test_writes_to_one_node_merge_first_wins(self):
+        import torch.cuda._graph_annotations as ga
+
+        ga.clear_kernel_annotations()
+        # Scopes reach a node innermost first, so the first write keeps the shared keys.
+        ga.record_node_annotation(7, {"name": "inner", "only_inner": 1})
+        ga.record_node_annotation(7, {"name": "outer", "only_outer": 2})
+        merged = {"name": "inner", "only_inner": 1, "only_outer": 2}
+        self.assertEqual(ga.annotation_for(7), merged)
+        self.assertEqual(dict(ga.get_kernel_annotations()), {7: [merged]})
+
+    def test_view_is_live_and_read_only(self):
+        import torch.cuda._graph_annotations as ga
+
+        ga.clear_kernel_annotations()
+        view = ga.get_kernel_annotations()
+        self.assertEqual(len(view), 0)
+        ga.record_node_annotation(7, {"name": "a"})
+        self.assertEqual(dict(view), {7: [{"name": "a"}]})
+        with self.assertRaises(TypeError):
+            view[7] = [{"name": "b"}]  # type: ignore[index]
 
 
 # Pure trace-JSON logic, no CUDA needed. Pins the canonical annotation key

--- a/torch/cuda/_annotate_cuda_graph_trace.py
+++ b/torch/cuda/_annotate_cuda_graph_trace.py
@@ -122,9 +122,11 @@ def annotate_trace(
 ) -> int:
     """Add annotation fields to kernel events matching the annotations dict.
 
-    Each annotation entry is a list (from nested ``mark_kernels`` scopes).
-    Fields from all annotations are merged into the event args; if multiple
-    annotations define the same key, later entries in the list win.
+    Each annotation entry is a one-element list holding the node's merged
+    annotation dict (older pickles hold several entries, from nested
+    ``mark_kernels`` scopes, and a bare dict is accepted as well). Fields from
+    all annotations are merged into the event args; if multiple annotations
+    define the same key, later entries in the list win.
 
     For graphed events (graph_node_id != 0), reassigns ``tid`` and
     ``args["stream"]`` to the stream recorded in annotations, or to
@@ -154,7 +156,10 @@ def annotate_trace(
             continue
         stream_id = None
         if graph_node_id in annotations:
-            for ann in annotations[graph_node_id]:
+            entry = annotations[graph_node_id]
+            # The registry hands out one-element lists; a bare dict is accepted too so a
+            # pickle of the raw store reads back.
+            for ann in entry if isinstance(entry, list) else [entry]:
                 if isinstance(ann, dict):
                     for key, value in ann.items():
                         # Legacy pickles wrapped bare strings as {"str": ...};

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -46,14 +46,14 @@ from __future__ import annotations
 import importlib.metadata
 import threading
 import warnings
-from collections import defaultdict
+from collections.abc import Mapping
 from contextlib import contextmanager
 from logging import getLogger
 from typing import Any, NamedTuple, TYPE_CHECKING, TypeAlias
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Iterable, Iterator
 
 import torch
 from torch.cuda._utils import (
@@ -159,7 +159,7 @@ def record_node_annotation(tools_id: int, annotation: dict[str, Any]) -> None:
     The CUPTI backend's entry point into the same store the edge walk fills, so both
     backends are remapped to exec-graph ids by ``remap_to_exec_graph`` identically. Not a
     public API."""
-    _kernel_annotations[tools_id].append(annotation)
+    _merge_annotation(tools_id, annotation)
 
 
 def _graph_id(graph: Any) -> int:
@@ -360,8 +360,36 @@ def _collect_descendants(
     return descendants
 
 
-# toolsId -> list of annotation objects.
-_kernel_annotations: defaultdict[int, list[Any]] = defaultdict(list)
+# toolsId -> the node's merged annotation. Exactly one dict per node: every writer goes
+# through _merge_annotation, and a node is only written more than once when scopes overlap
+# on it, which is precisely what the merge resolves.
+_kernel_annotations: dict[int, dict[str, Any]] = {}
+
+
+def _merge_annotation(tools_id: int, annotation: Any) -> None:
+    """Merge one scope's annotation into a node's entry; the first write wins per key.
+
+    First-wins is what makes nested scopes resolve inner-first: scopes are recorded in
+    completion order, so the innermost scope containing a node reaches it first and keeps
+    the keys it shares with its enclosing scopes, while their extra keys still come
+    through. Non-dict annotations are normalized to ``{"name": ...}``; ``mark_kernels``
+    already does that for strings, but the store is written by other callers too.
+    """
+    incoming = annotation if isinstance(annotation, dict) else {"name": annotation}
+    entry = _kernel_annotations.get(tools_id)
+    if entry is None:
+        _kernel_annotations[tools_id] = dict(incoming)
+        return
+    for key, value in incoming.items():
+        entry.setdefault(key, value)
+
+
+def annotation_for(tools_id: int) -> dict[str, Any] | None:
+    """The merged annotation recorded for one graph node, or ``None``. The in-process
+    accessor behind the profiler's graph annotation resolver, handing out the stored dict
+    rather than the list-wrapped public view. Not a public API."""
+    return _kernel_annotations.get(tools_id)
+
 
 # Node types we annotate (kernels, memcpys, memsets, batch mem ops, event
 # record/wait nodes, and host nodes), as driver node-type enums. Event and host
@@ -852,24 +880,11 @@ def resolve_pending_annotations() -> None:
         return
 
     try:
-        per_tools_id: defaultdict[int, list[Any]] = defaultdict(list)
+        # _pending_scopes is in scope-completion order (innermost first) and
+        # _merge_annotation is first-wins, so this applies the documented precedence.
         for annotation, tools_ids in _pending_scopes:
             for tools_id in tools_ids:
-                per_tools_id[tools_id].append(annotation)
-
-        for tools_id, ann_list in per_tools_id.items():
-            if len(ann_list) == 1:
-                _kernel_annotations[tools_id].append(ann_list[0])
-                continue
-
-            merged: dict[str, Any] = {}
-            for annotation in ann_list:
-                if isinstance(annotation, dict):
-                    for key, value in annotation.items():
-                        merged.setdefault(key, value)
-                else:
-                    merged.setdefault("name", annotation)
-            _kernel_annotations[tools_id].append(merged)
+                _merge_annotation(tools_id, annotation)
     except Exception:
         logger.exception("resolve_pending_annotations failed")
     finally:
@@ -924,29 +939,27 @@ def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
 
 
 def _rekey_annotations(
-    annotations: dict[int, list[Any]],
+    annotations: dict[int, dict[str, Any]],
     capture_graph_id: int,
     exec_graph_id: int,
-) -> dict[int, list[Any]]:
+) -> dict[int, dict[str, Any]]:
     """Rekey one graph's annotations from its capture id to its exec id.
 
     A toolsId packs the graph id in the upper 32 bits and the node id in the
     lower 32. Only entries whose upper bits match ``capture_graph_id`` are
     rewritten to ``exec_graph_id``; entries from other graphs (already remapped
-    to their own exec ids, or pending their own remap) are kept as-is. When two
-    capture-side ids collide on the same rekeyed id their lists are merged.
+    to their own exec ids, or pending their own remap) are kept as-is. The
+    rewritten keys cannot collide with anything: they share their upper bits and
+    differ in node id, and the driver mints graph and exec ids from one counter
+    that it does not reuse, so no other entry is keyed on a freshly minted exec id.
     """
-    remapped: dict[int, list[Any]] = {}
-    for tools_id, ann_list in annotations.items():
+    remapped: dict[int, dict[str, Any]] = {}
+    for tools_id, annotation in annotations.items():
         if tools_id >> 32 != capture_graph_id:
-            remapped[tools_id] = ann_list
+            remapped[tools_id] = annotation
             continue
         node_id = tools_id & 0xFFFFFFFF
-        new_tools_id = (exec_graph_id << 32) | node_id
-        if new_tools_id in remapped:
-            remapped[new_tools_id].extend(ann_list)
-        else:
-            remapped[new_tools_id] = list(ann_list)
+        remapped[(exec_graph_id << 32) | node_id] = annotation
     return remapped
 
 
@@ -960,22 +973,49 @@ def resolve_and_remap(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     remap_to_exec_graph(torch_cuda_graph)
 
 
+class _AnnotationsView(Mapping[int, "list[Any]"]):
+    """Read-only view of the annotation store, presenting each node's annotation as a
+    one-element list.
+
+    The store holds exactly one merged dict per node, but the public mapping has always
+    had list values -- and pickles of it are read back by
+    ``torch.cuda._annotate_cuda_graph_trace`` -- so the shape is kept. Wrapping on read
+    rather than storing lists is what makes "at most one annotation per node" explicit.
+    """
+
+    def __getitem__(self, tools_id: int) -> list[Any]:
+        return [_kernel_annotations[tools_id]]
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(_kernel_annotations)
+
+    def __len__(self) -> int:
+        return len(_kernel_annotations)
+
+    def __repr__(self) -> str:
+        return repr(dict(self))
+
+
+_annotations_view = _AnnotationsView()
+
+
 def get_kernel_annotations() -> Mapping[int, list[Any]]:
     r"""get_kernel_annotations() -> Mapping[int, list]
 
     Return the live registry of recorded kernel annotations.
 
     Keys are opaque integers matching the ``graph node id`` field that
-    CUPTI-based profilers attach to kernel events; values are the lists of
-    annotation dicts recorded for that node. The registry accumulates
-    across captures and is global to the process.
+    CUPTI-based profilers attach to kernel events; values are one-element
+    lists holding the annotation dict recorded for that node -- annotations
+    from overlapping scopes are merged into that single dict. The registry
+    accumulates across captures and is global to the process.
 
     The returned mapping is a **live view**: it is updated in place when a
     graph is instantiated (annotation keys are rekeyed to the executable
     graph's ids), so a reference obtained early stays current. Keys are
     valid for joining against a profiler trace once the corresponding
-    graphs have been instantiated. Treat the mapping as read-only; snapshot
-    it with ``dict(...)`` if isolation is needed.
+    graphs have been instantiated. The mapping is read-only; snapshot it
+    with ``dict(...)`` if isolation is needed.
 
     .. warning::
         This API is in prototype and may change in future releases.
@@ -987,7 +1027,7 @@ def get_kernel_annotations() -> Mapping[int, list[Any]]:
         >>> with open("annotations.pkl", "wb") as f:
         ...     pickle.dump(dict(annotations), f)
     """
-    return _kernel_annotations
+    return _annotations_view
 
 
 def clear_kernel_annotations() -> None:

--- a/torch/profiler/_cupti/observers/base.py
+++ b/torch/profiler/_cupti/observers/base.py
@@ -53,17 +53,17 @@ GraphDependencyResolver = Callable[[int], "list[int] | None"]
 
 
 def default_graph_annotation_resolver(graph_node_id: int) -> Any | None:
-    """Default resolver: map a CUDA-graph node id to its registered annotation, or None when
-    it has none."""
+    """Default resolver: map a CUDA-graph node id to its registered annotation dict, or None
+    when it has none. Reads the registry's in-process accessor rather than the list-wrapped
+    public view, so the exporters spread the annotation's fields instead of re-serializing a
+    list."""
     if graph_node_id == 0:
         return None
     try:
-        from torch.cuda._graph_annotations import get_kernel_annotations
-
-        annotations = get_kernel_annotations()
+        from torch.cuda._graph_annotations import annotation_for
     except Exception:
         return None
-    return annotations.get(graph_node_id)
+    return annotation_for(graph_node_id)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #194848
* __->__ #194847
* #194846

Human note:

_kernel_annotations type is now `map(int, list(Any))`, this masks that the list at most contains a single dict. 
Make the dict correct - for each node there's a single dict of annotations. 

The kernel annotation registry mapped a node's toolsId to a list of annotations,
but nothing ever put a second entry in that list on a reachable path. Both
writers already merge before they write: the CUPTI backend merges nested scopes
at scope entry and records one dict per node, and the edge-walk backend merges a
resolve batch's overlapping scopes and appends the single result. The remaining
paths that could append twice cannot happen -- the rekey collision branch needed
a graph and an exec id to be equal, and the driver mints both from one counter it
does not reuse (measured: graph/exec ids 1,2 / 4,5 / 7,8 ... across create and
destroy). So consumers carried list-merging code for a case the producer never
produced, and disagreed on precedence while doing it: the resolver merged
first-wins, the offline trace annotator later-wins.

Make the store dict[toolsId, annotation] with a single merge helper both writers
share (first write wins per key, which is the existing inner-scope-wins rule --
scopes are recorded innermost first). resolve_pending_annotations collapses to a
loop over pending scopes, and the rekey no longer needs its collision branch.

get_kernel_annotations() keeps its list-valued shape via a read-only Mapping view
that wraps each entry on read, since pickles of it are consumed by
_annotate_cuda_graph_trace and it is documented as a live view. Wrapping at the
boundary rather than storing lists is what makes "at most one annotation per
node" explicit. In-process consumers read the dict directly through the new
annotation_for(), so the profiler exporters spread its fields instead of
re-serializing a list into an opaque "annotation" string; the node timer's bucket
keys go from "[{'name': 'x'}]" to "{'name': 'x'}" for the same reason.

Review the store and merge helper first, then the resolve/rekey simplifications
that follow from it, then the view and the two consumers.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda_graph_utils.py
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/profiler/test_cupti_monitor.py
```

test_cuda_graph_utils passes (115 tests), including the new TestAnnotationStore
covering the merge rule and the view's liveness/read-only-ness. test_cupti_monitor
has one pre-existing failure (CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED in
full-suite runs); it fails identically on the parent commit and passes when run
alone.

Authored with assistance from Claude Code.