### PR TITLE
Annotate backward kernels under the CUPTI annotation backend

### DIFF
--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -2049,6 +2049,44 @@ class TestCuptiAnnotationBackend(TestCase):
         self.assertEqual(node_ids["cupti"], node_ids["edge_walk"])
         self.assertEqual(len(node_ids["cupti"]), 4)
 
+    def test_backward_parity_with_edge_walk(self):
+        # Backward kernels are attributed by the hooks a scope installs on the autograd
+        # nodes its forward creates, which are backend-independent: both backends must
+        # produce the same annotations, including for a backward running inside a different
+        # scope, whose lexical annotation the forward region outranks.
+        def warm(x):
+            s = torch.cuda.Stream()
+            s.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(s):
+                for _ in range(3):
+                    torch.autograd.grad((x * 2).sin().sum(), x)
+            torch.cuda.current_stream().wait_stream(s)
+
+        def run(backend):
+            clear_kernel_annotations()
+            x = torch.randn(64, 64, device="cuda", requires_grad=True)
+            warm(x)
+            g = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(
+                g, enable_annotations=True, annotation_config={"backend": backend}
+            ):
+                with mark_kernels("fwd"):
+                    y = (x * 2).sin()
+                with mark_kernels({"name": "bwd_region", "lane": 1}):
+                    torch.autograd.grad(y.sum(), x)
+            return {
+                tools_id & 0xFFFFFFFF: entries
+                for tools_id, entries in self._annotations().items()
+            }
+
+        cupti = run("cupti")
+        self.assertEqual(cupti, run("edge_walk"))
+        # The forward scope owns its backward kernels even though another scope is open
+        # around the backward call; that scope's other keys still merge in.
+        self.assertIn(
+            [{"name": "fwd", "lane": 1, "autograd_phase": "backward"}], cupti.values()
+        )
+
     def test_scope_entered_before_stream_joins_capture(self):
         # The edge walk snapshots the CURRENT stream's capture state on scope entry, so a
         # scope entered while that stream is not yet capturing records nothing at all --

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -620,7 +620,7 @@ class _BracketState(threading.local):
     """
 
     def __init__(self) -> None:
-        # Entries are (scope, prev_region, merged_region) or _SKIPPED.
+        # Entries are (scope, prev_region, tagged_region, published) or _SKIPPED.
         self.stack: list[Any] = []
 
 
@@ -664,11 +664,13 @@ def _attach_backward_hooks(node: Any, frozen: dict[str, Any], generation: int) -
     ``frozen`` is the region that was current when the node was created:
     the annotations of every scope then open, already collapsed inner-wins.
     The pair brackets the node's execution the same way ``mark_kernels``
-    brackets forward work: snapshot the capture frontier before, collect
-    the new nodes after. It runs on the autograd engine thread executing
-    the node, which during a whole-graph capture participates in the
-    capture; when backward runs outside a capture the prehook sees no
-    active capture and the pair is a no-op.
+    brackets forward work, and splits on the backend the same way: under the
+    edge walk it snapshots the capture frontier before and collects the new
+    nodes after, under CUPTI it publishes itself as the ambient annotation
+    for the nodes created while it runs. It runs on the autograd engine
+    thread executing the node, which during a whole-graph capture
+    participates in the capture; when backward runs outside a capture the
+    prehook sees no active capture and the pair is a no-op.
 
     Executing the node is semantically re-entering its frozen region, so
     the prehook merges ``frozen`` over the live region (a ``mark_kernels``
@@ -704,10 +706,22 @@ def _attach_backward_hooks(node: Any, frozen: dict[str, Any], generation: int) -
         # captured: kernels of nodes created here may be captured by a
         # later (e.g. second-order) annotated capture.
         merged = {**(_current_region() or {}), **frozen}
+        tagged = {**merged, "autograd_phase": "backward"}
         prev = _enter_region(merged)
         torch._C._autograd._push_node_creation_hook(creation_hook)
-        scope = _begin_kernel_scope() if _annotations_enabled else None
-        state.stack.append((scope, prev, merged))
+        # Under CUPTI the nodes this backward creates are attributed as they are created,
+        # so the bracket publishes itself instead of walking edges -- and it has to, since
+        # what CUPTI would otherwise record is the scope lexically open around the
+        # ``backward()`` call, which this outranks. A backward that throws leaks its push
+        # (there is no finally to pop from), but only until the capture ends, and a capture
+        # whose backward threw is aborted anyway.
+        published = _annotations_enabled and _annotation_backend == "cupti"
+        if published:
+            _active_scopes.append(tagged)
+        scope = (
+            _begin_kernel_scope() if _annotations_enabled and not published else None
+        )
+        state.stack.append((scope, prev, tagged, published))
 
     def posthook(_grad_inputs: Any, _grad_outputs: Any) -> None:
         if not state.stack:
@@ -715,18 +729,46 @@ def _attach_backward_hooks(node: Any, frozen: dict[str, Any], generation: int) -
         entry = state.stack.pop()
         if entry is _SKIPPED:
             return
-        scope, prev, merged = entry
+        scope, prev, tagged, published = entry
+        if published:
+            _active_scopes.pop()
         torch._C._autograd._pop_node_creation_hook()
         _exit_region(prev)
         if scope is None:
             return
         tools_ids = _end_kernel_scope(scope)
         if tools_ids:
-            tagged = {**merged, "autograd_phase": "backward"}
             _pending_scopes.append((tagged, tools_ids))
 
     node.register_prehook(prehook)
     node.register_hook(posthook)
+
+
+@contextmanager  # type: ignore[arg-type]
+def _annotation_region(annotation: dict[str, Any], backward: bool):
+    """Publish ``annotation`` as the current region for the body, hooking the autograd
+    nodes created in it when ``backward``.
+
+    Backend-independent, and shared by both of ``mark_kernels``' paths: whichever way the
+    scope's own nodes are discovered, a node's backward is bracketed by the hooks installed
+    here. The region is entered even when ``backward`` is False, since it must reflect the
+    full dynamic scope for nodes hooked by a nested ``backward=True`` scope (or by an
+    executing hooked node) to freeze this annotation too.
+    """
+    generation = _annotation_generation
+
+    def creation_hook(node: Any) -> None:
+        _freeze_region_hook(node, generation)
+
+    prev = _enter_region({**(_current_region() or {}), **annotation})
+    try:
+        if backward:
+            with torch.autograd.graph.node_creation_hook(creation_hook):
+                yield
+        else:
+            yield
+    finally:
+        _exit_region(prev)
 
 
 @contextmanager  # type: ignore[arg-type]
@@ -823,7 +865,8 @@ def mark_kernels(annotation: str | dict[str, Any], *, backward: bool = True):
             {**_active_scopes[-1], **annotation} if _active_scopes else annotation
         )
         try:
-            yield
+            with _annotation_region(annotation, backward):
+                yield
         finally:
             _active_scopes.pop()
         return
@@ -851,23 +894,8 @@ def mark_kernels(annotation: str | dict[str, Any], *, backward: bool = True):
         yield
         return
 
-    generation = _annotation_generation
-
-    def creation_hook(node: Any) -> None:
-        _freeze_region_hook(node, generation)
-
-    # Enter the region even when backward=False: the region must reflect the
-    # full dynamic scope so that nodes hooked by a nested backward=True scope
-    # (or by an executing hooked node) freeze this annotation too.
-    prev = _enter_region({**(_current_region() or {}), **annotation})
-    try:
-        if backward:
-            with torch.autograd.graph.node_creation_hook(creation_hook):
-                yield
-        else:
-            yield
-    finally:
-        _exit_region(prev)
+    with _annotation_region(annotation, backward):
+        yield
 
     tools_ids = _end_kernel_scope(scope)
     if tools_ids:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #194848
* #194847
* #194846

Human note:

backward annotation projection and cupti backend for getting annotations were merged approximately simultaneously, 
and cupti backend didn't correctly handle backward annotations - all the backward node stayed empty with cupti backend. 

Claude:
mark_kernels' CUPTI path returned as soon as it had pushed its annotation onto
the ambient scope stack, before the code that enters the annotation region and
installs the autograd node-creation hook. So with annotation_config={"backend":
"cupti"} the documented backward=True behaviour silently did nothing: no autograd
node created in a scope was ever bracketed, and backward kernels were attributed
only to whatever scope happened to be lexically open around the backward() call,
or to nothing at all.

The region and creation hook are backend-independent, so they move into a shared
_annotation_region context manager that both paths enter. The bracket the hook
installs then splits on the backend the same way mark_kernels does: under the
edge walk it snapshots the capture frontier and collects new nodes on the way
out, under CUPTI it publishes its (already merged) region on _active_scopes so
the nodes created while it runs are attributed as CUPTI reports them. Publishing
is also what gets the precedence right -- the forward region has to outrank the
scope lexically open around the backward call, which is what CUPTI would
otherwise record for those nodes.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda_graph_utils.py
```

116 tests pass. The new test_backward_parity_with_edge_walk captures a forward
scope plus a backward running inside a second scope and asserts both backends
produce identical annotations; on the parent commit the CUPTI run has no
autograd_phase entries at all.

Authored with assistance from Claude Code.