### PR TITLE
Add PrivateUse1 storage sharing for device IPC

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -513,6 +513,7 @@
 # /test/test_content_store.py
 # /test/test_dataloader.py
 # /test/test_datapipe.py
+# /test/test_device_ipc.py
 # /test/test_decomp.py
 # /test/test_determination.py
 # /test/test_dispatch.py

--- a/aten/src/ATen/test/CMakeLists.txt
+++ b/aten/src/ATen/test/CMakeLists.txt
@@ -37,6 +37,7 @@ list(APPEND ATen_CPU_TEST_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/scalar_tensor_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/scalar_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/StorageUtils_test.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/storage_impl_privateuse1_ipc_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/stride_properties_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/test_parallel.cpp

--- a/aten/src/ATen/test/storage_impl_privateuse1_ipc_test.cpp
+++ b/aten/src/ATen/test/storage_impl_privateuse1_ipc_test.cpp
@@ -1,0 +1,36 @@
+#include <gtest/gtest.h>
+
+#include <c10/core/StorageImpl.h>
+
+namespace {
+
+c10::intrusive_ptr<c10::StorageImpl> make_privateuse1_storage() {
+  return c10::make_intrusive<c10::StorageImpl>(
+      c10::StorageImpl::use_byte_size_t(),
+      0,
+      c10::DataPtr(nullptr, c10::Device(c10::DeviceType::PrivateUse1, 0)),
+      nullptr,
+      false);
+}
+
+} // namespace
+
+TEST(StorageImplReceivedViaIpc, ReceivedViaIpcDefaultFalse) {
+  auto storage = make_privateuse1_storage();
+  EXPECT_FALSE(storage->received_via_ipc());
+}
+
+TEST(StorageImplReceivedViaIpc, SetAndGetReceivedViaIpc) {
+  auto storage = make_privateuse1_storage();
+  storage->set_received_via_ipc(true);
+  EXPECT_TRUE(storage->received_via_ipc());
+  storage->set_received_via_ipc(false);
+  EXPECT_FALSE(storage->received_via_ipc());
+}
+
+TEST(StorageImplReceivedViaIpc, ReceivedViaIpcDoesNotAffectReceivedCuda) {
+  auto storage = make_privateuse1_storage();
+  storage->set_received_via_ipc(true);
+  ASSERT_TRUE(storage->received_via_ipc());
+  EXPECT_FALSE(storage->received_cuda());
+}

--- a/c10/core/StorageImpl.h
+++ b/c10/core/StorageImpl.h
@@ -67,6 +67,7 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
         size_bytes_is_heap_allocated_(size_bytes_.is_heap_allocated()),
         resizable_(resizable),
         received_cuda_(false),
+        received_via_ipc_(false),
         allocator_(allocator) {
     if (resizable) {
       TORCH_INTERNAL_ASSERT(
@@ -289,6 +290,14 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
     return received_cuda_;
   }
 
+  void set_received_via_ipc(bool received_via_ipc) {
+    received_via_ipc_ = received_via_ipc;
+  }
+
+  bool received_via_ipc() {
+    return received_via_ipc_;
+  }
+
   impl::PyObjectSlot* pyobj_slot() {
     return &pyobj_slot_;
   }
@@ -395,6 +404,9 @@ struct C10_API StorageImpl : public c10::intrusive_ptr_target {
   // Identifies that Storage was received from another process and doesn't have
   // local to process cuda memory allocation
   bool received_cuda_;
+  // Identifies that Storage was received via PrivateUse1 IPC; re-sharing is
+  // not supported without an explicit clone.
+  bool received_via_ipc_;
   // All special checks in data/data_ptr calls are guarded behind this single
   // boolean. This is for performance: .data/.data_ptr calls are commonly in the
   // hot-path.

--- a/test/test_device_ipc.py
+++ b/test/test_device_ipc.py
@@ -1,0 +1,85 @@
+# Owner(s): ["module: tests"]
+
+"""Unit tests for RFC #192099 device IPC additions.
+
+Covers:
+  - torch._C._acc._is_privateuse1_ipc_supported()
+  - New torch.UntypedStorage methods: _share_device_, _new_shared_device,
+    _release_ipc_counter_device
+  - Error paths that fire before any device-specific code
+"""
+
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
+
+
+TEST_PRIVATEUSE1_IPC = hasattr(torch.UntypedStorage, "_share_device_") and hasattr(
+    torch._C._acc, "_is_privateuse1_ipc_supported"
+)
+
+
+@unittest.skipIf(not TEST_PRIVATEUSE1_IPC, "PrivateUse1 IPC build not available")
+class TestIsPrivateUse1IpcSupported(TestCase):
+    """Tests for torch._C._acc._is_privateuse1_ipc_supported()."""
+
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_returns_false_no_hooks(self):
+        # assertIs checks both value (False) and type (bool), not just truthiness.
+        # 0 would pass assertFalse but fail here.
+        self.assertIs(torch._C._acc._is_privateuse1_ipc_supported(), False)
+
+
+@unittest.skipIf(not TEST_PRIVATEUSE1_IPC, "PrivateUse1 IPC build not available")
+class TestStorageSharingMethods(TestCase):
+    """Tests that the new sharing methods are registered on torch.UntypedStorage."""
+
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_share_device_method_exists(self):
+        self.assertTrue(hasattr(torch.UntypedStorage, "_share_device_"))
+
+    def test_new_shared_device_method_exists(self):
+        self.assertTrue(hasattr(torch.UntypedStorage, "_new_shared_device"))
+
+    def test_release_ipc_counter_device_method_exists(self):
+        self.assertTrue(hasattr(torch.UntypedStorage, "_release_ipc_counter_device"))
+
+
+@unittest.skipIf(not TEST_PRIVATEUSE1_IPC, "PrivateUse1 IPC build not available")
+class TestDeviceIPCErrors(TestCase):
+    """Tests error and safety behavior of the three new IPC methods."""
+
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_share_device_no_hooks_raises(self):
+        storage = torch.UntypedStorage(16)
+        with self.assertRaisesRegex(
+            RuntimeError, "PrivateUse1 hooks are not registered"
+        ):
+            storage._share_device_()
+
+    def test_new_shared_device_no_hooks_raises(self):
+        with self.assertRaisesRegex(
+            RuntimeError, "PrivateUse1 hooks are not registered"
+        ):
+            torch.UntypedStorage._new_shared_device(
+                0, b"handle", 16, 0, b"ref", 0, b"", False
+            )
+
+    def test_release_ipc_counter_device_nonexistent_handle(self):
+        # Best-effort: missing shm file is silently ignored so B's process
+        # continues even if A exited before B called this.
+        torch.UntypedStorage._release_ipc_counter_device(
+            b"nonexistent_shm_handle_xyz", 0
+        )
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/csrc/StorageSharing.cpp
+++ b/torch/csrc/StorageSharing.cpp
@@ -4,10 +4,12 @@
 #endif
 #include <structmember.h>
 
+#include <ATen/detail/PrivateUse1HooksInterface.h>
 #include <c10/core/CPUAllocator.h>
 #include <libshm.h>
 #include <torch/csrc/CudaIPCTypes.h>
 #include <torch/csrc/Device.h>
+#include <torch/csrc/DeviceIPCTypes.h>
 #include <torch/csrc/DynamicTypes.h>
 #include <torch/csrc/THP.h>
 #include <torch/csrc/autograd/utils/wrap_outputs.h>
@@ -393,6 +395,7 @@ static PyObject* THPStorage_releaseIPCCounter(
         sizeof(int64_t) * torch::CUDA_IPC_REF_COUNTER_FILE_SIZE,
         nullptr);
     *(static_cast<int64_t*>(sptr.get()) + ref_counter_offset) -= 1;
+    // NOLINTNEXTLINE(bugprone-empty-catch)
   } catch (c10::Error&) {
     // Already warned inside of producer process
   }
@@ -532,6 +535,7 @@ static PyObject* THPStorage_newSharedCuda(PyObject* _unused, PyObject* args) {
               sizeof(int64_t) * torch::CUDA_IPC_REF_COUNTER_FILE_SIZE,
               nullptr);
           *(static_cast<int64_t*>(sptr.get()) + ctx->ref_counter_offset) -= 1;
+          // NOLINTNEXTLINE(bugprone-empty-catch)
         } catch (c10::Error&) {
           // Already warned inside of producer process
         }
@@ -633,6 +637,282 @@ static PyObject* THPStorage_isShared(PyObject* self, PyObject* noargs) {
   }
 }
 
+static PyObject* THPStorage_shareDevice(PyObject* self, PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  THPStorage_assertNotNull(self);
+  const auto& storage = THPStorage_Unpack(self);
+  TORCH_CHECK(
+      at::isPrivateUse1HooksRegistered(),
+      "_share_device_: PrivateUse1 hooks are not registered. "
+      "Call RegisterPrivateUse1HooksInterface first.");
+  const auto& hooks = at::detail::getPrivateUse1Hooks();
+  TORCH_CHECK(
+      hooks.supportsIpc(),
+      "_share_device_: the registered PrivateUse1 device does not support IPC.");
+  c10::StorageImpl* storage_impl = storage.unsafeGetStorageImpl();
+  // Block re-sharing of a storage that was itself received via IPC.
+  // The underlying mapped memory belongs to another process; sharing it
+  // onward is not supported. The caller should clone() the tensor first.
+  TORCH_CHECK(
+      !storage_impl->received_via_ipc(),
+      "Attempted to send a PrivateUse1 tensor received from another process; "
+      "this is not currently supported. Consider cloning before sending.");
+
+  THPObjectPtr tuple(PyTuple_New(8));
+  THPObjectPtr device(THPUtils_packInt32(storage.device().index()));
+  THPObjectPtr _handle(Py_NewRef(Py_None));
+  THPObjectPtr size_bytes(THPUtils_packUInt64(storage.nbytes()));
+  THPObjectPtr _offset_bytes(THPUtils_packInt32(0));
+  THPObjectPtr _ref_counter(Py_NewRef(Py_None));
+  THPObjectPtr _ref_counter_offset(THPUtils_packInt32(0));
+  THPObjectPtr _event_handle(Py_NewRef(Py_None));
+  THPObjectPtr _event_sync_required(PyBool_FromLong(0));
+
+  if (storage.data()) {
+    // The vendor is responsible for any stream synchronisation needed before
+    // the handle can be safely transferred.  We call getIpcMemHandle and let
+    // the implementation decide when to sync.
+    auto mem_handle = hooks.getIpcMemHandle(storage.mutable_data());
+    _handle = PyBytes_FromStringAndSize(
+        mem_handle.handle.c_str(),
+        static_cast<Py_ssize_t>(mem_handle.handle.size()));
+    _offset_bytes =
+        PyLong_FromSsize_t(static_cast<Py_ssize_t>(mem_handle.offset));
+
+    // Wrap the storage data pointer in a ref-counted DataPtr so that we can
+    // track when all consumers have released the allocation.
+    // See Note [CUDA IPC Refcounting implementation explained] for the
+    // analogous CUDA description; the device path uses the same OS mechanism.
+    at::DataPtr sent_data_ptr = torch::GetNewRefCountedSentDataForDevice(
+        storage.mutable_data(), storage.device());
+    auto old_data_ptr = storage.set_data_ptr(std::move(sent_data_ptr));
+    auto sent_data = static_cast<torch::DeviceIPCSentData*>(
+        storage.data_ptr().get_context());
+    sent_data->set_original_ptr(std::move(old_data_ptr));
+    _ref_counter = PyBytes_FromString((sent_data->handle()).c_str());
+    _ref_counter_offset = THPUtils_packUInt64(sent_data->offset());
+
+    // Only fetch an event handle when the device requires event-based sync.
+    // Devices that set requiresEventSync() == false rely on the CPU-side
+    // stream_synchronize performed by the vendor inside getIpcMemHandle.
+    bool needs_event_sync = hooks.requiresEventSync();
+    if (needs_event_sync) {
+      std::string event_bytes = hooks.getIpcEventHandle();
+      _event_handle = PyBytes_FromStringAndSize(
+          event_bytes.c_str(), static_cast<Py_ssize_t>(event_bytes.size()));
+    } else {
+      _event_handle = PyBytes_FromStringAndSize("", 0);
+    }
+    _event_sync_required = PyBool_FromLong(needs_event_sync ? 1 : 0);
+  }
+
+  if (!tuple || !device || !_handle || !size_bytes || !_offset_bytes ||
+      !_ref_counter || !_ref_counter_offset || !_event_handle ||
+      !_event_sync_required) {
+    return nullptr;
+  }
+  PyTuple_SET_ITEM(tuple.get(), 0, device.release());
+  PyTuple_SET_ITEM(tuple.get(), 1, _handle.release());
+  PyTuple_SET_ITEM(tuple.get(), 2, size_bytes.release());
+  PyTuple_SET_ITEM(tuple.get(), 3, _offset_bytes.release());
+  PyTuple_SET_ITEM(tuple.get(), 4, _ref_counter.release());
+  PyTuple_SET_ITEM(tuple.get(), 5, _ref_counter_offset.release());
+  PyTuple_SET_ITEM(tuple.get(), 6, _event_handle.release());
+  PyTuple_SET_ITEM(tuple.get(), 7, _event_sync_required.release());
+  return tuple.release();
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPStorage_newSharedDevice(PyObject* _unused, PyObject* args) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(
+      at::isPrivateUse1HooksRegistered(),
+      "_new_shared_device: PrivateUse1 hooks are not registered.");
+  const auto& hooks = at::detail::getPrivateUse1Hooks();
+
+  TORCH_CHECK(PyTuple_GET_SIZE(args) == 8, "tuple of 8 items expected");
+  PyObject* _device = PyTuple_GET_ITEM(args, 0);
+  PyObject* _handle = PyTuple_GET_ITEM(args, 1);
+  PyObject* _size_bytes = PyTuple_GET_ITEM(args, 2);
+  PyObject* _offset_bytes = PyTuple_GET_ITEM(args, 3);
+  PyObject* _ref_counter = PyTuple_GET_ITEM(args, 4);
+  PyObject* _ref_counter_offset = PyTuple_GET_ITEM(args, 5);
+  PyObject* _event_handle = PyTuple_GET_ITEM(args, 6);
+  PyObject* _event_sync_required = PyTuple_GET_ITEM(args, 7);
+
+  if (!(THPUtils_checkLong(_device) && THPUtils_checkLong(_size_bytes) &&
+        PyBytes_Check(_handle) && PyBytes_Check(_ref_counter) &&
+        PyBytes_Check(_event_handle) && THPUtils_checkLong(_offset_bytes) &&
+        THPUtils_checkLong(_ref_counter_offset) &&
+        PyBool_Check(_event_sync_required))) {
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "_new_shared_device",
+        1,
+        "(int device, bytes handle, int storage_size_bytes, "
+        "int storage_offset_bytes, bytes ref_counter, "
+        "int ref_counter_offset, bytes event_handle, "
+        "bool event_sync_required)");
+    return nullptr;
+  }
+
+  size_t storage_size = THPUtils_unpackUInt64(_size_bytes) / sizeof(uint8_t);
+  ptrdiff_t storage_offset_bytes =
+      static_cast<ptrdiff_t>(THPUtils_unpackLong(_offset_bytes));
+  const auto device_index = c10::checked_convert<c10::DeviceIndex>(
+      THPUtils_unpackLong(_device), "c10::DeviceIndex");
+
+  // If the producer recorded an event, wait on it before reading to ensure
+  // the producer has finished writing to the shared memory region.
+  // We pass stream_id=0 (the default stream) because PrivateUse1HooksInterface
+  // does not expose a getCurrentStream hook. Vendor implementations of
+  // waitIpcEvent that need the actual current stream should look it up
+  // internally using their device-specific API rather than relying on the
+  // passed stream argument.
+  if (PyObject_IsTrue(_event_sync_required)) {
+    char* event_buf = nullptr;
+    Py_ssize_t event_size = 0;
+    TORCH_CHECK(
+        PyBytes_AsStringAndSize(_event_handle, &event_buf, &event_size) != -1,
+        "_new_shared_device: failed to decode event handle bytes");
+    std::string event_bytes(event_buf, event_size);
+    c10::Stream current_stream = c10::Stream::unpack3(
+        0,
+        static_cast<c10::DeviceIndex>(device_index),
+        c10::DeviceType::PrivateUse1);
+    hooks.waitIpcEvent(event_bytes, current_stream);
+  }
+
+  // Open the IPC handle.  The vendor returns a DataPtr whose custom deleter
+  // unmaps the shared region when the last reference is released.
+  char* handle_buf = nullptr;
+  Py_ssize_t handle_size = 0;
+  TORCH_CHECK(
+      PyBytes_AsStringAndSize(_handle, &handle_buf, &handle_size) != -1,
+      "_new_shared_device: failed to decode memory handle bytes");
+  std::string handle_str(handle_buf, handle_size);
+  c10::DataPtr ipc_data_ptr = hooks.openIpcMemHandle(handle_str);
+
+  // Apply the byte offset to locate the exact start of the storage within
+  // the larger mapped region returned by openIpcMemHandle.
+  void* base_ptr = ipc_data_ptr.get();
+  void* storage_ptr = static_cast<char*>(base_ptr) + storage_offset_bytes;
+
+  // Keep the mapped memory alive via shared_ptr with a custom deleter that
+  // holds the DataPtr alive until the mapped region is released.
+  auto dp_holder = std::make_shared<c10::DataPtr>(std::move(ipc_data_ptr));
+  std::shared_ptr<void> mapped_region(base_ptr, [dp_holder](void*) {});
+
+  std::string ref_counter_handle = PyBytes_AS_STRING(_ref_counter);
+  ptrdiff_t ref_counter_offset =
+      static_cast<ptrdiff_t>(THPUtils_unpackLong(_ref_counter_offset));
+
+  // Bundle everything the destructor needs to decrement the refcount and
+  // release the mapped memory.
+  struct DeviceIpcDeleterCtx {
+    std::string ref_counter_handle;
+    ptrdiff_t ref_counter_offset{};
+    c10::DeviceIndex device{-1};
+    torch::DeviceIPCReceivedData received_data;
+  };
+
+  auto ctx = std::make_unique<DeviceIpcDeleterCtx>();
+  ctx->ref_counter_handle = std::move(ref_counter_handle);
+  ctx->ref_counter_offset = ref_counter_offset;
+  ctx->device = device_index;
+  ctx->received_data.shared_ptr_ = std::move(mapped_region);
+
+  // Build the final DataPtr for the storage.
+  // The destructor:
+  //   1. Releases the vendor's mapped region (via received_data).
+  //   2. Decrements the producer's refcount slot so the producer can
+  //      eventually free the allocation once all consumers have released it.
+  c10::DataPtr data_ptr(
+      storage_ptr,
+      ctx.release(),
+      +[](void* ctx_) {
+        std::unique_ptr<DeviceIpcDeleterCtx> c(
+            static_cast<DeviceIpcDeleterCtx*>(ctx_));
+        // Release mapped memory.  The vendor's DataPtr deleter (set inside
+        // openIpcMemHandle) is responsible for synchronising any in-flight
+        // device work before unmapping.  This mirrors the CUDA path where
+        // CUDACachingAllocator performs an implicit stream sync on free.
+        c->received_data.shared_ptr_.reset();
+        // Decrement the producer's refcount slot.
+        // This is best-effort: if the producer has already terminated the
+        // shared memory file may be gone, which is expected and ignored.
+        int flags =
+            at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_NOCREATE;
+        try {
+          auto sptr = at::RefcountedMapAllocator::makeDataPtr(
+              c->ref_counter_handle.c_str(),
+              flags,
+              sizeof(int64_t) * torch::DEVICE_IPC_REF_COUNTER_FILE_SIZE,
+              nullptr);
+          *(static_cast<int64_t*>(sptr.get()) + c->ref_counter_offset) -= 1;
+          // NOLINTNEXTLINE(bugprone-empty-catch)
+        } catch (c10::Error&) {
+          // Producer process terminated before consumer released data.
+        }
+      },
+      at::Device(at::DeviceType::PrivateUse1, device_index));
+
+  auto base = c10::make_intrusive<at::StorageImpl>(
+      c10::StorageImpl::use_byte_size_t(),
+      storage_size,
+      std::move(data_ptr),
+      /*allocator=*/nullptr,
+      /*resizable=*/false);
+
+  base->set_resizable(false);
+  // Mark this storage as received via IPC to prevent re-sharing.
+  base->set_received_via_ipc(true);
+
+  return THPStorage_NewWithStorage(THPStorageClass, std::move(base));
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THPStorage_releaseIPCCounterDevice(
+    PyObject* _unused,
+    PyObject* args) {
+  HANDLE_TH_ERRORS
+  TORCH_CHECK(PyTuple_GET_SIZE(args) == 2, "tuple of 2 items expected");
+  PyObject* _ref_counter = PyTuple_GET_ITEM(args, 0);
+  PyObject* _ref_counter_offset = PyTuple_GET_ITEM(args, 1);
+  if (!(PyBytes_Check(_ref_counter) &&
+        THPUtils_checkLong(_ref_counter_offset))) {
+    THPUtils_invalidArguments(
+        args,
+        nullptr,
+        "_release_ipc_counter_device",
+        1,
+        "(bytes ref_counter, int ref_counter_offset)");
+    return nullptr;
+  }
+  // On a cache hit in rebuild_device_tensor() the consumer reuses an already-
+  // open storage and its destructor will NOT run for this send.  We must
+  // therefore decrement the producer's refcount slot immediately so that the
+  // count can eventually reach zero and the producer can free the allocation.
+  std::string ref_counter_handle = PyBytes_AS_STRING(_ref_counter);
+  ptrdiff_t ref_counter_offset =
+      static_cast<ptrdiff_t>(THPUtils_unpackLong(_ref_counter_offset));
+  int flags = at::ALLOCATOR_MAPPED_SHAREDMEM | at::ALLOCATOR_MAPPED_NOCREATE;
+  try {
+    auto sptr = at::RefcountedMapAllocator::makeDataPtr(
+        ref_counter_handle.c_str(),
+        flags,
+        sizeof(int64_t) * torch::DEVICE_IPC_REF_COUNTER_FILE_SIZE,
+        nullptr);
+    *(static_cast<int64_t*>(sptr.get()) + ref_counter_offset) -= 1;
+    // NOLINTNEXTLINE(bugprone-empty-catch)
+  } catch (c10::Error&) {
+    // Producer process terminated before consumer released data.
+  }
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-non-const-global-variables)
 static PyMethodDef THPStorage_sharingMethods[] = {
     {"_new_with_weak_ptr",
@@ -646,6 +926,15 @@ static PyMethodDef THPStorage_sharingMethods[] = {
      nullptr},
     {"_release_ipc_counter_cuda",
      THPStorage_releaseIPCCounter,
+     METH_VARARGS | METH_STATIC,
+     nullptr},
+    {"_share_device_", THPStorage_shareDevice, METH_NOARGS, nullptr},
+    {"_new_shared_device",
+     THPStorage_newSharedDevice,
+     METH_VARARGS | METH_STATIC,
+     nullptr},
+    {"_release_ipc_counter_device",
+     THPStorage_releaseIPCCounterDevice,
      METH_VARARGS | METH_STATIC,
      nullptr},
     {"_share_fd_cpu_", THPStorage_shareFd, METH_NOARGS, nullptr},

--- a/torch/csrc/acc/Module.cpp
+++ b/torch/csrc/acc/Module.cpp
@@ -192,6 +192,12 @@ void initModule(PyObject* module) {
       "register_python_privateuseone_device_guard",
       &registerPythonPrivateUse1DeviceGuard);
   _acc.def("create_empty_tensor", &createEmptyTensor);
+  _acc.def("_is_privateuse1_ipc_supported", []() -> bool {
+    if (!at::isPrivateUse1HooksRegistered()) {
+      return false;
+    }
+    return at::detail::getPrivateUse1Hooks().supportsIpc();
+  });
 }
 
 } // namespace torch::acc


### PR DESCRIPTION
## Summary

PR 3 of 5 for [RFC #192099](https://github.com/pytorch/pytorch/issues/192099) (Adding IPC Support for Third-Party Devices).

This PR wires **device-agnostic storage sharing** for `PrivateUse1` accelerators in `StorageSharing.cpp`. It adds `_share_device_`, `_new_shared_device`, and `_release_ipc_counter_device` on `torch.Storage`, dispatching through `PrivateUse1HooksInterface` and `DeviceIPCTypes` (from the dependency PRs below). The existing CUDA IPC path is unchanged.

Also adds `received_via_ipc` on `StorageImpl` so IPC-received storages cannot be re-shared without cloning, exposes `_is_privateuse1_ipc_supported` on `torch._C._acc`, and adds gtest/Python tests for the new surface.

**Depends on:**

- #193217 — IPC virtual methods on `PrivateUse1HooksInterface` (PR 1 of 5)
- #194020 — `DeviceIPCTypes` for device-agnostic IPC data structures (PR 2 of 5)

Follow-up PRs will add `reductions.py` dispatch (PR 4) and the OpenReg reference implementation with end-to-end tests (PR 5).

cc @ahkush @mansiag05 @fffrog @albanD @cyyever

## Test plan

```bash
# Requires #193217 and #194020 merged or stacked locally
python test/test_device_ipc.py -v

# After C++ test build (BUILD_TEST=1):
./build/bin/storage_impl_privateuse1_ipc_test
```
---

Authored with an AI assistant.
