### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_fx_traceback.py

### DIFF
--- a/test/fx/test_fx_traceback.py
+++ b/test/fx/test_fx_traceback.py
@@ -4,13 +4,19 @@ import torch
 from torch._functorch.aot_autograd import aot_export_module
 from torch.export import default_decompositions
 from torch.fx.traceback import get_graph_provenance_json, NodeSource, NodeSourceAction
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 CREATE_STR = NodeSourceAction.CREATE.name.lower()
 
 
 class TestFXNodeSource(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_node_source_shallow_copies_provenance_list(self):
         ancestor = NodeSource(
             node=None,


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestFXNodeSource
and import HardwareClassification from common_utils, enabling per-hardware-backend
test selection via --hw-classification.

## Changes
test/fx/test_fx_traceback.py: import HardwareClassification; add
hw_classification (GENERIC on TestFXNodeSource).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering.
The FX traceback tests (test_node_source, test_node_source_shallow_copies_provenance_list,
test_graph_provenance) exercise graph provenance / NodeSource metadata logic with no
device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_fx_traceback.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.