### PR TITLE
[Inductor] Ignore internal cat input consumers in multi-consumer heuristic

### DIFF
--- a/test/inductor/test_pad_as_cat.py
+++ b/test/inductor/test_pad_as_cat.py
@@ -16,6 +16,42 @@ torch._logging.set_logs(inductor_metrics=True)
 class TestCatMultiConsumer(TestCase):
     @torch._inductor.config.patch(fx_graph_cache=False)
     @requires_gpu()
+    def test_other_cat_input_is_not_external_consumer(self):
+        """A use feeding another input of the same cat is internal."""
+
+        def fn(x):
+            rotated = torch.sin(x)
+            concatenated = torch.cat((rotated, -rotated), dim=-1)
+            return torch.argmax(concatenated, dim=-1)
+
+        x = torch.randn(128, 64, device=GPU_TYPE)
+        compiled = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled, x)
+
+        self.assertEqual(result, fn(x))
+        self.assertNotIn("reinterpret_tensor", code)
+
+    @torch._inductor.config.patch(fx_graph_cache=False)
+    @requires_gpu()
+    def test_external_consumer_still_uses_concat_kernel(self):
+        """A consumer outside the cat inputs remains a multi-consumer."""
+
+        def fn(x):
+            rotated = torch.sin(x)
+            concatenated = torch.cat((rotated, -rotated), dim=-1)
+            return torch.argmax(concatenated, dim=-1), torch.cos(rotated)
+
+        x = torch.randn(128, 64, device=GPU_TYPE)
+        compiled = torch.compile(fn)
+        result, (code,) = run_and_get_code(compiled, x)
+        ref = fn(x)
+
+        self.assertEqual(result[0], ref[0])
+        self.assertEqual(result[1], ref[1])
+        self.assertIn("reinterpret_tensor", code)
+
+    @torch._inductor.config.patch(fx_graph_cache=False)
+    @requires_gpu()
     def test_cat_to_fp16(self):
         """Multi-consumer cat avoids duplicate computation."""
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2451,6 +2451,11 @@ def cat(inputs, dim=0):
             if any(skip_mask):
                 input_nodes = [n for n, skip in zip(input_nodes, skip_mask) if not skip]
 
+            # A cat input can be consumed by another input to the same cat, for
+            # example cat((rotated, -rotated)).  That use is internal to this
+            # cat and should not make rotated a multi-consumer input.
+            cat_input_nodes = OrderedSet(input_nodes)
+
             def is_unrealized_pointwise(x):
                 if isinstance(x, (TensorBox, ir.StorageBox)):
                     return is_unrealized_pointwise(unwrap_tensor(x))
@@ -2459,9 +2464,16 @@ def cat(inputs, dim=0):
             for arg, ir_input in zip(input_nodes, inputs):
                 if not hasattr(arg, "users") or len(arg.users) <= 1:
                     continue
+                external_users = [
+                    u
+                    for u in arg.users
+                    if u is not current_node and u not in cat_input_nodes
+                ]
+                if not external_users:
+                    continue
                 # input will be computed multiple times because other consumers
                 # (eg. pointwise) will also inline it. So we should realize-in-place via ConcatKernel
-                if any(is_pointwise_use(u) for u in arg.users if u is not current_node):
+                if any(is_pointwise_use(u) for u in external_users):
                     return True
                 # If input is an unrealized Pointwise with multiple consumers, pointwise_cat
                 # will inline input without realizing it to memory, causing separate


### PR DESCRIPTION
Fixes #194858

## Summary

This PR fixes a `pointwise_cat` selection regression where an input to `torch.cat` is classified as having an external consumer when that consumer is itself another direct input to the same cat.

For example:

```
rotated = ...
negated = -rotated
concatenated = torch.cat((rotated, negated), dim=-1)
result = torch.argmax(concatenated, dim=-1)
```

The FX graph is:

```
%rotated = ...
%negated = aten.neg(%rotated)
%cat = aten.cat([%rotated, %negated], dim=-1)
%result = aten.argmax(%cat, dim=-1)
```

Its user relationships are:

```
rotated.users = {negated, cat}
negated.users = {cat}
cat.users = {argmax}
```

The existing heuristic treats `negated` as an external pointwise consumer of `rotated`, disables `pointwise_cat`, and falls back to `ConcatKernel`.

However, `negated` is a direct input to the same cat:

```
cat.inputs = {rotated, negated}
```

It is therefore internal to the current cat computation rather than an independent consumer.

## Root cause

The existing check excludes only the current cat node:

```
if any(
    is_pointwise_use(user)
    for user in arg.users
    if user is not current_node
):
    return True
```

For `cat((rotated, -rotated))`, this leaves `negated` in the consumer list:

```
rotated.users - {current_cat}
= {negated}
```

Since `negated` is pointwise, `rotated` is incorrectly classified as a multi-consumer input.

## Fix

The updated heuristic first collects all direct input nodes of the current cat:

```
cat_input_nodes = OrderedSet(input_nodes)
```

It then evaluates only genuine external users:

```
external_users = [
    user
    for user in arg.users
    if user is not current_node
    and user not in cat_input_nodes
]
```

For the affected graph:

```
external_users(rotated)
= {negated, cat} - {cat} - {rotated, negated}
= {}
```

This allows the lowering to retain `pointwise_cat` and avoids unnecessary materialization of the cat output.

The change is intentionally limited to direct cat inputs. It does not attempt to classify arbitrary transitive consumer chains as internal.
## Graph Diff
Use the minimax producer in issue.
Graph before:
```
def call(self, args):
        arg0_1, = args
        args.clear()
        assert_size_stride(arg0_1, (128, 64), (64, 1), 'input')
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            arg0_1 = copy_if_misaligned(arg0_1)
            buf2 = empty_strided_cuda((128, 128), (128, 1), torch.float16)
            buf0 = reinterpret_tensor(buf2, (128, 64), (128, 1), 0)  # alias
            buf1 = reinterpret_tensor(buf2, (128, 64), (128, 1), 64)  # alias
            # Topologically Sorted Source Nodes: [rotated, neg], Original ATen: [aten.sin, aten.neg]
            # [Provenance debug handles] triton_poi_fused_neg_sin_0:1
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_neg_sin_0.run(arg0_1, buf0, buf1, 8192, stream=raw_stream0)
            del arg0_1
            buf3 = empty_strided_cuda((128, ), (1, ), torch.int64)
            # Topologically Sorted Source Nodes: [argmax], Original ATen: [aten.argmax]
            # [Provenance debug handles] triton_per_fused_argmax_1:2
            raw_stream0 = get_raw_stream(0)
            triton_per_fused_argmax_1.run(buf2, buf3, 128, 128, stream=raw_stream0)
            del buf0
            del buf1
            del buf2
        return (buf3, )
```
Graph after:
```
    def call(self, args):
        arg0_1, = args
        args.clear()
        assert_size_stride(arg0_1, (128, 64), (64, 1), 'input')
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            arg0_1 = copy_if_misaligned(arg0_1)
            buf0 = empty_strided_cuda((128, ), (1, ), torch.int64)
            # Topologically Sorted Source Nodes: [rotated, neg, concatenated, argmax], Original ATen: [aten.sin, aten.neg, aten.cat, aten.argmax]
            # [Provenance debug handles] triton_per_fused_argmax_cat_neg_sin_0:1
            raw_stream0 = get_raw_stream(0)
            triton_per_fused_argmax_cat_neg_sin_0.run(arg0_1, buf0, 128, 128, stream=raw_stream0)
            del arg0_1
        return (buf0, )

```

## Tests
This PR adds two targeted tests to `test/inductor/test_pad_as_cat.py`.

## Performance

Workload:

```
Model: hf_Reformer
Mode: inference
Batch size: 128
dtype: torch.float16
```

Result:

CUDA 4080Super GPU: 1.04x speedup 
Intel Client GPU：1.04x speedup

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey