### PR TITLE
[nn] Define generic TransformerEncoder device gates from the dispatcher

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -1123,6 +1123,38 @@ class TestTransformers(NNTestCase):
 
 
 
+    def test_fastpath_device_gate_follows_dispatcher(self, device):
+        # The gates query the dispatcher rather than matching a hardcoded list of
+        # device-type strings, so a backend is admitted exactly when it has
+        # registered the kernel the fastpath is about to call.
+        from torch.nn.modules.transformer import (
+            _encoder_layer_fastpath_supported,
+            _nested_tensor_fastpath_supported,
+        )
+
+        self.assertTrue(_nested_tensor_fastpath_supported("cpu"))
+        self.assertTrue(_encoder_layer_fastpath_supported("cpu"))
+        # Vulkan registers none of the ops; it must be rejected by the gate
+        # rather than reaching the call and raising NotImplementedError.
+        self.assertFalse(_nested_tensor_fastpath_supported("vulkan"))
+        self.assertFalse(_encoder_layer_fastpath_supported("vulkan"))
+        # The two gates cover different ops and do diverge: meta has
+        # _transformer_encoder_layer_fwd but neither nested-tensor-from-mask op.
+        self.assertTrue(_encoder_layer_fastpath_supported("meta"))
+        self.assertFalse(_nested_tensor_fastpath_supported("meta"))
+
+        src = torch.rand(2, 4, 8, device="meta")
+        key_padding_mask = torch.zeros(2, 4, dtype=torch.bool, device="meta")
+        model = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(
+                d_model=8, nhead=4, dim_feedforward=32, batch_first=True
+            ),
+            num_layers=2,
+        ).to("meta").eval()
+        with torch.no_grad():
+            out = model(src, src_key_padding_mask=key_padding_mask)
+        self.assertEqual(out.shape, src.shape)
+
     def test_script_encoder_subclass(self, device):
         class MyCustomLayer(nn.TransformerEncoderLayer):
             pass
@@ -1134,6 +1166,8 @@ class TestTransformers(NNTestCase):
 
     # brazenly adapted from test_transformerencoderlayer_src_mask to test execution of
     # torchscripted transformerencoderlayer subclass
+    # In eval mode eager takes the fused fastpath while the scripted copy falls
+    # back to the slowpath, so this compares the two implementations.
     def test_transformerencoderlayer_subclass(self, device):
         class MyCustomLayer(nn.TransformerEncoderLayer):
             pass
@@ -1168,7 +1202,8 @@ class TestTransformers(NNTestCase):
             scripted_result = script_model(src, src_mask=src_mask)
             self.assertEqual(result, scripted_result)
 
-
+    # In eval mode eager takes the fused fastpath while the scripted copy falls
+    # back to the slowpath, so this compares the two implementations.
     def test_transformerencoderlayer_subclass_model(self, device):
         class MyCustomLayer(nn.TransformerEncoderLayer):
             pass

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -236,6 +236,8 @@ constant_fold_functions = [
     torch.nn.functional._Reduction.get_enum,  # type: ignore[attr-defined]
     torch.promote_types,
     torch._C._get_privateuse1_backend_name,
+    torch._C._dispatch_key_for_device,
+    torch._C._dispatch_has_kernel_for_dispatch_key,
     torch.autograd._is_checkpoint_valid,
     torch.mps.is_available,
     torch.mtia.is_available,

--- a/torch/nn/modules/transformer.py
+++ b/torch/nn/modules/transformer.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import copy
+import functools
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -24,6 +25,29 @@ __all__ = [
     "TransformerEncoderLayer",
     "TransformerDecoderLayer",
 ]
+
+
+@functools.lru_cache
+def _kernel_registered(op_name: str, device_type: str) -> bool:
+    return torch._C._dispatch_has_kernel_for_dispatch_key(
+        op_name, torch._C._dispatch_key_for_device(device_type)
+    )
+
+
+def _nested_tensor_fastpath_supported(device_type: str) -> bool:
+    # The encoder fastpath calls both of these; they are registered separately,
+    # so neither one licenses the other.
+    if torch.jit.is_scripting():
+        return False
+    return _kernel_registered(
+        "aten::_nested_tensor_from_mask", device_type
+    ) and _kernel_registered("aten::_nested_tensor_from_mask_left_aligned", device_type)
+
+
+def _encoder_layer_fastpath_supported(device_type: str) -> bool:
+    if torch.jit.is_scripting():
+        return False
+    return _kernel_registered("aten::_transformer_encoder_layer_fwd", device_type)
 
 
 def _generate_square_subsequent_mask(
@@ -475,6 +499,11 @@ class TransformerEncoder(Module):
             )
         elif src_key_padding_mask is None:
             why_not_sparsity_fast_path = "src_key_padding_mask was None"
+        elif not _nested_tensor_fastpath_supported(src.device.type):
+            why_not_sparsity_fast_path = (
+                f"{src.device.type} has no aten::_nested_tensor_from_mask and "
+                "aten::_nested_tensor_from_mask_left_aligned kernels registered"
+            )
         # This check avoids a call to torch._nested_tensor_from_mask_left_aligned() that
         # breaks in torch.compile.
         elif do_mask_check and torch.compiler.is_compiling():
@@ -510,18 +539,8 @@ class TransformerEncoder(Module):
                 first_layer.linear2.weight,
                 first_layer.linear2.bias,
             )
-            _supported_device_type = [
-                "cpu",
-                "cuda",
-                "xpu",
-                torch.utils.backend_registration._privateuse1_backend_name,
-            ]
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
-            elif src.device.type not in _supported_device_type:
-                why_not_sparsity_fast_path = (
-                    f"src device is neither one of {_supported_device_type}"
-                )
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = (
                     "grad is enabled and at least one of query or the "
@@ -893,20 +912,14 @@ class TransformerEncoderLayer(Module):
 
             # We have to use list comprehensions below because TorchScript does not support
             # generator expressions.
-            _supported_device_type = [
-                "cpu",
-                "cuda",
-                "xpu",
-                torch.utils.backend_registration._privateuse1_backend_name,
-            ]
             if torch.overrides.has_torch_function(tensor_args):
                 why_not_sparsity_fast_path = "some Tensor argument has_torch_function"
             elif not all(
-                (x.device.type in _supported_device_type) for x in tensor_args
+                _encoder_layer_fastpath_supported(x.device.type) for x in tensor_args
             ):
                 why_not_sparsity_fast_path = (
-                    "some Tensor argument's device is neither one of "
-                    f"{_supported_device_type}"
+                    "some Tensor argument's device has no "
+                    "aten::_transformer_encoder_layer_fwd kernel registered"
                 )
             elif torch.is_grad_enabled() and any(x.requires_grad for x in tensor_args):
                 why_not_sparsity_fast_path = (


### PR DESCRIPTION
## What does this PR solve?

`transformer.py` gates the sparsity/nested-tensor fastpath on hardcoded lists of device-type strings, in two places. Both are hand-maintained proxies for "does this device have the kernel", so they need an edit every time a backend lands and they drift from the dispatch table in the meantime. Replace them with dispatcher queries, following the approach in #194266.

Related to this RFC: #194355

### `TransformerEncoderLayer` (`transformer.py`)

The gate matched `["cpu", "cuda", "xpu", privateuse1]` before calling `torch._transformer_encoder_layer_fwd`. Query `aten::_transformer_encoder_layer_fwd` instead, so the gate follows registrations rather than tracking them by hand. As in #194266, this also fixes the list's failure in the other direction: PrivateUse1 was admitted unconditionally, so a backend that had not registered the kernel entered the fastpath and hit `NotImplementedError` instead of falling back.

### `TransformerEncoder` (`transformer.py`)

`TransformerEncoder` only gates converting the input to a nested tensor, and the layers then gate themselves. So its query is `aten::_nested_tensor_from_mask`. The fastpath calls both `_nested_tensor_from_mask` and `_nested_tensor_from_mask_left_aligned`, which are separate registrations and nothing enforces their co-registration even though one is the predicate of other. So, the gate checks both rather than letting one license the other.

Also, the gate was in the wrong position. Nothing device-related preceded `torch._nested_tensor_from_mask_left_aligned()` in the `elif` chain and the device check sat about 30 lines *after* it. A device without those kernels therefore would raise `NotImplementedError` from inside the op rather than falling back. Swapping the list for a dispatcher query does not fix this on its own; the check has to move ahead of the call.

This reproduces on `meta`, which is a real in-tree device that has `_transformer_encoder_layer_fwd` but neither nested-tensor-from-mask op:

```python
src = torch.rand(2, 4, 8, device="meta")
mask = torch.zeros(2, 4, dtype=torch.bool, device="meta")
enc = nn.TransformerEncoder(
    nn.TransformerEncoderLayer(d_model=8, nhead=4, dim_feedforward=32, batch_first=True),
    num_layers=2,
).to("meta").eval()
enc(src, src_key_padding_mask=mask)
# before: NotImplementedError: aten::_nested_tensor_from_mask_left_aligned:
#         attempted to run this operator with Meta tensors ...
# after:  torch.Size([2, 4, 8])
```

### TorchScript

Both helpers return `False` under `torch.jit.is_scripting()`, matching `_check_arg_device` in #194266. So scripted modules keep working on the slowpath.

### Dynamo

The two `torch._C` dispatcher queries are added to `constant_fold_functions` to prevent graph breaks, the same two lines as #194266. Verified `fullgraph=True` compiles both gates in a single frame with no break.

## Behaviour changes

- **Scripted `TransformerEncoderLayer` loses the fused path.** Numerics are unaffected; measured divergence between the two implementations is 4.2e-7 worst case (6 layers, TF32 on), well inside `assertEqual`'s 1e-5 atol. Perf regresses on the deprecated TorchScript path only.
- **`meta` now reaches the layer fastpath**, where the hardcoded list blocked it. Same class of change as the `meta` note in #194266.
- **The gates are memoized** (`functools.lru_cache`), so the answer for a device type is fixed at first query. A backend registering kernels lazily *after* the first forward on that device would see a stale `False`. Backends register at import in practice; noting it because the name-based list had no such window.

## Test plan

Added `test_fastpath_device_gate_follows_dispatcher` in `test/test_transformers.py`, covering the gate helpers directly plus the `meta` regression above, which fails on `main`.

```
lintrunner -a
python -m pytest test/test_transformers.py -k "TestTransformers" -q
python -m pytest test/test_jit.py -k "multi_head or multihead" -q
python -m pytest test/test_modules.py -k "TransformerEncoder or TransformerDecoder or Transformer or MultiheadAttention" -q
python -m pytest test/test_nn.py -k "transformer or Transformer" -q
python -m pytest test/test_nestedtensor.py -k "mask" -q
```

Tested on a CUDA build.

This PR was authored with the assistance of an AI coding assistant. All changes have been reviewed by me.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98