### PR TITLE
Drop C10_RETURN_MOVE_IF_OLD_COMPILER

### DIFF
--- a/torch/csrc/jit/python/pybind_utils.cpp
+++ b/torch/csrc/jit/python/pybind_utils.cpp
@@ -676,11 +676,7 @@ py::object toPyObject(IValue ivalue) {
     for (const auto i : c10::irange(list.size())) {
       t[i] = toPyObject(IValue{list.get(i)});
     }
-#if C10_RETURN_MOVE_IF_OLD_COMPILER
-    return std::move(t);
-#else
     return t;
-#endif
   } else if (ivalue.isTuple()) {
     auto tuple = std::move(ivalue).toTuple();
     const auto& elements = tuple->elements();
@@ -715,11 +711,7 @@ py::object toPyObject(IValue ivalue) {
           .attr("_create_named_tuple")(
               t, unqualName, fieldNames, py::make_tuple(defaults));
     } else {
-#if C10_RETURN_MOVE_IF_OLD_COMPILER
-      return std::move(t);
-#else
       return t;
-#endif
     }
   } else if (ivalue.isDevice()) {
     return py::cast(std::move(ivalue).toDevice());
@@ -732,11 +724,7 @@ py::object toPyObject(IValue ivalue) {
       py_dict[toPyObject(IValue{pair.key()})] =
           toPyObject(IValue{pair.value()});
     }
-#if C10_RETURN_MOVE_IF_OLD_COMPILER
-    return std::move(py_dict);
-#else
     return py_dict;
-#endif
   } else if (ivalue.isRRef()) {
 #ifdef USE_RPC
     auto RRefPtr =

--- a/torch/csrc/jit/python/python_arg_flatten.cpp
+++ b/torch/csrc/jit/python/python_arg_flatten.cpp
@@ -115,11 +115,7 @@ py::object cast_sequence(std::vector<py::object> objs) {
   for (const auto i : c10::irange(num_objs)) {
     sequence[i] = std::move(objs[i]);
   }
-#if C10_RETURN_MOVE_IF_OLD_COMPILER
-  return std::move(sequence);
-#else
   return sequence;
-#endif
 }
 
 py::object cast_dict(std::vector<py::object> objs) {
@@ -129,11 +125,7 @@ py::object cast_dict(std::vector<py::object> objs) {
     py::tuple obj = py::reinterpret_borrow<py::tuple>(objs[i]);
     sequence[obj[0]] = obj[1];
   }
-#if C10_RETURN_MOVE_IF_OLD_COMPILER
-  return std::move(sequence);
-#else
   return sequence;
-#endif
 }
 
 py::object unflatten_rec(

--- a/torch/csrc/jit/tensorexpr/kernel.cpp
+++ b/torch/csrc/jit/tensorexpr/kernel.cpp
@@ -486,11 +486,7 @@ ExprHandle TensorExprKernel::getVarForShape(const c10::ShapeSymbol& ss) {
   if (it == shapeSymbolToVar_.end()) {
     VarHandle var("ss" + std::to_string(-value), kLong);
     shapeSymbolToVar_.emplace(value, var);
-#if C10_RETURN_MOVE_IF_OLD_COMPILER
-    return std::move(var);
-#else
     return var;
-#endif
   }
   return it->second;
 }
@@ -1027,11 +1023,7 @@ ExprHandle TensorExprKernel::getStrideArg(
         kLong);
     strideArgToVar_[std::pair<size_t, size_t>(
         tensor_input_index, stride_index)] = var;
-#if C10_RETURN_MOVE_IF_OLD_COMPILER
-    return std::move(var);
-#else
     return var;
-#endif
   }
   return it->second;
 }

--- a/torch/headeronly/macros/Macros.h
+++ b/torch/headeronly/macros/Macros.h
@@ -682,16 +682,6 @@ __host__ __device__
 
 #endif
 
-// This macro is used to find older C++ compilers
-// that don't support move optimization for return values.
-
-#if (defined(__GNUC__) && __GNUC__ < 13 && __cplusplus < 202002L) || \
-    (defined(__clang_major__) && __clang_major__ < 13)
-#define C10_RETURN_MOVE_IF_OLD_COMPILER 1
-#else
-#define C10_RETURN_MOVE_IF_OLD_COMPILER 0
-#endif
-
 // The HIDDEN_NAMESPACE_BEGIN and HIDDEN_NAMESPACE_END below
 // are needed for maintaining robustness in our header APIs in
 // torch/headeronly and torch/csrc/stable under the namespaces


### PR DESCRIPTION
## Summary
`C10_RETURN_MOVE_IF_OLD_COMPILER`'s guard condition can never hold: ATen.h's C++20 `#error` kills the GNU half, and `CMakeLists.txt:154`'s Clang-16 floor kills the Clang half for upstream Clang (AppleClang isn't covered by that check, but any AppleClang >= 10 already has guaranteed move-on-return per CWG 1579, so it's moot there too). The kept branch (no `std::move`) is correct regardless, since an explicit `std::move` on a return value blocks NRVO.

## Test plan
```
lintrunner -a
CC=gcc-15 CXX=g++-15 MAX_JOBS=5 pip install -e . -v --no-build-isolation
```

This PR description was drafted with an AI assistant (Claude Code); I've reviewed the change.

cc @EikanWang @jgong5