### PR TITLE
Fix _maybe_view_chunk_cat view shape for negative gather_dim

### DIFF
--- a/test/dynamo/test_fake_distributed.py
+++ b/test/dynamo/test_fake_distributed.py
@@ -166,6 +166,30 @@ class GraphModule(torch.nn.Module):
         expected = all_gather_single(x, gather_dim=2, group=dist.group.WORLD)
         self.assertEqual(result, expected)
 
+    def test_all_gather_tensor_gather_dim_negative_view_path(self):
+        """gather_dim=-1 on a 2D input must match gather_dim=1 (view path)."""
+
+        @torch.compile(fullgraph=True, backend="eager")
+        def fn(x):
+            return all_gather_single(x, gather_dim=-1, group=dist.group.WORLD)
+
+        x = torch.randn(1, 4)
+        result = fn(x)
+        expected = all_gather_single(x, gather_dim=1, group=dist.group.WORLD)
+        self.assertEqual(result, expected)
+
+    def test_all_gather_tensor_gather_dim_negative_chunk_cat_path(self):
+        """gather_dim=-1 on a 3D input must match gather_dim=2 (chunk+cat path)."""
+
+        @torch.compile(fullgraph=True, backend="eager")
+        def fn(x):
+            return all_gather_single(x, gather_dim=-1, group=dist.group.WORLD)
+
+        x = torch.randn(1, 3, 4)
+        result = fn(x)
+        expected = all_gather_single(x, gather_dim=2, group=dist.group.WORLD)
+        self.assertEqual(result, expected)
+
     def test_device_mesh_get_local_rank(self):
         device_mesh = init_device_mesh(
             device_type="cpu",

--- a/test/test_view_ops.py
+++ b/test/test_view_ops.py
@@ -1105,6 +1105,9 @@ class TestViewOps(TestCase):
             self.assertEqual(result, expected)
             self.assertTrue(result.is_contiguous())
 
+            # The movedim/flatten reference below requires a non-negative dim.
+            gather_dim = gather_dim % x.dim()
+
             # Check that whether result is a view matches the movedim reference implementation
             # Reference: chunks = torch.unflatten(x, 0, [group_size, -1])
             #            ref = torch.flatten(torch.movedim(chunks, 0, gather_dim), gather_dim, gather_dim + 1)
@@ -1137,6 +1140,9 @@ class TestViewOps(TestCase):
         test_config((4, 8, 6, 10), group_size=4, gather_dim=2)  # 4D, gather_dim=2
         test_config((4, 8, 6, 10), group_size=4, gather_dim=3)  # 4D, gather_dim=3
         test_config((8, 4, 6), group_size=8, gather_dim=1)  # group_size=8
+        test_config((4, 16), group_size=4, gather_dim=-1)  # negative dim, view case
+        test_config((4, 2, 8), group_size=4, gather_dim=-1)  # negative dim, cat case
+        test_config((4, 8, 16), group_size=4, gather_dim=-3)  # negative dim, no-op case
 
 
 class TestOldViewOps(TestCase):

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -1234,6 +1234,10 @@ def _maybe_view_chunk_cat(
         Tensor with data rearranged to gather along gather_dim
     """
 
+    # The shape slicing below assumes a non-negative gather_dim.
+    if gather_dim < 0:
+        gather_dim += res.dim()
+
     if gather_dim == 0:
         # When gather_dim is 0, chunk+cat is a no-op
         return res

--- a/torch/distributed/_functional_collectives.py
+++ b/torch/distributed/_functional_collectives.py
@@ -217,6 +217,10 @@ def all_gather_single(
     """
     group = _resolve_group(group, tag)
     group_size = c10d._get_group_size_by_name(group)
+    # The can_use_view check and _maybe_view_chunk_cat below assume a
+    # non-negative gather_dim.
+    if gather_dim < 0:
+        gather_dim += self.dim()
     tensor = torch.ops._c10d_functional.all_gather_into_tensor(
         self, group_size, _group_or_group_name(group)
     )


### PR DESCRIPTION
Fixes #194856

`_maybe_view_chunk_cat` builds the view target shape with `shape[gather_dim + 1:]`, which wraps around for `gather_dim == -1` (`shape[0:]` re-appends the whole shape), so `all_gather_single(x, gather_dim=-1, ...)` raises `RuntimeError: shape '[...]' is invalid for input of size ...` whenever the view optimization is eligible. The `numel_between` guard (`if gather_dim > 1 else 1`) mis-hands negative dims into the view branch, and `all_gather_single`'s `can_use_view` early-wait heuristic shares the same assumption.

This normalizes negative `gather_dim` once at each entry point:

- `torch/_utils.py::_maybe_view_chunk_cat`: normalize before the `gather_dim == 0` early return, so `gather_dim == -res.dim()` also takes the no-op path.
- `torch/distributed/_functional_collectives.py::all_gather_single`: normalize before the `can_use_view` heuristic so it and the helper see the same canonical dim.

## Tests

- `test/dynamo/test_fake_distributed.py`: two regression tests (`gather_dim=-1` view path and chunk+cat path), alongside the existing `gather_dim` 0/1/2 cases. Both fail without the fix (view `RuntimeError`) and pass with it.
- `test/test_view_ops.py::test_maybe_view_chunk_cat`: three negative-dim configs (view, cat, and no-op cases); the movedim/flatten view-status reference inside `test_config` normalizes the dim first since `flatten(gather_dim, gather_dim + 1)` itself requires a non-negative dim.

Minimal repro from the issue, before/after on stock `torch==2.13.0+cpu`:

```python
from torch._utils import _maybe_view_chunk_cat
_maybe_view_chunk_cat(torch.randn(4, 256), 4, -1)
# before: RuntimeError: shape '[1, 1024, 4, 256]' is invalid for input of size 1024
# after:  torch.Size([1, 1024]), equal to torch.cat(torch.chunk(t, 4, dim=0), dim=-1)
```

Root-cause analysis and this patch were prepared with AI assistance; I reviewed the change and validated the repro and tests locally.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98