### PR TITLE
Make `torch._numpy.arange(start=4)` raise TypeError to match NumPy

### DIFF
--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -457,6 +457,19 @@ class TestPythonArgsToArray(TestCase):
             raise AssertionError(f"Expected w.ndarray, got {type(a)}")
 
 
+class TestArange(TestCase):
+    def test_start_kwarg_requires_stop(self):
+        with self.assertRaisesRegex(
+            TypeError, r"arange\(\) requires stop to be specified"
+        ):
+            w.arange(start=4)
+
+    def test_positional_and_keyword_stop(self):
+        assert_equal(w.arange(4), w.arange(0, 4))
+        assert_equal(w.arange(stop=4), w.arange(4))
+        assert_equal(w.arange(start=1, stop=4), w.arange(1, 4))
+
+
 class TestNormalizations(TestCase):
     """Smoke test generic problems with normalizations."""
 

--- a/torch/_numpy/_funcs.py
+++ b/torch/_numpy/_funcs.py
@@ -1,3 +1,4 @@
+import functools
 import inspect
 import itertools
 from collections.abc import Callable
@@ -37,6 +38,15 @@ for name, func in itertools.chain(
     elif name == "einsum":
         # normalized manually
         decorated = func
+    elif name == "arange":
+        # The impl signature cannot tell arange(4) from arange(start=4).
+        @functools.wraps(func)
+        def arange(*args, _impl=func, **kwargs):
+            if not args and "start" in kwargs and "stop" not in kwargs:
+                raise TypeError("arange() requires stop to be specified.")
+            return _impl(*args, **kwargs)
+
+        decorated = normalizer(arange)
     else:
         decorated = normalizer(func)
 

--- a/torch/_numpy/_funcs_impl.py
+++ b/torch/_numpy/_funcs_impl.py
@@ -393,8 +393,8 @@ def arange(
     if stop is None:
         if start is None:
             raise TypeError
-        # XXX: this breaks if start is passed as a kwarg:
-        # arange(start=4) should raise (no stop) but doesn't
+        # One positional value is stop: arange(4) == arange(0, 4).
+        # arange(start=4) is rejected in _funcs.py before this remapping.
         start, stop = 0, start
     if start is None:
         start = 0


### PR DESCRIPTION
Fixes #194866

`arange(4)` and `arange(start=4)` both bind as `start=4, stop=None` on the impl signature, so the latter was silently rewritten to `arange(0, 4)`. Reject the keyword-only `start=` form at the call boundary, with NumPy's error message.

Drafted with AI assistance; I reviewed the change and the tests.

### Test plan

```bash
python test/torch_np/test_basic.py TestArange
```

Wrapper cases also checked against NumPy 2.2.6: `arange(4)`, `arange(stop=4)`, `arange(start=1, stop=4)` still work; `arange(start=4)` raises.