### PR TITLE
Move expandable_segments() out of the header

### DIFF
--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -13,6 +13,20 @@
 
 namespace c10::cuda::CUDACachingAllocator {
 
+bool CUDAAllocatorConfig::expandable_segments() {
+  bool enabled = c10::CachingAllocator::AcceleratorAllocatorConfig::
+      use_expandable_segments();
+#if !defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
+    (!defined(USE_ROCM) || (ROCM_VERSION < 70000))
+  if (enabled) {
+    TORCH_WARN_ONCE("expandable_segments not supported on this platform")
+  }
+  return false;
+#else
+  return enabled;
+#endif
+}
+
 size_t CUDAAllocatorConfig::parseAllocatorConfig(
     const c10::CachingAllocator::ConfigTokenizer& tokenizer,
     size_t i,

--- a/c10/cuda/CUDAAllocatorConfig.h
+++ b/c10/cuda/CUDAAllocatorConfig.h
@@ -71,19 +71,7 @@ class C10_CUDA_API CUDAAllocatorConfig {
         garbage_collection_threshold();
   }
 
-  static bool expandable_segments() {
-    bool enabled = c10::CachingAllocator::AcceleratorAllocatorConfig::
-        use_expandable_segments();
-#if !defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
-    (!defined(USE_ROCM) || (ROCM_VERSION < 70000))
-    if (enabled) {
-      TORCH_WARN_ONCE("expandable_segments not supported on this platform")
-    }
-    return false;
-#else
-    return enabled;
-#endif
-  }
+  static bool expandable_segments();
 
   static Expandable_Segments_Handle_Type expandable_segments_handle_type() {
     return instance().m_expandable_segments_handle_type;


### PR DESCRIPTION
## Summary
`CUDAAllocatorConfig::expandable_segments()` branches on `PYTORCH_C10_DRIVER_API_SUPPORTED`, which `c10/cuda/CMakeLists.txt` defines `PRIVATE` to `c10_cuda`. Being inline, the function recompiles in every translation unit that includes the header without that macro, so consumers see an unconditional `false` while the library itself sees the real answer. `CUDACachingAllocatorReserveDeviceTest` hits exactly this — it enables `expandable_segments` via `setAllocatorSettings` and asserts on this function, which can never pass from outside `c10_cuda`. Moving the body out of line keeps the macro check in the one TU that has it, without making the macro `PUBLIC`.

## Test plan
```
CC=gcc-15 CXX=g++-15 MAX_JOBS=5 BUILD_TEST=1 pip install -e . -v --no-build-isolation
build/bin/c10_cuda_CUDACachingAllocatorReserveDeviceTest
```

This PR description was drafted with an AI assistant (Claude Code); I've reviewed the change.