### PR TITLE
Inductor: consolidate FNUZ FP8 regression coverage

### DIFF
--- a/test/inductor/test_codegen_triton.py
+++ b/test/inductor/test_codegen_triton.py
@@ -1030,27 +1030,6 @@ def helper(x):
                     triton_utils.signature_of(fnuz_arg, size_dtype=None), "*u8"
                 )
 
-    def test_fnuz_to_dtype_uses_software_decoder(self):
-        class FakeGraph:
-            def get_current_device_or_throw(self):
-                return torch.device("cuda")
-
-        class FakeKernel:
-            min_elem_per_thread = 0
-
-        with (
-            V.set_graph_handler(FakeGraph()),
-            V.set_kernel_handler(FakeKernel()),
-            patch(
-                "torch._inductor.codegen.triton.use_uint8_triton_storage_for_cuda_fp8",
-                return_value=True,
-            ),
-        ):
-            code = TritonKernelOverrides.to_dtype(
-                "x", torch.bfloat16, torch.float8_e4m3fnuz
-            )
-        self.assertIn("triton_helpers.fp8e4m3fnuz_to_float32(x)", code)
-
     @inductor_config.patch("_use_fp64_for_unbacked_floats", True)
     @patch(
         "torch._inductor.codegen.triton_utils.device_supports_fp64",

--- a/test/inductor/test_fp8.py
+++ b/test/inductor/test_fp8.py
@@ -315,7 +315,8 @@ class TestFP8Types(TestCase):
     @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
     def test_cuda_unsupported_fp8_dequant_codegen(self, device, src_dtype):
         def fp8_dequant_add(x, y):
-            return x.to(torch.bfloat16) + y
+            value = x.to(torch.bfloat16)
+            return value + y, torch.isnan(value).int()
 
         bits = torch.arange(256, device=device, dtype=torch.uint8)
         x = bits.view(src_dtype)
@@ -465,54 +466,6 @@ class TestFP8Types(TestCase):
     @skipIfRocm
     @onlyCUDA
     @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
-    def test_cuda_unsupported_fp8_dequant_pointwise_chain_codegen(
-        self, device, src_dtype
-    ):
-        def fp8_dequant_pointwise_chain(x):
-            value = x.float()
-            return (
-                value.abs().half(),
-                value.clamp(-1, 1).bfloat16(),
-                torch.isnan(value),
-                torch.signbit(value),
-                torch.nan_to_num(value),
-                torch.isnan(value).int(),
-            )
-
-        bits = torch.arange(256, device=device, dtype=torch.uint8)
-        x = bits.view(src_dtype)
-        expected = fp8_dequant_pointwise_chain(x)
-        actual, code = run_and_get_code(
-            torch.compile(
-                fp8_dequant_pointwise_chain,
-                backend="inductor",
-                fullgraph=True,
-            ),
-            x,
-        )
-        source = "\n".join(code)
-        for actual_output, expected_output in zip(actual[:2], expected[:2]):
-            torch.testing.assert_close(
-                actual_output,
-                expected_output,
-                rtol=0,
-                atol=0,
-                equal_nan=True,
-            )
-        for actual_output, expected_output in zip(actual[2:], expected[2:]):
-            self.assertEqual(actual_output, expected_output)
-        helper = {
-            torch.float8_e4m3fnuz: "fp8e4m3fnuz_to_float32",
-            torch.float8_e5m2fnuz: "fp8e5m2fnuz_to_float32",
-        }[src_dtype]
-        self.assertIn(f"triton_helpers.{helper}", source)
-        self.assertNotIn("= torch.ops.prims.convert_element_type.default(", source)
-        self.assertEqual(source.count("async_compile.triton("), 1)
-
-    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA + Triton")
-    @skipIfRocm
-    @onlyCUDA
-    @parametrize("src_dtype", (torch.float8_e4m3fnuz, torch.float8_e5m2fnuz))
     def test_cuda_unsupported_fp8_dequant_non_float_users_fall_back(
         self, device, src_dtype
     ):
@@ -520,25 +473,23 @@ class TestFP8Types(TestCase):
             value = x.float()
             return value.long(), (value + 1).int()
 
-        for size in (1, 8, 256):
-            with self.subTest(size=size):
-                bits = torch.full((size,), 0x80, device=device, dtype=torch.uint8)
-                x = bits.view(src_dtype)
-                expected = fp8_dequant_integral_casts(x)
-                actual, code = run_and_get_code(
-                    torch.compile(
-                        fp8_dequant_integral_casts,
-                        backend="inductor",
-                        fullgraph=True,
-                    ),
-                    x,
-                )
-                source = "\n".join(code)
+        bits = torch.full((8,), 0x80, device=device, dtype=torch.uint8)
+        x = bits.view(src_dtype)
+        expected = fp8_dequant_integral_casts(x)
+        actual, code = run_and_get_code(
+            torch.compile(
+                fp8_dequant_integral_casts,
+                backend="inductor",
+                fullgraph=True,
+            ),
+            x,
+        )
+        source = "\n".join(code)
 
-                self.assertEqual(actual, expected)
-                self.assertIn("torch.ops.prims.convert_element_type.default", source)
-                self.assertNotIn("fnuz_to_float32", source)
-                self.assertNotIn("'*u8'", source)
+        self.assertEqual(actual, expected)
+        self.assertIn("torch.ops.prims.convert_element_type.default", source)
+        self.assertNotIn("fnuz_to_float32", source)
+        self.assertNotIn("'*u8'", source)
 
         def fp8_dequant_copy(x):
             return torch.empty(x.shape, device=x.device, dtype=torch.int64).copy_(
@@ -551,8 +502,6 @@ class TestFP8Types(TestCase):
                 dst, x.float(), dim=0, start=1, end=x.numel() + 1
             )
 
-        bits = torch.full((8,), 0x80, device=device, dtype=torch.uint8)
-        x = bits.view(src_dtype)
         for op in (fp8_dequant_copy, fp8_dequant_slice_scatter):
             with self.subTest(op=op):
                 expected = op(x)
@@ -594,12 +543,6 @@ class TestFP8Types(TestCase):
         def fp8_equal(x):
             return x == x
 
-        def to_bool(x):
-            return x.to(torch.bool)
-
-        def to_int32(x):
-            return x.to(torch.int32)
-
         def to_int64(x):
             return x.to(torch.int64)
 
@@ -609,8 +552,6 @@ class TestFP8Types(TestCase):
         ops_and_fallbacks = (
             (fp8_equal, "torch.ops.aten.eq.Tensor"),
             (torch.isnan, "torch.ops.aten.isnan.default"),
-            (to_bool, "torch.ops.prims.convert_element_type.default"),
-            (to_int32, "torch.ops.prims.convert_element_type.default"),
             (to_int64, "torch.ops.prims.convert_element_type.default"),
         )
         for op, fallback in ops_and_fallbacks:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2832,6 +2832,7 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
     if t.is_sparse:
         return True
 
+    # Keep these checks here because they are specific to Inductor/Triton.
     if not is_triton_fp8_dtype_supported(t.dtype, t.device):
         from .codegen.triton_utils import use_uint8_triton_storage_for_cuda_fp8
 
@@ -2858,10 +2859,6 @@ def unsupported_input_tensor(t: torch.Tensor, node=None):
             return False
         if node.target == prims.convert_element_type.default:
             if t.dtype == torch.float8_e4m3fn:
-                # Preserve the existing precursor behavior. Its decoder
-                # constructs E4M3FN NaNs from explicit signed bit patterns,
-                # and direct integral casts retain eager-compatible results.
-                # FNUZ's unique 0x80 NaN does not have that property.
                 return False
             dst_dtype = (
                 node.args[1] if len(node.args) >= 2 else node.kwargs.get("dtype")


### PR DESCRIPTION
Follow-up to #192786.

## Summary

#192786 adds CUDA FNUZ dequantization fusion and its regression coverage. This follow-up removes overlapping tests while preserving each distinct correctness and code-generation contract.

It folds the boolean-predicate path into the target fusion test, removes duplicate helper and pointwise-chain coverage, uses one representative tensor size for integral fallback, and keeps one direct `int64` conversion case. Exhaustive decoding, pointer signatures, masked block-pointer and tensor-descriptor loads, implicit copy/scatter casts, higher-order boundaries, and missing metadata remain covered.

The FP8 capability checks stay in Inductor because they describe Inductor/Triton limitations and must not constrain other Dynamo backends.

The net change is 83 fewer lines and fewer GPU compilations. Runtime behavior does not change.

## Validation

- `TestFP8Types.test_cuda_unsupported_fp8_dequant_codegen`
- `TestFP8Types.test_cuda_unsupported_fp8_dequant_all_encodings`
- `TestFP8Types.test_cuda_unsupported_fp8_dequant_non_float_users_fall_back`
- `TestFP8Types.test_cuda_unsupported_fp8_ops_fall_back`
- `TestFP8Types.test_fnuz_conversion_missing_metadata_falls_back`
- `TestFP8Types.test_float8_e4m3fn_uint8_decode_codegen`
- `TestFP8Types.test_float8_e4m3fn_uint8_storage_arithmetic_falls_back`
- `TestCodegenTriton.test_signature_of_unsupported_cuda_fp8_uses_uint8_inputs`

## BC

No public API or runtime behavior changes.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo