### PR TITLE
Use c10::fmap for container-to-vector transforms

### DIFF
--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -8,6 +8,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 //
 
+#include <ATen/core/functional.h>
 #include <ATen/cuda/CUDAContextLight.h>
 #include <ATen/cuda/tunable/Tunable.h>
 #include <c10/util/Exception.h>
@@ -504,10 +505,8 @@ static bool CheckKeysMatching(
     const TuningResultsValidator::GetValidateFuncs& gv_funcs,
     const std::unordered_map<std::string, std::string>& to_check) {
   auto get_keys = [](const auto& it) -> std::string { return it.first; };
-  std::vector<std::string> required_keys;
-  std::vector<std::string> provided_keys;
-  std::transform(gv_funcs.cbegin(), gv_funcs.cend(), std::back_inserter(required_keys), get_keys);
-  std::transform(to_check.cbegin(), to_check.cend(), std::back_inserter(provided_keys), get_keys);
+  std::vector<std::string> required_keys = c10::fmap(gv_funcs, get_keys);
+  std::vector<std::string> provided_keys = c10::fmap(to_check, get_keys);
   std::sort(required_keys.begin(), required_keys.end());
   std::sort(provided_keys.begin(), provided_keys.end());
 

--- a/torch/csrc/autograd/custom_function.h
+++ b/torch/csrc/autograd/custom_function.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
 #include <c10/core/SymInt.h>
 #include <c10/util/flat_hash_map.h>
@@ -452,13 +453,8 @@ inline void extract_vars(
 template <typename T>
 std::enable_if_t<std::is_same_v<T, variable_list>, T> to_output_type(
     std::vector<std::optional<Variable>>& output_list) {
-  variable_list result;
-  std::transform(
-      output_list.begin(),
-      output_list.end(),
-      std::back_inserter(result),
-      [](const std::optional<Variable>& var) { return *var; });
-  return result;
+  return c10::fmap(
+      output_list, [](const std::optional<Variable>& var) { return *var; });
 }
 
 template <typename T>
@@ -472,13 +468,7 @@ inline std::vector<std::optional<Variable>> to_optional(Variable& output) {
 }
 
 inline std::vector<std::optional<Variable>> to_optional(variable_list& output) {
-  std::vector<std::optional<Variable>> result;
-  std::transform(
-      output.begin(),
-      output.end(),
-      std::back_inserter(result),
-      [](const Variable& var) { return var; });
-  return result;
+  return c10::fmap<std::optional<Variable>>(output);
 }
 
 template <class T>

--- a/torch/csrc/autograd/init.cpp
+++ b/torch/csrc/autograd/init.cpp
@@ -1,3 +1,4 @@
+#include <ATen/core/functional.h>
 #include <torch/csrc/python_headers.h>
 
 #include <ATen/NodeCreationHooks.h>
@@ -262,15 +263,9 @@ PyObject* THPAutograd_initExtension(PyObject* _unused, PyObject* unused) {
       .def(
           "concrete_inputs",
           [](const KinetoEvent& e) {
-            std::vector<py::object> as_pyobj;
-            std::transform(
-                e.concreteInputs().begin(),
-                e.concreteInputs().end(),
-                std::back_inserter(as_pyobj),
-                [](const c10::IValue& val) {
-                  return torch::jit::toPyObject(val);
-                });
-            return as_pyobj;
+            return c10::fmap(e.concreteInputs(), [](const c10::IValue& val) {
+              return torch::jit::toPyObject(val);
+            });
           })
       .def(
           "kwinputs",

--- a/torch/csrc/dynamo/compiled_autograd.h
+++ b/torch/csrc/dynamo/compiled_autograd.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <ATen/TensorGeometry.h>
+#include <ATen/core/functional.h>
 #include <ATen/core/ivalue.h>
 #include <c10/core/impl/TorchDispatchModeTLS.h>
 #include <c10/util/flat_hash_map.h>
@@ -462,12 +463,8 @@ class CompiledNodeArgs {
   void collect(const ska::flat_hash_map<std::string, V>& m) {
     collect_size(m.size());
 
-    std::vector<std::string> keys;
-    keys.reserve(m.size());
-    std::transform(
-        m.begin(), m.end(), std::back_inserter(keys), [](const auto& entry) {
-          return entry.first;
-        });
+    std::vector<std::string> keys =
+        c10::fmap(m, [](const auto& entry) { return entry.first; });
     std::sort(keys.begin(), keys.end());
     for (const auto& k : keys) {
       collect(k);
@@ -965,12 +962,8 @@ class SwapSavedVariables {
 
   template <typename V>
   void before(ska::flat_hash_map<std::string, V>& m) {
-    std::vector<std::string> keys;
-    keys.reserve(m.size());
-    std::transform(
-        m.begin(), m.end(), std::back_inserter(keys), [](const auto& entry) {
-          return entry.first;
-        });
+    std::vector<std::string> keys =
+        c10::fmap(m, [](const auto& entry) { return entry.first; });
     std::sort(keys.begin(), keys.end());
     for (auto& k : keys) {
       before(m.at(k));

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -1,5 +1,6 @@
 #include <ATen/PythonTorchFunctionTLS.h>
 #include <ATen/autocast_mode.h>
+#include <ATen/core/functional.h>
 #include <c10/core/SafePyObject.h>
 #include <c10/core/impl/PyInterpreter.h>
 #include <c10/util/Exception.h>
@@ -1655,10 +1656,8 @@ class StorageOverlapChecker {
     if (_expected_overlapping == _overlapping.size() &&
         _expected_non_overlapping == _non_overlapping.size()) {
       // Transform each list of PyObject* into an actual list of Tensors.
-      auto overlapping_tensors =
-          _tensors_from(_overlapping, _expected_overlapping);
-      auto non_overlapping_tensors =
-          _tensors_from(_non_overlapping, _expected_non_overlapping);
+      auto overlapping_tensors = _tensors_from(_overlapping);
+      auto non_overlapping_tensors = _tensors_from(_non_overlapping);
       return check_overlapping(overlapping_tensors, non_overlapping_tensors);
     } else {
       // If we haven't collected them all yet, keep on running.
@@ -1678,16 +1677,9 @@ class StorageOverlapChecker {
   /**
    * Transforms a given list of PyObject* into a list of Tensor.
    */
-  std::vector<Tensor> _tensors_from(
-      const std::vector<PyObject*>& objects,
-      size_t size) {
-    std::vector<Tensor> tensors;
-    tensors.reserve(size);
-    std::ranges::transform(
-        objects, std::back_inserter(tensors), [](PyObject* obj) {
-          return THPVariable_Unpack(obj);
-        });
-    return tensors;
+  std::vector<Tensor> _tensors_from(const std::vector<PyObject*>& objects) {
+    return c10::fmap(
+        objects, [](PyObject* obj) { return THPVariable_Unpack(obj); });
   }
 
   // Expected number of possibly overlapping tensors.

--- a/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
+++ b/torch/csrc/inductor/aoti_eager/kernel_meta_info.cpp
@@ -1,4 +1,5 @@
 #if !defined(C10_MOBILE) && !defined(ANDROID)
+#include <ATen/core/functional.h>
 #include <c10/util/irange.h>
 #include <torch/csrc/inductor/aoti_eager/kernel_meta_info.h>
 #include <iostream>
@@ -37,18 +38,8 @@ TensorMetadata::TensorMetadata(
 void TensorMetadata::build_guard(const torch::dynamo::LocalState& local_state) {
   TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
       !is_symbolic_, "Not support symbolic shape now");
-  std::vector<std::optional<c10::SymInt>> sym_sizes;
-  std::vector<std::optional<c10::SymInt>> sym_strides;
-  std::transform(
-      sizes_.begin(),
-      sizes_.end(),
-      std::back_inserter(sym_sizes),
-      [](int64_t size) { return std::optional<c10::SymInt>(size); });
-  std::transform(
-      strides_.begin(),
-      strides_.end(),
-      std::back_inserter(sym_strides),
-      [](int64_t stride) { return std::optional<c10::SymInt>(stride); });
+  auto sym_sizes = c10::fmap<std::optional<c10::SymInt>>(sizes_);
+  auto sym_strides = c10::fmap<std::optional<c10::SymInt>>(strides_);
   tensor_check_ = torch::dynamo::TensorCheck(
       local_state,
       nullptr,


### PR DESCRIPTION
## Summary
Ten call sites built a vector with `std::transform` + `back_inserter` where `c10::fmap` already expresses that and reserves up front. Dropped the now-unused `size` parameter from `StorageOverlapChecker::_tensors_from` after removing its manual reserve. Left alone: a sub-range transform in `pybind_utils.cpp`, since `fmap` can't express a mid-container range.

## Test plan
```
lintrunner -a $(git diff --name-only)
python3 scripts/codeowners/check_taxonomy.py
```

This PR description was drafted with an AI assistant (Claude Code); I've reviewed the change.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk