### PR TITLE
Fix Triton codegen for neg to preserve signed zero

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19790,6 +19790,23 @@ if RUN_GPU or HAS_MPS:
         device = GPU_TYPE
 
         @requires_cuda_and_triton
+        def test_atan2_signed_zero(self):
+            # Regression for https://github.com/pytorch/pytorch/issues/185696
+            # Triton's fneg drops the sign of -0.0, so atan2(x, -x) returned 0
+            # instead of +/-pi when x was a signed zero.
+            tiny = 5.960464477539063e-08
+
+            def fn(x):
+                return torch.atan2(x, -x)
+
+            for dtype in (torch.float16, torch.bfloat16, torch.float32):
+                with self.subTest(dtype=dtype):
+                    x = torch.tensor(
+                        [0.0, tiny, -tiny], device=self.device, dtype=dtype
+                    )
+                    self.common(fn, (x,), check_lowp=False)
+
+        @requires_cuda_and_triton
         def test_noncontiguous_reshape_cat_backward(self):
             # Cross the 1024-element padding threshold with a non-aligned width.
             width = 342

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -1432,6 +1432,19 @@ class TritonOverrides(OpOverrides):
         return out
 
     @staticmethod
+    def neg(x):
+        # Triton's unary minus lowers to fneg, which drops the sign of -0.0.
+        # Multiplying by -1.0 preserves signed zero for floating-point dtypes
+        # while keeping integer negation as the original unary minus.
+        if (
+            isinstance(x, CSEVariable)
+            and x.dtype is not None
+            and x.dtype.is_floating_point
+        ):
+            return f"({x} * (-1.0))"
+        return f"-{x}"
+
+    @staticmethod
     def _shaped_constant(value, dtype, shape):
         type_ = torch._prims_common.dtype_to_type(dtype)
         triton_val = constant_repr(type_(value))


### PR DESCRIPTION
Fixes #185696

### Problem
Triton's unary minus lowers to LLVM `fneg`, which drops the sign of `-0.0`. This breaks any `torch.compile` kernel that depends on signed-zero semantics. A minimal example is `torch.atan2(x, -x)` returning `0` instead of `+/-pi` when `x` is a signed zero.

### Fix
Override `TritonOverrides.neg` to multiply floating-point inputs by `-1.0` instead of emitting unary minus. Integer negation is kept as the original unary minus.

### Test
Added `test_atan2_signed_zero` in `test/inductor/test_torchinductor.py` covering fp16, bf16, and fp32.

### Verification
Ran the repro below on a single H100 (CUDA 12.7, torch 2.6+cu124):
```python
import torch

def f(x):
    return torch.atan2(x, -x)

for dtype in [torch.float16, torch.bfloat16, torch.float32]:
    x = torch.tensor(
        [0.0, 5.960464477539063e-08, -5.960464477539063e-08],
        device="cuda",
        dtype=dtype,
    )
    assert torch.equal(f(x), torch.compile(f)(x))
```
All three dtypes pass.

This PR was prepared with assistance from an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo