### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_fx_xform_observer.py

### DIFF
--- a/test/fx/test_fx_xform_observer.py
+++ b/test/fx/test_fx_xform_observer.py
@@ -8,10 +8,12 @@ import torch
 from torch.fx import subgraph_rewriter, symbolic_trace
 from torch.fx.passes.graph_transform_observer import GraphTransformObserver
 from torch.fx.traceback import NodeSourceAction
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class TestGraphTransformObserver(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_graph_transform_observer(self):
         class M(torch.nn.Module):
             def forward(self, x):


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestGraphTransformObserver and import HardwareClassification from common_utils, enabling per-hardware-backend test selection via --hw-classification.

## Changes
test/fx/test_fx_xform_observer.py: import HardwareClassification; add hw_classification (GENERIC on TestGraphTransformObserver).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering. The FX xform observer tests (test_graph_transform_observer, test_graph_transform_observer_deepcopy, test_graph_transform_observer_node_tracking, test_graph_transform_observer_replace) exercise GraphTransformObserver / subgraph_rewriter provenance logic with no device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_fx_xform_observer.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.