### PR TITLE
Bind the generated grad_fn loop variable by reference

### DIFF
--- a/tools/autograd/gen_variable_type.py
+++ b/tools/autograd/gen_variable_type.py
@@ -733,7 +733,7 @@ LOOP_OVER_VECTOR_OF_GRAD_FNS = CodeTemplate(
 if (!grad_fns.empty()) {
     ${preamble}
     for (const auto& i : c10::irange(grad_fns.size())) {
-        auto grad_fn = grad_fns[i];
+        const auto& grad_fn = grad_fns[i];
         if (grad_fn != nullptr) {
             ${statements}
         }


### PR DESCRIPTION
## Summary
`LOOP_OVER_VECTOR_OF_GRAD_FNS` copied an `intrusive_ptr` out of the vector every iteration -- an atomic inc/dec for a handle the body only reads through, since the vector still owns it. Binding by `const` reference removes that pair from all ~128 generated call sites. Safe since `intrusive_ptr`'s constness is shallow (`operator->` returns non-`const`) and nothing in the loop rebinds `grad_fn`.

## Test plan
```
lintrunner -a tools/autograd/gen_variable_type.py
```

This PR description was drafted with an AI assistant (Claude Code); I've reviewed the change.