### PR TITLE
[Test] Make `functorch/test_aot_joint_with_descriptors.py` tests device-generic and enable testing XPU.

### DIFF
--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -38,8 +38,12 @@ from torch._functorch.aot_autograd import (
 )
 from torch._guards import tracing, TracingContext
 from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+from torch.testing._internal.common_device_type import (
+    instantiate_device_type_tests,
+    onlyAccelerator,
+)
 from torch.testing._internal.common_utils import (
-    requires_cuda,
+    HardwareClassification,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
@@ -66,6 +70,8 @@ def graph_capture(model, inputs, with_export):
 
 
 class TestAOTJointWithDescriptors(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_simple_linear_module(self):
         """Test basic linear module with aot_export_joint_with_descriptors"""
 
@@ -829,111 +835,6 @@ class inner_f(torch.nn.Module):
 ('call_function', 't_3', {'pp_stage': 0})""",
             )
 
-    @requires_cuda
-    def test_preserve_annotate_flex_attention(self):
-        def score_mod(score, b, h, m, n):
-            return score
-
-        def _get_block_causal_mask_mod(seq_idx):
-            def block_causal_mask(b, h, q_idx, kv_idx):
-                # must use this more complicated mask_mod so autograd seq_nr increases
-                return (seq_idx[b, q_idx] == seq_idx[b, kv_idx]) & (q_idx >= kv_idx)
-
-            return block_causal_mask
-
-        a = 12
-        b = 24
-        batch_size = 2
-        seqlen = a * b
-        device = "cuda"
-
-        # Create seq_idx tensor - maps each position to a document/sequence ID
-        # Example: Split sequence into 2 documents for each batch
-        # First half (0:384) belongs to document 0, second half (384:768) to document 1
-        seq_idx = torch.zeros(batch_size, seqlen, dtype=torch.int32, device=device)
-        seq_idx[:, seqlen // 2 :] = 1  # Second half belongs to document 1
-
-        # Get the mask_mod function with seq_idx captured in closure
-        mask_mod = _get_block_causal_mask_mod(seq_idx)
-
-        # Create block_mask with the mask_mod function (which only takes 4 args)
-        # Note: We don't compile create_block_mask itself, just flex_attention
-        block_mask = create_block_mask(mask_mod, None, None, seqlen, seqlen)
-
-        class FlexAttentionModule(torch.nn.Module):
-            """Flex attention submodule similar to the sdpa in Llama3 Attention"""
-
-            def forward(self, xq, xk, xv):
-                """
-                Args:
-                    xq: Query tensor (bs, n_heads, seqlen, head_dim)
-                    xk: Key tensor (bs, n_heads, seqlen, head_dim)
-                    xv: Value tensor (bs, n_heads, seqlen, head_dim)
-                Returns:
-                    Output tensor (bs, n_heads, seqlen, head_dim)
-                """
-                with fx_traceback.annotate({"compile_with_inductor": "flex_attention"}):
-                    output = flex_attention(
-                        xq, xk, xv, block_mask=block_mask, score_mod=score_mod
-                    )
-                return output
-
-        # Model configuration
-        n_heads = 4
-        head_dim = 64
-
-        # Create input tensors in the shape expected by FlexAttentionModule
-        # Shape: (bs, n_heads, seqlen, head_dim)
-        xq = torch.randn(
-            batch_size, n_heads, seqlen, head_dim, requires_grad=True, device=device
-        )
-        xk = torch.randn(
-            batch_size, n_heads, seqlen, head_dim, requires_grad=True, device=device
-        )
-        xv = torch.randn(
-            batch_size, n_heads, seqlen, head_dim, requires_grad=True, device=device
-        )
-
-        model = FlexAttentionModule().to(device)
-        inputs = (xq, xk, xv)
-
-        gm = graph_capture(model, inputs, with_export=True)
-
-        custom_metadata = fx_traceback._get_custom_metadata(gm)
-
-        # not using assertExpectedInline because some CI runs has fewer detach nodes in graph
-        # than other CI runs, so we can't use a fixed string to compare against
-
-        self.assertTrue(
-            "('get_attr', 'sdpa_score0', {'compile_with_inductor': 'flex_attention'})"
-            in custom_metadata
-        )
-        self.assertTrue(
-            "('get_attr', 'sdpa_mask0', {'compile_with_inductor': 'flex_attention'})"
-            in custom_metadata
-        )
-        self.assertTrue(
-            "('call_function', 'flex_attention', {'compile_with_inductor': 'flex_attention'})"
-            in custom_metadata
-        )
-
-        self.assertTrue(
-            "('get_attr', 'fw_graph0', {'compile_with_inductor': 'flex_attention'})"
-            in custom_metadata
-        )
-        self.assertTrue(
-            "('get_attr', 'joint_graph0', {'compile_with_inductor': 'flex_attention'})"
-            in custom_metadata
-        )
-        self.assertTrue(
-            "('get_attr', 'mask_graph0', {'compile_with_inductor': 'flex_attention'})"
-            in custom_metadata
-        )
-        self.assertTrue(
-            "('call_function', 'flex_attention_backward', {'compile_with_inductor': 'flex_attention'})"
-            in custom_metadata
-        )
-
     def test_preserve_annotate_function(self):
         """Test basic annotate_fn usage"""
 
@@ -1342,6 +1243,119 @@ class inner_f(torch.nn.Module):
 ('call_function', 'invoke_subgraph_1', {'call_id': 1, 'mod_name': 'my_mod'})
 ('call_function', 'getitem_1', {'mod_name': 'my_mod'})""",
         )
+
+
+class TestAOTJointWithDescriptorsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @onlyAccelerator
+    def test_preserve_annotate_flex_attention(self, device):
+        def score_mod(score, b, h, m, n):
+            return score
+
+        def _get_block_causal_mask_mod(seq_idx):
+            def block_causal_mask(b, h, q_idx, kv_idx):
+                # must use this more complicated mask_mod so autograd seq_nr increases
+                return (seq_idx[b, q_idx] == seq_idx[b, kv_idx]) & (q_idx >= kv_idx)
+
+            return block_causal_mask
+
+        a = 12
+        b = 24
+        batch_size = 2
+        seqlen = a * b
+
+        # Create seq_idx tensor - maps each position to a document/sequence ID
+        # Example: Split sequence into 2 documents for each batch
+        # First half (0:384) belongs to document 0, second half (384:768) to document 1
+        seq_idx = torch.zeros(batch_size, seqlen, dtype=torch.int32, device=device)
+        seq_idx[:, seqlen // 2 :] = 1  # Second half belongs to document 1
+
+        # Get the mask_mod function with seq_idx captured in closure
+        mask_mod = _get_block_causal_mask_mod(seq_idx)
+
+        # Create block_mask with the mask_mod function (which only takes 4 args)
+        # Note: We don't compile create_block_mask itself, just flex_attention
+        block_mask = create_block_mask(mask_mod, None, None, seqlen, seqlen)
+
+        class FlexAttentionModule(torch.nn.Module):
+            """Flex attention submodule similar to the sdpa in Llama3 Attention"""
+
+            def forward(self, xq, xk, xv):
+                """
+                Args:
+                    xq: Query tensor (bs, n_heads, seqlen, head_dim)
+                    xk: Key tensor (bs, n_heads, seqlen, head_dim)
+                    xv: Value tensor (bs, n_heads, seqlen, head_dim)
+                Returns:
+                    Output tensor (bs, n_heads, seqlen, head_dim)
+                """
+                with fx_traceback.annotate({"compile_with_inductor": "flex_attention"}):
+                    output = flex_attention(
+                        xq, xk, xv, block_mask=block_mask, score_mod=score_mod
+                    )
+                return output
+
+        # Model configuration
+        n_heads = 4
+        head_dim = 64
+
+        # Create input tensors in the shape expected by FlexAttentionModule
+        # Shape: (bs, n_heads, seqlen, head_dim)
+        xq = torch.randn(
+            batch_size, n_heads, seqlen, head_dim, requires_grad=True, device=device
+        )
+        xk = torch.randn(
+            batch_size, n_heads, seqlen, head_dim, requires_grad=True, device=device
+        )
+        xv = torch.randn(
+            batch_size, n_heads, seqlen, head_dim, requires_grad=True, device=device
+        )
+
+        model = FlexAttentionModule().to(device)
+        inputs = (xq, xk, xv)
+
+        gm = graph_capture(model, inputs, with_export=True)
+
+        custom_metadata = fx_traceback._get_custom_metadata(gm)
+
+        # not using assertExpectedInline because some CI runs has fewer detach nodes in graph
+        # than other CI runs, so we can't use a fixed string to compare against
+
+        self.assertTrue(
+            "('get_attr', 'sdpa_score0', {'compile_with_inductor': 'flex_attention'})"
+            in custom_metadata
+        )
+        self.assertTrue(
+            "('get_attr', 'sdpa_mask0', {'compile_with_inductor': 'flex_attention'})"
+            in custom_metadata
+        )
+        self.assertTrue(
+            "('call_function', 'flex_attention', {'compile_with_inductor': 'flex_attention'})"
+            in custom_metadata
+        )
+
+        self.assertTrue(
+            "('get_attr', 'fw_graph0', {'compile_with_inductor': 'flex_attention'})"
+            in custom_metadata
+        )
+        self.assertTrue(
+            "('get_attr', 'joint_graph0', {'compile_with_inductor': 'flex_attention'})"
+            in custom_metadata
+        )
+        self.assertTrue(
+            "('get_attr', 'mask_graph0', {'compile_with_inductor': 'flex_attention'})"
+            in custom_metadata
+        )
+        self.assertTrue(
+            "('call_function', 'flex_attention_backward', {'compile_with_inductor': 'flex_attention'})"
+            in custom_metadata
+        )
+
+
+instantiate_device_type_tests(
+    TestAOTJointWithDescriptorsDevice, globals(), only_for=("cuda",)
+)
 
 
 if __name__ == "__main__":

--- a/test/functorch/test_aot_joint_with_descriptors.py
+++ b/test/functorch/test_aot_joint_with_descriptors.py
@@ -1354,7 +1354,10 @@ class TestAOTJointWithDescriptorsDevice(TestCase):
 
 
 instantiate_device_type_tests(
-    TestAOTJointWithDescriptorsDevice, globals(), only_for=("cuda",)
+    TestAOTJointWithDescriptorsDevice,
+    globals(),
+    only_for=("cuda", "xpu"),
+    allow_xpu=True,
 )
 
 


### PR DESCRIPTION
This PR refactors `functorch/test_aot_joint_with_descriptors.py` test file to separate device-related tests from device-unrelated ones and enables testing XPU.

###  Changes

- Extract device-related `test_preserve_annotate_flex_attention` from `TestAOTJointWithDescriptors` into `TestAOTJointWithDescriptorsDevice`.
- Instantiate newly extracted `TestAOTJointWithDescriptorsDevice` with `instantiate_device_type_tests`.
- Use generic `device` parameter instead of hardcoded `"cuda"` device.
- Mark `test_preserve_annotate_flex_attention` as `@onlyAccelerator` as it was previously launched only on CUDA device and doesn't work for CPU.
- Remove `@requires_cuda` decorator as it is no longer needed when we use `instantiate_device_type_tests`.
- Add `HardwareClassification` to all test classes in the refactored file.
- Enable testing XPU.