### PR TITLE
Fix path in find_library_location for libs in pytorch/build/lib

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -5919,6 +5919,9 @@ def find_library_location(lib_name: str) -> Path:
     if os.path.exists(path):
         return path
     torch_root = Path(__file__).resolve().parents[2]
+    path = torch_root.parent / 'build' / 'lib' / lib_name
+    if os.path.exists(path):
+        return path
     return torch_root / 'build' / 'lib' / lib_name
 
 def skip_but_pass_in_sandcastle(reason):


### PR DESCRIPTION
Fixes issues found in https://github.com/intel/torch-xpu-ops/issues/4436

Affected XPU Cases:
```
export/test_converter_xpu.py
export/test_draft_export_xpu.py
export/test_export_xpu.py
export/test_passes_xpu.py
export/test_serialize_xpu.py
export/test_torchbind_xpu.py
functorch/test_control_flow_xpu.py
higher_order_ops/test_with_effects_xpu.py
test_fx_xpu.py
```

Currently, `find_library_location()` for `libtorchbind_test.so` resolves to:
_pytorch/torch/build/lib/libtorchbind_test.so_
but the actual built library is here:
_pytorch/build/lib/libtorchbind_test.so_

The issue was caused by copying these test cases for XPU here: https://github.com/intel/torch-xpu-ops/pull/3309
But it only exposed old issue introduced to `find_library_location()` here: https://github.com/pytorch/pytorch/pull/61960
