### PR TITLE
[Inductor] Retain default reduction config in max autotune

### DIFF
--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -269,6 +269,7 @@ class TestTritonHeuristics(TestCase):
 
         default_keys = [triton_config_to_hashable(c) for c in default_configs]
         max_autotune_keys = [triton_config_to_hashable(c) for c in max_autotune_configs]
+        self.assertTrue(max_autotune_configs)
         self.assertEqual(max_autotune_keys, default_keys)
         self.assertTrue(all("YBLOCK" in c.kwargs for c in max_autotune_configs))
 
@@ -334,8 +335,8 @@ class TestTritonHeuristics(TestCase):
             type="hip",
             index=0,
             multi_processor_count=1,
-            cc="gfx942",
-            major=None,
+            cc=80,
+            major=8,
             regs_per_multiprocessor=65536,
             max_threads_per_multi_processor=2048,
             max_threads_per_block=1024,

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -36,7 +36,10 @@ except ImportError:
     raise unittest.SkipTest("requires triton")  # noqa: B904
 
 from torch._inductor import config
-from torch._inductor.heuristics.triton_codegen.reduction import ROCmReductionHeuristic
+from torch._inductor.heuristics.triton_codegen.reduction import (
+    ROCmReductionHeuristic,
+    XPUReductionHeuristic,
+)
 from torch._inductor.runtime.hints import (
     AttrsDescriptorWrapper,
     AutotuneHint,
@@ -212,27 +215,55 @@ class TestTritonHeuristics(TestCase):
         with self.assertRaisesRegex(AssertionError, "exceeds Triton maximum"):
             make_matmul_triton_config({"x": 256, "y": 128, "r": 64}, 8, 1)
 
-    @parametrize("rnumel", [256, 1024])
     @parametrize(
-        "reduction_hint,rsplit_size",
+        "xnumel,rnumel,reduction_hint,rsplit_size,expected_max_configs",
         [
-            (ReductionHint.INNER, None),
-            (ReductionHint.INNER, 128),
-            (ReductionHint.OUTER, None),
-            (ReductionHint.OUTER_TINY, None),
+            (2048, 128, ReductionHint.INNER, None, [(1, 2), (8, 2), (32, 2)]),
+            (2048, 128, ReductionHint.OUTER, None, [(32, 8), (1, 2), (8, 8)]),
+            (
+                2048,
+                128,
+                ReductionHint.OUTER_TINY,
+                None,
+                [(4, 4), (1, 2), (8, 8), (32, 8)],
+            ),
+            (512, 256, ReductionHint.INNER, None, [(1, 2), (8, 2)]),
+            (1024, 256, ReductionHint.INNER, None, [(4, 1), (1, 2), (8, 2)]),
+            (2048, 256, ReductionHint.DEFAULT, None, [(1, 2), (8, 8)]),
+            (2048, 256, ReductionHint.INNER, None, [(4, 1), (1, 2), (8, 2)]),
+            (2048, 256, ReductionHint.INNER, 128, [(1, 2), (8, 2)]),
+            (2048, 256, ReductionHint.OUTER, None, [(8, 8), (1, 2)]),
+            (
+                2048,
+                256,
+                ReductionHint.OUTER_TINY,
+                None,
+                [(2, 4), (1, 2), (8, 8)],
+            ),
+            (2048, 512, ReductionHint.INNER, None, [(2, 1), (1, 4), (8, 4)]),
+            (2048, 512, ReductionHint.INNER, 128, [(1, 4), (8, 4)]),
+            (2048, 512, ReductionHint.OUTER, None, [(8, 8), (1, 4)]),
+            (2048, 512, ReductionHint.OUTER_TINY, None, [(1, 4), (8, 8)]),
+            (2048, 1024, ReductionHint.INNER, None, [(1, 1), (1, 8)]),
+            (2048, 1024, ReductionHint.INNER, 128, [(1, 8)]),
+            (2048, 1024, ReductionHint.OUTER, None, [(1, 8)]),
+            (2048, 1024, ReductionHint.OUTER_TINY, None, [(1, 8)]),
+            (2048, 2048, ReductionHint.INNER, None, [(1, 8)]),
         ],
     )
     @parametrize("max_autotune_flag", ["max_autotune", "max_autotune_pointwise"])
     def test_persistent_max_autotune_includes_default_config(
-        self, rnumel, reduction_hint, rsplit_size, max_autotune_flag
+        self,
+        xnumel,
+        rnumel,
+        reduction_hint,
+        rsplit_size,
+        expected_max_configs,
+        max_autotune_flag,
     ):
-        size_hints = {"x": 2048, "r0_": rnumel}
+        size_hints = {"x": xnumel, "r0_": rnumel}
         inductor_meta = {} if rsplit_size is None else {"RSPLIT_SIZE": rsplit_size}
         triton_meta = {"device": self._fake_cuda_device_properties()}
-        expected_inner_configs = {
-            256: [(4, 1), (1, 2), (8, 2)],
-            1024: [(1, 1), (1, 8)],
-        }
 
         default_configs = _persistent_reduction_configs(
             size_hints=size_hints,
@@ -247,20 +278,68 @@ class TestTritonHeuristics(TestCase):
             triton_meta=triton_meta,
         )
 
-        self.assertEqual(len(default_configs), 1)
-        if reduction_hint == ReductionHint.INNER and rsplit_size is None:
-            self.assertEqual(
-                [
-                    (config.kwargs["XBLOCK"], config.num_warps)
-                    for config in max_autotune_configs
-                ],
-                expected_inner_configs[rnumel],
+        default_keys = [triton_config_to_hashable(c) for c in default_configs]
+        max_autotune_keys = [triton_config_to_hashable(c) for c in max_autotune_configs]
+        self.assertEqual(max_autotune_keys[: len(default_keys)], default_keys)
+        self.assertEqual(len(max_autotune_keys), len(set(max_autotune_keys)))
+        self.assertEqual(
+            [(c.kwargs["XBLOCK"], c.num_warps) for c in max_autotune_configs],
+            expected_max_configs,
+        )
+
+    @parametrize(
+        "heuristic_cls,device_type,warp_size,expected_max_configs",
+        [
+            (
+                ROCmReductionHeuristic,
+                "hip",
+                64,
+                [(4, 1), (1, 2), (4, 2), (8, 2), (16, 2), (2, 4)],
+            ),
+            (XPUReductionHeuristic, "xpu", 32, [(8, 8), (1, 2), (8, 2)]),
+        ],
+    )
+    @parametrize("max_autotune_flag", ["max_autotune", "max_autotune_pointwise"])
+    def test_backend_persistent_max_autotune_retains_candidates(
+        self,
+        heuristic_cls,
+        device_type,
+        warp_size,
+        expected_max_configs,
+        max_autotune_flag,
+    ):
+        triton_meta = {
+            "device": DeviceProperties(
+                type=device_type,
+                index=0,
+                multi_processor_count=1,
+                cc=80,
+                major=8,
+                regs_per_multiprocessor=65536,
+                max_threads_per_multi_processor=2048,
+                max_threads_per_block=1024,
+                warp_size=warp_size,
             )
+        }
+        heuristic = heuristic_cls()
+        kwargs = {
+            "size_hints": {"x": 2048, "r0_": 256},
+            "reduction_hint": ReductionHint.INNER,
+            "triton_meta": triton_meta,
+        }
+        default_configs = heuristic.get_persistent_configs(**kwargs, inductor_meta={})
+        max_autotune_configs = heuristic.get_persistent_configs(
+            **kwargs, inductor_meta={max_autotune_flag: True}
+        )
 
         default_keys = [triton_config_to_hashable(c) for c in default_configs]
         max_autotune_keys = [triton_config_to_hashable(c) for c in max_autotune_configs]
         self.assertEqual(max_autotune_keys[: len(default_keys)], default_keys)
         self.assertEqual(len(max_autotune_keys), len(set(max_autotune_keys)))
+        self.assertEqual(
+            [(c.kwargs["XBLOCK"], c.num_warps) for c in max_autotune_configs],
+            expected_max_configs,
+        )
 
     def test_rocm_persistent_tiled_max_autotune_configs_remain_tiled(self):
         size_hints = {"x": 2048, "y": 16, "r0_": 512}

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -212,37 +212,50 @@ class TestTritonHeuristics(TestCase):
         with self.assertRaisesRegex(AssertionError, "exceeds Triton maximum"):
             make_matmul_triton_config({"x": 256, "y": 128, "r": 64}, 8, 1)
 
-    @parametrize("rnumel", [256, 512, 1024])
-    def test_persistent_max_autotune_includes_default_config(self, rnumel):
+    @parametrize("rnumel", [256, 1024])
+    @parametrize(
+        "reduction_hint,rsplit_size",
+        [
+            (ReductionHint.INNER, None),
+            (ReductionHint.INNER, 128),
+            (ReductionHint.OUTER, None),
+            (ReductionHint.OUTER_TINY, None),
+        ],
+    )
+    @parametrize("max_autotune_flag", ["max_autotune", "max_autotune_pointwise"])
+    def test_persistent_max_autotune_includes_default_config(
+        self, rnumel, reduction_hint, rsplit_size, max_autotune_flag
+    ):
         size_hints = {"x": 2048, "r0_": rnumel}
+        inductor_meta = {} if rsplit_size is None else {"RSPLIT_SIZE": rsplit_size}
         triton_meta = {"device": self._fake_cuda_device_properties()}
-        expected_max_configs = {
+        expected_inner_configs = {
             256: [(4, 1), (1, 2), (8, 2)],
-            512: [(2, 1), (1, 4), (8, 4)],
             1024: [(1, 1), (1, 8)],
         }
 
         default_configs = _persistent_reduction_configs(
             size_hints=size_hints,
-            reduction_hint=ReductionHint.INNER,
-            inductor_meta={},
+            reduction_hint=reduction_hint,
+            inductor_meta=inductor_meta,
             triton_meta=triton_meta,
         )
         max_autotune_configs = _persistent_reduction_configs(
             size_hints=size_hints,
-            reduction_hint=ReductionHint.INNER,
-            inductor_meta={"max_autotune": True},
+            reduction_hint=reduction_hint,
+            inductor_meta={**inductor_meta, max_autotune_flag: True},
             triton_meta=triton_meta,
         )
 
         self.assertEqual(len(default_configs), 1)
-        self.assertEqual(
-            [
-                (config.kwargs["XBLOCK"], config.num_warps)
-                for config in max_autotune_configs
-            ],
-            expected_max_configs[rnumel],
-        )
+        if reduction_hint == ReductionHint.INNER and rsplit_size is None:
+            self.assertEqual(
+                [
+                    (config.kwargs["XBLOCK"], config.num_warps)
+                    for config in max_autotune_configs
+                ],
+                expected_inner_configs[rnumel],
+            )
 
         default_keys = [triton_config_to_hashable(c) for c in default_configs]
         max_autotune_keys = [triton_config_to_hashable(c) for c in max_autotune_configs]

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -43,9 +43,11 @@ from torch._inductor.runtime.hints import (
     HeuristicType,
     native_matmul_block_numel,
     native_matmul_persistent_rblock,
+    ReductionHint,
     TRITON_MAX_BLOCK,
     TRITON_MAX_TENSOR_NUMEL,
 )
+from torch._inductor.runtime.runtime_utils import triton_config_to_hashable
 from torch._inductor.runtime.triton_helpers import math as tl_math
 from torch._inductor.runtime.triton_heuristics import (
     _check_max_grid_x,
@@ -208,6 +210,43 @@ class TestTritonHeuristics(TestCase):
 
         with self.assertRaisesRegex(AssertionError, "exceeds Triton maximum"):
             make_matmul_triton_config({"x": 256, "y": 128, "r": 64}, 8, 1)
+
+    @parametrize("rnumel", [256, 512, 1024])
+    def test_persistent_max_autotune_includes_default_config(self, rnumel):
+        size_hints = {"x": 2048, "r0_": rnumel}
+        triton_meta = {"device": self._fake_cuda_device_properties()}
+        expected_max_configs = {
+            256: [(4, 1), (1, 2), (8, 2)],
+            512: [(2, 1), (1, 4), (8, 4)],
+            1024: [(1, 1), (1, 8)],
+        }
+
+        default_configs = _persistent_reduction_configs(
+            size_hints=size_hints,
+            reduction_hint=ReductionHint.INNER,
+            inductor_meta={},
+            triton_meta=triton_meta,
+        )
+        max_autotune_configs = _persistent_reduction_configs(
+            size_hints=size_hints,
+            reduction_hint=ReductionHint.INNER,
+            inductor_meta={"max_autotune": True},
+            triton_meta=triton_meta,
+        )
+
+        self.assertEqual(len(default_configs), 1)
+        self.assertEqual(
+            [
+                (config.kwargs["XBLOCK"], config.num_warps)
+                for config in max_autotune_configs
+            ],
+            expected_max_configs[rnumel],
+        )
+
+        default_keys = [triton_config_to_hashable(c) for c in default_configs]
+        max_autotune_keys = [triton_config_to_hashable(c) for c in max_autotune_configs]
+        self.assertEqual(max_autotune_keys[: len(default_keys)], default_keys)
+        self.assertEqual(len(max_autotune_keys), len(set(max_autotune_keys)))
 
     def test_reduction_min_block_preserves_tile_product(self):
         cfg = _enforce_reduction_config_block_minimums(

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -36,6 +36,7 @@ except ImportError:
     raise unittest.SkipTest("requires triton")  # noqa: B904
 
 from torch._inductor import config
+from torch._inductor.heuristics.triton_codegen.reduction import ROCmReductionHeuristic
 from torch._inductor.runtime.hints import (
     AttrsDescriptorWrapper,
     AutotuneHint,
@@ -248,6 +249,29 @@ class TestTritonHeuristics(TestCase):
         self.assertEqual(max_autotune_keys[: len(default_keys)], default_keys)
         self.assertEqual(len(max_autotune_keys), len(set(max_autotune_keys)))
 
+    def test_rocm_persistent_tiled_max_autotune_configs_remain_tiled(self):
+        size_hints = {"x": 2048, "y": 16, "r0_": 512}
+        triton_meta = {"device": self._fake_rocm_device_properties()}
+        heuristic = ROCmReductionHeuristic()
+
+        default_configs = heuristic.get_persistent_configs(
+            size_hints=size_hints,
+            reduction_hint=ReductionHint.INNER,
+            inductor_meta={},
+            triton_meta=triton_meta,
+        )
+        max_autotune_configs = heuristic.get_persistent_configs(
+            size_hints=size_hints,
+            reduction_hint=ReductionHint.INNER,
+            inductor_meta={"max_autotune": True},
+            triton_meta=triton_meta,
+        )
+
+        default_keys = [triton_config_to_hashable(c) for c in default_configs]
+        max_autotune_keys = [triton_config_to_hashable(c) for c in max_autotune_configs]
+        self.assertEqual(max_autotune_keys, default_keys)
+        self.assertTrue(all("YBLOCK" in c.kwargs for c in max_autotune_configs))
+
     def test_reduction_min_block_preserves_tile_product(self):
         cfg = _enforce_reduction_config_block_minimums(
             [triton.Config({"XBLOCK": 64, "R0_BLOCK": 1024})],
@@ -302,6 +326,20 @@ class TestTritonHeuristics(TestCase):
             max_threads_per_multi_processor=2048,
             max_threads_per_block=1024,
             warp_size=32,
+        )
+
+    @staticmethod
+    def _fake_rocm_device_properties():
+        return DeviceProperties(
+            type="hip",
+            index=0,
+            multi_processor_count=1,
+            cc="gfx942",
+            major=None,
+            regs_per_multiprocessor=65536,
+            max_threads_per_multi_processor=2048,
+            max_threads_per_block=1024,
+            warp_size=64,
         )
 
     @staticmethod

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -369,6 +369,7 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             triton_config_tiled_reduction,
             triton_native_persistent_bmm_configs,
             triton_native_persistent_mm_configs,
+            unique_configs,
         )
 
         inductor_meta = {} if inductor_meta is None else inductor_meta
@@ -463,32 +464,35 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             )
         ]
 
+        max_autotune_configs = list(configs)
+
         # Defer to more autotuning for 3d tiling
         if "y" in size_hints:
             pass
-        elif not max_autotune_enabled:
-            if reduction_hint == ReductionHint.INNER and rnumel >= 256:
-                if (
-                    rnumel > 1024
-                    or xnumel // 8 < 128
-                    or inductor_meta.get("RSPLIT_SIZE")
-                ):
-                    configs = configs[:1]
-                else:
-                    configs = self._persistent_inner_config(
-                        size_hints,
-                        rnumel,
-                        xnumel,
-                        inductor_meta,
-                        reduction_hint,
-                        warp_size,
-                    )
-            elif reduction_hint == ReductionHint.OUTER:
-                configs = configs[-1:]
-            elif reduction_hint == ReductionHint.OUTER_TINY:
-                configs = tiny_configs
-        else:
-            configs = self._persistent_max_autotune_extras(configs, tiny_configs)
+        elif reduction_hint == ReductionHint.INNER and rnumel >= 256:
+            if rnumel > 1024 or xnumel // 8 < 128 or inductor_meta.get("RSPLIT_SIZE"):
+                configs = configs[:1]
+            else:
+                configs = self._persistent_inner_config(
+                    size_hints,
+                    rnumel,
+                    xnumel,
+                    inductor_meta,
+                    reduction_hint,
+                    warp_size,
+                )
+        elif reduction_hint == ReductionHint.OUTER:
+            configs = configs[-1:]
+        elif reduction_hint == ReductionHint.OUTER_TINY:
+            configs = tiny_configs
+
+        if max_autotune_enabled:
+            configs = unique_configs(
+                configs
+                + self._persistent_max_autotune_extras(
+                    max_autotune_configs, tiny_configs
+                )
+            )
 
         for c in configs:
             for p in size_hints:

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -486,7 +486,7 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         elif reduction_hint == ReductionHint.OUTER_TINY:
             configs = tiny_configs
 
-        if max_autotune_enabled:
+        if max_autotune_enabled and "y" not in size_hints:
             configs = unique_configs(
                 configs
                 + self._persistent_max_autotune_extras(


### PR DESCRIPTION
Fixes #194736

This keeps the exact default persistent-reduction config in the max-autotune search, then appends the existing backend-specific candidates with stable de-duplication for non-tiled reductions. Max autotune therefore remains a superset of the default search instead of possibly omitting its selected config.

The issue's FP16 row-mean examples reported the omitted config as 3% to 21% faster. On GB200, the restored candidates were correct and spill-free but did not win, so this fixes search-space completeness rather than claiming a universal speedup.

## Test plan

-   python test/inductor/test_triton_heuristics.py -k persistent_max_autotune -k rocm_persistent_tiled_max_autotune
- The tests cover reduction widths 256, 512, and 1,024, checking exact candidate order, retained max-autotune candidates, no duplicates, and unchanged tiled ROCm configs.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo