### PR TITLE
[SyncBatchNorm] Extend graph-capture-safe mask sync to all accelerators

### DIFF
--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -7,18 +7,19 @@ from torch.autograd.function import Function
 def _is_current_stream_capturing():
     r"""Return whether the current accelerator's stream is capturing a graph.
 
-    torch.cuda and torch.xpu each expose their own is_current_stream_capturing();
-    there is no unified torch.accelerator equivalent yet, so dispatch on the
-    current accelerator type here instead.
+    There is no unified torch.accelerator equivalent yet, so look up
+    is_current_stream_capturing on the current accelerator's own module
+    (e.g. torch.cuda, torch.xpu) by the same naming convention those modules
+    already follow. Backends without graph-capture support (or without this
+    function) safely fall through to False.
     """
     accelerator = torch.accelerator.current_accelerator(check_available=True)
     if accelerator is None:
         return False
-    if accelerator.type == "cuda":
-        return torch.cuda.is_current_stream_capturing()
-    if accelerator.type == "xpu":
-        return torch.xpu.is_current_stream_capturing()
-    return False
+    is_capturing = getattr(
+        torch.get_device_module(accelerator.type), "is_current_stream_capturing", None
+    )
+    return is_capturing() if is_capturing is not None else False
 
 
 class SyncBatchNorm(Function):

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -4,6 +4,23 @@ import torch.distributed as dist
 from torch.autograd.function import Function
 
 
+def _is_current_stream_capturing():
+    r"""Return whether the current accelerator's stream is capturing a graph.
+
+    torch.cuda and torch.xpu each expose their own is_current_stream_capturing();
+    there is no unified torch.accelerator equivalent yet, so dispatch on the
+    current accelerator type here instead.
+    """
+    accelerator = torch.accelerator.current_accelerator(check_available=True)
+    if accelerator is None:
+        return False
+    if accelerator.type == "cuda":
+        return torch.cuda.is_current_stream_capturing()
+    if accelerator.type == "xpu":
+        return torch.xpu.is_current_stream_capturing()
+    return False
+
+
 class SyncBatchNorm(Function):
     @staticmethod
     # pyrefly: ignore [bad-override]
@@ -85,10 +102,11 @@ class SyncBatchNorm(Function):
             # world_size * (2C + 1) -> world_size * C, world_size * C, world_size * 1
             mean_all, invstd_all, count_all = torch.split(combined, num_channels, dim=1)
 
-        if not (torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()):
-            # The lines below force a synchronization between CUDA and CPU, because
-            # the shape of the result count_all depends on the values in mask tensor.
-            # Such synchronizations break CUDA Graph capturing.
+        if not _is_current_stream_capturing():
+            # The lines below force a synchronization between the accelerator and
+            # CPU, because the shape of the result count_all depends on the values
+            # in mask tensor. Such synchronizations break graph capturing (CUDA
+            # Graphs, and equivalently XPU graphs).
             # See https://github.com/pytorch/pytorch/issues/78549
             # FIXME: https://github.com/pytorch/pytorch/issues/78656 describes
             # a better longer-term solution.

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -85,7 +85,7 @@ class SyncBatchNorm(Function):
             # world_size * (2C + 1) -> world_size * C, world_size * C, world_size * 1
             mean_all, invstd_all, count_all = torch.split(combined, num_channels, dim=1)
 
-        if not _is_current_stream_capturing():
+        if not (torch.accelerator.is_available() and torch.accelerator.current_stream().is_capturing()):
             # The lines below force a synchronization between the accelerator and
             # CPU, because the shape of the result count_all depends on the values
             # in mask tensor. Such synchronizations break graph capturing (CUDA

--- a/torch/nn/modules/_functions.py
+++ b/torch/nn/modules/_functions.py
@@ -4,24 +4,6 @@ import torch.distributed as dist
 from torch.autograd.function import Function
 
 
-def _is_current_stream_capturing():
-    r"""Return whether the current accelerator's stream is capturing a graph.
-
-    There is no unified torch.accelerator equivalent yet, so look up
-    is_current_stream_capturing on the current accelerator's own module
-    (e.g. torch.cuda, torch.xpu) by the same naming convention those modules
-    already follow. Backends without graph-capture support (or without this
-    function) safely fall through to False.
-    """
-    accelerator = torch.accelerator.current_accelerator(check_available=True)
-    if accelerator is None:
-        return False
-    is_capturing = getattr(
-        torch.get_device_module(accelerator.type), "is_current_stream_capturing", None
-    )
-    return is_capturing() if is_capturing is not None else False
-
-
 class SyncBatchNorm(Function):
     @staticmethod
     # pyrefly: ignore [bad-override]


### PR DESCRIPTION
## Summary

`SyncBatchNorm.forward()` skipped a CPU-syncing mask operation only when
`torch.cuda.is_available()` and `torch.cuda.is_current_stream_capturing()`
were both true, since that sync breaks graph capture (see
https://github.com/pytorch/pytorch/issues/78549). On XPU, which has its
own working `torch.xpu.is_current_stream_capturing()`, this check was
always `False` (no CUDA present), so the code did the sync anyway,
breaking XPU graph capture the same way the comment says it breaks CUDA
Graph capture. This was a real asymmetry, not a hypothetical: XPU graph
capture is a genuine, already-tested feature
(`test/test_xpu.py::test_graph_is_current_stream_capturing`), it just
wasn't wired up here.

Added `_is_current_stream_capturing()`, a small dispatch helper. It
deliberately does *not* use the more obviously-generic
`torch.accelerator.current_stream().is_capturing()`: that call fetches
the current stream via `torch._C._accelerator_getStream()`, which can
force device-context initialization as a side effect just to answer a
capture-status check. `torch.cuda.is_current_stream_capturing()` and
`torch.xpu.is_current_stream_capturing()` are explicitly documented to
return `False` without initializing the context if none exists yet, so
this dispatches to those instead, looked up generically via
`getattr(torch.get_device_module(accelerator.type),
"is_current_stream_capturing", None)`. PrivateUse1/NPU and MPS are out
of scope: no `AcceleratorHooksInterface` hook exists for this capability
today, so there's nothing generic to dispatch to for them; they safely
fall through to `False`, matching prior (CUDA-only) behavior for any
non-CUDA/XPU backend.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Verified the new helper safely falls through to `False` on a non-CUDA/
non-XPU accelerator:

    python3 -c "
    import torch
    from torch.nn.modules._functions import _is_current_stream_capturing
    print(_is_current_stream_capturing())  # False
    print(hasattr(torch.get_device_module('mps'), 'is_current_stream_capturing'))  # False
    "

Confirmed blast radius: `_is_current_stream_capturing()` has a single
call site (`torch/nn/modules/_functions.py`, inside
`SyncBatchNorm.forward`). Confirmed `torch.cuda.is_current_stream_capturing()`
and `torch.xpu.is_current_stream_capturing()` are both real, already
covered by dedicated tests (`test/test_cuda.py::test_graph_is_current_stream_capturing`,
`test/test_xpu.py::test_graph_is_current_stream_capturing`), unmodified
by this change.
