### PR TITLE
Default equality operators for member-wise-comparable structs

### DIFF
--- a/aten/src/ATen/core/Generator.h
+++ b/aten/src/ATen/core/Generator.h
@@ -62,13 +62,7 @@ struct TORCH_API Generator {
     TORCH_CHECK(impl_.get(), "GeneratorImpl with nullptr is not supported");
   }
 
-  bool operator==(const Generator& rhs) const {
-    return this->impl_ == rhs.impl_;
-  }
-
-  bool operator!=(const Generator& rhs) const {
-    return !((*this) == rhs);
-  }
+  bool operator==(const Generator& rhs) const = default;
 
   bool defined() const {
     return static_cast<bool>(impl_);

--- a/aten/src/ATen/core/function_schema.h
+++ b/aten/src/ATen/core/function_schema.h
@@ -219,9 +219,7 @@ struct TORCH_API SchemaArgument {
   SchemaArgType type;
   size_t index;
   SchemaArgument(SchemaArgType tpe, size_t idx) : type(tpe), index(idx) {}
-  bool operator==(const SchemaArgument& rhs) const {
-    return type == rhs.type && index == rhs.index;
-  }
+  bool operator==(const SchemaArgument& rhs) const = default;
 };
 
 bool operator==(const FunctionSchema& lhs, const FunctionSchema& rhs);

--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -278,10 +278,7 @@ struct TORCH_API Stride {
       const std::optional<size_t>& stride)
       : stride_index_(stride_index), contiguous_(contiguous), stride_(stride) {}
 
-  bool operator==(const Stride& b) const {
-    return stride_index_ == b.stride_index_ && contiguous_ == b.contiguous_ &&
-        stride_ == b.stride_;
-  }
+  bool operator==(const Stride& b) const = default;
 
   bool isComplete() const {
     return stride_index_ && contiguous_ && stride_;


### PR DESCRIPTION
## Summary
`SchemaArgument`, `Generator`, and `Stride` each hand-wrote `operator==` as a straight member-by-member comparison -- exactly what `= default` does. `Generator`'s hand-written `operator!=` is dropped since C++20's rewritten-candidates rule now synthesizes it from the defaulted `==`; `Stride`/`SchemaArgument` gain a free `!=` the same way.

## Test plan
```
lintrunner -a aten/src/ATen/core/function_schema.h aten/src/ATen/core/Generator.h aten/src/ATen/core/jit_type.h
```

This PR description was drafted with an AI assistant (Claude Code); I've reviewed the change.