### PR TITLE
[ATen]: complex type support for arange method

### DIFF
--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -210,15 +210,14 @@ Tensor& arange_out(const Scalar& start, const Scalar& end, const Scalar& step, T
 
     Tensor r = result.is_contiguous() ? result : result.contiguous();
     auto iter = TensorIterator::borrowing_nullary_op(r);
-    if(isComplexType(result.scalar_type())) {
-      Scalar endc;
+    if(isComplexType(r.scalar_type())) {
       if(size <= 1) {
-        endc = start;
+        result.fill_(start);
       } else {
-        endc = start.to<c10::complex<double>>() + step.to<c10::complex<double>>() * static_cast<double>(size - 1);
+        Scalar endc = start.to<c10::complex<double>>() + step.to<c10::complex<double>>() * static_cast<double>(size - 1);
+        linspace_stub(iter.device_type(), iter, start, endc, size);
       }
 
-      linspace_stub(iter.device_type(), iter, start, endc, size);
     } else {
       arange_stub(iter.device_type(), iter, start, size, step);
     }

--- a/aten/src/ATen/native/RangeFactories.cpp
+++ b/aten/src/ATen/native/RangeFactories.cpp
@@ -190,7 +190,7 @@ Tensor& range_out_no_step(const Scalar& start, const Scalar& end, Tensor& result
 }
 
 Tensor& arange_out(const Scalar& start, const Scalar& end, const Scalar& step, Tensor& result) {
-  AT_DISPATCH_ALL_TYPES_AND2(kHalf, kBFloat16, result.scalar_type(), "arange_cpu", [&]() {
+  AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(kHalf, kBFloat16, result.scalar_type(), "arange_cpu", [&]() {
     int64_t size = compute_arange_size<scalar_t>(start, end, step);
     int64_t numel = result.numel();
 
@@ -210,7 +210,18 @@ Tensor& arange_out(const Scalar& start, const Scalar& end, const Scalar& step, T
 
     Tensor r = result.is_contiguous() ? result : result.contiguous();
     auto iter = TensorIterator::borrowing_nullary_op(r);
-    arange_stub(iter.device_type(), iter, start, size, step);
+    if(isComplexType(result.scalar_type())) {
+      Scalar endc;
+      if(size <= 1) {
+        endc = start;
+      } else {
+        endc = start.to<c10::complex<double>>() + step.to<c10::complex<double>>() * static_cast<double>(size - 1);
+      }
+
+      linspace_stub(iter.device_type(), iter, start, endc, size);
+    } else {
+      arange_stub(iter.device_type(), iter, start, size, step);
+    }
     if (!result.is_contiguous()) {
       result.copy_(r);
     }

--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -10,6 +10,34 @@ inline void arange_check_bounds(
     const c10::Scalar& start,
     const c10::Scalar& end,
     const c10::Scalar& step) {
+  if(isComplexType(start.type()) || isComplexType(end.type()) || isComplexType(step.type())) {
+    auto startc = start.to<c10::complex<double>>();
+    auto endc = end.to<c10::complex<double>>();
+    auto stepc = step.to<c10::complex<double>>();
+
+    TORCH_CHECK(stepc.real() != 0 || stepc.imag() != 0, "step must be nonzero");
+    TORCH_CHECK(((stepc.real() > 0) && (endc.real() >= startc.real())) ||
+        ((stepc.real() <= 0) && (endc.real() <= startc.real())),
+        "upper bound and lower bound inconsistent with step sign for real part");
+    TORCH_CHECK(((stepc.imag() > 0) && (endc.imag() >= startc.imag())) ||
+        ((stepc.imag() <= 0) && (endc.imag() <= startc.imag())),
+        "upper bound and lower bound inconsistent with step sign for imaginary part");
+    TORCH_CHECK(
+        std::isfinite(startc.real()) && std::isfinite(endc.real()),
+        "unsupported range for real part: ",
+        startc.real(),
+        " -> ",
+        endc.real());
+    TORCH_CHECK(
+        std::isfinite(startc.imag()) && std::isfinite(endc.imag()),
+        "unsupported range for real part: ",
+        startc.imag(),
+        " -> ",
+        endc.imag());
+
+    return;
+  }
+
   // use double precision for validation to avoid precision issues
   double dstart = start.to<double>();
   double dend = end.to<double>();
@@ -51,6 +79,29 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
     } else {
       size_d = std::ceil((end.to<double>() - start.to<double>())
                           / step.to<double>());
+    }
+  } else if (isComplexType(start.type()) || isComplexType(end.type()) || isComplexType(step.type())) {
+    using step_t = std::conditional_t<std::is_same_v<scalar_t, c10::complex<double>>, c10::complex<double>, c10::complex<float>>;
+    auto xstartc = start.to<step_t>();
+    auto xendc = end.to<step_t>();
+    auto xstepc = step.to<step_t>();
+    auto distance = xendc - xstartc;
+
+    TORCH_CHECK(!(xstepc.real() == 0 && xstepc.imag() == 0), "complex step must be nonzero");
+    if(xstepc.real() == 0) {
+      int64_t sgn = (xstepc.imag() > 0) - (xstepc.imag() < 0);
+      size_d = std::ceil((distance.imag() + xstepc.imag() - sgn) / xstepc.imag());
+    } else if (xstepc.imag() == 0) {
+      int64_t sgn = (xstepc.real() > 0) - (xstepc.real() < 0);
+      size_d = std::ceil((distance.real() + xstepc.real() - sgn) / xstepc.real());
+    } else {
+      int64_t sgn_real = (xstepc.real() > 0) - (xstepc.real() < 0);
+      int64_t sgn_imag = (xstepc.imag() > 0) - (xstepc.imag() < 0);
+      auto size_d_real = std::ceil((distance.real() + xstepc.real() - sgn_real) / xstepc.real());
+      auto size_d_imag = std::ceil((distance.imag() + xstepc.imag() - sgn_imag) / xstepc.imag());
+      TORCH_CHECK(size_d_real == size_d_imag,
+                  "cannot perform step due to incorrect upper and lower bounds")
+        size_d = size_d_real; // size_d_imag is expected to be same
     }
   } else {
     size_d = std::ceil((end.to<double>() - start.to<double>())

--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -100,7 +100,7 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
       auto size_d_real = std::ceil((distance.real() + xstepc.real() - sgn_real) / xstepc.real());
       auto size_d_imag = std::ceil((distance.imag() + xstepc.imag() - sgn_imag) / xstepc.imag());
       TORCH_CHECK(size_d_real == size_d_imag,
-                  "cannot perform step due to incorrect upper and lower bounds")
+                  "cannot perform step due to incorrect upper and lower bounds");
         size_d = size_d_real; // size_d_imag is expected to be same
     }
   } else {

--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -19,9 +19,13 @@ inline void arange_check_bounds(
     TORCH_CHECK(((stepc.real() > 0) && (endc.real() >= startc.real())) ||
         ((stepc.real() <= 0) && (endc.real() <= startc.real())),
         "upper bound and lower bound inconsistent with step sign for real part");
+
+    if(stepc.imag() != 0) {
     TORCH_CHECK(((stepc.imag() > 0) && (endc.imag() >= startc.imag())) ||
         ((stepc.imag() <= 0) && (endc.imag() <= startc.imag())),
         "upper bound and lower bound inconsistent with step sign for imaginary part");
+    }
+
     TORCH_CHECK(
         std::isfinite(startc.real()) && std::isfinite(endc.real()),
         "unsupported range for real part: ",

--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -34,7 +34,7 @@ inline void arange_check_bounds(
         endc.real());
     TORCH_CHECK(
         std::isfinite(startc.imag()) && std::isfinite(endc.imag()),
-        "unsupported range for real part: ",
+        "unsupported range for imaginary part: ",
         startc.imag(),
         " -> ",
         endc.imag());
@@ -93,16 +93,12 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
 
     TORCH_CHECK(!(xstepc.real() == 0 && xstepc.imag() == 0), "complex step must be nonzero");
     if(xstepc.real() == 0) {
-      int64_t sgn = (xstepc.imag() > 0) - (xstepc.imag() < 0);
-      size_d = std::ceil((distance.imag() + xstepc.imag() - sgn) / xstepc.imag());
+      size_d = std::ceil((distance.imag()) / xstepc.imag());
     } else if (xstepc.imag() == 0) {
-      int64_t sgn = (xstepc.real() > 0) - (xstepc.real() < 0);
-      size_d = std::ceil((distance.real() + xstepc.real() - sgn) / xstepc.real());
+      size_d = std::ceil((distance.real()) / xstepc.real());
     } else {
-      int64_t sgn_real = (xstepc.real() > 0) - (xstepc.real() < 0);
-      int64_t sgn_imag = (xstepc.imag() > 0) - (xstepc.imag() < 0);
-      auto size_d_real = std::ceil((distance.real() + xstepc.real() - sgn_real) / xstepc.real());
-      auto size_d_imag = std::ceil((distance.imag() + xstepc.imag() - sgn_imag) / xstepc.imag());
+      auto size_d_real = std::ceil((distance.real()) / xstepc.real());
+      auto size_d_imag = std::ceil((distance.imag()) / xstepc.imag());
       TORCH_CHECK(size_d_real == size_d_imag,
                   "cannot perform step due to incorrect upper and lower bounds");
         size_d = size_d_real; // size_d_imag is expected to be same

--- a/aten/src/ATen/native/RangeUtils.h
+++ b/aten/src/ATen/native/RangeUtils.h
@@ -16,13 +16,21 @@ inline void arange_check_bounds(
     auto stepc = step.to<c10::complex<double>>();
 
     TORCH_CHECK(stepc.real() != 0 || stepc.imag() != 0, "step must be nonzero");
-    TORCH_CHECK(((stepc.real() > 0) && (endc.real() >= startc.real())) ||
-        ((stepc.real() <= 0) && (endc.real() <= startc.real())),
-        "upper bound and lower bound inconsistent with step sign for real part");
+    if(stepc.real() == 0) {
+      TORCH_CHECK(endc.real() == startc.real(),
+                  "step real part is zero but range is nonzero");
+    } else {
+      TORCH_CHECK(((stepc.real() > 0) && (endc.real() >= startc.real())) ||
+          ((stepc.real() < 0) && (endc.real() <= startc.real())),
+          "upper bound and lower bound inconsistent with step sign for real part");
+    }
 
-    if(stepc.imag() != 0) {
-    TORCH_CHECK(((stepc.imag() > 0) && (endc.imag() >= startc.imag())) ||
-        ((stepc.imag() <= 0) && (endc.imag() <= startc.imag())),
+    if(stepc.imag() == 0) {
+      TORCH_CHECK(endc.imag() == startc.imag(),
+                  "step imaginary part is zero but range is nonzero");
+    } else {
+      TORCH_CHECK(((stepc.imag() > 0) && (endc.imag() >= startc.imag())) ||
+        ((stepc.imag() < 0) && (endc.imag() <= startc.imag())),
         "upper bound and lower bound inconsistent with step sign for imaginary part");
     }
 
@@ -91,7 +99,8 @@ int64_t compute_arange_size(const Scalar& start, const Scalar& end, const Scalar
     auto xstepc = step.to<step_t>();
     auto distance = xendc - xstartc;
 
-    TORCH_CHECK(!(xstepc.real() == 0 && xstepc.imag() == 0), "complex step must be nonzero");
+    TORCH_CHECK(!(xstepc.real() == 0 && xstepc.imag() == 0),
+                "complex step must be nonzero");
     if(xstepc.real() == 0) {
       size_d = std::ceil((distance.imag()) / xstepc.imag());
     } else if (xstepc.imag() == 0) {

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5550,6 +5550,7 @@ def arange(
         isinstance(start, complex)
         or isinstance(end, complex)
         or isinstance(step, complex)
+        or (dtype is not None and dtype.is_complex)
     )
 
     # Case: torch.arange(5)
@@ -5559,29 +5560,29 @@ def arange(
     torch._check(step != 0, lambda: "step must be nonzero")
 
     if has_complex:
-        startc = complex(start)
-        endc = complex(end)
-        stepc = complex(step)
+        start = complex(start)
+        end = complex(end)
+        step = complex(step)
 
-        if stepc.real > 0:
+        if step.real > 0:
             torch._check(
-                endc.real >= startc.real,
+                end.real >= start.real,
                 lambda: "upper bound and lower bound inconsistent with step sign in real part",
             )
-        elif stepc.real < 0:
+        elif step.real < 0:
             torch._check(
-                endc.real <= startc.real,
+                end.real <= start.real,
                 lambda: "upper bound and lower bound inconsistent with step sign in real part",
             )
 
-        if stepc.imag > 0:
+        if step.imag > 0:
             torch._check(
-                endc.imag >= startc.imag,
+                end.imag >= start.imag,
                 lambda: "upper bound and lower bound inconsistent with step sign in imaginary part",
             )
-        elif stepc.imag < 0:
+        elif step.imag < 0:
             torch._check(
-                endc.imag <= startc.imag,
+                end.imag <= start.imag,
                 lambda: "upper bound and lower bound inconsistent with step sign in imaginary part",
             )
 
@@ -5612,7 +5613,9 @@ def arange(
     )
 
     args = (start, end, step)
-    integer_args = builtins.all(isinstance(arg, IntLike) for arg in args)
+    integer_args = (
+        builtins.all(isinstance(arg, IntLike) for arg in args) and not has_complex
+    )
 
     if dtype is None:
         dtype = torch.int64 if integer_args else torch.get_default_dtype()
@@ -5630,21 +5633,17 @@ def arange(
         length = (xend - xstart + xstep - sgn) // xstep  # type: ignore[possibly-undefined]
     elif has_complex:
         real_length = (
-            math.ceil((endc.real - startc.real) / stepc.real)  # type: ignore[possibly-undefined]
-            if stepc.real != 0  # type: ignore[possibly-undefined]
-            else 1
+            math.ceil((end.real - start.real) / step.real)  # type: ignore[possibly-undefined]
+            if step.real != 0 and math.isfinite(step.real)  # type: ignore[possibly-undefined]
+            else 0
         )
         imag_length = (
-            math.ceil((endc.imag - startc.imag) / stepc.imag)  # type: ignore[possibly-undefined]
-            if stepc.imag != 0  # type: ignore[possibly-undefined]
-            else 1
-        )
-        torch._check(
-            real_length == imag_length,
-            "cannot perform step due to incorrect upper and lower bounds",
+            math.ceil((end.imag - start.imag) / step.imag)  # type: ignore[possibly-undefined]
+            if step.imag != 0 and math.isfinite(step.imag)  # type: ignore[possibly-undefined]
+            else 0
         )
 
-        length = real_length
+        length = max(real_length, imag_length)
     else:
         length = math.ceil((end - start) / step)  # type: ignore[operator not supported]
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5546,30 +5546,60 @@ def arange(
     utils.check_pin_memory(pin_memory)
     device = torch.device(utils.device_or_default(device))
 
-    if isinstance(start, complex):
-        raise AssertionError("arange does not support complex start")
-    if isinstance(end, complex):
-        raise AssertionError("arange does not support complex end")
-    if isinstance(step, complex):
-        raise AssertionError("arange does not support complex step")
+    has_complex = (
+        isinstance(start, complex)
+        or isinstance(end, complex)
+        or isinstance(step, complex)
+    )
 
     # Case: torch.arange(5)
     if end is None:
         end = start
         start = 0
     torch._check(step != 0, lambda: "step must be nonzero")
-    if step > 0:
-        torch._check(
-            end >= start,
-            lambda: "upper bound and lower bound inconsistent with step sign",
-        )
-    elif step < 0:
-        torch._check(
-            end <= start,
-            lambda: "upper bound and lower bound inconsistent with step sign",
-        )
+
+    if has_complex:
+        startc = complex(start)
+        endc = complex(end)
+        stepc = complex(step)
+
+        if stepc.real > 0:
+            torch._check(
+                endc.real >= startc.real,
+                lambda: "upper bound and lower bound inconsistent with step sign in real part",
+            )
+        elif stepc.real < 0:
+            torch._check(
+                endc.real <= startc.real,
+                lambda: "upper bound and lower bound inconsistent with step sign in real part",
+            )
+
+        if stepc.imag > 0:
+            torch._check(
+                endc.imag >= startc.imag,
+                lambda: "upper bound and lower bound inconsistent with step sign in imaginary part",
+            )
+        elif stepc.imag < 0:
+            torch._check(
+                endc.imag <= startc.imag,
+                lambda: "upper bound and lower bound inconsistent with step sign in imaginary part",
+            )
+
+    else:
+        if step > 0:  # type: ignore[operator not supported]
+            torch._check(
+                end >= start,  # type: ignore[operator not supported]
+                lambda: "upper bound and lower bound inconsistent with step sign",
+            )
+        elif step < 0:  # type: ignore[operator not supported]
+            torch._check(
+                end <= start,  # type: ignore[operator not supported]
+                lambda: "upper bound and lower bound inconsistent with step sign",
+            )
 
     def is_finite(x):
+        if isinstance(x, complex):
+            return is_finite(x.real) and is_finite(x.imag)
         return not isinstance(x, FloatWithoutSymFloat) or math.isfinite(x)
 
     torch._check(
@@ -5598,8 +5628,25 @@ def arange(
         # Uses floordiv to avoid ceil in inductor.
         sgn = bool(xstep > 0) - bool(xstep < 0)  # type: ignore[possibly-undefined]
         length = (xend - xstart + xstep - sgn) // xstep  # type: ignore[possibly-undefined]
+    elif has_complex:
+        real_length = (
+            math.ceil((endc.real - startc.real) / stepc.real)  # type: ignore[possibly-undefined]
+            if stepc.real != 0  # type: ignore[possibly-undefined]
+            else 1
+        )
+        imag_length = (
+            math.ceil((endc.imag - startc.imag) / stepc.imag)  # type: ignore[possibly-undefined]
+            if stepc.imag != 0  # type: ignore[possibly-undefined]
+            else 1
+        )
+        torch._check(
+            real_length == imag_length,
+            "cannot perform step due to incorrect upper and lower bounds",
+        )
+
+        length = real_length
     else:
-        length = math.ceil((end - start) / step)
+        length = math.ceil((end - start) / step)  # type: ignore[operator not supported]
 
     if is_integer and integer_args:
         return prims.iota(

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5633,13 +5633,13 @@ def arange(
         length = (xend - xstart + xstep - sgn) // xstep  # type: ignore[possibly-undefined]
     elif has_complex:
         real_length = (
-            math.ceil((end.real - start.real) / step.real)  # type: ignore[possibly-undefined]
-            if step.real != 0 and math.isfinite(step.real)  # type: ignore[possibly-undefined]
+            math.ceil((end.real - start.real) / step.real)
+            if step.real != 0 and math.isfinite(step.real)
             else 0
         )
         imag_length = (
-            math.ceil((end.imag - start.imag) / step.imag)  # type: ignore[possibly-undefined]
-            if step.imag != 0 and math.isfinite(step.imag)  # type: ignore[possibly-undefined]
+            math.ceil((end.imag - start.imag) / step.imag)
+            if step.imag != 0 and math.isfinite(step.imag)
             else 0
         )
 

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5642,6 +5642,11 @@ def arange(
             if step.imag != 0 and math.isfinite(step.imag)
             else 0
         )
+        if step.real != 0 and step.imag != 0:
+            torch._check(
+                real_length == imag_length,
+                lambda: "cannot perform step due to incorrect upper and lower bounds",
+            )
 
         length = max(real_length, imag_length)
     else:

--- a/torch/_refs/__init__.py
+++ b/torch/_refs/__init__.py
@@ -5564,7 +5564,12 @@ def arange(
         end = complex(end)
         step = complex(step)
 
-        if step.real > 0:
+        if step.real == 0:
+            torch._check(
+                end.real == start.real,
+                lambda: "step real part is zero but real range is nonzero",
+            )
+        elif step.real > 0:
             torch._check(
                 end.real >= start.real,
                 lambda: "upper bound and lower bound inconsistent with step sign in real part",
@@ -5575,7 +5580,12 @@ def arange(
                 lambda: "upper bound and lower bound inconsistent with step sign in real part",
             )
 
-        if step.imag > 0:
+        if step.imag == 0:
+            torch._check(
+                end.imag == start.imag,
+                lambda: "step imaginary part is zero but imaginary range is nonzero",
+            )
+        elif step.imag > 0:
             torch._check(
                 end.imag >= start.imag,
                 lambda: "upper bound and lower bound inconsistent with step sign in imaginary part",

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11993,7 +11993,7 @@ op_db: list[OpInfo] = [
             ),
            ),
     OpInfo('arange',
-           dtypes=all_types_and_complex_and(torch.bfloat16, torch.float16, torch.bool),
+           dtypes=all_types_and_complex_and(torch.bfloat16, torch.float16),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int32, torch.int8),
            supports_out=True,
            supports_autograd=False,
@@ -12024,7 +12024,7 @@ op_db: list[OpInfo] = [
                # g: graph():
                #   %25 : Long(1, strides=[1], requires_grad=0, device=cpu) = prim::Constant[value={1}]()
                #   return (%25)
-               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32,)),
+               DecorateInfo(unittest.expectedFailure, 'TestJit', 'test_variant_consistency_jit', dtypes=(torch.float32, torch.complex64, torch.complex128)),
 
                # UserWarning not triggered : Resized a non-empty tensor but did not warn about it.
                DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning'),

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -11993,7 +11993,7 @@ op_db: list[OpInfo] = [
             ),
            ),
     OpInfo('arange',
-           dtypes=all_types_and(torch.bfloat16, torch.float16),
+           dtypes=all_types_and_complex_and(torch.bfloat16, torch.float16, torch.bool),
            dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int32, torch.int8),
            supports_out=True,
            supports_autograd=False,


### PR DESCRIPTION
Added support ComplexFloat and ComplexDouble for arange_cpu via linspace dispatch.

Issue: #160629

@ngimel @malfet

cc @ezyang @anjali411 @dylanbespalko @mruberry @nikitaved @amjames