### PR TITLE
[Test] Refactor `test_python_dispatch.py` to separate device-related from device-unrelated tests.

### DIFF
--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -556,136 +556,6 @@ class TestPythonRegistration(TestCase):
         # Validate that the old behavior is restored for sum
         self.assertEqual(torch.sum(x), torch.tensor(3))
 
-    def test_override_cuda_with_jiterator(self) -> None:
-        def override_where_cuda() -> None:
-            # Example 1: Invert the behavior of where's condition input
-            not_where_code_string = """
-            template <typename T> T inverted_where(bool cond, T a, T b){
-                return !cond ? a : b;
-            }
-            """
-            jitted_where = _create_jit_fn(not_where_code_string)
-
-            CALLED = [False]
-
-            def inverted_where(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_where(*args, **kwargs)
-
-            # overriding where's cuda kernel with Jiterator generated kernel
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::where.self", inverted_where, "CUDA")
-
-                device = "cuda"
-                cond = torch.tensor(
-                    [True, True, False], device=device, dtype=torch.bool
-                )
-                x = torch.tensor([1, 2, 3], device=device)
-                y = torch.tensor([-1, -2, -3], device=device)
-
-                self.assertEqual(torch.where(cond, x, y), torch.tensor([-1, -2, 3]))
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertEqual(torch.where(cond, x, y), torch.tensor([1, 2, -3]))
-
-        def override_gelu_cuda() -> None:
-            # Example 2: Use relu to approximate gelu for faster compute
-            fastest_gelu_code_string = """
-            template <typename T> T fast_gelu(T a){
-                return a > 0 ? a : 0;
-            }
-            """
-            jitted_gelu = _create_jit_fn(fastest_gelu_code_string)
-
-            CALLED = [False]
-
-            def fast_gelu(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_gelu(*args, **kwargs)
-
-            # overriding gelu's cuda kernel with Jiterator generated relu kernel
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::gelu", fast_gelu, "CUDA")
-
-                x = torch.rand([3, 3], device="cuda", dtype=torch.float)
-                self.assertEqual(
-                    torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
-                )
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertNotEqual(
-                torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
-            )
-
-        def override_exp_cuda() -> None:
-            # Example 3: Preventing exp from exploding for float16
-            clipped_exp_code_string = """
-            template <typename T> T clipped_exp(T a){
-                return a > T(10.0) ? T(22026.4657948) : exp(a);
-            }
-            """
-            jitted_exp = _create_jit_fn(clipped_exp_code_string)
-
-            CALLED = [False]
-
-            def clipped_exp(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_exp(*args, **kwargs)
-
-            # overriding exp's cuda kernel with clipped_exp kernel
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::exp", clipped_exp, "CUDA")
-
-                x = torch.tensor([0.0, 100.0], device="cuda", dtype=torch.float16)
-                self.assertEqual(
-                    torch.exp(x),
-                    torch.tensor([1.0, 22026.4657948], dtype=torch.float16),
-                )
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertEqual(
-                torch.exp(x), torch.tensor([1.0, torch.inf], dtype=torch.float16)
-            )
-
-        def override_add_cuda() -> None:
-            # Example 4: simulate a hardware bug, where the adder is always off by 1
-            buggy_add_code_string = """
-            template <typename T> T buggy_add(T a, T b){
-                return a + b + T(1);
-            }
-            """
-            jitted_add = _create_jit_fn(buggy_add_code_string)
-
-            CALLED = [False]
-
-            def buggy_add(*args, **kwargs):
-                CALLED[0] = True
-                return jitted_add(*args, **kwargs)
-
-            with _scoped_library("aten", "IMPL") as my_lib:
-                my_lib.impl("aten::add.Tensor", buggy_add, "CUDA")
-
-                x_cpu = torch.rand([3, 3], device="cpu")
-                y_cpu = torch.rand([3], device="cpu")
-
-                x_cuda = x_cpu.cuda()
-                y_cuda = y_cpu.cuda()
-
-                self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu + 1)
-                self.assertTrue(CALLED[0])
-
-            # behavior restored after deregistration
-            self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu)
-
-        if torch.cuda.is_available() and not TEST_WITH_ROCM:
-            override_where_cuda()
-            override_gelu_cuda()
-            override_exp_cuda()
-            override_add_cuda()
-
     def test_extend_library_with_dispatch_key_arg(self):
         def my_sum(*args, **kwargs):
             return args[0].clone()
@@ -875,6 +745,135 @@ class TestPythonRegistration(TestCase):
             # default behavior should have been restored
             self.assertEqual(torch.mm(a, b).dtype, torch.bfloat16)
 
+    def test_override_cuda_with_jiterator(self) -> None:
+        def override_where_cuda() -> None:
+            # Example 1: Invert the behavior of where's condition input
+            not_where_code_string = """
+            template <typename T> T inverted_where(bool cond, T a, T b){
+                return !cond ? a : b;
+            }
+            """
+            jitted_where = _create_jit_fn(not_where_code_string)
+
+            CALLED = [False]
+
+            def inverted_where(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_where(*args, **kwargs)
+
+            # overriding where's cuda kernel with Jiterator generated kernel
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::where.self", inverted_where, "CUDA")
+
+                device = "cuda"
+                cond = torch.tensor(
+                    [True, True, False], device=device, dtype=torch.bool
+                )
+                x = torch.tensor([1, 2, 3], device=device)
+                y = torch.tensor([-1, -2, -3], device=device)
+
+                self.assertEqual(torch.where(cond, x, y), torch.tensor([-1, -2, 3]))
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertEqual(torch.where(cond, x, y), torch.tensor([1, 2, -3]))
+
+        def override_gelu_cuda() -> None:
+            # Example 2: Use relu to approximate gelu for faster compute
+            fastest_gelu_code_string = """
+            template <typename T> T fast_gelu(T a){
+                return a > 0 ? a : 0;
+            }
+            """
+            jitted_gelu = _create_jit_fn(fastest_gelu_code_string)
+
+            CALLED = [False]
+
+            def fast_gelu(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_gelu(*args, **kwargs)
+
+            # overriding gelu's cuda kernel with Jiterator generated relu kernel
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::gelu", fast_gelu, "CUDA")
+
+                x = torch.rand([3, 3], device="cuda", dtype=torch.float)
+                self.assertEqual(
+                    torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
+                )
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertNotEqual(
+                torch.nn.functional.gelu(x), torch.nn.functional.relu(x)
+            )
+
+        def override_exp_cuda() -> None:
+            # Example 3: Preventing exp from exploding for float16
+            clipped_exp_code_string = """
+            template <typename T> T clipped_exp(T a){
+                return a > T(10.0) ? T(22026.4657948) : exp(a);
+            }
+            """
+            jitted_exp = _create_jit_fn(clipped_exp_code_string)
+
+            CALLED = [False]
+
+            def clipped_exp(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_exp(*args, **kwargs)
+
+            # overriding exp's cuda kernel with clipped_exp kernel
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::exp", clipped_exp, "CUDA")
+
+                x = torch.tensor([0.0, 100.0], device="cuda", dtype=torch.float16)
+                self.assertEqual(
+                    torch.exp(x),
+                    torch.tensor([1.0, 22026.4657948], dtype=torch.float16),
+                )
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertEqual(
+                torch.exp(x), torch.tensor([1.0, torch.inf], dtype=torch.float16)
+            )
+
+        def override_add_cuda() -> None:
+            # Example 4: simulate a hardware bug, where the adder is always off by 1
+            buggy_add_code_string = """
+            template <typename T> T buggy_add(T a, T b){
+                return a + b + T(1);
+            }
+            """
+            jitted_add = _create_jit_fn(buggy_add_code_string)
+
+            CALLED = [False]
+
+            def buggy_add(*args, **kwargs):
+                CALLED[0] = True
+                return jitted_add(*args, **kwargs)
+
+            with _scoped_library("aten", "IMPL") as my_lib:
+                my_lib.impl("aten::add.Tensor", buggy_add, "CUDA")
+
+                x_cpu = torch.rand([3, 3], device="cpu")
+                y_cpu = torch.rand([3], device="cpu")
+
+                x_cuda = x_cpu.cuda()
+                y_cuda = y_cpu.cuda()
+
+                self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu + 1)
+                self.assertTrue(CALLED[0])
+
+            # behavior restored after deregistration
+            self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu)
+
+        if torch.cuda.is_available() and not TEST_WITH_ROCM:
+            override_where_cuda()
+            override_gelu_cuda()
+            override_exp_cuda()
+            override_add_cuda()
 
 instantiate_parametrized_tests(TestPythonRegistration)
 

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -26,11 +26,13 @@ from torch.testing._internal.common_device_type import (
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import (
     first_sample,
+    HardwareClassification,
     instantiate_parametrized_tests,
     IS_WINDOWS,
     parametrize,
     run_tests,
     skipIfTorchDynamo,
+    TEST_CUDA,
     TEST_WITH_ROCM,
     TestCase,
 )
@@ -106,6 +108,8 @@ class _ClassmethodUnflattenWrapper(_TraceableWrapperSubclassTestBase):
 
 
 class TestDispatcherPythonBindings(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_call_boxed(self) -> None:
         sin = torch._C._dispatch_find_schema_or_throw("aten::sin", "")
         x = torch.randn(3)
@@ -114,6 +118,7 @@ class TestDispatcherPythonBindings(TestCase):
 
 
 class TestPythonRegistration(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     test_ns = "_test_python_registration"
 
     def tearDown(self):
@@ -745,6 +750,14 @@ class TestPythonRegistration(TestCase):
             # default behavior should have been restored
             self.assertEqual(torch.mm(a, b).dtype, torch.bfloat16)
 
+
+instantiate_parametrized_tests(TestPythonRegistration)
+
+
+@unittest.skipUnless(TEST_CUDA and not TEST_WITH_ROCM, "CUDA-only tests")
+class TestPythonRegistrationCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_override_cuda_with_jiterator(self) -> None:
         def override_where_cuda() -> None:
             # Example 1: Invert the behavior of where's condition input
@@ -869,16 +882,15 @@ class TestPythonRegistration(TestCase):
             # behavior restored after deregistration
             self.assertEqual(x_cuda + y_cuda, x_cpu + y_cpu)
 
-        if torch.cuda.is_available() and not TEST_WITH_ROCM:
-            override_where_cuda()
-            override_gelu_cuda()
-            override_exp_cuda()
-            override_add_cuda()
-
-instantiate_parametrized_tests(TestPythonRegistration)
+        override_where_cuda()
+        override_gelu_cuda()
+        override_exp_cuda()
+        override_add_cuda()
 
 
 class TestPythonDispatch(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self) -> None:
         with capture_logs() as logs:
             x = LoggingTensor(torch.tensor([3.0]), requires_grad=True)
@@ -2791,6 +2803,8 @@ def forward(self, x_1):
 
 
 class TestPythonDispatcher(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         x = torch.randn(2, requires_grad=True)
         r = torch._C._EnablePythonDispatcher()
@@ -2805,7 +2819,9 @@ class TestPythonDispatcher(TestCase):
         self.assertEqual(expected_shape, python_disp_shape)
 
 
-class TestWrapperSubclassAliasing(TestCase):
+class TestWrapperSubclassAliasingDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_wrapper_subclass_aliasing(self, op, args, kwargs):
         def to_subclass(t: torch.Tensor):
             return TwoTensor(t, t.clone())
@@ -2925,7 +2941,9 @@ class TestWrapperSubclassAliasing(TestCase):
             self._test_wrapper_subclass_aliasing(torch.ops.aten.fft_fft2, args, kwargs)
 
 
-instantiate_device_type_tests(TestWrapperSubclassAliasing, globals(), allow_xpu=True)
+instantiate_device_type_tests(
+    TestWrapperSubclassAliasingDevice, globals(), allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
This PR refactors `test/test_python_dispatch.py` test file to separate device-related tests from device-unrelated ones.

### Review notes

I split changes into two main commits:
| commit | description |
| - | - |
| **Only change functions order.** | This commit only changes order of test functions. **NO FUNCTIONAL CHANGES AT ALL** |
| **Refactor.** | This commit applies the real refactor. |

Any further commits are addressing review comments.

###  Changes

- Extract cuda-specific `test_override_cuda_with_jiterator` from `TestPythonRegistration` into newly created cuda-specific `TestPythonRegistrationCUDA`.
- Remove `test_override_cuda_with_jiterator` function-local `torch.cuda.is_available()` check and apply it as whole `TestPythonRegistrationCUDA` class skip using `@unittest.skipUnless(TEST_CUDA and not TEST_WITH_ROCM, "CUDA-only tests")`.
- Add `HardwareClassification` to all test classes in the file.
- Add `Device` suffix to device-generic `TestWrapperSubclassAliasing` class making it `TestWrapperSubclassAliasingDevice`.
