### PR TITLE
[FSDP] Fix dangerous mutable default dictionary in _override_module_mixed_precision

### DIFF
--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -232,7 +232,6 @@ class TestUtils(TestCase):
         self.assertIsNot(model1.lin._wrap_overrides, model2.lin._wrap_overrides)
 
 
-
 devices = ("cuda", "hpu", "xpu")
 instantiate_device_type_tests(TestUtils, globals(), only_for=devices, allow_xpu=True)
 if __name__ == "__main__":

--- a/test/distributed/fsdp/test_utils.py
+++ b/test/distributed/fsdp/test_utils.py
@@ -10,7 +10,10 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 from torch import distributed as dist
-from torch.distributed.fsdp._common_utils import _get_param_to_fqns
+from torch.distributed.fsdp._common_utils import (
+    _get_param_to_fqns,
+    _override_module_mixed_precision,
+)
 from torch.distributed.utils import _apply_to_tensors, _replace_by_prefix
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
@@ -201,6 +204,33 @@ class TestUtils(TestCase):
             f"expected <25x for O(N) but got ~64x indicating O(N^2) "
             f"(see https://github.com/pytorch/pytorch/issues/168329)",
         )
+
+    def test_override_module_mixed_precision_default_dict_isolation(self):
+        class SubModule(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = nn.Linear(4, 4)
+
+        model1 = SubModule()
+        model2 = SubModule()
+
+        # Call without explicit wrap_override_dict
+        _override_module_mixed_precision(model1, [nn.Linear])
+        self.assertTrue(hasattr(model1.lin, "_wrap_overrides"))
+        self.assertEqual(model1.lin._wrap_overrides, {"mixed_precision": None})
+
+        # Mutate the dictionary on model1
+        model1.lin._wrap_overrides["mixed_precision"] = torch.float16
+        model1.lin._wrap_overrides["custom_key"] = 123
+
+        # Call again on model2 without explicit wrap_override_dict
+        _override_module_mixed_precision(model2, [nn.Linear])
+        self.assertTrue(hasattr(model2.lin, "_wrap_overrides"))
+        # Verify model2 does not inherit mutations from model1
+        self.assertEqual(model2.lin._wrap_overrides, {"mixed_precision": None})
+        self.assertNotIn("custom_key", model2.lin._wrap_overrides)
+        self.assertIsNot(model1.lin._wrap_overrides, model2.lin._wrap_overrides)
+
 
 
 devices = ("cuda", "hpu", "xpu")

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -648,8 +648,10 @@ def _get_root_modules(modules: set[nn.Module]) -> set[nn.Module]:
 def _override_module_mixed_precision(
     root: torch.nn.Module,
     module_classes_to_override: Iterable[type[nn.Module]],
-    wrap_override_dict: dict[str, Any] = {"mixed_precision": None},  # noqa: B006
+    wrap_override_dict: Optional[dict[str, Any]] = None,
 ) -> set[type[nn.Module]]:
+    if wrap_override_dict is None:
+        wrap_override_dict = {"mixed_precision": None}
     module_classes_to_override = tuple(set(module_classes_to_override))
     # Return a set of the actually overridden module classes
     overridden_module_classes: set[type[nn.Module]] = set()

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -648,7 +648,7 @@ def _get_root_modules(modules: set[nn.Module]) -> set[nn.Module]:
 def _override_module_mixed_precision(
     root: torch.nn.Module,
     module_classes_to_override: Iterable[type[nn.Module]],
-    wrap_override_dict: Optional[dict[str, Any]] = None,
+    wrap_override_dict: dict[str, Any] | None = None,
 ) -> set[type[nn.Module]]:
     if wrap_override_dict is None:
         wrap_override_dict = {"mixed_precision": None}


### PR DESCRIPTION
Fixes #194894

### Description
This PR resolves a dangerous mutable default argument in `torch.distributed.fsdp._common_utils._override_module_mixed_precision`.

Previously, `_override_module_mixed_precision` declared `wrap_override_dict: dict[str, Any] = {"mixed_precision": None}` (`# noqa: B006`) and assigned `mod._wrap_overrides = wrap_override_dict`. Because the mutable default dictionary was shared across all calls, any in-place mutation of `_wrap_overrides` on one module contaminated all other modules and subsequent model wrapping calls in the same process.

### Changes Made
1. Changed `wrap_override_dict` default parameter to `Optional[dict[str, Any]] = None`.
2. Created a new dictionary `{"mixed_precision": None}` per function call when `wrap_override_dict` is None.
3. Removed `# noqa: B006`.
4. Added regression test `test_override_module_mixed_precision_default_dict_isolation` in `test/distributed/fsdp/test_utils.py` verifying state isolation across independent module overrides.

### Test Plan
Ran unit test:
```bash
python test/distributed/fsdp/test_utils.py -k test_override_module_mixed_precision_default_dict_isolation
```
Verified that modifying `_wrap_overrides` on one module does not leak state to subsequent `_override_module_mixed_precision` invocations.
