### PR TITLE
[accelerator] Fix _snapshot() to dispatch generically instead of hardcoding XPU/CUDA

### DIFF
--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -267,10 +267,12 @@ def _snapshot(device=None, augment_with_fx_traces: bool = False):
         dict: a dictionary containing memory allocator state information.
     """
     acc = torch.accelerator.current_accelerator()
-    if acc is not None and acc.type == "xpu":
-        return torch.xpu.memory._snapshot(
-            device, augment_with_fx_traces=augment_with_fx_traces
+    device_type = acc.type if acc is not None else "cuda"
+    device_module = getattr(torch, device_type)
+    if not hasattr(getattr(device_module, "memory", device_module), "_snapshot"):
+        raise NotImplementedError(
+            f"_snapshot is not implemented for the '{device_type}' accelerator"
         )
-    return torch.cuda.memory._snapshot(
+    return device_module.memory._snapshot(
         device, augment_with_fx_traces=augment_with_fx_traces
     )

--- a/torch/accelerator/memory.py
+++ b/torch/accelerator/memory.py
@@ -269,10 +269,11 @@ def _snapshot(device=None, augment_with_fx_traces: bool = False):
     acc = torch.accelerator.current_accelerator()
     device_type = acc.type if acc is not None else "cuda"
     device_module = getattr(torch, device_type)
-    if not hasattr(getattr(device_module, "memory", device_module), "_snapshot"):
+    snapshot_module = getattr(device_module, "memory", device_module)
+    if not hasattr(snapshot_module, "_snapshot"):
         raise NotImplementedError(
             f"_snapshot is not implemented for the '{device_type}' accelerator"
         )
-    return device_module.memory._snapshot(
+    return snapshot_module._snapshot(
         device, augment_with_fx_traces=augment_with_fx_traces
     )


### PR DESCRIPTION
## Summary

Every other function in `torch/accelerator/memory.py` (`empty_cache`,
`memory_stats`, `get_memory_info`, etc.) dispatches generically
through `torch._C._accelerator_*` hooks; `_snapshot()` was the
exception, hardcoding an XPU special case and silently falling back to
`torch.cuda.memory._snapshot()` for every other accelerator --
including MPS, MTIA, and PrivateUse1 -- producing confusing
CUDA-specific errors instead of a clear message.

Replaced the hardcoded branch with a generic module lookup
(`getattr(torch, device_type)`), matching the `_get_device_module`
pattern used elsewhere in the codebase. Backends without a `_snapshot`
implementation (confirmed: no MPS or MTIA equivalent exists today) now
raise a clear `NotImplementedError` naming the accelerator, instead of
silently calling CUDA's implementation and failing with an unrelated
CUDA-specific error.

The generalized dispatch checks capability via
`getattr(device_module, "memory", device_module)` (to support backends
that don't nest their APIs under a `.memory` submodule), and that same
resolved object is used consistently for both the capability check and
the actual call, a backend exposing `_snapshot` at the top level,
without a `.memory` submodule, is handled correctly rather than passing
the check and then hitting an unrelated `AttributeError` on the call.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

    python -c "
    import torch
    from torch.accelerator.memory import _snapshot
    print(_snapshot())
    "
    # -> NotImplementedError: _snapshot is not implemented for the 'mps' accelerator

Verified the submodule-fallback path specifically with a synthetic
module exposing `_snapshot` at the top level (no `.memory`
submodule), mocked in as the current accelerator:

    import torch, types
    from unittest import mock

    fake_mod = types.ModuleType("torch.fakeacc")
    fake_mod._snapshot = lambda device=None, augment_with_fx_traces=False: {"fake": True}

    class FakeDevice:
        type = "fakeacc"

    with mock.patch.object(torch, "fakeacc", fake_mod, create=True), \
         mock.patch("torch.accelerator.current_accelerator", return_value=FakeDevice()):
        from torch.accelerator.memory import _snapshot
        print(_snapshot())
    # -> {'fake': True}

Ran `lintrunner -a` on `torch/accelerator/memory.py`, no issues.