### PR TITLE
[FlexAttention] Remove dead OUTPUT_LOGSUMEXP branch and fix missing XPU in error message

### DIFF
--- a/torch/nn/attention/flex_attention.py
+++ b/torch/nn/attention/flex_attention.py
@@ -2172,9 +2172,6 @@ def _apply_kernel_options(
             # CPU/MPS support inference only, no LSE/backward yet.
             # TODO: support CPU for training and return lse
             kernel_options["OUTPUT_LOGSUMEXP"] = False
-        if any_inputs_on_mps_device:
-            # MPS supports inference only; backward / LSE not yet implemented
-            kernel_options["OUTPUT_LOGSUMEXP"] = False
 
     # If forward kernel needs to return max is decided by this rule internally.
     if "OUTPUT_MAX" in kernel_options:
@@ -2220,7 +2217,7 @@ def _validate_device(query: Tensor, key: Tensor, value: Tensor) -> None:
     supported_devices = {"cuda", "cpu", "xpu", "hpu", "mps"}
     if query.device.type not in supported_devices:
         raise ValueError(
-            "FlexAttention is only supported on CUDA, CPU, HPU, or MPS devices. "
+            "FlexAttention is only supported on CUDA, CPU, XPU, HPU, or MPS devices. "
             f"Found input tensors on {query.device.type} device."
         )
 


### PR DESCRIPTION
## Summary

Two small, unrelated-but-adjacent fixes in `torch/nn/attention/flex_attention.py`.

### 1. Dead code in `_apply_kernel_options`

`OUTPUT_LOGSUMEXP` was set to `False` twice for MPS inputs:

    if any_inputs_on_cpu_device or any_inputs_on_mps_device:
        # CPU/MPS support inference only, no LSE/backward yet.
        kernel_options["OUTPUT_LOGSUMEXP"] = False
    if any_inputs_on_mps_device:
        # MPS supports inference only; backward / LSE not yet implemented
        kernel_options["OUTPUT_LOGSUMEXP"] = False

Traced the history: when MPS support was added, the original
`if any_inputs_on_cpu_device:` check was correctly widened to also
cover `any_inputs_on_mps_device`, but the same commit additionally
appended a second, separate `if any_inputs_on_mps_device:` block doing
the identical assignment. Since `any_inputs_on_mps_device` being
`True` always implies the first (wider) condition is already `True`,
the second block could never have any effect. Removed it. No behavior
change; `any_inputs_on_mps_device` is still used elsewhere in the
function (the `OUTPUT_MAX` check), so it isn't now unused.

### 2. Missing XPU in `_validate_device`'s error message

`supported_devices` already included `"xpu"`:

    supported_devices = {"cuda", "cpu", "xpu", "hpu", "mps"}

but the error text for an unsupported device didn't mention it:

    "FlexAttention is only supported on CUDA, CPU, HPU, or MPS devices."

XPU inputs were never rejected by this check (the set was already
correct); the message was just stale and would confuse anyone hitting
this error for a genuinely unsupported device type. Now reads "CUDA,
CPU, XPU, HPU, or MPS devices," matching `supported_devices`.

## Test Plan

    python -c "
    import torch
    from torch.nn.attention.flex_attention import _validate_device

    class FakeDev:
        type = 'foo'
    class FakeTensor:
        device = FakeDev()
        requires_grad = False

    try:
        _validate_device(FakeTensor(), FakeTensor(), FakeTensor())
    except ValueError as e:
        print(e)
    "
    # -> FlexAttention is only supported on CUDA, CPU, XPU, HPU, or MPS devices. Found input tensors on foo device.

Confirmed `any_inputs_on_mps_device` remains referenced (no unused-variable
regression) and that the removed branch was provably redundant with the
preceding condition -- both `if` conditions can only be True/False together
for any MPS input.

Ran `lintrunner -a` on `torch/nn/attention/flex_attention.py` -- no issues.