### PR TITLE
[profiler][xpu] Test that ac2g CPU->GPU flow arrows end on the device

### DIFF
--- a/test/profiler/test_xpu_profiler.py
+++ b/test/profiler/test_xpu_profiler.py
@@ -15,6 +15,32 @@ from torch.testing._internal.common_utils import run_tests, TEST_XPU, TestCase
 Verbose = False
 
 
+def find_ac2g_flow_finishes_off_device(events):
+    """Return the ac2g flow-finish events that do not land on a GPU device track.
+
+    ac2g means Async CPU-to-GPU: every such flow starts at a host launch and
+    must end at the device op, so a flow finish (ph='f') must sit on a GPU
+    device track. GPU tracks are the pids labelled "GPU ..." by the chrome-trace
+    process_labels metadata; a finish on any other (host) track is malformed --
+    e.g. a redundant arrow to a driver/overhead subspan, or an orphan host
+    finish. Type-agnostic (does not look at record-type names).
+    """
+    gpu_pids = {
+        e.get("pid")
+        for e in events
+        if e.get("ph") == "M"
+        and e.get("name") == "process_labels"
+        and str((e.get("args") or {}).get("labels", "")).startswith("GPU")
+    }
+    return [
+        e
+        for e in events
+        if e.get("cat") == "ac2g"
+        and e.get("ph") == "f"
+        and e.get("pid") not in gpu_pids
+    ]
+
+
 class XpuProfilerTest(TestCase):
     @unittest.skipIf(not TEST_XPU, "test requires XPU")
     def test_profiler(self):
@@ -134,6 +160,45 @@ class XpuProfilerTest(TestCase):
 
         if Verbose:
             print(p.key_averages().table())
+
+    @unittest.skipIf(not TEST_XPU, "test requires XPU")
+    def test_ac2g_flows_end_on_device(self):
+        # ac2g = Async CPU-to-GPU: every CPU->GPU flow arrow starts at a host
+        # launch and must end at the device op, so no flow may both start and
+        # end on the host (e.g. a redundant arrow from a host span to its own
+        # nested host subspan, or an orphan host finish).
+        a = torch.rand([10, 20], device="xpu")
+        b = torch.rand([20, 30], device="xpu")
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.XPU,
+            ],
+        ) as p:
+            for _ in range(3):
+                r = torch.abs(torch.add(torch.matmul(a, b), 1.0))
+
+        self.assertTrue(r.numel() > 0)
+
+        with tempfile.NamedTemporaryFile(mode="w+", delete=True) as tmp:
+            p.export_chrome_trace(tmp.name)
+            with open(tmp.name) as f:
+                events = json.load(f)["traceEvents"]
+
+        # Sanity: the workload must actually produce CPU->GPU flows, otherwise
+        # the check below would pass vacuously.
+        ac2g_finishes = [
+            e for e in events if e.get("cat") == "ac2g" and e.get("ph") == "f"
+        ]
+        self.assertTrue(ac2g_finishes, "no ac2g CPU->GPU flows captured")
+
+        off_device = find_ac2g_flow_finishes_off_device(events)
+        self.assertEqual(
+            len(off_device),
+            0,
+            "ac2g flow(s) finish off the device (should end on a GPU track): "
+            f"{[(e.get('pid'), e.get('tid')) for e in off_device][:3]}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Add an XPU profiler regression test that asserts CPU→GPU ("ac2g") flow arrows
end on the device, in `test/profiler/test_xpu_profiler.py`.

## Why
`ac2g` means *async CPU→GPU*: a flow starts at a host launch and must end at
the device op, so no flow may both start and end on the host. On XPU the
exporter could attach flow endpoints to host-side Level Zero (`ze*`) driver /
overhead subspans, producing redundant host→host arrows and orphan host
finishes that break CPU→GPU trace correlation. This test locks the invariant so
the class of bug cannot regress.

## How
Profile a small workload, export a Chrome trace, and check every ac2g flow
finish lands on a GPU device track. GPU tracks are the pids labelled `"GPU …"`
in the trace's `process_labels` metadata; a finish on any other (host) track is
malformed. The check is type-agnostic (it does not enumerate record kinds), so
it catches any nested host subspan. A sanity assertion ensures the workload
actually produced ac2g flows.

## Notes
- **Draft on purpose:** the underlying fix lives in Kineto
  (pytorch/kineto#1549); this test will only pass once that fix is pulled into
  `third_party/kineto`. Ready to un-draft after the Kineto PR lands.
- Validated on Intel GPU hardware: the test correctly fails on the current
  (unfixed) trace and passes on the fixed one. XPU-gated (`TEST_XPU`).
