### PR TITLE
Add CUDA 13.4 nightly docker builds (runtime only)

### DIFF
--- a/.github/scripts/generate_binary_build_matrix.py
+++ b/.github/scripts/generate_binary_build_matrix.py
@@ -28,12 +28,19 @@ CUDA_ARCHES = ["12.6", "13.0", "13.2", "13.4"]
 CUDA_STABLE = "13.0"
 # Only consumed by generate_docker_release_matrix.py, whose Dockerfile installs
 # an already-published torch nightly. A CUDA version belongs here only once its
-# wheels are on the download.pytorch.org index, so 13.4 is deliberately absent.
+# wheels are on the download.pytorch.org index.
 CUDA_ARCHES_FULL_VERSION = {
     "12.6": "12.6.3",
     "13.0": "13.0.3",
     "13.2": "13.2.1",
+    "13.4": "13.4.0",
 }
+# CUDA versions that can only produce the runtime docker image. The devel image
+# apt-installs cuda-toolkit-<major>-<minor> from NVIDIA's repo, which carries
+# 13-0 through 13-3 only: 13.4 is still a release candidate (13.4.0rc1). The
+# runtime image just pip-installs the published cu134 nightly, so it builds.
+# Drop an entry once its toolkit ships in the apt repo.
+CUDA_ARCHES_RUNTIME_IMAGE_ONLY = ["13.4"]
 CUDA_ARCHES_CUDNN_VERSION = {
     "12.6": "9",
     "13.0": "9",

--- a/.github/scripts/generate_docker_release_matrix.py
+++ b/.github/scripts/generate_docker_release_matrix.py
@@ -25,6 +25,11 @@ def generate_docker_matrix() -> dict[str, list[dict[str, str]]]:
     # CPU arm64 image is only available as runtime.
     for cuda, version in generate_binary_build_matrix.CUDA_ARCHES_FULL_VERSION.items():
         for image in DOCKER_IMAGE_TYPES:
+            if (
+                image == "devel"
+                and cuda in generate_binary_build_matrix.CUDA_ARCHES_RUNTIME_IMAGE_ONLY
+            ):
+                continue
             ret.append(
                 {
                     "cuda": cuda,


### PR DESCRIPTION
## Summary

The nightly `Build Official Docker Images` run fails because `validate` expects CUDA 13.4 images that `build` never produced:

```
+ docker pull ghcr.io/pytorch/pytorch-nightly:2.15.0.dev20260826-cuda13.4-cudnn9-runtime
Error response from daemon: manifest unknown
```

Failing run: https://github.com/pytorch/pytorch/actions/runs/32944524141 (both `cuda13.4-cudnn9-runtime` and `cuda13.4-cudnn9-devel` legs)

The two sides of that workflow read different tables:

| | source | has 13.4? |
| --- | --- | --- |
| `build` matrix | `CUDA_ARCHES_FULL_VERSION` in this repo | no |
| `validate` matrix | `CUDA_ARCHES_DICT["nightly"]` + `CUDA_CUDNN_VERSIONS` in test-infra | yes |

## Change

**Add `"13.4": "13.4.0"` to `CUDA_ARCHES_FULL_VERSION`.** The comment above that table says a version belongs there once its wheels are on the download.pytorch.org index, and cu134 nightlies are published daily:

```
https://download.pytorch.org/whl/nightly/cu134/torch/
  torch-2.15.0.dev20260826+cu134-cp312-cp312-manylinux_2_28_x86_64.whl
```

**Emit only the runtime image for 13.4.** The devel image apt-installs the toolkit:

```dockerfile
CUDA_PKG_VERSION=$(echo ${CUDA_VERSION} | cut -d'.' -f1,2 | tr '.' '-') && apt-get install -y --no-install-recommends cuda-toolkit-${CUDA_PKG_VERSION}
```

and NVIDIA's repos do not have `cuda-toolkit-13-4` yet, because 13.4 is still `13.4.0rc1`. Both `ubuntu2204` and `ubuntu2404` carry `13-0`, `13-1`, `13-2`, `13-3` and stop there, so a devel build would fail on apt. The runtime image only pip-installs the published wheel, so it builds today.

That exclusion is expressed as `CUDA_ARCHES_RUNTIME_IMAGE_ONLY = ["13.4"]`, following the existing `CUDA_ARCHES_NO_WINDOWS` pattern for per-arch carve-outs, with a note to drop the entry once the toolkit ships.

Resulting matrix:

```
  12.6  12.6.3   runtime    13.0  13.0.3   runtime    13.2  13.2.1   runtime    13.4  13.4.0  runtime
  12.6  12.6.3   devel      13.0  13.0.3   devel      13.2  13.2.1   devel      cpu           runtime (arm64)
```

## Follow-up needed for a fully green nightly

This makes the 13.4 **runtime** validate leg pass, but test-infra still generates a 13.4 **devel** leg, which will keep failing since that image intentionally is not built. Removing it needs a matching carve-out in `tools/scripts/generate_docker_release_matrix.py` in test-infra — separate PR, happy to put it up.

## Test plan

`python3 .github/scripts/generate_docker_release_matrix.py` produces the matrix above: 13.4 runtime present, 13.4 devel absent, every other entry unchanged.

The image build itself can only be exercised by the nightly workflow (it pushes to ghcr), so the real confirmation is the next nightly run.

---

AI-Assisted: investigation and patch written with Claude Code. Author reviewed and validated all AI-generated content, per [AI_POLICY.md](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md).
