### PR TITLE
[varlen] Pass cumulative sequence lengths directly to cuDNN

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -351,17 +351,6 @@ constexpr int64_t kRequiredInt32Alignment =
     HasSetAlignment<fe::graph::Tensor_attributes> ? kInt32Alignment
                                                   : kLegacyTensorAlignment;
 
-// Direct cumulative lengths require support from both frontend and backend.
-bool supports_cumulative_sequence_lengths() {
-#if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
-  return std::min(
-             fe::detail::get_compiled_version(),
-             fe::detail::get_backend_version()) >= 92400;
-#else
-  return false;
-#endif
-}
-
 void checkInt32Alignment(const Tensor& tensor, const char* name) {
   const auto address = reinterpret_cast<uintptr_t>(tensor.const_data_ptr());
   TORCH_CHECK(
@@ -1755,7 +1744,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
   if (!o.defined()) {
     alloc_with_matching_layout(q, o, {q.size(0), h_q, d_v});
   }
-  const auto sequence_length_mode = supports_cumulative_sequence_lengths() &&
+  const auto sequence_length_mode = AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS &&
           !seqused_k.has_value() && dropout_probability == 0.0 &&
           q.stride(-3) > 0 && k.stride(-3) > 0 && v.stride(-3) > 0 &&
           o.stride(-3) > 0

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -177,6 +177,12 @@ void run_cudnn_SDP_bprop_nestedtensor(
 #include <cstdint>
 #include <iostream>
 
+#if CUDNN_FRONTEND_VERSION >= 12500 && CUDNN_VERSION >= 92400
+#define AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS 1
+#else
+#define AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS 0
+#endif
+
 namespace at::native {
 
 namespace fe = cudnn_frontend;
@@ -316,6 +322,7 @@ struct MHAParams {
   bool use_ragged;
   bool is_paged;
   bool is_nested;
+  bool use_cu_seqlen;
 };
 
 namespace {
@@ -338,6 +345,17 @@ constexpr int64_t kLegacyTensorAlignment = 16;
 constexpr int64_t kRequiredInt32Alignment =
     HasSetAlignment<fe::graph::Tensor_attributes> ? kInt32Alignment
                                                   : kLegacyTensorAlignment;
+
+// Direct cumulative lengths require support from both frontend and backend.
+bool supports_cumulative_sequence_lengths() {
+#if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
+  return std::min(
+             fe::detail::get_compiled_version(),
+             fe::detail::get_backend_version()) >= 92400;
+#else
+  return false;
+#endif
+}
 
 void checkInt32Alignment(const Tensor& tensor, const char* name) {
   const auto address = reinterpret_cast<uintptr_t>(tensor.const_data_ptr());
@@ -383,7 +401,8 @@ void setMHAParams(
     bool is_causal,
     bool return_softmaxstats,
     bool is_nested,
-    const std::optional<Tensor>& page_table) {
+    const std::optional<Tensor>& page_table,
+    bool use_cu_seqlen) {
   memset(&params, 0, sizeof(MHAParams));
   params.device_id = at::cuda::current_device();
   params.dataType = fe::DataType_t::HALF;
@@ -402,6 +421,7 @@ void setMHAParams(
   params.has_attn_bias = attn_bias.has_value();
   params.is_paged = page_table.has_value();
   params.is_nested = is_nested;
+  params.use_cu_seqlen = use_cu_seqlen;
   // Paged K/V remain 4D page pools in the nested path.
   const uint8_t q_rank = (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested);
   const uint8_t kv_rank = params.is_paged ? MAX_MHA_DIM : q_rank;
@@ -487,7 +507,8 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
       bool is_causal,
       bool return_softmaxstats,
       bool is_nested,
-      const std::optional<Tensor>& page_table = std::nullopt) {
+      const std::optional<Tensor>& page_table = std::nullopt,
+      bool use_cu_seqlen = false) {
     setMHAParams(
         this->pod,
         b,
@@ -507,7 +528,8 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
         is_causal,
         return_softmaxstats,
         is_nested,
-        page_table);
+        page_table,
+        use_cu_seqlen);
   }
 };
 
@@ -588,6 +610,8 @@ enum UIDS {
   DV,
   SEQ_LEN_Q,
   SEQ_LEN_KV,
+  CU_SEQ_LEN_Q,
+  CU_SEQ_LEN_KV,
   RAG_Q_OFF,
   RAG_K_OFF,
   RAG_V_OFF,
@@ -870,6 +894,7 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
     const Tensor& cum_seqlen_q,
     const Tensor& cum_seqlen_kv,
     const std::optional<Tensor>& page_table,
+    bool use_cu_seqlen,
     const Tensor& q,
     const Tensor& k,
     const Tensor& v,
@@ -899,18 +924,16 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
                             .set_stride({1, 1, 1, 1})
                             .set_is_pass_by_value(true)
                             .set_data_type(fe::DataType_t::FLOAT));
-  auto sequence_length_tensor = [&](UIDS uid, const char* name) {
+  auto index_tensor = [&](UIDS uid, const char* name, int64_t size) {
     auto attributes = fe::graph::Tensor_attributes();
     attributes.set_uid(uid)
         .set_name(name)
-        .set_dim({b, 1, 1, 1})
+        .set_dim({size, 1, 1, 1})
         .set_stride({1, 1, 1, 1})
         .set_data_type(fe::DataType_t::INT32);
     setAlignmentIfSupported(attributes, kInt32Alignment);
     return mha_graph->tensor(attributes);
   };
-  auto SEQ_LEN_Q_ = sequence_length_tensor(SEQ_LEN_Q, "Seq_q");
-  auto SEQ_LEN_KV_ = sequence_length_tensor(SEQ_LEN_KV, "Seq_kv");
 
   auto scaled_dot_product_flash_attention_options =
       fe::graph::SDPA_attributes()
@@ -922,9 +945,21 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
 #endif
           .set_causal_mask(is_causal)
           .set_attn_scale(attn_scale)
-          .set_seq_len_q(SEQ_LEN_Q_)
-          .set_seq_len_kv(SEQ_LEN_KV_)
           .set_padding_mask(true);
+#if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
+  if (use_cu_seqlen) {
+    auto CU_SEQ_LEN_Q_ = index_tensor(CU_SEQ_LEN_Q, "Cu_seq_q", b + 1);
+    auto CU_SEQ_LEN_KV_ = index_tensor(CU_SEQ_LEN_KV, "Cu_seq_kv", b + 1);
+    scaled_dot_product_flash_attention_options.set_cu_seq_len_q(CU_SEQ_LEN_Q_)
+        .set_cu_seq_len_kv(CU_SEQ_LEN_KV_)
+        .set_implementation(fe::AttentionImplementation_t::UNIFIED);
+  }
+#endif
+  if (!use_cu_seqlen) {
+    scaled_dot_product_flash_attention_options
+        .set_seq_len_q(index_tensor(SEQ_LEN_Q, "Seq_q", b))
+        .set_seq_len_kv(index_tensor(SEQ_LEN_KV, "Seq_kv", b));
+  }
   if (dropout_probability != 0.0f) {
     auto seed = mha_graph->tensor(fe::graph::Tensor_attributes()
                                       .set_uid(SEED)
@@ -1012,37 +1047,31 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
                               .set_dim(attn_bias.value().sizes().vec())
                               .set_stride(attn_bias.value().strides().vec())));
   }
-  auto RAG_Q_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_Q_OFF)
-                            .set_name("cum_seq_q")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
-  auto RAG_O_OFF_ =
-      mha_graph->tensor(fe::graph::Tensor_attributes()
-                            .set_uid(RAG_O_OFF)
-                            .set_name("cum_seq_o")
-                            .set_dim({b + 1, 1, 1, 1})
-                            .set_stride({1, 1, 1, 1})
-                            .set_data_type(fe::DataType_t::INT32));
+  auto ragged_offset_tensor = [&](UIDS uid, const char* name) {
+    auto attributes = fe::graph::Tensor_attributes();
+    attributes.set_uid(uid)
+        .set_name(name)
+        .set_dim({b + 1, 1, 1, 1})
+        .set_stride({1, 1, 1, 1})
+        .set_data_type(fe::DataType_t::INT32);
+    setAlignmentIfSupported(attributes, kInt32Alignment);
+    return mha_graph->tensor(attributes);
+  };
+  auto RAG_Q_OFF_ = ragged_offset_tensor(RAG_Q_OFF, "cum_seq_q");
+  auto RAG_O_OFF_ = ragged_offset_tensor(RAG_O_OFF, "cum_seq_o");
   Q_->set_ragged_offset(RAG_Q_OFF_);
   if (!is_paged) {
-    K_->set_ragged_offset(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_K_OFF)
-                              .set_name("cum_seq_k")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32)));
-    V_->set_ragged_offset(
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_V_OFF)
-                              .set_name("cum_seq_v")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32)));
+    K_->set_ragged_offset(ragged_offset_tensor(RAG_K_OFF, "cum_seq_k"));
+    V_->set_ragged_offset(ragged_offset_tensor(RAG_V_OFF, "cum_seq_v"));
   }
+#if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
+  if (use_cu_seqlen) {
+    TORCH_INTERNAL_ASSERT(!is_paged);
+    Q_->set_ragged_offset_multiplier(q.stride(-3));
+    K_->set_ragged_offset_multiplier(k.stride(-3));
+    V_->set_ragged_offset_multiplier(v.stride(-3));
+  }
+#endif
   auto [O_, Stats] =
       mha_graph->sdpa(Q_, K_, V_, scaled_dot_product_flash_attention_options);
   O_->set_output(true)
@@ -1050,20 +1079,19 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
       .set_dim({b, h_q, s_q, d_v})
       .set_stride(thd_to_bhsd_strides(o));
   O_->set_ragged_offset(RAG_O_OFF_);
+#if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
+  if (use_cu_seqlen) {
+    O_->set_ragged_offset_multiplier(o.stride(-3));
+  }
+#endif
   if (Stats) {
-    auto RAG_STATS_OFF =
-        mha_graph->tensor(fe::graph::Tensor_attributes()
-                              .set_uid(RAG_LSE_OFF)
-                              .set_name("cum_seq_stats")
-                              .set_dim({b + 1, 1, 1, 1})
-                              .set_stride({1, 1, 1, 1})
-                              .set_data_type(fe::DataType_t::INT32));
     Stats->set_output(true)
         .set_uid(LSE)
         .set_data_type(fe::DataType_t::FLOAT)
         .set_dim({b, h_q, s_q, 1})
         .set_stride(thd_to_bhsd_strides(softmaxstats));
-    Stats->set_ragged_offset(RAG_STATS_OFF);
+    Stats->set_ragged_offset(
+        ragged_offset_tensor(RAG_LSE_OFF, "cum_seq_stats"));
   }
   AT_CUDNN_FRONTEND_CHECK(mha_graph->validate());
   AT_CUDNN_FRONTEND_CHECK(mha_graph->build_operation_graph(handle));
@@ -1721,6 +1749,10 @@ void run_cudnn_SDP_fprop_nestedtensor(
   if (!o.defined()) {
     alloc_with_matching_layout(q, o, {q.size(0), h_q, d_v});
   }
+  const bool use_cu_seqlen = supports_cumulative_sequence_lengths() &&
+      !seqused_k.has_value() && dropout_probability == 0.0 &&
+      q.stride(-3) > 0 && k.stride(-3) > 0 && v.stride(-3) > 0 &&
+      o.stride(-3) > 0;
 
   if (return_softmaxstats && !softmaxstats.defined()) {
     // cuDNN wants T, H, 1, but torch/FA convention is H, T
@@ -1751,7 +1783,8 @@ void run_cudnn_SDP_fprop_nestedtensor(
       is_causal,
       return_softmaxstats,
       true,
-      page_table);
+      page_table,
+      use_cu_seqlen);
 
   MHAGraphCache& cache = getMHAGraphCache_();
   auto cache_it = cache.find(key);
@@ -1772,6 +1805,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
         cum_seqlen_q,
         cum_seqlen_kv,
         page_table,
+        use_cu_seqlen,
         q,
         k,
         v,
@@ -1785,49 +1819,59 @@ void run_cudnn_SDP_fprop_nestedtensor(
   }
   const fe::graph::Graph& mha_graph = *cache_it->second;
 
-  const bool shared_cum_seqlen = cum_seqlen_q.is_same(cum_seqlen_kv);
-  auto seqlen_q = at::diff(cum_seqlen_q, 1, 0);
-  Tensor seqlen_kv;
-  if (seqused_k.has_value()) {
-    seqlen_kv = seqused_k.value();
-  } else if (shared_cum_seqlen) {
-    seqlen_kv = seqlen_q;
-  } else {
-    seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
-  }
   check_ragged_offset_capacity(q, "query");
   check_ragged_offset_capacity(o, "out");
   if (!is_paged) {
     check_ragged_offset_capacity(k, "key");
     check_ragged_offset_capacity(v, "value");
   }
-  auto rag_q_off = cum_seqlen_q.mul(q.stride(-3));
-  auto rag_o_off =
-      ragged_offset(cum_seqlen_q, o.stride(-3), rag_q_off, q.stride(-3));
-  Tensor rag_k_off, rag_v_off;
-  if (!is_paged) {
-    rag_k_off = shared_cum_seqlen && k.stride(-3) == q.stride(-3)
-        ? rag_q_off
-        : cum_seqlen_kv.mul(k.stride(-3));
-    rag_v_off =
-        ragged_offset(cum_seqlen_kv, v.stride(-3), rag_k_off, k.stride(-3));
-  }
   std::unordered_map<int64_t, void*> variant_pack = {
       {Q, q.mutable_data_ptr()},
       {K, k.mutable_data_ptr()},
       {V, v.mutable_data_ptr()},
       {SCALE, &scaling_factor},
-      {O, o.mutable_data_ptr()},
-      {RAG_Q_OFF, rag_q_off.mutable_data_ptr()},
-      {RAG_O_OFF, rag_o_off.mutable_data_ptr()},
-      {SEQ_LEN_Q, seqlen_q.mutable_data_ptr()},
-      {SEQ_LEN_KV, seqlen_kv.mutable_data_ptr()}};
+      {O, o.mutable_data_ptr()}};
+  Tensor seqlen_q, seqlen_kv, rag_q_off, rag_k_off, rag_v_off, rag_o_off;
+#if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
+  if (use_cu_seqlen) {
+    variant_pack[CU_SEQ_LEN_Q] = cum_seqlen_q.mutable_data_ptr();
+    variant_pack[CU_SEQ_LEN_KV] = cum_seqlen_kv.mutable_data_ptr();
+    variant_pack[RAG_Q_OFF] = cum_seqlen_q.mutable_data_ptr();
+    variant_pack[RAG_O_OFF] = cum_seqlen_q.mutable_data_ptr();
+    variant_pack[RAG_K_OFF] = cum_seqlen_kv.mutable_data_ptr();
+    variant_pack[RAG_V_OFF] = cum_seqlen_kv.mutable_data_ptr();
+  }
+#endif
+  if (!use_cu_seqlen) {
+    const bool shared_cum_seqlen = cum_seqlen_q.is_same(cum_seqlen_kv);
+    seqlen_q = at::diff(cum_seqlen_q, 1, 0);
+    if (seqused_k.has_value()) {
+      seqlen_kv = seqused_k.value();
+    } else if (shared_cum_seqlen) {
+      seqlen_kv = seqlen_q;
+    } else {
+      seqlen_kv = at::diff(cum_seqlen_kv, 1, 0);
+    }
+    rag_q_off = cum_seqlen_q.mul(q.stride(-3));
+    rag_o_off =
+        ragged_offset(cum_seqlen_q, o.stride(-3), rag_q_off, q.stride(-3));
+    variant_pack[RAG_Q_OFF] = rag_q_off.mutable_data_ptr();
+    variant_pack[RAG_O_OFF] = rag_o_off.mutable_data_ptr();
+    variant_pack[SEQ_LEN_Q] = seqlen_q.mutable_data_ptr();
+    variant_pack[SEQ_LEN_KV] = seqlen_kv.mutable_data_ptr();
+    if (!is_paged) {
+      rag_k_off = shared_cum_seqlen && k.stride(-3) == q.stride(-3)
+          ? rag_q_off
+          : cum_seqlen_kv.mul(k.stride(-3));
+      rag_v_off =
+          ragged_offset(cum_seqlen_kv, v.stride(-3), rag_k_off, k.stride(-3));
+      variant_pack[RAG_K_OFF] = rag_k_off.mutable_data_ptr();
+      variant_pack[RAG_V_OFF] = rag_v_off.mutable_data_ptr();
+    }
+  }
   if (is_paged) {
     variant_pack[PAGE_TABLE_K] = page_table.value().mutable_data_ptr();
     variant_pack[PAGE_TABLE_V] = page_table.value().mutable_data_ptr();
-  } else {
-    variant_pack[RAG_K_OFF] = rag_k_off.mutable_data_ptr();
-    variant_pack[RAG_V_OFF] = rag_v_off.mutable_data_ptr();
   }
   if (return_softmaxstats) {
     TORCH_INTERNAL_ASSERT(

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -285,6 +285,11 @@ static fe::DataType_t bias_data_type(const Tensor& attn_bias) {
   }
 }
 
+enum class SequenceLengthMode : uint8_t {
+  PER_SEQUENCE = 0,
+  CUMULATIVE = 1,
+};
+
 struct MHAParams {
   c10::DeviceIndex device_id;
   fe::DataType_t dataType;
@@ -322,7 +327,7 @@ struct MHAParams {
   bool use_ragged;
   bool is_paged;
   bool is_nested;
-  bool use_cu_seqlen;
+  SequenceLengthMode sequence_length_mode;
 };
 
 namespace {
@@ -402,7 +407,7 @@ void setMHAParams(
     bool return_softmaxstats,
     bool is_nested,
     const std::optional<Tensor>& page_table,
-    bool use_cu_seqlen) {
+    SequenceLengthMode sequence_length_mode) {
   memset(&params, 0, sizeof(MHAParams));
   params.device_id = at::cuda::current_device();
   params.dataType = fe::DataType_t::HALF;
@@ -421,7 +426,7 @@ void setMHAParams(
   params.has_attn_bias = attn_bias.has_value();
   params.is_paged = page_table.has_value();
   params.is_nested = is_nested;
-  params.use_cu_seqlen = use_cu_seqlen;
+  params.sequence_length_mode = sequence_length_mode;
   // Paged K/V remain 4D page pools in the nested path.
   const uint8_t q_rank = (uint8_t)(MAX_MHA_DIM - (uint8_t)is_nested);
   const uint8_t kv_rank = params.is_paged ? MAX_MHA_DIM : q_rank;
@@ -508,7 +513,8 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
       bool return_softmaxstats,
       bool is_nested,
       const std::optional<Tensor>& page_table = std::nullopt,
-      bool use_cu_seqlen = false) {
+      SequenceLengthMode sequence_length_mode =
+          SequenceLengthMode::PER_SEQUENCE) {
     setMHAParams(
         this->pod,
         b,
@@ -529,7 +535,7 @@ struct MHACacheKeyWrapper : ParamsWrapper<MHAParams> {
         return_softmaxstats,
         is_nested,
         page_table,
-        use_cu_seqlen);
+        sequence_length_mode);
   }
 };
 
@@ -894,7 +900,7 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
     const Tensor& cum_seqlen_q,
     const Tensor& cum_seqlen_kv,
     const std::optional<Tensor>& page_table,
-    bool use_cu_seqlen,
+    SequenceLengthMode sequence_length_mode,
     const Tensor& q,
     const Tensor& k,
     const Tensor& v,
@@ -947,7 +953,7 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
           .set_attn_scale(attn_scale)
           .set_padding_mask(true);
 #if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
-  if (use_cu_seqlen) {
+  if (sequence_length_mode == SequenceLengthMode::CUMULATIVE) {
     auto CU_SEQ_LEN_Q_ = index_tensor(CU_SEQ_LEN_Q, "Cu_seq_q", b + 1);
     auto CU_SEQ_LEN_KV_ = index_tensor(CU_SEQ_LEN_KV, "Cu_seq_kv", b + 1);
     scaled_dot_product_flash_attention_options.set_cu_seq_len_q(CU_SEQ_LEN_Q_)
@@ -955,7 +961,7 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
         .set_implementation(fe::AttentionImplementation_t::UNIFIED);
   }
 #endif
-  if (!use_cu_seqlen) {
+  if (sequence_length_mode == SequenceLengthMode::PER_SEQUENCE) {
     scaled_dot_product_flash_attention_options
         .set_seq_len_q(index_tensor(SEQ_LEN_Q, "Seq_q", b))
         .set_seq_len_kv(index_tensor(SEQ_LEN_KV, "Seq_kv", b));
@@ -1065,7 +1071,7 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
     V_->set_ragged_offset(ragged_offset_tensor(RAG_V_OFF, "cum_seq_v"));
   }
 #if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
-  if (use_cu_seqlen) {
+  if (sequence_length_mode == SequenceLengthMode::CUMULATIVE) {
     TORCH_INTERNAL_ASSERT(!is_paged);
     Q_->set_ragged_offset_multiplier(q.stride(-3));
     K_->set_ragged_offset_multiplier(k.stride(-3));
@@ -1080,7 +1086,7 @@ std::unique_ptr<fe::graph::Graph> build_graph_nestedtensor(
       .set_stride(thd_to_bhsd_strides(o));
   O_->set_ragged_offset(RAG_O_OFF_);
 #if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
-  if (use_cu_seqlen) {
+  if (sequence_length_mode == SequenceLengthMode::CUMULATIVE) {
     O_->set_ragged_offset_multiplier(o.stride(-3));
   }
 #endif
@@ -1749,10 +1755,12 @@ void run_cudnn_SDP_fprop_nestedtensor(
   if (!o.defined()) {
     alloc_with_matching_layout(q, o, {q.size(0), h_q, d_v});
   }
-  const bool use_cu_seqlen = supports_cumulative_sequence_lengths() &&
-      !seqused_k.has_value() && dropout_probability == 0.0 &&
-      q.stride(-3) > 0 && k.stride(-3) > 0 && v.stride(-3) > 0 &&
-      o.stride(-3) > 0;
+  const auto sequence_length_mode = supports_cumulative_sequence_lengths() &&
+          !seqused_k.has_value() && dropout_probability == 0.0 &&
+          q.stride(-3) > 0 && k.stride(-3) > 0 && v.stride(-3) > 0 &&
+          o.stride(-3) > 0
+      ? SequenceLengthMode::CUMULATIVE
+      : SequenceLengthMode::PER_SEQUENCE;
 
   if (return_softmaxstats && !softmaxstats.defined()) {
     // cuDNN wants T, H, 1, but torch/FA convention is H, T
@@ -1784,7 +1792,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
       return_softmaxstats,
       true,
       page_table,
-      use_cu_seqlen);
+      sequence_length_mode);
 
   MHAGraphCache& cache = getMHAGraphCache_();
   auto cache_it = cache.find(key);
@@ -1805,7 +1813,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
         cum_seqlen_q,
         cum_seqlen_kv,
         page_table,
-        use_cu_seqlen,
+        sequence_length_mode,
         q,
         k,
         v,
@@ -1833,7 +1841,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
       {O, o.mutable_data_ptr()}};
   Tensor seqlen_q, seqlen_kv, rag_q_off, rag_k_off, rag_v_off, rag_o_off;
 #if AT_CUDNN_HAS_CUMULATIVE_SEQUENCE_LENGTHS
-  if (use_cu_seqlen) {
+  if (sequence_length_mode == SequenceLengthMode::CUMULATIVE) {
     variant_pack[CU_SEQ_LEN_Q] = cum_seqlen_q.mutable_data_ptr();
     variant_pack[CU_SEQ_LEN_KV] = cum_seqlen_kv.mutable_data_ptr();
     variant_pack[RAG_Q_OFF] = cum_seqlen_q.mutable_data_ptr();
@@ -1842,7 +1850,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
     variant_pack[RAG_V_OFF] = cum_seqlen_kv.mutable_data_ptr();
   }
 #endif
-  if (!use_cu_seqlen) {
+  if (sequence_length_mode == SequenceLengthMode::PER_SEQUENCE) {
     const bool shared_cum_seqlen = cum_seqlen_q.is_same(cum_seqlen_kv);
     seqlen_q = at::diff(cum_seqlen_q, 1, 0);
     if (seqused_k.has_value()) {

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1141,8 +1141,9 @@ class TestVarlenAttention(NNTestCase):
     ):
         """Select only large head-dimension combinations supported by cuDNN."""
         _check_cudnn_varlen_supported(device)
+        cudnn_version = torch.backends.cudnn.version() or 0
         required_version = 91900 if requires_backward else 92400
-        supported = supported and torch.backends.cudnn.version() >= required_version
+        is_supported = supported and cudnn_version >= required_version
         torch.manual_seed(42)
         seq_len, num_heads = 256, 2
         q = torch.randn(
@@ -1154,26 +1155,27 @@ class TestVarlenAttention(NNTestCase):
         ).requires_grad_(requires_backward)
         cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
 
-        if not supported:
-            contexts = (
-                (nullcontext(), torch.no_grad())
-                if requires_backward
-                else (nullcontext(),)
-            )
-            for context in contexts:
-                with context, sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-                    with self.assertRaisesRegex(
-                        RuntimeError, "unsupported for cuDNN varlen"
-                    ):
-                        varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-            return
-
         q_ref, k_ref, v_ref = (
             tensor.detach().double().requires_grad_(requires_backward)
             for tensor in (q, k, v)
         )
         scores = torch.einsum("thd,shd->hts", q_ref, k_ref) / math.sqrt(qk_dim)
         expected = torch.einsum("hts,shd->thd", scores.softmax(-1), v_ref)
+
+        if not is_supported:
+            with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                with self.assertRaisesRegex(
+                    RuntimeError, "unsupported for cuDNN varlen"
+                ):
+                    varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+                if requires_backward and cudnn_version >= 92400:
+                    with torch.no_grad():
+                        out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+                    self.assertEqual(
+                        out.float(), expected.float(), atol=2e-2, rtol=2e-2
+                    )
+            return
+
         grad_out = torch.randn_like(v)
         if requires_backward:
             expected_grads = torch.autograd.grad(

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1004,6 +1004,62 @@ class TestVarlenAttention(NNTestCase):
         self.assertEqual(actual, expected)
 
     @skipIfRocm
+    @parametrize("dtype", [torch.bfloat16, torch.float16])
+    @parametrize("different_kv_stride", [False, True])
+    def test_cudnn_varlen_cumulative_sequence_lengths(
+        self, device, dtype, different_kv_stride
+    ):
+        """Direct cumulative lengths match the legacy per-sequence path."""
+        _check_cudnn_varlen_supported(device)
+        if torch.backends.cudnn.version() < 92400:
+            raise unittest.SkipTest("direct cumulative lengths require cuDNN 9.24")
+        torch.manual_seed(42)
+        total, num_heads, head_dim = 512, 4, 64
+        q = torch.randn(
+            total, num_heads, head_dim, device=device, dtype=dtype
+        ).requires_grad_()
+
+        def make_kv():
+            shape = (total, num_heads, head_dim + 8) if different_kv_stride else q.shape
+            tensor = torch.randn(shape, device=device, dtype=dtype)
+            return tensor[..., :head_dim].requires_grad_()
+
+        k, v = make_kv(), make_kv()
+        cu_seq_q = torch.tensor([-1, 0, 192, total], device=device, dtype=torch.int32)[
+            1:
+        ]
+        cu_seq_k = torch.tensor([-1, 0, 256, total], device=device, dtype=torch.int32)[
+            1:
+        ]
+        self.assertNotEqual(cu_seq_q.data_ptr() % 16, 0)
+        self.assertNotEqual(cu_seq_k.data_ptr() % 16, 0)
+
+        def run(seqused_k):
+            with torch.no_grad(), sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                return varlen_attn(
+                    q,
+                    k,
+                    v,
+                    cu_seq_q,
+                    cu_seq_k,
+                    320,
+                    256,
+                    seqused_k=seqused_k,
+                    return_aux=AuxRequest(lse=True),
+                )
+
+        direct = run(None)
+        legacy = run(torch.diff(cu_seq_k))
+        direct_again = run(None)
+        self.assertEqual(direct, legacy)
+        self.assertEqual(direct_again, direct)
+        with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+            out = varlen_attn(q, k, v, cu_seq_q, cu_seq_k, 320, 256)
+            grads = torch.autograd.grad(out, (q, k, v), torch.randn_like(out))
+        for grad in grads:
+            self.assertTrue(torch.isfinite(grad).all())
+
+    @skipIfRocm
     @parametrize("tensor_idx", [0, 1, 2])
     def test_cudnn_varlen_unaligned_input_raises(self, device, tensor_idx):
         """Reject varlen inputs whose row strides are not 16-byte aligned.

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1011,8 +1011,6 @@ class TestVarlenAttention(NNTestCase):
     ):
         """Direct cumulative lengths match the legacy per-sequence path."""
         _check_cudnn_varlen_supported(device)
-        if torch.backends.cudnn.version() < 92400:
-            raise unittest.SkipTest("direct cumulative lengths require cuDNN 9.24")
         torch.manual_seed(42)
         total, num_heads, head_dim = 512, 4, 64
         q = torch.randn(

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -1121,40 +1121,74 @@ class TestVarlenAttention(NNTestCase):
             self.assertEqual(got.float(), want.float(), atol=2e-2, rtol=2e-2)
 
     @skipIfRocm
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
+    @unittest.skipUnless(SM100OrLater, "large varlen head dimensions require SM100")
+    @parametrize(
+        "qk_dim,value_dim,requires_backward,supported",
+        [
+            (192, 128, False, True),
+            (192, 192, False, True),
+            (256, 128, False, True),
+            (256, 256, False, True),
+            (128, 256, False, False),
+            (192, 128, True, True),
+            (192, 192, True, False),
+            (256, 128, True, False),
+            (256, 256, True, False),
+        ],
     )
-    def test_cudnn_varlen_rejects_large_head_dim(self, device):
-        """Head dims above 128 must fall back to Flash instead of failing in cuDNN."""
+    def test_cudnn_varlen_large_head_dims(
+        self, device, qk_dim, value_dim, requires_backward, supported
+    ):
+        """Select only large head-dimension combinations supported by cuDNN."""
         _check_cudnn_varlen_supported(device)
-        seq_len, num_heads, head_dim = 256, 2, 192
+        required_version = 91900 if requires_backward else 92400
+        supported = supported and torch.backends.cudnn.version() >= required_version
+        torch.manual_seed(42)
+        seq_len, num_heads = 256, 2
         q = torch.randn(
-            seq_len, num_heads, head_dim, device=device, dtype=torch.bfloat16
-        )
-        k, v = torch.randn_like(q), torch.randn_like(q)
+            seq_len, num_heads, qk_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_(requires_backward)
+        k = torch.randn_like(q, requires_grad=requires_backward)
+        v = torch.randn(
+            seq_len, num_heads, value_dim, device=device, dtype=torch.bfloat16
+        ).requires_grad_(requires_backward)
         cu_seq = torch.tensor([0, seq_len], device=device, dtype=torch.int32)
 
-        with (
-            patch.object(
-                torch.ops.aten,
-                "_flash_attention_forward",
-                wraps=torch.ops.aten._flash_attention_forward,
-            ) as flash_forward,
-            patch.object(
-                torch.ops.aten,
-                "_cudnn_attention_forward",
-                wraps=torch.ops.aten._cudnn_attention_forward,
-            ) as cudnn_forward,
-        ):
-            varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
-        self.assertEqual(flash_forward.call_count, 1)
-        self.assertEqual(cudnn_forward.call_count, 0)
+        if not supported:
+            contexts = (
+                (nullcontext(), torch.no_grad())
+                if requires_backward
+                else (nullcontext(),)
+            )
+            for context in contexts:
+                with context, sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                    with self.assertRaisesRegex(
+                        RuntimeError, "unsupported for cuDNN varlen"
+                    ):
+                        varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+            return
+
+        q_ref, k_ref, v_ref = (
+            tensor.detach().double().requires_grad_(requires_backward)
+            for tensor in (q, k, v)
+        )
+        scores = torch.einsum("thd,shd->hts", q_ref, k_ref) / math.sqrt(qk_dim)
+        expected = torch.einsum("hts,shd->thd", scores.softmax(-1), v_ref)
+        grad_out = torch.randn_like(v)
+        if requires_backward:
+            expected_grads = torch.autograd.grad(
+                expected, (q_ref, k_ref, v_ref), grad_out.double()
+            )
 
         with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
-            with self.assertRaisesRegex(
-                RuntimeError, "head dimensions must be at most 128"
-            ):
-                varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+            out = varlen_attn(q, k, v, cu_seq, cu_seq, seq_len, seq_len)
+            self.assertEqual(out.float(), expected.float(), atol=2e-2, rtol=2e-2)
+            if requires_backward:
+                grads = torch.autograd.grad(out, (q, k, v), grad_out)
+                for grad, expected_grad in zip(grads, expected_grads):
+                    self.assertEqual(
+                        grad.float(), expected_grad.float(), atol=2e-2, rtol=2e-2
+                    )
 
     @skipIfRocm
     def test_cudnn_varlen_key_head_dim_mismatch_raises(self, device):

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -23,6 +23,10 @@ __all__ = ["varlen_attn", "varlen_attn_out", "AuxRequest"]
 # Custom op schemas do not support enum arguments, so pass SDPBackend values as ints.
 _FLASH_ATTENTION_BACKEND = SDPBackend.FLASH_ATTENTION.value
 _CUDNN_ATTENTION_BACKEND = SDPBackend.CUDNN_ATTENTION.value
+_CUDNN_SM100_FORWARD_LARGE_HEAD_DIMS = frozenset(
+    {(192, 128), (192, 192), (256, 128), (256, 256)}
+)
+_CUDNN_SM100_BACKWARD_LARGE_HEAD_DIMS = frozenset({(192, 128)})
 
 
 def _normalize_window_size(window_size: list[int] | None) -> list[int]:
@@ -51,17 +55,38 @@ def _get_sdp_priority_order() -> list[int]:
 
 @lru_cache(maxsize=8)
 @torch.compiler.assume_constant_result
+def _cudnn_version_and_major_capability(device_index: int) -> tuple[int | None, int]:
+    """Cache cuDNN and device capability queries used by backend selection."""
+    return torch.backends.cudnn.version(), torch.cuda.get_device_capability(
+        device_index
+    )[0]
+
+
+@lru_cache(maxsize=8)
+@torch.compiler.assume_constant_result
 def _should_use_cudnn(device_index: int) -> bool:
     """Cache device capability check to avoid repeated CUDA calls."""
     if torch.version.hip is not None:
         return False
-    cudnn_version = torch.backends.cudnn.version()
-    if cudnn_version is None or cudnn_version < 91800:
-        return False
-    major_cap = torch.cuda.get_device_capability(device_index)[0]
-    if major_cap == 9 or major_cap == 10:
+    cudnn_version, major_cap = _cudnn_version_and_major_capability(device_index)
+    return cudnn_version is not None and cudnn_version >= 91800 and major_cap in (9, 10)
+
+
+def _cudnn_supports_head_dims(
+    query: torch.Tensor, value: torch.Tensor, needs_backward: bool
+) -> bool:
+    """Return whether cuDNN supports this varlen head-dimension combination."""
+    dims = (query.shape[-1], value.shape[-1])
+    if dims[0] <= 128 and dims[1] <= 128:
         return True
-    return False
+    if not query.is_cuda:
+        return False
+    cudnn_version, major_cap = _cudnn_version_and_major_capability(query.device.index)
+    if cudnn_version is None or major_cap != 10:
+        return False
+    if not needs_backward:
+        return cudnn_version >= 92400 and dims in _CUDNN_SM100_FORWARD_LARGE_HEAD_DIMS
+    return cudnn_version >= 91900 and dims in _CUDNN_SM100_BACKWARD_LARGE_HEAD_DIMS
 
 
 def _cudnn_rejection_reasons(
@@ -89,8 +114,13 @@ def _cudnn_rejection_reasons(
         reasons.append("query dtype must be float16 or bfloat16")
     if query.shape[-1] % 8 != 0 or value.shape[-1] % 8 != 0:
         reasons.append("query and value head dimensions must be divisible by 8")
-    if query.shape[-1] > 128 or value.shape[-1] > 128:
-        reasons.append("head dimensions must be at most 128")
+    needs_backward = any(tensor.requires_grad for tensor in (query, key, value))
+    if not _cudnn_supports_head_dims(query, value, needs_backward):
+        phase = "backward" if needs_backward else "forward"
+        reasons.append(
+            f"query/value head dimensions {(query.shape[-1], value.shape[-1])} "
+            f"are unsupported for cuDNN varlen {phase}"
+        )
     if window_size == [-1, 0]:
         if cu_seq_q is not cu_seq_k:
             reasons.append(

--- a/torch/nn/attention/varlen.py
+++ b/torch/nn/attention/varlen.py
@@ -114,7 +114,9 @@ def _cudnn_rejection_reasons(
         reasons.append("query dtype must be float16 or bfloat16")
     if query.shape[-1] % 8 != 0 or value.shape[-1] % 8 != 0:
         reasons.append("query and value head dimensions must be divisible by 8")
-    needs_backward = any(tensor.requires_grad for tensor in (query, key, value))
+    needs_backward = torch.is_grad_enabled() and any(
+        tensor.requires_grad for tensor in (query, key, value)
+    )
     if not _cudnn_supports_head_dims(query, value, needs_backward):
         phase = "backward" if needs_backward else "forward"
         reasons.append(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #194906

## Human Note

Use new API and also update headdim support table

## Agent note

This commit was authored with an AI assistant.

cuDNN varlen forward currently converts cumulative sequence lengths into per-sequence lengths with `diff`
and multiplies them by token strides to form ragged offsets. cuDNN 9.24 and Frontend 1.25 added direct
cumulative-length inputs and per-tensor ragged-offset multipliers, so regular packed forward can consume the
public API's existing metadata without either conversion kernel.

Use the direct representation only when the compiled frontend, compiled cuDNN headers, and loaded cuDNN
runtime support it. Dropout, `seqused_k`/paged KV, non-positive token strides, cuDNN 9.18-9.23, and older
frontend builds retain the existing path. The selected representation is part of the graph cache key because
regular and legacy calls with otherwise identical shapes require different graph UIDs. Backward remains on
per-sequence lengths because cuDNN 9.24 does not expose cumulative-length backward attributes.

The direct cumulative tensors also serve as Q/K/V/O ragged offsets. Their token strides are passed through
cuDNN's ragged-offset multiplier, reducing regular forward from four kernels to two:

```text
legacy: diff(cu_seq), cu_seq * token_stride, qkv_tma_setup, attention
direct:                                qkv_tma_setup, attention
```

## Performance

Matched A/B on one GB200, BF16 causal varlen, H=16, d=128, exactly 16,384 packed tokens. Both variants call
the internal custom op under `no_grad` so the legacy causal path can be forced with
`seqused_k == diff(cu_seq_k)`. Timings are medians of five alternating rounds; CUDA graph replay uses
Transformer Nuggets with 20 warmups and 100 fixed-pointer replays.

![Direct cumulative lengths before and after](https://gist.githubusercontent.com/drisspg/914f2970e21a7661e508184d9fa35426/raw/b5f330543a40ddd88bdea0f4c5ee22086fed9192/direct_cu_seqlen_before_after.png)

| workload | eager legacy -> direct | graph legacy -> direct |
| --- | ---: | ---: |
| uniform short | 260.9 -> 215.5 us | 83.9 -> 76.9 us |
| multi-scale | 349.4 -> 307.8 us | 200.6 -> 194.0 us |
| long-tail | 362.2 -> 321.7 us | 215.0 -> 205.8 us |
| uniform long | 455.5 -> 415.2 us | 295.8 -> 287.9 us |

The larger eager improvement comes from eliminating two host-separated launches; CUDA graph replay captures
the 3-9 us of removed GPU work. Full direct-path backend comparison:

![CUDA graph varlen throughput](https://gist.githubusercontent.com/drisspg/914f2970e21a7661e508184d9fa35426/raw/b5f330543a40ddd88bdea0f4c5ee22086fed9192/varlen_distribution_direct_cuda_graph_tflops.png)

![CUDA graph varlen MLA d192/d128 throughput](https://gist.githubusercontent.com/drisspg/914f2970e21a7661e508184d9fa35426/raw/f067a5b421a2375d303a7044322bd94f6ffb7673/varlen_distribution_mla_192x128_cuda_graph_tflops.png)

Other cuDNN features were tested and intentionally excluded:

- `unfuse_fma` regressed representative forward cases by 3-8%.
- The second heuristic-A plan was 1.8-10x slower than the first recommended plan.
- `max_total_seq_len_q/kv` on cuDNN 9.24 produced impossible >5 PFLOP/s-equivalent timings and gradient
  errors up to 5.16, indicating skipped work rather than a speedup.
- Packing documents longest-first improved d128 multi-scale cuDNN from 189.4 to 162.4 us forward and 766.6 to
  729.3 us backward, but ordering belongs in the upstream packer because cuDNN exposes no batch-remapping
  input and changing it inside the op would require data movement.

Raw samples, exact kernel names, reproduction scripts, and the investigation report are in the
[benchmark gist](https://gist.github.com/drisspg/914f2970e21a7661e508184d9fa35426).

## Test Plan

```bash
source ~/.venvs/dev/bin/activate && source ~/dotfiles/scripts/_build_setup.sh -b200 && CCACHE_NOHASHDIR=true uv pip install -e . --no-build-isolation -v
gpu-run auto -- env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/pytest -q test/test_varlen_attention.py -n 8
lintrunner -a
gpu-run auto -- zsh -ic 'cd /home/drisspg/meta/pytorch && sanitize env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/python agent_space/varlen_cudnn_audit/round2/perf_cuda_graphs/sanitize_alias_reuse.py'
gpu-run auto -- env PYTHONPATH=$PWD /home/drisspg/.venvs/dev/bin/python agent_space/varlen_cudnn_audit/round2/perf_direct_cu_seqlen/benchmark.py
```

388 passed / 72 skipped / 8 xfailed / 9 subtests passed; Compute Sanitizer memcheck reported zero errors.

cc @liangel-02 @howardzhang-cv
