### PR TITLE
[symm_mem] Fix multicast rendezvous cleanup

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -358,8 +358,17 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
 
         pg = dist.group.WORLD
         pg.use_pg_for_symm_mem_rendezvous = True
+        # A natively recording backend ("nccl") writes into the CUDAEvent
+        # recorder that _dump_nccl_trace reads; a hooked one ("nccl2") gets its
+        # own c10::Event instance keyed by backend name. Both name their entries
+        # after the backend, so read whichever instance this group records into.
+        backend_name = pg._get_backend(torch.device(self.device)).name()
+        records_natively = backend_name == "nccl"
         try:
-            torch._C._distributed_c10d._reset_fr_recording_nccl()
+            if records_natively:
+                torch._C._distributed_c10d._reset_fr_recording_nccl()
+            else:
+                torch._C._distributed_c10d._reset_fr_trace(backend=backend_name)
 
             t = symm_mem.empty(64, dtype=torch.float32, device=self.device).fill_(
                 self.rank
@@ -369,23 +378,26 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
             self.assertEqual(symm_mem_hdl.rank, self.rank)
             self.assertEqual(symm_mem_hdl.world_size, self.world_size)
 
-            entries = pickle.loads(torch._C._distributed_c10d._dump_nccl_trace())[
-                "entries"
-            ]
-            ag_entries = [
-                e for e in entries if e["profiling_name"] == "nccl:_all_gather_base"
-            ]
-            bc_entries = [e for e in entries if e["profiling_name"] == "nccl:broadcast"]
+            trace = (
+                torch._C._distributed_c10d._dump_nccl_trace()
+                if records_natively
+                else torch._C._distributed_c10d._dump_fr_trace(backend=backend_name)
+            )
+            entries = pickle.loads(trace)["entries"]
+            ag_name = f"{backend_name}:_all_gather_base"
+            ag_entries = [e for e in entries if e["profiling_name"] == ag_name]
+            bc_name = f"{backend_name}:broadcast"
+            bc_entries = [e for e in entries if e["profiling_name"] == bc_name]
             has_mc = symm_mem_hdl.multicast_ptr != 0
             # Exchanges routed through the PG: the RendezvousRequest allgather
             # (always), the handle exchange allgather (NVLink-fabric hardware
             # only; elsewhere handles go through ipc_channel), and, when
-            # multicast is set up, a success-flag allgather plus a multicast
-            # handle broadcast (fabric only).
-            lo, hi = (2, 3) if has_mc else (1, 2)
+            # multicast is set up, pre-bind and final success-flag allgathers
+            # plus a multicast handle broadcast (fabric only).
+            lo, hi = (3, 4) if has_mc else (1, 2)
             self.assertTrue(
                 lo <= len(ag_entries) <= hi,
-                f"expected {lo} to {hi} NCCL _all_gather_base from rendezvous "
+                f"expected {lo} to {hi} {ag_name} from rendezvous "
                 f"(multicast={has_mc}), got {len(ag_entries)}: "
                 f"{[e['profiling_name'] for e in entries]}",
             )

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -549,6 +549,23 @@ static bool check_group_multicast_support(
   }
 }
 
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
+    defined(CUDART_SUPPORTS_MULTICAST)
+static void warn_cuda_driver_error(CUresult err, const char* message) {
+  if (err == CUDA_SUCCESS) {
+    return;
+  }
+  const char* err_str = nullptr;
+  auto get_error_str_err =
+      c10::cuda::DriverAPI::get()->cuGetErrorString_(err, &err_str);
+  if (get_error_str_err != CUDA_SUCCESS) {
+    LOG(WARNING) << message << ": CUDA driver error: unknown error";
+  } else {
+    LOG(WARNING) << message << ": CUDA driver error: " << err_str;
+  }
+}
+#endif
+
 template <bool use_fabric_handle>
 static void init_multicast_for_block(
     HandleType& mc_handle,
@@ -600,25 +617,34 @@ static void init_multicast_for_block(
   }
 
   // Phase 2: Exchange handle
-  McHandleType recv_handle;
+  McHandleType recv_handle = invalidator;
   if constexpr (!use_fabric_handle) {
     recv_handle = ipc_channel.broadcast_fds(rank, 0, pids, mc_exported_handle);
   } else if (use_pg) {
     recv_handle = pg_broadcast(group, block->device_idx, 0, mc_exported_handle);
   } else {
     // TODO implement storeExchange.broadcast
-    auto gathered_handles = storeExchange.all_gather(store, rank, world_size, mc_exported_handle);
+    auto gathered_handles =
+        storeExchange.all_gather(store, rank, world_size, mc_exported_handle);
     recv_handle = std::move(gathered_handles[0]);
   }
 
   // Check exchange result
   if (memcmp(&recv_handle, &invalidator, sizeof(McHandleType)) == 0) {
+    if (rank == 0 && mc_handle != 0) {
+      warn_cuda_driver_error(
+          driver_api->cuMemRelease_(mc_handle),
+          "SymmetricMemory: failed to release multicast handle");
+      mc_handle = 0;
+    }
     LOG(WARNING) << "Gracefully skipping multicast initialization.";
     return;
   }
 
-  // Flip to true after all CUDA steps finish
+  // Track progress for cross-rank failure checks and cleanup.
+  bool import_add_success = false;
   bool success_end = false;
+  bool multicast_bound = false;
 
   // Phase 3: Import handle -- every rank, rank 0 included, which self-imports
   // the handle it just exported so that every rank's multicast mapping has
@@ -635,6 +661,33 @@ static void init_multicast_for_block(
   // multicast aperture always reports device ordinal 0, so src != dst forces
   // the peer path for every other device.
   HandleType imported_mc_handle = 0;
+  auto cleanup_multicast = [&]() {
+    if (mc_addr != nullptr) {
+      warn_cuda_driver_error(
+          driver_api->cuMemUnmap_(
+              reinterpret_cast<CUdeviceptr>(mc_addr), block->block_size),
+          "SymmetricMemory: failed to unmap multicast handle");
+      mc_addr = nullptr;
+    }
+    if (imported_mc_handle != 0) {
+      if (multicast_bound) {
+        warn_cuda_driver_error(
+            driver_api->cuMulticastUnbind_(
+                imported_mc_handle, block->device_idx, 0, block->block_size),
+            "SymmetricMemory: failed to unbind multicast handle");
+      }
+      warn_cuda_driver_error(
+          driver_api->cuMemRelease_(imported_mc_handle),
+          "SymmetricMemory: failed to release multicast handle");
+      imported_mc_handle = 0;
+    }
+    if (mc_handle != 0) {
+      warn_cuda_driver_error(
+          driver_api->cuMemRelease_(mc_handle),
+          "SymmetricMemory: failed to release multicast handle");
+      mc_handle = 0;
+    }
+  };
   if constexpr (!use_fabric_handle) {
     // Convert back to a handle from the broadcasted POSIX file descriptor.
     // The fd is the handle: widen it to pointer size, then reinterpret it as
@@ -642,20 +695,62 @@ static void init_multicast_for_block(
     C10_CUDA_DRIVER_CHECK_GOTO(driver_api->cuMemImportFromShareableHandle_(
         &imported_mc_handle,
         reinterpret_cast<void*>(static_cast<uintptr_t>(recv_handle)),
-        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR), check_all);
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR), check_import_add);
   } else {
     C10_CUDA_DRIVER_CHECK_GOTO(driver_api->cuMemImportFromShareableHandle_(
-        &imported_mc_handle, static_cast<void*>(&recv_handle), CU_MEM_HANDLE_TYPE_FABRIC), check_all);
+        &imported_mc_handle,
+        static_cast<void*>(&recv_handle),
+        CU_MEM_HANDLE_TYPE_FABRIC), check_import_add);
+  }
+
+  // All ranks add their device before any rank starts binding memory to the
+  // multicast object. Otherwise, cuMulticastBindMem can wait forever for a
+  // device that never joined the object.
+  C10_CUDA_DRIVER_CHECK_GOTO(
+      driver_api->cuMulticastAddDevice_(imported_mc_handle, block->device_idx),
+      check_import_add);
+  import_add_success = true;
+
+  // TODO: Keep this extra rendezvous in the existing goto style for now;
+  // refactor the multicast setup control flow separately.
+check_import_add:
+  bool all_import_add_succeed = true;
+  auto import_add_success_flag = static_cast<uint8_t>(import_add_success);
+  auto import_add_rank_successes = use_pg
+      ? pg_all_gather(group, block->device_idx, import_add_success_flag)
+      : storeExchange.all_gather(
+            store, rank, world_size, import_add_success_flag);
+  for (int r = 0; r < world_size; ++r) {
+    all_import_add_succeed &= (import_add_rank_successes[r] != 0);
+  }
+  if (!all_import_add_succeed) {
+    if constexpr (!use_fabric_handle) {
+      if (recv_handle >= 0) {
+        close(recv_handle);
+      }
+    }
+    cleanup_multicast();
+    LOG(WARNING) << "Gracefully skipping multicast initialization.";
+    return;
   }
 
   // Phase 4: Bind memory
-  // All rank adds their physical allocation to the multicast object
-  C10_CUDA_DRIVER_CHECK_GOTO(
-      driver_api->cuMulticastAddDevice_(imported_mc_handle, block->device_idx), check_all);
   C10_CUDA_DRIVER_CHECK_GOTO(driver_api->cuMulticastBindMem_(
       imported_mc_handle, 0, block->alloc_ref->handle, 0, block->block_size, 0), check_all);
+  multicast_bound = true;
 
-  success_end = true;
+  // Phase 5: Map to virtual memory
+  // map_block throws, so catch it to make every rank reach the final exchange.
+  // It writes mc_addr after reserving VA; cleanup needs to see that value if a
+  // later map/access step throws.
+  mc_addr = nullptr;
+  try {
+    map_block(&mc_addr, imported_mc_handle, block->block_size, block->device_idx);
+    success_end = true;
+  } catch (const std::exception& e) {
+    LOG(WARNING) << "SymmetricMemory: fail to map multicast handle.\n"
+                 << e.what();
+  }
 
 check_all:
   // Whether all ranks have succeeded
@@ -669,29 +764,30 @@ check_all:
   for (int r = 0; r < world_size; ++r) {
     all_succeed &= (rank_successes[r] != 0);
   }
+  // Close the file descriptor before exit
+  if constexpr (!use_fabric_handle) {
+    if (recv_handle >= 0) {
+      close(recv_handle);
+    }
+  }
+  if (!all_succeed) {
+    cleanup_multicast();
+    LOG(WARNING) << "Gracefully skipping multicast initialization.";
+    return;
+  }
   if (imported_mc_handle != 0) {
-    // Rank 0 may only drop the reference cuMulticastCreate gave it once every
-    // rank has imported, which the all_gather above guarantees. The exported
-    // handle stops resolving to this multicast object as soon as that reference
-    // is gone: a late importer silently gets a fresh, empty object instead, and
-    // then every rank blocks forever in cuMulticastBindMem waiting for a device
-    // that was added to somebody else's object.
+    // Rank 0 may only drop the reference cuMulticastCreate gave it after every
+    // rank has completed setup. The exported handle stops resolving to this
+    // multicast object as soon as that reference is gone: a late importer
+    // silently gets a fresh, empty object instead, and then every rank blocks
+    // forever in cuMulticastBindMem waiting for a device that was added to
+    // somebody else's object.
     if (rank == 0) {
       C10_CUDA_DRIVER_CHECK(driver_api->cuMemRelease_(mc_handle));
     }
     mc_handle = imported_mc_handle;
+    imported_mc_handle = 0;
   }
-  // Close the file descriptor before exit
-  if constexpr (!use_fabric_handle) {
-    close(recv_handle);
-  }
-  if (!all_succeed) {
-    LOG(WARNING) << "Gracefully skipping multicast initialization.";
-    return;
-  }
-
-  // Phase 5: Map to virtual memory
-  map_block(&mc_addr, mc_handle, block->block_size, block->device_idx);
 #endif
 }
 


### PR DESCRIPTION
CUDA symmetric memory could mark multicast setup successful after binding the multicast object but before mapping it. If the later map failed, peers could observe a successful rendezvous and then use an invalid multicast mapping; failure paths could also leave a partially initialized multicast handle behind.

This changes multicast setup so success is published only after the multicast handle has been mapped. When export, success exchange, mapping, or a peer failure causes multicast setup to be abandoned, the partially created multicast mapping, binding, and handle are cleaned up before returning.

NOTE: Changes also add an additional all_gather to exchange successful `cuMulticastAddDevice` across ranks. See detailed flow below

## After the new changes, we end up with the current flow:

```
rank 0  LOCAL   cuMulticastCreate + export
                on failure -> exported = invalidator
COLL A          broadcast(exported) -> recv
        if recv == invalidator:
            rank 0 releases created handle
            return
        LOCAL   cuMemImportFromShareableHandle    -> on failure jump to B
        LOCAL   cuMulticastAddDevice              -> on failure jump to B
                import_add_ok = true
COLL B          all_gather(import_add_ok) <-------- Additional all_gather
        if any rank failed:
            close recv; release imported and created handles
            return
        LOCAL   cuMulticastBindMem                -> on failure jump to C
        LOCAL   map_block -> mc_addr              -> on throw, catch and jump to C
                mapped_ok = true
COLL C          all_gather(mapped_ok)
        LOCAL   close recv
        if any rank failed:
            unmap mc_addr; unbind; release imported and created handles
            return
        rank 0 releases created handle
        commit imported handle + mc_addr to caller
```

##  Test plan

```bash
PYTHONSAFEPATH=1 .venv/bin/python test/distributed/test_symmetric_memory.py
```

___________________________

Authored with AI assistance. (Codex)