### PR TITLE
[symm_mem] Symm mem multicast timeout

### DIFF
--- a/test/cpp/c10d/CMakeLists.txt
+++ b/test/cpp/c10d/CMakeLists.txt
@@ -57,6 +57,10 @@ else()
   endif()
 endif()
 
+if(NOT WIN32 AND NOT USE_ROCM)
+  c10d_add_test(SymmetricMemoryUtilsTest.cpp LINK_LIBRARIES torch_cpu gtest_main INSTALL_TEST ${INSTALL_TEST})
+endif()
+
 if(USE_CUDA)
   if(USE_GLOO AND USE_C10D_GLOO)
     c10d_add_test(ProcessGroupGlooTest.cpp LINK_LIBRARIES torch_cpu c10d_cuda_test gtest_main INSTALL_TEST ${INSTALL_TEST})

--- a/test/cpp/c10d/SymmetricMemoryUtilsTest.cpp
+++ b/test/cpp/c10d/SymmetricMemoryUtilsTest.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include <torch/csrc/distributed/c10d/HashStore.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp>
+
+using c10d::symmetric_memory::StoreExchange;
+
+TEST(SymmetricMemoryUtilsTest, StoreExchangeAllGather) {
+  c10::intrusive_ptr<c10d::Store> store =
+      c10::make_intrusive<c10d::HashStore>();
+  StoreExchange rank0Exchange("SymmetricMemoryUtilsTest");
+  StoreExchange rank1Exchange("SymmetricMemoryUtilsTest");
+
+  std::vector<int> rank0Values;
+  std::vector<int> rank1Values;
+  std::thread rank0([&] {
+    rank0Values = rank0Exchange.all_gather(
+        store, /*rank=*/0, /*world_size=*/2, /*val=*/11);
+  });
+  std::thread rank1([&] {
+    rank1Values = rank1Exchange.all_gather(
+        store, /*rank=*/1, /*world_size=*/2, /*val=*/22);
+  });
+
+  rank0.join();
+  rank1.join();
+
+  const std::vector<int> expected{11, 22};
+  EXPECT_EQ(rank0Values, expected);
+  EXPECT_EQ(rank1Values, expected);
+}
+
+TEST(SymmetricMemoryUtilsTest, StoreExchangeAllGatherTimesOut) {
+  c10::intrusive_ptr<c10d::Store> store =
+      c10::make_intrusive<c10d::HashStore>();
+  StoreExchange exchange("SymmetricMemoryUtilsTimeoutTest");
+
+  auto start = std::chrono::steady_clock::now();
+  EXPECT_THROW(
+      exchange.all_gather(
+          store,
+          /*rank=*/0,
+          /*world_size=*/2,
+          /*val=*/11,
+          std::chrono::milliseconds(10)),
+      c10::DistStoreError);
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_LT(elapsed, std::chrono::seconds(5));
+}

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -16,6 +16,8 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <chrono>
+
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
 #elif defined(USE_ROCM)
@@ -32,6 +34,8 @@ namespace c10d::symmetric_memory {
 
 // A set of exchange methods with prefix "CUDASymmetricMemory"
 static StoreExchange storeExchange = StoreExchange("CUDASymmetricMemory");
+static constexpr auto kMulticastStoreExchangeTimeout =
+    std::chrono::milliseconds(60000);
 
 AllocationRef::AllocationRef(
     void* ptr,
@@ -658,16 +662,25 @@ static void init_multicast_for_block(
     // TODO implement storeExchange.broadcast
     std::vector<McHandleType> gathered_handles;
     try {
-      gathered_handles =
-          storeExchange.all_gather(store, rank, world_size, mc_exported_handle);
-    } catch (const c10::Error&) {
+      gathered_handles = storeExchange.all_gather(
+          store,
+          rank,
+          world_size,
+          mc_exported_handle,
+          kMulticastStoreExchangeTimeout);
+    } catch (const c10::Error& e) {
       if (rank == 0 && mc_handle != 0) {
         warn_cuda_driver_error(
             driver_api->cuMemRelease_(mc_handle),
             "SymmetricMemory: failed to release multicast handle");
         mc_handle = 0;
       }
-      throw;
+      TORCH_CHECK(
+          false,
+          "SymmetricMemory: failed to exchange multicast handle through store within ",
+          kMulticastStoreExchangeTimeout.count(),
+          " ms. ",
+          e.what_without_backtrace());
     }
     recv_handle = std::move(gathered_handles[0]);
   }
@@ -746,14 +759,19 @@ check_all:
   bool all_succeed = true;
   std::vector<bool> rank_successes;
   try {
-    rank_successes =
-        storeExchange.all_gather(store, rank, world_size, success_end);
-  } catch (const c10::Error&) {
+    rank_successes = storeExchange.all_gather(
+        store, rank, world_size, success_end, kMulticastStoreExchangeTimeout);
+  } catch (const c10::Error& e) {
     if constexpr (!use_fabric_handle) {
       close(recv_handle);
     }
     cleanup_multicast();
-    throw;
+    TORCH_CHECK(
+        false,
+        "SymmetricMemory: failed to exchange multicast success flags through store within ",
+        kMulticastStoreExchangeTimeout.count(),
+        " ms. ",
+        e.what_without_backtrace());
   }
   for (int r = 0; r < world_size; ++r) {
     all_succeed &= rank_successes[r];

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -585,6 +585,23 @@ static bool check_group_multicast_support(
   }
 }
 
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED) && \
+    defined(CUDART_SUPPORTS_MULTICAST)
+static void warn_cuda_driver_error(CUresult err, const char* message) {
+  if (err == CUDA_SUCCESS) {
+    return;
+  }
+  const char* err_str = nullptr;
+  auto get_error_str_err =
+      c10::cuda::DriverAPI::get()->cuGetErrorString_(err, &err_str);
+  if (get_error_str_err != CUDA_SUCCESS) {
+    LOG(WARNING) << message << ": CUDA driver error: unknown error";
+  } else {
+    LOG(WARNING) << message << ": CUDA driver error: " << err_str;
+  }
+}
+#endif
+
 template <bool use_fabric_handle>
 static void init_multicast_for_block(
     HandleType& mc_handle,
@@ -639,18 +656,58 @@ static void init_multicast_for_block(
     recv_handle = ipc_channel.broadcast_fds(rank, 0, pids, mc_exported_handle);
   } else {
     // TODO implement storeExchange.broadcast
-    auto gathered_handles = storeExchange.all_gather(store, rank, world_size, mc_exported_handle);
+    std::vector<McHandleType> gathered_handles;
+    try {
+      gathered_handles =
+          storeExchange.all_gather(store, rank, world_size, mc_exported_handle);
+    } catch (const c10::Error&) {
+      if (rank == 0 && mc_handle != 0) {
+        warn_cuda_driver_error(
+            driver_api->cuMemRelease_(mc_handle),
+            "SymmetricMemory: failed to release multicast handle");
+        mc_handle = 0;
+      }
+      throw;
+    }
     recv_handle = std::move(gathered_handles[0]);
   }
 
   // Check exchange result
   if (memcmp(&recv_handle, &invalidator, sizeof(McHandleType)) == 0) {
+    if (rank == 0 && mc_handle != 0) {
+      warn_cuda_driver_error(
+          driver_api->cuMemRelease_(mc_handle),
+          "SymmetricMemory: failed to release multicast handle");
+      mc_handle = 0;
+    }
     LOG(WARNING) << "Gracefully skipping multicast initialization.";
     return;
   }
 
   // Flip to true after all CUDA steps finish
   bool success_end = false;
+  bool multicast_bound = false;
+  auto cleanup_multicast = [&]() {
+    if (mc_addr != nullptr) {
+      warn_cuda_driver_error(
+          driver_api->cuMemUnmap_(
+              reinterpret_cast<CUdeviceptr>(mc_addr), block->block_size),
+          "SymmetricMemory: failed to unmap multicast handle");
+      mc_addr = nullptr;
+    }
+    if (mc_handle != 0) {
+      if (multicast_bound) {
+        warn_cuda_driver_error(
+            driver_api->cuMulticastUnbind_(
+                mc_handle, block->device_idx, 0, block->block_size),
+            "SymmetricMemory: failed to unbind multicast handle");
+      }
+      warn_cuda_driver_error(
+          driver_api->cuMemRelease_(mc_handle),
+          "SymmetricMemory: failed to release multicast handle");
+      mc_handle = 0;
+    }
+  };
 
   // Phase 3: Import handle (non-0 ranks only)
   if (rank != 0) {
@@ -672,13 +729,32 @@ static void init_multicast_for_block(
       driver_api->cuMulticastAddDevice_(mc_handle, block->device_idx), check_all);
   C10_CUDA_DRIVER_CHECK_GOTO(driver_api->cuMulticastBindMem_(
       mc_handle, 0, block->alloc_ref->handle, 0, block->block_size, 0), check_all);
+  multicast_bound = true;
 
-  success_end = true;
+  // Phase 5: Map to virtual memory
+  try {
+    map_block(&mc_addr, mc_handle, block->block_size, block->device_idx);
+    success_end = true;
+  } catch (const std::exception& e) {
+    mc_addr = nullptr;
+    LOG(WARNING) << "SymmetricMemory: fail to map multicast handle.\n"
+                 << e.what();
+  }
 
 check_all:
   // Whether all ranks have succeeded
   bool all_succeed = true;
-  auto rank_successes = storeExchange.all_gather(store, rank, world_size, success_end);
+  std::vector<bool> rank_successes;
+  try {
+    rank_successes =
+        storeExchange.all_gather(store, rank, world_size, success_end);
+  } catch (const c10::Error&) {
+    if constexpr (!use_fabric_handle) {
+      close(recv_handle);
+    }
+    cleanup_multicast();
+    throw;
+  }
   for (int r = 0; r < world_size; ++r) {
     all_succeed &= rank_successes[r];
   }
@@ -687,12 +763,10 @@ check_all:
     close(recv_handle);
   }
   if (!all_succeed) {
+    cleanup_multicast();
     LOG(WARNING) << "Gracefully skipping multicast initialization.";
     return;
   }
-
-  // Phase 5: Map to virtual memory
-  map_block(&mc_addr, mc_handle, block->block_size, block->device_idx);
 #endif
 }
 

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -34,7 +34,7 @@ namespace c10d::symmetric_memory {
 
 // A set of exchange methods with prefix "CUDASymmetricMemory"
 static StoreExchange storeExchange = StoreExchange("CUDASymmetricMemory");
-static constexpr auto kMulticastStoreExchangeTimeout =
+static constexpr auto kStoreExchangeTimeout =
     std::chrono::milliseconds(60000);
 
 AllocationRef::AllocationRef(
@@ -667,7 +667,7 @@ static void init_multicast_for_block(
           rank,
           world_size,
           mc_exported_handle,
-          kMulticastStoreExchangeTimeout);
+          kStoreExchangeTimeout);
     } catch (const c10::Error& e) {
       if (rank == 0 && mc_handle != 0) {
         warn_cuda_driver_error(
@@ -678,7 +678,7 @@ static void init_multicast_for_block(
       TORCH_CHECK(
           false,
           "SymmetricMemory: failed to exchange multicast handle through store within ",
-          kMulticastStoreExchangeTimeout.count(),
+          kStoreExchangeTimeout.count(),
           " ms. ",
           e.what_without_backtrace());
     }
@@ -760,7 +760,7 @@ check_all:
   std::vector<bool> rank_successes;
   try {
     rank_successes = storeExchange.all_gather(
-        store, rank, world_size, success_end, kMulticastStoreExchangeTimeout);
+        store, rank, world_size, success_end, kStoreExchangeTimeout);
   } catch (const c10::Error& e) {
     if constexpr (!use_fabric_handle) {
       close(recv_handle);
@@ -769,7 +769,7 @@ check_all:
     TORCH_CHECK(
         false,
         "SymmetricMemory: failed to exchange multicast success flags through store within ",
-        kMulticastStoreExchangeTimeout.count(),
+        kStoreExchangeTimeout.count(),
         " ms. ",
         e.what_without_backtrace());
   }

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryUtils.hpp
@@ -5,7 +5,9 @@
 #include <torch/csrc/distributed/c10d/Store.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemoryTypes.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#include <chrono>
 #include <cstring>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -97,7 +99,8 @@ class StoreExchange {
       const c10::intrusive_ptr<c10d::Store>& store,
       int rank,
       int world_size,
-      T val) {
+      T val,
+      std::optional<std::chrono::milliseconds> timeout = std::nullopt) {
     static_assert(std::is_trivially_copyable_v<T>);
 
     std::vector<std::string> peer_keys;
@@ -114,6 +117,10 @@ class StoreExchange {
           reinterpret_cast<uint8_t*>(&val),
           reinterpret_cast<uint8_t*>(&val) + sizeof(T));
       store->set(peer_keys[rank], payload);
+    }
+
+    if (timeout.has_value()) {
+      store->wait(peer_keys, *timeout);
     }
 
     auto payloads = store->multiGet(peer_keys);


### PR DESCRIPTION
Bound multicast rendezvous store waits
    
When one rank fails before publishing a multicast rendezvous key, the remaining ranks can block in the store-backed multicast handle or success exchange until the store default timeout. In the observed wearables failures that default was 1500000ms, so model load spent about 25 minutes waiting before surfacing the error.
    
This adds an optional timeout to StoreExchange::all_gather and uses a 60 second bound for the multicast handle and success exchanges. Normal rendezvous exchanges keep the existing default behavior unless a caller opts into a shorter timeout.

_________________________________

Authored with AI assistance. (Codex)
