### PR TITLE
Pin cython < 3.3.0 for the Windows Triton wheel build

### DIFF
--- a/.github/scripts/windows/build_triton.bat
+++ b/.github/scripts/windows/build_triton.bat
@@ -4,7 +4,9 @@ set DESIRED_PYTHON=%PY_VERS%
 call .ci/pytorch/windows/internal/install_python.bat
 
 :: Fix cmake version for issue https://github.com/pytorch/pytorch/issues/150480
-%PYTHON_EXEC% -m pip install wheel pybind11 certifi cython cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
+:: Cython 3.3.0's compiled cp315 extension access-violates (0xC0000005) under
+:: CPython 3.15, crashing `setup.py bdist_wheel`. Same defect as gh-194618.
+%PYTHON_EXEC% -m pip install wheel pybind11 certifi "cython<3.3.0" cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
 
 dir "%VC_INSTALL_PATH%"
 


### PR DESCRIPTION
## Summary

`Build Triton Windows Wheel (3.15, xpu)` fails in `setup.py bdist_wheel` with exit status **3221225477** (`0xC0000005`, access violation) — a hard crash, not a build error:

```
subprocess.CalledProcessError: Command '[...\python.exe', 'setup.py', 'bdist_wheel']'
  returned non-zero exit status 3221225477
```

Failing job: https://github.com/pytorch/pytorch/actions/runs/32979657567/job/98212890807 (tag `v2.14.0-rc8`)

Same issue on trunk: https://github.com/pytorch/pytorch/actions/runs/32820378685/job/97717024597

`cython` was the only unpinned package on the install line in `.github/scripts/windows/build_triton.bat`, so it resolves to **3.3.0** (released 2026-08-22), whose compiled cp315 extension access-violates under CPython 3.15. Nothing in PyTorch changed to trigger this — the Cython release did.

This is the same defect already worked around for the Windows and macOS wheel builds in #194618 and #194734 (on macOS it surfaces as `-11`/SIGSEGV instead of `0xC0000005`).

## Evidence that it's Cython's compiled extension

The 3.15 vs 3.15t split within the same run isolates it:

| job | cython artifact installed | result |
| --- | --- | --- |
| 3.10 – 3.14, 3.14t | compiled wheels, older ABI | pass |
| **3.15** | `cython-3.3.0-cp315-cp315-win_amd64.whl` (2.9 MB, compiled) | **crash** |
| **3.15t** | `cython-3.3.0-py3-none-any.whl` (1.3 MB, pure Python) | pass |

Same Cython *version* in both. 3.15t falls back to the pure-Python wheel because no free-threaded cp315t build exists, and it does not crash — so the fault is in the compiled cp315 extension, not in Cython's logic or in Triton. All 34 Linux Triton jobs in that run passed too.

## Change

```diff
-%PYTHON_EXEC% -m pip install wheel pybind11 certifi cython cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
+%PYTHON_EXEC% -m pip install wheel pybind11 certifi "cython<3.3.0" cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
```

Applied unconditionally rather than gated on 3.15: every other Python version was already resolving to a working Cython, so `<3.3.0` just holds them at the last good release instead of changing their behaviour.

## Notes

- Release-blocking for **v2.14.0-rc8** — intended for cherry-pick to `release/2.14`.
- CRLF line endings preserved (the file is an existing Windows `.bat`).


---

Filed with the help of Claude Code.
