### PR TITLE
[Cherry-pick][release/2.14] Pin cython < 3.3.0 for the Windows Triton wheel build

### DIFF
--- a/.github/scripts/windows/build_triton.bat
+++ b/.github/scripts/windows/build_triton.bat
@@ -4,7 +4,9 @@ set DESIRED_PYTHON=%PY_VERS%
 call .ci/pytorch/windows/internal/install_python.bat
 
 :: Fix cmake version for issue https://github.com/pytorch/pytorch/issues/150480
-%PYTHON_EXEC% -m pip install wheel pybind11 certifi cython cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
+:: Cython 3.3.0's compiled cp315 extension access-violates (0xC0000005) under
+:: CPython 3.15, crashing `setup.py bdist_wheel`. Same defect as gh-194618.
+%PYTHON_EXEC% -m pip install wheel pybind11 certifi "cython<3.3.0" cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
 
 dir "%VC_INSTALL_PATH%"
 


### PR DESCRIPTION
Cherry-pick of #194914 onto `release/2.14`. Unblocks **v2.14.0-rc8**.

## Problem

`Build Triton Windows Wheel (3.15, xpu)` fails in `setup.py bdist_wheel` with exit status **3221225477** (`0xC0000005`, access violation):

```
subprocess.CalledProcessError: Command '[...\python.exe', 'setup.py', 'bdist_wheel']'
  returned non-zero exit status 3221225477
```

Failing job on the rc8 tag: https://github.com/pytorch/pytorch/actions/runs/32979657567/job/98212890807

`cython` was unpinned in `.github/scripts/windows/build_triton.bat`, so it resolves to 3.3.0 (released 2026-08-22), whose compiled cp315 extension crashes under CPython 3.15. No PyTorch change triggered this — the Cython release did. Same defect handled in #194618 / #194734.

## Evidence

Within the same run:

| job | cython artifact | result |
| --- | --- | --- |
| 3.10 – 3.14, 3.14t | compiled, older ABI | pass |
| **3.15** | `cython-3.3.0-cp315-cp315-win_amd64.whl` (compiled) | **crash** |
| **3.15t** | `cython-3.3.0-py3-none-any.whl` (pure Python) | pass |

3.15t gets the pure-Python fallback (no cp315t build exists) and passes on the same Cython version — isolating the fault to the compiled cp315 extension. All 34 Linux Triton jobs passed.

## Change

One line, unconditional:

```diff
-%PYTHON_EXEC% -m pip install wheel pybind11 certifi cython cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
+%PYTHON_EXEC% -m pip install wheel pybind11 certifi "cython<3.3.0" cmake==3.31.6 setuptools==72.1.0 ninja==1.11.1.4
```

Cherry-picked with `git cherry-pick -x` — applied cleanly, no conflicts. CRLF line endings preserved.

---

Filed with the help of Claude Code.
