### PR TITLE
[inductor] Fuse sibling reductions with common reads

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -1088,7 +1088,7 @@ class TestScheduler(TestCase):
 
 class TestScoreFusionMemory(TestCase):
     """
-    Tests for _score_fusion_memory_by_buffer_overlap.
+    Tests for fusion memory scoring.
 
     These tests validate the fusion scoring logic that determines when nodes
     should be fused together based on their memory access patterns.
@@ -1130,6 +1130,50 @@ class TestScoreFusionMemory(TestCase):
         self.assertTrue(torch.allclose(out2_eager, out2_compiled, atol=1e-3, rtol=1e-3))
         # Should fuse into 1 kernel since both ops read exact same buffer
         self.assertEqual(metrics.generated_kernel_count, 1)
+
+    @onlyCUDA
+    def test_reduction_common_read_scoring(self) -> None:
+        def fn(base, correction):
+            base_3d = base.view(2, 16, 64)
+            final = torch.cat(
+                (
+                    base_3d[:, :1],
+                    base_3d[:, 1:] + correction.view(2, 15, 64),
+                ),
+                dim=1,
+            )
+            return final.flatten(0, 1).amax(-1), base.amax(-1)
+
+        torch._dynamo.reset()
+        metrics.reset()
+        args = (
+            torch.randn(32, 64, device=GPU_TYPE),
+            torch.randn(30, 64, device=GPU_TYPE),
+        )
+
+        expected = fn(*args)
+        actual = torch.compile(fn, fullgraph=True)(*args)
+
+        self.assertEqual(expected, actual)
+        self.assertEqual(metrics.generated_kernel_count, 1)
+
+        torch._dynamo.reset()
+        metrics.reset()
+        with inductor_config.patch("reduction_common_read_fusion", False):
+            actual = torch.compile(fn, fullgraph=True)(*args)
+        self.assertEqual(expected, actual)
+        self.assertEqual(metrics.generated_kernel_count, 2)
+
+        def disjoint(x):
+            return (
+                x[:16].repeat(2, 1).amax(-1),
+                x[16:].repeat(2, 1).amax(-1),
+            )
+
+        metrics.reset()
+        x = torch.randn(32, 64, device=GPU_TYPE)
+        self.assertEqual(disjoint(x), torch.compile(disjoint, fullgraph=True)(x))
+        self.assertEqual(metrics.generated_kernel_count, 2)
 
     @skipIf(not HAS_GPU, "GPU not available")
     @inductor_config.patch("score_fusion_memory_threshold", 1)

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1021,6 +1021,9 @@ max_fusion_size = 64
 # Valid range: [0, 1]. Default to not fusion.
 min_overlap_ratio = 1.1
 
+# Score compatible sibling CUDA reductions by their direct common reads.
+reduction_common_read_fusion = True
+
 # how many nodes to attempt pairwise fusion with in a buffer group
 max_fusion_buffer_group_pairwise_attempts = 64
 

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -6031,7 +6031,30 @@ class Scheduler:
                 config.loop_ordering_after_fusion
                 or config.loop_index_inversion_in_fusion
             ):
+                old_len = len(nodes)
                 nodes = self.fuse_nodes_once(nodes, is_reorder_round=True)
+                if config.reduction_common_read_fusion and 1 < len(nodes) < old_len:
+                    reduction_readers = collections.defaultdict(list)
+                    for node in nodes:
+                        device = node.get_device()
+                        if (
+                            device is not None
+                            and device.type == "cuda"
+                            and node.is_reduction()
+                        ):
+                            for name in OrderedSet(
+                                dep.name for dep in node.read_writes.reads
+                            ):
+                                reduction_readers[name].append(node)
+                    pair_limit = config.max_fusion_buffer_group_pairwise_attempts
+                    if any(
+                        self._score_reduction_common_reads(node1, node2, True)
+                        for readers in reduction_readers.values()
+                        for index, node1 in enumerate(readers)
+                        for node2 in readers[index + 1 : index + 1 + pair_limit]
+                    ):
+                        # Reordering can expose sibling common reads.
+                        nodes = self.fuse_nodes_once(nodes, is_reorder_round=False)
             return nodes
 
     def process_grouped_nodes(self) -> None:
@@ -9835,13 +9858,96 @@ class Scheduler:
 
         # This is a horizontal/common-read locality heuristic, not a
         # producer-consumer dependency match.
-        buffer_overlap_score = 0
-        if score == 0 and self._can_use_buffer_overlap_scoring(node1, node2):
+        buffer_overlap_score = self._score_reduction_common_reads(
+            node1, node2, count_bytes
+        )
+        if buffer_overlap_score == 0 and self._can_use_buffer_overlap_scoring(
+            node1, node2
+        ):
             buffer_overlap_score = self._score_fusion_memory_by_buffer_overlap(
                 node1, node2
             )
 
         return _construct_return_value(score, buffer_overlap_score, False)
+
+    def _score_reduction_common_reads(
+        self,
+        node1: BaseSchedulerNode,
+        node2: BaseSchedulerNode,
+        count_bytes: bool,
+    ) -> int:
+        """Score sibling reductions that directly read mostly the same buffers."""
+        if not config.reduction_common_read_fusion:
+            return 0
+
+        device1 = node1.get_device()
+        device2 = node2.get_device()
+        if (
+            device1 is None
+            or device2 is None
+            or device1.type != "cuda"
+            or device2.type != "cuda"
+            or not node1.is_reduction()
+            or not node2.is_reduction()
+            or node1.is_template()
+            or node2.is_template()
+            or node1.group != node2.group
+            or node1.get_operation_names() & node2.ancestors
+            or node2.get_operation_names() & node1.ancestors
+        ):
+            return 0
+
+        def external_reads(node: BaseSchedulerNode) -> list[Dep]:
+            outputs = node.get_buffer_names()
+            return [dep for dep in node.read_writes.reads if dep.name not in outputs]
+
+        reads1 = external_reads(node1)
+        reads2 = external_reads(node2)
+        common_names = OrderedSet(dep.name for dep in reads1) & OrderedSet(
+            dep.name for dep in reads2
+        )
+        common_reads = [
+            dep for dep in itertools.chain(reads1, reads2) if dep.name in common_names
+        ]
+        if not common_names or any(
+            not isinstance(dep, MemoryDep) or dep.is_indirect() for dep in common_reads
+        ):
+            return 0
+        common_memory_reads = typing.cast(list[MemoryDep], common_reads)
+        for name in common_names:
+            buffer_size = self.dep_size_hint(StarDep(name), count_bytes)
+            if buffer_size <= 0 or not any(
+                dep.name == name
+                and self.dep_size_hint(dep, count_bytes) == buffer_size
+                and dep.normalize().is_contiguous()
+                for dep in common_memory_reads
+            ):
+                return 0
+
+        def read_sizes(reads: list[Dep]) -> dict[str, int] | None:
+            sizes: dict[str, int] = defaultdict(int)
+            for dep in reads:
+                size = self.dep_size_hint(dep, count_bytes)
+                if size <= 0:
+                    return None
+                sizes[dep.name] += size
+            for name, size in sizes.items():
+                buffer_size = self.dep_size_hint(StarDep(name), count_bytes)
+                if buffer_size <= 0:
+                    return None
+                sizes[name] = min(size, buffer_size)
+            return sizes
+
+        sizes1 = read_sizes(reads1)
+        sizes2 = read_sizes(reads2)
+        if sizes1 is None or sizes2 is None:
+            return 0
+        total = max(sum(sizes1.values()), sum(sizes2.values()))
+        common = sum(min(sizes1[name], sizes2[name]) for name in common_names)
+        # The target reads one shared base plus an approximately equal-size
+        # correction, so 50% is the narrowest threshold that admits it. This
+        # path is separate from min_overlap_ratio, which excludes reductions.
+        return common if common * 2 >= total else 0
 
     def _can_use_buffer_overlap_scoring(
         self,


### PR DESCRIPTION
## Summary

Domino cross entropy reduces both corrected and base logits. Both reductions read the same large base tensor, but Inductor currently schedules them in separate kernels.

This PR lets Inductor fuse compatible sibling CUDA reductions when shared direct reads account for at least half of the larger reduction's input traffic. Indirect reads and disjoint slices do not qualify. The optimization has its own config switch.

Part of pytorch/pytorch#190718. Split from pytorch/pytorch#193121 at the maintainer's request.

## Results

On the exact reported BF16 shape, adding this change to the cat-recomputation patch reduced runtime from 3.686 ms to 2.642 ms and reduced the vocabulary kernels from three to two. Temporary memory remained at 0.1 MiB.

The focused CUDA test produces one kernel when common-read fusion is enabled. It produces two when disabled and two for repeated disjoint slices. All outputs match eager execution.

## Test plan

```text
python -m pip install -e . -v --no-build-isolation
python test/inductor/test_inductor_scheduler.py -k test_reduction_common_read_scoring
spin quicklint -- --skip FLAKE8 torch/_inductor/config.py torch/_inductor/scheduler.py test/inductor/test_inductor_scheduler.py
```

The focused CUDA test command passed. The scoped quicklint command also reports no issues.

## AI assistance disclosure

I wrote and reviewed the final patch and commit message. Codex assisted with tracing the scheduler behavior, suggesting parts of the implementation, running local checks, and revising this PR description. I reviewed the final diff, test results, and description, understand the changes, and take responsibility for this contribution. Thank you.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jansel @eellison
