### PR TITLE
Fix TritonBundler collect

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -5155,6 +5155,84 @@ class TestRemoteAOTAutogradCache(TestCase):
             self.assertEqual(b.grad, b2.grad)
 
 
+class TestTritonBundlerCollect(TestCase):
+    """
+    collect() saves the kernel binaries and a snapshot of each statically
+    launchable autotuner. load_autotuners() demands a binary for every
+    compile_result those snapshots name, so the bundle has to cover them.
+    """
+
+    @config.patch(
+        bundle_triton_into_fx_graph_cache=True,
+        use_static_triton_launcher=True,
+        force_disable_caches=False,
+    )
+    def test_bundle_covers_binaries_demanded_on_load(self):
+        from torch._inductor.runtime.runtime_utils import triton_hash_to_path_key
+        from torch._inductor.triton_bundler import (
+            StaticallyLaunchedAutotuner,
+            TritonBundler,
+        )
+
+        def stub_autotuner(cache_key, kernel_name, hashes):
+            # collect() only reaches kernel.compile_results[i].kernel.hash
+            return StaticallyLaunchedAutotuner(
+                cache_key,
+                kernel_name,
+                types.SimpleNamespace(
+                    compile_results=[
+                        types.SimpleNamespace(kernel=types.SimpleNamespace(hash=h))
+                        for h in hashes
+                    ]
+                ),
+            )
+
+        cache_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, cache_dir, True)
+
+        # "untuned" stands in for a single-config kernel that has not run by the
+        # time the cache is written, so no winner is ever recorded for it.
+        winner, loser, untuned = "hash_winner", "hash_loser", "hash_untuned"
+        keys = {h: triton_hash_to_path_key(h) for h in (winner, loser, untuned)}
+        for path_key in keys.values():
+            kernel_dir = os.path.join(cache_dir, path_key)
+            os.makedirs(kernel_dir)
+            with open(os.path.join(kernel_dir, "kernel.cubin"), "wb") as f:
+                f.write(b"\x00fake binary\x00")
+            with open(os.path.join(kernel_dir, "kernel.json"), "w") as f:
+                json.dump({"name": "kernel"}, f)
+
+        TritonBundler.begin_compile()
+        self.addCleanup(TritonBundler.end_compile)
+        with mock.patch(
+            "torch._inductor.triton_bundler.triton_cache_dir",
+            return_value=cache_dir,
+        ):
+            for path_key in keys.values():
+                TritonBundler.put(path_key, 0)
+            TritonBundler._static_autotuners = [
+                stub_autotuner("key_tuned", "tuned", [winner, loser]),
+                stub_autotuner("key_untuned", "untuned", [untuned]),
+            ]
+            # _winners is global, so one recorded winner turns the filter on for
+            # every kernel, "untuned" included.
+            TritonBundler.put_winner(keys[winner])
+            bundle, _metadata = TritonBundler.collect()
+
+        bundled = {artifacts.kernel_hash for artifacts in bundle.kernel_artifacts}
+        demanded = {
+            triton_hash_to_path_key(compile_result.kernel.hash)
+            for autotuner in bundle.static_autotuners
+            for compile_result in autotuner.kernel.compile_results
+        }
+
+        self.assertEqual(demanded - bundled, set())
+        self.assertIn(keys[winner], bundled)
+        # The losing config is still dropped, so the bundle does not grow.
+        self.assertNotIn(keys[loser], bundled)
+        self.assertIn(keys[untuned], bundled)
+
+
 class TestUtils(TestCase):
     @config.patch({"fx_graph_remote_cache": False})
     def test_fresh_cache(self):

--- a/torch/_inductor/triton_bundler.py
+++ b/torch/_inductor/triton_bundler.py
@@ -11,7 +11,7 @@ from torch._utils_internal import justknobs_check
 from torch.utils._filelock import FileLock
 from torch.utils._ordered_set import OrderedSet
 
-from .runtime.runtime_utils import triton_cache_dir
+from .runtime.runtime_utils import triton_cache_dir, triton_hash_to_path_key
 from .utils import _IS_WINDOWS, GPU_KERNEL_BIN_EXTS
 
 
@@ -282,15 +282,45 @@ class TritonBundler:
         with dynamo_timed(key="TritonBundler.collect", log_pt2_compile_event=True):
             entries = cls._entries
             if entries is not None:
-                # Only bundle winning autotuning configs. If _winners is
-                # non-empty, skip entries whose kernel_hash is not a winner.
-                # When _winners is empty (single-config kernels, or no
-                # autotuning ran), bundle everything.
+                # Collect the statically launchable autotuners first: what
+                # they reference decides what the bundle has to contain.
+                if config.use_static_triton_launcher:
+                    static_autotuners, static_kernel_names = (
+                        cls.collect_static_autotuners()
+                    )
+                else:
+                    static_autotuners = []
+                    static_kernel_names = []
                 winners = cls._winners
+                # load_autotuners() will ask for everything saved; prune to winner
+                required: OrderedSet[str] = OrderedSet()
+                for autotuner in static_autotuners:
+                    if winners:
+                        kept = [
+                            compile_result
+                            for compile_result in autotuner.kernel.compile_results
+                            if triton_hash_to_path_key(compile_result.kernel.hash)
+                            in winners
+                        ]
+                        if kept:
+                            autotuner.kernel.compile_results = kept
+                    for compile_result in autotuner.kernel.compile_results:
+                        required.add(
+                            triton_hash_to_path_key(compile_result.kernel.hash)
+                        )
+                # Only bundle winning autotuning configs. If _winners is
+                # non-empty, skip entries whose kernel_hash is neither a winner
+                # nor referenced by a saved autotuner. When _winners is empty
+                # (single-config kernels, or no autotuning ran), bundle
+                # everything.
                 result: list[TritonKernelArtifacts] = []
                 kernel_names: list[str] = []
                 for entry in entries:
-                    if winners and entry.kernel_hash not in winners:
+                    if (
+                        winners
+                        and entry.kernel_hash not in winners
+                        and entry.kernel_hash not in required
+                    ):
                         log.debug("Skipping non-winning kernel %s", entry.kernel_hash)
                         continue
                     artifacts: list[TritonKernelArtifact] = []
@@ -340,13 +370,6 @@ class TritonBundler:
                                 artifacts,
                             )
                         )
-                if config.use_static_triton_launcher:
-                    static_autotuners, static_kernel_names = (
-                        cls.collect_static_autotuners()
-                    )
-                else:
-                    static_autotuners = []
-                    static_kernel_names = []
                 cls.end_compile()
                 return TritonBundle(result, static_autotuners), TritonBundlerMetadata(
                     kernel_names, static_kernel_names


### PR DESCRIPTION
## Summary

`TritonBundler.collect()` writes two things into a single FX graph cache entry:
the kernel binaries (`.cubin` / `.hsaco` bytes) built from `cls._entries`, and a
pickled snapshot of every statically launchable autotuner from
`collect_static_autotuners()`.

Since #178470 the binaries are filtered down to winning autotune configs, but the
snapshots are saved unfiltered - they still name every `compile_result`. Nothing
enforces that what is saved covers what will later be asked for.

On a warm start `load_autotuners()` walks each snapshot and calls
`reload_cubin_path()` for every `compile_result` it names. That helper is a plain
`os.path.exists` check that raises if the file is absent, and one miss discards
the whole autotuner, including the configs whose binaries were bundled:

```python
for result in static_autotuners:
    try:
        for compile_result in result.kernel.compile_results:
            compile_result.reload_cubin_path()
    except RuntimeError:
        log.warning("Failed to reload cubin file statically launchable autotuner %s", ...)
        continue        # <- entire autotuner dropped
```

```
torch/_inductor/triton_bundler.py] Failed to reload cubin file statically launchable
  autotuner triton_poi_fused_add_clone_expand_index_mul_neg_slice_...
RuntimeError: ('Cubin file saved by TritonBundler not found at %s', '.../<KEY>/....hsaco')
```

## Two ways the bundle ends up incomplete

**Autotuned kernels.** A kernel keeps N `compile_results` in its snapshot while
only the winner's binary is bundled, so N-1 are missing.

**Kernels that never recorded a winner.** `_winners` is a process-global
`OrderedSet` but the filter is applied per entry. Once any kernel records a winner
the filter is live for every kernel, so a kernel that never autotuned has all of
its binaries dropped, even though it never had a competitor to lose to. This is
reachable in ordinary use because the two `put_winner()` call sites fire at
different times: during autotuning, and on first kernel launch - which for a
single-config kernel is the only site that records it. A kernel that has not run
by the time the cache is written has no winner recorded.

## Why this is rarely seen

`reload_cubin_path()` checks the filesystem before it complains, so a leftover
on-disk Triton cache from the original compile silently covers the gap. The bug
surfaces only when the FX graph cache is read somewhere the binaries are not: a
framework that relocates `TORCHINDUCTOR_CACHE_DIR` per model (this was found via
vLLM's per-model `torch_compile_cache`), or a cache restored onto a cold
container. The bundle is malformed either way; the filesystem usually hides it.

## Fix

Collect the static autotuners before filtering the entries, prune each snapshot to
its winning config where the winner is known, and treat whatever the pruned
snapshots still reference as required regardless of the winner set.

The space saving of #178470 is preserved - autotuned kernels still bundle exactly
one binary, and their pickled snapshot gets smaller too, since the losing
`compile_results` are no longer serialized.

## Test Plan

New unit test driving `collect()` with one autotuned kernel (winner + loser) and
one kernel that never recorded a winner, asserting the invariant directly:
nothing the loader would demand may be absent from the bundle, and the losing
config is still dropped so the bundle does not grow.

```
pytest test/inductor/test_codecache.py -k test_bundle_covers_binaries_demanded_on_load
```

Against unpatched torch it fails, catching both failure modes:

```
bundled  = ['hash_winner']
demanded = ['hash_loser', 'hash_untuned', 'hash_winner']
MISSING  = ['hash_loser', 'hash_untuned']
  - loader demands unbundled binaries: ['hash_loser', 'hash_untuned']
  - kernel with no recorded winner lost its binary
```

End to end, on torch 2.12.0+rocm7.14.0 and one MI355X, using the script below:

```
### before ###                  ### after ###
loaded_autotuners=0             loaded_autotuners=2
reload-cubin warnings=2         reload-cubin warnings=0
```

The exact counts vary between runs, since autotuning picks different winners and
saves a different number of autotuners each time; the direction does not. Before
the fix the warm start loses autotuners and warns, after it recovers all of them
silently, and the bundle does not grow.

<details>
<summary>min_repro_torch.py - no vLLM, no model, one GPU</summary>

```python
"""Minimal repro: TritonBundler saves only the winning autotune config's binary,
but load_autotuners() demands one for every compile_result, so the cached
statically launchable autotuner is thrown away on a warm start.

    python min_repro_torch.py

Needs one GPU and a torch containing #178470. Backend-neutral (.cubin/.hsaco).
"""

import logging, os, shutil, subprocess, sys, tempfile
from pathlib import Path

if os.environ.get("REPRO_CHILD"):
    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
    import torch
    import torch._inductor.config as cfg
    from torch._dynamo.utils import counters

    cfg.max_autotune_pointwise = True  # force more than one config per kernel
    fn = lambda x, y: (x * 2 + y).relu().sum(dim=-1)
    a = torch.randn(4096, 4096, device="cuda", dtype=torch.float16)
    b = torch.randn(4096, 4096, device="cuda", dtype=torch.float16)
    torch.compile(fn, mode="max-autotune-no-cudagraphs")(a, b)
    torch.cuda.synchronize()
    print(f"loaded_autotuners={counters['inductor']['triton_bundler_load_static_autotuner']}")
    raise SystemExit

cache = tempfile.mkdtemp()
env = {
    **os.environ,
    "REPRO_CHILD": "1",
    "TORCHINDUCTOR_CACHE_DIR": cache,
    # Records a winner before collect() runs, which engages the bundle filter.
    "TORCHINDUCTOR_AUTOTUNE_AT_COMPILE_TIME": "1",
}
env.pop("TRITON_CACHE_DIR", None)

subprocess.run(  # populate the cache
    [sys.executable, __file__], env=env, check=True, stdout=subprocess.DEVNULL
)
for d in Path(cache).rglob("triton"):  # stand in for a cache read where the binaries are not
    shutil.rmtree(d, ignore_errors=True)
warm = subprocess.run([sys.executable, __file__], env=env, capture_output=True, text=True)

shutil.rmtree(cache, ignore_errors=True)
print(warm.stdout.strip())
print(f"reload-cubin warnings={warm.stderr.count('Failed to reload cubin file')}")
```

</details>

Instrumenting `collect()` to print bundled-vs-demanded on two production models
shows the same malformed bundle in the wild, with snapshots referencing binaries
that were never saved - `deepseek-ai/DeepSeek-R1-0528` at 10 bundled against 26
demanded, and `Kimi-K2.6-MXFP4` on `-tp 4` at 6 against 20. Removing only the
Triton binaries while keeping the FX graph cache turns the DeepSeek-R1 mismatch
into 40 `Failed to reload cubin` warnings on the next start.

## AI assistance

Analysis, patch and measurements were developed with AI assistance (Claude) and
reviewed by the submitter.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo