### PR TITLE
[pytorch][mtia] Honor explicit Kineto activity filters (#194920)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1666,6 +1666,9 @@ test_libtorch_profiler() {
   # Tests for torch/csrc/profiler/collection.cpp.
   python test/run_test.py --cpp --verbose -i cpp/test_profiler_collection
 
+  # Tests for MTIA profiler activity filtering.
+  python test/run_test.py --cpp --verbose -i cpp/test_mtia_activity_filter
+
   # Tests for torch/csrc/profiler/util.h GlobalStateManager.
   python test/run_test.py --cpp --verbose -i cpp/test_global_state_manager
 }

--- a/test/cpp/profiler/CMakeLists.txt
+++ b/test/cpp/profiler/CMakeLists.txt
@@ -42,6 +42,24 @@ if(USE_KINETO)
     install(TARGETS test_profiler_collection DESTINATION bin)
   endif()
 
+  add_executable(test_mtia_activity_filter
+    ${TORCH_ROOT}/test/cpp/common/main.cpp
+    ${PROFILER_TEST_ROOT}/test_mtia_activity_filter.cpp
+  )
+
+  target_compile_definitions(test_mtia_activity_filter PRIVATE USE_GTEST USE_KINETO)
+
+  target_link_libraries(test_mtia_activity_filter PRIVATE ${PROFILER_TEST_DEPENDENCIES} kineto)
+  target_include_directories(test_mtia_activity_filter PRIVATE
+    ${ATen_CPU_INCLUDE}
+    ${KINETO_SOURCE_DIR}/include
+  )
+
+  if(INSTALL_TEST)
+    set_target_properties(test_mtia_activity_filter PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_RPATH}:${_rpath_portable_origin}/../lib")
+    install(TARGETS test_mtia_activity_filter DESTINATION bin)
+  endif()
+
   add_executable(test_global_state_manager
     ${TORCH_ROOT}/test/cpp/common/main.cpp
     ${PROFILER_TEST_ROOT}/test_global_state_manager.cpp

--- a/test/cpp/profiler/test_mtia_activity_filter.cpp
+++ b/test/cpp/profiler/test_mtia_activity_filter.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifdef USE_KINETO
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+
+#include <c10/util/Exception.h>
+#include <c10/util/env.h>
+#include <torch/csrc/profiler/kineto_shim.h>
+
+#include <IActivityProfiler.h>
+#include <libkineto.h>
+
+namespace {
+
+constexpr auto kCollectiveProfilingEnv =
+    "TORCH_PROFILER_ENABLE_COLLECTIVE_PROFILING";
+
+class CapturingProfiler : public libkineto::IActivityProfiler {
+ public:
+  explicit CapturingProfiler(
+      std::shared_ptr<std::set<libkineto::ActivityType>> configured_activities)
+      : configured_activities_{std::move(configured_activities)} {}
+
+  const std::string& name() const override {
+    return name_;
+  }
+  const std::set<libkineto::ActivityType>& availableActivities()
+      const override {
+    return activities_;
+  }
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      const std::set<libkineto::ActivityType>& activity_types,
+      [[maybe_unused]] const libkineto::Config& config) override {
+    *configured_activities_ = activity_types;
+    return nullptr;
+  }
+  std::unique_ptr<libkineto::IActivityProfilerSession> configure(
+      [[maybe_unused]] int64_t ts_ms,
+      [[maybe_unused]] int64_t duration_ms,
+      const std::set<libkineto::ActivityType>& activity_types,
+      const libkineto::Config& config) override {
+    return configure(activity_types, config);
+  }
+
+ private:
+  std::string name_{"capturing"};
+  std::set<libkineto::ActivityType> activities_{
+      libkineto::ActivityType::MTIA_INSIGHT,
+      libkineto::ActivityType::COLLECTIVE_COMM};
+  std::shared_ptr<std::set<libkineto::ActivityType>> configured_activities_;
+};
+
+} // namespace
+
+TEST(MtiaActivityFilterTest, CollectiveSelectionUsesFiltersAndAvailability) {
+  using torch::autograd::profiler::ActivityType;
+  using torch::profiler::impl::ExperimentalConfig;
+  using torch::profiler::impl::kineto::ActivityFilter;
+  using torch::profiler::impl::kineto::ActivitySet;
+  using torch::profiler::impl::kineto::prepareTrace;
+
+  const auto configured_activities =
+      std::make_shared<std::set<libkineto::ActivityType>>();
+  // Libkineto has no unregister API. This dedicated binary contains one test,
+  // so the process-lifetime factory cannot affect another test case.
+  libkineto::api().registerProfilerFactory([configured_activities]() {
+    return std::make_unique<CapturingProfiler>(configured_activities);
+  });
+
+  const auto prepareAndCapture = [&](const ActivitySet& activities,
+                                     const ActivityFilter& activity_filter,
+                                     const ExperimentalConfig& config) {
+    configured_activities->clear();
+    // Keep the test hardware-independent while exercising the same activity
+    // selection logic passed to registered profilers.
+    prepareTrace(
+        /*cpuOnly=*/true,
+        activities,
+        config,
+        /*trace_id=*/"",
+        activity_filter);
+  };
+
+  const std::set<libkineto::ActivityType> default_cpu_activities{
+      libkineto::ActivityType::CPU_OP,
+      libkineto::ActivityType::CPU_INSTANT_EVENT,
+      libkineto::ActivityType::USER_ANNOTATION,
+      libkineto::ActivityType::EXTERNAL_CORRELATION,
+      libkineto::ActivityType::XPU_RUNTIME,
+      libkineto::ActivityType::XPU_DRIVER,
+      libkineto::ActivityType::CUDA_RUNTIME,
+      libkineto::ActivityType::CUDA_DRIVER,
+      libkineto::ActivityType::PYTHON_FUNCTION,
+      libkineto::ActivityType::PRIVATEUSE1_RUNTIME,
+      libkineto::ActivityType::PRIVATEUSE1_DRIVER,
+  };
+
+  c10::utils::set_env(kCollectiveProfilingEnv, "1");
+
+  prepareAndCapture(
+      {ActivityType::CPU, ActivityType::MTIA},
+      {{ActivityType::MTIA, {"MTIA_INSIGHT"}}},
+      ExperimentalConfig{});
+  auto expected_cpu_and_insight = default_cpu_activities;
+  expected_cpu_and_insight.insert(libkineto::ActivityType::MTIA_INSIGHT);
+  EXPECT_EQ(*configured_activities, expected_cpu_and_insight);
+
+  prepareAndCapture(
+      {ActivityType::MTIA},
+      {{ActivityType::MTIA, {"COLLECTIVE_COMM"}}},
+      ExperimentalConfig{});
+  const std::set<libkineto::ActivityType> collective_only{
+      libkineto::ActivityType::COLLECTIVE_COMM};
+  EXPECT_EQ(*configured_activities, collective_only);
+
+  prepareAndCapture({ActivityType::CPU}, {}, ExperimentalConfig{});
+  auto expected_cpu_and_collectives = default_cpu_activities;
+  expected_cpu_and_collectives.insert(libkineto::ActivityType::COLLECTIVE_COMM);
+  EXPECT_EQ(*configured_activities, expected_cpu_and_collectives);
+
+  ExperimentalConfig custom_config;
+  custom_config.custom_profiler_config = "disable_runtime_events";
+  prepareAndCapture({ActivityType::MTIA}, {}, custom_config);
+  const std::set<libkineto::ActivityType> expected_custom_config{
+      libkineto::ActivityType::MTIA_CCP_EVENTS,
+      libkineto::ActivityType::MTIA_INSIGHT,
+      libkineto::ActivityType::MTIA_COUNTERS,
+      libkineto::ActivityType::COLLECTIVE_COMM,
+  };
+  EXPECT_EQ(*configured_activities, expected_custom_config);
+
+  EXPECT_THROW(
+      prepareAndCapture(
+          {ActivityType::MTIA},
+          {{ActivityType::MTIA, {"MTIA_INSIGHT"}}},
+          custom_config),
+      c10::Error);
+
+  c10::utils::set_env(kCollectiveProfilingEnv, "0");
+#if !defined(KINETO_HAS_HCCL_PROFILER)
+  prepareAndCapture(
+      {ActivityType::MTIA},
+      {{ActivityType::MTIA, {"MTIA_INSIGHT", "COLLECTIVE_COMM"}}},
+      ExperimentalConfig{});
+  const std::set<libkineto::ActivityType> insight_only{
+      libkineto::ActivityType::MTIA_INSIGHT};
+  EXPECT_EQ(*configured_activities, insight_only);
+#endif
+}
+
+#endif // USE_KINETO

--- a/torch/csrc/profiler/kineto_shim.cpp
+++ b/torch/csrc/profiler/kineto_shim.cpp
@@ -65,6 +65,7 @@ const ActivityTypeMap kMtiaTypes{
     {libkineto::ActivityType::MTIA_RUNTIME,          "MTIA_RUNTIME"},
     {libkineto::ActivityType::MTIA_INSIGHT,          "MTIA_INSIGHT"},
     {libkineto::ActivityType::MTIA_COUNTERS,         "MTIA_COUNTERS"},
+    {libkineto::ActivityType::COLLECTIVE_COMM,       "COLLECTIVE_COMM"},
 };
 
 const ActivityTypeMap kHpuTypes{
@@ -329,6 +330,11 @@ void prepareTrace(
 
   const bool has_cpu_activity =
       activities.contains(torch::autograd::profiler::ActivityType::CPU);
+  const bool has_mtia_activity =
+      activities.contains(torch::autograd::profiler::ActivityType::MTIA);
+  const bool has_mtia_activity_filter =
+      activity_filter.contains(torch::autograd::profiler::ActivityType::MTIA);
+  const bool has_collectives_profiler = collectivesProfilerExists();
 
   if (has_cpu_activity) {
     insertActivities(torch::autograd::profiler::ActivityType::CPU, kCpuTypes);
@@ -366,11 +372,16 @@ void prepareTrace(
       insertActivities(torch::autograd::profiler::ActivityType::XPU, kXpuTypes);
     }
   }
-  if (activities.contains(torch::autograd::profiler::ActivityType::MTIA)) {
-    if (config.custom_profiler_config.empty()) {
+  if (has_mtia_activity) {
+    TORCH_CHECK(
+        !has_mtia_activity_filter || config.custom_profiler_config.empty(),
+        "`custom_profiler_config` cannot be combined with an MTIA "
+        "`activity_filter`; use only one to select MTIA activities.");
+    if (has_mtia_activity_filter || config.custom_profiler_config.empty()) {
       insertActivities(
           torch::autograd::profiler::ActivityType::MTIA, kMtiaTypes);
     } else {
+      k_activities.insert(libkineto::ActivityType::COLLECTIVE_COMM);
       if (config.custom_profiler_config.find("disable_runtime_events") ==
           std::string::npos) {
         k_activities.insert(libkineto::ActivityType::MTIA_RUNTIME);
@@ -396,6 +407,9 @@ void prepareTrace(
         LOG(INFO) << "Disabling MTIA counter events";
       }
     }
+    if (!has_collectives_profiler) {
+      k_activities.erase(libkineto::ActivityType::COLLECTIVE_COMM);
+    }
   }
   if (activities.contains(torch::autograd::profiler::ActivityType::HPU)) {
     insertActivities(torch::autograd::profiler::ActivityType::HPU, kHpuTypes);
@@ -407,7 +421,7 @@ void prepareTrace(
       k_activities.insert(libkineto::ActivityType::CUDA_SYNC);
     }
   }
-  if (collectivesProfilerExists()) {
+  if (!has_mtia_activity && has_collectives_profiler) {
     k_activities.insert(libkineto::ActivityType::COLLECTIVE_COMM);
   }
   if (activities.contains(

--- a/torch/csrc/profiler/kineto_shim.h
+++ b/torch/csrc/profiler/kineto_shim.h
@@ -112,7 +112,7 @@ using ActivitySet = std::set<torch::autograd::profiler::ActivityType>;
 using ActivityFilter = std::unordered_map<
     torch::autograd::profiler::ActivityType,
     std::unordered_set<std::string>>;
-void prepareTrace(
+TORCH_API void prepareTrace(
     const bool cpuOnly,
     const ActivitySet& activities,
     const torch::profiler::impl::ExperimentalConfig& config,


### PR DESCRIPTION
Summary:

Fine-grained activity filters were bypassed by the MTIA custom-config path, and `COLLECTIVE_COMM` was injected separately from MTIA selection. This prevented Python callers from expressing an exact MTIA activity selection. Make `COLLECTIVE_COMM` a selectable/default MTIA activity, remove it from MTIA requests when no collective profiler is available, and preserve the historical global collective behavior for profiles that do not request MTIA.

Reject combining a non-empty `custom_profiler_config` with an explicit MTIA `activity_filter`, since they are competing mechanisms for selecting MTIA activities.

Test Plan:
# Before

With collective profiling available, the regression test failed because `COLLECTIVE_COMM` was still present for a mixed CPU plus `{ProfilerActivity.MTIA: ["MTIA_INSIGHT"]}` request.

Supplying both a non-empty `custom_profiler_config` and an explicit MTIA `activity_filter` was also ambiguous: the filter selected the activity set while the raw custom config was still forwarded to Kineto.

After adding the test to the OSS CMake suite, GitHub builds also failed to link `test_mtia_activity_filter` because `prepareTrace` was not exported from `libtorch`.

# After

The focused test covers exact MTIA collective inclusion and exclusion in one test process, the legacy MTIA custom-config path, rejection of conflicting custom-config and activity-filter inputs, and preserved CPU-only behavior.

```bash
buck test fbcode//caffe2/test/cpp/profiler:test_mtia_activity_filter
```

https://www.internalfb.com/intern/testinfra/testrun/28710447655788492

The full stack integration coverage exercises the Python vLLM and `mtia-launch` plumbing.

```bash
buck test fbcode//caffe2/test/cpp/profiler:test_mtia_activity_filter fbcode//vllm/fb/mtia/tests/unit:test_profiler_activity_filter fbcode//vllm/fb/mtia/tests/unit:test_mtia_worker fbcode//mtia/genai/inference/launch/test:test_profiler
```

https://www.internalfb.com/intern/testinfra/testrun/5629499923215536

Reviewed By: ryanzhang22, mzzchy

Differential Revision: D117536902


