### PR TITLE
ROCm CI: pass pod CPU limits to nested test containers

### DIFF
--- a/.github/actions/setup-rocm/action.yml
+++ b/.github/actions/setup-rocm/action.yml
@@ -113,6 +113,18 @@ runs:
         # The group name corresponding to group ID 1 can change depending on the OS, so both are necessary.
         echo "GPU_FLAG=--device=/dev/mem --device=/dev/kfd $DEVICE_FLAG --group-add video --group-add $render_gid --group-add daemon --group-add bin --cap-add=SYS_PTRACE --security-opt seccomp=unconfined" >> "${GITHUB_ENV}"
 
+    - name: ROCm set CPU_FLAG
+      shell: bash
+      run: |
+        # k8s ARC runners write /etc/podinfo/gha-docker-cpu-flags (rocOps podinfo) so nested
+        # test containers inherit the pod CPU quota instead of the full node count (~192).
+        if [ -f "/etc/podinfo/gha-docker-cpu-flags" ]; then
+          CPU_FLAG=$(cat /etc/podinfo/gha-docker-cpu-flags)
+        else
+          CPU_FLAG=""
+        fi
+        echo "CPU_FLAG=${CPU_FLAG}" >> "${GITHUB_ENV}"
+
     - name: Login to ECR
       uses: pytorch/pytorch/.github/actions/ecr-login@main
 

--- a/.github/workflows/_rocm-test.yml
+++ b/.github/workflows/_rocm-test.yml
@@ -231,10 +231,11 @@ jobs:
 
           # detached container should get cleaned up by teardown_ec2_linux
           # TODO: Stop building test binaries as part of the build phase
-          # Used for GPU_FLAG since that doesn't play nice
+          # Used for GPU_FLAG/CPU_FLAG since that doesn't play nice
           # shellcheck disable=SC2086,SC2090
           container_name=$(docker run \
             ${GPU_FLAG:-} \
+            ${CPU_FLAG:-} \
             -e BUILD_ENVIRONMENT \
             -e PR_NUMBER \
             -e GITHUB_ACTIONS \


### PR DESCRIPTION
## Summary
- Read \/etc/podinfo/gha-docker-cpu-flags\ in \setup-rocm\ (mirrors existing \gha-render-devices\ → \GPU_FLAG\ pattern) and export \CPU_FLAG\.
- Pass \\\ into the nested \docker run\ in \_rocm-test.yml\ so ARC sandbox test containers inherit the pod CPU quota (\--cpus=11\ / \--cpuset-cpus=...\) instead of seeing the full node (~192 CPUs).

## Problem
On k8s ARC runners (e.g. \	runk-rocm-sandbox\ on DPX MI350 pods), \setup-rocm\ already wires GPU isolation via podinfo, but CPU isolation was not applied to the nested ci-image container. \.ci/pytorch/test.sh\ documents that nested containers see host \
proc\ (~192) rather than the pod allocation, which can oversubscribe Inductor compile workers and contribute to shard timeouts on multi-pod-per-node fleets.

rocOps runners write \gha-docker-cpu-flags\; a runner-side \docker\ wrapper does not help because the workflow invokes \docker run\ from the runner host and the flags must appear on that command line.

## Changes
| File | Change |
|------|--------|
| \.github/actions/setup-rocm/action.yml\ | New \ROCm set CPU_FLAG\ step |
| \.github/workflows/_rocm-test.yml\ | Add \\\ to nested \docker run\ |

No-op on bare-metal / EC2 runners where podinfo is absent (\CPU_FLAG\ empty).

## Test plan
- [ ] Dispatch \	runk-rocm-sandbox\ on \md-sandbox-linux.rocm.gpu.mi350.1\ after rocOps CPU isolation is live
- [ ] Confirm job log \docker run\ includes \--cpus=11\ (or \--cpuset-cpus=...\)
- [ ] \docker exec\ into nested container: \
proc\ returns ~11, not ~192
- [ ] Shards that previously timed out at 270 min make progress / complete

## Related
- rocOps PR #960 (sandbox CPU isolation podinfo)
- PyTorch run [32913915211](https://github.com/pytorch/pytorch/actions/runs/32913915211) — nested \docker run\ had \-e MAX_JOBS=9\ but no \--cpus\


Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang