### PR TITLE
[Testcase Refactoring][ao][sparsity] Add CPU hw_classification to spa…

### DIFF
--- a/test/ao/sparsity/test_kernels.py
+++ b/test/ao/sparsity/test_kernels.py
@@ -20,6 +20,7 @@ from torch.testing._internal.common_quantized import (
     qengine_is_x86,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     raise_on_run_directly,
     skipIfTorchDynamo,
     TestCase,
@@ -32,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 class TestQuantizedSparseKernels(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     @skipIfTorchDynamo("TorchDynamo fails here for unknown reasons")
     @override_qengines
     def test_sparse_qlinear(self):
@@ -262,6 +265,8 @@ class SparseQuantizedModel(nn.Module):
 
 
 class TestQuantizedSparseLayers(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     @override_qengines
     def test_sparse_qlinear(self):
         # Note: At the moment, for sparse kernels


### PR DESCRIPTION
## Change background

PyTorch test classes are being annotated with hardware classification metadata
so test selection can distinguish device-specific tests from device-generic
tests.

`TestQuantizedSparseKernels` tests sparse quantized linear operators, and
`TestQuantizedSparseLayers` tests conversion and serialization of sparse
quantized linear modules. This classification follows the operator
implementation, not merely the default device used when creating tensors.

`TestQuantizedSparseKernels` directly invokes `sparse::qlinear_prepack`,
`sparse::qlinear`, and `sparse::qlinear_dynamic`. The prepack and static
linear operators are registered for `QuantizedCPU`; the dynamic linear operator
is registered for `CPU`. Their implementations select FBGEMM and QNNPACK,
which are CPU quantization backends. The test does not have an implementation
to dispatch to CUDA, NPU, or another accelerator.

`TestQuantizedSparseLayers` verifies eager quantization conversion, but its
converted sparse linear modules invoke the same `sparse::qlinear*` operators.
It is therefore CPU-specific for the same reason. No hardware decoupling or
class split is required, and both classes are classified as
`HardwareClassification.CPU`.

## Modification

- Import `HardwareClassification` from `torch.testing._internal.common_utils`.
- Add `hw_classification = HardwareClassification.CPU` to
  `TestQuantizedSparseKernels`.
- Add `hw_classification = HardwareClassification.CPU` to
  `TestQuantizedSparseLayers`.
- Keep test logic, assertions, and test names unchanged.

## Self-test

Environment:

- Linux x86_64, Python 3.13.12
- CPU nightly: PyTorch `2.15.0.dev20260826+cpu`
- `torch.backends.quantized.supported_engines`:
  `['qnnpack', 'onednn', 'x86', 'fbgemm']`

Commands:

```bash
python test/test_ao_sparsity.py --hw-classification CPU -v
python test/test_ao_sparsity.py --hw-classification GENERIC -v
python test/test_ao_sparsity.py --discover-tests
```

Results:

- CPU classification: 8 passed, including all 3 tests from
  `test/ao/sparsity/test_kernels.py`.
- The target kernel test exercised the FBGEMM static path and the QNNPACK
  dynamic path.
- GENERIC classification selected no tests, as expected. The test runner
  returns exit code 5 for `NO TESTS RAN`.
- `--discover-tests` completed successfully and listed 88 tests, including the
  three target tests.

The nightly wheel was used because the hardware-classification test runner
support is available on the main development line. Tests ran from outside the
source checkout so the installed nightly wheel was imported instead of the
source-tree package.

## Risks

Low. The change only imports the hardware classification enum and adds
class-level test metadata; test logic and product code are unchanged.

<details>
<summary>CPU nightly self-test log</summary>

```text
torch: 2.15.0.dev20260826+cpu
torch path: /tmp/torch-nightly-env/lib/python3.13/site-packages/torch/__init__.py
quantized engines: ['qnnpack', 'onednn', 'x86', 'fbgemm']
test_prune_lstm_layernorm_linear_multiple_layer (ao.sparsity.test_structured_sparsifier.TestBaseStructuredSparsifierCPU.test_prune_lstm_layernorm_linear_multiple_layer)
Test fusion support for LSTM(multi-layer) -> Linear ... ok
test_prune_lstm_layernorm_linear_single_layer (ao.sparsity.test_structured_sparsifier.TestBaseStructuredSparsifierCPU.test_prune_lstm_layernorm_linear_single_layer)
Test fusion support for LSTM (single-layer) -> Linear ... ok
test_prune_lstm_linear_multiple_layer (ao.sparsity.test_structured_sparsifier.TestBaseStructuredSparsifierCPU.test_prune_lstm_linear_multiple_layer)
Test fusion support for LSTM(multi-layer) -> Linear ... ok
test_prune_lstm_linear_single_layer (ao.sparsity.test_structured_sparsifier.TestBaseStructuredSparsifierCPU.test_prune_lstm_linear_single_layer)
Test fusion support for LSTM (single-layer) -> Linear ... ok
test_compute_distance (ao.sparsity.test_structured_sparsifier.TestFPGMPrunerCPU.test_compute_distance)
Test the distance computation function ... ok
test_sparse_qlinear (ao.sparsity.test_kernels.TestQuantizedSparseKernels.test_sparse_qlinear) ... /home/zj/shengsi/pytorch/test/ao/sparsity/test_kernels.py:80: UserWarning: torch.quantize_per_tensor, torch.quantize_per_channel and other quantized tensor creation functions that produce tensors with dtype torch.quint8, torch.qint8, and torch.qint32 are deprecated and will be removed in a future PyTorch release. Please see https://github.com/pytorch/pytorch/issues/184982 for more information. (Triggered internally at /__w/pytorch/pytorch/aten/src/ATen/quantized/Quantizer.cpp:111.)
  X_q = torch.quantize_per_tensor(
2026-08-26 15:58:11,993 - ao.sparsity.test_kernels - INFO - static sparse qlinear is only available in fbgemm
2026-08-26 15:58:11,994 - ao.sparsity.test_kernels - INFO - static sparse qlinear is only available in fbgemm
2026-08-26 15:58:11,994 - ao.sparsity.test_kernels - INFO - dynamic sparse qlinear is only available in qnnpack
2026-08-26 15:58:11,995 - ao.sparsity.test_kernels - INFO - dynamic sparse qlinear is only available in qnnpack
ok
test_sparse_qlinear (ao.sparsity.test_kernels.TestQuantizedSparseLayers.test_sparse_qlinear) ... /home/zj/shengsi/pytorch/test/ao/sparsity/test_kernels.py:185: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10.
For migrations of users:
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx), please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e)
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e)
see https://github.com/pytorch/ao/issues/2259 for more details
  tq.prepare(qmodel, inplace=True)
/home/zj/shengsi/pytorch/test/ao/sparsity/test_kernels.py:186: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10.
For migrations of users:
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx), please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e)
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e)
see https://github.com/pytorch/ao/issues/2259 for more details
  tq.prepare(sqmodel, inplace=True)
/tmp/torch-nightly-env/lib/python3.13/site-packages/torch/ao/quantization/observer.py:368: UserWarning: must run observer before calling calculate_qparams. Returning default values.
  if not check_min_max_valid(min_val, max_val):
/home/zj/shengsi/pytorch/test/ao/sparsity/test_kernels.py:215: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10.
For migrations of users:
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx), please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e)
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e)
see https://github.com/pytorch/ao/issues/2259 for more details
  tq.convert(sqmodel, inplace=True, mapping=sparse_mapping)
/home/zj/shengsi/pytorch/test/ao/sparsity/test_kernels.py:216: DeprecationWarning: torch.ao.quantization is deprecated and will be removed in 2.10.
For migrations of users:
1. Eager mode quantization (torch.ao.quantization.quantize, torch.ao.quantization.quantize_dynamic), please migrate to use torchao eager mode quantize_ API instead
2. FX graph mode quantization (torch.ao.quantization.quantize_fx.prepare_fx,torch.ao.quantization.quantize_fx.convert_fx), please migrate to use torchao pt2e quantization API instead (prepare_pt2e, convert_pt2e)
3. pt2e quantization has been migrated to torchao (https://github.com/pytorch/ao/tree/main/torchao/quantization/pt2e)
see https://github.com/pytorch/ao/issues/2259 for more details
  tq.convert(qmodel, inplace=True, mapping=ref_mapping)
[W826 15:58:11.663660141 qlinear_dynamic.cpp:251] Warning: Currently, qnnpack incorrectly ignores reduce_range when it is set to true; this may change in a future release. (function operator())
/tmp/torch-nightly-env/lib/python3.13/site-packages/torch/ao/quantization/observer.py:1039: UserWarning: Please use quant_min and quant_max to specify the range for observers. reduce_range will be deprecated in a future release of PyTorch.
  super().__init__(
ok
test_sparse_qlinear_serdes (ao.sparsity.test_kernels.TestQuantizedSparseLayers.test_sparse_qlinear_serdes) ... /tmp/torch-nightly-env/lib/python3.13/site-packages/torch/jit/_script.py:1491: FutureWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
  warnings.warn(
/tmp/torch-nightly-env/lib/python3.13/site-packages/torch/jit/_serialization.py:89: FutureWarning: `torch.jit.save` is deprecated. Please switch to `torch.export`.
  warnings.warn(
/tmp/torch-nightly-env/lib/python3.13/site-packages/torch/jit/_serialization.py:176: FutureWarning: `torch.jit.load` is deprecated. Please switch to `torch.export`.
  warnings.warn(
ok

----------------------------------------------------------------------
Ran 8 tests in 0.087s

OK
HW classification mode active (['CPU']): total=88, passed=8, unclassified=65, mismatched=15

----------------------------------------------------------------------
Ran 0 tests in 0.000s

NO TESTS RAN
HW classification mode active (['GENERIC']): total=88, passed=0, unclassified=65, mismatched=23
TestActivationSparsifier.test_activation_sparsifier
TestBaseDataScheduler.test_constructor
TestBaseDataScheduler.test_order_of_steps
TestBaseDataScheduler.test_state_dict
TestBaseDataScheduler.test_step
TestBaseDataSparsifier.test_nn_embeddings
TestBaseDataSparsifier.test_nn_parameters
TestBaseDataSparsifier.test_tensors
TestBaseSparsifier.test_constructor
TestBaseSparsifier.test_convert
TestBaseSparsifier.test_mask_squash
TestBaseSparsifier.test_mask_squash_with_params1
TestBaseSparsifier.test_mask_squash_with_params2
TestBaseSparsifier.test_mask_squash_with_params3
TestBaseSparsifier.test_prepare_config
TestBaseSparsifier.test_state_dict
TestBaseSparsifier.test_step
TestBaseStructuredSparsifierCPU.test_prune_lstm_layernorm_linear_multiple_layer
TestBaseStructuredSparsifierCPU.test_prune_lstm_layernorm_linear_single_layer
TestBaseStructuredSparsifierCPU.test_prune_lstm_linear_multiple_layer
TestBaseStructuredSparsifierCPU.test_prune_lstm_linear_single_layer
TestBaseStructuredSparsifierDeviceCPU.test_complex_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_constructor_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prepare_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prepare_linear_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_conv2d_activation_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_conv2d_bias_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_conv2d_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_conv2d_padding_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_conv2d_pool_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_linear_activation_linear_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_linear_bias_linear_cpu
TestBaseStructuredSparsifierDeviceCPU.test_prune_linear_linear_cpu
TestBaseStructuredSparsifierDeviceCPU.test_step_conv2d_cpu
TestBaseStructuredSparsifierDeviceCPU.test_step_linear_cpu
TestComposability.test_convert_without_squash_mask
TestComposability.test_fusion_before_s_prep
TestComposability.test_q_prep_before_s_prep
TestComposability.test_qat_prep_before_s_prep
TestComposability.test_s_prep_before_fusion
TestComposability.test_s_prep_before_q_prep
TestComposability.test_s_prep_before_qat_prep
TestCubicScheduler.test_constructor
TestCubicScheduler.test_step
TestFPGMPrunerCPU.test_compute_distance
TestFPGMPrunerDeviceCPU.test_update_mask_cpu
TestFakeSparsity.test_jit_trace
TestFakeSparsity.test_masking_logic
TestFakeSparsity.test_state_dict_preserved
TestFakeSparsity.test_weights_parametrized
TestFxComposability.test_q_prep_fx_before_s_prep
TestFxComposability.test_q_prep_fx_s_prep_ref_conv
TestFxComposability.test_s_prep_before_q_prep_fx
TestFxComposability.test_s_prep_before_qat_prep_fx
TestFxComposability.test_s_prep_q_prep_fx_ref
TestNearlyDiagonalSparsifier.test_constructor
TestNearlyDiagonalSparsifier.test_mask_squash
TestNearlyDiagonalSparsifier.test_prepare
TestNearlyDiagonalSparsifier.test_sparsity_levels
TestNearlyDiagonalSparsifier.test_step
TestNormDataSparsifiers.test_nn_embeddings
TestNormDataSparsifiers.test_nn_parameters
TestNormDataSparsifiers.test_tensors
TestQuantizationUtils.test_ptq_quantize_first
TestQuantizationUtils.test_ptq_sparsify_first
TestQuantizedSparseKernels.test_sparse_qlinear
TestQuantizedSparseLayers.test_sparse_qlinear
TestQuantizedSparseLayers.test_sparse_qlinear_serdes
TestSaliencyPrunerCPU.test_lstm_saliency_pruner_update_mask_cpu_float32
TestSaliencyPrunerCPU.test_saliency_pruner_update_mask_cpu_float32
TestScheduler.test_constructor
TestScheduler.test_lambda_scheduler
TestScheduler.test_order_of_steps
TestScheduler.test_step
TestSparsityUtilFunctions.test_fqn_to_module
TestSparsityUtilFunctions.test_fqn_to_module_fail
TestSparsityUtilFunctions.test_fqn_to_module_for_tensors
TestSparsityUtilFunctions.test_get_arg_info_from_tensor_fqn
TestSparsityUtilFunctions.test_get_arg_info_from_tensor_fqn_fail
TestSparsityUtilFunctions.test_module_to_fqn
TestSparsityUtilFunctions.test_module_to_fqn_fail
TestSparsityUtilFunctions.test_module_to_fqn_root
TestWeightNormSparsifier.test_constructor
TestWeightNormSparsifier.test_mask_squash
TestWeightNormSparsifier.test_prepare
TestWeightNormSparsifier.test_sparsity_levels
TestWeightNormSparsifier.test_step
TestWeightNormSparsifier.test_step_2_of_4
exit codes: cpu=0 generic=5 discover=0
```

</details>
