### PR TITLE
[cuDNN] Add guards for cuDNN SDPA decode

### DIFF
--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -209,10 +209,12 @@ static void check_cudnn_sdpa_execution(fe::error_t err) {
           : "");
 }
 
+// See #193893 and #194927 for reasoning
+// TODO: remove this and all associated calls/imports when fixed
 void check_cudnn_sdpa_decode(int64_t s_q) {
   TORCH_CHECK(
       s_q != 1 || !sdp::is_cudnn_attention_decode_disabled(),
-      "cuDNN SDPA decode is disabled for cuDNN versions 9.19+ on SM 10.x and 11.x.");
+      "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25 on SM 10.x and 11.x.");
 }
 
 // Whether we will use ragged offsets in the dense (non-nested) path

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -214,7 +214,7 @@ static void check_cudnn_sdpa_execution(fe::error_t err) {
 void check_cudnn_sdpa_decode(int64_t s_q) {
   TORCH_CHECK(
       s_q != 1 || !sdp::is_cudnn_attention_decode_disabled(),
-      "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25 on SM 10.x and 11.x.");
+      "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25.0 (except 9.24.1) on SM 10.x and 11.x.");
 }
 
 // Whether we will use ragged offsets in the dense (non-nested) path

--- a/aten/src/ATen/native/cudnn/MHA.cpp
+++ b/aten/src/ATen/native/cudnn/MHA.cpp
@@ -163,6 +163,7 @@ void run_cudnn_SDP_bprop_nestedtensor(
 #include <ATen/cudnn/Types.h>
 #include <ATen/cudnn/Utils.h>
 #include <ATen/native/cudnn/MHA.h>
+#include <ATen/native/transformers/cuda/sdp_utils.h>
 #include <ATen/native/transformers/sdp_utils.h>
 
 #include <ATen/cuda/Exceptions.h>
@@ -206,6 +207,12 @@ static void check_cudnn_sdpa_execution(fe::error_t err) {
             "calling torch.cuda.memory.set_per_process_memory_fraction(fraction) "
             "early in the process to leave memory available for cuDNN."
           : "");
+}
+
+void check_cudnn_sdpa_decode(int64_t s_q) {
+  TORCH_CHECK(
+      s_q != 1 || !sdp::is_cudnn_attention_decode_disabled(),
+      "cuDNN SDPA decode is disabled for cuDNN versions 9.19+ on SM 10.x and 11.x.");
 }
 
 // Whether we will use ragged offsets in the dense (non-nested) path
@@ -1539,6 +1546,7 @@ void run_cudnn_SDP_fprop(
   if (!q.numel() || !k.numel() || !v.numel()) {
     return;
   }
+  check_cudnn_sdpa_decode(s_q);
   Tensor seqlen_q, seqlen_kv;
   Tensor rag_off_q, rag_off_k, rag_off_v, rag_off_o, rag_off_lse;
 
@@ -1707,6 +1715,7 @@ void run_cudnn_SDP_fprop_nestedtensor(
     }
     return;
   }
+  check_cudnn_sdpa_decode(s_q);
   const bool is_paged = page_table.has_value();
   TORCH_INTERNAL_ASSERT(
       !is_paged || seqused_k.has_value(),
@@ -1877,6 +1886,7 @@ void run_cudnn_SDP_bprop(
       !softmaxstats.numel()) {
     return;
   }
+  check_cudnn_sdpa_decode(s_q);
   Tensor seqlen_q, seqlen_kv;
   Tensor rag_off_q, rag_off_k, rag_off_v, rag_off_o, rag_off_lse;
 
@@ -2047,6 +2057,7 @@ void run_cudnn_SDP_bprop_nestedtensor(
     dV.zero_();
     return;
   }
+  check_cudnn_sdpa_decode(s_q);
   TORCH_CHECK(
       softmaxstats.dim() == 2, "cuDNN SDPA expected a 2D (H, T) softmax_lse");
   auto softmaxstats_ = softmaxstats.unsqueeze(-1).transpose(0, 1);

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1010,7 +1010,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
   const bool has_kv_cache = seqused_k.has_value() || block_table.has_value();
   TORCH_CHECK(
       is_nested || query.size(2) != 1 || !sdp::is_cudnn_attention_decode_disabled(),
-      "cuDNN SDPA decode is disabled for cuDNN versions 9.19+ on SM 10.x and 11.x.");
+      "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25 on SM 10.x and 11.x.");
   TORCH_CHECK(
       query.scalar_type() == at::kHalf || query.scalar_type() == at::kBFloat16,
       "cuDNN attention only supports float16 and bfloat16, got ",

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1009,6 +1009,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
   const bool is_nested = cumulative_sequence_length_q.has_value();
   const bool has_kv_cache = seqused_k.has_value() || block_table.has_value();
   TORCH_CHECK(
+      is_nested || query.size(2) != 1 || !sdp::is_cudnn_attention_decode_disabled(),
+      "cuDNN SDPA decode is disabled for cuDNN versions 9.19+ on SM 10.x and 11.x.");
+  TORCH_CHECK(
       query.scalar_type() == at::kHalf || query.scalar_type() == at::kBFloat16,
       "cuDNN attention only supports float16 and bfloat16, got ",
       query.scalar_type());

--- a/aten/src/ATen/native/transformers/cuda/attention.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention.cu
@@ -1010,7 +1010,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, c10::SymInt, c10::SymInt, Tensor, Ten
   const bool has_kv_cache = seqused_k.has_value() || block_table.has_value();
   TORCH_CHECK(
       is_nested || query.size(2) != 1 || !sdp::is_cudnn_attention_decode_disabled(),
-      "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25 on SM 10.x and 11.x.");
+      "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25.0 (except 9.24.1) on SM 10.x and 11.x.");
   TORCH_CHECK(
       query.scalar_type() == at::kHalf || query.scalar_type() == at::kBFloat16,
       "cuDNN attention only supports float16 and bfloat16, got ",

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -250,7 +250,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_attention_backward(
     const bool is_nested = cum_seq_q.defined();
     TORCH_CHECK(
         is_nested || query.size(2) != 1 || !sdp::is_cudnn_attention_decode_disabled(),
-        "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25 on SM 10.x and 11.x.");
+        "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25.0 (except 9.24.1) on SM 10.x and 11.x.");
     TORCH_CHECK(
         !is_nested || max_q > 128,
         "cuDNN varlen attention does not support query sequence length <= 128.");

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -249,6 +249,9 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_attention_backward(
 
     const bool is_nested = cum_seq_q.defined();
     TORCH_CHECK(
+        is_nested || query.size(2) != 1 || !sdp::is_cudnn_attention_decode_disabled(),
+        "cuDNN SDPA decode is disabled for cuDNN versions 9.19+ on SM 10.x and 11.x.");
+    TORCH_CHECK(
         !is_nested || max_q > 128,
         "cuDNN varlen attention does not support query sequence length <= 128.");
 

--- a/aten/src/ATen/native/transformers/cuda/attention_backward.cu
+++ b/aten/src/ATen/native/transformers/cuda/attention_backward.cu
@@ -250,7 +250,7 @@ std::tuple<Tensor, Tensor, Tensor> _cudnn_attention_backward(
     const bool is_nested = cum_seq_q.defined();
     TORCH_CHECK(
         is_nested || query.size(2) != 1 || !sdp::is_cudnn_attention_decode_disabled(),
-        "cuDNN SDPA decode is disabled for cuDNN versions 9.19+ on SM 10.x and 11.x.");
+        "cuDNN SDPA decode is disabled for cuDNN versions 9.19-9.25 on SM 10.x and 11.x.");
     TORCH_CHECK(
         !is_nested || max_q > 128,
         "cuDNN varlen attention does not support query sequence length <= 128.");

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -715,7 +715,7 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
           dprops->major,
           ".",
           dprops->minor,
-          " for cuDNN versions 9.19-9.25");
+          " for cuDNN versions 9.19-9.25.0 (except 9.24.1)");
     }
     return false;
   }
@@ -1013,7 +1013,9 @@ bool is_cudnn_attention_decode_disabled() {
   static const std::vector<bool> disabled_by_device = [] {
     const auto cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
     std::vector<bool> disabled(at::cuda::device_count());
-    if (cudnn_version < 91900 || cudnn_version >= 92600) {
+    // cuDNN versions 9.19-9.25.0 (except 9.24.1) on SM 10.x and 11.x are disabled
+    // This check also allows possible future 9.24 patch versions without a rewrite
+    if (cudnn_version < 91900 || cudnn_version > 92500 || (cudnn_version > 92400 && cudnn_version < 92500)) {
       return disabled;
     }
     for (const auto device : c10::irange(at::cuda::device_count())) {

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -707,14 +707,15 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
   }
   auto head_dim_limit = 128;
   auto dprops = at::cuda::getCurrentDeviceProperties();
-  if (s_q == 1 && is_cudnn_attention_decode_disabled()) {
+  if (TORCH_GUARD_OR_FALSE(s_q.sym_eq(1)) &&
+      is_cudnn_attention_decode_disabled()) {
     if (debug) {
       TORCH_WARN(
           "cuDNN SDPA decode is disabled on SM ",
           dprops->major,
           ".",
           dprops->minor,
-          " for cuDNN versions 9.19+");
+          " for cuDNN versions 9.19-9.25");
     }
     return false;
   }
@@ -1005,17 +1006,18 @@ bool check_cudnn_deterministic(const sdp_params& params, bool debug) {
 
 } // namespace
 
+// See #193893 and #194927 for reasoning
+// TODO: Remove this and all associated calls/imports when fixed
 bool is_cudnn_attention_decode_disabled() {
 #if AT_CUDNN_ENABLED() && defined(CUDNN_VERSION)
   static const std::vector<bool> disabled_by_device = [] {
     const auto cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
     std::vector<bool> disabled(at::cuda::device_count());
-    if (cudnn_version < 91900) {
+    if (cudnn_version < 91900 || cudnn_version >= 92600) {
       return disabled;
     }
     for (const auto device : c10::irange(at::cuda::device_count())) {
       const auto* dprops = at::cuda::getDeviceProperties(device);
-      // TODO: Update this guard with an upper bound once a cuDNN release includes the fix
       disabled[device] = dprops->major == 10 || dprops->major == 11;
     }
     return disabled;

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -19,6 +19,7 @@
 #include <c10/util/string_view.h>
 
 #include <algorithm>
+#include <vector>
 
 #if AT_CUDNN_ENABLED()
 #include <ATen/cudnn/cudnn-wrapper.h>
@@ -706,6 +707,17 @@ bool check_cudnn_tensor_shapes(sdp_params const& params, bool debug) {
   }
   auto head_dim_limit = 128;
   auto dprops = at::cuda::getCurrentDeviceProperties();
+  if (s_q == 1 && is_cudnn_attention_decode_disabled()) {
+    if (debug) {
+      TORCH_WARN(
+          "cuDNN SDPA decode is disabled on SM ",
+          dprops->major,
+          ".",
+          dprops->minor,
+          " for cuDNN versions 9.19+");
+    }
+    return false;
+  }
   const bool is_sm90_or_sm10x =
       (dprops->major == 9 && !dprops->minor) || dprops->major == 10;
   const bool is_unsupported_sm107 =
@@ -992,6 +1004,27 @@ bool check_cudnn_deterministic(const sdp_params& params, bool debug) {
 }
 
 } // namespace
+
+bool is_cudnn_attention_decode_disabled() {
+#if AT_CUDNN_ENABLED() && defined(CUDNN_VERSION)
+  static const std::vector<bool> disabled_by_device = [] {
+    const auto cudnn_version = at::detail::getCUDAHooks().versionRuntimeCuDNN();
+    std::vector<bool> disabled(at::cuda::device_count());
+    if (cudnn_version < 91900) {
+      return disabled;
+    }
+    for (const auto device : c10::irange(at::cuda::device_count())) {
+      const auto* dprops = at::cuda::getDeviceProperties(device);
+      // TODO: Update this guard with an upper bound once a cuDNN release includes the fix
+      disabled[device] = dprops->major == 10 || dprops->major == 11;
+    }
+    return disabled;
+  }();
+  return disabled_by_device.at(at::cuda::current_device());
+#else
+  return false;
+#endif
+}
 
 bool can_use_cudnn_attention(const sdp_params& params, bool debug) {
 #if defined(USE_ROCM) || !AT_CUDNN_ENABLED() || !defined(CUDNN_VERSION)

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.h
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.h
@@ -13,5 +13,6 @@ C10_EXPORT bool is_flash_attention_available();
 C10_EXPORT bool can_use_flash_attention(sdp_params const& params, bool debug);
 C10_EXPORT bool can_use_mem_efficient_attention(sdp_params const& params, bool debug);
 C10_EXPORT bool can_use_cudnn_attention(sdp_params const& params, bool debug);
+C10_EXPORT bool is_cudnn_attention_decode_disabled();
 
 } // namespace sdp

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2966,6 +2966,29 @@ class TestSDPACudaOnly(NNTestCase):
     _do_cuda_memory_leak_check = True
     _do_cuda_non_default_stream = True
 
+    @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
+    def test_cudnn_attention_decode_disabled_on_affected_blackwell(self, device):
+        cudnn_version = torch.backends.cudnn.version() or 0
+        device_capability = torch.cuda.get_device_capability()
+        affected_arch = device_capability[0] in (10, 11)
+        if not (affected_arch and cudnn_version >= 91900):
+            self.skipTest("Requires cuDNN 9.19+ on SM 10.x or 11.x")
+
+        query = torch.randn(2, 8, 1, 64, device=device, dtype=torch.float16)
+        key = torch.randn(2, 8, 128, 64, device=device, dtype=torch.float16)
+        value = torch.randn(2, 8, 128, 64, device=device, dtype=torch.float16)
+        params = SDPAParams(query, key, value, None, 0.0, False, False)
+
+        self.assertFalse(torch.backends.cuda.can_use_cudnn_attention(params))
+        with self.assertRaisesRegex(RuntimeError, "cuDNN SDPA decode is disabled"):
+            torch.ops.aten._scaled_dot_product_cudnn_attention.default(
+                query, key, value, None, False, 0.0, False, False
+            )
+        with self.assertRaisesRegex(RuntimeError, "cuDNN SDPA decode is disabled"):
+            torch.ops.aten._cudnn_attention_forward.default(
+                query, key, value, None, None, None, 1, 128, False, 0.0, False, False
+            )
+
     # TODO USED FOR TESTING THE SCORES, e.g. testing ALIBI we don't need this now
     def normalize_flash_attn_S(
         self,

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2968,11 +2968,13 @@ class TestSDPACudaOnly(NNTestCase):
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_CUDNN_ATTENTION, "cuDNN Attention is not supported on this system")
     def test_cudnn_attention_decode_disabled_on_affected_blackwell(self, device):
+        # See #193893 and #194927 for reasoning
+        # TODO: Remove this test when fixed and disable is no longer needed
         cudnn_version = torch.backends.cudnn.version() or 0
         device_capability = torch.cuda.get_device_capability()
         affected_arch = device_capability[0] in (10, 11)
-        if not (affected_arch and cudnn_version >= 91900):
-            self.skipTest("Requires cuDNN 9.19+ on SM 10.x or 11.x")
+        if not (affected_arch and (91900 <= cudnn_version < 92600)):
+            self.skipTest("Requires cuDNN 9.19-9.25 on SM 10.x or 11.x")
 
         query = torch.randn(2, 8, 1, 64, device=device, dtype=torch.float16)
         key = torch.randn(2, 8, 128, 64, device=device, dtype=torch.float16)

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -2973,8 +2973,10 @@ class TestSDPACudaOnly(NNTestCase):
         cudnn_version = torch.backends.cudnn.version() or 0
         device_capability = torch.cuda.get_device_capability()
         affected_arch = device_capability[0] in (10, 11)
-        if not (affected_arch and (91900 <= cudnn_version < 92600)):
-            self.skipTest("Requires cuDNN 9.19-9.25 on SM 10.x or 11.x")
+        # cuDNN versions 9.19-9.25.0 (except 9.24.1) on SM 10.x and 11.x are disabled
+        # This check also allows possible future 9.24 patch versions without a rewrite
+        if not (affected_arch and (91900 <= cudnn_version <= 92500) and not (92400 < cudnn_version < 92500)):
+            self.skipTest("Requires cuDNN 9.19-9.25.0 (except 9.24.1) on SM 10.x or 11.x")
 
         query = torch.randn(2, 8, 1, 64, device=device, dtype=torch.float16)
         key = torch.randn(2, 8, 128, 64, device=device, dtype=torch.float16)


### PR DESCRIPTION
This PR adds guards that disable cuDNN SDPA on version+device combos that expose the decoding bug from #193893. Right now this blocks cuDNN on Blackwell on 9.19+, still waiting on a confirmed fixed release build to set an upper bound.

cc @eqy @drisspg 

Authored with assistance from Codex