### PR TITLE
Fix issue triage GitHub MCP startup

### DIFF
--- a/.claude/skills/distributed-triage/SKILL.md
+++ b/.claude/skills/distributed-triage/SKILL.md
@@ -45,8 +45,9 @@ Use these GitHub MCP tools for triage:
 
 | Tool | Purpose |
 |------|---------|
-| `mcp__github__issue_read` | Get issue details, comments, and existing labels |
-| `mcp__github__issue_write` | Apply labels or close issues |
+| `mcp__github__get_issue` | Get issue details and existing labels |
+| `mcp__github__get_issue_comments` | Get existing issue comments |
+| `mcp__github__update_issue` | Apply labels or close issues |
 | `mcp__github__add_issue_comment` | Add comment (only for reproduction requests or mislabel flags) |
 | `mcp__github__search_issues` | Find similar issues for context |
 
@@ -55,7 +56,7 @@ Use these GitHub MCP tools for triage:
 ## Comment Deduplication
 
 Before adding any issue comment:
-1. Read the existing comments with `mcp__github__issue_read`.
+1. Read the existing comments with `mcp__github__get_issue_comments`.
 2. Check whether the triage bot has already posted the same template or a substantially equivalent request/explanation.
 3. If a duplicate exists, do not add another comment. Continue with any non-comment actions that are still needed, such as labels.
 

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -52,8 +52,9 @@ Use these GitHub MCP tools for triage:
 
 | Tool | Purpose |
 |------|---------|
-| `mcp__github__issue_read` | Get issue details, comments, and existing labels |
-| `mcp__github__issue_write` | Apply labels or close issues |
+| `mcp__github__get_issue` | Get issue details and existing labels |
+| `mcp__github__get_issue_comments` | Get existing issue comments |
+| `mcp__github__update_issue` | Apply labels or close issues |
 | `mcp__github__add_issue_comment` | Add comment (only for redirecting questions) |
 | `mcp__github__search_issues` | Find similar issues for context |
 

--- a/.github/workflows/claude-distributed-triage.yml
+++ b/.github/workflows/claude-distributed-triage.yml
@@ -71,30 +71,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup GitHub MCP Server
+      - name: Pre-pull GitHub MCP Server
         if: steps.gate.outputs.proceed == 'true'
-        run: |
-          mkdir -p /tmp/mcp-config
-          cat > /tmp/mcp-config/mcp-servers.json << 'EOF'
-          {
-            "mcpServers": {
-              "github": {
-                "command": "docker",
-                "args": [
-                  "run",
-                  "-i",
-                  "--rm",
-                  "-e",
-                  "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:v0.30.1"
-                ],
-                "env": {
-                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
-                }
-              }
-            }
-          }
-          EOF
+        env:
+          # claude-code-action v1.0.89 injects this image when GitHub MCP tools are allowed.
+          GITHUB_MCP_IMAGE: "ghcr.io/github/github-mcp-server:sha-23fa0dd"
+        run: docker pull "$GITHUB_MCP_IMAGE"
 
       - name: Configure AWS credentials via OIDC
         if: steps.gate.outputs.proceed == 'true'
@@ -119,8 +101,7 @@ jobs:
           allowed_bots: "*"
           claude_args: |
             --model global.anthropic.claude-sonnet-5
-            --mcp-config /tmp/mcp-config/mcp-servers.json
-            --allowedTools "mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
+            --allowedTools "mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
           prompt: |
             /distributed-triage #${{ steps.issue.outputs.number }}
 

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -68,32 +68,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup GitHub MCP Server
-        run: |
-          mkdir -p /tmp/mcp-config
-          cat > /tmp/mcp-config/mcp-servers.json << 'EOF'
-          {
-            "mcpServers": {
-              "github": {
-                "command": "docker",
-                "args": [
-                  "run",
-                  "-i",
-                  "--rm",
-                  "-e",
-                  "GITHUB_PERSONAL_ACCESS_TOKEN",
-                  "ghcr.io/github/github-mcp-server:v0.30.1"
-                ],
-                "env": {
-                  "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
-                }
-              }
-            }
-          }
-          EOF
-
+      - name: Pre-pull GitHub MCP Server
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # claude-code-action v1.0.89 injects this image when GitHub MCP tools are allowed.
+          GITHUB_MCP_IMAGE: "ghcr.io/github/github-mcp-server:sha-23fa0dd"
+        run: docker pull "$GITHUB_MCP_IMAGE"
+
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
@@ -115,8 +95,7 @@ jobs:
           allowed_bots: "pytorch-bot"
           claude_args: |
             --model global.anthropic.claude-sonnet-5
-            --mcp-config /tmp/mcp-config/mcp-servers.json
-            --allowedTools "mcp__github__issue_read,mcp__github__get_issue,mcp__github__issue_write,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
+            --allowedTools "mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
           prompt: |
             /triaging-issues #${{ steps.issue.outputs.number }}
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #194930

## Human Note

We have seen a number of recurring outages in triage that seem to be due to a race in the mcp github and claude starting; this makes sure thatw e pre-pull the server so that any gh commands claude invokes are ready to go

## Agent note

Authored with an AI assistant. `claude-code-action@v1.0.89` injects its own pinned GitHub MCP
container whenever `mcp__github__*` tools are allowed. The workflows also supplied a file-based
v0.30.1 configuration, but the action's config merger retained the injected inline server instead.
That left the actual image to cold-pull during Claude's bounded MCP startup window, intermittently
leaving the server in `pending` state.

Pre-pull the image actually launched by the pinned action and remove the ineffective override. Also
align the allowlist and triage instructions with the fine-grained tools exposed by that image,
including `get_issue_comments`. The [ciforge end-to-end run](https://github.com/pytorch/ciforge/actions/runs/32991160998)
on [mirrored issue #545](https://github.com/pytorch/ciforge/issues/545) initialized GitHub MCP as
connected and successfully called `get_issue`, `get_issue_comments`, and `update_issue`.

## Test Plan

```bash
PATH="$HOME/.venvs/dev/bin:$PATH" lintrunner -a
```