### PR TITLE
[Distributed][NCCL] Initialize Backend group UID in constructor

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -1226,8 +1226,6 @@ class NCCLSymmetricMemoryNccl2Test(MultiProcContinuousTest):
         # Confirm the intended path: a torchcomms PG + the NCCL symm-mem backend.
         self.assertEqual(c10d.get_backend(c10d.group.WORLD), self.backend_name)
         self.assertEqual(symm_mem.get_backend(self.device), "NCCL")
-        # Publish the communicator before rendezvous looks it up.
-        c10d.all_reduce(torch.ones(1, device=self.device))
         group_name = c10d.group.WORLD.group_name
 
         t = symm_mem.empty(64, dtype=torch.float, device=self.device).fill_(self.rank)

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -100,6 +100,8 @@ ProcessGroupNCCL::ProcessGroupNCCL(
   name_ = options_c10d_->group_name.empty() ? std::string(kBackendName)
                                             : options_c10d_->group_name;
 
+  setGroupUid(options_c10d_->group_name);
+
   if (options_c10d_->config.blocking == NCCL_CONFIG_UNDEF_INT) {
     auto nonblocking = c10::utils::check_env("TORCH_NCCL_USE_COMM_NONBLOCKING");
     options_c10d_->config.blocking = nonblocking.value_or(false) ? 0 : 1;


### PR DESCRIPTION
`test_nccl_symmem_rendezvous` is failing on GB200 in nightly CI, and I was able to bisect to the eager path introduced by #192895. My agent thinks the new eager constructor just needs to assign the backend UID earlier to match the behavior of the prior lazy init. I've not worked much with NCCL but the reasoning and fix seemed sane. Error message and agent summary included below.
```
======================================================================
ERROR: test_nccl_symmem_rendezvous (__main__.NCCLSymmetricMemoryNccl2Test.test_nccl_symmem_rendezvous)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 2189, in wrapper
    raise deferred_exception
RuntimeError: Exception in worker process:
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 1948, in _worker_loop
    cls._run_test_given_id(test_id)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 1901, in _run_test_given_id
    test_fn(**kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 2192, in wrapper
    fn()
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 3832, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 315, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/distributed/test_nccl.py", line 1222, in test_nccl_symmem_rendezvous
    handle = symm_mem.rendezvous(t, group=group_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/torch/distributed/_symmetric_memory/__init__.py", line 2275, in rendezvous
    return _SymmetricMemory.rendezvous(tensor, group_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: NCCL host communicator for group 0 not found. Have you rendezvoused any tensor with this group?

To execute this test, run the following from the base repo dir:
    python test/distributed/test_nccl.py NCCLSymmetricMemoryNccl2Test.test_nccl_symmem_rendezvous

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0


----------------------------------------------------------------------
```
```
Problem

  nccl2 symmetric-memory rendezvous failed after eager communicator initialization was introduced in #192895. The failure was:

  RuntimeError: NCCL host communicator for group 0 not found

  The eager-init path initialized nccl2 while ProcessGroup::setBackend() was registering the backend. At that point, the backend had received Options.group_name, but its
  inherited Backend group UID had not yet been assigned by ProcessGroup::setGroupName(). nccl2 therefore published its host NCCL communicator to the symmetric-memory
  registry under an empty key. The later group-name assignment did not republish it, so rendezvous looking up the actual process-group name failed.

  Before #192895, a device_id-triggered eager connection happened after ProcessGroup::setGroupName(), and the no-device_id path initialized lazily on the first
  collective, also after naming. Both paths published under the correct group UID.

  Solution

  Initialize nccl2's inherited Backend group UID from Options.group_name in the nccl2 constructor. This is the final group ID provided by the backend creator and is the
  same value ProcessGroup::setGroupName() subsequently assigns. It preserves eager communicator initialization while ensuring the symmetric-memory registration uses the
  correct key.

  Use Options.group_name rather than the backend's name_ field: name_ falls back to "nccl2" when the group name is empty, which is not a unique process-group identity and
  could cause registry collisions.

  Testing

  Updated the nccl2 symmetric-memory regression test to rendezvous immediately after init_process_group(..., device_id=...). The test no longer warms up with all_reduce,
  so it directly verifies that eager initialization publishes the communicator under the process group's name.
```

Authored with assistance from Codex

cc @eqy