### PR TITLE
Skip bolt optimization for libtorch.so

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1797,7 +1797,6 @@ torch_optimize_layout_if_enabled(torch_cpu)
 if(USE_CUDA)
   torch_optimize_layout_if_enabled(torch_cuda)
 endif()
-torch_optimize_layout_if_enabled(torch)
 
 if(PRINT_CMAKE_DEBUG_INFO)
   print_target_properties(torch)

--- a/cmake/bolt_profiles/README.md
+++ b/cmake/bolt_profiles/README.md
@@ -9,7 +9,7 @@ the repo small; the build extracts them into the build tree at configure time.
 One YAML profile per library, named `lib<target>.yaml`. Each call to
 `torch_optimize_layout_if_enabled(<target>)` looks up `lib<target>.yaml`
 (e.g. target `torch_cuda` -> `libtorch_cuda.yaml`). The optimized libraries
-are: `libtorch_cuda`, `libtorch_cpu`, `libtorch`, `libtorch_python`, `libc10`,
+are: `libtorch_cuda`, `libtorch_cpu`, `libtorch_python`, `libc10`, and
 `libc10_cuda`.
 
 ## How profiles are consumed


### PR DESCRIPTION
NVIDIA internal measurements show that optimizing libtorch.so does not provide any statistically significant performance improvement across a variety of workloads. Removing it from the optimization set reduces the amount of BOLT profile data that we need to ship and keeps the build process simpler.

This change does not remove libtorch.yaml from torch.tar.zst to avoid changing the binary file and increasing the repo size. It will be removed during a future BOLT profile data update.

Related-to: #188602