### PR TITLE
[CUDA][AMP] Support BFloat16 gradients in AMP unscale

### DIFF
--- a/aten/src/ATen/native/cuda/AmpKernels.cu
+++ b/aten/src/ATen/native/cuda/AmpKernels.cu
@@ -52,7 +52,9 @@ void _amp_non_finite_check_and_unscale_cuda_(Tensor& scaled_grad,
   // Acts on scaled_grad in place.
   auto iter = TensorIterator::unary_op(scaled_grad, scaled_grad);
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+    at::ScalarType::Half,
+    at::ScalarType::BFloat16,
     iter.dtype(),
     "_amp_non_finite_check_and_unscale_cuda",
     [&iter, &found_inf, &inv_scale] {
@@ -147,7 +149,9 @@ void _amp_foreach_non_finite_check_and_unscale_cuda_(TensorList scaled_grads,
     }
   }
 
-  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+    at::ScalarType::Half,
+    at::ScalarType::BFloat16,
     tensor_lists[0][0].scalar_type(),
     "_amp_foreach_non_finite_check_and_unscale_cuda",
     [&tensor_lists, &found_inf, &inv_scale] {

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -5613,6 +5613,8 @@ class TestTorchDeviceType(TestCase):
 
     @onlyNativeDeviceTypes
     @dtypes(torch.float, torch.double)
+    @dtypesIfCPU(torch.float, torch.double, torch.bfloat16)
+    @dtypesIfCUDA(torch.float, torch.double, torch.bfloat16)
     def test_grad_scaling_unscale(self, device, dtype):
         device = torch.device(device)
         device0 = "cuda:0" if device.type == "cuda" else "cpu"


### PR DESCRIPTION
## Issue

Fixes #127176

## Summary

I reviewed the implementation and validation results and understand the change. The quoted description below was prepared with Codex assistance.

> Add BFloat16 support to the CUDA AMP non-finite check and unscale operator by extending dispatch in both the multi-tensor fast path and TensorIterator fallback. Extend the existing CUDA test to cover BF16 unscaling and Inf/NaN detection across both paths. The focused BF16 test and all 20 CUDA GradScaler tests pass against a local CUDA 12.6 source build on an RTX 3080.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results (not applicable)

## BC-breaking?

No.
