### PR TITLE
[CI] Benchmark TorchInductor perf against 2.13.0 release (baseline)

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -1247,6 +1247,19 @@ test_dynamo_benchmark() {
   local shard_id="$1"
   shift
 
+  ### Perf benchmark 2.13.0, need to reinstall detectron2 to avoid crashing when importing it
+  pip_uninstall torch torchvision torchaudio torchrec fbgemm-gpu triton pytorch-triton detectron2
+  pip_install torch==2.13.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
+  # Rebuild torchrec and fbgemm_gpu against the installed torch release
+  if [[ "${TEST_CONFIG}" == *torchbench* ]] && [[ "${TEST_CONFIG}" != *cpu* ]]; then
+    rm -rf dist/torchrec
+    rm -rf dist/fbgemm_gpu
+    install_torchrec_and_fbgemm
+  fi
+  # Same pinned commit as used in TorchBench (no ci)
+  pip_install git+https://github.com/facebookresearch/detectron2.git@0df2d73d0013db7de629602c23cc120219b4f2b8 --no-build-isolation
+  pip freeze
+
   # Exclude torchrec_dlrm for CUDA 13 as FBGEMM is not compatible
   local extra_args=()
   if [[ "$BUILD_ENVIRONMENT" == *cuda13* ]]; then


### PR DESCRIPTION
Temporary PR to benchmark TorchInductor against **torch==2.13.0** (stable `cu130`), the **baseline** for the 2.14.0 RC comparison. Not for merge.

Installs the release into the inductor-benchmarks image in `test_dynamo_benchmark()` (same pattern as #188781) and rebuilds torchrec/fbgemm + detectron2 for torchbench.

Compare against 2.14.0 (RC PR below) on the [PT2 dashboard](https://hud.pytorch.org/benchmark/compilers_regression); this is the left (baseline) branch.

_Authored with the assistance of Claude Code._
