### PR TITLE
Drop unused includes in c10

### DIFF
--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -1,6 +1,5 @@
 #include <c10/core/Allocator.h>
 #include <c10/core/CPUAllocator.h>
-#include <c10/core/DeviceType.h>
 #include <c10/core/alignment.h>
 #include <c10/core/impl/alloc_cpu.h>
 #include <c10/mobile/CPUCachingAllocator.h>

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -45,7 +45,6 @@
 #include <mutex>
 #include <new>
 #include <ranges>
-#include <regex>
 #include <set>
 #include <stack>
 #include <thread>

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -2,7 +2,6 @@
 
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAException.h>
-#include <c10/cuda/CUDAGuard.h>
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
 #endif

--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -1,5 +1,4 @@
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/driver_api.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>

--- a/c10/util/Exception.cpp
+++ b/c10/util/Exception.cpp
@@ -4,7 +4,6 @@
 #include <c10/util/Type.h>
 
 #include <atomic>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <utility>


### PR DESCRIPTION
## Summary

Split out of #194958. Removes unused `#include`s in c10, flagged by clang-tidy's misc-include-cleaner (not enabled by this repo's `.clang-tidy`/lintrunner config).

Narrower than before: dropped one file whose unused include kept conflicting with an unrelated migration in #187002.