### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_gradual_type.py

### DIFF
--- a/test/fx/test_gradual_type.py
+++ b/test/fx/test_gradual_type.py
@@ -17,7 +17,11 @@ from torch.fx.experimental.rewriter import RewritingTracer
 from torch.fx.experimental.unify_refinements import infer_symbolic_types
 from torch.fx.passes.shape_prop import ShapeProp
 from torch.fx.tensor_type import Dyn, is_consistent, is_more_precise, TensorType
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 try:
@@ -44,6 +48,8 @@ def conv3x3(in_planes, out_planes, stride=1, groups=1, dilation=1):
 
 
 class AnnotationsTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_annotations(self):
         """
         Test type annotations in the forward function.
@@ -142,6 +148,8 @@ class AnnotationsTest(TestCase):
 
 
 class TypeCheckerTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_type_check_add_with_broadcast(self):
         class M(torch.nn.Module):
             def forward(self, x: TensorType((1, 2, 3, Dyn)), y: TensorType((2, 3, 4))):


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to AnnotationsTest and TypeCheckerTest, and import HardwareClassification from common_utils, enabling per-hardware-backend test selection via --hw-classification.

## Changes
test/fx/test_gradual_type.py: import HardwareClassification; add hw_classification (GENERIC on AnnotationsTest and TypeCheckerTest).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering. The FX gradual type tests (test_annotate, test_annotations, test_broadcasting1-3, test_consistency, test_precision, test_type_check_*, test_flatten_fully_static, test_resnet50, etc.) exercise symbolic type inference / TensorType / type checker logic with no device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_gradual_type.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.