### PR TITLE
[guards] Make the bound-method reducer a fixed point over its own output

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -245,6 +245,48 @@ def _maybe_scoped(loaded):
     return loaded if hasattr(loaded, "__enter__") else contextlib.nullcontext()
 
 
+class _PrecompileRebound:
+    def forward(self, x):
+        return x * 2
+
+
+class _PrecompileReboundModule(torch.nn.Module):
+    def forward(self, x):
+        return x * 2
+
+
+def _precompile_rebound_shadow(x):
+    return x * 3
+
+
+class _PrecompileForwardHolder:
+    """The torchrec TrainPipelineSparseDist shape.
+
+    It keeps each module's ORIGINAL bound forward in a list, and optionally
+    rebinds the attribute the way TrainPipelineSparseDist swaps in a
+    PipelinedForward. Both halves matter: the saved method's receiver is what
+    pruning replaces with the sentinel, and whether the attribute still
+    resolves to the saved function is what used to pick the reducer's branch.
+    """
+
+    def __init__(self, inner, shadow):
+        self.inner = inner
+        self._original_forwards = [inner.forward]
+        self.scale = torch.zeros(4)
+        if shadow:
+            inner.forward = _precompile_rebound_shadow
+
+
+def _precompile_rebound_entry(pipeline, x):
+    return pipeline._original_forwards[0](x) + x
+
+
+def _precompile_rebound_unread_entry(pipeline, x):
+    # The holder is passed through and guarded, but nothing reads the saved
+    # method -- the shape the real model has.
+    return x * 2 + pipeline.scale
+
+
 def _precompile_defaulted_helper(model, x, scale):
     # A nested frame no name in the entry reaches, which is what puts the
     # capture into the installed serving mode.
@@ -1862,6 +1904,78 @@ class TestPrecompile(TestCase):
             with _maybe_scoped(loaded), torch.no_grad():
                 x = torch.randn(rows, 8)
                 self.assertEqual(loaded(model, x), _precompile_attr_entry(model, x))
+
+    @parametrize("module_receiver", [True, False])
+    @parametrize("shadow", [True, False])
+    @parametrize("read", [True, False])
+    def test_precompile_serves_a_bound_method_whose_receiver_was_pruned(
+        self, module_receiver, shadow, read
+    ):
+        # The bound-method reducer EMITS a bound method, so re-serializing its
+        # own output reaches it again with a receiver the first pass replaced
+        # with the _Missing sentinel. Deciding the branch by reading that
+        # receiver then raised "'_Missing' object has no attribute forward".
+        # Only the public path re-serializes -- the guard policy rebuilds each
+        # frame from the pickle capture already made -- so only it aborted.
+        #
+        # Serving, not merely capturing, is the assertion that matters: an
+        # earlier attempt at this fix degraded the method itself to the
+        # sentinel, which captured fine and then re-pinned the TYPE_MATCH on it
+        # to _Missing, so the artifact could never match a live receiver.
+        inner = _PrecompileReboundModule() if module_receiver else _PrecompileRebound()
+        holder = _PrecompileForwardHolder(inner, shadow)
+        entry = _precompile_rebound_entry if read else _precompile_rebound_unread_entry
+        x = torch.randn(4)
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                entry,
+                tracer="dynamo",
+                backend="eager",
+                example_inputs=[(holder, x)],
+                require_no_risky_drops=False,
+                require_complete=False,
+            )
+            expected = entry(holder, x)
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            self.assertEqual(loaded(holder, x), expected)
+
+    def test_precompile_pruned_receiver_identity_guard_is_risky_not_silent(self):
+        # The CLOSURE_MATCH identity slot on the saved function is dropped, as
+        # it is in every artifact -- but as RISKY, which the default refuses.
+        # Both entry points must agree on that, or require_no_risky_drops means
+        # something different depending on which one you called.
+        from torch._dynamo.precompile_package import precompile_capture
+
+        x = torch.randn(4)
+        with (
+            self.assertRaisesRegex(
+                torch.compiler.precompile.PrecompileError,
+                r"_original_forwards\[0\]",
+            ),
+            torch.no_grad(),
+        ):
+            torch.compiler.precompile(
+                _precompile_rebound_entry,
+                tracer="dynamo",
+                backend="eager",
+                example_inputs=[
+                    (_PrecompileForwardHolder(_PrecompileRebound(), True), x)
+                ],
+                require_complete=False,
+            )
+
+        session = precompile_capture(
+            _precompile_rebound_entry,
+            backend="eager",
+            example_inputs=[(_PrecompileForwardHolder(_PrecompileRebound(), True), x)],
+        )
+        with session:
+            pass
+        session.artifact(require_no_risky_drops=False, require_complete=False)
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        self.assertIn("pipeline._original_forwards[0].__func__", risky)
 
     def test_precompile_stale_module_memo_is_revalidated(self):
         # The filename -> module memo caches a hit outright, and its ABA check

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4919,7 +4919,21 @@ class GuardsStatePickler(pickle.Pickler):
         elif inspect.ismethod(obj):
             func = obj.__func__
             method_self = obj.__self__
-            inner_func = getattr(method_self, func.__name__)
+            # Decide from the receiver's FATE, not by reading it. This branch
+            # emits a bound method, so its own output comes back through here
+            # whenever the state is serialized twice -- which the guard policy
+            # does, rebuilding each frame from the pickle capture already made.
+            # By then the receiver is the sentinel, and the getattr below used
+            # to raise "'_Missing' object has no attribute <name>". Carrying the
+            # binding unconditionally makes the branch a FIXED POINT: it reduces
+            # its own output to itself, so the second pass is stable, and the
+            # reduction never depends on the receiver resolving the name at load
+            # either. The method stays a real method -- degrading it to the
+            # sentinel instead would re-pin a TYPE_MATCH on it to _Missing, and
+            # the artifact would capture and then never match a live receiver.
+            if self._reduces_to_missing(method_self):
+                return type(self)._unpickle_bound_method, (func, method_self)
+            inner_func = getattr(method_self, func.__name__, None)
             if inspect.ismethod(inner_func):
                 inner_func = inner_func.__func__
             if func is not inner_func:
@@ -5000,6 +5014,22 @@ class GuardsStatePickler(pickle.Pickler):
                 return type(self)._unpickle_fsdp_module_type, (original_type,)
 
         return NotImplemented
+
+    def _reduces_to_missing(self, obj: Any) -> bool:
+        """Whether this value is already, or is about to become, the sentinel.
+
+        Mirrors the three rules above that substitute _Missing for a value the
+        guard tree never reached. A reducer that has to know its own output will
+        round-trip asks here rather than reading the value, because reading is
+        exactly what the substitution breaks.
+        """
+        if type(obj) is _Missing or id(obj) in self.missing_values:
+            return True
+        if isinstance(obj, torch.nn.Module):
+            return id(obj) not in self.guard_tree_values
+        if isinstance(obj, torch.Tensor) and obj.device.type != "meta":
+            return id(obj) not in self.guard_tree_values
+        return False
 
     def _prune_unguarded_attributes(self, obj: Any) -> None:
         """Mark every ``__dict__`` value nothing guards as prunable.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

Serializing guard state twice aborts the capture when a bound method's receiver
was pruned:

    PackageError: AttributeError: '_Missing' object has no attribute 'forward'
      reached via: local_scope['pipeline']._original_forwards[0]

The branch emits a bound method -- _unpickle_bound_method(func, method_self) --
and then decides, on a later pass, whether to take that branch again by READING
the receiver: getattr(method_self, func.__name__). Pruning replaces a receiver
no guard reaches with the _Missing sentinel, so the second pass reads the name
off a sentinel and dies. func.__name__ is what supplies the "forward" in the
message; the _Missing is the method's __self__, not the value the path names.

Only torch.compiler.precompile's public path serializes twice: it sets
_prune_invariant_guards, so PrecompileSession.__exit__ runs _apply_guard_policy,
which rebuilds each frame from the pickle capture already made, with
save_guards=True. The capture session's _drop_unrebuildable_guards probes
without save_guards and never re-pickles, so the same model captured fine there
and aborted here.

Decide from the receiver's FATE instead of reading it. When the receiver is, or
is about to become, the sentinel, carry the binding unconditionally. The branch
then reduces its own output to itself, which is the property the second pass
needs, and the reduction stops depending on the receiver resolving the name at
load -- which is a second bug: where the attribute was NOT shadowed the branch
fell through to pickle's default method reduce, (getattr, (__self__, name)), and
raised a raw unwrapped AttributeError out of pickle.loads on the serving
machine.

The method stays a real method. Degrading it to the sentinel instead also stops
the abort, and was the first thing I tried, but it re-pins a TYPE_MATCH on the
method to _Missing: the artifact captures, loads, and then matches no live
receiver ever again. An abort is better than a permanent silent serve-miss, so
the test asserts SERVING rather than capture -- that assertion is the only thing
that distinguishes the two fixes.

Nothing extra is retained: the receiver still ships as the sentinel, and only
the encoding of an already-serialized method changes.

Not the cause, but worth recording while it is fresh. The pruning invariant
holds -- get_guard_manager_from_source recurses into source.base, so a guard on
x.a.b registers x and x.a too, and a value on a guard's path is never pruned.
The receiver here is reached by no guard at all. Separately,
_prune_unguarded_attributes marking an exact list/dict/tuple/set is a silent
no-op, because CPython's C pickler never routes exact builtins through
reducer_override; that is why the method was in the pickle to begin with.

Test Plan:

```
python test/test_precompile.py
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_package.py
```

test_precompile_serves_a_bound_method_whose_receiver_was_pruned is parametrized
over the eight shapes this family has -- receiver an nn.Module or a plain
object, the attribute shadowed or not, the saved method read by the region or
only carried -- and each one captures, loads, and is checked against eager.
Three abort on the unfixed tree and two more die in pickle.loads.

Authored with the assistance of an AI coding agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98