### PR TITLE
[release/2.14] Import SDPAParams in test_transformers to fix lint

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -17,6 +17,7 @@ from unittest.mock import patch, MagicMock, ANY
 import math
 import itertools
 import torch.optim as optim
+from torch.backends.cuda import SDPAParams
 from torch.testing._internal.common_device_type import expectedFailureMPS, instantiate_device_type_tests, onlyCUDA, largeTensorTest
 import torch.utils.cpp_extension
 from torch.testing._internal.common_nn import NNTestCase


### PR DESCRIPTION
Release-branch-only lint fix. `main` is unaffected and needs no change.

## Failure

https://github.com/pytorch/pytorch/actions/runs/33027878660/job/98373425899

```
>>> Lint for test/test_transformers.py:
  Error (RUFF) F821
    Undefined name `SDPAParams`.
    2983 |        params = SDPAParams(query, key, value, None, 0.0, False, False)
```

Introduced by `08187d9e0fb` — "[cuDNN] Add guards for cuDNN SDPA decode (#194963)", the cherry-pick of #194927.

## Why the cherry-pick was incomplete

On `main`, the guard test can say `SDPAParams` unqualified because the name is already imported at `test_transformers.py:20`:

```python
from torch.backends.cuda import can_use_flash_attention, SDPAParams
```

That import was **not** added by the cuDNN guard PR. It came from `e268912ed92` — "[SDPA] Support mixed head dimensions with FA4 (#193039)" — which is a feature PR and correctly **not** on `release/2.14` (verified: `git merge-base --is-ancestor` says no).

So #194963 landed a usage onto a branch that has no import for it. Nothing was mis-cherry-picked; the dependency was invisible because it lived in an unrelated feature commit.

## Why an import, not another cherry-pick

Cherry-picking #193039 would satisfy the import but drag unrelated FA4 mixed-head-dimension work onto the release branch. Adding the one import is the minimal correct fix.

## Why only `SDPAParams`

`main` imports `can_use_flash_attention, SDPAParams`. On this branch `can_use_flash_attention` has **zero** references — its only `main` call site (line 3934) also arrived with #193039 — so importing it would trade the F821 for an unused-import F401.

## Placement

Line 20, the same position as `main`. The import and the call site now sit at lines 20 and 2984 on both branches, so future cherry-picks touching this region apply cleanly instead of conflicting.

## Verification

Confirmed by inspection that the import is present at line 20 and the sole call site at line 2984, and that `can_use_flash_attention` is unreferenced. I could not run `ruff` or a 3.10+ AST parse locally (no suitable interpreter on that host — the file uses `match`, so 3.9 cannot parse it), so lint CI is the real confirmation for this one.

---

Filed with the help of Claude Code.
