### PR TITLE
[xpu] Fix OneDNN SDPA GQA with AttnMask Broadcast in head dimension

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Attention.cpp
@@ -111,8 +111,22 @@ struct SDPALogicalParams {
       reshaped_value = reshaped_value.unsqueeze(2);
       reshaped_attention = reshaped_attention.view(
           {batch_size, group_num, group_size, seq_len_q, head_dim_v});
-      if (attn_mask_.has_value() && attn_mask_.value().dim() == 4) {
-        reshaped_attn_mask = reshaped_attn_mask.unsqueeze(2);
+      if (attn_mask_.has_value() && reshaped_attn_mask.dim() == 4) {
+        // check_attn_mask_shape restricts a 4D mask's head
+        // dim to 1 or num_head_q. GQA target shape is
+        // [batch, group_num, group_size, seq_q, seq_k]. When mask head == 1
+        // we rely on implicit broadcast; when mask head == num_head_q we must
+        // split it into [group_num, group_size].
+        if (reshaped_attn_mask.size(1) == num_head_q) {
+          reshaped_attn_mask = reshaped_attn_mask.reshape(
+              {reshaped_attn_mask.size(0),
+               group_num,
+               group_size,
+               reshaped_attn_mask.size(2),
+               reshaped_attn_mask.size(3)});
+        } else {
+          reshaped_attn_mask = reshaped_attn_mask.unsqueeze(2);
+        }
       }
     }
 

--- a/test/xpu/test_transformers.py
+++ b/test/xpu/test_transformers.py
@@ -66,8 +66,10 @@ class TestSDPAXpuOnly(NNTestCase):
             self.assertNotEqual(
                 t.data_ptr() % 64,
                 0,
-                msg=lambda msg: f"{msg}\n{name} is unexpectedly 64-byte aligned; "
-                "the misalignment premise of this test is invalid",
+                msg=lambda msg: (
+                    f"{msg}\n{name} is unexpectedly 64-byte aligned; "
+                    "the misalignment premise of this test is invalid"
+                ),
             )
 
         q2 = q.clone().float()
@@ -184,6 +186,48 @@ class TestSDPAXpuOnly(NNTestCase):
                 dropout_p=0.0,
                 is_causal=False,
                 scale=scale,
+            )
+
+        self.assertEqual(actual, expected, atol=tol.atol, rtol=tol.rtol)
+
+    @parametrize("dtype", [torch.half, torch.bfloat16])
+    def test_onednn_attention_per_head_mask_gqa(self, device, dtype):
+        """Verify SDPA with GQA and a materialized per-head attn_mask of shape
+        [batch, num_head_q, seq_q, seq_kv].
+
+        This exercises the GQA reshape path where the mask's head dim equals
+        num_head_q and must be split into [group_num, group_size] to align with
+        the 5D query view oneDNN expects.
+        """
+        tol = Tolerances(1e-2, 1e-2)
+        if dtype is torch.bfloat16:
+            tol = Tolerances(5e-2, 5e-2)
+
+        batch, num_heads, num_kv_heads, seq_len, head_dim = 3, 8, 2, 8, 64
+        torch.manual_seed(0)
+        query = torch.randn(
+            batch, num_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        key = torch.randn(
+            batch, num_kv_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        value = torch.randn(
+            batch, num_kv_heads, seq_len, head_dim, device=device, dtype=dtype
+        )
+        attn_mask = torch.randn(
+            batch, num_heads, seq_len, seq_len, device=device, dtype=dtype
+        )
+
+        with sdpa_kernel(backends=[SDPBackend.OVERRIDEABLE]):
+            actual = F.scaled_dot_product_attention(
+                query, key, value, attn_mask=attn_mask, enable_gqa=True
+            )
+
+        key_expanded = key.repeat_interleave(num_heads // num_kv_heads, dim=1)
+        value_expanded = value.repeat_interleave(num_heads // num_kv_heads, dim=1)
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            expected = F.scaled_dot_product_attention(
+                query, key_expanded, value_expanded, attn_mask=attn_mask
             )
 
         self.assertEqual(actual, expected, atol=tol.atol, rtol=tol.rtol)


### PR DESCRIPTION
Fix https://github.com/intel/torch-xpu-ops/issues/5090.

OneDNN SDPA GQA need query/mask has shape [batch, group_num, group_size, seq_q, seq_k]. It requires to extend Pytorch 4D shape [batch, head, seq_q, seq_k] to the 5D shape for OneDNN.

We don't handle this case where head != 1.

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01