### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_lazy_graph_module.py

### DIFF
--- a/test/fx/test_lazy_graph_module.py
+++ b/test/fx/test_lazy_graph_module.py
@@ -18,10 +18,11 @@ from torch.fx._lazy_graph_module import (
 )
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.package import PackageExporter, PackageImporter
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class TestLazyGraphModule(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     exit_stack = None
 
     @classmethod


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestLazyGraphModule and import HardwareClassification from common_utils, enabling per-hardware-backend test selection via --hw-classification.

## Changes
test/fx/test_lazy_graph_module.py: import HardwareClassification; add hw_classification (GENERIC on TestLazyGraphModule).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering. The FX lazy graph module tests (test_accessing_code_cause_recompiling, test_call_forward_directly, test_dynamo_innermost_fn, test_graph_module_str, test_make_graph_module, test_multi_recompile, test_needs_recompile, test_package_fx_simple, test_pickle, test_recapture_with_dynamo, test_recapture_with_make_fx, test_recapture_with_symbolic_trace, test_replace_sin_with_cos, test_save_lazy_foward, test_to_folder_class, test_to_folder_sequential) exercise lazy GraphModule / recompilation / package serialization logic with no device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_lazy_graph_module.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.