### PR TITLE
[Testcase Refactoring]Add backend property to ShardedTensorTestBase and remove hardcoded backend name lists

### DIFF
--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -21,9 +21,25 @@ class ShardedTensorTestBase(MultiProcessTestCase):
     def world_size(self):
         return TEST_GPU_NUM
 
+    @property
+    def backend(self) -> str:
+        """Resolve the default distributed backend from the test variant's device_type.
+
+        Uses ``dist.get_default_backend_for_device()`` so any registered
+        out-of-tree backend is picked up automatically.  Falls back to
+        ``"gloo"`` for CPU variants.
+        """
+        device_type = getattr(self, "device_type", None)
+        if device_type is None or device_type == "cpu":
+            return "gloo"
+        return dist.get_default_backend_for_device(device_type)
+
     def init_pg(self, backend="nccl"):
-        if backend not in ["nccl", "gloo", "mpi", "hccl", "xccl"]:
-            raise RuntimeError(f"Backend {backend} not supported!")
+        # set device for accelerator pg for collectives
+        # must be called BEFORE init_process_group, otherwise HCCL
+        # communicator creation fails with "same physical device ID" error
+        if backend != "gloo":
+            torch.accelerator.set_device_index(self.rank)
 
         dist.init_process_group(
             backend=backend,
@@ -31,10 +47,6 @@ class ShardedTensorTestBase(MultiProcessTestCase):
             rank=self.rank,
             init_method=f"file://{self.file_name}",
         )
-
-        # set device for nccl pg for collectives
-        if backend == "nccl" or backend == "xccl":
-            torch.accelerator.set_device_index(self.rank)
 
     def init_rpc(self):
         rpc_backend_options = rpc.TensorPipeRpcBackendOptions(
@@ -94,16 +106,23 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
 
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        # Default "nccl" → resolve from self.backend at runtime
+        # Explicit backend (e.g. "gloo") → use as-is
+        if backend == "nccl":
+            resolved_backend = self.backend
+        else:
+            resolved_backend = backend
+
         # Skip test if backend requires accelerator but not enough devices available
-        acc = torch.accelerator.current_accelerator()
-        if backend in ["nccl", "xccl", "hccl"]:
+        if resolved_backend != "gloo":
+            acc = torch.accelerator.current_accelerator()
             if (
                 acc is None
-                or backend != dist.get_default_backend_for_device(acc)
+                or resolved_backend != dist.get_default_backend_for_device(acc)
                 or torch.accelerator.device_count() < self.world_size
             ):
                 sys.exit(TEST_SKIPS[f"multi-gpu-{self.world_size}"].exit_code)
-        self.init_comms(init_rpc=init_rpc, backend=backend)
+        self.init_comms(init_rpc=init_rpc, backend=resolved_backend)
         func(self, *args, **kwargs)
         self.destroy_comms(destroy_rpc=init_rpc)
 


### PR DESCRIPTION
## Summary

`ShardedTensorTestBase` and its `with_comms` decorator hardcode backend
name lists (`["nccl", "xccl", "hccl"]`) in two places: the accelerator
device-index check in `init_pg` and the admission check in `with_comms`.
This makes it impossible to support new out-of-tree backends without
adding their names to these lists.

This PR adds a `backend` property to `ShardedTensorTestBase` that
resolves the correct backend from the test variant's `device_type` using
`dist.get_default_backend_for_device()`, following the same pattern as
`DTensorTestBase` (PR #191288). It also replaces the hardcoded backend
name lists with a simple `!= "gloo"` check.

## Changes

- **Add `ShardedTensorTestBase.backend` property**: Resolves the default
  distributed backend from `self.device_type` via
  `dist.get_default_backend_for_device()`. Falls back to `"gloo"` for
  CPU variants or when `device_type` is not set.

- **Remove hardcoded backend name list in `init_pg`**: Replace
  `if backend in ("nccl", "xccl", "hccl")` with `if backend != "gloo"`
  for the `set_device_index` check.

- **Remove hardcoded backend name list in `with_comms`**: Replace
  `if backend in ["nccl", "xccl", "hccl"]` with `if backend != "gloo"`
  for the admission check.

- **Remove backend validation list in `init_pg`**: Delete the
  `if backend not in ["nccl", "gloo", "mpi", "hccl", "xccl"]` check.
  Invalid backends are caught by `dist.init_process_group()`.

## Depends on

This PR relies on the following upstream PRs (submitted but not yet merged):

- **#187650**: `skip_if_lt_x_gpu` hardware-agnostic refactoring.
- **#190528**: `ShardedTensorTestBase.init_pg` dynamic device setup.

## Not changed

- `with_comms` default `backend="nccl"` — preserved as-is.
- `init_pg` default `backend="nccl"` — preserved as-is.
- `init_comms` default `backend="nccl"` — preserved as-is.
- `init_rpc`, `destroy_comms`, `assert_sharded_tensor_equal` — unchanged.
- `TEST_GPU_NUM = 4` — unchanged.
- Test files are not modified in this PR — follow-up PR will update
  test files to use `self.backend` instead of module-level `backend` variable.

## Test plan

- TODO: Run existing ShardedTensor tests on CUDA to verify no regression.
  `python test/distributed/_shard/sharded_tensor/test_sharded_tensor.py`
- TODO: Run on an out-of-tree accelerator backend (PrivateUse1) to verify
  the `backend` property resolves correctly.
- TODO: Run on CPU-only to verify accelerator tests are correctly skipped.