### PR TITLE
[TEST] Add `hw_classification` to `test_cpp_extensions_aot.py`

### DIFF
--- a/test/test_cpp_extensions_aot.py
+++ b/test/test_cpp_extensions_aot.py
@@ -12,6 +12,7 @@ import torch.testing._internal.common_utils as common
 import torch.utils.cpp_extension
 from torch.testing._internal.common_cuda import TEST_CUDA
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_WINDOWS,
     skipIfTorchDynamo,
     TEST_XPU,
@@ -45,8 +46,8 @@ except ImportError as e:
 
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
-class TestCppExtensionAOT(common.TestCase):
-    """Tests ahead-of-time cpp extensions
+class TestCppExtensionAOTGeneric(common.TestCase):
+    """Tests ahead-of-time cpp extensions (CPU-only / device-agnostic)
 
     NOTE: run_test.py's test_cpp_extensions_aot_ninja target
     also runs this test case, but with ninja enabled. If you are debugging
@@ -54,6 +55,8 @@ class TestCppExtensionAOT(common.TestCase):
     (test_cpp_extensions_aot_no_ninja vs test_cpp_extensions_aot_ninja)
     failed.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_extension_function(self):
         x = torch.randn(4, 4)
@@ -85,6 +88,33 @@ class TestCppExtensionAOT(common.TestCase):
         expected_tensor_grad = torch.ones([4, 4], dtype=torch.double).mm(weights.t())
         self.assertEqual(tensor.grad, expected_tensor_grad)
 
+    @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
+    def test_no_python_abi_suffix_sets_the_correct_library_name(self):
+        # For this test, run_test.py will call
+        # `python -m pip install . -v --no-build-isolation` in the
+        # cpp_extensions/no_python_abi_suffix_test folder, where the
+        # `BuildExtension` class has a `no_python_abi_suffix` option set to
+        # `True`. This *should* mean that on Python 3, the produced shared
+        # library does not have an ABI suffix like
+        # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
+        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
+        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
+        self.assertEqual(len(matches), 1, msg=str(matches))
+        self.assertEqual(matches[0], "no_python_abi_suffix_test.so", msg=str(matches))
+
+    def test_optional(self):
+        has_value = cpp_extension.function_taking_optional(torch.ones(5))
+        self.assertTrue(has_value)
+        has_value = cpp_extension.function_taking_optional(None)
+        self.assertFalse(has_value)
+
+
+@torch.testing._internal.common_utils.markDynamoStrictTest
+class TestCppExtensionAOTCUDA(common.TestCase):
+    """Tests ahead-of-time cpp extensions requiring CUDA."""
+
+    hw_classification = HardwareClassification.CUDA
+
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
     def test_cuda_extension(self):
         import torch_test_cpp_extension.cuda as cuda_extension
@@ -93,35 +123,6 @@ class TestCppExtensionAOT(common.TestCase):
         y = torch.zeros(100, device="cuda", dtype=torch.float32)
 
         z = cuda_extension.sigmoid_add(x, y).cpu()
-
-        # 2 * sigmoid(0) = 2 * 0.5 = 1
-        self.assertEqual(z, torch.ones_like(z))
-
-    @unittest.skipIf(not torch.backends.mps.is_available(), "MPS not found")
-    def test_mps_extension(self):
-        import torch_test_cpp_extension.mps as mps_extension
-
-        tensor_length = 100000
-        x = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
-        y = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
-
-        cpu_output = mps_extension.get_cpu_add_output(x, y)
-        mps_output = mps_extension.get_mps_add_output(x.to("mps"), y.to("mps"))
-
-        self.assertEqual(cpu_output, mps_output.to("cpu"))
-
-    @unittest.skipIf(not TEST_XPU, "XPU not found")
-    @unittest.skipIf(
-        os.getenv("USE_NINJA", "0") == "0",
-        "sycl extension requires ninja to build",
-    )
-    def test_sycl_extension(self):
-        import torch_test_cpp_extension.sycl as sycl_extension
-
-        x = torch.zeros(100, device="xpu", dtype=torch.float32)
-        y = torch.zeros(100, device="xpu", dtype=torch.float32)
-
-        z = sycl_extension.sigmoid_add(x, y).cpu()
 
         # 2 * sigmoid(0) = 2 * 0.5 = 1
         self.assertEqual(z, torch.ones_like(z))
@@ -146,26 +147,6 @@ class TestCppExtensionAOT(common.TestCase):
         z = cusolver_extension.noop_cusolver_function(x)
         self.assertEqual(z, x)
 
-    @unittest.skipIf(IS_WINDOWS, "Not available on Windows")
-    def test_no_python_abi_suffix_sets_the_correct_library_name(self):
-        # For this test, run_test.py will call
-        # `python -m pip install . -v --no-build-isolation` in the
-        # cpp_extensions/no_python_abi_suffix_test folder, where the
-        # `BuildExtension` class has a `no_python_abi_suffix` option set to
-        # `True`. This *should* mean that on Python 3, the produced shared
-        # library does not have an ABI suffix like
-        # "cpython-37m-x86_64-linux-gnu" before the library suffix, e.g. "so".
-        root = os.path.join("cpp_extensions", "no_python_abi_suffix_test", "build")
-        matches = [f for _, _, fs in os.walk(root) for f in fs if f.endswith("so")]
-        self.assertEqual(len(matches), 1, msg=str(matches))
-        self.assertEqual(matches[0], "no_python_abi_suffix_test.so", msg=str(matches))
-
-    def test_optional(self):
-        has_value = cpp_extension.function_taking_optional(torch.ones(5))
-        self.assertTrue(has_value)
-        has_value = cpp_extension.function_taking_optional(None)
-        self.assertFalse(has_value)
-
     @common.skipIfRocm
     @unittest.skipIf(common.IS_WINDOWS, "Windows not supported")
     @unittest.skipIf(not TEST_CUDA, "CUDA not found")
@@ -184,6 +165,49 @@ class TestCppExtensionAOT(common.TestCase):
 
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
+class TestCppExtensionAOTMPS(common.TestCase):
+    """Tests ahead-of-time cpp extensions requiring MPS."""
+
+    hw_classification = HardwareClassification.MPS
+
+    @unittest.skipIf(not torch.backends.mps.is_available(), "MPS not found")
+    def test_mps_extension(self):
+        import torch_test_cpp_extension.mps as mps_extension
+
+        tensor_length = 100000
+        x = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
+        y = torch.randn(tensor_length, device="cpu", dtype=torch.float32)
+
+        cpu_output = mps_extension.get_cpu_add_output(x, y)
+        mps_output = mps_extension.get_mps_add_output(x.to("mps"), y.to("mps"))
+
+        self.assertEqual(cpu_output, mps_output.to("cpu"))
+
+
+@torch.testing._internal.common_utils.markDynamoStrictTest
+class TestCppExtensionAOTXPU(common.TestCase):
+    """Tests ahead-of-time cpp extensions requiring XPU."""
+
+    hw_classification = HardwareClassification.XPU
+
+    @unittest.skipIf(not TEST_XPU, "XPU not found")
+    @unittest.skipIf(
+        os.getenv("USE_NINJA", "0") == "0",
+        "sycl extension requires ninja to build",
+    )
+    def test_sycl_extension(self):
+        import torch_test_cpp_extension.sycl as sycl_extension
+
+        x = torch.zeros(100, device="xpu", dtype=torch.float32)
+        y = torch.zeros(100, device="xpu", dtype=torch.float32)
+
+        z = sycl_extension.sigmoid_add(x, y).cpu()
+
+        # 2 * sigmoid(0) = 2 * 0.5 = 1
+        self.assertEqual(z, torch.ones_like(z))
+
+
+@torch.testing._internal.common_utils.markDynamoStrictTest
 class TestPybindTypeCasters(common.TestCase):
     """Pybind tests for ahead-of-time cpp extensions
 
@@ -196,6 +220,8 @@ class TestPybindTypeCasters(common.TestCase):
     second argument to `PYBIND11_TYPE_CASTER` should be the type we expect to
     receive in python, in these tests we verify this at run-time.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     @staticmethod
     def expected_return_type(func):
@@ -298,6 +324,8 @@ class TestPybindTypeCasters(common.TestCase):
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestMAIATensor(common.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_unregistered(self):
         torch.arange(0, 10, device="cpu")
         with self.assertRaisesRegex(RuntimeError, "Could not run"):
@@ -382,6 +410,8 @@ class TestMAIATensor(common.TestCase):
 
 @torch.testing._internal.common_utils.markDynamoStrictTest
 class TestRNGExtension(common.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
 
@@ -419,6 +449,8 @@ class TestRNGExtension(common.TestCase):
 @torch.testing._internal.common_utils.markDynamoStrictTest
 @unittest.skipIf(not TEST_CUDA, "CUDA not found")
 class TestTorchLibrary(common.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def test_torch_library(self):
         import torch_test_cpp_extension.torch_library  # noqa: F401
 


### PR DESCRIPTION
## Summary

Classify all test classes in `test/test_cpp_extensions_aot.py` (module: `cpp-extensions`) with `HardwareClassification` attributes per the RFC in #185142 and #185590.

Split `TestCppExtensionAOT` (11 tests across 4 device backends) into device-specific classes:
- `TestCppExtensionAOTGeneric` (GENERIC): 5 CPU-only tests — extension function, module, backward, ABI suffix, optional args
- `TestCppExtensionAOTCUDA` (CUDA): 4 tests with `@skipIf(not TEST_CUDA)` + hardcoded `device="cuda"`
- `TestCppExtensionAOTMPS` (MPS): 1 test with `@skipIf(not mps.is_available())` + hardcoded `device="mps"`
- `TestCppExtensionAOTXPU` (XPU): 1 test with `@skipIf(not TEST_XPU)` + hardcoded `device="xpu"`

Other classes classified directly (no split needed):
- `TestPybindTypeCasters`: GENERIC — pure Python type-caster verification
- `TestMAIATensor`: GENERIC — MAIA is a custom mock device registered by the extension, no real hardware
- `TestRNGExtension`: GENERIC — CPU-only RNG generator test
- `TestTorchLibrary`: CUDA — class-level `@skipIf(not TEST_CUDA)` guard

## Test plan

- [x] AOT extensions built and tests run via `run_test.py`
- [x] Baseline comparison: 20 pass, 2 skip, 0 fail — identical in both versions
- [x] 2 skips accounted for: `test_mps_extension` (no MPS), `test_sycl_extension` (no XPU)
- [x] Zero duplicate test names across classes
- [x] GENERIC audit: no CUDA/MPS/XPU device references in GENERIC classes
- [x] `lintrunner -a` clean
- [x] `ast.parse` validates

Depends on #186918 for the `HardwareClassification` enum.

Co-authored with Opus 4.6

cc @RiyaP2508 @mansiag05 @vishalgoyal316 