### PR TITLE
Fix uint64 setitem overflow for values above INT64_MAX

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1537,6 +1537,17 @@ class TestIndexing(TestCase):
         r[...] = 9.9
         self.assertEqual(9.9, r)
 
+    # https://github.com/pytorch/pytorch/issues/191458
+    @onlyNativeDeviceTypes
+    def test_setitem_uint64_above_int64_max(self, device):
+        x = torch.zeros((1,), dtype=torch.uint64, device=device)
+        x[0] = 1 << 63
+        self.assertEqual(x[0].item(), 1 << 63)
+        x[0] = (1 << 64) - 1
+        self.assertEqual(x[0].item(), (1 << 64) - 1)
+        x[0] = (1 << 63) - 1
+        self.assertEqual(x[0].item(), (1 << 63) - 1)
+
     def test_basic_advanced_combined(self, device):
         # From the NumPy indexing example
         x = torch.arange(0, 12, device=device).view(4, 3)

--- a/torch/csrc/autograd/python_variable_indexing.cpp
+++ b/torch/csrc/autograd/python_variable_indexing.cpp
@@ -152,7 +152,14 @@ inline Variable valueToTensor(
   at::tracer::impl::NoTracerDispatchMode tracer_guard;
   Scalar scalar;
   if (THPUtils_checkLong(value) || PyBool_Check(value)) {
-    scalar = Scalar(THPUtils_unpackLong(value));
+    // uint64 values above INT64_MAX must not go through signed long long unpack
+    // (e.g. x[0] = 1 << 63). See
+    // https://github.com/pytorch/pytorch/issues/191458
+    if (options.dtype().toScalarType() == at::kUInt64) {
+      scalar = Scalar(THPUtils_unpackUInt64(value));
+    } else {
+      scalar = Scalar(THPUtils_unpackLong(value));
+    }
   } else if (PyFloat_Check(value)) {
     scalar = Scalar(THPUtils_unpackDouble(value));
   } else if (PyComplex_Check(value)) {


### PR DESCRIPTION
## Summary
- Fix `uint64` tensor setitem for Python integer values above `INT64_MAX` (e.g. `x[0] = 1 << 63`) by using `THPUtils_unpackUInt64` instead of `THPUtils_unpackLong` when the tensor dtype is `uint64`
- Add regression test covering values at and above `INT64_MAX`

Fixes #191458

## Test plan
- [x] Added `test_setitem_uint64_above_int64_max` in `test/test_indexing.py`
- [ ] Run `python test/test_indexing.py TestIndexing.test_setitem_uint64_above_int64_max`

