### PR TITLE
[DDE] symint-ify torch.chunk for data-dependent shapes

### DIFF
--- a/aten/src/ATen/native/TensorShape.cpp
+++ b/aten/src/ATen/native/TensorShape.cpp
@@ -1063,7 +1063,8 @@ std::vector<Tensor> chunk(const Tensor& self, int64_t chunks, int64_t dim) {
   // (because we can have an arbitrary number of 0-sized chunks adding up to 0).
   // So, call split_with_sizes with the correct number of chunks, eventually we
   // will do this for all cases.
-  if (split_size == 0 && dim_size == 0) {
+  if (TORCH_GUARD_OR_FALSE(split_size.sym_eq(0)) &&
+      TORCH_GUARD_OR_FALSE(dim_size.sym_eq(0))) {
     std::vector<c10::SymInt> split_sizes(chunks, split_size);
     split_sizes[chunks - 1] = split_size - (split_size * chunks - dim_size);
     return self.split_with_sizes_symint(split_sizes, dim);

--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -150,6 +150,22 @@ class TestUnbackedSymints(InductorTestCase):
 
     @skipGPUIf(not HAS_GPU, "requires gpu and triton")
     @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
+    def test_chunk(self, device):
+        # torch.chunk on a data-dependent (unbacked) dim size used to raise
+        # GuardOnDataDependentSymNode ("Could not guard on data-dependent
+        # expression Eq(u0, 0)") because chunk compared the symbolic
+        # split_size/dim_size against 0 with a hard equality guard.
+        def fn(x):
+            nz = torch.nonzero(x)  # unbacked symint in nz.size(0)
+            return torch.chunk(nz, 2, dim=0)
+
+        example_inputs = (torch.randn(32, device=device),)
+        actual = torch.compile(fn, fullgraph=True)(*example_inputs)
+        expected = fn(*example_inputs)
+        torch.testing.assert_close(actual, expected)
+
+    @skipGPUIf(not HAS_GPU, "requires gpu and triton")
+    @dynamo_config.patch({"capture_dynamic_output_shape_ops": True})
     def test_view_of_slice(self, device):
         # Tests View.create(slice, size_with_unbacked_symint)
         def fn(x):

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -1548,13 +1548,15 @@ def unsafe_split_with_sizes(
 
 @register_decomposition(aten.split.Tensor)
 def split(self: Tensor, split_size: int, dim: int = 0) -> tuple[Tensor, ...]:
+    from torch.fx.experimental.symbolic_shapes import guard_int, guard_or_false
+
     input_sizes = self.shape
     dim_size = input_sizes[dim]
     torch._check(
         split_size >= 0,
         lambda: f"split expects split_size be non-negative, but got split_size={split_size}",
     )
-    if dim_size == 0:
+    if guard_or_false(dim_size == 0):
         return (self.detach(),)
     torch._check(
         split_size > 0,
@@ -1562,9 +1564,6 @@ def split(self: Tensor, split_size: int, dim: int = 0) -> tuple[Tensor, ...]:
         f"but got dimension size of {dim_size}",
     )
     chunks = (dim_size + split_size - 1) // split_size
-
-    # Avoid importing sympy at a module level
-    from torch.fx.experimental.symbolic_shapes import guard_int
 
     chunks = guard_int(chunks)
     split_sizes = [split_size for i in range(chunks)]


### PR DESCRIPTION
UPDATE: doesn't work because the # of chunks would be data-dependent.

```
std::vector<Tensor> tensor_split_sections_symint(
    const Tensor& self,
    c10::SymInt sym_sections,
    int64_t dim) {
  TORCH_CHECK(
      self.dim() > 0,
      "tensor_split expected at least a 1-dimensional tensor, but got a tensor with ",
      self.dim(),
      " dims");
  int64_t dim_ = maybe_wrap_dim(dim, self.dim());
  // NB: intentional, sections specifies number of output tensors, which
  // cannot be polymorphic
  int64_t sections = sym_sections.guard_int(__FILE__, __LINE__);
```

Summary:
Authored by Claude.

`torch.chunk` failed during AOTInductor lowering on unbacked/data-dependent dim sizes with `Could not guard on data-dependent expression Eq(u0, 0)`.

The `chunk` implementation in `TensorShape.cpp` compared the symbolic `split_size`/`dim_size` against `0` using `SymInt::operator==`, which forces a hard `guard_bool` and throws on unbacked symbols.

This replaces the hard `==` guards with `TORCH_GUARD_OR_FALSE(... .sym_eq(0))`, so unbacked dims default to `false` and take the regular `split_symint` path (the common, non-empty case) instead of throwing. The special `split_with_sizes` branch still applies for statically-known empty dims. This mirrors the existing `TORCH_GUARD_OR_*` usage already in this file (`narrow`/`slice`, `setStorage`).

`unsafe_chunk` is left unchanged since it uses non-symbolic `int64_t` sizes.

---

### Error message
```
torch._dynamo.exc.UserError: Could not guard on data-dependent expression Eq(u0, 0) (unhinted: Eq(u0, 0)).  (Size-like symbols: u0)

consider using data-dependent friendly APIs such as guard_or_false, guard_or_true and statically_known_true.
Caused by: return torch.chunk(nz, 2, dim=0)  # test/inductor/test_unbacked_symints.py:128 in fn (_decomp/decompositions.py:1557 in split)
```

Reviewed By: georgiaphillips

Differential Revision: D109506282




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo