### PR TITLE
Remove outdated ROCm 6.4 hipblaslt-TT-fp32 workarounds

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -253,15 +253,6 @@ using detail::CuBlasLtGroupedMatrixLayout;
 
 template <typename Dtype, typename C_Dtype = Dtype>
 static inline bool bgemm_internal_cublaslt(CUDABLAS_BGEMM_ARGTYPES_AND_C_DTYPE(Dtype, C_Dtype)) {
-#if defined(USE_ROCM) && ROCM_VERSION == 60400
-  // regression in ROCm 6.4, planned fixed in 6.4.1, hipblaslt TT fp32 calculation errors
-  // best to disallow hipblaslt for this specific case
-  if constexpr (std::is_same_v<Dtype, float>) {
-    if (detail::cublasOpFromChar(transa) == CUBLAS_OP_T && detail::cublasOpFromChar(transb) == CUBLAS_OP_T) {
-        return false;
-    }
-  }
-#endif
   const auto type_info = detail::getCublasLtTypeInfo<Dtype, C_Dtype>();
   const cudaDataType_t abType = type_info.ab_type;
   const cudaDataType_t cType = type_info.c_type;
@@ -1886,18 +1877,16 @@ void scaled_gemm(
     matmulDescB = HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT;
   }
   else if (mat1_scale_dtype == kFloat8_e8m0fnu && mat2_scale_dtype == kFloat8_e8m0fnu) {
-  #if ROCM_VERSION >= 70000
-            std::vector<std::string> mx_archs{"gfx950"};
-  #if ROCM_VERSION >= 71400
-            mx_archs.push_back("gfx1250");
-  #endif
-            if (at::detail::getCUDAHooks().isGPUArch(mx_archs)) {
-                // TODO: add constraints based on hipblaslt internals
-                TORCH_CHECK((m % 16 == 0) && (n % 16 == 0) && (k % 128 == 0),
-                           "M, N must be multiples of 16 and K should be multiple of 128 for MX format. "
-                           "Got m=", m, ", n=", n, ", k=", k);
-            }
-  #endif
+    std::vector<std::string> mx_archs{"gfx950"};
+#if ROCM_VERSION >= 71400
+    mx_archs.push_back("gfx1250");
+#endif
+    if (at::detail::getCUDAHooks().isGPUArch(mx_archs)) {
+      // TODO: add constraints based on hipblaslt internals
+      TORCH_CHECK((m % 16 == 0) && (n % 16 == 0) && (k % 128 == 0),
+                 "M, N must be multiples of 16 and K should be multiple of 128 for MX format. "
+                 "Got m=", m, ", n=", n, ", k=", k);
+    }
   }
 #elif (CUDA_VERSION < 12090) && !defined(USE_ROCM)
   // hipblaslt supported row-wise before cublas, and did so their own way (via

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -640,14 +640,6 @@ auto GetHipBlasLtTypeStringAndOps() {
   auto b_datatype = HipDataTypeFor<BT>();
   auto in_out_datatype = HipDataTypeFor<CT>();
   std::vector<hipblasLtMatmulHeuristicResult_t> heuristic_result;
-#if ROCM_VERSION == 60400
-  // hipblaslt TT fp32 regression on ROCm 6.4, cannot use
-  if ((a_datatype == HIP_R_32F || b_datatype == HIP_R_32F || in_out_datatype == HIP_R_32F)
-          && (transa_outer == HIPBLAS_OP_T && transb_outer == HIPBLAS_OP_T)) {
-    std::vector<std::pair<std::string, std::unique_ptr<Callable<ParamsT>>>> ignore;
-    return ignore;
-  }
-#endif
 
   hipblasComputeType_t computeType = HipBlasComputeTypeFor<CT>();
   if constexpr (std::is_same_v<CT, float>) {

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -174,14 +174,6 @@ static bool isInputCompliesAddmmCudaLt(
   }
   #endif
 
-  #if defined(USE_ROCM) && ROCM_VERSION == 60400
-  // hipblaslt TT fp32 regression on ROCm 6.4, cannot use
-  const auto args = cublasCommonArgs(mat1, mat2, result);
-  if (args.transa == 't' && args.transb == 't') {
-    return false;
-  }
-  #endif
-
   const auto mat1_sizes = mat1.sizes();
   const auto mat2_sizes = mat2.sizes();
   const auto scalar_type = mat1.scalar_type();


### PR DESCRIPTION
## Summary

ROCm minimum supported version is now 7.1 (#192258), so the `ROCM_VERSION == 60400` workarounds for the hipblaslt TT fp32 regression in Blas.cpp/CUDABlas.cpp are dead code.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang