### PR TITLE
[SymmMem] Enable fabric handle rendezvous on ROCm

### DIFF
--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -5,6 +5,8 @@
 #include <c10/cuda/CUDAGuard.h>
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
+#elif defined(USE_ROCM)
+#include <hip/hip_runtime_api.h>
 #endif
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>
@@ -158,6 +160,73 @@ bool isFabricSupported() {
   return true;
 }
 
+#elif defined(USE_ROCM) && ROCM_VERSION >= 71500
+
+// Fabric handles on ROCm are UALink. Three things must hold: the GPU exposes
+// UALink, the accelerator has been provisioned to a ready state, and the loaded
+// runtime implements the export/import path. Only the first is queryable as a
+// device attribute, and the second is dynamic state checked at export time, so
+// probe the whole cycle instead. This also covers a build made against newer
+// headers than the runtime it ends up loading.
+bool isFabricSupported(c10::DeviceIndex dev) {
+  // hipMemImportFromShareableHandle imports onto the current device.
+  CUDAGuard guard(dev);
+
+  hipMemAllocationProp prop = {};
+  prop.type = hipMemAllocationTypePinned;
+  prop.requestedHandleType = hipMemHandleTypeFabric;
+  prop.location.type = hipMemLocationTypeDevice;
+  prop.location.id = static_cast<int>(dev);
+
+  // Every step below is expected to fail on most systems, so failures are
+  // returned rather than checked, and the sticky error each one arms must be
+  // consumed here or it surfaces at an unrelated call later.
+  size_t granularity = 0;
+  if (hipMemGetAllocationGranularity(
+          &granularity, &prop, hipMemAllocationGranularityRecommended) !=
+      hipSuccess) {
+    (void)hipGetLastError();
+    return false;
+  }
+
+  // 1. try allocating memory with FABRIC handle type
+  hipMemGenericAllocationHandle_t handle{};
+  if (hipMemCreate(&handle, granularity, &prop, 0) != hipSuccess) {
+    (void)hipGetLastError();
+    LOG(INFO)
+        << "Could not allocate memory with FABRIC handle, falling back to fd handle exchange\n";
+    return false;
+  }
+
+  // 2. check export. An unprovisioned accelerator fails here, not above.
+  hipMemFabricHandle_t shared_handle{};
+  if (hipMemExportToShareableHandle(
+          &shared_handle, handle, hipMemHandleTypeFabric, 0) != hipSuccess) {
+    (void)hipGetLastError();
+    LOG(INFO)
+        << "Could not export FABRIC handle, falling back to fd handle exchange\n";
+    (void)hipMemRelease(handle);
+    return false;
+  }
+
+  // 3. check import
+  hipMemGenericAllocationHandle_t import_handle{};
+  if (hipMemImportFromShareableHandle(
+          &import_handle, &shared_handle, hipMemHandleTypeFabric) !=
+      hipSuccess) {
+    (void)hipGetLastError();
+    LOG(INFO)
+        << "Could not import FABRIC handle, falling back to fd handle exchange\n";
+    (void)hipMemRelease(handle);
+    return false;
+  }
+
+  (void)hipMemRelease(import_handle);
+  (void)hipMemRelease(handle);
+  LOG(INFO) << "using fabric to exchange memory handles\n";
+  return true;
+}
+
 #endif
 } // namespace
 
@@ -212,6 +281,28 @@ bool get_fabric_access(c10::DeviceIndex dev) {
     fabricCliqueId_[dev] = kCliqueIdUnsupported;
     return false;
   }
+#elif defined(USE_ROCM) && ROCM_VERSION >= 71500
+  TORCH_CHECK(
+      num_devices_ >= 0,
+      "p2p access cache not initialized. "
+      "Ensure c10::cuda::detail::init_p2p_access_cache() is called first.");
+  TORCH_CHECK(
+      dev >= 0 && dev < num_devices_,
+      static_cast<int>(dev),
+      " is not a valid device");
+
+  auto& cache = fabricAccessEnabled_[dev];
+  if (cache != -1) {
+    return cache;
+  }
+  // There is no ROCm counterpart to the NVML fabric state query, and no UALink
+  // domain identifier is exposed, so clique_id stays unsupported and
+  // validate_nvlink_fabric_support() degrades to a no-op. Ranks spanning
+  // separate UALink domains therefore fail at import with a driver error rather
+  // than the message naming each rank's host and domain.
+  fabricCliqueId_[dev] = kCliqueIdUnsupported;
+  cache = isFabricSupported(dev) ? 1 : 0;
+  return cache;
 #else
   (void)dev; // Suppress unused parameter warning
   return false;

--- a/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/CUDASymmetricMemory.cu
@@ -28,6 +28,29 @@
 
 namespace c10d::symmetric_memory {
 
+// Shareable handle spellings, so the rendezvous code below can be written once
+// against `use_fabric_handle` instead of once per vendor per handle type.
+#if defined(USE_ROCM)
+#if ROCM_VERSION >= 71500
+using FabricHandleType = hipMemFabricHandle_t;
+constexpr auto kMemHandleTypeFabric = hipMemHandleTypeFabric;
+#else
+// Unreachable: get_fabric_access() is false below this ROCm version, so
+// handle_type_ never becomes FABRIC_HANDLE. Defined only so that the
+// use_fabric_handle=true instantiation of make_peer_alloc_info still compiles;
+// rendezvous() instantiates both branches unconditionally.
+struct FabricHandleType {
+  unsigned char data[64];
+};
+constexpr auto kMemHandleTypeFabric = hipMemHandleTypePosixFileDescriptor;
+#endif
+constexpr auto kMemHandleTypePosixFd = hipMemHandleTypePosixFileDescriptor;
+#else
+using FabricHandleType = CUmemFabricHandle;
+constexpr auto kMemHandleTypeFabric = CU_MEM_HANDLE_TYPE_FABRIC;
+constexpr auto kMemHandleTypePosixFd = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+#endif
+
 /* Start of CUDASymmetricMemory implementation */
 
 // A set of exchange methods with prefix "CUDASymmetricMemory"
@@ -368,13 +391,22 @@ void* CUDASymmetricMemoryAllocator::alloc(
   C10_CUDA_DRIVER_CHECK(driver_api->cuMemCreate_(&handle, block_size, &prop, 0));
 
 #elif defined(USE_ROCM)
-  handle_type_ = Expandable_Segments_Handle_Type::POSIX_FD;
   hipMemAllocationProp prop = {};
   prop.type = hipMemAllocationTypePinned;
   prop.location.type = hipMemLocationTypeDevice;
   // NOLINTNEXTLINE(bugprone-signed-char-misuse)
   prop.location.id = device_idx;
-  prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+  bool has_fabric_support = at::cuda::get_fabric_access(device_idx);
+  LOG(INFO) << "CUDASymmetricMemoryAllocator::alloc: has_fabric_support " << has_fabric_support;
+  if (handle_type_ == Expandable_Segments_Handle_Type::UNSPECIFIED) {
+    handle_type_ = has_fabric_support ? Expandable_Segments_Handle_Type::FABRIC_HANDLE : Expandable_Segments_Handle_Type::POSIX_FD;
+  }
+  // The handle type is fixed at creation: hipMemAllocationProp carries a single
+  // handle type rather than a mask, and ROCm rejects any combined value.
+  prop.requestedHandleType =
+      handle_type_ == Expandable_Segments_Handle_Type::POSIX_FD
+      ? kMemHandleTypePosixFd
+      : kMemHandleTypeFabric;
 
   size_t granularity;
   C10_CUDA_CHECK(hipMemGetAllocationGranularity(
@@ -700,13 +732,11 @@ template <bool use_fabric_handle>
 c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
     c10::intrusive_ptr<Block> block,
     const std::string& group_name) {
-#if defined(USE_ROCM)
-  using BlockHandleType = int;
-#else
   using BlockHandleType =
-      std::conditional_t<use_fabric_handle, CUmemFabricHandle, int>;
-#endif
-  BlockHandleType block_handle;
+      std::conditional_t<use_fabric_handle, FabricHandleType, int>;
+  // Value-initialized: ROCm's exporter writes only the leading 16 bytes of the
+  // 64-byte fabric handle, and the whole struct is all-gathered to every rank.
+  BlockHandleType block_handle{};
   c10::cuda::CUDAGuard guard(block->device_idx);
   if constexpr (!use_fabric_handle) {
     LOG(INFO) << "using posix fd to import symmetric memory handles.";
@@ -734,14 +764,13 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
   C10_CUDA_DRIVER_CHECK(driver_api->cuMemExportToShareableHandle_(
       &block_handle,
       block->alloc_ref->handle,
-      use_fabric_handle ? CU_MEM_HANDLE_TYPE_FABRIC
-                        : CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+      use_fabric_handle ? kMemHandleTypeFabric : kMemHandleTypePosixFd,
       0));
 #elif defined(USE_ROCM)
   C10_CUDA_CHECK(hipMemExportToShareableHandle(
       &block_handle,
       block->alloc_ref->handle,
-      hipMemHandleTypePosixFileDescriptor,
+      use_fabric_handle ? kMemHandleTypeFabric : kMemHandleTypePosixFd,
       0));
 #else
   TORCH_CHECK(
@@ -822,14 +851,22 @@ c10::intrusive_ptr<CUDAPeerAllocInfo> make_peer_alloc_info(
           import_err_msg(rank, r, reqs));
     }
 #elif defined(USE_ROCM)
-    C10_CUDA_CHECK(hipMemImportFromShareableHandle(
-        &handles[r],
+    // The two handle types differ in calling convention, not just in the type
+    // tag: ROCm dereferences the argument for a fabric handle but casts it by
+    // value for an fd.
+    if constexpr (use_fabric_handle) {
+      C10_CUDA_CHECK(hipMemImportFromShareableHandle(
+          &handles[r], &imported_handles[r], kMemHandleTypeFabric));
+    } else {
+      C10_CUDA_CHECK(hipMemImportFromShareableHandle(
+          &handles[r],
 #if ROCM_VERSION >= 70100
-        reinterpret_cast<void*>(static_cast<uintptr_t>(imported_handles[r])),
+          reinterpret_cast<void*>(static_cast<uintptr_t>(imported_handles[r])),
 #else
-        (void*)(uintptr_t) & (imported_handles[r]),
+          (void*)(uintptr_t) & (imported_handles[r]),
 #endif
-        hipMemHandleTypePosixFileDescriptor));
+          kMemHandleTypePosixFd));
+    }
 #else
     TORCH_CHECK(
         false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* (to be filled)

Symmetric memory rendezvous exchanges one shareable handle per rank so that
every rank can map every peer. Two mechanisms exist: a POSIX file descriptor
passed over a Unix domain socket with `SCM_RIGHTS`, and a 64-byte
position-independent fabric handle that rides the ordinary metadata all-gather.
ROCm only had the first, which confines rendezvous to processes that can pass
file descriptors to one another -- same host, cooperating processes, shared PID
namespace. This enables the second, so rendezvous also works across containers
and, where the fabric spans them, across nodes.

On AMD a fabric handle is UALink: `hipMemExportToShareableHandle` with
`hipMemHandleTypeFabric` reaches `hsa_amd_vmem_export_fabric_handle` and then
the `DRM_AMDGPU_UALINK_HANDLE` ioctl. Three conditions must hold -- the GPU
exposes UALink, the accelerator has been provisioned to a ready state, and the
loaded runtime implements the path -- and only the first is a device attribute.
The second is dynamic state checked when the handle is *exported*, not when the
memory is allocated.

That rules out an attribute query, because the handle type is frozen at
`hipMemCreate`: `hipMemAllocationProp` carries a single scalar handle type, ROCm
rejects a combined mask, and nothing can change it afterwards. The decision has
to be made at allocation time from local information alone, and it has to be
right. This follows what CUDA already does and probes the whole cycle once per
device -- create, export, import, release -- caching the result and falling back
to file descriptors on any failure. One probe covers all three conditions, and
also covers a build made against newer headers than the runtime it ends up
loading.

Review the `c10` probe first, then the allocator change that consumes it, then
the rendezvous plumbing. The plumbing is mostly deletion: the ROCm branches
hardcoded the fd handle type independently of the `use_fabric_handle` template
parameter they were being instantiated with, so introducing per-vendor spellings
for the two handle-type constants lets the ROCm `BlockHandleType` special case
disappear and the export site collapse to one expression. Import keeps a branch,
and that one is real -- ROCm dereferences the argument for a fabric handle but
casts it by value for a file descriptor.

Two smaller things ride along. The exported handle is now value-initialized:
ROCm's exporter writes only the leading 16 bytes of the 64-byte fabric handle
and the whole struct is all-gathered to every rank, so the remainder was
uninitialized stack going out on the wire. And `clique_id` stays unsupported on
ROCm, which is deliberate rather than an oversight -- ROCr exposes UALink
capability and readiness but no domain identifier, so
`validate_nvlink_fabric_support` degrades to a no-op and ranks in different
UALink domains get a driver error at import rather than a message naming each
rank's host and domain. Deriving an identifier from the opaque handle bytes
would be guessing at an undocumented format.

The `ROCM_VERSION` floor is a compile-time guard only; the probe is the runtime
gate. It is set one minor above the release in which the VMM fabric APIs first
appear, because the change that makes an unprovisioned accelerator return a
clean not-ready status from export landed later. **An AMD reviewer should pin
the exact value** -- it is the one number here derived from release tags rather
than from code.

Not covered, and not affected: multicast stays off on ROCm because it needs
switch-resident reduction and xGMI is a switchless mesh; that is orthogonal to
the handle type. Signal pads, barriers, the collective ops and the MemPool
integration are plain device memory and know nothing about how the handle was
exchanged, so they are unchanged rather than newly supported.

## Test Plan

Built and tested on a gfx942 (MI308X) host running ROCm 7.2.4. That runtime is
below the version floor and the machine has no UALink, so `get_fabric_access()`
returns false, the allocator selects `POSIX_FD`, and every path exercised is the
one that runs today.

```
PYTORCH_ROCM_ARCH=gfx942 USE_ROCM=1 pip install -e . -v --no-build-isolation
python test/distributed/test_symmetric_memory.py -v
```

```
Ran 140 tests in 62.795s

OK (skipped=106)
```

The skips are all pre-existing conditions unrelated to this change -- 53 for
absent multicast support, 42 `@skipIfRocm`, 5 for pytorch/pytorch#180464, 4 for
NCCL symmetric memory on ROCm, 2 for missing torchcomms. What does run covers
the code this change touches: `test_rendezvous_via_pg_allgather`,
`test_rendezvous_custom_backend`, `test_subgroup`, `test_large_alloc`,
`test_reduce_scatter`, `test_two_shot_all_reduce`, and the `low_contention_*`
collectives all go through `alloc()` and `make_peer_alloc_info()`.

Confirmed the new branch is the one executing, rather than being compiled out:

```
$ TORCH_CPP_LOG_LEVEL=INFO python -c "<allocate a symm-mem tensor and rendezvous>"
[rank0]:[I CUDASymmetricMemory.cu:400] CUDASymmetricMemoryAllocator::alloc: has_fabric_support 0
```

That line comes from the new ROCm arm of `alloc()`; the probe ran, found no
UALink, and the allocator selected `POSIX_FD`.

**This is a no-regression result only.** The fabric path is not exercised. It
requires a UALink-capable GPU, ROCm at or above the floor, and an accelerator
provisioned to a ready state; no such machine was available here, and PyTorch
ROCm CI gates on gfx942/gfx950, so no CI job executes the new branch either.

That is why this is a draft. It should not be promoted until someone runs it on
fabric-capable hardware.

Follow-up, deliberately not in this PR: `handle_type_` is not observable from
Python, so there is no way to assert which handle type was selected. Exposing it
would let the existing tests pin the selection logic (trivially `POSIX_FD`
today) and turn into a real check the moment fabric-capable hardware enters CI.

Authored with the assistance of an AI coding agent.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang