### PR TITLE
Fix forward AD gradcheck error indexing

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7593,7 +7593,7 @@ Done""",
         check(fast_mode=False)
 
     def test_gradcheck_fast_mode_forward_ad_error_indexing(self):
-        from torch.autograd.gradcheck import GradcheckError
+        from torch.autograd.gradcheck import FAST_FAIL_SLOW_OK_MSG, GradcheckError
 
         class BadMul(Function):
             @staticmethod
@@ -7638,8 +7638,10 @@ Done""",
                     "Jacobian computed with forward mode mismatch for output "
                     f"{output_idx} with respect to input 0"
                 )
-                with self.assertRaisesRegex(GradcheckError, err_msg):
+                with self.assertRaisesRegex(GradcheckError, err_msg) as cm:
                     gradcheck(fn, inputs, **kwargs)
+                if name == "integer output":
+                    self.assertNotIn(FAST_FAIL_SLOW_OK_MSG, str(cm.exception))
                 self.assertFalse(gradcheck(fn, inputs, raise_exception=False, **kwargs))
 
     def test_gradcheck_forward_ad(self):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -7592,6 +7592,56 @@ Done""",
         check(fast_mode=True)
         check(fast_mode=False)
 
+    def test_gradcheck_fast_mode_forward_ad_error_indexing(self):
+        from torch.autograd.gradcheck import GradcheckError
+
+        class BadMul(Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x.mul(2)
+
+            @staticmethod
+            def backward(ctx, grad):
+                return grad.mul(2)
+
+            @staticmethod
+            def jvp(ctx, grad):
+                return grad.mul(5)
+
+        x = torch.ones(2, dtype=torch.double, requires_grad=True)
+        a = torch.ones(3, dtype=torch.double)
+        cases = (
+            (
+                "non-differentiable output",
+                lambda x: (torch.zeros_like(x), BadMul.apply(x)),
+                (x,),
+                1,
+            ),
+            (
+                "integer output",
+                lambda x: (torch.ones_like(x, dtype=torch.int64), BadMul.apply(x)),
+                (x,),
+                0,
+            ),
+            ("non-differentiable input", lambda a, x: BadMul.apply(x), (a, x), 0),
+        )
+        kwargs = {
+            "fast_mode": True,
+            "check_backward_ad": False,
+            "check_batched_grad": False,
+            "check_forward_ad": True,
+        }
+
+        for name, fn, inputs, output_idx in cases:
+            with self.subTest(name=name):
+                err_msg = (
+                    "Jacobian computed with forward mode mismatch for output "
+                    f"{output_idx} with respect to input 0"
+                )
+                with self.assertRaisesRegex(GradcheckError, err_msg):
+                    gradcheck(fn, inputs, **kwargs)
+                self.assertFalse(gradcheck(fn, inputs, raise_exception=False, **kwargs))
+
     def test_gradcheck_forward_ad(self):
         def fn(x, y):
             return x + y, y

--- a/torch/autograd/gradcheck.py
+++ b/torch/autograd/gradcheck.py
@@ -1796,20 +1796,36 @@ def _run_slow_mode_and_get_error(
     func, tupled_inputs, outputs, input_idx, output_idx, rtol, atol, eps, is_forward_ad
 ):
     # Compute jacobians in slow mode for better error message
-    slow_numerical = _get_numerical_jacobian(
-        func, tupled_inputs, outputs, eps=eps, is_forward_ad=is_forward_ad
-    )[input_idx][output_idx]
     if is_forward_ad:
+        inp_tensors_idx, _ = _get_inp_tensors(tupled_inputs)
+        input_idx_in_tuple = inp_tensors_idx[input_idx]
 
         def new_fn(inp):
             new_inputs = list(tupled_inputs)
-            new_inputs[input_idx] = inp
-            return _as_tuple(func(*new_inputs))[output_idx]
+            new_inputs[input_idx_in_tuple] = inp
+            forward_outputs = tuple(
+                output
+                for output in _as_tuple(func(*new_inputs))
+                if _is_float_or_complex_tensor(output)
+            )
+            return forward_outputs[output_idx]
 
+        input_to_check = tupled_inputs[input_idx_in_tuple]
+        output_to_check = new_fn(input_to_check)
+        slow_numerical = _get_numerical_jacobian(
+            new_fn,
+            (input_to_check,),
+            (output_to_check,),
+            eps=eps,
+            is_forward_ad=True,
+        )[0][0]
         slow_analytical = _get_analytical_jacobian_forward_ad(
-            new_fn, (tupled_inputs[input_idx],), (outputs[output_idx],)
+            new_fn, (input_to_check,), (output_to_check,)
         )[0][0]
     else:
+        slow_numerical = _get_numerical_jacobian(
+            func, tupled_inputs, outputs, eps=eps, is_forward_ad=False
+        )[input_idx][output_idx]
         slow_analytical = _get_analytical_jacobian(
             tupled_inputs, outputs, input_idx, output_idx
         )


### PR DESCRIPTION
## Summary

I reviewed the patch before submission and understand the change as a fix to the forward-AD fast-mode diagnostic path, not the normal gradcheck computation. The technical summary and test notes below were drafted with ChatGPT assistance and are quoted to keep that AI-assisted text clearly separated.

> **Technical summary**
>
> `gradcheck(fast_mode=True, check_forward_ad=True)` indexes fast-mode inputs among differentiable inputs and outputs among floating/complex outputs. The slow-mode error reporter was reusing those indices directly against the original input/output tuples. If a non-differentiable input, integer output, or non-differentiable floating output appeared earlier, the diagnostic path could select the wrong tensor or raise `IndexError` instead of `GradcheckError`.
>
> This patch maps the fast-mode input index back to the original input tuple and recomputes the selected forward-AD output in the same floating/complex-output indexing domain before building the slow-mode diagnostic.
>
> The backward-mode mismatch from #194869 was fixed independently by #194222 and is unchanged here.
>
> **Test plan / results**
>
> - `python test/test_autograd.py -k gradcheck`
>   - 33 tests ran successfully, 2 skipped as expected on CPU
> - `python -m spin quicklint`
>   - `No lint issues.`
> - The regression test was checked against unmodified `main`: the relevant non-differentiable-output/input cases fail in the error-reporting path before the fix and pass with this patch.
>
> **BC-breaking:** No.

## AI assistance disclosure

The quoted technical summary and test notes above were drafted with ChatGPT assistance. ChatGPT also assisted with issue triage, reproducer validation, patch drafting, and local test execution.