### PR TITLE
[Testcase Refactoring] Resolve default backend from device in common test base classes

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -1278,7 +1278,6 @@ class MultiProcessTestCase(TestCase):
 # This abstracts the PG creation and deletion, the backends are selected based
 # on device type. The tests functions can be instantiated per device type using
 # common_device_type.instantiate_device_type_tests
-# other backends can add entry in backend() function
 class DistributedTestBase(MultiProcessTestCase):
     def setUp(self):
         super().setUp()
@@ -1296,14 +1295,7 @@ class DistributedTestBase(MultiProcessTestCase):
             pass
 
     def backend(self, device) -> str:
-        if "cuda" in device:
-            return "nccl"
-        elif "hpu" in device:  # intel gaudi
-            return "hccl"
-        elif "xpu" in device:
-            return "xccl"
-        else:
-            return "gloo"
+        return c10d.get_default_backend_for_device(device)
 
     def create_pg(self, device, world_size=None, backend=None):
         if world_size is None:
@@ -1311,18 +1303,10 @@ class DistributedTestBase(MultiProcessTestCase):
         backend = backend or self.backend(device)
         num_visible_devices = torch.get_device_module(device).device_count()
         store = torch.distributed.FileStore(self.file_name, num_visible_devices)
-        if "nccl" in backend or "xccl" in backend:
-            accelerator = torch.accelerator.current_accelerator()
-            if accelerator:
-                device_type = accelerator.type
-                device = torch.device(f"{device_type}:{self.rank}")
-                torch.set_default_device(device)
-                torch.accelerator.set_device_index(device)
-            else:
-                raise RuntimeError(
-                    "Expected to find an accelerator when initializing process group"
-                    f" with {backend} backend, but got None"
-                )
+        if backend != "gloo":
+            device = torch.device(f"{torch.device(device).type}:{self.rank}")
+            torch.set_default_device(device)
+            torch.accelerator.set_device_index(device)
         torch.distributed.init_process_group(
             backend=backend,
             world_size=world_size,

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -23,7 +23,10 @@ class ShardedTensorTestBase(MultiProcessTestCase):
 
     @property
     def backend(self) -> str:
-        return dist.get_default_backend_for_device(self.device_type)
+        device_type = getattr(self, "device_type", None)
+        if device_type is None:
+            return "nccl"
+        return dist.get_default_backend_for_device(device_type)
 
     @property
     def current_device(self) -> torch.device:
@@ -100,7 +103,6 @@ class ShardedTensorTestBase(MultiProcessTestCase):
 
 
 # wrapper to initialize comms (processgroup + rpc)
-# backend=None resolves the default backend for the instantiated device type
 def with_comms(func=None, init_rpc=True, backend=None):
     if func is None:
         return partial(
@@ -112,14 +114,8 @@ def with_comms(func=None, init_rpc=True, backend=None):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         # Skip test if backend requires accelerator but not enough devices available
-        pg_backend = backend or self.backend
-        acc = torch.accelerator.current_accelerator()
-        if pg_backend != dist.Backend.GLOO:
-            if (
-                acc is None
-                or pg_backend != dist.get_default_backend_for_device(acc)
-                or torch.accelerator.device_count() < self.world_size
-            ):
+        if (backend or self.backend) != dist.Backend.GLOO:
+            if torch.accelerator.device_count() < self.world_size:
                 sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)
         self.init_comms(init_rpc=init_rpc, backend=backend)
         func(self, *args, **kwargs)

--- a/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
+++ b/torch/testing/_internal/distributed/_shard/sharded_tensor/__init__.py
@@ -21,7 +21,18 @@ class ShardedTensorTestBase(MultiProcessTestCase):
     def world_size(self):
         return TEST_GPU_NUM
 
-    def init_pg(self, backend="nccl"):
+    @property
+    def backend(self) -> str:
+        return dist.get_default_backend_for_device(self.device_type)
+
+    @property
+    def current_device(self) -> torch.device:
+        if self.rank < 0:
+            return torch.device(self.device_type)
+        return torch.device(self.device_type, self.rank)
+
+    def init_pg(self, backend=None):
+        backend = backend or self.backend
         # Ask the distributed framework rather than matching a fixed list, so a
         # backend registered by an out-of-tree device is accepted the same way
         # the built-in ones are.
@@ -58,7 +69,7 @@ class ShardedTensorTestBase(MultiProcessTestCase):
             rpc_backend_options=rpc_backend_options,
         )
 
-    def init_comms(self, init_rpc=True, backend="nccl"):
+    def init_comms(self, init_rpc=True, backend=None):
         if init_rpc:
             self.init_rpc()
         self.init_pg(backend=backend)
@@ -89,7 +100,8 @@ class ShardedTensorTestBase(MultiProcessTestCase):
 
 
 # wrapper to initialize comms (processgroup + rpc)
-def with_comms(func=None, init_rpc=True, backend="nccl"):
+# backend=None resolves the default backend for the instantiated device type
+def with_comms(func=None, init_rpc=True, backend=None):
     if func is None:
         return partial(
             with_comms,
@@ -100,11 +112,12 @@ def with_comms(func=None, init_rpc=True, backend="nccl"):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         # Skip test if backend requires accelerator but not enough devices available
+        pg_backend = backend or self.backend
         acc = torch.accelerator.current_accelerator()
-        if backend != dist.Backend.GLOO:
+        if pg_backend != dist.Backend.GLOO:
             if (
                 acc is None
-                or backend != dist.get_default_backend_for_device(acc)
+                or pg_backend != dist.get_default_backend_for_device(acc)
                 or torch.accelerator.device_count() < self.world_size
             ):
                 sys.exit(TEST_SKIPS[f"multi-device-{self.world_size}"].exit_code)


### PR DESCRIPTION
[Testcase Refactoring] Resolve default backend from device in common test base classes

## Motivation

Two common test base classes select process-group backends and devices through
hard-coded CUDA-era paths:

- `ShardedTensorTestBase.with_comms` / `init_pg` default to `"nccl"`, so a
  device-instantiated out-of-tree accelerator class does not use its registered
  default backend unless every call site passes a module-level backend global.
- `DistributedTestBase.backend` maps cuda/hpu/xpu explicitly and sends every
  other device to gloo; `create_pg` then probes the current accelerator even
  though its device is already an argument.

## Changes

`ShardedTensorTestBase`:

- add a `backend` property that resolves the default backend from the injected
  `device_type`, while preserving the previous `"nccl"` default for legacy
  subclasses that have not yet migrated to `instantiate_device_type_tests`;
- add a `current_device` property that returns the unindexed injected device
  while `rank < 0`, and `device_type:rank` in worker processes;
- make `with_comms`, `init_comms`, and `init_pg` default to `backend=None`, with
  `init_pg` resolving `None` through the property while preserving explicit
  backend values;
- keep the `dist.is_backend_available()` admission check and the
  `torch.accelerator.is_available() and backend != dist.Backend.GLOO` rank
  binding as landed by #190528 (a superset of the non-gloo rule this PR
  proposed);
- reduce the wrapper precheck to the effective non-gloo backend and the
  device-count condition. The requested backend is resolved through the
  `backend` property, so a bare `@with_comms` on a device-instantiated class
  is not skipped for `None != default_backend`. The `current_accelerator()`
  probe and the backend-vs-accelerator-default comparison that #190528 carried
  are dropped: once the default backend comes from the instantiated device,
  a mismatch can only come from an explicit hard-coded backend at a call site,
  and that should surface as a failure to fix rather than a silent skip.

`DistributedTestBase`:

- replace the cuda/hpu/xpu/gloo chain with a direct
  `c10d.get_default_backend_for_device(device)` call;
- let `create_pg` accept an explicit backend override and bind non-gloo ranks
  from the injected `device` argument instead of `current_accelerator()`.

The legacy fallback applies only when `device_type` is absent. If a device type
is present but has no registered default backend, the registry lookup still
fails instead of silently selecting another backend.

## Scope

This PR covers only `DistributedTestBase` and `ShardedTensorTestBase`.
`C10dTorchCommsTestBase` is not included: TorchComms has its own backend
availability and registration path, and that work remains coordinated with
#194152 rather than being partially duplicated here.

#190528 (landed as 3476cfd24445) touched the same `ShardedTensorTestBase.init_pg`
/ `with_comms` region; this PR is rebased on top of it. The admission check and
rank binding are the ones #190528 landed; the wrapper precheck follows this
PR's reviewed shape (see Changes) and supersedes the three-part precheck
#190528 carried. #194152 touches the same `DistributedTestBase` region and the
usual rule applies to whichever lands second.

## Behavior

| path | before | after |
| --- | --- | --- |
| explicit `backend=...` | passed through | passed through |
| instantiated bare `@with_comms` | fixed nccl default | resolves from injected `device_type` |
| current rank device | no shared helper | unindexed device before spawn, `device_type:rank` in workers |
| `DistributedTestBase.backend`, cuda/xpu/hpu/cpu | nccl/xccl/hccl/gloo | same values through the registry |
| other registered devices | silently gloo | registered default backend |
| legacy subclass without `device_type` | fixed nccl default | preserves nccl default |
| present but unregistered device type | implicit fallback | explicit lookup error |
| `DistributedTestBase.create_pg` rank binding | nccl/xccl plus a runtime device probe | any non-gloo backend, using the injected device |
| `ShardedTensorTestBase` rank binding | as landed by #190528 | unchanged |
| `with_comms` precheck | accelerator present / backend equals its default / enough devices (#190528) | non-gloo effective backend and enough devices; no accelerator probe |
| explicit non-default backend on an accelerator host (e.g. `nccl` on a non-CUDA device) | skipped | not skipped; `init_pg` / `init_process_group` reports it |

## Test plan

Re-run on the rebased head, stacked on top of the landed #190528 change. The
focused suite contains eight contracts, including an uninstantiated legacy
`ShardedTensorTestBase` assertion:

- NPU: eight focused contracts passed with four HCCL ranks, covering
  default and explicit backends for `DistributedTestBase.create_pg`, an
  instantiated bare `@with_comms` path, and the parent/worker branches of
  `current_device`, plus the missing-`device_type` legacy fallback
  (8 passed, 0 skipped);
- CPU: the same eight contracts passed with gloo, including the bare
  `backend=None` path, both `current_device` branches, and confirmation that
  gloo does not bind an accelerator device (8 passed, 0 skipped);
- both runs asserted the reviewed source shape before executing and restored
  the prepared source tree byte-for-byte afterwards;
- CUDA: nccl resolution and multi-device behavior through CI.
