### PR TITLE
Disallow autograd for NCCL collectives

### DIFF
--- a/test/distributed/test_nccl.py
+++ b/test/distributed/test_nccl.py
@@ -192,6 +192,48 @@ class TestNCCL(TestCase):
         ):
             nccl.reduce_scatter(t, t)
 
+    @parametrize(
+        "op_name,requires_grad_arg",
+        [
+            ("all_reduce", "input"),
+            ("all_reduce", "output"),
+            ("reduce", "input"),
+            ("reduce", "output"),
+            ("broadcast", "input"),
+            ("all_gather", "input"),
+            ("all_gather", "output"),
+            ("reduce_scatter", "input"),
+            ("reduce_scatter", "output"),
+        ],
+    )
+    def test_collectives_reject_autograd(self, device, op_name, requires_grad_arg):
+        input = torch.ones(4, device=device, requires_grad=requires_grad_arg == "input")
+        output = torch.empty(
+            4, device=device, requires_grad=requires_grad_arg == "output"
+        )
+        collectives = {
+            "all_reduce": lambda: nccl.all_reduce(
+                [input], [output] if requires_grad_arg == "output" else None
+            ),
+            "reduce": lambda: nccl.reduce(
+                [input], output=output if requires_grad_arg == "output" else None
+            ),
+            "broadcast": lambda: nccl.broadcast([input]),
+            "all_gather": lambda: nccl.all_gather([input], [output]),
+            "reduce_scatter": lambda: nccl.reduce_scatter([input], [output]),
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "does not support autograd"):
+            collectives[op_name]()
+
+    def test_collectives_allow_no_grad(self, device):
+        tensor = torch.ones(4, device=device, requires_grad=True)
+
+        with torch.no_grad():
+            nccl.all_reduce([tensor])
+
+        self.assertEqual(tensor, torch.ones_like(tensor))
+
     @skip_but_pass_in_sandcastle_if(IS_WINDOWS, "NCCL doesn't support Windows")
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "only one GPU detected")
     @dtypes(*datatypes)

--- a/test/test_cuda_multigpu.py
+++ b/test/test_cuda_multigpu.py
@@ -15,6 +15,7 @@ from typing import NamedTuple
 
 import torch
 import torch.cuda.comm as comm
+from torch.cuda import nccl
 from torch.nn.parallel import scatter_gather
 from torch.testing._internal.common_cuda import (
     _create_scaling_case,
@@ -1320,6 +1321,47 @@ t2.start()
 
 
 class TestCudaComm(TestCase):
+    def test_broadcast_fallback_supports_autograd(self):
+        input = torch.randn(5, 5, requires_grad=True)
+
+        output = comm.broadcast(input, (0,))[0]
+        output.sum().backward()
+
+        self.assertEqual(input.grad, torch.ones_like(input))
+
+    def test_nccl_broadcasts_reject_autograd(self):
+        input = torch.ones(4, device=0, requires_grad=True)
+        if not nccl.is_available([input]):
+            self.skipTest("NCCL is not available")
+
+        collectives = {
+            "broadcast": lambda: comm.broadcast(input, (0,)),
+            "broadcast_coalesced": lambda: comm.broadcast_coalesced([input], (0,)),
+        }
+        for name, collective in collectives.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, "does not support autograd"):
+                    collective()
+
+    @unittest.skipIf(not TEST_MULTIGPU, "only one GPU detected")
+    def test_nccl_multigpu_collectives_reject_autograd(self):
+        input = torch.ones(4, device=0, requires_grad=True)
+        other = torch.ones(4, device=1)
+        if not nccl.is_available([input, other]):
+            self.skipTest("NCCL is not available")
+
+        collectives = {
+            "broadcast_out": lambda: comm.broadcast(input, out=[other]),
+            "reduce_add": lambda: comm.reduce_add([input, other]),
+            "reduce_add_coalesced": lambda: comm.reduce_add_coalesced(
+                [[input], [other]]
+            ),
+        }
+        for name, collective in collectives.items():
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, "does not support autograd"):
+                    collective()
+
     def _test_broadcast(self, input):
         if not TEST_MULTIGPU:
             raise unittest.SkipTest("only one GPU detected")

--- a/torch/csrc/cuda/nccl.cpp
+++ b/torch/csrc/cuda/nccl.cpp
@@ -3,6 +3,7 @@
 #include <torch/csrc/cuda/nccl.h>
 
 #include <ATen/ATen.h>
+#include <ATen/core/grad_mode.h>
 #include <c10/cuda/CUDAException.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/util/Exception.h>
@@ -12,6 +13,7 @@
 #include <nccl.h>
 
 #include <sched.h>
+#include <algorithm>
 #include <limits>
 #include <sstream>
 #include <type_traits>
@@ -493,6 +495,24 @@ void comm_destroy(ncclComm_t comm) {
 }
 
 namespace {
+void check_no_autograd(bool requires_grad) {
+  TORCH_CHECK(
+      !at::GradMode::is_enabled() || !requires_grad,
+      "NCCL does not support autograd. Please call with tensors "
+      "that do not require gradients or use torch.no_grad().");
+}
+
+void check_no_autograd(TensorList tensors) {
+  check_no_autograd(
+      std::any_of(tensors.begin(), tensors.end(), [](const auto& tensor) {
+        return tensor.requires_grad();
+      }));
+}
+
+void check_no_autograd(const Tensor& tensor) {
+  check_no_autograd(tensor.requires_grad());
+}
+
 // NCCL changed the numerical type used for count between NCCL1 and NCCL2.
 // So we use the following struct, which gets the type of the second argument
 // of T, if T is a function type, with ncclBcast, to get that type statically
@@ -533,6 +553,7 @@ void broadcast(
   TORCH_CHECK(
       root >= 0 && static_cast<size_t>(root) < tensors.size(), "invalid root");
   check_inputs(tensors, tensors, 1, 1);
+  check_no_autograd(tensors);
   auto data_type = to_nccl_data_type(tensors[0]);
   int64_t numel = tensors[0].numel();
 
@@ -583,6 +604,8 @@ void reduce(
       root >= 0 && static_cast<size_t>(root) < inputs.size(), "invalid root");
 
   check_inputs(inputs, output, root, 1, 1);
+  check_no_autograd(inputs);
+  check_no_autograd(output);
   const auto len = inputs.size();
 
   auto data_type = to_nccl_data_type(inputs[0]);
@@ -637,6 +660,8 @@ void all_reduce(
 #ifdef USE_NCCL
   using namespace torch::cuda::nccl::detail;
   check_inputs(inputs, outputs, 1, 1);
+  check_no_autograd(inputs);
+  check_no_autograd(outputs);
   const auto len = inputs.size();
 
   auto data_type = to_nccl_data_type(inputs[0]);
@@ -680,6 +705,8 @@ void reduce_scatter(
   using namespace torch::cuda::nccl::detail;
   const auto len = inputs.size();
   check_inputs(inputs, outputs, 1, len);
+  check_no_autograd(inputs);
+  check_no_autograd(outputs);
 
   auto data_type = to_nccl_data_type(inputs[0]);
 
@@ -721,6 +748,8 @@ void all_gather(
   using namespace torch::cuda::nccl::detail;
   const auto len = inputs.size();
   check_inputs(inputs, outputs, len, 1);
+  check_no_autograd(inputs);
+  check_no_autograd(outputs);
 
   auto data_type = to_nccl_data_type(inputs[0]);
 


### PR DESCRIPTION
## Issue

Fixes #4731

## Summary

Reject true NCCL collectives when grad mode is enabled and any input or output requires gradients. The guard lives in the C++ NCCL implementation, so it covers both `torch.cuda.nccl` and NCCL-backed `torch.cuda.comm` paths while preserving the differentiable fallback and `torch.no_grad()` usage.

## Testing

- Built an editable CUDA 13.0 / NCCL 2.30.7 PyTorch checkout and ran `test/distributed/test_nccl.py TestNCCLCUDA` on an RTX 4090: 22 tests passed, with 10 existing multi-GPU cases skipped.
- Ran the focused `TestCudaComm` fallback and NCCL autograd tests: 3 tests passed, with the multi-GPU case skipped on the single visible GPU.
- `git diff --check` passes.
- Six-GPU RTX 3090 validation was not run because that host was unreachable.

## Checklist

- [ ] Passes lint (`spin fixlint`); `spin quicklint` formatting checks pass, while existing whole-file clang-tidy findings in `nccl.cpp` remain outside this diff
- [x] Added/updated tests
- [x] Updated documentation (not applicable)
- [x] Included benchmark results (not applicable; no performance change)

## BC-breaking?

Yes, intentionally for unsupported usage: true NCCL collectives now raise when autograd is enabled and a participating tensor requires gradients. Calls under `torch.no_grad()` and the differentiable non-NCCL fallback remain unchanged.

## AI assistance

Codex assisted with implementation and test preparation. I reviewed the complete three-file diff and RTX 4090 validation results before authorizing submission, and I take responsibility for this change.