### PR TITLE
[inductor] Route compile options through backend registrations

### DIFF
--- a/docs/source/accelerator/autoload.md
+++ b/docs/source/accelerator/autoload.md
@@ -111,6 +111,24 @@ Device modules that instead expose `Scheduling`, `PythonWrapperCodegen`, and
 the codegen classes eagerly at `import torch`. A device that is already registered
 (for example eagerly from `_autoload`) skips the hook entirely.
 
+A backend that keeps its options in a `ConfigModule` can expose them through
+`torch.compile(options=...)`: register the module as `device_custom_config`, and
+its keys become addressable as `"<device>.<key>"` options. The values are patched
+onto the owning module for the duration of the compilation, instead of
+`torch._inductor.config`.
+
+```python
+register_backend_for_device(
+    "my_device",
+    MyScheduling,
+    MyWrapperCodegen,
+    MyCppWrapperCodegen,
+    device_custom_config=my_backend_config,
+)
+
+torch.compile(model, options={"my_device.my_config_key": 1})
+```
+
 ## Result
 
 After setting up the entry point and backend, build and install your backend. Now, we can use the new accelerator without explicitly importing it.

--- a/test/inductor/test_compile_options.py
+++ b/test/inductor/test_compile_options.py
@@ -1,0 +1,485 @@
+# Owner(s): ["module: inductor"]
+import contextlib
+import types
+import unittest
+from unittest import mock
+
+import torch
+import torch.fx as fx
+from torch._dynamo.utils import counters
+from torch._inductor import compile_fx_ext, config
+from torch._inductor.codecache import FxGraphCache
+from torch._inductor.codegen import common as codegen_common
+from torch._inductor.codegen.common import (
+    get_compile_option_owner,
+    patch_compile_options,
+    register_backend_for_device,
+)
+from torch._inductor.compile_fx import (
+    compile_fx,
+    FxCompileMode,
+    get_patched_config_dict,
+)
+from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal import fake_config_module, fake_config_module2
+from torch.utils._import_utils import import_dill
+
+
+dill = import_dill()
+HAS_DILL = dill is not None
+
+
+FAKE_MODULE = "torch.testing._internal.fake_config_module"
+FAKE_MODULE2 = "torch.testing._internal.fake_config_module2"
+
+
+def dummy_fn(x):
+    return torch.sigmoid(x + 1.0) / 10.0
+
+
+@contextlib.contextmanager
+def fake_backend_routes():
+    # populate the built-in devices first: patch.dict would otherwise swallow
+    # their lazy registration into the restore-on-exit snapshot
+    codegen_common.init_backend_registration()
+    with (
+        mock.patch.dict(codegen_common.device_codegens),
+        mock.patch.dict(codegen_common.custom_backend_codegen_configs),
+        mock.patch.dict(codegen_common.custom_backend_passes),
+    ):
+        register_backend_for_device(
+            "fake_device_a", None, None, device_custom_config=fake_config_module
+        )
+        register_backend_for_device(
+            "fake_device_b", None, None, device_custom_config=fake_config_module2
+        )
+        yield
+
+
+@contextlib.contextmanager
+def deferred_backend_routes():
+    # a backend integrating through the _inductor_backend_init hook registers
+    # on the first init_backend_registration() call; nothing before that can
+    # resolve its option names
+    real_init = codegen_common.init_backend_registration
+    # populate the built-in devices first: patch.dict would otherwise swallow
+    # their lazy registration into the restore-on-exit snapshot
+    real_init()
+    registered = []
+
+    def lazy_init():
+        real_init()
+        if not registered:
+            registered.append(True)
+            register_backend_for_device(
+                "fake_device_a", None, None, device_custom_config=fake_config_module
+            )
+
+    with (
+        mock.patch.object(codegen_common, "init_backend_registration", lazy_init),
+        mock.patch.dict(codegen_common.device_codegens),
+        mock.patch.dict(codegen_common.custom_backend_codegen_configs),
+        mock.patch.dict(codegen_common.custom_backend_passes),
+    ):
+        yield registered
+
+
+class TestCompileOptions(TestCase):
+    def test_lookup(self):
+        with fake_backend_routes():
+            self.assertEqual(
+                get_compile_option_owner("fake_device_a.e_bool"),
+                (fake_config_module, "e_bool"),
+            )
+            # dashed spelling resolves to the same owner and key
+            self.assertEqual(
+                get_compile_option_owner("fake_device_a.e-bool"),
+                (fake_config_module, "e_bool"),
+            )
+            # unknown devices, missing keys, and core names do not route
+            self.assertIsNone(get_compile_option_owner("other_device.e_bool"))
+            self.assertIsNone(get_compile_option_owner("fake_device_a.missing"))
+            self.assertIsNone(get_compile_option_owner("max_fusion_size"))
+        self.assertIsNone(get_compile_option_owner("fake_device_a.e_bool"))
+
+    def test_core_namespaced_keys_take_precedence(self):
+        # a device registered under a core namespace (e.g. a backend claiming
+        # "cuda") must not intercept core options like "cuda.arch"
+        with fake_backend_routes():
+            register_backend_for_device(
+                "cuda", None, None, device_custom_config=fake_config_module
+            )
+            # non-core keys under the device still route to its config
+            owner, key = get_compile_option_owner("cuda.e_bool")
+            self.assertEqual((owner, key), (fake_config_module, "e_bool"))
+            # core "cuda.*" keys stay on the core config
+            wrapper = torch._TorchCompileInductorWrapper(
+                None, {"cuda.arch": "sm_90"}, None
+            )
+            self.assertEqual(wrapper.config["cuda.arch"], "sm_90")
+            with patch_compile_options({"cuda.arch": "sm_90"}):
+                self.assertEqual(config.cuda.arch, "sm_90")
+                self.assertTrue(fake_config_module.e_bool)
+
+    def test_apply_options_routed(self):
+        with fake_backend_routes():
+            wrapper = torch._TorchCompileInductorWrapper(
+                None, {"fake_device_a.e_bool": False, "max_fusion_size": 33}, None
+            )
+            self.assertEqual(wrapper.config["fake_device_a.e_bool"], False)
+            self.assertEqual(wrapper.config["max_fusion_size"], 33)
+            # dashed spelling is normalized like inductor's own options
+            wrapper = torch._TorchCompileInductorWrapper(
+                None, {"fake-device-a.e-bool": False}, None
+            )
+            self.assertEqual(wrapper.config, {"fake_device_a.e_bool": False})
+            # type is checked against the owning module
+            with self.assertRaisesRegex(RuntimeError, "Unexpected type of attr"):
+                torch._TorchCompileInductorWrapper(
+                    None, {"fake_device_a.e_bool": "not a bool"}, None
+                )
+
+    def test_apply_options_unknown_name_rejected(self):
+        with fake_backend_routes():
+            with self.assertRaisesRegex(
+                RuntimeError, "Unexpected optimization option unregistered.option"
+            ):
+                torch._TorchCompileInductorWrapper(
+                    None, {"unregistered.option": True}, None
+                )
+
+    def test_patch_compile_options(self):
+        default_fusion_size = config.max_fusion_size
+        with fake_backend_routes():
+            with patch_compile_options(
+                {"fake_device_a.e_bool": False, "max_fusion_size": 64}
+            ):
+                self.assertFalse(fake_config_module.e_bool)
+                self.assertEqual(config.max_fusion_size, 64)
+            self.assertTrue(fake_config_module.e_bool)
+            self.assertEqual(config.max_fusion_size, default_fusion_size)
+
+    def test_patch_compile_options_decorator_reentry(self):
+        # backwards is compiled out of scope of the forward patch context; the
+        # decorator form must re-enter every owner patch on each call
+        with fake_backend_routes():
+            observed = []
+
+            def inner(depth):
+                observed.append((fake_config_module.e_bool, config.max_fusion_size))
+                if depth:
+                    decorated(depth - 1)
+
+            decorated = patch_compile_options(
+                {"fake_device_a.e_bool": False, "max_fusion_size": 64}
+            )(inner)
+        decorated(1)
+        decorated(0)
+        self.assertEqual(observed, [(False, 64)] * 3)
+        self.assertTrue(fake_config_module.e_bool)
+
+    def test_patch_compile_options_nested(self):
+        with fake_backend_routes():
+            with patch_compile_options({"fake_device_a.e_bool": False}):
+                self.assertFalse(fake_config_module.e_bool)
+                with patch_compile_options({"fake_device_a.e_bool": True}):
+                    self.assertTrue(fake_config_module.e_bool)
+                self.assertFalse(fake_config_module.e_bool)
+            self.assertTrue(fake_config_module.e_bool)
+
+    def test_compile_fx_patches_owner_module(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.sin(x * 2)
+
+        gm = fx.symbolic_trace(M())
+        x = torch.randn(4)
+        observed = []
+
+        def inner_compile(gm_, *args, **kwargs):
+            observed.append((fake_config_module.e_bool, config.max_fusion_size))
+            return gm_
+
+        with fake_backend_routes():
+            compiled = compile_fx(
+                gm,
+                [x],
+                inner_compile=inner_compile,
+                config_patches={"fake_device_a.e_bool": False, "max_fusion_size": 64},
+            )
+        compiled(x)
+        self.assertEqual(observed, [(False, 64)])
+        # patches are undone once compilation is over
+        self.assertTrue(fake_config_module.e_bool)
+
+    def test_compile_fx_backward_sees_routed_patches(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.sin(x * 2) * x.cos()
+
+        gm = fx.symbolic_trace(M())
+        x = torch.randn(4, requires_grad=True)
+        observed = []
+
+        def inner_compile(gm_, *args, **kwargs):
+            observed.append(fake_config_module.e_bool)
+            return gm_
+
+        with fake_backend_routes():
+            compiled = compile_fx(
+                gm,
+                [x],
+                inner_compile=inner_compile,
+                config_patches={"fake_device_a.e_bool": False},
+            )
+            out = compiled(x)
+        out.sum().backward()
+        # forward and the out-of-scope backward compilation both ran patched
+        self.assertEqual(observed, [False, False])
+        self.assertTrue(fake_config_module.e_bool)
+
+    @unittest.skipUnless(HAS_DILL, "dill not available")
+    def test_compile_fx_ext_replays_backend_configs(self):
+        # SERIALIZE mode runs the same serialize -> _run_in_child path
+        # in-process; the wire must carry the parent's backend configs so the
+        # child applies them instead of reading its own backend state
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.sin(x * 2)
+
+        gm = fx.symbolic_trace(M())
+        x = torch.randn(4)
+        real_serialize = compile_fx_ext._WireProtocolInput.serialize
+        real_import = compile_fx_ext.importlib.import_module
+        seen = []
+        applied = []
+
+        def serialize_spy(self):
+            seen.append(self.backend_configs)
+            return real_serialize(self)
+
+        def import_spy(name, *args, **kwargs):
+            module = real_import(name, *args, **kwargs)
+            if name != FAKE_MODULE:
+                return module
+
+            def patch_recorder(values, *patch_args, **patch_kwargs):
+                applied.append(values)
+                return module.patch(values, *patch_args, **patch_kwargs)
+
+            return types.SimpleNamespace(patch=patch_recorder)
+
+        with fake_backend_routes():
+            with (
+                mock.patch(
+                    "torch._inductor.compile_fx.fx_compile_mode",
+                    FxCompileMode.SERIALIZE,
+                ),
+                mock.patch.object(
+                    compile_fx_ext._WireProtocolInput, "serialize", serialize_spy
+                ),
+                mock.patch.object(
+                    compile_fx_ext.importlib, "import_module", import_spy
+                ),
+            ):
+                compiled = compile_fx(
+                    gm, [x], config_patches={"fake_device_a.e_bool": False}
+                )
+                compiled(x)
+
+        # the wire carried the full parent configs, patched value included
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(set(seen[0]), {FAKE_MODULE, FAKE_MODULE2})
+        self.assertIs(seen[0][FAKE_MODULE]["e_bool"], False)
+        # and the child applied the replayed config, not just the routed delta
+        self.assertEqual(len(applied), 1)
+        self.assertIn("e_string", applied[0])
+        self.assertIs(applied[0]["e_bool"], False)
+        self.assertTrue(fake_config_module.e_bool)
+
+    def test_get_patched_config_dict_routed(self):
+        with fake_backend_routes():
+            result = get_patched_config_dict(
+                {
+                    "fake_device_a.e_bool": False,
+                    "fake_device_b.e_aliasing_bool": True,
+                    "max_fusion_size": 64,
+                }
+            )
+        self.assertEqual(result["fake_device_a.e_bool"], False)
+        self.assertEqual(result["fake_device_b.e_aliasing_bool"], True)
+        self.assertEqual(result["max_fusion_size"], 64)
+
+    def test_get_patched_config_dict_forced_value(self):
+        with fake_backend_routes():
+            with mock.patch.object(
+                fake_config_module._config["e_bool"], "env_value_force", True
+            ):
+                result = get_patched_config_dict({"fake_device_a.e_bool": False})
+                self.assertTrue(result["fake_device_a.e_bool"])
+
+    def test_torch_compile_routed_option(self):
+        with fake_backend_routes():
+            optimized = torch.compile(dummy_fn, options={"fake_device_a.e_bool": False})
+            # get_compiler_config runs at torch.compile() time, before any
+            # device is known; routed keys must not crash it and must surface
+            # their effective value
+            compiler_config = optimized.get_compiler_config()
+            self.assertEqual(compiler_config["fake_device_a.e_bool"], False)
+            x = torch.randn(10)
+            torch.testing.assert_close(optimized(x), dummy_fn(x))
+        # the owner module is restored once compilation is over
+        self.assertTrue(fake_config_module.e_bool)
+
+    def test_torch_inductor_compile_entry_point(self):
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.sin(x * 2)
+
+        gm = fx.symbolic_trace(M())
+        x = torch.randn(4)
+        with fake_backend_routes():
+            compiled = torch._inductor.compile(
+                gm, [x], options={"fake_device_a.e_bool": False, "max_fusion_size": 64}
+            )
+        torch.testing.assert_close(compiled(x), M()(x))
+
+    def test_aot_compile_routed_option(self):
+        # aot_compile deepcopies the patches and runs them through
+        # maybe_aoti_standalone_config before compile_fx; a routed name that
+        # did not pass through untouched would fail the core config patch
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return (torch.sin(x * 2),)
+
+        gm = fx.symbolic_trace(M())
+        x = torch.randn(4)
+        with fake_backend_routes():
+            path = torch._inductor.aot_compile(
+                gm, (x,), options={"fake_device_a.e_bool": False, "max_fusion_size": 64}
+            )
+        self.assertIsInstance(path, str)
+        self.assertTrue(path)
+        self.assertTrue(fake_config_module.e_bool)
+
+    def test_standalone_compile_to_python_entry_point(self):
+        # compile_to_python merges ``options`` into the config-patch block,
+        # which must route vendor names like every other entry point
+        from torch._inductor import compile_to_python
+        from torch._inductor.decomposition import select_decomp_table
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        def fn(t):
+            return [torch.relu(t * 2.0 + 1.0)]
+
+        x = torch.randn(4)
+        with torch.enable_grad():
+            gm = make_fx(
+                fn, decomposition_table=select_decomp_table(), tracing_mode="fake"
+            )(x)
+        with fake_backend_routes():
+            src, _cache = compile_to_python(
+                gm,
+                [x],
+                options={"fake_device_a.e_bool": False, "max_fusion_size": 64},
+            )
+        self.assertTrue(fake_config_module.e_bool)
+        ns = {"__name__": "_compiled"}
+        exec(compile(src, "<compiled>", "exec"), ns)
+        with torch.no_grad():
+            torch.testing.assert_close(ns["call"]([x])[0], fn(x)[0])
+
+    def test_deferred_backend_apply_options(self):
+        # torch.compile() validates options before any compile runs; the name
+        # must resolve once the deferred registration has fired
+        with deferred_backend_routes() as registered:
+            wrapper = torch._TorchCompileInductorWrapper(
+                None, {"fake_device_a.e_bool": False}, None
+            )
+            self.assertEqual(wrapper.config["fake_device_a.e_bool"], False)
+            self.assertEqual(registered, [True])
+
+    def test_deferred_backend_compile_fx(self):
+        # compile_fx resolves routes inside patch_compile_options, before its
+        # own init_backend_registration() call further down
+        class M(torch.nn.Module):
+            def forward(self, x):
+                return torch.sin(x * 2)
+
+        gm = fx.symbolic_trace(M())
+        x = torch.randn(4)
+        observed = []
+
+        def inner_compile(gm_, *args, **kwargs):
+            observed.append(fake_config_module.e_bool)
+            return gm_
+
+        with deferred_backend_routes() as registered:
+            compiled = compile_fx(
+                gm,
+                [x],
+                inner_compile=inner_compile,
+                config_patches={"fake_device_a.e_bool": False},
+            )
+            compiled(x)
+        self.assertEqual(observed, [False])
+        self.assertEqual(registered, [True])
+        self.assertTrue(fake_config_module.e_bool)
+
+    @config.patch("fx_graph_cache", True)
+    @config.patch("fx_graph_remote_cache", False)
+    @torch._functorch.config.patch("enable_autograd_cache", False)
+    def test_fx_graph_cache_key_includes_routed_options(self):
+        # compiles differing only in a routed option value must not share an
+        # FX graph cache entry; the owner module participates in the key
+        # through its device_custom_config registration, with the patched
+        # values visible when the key is computed
+        x = torch.randn(10)
+        counters.clear()
+        FxGraphCache.clear()
+
+        with fake_backend_routes():
+            torch._dynamo.reset()
+            torch.compile(dummy_fn, options={"fake_device_a.e_bool": False})(x)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+
+            torch._dynamo.reset()
+            torch.compile(dummy_fn, options={"fake_device_a.e_bool": True})(x)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
+
+            torch._dynamo.reset()
+            torch.compile(dummy_fn, options={"fake_device_a.e_bool": False})(x)
+            self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+    @unittest.skipUnless(HAS_DILL, "dill not available")
+    @config.patch("fx_graph_cache", True)
+    @config.patch("fx_graph_remote_cache", False)
+    @torch._functorch.config.patch("enable_autograd_cache", False)
+    def test_fx_graph_cache_key_serialized_compile(self):
+        # a worker-side (SERIALIZE) compile must derive the same key from the
+        # replayed parent values: same options -> hit, different -> miss
+        x = torch.randn(10)
+        counters.clear()
+        FxGraphCache.clear()
+
+        with fake_backend_routes():
+            with mock.patch(
+                "torch._inductor.compile_fx.fx_compile_mode",
+                FxCompileMode.SERIALIZE,
+            ):
+                torch._dynamo.reset()
+                torch.compile(dummy_fn, options={"fake_device_a.e_bool": False})(x)
+                self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
+
+                torch._dynamo.reset()
+                torch.compile(dummy_fn, options={"fake_device_a.e_bool": True})(x)
+                self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 2)
+
+                torch._dynamo.reset()
+                torch.compile(dummy_fn, options={"fake_device_a.e_bool": False})(x)
+                self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 1)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -2882,23 +2882,36 @@ class _TorchCompileInductorWrapper:
             return
 
         from torch._inductor import config
-
-        current_config: dict[str, _Any] = config.get_config_copy()
+        from torch._inductor.codegen.common import (
+            get_compile_option_owner,
+            init_backend_registration,
+        )
 
         for key, val in options.items():
             attr_name = key.replace("-", "_")
-            if attr_name not in current_config:
-                raise RuntimeError(
-                    f"Unexpected optimization option {key}, known options are {list(current_config.keys())}"
+            if attr_name in config._config:  # type: ignore[attr-defined]
+                # core inductor keys take precedence over device namespaces
+                owner_config, target_key = config, attr_name
+            else:
+                # a deferred privateuse1 backend may not have registered yet
+                init_backend_registration()
+                owner_config, target_key = get_compile_option_owner(attr_name) or (
+                    config,
+                    attr_name,
                 )
-            attr_type = config.get_type(attr_name)  # type: ignore[attr-defined]
+            if target_key not in owner_config._config:  # type: ignore[attr-defined]
+                raise RuntimeError(
+                    f"Unexpected optimization option {key}, known options are "
+                    f"{list(config.get_config_copy())}"
+                )
+            attr_type = owner_config.get_type(target_key)  # type: ignore[attr-defined]
             # Subscriptable generic types don't support isinstance so skip the type
             # check. There doesn't seem to be a good way of checking membership without
             # 3rd party libraries.
             if _get_origin(attr_type) is None:
                 if not isinstance(val, attr_type):
                     val_type_str = type(val).__name__
-                    expected_type_str = type(current_config[attr_name]).__name__
+                    expected_type_str = type(getattr(owner_config, target_key)).__name__
                     raise RuntimeError(
                         f"Unexpected type of attr {key}, got {val_type_str} should be {expected_type_str}"
                     )

--- a/torch/_inductor/codegen/common.py
+++ b/torch/_inductor/codegen/common.py
@@ -581,6 +581,52 @@ def get_custom_backend_config_for_device(device: str) -> ConfigModule | None:
 _privateuse1_backend_init_in_progress = False
 
 
+# Compile options addressed as "<device>.<key>" are applied to that device's
+# registered device_custom_config. The owner module's existing registration
+# folds the patched values into the FX graph cache key (#158254).
+def get_compile_option_owner(name: str) -> tuple[ConfigModule, str] | None:
+    """(owning ConfigModule, config key) for a device-namespaced option name.
+
+    Returns None for names that are not a registered device's config key;
+    callers fall back to torch._inductor.config.
+    """
+    device, _, key = name.replace("-", "_").partition(".")
+    owner = custom_backend_codegen_configs.get(device)
+    if owner is not None and key in owner._config:
+        return owner, key
+    return None
+
+
+def patch_compile_options(config_patches: dict[str, Any] | None):
+    """Patch core and backend options; decorators replay patches on each call."""
+    # the checker cannot see that install_config_module made config a ConfigModule
+    core_config = cast(ConfigModule, config)
+    # Resolve owners now so delayed backward compilation keeps its bindings.
+    grouped: dict[ConfigModule, dict[str, Any]] = {}
+    for name, value in (config_patches or {}).items():
+        normalized = name.replace("-", "_")
+        if normalized in config._config:  # type: ignore[attr-defined]
+            # core inductor keys take precedence over device namespaces
+            owner, key = core_config, normalized
+        else:
+            # a deferred privateuse1 backend may not have registered yet
+            init_backend_registration()
+            owner, key = get_compile_option_owner(normalized) or (
+                core_config,
+                normalized,
+            )
+        grouped.setdefault(owner, {})[key] = value
+
+    @contextlib.contextmanager
+    def patch() -> Iterator[None]:
+        with contextlib.ExitStack() as stack:
+            for owner, values in grouped.items():
+                stack.enter_context(owner.patch(values))
+            yield
+
+    return patch()
+
+
 @functools.cache
 def _init_builtin_backend_registration() -> None:
     # The built-in devices are never unregistered, so this only needs to run

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -115,7 +115,12 @@ from ..fx._lazy_graph_module import _use_lazy_graph_module
 from ..fx.graph import _PyTreeCodeGen
 from ..utils._triton import has_triton
 from . import config, distributed_autotune, metrics
-from .codegen.common import get_wrapper_codegen_for_device, init_backend_registration
+from .codegen.common import (
+    get_compile_option_owner,
+    get_wrapper_codegen_for_device,
+    init_backend_registration,
+    patch_compile_options,
+)
 from .debug import DebugContext
 from .decomposition import select_decomp_table
 from .exc import InductorError
@@ -972,10 +977,19 @@ def fake_tensor_prop(
 
 # pass config dict back to user
 def get_patched_config_dict(
-    config_patches: str | dict[str, Any] | None = None,
+    config_patches: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    with config.patch(config_patches):
-        return config.get_config_copy()
+    with patch_compile_options(config_patches):
+        config_copy = config.get_config_copy()
+        for name in config_patches or {}:
+            # core inductor keys take precedence over device namespaces
+            if name.replace("-", "_") in config._config:  # type: ignore[attr-defined]
+                continue
+            route = get_compile_option_owner(name)
+            if route is not None:
+                owner_config, key = route
+                config_copy[name] = getattr(owner_config, key)
+        return config_copy
 
 
 @contextlib.contextmanager
@@ -3098,6 +3112,10 @@ def compile_fx(
     function orchestrates end-to-end compilation for the inductor backend when
     you use :func:`torch.compile`.
 
+    Entries of ``config_patches`` of the form ``"<device>.<key>"`` are
+    patched onto that device's ``device_custom_config`` module instead of
+    ``torch._inductor.config``.
+
     NB: This function TAKES OWNERSHIP of the input ``model_`` and can potentially
     mutate it!  Make a copy if you need to preserve the original GraphModule.
     """
@@ -3118,12 +3136,12 @@ def compile_fx(
         return model_
 
     if config_patches:
-        with config.patch(config_patches):
+        with patch_compile_options(config_patches):
             return compile_fx(
                 model_,
                 example_inputs_,
                 # need extra layer of patching as backwards is compiled out of scope
-                inner_compile=config.patch(config_patches)(inner_compile),
+                inner_compile=patch_compile_options(config_patches)(inner_compile),
                 decompositions=decompositions,
                 ignore_shape_env=ignore_shape_env,
                 compile_region_name=compile_region_name,

--- a/torch/_inductor/compile_fx_ext.py
+++ b/torch/_inductor/compile_fx_ext.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import functools
+import importlib
 import logging
 import os
 import queue
@@ -29,6 +30,7 @@ from torch._subclasses import FakeTensorMode
 from torch.utils._ordered_set import OrderedSet
 
 from . import config
+from .codegen.common import custom_backend_codegen_configs
 from .compile_fx import _CompileFxKwargs, _InProcessFxCompile, FxCompile, log
 from .debug import DebugContext
 from .graph import GraphLowering
@@ -216,6 +218,10 @@ class _WireProtocolInput:
     graph_kwargs: _CompileFxKwargs
     tracing_context: torch._guards.TracingContext | None
     config: dict[str, object]
+    # backend configs from the parent process ({module: {key: value}}),
+    # applied in the child instead of reading the worker's own backend
+    # config state
+    backend_configs: dict[str, dict[str, object]]
     virtualized: _VirtualizedSerializer
     deterministic_guard_for_testing: (  # type: ignore[name-defined]  # mypy bug
         torch.testing._internal.common_utils.DeterministicGuard | None
@@ -521,6 +527,11 @@ class _SerializedFxCompile(FxCompile):
                 graph_kwargs,
                 context,
                 config.save_config_portable(),
+                {
+                    m.__name__: m.get_serializable_config_copy()
+                    for m in custom_backend_codegen_configs.values()
+                    if m is not None
+                },
                 _VirtualizedSerializer.serialize(),
                 deterministic_guard_for_testing,
                 logger_state,
@@ -571,6 +582,8 @@ class _SerializedFxCompile(FxCompile):
             stack.enter_context(input.virtualized.patch())
             stack.enter_context(input.lowering.patch())
             stack.enter_context(config.patch(input.config))
+            for name, values in input.backend_configs.items():
+                stack.enter_context(importlib.import_module(name).patch(values))
             captured_logs = stack.enter_context(input.logger_state)
             if input.deterministic_guard_for_testing:
                 stack.enter_context(input.deterministic_guard_for_testing)

--- a/torch/_inductor/standalone_compile.py
+++ b/torch/_inductor/standalone_compile.py
@@ -31,6 +31,7 @@ from ._functionalize_collectives import (
     _functionalize_inplace_collectives,
     _unbox_process_group_torchbinds,
 )
+from .codegen.common import patch_compile_options
 
 
 if TYPE_CHECKING:
@@ -842,7 +843,7 @@ def compile_to_python(
     # CacheArtifactManager isolates the cache bundle ``_acceleration_cache_bytes`` returns.
     with (
         torch.no_grad(),
-        config.patch(config_patches),
+        patch_compile_options(config_patches),
         config.patch("triton.autotune_at_compile_time", True),
         tracing(TracingContext(fake_mode)),
         V.set_fake_mode(fake_mode),


### PR DESCRIPTION
### Motivation

Inductor backends can register a backend-owned `ConfigModule` through `register_backend_for_device(device_custom_config=...)`, but values from that module cannot currently be supplied through `torch.compile(options=...)`.

### Proposal

Allow backend config values to be addressed as `"<device>.<key>"` compile options:

```python
register_backend_for_device(
    "my_device",
    MyScheduling,
    MyWrapperCodegen,
    MyCppWrapperCodegen,
    device_custom_config=my_backend_config,
)

torch.compile(model, options={"my_device.my_config_key": 1})
```

Core Inductor option names take precedence over device namespaces. Backend registration is initialized on demand before resolving a namespaced option.

The same routing is used by `torch.compile`, direct Inductor compilation, AOTI, and standalone compilation. For subprocess compilation, registered backend configs are captured in the parent and applied in the worker.

Backend config values use the existing `device_custom_config` FX graph cache-key integration.


### Test Plan

```bash
python test/inductor/test_compile_options.py -v
python test/inductor/test_config.py -v
```

> AI-Assisted: Author reviewed and validated all AI-generated content.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo