### PR TITLE
[Testcase Refactoring] Add new class MultiProcContinuousForInstantiateTest

### DIFF
--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -2281,3 +2281,16 @@ class C10dTorchCommsTestBase(MultiProcContinuousTest):
     def rank_to_device(self, device):
         num_visible_devices = torch.get_device_module(device).device_count()
         return {i: [i % num_visible_devices] for i in range(self.world_size)}
+
+
+class MultiProcContinuousForInstantiateTest(MultiProcContinuousTest):
+
+    @classmethod
+    def backend_str(cls) -> str:
+        return c10d.get_default_backend_for_device(cls.device_type)
+
+    @property
+    def current_device(self) -> torch.device:
+        if self.rank < 0 or self.device_type == "cpu":
+            return torch.device(self.device_type)
+        return torch.device(self.device_type, self.rank)


### PR DESCRIPTION
## Summary

Added a new test base class `MultiProcContinuousForInstantiateTest` in
`torch/testing/_internal/common_distributed.py`. It is a thin subclass of
`MultiProcContinuousTest` that bridges the continuous-worker distributed test
base with device-type-parameterized test classes generated by
`instantiate_device_type_tests` (the `ComposabilityTest` use case), so that
distributed tests can resolve the communication backend and the per-rank
device through the base class instead of re-implementing them per test.

## Changes

### New class: MultiProcContinuousForInstantiateTest (extends MultiProcContinuousTest)

1. `backend_str()` classmethod
   - Returns `c10d.get_default_backend_for_device(cls.device_type)`.
   - The backend (nccl / hccl / gloo / ...) is resolved dynamically from the
     framework registry, keyed by the `device_type` string class attribute
     that `instantiate_device_type_tests` injects on the generated subclass.

2. `current_device` property
   - Gives every test a concrete per-rank device without duplicating the
     `(device_type, rank) -> torch.device` mapping in each test class.

### What the class intentionally does NOT do
- Does not override `_init_pg`: the parent's `_init_pg` already performs
  accelerator detection via `torch.accelerator.current_accelerator()` /
  `torch.accelerator.device_count()`, per-rank device binding via
  `torch.accelerator.set_device_index(rank % device_count)`, and per-rank
  HCCL port segmentation (`HCCL_NPU_SOCKET_PORT_RANGE`) for the NPU/hccl case.
- Does not define a `device` attribute: tests should use either the `device`
  kwarg injected by `instantiate_test` (string form, e.g. "npu:0") or
  `self.current_device` (torch.device form).

## Motivation

`MultiProcContinuousTest` requires a working `backend_str()` to call
`c10d.init_process_group` inside `_init_pg`, but the parent class does not
define `backend_str()` or `device_type` itself. Device-type test classes
produced by `instantiate_device_type_tests` receive a `device_type` string
class attribute, but no backend resolution and no device helper. Before this
change, every distributed test that wanted to be parameterized over device
types (e.g. `ComposabilityTest`) had to re-implement both on its own, which
was redundant and error-prone (a previous bug where `self.device_type`
evaluated to a classmethod object rather than a string came from exactly
this gap).

## Test Plan

Verified on the composability distributed test suite, e.g.:

```
python test/distributed/test_composability.py
```

## Notes
