### PR TITLE
[3/3][Test] Generalize `export/test_experimental.py` tests and enable on XPU

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -1692,12 +1692,13 @@ class TestExperimentDevice(TestCase):
                 kwargs={},
                 keep_inference_input_mutations=True,
             )
+            device_name = torch.device(device).type
             self.assertExpectedInline(
                 str(joint_with_descriptors.graph_module.code).strip(),
                 f"""\
 def forward(self, arg0_1):
-    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='{device}', index=0), pin_memory = False)
-    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='{device}', index=0), pin_memory = False)
+    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='{device_name}', index=0), pin_memory = False)
+    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='{device_name}', index=0), pin_memory = False)
     add = torch.ops.aten.add.Tensor(arange_3, 4);  arange_3 = None
     view = torch.ops.aten.view.default(arange_2, [64, 1]);  arange_2 = None
     ge = torch.ops.aten.ge.Tensor(view, add);  view = add = None
@@ -1728,19 +1729,19 @@ def forward(self, arg0_1):
     _to_copy_6 = torch.ops.aten._to_copy.default(sum_3, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_3 = None
     _to_copy_7 = torch.ops.aten._to_copy.default(getitem_3, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_3 = None
     new_zeros = torch.ops.aten.new_zeros.default(_to_copy_4, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
+    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device_name}', index=0), pin_memory = False)
     unsqueeze_2 = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
-    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
+    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device_name}', index=0), pin_memory = False)
     unsqueeze_3 = torch.ops.aten.unsqueeze.default(_to_copy_3, 3)
     lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_3);  arange_5 = unsqueeze_3 = None
-    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{device}', index=0))
+    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{device_name}', index=0))
     where = torch.ops.aten.where.self(lt_1, _to_copy_4, scalar_tensor);  lt_1 = scalar_tensor = None
     new_ones = torch.ops.aten.new_ones.default(new_zeros, [1, 1], pin_memory = False)
-    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
+    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device_name}', index=0))
     unsqueeze_4 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
     unsqueeze_5 = torch.ops.aten.unsqueeze.default(unsqueeze_4, -1);  unsqueeze_4 = None
     view_2 = torch.ops.aten.view.default(new_ones, [1, 1, 1, 1]);  new_ones = None
-    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
+    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device_name}', index=0))
     unsqueeze_6 = torch.ops.aten.unsqueeze.default(arange_7, -1);  arange_7 = None
     unsqueeze_7 = torch.ops.aten.unsqueeze.default(unsqueeze_6, -1);  unsqueeze_6 = None
     unsqueeze_8 = torch.ops.aten.unsqueeze.default(unsqueeze_7, -1);  unsqueeze_7 = None
@@ -1753,19 +1754,19 @@ def forward(self, arg0_1):
     _to_copy_8 = torch.ops.aten._to_copy.default(sum_4, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_4 = None
     _to_copy_9 = torch.ops.aten._to_copy.default(getitem_5, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_5 = None
     new_zeros_1 = torch.ops.aten.new_zeros.default(_to_copy_7, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
+    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device_name}', index=0), pin_memory = False)
     unsqueeze_9 = torch.ops.aten.unsqueeze.default(arange_8, -1);  arange_8 = None
-    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
+    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device_name}', index=0), pin_memory = False)
     unsqueeze_10 = torch.ops.aten.unsqueeze.default(_to_copy_6, 3)
     lt_2 = torch.ops.aten.lt.Tensor(arange_9, unsqueeze_10);  arange_9 = unsqueeze_10 = None
-    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{device}', index=0))
+    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{device_name}', index=0))
     where_1 = torch.ops.aten.where.self(lt_2, _to_copy_7, scalar_tensor_1);  lt_2 = scalar_tensor_1 = None
     new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [1, 1], pin_memory = False)
-    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
+    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device_name}', index=0))
     unsqueeze_11 = torch.ops.aten.unsqueeze.default(arange_10, -1);  arange_10 = None
     unsqueeze_12 = torch.ops.aten.unsqueeze.default(unsqueeze_11, -1);  unsqueeze_11 = None
     view_3 = torch.ops.aten.view.default(new_ones_1, [1, 1, 1, 1]);  new_ones_1 = None
-    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
+    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device_name}', index=0))
     unsqueeze_13 = torch.ops.aten.unsqueeze.default(arange_11, -1);  arange_11 = None
     unsqueeze_14 = torch.ops.aten.unsqueeze.default(unsqueeze_13, -1);  unsqueeze_13 = None
     unsqueeze_15 = torch.ops.aten.unsqueeze.default(unsqueeze_14, -1);  unsqueeze_14 = None
@@ -1886,7 +1887,9 @@ def forward(self, arg0_1):
 
 
 instantiate_device_type_tests(TestExperimentCPU, globals(), only_for="cpu")
-instantiate_device_type_tests(TestExperimentDevice, globals(), only_for="cuda")
+instantiate_device_type_tests(
+    TestExperimentDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -193,49 +193,6 @@ def forward(self, p_linear_weight, p_linear_bias, c_lifted_tensor_0, x):
     return (div, permute_3, view_3)""",
         )
 
-    def _test_export_blockmask_with_mask_fn(self, make_mask_fn):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        class Model(torch.nn.Module):
-            def __init__(self, mask_fn_factory):
-                super().__init__()
-                self.mask_fn_factory = mask_fn_factory
-
-            def forward(self, x):
-                mask_fn = self.mask_fn_factory()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model(make_mask_fn)
-
-        out_eager, mask_eager = module(x)
-
-        compiled = _dynamo_graph_capture_for_export(module)(x)
-        out_compiled, mask_compiled = compiled(x)
-
-        self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(
-            mask_eager.mask_mod(1, 1, 64, 64),
-            mask_compiled.mask_mod(1, 1, 64, 64),
-        )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask(self):
-        def make_mask_fn():
-            res = 4
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
     def test_export_with_default_kwargs(self):
         class FunctionalWrapper(torch.nn.Module):
             """Wrapper with keyword-only argument in __call__."""
@@ -270,54 +227,6 @@ def forward(self, args_0):
     out = torch._C._nn.linear(l_args_0_, l_self_modules_module_parameters_weight_, l_self_modules_module_parameters_bias_);  l_args_0_ = l_self_modules_module_parameters_weight_ = l_self_modules_module_parameters_bias_ = None
     return self._dynamo_bytecode_unflatten((out,), _fn_args)""",
         )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_mutated_closure(self):
-        def make_mask_fn():
-            res = 1
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            res = 4  # mutation after function definition
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_with_containers(self):
-        def make_mask_fn():
-            offsets = [1, 2, 3]
-            config = {"base": 4, "nested": {"scale": 2}}
-
-            def fn(b, h, q, k):
-                return q >= k + config["base"] + sum(offsets)
-
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_triple_nested(self):
-        def make_mask_fn():
-            a = 1
-
-            def level1():
-                b = 2
-
-                def level2():
-                    c = 3
-
-                    def fn(bx, h, q, k):
-                        return q >= k + a + b + c
-
-                    return fn
-
-                return level2()
-
-            return level1()
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_self_recursive(self):
@@ -1551,74 +1460,6 @@ def forward(self, arg0_1):
         _, spec_c = pytree.tree_flatten(mask_c)
         self.assertNotEqual(spec_a, spec_c)
 
-    def _assert_blockmask_partial_replays_bound_tensors(self, make_mask_mod):
-        from torch.fx.experimental.proxy_tensor import make_fx
-        from torch.nn.attention.flex_attention import BlockMask, create_block_mask
-
-        query_indices = torch.arange(8, dtype=torch.int32)[:, None]
-        key_indices = torch.arange(8, dtype=torch.int32)[None, :]
-        document_ids = torch.zeros(8, dtype=torch.int64)
-        batch0_attn_regions = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], dtype=torch.int32)
-        batch1_attn_regions = torch.tensor([0, 0, 1, 1, 0, 0, 1, 1], dtype=torch.int32)
-
-        def mask_rule(batch, head, query_idx, key_idx, attn_regions, document_ids):
-            return (
-                (query_idx >= key_idx)
-                & (attn_regions[query_idx] == attn_regions[key_idx])
-                & (document_ids[query_idx] == document_ids[key_idx])
-            )
-
-        def build_block_mask(attn_regions):
-            return create_block_mask(
-                make_mask_mod(mask_rule, attn_regions, document_ids),
-                B=1,
-                H=1,
-                Q_LEN=8,
-                KV_LEN=8,
-                device="cpu",
-                BLOCK_SIZE=4,
-            )
-
-        def trace_mask_mod(attn_regions):
-            block_mask = build_block_mask(attn_regions)
-            flat_leaves, spec = block_mask._flatten()
-            return make_fx(
-                lambda *flat_leaves: BlockMask._unflatten(flat_leaves, spec).mask_mod(
-                    0, 0, query_indices, key_indices
-                )
-            )(*flat_leaves)
-
-        traced_mask_mod = trace_mask_mod(batch0_attn_regions)
-        replayed_batch1 = traced_mask_mod(
-            *build_block_mask(batch1_attn_regions)._flatten()[0]
-        )
-        expected_batch0 = build_block_mask(batch0_attn_regions).mask_mod(
-            0, 0, query_indices, key_indices
-        )
-        expected_batch1 = build_block_mask(batch1_attn_regions).mask_mod(
-            0, 0, query_indices, key_indices
-        )
-
-        self.assertFalse(torch.equal(replayed_batch1, expected_batch0))
-        self.assertTrue(torch.equal(replayed_batch1, expected_batch1))
-
-    def test_blockmask_partial_extraction_replays_bound_tensors(self):
-        self._assert_blockmask_partial_replays_bound_tensors(
-            lambda mask_rule, attn_regions, document_ids: functools.partial(
-                mask_rule,
-                attn_regions=attn_regions,
-                document_ids=document_ids,
-            )
-        )
-
-    def test_blockmask_recursive_partial_extraction_replays_bound_tensors(self):
-        self._assert_blockmask_partial_replays_bound_tensors(
-            lambda mask_rule, attn_regions, document_ids: functools.partial(
-                functools.partial(mask_rule, attn_regions=attn_regions),
-                document_ids=document_ids,
-            )
-        )
-
     def test_mask_mod_wrapper_eq_for_partials(self):
         from torch.nn.attention.flex_attention import (
             _extract_callable_pytree,
@@ -1700,46 +1541,6 @@ def forward(self, arg0_1):
 
         self.assertEqual(wrapped_a, wrapped_b)
         self.assertEqual(hash(wrapped_a), hash(wrapped_b))
-
-    def test_blockmask_self_referential_function_closure_extraction(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_mod():
-            def helper():
-                return helper
-
-            def mask_mod(batch, head, query_idx, key_idx):
-                del batch, head
-                _ = helper
-                return query_idx >= key_idx
-
-            return mask_mod
-
-        mask_a = create_block_mask(
-            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
-        )
-        mask_b = create_block_mask(
-            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
-        )
-
-        leaves_a, spec_a = pytree.tree_flatten(mask_a)
-        leaves_b, spec_b = pytree.tree_flatten(mask_b)
-
-        self.assertEqual(spec_a, spec_b)
-
-        restored = pytree.tree_unflatten(leaves_a, spec_a)
-        self.assertTrue(
-            torch.equal(
-                restored.mask_mod(
-                    0, 0, torch.arange(8)[:, None], torch.arange(8)[None, :]
-                ),
-                mask_a.mask_mod(
-                    0, 0, torch.arange(8)[:, None], torch.arange(8)[None, :]
-                ),
-            )
-        )
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_blockmask_and_masks_closure_extraction(self):
@@ -1883,6 +1684,205 @@ def forward(self, arg0_1):
                 eager_buf,
                 msg=lambda msg: f"{msg}\n{label}: buffer mutation mismatch",
             )
+
+    def _assert_blockmask_partial_replays_bound_tensors(self, make_mask_mod):
+        from torch.fx.experimental.proxy_tensor import make_fx
+        from torch.nn.attention.flex_attention import BlockMask, create_block_mask
+
+        query_indices = torch.arange(8, dtype=torch.int32)[:, None]
+        key_indices = torch.arange(8, dtype=torch.int32)[None, :]
+        document_ids = torch.zeros(8, dtype=torch.int64)
+        batch0_attn_regions = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1], dtype=torch.int32)
+        batch1_attn_regions = torch.tensor([0, 0, 1, 1, 0, 0, 1, 1], dtype=torch.int32)
+
+        def mask_rule(batch, head, query_idx, key_idx, attn_regions, document_ids):
+            return (
+                (query_idx >= key_idx)
+                & (attn_regions[query_idx] == attn_regions[key_idx])
+                & (document_ids[query_idx] == document_ids[key_idx])
+            )
+
+        def build_block_mask(attn_regions):
+            return create_block_mask(
+                make_mask_mod(mask_rule, attn_regions, document_ids),
+                B=1,
+                H=1,
+                Q_LEN=8,
+                KV_LEN=8,
+                device="cpu",
+                BLOCK_SIZE=4,
+            )
+
+        def trace_mask_mod(attn_regions):
+            block_mask = build_block_mask(attn_regions)
+            flat_leaves, spec = block_mask._flatten()
+            return make_fx(
+                lambda *flat_leaves: BlockMask._unflatten(flat_leaves, spec).mask_mod(
+                    0, 0, query_indices, key_indices
+                )
+            )(*flat_leaves)
+
+        traced_mask_mod = trace_mask_mod(batch0_attn_regions)
+        replayed_batch1 = traced_mask_mod(
+            *build_block_mask(batch1_attn_regions)._flatten()[0]
+        )
+        expected_batch0 = build_block_mask(batch0_attn_regions).mask_mod(
+            0, 0, query_indices, key_indices
+        )
+        expected_batch1 = build_block_mask(batch1_attn_regions).mask_mod(
+            0, 0, query_indices, key_indices
+        )
+
+        self.assertFalse(torch.equal(replayed_batch1, expected_batch0))
+        self.assertTrue(torch.equal(replayed_batch1, expected_batch1))
+
+    def test_blockmask_partial_extraction_replays_bound_tensors(self):
+        self._assert_blockmask_partial_replays_bound_tensors(
+            lambda mask_rule, attn_regions, document_ids: functools.partial(
+                mask_rule,
+                attn_regions=attn_regions,
+                document_ids=document_ids,
+            )
+        )
+
+    def test_blockmask_recursive_partial_extraction_replays_bound_tensors(self):
+        self._assert_blockmask_partial_replays_bound_tensors(
+            lambda mask_rule, attn_regions, document_ids: functools.partial(
+                functools.partial(mask_rule, attn_regions=attn_regions),
+                document_ids=document_ids,
+            )
+        )
+
+    def test_blockmask_self_referential_function_closure_extraction(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_mod():
+            def helper():
+                return helper
+
+            def mask_mod(batch, head, query_idx, key_idx):
+                del batch, head
+                _ = helper
+                return query_idx >= key_idx
+
+            return mask_mod
+
+        mask_a = create_block_mask(
+            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
+        )
+        mask_b = create_block_mask(
+            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
+        )
+
+        leaves_a, spec_a = pytree.tree_flatten(mask_a)
+        leaves_b, spec_b = pytree.tree_flatten(mask_b)
+
+        self.assertEqual(spec_a, spec_b)
+
+        restored = pytree.tree_unflatten(leaves_a, spec_a)
+        self.assertTrue(
+            torch.equal(
+                restored.mask_mod(
+                    0, 0, torch.arange(8)[:, None], torch.arange(8)[None, :]
+                ),
+                mask_a.mask_mod(
+                    0, 0, torch.arange(8)[:, None], torch.arange(8)[None, :]
+                ),
+            )
+        )
+
+    def _test_export_blockmask_with_mask_fn(self, make_mask_fn):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        class Model(torch.nn.Module):
+            def __init__(self, mask_fn_factory):
+                super().__init__()
+                self.mask_fn_factory = mask_fn_factory
+
+            def forward(self, x):
+                mask_fn = self.mask_fn_factory()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device="cuda")
+        module = Model(make_mask_fn)
+
+        out_eager, mask_eager = module(x)
+
+        compiled = _dynamo_graph_capture_for_export(module)(x)
+        out_compiled, mask_compiled = compiled(x)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(
+            mask_eager.mask_mod(1, 1, 64, 64),
+            mask_compiled.mask_mod(1, 1, 64, 64),
+        )
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask(self):
+        def make_mask_fn():
+            res = 4
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask_mutated_closure(self):
+        def make_mask_fn():
+            res = 1
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            res = 4  # mutation after function definition
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask_closure_with_containers(self):
+        def make_mask_fn():
+            offsets = [1, 2, 3]
+            config = {"base": 4, "nested": {"scale": 2}}
+
+            def fn(b, h, q, k):
+                return q >= k + config["base"] + sum(offsets)
+
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask_closure_triple_nested(self):
+        def make_mask_fn():
+            a = 1
+
+            def level1():
+                b = 2
+
+                def level2():
+                    c = 3
+
+                    def fn(bx, h, q, k):
+                        return q >= k + a + b + c
+
+                    return fn
+
+                return level2()
+
+            return level1()
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn)
 
 
 if __name__ == "__main__":

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -228,272 +228,6 @@ def forward(self, args_0):
     return self._dynamo_bytecode_unflatten((out,), _fn_args)""",
         )
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_self_recursive(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            # Self-referential: fn captures itself through the closure
-            def fn(b, h, q, k):
-                _ = fn  # self-reference
-                return q >= k + 4
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_tensor(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            tensor = torch.ones(2, 2)
-
-            def fn(b, h, q, k):
-                _ = fn
-                return q >= k + 4 + tensor.sum()
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_unsupported_class_instance(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        class MaskConfig:
-            def __init__(self, offset):
-                self.offset = offset
-
-        def make_mask_fn():
-            cfg = MaskConfig(offset=5)
-
-            def fn(b, h, q, k):
-                return q >= k + cfg.offset
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_mutually_recursive(self):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            # Create mutually recursive closures: fn_a references fn_b, fn_b references fn_a
-            # This is non-constructible because we cannot serialize mutually recursive closures
-            def fn_a(b, h, q, k):
-                _ = fn_b  # reference to fn_b
-                return q >= k
-
-            def fn_b(b, h, q, k):
-                _ = fn_a  # reference to fn_a
-                return q >= k + 1
-
-            return fn_a
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model()
-
-        with self.assertRaisesRegex(
-            torch._dynamo.exc.Unsupported,
-            "nested function with non-constructible closure in output",
-        ):
-            _dynamo_graph_capture_for_export(module)(x)
-
-    @unittest.skipUnless(
-        IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
-        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
-    )
-    def test_aot_export_flex_attention_callable_mask_mod(self):
-        """Test flex_attention AOT export with callable class as mask_mod.
-
-        _MaskModWrapper must delegate __eq__ to callable objects for TreeSpec
-        comparison in AOTAutograd's PytreeThunk.set() (utils.py:162).
-        """
-        from torch._functorch.aot_autograd import aot_export_module
-        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
-
-        _register_blockmask_pytree()
-
-        class ComposedMaskMod:
-            def __init__(self, *mask_fns):
-                self.mask_fns = mask_fns
-
-            def __call__(self, b, h, q, k):
-                result = True
-                for fn in self.mask_fns:
-                    result = result & fn(b, h, q, k)
-                return result
-
-            def __eq__(self, other):
-                if not isinstance(other, ComposedMaskMod):
-                    return NotImplemented
-                return self.mask_fns == other.mask_fns
-
-            def __hash__(self):
-                return hash(self.mask_fns)
-
-        def causal_mask(b, h, q, k):
-            return q >= k
-
-        class FlexAttentionModel(torch.nn.Module):
-            def __init__(self, embed_dim: int, num_heads: int):
-                super().__init__()
-                self.num_heads = num_heads
-                self.head_dim = embed_dim // num_heads
-                self.q_proj = torch.nn.Linear(embed_dim, embed_dim)
-                self.k_proj = torch.nn.Linear(embed_dim, embed_dim)
-                self.v_proj = torch.nn.Linear(embed_dim, embed_dim)
-
-            def forward(self, x):
-                B, L, D = x.shape
-                q = self.q_proj(x).view(B, L, self.num_heads, self.head_dim)
-                k = self.k_proj(x).view(B, L, self.num_heads, self.head_dim)
-                v = self.v_proj(x).view(B, L, self.num_heads, self.head_dim)
-                q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
-
-                mask_mod = ComposedMaskMod(causal_mask)
-                block_mask = create_block_mask(
-                    mask_mod, B=B, H=self.num_heads, Q_LEN=L, KV_LEN=L, device=x.device
-                )
-                out = flex_attention(q, k, v, block_mask=block_mask)
-                return (out.transpose(1, 2).contiguous().view(B, L, D),)
-
-        embed_dim, num_heads, seq_len = 64, 2, 128
-        model = FlexAttentionModel(embed_dim, num_heads).cuda()
-        x = torch.randn(1, seq_len, embed_dim, device="cuda")
-
-        gm, signature = aot_export_module(model, [x], trace_joint=False)
-
-        # aot_export_module flattens params/buffers into the graph signature
-        params = [p for p in model.parameters()]
-        out_eager = model(x)[0]
-        out_export = gm(*params, x)[0]
-        self.assertEqual(out_eager.shape, out_export.shape)
-        self.assertTrue(torch.allclose(out_eager, out_export, atol=1e-5))
-
-    @unittest.skipUnless(
-        IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
-        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
-    )
-    def test_aot_export_flex_attention_with_blockmask_placeholders(self):
-        from torch._subclasses.fake_tensor import FakeTensorMode
-        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
-
-        _register_blockmask_pytree()
-
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.wq = torch.nn.Linear(64, 64, bias=False)
-                self.block_mask = create_block_mask(
-                    lambda b, h, q, kv: q >= kv,
-                    B=None,
-                    H=None,
-                    Q_LEN=16,
-                    KV_LEN=16,
-                    device="cuda",
-                )
-
-            def forward(self, x):
-                q = self.wq(x).view(1, 16, 4, 16).transpose(1, 2)
-                return flex_attention(q, q, q, block_mask=self.block_mask).sum()
-
-        with torch.device("meta"):
-            model = Model()
-
-        fake_mode = FakeTensorMode()
-        with fake_mode:
-            for name, param in list(model.named_parameters()):
-                parts = name.split(".")
-                mod = model
-                for part in parts[:-1]:
-                    mod = getattr(mod, part)
-                setattr(
-                    mod,
-                    parts[-1],
-                    torch.nn.Parameter(
-                        torch.empty(param.shape, dtype=param.dtype, device="cuda"),
-                        requires_grad=param.requires_grad,
-                    ),
-                )
-            x = torch.randn(1, 16, 64, device="cuda")
-
-        gm = dynamo_graph_capture_for_export(model)(x)
-        block_mask_placeholders = [
-            node
-            for node in gm.graph.nodes
-            if node.op == "placeholder" and "block_mask" in node.name
-        ]
-        self.assertGreater(len(block_mask_placeholders), 0)
-
-        with contextlib.ExitStack() as stack:
-            joint_with_descriptors = aot_export_joint_with_descriptors(stack, gm, (x,))
-
-        self.assertIsNotNone(joint_with_descriptors.graph_module)
-
     def test_joint_dynamic(self) -> None:
         from torch.export import Dim
 
@@ -1081,69 +815,6 @@ def forward(self, args_0):
         self.assertEqual(gm_results, foo(*test_inputs))
         self.assertEqual(len(GLOBAL_LIST), 1)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_dynamo_graph_capture_fx_graph_annotate_overlap_pass(self):
-        class DummyOp(torch.autograd.Function):
-            @staticmethod
-            def forward(ctx, x, scalar):
-                ctx.save_for_backward(x)
-                return x + scalar
-
-            @staticmethod
-            def backward(ctx, grad_out):
-                return grad_out, None
-
-        def mock_fw_compute(x):
-            with fx_traceback.annotate({"compute": 0}):
-                return DummyOp.apply(x, 10)
-
-        def mock_bw_comm(x):
-            with fx_traceback.annotate({"comm": 0}):
-                return DummyOp.apply(x, 20)
-
-        def mock_bw_compute(x):
-            return DummyOp.apply(x, 30)
-
-        class Model(torch.nn.Module):
-            def forward(self, fw_in, bw_in):
-                fw_out = mock_fw_compute(fw_in)
-                # bw_in blocks bw_out
-                bw_in = mock_bw_comm(bw_in)
-                bw_out = mock_bw_compute(bw_in)
-                return fw_out, bw_out
-
-        def input_fn():
-            inputs = (torch.rand(2, 128, device="cuda", requires_grad=True),)
-            grad_ins = (torch.rand(2, 128, device="cuda"),)
-            return (
-                *inputs,
-                *grad_ins,
-            )
-
-        with torch.device("meta"):
-            model = Model()
-
-        import torch.fx.traceback as fx_traceback
-
-        with fx_traceback.preserve_node_meta():
-            gm = dynamo_graph_capture_for_export(model)(*input_fn())
-
-        """
-        def forward(self, args_0, args_1):
-            _tree_leaf_0, _tree_leaf_1, _tree_leaf_2, = pytree.tree_leaves((self, args_0, args_1,))
-            L_fw_in_ , L_bw_in_ , = self._in_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2)
-            l_fw_in_ = L_fw_in_
-            l_bw_in_ = L_bw_in_
-            fwd_body_0 = self.fwd_body_0
-            bwd_body_0 = self.bwd_body_0
-            fw_out = torch.ops.higher_order.autograd_function_apply(fwd_body_0, bwd_body_0, l_fw_in_, args_tensor_mask = [True, False], non_differentiable_idx = []);  fwd_body_0 = bwd_body_0 = l_fw_in_ = None
-            bw_in = l_bw_in_ + 20;  l_bw_in_ = None
-            bw_out = bw_in + 30;  bw_in = None
-            return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2, fw_out, bw_out), self._out_spec)
-        """
-        test_inputs = input_fn()
-        self.assertEqual(gm(*test_inputs), model(*test_inputs))
-
     def test_dynamo_graph_capture_default_args(self):
         class Module(torch.nn.Module):
             def forward(self, x, y=1):
@@ -1272,194 +943,6 @@ def forward(self, args_0):
         with self.assertRaises(TypeError):
             _restore_state_dict(lambda x: x, gm)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_aot_export_blockmask_with_new_closure(self):
-        import contextlib
-
-        from torch._export.utils import _compiling_state_context
-        from torch._functorch.aot_autograd import (
-            aot_compile_joint_with_descriptors,
-            aot_export_joint_with_descriptors,
-        )
-        from torch._guards import tracing as torch_tracing, TracingContext
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn():
-            res = 4
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            return fn
-
-        class Model(torch.nn.Module):
-            def forward(self, x):
-                mask_fn = make_mask_fn()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        args = (torch.randn(2, 128, device="cuda"),)
-        gm = dynamo_graph_capture_for_export(Model())(*args)
-
-        fake_mode = gm.meta["fake_mode"]
-        with contextlib.ExitStack() as stack:
-            stack.enter_context(torch_tracing(TracingContext(fake_mode)))
-            stack.enter_context(_compiling_state_context())
-            stack.enter_context(fake_mode)
-
-            joint_with_descriptors = aot_export_joint_with_descriptors(
-                stack,
-                gm,
-                args=args,
-                kwargs={},
-                keep_inference_input_mutations=True,
-            )
-            self.assertExpectedInline(
-                str(joint_with_descriptors.graph_module.code).strip(),
-                """\
-def forward(self, arg0_1):
-    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
-    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
-    add = torch.ops.aten.add.Tensor(arange_3, 4);  arange_3 = None
-    view = torch.ops.aten.view.default(arange_2, [64, 1]);  arange_2 = None
-    ge = torch.ops.aten.ge.Tensor(view, add);  view = add = None
-    unsqueeze = torch.ops.aten.unsqueeze.default(ge, 0);  ge = None
-    expand = torch.ops.aten.expand.default(unsqueeze, [1, 64, 64]);  unsqueeze = None
-    unsqueeze_1 = torch.ops.aten.unsqueeze.default(expand, 0);  expand = None
-    expand_1 = torch.ops.aten.expand.default(unsqueeze_1, [1, 1, 64, 64]);  unsqueeze_1 = None
-    constant_pad_nd = torch.ops.aten.constant_pad_nd.default(expand_1, [0, 64, 0, 64], 0.0);  expand_1 = None
-    view_1 = torch.ops.aten.view.default(constant_pad_nd, [1, 1, 1, 128, 1, 128]);  constant_pad_nd = None
-    permute = torch.ops.aten.permute.default(view_1, [0, 1, 2, 4, 3, 5]);  view_1 = None
-    sum_1 = torch.ops.aten.sum.dim_IntList(permute, [-2, -1]);  permute = None
-    eq = torch.ops.aten.eq.Scalar(sum_1, 16384)
-    gt = torch.ops.aten.gt.Scalar(sum_1, 0)
-    lt = torch.ops.aten.lt.Scalar(sum_1, 16384);  sum_1 = None
-    bitwise_and = torch.ops.aten.bitwise_and.Tensor(gt, lt);  gt = lt = None
-    _to_copy = torch.ops.aten._to_copy.default(bitwise_and, dtype = torch.int8);  bitwise_and = None
-    _to_copy_1 = torch.ops.aten._to_copy.default(eq, dtype = torch.int8);  eq = None
-    _to_copy_2 = torch.ops.aten._to_copy.default(_to_copy, dtype = torch.int32);  _to_copy = None
-    sum_2 = torch.ops.aten.sum.dim_IntList(_to_copy_2, [-1])
-    sort = torch.ops.aten.sort.stable(_to_copy_2, stable = True, descending = True);  _to_copy_2 = None
-    getitem_1 = sort[1];  sort = None
-    _to_copy_3 = torch.ops.aten._to_copy.default(sum_2, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_2 = None
-    _to_copy_4 = torch.ops.aten._to_copy.default(getitem_1, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_1 = None
-    _to_copy_5 = torch.ops.aten._to_copy.default(_to_copy_1, dtype = torch.int32);  _to_copy_1 = None
-    sum_3 = torch.ops.aten.sum.dim_IntList(_to_copy_5, [-1])
-    sort_1 = torch.ops.aten.sort.stable(_to_copy_5, stable = True, descending = True);  _to_copy_5 = None
-    getitem_3 = sort_1[1];  sort_1 = None
-    _to_copy_6 = torch.ops.aten._to_copy.default(sum_3, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_3 = None
-    _to_copy_7 = torch.ops.aten._to_copy.default(getitem_3, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_3 = None
-    new_zeros = torch.ops.aten.new_zeros.default(_to_copy_4, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_2 = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
-    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_3 = torch.ops.aten.unsqueeze.default(_to_copy_3, 3)
-    lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_3);  arange_5 = unsqueeze_3 = None
-    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
-    where = torch.ops.aten.where.self(lt_1, _to_copy_4, scalar_tensor);  lt_1 = scalar_tensor = None
-    new_ones = torch.ops.aten.new_ones.default(new_zeros, [1, 1], pin_memory = False)
-    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_4 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
-    unsqueeze_5 = torch.ops.aten.unsqueeze.default(unsqueeze_4, -1);  unsqueeze_4 = None
-    view_2 = torch.ops.aten.view.default(new_ones, [1, 1, 1, 1]);  new_ones = None
-    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_6 = torch.ops.aten.unsqueeze.default(arange_7, -1);  arange_7 = None
-    unsqueeze_7 = torch.ops.aten.unsqueeze.default(unsqueeze_6, -1);  unsqueeze_6 = None
-    unsqueeze_8 = torch.ops.aten.unsqueeze.default(unsqueeze_7, -1);  unsqueeze_7 = None
-    index_put = torch.ops.aten.index_put.default(new_zeros, [unsqueeze_8, unsqueeze_5, unsqueeze_2, where], view_2);  new_zeros = unsqueeze_8 = unsqueeze_5 = unsqueeze_2 = where = view_2 = None
-    slice_3 = torch.ops.aten.slice.Tensor(index_put, 3, 0, 1);  index_put = None
-    transpose_1 = torch.ops.aten.transpose.int(slice_3, -2, -1);  slice_3 = None
-    sum_4 = torch.ops.aten.sum.dim_IntList(transpose_1, [-1])
-    sort_2 = torch.ops.aten.sort.stable(transpose_1, stable = True, descending = True);  transpose_1 = None
-    getitem_5 = sort_2[1];  sort_2 = None
-    _to_copy_8 = torch.ops.aten._to_copy.default(sum_4, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_4 = None
-    _to_copy_9 = torch.ops.aten._to_copy.default(getitem_5, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_5 = None
-    new_zeros_1 = torch.ops.aten.new_zeros.default(_to_copy_7, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_9 = torch.ops.aten.unsqueeze.default(arange_8, -1);  arange_8 = None
-    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
-    unsqueeze_10 = torch.ops.aten.unsqueeze.default(_to_copy_6, 3)
-    lt_2 = torch.ops.aten.lt.Tensor(arange_9, unsqueeze_10);  arange_9 = unsqueeze_10 = None
-    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
-    where_1 = torch.ops.aten.where.self(lt_2, _to_copy_7, scalar_tensor_1);  lt_2 = scalar_tensor_1 = None
-    new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [1, 1], pin_memory = False)
-    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_11 = torch.ops.aten.unsqueeze.default(arange_10, -1);  arange_10 = None
-    unsqueeze_12 = torch.ops.aten.unsqueeze.default(unsqueeze_11, -1);  unsqueeze_11 = None
-    view_3 = torch.ops.aten.view.default(new_ones_1, [1, 1, 1, 1]);  new_ones_1 = None
-    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
-    unsqueeze_13 = torch.ops.aten.unsqueeze.default(arange_11, -1);  arange_11 = None
-    unsqueeze_14 = torch.ops.aten.unsqueeze.default(unsqueeze_13, -1);  unsqueeze_13 = None
-    unsqueeze_15 = torch.ops.aten.unsqueeze.default(unsqueeze_14, -1);  unsqueeze_14 = None
-    index_put_1 = torch.ops.aten.index_put.default(new_zeros_1, [unsqueeze_15, unsqueeze_12, unsqueeze_9, where_1], view_3);  new_zeros_1 = unsqueeze_15 = unsqueeze_12 = unsqueeze_9 = where_1 = view_3 = None
-    slice_6 = torch.ops.aten.slice.Tensor(index_put_1, 3, 0, 1);  index_put_1 = None
-    transpose_3 = torch.ops.aten.transpose.int(slice_6, -2, -1);  slice_6 = None
-    sum_5 = torch.ops.aten.sum.dim_IntList(transpose_3, [-1])
-    sort_3 = torch.ops.aten.sort.stable(transpose_3, stable = True, descending = True);  transpose_3 = None
-    getitem_7 = sort_3[1];  sort_3 = None
-    _to_copy_10 = torch.ops.aten._to_copy.default(sum_5, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_5 = None
-    _to_copy_11 = torch.ops.aten._to_copy.default(getitem_7, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_7 = None
-    return (arg0_1, _to_copy_3, _to_copy_4, _to_copy_6, _to_copy_7, _to_copy_8, _to_copy_9, _to_copy_10, _to_copy_11)""",
-            )
-
-            compiled_fn = aot_compile_joint_with_descriptors(joint_with_descriptors)
-            # Shouldn't crash
-            self.assertIsNotNone(compiled_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_aot_export_blockmask_closure_spec_mismatch(self):
-        """BlockMasks with same closure structure produce equal TreeSpecs.
-
-        Closure values are extracted into pytree leaves, so two BlockMasks
-        whose mask_mod closures have the same code + structure but different
-        captured values have the same spec (values differ in the leaves, not
-        the context).  BlockMasks with different closure *structure* (e.g.
-        different code) must still produce different specs.
-        """
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        def make_mask_fn(offset):
-            def fn(b, h, q, k):
-                return q >= k + offset
-
-            return fn
-
-        mask_a = create_block_mask(
-            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-        mask_b = create_block_mask(
-            make_mask_fn(8), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-        mask_a_same = create_block_mask(
-            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-
-        _, spec_a = pytree.tree_flatten(mask_a)
-        _, spec_b = pytree.tree_flatten(mask_b)
-        _, spec_a_same = pytree.tree_flatten(mask_a_same)
-
-        # Same closure code + same captured value -> same spec
-        self.assertEqual(spec_a, spec_a_same)
-        # Same closure code + different captured value -> same spec
-        # (values are in the leaves, not the context)
-        self.assertEqual(spec_a, spec_b)
-
-        # Different closure *code* -> different spec
-        def different_mask(b, h, q, k):
-            return q > k
-
-        mask_c = create_block_mask(
-            different_mask, B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
-        )
-        _, spec_c = pytree.tree_flatten(mask_c)
-        self.assertNotEqual(spec_a, spec_c)
-
     def test_mask_mod_wrapper_eq_for_partials(self):
         from torch.nn.attention.flex_attention import (
             _extract_callable_pytree,
@@ -1541,58 +1024,6 @@ def forward(self, arg0_1):
 
         self.assertEqual(wrapped_a, wrapped_b)
         self.assertEqual(hash(wrapped_a), hash(wrapped_b))
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_blockmask_and_masks_closure_extraction(self):
-        """and_masks closure tensors are recursively extracted into pytree leaves.
-
-        and_masks(fn1, fn2) returns a closure capturing a tuple of functions.
-        _extract_callable_pytree must recursively process these functions
-        (extracting their closure tensors) rather than emitting the functions
-        themselves as leaves, since functions are not supported export input
-        types.
-        """
-        from torch.nn.attention.flex_attention import (
-            and_masks,
-            BlockMask,
-            create_block_mask,
-        )
-
-        _register_blockmask_pytree()
-
-        def causal(b, h, q_idx, kv_idx):
-            return q_idx >= kv_idx
-
-        offset = torch.tensor(3, device="cuda")
-
-        def offset_mask(b, h, q_idx, kv_idx):
-            return q_idx >= kv_idx + offset
-
-        mask_mod = and_masks(causal, offset_mask)
-        block_mask = create_block_mask(
-            mask_mod, B=1, H=None, Q_LEN=128, KV_LEN=128, device="cuda"
-        )
-
-        leaves, spec = pytree.tree_flatten(block_mask)
-
-        # Present BlockMask tensor attrs + offset extracted from
-        # offset_mask's closure
-        n_regular = sum(
-            getattr(block_mask, attr) is not None for attr in BlockMask._TENSOR_ATTRS
-        )
-        self.assertEqual(len(leaves), n_regular + 1)
-        self.assertTrue(all(isinstance(l, torch.Tensor) for l in leaves))
-        self.assertIs(leaves[n_regular], offset)
-
-        # Leaves must all pass check_user_input_output
-        from torch._dynamo.eval_frame import check_user_input_output
-        from torch._dynamo.exc import UserErrorType
-
-        check_user_input_output(leaves, UserErrorType.INVALID_INPUT)
-
-        # Round-trip: unflatten should reconstruct a working mask_mod
-        restored = pytree.tree_unflatten(leaves, spec)
-        self.assertTrue(callable(restored.mask_mod))
 
     def test_aot_export_closure_buffer_mutation(self):
         class Mod(torch.nn.Module):
@@ -1883,6 +1314,575 @@ def forward(self, arg0_1):
             return level1()
 
         self._test_export_blockmask_with_mask_fn(make_mask_fn)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask_closure_self_recursive(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            # Self-referential: fn captures itself through the closure
+            def fn(b, h, q, k):
+                _ = fn  # self-reference
+                return q >= k + 4
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device="cuda")
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask_closure_tensor(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            tensor = torch.ones(2, 2)
+
+            def fn(b, h, q, k):
+                _ = fn
+                return q >= k + 4 + tensor.sum()
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device="cuda")
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask_closure_unsupported_class_instance(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        class MaskConfig:
+            def __init__(self, offset):
+                self.offset = offset
+
+        def make_mask_fn():
+            cfg = MaskConfig(offset=5)
+
+            def fn(b, h, q, k):
+                return q >= k + cfg.offset
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device="cuda")
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_export_blockmask_closure_mutually_recursive(self):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            # Create mutually recursive closures: fn_a references fn_b, fn_b references fn_a
+            # This is non-constructible because we cannot serialize mutually recursive closures
+            def fn_a(b, h, q, k):
+                _ = fn_b  # reference to fn_b
+                return q >= k
+
+            def fn_b(b, h, q, k):
+                _ = fn_a  # reference to fn_a
+                return q >= k + 1
+
+            return fn_a
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device="cuda")
+        module = Model()
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "nested function with non-constructible closure in output",
+        ):
+            _dynamo_graph_capture_for_export(module)(x)
+
+    @unittest.skipUnless(
+        IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
+        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
+    )
+    def test_aot_export_flex_attention_callable_mask_mod(self):
+        """Test flex_attention AOT export with callable class as mask_mod.
+
+        _MaskModWrapper must delegate __eq__ to callable objects for TreeSpec
+        comparison in AOTAutograd's PytreeThunk.set() (utils.py:162).
+        """
+        from torch._functorch.aot_autograd import aot_export_module
+        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+        _register_blockmask_pytree()
+
+        class ComposedMaskMod:
+            def __init__(self, *mask_fns):
+                self.mask_fns = mask_fns
+
+            def __call__(self, b, h, q, k):
+                result = True
+                for fn in self.mask_fns:
+                    result = result & fn(b, h, q, k)
+                return result
+
+            def __eq__(self, other):
+                if not isinstance(other, ComposedMaskMod):
+                    return NotImplemented
+                return self.mask_fns == other.mask_fns
+
+            def __hash__(self):
+                return hash(self.mask_fns)
+
+        def causal_mask(b, h, q, k):
+            return q >= k
+
+        class FlexAttentionModel(torch.nn.Module):
+            def __init__(self, embed_dim: int, num_heads: int):
+                super().__init__()
+                self.num_heads = num_heads
+                self.head_dim = embed_dim // num_heads
+                self.q_proj = torch.nn.Linear(embed_dim, embed_dim)
+                self.k_proj = torch.nn.Linear(embed_dim, embed_dim)
+                self.v_proj = torch.nn.Linear(embed_dim, embed_dim)
+
+            def forward(self, x):
+                B, L, D = x.shape
+                q = self.q_proj(x).view(B, L, self.num_heads, self.head_dim)
+                k = self.k_proj(x).view(B, L, self.num_heads, self.head_dim)
+                v = self.v_proj(x).view(B, L, self.num_heads, self.head_dim)
+                q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+
+                mask_mod = ComposedMaskMod(causal_mask)
+                block_mask = create_block_mask(
+                    mask_mod, B=B, H=self.num_heads, Q_LEN=L, KV_LEN=L, device=x.device
+                )
+                out = flex_attention(q, k, v, block_mask=block_mask)
+                return (out.transpose(1, 2).contiguous().view(B, L, D),)
+
+        embed_dim, num_heads, seq_len = 64, 2, 128
+        model = FlexAttentionModel(embed_dim, num_heads).cuda()
+        x = torch.randn(1, seq_len, embed_dim, device="cuda")
+
+        gm, signature = aot_export_module(model, [x], trace_joint=False)
+
+        # aot_export_module flattens params/buffers into the graph signature
+        params = [p for p in model.parameters()]
+        out_eager = model(x)[0]
+        out_export = gm(*params, x)[0]
+        self.assertEqual(out_eager.shape, out_export.shape)
+        self.assertTrue(torch.allclose(out_eager, out_export, atol=1e-5))
+
+    @unittest.skipUnless(
+        IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
+        "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
+    )
+    def test_aot_export_flex_attention_with_blockmask_placeholders(self):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+        from torch.nn.attention.flex_attention import create_block_mask, flex_attention
+
+        _register_blockmask_pytree()
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.wq = torch.nn.Linear(64, 64, bias=False)
+                self.block_mask = create_block_mask(
+                    lambda b, h, q, kv: q >= kv,
+                    B=None,
+                    H=None,
+                    Q_LEN=16,
+                    KV_LEN=16,
+                    device="cuda",
+                )
+
+            def forward(self, x):
+                q = self.wq(x).view(1, 16, 4, 16).transpose(1, 2)
+                return flex_attention(q, q, q, block_mask=self.block_mask).sum()
+
+        with torch.device("meta"):
+            model = Model()
+
+        fake_mode = FakeTensorMode()
+        with fake_mode:
+            for name, param in list(model.named_parameters()):
+                parts = name.split(".")
+                mod = model
+                for part in parts[:-1]:
+                    mod = getattr(mod, part)
+                setattr(
+                    mod,
+                    parts[-1],
+                    torch.nn.Parameter(
+                        torch.empty(param.shape, dtype=param.dtype, device="cuda"),
+                        requires_grad=param.requires_grad,
+                    ),
+                )
+            x = torch.randn(1, 16, 64, device="cuda")
+
+        gm = dynamo_graph_capture_for_export(model)(x)
+        block_mask_placeholders = [
+            node
+            for node in gm.graph.nodes
+            if node.op == "placeholder" and "block_mask" in node.name
+        ]
+        self.assertGreater(len(block_mask_placeholders), 0)
+
+        with contextlib.ExitStack() as stack:
+            joint_with_descriptors = aot_export_joint_with_descriptors(stack, gm, (x,))
+
+        self.assertIsNotNone(joint_with_descriptors.graph_module)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_dynamo_graph_capture_fx_graph_annotate_overlap_pass(self):
+        class DummyOp(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x, scalar):
+                ctx.save_for_backward(x)
+                return x + scalar
+
+            @staticmethod
+            def backward(ctx, grad_out):
+                return grad_out, None
+
+        def mock_fw_compute(x):
+            with fx_traceback.annotate({"compute": 0}):
+                return DummyOp.apply(x, 10)
+
+        def mock_bw_comm(x):
+            with fx_traceback.annotate({"comm": 0}):
+                return DummyOp.apply(x, 20)
+
+        def mock_bw_compute(x):
+            return DummyOp.apply(x, 30)
+
+        class Model(torch.nn.Module):
+            def forward(self, fw_in, bw_in):
+                fw_out = mock_fw_compute(fw_in)
+                # bw_in blocks bw_out
+                bw_in = mock_bw_comm(bw_in)
+                bw_out = mock_bw_compute(bw_in)
+                return fw_out, bw_out
+
+        def input_fn():
+            inputs = (torch.rand(2, 128, device="cuda", requires_grad=True),)
+            grad_ins = (torch.rand(2, 128, device="cuda"),)
+            return (
+                *inputs,
+                *grad_ins,
+            )
+
+        with torch.device("meta"):
+            model = Model()
+
+        import torch.fx.traceback as fx_traceback
+
+        with fx_traceback.preserve_node_meta():
+            gm = dynamo_graph_capture_for_export(model)(*input_fn())
+
+        """
+        def forward(self, args_0, args_1):
+            _tree_leaf_0, _tree_leaf_1, _tree_leaf_2, = pytree.tree_leaves((self, args_0, args_1,))
+            L_fw_in_ , L_bw_in_ , = self._in_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2)
+            l_fw_in_ = L_fw_in_
+            l_bw_in_ = L_bw_in_
+            fwd_body_0 = self.fwd_body_0
+            bwd_body_0 = self.bwd_body_0
+            fw_out = torch.ops.higher_order.autograd_function_apply(fwd_body_0, bwd_body_0, l_fw_in_, args_tensor_mask = [True, False], non_differentiable_idx = []);  fwd_body_0 = bwd_body_0 = l_fw_in_ = None
+            bw_in = l_bw_in_ + 20;  l_bw_in_ = None
+            bw_out = bw_in + 30;  bw_in = None
+            return pytree.tree_unflatten(self._out_shuffle_graph(_tree_leaf_0, _tree_leaf_1, _tree_leaf_2, fw_out, bw_out), self._out_spec)
+        """
+        test_inputs = input_fn()
+        self.assertEqual(gm(*test_inputs), model(*test_inputs))
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_aot_export_blockmask_with_new_closure(self):
+        import contextlib
+
+        from torch._export.utils import _compiling_state_context
+        from torch._functorch.aot_autograd import (
+            aot_compile_joint_with_descriptors,
+            aot_export_joint_with_descriptors,
+        )
+        from torch._guards import tracing as torch_tracing, TracingContext
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn():
+            res = 4
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            return fn
+
+        class Model(torch.nn.Module):
+            def forward(self, x):
+                mask_fn = make_mask_fn()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        args = (torch.randn(2, 128, device="cuda"),)
+        gm = dynamo_graph_capture_for_export(Model())(*args)
+
+        fake_mode = gm.meta["fake_mode"]
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(torch_tracing(TracingContext(fake_mode)))
+            stack.enter_context(_compiling_state_context())
+            stack.enter_context(fake_mode)
+
+            joint_with_descriptors = aot_export_joint_with_descriptors(
+                stack,
+                gm,
+                args=args,
+                kwargs={},
+                keep_inference_input_mutations=True,
+            )
+            self.assertExpectedInline(
+                str(joint_with_descriptors.graph_module.code).strip(),
+                """\
+def forward(self, arg0_1):
+    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
+    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
+    add = torch.ops.aten.add.Tensor(arange_3, 4);  arange_3 = None
+    view = torch.ops.aten.view.default(arange_2, [64, 1]);  arange_2 = None
+    ge = torch.ops.aten.ge.Tensor(view, add);  view = add = None
+    unsqueeze = torch.ops.aten.unsqueeze.default(ge, 0);  ge = None
+    expand = torch.ops.aten.expand.default(unsqueeze, [1, 64, 64]);  unsqueeze = None
+    unsqueeze_1 = torch.ops.aten.unsqueeze.default(expand, 0);  expand = None
+    expand_1 = torch.ops.aten.expand.default(unsqueeze_1, [1, 1, 64, 64]);  unsqueeze_1 = None
+    constant_pad_nd = torch.ops.aten.constant_pad_nd.default(expand_1, [0, 64, 0, 64], 0.0);  expand_1 = None
+    view_1 = torch.ops.aten.view.default(constant_pad_nd, [1, 1, 1, 128, 1, 128]);  constant_pad_nd = None
+    permute = torch.ops.aten.permute.default(view_1, [0, 1, 2, 4, 3, 5]);  view_1 = None
+    sum_1 = torch.ops.aten.sum.dim_IntList(permute, [-2, -1]);  permute = None
+    eq = torch.ops.aten.eq.Scalar(sum_1, 16384)
+    gt = torch.ops.aten.gt.Scalar(sum_1, 0)
+    lt = torch.ops.aten.lt.Scalar(sum_1, 16384);  sum_1 = None
+    bitwise_and = torch.ops.aten.bitwise_and.Tensor(gt, lt);  gt = lt = None
+    _to_copy = torch.ops.aten._to_copy.default(bitwise_and, dtype = torch.int8);  bitwise_and = None
+    _to_copy_1 = torch.ops.aten._to_copy.default(eq, dtype = torch.int8);  eq = None
+    _to_copy_2 = torch.ops.aten._to_copy.default(_to_copy, dtype = torch.int32);  _to_copy = None
+    sum_2 = torch.ops.aten.sum.dim_IntList(_to_copy_2, [-1])
+    sort = torch.ops.aten.sort.stable(_to_copy_2, stable = True, descending = True);  _to_copy_2 = None
+    getitem_1 = sort[1];  sort = None
+    _to_copy_3 = torch.ops.aten._to_copy.default(sum_2, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_2 = None
+    _to_copy_4 = torch.ops.aten._to_copy.default(getitem_1, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_1 = None
+    _to_copy_5 = torch.ops.aten._to_copy.default(_to_copy_1, dtype = torch.int32);  _to_copy_1 = None
+    sum_3 = torch.ops.aten.sum.dim_IntList(_to_copy_5, [-1])
+    sort_1 = torch.ops.aten.sort.stable(_to_copy_5, stable = True, descending = True);  _to_copy_5 = None
+    getitem_3 = sort_1[1];  sort_1 = None
+    _to_copy_6 = torch.ops.aten._to_copy.default(sum_3, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_3 = None
+    _to_copy_7 = torch.ops.aten._to_copy.default(getitem_3, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_3 = None
+    new_zeros = torch.ops.aten.new_zeros.default(_to_copy_4, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
+    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze_2 = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
+    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze_3 = torch.ops.aten.unsqueeze.default(_to_copy_3, 3)
+    lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_3);  arange_5 = unsqueeze_3 = None
+    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
+    where = torch.ops.aten.where.self(lt_1, _to_copy_4, scalar_tensor);  lt_1 = scalar_tensor = None
+    new_ones = torch.ops.aten.new_ones.default(new_zeros, [1, 1], pin_memory = False)
+    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_4 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
+    unsqueeze_5 = torch.ops.aten.unsqueeze.default(unsqueeze_4, -1);  unsqueeze_4 = None
+    view_2 = torch.ops.aten.view.default(new_ones, [1, 1, 1, 1]);  new_ones = None
+    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_6 = torch.ops.aten.unsqueeze.default(arange_7, -1);  arange_7 = None
+    unsqueeze_7 = torch.ops.aten.unsqueeze.default(unsqueeze_6, -1);  unsqueeze_6 = None
+    unsqueeze_8 = torch.ops.aten.unsqueeze.default(unsqueeze_7, -1);  unsqueeze_7 = None
+    index_put = torch.ops.aten.index_put.default(new_zeros, [unsqueeze_8, unsqueeze_5, unsqueeze_2, where], view_2);  new_zeros = unsqueeze_8 = unsqueeze_5 = unsqueeze_2 = where = view_2 = None
+    slice_3 = torch.ops.aten.slice.Tensor(index_put, 3, 0, 1);  index_put = None
+    transpose_1 = torch.ops.aten.transpose.int(slice_3, -2, -1);  slice_3 = None
+    sum_4 = torch.ops.aten.sum.dim_IntList(transpose_1, [-1])
+    sort_2 = torch.ops.aten.sort.stable(transpose_1, stable = True, descending = True);  transpose_1 = None
+    getitem_5 = sort_2[1];  sort_2 = None
+    _to_copy_8 = torch.ops.aten._to_copy.default(sum_4, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_4 = None
+    _to_copy_9 = torch.ops.aten._to_copy.default(getitem_5, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_5 = None
+    new_zeros_1 = torch.ops.aten.new_zeros.default(_to_copy_7, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
+    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze_9 = torch.ops.aten.unsqueeze.default(arange_8, -1);  arange_8 = None
+    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    unsqueeze_10 = torch.ops.aten.unsqueeze.default(_to_copy_6, 3)
+    lt_2 = torch.ops.aten.lt.Tensor(arange_9, unsqueeze_10);  arange_9 = unsqueeze_10 = None
+    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
+    where_1 = torch.ops.aten.where.self(lt_2, _to_copy_7, scalar_tensor_1);  lt_2 = scalar_tensor_1 = None
+    new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [1, 1], pin_memory = False)
+    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_11 = torch.ops.aten.unsqueeze.default(arange_10, -1);  arange_10 = None
+    unsqueeze_12 = torch.ops.aten.unsqueeze.default(unsqueeze_11, -1);  unsqueeze_11 = None
+    view_3 = torch.ops.aten.view.default(new_ones_1, [1, 1, 1, 1]);  new_ones_1 = None
+    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    unsqueeze_13 = torch.ops.aten.unsqueeze.default(arange_11, -1);  arange_11 = None
+    unsqueeze_14 = torch.ops.aten.unsqueeze.default(unsqueeze_13, -1);  unsqueeze_13 = None
+    unsqueeze_15 = torch.ops.aten.unsqueeze.default(unsqueeze_14, -1);  unsqueeze_14 = None
+    index_put_1 = torch.ops.aten.index_put.default(new_zeros_1, [unsqueeze_15, unsqueeze_12, unsqueeze_9, where_1], view_3);  new_zeros_1 = unsqueeze_15 = unsqueeze_12 = unsqueeze_9 = where_1 = view_3 = None
+    slice_6 = torch.ops.aten.slice.Tensor(index_put_1, 3, 0, 1);  index_put_1 = None
+    transpose_3 = torch.ops.aten.transpose.int(slice_6, -2, -1);  slice_6 = None
+    sum_5 = torch.ops.aten.sum.dim_IntList(transpose_3, [-1])
+    sort_3 = torch.ops.aten.sort.stable(transpose_3, stable = True, descending = True);  transpose_3 = None
+    getitem_7 = sort_3[1];  sort_3 = None
+    _to_copy_10 = torch.ops.aten._to_copy.default(sum_5, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_5 = None
+    _to_copy_11 = torch.ops.aten._to_copy.default(getitem_7, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_7 = None
+    return (arg0_1, _to_copy_3, _to_copy_4, _to_copy_6, _to_copy_7, _to_copy_8, _to_copy_9, _to_copy_10, _to_copy_11)""",
+            )
+
+            compiled_fn = aot_compile_joint_with_descriptors(joint_with_descriptors)
+            # Shouldn't crash
+            self.assertIsNotNone(compiled_fn)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_aot_export_blockmask_closure_spec_mismatch(self):
+        """BlockMasks with same closure structure produce equal TreeSpecs.
+
+        Closure values are extracted into pytree leaves, so two BlockMasks
+        whose mask_mod closures have the same code + structure but different
+        captured values have the same spec (values differ in the leaves, not
+        the context).  BlockMasks with different closure *structure* (e.g.
+        different code) must still produce different specs.
+        """
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        def make_mask_fn(offset):
+            def fn(b, h, q, k):
+                return q >= k + offset
+
+            return fn
+
+        mask_a = create_block_mask(
+            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+        )
+        mask_b = create_block_mask(
+            make_mask_fn(8), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+        )
+        mask_a_same = create_block_mask(
+            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+        )
+
+        _, spec_a = pytree.tree_flatten(mask_a)
+        _, spec_b = pytree.tree_flatten(mask_b)
+        _, spec_a_same = pytree.tree_flatten(mask_a_same)
+
+        # Same closure code + same captured value -> same spec
+        self.assertEqual(spec_a, spec_a_same)
+        # Same closure code + different captured value -> same spec
+        # (values are in the leaves, not the context)
+        self.assertEqual(spec_a, spec_b)
+
+        # Different closure *code* -> different spec
+        def different_mask(b, h, q, k):
+            return q > k
+
+        mask_c = create_block_mask(
+            different_mask, B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+        )
+        _, spec_c = pytree.tree_flatten(mask_c)
+        self.assertNotEqual(spec_a, spec_c)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
+    def test_blockmask_and_masks_closure_extraction(self):
+        """and_masks closure tensors are recursively extracted into pytree leaves.
+
+        and_masks(fn1, fn2) returns a closure capturing a tuple of functions.
+        _extract_callable_pytree must recursively process these functions
+        (extracting their closure tensors) rather than emitting the functions
+        themselves as leaves, since functions are not supported export input
+        types.
+        """
+        from torch.nn.attention.flex_attention import (
+            and_masks,
+            BlockMask,
+            create_block_mask,
+        )
+
+        _register_blockmask_pytree()
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        offset = torch.tensor(3, device="cuda")
+
+        def offset_mask(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx + offset
+
+        mask_mod = and_masks(causal, offset_mask)
+        block_mask = create_block_mask(
+            mask_mod, B=1, H=None, Q_LEN=128, KV_LEN=128, device="cuda"
+        )
+
+        leaves, spec = pytree.tree_flatten(block_mask)
+
+        # Present BlockMask tensor attrs + offset extracted from
+        # offset_mask's closure
+        n_regular = sum(
+            getattr(block_mask, attr) is not None for attr in BlockMask._TENSOR_ATTRS
+        )
+        self.assertEqual(len(leaves), n_regular + 1)
+        self.assertTrue(all(isinstance(l, torch.Tensor) for l in leaves))
+        self.assertIs(leaves[n_regular], offset)
+
+        # Leaves must all pass check_user_input_output
+        from torch._dynamo.eval_frame import check_user_input_output
+        from torch._dynamo.exc import UserErrorType
+
+        check_user_input_output(leaves, UserErrorType.INVALID_INPUT)
+
+        # Round-trip: unflatten should reconstruct a working mask_mod
+        restored = pytree.tree_unflatten(leaves, spec)
+        self.assertTrue(callable(restored.mask_mod))
 
 
 if __name__ == "__main__":

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -1116,7 +1116,7 @@ def forward(self, args_0):
                 msg=lambda msg: f"{msg}\n{label}: buffer mutation mismatch",
             )
 
-    def _assert_blockmask_partial_replays_bound_tensors(self, make_mask_mod):
+    def _assert_blockmask_partial_replays_bound_tensors(self, device, make_mask_mod):
         from torch.fx.experimental.proxy_tensor import make_fx
         from torch.nn.attention.flex_attention import BlockMask, create_block_mask
 
@@ -1140,7 +1140,7 @@ def forward(self, args_0):
                 H=1,
                 Q_LEN=8,
                 KV_LEN=8,
-                device="cpu",
+                device=device,
                 BLOCK_SIZE=4,
             )
 
@@ -1168,23 +1168,28 @@ def forward(self, args_0):
         self.assertTrue(torch.equal(replayed_batch1, expected_batch1))
 
     def test_blockmask_partial_extraction_replays_bound_tensors(self):
+        device = "cpu"
         self._assert_blockmask_partial_replays_bound_tensors(
+            device,
             lambda mask_rule, attn_regions, document_ids: functools.partial(
                 mask_rule,
                 attn_regions=attn_regions,
                 document_ids=document_ids,
-            )
+            ),
         )
 
     def test_blockmask_recursive_partial_extraction_replays_bound_tensors(self):
+        device = "cpu"
         self._assert_blockmask_partial_replays_bound_tensors(
+            device,
             lambda mask_rule, attn_regions, document_ids: functools.partial(
                 functools.partial(mask_rule, attn_regions=attn_regions),
                 document_ids=document_ids,
-            )
+            ),
         )
 
     def test_blockmask_self_referential_function_closure_extraction(self):
+        device = "cpu"
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1201,10 +1206,10 @@ def forward(self, args_0):
             return mask_mod
 
         mask_a = create_block_mask(
-            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
+            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device=device, BLOCK_SIZE=4
         )
         mask_b = create_block_mask(
-            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device="cpu", BLOCK_SIZE=4
+            make_mask_mod(), B=1, H=1, Q_LEN=8, KV_LEN=8, device=device, BLOCK_SIZE=4
         )
 
         leaves_a, spec_a = pytree.tree_flatten(mask_a)
@@ -1224,7 +1229,7 @@ def forward(self, args_0):
             )
         )
 
-    def _test_export_blockmask_with_mask_fn(self, make_mask_fn):
+    def _test_export_blockmask_with_mask_fn(self, device, make_mask_fn):
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1241,7 +1246,7 @@ def forward(self, args_0):
                 )
                 return x, block_mask
 
-        x = torch.randn(2, 128, device="cuda")
+        x = torch.randn(2, 128, device=device)
         module = Model(make_mask_fn)
 
         out_eager, mask_eager = module(x)
@@ -1257,6 +1262,8 @@ def forward(self, args_0):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask(self):
+        device = "cuda"
+
         def make_mask_fn():
             res = 4
 
@@ -1265,10 +1272,12 @@ def forward(self, args_0):
 
             return fn
 
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
+        self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_mutated_closure(self):
+        device = "cuda"
+
         def make_mask_fn():
             res = 1
 
@@ -1278,10 +1287,12 @@ def forward(self, args_0):
             res = 4  # mutation after function definition
             return fn
 
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
+        self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_with_containers(self):
+        device = "cuda"
+
         def make_mask_fn():
             offsets = [1, 2, 3]
             config = {"base": 4, "nested": {"scale": 2}}
@@ -1291,10 +1302,12 @@ def forward(self, args_0):
 
             return fn
 
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
+        self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_triple_nested(self):
+        device = "cuda"
+
         def make_mask_fn():
             a = 1
 
@@ -1313,10 +1326,11 @@ def forward(self, args_0):
 
             return level1()
 
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
+        self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_self_recursive(self):
+        device = "cuda"
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1337,7 +1351,7 @@ def forward(self, args_0):
                 )
                 return x, block_mask
 
-        x = torch.randn(2, 128, device="cuda")
+        x = torch.randn(2, 128, device=device)
         module = Model()
 
         with self.assertRaisesRegex(
@@ -1348,6 +1362,7 @@ def forward(self, args_0):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_tensor(self):
+        device = "cuda"
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1369,7 +1384,7 @@ def forward(self, args_0):
                 )
                 return x, block_mask
 
-        x = torch.randn(2, 128, device="cuda")
+        x = torch.randn(2, 128, device=device)
         module = Model()
 
         with self.assertRaisesRegex(
@@ -1380,6 +1395,7 @@ def forward(self, args_0):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_unsupported_class_instance(self):
+        device = "cuda"
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1404,7 +1420,7 @@ def forward(self, args_0):
                 )
                 return x, block_mask
 
-        x = torch.randn(2, 128, device="cuda")
+        x = torch.randn(2, 128, device=device)
         module = Model()
 
         with self.assertRaisesRegex(
@@ -1415,6 +1431,7 @@ def forward(self, args_0):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_mutually_recursive(self):
+        device = "cuda"
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1440,7 +1457,7 @@ def forward(self, args_0):
                 )
                 return x, block_mask
 
-        x = torch.randn(2, 128, device="cuda")
+        x = torch.randn(2, 128, device=device)
         module = Model()
 
         with self.assertRaisesRegex(
@@ -1454,6 +1471,7 @@ def forward(self, args_0):
         "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
     )
     def test_aot_export_flex_attention_callable_mask_mod(self):
+        device = "cuda"
         """Test flex_attention AOT export with callable class as mask_mod.
 
         _MaskModWrapper must delegate __eq__ to callable objects for TreeSpec
@@ -1509,8 +1527,8 @@ def forward(self, args_0):
                 return (out.transpose(1, 2).contiguous().view(B, L, D),)
 
         embed_dim, num_heads, seq_len = 64, 2, 128
-        model = FlexAttentionModel(embed_dim, num_heads).cuda()
-        x = torch.randn(1, seq_len, embed_dim, device="cuda")
+        model = FlexAttentionModel(embed_dim, num_heads).to(device)
+        x = torch.randn(1, seq_len, embed_dim, device=device)
 
         gm, signature = aot_export_module(model, [x], trace_joint=False)
 
@@ -1526,6 +1544,7 @@ def forward(self, args_0):
         "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
     )
     def test_aot_export_flex_attention_with_blockmask_placeholders(self):
+        device = "cuda"
         from torch._subclasses.fake_tensor import FakeTensorMode
         from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 
@@ -1541,7 +1560,7 @@ def forward(self, args_0):
                     H=None,
                     Q_LEN=16,
                     KV_LEN=16,
-                    device="cuda",
+                    device=device,
                 )
 
             def forward(self, x):
@@ -1562,11 +1581,11 @@ def forward(self, args_0):
                     mod,
                     parts[-1],
                     torch.nn.Parameter(
-                        torch.empty(param.shape, dtype=param.dtype, device="cuda"),
+                        torch.empty(param.shape, dtype=param.dtype, device=device),
                         requires_grad=param.requires_grad,
                     ),
                 )
-            x = torch.randn(1, 16, 64, device="cuda")
+            x = torch.randn(1, 16, 64, device=device)
 
         gm = dynamo_graph_capture_for_export(model)(x)
         block_mask_placeholders = [
@@ -1583,6 +1602,8 @@ def forward(self, args_0):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_dynamo_graph_capture_fx_graph_annotate_overlap_pass(self):
+        device = "cuda"
+
         class DummyOp(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x, scalar):
@@ -1613,8 +1634,8 @@ def forward(self, args_0):
                 return fw_out, bw_out
 
         def input_fn():
-            inputs = (torch.rand(2, 128, device="cuda", requires_grad=True),)
-            grad_ins = (torch.rand(2, 128, device="cuda"),)
+            inputs = (torch.rand(2, 128, device=device, requires_grad=True),)
+            grad_ins = (torch.rand(2, 128, device=device),)
             return (
                 *inputs,
                 *grad_ins,
@@ -1646,6 +1667,7 @@ def forward(self, args_0):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_aot_export_blockmask_with_new_closure(self):
+        device = "cuda"
         import contextlib
 
         from torch._export.utils import _compiling_state_context
@@ -1674,7 +1696,7 @@ def forward(self, args_0):
                 )
                 return x, block_mask
 
-        args = (torch.randn(2, 128, device="cuda"),)
+        args = (torch.randn(2, 128, device=device),)
         gm = dynamo_graph_capture_for_export(Model())(*args)
 
         fake_mode = gm.meta["fake_mode"]
@@ -1692,10 +1714,10 @@ def forward(self, args_0):
             )
             self.assertExpectedInline(
                 str(joint_with_descriptors.graph_module.code).strip(),
-                """\
+                f"""\
 def forward(self, arg0_1):
-    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
-    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='cuda', index=0), pin_memory = False)
+    arange_2 = torch.ops.aten.arange.start(0, 64, device = device(type='{device}', index=0), pin_memory = False)
+    arange_3 = torch.ops.aten.arange.start(0, 64, device = device(type='{device}', index=0), pin_memory = False)
     add = torch.ops.aten.add.Tensor(arange_3, 4);  arange_3 = None
     view = torch.ops.aten.view.default(arange_2, [64, 1]);  arange_2 = None
     ge = torch.ops.aten.ge.Tensor(view, add);  view = add = None
@@ -1726,19 +1748,19 @@ def forward(self, arg0_1):
     _to_copy_6 = torch.ops.aten._to_copy.default(sum_3, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_3 = None
     _to_copy_7 = torch.ops.aten._to_copy.default(getitem_3, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_3 = None
     new_zeros = torch.ops.aten.new_zeros.default(_to_copy_4, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    arange_4 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
     unsqueeze_2 = torch.ops.aten.unsqueeze.default(arange_4, -1);  arange_4 = None
-    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    arange_5 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
     unsqueeze_3 = torch.ops.aten.unsqueeze.default(_to_copy_3, 3)
     lt_1 = torch.ops.aten.lt.Tensor(arange_5, unsqueeze_3);  arange_5 = unsqueeze_3 = None
-    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
+    scalar_tensor = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{device}', index=0))
     where = torch.ops.aten.where.self(lt_1, _to_copy_4, scalar_tensor);  lt_1 = scalar_tensor = None
     new_ones = torch.ops.aten.new_ones.default(new_zeros, [1, 1], pin_memory = False)
-    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    arange_6 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
     unsqueeze_4 = torch.ops.aten.unsqueeze.default(arange_6, -1);  arange_6 = None
     unsqueeze_5 = torch.ops.aten.unsqueeze.default(unsqueeze_4, -1);  unsqueeze_4 = None
     view_2 = torch.ops.aten.view.default(new_ones, [1, 1, 1, 1]);  new_ones = None
-    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    arange_7 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
     unsqueeze_6 = torch.ops.aten.unsqueeze.default(arange_7, -1);  arange_7 = None
     unsqueeze_7 = torch.ops.aten.unsqueeze.default(unsqueeze_6, -1);  unsqueeze_6 = None
     unsqueeze_8 = torch.ops.aten.unsqueeze.default(unsqueeze_7, -1);  unsqueeze_7 = None
@@ -1751,19 +1773,19 @@ def forward(self, arg0_1):
     _to_copy_8 = torch.ops.aten._to_copy.default(sum_4, dtype = torch.int32, memory_format = torch.contiguous_format);  sum_4 = None
     _to_copy_9 = torch.ops.aten._to_copy.default(getitem_5, dtype = torch.int32, memory_format = torch.contiguous_format);  getitem_5 = None
     new_zeros_1 = torch.ops.aten.new_zeros.default(_to_copy_7, [1, 1, 1, 2], dtype = torch.int32, pin_memory = False)
-    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    arange_8 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
     unsqueeze_9 = torch.ops.aten.unsqueeze.default(arange_8, -1);  arange_8 = None
-    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='cuda', index=0), pin_memory = False)
+    arange_9 = torch.ops.aten.arange.default(1, dtype = torch.int32, device = device(type='{device}', index=0), pin_memory = False)
     unsqueeze_10 = torch.ops.aten.unsqueeze.default(_to_copy_6, 3)
     lt_2 = torch.ops.aten.lt.Tensor(arange_9, unsqueeze_10);  arange_9 = unsqueeze_10 = None
-    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='cuda', index=0))
+    scalar_tensor_1 = torch.ops.aten.scalar_tensor.default(1, dtype = torch.int32, layout = torch.strided, device = device(type='{device}', index=0))
     where_1 = torch.ops.aten.where.self(lt_2, _to_copy_7, scalar_tensor_1);  lt_2 = scalar_tensor_1 = None
     new_ones_1 = torch.ops.aten.new_ones.default(new_zeros_1, [1, 1], pin_memory = False)
-    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    arange_10 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
     unsqueeze_11 = torch.ops.aten.unsqueeze.default(arange_10, -1);  arange_10 = None
     unsqueeze_12 = torch.ops.aten.unsqueeze.default(unsqueeze_11, -1);  unsqueeze_11 = None
     view_3 = torch.ops.aten.view.default(new_ones_1, [1, 1, 1, 1]);  new_ones_1 = None
-    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='cuda', index=0))
+    arange_11 = torch.ops.aten.arange.default(1, dtype = torch.int64, layout = torch.strided, device = device(type='{device}', index=0))
     unsqueeze_13 = torch.ops.aten.unsqueeze.default(arange_11, -1);  arange_11 = None
     unsqueeze_14 = torch.ops.aten.unsqueeze.default(unsqueeze_13, -1);  unsqueeze_13 = None
     unsqueeze_15 = torch.ops.aten.unsqueeze.default(unsqueeze_14, -1);  unsqueeze_14 = None
@@ -1784,6 +1806,7 @@ def forward(self, arg0_1):
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_aot_export_blockmask_closure_spec_mismatch(self):
+        device = "cuda"
         """BlockMasks with same closure structure produce equal TreeSpecs.
 
         Closure values are extracted into pytree leaves, so two BlockMasks
@@ -1803,13 +1826,13 @@ def forward(self, arg0_1):
             return fn
 
         mask_a = create_block_mask(
-            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
         )
         mask_b = create_block_mask(
-            make_mask_fn(8), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+            make_mask_fn(8), B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
         )
         mask_a_same = create_block_mask(
-            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+            make_mask_fn(4), B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
         )
 
         _, spec_a = pytree.tree_flatten(mask_a)
@@ -1827,13 +1850,14 @@ def forward(self, arg0_1):
             return q > k
 
         mask_c = create_block_mask(
-            different_mask, B=1, H=1, Q_LEN=64, KV_LEN=64, device="cuda"
+            different_mask, B=1, H=1, Q_LEN=64, KV_LEN=64, device=device
         )
         _, spec_c = pytree.tree_flatten(mask_c)
         self.assertNotEqual(spec_a, spec_c)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_blockmask_and_masks_closure_extraction(self):
+        device = "cuda"
         """and_masks closure tensors are recursively extracted into pytree leaves.
 
         and_masks(fn1, fn2) returns a closure capturing a tuple of functions.
@@ -1853,14 +1877,14 @@ def forward(self, arg0_1):
         def causal(b, h, q_idx, kv_idx):
             return q_idx >= kv_idx
 
-        offset = torch.tensor(3, device="cuda")
+        offset = torch.tensor(3, device=device)
 
         def offset_mask(b, h, q_idx, kv_idx):
             return q_idx >= kv_idx + offset
 
         mask_mod = and_masks(causal, offset_mask)
         block_mask = create_block_mask(
-            mask_mod, B=1, H=None, Q_LEN=128, KV_LEN=128, device="cuda"
+            mask_mod, B=1, H=None, Q_LEN=128, KV_LEN=128, device=device
         )
 
         leaves, spec = pytree.tree_flatten(block_mask)

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -1116,6 +1116,8 @@ def forward(self, args_0):
                 msg=lambda msg: f"{msg}\n{label}: buffer mutation mismatch",
             )
 
+
+class TestExperimentCPU(TestCase):
     def _assert_blockmask_partial_replays_bound_tensors(self, device, make_mask_mod):
         from torch.fx.experimental.proxy_tensor import make_fx
         from torch.nn.attention.flex_attention import BlockMask, create_block_mask
@@ -1229,6 +1231,8 @@ def forward(self, args_0):
             )
         )
 
+
+class TestExperimentDevice(TestCase):
     def _test_export_blockmask_with_mask_fn(self, device, make_mask_fn):
         from torch.nn.attention.flex_attention import create_block_mask
 

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -28,6 +28,7 @@ from torch.export.graph_signature import OutputKind
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import (
     IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED,
+    onlyAccelerator,
 )
 from torch.testing._internal.common_utils import HardwareClassification, TEST_CUDA
 from torch.utils import _pytree as pytree
@@ -1233,6 +1234,8 @@ class TestExperimentCPU(TestCase):
 
 
 class TestExperimentDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def _test_export_blockmask_with_mask_fn(self, device, make_mask_fn):
         from torch.nn.attention.flex_attention import create_block_mask
 
@@ -1264,10 +1267,7 @@ class TestExperimentDevice(TestCase):
             mask_compiled.mask_mod(1, 1, 64, 64),
         )
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask(self):
-        device = "cuda"
-
+    def test_export_blockmask(self, device):
         def make_mask_fn():
             res = 4
 
@@ -1278,10 +1278,7 @@ class TestExperimentDevice(TestCase):
 
         self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_mutated_closure(self):
-        device = "cuda"
-
+    def test_export_blockmask_mutated_closure(self, device):
         def make_mask_fn():
             res = 1
 
@@ -1293,10 +1290,7 @@ class TestExperimentDevice(TestCase):
 
         self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_with_containers(self):
-        device = "cuda"
-
+    def test_export_blockmask_closure_with_containers(self, device):
         def make_mask_fn():
             offsets = [1, 2, 3]
             config = {"base": 4, "nested": {"scale": 2}}
@@ -1308,10 +1302,7 @@ class TestExperimentDevice(TestCase):
 
         self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_triple_nested(self):
-        device = "cuda"
-
+    def test_export_blockmask_closure_triple_nested(self, device):
         def make_mask_fn():
             a = 1
 
@@ -1332,9 +1323,7 @@ class TestExperimentDevice(TestCase):
 
         self._test_export_blockmask_with_mask_fn(device, make_mask_fn)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_self_recursive(self):
-        device = "cuda"
+    def test_export_blockmask_closure_self_recursive(self, device):
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1364,9 +1353,7 @@ class TestExperimentDevice(TestCase):
         ):
             _dynamo_graph_capture_for_export(module)(x)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_tensor(self):
-        device = "cuda"
+    def test_export_blockmask_closure_tensor(self, device):
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1397,9 +1384,7 @@ class TestExperimentDevice(TestCase):
         ):
             _dynamo_graph_capture_for_export(module)(x)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_unsupported_class_instance(self):
-        device = "cuda"
+    def test_export_blockmask_closure_unsupported_class_instance(self, device):
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1433,9 +1418,7 @@ class TestExperimentDevice(TestCase):
         ):
             _dynamo_graph_capture_for_export(module)(x)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_mutually_recursive(self):
-        device = "cuda"
+    def test_export_blockmask_closure_mutually_recursive(self, device):
         from torch.nn.attention.flex_attention import create_block_mask
 
         _register_blockmask_pytree()
@@ -1474,8 +1457,7 @@ class TestExperimentDevice(TestCase):
         IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
         "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
     )
-    def test_aot_export_flex_attention_callable_mask_mod(self):
-        device = "cuda"
+    def test_aot_export_flex_attention_callable_mask_mod(self, device):
         """Test flex_attention AOT export with callable class as mask_mod.
 
         _MaskModWrapper must delegate __eq__ to callable objects for TreeSpec
@@ -1547,8 +1529,7 @@ class TestExperimentDevice(TestCase):
         IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED and not torch.version.hip,
         "Requires CUDA with SM >= 8.0, Triton, and not ROCm",
     )
-    def test_aot_export_flex_attention_with_blockmask_placeholders(self):
-        device = "cuda"
+    def test_aot_export_flex_attention_with_blockmask_placeholders(self, device):
         from torch._subclasses.fake_tensor import FakeTensorMode
         from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 
@@ -1604,10 +1585,7 @@ class TestExperimentDevice(TestCase):
 
         self.assertIsNotNone(joint_with_descriptors.graph_module)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_dynamo_graph_capture_fx_graph_annotate_overlap_pass(self):
-        device = "cuda"
-
+    def test_dynamo_graph_capture_fx_graph_annotate_overlap_pass(self, device):
         class DummyOp(torch.autograd.Function):
             @staticmethod
             def forward(ctx, x, scalar):
@@ -1669,9 +1647,7 @@ class TestExperimentDevice(TestCase):
         test_inputs = input_fn()
         self.assertEqual(gm(*test_inputs), model(*test_inputs))
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_aot_export_blockmask_with_new_closure(self):
-        device = "cuda"
+    def test_aot_export_blockmask_with_new_closure(self, device):
         import contextlib
 
         from torch._export.utils import _compiling_state_context
@@ -1808,9 +1784,7 @@ def forward(self, arg0_1):
             # Shouldn't crash
             self.assertIsNotNone(compiled_fn)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_aot_export_blockmask_closure_spec_mismatch(self):
-        device = "cuda"
+    def test_aot_export_blockmask_closure_spec_mismatch(self, device):
         """BlockMasks with same closure structure produce equal TreeSpecs.
 
         Closure values are extracted into pytree leaves, so two BlockMasks
@@ -1859,9 +1833,7 @@ def forward(self, arg0_1):
         _, spec_c = pytree.tree_flatten(mask_c)
         self.assertNotEqual(spec_a, spec_c)
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_blockmask_and_masks_closure_extraction(self):
-        device = "cuda"
+    def test_blockmask_and_masks_closure_extraction(self, device):
         """and_masks closure tensors are recursively extracted into pytree leaves.
 
         and_masks(fn1, fn2) returns a closure capturing a tuple of functions.
@@ -1914,6 +1886,7 @@ def forward(self, arg0_1):
 
 
 instantiate_device_type_tests(TestExperimentCPU, globals(), only_for="cpu")
+instantiate_device_type_tests(TestExperimentDevice, globals(), only_for="cuda")
 
 if __name__ == "__main__":
     run_tests()

--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -29,7 +29,7 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import (
     IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED,
 )
-from torch.testing._internal.common_utils import TEST_CUDA
+from torch.testing._internal.common_utils import HardwareClassification, TEST_CUDA
 from torch.utils import _pytree as pytree
 
 
@@ -1118,6 +1118,8 @@ def forward(self, args_0):
 
 
 class TestExperimentCPU(TestCase):
+    hw_classification = HardwareClassification.CPU
+
     def _assert_blockmask_partial_replays_bound_tensors(self, device, make_mask_mod):
         from torch.fx.experimental.proxy_tensor import make_fx
         from torch.nn.attention.flex_attention import BlockMask, create_block_mask
@@ -1169,8 +1171,7 @@ class TestExperimentCPU(TestCase):
         self.assertFalse(torch.equal(replayed_batch1, expected_batch0))
         self.assertTrue(torch.equal(replayed_batch1, expected_batch1))
 
-    def test_blockmask_partial_extraction_replays_bound_tensors(self):
-        device = "cpu"
+    def test_blockmask_partial_extraction_replays_bound_tensors(self, device):
         self._assert_blockmask_partial_replays_bound_tensors(
             device,
             lambda mask_rule, attn_regions, document_ids: functools.partial(
@@ -1180,8 +1181,7 @@ class TestExperimentCPU(TestCase):
             ),
         )
 
-    def test_blockmask_recursive_partial_extraction_replays_bound_tensors(self):
-        device = "cpu"
+    def test_blockmask_recursive_partial_extraction_replays_bound_tensors(self, device):
         self._assert_blockmask_partial_replays_bound_tensors(
             device,
             lambda mask_rule, attn_regions, document_ids: functools.partial(
@@ -1912,6 +1912,8 @@ def forward(self, arg0_1):
         restored = pytree.tree_unflatten(leaves, spec)
         self.assertTrue(callable(restored.mask_mod))
 
+
+instantiate_device_type_tests(TestExperimentCPU, globals(), only_for="cpu")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
This is part 3 of 3 in effort to generalize test/export/test_experimental.py tests.
Previously submitted version exceeded LoC limit, due to diff algorithm not recognizing code moves correctly, so I've stacked 2 PRs prior to this in order to separate code moves from actual implementation changes.
Part 1 is here: https://github.com/pytorch/pytorch/pull/196439
Part 2 is here: https://github.com/pytorch/pytorch/pull/196440

Changes in this PR in separate commits in order:
1. Move hardcoded device names from function arguments to a local variable,
2. Separate out CPU-specific and device-agnostic test classes.
3. Add instantiation and HW classification to TestExperimentCPU test class.
4. Add instantiation and HW classification to TestExperimentDevice test class.
5. Enable tests on XPU.