### PR TITLE
[Test] Make `test/quantization/core/test_workflow_ops.py` tests device-generic and enable testing XPU.

### DIFF
--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1321,9 +1321,13 @@ class TestFusedObsFakeQuantDevice(TestCase):
         self.assertTrue(x.grad.dtype == torch.float32)
 
 
-only_for = ("cpu", "cuda")
-instantiate_device_type_tests(TestFakeQuantizeOpsDevice, globals(), only_for=only_for)
-instantiate_device_type_tests(TestFusedObsFakeQuantDevice, globals(), only_for=only_for)
+only_for = ("cpu", "cuda", "xpu")
+instantiate_device_type_tests(
+    TestFakeQuantizeOpsDevice, globals(), only_for=only_for, allow_xpu=True
+)
+instantiate_device_type_tests(
+    TestFusedObsFakeQuantDevice, globals(), only_for=only_for, allow_xpu=True
+)
 
 
 if __name__ == '__main__':

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -286,6 +286,203 @@ NP_RANDOM_SEED = 19
 tolerance = 1e-6
 
 class TestFakeQuantizeOps(TestCase):
+    def test_forward_per_tensor_half_precision_numerics(self):
+        scale = .1
+        zero = 0
+        maxi = 255
+        mini = 0
+
+        for _ in range(20):
+            X1 = torch.randn(5, 5).to(torch.float16)
+            Y1 = torch.fake_quantize_per_tensor_affine(X1, scale, zero, mini, maxi)
+            Y1r = _fake_quantize_per_tensor_affine_reference(X1, scale, zero, mini, maxi)
+            self.assertEqual(Y1, Y1r, rtol=tolerance, atol=tolerance)
+
+        # to force overflow
+        X2 = torch.tensor(2**15 + .01).to(torch.float16)
+        Y2 = torch.fake_quantize_per_tensor_affine(X2, scale, zero, mini, maxi)
+        Y2r = _fake_quantize_per_tensor_affine_reference(X2, scale, zero, mini, maxi)
+        self.assertEqual(Y2, Y2r, rtol=tolerance, atol=tolerance)
+
+        scale = 10
+
+        # to force underflow
+        X3 = torch.tensor(2**-24).to(torch.float16)
+        Y3 = torch.fake_quantize_per_tensor_affine(X3, scale, zero, mini, maxi)
+        Y3r = _fake_quantize_per_tensor_affine_reference(X3, scale, zero, mini, maxi)
+        self.assertEqual(Y3, Y3r, rtol=tolerance, atol=tolerance)
+
+    def test_fq_serializable_per_tensor(self):
+        observer = default_observer
+        quant_min = 0
+        quant_max = 127
+        for FakeQuantizeClass in [FakeQuantize, _LearnableFakeQuantize]:
+            fq_module = FakeQuantizeClass(observer, quant_min, quant_max)
+            X = torch.tensor([-5, -3.5, -2, 0, 3, 5, 7], dtype=torch.float32)
+            y_ref = fq_module(X)
+            state_dict = fq_module.state_dict()
+            self.assertEqual(state_dict['scale'], 0.094488)
+            self.assertEqual(state_dict['zero_point'], 53)
+            b = io.BytesIO()
+            torch.save(state_dict, b)
+            for weights_only in [True, False]:
+                b.seek(0)
+                loaded_dict = torch.load(b, weights_only=weights_only)
+                loaded_fq_module = FakeQuantizeClass(observer, quant_min, quant_max)
+                loaded_fq_module.load_state_dict(loaded_dict)
+                for key in state_dict:
+                    self.assertEqual(state_dict[key], loaded_fq_module.state_dict()[key])
+
+                self.assertEqual(loaded_fq_module.calculate_qparams(), fq_module.calculate_qparams())
+
+    def test_fake_quant_control(self):
+        for fq_module in [torch.ao.quantization.default_fake_quant(),
+                          _LearnableFakeQuantize.with_args(observer=MovingAverageMinMaxObserver, quant_min=0,
+                                                           quant_max=255,
+                                                           dtype=torch.quint8, qscheme=torch.per_tensor_affine,
+                                                           reduce_range=True)()]:
+            torch.manual_seed(42)
+            X = torch.rand(20, 10, dtype=torch.float32)
+            # Output of fake quant is not identical to input
+            Y = fq_module(X)
+            self.assertNotEqual(Y, X)
+            if type(fq_module) is _LearnableFakeQuantize:
+                fq_module.toggle_fake_quant(False)
+            else:
+                torch.ao.quantization.disable_fake_quant(fq_module)
+            X = torch.rand(20, 10, dtype=torch.float32)
+            Y = fq_module(X)
+            # Fake quant is disabled,output is identical to input
+            self.assertEqual(Y, X)
+
+            # Explicit copy at this point in time, because FakeQuant keeps internal
+            # state in mutable buffers.
+            scale = fq_module.scale.detach().clone()
+            zero_point = fq_module.zero_point.detach().clone()
+
+            if type(fq_module) is _LearnableFakeQuantize:
+                fq_module.toggle_observer_update(False)
+                fq_module.toggle_fake_quant(True)
+            else:
+                torch.ao.quantization.disable_observer(fq_module)
+                torch.ao.quantization.enable_fake_quant(fq_module)
+            X = 10.0 * torch.rand(20, 10, dtype=torch.float32) - 5.0
+            Y = fq_module(X)
+            self.assertNotEqual(Y, X)
+            # Observer is disabled, scale and zero-point do not change
+            self.assertEqual(fq_module.scale, scale)
+            self.assertEqual(fq_module.zero_point, zero_point)
+            if type(fq_module) is _LearnableFakeQuantize:
+                fq_module.toggle_observer_update(True)
+            else:
+                torch.ao.quantization.enable_observer(fq_module)
+            Y = fq_module(X)
+            self.assertNotEqual(Y, X)
+            # Observer is enabled, scale and zero-point are different
+            self.assertNotEqual(fq_module.scale, scale)
+            self.assertNotEqual(fq_module.zero_point, zero_point)
+
+    def test_fake_quant_preserves_qparam_shapes_for_activations(self):
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = nn.Linear(4, 4)
+
+            def forward(self, x):
+                x = self.linear(x)
+                return x
+
+        m = Model()
+
+        m.qconfig = torch.ao.quantization.get_default_qat_qconfig('fbgemm')
+        torch.ao.quantization.prepare_qat(m, inplace=True)
+
+        scale_shape_before = m.linear.activation_post_process.scale.shape
+        zero_point_shape_before = m.linear.activation_post_process.zero_point.shape
+
+        x = torch.rand(4, 4, 4, 4)
+        m(x)
+        scale_shape_after = m.linear.activation_post_process.scale.shape
+        zero_point_shape_after = m.linear.activation_post_process.zero_point.shape
+        self.assertEqual(
+            scale_shape_before, scale_shape_after,
+            msg="FakeQuant scale shape must stay consistent")
+        self.assertEqual(
+            zero_point_shape_before, zero_point_shape_after,
+            msg="FakeQuant zero_point shape must stay consistent")
+
+    def fake_quant_scriptable(self):
+        observer = default_observer
+        quant_min = 0
+        quant_max = 255
+        for FakeQuantizeClass in [FakeQuantize, _LearnableFakeQuantize]:
+            fq_module = FakeQuantizeClass(observer, quant_min, quant_max)
+            scripted_module = torch.jit.script(fq_module)
+
+            X = torch.tensor([-5, -3.5, -2, 0, 3, 5, 7], dtype=torch.float32)
+
+            fq_module(X)
+            scripted_module(X)
+            self.assertEqual(fq_module.calculate_qparams(), scripted_module.calculate_qparams())
+
+            buf = io.BytesIO()
+            torch.jit.save(scripted_module, buf)
+            buf.seek(0)
+            loaded_module = torch.jit.load(buf)
+            self.assertEqual(fq_module.calculate_qparams(), loaded_module.calculate_qparams())
+
+    def test_forward_per_channel_half_precision_numerics(self):
+        scale = torch.randn(5).abs()
+        zero = torch.randn(5).to(dtype=torch.int)
+        axis = 1
+        mini = 0
+        maxi = 255
+
+        for _ in range(20):
+            X1 = torch.randn(4, 5).to(torch.float16)
+            Y1 = torch.fake_quantize_per_channel_affine(X1, scale, zero, axis, mini, maxi)
+            Y1r = _fake_quantize_per_channel_affine_reference(X1, scale, zero, axis, mini, maxi)
+            self.assertEqual(Y1, Y1r, rtol=tolerance, atol=tolerance)
+
+        # to force overflow
+        X2 = torch.randn(4, 5).to(torch.float16)
+        X2[0, 0] = 2**15 + .01
+        Y2 = torch.fake_quantize_per_channel_affine(X2, scale, zero, axis, mini, maxi)
+        Y2r = _fake_quantize_per_channel_affine_reference(X2, scale, zero, axis, mini, maxi)
+        self.assertEqual(Y2, Y2r, rtol=tolerance, atol=tolerance)
+
+        scale = torch.zeros(5) + 10
+
+        # to force underflow
+        X3 = torch.randn(4, 5).to(torch.float16)
+        X3[0, 0] = 2**-24
+        Y3 = torch.fake_quantize_per_channel_affine(X3, scale, zero, axis, mini, maxi)
+        Y3r = _fake_quantize_per_channel_affine_reference(X3, scale, zero, axis, mini, maxi)
+        self.assertEqual(Y3, Y3r, rtol=tolerance, atol=tolerance)
+
+    @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
+    def test_fake_quantize_per_channel_affine_scale_dtypes(self):
+        """
+        Ensure the error message is more helpful
+        """
+        dtype_list = [torch.float, torch.float64, torch.bfloat16, torch.half]
+        for scale_dtype in dtype_list:
+            input = torch.randn(3, 4, 5, 6)
+            scale = torch.Tensor([0.1, 0.2, 0.3, 0.4]).to(scale_dtype)
+            zero_point = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+            axis = 1
+            quant_min = 0
+            quant_max = 255
+            if scale_dtype != torch.float:
+                with self.assertRaises(RuntimeError):
+                    torch.fake_quantize_per_channel_affine(
+                        input, scale, zero_point, axis, quant_min, quant_max
+                    )
+            else:
+                torch.fake_quantize_per_channel_affine(
+                    input, scale, zero_point, axis, quant_min, quant_max
+                )
+
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
@@ -336,32 +533,6 @@ class TestFakeQuantizeOps(TestCase):
             out = net_prep(x).sum()
             out.backward()
             self.assertTrue(net_prep[0].weight.grad is not None)
-
-    def test_forward_per_tensor_half_precision_numerics(self):
-        scale = .1
-        zero = 0
-        maxi = 255
-        mini = 0
-
-        for _ in range(20):
-            X1 = torch.randn(5, 5).to(torch.float16)
-            Y1 = torch.fake_quantize_per_tensor_affine(X1, scale, zero, mini, maxi)
-            Y1r = _fake_quantize_per_tensor_affine_reference(X1, scale, zero, mini, maxi)
-            self.assertEqual(Y1, Y1r, rtol=tolerance, atol=tolerance)
-
-        # to force overflow
-        X2 = torch.tensor(2**15 + .01).to(torch.float16)
-        Y2 = torch.fake_quantize_per_tensor_affine(X2, scale, zero, mini, maxi)
-        Y2r = _fake_quantize_per_tensor_affine_reference(X2, scale, zero, mini, maxi)
-        self.assertEqual(Y2, Y2r, rtol=tolerance, atol=tolerance)
-
-        scale = 10
-
-        # to force underflow
-        X3 = torch.tensor(2**-24).to(torch.float16)
-        Y3 = torch.fake_quantize_per_tensor_affine(X3, scale, zero, mini, maxi)
-        Y3r = _fake_quantize_per_tensor_affine_reference(X3, scale, zero, mini, maxi)
-        self.assertEqual(Y3, Y3r, rtol=tolerance, atol=tolerance)
 
     def _test_forward_per_tensor_cachemask_impl(self, device):
         float_types = (torch.float32, torch.float16, torch.float64, torch.bfloat16)
@@ -595,126 +766,6 @@ class TestFakeQuantizeOps(TestCase):
         self.assertEqual(fixed_scale, fq_module.scale)
         self.assertEqual(fixed_zero_point, fq_module.zero_point)
 
-    def test_fq_serializable_per_tensor(self):
-        observer = default_observer
-        quant_min = 0
-        quant_max = 127
-        for FakeQuantizeClass in [FakeQuantize, _LearnableFakeQuantize]:
-            fq_module = FakeQuantizeClass(observer, quant_min, quant_max)
-            X = torch.tensor([-5, -3.5, -2, 0, 3, 5, 7], dtype=torch.float32)
-            y_ref = fq_module(X)
-            state_dict = fq_module.state_dict()
-            self.assertEqual(state_dict['scale'], 0.094488)
-            self.assertEqual(state_dict['zero_point'], 53)
-            b = io.BytesIO()
-            torch.save(state_dict, b)
-            for weights_only in [True, False]:
-                b.seek(0)
-                loaded_dict = torch.load(b, weights_only=weights_only)
-                loaded_fq_module = FakeQuantizeClass(observer, quant_min, quant_max)
-                loaded_fq_module.load_state_dict(loaded_dict)
-                for key in state_dict:
-                    self.assertEqual(state_dict[key], loaded_fq_module.state_dict()[key])
-
-                self.assertEqual(loaded_fq_module.calculate_qparams(), fq_module.calculate_qparams())
-
-    def test_fake_quant_control(self):
-        for fq_module in [torch.ao.quantization.default_fake_quant(),
-                          _LearnableFakeQuantize.with_args(observer=MovingAverageMinMaxObserver, quant_min=0,
-                                                           quant_max=255,
-                                                           dtype=torch.quint8, qscheme=torch.per_tensor_affine,
-                                                           reduce_range=True)()]:
-            torch.manual_seed(42)
-            X = torch.rand(20, 10, dtype=torch.float32)
-            # Output of fake quant is not identical to input
-            Y = fq_module(X)
-            self.assertNotEqual(Y, X)
-            if type(fq_module) is _LearnableFakeQuantize:
-                fq_module.toggle_fake_quant(False)
-            else:
-                torch.ao.quantization.disable_fake_quant(fq_module)
-            X = torch.rand(20, 10, dtype=torch.float32)
-            Y = fq_module(X)
-            # Fake quant is disabled,output is identical to input
-            self.assertEqual(Y, X)
-
-            # Explicit copy at this point in time, because FakeQuant keeps internal
-            # state in mutable buffers.
-            scale = fq_module.scale.detach().clone()
-            zero_point = fq_module.zero_point.detach().clone()
-
-            if type(fq_module) is _LearnableFakeQuantize:
-                fq_module.toggle_observer_update(False)
-                fq_module.toggle_fake_quant(True)
-            else:
-                torch.ao.quantization.disable_observer(fq_module)
-                torch.ao.quantization.enable_fake_quant(fq_module)
-            X = 10.0 * torch.rand(20, 10, dtype=torch.float32) - 5.0
-            Y = fq_module(X)
-            self.assertNotEqual(Y, X)
-            # Observer is disabled, scale and zero-point do not change
-            self.assertEqual(fq_module.scale, scale)
-            self.assertEqual(fq_module.zero_point, zero_point)
-            if type(fq_module) is _LearnableFakeQuantize:
-                fq_module.toggle_observer_update(True)
-            else:
-                torch.ao.quantization.enable_observer(fq_module)
-            Y = fq_module(X)
-            self.assertNotEqual(Y, X)
-            # Observer is enabled, scale and zero-point are different
-            self.assertNotEqual(fq_module.scale, scale)
-            self.assertNotEqual(fq_module.zero_point, zero_point)
-
-    def test_fake_quant_preserves_qparam_shapes_for_activations(self):
-        class Model(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.linear = nn.Linear(4, 4)
-
-            def forward(self, x):
-                x = self.linear(x)
-                return x
-
-        m = Model()
-
-        m.qconfig = torch.ao.quantization.get_default_qat_qconfig('fbgemm')
-        torch.ao.quantization.prepare_qat(m, inplace=True)
-
-        scale_shape_before = m.linear.activation_post_process.scale.shape
-        zero_point_shape_before = m.linear.activation_post_process.zero_point.shape
-
-        x = torch.rand(4, 4, 4, 4)
-        m(x)
-        scale_shape_after = m.linear.activation_post_process.scale.shape
-        zero_point_shape_after = m.linear.activation_post_process.zero_point.shape
-        self.assertEqual(
-            scale_shape_before, scale_shape_after,
-            msg="FakeQuant scale shape must stay consistent")
-        self.assertEqual(
-            zero_point_shape_before, zero_point_shape_after,
-            msg="FakeQuant zero_point shape must stay consistent")
-
-    def fake_quant_scriptable(self):
-        observer = default_observer
-        quant_min = 0
-        quant_max = 255
-        for FakeQuantizeClass in [FakeQuantize, _LearnableFakeQuantize]:
-            fq_module = FakeQuantizeClass(observer, quant_min, quant_max)
-            scripted_module = torch.jit.script(fq_module)
-
-            X = torch.tensor([-5, -3.5, -2, 0, 3, 5, 7], dtype=torch.float32)
-
-            fq_module(X)
-            scripted_module(X)
-            self.assertEqual(fq_module.calculate_qparams(), scripted_module.calculate_qparams())
-
-            buf = io.BytesIO()
-            torch.jit.save(scripted_module, buf)
-            buf.seek(0)
-            loaded_module = torch.jit.load(buf)
-            self.assertEqual(fq_module.calculate_qparams(), loaded_module.calculate_qparams())
-
-
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
@@ -763,35 +814,6 @@ class TestFakeQuantizeOps(TestCase):
     @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
     def test_forward_per_channel_cachemask_cuda(self):
         self._test_forward_per_channel_cachemask_impl('cuda')
-
-    def test_forward_per_channel_half_precision_numerics(self):
-        scale = torch.randn(5).abs()
-        zero = torch.randn(5).to(dtype=torch.int)
-        axis = 1
-        mini = 0
-        maxi = 255
-
-        for _ in range(20):
-            X1 = torch.randn(4, 5).to(torch.float16)
-            Y1 = torch.fake_quantize_per_channel_affine(X1, scale, zero, axis, mini, maxi)
-            Y1r = _fake_quantize_per_channel_affine_reference(X1, scale, zero, axis, mini, maxi)
-            self.assertEqual(Y1, Y1r, rtol=tolerance, atol=tolerance)
-
-        # to force overflow
-        X2 = torch.randn(4, 5).to(torch.float16)
-        X2[0, 0] = 2**15 + .01
-        Y2 = torch.fake_quantize_per_channel_affine(X2, scale, zero, axis, mini, maxi)
-        Y2r = _fake_quantize_per_channel_affine_reference(X2, scale, zero, axis, mini, maxi)
-        self.assertEqual(Y2, Y2r, rtol=tolerance, atol=tolerance)
-
-        scale = torch.zeros(5) + 10
-
-        # to force underflow
-        X3 = torch.randn(4, 5).to(torch.float16)
-        X3[0, 0] = 2**-24
-        Y3 = torch.fake_quantize_per_channel_affine(X3, scale, zero, axis, mini, maxi)
-        Y3r = _fake_quantize_per_channel_affine_reference(X3, scale, zero, axis, mini, maxi)
-        self.assertEqual(Y3, Y3r, rtol=tolerance, atol=tolerance)
 
     @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
@@ -1059,29 +1081,6 @@ class TestFakeQuantizeOps(TestCase):
                     self.assertEqual(
                         Y, Y_prime, "Difference found between dequant+quant_per_channel and fake_quantize_per_channel")
                 self.assertTrue(test_was_run)
-
-    @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
-    def test_fake_quantize_per_channel_affine_scale_dtypes(self):
-        """
-        Ensure the error message is more helpful
-        """
-        dtype_list = [torch.float, torch.float64, torch.bfloat16, torch.half]
-        for scale_dtype in dtype_list:
-            input = torch.randn(3, 4, 5, 6)
-            scale = torch.Tensor([0.1, 0.2, 0.3, 0.4]).to(scale_dtype)
-            zero_point = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
-            axis = 1
-            quant_min = 0
-            quant_max = 255
-            if scale_dtype != torch.float:
-                with self.assertRaises(RuntimeError):
-                    torch.fake_quantize_per_channel_affine(
-                        input, scale, zero_point, axis, quant_min, quant_max
-                    )
-            else:
-                torch.fake_quantize_per_channel_affine(
-                    input, scale, zero_point, axis, quant_min, quant_max
-                )
 
     @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
     @given(dtype=st.sampled_from([torch.float, torch.float64, torch.half, torch.bfloat16]),

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -25,12 +25,23 @@ import unittest
 import numpy as np
 
 # Testing utils
-from hypothesis import given, settings
-from hypothesis import strategies as st
+from hypothesis import given
 import torch.testing._internal.hypothesis_utils as hu
 hu.assert_deadline_disabled()
-from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import TestCase, skipIfTorchDynamo
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    dtypesIfCPU,
+    instantiate_device_type_tests,
+    onlyAccelerator,
+    onlyCPU,
+    skipCPUIf,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    parametrize,
+    TestCase,
+    skipIfTorchDynamo,
+)
 
 # Reference method for fake quantize
 # Note: because scale/zero_point are left as float in the actual kernel, this mimics how fake_quant works for float16/64
@@ -286,6 +297,8 @@ NP_RANDOM_SEED = 19
 tolerance = 1e-6
 
 class TestFakeQuantizeOps(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_forward_per_tensor_half_precision_numerics(self):
         scale = .1
         zero = 0
@@ -483,8 +496,11 @@ class TestFakeQuantizeOps(TestCase):
                     input, scale, zero_point, axis, quant_min, quant_max
                 )
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           X=hu.tensor(shapes=hu.array_shapes(1, 5,),
+
+class TestFakeQuantizeOpsDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
     def test_forward_per_tensor(self, device, X):
         r"""Tests the forward path of the FakeQuantizePerTensorAffine op.
@@ -500,8 +516,7 @@ class TestFakeQuantizeOps(TestCase):
             X, scale, zero_point, quant_min, quant_max)
         np.testing.assert_allclose(Y, Y_prime.cpu(), rtol=tolerance, atol=tolerance)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           X=hu.tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
     @unittest.skip("temporarily disable the test")
     def test_backward_per_tensor(self, device, X):
@@ -523,18 +538,20 @@ class TestFakeQuantizeOps(TestCase):
         Y_prime.backward(dout)
         np.testing.assert_allclose(dX.cpu(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
-    def test_forward_backward_per_tensor_with_amp(self):
+    @onlyAccelerator
+    def test_forward_backward_per_tensor_with_amp(self, device):
         net = nn.Sequential(nn.Conv2d(1, 1, 3))
         net.qconfig = torch.ao.quantization.get_default_qat_qconfig('fbgemm')
         net_prep = torch.ao.quantization.prepare_qat(net)
 
-        with torch.cuda.amp.autocast():
+        device_type = torch.device(device).type
+        with torch.amp.autocast(device_type):
             x = torch.randn(4, 1, 5, 5)
             out = net_prep(x).sum()
             out.backward()
             self.assertTrue(net_prep[0].weight.grad is not None)
 
-    def _test_forward_per_tensor_cachemask_impl(self, device):
+    def test_forward_per_tensor_cachemask(self, device):
         float_types = (torch.float32, torch.float16, torch.float64, torch.bfloat16)
         torch_types = (torch.qint8, torch.quint8)
         Xs = (torch.randn(4, 8, device=device), torch.randn(4, 16, device=device)[:, ::2])
@@ -556,16 +573,7 @@ class TestFakeQuantizeOps(TestCase):
             self.assertEqual(Y_test, Y_ref, rtol=tolerance, atol=tolerance)
             self.assertTrue(Y_test.dtype == float_type)
 
-    def test_forward_per_tensor_cachemask_cpu(self):
-        device = torch.device('cpu')
-        self._test_forward_per_tensor_cachemask_impl(device)
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_forward_per_tensor_cachemask_cuda(self):
-        device = torch.device('cuda')
-        self._test_forward_per_tensor_cachemask_impl(device)
-
-    def _test_backward_per_tensor_cachemask_impl(self, device):
+    def test_backward_per_tensor_cachemask(self, device):
         float_types = (torch.float32, torch.float16, torch.float64)
         torch_types = (torch.qint8, torch.quint8)
         tensor_qparams = (True, False)
@@ -596,16 +604,18 @@ class TestFakeQuantizeOps(TestCase):
             self.assertEqual(dX, X.grad)
             self.assertTrue(X.grad.dtype == float_type)
 
-    def test_backward_per_tensor_cachemask_cpu(self):
-        device = torch.device('cpu')
-        self._test_backward_per_tensor_cachemask_impl(device)
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_backward_per_tensor_cachemask_cuda(self):
-        device = torch.device('cuda')
-        self._test_backward_per_tensor_cachemask_impl(device)
-
-    def _test_learnable_forward_per_tensor(self, X, device, scale_base, zero_point_base):
+    @skipCPUIf(
+        True,
+        "this is broken without changes to any relevant code, "
+        "we need to remove hypothesis testing in CI"
+    )
+    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
+                       elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
+                       qparams=hu.qparams(dtypes=torch.quint8)))
+    def test_learnable_forward_per_tensor(self, device, X):
+        X, (_, _, _) = X
+        scale_base = torch.normal(mean=0, std=1, size=(1,)).clamp(1e-4, 100)
+        zero_point_base = torch.normal(mean=0, std=128, size=(1,))
         X_base = torch.tensor(X).to(device)
 
         for n_bits in (4, 8):
@@ -625,30 +635,6 @@ class TestFakeQuantizeOps(TestCase):
                 self.assertTrue(
                     torch.allclose(Y, Y_prime, rtol=tolerance, atol=tolerance),
                     "Expected kernel forward function to have results match the reference forward function")
-
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
-                       elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
-                       qparams=hu.qparams(dtypes=torch.quint8)))
-    @unittest.skip(
-        "this is broken without changes to any relevant code, "
-        "we need to remove hypothesis testing in CI")
-    def test_learnable_forward_per_tensor_cpu(self, X):
-        X, (_, _, _) = X
-        scale_base = torch.normal(mean=0, std=1, size=(1,)).clamp(1e-4, 100)
-        zero_point_base = torch.normal(mean=0, std=128, size=(1,))
-        self._test_learnable_forward_per_tensor(
-            X, 'cpu', scale_base, zero_point_base)
-
-    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
-                       elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
-                       qparams=hu.qparams(dtypes=torch.quint8)))
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_learnable_forward_per_tensor_cuda(self, X):
-        X, (_, _, _) = X
-        scale_base = torch.normal(mean=0, std=1, size=(1,)).clamp(1e-4, 100)
-        zero_point_base = torch.normal(mean=0, std=128, size=(1,))
-        self._test_learnable_forward_per_tensor(
-            X, 'cuda', scale_base, zero_point_base)
 
     def _test_learnable_backward_per_tensor(self, X, device, scale_base, zero_point_base, dtype=torch.float32):
         r"""Tests the backward method with additional backprop support for scale and zero point.
@@ -697,34 +683,34 @@ class TestFakeQuantizeOps(TestCase):
                 scale.grad.data.zero_()
                 zero_point.grad.data.zero_()
 
+    @onlyCPU
     @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        elements=hu.floats(-1e3, 1e3, allow_nan=False, allow_infinity=False),
                        qparams=hu.qparams(dtypes=torch.quint8)))
-    def test_learnable_backward_per_tensor_cpu(self, X):
+    def test_learnable_backward_per_tensor(self, device, X):
         torch.random.manual_seed(NP_RANDOM_SEED)
         X, (_, _, _) = X
         scale_base = torch.normal(mean=0, std=1, size=(1,)).clamp(1e-4, 100)
         zero_point_base = torch.normal(mean=0, std=128, size=(1,))
         self._test_learnable_backward_per_tensor(
-            X, 'cpu', scale_base, zero_point_base)
+            X, device, scale_base, zero_point_base)
 
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_learnable_backward_per_tensor_cuda(self):
+    @onlyAccelerator
+    @dtypes(torch.bfloat16, torch.float32)
+    def test_learnable_backward_per_tensor_accelerator(self, device, dtype):
         # setting seed to avoid increasing tolerance due to cases where
         # difference in Python vs CPP downcasting causes tensor mismatches
         # e.g. 27.87704 vs  27.8408 before downcasting, 27.7500 vs 27.8750 after downcasting for Python vs CPP op
         torch.random.manual_seed(12)
         x_shape = (2, 1)
 
-        for dtype in [torch.bfloat16, torch.float32]:
-            X_base = torch.randn(x_shape, dtype=dtype, device='cuda')
-            scale_base = torch.normal(mean=0, std=1, size=(1,)).clamp(1e-4, 100).to(dtype=dtype)
-            zero_point_base = torch.normal(mean=0, std=128, size=(1,)).to(dtype=dtype)
-            self._test_learnable_backward_per_tensor(
-                X_base, 'cuda', scale_base, zero_point_base, dtype)
+        X_base = torch.randn(x_shape, dtype=dtype, device=device)
+        scale_base = torch.normal(mean=0, std=1, size=(1,)).clamp(1e-4, 100).to(dtype=dtype)
+        zero_point_base = torch.normal(mean=0, std=128, size=(1,)).to(dtype=dtype)
+        self._test_learnable_backward_per_tensor(
+            X_base, device, scale_base, zero_point_base, dtype)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           X=hu.tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=[torch.quint8])),
            )
     def test_fq_module_per_tensor(self, device, X):
@@ -750,8 +736,7 @@ class TestFakeQuantizeOps(TestCase):
         dX = _fake_quantize_per_tensor_affine_grad_reference(dout, X, fq_module.scale, fq_module.zero_point, quant_min, quant_max)
         np.testing.assert_allclose(dX.cpu().numpy(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           X=hu.tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.tensor(shapes=hu.array_shapes(1, 5,),
                        qparams=hu.qparams(dtypes=torch.quint8)))
     def test_fixed_qparams_fq_module(self, device, X):
         X, (scale, zero_point, torch_type) = X
@@ -766,8 +751,7 @@ class TestFakeQuantizeOps(TestCase):
         self.assertEqual(fixed_scale, fq_module.scale)
         self.assertEqual(fixed_zero_point, fq_module.zero_point)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
     def test_forward_per_channel(self, device, X):
         r"""Tests the forward path of the FakeQuantizePerTensorAffine op.
@@ -785,7 +769,7 @@ class TestFakeQuantizeOps(TestCase):
             X, scale, zero_point, axis, quant_min, quant_max)
         np.testing.assert_allclose(Y, Y_prime.cpu(), rtol=tolerance, atol=tolerance)
 
-    def _test_forward_per_channel_cachemask_impl(self, device):
+    def test_forward_per_channel_cachemask(self, device):
         torch_types = (torch.qint8, torch.quint8)
         float_types = (torch.float32, torch.float16, torch.float64, torch.bfloat16)
         zero_point_types = (torch.int, torch.float32, torch.float16)
@@ -808,40 +792,32 @@ class TestFakeQuantizeOps(TestCase):
             torch.testing.assert_close(Y, Y_prime.cpu(), rtol=tolerance, atol=tolerance)
             self.assertTrue(Y.dtype == float_type)
 
-    def test_forward_per_channel_cachemask_cpu(self):
-        self._test_forward_per_channel_cachemask_impl('cpu')
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_forward_per_channel_cachemask_cuda(self):
-        self._test_forward_per_channel_cachemask_impl('cuda')
-
     @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
-    def test_fake_quant_per_channel_qparam_range(self, X):
+    def test_fake_quant_per_channel_qparam_range(self, device, X):
         X, (scale, zero_point, axis, torch_type) = X
         quant_min = torch.iinfo(torch_type).min
         quant_max = torch.iinfo(torch_type).max
 
-        for device in ['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']:
-            X = to_tensor(X, device)
-            scale = to_tensor(scale, device)
+        X = to_tensor(X, device)
+        scale = to_tensor(scale, device)
 
-            # Ensure that zero_point < quant_min.
-            zero_point = torch.full(zero_point.shape, -1 - quant_min).to(dtype=torch.int32, device=device)
+        # Ensure that zero_point < quant_min.
+        zero_point = torch.full(zero_point.shape, -1 - quant_min).to(dtype=torch.int32, device=device)
 
-            # For non-float zero_point, fakequant requires zero_point between quant_min and quant_max.
-            with self.assertRaisesRegex(RuntimeError, "`zero_point` must be between `quant_min` and `quant_max`."):
-                Y = torch.fake_quantize_per_channel_affine(X, scale, zero_point, axis, quant_min, quant_max)
+        # For non-float zero_point, fakequant requires zero_point between quant_min and quant_max.
+        with self.assertRaisesRegex(RuntimeError, "`zero_point` must be between `quant_min` and `quant_max`."):
+            Y = torch.fake_quantize_per_channel_affine(X, scale, zero_point, axis, quant_min, quant_max)
 
-            # For float zero_point, fakequant can be outside quant_min and quant_max.
-            for zero_point_dtype in [torch.float32, torch.float16]:
-                zero_point = zero_point.to(dtype=zero_point_dtype)
-                Y = torch.fake_quantize_per_channel_affine(X, scale, zero_point, axis, quant_min, quant_max)
-                Y_ref = _fake_quantize_per_channel_affine_reference(X.cpu(), scale.cpu(), zero_point.cpu(),
-                                                                    axis, quant_min, quant_max)
-                np.testing.assert_allclose(Y.cpu().numpy(), Y_ref.cpu().numpy(), rtol=tolerance, atol=tolerance)
+        # For float zero_point, fakequant can be outside quant_min and quant_max.
+        for zero_point_dtype in [torch.float32, torch.float16]:
+            zero_point = zero_point.to(dtype=zero_point_dtype)
+            Y = torch.fake_quantize_per_channel_affine(X, scale, zero_point, axis, quant_min, quant_max)
+            Y_ref = _fake_quantize_per_channel_affine_reference(X.cpu(), scale.cpu(), zero_point.cpu(),
+                                                                axis, quant_min, quant_max)
+            np.testing.assert_allclose(Y.cpu().numpy(), Y_ref.cpu().numpy(), rtol=tolerance, atol=tolerance)
 
-    def _test_learnable_forward_per_channel(self, X_base, device, scale_base, zero_point_base, axis):
+    def _test_learnable_forward_per_channel(self, device, X_base, scale_base, zero_point_base, axis):
         r"""Tests the forward path of the learnable FakeQuantizePerTensorAffine op.
         """
         for n_bits in (4, 8):
@@ -863,35 +839,35 @@ class TestFakeQuantizeOps(TestCase):
                     torch.allclose(Y, Y_prime, rtol=tolerance, atol=tolerance),
                     "Expected kernel forward function to have results match the reference forward function")
 
+    @onlyCPU
     @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
                                    qparams=hu.qparams(dtypes=torch.quint8)))
-    def test_learnable_forward_per_channel_cpu(self, X):
+    def test_learnable_forward_per_channel(self, device, X):
         torch.random.manual_seed(NP_RANDOM_SEED)
         X, (_, _, axis, _) = X
-        X_base = torch.tensor(X).to('cpu')
+        X_base = torch.tensor(X).to(device)
         channel_size = X_base.size(axis)
         scale_base = torch.normal(mean=0, std=1, size=(channel_size,)).clamp(1e-4, 100)
         zero_point_base = torch.normal(mean=0, std=128, size=(channel_size,))
         self._test_learnable_forward_per_channel(
-            X_base, 'cpu', scale_base, zero_point_base, axis)
+            device, X_base, scale_base, zero_point_base, axis)
 
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_learnable_forward_per_channel_cuda(self):
+    @onlyAccelerator
+    @dtypes(torch.float32, torch.bfloat16)
+    def test_learnable_forward_per_channel_accelerator(self, device, dtype):
         torch.random.manual_seed(NP_RANDOM_SEED)
         shape = (2, 1, 2, 10)
         axis = 1
 
-        for dtype in [torch.float32, torch.bfloat16]:
-            X_base = torch.randn(shape, device="cuda").to(dtype)
-            channel_size = X_base.size(axis)
-            scale_base = torch.normal(mean=0, std=1, size=(channel_size,)).clamp(1e-4, 100).to(dtype)
-            zero_point_base = torch.normal(mean=0, std=128, size=(channel_size,)).to(dtype)
+        X_base = torch.randn(shape, device=device).to(dtype)
+        channel_size = X_base.size(axis)
+        scale_base = torch.normal(mean=0, std=1, size=(channel_size,)).clamp(1e-4, 100).to(dtype)
+        zero_point_base = torch.normal(mean=0, std=128, size=(channel_size,)).to(dtype)
 
-            self._test_learnable_forward_per_channel(
-                X_base, 'cuda', scale_base, zero_point_base, axis)
+        self._test_learnable_forward_per_channel(
+            device, X_base, scale_base, zero_point_base, axis)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
+    @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(1, 5,),
            qparams=hu.qparams(dtypes=torch.quint8)))
     @unittest.skip(
         "this is broken without changes to any relevant code, "
@@ -918,7 +894,7 @@ class TestFakeQuantizeOps(TestCase):
             Y_prime.backward(dout)
             np.testing.assert_allclose(dX.cpu().detach().numpy(), X.grad.cpu().detach().numpy(), rtol=tolerance, atol=tolerance)
 
-    def _test_backward_per_channel_cachemask_impl(self, device):
+    def test_backward_per_channel_cachemask(self, device):
         torch_types = (torch.qint8, torch.quint8)
         float_types = (torch.float32, torch.float16, torch.float64)
         zero_point_types = (torch.int, torch.float32, torch.float16)
@@ -947,15 +923,7 @@ class TestFakeQuantizeOps(TestCase):
                     f"Expected X.grad.dtype to be {float_type}, got {X.grad.dtype}"
                 )
 
-
-    def test_backward_per_channel_cachemask_cpu(self):
-        self._test_backward_per_channel_cachemask_impl('cpu')
-
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_backward_per_channel_cachemask_cuda(self):
-        self._test_backward_per_channel_cachemask_impl('cuda')
-
-    def _test_learnable_backward_per_channel(self, X_base, device, scale_base, zero_point_base, axis, dtype=torch.float32):
+    def _test_learnable_backward_per_channel(self, device, X_base, scale_base, zero_point_base, axis, dtype=torch.float32):
         r"""Tests the backward path of the learnable FakeQuantizePerTensorAffine op.
         """
         for n_bits in (4, 8):
@@ -1005,12 +973,13 @@ class TestFakeQuantizeOps(TestCase):
                 scale_curr.grad.data.zero_()
                 zero_point_curr.grad.data.zero_()
 
+    @onlyCPU
     @given(X=hu.per_channel_tensor(shapes=hu.array_shapes(2, 5,),
                                    qparams=hu.qparams(dtypes=torch.quint8)))
     @unittest.skip(
         "this is broken without changes to any relevant code, "
         "we need to remove hypothesis testing in CI")
-    def test_learnable_backward_per_channel_cpu(self, X):
+    def test_learnable_backward_per_channel(self, device, X):
         torch.random.manual_seed(NP_RANDOM_SEED)
         X, (_, _, axis, _) = X
         X_base = torch.tensor(X).to('cpu')
@@ -1018,31 +987,26 @@ class TestFakeQuantizeOps(TestCase):
         scale_base = torch.normal(mean=0, std=1, size=(channel_size,)).clamp(1e-4, 100)
         zero_point_base = torch.normal(mean=0, std=128, size=(channel_size,))
         self._test_learnable_backward_per_channel(
-            X_base, 'cpu', scale_base, zero_point_base, axis)
+            device, X_base, scale_base, zero_point_base, axis)
 
-    @unittest.skipIf(not TEST_CUDA, "No gpu is not available.")
-    def test_learnable_backward_per_channel_cuda(self):
+    @onlyAccelerator
+    @dtypes(torch.bfloat16, torch.float32)
+    def test_learnable_backward_per_channel_accelerator(self, device, dtype):
         torch.random.manual_seed(NP_RANDOM_SEED)
 
         x_shape = (2, 1)
         scale_shape = (2,)
         zero_point_shape = (2,)
         axis = 0
-        for dtype in [torch.bfloat16, torch.float32]:
-            X_base = torch.randn(x_shape, dtype=dtype, device='cuda')
-            scale_base = torch.randn(scale_shape, dtype=dtype, device='cuda')
-            zero_point_base = torch.randint(0, 10, zero_point_shape, device='cuda').to(dtype=dtype)
-            self._test_learnable_backward_per_channel(
-                X_base, 'cuda', scale_base, zero_point_base, axis, dtype
-            )
+        X_base = torch.randn(x_shape, dtype=dtype, device=device)
+        scale_base = torch.randn(scale_shape, dtype=dtype, device=device)
+        zero_point_base = torch.randint(0, 10, zero_point_shape, device=device).to(dtype=dtype)
+        self._test_learnable_backward_per_channel(
+            device, X_base, scale_base, zero_point_base, axis, dtype
+        )
 
-    def test_numerical_consistency_per_tensor(self):
-        self._test_numerical_consistency('per_tensor')
-
-    def test_numerical_consistency_per_channel(self):
-        self._test_numerical_consistency('per_channel')
-
-    def _test_numerical_consistency(self, test_type):
+    @parametrize("test_type", ["per_tensor", "per_channel"])
+    def test_numerical_consistency(self, device, test_type):
         r"""Comparing numerical consistency between quantize/dequantize op and the fake quantize op across devices and dtypes
         """
         torch.random.manual_seed(NP_RANDOM_SEED)
@@ -1052,10 +1016,9 @@ class TestFakeQuantizeOps(TestCase):
             zero_types = [torch.int, torch.float, torch.float16]
         else:
             zero_types = [torch.int]
-        devices = [torch.device('cpu'), torch.device('cuda')] if torch.cuda.is_available() else [torch.device('cpu')]
         axis = 1
         for _ in range(20):
-            for torch_type, float_type, device, zero_type in itertools.product(torch_types, float_types, devices, zero_types):
+            for torch_type, float_type, zero_type in itertools.product(torch_types, float_types, zero_types):
                 X = torch.randn(3, 3, device=device).to(float_type)
                 scales = (10 * torch.randn(3, device=device)).abs()
                 scale = scales.mean().to(float).item()
@@ -1083,9 +1046,8 @@ class TestFakeQuantizeOps(TestCase):
                 self.assertTrue(test_was_run)
 
     @skipIfTorchDynamo("Not a suitable test for TorchDynamo")
-    @given(dtype=st.sampled_from([torch.float, torch.float64, torch.half, torch.bfloat16]),
-           device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']))
-    def test_fake_quantize_per_tensor_affine_inf(self, dtype, device) -> None:
+    @dtypes(torch.float, torch.float64, torch.half, torch.bfloat16)
+    def test_fake_quantize_per_tensor_affine_inf(self, device, dtype) -> None:
         # https://github.com/pytorch/pytorch/issues/154328
         input_tensor = torch.tensor([torch.inf], dtype=dtype).to(device)
         scale = 0.01
@@ -1098,20 +1060,18 @@ class TestFakeQuantizeOps(TestCase):
         self.assertEqual(result, ref_result)
 
 
-class TestFusedObsFakeQuant(TestCase):
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           sampled_dtype=st.sampled_from(['bf16', 'fp16', 'fp32']),
-           symmetric_quant=st.booleans(), use_bool=st.booleans())
-    @settings(deadline=None)
-    def test_fused_obs_fake_quant_moving_avg(self, device, sampled_dtype, symmetric_quant, use_bool) -> None:
+class TestFusedObsFakeQuantDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @dtypes(torch.bfloat16, torch.float16, torch.float32)
+    @dtypesIfCPU(torch.float32)
+    @parametrize("symmetric_quant", [True, False])
+    @parametrize("use_bool", [True, False])
+    def test_fused_obs_fake_quant_moving_avg(self, device, dtype, symmetric_quant, use_bool) -> None:
         """
         Tests the case where we call the fused_obs_fake_quant op multiple times
         and update the running_min and max of the activation tensors.
         """
-        if device == "cpu":
-            sampled_dtype = "fp32"
-        dtype = {'bf16' : torch.bfloat16, 'fp16' : torch.half, 'fp32' : torch.float32}[sampled_dtype]
-
         in_running_min_ref = out_running_min_ref = torch.tensor(float("inf"), dtype=dtype)
         in_running_min_op = torch.tensor(float("inf"), dtype=dtype, device=device)
         in_running_max_ref = out_running_max_ref = torch.tensor(float("-inf"), dtype=dtype)
@@ -1195,9 +1155,8 @@ class TestFusedObsFakeQuant(TestCase):
         output_shape = (0, 5)
         self.assertEqual(out.shape, output_shape)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
-           symmetric_quant=st.booleans(), use_bool=st.booleans())
-    @settings(deadline=None)
+    @parametrize("symmetric_quant", [True, False])
+    @parametrize("use_bool", [True, False])
     def test_fused_obs_fake_quant_moving_avg_per_channel(self, device, symmetric_quant, use_bool) -> None:
         """
         Tests the case where we call the fused_obs_fake_quant op multiple times
@@ -1268,8 +1227,6 @@ class TestFusedObsFakeQuant(TestCase):
                 self.assertEqual(in_running_max_ref, in_running_max_op)
                 torch.testing.assert_close(out, x_in)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),)
-    @settings(deadline=None)
     def test_fused_obs_fake_quant_backward_op(self, device) -> None:
         n = m = k = 10
         input_shape = (m, n)
@@ -1319,8 +1276,6 @@ class TestFusedObsFakeQuant(TestCase):
         self.assertEqual(dX, x.grad)
         self.assertTrue(x.grad.dtype == torch.float32)
 
-    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),)
-    @settings(deadline=None)
     def test_fused_backward_op_fake_quant_off(self, device) -> None:
         n = m = 4
         input_shape = (m, n)
@@ -1364,6 +1319,12 @@ class TestFusedObsFakeQuant(TestCase):
             dout, x, x_scale, x_zero_point, 0, 255)
         self.assertEqual(dX, x.grad)
         self.assertTrue(x.grad.dtype == torch.float32)
+
+
+only_for = ("cpu", "cuda")
+instantiate_device_type_tests(TestFakeQuantizeOpsDevice, globals(), only_for=only_for)
+instantiate_device_type_tests(TestFusedObsFakeQuantDevice, globals(), only_for=only_for)
+
 
 if __name__ == '__main__':
     raise RuntimeError("This test file is not meant to be run directly, use:\n\n"


### PR DESCRIPTION
This PR refactors `test/quantization/core/test_workflow_ops.py` test file to separate device-related tests from device-unrelated ones and make the cuda-specific tests device-agnostic. It also enables testing XPU.

### Review notes

I split changes into two main commits:
| commit | description |
| - | - |
| **Only change functions order.** | This commit only changes order of test functions. **NO FUNCTIONAL CHANGES AT ALL** |
| **Refactor.** | This commit applies the real refactor. |
| **Enable testing XPU.** | As in commit title. |

Any further commits are addressing review comments.

###  Main Changes

- Split `TestFakeQuantizeOps` test class into device-unrelated `TestFakeQuantizeOps` and device-related `TestFakeQuantizeOpsDevice`. Move test functions to appropriate test class.
- Rename `TestFusedObsFakeQuant` to `TestFusedObsFakeQuantDevice` as it contains only device-related test functions.
- Instantiate device-related test classes with `instantiate_device_type_tests`.
- Add `HardwareClassification` to all test classes.
- Change hypothesis-based device parametrization `@given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']))` to test function `device` parameter provided by `instantiate_device_type_tests`.
- Mark test functions that had `"cuda"` or `torch.cuda` hardcoded with `@onlyAccelerator` decorator.
- Change `for dtype in [torch.bfloat16, torch.float32]:` dtype parametrization to `@dtypes()` decorator and `dtype` functions parameter.
- Mark tests that had previously hardcoded `"cpu"` device as `@onlyCPU`.
- Enable testing XPU.