### PR TITLE
Deduplicate the ScalarType->dtype table shared by lowering.py and symmetric memory

### DIFF
--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -256,6 +256,7 @@ add_needs_realized_inputs(
     ]
 )
 
+
 # TODO(jansel): ezyang says we won't need this in the future, try removing it
 def decode_dtype(dtype: int | torch.dtype) -> torch.dtype:
     if not isinstance(dtype, int):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -45,6 +45,7 @@ from torch._prims_common import (
     is_integer_dtype,
     Number,
 )
+from torch._utils import _decode_scalar_type
 from torch.fx.experimental.sym_node import magic_methods, method_to_operator
 from torch.fx.experimental.symbolic_shapes import (
     free_unbacked_symbols,
@@ -256,38 +257,13 @@ add_needs_realized_inputs(
 )
 
 # TODO(jansel): ezyang says we won't need this in the future, try removing it
-# based on https://github.com/pytorch/pytorch/blob/9e3eb329df8f701/c10/core/ScalarType.h#L28
-DTYPE_ID_LOOKUP = {
-    0: torch.uint8,
-    1: torch.int8,
-    2: torch.int16,
-    3: torch.int32,
-    4: torch.int64,
-    5: torch.float16,
-    6: torch.float32,
-    7: torch.float64,
-    8: torch.complex32,
-    9: torch.complex64,
-    10: torch.complex32,
-    11: torch.bool,
-    15: torch.bfloat16,
-    # TODO(jansel): add quantized types?
-    #  _(c10::qint8, QInt8) /* 12 */
-    # _(c10::quint8, QUInt8) /* 13 */
-    # _(c10::qint32, QInt32) /* 14 */
-    # _(c10::quint4x2, QUInt4x2) /* 16 */
-    # _(c10::quint2x4, QUInt2x4) /* 17 */
-}
-
-
 def decode_dtype(dtype: int | torch.dtype) -> torch.dtype:
     if not isinstance(dtype, int):
         return dtype
-    if dtype not in DTYPE_ID_LOOKUP:
-        raise AssertionError(f"id {dtype} missing from DTYPE_ID_LOOKUP")
-
-    dtype = DTYPE_ID_LOOKUP[dtype]
-    return dtype
+    try:
+        return _decode_scalar_type(dtype)
+    except IndexError:
+        raise AssertionError(f"unrecognized scalar type {dtype}") from None
 
 
 def is_integer_type(x: object) -> TypeGuard[TensorBox | IRNode | sympy.Expr | int]:

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -21,7 +21,7 @@ import torch
 
 
 @functools.cache
-def _scalar_type_to_dtype() -> tuple[torch.dtype, ...]:
+def _scalar_type_to_dtype() -> "tuple[torch.dtype, ...]":
     # Indexed by c10::ScalarType (see ScalarType.h's
     # AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS); append-only.
     #
@@ -62,7 +62,7 @@ def _scalar_type_to_dtype() -> tuple[torch.dtype, ...]:
     )
 
 
-def _decode_scalar_type(scalar_type: int) -> torch.dtype:
+def _decode_scalar_type(scalar_type: int) -> "torch.dtype":
     dtypes = _scalar_type_to_dtype()
     if not (0 <= scalar_type < len(dtypes)):
         raise IndexError(scalar_type)

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -20,6 +20,55 @@ from typing_extensions import deprecated, NotRequired, ParamSpec
 import torch
 
 
+@functools.cache
+def _scalar_type_to_dtype() -> tuple[torch.dtype, ...]:
+    # Indexed by c10::ScalarType (see ScalarType.h's
+    # AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS); append-only.
+    #
+    # This is deferred (rather than a module-level tuple) because torch._utils
+    # is imported by torch/__init__.py before `torch._C import *` populates
+    # dtype attributes like `torch.uint8` on the torch module.
+    return (
+        torch.uint8,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.complex32,
+        torch.complex64,
+        torch.complex128,
+        torch.bool,
+        torch.qint8,
+        torch.quint8,
+        torch.qint32,
+        torch.bfloat16,
+        torch.quint4x2,
+        torch.quint2x4,
+        torch.bits1x8,
+        torch.bits2x4,
+        torch.bits4x2,
+        torch.bits8,
+        torch.bits16,
+        torch.float8_e5m2,
+        torch.float8_e4m3fn,
+        torch.float8_e5m2fnuz,
+        torch.float8_e4m3fnuz,
+        torch.uint16,
+        torch.uint32,
+        torch.uint64,
+    )
+
+
+def _decode_scalar_type(scalar_type: int) -> torch.dtype:
+    dtypes = _scalar_type_to_dtype()
+    if not (0 <= scalar_type < len(dtypes)):
+        raise IndexError(scalar_type)
+    return dtypes[scalar_type]
+
+
 def _type(self, dtype=None, non_blocking=False, **kwargs):
     """Returns the type if `dtype` is not provided, else casts this object to
     the specified type.

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -1702,7 +1702,11 @@ def _maybe_convert_scalar_types_to_dtypes(
     `ScalarType[]`, it is converted to a list of scalar type enum values. This
     function converts it back to a list of `torch.dtype`s.
     """
-    # Order defined in https://github.com/pytorch/pytorch/blob/344defc9733a45fee8d0c4d3f5530f631e823196/c10/core/ScalarType.h
+    # Values are the c10::ScalarType enumerators, whose numbering is part of the
+    # serialization format and so is append-only. Keep this in step with
+    # AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS in
+    # torch/headeronly/core/ScalarType.h; the indices there are written in a
+    # trailing comment on each line.
     _SCALAR_TYPE_TO_DTYPE = {
         0: torch.uint8,
         1: torch.int8,
@@ -1720,10 +1724,20 @@ def _maybe_convert_scalar_types_to_dtypes(
         13: torch.quint8,
         14: torch.qint32,
         15: torch.bfloat16,
-        16: torch.float8_e5m2,
-        17: torch.float8_e4m3fn,
-        18: torch.float8_e5m2fnuz,
-        19: torch.float8_e4m3fnuz,
+        16: torch.quint4x2,
+        17: torch.quint2x4,
+        18: torch.bits1x8,
+        19: torch.bits2x4,
+        20: torch.bits4x2,
+        21: torch.bits8,
+        22: torch.bits16,
+        23: torch.float8_e5m2,
+        24: torch.float8_e4m3fn,
+        25: torch.float8_e5m2fnuz,
+        26: torch.float8_e4m3fnuz,
+        27: torch.uint16,
+        28: torch.uint32,
+        29: torch.uint64,
     }
     if any(not isinstance(x, (type(None), int)) for x in scalar_types):
         return scalar_types

--- a/torch/distributed/_symmetric_memory/__init__.py
+++ b/torch/distributed/_symmetric_memory/__init__.py
@@ -21,6 +21,7 @@ from torch._C._distributed_c10d import (
     Work as _Work,
 )
 from torch._prims_common import make_contiguous_strides_for
+from torch._utils import _decode_scalar_type
 from torch.utils._triton import has_triton
 
 
@@ -1702,43 +1703,6 @@ def _maybe_convert_scalar_types_to_dtypes(
     `ScalarType[]`, it is converted to a list of scalar type enum values. This
     function converts it back to a list of `torch.dtype`s.
     """
-    # Values are the c10::ScalarType enumerators, whose numbering is part of the
-    # serialization format and so is append-only. Keep this in step with
-    # AT_FORALL_SCALAR_TYPES_WITH_COMPLEX_AND_QINTS in
-    # torch/headeronly/core/ScalarType.h; the indices there are written in a
-    # trailing comment on each line.
-    _SCALAR_TYPE_TO_DTYPE = {
-        0: torch.uint8,
-        1: torch.int8,
-        2: torch.short,
-        3: torch.int,
-        4: torch.int64,
-        5: torch.half,
-        6: torch.float,
-        7: torch.double,
-        8: torch.complex32,
-        9: torch.complex64,
-        10: torch.complex128,
-        11: torch.bool,
-        12: torch.qint8,
-        13: torch.quint8,
-        14: torch.qint32,
-        15: torch.bfloat16,
-        16: torch.quint4x2,
-        17: torch.quint2x4,
-        18: torch.bits1x8,
-        19: torch.bits2x4,
-        20: torch.bits4x2,
-        21: torch.bits8,
-        22: torch.bits16,
-        23: torch.float8_e5m2,
-        24: torch.float8_e4m3fn,
-        25: torch.float8_e5m2fnuz,
-        26: torch.float8_e4m3fnuz,
-        27: torch.uint16,
-        28: torch.uint32,
-        29: torch.uint64,
-    }
     if any(not isinstance(x, (type(None), int)) for x in scalar_types):
         return scalar_types
 
@@ -1746,10 +1710,11 @@ def _maybe_convert_scalar_types_to_dtypes(
     for scalar_type in scalar_types:
         if scalar_type is None:
             dtypes.append(scalar_type)
-        elif scalar_type not in _SCALAR_TYPE_TO_DTYPE:
-            raise ValueError(f"Unrecognized scalar type {scalar_type}")
-        else:
-            dtypes.append(_SCALAR_TYPE_TO_DTYPE[scalar_type])
+            continue
+        try:
+            dtypes.append(_decode_scalar_type(scalar_type))
+        except IndexError:
+            raise ValueError(f"Unrecognized scalar type {scalar_type}") from None
     return dtypes
 
 


### PR DESCRIPTION
_SCALAR_TYPE_TO_DTYPE moves into torch/_utils.py as a single table both files use through `_decode_scalar_type()`, indexed by c10::ScalarType. lowering.py's copy had complex128 mapped as complex32 (duplicating index 8) and was missing indices 12-14 and 16-29; filling those in made the two tables identical, so they're now one.

The table is built lazily (`functools.cache`) rather than as a module-level tuple, because `torch/_utils.py` is imported by `torch/__init__.py` before `from torch._C import *` populates dtype attributes like `torch.uint8` — a module-level tuple referencing `torch.uint8` at import time breaks `import torch` itself.

Authored with AI assistance (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo