### PR TITLE
[MPS] route dropout through the fused kernel

### DIFF
--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -40,7 +40,7 @@ Tensor make_feature_noise(const Tensor& input) {
 }
 
 bool is_fused_kernel_acceptable(const Tensor& input, double p) {
-  return (input.is_cuda() || input.is_xpu() || input.is_lazy() || input.is_privateuseone()) && p > 0 && p < 1 && input.sym_numel() > 0;
+  return (input.is_cuda() || input.is_mps() || input.is_xpu() || input.is_lazy() || input.is_privateuseone()) && p > 0 && p < 1 && input.sym_numel() > 0;
 }
 
 // NB: sure, we could have used different overloads here, but I would feel insecure

--- a/aten/src/ATen/native/Dropout.cpp
+++ b/aten/src/ATen/native/Dropout.cpp
@@ -40,7 +40,12 @@ Tensor make_feature_noise(const Tensor& input) {
 }
 
 bool is_fused_kernel_acceptable(const Tensor& input, double p) {
-  return (input.is_cuda() || input.is_mps() || input.is_xpu() || input.is_lazy() || input.is_privateuseone()) && p > 0 && p < 1 && input.sym_numel() > 0;
+  const bool mps_fused_kernel_acceptable =
+      input.is_mps() && input.is_floating_point() &&
+      input.is_non_overlapping_and_dense();
+  return (input.is_cuda() || mps_fused_kernel_acceptable || input.is_xpu() ||
+          input.is_lazy() || input.is_privateuseone()) &&
+      p > 0 && p < 1 && input.sym_numel() > 0;
 }
 
 // NB: sure, we could have used different overloads here, but I would feel insecure


### PR DESCRIPTION
Previously, out-of-place `nn.Dropout` or `F.dropout` on MPS went through  non fused path, while we have the fused path available which just needed to be enabled. 


<details>
<summary> Perf </summary>

| dtype | Shape | Layout | Before (us) | After (us) | Speedup |
|---|---:|---|---:|---:|---:|
| bf16 | 256 x 1024 | contiguous | 19.0 | 10.6 | 1.79x |
| bf16 | 8 x 512 x 1024 | contiguous | 202.5 | 52.8 | 3.84x |
| bf16 | 4096 x 4096 | contiguous | 953.1 | 313.3 | 3.04x |
| bf16 | 2048 x 4096 | transposed dense | 791.2 | 154.5 | 5.12x |
| bf16 | 16 x 128 x 64 x 64 | channels-last | 792.7 | 153.3 | 5.17x |
| bf16 | 4 x 32 x 32 x 32 x 32 | channels-last-3d | 361.7 | 53.1 | 6.82x |
| fp16 | 4096 x 4096 | contiguous | 947.3 | 322.0 | 2.94x |
| fp32 | 4096 x 4096 | contiguous | 1518.0 | 585.0 | 2.59x |
| fp32 | 16 x 128 x 64 x 64 | channels-last | 880.9 | 285.9 | 3.08x |

</details>