### PR TITLE
[MPS] Route large-K batched matmuls to Metal on Apple7/8

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.h
+++ b/aten/src/ATen/native/mps/OperationUtils.h
@@ -688,6 +688,18 @@ inline bool needsGather(const TensorBase& t) {
   return !is_macOS_15_0_or_newer && (!t.is_contiguous() || t.storage_offset());
 }
 
+// On Apple7/8 (M1/M2), for an (m x k) @ (k x n) product, the MPS matmul kernels
+// can read past the end of the operands once k >= 32767 and m, n >= 16: the
+// last tile of the reduction is not clipped, and what lands in the result
+// depends on the chunking and on neighboring memory (#177116, #193487).
+// PyTorch's own Metal kernels are unaffected.
+inline bool mps_matmul_overreads_k(int64_t m, int64_t k, int64_t n) {
+  static const bool is_affected_gpu = !is_apple_family_or_newer(AppleGPUFamily::APPLE_9_PLUS);
+  constexpr int64_t min_affected_k = 32767;
+  constexpr int64_t min_matrix_dim = 16;
+  return is_affected_gpu && k >= min_affected_k && m >= min_matrix_dim && n >= min_matrix_dim;
+}
+
 template <typename T>
 void MetalShaderLibrary::exec_unary_kernel_with_params(TensorIteratorBase& iter,
                                                        const std::string& name,

--- a/aten/src/ATen/native/mps/operations/Linear.mm
+++ b/aten/src/ATen/native/mps/operations/Linear.mm
@@ -22,19 +22,6 @@ static bool needs_nd_workaround(const Tensor& input) {
   return input.dim() > 2 && is_m5_or_newer && (input.scalar_type() == kHalf || input.scalar_type() == kBFloat16);
 }
 
-// Apple7/8 (M1/M2) MPSGraph matmul intermittently returns wrong results when the
-// reduction dimension exceeds 2^15 and both output dimensions are at least 16; the
-// corruption is allocator/session-state dependent and hits contiguous and transposed
-// operands alike. Apple9+ is fine. mm/addmm already divert such shapes to the
-// stride-aware metal kernels, but linear builds its own graph, so it has to test the
-// GEMM it would form and delegate instead. Mirrors use_metal_mm in LinearAlgebra.mm.
-static bool needs_mm_overflow_fallback(int64_t m, int64_t k, int64_t n) {
-  static const bool is_affected_gpu = !is_apple_family_or_newer(AppleGPUFamily::APPLE_9_PLUS);
-  constexpr int64_t max_mpsgraph_dim = 32768;
-  constexpr int64_t min_matrix_dim = 16;
-  return is_affected_gpu && k > max_mpsgraph_dim && m >= min_matrix_dim && n >= min_matrix_dim;
-}
-
 static void _mps_linear_nograph(const Tensor& input, const Tensor& weight, const Tensor& bias, Tensor& output) {
   bool is_bias_defined = bias.defined();
 
@@ -154,7 +141,7 @@ Tensor _mps_linear(const Tensor& input, const Tensor& weight_arg, const std::opt
 
   // See pytorch/pytorch#177116. Delegating to addmm/mm reaches the metal kernels, which
   // take the weight's real strides, so the transposed (column-major) operand costs nothing.
-  if (!is_complex && needs_mm_overflow_fallback(input.numel() / input.size(-1), input.size(-1), weight.size(0))) {
+  if (!is_complex && mps_matmul_overreads_k(input.numel() / input.size(-1), input.size(-1), weight.size(0))) {
     const auto input_2d = input.dim() != 2 ? input.reshape({-1, input.size(-1)}) : input;
     // addmm fuses the bias and routes rank-1 shapes to the GEMV kernels. A multi-dim bias
     // cannot broadcast against the 2D result, so it is added after the reshape instead.

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -665,15 +665,7 @@ bool use_metal_mm(const Tensor& self, const Tensor& other, const Tensor& output)
     return has_large_size_or_stride;
   }
 
-  // On Apple7/8, MPSGraph intermittently corrupts matmuls with a reduction
-  // dimension over 2^15 when both output dimensions use the matrix kernels;
-  // whether a given call misbehaves depends on allocator/session state, and
-  // fully contiguous operands are affected too. Apple9+ handles this
-  // correctly.
-  static const bool is_affected_gpu = !is_apple_family_or_newer(AppleGPUFamily::APPLE_9_PLUS);
-  constexpr int64_t min_matrix_dim = 16;
-  return is_affected_gpu && self.size(1) > max_stride_size && self.size(0) >= min_matrix_dim &&
-      other.size(1) >= min_matrix_dim;
+  return mps::mps_matmul_overreads_k(self.size(0), self.size(1), other.size(1));
 }
 
 } // anonymous namespace
@@ -1216,8 +1208,9 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
     return result;
   }
 
-  // Use Metal kernels for integer and complex types
-  if (c10::isIntegralType(batch1.scalar_type(), true) || c10::isComplexType(batch1.scalar_type())) {
+  // Use Metal kernels for integer and complex types, and for shapes the MPS kernels get wrong
+  if (c10::isIntegralType(batch1.scalar_type(), true) || c10::isComplexType(batch1.scalar_type()) ||
+      mps::mps_matmul_overreads_k(batch1.size(1), batch1.size(2), batch2.size(2))) {
     return do_metal_addbmm_or_baddbmm(input, batch1, batch2, alpha, beta, result, opType == BADDBMM_OP_TYPE);
   }
 
@@ -1577,6 +1570,10 @@ static Tensor& bmm_out_mps_impl(const Tensor& batch1, const Tensor& batch2, Tens
   // Same pre-macOS-15 crack as use_metal_mm: an output with a storage offset
   // is gathered into a temporary that nothing scatters back.
   if (needsGather(result)) {
+    return do_metal_bmm(batch1, batch2, result);
+  }
+  // MPS on Apple7/8 reads past the operands on long reductions; see mps_matmul_overreads_k.
+  if (mps::mps_matmul_overreads_k(batch1.size(1), batch1.size(2), batch2.size(2))) {
     return do_metal_bmm(batch1, batch2, result);
   }
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -722,6 +722,25 @@ class MatmulTest(TestCaseMPS):
         self.assertEqual(lin_cpu.weight.grad, lin_mps.weight.grad.cpu(), atol=1e-3, rtol=1e-4)
         self.assertEqual(x_cpu.grad, x_mps.grad.cpu(), atol=1e-3, rtol=1e-4)
 
+    # #177116 / #193487: the same over-read hits the batched entry points. The extra
+    # terms come from memory past the operands, so dirty it before computing.
+    @parametrize("op", ["bmm", "baddbmm", "matmul", "einsum"])
+    def test_batched_matmul_large_K(self, op):
+        torch.manual_seed(0)
+        b1_cpu, b2_cpu = torch.randn(2, 25, 40000), torch.randn(2, 40000, 25)
+        b1, b2 = b1_cpu.to("mps"), b2_cpu.to("mps")
+        torch.full((5_000_000,), 1000.0, device="mps")
+        if op == "bmm":
+            out_cpu, out = torch.bmm(b1_cpu, b2_cpu), torch.bmm(b1, b2)
+        elif op == "baddbmm":
+            bias_cpu = torch.randn(2, 25, 25)
+            out_cpu, out = torch.baddbmm(bias_cpu, b1_cpu, b2_cpu), torch.baddbmm(bias_cpu.to("mps"), b1, b2)
+        elif op == "matmul":
+            out_cpu, out = b1_cpu @ b2_cpu, b1 @ b2
+        else:
+            out_cpu, out = torch.einsum("bik,bkj->bij", b1_cpu, b2_cpu), torch.einsum("bik,bkj->bij", b1, b2)
+        self.assertEqual(out_cpu, out.cpu(), atol=1e-3, rtol=1e-4)
+
 class MPSLeakyReluTest(TestCaseMPS):
     def _npLeakyRelu(self, np_features, negative_slope=0.1):
         return np.maximum(np_features, negative_slope * np_features).astype(np_features.dtype)


### PR DESCRIPTION
I was following the examples in "Build a Large Language Model from Scratch" by Sebastian Raschka, using the MPS backend on a MacBook M2 Max, and training diverged because of strange behavior in matmul. The nightly build already has a workaround for this (#183535), which fixed my training run, but it only covers the 2-D paths: batched matmul (bmm, baddbmm, addbmm, and 3-D matmul/einsum through them) still goes to MPSGraph, which handles large reduction dimensions incorrectly on M1/M2, and its threshold is off by one. The fix mirrors #183535: route those shapes to PyTorch's own Metal shaders instead of MPSGraph. The description below was drafted with Claude and verified by me.

> **Description (drafted with an AI assistant, reviewed and verified by the author)**
>
> **Problem.** On Apple7/8 GPUs (M1/M2) the MPS matmul kernels can read past the end of both operands when the reduction dimension K is 32767 or longer, on the shapes that use the tiled kernels (both output dims >= 16): the last K tile is not clipped, so whatever sits in memory after the operands is summed into the result. Most such shapes over-read, a few tile-aligned ones do not, and freshly zeroed memory hides it, so it looks intermittent. #183535 routed the 2-D paths (`mm`/`addmm`/`linear`) to PyTorch's own Metal kernels, but `bmm`/`baddbmm`/`addbmm` -- and so 3-D `matmul` and `einsum` -- still go through MPSGraph and return silently wrong results on current `main`. #183535's threshold (K > 32768) is also off by one: K = 32767 is wrong by exactly one term on every kernel variant measured; K = 32768 only passes because it happens to split evenly.
>
> **Reproducer** (M1/M2; also in the gists below):
>
> ```python
> # Demo for M1/M2 Macs
> # Part 1 (2-D `@`) shows the bug on torch 2.13, the current stable; 2.14+ routes
> # 2-D matmul around it (pytorch/pytorch#183535) and that part comes out clean.
> # Part 2 (bmm) still fails on 2.14 / the 2.15 nightlies, which only route the
> # 2-D paths. Whether the dirty buffer lands where the kernel over-reads depends
> # on the allocator, so "clean" here proves less than "wrong" does.
> import torch
> print("torch", torch.__version__)
> torch.manual_seed(0)
>
> def report(tag, mps_out, ref):
>     err = (mps_out.cpu().double() - ref).abs().max().item()
>     print(f"  {tag:34s} max error {err:12.4f}   {'<-- WRONG' if err > 1e-2 else 'ok'}")
>
> # Part 1: plain 2-D matmul
> a = torch.randn(25, 40000); b = torch.randn(40000, 25)
> expected = a.double() @ b.double()
> am, bm = a.to("mps"), b.to("mps")
> report("2-D  @  fresh", am @ bm, expected)
> torch.full((5_000_000,), 1000.0, device="mps")    # write something nonzero into nearby memory
> report("2-D  @  after dirtying memory", am @ bm, expected)
>
> # Part 2: batched matmul, uploaded fresh so the dirty buffer lands next to it
> b1 = torch.randn(2, 25, 40000); b2 = torch.randn(2, 40000, 25)
> expected = torch.bmm(b1.double(), b2.double())
> b1m, b2m = b1.to("mps"), b2.to("mps")
> torch.full((5_000_000,), 1000.0, device="mps")
> report("bmm  after dirtying memory", torch.bmm(b1m, b2m), expected)
> report("einsum bik,bkj->bij (same path)", torch.einsum("bik,bkj->bij", b1m, b2m), expected)
> ```
>
> | build | 2-D `@` after dirtying (max abs err) | `bmm` after dirtying (max abs err) |
> |---|---|---|
> | 2.13.0 (stable) | 1.2e4 (wrong) | 3.2e7 (wrong) |
> | 2.15.0.dev20260821 (nightly) | 2.9e-3 (routed by #183535) | 3.2e7 (wrong) |
> | this branch | 2.9e-3 | 5.1e-3 |
>
> Seeded, so these are exact on an M2 Max. The 3.2e7 is 32 extra terms x 1000 x 1000: the fill buffer landed past both operands. Whether it lands there depends on the allocator, so a small error on the `bmm` line proves less than a large one does.
>
> **Change.** The condition moves into one inline helper, `mps_matmul_overreads_k(m, k, n)`, used by `use_metal_mm`, `_mps_linear`, `bmm_out_mps_impl` and `addbmm_or_baddbmm_out_mps_impl`, with the threshold corrected to K >= 32767. (Rebased on #194474, which already makes the Metal fallbacks honor `beta=0`; this PR no longer touches that.)
>
> **Alternative considered.** Chunking K into <= 32766 pieces through MPSGraph and summing measures at about the cost of the single MPSGraph call on the affected shapes (1.0x-1.3x on the three below), against the naive Metal kernels' ~8x, so it is the faster option. This PR routes to the Metal kernels anyway: it keeps `bmm`/`baddbmm` consistent with how #183535 already handles `mm`/`addmm`/`linear`, stays small, and leaves a single condition to relax if Apple fixes the kernels. Chunked-K is a reasonable follow-up if the cost matters to anyone.
>
> **Performance** (affected shapes only: Apple7/8, K >= 32767, m, n >= 16; M2 Max, ms per call):
>
> | shape | MPSGraph (wrong) | Metal (this PR) |
> |---|---|---|
> | bmm (2,25,40000)@(2,40000,25) | 0.32 | 2.45 |
> | bmm (2,256,50257)@(2,50257,768) | 4.4 | 36 |
> | bmm (8,512,40000)@(8,40000,64) | 2.3 | 20 |
>
> For comparison, routing *all* 2-D matmuls on Apple7/8 to the Metal kernels (`PYTORCH_MPS_PREFER_METAL=1`, same machine, fp32; fp16 is the same picture) costs 6-11x on ordinary shapes, which is why the condition stays narrow:
>
> | shape | MPSGraph | Metal |
> |---|---|---|
> | (1024x1024)@(1024x1024) | 0.33 | 1.95 |
> | (4096x4096)@(4096x4096) | 12.2 | 120.5 |
> | (2048x768)@(768x768) | 0.27 | 2.18 |
> | (2048x768)@(768x3072) | 0.87 | 8.54 |
> | (2048x768)@(768x50257) | 20.8 | 145.8 |
>
> **Test plan** (M2 Max, macOS 26.6.2, source build):
>
> ```
> python test/test_mps.py -k test_batched_matmul_large_K -k test_linear_large_K -v
> ```
> 6/6 pass. The body of `test_batched_matmul_large_K` run against the unpatched `2.15.0.dev20260821` nightly fails all four cases (max abs diff 17.6 vs 1e-3). Caveat: the batched test dirties memory with a 20 MB fill buffer that cannot be guaranteed to land after the operands from Python, so on some allocator states it may pass without the fix.
>
> ```
> python test/test_mps.py -k bmm -k matmul -k einsum -k linear -k addmm -k test_mm -k mv -k tensordot
> ```
> 513 tests, one failure: `TestConsistencyMPS.test_mm_stride_zero_mps`, which fails identically on the unpatched nightly (K = 1, untouched by this change; the #180201 fix appears not to hold on macOS 26.6.2 -- its own Swift reproducer from that thread fails here too, so this looks like a separate regression).
>
> Also checked against CPU on the routed path: fp16/bf16, transposed and broadcast batch operands, alpha/beta values, batch=64, K = 32766 (unrouted), autograd through `bmm`; and a 124M GPT-2 training run whose output-layer gradient (K = 50257) previously diverged now matches CPU to 6e-7 relative.
>
> **Scope.** Only ops that dispatch `mm`/`bmm`-family kernels are routed. Matmuls performed inside a single MPSGraph op are not; `scaled_dot_product_attention` with a 40000-token KV was checked on both its kernel path and its MPSGraph fallback (`PYTORCH_MPS_DISABLE_PREFILL_ATTENTION=1`, and head_dim=48) and matched CPU, so no gap is known there. Verified on M2; M1 (Apple7) runs the same `NDArrayMatrixMultiplyNNA14` kernels and is expected to behave identically.
>
> **References.** Fixes #195163. Related: #193487, #177116, #183535. Apple Feedback FB24518264.
>
> - Kernel-level analysis (IR): https://scottkirila.studio.site/blog/kernel-bug
> - Standalone MPSGraph reproducer (Swift): https://gist.github.com/scott-kirila/0854ceb1bcbbcd1f7fb94858a3e70359
> - PyTorch demo: https://gist.github.com/scott-kirila/779cc88de465c77ebb547435bfcb25a4

cc @Isalia20 @kulinseth @malfet
