### PR TITLE
[dynamo] Add whole-module content hashes

### DIFF
--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -3,6 +3,7 @@
 import contextlib
 import copy
 import functools
+import hashlib
 import inspect
 import multiprocessing as mp
 import os
@@ -842,6 +843,7 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
         )
 
         expected_content = inspect.getsource(sys.modules[__name__])
+        expected_content_hash = hashlib.sha256(expected_content.encode()).hexdigest()
 
         def check_source_info(source_info: SourceInfo) -> None:
             self.assertIsInstance(source_info, SourceInfo)
@@ -849,6 +851,7 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
             for source in source_info.inlined_sources:
                 self.assertEqual(source.module, __name__)
                 self.assertEqual(source.content, expected_content)
+                self.assertEqual(source.content_hash, expected_content_hash)
 
         source_info = compiled_fn.source_info()
         check_source_info(source_info)

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -171,6 +171,7 @@ class InlinedSource:
     firstlineno: int
     lastlineno: int
     checksum: str
+    content_hash: str
     _compressed_content: bytes = dataclasses.field(repr=False)
 
     @property
@@ -184,13 +185,23 @@ class InlinedSource:
             if not isinstance(content, str):
                 raise TypeError(f"Expected content to be str, got {type(content)}")
             state["_compressed_content"] = zlib.compress(content.encode())
+        if "content_hash" not in state:
+            compressed_content = state["_compressed_content"]
+            if not isinstance(compressed_content, bytes):
+                raise TypeError(
+                    f"Expected compressed content to be bytes, got {type(compressed_content)}"
+                )
+            state["content_hash"] = _hash_source(
+                zlib.decompress(compressed_content).decode()
+            )
         for name, value in state.items():
             object.__setattr__(self, name, value)
 
 
 @functools.cache
-def _get_compressed_module_content(module: types.ModuleType) -> bytes:
-    return zlib.compress(inspect.getsource(module).encode())
+def _get_module_source(module: types.ModuleType) -> tuple[bytes, str]:
+    content = inspect.getsource(module)
+    return zlib.compress(content.encode()), _hash_source(content)
 
 
 @dataclasses.dataclass
@@ -209,13 +220,15 @@ class SourceInfo:
                 f"Source mismatch for {module.__name__} "
                 f"(line {firstlineno}-{lastlineno})"
             )
+        compressed_content, content_hash = _get_module_source(module)
         self.inlined_sources.add(
             InlinedSource(
                 module=module.__name__,
                 firstlineno=firstlineno,
                 lastlineno=lastlineno,
                 checksum=_hash_source(source),
-                _compressed_content=_get_compressed_module_content(module),
+                content_hash=content_hash,
+                _compressed_content=compressed_content,
             )
         )
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #195018
* #195017

Human context: "Can you create a stack that impl the two suggestions in this comment? https://github.com/pytorch/pytorch/pull/194755#issuecomment-5441169014"

> AI-assisted implementation summary:
>
> Downstream consumers currently need each `InlinedSource` full module content
> to validate an artifact against the live source tree. A compact hash must be
> available before those consumers can migrate away from `content`.
>
> Add `content_hash` as the SHA-256 digest of the exact text exposed by
> `content`. Keep the compressed content during the compatibility window, and
> synthesize the hash when loading pickle state produced before this field
> existed.
>
> Test Plan:
>
> ```
> python -m py_compile torch/_dynamo/package.py test/dynamo/test_aot_compile.py
> ```
>
> ```
> python test/dynamo/test_aot_compile.py -k test_aot_compile_source_info
> ```
>
> The focused test could not import the active environment's editable PyTorch
> build because its extension lacks `torch._C._has_gds`.
>
> ```
> lintrunner -a
> ```
>
> The lint command was blocked while bootstrapping its environments because the
> configured PyPI tunnel returned an `UnknownIssuer` certificate error.
>
> This change was prepared with assistance from an AI coding assistant.