### PR TITLE
[MPS] enable masked_fill fast path for scalar boolean indexing

### DIFF
--- a/aten/src/ATen/TensorIndexing.h
+++ b/aten/src/ATen/TensorIndexing.h
@@ -407,7 +407,7 @@ inline Tensor asTensor(const Scalar& value, const Tensor& target) {
   if (isQIntType(target.scalar_type())) {
     return scalarToTensor(
         value, at::device(kCPU).dtype(kFloat), at::Device(kCPU));
-  } else if (target_device.is_cuda()) {
+  } else if (target_device.is_cuda() || target_device.is_mps()) {
     return scalarToTensor(value, target.options(), at::Device(kCPU));
   } else {
     return scalarToTensor(value, target.options(), target_device);


### PR DESCRIPTION
Keeps MPS indexing scalars on CPU, allowing `x[bool_mask] = scalar` to use the existing `masked_fill_` fast path instead of generic `index_put_`. Perf:

| dtype | Shape | Layout | Before (us) | After (us) | Speedup |
|---|---|---|---:|---:|---:|
| bf16 | 256 x 1024 | contiguous | 205.0 | 18.4 | 11.14x |
| bf16 | 8 x 512 x 1024 | contiguous | 847.6 | 51.3 | 16.52x |
| bf16 | 4096 x 4096 | contiguous | 2291.5 | 535.4 | 4.28x |
| bf16 | 2048 x 4096 | transposed dense | 1656.8 | 508.2 | 3.26x |
| bf16 | 16 x 128 x 64 x 64 | channels-last | 2602.0 | 962.4 | 2.70x |
| bf16 | 4 x 32 x 32 x 32 x 32 | channels-last-3d | 1656.0 | 626.1 | 2.64x |
| bf16 | 2048 x 2048 | sliced non-dense | 751.7 | 292.9 | 2.57x |
| fp16 | 4096 x 4096 | contiguous | 2375.4 | 544.7 | 4.36x |
| fp32 | 4096 x 4096 | contiguous | 2841.0 | 1068.5 | 2.66x |
| fp32 | 16 x 128 x 64 x 64 | channels-last | 2639.9 | 989.3 | 2.67x |


Smaller shapes

| dtype | Shape | Layout | Before (us) | After (us) | Speedup |
|---|---|---|---:|---:|---:|
| bf16 | 128 | contiguous | 168.7 | 7.0 | 24.24x |
| bf16 | 256 | contiguous | 168.4 | 7.5 | 22.61x |
| bf16 | 512 | contiguous | 168.3 | 6.7 | 25.19x |
| bf16 | 1024 | contiguous | 169.2 | 6.8 | 25.00x |
| bf16 | 32 x 32 | contiguous | 168.1 | 5.8 | 28.94x |
| bf16 | 64 x 64 | contiguous | 169.7 | 4.0 | 42.95x |
| bf16 | 128 x 128 | contiguous | 169.0 | 5.2 | 32.63x |
| bf16 | 256 x 256 | contiguous | 173.1 | 6.1 | 28.19x |
| fp16 | 128 | contiguous | 168.9 | 2.9 | 57.86x |
| fp16 | 256 | contiguous | 169.3 | 3.8 | 45.02x |
| fp16 | 512 | contiguous | 168.6 | 2.9 | 57.93x |
| fp16 | 1024 | contiguous | 169.3 | 3.0 | 56.05x |
| fp16 | 32 x 32 | contiguous | 169.3 | 3.0 | 57.00x |
| fp16 | 64 x 64 | contiguous | 169.0 | 2.6 | 64.02x |
| fp16 | 128 x 128 | contiguous | 169.3 | 2.7 | 63.42x |
| fp16 | 256 x 256 | contiguous | 173.5 | 3.1 | 56.14x |
| fp32 | 128 | contiguous | 169.8 | 2.3 | 74.82x |
| fp32 | 256 | contiguous | 168.3 | 2.3 | 73.51x |
| fp32 | 512 | contiguous | 169.3 | 2.4 | 71.72x |
| fp32 | 1024 | contiguous | 169.0 | 2.5 | 68.97x |
| fp32 | 32 x 32 | contiguous | 169.0 | 2.5 | 68.15x |
| fp32 | 64 x 64 | contiguous | 169.9 | 2.5 | 68.24x |
| fp32 | 128 x 128 | contiguous | 168.7 | 2.5 | 66.69x |
| fp32 | 256 x 256 | contiguous | 175.1 | 3.2 | 54.71x |
