### PR TITLE
[inductor][eager] Resolve which distribution provides the importable Triton module

### DIFF
--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -1,13 +1,17 @@
 # Owner(s): ["module: dsl-native-ops"]
 
+import contextlib
 import importlib.util
 import os
 import subprocess
 import sys
 import textwrap
 import uuid
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
+from torch._native import triton_utils
+from torch._vendor.packaging.version import Version
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -25,6 +29,92 @@ def _subprocess_lastline(script, env=None):
         text=True,
     ).strip()
     return result.rsplit("\n", 1)[-1]
+
+
+# Read from the lookup rather than repeated here, so that a name added there is
+# covered rather than silently untested. `triton` is excluded: it is the one
+# name the lookup resolved before the rest were handled.
+_WHEEL_DISTRIBUTIONS = tuple(
+    name for name in triton_utils._TRITON_DISTRIBUTIONS if name != "triton"
+)
+
+# Where the importable `triton` resolves to, for the tests that care which
+# distribution installed it.
+_MODULE_ORIGIN = "/site-packages/triton/__init__.py"
+
+
+def _triton_installed(versions):
+    """Patch the per-distribution version lookup with `versions`.
+
+    A distribution absent from the mapping is not installed.
+    """
+    return patch.object(
+        triton_utils,
+        "_available_version",
+        side_effect=lambda distribution: (
+            Version(versions[distribution]) if distribution in versions else None
+        ),
+    )
+
+
+def _triton_provided_by(*distributions, raises=False):
+    """Patch the sys.path scan to report `distributions` for the module.
+
+    With no distributions the module is absent from the mapping entirely, as it
+    is from the real scan: that only ever creates a key by appending to it, so
+    it cannot report a module with an empty provider list.
+    """
+    kwargs = (
+        {"side_effect": RuntimeError("unreadable metadata")}
+        if raises
+        else {"return_value": {"triton": list(distributions)} if distributions else {}}
+    )
+    return patch.object(triton_utils, "_packages_distributions", **kwargs)
+
+
+class _InstalledFile:
+    def __init__(self, path):
+        self._path = path
+
+    def locate(self):
+        return self._path
+
+
+class _InstalledDistribution:
+    def __init__(self, paths):
+        # None is a distribution with no RECORD, which reports no files at all.
+        self.files = None if paths is None else [_InstalledFile(p) for p in paths]
+
+
+def _triton_module_at(origin):
+    """Patch the resolved location of the importable module."""
+    return patch.object(triton_utils, "_module_origin", return_value=origin)
+
+
+def _triton_records(files_by_distribution):
+    """Patch distribution metadata with the files each one installed.
+
+    A distribution absent from the mapping is not installed; one mapped to None
+    installed no RECORD, so what it owns cannot be decided.
+    """
+
+    def lookup(name):
+        if name not in files_by_distribution:
+            raise PackageNotFoundError(name)
+        return _InstalledDistribution(files_by_distribution[name])
+
+    return patch.object(triton_utils, "_distribution", side_effect=lookup)
+
+
+def _rejects_a_nameless_distribution(distribution):
+    """Stand in for the version lookup, which rejects a `None` name.
+
+    A dist-info whose METADATA carries no `Name` is reported by the scan as a
+    `None` provider, and `importlib.metadata.version(None)` raises.
+    """
+    if distribution is None:
+        raise ValueError("A distribution name is required.")
+    return None
 
 
 def _import_module_directly(module_name, file_name):
@@ -54,6 +144,7 @@ class TestNativeDSLOps(TestCase):
             (
                 "torch._native.triton_utils",
                 [
+                    "_check_runtime_available",
                     "_version_is_sufficient",
                     "check_native_jit_disabled",
                     "check_native_version_skip",
@@ -618,7 +709,242 @@ class TestNativeDSLOps(TestCase):
         self.assertNotIn("incomplete_dsl", registry.list_all_dsls())
 
 
+class TestTritonDistributionDiscovery(TestCase):
+    """Which distribution answers for the importable `triton` module.
+
+    A name this lookup cannot resolve reports no version, and no version fails
+    the gate below -- so a working Triton install stops registering ops, with
+    nothing in the output naming the wheel as the reason.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Answer the ownership question the same way everywhere by default, so
+        # that only the cases below decide it, rather than this machine's own
+        # Triton install.
+        for default in (_triton_module_at(_MODULE_ORIGIN), _triton_records({})):
+            default.start()
+            self.addCleanup(default.stop)
+
+    def test_distribution_named_after_the_module_answers_directly(self):
+        with _triton_installed({"triton": "3.7.1"}), _triton_provided_by() as scan:
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+        # Not merely an optimization: the scan reads the metadata of every
+        # distribution on sys.path, on the import path of every torch process.
+        scan.assert_not_called()
+
+    @parametrize("distribution", _WHEEL_DISTRIBUTIONS)
+    def test_wheel_distribution_names_are_resolved(self, distribution):
+        with (
+            _triton_installed({distribution: "3.7.1"}),
+            _triton_provided_by(distribution),
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+    def test_provider_without_a_version_falls_through_to_the_next(self):
+        with (
+            _triton_installed({"pytorch-triton-rocm": "3.7.1"}),
+            _triton_provided_by("fbtriton", "pytorch-triton-rocm"),
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+    def test_module_owned_by_no_distribution_reports_no_version(self):
+        # A source or editable install: importable, with no metadata to read a
+        # version from.
+        with (
+            _triton_installed({}),
+            _triton_provided_by(),
+            self.assertLogs("torch._native.triton_utils", level="INFO") as logs,
+        ):
+            self.assertIsNone(triton_utils._available_triton_version())
+
+        self.assertIn("no installed distribution", "\n".join(logs.output))
+
+    def test_provider_that_reports_no_version_exhausts_the_candidates(self):
+        # A wheel owns the module but its metadata carries no parseable
+        # version, so every candidate the scan named is tried and rejected.
+        with (
+            _triton_installed({}),
+            _triton_provided_by("pytorch-triton-rocm"),
+            self.assertLogs("torch._native.triton_utils", level="INFO") as logs,
+        ):
+            self.assertIsNone(triton_utils._available_triton_version())
+
+        self.assertIn("no installed distribution", "\n".join(logs.output))
+
+    def test_unreadable_metadata_declines_instead_of_raising(self):
+        # This runs while the overrides register, during `import torch`, where
+        # an exception would take the process down.
+        with (
+            _triton_installed({}),
+            _triton_provided_by(raises=True) as scan,
+            self.assertLogs("torch._native.triton_utils", level="WARNING") as logs,
+        ):
+            self.assertIsNone(triton_utils._available_triton_version())
+
+        scan.assert_called_once()
+        self.assertIn("will not register", "\n".join(logs.output))
+
+    def test_stale_distribution_loses_to_the_one_that_owns_the_module(self):
+        # `triton` was installed, then overwritten by another provider whose
+        # uninstall left the dist-info behind. It still reports a version, and
+        # answering with it disables the ops against a working 3.7.1 install.
+        with (
+            _triton_installed({"triton": "3.2.0", "pytorch-triton-rocm": "3.7.1"}),
+            _triton_records(
+                {
+                    "triton": ["/site-packages/triton/removed.py"],
+                    "pytorch-triton-rocm": [_MODULE_ORIGIN],
+                }
+            ),
+            _triton_provided_by("triton", "pytorch-triton-rocm"),
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+    def test_distribution_published_under_an_unlisted_name_is_scanned_for(self):
+        # The list is an optimization, not the set of answers: a name it does
+        # not carry still resolves, through the scan.
+        with (
+            _triton_installed({"triton-nightly": "3.7.1"}),
+            _triton_records({"triton-nightly": [_MODULE_ORIGIN]}),
+            _triton_provided_by("triton-nightly") as scan,
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+        scan.assert_called_once()
+
+    def test_distribution_without_a_record_is_taken_at_its_word(self):
+        # Nothing was learned about what it owns, so it keeps the answer it
+        # would have given before the question was asked.
+        with (
+            _triton_installed({"triton": "3.7.1"}),
+            _triton_records({"triton": None}),
+            _triton_provided_by() as scan,
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+        scan.assert_not_called()
+
+    def test_unresolvable_module_is_not_held_against_a_distribution(self):
+        with (
+            _triton_installed({"triton": "3.7.1"}),
+            _triton_module_at(None),
+            _triton_records({"triton": ["/site-packages/somewhere/else.py"]}),
+            _triton_provided_by(),
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+    def test_nameless_distribution_declines_instead_of_raising(self):
+        # The scan reports a dist-info with no `Name` as a `None` provider, and
+        # the version lookup raises on it -- during `import torch`.
+        with (
+            patch.object(
+                triton_utils,
+                "_available_version",
+                side_effect=_rejects_a_nameless_distribution,
+            ),
+            _triton_provided_by(None),
+            self.assertLogs("torch._native.triton_utils", level="WARNING"),
+        ):
+            self.assertIsNone(triton_utils._available_triton_version())
+
+
+class TestTritonModuleOrigin(TestCase):
+    """Locating a module without importing it."""
+
+    def test_absent_module_has_no_origin(self):
+        self.assertIsNone(triton_utils._module_origin("_no_such_native_dsl_module"))
+
+    def test_broken_parent_package_declines_instead_of_raising(self):
+        # find_spec imports the parent package to search it, so anything the
+        # parent raises arrives here, during `import torch`.
+        with patch.object(triton_utils, "_find_spec", side_effect=ImportError("boom")):
+            self.assertIsNone(triton_utils._module_origin("triton"))
+
+
+class TestTritonVersionGate(TestCase):
+    """The gate that decides whether the Triton overrides register at all.
+
+    Both verdicts are `functools.cache`d, so every case has to clear them twice:
+    otherwise this machine's own install decides the first case and a stale
+    verdict decides the next one.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # The escape hatch is cached too, and the tests above leave it set: a
+        # verdict of "skip the version check" would pass every case here.
+        for verdict in (
+            triton_utils._check_runtime_available,
+            triton_utils._version_is_sufficient,
+            triton_utils.check_native_version_skip,
+            triton_utils.check_native_jit_disabled,
+        ):
+            verdict.cache_clear()
+            self.addCleanup(verdict.cache_clear)
+
+    @contextlib.contextmanager
+    def _installed_triton(self, versions, *distributions):
+        """Run the gate against an importable Triton described by `versions`."""
+        with (
+            _triton_installed(versions),
+            _triton_provided_by(*distributions),
+            _triton_module_at(_MODULE_ORIGIN),
+            _triton_records({}),
+            patch.object(triton_utils._cuda, "is_built", return_value=True),
+            patch.object(triton_utils, "_unavailable_reason", return_value=None),
+        ):
+            yield
+
+    def test_wheel_distribution_name_passes_the_gate(self):
+        with self._installed_triton({"triton-rocm": "3.7.1"}, "triton-rocm"):
+            self.assertTrue(triton_utils.runtime_available())
+            self.assertEqual(triton_utils.runtime_version(), Version("3.7.1"))
+            self.assertTrue(triton_utils._version_is_sufficient())
+
+    def test_versionless_install_still_fails_the_gate(self):
+        with self._installed_triton({}):
+            self.assertTrue(triton_utils.runtime_available())
+            self.assertIsNone(triton_utils.runtime_version())
+            self.assertFalse(triton_utils._version_is_sufficient())
+
+    # 3.6.0 is the boundary; 3.42.0 is a minor far past it, since the check
+    # compares the minor rather than the release.
+    @parametrize("version", ("3.6.0", "3.42.0"))
+    def test_supported_versions_pass_the_gate(self, version):
+        with self._installed_triton({"triton-rocm": version}, "triton-rocm"):
+            self.assertTrue(triton_utils._version_is_sufficient())
+
+    # One case per way of failing: 3.5.9 is the minor below the boundary, and
+    # 2.9.0 and 4.6.0 are rejected on the major alone -- both clear the minor,
+    # so nothing else here would notice the major check being loosened to an
+    # inequality, which would accept a 4.x Triton the overrides are not built
+    # against.
+    @parametrize("version", ("3.5.9", "2.9.0", "4.6.0"))
+    def test_unsupported_versions_fail_the_gate(self, version):
+        with self._installed_triton({"triton-rocm": version}, "triton-rocm"):
+            self.assertFalse(triton_utils._version_is_sufficient())
+
+    def test_version_skip_overrides_an_unsupported_version(self):
+        with (
+            self._installed_triton({"triton-rocm": "3.5.0"}, "triton-rocm"),
+            patch.object(triton_utils, "check_native_version_skip", return_value=True),
+        ):
+            self.assertTrue(triton_utils._version_is_sufficient())
+
+    def test_version_skip_does_not_rescue_an_unreported_version(self):
+        # The escape hatch overrides a version that is too old, not the absence
+        # of one: there is nothing to run the ops against.
+        with (
+            self._installed_triton({}),
+            patch.object(triton_utils, "check_native_version_skip", return_value=True),
+        ):
+            self.assertFalse(triton_utils._version_is_sufficient())
+
+
 instantiate_parametrized_tests(TestNativeDSLOps)
+instantiate_parametrized_tests(TestTritonDistributionDiscovery)
+instantiate_parametrized_tests(TestTritonVersionGate)
 
 
 if __name__ == "__main__":

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -1,13 +1,17 @@
 # Owner(s): ["module: dsl-native-ops"]
 
+import base64
 import contextlib
+import hashlib
 import importlib.util
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 import uuid
 from importlib.metadata import PackageNotFoundError
+from pathlib import Path
 from unittest.mock import patch
 
 from torch._native import common_utils as native_common_utils, triton_utils
@@ -31,23 +35,13 @@ def _subprocess_lastline(script, env=None):
     return result.rsplit("\n", 1)[-1]
 
 
-# Read from the lookup rather than repeated here, so that a name added there is
-# covered rather than silently untested. `triton` is excluded: it is the one
-# name the lookup resolved before the rest were handled.
 _WHEEL_DISTRIBUTIONS = tuple(
     name for name in triton_utils._TRITON_DISTRIBUTIONS if name != "triton"
 )
-
-# Where the importable `triton` resolves to, for the tests that care which
-# distribution installed it.
 _MODULE_ORIGIN = "/site-packages/triton/__init__.py"
 
 
 def _triton_installed(versions):
-    """Patch the per-distribution version lookup with `versions`.
-
-    A distribution absent from the mapping is not installed.
-    """
     return patch.object(
         triton_utils,
         "_available_version",
@@ -58,12 +52,6 @@ def _triton_installed(versions):
 
 
 def _triton_provided_by(*distributions, raises=False):
-    """Patch the sys.path scan to report `distributions` for the module.
-
-    With no distributions the module is absent from the mapping entirely, as it
-    is from the real scan: that only ever creates a key by appending to it, so
-    it cannot report a module with an empty provider list.
-    """
     kwargs = (
         {"side_effect": RuntimeError("unreadable metadata")}
         if raises
@@ -72,9 +60,20 @@ def _triton_provided_by(*distributions, raises=False):
     return patch.object(triton_utils, "_packages_distributions", **kwargs)
 
 
+class _FileHash:
+    def __init__(self, mode, value):
+        self.mode = mode
+        self.value = value
+
+
 class _InstalledFile:
-    def __init__(self, path):
+    def __init__(self, path, contents=None):
         self._path = path
+        self.hash = None
+        if contents is not None:
+            digest = hashlib.sha256(contents).digest()
+            value = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+            self.hash = _FileHash("sha256", value)
 
     def locate(self):
         return self._path
@@ -82,39 +81,26 @@ class _InstalledFile:
 
 class _InstalledDistribution:
     def __init__(self, paths):
-        # None is a distribution with no RECORD, which reports no files at all.
-        self.files = None if paths is None else [_InstalledFile(p) for p in paths]
+        self.files = (
+            None
+            if paths is None
+            else [
+                p if isinstance(p, _InstalledFile) else _InstalledFile(p) for p in paths
+            ]
+        )
 
 
 def _triton_module_at(origin):
-    """Patch the resolved location of the importable module."""
     return patch.object(triton_utils, "_module_origin", return_value=origin)
 
 
 def _triton_records(files_by_distribution):
-    """Patch distribution metadata with the files each one installed.
-
-    A distribution absent from the mapping is not installed; one mapped to None
-    installed no RECORD, so what it owns cannot be decided.
-    """
-
     def lookup(name):
         if name not in files_by_distribution:
             raise PackageNotFoundError(name)
         return _InstalledDistribution(files_by_distribution[name])
 
     return patch.object(triton_utils, "_distribution", side_effect=lookup)
-
-
-def _rejects_a_nameless_distribution(distribution):
-    """Stand in for the version lookup, which rejects a `None` name.
-
-    A dist-info whose METADATA carries no `Name` is reported by the scan as a
-    `None` provider, and `importlib.metadata.version(None)` raises.
-    """
-    if distribution is None:
-        raise ValueError("A distribution name is required.")
-    return None
 
 
 def _import_module_directly(module_name, file_name):
@@ -710,48 +696,39 @@ class TestNativeDSLOps(TestCase):
 
 
 class TestTritonDistributionDiscovery(TestCase):
-    """Which distribution answers for the importable `triton` module.
-
-    A name this lookup cannot resolve reports no version, and no version fails
-    the gate below -- so a working Triton install stops registering ops, with
-    nothing in the output naming the wheel as the reason.
-    """
-
     def setUp(self):
         super().setUp()
-        # Answer the ownership question the same way everywhere by default, so
-        # that only the cases below decide it, rather than this machine's own
-        # Triton install.
         for default in (_triton_module_at(_MODULE_ORIGIN), _triton_records({})):
             default.start()
             self.addCleanup(default.stop)
 
-    def test_distribution_named_after_the_module_answers_directly(self):
-        with _triton_installed({"triton": "3.7.1"}), _triton_provided_by() as scan:
+    def test_named_distribution_uses_fast_path(self):
+        with (
+            _triton_installed({"triton": "3.7.1"}),
+            _triton_provided_by() as scan,
+            _triton_module_at(_MODULE_ORIGIN) as origin,
+        ):
             self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
-        # Not merely an optimization: the scan reads the metadata of every
-        # distribution on sys.path, on the import path of every torch process.
+
         scan.assert_not_called()
+        origin.assert_not_called()
 
     @parametrize("distribution", _WHEEL_DISTRIBUTIONS)
-    def test_wheel_distribution_names_are_resolved(self, distribution):
+    def test_known_distribution_names(self, distribution):
         with (
             _triton_installed({distribution: "3.7.1"}),
             _triton_provided_by(distribution),
         ):
             self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
 
-    def test_provider_without_a_version_falls_through_to_the_next(self):
+    def test_missing_version_falls_through(self):
         with (
             _triton_installed({"pytorch-triton-rocm": "3.7.1"}),
             _triton_provided_by("fbtriton", "pytorch-triton-rocm"),
         ):
             self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
 
-    def test_module_owned_by_no_distribution_reports_no_version(self):
-        # A source checkout on PYTHONPATH: importable, with no dist-info at all,
-        # so nothing reports a version. An editable install is a different case
-        # -- it has metadata and reports a version -- and is covered below.
+    def test_source_checkout_reports_no_version(self):
         with (
             _triton_installed({}),
             _triton_provided_by(),
@@ -761,9 +738,7 @@ class TestTritonDistributionDiscovery(TestCase):
 
         self.assertIn("no installed distribution", "\n".join(logs.output))
 
-    def test_provider_that_reports_no_version_exhausts_the_candidates(self):
-        # A wheel owns the module but its metadata carries no parseable
-        # version, so every candidate the scan named is tried and rejected.
+    def test_scanned_provider_without_version(self):
         with (
             _triton_installed({}),
             _triton_provided_by("pytorch-triton-rocm"),
@@ -773,9 +748,7 @@ class TestTritonDistributionDiscovery(TestCase):
 
         self.assertIn("no installed distribution", "\n".join(logs.output))
 
-    def test_unreadable_metadata_declines_instead_of_raising(self):
-        # This runs while the overrides register, during `import torch`, where
-        # an exception would take the process down.
+    def test_unreadable_scan_is_caught(self):
         with (
             _triton_installed({}),
             _triton_provided_by(raises=True) as scan,
@@ -786,25 +759,64 @@ class TestTritonDistributionDiscovery(TestCase):
         scan.assert_called_once()
         self.assertIn("will not register", "\n".join(logs.output))
 
-    def test_stale_distribution_loses_to_the_one_that_owns_the_module(self):
-        # `triton` was installed, then overwritten by another provider whose
-        # uninstall left the dist-info behind. It still reports a version, and
-        # answering with it disables the ops against a working 3.7.1 install.
-        with (
-            _triton_installed({"triton": "3.2.0", "pytorch-triton-rocm": "3.7.1"}),
-            _triton_records(
-                {
-                    "triton": ["/site-packages/triton/removed.py"],
-                    "pytorch-triton-rocm": [_MODULE_ORIGIN],
-                }
-            ),
-            _triton_provided_by("triton", "pytorch-triton-rocm"),
-        ):
-            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+    def test_record_hash_selects_live_distribution(self):
+        with tempfile.TemporaryDirectory() as directory:
+            origin = Path(directory) / "triton" / "__init__.py"
+            origin.parent.mkdir()
+            contents = b'__version__ = "3.7.1"\n'
+            origin.write_bytes(contents)
 
-    def test_distribution_published_under_an_unlisted_name_is_scanned_for(self):
-        # The list is an optimization, not the set of answers: a name it does
-        # not carry still resolves, through the scan.
+            with (
+                _triton_installed({"triton": "3.2.0", "pytorch-triton-rocm": "3.7.1"}),
+                _triton_records(
+                    {
+                        "triton": [_InstalledFile(origin, b'__version__ = "3.2.0"\n')],
+                        "pytorch-triton-rocm": [_InstalledFile(origin, contents)],
+                    }
+                ),
+                _triton_module_at(str(origin)),
+                _triton_provided_by("triton", "pytorch-triton-rocm") as scan,
+            ):
+                self.assertEqual(
+                    triton_utils._available_triton_version(), Version("3.7.1")
+                )
+
+            scan.assert_not_called()
+
+    def test_unresolved_known_collision_scans_unlisted_provider(self):
+        with tempfile.TemporaryDirectory() as directory:
+            origin = Path(directory) / "triton" / "__init__.py"
+            origin.parent.mkdir()
+            contents = b'__version__ = "3.7.1"\n'
+            origin.write_bytes(contents)
+
+            with (
+                _triton_installed(
+                    {
+                        "triton": "3.2.0",
+                        "triton-rocm": "3.3.0",
+                        "triton-nightly": "3.7.1",
+                    }
+                ),
+                _triton_records(
+                    {
+                        "triton": [_InstalledFile(origin)],
+                        "triton-rocm": [
+                            _InstalledFile(origin, b'__version__ = "3.3.0"\n')
+                        ],
+                        "triton-nightly": [_InstalledFile(origin, contents)],
+                    }
+                ),
+                _triton_module_at(str(origin)),
+                _triton_provided_by("triton", "triton-rocm", "triton-nightly") as scan,
+            ):
+                self.assertEqual(
+                    triton_utils._available_triton_version(), Version("3.7.1")
+                )
+
+            scan.assert_called_once()
+
+    def test_unlisted_distribution_is_scanned(self):
         with (
             _triton_installed({"triton-nightly": "3.7.1"}),
             _triton_records({"triton-nightly": [_MODULE_ORIGIN]}),
@@ -814,12 +826,7 @@ class TestTritonDistributionDiscovery(TestCase):
 
         scan.assert_called_once()
 
-    def test_editable_install_keeps_the_version_it_reports(self):
-        # A PEP 660 editable install records the `.pth` and finder that put the
-        # module on sys.path and its own metadata, never the module -- which
-        # stays in the source tree, where the resolved origin points. Rejecting
-        # it would disable the ops on an install where `import triton` works,
-        # and where the plain name lookup used to answer fine.
+    def test_single_editable_install_skips_ownership(self):
         with (
             _triton_installed({"triton": "3.7.1"}),
             _triton_records(
@@ -832,31 +839,30 @@ class TestTritonDistributionDiscovery(TestCase):
                         "/site-packages/triton-3.7.1.dist-info/top_level.txt",
                     ]
                 }
-            ),
-            _triton_module_at("/home/dev/triton/python/triton/__init__.py"),
+            ) as distribution,
+            _triton_module_at("/src/triton/__init__.py") as origin,
             _triton_provided_by("triton"),
         ):
             self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
 
-    def test_unreadable_provider_does_not_abandon_the_ones_after_it(self):
-        # The scan lists providers in sys.path order, so a dist-info with no
-        # `Name` must not decide the answer for the ones behind it.
+        distribution.assert_not_called()
+        origin.assert_not_called()
+
+    def test_unreadable_provider_is_skipped(self):
         def version_of(distribution):
-            if distribution is None:
-                raise ValueError("A distribution name is required.")
+            if distribution == "broken-triton":
+                raise ValueError("broken metadata")
             return Version("3.7.1") if distribution == "triton-nightly" else None
 
         with (
             patch.object(triton_utils, "_available_version", side_effect=version_of),
             _triton_records({"triton-nightly": [_MODULE_ORIGIN]}),
-            _triton_provided_by(None, "triton-nightly"),
+            _triton_provided_by("broken-triton", "triton-nightly"),
             self.assertLogs("torch._native.triton_utils", level="WARNING"),
         ):
             self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
 
-    def test_provider_already_tried_under_another_spelling_is_not_retried(self):
-        # Metadata lookups normalize names, so `triton_rocm` from the scan is the
-        # `triton-rocm` already tried; re-checking it cannot change the answer.
+    def test_normalized_provider_is_not_retried(self):
         with (
             _triton_installed({}) as version_lookup,
             _triton_provided_by("triton_rocm"),
@@ -868,36 +874,71 @@ class TestTritonDistributionDiscovery(TestCase):
             [call.args[0] for call in version_lookup.call_args_list],
         )
 
-    def test_distribution_without_a_record_is_taken_at_its_word(self):
-        # Nothing was learned about what it owns, so it keeps the answer it
-        # would have given before the question was asked.
-        with (
-            _triton_installed({"triton": "3.7.1"}),
-            _triton_records({"triton": None}),
-            _triton_provided_by() as scan,
+    def test_missing_record_is_undecidable(self):
+        with _triton_records({"triton": None}):
+            self.assertIsNone(
+                triton_utils._distribution_matches("triton", _MODULE_ORIGIN)
+            )
+
+    def test_missing_record_hash_is_undecidable(self):
+        with _triton_records({"triton": [_MODULE_ORIGIN]}):
+            self.assertIsNone(
+                triton_utils._distribution_matches("triton", _MODULE_ORIGIN)
+            )
+
+    def test_unsupported_record_hash_is_undecidable(self):
+        record = _InstalledFile(_MODULE_ORIGIN)
+        record.hash = _FileHash("unsupported", "")
+        with _triton_records({"triton": [record]}):
+            self.assertIsNone(
+                triton_utils._distribution_matches("triton", _MODULE_ORIGIN)
+            )
+
+    def test_empty_record_does_not_match(self):
+        with _triton_records({"triton": []}):
+            self.assertIs(
+                triton_utils._distribution_matches("triton", _MODULE_ORIGIN),
+                False,
+            )
+
+    def test_editable_record_is_undecidable(self):
+        with _triton_records(
+            {
+                "triton": [
+                    "/site-packages/__editable__.triton-3.7.1.pth",
+                    "/site-packages/__editable___triton_3_7_1_finder.py",
+                    "/site-packages/triton-3.7.1.dist-info/RECORD",
+                ]
+            }
         ):
-            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+            self.assertIsNone(
+                triton_utils._distribution_matches("triton", "/src/triton/__init__.py")
+            )
 
-        scan.assert_not_called()
+    def test_hash_tie_uses_fast_path_order(self):
+        with tempfile.TemporaryDirectory() as directory:
+            origin = Path(directory) / "triton" / "__init__.py"
+            origin.parent.mkdir()
+            contents = b'__version__ = "3.7.1"\n'
+            origin.write_bytes(contents)
+            record = _InstalledFile(origin, contents)
 
-    def test_unresolvable_module_is_not_held_against_a_distribution(self):
+            with (
+                _triton_installed(
+                    {"triton": "3.7.1", "pytorch-triton-rocm": "3.7.1+rocm"}
+                ),
+                _triton_records({"triton": [record], "pytorch-triton-rocm": [record]}),
+                _triton_module_at(str(origin)),
+                _triton_provided_by("triton", "pytorch-triton-rocm"),
+                self.assertLogs("torch._native.triton_utils", level="WARNING"),
+            ):
+                self.assertEqual(
+                    triton_utils._available_triton_version(), Version("3.7.1")
+                )
+
+    def test_nameless_provider_is_skipped(self):
         with (
-            _triton_installed({"triton": "3.7.1"}),
-            _triton_module_at(None),
-            _triton_records({"triton": ["/site-packages/somewhere/else.py"]}),
-            _triton_provided_by(),
-        ):
-            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
-
-    def test_nameless_distribution_declines_instead_of_raising(self):
-        # The scan reports a dist-info with no `Name` as a `None` provider, and
-        # the version lookup raises on it -- during `import torch`.
-        with (
-            patch.object(
-                triton_utils,
-                "_available_version",
-                side_effect=_rejects_a_nameless_distribution,
-            ),
+            _triton_installed({}),
             _triton_provided_by(None),
             self.assertLogs("torch._native.triton_utils", level="WARNING"),
         ):
@@ -905,32 +946,17 @@ class TestTritonDistributionDiscovery(TestCase):
 
 
 class TestTritonModuleOrigin(TestCase):
-    """Locating a module without importing it."""
-
     def test_absent_module_has_no_origin(self):
         self.assertIsNone(triton_utils._module_origin("_no_such_native_dsl_module"))
 
     def test_broken_parent_package_declines_instead_of_raising(self):
-        # find_spec imports the parent package to search it, so anything the
-        # parent raises arrives here, during `import torch`.
         with patch.object(triton_utils, "_find_spec", side_effect=ImportError("boom")):
             self.assertIsNone(triton_utils._module_origin("triton"))
 
 
 class TestTritonVersionGate(TestCase):
-    """The gate that decides whether the Triton overrides register at all.
-
-    Both verdicts are `functools.cache`d, so every case has to clear them twice:
-    otherwise this machine's own install decides the first case and a stale
-    verdict decides the next one.
-    """
-
     def setUp(self):
         super().setUp()
-        # The escape hatch is cached too, and the tests above leave it set: a
-        # verdict of "skip the version check" would pass every case here. It is
-        # cleared on common_utils, where it is defined; triton_utils only
-        # re-exports the same object.
         for verdict in (
             triton_utils._check_runtime_available,
             triton_utils._version_is_sufficient,
@@ -965,18 +991,12 @@ class TestTritonVersionGate(TestCase):
             self.assertIsNone(triton_utils.runtime_version())
             self.assertFalse(triton_utils._version_is_sufficient())
 
-    # 3.6.0 is the boundary; 3.42.0 is a minor far past it, since the check
-    # compares the minor rather than the release.
     @parametrize("version", ("3.6.0", "3.42.0"))
     def test_supported_versions_pass_the_gate(self, version):
         with self._installed_triton({"triton-rocm": version}, "triton-rocm"):
             self.assertTrue(triton_utils._version_is_sufficient())
 
-    # One case per way of failing: 3.5.9 is the minor below the boundary, and
-    # 2.9.0 and 4.6.0 are rejected on the major alone -- both clear the minor,
-    # so nothing else here would notice the major check being loosened to an
-    # inequality, which would accept a 4.x Triton the overrides are not built
-    # against.
+    # The off-major cases clear the minor threshold.
     @parametrize("version", ("3.5.9", "2.9.0", "4.6.0"))
     def test_unsupported_versions_fail_the_gate(self, version):
         with self._installed_triton({"triton-rocm": version}, "triton-rocm"):
@@ -990,8 +1010,6 @@ class TestTritonVersionGate(TestCase):
             self.assertTrue(triton_utils._version_is_sufficient())
 
     def test_version_skip_does_not_rescue_an_unreported_version(self):
-        # The escape hatch overrides a version that is too old, not the absence
-        # of one: there is nothing to run the ops against.
         with (
             self._installed_triton({}),
             patch.object(triton_utils, "check_native_version_skip", return_value=True),

--- a/test/python_native/test_native_dsl_ops.py
+++ b/test/python_native/test_native_dsl_ops.py
@@ -10,7 +10,7 @@ import uuid
 from importlib.metadata import PackageNotFoundError
 from unittest.mock import patch
 
-from torch._native import triton_utils
+from torch._native import common_utils as native_common_utils, triton_utils
 from torch._vendor.packaging.version import Version
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
@@ -749,8 +749,9 @@ class TestTritonDistributionDiscovery(TestCase):
             self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
 
     def test_module_owned_by_no_distribution_reports_no_version(self):
-        # A source or editable install: importable, with no metadata to read a
-        # version from.
+        # A source checkout on PYTHONPATH: importable, with no dist-info at all,
+        # so nothing reports a version. An editable install is a different case
+        # -- it has metadata and reports a version -- and is covered below.
         with (
             _triton_installed({}),
             _triton_provided_by(),
@@ -813,6 +814,60 @@ class TestTritonDistributionDiscovery(TestCase):
 
         scan.assert_called_once()
 
+    def test_editable_install_keeps_the_version_it_reports(self):
+        # A PEP 660 editable install records the `.pth` and finder that put the
+        # module on sys.path and its own metadata, never the module -- which
+        # stays in the source tree, where the resolved origin points. Rejecting
+        # it would disable the ops on an install where `import triton` works,
+        # and where the plain name lookup used to answer fine.
+        with (
+            _triton_installed({"triton": "3.7.1"}),
+            _triton_records(
+                {
+                    "triton": [
+                        "/site-packages/__editable__.triton-3.7.1.pth",
+                        "/site-packages/__editable___triton_3_7_1_finder.py",
+                        "/site-packages/triton-3.7.1.dist-info/METADATA",
+                        "/site-packages/triton-3.7.1.dist-info/RECORD",
+                        "/site-packages/triton-3.7.1.dist-info/top_level.txt",
+                    ]
+                }
+            ),
+            _triton_module_at("/home/dev/triton/python/triton/__init__.py"),
+            _triton_provided_by("triton"),
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+    def test_unreadable_provider_does_not_abandon_the_ones_after_it(self):
+        # The scan lists providers in sys.path order, so a dist-info with no
+        # `Name` must not decide the answer for the ones behind it.
+        def version_of(distribution):
+            if distribution is None:
+                raise ValueError("A distribution name is required.")
+            return Version("3.7.1") if distribution == "triton-nightly" else None
+
+        with (
+            patch.object(triton_utils, "_available_version", side_effect=version_of),
+            _triton_records({"triton-nightly": [_MODULE_ORIGIN]}),
+            _triton_provided_by(None, "triton-nightly"),
+            self.assertLogs("torch._native.triton_utils", level="WARNING"),
+        ):
+            self.assertEqual(triton_utils._available_triton_version(), Version("3.7.1"))
+
+    def test_provider_already_tried_under_another_spelling_is_not_retried(self):
+        # Metadata lookups normalize names, so `triton_rocm` from the scan is the
+        # `triton-rocm` already tried; re-checking it cannot change the answer.
+        with (
+            _triton_installed({}) as version_lookup,
+            _triton_provided_by("triton_rocm"),
+        ):
+            self.assertIsNone(triton_utils._available_triton_version())
+
+        self.assertNotIn(
+            "triton_rocm",
+            [call.args[0] for call in version_lookup.call_args_list],
+        )
+
     def test_distribution_without_a_record_is_taken_at_its_word(self):
         # Nothing was learned about what it owns, so it keeps the answer it
         # would have given before the question was asked.
@@ -873,12 +928,14 @@ class TestTritonVersionGate(TestCase):
     def setUp(self):
         super().setUp()
         # The escape hatch is cached too, and the tests above leave it set: a
-        # verdict of "skip the version check" would pass every case here.
+        # verdict of "skip the version check" would pass every case here. It is
+        # cleared on common_utils, where it is defined; triton_utils only
+        # re-exports the same object.
         for verdict in (
             triton_utils._check_runtime_available,
             triton_utils._version_is_sufficient,
-            triton_utils.check_native_version_skip,
-            triton_utils.check_native_jit_disabled,
+            native_common_utils.check_native_version_skip,
+            native_common_utils.check_native_jit_disabled,
         ):
             verdict.cache_clear()
             self.addCleanup(verdict.cache_clear)

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -1,6 +1,12 @@
 import functools
 import logging
 import sys
+from importlib.metadata import (
+    distribution as _distribution,
+    packages_distributions as _packages_distributions,
+)
+from importlib.util import find_spec as _find_spec
+from pathlib import Path as _Path
 from typing import cast
 
 from torch._vendor.packaging.version import Version
@@ -28,6 +34,119 @@ _TRITON_DSL_NAME = "triton"
 _TRITON_REQUIRED_VERSION_MAJOR = 3
 _TRITON_MINIMUM_VERSION_MINOR = 6
 
+# Distribution names known to publish the `triton` module, tried before the
+# sys.path scan so that no install pays for it. TRITON_DISTRIBUTIONS in
+# tools/torchtlx/dev.py lists the ones that collide; `triton-xpu` is built by
+# .ci/pytorch/binary_populate_env.sh. A name missing here costs a scan, not a
+# wrong answer, so the list falling behind the wheels is not a correctness bug.
+_TRITON_DISTRIBUTIONS = (
+    "triton",
+    "triton-rocm",
+    "triton-xpu",
+    "pytorch-triton",
+    "pytorch-triton-rocm",
+    "fbtriton",
+)
+
+
+def _module_origin(module_name: str) -> str | None:
+    """
+    File the module resolves to, or None if that cannot be decided
+
+    NOTE: must not import at this point
+    """
+    try:
+        spec = _find_spec(module_name)
+    except Exception:
+        # A broken parent package raises rather than reporting the module
+        # missing, and an origin is a nicety here: the caller reads None as
+        # "cannot decide" and keeps whatever the distribution names report.
+        return None
+    return None if spec is None else spec.origin
+
+
+def _distribution_owns(name: str, origin: str | None) -> bool:
+    """
+    Whether the distribution `name` installed the file at `origin`
+
+    Undecidable in three cases -- no origin, metadata that cannot be read, and
+    a distribution with no RECORD -- and all three answer True: nothing was
+    learned, so the distribution keeps the benefit of the doubt it had before
+    the question was asked.
+    """
+    if origin is None:
+        return True
+
+    try:
+        files = _distribution(name).files
+    except Exception:
+        return True
+
+    if not files:
+        return True
+
+    located = [file.locate() for file in files]
+    if any(str(path) == origin for path in located):
+        return True
+
+    # Only a relocated or symlinked install needs the paths resolved, which
+    # stats every file the distribution installed.
+    origin_path = _Path(origin).resolve()
+    return any(_Path(path).resolve() == origin_path for path in located)
+
+
+def _available_triton_version() -> Version | None:
+    """
+    Version of the distribution that provides the importable `triton`
+
+    The same module ships under several distribution names, and a name this
+    lookup misses is indistinguishable from Triton not being installed, which
+    disables the ops on a working install with nothing to point at. The names
+    in _TRITON_DISTRIBUTIONS are tried first to keep the sys.path scan off the
+    import path, and the scan then covers any name not listed there, so a wheel
+    published under a new name still resolves.
+
+    Neither answer is taken on the name alone. Uninstalling one provider after
+    another has overwritten its files leaves a dist-info that still reports a
+    version for a module it no longer owns (TRITON_DISTRIBUTIONS in
+    tools/torchtlx/dev.py), and the scan lists providers in sys.path order,
+    which does not rank the owner first. Each candidate is therefore checked
+    against the file the module resolves to, and a candidate that cannot be
+    checked is accepted as before.
+
+    NOTE: must not import at this point
+    """
+    origin = _module_origin("triton")
+
+    for name in _TRITON_DISTRIBUTIONS:
+        version = _available_version(name)
+        if version is not None and _distribution_owns(name, origin):
+            return version
+
+    try:
+        for provider in _packages_distributions().get("triton", ()):
+            if provider in _TRITON_DISTRIBUTIONS:
+                # Already tried above, with the same answer.
+                continue
+            version = _available_version(provider)
+            if version is not None and _distribution_owns(provider, origin):
+                return version
+    except Exception:
+        # Reading the metadata is best-effort, but declining leaves the ops
+        # unregistered on an install where Triton itself works, so say so.
+        log.warning(
+            "Could not resolve the distribution providing triton; "
+            "triton native DSL ops will not register",
+            exc_info=True,
+        )
+        return None
+
+    log.info(
+        "no installed distribution reports a parseable version for the `triton` "
+        "module; triton native DSL ops will not register"
+    )
+    return None
+
 
 @functools.cache
 def _check_runtime_available() -> tuple[bool, Version | None]:
@@ -46,7 +165,7 @@ def _check_runtime_available() -> tuple[bool, Version | None]:
     reason = _unavailable_reason(deps)
     if reason is None:
         available = True
-        version = _available_version("triton")
+        version = _available_triton_version()
     else:
         # info, not warning: see cutedsl_utils._check_runtime_available for
         # rationale (missing optional deps is the common case; surface via
@@ -72,6 +191,9 @@ def _version_is_sufficient() -> bool:
     _, version = _check_runtime_available()
 
     if version is None:
+        # _available_triton_version already logged why. Falling through would
+        # report the absent version as the problem and point at
+        # TORCH_NATIVE_SKIP_VERSION_CHECK, which cannot rescue this case.
         return False
 
     # Either exact version, or same major

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -7,6 +7,7 @@ from importlib.metadata import (
 )
 from importlib.util import find_spec as _find_spec
 from pathlib import Path as _Path
+from re import sub as _re_sub
 from typing import cast
 
 from torch._vendor.packaging.version import Version
@@ -34,11 +35,14 @@ _TRITON_DSL_NAME = "triton"
 _TRITON_REQUIRED_VERSION_MAJOR = 3
 _TRITON_MINIMUM_VERSION_MINOR = 6
 
-# Distribution names known to publish the `triton` module, tried before the
-# sys.path scan so that no install pays for it. TRITON_DISTRIBUTIONS in
-# tools/torchtlx/dev.py lists the ones that collide; `triton-xpu` is built by
-# .ci/pytorch/binary_populate_env.sh. A name missing here costs a scan, not a
-# wrong answer, so the list falling behind the wheels is not a correctness bug.
+# Names to try before the sys.path scan, so that a recognized install does not
+# pay for it. No file in the tree is canonical here and this is not meant to be
+# one: .ci/pytorch/binary_populate_env.sh publishes `triton`, `triton-rocm` and
+# `triton-xpu`, TRITON_DISTRIBUTIONS in tools/torchtlx/dev.py covers the five
+# that collide in a dev environment, and neither is a superset of the other.
+# This is the union of what has been seen installed, kept as a fast path only:
+# the scan below resolves a name missing here, so drift costs a scan rather than
+# a wrong answer.
 _TRITON_DISTRIBUTIONS = (
     "triton",
     "triton-rocm",
@@ -46,6 +50,18 @@ _TRITON_DISTRIBUTIONS = (
     "pytorch-triton",
     "pytorch-triton-rocm",
     "fbtriton",
+)
+
+
+def _normalized_name(name: str) -> str:
+    """
+    Distribution name in the form metadata lookups compare (PEP 503)
+    """
+    return _re_sub(r"[-_.]+", "-", name).lower()
+
+
+_TRITON_DISTRIBUTION_KEYS = frozenset(
+    _normalized_name(name) for name in _TRITON_DISTRIBUTIONS
 )
 
 
@@ -65,14 +81,34 @@ def _module_origin(module_name: str) -> str | None:
     return None if spec is None else spec.origin
 
 
+def _records_only_import_shims(paths: list[str]) -> bool:
+    """
+    Whether a distribution recorded nothing but the shims that import the module
+
+    An editable install (PEP 660) records a `.pth` and a finder that put the
+    module on sys.path, and its own metadata, but never the module: setuptools
+    writes only those, and the module itself stays in the source tree. Such a
+    file list cannot say what the distribution owns.
+    """
+    for path in paths:
+        parts = _Path(path).parts
+        if any(part.endswith((".dist-info", ".egg-info")) for part in parts):
+            continue
+        name = _Path(path).name
+        if name.endswith(".pth") or name.startswith("__editable__"):
+            continue
+        return False
+    return True
+
+
 def _distribution_owns(name: str, origin: str | None) -> bool:
     """
     Whether the distribution `name` installed the file at `origin`
 
-    Undecidable in three cases -- no origin, metadata that cannot be read, and
-    a distribution with no RECORD -- and all three answer True: nothing was
-    learned, so the distribution keeps the benefit of the doubt it had before
-    the question was asked.
+    Undecidable in four cases -- no origin, metadata that cannot be read, a
+    distribution with no RECORD, and one that recorded only import shims -- and
+    all four answer True: nothing was learned, so the distribution keeps the
+    benefit of the doubt it had before the question was asked.
     """
     if origin is None:
         return True
@@ -85,14 +121,23 @@ def _distribution_owns(name: str, origin: str | None) -> bool:
     if not files:
         return True
 
-    located = [file.locate() for file in files]
-    if any(str(path) == origin for path in located):
+    # Stops at the match, so an ordinary install does not walk the whole RECORD.
+    if any(str(file.locate()) == origin for file in files):
         return True
 
-    # Only a relocated or symlinked install needs the paths resolved, which
-    # stats every file the distribution installed.
+    located = [str(file.locate()) for file in files]
+    if _records_only_import_shims(located):
+        return True
+
+    # Reached whenever the distribution does not own the module -- the stale
+    # dist-info this lookup exists to see through -- so compare only the entries
+    # that could match before resolving, which stats the file.
     origin_path = _Path(origin).resolve()
-    return any(_Path(path).resolve() == origin_path for path in located)
+    return any(
+        _Path(path).resolve() == origin_path
+        for path in located
+        if _Path(path).name == origin_path.name
+    )
 
 
 def _available_triton_version() -> Version | None:
@@ -124,13 +169,7 @@ def _available_triton_version() -> Version | None:
             return version
 
     try:
-        for provider in _packages_distributions().get("triton", ()):
-            if provider in _TRITON_DISTRIBUTIONS:
-                # Already tried above, with the same answer.
-                continue
-            version = _available_version(provider)
-            if version is not None and _distribution_owns(provider, origin):
-                return version
+        providers = _packages_distributions().get("triton", ())
     except Exception:
         # Reading the metadata is best-effort, but declining leaves the ops
         # unregistered on an install where Triton itself works, so say so.
@@ -141,6 +180,28 @@ def _available_triton_version() -> Version | None:
         )
         return None
 
+    for provider in providers:
+        try:
+            if _normalized_name(provider) in _TRITON_DISTRIBUTION_KEYS:
+                # Already tried above, with the same answer.
+                continue
+            version = _available_version(provider)
+            if version is not None and _distribution_owns(provider, origin):
+                return version
+        except Exception:
+            # A dist-info whose METADATA has no `Name` arrives here as a `None`
+            # provider, which the version lookup rejects. Skip it rather than
+            # abandoning the providers listed after it.
+            log.warning(
+                "Ignoring a distribution that reports providing triton but "
+                "cannot be read",
+                exc_info=True,
+            )
+
+    # Left at info: reaching here means no metadata reports a version at all,
+    # which is what a source checkout on PYTHONPATH looks like, and is expected
+    # rather than notable. An editable install is not this case -- it reports a
+    # version, and _distribution_owns accepts it.
     log.info(
         "no installed distribution reports a parseable version for the `triton` "
         "module; triton native DSL ops will not register"

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -36,13 +36,13 @@ _TRITON_REQUIRED_VERSION_MAJOR = 3
 _TRITON_MINIMUM_VERSION_MINOR = 6
 
 # Names to try before the sys.path scan, so that a recognized install does not
-# pay for it. No file in the tree is canonical here and this is not meant to be
-# one: .ci/pytorch/binary_populate_env.sh publishes `triton`, `triton-rocm` and
-# `triton-xpu`, TRITON_DISTRIBUTIONS in tools/torchtlx/dev.py covers the five
-# that collide in a dev environment, and neither is a superset of the other.
-# This is the union of what has been seen installed, kept as a fast path only:
-# the scan below resolves a name missing here, so drift costs a scan rather than
-# a wrong answer.
+# pay for it. No file in the tree enumerates all of them and this is not meant to
+# become that file: .ci/pytorch/binary_populate_env.sh publishes `triton`,
+# `triton-rocm`, `fbtriton` and `triton-xpu`, while TRITON_DISTRIBUTIONS in
+# tools/torchtlx/dev.py and tools/torchtlx/_probe.py list the five that collide
+# in a dev environment, omitting `triton-xpu` and adding the `pytorch-triton`
+# names. This tuple is their union, and only a fast path: the scan below resolves
+# a name missing here, so drift costs a scan rather than a wrong answer.
 _TRITON_DISTRIBUTIONS = (
     "triton",
     "triton-rocm",

--- a/torch/_native/triton_utils.py
+++ b/torch/_native/triton_utils.py
@@ -1,6 +1,9 @@
+import base64 as _base64
 import functools
+import hashlib as _hashlib
 import logging
 import sys
+from collections.abc import Iterable as _Iterable
 from importlib.metadata import (
     distribution as _distribution,
     packages_distributions as _packages_distributions,
@@ -8,7 +11,7 @@ from importlib.metadata import (
 from importlib.util import find_spec as _find_spec
 from pathlib import Path as _Path
 from re import sub as _re_sub
-from typing import cast
+from typing import Any as _Any, cast
 
 from torch._vendor.packaging.version import Version
 
@@ -35,14 +38,8 @@ _TRITON_DSL_NAME = "triton"
 _TRITON_REQUIRED_VERSION_MAJOR = 3
 _TRITON_MINIMUM_VERSION_MINOR = 6
 
-# Names to try before the sys.path scan, so that a recognized install does not
-# pay for it. No file in the tree enumerates all of them and this is not meant to
-# become that file: .ci/pytorch/binary_populate_env.sh publishes `triton`,
-# `triton-rocm`, `fbtriton` and `triton-xpu`, while TRITON_DISTRIBUTIONS in
-# tools/torchtlx/dev.py and tools/torchtlx/_probe.py list the five that collide
-# in a dev environment, omitting `triton-xpu` and adding the `pytorch-triton`
-# names. This tuple is their union, and only a fast path: the scan below resolves
-# a name missing here, so drift costs a scan rather than a wrong answer.
+# Fast-path union of names used by binary_populate_env.sh and torchtlx.
+# Missing names are discovered by _packages_distributions().
 _TRITON_DISTRIBUTIONS = (
     "triton",
     "triton-rocm",
@@ -54,42 +51,21 @@ _TRITON_DISTRIBUTIONS = (
 
 
 def _normalized_name(name: str) -> str:
-    """
-    Distribution name in the form metadata lookups compare (PEP 503)
-    """
+    """Distribution name in the form metadata lookups compare (PEP 503)."""
     return _re_sub(r"[-_.]+", "-", name).lower()
 
 
-_TRITON_DISTRIBUTION_KEYS = frozenset(
-    _normalized_name(name) for name in _TRITON_DISTRIBUTIONS
-)
-
-
 def _module_origin(module_name: str) -> str | None:
-    """
-    File the module resolves to, or None if that cannot be decided
-
-    NOTE: must not import at this point
-    """
+    """Resolve a module's file without importing it."""
     try:
         spec = _find_spec(module_name)
     except Exception:
-        # A broken parent package raises rather than reporting the module
-        # missing, and an origin is a nicety here: the caller reads None as
-        # "cannot decide" and keeps whatever the distribution names report.
         return None
     return None if spec is None else spec.origin
 
 
 def _records_only_import_shims(paths: list[str]) -> bool:
-    """
-    Whether a distribution recorded nothing but the shims that import the module
-
-    An editable install (PEP 660) records a `.pth` and a finder that put the
-    module on sys.path, and its own metadata, but never the module: setuptools
-    writes only those, and the module itself stays in the source tree. Such a
-    file list cannot say what the distribution owns.
-    """
+    """Whether a RECORD contains only editable-install shims and metadata."""
     for path in paths:
         parts = _Path(path).parts
         if any(part.endswith((".dist-info", ".egg-info")) for part in parts):
@@ -101,107 +77,146 @@ def _records_only_import_shims(paths: list[str]) -> bool:
     return True
 
 
-def _distribution_owns(name: str, origin: str | None) -> bool:
-    """
-    Whether the distribution `name` installed the file at `origin`
+def _record_hash_matches(path: _Path, file_hash: _Any) -> bool | None:
+    if file_hash is None:
+        return None
 
-    Undecidable in four cases -- no origin, metadata that cannot be read, a
-    distribution with no RECORD, and one that recorded only import shims -- and
-    all four answer True: nothing was learned, so the distribution keeps the
-    benefit of the doubt it had before the question was asked.
-    """
+    try:
+        digest = _hashlib.new(file_hash.mode)
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                digest.update(chunk)
+        value = _base64.urlsafe_b64encode(digest.digest()).rstrip(b"=").decode()
+        return value == file_hash.value
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+def _distribution_matches(name: str, origin: str | None) -> bool | None:
+    """Whether a distribution's RECORD matches the module, or is undecidable."""
     if origin is None:
-        return True
+        return None
 
     try:
         files = _distribution(name).files
     except Exception:
-        return True
+        return None
 
+    if files is None:
+        return None
     if not files:
-        return True
+        return False
 
-    # Stops at the match, so an ordinary install does not walk the whole RECORD.
-    if any(str(file.locate()) == origin for file in files):
-        return True
+    try:
+        origin_path = _Path(origin).resolve()
+        located = [(file, _Path(file.locate())) for file in files]
+        for file, path in located:
+            if str(path) == origin or (
+                path.name == origin_path.name and path.resolve() == origin_path
+            ):
+                return _record_hash_matches(origin_path, getattr(file, "hash", None))
+    except Exception:
+        return None
 
-    located = [str(file.locate()) for file in files]
-    if _records_only_import_shims(located):
-        return True
+    if _records_only_import_shims([str(path) for _, path in located]):
+        return None
+    return False
 
-    # Reached whenever the distribution does not own the module -- the stale
-    # dist-info this lookup exists to see through -- so compare only the entries
-    # that could match before resolving, which stats the file.
-    origin_path = _Path(origin).resolve()
-    return any(
-        _Path(path).resolve() == origin_path
-        for path in located
-        if _Path(path).name == origin_path.name
+
+def _candidate_versions(
+    names: _Iterable[str | None], seen: set[str]
+) -> list[tuple[str, Version]]:
+    candidates: list[tuple[str, Version]] = []
+    for name in names:
+        if not isinstance(name, str):
+            log.warning("Ignoring an unnamed distribution that provides triton")
+            continue
+
+        key = _normalized_name(name)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        try:
+            version = _available_version(name)
+        except Exception:
+            log.warning(
+                "Ignoring unreadable triton distribution %s", name, exc_info=True
+            )
+            continue
+        if version is not None:
+            candidates.append((name, version))
+    return candidates
+
+
+def _resolve_ambiguous_version(
+    candidates: list[tuple[str, Version]],
+    *,
+    fallback: bool,
+) -> Version | None:
+    origin = _module_origin("triton")
+    matched: list[tuple[str, Version]] = []
+    undecidable: list[tuple[str, Version]] = []
+    for candidate in candidates:
+        result = _distribution_matches(candidate[0], origin)
+        if result is True:
+            matched.append(candidate)
+        elif result is None:
+            undecidable.append(candidate)
+
+    if not fallback:
+        if matched and len({version for _, version in matched}) == 1:
+            return matched[0][1]
+        return None
+
+    choices = matched or undecidable or candidates
+    if len(choices) == 1 or len({version for _, version in choices}) == 1:
+        return choices[0][1]
+
+    log.warning(
+        "Could not uniquely identify the triton distribution; using %s %s",
+        *choices[0],
     )
+    return choices[0][1]
 
 
 def _available_triton_version() -> Version | None:
     """
-    Version of the distribution that provides the importable `triton`
+    Best-supported installed version for the importable `triton`.
 
-    The same module ships under several distribution names, and a name this
-    lookup misses is indistinguishable from Triton not being installed, which
-    disables the ops on a working install with nothing to point at. The names
-    in _TRITON_DISTRIBUTIONS are tried first to keep the sys.path scan off the
-    import path, and the scan then covers any name not listed there, so a wheel
-    published under a new name still resolves.
-
-    Neither answer is taken on the name alone. Uninstalling one provider after
-    another has overwritten its files leaves a dist-info that still reports a
-    version for a module it no longer owns (TRITON_DISTRIBUTIONS in
-    tools/torchtlx/dev.py), and the scan lists providers in sys.path order,
-    which does not rank the owner first. Each candidate is therefore checked
-    against the file the module resolves to, and a candidate that cannot be
-    checked is accepted as before.
-
-    NOTE: must not import at this point
+    Known names avoid a sys.path scan. A lone candidate is returned directly,
+    so a stale known name can hide an unlisted provider as it did on main.
+    Collisions are checked against RECORD; ties preserve the prior preference
+    for `triton`. This function must not import triton.
     """
-    origin = _module_origin("triton")
-
-    for name in _TRITON_DISTRIBUTIONS:
-        version = _available_version(name)
-        if version is not None and _distribution_owns(name, origin):
+    seen: set[str] = set()
+    candidates = _candidate_versions(_TRITON_DISTRIBUTIONS, seen)
+    if len(candidates) == 1:
+        return candidates[0][1]
+    if len(candidates) > 1:
+        version = _resolve_ambiguous_version(candidates, fallback=False)
+        if version is not None:
             return version
 
     try:
         providers = _packages_distributions().get("triton", ())
     except Exception:
-        # Reading the metadata is best-effort, but declining leaves the ops
-        # unregistered on an install where Triton itself works, so say so.
-        log.warning(
-            "Could not resolve the distribution providing triton; "
-            "triton native DSL ops will not register",
-            exc_info=True,
-        )
-        return None
-
-    for provider in providers:
-        try:
-            if _normalized_name(provider) in _TRITON_DISTRIBUTION_KEYS:
-                # Already tried above, with the same answer.
-                continue
-            version = _available_version(provider)
-            if version is not None and _distribution_owns(provider, origin):
-                return version
-        except Exception:
-            # A dist-info whose METADATA has no `Name` arrives here as a `None`
-            # provider, which the version lookup rejects. Skip it rather than
-            # abandoning the providers listed after it.
+        if not candidates:
             log.warning(
-                "Ignoring a distribution that reports providing triton but "
-                "cannot be read",
+                "Could not resolve the distribution providing triton; "
+                "triton native DSL ops will not register",
                 exc_info=True,
             )
+            return None
+        log.warning("Could not scan for additional triton distributions", exc_info=True)
+    else:
+        candidates.extend(_candidate_versions(providers, seen))
 
-    # Left at info: reaching here means no metadata reports a version at all,
-    # which is what a source checkout on PYTHONPATH looks like, and is expected
-    # rather than notable. An editable install is not this case -- it reports a
-    # version, and _distribution_owns accepts it.
+    if len(candidates) == 1:
+        return candidates[0][1]
+    if candidates:
+        return _resolve_ambiguous_version(candidates, fallback=True)
+
     log.info(
         "no installed distribution reports a parseable version for the `triton` "
         "module; triton native DSL ops will not register"


### PR DESCRIPTION
**Context:** split out of #194131, and addresses @slayton58's comment that the lookup returns `triton_rocm`'s version instead of `triton`'s and that "we should be careful for the event that" the two do not align.

### The problem

Native DSL ops gate on the Triton version, read from distribution metadata. `version("triton")` resolves by distribution *name* and never checks which files that distribution installed:

- Normalization never strips a suffix, so `triton-rocm` and `fbtriton` miss. The ops then silently do not register on an install where `import triton` works.
- A provider swap leaves the previous dist-info behind, still reporting a version for a module it no longer owns (`TRITON_DISTRIBUTIONS` in `tools/torchtlx/dev.py`).

### The fix

Collect versions from known distribution names before scanning `sys.path`. A single candidate is used directly. When multiple distributions report versions, compare the hash recorded for the resolved `triton` module with its bytes on disk; scan only if the known candidates remain unresolved.

- `find_spec` locates the module without importing it.
- Unlisted names still resolve through the scan, and names are compared using metadata normalization.
- A missing RECORD or hash and an editable-install shim RECORD are undecidable; an empty RECORD is evidence of non-ownership.
- One unreadable provider does not discard providers listed after it. Irreducible ties warn and preserve the prior preference for `triton`.

A lone candidate is intentionally not verified, preserving `main`'s behavior and avoiding RECORD work on the common path. Consequently, a lone stale known name can still hide an unlisted provider.

Also fixed: malformed metadata could raise during `import torch` and was logged only at `debug`; it is now caught and reported at `warning`.

### Cost

Against `main`'s single `version("triton")`, the common path measured **0.27 ms -> 0.76 ms**, once per process behind `functools.cache`. A known same-path collision resolves in about **1.7 ms**. The full 419 ms `sys.path` scan is reserved for an unknown provider or unresolved ambiguity.

### Test Plan

```
python test/python_native/test_native_dsl_ops.py
python test/test_public_bindings.py TestPublicBindings.test_correct_module_names
lintrunner torch/_native/triton_utils.py test/python_native/test_native_dsl_ops.py
```

Tests cover known and unlisted names, same-path RECORD collisions with different hashes, editable installs, missing/empty metadata, unreadable providers, normalized names, ambiguity fallback, and the version gate boundaries. The collision was also reproduced in isolated virtual environments with two actual wheels installed in both orders; the lookup selected the wheel whose bytes were live each time.

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang
