### PR TITLE
[ROCm] Remove -amdgpu-early-inline-all / -amdgpu-function-calls from CK SDPA build and Inductor CK builds

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -263,9 +263,6 @@ if(USE_FLASH_ATTENTION)
     #  list(APPEND CK_SDPA_EXTRA_HIPCC_FLAGS -mllvm -amdgpu-coerce-illegal-types=1)
     #endif()
 
-    list(APPEND CK_SDPA_EXTRA_HIPCC_FLAGS -mllvm=-amdgpu-early-inline-all=true)
-    list(APPEND CK_SDPA_EXTRA_HIPCC_FLAGS -mllvm=-amdgpu-function-calls=false)
-
     # Additional CK compiler flags
     set(CK_SDPA_EXTRA_HIPCC_OPTIONS
         CK_ENABLE_BF16

--- a/torch/_inductor/codegen/rocm/compile_command.py
+++ b/torch/_inductor/codegen/rocm/compile_command.py
@@ -97,10 +97,6 @@ def _rocm_compiler_options() -> list[str]:
         "-fPIC",
         "-fvisibility=hidden",
         "-mllvm",
-        "-amdgpu-early-inline-all=true",
-        "-mllvm",
-        "-amdgpu-function-calls=false",
-        "-mllvm",
         "-enable-post-misched=0",
     ]
     if config.rocm.is_debug:


### PR DESCRIPTION
**Summary:**
Removes the `-mllvm -amdgpu-early-inline-all=true` and `-mllvm -amdgpu-function-calls=false` flags from the two places that build Composable Kernel (CK) code on ROCm:
- `aten/src/ATen/CMakeLists.txt` — the `ck_sdpa` static library (`CK_SDPA_EXTRA_HIPCC_FLAGS`), built when `USE_ROCM_CK_SDPA` is on.
- `torch/_inductor/codegen/rocm/compile_command.py` — the Inductor ROCm CK runtime compile options (`_rocm_compiler_options`).

**Motivation:**
`-amdgpu-early-inline-all=true` and `-amdgpu-function-calls=false` force the AMDGPU llvm backend to inline everything.
With the module-wide `AlwaysInliner` now running early in the pipeline, this causes IR growth on the templated CK FMHA kernels, so the `ck_sdpa` build blows up in time/memory. These are compiler-internal debug flags ([llvm/llvm-project#86332](https://github.com/llvm/llvm-project/issues/86332)) and not tuning knobs. 
In ROCm CK library as well, these options are being phased out. See https://github.com/ROCm/rocm-libraries/pull/11183

**Test Plan:**
- CK SDPA (gfx942 / gfx950), builds with USE_ROCM_CK_SDPA=ON:
python test/test_transformers.py -k "ck" -v
- Inductor CK GEMM autotune (ROCm < 7.14 so tests don't skip):
python test/inductor/test_ck_backend.py -v

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben