### PR TITLE
Extract BOLT optimization logs into separate files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,15 +886,18 @@ elseif(LINUX AND CPU_AARCH64)
 endif()
 
 if(USE_LLVM_BOLT)
-  # BOLT requires -fno-reorder-blocks-and-partition for the compiler and
-  # --emit-relocs for the linker. Since --emit-relocs increases the binary
-  # size, we limit the use to libraries that are actually optimized by BOLT
-  # instead of applying globally (see torch_optimize_layout_if_enabled)
-  # NVIDIA internal benchmarking shows -fno-plt also provides a perf boost.
-  append_cxx_flag_if_supported("-fno-plt" CMAKE_CXX_FLAGS)
-  append_cxx_flag_if_supported("-fno-reorder-blocks-and-partition" CMAKE_CXX_FLAGS)
-  append_c_flag_if_supported("-fno-plt" CMAKE_C_FLAGS)
-  append_c_flag_if_supported("-fno-reorder-blocks-and-partition" CMAKE_C_FLAGS)
+  # In addition to the flags below, BOLT also requires --emit-relocs for the
+  # linker. Since --emit-relocs increases the binary size, we limit the use to
+  # libraries that are actually optimized by BOLT instead of applying globally
+  # (see torch_optimize_layout_if_enabled)
+  list(APPEND _bolt_flags
+    "-fno-plt" # shows a perf boost in NVIDIA internal CI
+    "-fno-reorder-blocks-and-partition" # required by BOLT when using GCC>=8
+  )
+  foreach(_flag IN LISTS _bolt_flags)
+    append_c_flag_if_supported("${_flag}" CMAKE_C_FLAGS)
+    append_cxx_flag_if_supported("${_flag}" CMAKE_CXX_FLAGS)
+  endforeach()
 
   # Extract the committed BOLT profiles for the build-time optimization
   # step (torch_optimize_layout_if_enabled in cmake/public/utils.cmake).

--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -588,15 +588,16 @@ function(torch_optimize_layout_if_enabled tgt)
     target_link_options_if_supported(${tgt} "--emit-relocs")
     set(_profile "${LLVM_BOLT_PROFILES_DIR}/lib${tgt}.yaml")
     set_property(TARGET ${tgt} APPEND PROPERTY LINK_DEPENDS "${_profile}")
-
+    set(_logfile "${CMAKE_BINARY_DIR}/logs/llvm-bolt-lib${tgt}.txt")
     set(_prebolt "$<TARGET_FILE_DIR:${tgt}>/prebolt/$<TARGET_FILE_NAME:${tgt}>")
     add_custom_command(
       TARGET ${tgt} POST_BUILD
-      COMMAND "${CMAKE_COMMAND}" -E make_directory "$<TARGET_FILE_DIR:${tgt}>/prebolt"
+      COMMAND "${CMAKE_COMMAND}" -E make_directory "$<PATH:GET_PARENT_PATH,${_logfile}>"
+      COMMAND "${CMAKE_COMMAND}" -E make_directory "$<PATH:GET_PARENT_PATH,${_prebolt}>"
       COMMAND "${CMAKE_COMMAND}" -E rename "$<TARGET_FILE:${tgt}>" "${_prebolt}"
       COMMAND "${LLVM_BOLT_EXECUTABLE}" "${_prebolt}"
               -o "$<TARGET_FILE:${tgt}>"
-              "-data=${_profile}"
+              "-data=${_profile}" "-log-file=${_logfile}"
               -lite -infer-stale-profile
               -reorder-blocks=ext-tsp -reorder-functions=hfsort
               -split-functions -split-all-cold -split-eh -dyno-stats


### PR DESCRIPTION
These optimization stats can be used to quantify how stale the BOLT profile data is. Creating a separate PR just for this change because this adds a new directory to the build dir: `build/logs/llvm-bolt-lib*.txt`

Related-to: https://github.com/pytorch/pytorch/issues/188602