### PR TITLE
docs: show how to inspect saved tensors in autograd graph

### DIFF
--- a/docs/source/autograd.md
+++ b/docs/source/autograd.md
@@ -405,6 +405,69 @@ True
 True
 ```
 
+To inspect tensors exposed as saved values by autograd nodes across a graph, you
+can traverse {attr}`~torch.autograd.graph.Node.next_functions` starting from an
+output tensor's ``grad_fn``:
+
+```python
+def iter_saved_tensors(tensor):
+    if tensor.grad_fn is None:
+        return
+
+    seen = set()
+    stack = [tensor.grad_fn]
+
+    while stack:
+        node = stack.pop()
+
+        if node in seen:
+            continue
+        seen.add(node)
+
+        for attr in dir(node):
+            if not attr.startswith("_saved_"):
+                continue
+
+            value = getattr(node, attr)
+
+            if isinstance(value, torch.Tensor):
+                yield node, attr, value
+            elif isinstance(value, (tuple, list)):
+                for i, item in enumerate(value):
+                    if isinstance(item, torch.Tensor):
+                        yield node, f"{attr}[{i}]", item
+
+        for next_node, _ in node.next_functions:
+            if next_node is not None:
+                stack.append(next_node)
+```
+
+For example:
+
+```python
+x = torch.randn(4, requires_grad=True)
+loss = torch.relu(x * x).sum()
+
+for node, name, tensor in iter_saved_tensors(loss):
+    print(node.name(), name, tensor.shape, tensor.device)
+```
+
+This can help identify values retained by autograd nodes for backward. The
+``_saved_*`` attributes are implementation details intended here only for
+debugging and educational inspection, and they do not necessarily expose every
+Tensor retained by an implementation. In particular, this example does not
+inspect arbitrary values stored by a custom {class}`~torch.autograd.Function`.
+
+The returned entries represent saved tensor slots rather than unique memory
+allocations. The same Tensor, or multiple Tensors sharing the same storage, may
+therefore appear more than once.
+
+Accessing a ``_saved_*`` attribute unpacks the saved value. If the Tensor was
+packed using {class}`~torch.autograd.graph.saved_tensors_hooks`, inspection may
+invoke the corresponding unpack hook even after the hooks context has exited.
+Saved tensors are also normally released after backward, so inspect them before
+backward unless the graph is retained.
+
 You can also define how these saved tensors should be packed / unpacked using hooks.
 A common application is to trade compute for memory by saving those intermediary results
 to disk or to CPU instead of leaving them on the GPU. This is especially useful if you


### PR DESCRIPTION
## Summary

Document how to traverse an autograd graph via `Node.next_functions` and inspect
tensor values exposed through `_saved_*` attributes.

The existing autograd documentation shows how to inspect saved values on an
individual `grad_fn`. This extends that example to graph traversal, which is
useful for debugging values retained for backward.

The documentation also calls out important caveats:
- `_saved_*` attributes are implementation details
- saved tensor slots do not necessarily correspond to unique memory allocations
- multiple entries may reference the same tensor or shared storage
- inspecting saved values may invoke unpack hooks installed with
  `saved_tensors_hooks`
- the example does not necessarily expose every tensor retained by custom
  autograd implementations

Addresses #91692

## Test plan

- `spin quicklint`
- `git diff --check`
- manually ran the traversal example against an installed PyTorch wheel and
  verified saved tensors were discovered across multiple autograd nodes

## AI assistance

ChatGPT and Codex were used to help develop and review this change. I reviewed
the final diff and verified the documented behavior.


cc @ezyang @albanD @gqchen @nikitaved @soulitzer @Varal7 @bobrenjc93