### PR TITLE
[dynamo] Fix DequeVariable maxlen=0 keeping items instead of emptying

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13738,6 +13738,26 @@ def ___make_guard_fn():
         self.assertEqual(eager[1:], compiled[1:])
         self.assertEqual(counter.frame_count, 1)
 
+    def test_deque_maxlen_zero(self):
+        # A deque with maxlen=0 is always empty: construction drops the initial
+        # items and every append/extend is a no-op, matching CPython. Guards the
+        # items[-0:] slice trap, which would otherwise keep everything.
+        def fn(x):
+            d = collections.deque([1, 2, 3], maxlen=0)
+            d.append(4)
+            e = collections.deque(maxlen=0)
+            e.extend([5, 6])
+            return x + 1, list(d), list(e), len(d), len(e)
+
+        x = torch.randn(3)
+        eager = fn(x)
+        counter = CompileCounter()
+        compiled = torch.compile(fn, backend=counter, fullgraph=True)(x)
+        self.assertEqual(eager[0], compiled[0])
+        self.assertEqual(eager[1:], compiled[1:])
+        self.assertEqual(compiled[1:], ([], [], 0, 0))
+        self.assertEqual(counter.frame_count, 1)
+
     def test_yield_from(self):
         def yield_from_fn(t_list, k):
             def yield_from_gen(l):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1466,7 +1466,7 @@ class DequeVariable(BaseListVariable):
         maxlen_val = self.maxlen.as_python_constant()
         if maxlen_val is not None:
             # maxlen == 0 must empty the deque; items[-0:] would keep everything.
-            items = items[-maxlen_val:] if maxlen_val else items[:0]
+            items = items[-maxlen_val:] if maxlen_val != 0 else items[:0]
         super().__init__(items, **kwargs)
         # Mirrors CPython deque->state: bumped on every structural mutation so
         # deque iterators can detect mutation during iteration.
@@ -1665,7 +1665,7 @@ class DequeVariable(BaseListVariable):
             # so fall through to items[:0] in that case.
             self.items[:] = (
                 self.items[-maxlen:]
-                if side == "right" and maxlen
+                if side == "right" and maxlen != 0
                 else self.items[:maxlen]
             )
 

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1463,8 +1463,10 @@ class DequeVariable(BaseListVariable):
             )
         self.maxlen = maxlen
         items = list(items)
-        if self.maxlen.as_python_constant() is not None:
-            items = items[-maxlen.as_python_constant() :]
+        maxlen_val = self.maxlen.as_python_constant()
+        if maxlen_val is not None:
+            # maxlen == 0 must empty the deque; items[-0:] would keep everything.
+            items = items[-maxlen_val:] if maxlen_val else items[:0]
         super().__init__(items, **kwargs)
         # Mirrors CPython deque->state: bumped on every structural mutation so
         # deque iterators can detect mutation during iteration.
@@ -1659,8 +1661,12 @@ class DequeVariable(BaseListVariable):
         # on the left (appendleft/extendleft).
         maxlen = self.maxlen.as_python_constant()
         if maxlen is not None and len(self.items) > maxlen:
+            # side == "right" and maxlen == 0 must empty; items[-0:] keeps all,
+            # so fall through to items[:0] in that case.
             self.items[:] = (
-                self.items[-maxlen:] if side == "right" else self.items[:maxlen]
+                self.items[-maxlen:]
+                if side == "right" and maxlen
+                else self.items[:maxlen]
             )
 
     def append(


### PR DESCRIPTION
DequeVariable clamps to maxlen with items[-maxlen:], but when maxlen is 0 that
slice is items[-0:], i.e. items[0:], which returns the whole list instead of an
empty one. So under torch.compile a deque(maxlen=0) modeled its contents wrong:
collections.deque([1, 2, 3], maxlen=0) traced as length 3, and appending or
extending a maxlen=0 deque kept the new items, while CPython keeps it empty in
every case. __init__ (construction) and _clamp_maxlen's right side (append and
extend) both used the bare slice; appendleft/extendleft use items[:maxlen],
which is already correct for 0. Both sites now special-case maxlen == 0 to
items[:0].

Test Plan:

```
python test/dynamo/test_misc.py MiscTests.test_deque_maxlen_zero
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_deque.py
```

test_deque_maxlen_zero is new and fails without the fix; the cpython deque suite
stays green.

This change was authored with the assistance of Claude (Anthropic).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98