### PR TITLE
[dynamo] Fix DequeVariable.pop() empty-deque error message

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13758,6 +13758,24 @@ def ___make_guard_fn():
         self.assertEqual(compiled[1:], ([], [], 0, 0))
         self.assertEqual(counter.frame_count, 1)
 
+    def test_deque_pop_empty_message(self):
+        # deque.pop() on an empty deque raises IndexError with CPython's "pop
+        # from an empty deque" message, not list's "pop from empty list".
+        def fn(x):
+            try:
+                collections.deque().pop()
+                msg = "no error"
+            except IndexError as e:
+                msg = str(e)
+            return x + 1, msg
+
+        x = torch.randn(3)
+        eager = fn(x)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(eager[0], compiled[0])
+        self.assertEqual(compiled[1], "pop from an empty deque")
+        self.assertEqual(eager[1], compiled[1])
+
     def test_yield_from(self):
         def yield_from_fn(t_list, k):
             def yield_from_gen(l):

--- a/torch/_dynamo/variables/lists.py
+++ b/torch/_dynamo/variables/lists.py
@@ -1787,6 +1787,10 @@ class DequeVariable(BaseListVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker | None:
+        # list_pop raises the list message ("pop from empty list"); deque uses
+        # its own, so check emptiness here before delegating.
+        if self.is_mutable() and not self.items:
+            raise_observed_exception(IndexError, tx, args=["pop from an empty deque"])
         result = BaseListVariable.list_pop(self, tx, args, kwargs)
         if result is None:
             return None


### PR DESCRIPTION
DequeVariable.pop() delegates to BaseListVariable.list_pop, which raises
IndexError("pop from empty list") on an empty container. CPython's deque_pop uses
its own message, "pop from an empty deque", so under torch.compile a
collections.deque().pop() surfaced the list message instead of the deque one.
pop() now checks emptiness itself and raises the deque message before delegating.

Test Plan:

```
python test/dynamo/test_misc.py MiscTests.test_deque_pop_empty_message
PYTORCH_TEST_WITH_DYNAMO=1 python test/cpython/v3_13/test_deque.py
```

test_deque_pop_empty_message is new and fails without the fix; the cpython deque
suite stays green.

This change was authored with the assistance of Claude (Anthropic).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98