### PR TITLE
[BE][Ez]: Add missing std::moves in aten and torch/csrc

### DIFF
--- a/aten/src/ATen/core/jit_type.h
+++ b/aten/src/ATen/core/jit_type.h
@@ -384,7 +384,7 @@ struct TORCH_API SymbolicShape {
     for(size_t i = 0; i < *rank; ++i) {
       shape_symbols.push_back(ShapeSymbol::newSymbol());
     }
-    dims_ = shape_symbols;
+    dims_ = std::move(shape_symbols);
   }
 
   // Mix of known and unknown ranks
@@ -398,7 +398,7 @@ struct TORCH_API SymbolicShape {
         shape_symbols.push_back(ShapeSymbol::fromStaticSize(*dim));
       }
     }
-    dims_ = shape_symbols;
+    dims_ = std::move(shape_symbols);
   }
 
   void dump() const;
@@ -411,7 +411,7 @@ struct TORCH_API SymbolicShape {
     for(int64_t dim : dims) {
       shape_symbols.push_back(ShapeSymbol::fromStaticSize(dim));
     }
-    dims_ = shape_symbols;
+    dims_ = std::move(shape_symbols);
   }
 
   ShapeSymbol operator[](size_t i) const {

--- a/aten/src/ATen/native/quantized/cpu/conv_serialization.h
+++ b/aten/src/ATen/native/quantized/cpu/conv_serialization.h
@@ -152,11 +152,11 @@ ConvParamsSerializationTypeV3 parse_conv_serialized_state(const c10::IValue& v) 
 
     std::vector<std::optional<at::Tensor>> tensors;
     tensors.emplace_back();
-    tensors.emplace_back(weight);
-    tensors.emplace_back(bias);
+    tensors.emplace_back(std::move(weight));
+    tensors.emplace_back(std::move(bias));
 
     int64_t version = 3;
-    return std::tie(version, config_vals, tensors);
+    return std::make_tuple(version, std::move(config_vals), std::move(tensors));
   } else if (version == 2) {
     // version 2
     const auto& elements = v.toTupleRef().elements();
@@ -189,11 +189,11 @@ ConvParamsSerializationTypeV3 parse_conv_serialized_state(const c10::IValue& v) 
 
     std::vector<std::optional<at::Tensor>> tensors;
     tensors.emplace_back();
-    tensors.emplace_back(weight);
-    tensors.emplace_back(bias);
+    tensors.emplace_back(std::move(weight));
+    tensors.emplace_back(std::move(bias));
 
     int64_t version = 3;
-    return std::tie(version, config_vals, tensors);
+    return std::make_tuple(version, std::move(config_vals), std::move(tensors));
   } else if (version == 3) {
     return v.to<ConvParamsSerializationTypeV3>();
   } else {
@@ -242,7 +242,8 @@ ConvParamsSerializationTypeV2 serialize_conv(
   non_optional.emplace_back(std::move(weight));
   optional.emplace_back(std::move(bias));
 
-  return std::tie(version, non_optional, optional);
+  return std::make_tuple(
+      std::move(version), std::move(non_optional), std::move(optional));
 }
 
 #elif QCONV_SERIALIZATION_VERSION == 3
@@ -269,11 +270,11 @@ ConvParamsSerializationTypeV3 serialize_conv(
 
   std::vector<std::optional<at::Tensor>> tensors;
   tensors.emplace_back();
-  tensors.emplace_back(weight);
-  tensors.emplace_back(bias);
+  tensors.emplace_back(std::move(weight));
+  tensors.emplace_back(std::move(bias));
 
   int64_t version = 3;
-  return std::tie(version, config_vals, tensors);
+  return std::make_tuple(version, std::move(config_vals), std::move(tensors));
 }
 
 #else

--- a/torch/csrc/dynamo/python_compiled_autograd.cpp
+++ b/torch/csrc/dynamo/python_compiled_autograd.cpp
@@ -828,7 +828,7 @@ static TraceState call_begin_capture(
     TORCH_INTERNAL_ASSERT(!Py_IsNone(compile_id_str));
     std::string formatted_compile_reason = unwrap_string(compile_id_str) +
         ": " + std::move(compile_reason.value());
-    cache.compile_reasons.emplace_back(formatted_compile_reason);
+    cache.compile_reasons.emplace_back(std::move(formatted_compile_reason));
     THPObjectPtr py_compile_reasons(wrap_string_list(cache.compile_reasons));
     static PyObject* log_compile_reasons =
         PyUnicode_InternFromString("log_compile_reasons");

--- a/torch/csrc/export/upgrader.cpp
+++ b/torch/csrc/export/upgrader.cpp
@@ -101,7 +101,7 @@ void registerUpgrader(
   while (std::getline(ss, component, '.')) {
     TORCH_CHECK_VALUE(
         !component.empty(), "Empty component in keypath: ", dot_keypath);
-    keypath_vector.push_back(component);
+    keypath_vector.push_back(std::move(component));
   }
 
   TORCH_CHECK_VALUE(!keypath_vector.empty(), "Empty keypath provided");
@@ -144,7 +144,7 @@ bool deregisterUpgrader(int version, const std::string& dot_keypath) {
   while (std::getline(ss, component, '.')) {
     TORCH_CHECK_VALUE(
         !component.empty(), "Empty component in keypath: ", dot_keypath);
-    keypath_vector.push_back(component);
+    keypath_vector.push_back(std::move(component));
   }
 
   TORCH_CHECK_VALUE(!keypath_vector.empty(), "Empty keypath provided");

--- a/torch/csrc/jit/mobile/type_parser.cpp
+++ b/torch/csrc/jit/mobile/type_parser.cpp
@@ -188,7 +188,7 @@ TypePtr TypeParser::parseNamedTuple(const std::string& qualified_name) {
     expect(",");
     TypePtr field_type = parse();
     field_names.emplace_back(field_name);
-    field_types.emplace_back(field_type);
+    field_types.emplace_back(std::move(field_type));
     expect("]");
     if (cur() == ",") {
       next();

--- a/torch/csrc/jit/passes/freeze_module.cpp
+++ b/torch/csrc/jit/passes/freeze_module.cpp
@@ -440,14 +440,14 @@ class AttributePropagator {
       for (const auto i : c10::irange(elems.size())) {
         elems.set(i, overrideGradient(elems.extract(i)));
       }
-      attr = elems;
+      attr = std::move(elems);
     } else if (attr.isGenericDict()) {
       auto dict = std::move(attr).toGenericDict();
       for (const auto& pair : dict) {
         auto val = pair.value();
         val = overrideGradient(std::move(val));
       }
-      attr = dict;
+      attr = std::move(dict);
     } else if (attr.isObject() && !attr.toObjectRef().type()->is_module()) {
       auto obj_type = attr.type()->expect<ClassType>();
       auto obj_value = std::move(attr).toObject();

--- a/torch/csrc/jit/passes/frozen_conv_folding.cpp
+++ b/torch/csrc/jit/passes/frozen_conv_folding.cpp
@@ -106,13 +106,13 @@ bool FoldFrozenConvBatchnorm(Block* b) {
       }
 
       ConvBNParameters params;
-      params.conv_w = conv_w;
-      params.conv_b = conv_b;
-      params.bn_rm = bn_rm;
-      params.bn_rv = bn_rv;
+      params.conv_w = std::move(conv_w);
+      params.conv_b = std::move(conv_b);
+      params.bn_rm = std::move(bn_rm);
+      params.bn_rv = std::move(bn_rv);
       params.bn_eps = bn_eps;
-      params.bn_w = bn_w;
-      params.bn_b = bn_b;
+      params.bn_w = std::move(bn_w);
+      params.bn_b = std::move(bn_b);
       std::tuple<Tensor, Tensor> out = computeUpdatedConvWeightAndBias(params);
       WithInsertPoint guard(conv);
       auto fused_conv_w = b->owningGraph()->insertConstant(std::get<0>(out));

--- a/torch/csrc/jit/passes/frozen_linear_folding.cpp
+++ b/torch/csrc/jit/passes/frozen_linear_folding.cpp
@@ -103,13 +103,13 @@ bool FoldFrozenLinearBatchnorm(Block* b) {
       }
 
       LinearBNParameters params;
-      params.linear_w = linear_w;
-      params.linear_b = linear_b;
-      params.bn_rm = bn_rm;
-      params.bn_rv = bn_rv;
+      params.linear_w = std::move(linear_w);
+      params.linear_b = std::move(linear_b);
+      params.bn_rm = std::move(bn_rm);
+      params.bn_rv = std::move(bn_rv);
       params.bn_eps = bn_eps;
-      params.bn_w = bn_w;
-      params.bn_b = bn_b;
+      params.bn_w = std::move(bn_w);
+      params.bn_b = std::move(bn_b);
       std::tuple<Tensor, Tensor> out =
           computeUpdatedLinearWeightAndBias(params);
       WithInsertPoint guard(linear);

--- a/torch/csrc/jit/runtime/interpreter/code_impl.h
+++ b/torch/csrc/jit/runtime/interpreter/code_impl.h
@@ -275,7 +275,7 @@ struct CodeImpl {
       std::vector<NodeSourceInfo> expandedStack;
       getNodeStack(current_node_, &expandedStack);
       auto insertIdx = expanded_node_stacks_.size();
-      expanded_node_stacks_.emplace_back(expandedStack);
+      expanded_node_stacks_.emplace_back(std::move(expandedStack));
       current_node_->i_(attr::node_stack_idx, insertIdx);
     }
 

--- a/torch/csrc/jit/serialization/export_module.cpp
+++ b/torch/csrc/jit/serialization/export_module.cpp
@@ -223,12 +223,12 @@ std::pair<IValue, IValue> getFunctionTuple(
           .append(",")
           .append(value_type_str)
           .append("]");
-      types.emplace_back(dict_str);
+      types.emplace_back(std::move(dict_str));
       continue;
     } else if (t->kind() == TypeKind::TupleType) {
       std::string named_tuple_str =
           get_named_tuple_str_or_default(compilation_unit, t, type_str);
-      types.emplace_back(named_tuple_str);
+      types.emplace_back(std::move(named_tuple_str));
       continue;
     } else if (type_str.starts_with(torch_prefix)) {
       TORCH_CHECK(
@@ -239,7 +239,7 @@ std::pair<IValue, IValue> getFunctionTuple(
           "define a pytorch class (class Foo(torch.nn.Module)). The problematic type is: ",
           type_str);
     }
-    types.emplace_back(type_str);
+    types.emplace_back(std::move(type_str));
   }
 
   // since the register location is embedded into the bytecode, pass the

--- a/torch/csrc/lazy/core/shape.cpp
+++ b/torch/csrc/lazy/core/shape.cpp
@@ -104,8 +104,7 @@ void applySymbolicShapesOnLT(
         converted_args.emplace_back(get_symbolic_shape(tensor));
       }
     } else if (arg.isTensor()) {
-      auto ss = get_symbolic_shape(arg.toTensor());
-      converted_args.emplace_back(ss);
+      converted_args.emplace_back(get_symbolic_shape(arg.toTensor()));
     } else {
       // If we need to support symbolic ints, here is the place
       // to add it.

--- a/torch/csrc/lazy/ts_backend/ts_eager_fallback.cpp
+++ b/torch/csrc/lazy/ts_backend/ts_eager_fallback.cpp
@@ -30,7 +30,7 @@ std::vector<at::Tensor> _to_eager(
             options,
             /*non_blocking*/ false,
             /*copy*/ false);
-        eager_tensors.push_back(eager_tensor);
+        eager_tensors.push_back(std::move(eager_tensor));
       }
       return eager_tensors;
     }

--- a/torch/csrc/profiler/collection.cpp
+++ b/torch/csrc/profiler/collection.cpp
@@ -102,8 +102,8 @@ OpArgData parseArgData(
                 shape.emplace_back(t.sizes_);
                 stride.emplace_back(t.strides_);
               }
-              shapes[i] = shape;
-              strides[i] = stride;
+              shapes[i] = std::move(shape);
+              strides[i] = std::move(stride);
               dtypes[i] = "TensorList";
             },
             [&](const c10::IValue&) { dtypes[i] = "Scalar"; },
@@ -134,11 +134,11 @@ OpArgData parseArgData(
 
   return OpArgData{
       .hasData = true,
-      .shapes = shapes,
-      .dtypes = dtypes,
-      .concreteInputs = concrete_inputs_list,
-      .shapesForKinetoEvent = shapesForKinetoEvent,
-      .strides = strides};
+      .shapes = std::move(shapes),
+      .dtypes = std::move(dtypes),
+      .concreteInputs = std::move(concrete_inputs_list),
+      .shapesForKinetoEvent = std::move(shapesForKinetoEvent),
+      .strides = std::move(strides)};
 }
 
 // ============================================================================


### PR DESCRIPTION
Adds a bunch of std::moves that prevent copying std::vectors and other expensive to copy types around

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @xmfan @aditvenk