### PR TITLE
[MPS] Do not read the bias in complex addbmm/baddbmm when beta is 0

### DIFF
--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -1200,7 +1200,16 @@ static Tensor& addbmm_or_baddbmm_out_mps_impl(const Tensor& input,
 
   // Use Metal kernels for integer and complex types
   if (c10::isIntegralType(batch1.scalar_type(), true) || c10::isComplexType(batch1.scalar_type())) {
-    return do_metal_addbmm_or_baddbmm(input, batch1, batch2, alpha, beta, result, opType == BADDBMM_OP_TYPE);
+    // beta == 0 means input is ignored, so nan/inf in it must not propagate (see the
+    // MPSGraph path below, which drops the bias node entirely). The Metal kernel always
+    // reads the bias, so hand it zeros instead.
+    return do_metal_addbmm_or_baddbmm((beta.toComplexDouble() == 0.0 ? (at::zeros_like(input)) : input),
+                                      batch1,
+                                      batch2,
+                                      alpha,
+                                      beta,
+                                      result,
+                                      opType == BADDBMM_OP_TYPE);
   }
 
   MPSStream* stream = getCurrentMPSStream();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* (to be filled)

torch.baddbmm and torch.addbmm document that when beta is 0 the content of
input is ignored and nan or inf in it is not propagated to the output. On MPS
the MPSGraph path already honors this by never building the beta*input node,
but complex and integral types return earlier into do_metal_addbmm_or_baddbmm,
and that kernel always reads the bias. A nan in input therefore poisons the
entire output for complex inputs.

Pass zeros to the Metal kernel when beta is 0 so the bias contents cannot
reach the result. Integral types cannot carry nan, so this only changes
observable behavior for complex.

The bfloat16 case reported in the issue no longer reproduces on main, since
the MPSGraph path was fixed after 2.13.0. Complex was still affected. On an
M4 with macOS 26.6.1:

    q = torch.randn(1, 8, 16, device="mps", dtype=torch.complex64)
    k = torch.randn(1, 16, 32, device="mps", dtype=torch.complex64)
    n = torch.full((1, 1, 1), complex(float("nan"), float("nan")),
                   device="mps", dtype=torch.complex64)
    out = torch.baddbmm(n, q, k, alpha=0.5, beta=0)
    torch.isnan(out.real).sum()

printed 256 out of 256 before this change and 0 after, matching CPU. Same for
addbmm. With identical inputs, results for beta != 0 are unchanged and agree
with CPU.

Fixes #194442