### PR TITLE
Fix stale float specialization in tensorify_python_scalars (#194976)

### DIFF
--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -9,9 +9,12 @@ import numpy as np
 import torch
 import torch._dynamo.test_case
 import torch._dynamo.testing
+import torch._functorch.config as functorch_config
+import torch._inductor.config as inductor_config
 import torch.nn.functional as F
 from torch._dynamo.comptime import comptime
 from torch._dynamo.testing import CompileCounter, CompileCounterWithBackend, same
+from torch._inductor.utils import fresh_cache
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_MEM_EFF_ATTENTION
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import skipIfWindows
@@ -867,6 +870,49 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(fn_opt(x, y2), fn(x, y2))
             self.assertEqual(fn_opt(x, y3), fn(x, y3))
             self.assertEqual(cnt.frame_count, 1)
+
+    @torch._dynamo.config.patch(specialize_float=False)
+    def test_unspecialized_float_clamp_tensorify(self):
+        # https://github.com/pytorch/pytorch/issues/194976
+        def fn(x, limit):
+            gate, up = torch.chunk(x, 2, dim=-1)
+            gate = F.silu(gate).clamp(max=limit)
+            up = up.clamp(min=-limit, max=limit)
+            return gate * up
+
+        cnt = CompileCounterWithBackend("inductor")
+        fn_opt = torch.compile(fn, backend=cnt)
+        for limit in [0.5, 1.0, 0.25]:
+            x = torch.full((1, 4), 0.75, requires_grad=True)
+            x_ref = x.detach().clone().requires_grad_(True)
+            actual = fn_opt(x, limit)
+            expected = fn(x_ref, limit)
+            self.assertEqual(actual, expected)
+            actual.sum().backward()
+            expected.sum().backward()
+            self.assertEqual(x.grad, x_ref.grad)
+        self.assertEqual(cnt.frame_count, 1)
+
+    @torch._dynamo.config.patch(specialize_float=False)
+    @inductor_config.patch("fx_graph_cache", True)
+    @inductor_config.patch("fx_graph_remote_cache", False)
+    @inductor_config.patch("force_disable_caches", False)
+    @functorch_config.patch({"enable_autograd_cache": True})
+    def test_unspecialized_float_untensorifiable_use_specializes(self):
+        # https://github.com/pytorch/pytorch/issues/194976
+        # torch.full's fill value cannot be tensorified while x * scale can.
+        # The surviving use must force Dynamo to specialize and guard on the
+        # float; specializing only in the joint graph poisons the
+        # AOTAutogradCache with a baked-in value that is silently reused for
+        # other values of scale.
+        def fn(x, scale):
+            return torch.full((3,), scale, device=x.device) + x * scale
+
+        fn_opt = torch.compile(fn, backend="inductor")
+        with fresh_cache():
+            x = torch.randn(3)
+            for scale in [0.5, 0.75, 1.0]:
+                self.assertEqual(fn_opt(x, scale), fn(x, scale))
 
     @torch._dynamo.config.patch(capture_scalar_outputs=True)
     def test_tensorfiy_python_scalars_1(self):

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -871,7 +871,11 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
             self.assertEqual(fn_opt(x, y3), fn(x, y3))
             self.assertEqual(cnt.frame_count, 1)
 
-    @torch._dynamo.config.patch(specialize_float=False)
+    # assume_static_by_default=False is needed for frame_count == 1 even when
+    # this test is rerun without the class-level patch (see
+    # test_nested_graph_breaks_wrapped.py); otherwise the first call compiles a
+    # static graph and the second recompiles dynamically.
+    @torch._dynamo.config.patch(specialize_float=False, assume_static_by_default=False)
     def test_unspecialized_float_clamp_tensorify(self):
         # https://github.com/pytorch/pytorch/issues/194976
         def fn(x, limit):

--- a/torch/fx/passes/_tensorify_python_scalars.py
+++ b/torch/fx/passes/_tensorify_python_scalars.py
@@ -102,6 +102,8 @@ SUPPORTED_OPS = {
     operator.le: torch.ops.aten.le.Tensor,
     operator.eq: torch.ops.aten.eq.Tensor,
     operator.ne: torch.ops.aten.ne.Tensor,
+    torch.ops.aten.clamp_min.default: torch.ops.aten.clamp_min.Tensor,
+    torch.ops.aten.clamp_max.default: torch.ops.aten.clamp_max.Tensor,
 }
 
 SUPPORTED_METHOD_OPS = {
@@ -399,7 +401,7 @@ def _tensorify_impl(
                         and "val" in a.meta
                         and isinstance(zf := a.meta["val"], torch.SymFloat)
                     ):
-                        failed_tensorify_ops.update(str(node.target))
+                        failed_tensorify_ops.add(str(node.target))
 
                         log.info("Failed to tensorify %s", node.target)
 
@@ -421,14 +423,22 @@ def _tensorify_impl(
                 if has_free_symbols(val.node.expr) and all(
                     symbol_is_type(s, SymT.FLOAT) for s in val.node.expr.free_symbols
                 ):
-                    # If all symbols are backed symfloats, we can just specialize the whole node
-                    # and get more precise guards. eg.
-                    #
-                    # zf = a.item()
-                    # zf2 = zf // 2
-                    # op(.. zf2 ..)
-                    #
-                    # It's better to guard on zf // 2 == 2.0 than zf == 5.0
+                    # This node has a live use we could not tensorify, so its
+                    # symfloats must be specialized by restarting analysis and
+                    # letting Dynamo bake the values into its output graph,
+                    # even if other uses of the same symbol were tensorified.
+                    # Specializing only here, by burning the hint into this
+                    # joint graph with a local ShapeEnv guard, is unsound with
+                    # caching: AOTAutogradCache keys on the graph, which is
+                    # identical for any value of the float, and prunes guards
+                    # on symbols that are not placeholder symints, so the
+                    # cached artifact would be silently reused for other
+                    # values of the float (#194976).
+                    for s in val.node.expr.free_symbols:
+                        name = str(s)
+                        if not TensorifyState.should_specialize(name):
+                            TensorifyState.specialize(name)
+                            should_restart = True
 
                     node.replace_all_uses_with(guard_scalar(val))
                     graph.erase_node(node)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195040

Under specialize_float=False, a Python float argument becomes a 0-d
tensor input plus an item() call producing a backed SymFloat. When some
uses of that symbol were tensorified (e.g. the backward's gt/lt.Scalar)
but another live use was not (e.g. clamp_min/clamp_max.default), the
final sweep in _tensorify_python_scalars.py burned the current hint
into the joint graph via guard_scalar, installing only a ShapeEnv
guard, and skipped the TensorifyState.specialize + restart path because
the symbol was in tensorified_symbols. That guard is over a symbol that
is not a placeholder symint, so AOTAutogradCache's get_pruned_guards
drops it, and the FX graph (the cache key) is identical for any float
value. The next call with a different float hit the poisoned cache
entry and silently computed with the stale constant, in both forward
and backward.

The fix makes the sweep mark those float symbols via
TensorifyState.specialize and restart analysis even when other uses
were tensorified. After the restart, Dynamo bakes the value into its
output graph, so the value is part of the cache key and the equality
guard is installed before anything is cached. This closes the hole for
all unsupported ops and argument positions, at the cost of exact
specialization (more recompiles) where the old path emitted a single
precise-but-uncacheable guard. Fixing AOTAutogradCache to keep such
guards instead is not viable: the float value lives inside a tensor
input and is unavailable to guard evaluation at cache lookup.

Also adds clamp_min/clamp_max.default to SUPPORTED_OPS so the pattern
from the issue stays genuinely dynamic (one compile across limit
values) rather than specializing per value, and fixes
failed_tensorify_ops.update(str(...)) which was adding individual
characters to the metrics set.

Test Plan:

New regression tests (both verified to fail with the library fix
reverted): test_unspecialized_float_clamp_tensorify covers the issue's
swiglu pattern fwd+bwd across three limit values and asserts a single
compile; test_unspecialized_float_untensorifiable_use_specializes
covers the mixed-use torch.full case with FX-graph and autograd caches
enabled.

```
python test/dynamo/test_unspec.py
python test/dynamo/test_misc.py -k tensorify
python test/dynamo/test_recompiles.py -k tensorify
python test/inductor/test_torchinductor_dynamic_shapes.py -k float
lintrunner -a torch/fx/passes/_tensorify_python_scalars.py test/dynamo/test_unspec.py
```

All pass (test_unspec: 65 tests, 1 skip, 2 pre-existing expected
failures; dynamic shapes: 86 tests, 16 skips; lint clean). The issue's
reproducer now gives forward_diff=0.0 and grad_diff=0.0 on all calls,
cold and warm cache.

Fixes #194976

Authored with Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98