### PR TITLE
[inductor] Fix frexp returning mantissa 0 for float32 subnormals on CUDA

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -147,6 +147,29 @@ class CudaReproTests(TestCase):
         self.assertEqual(actual_mantissa, expected_mantissa, equal_nan=True)
         self.assertEqual(actual_exponent, expected_exponent)
 
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    def test_frexp_subnormal(self):
+        # https://github.com/pytorch/pytorch/issues/195007
+        def fn(x):
+            return torch.frexp(x)
+
+        compiled = torch.compile(fn, backend="inductor", fullgraph=True)
+        for dtype, int_dtype, mbits, nbits in (
+            (torch.float32, torch.int32, 23, 32),
+            (torch.float64, torch.int64, 52, 64),
+        ):
+            # subnormals, +-0.0, and the smallest normal, both signs
+            pos = [0, 1, 2, 3, 127, (1 << mbits) - 1, 1 << mbits]
+            bits = pos + [p - (1 << (nbits - 1)) for p in pos]
+            x = torch.tensor(bits, dtype=int_dtype, device=device_type).view(dtype)
+            expected_mantissa, expected_exponent = fn(x)
+            actual_mantissa, actual_exponent = compiled(x)
+            # compare bit patterns to catch a lost -0.0 sign
+            self.assertEqual(
+                actual_mantissa.view(int_dtype), expected_mantissa.view(int_dtype)
+            )
+            self.assertEqual(actual_exponent, expected_exponent)
+
     def test_index_put_issue(self):
         def forward(
             self,

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -792,14 +792,43 @@ def exclusive_scan_decoupled_lookback_64(scratch_base, block_value, index, combi
 
 @triton.jit
 def frexp(x):
-    # TODO(isuruf): use inline_asm_elementwise here
-    zero = x == 0
-    not_finite = libdevice.isinf(x).to(tl.int1) | libdevice.isnan(x).to(tl.int1)
-    special = zero | not_finite
-    safe_x = tl.where(special, 1.0, x)
-    y = libdevice.ilogb(safe_x) + 1
-    exponent = tl.where(special, 0, y)
-    mantissa = tl.where(zero, 0, tl.where(not_finite, x, libdevice.ldexp(safe_x, -y)))
+    # Decompose the IEEE-754 bit pattern with integer ops rather than calling
+    # libdevice.ilogb/ldexp: CUDA compiles libdevice with FTZ, which flushes
+    # float32 subnormals to zero and would return a mantissa of 0 for subnormal
+    # inputs, and the float path also loses the sign of -0.0.
+    if x.dtype == tl.float64:
+        MBITS: tl.constexpr = 52
+        EMASK: tl.constexpr = 0x7FF
+        BIAS: tl.constexpr = 1023
+    elif x.dtype == tl.float32:
+        MBITS: tl.constexpr = 23
+        EMASK: tl.constexpr = 0xFF
+        BIAS: tl.constexpr = 127
+    elif x.dtype == tl.bfloat16:
+        MBITS: tl.constexpr = 7
+        EMASK: tl.constexpr = 0xFF
+        BIAS: tl.constexpr = 127
+    else:
+        tl.static_assert(x.dtype == tl.float16)
+        MBITS: tl.constexpr = 10
+        EMASK: tl.constexpr = 0x1F
+        BIAS: tl.constexpr = 15
+    FMASK: tl.constexpr = (1 << MBITS) - 1
+    idtype = tl.core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
+    bits = x.to(idtype, bitcast=True)
+    exp_field = (bits >> MBITS) & EMASK
+    frac = bits & FMASK
+    # Normalize subnormals by converting the fraction to float (exact, since
+    # it fits in the mantissa), then reuse the normal-number path on that.
+    is_sub = (exp_field == 0) & (frac != 0)
+    norm_bits = frac.to(x.dtype).to(idtype, bitcast=True)
+    src_bits = tl.where(is_sub, (bits & ~FMASK) | (norm_bits & FMASK), bits)
+    src_exp = tl.where(is_sub, (norm_bits >> MBITS) - (BIAS - 1 + MBITS), exp_field)
+    mantissa_bits = (src_bits & ~(EMASK << MBITS)) | ((BIAS - 1) << MBITS)
+    # frexp(+-0) = (+-0, 0), frexp(+-inf) = (+-inf, 0), frexp(nan) = (nan, 0)
+    special = (exp_field == EMASK) | ((exp_field == 0) & (frac == 0))
+    mantissa = tl.where(special, x, mantissa_bits.to(x.dtype, bitcast=True))
+    exponent = tl.where(special, 0, src_exp - (BIAS - 1)).to(tl.int32)
     return mantissa, exponent
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #195041

Fixes #195007

Inductor lowers torch.frexp to triton_helpers.frexp, which computed the
result in floating point via libdevice.ilogb/ldexp. Triton compiles the
CUDA libdevice bitcode with __CUDA_FTZ=1, so __nv_ilogbf flushes float32
subnormal inputs to zero and returns FP_ILOGB0 (INT_MIN), poisoning both
the mantissa and the exponent. float64 was unaffected because FTZ only
applies to float32. The old code also dropped the sign of -0.0 in the
mantissa via `tl.where(zero, 0, ...)`.

The helper now decomposes the IEEE-754 bit pattern with pure integer ops:
bitcast to a signed integer, extract the exponent/fraction fields, force
the exponent field to BIAS-1 to get a mantissa in [0.5, 1), and rebase
the integer exponent. Subnormals are normalized by converting the
fraction integer to float, which is exact (the fraction fits in the
significand) and always produces a normal number, so FTZ cannot touch
it. Zero, inf, and NaN pass through verbatim with exponent 0, matching
eager and preserving the sign of -0.0. As a side effect, fp16/bf16 now
work natively under triton.codegen_upcast_to_fp32=False, where the old
code failed to compile (libdevice.ilogb has no fp16 overload).

An alternative was inline_asm_elementwise (per the old TODO in the
helper), but that is CUDA-specific; this helper is shared by the CUDA,
ROCm, and XPU Triton backends, and the integer decomposition is portable
to all of them with no libdevice dependency at all.

Test Plan:

New regression test covering fp32/fp64 subnormal boundaries, +-0.0, and
the smallest normals, comparing mantissa bit patterns via .view(int) to
catch sign-of-zero loss; verified it fails against the old
implementation. Also verified bit-exactness against eager on exhaustive
sweeps out-of-band: all fp32 subnormals, all 65536 fp16 and bf16 bit
patterns (both upcast configs), and tens of millions of random fp32/fp64
bit patterns.

```
python test/inductor/test_cuda_repro.py -k frexp
python test/inductor/test_torchinductor_opinfo.py -k frexp
python test/inductor/test_op_dtype_prop.py -k frexp
python test/inductor/test_cpu_repro.py -k frexp
lintrunner -a torch/_inductor/runtime/triton_helpers.py test/inductor/test_cuda_repro.py
```

All pass (6+2+2+1 tests OK, lint clean) on CUDA (B200).

Authored with Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo