### PR TITLE
Bump pytorch_sphinx_theme2 pin to 0.4.13

### DIFF
--- a/.ci/docker/requirements-docs.txt
+++ b/.ci/docker/requirements-docs.txt
@@ -2,9 +2,9 @@ sphinx==7.2.6
 #Description: This is used to generate PyTorch docs
 #Pinned versions: 7.2.6
 
-pytorch_sphinx_theme2==0.4.11
+pytorch_sphinx_theme2==0.4.13
 #Description: This is needed to generate PyTorch docs
-#Pinned versions: 0.4.11
+#Pinned versions: 0.4.13
 
 sphinxcontrib.katex==0.9.11
 #Description: This is used to generate PyTorch docs


### PR DESCRIPTION
Picks up **both** halves of the docs search fix for #4954, in a single bump.

### Ranking — theme [#252](https://github.com/pytorch/pytorch_sphinx_theme/pull/252), released in 0.4.12

Sphinx's stock scorer ranked module stub pages above the API symbols they document: the Python domain gives modules search priority 0 (worth `+15`) against `+5` for classes and functions, and `performSearch` merges three passes onto one list without normalising their scales. Searching `nn.linear` returned twelve `*.modules.linear` module pages ahead of `torch.nn.Linear`, which sat at rank 29.

### Duplicates — theme [#255](https://github.com/pytorch/pytorch_sphinx_theme/pull/255), released in 0.4.13

Those same three passes each emitted a row for one page, and the built-in dedup keyed on `[docname, title, anchor, descr, filename]` — which differs per pass — so a single symbol page was listed repeatedly. Rows were also labelled with whichever heading matched, so `linear` returned eight indistinguishable entries reading `Linear`.

### Note on the Docker rebuild

This touches `.ci/docker/`, so it forces a docs image rebuild. That's unavoidable rather than accidental — `docs/requirements.txt` is a symlink to `.ci/docker/requirements-docs.txt`, and the image is what the docs job actually installs from. Both theme fixes are taken in one bump so the rebuild happens once rather than twice.

### Test plan

CI builds the docs and publishes a preview. On that preview, searching `nn.linear` should return `torch.nn.Linear` first rather than the quantized module pages, and `linear` should return distinct qualified names rather than repeated `Linear` rows.

Verified before landing against the preview index from an earlier revision of this PR (3472 docs, 8918 objects), running the real `searchtools.js` under node.

Rank of the wanted page:

| query | before | after |
|---|---|---|
| `nn.linear` → `torch.nn.Linear` | 29 | **1** |
| `linear` → `torch.nn.Linear` | 3 | **1** |
| `conv2d` → `torch.nn.Conv2d` | 3 | **1** |
| `adam` → `torch.optim.Adam` | 2 | **1** |
| `softmax` → `torch.nn.Softmax` | 2 | **1** |

Same-page duplicates in the top 10: `nn.linear` 4 → **0**, `conv2d` 2 → **0**, `adam` 1 → **0**. Prose queries (`cuda semantics`, `autograd mechanics`, `broadcasting semantics`) keep their existing top result.

### Not fixed here

`torch.optim.Adam` and `torch.optim.adam.Adam_class` are two separate generated pages documenting the same class (likewise `AdamW`, `Adamax`, `NAdam`, `RAdam`). No search change can merge those — it's an autodoc/autosummary duplication that puts genuine duplicates in the index, and it deserves its own issue.

---

Authored with the assistance of an AI coding agent.