### PR TITLE
Let nn.grad.convNd_input express a transposed convolution's output_padding

### DIFF
--- a/test/nn/test_convolution.py
+++ b/test/nn/test_convolution.py
@@ -1092,6 +1092,71 @@ class TestConvolutionNN(NNTestCase):
         )
         self.assertEqual(grad_weight_functional, grad_weight_autograd)
 
+    def test_functional_grad_conv_output_padding(self):
+        # A transposed convolution with a non-zero output_padding lands on a shape no
+        # forward convolution produces, so grad.convNd_input used to reject it with
+        # "grad_output[2:] shape ... must be equal to output size ...". It is the
+        # reference these ops are checked against, so it has to be able to say it.
+        for spatial, kernel, stride, padding, dilation, output_padding, groups in (
+            ((4,), (3,), (2,), (1,), (1,), (1,), 1),
+            ((4, 4), (4, 5), (3, 2), (1, 2), (4, 4), (2, 3), 2),
+            ((5, 7), (3, 3), (2, 3), (1, 1), (1, 1), (1, 2), 1),
+            ((3, 3, 3), (2, 2, 2), (2, 2, 2), (1, 1, 1), (1, 1, 1), (1, 1, 1), 1),
+        ):
+            dim = len(spatial)
+            conv_transpose = {
+                1: F.conv_transpose1d,
+                2: F.conv_transpose2d,
+                3: F.conv_transpose3d,
+            }[dim]
+            conv_input = {
+                1: torch.nn.grad.conv1d_input,
+                2: torch.nn.grad.conv2d_input,
+                3: torch.nn.grad.conv3d_input,
+            }[dim]
+
+            grad_output = torch.randn(2, 2 * groups, *spatial)
+            weight = torch.randn(2 * groups, 2, *kernel)
+
+            expected = conv_transpose(
+                grad_output,
+                weight,
+                None,
+                stride=stride,
+                padding=padding,
+                output_padding=output_padding,
+                groups=groups,
+                dilation=dilation,
+            )
+            actual = conv_input(
+                expected.shape,
+                weight,
+                grad_output,
+                stride,
+                padding,
+                dilation,
+                groups,
+                output_padding,
+            )
+            self.assertEqual(actual, expected)
+
+            # Control: the default output_padding still goes down the original path.
+            zero_padded = conv_transpose(
+                grad_output,
+                weight,
+                None,
+                stride=stride,
+                padding=padding,
+                groups=groups,
+                dilation=dilation,
+            )
+            self.assertEqual(
+                conv_input(
+                    zero_padded.shape, weight, grad_output, stride, padding, dilation, groups
+                ),
+                zero_padded,
+            )
+
     def test_functional_grad_conv2d(self):
         BATCH_SIZE = 4
         IN_CH = 8

--- a/torch/nn/grad.py
+++ b/torch/nn/grad.py
@@ -5,6 +5,74 @@ import torch
 from torch.nn.modules.utils import _pair, _single, _triple
 
 
+def _conv_input(
+    input_size,
+    weight,
+    grad_output,
+    stride,
+    padding,
+    dilation,
+    groups,
+    output_padding,
+    ntuple,
+):
+    """Shared body of :func:`conv1d_input`, :func:`conv2d_input` and :func:`conv3d_input`."""
+    stride, padding = ntuple(stride), ntuple(padding)
+    dilation, output_padding = ntuple(dilation), ntuple(output_padding)
+
+    if not any(output_padding):
+        input = grad_output.new_empty(1).expand(input_size)
+        return torch.ops.aten.convolution_backward(
+            grad_output,
+            input,
+            weight,
+            None,
+            stride,
+            padding,
+            dilation,
+            False,
+            [0],
+            groups,
+            (True, False, False),
+        )[0]
+
+    # A transposed convolution with a non-zero output_padding produces a shape no
+    # forward convolution produces, so convolution_backward has nothing to check
+    # input_size against and rejects it. Ask it instead for the gradient a
+    # zero-padded convolution would give, which is the uncropped one, and take the
+    # window the transposed convolution takes out of it: padding off the front, and
+    # zeros past the end for whatever output_padding reaches beyond it.
+    kernel_size = weight.shape[2:]
+    uncropped = [
+        (out - 1) * s + d * (k - 1) + 1
+        for out, s, d, k in zip(grad_output.shape[2:], stride, dilation, kernel_size)
+    ]
+    input = grad_output.new_empty(1).expand(list(input_size[:2]) + uncropped)
+    grad_input = torch.ops.aten.convolution_backward(
+        grad_output,
+        input,
+        weight,
+        None,
+        stride,
+        (0,) * len(uncropped),
+        dilation,
+        False,
+        [0],
+        groups,
+        (True, False, False),
+    )[0]
+
+    tail_pad = []
+    for dim in reversed(range(len(uncropped))):
+        available = uncropped[dim] - padding[dim]
+        tail_pad += [0, max(0, input_size[2 + dim] - available)]
+    grad_input = torch.constant_pad_nd(grad_input, tail_pad, 0)
+    for dim in range(len(uncropped)):
+        grad_input = grad_input.narrow(2 + dim, padding[dim], input_size[2 + dim])
+    return grad_input
+
+
+
 def conv1d_input(
     input_size,
     weight,
@@ -13,6 +81,7 @@ def conv1d_input(
     padding=0,
     dilation=1,
     groups=1,
+    output_padding=0,
 ):
     r"""Compute the gradient of conv1d with respect to the input of the convolution.
 
@@ -27,6 +96,9 @@ def conv1d_input(
         padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
+        output_padding (int or tuple, optional): Additional size added to one side of each
+            dimension of the output shape, matching the transposed convolution argument of
+            the same name. Default: 0
 
     Examples::
 
@@ -38,21 +110,17 @@ def conv1d_input(
         >>> F.grad.conv1d_input(input.shape, weight, grad_output)
 
     """
-    input = grad_output.new_empty(1).expand(input_size)
-
-    return torch.ops.aten.convolution_backward(
-        grad_output,
-        input,
+    return _conv_input(
+        input_size,
         weight,
-        None,
-        _single(stride),
-        _single(padding),
-        _single(dilation),
-        False,
-        [0],
+        grad_output,
+        stride,
+        padding,
+        dilation,
         groups,
-        (True, False, False),
-    )[0]
+        output_padding,
+        _single,
+    )
 
 
 def conv1d_weight(
@@ -111,6 +179,7 @@ def conv2d_input(
     padding=0,
     dilation=1,
     groups=1,
+    output_padding=0,
 ):
     r"""Compute the gradient of conv2d with respect to the input of the convolution.
 
@@ -125,6 +194,9 @@ def conv2d_input(
         padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
+        output_padding (int or tuple, optional): Additional size added to one side of each
+            dimension of the output shape, matching the transposed convolution argument of
+            the same name. Default: 0
 
     Examples::
 
@@ -136,21 +208,17 @@ def conv2d_input(
         >>> F.grad.conv2d_input(input.shape, weight, grad_output)
 
     """
-    input = grad_output.new_empty(1).expand(input_size)
-
-    return torch.ops.aten.convolution_backward(
-        grad_output,
-        input,
+    return _conv_input(
+        input_size,
         weight,
-        None,
-        _pair(stride),
-        _pair(padding),
-        _pair(dilation),
-        False,
-        [0],
+        grad_output,
+        stride,
+        padding,
+        dilation,
         groups,
-        (True, False, False),
-    )[0]
+        output_padding,
+        _pair,
+    )
 
 
 def conv2d_weight(
@@ -209,6 +277,7 @@ def conv3d_input(
     padding=0,
     dilation=1,
     groups=1,
+    output_padding=0,
 ):
     r"""Compute the gradient of conv3d with respect to the input of the convolution.
 
@@ -223,6 +292,9 @@ def conv3d_input(
         padding (int or tuple, optional): Zero-padding added to both sides of the input. Default: 0
         dilation (int or tuple, optional): Spacing between kernel elements. Default: 1
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
+        output_padding (int or tuple, optional): Additional size added to one side of each
+            dimension of the output shape, matching the transposed convolution argument of
+            the same name. Default: 0
 
     Examples::
 
@@ -234,21 +306,17 @@ def conv3d_input(
         >>> F.grad.conv3d_input(input.shape, weight, grad_output)
 
     """
-    input = grad_output.new_empty(1).expand(input_size)
-
-    return torch.ops.aten.convolution_backward(
-        grad_output,
-        input,
+    return _conv_input(
+        input_size,
         weight,
-        None,
-        _triple(stride),
-        _triple(padding),
-        _triple(dilation),
-        False,
-        [0],
+        grad_output,
+        stride,
+        padding,
+        dilation,
         groups,
-        (True, False, False),
-    )[0]
+        output_padding,
+        _triple,
+    )
 
 
 def conv3d_weight(


### PR DESCRIPTION
Fixes #86356.

## Symptom

`nn.grad.convNd_input` documents itself as "the same as the ND transposed convolution operator under the hood", and #86356 uses it as the reference `conv_transpose` is checked against. It has no `output_padding` parameter, so as soon as `conv_transpose` is given a non-default one the reference cannot follow:

```python
t = torch.rand(2, 2, 4, 4)
w = torch.rand(2, 2, 4, 5)
actual = torch.conv_transpose2d(t, w, None, groups=2, stride=(3, 2), padding=(1, 2),
                                dilation=(4, 4), output_padding=(2, 3))
nn.grad.conv2d_input(actual.shape, w, t, (3, 2), (1, 2), (4, 4), 2)
# RuntimeError: grad_output[2:] shape[4, 4] must be equal to output size 4 5
```

It is not simply unsupported, which is what makes it awkward to work around: `output_padding=(1, 0)` and `(0, 1)` on the same call happen to work, because those shapes are ones a forward convolution could have produced. `(2, 3)` is not, so it fails.

## Root cause

With `transposed=False`, `convolution_backward` checks `grad_output` against the output size the forward convolution of `input_size` would have. `conv_transpose` with `output_padding` produces a size that no forward convolution produces, so there is nothing for that check to agree with. Passing the value straight through does not help either, since `convolution_backward` rejects it outright for a non-transposed convolution:

```
RuntimeError: output_padding is not supported for non-transposed convolutions; got: 2 3
```

## Fix

Add `output_padding` to `conv1d_input` / `conv2d_input` / `conv3d_input`, last in the signature and defaulting to `0`, matching the name and meaning it has on `conv_transposeNd`.

- **When it is zero, which is every caller today, the existing `convolution_backward` call is unchanged.**
- When it is not, ask for the gradient a *zero-padded* convolution would give, which is the uncropped one, and take the window the transposed convolution takes out of it: `padding` off the front, and zeros past the end for whatever `output_padding` reaches beyond it. That window is `constant_pad_nd` plus `narrow`, so nothing is copied that the existing path was not already copying.

The three functions differed only in `_single`/`_pair`/`_triple`, so the body moved into one `_conv_input` helper that takes the tuple-maker; each public function keeps its signature, docstring and behaviour.

## Verification

`torch/nn/grad.py` is pure Python, so the patched module was loaded next to an unmodified torch 2.11.0 and compared against both the old module and the ops themselves.

**The default path is bit-identical.** 120 random `(dim, groups, kernel, stride, padding, dilation, input)` combinations across 1D/2D/3D, old module versus new, compared with `torch.equal`: all 120 identical.

**The new path matches `conv_transposeNd` exactly.** 370 random combinations across 1D/2D/3D with a non-zero `output_padding` (groups 1 to 3, kernel 1 to 4, stride 1 to 3, padding 0 to 3, dilation 1 to 3): **0 mismatches** in shape or values.

New test `test_functional_grad_conv_output_padding` in `test/nn/test_convolution.py` covers 1D, 2D and 3D, including the exact parameters from the issue, and asserts the zero-`output_padding` control still goes down the original path. Against `main` all four of its cases fail (`TypeError: conv2d_input() takes from 3 to 7 positional arguments but 8 were given`); with the fix all four pass.

I cannot build PyTorch in this environment, so the CUDA paths and the rest of `test_convolution.py` are for CI; the module under change is Python and was exercised directly as described above.
