### PR TITLE
[Inductor] Fix fused argmax/argmin index on channels_last

### DIFF
--- a/test/inductor/test_channels_last_fused_argreduce.py
+++ b/test/inductor/test_channels_last_fused_argreduce.py
@@ -1,0 +1,44 @@
+# Owner(s): ["module: inductor"]
+
+import unittest
+
+import torch
+from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.inductor_utils import HAS_CPU
+
+
+class TestChannelsLastFusedArgreduce(TestCase):
+    @unittest.skipUnless(HAS_CPU, "requires CPU")
+    def test_mean_argmax_channels_last(self):
+        # https://github.com/pytorch/pytorch/issues/193751
+        torch.manual_seed(1234)
+        x = torch.randn(4, 4, 8, 8).to(memory_format=torch.channels_last)
+
+        def fn(t):
+            return torch.argmax(torch.mean(t, dim=-1))
+
+        self.assertEqual(fn(x), torch.compile(fn)(x))
+
+    @unittest.skipUnless(HAS_CPU, "requires CPU")
+    def test_mean_argmax_channels_last_contiguous(self):
+        torch.manual_seed(1234)
+        x = torch.randn(4, 4, 8, 8)
+
+        def fn(t):
+            return torch.argmax(torch.mean(t, dim=-1))
+
+        self.assertEqual(fn(x), torch.compile(fn)(x))
+
+    @unittest.skipUnless(HAS_CPU, "requires CPU")
+    def test_mean_argmax_channels_last_3d(self):
+        torch.manual_seed(1234)
+        x = torch.randn(2, 3, 4, 5, 6).to(memory_format=torch.channels_last_3d)
+
+        def fn(t):
+            return torch.argmax(torch.mean(t, dim=-1))
+
+        self.assertEqual(fn(x), torch.compile(fn)(x))
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7275,12 +7275,11 @@ def _make_reduction_inner(
             kept_idx.append(i)
             kept_sizes.append(size[i])
 
-    # For argmax/argmin compute logical indices when the tensor has non-contiguous layout.
-    should_compute_logical_index = False
+    # Flattened argmax/argmin: report the logical row-major index.
     supports_logical_index_argreduce = is_triton(x) or (
         ir.get_device_type(x) == "cpu" and config.cpu_backend == "cpp"
     )
-    if (
+    should_compute_logical_index = (
         reduction_type
         in (
             "argmax",
@@ -7292,16 +7291,7 @@ def _make_reduction_inner(
         )
         and len(reduced_sizes) > 1
         and supports_logical_index_argreduce
-    ):
-        if isinstance(x.data, PermuteView):
-            should_compute_logical_index = True
-        elif isinstance(x.data, ir.ReinterpretView) or (
-            isinstance(x.data, ir.StorageBox) and isinstance(x.data.data, ir.Buffer)
-        ):
-            layout = x.get_layout()
-            should_compute_logical_index = (
-                layout.is_transposed() or not layout.is_contiguous()
-            )
+    )
 
     def loader(index, reduction_index):
         if len(reduction_index) != len(reduced_idx):


### PR DESCRIPTION
Fused argmax/argmin was returning the physical loop index of a non-row-major buffer, so `channels_last` inputs got the wrong index.

Always report the logical row-major index when flattening more than one dim.

Fixes #193751

Test plan (CPU nightly, seed 1234):

official script:
| | eager | compiled |
| unpatched | 14 | 25 |
| patched | 14 | 14 |

compiled matched eager after the patch for:
- mean/sum/amax/var/logsumexp + argmax on channels_last
- prod + argmin on channels_last
- channels_last_3d mean+argmax
- contiguous NCHW control
- aot_eager
- bare argmax/argmin
- contiguous reduction+argreduce
- channels_last with dim != -1

`python test/inductor/test_channels_last_fused_argreduce.py`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo