### PR TITLE
Fix test_exported_objects for NumPy >= 2.5.0 (row_stack removal)

### DIFF
--- a/test/torch_np/test_basic.py
+++ b/test/torch_np/test_basic.py
@@ -642,6 +642,9 @@ class TestExport(TestCase):
             # The following methods are removed in NumPy 2.
             # See https://numpy.org/devdocs/numpy_2_0_migration_guide.html#main-namespace
             exported_fns -= {"product", "round_", "sometrue", "cumproduct", "alltrue"}
+        if _np.__version__ >= "2.5.0":
+            # row_stack was removed in NumPy 2.5.0
+            exported_fns -= {"row_stack"}
 
         diff = exported_fns.difference(set(dir(_np)))
         if len(diff) != 0:


### PR DESCRIPTION
## Summary

In NumPy 2.5.0, `row_stack` (a legacy alias for` vstack`) was removed from the top-level numpy namespace.

## Problem
In `test/torch_np/test_basic.py`, `TestExport.test_exported_objects` asserts that all public functions exported by `torch._numpy` match the symbols present in NumPy's top-level module. Because `torch._numpy` still implements and exports `row_stack`, testing against NumPy >= 2.5.0 fails with:
```
AssertionError: {'row_stack'}
```

## Fix
This PR adds a version check to exclude `row_stack` from the required exported functions when running against NumPy >= 2.5.0, matching the existing handling for functions removed in NumPy 2.0.




cc @mruberry @rgommers