### PR TITLE
[inductor] Fix argmax/argmin logical index for non-row-major fused inputs

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19168,6 +19168,34 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
 
         self.common(fn, (torch.randn(6, 4, device=GPU_TYPE).t().contiguous().t(),))
 
+    @skip_if_halide  # no logical-index argreduce support
+    @skip_if_pallas  # no logical-index argreduce support
+    def test_argmax_argmin_fused_producer_channels_last(self):
+        # https://github.com/pytorch/pytorch/issues/193751
+        # The producer's output buffer may be materialized with a permuted
+        # stride order (or inlined), so the arg-reduce must report the
+        # logical row-major index, not the physical iteration index.
+        def fn(x):
+            return (
+                torch.argmax(torch.mean(x, dim=-1)),
+                torch.argmax(torch.sum(x, dim=-1)),
+                torch.argmax(torch.amax(x, dim=-1)),
+                torch.argmax(torch.var(x, dim=-1)),
+                torch.argmax(torch.logsumexp(x, dim=-1)),
+                torch.argmin(torch.prod(x, dim=-1)),
+                torch.argmax(x * 2),
+            )
+
+        x4d = torch.randn(4, 4, 8, 8, device=self.device).to(
+            memory_format=torch.channels_last
+        )
+        self.common(fn, (x4d,), check_lowp=False)
+
+        x5d = torch.randn(2, 3, 4, 5, 6, device=self.device).to(
+            memory_format=torch.channels_last_3d
+        )
+        self.common(fn, (x5d,), check_lowp=False)
+
     @skip_if_halide
     @requires_gpu_and_triton
     def test_unbacked_float_item(self):

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7293,15 +7293,23 @@ def _make_reduction_inner(
         and len(reduced_sizes) > 1
         and supports_logical_index_argreduce
     ):
-        if isinstance(x.data, PermuteView):
-            should_compute_logical_index = True
-        elif isinstance(x.data, ir.ReinterpretView) or (
+        # The default arg-reduce index is the kernel's flat iteration index,
+        # which matches the logical index only for a realized buffer whose
+        # layout is already fixed and contiguous. A FlexibleLayout may later
+        # be frozen to a permuted stride order and an unrealized producer's
+        # iteration order is unknown at lowering time, so compute the logical
+        # index explicitly in those cases.
+        if isinstance(x.data, ir.ReinterpretView) or (
             isinstance(x.data, ir.StorageBox) and isinstance(x.data.data, ir.Buffer)
         ):
             layout = x.get_layout()
             should_compute_logical_index = (
-                layout.is_transposed() or not layout.is_contiguous()
+                not isinstance(layout, ir.FixedLayout)
+                or layout.is_transposed()
+                or not layout.is_contiguous()
             )
+        else:
+            should_compute_logical_index = True
 
     def loader(index, reduction_index):
         if len(reduction_index) != len(reduced_idx):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195063

Fixes #193751

torch.compile returned wrong argmax/argmin indices when the arg-reduction
consumed a fused trailing-dim reduction (mean, sum, amax, var, logsumexp,
prod) or a pointwise op over a channels_last input, on both CPU and CUDA.
The reduction values were computed correctly but the reported index was
the kernel's flat physical iteration index rather than the logical
row-major index eager returns.

Root cause: arg-reduce kernels report their flat iteration index, which
matches the logical index only when the kernel iterates the input in
row-major order. _make_reduction_inner can instead bake a logical
ops.index_expr into the loader, but the decision was made at lowering
time from non-final layout information. For a realized producer buffer
(sum/amax/prod) the layout is still a FlexibleLayout with tentative
contiguous strides, so the old "is_transposed() or not is_contiguous()"
check concluded row-major even though decide_layout() later freezes the
buffer to the producer's permuted fill order. For an unrealized pointwise
producer (mean/var/logsumexp, or argmax(x * 2) directly) no branch of the
check fired at all.

The fix inverts the trust model: emit the logical index unless the input
is a realized buffer/ReinterpretView whose layout is already a frozen,
contiguous, non-transposed FixedLayout - the only case where flat
iteration order is guaranteed row-major (arg-reductions are never split
and reduction loops are not reordered post-fusion). This strictly widens
the logical-index path, so previously correct cases cannot regress; for
contiguous inputs the logical index expression collapses to the flat loop
variable after loop merging, and benchmarking an 8M-element fused argmax
showed no measurable difference on CPU or CUDA. Alternatives considered:
always emitting the logical index (same correctness but abandons the
proven fast path for plain contiguous argmax) and forcing realization or
disabling fusion (workarounds that do not address the root cause).

Halide and pallas backends lack logical-index argreduce support entirely
(supports_logical_index_argreduce excludes them), so they retain the
preexisting gap and the new test skips them.

Test Plan:

New regression test covering all six fused producer ops plus a pointwise
producer, on 4D channels_last and 5D channels_last_3d, device-generic.
Verified it fails without the lowering change (both CPU and GPU) and
passes with it:

```
python test/inductor/test_torchinductor.py -k test_argmax_argmin_fused_producer_channels_last
python test/inductor/test_torchinductor_dynamic_shapes.py -k test_argmax_argmin_fused_producer_channels_last
python test/inductor/test_torchinductor_codegen_dynamic_shapes.py -k test_argmax_argmin_fused_producer_channels_last
```

Targeted sweeps of neighboring functionality, all passing on CPU + CUDA:

```
python -m pytest test/inductor/test_torchinductor.py -k "argmax or argmin" -q
python -m pytest test/inductor/test_torchinductor_dynamic_shapes.py -k "argmax or argmin" -q
python -m pytest test/inductor/test_torchinductor_codegen_dynamic_shapes.py -k "argmax or argmin" -q
python -m pytest test/inductor/test_cpu_repro.py -k "argmax or argmin" -q
python -m pytest test/inductor/test_torchinductor.py -k "reduction" -q
python -m pytest test/inductor/test_cooperative_reductions.py -q
python -m pytest test/inductor/test_compile_subprocess.py -k "fused_producer_channels_last" -q
python -m pytest test/inductor/test_torchinductor.py -k "topk or (max and dim) or (min and dim) or minmax or max_min" -q
```

lintrunner -a reports no issues.

Authored with an AI assistant (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo