### PR TITLE
Coerce custom op backward grads to the output's memory format

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -4054,6 +4054,134 @@ class TestCustomOpAPI(TestCase):
         self.assertEqual(x.grad, (x.cos() - x.sin()) * 2.0)
 
     @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    @parametrize(
+        "op_factory, opname",
+        [
+            subtest((torch.library.custom_op, "custom"), name="custom_op"),
+            subtest((torch.library.triton_op, "triton"), name="triton_op"),
+        ],
+    )
+    def test_register_autograd_noncontiguous_grads_coerced(self, op_factory, opname):
+        # https://github.com/pytorch/pytorch/issues/194719
+        @op_factory(f"_torch_testing::noncontig_grads_{opname}", mutates_args=())
+        def f(x: Tensor) -> tuple[Tensor, Tensor]:
+            return 2 * x, 3 * x
+
+        observed = []
+
+        def backward(ctx, grad_y, grad_z):
+            observed.append((grad_y.is_contiguous(), grad_z.is_contiguous()))
+            return 2 * grad_y + 3 * grad_z
+
+        f.register_autograd(backward)
+
+        x = torch.randn(2, 3, requires_grad=True)
+        y, z = f(x)
+        out = torch.cat([y, z], dim=-1)
+        grad_out = torch.randn_like(out)
+        out.backward(grad_out)
+        self.assertEqual(observed, [(True, True)])
+        self.assertEqual(x.grad, 2 * grad_out[:, :3] + 3 * grad_out[:, 3:])
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_register_autograd_grads_coerced_channels_last(self):
+        @torch.library.custom_op("_torch_testing::channels_last_grads", mutates_args=())
+        def f(x: Tensor) -> Tensor:
+            return (2 * x).contiguous(memory_format=torch.channels_last)
+
+        observed = []
+
+        def backward(ctx, grad):
+            observed.append(grad.is_contiguous(memory_format=torch.channels_last))
+            return 2 * grad
+
+        f.register_autograd(backward)
+
+        x = torch.randn(2, 3, 4, 5, requires_grad=True)
+        # row-major contiguous grad gets coerced to the output's channels-last
+        # memory format
+        f(x).backward(torch.ones(2, 3, 4, 5))
+        # zero-stride expanded grad from sum() also gets coerced
+        f(x).sum().backward()
+        self.assertEqual(observed, [True, True])
+        self.assertEqual(x.grad, torch.full_like(x, 4.0))
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_register_autograd_none_grads_passthrough(self):
+        @torch.library.custom_op(
+            "_torch_testing::unmaterialized_grads", mutates_args=()
+        )
+        def f(x: Tensor) -> tuple[Tensor, Tensor]:
+            return x.sin(), x.cos()
+
+        observed = []
+
+        def setup_context(ctx, inputs, output):
+            ctx.set_materialize_grads(False)
+
+        def backward(ctx, grad_y, grad_z):
+            observed.append((grad_y.is_contiguous(), grad_z))
+            return grad_y
+
+        f.register_autograd(backward, setup_context=setup_context)
+
+        x = torch.randn(3, requires_grad=True)
+        y, _ = f(x)
+        grad_y = torch.randn(6)[::2]
+        y.backward(grad_y)
+        self.assertEqual(observed, [(True, None)])
+        self.assertEqual(x.grad, grad_y)
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_register_autograd_tensorlist_return_noncontiguous_grads(self):
+        @torch.library.custom_op(
+            "_torch_testing::tensorlist_noncontig_grads", mutates_args=()
+        )
+        def f(x: Tensor) -> list[Tensor]:
+            return [2 * x, 3 * x]
+
+        observed = []
+
+        def backward(ctx, grad_outputs):
+            observed.append([g.is_contiguous() for g in grad_outputs])
+            return 2 * grad_outputs[0] + 3 * grad_outputs[1]
+
+        f.register_autograd(backward)
+
+        x = torch.randn(2, 3, requires_grad=True)
+        y0, y1 = f(x)
+        out = torch.cat([y0, y1], dim=-1)
+        grad_out = torch.randn_like(out)
+        out.backward(grad_out)
+        self.assertEqual(observed, [[True, True]])
+        self.assertEqual(x.grad, 2 * grad_out[:, :3] + 3 * grad_out[:, 3:])
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
+    def test_register_autograd_nonstandard_layout_grads_passthrough(self):
+        @torch.library.custom_op(
+            "_torch_testing::nonstandard_layout_grads", mutates_args=()
+        )
+        def f(x: Tensor) -> Tensor:
+            return (2 * x).t().contiguous().t()
+
+        observed = []
+
+        def backward(ctx, grad):
+            observed.append(grad.stride())
+            return 2 * grad
+
+        f.register_autograd(backward)
+
+        # the output is not contiguous in any standard memory format, so the
+        # grad is passed through with its original strides
+        x = torch.randn(2, 3, requires_grad=True)
+        y = f(x)
+        grad_y = torch.randn(2, 6)[:, ::2]
+        y.backward(grad_y)
+        self.assertEqual(observed, [(6, 2)])
+        self.assertEqual(x.grad, 2 * grad_y)
+
+    @skipIfTorchDynamo("Expected to fail due to no FakeTensor support; not a bug")
     def test_manual_schema(self):
         @torch.library.custom_op(
             "_torch_testing::add",

--- a/torch/_library/autograd.py
+++ b/torch/_library/autograd.py
@@ -4,7 +4,9 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+import torch
 from torch import _C, _ops, autograd, Tensor
+from torch._prims_common import is_contiguous_for_memory_format
 from torch.utils import _pytree
 
 from . import utils
@@ -13,6 +15,45 @@ from . import utils
 class InfoProtocol(Protocol):
     _backward_fn: Callable | None
     _setup_context_fn: Callable | None
+
+
+# Note [Custom op backward grad layout]
+# The autograd engine may pass grads with arbitrary strides (e.g. torch.cat's
+# backward produces non-contiguous narrow views of the upstream grad). Custom
+# op backward formulas are typically opaque kernels that assume grads have the
+# same layout as the corresponding forward outputs, so when an output is
+# contiguous in some standard memory format, we coerce its grad to that memory
+# format before invoking the user backward. Grads for outputs with
+# non-standard layouts are passed through unchanged; this matches AOTAutograd,
+# which assumes tangents have the same strides as the corresponding forward
+# outputs (see Note [Tangents memory format]).
+# Contiguity is checked with false_if_dde=True so unbacked symbolic shapes
+# never raise: an output whose contiguity is undecidable records no memory
+# format (its grad passes through), and a grad whose contiguity is undecidable
+# is coerced via Tensor.contiguous, which is unbacked-safe and copies in that
+# case.
+_STANDARD_MEMORY_FORMATS = (
+    torch.contiguous_format,
+    torch.channels_last,
+    torch.channels_last_3d,
+)
+
+
+def _grad_memory_format(out: Any) -> torch.memory_format | None:
+    if not isinstance(out, Tensor) or out.layout != torch.strided:
+        return None
+    for fmt in _STANDARD_MEMORY_FORMATS:
+        if is_contiguous_for_memory_format(out, memory_format=fmt, false_if_dde=True):
+            return fmt
+    return None
+
+
+def _coerce_grad(grad: Any, fmt: torch.memory_format | None) -> Any:
+    if fmt is None or not isinstance(grad, Tensor) or grad.layout != torch.strided:
+        return grad
+    if is_contiguous_for_memory_format(grad, memory_format=fmt, false_if_dde=True):
+        return grad
+    return grad.contiguous(memory_format=fmt)
 
 
 @dataclasses.dataclass
@@ -70,10 +111,20 @@ def make_autograd_impl(op: _ops.OpOverload, info: InfoProtocol) -> Callable:
                     )
                 else:
                     info._setup_context_fn(ctx=ctx, inputs=args, output=result)
+            if hasattr(ctx, "_pt_grad_memory_formats"):
+                raise RuntimeError(
+                    "Please don't set ctx._pt_grad_memory_formats; PyTorch uses it "
+                    "to store info"
+                )
+            ctx._pt_grad_memory_formats = _pytree.tree_map(
+                _grad_memory_format, result if isinstance(result, tuple) else (result,)
+            )
             return result
 
     def backward(ctx, *grads):
         if info._backward_fn:
+            # See Note [Custom op backward grad layout]
+            grads = _pytree.tree_map(_coerce_grad, grads, ctx._pt_grad_memory_formats)
             try:
                 prev_needs_input_grad = ctx.needs_input_grad
                 ctx.needs_input_grad = prev_needs_input_grad[:-1]

--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -657,7 +657,12 @@ class CustomOpDef:
         the number of outputs of the operator.
         The ``ctx`` object is `the same ctx object <context_method_mixins>`_ used by
         :class:`torch.autograd.Function`. The semantics of ``backward_fn`` are the
-        same as :meth:`torch.autograd.Function.backward`.
+        same as :meth:`torch.autograd.Function.backward`. If a forward output is
+        contiguous (possibly in a non-default memory format like
+        ``torch.channels_last``), the corresponding gradient is guaranteed to be
+        contiguous in the same memory format; PyTorch copies the gradient if
+        necessary. Gradients for outputs that are not contiguous in any standard
+        memory format are passed through unchanged and may have arbitrary strides.
 
         ``setup_context(ctx, inputs, output)`` runs during the forward pass.
         Please save quantities needed for backward onto the ``ctx`` object via

--- a/torch/library.py
+++ b/torch/library.py
@@ -1341,7 +1341,12 @@ def register_autograd(
     the number of outputs of the operator.
     The ``ctx`` object is `the same ctx object <context_method_mixins>`_ used by
     :class:`torch.autograd.Function`. The semantics of ``backward_fn`` are the
-    same as :meth:`torch.autograd.Function.backward`.
+    same as :meth:`torch.autograd.Function.backward`. If a forward output is
+    contiguous (possibly in a non-default memory format like
+    ``torch.channels_last``), the corresponding gradient is guaranteed to be
+    contiguous in the same memory format; PyTorch copies the gradient if
+    necessary. Gradients for outputs that are not contiguous in any standard
+    memory format are passed through unchanged and may have arbitrary strides.
 
     ``setup_context(ctx, inputs, output)`` runs during the forward pass.
     Please save quantities needed for backward onto the ``ctx`` object via


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #195064

Fixes #194719

The autograd engine can pass gradients with arbitrary strides to a
backward function; for example, torch.cat's backward hands each input a
non-contiguous narrow view of the upstream grad buffer. Backward
formulas registered on custom ops via torch.library.register_autograd
(notably triton_op backwards) are opaque kernels that typically index
grads assuming the layout of the corresponding forward output, so in
the linked issue the user's Triton kernel silently read wrong rows and
produced wrong gradients. AOTAutograd already coerces boundary tangents
to the output's memory format under torch.compile (see Note [Tangents
memory format]), so eager custom op backwards diverged from the
compile-side contract, and torch.cat inside a compiled region hit the
same bug because the traced glue passed the non-contiguous grads
through.

The fix lives in the generated autograd glue (make_autograd_impl):
forward records which standard memory format (contiguous_format /
channels_last / channels_last_3d) each output is contiguous in, and
backward coerces each incoming grad to that format via
grad.contiguous(memory_format=...), a no-op when the layout already
matches. Grads for outputs with non-standard layouts pass through
unchanged, mirroring AOTAutograd's tangent-strides behavior (pinned by
test_flex_attn_noncontiguous_tangents). Contiguity is queried with
false_if_dde=True so unbacked symbolic shapes never raise a
data-dependent guard error during tracing; when a grad's contiguity is
undecidable it is coerced anyway, which Tensor.contiguous handles
safely by copying. Because AOTAutograd traces this same glue, the
cat-inside-compiled-region case is fixed as well. The guarantee is now
documented on register_autograd.

Alternatives considered: coercing to suggest_memory_format of the grad
targets the wrong layout and breaks the non-contiguous-tangent contract
above; restriding to the output's exact strides via empty_strided +
copy_ is unsafe under transforms and subclasses; treating this as user
error was rejected since gradcheck passes and users cannot control the
strides the engine produces.

Test Plan:

New tests in test/test_custom_ops.py cover the cat regression
(parametrized over custom_op and triton_op), channels-last outputs with
row-major and zero-stride expanded grads, tensorlist outputs, None
grads with set_materialize_grads(False), and non-standard-layout
passthrough. The coercion tests fail without the fix.

```
python test/test_custom_ops.py -k register_autograd  # Ran 26 tests, OK
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_custom_ops.py -k register_autograd  # Ran 26 tests, OK (skipped=24)
python test/test_custom_ops.py  # 398 tests, only pre-existing environment failures
python -m pytest test/functorch/test_aotdispatch.py -k "tangent or contig" -q  # 41 passed, 4 skipped
python -m pytest test/functorch/test_aotdispatch.py -k "custom or library" -q  # 12 passed, 1 xfailed
python -m pytest test/inductor/test_compiled_autograd.py -k graph_break_custom_op -x -q  # 1 passed
```

Also verified the exact repro from the issue now matches the eager
reference with and without cat (CUDA, eager and compiled, including an
op with data-dependent output shapes under
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1), and lintrunner -a reports no
issues.

Authored with Claude Code.