### PR TITLE
[CI] Use clang21 image for debug-distributed build

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -181,7 +181,7 @@ jobs:
     with:
       runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
       build-environment: linux-jammy-py3.10-gcc11-debug
-      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang18
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang21
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
       test-matrix: |
         { include: [


### PR DESCRIPTION
periodic.yml still asked for pytorch-linux-jammy-py3.10-clang18, which #191108 retired on 2026-07-27. docker-builds.yml never builds that name, so the tag is absent from ECR, the pod hangs in ImagePullBackOff, and ARC surfaces it as the generic "pod failed to come online". 0 pass / 16 fail on main. clang21 is the 1:1 successor and still sets GCC_VERSION=11, so the gcc11 debug build is unchanged.

The 8 distributed shards have never executed on any branch, so this needs a ciflow/periodic run for real signal.

Authored with AI assistance.