### PR TITLE
Create lvalue and rvalue overloads for toOptional

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -1058,9 +1058,9 @@ struct TORCH_API IValue final {
   // ToOptional: convert a IValue to the Optional obj that accepts both T and
   // None
   template <typename T>
-  std::optional<T> toOptional();
+  std::optional<T> toOptional() &&;
   template <typename T>
-  std::optional<T> toOptional() const;
+  std::optional<T> toOptional() const&;
 
   /// @private [doxygen private]
   /// this is a shallow comparison of two IValues to test the object identity

--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -2420,15 +2420,15 @@ inline PyObject* IValue::toPyObject() const {
 }
 
 template <typename T>
-inline std::optional<T> IValue::toOptional() {
+inline std::optional<T> IValue::toOptional() && {
   if (this->isNone()) {
     return std::nullopt;
   }
-  return this->to<T>();
+  return std::move(*this).to<T>();
 }
 
 template <typename T>
-inline std::optional<T> IValue::toOptional() const {
+inline std::optional<T> IValue::toOptional() const& {
   if (this->isNone()) {
     return std::nullopt;
   }


### PR DESCRIPTION
I believe the original implementation was unintended. There are a number of other `toBlaBla` functions in this class which has the `&&` and `const&` overloads. The `const` and non-`const` overloads were redundant because they did exactly the same thing.