### PR TITLE
[pipelining] Annotate schedule actions with mark_kernels for CUDA graph traces

### DIFF
--- a/torch/distributed/pipelining/schedules.py
+++ b/torch/distributed/pipelining/schedules.py
@@ -17,6 +17,7 @@ from typing import Any, cast, Literal, NamedTuple, Protocol
 import torch
 import torch.distributed as dist
 from torch._dynamo import OptimizedModule
+from torch.cuda.graph_annotations import mark_kernels
 from torch.distributed.fsdp import FSDPModule, UnshardHandle
 from torch.nn.modules.loss import _Loss
 from torch.profiler import record_function
@@ -2875,7 +2876,14 @@ class _PipelineScheduleRuntime(PipelineScheduleMulti):
                 action,
             )
             try:
-                with record_function(_get_profiler_function_name(action)):
+                profiler_name = _get_profiler_function_name(action)
+                # backward=False: each backward action gets its own scope below, so
+                # letting a forward scope also claim its backward kernels would
+                # double-attribute them.
+                with (
+                    record_function(profiler_name),
+                    mark_kernels(profiler_name, backward=False),
+                ):
                     if action.computation_type in self._comp_type_to_function_map:
                         ctx = _PipelineContext(
                             self,


### PR DESCRIPTION
### Summary

`_PipelineScheduleRuntime`'s action loop already wraps each action in a
`record_function` labeled `PP:<action>`, which makes the schedule legible on the
CPU side of a profiler trace. Once the workload is captured into a CUDA graph
that labeling is lost: replayed kernels carry only a graph node id, so nothing
tells you which pipeline action a given kernel came from.

This opens a `mark_kernels` scope over the same region with the same label, so
captured nodes are tagged with the action name and a trace can be joined back to
the schedule offline. `mark_kernels` is a no-op outside an
`enable_annotations=True` capture, so the normal path is unaffected.

### Why `backward=False`

By default `mark_kernels` also hooks the autograd nodes created inside the scope
so their backward kernels inherit the annotation. That is right for a plain
forward region but wrong here: the schedule dispatches `BACKWARD` /
`FULL_BACKWARD` / `BACKWARD_WEIGHT` as actions through this same loop, so
backward work already gets its own scope. Leaving the default on would have a
forward action's scope claim the same autograd nodes that the later backward
action annotates, double-attributing them.

### Test plan

Verified the import resolves and that the scope is inert off the capture path:

```
python -c "
import inspect
from torch.distributed.pipelining.schedules import _PipelineScheduleRuntime
from torch.cuda.graph_annotations import mark_kernels
print('backward kwarg:', 'backward' in inspect.signature(mark_kernels).parameters)
with mark_kernels('PP:0F0', backward=False):
    pass
print('no-op outside capture: ok')
"
```

Lint:

```
python -m ruff check torch/distributed/pipelining/schedules.py
python -m ruff format torch/distributed/pipelining/schedules.py
```

### Not covered

The annotation path itself is not exercised here. Testing it needs a multi-rank
pipeline captured under `torch.cuda.graph(enable_annotations=True)` on CUDA >=
13.1 with `cuda-bindings` installed.

---

Prepared with AI assistance (Claude Code).
