### PR TITLE
Fix exponential_ underflowing to exactly 0 for float16

### DIFF
--- a/aten/src/ATen/native/cpu/DistributionTemplates.h
+++ b/aten/src/ATen/native/cpu/DistributionTemplates.h
@@ -8,6 +8,7 @@
 #include <ATen/core/DistributionsHelper.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cpu/Loops.h>
+#include <c10/util/safe_numerics.h>
 #include <mutex>
 
 #ifdef CPU_CAPABILITY_AVX2
@@ -338,7 +339,9 @@ void exponential_kernel(TensorIteratorBase& iter, double lambda, RNG generator) 
     std::lock_guard<std::mutex> lock(generator->mutex_);
     at::exponential_distribution<double> exponential(lambda);
     cpu_serial_kernel(iter, [&exponential, generator]() -> scalar_t {
-      return static_cast<scalar_t>(exponential(generator));
+      // multinomial divides by this sample, so a float16 underflow to 0 would
+      // turn into 0/0; exponential_(inf) still returns an exact 0.
+      return c10::cast_no_underflow<scalar_t>(exponential(generator));
     });
   });
 }

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -8,6 +8,7 @@
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/cuda/Loops.cuh>
 #include <c10/util/Half.h>
+#include <c10/util/safe_numerics.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/detail/OffsetCalculator.cuh>
@@ -565,7 +566,9 @@ void exponential_kernel(TensorIteratorBase& iter, double lambda_, RNG gen) {
     auto lambda = static_cast<accscalar_t>(lambda_);
     // define lambda for exponential transformation
     auto exponential_func = [lambda] __device__ (accscalar_t rand) {
-      return static_cast<scalar_t>(transformation::exponential<accscalar_t>(rand, lambda));
+      // The eps/2 floor inside the transformation is in accscalar_t; for half
+      // it still narrows to 0 once lambda >= 2. multinomial divides by this.
+      return c10::cast_no_underflow<scalar_t>(transformation::exponential<accscalar_t>(rand, lambda));
     };
     uniform_and_transform<scalar_t, accscalar_t>(iter, gen, exponential_func);
    });

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <type_traits>
 
 // GCC has __builtin_mul_overflow from before it supported __has_builtin
@@ -109,6 +110,28 @@ bool safe_multiplies_u64(It first, It last, uint64_t* out) {
 template <typename Container>
 bool safe_multiplies_u64(const Container& c, uint64_t* out) {
   return safe_multiplies_u64(c.begin(), c.end(), out);
+}
+
+// Floating point conversion that never underflows a nonzero value to zero.
+// A narrowing cast (double -> Half, say) rounds anything smaller than the
+// destination's smallest subnormal down to an exact 0, which is a silent
+// correctness bug for callers that go on to divide by the result. Return
+// denorm_min with the sign of the input instead. A value that is already
+// exactly zero stays zero, and NaN stays NaN.
+template <typename To, typename From>
+C10_HOST_DEVICE inline To cast_no_underflow(From value) {
+  static_assert(
+      std::numeric_limits<From>::is_specialized &&
+          !std::numeric_limits<From>::is_integer &&
+          std::numeric_limits<To>::is_specialized &&
+          !std::numeric_limits<To>::is_integer,
+      "cast_no_underflow requires floating point source and destination types");
+  const auto result = static_cast<To>(value);
+  if (result == static_cast<To>(0) && value != static_cast<From>(0)) {
+    constexpr auto smallest = std::numeric_limits<To>::denorm_min();
+    return value > static_cast<From>(0) ? smallest : -smallest;
+  }
+  return result;
 }
 
 } // namespace c10

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2267,15 +2267,24 @@ class TestTorchDeviceType(TestCase):
         with self.assertRaises(RuntimeError):
             torch.empty((1,), device=device, dtype=dtype).exponential_(-0.5)
 
-    @onlyCUDA
+    @parametrize("lam", (1, 1024))
     @dtypes(torch.half, torch.float)
-    def test_exponential_no_zero(self, device, dtype):
+    def test_exponential_no_zero(self, device, dtype, lam):
         # naively, 0 in exponential can be generated with probability 2^-24
         # so we need more samples to check if it's not generated
         # instead of doing one
-        # don't test CPU, that would be a long test
-        x = torch.empty(50000000, device=device, dtype=dtype).exponential_()
+        # lam=1024 puts ~3e-5 of the samples under half's 2^-25 rounding
+        # threshold, where the narrowing cast used to produce exact zeros
+        x = torch.empty(50000000, device=device, dtype=dtype).exponential_(lam)
         self.assertTrue(x.min() > 0)
+
+    @dtypes(torch.half)
+    def test_exponential_half_underflow(self, device, dtype):
+        # On CPU this seed draws a double of 4.5e-9 at index 5833, below
+        # half's rounding threshold of 2^-25, which used to become an exact 0
+        torch.manual_seed(20)
+        x = torch.empty(10000, device=device, dtype=dtype).exponential_()
+        self.assertGreater(x.min(), 0)
 
     def _generate_correlation_tensors(self, device, dtype):
         yield make_tensor((0, 0), dtype=dtype, device=device)
@@ -5326,6 +5335,16 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(samples_1, samples_2)
             self.assertEqual(samples_1.dim(), 2, msg="wrong number of dimensions")
             self.assertEqual(samples_1.size(1), n_sample, msg="wrong number of samples")
+
+    @dtypes(torch.half)
+    def test_multinomial_zero_prob_half(self, device, dtype):
+        # A half exponential sample that rounds to 0 turns p / q into 0 / 0,
+        # and the NaN wins argmax; on CPU seed 0 first hits this in row 136
+        p = torch.zeros(151936, device=device, dtype=dtype)
+        p[0] = 1
+        torch.manual_seed(0)
+        samples = torch.multinomial(p.expand(200, -1), 1)
+        self.assertEqual(samples, torch.zeros_like(samples))
 
     # FIXME: move to test distributions
     @slowTest


### PR DESCRIPTION
Fixes #192812

## Root cause

`exponential_` samples in a wider type and narrows with `static_cast<scalar_t>`. Anything below float16's smallest subnormal becomes an exact 0.

On CPU the kernel samples in double, so a sample under `2^-25` rounds to zero about 3 times per 1e8 draws at `lambda=1`. On CUDA the `eps/2` floor inside `transformation::exponential` is applied in `accscalar_t` (float), which bounds the sample at `2^-24/lambda`; that sits at or below half's round-to-even tie point once `lambda >= 2`, so it narrows to zero as well.

`multinomial` without replacement divides `p` by the sample (Gumbel trick), so a zero turns a zero-probability category into `0/0 = NaN`, and NaN wins `argmax`. Only float16 is affected; bfloat16 and float32 subnormals are far below anything either kernel emits.

## Fix

`c10::cast_no_underflow<To>(value)` narrows, and returns `denorm_min` with the input's sign when the cast would otherwise flush a nonzero value to zero. Both kernels use it in place of their `static_cast`.

It lives in `c10/util/safe_numerics.h` rather than `TypeCast.h` because the template itself needs only `<limits>` (the destination's `numeric_limits` is instantiated at the call site), so the header stays cheap enough to include from CUDA kernels.

The random stream is untouched and an exact 0 stays 0, so `exponential_(inf)` still returns 0 (asserted by `test_exponential`) and every other output value is bit-identical.

Flooring before the cast does not work, since `eps/2` of a double still rounds to float16 0. Sampling on CPU in float with the CUDA floor would change the random stream for fp16/bf16/fp32 and still emit zeros for `lambda >= 2`, so it would need this floor anyway.

## Verification

`test_exponential_no_zero` is now parametrized over lambda and also runs on CPU. At `lambda=1024` roughly 3e-5 of the samples fall under the rounding threshold, so 5e7 samples produce about 1500 zeros before the fix against 1 at `lambda=1`; that is what makes it a real regression detector on both backends. `test_exponential_half_underflow` pins a deterministic CPU case (seed 20, index 5833).

```
python test/test_torch.py -k exponential
python test/test_torch.py -k multinomial
python test/test_torch.py -k kstest
```

Zeros in 1e8 float16 CPU samples (seed 0, Apple M5):

| lambda | before | after |
|---|---|---|
| 1 | 3 | 0 |
| 2 | 3 | 0 |
| 8 | 24 | 0 |

Perf is within noise: float16 `exponential_` on 1e7 samples goes 80.4 ms to 81.3 ms (minimum over 15 interleaved runs of the two builds); float64 is unchanged, the compiler folds the check away there.

I have no GPU on hand, so the CUDA change is unverified outside CI.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01