### PR TITLE
Revert "Use C++20 <bit> instead of c10::llvm bit helpers in c10 (#187…

### DIFF
--- a/aten/src/ATen/LegacyBatchedFallback.cpp
+++ b/aten/src/ATen/LegacyBatchedFallback.cpp
@@ -4,8 +4,8 @@
 #include <ATen/LegacyVmapTransforms.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/llvmMathExtras.h>
 #include <c10/util/irange.h>
-#include <bit>
 
 namespace at {
 
@@ -139,7 +139,7 @@ static void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, t
     if (self_vmap_levels != (self_vmap_levels | other_vmap_levels)) {
       // Find one vmap level to complain about
       auto additional_bdims = (self_vmap_levels | other_vmap_levels) ^ self_vmap_levels;
-      [[maybe_unused]] auto offending_level = std::bit_width(additional_bdims.to_ulong()) - 1;
+      [[maybe_unused]] auto offending_level = llvm::findLastSet(additional_bdims.to_ulong());
       // The following prints out "vmap: aten::add_(tensor, ...) is not possible",
       // but it would be better to print out "tensor.add_(...) is not possible".
       // Afaict there's no official way to get the add_ and there is no way to

--- a/aten/src/ATen/core/dispatch/CppSignature.h
+++ b/aten/src/ATen/core/dispatch/CppSignature.h
@@ -4,7 +4,6 @@
 #include <c10/macros/Macros.h>
 #include <c10/util/Metaprogramming.h>
 #include <c10/util/Type.h>
-#include <cstring>
 #include <typeindex>
 
 namespace c10::impl {
@@ -48,7 +47,7 @@ class TORCH_API CppSignature final {
     // linking libraries of different compilers together, they might have
     // different ways to serialize a type name. That, together with a missing
     // RTLD_GLOBAL, would still fail this.
-    if (0 == std::strcmp(lhs.signature_.name(), rhs.signature_.name())) {
+    if (0 == strcmp(lhs.signature_.name(), rhs.signature_.name())) {
       return true;
     }
 

--- a/aten/src/ATen/functorch/BatchedFallback.cpp
+++ b/aten/src/ATen/functorch/BatchedFallback.cpp
@@ -13,10 +13,10 @@
 #include <ATen/MatrixRef.h>
 #include <ATen/core/dispatch/Dispatcher.h>
 #include <c10/util/accumulate.h>
+#include <c10/util/llvmMathExtras.h>
 #include <c10/util/irange.h>
 
 #include <atomic>
-#include <bit>
 
 namespace at::functorch {
 
@@ -145,7 +145,7 @@ static void batchedTensorInplaceForLoopFallback(const c10::OperatorHandle& op, t
     if (self_vmap_levels != (self_vmap_levels | other_vmap_levels)) {
       // Find one vmap level to complain about
       auto additional_bdims = (self_vmap_levels | other_vmap_levels) ^ self_vmap_levels;
-      [[maybe_unused]] auto offending_level = std::bit_width(additional_bdims.to_ulong()) - 1;
+      [[maybe_unused]] auto offending_level = llvm::findLastSet(additional_bdims.to_ulong());
       // The following prints out "vmap: aten::add_(tensor, ...) is not possible",
       // but it would be better to print out "tensor.add_(...) is not possible".
       // Afaict there's no official way to get the add_ and there is no way to

--- a/aten/src/ATen/native/cpu/utils.h
+++ b/aten/src/ATen/native/cpu/utils.h
@@ -3,7 +3,7 @@
 #include <ATen/Parallel.h>
 #include <ATen/core/TensorAccessor.h>
 #include <ATen/cpu/vec/vec.h>
-#include <bit>
+#include <c10/util/llvmMathExtras.h>
 
 #ifdef USE_FBGEMM
 C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wextra-semi")
@@ -138,8 +138,9 @@ T CeilLog2(const T& x) {
   if (x <= 2) {
     return 1;
   }
-  // bit_width(x - 1) is ceil(log2(x)) for x > 1
-  return static_cast<T>(std::bit_width(static_cast<uint64_t>(x) - 1));
+  // Last set bit is floor(log2(x)), floor + 1 is ceil
+  // except when x is an exact powers of 2, so subtract 1 first
+  return static_cast<T>(llvm::findLastSet(static_cast<uint64_t>(x) - 1)) + 1;
 }
 
 // matrix transpose:

--- a/aten/src/ATen/test/cuda_caching_host_allocator_test.cpp
+++ b/aten/src/ATen/test/cuda_caching_host_allocator_test.cpp
@@ -7,8 +7,6 @@
 #include <c10/core/ScalarType.h>
 #include <c10/cuda/CUDAStream.h>
 
-#include <bit>
-
 constexpr int64_t N = 100;
 
 // NOTE: please leave this as the first test to ensure that
@@ -19,7 +17,7 @@ TEST(CachingHostAllocatorTest, check_stats) {
   }
 
   // Clear the stats and ensure they are zero.
-  size_t round_size = std::bit_ceil(static_cast<size_t>(N));
+  size_t round_size = c10::llvm::PowerOf2Ceil(N);
   auto stats = at::getHostAllocator(at::kCUDA)->get_stats();
   ASSERT_EQ(stats.allocations.current, 0);
   ASSERT_EQ(stats.allocations.peak, 0);
@@ -56,7 +54,7 @@ TEST(CachingHostAllocatorTest, check_stats) {
   // Ensure we don't reuse the allocation, due to size mismatch.
   {
     int64_t new_size = N*2;
-    size_t new_round_size = std::bit_ceil(static_cast<size_t>(new_size));
+    size_t new_round_size = c10::llvm::PowerOf2Ceil(new_size);
     auto pinned_tensor = at::empty(
         {new_size}, at::TensorOptions().dtype(at::kByte).pinned_memory(true));
     auto stats = at::getHostAllocator(at::kCUDA)->get_stats();

--- a/c10/core/AllocatorConfig.cpp
+++ b/c10/core/AllocatorConfig.cpp
@@ -1,9 +1,7 @@
 #include <c10/core/AllocatorConfig.h>
 #include <c10/util/Exception.h>
 #include <c10/util/env.h>
-#include <algorithm>
 #include <array>
-#include <bit>
 #include <limits>
 
 namespace c10::CachingAllocator {
@@ -69,12 +67,14 @@ AcceleratorAllocatorConfig::AcceleratorAllocatorConfig() {
 }
 
 size_t AcceleratorAllocatorConfig::roundup_power2_divisions(size_t size) {
-  size_t log_size = std::bit_width(size) - 1;
+  size_t log_size = (63 - llvm::countLeadingZeros(size));
 
   // Our intervals start at 1MB and end at 64GB
-  constexpr size_t interval_start = std::bit_width(kRoundUpPowerOfTwoStart) - 1;
-  constexpr size_t interval_end = std::bit_width(kRoundUpPowerOfTwoEnd) - 1;
-  static_assert(
+  const size_t interval_start =
+      63 - llvm::countLeadingZeros(kRoundUpPowerOfTwoStart);
+  const size_t interval_end =
+      63 - llvm::countLeadingZeros(kRoundUpPowerOfTwoEnd);
+  TORCH_CHECK_VALUE(
       interval_end - interval_start == kRoundUpPowerOfTwoIntervals,
       "kRoundUpPowerOfTwoIntervals mismatch");
 
@@ -170,7 +170,7 @@ size_t AcceleratorAllocatorConfig::parseRoundUpPower2Divisions(
       tokenizer.checkToken(++i, ":");
       size_t value = tokenizer.toSizeT(++i);
       TORCH_CHECK_VALUE(
-          value == 0 || std::has_single_bit(value),
+          value == 0 || llvm::isPowerOf2_64(value),
           "For roundups, the divisions has to be power of 2 or 0 to disable roundup ");
 
       if (tokenizer[value_index] == ">") {
@@ -184,10 +184,10 @@ size_t AcceleratorAllocatorConfig::parseRoundUpPower2Divisions(
       } else {
         size_t boundary = tokenizer.toSizeT(value_index);
         TORCH_CHECK_VALUE(
-            std::has_single_bit(boundary),
+            llvm::isPowerOf2_64(boundary),
             "For roundups, the intervals have to be power of 2 ");
 
-        size_t index = std::bit_width(boundary) - 1;
+        size_t index = 63 - llvm::countLeadingZeros(boundary);
         index =
             std::clamp(index, size_t{0}, roundup_power2_divisions_.size() - 1);
 
@@ -214,7 +214,7 @@ size_t AcceleratorAllocatorConfig::parseRoundUpPower2Divisions(
   } else { // Keep this for backwards compatibility
     size_t value = tokenizer.toSizeT(i);
     TORCH_CHECK_VALUE(
-        std::has_single_bit(value),
+        llvm::isPowerOf2_64(value),
         "For roundups, the divisions has to be power of 2 ");
     std::fill(
         roundup_power2_divisions_.begin(),

--- a/c10/core/AllocatorConfig.h
+++ b/c10/core/AllocatorConfig.h
@@ -2,6 +2,7 @@
 
 #include <c10/core/DeviceType.h>
 #include <c10/util/Exception.h>
+#include <c10/util/llvmMathExtras.h>
 
 #include <atomic>
 #include <mutex>

--- a/c10/core/DispatchKeySet.cpp
+++ b/c10/core/DispatchKeySet.cpp
@@ -1,7 +1,5 @@
 #include <c10/core/DispatchKeySet.h>
 #include <c10/util/irange.h>
-#include <c10/util/llvmMathExtras.h>
-#include <limits>
 
 namespace c10 {
 

--- a/c10/core/DispatchKeySet.h
+++ b/c10/core/DispatchKeySet.h
@@ -5,8 +5,8 @@
 #include <c10/util/Exception.h>
 #include <c10/util/Metaprogramming.h>
 #include <c10/util/TypeList.h>
+#include <c10/util/llvmMathExtras.h>
 #include <array>
-#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -441,7 +441,7 @@ class DispatchKeySet final {
   // - the highest "functionality" bit in the keyset.
   // - the highest "backend" bit in the keyset.
   [[nodiscard]] uint8_t indexOfHighestBit() const {
-    return static_cast<uint8_t>(std::bit_width(repr_));
+    return 64 - llvm::countLeadingZeros(repr_);
   }
 
 #if defined(C10_MOBILE_TRIM_DISPATCH_KEYS)

--- a/c10/cuda/CUDAAllocatorConfig.cpp
+++ b/c10/cuda/CUDAAllocatorConfig.cpp
@@ -9,8 +9,6 @@
 #include <c10/cuda/driver_api.h>
 #endif
 
-#include <bit>
-
 namespace c10::cuda::CUDACachingAllocator {
 
 bool CUDAAllocatorConfig::expandable_segments() {
@@ -182,7 +180,7 @@ size_t CUDAAllocatorConfig::parsePinnedNumRegisterThreads(
   tokenizer.checkToken(++i, ":");
   size_t val2 = tokenizer.toSizeT(++i);
   TORCH_CHECK_VALUE(
-      std::has_single_bit(val2),
+      llvm::isPowerOf2_64(val2),
       "Number of register threads has to be power of 2, got ",
       val2);
   auto maxThreads = CUDAAllocatorConfig::pinned_max_register_threads();

--- a/c10/util/safe_numerics.h
+++ b/c10/util/safe_numerics.h
@@ -8,8 +8,8 @@
 // GCC has __builtin_mul_overflow from before it supported __has_builtin
 #ifdef _MSC_VER
 #define C10_HAS_BUILTIN_OVERFLOW() (0)
+#include <c10/util/llvmMathExtras.h>
 #include <intrin.h>
-#include <bit>
 #else
 #define C10_HAS_BUILTIN_OVERFLOW() (1)
 #endif
@@ -68,7 +68,9 @@ C10_ALWAYS_INLINE bool mul_overflows(T a, T b, T* out) {
     // This test isn't exact, but avoids doing integer division
     *out = a * b;
     constexpr int bits = sizeof(T) * 8;
-    return (std::countl_zero(a) + std::countl_zero(b)) < bits;
+    return (
+        (c10::llvm::countLeadingZeros(a) + c10::llvm::countLeadingZeros(b)) <
+        bits);
   }
 #endif
 }
@@ -96,7 +98,7 @@ bool safe_multiplies_u64(It first, It last, uint64_t* out) {
     prod *= x;
     // log2(0) isn't valid, so need to track it specially
     is_zero |= (x == 0);
-    prod_log2 += std::bit_width(x - 1);
+    prod_log2 += c10::llvm::Log2_64_Ceil(x);
   }
   *out = prod;
   // This test isn't exact, but avoids doing integer division

--- a/c10/util/sparse_bitset.h
+++ b/c10/util/sparse_bitset.h
@@ -13,8 +13,8 @@
 
 #pragma once
 #include <c10/macros/Macros.h>
+#include <c10/util/llvmMathExtras.h>
 #include <array>
-#include <bit>
 #include <cassert>
 #include <climits>
 #include <iterator>
@@ -112,7 +112,7 @@ struct SparseBitVectorElement {
   size_type count() const {
     unsigned NumBits = 0;
     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
-      NumBits += std::popcount(Bits[i]);
+      NumBits += llvm::countPopulation(Bits[i]);
     return NumBits;
   }
 
@@ -120,7 +120,7 @@ struct SparseBitVectorElement {
   int find_first() const {
     for (unsigned i = 0; i < BITWORDS_PER_ELEMENT; ++i)
       if (Bits[i] != 0)
-        return i * BITWORD_SIZE + std::countr_zero(Bits[i]);
+        return i * BITWORD_SIZE + llvm::countTrailingZeros(Bits[i]);
     throw std::runtime_error("Illegal empty element");
   }
 
@@ -129,7 +129,8 @@ struct SparseBitVectorElement {
     for (unsigned I = 0; I < BITWORDS_PER_ELEMENT; ++I) {
       unsigned Idx = BITWORDS_PER_ELEMENT - I - 1;
       if (Bits[Idx] != 0)
-        return Idx * BITWORD_SIZE + std::bit_width(Bits[Idx]);
+        return Idx * BITWORD_SIZE + BITWORD_SIZE -
+            llvm::countLeadingZeros(Bits[Idx]);
     }
     throw std::runtime_error("Illegal empty element");
   }
@@ -150,12 +151,12 @@ struct SparseBitVectorElement {
     Copy &= ~0UL << BitPos;
 
     if (Copy != 0)
-      return WordPos * BITWORD_SIZE + std::countr_zero(Copy);
+      return WordPos * BITWORD_SIZE + llvm::countTrailingZeros(Copy);
 
     // Check subsequent words.
     for (unsigned i = WordPos + 1; i < BITWORDS_PER_ELEMENT; ++i)
       if (Bits[i] != 0)
-        return i * BITWORD_SIZE + std::countr_zero(Bits[i]);
+        return i * BITWORD_SIZE + llvm::countTrailingZeros(Bits[i]);
     return -1;
   }
 


### PR DESCRIPTION
…002)"

This reverts commit 144ddcdbb75247abac3c9fb01776dd4df1828267 manually since the PR has been reopened and updated prior to merge, to keep the internal sync consistent. Afterwards, we can remerge. with the forward fixes

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01