### PR TITLE
[dynamo] Decode minifier subprocess output leniently in isolate_fails

### DIFF
--- a/torch/_dynamo/repro/after_aot.py
+++ b/torch/_dynamo/repro/after_aot.py
@@ -1014,12 +1014,20 @@ def isolate_fails(
 
         stdout.seek(0)
         stderr.seek(0)
+        # The subprocess is a crashing repro; its stdout/stderr can contain
+        # non-UTF-8 bytes (e.g. a ROCm/HIP runtime abort). Decode leniently so
+        # the minifier still reports output and writes repro.py instead of dying
+        # with UnicodeDecodeError.
         print(
-            textwrap.indent(stdout.read().decode("utf-8"), prefix=">>  "),
+            textwrap.indent(
+                stdout.read().decode("utf-8", errors="replace"), prefix=">>  "
+            ),
             file=sys.stdout,
         )
         print(
-            textwrap.indent(stderr.read().decode("utf-8"), prefix=">>  "),
+            textwrap.indent(
+                stderr.read().decode("utf-8", errors="replace"), prefix=">>  "
+            ),
             file=sys.stderr,
         )
         # print(f"Isolated test failed - {file_name}")


### PR DESCRIPTION
## Problem

`MinifierIsolateTests.test_after_aot_gpu_runtime_error` is flaky on ROCm (#168624). #190696 fixed one half of it — the decode of subprocess output in the minifier **test harness** (`torch/_dynamo/test_minifier_common.py`) — but the **production** minifier still decodes strictly.

In `torch/_dynamo/repro/after_aot.py`, `isolate_fails()` runs the crashing repro as a subprocess and prints its captured stdout/stderr with a strict `decode("utf-8")`. On ROCm the GPU-runtime-error repro aborts in the HIP runtime and emits non-UTF-8 bytes, so `isolate_fails()` itself raises `UnicodeDecodeError` before `repro.py` is written. The test then fails with `FileNotFoundError: .../minifier/repro.py` (the observed trunk failure on `linux-jammy-rocm-py3.10-mi350`).

## Changes

- `torch/_dynamo/repro/after_aot.py`: decode the repro subprocess's stdout/stderr with `errors="replace"` in `isolate_fails()`, matching the lenient decode `#190696` introduced in the test harness (`_decode_subprocess_output`). The minifier now reports the (possibly non-UTF-8) output and still writes `repro.py`.

## Validation

- Existing coverage: `test/dynamo/test_minifier.py::...::test_decode_subprocess_output_handles_non_utf8_bytes` (added in #190696) exercises the lenient decode helper; this PR aligns the production path with it.
- ROCm signal: confirming `MinifierIsolateTests.test_after_aot_gpu_runtime_error` passes on `linux-jammy-rocm-py3.10-mi350` via `ciflow/trunk` on this PR.

Fixes #168624.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98