### PR TITLE
[MPS] Fix bool atomic_add on misaligned storage offsets

### DIFF
--- a/c10/metal/atomic.h
+++ b/c10/metal/atomic.h
@@ -212,22 +212,7 @@ struct AtomicType<bool> {
     if (!value) {
       return;
     }
-    auto ptr = data + (offset >> 2);
-    auto old =
-        ::metal::atomic_load_explicit(ptr, ::metal::memory_order_relaxed);
-    union {
-      uint i;
-      bool t[4];
-    } val;
-    do {
-      val.i = old;
-      val.t[offset & 3] = true;
-    } while (!::metal::atomic_compare_exchange_weak_explicit(
-        ptr,
-        &old,
-        val.i,
-        ::metal::memory_order_relaxed,
-        ::metal::memory_order_relaxed));
+    atomic_add_helper<bool>(data, offset, value);
   }
   // Generic packed-CAS supports any bool op (AND for prod/amin, OR for amax).
   static inline void atomic_binary_op(

--- a/c10/metal/atomic.h
+++ b/c10/metal/atomic.h
@@ -200,11 +200,12 @@ struct AtomicType<bfloat> {
   }
 };
 
-// Metal supports atomic_store_explicit for bools, but
-// sizeof(::metal::atomic_bool) is 4 Therefore it could not be used to
-// atomically modify unaligned memory, so fall back to compare and exchange
-// trick As accumulation over booleans are just or operation, do nothing if
-// value is false
+static inline bool true_op(bool, bool) {
+  return true;
+}
+
+// Accumulating booleans is an OR: skip false, otherwise OR in true via the
+// shared packed-CAS helper, which handles the sub-32-bit alignment fixup.
 template <>
 struct AtomicType<bool> {
   using type = ::metal::atomic<uint>;
@@ -212,7 +213,7 @@ struct AtomicType<bool> {
     if (!value) {
       return;
     }
-    atomic_add_helper<bool>(data, offset, value);
+    atomic_binary_op_helper<bool>(data, offset, true, true_op);
   }
   // Generic packed-CAS supports any bool op (AND for prod/amin, OR for amax).
   static inline void atomic_binary_op(

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -15304,6 +15304,30 @@ class TestAdvancedIndexing(TestCaseMPS):
         finally:
             torch.use_deterministic_algorithms(False)
 
+    @parametrize("op", ["scatter_add_", "index_add_", "index_put_"])
+    @parametrize("dtype", [torch.bool, torch.uint8])
+    @parametrize("offset", [0, 1, 2, 3])
+    def test_accumulate_misaligned_storage_offset(self, op, dtype, offset, device="mps"):
+        # 1-byte dtypes accumulate through a 4-byte atomic<uint> compare-exchange and
+        # the buffer is bound at storage_offset() * element_size(), so a view whose
+        # storage offset is not a multiple of 4 needs the kernel to realign the base
+        # pointer. A miss lands in front of the view, hence comparing the whole base
+        # tensor rather than just the view.
+        idx = torch.tensor([1, 3, 3, 6])
+        src = torch.ones(idx.numel(), dtype=dtype)
+
+        def run(dev):
+            base = torch.zeros(8 + offset, dtype=dtype, device=dev)
+            view = base.narrow(0, offset, 8)
+            index, values = idx.to(dev), src.to(dev)
+            if op == "index_put_":
+                view.index_put_((index,), values, accumulate=True)
+            else:
+                getattr(view, op)(0, index, values)
+            return base
+
+        self.assertEqual(run(device).cpu(), run("cpu"))
+
     def test_multiple_byte_mask(self, device="mps"):
         v = torch.randn(5, 7, 3, device=device)
         # note: these broadcast together and are transposed to the first dim


### PR DESCRIPTION
Fixes #195074

`scatter_add_`, `index_add_` and `index_put_(accumulate=True)` write to the wrong elements when the destination is a `torch.bool` view whose buffer is bound at a byte offset that is not a multiple of 4. The write lands at the start of the enclosing 4-byte word instead of at the view, so it corrupts memory in front of the view and leaves the intended elements false, with no error and no warning.

Indices set by `buf[off:].scatter_add_(0, tensor([0, 2]), ones(2, dtype=bool))` on a 16-element bool tensor. `index_add_` and `index_put_` behave identically.

| storage_offset | CPU | MPS before | MPS after |
| --- | --- | --- | --- |
| 0 | 0, 2 | 0, 2 | 0, 2 |
| 1 | 1, 3 | 0, 2 | 1, 3 |
| 2 | 2, 4 | 0, 2 | 2, 4 |
| 3 | 3, 5 | 0, 2 | 3, 5 |

## Root cause

A tensor buffer is bound at `storage_offset() * element_size()` bytes and `element_size()` is 1 for bool, so a bool view whose storage offset is not a multiple of 4 hands the kernel a `metal::atomic<uint>` base that is not 4-byte aligned. `AtomicType<bool>::atomic_add` then computes `data + (offset >> 2)` against that base and lands on the wrong word.

c97fd51e6ef (#176009) added this same realignment to `atomic_add_helper` and `atomic_binary_op_helper` for the other sub-32-bit dtypes. `AtomicType<bool>::atomic_add` keeps its own copy of the compare-exchange loop and was missed. `AtomicType<bool>::atomic_binary_op` right below it already delegates to the fixed helper, and `uint8` is correct for the same reason.

## Fix

Delete the hand-rolled loop and delegate to `atomic_add_helper<bool>`, which already does the realignment, the packed-word selection and the compare-exchange. After the early return `value` is always `true`, so the helper's `+=` stores the same `1` the old `= true` did.

## Test

`TestAdvancedIndexing.test_accumulate_misaligned_storage_offset` runs the three ops over `torch.bool` and `torch.uint8` at all four storage-offset residues and compares the whole base tensor against CPU, so a write landing outside the view is caught. It goes in `test_mps.py` rather than next to the #176009 test in `test_indexing.py` because `scatter_add_` has no `Bool` in its CUDA dispatch (`ScatterGatherKernel.cu`, `AT_DISPATCH_ALL_TYPES_AND2(Half, BFloat16)`), so a device-generic version would need a CUDA skip.

```
python test/test_mps.py -v -k test_accumulate_misaligned_storage_offset
```

Fails 9 of 24 subtests without the fix (`bool` at offsets 1, 2 and 3 for each of the three ops), all 24 pass with it. No regressions in `test_mps.py TestAdvancedIndexing` (89 pass), `test_indexing.py -k MPS` (146 pass, 13 skipped), or `test_mps.py` filtered on `scatter` / `index_add` / `index_put` (159 / 22 / 43 pass).
