### PR TITLE
Fix minor typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Note on OpenMP: The desired OpenMP implementation is Intel OpenMP (iomp). In ord
 In this mode PyTorch computations will leverage your GPU via CUDA for faster number crunching
 
 [NVTX](https://docs.nvidia.com/gameworks/content/gameworkslibrary/nvtx/nvidia_tools_extension_library_nvtx.htm) is needed to build PyTorch with CUDA.
-NVTX is a part of CUDA distributive, where it is called "Nsight Compute". To install it onto an already installed CUDA run CUDA installation once again and check the corresponding checkbox.
+NVTX is a part of CUDA the distribution, where it is called "Nsight Compute". To install it onto an already installed CUDA run CUDA installation once again and check the corresponding checkbox.
 Make sure that CUDA with Nsight Compute is installed after Visual Studio.
 
 Currently, VS 2017 / 2019, and Ninja are supported as the generator of CMake. If `ninja.exe` is detected in `PATH`, then Ninja will be used as the default generator, otherwise, it will use VS 2017 / 2019.
@@ -416,7 +416,7 @@ docker run --gpus all --rm -ti --ipc=host pytorch/pytorch:latest
 ```
 
 Please note that PyTorch uses shared memory to share data between processes, so if torch multiprocessing is used (e.g.
-for multithreaded data loaders) the default shared memory segment size that container runs with is not enough, and you
+for multithreaded data loaders) the default shared memory segment size that the container runs with is not enough, and you
 should increase shared memory size either with `--ipc=host` or `--shm-size` command line options to `nvidia-docker run`.
 
 #### Building the image yourself


### PR DESCRIPTION

## Summary
- Fix a word-choice typo: "distributive" → "distribution" in the CUDA/NVTX section.
- Fix the missing-article grammar issue in the Docker section.

## Details

### 1. `distributive` → `distribution`
In the **CUDA based build** section:

```diff
- NVTX is a part of CUDA distributive, where it is called "Nsight Compute".
+ NVTX is a part of the CUDA distribution, where it is called "Nsight Compute".
```

### 2. Missing article: "that container" → "that the container"
In the **Docker Image → Using pre-built images** section:

```diff
- the default shared memory segment size that container runs with is not enough
+ the default shared memory segment size that the container runs with is not enough
```

## Test plan
Docs-only change, no build/test impact.