### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_net_min_base.py

### DIFF
--- a/test/fx/test_net_min_base.py
+++ b/test/fx/test_net_min_base.py
@@ -9,10 +9,12 @@ from torch.fx.passes.net_min_base import (
     FxNetMinimizerResultMismatchError,
 )
 from torch.fx.passes.tools_common import Names
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class TestNetMinBaseBlock(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         # Setup test fixtures for each test method


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestNetMinBaseBlock
and import HardwareClassification from common_utils, enabling per-hardware-backend
test selection via --hw-classification.

## Changes
test/fx/test_net_min_base.py: import HardwareClassification; add
hw_classification (GENERIC on TestNetMinBaseBlock).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering.
The FX net minimizer tests (test_no_discrepancy, test_all_nodes_discrepancy,
test_first_node_discrepancy, test_last_node_discrepancy, test_middle_node_discrepancy,
test_contiguous_partial_discrepancy_end, test_continugous_partial_discrepancy_beginning)
exercise _MinimizerBase block-traversal provenance logic using mocked compare
functions with no device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_net_min_base.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.