### PR TITLE
Run on a populated constant buffer after swapping

### DIFF
--- a/test/cpp/aoti_inference/test.cpp
+++ b/test/cpp/aoti_inference/test.cpp
@@ -1423,6 +1423,10 @@ void test_aoti_record_function(const std::string& device) {
   EXPECT_TRUE(sawScope("AOTIModelContainerRunner::run"));
   EXPECT_TRUE(sawScope("AOTIModelContainerRunner::swap_constant_buffer"));
 
+  // Swap back: the buffer above was never populated and fails for reasons
+  // unrelated to callbacks.
+  runner->swap_constant_buffer();
+
   // Callbacks are torn down again, so later tests are unaffected.
   const size_t recorded = recordedScopeNames().size();
   runner->run(input_tensors);


### PR DESCRIPTION
test_aoti_record_function swaps the constant buffer then runs once more, but swap_constant_buffer never carries fold_state to the new buffer, which was never initialized - so the run throws "Unknown constant state: NONE" before the callback check happens. Swap back first so the run uses an initialized buffer.