### PR TITLE
[AOTInductor] Unmap mmap-backed constants on model destruction

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1242,6 +1242,71 @@ class AOTInductorTestsTemplate:
         with config.patch({"aot_inductor.force_mmap_weights": True}):
             self.check_model(Model(), example_inputs)
 
+    @unittest.skipUnless(
+        sys.platform == "linux" and os.path.exists("/proc/self/maps"),
+        "requires /proc/self/maps",
+    )
+    def test_mmaped_weights_unmapped_on_model_delete(self):
+        if self.device != "cpu":
+            raise unittest.SkipTest("CPU coverage is sufficient")
+
+        import gc
+
+        class Model(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.randn(16, 16))
+
+            def forward(self, x):
+                return x @ self.weight
+
+        example_inputs = (torch.randn(4, 16, device=self.device),)
+        ep = torch.export.export(Model().to(self.device), example_inputs)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            package_path = os.path.join(tmp_dir, "model.pt2")
+            torch._inductor.aoti_compile_and_package(
+                ep,
+                package_path=package_path,
+                inductor_configs={"aot_inductor.force_mmap_weights": True},
+            )
+
+            with zipfile.ZipFile(package_path) as package:
+                wrapper_files = [
+                    info
+                    for info in package.infolist()
+                    if info.filename.endswith(".wrapper.so")
+                ]
+            self.assertEqual(len(wrapper_files), 1)
+            wrapper_name = pathlib.PurePosixPath(wrapper_files[0].filename).name
+            wrapper_size = wrapper_files[0].file_size
+
+            def count_weight_mappings() -> int:
+                count = 0
+                with open("/proc/self/maps") as maps:
+                    for line in maps:
+                        if f"/{wrapper_name}" not in line:
+                            continue
+                        address_range, permissions, offset, *_ = line.split()
+                        start, end = (
+                            int(value, 16) for value in address_range.split("-")
+                        )
+                        if (
+                            permissions == "rw-p"
+                            and int(offset, 16) + end - start >= wrapper_size
+                        ):
+                            count += 1
+                return count
+
+            gc.collect()
+            baseline_mappings = count_weight_mappings()
+            for _ in range(2):
+                runner = torch._inductor.aoti_load_package(package_path)
+                self.assertGreater(count_weight_mappings(), baseline_mappings)
+
+                del runner
+                gc.collect()
+                self.assertEqual(count_weight_mappings(), baseline_mappings)
+
     def test_large_mmaped_weights_on_disk(self):
         class Model(torch.nn.Module):
             def __init__(self) -> None:

--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: inductor"]
 import contextlib
 import functools
+import gc
 import itertools
 import logging
 import os
@@ -1250,8 +1251,6 @@ class AOTInductorTestsTemplate:
         if self.device != "cpu":
             raise unittest.SkipTest("CPU coverage is sufficient")
 
-        import gc
-
         class Model(torch.nn.Module):
             def __init__(self) -> None:
                 super().__init__()
@@ -1280,6 +1279,10 @@ class AOTInductorTestsTemplate:
             wrapper_name = pathlib.PurePosixPath(wrapper_files[0].filename).name
             wrapper_size = wrapper_files[0].file_size
 
+            # Only the constants mapping reaches the tail of the wrapper file;
+            # the loader's own writable segment stops well before it. Counting
+            # by exact numbers rather than by delta keeps a mistargeted
+            # predicate from making this test pass without observing anything.
             def count_weight_mappings() -> int:
                 count = 0
                 with open("/proc/self/maps") as maps:
@@ -1298,14 +1301,14 @@ class AOTInductorTestsTemplate:
                 return count
 
             gc.collect()
-            baseline_mappings = count_weight_mappings()
+            self.assertEqual(count_weight_mappings(), 0)
             for _ in range(2):
                 runner = torch._inductor.aoti_load_package(package_path)
-                self.assertGreater(count_weight_mappings(), baseline_mappings)
+                self.assertEqual(count_weight_mappings(), 1)
 
                 del runner
                 gc.collect()
-                self.assertEqual(count_weight_mappings(), baseline_mappings)
+                self.assertEqual(count_weight_mappings(), 0)
 
     def test_large_mmaped_weights_on_disk(self):
         class Model(torch.nn.Module):

--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -257,12 +257,16 @@ void* mmap(
   return pData;
 }
 
+// length is ignored: this shim only supports unmapping a whole view.
 int munmap(void* addr, size_t length) {
-  // mmap may return an offset into the view, but UnmapViewOfFile needs its
-  // base.
+  // mmap rounds the file offset down to dwAllocationGranularity and returns
+  // lpMapAddress + iViewDelta, so addr can point into the middle of the view
+  // while UnmapViewOfFile requires the allocation base. VirtualQuery also
+  // succeeds for freed and heap addresses, so check that this really is a
+  // mapped view before unmapping it.
   MEMORY_BASIC_INFORMATION mbi{};
-  if (VirtualQuery(addr, &mbi, sizeof(mbi)) == 0 ||
-      !UnmapViewOfFile(mbi.AllocationBase)) {
+  if (VirtualQuery(addr, &mbi, sizeof(mbi)) == 0 || mbi.State == MEM_FREE ||
+      mbi.Type != MEM_MAPPED || !UnmapViewOfFile(mbi.AllocationBase)) {
     errno = EINVAL;
     return -1;
   }
@@ -280,8 +284,10 @@ int munmap(void* addr, size_t length) {
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <cerrno>
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <mutex>
 #include <optional>
@@ -892,10 +898,12 @@ class AOTInductorModelBase {
   ~AOTInductorModelBase() {
 #ifdef USE_MMAP_SELF
     if (self_mmap) {
-      if (munmap(self_mmap, constant_blob_size()) != 0) {
-        std::cerr << "Failed to unmap AOTInductor model constants\n";
+      if (munmap(self_mmap, self_mmap_size) != 0) {
+        std::cerr << "Failed to unmap AOTInductor model constants: "
+                  << std::strerror(errno) << '\n';
       }
       self_mmap = nullptr;
+      self_mmap_size = 0;
     }
 #endif // USE_MMAP_SELF
 #ifdef USE_CUDA
@@ -1570,6 +1578,7 @@ class AOTInductorModelBase {
     close(fd);
     AOTI_RUNTIME_CHECK(ptr != MAP_FAILED, "mmap() failed");
     self_mmap = static_cast<uint8_t*>(ptr);
+    self_mmap_size = static_cast<size_t>(weights_size);
     AOTI_RUNTIME_CHECK(
         reinterpret_cast<uint64_t*>(
             self_mmap + weights_size - sizeof(uint64_t))[0] == magic_number,
@@ -1615,6 +1624,8 @@ class AOTInductorModelBase {
 #if defined(USE_MMAP_SELF)
   // Mapped memory for weights
   uint8_t* self_mmap = NULL;
+  // Length passed to mmap, so the destructor unmaps exactly what was mapped.
+  size_t self_mmap_size = 0;
 #endif
 
 #if defined(USE_MMAP_EXTERNAL)

--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -258,7 +258,11 @@ void* mmap(
 }
 
 int munmap(void* addr, size_t length) {
-  if (!UnmapViewOfFile(addr)) {
+  // mmap may return an offset into the view, but UnmapViewOfFile needs its
+  // base.
+  MEMORY_BASIC_INFORMATION mbi{};
+  if (VirtualQuery(addr, &mbi, sizeof(mbi)) == 0 ||
+      !UnmapViewOfFile(mbi.AllocationBase)) {
     errno = EINVAL;
     return -1;
   }
@@ -886,6 +890,14 @@ class AOTInductorModelBase {
 
   // NOLINTNEXTLINE(modernize-use-equals-default)
   ~AOTInductorModelBase() {
+#ifdef USE_MMAP_SELF
+    if (self_mmap) {
+      if (munmap(self_mmap, constant_blob_size()) != 0) {
+        std::cerr << "Failed to unmap AOTInductor model constants\n";
+      }
+      self_mmap = nullptr;
+    }
+#endif // USE_MMAP_SELF
 #ifdef USE_CUDA
     if (run_finished_) {
       auto code = cudaEventDestroy(*run_finished_);

--- a/torch/csrc/inductor/aoti_runtime/model_base.h
+++ b/torch/csrc/inductor/aoti_runtime/model_base.h
@@ -263,10 +263,16 @@ int munmap(void* addr, size_t length) {
   // lpMapAddress + iViewDelta, so addr can point into the middle of the view
   // while UnmapViewOfFile requires the allocation base. VirtualQuery also
   // succeeds for freed and heap addresses, so check that this really is a
-  // mapped view before unmapping it.
+  // mapped view before unmapping it. Validation failures report EFAULT and an
+  // unmap failure reports EINVAL, so that the caller's strerror() output
+  // distinguishes a bad pointer from a genuine unmap error.
   MEMORY_BASIC_INFORMATION mbi{};
   if (VirtualQuery(addr, &mbi, sizeof(mbi)) == 0 || mbi.State == MEM_FREE ||
-      mbi.Type != MEM_MAPPED || !UnmapViewOfFile(mbi.AllocationBase)) {
+      mbi.Type != MEM_MAPPED) {
+    errno = EFAULT;
+    return -1;
+  }
+  if (!UnmapViewOfFile(mbi.AllocationBase)) {
     errno = EINVAL;
     return -1;
   }
@@ -902,8 +908,6 @@ class AOTInductorModelBase {
         std::cerr << "Failed to unmap AOTInductor model constants: "
                   << std::strerror(errno) << '\n';
       }
-      self_mmap = nullptr;
-      self_mmap_size = 0;
     }
 #endif // USE_MMAP_SELF
 #ifdef USE_CUDA


### PR DESCRIPTION
I reviewed the implementation, the regression test—including its negative-control failure—and the documented Windows coverage limitation. I agree that the quoted description accurately reflects the change, the supporting evidence, and the remaining risk.

> In the model destructor, when `USE_MMAP_SELF` is enabled, the code checks `self_mmap` and calls `munmap` to release the mapping. This prevents mmap regions from accumulating when `aoti_load_package` is called repeatedly and the resulting runners are destroyed.

> ## Issue
>
> Fixes #193915
>
> ## Summary
>
> AOTInductor models using self-mapped weights retained the file-backed constant mapping after runner destruction because the raw `self_mmap` pointer was never unmapped. This change releases the model-owned mapping in the model destructor, updates the Windows mmap shim to pass the allocation base to `UnmapViewOfFile`, and adds a Linux regression test covering repeated load and destruction. Following review, the destructor unmaps the length recorded at the `mmap` call site instead of re-deriving it, reports `strerror(errno)` on failure, the Windows shim rejects freed and non-view regions before unmapping, and the test asserts exact mapping counts.
>
> ## Testing
>
> ```bash
> pip install -e . -v --no-build-isolation
> ```
>
> Build succeeded.
>
> ```bash
> python -m pytest test/inductor/test_aot_inductor.py \
>   -k test_mmaped_weights_unmapped_on_model_delete -q
> ```
>
> Result: `1 passed, 3 skipped, 1516 deselected`.
>
> With the `model_base.h` changes reverted and only the test applied, the same command fails at the assertion following `del runner` with `Expected 0 but got 1`, confirming the test isolates the fix. The wrapper library is not unloaded on `del runner` — it contains `STB_GNU_UNIQUE` symbols, so all six of its ELF segments survive either way.
>
> ## Windows coverage
>
> The Windows `munmap` shim change is untested. This PR is its first caller, and CI cannot cover it: `test/inductor/test_aot_inductor.py` raises `SkipTest` at import under `IS_WINDOWS and IS_CI`; the `aoti_cross_compile_for_windows` job runs on a Linux runner and `determine_aoti_mmap_flags` raises for `cross_target_platform == "windows"` with `force_mmap_weights`; and the shim sits inside `#ifdef USE_MMAP_SELF`, which nothing in CI defines for Windows, so it is not even compiled. Splitting the hunk out is not an option: without it the new destructor `munmap` would reach the old shim with a pointer offset into the view and fail on every teardown, since `_get_constants_start()` only asserts 16K alignment while `dwAllocationGranularity` is 64K.
>
> ## Checklist
>
> - [x] Added/updated tests
> - [x] Relevant lint passes
> - [x] Documentation is not applicable
> - [x] Benchmark results are not applicable
>
> `spin lint -- --skip CLANGTIDY` passes. Whole-header `CLANGTIDY` reports pre-existing diagnostics in `model_base.h`; none point to the changed destructor or Windows unmap implementation.
>
> ## BC-breaking?
>
> No.
>
> AI assistance: Codex assisted with the original implementation; Claude Code assisted with the follow-up hardening and verification. Both drafted this quoted section.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
