### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_opaque_infrastructure.py

### DIFF
--- a/test/fx/test_opaque_infrastructure.py
+++ b/test/fx/test_opaque_infrastructure.py
@@ -3,7 +3,11 @@
 import torch
 from torch._library.opaque_object import register_custom_class
 from torch.fx.experimental.proxy_tensor import make_fx
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 # Define a simple opaque type for testing
@@ -38,6 +42,8 @@ class TestOpaqueInfrastructure(TestCase):
     This test validates infrastructure for tracking and passing opaque objects
     (like ProcessGroups) through AOTAutograd compilation without unwrapping/wrapping them.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_opaque_object_in_traced_graph(self):
         """Test that opaque objects can be traced into FX graphs."""


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestOpaqueInfrastructure
and import HardwareClassification from common_utils, enabling per-hardware-backend
test selection via --hw-classification.

## Changes
test/fx/test_opaque_infrastructure.py: import HardwareClassification; add
hw_classification (GENERIC on TestOpaqueInfrastructure).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering.
The opaque object infrastructure tests (test_opaque_object_in_traced_graph)
exercise opaque object descriptor / tracking and tracing through make_fx with
no device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_opaque_infrastructure.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.