### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_partitioner_order.py

### DIFF
--- a/test/fx/test_partitioner_order.py
+++ b/test/fx/test_partitioner_order.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 import torch
 from torch.fx.passes.infra.partitioner import CapabilityBasedPartitioner
 from torch.fx.passes.operator_support import OperatorSupport
-from torch.testing._internal.common_utils import TestCase
+from torch.testing._internal.common_utils import HardwareClassification, TestCase
 
 
 class DummyDevOperatorSupport(OperatorSupport):
@@ -33,6 +33,8 @@ class AddModule(torch.nn.Module):
 
 
 class TestPartitionerOrder(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # partitioner test to check graph node order remains the same with the original graph after partitioning
     def test_partitioner_graph_node_order(self):
         m = AddModule()


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestPartitionerOrder
and import HardwareClassification from common_utils, enabling per-hardware-backend
test selection via --hw-classification.

## Changes
test/fx/test_partitioner_order.py: import HardwareClassification; add
hw_classification (GENERIC on TestPartitionerOrder).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering.
The partitioner order tests (test_partitioner_graph_node_order,
test_partitioner_multiple_runs_order) exercise CapabilityBasedPartitioner node
ordering logic with no device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_partitioner_order.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.