### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_pass_infra.py

### DIFF
--- a/test/fx/test_pass_infra.py
+++ b/test/fx/test_pass_infra.py
@@ -9,7 +9,11 @@ from torch.fx.passes.infra.pass_manager import (
     PassManager,
     this_before_that_pass_constraint,
 )
-from torch.testing._internal.common_utils import raise_on_run_directly, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    raise_on_run_directly,
+    TestCase,
+)
 
 
 # Pass that uses PassBase and returns a PassResult (best scenario)
@@ -58,6 +62,8 @@ class AddModule(torch.nn.Module):
 
 
 class TestPassManager(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_pass_manager(self):
         """
         Tests that the pass manager runs the passes correctly.


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestPassManager
and import HardwareClassification from common_utils, enabling per-hardware-backend
test selection via --hw-classification.

## Changes
test/fx/test_pass_infra.py: import HardwareClassification; add
hw_classification (GENERIC on TestPassManager).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering.
The FX pass infrastructure tests (test_pass_manager, test_this_before_that_pass_constraint,
test_pass_manager_checks, test_pass_manager_bad_checks, test_topological_sort,
test_pass_manager_error) exercise PassManager / PassBase / pass constraint logic
with no device dependency, so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_pass_infra.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.