### PR TITLE
[Testcase Refactoring] Add hw_classification in test/fx/test_matcher_utils.py

### DIFF
--- a/test/fx/test_matcher_utils.py
+++ b/test/fx/test_matcher_utils.py
@@ -19,7 +19,7 @@ from torch.fx.passes.utils.matcher_utils import SubgraphMatcher
 from torch.fx.passes.utils.matcher_with_name_node_map_utils import (
     SubgraphMatcherWithNameNodeMap,
 )
-from torch.testing._internal.common_utils import IS_WINDOWS
+from torch.testing._internal.common_utils import HardwareClassification, IS_WINDOWS
 from torch.testing._internal.jit_utils import JitTestCase
 
 
@@ -33,6 +33,8 @@ class WrapperModule(torch.nn.Module):
 
 
 class TestMatcher(JitTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_subgraph_matcher_with_attributes(self):
         class LargeModel(torch.nn.Module):
             def __init__(self) -> None:


### PR DESCRIPTION
## Summary
Add hw_classification = HardwareClassification.GENERIC to TestMatcher
and import HardwareClassification from common_utils, enabling per-hardware-backend
test selection via --hw-classification.

## Changes
test/fx/test_matcher_utils.py: import HardwareClassification; add
hw_classification (GENERIC on TestMatcher).

## Motivation
hw_classification enables per-hardware-backend test selection and filtering.
The FX matcher tests (test_subgraph_matcher_with_attributes, test_subgraph_matcher_with_list,
test_subgraph_matcher_with_list_bad, test_subgraph_matcher_ignore_literals,
test_variatic_arg_matching, test_split_to_graph_and_name_node_map,
test_matcher_with_name_node_map_function, test_matcher_with_name_node_map_module) exercise
SubgraphMatcher / SubgraphMatcherWithNameNodeMap graph-matching logic with no device dependency,
so they are hardware-agnostic (GENERIC).

## Test Plan
CI: python -m pytest -q test/fx/test_matcher_utils.py

## Notes
This is part of the test case refactoring initiative tracked in #185590.