### PR TITLE
[export] Fix torch.export.load() failing when called from multiple threads

### DIFF
--- a/test/export/test_serialize.py
+++ b/test/export/test_serialize.py
@@ -12,6 +12,7 @@ import unittest
 import zipfile
 from collections import namedtuple
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import NamedTuple
 
@@ -64,6 +65,7 @@ from torch.testing._internal.common_utils import (
     IS_MACOS,
     IS_WINDOWS,
     parametrize,
+    run_concurrently,
     run_tests,
     TemporaryFileName,
     TestCase,
@@ -2559,6 +2561,36 @@ class TestSaveLoad(TestCase):
                         self.assertEqual(
                             node_source_orig.to_dict(), node_source_loaded.to_dict()
                         )
+
+    def test_concurrent_load(self) -> None:
+        # Deserialization state is passed to the pickle __reduce__ path out of
+        # band, so it must not be shared between concurrently loading threads.
+        class M(torch.nn.Module):
+            def __init__(self, dim, act):
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+                self.act = act
+
+            def forward(self, x):
+                return self.act(self.linear(x))
+
+        def pack(mod, inp):
+            buffer = io.BytesIO()
+            save(torch.export.export(mod, (inp,)), buffer)
+            return buffer.getvalue(), inp, mod(inp)
+
+        # Distinct shapes so a deserializer leaking across threads is detected.
+        cases = [
+            pack(M(8, torch.relu), torch.randn(4, 8)),
+            pack(M(16, torch.tanh), torch.randn(4, 16)),
+        ]
+
+        def worker(case):
+            data, inp, expected = case
+            loaded = load(io.BytesIO(data))
+            self.assertEqual(loaded.module()(inp), expected)
+
+        run_concurrently([partial(worker, cases[i % len(cases)]) for i in range(8)])
 
 
 @unittest.skipIf(not torchdynamo.is_dynamo_supported(), "dynamo doesn't support")

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -1,5 +1,6 @@
 # mypy: allow-untyped-defs
 import base64
+import contextvars
 import copy
 import copyreg
 import dataclasses
@@ -373,7 +374,12 @@ def serialize_tensor_meta(t: torch.Tensor) -> TensorMeta:
     )
 
 
-_CURRENT_DESERIALIZER: Optional["GraphModuleDeserializer"] = None
+# Context-local so concurrent torch.export.load() calls each see their own
+# deserializer. It is passed out of band because the pickle __reduce__ path
+# (_reconstruct_fake_tensor) cannot take it as an argument.
+_CURRENT_DESERIALIZER: contextvars.ContextVar[Optional["GraphModuleDeserializer"]] = (
+    contextvars.ContextVar("_CURRENT_DESERIALIZER", default=None)
+)
 
 
 def _reduce_fake_tensor(fake_tensor: FakeTensor):
@@ -392,9 +398,10 @@ def _reconstruct_fake_tensor(
     json_tensor_meta = json.loads(serialized_tensor_meta.decode("utf-8"))
     tensor_meta = _dict_to_dataclass(TensorMeta, json_tensor_meta)
     # Find the current fake mode
-    if _CURRENT_DESERIALIZER is None:
+    current_deserializer = _CURRENT_DESERIALIZER.get()
+    if current_deserializer is None:
         raise AssertionError("Need access to current deserializer state")
-    fake_tensor = _CURRENT_DESERIALIZER.deserialize_tensor_meta(tensor_meta)
+    fake_tensor = current_deserializer.deserialize_tensor_meta(tensor_meta)
     if is_parameter:
         fake_tensor = torch.nn.Parameter(fake_tensor)  # type: ignore[assignment]
     # pyrefly: ignore [bad-return]
@@ -2921,10 +2928,9 @@ class GraphModuleDeserializer(metaclass=Final):
         | None = None,
         symbol_name_to_range: dict[str, symbolic_shapes.ValueRanges] | None = None,
     ) -> Result:
-        global _CURRENT_DESERIALIZER
-        if _CURRENT_DESERIALIZER is not None:
+        if _CURRENT_DESERIALIZER.get() is not None:
             raise AssertionError("_CURRENT_DESERIALIZER is already set")
-        _CURRENT_DESERIALIZER = self
+        deserializer_token = _CURRENT_DESERIALIZER.set(self)
         try:
             log.debug("\n[deserialize]")
             self.shape_env = symbolic_shapes.ShapeEnv(assume_static_by_default=True)
@@ -3032,7 +3038,7 @@ class GraphModuleDeserializer(metaclass=Final):
                 example_inputs=self.example_inputs,
             )
         finally:
-            _CURRENT_DESERIALIZER = None
+            _CURRENT_DESERIALIZER.reset(deserializer_token)
 
     def sync_fx_node(self, name: str, fx_node: torch.fx.Node):
         if name in self.serialized_name_to_node:


### PR DESCRIPTION
Fixes #195099

### Problem

`torch.export.load()` fails when two threads load at the same time:

```
AssertionError: _CURRENT_DESERIALIZER is already set
```

### Root cause

`GraphModuleDeserializer.deserialize()` publishes the active deserializer in the module-level global `_CURRENT_DESERIALIZER`, guarded by an assertion that the global is unset and cleared in a `finally`. It is passed this way because `_reconstruct_fake_tensor` is reached through the `FakeTensor` `__reduce__` callback during unpickling and so cannot take it as an argument.

A module global is shared by every thread, so two concurrent loads collide on it and the second one trips the assertion. Subgraphs reuse the enclosing deserializer via `self.deserialize_graph()` rather than re-entering `deserialize()`, so the assertion never fires on legitimate nesting; concurrency is the only way to reach it.

This is the next contention point after #175983, which released the GIL during tensor deserialization and thereby made genuinely parallel loads possible.

### Fix

Make the state a `contextvars.ContextVar` so each thread gets its own binding, and keep the assertion as a per-thread re-entrancy check.

Dropping the assertion instead was considered and rejected: without isolation a second thread would overwrite the first thread's deserializer, and fake tensors would then be reconstructed against the wrong `FakeTensorMode`, turning a loud failure into silent cross-thread corruption. `threading.local()` would also isolate threads but does not carry across async tasks, so the more general primitive is used.

A `ContextVar` is only visible on the thread that set it, unlike the previous global, so this relies on the unpickling running on the calling thread. It does: no part of the load path dispatches to a thread pool, and `deserialize_torch_artifact()` calls `torch.load()` synchronously.

One narrower shared-global race remains on this path: `deserialize()` registers `nn.Module` input types in the process-global pytree registry via `_enable_graph_inputs_of_type_nn_module`, so concurrent loads of programs whose example inputs contain `nn.Module` leaves can still collide. That registry is a separate mechanism and is left for follow-up; plain tensor inputs, as in the reported case, never touch it.

Note that #123789 hit this same assertion from the opposite direction (ExecuTorch wanting recursive deserialization of delegated modules) and proposed making the global a stack; it went stale without review. A stack alone would permit recursion but would still race across threads, so the two concerns are independent. This PR addresses only the threading half; the assertion still rejects same-thread recursion, and a `ContextVar` holding a stack would cover both if recursion is still wanted.

### Test plan

New test, which fails before this change with the reported `AssertionError` and passes after it:

```
python test/export/test_serialize.py TestSaveLoad.test_concurrent_load
```

It loads two differently shaped models across 8 barrier-synchronized threads (via `run_concurrently` from `common_utils`) and checks numerics, so a deserializer leaking between threads is caught rather than just the assertion.

Surrounding suites:

```
python test/export/test_serialize.py     # 131 passed
python test/export/test_serdes.py        # 978 run, 12 pre-existing errors
python test/export/test_cpp_serdes.py    # 479 run, 6 pre-existing errors
python test/export/test_schema.py        # 5 passed
python test/export/test_package.py       # 7 passed
python test/export/test_torchbind.py     # 86 passed
```

The 18 errors in `test_serdes.py` and `test_cpp_serdes.py` are all `test_distributed_*` and `test_export_then_compile_tensor_ctor*`. They reproduce identically with this change reverted and come from a `USE_DISTRIBUTED=0` build and an unrelated inductor codegen failure.

