### PR TITLE
Use empty() rather than size() > 0 in the generated backward()

### DIFF
--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -438,7 +438,7 @@ class TORCH_API Tensor: public TensorBase {
     // currently does not support optional of TensorList our approach is to replace
     // backward in native_functions.yaml with _backward and call it here instead.
     if (inputs.has_value()) {
-      TORCH_CHECK(inputs.value().size() > 0, "'inputs' argument to backward cannot be empty")
+      TORCH_CHECK(!inputs.value().empty(), "'inputs' argument to backward cannot be empty")
       this->_backward(inputs.value(), gradient, retain_graph, create_graph);
     } else {
       this->_backward({}, gradient, retain_graph, create_graph);


### PR DESCRIPTION
readability-container-size-empty fires on the generated TensorBody.h, which is not a file anyone can edit; the check has to be answered in the template it comes from. inputs is a TensorList, so ArrayRef::empty() says the same thing and is what the check asks for. This is the only site of its kind left in the C++ templates.