### PR TITLE
[c10d] Set local rank in backend test workers

### DIFF
--- a/test/distributed/c10d_backend_common.py
+++ b/test/distributed/c10d_backend_common.py
@@ -148,6 +148,7 @@ class C10dBackendTest:
             pass
 
     def _init_pg(self):
+        os.environ["LOCAL_RANK"] = str(self.rank)
         if self.device_type == "cuda":
             torch.cuda.set_device(self.rank)
         store = dist.FileStore(self.file_name, self.world_size)

--- a/test/distributed/test_c10d_fr_hook.py
+++ b/test/distributed/test_c10d_fr_hook.py
@@ -78,6 +78,7 @@ class AbstractFlightRecorderHookTest:
         return os.environ["TORCH_FR_DUMP_TEMP_FILE"] + str(self.rank)
 
     def _init_pg(self):
+        os.environ["LOCAL_RANK"] = str(self.rank)
         if self.device_type == "cuda":
             torch.cuda.set_device(self.rank)
         if self._communicates:

--- a/test/distributed/test_c10d_suspend_resume.py
+++ b/test/distributed/test_c10d_suspend_resume.py
@@ -73,6 +73,7 @@ class AbstractSuspendResumeTest:
         self.assertEqual(recv_tensor, torch.full_like(recv_tensor, float(peer)))
 
     def _init_pg(self):
+        os.environ["LOCAL_RANK"] = str(self.rank)
         if self.device_type == "cuda":
             torch.cuda.set_device(self.rank)
         store = dist.FileStore(self.file_name, self.world_size)

--- a/test/distributed/test_c10d_window.py
+++ b/test/distributed/test_c10d_window.py
@@ -54,6 +54,7 @@ class AbstractWindowTest:
             pass
 
     def _init_pg(self):
+        os.environ["LOCAL_RANK"] = str(self.rank)
         if self.device_type == "cuda":
             torch.cuda.set_device(self.rank)
         store = dist.FileStore(self.file_name, self.world_size)


### PR DESCRIPTION
This change was prepared with AI assistance and reviewed by a human.

`MultiProcessTestCase` workers inherit `LOCAL_RANK` from their parent process. A stale value can cause eager NCCL2 initialization to bind every worker to the same GPU despite `_init_pg()` selecting a device by rank.

Set `LOCAL_RANK` from `self.rank` before process-group initialization so the environment and explicit device selection agree.

Context: [analysis of the behavior change in #193237](https://github.com/pytorch/pytorch/pull/193237#issuecomment-5448863211). The linked analysis was produced by Claude and should be independently reviewed.

## Test Plan

```text
python test/distributed/test_c10d_collectives.py  
python test/distributed/test_c10d_window.py
python test/distributed/test_c10d_fr_hook.py
python test/distributed/test_c10d_suspend_resume.py

```

cc @fbxai @ptrblck @eqy @tinglvv @syed-ahmed @atalman @malfet @ngimel @kwen2501 @xiaofanl-nvidia