### PR TITLE
Remove the last mixed_mm leftovers from the autoheuristic fuzzer and docs

### DIFF
--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -393,7 +393,7 @@ force_fuse_int_mm_with_mul = False
 # (may improve perf at the cost of accuracy for some models).
 keep_addmm_fused_for_half_dtypes = True
 
-use_mixed_mm = Config(
+use_mixed_mm: bool = Config(
     default=True, deprecated=True, deprecation_message="does not do anything"
 )
 

--- a/torch/_inductor/fuzzer.py
+++ b/torch/_inductor/fuzzer.py
@@ -179,14 +179,6 @@ TYPE_OVERRIDES: dict[str, list[Any]] = {
             "group_linear": {"require_fbgemm": True},
         },
     ],
-    "autoheuristic_collect": [
-        {"pad_mm": True},
-        {"pad_mm": False},
-    ],
-    "autoheuristic_use": [
-        {"pad_mm": True},
-        {"pad_mm": False},
-    ],
     "traceable_tensor_subclasses": [OrderedSet()],
     "nontraceable_tensor_subclasses": [OrderedSet()],
 }

--- a/torchgen/_autoheuristic/README.md
+++ b/torchgen/_autoheuristic/README.md
@@ -114,11 +114,6 @@ Note that you also have to specify these operations when you want to learn a heu
 Take a look at the following PRs in which AutoHeuristic has enabled for various optimizations.
 Looking at these examples may be helpful if you want to use AutoHeuristic yourself.
 - pad_mm: https://github.com/pytorch/pytorch/pull/128643
-- mixed_mm:
-    - Enabling of AutoHeuristic: https://github.com/pytorch/pytorch/pull/131610
-    - Script to collect data: https://github.com/pytorch/pytorch/pull/131611
-    - A100 heuristic: https://github.com/pytorch/pytorch/pull/131613
-    - H100 heuristic: https://github.com/pytorch/pytorch/pull/132685
 - flex_attention: https://github.com/pytorch/pytorch/pull/130398
 - mm (heuristic for ranking choices):
     - https://github.com/pytorch/pytorch/pull/131615


### PR DESCRIPTION
Follow-up to #193721, which removed the mixed_mm AutoHeuristic support. Three loose ends it
left behind, all in files that PR already touched.

**`torch/_inductor/fuzzer.py`** — the `autoheuristic_collect` and `autoheuristic_use` entries
in `TYPE_OVERRIDES` are unreachable. `TYPE_OVERRIDES` is read once, at `fuzzer.py:217`, as an
exact key lookup on a field name taken from `config_module._config`, and `install_config_module`
registers a subconfig class under a dotted prefix (`_config_module.py:238` recurses with
`f"{name}."`). Both names are classes in `torch/_inductor/config.py`, so `_config` holds
`autoheuristic_collect.pad_mm`, never the bare name:

```
>>> import torch._inductor.config as c; k = set(c._config)
>>> 'autoheuristic_collect' in k, 'autoheuristic_collect.pad_mm' in k
(False, True)
```

The other `TYPE_OVERRIDES` keys are untouched — `post_grad_fusion_options` and `cuda_backend`
are top-level configs and do resolve. `pad_mm` is a plain bool, already handled by the
`type_hint is bool` branch just below the lookup, so it needs no override.

**`torch/_inductor/config.py`** — `use_mixed_mm` was the only unannotated `Config()` in the
file; its sibling `mixed_mm_choice` and ~20 others all carry explicit types.

**`torchgen/_autoheuristic/README.md`** — the "Where has AutoHeuristic already been used?"
section still pointed at the four mixed_mm PRs as an example to follow, but #193721 deleted
every file those PRs added. The `pad_mm`, `flex_attention` and `mm` entries beside it are still
live and are left alone.

No behaviour change. `test/inductor/test_fuzzer.py` covers the fuzzer in CI.

Developed with AI assistance (Claude); I reviewed the change and the reasoning above.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @jansel
