### PR TITLE
Collapse ivalue::from's tag dispatch into one function

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -2479,29 +2479,17 @@ inline bool IValue::isSameIdentity(const IValue& rhs) const {
 }
 
 namespace ivalue {
-namespace detail {
-
-template <typename T>
-IValue from_(T&& x, std::true_type /*unused*/) {
-  return IValue(std::forward<T>(x));
-}
-template <typename T>
-IValue from_(c10::intrusive_ptr<T> x, std::false_type /*unused*/) {
-  return IValue(std::move(x));
-}
-template <typename T>
-IValue from_(T&& /*x*/, std::false_type /*unused*/) {
-  static_assert(
-      guts::false_t<T>::value,
-      "You are calling from with a type that it doesn't support, and isn't a potential custom class (ie: is an intrusive_ptr)");
-  return IValue();
-}
-} // namespace detail
 
 template <typename T>
 IValue from(T&& x) {
-  return detail::from_(
-      std::forward<T>(x), typename std::is_constructible<IValue, T>::type{});
+  if constexpr (std::is_constructible_v<IValue, T>) {
+    return IValue(std::forward<T>(x));
+  } else {
+    static_assert(
+        guts::false_t<T>::value,
+        "You are calling from with a type that it doesn't support, and isn't a potential custom class (ie: is an intrusive_ptr)");
+    return IValue();
+  }
 }
 
 } // namespace ivalue


### PR DESCRIPTION
detail::from_ had three overloads selected by an is_constructible tag. The unreachable one (intrusive_ptr<T> + false_type) is more specialized than the catch-all, so it shadows the diagnostic the catch-all exists to produce: calling from with an intrusive_ptr to a non-custom class reports an ambiguous-constructor error instead of the intended static_assert message.

Folding the three into one if constexpr in from() drops the tag and the detail namespace, and lets the static_assert fire where it was meant to.