### PR TITLE
Preserve submodule names in torch::nn::Sequential::clone()

### DIFF
--- a/test/cpp/api/sequential.cpp
+++ b/test/cpp/api/sequential.cpp
@@ -368,6 +368,47 @@ TEST_F(SequentialTest, IsCloneable) {
   }
 }
 
+TEST_F(SequentialTest, ClonePreservesSubmoduleNames) {
+  // clone() used to push the cloned submodules back unnamed, which renumbers
+  // them 0..N-1 and silently rewrites the state_dict keys. See gh-71069.
+  Sequential sequential(
+      {{"encoder", Linear(4, 3)}, {"act", Functional(torch::relu)}});
+  Sequential clone =
+      std::dynamic_pointer_cast<SequentialImpl>(sequential->clone());
+
+  ASSERT_EQ(
+      sequential->named_children().keys(), clone->named_children().keys());
+  ASSERT_EQ(clone->named_children()[0].key(), "encoder");
+  ASSERT_EQ(clone->named_children()[1].key(), "act");
+
+  // The keys users actually save and load.
+  ASSERT_EQ(
+      clone->named_parameters().keys(), sequential->named_parameters().keys());
+
+  // A submodule pushed without a name keeps the positional name it was given,
+  // rather than being renumbered around the named ones.
+  Sequential mixed({{"first", Linear(4, 3)}});
+  mixed->push_back(Functional(torch::relu));
+  mixed->push_back("last", Linear(3, 2));
+  Sequential mixed_clone =
+      std::dynamic_pointer_cast<SequentialImpl>(mixed->clone());
+  ASSERT_EQ(
+      mixed_clone->named_children().keys(), mixed->named_children().keys());
+  ASSERT_EQ(mixed_clone->named_children()[1].key(), "1");
+
+  // Entirely unnamed containers are unaffected: the auto-assigned names round
+  // trip, including when two submodules share a type.
+  Sequential unnamed(
+      Linear(4, 3),
+      Functional(torch::relu),
+      Linear(3, 2),
+      Functional(torch::relu));
+  Sequential unnamed_clone =
+      std::dynamic_pointer_cast<SequentialImpl>(unnamed->clone());
+  ASSERT_EQ(
+      unnamed_clone->named_children().keys(), unnamed->named_children().keys());
+}
+
 TEST_F(SequentialTest, RegistersElementsAsSubmodules) {
   Sequential sequential(Linear(10, 3), Conv2d(1, 2, 3), Dropout2d(0.5));
 

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -130,9 +130,9 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
     // Submodule names live in the registered children, not in `modules_`.
     // Pushing the clones back unnamed would renumber them 0..N-1 and silently
     // rewrite the state_dict keys of any `Sequential` built with names.
-    const std::vector<std::string> names = named_children().keys();
+    std::vector<std::string> names = named_children().keys();
     for (const auto i : c10::irange(modules_.size())) {
-      clone->push_back(names[i], modules_[i].clone(device));
+      clone->push_back(std::move(names[i]), modules_[i].clone(device));
     }
     return clone;
   }

--- a/torch/csrc/api/include/torch/nn/modules/container/sequential.h
+++ b/torch/csrc/api/include/torch/nn/modules/container/sequential.h
@@ -9,6 +9,7 @@
 #include <torch/types.h>
 
 #include <c10/util/Exception.h>
+#include <c10/util/irange.h>
 
 #include <cstdint>
 #include <memory>
@@ -126,8 +127,12 @@ class SequentialImpl : public Cloneable<SequentialImpl> {
   std::shared_ptr<Module> clone(
       const std::optional<Device>& device = std::nullopt) const override {
     auto clone = std::make_shared<SequentialImpl>();
-    for (const auto& module : modules_) {
-      clone->push_back(module.clone(device));
+    // Submodule names live in the registered children, not in `modules_`.
+    // Pushing the clones back unnamed would renumber them 0..N-1 and silently
+    // rewrite the state_dict keys of any `Sequential` built with names.
+    const std::vector<std::string> names = named_children().keys();
+    for (const auto i : c10::irange(modules_.size())) {
+      clone->push_back(names[i], modules_[i].clone(device));
     }
     return clone;
   }


### PR DESCRIPTION
Fixes #71069.

`SequentialImpl::clone()` rebuilt the container with the *unnamed* `push_back` overload, which
assigns each submodule the positional name `std::to_string(modules_.size())`. Every registered
name was replaced by its index, so cloning a named `Sequential` silently rewrote its
`state_dict` keys — `encoder.weight` became `0.weight` — breaking a save/load round trip
against the original module with no error.

`ModuleDictImpl::clone()` is unaffected because its `modules_` is an `OrderedDict` and it
clones through `insert(key, value)`. `Sequential`'s `modules_` is a plain `std::vector<AnyModule>`
and carries no names, so they have to come from the registered children. `clone()` now reads
them from the public `named_children()` and uses the named `push_back`.

This deliberately does not use `modules_[i].ptr()->name()`: that returns the demangled RTTI
type name, so a container holding two modules of the same type would produce duplicate keys.

### Test

`SequentialTest.ClonePreservesSubmoduleNames`, next to the existing `IsCloneable`. It asserts on
`named_children().keys()` and `named_parameters().keys()` rather than on `Module::name()` — the
latter is the *type* name and compares equal whether or not the bug is present, which is what
made the test in the earlier abandoned attempt (#90112) vacuous.

I cannot launch gtest binaries on my machine (Device Guard blocks unsigned executables), so the
same scenarios were run through a Python extension module against the real container. Before:

```
named   clone    : 0, 1
params  clone    : 0.weight, 0.bias
mixed   clone    : 0, 1, 2
unnamed clone    : 0, 1, 2, 3
```

After:

```
named   clone    : encoder, act
params  clone    : encoder.weight, encoder.bias
mixed   clone    : first, 1, last
unnamed clone    : 0, 1, 2, 3
```

An unnamed submodule keeps the positional name it was originally given rather than being
renumbered around the named ones, and a container with no names at all is unchanged.

### On numeric submodule names

@malfet asked this on the earlier attempt (#90112) and it was never answered, so:

```
numeric original : 2, 0, 1
numeric clone    : 2, 0, 1
numeric clone^2  : 2, 0, 1
collision build  : THREW on the original -> Submodule '1' already defined
```

Names round trip verbatim, so numeric names that do not match their position are preserved
rather than renumbered, and cloning is idempotent. A container whose auto-name would collide
with an explicit numeric one cannot be built at all: `register_module` inserts into an
`OrderedDict`, which throws on a duplicate key, so `Sequential({{"1", A}})` followed by an
unnamed `push_back` throws on the *original* long before `clone()` is reached. The proposed
behaviour is strictly closer to the original than today's renumbering.

Developed with AI assistance (Claude); I reviewed the change and the reasoning above.

cc @jbschlosser @malfet
