### PR TITLE
Probe AVX2 directly instead of through the quantized engine list

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -179,7 +179,7 @@ _T = TypeVar("_T")
 _P = ParamSpec("_P")
 
 
-HAS_AVX2 = "fbgemm" in torch.backends.quantized.supported_engines
+HAS_AVX2 = torch.cpu._is_avx2_supported()
 
 _OPS_WITHOUT_GPU_LOWP: frozenset[str] = frozenset(
     {


### PR DESCRIPTION
HAS_AVX2 was `"fbgemm" in torch.backends.quantized.supported_engines`, used only to skip test_pixel_shuffle_channels_last when AVX2 is missing. That whole engine list sits inside `#ifdef USE_FBGEMM`, so a build without FBGEMM reports no supported engines at all and HAS_AVX2 is false even on an AVX2 machine, silently skipping a test that has nothing to do with FBGEMM.

`torch.cpu._is_avx2_supported()` asks cpuinfo directly and is what `cpu_vec_isa.py` already uses for the same question.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo