### PR TITLE
Make fill_defaults linear in the number of schema arguments

### DIFF
--- a/torch/_library/utils.py
+++ b/torch/_library/utils.py
@@ -203,10 +203,14 @@ def mutates_and_returns_first_arg(op: OpOverload):
 
 
 def fill_defaults(schema, args, kwargs):
+    # Reading schema.arguments converts the underlying std::vector into a new
+    # Python list, so hoist it out of the loop to keep this linear in the
+    # number of arguments.
+    arguments = schema.arguments
     new_args = []
     new_kwargs = {}
-    for i in range(len(schema.arguments)):
-        info = schema.arguments[i]
+    for i in range(len(arguments)):
+        info = arguments[i]
         if info.kwarg_only:
             if info.name in kwargs:
                 new_kwargs[info.name] = kwargs[info.name]


### PR DESCRIPTION
`schema.arguments` is a pybind property: every access converts the whole
`std::vector<c10::Argument>` into a fresh Python list. `fill_defaults` reads it
inside its loop -- once for `len()` plus once per index -- so a call on an
n-argument schema materializes `(n + 1) * n` `Argument` objects, making the
helper quadratic in the arity.

This PR hoists the access out of the loop. The semantics are unchanged, since
the property is a pure read that returns an equal list on every access, but the
cost drops from O(n^2) to O(n).

### Why it matters

`torch._library.autograd` calls `fill_defaults` in the forward of every custom
op registered with `setup_context`, so the cost is paid on every invocation of
such an op. Operators with many arguments whose device work is short can end up
bounded by this dispatch overhead rather than by the kernel.
`torch.distributed.tensor`'s `as_strided_handler` is the other caller.

### Measurements

Per-call time of `fill_defaults` itself, on generated custom-op schemas with all
arguments supplied positionally:

| schema arity | before | after |
| ---: | ---: | ---: |
| 5 | 8.30 us | 2.15 us |
| 10 | 28.67 us | 4.03 us |
| 20 | 108.94 us | 7.96 us |
| 23 | 147.41 us | 8.96 us |
| 40 | 433.37 us | 15.65 us |

End to end, for a custom op with 22 arguments registered with
`register_autograd` + `setup_context`, the host-side time of one call goes from
169.2 us to 40.1 us, and gradients are unchanged.

### Equivalence

The rewritten helper was compared against the current implementation over 190
`(args, kwargs)` combinations across 10 schemas: generated custom ops of arity 1
to 24 with and without keyword-only arguments, plus `aten.as_strided.default`,
`aten.sum.dim_IntList`, `aten.native_layer_norm.default` and
`aten.topk.default`. Each schema was exercised over every prefix of positional
arguments, from all-supplied down to none-supplied, with and without
keyword-only arguments passed explicitly. All 190 results are identical.
