### PR TITLE
[Testcase Refactoring][DTensor] Classify experimental tests by hardware

### DIFF
--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -18,8 +18,15 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor._utils import ExplicitRedistributionContext
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import local_map
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import (
+    deviceCountAtLeast,
+    instantiate_device_type_tests,
+)
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -73,21 +80,24 @@ def mul_forward(X, scalar):  # no device mesh needed since we don't do collectiv
 
 
 class TestLocalMap(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2
 
     # simple correctness check
     @with_comms
-    def test_local_map_correctness(self):
+    def test_local_map_correctness(self, device):
+        device_type = torch.device(device).type
         device_mesh = init_device_mesh(
-            device_type=self.device_type, mesh_shape=(self.world_size,)
+            device_type=device_type, mesh_shape=(self.world_size,)
         )
         comm_mode = CommDebugMode()
 
         # Y = X @ W
-        X = torch.randn(16, 8, device=self.device_type, requires_grad=False)
-        W = torch.randn(8, 12, device=self.device_type, requires_grad=False)
+        X = torch.randn(16, 8, device=device_type, requires_grad=False)
+        W = torch.randn(8, 12, device=device_type, requires_grad=False)
         Y = torch.mm(X, W)
 
         X_dt = distribute_tensor(
@@ -133,16 +143,17 @@ class TestLocalMap(DTensorTestBase):
 
     # check for `out_placements`
     @with_comms
-    def test_local_map_out_placements(self):
+    def test_local_map_out_placements(self, device):
+        device_type = torch.device(device).type
         # Test 1: wrap out into DTensor w/ `out_placements`
         device_mesh = init_device_mesh(
-            device_type=self.device_type, mesh_shape=(self.world_size,)
+            device_type=device_type, mesh_shape=(self.world_size,)
         )
         comm_mode = CommDebugMode()
 
         # X.equal(Y)
-        X = torch.randn(8, 8, device=self.device_type, requires_grad=False)
-        Y = torch.randn(8, 8, device=self.device_type, requires_grad=False)
+        X = torch.randn(8, 8, device=device_type, requires_grad=False)
+        Y = torch.randn(8, 8, device=device_type, requires_grad=False)
         X_dt = distribute_tensor(X, device_mesh, row_wise)
         Y_dt = distribute_tensor(Y, device_mesh, row_wise)
         local_equal_allgather_forward = local_map(
@@ -159,9 +170,9 @@ class TestLocalMap(DTensorTestBase):
         # Test 2: directly return out if no argument is DTensor
         # matmul in DDP
         X = torch.randn(
-            4 // self.world_size, 4, device=self.device_type, requires_grad=False
+            4 // self.world_size, 4, device=device_type, requires_grad=False
         )
-        W = torch.randn(4, 4, device=self.device_type, requires_grad=False)
+        W = torch.randn(4, 4, device=device_type, requires_grad=False)
         local_mm_all_gather_forward = local_map(
             mm_all_gather_forward,
             out_placements=row_wise,
@@ -180,15 +191,16 @@ class TestLocalMap(DTensorTestBase):
 
     # check for `in_placements` handling
     @with_comms
-    def test_local_map_in_placements(self):
+    def test_local_map_in_placements(self, device):
+        device_type = torch.device(device).type
         device_mesh = init_device_mesh(
-            device_type=self.device_type, mesh_shape=(self.world_size,)
+            device_type=device_type, mesh_shape=(self.world_size,)
         )
         comm_mode = CommDebugMode()
 
         # Y = X @ W
-        X = torch.randn(16, 8, device=self.device_type, requires_grad=False)
-        W = torch.randn(8, 12, device=self.device_type, requires_grad=False)
+        X = torch.randn(16, 8, device=device_type, requires_grad=False)
+        W = torch.randn(8, 12, device=device_type, requires_grad=False)
         Y = torch.mm(X, W)
 
         X_dt = distribute_tensor(
@@ -287,15 +299,16 @@ class TestLocalMap(DTensorTestBase):
 
     # check for `redistribute_inputs` handling
     @with_comms
-    def test_local_map_redistribute(self):
+    def test_local_map_redistribute(self, device):
+        device_type = torch.device(device).type
         device_mesh = init_device_mesh(
-            device_type=self.device_type, mesh_shape=(self.world_size,)
+            device_type=device_type, mesh_shape=(self.world_size,)
         )
         comm_mode = CommDebugMode()
 
         # Y = X @ W
-        X = torch.randn(16, 8, device=self.device_type, requires_grad=False)
-        W = torch.randn(8, 12, device=self.device_type, requires_grad=False)
+        X = torch.randn(16, 8, device=device_type, requires_grad=False)
+        W = torch.randn(8, 12, device=device_type, requires_grad=False)
         Y = torch.mm(X, W)
 
         X_dt = distribute_tensor(
@@ -335,22 +348,23 @@ class TestLocalMap(DTensorTestBase):
 
     # check for `in_grad_placements` handling
     @with_comms()
-    def test_local_map_with_grad_placement(self):
+    def test_local_map_with_grad_placement(self, device):
         """
         Test the gradient result is correct when we specify the right
         `in_grad_placements`.
         """
+        device_type = torch.device(device).type
         device_mesh = init_device_mesh(
-            device_type=self.device_type, mesh_shape=(self.world_size,)
+            device_type=device_type, mesh_shape=(self.world_size,)
         )
         torch.manual_seed(12)
 
         # ground truth output, consider X as a batch of 2 on dim 0.
-        X = torch.randn(4, 2, device=self.device_type, requires_grad=True)
+        X = torch.randn(4, 2, device=device_type, requires_grad=True)
         X1, X2 = torch.chunk(X, 2, dim=0)
         X1 = X1.detach().requires_grad_()
         X2 = X2.detach().requires_grad_()
-        W = torch.randn(2, 4, device=self.device_type, requires_grad=True)
+        W = torch.randn(2, 4, device=device_type, requires_grad=True)
         Y1 = torch.mm(X1, W)
         Y2 = torch.mm(X2, W)
         loss = Y1.sum() + Y2.sum()
@@ -394,24 +408,25 @@ class TestLocalMap(DTensorTestBase):
             )
             self.assertEqual(W_dt.grad.full_tensor(), W.grad)
 
-    @skip_if_lt_x_gpu(4)
+    @deviceCountAtLeast(4)
     @with_comms
-    def test_multi_mesh_inputs(self):
+    def test_multi_mesh_inputs(self, devices):
         """
         Test the function can be applied to accept DTensors that lives
         on different device meshes.
         """
+        device_type = torch.device(devices[0]).type
         mesh_full = init_device_mesh(
-            device_type=self.device_type, mesh_shape=(self.world_size,)
+            device_type=device_type, mesh_shape=(self.world_size,)
         )
         mesh_2d = init_device_mesh(
-            device_type=self.device_type, mesh_shape=(self.world_size // 2, 2)
+            device_type=device_type, mesh_shape=(self.world_size // 2, 2)
         )
         comm_mode = CommDebugMode()
 
-        X = torch.randn(8, 32, device=self.device_type, requires_grad=False)
+        X = torch.randn(8, 32, device=device_type, requires_grad=False)
         x_placements = [Shard(1)]
-        W = torch.randn(16, 8, device=self.device_type, requires_grad=False)
+        W = torch.randn(16, 8, device=device_type, requires_grad=False)
         w_placements = [Shard(0), Shard(1)]
 
         X_dt = distribute_tensor(X, mesh_full, x_placements)
@@ -440,6 +455,8 @@ class TestLocalMap(DTensorTestBase):
 @unittest.skipUnless(dist._is_spmd_types_available(), "requires spmd_types")
 class TestLocalMapSpmdTypes(TestCase):
     """Single-process tests for local_map with spmd_types type checking."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     WORLD_SIZE = 2
 
@@ -761,12 +778,14 @@ If the forward and backward layouts intentionally diverge in a way not represent
 class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
     """Multi-GPU tests for local_map with spmd_types type checking."""
 
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self):
         return 2
 
     @with_comms()
-    def test_spmd_types_dp_matmul(self):
+    def test_spmd_types_dp_matmul(self, device):
         """DP matmul with custom autograd functions.
 
         Data is Shard(0) (V), weights are Replicate (R). The correct backward
@@ -777,6 +796,7 @@ class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
         Step 2: BuggyDPMatmul with spmd_types=True -> spmd.SpmdTypeError (V + I).
         Step 3: CorrectDPMatmul with spmd_types=True -> correct gradients.
         """
+        device_type = torch.device(device).type
         from spmd_types import (
             assert_type,
             MeshAxis,
@@ -825,14 +845,14 @@ class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
                 return out
 
         device_mesh = init_device_mesh(
-            device_type=self.device_type,
+            device_type=device_type,
             mesh_shape=(self.world_size,),
             mesh_dim_names=("dp",),
         )
         torch.manual_seed(42)
 
-        X = torch.randn(4, 8, device=self.device_type, requires_grad=True)
-        W = torch.randn(8, 4, device=self.device_type, requires_grad=True)
+        X = torch.randn(4, 8, device=device_type, requires_grad=True)
+        W = torch.randn(8, 4, device=device_type, requires_grad=True)
 
         # Single-node reference
         X_ref = X.detach().clone().requires_grad_()
@@ -890,21 +910,22 @@ class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
         self.assertEqual(W_dt.grad.full_tensor(), W_ref.grad)
 
     @with_comms()
-    def test_spmd_types_backward_grad_placements(self):
+    def test_spmd_types_backward_grad_placements(self, device):
         """
         Matching grad_out placements need no redistribution; mismatched grads get implicitly redistributed.
         """
+        device_type = torch.device(device).type
         device_mesh = init_device_mesh(
-            device_type=self.device_type,
+            device_type=device_type,
             mesh_shape=(self.world_size,),
             mesh_dim_names=("dp",),
         )
 
         # S(0) @ R -> S(0) FWD: backward expects S(0) grad
         def s0_r_mm():
-            X = torch.randn(4, 8, device=self.device_type, requires_grad=True)
+            X = torch.randn(4, 8, device=device_type, requires_grad=True)
             X_dt = distribute_tensor(X, device_mesh, [Shard(0)])
-            W = torch.randn(8, 4, device=self.device_type, requires_grad=True)
+            W = torch.randn(8, 4, device=device_type, requires_grad=True)
             W_dt = distribute_tensor(W, device_mesh, [Replicate()])
 
             wrapped_shard = local_map(
@@ -942,9 +963,9 @@ class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
         )
 
         def s1_s0_mm():
-            X = torch.randn(4, 8, device=self.device_type, requires_grad=True)
+            X = torch.randn(4, 8, device=device_type, requires_grad=True)
             X_dt = distribute_tensor(X, device_mesh, [Shard(1)])
-            W = torch.randn(8, 4, device=self.device_type, requires_grad=True)
+            W = torch.randn(8, 4, device=device_type, requires_grad=True)
             W_dt = distribute_tensor(W, device_mesh, [Shard(0)])
             return wrapped_partial(X_dt, W_dt), X_dt, W_dt
 
@@ -966,7 +987,7 @@ class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
 
         # P output type with P output placement expects Replicate grad, so a
         # Partial grad_out redistributes via all-reduce.
-        X = torch.randn(4, 8, device=self.device_type, requires_grad=True)
+        X = torch.randn(4, 8, device=device_type, requires_grad=True)
         X_dt = DTensor.from_local(X, device_mesh, [Partial()], run_check=False)
         wrapped_partial_out = local_map(
             lambda X: X * 2,
@@ -985,7 +1006,7 @@ class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
 
         # V output type with S(1) output placement expects S(1) grad, so a
         # Partial grad_out redistributes via reduce-scatter along dim 1.
-        X = torch.randn(4, 8, device=self.device_type, requires_grad=True)
+        X = torch.randn(4, 8, device=device_type, requires_grad=True)
         X_dt = distribute_tensor(X, device_mesh, [Shard(1)])
         wrapped_shard1_out = local_map(
             lambda X: X * 2,
@@ -1010,6 +1031,8 @@ class TestLocalMapSpmdTypesMultiGPU(DTensorTestBase):
 @unittest.skipUnless(dist._is_spmd_types_available(), "requires spmd_types")
 class TestLocalMapSpmdTypesMesh(TestCase):
     """Tests for local_map spmd_types with multi-dimensional meshes."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     WORLD_SIZE = 4
 
@@ -1075,6 +1098,20 @@ class TestLocalMapSpmdTypesMesh(TestCase):
             lambda: wrapped(X_dt),
             """Output tensor has no spmd_types annotation on DeviceMesh dimension dp but out_placements expects S(0). Actual annotations on this DeviceMesh are: []""",
         )
+
+
+instantiate_device_type_tests(
+    TestLocalMap,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestLocalMapSpmdTypesMultiGPU,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/experimental/test_local_map.py
+++ b/test/distributed/tensor/experimental/test_local_map.py
@@ -18,10 +18,8 @@ from torch.distributed.tensor import (
 from torch.distributed.tensor._utils import ExplicitRedistributionContext
 from torch.distributed.tensor.debug import CommDebugMode
 from torch.distributed.tensor.experimental import local_map
-from torch.testing._internal.common_device_type import (
-    deviceCountAtLeast,
-    instantiate_device_type_tests,
-)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     run_tests,
@@ -408,14 +406,14 @@ class TestLocalMap(DTensorTestBase):
             )
             self.assertEqual(W_dt.grad.full_tensor(), W.grad)
 
-    @deviceCountAtLeast(4)
+    @skip_if_lt_x_gpu(4)
     @with_comms
-    def test_multi_mesh_inputs(self, devices):
+    def test_multi_mesh_inputs(self, device):
         """
         Test the function can be applied to accept DTensors that lives
         on different device meshes.
         """
-        device_type = torch.device(devices[0]).type
+        device_type = torch.device(device).type
         mesh_full = init_device_mesh(
             device_type=device_type, mesh_shape=(self.world_size,)
         )

--- a/test/distributed/tensor/experimental/test_register_sharding.py
+++ b/test/distributed/tensor/experimental/test_register_sharding.py
@@ -6,7 +6,8 @@ import torch
 from torch.distributed.tensor import distribute_tensor, DTensor, Replicate, Shard
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor.experimental import register_sharding
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -17,6 +18,8 @@ aten = torch.ops.aten
 
 
 class TestRegisterSharding(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def tearDown(self):
         super().tearDown()
         # Clean up any custom ops registered during tests to avoid test pollution
@@ -31,7 +34,8 @@ class TestRegisterSharding(DTensorTestBase):
             delattr(torch.ops, "test_dtensor")
 
     @with_comms
-    def test_softmax_fwd(self):
+    def test_softmax_fwd(self, device):
+        device_type = torch.device(device).type
         # After registering the custom softmax sharding strategy,
         # the original entry would have been replaced.
         # The following line is for showcasing purpose only.
@@ -70,7 +74,7 @@ class TestRegisterSharding(DTensorTestBase):
 
         device_mesh = self.build_device_mesh()
 
-        x = torch.rand(8, 12, 16, device=self.device_type)
+        x = torch.rand(8, 12, 16, device=device_type)
         dims = range(3)  # used to convert -1 to the actual dim
         softmax_dims = [-1, 0, 1]
         shard_dims = [0, 1, 2]
@@ -92,7 +96,9 @@ class TestRegisterSharding(DTensorTestBase):
                 self.assertEqual(dist_y.full_tensor(), local_y)
 
     @with_comms
-    def test_argmax(self):
+    def test_argmax(self, device):
+        device_type = torch.device(device).type
+
         @register_sharding(aten.argmax.default)
         def custom_argmax_sharding(x, dim, keepdim):
             acceptable_shardings = []
@@ -120,7 +126,7 @@ class TestRegisterSharding(DTensorTestBase):
 
         device_mesh = self.build_device_mesh()
 
-        x = torch.rand(8, 12, device=self.device_type)
+        x = torch.rand(8, 12, device=device_type)
         dist_x = distribute_tensor(x, device_mesh, [Shard(0)])
 
         local_y = torch.argmax(x, dim=1, keepdim=True)
@@ -130,9 +136,10 @@ class TestRegisterSharding(DTensorTestBase):
         self.assertEqual(dist_y.full_tensor(), local_y)
 
     @with_comms
-    def test_register_sharding_for_tensor_kwargs(self):
+    def test_register_sharding_for_tensor_kwargs(self, device):
+        device_type = torch.device(device).type
         mesh = self.build_device_mesh()
-        x = torch.randn(4, 4, device=self.device_type)
+        x = torch.randn(4, 4, device=device_type)
         x_dt = distribute_tensor(x, mesh, [Replicate()])
 
         @register_sharding(aten.min.dim_min)
@@ -143,8 +150,8 @@ class TestRegisterSharding(DTensorTestBase):
             )
             return [all_replicate]
 
-        value = torch.randn(4, 1, device=self.device_type)
-        indices = torch.randn(4, 1, device=self.device_type).long()
+        value = torch.randn(4, 1, device=device_type)
+        indices = torch.randn(4, 1, device=device_type).long()
         value_dt = distribute_tensor(value, mesh, [Replicate()])
         indices_dt = distribute_tensor(indices, mesh, [Replicate()])
 
@@ -158,9 +165,12 @@ class TestRegisterSharding(DTensorTestBase):
         self.assertEqual(result[1].full_tensor(), expected_indices)
 
     @with_comms
-    def test_register_sharding_non_tensor_first_arg(self):
+    def test_register_sharding_non_tensor_first_arg(self, device):
+        device_type = torch.device(device).type
+
         # Test that get_mesh_from_args works when the first arg is not a DTensor
         # Regression test for https://github.com/pytorch/pytorch/issues/167915
+
         @torch.library.custom_op("test_dtensor::scalar_first_arg", mutates_args=())
         def scalar_first_arg(name: str, x: torch.Tensor) -> torch.Tensor:
             return x.clone()
@@ -174,7 +184,7 @@ class TestRegisterSharding(DTensorTestBase):
             return [([Replicate()], [None, Replicate()])]
 
         mesh = self.build_device_mesh()
-        x = torch.randn(4, 4, device=self.device_type)
+        x = torch.randn(4, 4, device=device_type)
         x_dt = distribute_tensor(x, mesh, [Replicate()])
 
         # This should not raise "Cannot find device mesh from args"
@@ -182,6 +192,14 @@ class TestRegisterSharding(DTensorTestBase):
 
         self.assertIsInstance(result, DTensor)
         self.assertEqual(result.full_tensor(), x)
+
+
+instantiate_device_type_tests(
+    TestRegisterSharding,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/experimental/test_tp_transform.py
+++ b/test/distributed/tensor/experimental/test_tp_transform.py
@@ -10,7 +10,8 @@ from torch.distributed.tensor.parallel.style import (
     ParallelStyle,
     RowwiseParallel,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -52,6 +53,8 @@ class DummyModel(torch.nn.Module):
 
 
 class TensorParallelTest(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def setUp(self) -> None:
         super().setUp()
 
@@ -66,9 +69,10 @@ class TensorParallelTest(DTensorTestBase):
         self.assertDictEqual(expected_ops_count, actual_ops_count)
 
     @with_comms
-    def test_tp_transform_with_uncovered_op(self):
-        model = DummyModel().to(device=self.device_type)
-        inputs = (torch.randn(7, 3, requires_grad=False).to(device=self.device_type),)
+    def test_tp_transform_with_uncovered_op(self, device):
+        device_type = torch.device(device).type
+        model = DummyModel().to(device=device_type)
+        inputs = (torch.randn(7, 3, requires_grad=False).to(device=device_type),)
         with torch.no_grad():
             res = model(*inputs)
             exported_program = torch.export.export(
@@ -78,7 +82,7 @@ class TensorParallelTest(DTensorTestBase):
             exported_program,
             self.rank,
             self.world_size,
-            self.device_type,
+            device_type,
             {"fc": ColwiseParallel},
         )
         tp_model = tp_exported_program.module()
@@ -95,10 +99,11 @@ class TensorParallelTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_tp_transform_e2e(self):
+    def test_tp_transform_e2e(self, device):
+        device_type = torch.device(device).type
         torch.manual_seed(0)
-        model = MLPListModule(2).to(device=self.device_type)
-        inputs = (torch.randn((10, 12)).to(device=self.device_type),)
+        model = MLPListModule(2).to(device=device_type)
+        inputs = (torch.randn((10, 12)).to(device=device_type),)
         parallel_strategies: dict[str, ParallelStyle] = {
             "mlps.0.0": ColwiseParallel,
             "mlps.0.2": RowwiseParallel,
@@ -115,7 +120,7 @@ class TensorParallelTest(DTensorTestBase):
             exported_program,
             self.rank,
             self.world_size,
-            self.device_type,
+            device_type,
             parallel_strategies,
         )
         tp_model = tp_exported_program.module()
@@ -132,10 +137,11 @@ class TensorParallelTest(DTensorTestBase):
         )
 
     @with_comms
-    def test_tp_transform_no_bias(self):
+    def test_tp_transform_no_bias(self, device):
+        device_type = torch.device(device).type
         torch.manual_seed(0)
-        model = MLPListModule(1, bias=False).to(device=self.device_type)
-        inputs = (torch.randn((10, 12)).to(device=self.device_type),)
+        model = MLPListModule(1, bias=False).to(device=device_type)
+        inputs = (torch.randn((10, 12)).to(device=device_type),)
         parallel_strategies: dict[str, ParallelStyle] = {
             "mlps.0.0": ColwiseParallel,
             "mlps.0.2": RowwiseParallel,
@@ -150,7 +156,7 @@ class TensorParallelTest(DTensorTestBase):
             exported_program,
             self.rank,
             self.world_size,
-            self.device_type,
+            device_type,
             parallel_strategies,
         )
         tp_model = tp_exported_program.module()
@@ -164,6 +170,14 @@ class TensorParallelTest(DTensorTestBase):
                 "_c10d_functional.wait_tensor.default": 1,
             },
         )
+
+
+instantiate_device_type_tests(
+    TensorParallelTest,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR classifies the remaining experimental DTensor tests and converts their accelerator-dependent classes to device-type instantiation.

## Changes

- Classify the local-map, sharding-registration, and tensor-parallel transform tests by their hardware requirements.
- Add generated `device` or `devices` arguments to device-specific methods and remove fixed device assumptions.
- Instantiate accelerator classes with CPU excluded and XPU enabled where supported by the test framework.
- Preserve existing multi-device skip behavior, including `skip_if_lt_x_gpu(4)`.

## Test plan

- `spin quicklint -a` - passed.
- `python -m py_compile test/distributed/tensor/experimental/test_local_map.py` - passed.
- `git diff --check` - passed.
- Full `spin lint -a` was attempted; the remaining checks passed except clang-tidy, which requires a local build.
- Device runtime tests were not run locally.

Prepared with assistance from an AI coding assistant.
