### PR TITLE
[Testcase Refactoring][DTensor] Classify small DTensor test suites by hardware

### DIFF
--- a/test/distributed/tensor/test_decompositions.py
+++ b/test/distributed/tensor/test_decompositions.py
@@ -4,7 +4,7 @@
 import torch
 import torch.distributed as dist
 from torch._decomp import register_decomposition
-from torch.distributed.device_mesh import DeviceMesh
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor
 from torch.distributed.tensor.placement_types import (
     _StridedShard,
@@ -12,7 +12,12 @@ from torch.distributed.tensor.placement_types import (
     Replicate,
     Shard,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -21,6 +26,8 @@ from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
 class TestDecompSharding(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 4
 
     def setUp(self):
@@ -247,8 +254,10 @@ class TestDecompSharding(TestCase):
 
 
 class TestDecompShardingWithComms(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @with_comms
-    def test_decomp_schema_caches_static_args(self):
+    def test_decomp_schema_caches_static_args(self, device):
         """
         Test that decomposition ops use the correct cache key with static args.
         unsafe_chunk decomposes through split, and two unsafe_chunk calls with different dims
@@ -256,8 +265,9 @@ class TestDecompShardingWithComms(DTensorTestBase):
 
         This checks the first call allows Shard(2) through, while the 2nd call forces Replicate.
         """
-        device_mesh = self.build_device_mesh()
-        t = torch.randn(8, 8, 8, requires_grad=False, device=self.device_type)
+        device_type = torch.device(device).type
+        device_mesh = init_device_mesh(device_type, (self.world_size,))
+        t = torch.randn(8, 8, 8, requires_grad=False, device=device_type)
         dt = distribute_tensor(t, device_mesh, [Shard(2)])
 
         # chunk on non-sharding dim propagates through
@@ -275,12 +285,11 @@ class TestDecompShardingWithComms(DTensorTestBase):
             self.assertEqual(r.full_tensor(), e)
 
     @with_comms
-    def test_decomp_schema_for_cache_aminmax(self):
+    def test_decomp_schema_for_cache_aminmax(self, device):
         """Test that aminmax with different dim kwargs doesn't hit stale cache."""
-        device_mesh = self.build_device_mesh()
-        t = torch.randn(
-            self.world_size, 4, 4, requires_grad=False, device=self.device_type
-        )
+        device_type = torch.device(device).type
+        device_mesh = init_device_mesh(device_type, (self.world_size,))
+        t = torch.randn(self.world_size, 4, 4, requires_grad=False, device=device_type)
         dt = distribute_tensor(t, device_mesh, [Shard(0)])
 
         # First call: full reduction (no dim kwarg)
@@ -295,6 +304,14 @@ class TestDecompShardingWithComms(DTensorTestBase):
         expected_dim1 = torch.aminmax(t, dim=1)
         self.assertTrue(torch.equal(result_dim1.min.full_tensor(), expected_dim1.min))
         self.assertTrue(torch.equal(result_dim1.max.full_tensor(), expected_dim1.max))
+
+
+instantiate_device_type_tests(
+    TestDecompShardingWithComms,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_dtensor_dispatch_overhead.py
+++ b/test/distributed/tensor/test_dtensor_dispatch_overhead.py
@@ -10,8 +10,9 @@ from collections import namedtuple
 import torch
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.tensor import distribute_tensor, DTensor, Shard
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import HardwareClassification, run_tests
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     with_comms,
@@ -62,26 +63,29 @@ class TimeCaptureMode(TorchDispatchMode):
 
 
 class DistOpDispatchOverHead(DTensorTestBase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @property
     def world_size(self) -> int:
         return 4
 
     @skip_if_lt_x_gpu(4)
     @with_comms
-    def test_dtensor_add_op_dispatch_overhead(self):
-        if torch.cuda.is_available():
-            device_props = torch.cuda.get_device_name(0)
-            gpu_name = device_props
-            logger.info("running on %s", gpu_name)
-            # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
+    def test_dtensor_add_op_dispatch_overhead(self, device):
+        device_type = torch.device(device).type
+        device_module = torch.get_device_module(device_type)
+        if hasattr(device_module, "get_device_name"):
+            device_name = device_module.get_device_name(device)
         else:
-            self.skipTest("CUDA not available")
+            device_name = device_type
+        logger.info("running on %s", device_name)
+        # TODO: adjust `expected_propagate_time` and `expected_dispatch_time` to target different hardware
         expected_propagate_time = 880  # noqa: F841
         expected_dispatch_time = 90  # noqa: F841
         diff_percent_threshold = 0.20  # noqa: F841
         propagator = DTensor._op_dispatcher.sharding_propagator
-        device_mesh = init_device_mesh("cuda", (self.world_size,))
-        input_data = torch.rand(512, 512, device="cuda")
+        device_mesh = init_device_mesh(device_type, (self.world_size,))
+        input_data = torch.rand(512, 512, device=device_type)
         a = distribute_tensor(input_data, device_mesh, [Shard(0)])
         # warm up
         with TimeCaptureMode() as tcm:
@@ -133,6 +137,14 @@ class DistOpDispatchOverHead(DTensorTestBase):
         #         f"expected {expected_dispatch_time} us"
         #     ),
         # )
+
+
+instantiate_device_type_tests(
+    DistOpDispatchOverHead,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_dtensor_logging.py
+++ b/test/distributed/tensor/test_dtensor_logging.py
@@ -8,13 +8,19 @@ from torch.distributed.tensor import DeviceMesh, DTensor, Replicate, Shard
 from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 from torch.distributed.tensor._op_schema import OpSchema
 from torch.distributed.tensor.debug import _clear_sharding_prop_cache
-from torch.testing._internal.common_utils import requires_cuda, run_tests, TestCase
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
-@requires_cuda
 class TestDTensorLogging(TestCase):
     """Test DTensor logging."""
+
+    hw_classification = HardwareClassification.ACCELERATOR
 
     def tearDown(self):
         super().tearDown()
@@ -28,10 +34,10 @@ class TestDTensorLogging(TestCase):
         dist.init_process_group(
             backend="fake", rank=0, world_size=self.world_size, store=store
         )
-        self.device_type = "cuda"
 
-    def test_sharding_prop_cache_logging(self):
-        mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+    def test_sharding_prop_cache_logging(self, device):
+        device_type = torch.device(device).type
+        mesh = DeviceMesh(device_type, list(range(self.world_size)))
 
         log_records = []
         handler = logging.Handler()
@@ -46,7 +52,9 @@ class TestDTensorLogging(TestCase):
         dispatch_logger.addHandler(handler)
 
         # Test simple miss/hit
-        x_dt = DTensor.from_local(torch.randn(2, 4), mesh, [Shard(0)], run_check=False)
+        x_dt = DTensor.from_local(
+            torch.randn(2, 4, device=device), mesh, [Shard(0)], run_check=False
+        )
         x_dt + x_dt  # miss
         x_dt + x_dt  # hit
 
@@ -55,16 +63,18 @@ class TestDTensorLogging(TestCase):
         x_dt1 + x_dt1
 
         # Test miss with different shapes
-        x_dt2 = DTensor.from_local(torch.randn(4, 4), mesh, [Shard(0)], run_check=False)
+        x_dt2 = DTensor.from_local(
+            torch.randn(4, 4, device=device), mesh, [Shard(0)], run_check=False
+        )
         x_dt2 + x_dt2
 
-        self.assertExpectedInline(
+        self.assertEqual(
             log_string(),
-            """\
-sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](S(0)))
+            f"""\
+sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))
 sharding_prop HIT (C++ fast path): aten::add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0))), 4822678189205111) -> Spec(f32[4, 4](S(0)))
-sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](R)), Spec(f32[4, 4](R))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](R))
-sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(f32[8, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[8, 4](S(0)))""",
+sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](R)), Spec(f32[4, 4](R))) on DeviceMesh((2,), '{device_type}', stride=(1,))) -> Spec(f32[4, 4](R))
+sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(f32[8, 4](S(0)))) on DeviceMesh((2,), '{device_type}', stride=(1,))) -> Spec(f32[8, 4](S(0)))""",
         )
 
         # Test Python LRU cache, directly with ShardingPropagator
@@ -86,16 +96,17 @@ sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(
         )
         propagator.propagate_op_sharding(op_schema)  # Python cache miss
         propagator.propagate_op_sharding(op_schema)  # Python cache hit
-        self.assertExpectedInline(
+        self.assertEqual(
             log_string(),
-            """\
-sharding_prop python cache MISS: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](S(0)))
-sharding_prop python cache HIT: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), 'cuda', stride=(1,))) -> Spec(f32[4, 4](S(0)))""",
+            f"""\
+sharding_prop python cache MISS: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))
+sharding_prop python cache HIT: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))""",
         )
 
-    def test_logging_level_change_resets_cpp_cache(self):
+    def test_logging_level_change_resets_cpp_cache(self, device):
         """setLevel on the dispatch logger resets the C++ cached logging flag."""
-        mesh = DeviceMesh(self.device_type, list(range(self.world_size)))
+        device_type = torch.device(device).type
+        mesh = DeviceMesh(device_type, list(range(self.world_size)))
         dispatch_logger = logging.getLogger("torch.distributed.tensor._dispatch")
 
         log_records: list[logging.LogRecord] = []
@@ -103,7 +114,9 @@ sharding_prop python cache HIT: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[
         handler.emit = lambda record: log_records.append(record)
         dispatch_logger.addHandler(handler)
 
-        x_dt = DTensor.from_local(torch.randn(2, 4), mesh, [Shard(0)], run_check=False)
+        x_dt = DTensor.from_local(
+            torch.randn(2, 4, device=device), mesh, [Shard(0)], run_check=False
+        )
 
         # With logging off, the C++ hit path should produce no records.
         dispatch_logger.setLevel(logging.WARNING)
@@ -121,6 +134,14 @@ sharding_prop python cache HIT: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[
         self.assertEqual(len(log_records), 2)
         self.assertIn("MISS", log_records[0].getMessage())
         self.assertIn("HIT", log_records[1].getMessage())
+
+
+instantiate_device_type_tests(
+    TestDTensorLogging,
+    globals(),
+    except_for=["cpu", "privateuse1"],
+    allow_xpu=True,
+)
 
 
 if __name__ == "__main__":

--- a/test/distributed/tensor/test_dtensor_logging.py
+++ b/test/distributed/tensor/test_dtensor_logging.py
@@ -68,7 +68,7 @@ class TestDTensorLogging(TestCase):
         )
         x_dt2 + x_dt2
 
-        self.assertEqual(
+        self.assertExpectedInline(
             log_string(),
             f"""\
 sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))
@@ -96,7 +96,7 @@ sharding_prop MISS (C++ fast path): aten.add.Tensor(Spec(f32[8, 4](S(0))), Spec(
         )
         propagator.propagate_op_sharding(op_schema)  # Python cache miss
         propagator.propagate_op_sharding(op_schema)  # Python cache hit
-        self.assertEqual(
+        self.assertExpectedInline(
             log_string(),
             f"""\
 sharding_prop python cache MISS: aten.add.Tensor(Spec(f32[4, 4](S(0))), Spec(f32[4, 4](S(0)))) on DeviceMesh((2,), '{device_type}', stride=(1,))) -> Spec(f32[4, 4](S(0)))

--- a/test/distributed/tensor/test_op_schema.py
+++ b/test/distributed/tensor/test_op_schema.py
@@ -5,10 +5,16 @@ import random
 
 from torch.distributed.tensor._dtensor_spec import DTensorSpec
 from torch.distributed.tensor._op_schema import OpSchema, RuntimeSchemaInfo
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 class TestOpSchema(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_equality_checks_lists_of_dtensor_spec(self):
         """If x == y, then we must have h(x) == h(y)."""
         dts = DTensorSpec(mesh=None, placements=tuple(), tensor_meta=None)

--- a/test/distributed/tensor/test_placement_types.py
+++ b/test/distributed/tensor/test_placement_types.py
@@ -24,11 +24,17 @@ from torch.fx.experimental.symbolic_shapes import (
     optimization_hint,
     ShapeEnv,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 
 
 # Basic functionality test for Placement types.
 class PlacementTypesTestCase(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_type_identification(self):
         shard = Shard(3)
         strided_shard = _StridedShard(dim=3, split_factor=7)

--- a/test/distributed/tensor/test_single_dim_strategy.py
+++ b/test/distributed/tensor/test_single_dim_strategy.py
@@ -52,7 +52,11 @@ from torch.distributed.tensor.placement_types import (
     _StridedShard,
     Placement,
 )
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TestCase,
+)
 from torch.testing._internal.distributed.fake_pg import FakeStore
 
 
@@ -93,6 +97,8 @@ def _get_mm_specs(
 
 
 class TestExpandPlaceholder(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 64
@@ -1300,6 +1306,8 @@ class TestExpandPlaceholder(TestCase):
 
 
 class TestDijkstraExpandSingleDimStrategy(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         store = FakeStore()
@@ -1949,6 +1957,8 @@ def _dummy_check_fake(x):
 class TestCommonPointwiseSingleDimStrategy(TestCase):
     """Unit tests for _common_pointwise_single_dim_strategy raw rule generation."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def _meta(self, *dims: int) -> TensorMeta:
         shape = torch.Size(dims)
         stride = torch.empty(shape).stride()
@@ -2042,6 +2052,8 @@ class TestCommonPointwiseSingleDimStrategy(TestCase):
 
 
 class TestSingleDimStrategyRegistration(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.world_size = 4

--- a/test/distributed/tensor/test_strategy_validation.py
+++ b/test/distributed/tensor/test_strategy_validation.py
@@ -35,11 +35,18 @@ from torch.distributed.tensor._ops.strategy_validation import (
 )
 from torch.distributed.tensor.placement_types import Partial, Shard
 from torch.testing._internal.common_methods_invocations import SampleInput
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_SLOW, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    TEST_WITH_SLOW,
+    TestCase,
+)
 
 
 class TestPlacementUtilities(TestCase):
     """Test placement utility functions."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_parse_placement_replicate(self):
         p = parse_placement("R")
@@ -73,6 +80,8 @@ class TestPlacementUtilities(TestCase):
 
 class TestPlacementNormalization(TestCase):
     """Test placement normalization for trivial shard deduplication."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_is_trivial_shard_size_1(self):
         """Shard on size-1 dimension is trivial."""
@@ -214,6 +223,8 @@ class TestPlacementNormalization(TestCase):
 class TestInputPlacements(TestCase):
     """Test input/output placement generation."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_get_1d_input_placements(self):
         t = torch.randn(4, 3)
         placements = get_1d_input_placements_for_tensor(t, include_partial=False)
@@ -293,6 +304,8 @@ class TestInputPlacements(TestCase):
 class TestExtractTensors(TestCase):
     """Test tensor extraction from samples."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_extract_single_input(self):
         sample = SampleInput(torch.randn(4, 3))
         tensors = extract_tensors_from_sample(sample)
@@ -319,6 +332,8 @@ class TestExtractTensors(TestCase):
 
 class TestValidateCombination(TestCase):
     """Test the core validate_combination function."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     world_size = 2
 
@@ -606,6 +621,8 @@ class TestValidateCombination(TestCase):
 class TestCreatePartialInput(TestCase):
     """Test the _create_partial_input helper."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_partial_sum_reduces_correctly(self):
         tensor = torch.randn(4, 3)
         local_tensor = _create_partial_input(tensor, Partial("sum"), world_size=2)
@@ -779,6 +796,8 @@ class TestPartialCombinationValidity(TestCase):
     (e.g., using symmetric splits or ignoring tensor_idx).
     """
 
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 2
 
     def setUp(self):
@@ -925,6 +944,8 @@ class TestPartialCombinationValidity(TestCase):
 class TestDecompStrategyPath(TestCase):
     """Test that decomposition-based strategy propagation discovers rules."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 2
 
     def setUp(self):
@@ -1053,6 +1074,8 @@ class TestDecompStrategyPath(TestCase):
 class TestQuerySingleDimStrategyKwargs(TestCase):
     """Test that query_single_dim_strategy forwards kwargs to strategy functions."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def test_kwargs_forwarded_to_strategy(self):
         """
         A kwargs-aware strategy should receive the actual kwargs, not {}.
@@ -1116,6 +1139,8 @@ class TestQuerySingleDimStrategyKwargs(TestCase):
 
 class TestCompareRules(TestCase):
     """Test _compare_rules populates per-op statistics correctly."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_true_positives_tracked_by_op(self):
         from torch.distributed.tensor._ops.strategy_validation import (
@@ -1217,6 +1242,8 @@ class TestCompareRules(TestCase):
 
 class TestCompareOperatorEndToEnd(TestCase):
     """End-to-end smoke test for compare_operator."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     world_size = 2
 
@@ -1323,6 +1350,8 @@ class TestCompareOperatorEndToEnd(TestCase):
 class TestAtenLevelValidation(TestCase):
     """Tests for aten-level validation (validate_aten_combination + allow_composite mode)."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     world_size = 2
 
     def setUp(self):
@@ -1427,6 +1456,8 @@ class TestAtenLevelValidation(TestCase):
 class TestMainModule(TestCase):
     """Test that strategy_validation can be run as a main module."""
 
+    hw_classification = HardwareClassification.GENERIC
+
     def _run_module(self, *extra_args):
         import subprocess
         import sys
@@ -1466,6 +1497,8 @@ class TestMainModule(TestCase):
 
 class TestOpInfoLookup(TestCase):
     """Tests for get_opinfo_by_name, _find_opinfo_candidates, and resolve_op_names."""
+
+    hw_classification = HardwareClassification.GENERIC
 
     def test_get_opinfo_by_name_exact(self):
         results = get_opinfo_by_name("add")


### PR DESCRIPTION
## Summary

This PR classifies several small DTensor test suites according to whether they are device-independent or accelerator-dependent.

## Changes

- Keep schema, placement, strategy-validation, and other device-independent checks in generic test classes without device-type instantiation.
- Split decomposition tests into generic and accelerator-dependent classes.
- Classify dispatch-overhead and logging tests by their actual device requirements and add generated device arguments where required.
- Exclude PrivateUse1 from the logging accelerator instantiation because this PR does not establish that backend's logging support.
- Preserve the original inline expected-output assertions and test behavior.

## Scope

This PR changes seven focused test files. It only reorganizes hardware classification and device selection; it does not add new backend capabilities or claim NPU runtime coverage.

## Test plan

- `spin quicklint -a` - passed.
- `python -m py_compile test/distributed/tensor/test_dtensor_logging.py` - passed.
- `git diff --check` - passed.
- Full `spin lint -a` was attempted; the remaining checks passed except clang-tidy, which requires a local build.
- Device runtime tests were not run locally.

Prepared with assistance from an AI coding assistant.
