### PR TITLE
Document and correctly dispatch extracted AOTI package directories

### DIFF
--- a/test/inductor/test_aot_inductor_package.py
+++ b/test/inductor/test_aot_inductor_package.py
@@ -312,7 +312,15 @@ class TestAOTInductorPackage(TestCase):
                     # The loader should be able to load from temp_dir which contains 'data/...'
                     # or 'some_prefix/data/...'
 
-                    loaded = torch._inductor.aoti_load_package(temp_dir)
+                    with (
+                        self.assertNoLogs(
+                            "torch._inductor.package.package", level="WARNING"
+                        ),
+                        self.assertNoLogs(
+                            "torch.export.pt2_archive._package", level="WARNING"
+                        ),
+                    ):
+                        loaded = torch._inductor.aoti_load_package(temp_dir)
                     actual = loaded(*example_inputs)
                     self.assertEqual(actual, expected)
 

--- a/torch/_inductor/__init__.py
+++ b/torch/_inductor/__init__.py
@@ -258,7 +258,7 @@ def aoti_load_package(
     path: FileLike, run_single_threaded: bool = False, device_index: int = -1
 ) -> AOTICompiledModel:
     """
-    Loads the model from the PT2 package.
+    Loads a model from a PT2 package or an extracted PT2 package directory.
 
     If multiple models were packaged into the PT2, this will load the default
     model. To load a specific model, you can directly call the load API
@@ -271,7 +271,7 @@ def aoti_load_package(
         compiled_model2 = load_package("my_package.pt2", "model2")
 
     Args:
-        path: Path to the .pt2 package
+        path: Path to the .pt2 package or extracted package directory.
         run_single_threaded (bool): Whether the model should be run without
             thread synchronization logic. This is useful to avoid conflicts with
             CUDAGraphs.

--- a/torch/_inductor/package/package.py
+++ b/torch/_inductor/package/package.py
@@ -107,20 +107,23 @@ def load_package(
     num_runners: int = 1,
     device_index: int = -1,
 ) -> AOTICompiledModel:
-    try:
-        pt2_contents = load_pt2(
-            path,
-            run_single_threaded=run_single_threaded,
-            num_runners=num_runners,
-            device_index=device_index,
-        )
-        if model_name not in pt2_contents.aoti_runners:
-            raise RuntimeError(f"Model {model_name} not found in package")
-        return pt2_contents.aoti_runners[model_name]
-    except RuntimeError as e:
-        if AOTI_PACKAGE_DEVICE_ERROR in str(e):
-            raise
-        log.warning("Loading outdated pt2 file. Please regenerate your package.")
+    """Load an AOTI model from a PT2 package or an extracted package directory."""
+    is_directory = isinstance(path, (str, os.PathLike)) and os.path.isdir(path)
+    if not is_directory:
+        try:
+            pt2_contents = load_pt2(
+                path,
+                run_single_threaded=run_single_threaded,
+                num_runners=num_runners,
+                device_index=device_index,
+            )
+            if model_name not in pt2_contents.aoti_runners:
+                raise RuntimeError(f"Model {model_name} not found in package")
+            return pt2_contents.aoti_runners[model_name]
+        except RuntimeError as e:
+            if AOTI_PACKAGE_DEVICE_ERROR in str(e):
+                raise
+            log.warning("Loading outdated pt2 file. Please regenerate your package.")
 
     if isinstance(path, (io.IOBase, IO)):
         with tempfile.NamedTemporaryFile(suffix=".pt2") as f:


### PR DESCRIPTION
The support introduced as part of #172436 allows `aoti_load_package` to load an extracted package directory directly, avoiding repeated extraction. However, the function's documentation does not mention this supported input, which may cause confusion for users of this API who are unaware that a directory path is a valid input. In addition, directory paths are currently passed to `load_pt2` first and reach the existing directory loader only through exception fallback. I updated the documentation and made a small dispatch change to recognize directory inputs up front, avoiding the unnecessary archive-loading attempt and its misleading warnings.

> Related to #194163.
>
> Verification prepared by Codex:
>
> - `test_load_package_from_directory` passed.
> - `spin quicklint` passed.
> - `lintrunner -a` passed.
>
> AI assistance disclosure: Codex assisted with code editing, testing, linting, and repository operations. The final implementation was reviewed and approved by the contributor.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo