### PR TITLE
Set USE_CMAKE_INSTRUMENTATION before including cmake/Dependencies.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,22 @@ cmake_dependent_option(
 cmake_dependent_option(BUILD_FUNCTORCH "Build Functorch" ON "BUILD_PYTHON" OFF)
 cmake_dependent_option(BUILD_BUNDLE_PTXAS "Bundle PTX into torch/bin folder"
                        OFF "USE_CUDA" OFF)
+cmake_dependent_option(
+  USE_CMAKE_INSTRUMENTATION
+  "Use cmake-instrumentation to collect build metrics"
+  OFF # disabled by default because it causes CI timeouts
+  "CMAKE_VERSION VERSION_GREATER_EQUAL 4.3"
+  OFF
+)
+if(USE_CMAKE_INSTRUMENTATION)
+  cmake_instrumentation(
+    API_VERSION 1
+    DATA_VERSION 1.0
+    HOOKS postCMakeBuild
+    OPTIONS trace
+    CALLBACK "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/build_trace_summary.py" --root "${CMAKE_CURRENT_SOURCE_DIR}" --index
+  )
+endif()
 cmake_dependent_option(USE_KLEIDIAI "Use KleidiAI for the ARM CPU & AARCH64 architecture." ON
                         "CPU_AARCH64" OFF)
 # prioritized text linker, ON by default for AArch64+Linux, option visible to all AArch64, x86 and ppc64le.
@@ -1106,23 +1122,6 @@ cmake_dependent_option(
   "Enable memory-efficient attention for scaled dot product attention.\
   Will be disabled if not supported by the platform" ON
   "USE_CUDA OR USE_ROCM" OFF)
-
-cmake_dependent_option(
-  USE_CMAKE_INSTRUMENTATION
-  "Use cmake-instrumentation to collect build metrics"
-  OFF # disabled by default because it causes CI timeouts
-  "CMAKE_VERSION VERSION_GREATER_EQUAL 4.3"
-  OFF
-)
-if(USE_CMAKE_INSTRUMENTATION)
-  cmake_instrumentation(
-    API_VERSION 1
-    DATA_VERSION 1.0
-    HOOKS postCMakeBuild
-    OPTIONS trace
-    CALLBACK "${Python_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/tools/build_trace_summary.py" --root "${CMAKE_CURRENT_SOURCE_DIR}" --index
-  )
-endif()
 
 #
 # Cannot be put into Dependencies.cmake due circular dependency:


### PR DESCRIPTION
This ensures that `USE_CMAKE_INSTRUMENTATION` is visible in nnpack.cmake so we can disable instrumentation for that library.

This is needed because NNPACK has a custom command that starts with PYTHONPATH=... This custom command fails when wrapped with ctest --instrument

Related-to: #189078