### PR TITLE
[CUDA] Hoist uniform divisor in avg_pool3d backward

### DIFF
--- a/aten/src/ATen/native/cuda/AveragePool3d.cu
+++ b/aten/src/ATen/native/cuda/AveragePool3d.cu
@@ -220,7 +220,8 @@ __global__ void avg_pool3d_cuda_update_grad_input_atomic(
   int dT, int dH, int dW,
   int padT, int padH, int padW,
   bool count_include_pad,
-  int offsetZ, int divisor_override, const int64_t gradInput_numel)
+  int offsetZ, const int64_t gradInput_numel,
+  bool uniform_divisor, accscalar_t hoisted_divide_factor)
 {
   int oCol   = blockIdx.x * blockDim.x + threadIdx.x;
   int oRow   = blockIdx.y * blockDim.y + threadIdx.y;
@@ -236,24 +237,27 @@ __global__ void avg_pool3d_cuda_update_grad_input_atomic(
     int tend = min(tstart + kT, gradInput.size(1) + padT);
     int hend = min(hstart + kH, gradInput.size(2) + padH);
     int wend = min(wstart + kW, gradInput.size(3) + padW);
-    int pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
+    // The clamp below bounds the scatter loop, so it stays. When the divisor is
+    // uniform across every window (see the host-side flag) it is hoisted in and
+    // we skip the per-thread pool_size / clamped-volume arithmetic.
+    accscalar_t divide_factor;
+    if (uniform_divisor) {
+      divide_factor = hoisted_divide_factor;
+    } else if (count_include_pad) {
+      divide_factor = static_cast<accscalar_t>(
+          (tend - tstart) * (hend - hstart) * (wend - wstart));
+    } else {
+      divide_factor = static_cast<accscalar_t>(
+          (min(tend, gradInput.size(1)) - max(tstart, 0)) *
+          (min(hend, gradInput.size(2)) - max(hstart, 0)) *
+          (min(wend, gradInput.size(3)) - max(wstart, 0)));
+    }
     tstart = max(tstart, 0);
     hstart = max(hstart, 0);
     wstart = max(wstart, 0);
     tend = min(tend, gradInput.size(1));
     hend = min(hend, gradInput.size(2));
     wend = min(wend, gradInput.size(3));
-
-    accscalar_t divide_factor;
-    if (divisor_override) {
-      divide_factor = static_cast<accscalar_t>(divisor_override);
-    } else {
-      if(count_include_pad) {
-        divide_factor = static_cast<accscalar_t>(pool_size);
-      } else {
-        divide_factor = static_cast<accscalar_t>((tend - tstart) * (hend - hstart) * (wend - wstart));
-      }
-    }
 
     scalar_t val = static_cast<scalar_t>(
       static_cast<accscalar_t>(gradOutput[slice][oFrame][oRow][oCol]) / divide_factor);
@@ -278,7 +282,8 @@ __global__ void avg_pool3d_cuda_update_grad_input(
   int kT, int kH, int kW,
   int dT, int dH, int dW,
   int padT, int padH, int padW,
-  bool count_include_pad, int offsetZ, int divisor_override)
+  bool count_include_pad, int offsetZ,
+  bool uniform_divisor, accscalar_t hoisted_divide_factor)
 {
   int oCol   = blockIdx.x * blockDim.x + threadIdx.x;
   int oRow   = blockIdx.y * blockDim.y + threadIdx.y;
@@ -294,24 +299,27 @@ __global__ void avg_pool3d_cuda_update_grad_input(
     int tend = min(tstart + kT, gradInput.size(1) + padT);
     int hend = min(hstart + kH, gradInput.size(2) + padH);
     int wend = min(wstart + kW, gradInput.size(3) + padW);
-    int pool_size = (tend - tstart) * (hend - hstart) * (wend - wstart);
+    // The clamp below bounds the scatter loop, so it stays. When the divisor is
+    // uniform across every window (see the host-side flag) it is hoisted in and
+    // we skip the per-thread pool_size / clamped-volume arithmetic.
+    accscalar_t divide_factor;
+    if (uniform_divisor) {
+      divide_factor = hoisted_divide_factor;
+    } else if (count_include_pad) {
+      divide_factor = static_cast<accscalar_t>(
+          (tend - tstart) * (hend - hstart) * (wend - wstart));
+    } else {
+      divide_factor = static_cast<accscalar_t>(
+          (min(tend, gradInput.size(1)) - max(tstart, 0)) *
+          (min(hend, gradInput.size(2)) - max(hstart, 0)) *
+          (min(wend, gradInput.size(3)) - max(wstart, 0)));
+    }
     tstart = max(tstart, 0);
     hstart = max(hstart, 0);
     wstart = max(wstart, 0);
     tend = min(tend, gradInput.size(1));
     hend = min(hend, gradInput.size(2));
     wend = min(wend, gradInput.size(3));
-
-    accscalar_t divide_factor;
-    if (divisor_override) {
-      divide_factor = static_cast<accscalar_t>(divisor_override);
-    } else {
-      if(count_include_pad) {
-        divide_factor = static_cast<accscalar_t>(pool_size);
-      } else {
-        divide_factor = static_cast<accscalar_t>((tend - tstart) * (hend - hstart) * (wend - wstart));
-      }
-    }
 
     scalar_t val = static_cast<scalar_t>(
       static_cast<accscalar_t>(gradOutput[slice][oFrame][oRow][oCol]) / divide_factor);
@@ -502,6 +510,13 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
 
   const bool kernelsOverlap = (dT < kT) || (dH < kH) || (dW < kW);
 
+  // When the divisor is the same for every window the general backward kernels
+  // can hoist it and skip the per-thread pool_size / clamp-volume arithmetic.
+  // Floor mode guarantees each window fits inside the padded input, so with
+  // count_include_pad (or no padding, or an explicit override) it is uniform.
+  const bool uniform_divisor = divisor_override.has_value() ||
+      (!ceil_mode && (count_include_pad || (padT == 0 && padH == 0 && padW == 0)));
+
   Tensor work_grad_input = gradInput;
   Tensor work_grad_output = gradOutput.contiguous();
 
@@ -556,6 +571,8 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
       "avg_pool3d_backward_out_frame",
       [&] {
         using accscalar_t = acc_type<scalar_t, true>;
+        const accscalar_t hoisted_divide_factor =
+            static_cast<accscalar_t>(divisor ? divisor : kT * kH * kW);
         int64_t totalZ = otime * nslices * nbatch;
         int64_t offsetZ = 0;
         dim3 block(32, 8);
@@ -574,7 +591,8 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
                   dT, dH, dW,
                   padT, padH, padW,
                   count_include_pad,
-                  offsetZ, divisor, work_grad_input.numel());
+                  offsetZ, work_grad_input.numel(),
+                  uniform_divisor, hoisted_divide_factor);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
           }
           else {
@@ -586,7 +604,8 @@ TORCH_IMPL_FUNC(avg_pool3d_backward_out_cuda) (
                   dT, dH, dW,
                   padT, padH, padW,
                   count_include_pad,
-                  offsetZ, divisor);
+                  offsetZ,
+                  uniform_divisor, hoisted_divide_factor);
             C10_CUDA_KERNEL_LAUNCH_CHECK();
           }
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -29,6 +29,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     largeTensorTest,
     onlyAccelerator,
+    onlyCUDA,
     onlyMPS,
     onlyNativeDeviceTypes,
     onlyOn,
@@ -1448,6 +1449,58 @@ torch.{device_type}.synchronize()
         helper(4, 8, 7, 7, 7, 3, stride=1)
         helper(4, 8, 7, 7, 7, 3, padding=1, stride=1)
         helper(2, 16, 10, 10, 10, 3, stride=2)
+
+    @onlyCUDA
+    @dtypes(torch.half, torch.bfloat16, torch.float, torch.double)
+    def test_avg_pool3d_backward_uniform_divisor(self, device, dtype):
+        # The general CUDA avg_pool3d backward kernels hoist the divisor and skip
+        # the per-thread pool_size / clamp-volume math when it is uniform across
+        # every window (!ceil_mode and count_include_pad, no padding, or an
+        # explicit divisor_override). Validate every path -- atomic (overlapping)
+        # and direct-write (non-overlapping), uniform and non-uniform -- against a
+        # CPU float64 oracle, over the dtypes that dispatch through acc_type.
+        tol = {
+            torch.half: dict(atol=2e-3, rtol=1e-2),
+            torch.bfloat16: dict(atol=2e-2, rtol=5e-2),
+            torch.float: dict(atol=1e-5, rtol=1e-4),
+            torch.double: dict(atol=1e-9, rtol=1e-9),
+        }[dtype]
+
+        def check(shape, **kw):
+            base = torch.randn(*shape)
+            xg = base.to(device=device, dtype=dtype).requires_grad_(True)
+            xref = base.double().requires_grad_(True)  # CPU float64 oracle
+            grad = torch.randn_like(F.avg_pool3d(xg, **kw))
+            F.avg_pool3d(xg, **kw).backward(grad)
+            F.avg_pool3d(xref, **kw).backward(grad.double().cpu())
+            self.assertEqual(xg.grad.double().cpu(), xref.grad, **tol)
+
+        s = (2, 3, 9, 11, 10)  # non-divisible on purpose (exercises dropped windows)
+        no_cip = dict(count_include_pad=False)
+        ceil_no_cip = dict(
+            count_include_pad=False, ceil_mode=True
+        )  # both clamp dirs bite
+        # atomic (overlapping windows, fastAtomicAdd)
+        check(s, kernel_size=3, stride=1, padding=1)  # uniform
+        check(s, kernel_size=3, stride=2)  # uniform, no pad
+        check(s, kernel_size=3, stride=1, padding=1, **no_cip)  # non-uniform, floor
+        check(
+            s, kernel_size=3, stride=2, padding=1, ceil_mode=True
+        )  # non-uniform, ceil
+        check(
+            s, kernel_size=3, stride=2, padding=1, **ceil_no_cip
+        )  # non-uniform, ceil+no-cip
+        # direct-write (non-overlapping windows)
+        check(s, kernel_size=2, stride=2)  # uniform, no pad
+        check(s, kernel_size=2, stride=2, padding=1)  # uniform
+        check(s, kernel_size=2, stride=2, padding=1, **no_cip)  # non-uniform, floor
+        check(s, kernel_size=2, stride=2, ceil_mode=True)  # non-uniform, ceil
+        check(
+            s, kernel_size=2, stride=2, padding=1, **ceil_no_cip
+        )  # non-uniform, ceil+no-cip
+        # divisor_override takes the hoisted path + stride-1 fast path (control)
+        check(s, kernel_size=2, stride=2, divisor_override=7)
+        check(s, kernel_size=3, stride=1)
 
     @onlyAccelerator
     @gcIfJetson


### PR DESCRIPTION
The avg_pool3d CUDA backward kernels recompute the divisor per output element -- computing `pool_size` and branching on `divisor_override` / `count_include_pad` in every thread. When the divisor is the same for every window that per-thread work is redundant.

Add a host-computed `uniform_divisor` flag, true when `divisor_override` is set, or when `!ceil_mode` and (`count_include_pad` or no padding). Floor mode guarantees each window fits inside the padded input, so `count_include_pad` makes the divisor exactly `kT*kH*kW` everywhere; no-padding and an explicit override are trivially uniform. The host hoists the divisor in and the kernel skips the per-thread `pool_size` / clamp-volume arithmetic.

The 3D backward is a per-output scatter, so the clamped bounds are the scatter loop bounds and stay; only the divisor computation is hoisted, not the clamp. Both general kernels are covered (atomic for overlapping windows, direct-write for non-overlapping); the stride-1 fast path already uses a uniform divisor and is untouched.

Numerically identical to the previous kernels.

## Test Plan
```
python test/nn/test_pooling.py TestPoolingNNDeviceCUDA -k avg_pool3d
compute-sanitizer --tool memcheck --error-exitcode 99 python <all-paths driver>
```
`test_avg_pool3d_backward_uniform_divisor` pins every path (atomic and direct-write, uniform and non-uniform including `ceil_mode` + `count_include_pad=False`, `divisor_override`, stride-1) against a CPU float64 oracle across {half, bfloat16, float, double}. memcheck reports 0 errors.
