### PR TITLE
Decouple _get_available_device_type/_get_device_attr from hardcoded device chains

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,12 +14,13 @@ import types
 import unittest
 import warnings
 from typing import Any, cast
+from unittest import mock
 
 import torch
 import torch.nn as nn
 import torch.utils.cpp_extension
 import torch.utils.data
-from torch._utils import try_import
+from torch._utils import _get_available_device_type, try_import
 from torch._utils_internal import deprecated
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
@@ -958,6 +959,49 @@ class TestDeviceUtils(TestCase):
 
 
 instantiate_device_type_tests(TestDeviceUtils, globals())
+
+
+class TestGetAvailableDeviceType(TestCase):
+    # current_accelerator() always prefers a *registered* PrivateUse1 backend
+    # over a compiled-in one, even when that PrivateUse1 backend isn't itself
+    # available, which can otherwise mask a different, real accelerator that
+    # is available. See torch/_utils.py::_get_available_device_type.
+    def test_privateuse1_unavailable_falls_back_to_real_accelerator(self):
+        fake_npu = types.ModuleType("torch.npu")
+        setattr(fake_npu, "is_available", lambda: False)  # noqa: B010
+        with (
+            mock.patch.object(torch, "npu", fake_npu, create=True),
+            mock.patch.object(
+                torch._C, "_get_privateuse1_backend_name", return_value="npu"
+            ),
+            mock.patch("torch.accelerator.current_accelerator", return_value=None),
+            mock.patch.object(torch.mps, "is_available", return_value=True),
+        ):
+            self.assertEqual(_get_available_device_type(), "mps")
+
+    def test_privateuse1_unavailable_and_no_real_accelerator_returns_none(self):
+        fake_npu = types.ModuleType("torch.npu")
+        setattr(fake_npu, "is_available", lambda: False)  # noqa: B010
+        with (
+            mock.patch.object(torch, "npu", fake_npu, create=True),
+            mock.patch.object(
+                torch._C, "_get_privateuse1_backend_name", return_value="npu"
+            ),
+            mock.patch("torch.accelerator.current_accelerator", return_value=None),
+            mock.patch.object(torch.mps, "is_available", return_value=False),
+        ):
+            self.assertIsNone(_get_available_device_type())
+
+    def test_no_privateuse1_backend_registered_returns_none_directly(self):
+        with (
+            mock.patch.object(
+                torch._C,
+                "_get_privateuse1_backend_name",
+                return_value="privateuseone",
+            ),
+            mock.patch("torch.accelerator.current_accelerator", return_value=None),
+        ):
+            self.assertIsNone(_get_available_device_type())
 
 
 class TestCppExtensionUtils(TestCase):

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -819,6 +819,20 @@ def cpu_count() -> int | None:
 def _get_available_device_type():
     if (acc := torch.accelerator.current_accelerator(check_available=True)) is not None:
         return acc.type
+    # current_accelerator() always prefers a *registered* PrivateUse1 backend over a
+    # compiled-in one, even when that PrivateUse1 backend isn't actually available
+    # (deliberate, to support test builds that register a PrivateUse1 test backend
+    # alongside a real accelerator -- see aten/src/ATen/DeviceAccelerator.cpp). That
+    # can mask a different, real accelerator that IS available. Retry, checking only
+    # the fixed, PyTorch-core-maintained set of compiled-in accelerators directly:
+    # unlike PrivateUse1, new hardware vendors never extend this list, they register
+    # as PrivateUse1 instead, so this doesn't reintroduce the per-vendor maintenance
+    # burden the generic current_accelerator() call above already eliminates.
+    if torch._C._get_privateuse1_backend_name() != "privateuseone":
+        for device_type in ("cuda", "xpu", "mps", "mtia"):
+            module = getattr(torch, device_type, None)
+            if module is not None and module.is_available():
+                return device_type
     return None
 
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -817,36 +817,16 @@ def cpu_count() -> int | None:
 
 
 def _get_available_device_type():
-    if torch.cuda.is_available():
-        return "cuda"
-    if torch.backends.mps.is_available():
-        return "mps"
-    if hasattr(torch, "xpu") and torch.xpu.is_available():  # type: ignore[attr-defined]
-        return "xpu"
-    if hasattr(torch, "mtia") and torch.mtia.is_available():
-        return "mtia"
-    custom_backend_name = torch._C._get_privateuse1_backend_name()
-    custom_device_mod = getattr(torch, custom_backend_name, None)
-    if custom_device_mod and custom_device_mod.is_available():
-        return custom_backend_name
-    # add more available device types here
+    if (acc := torch.accelerator.current_accelerator(check_available=True)) is not None:
+        return acc.type
     return None
 
 
 def _get_device_attr(get_member):
     device_type = _get_available_device_type()
-    if device_type and device_type.lower() == "cuda":
-        return get_member(torch.cuda)
-    if device_type and device_type.lower() == "mps":
-        return get_member(torch.mps)
-    if device_type and device_type.lower() == "xpu":
-        return get_member(torch.xpu)  # type: ignore[attr-defined]
-    if device_type and device_type.lower() == "mtia":
-        return get_member(torch.mtia)
-    if device_type == torch._C._get_privateuse1_backend_name():
-        return get_member(getattr(torch, device_type))
-    # add more available device types here
-    return None
+    if not device_type:
+        return None
+    return get_member(_get_device_module(device_type))
 
 
 def _get_current_device_index():


### PR DESCRIPTION
## Summary

`_get_available_device_type()` and `_get_device_attr()` in `torch/_utils.py`
manually reimplemented a priority-ordered device-detection chain
(`cuda > mps > xpu > mtia > privateuse1`) and a matching if/elif dispatch to
pick the right `torch.<device>` module, duplicating a literal "add more
available device types here" comment inviting further hardcoding for every
new backend.

Both already have a generic equivalent elsewhere in the codebase:
`torch.accelerator.current_accelerator()` does the same priority-ordered
detection centrally, in C++ (`aten/src/ATen/DeviceAccelerator.cpp`), and this
same file already defines `_get_device_module()` for generic module lookup by
device type string. Replaced both hardcoded chains with those two existing
primitives.

Part of the device-decoupling initiative proposed in #194355.

## A real gap this surfaced, and how it's handled

Swapping in `current_accelerator()` isn't a pure refactor: its C++
implementation checks PrivateUse1 first, unconditionally, whenever one is
*registered* -- not merely *available* -- deliberately, to support test
builds that register a PrivateUse1 test backend alongside a real accelerator.

That matters here because `current_accelerator(check_available=True)`
re-resolves through that same PrivateUse1-first call for its own
availability check. So in a process with a real accelerator (e.g. CUDA)
actually available *and* a PrivateUse1 backend registered but not currently
usable, a naive swap would make `_get_available_device_type()` return `None`
entirely, instead of falling through to CUDA -- silently reporting no
accelerator when one was working fine. This function has real callers
(`torch.nn.parallel.data_parallel.DataParallel`,
`torch.distributed.checkpoint.filesystem`), so this isn't a theoretical edge
case.

Fix: a narrow fallback -- when `current_accelerator()` comes back empty and a
PrivateUse1 backend is registered, check the fixed, PyTorch-core-maintained
set of compiled-in accelerators (`cuda`/`xpu`/`mps`/`mtia`) directly via their
own `is_available()`. Unlike PrivateUse1, new hardware vendors never extend
this list -- they register as PrivateUse1 instead -- so this doesn't
reintroduce the per-vendor maintenance burden the generic
`current_accelerator()` call above already eliminates.

## Test Plan

    python test/test_utils.py TestGetAvailableDeviceType -v

Three new tests cover: PrivateUse1 registered-but-unavailable falling back to
a real available accelerator (the bug case), PrivateUse1
registered-but-unavailable with no real accelerator available either
(correctly `None`), and no PrivateUse1 backend registered at all (unaffected).

    python -c "
    import torch
    from torch._utils import _get_available_device_type
    print(_get_available_device_type())
    "
    # -> mps (matches prior behavior on this machine; common case unaffected)

Ran `lintrunner` on `torch/_utils.py` and `test/test_utils.py` -- no issues.