### PR TITLE
[inductor] Add a non-overlapping fast path for max_pool2d backward.

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -13141,6 +13141,7 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 a, b, [3, 3], [2, 2], [1, 1], [1, 1], True, c
             )
 
+        torch._inductor.metrics.generated_kernel_count = 0
         x = torch.randn([2, 4, 40, 56])
         result, indices = aten.max_pool2d_with_indices(
             x,
@@ -13159,6 +13160,10 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 indices,
             ],
         )
+        if self.device == "xpu":
+            assertGeneratedKernelCountEqual(self, 0)
+        else:
+            assertGeneratedKernelCountGreater(self, 0)
 
     # From https://github.com/pytorch/torchdynamo/issues/1200
     def test_max_pool2d_with_indices_backward3(self):
@@ -13184,6 +13189,61 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 indices,
             ],
         )
+
+    @parametrize(
+        "shape,kernel_size,stride,padding,dilation,ceil_mode",
+        [
+            subtest(
+                ((2, 4, 5, 7), [2, 2], [2, 2], [0, 0], [1, 1], False),
+                name="nondivisible",
+            ),
+            subtest(
+                ((2, 4, 10, 11), [2, 2], [3, 3], [0, 0], [1, 1], False),
+                name="stride_gap",
+            ),
+            subtest(
+                ((2, 4, 6, 6), [2], [2], [0], [1], False),
+                name="single_value_args",
+            ),
+            subtest(
+                ((4, 5, 1), [2, 1], [2, 1], [0, 0], [1, 1], False),
+                name="unbatched_width_one",
+            ),
+            subtest(
+                ((2, 4, 5, 7), [2, 2], [2, 2], [0, 0], [1, 1], True),
+                name="ceil_mode_partial_window",
+            ),
+            subtest(
+                ((2, 4, 7, 10), [2, 2], [3, 3], [0, 0], [1, 1], True),
+                name="ceil_mode_stride_gap",
+            ),
+        ],
+    )
+    def test_max_pool2d_with_indices_backward_nonoverlap_edge_cases(
+        self, shape, kernel_size, stride, padding, dilation, ceil_mode
+    ):
+        def fn(a, b, c):
+            return aten.max_pool2d_with_indices_backward(
+                a,
+                b,
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                c,
+            )
+
+        x = torch.randn(shape)
+        result, indices = aten.max_pool2d_with_indices(
+            x,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            ceil_mode,
+        )
+        self.common(fn, [torch.randn_like(result), x, indices])
 
     # From https://github.com/pytorch/torchdynamo/issues/1352
     @xfail_if_mps  # Small tolerances bug
@@ -13281,21 +13341,38 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         if self.device != "mps" and self.device != "xpu":
             self.assertGreater(torch._inductor.metrics.generated_kernel_count, 0)
 
-    def test_max_pool2d_with_indices_backward_fallback(self):
+    @parametrize(
+        "kernel_size,ceil_mode",
+        [
+            subtest(([2, 2], False), name="two_by_two"),
+            subtest(([2, 2], True), name="ceil_mode"),
+            subtest(([5, 5], False), name="five_by_five"),
+        ],
+    )
+    def test_max_pool2d_with_indices_backward_nonoverlap_codegen(
+        self, kernel_size, ceil_mode
+    ):
         def fn(a, b, c):
             return aten.max_pool2d_with_indices_backward(
-                a, b, [2, 2], [2, 2], [0, 0], [1, 1], False, c
+                a,
+                b,
+                kernel_size,
+                kernel_size,
+                [0, 0],
+                [1, 1],
+                ceil_mode,
+                c,
             )
 
         torch._inductor.metrics.generated_kernel_count = 0
-        x = torch.randn([2, 4, 18, 14])
+        x = torch.randn([2, 4, 21, 23]).contiguous(memory_format=torch.channels_last)
         result, indices = aten.max_pool2d_with_indices(
             x,
-            [2, 2],
-            [2, 2],
+            kernel_size,
+            kernel_size,
             [0, 0],
             [1, 1],
-            False,
+            ceil_mode,
         )
         self.common(
             fn,
@@ -13305,10 +13382,36 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                 indices,
             ],
         )
-        if self.device == "xpu":
-            assertGeneratedKernelCountEqual(self, 0)
-        else:
-            assertGeneratedKernelCountGreater(self, 0)
+        assertGeneratedKernelCountGreater(self, 0)
+
+        if self.device in ("cuda", "xpu"):
+            x = x.to(self.device, dtype=torch.float16)
+            result, indices = aten.max_pool2d_with_indices(
+                x,
+                kernel_size,
+                kernel_size,
+                [0, 0],
+                [1, 1],
+                ceil_mode,
+            )
+            grad_output = torch.randn_like(result)
+            compiled = torch.compile(fn, fullgraph=True)
+            actual, codes = run_and_get_code(
+                compiled,
+                grad_output,
+                x,
+                indices,
+            )
+            self.assertEqual(
+                actual,
+                fn(grad_output, x, indices),
+                exact_stride=True,
+            )
+            source = "\n".join(codes)
+            FileCheck().check(
+                "triton_poi_fused_max_pool2d_with_indices_backward"
+            ).check("tl.store(").run(source)
+            FileCheck().check_not("tl.atomic_add(").run(source)
 
     def test_issue102546(self):
         def fn(x):

--- a/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_codegen_dynamic_shapes.py
@@ -233,17 +233,12 @@ test_failures = {
         ("cpu", "cuda", "xpu")
     ),
     "test_adaptive_max_pool2d2_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
-    # XPU falls back max_pool2d_with_indices_backward to ATen eager (see
-    # torch/_decomp/decompositions.py), so no Triton kernel is generated.
-    "test_max_pool2d_with_indices_backward_dynamic_shapes": TestFailure(("xpu",)),
+    # Unsupported XPU configurations still fall back to ATen eager, so no
+    # Triton kernel is generated.
     "test_max_pool2d_with_indices_backward2_dynamic_shapes": TestFailure(("xpu",)),
-    "test_max_pool2d_with_indices_backward3_dynamic_shapes": TestFailure(("xpu",)),
     "test_max_pool2d_with_indices_backward4_dynamic_shapes": TestFailure(("xpu",)),
     "test_max_pool2d_with_indices_backward5_dynamic_shapes": TestFailure(("xpu",)),
     "test_max_pool2d_with_indices_backward6_dynamic_shapes": TestFailure(("xpu",)),
-    "test_max_pool2d_with_indices_backward_fallback_dynamic_shapes": TestFailure(
-        ("xpu",)
-    ),
     "test_argmax_to_float_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_avg_pool2d7_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),
     "test_avg_pool2d_backward4_dynamic_shapes": TestFailure(("cpu", "cuda", "xpu")),

--- a/test/test_decomp.py
+++ b/test/test_decomp.py
@@ -34,9 +34,11 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_modules import module_db, modules
 from torch.testing._internal.common_utils import (
     is_iterable_of_tensors,
+    parametrize,
     run_tests,
     skipIfCrossRef,
     skipIfTorchDynamo,
+    subtest,
     suppress_warnings,
     TEST_WITH_ASAN,
     TEST_WITH_SLOW,
@@ -646,6 +648,108 @@ class TestDecomp(TestCase):
         res = hann_window_periodic(8, dtype=torch.float64, device=device)
         self.assertEqual(ref, res)
         self.assertEqual(res.dtype, torch.float64)
+
+    @onlyCPU
+    @parametrize(
+        "kernel_size,stride,ceil_mode,expect_scatter",
+        [
+            subtest(([2, 2], [2, 2], False, False), name="two_by_two"),
+            subtest(([2, 2], [2, 2], True, False), name="ceil_mode"),
+            subtest(([2, 2], [3, 3], False, False), name="stride_gap"),
+            subtest(([5, 5], [5, 5], False, False), name="five_by_five"),
+            subtest(([2, 13], [2, 13], False, False), name="larger_than_25_area"),
+            subtest(([2, 2], [1, 1], False, True), name="overlap"),
+        ],
+    )
+    def test_max_pool2d_backward_nonoverlap_decomp(
+        self, device, kernel_size, stride, ceil_mode, expect_scatter
+    ):
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        decomp = get_decompositions([aten.max_pool2d_with_indices_backward])[
+            aten.max_pool2d_with_indices_backward.default
+        ]
+        x = torch.randn(2, 4, 15, 16, device=device).contiguous(
+            memory_format=torch.channels_last
+        )
+        result, indices = aten.max_pool2d_with_indices(
+            x,
+            kernel_size,
+            stride,
+            [0, 0],
+            [1, 1],
+            ceil_mode,
+        )
+        grad_output = torch.randn_like(result)
+        graph = make_fx(
+            lambda grad, inp, ind: decomp(
+                grad,
+                inp,
+                kernel_size,
+                stride,
+                [0, 0],
+                [1, 1],
+                ceil_mode,
+                ind,
+            )
+        )(grad_output, x, indices)
+        targets = {node.target for node in graph.graph.nodes}
+
+        self.assertEqual(
+            aten.scatter_add.default in targets,
+            expect_scatter,
+        )
+        self.assertEqual(
+            graph(grad_output, x, indices),
+            aten.max_pool2d_with_indices_backward(
+                grad_output,
+                x,
+                kernel_size,
+                stride,
+                [0, 0],
+                [1, 1],
+                ceil_mode,
+                indices,
+            ),
+            exact_stride=True,
+        )
+
+    @onlyCPU
+    def test_max_pool2d_backward_nonoverlap_decomp_symbolic(self, device):
+        from torch.fx.experimental.proxy_tensor import make_fx
+
+        kernel_size = [2, 2]
+        decomp = get_decompositions([aten.max_pool2d_with_indices_backward])[
+            aten.max_pool2d_with_indices_backward.default
+        ]
+
+        def fn(grad_output, x, indices):
+            return decomp(
+                grad_output,
+                x,
+                kernel_size,
+                kernel_size,
+                [0, 0],
+                [1, 1],
+                True,
+                indices,
+            )
+
+        def inputs(shape):
+            x = torch.randn(shape, device=device)
+            result, indices = aten.max_pool2d_with_indices(
+                x,
+                kernel_size,
+                kernel_size,
+                [0, 0],
+                [1, 1],
+                True,
+            )
+            return torch.randn_like(result), x, indices
+
+        graph = make_fx(fn, tracing_mode="symbolic")(*inputs((2, 4, 15, 16)))
+        args = inputs((3, 4, 17, 19))
+        self.assertEqual(graph(*args), fn(*args), exact_stride=True)
 
     def test_uniform(self, device):
         size = (2, 3, 4, 5)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -6144,14 +6144,6 @@ def max_pool2d_with_indices_backward(
         and all(s >= k for s, k in zip(stride, kernel_size))
     )
     if nonoverlap:
-        # Add a temporary batch dim for unbatched (3D) inputs so the 4D-style
-        # indexing below works uniformly.
-        unbatched = self.dim() == 3
-        if unbatched:
-            self = self.unsqueeze(0)
-            grad_output = grad_output.unsqueeze(0)
-            indices = indices.unsqueeze(0)
-
         in_height, in_width = self.shape[-2:]
         out_height, out_width = grad_output.shape[-2:]
         h = torch.arange(in_height, device=self.device)
@@ -6165,20 +6157,17 @@ def max_pool2d_with_indices_backward(
 
         # indices is produced by max_pool2d_with_indices with the same parameters.
         # With non-overlapping windows, an input can belong to at most one output.
-        selected_indices = indices[:, :, ph][:, :, :, pw]
-        selected_grads = grad_output[:, :, ph][:, :, :, pw]
+        # Index the trailing H/W dims via Ellipsis so this handles both the
+        # unbatched (C, H, W) and batched (N, C, H, W) layouts.
+        selected_indices = indices[..., ph, :][..., pw]
+        selected_grads = grad_output[..., ph, :][..., pw]
         input_indices = h[:, None] * in_width + w[None, :]
         grad_input = torch.where(
             valid_h[:, None] & valid_w[None, :] & (selected_indices == input_indices),
             selected_grads,
             0,
         )
-        grad_input = grad_input.contiguous(
-            memory_format=utils.suggest_memory_format(self)
-        )
-        if unbatched:
-            grad_input = grad_input.squeeze(0)
-        return grad_input
+        return grad_input.contiguous(memory_format=utils.suggest_memory_format(self))
 
     if grad_output.is_xpu:
         return NotImplemented

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -6113,9 +6113,6 @@ def max_pool2d_with_indices_backward(
     Returns:
         Gradient w.r.t. input [B, C, H_in, W_in]
     """
-    # Use native kernel in deterministic mode
-    if torch.are_deterministic_algorithms_enabled():
-        return NotImplemented
 
     if not stride:
         stride = kernel_size
@@ -6163,6 +6160,9 @@ def max_pool2d_with_indices_backward(
             0,
         )
         return grad_input.contiguous(memory_format=utils.suggest_memory_format(self))
+    # Use native kernel in deterministic mode
+    if torch.are_deterministic_algorithms_enabled():
+        return NotImplemented
 
     if grad_output.is_xpu:
         return NotImplemented

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -6117,12 +6117,57 @@ def max_pool2d_with_indices_backward(
     if torch.are_deterministic_algorithms_enabled():
         return NotImplemented
 
-    if grad_output.is_xpu:
-        return NotImplemented
-
     # MPS: Use native kernel. scatter_add has correctness issues on macOS 14
     # (#163327) and numerical differences on macOS 15+.
     if grad_output.device.type == "mps":
+        return NotImplemented
+
+    if not stride:
+        stride = kernel_size
+
+    def to_pair(value):
+        if isinstance(value, IntLike):
+            return [value, value]
+        if len(value) == 1:
+            return [value[0], value[0]]
+        return list(value)
+
+    kernel_size = to_pair(kernel_size)
+    stride = to_pair(stride)
+    padding = to_pair(padding)
+    dilation = to_pair(dilation)
+
+    nonoverlap = (
+        self.dim() == 4
+        and all(p == 0 for p in padding)
+        and all(d == 1 for d in dilation)
+        and all(s >= k for s, k in zip(stride, kernel_size))
+    )
+    if nonoverlap:
+        in_height, in_width = self.shape[-2:]
+        out_height, out_width = grad_output.shape[-2:]
+        h = torch.arange(in_height, device=self.device)
+        w = torch.arange(in_width, device=self.device)
+        ph = h // stride[0]
+        pw = w // stride[1]
+        valid_h = (ph < out_height) & (h < ph * stride[0] + kernel_size[0])
+        valid_w = (pw < out_width) & (w < pw * stride[1] + kernel_size[1])
+        ph = ph.clamp(0, out_height - 1)
+        pw = pw.clamp(0, out_width - 1)
+
+        # indices is produced by max_pool2d_with_indices with the same parameters.
+        # With non-overlapping windows, an input can belong to at most one output.
+        selected_indices = indices[:, :, ph][:, :, :, pw]
+        selected_grads = grad_output[:, :, ph][:, :, :, pw]
+        input_indices = h[:, None] * in_width + w[None, :]
+        grad_input = torch.where(
+            valid_h[:, None] & valid_w[None, :] & (selected_indices == input_indices),
+            selected_grads,
+            0,
+        )
+        return grad_input.contiguous(memory_format=utils.suggest_memory_format(self))
+
+    if grad_output.is_xpu:
         return NotImplemented
 
     # Get spatial dimensions

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -6138,12 +6138,20 @@ def max_pool2d_with_indices_backward(
     dilation = to_pair(dilation)
 
     nonoverlap = (
-        self.dim() == 4
+        self.dim() in (3, 4)
         and all(p == 0 for p in padding)
         and all(d == 1 for d in dilation)
         and all(s >= k for s, k in zip(stride, kernel_size))
     )
     if nonoverlap:
+        # Add a temporary batch dim for unbatched (3D) inputs so the 4D-style
+        # indexing below works uniformly.
+        unbatched = self.dim() == 3
+        if unbatched:
+            self = self.unsqueeze(0)
+            grad_output = grad_output.unsqueeze(0)
+            indices = indices.unsqueeze(0)
+
         in_height, in_width = self.shape[-2:]
         out_height, out_width = grad_output.shape[-2:]
         h = torch.arange(in_height, device=self.device)
@@ -6165,7 +6173,12 @@ def max_pool2d_with_indices_backward(
             selected_grads,
             0,
         )
-        return grad_input.contiguous(memory_format=utils.suggest_memory_format(self))
+        grad_input = grad_input.contiguous(
+            memory_format=utils.suggest_memory_format(self)
+        )
+        if unbatched:
+            grad_input = grad_input.squeeze(0)
+        return grad_input
 
     if grad_output.is_xpu:
         return NotImplemented

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -6117,11 +6117,6 @@ def max_pool2d_with_indices_backward(
     if torch.are_deterministic_algorithms_enabled():
         return NotImplemented
 
-    # MPS: Use native kernel. scatter_add has correctness issues on macOS 14
-    # (#163327) and numerical differences on macOS 15+.
-    if grad_output.device.type == "mps":
-        return NotImplemented
-
     if not stride:
         stride = kernel_size
 
@@ -6170,6 +6165,11 @@ def max_pool2d_with_indices_backward(
         return grad_input.contiguous(memory_format=utils.suggest_memory_format(self))
 
     if grad_output.is_xpu:
+        return NotImplemented
+
+    # MPS: Use native kernel. scatter_add has correctness issues on macOS 14
+    # (#163327) and numerical differences on macOS 15+.
+    if grad_output.device.type == "mps":
         return NotImplemented
 
     # Get spatial dimensions


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/195123
## Summary
This PR adds an fast path to the global `max_pool2d_with_indices_backward` decomposition for non-overlapping pooling windows.

The existing decomposition always flattens `grad_output` and uses `scatter_add` to accumulate it into `grad_input`. That is required for overlapping windows, but it is redundant when every input position belongs to at most one output window.

For every input coordinate `(h, w)`, the fast path computes its only possible
output coordinate:

~~~text
ph = h // stride_h
pw = w // stride_w
~~~

It gathers the saved forward index and output gradient for `(ph, pw)`:

~~~python
selected_indices = indices[:, :, ph][:, :, :, pw]
selected_grads = grad_output[:, :, ph][:, :, :, pw]
~~~

The input gradient is then constructed with:

~~~python
torch.where(
    valid_h
    & valid_w
    & (selected_indices == input_indices),
    selected_grads,
    0,
)
~~~

## Decomposition and fallback behavior

- The fast path is implemented in the global decomposition rather than in an Inductor-specific lowering.

- For XPU, eligible non-overlapping configurations enter the decomposition before the existing XPU `NotImplemented` guard. Other XPU configurations continueusing the existing native fallback.

- The deterministic and MPS fallback behavior is unchanged.
## Graph Diff
use producer discussed in issue. Tested on nvidia 4080Super GPU.

Before
```
    def call(self, args):
        getitem_1, tangents_1 = args
        args.clear()
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            buf0 = empty_strided_cuda((512, 50176), (50176, 1), torch.float32)
            # Topologically Sorted Source Nodes: [clone, view, max_pool2d, clone_1, view_1, full_default, scatter_add], Original ATen: [aten.max_pool2d_with_indices_backward, aten.max_pool2d_with_indices]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_max_pool2d_with_indices_max_pool2d_with_indices_backward_0.run(buf0, 25690112, stream=raw_stream0)
            assert_size_stride_grouped((getitem_1, tangents_1), ((8, 64, 112, 112), (8, 64, 112, 112)), ((802816, 1, 7168, 64), (802816, 1, 7168, 64)), 'input')
            tangents_1 = copy_if_misaligned(tangents_1)
            # Topologically Sorted Source Nodes: [clone, view, max_pool2d, clone_1, view_1, full_default, scatter_add], Original ATen: [aten.max_pool2d_with_indices_backward, aten.max_pool2d_with_indices]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_max_pool2d_with_indices_max_pool2d_with_indices_backward_1.run(getitem_1, tangents_1, buf0, 6422528, stream=raw_stream0)
            del getitem_1
            del tangents_1
            buf2 = empty_strided_cuda((8, 64, 224, 224), (3211264, 1, 14336, 64), torch.float32)
            # Topologically Sorted Source Nodes: [view_2, clone_2], Original ATen: [aten.max_pool2d_with_indices_backward]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_max_pool2d_with_indices_backward_2.run(buf0, buf2, 512, 50176, stream=raw_stream0)
            del buf0
        return (buf2, )
```

After
```
    def call(self, args):
        getitem_1, tangents_1 = args
        args.clear()
        assert_size_stride_grouped((getitem_1, tangents_1), ((8, 64, 112, 112), (8, 64, 112, 112)), ((802816, 1, 7168, 64), (802816, 1, 7168, 64)), 'input')
        with torch.cuda._DeviceGuard(0):
            torch.cuda.set_device(0)
            tangents_1 = copy_if_misaligned(tangents_1)
            buf1 = empty_strided_cuda((8, 64, 224, 224), (3211264, 1, 14336, 64), torch.float32)
            # Topologically Sorted Source Nodes: [iota, div, clamp_min, clamp_max, index_2, index_3, unsqueeze, mul_2, unsqueeze_1, add_2, lt, mul, add, lt_1, bitwise_and, unsqueeze_2, unsqueeze_3, bitwise_and_2, max_pool2d, index, index_1, eq, bitwise_and_3, full_default, where, clone], Original ATen: [aten.max_pool2d_with_indices_backward, aten.max_pool2d_with_indices]
            raw_stream0 = get_raw_stream(0)
            triton_poi_fused_max_pool2d_with_indices_max_pool2d_with_indices_backward_0.run(getitem_1, tangents_1, buf1, 512, 50176, stream=raw_stream0)
            del getitem_1
            del tangents_1
        return (buf1, )
```

## Performance
use producer discussed in issue. Tested on nvidia 4080Super GPU.
### Before this PR
Main Kernel 1 of 3 maxpool bwd Kernels. 
Performance of dumped triton kernel:
```
0.494ms    0.058GB    117.11GB/s
```
```
@triton.jit
def triton_(in_ptr0, in_ptr1, out_ptr0, xnumel, XBLOCK : tl.constexpr):
xnumel = 6422528
xoffset = tl.program_id(0) * XBLOCK
xindex = xoffset + tl.arange(0, XBLOCK)[:]
xmask = tl.full([XBLOCK], True, tl.int1)[:]
x0 = (xindex % 512)
x1 = xindex // 512
tmp0 = tl.load(in_ptr0 + (64x1 + 802816(x0 // 64) + ((x0 % 64))), None)
tmp6 = tl.load(in_ptr1 + (64x1 + 802816(x0 // 64) + ((x0 % 64))), None)
tmp1 = (tl.full([XBLOCK], 4, tl.int32)).to(tl.int32)
tmp2 = tmp0 + tmp1
tmp3 = tmp0 < 0
tmp4 = tl.where(tmp3, tmp2, tmp0)
tl.device_assert((0 <= tmp4) & (tmp4 < 4), "index out of bounds: 0 <= tmp4 < 4")
tl.atomic_add(out_ptr0 + (tmp4 + 2*((x1 % 112)) + 222*(tmp4 // 2) + 448*(x1 // 112) + 50176*x0), tmp6, None, sem='relaxed')
```
2. After Single maxpool bwd kernels
performance of the only 1 generated kernel
```
0.211ms    0.135GB    639.38GB/s
```
```
@triton.jit
def triton_(in_ptr0, in_ptr1, out_ptr1, ynumel, xnumel, YBLOCK : tl.constexpr, XBLOCK : tl.constexpr):
ynumel = 512
xnumel = 50176
yoffset = tl.program_id(1) * YBLOCK
yindex = yoffset + tl.arange(0, YBLOCK)[:, None]
ymask = yindex < ynumel
xoffset = tl.program_id(0) * XBLOCK
xindex = xoffset + tl.arange(0, XBLOCK)[None, :]
xmask = xindex < xnumel
x3 = xindex // 224
x2 = (xindex % 224)
y0 = (yindex % 64)
y1 = yindex // 64
x4 = xindex
y5 = yindex
tmp20 = tl.load(in_ptr0 + (y0 + 64*((111) * ((111) <= (x2 // 2)) + (x2 // 2) * ((x2 // 2) < (111))) + 7168*((111) * ((111) <= (x3 // 2)) + (x3 // 2) * ((x3 // 2) < (111))) + 802816y1), xmask & ymask)
tmp32 = tl.load(in_ptr1 + (y0 + 64((111) * ((111) <= (x2 // 2)) + (x2 // 2) * ((x2 // 2) < (111))) + 7168*((111) * ((111) <= (x3 // 2)) + (x3 // 2) * ((x3 // 2) < (111))) + 802816y1), xmask & ymask)
tmp0 = (x3 // 2).to(tl.int64)
tmp1 = (tmp0).to(tl.int64)
tmp2 = tl.full([1, 1], 112, tl.int64)
tmp3 = tmp1 < tmp2
tmp4 = (x3).to(tl.int64)
tmp5 = (tmp4).to(tl.int64)
tmp6 = (2 + 2(x3 // 2)).to(tl.int64)
tmp7 = (tmp6).to(tl.int64)
tmp8 = tmp5 < tmp7
tmp9 = tmp3 & tmp8
tmp10 = (x2 // 2).to(tl.int64)
tmp11 = (tmp10).to(tl.int64)
tmp12 = tmp11 < tmp2
tmp13 = (x2).to(tl.int64)
tmp14 = (tmp13).to(tl.int64)
tmp15 = (2 + 2*(x2 // 2)).to(tl.int64)
tmp16 = (tmp15).to(tl.int64)
tmp17 = tmp14 < tmp16
tmp18 = tmp12 & tmp17
tmp19 = tmp9 & tmp18
tmp21 = (tl.full([1, 1], 4, tl.int32)).to(tl.int32)
tmp22 = tmp20 + tmp21
tmp23 = tmp20 < 0
tmp24 = tl.where(tmp23, tmp22, tmp20)
tl.device_assert(((0 <= tmp24) & (tmp24 < 4)) | ~(xmask & ymask), "index out of bounds: 0 <= tmp24 < 4")
tmp26 = (tmp24 + 2*((111) * ((111) <= (x2 // 2)) + (x2 // 2) * ((x2 // 2) < (111))) + 222*(tmp24 // 2) + 448*((111) * ((111) <= (x3 // 2)) + (x3 // 2) * ((x3 // 2) < (111)))).to(tl.int64)
tmp27 = (tmp26).to(tl.int64)
tmp28 = (x4).to(tl.int64)
tmp29 = (tmp28).to(tl.int64)
tmp30 = tmp27 == tmp29
tmp31 = tmp19 & tmp30
tmp33 = tl.full([1, 1], 0.0, tl.float32)
tmp34 = tl.where(tmp31, tmp32, tmp33)
tl.store(out_ptr1 + (y0 + 64x4 + 3211264y1), tmp34, xmask & ymask)
```


cc @frank-wei @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey