### PR TITLE
[Testcase Refactoring][DTensor] Classify micro-pipeline TP tests by hardware

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -66,18 +66,14 @@ def _fp8_all_gather(
     return torch.cat(chunks, dim=gather_dim).view(tensor.dtype)
 
 
-class MicroPipelineTPTest(TestCase):
-    hw_classification = HardwareClassification.CUDA
+class MicroPipelineTPPatternTest(TestCase):
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
-        torch._inductor.config._micro_pipeline_tp = True
 
         self.rank = 0
         self.world_size = 2
-        torch.get_device_module(type(self).device_type).set_device(
-            type(self).get_primary_device()
-        )
 
         store = FakeStore()
         dist.init_process_group(
@@ -90,9 +86,8 @@ class MicroPipelineTPTest(TestCase):
     def tearDown(self):
         dist.destroy_process_group()
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_find_all_gather_patterns(self, device):
+    def test_find_all_gather_patterns(self):
         group = dist.group.WORLD
 
         def func(
@@ -122,7 +117,7 @@ class MicroPipelineTPTest(TestCase):
             f = f_cat.narrow(1, 0, 32)
             return a, b, c, d, e, f
 
-        inp = torch.rand(64, 32, device=device)
+        inp = torch.rand(64, 32)
 
         gm = _make_post_grad_fx(func, inp)
         all_gathers = find_all_gather_patterns(gm.graph)
@@ -173,9 +168,8 @@ class MicroPipelineTPTest(TestCase):
             torch.ops.aten.slice.Tensor,
         )
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_find_reduce_scatter_patterns(self, device):
+    def test_find_reduce_scatter_patterns(self):
         group = dist.group.WORLD
 
         def func(
@@ -192,7 +186,7 @@ class MicroPipelineTPTest(TestCase):
             )
             return a, b, c
 
-        inp = torch.rand(64, 32, device=device)
+        inp = torch.rand(64, 32)
 
         gm = make_fx(func)(inp)
         reduce_scatters = find_reduce_scatter_patterns(gm.graph)
@@ -223,9 +217,8 @@ class MicroPipelineTPTest(TestCase):
         self.assertEqual(reduce_scatters[1].reduce_op, "avg")
         self.assertEqual(reduce_scatters[1].scatter_dim, 1)
 
-    @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_get_unexposed_collectives(self, device):
+    def test_get_unexposed_collectives(self):
         group = dist.group.WORLD
 
         def func(inp: torch.Tensor) -> torch.Tensor:
@@ -239,7 +232,7 @@ class MicroPipelineTPTest(TestCase):
             e = all_gather_single(d, gather_dim=0, group=group.group_name)
             return a, c, e
 
-        inp = torch.rand(64, 32, device=device)
+        inp = torch.rand(64, 32)
 
         gm = make_fx(func)(inp)
         overlappable_collectives = _get_unexposed_collectives(gm.graph)
@@ -247,6 +240,31 @@ class MicroPipelineTPTest(TestCase):
             list(map(str, overlappable_collectives)),
             ["all_gather_into_tensor", "reduce_scatter_tensor"],
         )
+
+
+class MicroPipelineTPTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def setUp(self):
+        super().setUp()
+        torch._inductor.config._micro_pipeline_tp = True
+
+        self.rank = 0
+        self.world_size = 2
+        torch.get_device_module(type(self).device_type).set_device(
+            type(self).get_primary_device()
+        )
+
+        store = FakeStore()
+        dist.init_process_group(
+            backend="fake",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+
+    def tearDown(self):
+        dist.destroy_process_group()
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @parametrize("A_dims", [2, 3])

--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -28,9 +28,12 @@ from torch.distributed.tensor.parallel import (
     RowwiseParallel,
 )
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
-from torch.testing._internal.common_device_type import e4m3_type
+from torch.testing._internal.common_device_type import (
+    e4m3_type,
+    instantiate_device_type_tests,
+)
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
-    instantiate_parametrized_tests,
+    HardwareClassification,
     IS_LINUX,
     parametrize,
     run_tests,
@@ -63,15 +66,18 @@ def _fp8_all_gather(
     return torch.cat(chunks, dim=gather_dim).view(tensor.dtype)
 
 
-@instantiate_parametrized_tests
 class MicroPipelineTPTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         torch._inductor.config._micro_pipeline_tp = True
 
         self.rank = 0
         self.world_size = 2
-        torch.cuda.set_device("cuda:0")
+        torch.get_device_module(type(self).device_type).set_device(
+            type(self).get_primary_device()
+        )
 
         store = FakeStore()
         dist.init_process_group(
@@ -86,7 +92,7 @@ class MicroPipelineTPTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_find_all_gather_patterns(self):
+    def test_find_all_gather_patterns(self, device):
         group = dist.group.WORLD
 
         def func(
@@ -116,7 +122,7 @@ class MicroPipelineTPTest(TestCase):
             f = f_cat.narrow(1, 0, 32)
             return a, b, c, d, e, f
 
-        inp = torch.rand(64, 32, device="cuda")
+        inp = torch.rand(64, 32, device=device)
 
         gm = _make_post_grad_fx(func, inp)
         all_gathers = find_all_gather_patterns(gm.graph)
@@ -169,7 +175,7 @@ class MicroPipelineTPTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_find_reduce_scatter_patterns(self):
+    def test_find_reduce_scatter_patterns(self, device):
         group = dist.group.WORLD
 
         def func(
@@ -186,7 +192,7 @@ class MicroPipelineTPTest(TestCase):
             )
             return a, b, c
 
-        inp = torch.rand(64, 32, device="cuda")
+        inp = torch.rand(64, 32, device=device)
 
         gm = make_fx(func)(inp)
         reduce_scatters = find_reduce_scatter_patterns(gm.graph)
@@ -219,7 +225,7 @@ class MicroPipelineTPTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_get_unexposed_collectives(self):
+    def test_get_unexposed_collectives(self, device):
         group = dist.group.WORLD
 
         def func(inp: torch.Tensor) -> torch.Tensor:
@@ -233,7 +239,7 @@ class MicroPipelineTPTest(TestCase):
             e = all_gather_single(d, gather_dim=0, group=group.group_name)
             return a, c, e
 
-        inp = torch.rand(64, 32, device="cuda")
+        inp = torch.rand(64, 32, device=device)
 
         gm = make_fx(func)(inp)
         overlappable_collectives = _get_unexposed_collectives(gm.graph)
@@ -247,7 +253,7 @@ class MicroPipelineTPTest(TestCase):
     @parametrize("gather_dim", [0, 1, 2])
     @parametrize("return_A", [True, False])
     @fresh_cache()
-    def test_fuse_all_gather_matmul(self, A_dims, gather_dim, return_A):
+    def test_fuse_all_gather_matmul(self, device, A_dims, gather_dim, return_A):
         if gather_dim >= A_dims:
             return
 
@@ -268,8 +274,8 @@ class MicroPipelineTPTest(TestCase):
             raise AssertionError(f"Invalid A_dims: {A_dims}")
 
         A_shard_shape[gather_dim] //= self.world_size
-        A_shard = torch.rand(*A_shard_shape, device="cuda")
-        B = torch.rand(32, 16, device="cuda")
+        A_shard = torch.rand(*A_shard_shape, device=device)
+        B = torch.rand(32, 16, device=device)
 
         with _test_mode():
             compiled = torch.compile(func)
@@ -289,7 +295,7 @@ class MicroPipelineTPTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_fuse_all_gather_matmul_view_optimization(self):
+    def test_fuse_all_gather_matmul_view_optimization(self, device):
         """When batch=1 and gather_dim=1, _maybe_view_chunk_cat uses a view
         (no data movement), so the all_gather is optimized away entirely and
         there is no all_gather+matmul pattern to fuse."""
@@ -302,8 +308,8 @@ class MicroPipelineTPTest(TestCase):
         # batch=1: after all_gather, shape[0] == world_size == group_size,
         # so the view optimization in _maybe_view_chunk_cat applies.
         # Shard is [1, 32, 32], all_gather gives [2, 32, 32], view to [1, 64, 32].
-        A_shard = torch.rand(1, 32, 32, device="cuda")
-        B = torch.rand(32, 16, device="cuda")
+        A_shard = torch.rand(1, 32, 32, device=device)
+        B = torch.rand(32, 16, device=device)
 
         with _test_mode():
             compiled = torch.compile(func)
@@ -313,7 +319,7 @@ class MicroPipelineTPTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_fuse_all_gather_matmul_slice_cat(self):
+    def test_fuse_all_gather_matmul_slice_cat(self, device):
         group = dist.group.WORLD
 
         def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -328,11 +334,11 @@ class MicroPipelineTPTest(TestCase):
             )
             return A @ B
 
-        A_shard = torch.rand(64, 2048, device="cuda")
+        A_shard = torch.rand(64, 2048, device=device)
         torch._dynamo.decorators.mark_unbacked(
             A_shard, 0, hint_override=A_shard.shape[0]
         )
-        B = torch.rand(4096, 16, device="cuda")
+        B = torch.rand(4096, 16, device=device)
 
         gm = _make_post_grad_fx(func, A_shard, B)
         with _test_mode():
@@ -343,7 +349,7 @@ class MicroPipelineTPTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_fuse_all_gather_matmul_slice_cat_trim(self):
+    def test_fuse_all_gather_matmul_slice_cat_trim(self, device):
         group = dist.group.WORLD
 
         def func(A_shard: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -358,11 +364,11 @@ class MicroPipelineTPTest(TestCase):
             )
             return A.narrow(1, 0, 4096) @ B
 
-        A_shard = torch.rand(64, 2048, device="cuda")
+        A_shard = torch.rand(64, 2048, device=device)
         torch._dynamo.decorators.mark_unbacked(
             A_shard, 0, hint_override=A_shard.shape[0]
         )
-        B = torch.rand(4096, 16, device="cuda")
+        B = torch.rand(4096, 16, device=device)
 
         gm = _make_post_grad_fx(func, A_shard, B)
         with _test_mode():
@@ -377,7 +383,7 @@ class MicroPipelineTPTest(TestCase):
     @parametrize("gather_dim", [0, 1, 2])
     @parametrize("return_A", [True, False])
     @fresh_cache()
-    def test_fuse_all_gather_scaled_matmul(self, A_dims, gather_dim, return_A):
+    def test_fuse_all_gather_scaled_matmul(self, device, A_dims, gather_dim, return_A):
         if gather_dim >= A_dims:
             return
 
@@ -414,10 +420,10 @@ class MicroPipelineTPTest(TestCase):
             raise AssertionError(f"Invalid A_dims: {A_dims}")
 
         A_shard_shape[gather_dim] //= self.world_size
-        A_shard = torch.rand(*A_shard_shape, device="cuda").to(e4m3_type)
-        B = torch.rand(16, 32, device="cuda").to(e4m3_type).T
-        A_scale = torch.tensor(0.1, device="cuda")
-        B_scale = torch.tensor(0.1, device="cuda")
+        A_shard = torch.rand(*A_shard_shape, device=device).to(e4m3_type)
+        B = torch.rand(16, 32, device=device).to(e4m3_type).T
+        A_scale = torch.tensor(0.1, device=device)
+        B_scale = torch.tensor(0.1, device=device)
 
         gm = _make_post_grad_fx(func, A_shard, B, A_scale, B_scale, torch.bfloat16)
         with _test_mode():
@@ -447,7 +453,7 @@ class MicroPipelineTPTest(TestCase):
     @parametrize("A_dims", [2, 3])
     @parametrize("scatter_dim", [0, 1, 2])
     @fresh_cache()
-    def test_fuse_matmul_reduce_scatter(self, A_dims, scatter_dim):
+    def test_fuse_matmul_reduce_scatter(self, device, A_dims, scatter_dim):
         if scatter_dim >= A_dims:
             return
 
@@ -457,12 +463,12 @@ class MicroPipelineTPTest(TestCase):
             return reduce_scatter_single(A @ B, "avg", scatter_dim, group)
 
         if A_dims == 2:
-            A = torch.rand(64, 32, device="cuda")
+            A = torch.rand(64, 32, device=device)
         elif A_dims == 3:
-            A = torch.rand(2, 64, 32, device="cuda")
+            A = torch.rand(2, 64, 32, device=device)
         else:
             raise AssertionError(f"Invalid A_dims: {A_dims}")
-        B = torch.rand(32, 16, device="cuda")
+        B = torch.rand(32, 16, device=device)
 
         with _test_mode():
             compiled = torch.compile(func)
@@ -473,7 +479,7 @@ class MicroPipelineTPTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_fuse_matmul_reduce_scatter_slice_cat(self):
+    def test_fuse_matmul_reduce_scatter_slice_cat(self, device):
         group = dist.group.WORLD
 
         def func(A: torch.Tensor, B: torch.Tensor) -> torch.Tensor:
@@ -488,8 +494,8 @@ class MicroPipelineTPTest(TestCase):
             )
             return reduce_scatter_tensor(C, "avg", 0, group)
 
-        A = torch.rand(64, 32, device="cuda")
-        B = torch.rand(32, 16, device="cuda")
+        A = torch.rand(64, 32, device=device)
+        B = torch.rand(32, 16, device=device)
         torch._dynamo.decorators.mark_unbacked(B, 1, hint_override=B.shape[1])
 
         gm = _make_post_grad_fx(func, A, B)
@@ -504,7 +510,7 @@ class MicroPipelineTPTest(TestCase):
     @parametrize("A_dims", [2, 3])
     @parametrize("scatter_dim", [0, 1, 2])
     @fresh_cache()
-    def test_fuse_scaled_matmul_reduce_scatter(self, A_dims, scatter_dim):
+    def test_fuse_scaled_matmul_reduce_scatter(self, device, A_dims, scatter_dim):
         if scatter_dim >= A_dims - 1:
             return
 
@@ -527,14 +533,14 @@ class MicroPipelineTPTest(TestCase):
             return reduce_scatter_single(C, "avg", scatter_dim, group)
 
         if A_dims == 2:
-            A = torch.rand(64, 32, device="cuda").to(e4m3_type)
+            A = torch.rand(64, 32, device=device).to(e4m3_type)
         elif A_dims == 3:
-            A = torch.rand(2, 64, 32, device="cuda").to(e4m3_type)
+            A = torch.rand(2, 64, 32, device=device).to(e4m3_type)
         else:
             raise AssertionError(f"Invalid A_dims: {A_dims}")
-        B = torch.rand(16, 32, device="cuda").to(e4m3_type).T
-        A_scale = torch.tensor(0.1, device="cuda")
-        B_scale = torch.tensor(0.1, device="cuda")
+        B = torch.rand(16, 32, device=device).to(e4m3_type).T
+        A_scale = torch.tensor(0.1, device=device)
+        B_scale = torch.tensor(0.1, device=device)
 
         gm = _make_post_grad_fx(func, A, B, A_scale, B_scale, torch.bfloat16)
         with _test_mode():
@@ -555,7 +561,7 @@ class MicroPipelineTPTest(TestCase):
     @parametrize("scatter_dim", [0, 1])
     @fresh_cache()
     def test_fuse_scaled_matmul_reduce_scatter_rowwise_scales_reshape_mm_reshape(
-        self, scatter_dim
+        self, device, scatter_dim
     ):
         group = dist.group.WORLD
 
@@ -583,14 +589,14 @@ class MicroPipelineTPTest(TestCase):
             C = C.view(*orig_shape[:-1], C.shape[-1])
             return reduce_scatter_single(C, "sum", scatter_dim, group)
 
-        A = torch.rand(2, 16, 32, device="cuda").to(e4m3_type)
-        B = torch.rand(64, 32, device="cuda").to(e4m3_type).T
+        A = torch.rand(2, 16, 32, device=device).to(e4m3_type)
+        B = torch.rand(64, 32, device=device).to(e4m3_type).T
 
         # A_scale = rowwise scales
-        A_scale = torch.full((2, 16, 1), 0.1, device="cuda")
+        A_scale = torch.full((2, 16, 1), 0.1, device=device)
 
         # B_scale = rowwise scales transposed for A @ B^T
-        B_scale = torch.full((1, 64), 0.1, device="cuda")
+        B_scale = torch.full((1, 64), 0.1, device=device)
 
         gm = _make_post_grad_fx(
             reshape_mm_reshape, A, B, A_scale, B_scale, torch.bfloat16
@@ -602,7 +608,8 @@ class MicroPipelineTPTest(TestCase):
         self.assertIn("fused_scaled_matmul_reduce_scatter", str(gm.graph))
         self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
 
-        if torch.cuda.get_device_capability() < (8, 9):
+        device_module = torch.get_device_module(torch.device(device).type)
+        if device_module.get_device_capability(device) < (8, 9):
             return
 
         with _test_mode():
@@ -621,10 +628,11 @@ class MicroPipelineTPTest(TestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @parametrize("shard_dim", [0, 1])
     @fresh_cache()
-    def test_dtensor_seq_par(self, shard_dim: int):
-        model: torch.nn.Module = MLPModule(device="cuda", bias=False)
+    def test_dtensor_seq_par(self, device, shard_dim: int):
+        device_type = torch.device(device).type
+        model: torch.nn.Module = MLPModule(device=device, bias=False)
         device_mesh = DeviceMesh(
-            "cuda",
+            device_type,
             torch.arange(0, self.world_size),
         )
         parallelize_plan = {
@@ -633,9 +641,9 @@ class MicroPipelineTPTest(TestCase):
         }
         model = parallelize_module(model, device_mesh, parallelize_plan)
         if shard_dim == 0:
-            inp = torch.rand(8, 10, device="cuda")
+            inp = torch.rand(8, 10, device=device)
         elif shard_dim == 1:
-            inp = torch.rand(2, 8, 10, device="cuda")
+            inp = torch.rand(2, 8, 10, device=device)
         else:
             raise AssertionError("Invalid shard_dim")
 
@@ -649,15 +657,18 @@ class MicroPipelineTPTest(TestCase):
         self.assertNotIn("reduce_scatter_tensor", code)
 
 
-@instantiate_parametrized_tests
 class MicroPipelineTP4GPUTest(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
     def setUp(self):
         super().setUp()
         torch._inductor.config._micro_pipeline_tp = True
 
         self.rank = 0
         self.world_size = 4
-        torch.cuda.set_device("cuda:0")
+        torch.get_device_module(type(self).device_type).set_device(
+            type(self).get_primary_device()
+        )
 
         store = FakeStore()
         dist.init_process_group(
@@ -673,9 +684,10 @@ class MicroPipelineTP4GPUTest(TestCase):
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
     @torch._inductor.config.patch(shape_padding=False)
-    def test_extra_collectives(self):
+    def test_extra_collectives(self, device):
+        device_type = torch.device(device).type
         device_mesh = DeviceMesh(
-            "cuda",
+            device_type,
             torch.arange(0, self.world_size).view(2, -1),
             mesh_dim_names=("tp", "other"),
         )
@@ -687,9 +699,9 @@ class MicroPipelineTP4GPUTest(TestCase):
             hidden = reduce_scatter_single(full_hidden, "avg", 0, (device_mesh, 1))
             return reduce_scatter_single(hidden @ w2.t(), "avg", 0, (device_mesh, 0))
 
-        inp = torch.rand(8, 10, device="cuda")
-        w1 = torch.rand(7, 10, device="cuda")
-        w2 = torch.rand(10, 7, device="cuda")
+        inp = torch.rand(8, 10, device=device)
+        w1 = torch.rand(7, 10, device=device)
+        w2 = torch.rand(10, 7, device=device)
 
         with _test_mode(group_names={device_mesh["tp"].get_group().group_name}):
             compiled = torch.compile(func)
@@ -702,7 +714,7 @@ class MicroPipelineTP4GPUTest(TestCase):
 
     @unittest.skipIf(not HAS_GPU, "Inductor+gpu needs triton and recent GPU arch")
     @fresh_cache()
-    def test_fusion_without_deprecated_enable(self):
+    def test_fusion_without_deprecated_enable(self, device):
         # Fusion must not require the deprecated enable_symm_mem_for_group
         # (https://github.com/pytorch/pytorch/issues/193027), so no _test_mode here.
         group = dist.group.WORLD
@@ -716,9 +728,9 @@ class MicroPipelineTP4GPUTest(TestCase):
                 A @ B, "avg", scatter_dim=0, group=group.group_name
             )
 
-        A_shard = torch.rand(32, 32, device="cuda")
-        A = torch.rand(64, 32, device="cuda")
-        B = torch.rand(32, 16, device="cuda")
+        A_shard = torch.rand(32, 32, device=device)
+        A = torch.rand(64, 32, device=device)
+        B = torch.rand(32, 16, device=device)
 
         gm = _make_post_grad_fx(ag_mm, A_shard, B)
         micro_pipeline_tp_pass(gm.graph)
@@ -729,6 +741,18 @@ class MicroPipelineTP4GPUTest(TestCase):
         micro_pipeline_tp_pass(gm.graph)
         self.assertIn("fused_matmul_reduce_scatter", str(gm.graph))
         self.assertNotIn("reduce_scatter_tensor", str(gm.graph))
+
+
+instantiate_device_type_tests(
+    MicroPipelineTPTest,
+    globals(),
+    only_for=["cuda"],
+)
+instantiate_device_type_tests(
+    MicroPipelineTP4GPUTest,
+    globals(),
+    only_for=["cuda"],
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR separates device-independent micro-pipeline pattern tests from CUDA-specific tensor-parallel runtime tests without changing the tested behavior.

## Changes

- Move the three FX graph pattern-analysis tests into a generic class that does not use device-type instantiation.
- Keep fusion, Triton, FP8, and multi-device tensor-parallel runtime tests in CUDA-specific classes.
- Instantiate CUDA classes only for CUDA and pass generated `device` or `devices` arguments into device-specific test methods.
- Replace fixed CUDA device strings in those methods with the generated device values.

## Test plan

- `lintrunner -a test/distributed/tensor/parallel/test_micro_pipeline_tp.py` - passed.
- `git diff --check` - passed.
- The generic CPU tests were not run locally because the installed PyTorch runtime lacks the required `all_gather_single` API.
- Ascend/NPU runtime tests were not run because the remote test environment was unavailable.

Prepared with assistance from an AI coding assistant.
