### PR TITLE
[Testcase Refactoring][DTensor] Classify compile-on-one-rank tests

### DIFF
--- a/test/distributed/tensor/test_compile_on_one_rank.py
+++ b/test/distributed/tensor/test_compile_on_one_rank.py
@@ -17,7 +17,13 @@ from torch.distributed.tensor import DTensor, Replicate, Shard
 from torch.distributed.tensor.parallel import parallelize_module, RowwiseParallel
 from torch.fx._graph_pickler import GraphPickler, Options
 from torch.fx.experimental.proxy_tensor import make_fx
+from torch.testing._internal.common_device_type import (
+    deviceCountAtLeast,
+    instantiate_device_type_tests,
+)
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
@@ -44,31 +50,33 @@ def extract_graph(fx_g, _, graph_cell):
 
 
 class TestCompileOnOneRank(DTensorTestBase):
-    def _assert_graphs_identical_across_ranks(self, local_graph_code):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def _assert_graphs_identical_across_ranks(self, local_graph_code, device_type):
         """Gather compiled graph code from all ranks and assert they are identical."""
         self.assertIsNotNone(local_graph_code, "Graph was not captured")
 
         graph_bytes = local_graph_code.encode("utf-8")
         graph_tensor = torch.tensor(
-            list(graph_bytes), dtype=torch.uint8, device=self.device_type
+            list(graph_bytes), dtype=torch.uint8, device=device_type
         )
 
         # Pad to same length across ranks
         local_len = torch.tensor(
-            [len(graph_bytes)], dtype=torch.int64, device=self.device_type
+            [len(graph_bytes)], dtype=torch.int64, device=device_type
         )
         all_lens = [
-            torch.zeros(1, dtype=torch.int64, device=self.device_type)
+            torch.zeros(1, dtype=torch.int64, device=device_type)
             for _ in range(self.world_size)
         ]
         dist.all_gather(all_lens, local_len)
         max_len = int(max(l.item() for l in all_lens))
 
-        padded_tensor = torch.zeros(max_len, dtype=torch.uint8, device=self.device_type)
+        padded_tensor = torch.zeros(max_len, dtype=torch.uint8, device=device_type)
         padded_tensor[: len(graph_bytes)] = graph_tensor
 
         all_graphs = [
-            torch.zeros(max_len, dtype=torch.uint8, device=self.device_type)
+            torch.zeros(max_len, dtype=torch.uint8, device=device_type)
             for _ in range(self.world_size)
         ]
         dist.all_gather(all_graphs, padded_tensor)
@@ -114,7 +122,7 @@ class TestCompileOnOneRank(DTensorTestBase):
 
     @with_comms
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_compiled_rowwise_embedding_graph_consistency(self):
+    def test_compiled_rowwise_embedding_graph_consistency(self, device):
         """Test that compiled graphs are identical across all ranks.
 
         When rowwise sharded embeddings are compiled with torch.compile, the
@@ -127,7 +135,8 @@ class TestCompileOnOneRank(DTensorTestBase):
         These values should be symbolic/dynamic, not baked-in literals, to
         ensure graph consistency across ranks.
         """
-        mesh = self.build_device_mesh()
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
 
         class Network(nn.Module):
             def __init__(self, num_embeddings, embedding_dim, device):
@@ -143,7 +152,7 @@ class TestCompileOnOneRank(DTensorTestBase):
         num_embeddings = 256
         embedding_dim = 64
 
-        model = Network(num_embeddings, embedding_dim, device=self.device_type)
+        model = Network(num_embeddings, embedding_dim, device=device_type)
 
         parallelize_module(
             model,
@@ -159,15 +168,16 @@ class TestCompileOnOneRank(DTensorTestBase):
         compiled_model, fw_graph_cell = self._compile_and_capture_graph(model)
 
         torch.manual_seed(42)
-        inp = torch.randint(0, num_embeddings, (64, 16), device=self.device_type)
+        inp = torch.randint(0, num_embeddings, (64, 16), device=device_type)
         replicated_inp = DTensor.from_local(inp, mesh, [Replicate()], run_check=False)
 
         compiled_model(replicated_inp)
-        self._assert_graphs_identical_across_ranks(fw_graph_cell[0])
+        self._assert_graphs_identical_across_ranks(fw_graph_cell[0], device_type)
 
     @with_comms
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_all_reduce_with_explicit_pg_input(self):
+    def test_all_reduce_with_explicit_pg_input(self, device):
+        device_type = torch.device(device).type
         pg = dist.distributed_c10d._get_default_group()
 
         def f(t, group):
@@ -175,19 +185,18 @@ class TestCompileOnOneRank(DTensorTestBase):
             dist.all_reduce(t, group=group)
             return t + 1
 
-        x = torch.arange(4, dtype=torch.float32, device=self.device_type)
+        x = torch.arange(4, dtype=torch.float32, device=device_type)
         opt = torch.compile(f, backend="inductor", fullgraph=True)
         out = opt(x, pg)
         self.assertEqual(out, f(x, pg))
 
     @with_comms
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_compiled_dtensor_rng_op_graph_consistency(self):
+    def test_compiled_dtensor_rng_op_graph_consistency(self, device):
         """Compiled random ops on sharded DTensors should produce identical graphs."""
-        mesh = self.build_device_mesh()
-        dt = DTensor.from_local(
-            torch.empty(8, 4, device=self.device_type), mesh, [Shard(0)]
-        )
+        device_type = torch.device(device).type
+        mesh = init_device_mesh(device_type, (self.world_size,))
+        dt = DTensor.from_local(torch.empty(8, 4, device=device_type), mesh, [Shard(0)])
 
         fw_graph_cell = [None]
         fw_compiler = functools.partial(extract_graph, graph_cell=fw_graph_cell)
@@ -204,11 +213,11 @@ class TestCompileOnOneRank(DTensorTestBase):
         )
 
         compiled_f(dt)
-        self._assert_graphs_identical_across_ranks(fw_graph_cell[0])
+        self._assert_graphs_identical_across_ranks(fw_graph_cell[0], device_type)
 
     @with_comms
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_all_reduce_with_implicit_world_group(self):
+    def test_all_reduce_with_implicit_world_group(self, device):
         """`dist.all_reduce(t)` with no `group=` (implicit `dist.group.WORLD`)
         should compile under compile_on_one_rank=True.
 
@@ -229,7 +238,8 @@ class TestCompileOnOneRank(DTensorTestBase):
             dist.all_reduce(t)
             return t + 1
 
-        x = torch.arange(4, dtype=torch.float32, device=self.device_type)
+        device_type = torch.device(device).type
+        x = torch.arange(4, dtype=torch.float32, device=device_type)
         opt = torch.compile(f, backend="aot_eager", fullgraph=True)
         out = opt(x)
         self.assertEqual(out, f(x))
@@ -242,8 +252,8 @@ def _factory_from_input_device(x):
     return torch.zeros(4, x.shape[1], device=x.device, dtype=x.dtype)
 
 
-def _indexed_cuda_device_nodes(gm):
-    """Nodes carrying a concrete, indexed cuda device in their args/kwargs.
+def _indexed_accelerator_device_nodes(gm, device_type):
+    """Nodes carrying a concrete, indexed accelerator device in their args/kwargs.
 
     These are the rank-specific constants that make a make_fx graph non
     device-agnostic. A device-agnostic graph fetches the device in-graph (via the
@@ -255,7 +265,7 @@ def _indexed_cuda_device_nodes(gm):
         for operand in operands:
             if (
                 isinstance(operand, torch.device)
-                and operand.type == "cuda"
+                and operand.type == device_type
                 and operand.index is not None
             ):
                 found.append(node)
@@ -273,91 +283,99 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
     """Device-as-parameter for the make_fx tracing path used by graph_trainer/CooR.
 
     Under compile_on_one_rank, a factory/cast op whose device matches the current
-    accelerator (e.g. cuda:0, or a bare cuda) traces with its device= fed by a single
-    in-graph current_device() node, instead of baking the concrete device. At
-    runtime the device follows each rank's current accelerator device (not any input),
-    so one compiled artifact runs on each rank's real GPU without --virtual-local-rank.
+    accelerator (indexed or unindexed) traces with its device= fed by a single in-graph
+    current_device() node, instead of baking the concrete device. At runtime the device
+    follows each rank's current accelerator device (not any input), so one compiled
+    artifact runs on each rank without --virtual-local-rank.
     A device that is a different accelerator, or a different index of the current
     accelerator, is refused (it could not run SPMD).
     """
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    hw_classification = HardwareClassification.ACCELERATOR
+
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_factory_device_replaced_with_current_device(self):
+    def test_factory_device_replaced_with_current_device(self, device):
+        device_type = torch.device(device).type
         gm = make_fx(_factory_from_input_device, tracing_mode="fake")(
-            torch.randn(2, 8, device="cuda:0")
+            torch.randn(2, 8, device=device)
         )
         ca = _current_device_nodes(gm)
         self.assertEqual(
             len(ca), 1, "device should be fetched in-graph via a single node"
         )
         self.assertTrue(ca[0].users, "the current_device() node must be consumed")
-        baked = _indexed_cuda_device_nodes(gm)
+        baked = _indexed_accelerator_device_nodes(gm, device_type)
         self.assertEqual(
             baked,
             [],
-            lambda msg: f"{msg}\nno node should bake a concrete indexed cuda device; found: {baked}",
+            lambda msg: f"{msg}\nfound indexed accelerator devices: {baked}",
         )
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
+    @deviceCountAtLeast(2)
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_runtime_follows_current_device_not_input(self):
+    def test_runtime_follows_current_device_not_input(self, devices):
+        primary = torch.device(devices[0])
+        secondary = torch.device(devices[1])
         # The runtime device follows the process's current device, not the input's.
-        # The input is kept on cuda:0 in both runs; only the current device changes.
+        # The input is kept on the primary device; only the current device changes.
         gm = make_fx(_factory_from_input_device, tracing_mode="fake")(
-            torch.randn(2, 8, device="cuda:0")
+            torch.randn(2, 8, device=devices[0])
         )
-        with torch.cuda.device(0):
+        with torch.accelerator.device_index(primary.index):
             self.assertEqual(
-                gm(torch.randn(2, 8, device="cuda:0")).device, torch.device("cuda:0")
+                gm(torch.randn(2, 8, device=devices[0])).device,
+                primary,
             )
-        with torch.cuda.device(1):
+        with torch.accelerator.device_index(secondary.index):
             self.assertEqual(
-                gm(torch.randn(2, 8, device="cuda:0")).device, torch.device("cuda:1")
+                gm(torch.randn(2, 8, device=devices[0])).device,
+                secondary,
             )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    def test_default_path_unchanged_bakes_device(self):
+    def test_default_path_unchanged_bakes_device(self, device):
+        device_type = torch.device(device).type
         # Without compile_on_one_rank the device stays baked (the feature must be
         # gated so it does not perturb the default tracing path).
         gm = make_fx(_factory_from_input_device, tracing_mode="fake")(
-            torch.randn(2, 8, device="cuda:0")
+            torch.randn(2, 8, device=device)
         )
         self.assertEqual(_current_device_nodes(gm), [])
-        self.assertTrue(_indexed_cuda_device_nodes(gm))
+        self.assertTrue(_indexed_accelerator_device_nodes(gm, device_type))
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_to_copy_explicit_device_replaced(self):
+    def test_to_copy_explicit_device_replaced(self, device):
+        device_type = torch.device(device).type
+
         # An explicit-device dtype cast (the SimpleFSDP mixed-precision pattern,
         # aten._to_copy with a device= kwarg) also gets its baked device rewired to
         # the current_device() node, alongside the factory-op path.
+
         def f(x):
-            return x.to(device="cuda:0", dtype=torch.bfloat16)
+            return x.to(device=device, dtype=torch.bfloat16)
 
-        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, 8, device="cuda:0"))
+        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, 8, device=device))
         self.assertEqual(len(_current_device_nodes(gm)), 1)
-        self.assertEqual(_indexed_cuda_device_nodes(gm), [])
+        self.assertEqual(_indexed_accelerator_device_nodes(gm, device_type), [])
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_unindexed_accelerator_device_replaced(self):
-        # A bare device="cuda" (index None) matching the current accelerator is also
-        # replaced by the current_device() node.
+    def test_unindexed_accelerator_device_replaced(self, device):
+        device_type = torch.device(device).type
+
+        # A bare accelerator device (index None) is also replaced.
+
         def f(x):
-            return torch.zeros(4, x.shape[1], device="cuda", dtype=x.dtype)
+            return torch.zeros(4, x.shape[1], device=device_type, dtype=x.dtype)
 
-        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, 8, device="cuda:0"))
+        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, 8, device=device))
         self.assertEqual(len(_current_device_nodes(gm)), 1)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_cpu_device_left_alone(self):
+    def test_cpu_device_left_alone(self, device):
         # cpu is portable on every rank, so a cpu factory is not rewritten.
         def f(x):
             return torch.zeros(4, x.shape[1], device="cpu")
 
-        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, 8, device="cuda:0"))
+        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, 8, device=device))
         self.assertEqual(_current_device_nodes(gm), [])
         cpu_ops = [
             n
@@ -369,9 +387,62 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         ]
         self.assertTrue(cpu_ops, "the cpu device should stay baked")
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_coor_check_current_accelerator(self):
+    def test_factory_without_matching_input_succeeds(self, device):
+        device_type = torch.device(device).type
+
+        # Unlike provenance-following, matching the current accelerator needs no input
+        # on that device: an accelerator factory in a CPU-input graph is rewritten.
+
+        def f(x):
+            return torch.zeros(x.shape[0], device=device)
+
+        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, device="cpu"))
+        self.assertEqual(len(_current_device_nodes(gm)), 1)
+        self.assertEqual(_indexed_accelerator_device_nodes(gm, device_type), [])
+
+    @compiler_config.patch(compile_on_one_rank=True)
+    def test_wrong_index_raises(self, device):
+        current = torch.device(device)
+        other_index = 0 if current.index != 0 else 1
+
+        # A non-current index cannot be made SPMD, so the rewrite refuses it.
+
+        def f(x):
+            return torch.zeros(4, device=torch.device(current.type, other_index))
+
+        with torch.accelerator.device_index(current.index):
+            with self.assertRaisesRegex(
+                RuntimeError, "index differs from the current accelerator"
+            ):
+                make_fx(f, tracing_mode="fake")(torch.randn(2, device=device))
+
+    @deviceCountAtLeast(2)
+    @compiler_config.patch(compile_on_one_rank=True)
+    def test_graph_code_identical_across_devices(self, devices):
+        device_type = torch.device(devices[0]).type
+
+        # The functional FX graph text (.code) must be byte-identical across ranks: the
+        # device operand is the current_device() node, never a baked device index.
+
+        def code_on(dev):
+            with torch.accelerator.device_index(torch.device(dev).index):
+                return make_fx(_factory_from_input_device, tracing_mode="fake")(
+                    torch.randn(2, 8, device=dev)
+                ).code
+
+        code0, code1 = code_on(devices[0]), code_on(devices[1])
+        self.assertEqual(code0, code1)
+        self.assertNotIn(f"{device_type}:", code0)
+
+
+class TestCompileOnOneRankCUDA(TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @compiler_config.patch(compile_on_one_rank=True)
+    def test_coor_check_current_accelerator(self, device):
+        current = torch.device(device)
+        other_index = 0 if current.index != 0 else 1
         # The shared validator (used by the make_fx input check, the operand rewrite, and the
         # benchmark-harness device renderer) must accept the current accelerator (bare or its
         # index) and cpu, and refuse a non-current accelerator -- so a device cannot be
@@ -382,74 +453,46 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
             _coor_current_accelerator,
         )
 
-        with torch.cuda.device(0):
+        with torch.cuda.device(device):
             cur = _coor_current_accelerator()
-            _coor_check_current_accelerator(torch.device("cuda:0"), cur)
-            _coor_check_current_accelerator(torch.device("cuda"), cur)
+            _coor_check_current_accelerator(current, cur)
+            _coor_check_current_accelerator(torch.device(current.type), cur)
             _coor_check_current_accelerator(torch.device("cpu"), cur)
             with self.assertRaisesRegex(RuntimeError, "device-agnostic"):
-                _coor_check_current_accelerator(torch.device("cuda:1"), cur)
+                _coor_check_current_accelerator(
+                    torch.device(current.type, other_index), cur
+                )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
     @torch._inductor.config.patch(cpp_wrapper=True)
-    def test_cpp_wrapper_under_coor_rejected(self):
+    def test_cpp_wrapper_under_coor_rejected(self, device):
         # cpp_wrapper/AOTInductor bakes the compile-time device index into the C++ device
         # guard, which is not rank-portable. Compile-on-one-rank must refuse it rather than
         # silently emit a non-portable artifact.
         # Exception (not RuntimeError) because dynamo wraps this in BackendCompilerFailed,
         # so the regex has to carry the specificity.
-        with torch.cuda.device(0):
+        with torch.cuda.device(device):
             with self.assertRaisesRegex(
                 Exception,
                 r"compile-on-one-rank .*not supported with cpp_wrapper/AOTInductor",
             ):
-                torch.compile(lambda x: x + 1)(torch.randn(8, device="cuda"))
+                torch.compile(lambda x: x + 1)(torch.randn(8, device=device))
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
     @torch._inductor.config.patch(fx_wrapper=True)
-    def test_fx_wrapper_under_coor_rejected(self):
+    def test_fx_wrapper_under_coor_rejected(self, device):
         # fx_wrapper's device-context codegen is a no-op, so it would bake the compile-time
         # device index like cpp_wrapper. Compile-on-one-rank must refuse it rather than
         # silently emit a non-portable artifact.
-        with torch.cuda.device(0):
+        with torch.cuda.device(device):
             with self.assertRaisesRegex(
                 Exception, r"compile-on-one-rank .*not supported with .*fx_wrapper"
             ):
-                torch.compile(lambda x: x + 1)(torch.randn(8, device="cuda"))
+                torch.compile(lambda x: x + 1)(torch.randn(8, device=device))
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
+    @deviceCountAtLeast(2)
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_factory_without_matching_input_succeeds(self):
-        # Unlike provenance-following, matching the current accelerator needs no input
-        # on that device: a cuda factory in a cpu-input graph is now rewritten, not
-        # rejected.
-        def f(x):
-            return torch.zeros(x.shape[0], device="cuda:0")
-
-        gm = make_fx(f, tracing_mode="fake")(torch.randn(2, device="cpu"))
-        self.assertEqual(len(_current_device_nodes(gm)), 1)
-        self.assertEqual(_indexed_cuda_device_nodes(gm), [])
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
-    @compiler_config.patch(compile_on_one_rank=True)
-    def test_wrong_index_raises(self):
-        # A cuda index that is not the current device's index cannot be made SPMD, so
-        # the rewrite refuses it (raised during tracing before the fake op runs, so
-        # this needs only the current device to exist).
-        def f(x):
-            return torch.zeros(4, device="cuda:1")
-
-        with torch.cuda.device(0):
-            with self.assertRaisesRegex(
-                RuntimeError, "index differs from the current accelerator"
-            ):
-                make_fx(f, tracing_mode="fake")(torch.randn(2, device="cuda:0"))
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
-    @compiler_config.patch(compile_on_one_rank=True)
-    def test_noncurrent_device_tensor_rejected(self):
+    def test_noncurrent_device_tensor_rejected(self, devices):
         # CooR rejects a device *operand* that isn't the current accelerator (see
         # test_wrong_index_raises), but its single-device invariant also requires the
         # graph's *tensors* to be on the current device: the inductor wrapper collapses
@@ -459,26 +502,9 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         def f(x):
             return x + 1
 
-        with torch.cuda.device(0):
+        with torch.cuda.device(devices[0]):
             with self.assertRaisesRegex(RuntimeError, "device-agnostic"):
-                make_fx(f, tracing_mode="fake")(torch.randn(4, device="cuda:1"))
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
-    @compiler_config.patch(compile_on_one_rank=True)
-    def test_graph_code_identical_across_devices(self):
-        # The functional FX graph text (.code) must be byte-identical across ranks: the
-        # device operand is the current_device() node, never a baked cuda:N. (.code
-        # carries no per-tensor device annotations, so it stays clean while the tensor meta
-        # remains on its real cuda:N device.)
-        def code_on(dev):
-            with torch.cuda.device(dev):
-                return make_fx(_factory_from_input_device, tracing_mode="fake")(
-                    torch.randn(2, 8, device=f"cuda:{dev}")
-                ).code
-
-        code0, code1 = code_on(0), code_on(1)
-        self.assertEqual(code0, code1)
-        self.assertNotIn("cuda:", code0)
+                make_fx(f, tracing_mode="fake")(torch.randn(4, device=devices[1]))
 
     # ---- inductor codegen and launcher must be device-agnostic across ranks ----
     # A device-derived factory + a reduction, so inductor emits a real kernel.
@@ -487,9 +513,8 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         z = torch.zeros(4, x.shape[1], device=x.device, dtype=x.dtype)
         return z + x.sum()
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_inductor_compiles_under_coor(self):
+    def test_inductor_compiles_under_coor(self, device):
         # The current_device() node must lower through inductor, and the generated code
         # must be device-agnostic: the device is resolved at runtime with no baked
         # rank-specific index, so one compiled artifact is shareable across ranks.
@@ -500,8 +525,8 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         compiled = torch.compile(
             self._coor_inductor_fn, backend="inductor", fullgraph=True
         )
-        out, codes = run_and_get_code(compiled, torch.randn(2, 8, device="cuda"))
-        self.assertEqual(out.device.type, "cuda")
+        out, codes = run_and_get_code(compiled, torch.randn(2, 8, device=device))
+        self.assertEqual(out.device.type, torch.device(device).type)
         code = "\n".join(codes)
         FileCheck().check("torch.cuda.current_device()").run(code)
         self._assert_no_baked_device(code)
@@ -514,22 +539,20 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         self.assertNotRegex(code, r"device\(type=.cuda., index=\d")
         self.assertNotRegex(code, r"DeviceProperties\([^)]*index=\d")
 
-    def _inductor_code_on_device(self, dev):
+    def _inductor_code_on_device(self, device):
         from torch._inductor.utils import run_and_get_code
 
         torch._dynamo.reset()
-        with torch.cuda.device(dev):
+        with torch.cuda.device(device):
             compiled = torch.compile(
                 self._coor_inductor_fn, backend="inductor", fullgraph=True
             )
-            _, codes = run_and_get_code(
-                compiled, torch.randn(2, 8, device=f"cuda:{dev}")
-            )
+            _, codes = run_and_get_code(compiled, torch.randn(2, 8, device=device))
         return "\n".join(codes)
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
+    @skip_if_lt_x_gpu(2)
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_inductor_code_identical_across_devices(self):
+    def test_inductor_code_identical_across_devices(self, device):
         # The inductor-side rewrite is a dozen independent opt-in `if _coor_enabled():`
         # sites with no structural funnel, so pattern-matching one rank's output cannot
         # show that none was missed. Diffing the code generated on two different devices
@@ -544,6 +567,15 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         def norm(s):
             return re.sub(r"AOT ID: \['\d+_", "AOT ID: ['N_", s)
 
+        primary_device = torch.device(device)
+        devices = [primary_device] + [
+            torch.device(candidate)
+            for candidate in type(self).get_all_devices()
+            if torch.device(candidate) != primary_device
+        ]
+        if len(devices) < 2:
+            self.skipTest(f"requires >= 2 {primary_device.type} devices")
+
         # Each config emits device references through a different path: the kernel's own
         # benchmark harness, and the compile-time autotune harness
         # (generate_example_value). Both are part of generated text that must match.
@@ -552,15 +584,15 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
             {"triton.autotune_at_compile_time": True},
         ):
             with self.subTest(cfg=cfg), torch._inductor.config.patch(**cfg):
-                code0 = self._inductor_code_on_device(0)
-                code1 = self._inductor_code_on_device(1)
+                code0 = self._inductor_code_on_device(devices[0])
+                code1 = self._inductor_code_on_device(devices[1])
                 if norm(code0) != norm(code1):
                     diff = "".join(
                         difflib.unified_diff(
                             norm(code0).splitlines(keepends=True),
                             norm(code1).splitlines(keepends=True),
-                            fromfile="cuda:0",
-                            tofile="cuda:1",
+                            fromfile=str(devices[0]),
+                            tofile=str(devices[1]),
                         )
                     )
                     self.fail(
@@ -569,10 +601,9 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
                     )
                 self._assert_no_baked_device(code0)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
     @torch._inductor.config.patch({"triton.force_cooperative_reductions": True})
-    def test_cooperative_reduction_workspace_name_not_baked(self):
+    def test_cooperative_reduction_workspace_name_not_baked(self, device):
         # The cooperative-reduction semaphore workspace is named after its device, and
         # that name is emitted into the wrapper -- so an index in it makes the wrapper
         # differ across ranks even though no "cuda:N" literal appears. This runs on
@@ -583,7 +614,7 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
 
         torch._dynamo.reset()
         compiled = torch.compile(lambda x: x.sum(), backend="inductor", fullgraph=True)
-        _, codes = run_and_get_code(compiled, torch.randn(4096, 4096, device="cuda"))
+        _, codes = run_and_get_code(compiled, torch.randn(4096, 4096, device=device))
         code = "\n".join(codes)
         self.assertIn("semaphores_cuda", code)  # the workspace is actually in play
         self.assertNotRegex(code, r"semaphores_cuda_\d")
@@ -593,7 +624,7 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         torch.version.cuda is None and torch.version.hip is None,
         "needs a GPU-enabled build whose devices can be hidden",
     )
-    def test_coor_compiles_on_gpu_build_with_no_visible_device(self):
+    def test_coor_compiles_on_gpu_build_with_no_visible_device(self, device):
         # A GPU-enabled build running where no device is visible -- a container started
         # without --gpus, a scheduler setting CUDA_VISIBLE_DEVICES="", every GPU already
         # allocated -- must still compile a cpu graph under CooR. current_accelerator()
@@ -638,9 +669,8 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
             f"CooR compile failed with no visible device:\n{proc.stderr[-3000:]}",
         )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_inductor_code_identical_across_cache_dirs(self):
+    def test_inductor_code_identical_across_cache_dirs(self, device):
         # The artifact may be built on one machine and run on another (compatible) one,
         # so generated text must not embed machine-specific paths -- the inductor cache
         # dir is absolute and carries the building user's name. Two fresh cache roots
@@ -652,7 +682,7 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
 
         def code_with_fresh_cache():
             with fresh_cache():
-                return self._inductor_code_on_device(0)
+                return self._inductor_code_on_device(device)
 
         code_a, code_b = code_with_fresh_cache(), code_with_fresh_cache()
 
@@ -673,9 +703,8 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
                 f"another machine:\n{diff}"
             )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires CUDA")
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_extern_kernel_device_arg_not_baked(self):
+    def test_extern_kernel_device_arg_not_baked(self, device):
         # An aten fallback that keeps a device= argument (randperm has no inductor
         # lowering) renders that argument through val_to_arg_str's repr() path, which
         # bakes the index as device(type='cuda', index=0) -- a form the "cuda:N" checks
@@ -686,50 +715,50 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
             return torch.randperm(8, device=x.device) + 0
 
         torch._dynamo.reset()
-        with torch.cuda.device(0):
+        with torch.cuda.device(device):
             compiled = torch.compile(f, backend="inductor", fullgraph=True)
-            out, codes = run_and_get_code(compiled, torch.randn(2, 8, device="cuda:0"))
+            out, codes = run_and_get_code(compiled, torch.randn(2, 8, device=device))
         code = "\n".join(codes)
         self.assertIn("torch.ops.aten.randperm", code)  # still the fallback path
         self._assert_no_baked_device(code)
         self.assertEqual(sorted(out.tolist()), list(range(8)))
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
+    @deviceCountAtLeast(2)
     @compiler_config.patch(compile_on_one_rank=True)
     @torch._inductor.config.patch({"triton.cudagraphs": True})
-    def test_cudagraphs_under_coor_runs_on_nonzero_device(self):
+    def test_cudagraphs_under_coor_runs_on_nonzero_device(self, devices):
         # cudagraphs is not refused under CooR (see the guard in compile_fx.py): its
         # device dependence lives in the wrapper-level artifact, which is not shared
         # across ranks today. Pin that it works on a rank's own device.
-        inp = torch.randn(2, 8, device="cuda:1")
+        inp = torch.randn(2, 8, device=devices[1])
         ref = self._coor_inductor_fn(inp)
         torch._dynamo.reset()
-        with torch.cuda.device(1):
+        with torch.cuda.device(devices[1]):
             compiled = torch.compile(
                 self._coor_inductor_fn, backend="inductor", fullgraph=True
             )
             for _ in range(3):  # replay, not just record
                 out = compiled(inp)
-        self.assertEqual(out.device, torch.device("cuda:1"))
+        self.assertEqual(out.device, torch.device(devices[1]))
         self.assertEqual(out, ref)
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
+    @deviceCountAtLeast(2)
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_inductor_runs_on_nonzero_device(self):
+    def test_inductor_runs_on_nonzero_device(self, devices):
         # Problem 2 (runtime): a graph compiled under CooR must run on a rank's own
         # (non-zero) device -- the device guard, stream, and kernel load must follow the
         # runtime current device, not a baked index.
         torch._dynamo.reset()
-        with torch.cuda.device(1):
+        with torch.cuda.device(devices[1]):
             compiled = torch.compile(
                 self._coor_inductor_fn, backend="inductor", fullgraph=True
             )
-            out = compiled(torch.randn(2, 8, device="cuda:1"))
-        self.assertEqual(out.device, torch.device("cuda:1"))
+            out = compiled(torch.randn(2, 8, device=devices[1]))
+        self.assertEqual(out.device, torch.device(devices[1]))
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
+    @deviceCountAtLeast(2)
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_inductor_compiled_on_one_device_runs_on_another(self):
+    def test_inductor_compiled_on_one_device_runs_on_another(self, devices):
         # Problem 3 (shareable artifact): a graph first compiled on cuda:0 must produce a
         # correct result when the same code is compiled and run on cuda:1 with the on-disk
         # cache warm from the cuda:0 run.
@@ -745,33 +774,33 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         from torch._dynamo.utils import counters
         from torch._inductor.utils import clear_caches, fresh_cache
 
-        inp1 = torch.randn(2, 8, device="cuda:1")
+        inp1 = torch.randn(2, 8, device=devices[1])
         ref = self._coor_inductor_fn(inp1)
         with fresh_cache():
-            with torch.cuda.device(0):
+            with torch.cuda.device(devices[0]):
                 compiled = torch.compile(
                     self._coor_inductor_fn, backend="inductor", fullgraph=True
                 )
-                compiled(torch.randn(2, 8, device="cuda:0"))  # populate cache on cuda:0
+                compiled(torch.randn(2, 8, device=devices[0]))
             # Drop in-memory caches (keeping the on-disk bundle) so the cuda:1 run reloads
             # from disk -- simulating a fresh per-rank process rather than reusing the
             # cuda:0 launcher in memory.
             torch._dynamo.reset()
             clear_caches()
             counters.clear()
-            with torch.cuda.device(1):
+            with torch.cuda.device(devices[1]):
                 compiled = torch.compile(
                     self._coor_inductor_fn, backend="inductor", fullgraph=True
                 )
                 out = compiled(inp1)
         self.assertEqual(counters["inductor"]["fxgraph_cache_hit"], 0)
         self.assertEqual(counters["inductor"]["fxgraph_cache_miss"], 1)
-        self.assertEqual(out.device, torch.device("cuda:1"))
+        self.assertEqual(out.device, torch.device(devices[1]))
         self.assertEqual(out, ref)
 
-    @unittest.skipIf(torch.cuda.device_count() < 2, "requires >= 2 GPUs")
+    @deviceCountAtLeast(2)
     @compiler_config.patch(compile_on_one_rank=True)
-    def test_inductor_shared_kernel_reused_in_process_across_devices(self):
+    def test_inductor_shared_kernel_reused_in_process_across_devices(self, devices):
         # A rank only ever drives one device, but CooR's kernel cache key is
         # device-agnostic, so within one process the in-memory autotuner hands the same
         # loaded launcher to whatever device is current. A loaded CUfunction is
@@ -782,9 +811,9 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
         # test file -- and it only shows up on a cold cache, so it is pinned here.
         from torch._inductor.utils import clear_caches, fresh_cache
 
-        inp0 = torch.randn(2, 8, device="cuda:0")
+        inp0 = torch.randn(2, 8, device=devices[0])
         ref0 = self._coor_inductor_fn(inp0)
-        inp1 = torch.randn(2, 8, device="cuda:1")
+        inp1 = torch.randn(2, 8, device=devices[1])
         ref1 = self._coor_inductor_fn(inp1)
         torch._dynamo.reset()
         clear_caches()
@@ -792,13 +821,13 @@ class TestCompileOnOneRankDeviceAsParameter(TestCase):
             compiled = torch.compile(
                 self._coor_inductor_fn, backend="inductor", fullgraph=True
             )
-            with torch.cuda.device(0):
+            with torch.cuda.device(devices[0]):
                 out0 = compiled(inp0)
             # The same in-process autotuner (loaded on cuda:0) now launches on cuda:1.
-            with torch.cuda.device(1):
+            with torch.cuda.device(devices[1]):
                 out1 = compiled(inp1)
-        self.assertEqual(out0.device, torch.device("cuda:0"))
-        self.assertEqual(out1.device, torch.device("cuda:1"))
+        self.assertEqual(out0.device, torch.device(devices[0]))
+        self.assertEqual(out1.device, torch.device(devices[1]))
         self.assertEqual(out0, ref0)
         self.assertEqual(out1, ref1)
 
@@ -851,6 +880,8 @@ class TestCompileOnOneRankLegacyCollective(TestCase):
         group as an op argument.
     Single process with a fake PG -- this is the failing precompile CI step.
     """
+
+    hw_classification = HardwareClassification.GENERIC
 
     def setUp(self):
         super().setUp()
@@ -918,6 +949,25 @@ class TestCompileOnOneRankLegacyCollective(TestCase):
         gm = make_fx(self._fn, tracing_mode="fake")(torch.arange(4.0), self.mesh)
         self.assertIn("c10d.allreduce_.default", _call_targets(gm))
         self.assertTrue(_baked_pg_constants(gm))
+
+
+instantiate_device_type_tests(
+    TestCompileOnOneRank,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestCompileOnOneRankDeviceAsParameter,
+    globals(),
+    except_for=["cpu"],
+    allow_xpu=True,
+)
+instantiate_device_type_tests(
+    TestCompileOnOneRankCUDA,
+    globals(),
+    only_for=["cuda"],
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- classify the DTensor compile-on-one-rank test classes by their hardware requirements
- instantiate device-specific classes and pass generated device arguments to their test methods
- keep the complete test file together when extracting it from #190987

## Test Plan

- `git diff --check upstream/main...HEAD`
- `python3 -m py_compile test/distributed/tensor/test_compile_on_one_rank.py`
- `lintrunner -a --skip PYREFLY,CLANGTIDY` as part of the combined DTensor split-file lint run

Device runtime tests were not run locally. This PR does not claim NPU runtime coverage.

Prepared with an AI coding assistant.
