### PR TITLE
[BE] Stop linking cufft twice into torch_cuda

### DIFF
--- a/aten/src/ATen/CMakeLists.txt
+++ b/aten/src/ATen/CMakeLists.txt
@@ -838,18 +838,13 @@ if(USE_CUDA AND NOT USE_ROCM)
   list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/cutlass/include)
   list(APPEND ATen_CUDA_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/../../../third_party/cutlass/tools/util/include)
 
+  # cufft comes from caffe2::cufft (cmake/Dependencies.cmake), which already
+  # tracks the public CAFFE2_STATIC_LINK_CUDA option; adding it here too
+  # duplicated it under the internal ATEN_STATIC_CUDA switch instead.
   if($ENV{ATEN_STATIC_CUDA})
-    if(CUDA_VERSION VERSION_LESS_EQUAL 12.9)
-      list(APPEND ATen_CUDA_DEPENDENCY_LIBS
-          ${CUDA_LIBRARIES}
-          CUDA::cusparse_static
-          CUDA::cufft_static_nocallback)
-    else()
-      list(APPEND ATen_CUDA_DEPENDENCY_LIBS
-          ${CUDA_LIBRARIES}
-          CUDA::cusparse_static
-          CUDA::cufft_static)
-    endif()
+    list(APPEND ATen_CUDA_DEPENDENCY_LIBS
+        ${CUDA_LIBRARIES}
+        CUDA::cusparse_static)
 
    if(NOT BUILD_LAZY_CUDA_LINALG)
      list(APPEND ATen_CUDA_DEPENDENCY_LIBS
@@ -861,7 +856,6 @@ if(USE_CUDA AND NOT USE_ROCM)
     list(APPEND ATen_CUDA_DEPENDENCY_LIBS
       ${CUDA_LIBRARIES}
       CUDA::cusparse
-      CUDA::cufft
     )
    if(NOT BUILD_LAZY_CUDA_LINALG)
      list(APPEND ATen_CUDA_DEPENDENCY_LIBS


### PR DESCRIPTION
Both cmake/Dependencies.cmake (via caffe2::cufft) and aten/src/ATen/CMakeLists.txt (via CUDA::cufft directly) put cufft on torch_cuda's link line, gated by two independent switches (CAFFE2_STATIC_LINK_CUDA, a public option, vs ATEN_STATIC_CUDA, a private CI env var) that can disagree. Drop ATen's copy and keep caffe2::cufft, since that's the one users can actually control; this also collapses ATen's two now-identical CUDA_VERSION branches into one.