### PR TITLE
fix(elastic): guard s.close() against unbound variable in find_free_port

### DIFF
--- a/torch/distributed/elastic/rendezvous/etcd_server.py
+++ b/torch/distributed/elastic/rendezvous/etcd_server.py
@@ -53,13 +53,15 @@ def find_free_port():
 
     for addr in addrs:
         family, type, proto, _, _ = addr
+        s = None
         try:
             s = socket.socket(family, type, proto)
             s.bind(("localhost", 0))
             s.listen(0)
             return s
         except OSError as e:
-            s.close()  # type: ignore[possibly-undefined]
+            if s is not None:
+                s.close()
             print(f"Socket creation attempt failed: {e}")
     raise RuntimeError("Failed to create a socket")
 


### PR DESCRIPTION
## Problem

If `socket.socket()` raises on the first address in `find_free_port()`, `s` was never assigned and the `except OSError` block raises `NameError` on `s.close()`.

## Fix

Initialize `s = None` before the try block and guard `s.close()` with `if s is not None`.

Resolves #191395