### PR TITLE
fix(elastic): close mkstemp file descriptor in _create_file_store

### DIFF
--- a/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
+++ b/torch/distributed/elastic/rendezvous/c10d_rendezvous_backend.py
@@ -192,7 +192,8 @@ def _create_file_store(params: RendezvousParameters) -> FileStore:
         try:
             # The temporary file is readable and writable only by the user of
             # this process.
-            _, path = tempfile.mkstemp()
+            fd, path = tempfile.mkstemp()
+            os.close(fd)
         except OSError as exc:
             raise RendezvousError(
                 "The file creation for C10d store has failed. See inner exception for details."


### PR DESCRIPTION
## Problem

`_create_file_store()` calls `tempfile.mkstemp()` which returns `(fd, path)` but discards the fd without closing it. FileStore opens the path independently, so the mkstemp fd leaks.

## Fix

Capture both return values from mkstemp, close the fd immediately (FileStore will open the file itself), then proceed with the path.

Resolves #191394