### PR TITLE
[TestCase Refactoring] Decouple Experiment tests from hardcoded CUDA, add instantiate + capability-based admission (PR 2/5: Migrate 4 blockmask closure tests)

### DIFF
--- a/test/export/test_experimental.py
+++ b/test/export/test_experimental.py
@@ -28,8 +28,9 @@ from torch.export.graph_signature import OutputKind
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import (
     IS_FLEX_ATTENTION_CUDA_PLATFORM_SUPPORTED,
+    instantiate_device_type_tests,
 )
-from torch.testing._internal.common_utils import TEST_CUDA
+from torch.testing._internal.common_utils import HardwareClassification, TEST_CUDA
 from torch.utils import _pytree as pytree
 
 
@@ -193,49 +194,6 @@ def forward(self, p_linear_weight, p_linear_bias, c_lifted_tensor_0, x):
     return (div, permute_3, view_3)""",
         )
 
-    def _test_export_blockmask_with_mask_fn(self, make_mask_fn):
-        from torch.nn.attention.flex_attention import create_block_mask
-
-        _register_blockmask_pytree()
-
-        class Model(torch.nn.Module):
-            def __init__(self, mask_fn_factory):
-                super().__init__()
-                self.mask_fn_factory = mask_fn_factory
-
-            def forward(self, x):
-                mask_fn = self.mask_fn_factory()
-                block_mask = create_block_mask(
-                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
-                )
-                return x, block_mask
-
-        x = torch.randn(2, 128, device="cuda")
-        module = Model(make_mask_fn)
-
-        out_eager, mask_eager = module(x)
-
-        compiled = _dynamo_graph_capture_for_export(module)(x)
-        out_compiled, mask_compiled = compiled(x)
-
-        self.assertEqual(out_eager, out_compiled)
-        self.assertEqual(
-            mask_eager.mask_mod(1, 1, 64, 64),
-            mask_compiled.mask_mod(1, 1, 64, 64),
-        )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask(self):
-        def make_mask_fn():
-            res = 4
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
     def test_export_with_default_kwargs(self):
         class FunctionalWrapper(torch.nn.Module):
             """Wrapper with keyword-only argument in __call__."""
@@ -270,54 +228,6 @@ def forward(self, args_0):
     out = torch._C._nn.linear(l_args_0_, l_self_modules_module_parameters_weight_, l_self_modules_module_parameters_bias_);  l_args_0_ = l_self_modules_module_parameters_weight_ = l_self_modules_module_parameters_bias_ = None
     return self._dynamo_bytecode_unflatten((out,), _fn_args)""",
         )
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_mutated_closure(self):
-        def make_mask_fn():
-            res = 1
-
-            def fn(b, h, q, k):
-                return q >= k + res
-
-            res = 4  # mutation after function definition
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_with_containers(self):
-        def make_mask_fn():
-            offsets = [1, 2, 3]
-            config = {"base": 4, "nested": {"scale": 2}}
-
-            def fn(b, h, q, k):
-                return q >= k + config["base"] + sum(offsets)
-
-            return fn
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA not available")
-    def test_export_blockmask_closure_triple_nested(self):
-        def make_mask_fn():
-            a = 1
-
-            def level1():
-                b = 2
-
-                def level2():
-                    c = 3
-
-                    def fn(bx, h, q, k):
-                        return q >= k + a + b + c
-
-                    return fn
-
-                return level2()
-
-            return level1()
-
-        self._test_export_blockmask_with_mask_fn(make_mask_fn)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_export_blockmask_closure_self_recursive(self):
@@ -1883,6 +1793,101 @@ def forward(self, arg0_1):
                 eager_buf,
                 msg=lambda msg: f"{msg}\n{label}: buffer mutation mismatch",
             )
+
+
+@unittest.skipIf(not torch._dynamo.is_dynamo_supported(), "dynamo isn't supported")
+class TestExperimentDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def _test_export_blockmask_with_mask_fn(self, make_mask_fn, device):
+        from torch.nn.attention.flex_attention import create_block_mask
+
+        _register_blockmask_pytree()
+
+        class Model(torch.nn.Module):
+            def __init__(self, mask_fn_factory):
+                super().__init__()
+                self.mask_fn_factory = mask_fn_factory
+
+            def forward(self, x):
+                mask_fn = self.mask_fn_factory()
+                block_mask = create_block_mask(
+                    mask_fn, B=1, H=1, Q_LEN=64, KV_LEN=64, device=x.device
+                )
+                return x, block_mask
+
+        x = torch.randn(2, 128, device=device)
+        module = Model(make_mask_fn)
+
+        out_eager, mask_eager = module(x)
+
+        compiled = _dynamo_graph_capture_for_export(module)(x)
+        out_compiled, mask_compiled = compiled(x)
+
+        self.assertEqual(out_eager, out_compiled)
+        self.assertEqual(
+            mask_eager.mask_mod(1, 1, 64, 64),
+            mask_compiled.mask_mod(1, 1, 64, 64),
+        )
+
+    def test_export_blockmask(self, device):
+        def make_mask_fn():
+            res = 4
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+    def test_export_blockmask_mutated_closure(self, device):
+        def make_mask_fn():
+            res = 1
+
+            def fn(b, h, q, k):
+                return q >= k + res
+
+            res = 4  # mutation after function definition
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+    def test_export_blockmask_closure_with_containers(self, device):
+        def make_mask_fn():
+            offsets = [1, 2, 3]
+            config = {"base": 4, "nested": {"scale": 2}}
+
+            def fn(b, h, q, k):
+                return q >= k + config["base"] + sum(offsets)
+
+            return fn
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+    def test_export_blockmask_closure_triple_nested(self, device):
+        def make_mask_fn():
+            a = 1
+
+            def level1():
+                b = 2
+
+                def level2():
+                    c = 3
+
+                    def fn(bx, h, q, k):
+                        return q >= k + a + b + c
+
+                    return fn
+
+                return level2()
+
+            return level1()
+
+        self._test_export_blockmask_with_mask_fn(make_mask_fn, device)
+
+
+instantiate_device_type_tests(TestExperimentDevice, globals(), except_for="cpu")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
---
**Decouple Experiment tests` across 5 incremental PRs (#195139, #195140, #195142, #195144, #195145). This is Part 2 of 5.**

***Depends on PR #195139. Please merge #195139 first.***

Migrate 4 blockmask closure tests from `TestExperiment` to `TestExperimentDevice` with device parameterization.

Changes
---
* Moved `test_export_blockmask_closure_self_recursive`, `_tensor`, `_unsupported_class_instance`, and `_mutually_recursive` to `TestExperimentDevice`.

Test Plan
---
```bash
python -c "import ast; ast.parse(open('test_experimental.py').read())"
python -m pytest -rA -v test_experimental.py
python test_experimental.py -v -k TestExperimentDevice