### PR TITLE
Move partial XPU device property utils to aten

### DIFF
--- a/aten/src/ATen/xpu/XPUContext.h
+++ b/aten/src/ATen/xpu/XPUContext.h
@@ -88,7 +88,9 @@ template <auto* KernelFn>
   return *std::min_element(subgroup_sizes.begin(), subgroup_sizes.end());
 }
 
-// Returns the maximum number of workitems that are permitted in a Xe-Core.
+// Returns the maximum number of workitems that can be concurrently resident
+// on an Xe Core, calculated from the maximum subgroup size, the number of EUs
+// per Xe Core, and the number of hardware threads per EU.
 [[nodiscard]] inline size_t getDeviceMaxWorkItemsPerXeCore(
     at::DeviceIndex device = at::xpu::current_device()) {
   const auto* device_prop = at::xpu::getDeviceProperties(device);
@@ -97,15 +99,16 @@ template <auto* KernelFn>
       device_prop->gpu_hw_threads_per_eu;
 }
 
-// Returns the number of Xe-Cores on the given device.
+// Returns the number of Xe Cores on the given device.
 [[nodiscard]] inline size_t getDeviceXeCoreCount(
     at::DeviceIndex device = at::xpu::current_device()) {
   const auto* device_prop = at::xpu::getDeviceProperties(device);
   return device_prop->gpu_eu_count / device_prop->gpu_eu_count_per_subslice;
 }
 
-// Returns the maximum number of workitems that are permitted on the given
-// device.
+// Returns the maximum number of workitems that can be concurrently resident
+// on the device, based on the maximum subgroup size, the total number of EUs,
+// and the number of hardware threads supported per EU.
 [[nodiscard]] inline size_t getDeviceMaxWorkItems(
     at::DeviceIndex device = at::xpu::current_device()) {
   const auto* device_prop = at::xpu::getDeviceProperties(device);

--- a/aten/src/ATen/xpu/XPUContext.h
+++ b/aten/src/ATen/xpu/XPUContext.h
@@ -3,6 +3,7 @@
 #include <ATen/Context.h>
 #include <c10/xpu/XPUFunctions.h>
 #include <c10/xpu/XPUStream.h>
+#include <sycl/sycl.hpp>
 
 namespace at::xpu {
 
@@ -18,5 +19,120 @@ TORCH_XPU_API DeviceProp* getDeviceProperties(DeviceIndex device);
 TORCH_XPU_API int32_t getGlobalIdxFromDevice(DeviceIndex device);
 
 TORCH_XPU_API bool canDeviceAccessPeer(DeviceIndex device, DeviceIndex peer);
+
+// Returns the maximum number of workitems that are permitted in a work-group
+// for a specific kernel on the given device.
+template <class KernelClass>
+[[nodiscard]] inline size_t getKernelMaxWorkGroupSize(
+    DeviceIndex device_index = c10::xpu::current_device()) {
+  auto& context = c10::xpu::get_device_context();
+  auto& device = c10::xpu::get_raw_device(device_index);
+  auto kernel_id = sycl::get_kernel_id<KernelClass>();
+
+  auto bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+      context, {device}, {kernel_id});
+  sycl::kernel kernel = bundle.get_kernel(kernel_id);
+  return kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
+      device);
+}
+
+// Overload for functor-based kernels: deduces KernelClass from the function
+// object.
+template <class KernelClass>
+[[nodiscard]] inline size_t getKernelMaxWorkGroupSize(
+    const KernelClass& /*kfn*/,
+    DeviceIndex device_index = c10::xpu::current_device()) {
+  return getKernelMaxWorkGroupSize<KernelClass>(device_index);
+}
+
+// Overload for SYCL free-function kernels.
+template <auto* KernelFn>
+[[nodiscard]] inline size_t getKernelMaxWorkGroupSize(
+    DeviceIndex device_index = at::xpu::current_device()) {
+  namespace syclex = sycl::ext::oneapi::experimental;
+  auto& context = c10::xpu::get_device_context();
+  auto& device = c10::xpu::get_raw_device(device_index);
+#if SYCL_COMPILER_VERSION < 20260100
+  auto bundle =
+      syclex::get_kernel_bundle<KernelFn, sycl::bundle_state::executable>(
+          context);
+  sycl::kernel kernel = bundle.template ext_oneapi_get_kernel<KernelFn>();
+  return kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
+      device);
+#else
+  return syclex::get_kernel_info<
+      KernelFn,
+      sycl::info::kernel_device_specific::work_group_size>(context, device);
+#endif
+}
+
+// Returns the maximum number of workitems that are permitted in a subgroup.
+[[nodiscard]] inline size_t getDeviceMaxSubGroupSize(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  const auto& subgroup_sizes = device_prop->sub_group_sizes;
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      !subgroup_sizes.empty(),
+      "The device subgroup sizes is empty, please check the device status.");
+  return *std::max_element(subgroup_sizes.begin(), subgroup_sizes.end());
+}
+
+// Returns the minimum number of workitems that are permitted in a subgroup.
+[[nodiscard]] inline size_t getDeviceMinSubGroupSize(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  const auto& subgroup_sizes = device_prop->sub_group_sizes;
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      !subgroup_sizes.empty(),
+      "The device subgroup sizes is empty, please check the device status.");
+  return *std::min_element(subgroup_sizes.begin(), subgroup_sizes.end());
+}
+
+// Returns the maximum number of workitems that are permitted in a Xe-Core.
+[[nodiscard]] inline size_t getDeviceMaxWorkItemsPerXeCore(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  return getDeviceMaxSubGroupSize(device) *
+      device_prop->gpu_eu_count_per_subslice *
+      device_prop->gpu_hw_threads_per_eu;
+}
+
+// Returns the number of Xe-Cores on the given device.
+[[nodiscard]] inline size_t getDeviceXeCoreCount(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  return device_prop->gpu_eu_count / device_prop->gpu_eu_count_per_subslice;
+}
+
+// Returns the maximum number of workitems that are permitted on the given
+// device.
+[[nodiscard]] inline size_t getDeviceMaxWorkItems(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  return getDeviceMaxSubGroupSize(device) * device_prop->gpu_eu_count *
+      device_prop->gpu_hw_threads_per_eu;
+}
+
+// Returns the maximum number of workitems that are permitted in a work-group on
+// the given device.
+[[nodiscard]] inline size_t getDeviceMaxWorkGroupSize(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  return device_prop->max_work_group_size;
+}
+
+// Returns the number of hardware threads on the given device.
+[[nodiscard]] inline size_t getDeviceHWThreads(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  return device_prop->gpu_hw_threads_per_eu * device_prop->gpu_eu_count;
+}
+
+// Returns the number of EUs per Xe-Core on the given device.
+[[nodiscard]] inline size_t getDeviceEUCountPerXeCore(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  return device_prop->gpu_eu_count_per_subslice;
+}
 
 } // namespace at::xpu

--- a/aten/src/ATen/xpu/XPUContext.h
+++ b/aten/src/ATen/xpu/XPUContext.h
@@ -89,7 +89,7 @@ template <auto* KernelFn>
 }
 
 // Returns the maximum number of workitems that can be concurrently resident
-// on an Xe Core, calculated from the maximum subgroup size, the number of EUs
+// on a Xe Core, calculated from the maximum subgroup size, the number of EUs
 // per Xe Core, and the number of hardware threads per EU.
 [[nodiscard]] inline size_t getDeviceMaxWorkItemsPerXeCore(
     at::DeviceIndex device = at::xpu::current_device()) {

--- a/aten/src/ATen/xpu/XPUContext.h
+++ b/aten/src/ATen/xpu/XPUContext.h
@@ -3,7 +3,6 @@
 #include <ATen/Context.h>
 #include <c10/xpu/XPUFunctions.h>
 #include <c10/xpu/XPUStream.h>
-#include <sycl/sycl.hpp>
 
 namespace at::xpu {
 
@@ -49,10 +48,10 @@ template <class KernelClass>
 template <auto* KernelFn>
 [[nodiscard]] inline size_t getKernelMaxWorkGroupSize(
     DeviceIndex device_index = at::xpu::current_device()) {
-  namespace syclex = sycl::ext::oneapi::experimental;
   auto& context = c10::xpu::get_device_context();
   auto& device = c10::xpu::get_raw_device(device_index);
 #if SYCL_COMPILER_VERSION < 20260100
+  namespace syclex = sycl::ext::oneapi::experimental;
   auto bundle =
       syclex::get_kernel_bundle<KernelFn, sycl::bundle_state::executable>(
           context);
@@ -60,6 +59,7 @@ template <auto* KernelFn>
   return kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
       device);
 #else
+  namespace syclex = sycl::ext::oneapi::experimental;
   return syclex::get_kernel_info<
       KernelFn,
       sycl::info::kernel_device_specific::work_group_size>(context, device);
@@ -122,17 +122,24 @@ template <auto* KernelFn>
 }
 
 // Returns the number of hardware threads on the given device.
-[[nodiscard]] inline size_t getDeviceHWThreads(
+[[nodiscard]] inline uint32_t getDeviceHWThreads(
     at::DeviceIndex device = at::xpu::current_device()) {
   const auto* device_prop = at::xpu::getDeviceProperties(device);
   return device_prop->gpu_hw_threads_per_eu * device_prop->gpu_eu_count;
 }
 
 // Returns the number of EUs per Xe-Core on the given device.
-[[nodiscard]] inline size_t getDeviceEUCountPerXeCore(
+[[nodiscard]] inline uint32_t getDeviceEUCountPerXeCore(
     at::DeviceIndex device = at::xpu::current_device()) {
   const auto* device_prop = at::xpu::getDeviceProperties(device);
   return device_prop->gpu_eu_count_per_subslice;
+}
+
+// Returns the share local memory size of the given device.
+[[nodiscard]] inline size_t getDeviceLocalMemSize(
+    at::DeviceIndex device = at::xpu::current_device()) {
+  const auto* device_prop = at::xpu::getDeviceProperties(device);
+  return device_prop->local_mem_size;
 }
 
 } // namespace at::xpu

--- a/aten/src/ATen/xpu/XPUContext.h
+++ b/aten/src/ATen/xpu/XPUContext.h
@@ -50,8 +50,8 @@ template <auto* KernelFn>
     DeviceIndex device_index = at::xpu::current_device()) {
   auto& context = c10::xpu::get_device_context();
   auto& device = c10::xpu::get_raw_device(device_index);
-#if SYCL_COMPILER_VERSION < 20260100
   namespace syclex = sycl::ext::oneapi::experimental;
+#if SYCL_COMPILER_VERSION < 20260100
   auto bundle =
       syclex::get_kernel_bundle<KernelFn, sycl::bundle_state::executable>(
           context);
@@ -59,7 +59,6 @@ template <auto* KernelFn>
   return kernel.get_info<sycl::info::kernel_device_specific::work_group_size>(
       device);
 #else
-  namespace syclex = sycl::ext::oneapi::experimental;
   return syclex::get_kernel_info<
       KernelFn,
       sycl::info::kernel_device_specific::work_group_size>(context, device);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #195146

# Motivation
We would like to move the device properties utils/helper from https://github.com/intel/torch-xpu-ops/blob/main/src/comm/DeviceProperties.h to aten, which will benefit:
1.  fix https://github.com/intel/torch-xpu-ops/issues/4958
2. gather device property-related code into one file.

# Additional Context
| Use Count | Original API | New API |
|------:|-----|-----|
| 158 | `syclMaxWorkGroupSize` | `getKernelMaxWorkGroupSize` |
| 43 | `syclMaxWorkItemsPerSubSlice` | `getDeviceMaxWorkItemsPerXeCore` |
| 34 | `syclMaxWorkItemsPerTile` | `getDeviceMaxWorkItems` |
| 25 | `syclMaxSubGroupSize` | `getDeviceMaxSubGroupSize` |
| 14 | `syclDeviceMaxWorkGroupSize` | `getDeviceMaxWorkGroupSize` |
| 11 | `syclGpuHWThreadsPerEU` | Use `getDeviceHWThreads`  instead |
| 10 | `syclGpuEuCount` | Use `getDeviceHWThreads`  instead |
| 7 | `syclLocalMemSize` | `getDeviceLocalMemSize` |
| 5 | `syclMaxDSSNum` | `getDeviceXeCoreCount` |
| 4 | `syclPrefVectorWidth` | Move to Memory.h |
| 4 | `syclGpuEUCountPerSubslice` | `getDeviceEUCountPerXeCore` |
| 3 | `syclMinSubGroupSize` | `getDeviceMinSubGroupSize` |
| 1 | `syclMaxWorkItemsPerEU` | `getDeviceMaxWorkItems/(getDeviceXeCoreCount*getDeviceEUCountPerXeCore)` |
| 1 | `syclMaxComputeUnitSize` | Use `dev_prop->gpu_eu_count` instead |
| 1 | `syclHasFloat64` | Use `dev_prop->has_fp64` instead |
| 0 | `syclNativeVectorWidth` | removed |
| 0 | `syclMaxNumSubGroups` | removed |
| 0 | `syclGpuEuSimdWidth` | removed |
| 0 | `syclGlobalMemSize` | removed |