### PR TITLE
[MPS] Fix pad corrupting rank > 4 tensors with >= 2^16 inner elements

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -212,6 +212,19 @@ static Tensor& pad_out_template(Tensor& output,
     grad_output = grad_output_.contiguous();
   }
 
+  // MPSGraph pads a rank > 4 operand incorrectly once the output inner extent is large
+  // (https://github.com/pytorch/pytorch/issues/194922). Only the trailing padding_size / 2 dims
+  // are padded, so fold the leading dims into one batch dim.
+  const bool needs_flatten = ndims > 4;
+  if (needs_flatten) {
+    const int64_t batch_end = ndims - padding_size / 2 - 1;
+    input = input.flatten(0, batch_end);
+    if (is_backward_pass) {
+      grad_output = grad_output.flatten(0, batch_end);
+    }
+    ndims = input.dim();
+  }
+
   const uint32_t dims_mask = (1U << ndims) - 1;
   uint32_t startMask = dims_mask, endMask = dims_mask;
   std::vector<NSNumber*> leftPadVec(ndims, @(0));
@@ -311,6 +324,11 @@ static Tensor& pad_out_template(Tensor& output,
         } else {
           newCachedGraph->gradInputTensor_ = padGradTensor;
         }
+      }
+      if (needs_flatten) {
+        newCachedGraph->gradInputTensor_ = [mpsGraph reshapeTensor:newCachedGraph->gradInputTensor_
+                                                         withShape:getMPSShape(output)
+                                                              name:nil];
       }
     });
 

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11975,24 +11975,24 @@ class TestPad(TestCaseMPS):
         gi_ref = torch.ops.aten.replication_pad1d_backward(go.cpu(), x.cpu(), (1, 1))
         self.assertEqual(gi.cpu(), gi_ref)
 
-    def test_pad_5d_large_inner_dims(self):
+    @parametrize("mode", ["constant", "replicate", "reflect"])
+    @parametrize("shape,padding", [((1, 2, 3, 256, 256), (0, 0, 0, 0, 2, 1)),
+                                   ((1, 1, 2, 2, 65536), (2, 1)),
+                                   ((1, 1, 2, 2, 65536), (0, 0, 2, 1))])
+    def test_pad_5d_large_inner_dims(self, mode, shape, padding):
         # MPSGraph pads rank > 4 operands incorrectly once the output inner extent is large.
         # See https://github.com/pytorch/pytorch/issues/194922
-        def helper(shape, padding, mode):
-            cpu_x = torch.randn(shape, requires_grad=True)
-            mps_x = cpu_x.detach().clone().to("mps").requires_grad_()
-            cpu_out = F.pad(cpu_x, padding, mode=mode)
-            mps_out = F.pad(mps_x, padding, mode=mode)
-            self.assertEqual(cpu_out, mps_out)
-            grad = torch.randn_like(cpu_out)
-            cpu_out.backward(gradient=grad)
-            mps_out.backward(gradient=grad.to("mps"))
-            self.assertEqual(cpu_x.grad, mps_x.grad)
-
-        for mode in ["constant", "replicate", "reflect"]:
-            helper((1, 2, 3, 256, 256), (0, 0, 0, 0, 2, 1), mode)
-        helper((1, 1, 2, 2, 65536), (2, 1), "constant")
-        helper((1, 1, 2, 2, 65536), (0, 0, 2, 1), "constant")
+        if mode != "constant" and len(padding) != 6:
+            self.skipTest("replicate and reflect need a 6-element pad for a 5D input")
+        cpu_x = torch.randn(shape, requires_grad=True)
+        mps_x = cpu_x.detach().clone().to("mps").requires_grad_()
+        cpu_out = F.pad(cpu_x, padding, mode=mode)
+        mps_out = F.pad(mps_x, padding, mode=mode)
+        self.assertEqual(cpu_out, mps_out)
+        grad = torch.randn_like(cpu_out)
+        cpu_out.backward(gradient=grad)
+        mps_out.backward(gradient=grad.to("mps"))
+        self.assertEqual(cpu_x.grad, mps_x.grad)
 
 class TestConv3dChannelsLast3dMPS(NNTestCase):
     def _run_conv3d_cl3d(self, *, input_shape, Cin, Cout, k, pad, with_bias, dtype, groups=1):
@@ -17451,6 +17451,7 @@ instantiate_parametrized_tests(TestMPS)
 instantiate_parametrized_tests(TestSDPA)
 instantiate_parametrized_tests(TestSmoothL1Loss)
 instantiate_parametrized_tests(TestMetalLibrary)
+instantiate_parametrized_tests(TestPad)
 instantiate_parametrized_tests(TestConv3dChannelsLast3dMPS)
 instantiate_parametrized_tests(TestConvolutionMPS)
 instantiate_parametrized_tests(TestLargeTensors)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11975,6 +11975,25 @@ class TestPad(TestCaseMPS):
         gi_ref = torch.ops.aten.replication_pad1d_backward(go.cpu(), x.cpu(), (1, 1))
         self.assertEqual(gi.cpu(), gi_ref)
 
+    def test_pad_5d_large_inner_dims(self):
+        # MPSGraph pads rank > 4 operands incorrectly once the output inner extent is large.
+        # See https://github.com/pytorch/pytorch/issues/194922
+        def helper(shape, padding, mode):
+            cpu_x = torch.randn(shape, requires_grad=True)
+            mps_x = cpu_x.detach().clone().to("mps").requires_grad_()
+            cpu_out = F.pad(cpu_x, padding, mode=mode)
+            mps_out = F.pad(mps_x, padding, mode=mode)
+            self.assertEqual(cpu_out, mps_out)
+            grad = torch.randn_like(cpu_out)
+            cpu_out.backward(gradient=grad)
+            mps_out.backward(gradient=grad.to("mps"))
+            self.assertEqual(cpu_x.grad, mps_x.grad)
+
+        for mode in ["constant", "replicate", "reflect"]:
+            helper((1, 2, 3, 256, 256), (0, 0, 0, 0, 2, 1), mode)
+        helper((1, 1, 2, 2, 65536), (2, 1), "constant")
+        helper((1, 1, 2, 2, 65536), (0, 0, 2, 1), "constant")
+
 class TestConv3dChannelsLast3dMPS(NNTestCase):
     def _run_conv3d_cl3d(self, *, input_shape, Cin, Cout, k, pad, with_bias, dtype, groups=1):
         torch.manual_seed(0)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11975,25 +11975,6 @@ class TestPad(TestCaseMPS):
         gi_ref = torch.ops.aten.replication_pad1d_backward(go.cpu(), x.cpu(), (1, 1))
         self.assertEqual(gi.cpu(), gi_ref)
 
-    @parametrize("mode", ["constant", "replicate", "reflect"])
-    @parametrize("shape,padding", [((1, 2, 3, 256, 256), (0, 0, 0, 0, 2, 1)),
-                                   ((1, 1, 2, 2, 65536), (2, 1)),
-                                   ((1, 1, 2, 2, 65536), (0, 0, 2, 1))])
-    def test_pad_5d_large_inner_dims(self, mode, shape, padding):
-        # MPSGraph pads rank > 4 operands incorrectly once the output inner extent is large.
-        # See https://github.com/pytorch/pytorch/issues/194922
-        if mode != "constant" and len(padding) != 6:
-            self.skipTest("replicate and reflect need a 6-element pad for a 5D input")
-        cpu_x = torch.randn(shape, requires_grad=True)
-        mps_x = cpu_x.detach().clone().to("mps").requires_grad_()
-        cpu_out = F.pad(cpu_x, padding, mode=mode)
-        mps_out = F.pad(mps_x, padding, mode=mode)
-        self.assertEqual(cpu_out, mps_out)
-        grad = torch.randn_like(cpu_out)
-        cpu_out.backward(gradient=grad)
-        mps_out.backward(gradient=grad.to("mps"))
-        self.assertEqual(cpu_x.grad, mps_x.grad)
-
 class TestConv3dChannelsLast3dMPS(NNTestCase):
     def _run_conv3d_cl3d(self, *, input_shape, Cin, Cout, k, pad, with_bias, dtype, groups=1):
         torch.manual_seed(0)
@@ -17451,7 +17432,6 @@ instantiate_parametrized_tests(TestMPS)
 instantiate_parametrized_tests(TestSDPA)
 instantiate_parametrized_tests(TestSmoothL1Loss)
 instantiate_parametrized_tests(TestMetalLibrary)
-instantiate_parametrized_tests(TestPad)
 instantiate_parametrized_tests(TestConv3dChannelsLast3dMPS)
 instantiate_parametrized_tests(TestConvolutionMPS)
 instantiate_parametrized_tests(TestLargeTensors)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7694,6 +7694,27 @@ class TestNNDeviceType(NNTestCase):
             c_cpu.backward(grad.cpu())
             self.assertEqual(x.grad, ref_x.grad)
 
+    @onlyAccelerator   # CPU is the reference the results are compared against
+    @parametrize_test("mode,shape,padding", [
+        ("constant", (1, 2, 3, 256, 256), (0, 0, 0, 0, 2, 1)),
+        ("constant", (1, 1, 2, 2, 65536), (2, 1)),
+        ("constant", (1, 1, 2, 2, 65536), (0, 0, 2, 1)),
+        ("replicate", (1, 2, 3, 256, 256), (0, 0, 0, 0, 2, 1)),
+        ("reflect", (1, 2, 3, 256, 256), (0, 0, 0, 0, 2, 1)),
+    ])
+    def test_pad_5d_large_inner_dims(self, device, mode, shape, padding):
+        # Padding a rank > 4 operand must not corrupt the copied input when the inner extent is large.
+        # https://github.com/pytorch/pytorch/issues/194922
+        x = torch.randn(shape, device=device, requires_grad=True)
+        ref_x = x.detach().cpu().requires_grad_()
+        out = F.pad(x, padding, mode=mode)
+        out_cpu = F.pad(ref_x, padding, mode=mode)
+        self.assertEqual(out, out_cpu)
+        grad = torch.randn_like(out)
+        out.backward(grad)
+        out_cpu.backward(grad.cpu())
+        self.assertEqual(x.grad, ref_x.grad)
+
     @onlyCUDA
     @largeTensorTest("48GB", "cpu")
     @largeTensorTest("48GB", "cuda")


### PR DESCRIPTION
## Issue

Fixes #194922

## Summary

MPSGraph's `padTensor:` and `padGradientWithIncomingGradientTensor:` overwrite the copied input data at rank > 4, mostly with zeros and partly with other wrong values. The shape is correct, so nothing notices: `F.pad(randn(1, 3, 9, 256, 544), (0,0,0,0,2,0))` is garbage in 79% of its elements. The boundary is in elements, not bytes: `max(output last dim, product of output dims after the padded axis) >= 65536`.

`pad_out_template` builds the graph at the operand's own rank, and only the trailing `padding_size / 2` dims are padded, so this folds the leading dims into one batch dim, pads at rank <= 4 (measured correct at any extent), and reshapes back in-graph. It is in the shared template, so it also fixes `reflection_pad3d` and `replication_pad3d`, equally corrupt today, forward and backward. #194944 fixes constant padding only, and applies cleanly on top.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No.

---
AI assistance was used: Claude Code wrote the patch, the test and this description under my direction; I reviewed every line.
