### PR TITLE
Skip first moment allocation in Adam when beta1=0

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -739,6 +739,35 @@ class TestOptimRenewed(TestCase):
             self.assertTrue(a1_grad_imags.all_popped())
             self.assertTrue(losses.all_popped())
 
+    def test_adam_beta1_zero_skips_exp_avg(self, device):
+        model = torch.nn.Linear(10, 10).to(device)
+        opt = torch.optim.Adam(model.parameters(), betas=(0.0, 0.999), foreach=False)
+        x = torch.randn(4, 10, device=device)
+        model(x).sum().backward()
+        opt.step()
+        for p in model.parameters():
+            state = opt.state[p]
+            self.assertNotIn("exp_avg", state)
+            self.assertIn("exp_avg_sq", state)
+
+    def test_adam_beta1_zero_correctness(self, device):
+        torch.manual_seed(42)
+        model1 = torch.nn.Linear(10, 10).to(device)
+        model2 = torch.nn.Linear(10, 10).to(device)
+        model2.load_state_dict(model1.state_dict())
+        opt1 = torch.optim.Adam(model1.parameters(), lr=0.01, betas=(0.0, 0.999), foreach=False)
+        opt2 = torch.optim.Adam(model2.parameters(), lr=0.01, betas=(1e-30, 0.999), foreach=False)
+        for _ in range(3):
+            x = torch.randn(4, 10, device=device)
+            model1(x).sum().backward()
+            model2(x).sum().backward()
+            opt1.step()
+            opt2.step()
+            opt1.zero_grad()
+            opt2.zero_grad()
+        for p1, p2 in zip(model1.parameters(), model2.parameters()):
+            self.assertTrue(torch.allclose(p1, p2, atol=1e-5))
+
     def test_adamw_serialization(self, device):
         model = torch.nn.Linear(5, 5).to(device)
         optim = torch.optim.AdamW(model.parameters())

--- a/torch/optim/adam.py
+++ b/torch/optim/adam.py
@@ -175,9 +175,15 @@ class Adam(Optimizer):
                         else torch.tensor(0.0, dtype=_get_scalar_dtype(), device="cpu")
                     )
                     # Exponential moving average of gradient values
-                    state["exp_avg"] = torch.zeros_like(
-                        p, memory_format=torch.preserve_format
+                    beta1 = group["betas"][0]
+                    skip_first_moment = (
+                        isinstance(beta1, float) and beta1 == 0.0
+                        and not group.get("fused") and not group.get("foreach")
                     )
+                    if not skip_first_moment:
+                        state["exp_avg"] = torch.zeros_like(
+                            p, memory_format=torch.preserve_format
+                        )
                     # Exponential moving average of squared gradient values
                     state["exp_avg_sq"] = torch.zeros_like(
                         p, memory_format=torch.preserve_format
@@ -188,7 +194,7 @@ class Adam(Optimizer):
                             p, memory_format=torch.preserve_format
                         )
 
-                exp_avgs.append(state["exp_avg"])
+                exp_avgs.append(state.get("exp_avg"))
                 exp_avg_sqs.append(state["exp_avg_sq"])
 
                 if group["amsgrad"]:
@@ -393,6 +399,8 @@ def _single_tensor_adam(
     else:
         beta1_dict = None
 
+    skip_exp_avg = isinstance(beta1, float) and beta1 == 0.0
+
     for i, param in enumerate(params):
         grad = grads[i] if not maximize else -grads[i]
         exp_avg = exp_avgs[i]
@@ -429,7 +437,8 @@ def _single_tensor_adam(
 
         if torch.is_complex(param):
             grad = torch.view_as_real(grad)
-            exp_avg = torch.view_as_real(exp_avg)
+            if exp_avg is not None:
+                exp_avg = torch.view_as_real(exp_avg)
             exp_avg_sq = torch.view_as_real(exp_avg_sq)
             if amsgrad:
                 max_exp_avg_sqs[i] = torch.view_as_real(max_exp_avg_sqs[i])
@@ -453,7 +462,8 @@ def _single_tensor_adam(
 
         # Decay the first and second moment running average coefficient
 
-        exp_avg.lerp_(grad, 1 - device_beta1)
+        if not skip_exp_avg:
+            exp_avg.lerp_(grad, 1 - device_beta1)
 
         # Nested if is necessary to bypass jitscript rules
         if differentiable and isinstance(beta2, Tensor):
@@ -520,14 +530,15 @@ def _single_tensor_adam(
                     exp_avg_sq.sqrt() / (bias_correction2_sqrt * step_size_neg)
                 ).add_(eps / step_size_neg)
 
+            momentum = grad if skip_exp_avg else exp_avg
             if differentiable:
-                param.addcdiv_(exp_avg.clone(), denom)
+                param.addcdiv_(momentum.clone(), denom)
             else:
-                param.addcdiv_(exp_avg, denom)
+                param.addcdiv_(momentum, denom)
         else:
             step = _get_value(step_t)
 
-            bias_correction1 = 1 - beta1**step
+            bias_correction1 = 1 if skip_exp_avg else 1 - beta1**step
             bias_correction2 = 1 - beta2**step
 
             step_size = lr / bias_correction1
@@ -543,7 +554,8 @@ def _single_tensor_adam(
             else:
                 denom = (exp_avg_sq.sqrt() / bias_correction2_sqrt).add_(eps)
 
-            param.addcdiv_(exp_avg, denom, value=-step_size)  # type: ignore[arg-type]
+            momentum = grad if skip_exp_avg else exp_avg
+            param.addcdiv_(momentum, denom, value=-step_size)  # type: ignore[arg-type]
 
         # Lastly, switch back to complex view
         if amsgrad and torch.is_complex(params[i]):


### PR DESCRIPTION
Fixes #138248

When beta1=0, the first moment (exp_avg) equals the gradient (m_t = 0*m_{t-1} + 1*g_t = g_t), so allocating a full parameter-sized tensor for it is wasteful. This is common in GAN training where betas=(0, 0.999) is standard (e.g. StyleGAN).

This PR skips exp_avg allocation and uses grad directly in the single-tensor Adam step when beta1=0 and foreach/fused are disabled.

Changes:
1. torch/optim/adam.py: Skip exp_avg allocation in _init_group, use grad directly in _single_tensor_adam
2. test/test_optim.py: Test state savings and correctness vs near-zero beta1

The foreach and fused paths still allocate exp_avg since their tensor-grouping APIs require it. This can be optimized in a follow-up.

cc @janeyx99 