### PR TITLE
Teach the triage skill to flag release-branch candidates

### DIFF
--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -34,6 +34,7 @@ This skill helps triage GitHub issues by routing issues, applying labels, and le
   - Step 3: Redirect to Secondary Oncall
   - Step 4: Label the Issue
   - Step 5: High Priority — REQUIRES HUMAN REVIEW
+  - Step 5.5: release-review — Possible Release-Branch Candidate
   - Step 6: bot-triaged (automatic)
   - Step 7: Mark Triaged
 - [V1 Constraints](#v1-constraints)
@@ -234,6 +235,39 @@ High priority criteria:
 - Many users affected
 - Core component or popular model impact
 
+### 5.5) release-review — Possible Release-Branch Candidate
+
+Add `release-review` when an issue plausibly meets the cherry-pick bar in
+[RELEASE.md](../../../RELEASE.md). The point is to surface candidates early so the release
+manager can find them with a search, not to decide anything — a fix may not exist yet, and
+the decision to cherry-pick is never the bot's.
+
+Add it when **any** of these hold:
+
+- **Regression against the most recent released minor version.** Pair it with
+  `module: regression`. Only against the last released minor (e.g. while 2.14 is in
+  progress, a regression versus 2.13.x) — a regression against a much older version is
+  not a release candidate.
+- **Critical correctness or stability:** silent correctness (wrong results, no error),
+  backwards-compatibility break, crash / segfault, deadlock or hang, or a large memory
+  leak.
+- **Critical fix to a feature introduced in the most recent minor release** — new
+  surface that shipped broken.
+- **Binary / packaging:** anything affecting wheels, conda packages, Docker images,
+  install, or the release build itself. Pair it with `module: binaries`.
+- **Affects the release currently being prepared.** A bug reported against a nightly, an
+  RC, or the release branch that would ship if it is not fixed — including anything found
+  by release validation or downstream canaries. This holds even when it is not a
+  regression against the previous minor, e.g. a defect in code that has never shipped.
+
+Apply it generously. A false positive costs the release manager one glance; a miss costs
+a broken release. When unsure, add it.
+
+`release-review` is a flag, not a verdict, and it is independent of `triage review` — an
+issue can carry both. Do not add it to feature requests, enhancements, or documentation-only
+issues, and do not add it for a regression against a version older than the last released
+minor.
+
 ### 6) bot-triaged (automatic)
 
 The `bot-triaged` label is automatically applied by a post-hook after any issue mutation. You do not need to add it manually.
@@ -257,6 +291,7 @@ If not transferred/redirected and not flagged for review, add `triaged`.
 **DO:**
 - Close clear usage questions and point to discuss.pytorch.org (per step 1)
 - Be conservative - when in doubt, add `triage review` for human attention
+- Add `release-review` whenever an issue plausibly meets the RELEASE.md cherry-pick bar (step 5.5); err toward adding it
 - Apply type labels (`feature`, `enhancement`, `function request`) when confident
 - Add `triaged` label when classification is complete
 

--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -1096,6 +1096,10 @@
       "description": "This tag is to mark Feature Tracked for PyTorch OSS Releases"
     },
     {
+      "name": "release-review",
+      "description": "Flagged as a possible release-branch candidate under the RELEASE.md cherry-pick criteria. For release-manager review; does not itself request a cherry-pick."
+    },
+    {
       "name": "security",
       "description": ""
     },


### PR DESCRIPTION
Has the triage bot flag release-branch candidates as it goes, so they can be found with a search instead of by reading the queue.

## Why

Release-relevant issues are currently surfaced by the release manager reading through incoming issues. Anything missed there is found later — often by a downstream user, sometimes after the RC. Flagging at triage time turns that into `is:issue label:release-review`.

## What it adds

**Step 5.5** in `SKILL.md`: apply `release-review` when an issue plausibly meets the [RELEASE.md](https://github.com/pytorch/pytorch/blob/main/RELEASE.md) cherry-pick bar —

- regression against the most recent released minor (pair with `module: regression`)
- critical correctness or stability: silent correctness, BC break, crash/segfault, deadlock, large memory leak
- critical fix to a feature introduced in the most recent minor
- binaries / packaging: wheels, conda, Docker, install, the release build (pair with `module: binaries`)
- **anything that would ship broken in the release currently being prepared** — bugs found on a nightly, an RC, or the release branch, including from release validation or downstream canaries. This case is not a regression against anything, but still blocks a release, so the other four criteria miss it.

The step says to apply it generously: a false positive costs the release manager one glance, a miss costs a broken release. It is explicitly a **flag, not a verdict** — a fix may not exist yet, and the cherry-pick decision stays with the release manager. Independent of `triage review`, so an issue can carry both. Excluded: feature requests, enhancements, docs-only, and regressions against versions older than the last released minor.

**`labels.json`**: adds the label entry. This is not documentation — `scripts/validate_labels.py` strips any label not present in that file, so without it the bot would appear to apply `release-review` and the hook would silently drop it.

## Required before this does anything

**The `release-review` label does not exist on pytorch/pytorch.** I checked; it 404s. It needs creating, and I can't do that from here.

Worth deciding at the same time: there is an existing **`patch release triage`** label with **zero** issues and no description. If that was meant for this purpose, it would be better to reuse it than add a second one — say the word and I'll switch the PR over.

## Scope

This flags **issues**. The example you gave, #194786, is a PR, and the skill only triages issues — PRs go through the existing cherry-pick process. So the effect here is: the issue behind a fix gets flagged, and the release manager sees the candidate before or alongside the PR.

## Note on labels.json

`count` in that file says `284` while the array holds `281` entries (282 after this change). Pre-existing drift; I left it alone rather than fold an unrelated correction into this PR, but someone may want to fix it.

---

Filed with the help of Claude Code.