### PR TITLE
Teach the triage skill to flag issues affecting an upcoming release

### DIFF
--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -34,7 +34,7 @@ This skill helps triage GitHub issues by routing issues, applying labels, and le
   - Step 3: Redirect to Secondary Oncall
   - Step 4: Label the Issue
   - Step 5: High Priority — REQUIRES HUMAN REVIEW
-  - Step 5.5: release triage — Possible Release-Branch Candidate
+  - Step 5.5: release triage — Affects an Upcoming Release
   - Step 6: bot-triaged (automatic)
   - Step 7: Mark Triaged
 - [V1 Constraints](#v1-constraints)
@@ -235,19 +235,29 @@ High priority criteria:
 - Many users affected
 - Core component or popular model impact
 
-### 5.5) release triage — Possible Release-Branch Candidate
+### 5.5) release triage — Affects an Upcoming Release
 
-Add `release triage` when an issue plausibly meets the cherry-pick bar in
-[RELEASE.md](../../../RELEASE.md). The point is to surface candidates early so the release
-manager can find them with `is:issue label:"release triage"`, not to decide anything — a fix
-may not exist yet, and the decision to cherry-pick is never the bot's.
+Add `release triage` when an issue would affect a release if it went unfixed. This is a
+continuous process, not something that only applies while a release branch is open. The
+label means "whoever owns the release needs to see this"; what happens next depends on
+where the cycle currently is:
+
+- **Between a completed release and the next branch cut** — the fix lands in main and
+  ships in the next release. Flagging early is what keeps the problem from reaching the
+  branch at all.
+- **Between branch cut and release** — the fix lands in main and is then cherry-picked to
+  the release branch, under the criteria in [RELEASE.md](../../../RELEASE.md).
+
+Either way the bot's job is the same: surface it so it can be found with
+`is:issue label:"release triage"`. It is not deciding anything — a fix may not exist yet,
+and whether to cherry-pick is never the bot's call.
 
 Add it when **any** of these hold:
 
 - **Regression against the most recent released minor version.** Pair it with
   `module: regression`. Only against the last released minor (e.g. while 2.14 is in
   progress, a regression versus 2.13.x) — a regression against a much older version is
-  not a release candidate.
+  not release-relevant.
 - **Critical correctness or stability:** silent correctness (wrong results, no error),
   backwards-compatibility break, crash / segfault, deadlock or hang, or a large memory
   leak.
@@ -255,18 +265,17 @@ Add it when **any** of these hold:
   surface that shipped broken.
 - **Binary / packaging:** anything affecting wheels, conda packages, Docker images,
   install, or the release build itself. Pair it with `module: binaries`.
-- **Affects the release currently being prepared.** A bug reported against a nightly, an
-  RC, or the release branch that would ship if it is not fixed — including anything found
-  by release validation or downstream canaries. This holds even when it is not a
-  regression against the previous minor, e.g. a defect in code that has never shipped.
+- **Would ship broken in the next release.** A defect on main, a nightly, an RC, or the
+  release branch that reaches users if nobody fixes it — including anything surfaced by
+  release validation or downstream canaries. This holds even when it is not a regression
+  against anything, e.g. a bug in code that has never shipped.
 
 Apply it generously. A false positive costs the release manager one glance; a miss costs
 a broken release. When unsure, add it.
 
-`release triage` is a flag, not a verdict, and it is independent of `triage review` — an
-issue can carry both. Do not add it to feature requests, enhancements, or documentation-only
-issues, and do not add it for a regression against a version older than the last released
-minor.
+`release triage` is independent of `triage review` — an issue can carry both. Do not add it
+to feature requests, enhancements, or documentation-only issues, and do not add it for a
+regression against a version older than the last released minor.
 
 ### 6) bot-triaged (automatic)
 
@@ -291,7 +300,7 @@ If not transferred/redirected and not flagged for review, add `triaged`.
 **DO:**
 - Close clear usage questions and point to discuss.pytorch.org (per step 1)
 - Be conservative - when in doubt, add `triage review` for human attention
-- Add `release triage` whenever an issue plausibly meets the RELEASE.md cherry-pick bar (step 5.5); err toward adding it
+- Add `release triage` whenever an issue would affect an upcoming release (step 5.5); err toward adding it
 - Apply type labels (`feature`, `enhancement`, `function request`) when confident
 - Add `triaged` label when classification is complete
 

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -34,6 +34,7 @@ This skill helps triage GitHub issues by routing issues, applying labels, and le
   - Step 3: Redirect to Secondary Oncall
   - Step 4: Label the Issue
   - Step 5: High Priority — REQUIRES HUMAN REVIEW
+  - Step 5.5: release triage — Possible Release-Branch Candidate
   - Step 6: bot-triaged (automatic)
   - Step 7: Mark Triaged
 - [V1 Constraints](#v1-constraints)
@@ -234,6 +235,39 @@ High priority criteria:
 - Many users affected
 - Core component or popular model impact
 
+### 5.5) release triage — Possible Release-Branch Candidate
+
+Add `release triage` when an issue plausibly meets the cherry-pick bar in
+[RELEASE.md](../../../RELEASE.md). The point is to surface candidates early so the release
+manager can find them with `is:issue label:"release triage"`, not to decide anything — a fix
+may not exist yet, and the decision to cherry-pick is never the bot's.
+
+Add it when **any** of these hold:
+
+- **Regression against the most recent released minor version.** Pair it with
+  `module: regression`. Only against the last released minor (e.g. while 2.14 is in
+  progress, a regression versus 2.13.x) — a regression against a much older version is
+  not a release candidate.
+- **Critical correctness or stability:** silent correctness (wrong results, no error),
+  backwards-compatibility break, crash / segfault, deadlock or hang, or a large memory
+  leak.
+- **Critical fix to a feature introduced in the most recent minor release** — new
+  surface that shipped broken.
+- **Binary / packaging:** anything affecting wheels, conda packages, Docker images,
+  install, or the release build itself. Pair it with `module: binaries`.
+- **Affects the release currently being prepared.** A bug reported against a nightly, an
+  RC, or the release branch that would ship if it is not fixed — including anything found
+  by release validation or downstream canaries. This holds even when it is not a
+  regression against the previous minor, e.g. a defect in code that has never shipped.
+
+Apply it generously. A false positive costs the release manager one glance; a miss costs
+a broken release. When unsure, add it.
+
+`release triage` is a flag, not a verdict, and it is independent of `triage review` — an
+issue can carry both. Do not add it to feature requests, enhancements, or documentation-only
+issues, and do not add it for a regression against a version older than the last released
+minor.
+
 ### 6) bot-triaged (automatic)
 
 The `bot-triaged` label is automatically applied by a post-hook after any issue mutation. You do not need to add it manually.
@@ -257,6 +291,7 @@ If not transferred/redirected and not flagged for review, add `triaged`.
 **DO:**
 - Close clear usage questions and point to discuss.pytorch.org (per step 1)
 - Be conservative - when in doubt, add `triage review` for human attention
+- Add `release triage` whenever an issue plausibly meets the RELEASE.md cherry-pick bar (step 5.5); err toward adding it
 - Apply type labels (`feature`, `enhancement`, `function request`) when confident
 - Add `triaged` label when classification is complete
 

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -251,10 +251,6 @@ does not decide anything.
 says `unknown`, skip the two version-dependent criteria below and judge the rest on their
 own merits.
 
-The other side of the comparison usually comes from the issue itself: the environment dump
-reports the `torch` version the reporter is on, and regressions normally name the version
-that last worked.
-
 Add it when **any** of these hold:
 
 - **Regression against the most recent released minor version.** The issue reports

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -268,7 +268,7 @@ Add it when **any** of these hold:
   that shipped broken. Go by what the issue says ("new in 2.x", "added in 2.x", "since
   upgrading to 2.x") checked against the version in `RELEASE CONTEXT`; do not try to recall
   which features shipped in which release.
-- **Binary / packaging:** anything affecting wheels, conda packages, Docker images,
+- **Binary / packaging:** anything affecting wheels, Docker images,
   install, or the release build itself. Pair it with `module: binaries`.
 - **Would ship broken in the next release.** A defect on main, a nightly, an RC, or the
   release branch that reaches users if nobody fixes it — including anything surfaced by

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -241,17 +241,31 @@ Add `release triage` when an issue would affect a release if it went unfixed. Th
 only surfaces the issue for whoever owns the release; it is not a cherry-pick request and
 does not decide anything.
 
+**You are told which version is current — never guess it.** Your prompt carries a
+`RELEASE CONTEXT` block giving the most recent released minor version, resolved from the
+newest non-prerelease [GitHub release](https://github.com/pytorch/pytorch/releases) at run
+time. Use that value only. Do not use a version written in this file, and do not rely on
+what you remember about PyTorch releases — that is stale by construction. If the block
+says `unknown`, skip the two version-dependent criteria below and judge the rest on their
+own merits.
+
+The other side of the comparison usually comes from the issue itself: the environment dump
+reports the `torch` version the reporter is on, and regressions normally name the version
+that last worked.
+
 Add it when **any** of these hold:
 
-- **Regression against the most recent released minor version.** Pair it with
-  `module: regression`. Only against the last released minor (e.g. while 2.14 is in
-  progress, a regression versus 2.13.x) — a regression against a much older version is
-  not release-relevant.
+- **Regression against the most recent released minor version.** The issue reports
+  something that worked on that minor (or later) and is broken now. Pair it with
+  `module: regression`. If the last-working version is older than that minor, it is not
+  release-relevant.
 - **Critical correctness or stability:** silent correctness (wrong results, no error),
   backwards-compatibility break, crash / segfault, deadlock or hang, or a large memory
   leak.
-- **Critical fix to a feature introduced in the most recent minor release** — new
-  surface that shipped broken.
+- **Critical fix to a feature introduced in the most recent minor release** — new surface
+  that shipped broken. Go by what the issue says ("new in 2.x", "added in 2.x", "since
+  upgrading to 2.x") checked against the version in `RELEASE CONTEXT`; do not try to recall
+  which features shipped in which release.
 - **Binary / packaging:** anything affecting wheels, conda packages, Docker images,
   install, or the release build itself. Pair it with `module: binaries`.
 - **Would ship broken in the next release.** A defect on main, a nightly, an RC, or the

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -33,10 +33,9 @@ This skill helps triage GitHub issues by routing issues, applying labels, and le
   - Step 2.5: PT2 Issues — Special Handling
   - Step 3: Redirect to Secondary Oncall
   - Step 4: Label the Issue
-  - Step 5: High Priority — REQUIRES HUMAN REVIEW
-  - Step 6: release triage — Affects an Upcoming Release
-  - Step 7: bot-triaged (automatic)
-  - Step 8: Mark Triaged
+  - Step 5: Escalate — High Priority (human review), then release triage
+  - Step 6: bot-triaged (automatic)
+  - Step 7: Mark Triaged
 - [V1 Constraints](#v1-constraints)
 
 **Labels reference:** See [labels.json](labels.json) for the full catalog of labels suitable for triage. **ONLY apply labels that exist in this file.** Do not invent or guess label names. This file excludes CI triggers, test configs, release notes, deprecated labels, and labels requiring human decision.
@@ -160,7 +159,7 @@ If the issue belongs in another repo (vision/text/audio/RL/ExecuTorch/etc.), tra
 
 ### 2.5) PT2 Issues — Special Handling
 
-**PT2 is NOT a redirect.** `oncall: pt2` is not like the other oncall labels in Step 3. PT2 issues continue through Steps 4–8 for full triage — add `oncall: pt2`, then proceed to label with `module:` labels, mark `triaged`, etc.
+**PT2 is NOT a redirect.** `oncall: pt2` is not like the other oncall labels in Step 3. PT2 issues continue through Steps 4–7 for full triage — add `oncall: pt2`, then proceed to label with `module:` labels, mark `triaged`, etc.
 
 **Every `oncall: pt2` issue MUST have at least one `module:` label.** The PT2 oncall queue is too broad without a module label — the team needs to know which component is affected (e.g., `module: dynamo`, `module: inductor`, `module: helion`, `module: dynamic shapes`). If you cannot determine the specific module, use `module: compile ux` as a fallback, but always try to be specific first. See [pt2-triage-rubric.md](pt2-triage-rubric.md) for detailed guidance.
 
@@ -220,7 +219,13 @@ Only if the issue stays in the general queue:
 
 **Label based on the actual bug, not keywords.** Read the issue to understand what is actually broken. A bug about broadcasting that happens to mention "nan" in a parameter name is a frontend bug, not a NaN/Inf bug.
 
-### 5) High Priority — REQUIRES HUMAN REVIEW
+### 5) Escalate — High Priority (human review), then release triage
+
+Two independent decisions, in this order. Work through 5a first, then 5b for **every**
+issue — 5b is not limited to issues you escalated in 5a, and an issue can end up with
+both labels, one, or neither.
+
+#### 5a) High Priority — REQUIRES HUMAN REVIEW
 
 **CRITICAL:** If you believe an issue is high priority, you MUST:
 1. Add `triage review` label and do not add `triaged`
@@ -235,7 +240,7 @@ High priority criteria:
 - Many users affected
 - Core component or popular model impact
 
-### 6) release triage — Affects an Upcoming Release
+#### 5b) release triage — Affects an Upcoming Release
 
 Add `release triage` when an issue would affect a release if it went unfixed. The label
 only surfaces the issue for whoever owns the release; it is not a cherry-pick request and
@@ -276,15 +281,15 @@ Add it when **any** of these hold:
 Apply it generously. A false positive costs the release manager one glance; a miss costs
 a broken release. When unsure, add it.
 
-`release triage` is independent of `triage review` — an issue can carry both. Do not add it
-to feature requests, enhancements, or documentation-only issues, and do not add it for a
-regression against a version older than the last released minor.
+`release triage` is independent of the `triage review` decision in 5a — an issue can carry
+both. Do not add it to feature requests, enhancements, or documentation-only issues, and do
+not add it for a regression against a version older than the last released minor.
 
-### 7) bot-triaged (automatic)
+### 6) bot-triaged (automatic)
 
 The `bot-triaged` label is automatically applied by a post-hook after any issue mutation. You do not need to add it manually.
 
-### 8) Mark triaged
+### 7) Mark triaged
 
 If not transferred/redirected and not flagged for review, add `triaged`.
 
@@ -303,7 +308,7 @@ If not transferred/redirected and not flagged for review, add `triaged`.
 **DO:**
 - Close clear usage questions and point to discuss.pytorch.org (per step 1)
 - Be conservative - when in doubt, add `triage review` for human attention
-- Add `release triage` whenever an issue would affect an upcoming release (step 6); err toward adding it
+- Add `release triage` whenever an issue would affect an upcoming release (step 5b); err toward adding it
 - Apply type labels (`feature`, `enhancement`, `function request`) when confident
 - Add `triaged` label when classification is complete
 

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -34,9 +34,9 @@ This skill helps triage GitHub issues by routing issues, applying labels, and le
   - Step 3: Redirect to Secondary Oncall
   - Step 4: Label the Issue
   - Step 5: High Priority — REQUIRES HUMAN REVIEW
-  - Step 5.5: release triage — Affects an Upcoming Release
-  - Step 6: bot-triaged (automatic)
-  - Step 7: Mark Triaged
+  - Step 6: release triage — Affects an Upcoming Release
+  - Step 7: bot-triaged (automatic)
+  - Step 8: Mark Triaged
 - [V1 Constraints](#v1-constraints)
 
 **Labels reference:** See [labels.json](labels.json) for the full catalog of labels suitable for triage. **ONLY apply labels that exist in this file.** Do not invent or guess label names. This file excludes CI triggers, test configs, release notes, deprecated labels, and labels requiring human decision.
@@ -160,7 +160,7 @@ If the issue belongs in another repo (vision/text/audio/RL/ExecuTorch/etc.), tra
 
 ### 2.5) PT2 Issues — Special Handling
 
-**PT2 is NOT a redirect.** `oncall: pt2` is not like the other oncall labels in Step 3. PT2 issues continue through Steps 4–7 for full triage — add `oncall: pt2`, then proceed to label with `module:` labels, mark `triaged`, etc.
+**PT2 is NOT a redirect.** `oncall: pt2` is not like the other oncall labels in Step 3. PT2 issues continue through Steps 4–8 for full triage — add `oncall: pt2`, then proceed to label with `module:` labels, mark `triaged`, etc.
 
 **Every `oncall: pt2` issue MUST have at least one `module:` label.** The PT2 oncall queue is too broad without a module label — the team needs to know which component is affected (e.g., `module: dynamo`, `module: inductor`, `module: helion`, `module: dynamic shapes`). If you cannot determine the specific module, use `module: compile ux` as a fallback, but always try to be specific first. See [pt2-triage-rubric.md](pt2-triage-rubric.md) for detailed guidance.
 
@@ -235,22 +235,11 @@ High priority criteria:
 - Many users affected
 - Core component or popular model impact
 
-### 5.5) release triage — Affects an Upcoming Release
+### 6) release triage — Affects an Upcoming Release
 
-Add `release triage` when an issue would affect a release if it went unfixed. This is a
-continuous process, not something that only applies while a release branch is open. The
-label means "whoever owns the release needs to see this"; what happens next depends on
-where the cycle currently is:
-
-- **Between a completed release and the next branch cut** — the fix lands in main and
-  ships in the next release. Flagging early is what keeps the problem from reaching the
-  branch at all.
-- **Between branch cut and release** — the fix lands in main and is then cherry-picked to
-  the release branch, under the criteria in [RELEASE.md](../../../RELEASE.md).
-
-Either way the bot's job is the same: surface it so it can be found with
-`is:issue label:"release triage"`. It is not deciding anything — a fix may not exist yet,
-and whether to cherry-pick is never the bot's call.
+Add `release triage` when an issue would affect a release if it went unfixed. The label
+only surfaces the issue for whoever owns the release; it is not a cherry-pick request and
+does not decide anything.
 
 Add it when **any** of these hold:
 
@@ -277,11 +266,11 @@ a broken release. When unsure, add it.
 to feature requests, enhancements, or documentation-only issues, and do not add it for a
 regression against a version older than the last released minor.
 
-### 6) bot-triaged (automatic)
+### 7) bot-triaged (automatic)
 
 The `bot-triaged` label is automatically applied by a post-hook after any issue mutation. You do not need to add it manually.
 
-### 7) Mark triaged
+### 8) Mark triaged
 
 If not transferred/redirected and not flagged for review, add `triaged`.
 
@@ -300,7 +289,7 @@ If not transferred/redirected and not flagged for review, add `triaged`.
 **DO:**
 - Close clear usage questions and point to discuss.pytorch.org (per step 1)
 - Be conservative - when in doubt, add `triage review` for human attention
-- Add `release triage` whenever an issue would affect an upcoming release (step 5.5); err toward adding it
+- Add `release triage` whenever an issue would affect an upcoming release (step 6); err toward adding it
 - Apply type labels (`feature`, `enhancement`, `function request`) when confident
 - Add `triaged` label when classification is complete
 

--- a/.claude/skills/triaging-issues/SKILL.md
+++ b/.claude/skills/triaging-issues/SKILL.md
@@ -247,10 +247,7 @@ only surfaces the issue for whoever owns the release; it is not a cherry-pick re
 does not decide anything.
 
 **You are told which version is current — never guess it.** Your prompt carries a
-`RELEASE CONTEXT` block giving the most recent released minor version, resolved from the
-newest non-prerelease [GitHub release](https://github.com/pytorch/pytorch/releases) at run
-time. Use that value only. Do not use a version written in this file, and do not rely on
-what you remember about PyTorch releases — that is stale by construction. If the block
+`RELEASE CONTEXT` block giving the most recent released minor version. If the block
 says `unknown`, skip the two version-dependent criteria below and judge the rest on their
 own merits.
 

--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -1097,7 +1097,7 @@
     },
     {
       "name": "release triage",
-      "description": "Flagged as a possible release-branch candidate under the RELEASE.md cherry-pick criteria. For release-manager review; does not itself request a cherry-pick."
+      "description": "Affects an upcoming release: fix before the next branch cut, or cherry-pick if the branch is already cut. For release-manager review; not itself a cherry-pick request."
     },
     {
       "name": "security",

--- a/.claude/skills/triaging-issues/labels.json
+++ b/.claude/skills/triaging-issues/labels.json
@@ -1096,6 +1096,10 @@
       "description": "This tag is to mark Feature Tracked for PyTorch OSS Releases"
     },
     {
+      "name": "release triage",
+      "description": "Flagged as a possible release-branch candidate under the RELEASE.md cherry-pick criteria. For release-manager review; does not itself request a cherry-pick."
+    },
+    {
       "name": "security",
       "description": ""
     },

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -128,7 +128,7 @@ jobs:
             /triaging-issues #${{ steps.issue.outputs.number }}
 
             RELEASE CONTEXT (authoritative -- use this and nothing else for the current
-            release train; ignore any version written in the skill files and do not rely
+            release version; ignore any version written in the skill files and do not rely
             on your own knowledge of PyTorch releases):
             - Most recent released minor version: ${{ steps.release.outputs.minor }}
 

--- a/.github/workflows/claude-issue-triage-run.yml
+++ b/.github/workflows/claude-issue-triage-run.yml
@@ -68,6 +68,34 @@ jobs:
         with:
           fetch-depth: 1
 
+      # The bot is limited to five GitHub MCP calls and cannot read the releases
+      # API, so the current release train has to be handed to it. Left to itself it
+      # would answer "what is the latest release" from training data, and a version
+      # written into the skill file would go stale at every release.
+      - name: Resolve the most recent released version
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          minor="unknown"
+          # /releases/latest excludes drafts and prereleases, so this is the newest GA.
+          if tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"; then
+            candidate="${tag#v}"
+            candidate="${candidate%.*}"
+            if [[ "${candidate}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+              minor="${candidate}"
+            else
+              echo "::warning::Could not parse a minor version from release tag '${tag}'"
+            fi
+          else
+            echo "::warning::Could not read the latest release"
+          fi
+          # Never fail triage over this: the skill drops the version-dependent
+          # criteria when this is "unknown" rather than guessing.
+          echo "minor=${minor}" >> "${GITHUB_OUTPUT}"
+          echo "Most recent released minor: ${minor}"
+
       - name: Pre-pull GitHub MCP Server
         env:
           # claude-code-action v1.0.89 injects this image when GitHub MCP tools are allowed.
@@ -98,6 +126,11 @@ jobs:
             --allowedTools "mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__update_issue,mcp__github__add_issue_comment,mcp__github__search_issues"
           prompt: |
             /triaging-issues #${{ steps.issue.outputs.number }}
+
+            RELEASE CONTEXT (authoritative -- use this and nothing else for the current
+            release train; ignore any version written in the skill files and do not rely
+            on your own knowledge of PyTorch releases):
+            - Most recent released minor version: ${{ steps.release.outputs.minor }}
 
             SECURITY:
             - ONLY modify issue #${{ steps.issue.outputs.number }} in ${{ github.repository }}


### PR DESCRIPTION
Has the triage bot flag issues that affect an upcoming release, so they can be found with a search instead of by reading the queue.

## Why

Release-relevant issues are currently surfaced by the release manager reading through incoming issues. Anything missed there tends to be found later — often by a downstream user, sometimes after the RC. Flagging at triage time turns that into:

```
is:issue label:"release triage"
```

## Release triage is continuous, not a branch-window activity

The label means *"whoever owns the release needs to see this"*. What happens next depends on where the cycle is:

- **Between a completed release and the next branch cut** — the fix lands in main and ships in the next release. Flagging early is what keeps the problem from reaching the branch at all.
- **Between branch cut and release** — the fix lands in main and is then cherry-picked, under the [RELEASE.md](https://github.com/pytorch/pytorch/blob/main/RELEASE.md) criteria.

Same signal either way; only the remedy differs. The step says this explicitly so the label doesn't get treated as meaningless outside the cherry-pick window.

## Criteria

Add `release triage` when **any** hold:

- regression against the most recent released minor (pair with `module: regression`)
- critical correctness or stability: silent correctness, BC break, crash/segfault, deadlock, large memory leak
- critical fix to a feature introduced in the most recent minor
- binaries / packaging: wheels, conda, Docker, install, the release build (pair with `module: binaries`)
- **would ship broken in the next release** — a defect on main, a nightly, an RC, or the release branch that reaches users if nobody fixes it, including anything surfaced by release validation or downstream canaries. This holds even when it is not a regression against anything, e.g. a bug in code that has never shipped. The other four criteria structurally miss this case, and it is where a lot of real release blockers come from.

Apply generously: a false positive costs one glance, a miss costs a broken release. It is a **flag, not a verdict** — a fix may not exist yet, and whether to cherry-pick is never the bot's call. Independent of `triage review`, so an issue can carry both. Excluded: feature requests, enhancements, docs-only, and regressions against versions older than the last released minor.

## Also

**`labels.json`** gets the label entry. Not documentation — `scripts/validate_labels.py` strips any label not present in that file, so without it the bot would appear to apply `release triage` while the hook silently dropped it every time.

## Prerequisite

The `release triage` label needs to exist on the repo before this does anything; @atalman is creating it.

## Scope

This flags **issues**. The skill only triages issues, so PRs continue through the existing cherry-pick process — the effect is that the issue behind a fix gets flagged, surfacing it before or alongside the PR. Flagging PRs would be a separate change.

`count` in `labels.json` says `284` while the array holds `281` entries (282 after this). Pre-existing drift; left alone rather than folding an unrelated correction into this PR.

---

Filed with the help of Claude Code.