### PR TITLE
[MPS] Migrate nll_loss backward from MPSGraph to a Metal kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LossOps.h
+++ b/aten/src/ATen/native/mps/kernels/LossOps.h
@@ -1,6 +1,22 @@
 #pragma once
 #include <c10/metal/common.h>
 
+struct NLLLossBackwardParams {
+  int64_t n_classes;
+  int64_t map_size;
+  int64_t batch_stride;
+  int64_t class_stride;
+  int64_t grad_input_offset;
+  int64_t grad_output_offset;
+  int64_t target_offset;
+  int64_t weight_offset;
+  int64_t total_weight_offset;
+  int64_t ignore_index;
+  int64_t tid_offset;
+  uint32_t reduction;
+  uint32_t has_weight;
+};
+
 template <typename index_t>
 struct CTCLossParams {
   index_t BLANK;

--- a/aten/src/ATen/native/mps/kernels/LossOps.h
+++ b/aten/src/ATen/native/mps/kernels/LossOps.h
@@ -1,20 +1,22 @@
 #pragma once
 #include <c10/metal/common.h>
 
+template <typename index_t = int64_t>
 struct NLLLossBackwardParams {
-  int64_t n_classes;
-  int64_t map_size;
-  int64_t batch_stride;
-  int64_t class_stride;
-  int64_t grad_input_offset;
-  int64_t grad_output_offset;
-  int64_t target_offset;
-  int64_t weight_offset;
-  int64_t total_weight_offset;
-  int64_t ignore_index;
-  int64_t tid_offset;
-  uint32_t reduction;
-  uint32_t has_weight;
+  index_t n_classes;
+  index_t map_size;
+  index_t batch_stride;
+  index_t class_stride;
+  index_t grad_input_offset;
+  index_t grad_output_offset;
+  index_t target_offset;
+  index_t weight_offset;
+  index_t total_weight_offset;
+  index_t ignore_index;
+  index_t tid_offset;
+  bool is_reduction;
+  bool is_mean;
+  bool has_weight;
 };
 
 template <typename index_t>

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -1,9 +1,53 @@
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <c10/metal/atomic.h>
+#include <c10/metal/error.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
 
 using namespace metal;
 using namespace c10::metal;
+
+template <typename T>
+kernel void nllnd_loss_backward(
+    device T* grad_input [[buffer(0)]],
+    constant T* grad_output [[buffer(1)]],
+    constant long* target [[buffer(2)]],
+    constant T* weight [[buffer(3)]],
+    constant T* total_weight [[buffer(4)]],
+    constant NLLLossBackwardParams& params [[buffer(5)]],
+    device ErrorMessages* error_buf [[buffer(6)]],
+    uint thread_index [[thread_position_in_grid]]) {
+  const long index = static_cast<long>(thread_index) + params.tid_offset;
+  const long target_index = target[params.target_offset + index];
+  if (target_index == params.ignore_index) {
+    return;
+  }
+  if (target_index < 0 || target_index >= params.n_classes) {
+    TORCH_REPORT_ERROR(
+        error_buf, "Target ", target_index, " is out of bounds.");
+    return;
+  }
+
+  const long grad_output_index =
+      params.grad_output_offset + (params.reduction == 0 ? index : 0);
+  T grad = -grad_output[grad_output_index];
+  if (params.reduction == 1) {
+    const T total = total_weight[params.total_weight_offset];
+    if (total == T(0)) {
+      return;
+    }
+    grad = static_cast<T>(grad / total);
+  }
+  if (params.has_weight) {
+    grad = static_cast<T>(grad * weight[params.weight_offset + target_index]);
+  }
+
+  const long batch = index / params.map_size;
+  const long spatial = index % params.map_size;
+  const long output_index = batch * params.batch_stride +
+      target_index * params.class_stride + spatial;
+  grad_input[params.grad_input_offset + output_index] = grad;
+}
 
 // Augmented target lookup: l'[idx] is BLANK for even idx, l[idx/2] for odd.
 template <typename T_target, typename T_index>
@@ -395,3 +439,19 @@ kernel void ctc_loss_backward_collect(
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(float);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(bfloat);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(half);
+
+#define INSTANTIATE_NLLND_LOSS_BACKWARD(T)                      \
+  template [[host_name("nllnd_loss_backward_" #T)]] kernel void \
+  nllnd_loss_backward<T>(                                       \
+      device T*,                                                \
+      constant T*,                                              \
+      constant long*,                                           \
+      constant T*,                                              \
+      constant T*,                                              \
+      constant NLLLossBackwardParams&,                          \
+      device ErrorMessages*,                                    \
+      uint);
+
+INSTANTIATE_NLLND_LOSS_BACKWARD(float);
+INSTANTIATE_NLLND_LOSS_BACKWARD(bfloat);
+INSTANTIATE_NLLND_LOSS_BACKWARD(half);

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -14,7 +14,7 @@ kernel void nllnd_loss_backward(
     constant long* target [[buffer(2)]],
     constant T* weight [[buffer(3)]],
     constant T* total_weight [[buffer(4)]],
-    constant NLLLossBackwardParams& params [[buffer(5)]],
+    constant NLLLossBackwardParams<>& params [[buffer(5)]],
     device ErrorMessages* error_buf [[buffer(6)]],
     uint thread_index [[thread_position_in_grid]]) {
   const long index = static_cast<long>(thread_index) + params.tid_offset;
@@ -29,9 +29,9 @@ kernel void nllnd_loss_backward(
   }
 
   const long grad_output_index =
-      params.grad_output_offset + (params.reduction == 0 ? index : 0);
+      params.grad_output_offset + (params.is_reduction ? 0 : index);
   T grad = -grad_output[grad_output_index];
-  if (params.reduction == 1) {
+  if (params.is_mean) {
     const T total = total_weight[params.total_weight_offset];
     if (total == T(0)) {
       return;
@@ -448,7 +448,7 @@ INSTANTIATE_CTC_LOSS_TARGET_TYPES(half);
       constant long*,                                           \
       constant T*,                                              \
       constant T*,                                              \
-      constant NLLLossBackwardParams&,                          \
+      constant NLLLossBackwardParams<>&,                        \
       device ErrorMessages*,                                    \
       uint);
 

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -287,17 +287,6 @@ static Tensor& bce_loss_out_impl(const Tensor& input,
 
 } // namespace BCELoss
 
-static inline MPSGraphTensor* divisionNoNaN(MPSGraph* mpsGraph, MPSGraphTensor* divident, MPSGraphTensor* divisor) {
-  auto* div = [mpsGraph divisionWithPrimaryTensor:divident
-                                  secondaryTensor:castMPSTensor(mpsGraph, divisor, divident.dataType)
-                                             name:@"divisionTensor"];
-  // Replace NaNs with 0 for divident elements equal to 0
-  return [mpsGraph selectWithPredicateTensor:castMPSTensor(mpsGraph, divisor, MPSDataTypeBool)
-                         truePredicateTensor:div
-                        falsePredicateTensor:[mpsGraph constantWithScalar:0.0 dataType:div.dataType]
-                                        name:nil];
-}
-
 // NLLLoss
 static void nllnd_loss_backward_impl(Tensor& grad_input_arg,
                                      const Tensor& grad_output_arg,
@@ -308,116 +297,81 @@ static void nllnd_loss_backward_impl(Tensor& grad_input_arg,
                                      int64_t ignore_index,
                                      const Tensor& total_weight,
                                      bool is2D) {
+  TORCH_CHECK(input_arg.is_mps(), "input must be an MPS tensor");
+  TORCH_CHECK(grad_input_arg.is_mps(), "grad_input must be an MPS tensor");
+  TORCH_CHECK(grad_output_arg.is_mps(), "grad_output must be an MPS tensor");
+  TORCH_CHECK(target_arg.is_mps(), "target must be an MPS tensor");
+  TORCH_CHECK(!weight_arg.defined() || weight_arg.is_mps(), "weight must be an MPS tensor");
+  TORCH_CHECK(total_weight.is_mps(), "total_weight must be an MPS tensor");
   if (grad_input_arg.numel() == 0) {
     return;
   }
-  struct CachedGraph : public MPSCachedGraph {
-    CachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-    MPSGraphTensor* inputTensor_ = nil;
-    MPSGraphTensor* targetTensor_ = nil;
-    MPSGraphTensor* weightTensor_ = nil;
-    MPSGraphTensor* totalWeightTensor_ = nil;
-    MPSGraphTensor* gradInputTensor_ = nil;
-    MPSGraphTensor* gradOutputTensor_ = nil;
+  TORCH_CHECK(grad_input_arg.scalar_type() == input_arg.scalar_type(),
+              "expected scalar type ",
+              input_arg.scalar_type(),
+              " but found ",
+              grad_input_arg.scalar_type());
+  TORCH_CHECK(grad_output_arg.scalar_type() == input_arg.scalar_type(),
+              "expected scalar type ",
+              input_arg.scalar_type(),
+              " but found ",
+              grad_output_arg.scalar_type());
+  TORCH_CHECK(!weight_arg.defined() || weight_arg.scalar_type() == input_arg.scalar_type(),
+              "expected scalar type ",
+              input_arg.scalar_type(),
+              " but found ",
+              weight_arg.scalar_type());
+  grad_input_arg.zero_();
+
+  const bool has_weight = weight_arg.defined() && weight_arg.numel() > 0;
+  const Tensor target =
+      (target_arg.scalar_type() == ScalarType::Long ? target_arg : target_arg.to(ScalarType::Long)).contiguous();
+  const Tensor grad_output = grad_output_arg.contiguous();
+  const Tensor weight = has_weight ? weight_arg.contiguous() : grad_input_arg;
+  const Tensor total_weight_cast =
+      (total_weight.scalar_type() == input_arg.scalar_type() ? total_weight : total_weight.to(input_arg.scalar_type()))
+          .contiguous();
+
+  const auto class_dim = input_arg.dim() == 1 ? 0 : 1;
+  const auto map_size = is2D ? input_arg.size(2) * input_arg.size(3) : 1;
+  const NLLLossBackwardParams params{
+      .n_classes = input_arg.size(class_dim),
+      .map_size = map_size,
+      .batch_stride = input_arg.dim() == 1 ? 0 : grad_input_arg.stride(0),
+      .class_stride = grad_input_arg.stride(class_dim),
+      .grad_input_offset = grad_input_arg.storage_offset(),
+      .grad_output_offset = grad_output.storage_offset(),
+      .target_offset = target.storage_offset(),
+      .weight_offset = has_weight ? weight.storage_offset() : 0,
+      .total_weight_offset = total_weight_cast.storage_offset(),
+      .ignore_index = ignore_index,
+      .tid_offset = 0,
+      .reduction = static_cast<uint32_t>(reduction),
+      .has_weight = static_cast<uint32_t>(has_weight),
   };
-  bool isWeightsArrayValid = weight_arg.defined() && weight_arg.numel() > 0;
-  bool isTargetCasted = target_arg.scalar_type() != ScalarType::Long;
-  int64_t channel_dim = grad_input_arg.dim() < 2 ? 0 : 1;
-  auto input = input_arg.dim() == 1 ? input_arg.view({1, input_arg.size(0)}) : input_arg;
-  auto target = target_arg.dim() == 0 ? target_arg.view({1}) : target_arg;
-  auto grad_input = grad_input_arg.dim() == 1 ? grad_input_arg.view({1, grad_input_arg.size(0)}) : grad_input_arg;
-  auto numClasses = grad_input.sizes()[1];
-  auto weight = weight_arg;
-  auto grad_output = grad_output_arg;
 
-  if (isWeightsArrayValid) {
-    std::vector<int64_t> weightShape(input.dim(), 1);
-    weightShape[1] = input.size(1);
-    weight = weight_arg.view(weightShape);
-  }
-  if (grad_output_arg.dim() < grad_input.dim() && grad_output_arg.dim() > 0) {
-    grad_output = grad_output_arg.unsqueeze(channel_dim);
-  }
-  @autoreleasepool {
-    std::string key = "nllnd_loss_backward" + getTensorsStringKey({input, grad_output, target, weight, total_weight}) +
-        std::to_string(numClasses) + ":" + std::to_string(ignore_index) + ":" + std::to_string(isWeightsArrayValid) +
-        ":" + std::to_string(isTargetCasted) + ":" + reductionToString(reduction);
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-      MPSGraphTensor* targetTensor = mpsGraphRankedPlaceHolder(mpsGraph, target);
-      MPSGraphTensor* castedTargetTensor =
-          isTargetCasted ? castMPSTensor(mpsGraph, targetTensor, MPSDataTypeInt64) : targetTensor;
-      MPSGraphTensor* weightTensor = nil;
-      if (isWeightsArrayValid) {
-        weightTensor = mpsGraphRankedPlaceHolder(mpsGraph, weight);
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto pso = lib.getPipelineStateForFunc("nllnd_loss_backward_" + scalarToMetalTypeString(input_arg));
+      auto encoder = stream->commandEncoder();
+      [encoder setComputePipelineState:pso];
+      mtl_setArgs(encoder,
+                  getMTLBufferStorage(grad_input_arg),
+                  getMTLBufferStorage(grad_output),
+                  getMTLBufferStorage(target),
+                  getMTLBufferStorage(weight),
+                  getMTLBufferStorage(total_weight_cast));
+      // Chunk only when the target exceeds Metal's uint32 thread-grid limit.
+      constexpr auto max_threads = int64_t{std::numeric_limits<uint32_t>::max()};
+      auto dispatch_params = params;
+      for (auto offset = int64_t{0}; offset < target.numel(); offset += max_threads) {
+        dispatch_params.tid_offset = offset;
+        mtl_setArgs<5>(encoder, dispatch_params, stream->getErrorBuffer());
+        mtl_dispatch1DJob(encoder, pso, std::min(max_threads, target.numel() - offset));
       }
-      MPSGraphTensor* totalWeightTensor = mpsGraphRankedPlaceHolder(mpsGraph, total_weight);
-      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-
-      MPSGraphTensor* updatedTargetTensor = castedTargetTensor;
-
-      // Replace ignored_index with length depth + 1 so that oneHotAPI ignores it
-      MPSGraphTensor* ignoreIndexTensor = [mpsGraph constantWithScalar:ignore_index dataType:MPSDataTypeInt64];
-      MPSGraphTensor* numClassesTensor = [mpsGraph constantWithScalar:(numClasses + 1) dataType:MPSDataTypeInt64];
-      MPSGraphTensor* isEqualTensor = [mpsGraph equalWithPrimaryTensor:castedTargetTensor
-                                                       secondaryTensor:ignoreIndexTensor
-                                                                  name:@"isEqualTensor"];
-      updatedTargetTensor = [mpsGraph selectWithPredicateTensor:isEqualTensor
-                                            truePredicateTensor:numClassesTensor
-                                           falsePredicateTensor:castedTargetTensor
-                                                           name:@"predicateTensor"];
-
-      // oneHotWithIndicesTensor only works for Float32 dtype
-      // cast it explicitly later if needed
-      auto* oneHotTensor = [mpsGraph oneHotWithIndicesTensor:updatedTargetTensor
-                                                       depth:numClasses
-                                                        axis:1
-                                                    dataType:MPSDataTypeFloat32
-                                                     onValue:-1.0f
-                                                    offValue:0.0f
-                                                        name:nil];
-      oneHotTensor = castMPSTensor(mpsGraph, oneHotTensor, [inputTensor dataType]);
-      if (isWeightsArrayValid) {
-        oneHotTensor = [mpsGraph multiplicationWithPrimaryTensor:oneHotTensor
-                                                 secondaryTensor:weightTensor
-                                                            name:@"scaleByWeightTensor"];
-      }
-      if (reduction == Reduction::Mean) {
-        oneHotTensor = divisionNoNaN(mpsGraph, oneHotTensor, totalWeightTensor);
-      }
-      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:oneHotTensor
-                                                                  secondaryTensor:gradOutputTensor
-                                                                             name:nil];
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->targetTensor_ = targetTensor;
-      newCachedGraph->weightTensor_ = weightTensor;
-      newCachedGraph->totalWeightTensor_ = totalWeightTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-    });
-
-    auto inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
-    auto gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    auto targetPlaceholder = Placeholder(cachedGraph->targetTensor_, target);
-    Placeholder weightPlaceholder = Placeholder();
-    if (isWeightsArrayValid) {
-      weightPlaceholder = Placeholder(cachedGraph->weightTensor_, weight);
     }
-    auto totalWeightPlaceholder = Placeholder(cachedGraph->totalWeightTensor_, total_weight);
-    auto gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-
-    NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
-    feeds[inputPlaceholder.getMPSGraphTensor()] = inputPlaceholder.getMPSGraphTensorData();
-    feeds[targetPlaceholder.getMPSGraphTensor()] = targetPlaceholder.getMPSGraphTensorData();
-    feeds[totalWeightPlaceholder.getMPSGraphTensor()] = totalWeightPlaceholder.getMPSGraphTensorData();
-    feeds[gradOutputPlaceholder.getMPSGraphTensor()] = gradOutputPlaceholder.getMPSGraphTensorData();
-
-    if (isWeightsArrayValid) {
-      feeds[weightPlaceholder.getMPSGraphTensor()] = weightPlaceholder.getMPSGraphTensorData();
-    }
-    runMPSGraph(getCurrentMPSStream(), cachedGraph->graph(), feeds, gradInputPlaceholder);
-  }
+  });
 }
 
 static void nllnd_loss_forward_impl(Tensor& output,
@@ -1249,8 +1203,21 @@ static void nll_loss2d_backward_out_mps_template(Tensor& grad_input,
                                                  int64_t ignore_index,
                                                  const Tensor& total_weight) {
   check_inputs_nll_loss2d(input, target, weight);
+  if (reduction == Reduction::None) {
+    TORCH_CHECK(grad_output.dim() == 3,
+                "grad_output must have same dimension as target (3) but got dimension: ",
+                grad_output.sizes());
+    TORCH_CHECK(grad_output.sizes() == target.sizes(),
+                "size mismatch (got grad_output: ",
+                grad_output.sizes(),
+                " target: ",
+                target.sizes());
+  } else {
+    TORCH_CHECK(grad_output.dim() <= 1 && grad_output.numel() == 1,
+                "Expected a single element grad_output tensor, but got: ",
+                grad_output.sizes());
+  }
   grad_input.resize_as_(input);
-  grad_input.zero_();
   TORCH_CHECK(grad_input.is_contiguous(), "grad_input must be contiguous");
   TORCH_CHECK(total_weight.numel() == 1,
               "expected total_weight to be a single element tensor, got: ",

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -306,21 +306,21 @@ static void nllnd_loss_backward_impl(Tensor& grad_input_arg,
   if (grad_input_arg.numel() == 0) {
     return;
   }
-  TORCH_CHECK(grad_input_arg.scalar_type() == input_arg.scalar_type(),
-              "expected scalar type ",
-              input_arg.scalar_type(),
-              " but found ",
-              grad_input_arg.scalar_type());
-  TORCH_CHECK(grad_output_arg.scalar_type() == input_arg.scalar_type(),
-              "expected scalar type ",
-              input_arg.scalar_type(),
-              " but found ",
-              grad_output_arg.scalar_type());
-  TORCH_CHECK(!weight_arg.defined() || weight_arg.scalar_type() == input_arg.scalar_type(),
-              "expected scalar type ",
-              input_arg.scalar_type(),
-              " but found ",
-              weight_arg.scalar_type());
+  TORCH_CHECK_TYPE(grad_input_arg.scalar_type() == input_arg.scalar_type(),
+                   "expected scalar type ",
+                   input_arg.scalar_type(),
+                   " but found ",
+                   grad_input_arg.scalar_type());
+  TORCH_CHECK_TYPE(grad_output_arg.scalar_type() == input_arg.scalar_type(),
+                   "expected scalar type ",
+                   input_arg.scalar_type(),
+                   " but found ",
+                   grad_output_arg.scalar_type());
+  TORCH_CHECK_TYPE(!weight_arg.defined() || weight_arg.scalar_type() == input_arg.scalar_type(),
+                   "expected scalar type ",
+                   input_arg.scalar_type(),
+                   " but found ",
+                   weight_arg.scalar_type());
   grad_input_arg.zero_();
 
   const bool has_weight = weight_arg.defined() && weight_arg.numel() > 0;
@@ -334,7 +334,7 @@ static void nllnd_loss_backward_impl(Tensor& grad_input_arg,
 
   const auto class_dim = input_arg.dim() == 1 ? 0 : 1;
   const auto map_size = is2D ? input_arg.size(2) * input_arg.size(3) : 1;
-  const NLLLossBackwardParams params{
+  const NLLLossBackwardParams<> params{
       .n_classes = input_arg.size(class_dim),
       .map_size = map_size,
       .batch_stride = input_arg.dim() == 1 ? 0 : grad_input_arg.stride(0),
@@ -346,8 +346,9 @@ static void nllnd_loss_backward_impl(Tensor& grad_input_arg,
       .total_weight_offset = total_weight_cast.storage_offset(),
       .ignore_index = ignore_index,
       .tid_offset = 0,
-      .reduction = static_cast<uint32_t>(reduction),
-      .has_weight = static_cast<uint32_t>(has_weight),
+      .is_reduction = reduction != Reduction::None,
+      .is_mean = reduction == Reduction::Mean,
+      .has_weight = has_weight,
   };
 
   MPSStream* stream = getCurrentMPSStream();

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -46,7 +46,7 @@ from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, Criteri
     module_tests, criterion_tests, loss_reference_fns, _create_basic_net, \
     ctcloss_reference, get_new_module_tests, single_batch_reference_fn, _test_bfloat16_ops, _test_module_empty_input
 from torch.testing._internal.common_device_type import dtypesIfMPS, instantiate_device_type_tests, dtypes, \
-    dtypesIfCUDA, precisionOverride, onlyCUDA, onlyCPU, onlyAccelerator, \
+    dtypesIfCUDA, precisionOverride, onlyCUDA, onlyCPU, onlyAccelerator, onlyOn, \
     skipCUDAIf, skipCUDAIfNoCudnn, skipCUDAIfRocm, skipMPSIf, skipMPS, \
     onlyNativeDeviceTypes, deviceCountAtLeast, largeTensorTest, expectedFailureMeta, expectedFailureMPS, \
     expectedFailureMPSPre27, skipMeta, get_all_device_types
@@ -12102,8 +12102,8 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue(torch.allclose(loss_cpu, loss.cpu(), rtol=1e-4, atol=1e-4))
 
     # Ref: https://github.com/pytorch/pytorch/issues/190139
-    @onlyCUDA
-    @largeTensorTest("5GB", "cuda")
+    @onlyOn(["cuda", "mps"])
+    @largeTensorTest("5GB")
     def test_nll_loss2d_backward_large_sample_offset(self, device):
         batch_size = 2**16 + 1
         num_classes = 2**15
@@ -12135,7 +12135,7 @@ class TestNNDeviceType(NNTestCase):
             one,
         )
 
-        torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         self.assertEqual(grad_input[-1, 0, 0, 0], -1)
 
     def _nll_loss_helper(self, input_size, reduction, expected, device, dtype):

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -9012,6 +9012,10 @@ def sample_inputs_nll_loss(op_info, device, dtype, requires_grad, **kwargs):
     target = torch.tensor([-1, 2], device=device, dtype=torch.long)
     yield SampleInput(make_input(shape), args=(target,), kwargs={'ignore_index': -1})
 
+    # Noncontiguous target
+    target = torch.randint(num_classes, (2 * shape[0],), device=device)[::2]
+    yield SampleInput(make_input(shape), args=(target,))
+
 
 def sample_inputs_binary_cross_entropy_with_logits(
     op_info, device, dtype, requires_grad, **kwargs
@@ -22581,8 +22585,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
                 "test_cow_input",
                 device_type=('cuda', 'xpu'),
             ),
-            DecorateInfo(unittest.skip("FP16 nll_loss cases have not been enabled on MPS yet"),
-                         dtypes=(torch.half,), device_type="mps"),
         ),
     ),
     OpInfo(


### PR DESCRIPTION
`nll_loss_backward` and `nll_loss2d_backward` on MPS used an MPSGraph one-hot graph. 
The graph cache is keyd on shape, which meant that variable length workloads would ocmpile one graph per shape and the driver memory would grow a lot due to caching of the one hot tensor in the intermediate calculation which wasn't being released. This PR replaces it with a single Metal scatter kernel. 
Some numbers:

Variable-length causal-LM training run, 140 steps, 107 distinct sequence lengths:

| Driver memory | Before | After |
|---|---:|---:|
| Peak | 20,967 MB | 7,969 MB |

Speed

| Case | Before | After | Speedup |
|---|---:|---:|---:|
| BF16 `[740, 32000]` | 0.974 ms | 0.226 ms | 4.31x |
| BF16 `[2048, 32000]` | 2.640 ms | 0.519 ms | 5.09x |
| BF16 `[3812, 32000]` | 5.010 ms | 0.988 ms | 5.07x |
| FP32 `[2048, 32000]` | 3.183 ms | 1.052 ms | 3.03x |
| BF16 `[2, 64, 17, 19]`, transposed target, 2d | 0.068 ms | 0.040 ms | 1.69x |
