### PR TITLE
[inductor] Preserve logical indices for arg reductions

### DIFF
--- a/test/inductor/test_optimize_indexing.py
+++ b/test/inductor/test_optimize_indexing.py
@@ -1,17 +1,50 @@
 # Owner(s): ["module: inductor"]
 
 import operator
+from unittest import mock
 
 import sympy
 
 import torch
+from torch._inductor import config, metrics
 from torch._inductor.codegen.common import deduce_output_dtype_by_name
-from torch._inductor.optimize_indexing import convert_index_expr_to_value_expr
+from torch._inductor.codegen.cpp import CppKernelProxy
+from torch._inductor.loop_body import LoopBody
+from torch._inductor.optimize_indexing import (
+    convert_index_expr_to_value_expr,
+    remove_redundant_argreduce_indices,
+)
+from torch._inductor.scheduler import Scheduler, SchedulerNode
+from torch._inductor.virtualized import V
 from torch.fx import Graph
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 from torch.utils._sympy.value_ranges import ValueRanges
 
 
+class _FakeSizeVars:
+    @staticmethod
+    def simplify_with_ranges(expr, var_ranges):
+        return expr
+
+    @staticmethod
+    def statically_known_equals(left, right):
+        return sympy.expand(left - right) == 0
+
+
+class _FakeGraph:
+    sizevars = _FakeSizeVars()
+
+    @staticmethod
+    def get_dtype(name):
+        return torch.bfloat16
+
+
+@instantiate_parametrized_tests
 class TestOptimizeIndexing(TestCase):
     @staticmethod
     def _make_loop_body(
@@ -48,6 +81,179 @@ class TestOptimizeIndexing(TestCase):
                 return self._bounds
 
         return FakeLoopBody()
+
+    def _make_argreduce_loop_body(self, logical_index, src_dtype=torch.float32):
+        r0, r1 = sympy.symbols("r0 r1", integer=True, nonnegative=True)
+
+        def fn(index, reduction_index):
+            value = (
+                V.ops.constant(1.0, src_dtype)
+                if src_dtype == torch.float32
+                else V.ops.load("arg0", 8 * reduction_index[0] + reduction_index[1])
+            )
+            index = V.ops.index_expr(logical_index(*reduction_index), torch.int64)
+            return V.ops.reduction(torch.int64, src_dtype, "argmax", (value, index))
+
+        with (
+            config.patch(constant_and_index_propagation=False),
+            V.set_graph_handler(_FakeGraph()),
+        ):
+            loop_body = LoopBody(
+                fn,
+                ([], [r0, r1]),
+                {r0: 4, r1: 8},
+                [],
+                [r0, r1],
+            )
+        return loop_body
+
+    @staticmethod
+    def _argreduce_nodes(loop_body):
+        graph = loop_body.root_block.graph
+        reduction = graph.find_nodes(op="call_method", target="reduction")[0]
+        value, index_expr = reduction.args[-1]
+        get_index = index_expr.args[1]
+        return graph, reduction, value, index_expr, get_index
+
+    def test_remove_redundant_argreduce_index(self):
+        loop_body = self._make_argreduce_loop_body(lambda r0, r1: 8 * r0 + r1)
+        graph, reduction, value, index_expr, get_index = self._argreduce_nodes(
+            loop_body
+        )
+        with V.set_graph_handler(_FakeGraph()):
+            undo = remove_redundant_argreduce_indices([loop_body])
+
+        self.assertEqual(undo, [(reduction, index_expr)])
+        self.assertIs(reduction.args[-1], value)
+        self.assertIn(index_expr, graph.nodes)
+        self.assertIn(get_index, graph.nodes)
+
+    def test_keep_non_native_argreduce_index(self):
+        loop_body = self._make_argreduce_loop_body(lambda r0, r1: 4 * r1 + r0)
+        graph, reduction, _, index_expr, get_index = self._argreduce_nodes(loop_body)
+        with V.set_graph_handler(_FakeGraph()):
+            undo = remove_redundant_argreduce_indices([loop_body])
+
+        self.assertEqual(undo, [])
+        self.assertIs(reduction.args[-1][1], index_expr)
+        self.assertIn(index_expr, graph.nodes)
+        self.assertIn(get_index, graph.nodes)
+
+    def test_keep_shared_non_native_argreduce_index(self):
+        original = self._make_argreduce_loop_body(lambda r0, r1: 8 * r0 + r1)
+        r0, r1 = original.reduce_vars
+        with V.set_graph_handler(_FakeGraph()):
+            native = LoopBody(
+                original,
+                ([], [r0, r1]),
+                original.var_ranges,
+                [],
+                [r0, r1],
+                allow_same_symbol_in_index=True,
+            )
+            reordered = LoopBody(
+                original,
+                ([], [r0, r1]),
+                original.var_ranges,
+                [],
+                [r0, r1],
+                allow_same_symbol_in_index=True,
+            )
+            reordered.indexing_exprs["index0"] = 4 * r1 + r0
+            undo = remove_redundant_argreduce_indices([native, reordered])
+
+        self.assertIs(native.root_block.graph, reordered.root_block.graph)
+        self.assertEqual(undo, [])
+        self.assertIsInstance(self._argreduce_nodes(native)[1].args[-1], tuple)
+        self.assertIsInstance(self._argreduce_nodes(reordered)[1].args[-1], tuple)
+        self.assertEqual(reordered.indexing_exprs["index0"], 4 * r1 + r0)
+
+    @parametrize("method", ("fused", "generate", "combo"))
+    def test_argreduce_finalization_is_temporary(self, method):
+        loop_body = self._make_argreduce_loop_body(lambda r0, r1: 8 * r0 + r1)
+        scheduler = object.__new__(Scheduler)
+        snode = object.__new__(SchedulerNode)
+        snode._body = loop_body
+
+        class Backend:
+            def check_finalized(self, nodes):
+                self.assert_finalized = nodes[0]._body is loop_body
+                reduction = nodes[0]._body.root_block.graph.find_nodes(
+                    op="call_method", target="reduction"
+                )[0]
+                self.reduction_value = reduction.args[-1]
+
+            def benchmark_fused_nodes(self, nodes):
+                self.check_finalized(nodes)
+                return 1.0, ""
+
+            def generate_kernel_code_from_nodes(
+                self, nodes, benchmark_kernel, hint_override=None
+            ):
+                self.check_finalized(nodes)
+                return ""
+
+            def benchmark_combo_kernel(self, nodes, node_benchmark_results):
+                self.check_finalized(nodes)
+                return 1.0, 1.0, [""]
+
+        backend = Backend()
+        scheduler.get_backend = lambda device: backend
+        with (
+            V.set_graph_handler(_FakeGraph()),
+            mock.patch.object(
+                SchedulerNode, "get_device", return_value=torch.device("cuda")
+            ),
+        ):
+            if method == "combo":
+                scheduler.benchmark_combo_kernel([snode], {})
+            elif method == "generate":
+                scheduler.generate_kernel_code_from_nodes([snode], False)
+            elif method == "fused":
+                scheduler.benchmark_fused_nodes([snode])
+            else:
+                raise AssertionError(f"unexpected method {method}")
+
+        self.assertTrue(backend.assert_finalized)
+        self.assertNotIsInstance(backend.reduction_value, tuple)
+        self.assertIs(snode._body, loop_body)
+        self.assertIsInstance(self._argreduce_nodes(loop_body)[1].args[-1], tuple)
+
+    def test_argreduce_restores_legalized_value(self):
+        loop_body = self._make_argreduce_loop_body(
+            lambda r0, r1: 8 * r0 + r1, torch.bfloat16
+        )
+        _, reduction, original_value, logical_index, _ = self._argreduce_nodes(
+            loop_body
+        )
+        scheduler = object.__new__(Scheduler)
+        snode = object.__new__(SchedulerNode)
+        snode._body = loop_body
+
+        class Backend:
+            def generate_kernel_code_from_nodes(
+                self, nodes, benchmark_kernel, hint_override=None
+            ):
+                CppKernelProxy.legalize_lowp_fp_dtype_loopbody(self, nodes[0]._body)
+                self.legalized_value = reduction.args[-1]
+                return ""
+
+        backend = Backend()
+        scheduler.get_backend = lambda device: backend
+        with (
+            V.set_graph_handler(_FakeGraph()),
+            mock.patch.object(
+                SchedulerNode, "get_device", return_value=torch.device("cpu")
+            ),
+            mock.patch.object(metrics, "cpp_to_dtype_count", 0),
+        ):
+            scheduler.generate_kernel_code_from_nodes([snode], False)
+
+        restored_value, restored_index = reduction.args[-1]
+        self.assertIs(restored_value, backend.legalized_value)
+        self.assertIsNot(restored_value, original_value)
+        self.assertEqual(restored_value.target, "to_dtype")
+        self.assertIs(restored_index, logical_index)
 
     def test_index_expr_mixed_use_converts_in_place(self):
         # When the same index_expr is used both as an index (load) and as a

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -16919,12 +16919,18 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
     @skip_if_gpu_halide
     def test_adaptive_avg_pool1d_argmax(self):
         # https://github.com/pytorch/pytorch/issues/113013
+        # https://github.com/pytorch/pytorch/issues/193492
         def fn(x):
             x = torch.adaptive_avg_pool1d(input=x, output_size=2)
             x = torch.argmax(input=x)
             return x
 
-        x = torch.rand([4, 4, 3], dtype=torch.float64)
+        x = torch.zeros(4, 4, 3, device=self.device, dtype=torch.float64).transpose(
+            0, 1
+        )
+        x[1, 3] = x.new_tensor([0.0, 1.0, 2.0])
+        self.assertFalse(x.is_contiguous())
+        self.assertEqual(fn(x), torch.tensor(15, device=self.device))
         self.common(fn, (x,))
 
     @skipCUDAIf(not SM80OrLater, "uses bfloat16 which requires SM >= 80")
@@ -18979,6 +18985,57 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertTrue("ReductionHint.OUTER" in code)
         self.assertFalse("ReductionHint.INNER" in code)
 
+    @parametrize("slice_pointwise", (False, True))
+    @skip_if_halide
+    def test_argmin_argmax_fused_reduction_logical_index(self, slice_pointwise):
+        # https://github.com/pytorch/pytorch/issues/193661
+        def fn(x):
+            reduced = torch.mean(x, dim=-1)
+            if slice_pointwise:
+                reduced = reduced[1:]
+            return reduced.argmin(), reduced.argmax()
+
+        x = (
+            torch.zeros(2, 4, 4, 8, device=self.device)
+            .transpose(0, 1)
+            .contiguous()
+            .transpose(0, 1)[..., ::2]
+        )
+        batch = 1 if slice_pointwise else 0
+        x[batch, 1, 1] = -1
+        x[batch, 3, 0] = 1
+        expected = (
+            torch.tensor(5, device=self.device),
+            torch.tensor(12, device=self.device),
+        )
+
+        self.assertEqual(fn(x), expected)
+        self.common(fn, (x,))
+
+    @skip_if_halide
+    @skip_if_pallas
+    def test_argreduce_native_index_cse(self):
+        if is_mps_backend(self.device):
+            self.skipTest("CPP or Triton codegen is required")
+
+        def fn(x):
+            return x.argmax(), x.reshape(-1).argmax()
+
+        x = torch.arange(4 * 6 * 8, device=self.device, dtype=torch.float32).reshape(
+            4, 6, 8
+        )
+        self.common(fn, (x,))
+
+        compiled = torch.compile(fn, fullgraph=True)
+        if is_cpp_backend(self.device):
+            _, code = run_and_get_cpp_code(compiled, x)
+            self.assertIn("tmp_acc0", code)
+            self.assertNotIn("tmp_acc1", code)
+        else:
+            code = run_and_get_triton_code(compiled, x)
+            self.assertEqual(code.count("@triton_heuristics."), 1)
+            self.assertEqual(code.count("triton_helpers.max_with_index"), 1)
+
     @skip_if_halide
     @requires_gpu_and_triton
     def test_triton_argmin_argmax_transpose_logical_index(self):
@@ -19015,6 +19072,21 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             return (x.argmin(), x.argmax())
 
         self.common(fn, (torch.randn(6, 4, device=GPU_TYPE).t().contiguous().t(),))
+
+        def fn(x):
+            return (
+                x.permute(1, 0, 2).argmax(),
+                x.transpose(0, 1).argmax(),
+                x.permute(2, 1, 0).argmax(),
+            )
+
+        x = torch.zeros(4, 6, 8, device=GPU_TYPE)
+        x[2, 4, 7] = 1
+        self.common(fn, (x,))
+        code = run_and_get_triton_code(torch.compile(fn, fullgraph=True), x)
+        self.assertEqual(code.count("@triton_heuristics."), 1)
+        # Equivalent value/index pairs merge; the distinct mapping does not.
+        self.assertEqual(code.count("triton_helpers.max_with_index"), 2)
 
     @skip_if_halide
     @requires_gpu_and_triton

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -5556,7 +5556,11 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
                 return "value"
             return "index"
 
-        cache_key = (src_dtype, reduction_type, value)
+        cache_key = (
+            src_dtype,
+            reduction_type,
+            value if logical_index is None else (value, logical_index),
+        )
         if cache_key in self.cse.reduction_cache:
             return self.cse.reduction_cache[cache_key]
 

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7275,12 +7275,12 @@ def _make_reduction_inner(
             kept_idx.append(i)
             kept_sizes.append(size[i])
 
-    # For argmax/argmin compute logical indices when the tensor has non-contiguous layout.
-    should_compute_logical_index = False
+    # Loop reordering happens after lowering, so the input IR cannot reliably predict
+    # when the physical reduction order will differ from the logical order.
     supports_logical_index_argreduce = is_triton(x) or (
         ir.get_device_type(x) == "cpu" and config.cpu_backend == "cpp"
     )
-    if (
+    should_compute_logical_index = (
         reduction_type
         in (
             "argmax",
@@ -7292,16 +7292,7 @@ def _make_reduction_inner(
         )
         and len(reduced_sizes) > 1
         and supports_logical_index_argreduce
-    ):
-        if isinstance(x.data, PermuteView):
-            should_compute_logical_index = True
-        elif isinstance(x.data, ir.ReinterpretView) or (
-            isinstance(x.data, ir.StorageBox) and isinstance(x.data.data, ir.Buffer)
-        ):
-            layout = x.get_layout()
-            should_compute_logical_index = (
-                layout.is_transposed() or not layout.is_contiguous()
-            )
+    )
 
     def loader(index, reduction_index):
         if len(reduction_index) != len(reduced_idx):

--- a/torch/_inductor/optimize_indexing.py
+++ b/torch/_inductor/optimize_indexing.py
@@ -1,4 +1,5 @@
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -10,7 +11,85 @@ from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.value_ranges import ValueRanges
 
 from .loop_body import LoopBody
-from .utils import dominated_nodes
+from .utils import dominated_nodes, flatten_index
+from .virtualized import V
+
+
+_ARG_REDUCTION_TYPES = (
+    "argmax",
+    "argmin",
+    "argmax_value",
+    "argmin_value",
+    "argmax_with_value",
+    "argmin_with_value",
+)
+
+
+def _get_argreduce_index(
+    node: torch.fx.Node,
+) -> tuple[Any, torch.fx.Node, str] | None:
+    if node.op != "call_method" or node.target != "reduction":
+        return None
+    value = node.args[-1]
+    if node.args[-2] not in _ARG_REDUCTION_TYPES or not (
+        isinstance(value, tuple) and len(value) == 2
+    ):
+        return None
+
+    reduction_value, logical_index = value
+    if not (
+        isinstance(logical_index, torch.fx.Node)
+        and logical_index.op == "call_method"
+        and logical_index.target in ("index_expr", "value_expr")
+    ):
+        return None
+
+    index_node = logical_index.args[1]
+    if not (
+        isinstance(index_node, torch.fx.Node)
+        and index_node.op == "call_module"
+        and index_node.target == "get_index"
+    ):
+        return None
+
+    index_name = index_node.args[0]
+    if not isinstance(index_name, str):
+        raise AssertionError(f"expected str index name, got {index_name!r}")
+    return reduction_value, logical_index, index_name
+
+
+def remove_redundant_argreduce_indices(
+    loop_bodies: Sequence[LoopBody],
+) -> list[tuple[torch.fx.Node, torch.fx.Node]]:
+    """Drop explicit arg-reduction indices that match the final loop order."""
+    reductions: dict[torch.fx.Node, tuple[Any, torch.fx.Node, bool]] = {}
+    for loop_body in loop_bodies:
+        if not loop_body.reduce_vars:
+            continue
+        native_index = flatten_index(loop_body.reduce_vars, loop_body.sizes[1])
+        seen_nodes: OrderedSet[torch.fx.Node] = OrderedSet()
+        blocks = [loop_body.root_block, *loop_body.subblocks.values()]
+        for node in (node for block in blocks for node in block.graph.nodes):
+            parsed = _get_argreduce_index(node)
+            if parsed is None or node in seen_nodes:
+                continue
+            seen_nodes.add(node)
+            reduction_value, logical_index, index_name = parsed
+            redundant = V.graph.sizevars.statically_known_equals(
+                loop_body.indexing_exprs[index_name], native_index
+            )
+            if node in reductions:
+                value, index, prior_redundant = reductions[node]
+                reductions[node] = value, index, prior_redundant and redundant
+            else:
+                reductions[node] = reduction_value, logical_index, redundant
+
+    undo: list[tuple[torch.fx.Node, torch.fx.Node]] = []
+    for node, (reduction_value, logical_index, redundant) in reductions.items():
+        if redundant:
+            undo.append((node, logical_index))
+            node.args = (*node.args[:-1], reduction_value)
+    return undo
 
 
 def val_expressable_in_32_bits(val: Any) -> bool:

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -4875,6 +4875,9 @@ class Scheduler:
             self.nodes = self.maybe_reorder_for_minimizing_partition(self.nodes)
             self.nodes = self.reorder_for_partition_with_simple_dependency(self.nodes)
 
+        # All fusion and loop-order transformations are complete. Finalize the
+        # LoopBodies before handing them to backend codegen.
+        self.finalize_loop_bodies(self.nodes)
         self.compute_last_usage()
 
         if torch._inductor.config.test_configs.track_memory_lifecycle:
@@ -4906,6 +4909,41 @@ class Scheduler:
         # Unlike V.graph.removed_buffers, the op recorded here is removed but
         # we still need the buffer (generated in alternative ways)
         self.removed_ops: OrderedSet[str] = OrderedSet()
+
+    @staticmethod
+    def _scheduler_nodes_with_loop_bodies(
+        nodes: Sequence[BaseSchedulerNode],
+    ) -> OrderedSet[SchedulerNode]:
+        return OrderedSet(
+            snode
+            for node in nodes
+            for snode in node.get_nodes()
+            if isinstance(snode, SchedulerNode) and isinstance(snode._body, LoopBody)
+        )
+
+    def finalize_loop_bodies(
+        self, nodes: Sequence[BaseSchedulerNode]
+    ) -> list[tuple[torch.fx.Node, torch.fx.Node]]:
+        """Apply optimizations that require the final scheduler loop order."""
+        from .optimize_indexing import remove_redundant_argreduce_indices
+
+        bodies = OrderedSet(
+            snode._body for snode in self._scheduler_nodes_with_loop_bodies(nodes)
+        )
+        return remove_redundant_argreduce_indices(list(bodies))
+
+    @contextlib.contextmanager
+    def finalized_loop_bodies(
+        self, nodes: Sequence[BaseSchedulerNode]
+    ) -> Iterator[None]:
+        """Temporarily finalize candidate LoopBodies for pre-codegen benchmarks."""
+        undo: list[tuple[torch.fx.Node, torch.fx.Node]] = []
+        try:
+            undo = self.finalize_loop_bodies(nodes)
+            yield
+        finally:
+            for node, logical_index in reversed(undo):
+                node.args = (*node.args[:-1], (node.args[-1], logical_index))
 
     def get_donated_buffers(self) -> dict[str, SchedulerDonatedBuffer]:
         name_to_donated_buf = {}
@@ -5796,10 +5834,13 @@ class Scheduler:
         device = nodes[0].get_device()
         self.current_device = device
         backend = self.get_backend(device)
-        with dynamo_timed(
-            "benchmark_fused_nodes",
-            log_pt2_compile_event=True,
-            dynamo_compile_column_us="compile_time_autotune_time_us",
+        with (
+            dynamo_timed(
+                "benchmark_fused_nodes",
+                log_pt2_compile_event=True,
+                dynamo_compile_column_us="compile_time_autotune_time_us",
+            ),
+            self.finalized_loop_bodies(nodes),
         ):
             return backend.benchmark_fused_nodes(nodes)
 
@@ -5817,7 +5858,10 @@ class Scheduler:
         device = nodes[0].get_device()
         self.current_device = device
         backend = self.get_backend(device)
-        with dynamo_timed("generate_kernel_code_from_nodes"):
+        with (
+            dynamo_timed("generate_kernel_code_from_nodes"),
+            self.finalized_loop_bodies(nodes),
+        ):
             return backend.generate_kernel_code_from_nodes(
                 nodes, benchmark_kernel, hint_override=hint_override
             )
@@ -10997,7 +11041,8 @@ class Scheduler:
         if device is None:
             raise AssertionError("expected device to be set")
         backend = self.get_backend(device)
-        return backend.benchmark_combo_kernel(node_list, node_benchmark_results)
+        with self.finalized_loop_bodies(node_list):
+            return backend.benchmark_combo_kernel(node_list, node_benchmark_results)
 
     def speedup_by_combo_kernel(self, nodes: list[BaseSchedulerNode]) -> bool:
         """


### PR DESCRIPTION
We have an optimization that replaces an argmax `(value, index)` pair with the loop index when iterating contiguously. Previously, that optimization ran at lowering time by inspecting input strides. However, this decision must compose with subsequent optimizations such as layout changes and loop reordering.

Instead, always preserve the logical index through lowering, even when inputs are contiguous, and move the optimization immediately before codegen, after loop transformations are complete.

> AI-assisted implementation details:
>
> The late optimization removes the explicit logical index only when it proves that the index matches the final native reduction order. Otherwise, codegen retains the explicit index. Triton reduction CSE also includes retained logical indices, so equivalent mappings can merge while distinct mappings remain separate.
>
> Fixes #193661. Also covers #193751.
>
> The implementation was prepared with an AI assistant and reviewed and validated by the author.
