### PR TITLE
Use concise output style for Claude Code

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -35,7 +35,7 @@ jobs:
           'medium'
         }}
       # Surface stalled Bedrock requests before the one-hour job timeout.
-      settings: '{"alwaysThinkingEnabled":true,"env":{"API_TIMEOUT_MS":"180000","CLAUDE_CODE_MAX_RETRIES":"2","CLAUDE_ENABLE_STREAM_WATCHDOG":"1"}}'
+      settings: '{"outputStyle":"Concise","alwaysThinkingEnabled":true,"env":{"API_TIMEOUT_MS":"180000","CLAUDE_CODE_MAX_RETRIES":"2","CLAUDE_ENABLE_STREAM_WATCHDOG":"1"}}'
       # These logs are public and may include assistant messages and tool output.
       show_full_output: true
       upload_execution_log: true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.16.0) (oldest at bottom):
* __->__ #195169

## Human Note

Opus is wayyyyyyyy to chatty let try and slow his role

## Agent note

This change was prepared with an AI assistant. Configure the interactive Claude Code workflow to use
Claude's `Concise` output style while preserving its existing thinking, timeout, retry, and watchdog
settings. The structured triage and autorevert workloads are unchanged.

## Test Plan

```bash
git diff --check
actionlint .github/workflows/claude-code.yml
```

Full lint setup could not complete because the local environment lacks the `packaging` module:

```bash
.venv/bin/spin lint -a
```