### PR TITLE
Fence the CUPTI selection change in _reconfigure

### DIFF
--- a/torch/profiler/_cupti/monitor.py
+++ b/torch/profiler/_cupti/monitor.py
@@ -1089,8 +1089,7 @@ class CuptiMonitor:
         # whose selection is unchanged stay enabled -- toggling them off/on is needless
         # churn and, for RUNTIME/DRIVER, breaks CUPTI's CUDA-graph kernel tracing (a
         # graph captured while those kinds were enabled stops emitting per-node kernel
-        # records once they're disabled+re-enabled). Each completed buffer carries
-        # CUPTI's own captured layout, so buffers from before a switch still decode.
+        # records once they're disabled+re-enabled).
         sub = self._subscriber
         if sub is None:
             return
@@ -1101,13 +1100,18 @@ class CuptiMonitor:
         added = [k for k in target if k not in self._enabled]
         for kind in (*removed, *changed):
             self._cupti.activity_disable(sub, kind)
-        # Flush between disabling and (re-)enabling a kind with a new field selection
-        # so records pending under the old selection aren't lost. NON-forced: we only
-        # force-flush while syncing (the fence). Forcing here would push in-progress
-        # buffers concurrently with host activity -- the flush race that freezes the
-        # decode worker.
+        # FENCE between disabling and (re-)enabling a kind with a new field selection.
+        # A completed buffer carries one layout per kind (ppRecordLayouts), so a buffer
+        # that spans the switch has one of its two record shapes read at the other's
+        # offsets -- field 24 (the kernel name) is the schema's only const char*, so it
+        # is the only field whose misparse faults; every misparsed numeric field is
+        # silently wrong. activity_flush_all() hands over COMPLETED buffers only and
+        # leaves the partially-filled one to refill under the new selection, so it must
+        # be the fence. Placement matters as much as the fence: the disable above is
+        # what stops the kind producing, so by here nothing is refilling the buffer the
+        # fence evacuates. No forced flush is involved.
         if removed or changed:
-            self._cupti.activity_flush_all()
+            self.flush(sync=True)
         for kind in (*added, *changed):
             self._cupti.activity_enable(sub, kind, target[kind])
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195172

A completed CUPTI buffer carries one field layout per activity kind
(pBufferCompleteInfo->ppRecordLayouts). A buffer that is still filling when the
enabled selection changes therefore ends up with one of its two record shapes read
at the other's offsets.

Field 24 of CONCURRENT_KERNEL (the kernel name) is the only const char* in the
schema, so it is the only field whose misparse faults: _deref_cstr strlen's a small
integer (observed 0xa, and 0x8000000a) and the process takes a SIGSEGV with no
Python frame. Every misparsed numeric field -- timestamps, durations, stream ids --
is silently wrong instead, which is the more damaging half: an observer that selects
no string field, such as the node timer, consumes bad numbers and never crashes.

_reconfigure already flushed in the right place, between the disable and the
re-enable, but with activity_flush_all(), which hands over COMPLETED buffers only.
The partially-filled buffer survives and keeps accumulating under the new selection.
flush(sync=True) evacuates it: the fence enables SYNCHRONIZATION for the call,
device-syncs, and waits until the decoder reports a sync record past a captured
timestamp; because CUPTI delivers buffers in fill order, seeing it means the
in-progress buffer has been delivered and decoded. No forced flush is involved, so
this does not reintroduce the CUPTI_ACTIVITY_FLAG_FLUSH_FORCED hazards.

Placement matters as much as the fence. activity_disable above is what stops the
kind producing records, so by the time the fence runs nothing is refilling the
buffer it evacuates. Fencing before the disable instead leaves the workload
producing, a fresh buffer starts filling under the old layout, and the enable
straddles it anyway -- measured as no better than not fencing at all.

Test: 2 x GB200, one rank per GPU, CUDA graph replay + concurrent kernel load +
torch.profiler cycling through the cupti_monitor backend, with a kernel-name pointer
validator counting unreadable pointers instead of faulting.

  unguarded                     3 of 4 runs affected (249, 0, 19, 401 bad pointers)
  fence before the disable      4 of 4 runs affected (3, 18, 18, 4)
  fence after the disable       0 of 4 runs affected

Cost is 2.7-15 ms per reconfiguration, paid once per profiler cycle.

Also drops the comment claiming buffers from before a switch still decode; that
holds for completed buffers, not for the one spanning the switch.