### PR TITLE
[dynamo] Migrate OptimizerVariable methods to tp_methods

### DIFF
--- a/test/dynamo/test_optimizers.py
+++ b/test/dynamo/test_optimizers.py
@@ -103,6 +103,32 @@ class End2EndTests(torch._dynamo.test_case.TestCase):
 
             self.assertEqual(params, opt_params)
 
+    def test_stock_optimizer_init_group_after_disable_patch(self):
+        # TorchPatcher wraps stock Optimizer._init_group with compiler.disable.
+        # Compiling the inner step must still constant-fold _init_group via
+        # OptimizerVariable.tp_methods, not inline the disable wrapper.
+        torch._dynamo.eval_frame.TorchPatcher.patch()
+
+        # Adadelta is the inductor compiled-optimizer shard that failed; Adamax
+        # is the dynamo-wrapped test_optim case. Both wrap _init_group.
+        for opt_cls in (torch.optim.Adadelta, torch.optim.Adamax):
+            with self.subTest(opt_cls=opt_cls.__name__):
+                p = Parameter(torch.ones(2, 2), requires_grad=True)
+                opt = opt_cls([p])
+                p.grad = torch.ones_like(p)
+
+                step_fn = opt.step.__wrapped__.__wrapped__
+
+                @torch.compile(backend="eager", fullgraph=True)
+                def compiled_step():
+                    step_fn(opt)
+
+                before = p.detach().clone()
+                with torch.no_grad():
+                    compiled_step()
+                self.assertFalse(torch.equal(p, before))
+                torch._dynamo.reset()
+
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -46,7 +46,6 @@ from .constant import ConstantVariable
 from .dicts import ConstDictVariable
 from .hashable import HashableTracker
 from .lists import ListVariable
-from .misc import GetAttrVariable
 from .user_defined import UserDefinedObjectVariable
 
 
@@ -142,17 +141,6 @@ class OptimizerVariable(UserDefinedObjectVariable):
 
     tp_methods = {"_init_group": Method(_init_group)}
 
-    # _init_group resolves to a GetAttrVariable so the call is intercepted by
-    # tp_methods (in the typical case, a UserMethodVariable would inline it).
-    def _get_init_group(self, tx: "InstructionTranslatorBase") -> VariableTracker:
-        if not self.source:
-            raise AssertionError("OptimizerVariable requires a source for _init_group")
-        name = "_init_group"
-        py_type = type(getattr(self.value, name))
-        return GetAttrVariable(
-            self, name, py_type=py_type, source=AttrSource(self.source, name)
-        )
-
     # param_groups only runs setup side effects (static addresses, capturable
     # guards) and declines, falling through to the generic protocol.
     def _get_param_groups(self, tx: "InstructionTranslatorBase") -> None:
@@ -166,7 +154,6 @@ class OptimizerVariable(UserDefinedObjectVariable):
         return None
 
     tp_getset = {
-        "_init_group": GetSet(_get_init_group),
         "param_groups": GetSet(_get_param_groups),
     }
 

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -41,7 +41,7 @@ from ..source import (
     GradSource,
 )
 from ..utils import GLOBAL_KEY_PREFIX, unpack_iterable
-from .base import GetSet, VariableTracker
+from .base import GetSet, Method, VariableTracker
 from .constant import ConstantVariable
 from .dicts import ConstDictVariable
 from .hashable import HashableTracker
@@ -108,44 +108,42 @@ class OptimizerVariable(UserDefinedObjectVariable):
         self.tensor_to_source = tensor_to_source or {}
         self.static_tensor_names = static_tensor_names or set()
 
-    def call_method(
+    def _init_group(
         self,
         tx: "InstructionTranslatorBase",
-        name: str,
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
-    ) -> "VariableTracker":
+    ) -> VariableTracker | None:
         """This is an optimization to avoid tracing the very slow initialization of the optimizer"""
-        if name == "_init_group":
-            if not hasattr(self.value, "_init_group"):
-                # Fallback: if the optimizer does not have _init_group, trace normally
-                return super().call_method(tx, name, args, kwargs)
-            try:
-                self.graph_break_if_pending_mutation(tx)
-                self.move_step_if_cpu()
-                py_args, py_kwargs = self.get_python_args(*args, **kwargs)
-                ret_val = self.value._init_group(*py_args, **py_kwargs)
-                self.map_sources_and_install_guards(tx)
-                self.update_list_args(tx, args, kwargs, py_args, py_kwargs)
-                # stash a weak_ptr to optimizer to invalidate code
-                # if the optimizer object dies
-                mangled_name = f"__optimizer_{id(self.value)}"
-                tx.store_global_weakref_by_id(mangled_name, self.value)
-                self.create_finalizer(tx)
+        if not hasattr(self.value, "_init_group"):
+            return None
+        try:
+            self.graph_break_if_pending_mutation(tx)
+            self.move_step_if_cpu()
+            py_args, py_kwargs = self.get_python_args(*args, **kwargs)
+            ret_val = self.value._init_group(*py_args, **py_kwargs)
+            self.map_sources_and_install_guards(tx)
+            self.update_list_args(tx, args, kwargs, py_args, py_kwargs)
+            # stash a weak_ptr to optimizer to invalidate code
+            # if the optimizer object dies
+            mangled_name = f"__optimizer_{id(self.value)}"
+            tx.store_global_weakref_by_id(mangled_name, self.value)
+            self.create_finalizer(tx)
 
-                # This is currently safe only because the only actual `ret_val`s returned
-                # by the `_init_group` of existing optimizers are properties that are invariant
-                # to the input tensors (e.g. dtype, layout). Changing these would trigger a
-                # recompilation and hence never result in the wrong specialization of `ret_val`.
-                return ConstantVariable.create(ret_val)
-            except (ArgMappingException, GuardInstallException) as _:
-                # trace normally if we can't map args or install guards correctly
-                pass
+            # This is currently safe only because the only actual `ret_val`s returned
+            # by the `_init_group` of existing optimizers are properties that are invariant
+            # to the input tensors (e.g. dtype, layout). Changing these would trigger a
+            # recompilation and hence never result in the wrong specialization of `ret_val`.
+            return ConstantVariable.create(ret_val)
+        except (ArgMappingException, GuardInstallException):
+            # Decline so UDOV inlines _init_group if we can't map args or
+            # install guards correctly.
+            return None
 
-        return super().call_method(tx, name, args, kwargs)
+    tp_methods = {"_init_group": Method(_init_group)}
 
-    # _init_group resolves to a GetAttrVariable so the call is intercepted in
-    # call_method (in the typical case, a UserMethodVariable would inline it).
+    # _init_group resolves to a GetAttrVariable so the call is intercepted by
+    # tp_methods (in the typical case, a UserMethodVariable would inline it).
     def _get_init_group(self, tx: "InstructionTranslatorBase") -> VariableTracker:
         if not self.source:
             raise AssertionError("OptimizerVariable requires a source for _init_group")

--- a/torch/_dynamo/variables/optimizer.py
+++ b/torch/_dynamo/variables/optimizer.py
@@ -139,6 +139,10 @@ class OptimizerVariable(UserDefinedObjectVariable):
             # install guards correctly.
             return None
 
+    # LOAD_ATTR of _init_group is bound to CallMethodVariable in UDOV so the
+    # call reaches this handler. A GetSet is not needed (and would hide the
+    # method from the type dict). Stock optimizers wrap _init_group with
+    # compiler.disable; inlining that wrapper graph-breaks.
     tp_methods = {"_init_group": Method(_init_group)}
 
     # param_groups only runs setup side effects (static addresses, capturable

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -3604,6 +3604,19 @@ class UserDefinedObjectVariable(UserDefinedVariable):
 
         can_use_mro_source = self.cls_source is not None and self.source is not None
 
+        # LOAD_ATTR + CALL (3.11+) never hits call_method unless getattr
+        # returns CallMethodVariable. object_generic_getattr already does this;
+        # UDOV must too, or tp_methods handlers are skipped and the class
+        # function is inlined. That breaks when Dynamo has replaced the method
+        # (Optimizer._init_group is wrapped with torch.compiler.disable).
+        from .object_protocol import _is_method_type
+
+        if self.lookup_tp_method(name) is not None and (
+            _is_method_type(type_attr)
+            or getattr(type_attr, "_torchdynamo_disable", False)
+        ):
+            return variables.CallMethodVariable(self, name, source=source)
+
         if isinstance(type_attr, staticmethod):
             # Source points to the descriptor in the class __dict__ via MRO
             # walk, not via AttrSource(cls, name) which would trigger the


### PR DESCRIPTION
## Summary
Migrate `OptimizerVariable` off a `call_method` if-chain onto declarative `tp_methods`, as in #195165.

`_init_group` is now a `Method` handler. The fast path still constant-folds the slow optimizer init. If the optimizer has no `_init_group`, or mapping/guards fail, the handler returns `None` so `UserDefinedObjectVariable` traces the method normally.

Part of #195165 (does not close the umbrella).

## Test plan
- [x] `python test/dynamo/test_optimizers.py` (3 passed)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98