### PR TITLE
[TorchInductor] Canonicalize torch.concatenate in normalization_pass

### DIFF
--- a/test/inductor/test_split_cat_fx_passes.py
+++ b/test/inductor/test_split_cat_fx_passes.py
@@ -122,14 +122,26 @@ class TestSplitCatFxPasses(TestCase):
         post_grad_fusion_options={},
     )
     def test_cat_normalization(self):
-        def caoncat_only(x):
+        def concat_only(x):
             return torch.concat(list(torch.split(x, 2, 1)), dim=1)
+
+        def concatenate_only(x):
+            return torch.concatenate(list(torch.split(x, 2, 1)), dim=1)
+
+        def concatenate_neg_dim(x):
+            return torch.concatenate(list(torch.split(x, 2, 1)), dim=-1)
+
+        def concatenate_axis(x):
+            return torch.concatenate(list(torch.split(x, 2, 1)), axis=1)
 
         args = [
             torch.randn(2, 32),
         ]
         for fn, dynamic, expected_cat_norm_count in [
-            (caoncat_only, False, 2),
+            (concat_only, False, 2),
+            (concatenate_only, False, 2),
+            (concatenate_neg_dim, False, 2),
+            (concatenate_axis, False, 2),
         ]:
             expected = fn(*args)
             actual = torch.compile(fn, dynamic=dynamic)(*args)

--- a/torch/_inductor/fx_passes/split_cat.py
+++ b/torch/_inductor/fx_passes/split_cat.py
@@ -315,7 +315,7 @@ def normalize_unbind_default(match: Match, *args, **kwargs):
 
 
 @register_graph_pattern(
-    CallFunctionVarArgs([torch.cat, torch.concat], users=MULTIPLE),
+    CallFunctionVarArgs([torch.cat, torch.concat, torch.concatenate], users=MULTIPLE),
     pass_dict=construct_pattern_matcher_pass("normalization_pass"),
 )
 def normalize_cat_default(match: Match, *args, **kwargs):


### PR DESCRIPTION
# Fixing an Issue

Before submitting, please review:
- [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy

---

## Issue

Fixes #194898

## Summary

In `normalization_pass` (`torch/_inductor/fx_passes/split_cat.py`), `CallFunctionVarArgs` was registered for `[torch.cat, torch.concat]`, but missed the `torch.concatenate` alias. Consequently, models using `torch.concatenate` left un-canonicalized `torch.concatenate` nodes in the FX graph, which prevented subsequent pre-grad optimizations (such as `split_cat_pass`, `merge_splits_pass`, etc.) from matching and optimizing them.

This PR adds `torch.concatenate` to `CallFunctionVarArgs` in `normalize_cat_default` and adds test coverage for `torch.concatenate` and negative dimension canonicalization in `test_split_cat_fx_passes.py`.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## BC-breaking?

No


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo