### PR TITLE
[dynamo] Migrate AutogradFunctionVariable methods

### DIFF
--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1320,6 +1320,39 @@ class AutogradFunctionVariable(VariableTracker):
         fn_vt = VariableTracker.build(tx, fn, source=fn_source, realize=True)
         return fn_vt.call_function(tx, args, kwargs)
 
+    def apply(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        from .builder import wrap_fx_proxy
+
+        if trace_rules.is_callable_allowed(self.fn_cls):
+            trampoline_autograd_apply = produce_trampoline_autograd_apply(self.fn_cls)
+            return wrap_fx_proxy(
+                tx=tx,
+                proxy=tx.output.create_proxy(
+                    "call_function",
+                    trampoline_autograd_apply,
+                    *proxy_args_kwargs(args, kwargs),
+                ),
+            )
+        return self.call_apply(tx, args, kwargs)
+
+    def backward(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return self.call_backward(tx, args, kwargs)
+
+    tp_methods = {
+        "apply": Method(apply),
+        "backward": Method(backward),
+    }
+
     def call_function(
         self,
         tx: "InstructionTranslatorBase",
@@ -1449,54 +1482,36 @@ class AutogradFunctionVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        from .builder import wrap_fx_proxy
+        if name in self.tp_methods:
+            return super().call_method(tx, name, args, kwargs)
 
-        if name == "apply":
-            if trace_rules.is_callable_allowed(self.fn_cls):
-                trampoline_autograd_apply = produce_trampoline_autograd_apply(
-                    self.fn_cls
-                )
-                return wrap_fx_proxy(
-                    tx=tx,
-                    proxy=tx.output.create_proxy(
-                        "call_function",
-                        trampoline_autograd_apply,
-                        *proxy_args_kwargs(args, kwargs),
-                    ),
-                )
-            else:
-                return self.call_apply(tx, args, kwargs)
+        source = (
+            AttrSource(self.fn_cls_source, name)
+            if self.fn_cls_source is not None
+            else None
+        )
+        try:
+            obj = inspect.getattr_static(self.fn_cls, name)
+        except AttributeError:
+            obj = None
 
-        elif name == "backward":
-            return self.call_backward(tx, args, kwargs)
-        else:
-            source = (
-                AttrSource(self.fn_cls_source, name)
-                if self.fn_cls_source is not None
-                else None
-            )
-            try:
-                obj = inspect.getattr_static(self.fn_cls, name)
-            except AttributeError:
-                obj = None
+        if type(obj) is staticmethod:
+            descriptor_source = self._get_raw_attribute_source(tx, name)
+            if descriptor_source is not None:
+                return self._resolve_staticmethod(
+                    obj, source, descriptor_source, name
+                ).call_function(tx, args, kwargs)
+        elif type(obj) is classmethod:
+            descriptor_source = self._get_raw_attribute_source(tx, name)
+            if descriptor_source is not None:
+                func_source = AttrSource(descriptor_source, "__func__")
+                install_guard(func_source.make_guard(GuardBuilder.ID_MATCH))
+                install_guard(func_source.make_guard(GuardBuilder.CLOSURE_MATCH))
+                return variables.UserMethodVariable(
+                    obj.__func__, self, source_fn=func_source, source=source
+                ).call_function(tx, args, kwargs)
 
-            if type(obj) is staticmethod:
-                descriptor_source = self._get_raw_attribute_source(tx, name)
-                if descriptor_source is not None:
-                    return self._resolve_staticmethod(
-                        obj, source, descriptor_source, name
-                    ).call_function(tx, args, kwargs)
-            elif type(obj) is classmethod:
-                descriptor_source = self._get_raw_attribute_source(tx, name)
-                if descriptor_source is not None:
-                    func_source = AttrSource(descriptor_source, "__func__")
-                    install_guard(func_source.make_guard(GuardBuilder.ID_MATCH))
-                    install_guard(func_source.make_guard(GuardBuilder.CLOSURE_MATCH))
-                    return variables.UserMethodVariable(
-                        obj.__func__, self, source_fn=func_source, source=source
-                    ).call_function(tx, args, kwargs)
-
-            self._unsupported_method(name)
+        self._unsupported_method(name)
 
 
 @dataclasses.dataclass

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1482,6 +1482,8 @@ class AutogradFunctionVariable(VariableTracker):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
+        # apply is a C method and backward is a @staticmethod, so they would
+        # not reach the Method handlers through the branches below.
         if name in self.tp_methods:
             return super().call_method(tx, name, args, kwargs)
 


### PR DESCRIPTION
## Summary
Migrate `AutogradFunctionVariable` off a `call_method` if-chain onto declarative `tp_methods`, as in #195165.

`apply` and `backward` are now `Method` handlers; static/class method handling is unchanged.

Part of #195165 (does not close the umbrella).

## Test plan
- [x] `git diff --check`
- [x] `python -m py_compile torch/_dynamo/variables/misc.py`

> AI-assisted implementation.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98