### PR TITLE
[dynamo] Migrate DictBuiltinVariable.fromkeys to tp_methods

### DIFF
--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -3247,9 +3247,7 @@ class DictBuiltinVariable(BaseBuiltinVariable):
         args: list[VariableTracker],
         kwargs: dict[str, VariableTracker],
     ) -> VariableTracker:
-        return DictBuiltinVariable.call_custom_dict_fromkeys(
-            tx, dict, *args, **kwargs
-        )
+        return DictBuiltinVariable.call_custom_dict_fromkeys(tx, dict, *args, **kwargs)
 
     tp_methods = {
         "fromkeys": Method(fromkeys),

--- a/torch/_dynamo/variables/builtin.py
+++ b/torch/_dynamo/variables/builtin.py
@@ -85,6 +85,7 @@ from .base import (
     AsPythonConstantNotImplementedError,
     GetSet,
     Member,
+    Method,
     ValueMutationNew,
     VariableTracker,
 )
@@ -3240,6 +3241,20 @@ class DictBuiltinVariable(BaseBuiltinVariable):
     ) -> VariableTracker:
         return DictBuiltinVariable.call_custom_dict(tx, dict, *args, **kwargs)
 
+    def fromkeys(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return DictBuiltinVariable.call_custom_dict_fromkeys(
+            tx, dict, *args, **kwargs
+        )
+
+    tp_methods = {
+        "fromkeys": Method(fromkeys),
+    }
+
     def call_method(
         self,
         tx: "InstructionTranslatorBase",
@@ -3262,11 +3277,6 @@ class DictBuiltinVariable(BaseBuiltinVariable):
                     [],
                     tx=tx,
                 )
-
-        if name == "fromkeys":
-            return DictBuiltinVariable.call_custom_dict_fromkeys(
-                tx, dict, *args, **kwargs
-            )
 
         resolved_fn = getattr(dict, name, None)
         if resolved_fn is not None and resolved_fn in dict_methods:


### PR DESCRIPTION
## Summary

Part of the VariableTracker migration tracked in #195165.

- Move `DictBuiltinVariable.fromkeys` from an ad-hoc `call_method` branch onto the declarative `tp_methods` table.
- `ListBuiltinVariable` is unchanged: its remaining `call_method` logic is only `__new__`, which the issue intentionally leaves out of `tp_methods` (tp_new slot).
- Unbound dict method forwarding (`dict.update(d, ...)`, etc.) stays in `call_method` because it is keyed dynamically over `dict_methods`.

## Why this item

All small/good-first-issue candidates on #195165 already have open PRs. Among the remaining medium items, `DictBuiltinVariable` is the smallest self-contained migration: one explicit named method (`fromkeys`), with existing Dynamo coverage for `dict.fromkeys`.

## Test plan

- [ ] `python test/dynamo/test_dicts.py -k test_fromkeys`
- [ ] `python test/dynamo/test_functions.py -k test_dict_fromkeys`
- [ ] `python test/dynamo/test_tp_getattro.py -k test_classmethod_descriptor_dict_fromkeys`

Local tests were not run in this environment (no built PyTorch checkout / venv available).

Fixes #195165

---


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98