### PR TITLE
Fix stack buffer overflow in libshm Unix socket path handling

### DIFF
--- a/torch/lib/libshm/socket.h
+++ b/torch/lib/libshm/socket.h
@@ -36,14 +36,16 @@ class Socket {
   struct sockaddr_un prepare_address(const char* path) {
     struct sockaddr_un address{};
     address.sun_family = AF_UNIX;
-    const size_t path_len = strlen(path);
+    const size_t path_len = std::strlen(path);
     TORCH_CHECK(
         path_len < sizeof(address.sun_path),
-        "Unix socket path too long (max ",
+        "Unix socket path is ",
+        path_len,
+        " bytes, but the limit is ",
         sizeof(address.sun_path) - 1,
-        " chars)");
-    strncpy(address.sun_path, path, sizeof(address.sun_path) - 1);
-    address.sun_path[sizeof(address.sun_path) - 1] = '\0';
+        ". Path: ",
+        path);
+    std::memcpy(address.sun_path, path, path_len + 1);
     return address;
   }
 

--- a/torch/lib/libshm/socket.h
+++ b/torch/lib/libshm/socket.h
@@ -34,9 +34,16 @@ class Socket {
   }
 
   struct sockaddr_un prepare_address(const char* path) {
-    struct sockaddr_un address;
+    struct sockaddr_un address{};
     address.sun_family = AF_UNIX;
-    strcpy(address.sun_path, path);
+    const size_t path_len = strlen(path);
+    TORCH_CHECK(
+        path_len < sizeof(address.sun_path),
+        "Unix socket path too long (max ",
+        sizeof(address.sun_path) - 1,
+        " chars)");
+    strncpy(address.sun_path, path, sizeof(address.sun_path) - 1);
+    address.sun_path[sizeof(address.sun_path) - 1] = '\0';
     return address;
   }
 


### PR DESCRIPTION
## Summary

Fixes #195182

Replace unbounded `strcpy()` in `Socket::prepare_address()` with a length check and bounded copy into `sockaddr_un.sun_path`.

## Changes

- Zero-initialize `sockaddr_un` with `{}`
- Reject paths >= `sizeof(sun_path)` via `TORCH_CHECK`
- Use `strncpy` with explicit null termination

## Test plan

- [ ] Default `torch_shm_manager` startup still works (typical `/tmp/torch-shm-dir-*/manager.sock` paths)
- [ ] Oversized path triggers clean `TORCH_CHECK` failure instead of stack corruption

## Notes

Identified via AMD ROCm security triage (ROCM-27017 / SEC-00828). Default auto-generated paths are short; overflow is reachable via long `TMPDIR` or explicit `manager_handle` in shared-storage APIs.


Made with [Cursor](https://cursor.com)