### PR TITLE
[dynamo] Migrate SymNodeVariable methods to tp_methods

### DIFF
--- a/test/dynamo/test_nested_graph_breaks_wrapped.py
+++ b/test/dynamo/test_nested_graph_breaks_wrapped.py
@@ -145,6 +145,8 @@ xfails = [
     NestedGraphBreaksSubGraphTests.test_resume_paths_join_nested_graph_breaks,  # noqa: F821
     NestedGraphBreaksReproTests.test_udf_classes_reconstruction_nested_graph_breaks,  # noqa: F821
     NestedGraphBreaksUnspecTests.test_unspecialized_float_multiply_precision,  # noqa: F821
+    # fullgraph Unsupported vs nested_graph_breaks exception handling
+    NestedGraphBreaksUnspecTests.test_symint_bit_length_wrong_arity,  # noqa: F821
 ]
 
 case = None

--- a/test/dynamo/test_nested_graph_breaks_wrapped.py
+++ b/test/dynamo/test_nested_graph_breaks_wrapped.py
@@ -98,55 +98,66 @@ for test in tests:
 
 del test
 
+# Bind generated classes so static checkers see the names.
+NestedGraphBreaksDecoratorTests = test_classes["NestedGraphBreaksDecoratorTests"]
+NestedGraphBreaksDefaultsTests = test_classes["NestedGraphBreaksDefaultsTests"]
+NestedGraphBreaksFunctionTests = test_classes["NestedGraphBreaksFunctionTests"]
+NestedGraphBreaksMiscTests = test_classes["NestedGraphBreaksMiscTests"]
+NestedGraphBreaksReproTests = test_classes["NestedGraphBreaksReproTests"]
+NestedGraphBreaksSubGraphTests = test_classes["NestedGraphBreaksSubGraphTests"]
+NestedGraphBreaksTupleTests = test_classes["NestedGraphBreaksTupleTests"]
+NestedGraphBreaksUnspecTests = test_classes["NestedGraphBreaksUnspecTests"]
+
 xfails = [
     # variable naming issues (debug_force_nested_calls changes L['x'] to L['args'][0])
-    NestedGraphBreaksMiscTests.test_flat_name_to_original_fqn_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_compare_shapes_with_constant_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_guard_failure_fn2_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_guard_failure_fn_shape_control_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_guard_filter_fn_by_name_and_value_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_guard_sym_node_fstring_when_used_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_replay_side_effects_config_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_replay_side_effects_model_attr_nested_graph_breaks,  # noqa: F821
+    NestedGraphBreaksMiscTests.test_flat_name_to_original_fqn_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_compare_shapes_with_constant_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_guard_failure_fn2_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_guard_failure_fn_shape_control_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_guard_filter_fn_by_name_and_value_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_guard_sym_node_fstring_when_used_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_replay_side_effects_config_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_replay_side_effects_model_attr_nested_graph_breaks,
     # doesn't work due to debug_force_nested_calls wrapping the top frame
-    NestedGraphBreaksMiscTests.test_dynamo_cache_move_to_front_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_dynamo_reset_clears_cache_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_fail_on_recompile_error_message_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_get_cache_entry_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_precompile_entries_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_precompile_entry_hit_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_precompile_fail_on_recompile_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksDecoratorTests.test_compile_staticmethod_caching_precompile_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_torch_guards_stack_frame_register_inlining_deep_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksMiscTests.test_torch_guards_stack_frame_register_inlining_nested_graph_breaks,  # noqa: F821
+    NestedGraphBreaksMiscTests.test_dynamo_cache_move_to_front_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_dynamo_reset_clears_cache_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_fail_on_recompile_error_message_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_get_cache_entry_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_precompile_entries_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_precompile_entry_hit_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_precompile_fail_on_recompile_nested_graph_breaks,
+    NestedGraphBreaksDecoratorTests.test_compile_staticmethod_caching_precompile_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_torch_guards_stack_frame_register_inlining_deep_nested_graph_breaks,
+    NestedGraphBreaksMiscTests.test_torch_guards_stack_frame_register_inlining_nested_graph_breaks,
     # differing op_count
-    NestedGraphBreaksMiscTests.test_nested_closure_nested_graph_breaks,  # noqa: F821
+    NestedGraphBreaksMiscTests.test_nested_closure_nested_graph_breaks,
     # debug_force_nested_calls tries to inline skipped functions
-    NestedGraphBreaksTupleTests.test_binop_add_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_binop_imul_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_cmp_eq_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_cmp_greater_than_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_cmp_greater_than_or_equal_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_cmp_less_than_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_cmp_less_than_or_equal_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_cmp_ne_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test___contains___nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_count_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test___getitem___nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_index_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test___iter___nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksTupleTests.test_list_mul_constant_tuple_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksFunctionTests.test_itertools_islice_basic_ops_nested_graph_breaks,  # noqa: F821
+    NestedGraphBreaksTupleTests.test_binop_add_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_binop_imul_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_cmp_eq_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_cmp_greater_than_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_cmp_greater_than_or_equal_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_cmp_less_than_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_cmp_less_than_or_equal_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_cmp_ne_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test___contains___nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_count_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test___getitem___nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_index_nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test___iter___nested_graph_breaks,
+    NestedGraphBreaksTupleTests.test_list_mul_constant_tuple_nested_graph_breaks,
+    NestedGraphBreaksFunctionTests.test_itertools_islice_basic_ops_nested_graph_breaks,
     # bytecode codegen issues with nested graph breaks
-    NestedGraphBreaksDefaultsTests.test_frozenset_reconstruction2_nested_graph_breaks,  # noqa: F821
+    NestedGraphBreaksDefaultsTests.test_frozenset_reconstruction2_nested_graph_breaks,
     # correctness issues due to debug_force_nested_calls wrapping
-    NestedGraphBreaksDecoratorTests.test_fullgraph_eval_frame_override_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksDecoratorTests.test_torch_guards_stack_frame_register_inlining_disable_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksSubGraphTests.test_resume_paths_join_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksReproTests.test_udf_classes_reconstruction_nested_graph_breaks,  # noqa: F821
-    NestedGraphBreaksUnspecTests.test_unspecialized_float_multiply_precision,  # noqa: F821
-    # fullgraph Unsupported vs nested_graph_breaks exception handling
-    NestedGraphBreaksUnspecTests.test_symint_bit_length_wrong_arity,  # noqa: F821
+    NestedGraphBreaksDecoratorTests.test_fullgraph_eval_frame_override_nested_graph_breaks,
+    NestedGraphBreaksDecoratorTests.test_torch_guards_stack_frame_register_inlining_disable_nested_graph_breaks,
+    NestedGraphBreaksSubGraphTests.test_resume_paths_join_nested_graph_breaks,
+    NestedGraphBreaksReproTests.test_udf_classes_reconstruction_nested_graph_breaks,
+    NestedGraphBreaksUnspecTests.test_unspecialized_float_multiply_precision,
+    # size(0) specializes to ConstantVariable(int); Method arity is not traced
+    NestedGraphBreaksUnspecTests.test_symint_bit_length_wrong_arity,
+    NestedGraphBreaksUnspecTests.test_symint_bit_length_wrong_arity_nested_graph_breaks,
 ]
 
 case = None

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -818,7 +818,10 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
     def test_symint_number_methods(self):
         def fn(x):
             n = x.size(0)
-            return n.bit_length() + n.conjugate() + n.as_integer_ratio()[0] + n.__int__()
+            bit_length = n.bit_length()
+            conjugate = n.conjugate()
+            ratio = n.as_integer_ratio()[0]
+            return bit_length + conjugate + ratio + n.__int__()
 
         x = torch.randn(8, 3)
         compiled = torch.compile(fn, backend="eager", fullgraph=True)

--- a/test/dynamo/test_unspec.py
+++ b/test/dynamo/test_unspec.py
@@ -815,6 +815,36 @@ class UnspecTests(torch._dynamo.test_case.TestCase):
         compl_fn = torch.compile(fn, dynamic=True, backend="eager")
         self.assertEqual(fn(t, 1.0), compl_fn(t, 1.0))
 
+    def test_symint_number_methods(self):
+        def fn(x):
+            n = x.size(0)
+            return n.bit_length() + n.conjugate() + n.as_integer_ratio()[0] + n.__int__()
+
+        x = torch.randn(8, 3)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(x), fn(x))
+
+    def test_symint_bit_length_wrong_arity(self):
+        def fn(x):
+            return x.size(0).bit_length(1)
+
+        x = torch.randn(8, 3)
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "takes no arguments"
+        ):
+            compiled(x)
+
+    @torch._dynamo.config.patch(specialize_float=False)
+    def test_symfloat_number_methods(self):
+        def fn(t, m):
+            return (2 * t if m.is_integer() else t) + m.conjugate()
+
+        t = torch.tensor([1.0])
+        compiled = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(compiled(t, 1.0), fn(t, 1.0))
+        self.assertEqual(compiled(t, 1.5), fn(t, 1.5))
+
     @torch._dynamo.config.patch(specialize_float=False)
     def test_unspec_roundtrip_float_input(self):
         def f(x, y):

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2946,22 +2946,6 @@ class SymNodeVariable(VariableTracker):
         "__int__": Method(int_),
     }
 
-    def call_method(
-        self,
-        tx: "InstructionTranslatorBase",
-        name: str,
-        args: list[VariableTracker],
-        kwargs: dict[str, VariableTracker],
-    ) -> VariableTracker:
-        # Unlisted names keep the generic FX-proxy path so getattr still
-        # dispatches through call_method (_has_custom_call_method).
-        method = self.lookup_tp_method(name)
-        if method is not None:
-            result = method(self, tx, name, args, kwargs)
-            if result is not None:
-                return result
-        return self._proxy_method(tx, name, args, kwargs)
-
     def nb_index_impl(
         self,
         tx: "InstructionTranslatorBase",

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2780,6 +2780,18 @@ class TensorVariable(VariableTracker):
         )
 
 
+def _symnode_proxy(name: str) -> Method:
+    def handler(
+        self: "SymNodeVariable",
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return self._proxy_method(tx, name, args, kwargs)
+
+    return Method(handler)
+
+
 class SymNodeVariable(VariableTracker):
     """
     Represents a symbolic scalar, either int, float or bool.  This is most commonly used to
@@ -2896,7 +2908,7 @@ class SymNodeVariable(VariableTracker):
                 case_name="constrain_as_size_example",
             )
 
-    def call_method(
+    def _proxy_method(
         self,
         tx: "InstructionTranslatorBase",
         name: str,
@@ -2913,6 +2925,42 @@ class SymNodeVariable(VariableTracker):
                 *proxy_args_kwargs([self, *args], kwargs),
             ),
         )
+
+    def int_(
+        self,
+        tx: "InstructionTranslatorBase",
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        return self.nb_int_impl(tx)
+
+    # Named instance methods on SymInt / SymFloat. Arithmetic dunders are
+    # number slots. Named int_ so this does not shadow Python's __int__.
+    tp_methods = {
+        "as_integer_ratio": _symnode_proxy("as_integer_ratio"),
+        "bit_length": _symnode_proxy("bit_length"),
+        "conjugate": _symnode_proxy("conjugate"),
+        "has_hint": _symnode_proxy("has_hint"),
+        "hex": _symnode_proxy("hex"),
+        "is_integer": _symnode_proxy("is_integer"),
+        "__int__": Method(int_),
+    }
+
+    def call_method(
+        self,
+        tx: "InstructionTranslatorBase",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        # Unlisted names keep the generic FX-proxy path so getattr still
+        # dispatches through call_method (_has_custom_call_method).
+        method = self.lookup_tp_method(name)
+        if method is not None:
+            result = method(self, tx, name, args, kwargs)
+            if result is not None:
+                return result
+        return self._proxy_method(tx, name, args, kwargs)
 
     def nb_index_impl(
         self,
@@ -2946,11 +2994,6 @@ class SymNodeVariable(VariableTracker):
                 {},
             ),
         )
-
-    def method___int__(
-        self, tx: "InstructionTranslatorBase", *args: Any, **kwargs: Any
-    ) -> VariableTracker:
-        return self.nb_int_impl(tx)
 
     def nb_add_impl(
         self,

--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -2946,6 +2946,22 @@ class SymNodeVariable(VariableTracker):
         "__int__": Method(int_),
     }
 
+    def call_method(
+        self,
+        tx: "InstructionTranslatorBase",
+        name: str,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker:
+        # Unlisted names keep the generic FX-proxy path so getattr still
+        # dispatches through call_method (_has_custom_call_method).
+        method = self.lookup_tp_method(name)
+        if method is not None:
+            result = method(self, tx, name, args, kwargs)
+            if result is not None:
+                return result
+        return self._proxy_method(tx, name, args, kwargs)
+
     def nb_index_impl(
         self,
         tx: "InstructionTranslatorBase",


### PR DESCRIPTION
## Summary
Migrate `SymNodeVariable` named methods onto declarative `tp_methods`, as in #195165.

`as_integer_ratio` / `bit_length` / `conjugate` / `has_hint` / `hex` / `is_integer` are now `Method` handlers (shared FX-proxy). `__int__` uses the existing `nb_int_impl` path (named `int_` so it does not shadow Python's `__int__`). Arithmetic dunders stay on number slots.

`call_method` keeps a generic FX-proxy fallback so unlisted names still dispatch through `call_method` (`_has_custom_call_method` / getattr).

Part of #195165 (does not close the umbrella).

## Test plan
- [x] `python test/dynamo/test_unspec.py UnspecTests.test_symint_number_methods UnspecTests.test_symint_bit_length_wrong_arity UnspecTests.test_symfloat_number_methods UnspecTests.test_symfloat_no_replacement` (4 passed)
- [x] `python test/dynamo/test_functions.py FunctionTests.test_is_integer` (passed)
- [x] `python test/dynamo/test_functions.py -k test_number_method` (7 passed)

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98