### PR TITLE
Skip redundant stream initialization guard check

### DIFF
--- a/c10/cuda/CUDAStream.cpp
+++ b/c10/cuda/CUDAStream.cpp
@@ -224,15 +224,17 @@ void initDeviceStreamState(DeviceIndex device_index) {
 
 // Init front-end to ensure initialization only occurs once
 void initCUDAStreamsOnce() {
+  // Quick return if streams have been initialized. current_streams
+  // is thread_local, we don't need to worry about a data race.
+  if (current_streams) {
+    return;
+  }
+
   // Inits default streams (once, globally)
   auto static init_flag [[maybe_unused]] = [] {
     initGlobalStreamState();
     return true;
   }();
-
-  if (current_streams) {
-    return;
-  }
 
   // Inits current streams (thread local) to default streams
   // NOLINTNEXTLINE(*-arrays)


### PR DESCRIPTION
I saw from `build/bolt_profiles/libc10_cuda.yaml` that `initCUDAStreamsOnce` is a hot function. This function does a one-time process-wide initialization and a per-thread initialization. With the help of GPT 5.6 I was able to identify that the function enters the initialization paths very rarely but pays the cost of the static flag lookup in each invocation.

I have reordered this function to avoid the static flag lookup in the common case.

GPT 5.6 analyzed the binaries before and after the change and noted 3 fewer instructions (global flag lookup) and 1 fewer branch in the generated assembly. This was also confirmed using perf on a micro- benchmark that calls this function in a tight loop.

Assisted-by: gpt-5.6-sol medium