### PR TITLE
[inductor] Rewrite iota index accumulation as slice_scatter

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2886,6 +2886,43 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         self.assertEqual(f(x_ref, y_ref), out)
 
     @skipCUDAIf(
+        not SM90OrLater, "eager BF16 index_select backward requires BF16 atomics"
+    )
+    def test_index_select_iota_backward_no_atomic(self):
+        def f(x):
+            index = torch.arange(8, device=x.device)
+            return torch.index_select(x, 3, index)
+
+        x = torch.randn(
+            2,
+            3,
+            4,
+            17,
+            dtype=torch.bfloat16,
+            device=device_type,
+            requires_grad=True,
+        )
+        x_ref = x.detach().clone().requires_grad_(True)
+
+        counters.clear()
+        out, (_, bw_code) = run_fw_bw_and_get_code(lambda: torch.compile(f)(x))
+        expected = f(x_ref)
+        expected.sum().backward()
+
+        self.assertEqual(out, expected)
+        self.assertEqual(x.grad, x_ref.grad)
+        self.assertEqual(
+            counters["inductor"]["index_accumulate_iota_to_slice_scatter"], 1
+        )
+        (
+            FileCheck()
+            .check_not("tl.atomic_add")
+            .check_not("torch.ops.aten.index_add.default")
+            .check_not("torch.ops.aten.index_put.default")
+            .run(bw_code)
+        )
+
+    @skipCUDAIf(
         not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"
     )
     @unittest.skipIf(

--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -906,6 +906,55 @@ class TestPatternMatcher(TestCase):
         joint_graph.joint_graph_passes(gm)
         self.assertEqual(count_calls(gm.graph), 2)
 
+    def test_index_accumulate_iota_to_slice_scatter(self):
+        def make_fn(op, start, alpha=1):
+            def fn(base, values):
+                index = torch.ops.prims.iota.default(
+                    3,
+                    start=start,
+                    step=1,
+                    dtype=torch.int64,
+                    device=base.device,
+                    requires_grad=False,
+                )
+                if op == torch.ops.aten.index_put.default:
+                    return op(base, (None, index), values, True)
+                return op(base, 1, index, values, alpha=alpha)
+
+            return fn
+
+        base = torch.randn(2, 5, 7, device=GPU_TYPE)
+        values = torch.randn(2, 3, 7, device=GPU_TYPE)
+        ops = (
+            torch.ops.aten.index_put.default,
+            torch.ops.aten.index_add.default,
+        )
+        cases = (
+            [(op, 0, 1, True) for op in ops]
+            + [(op, 1, 1, False) for op in ops]
+            + [(torch.ops.aten.index_add.default, 0, 2, False)]
+        )
+        for op, start, alpha, should_match in cases:
+            with self.subTest(op=op, start=start, alpha=alpha):
+                fn = make_fn(op, start, alpha)
+                expected = fn(base, values)
+                gm = make_fx(fn, tracing_mode="fake")(base, values)
+
+                counters.clear()
+                joint_graph.joint_graph_passes(gm)
+                torch.testing.assert_close(gm(base, values), expected)
+                self.assertEqual(
+                    counters["inductor"]["index_accumulate_iota_to_slice_scatter"],
+                    int(should_match),
+                )
+                targets = {
+                    node.target for node in gm.graph.nodes if node.op == "call_function"
+                }
+                self.assertEqual(op in targets, not should_match)
+                self.assertEqual(
+                    torch.ops.aten.slice_scatter.default in targets, should_match
+                )
+
     # Constant folding was explicitly turned off due to issue #108388
     # Turn it back on for test
     @inductor_config.patch(joint_graph_constant_folding=True)

--- a/torch/_inductor/fx_passes/joint_graph.py
+++ b/torch/_inductor/fx_passes/joint_graph.py
@@ -882,6 +882,99 @@ def fix_iota_device(match: Match, length, start, step, dtype, device, requires_g
             match.erase_nodes()
 
 
+_IOTA_INDEX = CallFunction(
+    prims.iota.default,
+    KeywordArg("length"),
+    start=0,
+    step=1,
+    _users=MULTIPLE,
+)
+
+
+@register_graph_pattern(
+    CallFunction(
+        aten.index_put.default,
+        KeywordArg("base"),
+        KeywordArg("indices"),
+        KeywordArg("values"),
+        True,
+    ),
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=patterns,
+)
+@register_graph_pattern(
+    CallFunction(
+        aten.index_add.default,
+        KeywordArg("base"),
+        KeywordArg("dim"),
+        KeywordArg("index"),
+        KeywordArg("values"),
+        alpha=1,
+    ),
+    # pyrefly: ignore [bad-argument-type]
+    pass_dict=patterns,
+)
+def index_accumulate_iota_to_slice_scatter(
+    match: Match,
+    base: torch.fx.Node,
+    values: torch.fx.Node,
+    dim: int | None = None,
+    index: torch.fx.Node | None = None,
+    indices: Sequence[torch.fx.Node | None] | None = None,
+):
+    """Remove atomics from identity-index accumulation before partitioning."""
+    if indices is not None:
+        indexed_dims = [
+            (dim, index) for dim, index in enumerate(indices) if index is not None
+        ]
+        if len(indexed_dims) != 1:
+            return
+        dim, index = indexed_dims[0]
+
+    if index is None or not isinstance(dim, int):
+        return
+    iota_match = _IOTA_INDEX.match(index)
+    if not isinstance(iota_match, Match):
+        return
+    length = iota_match.kwargs["length"]
+    if not isinstance(length, int):
+        return
+
+    base_val = base.meta.get("val")
+    values_val = values.meta.get("val")
+    if not (
+        isinstance(base_val, torch.Tensor)
+        and isinstance(values_val, torch.Tensor)
+        and base_val.ndim == values_val.ndim
+    ):
+        return
+
+    if dim < 0:
+        dim += base_val.ndim
+    if not 0 <= dim < base_val.ndim:
+        return
+
+    if not (
+        statically_known_true(sym_eq(values_val.shape[dim], length))
+        and statically_known_true(length <= base_val.shape[dim])
+        and all(
+            statically_known_true(sym_eq(values_val.shape[i], base_val.shape[i]))
+            for i in range(base_val.ndim)
+            if i != dim
+        )
+    ):
+        return
+
+    def repl(base, values):
+        base_slice = aten.slice.Tensor(base, dim, 0, length, 1)
+        updated_slice = aten.add.Tensor(base_slice, values)
+        return aten.slice_scatter.default(base, updated_slice, dim, 0, length, 1)
+
+    # pyrefly: ignore [bad-argument-type]
+    match.replace_by_example(repl, [base, values])
+    counters["inductor"]["index_accumulate_iota_to_slice_scatter"] += 1
+
+
 @register_graph_pattern(
     CallFunction(
         torch.ops.prims.convert_element_type.default,


### PR DESCRIPTION
AI assistance disclosure: This PR was prepared with Codex. I directed the work toward a joint-graph pattern match so the identity iota would neither be saved nor realized, and reviewed the resulting safety constraints. The AI-assisted writeup follows:

> ## Summary
>
> Rewrite accumulating `index_add` and `index_put` operations whose sole index is `iota(0, N, 1)` as a slice, pointwise add, and `slice_scatter` in the joint graph. The identity iota proves that every destination is updated exactly once, so the operation does not require atomics.
>
> Running before AOTAutograd partitioning also removes the backward use of the iota, allowing the partitioner to stop saving it from the forward. The match supports arbitrary rank and indexed dimensions, with static shape checks; non-unit starts/steps, non-unit `alpha`, and non-accumulating `index_put` fail closed.
>
> On an internal training graph, the matcher fires 24 times, removes the corresponding atomic scatters and saved iotas, and improves median step time by 1.84% on B200.
>
> ## Testing
>
> - `TestPatternMatcher.test_index_accumulate_iota_to_slice_scatter`
> - `CudaReproTests.test_index_select_iota_backward_no_atomic`
> - Ruff, Python compilation, and diff checks
>
> ## BC-breaking?
>
> No.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo