### PR TITLE
[inductor] Enable BF16 index_add lowering on SM90+ and ROCm

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2801,14 +2801,11 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         )
         self.assertEqual(foo(x0), result)
 
-    @unittest.skipIf(
-        not config.is_fbcode(),
-        "bfloat16 atomic add is only supported in fbcode today #97016",
-    )
     @skipCUDAIf(
-        not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"
+        not SM90OrLater and not TEST_WITH_ROCM,
+        "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",
     )
-    def test_atomic_add_bfloat16(self):
+    def test_index_add_bfloat16_dim0(self):
         def f(x, y):
             return torch.index_select(x, 0, y)
 
@@ -2861,47 +2858,76 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
             self.assertEqual(torch.compile(f)(x, y), out)
 
     @skipCUDAIf(
-        not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"
+        not SM90OrLater and not TEST_WITH_ROCM,
+        "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",
     )
-    @unittest.skipIf(
-        config.is_fbcode(),
-        "bfloat16 atomic add is supported in fbcode, so we won't fallback",
-    )
-    def test_index_add_fallback(self):
-        def f(x, y):
-            return torch.index_select(x, 0, y)
-
-        x = torch.randn(
-            2000, 384, dtype=torch.bfloat16, device=device_type, requires_grad=True
-        )
-        y = torch.ones(713268, dtype=torch.int64, device=device_type)
-        x_ref = x.clone().detach().requires_grad_(True)
-        y_ref = y.clone().detach()
-
-        out, (_, bw_code) = run_fw_bw_and_get_code(lambda: torch.compile(f)(x, y))
-        fc = FileCheck()
-        fc.check("aten.index_add")
-        fc.run(bw_code)
-
-        self.assertEqual(f(x_ref, y_ref), out)
-
-    @skipCUDAIf(
-        not SM90OrLater, "uses bfloat16 atomic add instrs which requires SM >= 90"
-    )
-    @unittest.skipIf(
-        config.is_fbcode(),
-        "bfloat16 atomic add is supported in fbcode, so we won't fallback",
-    )
-    def test_index_add_fallback_direct(self):
+    def test_index_add_bfloat16_direct(self):
         def f(x, idx, src):
-            return torch.index_add(x, 0, idx, src)
+            return torch.index_add(x, -1, idx, src, alpha=0.5)
 
-        x = torch.randn(16, 256, dtype=torch.bfloat16, device=device_type)
-        idx = torch.randperm(8, device=device_type)
-        src = torch.randn(8, 256, dtype=torch.bfloat16, device=device_type)
+        x = torch.zeros(16, 256, dtype=torch.bfloat16, device=device_type).T
+        idx = torch.tensor(
+            [0, 1, 1, 2, 2, 2, 7, 7], dtype=torch.int32, device=device_type
+        )
+        src = torch.ones(8, 256, dtype=torch.bfloat16, device=device_type).T
 
         out = f(x, idx, src)
-        compiled_out = torch.compile(f)(x, idx, src)
+        compiled_out, (code,) = run_and_get_code(
+            torch.compile(f, fullgraph=True), x, idx, src
+        )
+
+        FileCheck().check("tl.atomic_add").check_not(
+            "torch.ops.aten.index_add.default"
+        ).run(code)
+        self.assertEqual(out, compiled_out)
+
+    @skipCUDAIf(
+        not SM90OrLater and not TEST_WITH_ROCM,
+        "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",
+    )
+    def test_index_add_bfloat16_scalar_index(self):
+        def f(x, idx, src):
+            return torch.index_add(x, 1, idx, src)
+
+        x = torch.zeros(8, 16, dtype=torch.bfloat16, device=device_type)
+        idx = torch.tensor(3, device=device_type)
+        src = torch.ones(8, 1, dtype=torch.bfloat16, device=device_type)
+
+        out = f(x, idx, src)
+        compiled_out, (code,) = run_and_get_code(
+            torch.compile(f, fullgraph=True), x, idx, src
+        )
+
+        FileCheck().check("tl.atomic_add").check_not(
+            "torch.ops.aten.index_add.default"
+        ).run(code)
+        self.assertEqual(out, compiled_out)
+
+    @skipCUDAIf(
+        not SM90OrLater and not TEST_WITH_ROCM,
+        "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",
+    )
+    @unittest.skipIf(
+        config.is_fbcode(),
+        "fbcode uses its bfloat16 atomic add lowering",
+    )
+    def test_index_add_bfloat16_deterministic(self):
+        def f(x, idx, src):
+            return torch.index_add(x, 1, idx, src)
+
+        x = torch.zeros(32, 16, dtype=torch.bfloat16, device=device_type)
+        idx = torch.arange(8, device=device_type)
+        src = torch.ones(32, 8, dtype=torch.bfloat16, device=device_type)
+
+        with DeterministicGuard(True):
+            out = f(x, idx, src)
+            compiled_out, (code,) = run_and_get_code(
+                torch.compile(f, fullgraph=True), x, idx, src
+            )
+
+        FileCheck().check("aten.index_put_").check_not("tl.atomic_add").check_not(
+            "torch.ops.aten.index_add.default"
+        ).run(code)
         self.assertEqual(out, compiled_out)
 
     @requires_multigpu()

--- a/torch/_inductor/decomposition.py
+++ b/torch/_inductor/decomposition.py
@@ -362,13 +362,18 @@ def index_add(
     *,
     alpha: torch.types.Number = 1,
 ) -> torch.Tensor:
-    # If we are not in fbcode and dtype is bfloat16
-    # fallback to index_add kernel
-    # see https://github.com/pytorch/pytorch/issues/137425 for details
     if not is_fbcode() and x.dtype == torch.bfloat16:
-        return NotImplemented
-    else:
-        return _index_add(x, dim, index, tensor, inplace=False, alpha=alpha)
+        # Triton supports BF16 atomic add on ROCm and NVIDIA SM90 and newer.
+        if x.device.type != "cuda" or (
+            torch.version.hip is None
+            and torch.cuda.get_device_capability(x.device) < (9, 0)
+        ):
+            return NotImplemented
+    # The index_put lowering expects tensor indices to have at least one
+    # dimension. Normalizing a scalar index preserves index_add semantics.
+    if index.ndim == 0:
+        index = index.unsqueeze(0)
+    return _index_add(x, dim, index, tensor, inplace=False, alpha=alpha)
 
 
 # Not really sure how to put this into the main library.  PrimTorch wants


### PR DESCRIPTION
The Inductor `index_add` decomposition retained a stale OSS-only BF16 fallback after Triton added BF16 `atomic_add` support. This enables the decomposition on ROCm and on NVIDIA SM90+, allowing `index_add` to participate in fusion instead of becoming an ATen fallback kernel.

Triton support was added in https://github.com/triton-lang/triton/pull/6519 and was tested upstream on MI300 as well as NVIDIA GPUs. NVIDIA remains gated to SM90+ here because that is the native BF16 atomic instruction boundary; pre-SM90 Triton uses a CAS loop.

This also normalizes scalar indices before the decomposition because the resulting `index_put` lowering expects tensor indices to have at least one dimension.

Tests cover:
- BF16 `index_select` backward
- direct non-contiguous `index_add` with a negative dimension, int32 indices, duplicates, and non-unit alpha
- scalar indices
- deterministic-algorithm fallback without atomics

ROCm and NVIDIA SM90+ run the lowering/codegen assertions; older NVIDIA GPUs retain the ATen fallback.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben