### PR TITLE
Fix silu(-inf) returning NaN instead of the limit 0

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -1133,16 +1133,28 @@ void silu_kernel(TensorIteratorBase& iter) {
   if (at::isReducedFloatingType(iter.dtype())) {
     AT_DISPATCH_REDUCED_FLOATING_TYPES(iter.dtype(), "silu_cpu", [&]() {
       const Vectorized<float> kOneVec(1.0f);
+      const Vectorized<float> kZeroVec(0.0f);
+      const Vectorized<float> kNegInfVec(
+          -std::numeric_limits<float>::infinity());
       cpu_kernel_vec(
           iter,
           [](scalar_t x) -> scalar_t {
+            // silu(x) -> 0 as x -> -inf; the x/(1+exp(-x)) form would otherwise
+            // yield -inf/inf = NaN (see pytorch/pytorch#160876).
+            if (float(x) == -std::numeric_limits<float>::infinity()) {
+              return scalar_t(0);
+            }
             return float(x) / (1.0f + std::exp(-float(x)));
           },
-          [kOneVec](Vectorized<scalar_t> x_vec) -> Vectorized<scalar_t> {
+          [kOneVec, kZeroVec, kNegInfVec](
+              Vectorized<scalar_t> x_vec) -> Vectorized<scalar_t> {
             auto [x_vec0, x_vec1] = convert_to_float<scalar_t>(x_vec);
-            return convert_from_float<scalar_t>(
-              x_vec0 / (kOneVec + x_vec0.neg().exp()),
-              x_vec1 / (kOneVec + x_vec1.neg().exp()));
+            auto y0 = x_vec0 / (kOneVec + x_vec0.neg().exp());
+            auto y1 = x_vec1 / (kOneVec + x_vec1.neg().exp());
+            // Replace the -inf lanes (NaN above) with the limit, 0.
+            y0 = Vectorized<float>::blendv(y0, kZeroVec, x_vec0 == kNegInfVec);
+            y1 = Vectorized<float>::blendv(y1, kZeroVec, x_vec1 == kNegInfVec);
+            return convert_from_float<scalar_t>(y0, y1);
           });
     });
   } else {
@@ -1152,10 +1164,26 @@ void silu_kernel(TensorIteratorBase& iter) {
         cpu_kernel_vec(
             iter,
             [](scalar_t x) {
+              // Complex is excluded: c10::complex has no -inf ordering, and
+              // Vectorized<complex>::blendv does not instantiate.
+              if constexpr (!c10::is_complex<scalar_t>::value) {
+                // silu(x) -> 0 as x -> -inf (avoid -inf/inf = NaN); see
+                // pytorch/pytorch#160876.
+                if (x == -std::numeric_limits<scalar_t>::infinity()) {
+                  return scalar_t(0);
+                }
+              }
               return x / (scalar_t(1) + std::exp(-x));
             },
             [kOneVec](Vectorized<scalar_t> x_vec) {
-              return x_vec / (kOneVec + x_vec.neg().exp());
+              auto y = x_vec / (kOneVec + x_vec.neg().exp());
+              if constexpr (!c10::is_complex<scalar_t>::value) {
+                const Vectorized<scalar_t> kNegInfVec(
+                    -std::numeric_limits<scalar_t>::infinity());
+                y = Vectorized<scalar_t>::blendv(
+                    y, Vectorized<scalar_t>(scalar_t(0)), x_vec == kNegInfVec);
+              }
+              return y;
             });
       });
     }

--- a/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
+++ b/aten/src/ATen/native/cuda/ActivationSiluKernel.cu
@@ -30,6 +30,13 @@ void silu_kernel(TensorIteratorBase& iter) {
         gpu_kernel(iter, [] GPU_LAMBDA(scalar_t x) -> scalar_t {
           using opmath_t = at::opmath_type<scalar_t>;
           const opmath_t x_acc = static_cast<opmath_t>(x);
+          if constexpr (!c10::is_complex<scalar_t>::value) {
+            // silu(x) -> 0 as x -> -inf (avoid -inf/inf = NaN); see
+            // pytorch/pytorch#160876.
+            if (x_acc == -std::numeric_limits<opmath_t>::infinity()) {
+              return scalar_t(0);
+            }
+          }
           return x_acc / (opmath_t(1) + ::exp(-x_acc));
         });
       });

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1135,6 +1135,14 @@ class TestUnaryUfuncs(TestCase):
             rtol=rtol,
         )
 
+        # silu(-inf) is the limit 0, not the -inf/inf = NaN that the naive
+        # x/(1+exp(-x)) form produces (pytorch/pytorch#160876).
+        neg_inf = torch.tensor([float("-inf")], device=device, dtype=dtype)
+        self.assertEqual(
+            torch.nn.functional.silu(neg_inf),
+            torch.zeros(1, device=device, dtype=dtype),
+        )
+
     @dtypes(torch.complex64, torch.complex128)
     def test_silu_complex(self, device, dtype):
         atol = 1e-6

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17749,7 +17749,10 @@ op_db: list[OpInfo] = [
     UnaryUfuncInfo(
         'nn.functional.silu',
         aten_backward_name='silu_backward',
-        ref=lambda x, inplace=False: x / (1 + np.exp(-x)),
+        # silu(x) -> 0 as x -> -inf; the bare x/(1+exp(-x)) form yields
+        # -inf/inf = NaN there, so match the op's limit (pytorch/pytorch#160876).
+        ref=lambda x, inplace=False: np.where(
+            x == -np.inf, 0.0, x / (1 + np.exp(-x))),
         dtypes=floating_types_and(torch.bfloat16, torch.float16),
         dtypesIfMPS=floating_types_and(
             torch.bfloat16, torch.float16, torch.int16, torch.int32, torch.uint8, torch.bool, torch.int8


### PR DESCRIPTION
Fixes #160876

### Problem

`torch.nn.functional.silu(-inf)` returns `nan` instead of `0`.

ref: https://www.wolframalpha.com/input?i=lim+x+*+sigmoid%28x%29+as+x+-%3E+-inf

`silu(x) = x * sigmoid(x) = x / (1 + exp(-x))`. Mathematically `silu(x) -> 0` as `x -> -inf`. But evaluated directly at exactly `-inf`, the kernel computes `-inf / (1 + exp(inf)) = -inf / inf = nan`.

```python
>>> import torch
>>> torch.nn.functional.silu(torch.tensor(float("-inf")))
tensor(nan)   # expected: tensor(0.)
```

(Large finite-negative inputs already flush to `-0.0` correctly; only exactly `-inf` is affected.)

### Fix

Guard the `-inf` input so the kernels return the limit `0`:

- **CPU** (`aten/src/ATen/native/cpu/Activation.cpp`) — both the reduced-float (bf16/fp16) and floating/complex dispatch blocks, in the scalar and `Vectorized` lambdas. The vectorized path uses `blendv(y, 0, x == -inf)` to replace the affected lanes.
- **CUDA** (`aten/src/ATen/native/cuda/ActivationSiluKernel.cu`) — the `GPU_LAMBDA`.

Both guards are gated on `!c10::is_complex<scalar_t>` via `if constexpr`, so complex `silu` keeps its existing behavior (there is no `-inf` ordering for complex).

The `nn.functional.silu` OpInfo reference in `common_methods_invocations.py` is updated to match the limit (`np.where(x == -inf, 0.0, ...)`), so `test_reference_numerics_extremal` agrees with the op.

### Testing

Built CPU-only and ran locally:

- `python test/test_unary_ufuncs.py -k test_silu` — 4/4 pass (incl. a new `silu(-inf) == 0` regression assert added to `test_silu`).
- `python test/test_unary_ufuncs.py -k test_reference_numerics_extremal` (silu) — `float16`, `bfloat16`, `float32`, `float64`, `complex128` pass; `complex64` skip is pre-existing.

The CUDA kernel change mirrors the CPU logic; I don't have a GPU locally, so it relies on CI.

---
_Disclosure: this change was prepared with the assistance of an AI coding tool; I've reviewed and validated it._

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01