### PR TITLE
[ROCm] Use linux-jammy-rocm-3.10-mi350 as trunk-rocm-sandbox job name/environment

### DIFF
--- a/.github/workflows/trunk-rocm-sandbox.yml
+++ b/.github/workflows/trunk-rocm-sandbox.yml
@@ -41,15 +41,15 @@ jobs:
       curr_ref_type: ${{ github.ref_type }}
       check_experiments: amd-sandbox
 
-  linux-noble-rocm-py3_12-build:
-    name: linux-noble-rocm-py3.12-mi350
+  linux-jammy-rocm-py3_10-build:
+    name: linux-jammy-rocm-py3.10-mi350
     uses: ./.github/workflows/_linux-build.yml
     needs: get-label-type
     with:
       runner_prefix: "mt-"
       ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
-      build-environment: linux-noble-rocm-py3.12-mi350
-      docker-image-name: ci-image:pytorch-linux-noble-rocm-n-py3
+      build-environment: linux-jammy-rocm-py3.10-mi350
+      docker-image-name: ci-image:pytorch-linux-jammy-rocm-n-py3
       # The amd-sandbox experiment routes the mi350 test shards onto the
       # amd-sandbox- prefixed runner scale sets via the dedicated
       # amd-sandbox-label-type output (empty when the experiment is disabled, in
@@ -72,14 +72,14 @@ jobs:
         ]}
     secrets: inherit
 
-  linux-noble-rocm-py3_12-test:
-    name: linux-noble-rocm-py3.12-mi350
+  linux-jammy-rocm-py3_10-test:
+    name: linux-jammy-rocm-py3.10-mi350
     uses: ./.github/workflows/_rocm-test.yml
     needs:
-      - linux-noble-rocm-py3_12-build
+      - linux-jammy-rocm-py3_10-build
       - target-determination
     with:
-      build-environment: ${{ needs.linux-noble-rocm-py3_12-build.outputs.build-environment }}
-      docker-image: ${{ needs.linux-noble-rocm-py3_12-build.outputs.docker-image }}
-      test-matrix: ${{ needs.linux-noble-rocm-py3_12-build.outputs.test-matrix }}
+      build-environment: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-rocm-py3_10-build.outputs.test-matrix }}
     secrets: inherit


### PR DESCRIPTION
This should ensure that the trunk-rocm-sandbox workflow picks up the same sharding info as [trunk.yml workflow](https://github.com/pytorch/pytorch/blob/a484ab154368e52ba192a3adf8be71308a0d8ab3/.github/workflows/trunk.yml#L514) for the DPX experiment.

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang