### PR TITLE
[py3.14] Fix `partial` class attribute in inductor dynamic shapes test

### DIFF
--- a/test/inductor/test_torchinductor_dynamic_shapes.py
+++ b/test/inductor/test_torchinductor_dynamic_shapes.py
@@ -232,7 +232,7 @@ if (HAS_GPU or HAS_MPS) and not TEST_WITH_ASAN:
 
 
 class TestInductorDynamic(DynamicShapesTestCase):
-    compile_fn = partial(torch.compile, dynamic=True)
+    compile_fn = staticmethod(partial(torch.compile, dynamic=True))
 
     def setUp(self):
         # HAS_CUDA_AND_TRITON also checks compute capability to skip tests


### PR DESCRIPTION
Summary:
Python 3.14 made `functools.partial` a descriptor. `compile_fn` is a class
attribute holding `partial(torch.compile, dynamic=True)`, so `self.compile_fn(fn)`
now binds and passes `self` through as `torch.compile`'s first positional
argument:

```
TypeError: compile() takes from 0 to 1 positional arguments but 2 positional
arguments (and 1 keyword-only argument) were given
```

Test Plan:
Reproduced the binding change directly on both interpreters — a class attribute
holding a `partial` with a keyword-only argument, called through an instance:

```
$ for v in 3.12 3.14; do
    /usr/local/fbcode/platform010/bin/python$v /tmp/probe_partial.py ; done
  py3.12 bare partial : fn=MODEL, dynamic=True
  py3.12 staticmethod : fn=MODEL, dynamic=True
  py3.14 bare partial : TypeError: target() takes 1 positional argument but 2 positional arguments (and 1 keyword-only argument) were given
  py3.14 staticmethod : fn=MODEL, dynamic=True
```

The 3.14 `bare partial` line is the same shape as the canary failure; the
`staticmethod` form is correct on both.

`arc lint` & CI

Differential Revision: D115382057




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo