### PR TITLE
Move `DynamicShapesMiscTests.test_torch_size_tensor_index_scalar_constant_dynamic_shapes` to @periodic

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -172,6 +172,13 @@ if [[ -n $TESTS_TO_INCLUDE ]]; then
   INCLUDE_CLAUSE="--include $TESTS_TO_INCLUDE"
 fi
 
+if [[ "$TEST_CONFIG" == 'periodic' ]]; then
+  # These custom run_test.py targets cannot be filtered cleanly by -m periodic:
+  # doctests and autoload bypass pytest; AOT builds extensions before pytest;
+  # CI sanity expects its unmarked test to fail.
+  TESTS_TO_EXCLUDE="$TESTS_TO_EXCLUDE doctests test_cpp_extensions_aot_ninja test_cpp_extensions_aot_no_ninja test_autoload_enable test_autoload_disable test_ci_sanity_check_fail"
+fi
+
 # Exclude tests from run_test.py (symmetric to TESTS_TO_INCLUDE).
 if [[ -n $TESTS_TO_EXCLUDE ]]; then
   echo "Setting EXCLUDE_CLAUSE"

--- a/.github/workflows/periodic-strict.yml
+++ b/.github/workflows/periodic-strict.yml
@@ -65,17 +65,39 @@ jobs:
       build-environment: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.build-environment }}
       docker-image: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.docker-image }}
       test-matrix: ${{ needs.linux-jammy-cuda13_0-py3_10-gcc11-build.outputs.test-matrix }}
-      # These custom run_test.py targets cannot be filtered cleanly by -m periodic:
-      # doctests and autoload bypass pytest; AOT builds extensions before pytest;
-      # CI sanity expects its unmarked test to fail.
-      tests-to-exclude: >-
-        doctests
-        test_cpp_extensions_aot_ninja
-        test_cpp_extensions_aot_no_ninja
-        test_autoload_enable
-        test_autoload_disable
-        test_ci_sanity_check_fail
       python-version: "3.10"
       compiler: gcc11
       cuda-version: "13.0"
+    secrets: inherit
+
+  linux-jammy-py3_10-clang21-build:
+    name: linux-jammy-py3.10-clang21
+    uses: ./.github/workflows/_linux-build.yml
+    needs: get-label-type
+    with:
+      runner_prefix: "${{ needs.get-label-type.outputs.label-type }}"
+      build-environment: linux-jammy-py3.10-clang21
+      docker-image-name: ci-image:pytorch-linux-jammy-py3.10-clang21
+      ci-docker-hash: ${{ needs.get-label-type.outputs.ci-docker-hash }}
+      test-matrix: |
+        { include: [
+          { config: "periodic", shard: 1, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+          { config: "periodic", shard: 2, num_shards: 2, runner: "${{ needs.get-label-type.outputs.label-type }}linux.2xlarge" },
+        ]}
+      python-version: "3.10"
+      compiler: clang21
+    secrets: inherit
+
+  linux-jammy-py3_10-clang21-test:
+    name: linux-jammy-py3.10-clang21
+    uses: ./.github/workflows/_linux-test.yml
+    needs:
+      - linux-jammy-py3_10-clang21-build
+      - get-label-type
+    with:
+      build-environment: ${{ needs.linux-jammy-py3_10-clang21-build.outputs.build-environment }}
+      docker-image: ${{ needs.linux-jammy-py3_10-clang21-build.outputs.docker-image }}
+      test-matrix: ${{ needs.linux-jammy-py3_10-clang21-build.outputs.test-matrix }}
+      python-version: "3.10"
+      compiler: clang21
     secrets: inherit

--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -4,7 +4,7 @@ import warnings
 from torch._dynamo import config
 from torch._dynamo.testing import make_test_cls_with_patches
 from torch.fx.experimental import _config as fx_config
-from torch.testing._internal.common_utils import slowTest, TEST_Z3
+from torch.testing._internal.common_utils import periodic, slowTest, TEST_Z3
 
 
 try:
@@ -94,6 +94,10 @@ DynamicShapesExportTests.test_retracibility_dict_container_inp_out_dynamic_shape
 )
 DynamicShapesExportTests.test_retracibility_nested_list_out_dynamic_shapes = slowTest(  # noqa: F821
     DynamicShapesExportTests.test_retracibility_nested_list_out_dynamic_shapes  # noqa: F821
+)
+
+DynamicShapesMiscTests.test_torch_size_tensor_index_scalar_constant_dynamic_shapes = periodic(  # noqa: F821
+    DynamicShapesMiscTests.test_torch_size_tensor_index_scalar_constant_dynamic_shapes  # noqa: F821
 )
 
 if __name__ == "__main__":

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -118,7 +118,11 @@ NUM_PYTEST_RERUNS = int(os.getenv("PYTORCH_NUM_PYTEST_RERUNS", "2"))
 NUM_PROCESS_RETRIES = int(os.getenv("PYTORCH_NUM_PROCESS_RETRIES", "2"))
 DISTRIBUTED_TEST_PREFIX = "distributed"
 INDUCTOR_TEST_PREFIX = "inductor"
-IS_SLOW = "slow" in TEST_CONFIG or "slow" in BUILD_ENVIRONMENT
+# The periodic config hosts slow-gated tests (test.sh sets
+# PYTORCH_TEST_WITH_SLOW for it), so it gets slow's per-file timeout budget.
+IS_SLOW = (
+    "slow" in TEST_CONFIG or "slow" in BUILD_ENVIRONMENT or TEST_CONFIG == "periodic"
+)
 IS_S390X = platform.machine() == "s390x"
 
 


### PR DESCRIPTION
This diff moves a candidate test from `slow` to `periodic-strict`. This is the 15th slowest test (source: [test/slow_tests.json](https://github.com/pytorch/pytorch/blob/8b05648d878c333fadd0d998e35fd4bc616a9413/test/slow_tests.json#L249)). Note that we are reducing the number of platforms the test runs on by moving to this workflow.

### Before

| Workflow | Platform | Runner | Runtime |
|---|---|---|---:|
| `slow` | CPU clang21 | AVX512 CPU | 600.839s |
| `slow` | CPU clang21 ASAN | AVX512 CPU | 601.280s |
| `slow` | CUDA 13.0 SM86 | NVIDIA A10G | 601.041s |
| `slow` | CUDA 13.2 SM86 | NVIDIA A10G | 601.308s |

### After

| Workflow | Platform | Runner | Runtime |
|---|---|---|---:|
| `periodic-strict` | CPU clang21 | AVX512 CPU | 600.888s |
| `periodic-strict` | CUDA 13.0 | NVIDIA L4 | 601.004s |

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98