### PR TITLE
Fix NaN-dependent tensor length inconsistency in CPU backward kernels

### DIFF
--- a/aten/src/ATen/native/cpu/Activation.cpp
+++ b/aten/src/ATen/native/cpu/Activation.cpp
@@ -232,8 +232,8 @@ void elu_backward_kernel(TensorIteratorBase& it, const Scalar& alpha, const Scal
         [&negcoef_vec, &negiptcoef_vec, &poscoef_vec, &zero_vec, is_result](Vectorized<scalar_t> a, Vectorized<scalar_t> b) -> Vectorized<scalar_t> {
           auto [a0, a1] = convert_to_float<scalar_t>(a);
           auto [b0, b1] = convert_to_float<scalar_t>(b);
-          auto cmp0 = (b0 > zero_vec);
-          auto cmp1 = (b1 > zero_vec);
+          auto cmp0 = ~(b0 <= zero_vec);
+          auto cmp1 = ~(b1 <= zero_vec);
           auto get_res_masked = [&](Vectorized<float>& cmp, Vectorized<float>& a, Vectorized<float>& b) {
             if (is_result) {
               return !cmp.zero_mask() ? a * poscoef_vec :
@@ -267,7 +267,7 @@ void elu_backward_kernel(TensorIteratorBase& it, const Scalar& alpha, const Scal
             }
           },
           [&negcoef_vec, &negiptcoef_vec, &poscoef_vec, &zero_vec, is_result](Vec a, Vec b) -> Vec {
-            auto cmp = (b > zero_vec);
+            auto cmp = ~(b <= zero_vec);
             if (is_result) {
               if (!cmp.zero_mask()) {  // only a * poscoef (which is very quick) needs to be computed
                 return a * poscoef_vec;
@@ -690,7 +690,7 @@ void shrink_backward_kernel(TensorIteratorBase& iter, const Scalar& lambd) {
                                                                    : grad_val;
         },
         [=](Vectorized<scalar_t> grad_val, Vectorized<scalar_t> self_val) {
-          return ((self_val < -lambd_val) | (self_val > lambd_val)) & grad_val;
+          return (~((self_val >= -lambd_val) & (self_val <= lambd_val))) & grad_val;
         });
   });
 }
@@ -709,8 +709,8 @@ void hardtanh_backward_kernel(TensorIterator& iter, const Scalar& min, const Sca
             auto [grad_val0, grad_val1] = convert_to_float<scalar_t>(grad_val);
             auto [self_val0, self_val1] = convert_to_float<scalar_t>(self_val);
             return convert_from_float<scalar_t>(
-              ((self_val0 > min_val) & (self_val0 < max_val)) & grad_val0,
-              ((self_val1 > min_val) & (self_val1 < max_val)) & grad_val1
+              (~((self_val0 <= min_val) | (self_val0 >= max_val))) & grad_val0,
+              (~((self_val1 <= min_val) | (self_val1 >= max_val))) & grad_val1
             );
           });
     });
@@ -724,7 +724,7 @@ void hardtanh_backward_kernel(TensorIterator& iter, const Scalar& min, const Sca
           return (self_val <= min_val || self_val >= max_val) ? scalar_t(0) : grad_val;
         },
         [=](Vectorized<scalar_t> grad_val, Vectorized<scalar_t> self_val) {
-          return ((self_val > min_val) & (self_val < max_val)) & grad_val;
+          return (~((self_val <= min_val) | (self_val >= max_val))) & grad_val;
         });
   });
   }
@@ -813,7 +813,7 @@ void hardswish_backward_kernel(TensorIterator& iter) {
           Vec::blendv(
             grad_val0 * ((self_val0 / kThreeVec) + kOneHalfVec),
             grad_val0,
-            self_val0 >= kThreeVec
+            ~(self_val0 < kThreeVec)
           ),
           kZeroVec,
           self_val0 <= kNegThreeVec
@@ -822,7 +822,7 @@ void hardswish_backward_kernel(TensorIterator& iter) {
           Vec::blendv(
             grad_val1 * ((self_val1 / kThreeVec) + kOneHalfVec),
             grad_val1,
-            self_val1 >= kThreeVec
+            ~(self_val1 < kThreeVec)
           ),
           kZeroVec,
           self_val1 <= kNegThreeVec
@@ -857,7 +857,7 @@ void hardswish_backward_kernel(TensorIterator& iter) {
           Vec::blendv(
             grad_val * ((self_val / kThreeVec) + kOneHalfVec),
             grad_val,
-            self_val >= kThreeVec
+            ~(self_val < kThreeVec)
           ),
           kZeroVec,
           self_val <= kNegThreeVec

--- a/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
+++ b/aten/src/ATen/native/cpu/BinaryOpsKernel.cpp
@@ -944,7 +944,7 @@ void logit_backward_kernel(TensorIteratorBase& iter, const Scalar& eps_scalar) {
                 return Vectorized<scalar_t>::blendv(
                     kNanVec,
                     dy_vec / (x_vec * (kOneVec - x_vec)),
-                    (x_vec >= kZeroVec) & (x_vec <= kOneVec));
+                    ~((x_vec < kZeroVec) | (x_vec > kOneVec)));
               });
         } else {
           const scalar_t lo = eps;
@@ -965,7 +965,7 @@ void logit_backward_kernel(TensorIteratorBase& iter, const Scalar& eps_scalar) {
                 return Vectorized<scalar_t>::blendv(
                     kZeroVec,
                     dy_vec / (x_vec * (kOneVec - x_vec)),
-                    (x_vec >= lo_vec) & (x_vec <= hi_vec));
+                    ~((x_vec < lo_vec) | (x_vec > hi_vec)));
               });
         }
       });

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3627,6 +3627,28 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         x_grad_ref = torch.where(mask, grad, z)
         self.assertEqual(x.grad, x_grad_ref)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/195075:
+    # cpu_kernel_vec's vectorized and scalar-remainder lambdas disagreed on
+    # NaN, so the same op returned a different gradient at a NaN element
+    # depending only on unrelated tensor length/alignment.
+    def test_activation_backward_nan_length_invariant(self):
+        size = 128 + 1  # exceed AVX512 width so a scalar remainder tail runs
+        ops = (F.hardtanh, F.elu, F.hardswish, F.hardshrink, F.softshrink)
+        for op in ops:
+            for nan_pos in (0, size // 2, size - 1):
+                x = torch.full((size,), 0.3, dtype=torch.float32)
+                x[nan_pos] = float("nan")
+                x.requires_grad_(True)
+                (long_grad,) = torch.autograd.grad(op(x), x, torch.ones(size))
+
+                x1 = torch.tensor([float("nan")], dtype=torch.float32, requires_grad=True)
+                (short_grad,) = torch.autograd.grad(op(x1), x1, torch.ones(1))
+
+                self.assertEqual(
+                    long_grad[nan_pos], short_grad[0], equal_nan=True,
+                    msg=f"{op.__name__} backward depends on tensor length at NaN (pos {nan_pos}/{size})",
+                )
+
     def test_batchnorm_nhwc_cpu(self):
         def helper(self, mod, size, dtype, mixed_dtype=False, format=torch.channels_last, precision=None):
             channels = size[1]

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3633,21 +3633,23 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
     # depending only on unrelated tensor length/alignment.
     def test_activation_backward_nan_length_invariant(self):
         size = 128 + 1  # exceed AVX512 width so a scalar remainder tail runs
-        ops = (F.hardtanh, F.elu, F.hardswish, F.hardshrink, F.softshrink)
-        for op in ops:
-            for nan_pos in (0, size // 2, size - 1):
-                x = torch.full((size,), 0.3, dtype=torch.float32)
-                x[nan_pos] = float("nan")
-                x.requires_grad_(True)
-                (long_grad,) = torch.autograd.grad(op(x), x, torch.ones(size))
+        ops = (F.hardtanh, F.elu, F.celu, F.hardswish, F.hardshrink, F.softshrink)
+        dtypes = (torch.float32, torch.bfloat16, torch.float16)
+        for dtype in dtypes:
+            for op in ops:
+                for nan_pos in (0, size // 2, size - 1):
+                    x = torch.full((size,), 0.3, dtype=dtype)
+                    x[nan_pos] = float("nan")
+                    x.requires_grad_(True)
+                    (long_grad,) = torch.autograd.grad(op(x), x, torch.ones(size, dtype=dtype))
 
-                x1 = torch.tensor([float("nan")], dtype=torch.float32, requires_grad=True)
-                (short_grad,) = torch.autograd.grad(op(x1), x1, torch.ones(1))
+                    x1 = torch.tensor([float("nan")], dtype=dtype, requires_grad=True)
+                    (short_grad,) = torch.autograd.grad(op(x1), x1, torch.ones(1, dtype=dtype))
 
-                self.assertEqual(
-                    long_grad[nan_pos], short_grad[0], equal_nan=True,
-                    msg=f"{op.__name__} backward depends on tensor length at NaN (pos {nan_pos}/{size})",
-                )
+                    self.assertEqual(
+                        long_grad[nan_pos], short_grad[0], equal_nan=True,
+                        msg=f"{op.__name__} backward ({dtype}) depends on tensor length at NaN (pos {nan_pos}/{size})",
+                    )
 
     def test_batchnorm_nhwc_cpu(self):
         def helper(self, mod, size, dtype, mixed_dtype=False, format=torch.channels_last, precision=None):

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1573,7 +1573,7 @@ class TestUnaryUfuncs(TestCase):
     # NaN, so logit_backward returned a different gradient at a NaN element
     # depending only on unrelated tensor length/alignment.
     @onlyCPU
-    @dtypes(torch.float, torch.double)
+    @dtypes(torch.float, torch.double, torch.bfloat16, torch.half)
     def test_logit_backward_nan_length_invariant(self, device, dtype):
         size = 128 + 1  # exceed AVX512 width so a scalar remainder tail runs
         for eps in (None, 1e-6):

--- a/test/test_unary_ufuncs.py
+++ b/test/test_unary_ufuncs.py
@@ -1568,6 +1568,35 @@ class TestUnaryUfuncs(TestCase):
         for v in inp:
             self.assertGreater(math.copysign(1.0, v), 0.0)
 
+    # Regression test for https://github.com/pytorch/pytorch/issues/195075:
+    # cpu_kernel_vec's vectorized and scalar-remainder lambdas disagreed on
+    # NaN, so logit_backward returned a different gradient at a NaN element
+    # depending only on unrelated tensor length/alignment.
+    @onlyCPU
+    @dtypes(torch.float, torch.double)
+    def test_logit_backward_nan_length_invariant(self, device, dtype):
+        size = 128 + 1  # exceed AVX512 width so a scalar remainder tail runs
+        for eps in (None, 1e-6):
+            for nan_pos in (0, size // 2, size - 1):
+                x = torch.full((size,), 0.3, device=device, dtype=dtype)
+                x[nan_pos] = float("nan")
+                x.requires_grad_(True)
+                (long_grad,) = torch.autograd.grad(
+                    torch.logit(x, eps=eps), x, torch.ones(size, device=device, dtype=dtype)
+                )
+
+                x1 = torch.tensor(
+                    [float("nan")], device=device, dtype=dtype, requires_grad=True
+                )
+                (short_grad,) = torch.autograd.grad(
+                    torch.logit(x1, eps=eps), x1, torch.ones(1, device=device, dtype=dtype)
+                )
+
+                self.assertEqual(
+                    long_grad[nan_pos], short_grad[0], equal_nan=True,
+                    msg=f"logit_backward(eps={eps}) depends on tensor length at NaN (pos {nan_pos}/{size})",
+                )
+
     # TODO: update to compare against NumPy by rationalizing with OpInfo
     @onlyAccelerator
     @dtypes(torch.float, torch.double)


### PR DESCRIPTION
## Summary

Fixes #195075.

Several CPU backward kernels use separate scalar and SIMD implementations whose predicates are equivalent for ordered values but differ for NaN. As a result, the gradient at a NaN element can depend on whether that element is processed by the vectorized loop or scalar remainder.

This updates the SIMD predicates in `logit_backward`, `elu_backward`, `shrink_backward`, `hardtanh_backward`, and `hardswish_backward` to match their corresponding scalar predicates for unordered values. This PR only fixes the CPU vector/scalar inconsistency; choosing a broader cross-backend NaN convention is out of scope and left to maintainer consensus on the issue.

## Test plan

Added regression tests that place NaN values in both vectorized and scalar-remainder positions and compare their gradients against a scalar-only invocation. Coverage includes `float32`/`float64` plus the reduced-precision (`float16`/`bfloat16`) dispatch paths for the activation kernels, and `celu` alongside `elu` since both share `elu_backward_kernel`.

- `python -m pytest test/test_unary_ufuncs.py -k logit_backward -v`
- `python -m pytest test/test_nn.py -k "activation_backward_nan_length_invariant" -v`

The regression tests fail (at the reduced-precision dtypes too) when the kernel changes are reverted, and pass with the fix applied.

## AI assistance

Claude Code assisted with the investigation and implementation. I reviewed the complete change and ran the tests listed above.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01