### PR TITLE
[MPS] Fix compile_shader header resolution in editable installs

### DIFF
--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -155,9 +155,18 @@ def compile_shader(source: str):
 
     if not hasattr(torch._C, "_mps_compileShader"):
         raise RuntimeError("MPS is not available")
+    torch_root = Path(__file__).parent.parent
+    # A packaged install stages the headers under torch/include, but an
+    # editable install runs straight from the source checkout, where they are
+    # still at the repository root. Search both so `#include <c10/metal/...>`
+    # resolves either way.
+    include_dirs = [torch_root / "include"]
+    source_root = torch_root.parent
+    if (source_root / "c10" / "metal").is_dir():
+        include_dirs += [source_root, source_root / "aten" / "src"]
     source = _embed_headers(
         [l + "\n" for l in source.split("\n")],
-        [Path(__file__).parent.parent / "include"],
+        include_dirs,
         set(),
     )
     return torch._C._mps_compileShader(source)


### PR DESCRIPTION
Closes #195293

I have built this branch standalone and run its tests locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than presented as my own prose.

> ## Why this is needed
>
> Fixes a broken developer path rather than adding an operator. On any source build (`pip install -e .`), every `#include <c10/metal/...>` inside `torch.mps.compile_shader` fails to resolve, which silently turns 14 tests in `TestMetalLibrary` into errors instead of skips. Anyone working on MPS kernels hits this.
>
> ## Change
>
> `torch.mps.compile_shader` inlines `#include` directives before handing the
> source to the Metal compiler, and it looks for them in exactly one place:
> `torch/include`. That directory only exists in a packaged install. Building
> PyTorch from source with `pip install -e .` never creates it, so every
> `#include <c10/metal/...>` in a shader fails to resolve and the compile dies
> with "file not found".
>
> That is not a niche path. It is what every developer working on MPS kernels
> hits, and it silently disables a chunk of the test suite: on a source build,
> `TestMetalLibrary` loses `test_metal_include`, `test_metal_randn`,
> `test_metal_error_buffer`, `test_metal_compiler_bug_workaround`, the four
> `test_atomic_add_*` cases and the six `test_reduction_utils_*` cases, 14 tests
> in total, all reported as errors rather than skips.
>
> The fix is to also search the source checkout when the headers are visibly
> there, which is the same convention `embed_headers` in
> `torch/utils/_cpp_embed_headers.py` already uses for its own default. The
> repository root and `aten/src` are appended only when `c10/metal` exists next
> to the `torch` package, so a packaged install is unaffected: in site-packages
> that directory does not exist and the search list is unchanged.
> `_embed_headers` already skips include directories that do not resolve, so
> ordering the packaged path first keeps it authoritative where it exists.
>
> Test Plan:
>
> On a `pip install -e .` build, before the change every c10/metal header fails
> to resolve and after it they all do:
>
> ```
> python -c "
> import torch
> for h in ('c10/metal/atomic.h', 'c10/metal/utils.h',
>           'c10/metal/special_math.h', 'c10/metal/random.h',
>           'ATen/native/mps/kernels/Pooling.h'):
>     torch.mps.compile_shader('#include <%s>' % h)
>     print(h, 'OK')
> "
> ```
>
> The 14 tests listed above go from error to passing:
>
> ```
> python test/test_mps.py TestMetalLibrary -v
> python test/test_mps.py -k atomic_add -v
> ```
>
> `TestMetalLibrary` is 19 passed / 3 skipped, and the four `atomic_add` cases
> pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
