### PR TITLE
[profiler][cupti] Do not free activity buffers libcupti still holds in reset()

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -4556,14 +4556,27 @@ class TestCuptiMonitorNative(TestCase):
         pyprof._cupti_monitor.return_buffer(ptr_a)
 
         # The next request reuses the freed buffer: same pointer, no new alloc.
+        checked_out = []
         ptr_b, _ = do_request()
-        self.assertEqual(ptr_b, ptr_a)
-        self.assertEqual(pyprof._cupti_monitor.allocated_buffers(), 1)
+        checked_out.append(ptr_b)
+        try:
+            self.assertEqual(ptr_b, ptr_a)
+            self.assertEqual(pyprof._cupti_monitor.allocated_buffers(), 1)
 
-        # A second concurrently-outstanding buffer forces a fresh allocation.
-        ptr_c, _ = do_request()
-        self.assertNotEqual(ptr_c, ptr_b)
-        self.assertEqual(pyprof._cupti_monitor.allocated_buffers(), 2)
+            # A second concurrently-outstanding buffer forces a fresh allocation.
+            ptr_c, _ = do_request()
+            checked_out.append(ptr_c)
+            self.assertNotEqual(ptr_c, ptr_b)
+            self.assertEqual(pyprof._cupti_monitor.allocated_buffers(), 2)
+
+            pyprof._cupti_monitor.reset_buffers()
+            self.assertEqual(pyprof._cupti_monitor.allocated_buffers(), 2)
+        finally:
+            if pyprof._cupti_monitor.allocated_buffers() == len(checked_out):
+                for ptr in checked_out:
+                    do_complete(ptr)
+            pyprof._cupti_monitor.reset_buffers()
+        self.assertEqual(pyprof._cupti_monitor.allocated_buffers(), 0)
 
     def test_cupti_monitor_not_imported_without_active_session(self):
         # The optional CUPTI monitor import chain (observers.profiler -> monitor ->

--- a/torch/csrc/profiler/cupti/monitor_native.cpp
+++ b/torch/csrc/profiler/cupti/monitor_native.cpp
@@ -103,6 +103,7 @@ void CuptiMonitorBuffers::on_request(
     if (!free_.empty()) {
       buf = free_.back();
       free_.pop_back();
+      checked_out_.insert(buf);
     }
   }
   if (buf == nullptr) {
@@ -114,6 +115,9 @@ void CuptiMonitorBuffers::on_request(
     std::lock_guard<std::mutex> guard(mutex_);
     all_.push_back(buf);
     ++allocated_;
+    if (buf != nullptr) {
+      checked_out_.insert(buf);
+    }
   }
   *buffer = buf;
   *size = bytes;
@@ -133,6 +137,7 @@ void CuptiMonitorBuffers::on_complete(
       cuptiMonitorParseRecordLayouts(complete_info);
   {
     std::lock_guard<std::mutex> guard(mutex_);
+    checked_out_.erase(buffer);
     completed_.push_back({buffer, valid_size, 0, 0, std::move(layouts)});
   }
   cv_.notify_one();
@@ -189,12 +194,21 @@ void CuptiMonitorBuffers::reset() {
   std::lock_guard<std::mutex> guard(mutex_);
   completed_.clear();
   free_.clear();
+  // Buffers libcupti still holds (requested, never completed) are kept
+  // allocated: CUPTI writes into a held buffer even after unsubscribe, and
+  // freeing it here corrupts the heap. They stay in all_ so a later reset
+  // can free them once completed.
+  std::vector<uint8_t*> still_held;
   for (uint8_t* p : all_) {
+    if (checked_out_.count(p) != 0) {
+      still_held.push_back(p);
+      continue;
+    }
     // NOLINTNEXTLINE(cppcoreguidelines-no-malloc)
     std::free(p);
   }
-  all_.clear();
-  allocated_ = 0;
+  all_ = std::move(still_held);
+  allocated_ = all_.size();
   shutdown_ = false;
 }
 

--- a/torch/csrc/profiler/cupti/monitor_native.h
+++ b/torch/csrc/profiler/cupti/monitor_native.h
@@ -32,6 +32,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -111,6 +112,10 @@ class TORCH_API CuptiMonitorBuffers {
   // LIFO free list: reuse the warmest (most recently returned) buffer first.
   std::vector<uint8_t*> free_;
   std::vector<uint8_t*> all_; // every buffer ever allocated (for reset)
+  // Buffers currently held by libcupti (requested, not yet completed). CUPTI
+  // can write into a held buffer even after disarm+unsubscribe, so reset()
+  // must leak these rather than free them (a freed one corrupts the heap).
+  std::unordered_set<uint8_t*> checked_out_;
   std::deque<CompletedCuptiBuffer> completed_;
   size_t buffer_size_ = 4UL * 1024 * 1024;
   size_t allocated_ = 0;


### PR DESCRIPTION
Summary:
NVIDIA's CUPTI profiler writes activity records into buffers supplied by PyTorch. CUPTI owns each buffer from the request callback until it invokes the matching completion callback. PyTorch's `CuptiMonitorBuffers::reset()` previously freed every allocated buffer during shutdown, including buffers CUPTI had not returned. Core dumps and stress A/B results indicate that CUPTI later accessed one of these freed buffers, which led to intermittent glibc heap-corruption aborts. (The defect is in PyTorch's buffer lifetime handling, not in CUPTI.)

Track buffers from request until completion. `reset()` now frees only buffers CUPTI has returned and retains buffers it may still access. A retained buffer can be freed by a later reset if CUPTI eventually returns it; otherwise it remains allocated for the process lifetime. Each retained buffer is 4 MiB, and more than one may be retained per stop.

Test Plan:
`python test/profiler/test_cupti_monitor.py TestCuptiMonitorNative.test_cupti_monitor_buffer_pool_reuse`


Differential Revision: D117894704


