### PR TITLE
Fix CUDA illegal memory access in embedding_renorm_ for zero-width embeddings

### DIFF
--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -362,7 +362,7 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
   checkSameGPU("embedding_renorm", self_arg, indices_arg);
 
   auto num_indices = indices.numel();
-  if (num_indices == 0 || self.size(1) == 0) {
+  if (num_indices == 0) {
     return self;
   }
 

--- a/aten/src/ATen/native/cuda/Embedding.cu
+++ b/aten/src/ATen/native/cuda/Embedding.cu
@@ -362,7 +362,7 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
   checkSameGPU("embedding_renorm", self_arg, indices_arg);
 
   auto num_indices = indices.numel();
-  if (num_indices == 0) {
+  if (num_indices == 0 || self.size(1) == 0) {
     return self;
   }
 
@@ -400,7 +400,7 @@ Tensor & embedding_renorm_cuda_(Tensor & self, const Tensor & indices,
     const int64_t *num_unique_indices_ptr = num_unique_indices.const_data_ptr<int64_t>();
     dim3 grid = unique_indices.numel();
     dim3 block = num_threads();
-    int dim = self.stride(0);
+    int dim = self.size(1);
 
     AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, self.scalar_type(), "embedding_renorm_cuda_", [&] {
       using accscalar_t = acc_type<scalar_t, true>;

--- a/test/nn/test_embedding.py
+++ b/test/nn/test_embedding.py
@@ -1146,6 +1146,21 @@ class TestEmbeddingNNDeviceType(NNTestCase):
         self.assertEqual(output[1], output[2])
         self.assertTrue(output.data.norm(p=2, dim=1).le(1).all())
 
+    @onlyOn(["cuda"])
+    def test_embedding_max_norm_zero_embedding_dim(self, device):
+        # Regression test for https://github.com/pytorch/pytorch/issues/195185
+        # embedding_renorm_ used to infer the row length from self.stride(0),
+        # which does not equal self.size(1) when the embedding dim is 0, causing
+        # renorm_kernel to read out of bounds through the tensor's null data
+        # pointer.
+        weight = torch.empty((20, 0), dtype=torch.float32, device=device)
+        indices = torch.tensor([0], dtype=torch.int64, device=device)
+        out = torch.nn.functional.embedding(
+            indices, weight, max_norm=1.0, norm_type=2.0
+        )
+        torch.accelerator.synchronize()
+        self.assertEqual(out.shape, (1, 0))
+
     @dtypes(*itertools.product((torch.int, torch.long), (torch.int, torch.long)))
     def test_embedding_bag_empty_input(self, device, dtypes):
         m = 4


### PR DESCRIPTION
Fixes #195185

## Summary

`F.embedding(indices, weight, max_norm=...)` triggers an illegal `__global__`
memory read on CUDA (reported by compute-sanitizer) when `weight` has a
zero-width embedding dimension, e.g. `weight.shape == (20, 0)`.

## Root cause

`embedding_renorm_cuda_` in `aten/src/ATen/native/cuda/Embedding.cu` computed
the per-row element count as:

```cpp
int dim = self.stride(0);
```

This assumes `self.stride(0)` always equals the logical row width
(`self.size(1)`), which happens to hold for an ordinary contiguous 2-D
tensor but not for one with a zero-size trailing dimension:

```python
>>> torch.empty(20, 0).stride()
(1, 1)
```

So for `weight.shape == (20, 0)`, `self.size(1)` (the real embedding width) is
`0`, but `self.stride(0)` is `1`. That wrong `dim` value makes
`renorm_kernel`'s per-thread loop run one iteration and dereference the
weight tensor's data pointer, which is null since the tensor has zero
elements and no storage — exactly the reported
`Invalid __global__ read of size 4 bytes ... Address 0x0 is out of bounds`.

The CPU path (`embedding_renorm_cpu_`) is unaffected — it computes the row
norm via real tensor ops (`row.norm(norm_type)`), which handles a 0-width row
correctly.

## Fix

Use `self.size(1)` instead of `self.stride(0)` as the loop bound. `size(1)`
is the correct logical row width in general — the kernel already receives
the physical row/element strides separately (`weights_stride0`,
`weights_stride1`) for indexing, so this doesn't depend on the tensor being
contiguous. It's a no-op for the existing (non-degenerate) case, where
`stride(0)` already equals `size(1)`, and correctly evaluates to `0` for a
zero-width embedding, so the kernel's loop never touches the null weight
pointer.

This is the minimal fix: no early-return guard is needed, since a zero
`dim` alone already makes the kernel's per-element loops execute zero times.
Skipping the kernel launch entirely would also skip the index-bounds
validation done in `embedding_renorm_wrap_indices_kernel`, so it's avoided
here to keep that check intact for zero-width weights too.

## Test plan

- Added `test_embedding_max_norm_zero_embedding_dim` in
  `test/nn/test_embedding.py` (CUDA-only), reproducing the issue's exact
  repro and asserting it no longer crashes.
- `lintrunner --paths-cmd 'git diff --name-only upstream/main'` → no lint
  issues.
- **Verified on CUDA hardware** (NVIDIA A10, driver 580.126.20, CUDA 13.0,
  Compute Sanitizer 2025.3.1.0), building this branch from source
  (`USE_CUDA=1`):
  - Reverting the fix (`self.stride(0)`) and running the repro under
    `compute-sanitizer --tool memcheck` reproduces the exact reported bug:
    ```
    Invalid __global__ read of size 4 bytes
        at renorm_kernel<float, float, const long>+0x440
        Access to 0x0 is out of bounds
        Host Frame: embedding_renorm_cuda_(...) in Embedding.cu:371
    Program hit cudaErrorIllegalAddress ... ERROR SUMMARY: 3 errors
    ```
  - With the fix applied, the same repro and the new
    `test_embedding_max_norm_zero_embedding_dim_cuda` test both run clean
    under `compute-sanitizer` (`ERROR SUMMARY: 0 errors`).
  - Full `TestEmbeddingNNDeviceTypeCUDA` class in `test/nn/test_embedding.py`
    (excluding `@slowTest`): 131 passed, 25 skipped (CPU-only variants), 0
    failed — no regressions from the fix.

AI assistance disclosure: this fix (root-cause analysis, patch, and test)
was drafted with Claude Code assistance; I reviewed the change and the
reasoning above line-by-line before opening this PR. The CUDA verification
above (build, compute-sanitizer runs, and test execution) was also run via
Claude Code, on a machine with CUDA hardware; I reviewed the commands and
raw output before including them here.
