### PR TITLE
Document that backward gradients have undefined strides

### DIFF
--- a/torch/_library/custom_ops.py
+++ b/torch/_library/custom_ops.py
@@ -659,6 +659,17 @@ class CustomOpDef:
         :class:`torch.autograd.Function`. The semantics of ``backward_fn`` are the
         same as :meth:`torch.autograd.Function.backward`.
 
+        .. warning::
+            The strides of the gradients passed to ``backward_fn`` are undefined:
+            they may not match the strides of the corresponding forward outputs
+            (for example, the backward of :func:`torch.cat` produces gradients
+            that are non-contiguous views into a larger tensor). If
+            ``backward_fn`` calls a kernel that assumes a particular memory
+            layout (such as a raw Triton or CUDA kernel), it must call
+            :meth:`~torch.Tensor.contiguous` on the gradients or handle their
+            strides explicitly. Backward formulas composed of PyTorch operations
+            handle arbitrary strides automatically.
+
         ``setup_context(ctx, inputs, output)`` runs during the forward pass.
         Please save quantities needed for backward onto the ``ctx`` object via
         either :meth:`torch.autograd.function.FunctionCtx.save_for_backward`

--- a/torch/autograd/function.py
+++ b/torch/autograd/function.py
@@ -486,6 +486,11 @@ class _SingleLevelFunction(
         corresponding input. If an input is not a Tensor or is a Tensor not
         requiring grads, you can just pass None as a gradient for that input.
 
+        The strides of the gradients passed to :func:`backward` are undefined:
+        they are not guaranteed to be contiguous or to match the strides of the
+        corresponding forward outputs, so implementations must not assume a
+        particular memory layout.
+
         The context can be used to retrieve tensors saved during the forward
         pass. It also has an attribute :attr:`ctx.needs_input_grad` as a tuple
         of booleans representing whether each input needs gradient. E.g.,

--- a/torch/library.py
+++ b/torch/library.py
@@ -1343,6 +1343,17 @@ def register_autograd(
     :class:`torch.autograd.Function`. The semantics of ``backward_fn`` are the
     same as :meth:`torch.autograd.Function.backward`.
 
+    .. warning::
+        The strides of the gradients passed to ``backward_fn`` are undefined:
+        they may not match the strides of the corresponding forward outputs
+        (for example, the backward of :func:`torch.cat` produces gradients
+        that are non-contiguous views into a larger tensor). If
+        ``backward_fn`` calls a kernel that assumes a particular memory
+        layout (such as a raw Triton or CUDA kernel), it must call
+        :meth:`~torch.Tensor.contiguous` on the gradients or handle their
+        strides explicitly. Backward formulas composed of PyTorch operations
+        handle arbitrary strides automatically.
+
     ``setup_context(ctx, inputs, output)`` runs during the forward pass.
     Please save quantities needed for backward onto the ``ctx`` object via
     either :meth:`torch.autograd.function.FunctionCtx.save_for_backward`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195210

In #194719 a triton_op backward kernel silently computed wrong
gradients: torch.cat's backward passes each input a non-contiguous
narrow view of the upstream gradient, and the kernel indexed the grads
assuming they shared the forward output's contiguous layout. Nothing in
the docs states that the autograd engine may do this, and neither
gradcheck nor opcheck can surface it (both only exercise contiguous
grad_outputs), so the layout assumption looks safe until an op like cat
appears downstream.

This documents the actual contract in the two register_autograd
docstrings (torch.library.register_autograd and
CustomOpDef.register_autograd, which triton_op and custom_op results
use) as a warning admonition with the cat example and the
`.contiguous()` remedy, and adds the same statement to
torch.autograd.Function.backward, which both docstrings defer to for
backward semantics and which previously never stated it either.

An alternative is to have the custom op glue coerce grads to the
output's memory format (#195064); that is a semantics change pending
maintainer discussion, while this documents behavior that holds either
way.

Test Plan:

Docs-only change. Verified the docstrings render into the functions and
ran lint:

```
python -c "import torch; assert 'strides of the gradients' in torch.autograd.Function.backward.__doc__; assert 'strides of the gradients' in torch.library.register_autograd.__doc__"
spin lint
lintrunner -a
```

Authored with Claude Code.