### PR TITLE
[elastic] Fix lost-wakeup races that truncate tailed log output

### DIFF
--- a/test/distributed/elastic/multiprocessing/tail_log_test.py
+++ b/test/distributed/elastic/multiprocessing/tail_log_test.py
@@ -6,6 +6,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+import builtins
 import io
 import os
 import shutil
@@ -16,9 +17,10 @@ import unittest
 from concurrent.futures import wait
 from concurrent.futures._base import ALL_COMPLETED
 from concurrent.futures.thread import ThreadPoolExecutor
+from threading import Event
 from unittest import mock
 
-from torch.distributed.elastic.multiprocessing.tail_log import TailLog
+from torch.distributed.elastic.multiprocessing.tail_log import tail_logfile, TailLog
 
 
 def write(max: int, sleep: float, file: str):
@@ -84,6 +86,98 @@ class TailLogTest(unittest.TestCase):
             {f"[writer{i}]": set(range(max)) for i in range(nprocs)}, actual
         )
         self.assertTrue(tail.stopped())
+
+    def test_tail_logfile_created_while_producer_finishes(self):
+        """
+        The producer may create the log file in the window between the tailer's
+        existence check and its check of the finished event. The file still has
+        to be tailed rather than dropped.
+        """
+        file = os.path.join(self.test_dir, "0_stdout.log")
+        finished = Event()
+        dst = io.StringIO()
+
+        real_exists = os.path.exists
+        raced = False
+
+        def exists_then_finish(path):
+            nonlocal raced
+            result = real_exists(path)
+            if path == file and not raced:
+                raced = True
+                # the producer writes the file and exits inside the window
+                with open(file, "w") as producer:
+                    producer.write("0\n")
+                finished.set()
+            return result
+
+        with mock.patch(
+            "torch.distributed.elastic.multiprocessing.tail_log.os.path.exists",
+            side_effect=exists_then_finish,
+        ):
+            tail_logfile(
+                header="[writer0]:",
+                file=file,
+                dst=dst,
+                finished=finished,
+                interval_sec=0.001,
+                log_line_filter=lambda _: True,
+            )
+
+        self.assertEqual("[writer0]:0\n", dst.getvalue())
+
+    def test_tail_logfile_producer_finishes_at_eof(self):
+        """
+        The producer may append its last lines and set the finished event in the
+        window between the tailer reading EOF and the tailer checking the event.
+        Those lines still have to be tailed. See issue 143823.
+        """
+        file = os.path.join(self.test_dir, "0_stdout.log")
+        with open(file, "w") as producer:
+            producer.write("0\n")
+
+        finished = Event()
+        dst = io.StringIO()
+        real_open = builtins.open
+
+        class LateWriteFile:
+            def __init__(self, fp):
+                self._fp = fp
+                self._raced = False
+
+            def readline(self):
+                line = self._fp.readline()
+                if not line and not self._raced:
+                    self._raced = True
+                    # the producer appends its last line and exits inside the
+                    # window between this read and the finished check
+                    with real_open(file, "a") as producer:
+                        producer.write("1\n")
+                    finished.set()
+                return line
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                self._fp.close()
+                return False
+
+        def open_late_write_file(path, *args, **kwargs):
+            opened = real_open(path, *args, **kwargs)
+            return LateWriteFile(opened) if path == file else opened
+
+        with mock.patch("builtins.open", side_effect=open_late_write_file):
+            tail_logfile(
+                header="[writer0]:",
+                file=file,
+                dst=dst,
+                finished=finished,
+                interval_sec=0.001,
+                log_line_filter=lambda _: True,
+            )
+
+        self.assertEqual("[writer0]:0\n[writer0]:1\n", dst.getvalue())
 
     def test_tail_write_to_dst_file(self):
         """

--- a/torch/distributed/elastic/multiprocessing/tail_log.py
+++ b/torch/distributed/elastic/multiprocessing/tail_log.py
@@ -32,21 +32,32 @@ def tail_logfile(
     interval_sec: float,
     log_line_filter: Callable[[str], bool] | None = None,
 ):
-    while not os.path.exists(file):
-        if finished.is_set():
+    # Sample ``finished`` before each look at the file. A producer that creates
+    # the file and exits in the window between the two checks is missed if the
+    # event is sampled afterwards, and the file is then never tailed at all.
+    while True:
+        producer_finished = finished.is_set()
+        if os.path.exists(file):
+            break
+        if producer_finished:
             return
         time.sleep(interval_sec)
 
     with open(file, errors="replace") as fp:
         while True:
+            # Same ordering as above: the producer may append its last lines and
+            # set the event after this read hits EOF but before the event is
+            # checked, which silently truncates the tailed output.
+            producer_finished = finished.is_set()
             line = fp.readline()
 
             if line:
                 if log_line_filter and log_line_filter(line):
                     dst.write(f"{header}{line}")
             else:  # reached EOF
-                if finished.is_set():
-                    # log line producer is finished
+                if producer_finished:
+                    # log line producer was already finished before this read,
+                    # so EOF here means there is nothing left to come
                     break
                 else:
                     # log line producer is still going


### PR DESCRIPTION
Fixes #143823.

`tail_logfile()` samples the `finished` event **after** it inspects the file, in both of its loops. A producer that acts inside the window between the two checks is missed:

* **existence loop** — `os.path.exists()` runs first. If the producer creates the file and exits in the window, `is_set()` is then true and the tailer returns, so that file is never tailed at all.
* **read loop** — `readline()` runs first. If the producer appends its last lines and exits in the window, `is_set()` is then true and the tailer breaks, so those lines are dropped.

The second one is the flakiness reported in #143823. @cdzhan's analysis on that issue describes exactly this ordering: `writer31` reached EOF before the producer's final line landed, saw the event set, and stopped, so line 999 never made it into `dst`.

The fix is to sample the event **before** each check. If the producer had already finished when the event was read, then everything it will ever write is on disk by the time the check runs, so EOF (or a missing file) is final. Otherwise the tailer loops again and picks the data up. No new synchronisation, no change to the polling interval.

Both windows are covered by deterministic regression tests that drive the race with a mock instead of relying on timing, so they do not reintroduce flakiness.

## Test Plan

```
python test/distributed/elastic/multiprocessing/tail_log_test.py
```

or

```
pytest test/distributed/elastic/multiprocessing/tail_log_test.py -v
```

Verified by toggling the fix against a `2.15.0.dev20260827` nightly wheel with only `tail_log.py` overlaid:

* without the fix, the two new tests fail —
  `test_tail_logfile_created_while_producer_finishes` produces `''` (the file is dropped entirely) and
  `test_tail_logfile_producer_finishes_at_eof` produces `'[writer0]:0\n'` instead of `'[writer0]:0\n[writer0]:1\n'` (the last line is dropped).
* with the fix, all 9 tests in the file pass, including the 7 pre-existing ones.

Lint: `ruff==0.14.4` (the version pinned in `tools/linter/adapters/pyfmt_linter.py`) reports `2 files already formatted` and `All checks passed!` on both changed files.

---

*AI disclosure (per `AI_POLICY.md`): this change was written with AI assistance. The root cause, the fix and the tests were reviewed and verified by me against the toggle run described above; the contribution is not autonomous.*
