### PR TITLE
[pr_time_benchmarks] Refresh add_loop_eager_dynamic and add_loop_indu…

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -2,7 +2,7 @@ add_loop_eager,compile_time_instruction_count,3862000000,0.1
 
 
 
-add_loop_eager_dynamic,compile_time_instruction_count,5468000000,0.1
+add_loop_eager_dynamic,compile_time_instruction_count,4927000000,0.1
 
 
 
@@ -10,7 +10,7 @@ add_loop_inductor,compile_time_instruction_count,28860000000,0.1
 
 
 
-add_loop_inductor_dynamic_gpu,compile_time_instruction_count,37180000000,0.1
+add_loop_inductor_dynamic_gpu,compile_time_instruction_count,33650000000,0.1
 
 
 


### PR DESCRIPTION
…ctor_dynamic_gpu baselines

add_loop_eager_dynamic has been one of the dominant sources of trunk flakiness since 2026-08-26. It is not a code defect: compile-time instruction count drifted just past the -10% noise margin as optimizations landed, and check_results.py treats a WIN as a hard failure in order to force a baseline refresh. Measurements now straddle the threshold, so the same commit can both pass and fail.

add_loop_inductor_dynamic_gpu was at 95% of its band and is refreshed pre-emptively.

New values are medians over the last 308 trunk/main runs, chosen by an AI agent, rounded per replace_with_zeros.

Authored with assistance from Claude (Anthropic).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98