### PR TITLE
[nativert] Show real list arguments in op exception dumps (#195213)

### DIFF
--- a/test/cpp/nativert/test_c10_kernel.cpp
+++ b/test/cpp/nativert/test_c10_kernel.cpp
@@ -43,6 +43,58 @@ return (%x)
       torch::equal(frame.getTensor(graph->getValue("x")->id()), expected));
 }
 
+at::Tensor throwing_tensor_list_kernel(
+    const at::TensorList& tensors,
+    const at::Tensor& other) {
+  TORCH_CHECK(tensors.empty(), "intentional failure");
+  return other;
+}
+
+TEST(C10KernelTest, errorMessageRebuildsConsumedListArgs) {
+  // Unboxing moves a Tensor[] argument out of the stack, so the error path must
+  // re-derive the arguments from the frame instead of formatting the stack it
+  // just handed to callBoxed -- otherwise every list argument reads as "None".
+  auto registrar = c10::RegisterOperators().op(
+      "test::throwing_list(Tensor[] tensors, Tensor other) -> Tensor",
+      &throwing_tensor_list_kernel);
+
+  static constexpr std::string_view source =
+      R"(graph(%a, %b, %other):
+%tensors[] = prim.ListPack(l0=%a, l1=%b)
+%x = test.throwing_list.default(tensors=%tensors, other=%other)
+return (%x)
+)";
+
+  auto graph = stringToGraph(source);
+  const auto& nodes = graph->nodes();
+  auto it = nodes.begin();
+  std::advance(it, 2);
+  const Node& node = *it;
+
+  // Seed the packed list directly; only the throwing node is executed here.
+  auto frame = ExecutionFrame(*graph);
+  frame.setIValue(
+      graph->getValue("tensors")->id(),
+      c10::List<at::Tensor>({at::tensor({1, 2}), at::tensor({3, 4})}));
+  frame.setIValue(graph->getValue("other")->id(), at::tensor({5, 6}));
+
+  auto kernel = C10Kernel(&node);
+
+  try {
+    kernel.computeInternal(frame);
+    FAIL() << "expected test::throwing_list to throw";
+  } catch (const c10::Error& e) {
+    const std::string message = e.what();
+    EXPECT_EQ(message.find("arg0 tensors: None"), std::string::npos) << message;
+    EXPECT_NE(message.find("[int[2]cpu, int[2]cpu, ]"), std::string::npos)
+        << message;
+    // A Tensor bound to `const Tensor&` is borrowed, not moved, so it survives
+    // unboxing and was already printed correctly before this change.
+    EXPECT_NE(message.find("arg1 other: Tensor int[2]cpu"), std::string::npos)
+        << message;
+  }
+}
+
 TEST(ScalarBinaryOpKernelTest, computeInternal) {
   static constexpr std::string_view source =
       R"(graph(%a, %b):

--- a/torch/nativert/kernels/C10Kernel.cpp
+++ b/torch/nativert/kernels/C10Kernel.cpp
@@ -12,6 +12,37 @@
 
 namespace torch::nativert {
 
+namespace {
+
+// Rebuild the argument stack for an error message.
+//
+// callBoxed() unboxes a list-typed argument by moving it out of the stack --
+// ivalue_to_arg<ArrayRef<T>> in
+// ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h routes through
+// std::move(v).to<std::vector<T>>() -- which leaves that slot holding None.
+// Formatting the post-call stack therefore reports every Tensor[] / int[] /
+// float[] argument as "None" no matter what was passed, hiding exactly the
+// argument an op that takes a Tensor[] tends to fail on. Tensors bound to
+// `const Tensor&` and POD scalars are read in place and do survive.
+//
+// The frame still holds the inputs, so re-derive them here instead of copying
+// the stack on the hot path. Rebuilding must never mask the real exception, so
+// fall back to the consumed stack if it fails.
+std::vector<c10::IValue> rebuildArgsForError(
+    const ExecutionFrame& executionFrame,
+    const Arguments& arguments,
+    const std::vector<c10::IValue>& consumedStack) {
+  try {
+    std::vector<c10::IValue> stack = arguments.getStackWithStaticArgs();
+    fillDynamicInputs(executionFrame, arguments, stack);
+    return stack;
+  } catch (const std::exception&) {
+    return consumedStack;
+  }
+}
+
+} // namespace
+
 C10Kernel::C10Kernel(
     const Node* node,
     OpKernelKind kind,
@@ -38,7 +69,9 @@ void C10Kernel::computeInternal(ExecutionFrame& executionFrame) const {
         *node_,
         "\n"
         "with args:\n",
-        readableArgs(op_.schema(), stack),
+        readableArgs(
+            op_.schema(),
+            rebuildArgsForError(executionFrame, arguments_, stack)),
         "\n",
         ex.what(),
         "\n",


### PR DESCRIPTION
Summary:

When a `C10Kernel` node throws, the error message dumps the argument stack:

```
} catch (const std::exception& ex) {
  TORCH_CHECK(false, "Exception while executing node: ", *node_,
              "\nwith args:\n", readableArgs(op_.schema(), stack), ...)
}
```

but `stack` has already been consumed by `callBoxed`. Unboxing moves list-typed
arguments out of the stack -- `ivalue_to_arg<ArrayRef<T>>`
(`ATen/core/boxing/impl/make_boxed_from_unboxed_functor.h:439`) routes through
`std::move(v).to<std::vector<T>>()` -- and a moved-from `IValue` is left holding
None. Tensors bound to `const Tensor&` get an explicitly non-moving
specialization (`:421`, "We should not use the default implementation ...
because it moves from the IValue"), and POD scalars are copied, so those survive.

Net effect: every `Tensor[]` / `int[]` / `float[]` argument prints as `None`
regardless of what was passed, and it prints that way for *all* of them, so the
dump looks like the op was handed nulls. A real example, from an fbgemm device
mismatch that takes a `Tensor[]`:

```
with args:
arg0 pooled_embs: None
arg1 permutes: Tensor int[395, 6]cuda:0
arg2 in_shapes: Tensor int[1]cuda:0
arg3 out_shapes: Tensor int[11]cuda:0
arg4 out_lengths: None
arg5 reverse: Bool False
permutes must be on the same device as pooled_embs[0]!
```

`pooled_embs` was a non-empty list of live CUDA tensors -- the op had already
passed `TORCH_CHECK(!pooled_embs.empty())` and a `CUDA_DEVICE_GUARD` on element 0
before it threw -- and `out_lengths` is printed with real contents in the node
line of the same message, from the graph attribute. The two args you need in
order to diagnose a device mismatch are exactly the two the dump hides.

Fix: rebuild the stack in the catch block from `ExecutionFrame` +
`arguments_`, which still hold the inputs. This costs nothing on the hot path,
unlike snapshotting the stack before every call. `fillDynamicInputs` takes a
`const ExecutionFrame&` and copies out of it, so re-deriving is non-destructive,
and a fresh `getStackWithStaticArgs()` copy satisfies its
`TORCH_CHECK(stack.at(idx).isNone())` precondition. The rebuild is wrapped in
try/catch and falls back to the consumed stack, so a diagnostic can never
replace the real exception.

After change, error message successfully shows:

with args:
arg0 pooled_embs: GenericList [c10::Half[377, 161628]cuda:1, ]
arg1 permutes: Tensor int[395, 6]cuda:0
arg2 in_shapes: Tensor int[1]cuda:0
arg3 out_shapes: Tensor int[11]cuda:0
arg4 out_lengths: GenericList [160256, 864, 8, 24, 72, 12, 12, 228, 120, 24, 8]
arg5 reverse: Bool False

Test Plan:
```
buck2 test fbcode//caffe2/test/cpp/nativert:c10_kernel_test
```
`Pass 3. Fail 0.`

New `C10KernelTest.errorMessageRebuildsConsumedListArgs` registers an op taking
`(Tensor[] tensors, Tensor other)` that throws, and asserts the message contains
the list contents (`[int[2]cpu, int[2]cpu, ]`) and not `arg0 tensors: None`.

Verified the test fails without the code change -- reverting just the call site
and re-running gives:
```
✗ Fail: C10KernelTest.errorMessageRebuildsConsumedListArgs
  message.find("arg0 tensors: None")
arg0 tensors: None
Pass 2. Fail 1.
```

`arc lint` clean; `arc f` had no linters to run for these files.

After change, the error shows:

```
with args:
arg0 pooled_embs: GenericList [c10::Half[377, 161628]cuda:1, ]
arg1 permutes: Tensor int[395, 6]cuda:0
arg2 in_shapes: Tensor int[1]cuda:0
arg3 out_shapes: Tensor int[11]cuda:0
arg4 out_lengths: GenericList [160256, 864, 8, 24, 72, 12, 12, 228, 120, 24, 8]
arg5 reverse: Bool False

Reviewed By: desertfire

Differential Revision: D117915151


