### PR TITLE
[precompile] Record a backend for a graph the compiler short-circuited

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -255,6 +255,19 @@ def _precompile_accum_flaky_step(model, x, mode):
     return _precompile_accum_step(model, x, mode)
 
 
+class _PrecompileDeadResultModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.l = torch.nn.Linear(4, 4)
+
+
+def _precompile_dead_result(model, x):
+    # The result is unused, so the graph's output prunes to nothing -- the
+    # shape upstream short-circuits past the backend.
+    model.l(x)
+    return None
+
+
 class _PrecompileAttrCfg:
     """Discriminated by HASATTR, a slot the invariant policy CAN drop."""
 
@@ -2157,6 +2170,53 @@ class TestPrecompile(TestCase):
                 # The next good call must render and return, not inherit it.
                 self.assertIsNotNone(capture(model, x, "b"))
         self.assertEqual(_PRECOMPILE_ACCUM_RAN, ["a", "b"])
+
+    def test_precompile_records_a_backend_for_a_short_circuited_noop_graph(self):
+        # A graph that runs nothing and returns nothing never reaches the
+        # backend: output_graph substitutes noop_graph_call rather than pay a
+        # metadata pass and a joint trace for it. Ordinary torch.compile then
+        # discards the frame, but capture sets allow_empty_graphs, so it stays
+        # compiled, its id lands in backend_ids (derived by scanning co_names),
+        # and nothing was ever filed for it -- which the harvest reported as a
+        # compiled graph that lost its code, failing the whole capture.
+        #
+        # Only the inductor path: the eager one turns every cached backend into
+        # an artifact already, so it never saw this.
+        #
+        # is_noop_graph is forced rather than provoked. Whether a real frame
+        # prunes to an empty output depends on upstream pruning details that a
+        # toy model does not reproduce; what this pins is the packaging
+        # interaction, on a graph whose output IS already empty and whose one
+        # call is dead, so short-circuiting it changes nothing observable.
+        import torch._dynamo.output_graph as output_graph
+        import torch.utils._pytree as pytree
+
+        fired = []
+
+        def force_noop(gm):
+            outs = list(gm.graph.find_nodes(op="output"))
+            empty = bool(outs) and all(pytree.tree_leaves(n.args) == [] for n in outs)
+            fired.append(empty)
+            return empty
+
+        model = _PrecompileDeadResultModel()
+        x = torch.randn(2, 4)
+        with mock.patch.object(output_graph, "is_noop_graph", force_noop):
+            with torch.no_grad():
+                code, cache = torch.compiler.precompile(
+                    _precompile_dead_result,
+                    tracer="dynamo",
+                    backend="inductor",
+                    dynamic=False,
+                    example_inputs=[(model, x)],
+                    require_complete=False,
+                    require_no_risky_drops=False,
+                )
+        self.assertTrue(any(fired), "the no-op short-circuit never fired")
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            self.assertIsNone(loaded(model, x))
 
     def test_precompile_accumulate_rejects_make_fx_and_lone_paths(self):
         with self.assertRaisesRegex(ValueError, "only tracer='dynamo'"):

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -1537,12 +1537,38 @@ class PrecompileSession:
         self._finished = False
 
     def _take_backend_artifacts(self) -> None:
-        from torch._dynamo.precompile_context import PrecompileContext
+        from torch._dynamo.output_graph import noop_graph_call
+        from torch._dynamo.precompile_context import (
+            EagerCacheArtifact,
+            PrecompileContext,
+        )
 
         for backend_id in self._package.cache_entry().backend_ids:
             artifact = PrecompileContext.take_artifact(backend_id)
             if artifact is not None:
                 self._backend_artifacts[backend_id] = artifact
+            elif self._package.cached_backends.get(backend_id) is noop_graph_call:
+                # A graph that runs nothing and returns nothing never reaches
+                # the backend: output_graph short-circuits it to noop_graph_call
+                # rather than pay a metadata pass and a joint trace for a
+                # function with nothing in it. The id still exists -- the
+                # transformed bytecode names it, and backend_ids is derived by
+                # scanning co_names -- so nothing was ever filed for it and the
+                # harvest reads it as a compiled graph that lost its code.
+                #
+                # Only reachable under capture: allow_empty_graphs is what keeps
+                # such a frame compiled at all, and ordinary torch.compile
+                # discards it rather than packaging anything. Recorded rather
+                # than excused, so the served artifact dispatches the frame to
+                # the same no-op instead of skipping it at install and silently
+                # running eager.
+                #
+                # Here rather than in _collect_backends because teardown clears
+                # cached_backends for a non-eager backend, and _collect_backends
+                # runs after it.
+                self._backend_artifacts[backend_id] = EagerCacheArtifact(
+                    key=backend_id, content=noop_graph_call
+                )
 
     def _record_capture_error(self, error: BaseException) -> None:
         message = str(error)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195284
* __->__ #195215
* #195070
* #195014
* #194966
* #194952
* #194951
* #194950
* #194949
* #194948
* #194677
* #194622
* #194619
* #194549
* #194542
* #194541
* #194534
* #194488
* #194479
* #194455
* #194454
* #194452
* #194450
* #194449
* #194428
* #194427
* #194426
* #194409
* #194394
* #194393
* #194390
* #194389
* #194388
* #194387
* #194386
* #194385
* #194384
* #194383
* #194320
* #194319
* #194318
* #194317
* #194316
* #194302
* #194301
* #194300
* #194286
* #194285
* #194284
* #194283
* #194282
* #194250
* #194249
* #194248
* #194158
* #192379
* #193976
* #193697
* #192374
* #192866

A graph that runs nothing and returns nothing no longer reaches the backend:
output_graph substitutes noop_graph_call for it rather than pay a metadata
pass, a joint trace and a cache miss for a function with nothing in it. That is
a good optimization and it does not interact with torch.compile, which discards
such a frame anyway.

It interacts with capture, which does not discard it. _capture_config sets
allow_empty_graphs, so the frame stays compiled and its guards reach the
artifact -- that is the whole reason the flag exists. Dynamo's transformed
bytecode still names __compiled_fn_N, and backend_ids is derived by scanning
co_names, so the id lands in the cache entry with nothing filed behind it. The
harvest then reports it as a compiled graph that lost its code and fails the
capture:

    Precompilation recorded 83 of 84 compiled backend(s), so 1 graph(s) would
    reach the artifact with no code behind them: __compiled_fn_72_...

Unconditional, so no require_* gate relaxes it, and on a real model one such
frame is enough to take the whole capture down.

The id is recorded rather than excused. noop_graph_call is a module-level
function, so an EagerCacheArtifact holding it pickles by reference and
reconstructs to the same object, which keeps the entry self-consistent and
means the served artifact dispatches that frame to a no-op instead of skipping
it at install and silently running eager. Blunting the missing-backend check
instead would have traded a loud failure for a silent one, and that check has
caught real gaps.

Inductor only, in effect: the eager path already turns every cached backend
into an artifact, so it never saw this. It goes in _take_backend_artifacts
rather than _collect_backends because teardown clears cached_backends for a
non-eager backend and _collect_backends runs after it -- which is exactly the
path that was failing.

Test Plan:

```
python test/test_precompile.py
python test/dynamo/test_package.py
python test/dynamo/test_guard_serialization.py
python test/functorch/test_compile_to_python.py
```

test_precompile_records_a_backend_for_a_short_circuited_noop_graph captures a
region whose result is unused, so the graph's output prunes to nothing, and
asserts the artifact loads and serves. It fails without this change with the
verbatim error above.

The short-circuit is forced rather than provoked. Whether a real frame prunes to
an empty output depends on pruning details a toy model does not reproduce; the
test pins the packaging interaction, on a graph whose output IS already empty
and whose single call is dead, so short-circuiting it changes nothing
observable.

Authored with the assistance of an AI coding agent.