### PR TITLE
[dynamo] Migrate NumpyNdarrayVariable attributes to tp_getset

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -3290,6 +3290,53 @@ class NumpyNdarrayVariable(TensorVariable):
         )
         return NumpyNdarrayVariable.create(tx, proxy)
 
+    def _insert_attr_into_graph(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        from ..utils import numpy_attr_wrapper
+        from .builder import wrap_fx_proxy
+
+        return wrap_fx_proxy(
+            tx,
+            tx.output.create_proxy(
+                "call_function", numpy_attr_wrapper, (self.as_proxy(), name), {}
+            ),
+        )
+
+    def _get_shape_or_stride(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        example_ndarray = tnp.ndarray(self.as_proxy().node.meta["example_value"])
+        if not has_free_symbols(r := getattr(example_ndarray, name)):
+            return VariableTracker.build(tx, tuple(int(r) for r in r))
+        return self._insert_attr_into_graph(tx, name)
+
+    def _get_size(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        example_ndarray = tnp.ndarray(self.as_proxy().node.meta["example_value"])
+        if not has_free_symbols(r := example_ndarray.size):
+            return VariableTracker.build(tx, int(r))
+        return self._insert_attr_into_graph(tx, "size")
+
+    def _unsupported_attr(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        unimplemented(
+            gb_type="Unsupported ndarray attribute access",
+            context=f"tp_getattro_impl {self} {name}",
+            explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
+            hints=[],
+        )
+
+    def _unsupported_version_attr(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        unimplemented(
+            gb_type="Unsupported ndarray.__version__ access",
+            context=f"tp_getattro_impl {self} {name}",
+            explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
+            hints=[],
+        )
+
     tp_getset = {
         "ndim": GetSet(_get_ndim, None),
         "itemsize": GetSet(_get_itemsize, None),
@@ -3297,6 +3344,15 @@ class NumpyNdarrayVariable(TensorVariable):
         "real": GetSet(lambda s, tx: s._get_numpy_attr(tx, "real")),
         "imag": GetSet(lambda s, tx: s._get_numpy_attr(tx, "imag")),
         "flat": GetSet(lambda s, tx: s._get_numpy_attr(tx, "flat")),
+        "shape": GetSet(lambda s, tx: s._get_shape_or_stride(tx, "shape")),
+        "stride": GetSet(lambda s, tx: s._get_shape_or_stride(tx, "stride")),
+        "size": GetSet(lambda s, tx: s._get_size(tx)),
+        "base": GetSet(lambda s, tx: s._unsupported_attr(tx, "base")),
+        "flags": GetSet(lambda s, tx: s._unsupported_attr(tx, "flags")),
+        "dtype": GetSet(lambda s, tx: s._unsupported_attr(tx, "dtype")),
+        "__version__": GetSet(
+            lambda s, tx: s._unsupported_version_attr(tx, "__version__")
+        ),
     }
 
     def tp_getattro_impl(
@@ -3305,58 +3361,7 @@ class NumpyNdarrayVariable(TensorVariable):
         # NB: This INTENTIONALLY does not call super(), because there is
         # no intrinsic reason ndarray properties are related to Tensor
         # properties.  The inheritance here is for implementation sharing.
-        # tp_getset (ndim/itemsize/T/real/imag/flat) is resolved by
-        # generic_getattr before this method is reached, so it is not
-        # consulted here.
-        from ..utils import numpy_attr_wrapper
-        from .builder import wrap_fx_proxy
-
-        example_value = self.as_proxy().node.meta["example_value"]
-        example_ndarray = tnp.ndarray(example_value)
-
-        def insert_into_graph() -> VariableTracker:
-            return wrap_fx_proxy(
-                tx,
-                tx.output.create_proxy(
-                    "call_function", numpy_attr_wrapper, (self.as_proxy(), name), {}
-                ),
-            )
-
-        # These are awkward to implement.  The standard playbook for torch._numpy
-        # interop is to trace a call into the torch._numpy wrapper which works for
-        # Tensor operations.  However, we don't want to do this for calls
-        # that don't return Tensors, because in those cases we may not want
-        # to trace the attribute access into the graph at all (it is sort
-        # of harmless to do so, because AOTAutograd will eliminate them,
-        # but it's best not to trace them in to begin with.)  But in any
-        # case, tracing these into the graph is like trying to fit a square
-        # peg into a round hole; best not to do it.  So instead we
-        # painstakingly implement these by hand
-        #
-        # NB: only ALWAYS specialized attributes can go here; notably,
-        # size/shape not allowed!
-        if name in ("shape", "stride"):
-            if not has_free_symbols(r := getattr(example_ndarray, name)):
-                return VariableTracker.build(tx, tuple(int(r) for r in r))
-            return insert_into_graph()
-        elif name == "size":
-            if not has_free_symbols(r := example_ndarray.size):
-                return VariableTracker.build(tx, int(r))
-            return insert_into_graph()
-        elif name in ["base", "flags", "dtype"]:
-            unimplemented(
-                gb_type="Unsupported ndarray attribute access",
-                context=f"tp_getattro_impl {self} {name}",
-                explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
-                hints=[],
-            )
-        elif name == "__version__":
-            unimplemented(
-                gb_type="Unsupported ndarray.__version__ access",
-                context=f"tp_getattro_impl {self} {name}",
-                explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
-                hints=[],
-            )
+        # All handled attributes are declared in tp_getset above.
         raise NotImplementedError
 
     @staticmethod


### PR DESCRIPTION
Completes the tp_getset migration for NumpyNdarrayVariable: the remaining `if name == ...` branches in tp_getattro_impl move onto the declarative table alongside the existing ndim/itemsize/T/real/imag/flat entries.

shape/stride/size keep their free-symbol specialization, falling back to tracing the access into the graph when symbolic. base/flags/dtype and __version__ retain their distinct gb_type values, leaving graph_break_registry.json unchanged. tp_getattro_impl is kept (reduced to `raise NotImplementedError`) because it must not fall through to TensorVariable's implementation, and the NotImplementedError is what defers unknown attributes to GetAttrVariable.

Part of #195165.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98