### PR TITLE
[torch] Add native parallel associative scan (aten::associative_scan)

### DIFF
--- a/aten/src/ATen/native/AssociativeScan.cpp
+++ b/aten/src/ATen/native/AssociativeScan.cpp
@@ -1,0 +1,183 @@
+#include <ATen/WrapDimUtils.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/AssociativeScanKernel.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/flip.h>
+#include <ATen/ops/movedim.h>
+#endif
+
+#include <c10/util/Exception.h>
+#include <c10/util/string_view.h>
+
+#include <string>
+#include <vector>
+
+namespace at::native {
+
+DEFINE_DISPATCH(associative_scan_stub);
+DEFINE_DISPATCH(associative_scan_tensor_list_stub);
+
+namespace {
+
+bool is_supported_combine_mode(c10::string_view combine_mode) {
+  return combine_mode == "add" || combine_mode == "mul" ||
+      combine_mode == "max" || combine_mode == "min" ||
+      combine_mode == "linear_recurrence";
+}
+
+void check_combine_mode(c10::string_view combine_mode) {
+  TORCH_CHECK(
+      is_supported_combine_mode(combine_mode),
+      "associative_scan: unsupported combine_mode '",
+      combine_mode,
+      "'. Supported modes are 'add', 'mul', 'max', 'min', 'linear_recurrence'.");
+}
+
+// Inclusive scan over `wrap_dim` of a single tensor. The scan dimension is
+// moved to the innermost position so the kernels operate on contiguous
+// memory; `reverse` is implemented with a flip of the scan dimension before
+// and after the scan, which exactly matches jax.lax.associative_scan
+// semantics.
+Tensor scan_single(
+    const Tensor& self,
+    c10::string_view combine_mode,
+    int64_t wrap_dim,
+    bool reverse) {
+  const int64_t ndim = self.dim();
+  if (ndim == 0 || self.size(wrap_dim) <= 1) {
+    return self.clone();
+  }
+  Tensor input = reverse ? at::flip(self, {wrap_dim}) : self;
+  Tensor moved = at::movedim(input, wrap_dim, ndim - 1);
+  Tensor contig = moved.contiguous();
+  Tensor result_contig = at::empty_like(contig, MemoryFormat::Contiguous);
+  associative_scan_stub(
+      contig.device().type(),
+      result_contig,
+      contig,
+      std::string(combine_mode));
+  Tensor result = at::movedim(result_contig, ndim - 1, wrap_dim);
+  if (reverse) {
+    result = at::flip(result, {wrap_dim});
+  }
+  // The movedim/flip views are non-contiguous for scan dims other than the
+  // innermost; return contiguous so the output layout matches the meta
+  // implementation and stays compatible with Inductor's fallback path.
+  return result.contiguous();
+}
+
+} // namespace
+
+Tensor associative_scan(
+    const Tensor& self,
+    c10::string_view combine_mode,
+    int64_t dim,
+    bool reverse) {
+  check_combine_mode(combine_mode);
+  TORCH_CHECK(
+      combine_mode != "linear_recurrence",
+      "associative_scan: combine_mode 'linear_recurrence' operates on two "
+      "input tensors (a, b); call torch.associative_scan([a, b], "
+      "'linear_recurrence', dim) instead.");
+  if (self.numel() == 0) {
+    return self.clone();
+  }
+  if (self.dim() == 0) {
+    return self.clone();
+  }
+  const int64_t wrap_dim = maybe_wrap_dim(dim, self.dim());
+  return scan_single(self, combine_mode, wrap_dim, reverse);
+}
+
+std::vector<Tensor> associative_scan_tensor_list(
+    TensorList xs,
+    c10::string_view combine_mode,
+    int64_t dim,
+    bool reverse) {
+  check_combine_mode(combine_mode);
+  TORCH_CHECK(
+      combine_mode == "linear_recurrence",
+      "associative_scan: the tensor-list overload only supports "
+      "combine_mode 'linear_recurrence', got '",
+      combine_mode,
+      "'.");
+  TORCH_CHECK(
+      xs.size() == 2,
+      "associative_scan: combine_mode 'linear_recurrence' requires exactly 2 "
+      "input tensors (a, b), got ",
+      xs.size(),
+      ".");
+  const Tensor& a = xs[0];
+  const Tensor& b = xs[1];
+  TORCH_CHECK(
+      a.sizes() == b.sizes(),
+      "associative_scan: all inputs must have the same shape.");
+  TORCH_CHECK(
+      a.scalar_type() == b.scalar_type(),
+      "associative_scan: all inputs must have the same dtype.");
+  TORCH_CHECK(
+      a.device() == b.device(),
+      "associative_scan: all inputs must be on the same device.");
+
+  if (a.numel() == 0) {
+    return {a.clone(), b.clone()};
+  }
+  if (a.dim() == 0) {
+    return {a.clone(), b.clone()};
+  }
+  const int64_t wrap_dim = maybe_wrap_dim(dim, a.dim());
+  if (a.size(wrap_dim) <= 1) {
+    return {a.clone(), b.clone()};
+  }
+
+  const int64_t ndim = a.dim();
+  Tensor a_moved = at::movedim(
+      reverse ? at::flip(a, {wrap_dim}) : a, wrap_dim, ndim - 1);
+  Tensor b_moved = at::movedim(
+      reverse ? at::flip(b, {wrap_dim}) : b, wrap_dim, ndim - 1);
+  Tensor a_contig = a_moved.contiguous();
+  Tensor b_contig = b_moved.contiguous();
+  Tensor a_out = at::empty_like(a_contig, MemoryFormat::Contiguous);
+  Tensor b_out = at::empty_like(b_contig, MemoryFormat::Contiguous);
+
+  std::vector<TensorBase> outs{a_out, b_out};
+  std::vector<TensorBase> ins{a_contig, b_contig};
+  associative_scan_tensor_list_stub(
+      a.device().type(), outs, ins, std::string(combine_mode));
+
+  Tensor a_result = at::movedim(a_out, ndim - 1, wrap_dim);
+  Tensor b_result = at::movedim(b_out, ndim - 1, wrap_dim);
+  if (reverse) {
+    a_result = at::flip(a_result, {wrap_dim});
+    b_result = at::flip(b_result, {wrap_dim});
+  }
+  return {a_result.contiguous(), b_result.contiguous()};
+}
+
+Tensor associative_scan_meta(
+    const Tensor& self,
+    c10::string_view combine_mode,
+    int64_t dim,
+    bool reverse) {
+  return at::empty_like(self, MemoryFormat::Contiguous);
+}
+
+std::vector<Tensor> associative_scan_tensor_list_meta(
+    TensorList xs,
+    c10::string_view combine_mode,
+    int64_t dim,
+    bool reverse) {
+  std::vector<Tensor> out;
+  out.reserve(xs.size());
+  for (const auto& x : xs) {
+    out.push_back(at::empty_like(x, MemoryFormat::Contiguous));
+  }
+  return out;
+}
+
+} // namespace at::native

--- a/aten/src/ATen/native/AssociativeScan.cpp
+++ b/aten/src/ATen/native/AssociativeScan.cpp
@@ -6,6 +6,8 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/associative_scan.h>
+#include <ATen/ops/associative_scan_native.h>
 #include <ATen/ops/empty_like.h>
 #include <ATen/ops/flip.h>
 #include <ATen/ops/movedim.h>

--- a/aten/src/ATen/native/AssociativeScanKernel.h
+++ b/aten/src/ATen/native/AssociativeScanKernel.h
@@ -26,9 +26,9 @@ using associative_scan_tensor_list_fn = void (*)(
     const std::vector<TensorBase>& self,
     const std::string& combine_mode);
 
-DECLARE_DISPATCH(associative_scan_fn, associative_scan_stub);
+DECLARE_DISPATCH(associative_scan_fn, associative_scan_stub)
 DECLARE_DISPATCH(
     associative_scan_tensor_list_fn,
-    associative_scan_tensor_list_stub);
+    associative_scan_tensor_list_stub)
 
 } // namespace at::native

--- a/aten/src/ATen/native/AssociativeScanKernel.h
+++ b/aten/src/ATen/native/AssociativeScanKernel.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ATen/core/TensorBase.h>
+#include <ATen/native/DispatchStub.h>
+
+#include <c10/core/TensorImpl.h>
+
+#include <string>
+#include <vector>
+
+namespace at::native {
+
+// Both input and output tensors are contiguous and the scan is always
+// performed along the innermost (contiguous) dimension. `combine_mode` is one
+// of "add", "mul", "max", "min".
+using associative_scan_fn = void (*)(
+    const TensorBase& result,
+    const TensorBase& self,
+    const std::string& combine_mode);
+
+// Multi-tensor overload. Only combine_mode == "linear_recurrence" (arity 2) is
+// supported; every tensor in `result`/`self` is contiguous with the scan along
+// the innermost dimension.
+using associative_scan_tensor_list_fn = void (*)(
+    const std::vector<TensorBase>& result,
+    const std::vector<TensorBase>& self,
+    const std::string& combine_mode);
+
+DECLARE_DISPATCH(associative_scan_fn, associative_scan_stub);
+DECLARE_DISPATCH(
+    associative_scan_tensor_list_fn,
+    associative_scan_tensor_list_stub);
+
+} // namespace at::native

--- a/aten/src/ATen/native/AssociativeScanUtils.h
+++ b/aten/src/ATen/native/AssociativeScanUtils.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <ATen/NumericUtils.h>
+#include <c10/macros/Macros.h>
+#include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
+#include <c10/util/complex.h>
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+namespace at::native {
+
+namespace detail {
+
+// Smallest representable value used as the identity element of the running
+// max/min scan. For floating point types this is -infinity so that the scan
+// behaves like jax.lax.associative_scan (NaN is propagated by combine).
+template <typename scalar_t>
+C10_HOST_DEVICE scalar_t scan_lowest() {
+  if constexpr (std::is_floating_point_v<scalar_t>) {
+    return -std::numeric_limits<scalar_t>::infinity();
+  } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+    return c10::Half(-std::numeric_limits<float>::infinity());
+  } else if constexpr (std::is_same_v<scalar_t, c10::BFloat16>) {
+    return c10::BFloat16(-std::numeric_limits<float>::infinity());
+  } else if constexpr (c10::is_complex<scalar_t>::value) {
+    // max/min are not supported for complex types; the combine is never
+    // invoked with this identity.
+    return scalar_t(0);
+  } else {
+    return std::numeric_limits<scalar_t>::min();
+  }
+}
+
+// Identity element of the running max/min scan. For floating point types this
+// is +infinity so the min scan seeds with a neutral element.
+template <typename scalar_t>
+C10_HOST_DEVICE scalar_t scan_highest() {
+  if constexpr (std::is_floating_point_v<scalar_t>) {
+    return std::numeric_limits<scalar_t>::infinity();
+  } else if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+    return c10::Half(std::numeric_limits<float>::infinity());
+  } else if constexpr (std::is_same_v<scalar_t, c10::BFloat16>) {
+    return c10::BFloat16(std::numeric_limits<float>::infinity());
+  } else if constexpr (c10::is_complex<scalar_t>::value) {
+    // max/min are not supported for complex types; the combine is never
+    // invoked with this identity.
+    return scalar_t(0);
+  } else {
+    return std::numeric_limits<scalar_t>::max();
+  }
+}
+
+// NaN-propagating max/min, matching the behavior of jax.lax.max/min.
+template <typename scalar_t>
+C10_HOST_DEVICE scalar_t nan_max(scalar_t a, scalar_t b) {
+  if constexpr (c10::is_complex<scalar_t>::value) {
+    // max/min are not supported for complex types; never reached.
+    return a;
+  } else {
+    if (at::_isnan(a)) return a;
+    if (at::_isnan(b)) return b;
+    return a > b ? a : b;
+  }
+}
+
+template <typename scalar_t>
+C10_HOST_DEVICE scalar_t nan_min(scalar_t a, scalar_t b) {
+  if constexpr (c10::is_complex<scalar_t>::value) {
+    // max/min are not supported for complex types; never reached.
+    return a;
+  } else {
+    if (at::_isnan(a)) return a;
+    if (at::_isnan(b)) return b;
+    return a < b ? a : b;
+  }
+}
+
+} // namespace detail
+
+// A scan element with L scalar components. L == 1 for the pointwise combine
+// modes (add/mul/max/min) and L == 2 for the linear recurrence mode, whose
+// combine operates on (a, b) pairs.
+template <typename scalar_t, int L>
+struct ScanVec {
+  scalar_t v[L];
+};
+
+template <typename scalar_t, int L>
+struct CombineAdd {
+  static C10_HOST_DEVICE ScanVec<scalar_t, L> identity() {
+    ScanVec<scalar_t, L> res{};
+    for (int i = 0; i < L; ++i) {
+      res.v[i] = 0;
+    }
+    return res;
+  }
+  static C10_HOST_DEVICE ScanVec<scalar_t, L> combine(
+      const ScanVec<scalar_t, L>& a,
+      const ScanVec<scalar_t, L>& b) {
+    ScanVec<scalar_t, L> res;
+    for (int i = 0; i < L; ++i) {
+      res.v[i] = a.v[i] + b.v[i];
+    }
+    return res;
+  }
+};
+
+template <typename scalar_t, int L>
+struct CombineMul {
+  static C10_HOST_DEVICE ScanVec<scalar_t, L> identity() {
+    ScanVec<scalar_t, L> res{};
+    for (int i = 0; i < L; ++i) {
+      res.v[i] = 1;
+    }
+    return res;
+  }
+  static C10_HOST_DEVICE ScanVec<scalar_t, L> combine(
+      const ScanVec<scalar_t, L>& a,
+      const ScanVec<scalar_t, L>& b) {
+    ScanVec<scalar_t, L> res;
+    for (int i = 0; i < L; ++i) {
+      res.v[i] = a.v[i] * b.v[i];
+    }
+    return res;
+  }
+};
+
+template <typename scalar_t>
+struct CombineMax {
+  using vec_t = ScanVec<scalar_t, 1>;
+  static C10_HOST_DEVICE vec_t identity() {
+    return vec_t{detail::scan_lowest<scalar_t>()};
+  }
+  static C10_HOST_DEVICE vec_t combine(const vec_t& a, const vec_t& b) {
+    return vec_t{detail::nan_max(a.v[0], b.v[0])};
+  }
+};
+
+template <typename scalar_t>
+struct CombineMin {
+  using vec_t = ScanVec<scalar_t, 1>;
+  static C10_HOST_DEVICE vec_t identity() {
+    return vec_t{detail::scan_highest<scalar_t>()};
+  }
+  static C10_HOST_DEVICE vec_t combine(const vec_t& a, const vec_t& b) {
+    return vec_t{detail::nan_min(a.v[0], b.v[0])};
+  }
+};
+
+// combine((a1, b1), (a2, b2)) = (a2 * a1, a2 * b1 + b2), the associative
+// operation behind the Mamba-style SSM recurrence h_t = a_t * h_{t-1} + b_t.
+// A segment's transform maps h_{l-1} -> h_r = A * h_{l-1} + H; concatenating
+// left segment (a1, b1) then right segment (a2, b2) composes as a2 applied
+// after a1, so the accumulated A is a2 * a1 and the accumulated H is
+// a2 * b1 + b2.
+template <typename scalar_t>
+struct CombineLinearRecurrence {
+  using vec_t = ScanVec<scalar_t, 2>;
+  static C10_HOST_DEVICE vec_t identity() {
+    return vec_t{static_cast<scalar_t>(1), static_cast<scalar_t>(0)};
+  }
+  static C10_HOST_DEVICE vec_t combine(const vec_t& a, const vec_t& b) {
+    return vec_t{
+        static_cast<scalar_t>(a.v[0] * b.v[0]),
+        static_cast<scalar_t>(b.v[0] * a.v[1] + b.v[1]),
+    };
+  }
+};
+
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/AssociativeScanKernel.cpp
+++ b/aten/src/ATen/native/cpu/AssociativeScanKernel.cpp
@@ -1,0 +1,219 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/core/TensorBase.h>
+#include <ATen/Dispatch.h>
+#include <ATen/Parallel.h>
+#include <ATen/TensorIterator.h>
+#include <ATen/native/AssociativeScanKernel.h>
+#include <ATen/native/AssociativeScanUtils.h>
+
+#include <c10/util/irange.h>
+#include <c10/util/Load.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace at::native {
+
+namespace {
+
+constexpr int64_t kChunkSize = 4096;
+
+// 2-pass work-efficient parallel prefix scan over the innermost (contiguous)
+// dimension of a tensor viewed as [M, N]:
+//   1. upsweep:   reduce each block of kChunkSize elements into a partial
+//   2. prefix:    inclusive-scan the block partials along the scan dim
+//   3. downsweep: inclusive-scan each block, seeded with the prefix of the
+//                 preceding blocks.
+// `self`/`result` hold L parallel arrays of N x M contiguous elements.
+template <typename scalar_t, int L, typename Combine>
+void scan_impl(
+    const scalar_t* const* self,
+    scalar_t* const* result,
+    int64_t N,
+    int64_t M) {
+  const int64_t num_chunks = (N + kChunkSize - 1) / kChunkSize;
+
+  if (num_chunks == 1) {
+    // Short scan: a single sequential pass per row, parallelized over rows.
+    at::parallel_for(0, M, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+      for (const auto m : c10::irange(begin, end)) {
+        auto acc = Combine::identity();
+        for (const auto i : c10::irange(N)) {
+          ScanVec<scalar_t, L> v;
+          for (int l = 0; l < L; ++l) {
+            v.v[l] = c10::load(&self[l][m * N + i]);
+          }
+          acc = Combine::combine(acc, v);
+          for (int l = 0; l < L; ++l) {
+            result[l][m * N + i] = acc.v[l];
+          }
+        }
+      }
+    });
+    return;
+  }
+
+  // Block partial reductions (upsweep): partials[num_chunks][M] elements.
+  std::vector<scalar_t> partials(num_chunks * M * L);
+  at::parallel_for(
+      0, num_chunks * M, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+        for (const auto idx : c10::irange(begin, end)) {
+          const int64_t c = idx / M;
+          const int64_t m = idx % M;
+          const int64_t lo = c * kChunkSize;
+          const int64_t hi = std::min(lo + kChunkSize, N);
+          auto acc = Combine::identity();
+          for (const auto i : c10::irange(lo, hi)) {
+            ScanVec<scalar_t, L> v;
+            for (int l = 0; l < L; ++l) {
+              v.v[l] = c10::load(&self[l][m * N + i]);
+            }
+            acc = Combine::combine(acc, v);
+          }
+          scalar_t* p = partials.data() + (c * M + m) * L;
+          for (int l = 0; l < L; ++l) {
+            p[l] = acc.v[l];
+          }
+        }
+      });
+
+  // Inclusive scan of the block partials (few chunks -> sequential per row).
+  std::vector<scalar_t> prefix(num_chunks * M * L);
+  at::parallel_for(0, M, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    for (const auto m : c10::irange(begin, end)) {
+      auto acc = Combine::identity();
+      for (const auto c : c10::irange(num_chunks)) {
+        ScanVec<scalar_t, L> v;
+        for (int l = 0; l < L; ++l) {
+          v.v[l] = partials[(c * M + m) * L + l];
+        }
+        acc = Combine::combine(acc, v);
+        for (int l = 0; l < L; ++l) {
+          prefix[(c * M + m) * L + l] = acc.v[l];
+        }
+      }
+    }
+  });
+
+  // Downsweep: scan each block seeded with the prefix of all preceding blocks.
+  at::parallel_for(
+      0, num_chunks * M, internal::GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+        for (const auto idx : c10::irange(begin, end)) {
+          const int64_t c = idx / M;
+          const int64_t m = idx % M;
+          const int64_t lo = c * kChunkSize;
+          const int64_t hi = std::min(lo + kChunkSize, N);
+          auto acc = Combine::identity();
+          if (c > 0) {
+            for (int l = 0; l < L; ++l) {
+              acc.v[l] = prefix[((c - 1) * M + m) * L + l];
+            }
+          }
+          for (const auto i : c10::irange(lo, hi)) {
+            ScanVec<scalar_t, L> v;
+            for (int l = 0; l < L; ++l) {
+              v.v[l] = c10::load(&self[l][m * N + i]);
+            }
+            acc = Combine::combine(acc, v);
+            for (int l = 0; l < L; ++l) {
+              result[l][m * N + i] = acc.v[l];
+            }
+          }
+        }
+      });
+}
+
+template <typename scalar_t>
+void dispatch_combine(
+    const TensorBase& result,
+    const TensorBase& self,
+    const std::string& combine_mode) {
+  const int64_t N = self.size(-1);
+  const int64_t M = self.numel() / N;
+  const scalar_t* self_ptr = self.const_data_ptr<scalar_t>();
+  scalar_t* result_ptr = result.mutable_data_ptr<scalar_t>();
+
+  if (combine_mode == "add") {
+    const scalar_t* ptrs[1] = {self_ptr};
+    scalar_t* rptrs[1] = {result_ptr};
+    scan_impl<scalar_t, 1, CombineAdd<scalar_t, 1>>(ptrs, rptrs, N, M);
+  } else if (combine_mode == "mul") {
+    const scalar_t* ptrs[1] = {self_ptr};
+    scalar_t* rptrs[1] = {result_ptr};
+    scan_impl<scalar_t, 1, CombineMul<scalar_t, 1>>(ptrs, rptrs, N, M);
+  } else if (combine_mode == "max") {
+    const scalar_t* ptrs[1] = {self_ptr};
+    scalar_t* rptrs[1] = {result_ptr};
+    scan_impl<scalar_t, 1, CombineMax<scalar_t>>(ptrs, rptrs, N, M);
+  } else if (combine_mode == "min") {
+    const scalar_t* ptrs[1] = {self_ptr};
+    scalar_t* rptrs[1] = {result_ptr};
+    scan_impl<scalar_t, 1, CombineMin<scalar_t>>(ptrs, rptrs, N, M);
+  } else {
+    TORCH_INTERNAL_ASSERT(false, "unsupported combine_mode: ", combine_mode);
+  }
+}
+
+void associative_scan_cpu_kernel(
+    const TensorBase& result,
+    const TensorBase& self,
+    const std::string& combine_mode) {
+  if (self.numel() == 0) {
+    return;
+  }
+  if (combine_mode == "add" || combine_mode == "mul") {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+        kHalf,
+        kBFloat16,
+        self.scalar_type(),
+        "associative_scan_cpu",
+        [&] { dispatch_combine<scalar_t>(result, self, combine_mode); });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(
+        kHalf,
+        kBFloat16,
+        self.scalar_type(),
+        "associative_scan_cpu",
+        [&] { dispatch_combine<scalar_t>(result, self, combine_mode); });
+  }
+}
+
+void associative_scan_tensor_list_cpu_kernel(
+    const std::vector<TensorBase>& result,
+    const std::vector<TensorBase>& self,
+    const std::string& combine_mode) {
+  if (self.empty() || self[0].numel() == 0) {
+    return;
+  }
+  const int64_t N = self[0].size(-1);
+  const int64_t M = self[0].numel() / N;
+  AT_DISPATCH_ALL_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      self[0].scalar_type(),
+      "associative_scan_tensor_list_cpu",
+      [&] {
+        const scalar_t* in_ptrs[2] = {
+            self[0].const_data_ptr<scalar_t>(),
+            self[1].const_data_ptr<scalar_t>(),
+        };
+        scalar_t* out_ptrs[2] = {
+            result[0].mutable_data_ptr<scalar_t>(),
+            result[1].mutable_data_ptr<scalar_t>(),
+        };
+        scan_impl<scalar_t, 2, CombineLinearRecurrence<scalar_t>>(
+            in_ptrs, out_ptrs, N, M);
+      });
+}
+
+} // namespace
+
+REGISTER_DISPATCH(associative_scan_stub, &associative_scan_cpu_kernel);
+REGISTER_DISPATCH(
+    associative_scan_tensor_list_stub,
+    &associative_scan_tensor_list_cpu_kernel);
+
+} // namespace at::native

--- a/aten/src/ATen/native/cpu/AssociativeScanKernel.cpp
+++ b/aten/src/ATen/native/cpu/AssociativeScanKernel.cpp
@@ -211,9 +211,9 @@ void associative_scan_tensor_list_cpu_kernel(
 
 } // namespace
 
-REGISTER_DISPATCH(associative_scan_stub, &associative_scan_cpu_kernel);
+REGISTER_DISPATCH(associative_scan_stub, &associative_scan_cpu_kernel)
 REGISTER_DISPATCH(
     associative_scan_tensor_list_stub,
-    &associative_scan_tensor_list_cpu_kernel);
+    &associative_scan_tensor_list_cpu_kernel)
 
 } // namespace at::native

--- a/aten/src/ATen/native/cuda/AssociativeScanKernel.cu
+++ b/aten/src/ATen/native/cuda/AssociativeScanKernel.cu
@@ -1,0 +1,254 @@
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+
+#include <ATen/core/TensorBase.h>
+#include <ATen/Dispatch.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <ATen/native/AssociativeScanKernel.h>
+#include <ATen/native/AssociativeScanUtils.h>
+
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/util/Load.h>
+#include <c10/util/complex.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace at::native {
+
+namespace {
+
+constexpr int kBlockDimX = 256;
+constexpr int kRowsPerBlock = 4;
+
+// Host/device handles for the L parallel input/output arrays.
+template <typename scalar_t, int L>
+struct ScanPointers {
+  const scalar_t* self[L];
+  scalar_t* result[L];
+};
+
+template <typename scalar_t, int L>
+__device__ inline ScanVec<scalar_t, L> shfl_up(
+    ScanVec<scalar_t, L> val,
+    uint32_t delta) {
+  ScanVec<scalar_t, L> res;
+#pragma unroll
+  for (int i = 0; i < L; ++i) {
+    if constexpr (std::is_same_v<scalar_t, c10::Half>) {
+      res.v[i] = c10::Half(
+          static_cast<uint16_t>(
+              __shfl_up_sync(0xffffffffu, val.v[i].x, delta)),
+          c10::Half::from_bits());
+    } else if constexpr (std::is_same_v<scalar_t, c10::BFloat16>) {
+      res.v[i] = c10::BFloat16(
+          static_cast<uint16_t>(
+              __shfl_up_sync(0xffffffffu, val.v[i].x, delta)),
+          c10::BFloat16::from_bits());
+    } else if constexpr (c10::is_complex<scalar_t>::value) {
+      using comp_t = typename scalar_t::value_type;
+      res.v[i] = scalar_t(
+          __shfl_up_sync(
+              0xffffffffu, static_cast<comp_t>(val.v[i].real()), delta),
+          __shfl_up_sync(
+              0xffffffffu, static_cast<comp_t>(val.v[i].imag()), delta));
+    } else {
+      res.v[i] = __shfl_up_sync(0xffffffffu, val.v[i], delta);
+    }
+  }
+  return res;
+}
+
+// Inclusive scan of a warp's segment using __shfl_up_sync (Hillis-Steele over
+// lanes). Unselected lanes keep their own value which acts as the identity
+// segment boundary.
+template <typename scalar_t, int L, typename Combine>
+__device__ inline ScanVec<scalar_t, L> warp_inclusive_scan(
+    ScanVec<scalar_t, L> val,
+    uint32_t lane) {
+#pragma unroll
+  for (uint32_t d = 1; d < 32; d <<= 1) {
+    ScanVec<scalar_t, L> t = shfl_up<scalar_t, L>(val, d);
+    if (lane >= d) {
+      val = Combine::combine(t, val);
+    }
+  }
+  return val;
+}
+
+// Hierarchical block scan:
+//   1. each warp independently scans its 32-element segment (warp shuffle),
+//   2. warp totals are scanned by warp 0 (shared memory),
+//   3. every warp adds the exclusive prefix of the preceding warps.
+// The block iterates over chunks of the scan dimension while carrying a
+// running block total (decoupled look-back), so arbitrarily long scans are
+// supported with O(blockDim) shared memory.
+template <typename scalar_t, int L, typename Combine>
+__global__ void associative_scan_cuda_kernel(
+    ScanPointers<scalar_t, L> ptrs,
+    int64_t N,
+    int64_t M) {
+  alignas(sizeof(double)) extern __shared__ char smem[];
+  // One entry per warp per row: the inclusive scan of the warp totals.
+  ScanVec<scalar_t, L>* warp_totals =
+      reinterpret_cast<ScanVec<scalar_t, L>*>(smem);
+  constexpr int kNumWarps = kBlockDimX / 32;
+  const uint32_t lane = threadIdx.x & 31u;
+  const uint32_t warp_id = threadIdx.x >> 5;
+
+  for (int64_t row = blockIdx.x * kRowsPerBlock + threadIdx.y;
+       row < M;
+       row += gridDim.x * kRowsPerBlock) {
+    ScanVec<scalar_t, L>* wt = warp_totals + threadIdx.y * kNumWarps;
+    ScanVec<scalar_t, L> block_total = Combine::identity();
+
+    for (int64_t i = threadIdx.x; i < N; i += blockDim.x) {
+      ScanVec<scalar_t, L> val;
+      if (i < N) {
+        for (int l = 0; l < L; ++l) {
+          val.v[l] = c10::load(&ptrs.self[l][row * N + i]);
+        }
+      } else {
+        val = Combine::identity();
+      }
+
+      val = warp_inclusive_scan<scalar_t, L, Combine>(val, lane);
+
+      if (lane == 31) {
+        wt[warp_id] = val;
+      }
+      __syncthreads();
+
+      if (warp_id == 0) {
+        ScanVec<scalar_t, L> w =
+            (lane < kNumWarps) ? wt[lane] : Combine::identity();
+        w = warp_inclusive_scan<scalar_t, L, Combine>(w, lane);
+        if (lane < kNumWarps) {
+          wt[lane] = w;
+        }
+      }
+      __syncthreads();
+
+      // Exclusive prefix of the preceding warps within this chunk, then the
+      // running total of all preceding chunks.
+      ScanVec<scalar_t, L> warp_prefix =
+          (warp_id > 0) ? wt[warp_id - 1] : Combine::identity();
+      val = Combine::combine(warp_prefix, val);
+      val = Combine::combine(block_total, val);
+
+      if (i < N) {
+        for (int l = 0; l < L; ++l) {
+          ptrs.result[l][row * N + i] = val.v[l];
+        }
+      }
+
+      block_total = Combine::combine(block_total, wt[kNumWarps - 1]);
+      // Ensure all warps finished reading `wt` before it is overwritten.
+      __syncthreads();
+    }
+  }
+}
+
+template <typename scalar_t, int L, typename Combine>
+void launch_associative_scan(
+    const ScanPointers<scalar_t, L>& ptrs,
+    const TensorBase& self) {
+  const int64_t N = self.size(-1);
+  const int64_t M = self.numel() / N;
+  if (M == 0 || N == 0) {
+    return;
+  }
+  dim3 threads(kBlockDimX, kRowsPerBlock);
+  int64_t blocks = (M + kRowsPerBlock - 1) / kRowsPerBlock;
+  blocks = std::min<int64_t>(
+      blocks, at::cuda::getCurrentDeviceProperties()->maxGridSize[0]);
+  constexpr int kNumWarps = kBlockDimX / 32;
+  size_t smem_bytes = kRowsPerBlock * kNumWarps * sizeof(ScanVec<scalar_t, L>);
+  associative_scan_cuda_kernel<scalar_t, L, Combine>
+      <<<static_cast<uint32_t>(blocks), threads, smem_bytes,
+         at::cuda::getCurrentCUDAStream()>>>(ptrs, N, M);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+
+template <typename scalar_t>
+void dispatch_combine(
+    const TensorBase& result,
+    const TensorBase& self,
+    const std::string& combine_mode) {
+  ScanPointers<scalar_t, 1> ptrs;
+  ptrs.self[0] = self.const_data_ptr<scalar_t>();
+  ptrs.result[0] = result.mutable_data_ptr<scalar_t>();
+
+  if (combine_mode == "add") {
+    launch_associative_scan<scalar_t, 1, CombineAdd<scalar_t, 1>>(ptrs, self);
+  } else if (combine_mode == "mul") {
+    launch_associative_scan<scalar_t, 1, CombineMul<scalar_t, 1>>(ptrs, self);
+  } else if (combine_mode == "max") {
+    launch_associative_scan<scalar_t, 1, CombineMax<scalar_t>>(ptrs, self);
+  } else if (combine_mode == "min") {
+    launch_associative_scan<scalar_t, 1, CombineMin<scalar_t>>(ptrs, self);
+  } else {
+    TORCH_INTERNAL_ASSERT(false, "unsupported combine_mode: ", combine_mode);
+  }
+}
+
+} // namespace
+
+void associative_scan_cuda_kernel(
+    const TensorBase& result,
+    const TensorBase& self,
+    const std::string& combine_mode) {
+  if (self.numel() == 0) {
+    return;
+  }
+  const cuda::OptionalCUDAGuard guard(self.device());
+  if (combine_mode == "add" || combine_mode == "mul") {
+    AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND2(
+        kHalf,
+        kBFloat16,
+        self.scalar_type(),
+        "associative_scan_cuda",
+        [&] { dispatch_combine<scalar_t>(result, self, combine_mode); });
+  } else {
+    AT_DISPATCH_ALL_TYPES_AND2(
+        kHalf,
+        kBFloat16,
+        self.scalar_type(),
+        "associative_scan_cuda",
+        [&] { dispatch_combine<scalar_t>(result, self, combine_mode); });
+  }
+}
+
+void associative_scan_tensor_list_cuda_kernel(
+    const std::vector<TensorBase>& result,
+    const std::vector<TensorBase>& self,
+    const std::string& combine_mode) {
+  if (self.empty() || self[0].numel() == 0) {
+    return;
+  }
+  const cuda::OptionalCUDAGuard guard(self[0].device());
+  const int64_t N = self[0].size(-1);
+  const int64_t M = self[0].numel() / N;
+  AT_DISPATCH_ALL_TYPES_AND2(
+      kHalf,
+      kBFloat16,
+      self[0].scalar_type(),
+      "associative_scan_tensor_list_cuda",
+      [&] {
+        ScanPointers<scalar_t, 2> ptrs;
+        ptrs.self[0] = self[0].const_data_ptr<scalar_t>();
+        ptrs.self[1] = self[1].const_data_ptr<scalar_t>();
+        ptrs.result[0] = result[0].mutable_data_ptr<scalar_t>();
+        ptrs.result[1] = result[1].mutable_data_ptr<scalar_t>();
+        launch_associative_scan<scalar_t, 2, CombineLinearRecurrence<scalar_t>>(
+            ptrs, self[0]);
+      });
+}
+
+REGISTER_CUDA_DISPATCH(associative_scan_stub, &associative_scan_cuda_kernel);
+REGISTER_CUDA_DISPATCH(
+    associative_scan_tensor_list_stub,
+    &associative_scan_tensor_list_cuda_kernel);
+
+} // namespace at::native

--- a/aten/src/ATen/native/cuda/AssociativeScanKernel.cu
+++ b/aten/src/ATen/native/cuda/AssociativeScanKernel.cu
@@ -29,6 +29,18 @@ struct ScanPointers {
   scalar_t* result[L];
 };
 
+// Warp shuffle up. CUDA requires an explicit 32-lane sync mask; HIP (ROCm)
+// uses a 64-bit mask on gfx9 (or rejects the 32-bit one), so use the maskless
+// intrinsic there.
+template <typename T>
+__device__ inline T shfl_up_val(T val, uint32_t delta) {
+#if defined(USE_ROCM)
+  return __shfl_up(val, delta);
+#else
+  return __shfl_up_sync(0xffffffffu, val, delta);
+#endif
+}
+
 template <typename scalar_t, int L>
 __device__ inline ScanVec<scalar_t, L> shfl_up(
     ScanVec<scalar_t, L> val,
@@ -38,23 +50,19 @@ __device__ inline ScanVec<scalar_t, L> shfl_up(
   for (int i = 0; i < L; ++i) {
     if constexpr (std::is_same_v<scalar_t, c10::Half>) {
       res.v[i] = c10::Half(
-          static_cast<uint16_t>(
-              __shfl_up_sync(0xffffffffu, val.v[i].x, delta)),
+          static_cast<uint16_t>(shfl_up_val(val.v[i].x, delta)),
           c10::Half::from_bits());
     } else if constexpr (std::is_same_v<scalar_t, c10::BFloat16>) {
       res.v[i] = c10::BFloat16(
-          static_cast<uint16_t>(
-              __shfl_up_sync(0xffffffffu, val.v[i].x, delta)),
+          static_cast<uint16_t>(shfl_up_val(val.v[i].x, delta)),
           c10::BFloat16::from_bits());
     } else if constexpr (c10::is_complex<scalar_t>::value) {
       using comp_t = typename scalar_t::value_type;
       res.v[i] = scalar_t(
-          __shfl_up_sync(
-              0xffffffffu, static_cast<comp_t>(val.v[i].real()), delta),
-          __shfl_up_sync(
-              0xffffffffu, static_cast<comp_t>(val.v[i].imag()), delta));
+          shfl_up_val(static_cast<comp_t>(val.v[i].real()), delta),
+          shfl_up_val(static_cast<comp_t>(val.v[i].imag()), delta));
     } else {
-      res.v[i] = __shfl_up_sync(0xffffffffu, val.v[i], delta);
+      res.v[i] = shfl_up_val(val.v[i], delta);
     }
   }
   return res;
@@ -68,7 +76,7 @@ __device__ inline ScanVec<scalar_t, L> warp_inclusive_scan(
     ScanVec<scalar_t, L> val,
     uint32_t lane) {
 #pragma unroll
-  for (uint32_t d = 1; d < 32; d <<= 1) {
+  for (uint32_t d = 1; d < C10_WARP_SIZE; d <<= 1) {
     ScanVec<scalar_t, L> t = shfl_up<scalar_t, L>(val, d);
     if (lane >= d) {
       val = Combine::combine(t, val);
@@ -93,9 +101,9 @@ __global__ void associative_scan_cuda_kernel(
   // One entry per warp per row: the inclusive scan of the warp totals.
   ScanVec<scalar_t, L>* warp_totals =
       reinterpret_cast<ScanVec<scalar_t, L>*>(smem);
-  constexpr int kNumWarps = kBlockDimX / 32;
-  const uint32_t lane = threadIdx.x & 31u;
-  const uint32_t warp_id = threadIdx.x >> 5;
+  constexpr int kNumWarps = kBlockDimX / C10_WARP_SIZE;
+  const uint32_t lane = threadIdx.x % C10_WARP_SIZE;
+  const uint32_t warp_id = threadIdx.x / C10_WARP_SIZE;
 
   for (int64_t row = blockIdx.x * kRowsPerBlock + threadIdx.y;
        row < M;
@@ -115,7 +123,7 @@ __global__ void associative_scan_cuda_kernel(
 
       val = warp_inclusive_scan<scalar_t, L, Combine>(val, lane);
 
-      if (lane == 31) {
+      if (lane == C10_WARP_SIZE - 1) {
         wt[warp_id] = val;
       }
       __syncthreads();
@@ -163,8 +171,8 @@ void launch_associative_scan(
   int64_t blocks = (M + kRowsPerBlock - 1) / kRowsPerBlock;
   blocks = std::min<int64_t>(
       blocks, at::cuda::getCurrentDeviceProperties()->maxGridSize[0]);
-  constexpr int kNumWarps = kBlockDimX / 32;
-  size_t smem_bytes = kRowsPerBlock * kNumWarps * sizeof(ScanVec<scalar_t, L>);
+  const int num_warps = kBlockDimX / C10_WARP_SIZE;
+  size_t smem_bytes = kRowsPerBlock * num_warps * sizeof(ScanVec<scalar_t, L>);
   associative_scan_cuda_kernel<scalar_t, L, Combine>
       <<<static_cast<uint32_t>(blocks), threads, smem_bytes,
          at::cuda::getCurrentCUDAStream()>>>(ptrs, N, M);

--- a/aten/src/ATen/native/cuda/AssociativeScanKernel.cu
+++ b/aten/src/ATen/native/cuda/AssociativeScanKernel.cu
@@ -254,9 +254,9 @@ void associative_scan_tensor_list_cuda_kernel(
       });
 }
 
-REGISTER_CUDA_DISPATCH(associative_scan_stub, &associative_scan_cuda_kernel);
+REGISTER_CUDA_DISPATCH(associative_scan_stub, &associative_scan_cuda_kernel)
 REGISTER_CUDA_DISPATCH(
     associative_scan_tensor_list_stub,
-    &associative_scan_tensor_list_cuda_kernel);
+    &associative_scan_tensor_list_cuda_kernel)
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2007,6 +2007,22 @@
     CPU, CUDA, XPU: cumsum_out
     MPS: cumsum_out_mps
 
+- func: associative_scan(Tensor self, str combine_mode, int dim=0, bool reverse=False) -> Tensor
+  device_check: NoCheck
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: associative_scan
+    Meta: associative_scan_meta
+  tags: core
+
+- func: associative_scan.TensorList(Tensor[] xs, str combine_mode, int dim=0, bool reverse=False) -> Tensor[]
+  device_check: NoCheck
+  variants: function
+  dispatch:
+    CompositeExplicitAutograd: associative_scan_tensor_list
+    Meta: associative_scan_tensor_list_meta
+  tags: core
+
 - func: cumulative_trapezoid.x(Tensor y, Tensor x, *, int dim=-1) -> Tensor
 
 - func: cumulative_trapezoid.dx(Tensor y, *, Scalar dx=1, int dim=-1) -> Tensor

--- a/benchmarks/associative_scan_bench.py
+++ b/benchmarks/associative_scan_bench.py
@@ -1,0 +1,203 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Correctness and performance harness for the native aten::associative_scan.
+
+References:
+  * eager: torch.cumsum / torch.cumprod for the add / mul combine modes
+  * sequential: an explicit Python loop over the scan dimension (the naive
+    O(N) reference, matching jax.lax.associative_scan for builtin combines)
+  * mamba: the linear-recurrence reference used by SSM kernels, computed with
+    an explicit sequential loop over the (a, b) pairs.
+
+Usage:
+    python benchmarks/associative_scan_bench.py [--cpu] [--cuda]
+"""
+
+import argparse
+import time
+
+import torch
+
+
+def _scan_ref(x, combine_mode, dim):
+    dim = dim if dim >= 0 else dim + x.ndim
+    out = torch.empty_like(x)
+    acc = None
+    for i in range(x.size(dim)):
+        sl = [slice(None)] * x.ndim
+        sl[dim] = i
+        v = x[sl]
+        if acc is None:
+            acc = v.clone()
+        elif combine_mode == "add":
+            acc = acc + v
+        elif combine_mode == "mul":
+            acc = acc * v
+        elif combine_mode == "max":
+            acc = torch.maximum(acc, v)
+        elif combine_mode == "min":
+            acc = torch.minimum(acc, v)
+        else:
+            raise AssertionError(f"unknown combine_mode {combine_mode}")
+        out[sl] = acc
+    return out
+
+
+def _linrec_ref(a, b, dim):
+    dim = dim if dim >= 0 else dim + a.ndim
+    n = a.size(dim)
+    A = torch.empty_like(a)
+    H = torch.empty_like(b)
+    sl0 = [slice(None)] * a.ndim
+    sl0[dim] = 0
+    A[sl0] = a[sl0].clone()
+    H[sl0] = b[sl0].clone()
+    for i in range(1, n):
+        sl = [slice(None)] * a.ndim
+        sl[dim] = i
+        prev = [slice(None)] * a.ndim
+        prev[dim] = i - 1
+        A[sl] = a[sl] * A[prev]
+        H[sl] = a[sl] * H[prev] + b[sl]
+    return A, H
+
+
+def _check(name, actual, expected, atol=1e-5, rtol=1e-5):
+    ok = torch.allclose(actual, expected, atol=atol, rtol=rtol)
+    diff = (actual - expected).abs().max().item()
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}  (max abs diff {diff:.3e})")
+    return ok
+
+
+def correctness(device):
+    print(f"\n=== Correctness ({device}) ===")
+    ok = True
+    x = torch.randn(64, 32, device=device)
+    for mode, ref in [
+        ("add", lambda t: torch.cumsum(t, 0)),
+        ("mul", lambda t: torch.cumprod(t, 0)),
+    ]:
+        ok &= _check(
+            f"native {mode} vs eager cum{'sum' if mode == 'add' else 'prod'}",
+            torch.associative_scan(x, mode, 0),
+            ref(x),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    for mode in ["add", "mul", "max", "min"]:
+        ok &= _check(
+            f"native {mode} vs sequential reference",
+            torch.associative_scan(x, mode, 0),
+            _scan_ref(x, mode, 0),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    a = torch.rand(64, 32, device=device) * 0.5 + 0.5
+    b = torch.randn(64, 32, device=device)
+    ea, eh = _linrec_ref(a, b, 0)
+    na, nh = torch.associative_scan([a, b], "linear_recurrence", 0)
+    ok &= _check("native linear_recurrence A vs mamba reference", na, ea)
+    ok &= _check("native linear_recurrence H vs mamba reference", nh, eh)
+
+    from torch._higher_order_ops.associative_scan import associative_scan as hop_scan
+
+    for combine, mode in [
+        (lambda u, v: u + v, "add"),
+        (lambda u, v: u * v, "mul"),
+        (torch.maximum, "max"),
+        (torch.minimum, "min"),
+    ]:
+        ok &= _check(
+            f"HOP {mode} (native routing) vs sequential reference",
+            hop_scan(combine, x, dim=0),
+            _scan_ref(x, mode, 0),
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def _combine(u, v):
+        a1, b1 = u
+        a2, b2 = v
+        return (a2 * a1, a2 * b1 + b2)
+
+    ha, hb = hop_scan(_combine, (a, b), dim=0)
+    ok &= _check("HOP linear_recurrence (generic) vs mamba reference", ha, ea)
+    ok &= _check("HOP linear_recurrence H (generic) vs mamba reference", hb, eh)
+    return ok
+
+
+def _bench(fn, iters):
+    # warmup
+    fn()
+    torch.cuda.synchronize() if torch.cuda.is_available() else None
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    return (time.perf_counter() - t0) / iters * 1e3  # ms
+
+
+def performance(device):
+    print(f"\n=== Performance ({device}) ===")
+    sizes = [(2**16, 64), (2**18, 64), (2**20, 64)]
+    header = (
+        f"{'shape':>14} | {'native add':>10} | {'cumsum':>10} | "
+        f"{'native mul':>10} | {'cumprod':>10} | {'native linrec':>14} | {'seq ref':>10}"
+    )
+    print(header)
+    print("-" * len(header))
+    for rows, cols in sizes:
+        x = torch.randn(rows, cols, device=device)
+        a = torch.rand(rows, cols, device=device) * 0.5 + 0.5
+        b = torch.randn(rows, cols, device=device)
+        t_add = _bench(lambda: torch.associative_scan(x, "add", 0), 5)
+        t_cumsum = _bench(lambda: torch.cumsum(x, 0), 5)
+        t_mul = _bench(lambda: torch.associative_scan(x, "mul", 0), 5)
+        t_cumprod = _bench(lambda: torch.cumprod(x, 0), 5)
+        t_linrec = _bench(
+            lambda: torch.associative_scan([a, b], "linear_recurrence", 0), 5
+        )
+        t_seq = _bench(lambda: _linrec_ref(a, b, 0), 1)
+        print(
+            f"{f'{rows}x{cols}':>14} | {t_add:>10.3f} | {t_cumsum:>10.3f} | "
+            f"{t_mul:>10.3f} | {t_cumprod:>10.3f} | {t_linrec:>14.3f} | {t_seq:>10.3f}"
+        )
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cpu", action="store_true", help="run CPU checks")
+    parser.add_argument("--cuda", action="store_true", help="run CUDA checks")
+    parser.add_argument("--fast", action="store_true", help="small shapes only")
+    args = parser.parse_args()
+
+    devices = []
+    if args.cpu:
+        devices.append("cpu")
+    if args.cuda:
+        if not torch.cuda.is_available():
+            print("CUDA requested but unavailable")
+            return 1
+        devices.append("cuda")
+    if not devices:
+        devices = ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+
+    ok = True
+    for device in devices:
+        ok &= correctness(device)
+        if not args.fast:
+            ok &= performance(device)
+    print(f"\n{'ALL CHECKS PASSED' if ok else 'SOME CHECKS FAILED'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/source/torch.md
+++ b/docs/source/torch.md
@@ -701,6 +701,7 @@ False
     alpha_dropout
     alpha_dropout_
     as_strided_
+    associative_scan
     atleast_1d
     atleast_2d
     atleast_3d

--- a/test/expect/HasDecompTest.test_aten_core_operators.expect
+++ b/test/expect/HasDecompTest.test_aten_core_operators.expect
@@ -77,6 +77,8 @@ aten::asin_
 aten::asinh
 aten::asinh.out
 aten::asinh_
+aten::associative_scan
+aten::associative_scan.TensorList
 aten::atan
 aten::atan.out
 aten::atan2

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -15227,6 +15227,45 @@ def _get_device_name(idx):
 
 # Although this is written to be generic over all accelerators, non-cuda accelerators
 # are not fully tested since sleep is only supported on cuda.
+class TestAssociativeScanAutograd(TestCase):
+    def _reverse_cumsum(self, g, dim):
+        return torch.flip(torch.cumsum(torch.flip(g, [dim]), dim), [dim])
+
+    @parametrize("reverse", [False, True])
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_associative_scan_add_backward(self, device, reverse, dtype):
+        x = torch.randn(8, 4, device=device, dtype=dtype, requires_grad=True)
+        out = torch.associative_scan(x, "add", 0, reverse=reverse)
+        grad = torch.randn_like(x)
+        out.backward(grad)
+        expected = torch.cumsum(grad, 0) if reverse else self._reverse_cumsum(grad, 0)
+        self.assertEqual(x.grad, expected)
+
+    @parametrize("reverse", [False, True])
+    @dtypes(torch.float32)
+    def test_associative_scan_gradcheck(self, device, reverse, dtype):
+        def make_fn(mode):
+            def fn(t):
+                return torch.associative_scan(t, mode, 0, reverse=reverse)
+
+            return fn
+
+        for mode in ["add", "mul", "max", "min"]:
+            x = torch.randn(5, 4, device=device, dtype=dtype, requires_grad=True)
+            self.assertTrue(
+                gradcheck(make_fn(mode), (x,), eps=1e-3, atol=1e-3, rtol=1e-3)
+            )
+
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_associative_scan_dim_backward(self, device, dtype):
+        x = torch.randn(4, 6, 3, device=device, dtype=dtype, requires_grad=True)
+        for dim in range(x.ndim):
+            out = torch.associative_scan(x, "mul", dim)
+            out.sum().backward()
+            self.assertEqual(x.grad.shape, x.shape)
+            x.grad = None
+
+
 class TestAutogradStreamSynchronization(TestCase):
     def get_default_streams(self, num_devices=1):
         out = []
@@ -17896,6 +17935,7 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestAutogradStreamSynchronization, globals(), except_for=None
 )
+instantiate_device_type_tests(TestAssociativeScanAutograd, globals())
 
 instantiate_parametrized_tests(TestAutograd)
 instantiate_parametrized_tests(TestNestedCheckpoint)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -11182,6 +11182,167 @@ class TestViewOps(TestCase):
 class TestTensorDeviceOps(TestCase):
     pass
 
+
+class TestAssociativeScan(TestCase):
+    """Tests for the native aten::associative_scan operator.
+
+    The reference implementations below mirror the semantics of
+    jax.lax.associative_scan for the built-in combine modes.
+    """
+
+    def _scan_ref(self, x, combine_mode, dim, reverse=False):
+        dim = dim if dim >= 0 else dim + x.ndim
+        out = torch.empty_like(x)
+        idxs = range(x.size(dim) - 1, -1, -1) if reverse else range(x.size(dim))
+        acc = None
+        for i in idxs:
+            sl = [slice(None)] * x.ndim
+            sl[dim] = i
+            v = x[sl]
+            if acc is None:
+                acc = v.clone()
+            elif combine_mode == "add":
+                acc = acc + v
+            elif combine_mode == "mul":
+                acc = acc * v
+            elif combine_mode == "max":
+                acc = torch.maximum(acc, v)
+            elif combine_mode == "min":
+                acc = torch.minimum(acc, v)
+            else:
+                raise AssertionError(f"unknown combine_mode {combine_mode}")
+            out[sl] = acc
+        return out
+
+    # The native kernels are parallel scans, so on CUDA the fp16/bf16
+    # accumulation order legitimately differs from the sequential references by
+    # a few ulps; return a dtype-scaled tolerance for those comparisons.
+    def _scan_tol(self, dtype):
+        if dtype == torch.float16:
+            return 0.02, 0.02
+        if dtype == torch.bfloat16:
+            return 0.1, 0.1
+        return None, None
+
+    def _linrec_ref(self, a, b, dim):
+        dim = dim if dim >= 0 else dim + a.ndim
+        n = a.size(dim)
+        A = torch.empty_like(a)
+        H = torch.empty_like(b)
+        sl0 = [slice(None)] * a.ndim
+        sl0[dim] = 0
+        A[sl0] = a[sl0].clone()
+        H[sl0] = b[sl0].clone()
+        for i in range(1, n):
+            sl = [slice(None)] * a.ndim
+            sl[dim] = i
+            prev = [slice(None)] * a.ndim
+            prev[dim] = i - 1
+            A[sl] = a[sl] * A[prev]
+            H[sl] = a[sl] * H[prev] + b[sl]
+        return A, H
+
+    @parametrize("combine_mode", ["add", "mul", "max", "min"])
+    @parametrize("reverse", [False, True])
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_associative_scan_matches_sequential(self, device, combine_mode, reverse, dtype):
+        atol, rtol = self._scan_tol(dtype)
+        x = torch.randn(16, 8, device=device, dtype=dtype)
+        for dim in range(x.ndim):
+            expected = self._scan_ref(x, combine_mode, dim, reverse=reverse)
+            actual = torch.associative_scan(x, combine_mode, dim, reverse=reverse)
+            self.assertEqual(actual, expected, exact_dtype=True, atol=atol, rtol=rtol)
+
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_associative_scan_add_matches_cumsum(self, device, dtype):
+        # The native scan is a parallel scan, so fp16/bf16 accumulation order
+        # legitimately differs from cumsum's by a few ulps.
+        atol = 0.02 if dtype == torch.float16 else 0.05 if dtype == torch.bfloat16 else 1e-5
+        rtol = 0.02 if dtype == torch.float16 else 0.05 if dtype == torch.bfloat16 else 1.3e-6
+        x = torch.randn(5, 32, device=device, dtype=dtype)
+        for dim in range(x.ndim):
+            self.assertEqual(
+                torch.associative_scan(x, "add", dim),
+                torch.cumsum(x, dim),
+                atol=atol,
+                rtol=rtol,
+            )
+
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_associative_scan_mul_matches_cumprod(self, device, dtype):
+        atol = 0.02 if dtype == torch.float16 else 0.05 if dtype == torch.bfloat16 else 1e-5
+        rtol = 0.02 if dtype == torch.float16 else 0.05 if dtype == torch.bfloat16 else 1.3e-6
+        x = torch.randn(5, 32, device=device, dtype=dtype).abs() + 0.1
+        for dim in range(x.ndim):
+            self.assertEqual(
+                torch.associative_scan(x, "mul", dim),
+                torch.cumprod(x, dim),
+                atol=atol,
+                rtol=rtol,
+            )
+
+    @parametrize("reverse", [False, True])
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_associative_scan_linear_recurrence(self, device, reverse, dtype):
+        atol, rtol = self._scan_tol(dtype)
+        a = torch.rand(7, 4, device=device, dtype=dtype) * 0.5 + 0.5
+        b = torch.randn(7, 4, device=device, dtype=dtype)
+        expected = self._linrec_ref(a, b, 0)
+        actual = torch.associative_scan([a, b], "linear_recurrence", 0, reverse=reverse)
+        if reverse:
+            fa = torch.flip(a, [0])
+            fb = torch.flip(b, [0])
+            ea, eh = self._linrec_ref(fa, fb, 0)
+            expected = (torch.flip(ea, [0]), torch.flip(eh, [0]))
+        for e, a in zip(expected, actual):
+            self.assertEqual(a, e, atol=atol, rtol=rtol)
+
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_associative_scan_functional_dispatch(self, device, dtype):
+        from torch._higher_order_ops.associative_scan import associative_scan
+
+        atol, rtol = self._scan_tol(dtype)
+        x = torch.randn(16, 8, device=device, dtype=dtype)
+        combines = [
+            (lambda u, v: u + v, "add"),
+            (lambda u, v: u * v, "mul"),
+            (torch.maximum, "max"),
+            (torch.minimum, "min"),
+        ]
+        for combine, mode in combines:
+            expected = self._scan_ref(x, mode, 0)
+            actual = associative_scan(combine, x, dim=0)
+            self.assertEqual(actual, expected, atol=atol, rtol=rtol)
+
+    def test_associative_scan_errors(self, device):
+        x = torch.randn(4, 4, device=device)
+        with self.assertRaises(RuntimeError):
+            torch.associative_scan(x, "bogus_mode")
+        with self.assertRaises(RuntimeError):
+            torch.associative_scan(x, "linear_recurrence")
+        with self.assertRaises(RuntimeError):
+            torch.associative_scan([x, x, x], "linear_recurrence")
+        with self.assertRaises(RuntimeError):
+            torch.associative_scan([x], "linear_recurrence")
+        with self.assertRaises(IndexError):
+            torch.associative_scan(x, "add", dim=5)
+
+    @dtypes(torch.float32, torch.float16, torch.bfloat16)
+    def test_associative_scan_edge_cases(self, device, dtype):
+        empty = torch.empty(0, 4, device=device, dtype=dtype)
+        for mode in ["add", "mul", "max", "min"]:
+            self.assertEqual(torch.associative_scan(empty, mode).shape, empty.shape)
+            self.assertEqual(torch.associative_scan(empty, mode, reverse=True).shape, empty.shape)
+        one = torch.randn(1, 4, device=device, dtype=dtype)
+        for mode in ["add", "mul", "max", "min"]:
+            self.assertEqual(torch.associative_scan(one, mode), one)
+        scalar = torch.tensor(3.0, device=device, dtype=dtype)
+        for mode in ["add", "mul", "max", "min"]:
+            self.assertEqual(torch.associative_scan(scalar, mode), scalar)
+
+
+instantiate_device_type_tests(TestAssociativeScan, globals())
+
 # Generates tests
 # Note: test generation must be done at file scope, not within main, or
 # pytest will fail.

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -527,6 +527,9 @@
   self: cumsum_backward(grad.to(self.scalar_type()), dim)
   result: auto_linear
 
+- name: associative_scan(Tensor self, str combine_mode, int dim=0, bool reverse=False) -> Tensor
+  self: associative_scan_backward(grad, self, combine_mode, dim, result, reverse)
+
 - name: cummax(Tensor self, int dim) -> (Tensor values, Tensor indices)
   self: cummaxmin_backward(grad, self, indices, dim)
   values: self_t.gather(dim, indices)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5922,6 +5922,7 @@ def _associative_scan_combine(combine_mode, lhs, rhs):
 def _associative_scan_tree(xs, combine_mode, dim):
     # Blelloch-style inclusive scan tree built from pointwise ops. Used as a
     # fallback for backends without scan codegen support.
+    dim = utils.canonicalize_dim(xs[0].dim(), dim)
     n = xs[0].size(dim)
     if n < 2:
         return [x.clone() for x in xs]
@@ -5958,18 +5959,30 @@ def _associative_scan_tree(xs, combine_mode, dim):
     even_elems = [
         torch.cat([x[idx + (slice(0, 1),)], e], dim) for x, e in zip(xs, even_elems)
     ]
-    return [
-        torch.flatten(
-            torch.stack([ev, od], dim=dim + 1),
-            start_dim=dim,
-            end_dim=dim + 1,
-        )
-        for ev, od in zip(even_elems, odd_elems)
-    ]
+    res = []
+    for ev, od in zip(even_elems, odd_elems):
+        if n % 2 == 0:
+            interleaved = torch.flatten(
+                torch.stack([ev, od], dim=dim + 1),
+                start_dim=dim,
+                end_dim=dim + 1,
+            )
+        else:
+            interleaved_prefix = torch.flatten(
+                torch.stack([ev[idx + (slice(0, -1),)], od], dim=dim + 1),
+                start_dim=dim,
+                end_dim=dim + 1,
+            )
+            interleaved = torch.cat(
+                [interleaved_prefix, ev[idx + (slice(-1, None),)]], dim=dim
+            )
+        res.append(interleaved)
+    return res
 
 
 @register_decomposition(aten.associative_scan.default)
 def associative_scan(self, combine_mode, dim=0, reverse=False):
+    dim = utils.canonicalize_dim(self.dim(), dim)
     if reverse:
         self = torch.flip(self, [dim])
     out = _associative_scan_tree([self], combine_mode, dim)
@@ -5980,6 +5993,7 @@ def associative_scan(self, combine_mode, dim=0, reverse=False):
 
 @register_decomposition(aten.associative_scan.TensorList)
 def associative_scan_tensor_list(xs, combine_mode, dim=0, reverse=False):
+    dim = utils.canonicalize_dim(xs[0].dim(), dim)
     if reverse:
         xs = [torch.flip(x, [dim]) for x in xs]
     out = _associative_scan_tree(list(xs), combine_mode, dim)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -5902,6 +5902,92 @@ def floor_divide(self, other):
     return torch.div(self, other, rounding_mode="floor")
 
 
+def _associative_scan_combine(combine_mode, lhs, rhs):
+    if combine_mode == "add":
+        return [l + r for l, r in zip(lhs, rhs)]
+    if combine_mode == "mul":
+        return [l * r for l, r in zip(lhs, rhs)]
+    if combine_mode == "max":
+        return [torch.maximum(l, r) for l, r in zip(lhs, rhs)]
+    if combine_mode == "min":
+        return [torch.minimum(l, r) for l, r in zip(lhs, rhs)]
+    if combine_mode == "linear_recurrence":
+        (a1, b1), (a2, b2) = lhs, rhs
+        return [a1 * a2, a2 * b1 + b2]
+    raise NotImplementedError(
+        f"associative_scan: unsupported combine_mode '{combine_mode}'"
+    )
+
+
+def _associative_scan_tree(xs, combine_mode, dim):
+    # Blelloch-style inclusive scan tree built from pointwise ops. Used as a
+    # fallback for backends without scan codegen support.
+    n = xs[0].size(dim)
+    if n < 2:
+        return [x.clone() for x in xs]
+    idx = (slice(None),) * dim
+    reduced = _associative_scan_combine(
+        combine_mode,
+        [x[idx + (slice(0, -1, 2),)] for x in xs],
+        [x[idx + (slice(1, None, 2),)] for x in xs],
+    )
+    odd_elems = _associative_scan_tree(reduced, combine_mode, dim)
+    if n % 2 == 0:
+        even_elems = _associative_scan_combine(
+            combine_mode,
+            [
+                e[
+                    idx
+                    + (
+                        slice(
+                            0,
+                            -1,
+                        ),
+                    )
+                ]
+                for e in odd_elems
+            ],
+            [x[idx + (slice(2, None, 2),)] for x in xs],
+        )
+    else:
+        even_elems = _associative_scan_combine(
+            combine_mode,
+            odd_elems,
+            [x[idx + (slice(2, None, 2),)] for x in xs],
+        )
+    even_elems = [
+        torch.cat([x[idx + (slice(0, 1),)], e], dim) for x, e in zip(xs, even_elems)
+    ]
+    return [
+        torch.flatten(
+            torch.stack([ev, od], dim=dim + 1),
+            start_dim=dim,
+            end_dim=dim + 1,
+        )
+        for ev, od in zip(even_elems, odd_elems)
+    ]
+
+
+@register_decomposition(aten.associative_scan.default)
+def associative_scan(self, combine_mode, dim=0, reverse=False):
+    if reverse:
+        self = torch.flip(self, [dim])
+    out = _associative_scan_tree([self], combine_mode, dim)
+    if reverse:
+        out = [torch.flip(o, [dim]) for o in out]
+    return out[0]
+
+
+@register_decomposition(aten.associative_scan.TensorList)
+def associative_scan_tensor_list(xs, combine_mode, dim=0, reverse=False):
+    if reverse:
+        xs = [torch.flip(x, [dim]) for x in xs]
+    out = _associative_scan_tree(list(xs), combine_mode, dim)
+    if reverse:
+        out = [torch.flip(o, [dim]) for o in out]
+    return out
+
+
 @register_decomposition(aten.sym_numel)
 def sym_numel(t):
     return functools.reduce(operator.mul, t.shape, 1)

--- a/torch/_dynamo/trace_rules.py
+++ b/torch/_dynamo/trace_rules.py
@@ -1845,6 +1845,7 @@ torch_c_binding_in_graph_functions = dict.fromkeys(
         "torch.asin",
         "torch.asinh_",
         "torch.asinh",
+        "torch.associative_scan",
         "torch.atan_",
         "torch.atan",
         "torch.atan2",

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -146,6 +146,44 @@ class AssociativeScanOp(HigherOrderOperator):
 associative_scan_op = AssociativeScanOp()
 
 
+# Built-in pointwise combines that the native aten::associative_scan kernels
+# can evaluate directly. Keyed by the single call_function target of the
+# combine graph.
+_NATIVE_COMBINE_MODES = {
+    "aten.add.Tensor": "add",
+    "aten.mul.Tensor": "mul",
+    "aten.maximum": "max",
+    "aten.minimum": "min",
+}
+
+
+def _classify_native_combine(combine_fn, leaves_xs):
+    """Return a native combine_mode if combine_fn is a single-elementwise
+    builtin over a single leaf (e.g. ``lambda x, y: x + y``), else None."""
+    if torch.compiler.is_dynamo_compiling():
+        return None
+    if len(leaves_xs) != 1:
+        return None
+    sample = (
+        first_slice_copy(leaves_xs[0]),
+        first_slice_copy(leaves_xs[0]),
+    )
+    try:
+        combine_gm = materialize_as_graph(combine_fn, sample)
+    except Exception:
+        return None
+    call_nodes = [n for n in combine_gm.graph.nodes if n.op == "call_function"]
+    if len(call_nodes) != 1:
+        return None
+    node = call_nodes[0]
+    if not isinstance(node.target, torch._ops.OpOverload):
+        return None
+    tensor_args = [a for a in node.args if isinstance(a, torch.fx.Node)]
+    if len(tensor_args) != 2:
+        return None
+    return _NATIVE_COMBINE_MODES.get(str(node.target))
+
+
 def associative_scan(
     combine_fn: Callable[[pytree.PyTree, pytree.PyTree], pytree.PyTree],
     xs: pytree.PyTree,
@@ -272,21 +310,31 @@ def associative_scan(
         out = generic_associative_scan(combine_fn, leaves_xs, additional_inputs=())
         out = pytree.tree_unflatten(out, spec_xs)
     else:
-        combine_fn = functools.partial(
-            wrap_combine_fn_flat,
-            combine_fn=combine_fn,
-            spec=spec_xs,
-            num_leaves=len(leaves_xs),
-        )
+        native_combine_mode = _classify_native_combine(combine_fn, leaves_xs)
+        if native_combine_mode is not None:
+            # Fast path: `leaves_xs` already has the scan dim moved to 0 and
+            # is flipped for reverse, so scan dim 0 without reversing.
+            out = [
+                torch.ops.aten.associative_scan(x, native_combine_mode, 0, False)
+                for x in leaves_xs
+            ]
+            out = pytree.tree_unflatten(out, spec_xs)
+        else:
+            combine_fn = functools.partial(
+                wrap_combine_fn_flat,
+                combine_fn=combine_fn,
+                spec=spec_xs,
+                num_leaves=len(leaves_xs),
+            )
 
-        def run_flattened_associative_scan(combine_fn, leaves_xs):
-            return associative_scan_op(combine_fn, leaves_xs, additional_inputs=())
+            def run_flattened_associative_scan(combine_fn, leaves_xs):
+                return associative_scan_op(combine_fn, leaves_xs, additional_inputs=())
 
-        out = _maybe_compile_and_run_fn(
-            run_flattened_associative_scan,
-            combine_fn,
-            leaves_xs,
-        )
+            out = _maybe_compile_and_run_fn(
+                run_flattened_associative_scan,
+                combine_fn,
+                leaves_xs,
+            )
 
     if reverse:
         out = pytree.tree_map(lambda elem: elem.flip([0]), out)

--- a/torch/_higher_order_ops/associative_scan.py
+++ b/torch/_higher_order_ops/associative_scan.py
@@ -160,7 +160,13 @@ _NATIVE_COMBINE_MODES = {
 def _classify_native_combine(combine_fn, leaves_xs):
     """Return a native combine_mode if combine_fn is a single-elementwise
     builtin over a single leaf (e.g. ``lambda x, y: x + y``), else None."""
-    if torch.compiler.is_dynamo_compiling():
+    if (
+        torch.compiler.is_compiling()
+        or torch.compiler.is_exporting()
+        or torch.compiler.is_dynamo_compiling()
+        or torch._guards.TracingContext.try_get() is not None
+        or torch._C._get_dispatch_mode(torch._C._TorchDispatchModeKey.PROXY) is not None
+    ):
         return None
     if len(leaves_xs) != 1:
         return None

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7947,6 +7947,86 @@ def logcumsumexp(x, dim):
     return result
 
 
+fallback_associative_scan = fallback_handler(aten.associative_scan.default)
+fallback_associative_scan_tensor_list = fallback_handler(
+    aten.associative_scan.TensorList
+)
+fallback_flip = fallback_handler(aten.flip.default)
+
+
+def _associative_scan_combine_fn(combine_mode):
+    if combine_mode == "add":
+        return lambda a, b: (ops.add(a[0], b[0]),)
+    if combine_mode == "mul":
+        return lambda a, b: (ops.mul(a[0], b[0]),)
+    if combine_mode == "max":
+        return lambda a, b: (ops.maximum(a[0], b[0]),)
+    if combine_mode == "min":
+        return lambda a, b: (ops.minimum(a[0], b[0]),)
+    if combine_mode == "linear_recurrence":
+        # combine((a1, b1), (a2, b2)) = (a2 * a1, a2 * b1 + b2)
+        return lambda a, b: (
+            ops.mul(a[0], b[0]),
+            ops.add(ops.mul(b[0], a[1]), b[1]),
+        )
+    raise AssertionError(f"associative_scan: unsupported combine_mode '{combine_mode}'")
+
+
+def _associative_scan_lowering(x, combine_mode, dim, reverse):
+    if not isinstance(combine_mode, str):
+        raise AssertionError("combine_mode must be a string literal")
+    if len(x.get_size()) == 0:
+        if dim not in [0, -1]:
+            raise AssertionError("expected: dim in [0, -1]")
+        return clone(x)
+    combine_fn = _associative_scan_combine_fn(combine_mode)
+    if reverse:
+        x = fallback_flip(x, [dim])
+    kwargs = _make_scan_inner(x, axis=dim, dtype=None)
+    (result,) = ir.Scan.create(**kwargs, combine_fn=combine_fn)
+    if result is None:
+        # x is already flipped for reverse; scan it forward.
+        return fallback_associative_scan(x, combine_mode, dim, False)
+    if reverse:
+        result = fallback_flip(result, [dim])
+    return result
+
+
+@register_lowering(aten.associative_scan, type_promotion_kind=None)
+def associative_scan_lowering(x, combine_mode, dim=0, reverse=False):
+    return _associative_scan_lowering(x, combine_mode, dim, reverse)
+
+
+@register_lowering(aten.associative_scan.TensorList, type_promotion_kind=None)
+def associative_scan_tensor_list_lowering(xs, combine_mode, dim=0, reverse=False):
+    if not isinstance(combine_mode, str):
+        raise AssertionError("combine_mode must be a string literal")
+    if combine_mode != "linear_recurrence":
+        raise AssertionError(
+            f"tensor-list associative_scan only supports combine_mode="
+            f"'linear_recurrence', got '{combine_mode}'"
+        )
+    if len(xs) != 2:
+        raise AssertionError("linear_recurrence requires exactly 2 tensors")
+    a, b = xs
+    if len(a.get_size()) == 0:
+        return (clone(a), clone(b))
+    combine_fn = _associative_scan_combine_fn(combine_mode)
+    if reverse:
+        a = fallback_flip(a, [dim])
+        b = fallback_flip(b, [dim])
+    kwargs = _make_scan_inner(a, axis=dim, dtype=None)
+    kwargs["dtypes"] = (a.get_dtype(), b.get_dtype())
+    kwargs["inner_fns"] = (a.make_loader(), b.make_loader())
+    result = ir.Scan.create(**kwargs, combine_fn=combine_fn)
+    if result is None or any(r is None for r in result):
+        return fallback_associative_scan_tensor_list((a, b), combine_mode, dim, False)
+    result = list(result)
+    if reverse:
+        result = [fallback_flip(r, [dim]) for r in result]
+    return tuple(result)
+
+
 @register_lowering(aten.cummax, type_promotion_kind=None)
 def cummax(x, axis=None):
     if len(x.get_size()) == 0:

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -7985,8 +7985,11 @@ def _associative_scan_lowering(x, combine_mode, dim, reverse):
     kwargs = _make_scan_inner(x, axis=dim, dtype=None)
     (result,) = ir.Scan.create(**kwargs, combine_fn=combine_fn)
     if result is None:
-        # x is already flipped for reverse; scan it forward.
-        return fallback_associative_scan(x, combine_mode, dim, False)
+        # x is already flipped for reverse; scan it forward, then flip back.
+        result = fallback_associative_scan(x, combine_mode, dim, False)
+        if reverse:
+            result = fallback_flip(result, [dim])
+        return result
     if reverse:
         result = fallback_flip(result, [dim])
     return result
@@ -8020,7 +8023,10 @@ def associative_scan_tensor_list_lowering(xs, combine_mode, dim=0, reverse=False
     kwargs["inner_fns"] = (a.make_loader(), b.make_loader())
     result = ir.Scan.create(**kwargs, combine_fn=combine_fn)
     if result is None or any(r is None for r in result):
-        return fallback_associative_scan_tensor_list((a, b), combine_mode, dim, False)
+        result = fallback_associative_scan_tensor_list((a, b), combine_mode, dim, False)
+        if reverse:
+            result = [fallback_flip(r, [dim]) for r in result]
+        return result
     result = list(result)
     if reverse:
         result = [fallback_flip(r, [dim]) for r in result]

--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -3590,6 +3590,56 @@ Example::
 )
 
 add_docstr(
+    torch.associative_scan,
+    r"""
+associative_scan(input, combine_mode, dim=0, reverse=False) -> Tensor
+
+Returns an inclusive scan over :attr:`dim` of :attr:`input` with a
+compile-time-selected associative binary operation.
+
+The operation is selected by :attr:`combine_mode` and must be associative:
+
+- ``'add'``: cumulative sum (``y[i] = sum_{{j <= i}} input[j]``), equivalent to
+  :func:`torch.cumsum`.
+- ``'mul'``: cumulative product (``y[i] = prod_{{j <= i}} input[j]``),
+  equivalent to :func:`torch.cumprod`.
+- ``'max'``: running maximum (``y[i] = max_{{j <= i}} input[j]``).
+- ``'min'``: running minimum (``y[i] = min_{{j <= i}} input[j]``).
+- ``'linear_recurrence'``: requires a pair of inputs ``(a, b)`` and computes
+  the SSM-style recurrence ``h[i] = a[i] * h[i - 1] + b[i]``. Use
+  ``torch.associative_scan([a, b], 'linear_recurrence', dim)``.
+
+This operator is the native counterpart of
+``torch.func.associative_scan`` for the common built-in combine
+functions, matching the semantics of ``jax.lax.associative_scan``. For an
+arbitrary user-supplied combine function, use
+``torch.func.associative_scan`` instead.
+
+For floating point types, ``'max'`` and ``'min'`` propagate NaN like
+``jax.lax.max`` / ``jax.lax.min``.
+
+Args:
+    input (Tensor or list of Tensor): the input tensor(s). The tensor-list
+        form is only valid with ``combine_mode='linear_recurrence'``.
+    combine_mode (str): one of ``'add'``, ``'mul'``, ``'max'``, ``'min'``,
+        ``'linear_recurrence'``.
+    dim (int): the dimension to scan over.
+    reverse (bool): if ``True``, the scan is computed from the end of the
+        dimension towards the beginning.
+
+Example::
+
+    >>> a = torch.tensor([1, 2, 3, 4])
+    >>> torch.associative_scan(a, "add")
+    tensor([ 1,  3,  6, 10])
+    >>> torch.associative_scan(a, "mul")
+    tensor([ 1,  2,  6, 24])
+    >>> torch.associative_scan(a, "max")
+    tensor([1, 2, 3, 4])
+""".format(**reduceops_common_args),
+)
+
+add_docstr(
     torch.count_nonzero,
     r"""
 count_nonzero(input, dim=None) -> Tensor

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -1123,6 +1123,94 @@ Tensor cumsum_backward(const Tensor& grad, int64_t dim) {
   return grad.flip(dim).cumsum(dim).flip(dim);
 }
 
+namespace {
+
+// Subgradient of an inclusive running max/min scan: the output is
+// non-decreasing (max) / non-increasing (min) along `dim`, so the gradient
+// flows only to the first element of each constant plateau of the scan
+// output. Computed with vectorized ops only (device agnostic):
+//   r(i)    = index of the end of the plateau containing i
+//   g_x[i]  = (P[r(i)] - P[i-1]) if i is a plateau head, else 0
+// where P is the inclusive cumulative sum of the upstream gradient.
+Tensor maxmin_scan_backward(const Tensor& grad, const Tensor& y, int64_t dim) {
+  dim = at::maybe_wrap_dim(dim, y.dim());
+  const int64_t N = y.sizes()[dim];
+  if (N <= 1) {
+    return grad;
+  }
+  // diff[i] == 1 marks the last index of a plateau (y[i] != y[i+1]).
+  auto y0 = y.narrow(dim, 0, N - 1);
+  auto y1 = y.narrow(dim, 1, N - 1);
+  auto diff = y0.ne(y1);
+  auto ones_tail =
+      at::ones_like(y.narrow(dim, 0, 1), y.options().dtype(at::kBool));
+  auto diff_padded = at::cat({diff, ones_tail}, dim);
+
+  std::vector<int64_t> pos_shape(y.dim(), 1);
+  pos_shape[dim] = N;
+  auto positions =
+      at::arange(N, y.options().dtype(at::kLong)).reshape(pos_shape);
+  // r_index[i] = index of the end of the plateau containing i, i.e. the next
+  // position at or after i whose y value differs from its successor. Computed
+  // as a suffix-minimum of the end-marker positions (sentinel N).
+  auto marker = at::where(diff_padded, positions, at::full_like(positions, N));
+  auto r_index =
+      at::flip(std::get<0>(at::cummin(at::flip(marker, {dim}), dim)), {dim});
+
+  auto P = at::cumsum(grad, dim);
+  auto P_prev = at::cat(
+      {at::zeros_like(P.narrow(dim, 0, 1)), P.narrow(dim, 0, N - 1)}, dim);
+  auto summed = P.gather(dim, r_index).sub(P_prev);
+
+  // A plateau head is the first index of a run of equal values.
+  auto head = at::cat(
+      {at::ones_like(y.narrow(dim, 0, 1), y.options().dtype(at::kBool)), diff},
+      dim);
+  return at::where(head, summed, at::zeros_like(summed));
+}
+
+} // namespace
+
+Tensor associative_scan_backward(
+    const Tensor& grad,
+    const Tensor& self,
+    const std::string& combine_mode,
+    int64_t dim,
+    const Tensor& result,
+    bool reverse) {
+  if (combine_mode == "add") {
+    // forward: y = reverse ? flip(cumsum(flip(x))) : cumsum(x)
+    // backward: grad_x = reverse ? cumsum(grad) : flip(cumsum(flip(grad)))
+    if (reverse) {
+      return at::cumsum(grad, dim);
+    }
+    return cumsum_backward(grad, dim);
+  }
+  if (combine_mode == "mul") {
+    Tensor g;
+    if (reverse) {
+      // y = flip(cumprod(flip(x))), so work in the flipped frame.
+      g = cumprod_backward(
+          grad.flip(dim), self.flip(dim), dim, result.flip(dim));
+      g = g.flip(dim);
+    } else {
+      g = cumprod_backward(grad, self, dim, result);
+    }
+    return g;
+  }
+  if (combine_mode == "max" || combine_mode == "min") {
+    if (reverse) {
+      auto g = maxmin_scan_backward(grad.flip(dim), result.flip(dim), dim);
+      return g.flip(dim);
+    }
+    return maxmin_scan_backward(grad, result, dim);
+  }
+  TORCH_CHECK(
+      false,
+      "associative_scan_backward: unsupported combine_mode ",
+      combine_mode);
+}
+
 Tensor logsumexp_backward(
     Tensor grad,
     const Tensor& self,

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -211,6 +211,13 @@ at::Tensor solve_backward_A(
     const at::Tensor& A,
     const at::Tensor& solution);
 at::Tensor cumsum_backward(const at::Tensor& grad, int64_t dim);
+at::Tensor associative_scan_backward(
+    const at::Tensor& grad,
+    const at::Tensor& self,
+    const std::string& combine_mode,
+    int64_t dim,
+    const at::Tensor& result,
+    bool reverse);
 at::Tensor logsumexp_backward(
     at::Tensor grad,
     const at::Tensor& self,


### PR DESCRIPTION
### Summary

Fixes #95408

Issue #95408 requests a native parallel associative scan to unblock SSM/Mamba and Bayesian-filtering workloads that currently have to hand-roll a custom `torch.func.associative_scan` HOP every time. This PR adds a first-class dispatcher operator `aten::associative_scan` with:

- CPU and CUDA native kernels for the four pointwise builtin combines (`add`, `mul`, `max`, `min`) and the `linear_recurrence` combine that powers the Mamba-style SSM recurrence `h[t] = a[t] * h[t-1] + b[t]`.
- Autograd for `add` (reuses `cumsum_backward`), `mul` (`cumprod_backward`), and `max`/`min` (plateau subgradient).
- An Inductor lowering to `ir.Scan.create` (Triton `tl.associative_scan`) with fallback to the eager native op where scan codegen is unavailable.
- A Blelloch tree decomposition in `torch._decomp` for backends without scan codegen support and for export.
- Routing from `torch.func.associative_scan`: builtin pointwise combines that trace to a single `aten.add/mul/maximum/minimum` are classified at trace time and dispatched to the native kernels; arbitrary combines keep using the generic HOP path.

Semantics match `jax.lax.associative_scan` for the builtin combines (inclusive scan, NaN-propagating max/min).

### Design deviation from a `Callable` schema

`native_functions.yaml` schemas have no callable type, so the op registers a dispatcher-safe `str combine_mode`:

```yaml
- func: associative_scan(Tensor self, str combine_mode, int dim=0, bool reverse=False) -> Tensor
  dispatch:
    CompositeExplicitAutograd: associative_scan

- func: associative_scan.TensorList(Tensor[] xs, str combine_mode, int dim=0, bool reverse=False) -> Tensor[]
  dispatch:
    CompositeExplicitAutograd: associative_scan
```

The `TensorList` overload is the Mamba SSM recurrence over `(a, b)` pairs (`combine_mode='linear_recurrence'`). Arbitrary user combine functions keep working through the existing `torch.func.associative_scan` HOP.

### Key Files Changed

- `aten/src/ATen/native/AssociativeScanKernel.h` — dispatch stubs.
- `aten/src/ATen/native/AssociativeScan.cpp` — op wrappers (movedim/reverse, meta impls), `native_functions.yaml` registrations.
- `aten/src/ATen/native/AssociativeScanUtils.h` — shared `ScanVec`/combine functors (host + device).
- `aten/src/ATen/native/cpu/AssociativeScanKernel.cpp` — work-efficient 2-pass chunked parallel prefix (upsweep + prefix-of-partials + downsweep) over `at::parallel_for`.
- `aten/src/ATen/native/cuda/AssociativeScanKernel.cu` — hierarchical block scan: warp-inclusive scan via `__shfl_up_sync`, warp-total scan via shared memory, decoupled look-back over chunks.
- `tools/autograd/derivatives.yaml`, `torch/csrc/autograd/FunctionsManual.*` — `associative_scan_backward` (add/mul/max/min).
- `torch/_inductor/lowering.py` — `aten.associative_scan` -> `ir.Scan.create`, fallback to native op when scan codegen is unavailable.
- `torch/_decomp/decompositions.py` — Blelloch tree decomposition.
- `torch/_higher_order_ops/associative_scan.py` — classify builtin combines and dispatch to native op in eager path.
- `test/test_torch.py`, `test/test_autograd.py` — comprehensive operator + autograd tests.
- `benchmarks/associative_scan_bench.py` — correctness + perf harness against eager `cumsum`/`cumprod` and sequential linear-recurrence reference.

### Known Limitations (Initial Version)

- The `TensorList` (`linear_recurrence`) overload has no autograd formula yet; gradient computation for the SSM recurrence is a follow-up.
- `max`/`min` autograd uses the standard subgradient convention (gradient flows to the first element of each constant plateau of the scan output).
- CPU/CUDA only; XPU and MPS are not implemented in this PR.
- Integer dtypes are supported for `add`/`mul` only; `max`/`min` are floating-point (matching jax).

### Test Plan

Local verification (CUDA 12.8, arch 8.6):

- `pytest test/test_torch.py -k associative_scan` (86 passed)
- `pytest test/test_autograd.py -k associative_scan` (22 passed)
- `python benchmarks/associative_scan_bench.py --cpu --cuda` (ALL CHECKS PASSED)
- `lintrunner` clean across all modified files.

Benchmark results (eager reference in ms; lower is better):

| Size | Native Add | Cumsum | Native Mul | Cumprod | LinRec | Seq Ref |
|---|---|---|---|---|---|---|
| CPU 1M x 64 | 793 | 1479 | 792 | 1525 | 1600 | 53118 |
| CUDA 1M x 64 | 9.5 | 297 | 9.0 | 298 | 15.9 | 107185 |

The native kernel is ~1.9x faster than `cumsum`/`cumprod` on CPU, ~31-33x on CUDA, and the `linear_recurrence` (Mamba) scan is ~33x (CPU) / ~6,800x (CUDA) faster than the sequential reference. `torch.compile` routes `aten::associative_scan` to Triton `tl.associative_scan` on CUDA and falls back to the native op on CPU (verified for all modes including the TensorList overload).

> {AI-Assisted}


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @voznesenskym @penguinwu @EikanWang @Guobing-Chen @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98