### PR TITLE
[typing] Reject Tensor @ scalar at type-check time

### DIFF
--- a/test/typing/pass/arithmetic_ops.py
+++ b/test/typing/pass/arithmetic_ops.py
@@ -149,11 +149,11 @@ assert_type(FLOAT**TENSOR, Tensor)
 
 # Operator @
 assert_type(TENSOR @ TENSOR, Tensor)
-assert_type(TENSOR @ BOOL, Tensor)  # Should fail type checking
+assert_type(TENSOR @ BOOL, Tensor)  # type: ignore[operator]
 assert_type(BOOL @ TENSOR, Tensor)  # type: ignore[operator]
-assert_type(TENSOR @ INT, Tensor)  # Should fail type checking
+assert_type(TENSOR @ INT, Tensor)  # type: ignore[operator]
 assert_type(INT @ TENSOR, Tensor)  # type: ignore[operator]
-assert_type(TENSOR @ FLOAT, Tensor)  # Should fail type checking
+assert_type(TENSOR @ FLOAT, Tensor)  # type: ignore[operator]
 assert_type(FLOAT @ TENSOR, Tensor)  # type: ignore[operator]
 
 #

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -200,7 +200,6 @@ arithmetic_ops = (
     "pow",
     "mod",
     "truediv",
-    "matmul",
     "floordiv",
     "radd",
     "rsub",
@@ -215,6 +214,10 @@ arithmetic_ops = (
     "ifloordiv",
     "imod",  # inplace ops
 )
+# `@` is the only binary operator that never accepts a Python scalar: matmul
+# between a Tensor and an int/float/bool raises TypeError at runtime, so it must
+# not be typed like the other arithmetic operators.
+matmul_ops = ("matmul",)
 logic_ops = (
     "and",
     "or",
@@ -226,7 +229,7 @@ logic_ops = (
     "ior",
     "ixor",  # inplace ops
 )
-binary_ops = shift_ops + arithmetic_ops + logic_ops
+binary_ops = shift_ops + arithmetic_ops + matmul_ops + logic_ops
 
 symmetric_comparison_ops = ("eq", "ne")
 asymmetric_comparison_ops = ("ge", "gt", "lt", "le")
@@ -262,6 +265,8 @@ def sig_for_ops(opname: str) -> list[str]:
                 f"def {opname}(self, other: Tensor | Number | _complex) -> Tensor: ...{suffix}"
             ]
         return [f"def {opname}(self, other: Tensor | Number | _complex) -> Tensor: ..."]
+    elif name in matmul_ops:
+        return [f"def {opname}(self, other: Tensor) -> Tensor: ..."]
     elif name in logic_ops:
         return [f"def {opname}(self, other: Tensor | _int) -> Tensor: ..."]
     elif name in shift_ops:


### PR DESCRIPTION
Addresses the `@` half of #157266.

`__matmul__` is grouped with the arithmetic operators in `tools/pyi/gen_pyi.py`, so it is generated as:

```python
def __matmul__(self, other: Tensor | Number | _complex) -> Tensor: ...
```

That accepts a Python scalar. But `@` is the one binary operator that never does — all three of these raise at runtime:

```
>>> t @ 1      TypeError: unsupported operand type(s) for @: 'Tensor' and 'int'
>>> t @ 1.0    TypeError: unsupported operand type(s) for @: 'Tensor' and 'float'
>>> t @ True   TypeError: unsupported operand type(s) for @: 'Tensor' and 'bool'
```

while mypy reports `Success: no issues found`. The issue calls this out directly: *"We also need to consider the special case of `@` with scalars (it should fail), which has been forgotten because it's different."*

## Changes

* Move `matmul` out of `arithmetic_ops` into its own `matmul_ops`, still included in `binary_ops` so `__matmul__` is still generated, and give it `def __matmul__(self, other: Tensor) -> Tensor: ...`.
* The three `TENSOR @ scalar` lines in `test/typing/pass/arithmetic_ops.py` were already annotated `# Should fail type checking`. They now carry `# type: ignore[operator]`, matching their reverse counterparts (`BOOL @ TENSOR` etc.), which have always been rejected correctly.

This is the `@` case only. The `<<`, `>>`, `&`, `|`, `^` cases in the same issue have a different cause — `sig_for_ops` already emits `Tensor | _int` for them, but a second overload generated from the native `Scalar` signatures (`other: Number | _complex | PySymType`) still admits `float`. That needs a separate change and is left out of this PR.

## Test Plan

```
python test/typing/test_typing.py
lintrunner --take MYPY
```

## Test Result

Verified against a `2.15.0.dev20260827` nightly wheel with only the generated `__matmul__` signature narrowed to match this change:

**Stock stub** — the bug:
```
$ mypy check_matmul.py
Success: no issues found in 1 source file
```

**Narrowed stub** — mypy now agrees with the runtime:
```
check_matmul.py:9: error: Unsupported operand types for @ ("Tensor" and "int")  [operator]
check_matmul.py:10: error: Unsupported operand types for @ ("Tensor" and "float")  [operator]
check_matmul.py:11: error: Unsupported operand types for @ ("Tensor" and "bool")  [operator]
Found 3 errors in 1 file
```

And on the typing test itself, under the narrowed stub: the **unmodified** file reports exactly the three `@`-scalar lines as errors (152, 154, 156), and the **updated** file reports `Success: no issues found`.

`ruff==0.14.4` (the version pinned in `tools/linter/adapters/pyfmt_linter.py`): both files already formatted, all checks passed.

---

*AI disclosure (per `AI_POLICY.md`): this change was written with AI assistance. I reviewed the root cause, the fix and the toggle results above; the contribution is not autonomous.*
