### PR TITLE
[inductor] Preserve low-precision rounding before comparisons

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1713,9 +1713,7 @@ class CudaReproTests(TestCase):
             return (maximum == scaled).sum(dim=-1, keepdim=True)
 
         expected = fn(maximum, values)
-        actual = torch.compile(fn, backend="inductor", fullgraph=True)(
-            maximum, values
-        )
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(maximum, values)
 
         self.assertEqual(actual, expected)
         self.assertTrue((actual > 0).all())

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1700,25 +1700,6 @@ class CudaReproTests(TestCase):
         self.assertIn(f".to(tl.{lowp_name})", code)
 
     @parametrize("lowp_dtype", [torch.bfloat16, torch.float16])
-    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
-    @config.patch(emulate_precision_casts=False)
-    def test_lowp_pointwise_rounds_before_comparison(self, lowp_dtype):
-        torch.manual_seed(0)
-        values = torch.randn((6, 4, 1, 33), device=device_type, dtype=lowp_dtype)
-        scale = math.sqrt(32.0)
-        maximum = (values / scale).amax(dim=-1, keepdim=True)
-
-        def fn(maximum, values):
-            scaled = values / scale
-            return (maximum == scaled).sum(dim=-1, keepdim=True)
-
-        expected = fn(maximum, values)
-        actual = torch.compile(fn, backend="inductor", fullgraph=True)(maximum, values)
-
-        self.assertEqual(actual, expected)
-        self.assertTrue((actual > 0).all())
-
-    @parametrize("lowp_dtype", [torch.bfloat16, torch.float16])
     @torch._inductor.config.patch(emulate_precision_casts=True)
     def test_emulate_precision_casts_preserves_explicit_precision_cast(
         self, lowp_dtype

--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -1700,6 +1700,27 @@ class CudaReproTests(TestCase):
         self.assertIn(f".to(tl.{lowp_name})", code)
 
     @parametrize("lowp_dtype", [torch.bfloat16, torch.float16])
+    @unittest.skipIf(not TEST_CUDA, "requires CUDA")
+    @config.patch(emulate_precision_casts=False)
+    def test_lowp_pointwise_rounds_before_comparison(self, lowp_dtype):
+        torch.manual_seed(0)
+        values = torch.randn((6, 4, 1, 33), device=device_type, dtype=lowp_dtype)
+        scale = math.sqrt(32.0)
+        maximum = (values / scale).amax(dim=-1, keepdim=True)
+
+        def fn(maximum, values):
+            scaled = values / scale
+            return (maximum == scaled).sum(dim=-1, keepdim=True)
+
+        expected = fn(maximum, values)
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(
+            maximum, values
+        )
+
+        self.assertEqual(actual, expected)
+        self.assertTrue((actual > 0).all())
+
+    @parametrize("lowp_dtype", [torch.bfloat16, torch.float16])
     @torch._inductor.config.patch(emulate_precision_casts=True)
     def test_emulate_precision_casts_preserves_explicit_precision_cast(
         self, lowp_dtype

--- a/test/inductor/test_low_precision.py
+++ b/test/inductor/test_low_precision.py
@@ -1,0 +1,80 @@
+# Owner(s): ["module: inductor"]
+import math
+
+import torch
+from torch._inductor import config
+from torch._inductor.test_case import TestCase
+from torch._inductor.utils import run_and_get_code
+from torch.testing._internal.common_device_type import (
+    dtypes,
+    dtypesIfCPU,
+    dtypesIfCUDA,
+    dtypesIfXPU,
+    instantiate_device_type_tests,
+    skipXPUIf,
+)
+
+
+class LowPrecisionTest(TestCase):
+    @skipXPUIf(
+        True,
+        "truncf/fpext barriers may be folded (intel-xpu-backend-for-triton#7491)",
+    )
+    @dtypesIfCPU(torch.bfloat16)
+    @dtypesIfCUDA(torch.bfloat16, torch.float16)
+    @dtypesIfXPU(torch.bfloat16, torch.float16)
+    @dtypes(torch.bfloat16, torch.float16)
+    @config.patch(emulate_precision_casts=False)
+    def test_pointwise_rounds_before_comparison(self, device, dtype):
+        torch.manual_seed(0)
+        values = torch.randn((6, 4, 1, 33), device=device, dtype=dtype)
+        scale = math.sqrt(32.0)
+
+        def producer(x):
+            return ((x / scale) * 0.7) * 0.9
+
+        scaled = producer(values)
+        maximum = scaled.amax(dim=-1, keepdim=True)
+
+        def fn(maximum, values):
+            scaled = producer(values)
+            return (maximum == scaled).sum(dim=-1, keepdim=True)
+
+        expected = fn(maximum, values)
+        fused = ((values.float() / scale) * 0.7) * 0.9
+        fused_result = (maximum.float() == fused).sum(dim=-1, keepdim=True)
+        self.assertNotEqual(fused_result, expected)
+
+        actual, (code,) = run_and_get_code(
+            torch.compile(fn, backend="inductor", fullgraph=True), maximum, values
+        )
+        self.assertEqual(actual, expected)
+
+        def compare_realized(maximum, scaled):
+            return (maximum == scaled).sum(dim=-1, keepdim=True)
+
+        actual, (realized_code,) = run_and_get_code(
+            torch.compile(compare_realized, backend="inductor", fullgraph=True),
+            maximum,
+            scaled,
+        )
+        self.assertEqual(actual, compare_realized(maximum, scaled))
+
+        if device == "cuda":
+            lowp_name = "bfloat16" if dtype == torch.bfloat16 else "float16"
+            self.assertEqual(code.count(f".to(tl.{lowp_name})"), 3)
+            self.assertNotIn(f".to(tl.{lowp_name})", realized_code)
+
+
+instantiate_device_type_tests(
+    LowPrecisionTest,
+    globals(),
+    only_for=("cpu", "cuda", "xpu"),
+    allow_xpu=True,
+)
+
+
+if __name__ == "__main__":
+    from torch._inductor.test_case import run_tests
+
+    run_tests(needs="filelock")

--- a/test/inductor/test_low_precision.py
+++ b/test/inductor/test_low_precision.py
@@ -11,6 +11,7 @@ from torch.testing._internal.common_device_type import (
     dtypesIfCUDA,
     dtypesIfXPU,
     instantiate_device_type_tests,
+    onlyCPU,
     skipXPUIf,
 )
 
@@ -64,6 +65,30 @@ class LowPrecisionTest(TestCase):
             lowp_name = "bfloat16" if dtype == torch.bfloat16 else "float16"
             self.assertEqual(code.count(f".to(tl.{lowp_name})"), 3)
             self.assertNotIn(f".to(tl.{lowp_name})", realized_code)
+
+    @onlyCPU
+    @dtypes(torch.float16)
+    @config.patch(emulate_precision_casts=False)
+    def test_saved_backward_comparison_does_not_round_forward(self, device, dtype):
+        input = torch.tensor(
+            [0.09051513671875, -8.1796875],
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        target = torch.tensor([1.0, -1.0], device=device, dtype=dtype)
+
+        def fn(input, target):
+            return torch.nn.functional.hinge_embedding_loss(
+                input,
+                target,
+                margin=-7.167470387213217,
+                reduction="sum",
+            )
+
+        expected = fn(input.float(), target.float()).to(dtype)
+        actual = torch.compile(fn, backend="inductor", fullgraph=True)(input, target)
+        self.assertEqual(actual, expected, atol=0, rtol=0)
 
 
 instantiate_device_type_tests(

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -808,6 +808,9 @@ def make_pointwise(
         emulate_output_cast = (
             emulate_precision_casts or truncate_saved_output
         ) and dtype in low_pr_fp
+        # Boolean pointwise ops observe stored low-precision values in eager,
+        # so fused inputs must be rounded even outside full precision emulation.
+        truncate_inputs = emulate_precision_casts or dtype == torch.bool
 
         def inner_fn(index):
             if len(index) != len(ranges):
@@ -819,7 +822,7 @@ def make_pointwise(
                 for inp_index, load in enumerate(loaders):
                     out = load(index)
                     inp_dtype = inputs[inp_index].get_dtype()
-                    if emulate_precision_casts and inp_dtype in low_pr_fp:
+                    if truncate_inputs and inp_dtype in low_pr_fp:
                         downcast = ops.to_dtype(out, inp_dtype, use_compute_types=False)
                         out = ops.to_dtype(downcast, inp_dtype)
                     inputs_loaded.append(out)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -729,6 +729,36 @@ def _has_saved_lowp_output_use(node: torch.fx.Node | None) -> bool:
     return False
 
 
+def _has_bool_pointwise_use(node: torch.fx.Node) -> bool:
+    cache_key = "inductor_has_bool_pointwise_use"
+    if cache_key not in node.meta:
+        for candidate in reversed(node.graph.nodes):
+            result = False
+            for user in candidate.users:
+                if user.op != "call_function":
+                    continue
+
+                target = user.target
+                if target is operator.getitem:
+                    result = user.meta.get(cache_key, False)
+                elif isinstance(target, torch._ops.OpOverload) and (
+                    is_view(target) or torch.Tag.pointwise in target.tags
+                ):
+                    value = user.meta.get("val")
+                    result = (
+                        user.meta.get("low_precision_pointwise_barrier", False)
+                        and isinstance(value, torch.Tensor)
+                        and value.dtype == torch.bool
+                    ) or user.meta.get(cache_key, False)
+
+                if result:
+                    break
+
+            candidate.meta[cache_key] = result
+
+    return node.meta[cache_key]
+
+
 def make_pointwise(
     fn: Callable[..., Any],
     override_return_dtype: torch.dtype | None = None,
@@ -794,10 +824,13 @@ def make_pointwise(
         current_node = (
             getattr(V.graph, "current_node", None) if V.graph is not None else None
         )
-        emulate_precision_casts = (
+        is_precision_barrier = (
             current_node is not None
             and current_node.meta is not None
             and current_node.meta.get("low_precision_pointwise_barrier", False)
+        )
+        emulate_precision_casts = (
+            config.emulate_precision_casts and is_precision_barrier
         )
         truncate_saved_output = (
             config.emulate_precision_casts_on_saved_tensors
@@ -805,12 +838,17 @@ def make_pointwise(
             and dtype in low_pr_fp
             and _has_saved_lowp_output_use(current_node)
         )
+        # Exact boolean results can change discontinuously if fusion elides any
+        # eager low-precision rounding boundary in their pointwise producer chain.
+        truncate_for_comparison = (
+            is_precision_barrier
+            and dtype in low_pr_fp
+            and current_node is not None
+            and _has_bool_pointwise_use(current_node)
+        )
         emulate_output_cast = (
-            emulate_precision_casts or truncate_saved_output
+            emulate_precision_casts or truncate_saved_output or truncate_for_comparison
         ) and dtype in low_pr_fp
-        # Boolean pointwise ops observe stored low-precision values in eager,
-        # so fused inputs must be rounded even outside full precision emulation.
-        truncate_inputs = emulate_precision_casts or dtype == torch.bool
 
         def inner_fn(index):
             if len(index) != len(ranges):
@@ -822,7 +860,7 @@ def make_pointwise(
                 for inp_index, load in enumerate(loaders):
                     out = load(index)
                     inp_dtype = inputs[inp_index].get_dtype()
-                    if truncate_inputs and inp_dtype in low_pr_fp:
+                    if emulate_precision_casts and inp_dtype in low_pr_fp:
                         downcast = ops.to_dtype(out, inp_dtype, use_compute_types=False)
                         out = ops.to_dtype(downcast, inp_dtype)
                     inputs_loaded.append(out)

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -729,6 +729,27 @@ def _has_saved_lowp_output_use(node: torch.fx.Node | None) -> bool:
     return False
 
 
+def _is_saved_for_backward_only(node: torch.fx.Node) -> bool:
+    found_saved_output = False
+    for user in node.users:
+        if user.op != "output":
+            return False
+
+        descs = user.meta.get("desc")
+        if descs is None:
+            return False
+
+        output_values = pytree.tree_leaves(user.args[0])
+        for output_value, desc in zip(output_values, descs):
+            if output_value is not node:
+                continue
+            if not isinstance(desc, _SAVED_FOR_BACKWARDS_OUTPUT_DESC_TYPES):
+                return False
+            found_saved_output = True
+
+    return found_saved_output
+
+
 def _has_bool_pointwise_use(node: torch.fx.Node) -> bool:
     cache_key = "inductor_has_bool_pointwise_use"
     if cache_key not in node.meta:
@@ -745,10 +766,13 @@ def _has_bool_pointwise_use(node: torch.fx.Node) -> bool:
                     is_view(target) or torch.Tag.pointwise in target.tags
                 ):
                     value = user.meta.get("val")
+                    # AOTAutograd may emit boolean masks only to save for backward.
+                    # Those masks must not change forward-chain precision.
                     result = (
                         user.meta.get("low_precision_pointwise_barrier", False)
                         and isinstance(value, torch.Tensor)
                         and value.dtype == torch.bool
+                        and not _is_saved_for_backward_only(user)
                     ) or user.meta.get(cache_key, False)
 
                 if result:

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -2187,6 +2187,7 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
         self._invoke_subgraph_cache: dict[
             torch.fx.GraphModule | FunctionalizeCtxWrapper, str
         ] = {}
+
     @count
     def __torch_dispatch__(
         self,

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1109,10 +1109,10 @@ def _maybe_record_pointwise_barrier(
     func: object, proxy_mode: ProxyTorchDispatchMode
 ) -> None:
     """
-    Records operators whose tensor outputs or inputs are fp16/bf16 so downstream pointwise code can
-    emulate eager's rounding behavior when emulate_precision_casts is enabled.
+    Records eager operators with fp16/bf16 tensor outputs or inputs so downstream
+    pointwise code can preserve selected eager rounding boundaries.
     """
-    if proxy_mode.decomp_layers or not proxy_mode.emulate_precision_casts:
+    if proxy_mode.decomp_layers:
         return
 
     if not isinstance(func, torch._ops.OpOverload):
@@ -2187,10 +2187,6 @@ class ProxyTorchDispatchMode(TorchDispatchMode):
         self._invoke_subgraph_cache: dict[
             torch.fx.GraphModule | FunctionalizeCtxWrapper, str
         ] = {}
-        from torch._inductor import config
-
-        self.emulate_precision_casts: bool = config.emulate_precision_casts
-
     @count
     def __torch_dispatch__(
         self,


### PR DESCRIPTION
Fixes #195214

## Summary

- preserve each eager fp16/bf16 pointwise rounding boundary on fused
  pointwise paths that feed a forward-observable boolean operation
- restrict the change to real eager operation boundaries, leaving
  decomposition-internal comparisons and already-realized operands unchanged
- ignore AOTAutograd boolean masks emitted solely as saved-for-backward outputs,
  so they cannot change unrelated forward numerics
- add device-instantiated coverage for CPU bfloat16 and CUDA bfloat16/float16,
  including multi-operation producer chains and generated-code assertions

Eager materializes every low-precision pointwise output. Inductor normally
keeps fused low-precision chains in opmath precision, which is generally a
small numerical difference for floating-point outputs. For exact boolean
operations, however, the difference is discontinuous: equality ties can
collapse to zero and downstream gradients can become non-finite.

This is a targeted default-on subset of `emulate_precision_casts`. That opt-in
mode preserves every eligible low-precision eager boundary and changes broader
codegen behavior to reproduce eager numerics globally. This change preserves
only producer boundaries on paths ending in a forward-observable boolean
operation. Other floating-point paths retain normal Inductor numerics. When
`emulate_precision_casts` is enabled, it subsumes this behavior.

ProxyTensor records real eager low-precision operation boundaries independently
of full precision emulation. During lowering, a cached reverse-topological
analysis finds boundaries on pointwise paths ending in a forward-observable
boolean operation. Only those producer outputs are rounded. This handles
arbitrary producer depth without adding casts to materialized comparison
inputs. Boolean masks emitted solely as saved-for-backward AOT outputs are
excluded from the analysis.

XPU remains excluded because its truncf/fpext barriers may currently be folded
away; this is tracked by intel/intel-xpu-backend-for-triton#7491.

## Test plan

- `python test/inductor/test_low_precision.py`
- `PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=8 python test/inductor/test_torchinductor_opinfo.py TestInductorOpInfoCPU.test_comprehensive_nn_functional_hinge_embedding_loss_cpu_float16`
- `python test/inductor/test_cuda_repro.py -k precision_casts`
- standalone CPU bfloat16 and CUDA bfloat16/float16 comparison reproducers
- generated-code checks for three required CUDA rounding boundaries and zero
  added casts for realized inputs

AI assistance disclosure: Codex helped trace the original lowering bug, develop
the revised graph analysis, draft tests, and run local validation. The exact
changes and public text were reviewed before submission.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo