### PR TITLE
[meta] Reject a non-positive pixel_shuffle/unshuffle factor

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3365,6 +3365,36 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         test_pixel_shuffle_unshuffle_4D()
         test_pixel_shuffle_unshuffle_5D()
 
+    def test_pixel_shuffle_unshuffle_non_positive_factor(self):
+        """The meta and decomposition paths must reject a non-positive factor
+        the same way eager does, rather than dividing by it."""
+        from torch._refs.nn.functional import (
+            pixel_shuffle as pixel_shuffle_decomp,
+            pixel_unshuffle as pixel_unshuffle_decomp,
+        )
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        x = torch.randn(1, 4, 4, 4)
+
+        for factor in (0, -2):
+            # eager, for reference
+            with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+                torch.pixel_shuffle(x, factor)
+            with self.assertRaisesRegex(RuntimeError, "positive downscale_factor"):
+                torch.pixel_unshuffle(x, factor)
+
+            # decompositions
+            with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+                pixel_shuffle_decomp(x, factor)
+            with self.assertRaisesRegex(RuntimeError, "positive downscale_factor"):
+                pixel_unshuffle_decomp(x, factor)
+
+            # meta registration
+            with FakeTensorMode():
+                fake = torch.randn(1, 4, 4, 4)
+                with self.assertRaisesRegex(RuntimeError, "positive upscale_factor"):
+                    torch.ops.aten.pixel_shuffle(fake, factor)
+
     @set_default_dtype(torch.double)
     def test_pixel_shuffle_nhwc_cpu(self):
         input = torch.randn(3, 18, 4, 4, device='cpu')

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8142,12 +8142,16 @@ def meta_pixel_shuffle(self, upscale_factor):
         upscale_factor > 0,
         lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
     )
-    upscale_factor_squared = upscale_factor * upscale_factor
-    torch._check(
-        upscale_factor_squared <= torch.iinfo(torch.int64).max,
-        lambda: f"pixel_shuffle expects upscale_factor^2 to fit in int64, but got "
+    # Eager guards the square against int64 overflow with TORCH_CHECK_VALUE, i.e. a
+    # ValueError, and phrases the bound as a division so the product is never formed.
+    # Mirror both: a torch._check here would raise RuntimeError and swap one
+    # eager/meta divergence for another.
+    torch._check_value(
+        upscale_factor <= torch.iinfo(torch.int64).max // upscale_factor,
+        lambda: f"upscale factor is too large, (upscale_factor)^2 overflowed: "
         f"upscale_factor={upscale_factor}",
     )
+    upscale_factor_squared = upscale_factor * upscale_factor
     torch._check(
         len(self.shape) > 2,
         lambda: f"Invalid input shape for pixel_shuffle: {self.shape}",

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -8135,12 +8135,25 @@ def linear_backward(input_, grad_output_, weight_, output_mask):
 
 @register_meta(aten.pixel_shuffle.default)
 def meta_pixel_shuffle(self, upscale_factor):
+    # Guard the factor before it is squared and used as a divisor. Eager rejects
+    # a non-positive factor in native_functions; without the same check here the
+    # divisibility test below raises ZeroDivisionError for upscale_factor=0.
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
+    )
+    upscale_factor_squared = upscale_factor * upscale_factor
+    torch._check(
+        upscale_factor_squared <= torch.iinfo(torch.int64).max,
+        lambda: f"pixel_shuffle expects upscale_factor^2 to fit in int64, but got "
+        f"upscale_factor={upscale_factor}",
+    )
     torch._check(
         len(self.shape) > 2,
         lambda: f"Invalid input shape for pixel_shuffle: {self.shape}",
     )
     torch._check(
-        self.shape[-3] % (upscale_factor * upscale_factor) == 0,
+        self.shape[-3] % upscale_factor_squared == 0,
         lambda: f"Invalid input shape for pixel_shuffle: {self.shape} with upscale_factor = {upscale_factor}",
     )
 
@@ -8161,7 +8174,7 @@ def meta_pixel_shuffle(self, upscale_factor):
             return fmt
         return torch.contiguous_format
 
-    C = self.shape[-3] // (upscale_factor * upscale_factor)
+    C = self.shape[-3] // upscale_factor_squared
     Hr = self.shape[-2] * upscale_factor
     Wr = self.shape[-1] * upscale_factor
     out_shape = (*self.shape[:-3], C, Hr, Wr)

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1287,6 +1287,12 @@ def pixel_shuffle(self: Tensor, upscale_factor: int):
         self.dim() >= 3,
         lambda: f"pixel_shuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
     )
+    # Matches the eager check; without it the division below raises
+    # ZeroDivisionError for upscale_factor=0.
+    torch._check(
+        upscale_factor > 0,
+        lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
+    )
     batch = self.shape[:-3]
     C_out = self.shape[-3] // upscale_factor**2
     HW_out = (self.shape[-2] * upscale_factor, self.shape[-1] * upscale_factor)
@@ -1314,6 +1320,12 @@ def pixel_unshuffle(self: Tensor, downscale_factor: int):
     torch._check(
         self.dim() >= 3,
         lambda: f"pixel_unshuffle expects input to have at least 3 dimensions, but got input with {self.dim} dimension(s)",
+    )
+    # Matches the eager check; without it the division below raises
+    # ZeroDivisionError for downscale_factor=0.
+    torch._check(
+        downscale_factor > 0,
+        lambda: f"pixel_unshuffle expects a positive downscale_factor, but got {downscale_factor}",
     )
     batch = self.shape[:-3]
     C_out = self.shape[-3] * downscale_factor**2

--- a/torch/_refs/nn/functional/__init__.py
+++ b/torch/_refs/nn/functional/__init__.py
@@ -1293,6 +1293,15 @@ def pixel_shuffle(self: Tensor, upscale_factor: int):
         upscale_factor > 0,
         lambda: f"pixel_shuffle expects a positive upscale_factor, but got {upscale_factor}",
     )
+    # Eager also rejects a factor whose square overflows int64 (TORCH_CHECK_VALUE ->
+    # ValueError). Without it `upscale_factor**2` below is an arbitrary-precision
+    # Python int, so the view() built from it fails with an internal shape error
+    # instead of this message.
+    torch._check_value(
+        upscale_factor <= torch.iinfo(torch.int64).max // upscale_factor,
+        lambda: f"upscale factor is too large, (upscale_factor)^2 overflowed: "
+        f"upscale_factor={upscale_factor}",
+    )
     batch = self.shape[:-3]
     C_out = self.shape[-3] // upscale_factor**2
     HW_out = (self.shape[-2] * upscale_factor, self.shape[-1] * upscale_factor)
@@ -1327,6 +1336,10 @@ def pixel_unshuffle(self: Tensor, downscale_factor: int):
         downscale_factor > 0,
         lambda: f"pixel_unshuffle expects a positive downscale_factor, but got {downscale_factor}",
     )
+    # Deliberately no int64-overflow check here. Unlike pixel_shuffle, eager never
+    # squares the factor before using it -- it only tests H and W for divisibility --
+    # so a huge downscale_factor raises the ordinary divisibility RuntimeError. Adding
+    # an overflow check would introduce a divergence rather than remove one.
     batch = self.shape[:-3]
     C_out = self.shape[-3] * downscale_factor**2
     HW_out = (self.shape[-2] // downscale_factor, self.shape[-1] // downscale_factor)


### PR DESCRIPTION
Fixes #153327

Eager rejects a non-positive factor in `native_functions`:

```
RuntimeError: pixel_shuffle expects a positive upscale_factor, but got 0
```

The meta registration and the `_refs` decompositions never got the same check, so they divide by the factor instead:

| path | `factor = 0` | `factor = -2` |
|---|---|---|
| eager | `RuntimeError: ...positive upscale_factor, but got 0` | `RuntimeError: ...but got -2` |
| `meta_pixel_shuffle` | **`ZeroDivisionError: integer modulo by zero`** | `RuntimeError: Expected cond to be True, but got False. (Could this error message be improved?...)` |
| `_refs.pixel_shuffle` | **`ZeroDivisionError: integer division or modulo by zero`** | — |
| `_refs.pixel_unshuffle` | **`ZeroDivisionError: integer division or modulo by zero`** | — |

So the same call reports a clear error eagerly and a raw `ZeroDivisionError` (or a message-less `_check` failure) under `torch.compile` / `FakeTensor`.

## Changes

* `meta_pixel_shuffle`: check `upscale_factor > 0` before it is squared and used as a divisor, reusing eager's exact wording so the two paths agree verbatim. Hoist `upscale_factor * upscale_factor` into a local and guard it against exceeding `int64`, so a huge factor is reported rather than used to build an absurd output shape.
* `_refs.nn.functional.pixel_shuffle` / `pixel_unshuffle`: the same positivity check, with each function's own eager wording (`upscale_factor` / `downscale_factor`).

`pixel_unshuffle` has no meta registration — it reaches meta through the decomposition, which is covered here.

## Relationship to #182076

This is a rebase of the still-unfixed part of **#182076 by @rajfirke** onto current main. That PR was reviewed by @zou3519, had the requested tests added, and was then **closed by its own author** after 76 days awaiting re-review, with the note that the work *"can be revisited in a future PR if still needed"*. Since then the dimension and divisibility checks it added have landed by other means, but the positivity and overflow guards had not — which is what this PR restores. Credit for the original approach and error wording is theirs.

## Test Plan

```
python test/test_nn.py -k test_pixel_shuffle_unshuffle_non_positive_factor
```

The new test asserts eager, both decompositions, and the meta registration all reject `0` and `-2` with the same message.

## Test Result

Verified against a `2.15.0.dev20260827` nightly wheel with only the two changed Python files overlaid.

**Before:**
```
meta pixel_shuffle(0)   : ZeroDivisionError: integer modulo by zero
meta pixel_shuffle(-2)  : RuntimeError: Expected cond to be True, but got False. (Could this error...
refs pixel_shuffle(0)   : ZeroDivisionError: integer division or modulo by zero
refs pixel_unshuffle(0) : ZeroDivisionError: integer division or modulo by zero
```

**After:**
```
meta pixel_shuffle(0)   : RuntimeError: pixel_shuffle expects a positive upscale_factor, but got 0
meta pixel_shuffle(-2)  : RuntimeError: pixel_shuffle expects a positive upscale_factor, but got -2
refs pixel_shuffle(0)   : RuntimeError: pixel_shuffle expects a positive upscale_factor, but got 0
refs pixel_unshuffle(0) : RuntimeError: pixel_unshuffle expects a positive downscale_factor, but got 0
```

which matches the eager reference exactly:
```
eager pixel_shuffle(0)   : RuntimeError: pixel_shuffle expects a positive upscale_factor, but got 0
eager pixel_unshuffle(0) : RuntimeError: pixel_unshuffle expects a positive downscale_factor, but got 0
```

Lint: `ruff==0.14.4` (pinned in `tools/linter/adapters/pyfmt_linter.py`) reports both `torch/` files already formatted and all checks passed. `test/test_nn.py` is in the PYFMT exclude list at `.lintrunner.toml:1386` and already fails `ruff format --check` on unmodified main, so it is deliberately left unformatted.

## Update — overflow guard now matches eager exactly

Thanks @egeboy35 for the measured review. Three things came out of it, all addressed in
the follow-up commit:

1. **The overflow check raised the wrong exception type.** It used `torch._check`
   (`RuntimeError`), while eager uses `TORCH_CHECK_VALUE` and raises `ValueError`. That
   traded one eager/meta divergence for another. It now uses `torch._check_value` with
   eager's exact wording, and phrases the bound as a division
   (`factor <= int64_max // factor`) so the product is never formed — the same form as
   `check_pixel_shuffle_shapes`.

2. **`_refs.pixel_shuffle` had no overflow guard at all**, so the same input still produced
   an internal shape error there. Added.

3. **`pixel_unshuffle` deliberately gets no overflow check.** Eager never squares the
   downscale factor — it only tests H and W for divisibility — so adding one would
   introduce a divergence rather than remove one. Noted in a comment so it is not "fixed"
   later.

This also covers #153327, whose repro is an empty tensor with a near-2^62 factor. Eager has
since been fixed, but the meta path still fails with
`TypeError: empty_strided(): ... Overflow when unpacking`, and `_refs` with an internal
shape error. Both now report eager's message:

```
eager : ValueError: upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=4323455642275676160
meta  : ValueError: upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=4323455642275676160
_refs : ValueError: upscale factor is too large, (upscale_factor)^2 overflowed: upscale_factor=4323455642275676160
```

Re-verified on a `2.15.0.dev20260911` nightly after rebasing onto current main:
`test_nn.py -k pixel` 5 passed, `test_decomp.py` 24 passed, `test_meta.py` 72 passed, and
valid inputs are unchanged (`allclose` against eager for both ops).
---

*AI disclosure (per `AI_POLICY.md`): this change was written with AI assistance. I reviewed the root cause, the fix and the toggle results above; the contribution is not autonomous.*

