### PR TITLE
[MPS] Add special_log_ndtr

### DIFF
--- a/aten/src/ATen/native/mps/kernels/SpecialOps.metal
+++ b/aten/src/ATen/native/mps/kernels/SpecialOps.metal
@@ -16,6 +16,7 @@ DEFINE_UNARY_FLOATING_FUNCTOR(i0e);
 DEFINE_UNARY_FLOATING_FUNCTOR(i1);
 DEFINE_UNARY_FLOATING_FUNCTOR(i1e);
 DEFINE_UNARY_FLOATING_FUNCTOR(spherical_bessel_j0);
+DEFINE_UNARY_FLOATING_FUNCTOR(log_ndtr);
 
 // TODO: Replaceme with DEFINE_UNARY_FLOATING_FUNCTOR
 // But for some reason instantinating bessel_y[01] and entr on M1/M2 results in
@@ -79,7 +80,8 @@ struct entr_functor {
   REGISTER_UNARY_OP(i1, DTI, DTO);                                \
   REGISTER_UNARY_OP(i1e, DTI, DTO);                               \
   REGISTER_UNARY_OP(spherical_bessel_j0, DTI, DTO);               \
-  REGISTER_UNARY_OP(entr, DTI, DTO)
+  REGISTER_UNARY_OP(entr, DTI, DTO);                              \
+  REGISTER_UNARY_OP(log_ndtr, DTI, DTO)
 
 REGISTER_SPECIAL(float, float);
 REGISTER_SPECIAL(bool, float);

--- a/aten/src/ATen/native/mps/operations/SpecialOps.mm
+++ b/aten/src/ATen/native/mps/operations/SpecialOps.mm
@@ -32,6 +32,10 @@ static void spherical_bessel_j0_kernel_mps(TensorIteratorBase& iter) {
   lib.exec_unary_kernel(iter, "spherical_bessel_j0");
 }
 
+static void log_ndtr_kernel_mps(TensorIteratorBase& iter) {
+  lib.exec_unary_kernel(iter, "log_ndtr");
+}
+
 static void entr_kernel_mps(TensorIteratorBase& iter) {
   lib.exec_unary_kernel(iter, "entr");
 }
@@ -77,6 +81,7 @@ static void bessel_y1_kernel_mps(TensorIteratorBase& iter) {
 }
 
 REGISTER_DISPATCH(i0_stub, &i0_kernel_mps)
+REGISTER_DISPATCH(special_log_ndtr_stub, &log_ndtr_kernel_mps)
 REGISTER_DISPATCH(special_i0e_stub, &i0e_kernel_mps)
 REGISTER_DISPATCH(special_i1_stub, &i1_kernel_mps)
 REGISTER_DISPATCH(special_i1e_stub, &i1e_kernel_mps)

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13618,7 +13618,7 @@
   python_module: special
   variants: function
   dispatch:
-    CPU, CUDA, XPU: special_log_ndtr_out
+    CPU, CUDA, MPS, XPU: special_log_ndtr_out
   tags: pointwise
 
 - func: special_expm1(Tensor self) -> Tensor

--- a/c10/metal/special_math.h
+++ b/c10/metal/special_math.h
@@ -3125,5 +3125,25 @@ float erfcx(T x) {
   }
 }
 
+/*
+ * Logarithm of the Gaussian cumulative distribution function.
+ * Copy-n-paste from calc_log_ndtr in aten/src/ATen/native/Math.h, which
+ * follows SciPy's implementation. See NOTICE for the licenses.
+ */
+template <typename T>
+inline float log_ndtr(T x) {
+  /* 1 / sqrt(2) */
+  constexpr float frac_sqrt_2 = 0.707106781186547524400844362104849039;
+
+  const float xf = static_cast<float>(x);
+  const float t = xf * frac_sqrt_2;
+
+  if (xf < -1.0) {
+    return ::metal::precise::log(erfcx(-t) / 2) - t * t;
+  }
+
+  return log1p(-erfc(t) / 2);
+} // log_ndtr(T x)
+
 } // namespace metal
 } // namespace c10

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16443,6 +16443,13 @@ class TestConsistency(TestCaseMPS):
                 atol, rtol = 5e-5, 2.5e-2
             if op.name in ("special.bessel_y0", "special.bessel_y1") and dtype == torch.float16:
                 atol, rtol = 5e-4, 2e-3
+            if op.name == "special.log_ndtr" and dtype == torch.float32:
+                # d/dx log_ndtr(x) = exp(-x*x/2 - log_ndtr(x)), so an absolute
+                # error in the forward value shows up as a relative error of
+                # the same size in the gradient. For x around -11 the forward
+                # result is about -70, where one fp32 ulp is already ~8e-6, so
+                # CPU and MPS gradients cannot agree to the default rtol.
+                atol, rtol = 1e-4, 2e-5
             if op.name == "polar" and dtype == torch.float16:
                 # `d(real)/d(abs) = cos(angle)` near pi/2 collapses to ~0 in
                 # fp16; one unlucky seeded angle can produce ~0.1 absolute

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -591,7 +591,6 @@ if torch.backends.mps.is_available():
             "special.airy_ai": None,
             "special.laguerre_polynomial_l": None,
             "special.legendre_polynomial_p": None,
-            "special.log_ndtr": None,
             "special.ndtri": None,
             "stft": [torch.float16, torch.bfloat16],
             "svd_lowrank": None,


### PR DESCRIPTION
I have built and run the tests for this change locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than
presented as my own prose.

> Adds a native Metal kernel for `special.log_ndtr`, which so far only had CPU,
> CUDA and XPU implementations and was listed as unimplemented in the MPS xfail
> list. The helper is a short composition on top of `erfcx` and `erfc`, both of
> which were already ported to `c10/metal/special_math.h`, so it follows SciPy's
> two-branch form exactly as `calc_log_ndtr` in `aten/src/ATen/native/Math.h`
> does.
>
> The gradient test needs a tolerance override at float32, and the reason is
> worth spelling out because it is not an implementation defect. The derivative
> is `exp(-x*x/2 - log_ndtr(x))`, so an absolute error in the forward result
> turns into a relative error of the same size in the gradient. Around x = -11
> the forward result is about -70, where a single fp32 ulp is already 8e-6; the
> forward is dominated by the `-t*t` term and cannot be represented more
> precisely in fp32, so CPU and MPS gradients cannot agree to the default 1.3e-6
> relative tolerance no matter how the approximation is written. Measured
> worst-case relative gradient difference over x in [-12, 6] is 7.6e-6, matching
> the forward absolute difference of 7.6e-6 exactly, which is what confirms the
> diagnosis. The override is set to atol 1e-4 / rtol 2e-5.
>
> Test Plan:
>
> Removing the `special.log_ndtr` entry from `UNIMPLEMENTED_XFAILLIST` enables
> `test_output_match`, which runs the OpInfo on MPS and on CPU and compares the
> results for every supported dtype.
>
> ```
> python test/test_mps.py -k "log_ndtr" -v
> ```
>
> 8 tests pass (`test_output_match` for bool/int8/uint8/int16/int32/int64/float32
> and `test_output_grad_match` for float32).
>
> The forward and backward were also swept against CPU on a denser grid than the
> OpInfo samples, covering both branches of the approximation:
>
> ```
> python - <<'PY'
> import torch
> x = torch.linspace(-12, 6, 2001)
> out = {}
> for dev in ("cpu", "mps"):
>     xx = x.to(dev).clone().requires_grad_(True)
>     y = torch.special.log_ndtr(xx)
>     y.backward(torch.ones_like(y))
>     out[dev] = (y.detach().cpu(), xx.grad.cpu())
> print((out["mps"][0] - out["cpu"][0]).abs().max())   # 7.6e-06
> print(((out["mps"][1] - out["cpu"][1]).abs()
>        / out["cpu"][1].abs()).max())                 # 7.6e-06
> PY
> ```


🤖 Generated with [Claude Code](https://claude.com/claude-code)
