### PR TITLE
Fix duplicated word in DefaultStager.stage docstring

### DIFF
--- a/torch/distributed/checkpoint/staging.py
+++ b/torch/distributed/checkpoint/staging.py
@@ -199,7 +199,7 @@ class DefaultStager(AsyncStager):
         **kwargs: Any,
     ) -> STATE_DICT_TYPE | Future[STATE_DICT_TYPE]:
         """
-        This function is responsible for staging staging the state_dict.
+        This function is responsible for staging the state_dict.
         See class docstring for more details on staging.
         If use_async_staging is True, it will return a Future object that will be
         fulfilled when staging is complete.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #195233

**Impact:** documentation only (`torch.distributed.checkpoint.staging`)
**Risk:** low

## What
Drops the repeated "staging" in the `DefaultStager.stage` docstring: "responsible for staging staging the state_dict" -> "responsible for staging the state_dict".

## Why
Simple typo in a user-facing docstring that shows up in the rendered API docs.

Signed-off-by: Jean Schmidt <contato@jschmidt.me>