### PR TITLE
Exempt _efficient_attention_backward from debug storage use_count assert

### DIFF
--- a/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
+++ b/torch/csrc/autograd/autograd_not_implemented_fallback.cpp
@@ -422,11 +422,14 @@ static void autogradNotImplementedFallbackImpl(
         // TensorList, see https://github.com/pytorch/pytorch/issues/93940
         // Skip native_channel_shuffle as well as transformer_encoder
         // For details see https://github.com/pytorch/pytorch/issues/130073
+        // `_efficient_attention_backward` may return dq/dk/dv chunked from a
+        // single shared storage (shared_storage_dqdkdv=True).
         if (!is_aliased_output[idx_ret] && t.has_storage() &&
             op_name != "aten::_foreach_norm" &&
             op_name != "aten::_transformer_encoder_layer_fwd" &&
             op_name != "aten::native_channel_shuffle" &&
-            op_name != "aten::_sparse_semi_structured_tile")
+            op_name != "aten::_sparse_semi_structured_tile" &&
+            op_name != "aten::_efficient_attention_backward")
           TORCH_INTERNAL_ASSERT(t.storage().use_count() == 1);
       },
       stack,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195235
* __->__ #195234

test_mem_efficient_bottom_right_varlen_fully_masked_rows_shared_storage_dqdkdv_True_cuda
(added in #193632) calls _efficient_attention_backward with dq/dk/dv
chunked from a single shared storage. The autograd-not-implemented
fallback's debug-build validation asserts every non-aliased output has
storage().use_count() == 1, so the test fails every periodic debug run
(linux-jammy-cuda13.0/13.2-py3.10-gcc11-debug) since the 2026-08-24
reland:

  RuntimeError: t.storage().use_count() == 1 INTERNAL ASSERT FAILED at
  torch/csrc/autograd/autograd_not_implemented_fallback.cpp:430

Sharing an output storage is intentional for this op, matching existing
exemptions (_foreach_norm, _transformer_encoder_layer_fwd, ...), so add
it to the exemption list. Debug builds only run in periodic, which does
not run pre-merge, which is why this landed unnoticed.

Test Plan:
Not testable locally (the assert only fires in DEBUG builds, which run
only in the periodic CI workflow). Verified the op name against its
schema in aten/src/ATen/native/native_functions.yaml and linted:

```
lintrunner -a torch/csrc/autograd/autograd_not_implemented_fallback.cpp
```

Authored with Claude Code.