### PR TITLE
[pr_time_benchmarks] Rebase add_loop_eager_dynamic compile time expected value

### DIFF
--- a/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
+++ b/benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
@@ -2,7 +2,7 @@ add_loop_eager,compile_time_instruction_count,3862000000,0.1
 
 
 
-add_loop_eager_dynamic,compile_time_instruction_count,5468000000,0.1
+add_loop_eager_dynamic,compile_time_instruction_count,4919000000,0.1
 
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195235
* #195234

Since ~2026-08-27 the trunk pr_time_benchmarks job flickers red with:

  WIN: benchmark ('add_loop_eager_dynamic', 'compile_time_instruction_count')
  failed, actual result 4919471398 is -10.03% lower than expected
  5468000000 +/-10.00%

A change that landed around 2026-08-26 improved this benchmark's compile
time by ~10%, leaving the measured value sitting exactly at the -10% edge
of the tolerance band, so run-to-run noise fails the job at random (~8 of
~140 runs over two days, one CUDA config at a time). Update the expected
value to the new baseline. The failure message asks to update all results
that changed significantly, but the benchmark suite cannot be run locally
and only this benchmark is failing in CI, so only this row is updated.

Test Plan:
Not runnable locally (requires the CI benchmark runner). Verified the new
value 4919000000 matches the rounding style of neighboring rows and the
tolerance column is unchanged, and linted:

```
lintrunner -a benchmarks/dynamo/pr_time_benchmarks/expected_results.csv
```

Authored with Claude Code.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98