### PR TITLE
Add the missing <ostream> include to Stream.cpp

### DIFF
--- a/c10/core/Stream.cpp
+++ b/c10/core/Stream.cpp
@@ -1,5 +1,6 @@
 #include <c10/core/Stream.h>
 #include <c10/core/impl/VirtualGuardImpl.h>
+#include <ostream>
 
 namespace c10 {
 


### PR DESCRIPTION
c10/core/Stream.cpp defines operator<<(std::ostream&, const Stream&) but only gets <ostream> transitively via Stream.h.

> Drafted with AI assistance (Claude Code).