### PR TITLE
Enable Leak Sanitizer

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -310,11 +310,16 @@ fi
 # if you're not careful.  Check this if you made some changes and the
 # ASAN test is not working
 if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
-    export ASAN_OPTIONS=detect_leaks=0:symbolize=1:detect_stack_use_after_return=true:strict_init_order=true:detect_odr_violation=1:detect_container_overflow=0:check_initialization_order=true:debug=true
+    export ASAN_OPTIONS=detect_leaks=1:symbolize=1:detect_stack_use_after_return=true:strict_init_order=true:detect_odr_violation=1:detect_container_overflow=0:check_initialization_order=true:debug=true:fast_unwind_on_malloc=1
     if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
         export ASAN_OPTIONS="${ASAN_OPTIONS}:protect_shadow_gap=0"
     fi
     export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/ubsan.supp
+    # Suppress some hard to solve indirect leaks
+    # malloc_context_size is capped low because lsan.supp only matches on
+    # shallow symbol/module names, and capturing a full stack on every
+    # allocation under ASan is what makes this job run ~2x slower.
+    export LSAN_OPTIONS="suppressions=$PWD/lsan.supp:malloc_context_size=2"
     export PYTORCH_TEST_WITH_ASAN=1
     export PYTORCH_TEST_WITH_UBSAN=1
     # TODO: Figure out how to avoid hard-coding these paths

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,0 +1,29 @@
+leak:pybind11::cpp_function
+leak:PyMem_RawMalloc
+leak:unicode_resize
+leak:PyObject_Malloc
+leak:PyByteArray_Resize
+leak:numpy
+leak:list_append
+leak:unicodeobject
+leak:obmalloc
+leak:gcmodule
+leak:listobject
+leak:bytesobject
+leak:PyThread_allocate_lock
+leak:sccache
+leak:gcc/x86_64-linux-gnu/11
+leak:x86_64-linux-gnu-gcc-11
+leak:libbfd
+leak:x86_64-linux-gnu-ld.bfd
+leak:git
+leak:libio
+leak:unknown module
+leak:g++
+leak:conda-linux-gnu-ld
+leak:crypto
+leak:torch::detail::(anonymous namespace)::get_set_cached_attr
+leak:torch::jit::tensorexpr::TensorExprKernel::preAllocIntermediateBufs
+leak:optree
+leak:python
+leak:torch::tensors::initialize_aten_types


### PR DESCRIPTION
Supersedes #127171 (couldn't reopen - GitHub rejected it since the branch had been force-pushed since closing).

Flips `ASAN_OPTIONS` `detect_leaks` to 1 for the asan CI job and adds `lsan.supp` for known/accepted leaks (glibc/CPython allocator internals, gcc-11 toolchain, a couple of intentional PyTorch leaks already documented in-code, e.g. `torch::tensors::initialize_aten_types`).

Dropped the `rustc-1.61.0` suppression entry since the pinned Rust toolchain is now 1.97.1 and that path no longer matches. Capped `LSAN_OPTIONS` `malloc_context_size` at 2 - `lsan.supp` only matches shallow symbol/module names, and capturing a full allocation stack under ASan is what roughly doubles this job's runtime otherwise.

This is a two-year-old suppression list being turned back on against a codebase that's grown substantially since - I could not run LeakSanitizer locally to verify it's still sufficient, so CI's first run here is the real test. It will likely need more suppressions added for leaks introduced since 2023.

> Drafted with AI assistance (Claude Code).