### PR TITLE
Enable Leak Sanitizer

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -310,11 +310,15 @@ fi
 # if you're not careful.  Check this if you made some changes and the
 # ASAN test is not working
 if [[ "$BUILD_ENVIRONMENT" == *asan* ]]; then
-    export ASAN_OPTIONS=detect_leaks=0:symbolize=1:detect_stack_use_after_return=true:strict_init_order=true:detect_odr_violation=1:detect_container_overflow=0:check_initialization_order=true:debug=true
+    export ASAN_OPTIONS=detect_leaks=1:symbolize=1:detect_stack_use_after_return=true:strict_init_order=true:detect_odr_violation=1:detect_container_overflow=0:check_initialization_order=true:debug=true:fast_unwind_on_malloc=1:print_suppressions=0
     if [[ "$BUILD_ENVIRONMENT" == *cuda* ]]; then
         export ASAN_OPTIONS="${ASAN_OPTIONS}:protect_shadow_gap=0"
     fi
     export UBSAN_OPTIONS=print_stacktrace=1:suppressions=$PWD/ubsan.supp
+    # malloc_context_size capped low: lsan.supp only matches shallow
+    # symbol/module names, and a full allocation stack on every malloc is
+    # what makes this job run ~2x slower.
+    export LSAN_OPTIONS="suppressions=$PWD/lsan.supp:malloc_context_size=2"
     export PYTORCH_TEST_WITH_ASAN=1
     export PYTORCH_TEST_WITH_UBSAN=1
     # TODO: Figure out how to avoid hard-coding these paths

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -901,6 +901,7 @@
 #
 # [infra_ci]
 /.ci/ @pytorch/pytorch-dev-infra
+/lsan.supp @pytorch/pytorch-dev-infra
 /.ci/docker/ubuntu-rocm/ @jeffdaily
 /.ci/docker/common/install_roc*.sh @jeffdaily
 /.ci/docker/common/install_amdsmi.sh @jeffdaily

--- a/lsan.supp
+++ b/lsan.supp
@@ -1,0 +1,32 @@
+# CPython interpreter internals (allocator, GC, interned objects) never freed
+# before process exit, not PyTorch leaks. Matched by the interpreter/venv
+# path (contains "python3.") rather than "python" alone, since the latter
+# also matches PyTorch's own libtorch_python.so and would mask real leaks.
+leak:python3.
+leak:PyMem_RawMalloc
+leak:PyObject_Malloc
+leak:unicodeobject
+leak:obmalloc
+leak:gcmodule
+leak:listobject
+leak:bytesobject
+leak:torch::jit::tensorexpr::TensorExprKernel::preAllocIntermediateBufs
+leak:optree
+leak:torch::tensors::initialize_aten_types
+# pybind11's own function/method registration bookkeeping (make_function_record,
+# initialize_generic, strdup_guard, ...), allocated once per bound API and
+# never freed by design. Third-party namespace PyTorch doesn't write code in,
+# so this can't mask a real PyTorch-authored leak.
+leak:pybind11::
+# GCC/binutils toolchain subprocess internals never freed before exit, not
+# PyTorch leaks (cc1, collect2, ld.bfd, libbfd, ...)
+leak:/usr/lib/gcc/
+leak:x86_64-linux-gnu-gcc
+leak:ld.bfd
+leak:libbfd
+# OpenSSL's lazily-initialized global state, never freed without OPENSSL_cleanup()
+leak:libcrypto.so
+# pybind11 registration in JIT-built test extensions; unsymbolized, match
+# by .so name instead.
+leak:cpp_frontend_extension
+leak:pybind11_enum_test


### PR DESCRIPTION
Supersedes #127171 and #154584 (both closed; #154584 landed once and was reverted for roughly doubling the asan CI job's runtime).

Flips `ASAN_OPTIONS` `detect_leaks` to 1 for the asan CI job, using the `lsan.supp` suppression list already refined against real CI output from #154584. Caps `LSAN_OPTIONS` `malloc_context_size` at 2 to address the prior slowdown directly - `lsan.supp` only matches shallow symbol/module names, so capturing a full allocation stack on every malloc under ASan isn't needed and was most of the added cost.

> Drafted with AI assistance (Claude Code).