### PR TITLE
Add register_rng_tracker API for device-specific DTensor RNG trackers

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -1062,6 +1062,120 @@ class DistTensorRandomOpsTest3D(DTensorTestBase):
         compute_rankwise_if_local_tensor(weight_local, self.rank)
 
 
+class RNGTrackerRegistryTest(DTensorTestBase):
+    """Tests for the RNG tracker registration API (``register_rng_tracker``,
+    ``set_rng_tracker``, ``get_or_create_rng_tracker``).
+
+    These tests are CPU-runnable: they use a cpu device mesh and fake tracker
+    classes, so no accelerator is required.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # isolate the global tracker/registry state between tests
+        self._saved_tracker = random._rng_tracker
+        self._saved_registry = dict(random._RNG_TRACKER_REGISTRY)
+
+    def tearDown(self):
+        random._rng_tracker = self._saved_tracker
+        random._RNG_TRACKER_REGISTRY.clear()
+        random._RNG_TRACKER_REGISTRY.update(self._saved_registry)
+        super().tearDown()
+
+    @with_comms
+    def test_register_rng_tracker_type_check(self):
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+
+        with self.assertRaises(TypeError):
+            random.register_rng_tracker("cpu", object)  # type: ignore[arg-type]
+        with self.assertRaises(TypeError):
+            random.register_rng_tracker("cpu", FakeTracker(None, False))  # type: ignore[arg-type]
+        random.register_rng_tracker("cpu", FakeTracker)
+        self.assertIs(random._RNG_TRACKER_REGISTRY["cpu"], FakeTracker)
+
+        # registering again overrides the previous entry
+        random.register_rng_tracker("cpu", FakeTracker)
+        self.assertIs(random._RNG_TRACKER_REGISTRY["cpu"], FakeTracker)
+
+    @with_comms
+    def test_set_rng_tracker(self):
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+
+        fake = FakeTracker(None, False)
+        with self.assertRaises(TypeError):
+            random.set_rng_tracker(object())  # type: ignore[arg-type]
+        random.set_rng_tracker(fake)
+        self.assertIs(random._rng_tracker, fake)
+
+    @with_comms
+    def test_registered_tracker_created_at_manual_seed(self):
+        created = []
+
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                created.append((device_mesh, run_state_sync))
+                self.device_mesh = device_mesh
+
+            def _distribute_region(self, spec, generator=None):
+                yield
+
+        device_mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+        # torch.cpu has no ``set_rng_state``, so without a registration the cpu
+        # mesh is reported unsupported; a registered tracker makes it supported
+        self.assertFalse(is_rng_supported_mesh(device_mesh))
+        random.register_rng_tracker("cpu", FakeTracker)
+        self.assertTrue(is_rng_supported_mesh(device_mesh))
+
+        # the creation point in manual_seed instantiates the registered class
+        # instead of the default OffsetBasedRNGTracker
+        manual_seed(42, device_mesh)
+        self.assertEqual(len(created), 1)
+        self.assertIs(created[0][0], device_mesh)
+        self.assertFalse(created[0][1])  # manual_seed uses run_state_sync=False
+        self.assertIsInstance(random._rng_tracker, FakeTracker)
+
+    @with_comms
+    def test_get_or_create_rng_tracker_returns_existing(self):
+        # get_or_create returns the already-created instance instead of
+        # re-creating, and passes run_state_sync through to the constructor
+        device_mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+                self.run_state_sync = run_state_sync
+
+        random.register_rng_tracker("cpu", FakeTracker)
+        tracker = random.get_or_create_rng_tracker(device_mesh, True)
+        self.assertIsInstance(tracker, FakeTracker)
+        self.assertTrue(tracker.run_state_sync)
+        # second call returns the same instance instead of re-creating
+        self.assertIs(random.get_or_create_rng_tracker(device_mesh, True), tracker)
+
+    @with_comms
+    def test_unregistered_behavior_unchanged(self):
+        device_mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+        with self.assertWarns(UserWarning):
+            self.assertFalse(is_rng_supported_mesh(device_mesh))
+        self.assertIsNone(random._rng_tracker)
+
+    def test_compute_rng_offsets_contract(self):
+        # trackers that do not implement the counter-based offset contract
+        # must raise NotImplementedError (consumed by the capability probe in
+        # torch/distributed/tensor/_dispatch.py)
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+
+        fake = FakeTracker(None, False)
+        with self.assertRaises(NotImplementedError):
+            fake._compute_rng_offsets(None)  # type: ignore[arg-type]
+
+
 DistTensorRandomInitTestWithLocalTensor = create_local_tensor_test_class(
     DistTensorRandomInitTest,
 )

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -20,15 +20,106 @@ __all__ = [
     "is_rng_supported_mesh",
     "manual_seed",
     "OffsetBasedRNGTracker",
+    "register_rng_tracker",
+    "set_rng_tracker",
+    "get_or_create_rng_tracker",
 ]
 
 _rng_tracker: Optional["_RNGStateTracker"] = None
 
+# Registry of RNG tracker classes per device type, populated by third-party
+# backends (e.g. privateuse1 devices) via ``register_rng_tracker``. Devices
+# without an entry keep the default ``OffsetBasedRNGTracker`` behavior.
+_RNG_TRACKER_REGISTRY: dict[str, type["_RNGStateTracker"]] = {}
+
+
+def register_rng_tracker(device_type: str, tracker_cls: type["_RNGStateTracker"]) -> None:
+    """Register a custom RNG tracker class for a device type.
+
+    Third-party backends whose RNG does not follow the CUDA philox
+    counter/offset semantics assumed by the default
+    :class:`OffsetBasedRNGTracker` can register their own tracker here. A
+    registered tracker is instantiated by the DTensor random-op machinery
+    (``manual_seed`` and the creation points in ``_dispatch.py``/``_api.py``)
+    in place of the default one, without monkey-patching the private
+    ``_rng_tracker`` module global.
+
+    The tracker class must subclass ``_RNGStateTracker`` and accept the
+    constructor signature ``(device_mesh: DeviceMesh, run_state_sync: bool)``.
+
+    This follows the same registration pattern as
+    ``register_graphsafe_rng_dispatch`` in ``torch/_prims/rng_prims.py``.
+
+    Args:
+        device_type (str): The device type the tracker handles (e.g. ``"npu"``).
+        tracker_cls (type): The tracker class to register.
+
+    Returns:
+        None
+    """
+    if not (isinstance(tracker_cls, type) and issubclass(tracker_cls, _RNGStateTracker)):
+        raise TypeError(
+            f"tracker_cls must be a subclass of _RNGStateTracker, got {tracker_cls!r}"
+        )
+    _RNG_TRACKER_REGISTRY[device_type] = tracker_cls
+
+
+def set_rng_tracker(tracker: "_RNGStateTracker") -> None:
+    """Set the active RNG tracker instance directly.
+
+    This is the public form of assigning the private ``_rng_tracker`` module
+    global. It allows advanced users to install a custom tracker instance
+    (e.g. one that is pre-configured or shared across meshes) without
+    reaching into private module state.
+
+    Args:
+        tracker (:class:`_RNGStateTracker`): The tracker instance to install.
+
+    Returns:
+        None
+    """
+    global _rng_tracker
+    if not isinstance(tracker, _RNGStateTracker):
+        raise TypeError(
+            f"tracker must be an instance of _RNGStateTracker, got {tracker!r}"
+        )
+    _rng_tracker = tracker
+
+
+def get_or_create_rng_tracker(
+    device_mesh: DeviceMesh, run_state_sync: bool
+) -> "_RNGStateTracker":
+    """Return the active RNG tracker, creating it if it does not exist yet.
+
+    Centralizes the tracker creation logic used by the creation points in
+    ``manual_seed``, ``torch/distributed/tensor/_dispatch.py`` and
+    ``torch/distributed/tensor/_api.py``. The tracker class is looked up in
+    the registry populated by :func:`register_rng_tracker`; devices without
+    an entry fall back to the default :class:`OffsetBasedRNGTracker`.
+
+    Args:
+        device_mesh (:class:`DeviceMesh`): The device mesh the tracker manages.
+        run_state_sync (bool): Whether to synchronize RNG state across ranks
+            on creation (see :class:`OffsetBasedRNGTracker`).
+
+    Returns:
+        The active :class:`_RNGStateTracker` instance.
+    """
+    global _rng_tracker
+    if not _rng_tracker:
+        tracker_cls = _RNG_TRACKER_REGISTRY.get(
+            device_mesh.device_type, OffsetBasedRNGTracker
+        )
+        _rng_tracker = tracker_cls(device_mesh, run_state_sync)
+    return _rng_tracker
+
 
 def is_rng_supported_mesh(device_mesh: DeviceMesh) -> bool:
     """Checks if the current device of ``device_mesh`` supports DTensor's random APIs.
-    Currently DTensor Random APIs only supports cuda/cuda-like devices. We suggest
-    users call this API to test the availability before using our random APIs.
+    A device type with a tracker registered via :func:`register_rng_tracker` is
+    considered supported. Otherwise we probe the device module for RNG state
+    APIs. We suggest users call this API to test the availability before using
+    our random APIs.
 
     Args:
         device_mesh (:class:`DeviceMesh`): The device mesh on which we check if the
@@ -38,8 +129,11 @@ def is_rng_supported_mesh(device_mesh: DeviceMesh) -> bool:
         A bool value. True if ``device_mesh`` supports DTensor Random APIs; False otherwise.
 
     .. warning::
-        Currently we only support correct RNG on cuda/cuda-like devices.
+        Without a registered tracker, correct RNG is only guaranteed on
+        cuda/cuda-like devices.
     """
+    if device_mesh.device_type in _RNG_TRACKER_REGISTRY:
+        return True
     device_handle = _get_device_handle(device_mesh.device_type)
     if device_handle and hasattr(device_handle, "set_rng_state"):
         return True
@@ -90,10 +184,9 @@ def manual_seed(seed: int, device_mesh: DeviceMesh) -> None:
     # Note: we still need to ensure setting `run_state_sync=False` to support the pp case
 
     # instantiate a RNG tracker if haven't. By default DTensor uses an
-    # OffsetBasedRNGTracker to perform random operators.
-    global _rng_tracker
-    if not _rng_tracker:
-        _rng_tracker = OffsetBasedRNGTracker(device_mesh, run_state_sync=False)
+    # OffsetBasedRNGTracker to perform random operators, unless the device
+    # type has a tracker registered via ``register_rng_tracker``.
+    get_or_create_rng_tracker(device_mesh, run_state_sync=False)
 
     if device_mesh.get_coordinate() is None:
         raise RuntimeError(
@@ -180,6 +273,24 @@ class _RNGStateTracker:
 
     def _manual_seed(self, parallel_seed: int) -> None:
         pass
+
+    def _compute_rng_offsets(self, spec: DTensorSpec) -> tuple[int, int]:
+        """Compute the RNG offset increments for a distributed random op.
+
+        Optional contract for counter-based (offset-based) RNG trackers:
+        returns ``(start_offset_incr, end_offset_incr)`` for the DTensor
+        described by ``spec``. Trackers that implement this contract enable
+        the traceable HOP path in ``torch/distributed/tensor/_dispatch.py``
+        (``run_dtensor_rng_op``). Trackers whose RNG is not counter-based
+        leave this unimplemented and run random ops under
+        ``_distribute_region`` instead.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement the counter-based "
+            f"RNG offset contract (_compute_rng_offsets); random ops on this "
+            f"tracker run under _distribute_region instead of the "
+            f"run_dtensor_rng_op HOP path."
+        )
 
 
 class OffsetBasedRNGTracker(_RNGStateTracker):


### PR DESCRIPTION
## Summary

DTensor RNG (`torch/distributed/tensor/_random.py`) hardcodes `OffsetBasedRNGTracker` at every tracker creation point. A third-party backend whose RNG state does not follow the CUDA philox offset-based contract has no way to plug in its own tracker without monkey-patching the private `_rng_tracker` module global.

This PR adds a small registry, mirroring the existing `register_graphsafe_rng_dispatch` pattern in `torch/_prims/rng_prims.py`:

- `register_rng_tracker(device_type, tracker_cls)` registers a `_RNGStateTracker` subclass for a device type.
- `get_or_create_rng_tracker(device_mesh, run_state_sync)` centralizes tracker creation, returning the registered class when present and falling back to `OffsetBasedRNGTracker` otherwise.
- `set_rng_tracker(tracker)` is the public form of assigning the module global.
- `is_rng_supported_mesh` reports a mesh as RNG-supported when its device type has a registered tracker (previously derived only from the device handle probe).
- `_RNGStateTracker._compute_rng_offsets` documents the counter-based offset contract with a `NotImplementedError` default, so non-counter-based trackers can opt out of the `run_dtensor_rng_op` HOP path (consumed by the follow-up PR).

No behavior change for existing devices: cuda/xpu continue to resolve to `OffsetBasedRNGTracker` exactly as before. The consumption points in `_dispatch.py` / `_api.py` / `rng_prims.py` are wired in a stacked PR.

## Motivation / evidence

On Ascend NPU (torch_npu), DTensor random ops under `Shard` placements currently produce silently-wrong values: the philox state layout is compatible, but the offset-to-value mapping differs (8 values consumed advance the offset by 12, not 8), so rank 1's shard does not match the single-process reference while rank 0's does (verified with a 2-rank `dt.uniform_` experiment; a manual `offset=8` state exactly reproduces rank 1's shard). Today there is no way for torch_npu to supply a correct tracker without forking core.

## Test plan

- [x] New `RNGTrackerRegistryTest` (CPU-runnable): type checks on registration, `set_rng_tracker`, registered tracker created at `manual_seed`, `get_or_create_rng_tracker` returns the existing instance, unregistered behavior unchanged (warning + `False`), `_compute_rng_offsets` contract.
- [x] Existing `test/distributed/tensor/test_random_ops.py` suites pass unchanged (container run: `Ran 6 tests ... OK` plus existing suites).
- [ ] CI.

cc @ezyang @fduwjj @wanchaol

