### PR TITLE
Consume registered RNG trackers in DTensor random-op dispatch

### DIFF
--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -1062,6 +1062,120 @@ class DistTensorRandomOpsTest3D(DTensorTestBase):
         compute_rankwise_if_local_tensor(weight_local, self.rank)
 
 
+class RNGTrackerRegistryTest(DTensorTestBase):
+    """Tests for the RNG tracker registration API (``register_rng_tracker``,
+    ``set_rng_tracker``, ``get_or_create_rng_tracker``).
+
+    These tests are CPU-runnable: they use a cpu device mesh and fake tracker
+    classes, so no accelerator is required.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # isolate the global tracker/registry state between tests
+        self._saved_tracker = random._rng_tracker
+        self._saved_registry = dict(random._RNG_TRACKER_REGISTRY)
+
+    def tearDown(self):
+        random._rng_tracker = self._saved_tracker
+        random._RNG_TRACKER_REGISTRY.clear()
+        random._RNG_TRACKER_REGISTRY.update(self._saved_registry)
+        super().tearDown()
+
+    @with_comms
+    def test_register_rng_tracker_type_check(self):
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+
+        with self.assertRaises(TypeError):
+            random.register_rng_tracker("cpu", object)  # type: ignore[arg-type]
+        with self.assertRaises(TypeError):
+            random.register_rng_tracker("cpu", FakeTracker(None, False))  # type: ignore[arg-type]
+        random.register_rng_tracker("cpu", FakeTracker)
+        self.assertIs(random._RNG_TRACKER_REGISTRY["cpu"], FakeTracker)
+
+        # registering again overrides the previous entry
+        random.register_rng_tracker("cpu", FakeTracker)
+        self.assertIs(random._RNG_TRACKER_REGISTRY["cpu"], FakeTracker)
+
+    @with_comms
+    def test_set_rng_tracker(self):
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+
+        fake = FakeTracker(None, False)
+        with self.assertRaises(TypeError):
+            random.set_rng_tracker(object())  # type: ignore[arg-type]
+        random.set_rng_tracker(fake)
+        self.assertIs(random._rng_tracker, fake)
+
+    @with_comms
+    def test_registered_tracker_created_at_manual_seed(self):
+        created = []
+
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                created.append((device_mesh, run_state_sync))
+                self.device_mesh = device_mesh
+
+            def _distribute_region(self, spec, generator=None):
+                yield
+
+        device_mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+        # torch.cpu has no ``set_rng_state``, so without a registration the cpu
+        # mesh is reported unsupported; a registered tracker makes it supported
+        self.assertFalse(is_rng_supported_mesh(device_mesh))
+        random.register_rng_tracker("cpu", FakeTracker)
+        self.assertTrue(is_rng_supported_mesh(device_mesh))
+
+        # the creation point in manual_seed instantiates the registered class
+        # instead of the default OffsetBasedRNGTracker
+        manual_seed(42, device_mesh)
+        self.assertEqual(len(created), 1)
+        self.assertIs(created[0][0], device_mesh)
+        self.assertFalse(created[0][1])  # manual_seed uses run_state_sync=False
+        self.assertIsInstance(random._rng_tracker, FakeTracker)
+
+    @with_comms
+    def test_get_or_create_rng_tracker_returns_existing(self):
+        # get_or_create returns the already-created instance instead of
+        # re-creating, and passes run_state_sync through to the constructor
+        device_mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+                self.run_state_sync = run_state_sync
+
+        random.register_rng_tracker("cpu", FakeTracker)
+        tracker = random.get_or_create_rng_tracker(device_mesh, True)
+        self.assertIsInstance(tracker, FakeTracker)
+        self.assertTrue(tracker.run_state_sync)
+        # second call returns the same instance instead of re-creating
+        self.assertIs(random.get_or_create_rng_tracker(device_mesh, True), tracker)
+
+    @with_comms
+    def test_unregistered_behavior_unchanged(self):
+        device_mesh = DeviceMesh("cpu", torch.arange(self.world_size))
+        with self.assertWarns(UserWarning):
+            self.assertFalse(is_rng_supported_mesh(device_mesh))
+        self.assertIsNone(random._rng_tracker)
+
+    def test_compute_rng_offsets_contract(self):
+        # trackers that do not implement the counter-based offset contract
+        # must raise NotImplementedError (consumed by the capability probe in
+        # torch/distributed/tensor/_dispatch.py)
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+
+        fake = FakeTracker(None, False)
+        with self.assertRaises(NotImplementedError):
+            fake._compute_rng_offsets(None)  # type: ignore[arg-type]
+
+
 DistTensorRandomInitTestWithLocalTensor = create_local_tensor_test_class(
     DistTensorRandomInitTest,
 )

--- a/test/distributed/tensor/test_random_ops.py
+++ b/test/distributed/tensor/test_random_ops.py
@@ -760,6 +760,54 @@ class DistTensorRandomOpTest(DTensorTestBase):
         self.assertEqual(out.device.type, self.device_type)
         self.assertEqual(offset_after, offset_before + 4)
 
+    @skip_unless_torch_gpu
+    def test_register_run_dtensor_rng_dispatch(self):
+        """register_run_dtensor_rng_dispatch registers a py_impl idempotently."""
+        from torch._C import DispatchKey
+        from torch._prims.rng_prims import register_run_dtensor_rng_dispatch
+
+        register_run_dtensor_rng_dispatch(DispatchKey.PrivateUse1)
+        # registering the same key twice is a no-op
+        register_run_dtensor_rng_dispatch(DispatchKey.PrivateUse1)
+
+    @with_comms
+    @skip_unless_torch_gpu
+    def test_registered_tracker_falls_back_from_hop(self):
+        """A tracker registered via register_rng_tracker that does not implement
+        the counter-based offset contract runs random ops under _distribute_region
+        instead of the run_dtensor_rng_op HOP path (previously this raised an
+        AssertionError at the isinstance gate)."""
+        import contextlib
+
+        class FakeTracker(random._RNGStateTracker):
+            def __init__(self, device_mesh, run_state_sync):
+                self.device_mesh = device_mesh
+                self._use_distribute_region = True
+
+            @contextlib.contextmanager
+            def _distribute_region(self, spec, generator=None):
+                yield
+
+        device_mesh = DeviceMesh(self.device_type, torch.arange(self.world_size))
+        random.register_rng_tracker(self.device_type, FakeTracker)
+        saved_tracker = random._rng_tracker
+        try:
+            # manual_seed is the creation point that consults the registry
+            random.manual_seed(0, device_mesh)
+            self.assertIsInstance(random._rng_tracker, FakeTracker)
+            dt = distribute_tensor(
+                torch.empty([self.world_size], device=self.device_type),
+                device_mesh,
+                [Shard(0)],
+            )
+            # before the capability-probe change this raised
+            # AssertionError: tracker is not OffsetBasedRNGTracker
+            dt.uniform_(0, 1)
+            self.assertIsInstance(random._rng_tracker, FakeTracker)
+        finally:
+            random._rng_tracker = saved_tracker
+            random._RNG_TRACKER_REGISTRY.pop(self.device_type, None)
+
 
 class DistTensorRandomOpCompileTest(DTensorTestBase):
     def _run_with_seed(self, fn, create_input, num_runs):

--- a/torch/_prims/rng_prims.py
+++ b/torch/_prims/rng_prims.py
@@ -1,5 +1,5 @@
 # mypy: allow-untyped-defs
-from typing import cast
+from typing import Any, Callable, cast
 
 import torch
 import torch.utils._pytree as pytree
@@ -490,6 +490,11 @@ def register_run_dtensor_rng_op():
     run_dtensor_rng_op.py_impl(DispatchKey.CUDA)(_impl_device)
     run_dtensor_rng_op.py_impl(DispatchKey.XPU)(_impl_device)
 
+    # expose the device-generic impl to the module-level registration API
+    # (register_run_dtensor_rng_dispatch, defined below)
+    global _impl_run_dtensor_rng_device
+    _impl_run_dtensor_rng_device = _impl_device
+
     @run_dtensor_rng_op.py_impl(DispatchKey.BackendSelect)
     def impl_backend_select(start_offset_incr, end_offset_incr, op, *args, **kwargs):
         device = get_device(args, kwargs)
@@ -542,7 +547,40 @@ def register_run_dtensor_rng_op():
     return run_dtensor_rng_op
 
 
+# reference to the device-generic run_dtensor_rng_op impl, populated by
+# register_run_dtensor_rng_op() below and consumed by
+# register_run_dtensor_rng_dispatch below
+_impl_run_dtensor_rng_device: Callable[..., Any] | None = None
+
 run_dtensor_rng_op = register_run_dtensor_rng_op()
+
+_registered_dtensor_rng_dispatch_keys: set["DispatchKey"] = set()
+
+
+def register_run_dtensor_rng_dispatch(dispatch_key: "DispatchKey") -> None:
+    """Register ``run_dtensor_rng_op`` py_impl for a dispatch key.
+
+    This is the entry point for third-party backends (e.g. privateuse1
+    devices) whose RNG follows the counter-based (philox-style seed/offset)
+    contract to use the traceable DTensor RNG higher-order operator, instead
+    of each backend requiring a core-side code change. The backend's RNG
+    tracker (registered via
+    ``torch.distributed.tensor._random.register_rng_tracker``) must implement
+    the offset contract (``_compute_rng_offsets``).
+
+    This follows the same registration pattern as
+    ``register_graphsafe_rng_dispatch`` in this module.
+    """
+    if _impl_run_dtensor_rng_device is None:
+        raise RuntimeError(
+            "run_dtensor_rng_op has not been registered yet; "
+            "register_run_dtensor_rng_dispatch must be called after "
+            "importing torch"
+        )
+    if dispatch_key in _registered_dtensor_rng_dispatch_keys:
+        return
+    _registered_dtensor_rng_dispatch_keys.add(dispatch_key)
+    run_dtensor_rng_op.py_impl(dispatch_key)(_impl_run_dtensor_rng_device)
 
 
 def register_rng_prims():

--- a/torch/distributed/tensor/_api.py
+++ b/torch/distributed/tensor/_api.py
@@ -1492,7 +1492,8 @@ def _dtensor_init_helper(  # type: ignore[no-untyped-def]
         spec = DTensorSpec(device_mesh, tuple(placements), tensor_meta=tensor_meta)
 
         if random.is_rng_supported_mesh(device_mesh) and not random._rng_tracker:
-            random._rng_tracker = random.OffsetBasedRNGTracker(device_mesh)
+            # create the default (or device-registered) RNG tracker
+            random.get_or_create_rng_tracker(device_mesh, run_state_sync=True)
 
         if random._rng_tracker is None:
             raise AssertionError

--- a/torch/distributed/tensor/_dispatch.py
+++ b/torch/distributed/tensor/_dispatch.py
@@ -374,7 +374,9 @@ class OpDispatcher:
             local_tensor_args = cast(tuple[object, ...], local_tensor_args)
             if op_call in self._random_ops:
                 if not random._rng_tracker and is_rng_supported_mesh(mesh):
-                    # Default to `OffsetBasedRNGTracker` if the parallelism API did not already construct one
+                    # Default to `OffsetBasedRNGTracker` (or the device's
+                    # registered tracker) if the parallelism API did not
+                    # already construct one
                     # Skip RNG state sync during tracing to avoid lazily initializing real RNG state under fake mode.
                     run_state_sync = not _are_we_tracing()
                     if not run_state_sync:
@@ -385,9 +387,7 @@ class OpDispatcher:
                             "the same seed on all ranks before compiling DTensor random ops.",
                             stacklevel=2,
                         )
-                    random._rng_tracker = random.OffsetBasedRNGTracker(
-                        mesh, run_state_sync
-                    )
+                    random.get_or_create_rng_tracker(mesh, run_state_sync)
 
                 first_arg, first_local_arg = (
                     cast(dtensor.DTensor, args[0]),
@@ -410,6 +410,20 @@ class OpDispatcher:
                     and random._rng_tracker.distribute_region_enabled
                 ):
                     accelerator = torch.accelerator.current_accelerator()
+
+                    def _run_op_under_distribute_region():
+                        # shared execution block for the generic
+                        # (non-counter-based) RNG path
+                        with random._rng_tracker._distribute_region(
+                            first_arg._spec, generator=maybe_user_generator
+                        ):
+                            with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
+                                output_sharding.output_spec
+                            ):
+                                return op_call(
+                                    *local_tensor_args, **op_info.local_kwargs
+                                )
+
                     if (
                         maybe_user_generator is not None
                         or accelerator is None
@@ -419,34 +433,32 @@ class OpDispatcher:
                             and type(first_local_arg) is not torch.Tensor
                         )
                     ):
-                        with random._rng_tracker._distribute_region(
-                            first_arg._spec, generator=maybe_user_generator
-                        ):
+                        local_results = _run_op_under_distribute_region()
+                    else:
+                        # Accelerator device without user generator: use the
+                        # traceable HOP when the tracker implements the
+                        # counter-based offset contract; otherwise (e.g. a
+                        # custom tracker registered via ``register_rng_tracker``)
+                        # fall back to the generic distribute-region path.
+                        try:
+                            start_offset_incr, end_offset_incr = (
+                                random._rng_tracker._compute_rng_offsets(
+                                    first_arg._spec
+                                )
+                            )
+                        except NotImplementedError:
+                            local_results = _run_op_under_distribute_region()
+                        else:
                             with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
                                 output_sharding.output_spec
                             ):
-                                local_results = op_call(
-                                    *local_tensor_args, **op_info.local_kwargs
+                                local_results = run_dtensor_rng_op(
+                                    start_offset_incr,
+                                    end_offset_incr,
+                                    op_call,
+                                    *local_tensor_args,
+                                    **op_info.local_kwargs,
                                 )
-                    else:
-                        # Accelerator device without user generator, use HOP for traceability
-                        if not isinstance(
-                            random._rng_tracker, random.OffsetBasedRNGTracker
-                        ):
-                            raise AssertionError
-                        start_offset_incr, end_offset_incr = (
-                            random._rng_tracker._compute_rng_offsets(first_arg._spec)
-                        )
-                        with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(
-                            output_sharding.output_spec
-                        ):
-                            local_results = run_dtensor_rng_op(
-                                start_offset_incr,
-                                end_offset_incr,
-                                op_call,
-                                *local_tensor_args,
-                                **op_info.local_kwargs,
-                            )
                 else:
                     # No rng_tracker, meta tensor, or distribute_region disabled
                     with _ignore_fresh_unbacked_symbols_for_dtensor_tracing(

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -20,15 +20,106 @@ __all__ = [
     "is_rng_supported_mesh",
     "manual_seed",
     "OffsetBasedRNGTracker",
+    "register_rng_tracker",
+    "set_rng_tracker",
+    "get_or_create_rng_tracker",
 ]
 
 _rng_tracker: Optional["_RNGStateTracker"] = None
 
+# Registry of RNG tracker classes per device type, populated by third-party
+# backends (e.g. privateuse1 devices) via ``register_rng_tracker``. Devices
+# without an entry keep the default ``OffsetBasedRNGTracker`` behavior.
+_RNG_TRACKER_REGISTRY: dict[str, type["_RNGStateTracker"]] = {}
+
+
+def register_rng_tracker(device_type: str, tracker_cls: type["_RNGStateTracker"]) -> None:
+    """Register a custom RNG tracker class for a device type.
+
+    Third-party backends whose RNG does not follow the CUDA philox
+    counter/offset semantics assumed by the default
+    :class:`OffsetBasedRNGTracker` can register their own tracker here. A
+    registered tracker is instantiated by the DTensor random-op machinery
+    (``manual_seed`` and the creation points in ``_dispatch.py``/``_api.py``)
+    in place of the default one, without monkey-patching the private
+    ``_rng_tracker`` module global.
+
+    The tracker class must subclass ``_RNGStateTracker`` and accept the
+    constructor signature ``(device_mesh: DeviceMesh, run_state_sync: bool)``.
+
+    This follows the same registration pattern as
+    ``register_graphsafe_rng_dispatch`` in ``torch/_prims/rng_prims.py``.
+
+    Args:
+        device_type (str): The device type the tracker handles (e.g. ``"npu"``).
+        tracker_cls (type): The tracker class to register.
+
+    Returns:
+        None
+    """
+    if not (isinstance(tracker_cls, type) and issubclass(tracker_cls, _RNGStateTracker)):
+        raise TypeError(
+            f"tracker_cls must be a subclass of _RNGStateTracker, got {tracker_cls!r}"
+        )
+    _RNG_TRACKER_REGISTRY[device_type] = tracker_cls
+
+
+def set_rng_tracker(tracker: "_RNGStateTracker") -> None:
+    """Set the active RNG tracker instance directly.
+
+    This is the public form of assigning the private ``_rng_tracker`` module
+    global. It allows advanced users to install a custom tracker instance
+    (e.g. one that is pre-configured or shared across meshes) without
+    reaching into private module state.
+
+    Args:
+        tracker (:class:`_RNGStateTracker`): The tracker instance to install.
+
+    Returns:
+        None
+    """
+    global _rng_tracker
+    if not isinstance(tracker, _RNGStateTracker):
+        raise TypeError(
+            f"tracker must be an instance of _RNGStateTracker, got {tracker!r}"
+        )
+    _rng_tracker = tracker
+
+
+def get_or_create_rng_tracker(
+    device_mesh: DeviceMesh, run_state_sync: bool
+) -> "_RNGStateTracker":
+    """Return the active RNG tracker, creating it if it does not exist yet.
+
+    Centralizes the tracker creation logic used by the creation points in
+    ``manual_seed``, ``torch/distributed/tensor/_dispatch.py`` and
+    ``torch/distributed/tensor/_api.py``. The tracker class is looked up in
+    the registry populated by :func:`register_rng_tracker`; devices without
+    an entry fall back to the default :class:`OffsetBasedRNGTracker`.
+
+    Args:
+        device_mesh (:class:`DeviceMesh`): The device mesh the tracker manages.
+        run_state_sync (bool): Whether to synchronize RNG state across ranks
+            on creation (see :class:`OffsetBasedRNGTracker`).
+
+    Returns:
+        The active :class:`_RNGStateTracker` instance.
+    """
+    global _rng_tracker
+    if not _rng_tracker:
+        tracker_cls = _RNG_TRACKER_REGISTRY.get(
+            device_mesh.device_type, OffsetBasedRNGTracker
+        )
+        _rng_tracker = tracker_cls(device_mesh, run_state_sync)
+    return _rng_tracker
+
 
 def is_rng_supported_mesh(device_mesh: DeviceMesh) -> bool:
     """Checks if the current device of ``device_mesh`` supports DTensor's random APIs.
-    Currently DTensor Random APIs only supports cuda/cuda-like devices. We suggest
-    users call this API to test the availability before using our random APIs.
+    A device type with a tracker registered via :func:`register_rng_tracker` is
+    considered supported. Otherwise we probe the device module for RNG state
+    APIs. We suggest users call this API to test the availability before using
+    our random APIs.
 
     Args:
         device_mesh (:class:`DeviceMesh`): The device mesh on which we check if the
@@ -38,8 +129,11 @@ def is_rng_supported_mesh(device_mesh: DeviceMesh) -> bool:
         A bool value. True if ``device_mesh`` supports DTensor Random APIs; False otherwise.
 
     .. warning::
-        Currently we only support correct RNG on cuda/cuda-like devices.
+        Without a registered tracker, correct RNG is only guaranteed on
+        cuda/cuda-like devices.
     """
+    if device_mesh.device_type in _RNG_TRACKER_REGISTRY:
+        return True
     device_handle = _get_device_handle(device_mesh.device_type)
     if device_handle and hasattr(device_handle, "set_rng_state"):
         return True
@@ -90,10 +184,9 @@ def manual_seed(seed: int, device_mesh: DeviceMesh) -> None:
     # Note: we still need to ensure setting `run_state_sync=False` to support the pp case
 
     # instantiate a RNG tracker if haven't. By default DTensor uses an
-    # OffsetBasedRNGTracker to perform random operators.
-    global _rng_tracker
-    if not _rng_tracker:
-        _rng_tracker = OffsetBasedRNGTracker(device_mesh, run_state_sync=False)
+    # OffsetBasedRNGTracker to perform random operators, unless the device
+    # type has a tracker registered via ``register_rng_tracker``.
+    get_or_create_rng_tracker(device_mesh, run_state_sync=False)
 
     if device_mesh.get_coordinate() is None:
         raise RuntimeError(
@@ -180,6 +273,24 @@ class _RNGStateTracker:
 
     def _manual_seed(self, parallel_seed: int) -> None:
         pass
+
+    def _compute_rng_offsets(self, spec: DTensorSpec) -> tuple[int, int]:
+        """Compute the RNG offset increments for a distributed random op.
+
+        Optional contract for counter-based (offset-based) RNG trackers:
+        returns ``(start_offset_incr, end_offset_incr)`` for the DTensor
+        described by ``spec``. Trackers that implement this contract enable
+        the traceable HOP path in ``torch/distributed/tensor/_dispatch.py``
+        (``run_dtensor_rng_op``). Trackers whose RNG is not counter-based
+        leave this unimplemented and run random ops under
+        ``_distribute_region`` instead.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement the counter-based "
+            f"RNG offset contract (_compute_rng_offsets); random ops on this "
+            f"tracker run under _distribute_region instead of the "
+            f"run_dtensor_rng_op HOP path."
+        )
 
 
 class OffsetBasedRNGTracker(_RNGStateTracker):

--- a/torch/distributed/tensor/_random.py
+++ b/torch/distributed/tensor/_random.py
@@ -299,7 +299,9 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
     should be shared and synchronized among all ranks to respect the semantics of DTensor
     random operators.
 
-    note: _RNGStateTracker only supports cuda/cuda-like device.
+    note: the default policy assumes a cuda/cuda-like philox RNG. Devices whose
+    RNG does not follow those semantics should register their own tracker via
+    :func:`register_rng_tracker`.
     """
 
     def __init__(
@@ -310,11 +312,13 @@ class OffsetBasedRNGTracker(_RNGStateTracker):
         super().__init__(_resolve_device(device_mesh=device_mesh))
         if self._device_handle is None:
             raise AssertionError
-        # DTensor RNG tracker so far only supports CUDA/CUDA-like devices
+        # the default tracker assumes a non-cpu device module with
+        # philox-style RNG state APIs
         if self._device.type == "cpu":
             raise RuntimeError(
-                f"{self.__class__.__name__} instantiation requires the presence of "
-                f"CUDA/CUDA-like/XPU device. Got {self._device.type} instead."
+                f"{self.__class__.__name__} instantiation requires a non-cpu "
+                f"device with device-module RNG state APIs. Got "
+                f"{self._device.type} instead."
             )
 
         if run_state_sync:


### PR DESCRIPTION
## Summary

**Stacked on #195245** (`register_rng_tracker` API) — only the last commit is new; please review the `_dispatch.py` / `_api.py` / `rng_prims.py` wiring here.

Wires the RNG tracker registry into the three consumption points that previously assumed an `OffsetBasedRNGTracker`:

- **`_dispatch.py`**: the tracker creation point uses `get_or_create_rng_tracker`; the accelerator HOP gate now probes the tracker for the counter-based offset contract (`_compute_rng_offsets`) instead of asserting `isinstance(tracker, OffsetBasedRNGTracker)`. A tracker that opts out (e.g. a backend whose RNG is not philox-offset-based) falls back to the generic `_distribute_region` path — the behavior before #187969 — instead of crashing the dispatch.
- **`_api.py`**: DTensor device-mesh init uses `get_or_create_rng_tracker`.
- **`rng_prims.py`**: adds `register_run_dtensor_rng_dispatch(dispatch_key)` so a backend can register the device-generic `run_dtensor_rng_op` impl under its own dispatch key (mirrors `register_graphsafe_rng_dispatch`), instead of requiring a core-side `py_impl` registration for each new device.

## Behavior notes

For unregistered devices (cuda/xpu) behavior is bit-identical to main: `OffsetBasedRNGTracker` implements `_compute_rng_offsets`, so the HOP path is taken exactly as before. Verified on Ascend NPU (torch_npu, 2-rank HCCL):

- without registration, 2-rank `DTensor` `Shard(0)` `uniform_` output matches upstream main byte-for-byte;
- with a registered custom tracker, random ops run under `_distribute_region` and rank shards match the single-process reference (`R0 == ref[0:8]`), where the current code path either crashes at the removed `isinstance` assertion or silently produces wrong shards.

## Test plan

- [x] `test_register_run_dtensor_rng_dispatch`: registers `DispatchKey.PrivateUse1` idempotently.
- [x] `test_registered_tracker_falls_back_from_hop`: registered tracker without the offset contract runs `uniform_` under `_distribute_region` (previously `AssertionError`).
- [x] Full `RNGTrackerRegistryTest` + existing suites pass in container.
- [ ] CI.

cc @ezyang @fduwjj @wanchaol