### PR TITLE
Generalize RemoteModule device handling beyond CUDA

### DIFF
--- a/test/distributed/nn/jit/test_instantiator.py
+++ b/test/distributed/nn/jit/test_instantiator.py
@@ -57,6 +57,45 @@ class TestInstantiator(TestCase):
         self.assertTrue(hasattr(generated_module, "_remote_forward"))
         self.assertTrue(hasattr(generated_module, "_generated_methods"))
 
+    def test_template_variant_cache_key(self):
+        # The same interface class can be used by both a RemoteModule on an
+        # accelerator device and one on cpu. The two must instantiate different
+        # template variants: the cache key in ``sys.modules`` must include
+        # ``enable_moving_cpu_tensors_to_cuda``. Otherwise the second
+        # instantiation silently reuses the first one's variant.
+        device_module = instantiator.instantiate_scriptable_remote_module_template(
+            MyModuleInterface, enable_moving_cpu_tensors_to_cuda=True
+        )
+        cpu_module = instantiator.instantiate_scriptable_remote_module_template(
+            MyModuleInterface, enable_moving_cpu_tensors_to_cuda=False
+        )
+        self.assertIsNot(device_module, cpu_module)
+        # Repeated instantiation of the same variant still hits the cache.
+        self.assertIs(
+            cpu_module,
+            instantiator.instantiate_scriptable_remote_module_template(
+                MyModuleInterface, enable_moving_cpu_tensors_to_cuda=False
+            ),
+        )
+        # The device variant moves CPU tensors to the device; the cpu variant
+        # must not contain the moving logic at all.
+        device_source = device_module.__loader__.get_source(device_module.__name__)
+        cpu_source = cpu_module.__loader__.get_source(cpu_module.__name__)
+        self.assertIn("out_args", device_source)
+        self.assertNotIn("out_args", cpu_source)
+
+    def test_template_device_branch_is_device_generic(self):
+        # The moving template must gate on ``device.type == "cpu"`` (early
+        # return for cpu) instead of ``device.type != "cuda"``, so that
+        # tensors are moved for any non-cpu device (cuda, xpu, npu, ...)
+        # registered by a backend, not just cuda.
+        generated_module = instantiator.instantiate_scriptable_remote_module_template(
+            MyModuleInterface, enable_moving_cpu_tensors_to_cuda=True
+        )
+        source = generated_module.__loader__.get_source(generated_module.__name__)
+        self.assertIn('if device.type == "cpu":', source)
+        self.assertNotIn('!= "cuda"', source)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/nn/api/remote_module.py
+++ b/torch/distributed/nn/api/remote_module.py
@@ -477,7 +477,13 @@ class _RemoteModule(nn.Module):
         # If ``enable_moving_cpu_tensors_to_cuda`` is true, but the device map is not set,
         # then any CPU tensors can still be moved to a cuda device to run forward,
         # but the output must be moved back to CPU before being sent over the wire.
-        enable_moving_cpu_tensors_to_cuda = torch.device(self.device).type == "cuda"
+        # Instead of hardcoding ``"cuda"``, enable this for any non-CPU device type
+        # that is registered in torch (e.g., cuda, xpu, npu, ...), so that
+        # third-party backends do not need to fork this module.
+        device_type = torch.device(self.device).type
+        enable_moving_cpu_tensors_to_cuda = (
+            device_type != "cpu" and getattr(torch, device_type, None) is not None
+        )
         return enable_moving_cpu_tensors_to_cuda
 
     def _init_template(self, module_interface_cls, enable_moving_cpu_tensors_to_cuda):

--- a/torch/distributed/nn/jit/instantiator.py
+++ b/torch/distributed/nn/jit/instantiator.py
@@ -123,11 +123,21 @@ def instantiate_scriptable_remote_module_template(
             "@torch.jit.interface"
         )
 
-    # Generate the template instance name.
+    # Generate the template instance name. The generated module's behavior
+    # depends on ``enable_moving_cpu_tensors_to_cuda``, so the flag must be part
+    # of the module name, which serves as the cache key in ``sys.modules``.
+    # Otherwise, instantiating the same interface class first for a cuda device
+    # and then for a cpu device would incorrectly reuse the cached cuda variant
+    # (and vice versa).
     module_interface_cls_name = torch._jit_internal._qualified_name(
         module_interface_cls
     ).replace(".", "_")
-    generated_module_name = f"{_FILE_PREFIX}{module_interface_cls_name}"
+    variant_suffix = (
+        "_enable_moving_cpu_tensors_to_cuda" if enable_moving_cpu_tensors_to_cuda else ""
+    )
+    generated_module_name = (
+        f"{_FILE_PREFIX}{module_interface_cls_name}{variant_suffix}"
+    )
 
     # Generate type annotation strs.
     assign_module_interface_cls_str = (

--- a/torch/distributed/nn/jit/templates/remote_module_template.py
+++ b/torch/distributed/nn/jit/templates/remote_module_template.py
@@ -65,11 +65,11 @@ def _remote_forward(
     module = module_rref.local_value()
     device = torch.device(device)
 
-    if device.type != "cuda":
+    if device.type == "cpu":
         return module.forward({args}, {kwargs})
 
-    # If the module is on a cuda device,
-    # move any CPU tensor in args or kwargs to the same cuda device.
+    # If the module is on a non-CPU device (e.g., cuda, xpu, npu, ...),
+    # move any CPU tensor in args or kwargs to the same device.
     # Since torch script does not support generator expression,
     # have to use concatenation instead of
     # ``tuple(i.to(device) if isinstance(i, Tensor) else i for i in *args)``.


### PR DESCRIPTION
## Summary

`RemoteModule` hardcodes CUDA in three places, which breaks RPC module placement on any other registered device (xpu, npu, ...) without forking:

1. **`remote_module.py`**: `enable_moving_cpu_tensors_to_cuda` was `torch.device(self.device).type == "cuda"`. Now any non-cpu device type that is registered in torch (`getattr(torch, device_type, None) is not None`) enables input moving.
2. **`remote_module_template.py`**: the moving template gated on `device.type != "cuda"` (early-return for everything but CUDA). Now gates on `device.type == "cpu"` so every non-cpu device gets input/output moving.
3. **`instantiator.py`**: the generated module name doubles as the `sys.modules` cache key but did not include `enable_moving_cpu_tensors_to_cuda`, so instantiating the same interface class first for a cuda device and then for a cpu device silently reused the cached cuda variant (and vice versa). The flag is now part of the cache key. This is an independent latent bugfix — a red/green test is included.

Behavior for cpu and cuda is unchanged.

## Motivation / evidence

On Ascend NPU (torch_npu, TensorPipe RPC, world_size=1): `RemoteModule("worker0/npu:0", nn.Linear, (4, 4))` + `forward(cpu_tensor)` previously failed loudly with

```
RuntimeError: Expected all tensors to be on the same device, but got mat1 is on cpu, different from other tensors on npu:0
```

because the flag selected the non-moving template for npu. With this change the CPU input is moved to `npu:0`, forward runs, and outputs are moved back to cpu before being sent over the wire (verified end-to-end in container).

## Test plan

- [x] `test_template_variant_cache_key` (red on main, green here): same interface class instantiated for a device and for cpu selects the correct template variant each time; repeated instantiation of the same variant still hits the cache.
- [x] `test_template_device_branch_is_device_generic`: the moving template gates on `device.type == "cpu"`.
- [x] Existing `test/distributed/nn/jit/test_instantiator.py` suites pass.
- [ ] `test/distributed/rpc` remote-module suites (incl. `CudaRemoteModuleTest.test_input_moved_to_cuda_device`) on CUDA CI.
- [ ] CI.

cc @ezyang @fduwjj @wanchaol @pritamdamania87