### PR TITLE
Fall back to full-state RNG sync check for non-philox devices

### DIFF
--- a/test/distributed/test_collective_utils.py
+++ b/test/distributed/test_collective_utils.py
@@ -216,6 +216,35 @@ class TestUtils(TestCase):
             "1",
         )
 
+    def test_check_rng_sync_internal_dispatch(self):
+        # cuda/xpu generators use the Philox (seed, offset) check; every other
+        # device — cpu and third-party (privateuse1) backends alike — must fall
+        # back to comparing full generator state tensors instead of raising
+        # NotImplementedError.
+        import torch.distributed.collective_utils as collective_utils
+
+        group = mock.sentinel.group
+        for device_type, expect_philox in [
+            ("cuda", True),
+            ("xpu", True),
+            ("cpu", False),
+            ("privateuse1", False),
+        ]:
+            generator = mock.MagicMock()
+            generator.device.type = device_type
+            with mock.patch.object(
+                collective_utils, "_check_philox_rng_sync"
+            ) as philox_check, mock.patch.object(
+                collective_utils, "_check_cpu_rng_sync"
+            ) as cpu_check:
+                collective_utils._check_rng_sync_internal(generator, group)
+            if expect_philox:
+                philox_check.assert_called_once_with(generator, group)
+                cpu_check.assert_not_called()
+            else:
+                cpu_check.assert_called_once_with(generator, group)
+                philox_check.assert_not_called()
+
 
 instantiate_parametrized_tests(TestCollectiveUtils)
 

--- a/torch/distributed/collective_utils.py
+++ b/torch/distributed/collective_utils.py
@@ -318,13 +318,15 @@ def _check_rng_sync_internal(
     generator: torch.Generator, group: dist.ProcessGroup
 ) -> tuple[dict[Any, set], str]:
     if generator.device.type in {"cuda", "xpu"}:
+        # Counter-based RNGs (Philox) whose 16-byte state can be interpreted
+        # as a (seed, offset) pair.
         return _check_philox_rng_sync(generator, group)
-    elif generator.device.type == "cpu":
-        return _check_cpu_rng_sync(generator, group)
     else:
-        raise NotImplementedError(
-            f"Unsupported generator device: {generator.device.type}"
-        )
+        # Any other device (cpu, npu, ...) falls back to comparing the full
+        # generator state tensors, which works for generators whose
+        # ``get_state()`` returns a tensor. This keeps the check usable by
+        # third-party backends without raising NotImplementedError.
+        return _check_cpu_rng_sync(generator, group)
 
 
 def _desync_table_str(tag: str, value_ranks: dict[Any, set[int]]) -> str:


### PR DESCRIPTION
## Summary

`_check_rng_sync_internal` in `torch/distributed/collective_utils.py` raised `NotImplementedError` for generators on any device other than cuda/xpu/cpu. As a result FSDP2's RNG-state desync detection crashes on third-party backends (npu, hpu, ...) instead of reporting the desync table.

Since `_check_cpu_rng_sync` only requires `generator.get_state()` to return a tensor (it all-gathers the states and hashes them), route every non-philox device there. cuda/xpu keep the `(seed, offset)` philox interpretation; behavior for existing devices is unchanged.

## Test plan

- [x] `test_check_rng_sync_internal_dispatch`: cuda/xpu dispatch to `_check_philox_rng_sync`; cpu and privateuse1 dispatch to `_check_cpu_rng_sync` (mocked, single-process).
- [x] Existing `test/distributed/test_collective_utils.py` suites pass.
- [ ] CI.

cc @ezyang @fduwjj @wanchaol @H-Huang