### PR TITLE
Cache OperatorName's namespace separator instead of rescanning on each call

### DIFF
--- a/aten/src/ATen/core/operator_name.h
+++ b/aten/src/ATen/core/operator_name.h
@@ -12,25 +12,33 @@
 
 namespace c10 {
 
-// TODO: consider storing namespace separately too
 struct OperatorName final {
   std::string name;
   std::string overload_name;
   OperatorName(std::string name, std::string overload_name)
-      : name(std::move(name)), overload_name(std::move(overload_name)) {}
-
-  // TODO: These two functions below are slow!  Fix internal data structures so
-  // I don't have to manually reconstruct the namespaces!
+      : name(std::move(name)),
+        overload_name(std::move(overload_name)),
+        namespace_sep_(this->name.find("::")) {}
 
   // Return the namespace of this OperatorName, if it exists.  The
   // returned string_view is only live as long as the OperatorName
   // exists and name is not mutated
   std::optional<std::string_view> getNamespace() const {
-    auto pos = name.find("::");
-    if (pos == std::string::npos) {
+    if (namespace_sep_ == std::string::npos) {
       return std::nullopt;
     } else {
-      return std::string_view(name.data(), pos);
+      return std::string_view(name.data(), namespace_sep_);
+    }
+  }
+
+  // Return the part of name after the namespace prefix, if any (e.g. "add"
+  // for "aten::add"), otherwise the whole name. The returned string_view is
+  // only live as long as the OperatorName exists and name is not mutated.
+  std::string_view getBaseName() const {
+    if (namespace_sep_ == std::string::npos) {
+      return name;
+    } else {
+      return std::string_view(name).substr(namespace_sep_ + 2);
     }
   }
 
@@ -47,11 +55,19 @@ struct OperatorName final {
       std::char_traits<char>::copy(name_data, ns, ns_len);
       name[ns_len] = ':';
       name[ns_len + 1] = ':';
+      namespace_sep_ = ns_len;
       return true;
     } else {
       return false;
     }
   }
+
+ private:
+  // Byte offset of the "::" namespace separator in `name`, or
+  // std::string::npos if `name` has no namespace. Computed once at
+  // construction (and updated by setNamespaceIfNotSet) instead of doing a
+  // linear scan on every getNamespace()/getBaseName() call.
+  std::string::size_type namespace_sep_;
 };
 
 // Non-owning view of an OperatorName.  Unlike OperatorName, most of

--- a/torch/csrc/PyInterpreter.cpp
+++ b/torch/csrc/PyInterpreter.cpp
@@ -959,20 +959,19 @@ PyInterpreterHolder self_interpreter;
 
 py::handle getTorchApiFunction(const c10::OperatorHandle& op) {
   return op.getPythonOp([&]() -> PyObject* {
-    // Parse the name into namespace and name (no overload_name)
-    // TODO: put this into the library
     const auto& schema = op.schema();
-    const auto& qualified_name = op.operator_name().name;
+    const auto& operator_name = op.operator_name();
     const auto& overload_name = schema.overload_name();
-    auto pos = qualified_name.find("::");
-    TORCH_INTERNAL_ASSERT(pos != std::string::npos, qualified_name);
+    auto ns = operator_name.getNamespace();
+    TORCH_INTERNAL_ASSERT(ns.has_value(), operator_name.name);
     // Make me some null terminated strings
-    std::string ns_str = qualified_name.substr(0, pos);
-    const char* ns = ns_str.c_str();
-    const char* func_name = qualified_name.c_str() + pos + strlen("::");
+    std::string ns_str(*ns);
+    std::string func_name(operator_name.getBaseName());
 
-    py::handle torch_api_function =
-        py::module::import("torch").attr("ops").attr(ns).attr(func_name);
+    py::handle torch_api_function = py::module::import("torch")
+                                        .attr("ops")
+                                        .attr(ns_str.c_str())
+                                        .attr(func_name.c_str());
     if (overload_name.empty()) {
       return torch_api_function.attr("default").ptr();
     } else {


### PR DESCRIPTION
`OperatorName::getNamespace()` rescanned `name` for "::" on every call. Caches the byte offset once at construction, kept in sync by `setNamespaceIfNotSet`. Adds `getBaseName()` for the part after the namespace, and uses both to replace a hand-rolled namespace/name split on `PyInterpreter.cpp`'s dispatch hot path.

Dropped a second commit that made `name` private behind a `name()` accessor: CI caught that `third_party/torch-xpu-ops` (pinned externally, not fixable in this tree) reads `operator_name().name` as a bare field in three places, so making it a method broke the XPU build.

Drafted with AI assistance (Claude Code). Could not compile locally (no C++ toolchain) - CI is the real verification here.