### PR TITLE
Drop unused includes in c10

### DIFF
--- a/c10/core/CPUAllocator.cpp
+++ b/c10/core/CPUAllocator.cpp
@@ -1,6 +1,5 @@
 #include <c10/core/Allocator.h>
 #include <c10/core/CPUAllocator.h>
-#include <c10/core/DeviceType.h>
 #include <c10/core/alignment.h>
 #include <c10/core/impl/alloc_cpu.h>
 #include <c10/mobile/CPUCachingAllocator.h>

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -45,7 +45,6 @@
 #include <mutex>
 #include <new>
 #include <ranges>
-#include <regex>
 #include <set>
 #include <stack>
 #include <thread>

--- a/c10/cuda/PeerToPeerAccess.cpp
+++ b/c10/cuda/PeerToPeerAccess.cpp
@@ -2,7 +2,6 @@
 
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <c10/cuda/CUDAException.h>
-#include <c10/cuda/CUDAGuard.h>
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
 #endif

--- a/c10/cuda/driver_api.cpp
+++ b/c10/cuda/driver_api.cpp
@@ -1,5 +1,4 @@
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-#include <c10/cuda/CUDAException.h>
 #include <c10/cuda/driver_api.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Logging.h>


### PR DESCRIPTION
Supersedes #194959. That PR landed once and was reverted internally: removing `<iostream>` from `c10/util/Exception.cpp` dropped `std::cerr`, which the file still uses - `misc-include-cleaner` (and clangd's own unused-includes check) misattributes `std::cerr` to a different header than the one the standard actually guarantees provides it, a known blind spot for this class of global stream object.

Kept `<iostream>`; re-verified the other 4 files' removals by grepping for any remaining use of a symbol from each removed header, found no other misses.

> Drafted with AI assistance (Claude Code).