### PR TITLE
Fix printing an FX graph whose meta carries a BSR or BSC tensor

### DIFF
--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -1489,6 +1489,35 @@ class TestFX(JitTestCase):
                 f"Expected 2 occurrences of '_torch__ops_aten_aten_relu_', got {count}"
             )
 
+    def test_print_readable_with_sparse_meta_val(self):
+        # The compressed sparse layouts have no strides; annotating a node
+        # whose meta["val"] carries one used to raise from Tensor.stride().
+        for layout in (
+            torch.sparse_csr,
+            torch.sparse_csc,
+            torch.sparse_bsr,
+            torch.sparse_bsc,
+        ):
+            with self.subTest(layout=layout):
+                dense = torch.eye(4)
+                kwargs = (
+                    {"blocksize": (2, 2)}
+                    if layout in (torch.sparse_bsr, torch.sparse_bsc)
+                    else {}
+                )
+                sparse = dense.to_sparse(layout=layout, **kwargs)
+
+                graph = torch.fx.Graph()
+                node = graph.create_node("placeholder", "x")
+                node.meta["val"] = sparse
+                graph.output(node)
+                gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+                text = gm.print_readable(
+                    print_output=False, include_stride=True, include_device=True
+                )
+                self.assertIn("x", text)
+
     def test_print_readable_no_trailing_whitespace_with_inner_graph(self):
         # When a GraphModule has a child GraphModule (e.g., from invoke_subgraph),
         # print_readable() should not produce lines with trailing whitespace.

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -792,6 +792,7 @@ class CodeGen:
                 except ModuleNotFoundError:
                     DTensor = None  # type: ignore[assignment,misc]
                     dtensorspec_format_shard_order_str = None
+                from torch._subclasses.meta_utils import is_sparse_compressed_layout
                 from torch.fx.experimental.proxy_tensor import py_sym_types
                 from torch.fx.passes.shape_prop import TensorMetadata
 
@@ -811,10 +812,11 @@ class CodeGen:
                     )
 
                 # use string as annotation, to make it valid python code
-                if isinstance(meta_val, torch.Tensor) and meta_val.layout not in (
-                    torch.sparse_csc,
-                    torch.sparse_csr,
-                ):
+                # Compressed sparse layouts have no strides, and asking for
+                # them raises; _tensor_annotation would do exactly that.
+                if isinstance(
+                    meta_val, torch.Tensor
+                ) and not is_sparse_compressed_layout(meta_val.layout):
                     # Fake tensors cause tests to wobble, so do not custom print them.
                     is_plain = type(meta_val) is torch.Tensor or isinstance(
                         meta_val, torch._subclasses.FakeTensor

--- a/torch/fx/node.py
+++ b/torch/fx/node.py
@@ -675,6 +675,7 @@ class Node(_NodeBase):
                 maybe_return_typename[0] = f" -> {_type_repr(self.type)}"
             return f"return {self.args[0]}"
         else:
+            from torch._subclasses.meta_utils import is_sparse_compressed_layout
 
             def stringify_shape(shape: Iterable[Any]) -> str:
                 return f"[{', '.join([str(x) for x in shape])}]"
@@ -687,11 +688,7 @@ class Node(_NodeBase):
             if (
                 include_tensor_metadata
                 and isinstance(meta_val, torch.Tensor)
-                and meta_val.layout
-                not in (
-                    torch.sparse_csc,
-                    torch.sparse_csr,
-                )
+                and not is_sparse_compressed_layout(meta_val.layout)
             ):
                 stride_annotation = f"{stringify_shape(meta_val.stride())}"
                 device_annotation = _device_annotation(meta_val.device)


### PR DESCRIPTION
```
_tensor_annotation calls Tensor.stride(), which raises for the compressed
sparse layouts, so the caller guards on the layout first. That guard listed
only sparse_csc and sparse_csr; sparse_bsr and sparse_bsc reached it and
raised "Sparse BSR tensors do not have strides".

trace_structured evaluates its payload whenever torch.__trace has a handler,
and dynamo_output_graph's payload is gm.print_readable(include_stride=True),
so exporting a model that takes a BSR or BSC input failed outright once
TORCH_TRACE was set.

Used the existing is_sparse_compressed_layout() (torch/_subclasses/meta_utils.py)
instead of hand-listing the four layouts, since torch/fx/node.py's Node.format_node
has the identical pattern (also missing bsr/bsc) for non-placeholder nodes -
fixed both call sites off the one helper instead of duplicating the list twice.
Imported it locally inside each function rather than at module scope: a
module-level import broke CI everywhere with "ImportError: cannot import
name 'Graph' from partially initialized module 'torch.fx.graph'" -
torch._subclasses.meta_utils pulls in torch._subclasses/__init__.py (fake_tensor
etc.) at import time, which cycles back into torch.fx while it's still
initializing. graph.py already imports other torch.fx.* symbols locally in
this exact function for the same reason.

Test Plan:

python test/test_fx.py TestFX.test_print_readable_with_sparse_meta_val
```

Drafted with AI assistance (Claude Code).