### PR TITLE
Fix compile_so passing use_relative_path twice

### DIFF
--- a/test/inductor/test_cpp_builder.py
+++ b/test/inductor/test_cpp_builder.py
@@ -1,11 +1,15 @@
 # Owner(s): ["oncall: cpu inductor"]
 
+import json
+import os
+import tempfile
+
 from torch._dynamo.device_interface import (
     device_interfaces,
     DeviceInterface,
     register_interface_for_device,
 )
-from torch._inductor.cpp_builder import get_cpp_torch_device_options
+from torch._inductor.cpp_builder import BuildOptionsBase, get_cpp_torch_device_options
 from torch.testing._internal.common_utils import run_tests, TestCase
 
 
@@ -54,6 +58,25 @@ class TestCppBuilder(TestCase):
         self.assertEqual(cflags, [])
         self.assertEqual(libraries, [])
         self.assertEqual(passthrough, [])
+
+
+class TestBuildFlagsRoundTrip(TestCase):
+    def test_saved_flags_omit_use_relative_path(self) -> None:
+        # use_relative_path describes the environment doing a build, not a
+        # recorded flag; a loader always re-supplies it, so it must never be
+        # among the saved keys or BuildOptionsBase(**loaded, use_relative_path=x)
+        # collides on the key.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "flags.json")
+            BuildOptionsBase(compiler="g++", use_relative_path=True).save_flags_to_json(
+                path
+            )
+            with open(path) as f:
+                flags = json.load(f)
+
+        self.assertNotIn("use_relative_path", flags)
+        options = BuildOptionsBase(**flags, use_relative_path=False)
+        self.assertEqual(options.get_compiler(), "g++")
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -886,6 +886,10 @@ class BuildOptionsBase:
         return self._preprocessing
 
     def save_flags_to_json(self, file: str) -> None:
+        # use_relative_path describes the environment doing a build, not a
+        # property of this one, so a loader always re-supplies it and it must
+        # not round-trip here (else BuildOptionsBase(**loaded, use_relative_path=x)
+        # collides on the key).
         attrs = {
             "compiler": self.get_compiler(),
             "definitions": self.get_definitions(),
@@ -896,7 +900,6 @@ class BuildOptionsBase:
             "libraries": self.get_libraries(),
             "passthrough_args": self.get_passthrough_args(),
             "aot_mode": self.get_aot_mode(),
-            "use_relative_path": self.get_use_relative_path(),
             "compile_only": self.get_compile_only(),
         }
 


### PR DESCRIPTION
```
compile_so() reloads the flags that BuildOptionsBase.save_flags_to_json
wrote, splats them into BuildOptionsBase, and also passes
use_relative_path itself:

    compile_options = BuildOptionsBase(
        **compile_flags, use_relative_path=config.is_fbcode()
    )

save_flags_to_json records "use_relative_path" among its keys, so that
call always raises:

    TypeError: BuildOptionsBase() got multiple values for keyword
    argument 'use_relative_path'

The path is reached from torch/_inductor/package/build_package.py, the
script packaged alongside an AOTInductor artifact so a consumer can
rebuild the .so from the unpacked files, and it has no test, which is how
this survived.

use_relative_path describes the environment doing the build, not a
property of the build being recorded - a loader always has to re-supply
it - so the fix is at the source: drop it from save_flags_to_json's
output instead of patching every reload site to work around its
presence. compile_so's two call sites (compile_flags, linker_flags) are
the only readers of these files in the tree; both need no changes once
the key is never written.

Test Plan:

New test in test/inductor/test_cpp_builder.py saves flags with
use_relative_path=True and asserts the reloaded JSON does not contain
the key, then confirms BuildOptionsBase(**flags, use_relative_path=False)
still works.

python test/inductor/test_cpp_builder.py -k test_saved_flags_omit_use_relative_path
lintrunner torch/_inductor/cpp_builder.py torch/_inductor/package/package.py test/inductor/test_cpp_builder.py
```

Drafted with AI assistance (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo