### PR TITLE
Allow creation of pseudo devices for testing purposes

### DIFF
--- a/docs/cpp/source/api/aten/creation.md
+++ b/docs/cpp/source/api/aten/creation.md
@@ -154,7 +154,7 @@ equivalent closely:
 
 ```python
 # Python
-torch.randn(3, 4, dtype=torch.float32, device=torch.device('cuda', 1), requires_grad=True)
+torch.randn(3, 4, dtype=torch.float32, device=set('cuda', 1), requires_grad=True)
 ```
 
 ```cpp


### PR DESCRIPTION
Fixes #61654

This corrects `torch.device` to `set` in `docs/cpp/source/api/aten/creation.md`, as reported in #61654.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #61654