### PR TITLE
[MPS] Add adaptive_max_pool3d

### DIFF
--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -11,6 +11,8 @@
 #else
 #include <ATen/ops/adaptive_max_pool2d_backward_native.h>
 #include <ATen/ops/adaptive_max_pool2d_native.h>
+#include <ATen/ops/adaptive_max_pool3d_backward_native.h>
+#include <ATen/ops/adaptive_max_pool3d_native.h>
 #include <ATen/ops/aminmax.h>
 #include <ATen/ops/avg_pool2d.h>
 #include <ATen/ops/avg_pool2d_backward.h>
@@ -1134,6 +1136,26 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_mps)
                                           static_cast<int32_t>(input.dim()),
                                           /*pooling_dims=*/2,
                                           "adaptive_max_pool2d_backward");
+}
+
+TORCH_IMPL_FUNC(adaptive_max_pool3d_out_mps)
+(const Tensor& input, IntArrayRef output_size, const Tensor& output, const Tensor& indices) {
+  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(input.scalar_type()),
+                              "Adaptive max pooling for complex is not supported for MPS");
+  mps::adaptive_max_pool_out_mps_template(output, indices, input, /*pooling_dims=*/3, "adaptive_max_pool3d");
+}
+
+TORCH_IMPL_FUNC(adaptive_max_pool3d_backward_out_mps)
+(const Tensor& grad_output, const Tensor& input, const Tensor& indices, const Tensor& grad_input) {
+  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(input.scalar_type()),
+                              "Adaptive max pooling backward for complex is not supported for MPS");
+  mps::max_pool_backward_out_mps_template(const_cast<Tensor&>(grad_input),
+                                          indices,
+                                          input,
+                                          grad_output,
+                                          static_cast<int32_t>(input.dim()),
+                                          /*pooling_dims=*/3,
+                                          "adaptive_max_pool3d_backward");
 }
 
 std::tuple<Tensor&, Tensor&> max_pool3d_with_indices_out_mps(const Tensor& input,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12467,6 +12467,7 @@
   dispatch:
     CPU: adaptive_max_pool3d_out_cpu
     CUDA: adaptive_max_pool3d_out_cuda
+    MPS: adaptive_max_pool3d_out_mps
     XPU: adaptive_max_pool3d_out_xpu
 
 # Return: (Tensor output, Tensor indices)
@@ -12480,6 +12481,7 @@
   dispatch:
     CPU: adaptive_max_pool3d_backward_out_cpu
     CUDA: adaptive_max_pool3d_backward_out_cuda
+    MPS: adaptive_max_pool3d_backward_out_mps
     XPU: adaptive_max_pool3d_backward_out_xpu
 
 - func: adaptive_max_pool3d_backward(Tensor grad_output, Tensor self, Tensor indices) -> Tensor

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -41,6 +41,8 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__weight_int8pack_mm(AtenTensorHa
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_abs(AtenTensorHandle self, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_adaptive_max_pool2d(AtenTensorHandle self, const int64_t* output_size, int64_t output_size_len_, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_adaptive_max_pool2d_backward(AtenTensorHandle grad_output, AtenTensorHandle self, AtenTensorHandle indices, AtenTensorHandle* ret0);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_adaptive_max_pool3d(AtenTensorHandle self, const int64_t* output_size, int64_t output_size_len_, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_adaptive_max_pool3d_backward(AtenTensorHandle grad_output, AtenTensorHandle self, AtenTensorHandle indices, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_add_Scalar(AtenTensorHandle self, double other, double alpha, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_add_Tensor(AtenTensorHandle self, AtenTensorHandle other, double alpha, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_addbmm(AtenTensorHandle self, AtenTensorHandle batch1, AtenTensorHandle batch2, double beta, double alpha, AtenTensorHandle* ret0);

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -458,7 +458,6 @@ if torch.backends.mps.is_available():
                 torch.bool,
                 torch.int8,
             ],
-            "nn.functional.adaptive_max_pool3d": None,
             "nn.functional.interpolatearea": None,
             "nn.functional.interpolatebicubic": [torch.uint8],
             "nn.functional.local_response_norm": [


### PR DESCRIPTION
I have built this branch standalone and run its tests locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than presented as my own prose.

> ## Why this is needed
>
> Requested on #141287, with a `+1` on `aten::adaptive_max_pool3d.out`.
>
> ## Change
>
> Adds MPS support for `adaptive_max_pool3d` and its backward, which so far only
> had CPU, CUDA and XPU implementations and were listed as unimplemented in the
> MPS xfail list.
>
> No new Metal code was needed. `adaptive_max_pool_out_mps_template` in
> `Pooling.mm` is already parameterised on `pooling_dims` and sets
> `params.adaptive`, `PoolingParams<5>` is sized for 3-D pooling, and the
> `max_pool` kernel already has a `pooling_dims == 3` arm that
> `max_pool3d_with_indices` exercises. So the two structured impls are the same
> shape as the existing 2-D ones, and the backward reuses
> `max_pool_backward_out_mps_template` unchanged.
>
> The generated AOTI C shim header is regenerated because adding an MPS dispatch
> entry for a fallback op changes its contents; without that the build fails in
> `cmake/Codegen.cmake` on the stale checked-in copy.
>
> Test Plan:
>
> Removing the `nn.functional.adaptive_max_pool3d` entry from
> `UNIMPLEMENTED_XFAILLIST` enables `test_output_match` and
> `test_output_grad_match`, which run the OpInfo on MPS and on CPU and compare
> outputs and gradients.
>
> ```
> python test/test_mps.py -k "adaptive_max_pool3d" -v
> ```
>
> 6 tests pass (forward for bfloat16/float16/float32, gradients for
> float16/float32, and error inputs).
>
> The OpInfo samples do not cover 4-D (unbatched) input, channels-last-3d input,
> or output sizes that do not divide the input evenly, so those were checked
> against CPU separately, comparing values, indices and gradients:
>
> ```
> python - <<'PY'
> import torch
> torch.manual_seed(0)
> tol = {torch.float32: (1e-5, 1e-5), torch.float16: (5e-3, 5e-3),
>        torch.bfloat16: (5e-2, 5e-2)}
> cases = [((2, 3, 8, 9, 7), (4, 3, 2)), ((3, 5, 6, 4), (2, 2, 2)),
>          ((1, 1, 5, 5, 5), (5, 5, 5)), ((2, 2, 7, 5, 3), (1, 1, 1)),
>          ((2, 3, 4, 6, 8), (3, 4, 5))]
> for shape, osz in cases:
>     for dt, (atol, rtol) in tol.items():
>         x = torch.randn(*shape, dtype=dt)
>         for cl in (False, True):
>             xi = (x.contiguous(memory_format=torch.channels_last_3d)
>                   if cl and x.dim() == 5 else x)
>             xc = xi.clone().requires_grad_(True)
>             xm = xi.to("mps").clone().requires_grad_(True)
>             oc, ic = torch.nn.functional.adaptive_max_pool3d(xc, osz, return_indices=True)
>             om, im = torch.nn.functional.adaptive_max_pool3d(xm, osz, return_indices=True)
>             torch.testing.assert_close(om.cpu(), oc, atol=atol, rtol=rtol)
>             torch.testing.assert_close(im.cpu(), ic)
>             g = torch.randn_like(oc)
>             oc.backward(g); om.backward(g.to("mps"))
>             torch.testing.assert_close(xm.grad.cpu(), xc.grad, atol=atol, rtol=rtol)
> PY
> ```
>
> Half and bfloat16 gradients need looser tolerances there because adaptive
> pooling maps several output cells onto the same input element, so the backward
> accumulates with atomics in a different order than the CPU's sequential sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
