### PR TITLE
[MPS] Add pdist

### DIFF
--- a/aten/src/ATen/native/Distance.cpp
+++ b/aten/src/ATen/native/Distance.cpp
@@ -243,7 +243,7 @@ Tensor _cdist_backward(const Tensor& _grad, const Tensor& _x1, const Tensor& _x2
 Tensor _pdist_forward(const Tensor& self, const double p) {
   TORCH_CHECK(self.is_contiguous(), "_pdist_forward requires contiguous input");
   auto device = self.device().type();
-  TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU || device == kPrivateUse1, "_pdist_forward only supports CPU, XPU, CUDA and PrivateUse1 devices, got: ", device);
+  TORCH_CHECK(device == kCPU || device == kCUDA || device == kMPS || device == kXPU || device == kPrivateUse1, "_pdist_forward only supports CPU, XPU, CUDA, MPS and PrivateUse1 devices, got: ", device);
   Tensor result = at::empty({0}, self.options(), LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   if (self.size(0) <= 1) {
     result.resize_({0});
@@ -264,7 +264,7 @@ Tensor _pdist_backward(const Tensor& grad, const Tensor& self, const double p, c
   TORCH_CHECK(self.is_contiguous(), "_pdist_backward requires self to be contiguous");
   TORCH_CHECK(pdist.is_contiguous(), "_pdist_backward requires pdist to be contiguous");
   auto device = self.device().type();
-  TORCH_CHECK(device == kCPU || device == kCUDA || device == kXPU || device == kPrivateUse1, "_pdist_backward only supports CPU, XPU, CUDA and PrivateUse1 devices, got: ", device);
+  TORCH_CHECK(device == kCPU || device == kCUDA || device == kMPS || device == kXPU || device == kPrivateUse1, "_pdist_backward only supports CPU, XPU, CUDA, MPS and PrivateUse1 devices, got: ", device);
   Tensor result = at::empty_like(self, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
   pdist_backward_stub(device, result, grad, self, p, pdist);
   return result;

--- a/aten/src/ATen/native/mps/kernels/Distance.h
+++ b/aten/src/ATen/native/mps/kernels/Distance.h
@@ -7,3 +7,9 @@ struct CdistBwdParams {
   long D;
   float p_minus_1;
 };
+
+struct PdistParams {
+  long N;
+  long D;
+  float p;
+};

--- a/aten/src/ATen/native/mps/kernels/Distance.metal
+++ b/aten/src/ATen/native/mps/kernels/Distance.metal
@@ -124,3 +124,70 @@ kernel void cdist_backward(
 REGISTER_CDIST_BACKWARD_FOR_TYPE(float)
 REGISTER_CDIST_BACKWARD_FOR_TYPE(half)
 REGISTER_CDIST_BACKWARD_FOR_TYPE(bfloat)
+
+// One thread per (i, j) pair of rows; threads with j <= i drop out. `out` is
+// the row-major strict upper triangle, which is exactly pdist's layout.
+// P_KIND: 0 = p==0, 1 = p==1, 2 = p==2, 3 = p==inf, 4 = generic.
+template <typename T, int P_KIND>
+kernel void pdist(
+    constant T* x [[buffer(0)]],
+    device T* out [[buffer(1)]],
+    constant PdistParams& params [[buffer(2)]],
+    uint2 tid [[thread_position_in_grid]]) {
+  const long n = params.N;
+  const long i = static_cast<long>(tid.y);
+  const long j = static_cast<long>(tid.x);
+
+  if (i >= n || j >= n || j <= i) {
+    return;
+  }
+
+  const long d = params.D;
+  constant T* xi = x + i * d;
+  constant T* xj = x + j * d;
+
+  float acc = 0.0f;
+  for (long c = 0; c < d; ++c) {
+    const float diff = ::metal::precise::abs(
+        static_cast<float>(xi[c]) - static_cast<float>(xj[c]));
+    if IF_CONSTEXPR (P_KIND == 0) {
+      acc += (diff != 0.0f) ? 1.0f : 0.0f;
+    } else if IF_CONSTEXPR (P_KIND == 1) {
+      acc += diff;
+    } else if IF_CONSTEXPR (P_KIND == 2) {
+      acc += diff * diff;
+    } else if IF_CONSTEXPR (P_KIND == 3) {
+      acc = ::metal::max(acc, diff);
+    } else {
+      acc += ::metal::precise::pow(diff, params.p);
+    }
+  }
+
+  float result = acc;
+  if IF_CONSTEXPR (P_KIND == 2) {
+    result = ::metal::precise::sqrt(acc);
+  } else if IF_CONSTEXPR (P_KIND == 4) {
+    result = ::metal::precise::pow(acc, 1.0f / params.p);
+  }
+
+  out[i * n - (i * (i + 1)) / 2 + (j - i - 1)] = static_cast<T>(result);
+}
+
+#define REGISTER_PDIST(T, P_KIND)                              \
+  template [[host_name("pdist_" #T "_p" #P_KIND)]] kernel void \
+  pdist<T, P_KIND>(                                            \
+      constant T * x [[buffer(0)]],                            \
+      device T * out [[buffer(1)]],                            \
+      constant PdistParams & params [[buffer(2)]],             \
+      uint2 tid [[thread_position_in_grid]]);
+
+#define REGISTER_PDIST_FOR_TYPE(T) \
+  REGISTER_PDIST(T, 0)             \
+  REGISTER_PDIST(T, 1)             \
+  REGISTER_PDIST(T, 2)             \
+  REGISTER_PDIST(T, 3)             \
+  REGISTER_PDIST(T, 4)
+
+REGISTER_PDIST_FOR_TYPE(float)
+REGISTER_PDIST_FOR_TYPE(half)
+REGISTER_PDIST_FOR_TYPE(bfloat)

--- a/aten/src/ATen/native/mps/operations/Distance.mm
+++ b/aten/src/ATen/native/mps/operations/Distance.mm
@@ -7,8 +7,11 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_cdist_backward.h>
 #include <ATen/ops/linalg_vector_norm.h>
+#include <ATen/ops/ones.h>
 #include <ATen/ops/where.h>
+#include <ATen/ops/zeros.h>
 #endif
 
 #include <ATen/native/mps/kernels/Distance.h>
@@ -107,7 +110,69 @@ static void cdist_backward_kernel_mps(Tensor& result,
   }
 }
 
+static void pdist_forward_kernel_mps(Tensor& result, const Tensor& self, const double p) {
+  const int64_t n = self.size(0);
+  const PdistParams params{
+      .N = n,
+      .D = self.size(1),
+      .p = static_cast<float>(p),
+  };
+
+  // Values must match `P_KIND` in kernels/Distance.metal.
+  const int p_kind = (p == 0.0) ? 0 : (p == 1.0) ? 1 : (p == 2.0) ? 2 : (std::isinf(p) ? 3 : 4);
+
+  auto stream = getCurrentMPSStream();
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc(fmt::format("pdist_{}_p{}", scalarToMetalTypeString(self), p_kind));
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto compute_encoder = stream->commandEncoder();
+        [compute_encoder setComputePipelineState:pso];
+        mtl_setArgs(compute_encoder, self, result, params);
+        const auto width = std::min<NSUInteger>(pso.maxTotalThreadsPerThreadgroup, static_cast<NSUInteger>(n));
+        const MTLSize grid = MTLSizeMake(static_cast<NSUInteger>(n), static_cast<NSUInteger>(n), 1);
+        [compute_encoder dispatchThreads:grid threadsPerThreadgroup:MTLSizeMake(width, 1, 1)];
+      }
+    });
+  }
+}
+
+// pdist is the strict upper triangle of cdist(self, self), and because the
+// distance is symmetric in its two arguments, the total gradient of row i is
+// the cdist gradient with respect to x1 once the per-pair gradients and
+// distances are mirrored into full matrices. That lets the backward reuse the
+// cdist backward kernel instead of duplicating it; the zero diagonal
+// contributes nothing since that kernel skips zero coordinate differences.
+static void pdist_backward_kernel_mps(Tensor& result,
+                                      const Tensor& grad,
+                                      const Tensor& self,
+                                      const double p,
+                                      const Tensor& dist) {
+  const int64_t n = self.size(0);
+  if (result.numel() == 0) {
+    return;
+  }
+  if (p == 0.0 || n < 2 || self.size(1) == 0) {
+    result.fill_(0);
+    return;
+  }
+
+  const auto upper = at::ones({n, n}, self.options().dtype(at::kBool)).triu(1);
+
+  auto grad_full = at::zeros({n, n}, self.options());
+  grad_full.masked_scatter_(upper, grad);
+  grad_full = grad_full.add(grad_full.t());
+
+  auto dist_full = at::zeros({n, n}, self.options());
+  dist_full.masked_scatter_(upper, dist);
+  dist_full = dist_full.add(dist_full.t());
+
+  result.copy_(at::_cdist_backward(grad_full.contiguous(), self, self, p, dist_full.contiguous()));
+}
+
 REGISTER_DISPATCH(cdist_stub, &cdist_kernel_mps)
 REGISTER_DISPATCH(cdist_backward_stub, &cdist_backward_kernel_mps)
+REGISTER_DISPATCH(pdist_forward_stub, &pdist_forward_kernel_mps)
+REGISTER_DISPATCH(pdist_backward_stub, &pdist_backward_kernel_mps)
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4537,13 +4537,13 @@
 
 - func: _pdist_forward(Tensor self, float p=2) -> Tensor
   dispatch:
-    CPU, CUDA, XPU: _pdist_forward
+    CPU, CUDA, MPS, XPU: _pdist_forward
   autogen: _pdist_forward.out
   tags: core
 
 - func: _pdist_backward(Tensor grad_output, Tensor self, float p, Tensor pdist) -> Tensor
   dispatch:
-    CPU, CUDA, XPU: _pdist_backward
+    CPU, CUDA, MPS, XPU: _pdist_backward
   autogen: _pdist_backward.out
 
 - func: cosine_similarity(Tensor x1, Tensor x2, int dim=1, float eps=1e-08) -> Tensor

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -28,6 +28,8 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__fused_rms_norm(AtenTensorHandle
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__grouped_mm(AtenTensorHandle self, AtenTensorHandle mat2, AtenTensorHandle* offs, AtenTensorHandle* bias, int32_t* out_dtype, AtenTensorHandle* ret0);
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_12_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__histogramdd_from_bin_cts(AtenTensorHandle self, const int64_t* bins, int64_t bins_len_, const double** range, int64_t range_len_, AtenTensorHandle* weight, int32_t density, AtenTensorHandle* ret0);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__pdist_backward(AtenTensorHandle grad_output, AtenTensorHandle self, double p, AtenTensorHandle pdist, AtenTensorHandle* ret0);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__pdist_forward(AtenTensorHandle self, double p, AtenTensorHandle* ret0);
 #if TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps__scaled_dot_product_attention_math_for_mps_v2(AtenTensorHandle query, AtenTensorHandle key, AtenTensorHandle value, AtenTensorHandle* attn_mask, double dropout_p, int32_t is_causal, AtenTensorHandle* dropout_mask, double* scale, int32_t enable_gqa, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 #endif // TORCH_FEATURE_VERSION >= TORCH_VERSION_2_13_0

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -556,7 +556,6 @@ if torch.backends.mps.is_available():
                 torch.int8,
             ],
             "nn.functional.padreplicate_negative": [torch.bool],
-            "nn.functional.pdist": None,
             "nn.functional.rrelu": None,
             "nn.functional.silu": [
                 torch.int16,


### PR DESCRIPTION
I have built this branch standalone and run its tests locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than presented as my own prose.

> ## Why this is needed
>
> Requested five times across #77764 and #141287, including a user hitting `aten::_pdist_forward` from real code (`sq_dist = torch.pdist(x, p=2).pow(2)`).
>
> ## Change
>
> Adds MPS support for `_pdist_forward` and `_pdist_backward`, which so far only
> had CPU, CUDA and XPU implementations and were listed as unimplemented in the
> MPS xfail list. Both are stub-dispatched, so this registers into
> `pdist_forward_stub` and `pdist_backward_stub` and widens the device checks in
> `aten/src/ATen/native/Distance.cpp`, which explicitly enumerate the allowed
> backends.
>
> The forward is a new Metal kernel, one thread per pair of rows, dropping the
> lower triangle and writing directly at the pair's position in the row-major
> strict upper triangle, which is exactly pdist's output layout. It is
> specialised on the five interesting values of p the way the existing
> `cdist_backward` kernel is. Note this deliberately does not follow the MPS
> cdist forward, which composes `unsqueeze`/`sub`/`linalg_vector_norm` and so
> materializes an n-by-n-by-d difference tensor; for pdist that would be a large
> memory regression over CPU and CUDA, which only ever hold the output.
>
> The backward reuses the existing `cdist_backward` kernel rather than adding a
> second one. pdist is the strict upper triangle of `cdist(self, self)`, and
> since the distance is symmetric in its two arguments, the gradient of row i is
> the cdist gradient with respect to x1 once the per-pair gradients and distances
> are mirrored into full symmetric matrices. The zero diagonal contributes
> nothing because that kernel already skips zero coordinate differences, which is
> also what keeps p < 1 from evaluating pow(0, negative).
>
> Test Plan:
>
> Removing the `nn.functional.pdist` entry from `UNIMPLEMENTED_XFAILLIST` enables
> `test_output_match`, which runs the OpInfo on MPS and on CPU and compares the
> results.
>
> ```
> python test/test_mps.py -k "pdist" -v
> ```
>
> Forward and gradient tests pass for float32 (the OpInfo covers only float32
> here, since CPU pdist is not implemented for half or bfloat16).
>
> The OpInfo samples do not vary p, so the full set of specialisations was
> checked against CPU separately, along with the degenerate shapes and duplicate
> rows that exercise the zero-distance path:
>
> ```
> python - <<'PY'
> import torch
> torch.manual_seed(0)
> for n, d in ((1, 4), (2, 3), (5, 1), (17, 8), (40, 33), (2, 0)):
>     for p in (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, float('inf')):
>         generic = p not in (0.0, 1.0, 2.0, float('inf'))
>         ba = br = 1e-3 if generic else 1e-5
>         x = torch.randn(n, d)
>         if n > 2 and d > 0:
>             x[1] = x[0]
>         xc = x.clone().requires_grad_(True)
>         xm = x.to("mps").clone().requires_grad_(True)
>         oc = torch.nn.functional.pdist(xc, p)
>         om = torch.nn.functional.pdist(xm, p)
>         torch.testing.assert_close(om.cpu(), oc, atol=1e-5, rtol=1e-5)
>         if oc.numel() and p != 0.0:
>             g = torch.randn_like(oc)
>             oc.backward(g); om.backward(g.to("mps"))
>             torch.testing.assert_close(xm.grad.cpu(), xc.grad, atol=ba, rtol=br)
> PY
> ```
>
> Gradients for non-integral p need a looser tolerance there, around 1e-4
> relative. That is not new: the same script run against `cdist` on this branch
> shows the same 1e-4 relative spread for p = 0.5, 1.5 and 3.0, since it is the
> `pow(., p - 1)` evaluation inside the shared kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
