### PR TITLE
[MPS] Add multi_margin_loss

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LossOps.h
+++ b/aten/src/ATen/native/mps/kernels/LossOps.h
@@ -35,3 +35,13 @@ struct CTCLossBackwardCollectParams {
   index_t grad_out_batch_stride;
   bool zero_infinity;
 };
+
+struct MultiMarginParams {
+  long nframe;
+  long dim;
+  int p;
+  float margin;
+  // Scale applied in the backward pass: 1/dim, or 1/(nframe*dim) for `mean`.
+  float g;
+  bool has_weight;
+};

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -1,4 +1,5 @@
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <c10/metal/error.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
 
@@ -395,3 +396,110 @@ kernel void ctc_loss_backward_collect(
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(float);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(bfloat);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(half);
+
+// One thread per sample. `weight` may be null, in which case `has_weight` is
+// false and the per-class weighting is skipped.
+template <typename T>
+kernel void multi_margin_loss(
+    constant T* input [[buffer(0)]],
+    constant long* target [[buffer(1)]],
+    device T* output [[buffer(2)]],
+    constant T* weight [[buffer(3)]],
+    constant MultiMarginParams& params [[buffer(4)]],
+    device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  const long dim = params.dim;
+  const long t = static_cast<long>(tid);
+  const long target_idx = target[t];
+
+  if (target_idx < 0 || target_idx >= dim) {
+    TORCH_REPORT_ERROR(error_buf, "target out of range");
+    return;
+  }
+
+  constant T* row = input + t * dim;
+  const float input_target = static_cast<float>(row[target_idx]);
+  const float w =
+      params.has_weight ? static_cast<float>(weight[target_idx]) : 1.0;
+
+  float sum = 0.0;
+  for (long d = 0; d < dim; ++d) {
+    if (d == target_idx) {
+      continue;
+    }
+    const float z = params.margin - input_target + static_cast<float>(row[d]);
+    if (z > 0.0) {
+      sum += ((params.p == 1) ? z : z * z) * w;
+    }
+  }
+
+  output[t] = static_cast<T>(sum / static_cast<float>(dim));
+}
+
+// One thread per sample. The result is not yet scaled by grad_output; the host
+// applies that afterwards, since it broadcasts differently for the reduced and
+// unreduced cases.
+template <typename T>
+kernel void multi_margin_loss_backward(
+    device T* grad_input [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant long* target [[buffer(2)]],
+    constant T* weight [[buffer(3)]],
+    constant MultiMarginParams& params [[buffer(4)]],
+    device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  const long dim = params.dim;
+  const long t = static_cast<long>(tid);
+  const long target_idx = target[t];
+
+  if (target_idx < 0 || target_idx >= dim) {
+    TORCH_REPORT_ERROR(error_buf, "target out of range");
+    return;
+  }
+
+  constant T* row = input + t * dim;
+  device T* grad_row = grad_input + t * dim;
+  const float input_target = static_cast<float>(row[target_idx]);
+  const float w =
+      params.has_weight ? static_cast<float>(weight[target_idx]) : 1.0;
+
+  float grad_target = 0.0;
+  for (long d = 0; d < dim; ++d) {
+    if (d == target_idx) {
+      continue;
+    }
+    const float z = params.margin - input_target + static_cast<float>(row[d]);
+    if (z > 0.0) {
+      const float h = ((params.p == 1) ? params.g : 2 * params.g * z) * w;
+      grad_target -= h;
+      grad_row[d] = static_cast<T>(h);
+    } else {
+      grad_row[d] = static_cast<T>(0.0);
+    }
+  }
+  grad_row[target_idx] = static_cast<T>(grad_target);
+}
+
+#define REGISTER_MULTI_MARGIN_LOSS(T)                                  \
+  template [[host_name("multi_margin_loss_" #T)]] kernel void          \
+  multi_margin_loss<T>(                                                \
+      constant T * input [[buffer(0)]],                                \
+      constant long* target [[buffer(1)]],                             \
+      device T* output [[buffer(2)]],                                  \
+      constant T* weight [[buffer(3)]],                                \
+      constant MultiMarginParams& params [[buffer(4)]],                \
+      device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],     \
+      uint tid [[thread_position_in_grid]]);                           \
+  template [[host_name("multi_margin_loss_backward_" #T)]] kernel void \
+  multi_margin_loss_backward<T>(                                       \
+      device T * grad_input [[buffer(0)]],                             \
+      constant T * input [[buffer(1)]],                                \
+      constant long* target [[buffer(2)]],                             \
+      constant T* weight [[buffer(3)]],                                \
+      constant MultiMarginParams& params [[buffer(4)]],                \
+      device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],     \
+      uint tid [[thread_position_in_grid]]);
+
+REGISTER_MULTI_MARGIN_LOSS(float);
+REGISTER_MULTI_MARGIN_LOSS(half);
+REGISTER_MULTI_MARGIN_LOSS(bfloat);

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/CanUse32BitIndexMath.h>
+#include <ATen/native/LossMulti.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/LossOps.h>
 
@@ -17,6 +18,8 @@
 #include <ATen/ops/huber_loss_native.h>
 #include <ATen/ops/mse_loss_backward_native.h>
 #include <ATen/ops/mse_loss_native.h>
+#include <ATen/ops/multi_margin_loss_backward_native.h>
+#include <ATen/ops/multi_margin_loss_native.h>
 #include <ATen/ops/nll_loss2d_backward_native.h>
 #include <ATen/ops/nll_loss2d_forward_native.h>
 #include <ATen/ops/nll_loss_backward_native.h>
@@ -1646,6 +1649,149 @@ Tensor ctc_loss_backward_mps(const Tensor& grad_out,
   }
 
   return grad;
+}
+
+namespace mps {
+
+static void multi_margin_loss_launch(const std::string& kernel,
+                                     const std::initializer_list<Tensor>& buffers,
+                                     const std::optional<Tensor>& weight,
+                                     const MultiMarginParams& params) {
+  auto stream = getCurrentMPSStream();
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc(kernel);
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto compute_encoder = stream->commandEncoder();
+        [compute_encoder setComputePipelineState:pso];
+        unsigned idx = 0;
+        for (const auto& t : buffers) {
+          mtl_setBuffer(compute_encoder, t, idx++);
+        }
+        detail::mtl_setArg(compute_encoder, weight, idx++);
+        mtl_setBytes(compute_encoder, params, idx++);
+        [compute_encoder setBuffer:stream->getErrorBuffer() offset:0 atIndex:idx];
+        mtl_dispatch1DJob(compute_encoder, pso, static_cast<uint32_t>(params.nframe));
+      }
+    });
+  }
+}
+
+} // namespace mps
+
+Tensor& multi_margin_loss_mps_out(const Tensor& input,
+                                  const Tensor& target,
+                                  const Scalar& p,
+                                  const Scalar& margin,
+                                  const std::optional<Tensor>& weight,
+                                  int64_t reduction,
+                                  Tensor& output) {
+  int64_t nframe = 0, dim = 0;
+  TORCH_CHECK(p.toLong() == 1 || p.toLong() == 2, "only p == 1 and p == 2 supported");
+  multi_margin_loss_shape_check(nframe, dim, input.dim(), input, target, weight);
+  TORCH_CHECK(target.scalar_type() == kLong, "expected scalar type Long but found ", target.scalar_type());
+
+  // A 1-D input produces a scalar output, as on CPU.
+  if (reduction == Reduction::None && target.dim() > 0) {
+    output.resize_({nframe});
+  } else {
+    output.resize_({});
+  }
+  if (input.numel() == 0) {
+    return output;
+  }
+
+  const auto input_c = input.contiguous().reshape({nframe, dim});
+  const auto target_c = target.contiguous();
+  const auto weight_c = (weight && weight->defined()) ? std::optional<Tensor>(weight->contiguous()) : std::nullopt;
+  auto per_sample = at::empty({nframe}, input.options());
+
+  const MultiMarginParams params{
+      .nframe = nframe,
+      .dim = dim,
+      .p = static_cast<int>(p.toLong()),
+      .margin = margin.to<float>(),
+      .g = 0.0f,
+      .has_weight = weight_c.has_value(),
+  };
+  mps::multi_margin_loss_launch(
+      "multi_margin_loss_" + mps::scalarToMetalTypeString(input), {input_c, target_c, per_sample}, weight_c, params);
+
+  if (reduction == Reduction::None && target.dim() > 0) {
+    output.copy_(per_sample);
+  } else if (reduction == Reduction::Mean) {
+    output.copy_(per_sample.sum().div(nframe));
+  } else {
+    output.copy_(per_sample.sum());
+  }
+  return output;
+}
+
+Tensor multi_margin_loss_mps(const Tensor& input,
+                             const Tensor& target,
+                             const Scalar& p,
+                             const Scalar& margin,
+                             const std::optional<Tensor>& weight,
+                             int64_t reduction) {
+  auto output = at::empty({0}, input.options());
+  multi_margin_loss_mps_out(input, target, p, margin, weight, reduction, output);
+  return output;
+}
+
+Tensor& multi_margin_loss_mps_backward_out(const Tensor& grad_output,
+                                           const Tensor& input,
+                                           const Tensor& target,
+                                           const Scalar& p,
+                                           const Scalar& margin,
+                                           const std::optional<Tensor>& weight,
+                                           int64_t reduction,
+                                           Tensor& grad_input) {
+  int64_t nframe = 0, dim = 0;
+  TORCH_CHECK(p.toLong() == 1 || p.toLong() == 2, "only p == 1 and p == 2 supported");
+  multi_margin_loss_shape_check(nframe, dim, input.dim(), input, target, weight);
+  TORCH_CHECK(target.scalar_type() == kLong, "expected scalar type Long but found ", target.scalar_type());
+  grad_input.resize_as_(input);
+  if (input.numel() == 0) {
+    return grad_input;
+  }
+
+  const auto input_c = input.contiguous().reshape({nframe, dim});
+  const auto target_c = target.contiguous();
+  const auto weight_c = (weight && weight->defined()) ? std::optional<Tensor>(weight->contiguous()) : std::nullopt;
+  auto grad = at::empty({nframe, dim}, input.options());
+
+  const MultiMarginParams params{
+      .nframe = nframe,
+      .dim = dim,
+      .p = static_cast<int>(p.toLong()),
+      .margin = margin.to<float>(),
+      .g = static_cast<float>(reduction == Reduction::Mean ? 1.0 / (nframe * dim) : 1.0 / dim),
+      .has_weight = weight_c.has_value(),
+  };
+  mps::multi_margin_loss_launch(
+      "multi_margin_loss_backward_" + mps::scalarToMetalTypeString(input), {grad, input_c, target_c}, weight_c, params);
+
+  // Reduced losses carry a scalar grad_output; the unreduced case has one per
+  // sample and broadcasts along the class dimension.
+  if (reduction != Reduction::None || grad_output.dim() == 0) {
+    grad.mul_(grad_output.reshape({}));
+  } else {
+    grad.mul_(grad_output.reshape({nframe, 1}));
+  }
+  grad_input.copy_(grad.reshape(input.sizes()));
+  return grad_input;
+}
+
+Tensor multi_margin_loss_mps_backward(const Tensor& grad_output,
+                                      const Tensor& input,
+                                      const Tensor& target,
+                                      const Scalar& p,
+                                      const Scalar& margin,
+                                      const std::optional<Tensor>& weight,
+                                      int64_t reduction) {
+  auto grad_input = at::empty({0}, input.options());
+  multi_margin_loss_mps_backward_out(grad_output, input, target, p, margin, weight, reduction, grad_input);
+  return grad_input;
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11816,6 +11816,7 @@
   dispatch:
     CPU: multi_margin_loss_cpu_out
     CUDA: multi_margin_loss_cuda_out
+    MPS: multi_margin_loss_mps_out
     XPU: multi_margin_loss_xpu_out
 
 - func: multi_margin_loss(Tensor self, Tensor target, Scalar p=1, Scalar margin=1, Tensor? weight=None, int reduction=Mean) -> Tensor
@@ -11823,6 +11824,7 @@
   dispatch:
     CPU: multi_margin_loss_cpu
     CUDA: multi_margin_loss_cuda
+    MPS: multi_margin_loss_mps
     XPU: multi_margin_loss_xpu
 
 - func: multi_margin_loss_backward.grad_input(Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor? weight=None, int reduction=Mean, *, Tensor(a!) grad_input) -> Tensor(a!)
@@ -11830,6 +11832,7 @@
   dispatch:
     CPU: multi_margin_loss_cpu_backward_out
     CUDA: multi_margin_loss_cuda_backward_out
+    MPS: multi_margin_loss_mps_backward_out
     XPU: multi_margin_loss_xpu_backward_out
 
 - func: multi_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, Scalar p, Scalar margin, Tensor? weight=None, int reduction=Mean) -> Tensor
@@ -11837,6 +11840,7 @@
   dispatch:
     CPU: multi_margin_loss_cpu_backward
     CUDA: multi_margin_loss_cuda_backward
+    MPS: multi_margin_loss_mps_backward
     XPU: multi_margin_loss_xpu_backward
 
 - func: multilabel_margin_loss.out(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) out) -> Tensor(a!)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -533,7 +533,6 @@ if torch.backends.mps.is_available():
                 torch.int8,
                 torch.int16,
             ],
-            "nn.functional.multi_margin_loss": None,
             "nn.functional.multilabel_margin_loss": [
                 torch.int8,
                 torch.uint8,


### PR DESCRIPTION
I have built this branch standalone and run its tests locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than presented as my own prose.

> ## Why this is needed
>
> Requested on #141287, where a user reports `aten::multi_margin_loss` missing.
>
> ## Change
>
> Adds MPS support for `multi_margin_loss` and its backward, which so far only
> had CPU, CUDA and XPU implementations and were listed as unimplemented in the
> MPS xfail list.
>
> Two Metal kernels, one thread per sample, ported from the CPU reference in
> `aten/src/ATen/native/LossMultiMargin.cpp`. Both take the optional per-class
> weight as a buffer that is left unbound when absent, guarded by a flag in the
> params struct, which avoids materializing a tensor of ones for the common
> unweighted case. `LossOps.mm` is otherwise almost entirely MPSGraph-based;
> these follow `ctc_loss_mps`, the one hand-written Metal kernel already there.
>
> Two things are done on the host rather than in the kernel. The reduction is
> applied afterwards, since the kernel always produces the per-sample losses and
> `sum`/`mean` are then a `sum()` and a divide. And the backward kernel writes
> the gradient before scaling by `grad_output`, because that broadcasts
> differently for the reduced case (a scalar) and the unreduced case (one value
> per sample, broadcast along the class dimension).
>
> Out-of-range targets are reported through the MPS error buffer rather than a
> host-side check, so they surface as an `AcceleratorError` on the next sync
> instead of costing a device-to-host synchronization on every call. The target
> dtype, on the other hand, is checked on the host: CPU raises "expected scalar
> type Long but found Float" from its `data_ptr<int64_t>` access, and without an
> explicit check MPS would silently reinterpret float bits as indices.
>
> Test Plan:
>
> Removing the `nn.functional.multi_margin_loss` entry from
> `UNIMPLEMENTED_XFAILLIST` enables `test_output_match`, which runs the OpInfo on
> MPS and on CPU and compares the results.
>
> ```
> python test/test_mps.py -k "multi_margin" -v
> ```
>
> 3 tests pass: forward, gradients, and the 9 error inputs (which include the
> target dtype case above).
>
> The OpInfo samples do not sweep `p`, `margin`, the optional weight, the
> reduction modes or 1-D input, so those were checked against CPU as a product:
>
> ```
> python - <<'PY'
> import torch, itertools
> torch.manual_seed(0)
> for shape in ((7, 5), (5,), (1, 3)):
>     n = shape[0] if len(shape) == 2 else 1
>     C = shape[-1]
>     for p, margin, use_w, red in itertools.product(
>             (1, 2), (1.0, 0.0, 2.5), (False, True), ("none", "sum", "mean")):
>         x = torch.randn(*shape)
>         t = torch.randint(0, C, (n,))
>         w = torch.rand(C) if use_w else None
>         xc = x.clone().requires_grad_(True)
>         xm = x.to("mps").clone().requires_grad_(True)
>         kw = dict(p=p, margin=margin, reduction=red)
>         kwc = dict(kw, weight=w) if use_w else kw
>         kwm = dict(kw, weight=w.to("mps")) if use_w else kw
>         oc = torch.nn.functional.multi_margin_loss(xc, t, **kwc)
>         om = torch.nn.functional.multi_margin_loss(xm, t.to("mps"), **kwm)
>         torch.testing.assert_close(om.cpu(), oc)
>         g = torch.randn_like(oc)
>         oc.backward(g); om.backward(g.to("mps"))
>         torch.testing.assert_close(xm.grad.cpu(), xc.grad)
> PY
> ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
