### PR TITLE
[MPS] Add fractional_max_pool2d

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Pooling.h
+++ b/aten/src/ATen/native/mps/kernels/Pooling.h
@@ -60,3 +60,13 @@ struct MaxUnpoolingParams {
   ::c10::metal::array<idx_type_t, N> output_strides;
   ::c10::metal::array<idx_type_t, N> indices_strides;
 };
+
+struct FractionalMaxPoolParams {
+  int32_t numPlanes;
+  int32_t inputH;
+  int32_t inputW;
+  int32_t outputH;
+  int32_t outputW;
+  int32_t poolH;
+  int32_t poolW;
+};

--- a/aten/src/ATen/native/mps/kernels/Pooling.metal
+++ b/aten/src/ATen/native/mps/kernels/Pooling.metal
@@ -838,3 +838,106 @@ REGISTER_POOL_OP(bool);
 REGISTER_POOL_BACKWARD_OP(float);
 REGISTER_POOL_BACKWARD_OP(half);
 REGISTER_POOL_BACKWARD_OP(bfloat);
+
+// Start of the pooling region for one output index, from the per-plane random
+// sample. Matches get_interval in the CPU and CUDA implementations.
+inline int32_t fractional_pool_start(
+    float sample,
+    int32_t index,
+    int32_t inputSize,
+    int32_t outputSize,
+    int32_t poolSize) {
+  if (index == outputSize - 1) {
+    return inputSize - poolSize;
+  }
+  const float alpha = static_cast<float>(inputSize - poolSize) /
+      static_cast<float>(outputSize - 1);
+  return static_cast<int32_t>((index + sample) * alpha) -
+      static_cast<int32_t>(sample * alpha);
+}
+
+// One thread per output element of an NCHW tensor.
+template <typename T>
+kernel void fractional_max_pool2d(
+    constant T* input [[buffer(0)]],
+    constant T* samples [[buffer(1)]],
+    device T* output [[buffer(2)]],
+    device int64_t* indices [[buffer(3)]],
+    constant FractionalMaxPoolParams& params [[buffer(4)]],
+    uint tid [[thread_position_in_grid]]) {
+  const int32_t outputW = params.outputW;
+  const int32_t outputH = params.outputH;
+  const int32_t inputW = params.inputW;
+  const int32_t inputH = params.inputH;
+
+  const int32_t ow = static_cast<int32_t>(tid) % outputW;
+  const int32_t oh = (static_cast<int32_t>(tid) / outputW) % outputH;
+  const int32_t plane = static_cast<int32_t>(tid) / (outputW * outputH);
+
+  // samples is (N, C, 2), so the plane index also selects the batch element.
+  const float sampleW = static_cast<float>(samples[2 * plane]);
+  const float sampleH = static_cast<float>(samples[2 * plane + 1]);
+
+  const int32_t poolW =
+      fractional_pool_start(sampleW, ow, inputW, outputW, params.poolW);
+  const int32_t poolH =
+      fractional_pool_start(sampleH, oh, inputH, outputH, params.poolH);
+
+  constant T* plane_input = input + static_cast<long>(plane) * inputH * inputW;
+
+  int32_t max_index = poolH * inputW + poolW;
+  T max_val = plane_input[max_index];
+
+  for (int32_t h = poolH; h < poolH + params.poolH; ++h) {
+    for (int32_t w = poolW; w < poolW + params.poolW; ++w) {
+      const T val = plane_input[h * inputW + w];
+      // For consistency with the CPU implementation, favor the first max.
+      if (val > max_val || ::metal::isnan(static_cast<float>(val))) {
+        max_index = h * inputW + w;
+        max_val = val;
+      }
+    }
+  }
+
+  output[tid] = max_val;
+  indices[tid] = max_index;
+}
+
+// One thread per grad output element; scatters into grad input, which the host
+// has already zeroed. Pooling regions overlap, so the add must be atomic.
+template <typename T>
+kernel void fractional_max_pool2d_backward(
+    device ::c10::metal::AtomicType_t<T>* grad_input [[buffer(0)]],
+    constant T* grad_output [[buffer(1)]],
+    constant int64_t* indices [[buffer(2)]],
+    constant FractionalMaxPoolParams& params [[buffer(3)]],
+    uint tid [[thread_position_in_grid]]) {
+  const int32_t plane =
+      static_cast<int32_t>(tid) / (params.outputW * params.outputH);
+  const long plane_offset =
+      static_cast<long>(plane) * params.inputH * params.inputW;
+
+  ::c10::metal::AtomicType<T>::atomic_add(
+      grad_input, plane_offset + indices[tid], grad_output[tid]);
+}
+
+#define REGISTER_FRACTIONAL_MAX_POOL2D(T)                                  \
+  template [[host_name("fractional_max_pool2d_" #T)]] kernel void          \
+  fractional_max_pool2d<T>(                                                \
+      constant T * input [[buffer(0)]],                                    \
+      constant T * samples [[buffer(1)]],                                  \
+      device T * output [[buffer(2)]],                                     \
+      device int64_t* indices [[buffer(3)]],                               \
+      constant FractionalMaxPoolParams& params [[buffer(4)]],              \
+      uint tid [[thread_position_in_grid]]);                               \
+  template [[host_name("fractional_max_pool2d_backward_" #T)]] kernel void \
+  fractional_max_pool2d_backward<T>(                                       \
+      device ::c10::metal::AtomicType_t<T> * grad_input [[buffer(0)]],     \
+      constant T * grad_output [[buffer(1)]],                              \
+      constant int64_t* indices [[buffer(2)]],                             \
+      constant FractionalMaxPoolParams& params [[buffer(3)]],              \
+      uint tid [[thread_position_in_grid]]);
+
+REGISTER_FRACTIONAL_MAX_POOL2D(float);
+REGISTER_FRACTIONAL_MAX_POOL2D(half);
+REGISTER_FRACTIONAL_MAX_POOL2D(bfloat);

--- a/aten/src/ATen/native/mps/operations/Pooling.mm
+++ b/aten/src/ATen/native/mps/operations/Pooling.mm
@@ -18,6 +18,8 @@
 #include <ATen/ops/avg_pool2d_native.h>
 #include <ATen/ops/avg_pool3d_backward_native.h>
 #include <ATen/ops/avg_pool3d_native.h>
+#include <ATen/ops/fractional_max_pool2d_backward_native.h>
+#include <ATen/ops/fractional_max_pool2d_native.h>
 #include <ATen/ops/max_pool2d_backward_native.h>
 #include <ATen/ops/max_pool2d_native.h>
 #include <ATen/ops/max_pool2d_with_indices_backward_native.h>
@@ -557,6 +559,88 @@ static void adaptive_max_pool_out_mps_template(const Tensor& output,
   }
 
   launch_max_pool_kernel(input, output, indices, params, op_name);
+}
+
+static void fractional_max_pool2d_out_mps_template(const Tensor& output,
+                                                   const Tensor& indices,
+                                                   const Tensor& input,
+                                                   IntArrayRef pool_size,
+                                                   IntArrayRef output_size,
+                                                   const Tensor& random_samples) {
+  if (output.numel() == 0) {
+    return;
+  }
+  const auto ndims = input.dim();
+  const auto num_planes = static_cast<int32_t>(input.size(ndims == 4 ? 1 : 0));
+  const auto batch = static_cast<int32_t>(ndims == 4 ? input.size(0) : 1);
+
+  const FractionalMaxPoolParams params{
+      .numPlanes = num_planes,
+      .inputH = safe_downcast<int32_t, int64_t>(input.size(ndims - 2)),
+      .inputW = safe_downcast<int32_t, int64_t>(input.size(ndims - 1)),
+      .outputH = safe_downcast<int32_t, int64_t>(output_size[0]),
+      .outputW = safe_downcast<int32_t, int64_t>(output_size[1]),
+      .poolH = safe_downcast<int32_t, int64_t>(pool_size[0]),
+      .poolW = safe_downcast<int32_t, int64_t>(pool_size[1]),
+  };
+
+  const auto input_c = input.contiguous();
+  const auto samples_c = random_samples.contiguous();
+  const auto numThreads = static_cast<uint32_t>(batch) * num_planes * params.outputH * params.outputW;
+
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc("fractional_max_pool2d_" + scalarToMetalTypeString(input));
+      getMPSProfiler().beginProfileKernel(pso, "fractional_max_pool2d", {input}, stream);
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(computeEncoder, input_c, samples_c, output, indices, params);
+      mtl_dispatch1DJob(computeEncoder, pso, numThreads);
+      getMPSProfiler().endProfileKernel(pso, stream);
+    }
+  });
+}
+
+static void fractional_max_pool2d_backward_out_mps_template(const Tensor& grad_input,
+                                                            const Tensor& grad_output,
+                                                            const Tensor& input,
+                                                            IntArrayRef output_size,
+                                                            const Tensor& indices) {
+  grad_input.zero_();
+  if (grad_output.numel() == 0) {
+    return;
+  }
+  const auto ndims = input.dim();
+  const auto num_planes = static_cast<int32_t>(input.size(ndims == 4 ? 1 : 0));
+  const auto batch = static_cast<int32_t>(ndims == 4 ? input.size(0) : 1);
+
+  const FractionalMaxPoolParams params{
+      .numPlanes = num_planes,
+      .inputH = safe_downcast<int32_t, int64_t>(input.size(ndims - 2)),
+      .inputW = safe_downcast<int32_t, int64_t>(input.size(ndims - 1)),
+      .outputH = safe_downcast<int32_t, int64_t>(output_size[0]),
+      .outputW = safe_downcast<int32_t, int64_t>(output_size[1]),
+      .poolH = 0,
+      .poolW = 0,
+  };
+
+  const auto grad_output_c = grad_output.contiguous();
+  const auto indices_c = indices.contiguous();
+  const auto numThreads = static_cast<uint32_t>(batch) * num_planes * params.outputH * params.outputW;
+
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      auto computeEncoder = stream->commandEncoder();
+      auto pso = lib.getPipelineStateForFunc("fractional_max_pool2d_backward_" + scalarToMetalTypeString(input));
+      getMPSProfiler().beginProfileKernel(pso, "fractional_max_pool2d_backward", {grad_output}, stream);
+      [computeEncoder setComputePipelineState:pso];
+      mtl_setArgs(computeEncoder, grad_input, grad_output_c, indices_c, params);
+      mtl_dispatch1DJob(computeEncoder, pso, numThreads);
+      getMPSProfiler().endProfileKernel(pso, stream);
+    }
+  });
 }
 
 static void max_pool_backward_out_mps_template(Tensor& grad_input,
@@ -1134,6 +1218,26 @@ TORCH_IMPL_FUNC(adaptive_max_pool2d_backward_out_mps)
                                           static_cast<int32_t>(input.dim()),
                                           /*pooling_dims=*/2,
                                           "adaptive_max_pool2d_backward");
+}
+
+TORCH_IMPL_FUNC(fractional_max_pool2d_out_mps)
+(const Tensor& input,
+ IntArrayRef pool_size,
+ IntArrayRef output_size,
+ const Tensor& random_samples,
+ const Tensor& output,
+ const Tensor& indices) {
+  mps::fractional_max_pool2d_out_mps_template(output, indices, input, pool_size, output_size, random_samples);
+}
+
+TORCH_IMPL_FUNC(fractional_max_pool2d_backward_mps)
+(const Tensor& grad_output,
+ const Tensor& input,
+ IntArrayRef pool_size,
+ IntArrayRef output_size,
+ const Tensor& indices,
+ const Tensor& grad_input) {
+  mps::fractional_max_pool2d_backward_out_mps_template(grad_input, grad_output, input, output_size, indices);
 }
 
 std::tuple<Tensor&, Tensor&> max_pool3d_with_indices_out_mps(const Tensor& input,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12566,6 +12566,7 @@
   dispatch:
     CPU: fractional_max_pool2d_out_cpu
     CUDA: fractional_max_pool2d_out_cuda
+    MPS: fractional_max_pool2d_out_mps
     XPU: fractional_max_pool2d_out_xpu
 
 # Return: (Tensor output, Tensor indices)
@@ -12579,6 +12580,7 @@
   dispatch:
     CPU: fractional_max_pool2d_backward_cpu
     CUDA: fractional_max_pool2d_backward_cuda
+    MPS: fractional_max_pool2d_backward_mps
     XPU: fractional_max_pool2d_backward_xpu
 
 - func: fractional_max_pool2d_backward(Tensor grad_output, Tensor self, int[2] kernel_size, int[2] output_size, Tensor indices) -> Tensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -879,6 +879,43 @@ class TestAvgPool(TestCaseMPS):
         self.assertEqual(bn_mps.cpu(), bn_cpu)
 
 
+class TestFractionalMaxPool(TestCaseMPS):
+    # `fractional_max_pool2d` draws its pooling regions from the device RNG when
+    # `_random_samples` is not given, so the OpInfo consistency test can only
+    # check metadata. Pass the samples explicitly to get a deterministic
+    # comparison against CPU.
+    @parametrize("shape,kernel,output_size", [
+        ((1, 3, 9, 9), (4, 4), (2, 3)),
+        ((1, 3, 9, 9), (3, 3), (3, 3)),
+        ((2, 4, 10, 7), (2, 3), (5, 4)),
+        ((3, 8, 8), (2, 2), (4, 4)),
+        ((1, 1, 4, 4), (2, 2), (1, 1)),
+    ])
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_fractional_max_pool2d(self, shape, kernel, output_size, dtype):
+        torch.manual_seed(0)
+        x = torch.randn(shape, dtype=dtype)
+        sample_shape = (shape[0], shape[1], 2) if len(shape) == 4 else (1, shape[0], 2)
+        samples = torch.rand(sample_shape, dtype=dtype)
+
+        cpu_x = x.clone().requires_grad_(True)
+        mps_x = x.to("mps").clone().requires_grad_(True)
+
+        cpu_out, cpu_idx = F.fractional_max_pool2d(
+            cpu_x, kernel, output_size=output_size, return_indices=True, _random_samples=samples)
+        mps_out, mps_idx = F.fractional_max_pool2d(
+            mps_x, kernel, output_size=output_size, return_indices=True,
+            _random_samples=samples.to("mps"))
+
+        self.assertEqual(mps_out.cpu(), cpu_out)
+        self.assertEqual(mps_idx.cpu(), cpu_idx)
+
+        grad = torch.randn_like(cpu_out)
+        cpu_out.backward(grad)
+        mps_out.backward(grad.to("mps"))
+        self.assertEqual(mps_x.grad.cpu(), cpu_x.grad)
+
+
 class TestMPS(TestCaseMPS):
     def ulpAssertAllClose(self, output, reference, n_ulps):
         """
@@ -16076,9 +16113,17 @@ class TestConsistency(TestCaseMPS):
         'nn.functional.dropout2d',
         'nn.functional.dropout3d',
         'nn.functional.feature_alpha_dropout',
+        # Pooling regions are drawn from the device RNG unless
+        # `_random_samples` is passed, which the OpInfo samples do not do.
+        # Deterministic coverage lives in TestFractionalMaxPool.
+        'nn.functional.fractional_max_pool2d',
     }
 
     def _assert_random_op_match(self, mps_out, cpu_out):
+        if not isinstance(mps_out, torch.Tensor):
+            for mps_t, cpu_t in zip(mps_out, cpu_out):
+                self._assert_random_op_match(mps_t, cpu_t)
+            return
         # MPS and CPU consume independent RNG streams, so element-wise
         # comparison is meaningless. Summary stats (min/max/mean) are also
         # unreliable: dropout/multinomial outputs depend on which input
@@ -17314,6 +17359,7 @@ instantiate_parametrized_tests(TestAdvancedIndexing)
 instantiate_parametrized_tests(TestAutocastMPS)
 instantiate_parametrized_tests(MatmulTest)
 instantiate_parametrized_tests(TestBinaryIteratorConformance)
+instantiate_parametrized_tests(TestFractionalMaxPool)
 instantiate_parametrized_tests(TestLogical)
 instantiate_parametrized_tests(TestMPS)
 instantiate_parametrized_tests(TestSDPA)

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -67,6 +67,8 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_cumprod(AtenTensorHandle self, i
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_cumsum(AtenTensorHandle self, int64_t dim, int32_t* dtype, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_exponential(AtenTensorHandle self, double lambd, AtenGeneratorHandle* generator, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_fill__Scalar(AtenTensorHandle self, double value);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_fractional_max_pool2d(AtenTensorHandle self, const int64_t* kernel_size, int64_t kernel_size_len_, const int64_t* output_size, int64_t output_size_len_, AtenTensorHandle random_samples, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_fractional_max_pool2d_backward(AtenTensorHandle grad_output, AtenTensorHandle self, const int64_t* kernel_size, int64_t kernel_size_len_, const int64_t* output_size, int64_t output_size_len_, AtenTensorHandle indices, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_gcd(AtenTensorHandle self, AtenTensorHandle other, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_geqrf(AtenTensorHandle self, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_grid_sampler_2d_backward(AtenTensorHandle grad_output, AtenTensorHandle input, AtenTensorHandle grid, int64_t interpolation_mode, int64_t padding_mode, int32_t align_corners, const int32_t* output_mask, int64_t output_mask_len_, AtenTensorHandle* ret0, AtenTensorHandle* ret1);

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -425,7 +425,6 @@ if torch.backends.mps.is_available():
                 torch.int16,
                 torch.int32,
             ],
-            "nn.functional.fractional_max_pool2d": None,
             "nn.functional.fractional_max_pool3d": None,
             "nn.functional.glu": [
                 torch.int32,
@@ -886,6 +885,12 @@ if torch.backends.mps.is_available():
                 torch.float16,
                 torch.float32,
             ],
+            # fractional_max_pool draws its pooling regions from the device
+            # RNG unless `_random_samples` is passed, and the OpInfo samples do
+            # not pass it, so MPS and CPU pool over different regions and the
+            # gradients legitimately diverge. Deterministic coverage lives in
+            # TestFractionalMaxPool in test_mps.py.
+            "nn.functional.fractional_max_pool2d": [torch.float16, torch.float32],
             # PCA singular vectors are sign-ambiguous - same root cause as the
             # forward leg above. RNG shift lands seeded samples on different
             # sign choices.


### PR DESCRIPTION
I have built and run the tests for this change locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than
presented as my own prose.

> Adds MPS support for `fractional_max_pool2d` and its backward, which so far
> only had CPU, CUDA and XPU implementations and were listed as unimplemented in
> the MPS xfail list.
>
> Two Metal kernels, one thread per output element of the NCHW tensor. The
> pooling region start is the same `get_interval` formula the CPU and CUDA
> implementations use, evaluated per output index from the per-plane random
> sample; NaN handling follows CPU, which takes a NaN over any previous value.
> The backward scatters through the saved indices with an atomic add, since the
> pooling regions may overlap, which is also what CUDA does.
>
> The op cannot be verified by the OpInfo consistency test alone. When
> `_random_samples` is not given, the pooling regions are drawn from the device
> RNG, and the OpInfo samples never pass it, so MPS and CPU pool over different
> regions. That is invisible for the samples whose output size makes the interval
> independent of the draw, which is why only some of them diverge. Rather than
> paper over it with a tolerance, the op joins the other RNG-driven ops in
> `RANDOM_OP_NAMES` (metadata-only forward check, extended here to handle
> multi-output ops) and its grad leg is xfailed for the same reason the dropout
> family already is, and real verification moves to a deterministic test.
>
> Test Plan:
>
> New `TestFractionalMaxPool.test_fractional_max_pool2d` in `test/test_mps.py`
> passes `_random_samples` explicitly and compares values, indices and gradients
> against CPU across five shape and kernel combinations (including unbatched 3-D
> input and a 1x1 output) and three dtypes.
>
> ```
> python test/test_mps.py -k "fractional_max_pool2d" -v
> ```
>
> 20 tests: 15 deterministic tests pass, the 3 OpInfo forward checks pass, and
> the 2 OpInfo grad checks are expected failures for the RNG reason above.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
