### PR TITLE
[MPS] Add rrelu_with_noise

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -1,5 +1,6 @@
 #include <ATen/native/mps/kernels/Activation.h>
 #include <c10/metal/indexing.h>
+#include <c10/metal/random.h>
 #include <c10/metal/special_math.h>
 #include <metal_stdlib>
 using namespace metal;
@@ -522,3 +523,49 @@ struct log_sigmoid_backward_functor {
 REGISTER_BINARY_OP(log_sigmoid_backward, float, float);
 REGISTER_BINARY_OP(log_sigmoid_backward, half, half);
 REGISTER_BINARY_OP(log_sigmoid_backward, bfloat, bfloat);
+
+// Training-mode rrelu: one Philox-4x32-10 round per thread yields 4 uniforms,
+// used only where the input is non-positive. Elsewhere the noise is exactly 1,
+// so the output is the input unchanged. Mirrors the fused dropout kernel.
+template <typename T>
+kernel void rrelu_with_noise(
+    device T* output [[buffer(0)]],
+    device T* noise [[buffer(1)]],
+    device const T* input [[buffer(2)]],
+    constant float2& bounds [[buffer(3)]],
+    constant long2& seed_base_offset [[buffer(4)]],
+    constant uint& numel [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  const uint base = tid * 4;
+  const uint4 raw =
+      c10::metal::philox4::rand(seed_base_offset.x, seed_base_offset.y + tid);
+  const float lower = bounds.x;
+  const float upper = bounds.y;
+  const uint count = ::metal::min(4u, numel - base);
+
+  for (uint i = 0; i < count; ++i) {
+    const float x = static_cast<float>(input[base + i]);
+    float r = 1.0;
+    if (x <= 0.0) {
+      r = lower +
+          (upper - lower) * c10::metal::detail::uint32_to_uniform_float(raw[i]);
+    }
+    noise[base + i] = static_cast<T>(r);
+    output[base + i] = static_cast<T>(x * r);
+  }
+}
+
+#define REGISTER_RRELU_WITH_NOISE(DTYPE)                         \
+  template [[host_name("rrelu_with_noise_" #DTYPE)]] kernel void \
+  rrelu_with_noise<DTYPE>(                                       \
+      device DTYPE*,                                             \
+      device DTYPE*,                                             \
+      device const DTYPE*,                                       \
+      constant float2&,                                          \
+      constant long2&,                                           \
+      constant uint&,                                            \
+      uint)
+
+REGISTER_RRELU_WITH_NOISE(float);
+REGISTER_RRELU_WITH_NOISE(half);
+REGISTER_RRELU_WITH_NOISE(bfloat);

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -1,6 +1,7 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/Dispatch.h>
 #include <ATen/TensorIterator.h>
+#include <ATen/mps/MPSGeneratorImpl.h>
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/Activation.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -13,11 +14,13 @@
 #include <ATen/ops/empty_like.h>
 #include <ATen/ops/glu_backward_native.h>
 #include <ATen/ops/glu_native.h>
+#include <ATen/ops/leaky_relu.h>
 #include <ATen/ops/log_sigmoid_backward_native.h>
 #include <ATen/ops/log_sigmoid_forward_native.h>
 #include <ATen/ops/mul.h>
 #include <ATen/ops/mul_native.h>
 #include <ATen/ops/relu_native.h>
+#include <ATen/ops/rrelu_with_noise_native.h>
 #include <ATen/ops/rsub.h>
 #include <ATen/ops/sigmoid.h>
 #include <ATen/ops/sigmoid_backward_native.h>
@@ -350,6 +353,110 @@ REGISTER_DISPATCH(hardswish_stub, hardswish_kernel);
 REGISTER_DISPATCH(hardswish_backward_stub, hardswish_backward_kernel);
 REGISTER_DISPATCH(elu_stub, elu_kernel);
 REGISTER_DISPATCH(elu_backward_stub, elu_backward_kernel);
+
+static Tensor& rrelu_with_noise_out_mps_impl(const Tensor& self,
+                                             Tensor& noise,
+                                             const Scalar& lower,
+                                             const Scalar& upper,
+                                             bool training,
+                                             std::optional<Generator> generator,
+                                             Tensor& output) {
+  TORCH_CHECK(self.sizes() == noise.sizes(),
+              "noise tensor shape must match self tensor shape. Got self.shape = ",
+              self.sizes(),
+              " noise.shape = ",
+              noise.sizes());
+
+  if (!training) {
+    // Matches CPU and CUDA: outside training this is leaky_relu with the mean
+    // of the bounds, and the noise tensor is left alone.
+    const Scalar negative_slope = (lower.to<double>() + upper.to<double>()) / 2;
+    return at::leaky_relu_out(output, self, negative_slope);
+  }
+
+  output.resize_as_(self);
+  if (self.numel() == 0) {
+    return output;
+  }
+
+  using namespace mps;
+
+  const auto input_c = self.contiguous();
+  auto output_c = output.is_contiguous() ? output : at::empty_like(input_c);
+  auto noise_c = noise.is_contiguous() ? noise : at::empty_like(input_c);
+
+  auto mps_gen = get_generator_or_default<MPSGeneratorImpl>(generator, at::mps::detail::getDefaultMPSGenerator());
+  auto stream = getCurrentMPSStream();
+  const auto numel = static_cast<uint32_t>(input_c.numel());
+  const uint32_t threads = (numel + 3) / 4;
+
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc("rrelu_with_noise_" + scalarToMetalTypeString(input_c));
+
+    int64_t seed;
+    int64_t base_offset;
+    {
+      // See Note [Acquire lock when using random generators]
+      std::lock_guard<std::mutex> lock(mps_gen->mutex_);
+      seed = static_cast<int64_t>(mps_gen->current_seed());
+      base_offset = static_cast<int64_t>(mps_gen->get_offset());
+      mps_gen->set_offset(base_offset + threads);
+    }
+
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto computeEncoder = stream->commandEncoder();
+        [computeEncoder setComputePipelineState:pso];
+        mtl_setArgs(computeEncoder,
+                    output_c,
+                    noise_c,
+                    input_c,
+                    std::array<float, 2>{lower.to<float>(), upper.to<float>()},
+                    std::array<long, 2>{seed, base_offset},
+                    numel);
+        mtl_dispatch1DJob(computeEncoder, pso, threads);
+      }
+    });
+  }
+
+  if (!output.is_contiguous()) {
+    output.copy_(output_c);
+  }
+  if (!noise.is_contiguous()) {
+    noise.copy_(noise_c);
+  }
+  return output;
+}
+
+Tensor& rrelu_with_noise_out_mps(const Tensor& self,
+                                 Tensor& noise,
+                                 const Scalar& lower,
+                                 const Scalar& upper,
+                                 bool training,
+                                 std::optional<Generator> generator,
+                                 Tensor& output) {
+  return rrelu_with_noise_out_mps_impl(self, noise, lower, upper, training, std::move(generator), output);
+}
+
+Tensor rrelu_with_noise_mps(const Tensor& self,
+                            Tensor& noise,
+                            const Scalar& lower,
+                            const Scalar& upper,
+                            bool training,
+                            std::optional<Generator> generator) {
+  Tensor output = at::empty_like(self);
+  return rrelu_with_noise_out_mps_impl(self, noise, lower, upper, training, std::move(generator), output);
+}
+
+Tensor& rrelu_with_noise_mps_(Tensor& self,
+                              Tensor& noise,
+                              const Scalar& lower,
+                              const Scalar& upper,
+                              bool training,
+                              std::optional<Generator> generator) {
+  return rrelu_with_noise_out_mps_impl(self, noise, lower, upper, training, std::move(generator), self);
+}
+
 REGISTER_DISPATCH(leaky_relu_stub, leaky_relu_kernel);
 REGISTER_DISPATCH(leaky_relu_backward_stub, leaky_relu_backward_kernel);
 REGISTER_DISPATCH(silu_stub, silu_kernel);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -12270,6 +12270,7 @@
   dispatch:
     CPU: rrelu_with_noise_out_cpu
     CUDA: rrelu_with_noise_out_cuda
+    MPS: rrelu_with_noise_out_mps
     XPU: rrelu_with_noise_out_xpu
 
 - func: rrelu_with_noise(Tensor self, Tensor(b!) noise, Scalar lower=0.125, Scalar upper=0.3333333333333333, bool training=False, Generator? generator=None) -> Tensor
@@ -12277,6 +12278,7 @@
   dispatch:
     CPU: rrelu_with_noise_cpu
     CUDA: rrelu_with_noise_cuda
+    MPS: rrelu_with_noise_mps
     XPU: rrelu_with_noise_xpu
   tags: nondeterministic_seeded
   autogen: rrelu_with_noise_functional
@@ -12293,6 +12295,7 @@
   dispatch:
     CPU: rrelu_with_noise_cpu_
     CUDA: rrelu_with_noise_cuda_
+    MPS: rrelu_with_noise_mps_
     XPU: rrelu_with_noise_xpu_
 
 - func: softplus.out(Tensor self, Scalar beta=1, Scalar threshold=20, *, Tensor(a!) out) -> Tensor(a!)

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -879,6 +879,65 @@ class TestAvgPool(TestCaseMPS):
         self.assertEqual(bn_mps.cpu(), bn_cpu)
 
 
+class TestRRelu(TestCaseMPS):
+    # In training mode the negative slopes are drawn from the device RNG, so
+    # the OpInfo consistency test can only check metadata. Eval mode is
+    # deterministic and compared against CPU directly; training mode is checked
+    # through the invariants the op guarantees.
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_rrelu_eval_matches_cpu(self, dtype):
+        torch.manual_seed(0)
+        x = torch.randn(5, 7, dtype=dtype)
+        for lower, upper in ((0.125, 1 / 3), (0.0, 1.0), (0.4, 0.4)):
+            cpu_x = x.clone().requires_grad_(True)
+            mps_x = x.to("mps").clone().requires_grad_(True)
+            cpu_noise = torch.zeros_like(cpu_x)
+            mps_noise = torch.zeros_like(mps_x)
+
+            cpu_out = torch._C._nn.rrelu_with_noise(cpu_x, cpu_noise, lower, upper, False)
+            mps_out = torch._C._nn.rrelu_with_noise(mps_x, mps_noise, lower, upper, False)
+            self.assertEqual(mps_out.cpu(), cpu_out)
+
+            grad = torch.randn_like(cpu_out)
+            cpu_out.backward(grad)
+            mps_out.backward(grad.to("mps"))
+            self.assertEqual(mps_x.grad.cpu(), cpu_x.grad)
+
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_rrelu_train_invariants(self, dtype):
+        torch.manual_seed(0)
+        lower, upper = 0.125, 1 / 3
+        x = torch.randn(64, 33, dtype=dtype)
+        mps_x = x.to("mps")
+        noise = torch.zeros_like(mps_x)
+        out = torch._C._nn.rrelu_with_noise(mps_x, noise, lower, upper, True)
+
+        # noise is 1 where the input is positive, and the drawn slope elsewhere
+        positive = mps_x > 0
+        self.assertEqual(noise[positive], torch.ones_like(noise[positive]))
+        negative_noise = noise[~positive]
+        self.assertTrue(bool((negative_noise >= lower).all()))
+        self.assertTrue(bool((negative_noise <= upper).all()))
+        # and the output is exactly the input scaled by that noise
+        self.assertEqual(out, mps_x * noise)
+
+    def test_rrelu_inplace_and_out(self):
+        torch.manual_seed(0)
+        x = torch.randn(9, device="mps")
+        noise = torch.zeros_like(x)
+
+        out = torch.empty_like(x)
+        torch._C._nn.rrelu_with_noise(x, noise, 0.2, 0.5, False, None, out=out)
+        self.assertEqual(out, torch.nn.functional.leaky_relu(x, 0.35))
+
+        inplace = x.clone()
+        noise2 = torch.zeros_like(x)
+        torch._C._nn.rrelu_with_noise_(inplace, noise2, 0.2, 0.5, False)
+        self.assertEqual(inplace, out)
+
+
+
+
 class TestMPS(TestCaseMPS):
     def ulpAssertAllClose(self, output, reference, n_ulps):
         """
@@ -16076,6 +16135,7 @@ class TestConsistency(TestCaseMPS):
         'nn.functional.dropout2d',
         'nn.functional.dropout3d',
         'nn.functional.feature_alpha_dropout',
+        'nn.functional.rrelu',
     }
 
     def _assert_random_op_match(self, mps_out, cpu_out):
@@ -17314,6 +17374,7 @@ instantiate_parametrized_tests(TestAdvancedIndexing)
 instantiate_parametrized_tests(TestAutocastMPS)
 instantiate_parametrized_tests(MatmulTest)
 instantiate_parametrized_tests(TestBinaryIteratorConformance)
+instantiate_parametrized_tests(TestRRelu)
 instantiate_parametrized_tests(TestLogical)
 instantiate_parametrized_tests(TestMPS)
 instantiate_parametrized_tests(TestSDPA)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -557,7 +557,6 @@ if torch.backends.mps.is_available():
             ],
             "nn.functional.padreplicate_negative": [torch.bool],
             "nn.functional.pdist": None,
-            "nn.functional.rrelu": None,
             "nn.functional.silu": [
                 torch.int16,
                 torch.int32,
@@ -882,6 +881,11 @@ if torch.backends.mps.is_available():
             "nn.functional.dropout2d": [torch.float16, torch.float32],
             "nn.functional.dropout3d": [torch.float16, torch.float32],
             "nn.functional.alpha_dropout": [torch.float16, torch.float32],
+            # rrelu in training mode multiplies by a random slope drawn on the
+            # device, so the gradient depends on that draw exactly as the
+            # dropout mask does. Deterministic coverage lives in TestRRelu in
+            # test_mps.py.
+            "nn.functional.rrelu": [torch.float16, torch.float32],
             "nn.functional.feature_alpha_dropoutwith_train": [
                 torch.float16,
                 torch.float32,


### PR DESCRIPTION
I have built and run the tests for this change locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than
presented as my own prose.

> Adds MPS support for `rrelu_with_noise`, its out variant and its in-place
> variant, which so far only had CPU, CUDA and XPU implementations and were
> listed as unimplemented in the MPS xfail list. The backward is already
> `CompositeExplicitAutograd`, so it comes for free.
>
> Training mode is one fused Metal kernel modeled on the dropout forward kernel
> next door: a single Philox-4x32-10 round per thread produces four uniforms, and
> each is mapped into [lower, upper] only where the input is non-positive. Where
> the input is positive the noise is exactly 1, so the output is the input
> unchanged rather than a rounded multiply. The generator offset is advanced by
> the number of Philox indices the kernel actually consumes, one per thread,
> following the convention documented in `Distributions.mm`.
>
> Outside training the op is `leaky_relu` with the mean of the bounds and leaves
> the noise tensor alone, so it delegates to `at::leaky_relu_out` exactly as CPU
> and CUDA do.
>
> Test Plan:
>
> New `TestRRelu` in `test/test_mps.py`. Eval mode is deterministic, so it is
> compared against CPU directly for three dtypes and three bound pairs, forward
> and backward. Training mode cannot be compared element-wise (MPS and CPU draw
> different slopes), so it is checked through the invariants the op guarantees:
> the noise is exactly 1 where the input is positive, lies within [lower, upper]
> elsewhere, and the output is exactly the input times the noise. A third test
> covers the out and in-place variants.
>
> ```
> python test/test_mps.py -k "rrelu" -v
> ```
>
> 11 tests: 7 new deterministic tests pass, the OpInfo forward checks and error
> inputs pass, and the OpInfo grad check is an expected failure. The op joins
> `RANDOM_OP_NAMES` and `XFAILLIST_GRAD` for the same reason the dropout family
> already is: the gradient depends on which slopes were drawn.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
