### PR TITLE
[MPS] Add multilabel_margin_loss

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LossOps.h
+++ b/aten/src/ATen/native/mps/kernels/LossOps.h
@@ -35,3 +35,10 @@ struct CTCLossBackwardCollectParams {
   index_t grad_out_batch_stride;
   bool zero_infinity;
 };
+
+struct MultilabelMarginParams {
+  long nframe;
+  long dim;
+  // Scale applied in the backward pass: 1/dim, or 1/(nframe*dim) for `mean`.
+  float g;
+};

--- a/aten/src/ATen/native/mps/kernels/LossOps.metal
+++ b/aten/src/ATen/native/mps/kernels/LossOps.metal
@@ -1,4 +1,5 @@
 #include <ATen/native/mps/kernels/LossOps.h>
+#include <c10/metal/error.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
 
@@ -395,3 +396,130 @@ kernel void ctc_loss_backward_collect(
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(float);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(bfloat);
 INSTANTIATE_CTC_LOSS_TARGET_TYPES(half);
+
+// One thread per sample. Targets are label indices terminated by a negative
+// value; `is_target` marks which classes are labels for that sample and is
+// consumed by the backward pass.
+template <typename T>
+kernel void multilabel_margin_loss(
+    constant T* input [[buffer(0)]],
+    constant long* target [[buffer(1)]],
+    device T* output [[buffer(2)]],
+    device T* is_target [[buffer(3)]],
+    constant MultilabelMarginParams& params [[buffer(4)]],
+    device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  const long dim = params.dim;
+  const long t = static_cast<long>(tid);
+  constant T* row = input + t * dim;
+  constant long* target_row = target + t * dim;
+  device T* is_target_row = is_target + t * dim;
+
+  for (long d = 0; d < dim; ++d) {
+    const long target_idx = target_row[d];
+    if (target_idx < 0) {
+      break;
+    }
+    if (target_idx >= dim) {
+      TORCH_REPORT_ERROR(error_buf, "target is out of range");
+      return;
+    }
+    is_target_row[target_idx] = static_cast<T>(1.0);
+  }
+
+  float sum = 0.0;
+  for (long dt = 0; dt < dim; ++dt) {
+    const long target_idx = target_row[dt];
+    if (target_idx < 0) {
+      break;
+    }
+    const float input_target = static_cast<float>(row[target_idx]);
+    for (long d = 0; d < dim; ++d) {
+      if (static_cast<float>(is_target_row[d]) == 0.0) {
+        const float z = 1.0 - input_target + static_cast<float>(row[d]);
+        if (z > 0.0) {
+          sum += z;
+        }
+      }
+    }
+  }
+
+  output[t] = static_cast<T>(sum / static_cast<float>(dim));
+}
+
+// One thread per sample. Each thread only touches its own row, so the
+// accumulation needs no atomics. The result is not yet scaled by grad_output;
+// the host applies that afterwards.
+template <typename T>
+kernel void multilabel_margin_loss_backward(
+    device T* grad_input [[buffer(0)]],
+    constant T* input [[buffer(1)]],
+    constant long* target [[buffer(2)]],
+    constant T* is_target [[buffer(3)]],
+    constant MultilabelMarginParams& params [[buffer(4)]],
+    device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],
+    uint tid [[thread_position_in_grid]]) {
+  const long dim = params.dim;
+  const long t = static_cast<long>(tid);
+  constant T* row = input + t * dim;
+  constant long* target_row = target + t * dim;
+  constant T* is_target_row = is_target + t * dim;
+  device T* grad_row = grad_input + t * dim;
+  const float g = params.g;
+
+  for (long d = 0; d < dim; ++d) {
+    const float flag = static_cast<float>(is_target_row[d]);
+    if (flag < 0.0 || flag > 1.0) {
+      TORCH_REPORT_ERROR(error_buf, "is_target is out of range");
+      return;
+    }
+    grad_row[d] = static_cast<T>(0.0);
+  }
+
+  for (long dt = 0; dt < dim; ++dt) {
+    const long target_idx = target_row[dt];
+    if (target_idx < 0) {
+      break;
+    }
+    if (target_idx >= dim) {
+      TORCH_REPORT_ERROR(error_buf, "target is out of range");
+      return;
+    }
+    const float input_target = static_cast<float>(row[target_idx]);
+    float grad_target = static_cast<float>(grad_row[target_idx]);
+    for (long d = 0; d < dim; ++d) {
+      if (static_cast<float>(is_target_row[d]) == 0.0) {
+        const float z = 1.0 - input_target + static_cast<float>(row[d]);
+        if (z > 0.0) {
+          grad_target -= g;
+          grad_row[d] = static_cast<T>(static_cast<float>(grad_row[d]) + g);
+        }
+      }
+    }
+    grad_row[target_idx] = static_cast<T>(grad_target);
+  }
+}
+
+#define REGISTER_MULTILABEL_MARGIN_LOSS(T)                                  \
+  template [[host_name("multilabel_margin_loss_" #T)]] kernel void          \
+  multilabel_margin_loss<T>(                                                \
+      constant T * input [[buffer(0)]],                                     \
+      constant long* target [[buffer(1)]],                                  \
+      device T* output [[buffer(2)]],                                       \
+      device T* is_target [[buffer(3)]],                                    \
+      constant MultilabelMarginParams& params [[buffer(4)]],                \
+      device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],          \
+      uint tid [[thread_position_in_grid]]);                                \
+  template [[host_name("multilabel_margin_loss_backward_" #T)]] kernel void \
+  multilabel_margin_loss_backward<T>(                                       \
+      device T * grad_input [[buffer(0)]],                                  \
+      constant T * input [[buffer(1)]],                                     \
+      constant long* target [[buffer(2)]],                                  \
+      constant T* is_target [[buffer(3)]],                                  \
+      constant MultilabelMarginParams& params [[buffer(4)]],                \
+      device ::c10::metal::ErrorMessages* error_buf [[buffer(5)]],          \
+      uint tid [[thread_position_in_grid]]);
+
+REGISTER_MULTILABEL_MARGIN_LOSS(float);
+REGISTER_MULTILABEL_MARGIN_LOSS(half);
+REGISTER_MULTILABEL_MARGIN_LOSS(bfloat);

--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -1,6 +1,7 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/native/CanUse32BitIndexMath.h>
+#include <ATen/native/LossMulti.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/kernels/LossOps.h>
 
@@ -17,6 +18,8 @@
 #include <ATen/ops/huber_loss_native.h>
 #include <ATen/ops/mse_loss_backward_native.h>
 #include <ATen/ops/mse_loss_native.h>
+#include <ATen/ops/multilabel_margin_loss_backward_native.h>
+#include <ATen/ops/multilabel_margin_loss_forward_native.h>
 #include <ATen/ops/nll_loss2d_backward_native.h>
 #include <ATen/ops/nll_loss2d_forward_native.h>
 #include <ATen/ops/nll_loss_backward_native.h>
@@ -1646,6 +1649,137 @@ Tensor ctc_loss_backward_mps(const Tensor& grad_out,
   }
 
   return grad;
+}
+
+namespace mps {
+
+static void multilabel_margin_loss_launch(const std::string& kernel,
+                                          const std::initializer_list<Tensor>& buffers,
+                                          const MultilabelMarginParams& params) {
+  auto stream = getCurrentMPSStream();
+  @autoreleasepool {
+    auto pso = lib.getPipelineStateForFunc(kernel);
+    dispatch_sync_with_rethrow(stream->queue(), ^() {
+      @autoreleasepool {
+        auto compute_encoder = stream->commandEncoder();
+        [compute_encoder setComputePipelineState:pso];
+        unsigned idx = 0;
+        for (const auto& t : buffers) {
+          mtl_setBuffer(compute_encoder, t, idx++);
+        }
+        mtl_setBytes(compute_encoder, params, idx++);
+        [compute_encoder setBuffer:stream->getErrorBuffer() offset:0 atIndex:idx];
+        mtl_dispatch1DJob(compute_encoder, pso, static_cast<uint32_t>(params.nframe));
+      }
+    });
+  }
+}
+
+} // namespace mps
+
+std::tuple<Tensor&, Tensor&> multilabel_margin_loss_forward_out_mps(const Tensor& input,
+                                                                    const Tensor& target,
+                                                                    int64_t reduction,
+                                                                    Tensor& output,
+                                                                    Tensor& is_target) {
+  int64_t nframe = 0, dim = 0;
+  multilabel_margin_loss_shape_check(nframe, dim, input.dim(), input, target);
+  TORCH_CHECK(target.scalar_type() == kLong, "expected scalar type Long but found ", target.scalar_type());
+
+  // A 1-D input produces a scalar output even under Reduction::None, as on CPU.
+  if (reduction != Reduction::None || target.dim() <= 1) {
+    output.resize_({});
+  } else {
+    output.resize_({nframe});
+  }
+  is_target.resize_as_(target);
+  TORCH_CHECK(is_target.is_contiguous(), "is_target must be contiguous");
+  is_target.zero_();
+
+  if (input.numel() == 0) {
+    return {output, is_target};
+  }
+
+  const auto input_c = input.contiguous().reshape({nframe, dim});
+  const auto target_c = target.contiguous();
+  auto per_sample = at::empty({nframe}, input.options());
+
+  const MultilabelMarginParams params{.nframe = nframe, .dim = dim, .g = 0.0f};
+  mps::multilabel_margin_loss_launch("multilabel_margin_loss_" + mps::scalarToMetalTypeString(input),
+                                     {input_c, target_c, per_sample, is_target},
+                                     params);
+
+  if (reduction == Reduction::None && target.dim() > 1) {
+    output.copy_(per_sample);
+  } else if (reduction == Reduction::Mean) {
+    output.copy_(per_sample.sum().div(nframe));
+  } else {
+    output.copy_(per_sample.sum());
+  }
+  return {output, is_target};
+}
+
+std::tuple<Tensor, Tensor> multilabel_margin_loss_forward_mps(const Tensor& input,
+                                                              const Tensor& target,
+                                                              int64_t reduction) {
+  auto output = at::empty({0}, input.options());
+  auto is_target = at::empty({0}, input.options());
+  multilabel_margin_loss_forward_out_mps(input, target, reduction, output, is_target);
+  return {std::move(output), std::move(is_target)};
+}
+
+Tensor& multilabel_margin_loss_backward_mps_out(const Tensor& grad_output,
+                                                const Tensor& input,
+                                                const Tensor& target,
+                                                int64_t reduction,
+                                                const Tensor& is_target,
+                                                Tensor& grad_input) {
+  int64_t nframe = 0, dim = 0;
+  multilabel_margin_loss_shape_check(nframe, dim, input.dim(), input, target);
+  TORCH_CHECK(target.scalar_type() == kLong, "expected scalar type Long but found ", target.scalar_type());
+  TORCH_CHECK(is_target.sizes() == target.sizes(),
+              "inconsistent is_target size: ",
+              is_target.sizes(),
+              " for target of size: ",
+              target.sizes());
+  grad_input.resize_as_(input);
+  if (grad_input.numel() == 0) {
+    return grad_input;
+  }
+
+  const auto input_c = input.contiguous().reshape({nframe, dim});
+  const auto target_c = target.contiguous();
+  const auto is_target_c = is_target.contiguous();
+  auto grad = at::empty({nframe, dim}, input.options());
+
+  const MultilabelMarginParams params{
+      .nframe = nframe,
+      .dim = dim,
+      .g = static_cast<float>(reduction == Reduction::Mean ? 1.0 / (nframe * dim) : 1.0 / dim),
+  };
+  mps::multilabel_margin_loss_launch("multilabel_margin_loss_backward_" + mps::scalarToMetalTypeString(input),
+                                     {grad, input_c, target_c, is_target_c},
+                                     params);
+
+  // Reduced losses carry a scalar grad_output; the unreduced case has one per
+  // sample and broadcasts along the class dimension.
+  if (reduction != Reduction::None || grad_output.dim() == 0) {
+    grad.mul_(grad_output.reshape({}));
+  } else {
+    grad.mul_(grad_output.reshape({nframe, 1}));
+  }
+  grad_input.copy_(grad.reshape(input.sizes()));
+  return grad_input;
+}
+
+Tensor multilabel_margin_loss_backward_mps(const Tensor& grad_output,
+                                           const Tensor& input,
+                                           const Tensor& target,
+                                           int64_t reduction,
+                                           const Tensor& is_target) {
+  auto grad_input = at::empty({0}, input.options());
+  multilabel_margin_loss_backward_mps_out(grad_output, input, target, reduction, is_target, grad_input);
+  return grad_input;
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -11850,6 +11850,7 @@
   dispatch:
     CPU: multilabel_margin_loss_forward_out_cpu
     CUDA: multilabel_margin_loss_forward_out_cuda
+    MPS: multilabel_margin_loss_forward_out_mps
     XPU: multilabel_margin_loss_forward_out_xpu
 
 - func: multilabel_margin_loss_forward(Tensor self, Tensor target, int reduction) -> (Tensor output, Tensor is_target)
@@ -11857,6 +11858,7 @@
   dispatch:
     CPU: multilabel_margin_loss_forward_cpu
     CUDA: multilabel_margin_loss_forward_cuda
+    MPS: multilabel_margin_loss_forward_mps
     XPU: multilabel_margin_loss_forward_xpu
 
 - func: multilabel_margin_loss_backward.grad_input(Tensor grad_output, Tensor self, Tensor target, int reduction, Tensor is_target, *, Tensor(a!) grad_input) -> Tensor(a!)
@@ -11864,6 +11866,7 @@
   dispatch:
     CPU: multilabel_margin_loss_backward_cpu_out
     CUDA: multilabel_margin_loss_backward_cuda_out
+    MPS: multilabel_margin_loss_backward_mps_out
     XPU: multilabel_margin_loss_backward_xpu_out
 
 - func: multilabel_margin_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction, Tensor is_target) -> Tensor
@@ -11871,6 +11874,7 @@
   dispatch:
     CPU: multilabel_margin_loss_backward_cpu
     CUDA: multilabel_margin_loss_backward_cuda
+    MPS: multilabel_margin_loss_backward_mps
     XPU: multilabel_margin_loss_backward_xpu
 
 - func: nll_loss.out(Tensor self, Tensor target, Tensor? weight=None, int reduction=Mean, SymInt ignore_index=-100, *, Tensor(a!) out) -> Tensor(a!)

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -534,13 +534,6 @@ if torch.backends.mps.is_available():
                 torch.int16,
             ],
             "nn.functional.multi_margin_loss": None,
-            "nn.functional.multilabel_margin_loss": [
-                torch.int8,
-                torch.uint8,
-                torch.int32,
-                torch.int16,
-                torch.float32,
-            ],
             "nn.functional.multilabel_soft_margin_loss": [
                 torch.int8,
                 torch.uint8,


### PR DESCRIPTION
I have built this branch standalone and run its tests locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than presented as my own prose.

> ## Why this is needed
>
> 5 votes for `multilabel_margin_loss_forward` on the most-requested list (#154052), and a user on #141287 explicitly looking for `aten::multilabel_margin_loss_forward` after failing to find anyone else asking for it.
>
> ## Change
>
> Adds MPS support for `multilabel_margin_loss_forward` and
> `multilabel_margin_loss_backward`, which so far only had CPU, CUDA and XPU
> implementations and were listed as unimplemented in the MPS xfail list. The
> `multilabel_margin_loss` entry points themselves have no dispatch of their own,
> so those two are all that is needed.
>
> Two Metal kernels, one thread per sample, ported from the CPU reference in
> `aten/src/ATen/native/LossMultiLabelMargin.cpp`. The forward marks the sample's
> label set in `is_target` and then sums the hinge terms over the non-label
> classes; the backward reuses that `is_target` and accumulates into its own row
> only, so it needs no atomics. Following the multi_margin_loss change before it,
> the reduction and the `grad_output` scaling stay on the host, since the scalar
> and per-sample cases broadcast differently.
>
> The CPU backward validates `is_target` with `min().item()` and `max().item()`,
> which on MPS would force a device-to-host synchronization on every call. The
> same check is done per element inside the kernel instead and reported through
> the MPS error buffer, so it surfaces as an `AcceleratorError` on the next sync
> at no cost to the fast path. Out-of-range targets are handled the same way; the
> target dtype is checked on the host as it is for multi_margin_loss.
>
> Test Plan:
>
> Removing the `nn.functional.multilabel_margin_loss` entry from
> `UNIMPLEMENTED_XFAILLIST` enables `test_output_match`, which runs the OpInfo on
> MPS and on CPU and compares the results.
>
> ```
> python test/test_mps.py -k "multilabel_margin" -v
> ```
>
> 3 tests pass: forward, gradients and error inputs.
>
> The OpInfo samples do not vary the reduction, cover 1-D input, or exercise
> empty and full label sets, so those were checked against CPU separately, along
> with the `is_target` second output which the functional API hides:
>
> ```
> python - <<'PY'
> import torch
> torch.manual_seed(0)
> def make_target(n, C):
>     t = torch.full((n, C), -1, dtype=torch.long)
>     for i in range(n):
>         k = torch.randint(0, C + 1, (1,)).item()
>         t[i, :k] = torch.randperm(C)[:k]
>     return t
> for n, C in ((7, 5), (1, 4), (3, 1)):
>     for red in ("none", "sum", "mean"):
>         t2 = make_target(n, C)
>         for x, tt in ((torch.randn(n, C), t2), (torch.randn(C), t2[0])):
>             xc = x.clone().requires_grad_(True)
>             xm = x.to("mps").clone().requires_grad_(True)
>             oc = torch.nn.functional.multilabel_margin_loss(xc, tt, reduction=red)
>             om = torch.nn.functional.multilabel_margin_loss(xm, tt.to("mps"), reduction=red)
>             torch.testing.assert_close(om.cpu(), oc)
>             g = torch.randn_like(oc)
>             oc.backward(g); om.backward(g.to("mps"))
>             torch.testing.assert_close(xm.grad.cpu(), xc.grad)
> x, t = torch.randn(4, 6), make_target(4, 6)
> for red in (0, 1, 2):
>     oc, ic = torch.ops.aten.multilabel_margin_loss_forward(x, t, red)
>     om, im = torch.ops.aten.multilabel_margin_loss_forward(x.to("mps"), t.to("mps"), red)
>     torch.testing.assert_close(om.cpu(), oc)
>     torch.testing.assert_close(im.cpu(), ic)
> PY
> ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
