### PR TITLE
[MPS] Add mode

### DIFF
--- a/aten/src/ATen/native/TensorCompare.cpp
+++ b/aten/src/ATen/native/TensorCompare.cpp
@@ -735,8 +735,9 @@ std::tuple<Tensor&, Tensor&> mode_out(
     Tensor& values,
     Tensor& indices) {
   TORCH_CHECK(
-      self.device().is_cpu() || self.is_cuda() || self.is_xpu(),
-      "mode only supports CPU, CUDA and XPU device type, got: ",
+      self.device().is_cpu() || self.is_cuda() || self.is_mps() ||
+          self.is_xpu(),
+      "mode only supports CPU, CUDA, MPS and XPU device type, got: ",
       self.device().type());
   TORCH_CHECK(
       self.layout() == Layout::Strided,

--- a/aten/src/ATen/native/mps/operations/Sort.mm
+++ b/aten/src/ATen/native/mps/operations/Sort.mm
@@ -8,6 +8,7 @@
 #include <ATen/native/ReduceOpsUtils.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/SortingUtils.h>
+#include <ATen/native/TensorCompare.h>
 #include <ATen/native/TensorShape.h>
 #include <ATen/native/TypeProperties.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -19,16 +20,23 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/arange.h>
 #include <ATen/ops/as_strided.h>
+#include <ATen/ops/cat.h>
+#include <ATen/ops/cummax.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/full.h>
+#include <ATen/ops/full_like.h>
 #include <ATen/ops/kthvalue_native.h>
 #include <ATen/ops/median_native.h>
 #include <ATen/ops/nanmedian_native.h>
+#include <ATen/ops/ones.h>
 #include <ATen/ops/sort.h>
 #include <ATen/ops/sort_native.h>
 #include <ATen/ops/topk_native.h>
+#include <ATen/ops/where.h>
 #include <ATen/ops/zeros.h>
+#include <ATen/ops/zeros_like.h>
 #endif
 namespace at::native {
 namespace {
@@ -797,4 +805,58 @@ std::tuple<Tensor&, Tensor&> nanmedian_out_mps(const Tensor& self,
                                                Tensor& indices) {
   return median_with_indices_impl_mps(values, indices, self, dim, keepdim, /*ignore_nan=*/self.is_floating_point());
 }
+
+// `mode` is implemented as a sort followed by a scan for the longest run of
+// equal values, which is the same shape as the CUDA fallback path. Doing it by
+// composition keeps it on the existing MPS sort rather than duplicating a
+// bitonic sort in Metal.
+static void mode_kernel_mps(Tensor& values, Tensor& indices, const Tensor& self, int64_t dim, bool keepdim) {
+  auto out_sizes = self.sizes().vec();
+  if (keepdim) {
+    out_sizes[dim] = 1;
+  } else {
+    out_sizes.erase(out_sizes.begin() + dim);
+  }
+  at::native::resize_output(values, out_sizes);
+  at::native::resize_output(indices, out_sizes);
+
+  const auto n = self.size(dim);
+  if (n == 1) {
+    values.copy_(keepdim ? self : self.squeeze(dim));
+    indices.zero_();
+    return;
+  }
+
+  auto [sorted, sorted_indices] = at::sort(self, /*stable=*/true, dim, /*descending=*/false);
+
+  // Boundaries of the runs of equal values in the sorted slice.
+  const auto differs = sorted.slice(dim, 0, n - 1).ne(sorted.slice(dim, 1, n));
+  auto edge_sizes = sorted.sizes().vec();
+  edge_sizes[dim] = 1;
+  const auto edge = at::ones(edge_sizes, self.options().dtype(kBool));
+  const auto run_start = at::cat({edge, differs}, dim);
+  const auto run_end = at::cat({differs, edge}, dim);
+
+  // Length of the run each position belongs to, known once its end is reached.
+  std::vector<int64_t> pos_shape(self.dim(), 1);
+  pos_shape[dim] = n;
+  const auto pos = at::arange(n, self.options().dtype(kLong)).view(pos_shape).expand(sorted.sizes());
+  const auto run_first = std::get<0>(at::cummax(at::where(run_start, pos, at::zeros_like(pos)), dim));
+  const auto run_length = pos.sub(run_first).add(1);
+
+  // Rank run ends by length, breaking ties towards the earlier position, which
+  // is the smaller value since the slice is sorted ascending. That matches the
+  // CPU kernel, whose frequency comparison is strict.
+  const auto rank =
+      at::where(run_end, run_length.mul(n).sub(pos), at::full_like(pos, std::numeric_limits<int64_t>::lowest()));
+  const auto winner = rank.argmax(dim, /*keepdim=*/true);
+
+  const auto mode_values = sorted.gather(dim, winner);
+  const auto mode_indices = sorted_indices.gather(dim, winner);
+  values.copy_(keepdim ? mode_values : mode_values.squeeze(dim));
+  indices.copy_(keepdim ? mode_indices : mode_indices.squeeze(dim));
+}
+
+REGISTER_DISPATCH(mode_stub, &mode_kernel_mps)
+
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4236,7 +4236,7 @@
 - func: mode(Tensor self, int dim=-1, bool keepdim=False) -> (Tensor values, Tensor indices)
   variants: function, method
   dispatch:
-    CPU, CUDA, XPU: mode
+    CPU, CUDA, MPS, XPU: mode
 
 - func: mode.values(Tensor self, int dim=-1, bool keepdim=False, *, Tensor(a!) values, Tensor(b!) indices) -> (Tensor(a!) values, Tensor(b!) indices)
   dispatch:

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16229,6 +16229,19 @@ class TestConsistency(TestCaseMPS):
                 self.assertEqual(values if keep_dim else values.squeeze(dim), mps_out[0])
                 continue
 
+            if op.name == "mode":
+                # Repeated values make the returned index non-unique (CPU picks
+                # whichever duplicate its unstable sort left last in the run),
+                # so validate the index by gathering through it instead.
+                self.assertEqual(cpu_out[0], mps_out[0], atol=atol, rtol=rtol)
+                dim = mps_sample.kwargs.get("dim", mps_sample.args[0] if mps_sample.args else -1)
+                keepdim = mps_sample.kwargs.get(
+                    "keepdim", mps_sample.args[1] if len(mps_sample.args) > 1 else False)
+                idx = mps_out[1] if keepdim else mps_out[1].unsqueeze(dim)
+                values = torch.gather(mps_sample.input, dim, idx)
+                self.assertEqual(values if keepdim else values.squeeze(dim), mps_out[0])
+                continue
+
             if op.name == "topk":
                 # Tied values give non-unique indices; gather-validate them instead of comparing.
                 self.assertEqual(cpu_out[0], mps_out[0], atol=atol, rtol=rtol)

--- a/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
+++ b/torch/csrc/inductor/aoti_torch/generated/c_shim_mps.h
@@ -96,6 +96,7 @@ AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_max_unpool2d(AtenTensorHandle se
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_max_unpool3d(AtenTensorHandle self, AtenTensorHandle indices, const int64_t* output_size, int64_t output_size_len_, const int64_t* stride, int64_t stride_len_, const int64_t* padding, int64_t padding_len_, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_median(AtenTensorHandle self, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_mm_out(AtenTensorHandle out, AtenTensorHandle self, AtenTensorHandle mat2);
+AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_mode(AtenTensorHandle self, int64_t dim, int32_t keepdim, AtenTensorHandle* ret0, AtenTensorHandle* ret1);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_mul_Scalar(AtenTensorHandle self, double other, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_mul_Tensor(AtenTensorHandle self, AtenTensorHandle other, AtenTensorHandle* ret0);
 AOTI_TORCH_EXPORT AOTITorchError aoti_torch_mps_nanmedian(AtenTensorHandle self, AtenTensorHandle* ret0);

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -389,7 +389,6 @@ if torch.backends.mps.is_available():
                 torch.uint8,
             ],
             "median": [torch.bool],
-            "mode": None,
             "nanmedian": [torch.bool],
             "native_batch_norm": [
                 torch.uint8,
@@ -925,6 +924,10 @@ if torch.backends.mps.is_available():
         }
 
         SKIPLIST_GRAD = {
+            # mode's index is only defined up to the choice of duplicate, and
+            # the gradient is a scatter at that index, so MPS and CPU can seed
+            # different positions once fp16 rounding creates ties.
+            "mode": [torch.float16],
             # topk index gather is flaky on fp16 - whether duplicates appear
             # in the seeded sample input depends on prior test order's RNG
             # draws, so we skip rather than xfail.


### PR DESCRIPTION
I have built this branch standalone and run its tests locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than presented as my own prose.

> ## Why this is needed
>
> Requested on #141287 with a concrete use case: a user training a segmentation model that also classifies the image needs the per-pixel majority label to compute accuracy.
>
> ## Change
>
> Adds MPS support for `mode`, which so far only had CPU, CUDA and XPU
> implementations and was listed as unimplemented in the MPS xfail list. It is
> stub-dispatched, so this registers into `mode_stub` and widens the device check
> in `TensorCompare.cpp`, which enumerates the allowed backends explicitly.
>
> The implementation is a sort followed by a scan for the longest run of equal
> values, which is the shape of the CUDA fallback path, but composed from
> existing MPS ops rather than written as a new kernel. CUDA's fast path is a
> fused in-block bitonic sort plus segmented scan spread over roughly 840 lines
> across `TensorModeKernel.{cu,cuh,cpp}`; MPS already has a stable sort, a
> cummax scan and gather, and reusing them is a much smaller surface than porting
> that. Ties in frequency resolve to the smaller value, matching the CPU kernel's
> strict frequency comparison, by ranking run ends with `length * n - position`.
>
> The returned index is not unique when the mode value repeats. The CPU kernel
> sorts (value, index) pairs with an unstable sort and takes whichever duplicate
> ended the run, so there is nothing to match exactly. `test_output_match` gets
> the same treatment `kthvalue` and `topk` already have: values are compared
> directly, and the index is validated by gathering the input through it. For the
> same reason the fp16 gradient is skipped, since the gradient is a scatter at
> that index and fp16 rounding creates the ties.
>
> Test Plan:
>
> Removing the `mode` entry from `UNIMPLEMENTED_XFAILLIST` enables
> `test_output_match`, which runs the OpInfo on MPS and on CPU.
>
> ```
> python test/test_mps.py -k "mode_mps" -v
> ```
>
> 11 tests: 10 pass (forward for bool and every integer and float dtype, float32
> gradients), fp16 gradients skipped for the reason above.
>
> The OpInfo samples are float-dominated and do not sweep dims, so the op was
> also checked against CPU on inputs drawn from a small range to force ties,
> across dtypes, dims, keepdim, a constant slice, a tie-free slice, a negative
> dim and a transposed input:
>
> ```
> python - <<'PY'
> import torch
> torch.manual_seed(0)
> def check(x, dim, keepdim):
>     vc, _ = torch.mode(x, dim, keepdim)
>     vm, im = torch.mode(x.to("mps"), dim, keepdim)
>     torch.testing.assert_close(vm.cpu(), vc)
>     idx = im if keepdim else im.unsqueeze(dim)
>     got = torch.gather(x.to("mps"), dim, idx)
>     torch.testing.assert_close((got if keepdim else got.squeeze(dim)).cpu(), vm.cpu())
> for dt in (torch.float32, torch.int64, torch.uint8, torch.bool,
>            torch.float16, torch.bfloat16):
>     for shape in ((7,), (4, 5), (3, 4, 5), (1, 9)):
>         for dim in range(len(shape)):
>             for keepdim in (False, True):
>                 x = torch.randint(0, 2 if dt is torch.bool else 4, shape).to(dt)
>                 check(x, dim, keepdim)
> check(torch.full((3, 6), 2.0), 1, False)
> check(torch.arange(12.0).reshape(3, 4), 1, True)
> check(torch.randint(0, 3, (5, 6)).float().t(), -1, False)
> PY
> ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
