### PR TITLE
[Testcase Refactoring] Refactor test_repros.py for test cases classification and device generalization--part2

### DIFF
--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -77,6 +77,7 @@ from torch.testing._internal.common_device_type import (
     onlyAccelerator,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
     serialTest,
@@ -1008,6 +1009,8 @@ class LRUCacheWarningTests(LoggingTestCase):
 
 
 class ReproTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self) -> None:
         super().setUp()
         try:
@@ -8879,6 +8882,173 @@ SavedForBackwardsAOTOutput(idx=5)""",
         self.assertEqual(opt_fn(inp2, grid2), fn(inp2, grid2))
         self.assertEqual(cnt.frame_count, 1)
 
+    def test_filter_safe_grad_warning(self):
+        x = torch.ones(2, 2, requires_grad=True)
+        y = x * 5  # non-leaf, .grad should warn
+        torch._subclasses.meta_utils.safe_grad(y)  # filters out warning
+
+        def unsafe_grad(y):
+            return y.grad
+
+        with warnings.catch_warnings(record=True) as w:
+            unsafe_grad(y)  # should still warn, different callsite
+            self.assertEqual(len(w), 1)
+            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
+
+            unsafe_grad(y)  # should not warn
+            self.assertEqual(len(w), 1)
+
+    def test_filter_user_warnings(self):
+        x = torch.ones(2, 2, requires_grad=True)
+        y = x * 5  # non-leaf, .grad should warn
+
+        @torch._dynamo.eval_frame.TorchPatcher.suppress_torch_distributed_warnings
+        def mute_warn(y):
+            return y.grad
+
+        mute_warn(y)  # filters out warning
+
+        def unsafe_grad(y):
+            return y.grad
+
+        with warnings.catch_warnings(record=True) as w:
+            unsafe_grad(y)  # should still warn, different callsite
+            self.assertEqual(len(w), 1)
+            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
+
+            unsafe_grad(y)  # should not warn
+            self.assertEqual(len(w), 1)
+
+    def test_partial_export(self):
+        class Foo(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def parallelize(self):
+                fn = self._call_impl
+
+                def wrapped_fn(fn, *args, **kwargs):
+                    new_args_0 = args[0].to(torch.bfloat16)
+                    new_args_1 = args[1].to(torch.bfloat16)
+                    return fn(new_args_0, new_args_1)
+
+                fn = functools.partial(wrapped_fn, fn)
+                self._call_impl = fn
+
+            def forward(self, a, b):
+                return a + b
+
+        from torch._dynamo.functional_export import dynamo_graph_capture_for_export
+
+        foo = Foo()
+        foo.parallelize()
+        x = torch.randn(4, 4, dtype=torch.float32)
+        y = torch.randn(4, 4, dtype=torch.float32)
+        ref = foo(x, y)
+        gm = dynamo_graph_capture_for_export(foo)(x, y)
+        res = gm(x, y)
+        self.assertEqual(res, ref)
+
+    def test_current_accelerator(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn(x):
+            torch.accelerator.current_accelerator()
+            return x + 1
+
+        self.assertEqual(fn(torch.ones(3)), torch.ones(3) + 1)
+
+    def test_pytree_get_node_type_not_traced(self):
+        # Test that torch.utils._pytree._get_node_type is not traced into
+        # and doesn't cause excessive trace time overhead
+        from torch.utils._pytree import _get_node_type
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(x, y):
+            # Call _get_node_type which is used internally by pytree operations
+            node_type = _get_node_type([x, y])
+            assert node_type is list  # noqa: S101
+            # Do some work with pytree structures
+            data = {"a": x, "b": y}
+            flat, spec = pytree.tree_flatten(data)
+            result = flat[0] + flat[1]
+            return result
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        result = fn(x, y)
+        expected = x + y
+
+        self.assertTrue(torch.allclose(result, expected))
+        # Should compile successfully with fullgraph=True
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_pytree_get_node_type_with_namedtuple(self):
+        # Test that torch.utils._pytree._get_node_type handles namedtuples correctly
+        # without being traced into, even when is_namedtuple_class is True
+        from collections import namedtuple
+
+        from torch.utils._pytree import _get_node_type
+
+        Point = namedtuple("Point", ["x", "y"])
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(a, b):
+            # Create a namedtuple
+            point = Point(a, b)
+            # Call _get_node_type with a namedtuple instance
+            node_type = _get_node_type(point)
+            assert node_type is namedtuple  # noqa: S101
+            # Use pytree operations with namedtuples
+            flat, spec = pytree.tree_flatten(point)
+            result = flat[0] + flat[1]
+            return result
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        result = fn(x, y)
+        expected = x + y
+
+        self.assertTrue(torch.allclose(result, expected))
+        # Should compile successfully with fullgraph=True
+        self.assertEqual(cnt.frame_count, 1)
+
+    def test_pytree_tree_is_leaf_not_traced(self):
+        # Test that torch.utils._pytree.tree_is_leaf is not traced into
+        # when is_leaf parameter is None (the common case)
+        from torch.utils._pytree import tree_is_leaf
+
+        cnt = torch._dynamo.testing.CompileCounter()
+
+        @torch.compile(backend=cnt, fullgraph=True)
+        def fn(x, y):
+            # Test with various types
+            # Tensors are leaves
+            is_leaf_tensor = tree_is_leaf(x)
+            assert is_leaf_tensor is True  # noqa: S101
+
+            # Lists are not leaves (they're in SUPPORTED_NODES)
+            is_leaf_list = tree_is_leaf([x, y])
+            assert is_leaf_list is False  # noqa: S101
+
+            # Dicts are not leaves
+            is_leaf_dict = tree_is_leaf({"a": x, "b": y})
+            assert is_leaf_dict is False  # noqa: S101
+
+            return x + y
+
+        x = torch.randn(3, 4)
+        y = torch.randn(3, 4)
+        result = fn(x, y)
+        expected = x + y
+
+        self.assertTrue(torch.allclose(result, expected))
+        # Should compile successfully with fullgraph=True
+        self.assertEqual(cnt.frame_count, 1)
+
 
 class ReproTestsDevice(torch._dynamo.test_case.TestCase):
     @serialTest()
@@ -9592,173 +9762,6 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
             f(x)
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[0].message), "foobar")
-
-    def test_filter_safe_grad_warning(self):
-        x = torch.ones(2, 2, requires_grad=True)
-        y = x * 5  # non-leaf, .grad should warn
-        torch._subclasses.meta_utils.safe_grad(y)  # filters out warning
-
-        def unsafe_grad(y):
-            return y.grad
-
-        with warnings.catch_warnings(record=True) as w:
-            unsafe_grad(y)  # should still warn, different callsite
-            self.assertEqual(len(w), 1)
-            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
-
-            unsafe_grad(y)  # should not warn
-            self.assertEqual(len(w), 1)
-
-    def test_filter_user_warnings(self):
-        x = torch.ones(2, 2, requires_grad=True)
-        y = x * 5  # non-leaf, .grad should warn
-
-        @torch._dynamo.eval_frame.TorchPatcher.suppress_torch_distributed_warnings
-        def mute_warn(y):
-            return y.grad
-
-        mute_warn(y)  # filters out warning
-
-        def unsafe_grad(y):
-            return y.grad
-
-        with warnings.catch_warnings(record=True) as w:
-            unsafe_grad(y)  # should still warn, different callsite
-            self.assertEqual(len(w), 1)
-            self.assertTrue("The .grad attribute of a Tensor" in str(w[0].message))
-
-            unsafe_grad(y)  # should not warn
-            self.assertEqual(len(w), 1)
-
-    def test_partial_export(self):
-        class Foo(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-
-            def parallelize(self):
-                fn = self._call_impl
-
-                def wrapped_fn(fn, *args, **kwargs):
-                    new_args_0 = args[0].to(torch.bfloat16)
-                    new_args_1 = args[1].to(torch.bfloat16)
-                    return fn(new_args_0, new_args_1)
-
-                fn = functools.partial(wrapped_fn, fn)
-                self._call_impl = fn
-
-            def forward(self, a, b):
-                return a + b
-
-        from torch._dynamo.functional_export import dynamo_graph_capture_for_export
-
-        foo = Foo()
-        foo.parallelize()
-        x = torch.randn(4, 4, dtype=torch.float32)
-        y = torch.randn(4, 4, dtype=torch.float32)
-        ref = foo(x, y)
-        gm = dynamo_graph_capture_for_export(foo)(x, y)
-        res = gm(x, y)
-        self.assertEqual(res, ref)
-
-    def test_current_accelerator(self):
-        @torch.compile(backend="eager", fullgraph=True)
-        def fn(x):
-            torch.accelerator.current_accelerator()
-            return x + 1
-
-        self.assertEqual(fn(torch.ones(3)), torch.ones(3) + 1)
-
-    def test_pytree_get_node_type_not_traced(self):
-        # Test that torch.utils._pytree._get_node_type is not traced into
-        # and doesn't cause excessive trace time overhead
-        from torch.utils._pytree import _get_node_type
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt, fullgraph=True)
-        def fn(x, y):
-            # Call _get_node_type which is used internally by pytree operations
-            node_type = _get_node_type([x, y])
-            assert node_type is list  # noqa: S101
-            # Do some work with pytree structures
-            data = {"a": x, "b": y}
-            flat, spec = pytree.tree_flatten(data)
-            result = flat[0] + flat[1]
-            return result
-
-        x = torch.randn(3, 4)
-        y = torch.randn(3, 4)
-        result = fn(x, y)
-        expected = x + y
-
-        self.assertTrue(torch.allclose(result, expected))
-        # Should compile successfully with fullgraph=True
-        self.assertEqual(cnt.frame_count, 1)
-
-    def test_pytree_get_node_type_with_namedtuple(self):
-        # Test that torch.utils._pytree._get_node_type handles namedtuples correctly
-        # without being traced into, even when is_namedtuple_class is True
-        from collections import namedtuple
-
-        from torch.utils._pytree import _get_node_type
-
-        Point = namedtuple("Point", ["x", "y"])
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt, fullgraph=True)
-        def fn(a, b):
-            # Create a namedtuple
-            point = Point(a, b)
-            # Call _get_node_type with a namedtuple instance
-            node_type = _get_node_type(point)
-            assert node_type is namedtuple  # noqa: S101
-            # Use pytree operations with namedtuples
-            flat, spec = pytree.tree_flatten(point)
-            result = flat[0] + flat[1]
-            return result
-
-        x = torch.randn(3, 4)
-        y = torch.randn(3, 4)
-        result = fn(x, y)
-        expected = x + y
-
-        self.assertTrue(torch.allclose(result, expected))
-        # Should compile successfully with fullgraph=True
-        self.assertEqual(cnt.frame_count, 1)
-
-    def test_pytree_tree_is_leaf_not_traced(self):
-        # Test that torch.utils._pytree.tree_is_leaf is not traced into
-        # when is_leaf parameter is None (the common case)
-        from torch.utils._pytree import tree_is_leaf
-
-        cnt = torch._dynamo.testing.CompileCounter()
-
-        @torch.compile(backend=cnt, fullgraph=True)
-        def fn(x, y):
-            # Test with various types
-            # Tensors are leaves
-            is_leaf_tensor = tree_is_leaf(x)
-            assert is_leaf_tensor is True  # noqa: S101
-
-            # Lists are not leaves (they're in SUPPORTED_NODES)
-            is_leaf_list = tree_is_leaf([x, y])
-            assert is_leaf_list is False  # noqa: S101
-
-            # Dicts are not leaves
-            is_leaf_dict = tree_is_leaf({"a": x, "b": y})
-            assert is_leaf_dict is False  # noqa: S101
-
-            return x + y
-
-        x = torch.randn(3, 4)
-        y = torch.randn(3, 4)
-        result = fn(x, y)
-        expected = x + y
-
-        self.assertTrue(torch.allclose(result, expected))
-        # Should compile successfully with fullgraph=True
-        self.assertEqual(cnt.frame_count, 1)
 
     def test_ordered_set_doesnt_recompile_with_ac(self):
         import torch


### PR DESCRIPTION
## Summary

This PR reorganizes `test/dynamo/test_repros.py` to decouple test classes from specific hardware backends by promoting device-generic tests out of `ReproTestsDevice`, converting CUDA-hardcoded cross-device tests to use the `device` parameter, adding `hw_classification` annotations, and broadening `instantiate_device_type_tests` to cover all available accelerators instead of a hardcoded device list.

## Changes

- Add `HardwareClassification` import from `torch.testing._internal.common_utils`.
- Annotate `ReproTests` with `hw_classification = HardwareClassification.GENERIC`.
- Move the following 7 tests from `ReproTestsDevice` to `ReproTests`:
  - `test_filter_safe_grad_warning`
  - `test_filter_user_warnings`
  - `test_partial_export`
  - `test_current_accelerator`
  - `test_pytree_get_node_type_not_traced`
  - `test_pytree_get_node_type_with_namedtuple`
  - `test_pytree_tree_is_leaf_not_traced`

## Notes

- For the complete modifications to the test_structured_trace.py file, please refer to [#193131](https://github.com/pytorch/pytorch/pull/193131). Since the changes involve a large number of lines, some modifications have been split into this PR to facilitate review and merging.
- This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98