### PR TITLE
[precompile] Keep the guards whose loss changes the answer

### DIFF
--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -255,6 +255,21 @@ def _precompile_accum_flaky_step(model, x, mode):
     return _precompile_accum_step(model, x, mode)
 
 
+class _PrecompileHasattrCfg:
+    """Branched on by hasattr, so the branch taken depends on a HASATTR guard."""
+
+
+def _precompile_hasattr_branch(cfg, x):
+    if hasattr(cfg, "fast"):
+        return x * 2.0
+    return x * 100.0
+
+
+def _precompile_dict_len(d, x):
+    # len(d) rides on the same Guard as the key check, as a DERIVED type.
+    return d["a"] * len(d)
+
+
 class _PrecompileDeadResultModel(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -2217,6 +2232,93 @@ class TestPrecompile(TestCase):
         loaded = torch.compiler.precompile.load(code, cache)
         with _maybe_scoped(loaded), torch.no_grad():
             self.assertIsNone(loaded(model, x))
+
+    def test_precompile_keeps_a_hasattr_guard_under_default_gates(self):
+        # hasattr is a branch. A single-variant capture makes every slot look
+        # invariant -- varying_guard_slots over one variant is empty by
+        # construction -- so the policy dropped the HASATTR and the artifact
+        # answered a caller on the OTHER branch with the captured one: 2.0
+        # where eager says 100.0, on fully default gates, with
+        # RISKY_DROPPED_GUARDS = [] and no error.
+        with_attr = _PrecompileHasattrCfg()
+        with_attr.fast = True
+        without = _PrecompileHasattrCfg()
+        x = torch.ones(3)
+        self.assertNotEqual(
+            _precompile_hasattr_branch(with_attr, x)[0].item(),
+            _precompile_hasattr_branch(without, x)[0].item(),
+        )
+        with torch.no_grad():
+            # Deliberately every gate at its default.
+            code, cache = torch.compiler.precompile(
+                _precompile_hasattr_branch,
+                tracer="dynamo",
+                backend="eager",
+                dynamic=False,
+                example_inputs=[(with_attr, x)],
+            )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            self.assertEqual(
+                loaded(with_attr, x), _precompile_hasattr_branch(with_attr, x)
+            )
+            # Refused, rather than served the captured branch's answer.
+            with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+                loaded(without, x)
+
+    def test_precompile_keeps_a_guard_whose_derived_type_must_survive(self):
+        # One Guard can emit several checks: a DICT_KEYS_MATCH emits the
+        # SEQUENCE_LENGTH for the same dict, as a DERIVED type. The filter
+        # removes whole Guards, so judging only the top-level type took the
+        # length check down with its parent and a four-key dict was answered
+        # with the two-key graph.
+        two = {"a": torch.ones(3), "b": torch.ones(3)}
+        four = {k: torch.ones(3) for k in ("a", "b", "c", "e")}
+        x = torch.ones(3)
+        self.assertNotEqual(
+            _precompile_dict_len(two, x)[0].item(),
+            _precompile_dict_len(four, x)[0].item(),
+        )
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                _precompile_dict_len,
+                tracer="dynamo",
+                backend="eager",
+                dynamic=False,
+                example_inputs=[(two, x)],
+            )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            self.assertEqual(loaded(two, x), _precompile_dict_len(two, x))
+            with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+                loaded(four, x)
+
+    def test_precompile_accumulate_reports_the_pass_that_just_ran(self):
+        # The gates read policy_dropped_guards, and the policy is what fills
+        # them, so gating first judged the PREVIOUS render's numbers -- inert
+        # on the first call. A capture that renders once therefore wrote
+        # POLICY_DROPPED_GUARDS = [] while that same pass had dropped every
+        # invariant slot.
+        model = _PrecompileAccumModel()
+        x = torch.randn(3, 8)
+        with tempfile.TemporaryDirectory() as d:
+            artifact_path = os.path.join(d, "m.py")
+            with torch.compiler.precompile.accumulate(
+                _precompile_accum_step,
+                artifact_path=artifact_path,
+                cache_path=os.path.join(d, "m.cache"),
+                backend="eager",
+                dynamic=False,
+                training=True,
+                require_complete=False,
+                require_no_risky_drops=False,
+            ) as capture:
+                capture(model, x, "a")  # exactly ONE render
+            with open(artifact_path) as f:
+                rendered = f.read()
+        self.assertNotIn("POLICY_DROPPED_GUARDS = []", rendered)
 
     def test_precompile_accumulate_rejects_make_fx_and_lone_paths(self):
         with self.assertRaisesRegex(ValueError, "only tracer='dynamo'"):

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -255,6 +255,17 @@ def _precompile_accum_flaky_step(model, x, mode):
     return _precompile_accum_step(model, x, mode)
 
 
+class _PrecompileClassAttrCfg:
+    # A CLASS attribute, so the instance __dict__ lacks it and Dynamo guards
+    # its absence with NOT_PRESENT_IN_GENERIC_DICT -- a type no never-drop
+    # list covers.
+    mode = "a"
+
+
+def _precompile_class_attr_branch(cfg, x):
+    return x * (2.0 if cfg.mode == "a" else 100.0)
+
+
 class _PrecompileHasattrCfg:
     """Branched on by hasattr, so the branch taken depends on a HASATTR guard."""
 
@@ -308,6 +319,10 @@ class _PrecompileAccumModel(torch.nn.Module):
         if mode == "b":
             return y.sum() + 1
         return y.sum() - 3
+
+
+def _precompile_accum_forward(model, x, mode):
+    return model(x, mode)
 
 
 def _precompile_accum_step(model, x, mode):
@@ -2232,6 +2247,70 @@ class TestPrecompile(TestCase):
         loaded = torch.compiler.precompile.load(code, cache)
         with _maybe_scoped(loaded), torch.no_grad():
             self.assertIsNone(loaded(model, x))
+
+    def test_precompile_keeps_input_rooted_slots_the_policy_cannot_judge(self):
+        # The policy drops what held identically in every variant, on the
+        # caller's statement that the environment is fixed and every variation
+        # is in the inputs. It cannot check which of the two a slot is, so it
+        # infers it from observed variance -- and one variant is no evidence,
+        # which is the default shape. So it dropped guards rooted in the very
+        # category its own rationale promises not to touch.
+        #
+        # Classified by root instead: module structure, globals, global state
+        # and the shape env are the environment; a local holding anything else
+        # is data the caller passes in. This asserts the general rule, on a
+        # guard type that no never-drop list covers, so it cannot pass by way
+        # of the HASATTR or derived-type fixes.
+        from torch._dynamo.precompile_package import precompile_capture
+
+        cfg = _PrecompileClassAttrCfg()
+        x = torch.ones(3)
+        session = precompile_capture(
+            _precompile_class_attr_branch,
+            backend="eager",
+            example_inputs=[(cfg, x)],
+        )
+        session._prune_invariant_guards = True
+        with session:
+            pass
+        session.artifact(require_no_risky_drops=False, require_complete=False)
+        input_rooted = [
+            (t, n) for t, n in session._policy_dropped_guards if n.startswith("cfg")
+        ]
+        self.assertEqual(input_rooted, [])
+        # And the module-structure slots are still pruned, or this would have
+        # bought correctness by keeping everything.
+        self.assertTrue(session._policy_dropped_guards)
+
+    def test_precompile_still_prunes_module_structure(self):
+        # The pruning win is the point of the policy: on a real model the bulk
+        # of the invariant guards genuinely are module structure, and those
+        # must still go.
+        from torch._dynamo.precompile_package import precompile_capture
+
+        model = _PrecompileAccumModel()
+        x = torch.randn(3, 8)
+        session = precompile_capture(
+            _precompile_accum_forward,
+            backend="eager",
+            example_inputs=[(model, x, "a")],
+        )
+        session._prune_invariant_guards = True
+        with session:
+            pass
+        session.artifact(require_no_risky_drops=False, require_complete=False)
+        dropped = session._policy_dropped_guards
+        self.assertTrue(dropped)
+        # Every one of them is environment: rooted at the module, or a
+        # global-state guard with no source at all.
+        # "self" as well as "model": an inner frame is the module's own
+        # forward, so the module arrives as self there. Both are the module by
+        # VALUE, which is what the rule keys on.
+        for _, name in dropped:
+            self.assertTrue(
+                name == "" or name.startswith(("model", "self", "G[")),
+                f"dropped a slot that is not environment-rooted: {name!r}",
+            )
 
     def test_precompile_keeps_a_hasattr_guard_under_default_gates(self):
         # hasattr is a branch. A single-variant capture makes every slot look

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -2248,6 +2248,47 @@ class TestPrecompile(TestCase):
         with _maybe_scoped(loaded), torch.no_grad():
             self.assertIsNone(loaded(model, x))
 
+    def test_precompile_records_what_each_dropped_slot_checked(self):
+        # A slot is named by its type and SOURCE, and for some types that is
+        # not enough to judge the drop. A dropped HASATTR on a source may be
+        # the benign companion of a kept TENSOR_MATCH on the same source, or
+        # the only thing pinning an optional attribute, and those want very
+        # different reactions from whoever is auditing the artifact. The
+        # rendered check names the attribute and tells them apart.
+        from torch._precompile import _parse_artifact_metadata
+
+        cfg = _PrecompileClassAttrCfg()
+        x = torch.ones(3)
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                _precompile_class_attr_branch,
+                tracer="dynamo",
+                backend="eager",
+                dynamic=False,
+                example_inputs=[(cfg, x)],
+                require_no_risky_drops=False,
+            )
+        meta = _parse_artifact_metadata(code)
+        rendered = meta["DROPPED_GUARD_CODE"]
+        self.assertTrue(rendered, "no dropped slot carried its check")
+        for gtype, name, check in rendered:
+            self.assertIsInstance(gtype, str)
+            self.assertIsInstance(name, str)
+            # The point of the field: something to read, not an empty slot.
+            self.assertTrue(check)
+        # And every slot named here is one of the slots reported as dropped.
+        every_drop = {
+            (t, n)
+            for key in (
+                "DROPPED_GUARDS",
+                "RISKY_DROPPED_GUARDS",
+                "POLICY_DROPPED_GUARDS",
+            )
+            for t, n in meta[key]
+        }
+        for gtype, name, _ in rendered:
+            self.assertIn((gtype, name), every_drop)
+
     def test_precompile_keeps_input_rooted_slots_the_policy_cannot_judge(self):
         # The policy drops what held identically in every variant, on the
         # caller's statement that the environment is fixed and every variation

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -1452,6 +1452,7 @@ def _summarize(
     uncovered: frozenset[str],
     capture_errors: Sequence[str],
     guard_sets: Mapping[tuple[str, str, int], Sequence[frozenset[_GuardFact]]],
+    dropped_code: Mapping[tuple[str, str], str],
 ) -> PrecompileSummary:
     wont_generalize = _wont_generalize(kept, guard_sets)
     return PrecompileSummary(
@@ -1464,6 +1465,11 @@ def _summarize(
         uncovered_frames=tuple(sorted(uncovered)),
         wont_generalize=wont_generalize,
         dropped_guards=tuple(sorted(dropped)),
+        dropped_guard_code=tuple(
+            (gtype, name, dropped_code[(gtype, name)])
+            for gtype, name in sorted(dropped | policy_dropped | risky)
+            if (gtype, name) in dropped_code
+        ),
         kept_guards=tuple(sorted(kept)),
         risky_dropped_guards=tuple(sorted(risky)),
         policy_dropped_guards=tuple(sorted(policy_dropped)),
@@ -1553,6 +1559,10 @@ class PrecompileSession:
         self._keep_graphs = False
         self._backend_obj: _PrecompileBackend | None = None
         self._policy_dropped_guards: set[tuple[str, str]] = set()
+        # slot -> the check it rendered as, for every slot dropped by any
+        # route. See PrecompileSummary.dropped_guard_code for why the slot
+        # tuple alone cannot be audited.
+        self._dropped_guard_code: dict[tuple[str, str], str] = {}
         self._dropped_guards: set[tuple[str, str]] = set()
         self._kept_guards: set[tuple[str, str]] = set()
         self._risky_dropped_guards: set[tuple[str, str]] = set()
@@ -2075,6 +2085,14 @@ class PrecompileSession:
                 or (guard_type, _normalize(name)) in keep_only
             )
 
+        # The facts, unlike the serialized guards above, are still filtered by
+        # observed variance alone -- a GuardFact carries no source object, so it
+        # cannot be root-classified the way _environment_rooted does it. Not a
+        # correctness gap on either path: keep_only is computed before this
+        # loop, so the pruning cannot feed itself, and this whole method never
+        # runs on the accumulating path, where close() retires the session
+        # without going through __exit__. It costs reporting fidelity in
+        # invariants(), nothing more.
         for key, variants in self._guard_sets.items():
             self._guard_sets[key] = [
                 frozenset(
@@ -2169,7 +2187,9 @@ class PrecompileSession:
                     tuple(getattr(entry, "derived_guard_types", ()) or ()),
                 )
                 if not keep:
-                    dropped.add((entry.guard_type, entry.name))
+                    slot = (entry.guard_type, entry.name)
+                    dropped.add(slot)
+                    self._record_dropped_code(slot, entry)
                 decisions.append(keep)
             return decisions
 
@@ -2213,6 +2233,21 @@ class PrecompileSession:
 
         return dropped
 
+    def _record_dropped_code(
+        self, slot: tuple[str, str], entry: GuardFilterEntry
+    ) -> None:
+        """Remember what a dropped slot actually checked.
+
+        First writer wins: the same slot is dropped once per variant and per
+        re-serialization, and the renderings agree up to the ids _normalize
+        already masks.
+        """
+        if slot in self._dropped_guard_code:
+            return
+        rendered = " ; ".join(_render_code(entry.code))
+        if rendered:
+            self._dropped_guard_code[slot] = rendered
+
     def _recording_filter(
         self,
         inner: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]],
@@ -2236,6 +2271,8 @@ class PrecompileSession:
             undetermined: set[_GuardFact] = set()
             for keep, entry in zip(decisions, entries):
                 slot = (entry.guard_type, entry.name)
+                if not keep:
+                    self._record_dropped_code(slot, entry)
                 target = self._kept_guards if keep else self._dropped_guards
                 target.add(slot)
                 if not keep and (
@@ -2435,6 +2472,7 @@ class PrecompileSession:
             self._package.uncovered_frames,
             self._capture_errors,
             self._guard_sets,
+            self._dropped_guard_code,
         )
 
     def _gated_summary(

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -976,6 +976,13 @@ _SHAPE_BEARING_GUARD_TYPES = frozenset(
         "CONSTANT_MATCH",
         "EQUALS_MATCH",
         "DUPLICATE_INPUT",
+        # And the one that pins whether an attribute is THERE. hasattr is a
+        # branch like any other, so dropping it serves the captured side to a
+        # caller on the other one -- the same silent wrong answer as a dropped
+        # CONSTANT_MATCH. Reachable on the DEFAULT gates, because a
+        # single-variant capture makes every slot look invariant and the drop
+        # is not classed risky.
+        "HASATTR",
         # And the guard that pins an input's KIND. Dropped, a graph traced for
         # one class is served to another and returns the first one's answer,
         # silently -- there is no shape to crash on. Upstream depends on this
@@ -2080,22 +2087,37 @@ class PrecompileSession:
         keep_only = varying_guard_slots(self._guard_sets)
         dropped: set[tuple[str, str]] = set()
 
-        def survives(guard_type: str, name: str) -> bool:
+        def survives(guard_type: str, name: str, derived: Sequence[str] = ()) -> bool:
             # An unmodelled guard never enters _guard_sets, so it was never
             # shown to be constant -- only never analyzed. This policy drops
             # what it PROVED invariant, so these stay. SHAPE_ENV is the one
             # that matters: it carries symbolic shape constraints that no
             # TENSOR_MATCH repeats.
+            #
+            # The DERIVED types decide too, the way default_guard_filter_fn
+            # reads them. One Guard can emit several checks -- a
+            # DICT_KEYS_MATCH emits the SEQUENCE_LENGTH for the same dict --
+            # and the filter removes whole Guards, so judging only the
+            # top-level type takes the length check down with its parent and
+            # the artifact answers a four-key dict with the two-key graph.
             return (
                 guard_type in _UNMODELLED_GUARD_TYPES
                 or guard_type in _SHAPE_BEARING_GUARD_TYPES
+                or any(
+                    d in _UNMODELLED_GUARD_TYPES or d in _SHAPE_BEARING_GUARD_TYPES
+                    for d in derived
+                )
                 or (guard_type, _normalize(name)) in keep_only
             )
 
         def policy(entries: Sequence[GuardFilterEntry]) -> Sequence[bool]:
             decisions = []
             for entry in entries:
-                keep = survives(entry.guard_type, entry.name)
+                keep = survives(
+                    entry.guard_type,
+                    entry.name,
+                    tuple(getattr(entry, "derived_guard_types", ()) or ()),
+                )
                 if not keep:
                     dropped.add((entry.guard_type, entry.name))
                 decisions.append(keep)
@@ -2579,6 +2601,12 @@ class PrecompileSession:
         call. See :meth:`_policy_filtered_codes` for why applying the policy to
         the session itself would quietly destroy the artifact.
         """
+        # The policy FIRST: it is what populates policy_dropped_guards, and the
+        # gates below read them. Gating first leaves require_no_risky_drops
+        # judging the previous render's numbers -- inert on the first call, and
+        # a capture that renders once therefore reports POLICY_DROPPED_GUARDS =
+        # [] while that same pass dropped every invariant slot.
+        codes = self._policy_filtered_codes()
         summary = self._gated_summary(
             require_complete=require_complete,
             require_no_risky_drops=require_no_risky_drops,
@@ -2588,9 +2616,7 @@ class PrecompileSession:
         from torch._precompile import _build_multigraph_artifact
 
         backends = self._collect_backends()
-        entry = dataclasses.replace(
-            self._package.cache_entry(), codes=self._policy_filtered_codes()
-        )
+        entry = dataclasses.replace(self._package.cache_entry(), codes=codes)
         return _build_multigraph_artifact(
             entry,
             backends,

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -146,7 +146,7 @@ from .package import (
     PrecompileCacheEntry,
 )
 from .pgo import _use_code_state
-from .source import AttrSource, DictGetItemSource, GlobalSource
+from .source import AttrSource, DictGetItemSource, GlobalSource, LocalSource
 
 
 if TYPE_CHECKING:
@@ -1177,6 +1177,53 @@ def _autograd_cache_bypasses() -> int:
     return counters["aot_autograd"].get("autograd_cache_bypass", 0)
 
 
+def _environment_rooted(entries: Sequence[GuardFilterEntry]) -> set[str]:
+    """The slots the precompile contract pins, by what they are ROOTED at.
+
+    The invariant policy drops a slot that held identically in every captured
+    variant, on the caller's statement that the environment is fixed and every
+    variation is in the inputs. It has no way to check which of the two a slot
+    is, so it infers it from observed variance -- and variance is evidence only
+    when there is more than one variant to compare. varying_guard_slots over a
+    single variant is empty by construction, which is the shipped default, so
+    the inference runs on no evidence and calls the inputs invariant too.
+
+    Classify by the root instead. Environment is the module structure, the
+    process globals, the global interpreter state and the shape env; a local
+    holding anything else is data the caller passes in, and the contract does
+    not license dropping guards on it. Measured on a real ranking model that is
+    roughly 60 of 7,575 slots retained, because in a real model the bulk of the
+    invariant guards genuinely are module structure.
+
+    Module-rooted is decided by VALUE, not by the name starting with "self":
+    precompile's own calling convention passes the model in as an argument, so
+    on the public API the module structure hangs off a local like ``model``.
+    """
+    modules = sorted(
+        (
+            e.name
+            for e in entries
+            if e.has_value and isinstance(e.value, torch.nn.Module) and e.name
+        ),
+        key=len,
+    )
+
+    def under_a_module(name: str) -> bool:
+        return any(
+            name == m or name.startswith(f"{m}.") or name.startswith(f"{m}[")
+            for m in modules
+        )
+
+    rooted = set()
+    for e in entries:
+        root = _source_root(e.orig_guard.originating_source)
+        # Anything not rooted at a local is environment outright: a module
+        # global, the global state guards, the shape env.
+        if not isinstance(root, LocalSource) or under_a_module(e.name):
+            rooted.add(e.name)
+    return rooted
+
+
 def _missing_backends_message(
     total: int, missing: Sequence[object], backend: str = "inductor"
 ) -> str:
@@ -2111,9 +2158,12 @@ class PrecompileSession:
             )
 
         def policy(entries: Sequence[GuardFilterEntry]) -> Sequence[bool]:
+            # Only environment slots are the policy's to drop. See
+            # _environment_rooted for why observed variance cannot decide this.
+            environment = _environment_rooted(entries)
             decisions = []
             for entry in entries:
-                keep = survives(
+                keep = entry.name not in environment or survives(
                     entry.guard_type,
                     entry.name,
                     tuple(getattr(entry, "derived_guard_types", ()) or ()),

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -1681,13 +1681,18 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
             "USER_INPUT_BOUNDS",
         }
     found: dict[str, object] = {}
+    # Parsed when present, never required: the guard-audit sections are
+    # reporting, and artifacts predating them load unchanged. An auditor
+    # reading a shipped artifact wants them back as data rather than by
+    # grepping the source.
+    optional = {"POLICY_DROPPED_GUARDS", "DROPPED_GUARD_CODE"}
     for node in tree.body:
         if not isinstance(node, ast.Assign) or len(node.targets) != 1:
             continue
         target = node.targets[0]
         if not isinstance(target, ast.Name):
             continue
-        if target.id in wanted:
+        if target.id in wanted or target.id in optional:
             try:
                 found[target.id] = ast.literal_eval(node.value)
             except (ValueError, SyntaxError) as e:
@@ -2002,6 +2007,17 @@ def _build_multigraph_python_source(
     parts.append(
         f"POLICY_DROPPED_GUARDS = "
         f"{[list(g) for g in getattr(summary, 'policy_dropped_guards', ())]!r}"
+    )
+    parts.append("")
+    parts.append("# What each dropped slot above actually checked. A slot is named by")
+    parts.append("# its type and SOURCE, which for some types does not say enough to")
+    parts.append("# judge the drop: a dropped HASATTR on a source may be the benign")
+    parts.append("# companion of a kept TENSOR_MATCH on the same source, or the only")
+    parts.append("# thing pinning an optional attribute. The rendered check names the")
+    parts.append("# attribute and tells the two apart.")
+    parts.append(
+        f"DROPPED_GUARD_CODE = "
+        f"{[list(g) for g in getattr(summary, 'dropped_guard_code', ())]!r}"
     )
     parts.append("")
     parts.append("# Values pinned to exactly what capture saw; any other value misses.")

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -2009,7 +2009,8 @@ def _build_multigraph_python_source(
         f"{[list(g) for g in getattr(summary, 'policy_dropped_guards', ())]!r}"
     )
     parts.append("")
-    parts.append("# What each dropped slot above actually checked. A slot is named by")
+    parts.append("# What a dropped slot above actually checked, where it renders one.")
+    parts.append("# A slot is named by")
     parts.append("# its type and SOURCE, which for some types does not say enough to")
     parts.append("# judge the drop: a dropped HASATTR on a source may be the benign")
     parts.append("# companion of a kept TENSOR_MATCH on the same source, or the only")

--- a/torch/compiler/_precompile_types.py
+++ b/torch/compiler/_precompile_types.py
@@ -71,8 +71,13 @@ class PrecompileSummary:
     # the remedy differ -- but reported, because a capture that silently
     # discards a precondition should not look like one that had none.
     policy_dropped_guards: tuple[tuple[str, str], ...] = ()
-    # (guard_type, source, rendered check) for every slot that was dropped, by
-    # whichever route. A slot is identified by its type and its SOURCE, which
+    # (guard_type, source, rendered check) for each dropped slot that HAS a
+    # rendered check. Some do not: EMPTY_NN_MODULE_HOOKS_DICT installs nothing
+    # under the default skip_nnmodule_hook_guards, and the global-state guards
+    # are checked in C++ against no source, so those appear in the drop lists
+    # with no entry here rather than with an empty one.
+    #
+    # A slot is identified by its type and its SOURCE, which
     # for some types is not enough to judge the drop: a dropped
     # ``('HASATTR', "counts['pixel']")`` may be the benign companion of a kept
     # TENSOR_MATCH on the same source, or the only thing standing between the

--- a/torch/compiler/_precompile_types.py
+++ b/torch/compiler/_precompile_types.py
@@ -71,6 +71,16 @@ class PrecompileSummary:
     # the remedy differ -- but reported, because a capture that silently
     # discards a precondition should not look like one that had none.
     policy_dropped_guards: tuple[tuple[str, str], ...] = ()
+    # (guard_type, source, rendered check) for every slot that was dropped, by
+    # whichever route. A slot is identified by its type and its SOURCE, which
+    # for some types is not enough to judge the drop: a dropped
+    # ``('HASATTR', "counts['pixel']")`` may be the benign companion of a kept
+    # TENSOR_MATCH on the same source, or the only thing standing between the
+    # artifact and an optional attribute going missing, and those want very
+    # different reactions. The rendered check names the attribute and so tells
+    # them apart. Reported alongside the three lists rather than folded into
+    # them, so the slot tuples stay the identity the policy compares on.
+    dropped_guard_code: tuple[tuple[str, str, str], ...] = ()
     capture_errors: tuple[str, ...] = ()
 
     @property


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #195284
* #195215
* #195070
* #195014
* #194966
* #194952
* #194951
* #194950
* #194949
* #194948
* #194677
* #194622
* #194619
* #194549
* #194542
* #194541
* #194534
* #194488
* #194479
* #194455
* #194454
* #194452
* #194450
* #194449
* #194428
* #194427
* #194426
* #194409
* #194394
* #194393
* #194390
* #194389
* #194388
* #194387
* #194386
* #194385
* #194384
* #194383
* #194320
* #194319
* #194318
* #194317
* #194316
* #194302
* #194301
* #194300
* #194286
* #194285
* #194284
* #194283
* #194282
* #194250
* #194249
* #194248
* #194158
* #192379
* #193976
* #193697
* #192374
* #192866

Three holes in the invariant-guard policy, each of which serves a wrong answer
rather than refusing, and the first two on the DEFAULT gates.

The policy drops a slot that held identically in every captured variant, on the
stated contract that the environment is fixed and every variation is in the
inputs. varying_guard_slots over a SINGLE variant is empty by construction --
one variant cannot disagree with itself -- so a one-shot precompile() drops
every droppable slot in the artifact. That is why both of the first two
reproduce with no gate relaxed.

HASATTR was not in the never-drop set. hasattr is a branch, so dropping it
serves the captured side to a caller on the other one. Captured with the
attribute and served without it, a `x * 2.0` / `x * 100.0` branch returns 2.0
where eager returns 100.0, RISKY_DROPPED_GUARDS is empty, and nothing raises.
It belongs beside CONSTANT_MATCH and EQUALS_MATCH, which are in the set for
exactly this reason: they pin a Python value the graph specialized on, and
shapes at least crash inside a kernel where these do not.

survives() judged only the top-level guard type. default_guard_filter_fn reads
derived_guard_types and this did not, but one Guard emits several checks -- a
DICT_KEYS_MATCH emits the SEQUENCE_LENGTH for the same dict -- and apply_filter
removes whole Guards. So the length check went out with its parent, and
`d["a"] * len(d)` captured on a two-key dict answers a four-key dict with the
two-key result.

And on the accumulating path the gates ran before the policy pass.
snapshot_artifact called _gated_summary and only then _policy_filtered_codes,
so require_no_risky_drops judged the PREVIOUS render's numbers -- nothing at
all on the first call. A capture that renders once therefore wrote
POLICY_DROPPED_GUARDS = [] into the artifact while that same pass had dropped
ten slots. The existing regression test makes two calls, so it read the lagged
value and passed.

And the general form of the first one, which is the better fix and which a
reviewer pushed back for. Blanket-protecting a guard type is a blocklist: it
closes HASATTR and leaves every other type whose drop is silently wrong open.
The premise the policy rests on already names the right rule -- "the environment
is fixed and every variation is in the inputs" -- so classify a slot by what it
is ROOTED at rather than by whether it was observed to vary. Environment is the
module structure, the process globals, the global interpreter state and the
shape env; a local holding anything else is data the caller passed in, and the
contract does not license dropping guards on it.

Module-rooted is decided by VALUE, not by the name starting with "self".
precompile's own calling convention passes the model in as an argument, so on
the public API the module structure hangs off a local like `model`, and a
name-prefix rule would keep all of it -- 35 of 38 dropped slots in the test
model. Keying on isinstance(value, nn.Module) covers both that and the
`self`-rooted shape an inner frame sees.

It costs almost nothing, which is the point: on a six-block model the drop count
and the rendered artifact are byte-identical with and without it, because the
bulk of a real model's invariant guards genuinely are module structure. On the
reporting model it was measured at roughly 60 of 7,575 slots retained.

HASATTR stays in the never-drop set as well. The root rule is the general
answer, but that one type's failure is a silently wrong branch and it has
already bitten once.

And two things a reviewer asked for on top, neither of which is a correctness
change.

Every dropped slot now carries what it actually checked, as DROPPED_GUARD_CODE
in the artifact and PrecompileSummary.dropped_guard_code. A slot is identified
by its type and its SOURCE, and for some types that is not enough to judge the
drop: a dropped ('HASATTR', "counts['pixel']") may be the benign companion of a
kept TENSOR_MATCH on the same source, or the only thing standing between the
artifact and an optional attribute going missing, and those want very different
reactions from whoever is auditing it. The rendered check names the attribute
and tells them apart. Reported alongside the three lists rather than folded into
them, so the slot tuples stay the identity the policy compares on.
_parse_artifact_metadata reads it, and POLICY_DROPPED_GUARDS, as OPTIONAL keys,
so an auditor gets them back as data and artifacts predating them still load.
Not every dropped slot renders a check -- EMPTY_NN_MODULE_HOOKS_DICT installs
nothing under the default skip_nnmodule_hook_guards, and the global-state guards
are checked in C++ against no source -- so those appear in the drop lists with
no entry here rather than with an empty one.

And a comment on the facts-pruning loop saying why it is still classified by
observed variance: a GuardFact carries no source object, so it cannot be
root-classified. It is not a correctness gap on either path -- keep_only is
computed before the loop, so the pruning cannot feed itself, and the method
never runs on the accumulating path, where close() retires the session without
going through __exit__. It costs reporting fidelity in invariants(), nothing
more. Written down because the next reader will have the same worry.

Test Plan:

```
python test/test_precompile.py
python test/dynamo/test_package.py
python test/dynamo/test_guard_serialization.py
python test/functorch/test_compile_to_python.py
```

Six new tests. Three, one per hole, each assert the served artifact REFUSES the
call it cannot answer rather than answering it wrongly. The first two capture
under fully default gates on purpose -- that is the claim -- and both return the
captured branch's numbers without this change. The third renders exactly once
and asserts the artifact does not write an empty POLICY_DROPPED_GUARDS.

Two more cover the root rule from both sides: an input-rooted slot of a type no
never-drop list covers (NOT_PRESENT_IN_GENERIC_DICT on a class attribute) is no
longer dropped, and a module-heavy capture still prunes every slot it used to,
so the fix did not buy correctness by keeping everything.

One more asserts every dropped slot carries a non-empty check and that each is
one of the slots the three lists report.

Nothing regressed: the whole suite passes, so no test was relying on these
going out.

Reported by a reviewer running the stack against a production model; the
reproductions here are theirs, reduced to the public API.

Authored with the assistance of an AI coding agent.