### PR TITLE
[typing] Mark torch.utils imports as explicit re-exports

### DIFF
--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -13,11 +13,11 @@ from torch.utils import (
     hooks as hooks,
 )
 from torch.utils.backend_registration import (
-    generate_methods_for_privateuse1_backend,
-    rename_privateuse1_backend,
+    generate_methods_for_privateuse1_backend as generate_methods_for_privateuse1_backend,
+    rename_privateuse1_backend as rename_privateuse1_backend,
 )
-from torch.utils.cpp_backtrace import get_cpp_backtrace
-from torch.utils.throughput_benchmark import ThroughputBenchmark
+from torch.utils.cpp_backtrace import get_cpp_backtrace as get_cpp_backtrace
+from torch.utils.throughput_benchmark import ThroughputBenchmark as ThroughputBenchmark
 
 
 def set_module(obj, mod):


### PR DESCRIPTION
Partially addresses #131765

## Summary

- Mark imported `torch.utils` functions and classes as explicit same-name re-exports for static type checkers.
- Cover `generate_methods_for_privateuse1_backend`, `rename_privateuse1_backend`, `get_cpp_backtrace`, and `ThroughputBenchmark`.
- Preserve runtime behavior and avoid changing `from torch.utils import *` semantics by introducing a new `__all__`.

## Testing

Import-only typing change; no runtime behavior is modified.
