### PR TITLE
[Inductor] Reinplace generalized_scatter through index_put copy-back

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -183,6 +183,75 @@ class CPUReproTests(TestCase):
         self.assertEqual(actual, expected)
         self.assertNotIn("aten.slice_scatter.default", post_grad_graphs)
 
+    def test_generalized_scatter_copy_back_preserves_live_view(self):
+        # Returning a pre-copy view of the scatter must not alias the mutated input.
+        def composed(field, src, indices, values):
+            scatter = aten.slice_scatter.default(field, src, 0, 1, -1)
+            view = aten.slice.Tensor(scatter, 0, 0, 2)
+            updated = aten.index_put.default(scatter, [indices], values)
+            aten.copy_.default(field, updated)
+            return view
+
+        field = torch.arange(6, dtype=torch.float32)
+        src = torch.tensor([-1.0, -2.0, -3.0, -4.0])
+        indices = torch.tensor([0], dtype=torch.int64)
+        values = torch.tensor([99.0])
+
+        expected_field = field.clone()
+        expected = composed(expected_field, src, indices, values)
+
+        compiled = torch.compile(composed, fullgraph=True, backend="inductor")
+        with fresh_cache():
+            actual_field = field.clone()
+            actual = compiled(actual_field, src, indices, values)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_field, expected_field)
+        self.assertFalse(torch._C._is_alias_of(expected, expected_field))
+        self.assertFalse(torch._C._is_alias_of(actual, actual_field))
+
+    @parametrize("output_kind", ("terminal", "intermediate_view", "sibling"))
+    def test_generalized_scatter_copy_back_preserves_live_indexed_update(
+        self, output_kind
+    ):
+        # Path-wide liveness: reinplacing must not overwrite returned terminal,
+        # intermediate-view, or sibling indexed-update results via copy-back.
+        def composed(field, src, indices, first_values, second_values):
+            scatter = aten.slice_scatter.default(field, src, 0, 1, -1)
+            first = aten.index_put.default(scatter, [indices], first_values)
+            if output_kind == "intermediate_view":
+                result = aten.slice.Tensor(first, 0, 0, 2)
+                updated = aten.index_put.default(first, [indices], second_values)
+            elif output_kind == "sibling":
+                result = aten.index_put.default(scatter, [indices], second_values)
+                updated = first
+            else:
+                result = updated = first
+            aten.copy_.default(field, updated)
+            return result
+
+        field = torch.arange(6, dtype=torch.float32)
+        src = torch.tensor([10.0, 11.0, 12.0, 13.0])
+        indices = torch.tensor([0], dtype=torch.int64)
+        first_values = torch.tensor([100.0])
+        second_values = torch.tensor([999.0])
+
+        expected_field = field.clone()
+        expected = composed(expected_field, src, indices, first_values, second_values)
+
+        compiled = torch.compile(composed, fullgraph=True, backend="inductor")
+        with fresh_cache():
+            actual_field = field.clone()
+            actual = compiled(actual_field, src, indices, first_values, second_values)
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual_field, expected_field)
+        self.assertFalse(torch._C._is_alias_of(expected, expected_field))
+        self.assertFalse(torch._C._is_alias_of(actual, actual_field))
+
+        actual_field.add_(1)
+        self.assertEqual(actual, expected)
+
     @skipIfNoLapack
     def test_torch_linalg_qr_tuple_slice(self):
         def fn(x):

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -57,6 +57,7 @@ from torch.testing._internal.common_utils import (
     xfailIf,
     xfailIfS390X,
 )
+from torch.testing._internal.logging_utils import logs_to_string
 from torch.utils._python_dispatch import TorchDispatchMode
 
 
@@ -154,6 +155,33 @@ class LstmModule(torch.nn.Module):
 @instantiate_parametrized_tests
 class CPUReproTests(TestCase):
     common = check_model
+
+    def test_generalized_scatter_data_dependent_index_copy(self):
+        # CPU regression for #195285: data-dependent index_copy after slice mutation.
+        def composed(field, delta, indices, gain):
+            field[1:-1].add_(delta)
+            values = torch.index_select(field, 0, indices) * gain
+            field.index_copy_(0, indices, values)
+
+        field = torch.randn(512)
+        delta = torch.randn(510)
+        indices = torch.arange(0, 64, 2, dtype=torch.int64)
+        gain = torch.randn(indices.shape[0])
+
+        expected = field.clone()
+        composed(expected, delta, indices, gain)
+
+        log_stream, ctx = logs_to_string(
+            "torch._inductor.compile_fx", "post_grad_graphs"
+        )
+        compiled = torch.compile(composed, fullgraph=True, backend="inductor")
+        with fresh_cache(), ctx():
+            actual = field.clone()
+            compiled(actual, delta, indices, gain)
+        post_grad_graphs = log_stream.getvalue()
+
+        self.assertEqual(actual, expected)
+        self.assertNotIn("aten.slice_scatter.default", post_grad_graphs)
 
     @skipIfNoLapack
     def test_torch_linalg_qr_tuple_slice(self):

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -554,30 +554,77 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(post_grad_graphs.count("aten.clone"), 0)
         self.assertNotIn("aten.slice_scatter.default", post_grad_graphs)
 
-    def test_should_reinplace_scatter_indexed_update_chain(self):
+    @parametrize(
+        "put_op",
+        [
+            subtest(aten.index_put.default, name="index_put"),
+            subtest(aten._unsafe_index_put.default, name="unsafe_index_put"),
+        ],
+    )
+    def test_should_reinplace_scatter_indexed_update_chain(self, put_op):
+        from torch._inductor.fx_passes.control_dependencies import control_deps
         from torch._inductor.fx_passes.reinplace import (
             ViewOp,
             _generalized_scatter,
             should_reinplace_scatter,
         )
 
-        def build_graph(*, values_from_scatter: bool, copy_dst_is_inp: bool):
+        def build_graph(
+            *,
+            values_from_scatter: bool,
+            copy_dst_is_inp: bool,
+            num_updates: int = 1,
+            post_copy_use: str | None = None,
+        ):
             g = torch.fx.Graph()
             inp = g.placeholder("inp")
             other = g.placeholder("other")
             src = g.placeholder("src")
             indices = g.placeholder("indices")
             values = g.placeholder("values")
+            subgraph = g.placeholder("subgraph")
             view_ops = [ViewOp(target=aten.slice.Tensor, args=(0, 1, -1), kwargs={})]
             scatter = g.call_function(_generalized_scatter, (inp, src, view_ops))
+            live_result = None
+            if post_copy_use == "view_output":
+                live_result = g.call_function(aten.slice.Tensor, (scatter, 0, 0, None))
             if values_from_scatter:
                 values = g.call_function(aten.index.Tensor, (scatter, [indices]))
-            put = g.call_function(
-                aten.index_put.default, (scatter, [indices], values, False)
-            )
+            updates = [scatter]
+            for _ in range(num_updates):
+                updates.append(
+                    g.call_function(put_op, (updates[-1], [indices], values, False))
+                )
+            put = updates[-1]
+            if post_copy_use == "indexed_output":
+                live_result = put
+            elif post_copy_use == "intermediate_view_output":
+                live_result = g.call_function(
+                    aten.slice.Tensor, (updates[-2], 0, 0, None)
+                )
+            elif post_copy_use == "sibling_output":
+                live_result = g.call_function(
+                    put_op, (scatter, [indices], values, False)
+                )
+            elif post_copy_use == "indexed_split_output":
+                split = g.call_function(aten.split.Tensor, (put, 1))
+                live_result = g.call_function(operator.getitem, (split, 0))
             copy_dst = inp if copy_dst_is_inp else other
             g.call_function(aten.copy_.default, (copy_dst, put))
-            g.output(copy_dst)
+            if post_copy_use == "metadata":
+                g.call_function(aten.sym_size.int, (scatter, 0))
+            elif post_copy_use == "ordering":
+                g.call_function(control_deps, ((scatter,), subgraph, other))
+            elif post_copy_use not in (
+                None,
+                "view_output",
+                "indexed_output",
+                "intermediate_view_output",
+                "sibling_output",
+                "indexed_split_output",
+            ):
+                raise AssertionError(f"unexpected post_copy_use: {post_copy_use}")
+            g.output(live_result if live_result is not None else copy_dst)
             return scatter
 
         self.assertTrue(
@@ -585,15 +632,87 @@ class TestReinplacingPassCorrectness(InductorTestCase):
                 build_graph(values_from_scatter=False, copy_dst_is_inp=True)
             )
         )
-        # Extra reader of the scatter result (data-dependent values) is allowed.
         self.assertTrue(
             should_reinplace_scatter(
                 build_graph(values_from_scatter=True, copy_dst_is_inp=True)
             )
         )
+        self.assertTrue(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    num_updates=2,
+                )
+            )
+        )
         self.assertFalse(
             should_reinplace_scatter(
                 build_graph(values_from_scatter=False, copy_dst_is_inp=False)
+            )
+        )
+        self.assertFalse(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    post_copy_use="view_output",
+                )
+            )
+        )
+        self.assertFalse(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    post_copy_use="sibling_output",
+                )
+            )
+        )
+        self.assertFalse(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    post_copy_use="indexed_split_output",
+                )
+            )
+        )
+        self.assertFalse(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    post_copy_use="indexed_output",
+                )
+            )
+        )
+        self.assertFalse(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    num_updates=2,
+                    post_copy_use="intermediate_view_output",
+                )
+            )
+        )
+        self.assertTrue(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    post_copy_use="metadata",
+                )
+            )
+        )
+        self.assertTrue(
+            should_reinplace_scatter(
+                build_graph(
+                    values_from_scatter=False,
+                    copy_dst_is_inp=True,
+                    post_copy_use="ordering",
+                )
             )
         )
 

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -524,6 +524,76 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         result = torch.compile(fn, fullgraph=True, backend="inductor")(x)
         self.assertEqual(result, expected)
 
+    def test_generalized_scatter_through_index_put_copy_back(self):
+        # Slice + index_put on the same input should reinplace scatter (#195285).
+        def composed(field, delta, indices, values):
+            field[1:-1].add_(delta)
+            field.index_put_((indices,), values)
+
+        field = torch.randn(512, device=device)
+        delta = torch.randn(510, device=device)
+        indices = torch.arange(0, 64, 2, device=device, dtype=torch.int64)
+        values = torch.randn(indices.shape[0], device=device)
+
+        expected = field.clone()
+        composed(expected, delta, indices, values)
+
+        log_stream, ctx = logs_to_string(
+            "torch._inductor.compile_fx", "post_grad_graphs"
+        )
+        compiled = torch.compile(composed, fullgraph=True, backend="inductor")
+        with ctx():
+            actual = field.clone()
+            compiled(actual, delta, indices, values)
+        post_grad_graphs = "\n".join(
+            log_stream.getvalue().strip().split("\n")[3:]
+        ).strip()
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(post_grad_graphs.count("aten.clone"), 0)
+
+    def test_should_reinplace_scatter_indexed_update_chain(self):
+        from torch._inductor.fx_passes.reinplace import (
+            ViewOp,
+            _generalized_scatter,
+            should_reinplace_scatter,
+        )
+
+        def build_graph(*, extra_scatter_user: bool, copy_dst_is_inp: bool):
+            g = torch.fx.Graph()
+            inp = g.placeholder("inp")
+            other = g.placeholder("other")
+            src = g.placeholder("src")
+            indices = g.placeholder("indices")
+            values = g.placeholder("values")
+            view_ops = [ViewOp(target=aten.slice.Tensor, args=(0, 1, -1), kwargs={})]
+            scatter = g.call_function(_generalized_scatter, (inp, src, view_ops))
+            put = g.call_function(
+                aten.index_put.default, (scatter, [indices], values, False)
+            )
+            if extra_scatter_user:
+                g.call_function(aten.sin.default, (scatter,))
+            copy_dst = inp if copy_dst_is_inp else other
+            g.call_function(aten.copy_.default, (copy_dst, put))
+            g.output(copy_dst)
+            return scatter
+
+        self.assertTrue(
+            should_reinplace_scatter(
+                build_graph(extra_scatter_user=False, copy_dst_is_inp=True)
+            )
+        )
+        self.assertFalse(
+            should_reinplace_scatter(
+                build_graph(extra_scatter_user=True, copy_dst_is_inp=True)
+            )
+        )
+        self.assertFalse(
+            should_reinplace_scatter(
+                build_graph(extra_scatter_user=False, copy_dst_is_inp=False)
+            )
+        )
+
     @parametrize(
         "factory_op",
         [

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -525,18 +525,19 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(result, expected)
 
     def test_generalized_scatter_through_index_put_copy_back(self):
-        # Slice + index_put on the same input should reinplace scatter (#195285).
-        def composed(field, delta, indices, values):
+        # Data-dependent indexed values from the updated field (#195285).
+        def composed(field, delta, indices, gain):
             field[1:-1].add_(delta)
+            values = torch.index_select(field, 0, indices) * gain
             field.index_put_((indices,), values)
 
         field = torch.randn(512, device=device)
         delta = torch.randn(510, device=device)
         indices = torch.arange(0, 64, 2, device=device, dtype=torch.int64)
-        values = torch.randn(indices.shape[0], device=device)
+        gain = torch.randn(indices.shape[0], device=device)
 
         expected = field.clone()
-        composed(expected, delta, indices, values)
+        composed(expected, delta, indices, gain)
 
         log_stream, ctx = logs_to_string(
             "torch._inductor.compile_fx", "post_grad_graphs"
@@ -544,13 +545,14 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         compiled = torch.compile(composed, fullgraph=True, backend="inductor")
         with ctx():
             actual = field.clone()
-            compiled(actual, delta, indices, values)
+            compiled(actual, delta, indices, gain)
         post_grad_graphs = "\n".join(
             log_stream.getvalue().strip().split("\n")[3:]
         ).strip()
 
         self.assertEqual(actual, expected)
         self.assertEqual(post_grad_graphs.count("aten.clone"), 0)
+        self.assertNotIn("aten.slice_scatter.default", post_grad_graphs)
 
     def test_should_reinplace_scatter_indexed_update_chain(self):
         from torch._inductor.fx_passes.reinplace import (
@@ -559,7 +561,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             should_reinplace_scatter,
         )
 
-        def build_graph(*, extra_scatter_user: bool, copy_dst_is_inp: bool):
+        def build_graph(*, values_from_scatter: bool, copy_dst_is_inp: bool):
             g = torch.fx.Graph()
             inp = g.placeholder("inp")
             other = g.placeholder("other")
@@ -568,11 +570,11 @@ class TestReinplacingPassCorrectness(InductorTestCase):
             values = g.placeholder("values")
             view_ops = [ViewOp(target=aten.slice.Tensor, args=(0, 1, -1), kwargs={})]
             scatter = g.call_function(_generalized_scatter, (inp, src, view_ops))
+            if values_from_scatter:
+                values = g.call_function(aten.index.Tensor, (scatter, [indices]))
             put = g.call_function(
                 aten.index_put.default, (scatter, [indices], values, False)
             )
-            if extra_scatter_user:
-                g.call_function(aten.sin.default, (scatter,))
             copy_dst = inp if copy_dst_is_inp else other
             g.call_function(aten.copy_.default, (copy_dst, put))
             g.output(copy_dst)
@@ -580,17 +582,18 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         self.assertTrue(
             should_reinplace_scatter(
-                build_graph(extra_scatter_user=False, copy_dst_is_inp=True)
+                build_graph(values_from_scatter=False, copy_dst_is_inp=True)
+            )
+        )
+        # Extra reader of the scatter result (data-dependent values) is allowed.
+        self.assertTrue(
+            should_reinplace_scatter(
+                build_graph(values_from_scatter=True, copy_dst_is_inp=True)
             )
         )
         self.assertFalse(
             should_reinplace_scatter(
-                build_graph(extra_scatter_user=True, copy_dst_is_inp=True)
-            )
-        )
-        self.assertFalse(
-            should_reinplace_scatter(
-                build_graph(extra_scatter_user=False, copy_dst_is_inp=False)
+                build_graph(values_from_scatter=False, copy_dst_is_inp=False)
             )
         )
 

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -231,6 +231,40 @@ _SCATTER_COPY_BACK_THROUGH_OPS = OrderedSet(
 )
 
 
+def _has_data_use_of_aliases_after_node(
+    nodes: Sequence[torch.fx.Node], after: torch.fx.Node
+) -> bool:
+    """True if any of `nodes` (or a view/getitem alias) has a real use after `after`.
+
+    Metadata-only and control_deps ordering-only uses are ignored. Following
+    getitem of multi-output views is required so split/unbind results count as
+    live aliases of an indexed-update result.
+    """
+    node_order = {n: i for i, n in enumerate(after.graph.nodes)}
+    after_loc = node_order[after]
+    pending = list(nodes)
+    seen: OrderedSet[torch.fx.Node] = OrderedSet()
+    while pending:
+        alias = pending.pop()
+        if alias in seen:
+            continue
+        seen.add(alias)
+        for user in alias.users:
+            if (_is_view_op(user.target) and user.args[0] is alias) or (
+                user.target is operator.getitem
+                and user.args[0] is alias
+                and _is_view_op(alias.target)
+            ):
+                pending.append(user)
+            elif (
+                node_order[user] > after_loc
+                and user.target not in META_ONLY_OPS
+                and not _is_control_deps_ordering_only_use(user, alias)
+            ):
+                return True
+    return False
+
+
 def _is_copied_back_to_input(node: torch.fx.Node, inp: torch.fx.Node) -> bool:
     return any(
         user.target is aten.copy_.default and user.args[0] is inp for user in node.users
@@ -240,22 +274,42 @@ def _is_copied_back_to_input(node: torch.fx.Node, inp: torch.fx.Node) -> bool:
 def _scatter_copied_back_through_indexed_updates(
     node: torch.fx.Node, inp: torch.fx.Node
 ) -> bool:
-    """True if node reaches copy_(inp, ...) through indexed-update base edges."""
-    pending = [node]
-    seen: OrderedSet[torch.fx.Node] = OrderedSet()
+    """True if a reachable copy-back leaves no indexed-update aliases live.
+
+    Collect every indexed update reachable over the mutation-base edge, then
+    accept reinplacing only when some copy_(inp, ...) has no real later use of
+    the root scatter, any reachable indexed-update result, or a view/getitem
+    alias of those. Checking only the terminal path would leave sibling
+    branches unsafe after reinplace + copy-back.
+    """
+    pending = [
+        user
+        for user in node.users
+        if user.target in _SCATTER_COPY_BACK_THROUGH_OPS and user.args[0] is node
+    ]
+    reachable: OrderedSet[torch.fx.Node] = OrderedSet([node])
+    copy_backs: OrderedSet[torch.fx.Node] = OrderedSet()
     while pending:
         current = pending.pop()
-        if current in seen:
+        if current in reachable:
             continue
-        seen.add(current)
-        if _is_copied_back_to_input(current, inp):
-            return True
+        reachable.add(current)
+        for user in current.users:
+            if (
+                user.target is aten.copy_.default
+                and user.args[0] is inp
+                and user.args[1] is current
+            ):
+                copy_backs.add(user)
         pending.extend(
             user
             for user in current.users
             if user.target in _SCATTER_COPY_BACK_THROUGH_OPS and user.args[0] is current
         )
-    return False
+    return any(
+        not _has_data_use_of_aliases_after_node(tuple(reachable), copy_back)
+        for copy_back in copy_backs
+    )
 
 
 def should_reinplace_scatter(node: torch.fx.Node) -> bool:
@@ -277,11 +331,12 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
 
     # If the output is copied back into the input (directly, or through a
     # chain of known inplaceable indexed updates), this forces both to be
-    # realized as the output is a user of the input. Other output users do not
-    # change that profitability decision; alias and liveness checks remain the
-    # safety gate for reinplacing.
+    # realized as the output is a user of the input. The indexed-update graph
+    # must not leave any reachable result alias live after the copy-back, since
+    # reinplacing would make that alias observe the input mutation.
     if inp.op in ("placeholder", "get_attr") and (  # type: ignore[union-attr]
-        _scatter_copied_back_through_indexed_updates(node, inp)  # type: ignore[arg-type]
+        _is_copied_back_to_input(node, inp)  # type: ignore[arg-type]
+        or _scatter_copied_back_through_indexed_updates(node, inp)  # type: ignore[arg-type]
     ):
         return True
 

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -221,11 +221,12 @@ def scatter_always_uses_mutation(node: torch.fx.Node) -> bool:
 
 # Indexed updates allowed between generalized_scatter and copy_ back to a graph
 # input when deciding scatter reinplace profitability (see #195285).
+# index_copy is omitted: it is not in inplaceable_ops and is normally decomposed
+# to index_put before this pass.
 _SCATTER_COPY_BACK_THROUGH_OPS = OrderedSet(
     [
         aten.index_put.default,
         aten._unsafe_index_put.default,
-        aten.index_copy.default,
     ]
 )
 
@@ -239,20 +240,21 @@ def _is_copied_back_to_input(node: torch.fx.Node, inp: torch.fx.Node) -> bool:
 def _scatter_copied_back_through_indexed_updates(
     node: torch.fx.Node, inp: torch.fx.Node
 ) -> bool:
-    """True if node reaches copy_(inp, ...) directly or via a single-user chain."""
-    current = node
+    """True if node reaches copy_(inp, ...) through indexed-update base edges."""
+    pending = [node]
     seen: OrderedSet[torch.fx.Node] = OrderedSet()
-    while current not in seen:
+    while pending:
+        current = pending.pop()
+        if current in seen:
+            continue
         seen.add(current)
         if _is_copied_back_to_input(current, inp):
             return True
-        if len(current.users) != 1:
-            return False
-        user = next(iter(current.users))
-        through = user.target in _SCATTER_COPY_BACK_THROUGH_OPS
-        if not through or user.args[0] is not current:
-            return False
-        current = user
+        pending.extend(
+            user
+            for user in current.users
+            if user.target in _SCATTER_COPY_BACK_THROUGH_OPS and user.args[0] is current
+        )
     return False
 
 
@@ -274,8 +276,10 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
         return True
 
     # If the output is copied back into the input (directly, or through a
-    # single-user chain of known inplaceable indexed updates), this forces both
-    # to be realized as the output is a user of the input.
+    # chain of known inplaceable indexed updates), this forces both to be
+    # realized as the output is a user of the input. Other output users do not
+    # change that profitability decision; alias and liveness checks remain the
+    # safety gate for reinplacing.
     if inp.op in ("placeholder", "get_attr") and (  # type: ignore[union-attr]
         _scatter_copied_back_through_indexed_updates(node, inp)  # type: ignore[arg-type]
     ):

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -219,6 +219,43 @@ def scatter_always_uses_mutation(node: torch.fx.Node) -> bool:
     )
 
 
+# Indexed updates allowed between generalized_scatter and copy_ back to a graph
+# input when deciding scatter reinplace profitability (see #195285).
+_SCATTER_COPY_BACK_THROUGH_OPS = OrderedSet(
+    [
+        aten.index_put.default,
+        aten._unsafe_index_put.default,
+        aten.index_copy.default,
+    ]
+)
+
+
+def _is_copied_back_to_input(node: torch.fx.Node, inp: torch.fx.Node) -> bool:
+    return any(
+        user.target is aten.copy_.default and user.args[0] is inp for user in node.users
+    )
+
+
+def _scatter_copied_back_through_indexed_updates(
+    node: torch.fx.Node, inp: torch.fx.Node
+) -> bool:
+    """True if node reaches copy_(inp, ...) directly or via a single-user chain."""
+    current = node
+    seen: OrderedSet[torch.fx.Node] = OrderedSet()
+    while current not in seen:
+        seen.add(current)
+        if _is_copied_back_to_input(current, inp):
+            return True
+        if len(current.users) != 1:
+            return False
+        user = next(iter(current.users))
+        through = user.target in _SCATTER_COPY_BACK_THROUGH_OPS
+        if not through or user.args[0] is not current:
+            return False
+        current = user
+    return False
+
+
 def should_reinplace_scatter(node: torch.fx.Node) -> bool:
     """Choose between mutating and functional scatter decompositions
 
@@ -236,10 +273,11 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
     if is_node_realized(inp) and is_node_realized(node):  # type: ignore[arg-type]
         return True
 
-    # If the output is copied back into the input, this forces both to be
-    # realized as the output is a user of the input
-    if inp.op in ("placeholder", "get_attr") and any(  # type: ignore[union-attr]
-        user.target is aten.copy_.default and user.args[0] is inp for user in node.users
+    # If the output is copied back into the input (directly, or through a
+    # single-user chain of known inplaceable indexed updates), this forces both
+    # to be realized as the output is a user of the input.
+    if inp.op in ("placeholder", "get_attr") and (  # type: ignore[union-attr]
+        _scatter_copied_back_through_indexed_updates(node, inp)  # type: ignore[arg-type]
     ):
         return True
 


### PR DESCRIPTION
## Summary

Fixes a missed reinplace in Inductor when a graph input is updated by a composed slice mutation followed by an indexed mutation. Functionalization produces:

```
_generalized_scatter(input, ...) -> index_put/index_copy -> copy_(input, ...)
```

`should_reinplace_scatter()` previously only treated a *direct* `generalized_scatter -> copy_(input)` edge as profitable, so the scatter stayed functional and cloned the full input buffer on every call.

This change walks a single-user chain through known indexed-update ops (`index_put`, `_unsafe_index_put`, `index_copy`) and reinplaces when the final result is copied back to the same placeholder/`get_attr`. Existing alias/liveness checks in the reinplace pass remain the safety gate.

Motivated by the GMES CPU mixed-material investigation (https://github.com/ruddyscent/gmes/issues/147) and reported upstream in #195285. Related but distinct from #190548 (Triton RW view copy-back).

Fixes #195285

## Files touched

- `torch/_inductor/fx_passes/reinplace.py`
- `test/inductor/test_inplacing_pass.py`

## Test plan

- [ ] `pytest test/inductor/test_inplacing_pass.py -k "generalized_scatter"`
- [ ] Confirm composed slice + `index_put_` no longer emits a full-buffer `aten.clone` in the post-grad graph
- [ ] Negative unit cases: extra scatter consumer; copy-back to a different input


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo