### PR TITLE
[MPS] Resolve compile_shader headers the way cpp_extension does

### DIFF
--- a/torch/mps/__init__.py
+++ b/torch/mps/__init__.py
@@ -151,13 +151,18 @@ def compile_shader(source: str):
     """
     from pathlib import Path
 
+    from torch._utils_internal import get_file_path
     from torch.utils._cpp_embed_headers import _embed_headers
 
     if not hasattr(torch._C, "_mps_compileShader"):
         raise RuntimeError("MPS is not available")
+    # Resolve the header directory the same way cpp_extension does. Deriving it
+    # from `__file__` breaks under an editable install, where the package is
+    # redirected to the source checkout while the headers are staged next to
+    # the installed distribution.
     source = _embed_headers(
         [l + "\n" for l in source.split("\n")],
-        [Path(__file__).parent.parent / "include"],
+        [Path(get_file_path("torch")) / "include"],
         set(),
     )
     return torch._C._mps_compileShader(source)


### PR DESCRIPTION
`compile_shader` resolves its header directory from `__file__`, while the rest of PyTorch uses `get_file_path("torch")`. The two diverge under an editable install, where the package is redirected to the checkout but the headers are staged next to the installed distribution, so every `#include <c10/metal/...>` fails with "file not found" even though the headers are there and `cpp_extension` finds them.

Regression from #180247, which changed the editable install layout.

Fixes #195293.

Test: on such an install `TestMetalLibrary` goes from 14 errors to 27 passed / 3 skipped, and the four `atomic_add` cases pass.

*(Description drafted with an AI assistant.)*
