### PR TITLE
[BE] [MPS] Use a typed struct for LU scratch space

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.h
@@ -71,3 +71,15 @@ struct EighParams {
 C10_METAL_CONSTEXPR unsigned kLUStreamNT = 256;
 C10_METAL_CONSTEXPR unsigned kLUStreamWarpsPerTG =
     kLUStreamNT / c10::metal::simdgroup_size;
+
+// Per-batch streaming LU scratch: argmax value partials (float magnitudes),
+// argmax index partials (uint), then the U row in the element type. Shared
+// host/device so the host allocates B * sizeof(LUStreamScratch<T>) bytes and
+// binds it untyped; the kernel indexes scratch[batch] and the compiler owns the
+// stride. T is float or c10::metal::complex<float> (float2 on Metal).
+template <typename T>
+struct LUStreamScratch {
+  ::c10::metal::array<float, kLUStreamNT> vpart;
+  ::c10::metal::array<uint32_t, kLUStreamNT> ipart;
+  ::c10::metal::array<T, c10::metal::simdgroup_size> uRow;
+};

--- a/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
+++ b/aten/src/ATen/native/mps/kernels/LinearAlgebra.metal
@@ -1598,21 +1598,13 @@ INSTANTIATE_FACTOR_PANEL_LU(float2, 4, 8)
 // factorPanelLU no longer fits. luStreamUpdate applies column j's rank-1 update
 // over all rows and writes each threadgroup's local argmax partial to scratch;
 // luStreamPivot then reduces those partials to the global pivot for column j.
-// Streaming scratch layout per batch (in floats): kLUStreamNT argmax value
-// partials, kLUStreamNT index partials, then the 32-element U row in the
-// kernel's element type (32 floats for float, 64 floats for float2).
-template <typename T>
-inline uint luStreamScratchStride() {
-  return 2 * kLUStreamNT + 32 * (sizeof(T) / sizeof(float));
-}
-
 template <typename T>
 [[max_total_threads_per_threadgroup(kLUStreamNT)]]
 kernel void luStreamUpdate(
     device T* A [[buffer(0)]],
     constant uint2& dims [[buffer(3)]],
     constant uint4& params [[buffer(4)]], // d0, j, RPT, searchOnly
-    device float* scratch [[buffer(6)]],
+    device LUStreamScratch<T>* scratch [[buffer(6)]],
     uint3 tgid [[threadgroup_position_in_grid]],
     uint warp_id [[simdgroup_index_in_threadgroup]],
     uint lane [[thread_index_in_simdgroup]]) {
@@ -1626,8 +1618,7 @@ kernel void luStreamUpdate(
   const uint nb = min(32u, minMN - d0);
   const uint H = M - d0;
   device T* Ab = A + ulong(tgid.y) * M * N;
-  device float* scr = scratch + ulong(tgid.y) * luStreamScratchStride<T>();
-  device T* uRow = (device T*)(scr + 2 * kLUStreamNT);
+  device auto& scr = scratch[tgid.y];
 
   const uint rowStart = searchOnly ? j : j + 1;
   const uint sc = searchOnly ? j : j + 1; // column searched for next pivot
@@ -1637,10 +1628,10 @@ kernel void luStreamUpdate(
   T rp = T(0.0f);
   bool doUpdate = false;
   if (!searchOnly) {
-    const T upiv = uRow[j];
+    const T upiv = scr.uRow[j];
     doUpdate = luPivotMag(upiv) != 0.0f;
     rp = doUpdate ? luRecip(upiv) : T(0.0f);
-    uc = (lane < nb) ? uRow[lane] : T(0.0f);
+    uc = (lane < nb) ? scr.uRow[lane] : T(0.0f);
   }
 
   float bv = -1.0f;
@@ -1691,21 +1682,21 @@ kernel void luStreamUpdate(
     const float m2 = simd_max(v2);
     const uint p2 = simd_min((v2 == m2) ? i2 : 0xffffffffu);
     if (lane == 0) {
-      scr[tgid.x] = m2;
-      ((device uint*)(scr + kLUStreamNT))[tgid.x] = p2;
+      scr.vpart[tgid.x] = m2;
+      scr.ipart[tgid.x] = p2;
     }
   }
 }
 
-#define INSTANTIATE_LU_STREAM_UPDATE(T)                \
-  template [[host_name("luStreamUpdate_" #T)]]         \
-  kernel void luStreamUpdate<T>(                       \
-      device T * A [[buffer(0)]],                      \
-      constant uint2 & dims [[buffer(3)]],             \
-      constant uint4 & params [[buffer(4)]],           \
-      device float* scratch [[buffer(6)]],             \
-      uint3 tgid [[threadgroup_position_in_grid]],     \
-      uint warp_id [[simdgroup_index_in_threadgroup]], \
+#define INSTANTIATE_LU_STREAM_UPDATE(T)                  \
+  template [[host_name("luStreamUpdate_" #T)]]           \
+  kernel void luStreamUpdate<T>(                         \
+      device T * A [[buffer(0)]],                        \
+      constant uint2 & dims [[buffer(3)]],               \
+      constant uint4 & params [[buffer(4)]],             \
+      device LUStreamScratch<T> * scratch [[buffer(6)]], \
+      uint3 tgid [[threadgroup_position_in_grid]],       \
+      uint warp_id [[simdgroup_index_in_threadgroup]],   \
       uint lane [[thread_index_in_simdgroup]]);
 
 INSTANTIATE_LU_STREAM_UPDATE(float)
@@ -1722,7 +1713,7 @@ kernel void luStreamPivot(
     device int* info [[buffer(2)]],
     constant uint2& dims [[buffer(3)]],
     constant uint4& params [[buffer(4)]], // d0, j, npart
-    device float* scratch [[buffer(6)]],
+    device LUStreamScratch<T>* scratch [[buffer(6)]],
     uint3 tid3 [[thread_position_in_threadgroup]],
     uint3 tgid [[threadgroup_position_in_grid]],
     uint warp_id [[simdgroup_index_in_threadgroup]],
@@ -1737,9 +1728,7 @@ kernel void luStreamPivot(
   const uint tid = tid3.x; // threadgroup of kLUStreamNT threads
   device T* Ab = A + ulong(tgid.x) * M * N;
   device int* pv = pivots + ulong(tgid.x) * minMN;
-  device float* scr = scratch + ulong(tgid.x) * luStreamScratchStride<T>();
-  device const uint* sidx = (device const uint*)(scr + kLUStreamNT);
-  device T* uRow = (device T*)(scr + 2 * kLUStreamNT);
+  device auto& scr = scratch[tgid.x];
 
   if (d0 == 0 && j == 0 && tid == 0) {
     info[tgid.x] = 0;
@@ -1752,8 +1741,8 @@ kernel void luStreamPivot(
   float bv = -1.0f;
   uint bi = 0xffffffffu;
   for (uint i = tid; i < npart; i += kLUStreamNT) {
-    const float v = scr[i];
-    const uint ix = sidx[i];
+    const float v = scr.vpart[i];
+    const uint ix = scr.ipart[i];
     if (v > bv || (v == bv && ix < bi)) {
       bv = v;
       bi = ix;
@@ -1793,23 +1782,23 @@ kernel void luStreamPivot(
         *rp2 = vj;
         vj = vp;
       }
-      uRow[lane] = vj;
+      scr.uRow[lane] = vj;
     }
   }
 }
 
-#define INSTANTIATE_LU_STREAM_PIVOT(T)                 \
-  template [[host_name("luStreamPivot_" #T)]]          \
-  kernel void luStreamPivot<T>(                        \
-      device T * A [[buffer(0)]],                      \
-      device int* pivots [[buffer(1)]],                \
-      device int* info [[buffer(2)]],                  \
-      constant uint2& dims [[buffer(3)]],              \
-      constant uint4& params [[buffer(4)]],            \
-      device float* scratch [[buffer(6)]],             \
-      uint3 tid3 [[thread_position_in_threadgroup]],   \
-      uint3 tgid [[threadgroup_position_in_grid]],     \
-      uint warp_id [[simdgroup_index_in_threadgroup]], \
+#define INSTANTIATE_LU_STREAM_PIVOT(T)                  \
+  template [[host_name("luStreamPivot_" #T)]]           \
+  kernel void luStreamPivot<T>(                         \
+      device T * A [[buffer(0)]],                       \
+      device int* pivots [[buffer(1)]],                 \
+      device int* info [[buffer(2)]],                   \
+      constant uint2& dims [[buffer(3)]],               \
+      constant uint4& params [[buffer(4)]],             \
+      device LUStreamScratch<T>* scratch [[buffer(6)]], \
+      uint3 tid3 [[thread_position_in_threadgroup]],    \
+      uint3 tgid [[threadgroup_position_in_grid]],      \
+      uint warp_id [[simdgroup_index_in_threadgroup]],  \
       uint lane [[thread_index_in_simdgroup]]);
 
 INSTANTIATE_LU_STREAM_PIVOT(float)

--- a/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
+++ b/aten/src/ATen/native/mps/operations/LinearAlgebra.mm
@@ -720,15 +720,13 @@ static void lu_factor_panel_encode(const Tensor& LU,
   const auto uB = static_cast<uint32_t>(B);
   const uint32_t mn = std::min(uM, uN);
   const uint32_t NBo = mn <= 1024 ? 32 : mn <= 2048 ? 64 : 128;
-  // panels taller than this use the streaming kernels (kLUStreamNT argmax
-  // partials and the 32-element U row per batch in scratch; the partials are
-  // always floats, the U row is in the element type: 32 floats for float,
-  // 64 for complex64)
+  // panels taller than this use the streaming kernels; scratch is one
+  // LUStreamScratch<T> slice per batch, bound untyped as a raw byte buffer.
   const uint32_t kStreamMinRows = 4 * maxG;
   Tensor scratch;
   if (uM > kStreamMinRows) {
-    const int64_t scratchStride = 2 * kLUStreamNT + (isComplex ? 64 : 32);
-    scratch = at::empty({B, scratchStride}, LU.options().dtype(kFloat));
+    const int64_t perBatch = isComplex ? sizeof(LUStreamScratch<c10::complex<float>>) : sizeof(LUStreamScratch<float>);
+    scratch = at::empty({B * perBatch}, LU.options().dtype(kByte));
   }
 
   @autoreleasepool {

--- a/c10/metal/common.h
+++ b/c10/metal/common.h
@@ -5,6 +5,7 @@
 #include <metal_array>
 #define C10_METAL_CONSTEXPR constant constexpr
 #else
+#include <c10/util/complex.h>
 #include <array>
 #define C10_METAL_CONSTEXPR constexpr
 #endif
@@ -52,6 +53,9 @@ template <typename T, unsigned N>
 using array = ::metal::array<T, N>;
 template <typename T>
 using vec3 = ::metal::vec<T, 3>;
+// Metal's builtin 2-component vectors (float2/half2) are the complex ABI.
+template <typename T>
+using complex = ::metal::vec<T, 2>;
 #else
 template <typename T, unsigned N>
 using array = std::array<T, N>;
@@ -62,6 +66,10 @@ template <typename T>
 struct alignas(4 * sizeof(T)) vec3 {
   T x, y, z;
 };
+// Host mirror of Metal's float2/half2 complex ABI. c10::complex<T> is
+// alignas(2 * sizeof(T)), matching the layout of Metal's vec<T, 2>.
+template <typename T>
+using complex = ::c10::complex<T>;
 #endif
 
 // Integer ceiling division: ceil(a / b). Usable from both host code and

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -186,11 +186,6 @@ template <typename T>
 constexpr constant bool is_complex_v =
     ::metal::is_same_v<T, float2> || ::metal::is_same_v<T, half2>;
 
-// The complex<T> alias (common.h) must map onto Metal's float2/half2 so it is
-// recognized as complex here and is layout-compatible with the host mirror.
-static_assert(is_complex_v<complex<float>>, "complex<float> must be float2");
-static_assert(is_complex_v<complex<half>>, "complex<half> must be half2");
-
 template <typename T>
 constexpr constant bool is_scalar_floating_point_v =
     ::metal::is_floating_point_v<T> && ::metal::is_scalar_v<T>;

--- a/c10/metal/utils.h
+++ b/c10/metal/utils.h
@@ -186,6 +186,11 @@ template <typename T>
 constexpr constant bool is_complex_v =
     ::metal::is_same_v<T, float2> || ::metal::is_same_v<T, half2>;
 
+// The complex<T> alias (common.h) must map onto Metal's float2/half2 so it is
+// recognized as complex here and is layout-compatible with the host mirror.
+static_assert(is_complex_v<complex<float>>, "complex<float> must be float2");
+static_assert(is_complex_v<complex<half>>, "complex<half> must be half2");
+
 template <typename T>
 constexpr constant bool is_scalar_floating_point_v =
     ::metal::is_floating_point_v<T> && ::metal::is_scalar_v<T>;


### PR DESCRIPTION
Introduce `c10::metal::complex<T>` alias to either `c10::complex` or `metal::vec<T, 2>`
Introduce `LUStreamScratch` that holds float, uint and T scratch spaces for various stages of LU decomposition 
That allows one to kill pointer arithmetic on device and allocate it as `sizeof(LUStreamScratch)` rather than some complex dance of magic constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)
