### PR TITLE
[nn] Clarify MultiLabelMarginLoss shape errors

### DIFF
--- a/aten/src/ATen/native/LossMulti.h
+++ b/aten/src/ATen/native/LossMulti.h
@@ -11,7 +11,7 @@ namespace at::native {
     const int64_t& ndims,
     const Tensor& input,
     const Tensor& target) {
-    TORCH_CHECK(
+    TORCH_CHECK_VALUE(
         (ndims == 2 && input.size(1) != 0) || (ndims == 1 && input.size(0) != 0) || ndims == 0,
         "Expected input to be a scalar, non-empty 1D tensor, or non-empty 2D "
         "tensor, but got input with ",
@@ -22,7 +22,7 @@ namespace at::native {
     if (ndims <= 1) {
       nframe = 1;
       dim = ndims == 0 ? 1 : input.size(0);
-      TORCH_CHECK(
+      TORCH_CHECK_VALUE(
           target.dim() <= 1 && target.numel() == dim,
           "Expected target to have at most 1 dimension and ",
           dim,
@@ -31,7 +31,7 @@ namespace at::native {
     } else {
       nframe = input.size(0);
       dim = input.size(1);
-      TORCH_CHECK(
+      TORCH_CHECK_VALUE(
           target.dim() == 2 && target.size(0) == nframe &&
           target.size(1) == dim,
           "Expected target to be 2D with shape [",

--- a/aten/src/ATen/native/LossMulti.h
+++ b/aten/src/ATen/native/LossMulti.h
@@ -13,7 +13,10 @@ namespace at::native {
     const Tensor& target) {
     TORCH_CHECK(
         (ndims == 2 && input.size(1) != 0) || (ndims == 1 && input.size(0) != 0) || ndims == 0,
-        "Expected non-empty vector or matrix with optional 0-dim batch size, but got: ",
+        "Expected input to be a scalar, non-empty 1D tensor, or non-empty 2D "
+        "tensor, but got input with ",
+        ndims,
+        " dimensions and shape ",
         input.sizes());
 
     if (ndims <= 1) {
@@ -21,16 +24,24 @@ namespace at::native {
       dim = ndims == 0 ? 1 : input.size(0);
       TORCH_CHECK(
           target.dim() <= 1 && target.numel() == dim,
-          "inconsistent target size: ", target.sizes(), " for input of size: ",
-          input.sizes());
+          "Expected target to have at most 1 dimension and ",
+          dim,
+          " elements to match input, but got target with shape ",
+          target.sizes());
     } else {
       nframe = input.size(0);
       dim = input.size(1);
       TORCH_CHECK(
           target.dim() == 2 && target.size(0) == nframe &&
           target.size(1) == dim,
-          "inconsistent target size: ", target.sizes(), " for input of size: ",
-          input.sizes());
+          "Expected target to be 2D with shape [",
+          nframe,
+          ", ",
+          dim,
+          "] to match input, but got target with ",
+          target.dim(),
+          " dimensions and shape ",
+          target.sizes());
     }
   }
 

--- a/test/test_multilabel_margin_loss.py
+++ b/test/test_multilabel_margin_loss.py
@@ -12,7 +12,7 @@ class TestMultiLabelMarginLossErrors(TestCase):
         target = torch.zeros(2, 3, dtype=torch.long)
 
         with self.assertRaisesRegex(
-            RuntimeError,
+            ValueError,
             "Expected input to be a scalar, non-empty 1D tensor, or non-empty 2D tensor",
         ):
             loss(input, target)
@@ -23,7 +23,7 @@ class TestMultiLabelMarginLossErrors(TestCase):
         target = torch.zeros(2, 2, dtype=torch.long)
 
         with self.assertRaisesRegex(
-            RuntimeError,
+            ValueError,
             r"Expected target to be 2D with shape \[1, 3\] to match input",
         ):
             loss(input, target)
@@ -34,7 +34,7 @@ class TestMultiLabelMarginLossErrors(TestCase):
         target = torch.zeros(2, 2, dtype=torch.long)
 
         with self.assertRaisesRegex(
-            RuntimeError,
+            ValueError,
             "Expected target to have at most 1 dimension and 3 elements to match input",
         ):
             loss(input, target)

--- a/test/test_multilabel_margin_loss.py
+++ b/test/test_multilabel_margin_loss.py
@@ -1,0 +1,44 @@
+# Owner(s): ["module: nn"]
+
+import torch
+from torch import nn
+from torch.testing._internal.common_utils import TestCase, run_tests
+
+
+class TestMultiLabelMarginLossErrors(TestCase):
+    def test_input_shape_error(self):
+        loss = nn.MultiLabelMarginLoss()
+        input = torch.rand(2, 3, 4)
+        target = torch.zeros(2, 3, dtype=torch.long)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected input to be a scalar, non-empty 1D tensor, or non-empty 2D tensor",
+        ):
+            loss(input, target)
+
+    def test_batched_target_shape_error(self):
+        loss = nn.MultiLabelMarginLoss()
+        input = torch.rand(1, 3)
+        target = torch.zeros(2, 2, dtype=torch.long)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Expected target to be 2D with shape \[1, 3\] to match input",
+        ):
+            loss(input, target)
+
+    def test_unbatched_target_shape_error(self):
+        loss = nn.MultiLabelMarginLoss()
+        input = torch.rand(3)
+        target = torch.zeros(2, 2, dtype=torch.long)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected target to have at most 1 dimension and 3 elements to match input",
+        ):
+            loss(input, target)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
Fixes #106011

## Summary

- Clarify the `MultiLabelMarginLoss` error for unsupported input dimensionality by reporting the accepted forms, actual rank, and shape.
- Clarify target-shape errors separately for batched and unbatched inputs.
- Use `TORCH_CHECK_VALUE` for these invalid-shape checks so Python callers receive `ValueError` rather than `RuntimeError`.
- Add focused regression coverage for all three shape-validation paths and exception type.
- Supersedes #150606, which was closed unmerged after becoming stale.

## Testing

Added focused regression coverage in `test/test_multilabel_margin_loss.py`.

Not run locally; exercising the C++ error-message change requires a PyTorch source build.