### PR TITLE
[BE][Ez]: Removes double probes in STL collections

### DIFF
--- a/aten/src/ATen/core/ivalue.cpp
+++ b/aten/src/ATen/core/ivalue.cpp
@@ -898,8 +898,8 @@ IValue IValue::deepcopy(std::optional<at::Device> device) const {
 IValue IValue::deepcopy(
     IValue::HashIdentityIValueMap& memo,
     std::optional<at::Device> device) const {
-  if (memo.contains(*this)) {
-    return memo.at(*this);
+  if (auto it = memo.find(*this); it != memo.end()) {
+    return it->second;
   }
   IValue copy;
   switch(tag) {

--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
@@ -1135,10 +1135,11 @@ static at::Tensor linear_int8_with_onednn_weight(
           context_cache_enabled && !(is_fp8 && !cpuinfo_has_x86_amx_fp16());
 #endif
   if (allow_cache) {
-    if (qlinear_forward_params_map.contains(cache_key)) {
+    if (auto it = qlinear_forward_params_map.find(cache_key);
+        it != qlinear_forward_params_map.end()) {
       auto input_contig =
           dim == 2 ? input.contiguous() : input.reshape({-1, input.size(dim - 1)}).contiguous();
-      auto& params = qlinear_forward_params_map.at(cache_key);
+      auto& params = it->second;
       if (params.K == K && params.N == N) {
         at::Tensor output = binary_post_op == "sum"
             ? other.value()

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -163,8 +163,8 @@ void RNNImplBase<Derived>::reset() {
   flat_weights_ = {};
   for (const auto& wn : flat_weights_names_) {
     auto named_parameters = this->named_parameters(/*recurse=*/false);
-    if (auto it = named_parameters.find(wn); it != named_parameters.end()) {
-      flat_weights_.emplace_back(it->value());
+    if (auto* parameter = named_parameters.find(wn)) {
+      flat_weights_.emplace_back(*parameter);
     } else {
       flat_weights_.emplace_back();
     }
@@ -242,8 +242,8 @@ void RNNImplBase<Derived>::reset_flat_weights() {
   flat_weights_ = {};
   for (const auto& wn : flat_weights_names_) {
     auto named_parameters = this->named_parameters(/*recurse=*/false);
-    if (auto it = named_parameters.find(wn); it != named_parameters.end()) {
-      flat_weights_.emplace_back(it->value());
+    if (auto* parameter = named_parameters.find(wn)) {
+      flat_weights_.emplace_back(*parameter);
     } else {
       flat_weights_.emplace_back();
     }

--- a/torch/csrc/api/src/nn/modules/rnn.cpp
+++ b/torch/csrc/api/src/nn/modules/rnn.cpp
@@ -163,8 +163,8 @@ void RNNImplBase<Derived>::reset() {
   flat_weights_ = {};
   for (const auto& wn : flat_weights_names_) {
     auto named_parameters = this->named_parameters(/*recurse=*/false);
-    if (named_parameters.contains(wn)) {
-      flat_weights_.emplace_back(named_parameters[wn]);
+    if (auto it = named_parameters.find(wn); it != named_parameters.end()) {
+      flat_weights_.emplace_back(it->value());
     } else {
       flat_weights_.emplace_back();
     }
@@ -242,8 +242,8 @@ void RNNImplBase<Derived>::reset_flat_weights() {
   flat_weights_ = {};
   for (const auto& wn : flat_weights_names_) {
     auto named_parameters = this->named_parameters(/*recurse=*/false);
-    if (named_parameters.contains(wn)) {
-      flat_weights_.emplace_back(named_parameters[wn]);
+    if (auto it = named_parameters.find(wn); it != named_parameters.end()) {
+      flat_weights_.emplace_back(it->value());
     } else {
       flat_weights_.emplace_back();
     }

--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -356,8 +356,9 @@ std::vector<uint8_t> FileStore::compareSet(
   // Always refresh since even though the key exists in the cache,
   // it might be outdated
   pos_ = refresh(file, pos_, cache_, deletePrefix_);
-  if ((!cache_.contains(regKey) && expectedValue.empty()) ||
-      (cache_.contains(regKey) && cache_[regKey] == expectedValue)) {
+  const auto it = cache_.find(regKey);
+  if ((it == cache_.end() && expectedValue.empty()) ||
+      (it != cache_.end() && it->second == expectedValue)) {
     // if the key does not exist and currentValue arg is empty or
     // the key does exist and current value is what is expected, then set it
     file.seek(0, SEEK_END);
@@ -401,8 +402,8 @@ std::vector<uint8_t> FileStore::get(const std::string& key) {
     // Always refresh since even though the key exists in the cache,
     // it might be outdated
     pos_ = refresh(file, pos_, cache_, deletePrefix_);
-    if (cache_.contains(regKey)) {
-      return cache_[regKey];
+    if (auto it = cache_.find(regKey); it != cache_.end()) {
+      return it->second;
     }
   }
 }

--- a/torch/csrc/distributed/c10d/FileStore.cpp
+++ b/torch/csrc/distributed/c10d/FileStore.cpp
@@ -365,12 +365,12 @@ std::vector<uint8_t> FileStore::compareSet(
     file.write(regKey);
     file.write(desiredValue);
     return desiredValue;
-  } else if (!cache_.contains(regKey)) {
+  } else if (it == cache_.end()) {
     // if the key does not exist
     return expectedValue;
   }
   // key exists but current value is not expected
-  return cache_[regKey];
+  return it->second;
 }
 
 std::vector<uint8_t> FileStore::get(const std::string& key) {

--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
@@ -102,8 +102,9 @@ bool isP2POp(OpType opType, bool batchP2P /*= false*/) {
 c10::intrusive_ptr<Backend> ProcessGroup::getBackend(
     c10::DeviceType deviceType) {
   // If there is a backend associated with this device type then return it
-  if (deviceTypeToBackend_.contains(deviceType)) {
-    return deviceTypeToBackend_.at(deviceType);
+  if (auto it = deviceTypeToBackend_.find(deviceType);
+      it != deviceTypeToBackend_.end()) {
+    return it->second;
   }
 
   // Get the backend type associated with the device
@@ -116,8 +117,9 @@ c10::intrusive_ptr<Backend> ProcessGroup::getBackend(
   }
 
   // Check if the backend has already been initialized
-  if (backendTypeToBackend_.contains(backendType)) {
-    auto backend = backendTypeToBackend_.at(backendType);
+  if (auto it = backendTypeToBackend_.find(backendType);
+      it != backendTypeToBackend_.end()) {
+    auto backend = it->second;
     deviceTypeToBackend_[deviceType] = backend;
     return backend;
   }

--- a/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
+++ b/torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.cpp
@@ -162,8 +162,9 @@ static at::Tensor empty_strided_p2p_persistent(
 
   auto allocator = get_allocator(device.type());
   void* dev_ptr = nullptr;
-  if (alloc_id_to_dev_ptr.contains(alloc_id)) {
-    dev_ptr = alloc_id_to_dev_ptr[alloc_id];
+  if (auto it = alloc_id_to_dev_ptr.find(alloc_id);
+      it != alloc_id_to_dev_ptr.end()) {
+    dev_ptr = it->second;
     TORCH_CHECK(
         alloc_size == allocator->get_alloc_size(dev_ptr),
         "SymmetricMemory::empty_strided_p2p_persistent: ",

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -998,11 +998,13 @@ void AOTIModelPackageLoader::load_constants(
   std::unordered_map<std::string, std::string> constant_name_to_fqn =
       runner_->getConstantNamesToOriginalFQNs();
   std::unordered_map<std::string, std::string> fqn_to_constant_name;
+  fqn_to_constant_name.reserve(constant_name_to_fqn.size());
   for (const auto& it : constant_name_to_fqn) {
     fqn_to_constant_name.emplace(it.second, it.first);
   }
 
   std::unordered_map<std::string, at::Tensor> updated_constants_map;
+  updated_constants_map.reserve(constants_map.size());
   for (const auto& it : constants_map) {
     if (auto fqn_it = fqn_to_constant_name.find(it.first);
         fqn_it != fqn_to_constant_name.end()) {

--- a/torch/csrc/inductor/aoti_package/model_package_loader.cpp
+++ b/torch/csrc/inductor/aoti_package/model_package_loader.cpp
@@ -1004,8 +1004,9 @@ void AOTIModelPackageLoader::load_constants(
 
   std::unordered_map<std::string, at::Tensor> updated_constants_map;
   for (const auto& it : constants_map) {
-    if (fqn_to_constant_name.contains(it.first)) {
-      updated_constants_map.emplace(fqn_to_constant_name[it.first], it.second);
+    if (auto fqn_it = fqn_to_constant_name.find(it.first);
+        fqn_it != fqn_to_constant_name.end()) {
+      updated_constants_map.emplace(fqn_it->second, it.second);
     } else {
       TORCH_CHECK(false, "Constant not found: ", it.first);
     }

--- a/torch/csrc/jit/mobile/model_tracer/TracerRunner.cpp
+++ b/torch/csrc/jit/mobile/model_tracer/TracerRunner.cpp
@@ -211,8 +211,8 @@ static void recordCustomClassesFromOpSchemas(
     // Certain models can only run on a specific backend say metal.
     // Those ops will be present in the models root ops, but likely
     // not the tracer on linux
-    if (ops_and_schemas.contains(op_name)) {
-      auto& schema = ops_and_schemas.at(op_name);
+    if (auto it = ops_and_schemas.find(op_name); it != ops_and_schemas.end()) {
+      auto& schema = it->second;
       for (auto& arg : schema.arguments()) {
         record_if_class(arg.type()->annotation_str());
       }

--- a/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
+++ b/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
@@ -166,8 +166,8 @@ struct ConvertTracedAttrReferences {
 
         // Short circuit: if we've already emitted a new Value for this
         // attribute, just use that.
-        if (local_remaps.contains(inp)) {
-          n->replaceInput(inp_idx, local_remaps[inp]);
+        if (auto it = local_remaps.find(inp); it != local_remaps.end()) {
+          n->replaceInput(inp_idx, it->second);
           continue;
         }
 
@@ -256,8 +256,8 @@ struct MakeDefsDominateUses {
       // Already lifted to this level by a previously processed Use, switch to
       // remapped value
       Value* inp_remapped = inp;
-      if (remap.contains(inp_remapped)) {
-        n->replaceInput(i, remap[inp_remapped]);
+      if (auto it = remap.find(inp_remapped); it != remap.end()) {
+        n->replaceInput(i, it->second);
         inp_remapped = remap[inp_remapped];
       }
 

--- a/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
+++ b/torch/csrc/jit/passes/fixup_trace_scope_blocks.cpp
@@ -258,7 +258,7 @@ struct MakeDefsDominateUses {
       Value* inp_remapped = inp;
       if (auto it = remap.find(inp_remapped); it != remap.end()) {
         n->replaceInput(i, it->second);
-        inp_remapped = remap[inp_remapped];
+        inp_remapped = it->second;
       }
 
       // This conditional isn't strictly necessary, but saves a lot of

--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -277,9 +277,9 @@ void ConstantValueMap::PrintMaps() {
   std::cout << "Rank/Shape Map:" << '\n';
   for (const auto& x : ConstantValueMap::getInstance().rankMap) {
     std::stringstream ss;
-    if (ConstantValueMap::getInstance().shapeMap.contains(x.first)) {
-      auto shape_symbols =
-          ConstantValueMap::getInstance().shapeMap[x.first].sizes();
+    auto& shape_map = ConstantValueMap::getInstance().shapeMap;
+    if (auto it = shape_map.find(x.first); it != shape_map.end()) {
+      auto shape_symbols = it->second.sizes();
       if (shape_symbols.has_value()) {
         for (const auto& shape_symbol : shape_symbols.value()) {
           if (shape_symbol.is_static()) {

--- a/torch/csrc/jit/passes/onnx/constant_map.cpp
+++ b/torch/csrc/jit/passes/onnx/constant_map.cpp
@@ -25,10 +25,12 @@ bool ConstantValueMap::HasRank(const std::string& tensorName) {
 }
 
 std::optional<size_t> ConstantValueMap::GetRank(const std::string& tensorName) {
-  if (!HasRank(tensorName)) {
+  const auto& rank_map = ConstantValueMap::getInstance().rankMap;
+  auto it = rank_map.find(tensorName);
+  if (it == rank_map.end()) {
     return std::nullopt;
   }
-  return ConstantValueMap::getInstance().rankMap[tensorName];
+  return it->second;
 }
 
 void ConstantValueMap::SetAllGraphInputsStatic(bool all_static) {

--- a/torch/csrc/jit/passes/shape_analysis.cpp
+++ b/torch/csrc/jit/passes/shape_analysis.cpp
@@ -361,8 +361,9 @@ class ShapePropagator : public PropertyPropBase {
   // know whether the dependency has been executed.
   std::unordered_map<Node*, bool> dependsOnMutationMemo_;
   bool dependsOnMutation(Node* node) {
-    if (dependsOnMutationMemo_.contains(node)) {
-      return dependsOnMutationMemo_[node];
+    if (auto it = dependsOnMutationMemo_.find(node);
+        it != dependsOnMutationMemo_.end()) {
+      return it->second;
     }
 
     if (aliasDb_.hasWriters(node)) {

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -879,9 +879,10 @@ struct SymbolicShapeGraphAnalyzer {
       Value* output = stitched_shape_compute_graph->outputs().at(i);
       // this Value is already contained, so the symbolic shape for i must be
       // equal to the symbolic shape at the existing index
-      if (graph_output_to_symbolic_shape_dim.contains(output)) {
+      if (auto it = graph_output_to_symbolic_shape_dim.find(output);
+          it != graph_output_to_symbolic_shape_dim.end()) {
         auto curr_sym_shape = output_index_to_symbolic_shape_[i];
-        auto existing_sym_shape = graph_output_to_symbolic_shape_dim[output];
+        auto existing_sym_shape = it->second;
         discovered_sym_shape_equalities[curr_sym_shape] = existing_sym_shape;
         erase_indices.push_back(i);
       } else {
@@ -924,9 +925,10 @@ struct SymbolicShapeGraphAnalyzer {
         auto new_sizes =
             c10::fmap(std::move(shape_vec), [&](const at::ShapeSymbol& shape) {
               auto value = shape.value();
-              if (sym_shape_equalities.contains(value)) {
+              if (auto it = sym_shape_equalities.find(value);
+                  it != sym_shape_equalities.end()) {
                 changed = true;
-                return sym_shape_equalities[value];
+                return it->second;
               }
               return value;
             });

--- a/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
+++ b/torch/csrc/jit/passes/symbolic_shape_analysis.cpp
@@ -250,9 +250,11 @@ c10::SymbolicShape extractListShape(
   }
   Node* list_construct = list->node();
   std::vector<std::optional<int64_t>> output_shape;
+  output_shape.reserve(list_construct->inputs().size());
   for (Value* input : list_construct->inputs()) {
-    if (symbolic_shape_values.contains(input)) {
-      output_shape.emplace_back(symbolic_shape_values[input]);
+    if (auto it = symbolic_shape_values.find(input);
+        it != symbolic_shape_values.end()) {
+      output_shape.emplace_back(it->second);
     } else {
       output_shape.push_back(constant_as<int64_t>(input));
     }

--- a/torch/csrc/jit/runtime/autodiff.cpp
+++ b/torch/csrc/jit/runtime/autodiff.cpp
@@ -728,14 +728,14 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
   for (Value* capture_val : reverse_captures) {
     // If it's already an output we don't have to add anything,
     // but register the fact that it needs to be captured.
-    if (orig_primal_outputs_idx.contains(capture_val)) {
-      grad_desc.df_input_captured_outputs.push_back(
-          orig_primal_outputs_idx[capture_val]);
+    if (auto it = orig_primal_outputs_idx.find(capture_val);
+        it != orig_primal_outputs_idx.end()) {
+      grad_desc.df_input_captured_outputs.push_back(it->second);
       // If it's an input, we could add it as an output but in fact it's
       // more efficient to use a special kind of capture.
-    } else if (orig_primal_inputs_idx.contains(capture_val)) {
-      grad_desc.df_input_captured_inputs.push_back(
-          orig_primal_inputs_idx.at(capture_val));
+    } else if (auto it = orig_primal_inputs_idx.find(capture_val);
+               it != orig_primal_inputs_idx.end()) {
+      grad_desc.df_input_captured_inputs.push_back(it->second);
       // Otherwise it's just a regular intermediate value that we need to add as
       // an output
     } else {
@@ -767,11 +767,12 @@ static void lambdaLiftReverse(Gradient& grad_desc, ReverseDetails& rev_info) {
     // false positives), while the gradients we will emit for this value can get
     // DCE-d in the optimization pass (because it has no influence on the real
     // f's outputs that we differentiate).
-    if (!rev_info.grad_map.contains(tmp))
+    auto it = rev_info.grad_map.find(tmp);
+    if (it == rev_info.grad_map.end())
       continue;
 
     Value* tmp_vjp_in = reverse_block->addInput()->setType(tmp->type());
-    Value* tmp_vjp_prev = rev_info.grad_map.at(tmp);
+    Value* tmp_vjp_prev = it->second;
     // This is quite weird because we can't first make a sum and then replace
     // all uses of tmp_vjp_prev (that would replace its use in the sum too!), so
     // we create an incorrect sum that doesn't use prev vjp, replace uses, and

--- a/torch/csrc/jit/runtime/graph_executor.cpp
+++ b/torch/csrc/jit/runtime/graph_executor.cpp
@@ -288,8 +288,9 @@ struct DifferentiableGraphBackward : public autograd::Node {
       } else if (v.isTensor()) {
         if (!v.toTensor().defined()) {
           // this undefined gradient actually corresponds to a tensor list
-          if (input_tensor_lists_.contains(output_index)) {
-            size_t list_size = input_tensor_lists_[output_index];
+          if (auto it = input_tensor_lists_.find(output_index);
+              it != input_tensor_lists_.end()) {
+            size_t list_size = it->second;
             for (size_t i = 0; i < list_size; i++) {
               produceOutput(output_index++, {}, outputs);
             }

--- a/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
+++ b/torch/csrc/jit/runtime/symbolic_shape_registry.cpp
@@ -252,9 +252,10 @@ std::shared_ptr<Graph> genShapeComputeFn(
       *schema_string,
       " with shape compute func: ",
       shape_compute_function_name);
-  if (reused_functions.contains(shape_compute_function_name)) {
+  if (auto it = reused_functions.find(shape_compute_function_name);
+      it != reused_functions.end()) {
     GRAPH_DEBUG("Registering reused schema");
-    graph = reused_functions[shape_compute_function_name];
+    graph = it->second;
   } else {
     Function& shape_compute_function =
         module.get_function(shape_compute_function_name);

--- a/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
+++ b/torch/csrc/jit/tensorexpr/llvm_codegen.cpp
@@ -1307,10 +1307,10 @@ void LLVMCodeGenImpl::visit(const VarPtr& v) {
 llvm::Value* LLVMCodeGenImpl::varToValue(VarPtr v) {
   // It is possible for v to be in both varToVal_ and varToArgs.
   // In that case, varToVal_ takes precedence.
-  if (varToVal_.count(v)) {
-    return varToVal_.at(v);
-  } else if (varToArg_.count(v)) {
-    auto idx = varToArg_.at(v);
+  if (auto it = varToVal_.find(v); it != varToVal_.end()) {
+    return it->second;
+  } else if (auto it = varToArg_.find(v); it != varToArg_.end()) {
+    auto idx = it->second;
     auto arg = fn_->arg_begin() + idx;
     return arg;
   }

--- a/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
+++ b/torch/csrc/jit/tensorexpr/mem_dependency_checker.cpp
@@ -1114,8 +1114,8 @@ void MemDependencyChecker::visit(const LetPtr& v) {
   lastStmt_ = last;
 
   VarPtr var = v->var();
-  if (knownVarBounds_.contains(var)) {
-    currentScope_->shadowedVarBounds[var] = knownVarBounds_[var];
+  if (auto it = knownVarBounds_.find(var); it != knownVarBounds_.end()) {
+    currentScope_->shadowedVarBounds[var] = it->second;
   }
 
   currentScope_->localVars.insert(var);

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -607,8 +607,8 @@ static void handleKernelBackendInfo(
     const RecordFunction& fn) {
   // triton kernel related information are in kwinputs
   const auto& kwinputs = fn.kwinputs();
-  if (kwinputs.contains("kernel_backend")) {
-    fc.kernelBackend = kwinputs.at("kernel_backend").toStringRef();
+  if (auto it = kwinputs.find("kernel_backend"); it != kwinputs.end()) {
+    fc.kernelBackend = it->value().toStringRef();
     if (fc.kernelBackend == "triton") {
       fc.kernelFile = kwinputs.at("kernel_file").toStringRef();
       TORCH_INTERNAL_ASSERT(

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -610,10 +610,11 @@ static void handleKernelBackendInfo(
   if (auto it = kwinputs.find("kernel_backend"); it != kwinputs.end()) {
     fc.kernelBackend = it->value().toStringRef();
     if (fc.kernelBackend == "triton") {
-      fc.kernelFile = kwinputs.at("kernel_file").toStringRef();
+      auto kernel_file_it = kwinputs.find("kernel_file");
       TORCH_INTERNAL_ASSERT(
-          kwinputs.find("kernel_file") != kwinputs.end(),
+          kernel_file_it != kwinputs.end(),
           "kernel file is missing in triton kernel");
+      fc.kernelFile = kernel_file_it->value().toStringRef();
       // Remove the path of the file name
       if (fc.kernelFile.find_last_of('/') != std::string::npos) {
         fc.kernelFile =

--- a/torch/csrc/profiler/standalone/execution_trace_observer.cpp
+++ b/torch/csrc/profiler/standalone/execution_trace_observer.cpp
@@ -608,13 +608,13 @@ static void handleKernelBackendInfo(
   // triton kernel related information are in kwinputs
   const auto& kwinputs = fn.kwinputs();
   if (auto it = kwinputs.find("kernel_backend"); it != kwinputs.end()) {
-    fc.kernelBackend = it->value().toStringRef();
+    fc.kernelBackend = it->second.toStringRef();
     if (fc.kernelBackend == "triton") {
       auto kernel_file_it = kwinputs.find("kernel_file");
       TORCH_INTERNAL_ASSERT(
           kernel_file_it != kwinputs.end(),
           "kernel file is missing in triton kernel");
-      fc.kernelFile = kernel_file_it->value().toStringRef();
+      fc.kernelFile = kernel_file_it->second.toStringRef();
       // Remove the path of the file name
       if (fc.kernelFile.find_last_of('/') != std::string::npos) {
         fc.kernelFile =

--- a/torch/nativert/executor/Weights.cpp
+++ b/torch/nativert/executor/Weights.cpp
@@ -121,8 +121,9 @@ Weights::Weights(
       }
 
       std::string paramName = it->second;
-      if (maybeNewWeightsMeta->contains(paramName)) {
-        newTensorMeta = *maybeNewWeightsMeta->at(paramName);
+      if (auto metaIt = maybeNewWeightsMeta->find(paramName);
+          metaIt != maybeNewWeightsMeta->end()) {
+        newTensorMeta = *metaIt->second;
       } else {
         TORCH_CHECK(
             false,

--- a/torch/nativert/executor/Weights.cpp
+++ b/torch/nativert/executor/Weights.cpp
@@ -104,8 +104,8 @@ Weights::Weights(
     // /extra/xl_weights/<model_name>_model_param_config.json
     // Currently, we only use the metadata from model definition.
     std::optional<TensorMeta> tensorMeta;
-    if (weightsMeta_.contains(tensorName)) {
-      tensorMeta = weightsMeta_.at(tensorName);
+    if (auto it = weightsMeta_.find(tensorName); it != weightsMeta_.end()) {
+      tensorMeta = it->second;
     } else {
       TORCH_CHECK(
           false,
@@ -115,11 +115,12 @@ Weights::Weights(
     }
     std::optional<TensorMeta> newTensorMeta;
     if (maybeNewWeightsMeta) {
-      if (!stateDictPaths.contains(tensorName)) {
+      auto it = stateDictPaths.find(tensorName);
+      if (it == stateDictPaths.end()) {
         TORCH_CHECK(false, "Tensor name not found in state dict paths");
       }
 
-      std::string paramName = stateDictPaths.at(tensorName);
+      std::string paramName = it->second;
       if (maybeNewWeightsMeta->contains(paramName)) {
         newTensorMeta = *maybeNewWeightsMeta->at(paramName);
       } else {

--- a/torch/nativert/executor/Weights.cpp
+++ b/torch/nativert/executor/Weights.cpp
@@ -441,13 +441,14 @@ void Weights::setValue(
     const std::string& name,
     const at::Tensor& newValue,
     bool skipDeviceCheck) {
-  if (allValues_.contains(name)) {
+  auto it = allValues_.find(name);
+  if (it != allValues_.end()) {
     validateValue(name, newValue, skipDeviceCheck);
+    it->second = newValue;
   } else {
     LOG(WARNING) << name << " is not found in the registered weights";
+    allValues_.emplace(name, newValue);
   }
-
-  allValues_[name] = newValue;
 }
 
 void Weights::updateValue(const std::string& name, const at::Tensor& newValue) {

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -476,8 +476,8 @@ Value* Graph::tryGetValue(std::string_view name) const {
   // TODO: can eliminate this string copy by enabling heterogeneous lookup for
   // the container
   const auto key = std::string(name);
-  if (values_.contains(key)) {
-    return values_.at(key).get();
+  if (auto it = values_.find(key); it != values_.end()) {
+    return it->second.get();
   }
   return nullptr;
 }

--- a/torch/nativert/graph/passes/SubgraphRewriter.cpp
+++ b/torch/nativert/graph/passes/SubgraphRewriter.cpp
@@ -159,9 +159,9 @@ bool SubgraphMatcher::tryMatchNodeInputs(
     Value* dummyOutput = dummyNode->addOutput(
         targetGraph->getUniqueValueName(), Type::Kind::None);
     targetGraph->insertBefore(dummyNode, target_node);
-    if (match.value_map.contains(patternInput->value)) {
-      return match.value_map[patternInput->value]->producer()->target() ==
-          kDummyTarget;
+    if (auto it = match.value_map.find(patternInput->value);
+        it != match.value_map.end()) {
+      return it->second->producer()->target() == kDummyTarget;
     }
     match.value_map[patternInput->value] = dummyOutput;
     match.dummy_input_to_attribute_map[dummyOutput] = &it.value;
@@ -173,8 +173,8 @@ bool SubgraphMatcher::tryMatchNode(
     const Node* pattern_node,
     Node* target_node,
     Match& match) {
-  if (match.node_map.contains(pattern_node)) {
-    return match.node_map[pattern_node] == target_node;
+  if (auto it = match.node_map.find(pattern_node); it != match.node_map.end()) {
+    return it->second == target_node;
   }
 
   // If the pattern node is an input, it should match every node
@@ -225,8 +225,8 @@ bool SubgraphMatcher::tryMatchValue(
     const Value* pval,
     Value* tval,
     Match& match) {
-  if (match.value_map.contains(pval)) {
-    return match.value_map[pval] == tval;
+  if (auto it = match.value_map.find(pval); it != match.value_map.end()) {
+    return it->second == tval;
   }
 
   const Node* pProducer = pval->producer();
@@ -361,10 +361,11 @@ void SubgraphRewriter::rewriteMatch(
   Node* insertionPoint = nullptr;
   std::vector<Value*> inputs, outputs;
   for (Value* v : pattern.inputs()) {
-    if (!match.value_map.contains(v)) {
+    auto it = match.value_map.find(v);
+    if (it == match.value_map.end()) {
       continue;
     }
-    Value* input = match.value_map.at(v);
+    Value* input = it->second;
     // We want to insert after latest producer of any input that is not a dummy
     // node
     if (!insertionPoint ||
@@ -405,8 +406,9 @@ void SubgraphRewriter::rewriteMatch(
   }
 
   for (auto& patternNode : pattern.nodes()) {
-    if (match.node_map.contains(&patternNode)) {
-      Node* n = match.node_map.at(&patternNode);
+    if (auto it = match.node_map.find(&patternNode);
+        it != match.node_map.end()) {
+      Node* n = it->second;
       replacedNodes_.insert(n);
     }
   }


### PR DESCRIPTION
Finds the common contains and then at STL collection pattern and replaces them using the find() API which both checks if the object exists in the collection and returns its reference. This removes the need for looking up the key twice. Use Codex Luna to automatically find all of these and then I manually reviewed all of them.

Test Plan:
NFC all tests should pass

cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @EikanWang