### PR TITLE
[ATen] Zero CUDA tensors with cudaMemsetAsync instead of a fill kernel (#195303)

### DIFF
--- a/aten/src/ATen/native/cuda/TensorFactories.cu
+++ b/aten/src/ATen/native/cuda/TensorFactories.cu
@@ -3,6 +3,7 @@
 #include <ATen/Dispatch.h>
 #include <ATen/cuda/CUDAApplyUtils.cuh>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/Exceptions.h>
 #include <ATen/cuda/EmptyTensor.h>
 #include <ATen/InitialTensorOptions.h>
 #include <ATen/native/cuda/Resize.h>
@@ -23,6 +24,7 @@
 #include <ATen/ops/tril_native.h>
 #include <ATen/ops/triu_indices_native.h>
 #include <ATen/ops/triu_native.h>
+#include <ATen/ops/zero_native.h>
 #endif
 
 #include <algorithm>
@@ -30,6 +32,19 @@
 #include <cstddef>
 
 namespace at::native {
+
+Tensor& zero_cuda_(Tensor& self) {
+  void* const ptr = self.mutable_data_ptr();
+  if (ptr != nullptr && self.is_non_overlapping_and_dense()) {
+    AT_CUDA_CHECK(cudaMemsetAsync(
+        ptr,
+        0,
+        self.numel() * self.dtype().itemsize(),
+        at::cuda::getCurrentCUDAStream(self.device().index())));
+    return self;
+  }
+  return self.fill_(0);
+}
 
 Tensor& eye_out_cuda(int64_t n, Tensor& result) {
   // the default value of `m` equals to `n`

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -6927,7 +6927,8 @@
   device_check: NoCheck   # TensorIterator
   variants: method, function
   dispatch:
-    CPU, CUDA, MPS, XPU: zero_
+    CPU, MPS, XPU: zero_
+    CUDA: zero_cuda_
     Meta: zero_meta_
     SparseCPU, SparseCUDA, SparseMPS, SparseMeta, SparseXPU: zero_sparse_
     SparseCsrCPU, SparseCsrCUDA, SparseCsrMeta, SparseCsrXPU: zero_sparse_csr_

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -133,6 +133,67 @@ class TestTorchDeviceType(TestCase):
             scalar = bytes_to_scalar(bytes_list, dtype, device)
             self.assertEqual(scalar.storage().untyped().tolist(), bytes_list)
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float32, torch.complex64, torch.complex128)
+    def test_zero_dense_view_with_storage_offset(self, device, dtype):
+        base = make_tensor((64, 96), dtype=dtype, device=device, low=1, high=2)
+        original = base.clone()
+        base[16:32].zero_()
+        self.assertEqual(base[16:32].count_nonzero().item(), 0)
+        self.assertEqual(base[:16], original[:16])
+        self.assertEqual(base[32:], original[32:])
+
+    @onlyNativeDeviceTypes
+    def test_zero_transposed_dense_view(self, device):
+        base = torch.ones(64, 96, device=device)
+        base[16:32].t().zero_()
+        self.assertEqual(base[16:32].count_nonzero().item(), 0)
+        self.assertEqual(base[:16], torch.ones(16, 96, device=device))
+        self.assertEqual(base[32:], torch.ones(32, 96, device=device))
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float32, torch.complex64)
+    def test_zero_strided_view_with_gaps(self, device, dtype):
+        base = make_tensor((64, 96), dtype=dtype, device=device, low=1, high=2)
+        original = base.clone()
+        base[:, ::2].zero_()
+        self.assertEqual(base[:, ::2].count_nonzero().item(), 0)
+        self.assertEqual(base[:, 1::2], original[:, 1::2])
+
+    @onlyNativeDeviceTypes
+    def test_zero_empty_view_leaves_storage_intact(self, device):
+        base = torch.ones(4, device=device)
+        base[2:2].zero_()
+        self.assertEqual(base, torch.ones(4, device=device))
+
+    @onlyNativeDeviceTypes
+    @dtypes(torch.bits1x8, torch.bits2x4, torch.bits4x2, torch.bits8,
+            torch.bits16, torch.float4_e2m1fn_x2)
+    def test_zero_dtypes_without_fill_kernel(self, device, dtype):
+        raw = torch.ones(1024, dtype=torch.uint8, device=device)
+        raw.view(dtype).zero_()
+        self.assertEqual(raw.count_nonzero().item(), 0)
+
+    @onlyCUDA
+    @unittest.skipIf(not torch.autograd.kineto_available(), "Kineto is required")
+    def test_zero_dense_emits_memset(self, device):
+        base = torch.ones(64, 96, device=device)
+        with torch.profiler.profile() as prof:
+            base[16:32].zero_()
+            torch.cuda.synchronize()
+        names = tuple(event.key for event in prof.key_averages())
+        self.assertTrue(any("Memset" in name for name in names), names)
+
+    @onlyCUDA
+    @unittest.skipIf(not torch.autograd.kineto_available(), "Kineto is required")
+    def test_zero_strided_emits_fill_kernel(self, device):
+        base = torch.ones(64, 96, device=device)
+        with torch.profiler.profile() as prof:
+            base[:, ::2].zero_()
+            torch.cuda.synchronize()
+        names = tuple(event.key for event in prof.key_averages())
+        self.assertTrue(any("elementwise_kernel" in name for name in names), names)
+
     # For testing in64 support in upsample_nearest3d
     @skipIfRocmArch(MI200_ARCH)
     @onlyCUDA


### PR DESCRIPTION
Summary:

# Context
Currently, when invoking `zero_` for a tensor which lives on GPU, the implementation uses `fill_` under the hood, which launches an elementwise kernel rather than simply using `cudaMemsetAsync`.

# This PR
Use `cudaMemsetAsync` to `zero_` GPU tensors.

NOTE: `bits*` and `Float4_e2m1fn_x2` dtypes, which previously would throw an exception in `zero_` due to not having `fill_cuda` implementations, now succeed if `self.is_non_overlapping_and_dense()`.

Test Plan:
# Automated
Added tests.

# Benchmarks

Sources in D117944285. Medians of repeated runs, no profiler attached, so no CUPTI accounting is involved.

**Nvidia:**

Per-call host wall time on an A100 host., control = base, test = this diff. (`aten::zero_` is the function we modified; the other rows are just for context.) New impl saves 2.30 us per call.

| probe | control | test |
| --- | --- | --- |
| `aten::zero_` | 5.67 us | 3.37 us |
| `aten::fill_` (untouched) | 6.51 us | 6.22 us |
| raw `cudaLaunchKernel` (untouched) | 3.74 us | 3.75 us |
| raw `cudaMemsetAsync` (untouched) | 2.87 us | 3.03 us |

A100 MIG device wall time shows new impl is significantly faster on small buffers and about the same on large ones. Control is the `fill_` kernel, test is the `zero_` memset, both in the same build.

| bytes | control | test | ratio |
| --- | --- | --- | --- |
| 1048 | 7.28 us | 3.97 us | 1.83x |
| 10485 | 6.93 us | 5.00 us | 1.39x |
| 104857 | 6.90 us | 5.21 us | 1.32x |
| 1048576 | 6.94 us | 5.28 us | 1.32x |
| 8388608 | 9.54 us | 9.71 us | 0.98x |
| 67108864 | 87.70 us | 88.74 us | 0.99x |
| 268435456 | 347.01 us | 347.51 us | 1.00x |

**AMD:**

Per-call host wall time on an MI300X. Control is the `fill_` kernel, test is the `zero_` memset, both in the same build.

| bytes | control | test |
| --- | --- | --- |
| 4 | 5.531 us | 3.915 us |
| 1024 | 5.503 us | 3.901 us |
| 65536 | 5.505 us | 3.905 us |
| 1048576 | 5.503 us | 3.902 us |
| 16777216 | 5.423 us | 3.909 us |
| 268435456 | 5.471 us | 3.964 us |

MI300X device wall time.

| bytes | control | test | ratio |
| --- | --- | --- | --- |
| 4 | 5.92 us | 4.27 us | 1.38x |
| 1024 | 5.85 us | 4.25 us | 1.38x |
| 65536 | 5.80 us | 4.25 us | 1.37x |
| 1048576 | 5.72 us | 4.23 us | 1.35x |
| 16777216 | 5.76 us | 5.38 us | 1.07x |
| 268435456 | 45.73 us | 43.20 us | 1.06x |

# Real MAST Job
Experimented on real jobs (Feature Importance, fairly arbitrary choice) on `T20_SUPERMICRO_A100_80GB`.

* Control
  * MAST job = `f1133874019-FeatureImportanceApplication`
  * [Trace](https://www.internalfb.com/manifold/explorer/gpu_traces/tree/traces/dynocli/f1133874019-FeatureImportanceApplication/1787934683/twshared0424.04.ncg3/libkineto_activities_2733.json.gz)
* Test
  * MAST job = `f1133874099-FeatureImportanceApplication`
  * [Trace](https://www.internalfb.com/manifold/explorer/gpu_traces/tree/traces/dynocli/f1133874099-FeatureImportanceApplication/1787934681/twshared6022.05.ncg3/libkineto_activities_2717.json.gz)

| metric | control | test |
| --- | --- | --- |
| `aten::zero_` cpu_ops | 9 | 9 |
| ...with a nested `aten::fill_` | 9 | 0 |
| device ops beneath `aten::zero_` | `kernel` x9 | `gpu_memset` x9 |
| avg host wall time per `aten::zero_` | 19.24 us | 17.32 us |
| avg device wall time per `aten::zero_` | 2.24 us | 1.91 us |
| `aten::fill_` cpu_ops | 50 | 41 |
| `gpu_memset` total | 4 | 13 |

Differential Revision: D117790729
