### PR TITLE
[CI] Skip dynamic indirect indexing smoke test on torch < 2.14

### DIFF
--- a/.ci/pytorch/smoke_test/smoke_test.py
+++ b/.ci/pytorch/smoke_test/smoke_test.py
@@ -534,6 +534,14 @@ def smoke_test_compile_dynamic_indirect_indexing(device: str = "cuda") -> None:
     emitted Triton whose epilogue read a loop-local temp. Only reproduces on the
     second compile, once a differing shape triggers automatic dynamic shapes.
     """
+    # fix (gh-194786) is in 2.14. This skip should be removed if also cherry-picked
+    # into prior versions.
+    from torch.torch_version import TorchVersion
+
+    if TorchVersion(torch.__version__) < (2, 14):
+        print(f"Skipping dynamic indirect indexing test on torch {torch.__version__}")
+        return
+
     if not torch.cuda.is_available():
         print("CUDA is not available, skipping dynamic indirect indexing test")
         return


### PR DESCRIPTION
test-infra's Release Binaries Validations checks out smoke_test.py from pytorch main but installs the published stable wheel. The regression check added in #195024 covers gh-194490, whose fix (#194786) landed after the 2.13 branch cut, so it reds all six linux CUDA 12.6 legs against the immutable 2.13.0 artifact with NameError('tmp19 is not defined').

Gate on the first release series containing the fix: 2.14, which has it via cherry-pick #194833. Reverting #195024 was the alternative, but it drops nightly coverage and leaves the next regression test added here to hit the same trap.

Test Plan:

2.13.0 skips; 2.14.0, main and nightly run.

```
python -c "
from torch.torch_version import TorchVersion
for v in ['2.13.0+cu126','2.14.0+cu130','2.15.0a0+gitabc','2.15.0.dev20260829+cu126']:
    print(v, TorchVersion(v) < (2, 14))
"
lintrunner -a --paths-cmd 'echo .ci/pytorch/smoke_test/smoke_test.py'
```

Authored with assistance from Claude Code.