### PR TITLE
Pop the diagnostic pushes that were never popped

### DIFF
--- a/aten/src/ATen/native/cuda/GroupMM.cu
+++ b/aten/src/ATen/native/cuda/GroupMM.cu
@@ -433,3 +433,7 @@ void bf16bf16_grouped_mm(
 }
 
 } // namespace at::cuda::detail
+
+C10_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()

--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -1146,3 +1146,5 @@ void f8f8bf16_rowwise(
 }
 
 } // namespace at::cuda::detail
+
+C10_DIAGNOSTIC_POP()

--- a/c10/core/ScalarType.h
+++ b/c10/core/ScalarType.h
@@ -303,3 +303,4 @@ C10_API const std::unordered_map<std::string, ScalarType>& getStringToDtypeMap()
 } // namespace c10
 
 C10_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()

--- a/c10/cuda/CUDADeviceAssertion.h
+++ b/c10/cuda/CUDADeviceAssertion.h
@@ -65,7 +65,7 @@ static __device__ void dsa_add_new_assertion_failure(
   self.thread_id[1] = thread_id.y;
   self.thread_id[2] = thread_id.z;
 }
-C10_CLANG_DIAGNOSTIC_POP()
+C10_DIAGNOSTIC_POP()
 
 // Emulates a kernel assertion. The assertion won't stop the kernel's progress,
 // so you should assume everything the kernel produces is garbage if there's an


### PR DESCRIPTION
```
Four places push a diagnostic scope and never balance it, so the
suppression leaks past its intended region into every translation unit
that includes the header (or to end of file, for the two .cu files):

- c10/core/ScalarType.h: pushes twice, pops once
- c10/cuda/CUDADeviceAssertion.h: pops with C10_CLANG_DIAGNOSTIC_POP,
  which is a no-op under GCC, so the push is never balanced there
- aten/src/ATen/native/cuda/GroupMM.cu: pushes 3x, pops 0x
- aten/src/ATen/native/cuda/RowwiseScaledMM.cu: pushes 4x, pops 3x

Test Plan: g++-15 -Wswitch-enum on a switch missing one enumerator,
after including ScalarType.h: 0 warnings before this fix, 1 after.
```

Drafted with AI assistance (Claude Code).