### PR TITLE
Name the unused interface parameters out instead of muting the warning

### DIFF
--- a/aten/src/ATen/core/CachingHostAllocator.h
+++ b/aten/src/ATen/core/CachingHostAllocator.h
@@ -18,7 +18,6 @@
 #include <mutex>
 #include <shared_mutex>
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 namespace at {
 
 using c10::CachingAllocator::Stat;
@@ -1329,25 +1328,25 @@ struct TORCH_API HostAllocator : public at::Allocator {
   virtual void reset_peak_stats() = 0;
 
   virtual void begin_allocate_to_pool(
-      c10::MempoolId_t pool_id,
-      std::function<bool(c10::Stream)> filter) {
+      c10::MempoolId_t /*pool_id*/,
+      std::function<bool(c10::Stream)> /*filter*/) {
     TORCH_CHECK_NOT_IMPLEMENTED(false, "Not implemented for begin_allocate_to_pool");
   }
 
-  virtual void end_allocate_to_pool(c10::MempoolId_t pool_id) {
+  virtual void end_allocate_to_pool(c10::MempoolId_t /*pool_id*/) {
     TORCH_CHECK_NOT_IMPLEMENTED(false, "Not implemented for end_allocate_to_pool");
   }
 
-  virtual void release_pool(c10::MempoolId_t pool_id) {
+  virtual void release_pool(c10::MempoolId_t /*pool_id*/) {
     TORCH_CHECK_NOT_IMPLEMENTED(false, "Not implemented for release_pool");
   }
 
   virtual void record_history(
-      bool enabled,
-      c10::CachingDeviceAllocator::CreateContextFn context_recorder,
-      size_t max_entries,
-      c10::CachingDeviceAllocator::RecordContext when,
-      bool clearHistory) {}
+      bool /*enabled*/,
+      c10::CachingDeviceAllocator::CreateContextFn /*context_recorder*/,
+      size_t /*max_entries*/,
+      c10::CachingDeviceAllocator::RecordContext /*when*/,
+      bool /*clearHistory*/) {}
 
   virtual bool is_history_enabled() const {
     return false;
@@ -1492,4 +1491,3 @@ struct HostAllocatorRegistry {
   }
 
 } // namespace at
-C10_DIAGNOSTIC_POP()

--- a/aten/src/ATen/detail/AcceleratorHooksInterface.h
+++ b/aten/src/ATen/detail/AcceleratorHooksInterface.h
@@ -6,7 +6,6 @@
 #include <c10/core/Device.h>
 #include <c10/core/Stream.h>
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 
 namespace at {
 
@@ -48,7 +47,7 @@ struct TORCH_API AcceleratorHooksInterface {
     return 0;
   }
 
-  virtual void setCurrentDevice(DeviceIndex device) const {
+  virtual void setCurrentDevice(DeviceIndex /*device*/) const {
     TORCH_CHECK(false, "Backend doesn't support setCurrentDevice()");
   }
 
@@ -57,17 +56,17 @@ struct TORCH_API AcceleratorHooksInterface {
     return -1;
   }
 
-  virtual DeviceIndex exchangeDevice(DeviceIndex device) const {
+  virtual DeviceIndex exchangeDevice(DeviceIndex /*device*/) const {
     TORCH_CHECK(false, "Backend doesn't support exchangeDevice()");
     return -1;
   }
 
-  virtual DeviceIndex maybeExchangeDevice(DeviceIndex device) const {
+  virtual DeviceIndex maybeExchangeDevice(DeviceIndex /*device*/) const {
     TORCH_CHECK(false, "Backend doesn't support maybeExchangeDevice()");
     return -1;
   }
 
-  virtual bool isPinnedPtr(const void* data) const {
+  virtual bool isPinnedPtr(const void* /*data*/) const {
     return false;
   }
 
@@ -76,7 +75,7 @@ struct TORCH_API AcceleratorHooksInterface {
     return nullptr;
   }
 
-  virtual Device getDeviceFromPtr(void* data) const {
+  virtual Device getDeviceFromPtr(void* /*data*/) const {
     TORCH_CHECK(false, "Backend doesn't support getDeviceFromPtr()");
   }
 
@@ -92,5 +91,3 @@ struct TORCH_API AcceleratorHooksInterface {
 };
 
 } // namespace at
-
-C10_DIAGNOSTIC_POP()

--- a/aten/src/ATen/detail/MPSHooksInterface.h
+++ b/aten/src/ATen/detail/MPSHooksInterface.h
@@ -10,7 +10,6 @@
 
 #include <cstddef>
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 namespace at {
 
 struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
@@ -28,7 +27,9 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   virtual bool hasMPS() const {
     return false;
   }
-  virtual bool isOnMacOSorNewer(unsigned major = 13, unsigned minor = 0) const {
+  virtual bool isOnMacOSorNewer(
+      [[maybe_unused]] unsigned major = 13,
+      [[maybe_unused]] unsigned minor = 0) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
   const Generator& getDefaultGenerator(
@@ -72,40 +73,40 @@ struct TORCH_API MPSHooksInterface : AcceleratorHooksInterface {
   virtual void setMemoryFraction(double /*ratio*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual void profilerStartTrace(const std::string& mode, bool waitUntilCompleted) const {
+  virtual void profilerStartTrace(const std::string& /*mode*/, bool /*waitUntilCompleted*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
   virtual void profilerStopTrace() const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual uint32_t acquireEvent(bool enable_timing) const {
+  virtual uint32_t acquireEvent(bool /*enable_timing*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  Device getDeviceFromPtr(void* data) const override {
+  Device getDeviceFromPtr(void* /*data*/) const override {
     TORCH_CHECK(false, "Cannot get device of pointer on MPS without ATen_mps library. ");
   }
-  virtual void releaseEvent(uint32_t event_id) const {
+  virtual void releaseEvent(uint32_t /*event_id*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual void recordEvent(uint32_t event_id) const {
+  virtual void recordEvent(uint32_t /*event_id*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual void waitForEvent(uint32_t event_id) const {
+  virtual void waitForEvent(uint32_t /*event_id*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual void synchronizeEvent(uint32_t event_id) const {
+  virtual void synchronizeEvent(uint32_t /*event_id*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual bool queryEvent(uint32_t event_id) const {
+  virtual bool queryEvent(uint32_t /*event_id*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  virtual double elapsedTimeOfEvents(uint32_t start_event_id, uint32_t end_event_id) const {
+  virtual double elapsedTimeOfEvents(uint32_t /*start_event_id*/, uint32_t /*end_event_id*/) const {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex /*device_index*/) const override {
     FAIL_MPSHOOKS_FUNC(__func__);
   }
-  bool isPinnedPtr(const void* data) const override {
+  bool isPinnedPtr(const void* /*data*/) const override {
     return false;
   }
   Allocator* getPinnedMemoryAllocator() const override {
@@ -126,4 +127,3 @@ TORCH_API const MPSHooksInterface& getMPSHooks();
 
 } // namespace detail
 } // namespace at
-C10_DIAGNOSTIC_POP()

--- a/aten/src/ATen/detail/PrivateUse1HooksInterface.h
+++ b/aten/src/ATen/detail/PrivateUse1HooksInterface.h
@@ -8,7 +8,6 @@
 #include <c10/core/Storage.h>
 #include <c10/util/Exception.h>
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 
 namespace at {
 
@@ -32,7 +31,7 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
   }
 
   const at::Generator& getDefaultGenerator(
-      c10::DeviceIndex device_index) const override {
+      c10::DeviceIndex /*device_index*/) const override {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 
@@ -45,11 +44,11 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 
-  at::Device getDeviceFromPtr(void* data) const override {
+  at::Device getDeviceFromPtr(void* /*data*/) const override {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 
-  bool isPinnedPtr(const void* data) const override {
+  bool isPinnedPtr(const void* /*data*/) const override {
     return false;
   }
 
@@ -57,14 +56,14 @@ struct TORCH_API PrivateUse1HooksInterface : AcceleratorHooksInterface {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 
-  bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex /*device_index*/) const override {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 
   void init() const override {}
   virtual void resizePrivateUse1Bytes(
-      const c10::Storage& storage,
-      size_t newsize) const {
+      const c10::Storage& /*storage*/,
+      size_t /*newsize*/) const {
     FAIL_PRIVATEUSE1HOOKS_FUNC(__func__);
   }
 
@@ -85,5 +84,3 @@ TORCH_API const at::PrivateUse1HooksInterface& getPrivateUse1Hooks();
 } // namespace detail
 
 } // namespace at
-
-C10_DIAGNOSTIC_POP()

--- a/aten/src/ATen/detail/XLAHooksInterface.h
+++ b/aten/src/ATen/detail/XLAHooksInterface.h
@@ -6,7 +6,6 @@
 
 #include <ATen/detail/AcceleratorHooksInterface.h>
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 
 namespace at {
 
@@ -56,11 +55,11 @@ struct TORCH_API XLAHooksInterface : AcceleratorHooksInterface {
     TORCH_CHECK(false, "Cannot get XLA pinned memory allocator without torch_xla library. ", XLA_HELP);
   }
 
-  bool isPinnedPtr(const void* data) const override {
+  bool isPinnedPtr(const void* /*data*/) const override {
     return false;
   }
 
-  bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex /*device_index*/) const override {
     TORCH_CHECK(false, "Cannot query primary context without torch_xla library. ", XLA_HELP);
   }
 
@@ -77,4 +76,3 @@ namespace detail {
 TORCH_API const XLAHooksInterface& getXLAHooks();
 } // namespace detail
 } // namespace at
-C10_DIAGNOSTIC_POP()

--- a/aten/src/ATen/detail/XPUHooksInterface.h
+++ b/aten/src/ATen/detail/XPUHooksInterface.h
@@ -6,7 +6,6 @@
 
 #include <ATen/detail/AcceleratorHooksInterface.h>
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
 
 namespace at {
 
@@ -33,7 +32,7 @@ struct TORCH_API XPUHooksInterface : AcceleratorHooksInterface{
         "Cannot query detailed XPU version without ATen_xpu library.");
   }
 
-  virtual int32_t getGlobalIdxFromDevice(const Device& device) const {
+  virtual int32_t getGlobalIdxFromDevice(const Device& /*device*/) const {
     TORCH_CHECK(false, "Cannot get XPU global device index without ATen_xpu library.");
   }
 
@@ -68,11 +67,11 @@ struct TORCH_API XPUHooksInterface : AcceleratorHooksInterface{
     TORCH_CHECK(false, "Cannot get XPU pinned memory allocator without ATen_xpu library.");
   }
 
-  bool isPinnedPtr(const void* data) const override {
+  bool isPinnedPtr(const void* /*data*/) const override {
     return false;
   }
 
-  bool hasPrimaryContext(DeviceIndex device_index) const override {
+  bool hasPrimaryContext(DeviceIndex /*device_index*/) const override {
     TORCH_CHECK(false, "Cannot query primary context without ATen_xpu library.");
   }
 
@@ -92,4 +91,3 @@ namespace detail {
 TORCH_API const XPUHooksInterface& getXPUHooks();
 } // namespace detail
 } // namespace at
-C10_DIAGNOSTIC_POP()

--- a/c10/core/CachingDeviceAllocator.h
+++ b/c10/core/CachingDeviceAllocator.h
@@ -259,7 +259,7 @@ struct C10_API DeviceAllocator : public c10::Allocator {
 
   // Return the free memory size and total memory size in bytes for the
   // specified device.
-  virtual std::pair<size_t, size_t> getMemoryInfo(c10::DeviceIndex device) {
+  virtual std::pair<size_t, size_t> getMemoryInfo(c10::DeviceIndex /*device*/) {
     TORCH_CHECK_NOT_IMPLEMENTED(
         false, "getMemoryInfo is not implemented for this allocator yet.");
   }

--- a/c10/core/SymNodeImpl.h
+++ b/c10/core/SymNodeImpl.h
@@ -10,8 +10,6 @@
 #include <ostream>
 #include <string>
 
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-parameter")
-
 namespace c10 {
 
 class SymNodeImpl;
@@ -43,17 +41,17 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
   virtual bool is_nested_int() const {
     return false;
   }
-  virtual SymNode add(const SymNode& other) {
+  virtual SymNode add(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode sub(const SymNode& other) {
+  virtual SymNode sub(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode mul(const SymNode& other) {
+  virtual SymNode mul(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
   // NB: legacy, prefer float_truediv or int_truediv
-  virtual SymNode truediv(const SymNode& other) {
+  virtual SymNode truediv(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode float_truediv(const SymNode& other) {
@@ -63,7 +61,7 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
     return truediv(other);
   }
   // NB: legacy, prefer float_pow or pow_by_natural
-  virtual SymNode pow(const SymNode& other) {
+  virtual SymNode pow(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode float_pow(const SymNode& other) {
@@ -73,31 +71,31 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
     return pow(other);
   }
   // NB: legacy, prefer int_floordiv
-  virtual SymNode floordiv(const SymNode& other) {
+  virtual SymNode floordiv(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode int_floordiv(const SymNode& other) {
     return floordiv(other);
   }
-  virtual SymNode mod(const SymNode& other) {
+  virtual SymNode mod(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode eq(const SymNode& other) {
+  virtual SymNode eq(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode ne(const SymNode& other) {
+  virtual SymNode ne(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode gt(const SymNode& other) {
+  virtual SymNode gt(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode lt(const SymNode& other) {
+  virtual SymNode lt(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode le(const SymNode& other) {
+  virtual SymNode le(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode ge(const SymNode& other) {
+  virtual SymNode ge(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode ceil() {
@@ -109,53 +107,55 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
   virtual SymNode neg() {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode sym_min(const SymNode& other) {
+  virtual SymNode sym_min(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode sym_max(const SymNode& other) {
+  virtual SymNode sym_max(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode sym_or(const SymNode& other) {
+  virtual SymNode sym_or(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode sym_and(const SymNode& other) {
+  virtual SymNode sym_and(const SymNode& /*other*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode sym_not() {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode sym_ite(const SymNode& then_val, const SymNode& else_val) {
+  virtual SymNode sym_ite(
+      const SymNode& /*then_val*/,
+      const SymNode& /*else_val*/) {
     TORCH_CHECK(false, "NYI");
   }
   // NB: self is ignored here, only the arguments are used
   virtual SymNode is_contiguous(
-      ArrayRef<SymNode> sizes,
-      ArrayRef<SymNode> strides) {
+      ArrayRef<SymNode> /*sizes*/,
+      ArrayRef<SymNode> /*strides*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode is_channels_last_contiguous_2d(
-      ArrayRef<SymNode> sizes,
-      ArrayRef<SymNode> strides) {
+      ArrayRef<SymNode> /*sizes*/,
+      ArrayRef<SymNode> /*strides*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode is_channels_last_contiguous_3d(
-      ArrayRef<SymNode> sizes,
-      ArrayRef<SymNode> strides) {
+      ArrayRef<SymNode> /*sizes*/,
+      ArrayRef<SymNode> /*strides*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode is_channels_last_strides_2d(
-      ArrayRef<SymNode> sizes,
-      ArrayRef<SymNode> strides) {
+      ArrayRef<SymNode> /*sizes*/,
+      ArrayRef<SymNode> /*strides*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode is_channels_last_strides_3d(
-      ArrayRef<SymNode> sizes,
-      ArrayRef<SymNode> strides) {
+      ArrayRef<SymNode> /*sizes*/,
+      ArrayRef<SymNode> /*strides*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode is_non_overlapping_and_dense(
-      ArrayRef<SymNode> sizes,
-      ArrayRef<SymNode> strides) {
+      ArrayRef<SymNode> /*sizes*/,
+      ArrayRef<SymNode> /*strides*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual SymNode clone() {
@@ -164,22 +164,22 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
   virtual SymNode sym_float() {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode wrap_int(int64_t num) {
+  virtual SymNode wrap_int(int64_t /*num*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode wrap_float(double num) {
+  virtual SymNode wrap_float(double /*num*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual SymNode wrap_bool(bool num) {
+  virtual SymNode wrap_bool(bool /*num*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual int64_t guard_int(const char* file, int64_t line) {
+  virtual int64_t guard_int(const char* /*file*/, int64_t /*line*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual bool guard_bool(const char* file, int64_t line) {
+  virtual bool guard_bool(const char* /*file*/, int64_t /*line*/) {
     TORCH_CHECK(false, "NYI");
   }
-  virtual double guard_float(const char* file, int64_t line) {
+  virtual double guard_float(const char* /*file*/, int64_t /*line*/) {
     TORCH_CHECK(false, "NYI");
   }
   virtual bool guard_size_oblivious(const char* file, int64_t line) {
@@ -253,4 +253,3 @@ class C10_API SymNodeImpl : public c10::intrusive_ptr_target {
 };
 
 } // namespace c10
-C10_DIAGNOSTIC_POP()


### PR DESCRIPTION
```
Seven headers blanket-suppress -Wunused-parameter instead of naming
individual unused params, so a genuinely new unused parameter is
silenced too. Comment the names out instead, matching the rest of the
tree. isOnMacOSorNewer's defaulted args use [[maybe_unused]] instead,
since they can't be commented out.

Test Plan: -Wunused-parameter on the 8 changed files: 81 warnings
before, 0 after, no errors.
```

Drafted with AI assistance (Claude Code).