### PR TITLE
Drop the unused caffe2::cuda CMake target

### DIFF
--- a/cmake/public/cuda.cmake
+++ b/cmake/public/cuda.cmake
@@ -142,12 +142,6 @@ endif()
 # libraries installed. This flag should only be used for binary builds, so
 # end-users should never have this flag set.
 
-# cuda
-add_library(caffe2::cuda INTERFACE IMPORTED)
-set_property(
-    TARGET caffe2::cuda PROPERTY INTERFACE_LINK_LIBRARIES
-    CUDA::cuda_driver)
-
 # cudart
 add_library(torch::cudart INTERFACE IMPORTED)
 if(CAFFE2_STATIC_LINK_CUDA)
@@ -300,7 +294,7 @@ set_property(
 add_library(caffe2::nvrtc INTERFACE IMPORTED)
 set_property(
     TARGET caffe2::nvrtc PROPERTY INTERFACE_LINK_LIBRARIES
-    CUDA::nvrtc caffe2::cuda)
+    CUDA::nvrtc CUDA::cuda_driver)
 
 # Add onnx namespace definition to nvcc
 if(ONNX_NAMESPACE)


### PR DESCRIPTION
```
caffe2::cuda only forwards CUDA::cuda_driver to its one consumer,
caffe2::nvrtc. No other .cmake/CMakeLists.txt file references it, and
it's not part of the documented extension-linking pattern (TORCH_LIBRARIES).
Link CUDA::cuda_driver into caffe2::nvrtc directly instead.

It does ship in the installed Caffe2Config package, so an out-of-tree
project naming caffe2::cuda directly - undocumented, unlikely - would
need to switch to CUDA::cuda_driver.

Test Plan: no CUDA toolchain here; CI's CUDA build is the verification.
```

Drafted with AI assistance (Claude Code).