### PR TITLE
Drop the unused torch::sycl CMake target

### DIFF
--- a/cmake/public/xpu.cmake
+++ b/cmake/public/xpu.cmake
@@ -38,24 +38,17 @@ if(NOT SYCL_FOUND)
 endif()
 set(PYTORCH_FOUND_XPU TRUE)
 
-# SYCL library interface
-add_library(torch::sycl INTERFACE IMPORTED)
-
-set_property(
-    TARGET torch::sycl PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-    ${SYCL_INCLUDE_DIR})
-set_property(
-    TARGET torch::sycl PROPERTY INTERFACE_LINK_DIRECTORIES
-    ${SYCL_LIBRARY_DIR})
-set_property(
-    TARGET torch::sycl PROPERTY INTERFACE_LINK_LIBRARIES
-    ${SYCL_LIBRARY})
-
 # xpurt
 add_library(torch::xpurt INTERFACE IMPORTED)
 set_property(
+    TARGET torch::xpurt PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    ${SYCL_INCLUDE_DIR})
+set_property(
+    TARGET torch::xpurt PROPERTY INTERFACE_LINK_DIRECTORIES
+    ${SYCL_LIBRARY_DIR})
+set_property(
     TARGET torch::xpurt PROPERTY INTERFACE_LINK_LIBRARIES
-    torch::sycl)
+    ${SYCL_LIBRARY})
 
 # setting xpu arch flags
 torch_xpu_get_arch_list(XPU_ARCH_FLAGS)


### PR DESCRIPTION
```
torch::sycl only forwards its three properties to its one consumer,
torch::xpurt. No other .cmake/CMakeLists.txt file references it, and
it's not part of the documented extension-linking pattern (TORCH_LIBRARIES).
Set the properties on torch::xpurt directly instead.

It does ship in the installed Caffe2Config package, so an out-of-tree
project naming torch::sycl directly - undocumented, unlikely - would
need to switch to torch::xpurt.

Test Plan: no XPU toolchain here; CI's XPU build is the verification.
```

Drafted with AI assistance (Claude Code).