### PR TITLE
[FSDP] Avoid mutable default dictionary in _override_module_mixed_precision

### DIFF
--- a/test/distributed/fsdp/test_fsdp_misc.py
+++ b/test/distributed/fsdp/test_fsdp_misc.py
@@ -21,7 +21,10 @@ from torch.distributed.fsdp import (
     FullyShardedDataParallel as FSDP,
     ShardingStrategy,
 )
-from torch.distributed.fsdp._common_utils import clean_tensor_name
+from torch.distributed.fsdp._common_utils import (
+    _override_module_mixed_precision,
+    clean_tensor_name,
+)
 from torch.distributed.fsdp._flat_param import _FSDP_USE_UNSAFE_SETATTR
 from torch.distributed.fsdp._runtime_utils import HOMOGENEOUS_ATTR_NAMES
 from torch.distributed.fsdp.wrap import (
@@ -1221,6 +1224,20 @@ class TestFSDPMiscWorldSize1(FSDPTestMultiThread):
         called_setattr_override = False
         fsdp_module(inp)
         self.assertTrue(called_setattr_override)
+
+    def test_override_module_mixed_precision_default_dict(self):
+        """Tests that _override_module_mixed_precision properly overrides wrap dictionary without mutable default side-effects."""
+        m1 = nn.Sequential(nn.Linear(5, 5))
+        _override_module_mixed_precision(m1, [nn.Linear])
+        self.assertEqual(m1[0]._wrap_overrides, {"mixed_precision": None})
+
+        # Mutate the first module's overrides
+        m1[0]._wrap_overrides["mixed_precision"] = "mutated"
+
+        # A second invocation using the default should not inherit mutated state
+        m2 = nn.Sequential(nn.Linear(5, 5))
+        _override_module_mixed_precision(m2, [nn.Linear])
+        self.assertEqual(m2[0]._wrap_overrides, {"mixed_precision": None})
 
 
 instantiate_parametrized_tests(TestFSDPMiscMultiThread)

--- a/torch/distributed/fsdp/_common_utils.py
+++ b/torch/distributed/fsdp/_common_utils.py
@@ -648,8 +648,10 @@ def _get_root_modules(modules: set[nn.Module]) -> set[nn.Module]:
 def _override_module_mixed_precision(
     root: torch.nn.Module,
     module_classes_to_override: Iterable[type[nn.Module]],
-    wrap_override_dict: dict[str, Any] = {"mixed_precision": None},  # noqa: B006
+    wrap_override_dict: dict[str, Any] | None = None,
 ) -> set[type[nn.Module]]:
+    if wrap_override_dict is None:
+        wrap_override_dict = {"mixed_precision": None}
     module_classes_to_override = tuple(set(module_classes_to_override))
     # Return a set of the actually overridden module classes
     overridden_module_classes: set[type[nn.Module]] = set()


### PR DESCRIPTION
### Summary
Fixes #194893: Replaces the mutable default argument `wrap_override_dict: dict[str, Any] = {"mixed_precision": None}` in `_override_module_mixed_precision` (`torch/distributed/fsdp/_common_utils.py`) with `wrap_override_dict: dict[str, Any] | None = None` and initializes the default dict inside the function body.

This avoids dangerous shared mutable state and mutable default bugs.

### Test Plan
Added unit test `test_override_module_mixed_precision_default_dict` in `test/distributed/fsdp/test_fsdp_misc.py`.

Signed-off-by: Sundeep <sundeep8967@gmail.com>