### PR TITLE
[elastic] Guard rendezvous shutdown in launch_agent to avoid masking ChildFailedError

### DIFF
--- a/test/distributed/launcher/test_api.py
+++ b/test/distributed/launcher/test_api.py
@@ -96,6 +96,38 @@ class LauncherApiTest(TestCase):
             "SIGTERM,SIGINT,SIGHUP,SIGQUIT",
         )
 
+    @patch("torch.distributed.launcher.api.LocalElasticAgent")
+    @patch("torch.distributed.launcher.api.rdzv_registry.get_rendezvous_handler")
+    def test_launch_agent_failing_rdzv_shutdown_does_not_mask_child_failed_error(
+        self, mock_get_handler, mock_agent
+    ):
+        """Test that a failing rendezvous shutdown does not mask ChildFailedError."""
+        from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
+
+        config = LaunchConfig(
+            min_nodes=1,
+            max_nodes=1,
+            nproc_per_node=1,
+            run_id="test_run",
+        )
+        entrypoint = "dummy_script.py"
+        args = []
+
+        mock_rdzv_handler = MagicMock()
+        mock_rdzv_handler.shutdown.side_effect = RuntimeError("Rendezvous store unreachable")
+        mock_get_handler.return_value = mock_rdzv_handler
+
+        mock_agent_instance = MagicMock()
+        mock_agent_instance.run.return_value = MagicMock(
+            is_failed=lambda: True, failures={}
+        )
+        mock_agent.return_value = mock_agent_instance
+
+        with self.assertRaises(ChildFailedError):
+            launch_agent(config, entrypoint, args)
+
+        mock_rdzv_handler.shutdown.assert_called_once()
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -403,4 +403,9 @@ def launch_agent(
         raise
     finally:
         if shutdown_rdzv:
-            spec.rdzv_handler.shutdown()
+            try:
+                spec.rdzv_handler.shutdown()
+            except Exception:
+                logger.error(
+                    "Error shutting down rendezvous handler", exc_info=True
+                )


### PR DESCRIPTION
### Summary
Fixes #194871: In `torch/distributed/launcher/api.py`, `launch_agent()` previously shut down the rendezvous handler in an unguarded `finally` block. If `spec.rdzv_handler.shutdown()` threw an exception (such as an unreachable store or network timeout during teardown), it replaced any in-flight exception, discarding critical worker failure diagnostics like `ChildFailedError`.

This PR wraps `spec.rdzv_handler.shutdown()` in a `try-except Exception` block that logs the error at ERROR level while allowing in-flight worker failure exceptions to propagate cleanly.

### Test Plan
Added unit test `test_launch_agent_failing_rdzv_shutdown_does_not_mask_child_failed_error` in `test/distributed/launcher/test_api.py`.

Signed-off-by: Sundeep <sundeep8967@gmail.com>