### PR TITLE
Fix clang-tidy warnings in sdp_utils_cpp.h

### DIFF
--- a/aten/src/ATen/native/transformers/sdp_utils_cpp.h
+++ b/aten/src/ATen/native/transformers/sdp_utils_cpp.h
@@ -17,7 +17,6 @@
 #include <c10/core/SymFloat.h>
 #include <cmath>
 #include <cstdint>
-#include <functional>
 #include <string_view>
 
 namespace sdp {
@@ -68,10 +67,9 @@ SDPBackend select_sdp_backend_cpp(sdp_params const& kernel_params);
 inline c10::SymFloat calculate_scale(
     const at::Tensor& query,
     std::optional<double> scale) {
-  const auto softmax_scale = scale.has_value()
+  return scale.has_value()
       ? scale.value()
       : (c10::SymFloat(1.0) / (c10::SymFloat(query.sym_size(-1)).sqrt()));
-  return c10::SymFloat(softmax_scale);
 }
 
 inline bool input_requires_grad(sdp_params const& params) {
@@ -101,7 +99,7 @@ inline bool check_tensor_dtype(
     sdp_params const& params,
     dtype_vector allowed_dtypes,
     bool debug) {
-  auto query_dtype = params.query.dtype();
+  const auto query_dtype = params.query.dtype();
   if (!(query_dtype == params.key.dtype() &&
         query_dtype == params.value.dtype() &&
         (std::find(allowed_dtypes.begin(), allowed_dtypes.end(), query_dtype) !=
@@ -126,9 +124,9 @@ inline bool check_tensor_dtype(
 
 
 inline bool try_broadcast_param_size(
-    const c10::SymInt q_size,
-    const c10::SymInt k_size,
-    const c10::SymInt v_size,
+    const c10::SymInt& q_size,
+    const c10::SymInt& k_size,
+    const c10::SymInt& v_size,
     std::string_view param_name,
     bool debug) {
   auto max_size = std::max({q_size, k_size, v_size});
@@ -286,11 +284,12 @@ inline bool check_for_attn_mask(sdp_params const& params, bool debug) {
 }
 
 inline bool check_attn_mask_shape(sdp_params const& params, bool debug) {
-  auto attn_mask = params.attn_mask;
+  const auto& attn_mask = params.attn_mask;
   if (!attn_mask.has_value()) {
     return true;
   }
-  if (attn_mask.value().requires_grad()) {
+  const auto& mask = attn_mask.value();
+  if (mask.requires_grad()) {
     return false;
   }
   auto batchSize = params.query.sym_size(0);
@@ -311,19 +310,19 @@ inline bool check_attn_mask_shape(sdp_params const& params, bool debug) {
     return mask_int.has_value() && *mask_int == 1;
   };
 
-  auto mask_qsize = attn_mask.value().sym_size(-2);
+  auto mask_qsize = mask.sym_size(-2);
   if (!dim_compatible(mask_qsize, qSize)) {
     return false;
   }
-  auto mask_kvsize = attn_mask.value().sym_size(-1);
+  auto mask_kvsize = mask.sym_size(-1);
   if (!dim_compatible(mask_kvsize, kvSize)) {
     return false;
   }
-  if (attn_mask.value().dim() == 2) {
+  if (mask.dim() == 2) {
     return true;
-  } else if (attn_mask.value().dim() == 4) {
-    auto mask_b = attn_mask.value().sym_size(0);
-    auto mask_h = attn_mask.value().sym_size(1);
+  } else if (mask.dim() == 4) {
+    auto mask_b = mask.sym_size(0);
+    auto mask_h = mask.sym_size(1);
     if (dim_compatible(mask_b, batchSize) &&
         dim_compatible(mask_h, num_head)) {
       return true;

--- a/aten/src/ATen/native/transformers/xpu/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/xpu/sdp_utils.cpp
@@ -54,7 +54,7 @@ inline bool check_flash_attention_datatype(
   constexpr auto supported_dtypes =
       std::to_array<at::ScalarType>({at::kBFloat16, at::kHalf});
 
-  auto query_dtype = params.query.dtype();
+  const auto query_dtype = params.query.dtype();
   if (!(query_dtype == params.key.dtype() &&
         query_dtype == params.value.dtype() &&
         (std::find(


### PR DESCRIPTION
```
- Drop the unused <functional> include.
- calculate_scale: the ternary already deduces c10::SymFloat (double
  converts implicitly), so the intermediate variable and the
  re-wrapping return c10::SymFloat(...) were redundant.
- check_tensor_dtype's query_dtype and check_attn_mask_shape's
  attn_mask are never reassigned; make that const (and a reference for
  attn_mask, an optional<Tensor>, to skip the copy - it's atomic
  intrusive_ptr incref/decref on the underlying Tensor otherwise).
  check_attn_mask_shape then binds attn_mask.value() to a single `mask`
  reference instead of re-calling .value() at each of its 7 other uses.
- try_broadcast_param_size takes its three SymInt args by const
  reference instead of by value; the body only reads them, and SymInt's
  copy ctor is an intrusive_ptr incref when the value is symbolic - this
  matches the const& convention hand-written SymInt helpers elsewhere
  in aten already use (e.g. EmptyTensor.h, TensorIndexing.h).
- xpu/sdp_utils.cpp's check_flash_attention_datatype has the identical
  query_dtype pattern as check_tensor_dtype; applied the same const fix
  there for consistency (no perf effect, dtype() returns by value either
  way).

Test Plan: could not compile locally (no working C++ toolchain in this
environment); this is a pure const/reference-ness and dead-code cleanup
with no behavior change, and CI covers the actual build.
```

Drafted with AI assistance (Claude Code).