### PR TITLE
fix(deps): bump lxml, onnx, pip, setuptools in CI requirements to patch disclosed CVEs

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -341,8 +341,7 @@ pywavelets==1.7.0 ; python_version >= "3.12"
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==5.3.0 ; python_version < "3.14"
-lxml==6.1.0 ; python_version >= "3.14"
+lxml==6.1.0
 #Description: This is a requirement of unittest-xml-reporting
 
 PyGithub==2.3.0
@@ -352,7 +351,7 @@ sympy==1.13.3
 #Pinned versions:
 #test that import:
 
-onnx==1.21.0
+onnx==1.22.0
 #Description: Required by the torch.onnx exporter
 #Pinned versions:
 #test that import:
@@ -382,10 +381,10 @@ pwlf==2.2.1
 #test that import: test_sac_estimator.py
 
 # To build PyTorch itself
-pip==26.1.2
+pip==26.2
 pyyaml==6.0.3
 pyzstd
-setuptools==78.1.1
+setuptools==83.0.0
 packaging==24.2
 six
 


### PR DESCRIPTION
Automated dependency bump to address disclosed CVEs in `.ci/docker/requirements-ci.txt`.

- **lxml** `5.3.0` -> `6.1.0` (for `python_version < "3.14"`; the `>= "3.14"` branch was already on 6.1.0, so the two conditional lines collapse into one now that both resolve to the same version) -- [GHSA-vfmq-68hx-4jfw](https://github.com/advisories/GHSA-vfmq-68hx-4jfw), **high**: default `iterparse()`/`ETCompatXMLParser()` config allows XXE against local files.
- **onnx** `1.21.0` -> `1.22.0` -- [GHSA-hwpq-hmq9-wj77](https://github.com/advisories/GHSA-hwpq-hmq9-wj77) (NULL pointer dereference in the Upsample version-converter with zero inputs), [GHSA-p893-rvq9-2xf9](https://github.com/advisories/GHSA-p893-rvq9-2xf9) (heap-buffer-overflow read in the Gemm version-converter via an undersized input shape).
- **pip** `26.1.2` -> `26.2` -- PYSEC-2026-3721.
- **setuptools** `78.1.1` -> `83.0.0` -- [GHSA-h35f-9h28-mq5c](https://github.com/advisories/GHSA-h35f-9h28-mq5c): `MANIFEST.in` exclusion bypass in sdist via a Unicode NFC/NFD normalization collision. `83.0.0` is already the pin used elsewhere in this repo's own CI (`.ci/docker/common/requirements_tpu.txt`), so it's a known-working version in this build environment.

Detected by [osv-scanner](https://google.github.io/osv-scanner/) against this file. All four target versions independently re-verified against the OSV API (zero remaining advisories at the landed version).

**Not bundled in this PR** (need a wider compatibility check before landing something this disruptive):
- `pytest` `7.3.2` is only fixed at `9.0.3` ([GHSA-6w46-j5rx-g56g](https://github.com/advisories/GHSA-6w46-j5rx-g56g), predictable `/tmp/pytest-of-{user}` path -> local-multiuser DoS/privilege issue, CWE-379). That's a 2-major-version jump for the runner driving the entire test suite -- too large a blast radius for a routine bump PR. Happy to open it separately if useful.
- `urllib3` `1.26.20` in `.github/requirements-gha-cache.txt` carries 5 disclosed CVEs fixed across `2.5.0`-`2.7.0` (decompression-bomb bypass, unbounded compression chain, redirect/header handling) but is a 1.x -> 2.x major bump with real API changes; leaving that for a dedicated PR too.
- `tqdm` is pinned as `>=4.66.0` (a floor, not an exact version), so the CVE-fixed `4.66.3` is already satisfiable at resolve time today -- no functional change needed unless you want to raise the floor as defense-in-depth.

No code changes outside this one requirements file.

---
Filed by [Aeon](https://github.com/aeonfun/aeon) -- an automated vulnerability-disclosure agent. This is a public dependency-CVE bump (the advisories above are already public), per this instance's practice of only opening public PRs for already-disclosed dependency CVEs and routing code-level findings through private channels.
