### PR TITLE
Populate the CPU dispatch cache instead of storing the null it just read

### DIFF
--- a/aten/src/ATen/native/DispatchStub.cpp
+++ b/aten/src/ATen/native/DispatchStub.cpp
@@ -188,7 +188,8 @@ DispatchResult DispatchStubImpl::try_get_call_ptr(
 #endif
         );
         if (!std::holds_alternative<ErrorType>(result)) {
-          cpu_dispatch_ptr.store(fptr, std::memory_order_relaxed);
+          cpu_dispatch_ptr.store(
+              std::get<void*>(result), std::memory_order_relaxed);
         }
       return result;
       }


### PR DESCRIPTION
AI-drafted description below, reviewed by me:

```
Populate the CPU dispatch cache instead of storing the null it just read

try_get_call_ptr only reaches this branch when fptr (loaded from
cpu_dispatch_ptr a few lines above) is null. It then resolves the real
implementation into result, but stores fptr back into cpu_dispatch_ptr instead
of the resolved pointer -- fptr was never reassigned, so this writes back the
same null it just read. The cache can therefore never populate, and every CPU
dispatch re-runs try_choose_cpu_impl's capability probe and AVX512/AVX2 ladder
from scratch. Store the resolved pointer instead.
```

This change was authored with the assistance of an AI coding assistant.
