### PR TITLE
linear_cross_entropy: extract the chunked-path gate

### DIFF
--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -3701,6 +3701,63 @@ def binary_cross_entropy_with_logits(
     )
 
 
+def _linear_cross_entropy_chunked_applies(
+    input: Tensor,
+    linear_weight: Tensor,
+    target: Tensor,
+    linear_bias: Tensor | None,
+    reduction: str,
+    label_smoothing: float,
+    options: "LinearCrossEntropyOptions | None",
+    *,
+    warn: bool = True,
+) -> bool:
+    """Whether :func:`linear_cross_entropy` routes to the chunked custom ops.
+
+    Warns when ``options`` was supplied but cannot be honoured, so a caller
+    whose options are being ignored hears about it. Kept as one function
+    because the answer is needed in more than one place: the dispatch below,
+    that warning, and the OpInfo sample filter for the native overrides, which
+    has to predict which samples ever reach the ops -- that caller passes
+    ``warn=False``, since it is asking rather than dispatching.
+    """
+    if options is None:
+        return False
+    # K-dim loss falls back: the chunked op softmaxes over the full
+    # linear_weight.shape[0], not per-position over num_classes.
+    out_features = linear_weight.shape[1:-1]
+    # The chunked op has no gradient slot for the target, so a probability
+    # target requiring grad falls back to the reference path.
+    logits_shape = (*input.shape[:-1], linear_weight.shape[0], *out_features)
+    chunkable_prob_target = (
+        target.shape == logits_shape
+        and target.dtype == input.dtype
+        and not (target.requires_grad and torch.is_grad_enabled())
+    )
+    applies = (
+        reduction in {"mean", "sum", "none"}
+        and label_smoothing == 0.0
+        and (target.dtype == torch.int64 or chunkable_prob_target)
+        and not out_features
+        and not torch.jit.is_tracing()
+    )
+    if not applies and warn:
+        warnings.warn(
+            "linear_cross_entropy: ``options`` ignored; chunked path needs "
+            "reduction in {'mean','sum','none'}, label_smoothing == 0, target.dtype"
+            " == int64 (or a probability target with dtype matching input and"
+            " requires_grad == False), out_features == (). Got "
+            f"reduction={reduction!r}, label_smoothing={label_smoothing}, "
+            f"target.dtype={target.dtype}, out_features={tuple(out_features)}"
+            f", tracing={torch.jit.is_tracing()}"
+            f", target.requires_grad={target.requires_grad}"
+            f", linear_bias.shape="
+            f"{tuple(linear_bias.shape) if linear_bias is not None else None}.",
+            stacklevel=3,
+        )
+    return applies
+
+
 def linear_cross_entropy(
     input: Tensor,
     linear_weight: Tensor,
@@ -3890,44 +3947,11 @@ def linear_cross_entropy(
             "ignore_index cannot be specified when target contains probabilities"
         )
     ignore_index = ignore_index if ignore_index is not None else -100
-
-    # The chunked op has no gradient slot for the target, so a probability
-    # target requiring grad falls back to the reference path.
-    chunkable_prob_target = (
-        target_contains_probabilities
-        and target.dtype == input.dtype
-        and not (target.requires_grad and torch.is_grad_enabled())
-    )
-    # K-dim loss falls back: the chunked op softmaxes over the full
-    # linear_weight.shape[0], not per-position over num_classes.
-    if options is not None and (
-        out_features
-        or reduction not in {"mean", "sum", "none"}
-        or label_smoothing != 0.0
-        or (target.dtype != torch.int64 and not chunkable_prob_target)
-        or torch.jit.is_tracing()
-    ):
-        warnings.warn(
-            "linear_cross_entropy: ``options`` ignored; chunked path needs "
-            "reduction in {'mean','sum','none'}, label_smoothing == 0, target.dtype"
-            " == int64 (or a probability target with dtype matching input and"
-            " requires_grad == False), out_features == (). Got "
-            f"reduction={reduction!r}, label_smoothing={label_smoothing}, "
-            f"target.dtype={target.dtype}, out_features={tuple(out_features)}"
-            f", tracing={torch.jit.is_tracing()}"
-            f", target.requires_grad={target.requires_grad}"
-            f", linear_bias.shape="
-            f"{tuple(linear_bias.shape) if linear_bias is not None else None}.",
-            stacklevel=2,
-        )
-
-    if (
-        options is not None
-        and reduction in {"mean", "sum", "none"}
-        and label_smoothing == 0.0
-        and (target.dtype == torch.int64 or chunkable_prob_target)
-        and not out_features
-        and not torch.jit.is_tracing()
+    # ``options is not None`` is redundant with the predicate, which returns
+    # False for None -- it is here so the type checker narrows ``options`` for
+    # the ``_adjust`` call below.
+    if options is not None and _linear_cross_entropy_chunked_applies(
+        input, linear_weight, target, linear_bias, reduction, label_smoothing, options
     ):
         if input.dim() == 2:
             num_batches = input.shape[0]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #195335
* #195334
* __->__ #195333
* #195332
* #195331
* #194510
* #194509

The condition deciding whether `linear_cross_entropy` uses the chunked custom
ops was written twice in the same function: once negated, to warn that a
supplied `options` is being ignored, and once positive, to take the branch. The
two had to be kept in agreement by hand, and a reader had to check they were.

`_linear_cross_entropy_chunked_applies` is now the single statement of it, and
it owns the warning as well -- "does the chunked path apply, and if not, say
so" is one decision, not two. The caller's `chunkable_prob_target` local goes
away, since that condition is only ever needed to answer this question.

There is a third caller. The OpInfo variants for the `torch._native` overrides
of these ops have to select the samples that actually reach them, which is the
same question; without a shared predicate that selection is a hand-written
restatement of this gate, which drifts the moment the gate changes. `warn=False`
is for that caller: it is asking, not dispatching, so a user-facing warning
would be wrong.

Two details are not pure motion. The warning is one frame deeper now, so
`stacklevel` goes 2 -> 3 to keep pointing at the caller of
`linear_cross_entropy` rather than into this file. And the branch keeps an
explicit `options is not None`, redundant with the predicate, so the type
checker still narrows `options` for the `_adjust` call that follows.

Test Plan:

Behaviour-preserving, so the existing coverage is the test. Checked separately
that the predicate answers as before on eligible / `options=None` /
`label_smoothing` / `reduction='none'` inputs, that the warning fires only when
`options` was supplied and cannot be honoured, and that it is attributed to the
caller's line rather than to functional.py.

```
python -m pytest test/test_nn.py -q -k linear_cross_entropy
python -m pytest test/test_ops.py -q -k linear_cross_entropy
python scripts/lintrunner.py
```

---
_🤖 Drafted by Claude Code (an AI agent) and reviewed & approved by pearu._