### PR TITLE
torch/_native: run the linear_cross_entropy override tests on B200

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -510,6 +510,12 @@ test_python_smoke_b200() {
     --upload-artifacts-while-running \
     --pytest-xdist-workers 32
 
+  # The CuTeDSL linear_cross_entropy overrides: the routing test, and the OpInfo
+  # variants that only exist where the CuTeDSL runtime does, so they are
+  # collected nowhere else.
+  time python test/run_test.py --include python_native/test_linear_cross_entropy_override $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+  time env OPINFO_RESTRICT_TO_DSL=cutedsl python test/run_test.py --include test_ops -k linear_cross_entropy $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
+
   time python test/run_test.py --include test_linalg -k "mm or addmv" $PYTHON_TEST_EXTRA_OPTION --upload-artifacts-while-running
   assert_git_not_dirty
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #195335
* #195334
* #195333
* #195332
* #195331
* #194510
* #194509

The CuTeDSL overrides are only exercised where the runtime is installed, and
smoke_b200 is the one job that has it. Its include list holds no test that
iterates `op_db`, so the `cutedsl` and `cutedsl_none` OpInfo variants -- which
are constructed only when the runtime is importable -- are collected nowhere in
CI, and neither is the routing test. This adds both.

`OPINFO_RESTRICT_TO_DSL=cutedsl` narrows `op_db` to the DSL entries, and `-k`
narrows further to this op, so the run is the two variants and nothing else: 27
tests in 37s on an H100. Keeping it to this op means a failure here points at
this stack rather than at another DSL override.

Test Plan: the job itself can only run in CI. Verified on an H100 (sm_90) that
both invocations select what they claim to -- 7 tests for the routing file, 27
for the restricted OpInfo run -- and that `test_ops` accepts `-k` the way the
neighbouring `test_linalg` line already relies on.

```
python -m pytest test/python_native/test_linear_cross_entropy_override.py -q
OPINFO_RESTRICT_TO_DSL=cutedsl python -m pytest test/test_ops.py -q -k linear_cross_entropy
```

---
_🤖 Drafted by Claude Code (an AI agent) and reviewed & approved by pearu._