### PR TITLE
Validate leading dims of input and grad_output in _adaptive_avg_pool2…

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -68,6 +68,11 @@ namespace {
       __func__, ": Expected dimensions ", input.dim(), " for `grad_output` but got dimensions ", ndim);
     TORCH_CHECK((ndim == 3 || ndim == 4),
       __func__, ": Expected 3D or 4D tensor, but got ", input.sizes());
+    for (const auto i : c10::irange(ndim - 2)) {
+      TORCH_CHECK(input.size(i) == grad_output.size(i),
+        __func__, ": input and grad_output must have the same size at dim ", i,
+        ", but got ", input.size(i), " and ", grad_output.size(i));
+    }
     TORCH_CHECK(input.dtype() == grad_output.dtype(),
       __func__, ": Expected dtype ", input.dtype(), " for `grad_output` but got dtype ", grad_output.dtype());
     TORCH_CHECK(input.dtype() == grad_input.dtype(),

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -616,6 +616,11 @@ namespace {
     adaptive_pool_empty_output_check(gradOutput_, "adaptive_avg_pool2d_backward");
     TORCH_CHECK(input.dim() == gradOutput_.dim(),
       __func__, ": Expected dimensions ", input.dim(), " for `gradOutput_` but got dimensions ", gradOutput_.dim());
+    for (const auto i : c10::irange(input.dim() - 2)) {
+      TORCH_CHECK(input.size(i) == gradOutput_.size(i),
+        __func__, ": input and gradOutput_ must have the same size at dim ", i,
+        ", but got ", input.size(i), " and ", gradOutput_.size(i));
+    }
 
     checkAllSameGPU(__func__, {grad_input_arg, grad_output_arg, input_arg});
 

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -823,6 +823,18 @@ class TestPoolingNNDevice(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "Expected dimensions"):
             torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
 
+        grad_output = torch.randn(1, 3, 7, 7, device=device)
+        input = torch.randn(1, 2, 3, 3, device=device)
+        with self.assertRaisesRegex(RuntimeError, "must have the same size at dim"):
+            torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
+
+        # channels_last takes the channel count from input and strides
+        # grad_output with it, so it runs off grad_output rather than grad_input
+        grad_output = torch.randn(1, 2, 7, 7, device=device).to(memory_format=torch.channels_last)
+        input = torch.randn(1, 3, 3, 3, device=device).to(memory_format=torch.channels_last)
+        with self.assertRaisesRegex(RuntimeError, "must have the same size at dim"):
+            torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
+
         grad_output = torch.randn(1, 2, 7, 7, device=device)
         input = torch.randn(1, 2, 3, 3, 3, device=device)
         with self.assertRaisesRegex(RuntimeError, "Expected dimensions"):


### PR DESCRIPTION
Fixes #194803. This is the 2D counterpart to #195304, which fixes the same
defect in `_adaptive_avg_pool3d_backward`.

`adaptive_avg_pool2d_backward_out_cpu_template` validates that `input` and
`grad_output` have equal rank, but never that their batch and channel sizes
agree. `grad_input` is sized from `input`, while the kernel takes its channel
loop bound from `grad_output`, so a mismatch strides one pointer past the end of
the other tensor. With the reported `input=(1,1,1,1)` and
`grad_output=(1,2,1,1)`, every existing check passes.

Worth noting for the placement: the two memory formats fail in opposite
directions. The contiguous kernel takes the channel count from `grad_output` and
strides `grad_input` with it, so it overruns `grad_input` when `grad_output` has
more channels. The channels-last kernel takes the count from `grad_input` and
strides `grad_output` with it, so it overruns `grad_output` when `grad_output`
has fewer. The CUDA template carries the same rank-only guard in the same
position above its memory-format switch.

So the check goes in the host-side templates rather than the kernels: one
equality check on the leading dimensions covers both memory formats, both
directions, and both devices, where a kernel-side fix would need four patches and
would still miss the mirrored case.

The new message deliberately differs from the existing `"Expected dimensions"`
text so the pre-existing rank assertions in
`test_adaptive_avg_pooling_backward_fails` keep exercising the rank path rather
than passing on the new check.

### Test plan

The reported repro returned silently before and now raises:

```
RuntimeError: adaptive_avg_pool2d_backward_out_cpu_template: input and
grad_output must have the same size at dim 1, but got 1 and 2
```

```
python test/nn/test_pooling.py -k adaptive_avg_pooling_backward_fails
```

Ran 1 test, OK. The test is extended with a contiguous and a channels-last
mismatch so both overrun directions are covered.

```
python test/nn/test_pooling.py -k adaptive
```

38 tests, 12 failures, 11 skipped, identical with and without this change against
a rebuilt baseline. Those failures are pre-existing on a CPU-only build without
BLAS or MKL and include `AdaptiveMaxPool2d` cases this patch does not touch.

The CUDA hunk was verified by reading the code. My local build is CPU-only, so
CUDA is exercised by CI rather than locally.

**BC-breaking:** no. The newly rejected inputs previously caused out-of-bounds
accesses and garbage results.
