### PR TITLE
[ATen] Raise IndexError for advanced index lists with no tensors

### DIFF
--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -972,9 +972,7 @@ Tensor& _index_put_impl_(
       " (got ",
       indices.size(),
       ")");
-  if (!indices.empty()) {
-    checkAtLeastOneIndexTensor(indices);
-  }
+  checkAtLeastOneIndexTensor(indices);
   if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
         "Use of index_put_ on expanded tensors is deprecated. "

--- a/aten/src/ATen/native/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/TensorAdvancedIndexing.cpp
@@ -524,6 +524,7 @@ TORCH_PRECOMPUTE_META_FUNC2(index, Tensor)
       " (got ",
       materialized.size(),
       ")");
+  at::native::checkAtLeastOneIndexTensor(indices);
 
   // Only allow: `dev_tensor[{cpu,dev}_tensor]`.
   // See: https://github.com/pytorch/pytorch/pull/69607
@@ -971,6 +972,9 @@ Tensor& _index_put_impl_(
       " (got ",
       indices.size(),
       ")");
+  if (!indices.empty()) {
+    checkAtLeastOneIndexTensor(indices);
+  }
   if (at::has_internal_overlap(self) == MemOverlap::Yes) {
     TORCH_WARN(
         "Use of index_put_ on expanded tensors is deprecated. "

--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -3,6 +3,8 @@
 #include <ATen/native/IndexingUtils.h>
 #include <ATen/native/TensorIterator.h>
 
+#include <algorithm>
+
 namespace at::native {
 namespace {
 #ifndef STRIP_ERROR_MESSAGES
@@ -67,6 +69,17 @@ inline std::tuple<bool, Tensor> canDispatchToMaskedFill(
     mask = mask.unsqueeze(-1);
   }
   return std::make_tuple(true, std::move(mask));
+}
+
+inline void checkAtLeastOneIndexTensor(IOptTensorListRef indices) {
+  TORCH_CHECK_INDEX(
+      std::any_of(
+          indices.begin(),
+          indices.end(),
+          [](const OptionalTensorRef& index) {
+            return index.has_value() && index->defined();
+          }),
+      "at least one index tensor must be provided");
 }
 
 inline AdvancedIndex make_info(Tensor self, IOptTensorListRef orig) {

--- a/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
+++ b/aten/src/ATen/native/TensorAdvancedIndexingUtils.h
@@ -72,6 +72,9 @@ inline std::tuple<bool, Tensor> canDispatchToMaskedFill(
 }
 
 inline void checkAtLeastOneIndexTensor(IOptTensorListRef indices) {
+  if (indices.empty()) {
+    return;
+  }
   TORCH_CHECK_INDEX(
       std::any_of(
           indices.begin(),

--- a/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
@@ -115,9 +115,7 @@ Tensor & masked_fill__quantized_cuda(Tensor& self, const Tensor & mask, const Te
 
 Tensor& _index_put_impl_quantized_cpu_(Tensor & self, const torch::List<std::optional<Tensor>>& indices, const Tensor & value, const bool accumulate, const bool unsafe) {
   TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
-  if (!indices.empty()) {
-    checkAtLeastOneIndexTensor(indices);
-  }
+  checkAtLeastOneIndexTensor(indices);
   TORCH_CHECK(!value.is_quantized(), "Value argument for quantized input_put should not be quantized");
   TORCH_CHECK(self.qscheme() == c10::kPerTensorAffine, "index_put for quantized tensors is currently only supported for per tensor quantized tensors");
   TORCH_CHECK(!accumulate, "index_put for quantized tensors is currently only supported for accumulate=False");
@@ -153,9 +151,7 @@ Tensor& _index_put_impl_quantized_cpu_(Tensor & self, const torch::List<std::opt
 
 Tensor& _index_put_impl_quantized_cuda_(Tensor & self, const torch::List<std::optional<Tensor>>& indices, const Tensor & value, const bool accumulate, const bool unsafe) {
   TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
-  if (!indices.empty()) {
-    checkAtLeastOneIndexTensor(indices);
-  }
+  checkAtLeastOneIndexTensor(indices);
   TORCH_CHECK(!value.is_quantized(), "Value argument for quantized input_put should not be quantized");
   TORCH_CHECK(self.qscheme() == c10::kPerTensorAffine, "index_put for quantized tensors is currently only supported for per tensor quantized tensors");
   TORCH_CHECK(!accumulate, "index_put for quantized tensors is currently only supported for accumulate=False");

--- a/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
+++ b/aten/src/ATen/native/quantized/TensorAdvancedIndexing.cpp
@@ -115,6 +115,9 @@ Tensor & masked_fill__quantized_cuda(Tensor& self, const Tensor & mask, const Te
 
 Tensor& _index_put_impl_quantized_cpu_(Tensor & self, const torch::List<std::optional<Tensor>>& indices, const Tensor & value, const bool accumulate, const bool unsafe) {
   TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
+  if (!indices.empty()) {
+    checkAtLeastOneIndexTensor(indices);
+  }
   TORCH_CHECK(!value.is_quantized(), "Value argument for quantized input_put should not be quantized");
   TORCH_CHECK(self.qscheme() == c10::kPerTensorAffine, "index_put for quantized tensors is currently only supported for per tensor quantized tensors");
   TORCH_CHECK(!accumulate, "index_put for quantized tensors is currently only supported for accumulate=False");
@@ -150,6 +153,9 @@ Tensor& _index_put_impl_quantized_cpu_(Tensor & self, const torch::List<std::opt
 
 Tensor& _index_put_impl_quantized_cuda_(Tensor & self, const torch::List<std::optional<Tensor>>& indices, const Tensor & value, const bool accumulate, const bool unsafe) {
   TORCH_CHECK_INDEX(indices.size() <= (size_t)self.dim(), "too many indices for tensor of dimension ", self.dim(), " (got ", indices.size(), ")");
+  if (!indices.empty()) {
+    checkAtLeastOneIndexTensor(indices);
+  }
   TORCH_CHECK(!value.is_quantized(), "Value argument for quantized input_put should not be quantized");
   TORCH_CHECK(self.qscheme() == c10::kPerTensorAffine, "index_put for quantized tensors is currently only supported for per tensor quantized tensors");
   TORCH_CHECK(!accumulate, "index_put for quantized tensors is currently only supported for accumulate=False");

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -922,6 +922,100 @@ class TestIndexing(TestCase):
         with self.assertRaisesRegex(IndexError, "at least one index must be provided"):
             torch.ops.aten.index.Tensor(t, [])
 
+    def test_index_tensor_all_none_indices(self, device):
+        source = torch.arange(4, device=device).reshape(2, 2)
+        indices = [None]
+
+        with self.assertRaisesRegex(
+            IndexError, "at least one index tensor must be provided"
+        ):
+            torch.ops.aten.index.Tensor(source, indices)
+
+        out = torch.empty_like(source)
+        with self.assertRaisesRegex(
+            IndexError, "at least one index tensor must be provided"
+        ):
+            torch.ops.aten.index.Tensor_out(source, indices, out=out)
+
+    @parametrize(
+        "variant, accumulate, scalar_value",
+        [
+            ("out", False, False),
+            ("inplace", False, True),
+            ("functional", True, True),
+        ],
+    )
+    def test_index_put_all_none_indices(
+        self, device, variant, accumulate, scalar_value
+    ):
+        source = torch.arange(4, dtype=torch.float32, device=device).reshape(2, 2)
+        indices = [None]
+        values = (
+            torch.tensor(10.0)
+            if scalar_value
+            else torch.tensor([10.0, 20.0], device=device)
+        )
+
+        with self.assertRaisesRegex(
+            IndexError, "at least one index tensor must be provided"
+        ):
+            if variant == "out":
+                torch.ops.aten.index_put.out(
+                    source,
+                    indices,
+                    values,
+                    accumulate,
+                    out=torch.empty_like(source),
+                )
+            elif variant == "inplace":
+                torch.ops.aten.index_put_.default(
+                    source.clone(), indices, values, accumulate
+                )
+            else:
+                torch.ops.aten.index_put.default(source, indices, values, accumulate)
+
+    @onlyCPU
+    def test_all_none_indices_meta(self, device):
+        source = torch.empty(2, 2, device="meta")
+        values = torch.empty(2, device="meta")
+
+        with self.assertRaisesRegex(
+            IndexError, "at least one index tensor must be provided"
+        ):
+            torch.ops.aten.index.Tensor(source, [None])
+        with self.assertRaisesRegex(
+            IndexError, "at least one index tensor must be provided"
+        ):
+            torch.ops.aten.index_put.default(source, [None], values)
+        with self.assertRaisesRegex(
+            IndexError, "at least one index tensor must be provided"
+        ):
+            torch.ops.aten.index_put_.default(source, [None], values)
+
+    @onlyCPU
+    def test_index_put_all_none_indices_quantized(self, device):
+        source = torch.quantize_per_tensor(
+            torch.arange(4, dtype=torch.float32).reshape(2, 2),
+            scale=0.25,
+            zero_point=5,
+            dtype=torch.qint8,
+        )
+        values = torch.tensor([1.25, 2.5])
+
+        with self.assertRaisesRegex(
+            IndexError, "at least one index tensor must be provided"
+        ):
+            torch.ops.aten.index_put.default(source, [None], values, False)
+
+    def test_all_none_indices_too_many(self, device):
+        source = torch.empty(2, 2, device=device)
+        indices = [None, None, None]
+
+        with self.assertRaisesRegex(IndexError, "too many indices"):
+            torch.ops.aten.index.Tensor(source, indices)
+        with self.assertRaisesRegex(IndexError, "too many indices"):
+            torch.ops.aten.index_put.default(source, indices, source)
+
     def test_bool_indices_accumulate(self, device):
         mask = torch.zeros(size=(10,), dtype=torch.bool, device=device)
         y = torch.ones(size=(10, 10), device=device)

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -993,6 +993,23 @@ class TestIndexing(TestCase):
             torch.ops.aten.index_put_.default(source, [None], values)
 
     @onlyCPU
+    @parametrize("index_count", [0, 1, 2, 3])
+    def test_invalid_index_lists_fake(self, device, index_count):
+        from torch._subclasses.fake_tensor import FakeTensorMode
+
+        message = (
+            "at least one index must be provided"
+            if index_count == 0
+            else "too many indices"
+            if index_count > 2
+            else "at least one index tensor must be provided"
+        )
+        with FakeTensorMode():
+            source = torch.empty(2, 2, device=device)
+            with self.assertRaisesRegex(IndexError, message):
+                torch.ops.aten.index.Tensor(source, [None] * index_count)
+
+    @onlyCPU
     def test_index_put_all_none_indices_quantized(self, device):
         source = torch.quantize_per_tensor(
             torch.arange(4, dtype=torch.float32).reshape(2, 2),

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3903,6 +3903,7 @@ def nonzero(self):
 @register_meta([aten.index.Tensor, aten._unsafe_index.Tensor])
 def meta_index_Tensor(self, indices):
     torch._check(bool(indices), lambda: "at least one index must be provided")
+    has_index = any(index is not None for index in indices)
     # aten::index is the internal advanced indexing implementation
     # checkIndexTensorTypes and expandTensors
     result: list[Tensor | None] = []
@@ -3934,6 +3935,10 @@ def meta_index_Tensor(self, indices):
     torch._check(
         len(indices) <= self.ndim,
         lambda: f"too many indices for tensor of dimension {self.ndim} (got {len(indices)})",
+    )
+    torch._check_index(
+        has_index,
+        lambda: "at least one index tensor must be provided",
     )
     # expand_outplace
     import torch._refs as refs  # avoid import cycle in mypy
@@ -4967,6 +4972,15 @@ def meta_rrelu_with_noise_(
 
 @register_meta([aten.index_put.default, aten._unsafe_index_put.default])
 def meta_index_put(self, indices, values, accumulate=False):
+    if indices:
+        torch._check_index(
+            len(indices) <= self.ndim,
+            lambda: f"too many indices for tensor of dimension {self.ndim} (got {len(indices)})",
+        )
+        torch._check_index(
+            any(index is not None for index in indices),
+            lambda: "at least one index tensor must be provided",
+        )
     return torch.empty_like(self)
 
 
@@ -5012,6 +5026,15 @@ def meta_masked_scatter_backward(self, mask, sizes):
 
 @register_meta(aten.index_put_.default)
 def meta_index_put_(self, indices, values, accumulate=False):
+    if indices:
+        torch._check_index(
+            len(indices) <= self.ndim,
+            lambda: f"too many indices for tensor of dimension {self.ndim} (got {len(indices)})",
+        )
+        torch._check_index(
+            any(index is not None for index in indices),
+            lambda: "at least one index tensor must be provided",
+        )
     return self
 
 

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3902,7 +3902,7 @@ def nonzero(self):
 
 @register_meta([aten.index.Tensor, aten._unsafe_index.Tensor])
 def meta_index_Tensor(self, indices):
-    torch._check(bool(indices), lambda: "at least one index must be provided")
+    torch._check_index(bool(indices), lambda: "at least one index must be provided")
     has_index = any(index is not None for index in indices)
     # aten::index is the internal advanced indexing implementation
     # checkIndexTensorTypes and expandTensors
@@ -3932,7 +3932,7 @@ def meta_index_Tensor(self, indices):
         else:
             result.append(index)
     indices = result
-    torch._check(
+    torch._check_index(
         len(indices) <= self.ndim,
         lambda: f"too many indices for tensor of dimension {self.ndim} (got {len(indices)})",
     )


### PR DESCRIPTION
## Issue

Fixes #107699.

## Summary

I reproduced the issue on CPU and CUDA and reviewed the implementation and regression tests. ChatGPT helped draft the summary and checklist below.

> A non-empty ATen optional-tensor index list containing only `None` values currently bypasses validation. It can later trigger backend assertions, and the CUDA accumulate path may return without applying the update. This PR adds a shared check requiring every non-empty index list to contain at least one tensor, and uses the same `IndexError` for native, quantized, Meta, and FakeTensor paths. Empty index lists and Python `x[None]` indexing are unchanged.
>
> **Checklist**
>
> - [x] `spin fixlint` passes.
> - [x] Added CPU, CUDA, Meta, FakeTensor, and QuantizedCPU regression tests.
> - [x] Existing empty-index and Python newaxis tests pass.
> - [x] No documentation update is needed.
> - [x] No performance impact is expected.

## BC-breaking?

No.
