### PR TITLE
Reject overlapping out= tensors in aminmax

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -377,8 +377,13 @@ TORCH_META_FUNC(aminmax)
   if (min.defined() && max.defined()) {
     // The two outputs are written independently, so overlapping storage makes
     // whichever write lands last clobber the other, silently.
+    // Only Partial and Full are rejected. TooHard covers non-dense outputs and
+    // symbolic shapes, where overlap cannot be proven either way; requiring No
+    // there would reject non-contiguous out= tensors that do not overlap.
+    const auto overlap = at::get_overlap_status(min, max);
     TORCH_CHECK(
-        at::get_overlap_status(min, max) == at::MemOverlapStatus::No,
+        overlap != at::MemOverlapStatus::Partial &&
+            overlap != at::MemOverlapStatus::Full,
         "aminmax(): the `min` and `max` out= tensors must not overlap.");
   }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -377,9 +377,8 @@ TORCH_META_FUNC(aminmax)
   if (min.defined() && max.defined()) {
     // The two outputs are written independently, so overlapping storage makes
     // whichever write lands last clobber the other, silently.
-    const auto overlap = at::get_overlap_status(min, max);
     TORCH_CHECK(
-        overlap == at::MemOverlapStatus::No,
+        at::get_overlap_status(min, max) == at::MemOverlapStatus::No,
         "aminmax(): the `min` and `max` out= tensors must not overlap.");
   }
 

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -379,10 +379,8 @@ TORCH_META_FUNC(aminmax)
     // whichever write lands last clobber the other, silently.
     const auto overlap = at::get_overlap_status(min, max);
     TORCH_CHECK(
-        overlap != at::MemOverlapStatus::Partial &&
-            overlap != at::MemOverlapStatus::Full,
-        "aminmax(): the `min` and `max` out= tensors must not share memory, "
-        "but they overlap. Pass two distinct tensors.");
+        overlap == at::MemOverlapStatus::No,
+        "aminmax(): the `min` and `max` out= tensors must not overlap.");
   }
 
   DimVector shape;

--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -5,6 +5,7 @@
 #include <ATen/AccumulateType.h>
 #include <ATen/Dispatch.h>
 #include <ATen/Dispatch_v2.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/Parallel.h>
 #include <ATen/WrapDimUtils.h>
 #include <ATen/WrapDimUtilsMulti.h>
@@ -373,6 +374,16 @@ TORCH_META_FUNC(aminmax)
       ", but got ",
       max.dtype(),
       " instead");
+  if (min.defined() && max.defined()) {
+    // The two outputs are written independently, so overlapping storage makes
+    // whichever write lands last clobber the other, silently.
+    const auto overlap = at::get_overlap_status(min, max);
+    TORCH_CHECK(
+        overlap != at::MemOverlapStatus::Partial &&
+            overlap != at::MemOverlapStatus::Full,
+        "aminmax(): the `min` and `max` out= tensors must not share memory, "
+        "but they overlap. Pass two distinct tensors.");
+  }
 
   DimVector shape;
   if (dim_opt.has_value()) {

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1223,7 +1223,7 @@ class TestReductions(TestCase):
         # `min` and `max` are written independently, so sharing storage makes
         # whichever write lands last clobber the other, silently.
         out = torch.empty(3, device=device, dtype=dtype)
-        with self.assertRaisesRegex(RuntimeError, "must not share overlap"):
+        with self.assertRaisesRegex(RuntimeError, "must not overlap"):
             torch.aminmax(x, dim=1, out=(out, out))
 
         buf = torch.empty(5, device=device, dtype=dtype)

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1236,6 +1236,19 @@ class TestReductions(TestCase):
         self.assertEqual(result.min, expected.min)
         self.assertEqual(result.max, expected.max)
 
+        # Non-contiguous outputs must keep working. get_overlap_status reports
+        # TooHard rather than No for these, so a check demanding No would
+        # reject them even though they provably do not overlap.
+        strided = [torch.empty(6, device=device, dtype=dtype)[::2] for _ in range(2)]
+        result = torch.aminmax(x, dim=1, out=(strided[0], strided[1]))
+        self.assertEqual(result.min, expected.min)
+        self.assertEqual(result.max, expected.max)
+
+        buf = torch.empty(6, device=device, dtype=dtype)
+        result = torch.aminmax(x, dim=1, out=(buf[0::2], buf[1::2]))
+        self.assertEqual(result.min, expected.min)
+        self.assertEqual(result.max, expected.max)
+
     # TODO: bincount isn't a classic reduction -- maybe this test suite is
     #   reductions and summary ops?
     @skipIfMPS

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1223,11 +1223,11 @@ class TestReductions(TestCase):
         # `min` and `max` are written independently, so sharing storage makes
         # whichever write lands last clobber the other, silently.
         out = torch.empty(3, device=device, dtype=dtype)
-        with self.assertRaisesRegex(RuntimeError, "must not share memory"):
+        with self.assertRaisesRegex(RuntimeError, "must not share overlap"):
             torch.aminmax(x, dim=1, out=(out, out))
 
         buf = torch.empty(5, device=device, dtype=dtype)
-        with self.assertRaisesRegex(RuntimeError, "must not share memory"):
+        with self.assertRaisesRegex(RuntimeError, "must not overlap"):
             torch.aminmax(x, dim=1, out=(buf[0:3], buf[2:5]))
 
         # Disjoint views of one storage do not overlap and stay allowed.

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1214,6 +1214,28 @@ class TestReductions(TestCase):
         with self.assertRaisesRegex(TypeError, 'not implemented'):
             torch.aminmax(torch.tensor(1., dtype=dtype, device=device), dim=0)
 
+    @onlyNativeDeviceTypes
+    @dtypes(torch.float32)
+    def test_aminmax_out_overlap(self, device, dtype):
+        x = torch.randn(3, 4, device=device, dtype=dtype)
+        expected = torch.aminmax(x, dim=1)
+
+        # `min` and `max` are written independently, so sharing storage makes
+        # whichever write lands last clobber the other, silently.
+        out = torch.empty(3, device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, "must not share memory"):
+            torch.aminmax(x, dim=1, out=(out, out))
+
+        buf = torch.empty(5, device=device, dtype=dtype)
+        with self.assertRaisesRegex(RuntimeError, "must not share memory"):
+            torch.aminmax(x, dim=1, out=(buf[0:3], buf[2:5]))
+
+        # Disjoint views of one storage do not overlap and stay allowed.
+        buf = torch.empty(6, device=device, dtype=dtype)
+        result = torch.aminmax(x, dim=1, out=(buf[0:3], buf[3:6]))
+        self.assertEqual(result.min, expected.min)
+        self.assertEqual(result.max, expected.max)
+
     # TODO: bincount isn't a classic reduction -- maybe this test suite is
     #   reductions and summary ops?
     @skipIfMPS

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3178,6 +3178,10 @@ def error_inputs_aminmax_amax_amin(op_info, device, **kwargs):
     elif op_info.name == 'aminmax':
         yield ErrorInput(SampleInput(input5, kwargs={'dim': 0, 'out': (max_values, min_values)}),
                          error_regex=err_msg_aminmax2)
+        # The two outputs are written independently, so they must not alias.
+        shared = torch.empty(L, dtype=torch.float32, device=device)
+        yield ErrorInput(SampleInput(input5, kwargs={'dim': 0, 'out': (shared, shared)}),
+                         error_regex="must not overlap")
 
     # Error Inputs for functions to raise an error on specified zero'd dimension as reduction dim
     err_msg3 = "reduction"


### PR DESCRIPTION
Fixes #195338.

`torch.aminmax(x, out=(t, t))` silently returned a wrong result. The two outputs are written
independently, so when they share storage whichever write lands last clobbers the other:

```python
>>> torch.manual_seed(0); x = torch.randn(5)
>>> torch.aminmax(x)
torch.return_types.aminmax(min=tensor(-2.1788), max=tensor(1.5410))
>>> t = torch.empty((), dtype=x.dtype)
>>> torch.aminmax(x, out=(t, t))
torch.return_types.aminmax_out(min=tensor(1.5410), max=tensor(1.5410))
```

No error, no warning, and `min > max` is reachable the same way.

`TORCH_META_FUNC(aminmax)` validated each output's dtype but never compared their storage. This
adds that check, using the same `get_overlap_status` machinery `kthvalue` reaches through
`at::assert_no_overlap` (`Sorting.cpp:569`). It does not call that helper directly because its
message describes an *input* aliasing the output, which would point a user at the wrong tensor.

### Why the predicate is `!= Partial && != Full` and not `== No`

`get_overlap_status` returns `TooHard` — not `No` — whenever a tensor has symbolic sizes/strides
or is not non-overlapping-and-dense (`MemoryOverlap.cpp`). Requiring `No` therefore rejects
non-contiguous `out=` tensors that provably do not overlap, and calls under dynamic shapes. Both
of these are correct today and must stay working:

```python
b1, b2 = torch.empty(6), torch.empty(6)
torch.aminmax(x, dim=1, out=(b1[::2], b2[::2]))     # separate storages, strided
b3 = torch.empty(6)
torch.aminmax(x, dim=1, out=(b3[0::2], b3[1::2]))   # one storage, interleaved, disjoint
```

Rejecting only `Partial` and `Full` is what `at::assert_no_overlap` itself does. Both cases are now
in the test, and there is a comment at the predicate, so this does not get tightened by accident.

### Tests

`TestReductions.test_aminmax_out_overlap` covers the same tensor twice, two partially overlapping
views, two disjoint contiguous views, and the two strided cases above. The overlapping case is also
registered in `error_inputs_aminmax_amax_amin`, so the generic `test_errors` harness exercises it
on every device the op is registered for, not just CPU.

```
python -m pytest test/test_reductions.py -k aminmax -q   # 7 passed
python -m pytest test/test_ops.py -k aminmax -q          # 20 passed, 7 skipped
```

Also checked by hand on a CPU build: the reproducer raises; separate `out=`, no-`out=`, `dim=` and
`keepdim=` are unchanged and still match a reference run; partial overlap and full overlap are
rejected; disjoint views of one storage are not.

### One thing this does not cover

`aten.aminmax` is in `core_aten_decompositions` (`torch/_decomp/__init__.py:330`) and its
decomposition computes `amin` and `amax` separately through `out_wrapper`
(`decompositions.py:5652`). That path does not go through this meta function, so tracing/compile
still has the original behaviour. Fixing that belongs
in the decomposition rather than here; happy to follow up if you want it.

Developed with AI assistance (Claude); I reproduced the bug, wrote the fix and ran the tests above.

