### PR TITLE
[MPS] Fix complex std/var to return a real result

### DIFF
--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -370,7 +370,7 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
   // complex input split into real/imaginary parts inside the graph and sum the
   // two variances. The real dtype is used for the output and Bessel constant.
   const bool is_complex = input_t.is_complex();
-  const auto out_dtype = is_complex ? c10::toRealValueType(input_t.scalar_type()) : input_t.scalar_type();
+  const auto out_dtype = c10::toRealValueType(input_t.scalar_type());
 
   using CachedGraph = MPSUnaryCachedGraph;
 

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -485,8 +485,7 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
     }
   }
 
-  Tensor output_t = at::empty(
-      IntArrayRef(output_shape.data(), num_output_dims), out_dtype, std::nullopt, kMPS, std::nullopt, std::nullopt);
+  Tensor output_t = at::empty(IntArrayRef(output_shape.data(), num_output_dims), input_t.options().dtype(out_dtype));
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     output_t.fill_(std::numeric_limits<float>::quiet_NaN());

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -19,7 +19,6 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
-#include <ATen/ops/add.h>
 #include <ATen/ops/all_native.h>
 #include <ATen/ops/amax.h>
 #include <ATen/ops/amax_native.h>
@@ -29,13 +28,11 @@
 #include <ATen/ops/argmax_native.h>
 #include <ATen/ops/argmin_native.h>
 #include <ATen/ops/count_nonzero_native.h>
-#include <ATen/ops/imag.h>
 #include <ATen/ops/max_native.h>
 #include <ATen/ops/mean_native.h>
 #include <ATen/ops/min_native.h>
 #include <ATen/ops/nansum_native.h>
 #include <ATen/ops/prod_native.h>
-#include <ATen/ops/real.h>
 #include <ATen/ops/std_mean_native.h>
 #include <ATen/ops/std_native.h>
 #include <ATen/ops/sum.h>
@@ -368,18 +365,12 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
   TORCH_CHECK_TYPE(input_t.is_floating_point() || input_t.is_complex(),
                    "std and var only support floating point and complex dtypes");
 
-  if (input_t.is_complex()) {
-    // Variance of a complex tensor is real: var(z) = var(Re z) + var(Im z).
-    // MPSGraph's varianceOfTensor computes E[(z - mu)^2] (no conjugation) on
-    // complex input, so decompose into real components like the CPU path does.
-    // TODO: This is correct but slow: at::real/at::imag materialize strided
-    // views that force gathers, and it runs two separate reduction graphs plus
-    // an add. Refactor to a single graph (or a dedicated Metal kernel) that
-    // reduces |z - mu|^2 directly.
-    auto var = at::add(std_var_common_impl_mps(at::real(input_t), dim, correction, keepdim, STANDARD_VARIANCE),
-                       std_var_common_impl_mps(at::imag(input_t), dim, correction, keepdim, STANDARD_VARIANCE));
-    return (stdVarType == STANDARD_DEVIATION) ? var.sqrt() : var;
-  }
+  // Variance of a complex tensor is real: var(z) = var(Re z) + var(Im z).
+  // MPSGraph's varianceOfTensor computes E[(z - mu)^2] (no conjugation), so for
+  // complex input split into real/imaginary parts inside the graph and sum the
+  // two variances. The real dtype is used for the output and Bessel constant.
+  const bool is_complex = input_t.is_complex();
+  const auto out_dtype = is_complex ? c10::toRealValueType(input_t.scalar_type()) : input_t.scalar_type();
 
   using CachedGraph = MPSUnaryCachedGraph;
 
@@ -494,12 +485,8 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
     }
   }
 
-  Tensor output_t = at::empty(IntArrayRef(output_shape.data(), num_output_dims),
-                              input_t.scalar_type(),
-                              std::nullopt,
-                              kMPS,
-                              std::nullopt,
-                              std::nullopt);
+  Tensor output_t = at::empty(
+      IntArrayRef(output_shape.data(), num_output_dims), out_dtype, std::nullopt, kMPS, std::nullopt, std::nullopt);
 
   if (output_t.numel() == 0 || input_t.numel() == 0) {
     output_t.fill_(std::numeric_limits<float>::quiet_NaN());
@@ -521,11 +508,21 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
 
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input_t);
-      MPSGraphTensor* outputVarTensor = [mpsGraph varianceOfTensor:inputTensor axes:wrappedAxes name:nil];
+      MPSGraphTensor* outputVarTensor;
+      if (is_complex) {
+        MPSGraphTensor* reTensor = [mpsGraph realPartOfTensor:inputTensor name:nil];
+        MPSGraphTensor* imTensor = [mpsGraph imaginaryPartOfTensor:inputTensor name:nil];
+        MPSGraphTensor* varRe = [mpsGraph varianceOfTensor:reTensor axes:wrappedAxes name:nil];
+        MPSGraphTensor* varIm = [mpsGraph varianceOfTensor:imTensor axes:wrappedAxes name:nil];
+        outputVarTensor = [mpsGraph additionWithPrimaryTensor:varRe secondaryTensor:varIm name:nil];
+      } else {
+        outputVarTensor = [mpsGraph varianceOfTensor:inputTensor axes:wrappedAxes name:nil];
+      }
       MPSGraphTensor* outputTensor = nil;
 
       if (use_correction && correction_value) {
-        MPSGraphTensor* besselTensor = [mpsGraph constantWithScalar:bessel_correction dataType:getMPSDataType(input_t)];
+        MPSGraphTensor* besselTensor = [mpsGraph constantWithScalar:bessel_correction
+                                                           dataType:getMPSDataType(out_dtype)];
         MPSGraphTensor* correctedTensor = [mpsGraph multiplicationWithPrimaryTensor:outputVarTensor
                                                                     secondaryTensor:besselTensor
                                                                                name:nil];

--- a/aten/src/ATen/native/mps/operations/ReduceOps.mm
+++ b/aten/src/ATen/native/mps/operations/ReduceOps.mm
@@ -19,6 +19,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/add.h>
 #include <ATen/ops/all_native.h>
 #include <ATen/ops/amax.h>
 #include <ATen/ops/amax_native.h>
@@ -28,11 +29,13 @@
 #include <ATen/ops/argmax_native.h>
 #include <ATen/ops/argmin_native.h>
 #include <ATen/ops/count_nonzero_native.h>
+#include <ATen/ops/imag.h>
 #include <ATen/ops/max_native.h>
 #include <ATen/ops/mean_native.h>
 #include <ATen/ops/min_native.h>
 #include <ATen/ops/nansum_native.h>
 #include <ATen/ops/prod_native.h>
+#include <ATen/ops/real.h>
 #include <ATen/ops/std_mean_native.h>
 #include <ATen/ops/std_native.h>
 #include <ATen/ops/sum.h>
@@ -364,6 +367,20 @@ static Tensor std_var_common_impl_mps(const Tensor& input_t,
                                       StdVarType stdVarType) {
   TORCH_CHECK_TYPE(input_t.is_floating_point() || input_t.is_complex(),
                    "std and var only support floating point and complex dtypes");
+
+  if (input_t.is_complex()) {
+    // Variance of a complex tensor is real: var(z) = var(Re z) + var(Im z).
+    // MPSGraph's varianceOfTensor computes E[(z - mu)^2] (no conjugation) on
+    // complex input, so decompose into real components like the CPU path does.
+    // TODO: This is correct but slow: at::real/at::imag materialize strided
+    // views that force gathers, and it runs two separate reduction graphs plus
+    // an add. Refactor to a single graph (or a dedicated Metal kernel) that
+    // reduces |z - mu|^2 directly.
+    auto var = at::add(std_var_common_impl_mps(at::real(input_t), dim, correction, keepdim, STANDARD_VARIANCE),
+                       std_var_common_impl_mps(at::imag(input_t), dim, correction, keepdim, STANDARD_VARIANCE));
+    return (stdVarType == STANDARD_DEVIATION) ? var.sqrt() : var;
+  }
+
   using CachedGraph = MPSUnaryCachedGraph;
 
   IntArrayRef input_shape = input_t.sizes();

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -22316,16 +22316,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
                 unittest.skip('Skipped!'), 'TestReductions', 'test_ref_small_input',
                 device_type='xpu',
                 dtypes=[torch.float64]),
-            # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # The operator 'aten::std.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -22349,16 +22339,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             # FIXME: dim=[] reduces all dimensions
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
-            # MPS: std does not support automatic differentiation for outputs with complex dtype
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     ReductionOpInfo(
@@ -22387,16 +22367,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_duplicate_values'),
             # NumPy is giving NaN for this
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_ref_large_input'),
-            # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_variant_consistency_eager',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_noncontiguous_samples',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
             # NotImplementedError: The operator 'aten::var.correction_out' is not currently implemented for the MPS device
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
             DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
@@ -22420,9 +22390,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
             # FIXME: dim=[] reduces all dimensions
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty'),
             DecorateInfo(unittest.skip("Skipped!"), 'TestReductions', 'test_dim_empty_keepdim'),
-            # RuntimeError: var does not support automatic differentiation for outputs with complex dtype.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', device_type='mps', dtypes=(torch.complex64,)),
         ),
     ),
     ReductionOpInfo(
@@ -26316,27 +26283,12 @@ python_ref_db = [
                 unittest.skip('Skipped!'), 'TestReductions', 'test_ref_small_input',
                 device_type='xpu',
                 dtypes=[torch.float64]),
-            # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     # std_mean and var_mean are not ReductionInfos
     PythonRefInfo(
         "_refs.std_mean",
         torch_opinfo_name="std_mean",
-        skips=(
-            # Exception: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-        ),
     ),
     ReductionPythonRefInfo(
         "_refs.sum",
@@ -26430,26 +26382,12 @@ python_ref_db = [
                 unittest.skip("Skipped!"), 'TestReductions', 'test_ref_small_input'),
             DecorateInfo(
                 unittest.skip("Skipped!"), 'TestReductions', 'test_ref_duplicate_values'),
-            # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
         ),
     ),
     PythonRefInfo(
         "_refs.var_mean",
         torch_opinfo_name="var_mean",
         validate_view_consistency=False,
-        skips=(
-            # torch._subclasses.fake_tensor.MetadataMismatchError: Dtypes torch.float32 and torch.complex64 are not equal!
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_python_ref', device_type='mps', dtypes=(torch.complex64,)),
-            DecorateInfo(
-                unittest.expectedFailure, 'TestCommon', 'test_python_ref_torch_fallback',
-                device_type='mps', dtypes=(torch.complex64,)
-            ),
-        ),
     ),
     #
     # Linear Algebra Operators

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -72,17 +72,9 @@ if torch.backends.mps.is_available():
             "resize_",
             "resize_as_",
             "sparse.sampled_addmm",
-            "std",
-            "std_mean",
-            "std_meanunbiased",
-            "stdunbiased",
             "to",
             "to_sparse",
             "triangular_solve",
-            "var",
-            "var_mean",
-            "var_meanunbiased",
-            "varunbiased",
         }
 
         MACOS_BEFORE_14_4_XFAILLIST = {


### PR DESCRIPTION
`std`/`var` on MPS returned a **complex** tensor for complex input, and the value was wrong. `std_var_common_impl_mps` allocated the output with `input_t.scalar_type()` (complex in -> complex out) and fed the complex tensor straight into MPSGraph's `varianceOfTensor:axes:`, which computes `E[(z - mu)^2]` with no conjugation -- a complex quantity -- instead of the real variance `E[|z - mu|^2]`.

CPU (correctly) returns a real tensor: `var(z) = var(Re z) + var(Im z)`.

## Fix

Mirror the CPU path: for complex input, decompose into real/imaginary parts, run the existing real reduction on each, add them, and take `sqrt` for `std`. Reusing the real code path handles all `dim`/`keepdim`/`correction` combinations and drops the output to the matching real dtype (`complex64 -> float32`, `complex32 -> float16`).

`std`/`var` (and the `_mean`/`unbiased` variants) are removed from `UNSUPPORTED_COMPLEX_OPS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)