### PR TITLE
[guards] Make serialized guards rebuild correctly in a fresh process

### DIFF
--- a/docs/source/user_guide/torch_compiler/torch.compiler_aot_compile.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler_aot_compile.md
@@ -128,6 +128,11 @@ original function but runs the pre-compiled code. It also exposes:
 
 - `save_compiled_function(path)` -- Serialize the compiled artifact to disk.
 - `disable_guard_check()` -- Disable runtime guard validation (advanced use).
+  When several compiled results are loaded into one `AOTCompiledModel`, an
+  opted-out result is only served when it is the sole candidate; if the model
+  holds more than one result and none of their guards match a call, the call
+  raises `RuntimeError` with one line per rejected candidate rather than
+  falling through to the opted-out one.
 
 **Requirements:**
 

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import copy
+import dataclasses
 import functools
 import inspect
 import multiprocessing as mp
@@ -27,6 +28,7 @@ import torch.utils.cpp_extension
 from torch._dynamo.aot_compile import AOTCompiledModel, ModelInput, SerializableCallable
 from torch._dynamo.aot_compile_types import BundledAOTAutogradSerializableCallable
 from torch._dynamo.exc import PackageError, Unsupported
+from torch._dynamo.guards import CheckFunctionManager
 from torch._dynamo.package import DynamoCache
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._functorch.aot_autograd import (
@@ -348,6 +350,92 @@ class SimpleLinearModule(torch.nn.Module):
         return self.linear(x)
 
 
+class ScaleModule(torch.nn.Module):
+    def forward(self, x):
+        return x * 2
+
+
+AOT_HERMETIC_WEIGHT = torch.eye(3)
+
+
+class HermeticModule(torch.nn.Module):
+    def forward(self, x):
+        return x @ AOT_HERMETIC_WEIGHT
+
+
+GLOBAL_POOLING_CONFIG = {"pooling": "sum"}
+
+
+class GlobalConfigModule(torch.nn.Module):
+    def forward(self, x):
+        if GLOBAL_POOLING_CONFIG["pooling"] == "sum":
+            return x.sum(1)
+        return x.mean(1) * 10.0
+
+
+@contextmanager
+def _set_pooling(mode):
+    old = GLOBAL_POOLING_CONFIG["pooling"]
+    GLOBAL_POOLING_CONFIG["pooling"] = mode
+    try:
+        yield
+    finally:
+        GLOBAL_POOLING_CONFIG["pooling"] = old
+
+
+AOT_POOL_MODE = "sum"
+
+
+class GlobalRebindModule(torch.nn.Module):
+    def forward(self, x):
+        if AOT_POOL_MODE == "sum":
+            return x.sum(1)
+        return x.mean(1) * 10.0
+
+
+@contextmanager
+def _set_pool_mode(mode):
+    global AOT_POOL_MODE
+    old = AOT_POOL_MODE
+    AOT_POOL_MODE = mode
+    try:
+        yield
+    finally:
+        AOT_POOL_MODE = old
+
+
+AOT_ABSENT_WEIGHT = torch.eye(3) * 3.0
+
+
+class AbsentGlobalModule(torch.nn.Module):
+    def forward(self, x):
+        return x @ AOT_ABSENT_WEIGHT
+
+
+class ParentWithChildModule(torch.nn.Module):
+    # Calling a CHILD module routes through nn.Module.__call__, whose hook-dict
+    # guards are rooted at Dynamo's synthetic __import_torch_dot_nn_... alias.
+    # That is the shape a reloaded artifact could not resolve.
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+def keep_global_guards(guard_entries):
+    # Same policy the guard serializer enforces: drop only what cannot be
+    # serialized, and in particular keep the global guards that the default
+    # aot_compile filter drops wholesale.
+    unsupported = CheckFunctionManager.UNSUPPORTED_SERIALIZATION_GUARD_TYPES
+    return [
+        g.guard_type not in unsupported
+        and not any(d in unsupported for d in g.derived_guard_types)
+        for g in guard_entries
+    ]
+
+
 class RepeatInterleaveModule(torch.nn.Module):
     def forward(self, x):
         chunk = x.chunk(2, dim=-1)
@@ -574,6 +662,147 @@ def wrap_forward_function(fn: Callable):
 @torch._dynamo.config.patch("enable_aot_compile", True)
 @instantiate_parametrized_tests
 class TestAOTCompile(torch._inductor.test_case.TestCase):
+    def test_aot_compile_module_import_alias_guard_survives_reload(self):
+        # Dynamo mints __import_* aliases into the TRACING process's globals and
+        # roots guards at them. A process that only loads never traced, so the
+        # live module dict this artifact guards against has none of them -- and
+        # every call died on KeyError on G['__import_torch_dot_nn_dot_modules_
+        # dot_module'] before the aliases were seeded. The existing scope tests
+        # cannot see it: the capture in the same process already leaked those
+        # names into this module's globals, so they resolve. Pop them to get
+        # what a fresh process sees.
+        mod = ParentWithChildModule()
+        x = torch.randn(4, 4)
+        expected = mod(x)
+        model = torch.compile(
+            mod,
+            fullgraph=True,
+            backend="eager",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        model._aot_compile([ModelInput(args=(x,), kwargs={}, contexts=[])])
+        data = model._save_aot_compiled_module()
+        torch._dynamo.reset()
+        g = globals()
+        aliases = {k: g.pop(k) for k in [k for k in g if k.startswith("__import_")]}
+        self.assertTrue(aliases, "capture leaked no aliases; the test cannot bite")
+        try:
+            fresh = ParentWithChildModule()
+            fresh.load_state_dict(mod.state_dict())
+            reloaded = torch.compile(
+                fresh,
+                fullgraph=True,
+                backend="eager",
+                options={"guard_filter_fn": keep_global_guards},
+            )
+            reloaded._load_aot_compiled_module(data)
+            self.assertEqual(reloaded(x), expected)
+        finally:
+            g.update(aliases)
+
+    def test_no_match_message_survives_a_raising_guard(self):
+        # __call__ has already established that nothing matched; re-evaluating
+        # the guards to say WHY must not replace that answer with a secondary
+        # failure from one entry, which hides both the entry that raised and
+        # every other entry's reason.
+        class RaisingGuardManager:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def check(self, f_locals):
+                return self._inner.check(f_locals)
+
+            def check_verbose(self, f_locals):
+                raise KeyError("G['SOME_GLOBAL']")
+
+        model = torch.compile(ScaleModule(), fullgraph=True, backend="inductor")
+        model._aot_compile(
+            [
+                ModelInput(
+                    args=(torch.randn(3, 3, dtype=torch.float32),),
+                    kwargs={},
+                    contexts=[],
+                ),
+                ModelInput(
+                    args=(torch.randn(3, 3, dtype=torch.float64),),
+                    kwargs={},
+                    contexts=[],
+                ),
+            ]
+        )
+        results = model.forward.compiled_results
+        results[0]._artifacts.guard_manager = RaisingGuardManager(
+            results[0]._artifacts.guard_manager
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            model(torch.randn(3, 3, dtype=torch.float16))
+        message = str(ctx.exception)
+        self.assertIn("No AOT compiled graph matched this call", message)
+        self.assertIn("KeyError", message)
+        self.assertIn("SOME_GLOBAL", message)
+        # The entry that raised must not swallow the one that can explain itself.
+        self.assertIn("dtype mismatch", message)
+        self.assertEqual(len(message.splitlines()), 4)
+
+    def test_check_compatibility_compares_artifact_against_current_machine(self):
+        # CompileArtifacts.check_compatibility must invoke the CACHED
+        # SystemInfo's method with the current machine as `other`, the way
+        # _DynamoCacheEntry.check_versions does. Reversed, the "artifact
+        # predates cpu_codegen_target" skip is evaluated against the current
+        # machine -- never None -- so every old artifact is rejected, and every
+        # mismatch message reports the two sides the wrong way round.
+        from torch._dynamo.package import SystemInfo
+
+        def fn(x):
+            return x + 1
+
+        compiled = torch.compile(fn, fullgraph=True, backend="eager").aot_compile(
+            ((torch.randn(3, 3),), {})
+        )
+        artifacts = compiled._artifacts
+        self.assertEqual(artifacts.device_type, "cpu")
+        stale = ("mips", "DEFAULT", None, "INVALID", None, None)
+
+        # An eager artifact holds no generated code, so there is no baked vector
+        # width to protect and the comparison must not run at all -- otherwise
+        # capture-here/serve-there, which is the whole point of the feature,
+        # rejects an artifact over a target it never used.
+        self.assertEqual(artifacts.backend_name, "eager")
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=stale
+        )
+        artifacts.check_compatibility()
+
+        # The rest is about the receiver order, which only a native backend
+        # reaches.
+        artifacts.backend_name = "inductor"
+        current_target = SystemInfo.current().cpu_codegen_target
+        if current_target is None:
+            # No usable C++ compiler, so there is no current target to compare
+            # against and the skew arms below have nothing to assert. Skipping
+            # rather than failing is the point of the lazy probe.
+            self.skipTest("no CPU codegen target on this host")
+
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=None
+        )
+        artifacts.check_compatibility()
+
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=stale
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            artifacts.check_compatibility()
+        message = str(ctx.exception)
+        self.assertIn(f"cached={stale}", message)
+        self.assertIn(f"current={current_target}", message)
+
+        artifacts.system_info = dataclasses.replace(
+            artifacts.system_info, cpu_codegen_target=None, torch_version="0.0.0-fake"
+        )
+        with self.assertRaisesRegex(RuntimeError, "0.0.0-fake"):
+            artifacts.check_compatibility()
+
     def path(self):
         path = os.path.join(cache_dir(), f"package_{self.id()}")
         os.makedirs(path, exist_ok=True)
@@ -969,6 +1198,271 @@ from user code:
 
     def test_aot_compile_module(self):
         _run_in_subprocess(_subprocess_aot_compile_module)
+
+    def test_aot_compile_module_dispatches_on_global_guard(self):
+        # The default guard_filter_fn drops all global guards, so a caller who
+        # needs one honored has to opt in. Keeping it only works because
+        # AOTCompiledModel.deserialize supplies the traced function's globals.
+        mod = GlobalConfigModule()
+        model = torch.compile(
+            mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        x = torch.randn(4, 8)
+
+        expected = {}
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                expected[mode] = mod(x)
+        self.assertNotEqual(expected["sum"].tolist(), expected["mean"].tolist())
+
+        model._aot_compile(
+            [
+                ModelInput(args=(x,), kwargs={}, contexts=[_set_pooling("sum")]),
+                ModelInput(args=(x,), kwargs={}, contexts=[_set_pooling("mean")]),
+            ]
+        )
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                self.assertEqual(model(x), expected[mode])
+
+        data = model._save_aot_compiled_module()
+        torch._dynamo.reset()
+        reloaded = torch.compile(
+            GlobalConfigModule(),
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        reloaded._load_aot_compiled_module(data)
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                self.assertEqual(reloaded(x), expected[mode])
+
+    def test_aot_compile_module_no_match_error(self):
+        # Two inputs, so the message has to account for both rather than
+        # reporting only the first one's guard failure. Vary dtype rather than
+        # shape: aot_compile_module does not forward `dynamic`, so a second
+        # shape goes automatic-dynamic and would subsume the unmatched input.
+        model = torch.compile(ScaleModule(), fullgraph=True, backend="inductor")
+        model._aot_compile(
+            [
+                ModelInput(
+                    args=(torch.randn(3, 3, dtype=torch.float32),),
+                    kwargs={},
+                    contexts=[],
+                ),
+                ModelInput(
+                    args=(torch.randn(3, 3, dtype=torch.float64),),
+                    kwargs={},
+                    contexts=[],
+                ),
+            ]
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            model(torch.randn(3, 3, dtype=torch.float16))
+        message = str(ctx.exception)
+        self.assertIn("No AOT compiled graph matched this call", message)
+        self.assertIn("Tried 2 compiled input(s)", message)
+        self.assertIn("[0]", message)
+        self.assertIn("[1]", message)
+        # One line per input, not a multi-line GuardDebugInfo repr per input.
+        self.assertEqual(len(message.splitlines()), 4)
+
+    def test_aot_compile_module_disable_guard_check(self):
+        # disable_guard_check() is the escape hatch for an artifact whose guards
+        # fail on the serving machine; module dispatch has to honour it too, or
+        # a module artifact has no opt-out while a function artifact does.
+        model = torch.compile(ScaleModule(), fullgraph=True, backend="inductor")
+        model._aot_compile(
+            [ModelInput(args=(torch.randn(3, 3),), kwargs={}, contexts=[])]
+        )
+        # requires_grad is guarded but does not change what the graph computes.
+        x = torch.randn(3, 3, requires_grad=True)
+        with self.assertRaisesRegex(RuntimeError, "No AOT compiled graph matched"):
+            model(x)
+        model.forward.compiled_results[0].disable_guard_check()
+        self.assertEqual(model(x), x * 2)
+
+    def test_disable_guard_check_does_not_shadow_a_matching_result(self):
+        # An opted-out result accepts anything, so it has to be the last resort
+        # rather than a candidate in the ordinary scan: consulting it before
+        # every real guard check has been tried serves the first artifact for a
+        # call the second one was compiled for. Same shapes, same dtypes, no
+        # error, different numbers.
+        mod = GlobalConfigModule()
+        model = torch.compile(
+            mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        x = torch.randn(4, 8)
+        expected = {}
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                expected[mode] = mod(x)
+        self.assertNotEqual(expected["sum"].tolist(), expected["mean"].tolist())
+
+        model._aot_compile(
+            [
+                ModelInput(args=(x,), kwargs={}, contexts=[_set_pooling("sum")]),
+                ModelInput(args=(x,), kwargs={}, contexts=[_set_pooling("mean")]),
+            ]
+        )
+        model.forward.compiled_results[0].disable_guard_check()
+        with _set_pooling("mean"):
+            self.assertEqual(model(x), expected["mean"])
+
+    def test_aot_compile_module_scope_resolves_through_forward_hook(self):
+        # A registered forward hook makes get_traced_fn(model) return
+        # Module._wrapped_call_impl, whose globals are torch/nn/modules/module.py.
+        # The guard scope has to come from what was actually traced, model.forward.
+        #
+        # The hook is deliberately the identity: aot_compile_module traces
+        # model.forward directly and never runs hooks, so a hook with an effect
+        # would simply be dropped from the compiled result. This pins the guard
+        # SCOPE resolution on a hooked module, not hook support.
+        mod = GlobalConfigModule()
+        mod.register_forward_hook(lambda m, i, o: o)
+        model = torch.compile(
+            mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        x = torch.randn(4, 8)
+        expected = {}
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                expected[mode] = mod(x)
+
+        model._aot_compile(
+            [
+                ModelInput(args=(x,), kwargs={}, contexts=[_set_pooling(m)])
+                for m in ("sum", "mean")
+            ]
+        )
+        data = model._save_aot_compiled_module()
+        torch._dynamo.reset()
+        reloaded_mod = GlobalConfigModule()
+        reloaded_mod.register_forward_hook(lambda m, i, o: o)
+        reloaded = torch.compile(
+            reloaded_mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        reloaded._load_aot_compiled_module(data)
+        for mode in ("sum", "mean"):
+            with _set_pooling(mode):
+                self.assertEqual(reloaded(x), expected[mode])
+
+    def test_aot_compile_module_reload_is_hermetic(self):
+        # The graph's own globals must stay as serialized. Supplying a scope for
+        # guards must not rewire what the compiled bytecode reads, or a reloaded
+        # artifact silently recomputes against the loading process's state. The
+        # rebind has to happen before the load: deserialization copies the scope
+        # into the reconstructed function's globals, so rebinding afterwards is
+        # invisible whether or not the two scopes are wired together.
+        global AOT_HERMETIC_WEIGHT
+        model = torch.compile(HermeticModule(), fullgraph=True, backend="inductor")
+        x = torch.randn(3, 3)
+        expected = model._orig_mod(x)
+        model._aot_compile([ModelInput(args=(x,), kwargs={}, contexts=[])])
+        data = model._save_aot_compiled_module()
+
+        torch._dynamo.reset()
+        saved = AOT_HERMETIC_WEIGHT
+        try:
+            AOT_HERMETIC_WEIGHT = AOT_HERMETIC_WEIGHT * 2
+            reloaded = torch.compile(
+                HermeticModule(), fullgraph=True, backend="inductor"
+            )
+            reloaded._load_aot_compiled_module(data)
+            self.assertEqual(reloaded(x), expected)
+        finally:
+            AOT_HERMETIC_WEIGHT = saved
+
+    def test_aot_compile_module_guards_track_rebound_global(self):
+        # The other half of hermeticity. Guards resolve against the loading
+        # process's scope dict itself, so a global rebound after the artifact is
+        # loaded redirects dispatch. A copy taken at load time would go on
+        # serving whichever graph matched then, with no error and a wrong answer.
+        global AOT_POOL_MODE
+        mod = GlobalRebindModule()
+        x = torch.randn(4, 8)
+        expected = {}
+        for mode in ("sum", "mean"):
+            with _set_pool_mode(mode):
+                expected[mode] = mod(x)
+        self.assertNotEqual(expected["sum"].tolist(), expected["mean"].tolist())
+
+        model = torch.compile(
+            mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        model._aot_compile(
+            [
+                ModelInput(args=(x,), kwargs={}, contexts=[_set_pool_mode(m)])
+                for m in ("sum", "mean")
+            ]
+        )
+        data = model._save_aot_compiled_module()
+
+        torch._dynamo.reset()
+        saved = AOT_POOL_MODE
+        try:
+            AOT_POOL_MODE = "sum"
+            reloaded = torch.compile(
+                GlobalRebindModule(),
+                fullgraph=True,
+                backend="inductor",
+                options={"guard_filter_fn": keep_global_guards},
+            )
+            reloaded._load_aot_compiled_module(data)
+            self.assertEqual(reloaded(x), expected["sum"])
+            AOT_POOL_MODE = "mean"
+            self.assertEqual(reloaded(x), expected["mean"])
+        finally:
+            AOT_POOL_MODE = saved
+
+    def test_aot_compile_module_absent_global_fails_guard(self):
+        # A guarded global the loading process does not have has to fail the
+        # guard. Falling back to the serialized scope would make the guard a
+        # no-op checked against capture-time state, which is the silent failure
+        # mode -- the loud one is recoverable on the serving machine.
+        mod = AbsentGlobalModule()
+        x = torch.randn(3, 3)
+        model = torch.compile(
+            mod,
+            fullgraph=True,
+            backend="inductor",
+            options={"guard_filter_fn": keep_global_guards},
+        )
+        model._aot_compile([ModelInput(args=(x,), kwargs={}, contexts=[])])
+        data = model._save_aot_compiled_module()
+
+        torch._dynamo.reset()
+        saved = globals().pop("AOT_ABSENT_WEIGHT")
+        try:
+            reloaded = torch.compile(
+                AbsentGlobalModule(),
+                fullgraph=True,
+                backend="inductor",
+                options={"guard_filter_fn": keep_global_guards},
+            )
+            reloaded._load_aot_compiled_module(data)
+            with self.assertRaises(RuntimeError) as ctx:
+                reloaded(x)
+            self.assertIn("No AOT compiled graph matched", str(ctx.exception))
+            self.assertIn("AOT_ABSENT_WEIGHT", str(ctx.exception))
+        finally:
+            globals()["AOT_ABSENT_WEIGHT"] = saved
 
     def test_aot_module_simplified_serializable_autograd(self):
         mod = SimpleLinearModule()

--- a/test/dynamo/test_aot_compile.py
+++ b/test/dynamo/test_aot_compile.py
@@ -662,6 +662,14 @@ def wrap_forward_function(fn: Callable):
 @torch._dynamo.config.patch("enable_aot_compile", True)
 @instantiate_parametrized_tests
 class TestAOTCompile(torch._inductor.test_case.TestCase):
+    def assertNoMatchReportShape(self, message, num_candidates):
+        lines = message.splitlines()
+        self.assertEqual(len(lines), num_candidates + 2, message)
+        self.assertTrue(lines[0].startswith("No AOT compiled graph matched"), lines[0])
+        for i in range(num_candidates):
+            self.assertTrue(lines[i + 1].startswith(f"  [{i}] "), lines[i + 1])
+        self.assertTrue(lines[-1].startswith("Add a ModelInput"), lines[-1])
+
     def test_aot_compile_module_import_alias_guard_survives_reload(self):
         # Dynamo mints __import_* aliases into the TRACING process's globals and
         # roots guards at them. A process that only loads never traced, so the
@@ -742,7 +750,7 @@ class TestAOTCompile(torch._inductor.test_case.TestCase):
         self.assertIn("SOME_GLOBAL", message)
         # The entry that raised must not swallow the one that can explain itself.
         self.assertIn("dtype mismatch", message)
-        self.assertEqual(len(message.splitlines()), 4)
+        self.assertNoMatchReportShape(message, num_candidates=2)
 
     def test_check_compatibility_compares_artifact_against_current_machine(self):
         # CompileArtifacts.check_compatibility must invoke the CACHED
@@ -1269,7 +1277,25 @@ from user code:
         self.assertIn("[0]", message)
         self.assertIn("[1]", message)
         # One line per input, not a multi-line GuardDebugInfo repr per input.
-        self.assertEqual(len(message.splitlines()), 4)
+        self.assertNoMatchReportShape(message, num_candidates=2)
+
+    def test_disable_guard_check_is_ignored_with_several_candidates_on_a_miss(self):
+        # With more than one result loaded, an opted-out result is not a
+        # fallback for a call none of them matched: the opt-out says nothing
+        # about which graph the call belongs to, so the miss is reported.
+        model = torch.compile(ScaleModule(), fullgraph=True, backend="inductor")
+        model._aot_compile(
+            [
+                ModelInput(
+                    args=(torch.randn(3, 3, dtype=dtype),), kwargs={}, contexts=[]
+                )
+                for dtype in (torch.float32, torch.float64)
+            ]
+        )
+        model.forward.compiled_results[0].disable_guard_check()
+        with self.assertRaisesRegex(RuntimeError, "Tried 2 compiled input") as ctx:
+            model(torch.randn(3, 3, dtype=torch.float16))
+        self.assertNoMatchReportShape(str(ctx.exception), num_candidates=2)
 
     def test_aot_compile_module_disable_guard_check(self):
         # disable_guard_check() is the escape hatch for an artifact whose guards

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1,6 +1,8 @@
 # Owner(s): ["module: dynamo"]
 
 import dataclasses
+import functools
+import io
 import itertools
 import pickle
 import sys
@@ -67,6 +69,222 @@ class GlobalNestedModule(torch.nn.Module):
 
 def global_func(x):
     return x + 1
+
+
+def keep_defaults(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if len(func.__defaults__) == 2:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_kwdefaults(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__kwdefaults__["scale"] == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_attribute(func):
+    func.scale_flag = 2.0
+
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.scale_flag == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_name(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "forward":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_renamed_name(func):
+    # __name__ reassigned away from co_name, so a reconstruction that falls back
+    # to code.co_name reads "forward" where the real function says otherwise.
+    # keep_name alone cannot catch that: there the two agree.
+    func.__name__ = "renamed_forward"
+
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "renamed_forward":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+FQN_MISMATCH_GLOBAL = 2
+
+
+def keep_global(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__globals__["FQN_MISMATCH_GLOBAL"] == 2:
+            x = x + 10
+        return func(self, x)
+
+    return wrapper
+
+
+def keep_globals_length(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        return func(self, x) + len(func.__globals__)
+
+    return wrapper
+
+
+class UnpicklableDefault:
+    def __reduce__(self):
+        raise RuntimeError("unrelated default cannot pickle")
+
+
+def keep_name_with_unpicklable_default(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "forward":
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+class DecoratedForwardModule(torch.nn.Module):
+    # forward is the wrapper; the undecorated function it closes over has the
+    # same __qualname__ but is unreachable from the module, which is what makes
+    # it unpicklable by reference.
+    @keep_defaults
+    def forward(self, x, scale=2.0, shift=1.0):
+        return x * scale + shift
+
+
+class DecoratedKwdefaultsForwardModule(torch.nn.Module):
+    @keep_kwdefaults
+    def forward(self, x, *, scale=2.0):
+        return x * scale
+
+
+class DecoratedAttributeForwardModule(torch.nn.Module):
+    @keep_attribute
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedNameForwardModule(torch.nn.Module):
+    @keep_name
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedRenamedNameForwardModule(torch.nn.Module):
+    @keep_renamed_name
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedGlobalForwardModule(torch.nn.Module):
+    @keep_global
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedGlobalsLengthForwardModule(torch.nn.Module):
+    @keep_globals_length
+    def forward(self, x):
+        return x * 2
+
+
+class DecoratedUnpicklableDefaultForwardModule(torch.nn.Module):
+    @keep_name_with_unpicklable_default
+    def forward(self, x, unused=UnpicklableDefault()):
+        return x * 2
+
+
+# --- module-scope wrappers that reach themselves through their own globals ---
+# `wrapped = deco(base)` at module scope: the wrapper is reachable from its own
+# __globals__, so a globals snapshot passed as a reduce ARG contains the very
+# object being reduced. pickle memoizes only after saving args, so that recursed
+# forever; two wrappers referencing each other do it across the pair.
+MODULE_SCOPE_CONST = 2
+
+
+def module_scope_wrapper(func):
+    @functools.wraps(func)
+    def wrapper(x):
+        # Roots a guard at func.__globals__, which forces the snapshot -- and
+        # the snapshot contains the wrappers themselves.
+        if func.__globals__["MODULE_SCOPE_CONST"] == 2:
+            x = x + 1
+        return func(x)
+
+    return wrapper
+
+
+def _module_scope_base_a(x):
+    return x * 2
+
+
+def _module_scope_base_b(x):
+    return x * 3
+
+
+MODULE_SCOPE_WRAPPED_A = module_scope_wrapper(_module_scope_base_a)
+MODULE_SCOPE_WRAPPED_B = module_scope_wrapper(_module_scope_base_b)
+
+
+# --- an empty closure cell -------------------------------------------------
+def keep_name_with_empty_cell(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__name__ == "forward":
+            x = x + 1
+        if x is None:
+            return unset
+        return func(self, x)
+
+    if func is None:
+        unset = 1  # never runs, so the cell wrapper closes over stays EMPTY
+
+    return wrapper
+
+
+def _empty_cell_base(self, x):
+    return x * 2
+
+
+EMPTY_CELL_WRAPPED = keep_name_with_empty_cell(_empty_cell_base)
+
+
+# --- a guarded default whose VALUE must survive, not just the tuple length --
+def keep_default_value(func):
+    @functools.wraps(func)
+    def wrapper(self, x):
+        if func.__defaults__[0] == 2.0:
+            x = x + 1
+        return func(self, x)
+
+    return wrapper
+
+
+class DecoratedDefaultValueForwardModule(torch.nn.Module):
+    @keep_default_value
+    def forward(self, x, scale=2.0):
+        return x * scale
 
 
 class ModuleNotSerializable(torch.nn.Module):
@@ -484,6 +702,181 @@ class TestGuardSerialization(TestGuardSerializationBase):
             return g(x) + 1
 
         self._test_serialization("TENSOR_MATCH", fn, torch.randn(3), foo)
+
+    def test_guard_rooted_at_module_scope_wrappers_that_reach_themselves(self):
+        # Driven through a real capture, not the pickler: two functools.wraps
+        # helpers bound at module scope and called from one compiled frame is
+        # ordinary code, and the globals snapshot each one carries contains
+        # both of them. Passing that snapshot as a reduce ARG recursed until
+        # RecursionError; it goes in reduce STATE, which pickle applies after
+        # memoizing, so the references resolve to the functions it already
+        # built.
+        def fn(x):
+            return MODULE_SCOPE_WRAPPED_A(x) + MODULE_SCOPE_WRAPPED_B(x)
+
+        x = torch.randn(3)
+        ref, loaded = self._test_serialization("EQUALS_MATCH", fn, x)
+        self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, True)
+
+    def test_reducer_handles_an_empty_cell_reached_directly(self):
+        # _reduce_cell only covers cells it builds for a reconstructed
+        # function. A cell reached directly -- a guarded __closure__ tuple, or
+        # the cell itself -- goes through reducer_override's CellType branch,
+        # which read cell_contents unguarded and raised ValueError out of the
+        # pickler, i.e. a package bypass. Pickler-level because a guard cannot
+        # root at a raw cell through a capture: CLOSURE_MATCH is dropped.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        empty = [
+            c for c in EMPTY_CELL_WRAPPED.__closure__ if not self._cell_has_contents(c)
+        ]
+        self.assertEqual(len(empty), 1)
+        buf = io.BytesIO()
+        GuardsStatePickler({}, {}, {}, buf).dump({"cell": empty[0]})
+        self.assertGreater(len(buf.getvalue()), 0)
+
+    def test_reduce_handles_an_empty_closure_cell(self):
+        # A free variable a decorator only assigns on a path that did not run
+        # has no contents; reading it raised ValueError out of the reducer,
+        # which reaches the caller as a package bypass.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        wrapped = EMPTY_CELL_WRAPPED
+        empty = [c for c in wrapped.__closure__ if not self._cell_has_contents(c)]
+        self.assertEqual(len(empty), 1)
+        gtv = {id(wrapped): wrapped}
+        buf = io.BytesIO()
+        GuardsStatePickler(gtv, {}, {}, buf).dump({"fn": wrapped})
+        self.assertGreater(len(buf.getvalue()), 0)
+
+    @staticmethod
+    def _cell_has_contents(cell):
+        try:
+            cell.cell_contents
+        except ValueError:
+            return False
+        return True
+
+    def test_fqn_mismatched_function_preserves_a_guarded_default_value(self):
+        # The SEQUENCE_LENGTH test pins the defaults TUPLE's length. This pins
+        # that a guarded element's value survives: forcing every default to
+        # _Missing passes that one and fails this one.
+        mod = DecoratedDefaultValueForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_keeps_a_shared_closure_cell_shared(self):
+        # Two functions closing over one variable must still share the cell
+        # after reload; rebuilding every cell silently unshares them.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        def outer():
+            shared = torch.zeros(2)
+
+            def a():
+                return shared
+
+            def b():
+                return shared
+
+            return a, b
+
+        a, b = outer()
+        self.assertIs(a.__closure__[0], b.__closure__[0])
+        buf = io.BytesIO()
+        cell = a.__closure__[0]
+        gtv = {id(a): a, id(b): b, id(cell): cell}
+        pickler = GuardsStatePickler(gtv, {}, {}, buf)
+        pickler.dump({"a": a, "b": b})
+        out = pickle.loads(buf.getvalue())
+        self.assertIs(out["a"].__closure__[0], out["b"].__closure__[0])
+
+    def test_guard_rooted_at_fqn_mismatched_function(self):
+        mod = DecoratedForwardModule()
+        ref, loaded = self._test_serialization("SEQUENCE_LENGTH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_kwdefaults(self):
+        mod = DecoratedKwdefaultsForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_attributes(self):
+        mod = DecoratedAttributeForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_name(self):
+        mod = DecoratedNameForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_a_renamed_name(self):
+        # keep_name's __name__ happens to equal co_name, so it passes even if
+        # reconstruction falls back to co_name. This one does not.
+        mod = DecoratedRenamedNameForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self.assertNotEqual(inner.__name__, inner.__code__.co_name)
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_preserves_guarded_globals(self):
+        global FQN_MISMATCH_GLOBAL
+
+        mod = DecoratedGlobalForwardModule()
+        x = torch.ones(1)
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, x)
+        inner = type(mod).forward.__wrapped__
+        inputs = {"self": mod, "x": x, "func": inner}
+        self._test_check_fn(ref, loaded, inputs, True)
+
+        try:
+            FQN_MISMATCH_GLOBAL = 3
+            self.assertFalse(ref.check(inputs))
+            guards_state = torch._dynamo.package.load_guards_state(
+                self._cached_guards_state
+            )
+            loaded = torch._dynamo.package.load_guard_manager(
+                guards_state,
+                self._cached_f_code,
+                globals(),
+            )
+            self.assertFalse(loaded.check(inputs))
+        finally:
+            FQN_MISMATCH_GLOBAL = 2
+
+    def test_fqn_mismatched_function_preserves_globals_structure(self):
+        mod = DecoratedGlobalsLengthForwardModule()
+        ref, loaded = self._test_serialization("DICT_KEYS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
+
+    def test_fqn_mismatched_function_prunes_unguarded_defaults(self):
+        mod = DecoratedUnpicklableDefaultForwardModule()
+        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+        inner = type(mod).forward.__wrapped__
+        self._test_check_fn(
+            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
+        )
 
     def test_tensor_match(self):
         def f(x: torch.Tensor):

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -34,8 +34,11 @@ from torch._dynamo.utils import dynamo_timed, get_metrics_context
 from torch._guards import compile_context, CompileContext, tracing
 from torch.overrides import TorchFunctionMode
 from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
     IS_LINUX,
     IS_MACOS,
+    parametrize,
+    subtest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
 )
@@ -154,16 +157,6 @@ class UnpicklableDefault:
         raise RuntimeError("unrelated default cannot pickle")
 
 
-def keep_name_with_unpicklable_default(func):
-    @functools.wraps(func)
-    def wrapper(self, x):
-        if func.__name__ == "forward":
-            x = x + 1
-        return func(self, x)
-
-    return wrapper
-
-
 class DecoratedForwardModule(torch.nn.Module):
     # forward is the wrapper; the undecorated function it closes over has the
     # same __qualname__ but is unreachable from the module, which is what makes
@@ -210,7 +203,7 @@ class DecoratedGlobalsLengthForwardModule(torch.nn.Module):
 
 
 class DecoratedUnpicklableDefaultForwardModule(torch.nn.Module):
-    @keep_name_with_unpicklable_default
+    @keep_name
     def forward(self, x, unused=UnpicklableDefault()):
         return x * 2
 
@@ -312,6 +305,24 @@ def _self_referencing_base(x):
 
 
 SELF_REFERENCING_WRAPPED = self_referencing_wrapper(_self_referencing_base)
+
+
+def _make_function_cycle():
+    # The wrapper closes over the base and the base holds the wrapper in its
+    # __dict__, so the cycle runs through the closure of one and the attributes
+    # of the other. Neither is reachable by fqn, so both are reconstructed.
+    def base(x):
+        return x * 2
+
+    @functools.wraps(base)
+    def wrapper(x):
+        return base(x) + 1
+
+    base.wrapper = wrapper
+    return base, wrapper
+
+
+CYCLE_BASE, CYCLE_WRAPPER = _make_function_cycle()
 
 
 # --- an empty closure cell -------------------------------------------------
@@ -760,6 +771,7 @@ class TestGuardSerializationBase(torch._inductor.test_case.TestCase):
 
 
 @torch._dynamo.config.patch({"strict_precompile": True})
+@instantiate_parametrized_tests
 class TestGuardSerialization(TestGuardSerializationBase):
     def test_function_locals(self):
         def foo(x):
@@ -823,10 +835,11 @@ class TestGuardSerialization(TestGuardSerializationBase):
         self.assertTrue(any(contents is got for contents in cells))
 
     def test_a_shared_closure_cell_survives_a_self_reference(self):
-        # The self-reference fix builds a placeholder cell, so it must not cost
-        # the sharing that _reduce_cell passes cells through unchanged to keep:
-        # two functions closing over one variable must still close over ONE
-        # cell after the round trip.
+        # A cell's CONTENTS travel in the owning function's state, so the cell
+        # itself comes back empty -- that must not cost the sharing keeping the
+        # cell object in the reduce args exists to preserve: two functions
+        # closing over one variable must still close over ONE cell after the
+        # round trip.
         from torch._dynamo.guards import GuardsStatePickler
 
         def pair():
@@ -865,7 +878,7 @@ class TestGuardSerialization(TestGuardSerializationBase):
             ):
                 _REDUCE_RAISES = exc_type
                 with self.subTest(exc=exc_type.__name__):
-                    with self.assertRaises(exc_type):
+                    with self.assertRaisesRegex(exc_type, "from __reduce__"):
                         _dump_through_pickle_guards_state(_RaisesFromReduce())
 
             # ... while an ordinary failure inside __reduce__ still becomes one.
@@ -878,17 +891,15 @@ class TestGuardSerialization(TestGuardSerializationBase):
             _REDUCE_RAISES = original
 
     def test_reducer_handles_an_empty_cell_reached_directly(self):
-        # _reduce_cell only covers cells it builds for a reconstructed
-        # function. A cell reached directly -- a guarded __closure__ tuple, or
-        # the cell itself -- goes through reducer_override's CellType branch,
+        # A cell in a reconstructed function's closure is filled from that
+        # function's state. A cell reached directly -- a guarded __closure__
+        # tuple, or the cell itself -- goes through reducer_override's branch,
         # which read cell_contents unguarded and raised ValueError out of the
         # pickler, i.e. a package bypass. Pickler-level because a guard cannot
         # root at a raw cell through a capture: CLOSURE_MATCH is dropped.
         from torch._dynamo.guards import GuardsStatePickler
 
-        empty = [
-            c for c in EMPTY_CELL_WRAPPED.__closure__ if not self._cell_has_contents(c)
-        ]
+        empty = [c for c in EMPTY_CELL_WRAPPED.__closure__ if not _cell_is_full(c)]
         self.assertEqual(len(empty), 1)
         buf = io.BytesIO()
         GuardsStatePickler({}, {}, {}, buf).dump({"cell": empty[0]})
@@ -901,31 +912,12 @@ class TestGuardSerialization(TestGuardSerializationBase):
         from torch._dynamo.guards import GuardsStatePickler
 
         wrapped = EMPTY_CELL_WRAPPED
-        empty = [c for c in wrapped.__closure__ if not self._cell_has_contents(c)]
+        empty = [c for c in wrapped.__closure__ if not _cell_is_full(c)]
         self.assertEqual(len(empty), 1)
         gtv = {id(wrapped): wrapped}
         buf = io.BytesIO()
         GuardsStatePickler(gtv, {}, {}, buf).dump({"fn": wrapped})
         self.assertGreater(len(buf.getvalue()), 0)
-
-    @staticmethod
-    def _cell_has_contents(cell):
-        try:
-            cell.cell_contents
-        except ValueError:
-            return False
-        return True
-
-    def test_fqn_mismatched_function_preserves_a_guarded_default_value(self):
-        # The SEQUENCE_LENGTH test pins the defaults TUPLE's length. This pins
-        # that a guarded element's value survives: forcing every default to
-        # _Missing passes that one and fails this one.
-        mod = DecoratedDefaultValueForwardModule()
-        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
-        inner = type(mod).forward.__wrapped__
-        self._test_check_fn(
-            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
-        )
 
     def test_fqn_mismatched_function_keeps_a_shared_closure_cell_shared(self):
         # Two functions closing over one variable must still share the cell
@@ -953,33 +945,36 @@ class TestGuardSerialization(TestGuardSerializationBase):
         out = pickle.loads(buf.getvalue())
         self.assertIs(out["a"].__closure__[0], out["b"].__closure__[0])
 
-    def test_guard_rooted_at_fqn_mismatched_function(self):
-        mod = DecoratedForwardModule()
-        ref, loaded = self._test_serialization("SEQUENCE_LENGTH", mod, torch.randn(3))
-        inner = type(mod).forward.__wrapped__
-        self._test_check_fn(
-            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
-        )
-
-    def test_fqn_mismatched_function_preserves_kwdefaults(self):
-        mod = DecoratedKwdefaultsForwardModule()
-        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
-        inner = type(mod).forward.__wrapped__
-        self._test_check_fn(
-            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
-        )
-
-    def test_fqn_mismatched_function_preserves_attributes(self):
-        mod = DecoratedAttributeForwardModule()
-        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
-        inner = type(mod).forward.__wrapped__
-        self._test_check_fn(
-            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
-        )
-
-    def test_fqn_mismatched_function_preserves_name(self):
-        mod = DecoratedNameForwardModule()
-        ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
+    @parametrize(
+        "module_type,guard_type",
+        [
+            # The defaults TUPLE's length, and separately the VALUE of a guarded
+            # element: forcing every default to _Missing passes the first and
+            # fails the second.
+            subtest((DecoratedForwardModule, "SEQUENCE_LENGTH"), name="defaults"),
+            subtest(
+                (DecoratedDefaultValueForwardModule, "EQUALS_MATCH"),
+                name="default_value",
+            ),
+            subtest(
+                (DecoratedKwdefaultsForwardModule, "EQUALS_MATCH"), name="kwdefaults"
+            ),
+            subtest(
+                (DecoratedAttributeForwardModule, "EQUALS_MATCH"), name="attribute"
+            ),
+            subtest((DecoratedNameForwardModule, "EQUALS_MATCH"), name="name"),
+            subtest(
+                (DecoratedGlobalsLengthForwardModule, "DICT_KEYS_MATCH"),
+                name="globals_structure",
+            ),
+        ],
+    )
+    def test_guard_rooted_at_fqn_mismatched_function(self, module_type, guard_type):
+        # forward is a functools.wraps wrapper, so the function it closes over is
+        # unreachable by fqn and has to be reconstructed. Each case guards a
+        # different piece of what the reconstruction must carry with it.
+        mod = module_type()
+        ref, loaded = self._test_serialization(guard_type, mod, torch.randn(3))
         inner = type(mod).forward.__wrapped__
         self._test_check_fn(
             ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
@@ -1021,14 +1016,6 @@ class TestGuardSerialization(TestGuardSerializationBase):
         finally:
             FQN_MISMATCH_GLOBAL = 2
 
-    def test_fqn_mismatched_function_preserves_globals_structure(self):
-        mod = DecoratedGlobalsLengthForwardModule()
-        ref, loaded = self._test_serialization("DICT_KEYS_MATCH", mod, torch.randn(3))
-        inner = type(mod).forward.__wrapped__
-        self._test_check_fn(
-            ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
-        )
-
     def test_fqn_mismatched_function_prunes_unguarded_defaults(self):
         mod = DecoratedUnpicklableDefaultForwardModule()
         ref, loaded = self._test_serialization("EQUALS_MATCH", mod, torch.randn(3))
@@ -1036,6 +1023,39 @@ class TestGuardSerialization(TestGuardSerializationBase):
         self._test_check_fn(
             ref, loaded, {"self": mod, "x": torch.randn(3), "func": inner}, True
         )
+
+    def test_two_functions_that_reference_each_other(self):
+        # Deferring to state used to be conditional on a DIRECT self-reference,
+        # which a PAIR does not have: the wrapper's cell reaches the base, whose
+        # __dict__ reaches the wrapper, and neither is memoized while its own
+        # args are being saved, so the pair recursed until RecursionError. Only
+        # the code, the names and the cells travel in args now.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        base, wrapper = CYCLE_BASE, CYCLE_WRAPPER
+        cell = wrapper.__closure__[0]
+        gtv = {id(base): base, id(wrapper): wrapper, id(cell): cell}
+        buf = io.BytesIO()
+        GuardsStatePickler(gtv, {}, {}, buf).dump({"wrapper": wrapper})
+        got = pickle.loads(buf.getvalue())["wrapper"]
+        inner = got.__closure__[0].cell_contents
+        self.assertIs(inner.wrapper, got)
+        self.assertEqual(got(torch.ones(1)), torch.full((1,), 3.0))
+
+    def test_a_reconstructed_function_keeps_its_module(self):
+        # A guarded __globals__ makes the function rebuild from a globals
+        # SNAPSHOT, and FunctionType reads __module__ out of globals["__name__"],
+        # which a snapshot has no reason to contain -- so __module__ came back
+        # None and a guard reading it could never match.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        w = SELF_REFERENCING_WRAPPED
+        buf = io.BytesIO()
+        gtv = {id(w): w, id(w.__globals__): w.__globals__}
+        GuardsStatePickler(gtv, {}, {}, buf).dump({"fn": w})
+        got = pickle.loads(buf.getvalue())["fn"]
+        self.assertEqual(got.__module__, w.__module__)
+        self.assertEqual(got.__doc__, w.__doc__)
 
     def test_tensor_match(self):
         def f(x: torch.Tensor):

--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -247,6 +247,73 @@ MODULE_SCOPE_WRAPPED_A = module_scope_wrapper(_module_scope_base_a)
 MODULE_SCOPE_WRAPPED_B = module_scope_wrapper(_module_scope_base_b)
 
 
+# The pickler refuses a locally-defined class before __reduce__ ever runs, so
+# a value whose __reduce__ is the thing under test has to live at module scope.
+_REDUCE_RAISES: type[BaseException] = AssertionError
+
+
+class _RaisesFromReduce:
+    def __reduce__(self):
+        raise _REDUCE_RAISES("from __reduce__")
+
+
+def _cell_is_full(cell):
+    try:
+        cell.cell_contents
+    except ValueError:
+        return False
+    return True
+
+
+def _dump_through_pickle_guards_state(value):
+    """Run ``value`` through pickle_guards_state's try/except.
+
+    A capture cannot reach that handler with an arbitrary exception -- Dynamo
+    would have to raise it from inside a guarded value's __reduce__ mid-trace
+    -- so the state is assembled directly. Only the fields the function reads
+    are populated; the point is which exceptions cross the handler, not what a
+    real GuardsState contains.
+    """
+    from torch._dynamo.guards import GuardsState, pickle_guards_state
+
+    graph = types.SimpleNamespace(
+        guards=[],
+        local_scope={"value": value},
+        global_scope={},
+        guard_on_key_order=set(),
+    )
+    # Kept, not pruned: an unguarded value is replaced by a _Missing sentinel
+    # and its __reduce__ never runs, so the handler is never reached.
+    builder = types.SimpleNamespace(guard_tree_values={id(value): value})
+    state = GuardsState(output_graph=graph, shape_code_parts=None)
+    return pickle_guards_state(state, builder)
+
+
+def self_referencing_wrapper(func):
+    # The wrapper reads an attribute off ITSELF, so `wrapper` becomes one of
+    # its own free variables and the cell holds the object being reduced. A
+    # counter or a cache on the wrapper is the ordinary way a decorator does
+    # this; functools.wraps then makes it fqn-unreachable, which is exactly
+    # the shape the reducer reconstructs.
+    @functools.wraps(func)
+    def wrapper(x):
+        wrapper.calls += 1
+        if func.__globals__["MODULE_SCOPE_CONST"] == 2:
+            x = x + 1
+        return func(x)
+
+    wrapper.calls = 0
+    wrapper.me = wrapper
+    return wrapper
+
+
+def _self_referencing_base(x):
+    return x * 5
+
+
+SELF_REFERENCING_WRAPPED = self_referencing_wrapper(_self_referencing_base)
+
+
 # --- an empty closure cell -------------------------------------------------
 def keep_name_with_empty_cell(func):
     @functools.wraps(func)
@@ -717,6 +784,98 @@ class TestGuardSerialization(TestGuardSerializationBase):
         x = torch.randn(3)
         ref, loaded = self._test_serialization("EQUALS_MATCH", fn, x)
         self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, True)
+
+    def test_guard_rooted_at_a_wrapper_that_reaches_itself(self):
+        # The globals snapshot moved to reduce STATE, but a kept closure cell,
+        # __dict__ entry or default still travelled in the reduce ARGS. pickle
+        # memoizes an object only AFTER saving its args, so a wrapper holding
+        # itself in any of those re-entered the reducer and recursed until
+        # RecursionError -- a hard capture failure, since aot_compile passes
+        # strict_error=True. Everything that reaches the function now goes in
+        # state too, and __closure__, which is read-only after construction,
+        # is built empty and filled by the state setter.
+        def fn(x):
+            return SELF_REFERENCING_WRAPPED(x)
+
+        x = torch.randn(3)
+        ref, loaded = self._test_serialization("EQUALS_MATCH", fn, x)
+        self._test_check_fn(ref, loaded, {"x": torch.randn(3)}, True)
+
+    def test_a_reconstructed_wrapper_still_points_at_itself(self):
+        # Deferring to state is only correct if the reference comes BACK. A
+        # wrapper whose cell or attribute silently lost its self-reference
+        # would raise NameError or AttributeError on the first served call
+        # rather than at load, so assert the identity directly.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        w = SELF_REFERENCING_WRAPPED
+        buf = io.BytesIO()
+        GuardsStatePickler(
+            {id(w): w, id(w.__globals__): w.__globals__}, {}, {}, buf
+        ).dump({"fn": w})
+        got = pickle.loads(buf.getvalue())["fn"]
+        self.assertIs(got.me, got)
+        cells = [
+            cell.cell_contents
+            for cell in (got.__closure__ or ())
+            if _cell_is_full(cell)
+        ]
+        self.assertTrue(any(contents is got for contents in cells))
+
+    def test_a_shared_closure_cell_survives_a_self_reference(self):
+        # The self-reference fix builds a placeholder cell, so it must not cost
+        # the sharing that _reduce_cell passes cells through unchanged to keep:
+        # two functions closing over one variable must still close over ONE
+        # cell after the round trip.
+        from torch._dynamo.guards import GuardsStatePickler
+
+        def pair():
+            shared = [0]
+
+            def f():
+                return shared
+
+            def g():
+                return shared
+
+            return f, g
+
+        f, g = pair()
+        buf = io.BytesIO()
+        GuardsStatePickler(
+            {id(f): f, id(g): g, id(f.__closure__[0]): f.__closure__[0]}, {}, {}, buf
+        ).dump({"f": f, "g": g})
+        out = pickle.loads(buf.getvalue())
+        self.assertIs(out["f"].__closure__[0], out["g"].__closure__[0])
+
+    def test_a_dynamo_control_flow_exception_is_not_a_package_bypass(self):
+        # pickle_guards_state catches Exception so a user assert in a
+        # __reduce__ becomes a bypass rather than a hard compile failure. Every
+        # exception Dynamo steers compilation with -- RestartAnalysis,
+        # SkipFrame, Unsupported -- derives from TorchDynamoException, which
+        # derives from RuntimeError, so the broad catch swallowed those too and
+        # a restart silently became a logged bypass. They must propagate.
+        global _REDUCE_RAISES
+        original = _REDUCE_RAISES
+        try:
+            for exc_type in (
+                torch._dynamo.exc.RestartAnalysis,
+                torch._dynamo.exc.SkipFrame,
+                torch._dynamo.exc.Unsupported,
+            ):
+                _REDUCE_RAISES = exc_type
+                with self.subTest(exc=exc_type.__name__):
+                    with self.assertRaises(exc_type):
+                        _dump_through_pickle_guards_state(_RaisesFromReduce())
+
+            # ... while an ordinary failure inside __reduce__ still becomes one.
+            _REDUCE_RAISES = AssertionError
+            with self.assertRaisesRegex(
+                PackageError, "AssertionError: from __reduce__"
+            ):
+                _dump_through_pickle_guards_state(_RaisesFromReduce())
+        finally:
+            _REDUCE_RAISES = original
 
     def test_reducer_handles_an_empty_cell_reached_directly(self):
         # _reduce_cell only covers cells it builds for a reconstructed

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -1,19 +1,27 @@
 # Owner(s): ["module: dynamo"]
 
+import copy
 import gc
 import importlib
 import os
+import pickle
 import sys
 import tempfile
 import unittest
 
 import torch
+import torch._dynamo.package as dynamo_package
 import torch._dynamo.testing
 import torch._inductor.config
 import torch._inductor.test_case
 import torch.onnx.operators
 import torch.utils.cpp_extension
-from torch._dynamo.package import CompilePackage, DiskDynamoStore, DynamoCache
+from torch._dynamo.package import (
+    CompilePackage,
+    DiskDynamoStore,
+    DynamoCache,
+    SystemInfo,
+)
 from torch._dynamo.precompile_context import PrecompileContext
 from torch._dynamo.testing import reduce_to_scalar_loss
 from torch._dynamo.utils import CleanupManager
@@ -85,6 +93,47 @@ class TestPackage(torch._inductor.test_case.TestCase):
 
         cache_entry = package.cache_entry()
         self.assertEqual(cache_entry.codes[0].backend_ids, [backend_id])
+
+    def test_cache_entry_loads_from_a_pickle_without_newer_fields(self):
+        # A pickle written before these fields existed must still load and pass
+        # check_versions(), which reads them directly.
+        def fn(x):
+            return x + 1
+
+        code_entry = dynamo_package._DynamoCodeCacheEntry(
+            python_code=dynamo_package.SerializedCode.from_code_object(fn.__code__),
+            python_module=__name__,
+            function_names=[],
+            guarded_codes=[],
+            import_sources={},
+            backend_ids=[],
+            code_source=None,
+            install_to_global=False,
+        )
+        old_code_entry = copy.copy(code_entry)
+        old_code_entry.__dict__.pop("bypassed")
+        entry = dynamo_package._DynamoCacheEntry(
+            codes=[old_code_entry],
+            source_info=dynamo_package.SourceInfo(set()),
+            device_type="cpu",
+            device_types=frozenset({"cpu"}),
+        )
+        old = copy.copy(entry)
+        for name in (
+            "device_types",
+            "requires_native_backend_compatibility",
+            "system_info",
+        ):
+            old.__dict__.pop(name)
+
+        loaded = pickle.loads(pickle.dumps(old))
+        self.assertIsNone(loaded.device_types)
+        self.assertTrue(loaded.requires_native_backend_compatibility)
+        self.assertIsInstance(loaded.system_info, SystemInfo)
+        self.assertIsNone(loaded.system_info.cpu_codegen_target)
+        self.assertFalse(loaded.codes[0].bypassed)
+        loaded.check_versions()
+        self.assertEqual(loaded.debug_info()["device_types"], ["cpu"])
 
     @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
     def test_nn_module(self):

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -96,7 +96,9 @@ class TestPackage(torch._inductor.test_case.TestCase):
 
     def test_cache_entry_loads_from_a_pickle_without_newer_fields(self):
         # A pickle written before these fields existed must still load and pass
-        # check_versions(), which reads them directly.
+        # check_versions(), which reads them directly. system_info is the
+        # exception: with nothing recorded there is nothing to compare the host
+        # against, and synthesizing one on load compared the host to itself.
         def fn(x):
             return x + 1
 
@@ -117,23 +119,24 @@ class TestPackage(torch._inductor.test_case.TestCase):
             source_info=dynamo_package.SourceInfo(set()),
             device_type="cpu",
             device_types=frozenset({"cpu"}),
+            system_info=SystemInfo.current(cpu_codegen=False),
         )
         old = copy.copy(entry)
-        for name in (
-            "device_types",
-            "requires_native_backend_compatibility",
-            "system_info",
-        ):
+        for name in ("device_types", "requires_native_backend_compatibility"):
             old.__dict__.pop(name)
 
         loaded = pickle.loads(pickle.dumps(old))
         self.assertIsNone(loaded.device_types)
         self.assertTrue(loaded.requires_native_backend_compatibility)
-        self.assertIsInstance(loaded.system_info, SystemInfo)
-        self.assertIsNone(loaded.system_info.cpu_codegen_target)
         self.assertFalse(loaded.codes[0].bypassed)
         loaded.check_versions()
         self.assertEqual(loaded.debug_info()["device_types"], ["cpu"])
+
+        old.__dict__.pop("system_info")
+        loaded = pickle.loads(pickle.dumps(old))
+        self.assertIsNone(loaded.system_info)
+        with self.assertRaisesRegex(RuntimeError, "records no system info"):
+            loaded.check_versions()
 
     @unittest.expectedFailure  # FUNCTION_MATCH guard not serializable today
     def test_nn_module(self):

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -16,7 +16,7 @@ import torch
 import torch.fx
 from torch._dynamo.convert_frame import GraphRuntimeEnv
 from torch._dynamo.graph_utils import _graph_device_type
-from torch._dynamo.package import SystemInfo
+from torch._dynamo.package import emits_native_code, SystemInfo
 
 from . import convert_frame
 from .aot_compile_types import (
@@ -56,9 +56,29 @@ class CompileArtifacts:
     backend_name: str
     system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
 
+    @property
+    def emits_native_code(self) -> bool:
+        from torch._dynamo.package import emits_native_code
+
+        return emits_native_code(self.backend_name)
+
     def check_compatibility(self) -> None:
-        current_system = SystemInfo.current()
-        current_system.check_compatibility(self.system_info, self.device_type)
+        # The CACHED info is the receiver, matching _DynamoCacheEntry: the skip
+        # for an artifact predating cpu_codegen_target keys off self, and every
+        # mismatch message labels self "cached" and the argument "current".
+        # Determining the codegen target runs the C++ toolchain, so only pay for
+        # it when this artifact actually records one to compare against.
+        check_codegen = self.emits_native_code
+        current = SystemInfo.current(
+            cpu_codegen=(
+                check_codegen
+                and self.device_type == "cpu"
+                and self.system_info.cpu_codegen_target is not None
+            )
+        )
+        self.system_info.check_compatibility(
+            current, self.device_type, check_codegen=check_codegen
+        )
 
 
 class AOTCompilePickler(pickle.Pickler):
@@ -193,6 +213,11 @@ class AOTCompiledFunction:
     _artifacts: CompileArtifacts
     _guard_check_enabled: bool = True
     _extra_globals: dict[str, object] | None = None
+    # Scope used ONLY to resolve guards, kept separate from _extra_globals so
+    # that supplying it cannot rewire what the compiled bytecode reads. It is
+    # held by reference, not copied, so guards track the loading process's
+    # globals as they change.
+    _guard_globals: dict[str, object] | None = None
 
     def prepare_f_locals(self, *args: object, **kwargs: object) -> dict[str, object]:
         f_locals: dict[str, object] = {}
@@ -228,10 +253,36 @@ class AOTCompiledFunction:
 
         if self._artifacts.guard_manager is None:
             guards_state = load_guards_state(self._artifacts.guards_state)
+            # The guard manager keeps this dict by reference, so handing it the
+            # loading process's scope rather than a copy is what makes a global
+            # rebound after load redirect dispatch instead of silently serving
+            # whichever graph matched at load time. There is deliberately no
+            # fallback to the serialized scope: a name the loading process does
+            # not have must fail the guard, not resolve against the value baked
+            # into the artifact. The graph's own globals stay as serialized.
+            guard_scope = self._guard_globals
+            if guard_scope is None:
+                guard_scope = self.fn.__globals__
+            else:
+                # Seed the artifact's own __import_* aliases. Dynamo MINTS those
+                # at trace time (symbolic_convert.import_source writes them into
+                # the tracing process's globals) and roots guards at them -- every
+                # child nn.Module call guards its hook dicts through
+                # G['__import_torch_dot_nn_dot_modules_dot_module']. A process
+                # that only LOADS never traced, so its module dict has none and
+                # the guard KeyErrors on every call. setdefault, so only the
+                # synthetic names are added: a real global the loading process
+                # already has keeps its live value, which is the point of using
+                # the live scope at all.
+                for (
+                    alias,
+                    module_name,
+                ) in self._artifacts.runtime_env.import_sources.items():
+                    guard_scope.setdefault(alias, importlib.import_module(module_name))
             self._artifacts.guard_manager = load_guard_manager(
                 guards_state,
                 self._artifacts.original_code,
-                self.fn.__globals__,
+                guard_scope,
             )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
@@ -287,6 +338,7 @@ class AOTCompiledFunction:
         data: bytes,
         f_globals: dict[str, object] | None = None,
         external_closure_data: dict[str, Any] | None = None,
+        guard_globals: dict[str, object] | None = None,
     ) -> "AOTCompiledFunction":
         from torch._dynamo.package import SerializedCode
 
@@ -305,7 +357,7 @@ class AOTCompiledFunction:
         state["original_code"] = SerializedCode.to_code_object(state["original_code"])
 
         artifacts = CompileArtifacts(**state)
-        return cls(artifacts, _extra_globals=f_globals)
+        return cls(artifacts, _extra_globals=f_globals, _guard_globals=guard_globals)
 
     def disable_guard_check(self) -> None:
         self._guard_check_enabled = False
@@ -352,6 +404,14 @@ def aot_compile_fullgraph(
             def new_guard_filter_fn(
                 guard_entries: Sequence[GuardFilterEntry],
             ) -> Sequence[bool]:
+                # NB: dropping every global guard is what
+                # torch.compiler.skip_guard_on_globals_unsafe does explicitly,
+                # and the "unsafe" in that name applies here too: a dropped
+                # global guard does not fail, it silently reuses a graph traced
+                # under a different global value. Narrowing this default needs
+                # guard construction to resolve arbitrary global references
+                # first (today they can raise KeyError on G['...']), so callers
+                # who need a specific global guarded must pass guard_filter_fn.
                 return [
                     (
                         not (
@@ -443,6 +503,7 @@ def aot_compile_fullgraph(
         for traced_code in graph_capture_output.traced_code:
             source_info.add_code(traced_code)
 
+        backend_name = getattr(backend, "compiler_name", "unknown")
         artifacts = CompileArtifacts(
             signature=convert_frame._get_signature(fn),
             guard_manager=check_fn.guard_manager,
@@ -453,7 +514,13 @@ def aot_compile_fullgraph(
             runtime_env=graph_capture_output.get_runtime_env(),
             source_info=source_info,
             device_type=device_type,
-            backend_name=getattr(backend, "compiler_name", "unknown"),
+            backend_name=backend_name,
+            # The field's default_factory would run the C++ toolchain probe on
+            # every capture; only an artifact that can hold CPU native code has
+            # a baked vector width to record.
+            system_info=SystemInfo.current(
+                cpu_codegen=(emits_native_code(backend_name) and device_type == "cpu")
+            ),
         )
         aot_compiled_fn = AOTCompiledFunction(
             _artifacts=artifacts, _extra_globals=fn.__globals__
@@ -490,8 +557,45 @@ class AOTCompiledModel:
         for result in self.compiled_results:
             if result.guard_check(self.model, *args, **kwargs):
                 return result(self.model, *args, **kwargs)
-        # All guards failed, just run one of them and throw the guard check error.
-        return self.compiled_results[0](self.model, *args, **kwargs)
+        # disable_guard_check() is the escape hatch for an artifact whose guards
+        # fail on the serving machine for a reason the caller judges benign. A
+        # result that opted out accepts anything, but only after a real match has
+        # been looked for, so dispatch is unchanged when nobody opted out.
+        for result in self.compiled_results:
+            if not result._guard_check_enabled:
+                return result(self.model, *args, **kwargs)
+        raise RuntimeError(self._no_match_message(*args, **kwargs))
+
+    def _no_match_message(self, *args: Any, **kwargs: Any) -> str:
+        # Report why every compiled input was rejected, not just the first one,
+        # so it is clear which ModelInput is missing.
+        lines = [
+            f"No AOT compiled graph matched this call. Tried "
+            f"{len(self.compiled_results)} compiled input(s):"
+        ]
+        for i, result in enumerate(self.compiled_results):
+            guard_manager = result._artifacts.guard_manager
+            if guard_manager is None:
+                lines.append(f"  [{i}] <guards unavailable>")
+                continue
+            # A guard that raises while being re-evaluated for this report must
+            # not replace the report. The call did not match, and that -- along
+            # with every other entry's reason -- is what the caller has to hear.
+            try:
+                f_locals = result.prepare_f_locals(self.model, *args, **kwargs)
+                reason = guard_manager.check_verbose(f_locals)
+            except Exception as e:
+                lines.append(f"  [{i}] <guard check raised {type(e).__name__}: {e}>")
+                continue
+            # Report just the failing guard: GuardDebugInfo's repr is multi-line
+            # and would break the per-entry layout into an unreadable blob.
+            parts = getattr(reason, "verbose_code_parts", None) or [str(reason)]
+            lines.append(f"  [{i}] {'; '.join(str(p) for p in parts)}")
+        lines.append(
+            "Add a ModelInput covering this call, or check whether a guard that "
+            "distinguishes it was dropped by guard_filter_fn."
+        )
+        return "\n".join(lines)
 
     def serialize(self) -> bytes:
         data: list[bytes] = []
@@ -504,6 +608,37 @@ class AOTCompiledModel:
         from torch._dynamo.utils import get_metrics_context
         from torch._guards import compile_context, CompileContext
 
+        # Guards on globals resolve against the traced function's global scope,
+        # which is not reconstructible from the serialized bytecode alone: a
+        # global that was specialized away never appears in it.
+        #
+        # Resolve from model.forward, which is what aot_compile_module traces.
+        # Passing the model instead would go through get_traced_fn's nn.Module
+        # branch and, whenever a forward hook is registered, hand back
+        # Module._wrapped_call_impl and torch/nn/modules/module.py's namespace.
+        # Only needed when a global guard survived the filter, which requires a
+        # caller-supplied guard_filter_fn. get_traced_fn refuses anything that
+        # is not a function or bound method -- a forward rebound to a partial,
+        # a callable object -- so failing here would stop such a model loading
+        # an artifact that has no global guards at all. Fall back to the old
+        # behaviour for those instead: no scope, guards resolve as before.
+        try:
+            traced_fn, _ = convert_frame.get_traced_fn(model.forward)
+            guard_globals = traced_fn.__globals__
+        except RuntimeError:
+            # Log rather than swallow: if this model DOES carry a surviving
+            # global guard, it now resolves against self.fn.__globals__ -- the
+            # bug this change exists to fix -- and that should be visible.
+            # info, not warning: the overwhelmingly common case is a model with
+            # no surviving global guard at all, where this is harmless.
+            log.info(
+                "Could not resolve a guard scope from %s.forward; global guards "
+                "will resolve against the reconstructed scope instead",
+                type(model).__name__,
+                exc_info=True,
+            )
+            guard_globals = None
+
         results: list[bytes] = pickle.loads(data)
         compiled_results = []
         for result in results:
@@ -511,7 +646,9 @@ class AOTCompiledModel:
                 compile_context(CompileContext(convert_frame.get_compile_id({}))),
                 get_metrics_context(),
             ):
-                compiled_results.append(AOTCompiledFunction.deserialize(result))
+                compiled_results.append(
+                    AOTCompiledFunction.deserialize(result, guard_globals=guard_globals)
+                )
         return cls(model, compiled_results)
 
 

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -66,8 +66,6 @@ class CompileArtifacts:
 
     @property
     def emits_native_code(self) -> bool:
-        from torch._dynamo.package import emits_native_code
-
         return emits_native_code(self.backend_name)
 
     def check_compatibility(self) -> None:
@@ -224,7 +222,9 @@ class AOTCompiledFunction:
     # Scope used ONLY to resolve guards, kept separate from _extra_globals so
     # that supplying it cannot rewire what the compiled bytecode reads. It is
     # held by reference, not copied, so guards track the loading process's
-    # globals as they change.
+    # globals as they change. Loading writes Dynamo's synthetic __import_*
+    # aliases into this dict (only the names it does not already have) and
+    # leaves them there, exactly as tracing does to the capturing process.
     _guard_globals: dict[str, object] | None = None
 
     def prepare_f_locals(self, *args: object, **kwargs: object) -> dict[str, object]:
@@ -278,15 +278,16 @@ class AOTCompiledFunction:
                 # child nn.Module call guards its hook dicts through
                 # G['__import_torch_dot_nn_dot_modules_dot_module']. A process
                 # that only LOADS never traced, so its module dict has none and
-                # the guard KeyErrors on every call. setdefault, so only the
-                # synthetic names are added: a real global the loading process
-                # already has keeps its live value, which is the point of using
-                # the live scope at all.
+                # the guard KeyErrors on every call. Only absent names are
+                # added, and nothing is imported for a name already bound: a
+                # real global the loading process already has keeps its live
+                # value, which is the point of using the live scope at all.
                 for (
                     alias,
                     module_name,
                 ) in self._artifacts.runtime_env.import_sources.items():
-                    guard_scope.setdefault(alias, importlib.import_module(module_name))
+                    if alias not in guard_scope:
+                        guard_scope[alias] = importlib.import_module(module_name)
             self._artifacts.guard_manager = load_guard_manager(
                 guards_state,
                 self._artifacts.original_code,
@@ -584,24 +585,31 @@ class AOTCompiledModel:
             f"No AOT compiled graph matched this call. Tried "
             f"{len(self.compiled_results)} compiled input(s):"
         ]
+        # One line per entry, so the report's shape is fixed: a header, one
+        # line per candidate, a footer. Every interpolated piece is flattened
+        # because guard code parts and exception messages can span lines.
         for i, result in enumerate(self.compiled_results):
-            guard_manager = result._artifacts.guard_manager
-            if guard_manager is None:
-                lines.append(f"  [{i}] <guards unavailable>")
-                continue
             # A guard that raises while being re-evaluated for this report must
             # not replace the report. The call did not match, and that -- along
             # with every other entry's reason -- is what the caller has to hear.
+            guard_manager = result._artifacts.guard_manager
+            if guard_manager is None:
+                raise AssertionError("guard_manager must not be None")
             try:
                 f_locals = result.prepare_f_locals(self.model, *args, **kwargs)
                 reason = guard_manager.check_verbose(f_locals)
             except Exception as e:
-                lines.append(f"  [{i}] <guard check raised {type(e).__name__}: {e}>")
+                detail = " ".join(str(e).splitlines())
+                lines.append(
+                    f"  [{i}] <guard check raised {type(e).__name__}: {detail}>"
+                )
                 continue
             # Report just the failing guard: GuardDebugInfo's repr is multi-line
             # and would break the per-entry layout into an unreadable blob.
-            parts = getattr(reason, "verbose_code_parts", None) or [str(reason)]
-            lines.append(f"  [{i}] {'; '.join(str(p) for p in parts)}")
+            parts = reason.verbose_code_parts or [str(reason)]
+            lines.append(
+                f"  [{i}] {'; '.join(' '.join(str(p).splitlines()) for p in parts)}"
+            )
         lines.append(
             "Add a ModelInput covering this call, or check whether a guard that "
             "distinguishes it was dropped by guard_filter_fn."

--- a/torch/_dynamo/aot_compile.py
+++ b/torch/_dynamo/aot_compile.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import importlib
 import inspect
 import io
@@ -54,7 +55,14 @@ class CompileArtifacts:
     source_info: "SourceInfo"
     device_type: str
     backend_name: str
-    system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
+    # Probe-free on purpose: this default is what CompileArtifacts(**state)
+    # reaches for a pickle written before the field existed, and running the
+    # C++ toolchain there is seconds on a cold cache and a hard error on a
+    # host with no compiler. Every site that compares the target passes
+    # cpu_codegen= explicitly.
+    system_info: SystemInfo = dataclasses.field(
+        default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
+    )
 
     @property
     def emits_native_code(self) -> bool:
@@ -558,12 +566,15 @@ class AOTCompiledModel:
             if result.guard_check(self.model, *args, **kwargs):
                 return result(self.model, *args, **kwargs)
         # disable_guard_check() is the escape hatch for an artifact whose guards
-        # fail on the serving machine for a reason the caller judges benign. A
-        # result that opted out accepts anything, but only after a real match has
-        # been looked for, so dispatch is unchanged when nobody opted out.
-        for result in self.compiled_results:
-            if not result._guard_check_enabled:
-                return result(self.model, *args, **kwargs)
+        # fail on the serving machine for a reason the caller judges benign. It
+        # is honoured only when that artifact is the ONLY candidate: with two
+        # loaded, serving an opted-out result for a call the other was compiled
+        # for is the silent-wrong-numbers case this dispatch exists to prevent,
+        # and the opt-out says nothing about which graph the call belongs to.
+        if len(self.compiled_results) == 1 and not (
+            self.compiled_results[0]._guard_check_enabled
+        ):
+            return self.compiled_results[0](self.model, *args, **kwargs)
         raise RuntimeError(self._no_match_message(*args, **kwargs))
 
     def _no_match_message(self, *args: Any, **kwargs: Any) -> str:

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1579,6 +1579,31 @@ class DisableContext(_TorchDynamoContext):
         return (self.__class__, ())
 
 
+def _backend_emits_native_code(backend: str | Callable[..., Any] | None) -> bool:
+    """
+    Whether artifacts of this backend carry a CPU codegen target to protect.
+
+    get_compiler_fn erases the name, and torch.compile hands over a
+    _TorchCompileWrapper rather than the string the user wrote, so the name is
+    recovered from the wrapper, then from the registry (a registered callable
+    passed directly, e.g. optimize(eager)), then from __name__. A callable that
+    yields no name is assumed to emit native code: a false rejection at load is
+    recoverable and silently running a kernel built for another ISA is not.
+    """
+    from torch._dynamo.package import emits_native_code
+
+    from .backends.registry import _COMPILER_FNS
+
+    if isinstance(backend, str):
+        return emits_native_code(backend)
+    name = getattr(backend, "compiler_name", None)
+    if name is None:
+        name = next((n for n, fn in _COMPILER_FNS.items() if fn is backend), None)
+    if name is None:
+        name = getattr(backend, "__name__", None)
+    return name is None or emits_native_code(name)
+
+
 def _optimize_catch_errors(
     compile_fn: convert_frame.ConvertFrameProtocol,
     hooks: Hooks,
@@ -1886,13 +1911,7 @@ def _optimize(
             dynamic_shapes=dynamic_shapes,
         )
 
-    # get_compiler_fn erases the name, and torch.compile hands us a
-    # _TorchCompileWrapper rather than the string the user wrote.
-    from torch._dynamo.package import emits_native_code as _emits_native_code
-
-    emits_native_code = _emits_native_code(
-        str(getattr(backend, "compiler_name", backend))
-    )
+    emits_native_code = _backend_emits_native_code(backend)
     backend = get_compiler_fn(backend)
 
     # Find if backend has any extra context manager
@@ -2842,13 +2861,7 @@ def _optimize_assert(
     Used for fullgraph=True and export, since we must always error on graph breaks and ignore
     symbolic_convert.error_on_graph_break. Can also be used for testing.
     """
-    # get_compiler_fn erases the name, and torch.compile hands us a
-    # _TorchCompileWrapper rather than the string the user wrote.
-    from torch._dynamo.package import emits_native_code as _emits_native_code
-
-    emits_native_code = _emits_native_code(
-        str(getattr(backend, "compiler_name", backend))
-    )
+    emits_native_code = _backend_emits_native_code(backend)
     backend = get_compiler_fn(backend)
 
     # Find if backend has any extra context manager

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -1886,6 +1886,13 @@ def _optimize(
             dynamic_shapes=dynamic_shapes,
         )
 
+    # get_compiler_fn erases the name, and torch.compile hands us a
+    # _TorchCompileWrapper rather than the string the user wrote.
+    from torch._dynamo.package import emits_native_code as _emits_native_code
+
+    emits_native_code = _emits_native_code(
+        str(getattr(backend, "compiler_name", backend))
+    )
     backend = get_compiler_fn(backend)
 
     # Find if backend has any extra context manager
@@ -1900,7 +1907,12 @@ def _optimize(
     if config.caching_precompile and package is None:
         from .package import CompilePackage
 
-        package = CompilePackage(fn=None, dynamo=None, ignore_inlined_sources=False)
+        package = CompilePackage(
+            fn=None,
+            dynamo=None,
+            ignore_inlined_sources=False,
+            requires_native_backend_compatibility=emits_native_code,
+        )
 
     return _optimize_catch_errors(
         convert_frame.convert_frame(
@@ -2830,6 +2842,13 @@ def _optimize_assert(
     Used for fullgraph=True and export, since we must always error on graph breaks and ignore
     symbolic_convert.error_on_graph_break. Can also be used for testing.
     """
+    # get_compiler_fn erases the name, and torch.compile hands us a
+    # _TorchCompileWrapper rather than the string the user wrote.
+    from torch._dynamo.package import emits_native_code as _emits_native_code
+
+    emits_native_code = _emits_native_code(
+        str(getattr(backend, "compiler_name", backend))
+    )
     backend = get_compiler_fn(backend)
 
     # Find if backend has any extra context manager
@@ -2843,7 +2862,12 @@ def _optimize_assert(
         # and OptimizeContext.
         from .package import CompilePackage
 
-        package = CompilePackage(fn=None, dynamo=None, ignore_inlined_sources=False)
+        package = CompilePackage(
+            fn=None,
+            dynamo=None,
+            ignore_inlined_sources=False,
+            requires_native_backend_compatibility=emits_native_code,
+        )
 
     return _optimize_catch_errors(
         convert_frame.convert_frame_assert(

--- a/torch/_dynamo/graph_utils.py
+++ b/torch/_dynamo/graph_utils.py
@@ -80,16 +80,27 @@ def _detect_cycles(
     return "no cycle detected"
 
 
-def _graph_device_type(graph: Graph | None) -> str:
-    if graph is None:
-        return "cpu"
+def _graph_device_types(graph: Graph | None) -> frozenset[str]:
+    """Every device type the graph's generated code targets.
 
-    def _device_type(x: Any) -> str:
+    A SCAN, not "the device of the first meta value": under dynamic shapes the
+    leading placeholder is a SymInt, which has no device, so reading one value
+    reported "cpu" for an all-accelerator graph -- and callers hang a toolchain
+    probe and a hard load-time rejection off that answer. Values carrying no
+    device (SymInt, int, None) contribute nothing rather than defaulting.
+
+    An empty result means the graph names no device at all, which for a graph
+    that emits no code is the honest answer and is not the same as "cpu".
+    """
+    if graph is None:
+        return frozenset()
+
+    def _device_type(x: Any) -> str | None:
         if isinstance(x, torch.device):
             return x.type
         if isinstance(x, torch.Tensor):
             return x.device.type
-        return "cpu"
+        return None
 
     def _flatten_meta(node: Node, key: str) -> list[Any]:
         if key not in node.meta:
@@ -97,21 +108,33 @@ def _graph_device_type(graph: Graph | None) -> str:
         flat, _ = tree_flatten(node.meta[key])
         return flat
 
+    devices: set[str] = set()
     for node in graph.nodes:
         for key in ("val", "example_value"):
             for obj in _flatten_meta(node, key):
-                return _device_type(obj)
+                if (device := _device_type(obj)) is not None:
+                    devices.add(device)
 
         # Check for device conversions
         if node.op == "call_method":
             for gpu in ["cuda", "xpu"]:
-                if node.target == gpu:
-                    return gpu
-                if node.target == "to" and gpu in node.args:
-                    return gpu
+                if node.target == gpu or (node.target == "to" and gpu in node.args):
+                    devices.add(gpu)
 
         # Check args/kwargs for non-CPU device specs
         flat_args, _ = tree_flatten((node.args, node.kwargs))
         for obj in flat_args:
-            return _device_type(obj)
-    return "cpu"
+            if (device := _device_type(obj)) is not None:
+                devices.add(device)
+    return frozenset(devices)
+
+
+def _graph_device_type(graph: Graph | None) -> str:
+    """The single device an artifact records for a graph.
+
+    An accelerator wins over cpu: a mixed graph's generated code is the
+    accelerator's, and "cpu" here would arm a CPU codegen-target check the
+    artifact does not need.
+    """
+    devices = _graph_device_types(graph)
+    return next((d for d in sorted(devices) if d != "cpu"), "cpu")

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4311,9 +4311,161 @@ class GuardsStatePickler(pickle.Pickler):
         qualname: str,
         argdefs: tuple[object, ...] | None,
         closure: tuple[types.CellType, ...] | None,
+        kwdefaults: dict[str, object] | None = None,
+        name: str | None = None,
+        attributes: dict[str, object] | None = None,
+        guarded_globals: dict[str, object] | None = None,
+        snapshot_globals: bool = False,
     ) -> types.FunctionType:
-        f_globals = importlib.import_module(module).__dict__
-        return types.FunctionType(code, f_globals, qualname, argdefs, closure)
+        if snapshot_globals:
+            # Deliberately no import_module here: the snapshot IS the scope, and
+            # importing a module only to discard it is a load-time failure mode
+            # this branch does not otherwise have.
+            f_globals: dict[str, Any] = dict(guarded_globals or {})
+        else:
+            # NB obj.__module__ is not reliably the module the function LIVES in
+            # -- functools.wraps copies it from the wrapped function -- so this
+            # scope can belong to a different file. It is only reached when no
+            # guard walks __globals__, since one that does registers the dict
+            # and forces the snapshot above.
+            f_globals = importlib.import_module(module).__dict__
+        fn = types.FunctionType(
+            code,
+            f_globals,
+            name if name is not None else code.co_name,
+            argdefs,
+            closure,
+        )
+        fn.__qualname__ = qualname
+        fn.__kwdefaults__ = kwdefaults
+        if attributes:
+            fn.__dict__.update(attributes)
+        return fn
+
+    def _keep(self, value: object) -> bool:
+        """Whether a value a reconstructed function holds has to be carried.
+
+        Only values some guard tree node references: everything else becomes a
+        _Missing sentinel, so widening the set of reconstructed functions does
+        not drag unrelated -- and possibly unpicklable -- neighbours into the
+        pickle with them. Matching is by identity, which for an interned value
+        (True, None, a small int, a short str) can coincide with an unrelated
+        guarded one and keep it. That is harmless: such values are trivially
+        picklable, and a kept value is always the real one.
+        """
+        return id(value) in self.guard_tree_values
+
+    def _reduce_cell(self, cell: types.CellType) -> types.CellType:
+        """Carry a closure cell, or replace it with a sentinel one.
+
+        A carried cell is passed through UNCHANGED so that two functions
+        closing over the same variable still share it after reload, and so that
+        pickle can memoize it. Only a dropped cell is rebuilt.
+
+        An EMPTY cell -- a free variable a decorator only assigns on a path that
+        did not run -- has no contents to read at all, so presence is checked
+        before identity. Reading it unconditionally raised ValueError here,
+        which reaches the caller as a package bypass.
+        """
+        try:
+            contents = cell.cell_contents
+        except ValueError:
+            return type(self)._unpickle_cell(_Missing("empty function closure"))
+        if self._keep(cell) or self._keep(contents):
+            return cell
+        return type(self)._unpickle_cell(_Missing("unguarded function closure"))
+
+    @staticmethod
+    def _apply_function_globals(
+        fn: types.FunctionType, guarded_globals: dict[str, object]
+    ) -> None:
+        fn.__globals__.update(guarded_globals)
+
+    def _reduce_nested_function(self, obj: types.FunctionType) -> tuple[Any, ...]:
+        snapshot_globals = id(obj.__globals__) in self.guard_tree_values
+        guarded_globals = (
+            {
+                name: (
+                    value
+                    if self._keep(value)
+                    else _Missing("unguarded function global")
+                )
+                for name, value in obj.__globals__.items()
+            }
+            if snapshot_globals
+            else None
+        )
+
+        defaults = obj.__defaults__
+        if defaults is not None:
+            keep_defaults = self._keep(defaults) or any(
+                self._keep(value) for value in defaults
+            )
+            defaults = (
+                tuple(
+                    value
+                    if self._keep(value)
+                    else _Missing("unguarded function default")
+                    for value in defaults
+                )
+                if keep_defaults
+                else None
+            )
+
+        kwdefaults = obj.__kwdefaults__
+        if kwdefaults is not None:
+            keep_kwdefaults = self._keep(kwdefaults)
+            kwdefaults = {
+                name: (
+                    value
+                    if self._keep(value)
+                    else _Missing("unguarded function keyword default")
+                )
+                for name, value in kwdefaults.items()
+                if keep_kwdefaults or self._keep(value)
+            }
+            if not kwdefaults and not keep_kwdefaults:
+                kwdefaults = None
+
+        closure = obj.__closure__
+        if closure is not None:
+            closure = tuple(self._reduce_cell(cell) for cell in closure)
+        attributes = (
+            dict(obj.__dict__)
+            if self._keep(obj.__dict__)
+            else {
+                name: value for name, value in obj.__dict__.items() if self._keep(value)
+            }
+        )
+        args = (
+            obj.__code__,
+            obj.__module__,
+            obj.__qualname__,
+            defaults,
+            closure,
+            kwdefaults,
+            obj.__name__,
+            attributes,
+            None,
+            snapshot_globals,
+        )
+        if not snapshot_globals:
+            return type(self)._unpickle_nested_function, args
+        # The snapshot goes in STATE, not in the args. pickle memoizes an object
+        # only after saving its reduce args, so a snapshot passed as an arg that
+        # reaches back to obj -- the ordinary `wrapped = deco(base)` at module
+        # scope, or two functools.wraps helpers referencing each other through
+        # the module dict -- recurses until RecursionError. State is applied
+        # AFTER memoization, so those references resolve to the function pickle
+        # already built.
+        return (
+            type(self)._unpickle_nested_function,
+            args,
+            guarded_globals,
+            None,
+            None,
+            type(self)._apply_function_globals,
+        )
 
     # pyrefly: ignore [bad-override]
     def reducer_override(
@@ -4467,19 +4619,15 @@ class GuardsStatePickler(pickle.Pickler):
 
         elif inspect.isfunction(obj):
             if "<locals>" in obj.__qualname__:
-                return type(self)._unpickle_nested_function, (
-                    obj.__code__,
-                    obj.__module__,
-                    obj.__qualname__,
-                    obj.__defaults__,
-                    obj.__closure__,
-                )
+                return self._reduce_nested_function(obj)
             if obj.__module__ in sys.modules:
                 f = sys.modules[obj.__module__]
                 for name in obj.__qualname__.split("."):
                     f = getattr(f, name, None)  # type: ignore[assignment]
                 if f is not obj:
-                    return _Missing, ("fqn mismatch",)
+                    if id(obj) not in self.guard_tree_values:
+                        return _Missing, ("fqn mismatch",)
+                    return self._reduce_nested_function(obj)
         elif inspect.ismethod(obj):
             func = obj.__func__
             method_self = obj.__self__
@@ -4490,7 +4638,16 @@ class GuardsStatePickler(pickle.Pickler):
                 return type(self)._unpickle_bound_method, (func, method_self)
 
         elif isinstance(obj, type((lambda x: lambda: x)(0).__closure__[0])):  # type: ignore[index] # noqa: PLC3002
-            return type(self)._unpickle_cell, (obj.cell_contents,)
+            # An EMPTY cell -- a free variable only assigned on a path that
+            # did not run -- has nothing to read, and reading it raised
+            # ValueError out of here, which reaches the caller as a package
+            # bypass. _reduce_cell handles the cells it builds; this is the
+            # path a cell reached directly takes.
+            try:
+                contents = obj.cell_contents
+            except ValueError:
+                contents = _Missing("empty function closure")
+            return type(self)._unpickle_cell, (contents,)
 
         if hasattr(torch.distributed, "distributed_c10d") and isinstance(
             obj, torch.distributed.distributed_c10d.Work
@@ -4599,8 +4756,20 @@ def pickle_guards_state(
 
     try:
         pickler.dump(state)
-    except AttributeError as e:
-        raise torch._dynamo.exc.PackageError(str(e)) from e
+    except torch._dynamo.exc.PackageError:
+        raise
+    except Exception as e:
+        # Deliberately broad, including AssertionError. It is tempting to let
+        # that one through as "our bug", but it is not ours to claim:
+        # GradScaler.__getstate__ asserts when pickled mid-iteration, tensor
+        # subclasses assert in __tensor_flatten__, and any user assert in a
+        # __reduce__ or a property lands here. Propagating those turns a
+        # serialization limitation into a hard torch.compile failure for a
+        # program that has nothing wrong with it.
+        # The caller turns PackageError into a package bypass, or re-raises it
+        # under strict_precompile. Name the original type so the reason stays
+        # diagnosable in the bypass message.
+        raise torch._dynamo.exc.PackageError(f"{type(e).__name__}: {e}") from e
     return buf.getvalue()
 
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4137,33 +4137,17 @@ class _Missing:
         return _Missing()
 
 
-def _reaches(container: object, target: object) -> bool:
-    """Whether ``container`` holds ``target`` directly.
-
-    Only one level: a decorator stores its wrapper straight into the wrapper's
-    own __dict__, defaults or closure, and that is the shape that recurses.
-    A reference buried inside a user object would need a full traversal, which
-    would have to run arbitrary __iter__ on values the pickler has not vetted.
-    """
-    if container is target:
-        return True
-    if isinstance(container, dict):
-        return any(value is target for value in container.values())
-    if isinstance(container, (tuple, list)):
-        return any(value is target for value in container)
-    return False
-
-
 @dataclasses.dataclass(frozen=True)
 class _DeferredFunctionState:
-    """What a reconstructed function cannot receive through its reduce args.
+    """Everything a reconstructed function receives after it exists.
 
-    A decorator that gives its wrapper a call counter, a cache attribute or a
-    recursive default writes the wrapper into its own closure, __dict__ or
-    __defaults__. Those all travel in the reduce args, which pickle saves
-    BEFORE memoizing the function, so the reference re-enters the reducer and
-    recurses. Whatever reaches the function is moved here instead and applied
-    by _apply_function_state once the pickle exists.
+    pickle saves an object's reduce ARGS before memoizing the object, so a
+    reference from those args back to the function -- a decorator's call counter
+    on its own wrapper, a recursive default, or a second function that closes
+    over this one and is held in its __dict__ -- re-enters the reducer and
+    recurses until RecursionError. So none of it travels in args: state is
+    applied by _apply_function_state once the pickle exists, and by then every
+    such reference resolves to the function already built.
     """
 
     guarded_globals: dict[str, object] | None = None
@@ -4180,44 +4164,6 @@ class _DeferredFunctionState:
             or self.kwdefaults is not None
             or self.attributes
         )
-
-
-# A reconstructed FakeTensor keeps its own bookkeeping in __dict__ alongside
-# anything the user hung there. Re-serializing one must not carry these across:
-# the reconstructor sets them itself, and carrying them would accrete a fresh
-# copy of each on every round trip.
-_FAKE_TENSOR_OWNED_ATTRIBUTES = frozenset(
-    {
-        "_fake_device",
-        "fake_mode",
-        "constant",
-        "pytype",
-        "dispatch_keys",
-        "real_tensor",
-        "_nonzero_memo",
-        "_nonzero_memo_vc",
-        "_nonzero_memo_epoch",
-        "_item_memo",
-        "_item_memo_vc",
-        "_item_memo_epoch",
-        "_unique_memo",
-        "_unique_memo_vc",
-        "_unique_memo_epoch",
-        "_unique_consecutive_memo",
-        "_unique_consecutive_memo_vc",
-        "_unique_consecutive_memo_epoch",
-        "_nested_int_memo",
-        "_nested_int_memo_vc",
-        "_nested_int_memo_epoch",
-    }
-)
-
-# The subset a reconstructed FakeTensor genuinely needs to BE one. A user
-# attribute of the same name would overwrite it, so those are refused by name
-# rather than left to fail somewhere inside the rebuild.
-_FAKE_TENSOR_RESERVED_ATTRIBUTES = frozenset(
-    {"_fake_device", "fake_mode", "pytype", "dispatch_keys"}
-)
 
 
 @functools.cache
@@ -4249,6 +4195,9 @@ class GuardsStatePickler(pickle.Pickler):
         self.guard_tree_values = guard_tree_values
         self.empty_values = empty_values
         self.missing_values = missing_values
+        # Cells kept in a reconstructed function's closure: reduced empty, filled
+        # from that function's state so a self-reference cannot recurse.
+        self.deferred_cells: set[int] = set()
 
     @classmethod
     def _unpickle_module(cls, state: Any) -> torch.nn.Module:
@@ -4392,19 +4341,17 @@ class GuardsStatePickler(pickle.Pickler):
         code: types.CodeType,
         module: str,
         qualname: str,
-        argdefs: tuple[object, ...] | None,
+        name: str,
         closure: tuple[types.CellType, ...] | None,
-        kwdefaults: dict[str, object] | None = None,
-        name: str | None = None,
-        attributes: dict[str, object] | None = None,
-        guarded_globals: dict[str, object] | None = None,
-        snapshot_globals: bool = False,
+        snapshot_globals: bool,
+        doc: str | None = None,
     ) -> types.FunctionType:
         if snapshot_globals:
             # Deliberately no import_module here: the snapshot IS the scope, and
             # importing a module only to discard it is a load-time failure mode
-            # this branch does not otherwise have.
-            f_globals: dict[str, Any] = dict(guarded_globals or {})
+            # this branch does not otherwise have. The snapshot arrives with the
+            # rest of the deferred state.
+            f_globals: dict[str, Any] = {}
         else:
             # NB obj.__module__ is not reliably the module the function LIVES in
             # -- functools.wraps copies it from the wrapped function -- so this
@@ -4412,17 +4359,13 @@ class GuardsStatePickler(pickle.Pickler):
             # guard walks __globals__, since one that does registers the dict
             # and forces the snapshot above.
             f_globals = importlib.import_module(module).__dict__
-        fn = types.FunctionType(
-            code,
-            f_globals,
-            name if name is not None else code.co_name,
-            argdefs,
-            closure,
-        )
+        fn = types.FunctionType(code, f_globals, name, None, closure)
         fn.__qualname__ = qualname
-        fn.__kwdefaults__ = kwdefaults
-        if attributes:
-            fn.__dict__.update(attributes)
+        # FunctionType reads __module__ out of f_globals["__name__"], which the
+        # snapshot scope above does not have, so a guard on fn.__module__ used to
+        # rebuild against None.
+        fn.__module__ = module
+        fn.__doc__ = doc
         return fn
 
     def _keep(self, value: object) -> bool:
@@ -4438,38 +4381,26 @@ class GuardsStatePickler(pickle.Pickler):
         """
         return id(value) in self.guard_tree_values
 
-    def _reduce_cell(self, cell: types.CellType) -> types.CellType:
-        """Carry a closure cell, or replace it with a sentinel one.
+    @classmethod
+    def _unpickle_empty_cell(cls) -> types.CellType:
+        return types.CellType()
 
-        A carried cell is passed through UNCHANGED so that two functions
-        closing over the same variable still share it after reload, and so that
-        pickle can memoize it. Only a dropped cell is rebuilt.
-
-        An EMPTY cell -- a free variable a decorator only assigns on a path that
-        did not run -- has no contents to read at all, so presence is checked
-        before identity. Reading it unconditionally raised ValueError here,
-        which reaches the caller as a package bypass.
-        """
-        try:
-            contents = cell.cell_contents
-        except ValueError:
-            return type(self)._unpickle_cell(_Missing("empty function closure"))
-        if self._keep(cell) or self._keep(contents):
-            return cell
-        return type(self)._unpickle_cell(_Missing("unguarded function closure"))
+    def _dropped_cell(self, reason: str) -> types.CellType:
+        """A stand-in for a closure cell whose contents must not travel."""
+        return type(self)._unpickle_cell(_Missing(reason))
 
     @staticmethod
     def _apply_function_state(
         fn: types.FunctionType, state: _DeferredFunctionState
     ) -> None:
-        """Apply the pieces of a reconstructed function that reach the function.
+        """Apply everything a reconstructed function receives after it exists.
 
-        pickle memoizes an object only after saving its reduce ARGS, so
-        anything in args holding a reference back to the function being reduced
-        recurses until RecursionError. State is applied after memoization, so
-        those references resolve to the pickle already built. Everything here
-        is settable post-construction; __closure__ is not, which is why a
-        deferred cell is built empty in args and filled by contents here.
+        pickle memoizes an object only after saving its reduce ARGS, so anything
+        in args holding a reference back to the function being reduced recurses
+        until RecursionError. State is applied after memoization, so those
+        references resolve to the pickle already built. Everything here is
+        settable post-construction; __closure__ is not, which is why a cell
+        arrives empty in args and is filled with its contents here.
         """
         if state.guarded_globals:
             fn.__globals__.update(state.guarded_globals)
@@ -4529,12 +4460,15 @@ class GuardsStatePickler(pickle.Pickler):
             if not kwdefaults and not keep_kwdefaults:
                 kwdefaults = None
 
-        # Anything below that holds obj itself has to travel in STATE rather
-        # than in the reduce args: pickle memoizes obj only after saving its
-        # args, so a self-reference in args re-enters the reducer and recurses.
-        # A decorator writing a counter or a cache onto its own wrapper is the
-        # ordinary way this happens, and functools.wraps makes such a wrapper
-        # exactly the fqn-mismatched shape this reducer exists to rebuild.
+        # Everything below travels in STATE rather than in the reduce args, and
+        # unconditionally: pickle memoizes obj only after saving its args, so
+        # ANY path from an arg back to obj re-enters the reducer and recurses.
+        # A self-reference is the obvious one -- a decorator writing a counter
+        # onto its own wrapper -- but two kept functions referring to each other
+        # do it across the pair, which no per-value check can see from here.
+        # Only the cells themselves stay in args, because __closure__ is
+        # read-only after construction; they arrive empty and the state setter
+        # fills their contents.
         deferred_cells: list[tuple[int, object]] = []
         closure = obj.__closure__
         if closure is not None:
@@ -4543,16 +4477,18 @@ class GuardsStatePickler(pickle.Pickler):
                 try:
                     contents = cell.cell_contents
                 except ValueError:
-                    rebuilt.append(self._reduce_cell(cell))
+                    # A free variable a decorator only assigns on a path that
+                    # did not run: nothing to read, so nothing to carry.
+                    rebuilt.append(self._dropped_cell("empty function closure"))
                     continue
-                if contents is obj and (self._keep(cell) or self._keep(contents)):
-                    # __closure__ is read-only after construction, so unlike the
-                    # rest this cannot simply move to state: build the cell empty
-                    # and let the state setter fill its contents.
-                    rebuilt.append(types.CellType())
+                if self._keep(cell) or self._keep(contents):
+                    # The cell object itself is kept so that two functions
+                    # closing over one variable still share one cell after load.
+                    self.deferred_cells.add(id(cell))
+                    rebuilt.append(cell)
                     deferred_cells.append((index, contents))
                 else:
-                    rebuilt.append(self._reduce_cell(cell))
+                    rebuilt.append(self._dropped_cell("unguarded function closure"))
             closure = tuple(rebuilt)
 
         attributes = (
@@ -4562,27 +4498,21 @@ class GuardsStatePickler(pickle.Pickler):
                 name: value for name, value in obj.__dict__.items() if self._keep(value)
             }
         )
-        deferred_defaults = defaults if _reaches(defaults, obj) else None
-        deferred_kwdefaults = kwdefaults if _reaches(kwdefaults, obj) else None
-        deferred_attributes = attributes if _reaches(attributes, obj) else None
         state = _DeferredFunctionState(
             guarded_globals=guarded_globals,
             cell_contents=tuple(deferred_cells),
-            defaults=deferred_defaults,
-            kwdefaults=deferred_kwdefaults,
-            attributes=deferred_attributes,
+            defaults=defaults,
+            kwdefaults=kwdefaults,
+            attributes=attributes,
         )
         args = (
             obj.__code__,
             obj.__module__,
             obj.__qualname__,
-            None if deferred_defaults is not None else defaults,
-            closure,
-            None if deferred_kwdefaults is not None else kwdefaults,
             obj.__name__,
-            None if deferred_attributes is not None else attributes,
-            None,
+            closure,
             snapshot_globals,
+            obj.__doc__,
         )
         if not state:
             return type(self)._unpickle_nested_function, args
@@ -4765,12 +4695,17 @@ class GuardsStatePickler(pickle.Pickler):
             if func is not inner_func:
                 return type(self)._unpickle_bound_method, (func, method_self)
 
-        elif isinstance(obj, type((lambda x: lambda: x)(0).__closure__[0])):  # type: ignore[index] # noqa: PLC3002
+        elif isinstance(obj, types.CellType):
+            if id(obj) in self.deferred_cells:
+                # A cell in some reconstructed function's closure: it travels so
+                # that sharing survives, but its CONTENTS come back through that
+                # function's state, because saving them here -- inside the
+                # function's args -- is what recurses.
+                return type(self)._unpickle_empty_cell, ()
             # An EMPTY cell -- a free variable only assigned on a path that
             # did not run -- has nothing to read, and reading it raised
             # ValueError out of here, which reaches the caller as a package
-            # bypass. _reduce_cell handles the cells it builds; this is the
-            # path a cell reached directly takes.
+            # bypass.
             try:
                 contents = obj.cell_contents
             except ValueError:
@@ -4884,14 +4819,20 @@ def pickle_guards_state(
 
     try:
         pickler.dump(state)
+    except RecursionError:
+        # Not a user's serialization limitation: either a reducer failed to
+        # break a cycle in the state, or the pickler recursed on depth it should
+        # have flattened. Both are ours, and a bypass would hide them behind a
+        # model that silently runs eager.
+        raise
     except torch._dynamo.exc.TorchDynamoException:
         # Dynamo steers compilation with exceptions -- RestartAnalysis,
         # SkipFrame, Unsupported, ObservedException -- and all of them derive
         # from TorchDynamoException, which derives from RuntimeError. Pickling
-        # runs user __reduce__, __getstate__ and property getters, so a value
-        # whose getter is itself traced can raise one here. Rewriting a restart
-        # into a package bypass means the restart never happens, so the whole
-        # family propagates; PackageError is in it and keeps its old meaning.
+        # runs user __reduce__, __getstate__ and property getters, any of which
+        # may call a COMPILED callable, and one of these coming back out of that
+        # call belongs to the frame being compiled there: rewriting it into a
+        # package bypass means the restart or the graph break never happens.
         raise
     except Exception as e:
         # Deliberately broad, including AssertionError. It is tempting to let

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4137,6 +4137,89 @@ class _Missing:
         return _Missing()
 
 
+def _reaches(container: object, target: object) -> bool:
+    """Whether ``container`` holds ``target`` directly.
+
+    Only one level: a decorator stores its wrapper straight into the wrapper's
+    own __dict__, defaults or closure, and that is the shape that recurses.
+    A reference buried inside a user object would need a full traversal, which
+    would have to run arbitrary __iter__ on values the pickler has not vetted.
+    """
+    if container is target:
+        return True
+    if isinstance(container, dict):
+        return any(value is target for value in container.values())
+    if isinstance(container, (tuple, list)):
+        return any(value is target for value in container)
+    return False
+
+
+@dataclasses.dataclass(frozen=True)
+class _DeferredFunctionState:
+    """What a reconstructed function cannot receive through its reduce args.
+
+    A decorator that gives its wrapper a call counter, a cache attribute or a
+    recursive default writes the wrapper into its own closure, __dict__ or
+    __defaults__. Those all travel in the reduce args, which pickle saves
+    BEFORE memoizing the function, so the reference re-enters the reducer and
+    recurses. Whatever reaches the function is moved here instead and applied
+    by _apply_function_state once the pickle exists.
+    """
+
+    guarded_globals: dict[str, object] | None = None
+    cell_contents: tuple[tuple[int, object], ...] = ()
+    defaults: tuple[object, ...] | None = None
+    kwdefaults: dict[str, object] | None = None
+    attributes: dict[str, object] | None = None
+
+    def __bool__(self) -> bool:
+        return bool(
+            self.guarded_globals
+            or self.cell_contents
+            or self.defaults is not None
+            or self.kwdefaults is not None
+            or self.attributes
+        )
+
+
+# A reconstructed FakeTensor keeps its own bookkeeping in __dict__ alongside
+# anything the user hung there. Re-serializing one must not carry these across:
+# the reconstructor sets them itself, and carrying them would accrete a fresh
+# copy of each on every round trip.
+_FAKE_TENSOR_OWNED_ATTRIBUTES = frozenset(
+    {
+        "_fake_device",
+        "fake_mode",
+        "constant",
+        "pytype",
+        "dispatch_keys",
+        "real_tensor",
+        "_nonzero_memo",
+        "_nonzero_memo_vc",
+        "_nonzero_memo_epoch",
+        "_item_memo",
+        "_item_memo_vc",
+        "_item_memo_epoch",
+        "_unique_memo",
+        "_unique_memo_vc",
+        "_unique_memo_epoch",
+        "_unique_consecutive_memo",
+        "_unique_consecutive_memo_vc",
+        "_unique_consecutive_memo_epoch",
+        "_nested_int_memo",
+        "_nested_int_memo_vc",
+        "_nested_int_memo_epoch",
+    }
+)
+
+# The subset a reconstructed FakeTensor genuinely needs to BE one. A user
+# attribute of the same name would overwrite it, so those are refused by name
+# rather than left to fail somewhere inside the rebuild.
+_FAKE_TENSOR_RESERVED_ATTRIBUTES = frozenset(
+    {"_fake_device", "fake_mode", "pytype", "dispatch_keys"}
+)
+
+
 @functools.cache
 def _get_unsupported_types() -> tuple[type, ...]:
     # We only do ID_MATCH on C objects which is already banned from guards serialization.
@@ -4376,10 +4459,29 @@ class GuardsStatePickler(pickle.Pickler):
         return type(self)._unpickle_cell(_Missing("unguarded function closure"))
 
     @staticmethod
-    def _apply_function_globals(
-        fn: types.FunctionType, guarded_globals: dict[str, object]
+    def _apply_function_state(
+        fn: types.FunctionType, state: _DeferredFunctionState
     ) -> None:
-        fn.__globals__.update(guarded_globals)
+        """Apply the pieces of a reconstructed function that reach the function.
+
+        pickle memoizes an object only after saving its reduce ARGS, so
+        anything in args holding a reference back to the function being reduced
+        recurses until RecursionError. State is applied after memoization, so
+        those references resolve to the pickle already built. Everything here
+        is settable post-construction; __closure__ is not, which is why a
+        deferred cell is built empty in args and filled by contents here.
+        """
+        if state.guarded_globals:
+            fn.__globals__.update(state.guarded_globals)
+        closure = fn.__closure__ or ()
+        for index, contents in state.cell_contents:
+            closure[index].cell_contents = contents
+        if state.defaults is not None:
+            fn.__defaults__ = state.defaults
+        if state.kwdefaults is not None:
+            fn.__kwdefaults__ = state.kwdefaults
+        if state.attributes:
+            fn.__dict__.update(state.attributes)
 
     def _reduce_nested_function(self, obj: types.FunctionType) -> tuple[Any, ...]:
         snapshot_globals = id(obj.__globals__) in self.guard_tree_values
@@ -4427,9 +4529,32 @@ class GuardsStatePickler(pickle.Pickler):
             if not kwdefaults and not keep_kwdefaults:
                 kwdefaults = None
 
+        # Anything below that holds obj itself has to travel in STATE rather
+        # than in the reduce args: pickle memoizes obj only after saving its
+        # args, so a self-reference in args re-enters the reducer and recurses.
+        # A decorator writing a counter or a cache onto its own wrapper is the
+        # ordinary way this happens, and functools.wraps makes such a wrapper
+        # exactly the fqn-mismatched shape this reducer exists to rebuild.
+        deferred_cells: list[tuple[int, object]] = []
         closure = obj.__closure__
         if closure is not None:
-            closure = tuple(self._reduce_cell(cell) for cell in closure)
+            rebuilt: list[types.CellType] = []
+            for index, cell in enumerate(closure):
+                try:
+                    contents = cell.cell_contents
+                except ValueError:
+                    rebuilt.append(self._reduce_cell(cell))
+                    continue
+                if contents is obj and (self._keep(cell) or self._keep(contents)):
+                    # __closure__ is read-only after construction, so unlike the
+                    # rest this cannot simply move to state: build the cell empty
+                    # and let the state setter fill its contents.
+                    rebuilt.append(types.CellType())
+                    deferred_cells.append((index, contents))
+                else:
+                    rebuilt.append(self._reduce_cell(cell))
+            closure = tuple(rebuilt)
+
         attributes = (
             dict(obj.__dict__)
             if self._keep(obj.__dict__)
@@ -4437,34 +4562,37 @@ class GuardsStatePickler(pickle.Pickler):
                 name: value for name, value in obj.__dict__.items() if self._keep(value)
             }
         )
+        deferred_defaults = defaults if _reaches(defaults, obj) else None
+        deferred_kwdefaults = kwdefaults if _reaches(kwdefaults, obj) else None
+        deferred_attributes = attributes if _reaches(attributes, obj) else None
+        state = _DeferredFunctionState(
+            guarded_globals=guarded_globals,
+            cell_contents=tuple(deferred_cells),
+            defaults=deferred_defaults,
+            kwdefaults=deferred_kwdefaults,
+            attributes=deferred_attributes,
+        )
         args = (
             obj.__code__,
             obj.__module__,
             obj.__qualname__,
-            defaults,
+            None if deferred_defaults is not None else defaults,
             closure,
-            kwdefaults,
+            None if deferred_kwdefaults is not None else kwdefaults,
             obj.__name__,
-            attributes,
+            None if deferred_attributes is not None else attributes,
             None,
             snapshot_globals,
         )
-        if not snapshot_globals:
+        if not state:
             return type(self)._unpickle_nested_function, args
-        # The snapshot goes in STATE, not in the args. pickle memoizes an object
-        # only after saving its reduce args, so a snapshot passed as an arg that
-        # reaches back to obj -- the ordinary `wrapped = deco(base)` at module
-        # scope, or two functools.wraps helpers referencing each other through
-        # the module dict -- recurses until RecursionError. State is applied
-        # AFTER memoization, so those references resolve to the function pickle
-        # already built.
         return (
             type(self)._unpickle_nested_function,
             args,
-            guarded_globals,
+            state,
             None,
             None,
-            type(self)._apply_function_globals,
+            type(self)._apply_function_state,
         )
 
     # pyrefly: ignore [bad-override]
@@ -4756,7 +4884,14 @@ def pickle_guards_state(
 
     try:
         pickler.dump(state)
-    except torch._dynamo.exc.PackageError:
+    except torch._dynamo.exc.TorchDynamoException:
+        # Dynamo steers compilation with exceptions -- RestartAnalysis,
+        # SkipFrame, Unsupported, ObservedException -- and all of them derive
+        # from TorchDynamoException, which derives from RuntimeError. Pickling
+        # runs user __reduce__, __getstate__ and property getters, so a value
+        # whose getter is itself traced can raise one here. Rewriting a restart
+        # into a package bypass means the restart never happens, so the whole
+        # family propagates; PackageError is in it and keeps its old meaning.
         raise
     except Exception as e:
         # Deliberately broad, including AssertionError. It is tempting to let

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -436,10 +436,17 @@ _NO_NATIVE_CODE_BACKENDS = frozenset(
         "aot_eager_decomp_partition_crossref",
         "aot_eager_decomp_partition_with_mode",
         "aot_eager_default_partitioner",
+        "aot_ts",
+        "cudagraphs",
         "eager",
         "eager_debug",
         "eager_noexcept",
+        "non_leaf_compile_error_TESTING_ONLY",
         "pre_dispatch_eager",
+        "relu_accuracy_error_TESTING_ONLY",
+        "relu_compile_error_TESTING_ONLY",
+        "relu_runtime_error_TESTING_ONLY",
+        "ts",
     }
 )
 
@@ -583,6 +590,7 @@ class _DynamoCacheEntry:
     system_info: SystemInfo = dataclasses.field(
         default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
     )
+    device_types: frozenset[str] | None = None
     requires_native_backend_compatibility: bool = True
     fn_name: str | None = None
     fn_first_lineno: str | None = None
@@ -593,21 +601,25 @@ class _DynamoCacheEntry:
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
-        # Determining the codegen target runs the C++ toolchain -- seconds on a
-        # cold inductor cache, and a re-raised InvalidCxxCompiler on a host with
-        # no compiler at all -- so only pay for it when this artifact actually
-        # records one to compare against.
-        check_codegen = self.requires_native_backend_compatibility
+        device_types = getattr(self, "device_types", None) or frozenset(
+            (self.device_type,)
+        )
+        check_codegen = getattr(self, "requires_native_backend_compatibility", True)
+        # Determining the codegen target runs the C++ toolchain, so only pay for
+        # it when this artifact actually records one to compare against.
         current_system_info = SystemInfo.current(
             cpu_codegen=(
                 check_codegen
-                and self.device_type == "cpu"
+                and "cpu" in device_types
                 and self.system_info.cpu_codegen_target is not None
             )
         )
-        self.system_info.check_compatibility(
-            current_system_info, self.device_type, check_codegen=check_codegen
-        )
+        for device_type in device_types:
+            self.system_info.check_compatibility(
+                current_system_info,
+                device_type,
+                check_codegen=check_codegen,
+            )
 
     def debug_info(self) -> dict[str, Any]:
         if len(self.codes) == 0:
@@ -617,6 +629,9 @@ class _DynamoCacheEntry:
             "fn_name": self.fn_name,
             "fn_first_lineno": self.fn_first_lineno,
             "device_type": self.device_type,
+            "device_types": sorted(
+                getattr(self, "device_types", None) or frozenset((self.device_type,))
+            ),
             "backend_ids": list(self.backend_ids),
         }
 
@@ -761,8 +776,9 @@ class CompilePackage:
 
         self._current_entry: _DynamoCodeCacheEntry | None = None
         self._installed_globals: dict[types.ModuleType, list[str]] = {}
-        # device_type that model compiled with.
-        self._device_type = "cpu"
+        # Every device the captured graphs name; the cache entry records the
+        # set, so an accelerator capture with a CPU epilogue is checked as both.
+        self._device_types: set[str] = set()
         # Whether this package's backend generates native code. An eager one
         # bakes no vector width, so it must neither pay the C++ toolchain probe
         # at save nor be rejected on ISA skew at load.
@@ -794,6 +810,7 @@ class CompilePackage:
         if self._initialized:
             raise AssertionError("CompilePackage is already initialized")
         self._source_info = SourceInfo(inlined_sources=set())
+        self._device_types = set()
         self._innermost_fn = innermost_fn(fn)  # type: ignore[assignment]
         if self._innermost_fn is None:
             raise AssertionError("innermost_fn returned None")
@@ -811,6 +828,9 @@ class CompilePackage:
                         )
 
                 self._source_info = dynamo.source_info
+                self._device_types = set(
+                    getattr(dynamo, "device_types", None) or (dynamo.device_type,)
+                )
 
             main, *codes = dynamo.codes
             self._codes = {self._innermost_fn.__code__: main}
@@ -934,10 +954,7 @@ class CompilePackage:
         # a cpu_codegen_target it has no native code for -- which then refuses
         # to load on a host with a different vector ISA or no C++ compiler. A
         # graph that names nothing emits nothing and contributes nothing.
-        device_types = _graph_device_types(graph)
-        if not device_types:
-            return
-        self._device_type = next((d for d in sorted(device_types) if d != "cpu"), "cpu")
+        self._device_types.update(_graph_device_types(graph))
 
     def bypass_current_entry(self) -> None:
         if self._current_entry is None:
@@ -1139,17 +1156,23 @@ class CompilePackage:
         self.validate()
         if self._innermost_fn is None:
             raise AssertionError("_innermost_fn is not set in cache_entry")
+        device_types = frozenset(self._device_types or ("cpu",))
+        device_type = next(
+            (device for device in sorted(device_types) if device != "cpu"),
+            "cpu",
+        )
         return _DynamoCacheEntry(
             codes=list(self._codes.values()),
             source_info=self._source_info,
-            device_type=self._device_type,
+            device_type=device_type,
+            device_types=device_types,
             # The field's default_factory would run the C++ toolchain probe on
             # every save; only an artifact that can hold CPU native code has a
             # baked vector width to record.
             system_info=SystemInfo.current(
                 cpu_codegen=(
                     self._requires_native_backend_compatibility
-                    and self._device_type == "cpu"
+                    and "cpu" in device_types
                 )
             ),
             requires_native_backend_compatibility=(

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -32,7 +32,7 @@ from typing_extensions import Never
 
 import torch
 from torch._dynamo.exc import PackageError
-from torch._dynamo.graph_utils import _graph_device_type
+from torch._dynamo.graph_utils import _graph_device_types
 from torch.utils.weak import WeakIdKeyDictionary
 
 from .bytecode_transformation import (
@@ -387,10 +387,71 @@ def _get_code_source(code: types.CodeType) -> tuple[str, str]:
     return toplevel.__qualname__, code_source.strip(".")
 
 
+_CpuCodegenTarget = tuple[str, str, str | None, str, int | None, str | None]
+
+
+def _current_cpu_codegen_target() -> _CpuCodegenTarget | None:
+    """The vector-width inputs inductor bakes into generated CPU code.
+
+    ``pick_vec_isa`` dry-compiles a probe with the C++ toolchain: seconds on a
+    cold inductor cache, and a hard ``InvalidCxxCompiler`` where there is no
+    compiler at all. Callers must ask for it only when the artifact can hold CPU
+    native code, and a host that cannot build any records None -- it can neither
+    have produced nor be about to run an inductor CPU kernel, so there is no
+    baked vector width to protect.
+    """
+    from torch._inductor import config as inductor_config
+    from torch._inductor.cpu_vec_isa import pick_vec_isa
+
+    try:
+        vec_isa = str(pick_vec_isa())
+    except Exception:
+        logger.warning(
+            "Could not determine the CPU vector ISA, so no CPU codegen target "
+            "is recorded and none will be checked.",
+            exc_info=True,
+        )
+        return None
+
+    return (
+        platform.machine(),
+        torch.backends.cpu.get_cpu_capability(),
+        os.environ.get("ATEN_CPU_CAPABILITY"),
+        vec_isa,
+        inductor_config.cpp.simdlen,
+        inductor_config.cpp.march,
+    )
+
+
+# Registered backends that generate no native code, so an artifact of theirs
+# has no baked vector width to protect and must not be gated on one. This is a
+# blacklist on purpose: anything unrecognised -- including a user's own
+# callable, whose compiler_name is just its __name__ -- is assumed to emit
+# code, because a false rejection at load is recoverable and silently running a
+# kernel built for another ISA is not.
+_NO_NATIVE_CODE_BACKENDS = frozenset(
+    {
+        "aot_eager",
+        "aot_eager_decomp_partition",
+        "aot_eager_decomp_partition_crossref",
+        "aot_eager_decomp_partition_with_mode",
+        "aot_eager_default_partitioner",
+        "eager",
+        "eager_debug",
+        "eager_noexcept",
+        "pre_dispatch_eager",
+    }
+)
+
+
+def emits_native_code(backend_name: str) -> bool:
+    return backend_name not in _NO_NATIVE_CODE_BACKENDS
+
+
 @dataclasses.dataclass(frozen=True)
 class SystemInfo:
     """
-    System information including Python, PyTorch, and GPU details.
+    System information including Python, PyTorch, CPU codegen, and GPU details.
     This information is used to ensure compiled artifacts can only be loaded
     with compatible system configurations.
     """
@@ -400,13 +461,17 @@ class SystemInfo:
     toolkit_version: str | None
     triton_version: tuple[int, int] | None
     gpu_name: str | None
+    cpu_codegen_target: _CpuCodegenTarget | None = None
     CHECK_GPUS = ("cuda", "xpu")
 
     @classmethod
-    def current(cls) -> "SystemInfo":
-        """Create a SystemInfo instance with current system information."""
-        # Get GPU name if CUDA or XPU is available
-        gpu_name = None
+    def current(cls, *, cpu_codegen: bool = True) -> "SystemInfo":
+        """Create a SystemInfo instance with current system information.
+
+        ``cpu_codegen=False`` skips the toolchain probe behind
+        ``cpu_codegen_target``; everything else in here costs microseconds. Pass
+        it only where the result cannot reach a comparison that reads the field.
+        """
         from torch.utils._triton import get_triton_version
 
         gpu_name, toolkit_version = None, None
@@ -425,10 +490,15 @@ class SystemInfo:
             toolkit_version=toolkit_version,
             triton_version=get_triton_version((0, 0)),
             gpu_name=gpu_name,
+            cpu_codegen_target=_current_cpu_codegen_target() if cpu_codegen else None,
         )
 
     def check_compatibility(
-        self, other: "SystemInfo", device_type: str = "cpu"
+        self,
+        other: "SystemInfo",
+        device_type: str = "cpu",
+        *,
+        check_codegen: bool = True,
     ) -> None:
         """
         Check if this SystemInfo is compatible with another SystemInfo.
@@ -443,9 +513,41 @@ class SystemInfo:
             raise RuntimeError(
                 f"Compile package was created with a different PyTorch version: {self.torch_version}"
             )
+        # None means the artifact predates this field, not "no vector ISA".
+        # Only a build with a stable torch_version reaches here with None at
+        # all -- a dev build embeds the git hash, so the torch_version check
+        # just above fires first -- but for a release build it is every artifact already on
+        # disk, rejected over a target they never recorded. New artifacts always
+        # carry a tuple, so the skip does not widen over time.
+        if (
+            check_codegen
+            and device_type == "cpu"
+            and self.cpu_codegen_target is not None
+            and self.cpu_codegen_target != other.cpu_codegen_target
+        ):
+            # None on the current side means the probe could not run at all;
+            # None on the cached side is the "predates the field" case handled
+            # by the condition above and never reaches here.
+            hint = (
+                " The current target is unknown because no usable C++ compiler was found."
+                if other.cpu_codegen_target is None
+                else ""
+            )
+            raise RuntimeError(
+                "Compile package was created with a different CPU codegen target: "
+                f"cached={self.cpu_codegen_target}, current={other.cpu_codegen_target}.{hint}"
+            )
         if device_type in self.CHECK_GPUS:
+            # Device EXISTENCE is not a native-code question: an artifact
+            # holding cuda tensors cannot run without cuda whatever backend
+            # produced it, so this check stays outside check_codegen. Only the
+            # toolkit/Triton/GPU-model checks below describe generated code and
+            # are skipped for a backend that emits none.
             if not getattr(torch, device_type).is_available():
                 raise RuntimeError(f"{device_type} is not available")
+
+            if not check_codegen:
+                return
 
             if self.toolkit_version != other.toolkit_version:
                 raise RuntimeError(
@@ -474,6 +576,7 @@ class _DynamoCacheEntry:
     source_info: SourceInfo
     device_type: str
     system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
+    requires_native_backend_compatibility: bool = True
     fn_name: str | None = None
     fn_first_lineno: str | None = None
 
@@ -483,8 +586,21 @@ class _DynamoCacheEntry:
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
-        current_system_info = SystemInfo.current()
-        self.system_info.check_compatibility(current_system_info, self.device_type)
+        # Determining the codegen target runs the C++ toolchain -- seconds on a
+        # cold inductor cache, and a re-raised InvalidCxxCompiler on a host with
+        # no compiler at all -- so only pay for it when this artifact actually
+        # records one to compare against.
+        check_codegen = self.requires_native_backend_compatibility
+        current_system_info = SystemInfo.current(
+            cpu_codegen=(
+                check_codegen
+                and self.device_type == "cpu"
+                and self.system_info.cpu_codegen_target is not None
+            )
+        )
+        self.system_info.check_compatibility(
+            current_system_info, self.device_type, check_codegen=check_codegen
+        )
 
     def debug_info(self) -> dict[str, Any]:
         if len(self.codes) == 0:
@@ -631,6 +747,7 @@ class CompilePackage:
         fn: Callable[..., Any] | None,
         dynamo: _DynamoCacheEntry | None = None,
         ignore_inlined_sources: bool = False,
+        requires_native_backend_compatibility: bool = True,
     ) -> None:
         self._innermost_fn = None
         self._codes: dict[types.CodeType, _DynamoCodeCacheEntry] = {}
@@ -639,6 +756,12 @@ class CompilePackage:
         self._installed_globals: dict[types.ModuleType, list[str]] = {}
         # device_type that model compiled with.
         self._device_type = "cpu"
+        # Whether this package's backend generates native code. An eager one
+        # bakes no vector width, so it must neither pay the C++ toolchain probe
+        # at save nor be rejected on ISA skew at load.
+        self._requires_native_backend_compatibility = (
+            requires_native_backend_compatibility
+        )
 
         # For debugging/testing purpose only.
         self._cached_backends: dict[_BackendId, Any] = {}
@@ -798,7 +921,16 @@ class CompilePackage:
             self._source_info.add_code(code)
 
     def update_device_type(self, graph: torch.fx.Graph | None) -> None:
-        self._device_type = _graph_device_type(graph)
+        # Every device the graph NAMES, not the first meta value it carries:
+        # under dynamic shapes the leading placeholder is a SymInt, which has no
+        # device, and reading it as "cpu" makes a pure-accelerator capture bake
+        # a cpu_codegen_target it has no native code for -- which then refuses
+        # to load on a host with a different vector ISA or no C++ compiler. A
+        # graph that names nothing emits nothing and contributes nothing.
+        device_types = _graph_device_types(graph)
+        if not device_types:
+            return
+        self._device_type = next((d for d in sorted(device_types) if d != "cpu"), "cpu")
 
     def bypass_current_entry(self) -> None:
         if self._current_entry is None:
@@ -1004,6 +1136,18 @@ class CompilePackage:
             codes=list(self._codes.values()),
             source_info=self._source_info,
             device_type=self._device_type,
+            # The field's default_factory would run the C++ toolchain probe on
+            # every save; only an artifact that can hold CPU native code has a
+            # baked vector width to record.
+            system_info=SystemInfo.current(
+                cpu_codegen=(
+                    self._requires_native_backend_compatibility
+                    and self._device_type == "cpu"
+                )
+            ),
+            requires_native_backend_compatibility=(
+                self._requires_native_backend_compatibility
+            ),
             fn_name=self._innermost_fn.__qualname__,
             fn_first_lineno=self._innermost_fn.__code__.co_firstlineno,
         )

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -243,17 +243,14 @@ class _DynamoCodeCacheEntry:
 
 
 def _restore_missing_fields(obj: Any, state: dict[str, Any]) -> None:
-    """Unpickle a dataclass written before some of its fields existed. A plain
-    default is reachable as a class attribute anyway; a default_factory field
-    (system_info) is not, and read as an AttributeError on load."""
+    """Unpickle a dataclass written before some of its fields existed, filling
+    in plain defaults only. Nothing here may be computed on the loading host:
+    a synthesized SystemInfo compared the host to itself and let any artifact
+    missing one install."""
     obj.__dict__.update(state)
     for field in dataclasses.fields(obj):
-        if field.name in state:
-            continue
-        if field.default is not dataclasses.MISSING:
+        if field.name not in state and field.default is not dataclasses.MISSING:
             setattr(obj, field.name, field.default)
-        elif field.default_factory is not dataclasses.MISSING:
-            setattr(obj, field.name, field.default_factory())
 
 
 def _lookup_code(entry: _DynamoCodeCacheEntry) -> types.CodeType:
@@ -599,14 +596,10 @@ class _DynamoCacheEntry:
     codes: list[_DynamoCodeCacheEntry]
     source_info: SourceInfo
     device_type: str
-    # Probe-free on purpose: this default is what CompileArtifacts(**state)
-    # reaches for a pickle written before the field existed, and running the
-    # C++ toolchain there is seconds on a cold cache and a hard error on a
-    # host with no compiler. Every site that compares the target passes
-    # cpu_codegen= explicitly.
-    system_info: SystemInfo = dataclasses.field(
-        default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
-    )
+    # None only for a pickle written without it (or one that lost the key);
+    # check_versions() rejects it, since there is nothing to compare the host
+    # against. cache_entry() always records one.
+    system_info: SystemInfo | None = None
     device_types: frozenset[str] | None = None
     requires_native_backend_compatibility: bool = True
     fn_name: str | None = None
@@ -621,6 +614,11 @@ class _DynamoCacheEntry:
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
+        if self.system_info is None:
+            raise RuntimeError(
+                "Compile package records no system info; it cannot be checked "
+                "against this host"
+            )
         device_types = self.device_types or frozenset((self.device_type,))
         check_codegen = self.requires_native_backend_compatibility
         # Determining the codegen target runs the C++ toolchain, so only pay for

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -575,7 +575,14 @@ class _DynamoCacheEntry:
     codes: list[_DynamoCodeCacheEntry]
     source_info: SourceInfo
     device_type: str
-    system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
+    # Probe-free on purpose: this default is what CompileArtifacts(**state)
+    # reaches for a pickle written before the field existed, and running the
+    # C++ toolchain there is seconds on a cold cache and a hard error on a
+    # host with no compiler. Every site that compares the target passes
+    # cpu_codegen= explicitly.
+    system_info: SystemInfo = dataclasses.field(
+        default_factory=functools.partial(SystemInfo.current, cpu_codegen=False)
+    )
     requires_native_backend_compatibility: bool = True
     fn_name: str | None = None
     fn_first_lineno: str | None = None

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -238,6 +238,23 @@ class _DynamoCodeCacheEntry:
     has_compile_id: bool = False
     bypassed: bool = False
 
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        _restore_missing_fields(self, state)
+
+
+def _restore_missing_fields(obj: Any, state: dict[str, Any]) -> None:
+    """Unpickle a dataclass written before some of its fields existed. A plain
+    default is reachable as a class attribute anyway; a default_factory field
+    (system_info) is not, and read as an AttributeError on load."""
+    obj.__dict__.update(state)
+    for field in dataclasses.fields(obj):
+        if field.name in state:
+            continue
+        if field.default is not dataclasses.MISSING:
+            setattr(obj, field.name, field.default)
+        elif field.default_factory is not dataclasses.MISSING:
+            setattr(obj, field.name, field.default_factory())
+
 
 def _lookup_code(entry: _DynamoCodeCacheEntry) -> types.CodeType:
     if len(entry.function_names) != 1:
@@ -595,16 +612,17 @@ class _DynamoCacheEntry:
     fn_name: str | None = None
     fn_first_lineno: str | None = None
 
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        _restore_missing_fields(self, state)
+
     @property
     def backend_ids(self) -> set[_BackendId]:
         return {backend_id for code in self.codes for backend_id in code.backend_ids}
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
-        device_types = getattr(self, "device_types", None) or frozenset(
-            (self.device_type,)
-        )
-        check_codegen = getattr(self, "requires_native_backend_compatibility", True)
+        device_types = self.device_types or frozenset((self.device_type,))
+        check_codegen = self.requires_native_backend_compatibility
         # Determining the codegen target runs the C++ toolchain, so only pay for
         # it when this artifact actually records one to compare against.
         current_system_info = SystemInfo.current(
@@ -629,9 +647,7 @@ class _DynamoCacheEntry:
             "fn_name": self.fn_name,
             "fn_first_lineno": self.fn_first_lineno,
             "device_type": self.device_type,
-            "device_types": sorted(
-                getattr(self, "device_types", None) or frozenset((self.device_type,))
-            ),
+            "device_types": sorted(self.device_types or frozenset((self.device_type,))),
             "backend_ids": list(self.backend_ids),
         }
 
@@ -828,14 +844,12 @@ class CompilePackage:
                         )
 
                 self._source_info = dynamo.source_info
-                self._device_types = set(
-                    getattr(dynamo, "device_types", None) or (dynamo.device_type,)
-                )
 
             main, *codes = dynamo.codes
             self._codes = {self._innermost_fn.__code__: main}
             for code in codes:
                 self._codes[SerializedCode.to_code_object(code.python_code)] = code
+            self._device_types = set(dynamo.device_types or (dynamo.device_type,))
         else:
             self._add_function(
                 self._innermost_fn.__code__, self._innermost_fn.__module__

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -989,6 +989,7 @@ def load_compiled_function(
     *,
     f_globals: dict[str, object] | None = None,
     external_data: dict[str, Any] | None = None,
+    guard_globals: dict[str, object] | None = None,
 ) -> Callable[..., Any]:
     """
     Load an aot-compiled function from a file.
@@ -1003,6 +1004,12 @@ def load_compiled_function(
         external_data: Optional data to be loaded into the runtime environment
                        of the compiled function. This should contain the same
                        data as AOTCompileResult.external_data returned from save_compiled_function() call.
+        guard_globals: Optional live global scope the serialized global guards are
+                       checked against, held by reference so a global rebound after
+                       load redirects dispatch. Defaults to the compiled function's
+                       own (reconstructed) globals. Loading injects Dynamo's synthetic
+                       ``__import_*`` module aliases into this scope for any alias not
+                       already bound there, and leaves them in place.
 
     Returns:
         A torch-compiled function with compilation preloaded from disk.
@@ -1010,4 +1017,6 @@ def load_compiled_function(
     from torch._dynamo.aot_compile import AOTCompiledFunction
 
     data = file.read()
-    return AOTCompiledFunction.deserialize(data, f_globals, external_data)
+    return AOTCompiledFunction.deserialize(
+        data, f_globals, external_data, guard_globals=guard_globals
+    )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195352
* #195351
* #195664
* #195350
* #195349
* #195348
* #195347
* __->__ #195346

torch.compile can save a compiled model to disk and load it in a different
process (torch._dynamo.aot_compile). Alongside the code it saves GUARDS:
recorded checks that say which inputs the saved code is valid for, such as "x
is a float32 tensor of shape (3,)" or "the global SCALE is still 2.0". On load
those guards are rebuilt and checked before the saved code runs, so the whole
scheme works only if a guard still means the same thing after the round trip.

Four things broke that. Two crash, and two return silently wrong answers,
which is why they are worth fixing rather than documenting. None of it is
precompile-specific: this is aot_compile's own capture-and-reload path and the
guard pickler that every serializing consumer shares.

1. A model with a decorated forward could not be saved at all

Guards save a function by NAME: write down its module and qualname, look it up
again on load, check you got the same object back. functools.wraps breaks that
assumption, and it is present in every ordinary decorator:

    def keep_defaults(func):
        @functools.wraps(func)
        def wrapper(self, x):
            if len(func.__defaults__) == 2:    # reads the ORIGINAL
                x = x + 1
            return func(self, x)
        return wrapper

    class M(torch.nn.Module):
        @keep_defaults
        def forward(self, x, scale=2.0, shift=1.0):
            return x * scale + shift

wraps copies the original's __qualname__ onto the wrapper, so M.forward now
resolves to the wrapper, and the original -- which the wrapper closes over,
and which the guard is therefore rooted at -- is unreachable by its own name:

    lookup(wrapper)  is wrapper  : True
    lookup(original) is original : False

GuardsStatePickler concluded "unreachable, so nobody needs it" and wrote a
_Missing sentinel. That is correct for an incidental reference and wrong for a
guard root: _Missing carries none of the attributes the guard's source reads,
so the REBUILD fails rather than the guard. Binding a wrapper under a
different name does the same thing to the wrapper. A function that appears in
guard_tree_values is now reconstructed instead, and the sentinel stays for
every function no guard needs.

2. A reloaded nn.Module resolved its global guards against the wrong scope

    SCALE = 2.0

    class M(torch.nn.Module):
        def forward(self, x):
            return x * SCALE

The guard here is "the global SCALE is still 2.0".
AOTCompiledModel.deserialize supplied no scope, so the guard was checked
against a namespace forward_callable SYNTHESIZES from the artifact rather than
against the loading process's real globals. Either SCALE is absent from it and
every call fails with "KeyError on G['SCALE']" as its reason, or it is present
holding the value baked in at capture, so rebinding SCALE to 3.0 changes
nothing and the artifact quietly keeps computing with 2.0.

One precondition worth stating: aot_compile_fullgraph's default guard filter
drops every global guard, so reaching this needs a caller who passed a
guard_filter_fn to keep one, which is what the new tests do.

The load path now takes a real scope and holds it by reference, so a global
rebound after load redirects dispatch. There is deliberately no fallback to
the serialized value: a loud refusal on the serving machine is recoverable
where a silently stale answer is not.

3. "Nothing matched" reported the wrong candidate

Compile for three input shapes and call with a fourth, and dispatch ran graph
0 purely so that its guard check would raise. The error therefore always
blamed the first compiled input, whichever candidate was actually closest. It
now reports one line per candidate saying why that candidate was rejected, and
ends with what to do about it.

The related case is worse. A result whose owner called disable_guard_check
accepts ANYTHING. Before, a total miss simply ran compiled_results[0], so an
opted-out artifact at index 0 answered a call meant for another one: no error,
different numbers. That fallback is now conditional on the opted-out result
being the ONLY candidate. Honouring it at any index would have moved the same
silent-wrong-answer from index 0 to "whichever opted out" rather than removing
it, since the opt-out says the guards may be ignored, not that this graph is
the right one for the call.

4. The machine-compatibility gate ran backwards, and missed vector width

Inductor bakes a vector width into generated CPU code, so an artifact built on
an AVX-512 host executes instructions an AVX2 host does not have. Nothing
checked for it. SystemInfo now records the inputs inductor picks a target
from and refuses an artifact captured against a different one. Backends that
emit no native code are exempt by name, and the exemption is a blacklist on
purpose: a false rejection at load is recoverable, and running a kernel built
for an ISA the host lacks is not. An entry pickled before these fields existed
loads with them at their plain defaults through __setstate__ (each code entry
restores bypassed the same way), so a cache written by an older build is not
refused for a field it could not know about. The record of the capturing
machine is the exception: a pickle that predates system_info now fails
check_versions() instead of being compared against the loading host itself,
since a SystemInfo synthesized on load matched the host to itself and let any
artifact missing one install.

Separately, CompileArtifacts.check_compatibility called the comparison on the
wrong receiver, current machine first and artifact second. Every message
interpolates self, so "created with a different Python/PyTorch/toolkit/Triton
version" printed the CURRENT process's value while labelling it the
artifact's. Reversed the same way, the skip for an artifact predating
cpu_codegen_target was evaluated against the current machine, which is never
None, so it would have rejected every artifact already on disk over a target
it never recorded. The cached info is the receiver now, matching
_DynamoCacheEntry.check_versions.

Implementation notes

The reconstructed function is built from its code, module, qualname, name and
__doc__ alone; defaults, kwdefaults, attributes, closure contents and the
__globals__ snapshot all travel in the reduce STATE slot, pruning everything
unreferenced to a sentinel so that reconstructing more functions does not drag
unpicklable neighbours in with them. Nothing that can hold a function goes in
the args because pickle memoizes an object only after saving its args, so ANY
path from an arg back to the function being reduced -- a decorator writing a
counter onto its own wrapper, an ordinary module-scope `wrapped = deco(base)`
reaching itself through its globals, or two kept functions that refer to each
other -- recursed until RecursionError, whereas state is applied after
memoization and those references resolve to the pickle already built. Cells
are the exception, since __closure__ is read-only after construction: a kept
cell travels in args by identity, reduced EMPTY, and its contents come back
through the owning function's state, which is what keeps two functions
closing over one variable sharing one cell. __module__ is set explicitly,
because FunctionType reads it out of globals["__name__"], which a snapshot
scope does not have. An empty cell -- a free variable a decorator only assigns
on a path that did not run -- no longer escapes as ValueError.

pickle_guards_state widens its handler from AttributeError to Exception, so an
assert inside a user __reduce__ becomes a package bypass instead of a failed
compile. Two kinds are excluded. Dynamo's own control flow -- RestartAnalysis,
SkipFrame, Unsupported and ObservedException all derive from
TorchDynamoException -- because pickling runs user __reduce__, __getstate__
and property getters, any of which may call a compiled callable, and one of
these coming back out of that call belongs to the frame being compiled there.
And RecursionError, which here is a reducer that failed to break a cycle or
a pickler that recursed on depth it should have flattened: both are ours, and
a bypass would hide them behind a model that silently runs eager.

The reload scope is a dedicated guard_globals parameter and _guard_globals
field rather than the existing f_globals / _extra_globals, which feed
forward_callable and would rewire what the compiled bytecode reads. It comes
from model.forward, which is what aot_compile_module traces; passing the model
would take get_traced_fn's nn.Module branch and hand back
Module._wrapped_call_impl's namespace for any hooked module. A forward that is
not a function or bound method logs at info and keeps the old behaviour rather
than failing a load for a model that very likely has no global guards at all.
Because the scope is now the loading process's, the same path seeds
the artifact's __import_* aliases, which Dynamo mints into the tracing
process's globals and roots hook-dict guards at, and which a process that only
loads never has; an alias already bound there is left alone, so loading does
not import modules the scope already holds. torch.compiler.load_compiled_function
takes the same guard_globals, so the function path can be given a live scope
as well; without one it keeps resolving against the reconstructed globals.
The no-match report flattens each candidate's reason onto one line, so it is
one line per candidate however a guard's failure text is formatted.

Determining the codegen target dry-compiles a probe with the C++ toolchain,
seconds on a cold inductor cache and a hard error on a host with no compiler,
so save and load ask for it only when the artifact can hold CPU native code;
that is why the answer is carried on _DynamoCacheEntry and CompilePackage, and
why eval_frame classifies the backend before get_compiler_fn erases its name,
through one helper that also recognises a registered backend callable by
identity rather than by stringifying it. The exemption list is new here and
names eager and its aot_eager variants, ts, aot_ts, cudagraphs and the
testing-only debugging backends, since none emits CPU native code.
Finally, _graph_device_types replaces reading the graph's first meta value,
which under dynamic shapes is a SymInt with no device and so reported "cpu"
for an all-accelerator graph, arming the CPU codegen check on an artifact with
no CPU code in it.

Read torch/_dynamo/guards.py first for the serialization half, then
torch/_dynamo/aot_compile.py for the reload scope and the dispatch report;
package.py, graph_utils.py and eval_frame.py are last and are the
compatibility gate, which is what decides whether an artifact captured on one
machine is allowed to run on another at all.

The cache entry records every device the captured graphs name, not one: an
accelerator capture with a CPU epilogue is compatibility-checked as both, and
the CPU codegen gate is armed only when "cpu" is among them. The
torch.compiler_aot_compile docs state the disable_guard_check rule above.

Test Plan:

```
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_aot_compile.py
python test/dynamo/test_package.py
```

test_guard_serialization.py gains fourteen tests. Most drive a real capture
of a functools.wraps-decorated forward: one parametrized case per carried
piece, so dropping any one of __kwdefaults__, attributes, __name__, defaults
or the globals snapshot fails a case that names it; a renamed-name case
catches a reconstruction that falls back to co_name; one guards a global the
reconstructed function reads and one gives it an unpicklable default no
guard reads, pinning what the snapshot keeps and what it prunes; the
module-scope pair of wrappers that reach themselves through their own
globals, the wrapper that holds itself in a cell or attribute, and the pair
of functions that reach each other are the RecursionError regressions; and a
function guarded on its __module__ pins that it comes back set. The rest go
at the pickler directly: two for the empty cell, one asserting a
self-reference comes BACK rather than being silently dropped, two asserting
a shared closure cell is still shared after a round trip (one through a
self-reference, one through an fqn-mismatched forward), and one that a
TorchDynamoException raised inside a __reduce__ propagates instead of
becoming a bypass.

The new tests in test_aot_compile.py: six on the reload, two on the
no-match report including the one where re-checking a guard raises and must
not replace the report, three on disable_guard_check being a last resort rather
than a candidate, including the several-candidate total miss that used to be
served by the opted-out result, and one on the compatibility receiver order, which also pins
that an eager artifact is not gated on a codegen target at all. Of the reload
tests, global dispatch, the forward-hook scope, the rebound global and the
absent global all fail on the pre-change tree. The import-alias test is the
opposite kind: the synthesized scope already contained those aliases, so it
bites this change without the seeding step. Hermeticity is pinned from both
sides, rebinding a global before load and asserting the graph keeps the
serialized value, then after load and asserting dispatch follows the live one.
test_package.py gains one test that loads a cache entry pickled without the
new fields, and the rest of it is run as a regression check on the package and
eval_frame edits.

Authored with the assistance of an AI coding agent.