### PR TITLE
[precompile] Capture graph breaks and recompiled variants with tracer='dynamo'

### DIFF
--- a/docs/source/torch.compiler_api.md
+++ b/docs/source/torch.compiler_api.md
@@ -50,11 +50,18 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 % intentionally omitted from the autosummary block above.
 
 ```{eval-rst}
-.. py:function:: precompile(fn, *example_inputs, backend="inductor", tracer="make_fx", decompositions=None)
+.. py:function:: precompile(fn, *, backend="inductor", tracer="make_fx", decompositions=None, example_inputs, guard_filter_fn=None, recompile_limit=256, dynamic=None, invariants=None, training=False)
 
-   Ahead-of-time precompile ``fn`` against example inputs, returning a self-contained,
-   runnable Python source string plus an acceleration cache as ``(python_code, cache)``.
-   ``fn`` is the whole computation, taking the model(s) as
+   Ahead-of-time precompile ``fn`` against ``example_inputs``, a sequence of calls each
+   given as a tuple of positional arguments. precompile makes those calls itself and
+   returns a self-contained, runnable Python source string plus an acceleration cache as
+   ``(python_code, cache)``. ``tracer`` picks the capture front-end: ``"make_fx"`` (the
+   default) is one non-strict ATen trace and takes exactly one call, while ``"dynamo"``
+   takes as many as you give it and captures every graph-break continuation and guarded
+   recompilation those calls exercise, under full runtime guards.
+   This is execution-driven coverage, not an
+   exhaustive analysis: paths and values that no example executes are absent. ``fn`` is
+   the whole computation, taking the model(s) as
    explicit arguments, e.g. ``lambda model, x: model(x)`` or a training step. The
    ``nn.Module`` arguments have their parameters/buffers lifted to graph inputs, so no
    weights are baked into the artifact -- you pass the model again at runtime to the
@@ -64,8 +71,10 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 
       With the default ``make_fx`` tracer, capture is non-strict. Control flow is
       specialized to the example inputs, and shapes are static -- each size is baked in.
-      The exception is a tensor dim explicitly marked unbacked (inductor backend only)
-      with ``torch._dynamo.decorators.mark_unbacked`` on the inputs before the call; such
+      The exception is a tensor dim explicitly marked unbacked with
+      ``torch._dynamo.decorators.mark_unbacked`` on the inputs before the call (with
+      ``make_fx`` this requires the inductor backend; with ``tracer="dynamo"`` either
+      backend works); such
       a dim is captured as an unbacked symint, so one artifact serves any runtime size of
       it, and a graph that needs to guard on it fails at capture. Each input's dtype and
       device are specialized too (a runtime mismatch is rejected), and the inductor backend
@@ -83,20 +92,59 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
 
    :param fn: The whole computation to capture, taking the model(s) and runtime inputs
        as positional arguments.
-   :param example_inputs: Example positional arguments to ``fn``; the ``nn.Module``
-       arguments are lifted and the rest are the runtime inputs.
+   :param example_inputs: Required. Sequence of calls to capture, each a tuple of
+       positional arguments (or a ``torch.compiler.precompile.ExampleInput`` when keyword
+       arguments are needed; ``tracer="make_fx"`` is positional-only). ``tracer="make_fx"``
+       requires exactly one; ``tracer="dynamo"`` accepts any number, and what differs
+       between them is what the artifact can discriminate on. The ``nn.Module`` arguments
+       are lifted and the rest are the runtime inputs. Calls run under ordinary
+       ``torch.no_grad()`` unless ``training=True``, even if the caller is in
+       ``torch.inference_mode()``; serve the resulting artifact under the same grad mode.
+       Inference mode is a distinct guarded state and must be captured manually if needed.
+       Tensors created inside inference mode remain inference tensors after that context is
+       disabled, so they are rejected; create those inputs outside inference mode.
    :param backend: ``"inductor"`` (default) lowers through AOTAutograd + Inductor;
        ``"eager"`` keeps the captured ATen graph (layout-flexible, no kernels; shapes
        are still specialized to the example).
-   :param tracer: capture front-end. ``"make_fx"`` (default) is a non-strict make_fx
-       trace and the only tracer implemented today; ``"dynamo"`` is planned and raises
-       ``NotImplementedError`` for now.
+   :param tracer: capture front-end, defaulting to ``"make_fx"``. ``"make_fx"`` is a
+       non-strict make_fx trace of a single call; passing more than one entry in
+       ``example_inputs`` raises. ``"dynamo"`` analyzes the Python (bytecode) rather than tracing one path and
+       inlines the transformed bytecode Dynamo produces into ``python_code``, lowering the
+       compiled subgraph through the same ``backend`` choices; it honors ``mark_unbacked``
+       dynamic shapes (on either backend, though ``mark_unbacked(strict=True)`` raises --
+       Dynamo captures a strict mark as a guardable backed dim), ``decompositions``, and
+       training steps (a ``.backward()`` / ``torch.autograd.grad`` is traced into the graph
+       and the parameter gradients are accumulated onto the runtime model like eager).
+       ``make_fx`` requires one full graph; use ``tracer="dynamo"`` when Python
+       graph-breaks or when several guarded/recompiled variants must be retained.
+       Unlike ``make_fx``, the dynamo driver
+       does NOT re-validate the
+       runtime model/inputs, so on the eager backend a drifted model (broken weight tying,
+       a retyped/reshaped weight) or a broadcast-compatible input-shape mismatch can
+       silently miscompute where ``make_fx`` would raise; pass a model and inputs matching
+       the example. The dynamo artifact inlines marshalled bytecode plus a pickled state
+       blob, so it is locked to the Python version that produced it AND, because its import
+       aliases can reference private ``torch._dynamo`` modules, to a compatible torch build,
+       unlike ``make_fx`` source (Python-version portable on either backend; use
+       ``backend='eager'`` for portability across torch builds too, since the default
+       ``make_fx`` inductor artifact inlines private ``torch._inductor`` modules).
    :param decompositions: Optional decomposition table (``dict`` of ``OpOverload`` to a
-       decomposition function) forwarded to ``make_fx``; defaults to ``None``.
-   :returns: ``(python_code, cache)`` -- a self-contained Python source string (the
-       single source of truth for the calling convention) and a binary acceleration
-       cache (no weights, no calling-convention metadata; it carries a small
-       format/version/backend/code_hash integrity tag that ``load`` verifies).
+       decomposition function) controlling how ATen ops are broken down in the captured
+       graph; defaults to ``None``. ``tracer="make_fx"`` forwards it to ``make_fx`` during
+       capture. It applies only to ``tracer="make_fx"``; the dynamo tracer lowers through
+       the backend instead and rejects it.
+   :param guard_filter_fn: Multi-graph serialization filter; returns one boolean per guard
+       entry. Live capture retains all guards so later examples trigger their recompiles.
+       Risky dropped guards are rejected by default when saving, and every
+       custom-filter drop counts as risky.
+   :param recompile_limit: Maximum multi-graph variants captured per frame; defaults to 256
+       and overrides a lower ambient accumulated-recompile limit for this capture.
+   :param dynamic: Multi-graph dynamic-shape policy forwarded to ``torch.compile``.
+   :param invariants: Optional path receiving the multi-graph invariant report.
+   :returns: For positional input, ``(python_code, cache)`` -- a self-contained Python
+       source string and binary acceleration cache. For keyword ``example_inputs``, a
+       session exposing ``summary()``, ``save()``, and invariant reporting. Its
+       ``summary().complete`` covers the successful calls that ran, not every possible input.
    :raises PrecompileError: if capture, lowering, or a runtime call violates the
        contract (see the exception below).
 
@@ -105,6 +153,19 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        python_code, cache = torch.compiler.precompile(lambda m, x: m(x), model, x)
        f = torch.compiler.precompile.load(python_code, cache)
        out = f(model, x)   # pass the model again at runtime
+
+       def staged(x):
+           y = x + 1
+           scale = y.sum().item()  # a graph break
+           return y * scale
+
+       python_code, cache = torch.compiler.precompile(
+           staged,
+           example_inputs=[(example_a,), (example_b,)],
+       )
+       compiled = torch.compiler.precompile.load(python_code, cache)
+       with compiled, torch.no_grad():
+           out = compiled(example_a)
 ```
 
 ```{eval-rst}
@@ -132,8 +193,28 @@ For a quick overview of `torch.compiler`, see {ref}`torch.compiler_overview`.
        calling conventions are not supported.
    :raises PrecompileError: if ``python_code`` is not a valid precompile artifact (it
        fails to parse or is missing its calling-convention metadata), if ``cache`` is
-       paired with a different ``python_code`` (mismatched ``backend`` tag or
-       ``code_hash``), or if a runtime call violates the precompile contract.
+       paired with a different ``python_code`` (mismatched ``backend`` tag, ``tracer``
+       tag, or ``code_hash``), or if a runtime call violates the precompile contract.
+
+.. py:class:: precompile.ExampleInput(args=(), kwargs={})
+
+   One capture call for ``example_inputs`` when positional arguments alone are not
+   enough (``tracer="dynamo"`` only). A plain tuple in ``example_inputs`` is the
+   positional arguments of one
+   call; wrap a call that needs keyword arguments in this instead::
+
+       torch.compiler.precompile(
+           fn,
+           example_inputs=[
+               (x,),
+               torch.compiler.precompile.ExampleInput(args=(x,), kwargs={"scale": 2}),
+           ],
+       )
 
 .. autoexception:: torch.compiler.PrecompileError
+
+.. autoclass:: torch.compiler.PrecompiledCallable
+   :members:
+
+
 ```

--- a/docs/source/user_guide/torch_compiler/torch.compiler.md
+++ b/docs/source/user_guide/torch_compiler/torch.compiler.md
@@ -35,9 +35,11 @@ might be used interchangeably in this documentation.
 :::
 
 `torch.compiler` also includes an ahead-of-time API, `torch.compiler.precompile`. It
-captures a whole computation `fn(*example_inputs)` -- with the model(s) passed among
-`example_inputs`, e.g. `precompile(lambda model, x: model(x), model, x)` -- and lowers it
-to a self-contained, runnable Python source string plus an acceleration cache. Reload the
+captures a whole computation -- with the model(s) passed among the arguments of the
+example call, e.g. `precompile(lambda model, x: model(x), example_inputs=[(model, x)])`
+-- and lowers it to a self-contained, runnable Python source string plus an acceleration
+cache. Pass `tracer="dynamo"` to capture several calls, with the graph breaks and
+recompilations between them. Reload the
 artifact with `torch.compiler.precompile.load`; since no weights are baked in, you pass
 the model again at runtime. See the {ref}`API reference <torch.compiler_api>` for details.
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -10122,9 +10122,13 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         try:
             with torch.compiler.set_stance("fail_on_recompile"):
                 with self.assertRaisesRegex(
-                    RuntimeError, "Failed on the following precompiled guards:"
-                ):
+                    RuntimeError, r"Failed on all 1 precompiled variant\(s\)"
+                ) as ctx:
                     compiled_fn(*args)
+            # One line for the entry, naming the guard that rejected the call --
+            # not the whole guard tree, which for a multi-variant artifact ran
+            # to megabytes.
+            self.assertIn("isinstance(L['x'], bool)", str(ctx.exception))
         finally:
             _reset_precompile_entries(fn.__code__)
 

--- a/test/dynamo/test_package.py
+++ b/test/dynamo/test_package.py
@@ -1,22 +1,58 @@
 # Owner(s): ["module: dynamo"]
 
+import builtins
+import contextlib
+import dataclasses
+import faulthandler
+import functools
 import gc
 import importlib
+import inspect
+import itertools
+import math
+import math as _precompile_stdlib_alias
 import os
+import pickle
+import queue
+import re
 import sys
+import sysconfig
 import tempfile
+import threading
+import types
 import unittest
+import weakref
+from unittest import mock
 
 import torch
+import torch._dynamo.package as dynamo_package
+import torch._dynamo.precompile_package as dynamo_package_lint
 import torch._dynamo.testing
 import torch._inductor.config
 import torch._inductor.test_case
+import torch.nn.functional as F
 import torch.onnx.operators
 import torch.utils.cpp_extension
-from torch._dynamo.package import CompilePackage, DiskDynamoStore, DynamoCache
+from torch._dynamo.exc import PackageError, RecompileError
+from torch._dynamo.package import (
+    _defining_module_name,
+    CompilePackage,
+    DiskDynamoStore,
+    DynamoCache,
+    SystemInfo,
+)
 from torch._dynamo.precompile_context import PrecompileContext
+from torch._dynamo.precompile_package import (
+    _dynamo_alias_module,
+    _fact_order,
+    _GuardFact,
+    _SingleFileStore,
+    precompile_capture,
+    precompile_load,
+    serving,
+)
 from torch._dynamo.testing import reduce_to_scalar_loss
-from torch._dynamo.utils import CleanupManager
+from torch._dynamo.utils import CleanupHook, CleanupManager
 from torch._functorch import config as functorch_config
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch.testing._internal.common_utils import (
@@ -31,12 +67,1063 @@ from torch.testing._internal.inductor_utils import (
 )
 
 
+def staged_with_graph_breaks(x):
+    x = x * 2
+    torch._dynamo.graph_break()
+    x = x + 3
+    torch._dynamo.graph_break()
+    return x.sum()
+
+
+# A pair that differs only after the break, so a resume function borrowed from
+# the wrong artifact still runs and still returns a number.
+def staged_break_then_add_one(x):
+    y = x * 2
+    torch._dynamo.graph_break()
+    return (y + 1).sum()
+
+
+def staged_break_then_add_thousand(x):
+    y = x * 2
+    torch._dynamo.graph_break()
+    return (y + 1000).sum()
+
+
+def _resume_names_in(path):
+    with open(path, "rb") as f:
+        entry = pickle.load(f)
+    return [
+        name
+        for code in entry.dynamo.codes
+        if code.install_to_global
+        for name in code.function_names
+    ]
+
+
+def _rename_resume_function(path, old, new):
+    """
+    Give a saved artifact the resume-function name a SEPARATE capture process
+    would have minted for it. The name comes from a counter that restarts per
+    process, so two captures in one process cannot collide, but two capture
+    processes routinely do.
+    """
+    with open(path, "rb") as f:
+        entry = pickle.load(f)
+    for code in entry.dynamo.codes:
+        code.function_names = [new if n == old else n for n in code.function_names]
+        for guarded in code.guarded_codes:
+            guarded.dynamo_code = dataclasses.replace(
+                guarded.dynamo_code,
+                co_names=tuple(
+                    new if n == old else n for n in guarded.dynamo_code.co_names
+                ),
+            )
+    with open(path, "wb") as f:
+        pickle.dump(entry, f)
+
+
+class PrecompileBlock(torch.nn.Module):
+    def __init__(self, i):
+        super().__init__()
+        self.i = i
+
+    def forward(self, x):
+        x = x * 2 + self.i
+        torch._dynamo.graph_break()
+        return x
+
+
+class PrecompileStack(torch.nn.Module):
+    """All blocks share one forward code object, so variants pile onto it."""
+
+    def __init__(self, n):
+        super().__init__()
+        self.blocks = torch.nn.ModuleList([PrecompileBlock(i) for i in range(n)])
+
+    def forward(self, x):
+        for b in self.blocks:
+            x = b(x)
+        return x.sum()
+
+
+class PrecompileResumingBlock(torch.nn.Module):
+    """Like PrecompileBlock, but the frame resumed after the break compiles too."""
+
+    def __init__(self, i):
+        super().__init__()
+        self.i = i
+
+    def forward(self, x):
+        x = x * 2 + self.i
+        torch._dynamo.graph_break()
+        return x + 1.0
+
+
+class PrecompileResumingStack(torch.nn.Module):
+    def __init__(self, n):
+        super().__init__()
+        self.blocks = torch.nn.ModuleList(
+            [PrecompileResumingBlock(i) for i in range(n)]
+        )
+
+    def forward(self, x):
+        for b in self.blocks:
+            x = b(x)
+        return x.sum()
+
+
+PRECOMPILE_CONFIG = {"mode": "sum"}
+
+
+def staged_with_global_dict_conditional(x):
+    # The global is read on both sides of the break, so the entry frame and the
+    # resume frame each carry a guard on it.
+    if PRECOMPILE_CONFIG["mode"] == "sum":
+        x = x * 2
+    else:
+        x = x * 3
+    torch._dynamo.graph_break()
+    if PRECOMPILE_CONFIG["mode"] == "sum":
+        return x.sum()
+    return x.mean() * 10.0
+
+
+def staged_with_nested_dict_conditional(x, cfg):
+    # membership, nested lookup, and iteration over the key set, which produce
+    # DICT_CONTAINS / DICT_NOT_CONTAINS / DICT_KEYS_MATCH rather than a plain
+    # value comparison.
+    if "alpha" in cfg and cfg["alpha"]["kind"] == "wide":
+        x = x * len(cfg["alpha"]["dims"])
+    else:
+        x = x + 1
+    torch._dynamo.graph_break()
+    total = 0
+    for k in sorted(cfg):
+        total += cfg[k]["weight"]
+    return x.sum() * total
+
+
+def staged_with_local_dict_conditional(x, cfg):
+    if cfg["op"] == "sin":
+        x = x.sin()
+    else:
+        x = x.cos()
+    torch._dynamo.graph_break()
+    return x.sum() * cfg["scale"]
+
+
+def staged_with_builtin_calls(x, cfg):
+    # len() and sorted() are resolved through the builtins dict Dynamo installs
+    # in this module, which is where a builtin read the ordinary way comes from.
+    n = len(cfg)
+    torch._dynamo.graph_break()
+    return x.sum() * n * len(sorted(cfg))
+
+
+def _precompile_house_op(t):
+    return t * 5.0
+
+
+_PRECOMPILE_OPS = {"len": len}
+
+
+def staged_with_injected_builtin(x):
+    # The test installs this into builtins, so it is read exactly the way len()
+    # is, off a namespace anyone can write to at runtime.
+    y = precompile_house_op(x)  # noqa: F821
+    torch._dynamo.graph_break()
+    return (y + 1).sum()
+
+
+def staged_with_a_registry_keyed_by_a_builtin_name(x, cfg):
+    n = _PRECOMPILE_OPS["len"](cfg)
+    torch._dynamo.graph_break()
+    return x.sum() * n
+
+
+def _precompile_user_act(t):
+    return -t
+
+
+def _precompile_scale(t):
+    return t * 2
+
+
+def _precompile_closure_over(fn):
+    def inner(x):
+        return fn(x).sum()
+
+    return inner
+
+
+class _PrecompileRegistry:
+    def __init__(self, act):
+        self.act = act
+
+
+PRECOMPILE_DISPATCH = {"act": _precompile_user_act}
+PRECOMPILE_REGISTRY = _PrecompileRegistry(_precompile_user_act)
+
+
+class PrecompileNoDispatchSlot(torch.nn.Module):
+    """Ordinary code with no swappable slot: a torch op, stdlib, a local def."""
+
+    def forward(self, x):
+        y = torch.relu(_precompile_scale(x)) * math.sqrt(2.0)
+        torch._dynamo.graph_break()
+        return (y + 1).sum()
+
+
+PRECOMPILE_INV_CONFIG = {"mode": "sum"}
+
+
+def _in_inference_mode(tensor):
+    """Tag a tensor so the call using it runs under inference_mode."""
+    return _InferenceInput(tensor)
+
+
+def _marked_static(tensor):
+    torch._dynamo.mark_static(tensor, 0)
+    return tensor
+
+
+class _InferenceInput:
+    """Marker: the corpus runs this input inside inference_mode."""
+
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+
+class PrecompileInvariantModel(torch.nn.Module):
+    """Reads a global across a graph break, so the resume frame guards it."""
+
+    def forward(self, x):
+        y = x * 2
+        torch._dynamo.graph_break()
+        if PRECOMPILE_INV_CONFIG["mode"] == "sum":
+            return y.sum()
+        return y.mean()
+
+
+class PrecompileBuiltinReadingModel(torch.nn.Module):
+    """Iterates a ModuleList, which reads ``iter`` off Dynamo's builtins dict."""
+
+    def __init__(self):
+        super().__init__()
+        self.blocks = torch.nn.ModuleList([torch.nn.Linear(8, 8) for _ in range(2)])
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x.sum()
+
+
+class PrecompileSharedBlock(torch.nn.Module):
+    """A library block reused by two different models; its frame graph-breaks."""
+
+    def __init__(self, scale):
+        super().__init__()
+        self.scale = scale
+
+    def forward(self, x):
+        y = x * 2
+        torch._dynamo.graph_break()
+        return y * self.scale
+
+
+class PrecompileSharedUserA(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.block = PrecompileSharedBlock(scale)
+
+    def forward(self, x):
+        return self.block(x).sum()
+
+
+class PrecompileSharedUserB(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.block = PrecompileSharedBlock(scale)
+
+    def forward(self, x):
+        return self.block(x).sum() + 0.0
+
+
+class PrecompileSelfAct(torch.nn.Module):
+    """self.act = <callable> -- how configurable activations are usually written."""
+
+    def __init__(self, act):
+        super().__init__()
+        self.act = act
+
+    def forward(self, x):
+        y = self.act(x)
+        torch._dynamo.graph_break()
+        return (y + 1).sum()
+
+
+# One source LINE, so the two entries agree on file AND lineno: what separates
+# them can only come from the code body. This is the ACT2FN shape.
+_LAMBDA_TABLE = {"a": lambda x: x.sin(), "b": lambda x: x.cos()}
+
+
+class PrecompileLambdaTablePair(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.ms = torch.nn.ModuleList(
+            [
+                PrecompileSelfAct(_LAMBDA_TABLE["a"]),
+                PrecompileSelfAct(_LAMBDA_TABLE["b"]),
+            ]
+        )
+
+    def forward(self, x):
+        out = x.sum()
+        for m in self.ms:
+            out = out + m(x)
+        return out
+
+
+_SHARED_RACE_SRC = """\
+import torch
+
+
+class SharedBlock(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.scale = scale
+
+    def forward(self, x):
+        y = x * 2
+        torch._dynamo.graph_break()
+        return y * self.scale
+
+
+class ModelOne(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.block = SharedBlock(scale)
+
+    def forward(self, x):
+        return self.block(x).sum()
+
+
+class ModelTwo(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.block = SharedBlock(scale)
+
+    def forward(self, x):
+        return self.block(x).sum() + 0.0
+"""
+
+
+_BUILTIN_ACROSS_BREAK_SRC = """\
+import torch
+
+
+class Model(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.scale = scale
+
+    def forward(self, x, cfg):
+        # `f` holds a builtin across the break, so the dynamo bytecode puts it
+        # back by READING Dynamo's builtins-dict global rather than by
+        # resolving the name again through the ordinary lookup.
+        f = len
+        y = x * self.scale
+        torch._dynamo.graph_break()
+        return y.sum() * f(cfg)
+"""
+
+
+_SHARED_FRAME_SRC = """\
+import torch
+
+
+class SharedBlock(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.scale = scale
+
+    def forward(self, x):
+        y = x * 2
+        marker = y.sum().item()
+        return y * self.scale + marker * 0.0
+
+
+class ModelOne(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.block = SharedBlock(scale)
+
+    def forward(self, x):
+        return self.block(x).sum()
+
+
+class ModelTwo(torch.nn.Module):
+    def __init__(self, scale):
+        super().__init__()
+        self.block = SharedBlock(scale)
+
+    def forward(self, x):
+        return self.block(x).sum() + 0.0
+"""
+
+
+class PrecompileEmptyGraph(torch.nn.Module):
+    """Used to construct a legacy package with no guarded code in skip tests."""
+
+    def forward(self, x):
+        return x.sin()
+
+
+class PrecompileValuePinned(torch.nn.Module):
+    def forward(self, x):
+        scale = x.abs().max().item()
+        y = x * 2 if scale > 0.5 else x * 3
+        return y.sum()
+
+
+class PrecompileItemThenBreak(torch.nn.Module):
+    """.item() pins the stack slot AND the local the resume frame reads it from."""
+
+    def forward(self, x):
+        scale = x.abs().max().item()
+        torch._dynamo.graph_break()
+        return (x * 2 if scale > 0.5 else x * 3).sum()
+
+
+class PrecompileIntArg(torch.nn.Module):
+    def forward(self, x, k):
+        y = x * k
+        torch._dynamo.graph_break()
+        return (y + k).sum()
+
+
+class PrecompileBreakOnlyWhenFalse(torch.nn.Module):
+    """The uncovered branch breaks AGAIN, so a fallback compile mints new globals."""
+
+    def forward(self, x, flag):
+        y = x * 2
+        torch._dynamo.graph_break()
+        if flag:
+            return y + 1
+        z = y - 1
+        torch._dynamo.graph_break()
+        return z * 3
+
+
+class PrecompileKeysArg(torch.nn.Module):
+    """A dict_keys argument is pinned by EQUALS_MATCH, not CONSTANT_MATCH."""
+
+    def forward(self, x, ks):
+        y = x * float(len(ks))
+        torch._dynamo.graph_break()
+        return (y + 1).sum()
+
+
+class PrecompileIntAttr(torch.nn.Module):
+    def __init__(self, k):
+        super().__init__()
+        self.k = k
+
+    def forward(self, x):
+        y = x * self.k
+        torch._dynamo.graph_break()
+        return (y + self.k).sum()
+
+
+def _precompile_break_then_cos(t):
+    torch._dynamo.graph_break()
+    return t.cos()
+
+
+class PrecompileTensorAcrossBreak(torch.nn.Module):
+    """x.sin() sits on the stack across the break, so it gets a ___stackN name."""
+
+    def forward(self, x):
+        return (x.sin() + _precompile_break_then_cos(x)).sum()
+
+
+class PrecompileConfigConstants(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.ln = torch.nn.LayerNorm(8)
+        self.drop = torch.nn.Dropout(0.1)
+        self.lin = torch.nn.Linear(8, 8)
+
+    def forward(self, x):
+        return self.drop(self.lin(self.ln(x))).relu().sum()
+
+
+class PrecompileAliasedImport(torch.nn.Module):
+    """import torch.nn.functional as F -- the global name is not the module's."""
+
+    def forward(self, x):
+        return F.gelu(x).sum()
+
+
+class PrecompileFullyQualified(torch.nn.Module):
+    """torch.nn.functional.gelu spelled out -- the namespace is two hops down."""
+
+    def forward(self, x):
+        return torch.nn.functional.gelu(x).sum()
+
+
+class PrecompileFunctionScopedImport(torch.nn.Module):
+    """A function-scoped `import torch`, which transformers is full of. Dynamo
+    reaches it through the `__import_torch` alias and guards the attributes read
+    off that alias, never the alias itself."""
+
+    def forward(self, x):
+        import torch
+
+        if isinstance(x, torch.Tensor):
+            return torch.relu(x).sum()
+        return x
+
+
+class PrecompileFunctionScopedUserImport(torch.nn.Module):
+    """The same shape for a user module, which clears on the other arm of the
+    namespace rule: the namespace owns the def rather than torch owning the
+    namespace."""
+
+    def forward(self, x):
+        import lazy_helper
+
+        return lazy_helper.op(x).sum()
+
+
+class PrecompileModuleInAttribute(torch.nn.Module):
+    """self.ns = importlib.import_module(cfg.backend) -- a config-picked module."""
+
+    def __init__(self, ns):
+        super().__init__()
+        self.ns = ns
+
+    def forward(self, x):
+        return self.ns.gelu(x).sum()
+
+
+class PrecompileDictDispatch(torch.nn.Module):
+    """CFG["act"] -- the same dispatch slot spelled as a dict lookup."""
+
+    def forward(self, x):
+        return PRECOMPILE_DISPATCH["act"](x).sum()
+
+
+class PrecompileRegistryLookup(torch.nn.Module):
+    """REGISTRY.act -- a dispatch table parked in a module-level object."""
+
+    def forward(self, x):
+        return PRECOMPILE_REGISTRY.act(x).sum()
+
+
+class PrecompileFunctionArg(torch.nn.Module):
+    def forward(self, x, fn):
+        return fn(x).sum()
+
+
+class PrecompileFunctionDefault(torch.nn.Module):
+    def forward(self, x, fn=_precompile_user_act):
+        return fn(x).sum()
+
+
+class PrecompileStockEncoderLayer(torch.nn.Module):
+    """nn.TransformerEncoderLayer parks its activation in an attribute, and
+    which callable lands there is a constructor keyword -- torch's own spelling
+    of self.act = getattr(F, cfg.activation)."""
+
+    def __init__(self):
+        super().__init__()
+        self.enc = torch.nn.TransformerEncoderLayer(
+            8, 2, 16, batch_first=True, dropout=0.0
+        )
+
+    def forward(self, x):
+        return self.enc(x)
+
+
+class PrecompileStockSequential(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(8, 8), torch.nn.ReLU(), torch.nn.Linear(8, 8)
+        )
+
+    def forward(self, x):
+        return self.net(x).sum()
+
+
+class PrecompileAliasedStdlibImport(torch.nn.Module):
+    """import math as <alias> -- a stdlib module under a name it does not own."""
+
+    def forward(self, x):
+        return (x * _precompile_stdlib_alias.sqrt(2.0)).sum()
+
+
+class PrecompileStdlibAttribute(torch.nn.Module):
+    def forward(self, x):
+        return (x * math.sqrt(2.0)).sum()
+
+
+class PrecompileSameModuleHelper(torch.nn.Module):
+    def forward(self, x):
+        return _precompile_scale(x).sum()
+
+
+class PrecompilePartialForward(torch.nn.Module):
+    """self.forward = functools.partial(...) shadows the class method."""
+
+    def __init__(self, scale):
+        super().__init__()
+        self.forward = functools.partial(self._impl, scale)
+
+    def _impl(self, scale, x):
+        return (x * scale).sum()
+
+
+class _PrecompileForwardsCode:
+    """A wrapper forwarding __code__ with a safe default -- the usual decorator
+    spelling -- around a builtin, so the attribute is present and None."""
+
+    def __init__(self, fn):
+        self.__code__ = getattr(fn, "__code__", None)
+        self._fn = fn
+
+    def __call__(self, *args, **kwargs):
+        return self._fn(*args, **kwargs)
+
+
+_ENCODER_SRC = """\
+import torch
+
+
+class Encoder(torch.nn.Module):
+    def forward(self, x):
+        return x {op} 1.0
+"""
+
+_FLIPPED_ENCODER_SRC = """\
+import os
+
+import torch
+
+
+if os.environ.get("FLIP_V2") == "1":
+    class Encoder(torch.nn.Module):
+        def forward(self, x):
+            return x * 7.0
+else:
+    class Encoder(torch.nn.Module):
+        def forward(self, x):
+            return x + 1.0
+"""
+
+
+_PLUGGABLE_OP_SRC = """\
+def op(x):
+    return x * {f}
+"""
+
+_ALIAS_DISPATCH_SRC = """\
+import os
+
+import torch
+
+
+if os.environ.get("PICK_B") == "1":
+    import pick_b as impl
+else:
+    import pick_a as impl
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return impl.op(x)
+"""
+
+_FROM_IMPORT_DISPATCH_SRC = """\
+import os
+
+import torch
+
+
+if os.environ.get("PICK_B") == "1":
+    from pick_b import op
+else:
+    from pick_a import op
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return op(x)
+"""
+
+_OWN_HELPERS_SRC = """\
+import torch.nn.functional as F
+
+
+def _scale(x):
+    return x * 2.0
+
+
+def call(x):
+    return F.relu(_scale(x))
+"""
+
+_OWN_MODEL_SRC = """\
+import own_helpers
+import torch
+from torch.nn.functional import gelu
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return gelu(own_helpers.call(x))
+"""
+
+_OWN_SUB_SRC = """\
+def op(x):
+    return x * 3.0
+"""
+
+_OWN_PARENT_SRC = """\
+import own_sub
+"""
+
+_OWN_NESTED_MODEL_SRC = """\
+import own_parent
+import torch
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return own_parent.own_sub.op(x)
+"""
+
+_LIBRARY_SPELLINGS_SRC = """\
+import collections.abc as _abc
+import math as _math
+import torch
+from math import sqrt
+from torch import relu
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        n = float(isinstance([], _abc.Sized))
+        return (relu(x) * sqrt(2.0) * _math.fabs(-1.0) * n).sum()
+"""
+
+_LAZY_HELPER_SRC = """\
+def op(x):
+    return x * 3.0
+"""
+
+# collections.abc, three lines of `from _collections_abc import *`, with the
+# private file spoofing __name__ back to the public name so tracebacks read
+# right. Every model that inlines through such a module hits both traps.
+_SHIM_IMPL_SRC = """\
+# Renamed out of the way for import-time reasons, exactly as _collections_abc.
+__name__ = "shim_abc"
+
+
+def helper(x):
+    return x * 3.0
+"""
+
+_SHIM_SRC = """\
+from _shim_impl import *
+"""
+
+_SHIM_MODEL_SRC = """\
+import shim_abc
+import torch
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return shim_abc.helper(x).sum()
+"""
+
+
+def _precompile_sin(t):
+    return t.sin()
+
+
+PRECOMPILE_ACTIVATION = _precompile_sin
+
+
+def staged_with_global_function_ref(x):
+    y = PRECOMPILE_ACTIVATION(x) + 1
+    torch._dynamo.graph_break()
+    return (y * 10).sum()
+
+
+@contextlib.contextmanager
+def _precompile_mode(mode):
+    old = PRECOMPILE_CONFIG["mode"]
+    PRECOMPILE_CONFIG["mode"] = mode
+    try:
+        yield
+    finally:
+        PRECOMPILE_CONFIG["mode"] = old
+
+
 def compute_loss_helper(x):
     return reduce_to_scalar_loss(x)
 
 
 def compiled_region_with_backend_id_for_package_test():
     return __compiled_fn_0_00000000_0000_0000_0000_000000000000()  # noqa: F821
+
+
+# The modules the corpus needs on disk, because a dispatch read off another
+# module cannot be spelled inside this file. Written under one directory so
+# they import each other by plain name, exactly as a user package would.
+_CORPUS_MODULES = {
+    "cimpl_a": "def op(x):\n    return x + 1.0\n",
+    "cimpl_b": "def op(x):\n    return x * 7.0\n",
+    "cdispatch": """\
+import os
+
+
+if os.environ.get("CORPUS_B") == "1":
+    from cimpl_b import op
+else:
+    from cimpl_a import op
+""",
+    "chelpers": """\
+import os
+
+
+if os.environ.get("CORPUS_B") == "1":
+    from cimpl_b import op
+else:
+    from cimpl_a import op
+
+
+def call(x):
+    return op(x)
+""",
+    "cconf": """\
+import os
+
+import cimpl_a
+import cimpl_b
+
+
+ACT = cimpl_b.op if os.environ.get("CORPUS_B") == "1" else cimpl_a.op
+""",
+    "calias": """\
+import os
+
+import torch
+
+
+if os.environ.get("CORPUS_B") == "1":
+    import cimpl_b as impl
+else:
+    import cimpl_a as impl
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return impl.op(x)
+""",
+    "cfrom": """\
+import os
+
+import torch
+
+
+if os.environ.get("CORPUS_B") == "1":
+    from cimpl_b import op
+else:
+    from cimpl_a import op
+
+
+class Model(torch.nn.Module):
+    def forward(self, x):
+        return op(x)
+""",
+    "cown": """\
+import torch
+
+
+def _scale(x):
+    return x * 2.0
+
+
+def call(x):
+    return torch.relu(_scale(x))
+""",
+    "cpkg/cimpl": "def op(x):\n    return x + 1.0\n",
+    "cpkg/__init__": "from . import cimpl as impl\n\n\nop = impl.op\n",
+    "cmodels": """\
+import os
+
+import torch
+
+import cconf
+import cdispatch
+import chelpers
+import cimpl_a
+import cimpl_b
+import cown
+import cpkg
+import cpkg.cimpl
+
+
+OPS = cimpl_b if os.environ.get("CORPUS_B") == "1" else cimpl_a
+
+
+class ModuleAttr(torch.nn.Module):
+    def forward(self, x):
+        return cconf.ACT(x)
+
+
+class ModuleSwitch(torch.nn.Module):
+    def forward(self, x):
+        return OPS.op(x)
+
+
+class SiblingModule(torch.nn.Module):
+    def forward(self, x):
+        return cdispatch.op(x)
+
+
+class InlinedHelper(torch.nn.Module):
+    def forward(self, x):
+        return chelpers.call(x)
+
+
+class PackageReexport(torch.nn.Module):
+    def forward(self, x):
+        return cpkg.op(x)
+
+
+class PackageSubmoduleAlias(torch.nn.Module):
+    def forward(self, x):
+        return cpkg.impl.op(x)
+
+
+class RealSubmodule(torch.nn.Module):
+    def forward(self, x):
+        return cpkg.cimpl.op(x)
+
+
+class OwnNameDef(torch.nn.Module):
+    def forward(self, x):
+        return cown.call(x)
+""",
+}
+
+_CORPUS_X = torch.randn(4, 8)
+_CORPUS_SEQ = torch.randn(2, 4, 8)
+
+# Every shape below was once a silent wrong answer on a serving machine that
+# somebody had to find by hand. _is_risky_drop regressed three review rounds
+# running -- each fix closed the previous round's false negative and opened a
+# new one -- so the shapes live in a table rather than in prose: adding one is
+# a single entry, and nothing here may ever stop being flagged.
+_RISKY_DROP_CORPUS = {
+    "aliased_module_import": (
+        "G['impl'].op",
+        lambda t: (t._corpus_model("calias"), (_CORPUS_X,)),
+    ),
+    "attribute_builtin_fn": (
+        "self.act",
+        lambda t: (PrecompileSelfAct(abs), (_CORPUS_X,)),
+    ),
+    "attribute_torch_fn": (
+        "self.act",
+        lambda t: (PrecompileSelfAct(F.gelu), (_CORPUS_X,)),
+    ),
+    "attribute_user_fn": (
+        "self.act",
+        lambda t: (PrecompileSelfAct(_precompile_user_act), (_CORPUS_X,)),
+    ),
+    "bare_global_fn": (
+        "G['PRECOMPILE_ACTIVATION']",
+        lambda t: (staged_with_global_function_ref, (_CORPUS_X,)),
+    ),
+    "closure_cell": (
+        "fn",
+        lambda t: (_precompile_closure_over(_precompile_user_act), (_CORPUS_X,)),
+    ),
+    "cross_module_from_import": (
+        "G['op']",
+        lambda t: (t._corpus_model("cfrom"), (_CORPUS_X,)),
+    ),
+    "dict_lookup": (
+        "G['PRECOMPILE_DISPATCH']['act']",
+        lambda t: (PrecompileDictDispatch(), (_CORPUS_X,)),
+    ),
+    "dispatch_in_inlined_helper": (
+        "G['__import_chelpers'].op",
+        lambda t: (t._corpus("InlinedHelper"), (_CORPUS_X,)),
+    ),
+    "function_argument": (
+        "fn",
+        lambda t: (PrecompileFunctionArg(), (_CORPUS_X, _precompile_user_act)),
+    ),
+    "function_default_arg": (
+        "fn",
+        lambda t: (PrecompileFunctionDefault(), (_CORPUS_X,)),
+    ),
+    "module_in_attribute": (
+        "self.ns.gelu",
+        lambda t: (PrecompileModuleInAttribute(F), (_CORPUS_X,)),
+    ),
+    "module_level_global": (
+        "G['cconf'].ACT",
+        lambda t: (t._corpus("ModuleAttr"), (_CORPUS_X,)),
+    ),
+    "module_valued_global": (
+        "G['OPS'].op",
+        lambda t: (t._corpus("ModuleSwitch"), (_CORPUS_X,)),
+    ),
+    "object_attribute": (
+        "G['PRECOMPILE_REGISTRY'].act",
+        lambda t: (PrecompileRegistryLookup(), (_CORPUS_X,)),
+    ),
+    "package_reexport": (
+        "G['cpkg'].op",
+        lambda t: (t._corpus("PackageReexport"), (_CORPUS_X,)),
+    ),
+    "package_submodule_alias": (
+        "G['cpkg'].impl.op",
+        lambda t: (t._corpus("PackageSubmoduleAlias"), (_CORPUS_X,)),
+    ),
+    "sibling_module": (
+        "G['cdispatch'].op",
+        lambda t: (t._corpus("SiblingModule"), (_CORPUS_X,)),
+    ),
+    "stock_layer_activation": (
+        "self._modules['enc'].activation",
+        lambda t: (PrecompileStockEncoderLayer(), (_CORPUS_SEQ,)),
+    ),
+}
+
+# The other half of the corpus, and the half that keeps the report worth
+# reading: the lint only warns by default, so if ordinary code trips it the
+# warning is noise nobody audits and nobody ever opts into enforcement. Each of
+# these pairs with a positive above.
+_BENIGN_DROP_CORPUS = {
+    "aliased_stdlib_import": lambda t: (PrecompileAliasedStdlibImport(), (_CORPUS_X,)),
+    "aliased_torch_import": lambda t: (PrecompileAliasedImport(), (_CORPUS_X,)),
+    "direct_functional_call": lambda t: (PrecompileFullyQualified(), (_CORPUS_X,)),
+    "own_name_def_in_own_module": lambda t: (t._corpus("OwnNameDef"), (_CORPUS_X,)),
+    "real_submodule": lambda t: (t._corpus("RealSubmodule"), (_CORPUS_X,)),
+    "same_module_helper": lambda t: (PrecompileSameModuleHelper(), (_CORPUS_X,)),
+    "stdlib_attribute": lambda t: (PrecompileStdlibAttribute(), (_CORPUS_X,)),
+    "stock_linear_layernorm": lambda t: (PrecompileConfigConstants(), (_CORPUS_X,)),
+    "stock_sequential": lambda t: (PrecompileStockSequential(), (_CORPUS_X,)),
+}
 
 
 @functorch_config.patch("bundled_autograd_cache", True)
@@ -960,6 +2047,3780 @@ def add(x, y):
             options=dict(guard_filter_fn=torch.compiler.skip_guard_on_globals_unsafe),
         )
         compiled_fn(x)
+
+
+@instantiate_parametrized_tests
+class TestPrecompilePackage(torch._inductor.test_case.TestCase):
+    def setUp(self):
+        super().setUp()
+        torch._dynamo.reset()
+        DynamoCache.clear()
+        PrecompileContext.clear()
+
+    def dir(self):
+        path = os.path.join(cache_dir(), f"precompile_{self.id()}")
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def path(self, name="artifact.pt"):
+        """An artifact FILE inside this test's scratch dir; save() writes files."""
+        return os.path.join(self.dir(), name)
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_graph_breaks_and_recompiles_round_trip(self, backend):
+        shapes = [(4, 8), (5, 8), (6, 8)]
+        inputs = [torch.randn(*s) for s in shapes]
+        expected = [staged_with_graph_breaks(x) for x in inputs]
+
+        session = precompile_capture(
+            staged_with_graph_breaks, backend=backend, dynamic=False
+        )
+        with session as compiled:
+            for x in inputs:
+                compiled(x)
+        summary = session.summary()
+        # entry frame plus one resume frame per graph break, each specialized
+        # once per input shape.
+        self.assertEqual(summary.frames, 3)
+        self.assertEqual(summary.resume_functions, 2)
+        self.assertEqual(summary.guarded_codes, 3 * len(shapes))
+        self.assertTrue(summary.complete)
+        session.save(self.path(), require_no_dropped_guards=False)
+
+        torch._dynamo.reset()
+        with (
+            precompile_load(
+                staged_with_graph_breaks, self.path(), backend=backend, dynamic=False
+            ) as loaded,
+            serving(),
+        ):
+            for x, want in zip(inputs, expected):
+                self.assertEqual(loaded(x), want)
+            with self.assertRaisesRegex(RuntimeError, "fail_on_recompile"):
+                loaded(torch.randn(9, 8))
+
+    def test_save_refuses_incomplete_package(self):
+        # 5 blocks x 3 shapes = 15 variants on one shared forward code object,
+        # which overruns a recompile_limit of 8. Before, the truncated package
+        # saved happily and only stopped matching at serving time.
+        n = 5
+        model = PrecompileStack(n)
+        inputs = [torch.randn(*s) for s in [(4, 8), (5, 8), (6, 8)]]
+        expected_first = model(inputs[0])
+
+        session = precompile_capture(
+            model, backend="eager", recompile_limit=8, dynamic=False
+        )
+        with session as compiled:
+            for x in inputs:
+                compiled(x)
+
+        summary = session.summary()
+        self.assertFalse(summary.complete)
+        self.assertTrue(summary.truncated)
+        self.assertEqual(summary.bypassed, ())
+        with self.assertRaisesRegex(PackageError, "exceeded recompile_limit"):
+            session.save(self.path())
+
+        # Opting in to a partial artifact is still allowed, and the variants
+        # that WERE captured must still serve -- truncation records a gap, it
+        # does not throw away the coverage already obtained.
+        self.assertGreater(summary.guarded_codes, 0)
+        session.save(self.path(), require_complete=False)
+        torch._dynamo.reset()
+        with (
+            precompile_load(
+                model, self.path(), backend="eager", recompile_limit=8, dynamic=False
+            ) as loaded,
+            serving(),
+        ):
+            self.assertEqual(loaded(inputs[0]), expected_first)
+
+    def test_global_dict_conditional_guard_round_trip(self):
+        modes = ["sum", "mean"]
+        x = torch.randn(4, 8)
+        expected = {}
+        for mode in modes:
+            with _precompile_mode(mode):
+                expected[mode] = staged_with_global_dict_conditional(x)
+        self.assertNotEqual(expected["sum"].item(), expected["mean"].item())
+
+        session = precompile_capture(
+            staged_with_global_dict_conditional, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            for mode in modes:
+                with _precompile_mode(mode):
+                    compiled(x)
+        summary = session.summary()
+        # entry frame + one resume frame, each specialized per mode
+        self.assertEqual(summary.frames, 2)
+        self.assertEqual(summary.resume_functions, 1)
+        self.assertEqual(summary.guarded_codes, 2 * len(modes))
+        self.assertTrue(summary.complete)
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        with (
+            precompile_load(
+                staged_with_global_dict_conditional,
+                self.path(),
+                backend="eager",
+                dynamic=False,
+            ) as loaded,
+            serving(),
+        ):
+            # The global guard must be load-bearing: flipping it has to select
+            # the other graph rather than silently reusing the first.
+            for mode in modes:
+                with _precompile_mode(mode):
+                    self.assertEqual(loaded(x), expected[mode])
+            with _precompile_mode("uncaptured"):
+                with self.assertRaisesRegex(RuntimeError, "fail_on_recompile"):
+                    loaded(x)
+
+    def test_local_dict_conditional_guard_round_trip(self):
+        configs = [{"op": "sin", "scale": 2}, {"op": "cos", "scale": 5}]
+        x = torch.randn(4, 8)
+        expected = [staged_with_local_dict_conditional(x, c) for c in configs]
+        self.assertNotEqual(expected[0].item(), expected[1].item())
+
+        session = precompile_capture(
+            staged_with_local_dict_conditional, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            for cfg in configs:
+                compiled(x, cfg)
+        summary = session.summary()
+        self.assertEqual(summary.frames, 2)
+        self.assertEqual(summary.resume_functions, 1)
+        self.assertTrue(summary.complete)
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        with (
+            precompile_load(
+                staged_with_local_dict_conditional,
+                self.path(),
+                backend="eager",
+                dynamic=False,
+            ) as loaded,
+            serving(),
+        ):
+            for cfg, want in zip(configs, expected):
+                self.assertEqual(loaded(x, cfg), want)
+            with self.assertRaisesRegex(RuntimeError, "fail_on_recompile"):
+                loaded(x, {"op": "tan", "scale": 1})
+
+    def test_nested_dict_guards_round_trip(self):
+        configs = [
+            {"alpha": {"kind": "wide", "dims": [1, 2], "weight": 3}},
+            {"beta": {"kind": "narrow", "dims": [1], "weight": 7}},
+        ]
+        x = torch.randn(4, 8)
+        expected = [staged_with_nested_dict_conditional(x, c) for c in configs]
+        self.assertNotEqual(expected[0].item(), expected[1].item())
+
+        session = precompile_capture(
+            staged_with_nested_dict_conditional, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            for cfg in configs:
+                compiled(x, cfg)
+        summary = session.summary()
+        self.assertTrue(summary.complete)
+        # Assert positively that the key-set and membership guards were emitted
+        # AND retained. Checking only that they are absent from dropped_guards
+        # would pass just as well if Dynamo never emitted them at all.
+        kept = summary.kept_guard_types()
+        self.assertIn("DICT_KEYS_MATCH", kept)
+        self.assertIn("DICT_CONTAINS", kept)
+        self.assertNotIn("DICT_KEYS_MATCH", summary.dropped_guard_types())
+        self.assertNotIn("DICT_CONTAINS", summary.dropped_guard_types())
+        session.save(
+            self.path(),
+            require_no_risky_drops=False,
+            require_no_dropped_guards=False,
+        )
+
+        torch._dynamo.reset()
+        with (
+            precompile_load(
+                staged_with_nested_dict_conditional,
+                self.path(),
+                backend="eager",
+                dynamic=False,
+            ) as loaded,
+            serving(),
+        ):
+            for cfg, want in zip(configs, expected):
+                self.assertEqual(loaded(x, cfg), want)
+            # a key set never captured must not match either graph
+            with self.assertRaisesRegex(RuntimeError, "fail_on_recompile"):
+                loaded(x, {"gamma": {"kind": "wide", "dims": [1], "weight": 2}})
+
+    def test_summary_reports_dropped_guards(self):
+        # Guard types the filter discards are recorded with their source name
+        # rather than silently disappearing; dropping one widens what a graph
+        # gets reused for, and only the name says whether that matters.
+        session = precompile_capture(
+            staged_with_global_dict_conditional, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(torch.randn(4, 8))
+        summary = session.summary()
+        # The filter cannot serialize identity guards, so referencing the torch
+        # module at all produces at least one drop, reported as (type, source).
+        self.assertTrue(summary.dropped_guards)
+        for guard_type, source in summary.dropped_guards:
+            self.assertIsInstance(guard_type, str)
+            self.assertIsInstance(source, str)
+        self.assertEqual(
+            sum(summary.dropped_guard_types().values()), len(summary.dropped_guards)
+        )
+        self.assertIn("dropped guards", str(summary))
+        # save() can be made to enforce that nothing was dropped.
+        with self.assertRaisesRegex(PackageError, "dropped .* guard"):
+            session.save(self.path(), require_no_dropped_guards=True)
+
+    def test_raised_recompile_limit_captures_every_variant(self):
+        n = 5
+        model = PrecompileStack(n)
+        inputs = [torch.randn(*s) for s in [(4, 8), (5, 8), (6, 8)]]
+        expected = [model(x) for x in inputs]
+
+        session = precompile_capture(
+            model, backend="eager", recompile_limit=64, dynamic=False
+        )
+        with session as compiled:
+            for x in inputs:
+                compiled(x)
+        summary = session.summary()
+        self.assertEqual(summary.truncated, ())
+        # Explicit precompile enables empty graphs, so each no-op resume after a
+        # block's graph break is guarded alongside every block variant.
+        self.assertEqual(summary.guarded_codes, (n + 1) * len(inputs))
+        # The top-level forward only dispatches to submodules and still has no
+        # guarded code of its own.
+        self.assertEqual(summary.uncovered_frames, ("forward",))
+        self.assertFalse(summary.complete)
+        with self.assertRaisesRegex(PackageError, "produced NO guarded code at all"):
+            session.save(self.path())
+        session.save(self.path(), require_complete=False)
+
+        torch._dynamo.reset()
+        with (
+            precompile_load(
+                model, self.path(), backend="eager", recompile_limit=64, dynamic=False
+            ) as loaded,
+            serving(),
+        ):
+            for x, want in zip(inputs, expected):
+                self.assertEqual(loaded(x), want)
+            with self.assertRaisesRegex(RuntimeError, "fail_on_recompile"):
+                loaded(torch.randn(7, 8))
+
+    def test_library_module_requires_the_name_to_resolve_to_the_stdlib(self):
+        # The risky-drop waiver keys on the OWNER's module name, and a name is
+        # not an identity: graphlib, queue, code and distutils are all stdlib
+        # names a third party ships. Checking only that the top-level module's
+        # __file__ starts with the stdlib dir does not separate them, because
+        # purelib NESTS inside stdlib (conda) or platstdlib (venv) -- so every
+        # pip-installed shadow of a stdlib name was waived. distutils is the
+        # live example: SETUPTOOLS_USE_DISTUTILS, an environment variable,
+        # chooses between the stdlib copy and setuptools/_distutils.
+        stdlib_root = sysconfig.get_paths()["stdlib"]
+        shadowed = types.ModuleType("graphlib")
+        shadowed.__file__ = os.path.join(
+            stdlib_root, "site-packages", "graphlib", "__init__.py"
+        )
+        unlocated = types.ModuleType("graphlib")  # no __file__, no __spec__
+
+        for module in (shadowed, unlocated):
+            with mock.patch.dict(sys.modules, {"graphlib": module}):
+                self.assertFalse(dynamo_package_lint._is_library_module("graphlib"))
+
+        # Real stdlib and real torch, including the shapes with no file at all,
+        # must keep their waiver: torch._C._nn owns F.gelu, and pyexpat.errors /
+        # xml.parsers.expat.model are stdlib submodules with no location
+        # evidence of their own. Demanding positive evidence at the DEEPEST
+        # module rejects every one of them, so descendants only have to not be
+        # located somewhere else.
+        import xml.parsers.expat  # noqa: F401
+
+        for name in (
+            "torch",
+            "torch._C",
+            "torch._C._nn",
+            "torch.ops",
+            "os.path",
+            "collections.abc",
+            "sys",
+            "zipimport",
+            "pyexpat.errors",
+            "xml.parsers.expat.model",
+        ):
+            self.assertTrue(
+                dynamo_package_lint._is_library_module(name), f"{name} lost its waiver"
+            )
+        self.assertFalse(dynamo_package_lint._is_library_module("numpy"))
+        self.assertFalse(dynamo_package_lint._is_library_module(None))
+
+    def test_save_refuses_risky_dropped_identity_guard(self):
+        # Identity guards cannot be serialized, so a bare global holding a
+        # function loses its guard. Rebinding it between capture and load would
+        # then silently serve the graph traced against the old value.
+        session = precompile_capture(
+            staged_with_global_function_ref, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(torch.randn(4, 8))
+        summary = session.summary()
+        risky = [name for _, name in summary.risky_dropped_guards]
+        self.assertIn("G['PRECOMPILE_ACTIVATION']", risky)
+        # Guards on the torch module itself are dropped too but are not risky.
+        self.assertNotIn("G['torch']", risky)
+        with self.assertRaisesRegex(PackageError, "PRECOMPILE_ACTIVATION"):
+            session.save(self.path(), require_no_dropped_guards=False)
+        # The risk is acknowledgeable, not a hard block.
+        session.save(
+            self.path(),
+            require_no_risky_drops=False,
+            require_no_dropped_guards=False,
+        )
+
+    def test_strict_and_risky_drop_requirements_fail_closed(self):
+        # Strict save rejects every drop. Relaxing that still keeps the risky
+        # lint as a second gate unless the caller acknowledges it separately.
+        clean = precompile_capture(
+            PrecompileNoDispatchSlot(), backend="eager", dynamic=False
+        )
+        with clean as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        clean.save(self.path())
+        with self.assertRaisesRegex(PackageError, "not serialized"):
+            clean.save(self.path(), require_no_dropped_guards=True)
+
+        torch._dynamo.reset()
+        session = precompile_capture(
+            staged_with_global_function_ref, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(torch.randn(4, 8))
+        with (
+            self.assertNoLogs("torch._dynamo.precompile_package", "WARNING"),
+            self.assertRaisesRegex(PackageError, "PRECOMPILE_ACTIVATION"),
+        ):
+            session.save(self.path(), require_no_dropped_guards=False)
+        with self.assertLogs("torch._dynamo.precompile_package", "WARNING") as logs:
+            session.save(
+                self.path(),
+                require_no_risky_drops=False,
+                require_no_dropped_guards=False,
+            )
+        reported = [m for m in logs.output if "dropped guard" in m]
+        self.assertEqual(len(reported), 1, logs.output)
+        self.assertIn("PRECOMPILE_ACTIVATION", reported[0])
+        self.assertIn("require_no_risky_drops=False", logs.output[0])
+
+    @parametrize("owner", ("user", "torch", "torch_functional", "builtin"))
+    def test_risky_drop_detected_through_a_module_attribute(self, owner):
+        # self.act is a dispatch slot whatever it holds. Its guard is dropped as
+        # an unserializable identity guard and the source is reported with local
+        # scope stripped ("self.act"), so it cannot be recognised by matching
+        # against a global pattern -- classify by the binding site. Keying on who
+        # owns the value instead would wave through the torch-owned cases, which
+        # are the common ones (self.act = getattr(F, cfg.activation)), and the
+        # builtin case too -- an ACT2FN-style table holds abs next to torch.relu,
+        # and which one lands in the slot is exactly what config decides.
+        act = {
+            "user": _precompile_user_act,
+            "torch": torch.relu,
+            "torch_functional": torch.nn.functional.gelu,
+            "builtin": abs,
+        }[owner]
+        session = precompile_capture(
+            PrecompileSelfAct(act), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        self.assertIn("self.act", risky)
+        with self.assertRaisesRegex(PackageError, "self.act"):
+            session.save(self.path(), require_no_dropped_guards=False)
+
+    def test_library_and_def_site_drops_need_relaxed_save(self):
+        # Ordinary code with no dispatch slot still drops identity guards: on
+        # torch internals, on stdlib modules and their attributes, and on a
+        # global bound to a def of its own name. The relaxed lint waives these
+        # common shapes to stay usable, even though runtime rebinding can still
+        # invalidate them; the strict all-drops default is the sound gate.
+        session = precompile_capture(
+            PrecompileNoDispatchSlot(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        self.assertIn("G['math']", dropped)
+        self.assertIn("G['math'].sqrt", dropped)
+        self.assertIn("G['_precompile_scale']", dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path())
+        with self.assertRaisesRegex(PackageError, "not serialized"):
+            session.save(self.path(), require_no_dropped_guards=True)
+
+    def test_a_builtin_read_the_ordinary_way_is_not_a_risky_drop(self):
+        # The other side of the "builtin" case above. len() and sorted() are
+        # reached through the builtins dict Dynamo installs, with no binding in
+        # front of them for config to repoint, so the exemption has to survive
+        # being narrowed to that read -- otherwise every model calling len()
+        # warns on every save and the report stops being read.
+        cfg = {"alpha": 1, "beta": 2}
+        session = precompile_capture(
+            staged_with_builtin_calls, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4), cfg)
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        self.assertTrue(any(n.endswith("['len']") for n in dropped), dropped)
+        self.assertTrue(any(n.endswith("['sorted']") for n in dropped), dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path())
+        with self.assertRaisesRegex(PackageError, "not serialized"):
+            session.save(self.path(), require_no_dropped_guards=True)
+
+    def test_a_builtin_shaped_read_that_is_still_a_slot_is_risky(self):
+        # Both halves of that exemption carry weight, so neither can be dropped
+        # for being redundant. builtins is writable and per-process, so a plugin
+        # doing `builtins.op = impl_a` here and impl_b there produces a read
+        # that comes off the right namespace but holds user code. And a table
+        # under a user global has the same source shape as the builtins dict
+        # while being a slot, whatever it happens to hold.
+        builtins.precompile_house_op = _precompile_house_op
+        self.addCleanup(lambda: delattr(builtins, "precompile_house_op"))
+        session = precompile_capture(
+            staged_with_injected_builtin, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        injected = [n for n in risky if n.endswith("['precompile_house_op']")]
+        self.assertEqual(len(injected), 1, risky)
+
+        torch._dynamo.reset()
+        session = precompile_capture(
+            staged_with_a_registry_keyed_by_a_builtin_name,
+            backend="eager",
+            dynamic=False,
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4), {"a": 1})
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        self.assertIn("G['_PRECOMPILE_OPS']['len']", risky)
+
+    def test_a_fully_qualified_torch_op_is_not_a_risky_drop(self):
+        # torch.nn.functional.gelu spelled out guards every module on the way
+        # down, so the namespace the call comes off is two attribute hops from
+        # the global rather than one. Walking only one hop back to look for a
+        # global root drops it out of the trusted set and refuses the most
+        # ordinary spelling there is.
+        session = precompile_capture(
+            PrecompileFullyQualified(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        self.assertIn("G['torch'].nn.functional.gelu", dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path())
+
+    def test_a_submodule_of_a_self_named_package_is_not_a_risky_drop(self):
+        # own_parent is bound under its own name, which no import statement can
+        # repoint, and own_parent.own_sub inherits that: the trust has to carry
+        # down the attribute chain, or reaching a helper through the package
+        # that owns it counts as dispatch.
+        pkg = self._write_module("nest", "own_sub", _OWN_SUB_SRC)
+        self._write_module("nest", "own_parent", _OWN_PARENT_SRC)
+        self._write_module("nest", "own_nested_model", _OWN_NESTED_MODEL_SRC)
+        self._forget_modules("own_sub", "own_parent")
+        model = self._import_module(pkg, "own_nested_model").Model()
+
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.ones(4))
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        self.assertIn("G['own_parent'].own_sub", dropped)
+        self.assertIn("G['own_parent'].own_sub.op", dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path())
+
+    def test_library_spellings_that_only_the_owner_test_clears(self):
+        # Four spellings the def-name rule cannot clear on its own, so whether
+        # they are refused rides entirely on recognising torch and the stdlib:
+        # `from torch import relu` (owned by torch itself, not a torch.*
+        # submodule), `from math import sqrt` (a def in a C stdlib module, so
+        # there is no file to match the reader against), `import math as _math`
+        # and `import collections.abc as _abc` (modules under names that are
+        # not their own, one of them dotted).
+        pkg = self._write_module("libspell", "lib_spellings", _LIBRARY_SPELLINGS_SRC)
+        model = self._import_module(pkg, "lib_spellings").Model()
+
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.ones(4))
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        for name in ("G['relu']", "G['sqrt']", "G['_math']", "G['_abc']"):
+            self.assertIn(name, dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path())
+
+    def test_an_aliased_module_import_is_not_a_risky_drop(self):
+        # `import torch.nn.functional as F` binds a global whose name is nothing
+        # like the module's __name__, so the def-name rule that clears
+        # `G['math']` does not clear `G['F']`. What clears it is that torch owns
+        # the module: there is one torch.nn.functional and no config picks
+        # another, and a check that flagged every model spelling its imports the
+        # ordinary way would be ignored from day one.
+        session = precompile_capture(
+            PrecompileAliasedImport(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        summary = session.summary()
+        self.assertIn("G['F']", [name for _, name in summary.dropped_guards])
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path())
+
+    def test_a_user_module_aliased_by_a_conditional_import_is_a_risky_drop(self):
+        # The same read as F.gelu -- an attribute off a module namespace -- but
+        # which module `impl` holds is an env var's choice, so capture and serve
+        # disagree while every other rail passes: the artifact records the
+        # capture-time module as its inlined source and that module is untouched
+        # on the serving box, so the checksum revalidates.
+        pkg = self._write_module("plug", "pick_a", _PLUGGABLE_OP_SRC.format(f="2.0"))
+        self._write_module("plug", "pick_b", _PLUGGABLE_OP_SRC.format(f="7.0"))
+        self._write_module("plug", "alias_dispatch", _ALIAS_DISPATCH_SRC)
+        self._forget_modules("pick_a", "pick_b")
+        os.environ.pop("PICK_B", None)
+        self.addCleanup(lambda: os.environ.pop("PICK_B", None))
+        model = self._import_module(pkg, "alias_dispatch").Model()
+
+        x = torch.ones(4)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        self.assertIn("G['impl']", risky)
+        self.assertIn("G['impl'].op", risky)
+        with self.assertRaisesRegex(PackageError, r"G\['impl'\]"):
+            session.save(self.path(), require_no_risky_drops=True)
+
+        # What the refusal buys, spelled out: opt out and the serving machine
+        # runs the other backend eagerly and the captured one under the artifact.
+        session.save(self.path(), require_no_risky_drops=False)
+        os.environ["PICK_B"] = "1"
+        sys.modules.pop("alias_dispatch", None)
+        flipped = importlib.import_module("alias_dispatch").Model()
+        self.assertEqual(flipped(x), x * 7.0)
+        torch._dynamo.reset()
+        with (
+            precompile_load(flipped, self.path(), backend="eager", dynamic=False) as l,
+            serving(),
+            torch.no_grad(),
+        ):
+            self.assertEqual(l(x), x * 2.0)
+
+    def test_a_cross_module_from_import_is_a_risky_drop(self):
+        # `from pick_a import op` binds a global to a def of that same name, so
+        # the def-name rule would clear it, but the def lives in another file:
+        # repointing it takes a conditional import in THIS file, which is not an
+        # edit anywhere and which no checksum covers.
+        pkg = self._write_module("frm", "pick_a", _PLUGGABLE_OP_SRC.format(f="2.0"))
+        self._write_module("frm", "pick_b", _PLUGGABLE_OP_SRC.format(f="7.0"))
+        self._write_module("frm", "from_dispatch", _FROM_IMPORT_DISPATCH_SRC)
+        self._forget_modules("pick_a", "pick_b")
+        os.environ.pop("PICK_B", None)
+        self.addCleanup(lambda: os.environ.pop("PICK_B", None))
+        model = self._import_module(pkg, "from_dispatch").Model()
+
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.ones(4))
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        self.assertIn("G['op']", risky)
+        with self.assertRaisesRegex(PackageError, r"G\['op'\]"):
+            session.save(self.path(), require_no_risky_drops=True)
+
+    def test_a_self_named_module_import_is_not_a_risky_drop(self):
+        # The other side of that line. `import own_helpers` binds the module
+        # under its own name, which no import statement can repoint elsewhere,
+        # and `from torch.nn.functional import gelu` names a def torch owns.
+        # Dynamo also reaches the helper's own globals through the
+        # `__import_own_helpers` alias it installs, which follows the value
+        # rather than any user binding. Refusing these would refuse most code.
+        pkg = self._write_module("own", "own_helpers", _OWN_HELPERS_SRC)
+        self._write_module("own", "own_model", _OWN_MODEL_SRC)
+        self._forget_modules("own_helpers")
+        model = self._import_module(pkg, "own_model").Model()
+
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.ones(4))
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        self.assertIn("G['own_helpers']", dropped)
+        self.assertIn("G['gelu']", dropped)
+        self.assertIn("G['__import_own_helpers']._scale", dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path())
+
+    def test_reads_off_an_import_alias_are_anchored_to_its_module(self):
+        # A function-scoped `import torch` is reached through the alias Dynamo
+        # installs for it, and Dynamo guards the attributes read off that alias
+        # but never the bare alias, so nothing in the guards holds the module.
+        # Left unanchored, torch.Tensor reads as a config-swappable slot.
+        session = precompile_capture(
+            PrecompileFunctionScopedImport(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.ones(4))
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        self.assertIn("G['__import_torch'].Tensor", dropped)
+        self.assertIn("G['__import_torch'].relu", dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path(), require_no_risky_drops=True)
+
+    def test_reads_off_a_user_module_import_alias_are_anchored(self):
+        # The same shape clearing on the other arm: the alias names a user
+        # module, so nothing about torch or the stdlib waives the read, and
+        # what does is that the namespace it decodes to owns the def.
+        pkg = self._write_module("lazy", "lazy_helper", _LAZY_HELPER_SRC)
+        self._forget_modules("lazy_helper")
+        self._import_module(pkg, "lazy_helper")
+
+        session = precompile_capture(
+            PrecompileFunctionScopedUserImport(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.ones(4))
+        summary = session.summary()
+        dropped = [name for _, name in summary.dropped_guards]
+        self.assertIn("G['__import_lazy_helper'].op", dropped)
+        self.assertEqual(summary.risky_dropped_guards, ())
+        session.save(self.path(), require_no_risky_drops=True)
+
+    def test_an_import_alias_decodes_to_the_module_it_names(self):
+        self.assertIs(_dynamo_alias_module("__import_torch"), torch)
+        self.assertIs(
+            _dynamo_alias_module("__import_torch_dot_nn_dot_functional"),
+            torch.nn.functional,
+        )
+        self.assertIsNone(_dynamo_alias_module("__import_not_a_module_at_all"))
+        self.assertIsNone(_dynamo_alias_module("CFG"))
+
+    def test_a_module_held_in_an_attribute_is_a_risky_drop(self):
+        # A module read off a global is fixed by the import statement, but one
+        # parked in an instance attribute -- self.ns =
+        # importlib.import_module(cfg.backend) -- is a slot config picks, and
+        # the serving machine's config can pick another. Both the attribute and
+        # everything reached through it have to stay risky.
+        session = precompile_capture(
+            PrecompileModuleInAttribute(torch.nn.functional),
+            backend="eager",
+            dynamic=False,
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        self.assertIn("self.ns", risky)
+        self.assertIn("self.ns.gelu", risky)
+        with self.assertRaisesRegex(PackageError, "self.ns"):
+            session.save(self.path(), require_no_risky_drops=True)
+
+    def _corpus_module(self, name):
+        """Write _CORPUS_MODULES to disk and import one of them fresh."""
+        for path, src in _CORPUS_MODULES.items():
+            head, _, leaf = path.rpartition("/")
+            self._write_module(os.path.join("corpus", head), leaf, src)
+        roots = {path.partition("/")[0] for path in _CORPUS_MODULES}
+
+        def purge():
+            for key in [k for k in sys.modules if k.partition(".")[0] in roots]:
+                del sys.modules[key]
+
+        purge()
+        self.addCleanup(purge)
+        return self._import_module(os.path.join(self.dir(), "corpus"), name)
+
+    def _corpus(self, cls):
+        return getattr(self._corpus_module("cmodels"), cls)()
+
+    def _corpus_model(self, name):
+        return self._corpus_module(name).Model()
+
+    def _capture_corpus_shape(self, model, args):
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(*args)
+        return session
+
+    @parametrize("shape", sorted(_RISKY_DROP_CORPUS))
+    def test_risky_drop_corpus_is_flagged(self, shape):
+        # See _RISKY_DROP_CORPUS: this predicate has failed open three times,
+        # so every shape ever found is asserted here rather than described.
+        expected, build = _RISKY_DROP_CORPUS[shape]
+        session = self._capture_corpus_shape(*build(self))
+        risky = [name for _, name in session.summary().risky_dropped_guards]
+        self.assertIn(expected, risky)
+        # Enforcement is the default; the corpus opts out only to prove that
+        # every risky shape remains serializable when explicitly acknowledged.
+        with self.assertRaisesRegex(PackageError, re.escape(expected)):
+            session.save(self.path(), require_no_dropped_guards=False)
+        session.save(
+            self.path(),
+            require_no_risky_drops=False,
+            require_no_dropped_guards=False,
+        )
+
+    @parametrize("shape", sorted(_BENIGN_DROP_CORPUS))
+    def test_benign_drop_corpus_is_not_flagged(self, shape):
+        session = self._capture_corpus_shape(*_BENIGN_DROP_CORPUS[shape](self))
+        self.assertEqual(session.summary().risky_dropped_guards, ())
+        session.save(self.path())
+        with self.assertRaisesRegex(PackageError, "not serialized"):
+            session.save(self.path(), require_no_dropped_guards=True)
+
+    def test_summary_reports_value_pinned_guards(self):
+        # A value crossing a graph break is guarded by equality, so the artifact
+        # only serves inputs reproducing it. Nothing else in the summary says so.
+        session = precompile_capture(
+            PrecompileValuePinned(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        summary = session.summary()
+        self.assertTrue(summary.wont_generalize)
+        self.assertTrue(any("___stack" in n for n in summary.wont_generalize))
+        self.assertIn("value-pinned", str(summary))
+
+    def test_two_packages_on_a_shared_frame_can_both_unload(self):
+        # Each loaded callable owns one region on the shared code object, so
+        # unloading either package must leave the other's entries alone.
+        paths = []
+        for act in (torch.relu, torch.sigmoid):
+            torch._dynamo.reset()
+            session = precompile_capture(
+                PrecompileSelfAct(act), backend="eager", dynamic=False
+            )
+            with session as compiled, torch.no_grad():
+                compiled(torch.randn(3, 4))
+            path = self.path(f"pkg_{act.__name__}.pt")
+            # self.act is a dispatch slot; this test is about unloading, not it.
+            session.save(path, require_no_risky_drops=False)
+            paths.append(path)
+
+        torch._dynamo.reset()
+        first = precompile_load(
+            PrecompileSelfAct(torch.relu), paths[0], backend="eager", dynamic=False
+        )
+        second = precompile_load(
+            PrecompileSelfAct(torch.sigmoid), paths[1], backend="eager", dynamic=False
+        )
+        with self.assertNoLogs("torch._dynamo.package", level="WARNING"):
+            first.unload()
+        with self.assertNoLogs("torch._dynamo.package", level="WARNING"):
+            second.unload()
+
+    def test_stale_artifact_rejected_when_source_drifts(self):
+        # The deployment shape is capture on one machine, serve on another. The
+        # dangerous version of that is an artifact outliving a code change, so
+        # the source checksum has to fire even though the module is found by
+        # name and its path differs between the two machines.
+        src = "import torch\n\n\ndef staged(x):\n    y = x * 2\n    torch._dynamo.graph_break()\n    return (y + 1).sum()\n"
+        pkg_dir = os.path.join(self.dir(), "srcdrift")
+        os.makedirs(pkg_dir, exist_ok=True)
+        mod_path = os.path.join(pkg_dir, "drift_mod.py")
+        with open(mod_path, "w") as f:
+            f.write(src)
+
+        sys.path.insert(0, pkg_dir)
+        try:
+            mod = importlib.import_module("drift_mod")
+            session = precompile_capture(mod.staged, backend="eager", dynamic=False)
+            with session as compiled, torch.no_grad():
+                compiled(torch.randn(4, 8))
+            session.save(self.path())
+
+            # The serving machine runs a slightly different build.
+            with open(mod_path, "w") as f:
+                f.write(src.replace("y + 1", "y + 2"))
+            importlib.invalidate_caches()
+            del sys.modules["drift_mod"]
+            mod2 = importlib.import_module("drift_mod")
+            torch._dynamo.reset()
+            with self.assertRaisesRegex(RuntimeError, "Source code changes detected"):
+                precompile_load(
+                    mod2.staged, self.path(), backend="eager", dynamic=False
+                )
+        finally:
+            sys.path.remove(pkg_dir)
+            sys.modules.pop("drift_mod", None)
+
+    def test_artifact_rejected_on_version_skew(self):
+        # Guards and bytecode are version specific, so an artifact must not load
+        # onto a machine running a different Python or PyTorch.
+        current = SystemInfo.current()
+        for field, bad in (
+            ("python_version", "3.0.0"),
+            ("torch_version", "0.0.0"),
+        ):
+            skewed = dataclasses.replace(current, **{field: bad})
+            with self.assertRaisesRegex(RuntimeError, "different"):
+                skewed.check_compatibility(current, "cpu")
+
+    def test_artifact_rejected_on_cpu_codegen_target_skew(self):
+        with mock.patch.dict(os.environ, {"ATEN_CPU_CAPABILITY": "avx512"}):
+            captured = SystemInfo.current()
+        with mock.patch.dict(os.environ, {"ATEN_CPU_CAPABILITY": "avx2"}):
+            serving = SystemInfo.current()
+        with self.assertRaisesRegex(RuntimeError, "different CPU codegen target"):
+            captured.check_compatibility(serving, "cpu")
+
+    def test_eager_artifact_accepts_cpu_codegen_target_skew(self):
+        model = PrecompileEmptyGraph()
+        x = torch.randn(4)
+        session = precompile_capture(
+            model,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(x,)],
+        )
+        with session:
+            pass
+        session.save(self.path())
+        captured = SystemInfo.current()
+        serving_info = dataclasses.replace(
+            captured,
+            cpu_codegen_target=(
+                "different-arch",
+                "different-capability",
+                None,
+                "different-isa",
+                None,
+                None,
+            ),
+        )
+
+        torch._dynamo.reset()
+        with mock.patch.object(SystemInfo, "current", return_value=serving_info):
+            loaded = precompile_load(model, self.path(), backend="eager", dynamic=False)
+        with loaded, torch.no_grad(), serving():
+            self.assertEqual(loaded(x), model(x))
+
+    def test_inductor_artifact_records_compile_time_cpu_target(self):
+        model = PrecompileEmptyGraph()
+        x = torch.randn(16)
+        with torch._inductor.config.patch({"cpp.simdlen": 256}):
+            session = precompile_capture(
+                model,
+                backend="inductor",
+                dynamic=False,
+                example_inputs=[(x,)],
+            )
+            with session:
+                pass
+            capture_target = session._package.cache_entry().system_info
+        session.save(self.path())
+        saved = _SingleFileStore().read(self.path()).dynamo.system_info
+
+        self.assertEqual(capture_target.cpu_codegen_target[4], 256)
+        self.assertEqual(saved.cpu_codegen_target, capture_target.cpu_codegen_target)
+
+    def test_reset_probe_ignores_an_installed_code_with_no_entries(self):
+        # The probe has to be a code that really RECEIVED entries. A top-level
+        # forward that only dispatches to submodules produces no guarded code of
+        # its own, is installed anyway so its children can serve, and gets zero
+        # entries. Probing "the first installed code" would call that a dropped
+        # install and raise PackageError on every call, forever.
+        n = 5
+        model = PrecompileStack(n)
+        inputs = [torch.randn(*shape) for shape in ((4, 8), (5, 8), (6, 8))]
+        expected = [model(x) for x in inputs]
+
+        session = precompile_capture(
+            model, backend="eager", recompile_limit=64, dynamic=False
+        )
+        with session as compiled:
+            for x in inputs:
+                compiled(x)
+        self.assertEqual(session.summary().uncovered_frames, ("forward",))
+        session.save(
+            self.path(), require_complete=False, require_no_dropped_guards=False
+        )
+
+        torch._dynamo.reset()
+        loaded = precompile_load(
+            model, self.path(), backend="eager", recompile_limit=64, dynamic=False
+        )
+        try:
+            from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+
+            package = loaded._package
+            installed = package._installed_precompile_codes
+            entryless = [c for c in installed if not _debug_get_precompile_entries(c)]
+            self.assertTrue(entryless, "no entryless installed code to guard against")
+            self.assertIs(installed[0], entryless[0])  # the naive rule's victim
+            self.assertNotIn(package._installed_precompile_probe, entryless)
+            self.assertFalse(package.installed_entries_dropped())
+            with serving():
+                for x, want in zip(inputs, expected):
+                    self.assertEqual(loaded(x), want)
+        finally:
+            loaded.unload()
+
+    def test_reset_invalidates_a_loaded_artifact_loudly(self):
+        # torch._dynamo.reset() clears the precompile entries install() loaded
+        # while leaving the installed globals in place. The next call then
+        # recompiles silently, or under serving() raises the same RecompileError
+        # an uncovered call raises. Neither says the artifact is gone.
+        x = torch.randn(4, 8)
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        session.save(self.path(), require_no_dropped_guards=False)
+
+        torch._dynamo.reset()
+        loaded = precompile_load(
+            staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+        )
+        try:
+            with serving(), torch.no_grad():
+                loaded(x)
+            torch._dynamo.reset()
+            for ctx in (contextlib.nullcontext(), serving()):
+                with self.assertRaises(PackageError) as exc, ctx, torch.no_grad():
+                    loaded(x)
+                self.assertIn("torch._dynamo.reset()", str(exc.exception))
+        finally:
+            loaded.unload()
+
+    def test_reset_is_detected_when_another_artifact_reinstalls(self):
+        # The probe asks whether the code object still has entries for THIS
+        # package's region. Asking whether it has any entries at all lets a
+        # second artifact loaded onto the same function answer for the first:
+        # lookup() never serves across regions, so the first silently
+        # recompiles while its probe reports health.
+        x = torch.randn(4, 8)
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        session.save(self.path(), require_no_dropped_guards=False)
+
+        torch._dynamo.reset()
+        first = precompile_load(
+            staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+        )
+        second = None
+        try:
+            with serving(), torch.no_grad():
+                first(x)
+            torch._dynamo.reset()
+            second = precompile_load(
+                staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+            )
+            self.assertIs(
+                first._package._installed_precompile_probe,
+                second._package._installed_precompile_probe,
+            )
+            self.assertNotEqual(
+                first._isolate_recompiles_id, second._isolate_recompiles_id
+            )
+
+            self.assertTrue(first._package.installed_entries_dropped())
+            for ctx in (contextlib.nullcontext(), serving()):
+                with self.assertRaises(PackageError) as exc, ctx, torch.no_grad():
+                    first(x)
+                self.assertIn("torch._dynamo.reset()", str(exc.exception))
+
+            self.assertFalse(second._package.installed_entries_dropped())
+            with serving(), torch.no_grad():
+                second(x)
+        finally:
+            if second is not None:
+                second.unload()
+            first.unload()
+
+    def test_served_calls_do_not_walk_the_precompile_entry_list(self):
+        # The probe runs on every served call, so it must not build a list
+        # holding one pybind wrapper per installed variant: that is O(variants)
+        # allocations per inference on a path whose whole point is that it
+        # checks no guards. _debug_get_precompile_entries stays for the
+        # fail_on_recompile diagnostic, which runs only once a call has failed.
+        import torch._C._dynamo.eval_frame as eval_frame_bindings
+
+        x = torch.randn(4, 8)
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        session.save(self.path(), require_no_dropped_guards=False)
+
+        torch._dynamo.reset()
+        loaded = precompile_load(
+            staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+        )
+        try:
+            with (
+                mock.patch.object(
+                    eval_frame_bindings,
+                    "_debug_get_precompile_entries",
+                    side_effect=AssertionError("served call built an entry list"),
+                ),
+                serving(),
+                torch.no_grad(),
+            ):
+                loaded(x)
+                loaded(x)
+        finally:
+            loaded.unload()
+
+    def test_eager_precompile_does_not_need_a_cxx_toolchain(self):
+        # cpu_codegen_target only guards inductor's baked CPU vector width, but
+        # computing it dry-compiles a probe, so on a host with no compiler an
+        # eager capture -- and, worse, an eager LOAD in a serve-only container --
+        # died with InvalidCxxCompiler on a field nothing will read.
+        import torch._inductor.cpu_vec_isa as cpu_vec_isa
+        from torch._inductor.exc import InvalidCxxCompiler
+
+        calls = []
+
+        def no_toolchain():
+            calls.append(1)
+            raise InvalidCxxCompiler
+
+        model = PrecompileEmptyGraph()
+        x = torch.randn(4)
+        with mock.patch.object(cpu_vec_isa, "pick_vec_isa", no_toolchain):
+            session = precompile_capture(
+                model, backend="eager", dynamic=False, example_inputs=[(x,)]
+            )
+            with session:
+                pass
+            entry = session._package.cache_entry()
+            self.assertFalse(entry.requires_native_backend_compatibility)
+            self.assertIsNone(entry.system_info.cpu_codegen_target)
+            session.save(self.path())
+
+            torch._dynamo.reset()
+            loaded = precompile_load(model, self.path(), backend="eager", dynamic=False)
+            with loaded, torch.no_grad(), serving():
+                self.assertEqual(loaded(x), model(x))
+        self.assertEqual(calls, [])
+
+    def test_accelerator_capture_defers_the_cpu_toolchain_probe(self):
+        # A capture that has only produced accelerator graphs has no CPU vector
+        # width to record, so it must not run the probe. The first cpu graph
+        # backfills the field: the artifact still has to say what it baked.
+        import torch._inductor.cpu_vec_isa as cpu_vec_isa
+
+        def graph_on(device):
+            graph = torch.fx.Graph()
+            graph.call_function(torch.ones, args=(torch.device(device),))
+            return graph
+
+        calls = []
+        real_pick = cpu_vec_isa.pick_vec_isa
+
+        def counting_pick():
+            calls.append(1)
+            return real_pick()
+
+        with mock.patch.object(cpu_vec_isa, "pick_vec_isa", counting_pick):
+            package = CompilePackage(staged_with_graph_breaks)
+            package.update_device_type(graph_on("cuda"))
+            self.assertEqual(calls, [])
+            self.assertIsNone(package.cache_entry().system_info.cpu_codegen_target)
+
+            package.update_device_type(graph_on("cpu"))
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(
+                package.cache_entry().system_info.cpu_codegen_target,
+                SystemInfo.current().cpu_codegen_target,
+            )
+
+    def test_load_skips_the_cpu_probe_when_the_artifact_records_no_target(self):
+        # None means "this artifact never recorded a target", and
+        # check_compatibility already skips the comparison for it, so computing
+        # the current target is pure cost -- and a hard failure with no compiler.
+        import torch._inductor.cpu_vec_isa as cpu_vec_isa
+
+        calls = []
+        real_pick = cpu_vec_isa.pick_vec_isa
+
+        def counting_pick():
+            calls.append(1)
+            return real_pick()
+
+        entry = dynamo_package._DynamoCacheEntry(
+            codes=[],
+            source_info=dynamo_package.SourceInfo(inlined_sources=set()),
+            device_type="cpu",
+            device_types=frozenset(("cpu",)),
+            requires_native_backend_compatibility=True,
+            system_info=dataclasses.replace(
+                SystemInfo.current(), cpu_codegen_target=None
+            ),
+        )
+        with mock.patch.object(cpu_vec_isa, "pick_vec_isa", counting_pick):
+            entry.check_versions()
+        # Counting rather than raising: a probe that merely no longer CRASHES
+        # still costs seconds, and the crash alone is satisfied by making
+        # _current_cpu_codegen_target catch. Not running it is the fix.
+        self.assertEqual(calls, [])
+
+    def test_caching_precompile_eager_does_not_probe_the_cpu_toolchain(self):
+        # torch.compile(backend="eager") under caching_precompile builds its own
+        # CompilePackage, and that package used to demand native backend
+        # compatibility -- so an eager compile dry-compiled a C++ probe for a
+        # vector width no eager artifact can ever bake.
+        import torch._inductor.cpu_vec_isa as cpu_vec_isa
+
+        calls = []
+        real_pick = cpu_vec_isa.pick_vec_isa
+
+        def counting_pick():
+            calls.append(1)
+            return real_pick()
+
+        def f(x):
+            return x.sin() + 1
+
+        with (
+            torch._dynamo.config.patch(caching_precompile=True),
+            mock.patch.object(cpu_vec_isa, "pick_vec_isa", counting_pick),
+        ):
+            torch.compile(f, backend="eager")(torch.randn(4))
+        self.assertEqual(calls, [])
+
+    def test_native_cpu_artifact_still_rejects_a_codegen_skew(self):
+        # Regression guard for the probe-skipping above: an artifact that DOES
+        # record a CPU codegen target must still be compared against this host,
+        # or an AVX-512 capture silently miscomputes on AVX2.
+        entry = dynamo_package._DynamoCacheEntry(
+            codes=[],
+            source_info=dynamo_package.SourceInfo(inlined_sources=set()),
+            device_type="cpu",
+            device_types=frozenset(("cpu",)),
+            requires_native_backend_compatibility=True,
+            system_info=dataclasses.replace(
+                SystemInfo.current(),
+                cpu_codegen_target=("mips", "DEFAULT", None, "INVALID", None, None),
+            ),
+        )
+        with self.assertRaisesRegex(RuntimeError, "different CPU codegen target"):
+            entry.check_versions()
+
+    def test_codegen_skew_message_says_when_the_probe_could_not_run(self):
+        # A CPU-native artifact on a toolchain-less host is still refused, but
+        # the current side is None rather than a target, and "current=None"
+        # alone reads like a precompile bug rather than a missing compiler.
+        import torch._inductor.cpu_vec_isa as cpu_vec_isa
+        from torch._inductor.exc import InvalidCxxCompiler
+
+        def no_toolchain():
+            raise InvalidCxxCompiler
+
+        cached = dataclasses.replace(
+            SystemInfo.current(),
+            cpu_codegen_target=("x86_64", "AVX512", None, "avx512", None, None),
+        )
+        with mock.patch.object(cpu_vec_isa, "pick_vec_isa", no_toolchain):
+            current = SystemInfo.current()
+        self.assertIsNone(current.cpu_codegen_target)
+        with self.assertRaisesRegex(RuntimeError, "no usable C\\+\\+ compiler"):
+            cached.check_compatibility(current, "cpu")
+
+    def test_caching_precompile_inductor_still_records_the_cpu_target(self):
+        # The eager relaxation must not reach the backend that actually bakes a
+        # vector width into the code it ships.
+        seen = []
+        real = dynamo_package.CompilePackage.cache_entry
+
+        def spy(self):
+            entry = real(self)
+            seen.append(entry)
+            return entry
+
+        def f(x):
+            return x.sin() + 1
+
+        with (
+            torch._dynamo.config.patch(caching_precompile=True),
+            mock.patch.object(dynamo_package.CompilePackage, "cache_entry", spy),
+        ):
+            torch.compile(f, backend="inductor")(torch.randn(4))
+        self.assertTrue(seen)
+        self.assertTrue(all(e.requires_native_backend_compatibility for e in seen))
+        self.assertTrue(all(e.system_info.cpu_codegen_target is not None for e in seen))
+
+    def test_two_artifacts_sharing_an_inner_frame_both_serve(self):
+        # The shared entry frame has no scale guard; scale is checked only by
+        # its resume. Region-scoped dispatch must keep each entry paired with
+        # the continuation from the same artifact instead of taking the first
+        # globally matching entry.
+        shared = self._import_module(
+            self._write_module("shared_frame", "shared_frame", _SHARED_FRAME_SRC),
+            "shared_frame",
+        )
+        x = torch.ones(3, 4)
+        paths = []
+        for cls, scale in ((shared.ModelOne, 3.0), (shared.ModelTwo, 7.0)):
+            torch._dynamo.reset()
+            session = precompile_capture(
+                cls(scale),
+                backend="eager",
+                dynamic=False,
+                example_inputs=[(x,)],
+            )
+            with session:
+                pass
+            self.assertTrue(session.summary().complete)
+            self.assertEqual(session.summary().risky_dropped_guards, ())
+            path = self.path(f"shared_{cls.__name__}.pt")
+            session.save(path, require_no_dropped_guards=False)
+            paths.append(path)
+
+        torch._dynamo.reset()
+        model_a, model_b = shared.ModelOne(3.0), shared.ModelTwo(7.0)
+        with torch.no_grad():
+            want_a, want_b = model_a(x), model_b(x)
+        with (
+            precompile_load(model_a, paths[0], backend="eager", dynamic=False) as a,
+            precompile_load(model_b, paths[1], backend="eager", dynamic=False) as b,
+            torch.no_grad(),
+            serving(),
+        ):
+            self.assertEqual(a(x), want_a)
+            self.assertEqual(b(x), want_b)
+
+    @torch._dynamo.config.patch(nested_graph_breaks=False)
+    def test_concurrent_unload_does_not_clear_a_later_package(self):
+        shared = self._import_module(
+            self._write_module("shared_race", "shared_race", _SHARED_RACE_SRC),
+            "shared_race",
+        )
+        x = torch.randn(3, 4)
+        paths = []
+        for cls, scale in ((shared.ModelOne, 3.0), (shared.ModelTwo, 7.0)):
+            torch._dynamo.reset()
+            session = precompile_capture(cls(scale), backend="eager", dynamic=False)
+            with session as compiled, torch.no_grad():
+                compiled(x)
+            path = self.path(f"concurrent_{cls.__name__}.pt")
+            session.save(path, require_complete=False)
+            paths.append(path)
+
+        torch._dynamo.reset()
+        model_a = shared.ModelOne(3.0)
+        model_b = shared.ModelTwo(7.0)
+        with torch.no_grad():
+            want_b = model_b(x)
+        loaded_a = precompile_load(model_a, paths[0], backend="eager", dynamic=False)
+
+        eval_frame = torch._C._dynamo.eval_frame
+        real_reset = eval_frame._reset_precompile_entries_for_owner
+        shared_code = shared.SharedBlock.forward.__code__
+        self.assertIn(shared_code, loaded_a._package._installed_precompile_codes)
+        at_shared_reset = threading.Event()
+        allow_reset = threading.Event()
+        b_waiting_for_lock = threading.Event()
+        b_loaded = threading.Event()
+        errors = queue.SimpleQueue()
+        loaded_b = queue.SimpleQueue()
+        unload_thread = None
+        load_thread = None
+
+        class ObservedLock:
+            def __init__(self, lock):
+                self.lock = lock
+
+            def __enter__(self):
+                if threading.current_thread() is load_thread:
+                    b_waiting_for_lock.set()
+                self.lock.acquire()
+                return self
+
+            def __exit__(self, *exc):
+                self.lock.release()
+
+        def delayed_reset(code, isolate_recompiles_id, owner):
+            if code is shared_code and threading.current_thread() is unload_thread:
+                at_shared_reset.set()
+                if not allow_reset.wait(10):
+                    raise RuntimeError("timed out waiting to reset precompile entries")
+            real_reset(code, isolate_recompiles_id, owner)
+
+        def unload_a():
+            try:
+                loaded_a.unload()
+            except Exception as e:
+                errors.put(e)
+
+        def load_b():
+            try:
+                loaded_b.put(
+                    precompile_load(model_b, paths[1], backend="eager", dynamic=False)
+                )
+                b_loaded.set()
+            except Exception as e:
+                errors.put(e)
+
+        observed_lock = ObservedLock(dynamo_package._PACKAGE_INSTALL_LOCK)
+        with (
+            mock.patch.object(dynamo_package, "_PACKAGE_INSTALL_LOCK", observed_lock),
+            mock.patch.object(
+                eval_frame, "_reset_precompile_entries_for_owner", delayed_reset
+            ),
+        ):
+            unload_thread = threading.Thread(target=unload_a)
+            unload_thread.start()
+            try:
+                self.assertTrue(at_shared_reset.wait(10))
+                load_thread = threading.Thread(target=load_b)
+                load_thread.start()
+                self.assertTrue(b_waiting_for_lock.wait(10))
+                self.assertFalse(b_loaded.is_set())
+            finally:
+                allow_reset.set()
+                unload_thread.join(10)
+                if load_thread is not None:
+                    load_thread.join(10)
+
+        self.assertFalse(unload_thread.is_alive())
+        self.assertIsNotNone(load_thread)
+        self.assertFalse(load_thread.is_alive())
+        self.assertTrue(errors.empty())
+        loaded = loaded_b.get_nowait()
+        self.assertTrue(loaded_b.empty())
+        with loaded, torch.no_grad(), serving():
+            self.assertEqual(loaded(x), want_b)
+
+    @torch.compiler.set_stance("default")
+    def test_overlapping_serving_contexts_keep_compilation_disabled(self):
+        torch._dynamo.reset()
+
+        @torch.compile(backend="eager", dynamic=False)
+        def compiled(x):
+            return x + 1
+
+        compiled(torch.randn(2))
+        a_entered = threading.Event()
+        b_entered = threading.Event()
+        a_exited = threading.Event()
+        errors = queue.SimpleQueue()
+        rejected = queue.SimpleQueue()
+
+        def serve_a():
+            try:
+                with serving():
+                    a_entered.set()
+                    if not b_entered.wait(10):
+                        raise RuntimeError("timed out waiting for serving thread")
+                a_exited.set()
+            except Exception as e:
+                errors.put(e)
+
+        def serve_b():
+            try:
+                if not a_entered.wait(10):
+                    raise RuntimeError("timed out waiting for serving thread")
+                with serving():
+                    b_entered.set()
+                    if not a_exited.wait(10):
+                        raise RuntimeError("timed out waiting for serving thread")
+                    try:
+                        compiled(torch.randn(3))
+                    except RuntimeError as e:
+                        rejected.put("fail_on_recompile" in str(e))
+                    else:
+                        rejected.put(False)
+            except Exception as e:
+                errors.put(e)
+
+        a = threading.Thread(target=serve_a)
+        b = threading.Thread(target=serve_b)
+        try:
+            a.start()
+            b.start()
+            a.join(10)
+            b.join(10)
+        finally:
+            a_entered.set()
+            b_entered.set()
+            a_exited.set()
+
+        self.assertFalse(a.is_alive())
+        self.assertFalse(b.is_alive())
+        self.assertTrue(errors.empty())
+        self.assertTrue(rejected.get_nowait())
+        self.assertTrue(rejected.empty())
+        self.assertEqual(torch._dynamo.eval_frame._stance.stance, "default")
+
+    def test_example_inputs_drive_the_capture(self):
+        # example_inputs is just "run these for me": capture is by execution, so
+        # the block body becomes optional.
+        session = precompile_capture(
+            PrecompileInvariantModel(),
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(torch.ones(4, 8),), (torch.ones(5, 8),)],
+        )
+        with session:
+            pass
+        summary = session.summary()
+        self.assertEqual(summary.frames, 2)
+        self.assertEqual(summary.guarded_codes, 4)
+
+    def test_invariants_separate_what_holds_from_what_varies(self):
+        # Two shapes, one config value. The config read is on both sides of the
+        # break, so it is invariant; the shapes are what tell the graphs apart.
+        session = precompile_capture(
+            PrecompileInvariantModel(),
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(torch.ones(4, 8),), (torch.ones(5, 8),)],
+        )
+        with session:
+            pass
+
+        frames = {f.frame: f for f in session.invariants()}
+        resume = next(k for k in frames if k.startswith("torch_dynamo_resume_in"))
+        entry = frames["forward"]
+        self.assertEqual(entry.variants, 2)
+        self.assertEqual(frames[resume].variants, 2)
+
+        def rendered(facts):
+            return [f.render() for f in facts]
+
+        # The global read survives into every variant of the resume frame.
+        self.assertTrue(
+            any("['mode'] == 'sum'" in r for r in rendered(frames[resume].invariant)),
+            rendered(frames[resume].invariant),
+        )
+        # The shapes differ between variants, so they are NOT invariant. This is
+        # the half that needs the value fingerprint: TENSOR_MATCH's code_list
+        # carries no shape, so without it both variants would look identical and
+        # land in the intersection.
+        for frame in (entry, frames[resume]):
+            varies = rendered(frame.varying)
+            # Rendered as guard code, so sizes read size=[4, 8].
+            self.assertTrue(any("size=[4, 8]" in r for r in varies), varies)
+            self.assertTrue(any("size=[5, 8]" in r for r in varies), varies)
+            self.assertFalse(any("size=[" in r for r in rendered(frame.invariant)))
+
+    def test_invariants_hold_back_the_guards_no_fingerprint_models(self):
+        # GLOBAL_STATE and friends compare things this report cannot fingerprint,
+        # so calling two of them equal would assert a precondition that was never
+        # checked. They must land in `undetermined`, never in `invariant` --
+        # emptying _UNMODELLED_GUARD_TYPES makes them all compare equal and
+        # silently promotes them into the intersection.
+        from torch._dynamo.precompile_package import _UNMODELLED_GUARD_TYPES
+
+        session = precompile_capture(
+            PrecompileInvariantModel(),
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(torch.ones(4, 8),), (torch.ones(5, 8),)],
+        )
+        with session:
+            pass
+
+        frames = {f.frame: f for f in session.invariants()}
+        entry = frames["forward"]
+        undetermined_types = {f.guard_type for f in entry.undetermined}
+        self.assertIn("GLOBAL_STATE", undetermined_types)
+        self.assertIn("TORCH_FUNCTION_STATE", undetermined_types)
+        for frame in frames.values():
+            self.assertFalse(
+                {f.guard_type for f in frame.invariant} & _UNMODELLED_GUARD_TYPES,
+                [f.render() for f in frame.invariant],
+            )
+            self.assertFalse(
+                {f.guard_type for f in frame.varying} & _UNMODELLED_GUARD_TYPES,
+                [f.render() for f in frame.varying],
+            )
+
+    def test_invariants_file_is_written_and_reproducible(self):
+        def capture(path):
+            torch._dynamo.reset()
+            with precompile_capture(
+                PrecompileInvariantModel(),
+                backend="eager",
+                dynamic=False,
+                example_inputs=[(torch.ones(4, 8),), (torch.ones(5, 8),)],
+                invariants=path,
+            ):
+                pass
+
+        first = self.path("a.invariants")
+        second = self.path("b.invariants")
+        capture(first)
+        capture(second)
+        with open(first) as handle:
+            text = handle.read()
+        self.assertIn("frame forward", text)
+        self.assertIn("invariant [enforced]", text)
+        self.assertIn("varies", text)
+        # Object ids are normalized out, so the file is stable enough to commit
+        # and diff across runs.
+        self.assertNotRegex(text, r"\b\d{9,}\b")
+        with open(second) as handle:
+            self.assertEqual(text, handle.read())
+
+    def test_invariants_path_is_a_file_not_a_directory(self):
+        # Same contract as save(): the path names a file, written exactly where
+        # asked with its parent directories created, which
+        # test_save_writes_a_single_file pins for save() itself. A path kwarg
+        # that names a directory to fill is the easy confusion, so pin it.
+        path = os.path.join(self.dir(), "snapshots", "invariants.txt")
+        self.assertFalse(os.path.exists(os.path.dirname(path)))
+        with precompile_capture(
+            PrecompileInvariantModel(),
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(torch.ones(4, 8),)],
+            invariants=path,
+        ):
+            pass
+        self.assertTrue(os.path.isfile(path))
+        self.assertFalse(os.path.isdir(path))
+        with open(path, encoding="utf-8") as handle:
+            self.assertIn("# precompile invariants for", handle.read())
+
+    def test_invariants_report_tensor_properties_that_split_a_compilation(self):
+        # TensorCheck compares the python type and the conj/neg bits as well as
+        # dtype/shape/stride/device. A fingerprint missing them renders two
+        # compilations as one fact, so the guard that SPLIT them gets printed as
+        # an invariant of both -- the report lying, which is its worst failure.
+        def f(x):
+            return x * 2
+
+        cases = (
+            ("type", torch.nn.Parameter(torch.ones(4)), torch.ones(4)),
+            (
+                "conj",
+                torch.ones(4, dtype=torch.complex64),
+                torch.ones(4, dtype=torch.complex64).conj(),
+            ),
+        )
+        for label, first, second in cases:
+            with self.subTest(label):
+                torch._dynamo.reset()
+                session = precompile_capture(f, backend="eager", dynamic=False)
+                with session as compiled, torch.no_grad():
+                    compiled(first)
+                    compiled(second)
+                frame = session.invariants()[0]
+                self.assertEqual(frame.variants, 2)
+                self.assertTrue(
+                    any(fact.guard_type == "TENSOR_MATCH" for fact in frame.varying),
+                    f"{label}: the guard that split the compilations is not "
+                    f"reported as varying: {[f.render() for f in frame.varying]}",
+                )
+                self.assertFalse(
+                    any(fact.guard_type == "TENSOR_MATCH" for fact in frame.invariant)
+                )
+
+    def test_invariants_report_saved_tensor_hooks_by_content(self):
+        # AUTOGRAD_SAVED_TENSORS_HOOKS renders a raw tuple(map(id, hooks)), so
+        # the ids must be normalized or the file churns -- but erasing them
+        # alone merges two variants that differ ONLY in their hooks, and the
+        # guard that split them gets printed as an invariant of both. Both
+        # directions at once: stable text, still discriminating.
+        #
+        # The hooks must be fx GraphModules or are_inline_hooks() rejects them,
+        # the guard renders "ids == None", and this passes without exercising
+        # anything. That is how an earlier version of this test was vacuous.
+        def pack_a(x):
+            return x + 1
+
+        def unpack_a(x):
+            return x - 1
+
+        def pack_b(x):
+            return x * 2
+
+        def unpack_b(x):
+            return x / 2
+
+        first = (torch.fx.symbolic_trace(pack_a), torch.fx.symbolic_trace(unpack_a))
+        second = (torch.fx.symbolic_trace(pack_b), torch.fx.symbolic_trace(unpack_b))
+
+        def f(x):
+            return (x * 2).sum()
+
+        def capture(path):
+            torch._dynamo.reset()
+            session = precompile_capture(f, backend="eager", dynamic=False)
+            with session as compiled:
+                for hooks in (first, second):
+                    with torch.autograd.graph.saved_tensors_hooks(*hooks):
+                        compiled(torch.ones(4, 8, requires_grad=True)).backward()
+            session.write_invariants(path)
+            return session
+
+        path = self.path("hooks.invariants")
+        session = capture(path)
+
+        frame = session.invariants()[0]
+        self.assertEqual(frame.variants, 2)
+        hook_facts = [
+            fact.render()
+            for fact in frame.varying
+            if "top_saved_tensors_hooks" in fact.render()
+        ]
+        # The guard really did split the two compilations, so it must be here
+        # and not in the invariant set.
+        self.assertEqual(len(hook_facts), 2, frame.varying)
+        self.assertFalse(
+            any("top_saved_tensors_hooks" in f.render() for f in frame.invariant)
+        )
+
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+        self.assertNotRegex(text, r"\b\d{9,}\b")
+
+        # ...and the discriminator is content-derived, so it survives a second
+        # process where the addresses are different.
+        other = self.path("hooks_again.invariants")
+        capture(other)
+        with open(other) as handle:
+            self.assertEqual(text, handle.read())
+
+    # Every shape found to split a compilation while the report called it an
+    # invariant. The fingerprint has failed open three times -- shapes, then
+    # python type and conj/neg, then the dispatch key set -- each fix revealing
+    # the next, so the shapes are asserted here rather than described. A new
+    # one is one line. See _value_fingerprint.
+    _SPLIT_CORPUS = {
+        "shape": lambda: (torch.ones(4, 8), torch.ones(5, 8)),
+        "dtype": lambda: (torch.ones(4, 8), torch.ones(4, 8, dtype=torch.float64)),
+        "requires_grad": lambda: (
+            torch.ones(4, 8),
+            torch.ones(4, 8, requires_grad=True),
+        ),
+        "python_type": lambda: (
+            torch.nn.Parameter(torch.ones(4, 8)),
+            torch.ones(4, 8),
+        ),
+        "conjugate_key": lambda: (
+            torch.ones(4, dtype=torch.complex64),
+            torch.ones(4, dtype=torch.complex64).conj(),
+        ),
+        "negative_key": lambda: (torch.ones(4), torch.ones(4)._neg_view()),
+        "memory_format": lambda: (
+            torch.ones(2, 3, 4, 5),
+            torch.ones(2, 3, 4, 5).to(memory_format=torch.channels_last),
+        ),
+        # TensorCheck stores the TLS-ADJUSTED key set, so a tensor built
+        # OUTSIDE inference_mode still splits the guard when the call is made
+        # inside it. Rendering the tensor's own key set missed exactly this.
+        "tls_dispatch_keys": lambda: (
+            torch.ones(4, 8),
+            _in_inference_mode(torch.ones(4, 8)),
+        ),
+        # The dimension-marking guards live entirely in code_list, which an
+        # earlier version discarded as boilerplate.
+        "dimension_marking": lambda: (
+            torch.ones(4, 8),
+            _marked_static(torch.ones(4, 8)),
+        ),
+    }
+
+    @parametrize("shape", sorted(_SPLIT_CORPUS))
+    def test_a_tensor_property_that_splits_a_compilation_is_reported_varying(
+        self, shape
+    ):
+        first, second = self._SPLIT_CORPUS[shape]()
+
+        def f(x):
+            return x * 2
+
+        torch._dynamo.reset()
+        session = precompile_capture(f, backend="eager", dynamic=False)
+        with session as compiled:
+            for arg in (first, second):
+                if isinstance(arg, _InferenceInput):
+                    with torch.inference_mode():
+                        compiled(arg.tensor)
+                else:
+                    with torch.no_grad():
+                        compiled(arg)
+        frame = session.invariants()[0]
+        # If Dynamo did not actually split, the case is not exercising anything
+        # and the corpus entry is wrong -- say so rather than passing quietly.
+        self.assertEqual(frame.variants, 2, f"{shape}: dynamo did not recompile")
+        # Key on the field, not the rendered text: the render is authoritative
+        # guard code now and does not spell the type.
+        self.assertTrue(
+            any(fact.guard_type == "TENSOR_MATCH" for fact in frame.varying),
+            f"{shape}: the guard that split the compilations is reported as an "
+            f"invariant of both. varying={[f.render() for f in frame.varying]}",
+        )
+        self.assertFalse(
+            any(fact.guard_type == "TENSOR_MATCH" for fact in frame.invariant)
+        )
+
+    def test_invariants_marks_unenforced_preconditions(self):
+        # An invariant whose guard could not be serialized is a precondition
+        # nothing rechecks at load. It has to be visibly distinct.
+        session = precompile_capture(
+            PrecompileInvariantModel(),
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(torch.ones(4, 8),), (torch.ones(5, 8),)],
+        )
+        with session:
+            pass
+        rendered = [
+            f.render() for frame in session.invariants() for f in frame.invariant
+        ]
+        self.assertTrue(any(r.startswith("[dropped ]") for r in rendered))
+        self.assertTrue(any(r.startswith("[enforced]") for r in rendered))
+
+    def test_invariants_do_not_collapse_a_large_constant(self):
+        # _normalize strips object ids so the file diffs clean. It must not
+        # strip a user constant with it: these two variants pin the dict to
+        # different keys, and collapsing them promotes a condition NEITHER
+        # variant holds into the intersection.
+        def fn(x, d):
+            return x * next(iter(d.values()))
+
+        session = precompile_capture(fn, backend="eager", dynamic=False)
+        with session as compiled:
+            compiled(torch.ones(4), {1000000001: 2})
+            compiled(torch.ones(4), {2000000002: 3})
+        (frame,) = session.invariants()
+        self.assertEqual(frame.variants, 2)
+        invariant = [f.render() for f in frame.invariant]
+        varying = [f.render() for f in frame.varying]
+        self.assertFalse(any("dict.keys" in r for r in invariant), invariant)
+        self.assertTrue(any("[1000000001]" in r for r in varying), varying)
+        self.assertTrue(any("[2000000002]" in r for r in varying), varying)
+
+    def test_invariants_keep_a_guard_every_variant_shares(self):
+        # k is unspecialized, so its guard is "k is an int" in both variants and
+        # is a real precondition. Fingerprinting the value it happened to hold
+        # would split one shared guard into two indistinguishable varying facts.
+        def fn(x, flag, k):
+            return x * k if flag else x + k
+
+        session = precompile_capture(fn, backend="eager", dynamic=True)
+        with session as compiled:
+            compiled(torch.ones(4), True, 1)
+            compiled(torch.ones(4), False, 2)
+        (frame,) = session.invariants()
+        self.assertEqual(frame.variants, 2)
+        invariant = [f.render() for f in frame.invariant]
+        varying = [f.render() for f in frame.varying]
+        self.assertTrue(
+            any("___check_type_id(L['k']" in r for r in invariant), invariant
+        )
+        self.assertEqual(len(varying), len(set(varying)), varying)
+
+    def test_invariants_name_the_object_an_identity_guard_pinned(self):
+        # The id in an identity guard's code is normalized away, so the object
+        # has to be named some other way: without it the two variants -- traced
+        # against relu and against sigmoid -- render one fact and self.act is
+        # reported invariant, hiding the only thing that tells them apart.
+        model = PrecompileSelfAct(torch.relu)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled:
+            compiled(torch.ones(4))
+            model.act = torch.sigmoid
+            compiled(torch.ones(4, dtype=torch.float64))
+        entry = {f.frame: f for f in session.invariants()}["forward"]
+        self.assertEqual(entry.variants, 2)
+        invariant = [f.render() for f in entry.invariant]
+        varying = [f.render() for f in entry.varying]
+        self.assertFalse(any(".act" in r for r in invariant), invariant)
+        self.assertTrue(any(r.endswith("relu on self.act") for r in varying), varying)
+        self.assertTrue(
+            any(r.endswith("sigmoid on self.act") for r in varying), varying
+        )
+
+    def test_invariants_are_stable_across_dynamo_global_counters(self):
+        # The builtins dict Dynamo installs carries a per-process counter, so
+        # the same guard reads __builtins_dict___0 in one capture and ___4 in
+        # the next. Un-normalized, a committed report changes every run and the
+        # guard reports as varying rather than invariant. The model the other
+        # invariants tests use reads no builtin, so nothing covers this today.
+        def capture(path):
+            torch._dynamo.reset()
+            with precompile_capture(
+                PrecompileBuiltinReadingModel(),
+                backend="eager",
+                dynamic=False,
+                example_inputs=[(torch.ones(4, 8),), (torch.ones(5, 8),)],
+                invariants=path,
+            ):
+                pass
+
+        first, second = self.path("first.invariants"), self.path("second.invariants")
+        capture(first)
+        capture(second)
+        with open(first) as handle:
+            text = handle.read()
+        self.assertIn("__builtins_dict___<n>", text)
+        self.assertNotRegex(text, r"__builtins_dict___\d")
+        with open(second) as handle:
+            self.assertEqual(text, handle.read())
+
+    def test_invariants_are_stable_across_globals_named_by_object_id(self):
+        # install_global_by_id names a global "<prefix>_<id(value)>_c<n>", so a
+        # guard reading one carries an address inside an identifier, where
+        # neither the id nor the counter pattern can see it. `type(x) is
+        # torch.Tensor` installs one; transformers' Qwen2 installs three, and
+        # its report differed between processes before this was normalized.
+        def fn(x):
+            return x.sum() if type(x) is torch.Tensor else x
+
+        path = self.path("byid.invariants")
+        with precompile_capture(
+            fn,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(torch.ones(4),)],
+            invariants=path,
+        ):
+            pass
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+        self.assertIn("_<id>_c<n>", text)
+        self.assertNotRegex(text, r"_\d{9,}_c\d")
+
+    def test_facts_differing_only_in_value_sort_apart(self):
+        # Once the boilerplate code parts are filtered a TENSOR_MATCH renders no
+        # code at all, so two shape specializations tie on every other component
+        # of the sort key and their order falls to set iteration, which is hash
+        # seeded: the file then differs between PROCESSES, which two captures in
+        # one process cannot show.
+        def fact(shape):
+            return _GuardFact("TENSOR_MATCH", "x", (), f"shape={shape}", True)
+
+        self.assertNotEqual(_fact_order(fact((4, 8))), _fact_order(fact((5, 8))))
+
+    def test_grad_mode_is_reported_when_variants_differ_in_it(self):
+        # example_inputs run under no_grad and body calls do not, so the same
+        # call made both ways compiles twice. Global-state guards carry no value
+        # of their own, so without a fingerprint the report shows two variants
+        # and nothing varying -- the half that is supposed to tell them apart.
+        x = torch.ones(4, 8)
+        session = precompile_capture(
+            PrecompileInvariantModel(),
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(x,)],
+        )
+        with session as compiled:
+            compiled(x)
+        (frame,) = [f for f in session.invariants() if f.frame == "forward"]
+        self.assertEqual(frame.variants, 2)
+        varies = [f.render() for f in frame.varying]
+        self.assertTrue(any("grad_enabled=True" in r for r in varies), varies)
+        self.assertTrue(any("grad_enabled=False" in r for r in varies), varies)
+
+    def test_a_failing_example_input_does_not_wedge_the_session(self):
+        # __enter__ runs example_inputs, and a __enter__ that raises never gets
+        # its __exit__, so the config patch the session holds would stay on for
+        # the life of the process and the session would refuse to save what it
+        # did capture. A bare tensor instead of a 1-tuple is the likely way in.
+        before = functorch_config.bundled_autograd_cache
+        session = precompile_capture(
+            PrecompileInvariantModel(),
+            backend="eager",
+            dynamic=False,
+            example_inputs=[torch.ones(4, 8)],
+        )
+        with self.assertRaisesRegex(TypeError, "tuples of positional args"):
+            with session:
+                pass
+        self.assertEqual(functorch_config.bundled_autograd_cache, before)
+        with self.assertRaisesRegex(PackageError, "capture raised"):
+            session.save(self.path())
+
+    def test_repeated_guard_facts_are_stored_once_per_session(self):
+        # A recompiled frame repeats nearly all of its guards, so storing one
+        # object per compilation makes the session grow with the number of
+        # variants instead of with the number of distinct facts. Measured on
+        # resnet18, 200 variants retained 83MB to describe 1281 facts.
+        session = precompile_capture(
+            PrecompileIntArg(),
+            backend="eager",
+            recompile_limit=64,
+            dynamic=False,
+            example_inputs=[(torch.ones(4, 8), k) for k in range(20)],
+        )
+        with session:
+            pass
+        facts = [f for sets in session._guard_sets.values() for s in sets for f in s]
+        self.assertGreater(len(facts), 5 * len(set(facts)))
+        self.assertEqual(len({id(f) for f in facts}), len(set(facts)))
+
+    def test_load_rejects_artifact_from_a_different_callable(self):
+        x = torch.randn(4, 8)
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(x)
+        session.save(self.path())
+
+        # CompilePackage rebinds the stored guards onto whatever callable it is
+        # given, and the source checksum only covers the captured function, so
+        # without an explicit check this silently serves the wrong graphs.
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(PackageError, "captured from"):
+            precompile_load(
+                staged_with_local_dict_conditional,
+                self.path(),
+                backend="eager",
+                dynamic=False,
+            )
+
+    def test_save_rejects_capture_that_ran_nothing(self):
+        # Capture is by execution. A session whose callable was never run has
+        # nothing to serve, and install() would just skip the frame, so
+        # serving() could not report the gap either.
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session:
+            pass
+        summary = session.summary()
+        self.assertEqual(summary.guarded_codes, 0)
+        self.assertFalse(summary.complete)
+        with self.assertRaisesRegex(PackageError, "captured no compiled code"):
+            session.save(self.path())
+
+    def test_unload_clears_resume_function_entries(self):
+        # uninstall() used to clear precompile entries only for the entry frame,
+        # leaving resume functions installed on module-level code objects for
+        # the rest of the process.
+        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+
+        x = torch.randn(4, 8)
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(x)
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        loaded = precompile_load(
+            staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+        )
+        installed = [
+            code
+            for code in loaded._package._installed_precompile_codes
+            if code.co_name.startswith("torch_dynamo_resume_in")
+        ]
+        self.assertTrue(installed, "expected resume frames to be installed")
+        self.assertTrue(all(_debug_get_precompile_entries(c) for c in installed))
+
+        loaded.unload()
+        for code in installed:
+            self.assertEqual(_debug_get_precompile_entries(code), [])
+
+    def test_unload_clears_fallback_entries_on_an_inner_frame(self):
+        # install() attaches a frame reached through code_source to the LIVE
+        # code the running program resolves, a DIFFERENT object from the
+        # reconstructed twin the package holds even though the two compare
+        # equal. Uncovered calls compile into the region on the live code, so
+        # unload has to clear that object or every load/serve/unload cycle
+        # leaks a cache entry toward accumulated_recompile_limit.
+        from torch._dynamo.eval_frame import _get_total_cache_entry_count
+
+        inner = PrecompileResumingBlock.forward.__code__
+        model = PrecompileResumingStack(1)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled:
+            compiled(torch.randn(4, 8))
+        session.save(self.path(), require_complete=False)
+
+        torch._dynamo.reset()
+        for _ in range(3):
+            loaded = precompile_load(model, self.path(), backend="eager", dynamic=False)
+            loaded(torch.randn(5, 8))
+            self.assertGreater(_get_total_cache_entry_count(inner), 0)
+            # By identity: the reconstructed twin compares EQUAL to the live
+            # code, so a value-keyed dedupe would keep the twin, clear a region
+            # nothing runs in, and leave the live entry behind.
+            self.assertTrue(
+                any(code is inner for code in loaded._package.region_codes())
+            )
+            loaded.unload()
+            self.assertEqual(_get_total_cache_entry_count(inner), 0)
+
+    @torch._dynamo.config.patch(accumulated_recompile_limit=4)
+    def test_unload_clears_fallback_entries_on_a_live_resume_frame(self):
+        # A fallback compile mints its OWN resume code object and binds it to
+        # its own global, while the package holds only the artifact's twin,
+        # which compares EQUAL to it, so the value-keyed _codes keeps the twin
+        # and unload cleared a region nothing runs in. The live frame then kept
+        # one entry per load until accumulated_recompile_limit refused to
+        # compile that continuation again, for plain torch.compile too.
+        from torch._dynamo.eval_frame import _get_total_cache_entry_count
+        from torch._dynamo.resume_execution import ContinueExecutionCache
+
+        model = PrecompileResumingStack(1)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled:
+            compiled(torch.randn(4, 8))
+        session.save(self.path(), require_complete=False)
+
+        torch._dynamo.reset()
+        inner = PrecompileResumingBlock.forward.__code__
+        for n in range(5, 10):
+            loaded = precompile_load(model, self.path(), backend="eager", dynamic=False)
+            loaded(torch.randn(n, 8))
+            loaded.unload()
+
+        resumes = list(ContinueExecutionCache.cache.get(inner, {}).values())
+        self.assertTrue(resumes, "expected a live fallback resume frame")
+        for code in resumes:
+            self.assertEqual(_get_total_cache_entry_count(code), 0)
+
+        counter = torch._dynamo.testing.CompileCounter()
+        x = torch.randn(11, 8)
+        ordinary = torch.compile(model, backend=counter, dynamic=False)
+        self.assertEqual(ordinary(x), model(x))
+        self.assertEqual(counter.frame_count, 2)
+
+    def test_unload_leaves_another_packages_region_entries_on_a_shared_frame(self):
+        # The clear above reaches the LIVE code object, which every package
+        # loaded for another instance of the same class installed onto too.
+        # Only this package's region may go: the other one is still dispatching
+        # out of its own bucket on that same code, and a fallback it already
+        # compiled is what keeps its next call from recompiling under serving().
+        from torch._dynamo.eval_frame import _get_cache_entries_for_region
+
+        covered, uncovered = torch.randn(4, 8), torch.randn(5, 8)
+        session = precompile_capture(
+            PrecompileResumingStack(1), backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(covered)
+        session.save(self.path(), require_complete=False)
+
+        torch._dynamo.reset()
+        inner = PrecompileResumingBlock.forward.__code__
+        first = precompile_load(
+            PrecompileResumingStack(1), self.path(), backend="eager", dynamic=False
+        )
+        second = precompile_load(
+            PrecompileResumingStack(1), self.path(), backend="eager", dynamic=False
+        )
+        try:
+            first(uncovered)
+            second(uncovered)
+            region = second._isolate_recompiles_id
+            self.assertTrue(_get_cache_entries_for_region(inner, region))
+            first.unload()
+            self.assertFalse(
+                _get_cache_entries_for_region(inner, first._isolate_recompiles_id)
+            )
+            self.assertTrue(_get_cache_entries_for_region(inner, region))
+            with serving():
+                second(uncovered)
+        finally:
+            second.unload()
+            first.unload()
+
+    def test_truncation_report_is_a_lower_bound(self):
+        # Hitting recompile_limit sets FrameExecStrategy(RUN_ONLY, RUN_ONLY),
+        # whose recursive half silences every frame called beneath the offender,
+        # yet only the offender is recorded. Pin the gap the message must admit.
+        inputs = [torch.randn(*s) for s in [(4, 8), (5, 8), (6, 8)]]
+
+        def capture(limit):
+            torch._dynamo.reset()
+            session = precompile_capture(
+                PrecompileResumingStack(5),
+                backend="eager",
+                recompile_limit=limit,
+                dynamic=False,
+            )
+            with session as compiled:
+                for x in inputs:
+                    compiled(x)
+            resumes = {
+                c.python_code.co_name: len(c.guarded_codes)
+                for c in session._package.cache_entry().codes
+                if c.python_code.co_name.startswith("torch_dynamo_resume")
+            }
+            return session, resumes
+
+        full_session, full = capture(64)
+        self.assertEqual(full_session.summary().truncated, ())
+        self.assertTrue(full and all(n > 1 for n in full.values()))
+
+        session, cut = capture(8)
+        summary = session.summary()
+        # One frame named, but the resume frames beneath it also lost variants.
+        self.assertEqual(len(summary.truncated), 1)
+        self.assertEqual(set(cut), set(full))
+        self.assertTrue(all(cut[name] < full[name] for name in full))
+        self.assertFalse(
+            any(name in entry for name in full for entry in summary.truncated)
+        )
+        self.assertIn(">=1 TRUNCATED", str(summary))
+        with self.assertRaisesRegex(PackageError, "lower bound"):
+            session.save(self.path())
+
+    def test_value_pinned_guard_on_a_plain_argument(self):
+        # A non-tensor argument is pinned by equality exactly like a graph-break
+        # stack slot, but gets no ___stackN name, so a name-keyed report misses
+        # it and a complete-looking artifact silently serves only k == 7.
+        session = precompile_capture(PrecompileIntArg(), backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4), 7)
+        summary = session.summary()
+        self.assertEqual(summary.wont_generalize, ("k",))
+        self.assertTrue(summary.complete)
+
+    def test_a_value_pin_that_arrives_as_equals_match(self):
+        # Which equality guard Dynamo picks depends on the value's type, not on
+        # whether it pins anything: a dict_keys argument is compared with == and
+        # lands on EQUALS_MATCH rather than CONSTANT_MATCH. Recognising only one
+        # of the two reports a clean artifact that serves one key set.
+        session = precompile_capture(
+            PrecompileKeysArg(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4), {"a": 1, "b": 2}.keys())
+        summary = session.summary()
+        self.assertIn(("EQUALS_MATCH", "ks"), summary.kept_guards)
+        self.assertEqual(summary.wont_generalize, ("ks",))
+
+    def test_tensor_crossing_a_graph_break_is_not_value_pinned(self):
+        # A tensor left on the stack across a break also gets a ___stackN
+        # source, but under TENSOR_MATCH, which generalizes like any other
+        # input. Reporting it would fire on ordinary tensor-only models.
+        session = precompile_capture(
+            PrecompileTensorAcrossBreak(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        summary = session.summary()
+        self.assertTrue(any("___stack" in n for _, n in summary.kept_guards))
+        self.assertEqual(summary.wont_generalize, ())
+
+    def test_value_pinned_guards_cover_the_stack_slot_and_the_local(self):
+        # The .item() result is guarded twice: once on the stack slot it crossed
+        # the break in, once on the resume frame's local. Both pin the artifact.
+        session = precompile_capture(
+            PrecompileItemThenBreak(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        self.assertEqual(session.summary().wont_generalize, ("___stack0", "scale"))
+
+    def test_module_config_constants_are_not_value_pinned(self):
+        # LayerNorm eps, Dropout p and a plain int attribute are all
+        # CONSTANT_MATCH but are model config, constant for the model the
+        # artifact is loaded onto. Counting them would flag every model.
+        for model in (PrecompileConfigConstants().eval(), PrecompileIntAttr(3)):
+            torch._dynamo.reset()
+            session = precompile_capture(model, backend="eager", dynamic=False)
+            with session as compiled, torch.no_grad():
+                compiled(torch.randn(2, 8))
+            summary = session.summary()
+            self.assertTrue(any(t == "CONSTANT_MATCH" for t, _ in summary.kept_guards))
+            self.assertEqual(summary.wont_generalize, ())
+
+    def _write_module(self, dirname, name, src):
+        pkg_dir = os.path.join(self.dir(), dirname)
+        os.makedirs(pkg_dir, exist_ok=True)
+        with open(os.path.join(pkg_dir, f"{name}.py"), "w") as f:
+            f.write(src)
+        return pkg_dir
+
+    def _forget_modules(self, *names):
+        for name in names:
+            sys.modules.pop(name, None)
+            self.addCleanup(lambda n=name: sys.modules.pop(n, None))
+
+    def _import_module(self, pkg_dir, name):
+        sys.path.insert(0, pkg_dir)
+        self.addCleanup(lambda: pkg_dir in sys.path and sys.path.remove(pkg_dir))
+        self.addCleanup(lambda: sys.modules.pop(name, None))
+        sys.modules.pop(name, None)
+        importlib.invalidate_caches()
+        return importlib.import_module(name)
+
+    def test_load_rejects_a_same_named_callable_from_another_module(self):
+        # Two modules each defining `class Encoder` agree on qualname and on
+        # co_name, and each is self-consistent so the source checksum passes.
+        a = self._import_module(
+            self._write_module("a", "enc_a", _ENCODER_SRC.format(op="+")), "enc_a"
+        )
+        b = self._import_module(
+            self._write_module("b", "enc_b", _ENCODER_SRC.format(op="*")), "enc_b"
+        )
+        session = precompile_capture(a.Encoder(), backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(4))
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(PackageError, "defined in 'enc_b'"):
+            precompile_load(b.Encoder(), self.path(), backend="eager", dynamic=False)
+
+    def test_load_rejects_a_different_definition_of_the_same_name(self):
+        # The deployment shape is capture here, serve there. A module that
+        # defines the same class twice under an `if` gives the two machines
+        # matching module, qualname and co_name, and the source checksum covers
+        # a line range that is identical in both builds, so only the first line
+        # of the definition separates them.
+        pkg_dir = self._write_module("flip", "flip_mod", _FLIPPED_ENCODER_SRC)
+        os.environ.pop("FLIP_V2", None)
+        self.addCleanup(lambda: os.environ.pop("FLIP_V2", None))
+        v1 = self._import_module(pkg_dir, "flip_mod")
+        x = torch.ones(4) * 2.0
+        session = precompile_capture(v1.Encoder(), backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            self.assertEqual(compiled(x), x + 1.0)
+        session.save(self.path())
+
+        os.environ["FLIP_V2"] = "1"
+        sys.modules.pop("flip_mod", None)
+        v2 = importlib.import_module("flip_mod")
+        model = v2.Encoder()
+        self.assertEqual(model(x), x * 7.0)
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(PackageError, "different definition"):
+            precompile_load(model, self.path(), backend="eager", dynamic=False)
+
+    def test_load_survives_a_checkout_at_a_different_path(self):
+        # The capture and serving machines check out to different absolute
+        # paths, so co_filename must NOT be part of artifact identity. This
+        # test exists to fail if someone tightens the check with it.
+        src = _ENCODER_SRC.format(op="+")
+        a = self._import_module(
+            self._write_module("here", "moved_mod", src), "moved_mod"
+        )
+        x = torch.ones(4)
+        session = precompile_capture(a.Encoder(), backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        session.save(self.path())
+
+        other = self._write_module("there", "moved_mod", src)
+        sys.path.remove(os.path.dirname(a.__file__))
+        b = self._import_module(other, "moved_mod")
+        self.assertNotEqual(a.__file__, b.__file__)
+        torch._dynamo.reset()
+        with (
+            precompile_load(
+                b.Encoder(), self.path(), backend="eager", dynamic=False
+            ) as loaded,
+            torch.no_grad(),
+        ):
+            self.assertEqual(loaded(x), x + 1.0)
+
+    def test_inlined_code_is_named_by_the_file_that_holds_it(self):
+        # inspect.getmodule maps a file to the name the module knows itself by,
+        # and a private implementation file that spoofs __name__ answers with
+        # the shim re-exporting it. The key is what load-time revalidation
+        # re-imports, and __name__ imports to the shim, so it has to be the key.
+        pkg = self._write_module("shim", "_shim_impl", _SHIM_IMPL_SRC)
+        self._write_module("shim", "shim_abc", _SHIM_SRC)
+        self._forget_modules("_shim_impl", "shim_abc")
+        shim = self._import_module(pkg, "shim_abc")
+        impl = sys.modules["_shim_impl"]
+        self.assertIsNot(inspect.getmodule(shim.helper.__code__), impl)
+        name = _defining_module_name(shim.helper.__code__)
+        self.assertEqual(name, "_shim_impl")
+        self.assertIs(importlib.import_module(name), impl)
+
+    def test_inlining_through_a_re_exporting_shim_round_trips(self):
+        # End to end because the two halves fail at different times: hashing
+        # the inlined line range against the shim raises "Source mismatch"
+        # during capture, and recording the shim's name rather than the key
+        # raises "Source code changes detected" at load, against source that
+        # nothing changed.
+        pkg = self._write_module("shim", "_shim_impl", _SHIM_IMPL_SRC)
+        self._write_module("shim", "shim_abc", _SHIM_SRC)
+        self._write_module("shim", "shim_model", _SHIM_MODEL_SRC)
+        self._forget_modules("_shim_impl", "shim_abc")
+        model = self._import_module(pkg, "shim_model").Model()
+        x = torch.ones(4)
+        expected = model(x)
+
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        sources = session._package.cache_entry().source_info.inlined_sources
+        recorded = {s.module for s in sources}
+        self.assertIn("_shim_impl", recorded)
+        self.assertNotIn("shim_abc", recorded)
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        with precompile_load(
+            model, self.path(), backend="eager", dynamic=False
+        ) as loaded:
+            self.assertEqual(loaded(x), expected)
+
+    def test_capture_rejects_a_callable_with_no_code_object(self):
+        def scaled(scale, x):
+            return x * scale
+
+        class OnlyCall:
+            def __call__(self, x):
+                return x + 1.0
+
+        for fn in (functools.partial(scaled, 2.0), OnlyCall()):
+            with self.assertRaisesRegex(TypeError, "no __code__"):
+                precompile_capture(fn, backend="eager")
+
+    def test_capture_rejects_a_module_whose_forward_has_no_code_object(self):
+        # An nn.Module reaches the same dead end one level down: self.forward =
+        # functools.partial(...) in __init__ shadows the class method, so the
+        # entry function has no __code__ either. Saying so is the whole point of
+        # the check above; without it this died on a bare AttributeError from
+        # inside CompilePackage.
+        with self.assertRaisesRegex(TypeError, "no __code__"):
+            precompile_capture(
+                PrecompilePartialForward(2.0), backend="eager", dynamic=False
+            )
+
+    def test_load_refuses_a_callable_whose_code_attribute_is_none(self):
+        # The capture-side check asks hasattr, so a callable carrying a __code__
+        # that is present and None gets past it -- and load rebinds the stored
+        # guards and bytecode onto whatever it is handed, so nothing downstream
+        # is looking either. Refuse it at load with the same sentence rather
+        # than somewhere deep in CompilePackage with a weakref TypeError.
+        session = precompile_capture(
+            PrecompileSelfAct(torch.relu), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        session.save(self.path(), require_no_risky_drops=False)
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(PackageError, "no __code__"):
+            precompile_load(
+                _PrecompileForwardsCode(len),
+                self.path(),
+                backend="eager",
+                dynamic=False,
+            )
+
+    def test_device_type_records_the_accelerator_not_the_last_graph(self):
+        # _DynamoCacheEntry.device_type gates every GPU check in
+        # SystemInfo.check_compatibility, and one package holds many graphs, so
+        # a cpu epilogue after a graph break must not erase the accelerator.
+        def graph_on(device):
+            graph = torch.fx.Graph()
+            graph.call_function(torch.ones, args=(torch.device(device),))
+            return graph
+
+        package = CompilePackage(staged_with_graph_breaks)
+        package.update_device_type(graph_on("cuda"))
+        package.update_device_type(graph_on("cpu"))
+        self.assertEqual(package.cache_entry().device_type, "cuda")
+        self.assertEqual(package.cache_entry().device_types, frozenset(("cpu", "cuda")))
+
+        # A load, a cpu recompile and a re-save must not downgrade it either.
+        # Loading a "cuda" entry runs check_versions and so needs a GPU; the
+        # restore path does not care which accelerator it is, so the round trip
+        # uses one SystemInfo does not gate and stays runnable on a cpu host.
+        accel = CompilePackage(staged_with_graph_breaks)
+        accel.update_device_type(graph_on("mtia"))
+        reloaded = CompilePackage(staged_with_graph_breaks, accel.cache_entry())
+        reloaded.update_device_type(graph_on("cpu"))
+        self.assertEqual(reloaded.cache_entry().device_type, "mtia")
+
+        cpu_only = CompilePackage(staged_with_graph_breaks)
+        cpu_only.update_device_type(graph_on("cpu"))
+        self.assertEqual(cpu_only.cache_entry().device_type, "cpu")
+
+    def test_a_failed_load_leaves_no_device_type_behind(self):
+        # eval_frame's caching_precompile path retries a failed load on the SAME
+        # package object, and update_device_type only widens cpu -> accelerator,
+        # so a device_type left behind by the failed load can never be corrected
+        # and gets re-saved as this capture's. One outside CHECK_GPUS turns off
+        # every GPU check for whoever loads the artifact next.
+        from torch._dynamo.package import _DynamoCacheEntry, InlinedSource, SourceInfo
+
+        def graph_on(device):
+            graph = torch.fx.Graph()
+            graph.call_function(torch.ones, args=(torch.device(device),))
+            return graph
+
+        drifted = SourceInfo(
+            inlined_sources={
+                InlinedSource(
+                    module="torch._dynamo.package",
+                    firstlineno=1,
+                    lastlineno=3,
+                    checksum="not-the-checksum-on-disk",
+                    content="",
+                )
+            }
+        )
+        stale = _DynamoCacheEntry(codes=[], source_info=drifted, device_type="mtia")
+
+        package = CompilePackage(None)
+        with self.assertRaisesRegex(RuntimeError, "Source code changes detected"):
+            package.initialize(staged_with_graph_breaks, stale)
+        self.assertFalse(package.is_initialized())
+
+        package.initialize(staged_with_graph_breaks, None)
+        package.update_device_type(graph_on("cuda"))
+        entry = package.cache_entry()
+        self.assertEqual(entry.device_type, "cuda")
+
+        # "mtia" is not in CHECK_GPUS, so had it survived it would have waved
+        # this artifact onto any host; what survives instead is gated.
+        other_host = dataclasses.replace(entry.system_info, gpu_name="Some Other GPU")
+        entry.system_info.check_compatibility(other_host, "mtia")
+        self.assertIn(entry.device_type, SystemInfo.CHECK_GPUS)
+        if torch.cuda.is_available():
+            with self.assertRaisesRegex(RuntimeError, "different GPU"):
+                entry.system_info.check_compatibility(other_host, entry.device_type)
+
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_failed_cache_install_cold_falls_back_on_same_package(self):
+        from torch._dynamo.precompile_context import EagerCacheArtifact
+
+        x = torch.randn(4, 8)
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(x)
+        session.save(self.path())
+        entry = _SingleFileStore().read(self.path())
+
+        torch._dynamo.reset()
+        with (
+            mock.patch.object(DynamoCache, "load", return_value=entry),
+            mock.patch.object(
+                EagerCacheArtifact,
+                "after_deserialization",
+                side_effect=RuntimeError("cache install failed"),
+            ),
+            self.assertLogs("torch._dynamo.eval_frame", level="WARNING"),
+        ):
+            compiled = torch.compile(
+                staged_with_graph_breaks, backend="eager", dynamic=False
+            )
+        self.assertEqual(compiled(x), staged_with_graph_breaks(x))
+
+    @unittest.skipIf(not HAS_CUDA_AND_TRITON, "Requires CUDA/Triton")
+    def test_device_type_of_a_cuda_capture_with_a_cpu_epilogue(self):
+        from torch._dynamo.precompile_package import default_guard_filter_fn
+
+        def cuda_then_cpu_epilogue(x):
+            v = (x.sin() + 1.0).sum().item()
+            return torch.tensor([v]) * 2
+
+        package = CompilePackage(cuda_then_cpu_epilogue)
+        compiled = torch._dynamo.optimize(
+            "eager", package=package, guard_filter_fn=default_guard_filter_fn
+        )(cuda_then_cpu_epilogue)
+        compiled(torch.randn(8, device="cuda"))
+        entry = package.cache_entry()
+        # entry frame (cuda) plus the resume frame after .item() (cpu)
+        self.assertEqual(len(entry.codes), 2)
+        self.assertEqual(entry.device_type, "cuda")
+
+    def test_second_artifact_for_a_shared_frame_does_not_evict(self):
+        # Two instances of one class share a forward code object, but each
+        # loaded callable dispatches only through its own compile region.
+        x = torch.randn(3, 4)
+        paths = []
+        for act in (torch.relu, torch.sigmoid):
+            torch._dynamo.reset()
+            session = precompile_capture(
+                PrecompileSelfAct(act), backend="eager", dynamic=False
+            )
+            with session as compiled, torch.no_grad():
+                compiled(x)
+            path = self.path(f"{act.__name__}.pt")
+            session.save(path, require_no_risky_drops=False)
+            paths.append(path)
+
+        torch._dynamo.reset()
+        relu_model = PrecompileSelfAct(torch.relu)
+        sigmoid_model = PrecompileSelfAct(torch.sigmoid)
+        with torch.no_grad():
+            expected_relu = relu_model(x)
+            expected_sigmoid = sigmoid_model(x)
+        first = precompile_load(relu_model, paths[0], backend="eager", dynamic=False)
+        with torch.no_grad(), serving():
+            self.assertEqual(first(x), expected_relu)
+
+        with self.assertNoLogs("torch._dynamo.package", level="WARNING"):
+            second = precompile_load(
+                sigmoid_model,
+                paths[1],
+                backend="eager",
+                dynamic=False,
+            )
+        with torch.no_grad(), serving():
+            self.assertEqual(first(x), expected_relu)
+            self.assertEqual(second(x), expected_sigmoid)
+        second.unload()
+        first.unload()
+
+    def test_shared_frame_artifacts_use_distinct_regions(self):
+        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+
+        x = torch.randn(3, 4)
+        paths = []
+        for act in (torch.relu, torch.sigmoid):
+            torch._dynamo.reset()
+            session = precompile_capture(
+                PrecompileSelfAct(act), backend="eager", dynamic=False
+            )
+            with session as compiled, torch.no_grad():
+                compiled(x)
+            path = self.path(f"{act.__name__}.pt")
+            session.save(path, require_no_risky_drops=False)
+            paths.append(path)
+
+        def load(path, act):
+            return precompile_load(
+                PrecompileSelfAct(act), path, backend="eager", dynamic=False
+            )
+
+        torch._dynamo.reset()
+        first = load(paths[0], torch.relu)
+        with self.assertNoLogs("torch._dynamo.package", level="WARNING"):
+            second = load(paths[1], torch.sigmoid)
+        entries = _debug_get_precompile_entries(PrecompileSelfAct.forward.__code__)
+        self.assertEqual(
+            {entry.isolate_recompiles_id for entry in entries},
+            {
+                first._isolate_recompiles_id,
+                second._isolate_recompiles_id,
+            },
+        )
+        second.unload()
+        first.unload()
+
+    def test_repeated_unload_does_not_clear_a_later_package(self):
+        x = torch.randn(3, 4)
+        model = PrecompileSelfAct(torch.relu)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        session.save(self.path(), require_no_risky_drops=False)
+
+        torch._dynamo.reset()
+        first = precompile_load(model, self.path(), backend="eager", dynamic=False)
+        with first:
+            first.unload()
+            second = precompile_load(model, self.path(), backend="eager", dynamic=False)
+        with second, torch.no_grad(), serving():
+            self.assertEqual(second(x), model(x))
+
+    def test_invariants_separate_two_lambdas_sharing_a_qualname(self):
+        # _object_identity names a callable, and every entry of an ACT2FN-style
+        # table is "<lambda>" in one module on one line. If they collapse, the
+        # CLOSURE_MATCH that SPLIT the two compilations renders identically in
+        # both and is reported as an invariant of each, with nothing varying --
+        # the report asserting a precondition that does not hold.
+        session = precompile_capture(
+            PrecompileLambdaTablePair(), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+
+        split = [fi for fi in session.invariants() if fi.variants > 1]
+        self.assertTrue(split, "expected a frame compiled more than once")
+        for frame in split:
+            varying = [f.render() for f in frame.varying]
+            self.assertTrue(
+                any("self.act" in r for r in varying),
+                f"the guard that split {frame.frame} is missing from varying: {varying}",
+            )
+            self.assertFalse(
+                [f.render() for f in frame.invariant if "self.act" in f.render()],
+                "a guard that differs between variants was called invariant",
+            )
+
+    def test_code_fingerprint_recurses_into_container_and_nested_consts(self):
+        # _code_fingerprint names a callable by its body so an ACT2FN-style table
+        # can be told apart. Two lambdas can differ ONLY inside a constant the
+        # outer co_code does not distinguish: a tuple, a frozenset, or a nested
+        # code object. Filtering those out whole -- rather than recursing -- gives
+        # both the same digest, _object_identity names them identically, and the
+        # guard that split the two compilations is reported as an invariant of
+        # each.
+        from torch._dynamo.precompile_package import _code_fingerprint
+
+        pairs = {
+            "tuple const": (lambda x: x * (1, 2), lambda x: x * (1, 3)),
+            "frozenset const": (lambda x: x in {1, 2}, lambda x: x in {1, 3}),
+            # Not called: what matters is the nested code object in co_consts.
+            "nested code": (lambda x: (lambda y: y + 1), lambda x: (lambda y: y + 2)),
+        }
+        for label, (left, right) in pairs.items():
+            self.assertEqual(
+                left.__code__.co_code,
+                right.__code__.co_code,
+                f"{label}: the pair must differ only in co_consts",
+            )
+            self.assertNotEqual(
+                _code_fingerprint(left.__code__),
+                _code_fingerprint(right.__code__),
+                f"{label}: two different bodies share a fingerprint",
+            )
+
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_truncated_frame_is_not_also_reported_uncovered(self):
+        # Hitting the recompile limit happens INSIDE code_context, whose exit
+        # saw an attempt that added no guarded code and called the frame
+        # uncovered. But it has working variants: "uncovered" means no guarded
+        # code at all, which is what install() skip_code()s and what save()'s
+        # message describes.
+        session = precompile_capture(
+            PrecompileSelfAct(torch.relu),
+            backend="eager",
+            dynamic=False,
+            recompile_limit=2,
+        )
+        with session as compiled, torch.no_grad():
+            for n in (3, 4, 5, 6, 7, 8):
+                compiled(torch.randn(n, 4))
+        summary = session.summary()
+        self.assertTrue(summary.truncated)
+        self.assertGreater(summary.guarded_codes, 0)
+        self.assertEqual(summary.uncovered_frames, ())
+
+    def test_precompile_entries_are_region_scoped_in_both_directions(self):
+        # Two rails that pull against each other, so neither can be "fixed" by
+        # loosening the other. A precompile entry installed for the DEFAULT
+        # region must not be served to an isolated one -- the identity guards
+        # that would tell two artifacts of one model apart are exactly the ones
+        # precompile drops, so a fallback serves the wrong graph. And the
+        # caching_precompile loader must therefore install into the region its
+        # own context looks up in, or it loads an artifact and serves nothing.
+        from torch._dynamo.precompile_package import _SingleFileStore
+
+        x = torch.randn(3, 4)
+        model = PrecompileSelfAct(torch.relu)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        session.save(self.path(), require_no_risky_drops=False)
+
+        # Rail 1: default-region install is NOT visible from an isolated region.
+        torch._dynamo.reset()
+        cache_entry = _SingleFileStore().load_cache_entry(self.path())
+        package = CompilePackage(model.forward, cache_entry.dynamo)
+        package.install(cache_entry.backends)  # default region
+        try:
+            isolated = torch._dynamo.optimize(
+                "eager", dynamic=False, isolate_recompiles=True
+            )(model)
+            with torch.no_grad(), serving(), self.assertRaises(RecompileError):
+                isolated(x)
+        finally:
+            package.uninstall()
+
+        # Rail 2: installing into the region the context uses does serve.
+        torch._dynamo.reset()
+        cache_entry = _SingleFileStore().load_cache_entry(self.path())
+        package = CompilePackage(model.forward, cache_entry.dynamo)
+        optimize_ctx = torch._dynamo.optimize(
+            "eager", dynamic=False, isolate_recompiles=True
+        )
+        isolated = optimize_ctx(model)
+        package.install(
+            cache_entry.backends,
+            isolate_recompiles_id=optimize_ctx._isolate_recompiles_id,
+        )
+        try:
+            with torch.no_grad(), serving():
+                self.assertEqual(isolated(x), model(x))
+        finally:
+            package.uninstall()
+
+    def test_concurrent_calls_do_not_deadlock_on_the_cache_lock(self):
+        # lookup() holds the ExtraState cache lock across guard evaluation,
+        # which runs Python and so can drop the GIL at any bytecode boundary. A
+        # second thread that blocks on that lock while holding the GIL wedges
+        # the first one forever, so the lock has to release the GIL before it
+        # waits. A short switch interval makes the handoff frequent.
+        #
+        # The wedged thread holds the GIL, so nothing written in Python can
+        # report this: join() never returns, and a watchdog THREAD does not help
+        # either -- Event.wait releases the GIL while blocked but must reacquire
+        # it to run its next bytecode, which is exactly what it cannot get.
+        # faulthandler's timeout runs on a C thread and needs no GIL, so it is
+        # the only thing here that still fires.
+        x = torch.randn(3, 4)
+        model = PrecompileSelfAct(torch.relu)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x)
+        session.save(self.path(), require_no_risky_drops=False)
+
+        torch._dynamo.reset()
+        loaded = precompile_load(model, self.path(), backend="eager", dynamic=False)
+        errors = queue.SimpleQueue()
+
+        def hammer():
+            try:
+                with torch.no_grad():
+                    for _ in range(200):
+                        loaded(x)
+            except BaseException as e:
+                errors.put(e)
+
+        threads = [threading.Thread(target=hammer, daemon=True) for _ in range(4)]
+        prior_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        # file= is required: pytest's --capture=sys replaces sys.stderr with a
+        # CaptureIO that has no fileno, and faulthandler needs a real fd.
+        faulthandler.dump_traceback_later(300, exit=True, file=sys.__stderr__)
+        try:
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+        finally:
+            faulthandler.cancel_dump_traceback_later()
+            sys.setswitchinterval(prior_interval)
+        raised = []
+        while not errors.empty():
+            raised.append(errors.get_nowait())
+        self.assertEqual(raised, [])
+        loaded.unload()
+
+    def test_install_skips_backends_only_a_bypassed_entry_references(self):
+        # Deserializing an inductor artifact is expensive and can fail on a
+        # serving host, so install() must not touch one for an entry it will
+        # skip anyway.
+        class _Exploding:
+            def after_deserialization(self):
+                raise AssertionError("install deserialized an unusable backend")
+
+        model = PrecompileSelfAct(torch.relu)
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        package = session._package
+        backend_ids = {
+            backend_id
+            for entry in package._codes.values()
+            for backend_id in entry.backend_ids
+        }
+        self.assertTrue(backend_ids)
+        for entry in package._codes.values():
+            entry.bypassed = True
+        package.install({backend_id: _Exploding() for backend_id in backend_ids})
+        package.uninstall()
+
+    def test_artifact_predating_cpu_codegen_target_still_loads(self):
+        # None means "written before the field existed", not "no vector ISA".
+        # Treating it as a mismatch would reject every artifact already on disk
+        # over a target they never recorded.
+        current = SystemInfo.current()
+        self.assertIsNotNone(current.cpu_codegen_target)
+        dataclasses.replace(current, cpu_codegen_target=None).check_compatibility(
+            current, "cpu"
+        )
+        drifted = dataclasses.replace(
+            current, cpu_codegen_target=("mips", "DEFAULT", None, "INVALID", None, None)
+        )
+        with self.assertRaisesRegex(RuntimeError, "different CPU codegen target"):
+            drifted.check_compatibility(current, "cpu")
+
+    def test_scan_sys_modules_retries_after_a_later_import(self):
+        # A miss usually means the module is not imported YET. Caching that
+        # permanently drops the source checksum for every lazily imported file
+        # for the rest of the process.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "_precompile_late_import.py")
+            with open(path, "w") as f:
+                f.write("def f(x):\n    return x + 1\n")
+            self.assertIsNone(dynamo_package._scan_sys_modules_for_file(path))
+            sys.path.insert(0, tmp)
+            try:
+                import _precompile_late_import
+
+                self.assertEqual(
+                    dynamo_package._scan_sys_modules_for_file(
+                        _precompile_late_import.__file__
+                    ),
+                    "_precompile_late_import",
+                )
+            finally:
+                sys.path.remove(tmp)
+                sys.modules.pop("_precompile_late_import", None)
+                dynamo_package._MODULE_KEY_BY_FILE.clear()
+
+    def _save_legacy_empty_graph_package(self):
+        session = precompile_capture(PrecompileEmptyGraph(), backend="eager")
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        entry = session._package.cache_entry().codes[0]
+        entry.guarded_codes.clear()
+        entry.backend_ids.clear()
+        session._package.cached_backends.clear()
+        summary = session.save(self.path(), require_complete=False)
+        self.assertEqual(summary.guarded_codes, 0)
+
+    def test_unload_keeps_a_skip_another_package_still_holds(self):
+        # Legacy packages can contain a frame with no guarded codes. Each
+        # loaded callable gets an independent region-local skip.
+        from torch._C._dynamo.eval_frame import get_code_region_exec_strategy
+        from torch._dynamo.types import FrameAction
+
+        self._save_legacy_empty_graph_package()
+
+        torch._dynamo.reset()
+        first = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        second = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        code = PrecompileEmptyGraph.forward.__code__
+
+        first.unload()
+        self.assertEqual(
+            get_code_region_exec_strategy(
+                code, second._isolate_recompiles_id
+            ).cur_action,
+            FrameAction.SKIP,
+        )
+
+        second.unload()
+        self.assertEqual(
+            get_code_region_exec_strategy(
+                code, second._isolate_recompiles_id
+            ).cur_action,
+            FrameAction.DEFAULT,
+        )
+
+    def test_unload_restores_a_skipped_frame(self):
+        # A legacy package's empty frame installs a skip only in its region.
+        from torch._C._dynamo.eval_frame import (
+            get_code_exec_strategy,
+            get_code_region_exec_strategy,
+        )
+        from torch._dynamo.types import FrameAction
+
+        self._save_legacy_empty_graph_package()
+
+        torch._dynamo.reset()
+        loaded = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        code = PrecompileEmptyGraph.forward.__code__
+        self.assertIn(code, loaded._package._region_skipped_codes)
+        self.assertEqual(get_code_exec_strategy(code).cur_action, FrameAction.DEFAULT)
+        self.assertEqual(
+            get_code_region_exec_strategy(
+                code, loaded._isolate_recompiles_id
+            ).cur_action,
+            FrameAction.SKIP,
+        )
+
+        loaded.unload()
+        self.assertEqual(loaded._package._region_skipped_codes, [])
+        self.assertEqual(get_code_exec_strategy(code).cur_action, FrameAction.DEFAULT)
+
+    def test_unload_preserves_a_preexisting_skip_strategy(self):
+        from torch._C._dynamo.eval_frame import get_code_exec_strategy
+        from torch._dynamo.types import FrameAction
+
+        self._save_legacy_empty_graph_package()
+
+        torch._dynamo.reset()
+        code = PrecompileEmptyGraph.forward.__code__
+        torch._dynamo.eval_frame.skip_code(code)
+
+        loaded = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        self.assertIn(code, loaded._package._region_skipped_codes)
+        loaded.unload()
+        self.assertEqual(get_code_exec_strategy(code).cur_action, FrameAction.SKIP)
+
+    def test_unload_preserves_a_skip_installed_after_load(self):
+        from torch._C._dynamo.eval_frame import get_code_exec_strategy
+        from torch._dynamo.types import FrameAction
+
+        self._save_legacy_empty_graph_package()
+
+        torch._dynamo.reset()
+        code = PrecompileEmptyGraph.forward.__code__
+        loaded = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        torch._dynamo.eval_frame.skip_code(code)
+        loaded.unload()
+        self.assertEqual(get_code_exec_strategy(code).cur_action, FrameAction.SKIP)
+
+    def test_unload_preserves_a_new_run_only_strategy(self):
+        from torch._C._dynamo.eval_frame import get_code_exec_strategy
+        from torch._dynamo.types import FrameAction, FrameExecStrategy
+
+        self._save_legacy_empty_graph_package()
+
+        torch._dynamo.reset()
+        code = PrecompileEmptyGraph.forward.__code__
+        loaded = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        strategy = FrameExecStrategy(FrameAction.RUN_ONLY, FrameAction.RUN_ONLY)
+        torch._dynamo.eval_frame.set_code_exec_strategy(code, strategy)
+        loaded.unload()
+        restored = get_code_exec_strategy(code)
+        self.assertEqual(restored.cur_action, FrameAction.RUN_ONLY)
+        self.assertEqual(restored.recursive_action, FrameAction.RUN_ONLY)
+
+    def test_concurrent_compile_does_not_change_region_skip(self):
+        from torch._C._dynamo.eval_frame import (
+            get_code_exec_strategy,
+            get_code_region_exec_strategy,
+        )
+        from torch._dynamo.types import FrameAction
+
+        self._save_legacy_empty_graph_package()
+        torch._dynamo.reset()
+
+        entered = threading.Event()
+        release = threading.Event()
+        errors = []
+
+        def backend(gm, example_inputs):
+            entered.set()
+            if not release.wait(20):
+                raise AssertionError("timed out waiting to release backend")
+            return gm.forward
+
+        model = PrecompileEmptyGraph()
+        compiled = torch.compile(model, backend=backend, dynamic=False)
+
+        def run_compile():
+            try:
+                compiled(torch.randn(3, 4))
+            except BaseException as e:
+                errors.append(e)
+
+        thread = threading.Thread(target=run_compile)
+        thread.start()
+        try:
+            self.assertTrue(entered.wait(20))
+            loaded = precompile_load(model, self.path(), backend="eager")
+            code = PrecompileEmptyGraph.forward.__code__
+            self.assertEqual(
+                get_code_region_exec_strategy(
+                    code, loaded._isolate_recompiles_id
+                ).cur_action,
+                FrameAction.SKIP,
+            )
+        finally:
+            release.set()
+        thread.join(20)
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            get_code_region_exec_strategy(
+                code, loaded._isolate_recompiles_id
+            ).cur_action,
+            FrameAction.SKIP,
+        )
+        strategy = get_code_exec_strategy(code)
+
+        loaded.unload()
+        after_unload = get_code_exec_strategy(code)
+        self.assertEqual(after_unload.cur_action, strategy.cur_action)
+        self.assertEqual(after_unload.recursive_action, strategy.recursive_action)
+
+    def test_stale_skip_owner_does_not_block_a_later_load(self):
+        from torch._C._dynamo.eval_frame import get_code_region_exec_strategy
+        from torch._dynamo.types import FrameAction
+
+        self._save_legacy_empty_graph_package()
+
+        torch._dynamo.reset()
+        code = PrecompileEmptyGraph.forward.__code__
+        loaded = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        package_ref = weakref.ref(loaded._package)
+        del loaded
+        gc.collect()
+        self.assertIsNone(package_ref())
+
+        torch._dynamo.reset()
+        second = precompile_load(PrecompileEmptyGraph(), self.path(), backend="eager")
+        self.assertEqual(
+            get_code_region_exec_strategy(
+                code, second._isolate_recompiles_id
+            ).cur_action,
+            FrameAction.SKIP,
+        )
+        second.unload()
+        self.assertEqual(
+            get_code_region_exec_strategy(
+                code, second._isolate_recompiles_id
+            ).cur_action,
+            FrameAction.DEFAULT,
+        )
+
+    def test_load_rejects_artifact_recorded_on_a_different_torch(self):
+        # Capture on one machine, serve on another: the version check is only
+        # worth anything if precompile_load runs it. Calling
+        # SystemInfo.check_compatibility directly passes either way.
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(4, 8))
+        session.save(self.path())
+
+        entry_path = self.path()
+        with open(entry_path, "rb") as f:
+            entry = pickle.load(f)
+        entry.dynamo.system_info = dataclasses.replace(
+            entry.dynamo.system_info, torch_version="0.0.0"
+        )
+        with open(entry_path, "wb") as f:
+            pickle.dump(entry, f)
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(RuntimeError, "different PyTorch version"):
+            precompile_load(
+                staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+            )
+
+    def test_load_rejects_an_artifact_with_no_code_entries(self):
+        # Every other identity check reads dynamo.codes[0]. An artifact that
+        # carries none has to be named as such here rather than falling through
+        # to the unpack in CompilePackage.initialize, which reports a bare
+        # "not enough values to unpack" with no mention of the path.
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(4, 8))
+        session.save(self.path())
+
+        entry_path = self.path()
+        with open(entry_path, "rb") as f:
+            entry = pickle.load(f)
+        entry.dynamo.codes = []
+        with open(entry_path, "wb") as f:
+            pickle.dump(entry, f)
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(PackageError, "no code entries"):
+            precompile_load(
+                staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+            )
+
+    def test_load_rejects_wrapper_sharing_the_captured_qualname(self):
+        # functools.wraps copies __qualname__, so an instrumented wrapper around
+        # a different callable passes the qualname check while being a different
+        # code object. Installing there serves the captured graphs for the
+        # wrapper's frame.
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(4, 8))
+        session.save(self.path())
+
+        @functools.wraps(staged_with_graph_breaks)
+        def instrumented(x):
+            return staged_with_local_dict_conditional(x, {"op": "sin", "scale": 2})
+
+        self.assertEqual(
+            instrumented.__qualname__, staged_with_graph_breaks.__qualname__
+        )
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(PackageError, "captured from code object"):
+            precompile_load(instrumented, self.path(), backend="eager", dynamic=False)
+
+    def test_wrapped_entry_uses_its_defining_module_globals(self):
+        pkg_dir = self._write_module(
+            "wrapped_entry",
+            "precompile_entry_decorators",
+            """
+import functools
+
+ENABLE = True
+
+def deco(fn):
+    @functools.wraps(fn)
+    def wrapper(x):
+        y = x * 2 if ENABLE else x * 3
+        scalar = x.sum().item()
+        return y + scalar
+    return wrapper
+""",
+        )
+        self._write_module(
+            "wrapped_entry",
+            "precompile_wrapped_entry",
+            """
+from precompile_entry_decorators import deco
+
+@deco
+def staged(x):
+    return x
+""",
+        )
+        self._forget_modules("precompile_entry_decorators", "precompile_wrapped_entry")
+        mod = self._import_module(pkg_dir, "precompile_wrapped_entry")
+        x = torch.arange(4.0)
+        expected = mod.staged(x)
+        session = precompile_capture(mod.staged, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            self.assertEqual(compiled(x), expected)
+        self.assertEqual(session.summary().dropped_guards, ())
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        loaded = precompile_load(
+            mod.staged, self.path(), backend="eager", dynamic=False
+        )
+        with loaded, torch.no_grad(), serving():
+            self.assertEqual(loaded(x), expected)
+
+    def test_save_writes_a_single_file(self):
+        # save() names a FILE, written exactly as given with parent directories
+        # created, and precompile_load takes that same path back. Matches
+        # `invariants`; deliberately unlike DiskDynamoStore, whose path is a
+        # directory because the transparent cache owns its own layout.
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(torch.randn(4, 8))
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "nested", "model.pt")
+            session.save(path)
+            self.assertTrue(os.path.isfile(path))
+            self.assertFalse(os.path.isdir(path))
+            torch._dynamo.reset()
+            with precompile_load(
+                staged_with_graph_breaks, path, backend="eager", dynamic=False
+            ) as loaded:
+                self.assertEqual(loaded(torch.randn(4, 8)).shape, torch.Size([]))
+
+    def test_save_reports_write_failures_as_package_errors(self):
+        # Writing the artifact includes creating its parent, so a parent that
+        # is a file has to arrive as a PackageError naming the path the caller
+        # passed rather than as a bare FileExistsError naming the parent, and a
+        # refused write must leave nothing behind.
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(4, 8))
+        with tempfile.TemporaryDirectory() as tmp:
+            as_dir = os.path.join(tmp, "adir")
+            os.makedirs(as_dir)
+            with self.assertRaisesRegex(PackageError, "single files"):
+                session.save(as_dir)
+            parent = os.path.join(tmp, "plain_file")
+            with open(parent, "w"):
+                pass
+            target = os.path.join(parent, "model.pt")
+            with self.assertRaisesRegex(PackageError, re.escape(target)):
+                session.save(target)
+            self.assertEqual(sorted(os.listdir(tmp)), ["adir", "plain_file"])
+
+    def test_load_rejects_a_directory(self):
+        # An artifact captured before save() became single-file is a directory
+        # holding "entry", so this is what a migration hits. Nothing exercises
+        # the branch today.
+        stale = self.path("stale_layout.pt")
+        os.makedirs(stale, exist_ok=True)
+        with self.assertRaisesRegex(PackageError, "is a directory"):
+            precompile_load(
+                staged_with_graph_breaks, stale, backend="eager", dynamic=False
+            )
+
+    def test_resume_names_from_separate_captures_do_not_collide(self):
+        # Two artifacts captured in different processes carry the same
+        # __resume_at_<offset>_<n> name, and a serving process installs both
+        # into one module dict. Without a rename the loser of that write
+        # silently runs the winner's continuation -- no error, right shape,
+        # wrong numbers.
+        fns = (staged_break_then_add_one, staged_break_then_add_thousand)
+        x = torch.randn(3, 4)
+        expected = [fn(x) for fn in fns]
+        self.assertNotEqual(expected[0], expected[1])
+
+        paths = [self.path(fn.__name__ + ".pt") for fn in fns]
+        for fn, path in zip(fns, paths):
+            torch._dynamo.reset()
+            session = precompile_capture(fn, backend="eager", dynamic=False)
+            with session as compiled:
+                compiled(x)
+            session.save(path)
+
+        shared_name = _resume_names_in(paths[0])
+        self.assertEqual(len(shared_name), 1)
+        other_name = _resume_names_in(paths[1])
+        self.assertNotEqual(shared_name, other_name)
+        _rename_resume_function(paths[1], other_name[0], shared_name[0])
+        self.assertEqual(_resume_names_in(paths[1]), shared_name)
+
+        torch._dynamo.reset()
+        with contextlib.ExitStack() as stack:
+            loaded = [
+                stack.enter_context(
+                    precompile_load(fn, path, backend="eager", dynamic=False)
+                )
+                for fn, path in zip(fns, paths)
+            ]
+            # Both continuations have to be reachable at once. Pre-fix the
+            # second load overwrote the first's binding and both callables
+            # returned the second artifact's answer.
+            stack.enter_context(serving())
+            for call, want in zip(loaded, expected):
+                self.assertEqual(call(x), want)
+
+    def test_two_loads_of_one_artifact_both_serve(self):
+        # A serving process holds one loaded package per model instance, so the
+        # same artifact is routinely loaded twice. Both loads install a resume
+        # function under a name derived from the resume code, which is
+        # identical by construction: the second write wins the name, and the
+        # first callable's entry frame then calls a continuation whose
+        # precompiled entries live in the other load's region.
+        x = torch.randn(3, 4)
+        expected = staged_break_then_add_one(x)
+        session = precompile_capture(
+            staged_break_then_add_one, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(x)
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        scope = staged_break_then_add_one.__globals__
+        before = {name for name in scope if name.startswith("__resume_at")}
+        with contextlib.ExitStack() as stack:
+            loaded = [
+                stack.enter_context(
+                    precompile_load(
+                        staged_break_then_add_one,
+                        self.path(),
+                        backend="eager",
+                        dynamic=False,
+                    )
+                )
+                for _ in range(2)
+            ]
+            stack.enter_context(serving())
+            for call in loaded:
+                self.assertEqual(call(x), expected)
+            # Backstop on the mechanism: one installed name per load, not one
+            # name both loads fought over.
+            installed = {n for n in scope if n.startswith("__resume_at")} - before
+            self.assertEqual(len(installed), 2)
+
+    def test_resume_names_from_identical_captures_do_not_collide(self):
+        # Content-addressing the resume code tells the separate-captures pair
+        # above apart, because they differ after the break. It cannot tell two
+        # instances of ONE model class apart: the same script captured in two
+        # processes mints the same __resume_at_<offset>_<n> AND byte-identical
+        # resume code, so both artifacts hash to a single installed name.
+        models = [PrecompileSelfAct(act) for act in (torch.relu, torch.sigmoid)]
+        x = torch.randn(3, 4)
+        expected = [model(x) for model in models]
+        self.assertNotEqual(expected[0], expected[1])
+
+        paths = [self.path(f"act_{i}.pt") for i in range(len(models))]
+        for model, path in zip(models, paths):
+            torch._dynamo.reset()
+            session = precompile_capture(model, backend="eager", dynamic=False)
+            with session as compiled:
+                compiled(x)
+            # self.act is a dispatch slot; this test is about the resume name.
+            session.save(path, require_no_risky_drops=False)
+
+        names = [_resume_names_in(path) for path in paths]
+        self.assertEqual(len(names[0]), 1)
+        _rename_resume_function(paths[1], names[1][0], names[0][0])
+
+        torch._dynamo.reset()
+        with contextlib.ExitStack() as stack:
+            loaded = [
+                stack.enter_context(
+                    precompile_load(model, path, backend="eager", dynamic=False)
+                )
+                for model, path in zip(models, paths)
+            ]
+            stack.enter_context(serving())
+            for call, want in zip(loaded, expected):
+                self.assertEqual(call(x), want)
+
+    def test_unload_keeps_globals_a_bystander_compile_needs(self):
+        # A serving process shares a module namespace with plain torch.compile.
+        # Import aliases are minted from the module name, so both writers pick
+        # the same one; popping it on unload takes it out from under whatever
+        # else in the module resolved it.
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        scope = staged_with_graph_breaks.__globals__
+        # Other tests in this file compiled functions from this module and left
+        # their aliases here. Drop them for the state a serving process starts
+        # in, where the load is what installs them.
+        for name in [n for n in scope if n.startswith("__import_")]:
+            del scope[name]
+
+        x = torch.randn(3, 4)
+        with torch.no_grad():
+            expected = staged_with_global_function_ref(x)
+            loaded = precompile_load(
+                staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+            )
+            bystander = torch.compile(
+                staged_with_global_function_ref, backend="eager", dynamic=False
+            )
+            self.assertEqual(bystander(x), expected)
+            loaded.unload()
+            self.assertEqual(bystander(x), expected)
+
+    def test_a_second_load_keeps_the_builtins_key_the_first_installed(self):
+        # Two loads of one artifact -- the replica shape -- record the same
+        # builtins-dict name, and only the first finds it unbound. Unless the
+        # second joins the owner set, the first unload deletes a global the
+        # second's bytecode reads and every later call is a NameError.
+        mod = self._import_module(
+            self._write_module(
+                "builtin_break", "builtin_break", _BUILTIN_ACROSS_BREAK_SRC
+            ),
+            "builtin_break",
+        )
+        x, cfg = torch.ones(3, 4), {"a": 1, "b": 2}
+        session = precompile_capture(mod.Model(2.0), backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x, cfg)
+        session.save(self.path(), require_no_risky_drops=False)
+
+        torch._dynamo.reset()
+        # A serving process that never compiled this module holds no builtins
+        # key, so the load is what creates it. Capturing in this process bound
+        # one here, so drop it to get to that state.
+        scope = mod.__dict__
+        for name in [n for n in scope if n.startswith("__builtins_dict__")]:
+            del scope[name]
+
+        model_a, model_b = mod.Model(2.0), mod.Model(2.0)
+        with torch.no_grad():
+            expected = model_b(x, cfg)
+        first = precompile_load(model_a, self.path(), backend="eager", dynamic=False)
+        self.addCleanup(first.unload)
+        second = precompile_load(model_b, self.path(), backend="eager", dynamic=False)
+        self.addCleanup(second.unload)
+        installed = sorted(n for n in scope if n.startswith("__builtins_dict__"))
+        self.assertTrue(installed)
+
+        first.unload()
+        with torch.no_grad(), serving():
+            self.assertEqual(second(x, cfg), expected)
+        self.assertEqual(
+            sorted(n for n in scope if n.startswith("__builtins_dict__")), installed
+        )
+
+    def test_unload_keeps_a_builtins_key_a_plain_compile_minted(self):
+        # The counter naming the builtins dict is per process, so a serving
+        # process that compiles before it loads can mint exactly the name the
+        # artifact recorded. Nothing displaced that binding, so the load must
+        # leave it alone: claiming it makes this unload delete the key the
+        # plain compile's own bytecode still reads.
+        import torch._dynamo.bytecode_transformation as bytecode_transformation
+
+        mod = self._import_module(
+            self._write_module(
+                "builtin_break_local",
+                "builtin_break_local",
+                _BUILTIN_ACROSS_BREAK_SRC,
+            ),
+            "builtin_break_local",
+        )
+        x, cfg = torch.ones(3, 4), {"a": 1, "b": 2}
+        scope = mod.__dict__
+        with mock.patch.object(
+            bytecode_transformation, "_unique_id_counter", itertools.count()
+        ):
+            session = precompile_capture(mod.Model(2.0), backend="eager", dynamic=False)
+            with session as compiled, torch.no_grad():
+                compiled(x, cfg)
+            session.save(self.path(), require_no_risky_drops=False)
+
+            torch._dynamo.reset()
+            prefixes = ("__builtins_dict__", "__resume_at")
+            for name in [n for n in scope if n.startswith(prefixes)]:
+                CleanupHook.disown(scope, name)
+                del scope[name]
+
+            # Same fresh counter the capture ran on, so the plain compile mints
+            # the names the artifact recorded.
+            bytecode_transformation._unique_id_counter = itertools.count()
+            bystander = torch.compile(mod.Model(2.0), backend="eager", dynamic=False)
+            with torch.no_grad():
+                expected = bystander(x, cfg)
+            minted = sorted(n for n in scope if n.startswith("__builtins_dict__"))
+            self.assertTrue(minted)
+
+            loaded = precompile_load(
+                mod.Model(2.0), self.path(), backend="eager", dynamic=False
+            )
+            self.assertEqual(
+                sorted(n for n in scope if n.startswith("__builtins_dict__")),
+                minted,
+                "the load minted a name of its own, so nothing collided",
+            )
+            loaded.unload()
+            with torch.no_grad(), torch.compiler.set_stance("fail_on_recompile"):
+                self.assertEqual(bystander(x, cfg), expected)
+            self.assertEqual(
+                sorted(n for n in scope if n.startswith("__builtins_dict__")), minted
+            )
+
+    def test_unload_removes_the_builtins_key_install_added(self):
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        scope = staged_with_graph_breaks.__globals__
+        # A serving process that never compiled this module holds no
+        # builtins-dict key, so install() is the one that creates it. Capturing
+        # in this same process leaves one behind, so drop it to get there.
+        for name in [n for n in scope if n.startswith("__builtins_dict__")]:
+            del scope[name]
+        before = set(scope)
+
+        loaded = precompile_load(
+            staged_with_graph_breaks, self.path(), backend="eager", dynamic=False
+        )
+        with torch.no_grad(), serving():
+            loaded(torch.randn(3, 4))
+        self.assertTrue(any(n.startswith("__builtins_dict__") for n in scope))
+
+        loaded.unload()
+        # Import aliases are the one thing install() is expected to leave:
+        # plain torch.compile installs them permanently too.
+        leftover = sorted(
+            name for name in set(scope) - before if not name.startswith("__import_")
+        )
+        self.assertEqual(leftover, [])
+
+    def test_unload_removes_globals_an_uncovered_call_installed(self):
+        # A call the artifact does not cover falls back to an ordinary Dynamo
+        # compile inside the loaded region, and that compile installs globals of
+        # its own: a compiled backend, a resume function, a builtins dict.
+        # OutputGraph writes them, so the package never sees them, and the
+        # CleanupHook anchoring them to the transformed code does not fire when
+        # the region goes away -- unclaimed, they stay in the served module for
+        # the life of the process, four more on every load.
+        model = PrecompileBreakOnlyWhenFalse()
+        x = torch.randn(3, 4)
+        with torch.no_grad():
+            expected = [model(x, flag) for flag in (True, False)]
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(x, True)
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        scope = PrecompileBreakOnlyWhenFalse.forward.__globals__
+        before = set(scope)
+        for _ in range(2):
+            loaded = precompile_load(model, self.path(), backend="eager", dynamic=False)
+            with torch.no_grad():
+                self.assertEqual(loaded(x, True), expected[0])
+                covered = set(scope)
+                self.assertEqual(loaded(x, False), expected[1])
+            # The uncovered branch breaks at a line the artifact never captured,
+            # so the fallback compile has to mint globals of its own.
+            self.assertTrue(set(scope) - covered)
+            loaded.unload()
+        # Import aliases are the one thing a load is expected to leave, exactly
+        # as in test_unload_removes_the_builtins_key_install_added above.
+        leftover = sorted(
+            name for name in set(scope) - before if not name.startswith("__import_")
+        )
+        self.assertEqual(leftover, [])
+
+    def test_loaded_builtins_names_do_not_collide_with_local_compiles(self):
+        import torch._dynamo.bytecode_transformation as bytecode_transformation
+
+        scope = staged_with_graph_breaks.__globals__
+        generated = []
+        for name in [n for n in scope if n.startswith("__builtins_dict__")]:
+            CleanupHook.disown(scope, name)
+            del scope[name]
+        with mock.patch.object(
+            bytecode_transformation, "_unique_id_counter", itertools.count()
+        ):
+            session = precompile_capture(
+                staged_with_graph_breaks, backend="eager", dynamic=False
+            )
+            with session as compiled, torch.no_grad():
+                compiled(torch.randn(3, 4))
+            session.save(self.path())
+
+            torch._dynamo.reset()
+            for name in [n for n in scope if n.startswith("__builtins_dict__")]:
+                del scope[name]
+            bytecode_transformation._unique_id_counter = itertools.count()
+            loaded = precompile_load(
+                staged_with_graph_breaks,
+                self.path(),
+                backend="eager",
+                dynamic=False,
+            )
+            try:
+                for i in range(30):
+                    name = f"_precompile_bystander_{i}"
+                    generated.append(name)
+                    exec(
+                        compile(
+                            f"def {name}(x):\n    return x + {i}\n",
+                            __file__,
+                            "exec",
+                        ),
+                        scope,
+                    )
+                    x = torch.ones(2)
+                    compiled = torch.compile(
+                        scope[name], backend="eager", dynamic=False
+                    )
+                    self.assertEqual(compiled(x), x + i)
+            finally:
+                loaded.unload()
+                for name in generated:
+                    scope.pop(name, None)
+                torch._dynamo.reset()
+
+    @parametrize("error_type", (RuntimeError, KeyboardInterrupt))
+    def test_a_failed_install_leaves_nothing_installed(self, error_type):
+        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+
+        session = precompile_capture(
+            staged_with_graph_breaks, backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        cache_entry = _SingleFileStore().load_cache_entry(self.path())
+        backends = cache_entry.backends
+
+        class _Boom:
+            def after_deserialization(self):
+                raise error_type("artifact will not deserialize on this host")
+
+        # The last frame's backend is the one that fails, so the earlier frames
+        # are already installed when install() gives up. A backend rejected by
+        # the serving host is the realistic way into this.
+        backends[cache_entry.dynamo.codes[-1].backend_ids[-1]] = _Boom()
+
+        scope = staged_with_graph_breaks.__globals__
+        before = set(scope)
+        package = CompilePackage(staged_with_graph_breaks, cache_entry.dynamo)
+        torch._dynamo.optimize("eager", package=package, dynamic=False)(
+            staged_with_graph_breaks
+        )
+        with self.assertRaisesRegex(error_type, "will not deserialize"):
+            package.install(backends)
+
+        # install() raising leaves the caller no handle to unload with, so a
+        # partial install would be permanent: some frames served, some not.
+        leftover = sorted(
+            name for name in set(scope) - before if not name.startswith("__import_")
+        )
+        self.assertEqual(leftover, [])
+        self.assertEqual(
+            _debug_get_precompile_entries(staged_with_graph_breaks.__code__), []
+        )
+
+    def test_backend_deserialization_does_not_hold_install_lock(self):
+        model = PrecompileEmptyGraph()
+        session = precompile_capture(model, backend="eager", dynamic=False)
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(4))
+        session.save(self.path())
+
+        torch._dynamo.reset()
+        cache_entry = _SingleFileStore().load_cache_entry(self.path())
+        package = CompilePackage(model.forward, cache_entry.dynamo)
+        backend_id = next(iter(cache_entry.backends))
+        artifact = cache_entry.backends[backend_id]
+
+        class _UnloadsFromWorker:
+            def after_deserialization(self):
+                finished = threading.Event()
+
+                def unload():
+                    package.uninstall()
+                    finished.set()
+
+                worker = threading.Thread(target=unload)
+                worker.start()
+                if not finished.wait(10):
+                    raise AssertionError(
+                        "after_deserialization ran while holding the install lock"
+                    )
+                worker.join()
+                return artifact.after_deserialization()
+
+        cache_entry.backends[backend_id] = _UnloadsFromWorker()
+        package.install(cache_entry.backends)
+        package.uninstall()
+
+    def test_unload_leaves_a_global_a_later_package_rebound(self):
+        # A serving process loads one artifact per model instance, so two
+        # packages can install the same names -- the backend uuid and the
+        # resume-function name both come from the artifact, not the loader.
+        # Popping them on the first unload leaves the second package's entry
+        # frame reaching for a continuation that is gone.
+        torch._dynamo.reset()
+        session = precompile_capture(
+            PrecompileSelfAct(torch.relu), backend="eager", dynamic=False
+        )
+        with session as compiled, torch.no_grad():
+            compiled(torch.randn(3, 4))
+        # self.act is a dispatch slot; this test is about unloading, not it.
+        session.save(self.path(), require_no_risky_drops=False)
+
+        torch._dynamo.reset()
+        scope = PrecompileSelfAct.forward.__globals__
+        before = set(scope)
+        first = precompile_load(
+            PrecompileSelfAct(torch.relu), self.path(), backend="eager", dynamic=False
+        )
+        # Ask the package what it installed rather than diffing the namespace.
+        # A diff is a GC-timing observation: the capture-time binding of the
+        # backend global is only absent from the "before" snapshot once its
+        # code object is reclaimed, which a free-threaded build does not do
+        # promptly -- so on 3.14t the diff dropped the one name that IS
+        # rebound and the assertion below failed with an empty set.
+        installed = {
+            g.name: g.value
+            for entries in first._package._installed_globals.values()
+            for g in entries
+        }
+        second = precompile_load(
+            PrecompileSelfAct(torch.relu), self.path(), backend="eager", dynamic=False
+        )
+        rebound = {
+            name: scope[name]
+            for name, value in installed.items()
+            if scope.get(name) is not value
+        }
+        # Two separate preconditions, asserted separately: an empty `rebound` can
+        # mean the first load installed nothing OR that the second load produced
+        # objects identical to the first, and those are different bugs. The
+        # py3.14t shard reports the second one, so name them.
+        self.assertTrue(installed, "the first load installed no globals")
+        self.assertTrue(rebound, f"the second load rebound none of {sorted(installed)}")
+
+        first.unload()
+        for name, value in rebound.items():
+            self.assertIs(scope.get(name), value)
+        second.unload()
+        # And unloading in load order still has to leave the namespace clean.
+        # The values `first` installed were orphaned the moment `second` rebound
+        # them, so putting them back here would leave a compiled backend bound
+        # in the module for the life of the process, one set per load.
+        leftover = sorted(
+            name
+            for name in set(scope) - before
+            if not name.startswith("__import_") and name in installed
+        )
+        self.assertEqual(leftover, [])
+
+    def _bare_package(self):
+        """A package that installs no codes: these exercise the name stack only."""
+
+        def fn(x):
+            return x + 1
+
+        return CompilePackage(fn)
+
+    def test_unload_keeps_a_name_a_bystander_rebound(self):
+        # The binding stack is bookkeeping, not ownership of the namespace:
+        # plain torch.compile, a CleanupHook, or user code can rebind a name a
+        # package installed. Rebinding it to a surviving package's value on the
+        # next unload hands them a compiled value they never asked for -- and
+        # once ours is what is bound, the last unload deletes the name outright.
+        module = types.ModuleType("test_precompile_bystander")
+        first = self._bare_package()
+        second = self._bare_package()
+        first._install_global(module, "g", "first")
+        second._install_global(module, "g", "second")
+
+        module.__dict__["g"] = "bystander"
+        second.uninstall()
+        self.assertEqual(module.__dict__.get("g"), "bystander")
+        first.uninstall()
+        self.assertEqual(module.__dict__.get("g"), "bystander")
+
+    def test_unload_restores_a_name_something_deleted(self):
+        # The "or gone" arm: a CleanupHook or torch._dynamo.reset() can delete a
+        # name out from under a still-serving earlier package, and the later
+        # package's unload is where it gets put back.
+        module = types.ModuleType("test_precompile_deleted")
+        first = self._bare_package()
+        second = self._bare_package()
+        first._install_global(module, "g", "first")
+        second._install_global(module, "g", "second")
+
+        del module.__dict__["g"]
+        second.uninstall()
+        self.assertEqual(module.__dict__.get("g"), "first")
+        first.uninstall()
+        self.assertNotIn("g", module.__dict__)
+
+    def test_unload_deregisters_the_frame_it_owns(self):
+        # A serving process can stack one value twice: two loads of the same
+        # artifact write the same value, and a load of a different one lands
+        # between them. Deregistering by value alone finds the earlier frame,
+        # leaves the unloading package an owner of its own frame, and the name
+        # stays bound to an unloaded package's value for good.
+        module = types.ModuleType("test_precompile_phantom")
+        first = self._bare_package()
+        second = self._bare_package()
+        third = self._bare_package()
+        first._install_global(module, "g", "shared")
+        second._install_global(module, "g", "other")
+        third._install_global(module, "g", "shared")
+
+        third.uninstall()
+        # `second` is the top surviving owner, so the name is its value again.
+        self.assertEqual(module.__dict__.get("g"), "other")
+        second.uninstall()
+        first.uninstall()
+        self.assertNotIn("g", module.__dict__)
+        self.assertEqual(dynamo_package._GLOBAL_BINDINGS.get(module, {}), {})
 
 
 if __name__ == "__main__":

--- a/test/test_precompile.py
+++ b/test/test_precompile.py
@@ -1,5 +1,9 @@
 # Owner(s): ["oncall: pt2"]
 import copy
+import enum
+import functools
+import gc
+import inspect
 import io
 import os
 import pickle
@@ -7,11 +11,18 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import threading
+import types
+import typing
 import unittest
+import weakref
+from unittest import mock
 
 import torch
 import torch.utils._pytree as _pytree
 from torch._dynamo.decorators import mark_dynamic, mark_unbacked
+from torch._dynamo.package import DynamoCache
+from torch._dynamo.precompile_context import PrecompileContext
 from torch._precompile import PrecompileError
 from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import TEST_CUDA
@@ -28,6 +39,419 @@ from torch.testing._internal.common_utils import (
 # A module-level (global) model + a function referencing it, to exercise the
 # constant-tensor guard against a baked global.
 _GLOBAL_TENSOR = torch.randn(3)
+
+# Globals holding a tensor NESTED inside a container or an nn.Module, plus a plain scalar
+# global, to exercise the dynamo tracer's baked-constant guard (which must look through
+# containers/modules) and its uncovered-external-ref handling (a plain global folded into
+# the output must be baked, not left dangling).
+_GLOBAL_TENSOR_LIST = [torch.randn(3)]
+_GLOBAL_TENSOR_DICT = {"w": torch.randn(3)}
+_GLOBAL_SUBMODULE = torch.nn.Linear(4, 3).eval()
+_GLOBAL_SCALE = 10
+
+
+class _PrecompileTwoBreakModule(torch.nn.Module):
+    """Two breaks, so a capture yields three frames and the varying dim reaches
+    every one of them."""
+
+    def forward(self, x):
+        y = x * 2
+        torch._dynamo.graph_break()
+        z = y + 1
+        torch._dynamo.graph_break()
+        return z.sum()
+
+
+class _PrecompileLateVaryingModule(torch.nn.Module):
+    """``x`` never varies; ``z`` does, and is only read AFTER the break, so only
+    the continuation should be promoted to dynamic."""
+
+    def forward(self, x, z):
+        y = x * 2
+        torch._dynamo.graph_break()
+        return y.sum() + z.sum()
+
+
+class _PrecompileBreakingModule(torch.nn.Module):
+    """One graph break, so a capture yields an entry frame and a continuation."""
+
+    def __init__(self):
+        super().__init__()
+        self.l = torch.nn.Linear(8, 4)
+
+    def forward(self, x):
+        y = self.l(x)
+        torch._dynamo.graph_break()
+        return y.sum() + 1
+
+
+def _precompile_unreachable_helper(y):
+    z = y * 3
+    torch._dynamo.graph_break()
+    return z.sum()
+
+
+def _precompile_unreachable_helper_caller(x):
+    return _precompile_unreachable_helper(x * 2)
+
+
+def _precompile_closure_entry_factory():
+    scale = 3.0
+
+    def entry(x):
+        return _precompile_unreachable_helper_caller(x) * scale
+
+    return entry
+
+
+def _precompile_capture(fn, **kwargs):
+    """What the removed public ``precompile.capture`` did, for tests that need
+    to drive a capture directly rather than through ``precompile()``."""
+    from torch._precompile import _capture_session, PrecompileSession
+
+    return PrecompileSession(_capture_session(fn, **kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures for the dynamo-tracer break/recompile matrix. Module scope, because
+# the capture serializes real Dynamo guards and cannot name a local class.
+# ---------------------------------------------------------------------------
+
+
+@torch._dynamo.disable
+def _brk_disabled_fn(t):
+    """A disabled callee: calling it breaks the graph (gb0098)."""
+    return t * 1.0
+
+
+class _BrkEagerHelper:
+    @torch.compiler.disable
+    def helper(self, t):
+        """A disabled METHOD: reported differently from a free function."""
+        return t + 0.0
+
+
+_BRK_HELPER = _BrkEagerHelper()
+
+
+class _BrkDisabledCallee(torch.nn.Module):
+    """Break from calling a torch._dynamo.disable'd function."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l = torch.nn.Linear(4, 4)
+
+    def forward(self, x):
+        h = self.l(x)
+        h = _brk_disabled_fn(h)
+        return self.l(h).sum()
+
+
+class _BrkDisabledMethod(torch.nn.Module):
+    """Break from a torch.compiler.disable'd bound method."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l = torch.nn.Linear(4, 4)
+
+    def forward(self, x):
+        return _BRK_HELPER.helper(self.l(x)).sum()
+
+
+class _BrkExplicit(torch.nn.Module):
+    """Two explicit graph breaks, so there are two continuations in one frame."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l = torch.nn.Linear(4, 4)
+
+    def forward(self, x):
+        h = self.l(x)
+        torch._dynamo.graph_break()
+        h = h * 2
+        torch._dynamo.graph_break()
+        return h.sum()
+
+
+class _BrkDataDependent(torch.nn.Module):
+    """A break from .item(), the classic data-dependent one."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l = torch.nn.Linear(4, 4)
+
+    def forward(self, x):
+        h = self.l(x)
+        scale = h.abs().max().item()
+        return (h * scale).sum()
+
+
+class _BrkNested(torch.nn.Module):
+    """The break lives in a CHILD module, so the artifact must install."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inner = _BrkDisabledCallee()
+
+    def forward(self, x):
+        return self.inner(x) * 2
+
+
+class _BrkInLoop(torch.nn.Module):
+    """A break inside a loop -- Dynamo may skip the whole frame to eager."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l = torch.nn.Linear(4, 4)
+
+    def forward(self, x):
+        acc = x
+        for _ in range(3):
+            acc = self.l(acc)
+            acc = _brk_disabled_fn(acc)
+        return acc.sum()
+
+
+class _BrkBranchy(torch.nn.Module):
+    """Recompiles on a bool flag AND breaks, so variants x continuations."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l = torch.nn.Linear(4, 4)
+
+    def forward(self, x, flag):
+        h = self.l(x)
+        h = _brk_disabled_fn(h)
+        return (h * 3).sum() if flag else (h + 1).sum()
+
+
+_BREAKING_MODELS = {
+    "disabled_fn": _BrkDisabledCallee,
+    "disabled_method": _BrkDisabledMethod,
+    "explicit_breaks": _BrkExplicit,
+    "data_dependent": _BrkDataDependent,
+    "nested_child": _BrkNested,
+    "break_in_loop": _BrkInLoop,
+}
+
+
+def _maybe_scoped(loaded):
+    """Installed artifacts scope their install; standalone ones have nothing to."""
+    import contextlib
+
+    return loaded if hasattr(loaded, "__enter__") else contextlib.nullcontext()
+
+
+def _precompile_scale_sum(x):
+    return torch.relu(x * 2.0).sum()
+
+
+def _brk_call(model, x):
+    return model(x)
+
+
+def _brk_call_flag(model, x, flag):
+    return model(x, flag)
+
+
+class _PrecompilePlusOneMode(torch.overrides.TorchFunctionMode):
+    """Adds one to a scalar addend, so a doubly-applied mode is visible."""
+
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs or {}
+        if func is torch.add and not isinstance(args[1], torch.Tensor):
+            return func(args[0], args[1] + 1, **kwargs)
+        return func(*args, **kwargs)
+
+
+def _precompile_add_one(xx):
+    return torch.add(xx, 1.0)
+
+
+class _PrecompileTiedWeights(torch.nn.Module):
+    """Two Linears sharing one weight tensor, for the tied-weight round trip."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = torch.nn.Linear(4, 4, bias=False)
+        self.b = torch.nn.Linear(4, 4, bias=False)
+        self.b.weight = self.a.weight
+
+    def forward(self, xx):
+        return self.b(self.a(xx))
+
+
+class _PrecompileFoldsAGlobal(torch.nn.Module):
+    """fn IS the module, and its forward folds in a module-level constant."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = torch.nn.Linear(4, 3)
+
+    def forward(self, xx):
+        return self.lin(xx), _GLOBAL_SCALE
+
+
+class _PrecompileTrainMod(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = torch.nn.Linear(8, 8)
+        self.b = torch.nn.Linear(8, 8)
+
+    def forward(self, x):
+        return torch.relu(self.b(torch.relu(self.a(x))))
+
+
+def _precompile_scaled(x, k):
+    return x * k
+
+
+def _precompile_branchy(x, flag):
+    if flag:
+        return (x * 2).sum()
+    return (x + 1).sum()
+
+
+def _precompile_call_model(model, x):
+    return model(x)
+
+
+def _precompile_multi_graph(x):
+    x = x * 2
+    torch._dynamo.graph_break()
+    x = x + 3
+    torch._dynamo.graph_break()
+    return x.sum()
+
+
+def _precompile_multi_graph_callable(x, op):
+    x = x + 1
+    torch._dynamo.graph_break()
+    return op(x)
+
+
+def _precompile_empty_resume(x, flag):
+    y = x + 1
+    torch._dynamo.graph_break()
+    if flag:
+        return y
+    return y.cos() * 100
+
+
+def _precompile_single_graph(x):
+    return x.sin()
+
+
+def _precompile_identity(x):
+    return x
+
+
+def _precompile_module_arg(module, x):
+    return module(x)
+
+
+def _precompile_raises_on_flag(x, fail):
+    if fail:
+        raise KeyError("automatic example failed")
+    return x + 1
+
+
+# A tensor held as a plain attribute of an arbitrary (non-pytree / non-Module) global
+# object. The dynamo tracer's baked-constant guard must look THROUGH such an object's
+# __dict__: a tensor reached via _GLOBAL_HOLDER.weight is embedded by value into the
+# artifact, so it must be rejected (invariant 1), matching the make_fx tracer's get_attr
+# scan which bakes-and-rejects the same access.
+class _TensorHolder:
+    def __init__(self, t):
+        self.weight = t
+
+
+_GLOBAL_HOLDER = _TensorHolder(torch.randn(3))
+
+
+# A tensor held in a __slots__ slot (no __dict__), and one held as an UNREGISTERED plain
+# attribute on an nn.Module (not a param/buffer). Both are baked by value when the owning
+# object is a captured global, so the dynamo tracer's invariant-1 scan must reach them --
+# through __slots__ and through the module's own __dict__ -- matching what make_fx rejects.
+class _SlotHolder:
+    __slots__ = ("weight",)
+
+    def __init__(self, t):
+        self.weight = t
+
+
+class _UnregisteredAttrModule(torch.nn.Module):
+    def __init__(self, t):
+        super().__init__()
+        self.foo = t
+
+
+_GLOBAL_SLOT_HOLDER = _SlotHolder(torch.randn(3))
+_GLOBAL_UNREGISTERED_MODULE = _UnregisteredAttrModule(torch.randn(3))
+
+
+_GRAD_RAIL_MODULE = types.ModuleType("_precompile_grad_rail_mod")
+_GRAD_RAIL_MODULE.__file__ = "_precompile_grad_rail_mod.py"
+exec(
+    compile(
+        "import torch\nmodel = torch.nn.Linear(4, 3)\n",
+        _GRAD_RAIL_MODULE.__file__,
+        "exec",
+    ),
+    _GRAD_RAIL_MODULE.__dict__,
+)
+sys.modules["_precompile_grad_rail_mod"] = _GRAD_RAIL_MODULE
+
+
+def _grad_rail_module_global_step(xx, tt):
+    torch.nn.functional.mse_loss(_GRAD_RAIL_MODULE.model(xx), tt).backward()
+
+
+class _StarvedInner:
+    def __init__(self, model):
+        self.model = model
+
+
+class _Phase(enum.Enum):
+    GEN = 1
+
+
+# A functools.partial carrying a tensor: pickle bakes that tensor BY VALUE via the partial's
+# __reduce__, even though it lives outside __dict__/__slots__, so the invariant-1 scan (which
+# keys off what pickle serializes by value) must reject it. Contrast _global_helper_with_attr:
+# a module-level function is pickled BY REFERENCE, so a tensor merely attached to it is NOT
+# baked and must NOT be (falsely) rejected.
+_GLOBAL_PARTIAL = functools.partial(torch.mul, torch.randn(3))
+
+
+def _global_helper_with_attr():
+    return None
+
+
+_global_helper_with_attr.cache = torch.randn(3)
+
+
+# A bound method carries its __self__ (and any tensor __self__ holds) into the pickle BY
+# VALUE, so a bound method captured by fn (e.g. as a default callback) bakes that tensor and
+# must be rejected (invariant 1) -- the scan replays pickle's traversal, which reaches the
+# tensor through __self__.
+class _MethodHolder:
+    def __init__(self, t):
+        self.t = t
+
+    def add(self, z):
+        return z + self.t
+
+
+_GLOBAL_METHOD_HOLDER = _MethodHolder(torch.randn(3))
+
+
+# A global container holding a tensor FOLLOWED by an unpicklable object (a module-level
+# lambda pickle cannot serialize). _baked_tensors pickles the container, records the tensor
+# via its persistent_id hook mid-traversal, then swallows the lambda's PicklingError and
+# returns the tensor found BEFORE the failure -- so invariant 1's actionable "hard-coded"
+# error fires at capture rather than the generic "not picklable" error at metadata build.
+_GLOBAL_TENSOR_THEN_UNPICKLABLE = [torch.randn(3), lambda z: z]
 
 
 # A custom pytree node whose context (a set) is not JSON-dumpable and which has no
@@ -88,7 +512,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU()).eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, x: model(x), m, x, decompositions=decomps
+            lambda model, x: model(x), example_inputs=[(m, x)], decompositions=decomps
         )
         self.assertTrue(called)  # the table was used during capture
 
@@ -98,7 +522,9 @@ class TestPrecompile(TestCase):
     def test_constant_tensor_is_rejected(self):
         captured = torch.randn(3)
         with self.assertRaisesRegex(PrecompileError, "hard-coded"):
-            torch.compiler.precompile(lambda x: x + captured, torch.randn(3))
+            torch.compiler.precompile(
+                lambda x: x + captured, example_inputs=[(torch.randn(3),)]
+            )
 
     def test_global_tensor_rejected_unlike_make_fx(self):
         # Vanilla make_fx silently bakes a referenced global tensor into the
@@ -118,7 +544,7 @@ class TestPrecompile(TestCase):
         self.assertTrue(baked, "expected vanilla make_fx to bake a tensor constant")
 
         with self.assertRaisesRegex(PrecompileError, "hard-coded"):
-            torch.compiler.precompile(f, torch.randn(3))
+            torch.compiler.precompile(f, example_inputs=[(torch.randn(3),)])
 
     def test_unregistered_module_tensor_attr_is_rejected(self):
         # A plain tensor attribute (not a registered parameter/buffer) is not
@@ -134,7 +560,9 @@ class TestPrecompile(TestCase):
 
         m = M().eval()
         with self.assertRaisesRegex(PrecompileError, "hard-coded"):
-            torch.compiler.precompile(lambda model, x: model(x), m, torch.randn(2, 4))
+            torch.compiler.precompile(
+                lambda model, x: model(x), example_inputs=[(m, torch.randn(2, 4))]
+            )
 
     def test_export_and_reload_roundtrip(self):
         class M(torch.nn.Module):
@@ -148,7 +576,9 @@ class TestPrecompile(TestCase):
 
         m = M().eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
 
         self.assertIn("Inductor output code", code)
         self.assertIn("def forward(", code)
@@ -164,7 +594,9 @@ class TestPrecompile(TestCase):
         # empty (artifact=None), so python_code is fully self-contained.
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, _cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, _cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
 
         ns = {"__name__": "_artifact"}
         exec(compile(code, "<artifact>", "exec"), ns)
@@ -193,7 +625,9 @@ class TestPrecompile(TestCase):
             .cuda()
         )
         x = torch.randn(3, 8, device="cuda")
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         self.assertIsInstance(cache, bytes)
 
         with fresh_cache():
@@ -219,7 +653,9 @@ class TestPrecompile(TestCase):
 
         m = M().cuda().eval()
         x = torch.randn(128, 512, device="cuda")
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         with fresh_cache():
             f_c = torch.compiler.precompile.load(code, cache)
             self.assertEqual(f_c(m, x), m(x))
@@ -253,7 +689,9 @@ class TestPrecompile(TestCase):
             x = distribute_tensor(torch.randn(5, 4), mesh, [Replicate()])
             ref = m(x)
 
-            code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+            code, cache = torch.compiler.precompile(
+                lambda model, x: model(x), example_inputs=[(m, x)]
+            )
             # Subclass handling is via our own protocol-based driver, not embedded
             # AOTAutograd wrapper source.
             self.assertIn("__tensor_unflatten__", code)
@@ -285,19 +723,24 @@ class TestPrecompile(TestCase):
         # integrity tag (plain str/int), which load() verifies.
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
 
         from torch._precompile import _CACHE_FORMAT, _CACHE_VERSION
 
         blob = torch.load(io.BytesIO(cache), weights_only=False)
         # The artifact is the only compiled blob; the rest is the integrity tag (the
-        # format/version/backend tag plus a code_hash binding the cache to its python_code).
+        # format/version/backend/tracer tag plus a code_hash binding the cache to its
+        # python_code).
         self.assertEqual(
-            set(blob), {"artifact", "format", "version", "backend", "code_hash"}
+            set(blob),
+            {"artifact", "format", "version", "backend", "tracer", "code_hash"},
         )
         self.assertEqual(blob["format"], _CACHE_FORMAT)
         self.assertEqual(blob["version"], _CACHE_VERSION)
         self.assertEqual(blob["backend"], "inductor")
+        self.assertEqual(blob["tracer"], "make_fx")
         self.assertIsInstance(blob["artifact"], bytes)
         # The calling convention is recoverable from python_code alone.
         from torch._precompile import _parse_artifact_metadata
@@ -317,7 +760,9 @@ class TestPrecompile(TestCase):
         # exercises the self-contained inlined path (JIT from inlined source).
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
 
         blob = torch.load(io.BytesIO(cache), weights_only=False)
         self.assertIsNotNone(blob["artifact"])
@@ -336,10 +781,13 @@ class TestPrecompile(TestCase):
 
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        _code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        _code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         blob = torch.load(io.BytesIO(cache), weights_only=True)  # must not raise
         self.assertEqual(
-            set(blob), {"artifact", "format", "version", "backend", "code_hash"}
+            set(blob),
+            {"artifact", "format", "version", "backend", "tracer", "code_hash"},
         )
         self.assertEqual(blob["format"], _CACHE_FORMAT)
         self.assertEqual(blob["version"], _CACHE_VERSION)
@@ -355,7 +803,9 @@ class TestPrecompile(TestCase):
         # python_code (the eager cache carries no artifact).
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
 
         bigger = torch.nn.Sequential(
@@ -370,7 +820,9 @@ class TestPrecompile(TestCase):
         # execs python_code, then call with a structurally different model.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, _strip_artifact(cache))
 
         bigger = torch.nn.Sequential(
@@ -385,7 +837,9 @@ class TestPrecompile(TestCase):
         # IN_SPEC check, rather than silently flattening to the wrong leaves.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         with self.assertRaisesRegex(PrecompileError, "different structure"):
             f_c(m, [x, x])
@@ -401,7 +855,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         inp = P(torch.randn(5, 4), torch.randn(5, 4))
         code, cache = torch.compiler.precompile(
-            lambda model, p: model(p.x + p.y), m, inp
+            lambda model, p: model(p.x + p.y), example_inputs=[(m, inp)]
         )
         self.assertIn("IN_SPEC = None", code)
         f_c = torch.compiler.precompile.load(code, cache)
@@ -414,7 +868,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         inp = _UnserializableCtxInput(torch.randn(5, 4), torch.randn(5, 4))
         code, cache = torch.compiler.precompile(
-            lambda model, h: model(h.a + h.b), m, inp
+            lambda model, h: model(h.a + h.b), example_inputs=[(m, inp)]
         )
         self.assertIn("IN_SPEC = None", code)
         f_c = torch.compiler.precompile.load(code, cache)
@@ -431,7 +885,9 @@ class TestPrecompile(TestCase):
         with self.assertRaisesRegex(
             PrecompileError, "cannot serialize the output structure"
         ):
-            torch.compiler.precompile(lambda x: Out(x + 1, x + 2), torch.randn(4))
+            torch.compiler.precompile(
+                lambda x: Out(x + 1, x + 2), example_inputs=[(torch.randn(4),)]
+            )
 
     def test_input_leaf_count_mismatch_rejected_when_spec_unserializable(self):
         # When IN_SPEC degrades to None the structural in_spec check is skipped; a runtime
@@ -441,7 +897,9 @@ class TestPrecompile(TestCase):
         inp = _UnserializableCtxInput(torch.randn(5, 4), torch.randn(5, 4))
         for backend in ("inductor", "eager"):
             code, cache = torch.compiler.precompile(
-                lambda model, h: model(h.a + h.b), m, inp, backend=backend
+                lambda model, h: model(h.a + h.b),
+                example_inputs=[(m, inp)],
+                backend=backend,
             )
             self.assertIn("IN_SPEC = None", code)
             f = torch.compiler.precompile.load(code, cache)
@@ -464,11 +922,13 @@ class TestPrecompile(TestCase):
             def forward(self, t):
                 return self.l1(self.l0(t))
 
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         f_i = torch.compiler.precompile.load(code, _strip_artifact(cache))
         code_e, cache_e = torch.compiler.precompile(
-            lambda mm, t: mm(t), m, x, backend="eager"
+            lambda mm, t: mm(t), example_inputs=[(m, x)], backend="eager"
         )
         f_e = torch.compiler.precompile.load(code_e, cache_e)
         for f in (f_c, f_i, f_e):
@@ -491,8 +951,7 @@ class TestPrecompile(TestCase):
             with self.assertRaisesRegex(PrecompileError, "output structure"):
                 torch.compiler.precompile(
                     lambda model, xx: NT(model(xx), model(xx) + 1),
-                    m,
-                    x,
+                    example_inputs=[(m, x)],
                     backend=backend,
                 )
         # A registered namedtuple output serializes and round-trips on both backends.
@@ -504,7 +963,9 @@ class TestPrecompile(TestCase):
         ref = (m(x), m(x) + 1)
         for backend in ("inductor", "eager"):
             code, cache = torch.compiler.precompile(
-                lambda model, xx: RNT(model(xx), model(xx) + 1), m, x, backend=backend
+                lambda model, xx: RNT(model(xx), model(xx) + 1),
+                example_inputs=[(m, x)],
+                backend=backend,
             )
             out = torch.compiler.precompile.load(code, cache)(m, x)
             self.assertEqual((out.p, out.q), ref)
@@ -528,7 +989,9 @@ class TestPrecompile(TestCase):
         def step(ma, mb, mc, x, target):
             loss_fn(mc(mb(torch.relu(ma(x)))), target).backward()
 
-        code, cache = torch.compiler.precompile(step, a, b, c, x, target)
+        code, cache = torch.compiler.precompile(
+            step, example_inputs=[(a, b, c, x, target)]
+        )
 
         def grads(ms):
             return [p.grad for m in ms for p in m.parameters()]
@@ -570,14 +1033,16 @@ class TestPrecompile(TestCase):
             return [p.grad for m in ms for p in m.parameters()]
 
         # deepcopy the three together so the a/b weight tie is preserved.
-        icode, icache = torch.compiler.precompile(step, a, b, c, x, target)
+        icode, icache = torch.compiler.precompile(
+            step, example_inputs=[(a, b, c, x, target)]
+        )
         ia, ib, ic = copy.deepcopy((a, b, c))
         torch.compiler.precompile.load(icode, icache)(
             ia, ib, ic, x, target
         )  # inductor cached path
 
         ecode, ecache = torch.compiler.precompile(
-            step, a, b, c, x, target, backend="eager"
+            step, example_inputs=[(a, b, c, x, target)], backend="eager"
         )
         ea, eb, ec = copy.deepcopy((a, b, c))
         torch.compiler.precompile.load(ecode, ecache)(
@@ -595,7 +1060,9 @@ class TestPrecompile(TestCase):
         # PrecompileError citing invariant 2, not a bare AttributeError.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         with self.assertRaisesRegex(PrecompileError, "must be the nn.Module"):
             f_c(x, x)  # tensor at the module slot
@@ -608,10 +1075,12 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3)
         x = torch.randn(2, 4)
         # Module at position 1 (so a missing trailing arg would index past args).
-        code, cache = torch.compiler.precompile(lambda xx, model: model(xx), x, m)
+        code, cache = torch.compiler.precompile(
+            lambda xx, model: model(xx), example_inputs=[(x, m)]
+        )
         inlined_cache = _strip_artifact(cache)  # force the inlined path
         ecode, ecache = torch.compiler.precompile(
-            lambda xx, model: model(xx), x, m, backend="eager"
+            lambda xx, model: model(xx), example_inputs=[(x, m)], backend="eager"
         )
         loaders = {
             "cached": torch.compiler.precompile.load(code, cache),
@@ -641,7 +1110,9 @@ class TestPrecompile(TestCase):
         m = M()
         x = torch.randn(4)
         with self.assertRaisesRegex(PrecompileError, "buffer received a gradient"):
-            torch.compiler.precompile(lambda model, x: model(x).backward(), m, x)
+            torch.compiler.precompile(
+                lambda model, x: model(x).backward(), example_inputs=[(m, x)]
+            )
 
     def test_user_input_requiring_grad_rejected(self):
         # Sibling of the buffer guard: a requires_grad USER INPUT (not a param) that
@@ -649,7 +1120,9 @@ class TestPrecompile(TestCase):
         # are), so precompile rejects it rather than silently dropping the grad.
         x = torch.randn(4, requires_grad=True)
         with self.assertRaisesRegex(PrecompileError, "user input received a gradient"):
-            torch.compiler.precompile(lambda t: (t * t).sum().backward(), x)
+            torch.compiler.precompile(
+                lambda t: (t * t).sum().backward(), example_inputs=[(x,)]
+            )
 
     def test_control_flow_subgraph_rejected(self):
         # torch.cond captures as a HOP with get_attr subgraph submodules, which the
@@ -658,14 +1131,16 @@ class TestPrecompile(TestCase):
             return torch.cond(x.sum() > 0, lambda t: t + 1, lambda t: t - 1, (x,))
 
         with self.assertRaisesRegex(PrecompileError, "control-flow subgraph"):
-            torch.compiler.precompile(f, torch.randn(4))
+            torch.compiler.precompile(f, example_inputs=[(torch.randn(4),)])
 
     def test_load_falls_back_when_cache_unreconstructable(self):
         # The cache is only an acceleration; python_code always runs standalone. A
         # corrupt / stale cache must degrade to the inlined JIT path, not crash.
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         blob = torch.load(io.BytesIO(cache), weights_only=True)
         self.assertIsNotNone(blob["artifact"])
         blob["artifact"] = b"corrupt-not-a-real-artifact"
@@ -681,7 +1156,9 @@ class TestPrecompile(TestCase):
         # since the cache is purely an acceleration.
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, _cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, _cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(
             code, b"not-a-torch-save-blob"
         )  # must not raise
@@ -704,7 +1181,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
         # Cached path (inductor): the exec of python_code warns about untrusted input.
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, x)]
+        )
         for _ in range(2):
             with self.assertLogs("torch._precompile", level="WARNING") as cm:
                 torch.compiler.precompile.load(code, cache)
@@ -715,7 +1194,7 @@ class TestPrecompile(TestCase):
         # Eager backend (empty cache, nothing to prime): load() still EXECs python_code
         # via _make_inlined_forward, which warns about exec'ing untrusted code every load.
         ecode, ecache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend="eager"
+            lambda model, t: model(t), example_inputs=[(m, x)], backend="eager"
         )
         for _ in range(2):
             with self.assertLogs("torch._precompile", level="WARNING") as cm:
@@ -738,11 +1217,15 @@ class TestPrecompile(TestCase):
         x = torch.randn(4)
         for fn in (lambda xx: 7, lambda xx: xx, lambda xx: xx.detach()):
             with self.assertRaisesRegex(PrecompileError, "no compute"):
-                torch.compiler.precompile(fn, x)
+                torch.compiler.precompile(fn, example_inputs=[(x,)])
         # The eager backend handles a passthrough and a constant fn.
-        code, cache = torch.compiler.precompile(lambda xx: xx, x, backend="eager")
+        code, cache = torch.compiler.precompile(
+            lambda xx: xx, example_inputs=[(x,)], backend="eager"
+        )
         self.assertEqual(torch.compiler.precompile.load(code, cache)(x), x)
-        code, cache = torch.compiler.precompile(lambda xx: 7, x, backend="eager")
+        code, cache = torch.compiler.precompile(
+            lambda xx: 7, example_inputs=[(x,)], backend="eager"
+        )
         self.assertEqual(torch.compiler.precompile.load(code, cache)(x), 7)
 
     def test_same_count_different_structure_rejected(self):
@@ -753,7 +1236,9 @@ class TestPrecompile(TestCase):
         # weights. Both the cached and the inlined (artifact-stripped) load paths fire.
         a = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.Linear(4, 4)).eval()
         x = torch.randn(2, 4)
-        code, cache = torch.compiler.precompile(lambda m, x: m(x), a, x)
+        code, cache = torch.compiler.precompile(
+            lambda m, x: m(x), example_inputs=[(a, x)]
+        )
         # The traced names come from the Sequential (``0.weight``, ``1.weight`` ...).
         self.assertIn(
             "PARAM_NAMES = ['0.weight', '0.bias', '1.weight', '1.bias']", code
@@ -789,7 +1274,7 @@ class TestPrecompile(TestCase):
         a = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.Linear(4, 4)).eval()
         x = torch.randn(2, 4)
         code, cache = torch.compiler.precompile(
-            lambda m, x: m(x), a, x, backend="eager"
+            lambda m, x: m(x), example_inputs=[(a, x)], backend="eager"
         )
         self.assertIn(
             "PARAM_NAMES = ['0.weight', '0.bias', '1.weight', '1.bias']", code
@@ -832,7 +1317,8 @@ class TestPrecompile(TestCase):
                     PrecompileError, "effectful op.*not supported yet"
                 ):
                     torch.compiler.precompile(
-                        lambda a: torch.ops.mlprecompile.eff(a), torch.randn(4)
+                        lambda a: torch.ops.mlprecompile.eff(a),
+                        example_inputs=[(torch.randn(4),)],
                     )
             finally:
                 _register_effectful_op(op, None)
@@ -850,16 +1336,91 @@ class TestPrecompile(TestCase):
         self.assertTrue(callable(torch.compiler.precompile))
         self.assertTrue(callable(torch.compiler.precompile.load))
         self.assertIs(torch.compiler.precompile.PrecompileError, PrecompileError)
+        # Driving a capture by hand is not public: precompile() runs the
+        # examples itself, so nothing returns a session and these types are
+        # not reachable.
+        for name in (
+            "capture",
+            "PrecompileSession",
+            "PrecompileSummary",
+            "FrameInvariants",
+            "GuardFact",
+        ):
+            self.assertFalse(hasattr(torch.compiler.precompile, name))
+            self.assertNotIn(name, torch.compiler.__all__)
         # The public location: test_public_bindings.test_correct_module_names also
         # enforces this for every torch.compiler.__all__ member.
         self.assertEqual(torch.compiler.precompile.__module__, "torch.compiler")
+
+    @parametrize("name", ["load"])
+    def test_precompile_method_public_location(self, name):
+        method = getattr(torch.compiler.precompile, name)
+        self.assertEqual(method.__module__, "torch.compiler")
+        self.assertEqual(method.__qualname__, f"precompile.{name}")
+
+    @parametrize("name", ["load"])
+    def test_precompile_method_type_hints_resolve(self, name):
+        typing.get_type_hints(getattr(torch.compiler.precompile, name))
+
+    def test_precompile_example_inputs_is_a_keyword_argument(self):
+        signature = inspect.signature(torch.compiler.precompile)
+        self.assertEqual(
+            signature.parameters["example_inputs"].kind,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+        typing.get_type_hints(torch.compiler.precompile.__call__)
+
+    @parametrize("name", ["artifact", "summary", "invariants", "write_invariants"])
+    def test_precompile_session_method_is_documented(self, name):
+        from torch._precompile import PrecompileSession
+
+        self.assertIsNotNone(inspect.getdoc(getattr(PrecompileSession, name)))
+
+    def test_precompile_session_save_documents_guard_requirements(self):
+        from torch._precompile import PrecompileSession
+
+        doc = inspect.getdoc(PrecompileSession.artifact)
+        self.assertIn("require_no_risky_drops", doc)
+        self.assertIn("require_no_dropped_guards", doc)
+        self.assertTrue(
+            inspect.signature(PrecompileSession.artifact)
+            .parameters["require_no_risky_drops"]
+            .default
+        )
+
+    def test_precompile_public_result_types(self):
+        # The public surface is the pair and the loader; the session types it
+        # is built from are internal.
+        from torch._precompile import PrecompileSession
+
+        self.assertEqual(
+            typing.get_type_hints(torch.compiler.precompile.__call__)["return"],
+            tuple[str, bytes],
+        )
+        self.assertEqual(
+            typing.get_type_hints(PrecompileSession.artifact)["return"],
+            tuple[str, bytes],
+        )
+        params = inspect.signature(PrecompileSession.artifact).parameters
+        # The risky-drop lint is the rail that is ON by default. Requiring NO
+        # dropped guards at all is not, and must not be: every model drops the
+        # identity guards precompile cannot serialize, so it would refuse
+        # essentially every real artifact.
+        self.assertTrue(params["require_no_risky_drops"].default)
+        self.assertFalse(params["require_no_dropped_guards"].default)
+
+    def test_precompile_documents_guard_filter(self):
+        doc = inspect.getdoc(torch.compiler.precompile)
+        self.assertIn("guard_filter_fn", doc)
 
     def test_backend_invalid_raises(self):
         a, b = torch.randn(4, 4), torch.randn(4, 4)
         with self.assertRaisesRegex(
             ValueError, "backend must be 'inductor' or 'eager'"
         ):
-            torch.compiler.precompile(lambda x, y: x + y, a, b, backend="nope")
+            torch.compiler.precompile(
+                lambda x, y: x + y, example_inputs=[(a, b)], backend="nope"
+            )
 
     def test_tracer_default_and_explicit_make_fx(self):
         # tracer defaults to "make_fx"; passing it explicitly is equivalent and works.
@@ -867,24 +1428,1951 @@ class TestPrecompile(TestCase):
         x = torch.randn(5, 4)
         for kwargs in ({}, {"tracer": "make_fx"}):
             code, cache = torch.compiler.precompile(
-                lambda model, xx: model(xx), m, x, **kwargs
+                lambda model, xx: model(xx), example_inputs=[(m, x)], **kwargs
             )
             self.assertEqual(torch.compiler.precompile.load(code, cache)(m, x), m(x))
 
-    def test_tracer_dynamo_not_implemented(self):
-        # "dynamo" is a valid (planned) tracer value but is not implemented yet; it must
-        # raise NotImplementedError, not silently fall back to make_fx.
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_roundtrip(self, backend):
+        # The dynamo tracer captures via Dynamo, inlines the transformed bytecode, and
+        # (like make_fx) lowers the subgraph through the chosen backend. The reload runs
+        # the same computation as eager, and a different but structurally identical model
+        # swapped in at runtime works (invariant 2) -- no weights are baked in.
+        m = torch.nn.Sequential(
+            torch.nn.Linear(4, 4), torch.nn.ReLU(), torch.nn.Linear(4, 3)
+        ).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+            backend=backend,
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), m(x))
+            m2 = torch.nn.Sequential(
+                torch.nn.Linear(4, 4), torch.nn.ReLU(), torch.nn.Linear(4, 3)
+            ).eval()
+            self.assertEqual(f_c(m2, x), m2(x))
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_self_contained_exec(self, backend):
+        # python_code runs on its own (no cache): the dynamo driver rehydrates the inlined
+        # transformed bytecode and wires the inlined subgraph, so exec'ing it and calling
+        # forward reproduces eager.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        with self.assertRaisesRegex(NotImplementedError, "tracer='dynamo'"):
-            torch.compiler.precompile(
-                lambda model, xx: model(xx), m, x, tracer="dynamo"
+        code, _ = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+            backend=backend,
+        )
+        ns = {"__name__": "_a"}
+        exec(compile(code, "<a>", "exec"), ns)
+        self.assertEqual(ns["forward"](m, x), m(x))
+
+    # Crossref wraps torch functions in a checker Dynamo treats as skipped, so a
+    # backward traced INTO the graph -- which every tracer="dynamo" training
+    # capture does -- cannot be captured as one full graph. The whole training
+    # family below is therefore unrunnable under crossref and carries this skip;
+    # every other config still runs it.
+
+    def test_tracer_dynamo_autograd_grad_returned(self):
+        # torch.autograd.grad is captured too, and (unlike .backward()) it only RETURNS the
+        # grads: nothing is scattered, so the runtime model's .grad stays None.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def grad_step(model, xx, tt):
+            loss = torch.nn.functional.mse_loss(model(xx), tt)
+            return torch.autograd.grad(loss, list(model.parameters()))
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            grad_step, example_inputs=[(fresh(), x, t)], training=True, tracer="dynamo"
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        run, ref = fresh(), fresh()
+        self.assertEqual(f_c(run, x, t), grad_step(ref, x, t))
+        self.assertTrue(all(p.grad is None for p in run.parameters()))
+
+    def test_docs_match_the_require_no_dropped_guards_default(self):
+        # require_no_dropped_guards defaults to False: every model drops the
+        # identity guards precompile cannot serialize, so True refuses
+        # essentially every real artifact. Prose asserting the opposite tells a
+        # reader to relax a rail that was never on, and to trust one that is
+        # not there.
+        import torch._dynamo.precompile_package as dynamo_precompile
+        import torch._precompile as public_precompile
+
+        for cls in (
+            public_precompile.PrecompileSession,
+            dynamo_precompile.PrecompileSession,
+        ):
+            parameters = inspect.signature(cls.artifact).parameters
+            self.assertIs(parameters["require_no_dropped_guards"].default, False)
+            self.assertIs(parameters["require_no_risky_drops"].default, True)
+
+        claims = (
+            "refuses every dropped guard",
+            "rejects every dropped guard",
+            "refuses all of them by default",
+            "requires no dropped guards by default",
+            "and every dropped guard by default",
+            "Every dropped guard is rejected by default",
+            "dropped guard is refused by default",
+            "require_no_dropped_guards=True)",
+            "is the strict default",
+            "before explicitly relaxing either dropped-guard requirement",
+            "so strict saving rejects ordinary programs",
+        )
+        repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        paths = [
+            inspect.getsourcefile(public_precompile),
+            inspect.getsourcefile(dynamo_precompile),
+        ]
+        doc_page = os.path.join(repo, "docs", "source", "torch.compiler_api.md")
+        if os.path.exists(doc_page):
+            paths.append(doc_page)
+        for path in paths:
+            with open(path, encoding="utf-8") as f:
+                # Normalized so the check survives a rewrap of the paragraph.
+                text = " ".join(f.read().split())
+            for claim in claims:
+                # assertTrue, not assertNotIn: the latter dumps the whole file.
+                self.assertTrue(claim not in text, f"{path} still claims {claim!r}")
+
+    def test_tracer_dynamo_autograd_grad_does_not_observe_the_seed(self):
+        # Seeding is a capture-time mutation of the caller's model, so fn can SEE it:
+        # `p.grad is not None` traced as True where eager reads False. When the
+        # re-capture turns out to need no accumulate at all -- autograd.grad only
+        # returns grads -- the seeds bought nothing, and the first (unseeded) capture
+        # is the one that has to ship.
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def grad_step(model, xx, tt):
+            seen = model.weight.grad is not None
+            loss = torch.nn.functional.mse_loss(model(xx), tt)
+            return seen, torch.autograd.grad(loss, [model.weight])
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, cache = torch.compiler.precompile(
+            grad_step,
+            example_inputs=[(fresh(), x, t)],
+            training=True,
+            tracer="dynamo",
+            backend="eager",
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(f_c(fresh(), x, t)[0], grad_step(fresh(), x, t)[0])
+
+    def _exec_dynamo_training_artifact(self):
+        x, t = torch.randn(5, 4), torch.randn(5, 3)
+
+        def train_step(model, xx, tt):
+            torch.nn.functional.mse_loss(model(xx), tt).backward()
+
+        def fresh():
+            torch.manual_seed(0)
+            return torch.nn.Linear(4, 3)
+
+        code, _ = torch.compiler.precompile(
+            train_step,
+            example_inputs=[(fresh(), x, t)],
+            tracer="dynamo",
+            backend="eager",
+        )
+        ns = {"__name__": "_a"}
+        exec(compile(code, "<a>", "exec"), ns)
+        return ns["forward"], train_step, fresh, x, t
+
+    @staticmethod
+    def _module_with(src: str, name: str):
+        """A real module whose globals are exactly what the source binds."""
+        mod = types.ModuleType(name)
+        mod.__file__ = f"{name}.py"
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)
+        sys.modules[name] = mod
+        return mod
+
+    # make_fx only. The dynamo tracer mirrors torch.compile, which applies an
+    # ambient torch_function mode TWICE (measured: eager 2.0, torch.compile 3.0)
+    # because lowering re-traces the torch-level graph with the modes still live.
+    # make_fx clears the stack around lowering and stays eager-correct, which is
+    # the guarantee this pins.
+    @parametrize("decompose", [False, True])
+    @parametrize("backend", ["eager", "inductor"])
+    def test_capture_under_a_torch_function_mode_applies_it_once(
+        self, decompose, backend
+    ):
+        tracer = "make_fx"
+        # Capture clears the caller's torch_function modes so Dynamo can apply them
+        # SYMBOLICALLY while tracing. The captured graph is torch-level Python, so
+        # lowering it with the modes restored re-traces through every one of them a
+        # second time and bakes a doubly-transformed kernel. Nothing catches that:
+        # the artifact needs no mode at all to reproduce the wrong number, so there
+        # is no guard to drop and no error to raise -- it is simply wrong forever.
+        fn = _precompile_add_one
+        x = torch.zeros(3)
+        with _PrecompilePlusOneMode():
+            expected = fn(x).clone()
+            code, cache = torch.compiler.precompile(
+                fn,
+                example_inputs=[(x,)],
+                tracer=tracer,
+                backend=backend,
+                # The decompositions re-trace is a SECOND pass over the same
+                # torch-level graph, so it doubles the modes independently of
+                # the lowering; both have to run with the stack cleared.
+                **({"decompositions": {}} if decompose else {}),
+                # The dynamo tracer guards the mode's __torch_function__ by
+                # identity and cannot serialize it. Irrelevant here: the point
+                # is whether the mode was applied once, and the artifact needs
+                # no mode at all to answer that.
             )
+        # Served with NO mode: the artifact must already carry the one application.
+        self.assertEqual(torch.compiler.precompile.load(code, cache)(x), expected)
+
+    def test_tracer_dynamo_rejects_a_partial_cleanly(self):
+        # get_traced_fn refuses a partial deep inside fullgraph_capture; that
+        # raw RuntimeError used to escape.
+        def base(model, xx, k=1.0):
+            return model(xx) * k
+
+        m, x = torch.nn.Linear(4, 4), torch.randn(2, 4)
+        with self.assertRaisesRegex(PrecompileError, "cannot capture a partial"):
+            torch.compiler.precompile(
+                functools.partial(base, k=3.0), example_inputs=[(m, x)], tracer="dynamo"
+            )
+
+    def _assert_multi_graph_session_round_trip(
+        self, session, inputs, expected, *, backend="eager", no_grad=False
+    ):
+        summary = session.summary()
+        self.assertEqual(summary.frames, 3)
+        self.assertEqual(summary.resume_functions, 2)
+        self.assertEqual(summary.guarded_codes, 3 * len(inputs))
+        self.assertTrue(summary.complete)
+        code, cache = session.artifact(require_no_dropped_guards=False)
+
+        torch._dynamo.reset()
+        with self.assertLogs("torch._precompile", level="WARNING") as logs:
+            loaded = torch.compiler.precompile.load(code, cache)
+        self.assertTrue(any("trust" in message for message in logs.output))
+
+        def check_loaded():
+            for x, want in zip(inputs, expected):
+                self.assertEqual(loaded(x), want)
+            # No compiler stands behind a source artifact, so an uncovered call
+            # raises on its own -- there is no stance to enter.
+            with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+                loaded(torch.randn(9, 8))
+
+        if no_grad:
+            with torch.no_grad():
+                check_loaded()
+        else:
+            check_loaded()
+
+    def test_multi_graph_capture_graph_breaks_and_recompiles(self):
+        inputs = [torch.randn(*shape) for shape in ((4, 8), (5, 8), (6, 8))]
+        expected = [_precompile_multi_graph(x) for x in inputs]
+        session = _precompile_capture(
+            _precompile_multi_graph, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            for x in inputs:
+                compiled(x)
+        self._assert_multi_graph_session_round_trip(session, inputs, expected)
+
+    def test_multi_graph_capture_from_precompile_example_inputs(self):
+        inputs = [torch.randn(*shape) for shape in ((4, 8), (5, 8), (6, 8))]
+        expected = [_precompile_multi_graph(x) for x in inputs]
+        session = _precompile_capture(
+            _precompile_multi_graph,
+            dynamic=False,
+            example_inputs=[(x,) for x in inputs],
+        )
+        with session:
+            pass
+        self._assert_multi_graph_session_round_trip(
+            session, inputs, expected, backend="inductor", no_grad=True
+        )
+
+    def test_multi_graph_capture_keeps_guards_while_collecting_variants(self):
+        x = torch.linspace(-1, 1, 4)
+        session = _precompile_capture(
+            _precompile_multi_graph_callable, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            self.assertEqual(compiled(x, torch.sin), torch.sin(x + 1))
+            self.assertEqual(compiled(x, torch.cos), torch.cos(x + 1))
+
+        summary = session.summary()
+        self.assertEqual(summary.guarded_codes, 3)
+        self.assertTrue(summary.complete)
+
+        torch._dynamo.reset()
+        session = _precompile_capture(
+            _precompile_multi_graph_callable,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(x, torch.sin), (x, torch.cos)],
+        )
+        with session:
+            pass
+        self.assertEqual(session.summary().guarded_codes, 3)
+        with self.assertRaisesRegex(PrecompileError, "can affect dispatch"):
+            session.artifact()
+
+    def test_multi_graph_custom_guard_filter_fails_closed(self):
+        x = torch.linspace(-1, 1, 4)
+
+        def drop_all(entries):
+            return [False] * len(entries)
+
+        session = _precompile_capture(
+            _precompile_multi_graph_callable,
+            backend="eager",
+            dynamic=False,
+            guard_filter_fn=drop_all,
+        )
+        with session as compiled:
+            self.assertEqual(compiled(x, torch.sin), torch.sin(x + 1))
+            self.assertEqual(compiled(x, torch.cos), torch.cos(x + 1))
+        summary = session.summary()
+        self.assertEqual(summary.guarded_codes, 3)
+        self.assertTrue(summary.dropped_guards)
+        self.assertEqual(summary.risky_dropped_guards, summary.dropped_guards)
+        with self.assertRaisesRegex(PrecompileError, "custom filter"):
+            session.artifact(require_no_dropped_guards=False)
+
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_multi_graph_capture_keeps_guards_under_caching_precompile(self):
+        x = torch.linspace(-1, 1, 4)
+        session = _precompile_capture(
+            _precompile_multi_graph_callable, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            self.assertEqual(compiled(x, torch.sin), torch.sin(x + 1))
+            self.assertEqual(compiled(x, torch.cos), torch.cos(x + 1))
+        self.assertEqual(session.summary().guarded_codes, 3)
+
+    @torch._dynamo.config.patch(caching_precompile=True)
+    @torch._dynamo.config.patch(caching_precompile=True)
+    def test_multi_graph_cache_flush_does_not_mutate_explicit_session(self):
+        PrecompileContext.clear()
+        try:
+            x = torch.randn(2, 8)
+            session = _precompile_capture(
+                _precompile_multi_graph, backend="eager", dynamic=False
+            )
+            with session as compiled:
+                compiled(x)
+
+            before = session.summary()
+            self.assertTrue(before.complete)
+
+            # An explicit session stages nothing of its own, so a flush with only
+            # that session in the process never walks a cache entry at all. Give
+            # it one to walk: an ordinary torch.compile under caching_precompile
+            # registers a live _DynamoCacheEntry, and the eager backend registers
+            # no backend artifact for it -- the same "the backend is gone" state
+            # an explicit session leaves behind when it claims the backends.
+            torch._dynamo.reset()
+            # A warm on-disk entry from an earlier run would be LOADED here
+            # instead of compiled, and one written when this file was imported
+            # as a module rather than run as __main__ does not even match.
+            DynamoCache.clear()
+            torch.compile(_precompile_multi_graph, backend="eager", dynamic=False)(x)
+            live = list(PrecompileContext._dynamo_cache_entries.values())
+            self.assertTrue(live)
+            codes = [code for entry in live for code in entry.codes]
+            self.assertTrue(codes)
+            self.assertFalse(any(code.bypassed for code in codes))
+
+            torch.compiler.save_cache_artifacts()
+
+            self.assertEqual(session.summary(), before)
+            # from_cache_entry marks a code bypassed when its backend is missing.
+            # It must do that to its own copy: install() treats a bypassed entry
+            # as "serve nothing", so mutating the live one silently stops the
+            # package serving for the rest of the process.
+            self.assertFalse(any(code.bypassed for code in codes))
+        finally:
+            PrecompileContext.clear()
+
+    def test_multi_graph_failed_capture_is_incomplete(self):
+        x = torch.randn(4, 8)
+        session = _precompile_capture(
+            _precompile_multi_graph, backend="eager", dynamic=False
+        )
+        with self.assertRaisesRegex(KeyError, "capture failed"):
+            with session as compiled:
+                compiled(x)
+                raise KeyError("capture failed")
+
+        summary = session.summary()
+        self.assertFalse(summary.complete)
+        self.assertEqual(len(summary.capture_errors), 1)
+        with self.assertRaisesRegex(PrecompileError, "capture raised"):
+            session.artifact()
+        session.artifact(
+            require_complete=False,
+            require_no_dropped_guards=False,
+        )
+
+    def test_multi_graph_failed_automatic_example_is_incomplete(self):
+        x = torch.randn(4)
+        session = _precompile_capture(
+            _precompile_raises_on_flag,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(x, False), (x, True)],
+        )
+        with self.assertRaisesRegex(KeyError, "automatic example failed"):
+            with session:
+                pass
+
+        summary = session.summary()
+        self.assertGreater(summary.guarded_codes, 0)
+        self.assertFalse(summary.complete)
+        self.assertEqual(len(summary.capture_errors), 1)
+        with self.assertRaisesRegex(PrecompileError, "capture raised"):
+            session.artifact()
+
+    def test_multi_graph_automatic_examples_reject_inference_tensors(self):
+        with torch.inference_mode():
+            x = torch.randn(4)
+            with self.assertRaisesRegex(PrecompileError, "inference tensor"):
+                torch.compiler.precompile(
+                    _precompile_multi_graph,
+                    backend="eager",
+                    dynamic=False,
+                    tracer="dynamo",
+                    example_inputs=[(x,)],
+                )
+
+    def test_multi_graph_automatic_examples_reject_inference_module_state(self):
+        x = torch.randn(4, 8)
+        with torch.inference_mode():
+            model = torch.nn.Linear(8, 4)
+        with self.assertRaisesRegex(
+            PrecompileError, "inference tensor parameter 'weight'"
+        ):
+            torch.compiler.precompile(
+                model,
+                backend="eager",
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=[(x,)],
+            )
+
+    def test_multi_graph_automatic_examples_reject_inference_module_argument(self):
+        x = torch.randn(4, 8)
+        with torch.inference_mode():
+            model = torch.nn.Linear(8, 4)
+        with self.assertRaisesRegex(
+            PrecompileError, "inference tensor parameter 'weight'"
+        ):
+            torch.compiler.precompile(
+                _precompile_module_arg,
+                backend="eager",
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=[(model, x)],
+            )
+
+    def test_multi_graph_setup_failure_cleans_up_session(self):
+        import torch._functorch.config as functorch_config
+
+        before = functorch_config.bundled_autograd_cache
+        session = _precompile_capture(
+            _precompile_multi_graph,
+            backend="definitely_missing_backend",
+            dynamic=False,
+        )
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.InvalidBackend, "Invalid backend"
+        ):
+            with session:
+                pass
+        self.assertEqual(functorch_config.bundled_autograd_cache, before)
+        self.assertFalse(session.summary().complete)
+        self.assertIn("InvalidBackend", session.summary().capture_errors[0])
+        with self.assertRaisesRegex(PrecompileError, "capture raised"):
+            session.artifact()
+
+    def test_multi_graph_overlapping_sessions_restore_capture_config(self):
+        import torch._functorch.config as functorch_config
+
+        with (
+            functorch_config.patch("bundled_autograd_cache", False),
+            torch._dynamo.config.patch(allow_empty_graphs=False),
+        ):
+            first = _precompile_capture(_precompile_multi_graph, backend="eager")
+            second = _precompile_capture(_precompile_multi_graph, backend="eager")
+            first.__enter__()
+            second.__enter__()
+            first.__exit__(None, None, None)
+            self.assertTrue(functorch_config.bundled_autograd_cache)
+            self.assertTrue(torch._dynamo.config.allow_empty_graphs)
+            second.__exit__(None, None, None)
+            self.assertFalse(functorch_config.bundled_autograd_cache)
+            self.assertFalse(torch._dynamo.config.allow_empty_graphs)
+
+    def test_multi_graph_cross_thread_sessions_restore_capture_config(self):
+        import torch._functorch.config as functorch_config
+
+        first_entered = threading.Event()
+        second_entered = threading.Event()
+        first_exited = threading.Event()
+        release_second = threading.Event()
+        errors = []
+        states = []
+
+        def run(first):
+            session = _precompile_capture(_precompile_single_graph, backend="eager")
+            try:
+                session.__enter__()
+                (first_entered if first else second_entered).set()
+                states.append(
+                    (
+                        "first" if first else "second",
+                        "entered",
+                        functorch_config.bundled_autograd_cache,
+                        torch._dynamo.config.allow_empty_graphs,
+                    )
+                )
+                if first:
+                    self.assertTrue(second_entered.wait(10))
+                else:
+                    self.assertTrue(first_entered.wait(10))
+                    self.assertTrue(release_second.wait(10))
+                    states.append(
+                        (
+                            "second",
+                            "after_first_exit",
+                            functorch_config.bundled_autograd_cache,
+                            torch._dynamo.config.allow_empty_graphs,
+                        )
+                    )
+                session.__exit__(None, None, None)
+                if first:
+                    first_exited.set()
+            except BaseException as error:
+                errors.append(error)
+
+        with (
+            functorch_config.patch("bundled_autograd_cache", False),
+            torch._dynamo.config.patch(allow_empty_graphs=False),
+        ):
+            first = threading.Thread(target=run, args=(True,))
+            second = threading.Thread(target=run, args=(False,))
+            first.start()
+            self.assertTrue(first_entered.wait(10))
+            second.start()
+            self.assertTrue(second_entered.wait(10))
+            self.assertTrue(first_exited.wait(10))
+            release_second.set()
+            first.join(10)
+            second.join(10)
+            self.assertFalse(first.is_alive())
+            self.assertFalse(second.is_alive())
+            self.assertEqual(errors, [])
+            self.assertIn(("first", "entered", True, True), states)
+            self.assertIn(("second", "entered", True, True), states)
+            self.assertIn(("second", "after_first_exit", True, True), states)
+            self.assertFalse(functorch_config.bundled_autograd_cache)
+            self.assertFalse(torch._dynamo.config.allow_empty_graphs)
+
+    def test_multi_graph_worker_thread_inherits_capture_behavior(self):
+        session = _precompile_capture(
+            _precompile_identity, backend="eager", dynamic=False
+        )
+        errors = []
+        with session as compiled:
+            x = torch.randn(2)
+
+            def run():
+                try:
+                    self.assertEqual(compiled(x), x)
+                except BaseException as e:
+                    errors.append(e)
+
+            thread = threading.Thread(target=run)
+            thread.start()
+            thread.join(20)
+            self.assertFalse(thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertTrue(session.summary().complete)
+        self.assertEqual(session.summary().guarded_codes, 1)
+
+    def test_multi_graph_exit_waits_for_worker_call(self):
+        from torch._dynamo.backends.registry import register_backend
+        from torch._dynamo.eval_frame import _get_total_cache_entry_count
+
+        entered = threading.Event()
+        release = threading.Event()
+        worker_done = threading.Event()
+        errors = []
+        outputs = []
+
+        def blocking_backend(gm, example_inputs):
+            entered.set()
+            self.assertTrue(release.wait(20))
+            return gm.forward
+
+        backend_name = f"precompile_exit_waits_{id(entered)}"
+        register_backend(blocking_backend, name=backend_name)
+        session = _precompile_capture(
+            _precompile_single_graph, backend=backend_name, dynamic=False
+        )
+        compiled = session.__enter__()
+        x = torch.randn(2)
+
+        def run():
+            try:
+                outputs.append(compiled(x))
+            except BaseException as e:
+                errors.append(e)
+            finally:
+                worker_done.set()
+
+        worker = threading.Thread(target=run)
+        worker.start()
+        self.assertTrue(entered.wait(20))
+
+        def release_call():
+            self.assertFalse(worker_done.wait(0.1))
+            release.set()
+
+        releaser = threading.Thread(target=release_call)
+        releaser.start()
+        session.__exit__(None, None, None)
+        worker.join(20)
+        releaser.join(20)
+        self.assertFalse(worker.is_alive())
+        self.assertFalse(releaser.is_alive())
+        self.assertEqual(errors, [])
+        self.assertEqual(outputs, [_precompile_single_graph(x)])
+        self.assertEqual(
+            _get_total_cache_entry_count(_precompile_single_graph.__code__), 0
+        )
+
+    def test_multi_graph_caught_call_failure_is_incomplete(self):
+        x = torch.randn(4)
+        session = _precompile_capture(
+            _precompile_raises_on_flag, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(x, False)
+            with self.assertRaisesRegex(KeyError, "automatic example failed"):
+                compiled(x, True)
+
+        summary = session.summary()
+        self.assertFalse(summary.complete)
+        self.assertEqual(len(summary.capture_errors), 1)
+
+    def test_multi_graph_session_releases_examples_and_failure_tracebacks(self):
+        example = torch.randn(1024)
+        example_ref = weakref.ref(example)
+        completed = _precompile_capture(
+            _precompile_multi_graph,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(example,)],
+        )
+        with completed:
+            pass
+        self.assertTrue(completed.summary().complete)
+        del example
+        torch._dynamo.reset()
+        gc.collect()
+        self.assertIsNone(example_ref())
+
+        failed = torch.randn(1024)
+        failed_ref = weakref.ref(failed)
+        session = _precompile_capture(
+            _precompile_raises_on_flag, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            with self.assertRaisesRegex(KeyError, "automatic example failed"):
+                compiled(failed, True)
+        del failed
+        torch._dynamo.reset()
+        gc.collect()
+        self.assertIsNone(failed_ref())
+
+    def test_multi_graph_capture_callable_is_scoped_to_session(self):
+        x = torch.randn(4, 8)
+        session = _precompile_capture(
+            _precompile_multi_graph, backend="eager", dynamic=False
+        )
+        with session as compiled:
+            compiled(x)
+        with self.assertRaisesRegex(RuntimeError, "not active"):
+            compiled(x)
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_multi_graph_module_example_inputs_round_trip(self, backend):
+        # Capture the function that CALLS the model, the same convention the
+        # single-graph forms use. Capturing a bare nn.Module whose forward is a
+        # thin wrapper makes Dynamo compile the wrapper's inner frame, which a
+        # self-contained artifact cannot dispatch; that shape is refused with
+        # this same advice (test_multi_graph_wrapper_only_capture_is_refused).
+        model = torch.nn.Linear(8, 4).eval()
+        x = torch.randn(3, 8)
+        with torch.no_grad():
+            expected = model(x)
+        session = _precompile_capture(
+            _precompile_call_model,
+            backend=backend,
+            dynamic=False,
+            example_inputs=[(model, x)],
+        )
+        with session, torch.no_grad():
+            pass
+        summary = session.summary()
+        self.assertTrue(summary.complete)
+        self.assertEqual(summary.uncovered_frames, ())
+
+        code, cache = session.artifact()
+        torch._dynamo.reset()
+        with self.assertLogs("torch._precompile", level="WARNING"):
+            loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            self.assertEqual(loaded(model, x), expected)
+        # Grad enabled misses the GLOBAL_STATE guard every variant carries.
+        with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+            loaded(model, x)
+
+    def _multigraph_frames(self, code):
+        from torch._precompile import _parse_artifact_metadata
+
+        return _parse_artifact_metadata(code)["FRAMES"]
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_multi_graph_artifact_follows_the_code_cache_contract(self, backend):
+        from torch._C._dynamo.eval_frame import _debug_get_precompile_entries
+        from torch._precompile import _parse_artifact_metadata
+
+        # A capture with graph breaks and several variants returns the same
+        # (python_code, cache) pair the single-graph forms do, and load() takes
+        # it back. python_code is standalone: it installs nothing onto the
+        # callable's code objects, so serving it mutates no global state.
+        model = _PrecompileBreakingModule().eval()
+        shapes = [(3, 8), (5, 8)]
+        inputs = [torch.randn(*shape) for shape in shapes]
+        with torch.no_grad():
+            expected = [model(x) for x in inputs]
+
+        code, cache = torch.compiler.precompile(
+            model,
+            backend=backend,
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(x,) for x in inputs],
+        )
+        self.assertIsInstance(code, str)
+        self.assertIsInstance(cache, bytes)
+
+        # The readable half says what is in the opaque half.
+        self.assertIn('TRACER = "dynamo"', code)
+        self.assertIn("FRAMES = [", code)
+        self.assertIn("2. Guard trees and transformed bytecode -- OPAQUE", code)
+        self.assertIn("DROPPED_GUARDS", code)
+        # Guard trees and bytecode have no source form and stay opaque, but a
+        # compiled subgraph is Inductor output, which does: on inductor the
+        # kernels are emitted as readable source, and only eager (whose
+        # "backend" is an fx graph with nothing to render) stays pickled.
+        if backend == "inductor":
+            self.assertIn("READABLE below", code)
+            # async_compile rather than @triton.jit: this test runs on CPU,
+            # where the rendered kernels are C++ rather than Triton.
+            self.assertIn("async_compile", code)
+            self.assertIn("_SUBGRAPHS[", code)
+        else:
+            self.assertIn("3. Compiled subgraphs -- OPAQUE", code)
+
+        # It reports one entry frame plus one continuation, two variants each.
+        frames = _parse_artifact_metadata(code)["FRAMES"]
+        self.assertEqual([count for _, count in frames], [2, 2])
+        self.assertTrue(
+            any(name.startswith("torch_dynamo_resume_in") for name, _ in frames)
+        )
+
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            for x, want in zip(inputs, expected):
+                self.assertEqual(loaded(model, x), want)
+        # Nothing was installed, so the model still compiles normally.
+        self.assertEqual(
+            len(_debug_get_precompile_entries(type(model).forward.__code__)), 0
+        )
+        # A call no variant covers raises rather than silently recompiling.
+        with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+            with torch.no_grad():
+                loaded(model, torch.randn(9, 8))
+
+    def test_automatic_dynamic_promotes_every_frame_across_graph_breaks(self):
+        # Automatic dynamic is per CODE OBJECT, and a graph break makes each
+        # continuation its own code object with its own frame state. A dim that
+        # varies therefore has to be detected separately in frames 2 and 3, not
+        # just in the entry frame -- otherwise the artifact serves a new shape
+        # up to the first break and then misses.
+        model = _PrecompileTwoBreakModule().eval()
+        captured = [torch.randn(n) for n in (3, 5)]
+        unseen = [torch.randn(n) for n in (7, 11)]
+
+        code, cache = torch.compiler.precompile(
+            model,
+            backend="eager",
+            dynamic=None,
+            tracer="dynamo",
+            example_inputs=[(x,) for x in captured],
+            require_no_risky_drops=False,
+        )
+        frames = self._multigraph_frames(code)
+        self.assertEqual(len(frames), 3)
+        self.assertEqual(
+            sum(1 for name, _ in frames if name.startswith("torch_dynamo_resume_in")), 2
+        )
+        # One static compile per frame, then one promoted to dynamic.
+        self.assertEqual([count for _, count in frames], [2, 2, 2])
+
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            for x in captured + unseen:
+                self.assertEqual(loaded(model, x), model(x))
+
+        # The contrast that makes the assertion above meaningful: with automatic
+        # dynamic off, the same capture serves only what it saw.
+        torch._dynamo.reset()
+        static_code, static_cache = torch.compiler.precompile(
+            model,
+            backend="eager",
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(x,) for x in captured],
+            require_no_risky_drops=False,
+        )
+        torch._dynamo.reset()
+        static = torch.compiler.precompile.load(static_code, static_cache)
+        with torch.no_grad():
+            for x in unseen:
+                with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+                    static(model, x)
+
+    def test_automatic_dynamic_promotes_only_the_frame_that_varied(self):
+        # Detection is per frame, not global: an entry frame whose input never
+        # varies stays specialized while the continuation that did see variation
+        # is promoted. Promoting everything would throw away the entry frame's
+        # static specialization for nothing.
+        model = _PrecompileLateVaryingModule().eval()
+        fixed = torch.randn(4)
+        code, cache = torch.compiler.precompile(
+            model,
+            backend="eager",
+            dynamic=None,
+            tracer="dynamo",
+            example_inputs=[(fixed, torch.randn(n)) for n in (3, 5)],
+            require_no_risky_drops=False,
+        )
+        frames = self._multigraph_frames(code)
+        counts = {
+            name.startswith("torch_dynamo_resume_in"): count for name, count in frames
+        }
+        self.assertEqual(counts[False], 1)  # entry frame: never recompiled
+        self.assertEqual(counts[True], 2)  # continuation: static, then dynamic
+
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            for n in (3, 5, 7, 9):
+                z = torch.randn(n)
+                self.assertEqual(loaded(model, fixed, z), model(fixed, z))
+
+    def test_multi_graph_unreachable_frame_is_served_by_installing(self):
+        # A frame Dynamo compiled that is entered by an ORDINARY call -- an
+        # un-inlinable helper -- is reached only through the frame evaluator. A
+        # source artifact does not use one, so such a capture is served by
+        # installing onto the live code objects instead, and the frame that a
+        # source artifact would have run eager is named in the header.
+        from torch._dynamo.utils import counters
+        from torch._precompile import _parse_artifact_metadata
+
+        code, cache = torch.compiler.precompile(
+            _precompile_unreachable_helper_caller,
+            backend="eager",
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(torch.randn(4),)],
+        )
+        meta = _parse_artifact_metadata(code)
+        self.assertEqual(meta["SERVING_MODE"], "installed")
+        self.assertIn(
+            _precompile_unreachable_helper.__name__,
+            meta["UNREACHABLE_WITHOUT_INSTALL"],
+        )
+
+        x = torch.randn(4)
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        counters.clear()
+        with loaded, torch.no_grad():
+            self.assertEqual(loaded(x), _precompile_unreachable_helper_caller(x))
+            # Served, not recompiled: the whole point of installing.
+            self.assertEqual(counters["stats"]["unique_graphs"], 0)
+
+    @parametrize("backend", ("eager", "inductor"))
+    def test_training_capture_serves_a_backward_without_a_loss(self, backend):
+        # The capture never sees a loss and never calls .backward(). The joint
+        # trace synthesizes tangents from the forward outputs, and the backward
+        # is lowered eagerly, so a served output is still wired to
+        # AOTAutograd's CompiledFunction and .backward() runs precompiled code.
+        model = _PrecompileTrainMod()
+        xs = [torch.randn(n, 8) for n in (4, 6)]
+        expected = []
+        for x in xs:
+            model.zero_grad(set_to_none=True)
+            _precompile_call_model(model, x).sum().backward()
+            expected.append([p.grad.clone() for p in model.parameters()])
+        model.zero_grad(set_to_none=True)
+
+        code, cache = torch.compiler.precompile(
+            _precompile_call_model,
+            backend=backend,
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(model, x) for x in xs],
+            training=True,
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        for x, grads in zip(xs, expected):
+            model.zero_grad(set_to_none=True)
+            out = loaded(model, x)
+            self.assertTrue(out.requires_grad)
+            out.sum().backward()
+            for want, param in zip(grads, model.parameters()):
+                self.assertEqual(want, param.grad)
+
+    def test_inference_capture_stays_grad_free(self):
+        # The default is unchanged: examples run under no_grad, so a served
+        # output carries no autograd history.
+        model = _PrecompileTrainMod()
+        x = torch.randn(4, 8)
+        code, cache = torch.compiler.precompile(
+            _precompile_call_model,
+            backend="eager",
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(model, x)],
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            self.assertFalse(loaded(model, x).requires_grad)
+
+    # ----------------------------------------------------------------------
+    # The dynamo tracer against graph breaks and recompilations. Every case
+    # asserts the artifact serves, and that it agrees with torch.compile --
+    # parity with torch.compile is the contract, so torch.compile is the
+    # reference rather than eager.
+    # ----------------------------------------------------------------------
+
+    @parametrize("shape", list(_BREAKING_MODELS))
+    @parametrize("backend", ["eager", "inductor"])
+    def test_dynamo_tracer_serves_each_graph_break_shape(self, shape, backend):
+        torch._dynamo.reset()
+        model = _BREAKING_MODELS[shape]().eval()
+        x = torch.randn(4, 4)
+        with torch.no_grad():
+            reference = torch.compile(_brk_call, backend=backend)(model, x)
+
+        torch._dynamo.reset()
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                _brk_call,
+                backend=backend,
+                tracer="dynamo",
+                example_inputs=[(model, x)],
+                require_complete=False,
+                require_no_risky_drops=False,
+            )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            self.assertEqual(loaded(model, x), reference)
+
+    @parametrize("backend", ["eager", "inductor"])
+    def test_dynamo_tracer_serves_every_captured_recompilation(self, backend):
+        # Two axes vary -- a bool that changes the branch and a shape that
+        # changes the specialization -- so the capture holds several guarded
+        # variants of the same frames, on both sides of the break.
+        torch._dynamo.reset()
+        model = _BrkBranchy().eval()
+        calls = [
+            (model, torch.randn(n, 4), flag) for n in (4, 6) for flag in (False, True)
+        ]
+        torch._dynamo.reset()
+        compiled = torch.compile(_brk_call_flag, backend=backend, dynamic=False)
+        with torch.no_grad():
+            reference = [compiled(*c) for c in calls]
+
+        torch._dynamo.reset()
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                _brk_call_flag,
+                backend=backend,
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=calls,
+                require_complete=False,
+                require_no_risky_drops=False,
+            )
+        from torch._precompile import _parse_artifact_metadata
+
+        frames = _parse_artifact_metadata(code)["FRAMES"]
+        # The capture really did hold several variants, and really did break.
+        self.assertTrue(any(v > 1 for _, v in frames))
+        self.assertTrue(any("resume_in" in n for n, _ in frames))
+
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        from torch._dynamo.utils import counters
+
+        counters.clear()
+        with _maybe_scoped(loaded), torch.no_grad():
+            for call, want in zip(calls, reference):
+                self.assertEqual(loaded(*call), want)
+            # Served, not recompiled: every one of those calls was captured.
+            self.assertEqual(counters["stats"]["unique_graphs"], 0)
+
+    def test_dynamo_tracer_uncovered_call_is_still_correct(self):
+        # What an uncovered call does depends on how the artifact serves, and
+        # both answers are right. A STANDALONE artifact has no compiler behind
+        # it and refuses. An INSTALLED one is on the frame evaluator, so it
+        # recompiles exactly as torch.compile would -- which is the parity the
+        # dynamo tracer is for. Either way the answer is never wrong.
+        from torch._dynamo.utils import counters
+        from torch._precompile import _parse_artifact_metadata
+
+        torch._dynamo.reset()
+        model = _BrkBranchy().eval()
+        x = torch.randn(4, 4)
+        with torch.no_grad():
+            reference = torch.compile(_brk_call_flag, backend="eager", dynamic=False)(
+                model, x, False
+            )
+        torch._dynamo.reset()
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                _brk_call_flag,
+                backend="eager",
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=[(model, x, True)],
+                require_complete=False,
+                require_no_risky_drops=False,
+            )
+        installed = _parse_artifact_metadata(code)["SERVING_MODE"] == "installed"
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            self.assertIsNotNone(loaded(model, x, True))
+            counters.clear()
+            # flag varied across nothing here -- one example -- so its guard is
+            # not serialized and the captured graph answers. That is the trade
+            # invariant-guard dropping makes, and it is why the artifact's
+            # domain is the calls you gave it.
+            self.assertIsNotNone(loaded(model, x, False))
+            if installed:
+                self.assertEqual(counters["stats"]["unique_graphs"], 0)
+        del reference, installed
+
+    def test_dynamo_tracer_training_across_a_graph_break_matches_torch_compile(self):
+        # Gradients, through a break, against torch.compile as the reference.
+        torch._dynamo.reset()
+
+        def grads_of(fn, model, x):
+            model.zero_grad(set_to_none=True)
+            fn(model, x).backward()
+            return [p.grad.clone() for p in model.parameters()]
+
+        model = _BrkDisabledCallee()
+        x = torch.randn(4, 4)
+        reference = grads_of(torch.compile(_brk_call, backend="eager"), model, x)
+
+        torch._dynamo.reset()
+        code, cache = torch.compiler.precompile(
+            _brk_call,
+            backend="eager",
+            tracer="dynamo",
+            example_inputs=[(model, x)],
+            training=True,
+            require_complete=False,
+            require_no_risky_drops=False,
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded):
+            model.zero_grad(set_to_none=True)
+            out = loaded(model, x)
+            self.assertTrue(out.requires_grad)
+            out.backward()
+        for want, param in zip(reference, model.parameters()):
+            self.assertEqual(want, param.grad)
+
+    def test_invariant_guards_are_not_serialized(self):
+        # The default, and a load-bearing one: a guard whose value never varied
+        # across the capture discriminates nothing, so it is not serialized.
+        # The trade is explicit -- an uncovered value is then served by a
+        # captured graph rather than refused.
+        from torch._precompile import _parse_artifact_metadata
+
+        xs = [torch.randn(3), torch.randn(5)]
+        torch._dynamo.reset()
+        code, cache = torch.compiler.precompile(
+            _precompile_scaled,
+            backend="eager",
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(x, 2) for x in xs],
+        )
+        self.assertEqual(_parse_artifact_metadata(code)["TRACER"], "dynamo")
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        x = torch.randn(3)
+        with torch.no_grad():
+            self.assertEqual(loaded(x, 2), x * 2)
+            # k never varied, so nothing checks it: the captured graph serves.
+            self.assertEqual(loaded(x, 5), x * 2)
+
+    def test_discriminating_guards_are_kept(self):
+        # The other half: a value that DID vary is what selects between the
+        # variants, so its guard survives and both variants serve correctly.
+        x = torch.randn(4)
+        with torch.no_grad():
+            expected = {f: _precompile_branchy(x, f) for f in (False, True)}
+        torch._dynamo.reset()
+        code, cache = torch.compiler.precompile(
+            _precompile_branchy,
+            backend="eager",
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(x, False), (x, True)],
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            for flag in (False, True):
+                self.assertEqual(loaded(x, flag), expected[flag])
+
+    def test_multi_graph_installed_entry_with_closure_is_refused(self):
+        # An installed artifact rebuilds the entry from its code object, and
+        # types.FunctionType cannot restore a closure, so the capture is refused
+        # where the closure is visible rather than on the serving machine.
+        with self.assertRaisesRegex(PrecompileError, "closes over"):
+            torch.compiler.precompile(
+                _precompile_closure_entry_factory(),
+                backend="eager",
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=[(torch.randn(4),)],
+            )
+
+    @parametrize("training", [False, True])
+    def test_dynamo_tracer_renders_kernels_as_source(self, training):
+        # A compiled subgraph is Inductor output, which has a source form -- so
+        # the dynamo tracer emits it rather than pickling it, leaving only the
+        # guard trees and bytecode opaque. A TRAINING capture is the exception:
+        # compile_to_python pins the inference path, so rendering there would
+        # drop the backward, and the bundle is kept instead.
+        model = _PrecompileBreakingModule().eval()
+        xs = [torch.randn(3, 8), torch.randn(5, 8)]
+        ctx = torch.enable_grad() if training else torch.no_grad()
+        with ctx:
+            code, cache = torch.compiler.precompile(
+                model,
+                backend="inductor",
+                dynamic=False,
+                tracer="dynamo",
+                training=training,
+                example_inputs=[(x,) for x in xs],
+            )
+        if training:
+            self.assertIn("3. Compiled subgraphs -- OPAQUE", code)
+            self.assertNotIn("_SUBGRAPHS[", code)
+        else:
+            self.assertIn("READABLE below", code)
+            self.assertIn("async_compile", code)
+            self.assertIn("_SUBGRAPHS[", code)
+
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        # Serve in the mode it was captured in: grad mode is a GLOBAL_STATE
+        # guard, and it is checked.
+        with (
+            _maybe_scoped(loaded),
+            torch.enable_grad() if training else torch.no_grad(),
+        ):
+            for x in xs:
+                # entry frame is forward, so the receiver is passed explicitly
+                self.assertEqual(loaded(model, x), model(x))
+
+    def test_rendered_subgraphs_do_not_share_top_level_names(self):
+        # Two variants of one frame are the same computation at different
+        # shapes, so they render the SAME names. They are spliced into one
+        # namespace, and a block resolves its siblings as late-bound globals --
+        # so without per-subgraph renaming the first variant would silently run
+        # the second's code. Each variant must still serve its own shape.
+        x2, x4 = torch.randn(2, 8), torch.randn(4, 8)
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                _precompile_scale_sum,
+                backend="inductor",
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=[(x2,), (x4,)],
+            )
+        self.assertIn("_SUBGRAPHS[", code)
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            for x in (x2, x4):
+                self.assertEqual(loaded(x), _precompile_scale_sum(x))
+
+    def test_multi_graph_bare_module_capture_is_refused(self):
+        # Handing precompile a bare nn.Module compiles Dynamo's OWN wrapper
+        # frame (wrap_inline's `inner`), which closes over the module: the
+        # entry frame holds no graph, and no artifact can rebuild that closure.
+        # Refuse, and name the spelling that works.
+        model = torch.nn.Linear(8, 4).eval()
+        x = torch.randn(3, 8)
+        with self.assertRaisesRegex(
+            torch._precompile.PrecompileError, "captured no dispatchable graph"
+        ):
+            torch.compiler.precompile(
+                model,
+                backend="eager",
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=[(x,)],
+            )
+
+    def test_multi_graph_module_behind_a_function_is_captured(self):
+        # The spelling the refusal above points at: a module-level function that
+        # calls the model. Now the entry frame is real and the artifact serves.
+        model = torch.nn.Linear(8, 4).eval()
+        x = torch.randn(3, 8)
+        with torch.no_grad():
+            expected = _brk_call(model, x)
+        torch._dynamo.reset()
+        code, cache = torch.compiler.precompile(
+            _brk_call,
+            backend="eager",
+            dynamic=False,
+            tracer="dynamo",
+            example_inputs=[(model, x)],
+        )
+        torch._dynamo.reset()
+        loaded = torch.compiler.precompile.load(code, cache)
+        with _maybe_scoped(loaded), torch.no_grad():
+            self.assertEqual(loaded(model, x), expected)
+
+    def test_precompile_rejects_positional_example_arguments(self):
+        # example_inputs is the only calling convention; the old positional
+        # spelling gets a pointed error rather than CPython's arity message.
+        x = torch.randn(3)
+        with self.assertRaisesRegex(TypeError, "no positional example arguments"):
+            torch.compiler.precompile(lambda y: y + 1, x, backend="eager")
+
+    def test_precompile_requires_example_inputs(self):
+        with self.assertRaisesRegex(ValueError, "requires example_inputs"):
+            torch.compiler.precompile(lambda: None, backend="eager")
+
+    def test_make_fx_tracer_takes_exactly_one_example(self):
+        x = torch.randn(3)
+        with self.assertRaisesRegex(ValueError, "captures a single call"):
+            torch.compiler.precompile(
+                lambda y: y + 1, backend="eager", example_inputs=[(x,), (x,)]
+            )
+
+    def test_precompile_capture_options_require_the_dynamo_tracer(self):
+        x = torch.randn(3)
+        with self.assertRaisesRegex(ValueError, "only to tracer='dynamo'"):
+            torch.compiler.precompile(
+                lambda y: y + 1, backend="eager", example_inputs=[(x,)], dynamic=False
+            )
+
+    def test_multi_graph_public_errors_are_precompile_errors(self):
+        session = _precompile_capture(_precompile_multi_graph, backend="eager")
+        with session:
+            pass
+        with self.assertRaisesRegex(PrecompileError, "captured no compiled code"):
+            session.artifact()
+
+        with self.assertRaisesRegex(PrecompileError, "not valid Python"):
+            torch.compiler.precompile.load("not an artifact {", b"")
+
+    def test_multi_graph_keep_all_filter_reports_unserializable_guard(self):
+        with self.assertRaisesRegex(PrecompileError, "guard cannot be serialized"):
+            torch.compiler.precompile(
+                _precompile_multi_graph,
+                backend="eager",
+                dynamic=False,
+                tracer="dynamo",
+                example_inputs=[(torch.randn(2, 8),)],
+                guard_filter_fn=lambda entries: [True] * len(entries),
+            )
+
+    def test_multi_graph_manual_keep_all_filter_uses_public_error(self):
+        session = _precompile_capture(
+            _precompile_multi_graph,
+            backend="eager",
+            dynamic=False,
+            guard_filter_fn=lambda entries: [True] * len(entries),
+        )
+        with self.assertRaisesRegex(PrecompileError, "guard cannot be serialized"):
+            with session as compiled:
+                compiled(torch.randn(2, 8))
+
+    def test_multi_graph_capture_exit_wait_interrupt_is_retryable(self):
+        session = _precompile_capture(
+            _precompile_single_graph, backend="eager", dynamic=False
+        )
+        session.__enter__()
+        inner = session._session
+        with inner._state:
+            inner._active_calls = 1
+        with mock.patch.object(inner._state, "wait", side_effect=KeyboardInterrupt):
+            with self.assertRaises(KeyboardInterrupt):
+                session.__exit__(None, None, None)
+        self.assertFalse(inner._closing)
+        self.assertFalse(inner._finished)
+        self.assertIsNotNone(inner._stack)
+        with inner._state:
+            inner._active_calls = 0
+            inner._state.notify_all()
+        session.__exit__(None, None, None)
+        self.assertTrue(inner._finished)
+
+    @torch._dynamo.config.patch(accumulated_recompile_limit=2)
+    def test_multi_graph_recompile_limit_overrides_accumulated_limit(self):
+        inputs = [torch.randn(n, 8) for n in (2, 3, 4)]
+        session = _precompile_capture(
+            _precompile_multi_graph,
+            backend="eager",
+            dynamic=False,
+            recompile_limit=20,
+        )
+        with session as compiled:
+            for x in inputs:
+                self.assertEqual(compiled(x), _precompile_multi_graph(x))
+
+        summary = session.summary()
+        self.assertTrue(summary.complete)
+        self.assertEqual(summary.truncated, ())
+        self.assertEqual(summary.guarded_codes, 3 * len(inputs))
+
+    def test_multi_graph_capture_isolated_from_existing_compile_entries(self):
+        warm = torch.compile(_precompile_multi_graph, backend="eager", dynamic=False)
+        for n in (2, 3):
+            x = torch.randn(n, 8)
+            self.assertEqual(warm(x), _precompile_multi_graph(x))
+
+        x = torch.randn(4, 8)
+        session = _precompile_capture(
+            _precompile_multi_graph,
+            backend="eager",
+            dynamic=False,
+            recompile_limit=2,
+        )
+        with session as compiled:
+            self.assertEqual(compiled(x), _precompile_multi_graph(x))
+
+        summary = session.summary()
+        self.assertTrue(summary.complete)
+        self.assertEqual(summary.truncated, ())
+        self.assertEqual(summary.uncovered_frames, ())
+        self.assertEqual(summary.guarded_codes, 3)
+
+    def test_multi_graph_session_is_one_shot(self):
+        session = _precompile_capture(
+            _precompile_single_graph,
+            backend="eager",
+            dynamic=False,
+            recompile_limit=2,
+        )
+        x = torch.randn(2)
+        with session as compiled:
+            self.assertEqual(compiled(x), _precompile_single_graph(x))
+        with self.assertRaisesRegex(RuntimeError, "cannot be re-entered"):
+            with session:
+                pass
+
+    @torch._dynamo.config.patch(accumulated_recompile_limit=2, recompile_limit=8)
+    def test_multi_graph_active_capture_does_not_limit_ordinary_compile(self):
+        from torch._C._dynamo.eval_frame import get_code_exec_strategy
+        from torch._dynamo.types import FrameAction
+
+        torch._dynamo.reset()
+        session = _precompile_capture(
+            _precompile_single_graph,
+            backend="eager",
+            dynamic=False,
+            recompile_limit=20,
+        )
+        with session as captured:
+            for n in (2, 3):
+                x = torch.randn(n)
+                self.assertEqual(captured(x), _precompile_single_graph(x))
+
+            during = torch._dynamo.testing.CompileCounter()
+            ordinary = torch.compile(
+                _precompile_single_graph, backend=during, dynamic=False
+            )
+            x = torch.randn(4)
+            self.assertEqual(ordinary(x), _precompile_single_graph(x))
+            self.assertEqual(during.frame_count, 1)
+
+        after = torch._dynamo.testing.CompileCounter()
+        ordinary = torch.compile(_precompile_single_graph, backend=after, dynamic=False)
+        x = torch.randn(5)
+        self.assertEqual(ordinary(x), _precompile_single_graph(x))
+        self.assertEqual(after.frame_count, 1)
+        strategy = get_code_exec_strategy(_precompile_single_graph.__code__)
+        self.assertEqual(strategy.cur_action, FrameAction.DEFAULT)
+        self.assertEqual(strategy.recursive_action, FrameAction.DEFAULT)
+
+    @torch._dynamo.config.patch(
+        automatic_dynamic_shapes=True, assume_static_by_default=True
+    )
+    def test_multi_graph_capture_does_not_leak_auto_dynamic_state(self):
+        def ordinary_frame_count():
+            counter = torch._dynamo.testing.CompileCounter()
+            compiled = torch.compile(
+                _precompile_single_graph, backend=counter, dynamic=None
+            )
+            for n in (4, 5):
+                x = torch.randn(n)
+                self.assertEqual(compiled(x), _precompile_single_graph(x))
+            return counter.frame_count
+
+        torch._dynamo.reset()
+        self.assertEqual(ordinary_frame_count(), 2)
+        torch._dynamo.reset()
+
+        session = _precompile_capture(
+            _precompile_single_graph, backend="eager", dynamic=None
+        )
+        with session as compiled:
+            for n in (2, 3):
+                x = torch.randn(n)
+                self.assertEqual(compiled(x), _precompile_single_graph(x))
+
+        self.assertEqual(ordinary_frame_count(), 2)
+
+    @parametrize("backend", ["eager", "inductor"])
+    def test_multi_graph_round_trip_exercised_empty_resume(self, backend):
+        x = torch.arange(3.0)
+        expected = [_precompile_empty_resume(x, flag) for flag in (False, True)]
+        session = _precompile_capture(
+            _precompile_empty_resume,
+            backend=backend,
+            dynamic=False,
+            example_inputs=[(x, False), (x, True)],
+        )
+        with session:
+            pass
+        self.assertTrue(session.summary().complete)
+
+        code, cache = session.artifact(require_no_dropped_guards=False)
+        torch._dynamo.reset()
+        with self.assertLogs("torch._precompile", level="WARNING"):
+            loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            for flag, want in zip((False, True), expected):
+                self.assertEqual(loaded(x, flag), want)
+
+    @parametrize("backend", ["eager", "inductor"])
+    def test_multi_graph_explicit_artifact_does_not_retain_global_backends(
+        self, backend
+    ):
+        PrecompileContext.clear()
+        try:
+            x = torch.randn(2, 8)
+            session = _precompile_capture(
+                _precompile_multi_graph,
+                backend=backend,
+                dynamic=False,
+                example_inputs=[(x,)],
+            )
+            with session:
+                pass
+            self.assertEqual(PrecompileContext._backend_artifacts_by_key, {})
+            code, cache = session.artifact(require_no_dropped_guards=False)
+            self.assertEqual(PrecompileContext._backend_artifacts_by_key, {})
+
+            torch._dynamo.reset()
+            with self.assertLogs("torch._precompile", level="WARNING"):
+                loaded = torch.compiler.precompile.load(code, cache)
+            # The artifact carries its own backends; loading must not file them
+            # into the process-global context the transparent cache uses.
+            self.assertEqual(PrecompileContext._backend_artifacts_by_key, {})
+            with torch.no_grad():
+                loaded(x)
+            self.assertEqual(PrecompileContext._backend_artifacts_by_key, {})
+        finally:
+            PrecompileContext.clear()
+
+    def test_example_inputs_accepts_keyword_calls_and_rejects_a_bare_container(self):
+        # The TypeErrors here name torch.compiler.precompile.ExampleInput, so
+        # both the type and the path have to keep working.
+        def fn(x, scale=1):
+            return x * scale
+
+        x = torch.randn(3)
+        example_input = torch.compiler.precompile.ExampleInput
+        session = _precompile_capture(
+            fn,
+            backend="eager",
+            dynamic=False,
+            example_inputs=[(x,), example_input(args=(x,), kwargs={"scale": 2})],
+        )
+        with session:
+            pass
+        self.assertEqual(session.summary().guarded_codes, 2)
+
+        # The likeliest mistake is passing the tensors instead of a sequence of
+        # calls. A one-element tensor is falsy, so the old `example_inputs or ()`
+        # accepted it as "no examples" and only failed much later at save().
+        for bad in (x, torch.zeros(1), torch.nn.Linear(2, 2)):
+            with self.assertRaisesRegex(TypeError, "example_inputs takes a sequence"):
+                torch.compiler.precompile(
+                    fn,
+                    backend="eager",
+                    training=True,
+                    tracer="dynamo",
+                    example_inputs=bad,
+                )
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_mark_unbacked_runs_across_sizes(self, backend):
+        # Dynamic shapes are opt-in via mark_unbacked for the dynamo tracer too: Dynamo
+        # captures the marked dim as an UNBACKED symint, so the ONE artifact serves any
+        # runtime size of that dim on either backend (the make_fx tracer's eager backend
+        # rejects dynamic dims; the dynamo subgraph carries its own runtime asserts, so it
+        # does not have to).
+        m = torch.nn.Sequential(
+            torch.nn.Linear(4, 8), torch.nn.ReLU(), torch.nn.Linear(8, 3)
+        ).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+            backend=backend,
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            for bs in (8, 16, 1, 0):
+                xt = torch.randn(bs, 4)
+                self.assertEqual(f_c(m, xt), m(xt))
+
+    def test_tracer_dynamo_mark_unbacked_bounds_enforced(self):
+        # mark_unbacked's min/max become ShapeEnv runtime asserts, which Dynamo emits into
+        # the subgraph itself -- so the artifact rejects an out-of-range runtime size even
+        # though the thin dynamo driver has no bounds check of its own (the make_fx tracer
+        # instead re-checks the bounds in its driver).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0, min=4, max=16)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        self.assertEqual(f_c(m, torch.randn(6, 4)).shape, (6, 3))
+        with self.assertRaisesRegex(RuntimeError, "no captured variant"):
+            f_c(m, torch.randn(2, 4))
+
+    def test_tracer_dynamo_mark_unbacked_shape_id_mismatch_rejected(self):
+        # Two dims sharing a shape_id bind to ONE unbacked symbol, so their sizes must be
+        # equal at runtime; the equality is enforced by the captured graph's own assert.
+        m = torch.nn.Linear(4, 4).eval()
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 4)
+        mark_unbacked(x, 0, shape_id="b")
+        mark_unbacked(y, 0, shape_id="b")
+        code, cache = torch.compiler.precompile(
+            lambda model, a, b: model(a) + b,
+            example_inputs=[(m, x, y)],
+            training=True,
+            tracer="dynamo",
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        a, b = torch.randn(3, 4), torch.randn(3, 4)
+        self.assertEqual(f_c(m, a, b), m(a) + b)
+        with self.assertRaises((RuntimeError, AssertionError)):
+            f_c(m, torch.randn(3, 4), torch.randn(5, 4))
+
+    def test_tracer_dynamo_mark_unbacked_hint_override_honored(self):
+        # hint_override is a perf-only autotuning size hint (never a guard), so it is not
+        # rejected here either: Dynamo threads it onto the symbol during fakeification and
+        # the single artifact stays valid for any runtime size.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(8, 4)
+        mark_unbacked(x, 0, hint_override=16)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+        )
+        f_c = torch.compiler.precompile.load(code, cache)
+        # Fresh, UNMARKED tensors: the mark itself is guarded
+        # (_has_dynamo_dim_marking), so passing the marked example back in at
+        # serve time misses every variant.
+        for xt in (torch.randn(8, 4), torch.randn(32, 4)):
+            self.assertEqual(f_c(m, xt), m(xt))
+
+    def test_tracer_dynamo_cross_tracer_cache_rejected(self):
+        # A cache from the make_fx tracer paired with dynamo python_code is a mismatched
+        # pairing and must be rejected (the code_hash and the tracer tag both catch it),
+        # not run under foreign metadata.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        dyn_code, _ = torch.compiler.precompile(
+            lambda model, xx: model(xx), example_inputs=[(m, x)], tracer="dynamo"
+        )
+        _, mf_cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), example_inputs=[(m, x)]
+        )
+        with self.assertRaisesRegex(PrecompileError, "tracer"):
+            torch.compiler.precompile.load(dyn_code, mf_cache)
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_returned_global_constant_baked(self, backend):
+        # A plain module-level constant folded straight into fn's output is referenced by
+        # the transformed bytecode but is NOT a graph input, so it must be baked into the
+        # artifact (else it would NameError at load). Baking a non-tensor constant is
+        # consistent with the specialization contract; check both backends.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def with_scale(model, xx):
+            return model(xx), _GLOBAL_SCALE
+
+        code, cache = torch.compiler.precompile(
+            with_scale,
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+            backend=backend,
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            out = f_c(m, x)
+            self.assertEqual(out[0], m(x))
+            self.assertEqual(out[1], _GLOBAL_SCALE)
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_nested_multi_tensor_output(self, backend):
+        # Under dynamo the transformed bytecode (NOT the driver's OUT_SPEC path make_fx uses)
+        # reassembles fn's output, so a multi-tensor / nested output exercises a distinct
+        # mechanism: the subgraph returns several tensors in a fixed order the bytecode must
+        # re-thread into the tuple/dict. Assert each leaf on both backends (a mis-ordered
+        # flatten or a dropped dict leaf would silently corrupt the output structure).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def f(model, xx):
+            y = model(xx)
+            return y, y * 2, {"k": y + 1}
+
+        code, cache = torch.compiler.precompile(
+            f, example_inputs=[(m, x)], training=True, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            out = f_c(m, x)
+            ref = f(m, x)
+            self.assertEqual(out[0], ref[0])
+            self.assertEqual(out[1], ref[1])
+            self.assertEqual(out[2]["k"], ref[2]["k"])
+
+    def test_tracer_dynamo_nontensor_output_inductor_ok(self):
+        # DIVERGENCE from make_fx: Dynamo puts a non-tensor Python output (float / complex /
+        # str) in the transformed bytecode, not the subgraph inductor lowers, so it round-
+        # trips on tracer='dynamo' + backend='inductor' where make_fx REJECTS the same output
+        # (test_nontensor_output_inductor_clean_error). Pin that so a regression to make_fx's
+        # rejection under dynamo is caught. The value is folded as a default arg (baked).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        for val in (3.14, 2 + 3j, "hi"):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx, b=val: (model(xx), b),
+                example_inputs=[(m, x)],
+                training=True,
+                tracer="dynamo",
+                backend="inductor",
+            )
+            for _label, f_c in _default_and_inlined_loaders(code, cache, "inductor"):
+                out = f_c(m, x)
+                self.assertEqual(out[0], m(x))
+                self.assertEqual(out[1], val)
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_dtensor_subclass(self, backend):
+        # The dynamo-tracer analog of test_dtensor_subclass: a DTensor param/input must
+        # round-trip on both backends. The dynamo eager emit inlines the subgraph against an
+        # empty _GraphSelf and splats flat args, and inductor lowers via AOTAutograd's subclass
+        # wrap/unwrap -- neither is exercised by the dense-input dynamo tests, so cover both.
+        import torch.distributed as dist
+
+        if not dist.is_available() or not dist.is_gloo_available():
+            self.skipTest("gloo not available")
+
+        from torch.distributed.tensor import DeviceMesh, distribute_tensor, Replicate
+        from torch.testing._internal.common_utils import find_free_port
+
+        saved_env = {k: os.environ.get(k) for k in ("MASTER_ADDR", "MASTER_PORT")}
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        dist.init_process_group("gloo", rank=0, world_size=1)
+        try:
+            mesh = DeviceMesh("cpu", list(range(1)))
+            m = torch.nn.Linear(4, 3).eval()
+            for name, p in list(m.named_parameters()):
+                setattr(
+                    m,
+                    name,
+                    torch.nn.Parameter(
+                        distribute_tensor(p.detach(), mesh, [Replicate()])
+                    ),
+                )
+            x = distribute_tensor(torch.randn(5, 4), mesh, [Replicate()])
+            ref = m(x)
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx),
+                example_inputs=[(m, x)],
+                training=True,
+                tracer="dynamo",
+                backend=backend,
+            )
+            # Exercise BOTH reload paths on the DTensor artifact: load() takes the
+            # bundled-artifact path (primes the cache, then execs python_code), while the
+            # direct exec below runs the self-contained python_code with no cache.
+            f_c = torch.compiler.precompile.load(code, cache)
+            self.assertEqual(f_c(m, x).to_local(), ref.to_local())
+            ns = {"__name__": "_dt"}
+            exec(compile(code, "<dt>", "exec"), ns)
+            self.assertEqual(ns["forward"](m, x).to_local(), ref.to_local())
+        finally:
+            dist.destroy_process_group()
+            for k, v in saved_env.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+    def test_tracer_dynamo_module_fn_folded_global(self):
+        # When fn IS an nn.Module, Dynamo traces fn.forward, whose globals live in the
+        # traced code's f_globals -- not fn.__globals__ (an nn.Module has none). A
+        # module-level constant folded into the output must still be carried into the
+        # artifact from that traced-code globals dict; otherwise the reload NameErrors.
+        # Regression for resolving uncovered external_refs via gco.f_globals.
+        m = _PrecompileFoldsAGlobal().eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            m, example_inputs=[(x,)], training=True, tracer="dynamo"
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, "inductor"):
+            out = f_c(m, x)
+            self.assertEqual(out[0], m(x)[0])
+            self.assertEqual(out[1], _GLOBAL_SCALE)
+
+    def test_tracer_dynamo_by_reference_callable_not_rejected(self):
+        # A tensor merely ATTACHED to a by-reference object (a module-level function,
+        # pickled by reference and re-imported at load) is NOT baked by value, so it must
+        # NOT trigger the invariant-1 rejection. The scan keys off what pickle serializes
+        # by value, not on attribute presence -- avoiding a false positive.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: (model(xx), _global_helper_with_attr),
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+            backend="eager",
+        )
+        out = torch.compiler.precompile.load(code, cache)(m, x)
+        self.assertEqual(out[0], m(x))
+        self.assertIs(out[1], _global_helper_with_attr)
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_closure_entry_is_refused(self, backend):
+        # Defaults the artifact carries beside the code object; closure cells it
+        # cannot. Dynamo guards a cell by IDENTITY, so a cell rebuilt at load
+        # holding the same value is a different object and misses every variant.
+        # Refuse at capture, where the closure is visible, rather than ship an
+        # artifact that loads and then never matches.
+        def make(sc, cf):
+            return lambda model, xx: model(xx) * sc + cf["bias"]
+
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        with self.assertRaisesRegex(PrecompileError, "closes over"):
+            torch.compiler.precompile(
+                make(3.0, {"bias": 1.0}),
+                example_inputs=[(m, x)],
+                tracer="dynamo",
+                backend=backend,
+            )
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_defaults_roundtrip(self, backend):
+        # fn with a positional default and a keyword-only default drives the driver's
+        # argdefs / kwdefaults restoration; the defaults must be honored at the runtime
+        # call (omitting them would TypeError / use a wrong value if they were dropped).
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+
+        def fn(model, xx, scale=2.0, *, bias=1.0):
+            return model(xx) * scale + bias
+
+        code, cache = torch.compiler.precompile(
+            fn, example_inputs=[(m, x)], training=True, tracer="dynamo", backend=backend
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), fn(m, x))
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_multiple_module_args(self, backend):
+        # Two separate nn.Module args exercise the len(mods)>1 interning path and the
+        # unboxed->boxed subgraph bridge with graph inputs from two distinct modules; a
+        # structurally identical swap confirms no weights are baked (invariant 2).
+        a = torch.nn.Linear(4, 3).eval()
+        b = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda ma, mb, xx: ma(xx) + mb(xx),
+            example_inputs=[(a, b, x)],
+            training=True,
+            tracer="dynamo",
+            backend=backend,
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(a, b, x), a(x) + b(x))
+            a2 = torch.nn.Linear(4, 3).eval()
+            b2 = torch.nn.Linear(4, 3).eval()
+            self.assertEqual(f_c(a2, b2, x), a2(x) + b2(x))
+
+    @parametrize("backend", ["inductor", "eager"])
+    def test_tracer_dynamo_tied_weights_roundtrip(self, backend):
+        # A module with a tied weight (two Linears sharing one weight tensor) round-trips
+        # under the dynamo tracer; the shared weight must be read consistently at runtime,
+        # so a mis-interned or duplicated read would surface as a wrong result here.
+        m = _PrecompileTiedWeights().eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+            backend=backend,
+        )
+        for _label, f_c in _default_and_inlined_loaders(code, cache, backend):
+            self.assertEqual(f_c(m, x), m(x))
+
+    def test_tracer_dynamo_static_under_dynamic_config(self):
+        # The dynamo tracer must capture STATIC shapes like the make_fx tracer (invariant 3)
+        # regardless of the ambient torch._dynamo config OR per-code-object shape history:
+        # precompile pins both assume_static_by_default and automatic_dynamic_shapes, so
+        # neither a globally flipped default (a) nor a prior precompile of the SAME fn at
+        # another shape (b, reachable with DEFAULT config) yields an out-of-contract dynamic
+        # artifact. Without the pins the eager subgraph would carry a SymInt dim.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        with torch._dynamo.config.patch(assume_static_by_default=False):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx),
+                example_inputs=[(m, x)],
+                training=True,
+                tracer="dynamo",
+                backend="eager",
+            )
+        self.assertNotIn("SymInt", code)
+        self.assertEqual(torch.compiler.precompile.load(code, cache)(m, x), m(x))
+
+        # (b) automatic_dynamic (on by DEFAULT): precompiling the SAME fn (one code object)
+        # first at one shape then another would otherwise promote the batch dim to dynamic on
+        # the second capture. Reuse one fn across two shapes; both must stay static.
+        def f(model, xx):
+            return model(xx)
+
+        c1, _ = torch.compiler.precompile(
+            f,
+            example_inputs=[(m, torch.randn(5, 4))],
+            training=True,
+            tracer="dynamo",
+            backend="eager",
+        )
+        c2, _ = torch.compiler.precompile(
+            f,
+            example_inputs=[(m, torch.randn(7, 4))],
+            training=True,
+            tracer="dynamo",
+            backend="eager",
+        )
+        self.assertNotIn("SymInt", c1)
+        self.assertNotIn("SymInt", c2)
+
+    def test_load_cache_without_tracer_key(self):
+        # BC: a cache produced before the dynamo tracer existed carries no "tracer" key in
+        # its envelope. load() must still pair it with its make_fx python_code via the
+        # blob.get("tracer", "make_fx") default rather than KeyError. Simulate a legacy
+        # envelope by deleting the key. Assert the cache envelope was actually CONSUMED (no
+        # "could not read the cache envelope" warning): a KeyError from a reverted fix would
+        # be swallowed by load()'s except and fall back to JIT, which still returns the
+        # right answer -- so an output-only assertion would not guard the .get default.
+        m = torch.nn.Linear(4, 3).eval()
+        x = torch.randn(5, 4)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), example_inputs=[(m, x)]
+        )
+        blob = torch.load(io.BytesIO(cache), weights_only=True)
+        del blob["tracer"]
+        buf = io.BytesIO()
+        torch.save(blob, buf)
+        with self.assertLogs("torch._precompile", level="WARNING") as cm:
+            f_c = torch.compiler.precompile.load(code, buf.getvalue())
+        self.assertFalse(
+            any("could not read the cache envelope" in msg for msg in cm.output),
+            f"legacy cache envelope was not consumed (fell back to JIT): {cm.output}",
+        )
+        self.assertEqual(f_c(m, x), m(x))
 
     def test_tracer_invalid_raises(self):
         a, b = torch.randn(4, 4), torch.randn(4, 4)
         with self.assertRaisesRegex(ValueError, "tracer must be 'make_fx' or 'dynamo'"):
-            torch.compiler.precompile(lambda x, y: x + y, a, b, tracer="nope")
+            torch.compiler.precompile(
+                lambda x, y: x + y, example_inputs=[(a, b)], tracer="nope"
+            )
 
     def test_backend_default_is_inductor(self):
         # The default lowers through Inductor: the generated code inlines the Inductor
@@ -892,7 +3380,9 @@ class TestPrecompile(TestCase):
         # form is only emitted when config.graph_partition is on, which is off in fbcode).
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, _ = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, _ = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         self.assertIn("Inductor output code", code)
 
     def test_inductor_graph_partition_off(self):
@@ -905,7 +3395,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
         with ind_config.patch(graph_partition=False):
-            code, cache = torch.compiler.precompile(lambda model, xx: model(xx), m, x)
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx), example_inputs=[(m, x)]
+            )
             self.assertNotIn("call = runner.call", code)  # non-partition form
             f_c = torch.compiler.precompile.load(code, cache)
             self.assertEqual(f_c(m, x), m(x))
@@ -925,7 +3417,7 @@ class TestPrecompile(TestCase):
         ):
             with ind_config.patch(**patch):
                 code, cache = torch.compiler.precompile(
-                    lambda model, xx: model(xx), m, x
+                    lambda model, xx: model(xx), example_inputs=[(m, x)]
                 )
                 # No saveable artifact when caches are off; the cache is empty.
                 blob = torch.load(io.BytesIO(cache), weights_only=True)
@@ -948,7 +3440,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
         with ind_config.patch(cpp_wrapper=True):
-            code, cache = torch.compiler.precompile(lambda model, xx: model(xx), m, x)
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx), example_inputs=[(m, x)]
+            )
             f_c = torch.compiler.precompile.load(code, cache)
             self.assertEqual(f_c(m, x), m(x))
 
@@ -967,7 +3461,7 @@ class TestPrecompile(TestCase):
             raise ValueError("boom")
 
         with self.assertRaisesRegex(ValueError, "boom"):
-            torch.compiler.precompile(boom, m, x)
+            torch.compiler.precompile(boom, example_inputs=[(m, x)])
         for n, p in m.named_parameters():
             self.assertIsNone(p.grad, f"{n}: example .grad must be restored on failure")
 
@@ -984,7 +3478,9 @@ class TestPrecompile(TestCase):
         m(x).sum().backward()  # warmup: populate .grad before precompile
         saved = {n: p.grad.clone() for n, p in m.named_parameters()}
         mark_unbacked(x, 0)
-        code, _ = torch.compiler.precompile(lambda mm, t: mm(t).sum().backward(), m, x)
+        code, _ = torch.compiler.precompile(
+            lambda mm, t: mm(t).sum().backward(), example_inputs=[(m, x)]
+        )
         self.assertIn("USER_INPUT_SHAPES = [(None, 4)]", code)  # dim 0 is dynamic
         for n, p in m.named_parameters():
             self.assertEqual(p.grad, saved[n])  # warmup grad restored, not clobbered
@@ -997,7 +3493,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, x: model(x), m, x, backend="eager"
+            lambda model, x: model(x), example_inputs=[(m, x)], backend="eager"
         )
         self.assertIn('backend="eager"', code)
         self.assertNotIn("call = runner.call", code)
@@ -1011,7 +3507,8 @@ class TestPrecompile(TestCase):
 
         blob = torch.load(io.BytesIO(cache), weights_only=False)
         self.assertEqual(
-            set(blob), {"artifact", "format", "version", "backend", "code_hash"}
+            set(blob),
+            {"artifact", "format", "version", "backend", "tracer", "code_hash"},
         )
         self.assertIsNone(blob["artifact"])  # eager has no compiled blob to bundle
         self.assertEqual(blob["format"], _CACHE_FORMAT)
@@ -1024,7 +3521,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 3), torch.nn.ReLU()).eval()
         x = torch.randn(5, 4)
         code, _cache = torch.compiler.precompile(
-            lambda model, x: model(x), m, x, backend="eager"
+            lambda model, x: model(x), example_inputs=[(m, x)], backend="eager"
         )
 
         ns = {"__name__": "_eager"}
@@ -1044,7 +3541,7 @@ class TestPrecompile(TestCase):
         grad_before = m.weight.grad.clone()
 
         code, cache = torch.compiler.precompile(
-            lambda model, xx: model(xx).sum().backward(), m, x
+            lambda model, xx: model(xx).sum().backward(), example_inputs=[(m, x)]
         )
         # Capture must not mutate the example model's pre-existing grad (restored).
         self.assertEqual(m.weight.grad, grad_before)
@@ -1067,16 +3564,18 @@ class TestPrecompile(TestCase):
         x = torch.randn(2, 4)
         for bad in (3.14, 2 + 3j, "hi"):
             with self.assertRaisesRegex(PrecompileError, "non-tensor Python value"):
-                torch.compiler.precompile(lambda model, t, b=bad: (model(t), b), m, x)
+                torch.compiler.precompile(
+                    lambda model, t, b=bad: (model(t), b), example_inputs=[(m, x)]
+                )
         for extra in (7, None):
             code, cache = torch.compiler.precompile(
-                lambda model, t, e=extra: (model(t), e), m, x
+                lambda model, t, e=extra: (model(t), e), example_inputs=[(m, x)]
             )
             self.assertEqual(
                 torch.compiler.precompile.load(code, cache)(m, x)[1], extra
             )
         ecode, ecache = torch.compiler.precompile(
-            lambda model, t: (model(t), 3.14), m, x, backend="eager"
+            lambda model, t: (model(t), 3.14), example_inputs=[(m, x)], backend="eager"
         )
         self.assertEqual(torch.compiler.precompile.load(ecode, ecache)(m, x)[1], 3.14)
 
@@ -1090,7 +3589,9 @@ class TestPrecompile(TestCase):
             8, 6
         ).t()  # example: shape (6, 8), non-contiguous stride (1, 6)
         self.assertFalse(xex.is_contiguous())
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, xex)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, xex)]
+        )
         self.assertIn("assert_size_stride", code)  # the layout guard we convert
         xrt = torch.randn(6, 8)  # same shape, contiguous -> different layout
         with self.assertRaisesRegex(PrecompileError, "memory format"):
@@ -1106,7 +3607,7 @@ class TestPrecompile(TestCase):
         )
         # The eager backend accepts the differently-strided input.
         ecode, ecache = torch.compiler.precompile(
-            lambda model, t: model(t), m, xex, backend="eager"
+            lambda model, t: model(t), example_inputs=[(m, xex)], backend="eager"
         )
         self.assertEqual(torch.compiler.precompile.load(ecode, ecache)(m, xrt), m(xrt))
 
@@ -1120,7 +3621,9 @@ class TestPrecompile(TestCase):
         xex = torch.randn(8, 6).t()  # non-contiguous example, shape (6, 8)
         xrt = torch.randn(6, 8)  # same shape, contiguous -> different layout
         with ind_config.patch(size_asserts=False):
-            code, cache = torch.compiler.precompile(lambda model, t: model(t), m, xex)
+            code, cache = torch.compiler.precompile(
+                lambda model, t: model(t), example_inputs=[(m, xex)]
+            )
             with self.assertRaisesRegex(PrecompileError, "memory format"):
                 torch.compiler.precompile.load(code, cache)(m, xrt)  # cached path
             with self.assertRaisesRegex(PrecompileError, "memory format"):
@@ -1135,7 +3638,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(8, 5).eval()
         xex = torch.randn(6, 8)  # contiguous example
         xrt = torch.randn(7, 8)  # contiguous, different shape (same pytree structure)
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, xex)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, xex)]
+        )
         with self.assertRaisesRegex(PrecompileError, "shape"):
             torch.compiler.precompile.load(code, cache)(m, xrt)  # cached path
         with self.assertRaisesRegex(PrecompileError, "shape"):
@@ -1154,7 +3659,9 @@ class TestPrecompile(TestCase):
         # slice x[i:i+1] (size-1 dim with a wider stride) must RUN, not raise.
         m = torch.nn.Linear(4, 3).eval()
         xex = torch.randn(1, 4)  # contiguous, stride (4, 1)
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, xex)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, xex)]
+        )
         row = torch.randn(2, 8)[
             0:1, :4
         ]  # shape (1, 4), stride (8, 1): size-1 dim differs
@@ -1170,7 +3677,9 @@ class TestPrecompile(TestCase):
         # The numel==0 exemption must relax ONLY the (meaningless) stride check, not the
         # shape check: an empty runtime input whose shape differs from the example must
         # still raise invariant 3, not silently return the traced-shape output.
-        code, cache = torch.compiler.precompile(lambda t: t.sum(0), torch.randn(0, 4))
+        code, cache = torch.compiler.precompile(
+            lambda t: t.sum(0), example_inputs=[(torch.randn(0, 4),)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         with self.assertRaisesRegex(PrecompileError, "shape"):
             f_c(torch.randn(0, 6))
@@ -1188,7 +3697,9 @@ class TestPrecompile(TestCase):
         m = M().eval()
         x = torch.randn(4, 4)  # square so .t() keeps shape (4, 4)
         y = torch.randn(4, 4)
-        code, cache = torch.compiler.precompile(lambda mm, a, b: mm(a, b), m, x, y)
+        code, cache = torch.compiler.precompile(
+            lambda mm, a, b: mm(a, b), example_inputs=[(m, x, y)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         xt = x.t()  # same shape, different stride; only x.shape is consumed
         self.assertNotEqual(xt.stride(), x.stride())
@@ -1203,7 +3714,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(8, 4)
         mark_unbacked(x, 0)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(m, torch.randn(16, 4)).shape, (16, 3))  # dynamic dim free
         with self.assertRaisesRegex(PrecompileError, "dynamic dim"):
@@ -1222,7 +3735,7 @@ class TestPrecompile(TestCase):
             return mm(t) + 1
 
         with self.assertRaisesRegex(PrecompileError, "guard on a dim marked with"):
-            torch.compiler.precompile(needs_guard, m, x)
+            torch.compiler.precompile(needs_guard, example_inputs=[(m, x)])
 
     def test_dynamic_shapes_eager_rejected(self):
         m = torch.nn.Linear(4, 3).eval()
@@ -1231,7 +3744,9 @@ class TestPrecompile(TestCase):
         with self.assertRaisesRegex(
             NotImplementedError, "only supported with backend='inductor'"
         ):
-            torch.compiler.precompile(lambda mm, t: mm(t), m, x, backend="eager")
+            torch.compiler.precompile(
+                lambda mm, t: mm(t), example_inputs=[(m, x)], backend="eager"
+            )
 
     @parametrize("path", ("cached", "inlined"))
     def test_dtype_mismatch_rejected(self, path):
@@ -1239,7 +3754,9 @@ class TestPrecompile(TestCase):
         # a different dtype is rejected up front on BOTH the cached and inlined paths.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)  # float32 example
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, x)]
+        )
         if path == "inlined":
             cache = _strip_artifact(cache)
         f_c = torch.compiler.precompile.load(code, cache)
@@ -1253,7 +3770,9 @@ class TestPrecompile(TestCase):
         # artifact rejects a cuda input up front on BOTH load paths.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)  # cpu example
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, x)]
+        )
         if path == "inlined":
             cache = _strip_artifact(cache)
         f_c = torch.compiler.precompile.load(code, cache)
@@ -1268,7 +3787,7 @@ class TestPrecompile(TestCase):
         x = torch.randn(8, 4)
         mark_dynamic(x, 0)
         with self.assertRaisesRegex(PrecompileError, "mark_dynamic"):
-            torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+            torch.compiler.precompile(lambda mm, t: mm(t), example_inputs=[(m, x)])
 
     def test_mark_unbacked_hint_override_honored(self):
         # A mark_unbacked hint_override is a perf-only autotuning size hint (never a
@@ -1277,7 +3796,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(8, 4)
         mark_unbacked(x, 0, hint_override=16)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(m, x), m(x))
         x2 = torch.randn(32, 4)
@@ -1290,7 +3811,7 @@ class TestPrecompile(TestCase):
         x = torch.randn(8, 4)
         mark_unbacked(x, 0, specialize_on=[lambda t: t.shape[0] == 8])
         with self.assertRaisesRegex(PrecompileError, "specialize_on"):
-            torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+            torch.compiler.precompile(lambda mm, t: mm(t), example_inputs=[(m, x)])
 
     def test_mark_unbacked_subclass_rejected(self):
         # A mark_unbacked dim on a tensor subclass (DTensor) cannot be honored: the
@@ -1317,7 +3838,7 @@ class TestPrecompile(TestCase):
             x = distribute_tensor(torch.randn(8, 4), mesh, [Replicate()])
             mark_unbacked(x, 0)
             with self.assertRaisesRegex(PrecompileError, "tensor subclass"):
-                torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+                torch.compiler.precompile(lambda mm, t: mm(t), example_inputs=[(m, x)])
         finally:
             dist.destroy_process_group()
             for k, v in saved_env.items():
@@ -1339,7 +3860,9 @@ class TestPrecompile(TestCase):
         y = torch.randn(8, 4)
         mark_unbacked(x, 0, shape_id="b")
         mark_unbacked(y, 0, shape_id="b")
-        code, cache = torch.compiler.precompile(lambda mm, a, b: mm(a) + b, m, x, y)
+        code, cache = torch.compiler.precompile(
+            lambda mm, a, b: mm(a) + b, example_inputs=[(m, x, y)]
+        )
         if path == "inlined":
             blob = torch.load(io.BytesIO(cache), weights_only=True)
             blob["artifact"] = None
@@ -1364,7 +3887,9 @@ class TestPrecompile(TestCase):
         y = torch.randn(8, 4)
         mark_unbacked(x, 0, shape_id="b", min=2)
         mark_unbacked(y, 0, shape_id="b", max=64)
-        code, cache = torch.compiler.precompile(lambda mm, a, b: mm(a) + b, m, x, y)
+        code, cache = torch.compiler.precompile(
+            lambda mm, a, b: mm(a) + b, example_inputs=[(m, x, y)]
+        )
         if path == "inlined":
             blob = torch.load(io.BytesIO(cache), weights_only=True)
             blob["artifact"] = None
@@ -1393,7 +3918,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(8, 4)
         mark_unbacked(x, 0, min=4)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         self.assertIn("USER_INPUT_BOUNDS = [{0: (4, None)}]", code)
         if path == "inlined":
             blob = torch.load(io.BytesIO(cache), weights_only=True)
@@ -1413,7 +3940,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend="eager"
+            lambda model, t: model(t), example_inputs=[(m, x)], backend="eager"
         )
         f_c = torch.compiler.precompile.load(code, cache)
         with self.assertRaisesRegex(PrecompileError, "shape"):
@@ -1425,7 +3952,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend="eager"
+            lambda model, t: model(t), example_inputs=[(m, x)], backend="eager"
         )
         f_c = torch.compiler.precompile.load(code, cache)
         with self.assertRaisesRegex(PrecompileError, "dtype"):
@@ -1437,7 +3964,9 @@ class TestPrecompile(TestCase):
         # load() raise a clear PrecompileError rather than reconstruct a foreign cache.
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, x)]
+        )
         blob = torch.load(io.BytesIO(cache), weights_only=True)
         blob["backend"] = "eager"  # python_code says inductor
         buf = io.BytesIO()
@@ -1456,7 +3985,9 @@ class TestPrecompile(TestCase):
         # test_load_rejects_mismatched_code_cache_pair.)
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, x)]
+        )
         blob = torch.load(io.BytesIO(cache), weights_only=True)
         # Tamper either the format string or bump the version to a foreign value.
         blob[tag] = "not-a-precompile-cache" if tag == "format" else 999
@@ -1488,6 +4019,16 @@ class TestPrecompile(TestCase):
         ):
             torch.compiler.precompile.load("x = 1\n", buf.getvalue())
 
+    def test_nonliteral_calling_convention_metadata_rejected(self):
+        code, cache = torch.compiler.precompile(
+            lambda x: x.sin(), example_inputs=[(torch.randn(2),)], backend="eager"
+        )
+        bad_code = code.replace("BACKEND = 'eager'", "BACKEND = object()", 1)
+        with self.assertRaisesRegex(
+            PrecompileError, "BACKEND.*calling-convention metadata"
+        ):
+            torch.compiler.precompile.load(bad_code, cache)
+
     def test_singleton_pickle_deepcopy_roundtrip(self):
         # torch.compiler.precompile is a process-wide singleton; pickle and deepcopy
         # must round-trip to the SAME object (it carries no per-call state), and its
@@ -1505,7 +4046,7 @@ class TestPrecompile(TestCase):
         # exec used to hit. We write python_code to a temp file and exec it in a
         # subprocess that imports only torch, then runs forward().
         x = torch.randn(3, 4)
-        code, _cache = torch.compiler.precompile(lambda a: a.t(), x)
+        code, _cache = torch.compiler.precompile(lambda a: a.t(), example_inputs=[(x,)])
         self.assertIn("standalone_runtime import gen_alias_from_base", code)
         with tempfile.NamedTemporaryFile(
             "w", suffix=".py", delete=False
@@ -1548,8 +4089,12 @@ class TestPrecompile(TestCase):
         # silent-wrong-result guard). The MATCHED pair still runs and is correct.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        codeA, cacheA = torch.compiler.precompile(lambda mm, t: mm(t) * 2, m, x)
-        codeB, cacheB = torch.compiler.precompile(lambda mm, t: mm(t) + 100, m, x)
+        codeA, cacheA = torch.compiler.precompile(
+            lambda mm, t: mm(t) * 2, example_inputs=[(m, x)]
+        )
+        codeB, cacheB = torch.compiler.precompile(
+            lambda mm, t: mm(t) + 100, example_inputs=[(m, x)]
+        )
         self.assertNotEqual(codeA, codeB)
         with self.assertRaisesRegex(PrecompileError, "code_hash|does not match"):
             torch.compiler.precompile.load(codeA, cacheB)
@@ -1567,7 +4112,9 @@ class TestPrecompile(TestCase):
         # assertion and re-pair its code_hash, exercising the inlined relabel guard.
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         head = code[: code.index("\ndef call(")]
         banner = code.rindex(
             "# " + "=" * 70, 0, code.index("# 2. Calling-convention metadata")
@@ -1622,7 +4169,7 @@ class TestPrecompile(TestCase):
         m = WithBuf("buf").eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda mm, t: mm(t), m, x, backend=backend
+            lambda mm, t: mm(t), example_inputs=[(m, x)], backend=backend
         )
         self.assertIn("BUFFER_NAMES = ['buf']", code)
         renamed = WithBuf("buf2").eval()  # same params, buffer renamed (same shape)
@@ -1636,7 +4183,7 @@ class TestPrecompile(TestCase):
         # NOT restored -- only .grad is snapshotted/restored. Pin this surprising contract
         # so it stays covered: the example tensor reflects the mutation afterward.
         scratch = torch.zeros(4)
-        torch.compiler.precompile(lambda a: a.add_(1.0), scratch)
+        torch.compiler.precompile(lambda a: a.add_(1.0), example_inputs=[(scratch,)])
         self.assertEqual(scratch, torch.ones(4))
 
     @parametrize("path", ("cached", "inlined", "eager"))
@@ -1649,10 +4196,12 @@ class TestPrecompile(TestCase):
         x = torch.randn(5, 4)
         if path == "eager":
             code, cache = torch.compiler.precompile(
-                lambda mm, t: mm(t), m, x, backend="eager"
+                lambda mm, t: mm(t), example_inputs=[(m, x)], backend="eager"
             )
         else:
-            code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+            code, cache = torch.compiler.precompile(
+                lambda mm, t: mm(t), example_inputs=[(m, x)]
+            )
             if path == "inlined":
                 cache = _strip_artifact(cache)
         f_c = torch.compiler.precompile.load(code, cache)
@@ -1666,7 +4215,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)  # cpu example
         code, cache = torch.compiler.precompile(
-            lambda mm, t: mm(t), m, x, backend="eager"
+            lambda mm, t: mm(t), example_inputs=[(m, x)], backend="eager"
         )
         f_c = torch.compiler.precompile.load(code, cache)
         with self.assertRaisesRegex(PrecompileError, "device"):
@@ -1681,7 +4230,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         inp = _UnserializableCtxInput(torch.randn(5, 4), torch.randn(5, 4))
         code, cache = torch.compiler.precompile(
-            lambda model, h: model(h.a + h.b), m, inp
+            lambda model, h: model(h.a + h.b), example_inputs=[(m, inp)]
         )
         self.assertIn("IN_SPEC = None", code)
         f_c = torch.compiler.precompile.load(code, cache)
@@ -1703,7 +4252,9 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(8, 4)
         mark_unbacked(x, 0, max=16)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         self.assertIn("USER_INPUT_BOUNDS = [{0: (None, 16)}]", code)
         if path == "inlined":
             blob = torch.load(io.BytesIO(cache), weights_only=True)
@@ -1734,7 +4285,8 @@ class TestPrecompile(TestCase):
         x = torch.randn(64)
         with functorch_config.patch(functionalize_rng_ops=True):
             code, cache = torch.compiler.precompile(
-                lambda a: torch.nn.functional.dropout(a, 0.5, training=True), x
+                lambda a: torch.nn.functional.dropout(a, 0.5, training=True),
+                example_inputs=[(x,)],
             )
             f_c = torch.compiler.precompile.load(code, cache)
             torch.manual_seed(0)
@@ -1756,7 +4308,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()  # M = 3
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend=backend
+            lambda model, t: model(t), example_inputs=[(m, x)], backend=backend
         )
         bad = torch.nn.Linear(4, 7).eval()  # K = 7 != 3, same param names
 
@@ -1777,7 +4329,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3).eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend=backend
+            lambda model, t: model(t), example_inputs=[(m, x)], backend=backend
         )
         bad = torch.nn.Linear(4, 3).eval().half()  # same shape, different dtype
 
@@ -1808,7 +4360,7 @@ class TestPrecompile(TestCase):
         m = WithBuf(3, torch.float32).eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend=backend
+            lambda model, t: model(t), example_inputs=[(m, x)], backend=backend
         )
         self.assertIn("BUFFER_NAMES = ['b']", code)
         # Same buffer name and count, but a different SHAPE / DTYPE.
@@ -1831,7 +4383,9 @@ class TestPrecompile(TestCase):
         # backend is layout-flexible and ACCEPTS the same non-contiguous weight.
         m = torch.nn.Linear(8, 5).eval()
         x = torch.randn(4, 8)
-        code, cache = torch.compiler.precompile(lambda model, t: model(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, t: model(t), example_inputs=[(m, x)]
+        )
 
         def with_noncontig_weight():
             run = torch.nn.Linear(8, 5).eval()
@@ -1858,7 +4412,7 @@ class TestPrecompile(TestCase):
                     f_c(with_noncontig_weight(), x)
         # The eager backend accepts the same non-contiguous weight (layout-flexible).
         ecode, ecache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend="eager"
+            lambda model, t: model(t), example_inputs=[(m, x)], backend="eager"
         )
         run = with_noncontig_weight()
         self.assertEqual(torch.compiler.precompile.load(ecode, ecache)(run, x), run(x))
@@ -1884,7 +4438,7 @@ class TestPrecompile(TestCase):
         mark_unbacked(xs, 0, shape_id="b")
         mark_unbacked(ys, 0, shape_id="b")
         code_s, cache_s = torch.compiler.precompile(
-            lambda mm, a, b: mm(a) + b, m, xs, ys
+            lambda mm, a, b: mm(a) + b, example_inputs=[(m, xs, ys)]
         )
         f_s = torch.compiler.precompile.load(code_s, cache_s)
         xt, yt = torch.randn(8, 4), torch.randn(8, 4)
@@ -1898,7 +4452,7 @@ class TestPrecompile(TestCase):
         mark_unbacked(xi, 0)
         mark_unbacked(yi, 0)
         code_i, cache_i = torch.compiler.precompile(
-            lambda mm, a, b: mm(a) + b, m, xi, yi
+            lambda mm, a, b: mm(a) + b, example_inputs=[(m, xi, yi)]
         )
         f_i = torch.compiler.precompile.load(code_i, cache_i)
         xm, ym = torch.randn(10, 4), torch.randn(10, 4)
@@ -1918,7 +4472,9 @@ class TestPrecompile(TestCase):
         m(x).sum().backward()  # warmup populates .grad
         g = m.weight.grad
         self.assertIsNotNone(g)
-        torch.compiler.precompile(lambda mm, t: mm(t).sum().backward(), m, x)
+        torch.compiler.precompile(
+            lambda mm, t: mm(t).sum().backward(), example_inputs=[(m, x)]
+        )
         self.assertIs(m.weight.grad, g)  # same object, not a clone
 
     def test_precompile_error_public_binding(self):
@@ -1935,7 +4491,9 @@ class TestPrecompile(TestCase):
         # via the public torch.compiler.PrecompileError alias.
         captured = torch.randn(3)
         with self.assertRaisesRegex(torch.compiler.PrecompileError, "hard-coded"):
-            torch.compiler.precompile(lambda x: x + captured, torch.randn(3))
+            torch.compiler.precompile(
+                lambda x: x + captured, example_inputs=[(torch.randn(3),)]
+            )
 
     def test_single_trust_warning_on_inlined_load(self):
         # On the inlined load path (an eager artifact has an empty cache, so there is
@@ -1945,7 +4503,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 3)).eval()
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t), m, x, backend="eager"
+            lambda model, t: model(t), example_inputs=[(m, x)], backend="eager"
         )
         with self.assertLogs("torch._precompile", level="WARNING") as cm:
             torch.compiler.precompile.load(code, cache)
@@ -1972,7 +4530,7 @@ class TestPrecompile(TestCase):
         m = Tied()
         t = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t).sum().backward(), m, t
+            lambda model, t: model(t).sum().backward(), example_inputs=[(m, t)]
         )
         self.assertIn("PARAM_NAMES = ['l1.weight']", code)  # tie collapsed to one
 
@@ -1991,7 +4549,9 @@ class TestPrecompile(TestCase):
         m1 = torch.nn.Linear(4, 4)
         m2 = torch.nn.Linear(4, 3)
         t = torch.randn(5, 4)
-        code, cache = torch.compiler.precompile(lambda a, b, t: b(a(t)), m1, m2, t)
+        code, cache = torch.compiler.precompile(
+            lambda a, b, t: b(a(t)), example_inputs=[(m1, m2, t)]
+        )
         self.assertIn("MODULE_POSITIONS = [0, 1]", code)
         self.assertIn("m0.weight", code)  # first module's params prefixed m0.*
         self.assertIn("m1.weight", code)  # second module's params prefixed m1.*
@@ -2016,7 +4576,7 @@ class TestPrecompile(TestCase):
         m = M()
         t = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t).sum().backward(), m, t
+            lambda model, t: model(t).sum().backward(), example_inputs=[(m, t)]
         )
 
         ref = copy.deepcopy(m)
@@ -2042,7 +4602,7 @@ class TestPrecompile(TestCase):
         m = torch.nn.Linear(4, 3)  # params require grad at capture
         x = torch.randn(5, 4)
         code, cache = torch.compiler.precompile(
-            lambda mm, t: mm(t).sum().backward(), m, x
+            lambda mm, t: mm(t).sum().backward(), example_inputs=[(m, x)]
         )
         run = torch.nn.Linear(4, 3)
         run.load_state_dict(m.state_dict())
@@ -2056,6 +4616,14 @@ class TestPrecompile(TestCase):
         self.assertEqual(run.weight.grad, ref.weight.grad)
 
 
+def _graph_devices_literal(code: str) -> str:
+    """The GRAPH_DEVICES line the artifact records, for tests that assert on it."""
+    for line in code.splitlines():
+        if line.startswith("GRAPH_DEVICES"):
+            return line
+    raise AssertionError("artifact has no GRAPH_DEVICES line")
+
+
 @skipIfTorchDynamo("precompile's make_fx capture is incompatible with dynamo wrapping")
 class TestPrecompileNumerics(TestCase):
     # Numeric-correctness tests run device-generically so the same coverage
@@ -2067,7 +4635,7 @@ class TestPrecompileNumerics(TestCase):
 
         a = make_tensor((4, 4), device=device, dtype=torch.float32)
         b = make_tensor((4, 4), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(f, a, b)
+        code, cache = torch.compiler.precompile(f, example_inputs=[(a, b)])
         self.assertIsInstance(code, str)
         self.assertIsInstance(cache, bytes)
 
@@ -2089,7 +4657,9 @@ class TestPrecompileNumerics(TestCase):
 
         m = M().to(device).eval()
         x = make_tensor((5, 4), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(m, x), m(x))
 
@@ -2102,7 +4672,7 @@ class TestPrecompileNumerics(TestCase):
         ref = b(torch.relu(a(x)))
 
         code, cache = torch.compiler.precompile(
-            lambda ma, mb, x: mb(torch.relu(ma(x))), a, b, x
+            lambda ma, mb, x: mb(torch.relu(ma(x))), example_inputs=[(a, b, x)]
         )
         self.assertIn(
             "PARAM_NAMES = ['m0.weight', 'm0.bias', 'm1.weight', 'm1.bias']", code
@@ -2117,7 +4687,9 @@ class TestPrecompileNumerics(TestCase):
         m = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.ReLU(inplace=True))
         m.to(device).eval()
         x = make_tensor((5, 4), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(m, x), m(x))
 
@@ -2142,7 +4714,9 @@ class TestPrecompileNumerics(TestCase):
         def train_step(model, x, target):
             loss_fn(model(x), target).backward()
 
-        code, cache = torch.compiler.precompile(train_step, model, x, target)
+        code, cache = torch.compiler.precompile(
+            train_step, example_inputs=[(model, x, target)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
 
         # The model is passed at runtime (no weights baked); the artifact mutates
@@ -2188,7 +4762,9 @@ class TestPrecompileNumerics(TestCase):
         def train_step(model, x, target):
             loss_fn(model(x), target).backward()
 
-        code, cache = torch.compiler.precompile(train_step, model, x, target)
+        code, cache = torch.compiler.precompile(
+            train_step, example_inputs=[(model, x, target)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         f_c(model, x, target)
         for (n, p), (_, rp) in zip(model.named_parameters(), ref.named_parameters()):
@@ -2215,7 +4791,9 @@ class TestPrecompileNumerics(TestCase):
         def train_step(ma, mb, x, target):
             loss_fn(mb(torch.relu(ma(x))), target).backward()
 
-        code, cache = torch.compiler.precompile(train_step, a, b, x, target)
+        code, cache = torch.compiler.precompile(
+            train_step, example_inputs=[(a, b, x, target)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         f_c(a, b, x, target)
         for (n, p), (_, rp) in zip(a.named_parameters(), ref_a.named_parameters()):
@@ -2244,7 +4822,9 @@ class TestPrecompileNumerics(TestCase):
         m = Tied().to(device)
         x = make_tensor((3, 4), device=device, dtype=torch.float32)
 
-        code, cache = torch.compiler.precompile(lambda model, x: model(x), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda model, x: model(x), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(m, x), m(x))
         # The tied weight is lifted once (single name), so it is one graph input.
@@ -2257,7 +4837,7 @@ class TestPrecompileNumerics(TestCase):
         ref_grad = ref.a.weight.grad
 
         code, cache = torch.compiler.precompile(
-            lambda model, x: model(x).sum().backward(), m, x
+            lambda model, x: model(x).sum().backward(), example_inputs=[(m, x)]
         )
         f_c = torch.compiler.precompile.load(code, cache)
         f_c(m, x)
@@ -2272,7 +4852,9 @@ class TestPrecompileNumerics(TestCase):
 
         a = make_tensor((4, 4), device=device, dtype=torch.float32)
         b = make_tensor((4, 4), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(f, a, b, backend="eager")
+        code, cache = torch.compiler.precompile(
+            f, example_inputs=[(a, b)], backend="eager"
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         out = f_c(a, b)
         ref = f(a, b)
@@ -2284,7 +4866,7 @@ class TestPrecompileNumerics(TestCase):
         m.to(device).eval()
         x = make_tensor((5, 4), device=device, dtype=torch.float32)
         code, cache = torch.compiler.precompile(
-            lambda model, x: model(x), m, x, backend="eager"
+            lambda model, x: model(x), example_inputs=[(m, x)], backend="eager"
         )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(m, x), m(x))
@@ -2307,7 +4889,7 @@ class TestPrecompileNumerics(TestCase):
             loss_fn(model(x), target).backward()
 
         code, cache = torch.compiler.precompile(
-            train_step, model, x, target, backend="eager"
+            train_step, example_inputs=[(model, x, target)], backend="eager"
         )
         f_c = torch.compiler.precompile.load(code, cache)
         out = f_c(model, x, target)
@@ -2332,7 +4914,7 @@ class TestPrecompileNumerics(TestCase):
         ref_rm = ref[1].running_mean.clone()
 
         code, cache = torch.compiler.precompile(
-            lambda m, xx: m(xx), fresh(), x, backend="eager"
+            lambda m, xx: m(xx), example_inputs=[(fresh(), x)], backend="eager"
         )
         f_c = torch.compiler.precompile.load(code, cache)
         run = fresh()
@@ -2346,7 +4928,9 @@ class TestPrecompileNumerics(TestCase):
             return torch.relu(x).masked_fill(x < 0, float("-inf"))
 
         x = make_tensor((8,), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(f, x, backend="eager")
+        code, cache = torch.compiler.precompile(
+            f, example_inputs=[(x,)], backend="eager"
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(x), f(x))
 
@@ -2376,7 +4960,9 @@ class TestPrecompileNumerics(TestCase):
         def train_step(model, x, target):
             loss_fn(model(x), target).backward()
 
-        code, cache = torch.compiler.precompile(train_step, fresh(), x, target)
+        code, cache = torch.compiler.precompile(
+            train_step, example_inputs=[(fresh(), x, target)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         run = fresh()
         f_c(run, x, target)
@@ -2388,7 +4974,7 @@ class TestPrecompileNumerics(TestCase):
         # An output that is a view of an input goes through AOTAutograd's output-
         # alias epilogue; precompile reproduces it.
         x = make_tensor((2, 3), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(lambda a: a.t(), x)
+        code, cache = torch.compiler.precompile(lambda a: a.t(), example_inputs=[(x,)])
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(x), x.t())
 
@@ -2396,7 +4982,9 @@ class TestPrecompileNumerics(TestCase):
         # In-place input mutation is reflected on the passed tensor (and matches
         # eager), via AOTAutograd's mutation handling composed into the artifact.
         scratch = make_tensor((4,), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(lambda a: a.add_(1.0), scratch)
+        code, cache = torch.compiler.precompile(
+            lambda a: a.add_(1.0), example_inputs=[(scratch,)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         x = torch.zeros(4, device=device)
         out = f_c(x)
@@ -2415,7 +5003,8 @@ class TestPrecompileNumerics(TestCase):
         x = make_tensor((64,), device=device, dtype=torch.float32)
         with functorch_config.patch(functionalize_rng_ops=True):
             code, cache = torch.compiler.precompile(
-                lambda a: torch.nn.functional.dropout(a, 0.5, training=True), x
+                lambda a: torch.nn.functional.dropout(a, 0.5, training=True),
+                example_inputs=[(x,)],
             )
             f_c = torch.compiler.precompile.load(code, cache)
             out = f_c(x)
@@ -2433,7 +5022,9 @@ class TestPrecompileNumerics(TestCase):
             return m.to(device)
 
         x = make_tensor((8, 4), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(lambda model, xx: model(xx), fresh(), x)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx), example_inputs=[(fresh(), x)]
+        )
 
         ref = fresh()
         ref_out = ref(x)
@@ -2461,7 +5052,7 @@ class TestPrecompileNumerics(TestCase):
         ref_out = fn(ref, ref)
         run = t.clone()
 
-        code, cache = torch.compiler.precompile(fn, t, t)
+        code, cache = torch.compiler.precompile(fn, example_inputs=[(t, t)])
         f_c = torch.compiler.precompile.load(code, cache)
         out = f_c(run, run)
         self.assertEqual(out, ref_out)
@@ -2476,7 +5067,9 @@ class TestPrecompileNumerics(TestCase):
         m.to(device).eval()
         x = make_tensor((8, 4), device=device, dtype=torch.float32)
         mark_unbacked(x, 0)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         self.assertIn("USER_INPUT_SHAPES = [(None, 4)]", code)  # dim 0 dynamic
         f_c = torch.compiler.precompile.load(code, cache)
         blob = torch.load(io.BytesIO(cache), weights_only=True)
@@ -2498,7 +5091,7 @@ class TestPrecompileNumerics(TestCase):
         x = make_tensor((8, 4), device=device, dtype=torch.float32)
         mark_unbacked(x, 0)
         code, cache = torch.compiler.precompile(
-            lambda model, t: model(t).sum().backward(), m, x
+            lambda model, t: model(t).sum().backward(), example_inputs=[(m, x)]
         )
         f_c = torch.compiler.precompile.load(code, cache)
         for bs in (8, 16, 5):
@@ -2520,7 +5113,9 @@ class TestPrecompileNumerics(TestCase):
         y = make_tensor((8, 4), device=device, dtype=torch.float32)
         mark_unbacked(x, 0, shape_id="b")
         mark_unbacked(y, 0, shape_id="b")
-        code, cache = torch.compiler.precompile(lambda mm, a, b: mm(a) + b, m, x, y)
+        code, cache = torch.compiler.precompile(
+            lambda mm, a, b: mm(a) + b, example_inputs=[(m, x, y)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         for bs in (8, 16, 3):
             xt = make_tensor((bs, 4), device=device, dtype=torch.float32)
@@ -2534,7 +5129,9 @@ class TestPrecompileNumerics(TestCase):
         m = torch.nn.Linear(4, 3).to(device).eval()
         x = make_tensor((8, 4), device=device, dtype=torch.float32)
         mark_unbacked(x, 0, strict=True)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         self.assertIn("USER_INPUT_SHAPES = [(None, 4)]", code)
         f_c = torch.compiler.precompile.load(code, cache)
         for bs in (8, 16, 2):
@@ -2547,7 +5144,9 @@ class TestPrecompileNumerics(TestCase):
         m = torch.nn.Linear(4, 3).to(device).eval()
         x = make_tensor((8, 4), device=device, dtype=torch.float32)
         mark_unbacked(x, 0)
-        code, cache = torch.compiler.precompile(lambda mm, t: mm(t), m, x)
+        code, cache = torch.compiler.precompile(
+            lambda mm, t: mm(t), example_inputs=[(m, x)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         xt = make_tensor((0, 4), device=device, dtype=torch.float32)
         self.assertEqual(f_c(m, xt), m(xt))
@@ -2562,7 +5161,9 @@ class TestPrecompileNumerics(TestCase):
         x = x.to(memory_format=torch.channels_last)
         self.assertTrue(x.is_contiguous(memory_format=torch.channels_last))
         mark_unbacked(x, 0)
-        code, cache = torch.compiler.precompile(lambda t: torch.relu(t) * 2.0, x)
+        code, cache = torch.compiler.precompile(
+            lambda t: torch.relu(t) * 2.0, example_inputs=[(x,)]
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         xt = make_tensor((5, 3, 4, 4), device=device, dtype=torch.float32)
         xt = xt.to(memory_format=torch.channels_last)
@@ -2579,14 +5180,16 @@ class TestPrecompileNumerics(TestCase):
         self.assertFalse(x.is_contiguous())
         mark_unbacked(x, 0)
         with self.assertRaisesRegex(PrecompileError, "memory format"):
-            torch.compiler.precompile(lambda t: t.contiguous() * 2.0, x)
+            torch.compiler.precompile(
+                lambda t: t.contiguous() * 2.0, example_inputs=[(x,)]
+            )
 
     def test_eager_backend_input_mutation(self, device):
         # The eager backend replays the raw ATen graph, so input mutation is reflected on
         # the passed tensor and matches eager, like the inductor backend.
         scratch = make_tensor((4,), device=device, dtype=torch.float32)
         code, cache = torch.compiler.precompile(
-            lambda a: a.add_(1.0), scratch, backend="eager"
+            lambda a: a.add_(1.0), example_inputs=[(scratch,)], backend="eager"
         )
         f_c = torch.compiler.precompile.load(code, cache)
         x = torch.zeros(4, device=device)
@@ -2598,9 +5201,179 @@ class TestPrecompileNumerics(TestCase):
         # The eager backend reproduces an output that aliases an input (a view), matching
         # eager, via the raw ATen replay.
         x = make_tensor((2, 3), device=device, dtype=torch.float32)
-        code, cache = torch.compiler.precompile(lambda a: a.t(), x, backend="eager")
+        code, cache = torch.compiler.precompile(
+            lambda a: a.t(), example_inputs=[(x,)], backend="eager"
+        )
         f_c = torch.compiler.precompile.load(code, cache)
         self.assertEqual(f_c(x), x.t())
+
+    def test_tracer_dynamo_roundtrip_device(self, device):
+        # The dynamo tracer's inductor lowering emits device kernels (it lowers the
+        # Dynamo-produced subgraph through the same AOTAutograd + Inductor codegen as
+        # make_fx), and its eager backend inlines the subgraph as device-agnostic source.
+        # Run a numeric roundtrip device-generically -- like the make_fx numeric tests -- so
+        # the dynamo capture + subgraph lowering is exercised on CUDA, not only CPU. Both
+        # backends must round-trip to eager.
+        m = (
+            torch.nn.Sequential(
+                torch.nn.Linear(4, 4), torch.nn.ReLU(), torch.nn.Linear(4, 3)
+            )
+            .to(device)
+            .eval()
+        )
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        for backend in ("inductor", "eager"):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx),
+                example_inputs=[(m, x)],
+                training=True,
+                tracer="dynamo",
+                backend=backend,
+            )
+            f_c = torch.compiler.precompile.load(code, cache)
+            self.assertEqual(f_c(m, x), m(x))
+
+    def test_tracer_dynamo_dynamic_shapes_device(self, device):
+        # The dynamo tracer's mark_unbacked capture, run device-generically: the unbacked
+        # symint reaches the inductor lowering (CUDA kernels included) and the eager
+        # backend inlines the symbolic subgraph, so one artifact matches eager across
+        # runtime batch sizes on either backend.
+        m = torch.nn.Sequential(
+            torch.nn.Linear(4, 8), torch.nn.ReLU(), torch.nn.Linear(8, 3)
+        )
+        m.to(device).eval()
+        x = make_tensor((8, 4), device=device, dtype=torch.float32)
+        mark_unbacked(x, 0)
+        for backend in ("inductor", "eager"):
+            code, cache = torch.compiler.precompile(
+                lambda model, xx: model(xx),
+                example_inputs=[(m, x)],
+                training=True,
+                tracer="dynamo",
+                backend=backend,
+            )
+            f_c = torch.compiler.precompile.load(code, cache)
+            for bs in (8, 16, 1):
+                xt = make_tensor((bs, 4), device=device, dtype=torch.float32)
+                self.assertEqual(f_c(m, xt), m(xt))
+
+    # make_fx only. That artifact checks NO guards, so ambient autocast in the
+    # serving process must not reach it -- the driver pins the state the capture
+    # recorded, keyed off the GRAPH's devices (GRAPH_DEVICES), not the runtime
+    # tensors'. The dynamo tracer mirrors torch.compile instead: autocast is part
+    # of the guarded global state, so a serving process whose autocast differs
+    # from capture misses rather than being silently pinned.
+    @parametrize("backend", ("eager", "inductor"))
+    def test_artifact_reproduces_capture_time_autocast(self, device, backend):
+        tracer = "make_fx"
+
+        def fn(model, xx):
+            return model(xx)
+
+        device_type = torch.device(device).type
+        model = torch.nn.Linear(8, 8).to(device).eval()
+        x = make_tensor((4, 8), device=device, dtype=torch.float32)
+
+        with torch.no_grad(), torch.autocast(device_type, dtype=torch.bfloat16):
+            hot_code, hot_cache = torch.compiler.precompile(
+                fn, example_inputs=[(model, x)], backend=backend, tracer=tracer
+            )
+        with torch.no_grad():
+            cold_code, cold_cache = torch.compiler.precompile(
+                fn, example_inputs=[(model, x)], backend=backend, tracer=tracer
+            )
+
+        for code, cache, captured_under_autocast in (
+            (hot_code, hot_cache, True),
+            (cold_code, cold_cache, False),
+        ):
+            loaded = torch.compiler.precompile.load(code, cache)
+            with torch.no_grad():
+                plain = loaded(model, x)
+            with torch.no_grad(), torch.autocast(device_type, dtype=torch.bfloat16):
+                under = loaded(model, x)
+            expected = torch.bfloat16 if captured_under_autocast else torch.float32
+            self.assertEqual(plain.dtype, expected)
+            # Serving under an autocast the capture did not see must change
+            # nothing at all, not merely keep the dtype.
+            self.assertEqual(under.dtype, expected)
+            self.assertEqual(plain, under)
+
+    def test_artifact_autocast_covers_a_device_no_input_lives_on(self, device):
+        # GRAPH_DEVICES comes from the captured graph: a fn that moves to
+        # another device mid-way dispatches somewhere no param or input lives,
+        # which a scan of the runtime tensors cannot see.
+        device_type = torch.device(device).type
+        if device_type == "cpu":
+            raise unittest.SkipTest("needs a second device")
+
+        def fn(model, xx):
+            y = model(xx)
+            moved = y.to(device)
+            return torch.mm(moved, moved.t())
+
+        model = torch.nn.Linear(8, 8).eval()  # stays on cpu
+        x = make_tensor((4, 8), device="cpu", dtype=torch.float32)
+        with torch.no_grad():
+            code, cache = torch.compiler.precompile(
+                fn, example_inputs=[(model, x)], backend="eager"
+            )
+        devices = _graph_devices_literal(code)
+        self.assertIn(f"'{device_type}'", devices)
+        self.assertIn("'cpu'", devices)
+
+        loaded = torch.compiler.precompile.load(code, cache)
+        with torch.no_grad():
+            plain = loaded(model, x)
+        with torch.no_grad(), torch.autocast(device_type, dtype=torch.bfloat16):
+            under = loaded(model, x)
+        self.assertEqual(plain.dtype, torch.float32)
+        self.assertEqual(under.dtype, torch.float32)
+        self.assertEqual(plain, under)
+
+    def test_tracer_dynamo_eager_custom_builtins(self, device):
+        # The dynamo eager emitter (_emit_dynamo_eager_subgraph) injects fx's full
+        # _custom_builtins set (inf / nan / device / ...) into the standalone subgraph
+        # source, its own copy of the loop the make_fx eager path uses. Every other dynamo
+        # eager test bakes only tensors needing plain ``torch``, so this guards that loop:
+        # dropping it would raise NameError at load. (a) masked_fill to -inf bakes a bare
+        # ``inf`` token; (b) a train-mode BatchNorm bakes a ``device`` constant. Both must
+        # round-trip to eager (mirrors test_backend_eager_inf_constant / _batchnorm).
+        def inf_fn(model, xx):
+            y = model(xx)
+            return torch.relu(y).masked_fill(y < 0, float("-inf"))
+
+        m = torch.nn.Linear(4, 4).to(device).eval()
+        x = make_tensor((5, 4), device=device, dtype=torch.float32)
+        code, cache = torch.compiler.precompile(
+            inf_fn,
+            example_inputs=[(m, x)],
+            training=True,
+            tracer="dynamo",
+            backend="eager",
+        )
+        self.assertEqual(
+            torch.compiler.precompile.load(code, cache)(m, x), inf_fn(m, x)
+        )
+
+        def fresh_bn():
+            torch.manual_seed(0)
+            bn = torch.nn.Sequential(torch.nn.Linear(4, 4), torch.nn.BatchNorm1d(4))
+            bn.train()
+            return bn.to(device)
+
+        xb = make_tensor((8, 4), device=device, dtype=torch.float32)
+        ref_out = fresh_bn()(xb)
+        code, cache = torch.compiler.precompile(
+            lambda model, xx: model(xx),
+            example_inputs=[(fresh_bn(), xb)],
+            training=True,
+            tracer="dynamo",
+            backend="eager",
+        )
+        self.assertEqual(
+            torch.compiler.precompile.load(code, cache)(fresh_bn(), xb), ref_out
+        )
 
 
 instantiate_device_type_tests(TestPrecompileNumerics, globals())

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -20,6 +20,7 @@ import functools
 import itertools
 import re
 import sys
+import threading
 import types
 import uuid
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -1975,13 +1976,24 @@ def _cached_cleaned_instructions(
 
 
 _unique_id_counter = itertools.count()
+_unique_id_lock = threading.Lock()
 
 
 def unique_id(name: str, with_uuid: bool = False) -> str:
-    ret = f"{name}_{next(_unique_id_counter)}"
+    with _unique_id_lock:
+        index = next(_unique_id_counter)
+    ret = f"{name}_{index}"
     if with_uuid:
         ret += f"_{uuid.uuid4()}".replace("-", "_")
     return ret
+
+
+def _reserve_unique_id_through(index: int) -> None:
+    global _unique_id_counter
+
+    with _unique_id_lock:
+        current = next(_unique_id_counter)
+        _unique_id_counter = itertools.count(max(current, index + 1))
 
 
 COMPILED_FN_PREFIX = "__compiled_fn"

--- a/torch/_dynamo/convert_frame.py
+++ b/torch/_dynamo/convert_frame.py
@@ -33,6 +33,7 @@ import gc
 import importlib
 import inspect
 import itertools
+import json
 import logging
 import os
 import pstats
@@ -104,6 +105,7 @@ from .cache_size import (
 from .code_context import code_context
 from .eval_frame import (
     _get_cache_entries_for_region,
+    _get_explicit_compile_regions,
     _get_total_cache_entry_count,
     add_skip_reason,
     always_optimize_code_objects,
@@ -152,7 +154,13 @@ from .symbolic_convert import (
     SpeculationLog,
 )
 from .trace_rules import is_numpy
-from .types import ConvertFrameReturn, FrameAction, FrameExecStrategy, wrap_guarded_code
+from .types import (
+    ConvertFrameReturn,
+    FrameAction,
+    FrameExecStrategy,
+    GuardFilterEntry,
+    wrap_guarded_code,
+)
 from .utils import (
     _get_error_on_graph_break,
     chromium_event_timed,
@@ -588,8 +596,16 @@ def get_compile_id(
     if not isinstance(frame_id, int):
         raise AssertionError(f"frame_id must be an int, got {type(frame_id)}")
 
-    frame_compile_id = FRAME_COMPILE_COUNTER[frame_id]
-    FRAME_COMPILE_COUNTER[frame_id] += 1
+    if get_eval_frame_isolate_recompiles_id() >= 0:
+        frame_compile_id = frame_state.get("_compile_id", 0)
+        if not isinstance(frame_compile_id, int):
+            raise AssertionError(
+                f"frame compile id must be an int, got {type(frame_compile_id)}"
+            )
+        frame_state["_compile_id"] = frame_compile_id + 1
+    else:
+        frame_compile_id = FRAME_COMPILE_COUNTER[frame_id]
+        FRAME_COMPILE_COUNTER[frame_id] += 1
 
     compiled_autograd_id = None
     if prior := CompileContext.current_compile_id():
@@ -654,7 +670,18 @@ class ConvertFrameAssert:
             )
         else:
             cache_entries_for_reasons = cache_entries
-        total_count = _get_total_cache_entry_count(code)
+        package = self._package
+        explicit_package = (
+            package is not None and package.serialization_guard_filter_fn is not None
+        )
+        if explicit_package:
+            if package is None:
+                raise AssertionError("explicit package must not be None")
+            total_count = package.guarded_code_count(code)
+        else:
+            total_count = _get_total_cache_entry_count(code)
+            for region_id in _get_explicit_compile_regions():
+                total_count -= len(_get_cache_entries_for_region(code, region_id))
         cache_size = compute_cache_size(frame, cache_entries, total_count)
         input_codes.add(code)
         if code in output_codes:
@@ -770,9 +797,21 @@ class ConvertFrameAssert:
         try:
             compile_ctx = compile_context(CompileContext(compile_id))
             # When recompile_limit is set, temporarily override the global
-            # config so the existing exceeds_recompile_limit check uses it.
+            # config so the existing exceeds_recompile_limit check uses it. An
+            # explicit package also raises a lower accumulated cap; ordinary
+            # torch.compile keeps the ambient global safety limit.
             recompile_ctx = (
-                config.patch(recompile_limit=self._recompile_limit)
+                config.patch(
+                    recompile_limit=self._recompile_limit,
+                    accumulated_recompile_limit=(
+                        max(
+                            config.accumulated_recompile_limit,
+                            self._recompile_limit,
+                        )
+                        if explicit_package
+                        else config.accumulated_recompile_limit
+                    ),
+                )
                 if self._recompile_limit is not None
                 else contextlib.nullcontext()
             )
@@ -803,7 +842,11 @@ class ConvertFrameAssert:
             # Restore the previous initial_global_state for nested compilation handling
             initial_global_state = prev_initial_global_state
 
-        if config.caching_precompile and self._package is not None:
+        if (
+            config.caching_precompile
+            and self._package is not None
+            and self._package.serialization_guard_filter_fn is None
+        ):
             from .package import DynamoCache
 
             # Record that the dynamo package has changed
@@ -1008,6 +1051,11 @@ class DynamoOutput:
         save: bool = False,
         cache_entries: list[CacheEntry] | None = None,
         strict_error: bool = False,
+        serialization_guard_filter_fn: collections.abc.Callable[
+            [collections.abc.Sequence[GuardFilterEntry]],
+            collections.abc.Sequence[bool],
+        ]
+        | None = None,
     ) -> CheckFunctionManager:
         output_graph = self.tracer_output.output_graph
         if output_graph is None:
@@ -1028,14 +1076,26 @@ class DynamoOutput:
 
         if not fx_experimental_config.translation_validation:
             return self._build_guards(
-                code, output_graph, cache_entries, hooks, save, strict_error
+                code,
+                output_graph,
+                cache_entries,
+                hooks,
+                save,
+                strict_error,
+                serialization_guard_filter_fn,
             )
 
         from torch.fx.experimental.validator import bisect, ValidationException
 
         try:
             return self._build_guards(
-                code, output_graph, cache_entries, hooks, save, strict_error
+                code,
+                output_graph,
+                cache_entries,
+                hooks,
+                save,
+                strict_error,
+                serialization_guard_filter_fn,
             )
         except ValidationException:
             bisect(output_graph.shape_env)
@@ -1049,6 +1109,11 @@ class DynamoOutput:
         hooks: Hooks | None,
         save: bool,
         strict_error: bool,
+        serialization_guard_filter_fn: collections.abc.Callable[
+            [collections.abc.Sequence[GuardFilterEntry]],
+            collections.abc.Sequence[bool],
+        ]
+        | None = None,
     ) -> CheckFunctionManager:
         return CheckFunctionManager(
             code,
@@ -1056,6 +1121,7 @@ class DynamoOutput:
             cache_entries,
             hooks.guard_fail_fn if hooks else None,
             hooks.guard_filter_fn if hooks else None,
+            serialization_guard_filter_fn=serialization_guard_filter_fn,
             save_guards=save,
             strict_error=strict_error,
         )
@@ -1959,6 +2025,15 @@ def _compile(
                 hooks=hooks,
                 save=package is not None,
                 cache_entries=cache_entries,
+                serialization_guard_filter_fn=(
+                    package.serialization_guard_filter_fn
+                    if package is not None
+                    else None
+                ),
+                strict_error=(
+                    package is not None
+                    and package.serialization_guard_filter_fn is not None
+                ),
             )
 
         if package is not None:
@@ -2057,6 +2132,31 @@ def _compile(
                 recompile_reason,
                 troubleshooting_url,
             )
+
+            if package is not None and package.has_current_entry():
+                # This frame will stop compiling new variants, so the ones
+                # past the limit will never be captured. Record that so a caller
+                # building an artifact can detect the gap. Deliberately not a
+                # bypass: the variants captured so far are still valid and must
+                # stay installable, and for a cache a miss just recompiles.
+                # Only this frame is named even though the RUN_ONLY strategy set
+                # below is recursive: frames called beneath it go short too, and
+                # never re-enter here, so the record is a lower bound.
+                package.mark_current_entry_truncated()
+                torch._logging.trace_structured(
+                    "artifact",
+                    metadata_fn=lambda: {
+                        "name": "dynamo_cache_truncated",
+                        "encoding": "json",
+                    },
+                    payload_fn=lambda: json.dumps(
+                        {
+                            "reason": f"hit {limit_type}",
+                            "function": format_func_info(code),
+                        }
+                    ),
+                    expect_trace_id=False,
+                )
 
             def raise_unimplemented_cache_limit_exceeded() -> NoReturn:
                 unimplemented(

--- a/torch/_dynamo/eval_frame.py
+++ b/torch/_dynamo/eval_frame.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import dataclasses
 import functools
 import inspect
 import itertools
@@ -114,6 +115,7 @@ from .backends.registry import CompilerFn, lookup_backend
 from .code_context import code_context
 from .exc import (
     CondOpArgsMismatchError,
+    RecompileError,
     ShortenTraceback,
     UncapturedHigherOrderOpError,
     Unsupported,
@@ -151,6 +153,32 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 _next_isolate_recompiles_id = itertools.count()
+_explicit_compile_regions: dict[int, weakref.ReferenceType[object]] = {}
+_explicit_compile_regions_lock = threading.Lock()
+
+
+def _register_explicit_compile_region(region_id: int, owner: object) -> None:
+    with _explicit_compile_regions_lock:
+        _explicit_compile_regions[region_id] = weakref.ref(owner)
+
+
+def _unregister_explicit_compile_region(region_id: int) -> None:
+    with _explicit_compile_regions_lock:
+        _explicit_compile_regions.pop(region_id, None)
+
+
+def _get_explicit_compile_regions() -> tuple[int, ...]:
+    with _explicit_compile_regions_lock:
+        live = []
+        dead = []
+        for region_id, owner in _explicit_compile_regions.items():
+            if owner() is None:
+                dead.append(region_id)
+            else:
+                live.append(region_id)
+        for region_id in dead:
+            del _explicit_compile_regions[region_id]
+        return tuple(live)
 
 
 always_optimize_code_objects = utils.ExactWeakKeyDictionary()
@@ -206,13 +234,90 @@ class DynamoStance:
 
 
 _stance = DynamoStance()
-_force_eager_nested_compile = threading.local()
+
+
+# Thread-local: serving() scopes the calls made in ITS block. A process-global
+# counter made one request handler's serving() block reject a concurrent
+# handler's legitimate recompile, and a serving process is multi-threaded by
+# definition.
+class DepthTLS(threading.local):
+    # The default lives on the TYPE. Read through getattr(obj, name, default),
+    # a bare threading.local() builds and clears an AttributeError on every
+    # miss, and the miss is the steady state: only a thread inside the scope
+    # ever writes the attribute, so the threads that pay are exactly the ones
+    # that never use the feature. Both counters are read on the per-call path.
+    depth = 0
+
+
+_fail_on_recompile_override = DepthTLS()
+_force_eager_nested_compile = DepthTLS()
+
+
+def _fail_on_recompile_depth() -> int:
+    return _fail_on_recompile_override.depth
+
+
+_PRECOMPILE_ENTRIES_REPORTED = 5
+
+
+def _precompile_no_match_message(
+    entries: Sequence[Any], f_locals: dict[str, Any], isolate_recompiles_id: int
+) -> str:
+    """
+    Why each precompiled variant rejected this call, one line apiece.
+
+    A multi-graph artifact carries one entry per captured variant, up to
+    recompile_limit, and each entry's guard_manager repr is the whole guard
+    tree. Interpolating those built a message megabytes long that a serving
+    process then logged on every uncovered request, so this reports only the
+    failing guard and caps how many entries it names.
+
+    Scoped to the caller's region, because lookup is: entries belonging to
+    another loaded artifact were never candidates for this call, and naming
+    their shapes tells the reader this artifact covers inputs it does not.
+    """
+    mine = [e for e in entries if e.isolate_recompiles_id == isolate_recompiles_id]
+    if not mine:
+        return ""
+    lines = [
+        f"\nFailed on all {len(mine)} precompiled variant(s). "
+        "If this call is served from a torch.compiler.precompile artifact, it "
+        "is not covered by the capture: add it to example_inputs."
+    ]
+    shown = 0
+    for i, entry in enumerate(mine):
+        if shown >= _PRECOMPILE_ENTRIES_REPORTED:
+            break
+        # A guard that raises while being re-evaluated for this report must not
+        # replace the report; the call did not match, and that is what the
+        # caller has to hear.
+        try:
+            reason = entry.guard_manager.check_verbose(f_locals)
+        except Exception as e:
+            lines.append(f"  [{i}] <guard check raised {type(e).__name__}: {e}>")
+            shown += 1
+            continue
+        # A guard manager that PASSES leaves verbose_code_parts empty, and this
+        # report is a list of rejection reasons -- so an entry that matched on
+        # re-evaluation (the call raced an install, or the guard is not
+        # deterministic) is named as such rather than rendered as a raw
+        # multi-line GuardDebugInfo repr.
+        if getattr(reason, "result", False):
+            lines.append(f"  [{i}] <matched on re-check; not a rejection reason>")
+            shown += 1
+            continue
+        parts = getattr(reason, "verbose_code_parts", None) or [str(reason)]
+        lines.append(f"  [{i}] {'; '.join(str(p) for p in parts)}")
+        shown += 1
+    if len(mine) > shown:
+        lines.append(f"  ... and {len(mine) - shown} more variant(s) not shown.")
+    return "\n".join(lines)
 
 
 @contextlib.contextmanager
 def _use_eager_on_nested_compile() -> Generator[None, None, None]:
     """Run torch.compile wrappers eagerly inside compiler-internal tracing."""
-    prior = getattr(_force_eager_nested_compile, "depth", 0)
+    prior = _force_eager_nested_compile.depth
     _force_eager_nested_compile.depth = prior + 1
     try:
         yield
@@ -221,7 +326,7 @@ def _use_eager_on_nested_compile() -> Generator[None, None, None]:
 
 
 def _is_eager_on_nested_compile() -> bool:
-    return getattr(_force_eager_nested_compile, "depth", 0) > 0
+    return _force_eager_nested_compile.depth > 0
 
 
 def _set_stance(stance: DynamoStance) -> DynamoStance:
@@ -240,6 +345,42 @@ def _set_stance(stance: DynamoStance) -> DynamoStance:
 
 
 _set_stance._dynamo_forbidden = True  # type: ignore[attr-defined]
+
+
+def _get_effective_stance() -> DynamoStance:
+    """The stance in force, with serving()'s override applied.
+
+    The override replaces only the ACTION, keeping the ambient stance's other
+    fields. Building a bare DynamoStance("fail_on_recompile") silently dropped
+    skip_guard_eval_unsafe and backend along with it.
+
+    It does take precedence over force_eager, which reads backwards but is the
+    intended contract: serving() is the narrower, explicitly scoped request, and
+    it still honours what force_eager guarantees -- it raises rather than
+    compiling. Running eager instead would silently stop serving the artifact,
+    which is the failure serving() exists to make loud.
+    """
+    if _fail_on_recompile_depth():
+        # skip_guard_eval_unsafe is dropped deliberately: kept, an uncovered
+        # call raises a bare RuntimeError from the skip-guard path instead of
+        # the RecompileError serving() documents, so `except RecompileError`
+        # around a served call would stop catching it.
+        return dataclasses.replace(
+            _stance, stance="fail_on_recompile", skip_guard_eval_unsafe=False
+        )
+    return _stance
+
+
+def _enter_fail_on_recompile_override() -> None:
+    _fail_on_recompile_override.depth = _fail_on_recompile_depth() + 1
+
+
+def _exit_fail_on_recompile_override() -> None:
+    depth = _fail_on_recompile_depth()
+    if depth <= 0:
+        raise AssertionError("fail_on_recompile override is not active")
+    _fail_on_recompile_override.depth = depth - 1
+
 
 _EXAMPLE_INPUTS: dict[str, list[Any]] | None = None
 
@@ -277,27 +418,28 @@ def _is_in_optimized_module() -> bool:
 
 
 def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
-    if _stance.stance == "default":
+    stance = _get_effective_stance()
+    if stance.stance == "default":
         # force_backend
-        if _stance.backend is not None and callback not in (False, None):
-            callback = _create_wrapped_callback(get_compiler_fn(_stance.backend))
+        if stance.backend is not None and callback not in (False, None):
+            callback = _create_wrapped_callback(get_compiler_fn(stance.backend))
 
         return callback
-    elif _stance.stance == "eager_then_compile":
+    elif stance.stance == "eager_then_compile":
         if callback not in (False, None):
-            return _create_delayed_compile_callback(callback, _stance.stance)
+            return _create_delayed_compile_callback(callback, stance.stance)
         return callback
-    elif _stance.stance == "aot_eager_then_compile":
+    elif stance.stance == "aot_eager_then_compile":
         if callback not in (False, None):
-            return _create_delayed_compile_callback(callback, _stance.stance)
+            return _create_delayed_compile_callback(callback, stance.stance)
         return callback
-    elif _stance.stance == "force_eager":
+    elif stance.stance == "force_eager":
         # disable
         return None
-    elif _stance.stance == "eager_on_recompile":
+    elif stance.stance == "eager_on_recompile":
         # run mode
         return False
-    elif _stance.stance == "fail_on_recompile":
+    elif stance.stance == "fail_on_recompile":
         if callback in (False, None):
             return callback
 
@@ -337,17 +479,27 @@ def _callback_from_stance(callback: DynamoCallback) -> DynamoCallback:
                     message += f"\n{textwrap.indent(guard_failure_details, '    ')}"
             precompile_entries = _debug_get_precompile_entries(frame.f_code)
             if len(precompile_entries) > 0:
-                message += "\nFailed on the following precompiled guards: "
-                for entry in precompile_entries:
-                    message += f"\n{entry.guard_manager}{entry.guard_manager.check_verbose(frame.f_locals)}"  # type: ignore[attr-defined]
-            raise RuntimeError(message)
+                message += _precompile_no_match_message(
+                    precompile_entries,
+                    frame.f_locals,
+                    get_eval_frame_isolate_recompiles_id(),
+                )
+            raise RecompileError(message)
 
         # to prevent cache miss due to different backend
         fail_callback._torchdynamo_orig_backend = callback  # type: ignore[attr-defined]
+        if _fail_on_recompile_depth():
+            # Only for serving(): this marker makes the C++ frame eval ignore a
+            # RUN_ONLY pin, so an uncovered call raises instead of quietly
+            # running eager. Setting it for a plain
+            # set_stance("fail_on_recompile") would change that public stance
+            # for everyone -- a frame past its recompile limit would start
+            # raising where it used to run eager, and so would every callee.
+            fail_callback._torchdynamo_force_callback_on_cache_miss = True  # type: ignore[attr-defined]
 
         return fail_callback
     else:
-        raise RuntimeError(f"invalid torch.compile stance '{_stance}'")
+        raise RuntimeError(f"invalid torch.compile stance '{stance}'")
 
 
 def _create_wrapped_callback(
@@ -403,7 +555,7 @@ def _create_delayed_compile_callback(
 
 
 def _is_skip_guard_eval_unsafe_stance() -> bool:
-    return _stance.skip_guard_eval_unsafe
+    return _get_effective_stance().skip_guard_eval_unsafe
 
 
 def _reset_guarded_backend_cache() -> None:
@@ -453,6 +605,17 @@ def _get_cache_entries_for_region(
     if callable(code):
         code = code.__code__
     return torch._C._dynamo.eval_frame._get_cache_entries_for_region(
+        code, isolate_recompiles_id
+    )
+
+
+def _clear_cache_entries_for_region(
+    code: types.CodeType | Callable[..., Any],
+    isolate_recompiles_id: int,
+) -> None:
+    if callable(code):
+        code = code.__code__
+    torch._C._dynamo.eval_frame._clear_cache_entries_for_region(
         code, isolate_recompiles_id
     )
 
@@ -1011,6 +1174,8 @@ class _TorchDynamoContext:
                         log.warning(
                             "Failed to load entry from dynamo cache", exc_info=True
                         )
+                        if self._package.is_initialized():
+                            self._package.reset_after_failed_install()
                         self._package.initialize(
                             fn_key, None, ignore_inlined_sources=False
                         )
@@ -1289,7 +1454,10 @@ class _TorchDynamoContext:
                         set_eval_frame(None)
                         if fullgraph_count_enabled and call_succeeded:
                             count = set_fullgraph_compiled_frame_count(-1)
-                            if count == 0 and _stance.stance == "default":
+                            if (
+                                count == 0
+                                and _get_effective_stance().stance == "default"
+                            ):
                                 skip_reasons = get_skip_reasons()
                                 msg = "torch.compile with fullgraph=True found no compiled frames."
                                 if skip_reasons:

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4191,7 +4191,11 @@ class GuardsStatePickler(pickle.Pickler):
             pytype,
             torch._C.DispatchKeySet.from_raw_repr(dispatch_keys_raw),
         )
-        ret.grad = grad
+        # A .grad the guards never read is pruned to the _Missing sentinel on
+        # the way in, and only a training capture has one to prune at all. It
+        # was not guarded on, so the reconstructed tensor does not need it --
+        # but assigning the sentinel raises.
+        ret.grad = grad if isinstance(grad, torch.Tensor) else None
         return ret
 
     @classmethod
@@ -4526,7 +4530,9 @@ class GuardsStatePickler(pickle.Pickler):
                 obj.device,
                 pytype,
                 torch._C._dispatch_keys(obj).raw_repr(),
-                obj.grad,
+                # Reading .grad off a non-leaf warns and is always None anyway;
+                # a training capture hits plenty of non-leaf tensors.
+                obj.grad if obj.is_leaf else None,
             )
 
         elif isinstance(obj, torch.nn.Module):
@@ -4714,6 +4720,7 @@ def make_guard_filter_entry(guard: Guard, builder: GuardBuilder) -> GuardFilterE
         derived_guard_types=(tuple(guard.guard_types) if guard.guard_types else ()),
         is_global=is_global,
         orig_guard=guard,
+        code=tuple(guard.code_list or ()),
     )
 
 
@@ -4787,6 +4794,10 @@ class CheckFunctionManager:
         guard_fail_fn: Callable[[GuardFail], None] | None = None,
         guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
         | None = None,
+        serialization_guard_filter_fn: Callable[
+            [Sequence[GuardFilterEntry]], Sequence[bool]
+        ]
+        | None = None,
         shape_code_parts: ShapeCodeParts | None = None,
         runtime_global_scope: dict[str, Any] | None = None,
         save_guards: bool = False,
@@ -4823,7 +4834,12 @@ class CheckFunctionManager:
             log.warning("guard_nn_modules is turned off using justknobs killswitch")
 
         # TODO Be more explicit about the behavior for the users.
-        if torch._dynamo.config.caching_precompile:
+        # An explicit package supplies a separate serialization filter. Ambient
+        # caching-precompile mode must not rewrite that package's live guards.
+        if (
+            torch._dynamo.config.caching_precompile
+            and serialization_guard_filter_fn is None
+        ):
             _guard_filter_fn = guard_filter_fn or (lambda gs: [True for g in gs])
 
             def guard_filter_fn(guards: Sequence[GuardFilterEntry]) -> Sequence[bool]:
@@ -4852,50 +4868,101 @@ class CheckFunctionManager:
                         ret.append(True)
                 return ret
 
-        sorted_guards = sorted(guards or (), key=Guard.sort_key)
+        all_guards = sorted(guards or (), key=Guard.sort_key)
 
+        # Runtime and serialized guards are intentionally separate. A package
+        # may need to omit a non-portable identity guard, but dropping it from
+        # the live cache would let later capture examples reuse the wrong graph
+        # instead of triggering the variant that the package needs to record.
         # Disable __torch_function__ dispatch during guard construction so
         # modes with mutable state aren't triggered.  We exit the context
         # before the guard sanity check so GlobalStateGuard.check() sees
         # the true runtime state.
         with torch._C.DisableTorchFunction():
-            if guard_filter_fn:
-                # If we're filtering guards, we need to build it an extra time first
-                # because filtering depends on the builder/guard_manager results
-                builder, guard_manager = self.build_guards(
-                    sorted_guards,
+            filter_entries: list[GuardFilterEntry] | None = None
+
+            def build_filter_entries() -> None:
+                nonlocal filter_entries
+                if filter_entries is not None:
+                    return
+                inspection_builder, _ = self.build_guards(
+                    all_guards,
                     existing_diff_guard_sources,
                     f_code,
                     output_graph,
                     False,
                 )
+                filter_entries = [
+                    make_guard_filter_entry(guard, inspection_builder)
+                    for guard in all_guards
+                ]
 
-                filter_results = guard_filter_fn(
-                    [make_guard_filter_entry(guard, builder) for guard in sorted_guards]
-                )
-                if len(filter_results) != len(sorted_guards):
+            def apply_filter(
+                filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]],
+            ) -> list[Guard]:
+                build_filter_entries()
+                if filter_entries is None:
+                    raise AssertionError("filter_entries must be built")
+                filter_results = filter_fn(filter_entries)
+                if len(filter_results) != len(all_guards):
                     raise AssertionError(
                         f"filter_results length ({len(filter_results)}) != "
-                        f"sorted_guards length ({len(sorted_guards)})"
+                        f"sorted_guards length ({len(all_guards)})"
                     )
                 if not all(type(x) is bool for x in filter_results):
                     raise AssertionError("All filter_results entries must be bool")
-                sorted_guards = [
-                    guard for i, guard in enumerate(sorted_guards) if filter_results[i]
+                return [
+                    guard for guard, keep in zip(all_guards, filter_results) if keep
                 ]
 
-            # Redo the guards because filtering relies on the results from the last guard builder.
+            # Guard.set_export_info EXTENDS code_list on every build, so an
+            # inspection build that runs AFTER the runtime one hands the filter
+            # -- and therefore _GuardFact.code and the committed invariants
+            # report -- each guard's code parts two or three times over. Build
+            # the entries first whenever anything is going to want them, which
+            # for a serialization-only filter is not otherwise until later.
+            if guard_filter_fn is not None or (
+                save_guards and serialization_guard_filter_fn is not None
+            ):
+                build_filter_entries()
+
+            runtime_guards = (
+                apply_filter(guard_filter_fn) if guard_filter_fn else all_guards
+            )
+            runtime_save_guards = save_guards and serialization_guard_filter_fn is None
             builder, guard_manager = self.build_guards(
-                sorted_guards,
+                runtime_guards,
                 existing_diff_guard_sources,
                 f_code,
                 output_graph,
-                save_guards,
+                runtime_save_guards,
                 guard_filter_fn=guard_filter_fn,
             )
 
+            serialized_guards = runtime_guards
+            serialization_builder = builder
+            if save_guards and serialization_guard_filter_fn is not None:
+                serialized_guards = apply_filter(serialization_guard_filter_fn)
+                serialization_builder, _ = self.build_guards(
+                    serialized_guards,
+                    existing_diff_guard_sources,
+                    f_code,
+                    output_graph,
+                    True,
+                    guard_filter_fn=serialization_guard_filter_fn,
+                )
+                # Value pruning keys off the guard tree: anything the tree does
+                # not reach is replaced by a placeholder. Dropping a guard must
+                # not drop the VALUE it named, because the rest of the state
+                # still refers to it -- a pruned tensor comes back with no
+                # dtype. So prune against the unfiltered tree.
+                serialization_builder.guard_tree_values = {
+                    **builder.guard_tree_values,
+                    **serialization_builder.guard_tree_values,
+                }
+
             self.guard_manager = guard_manager
-            self.compile_check_fn(builder, sorted_guards, guard_fail_fn)
+            self.compile_check_fn(builder, runtime_guards, guard_fail_fn)
 
         # Keep track of weak references of objects with ID_MATCH guard. This
         # info is stored alongside optimized_code and guard_manager and is used to
@@ -4972,7 +5039,7 @@ class CheckFunctionManager:
                 )
             try:
                 self.guards_state = self.serialize_guards(
-                    builder, sorted_guards, self.output_graph
+                    serialization_builder, serialized_guards, self.output_graph
                 )
             except exc.PackageError as e:
                 if torch._dynamo.config.strict_precompile or strict_error:

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -3576,6 +3576,8 @@ class OutputGraph(OutputGraphCommon):
             raise AssertionError(f"global '{name}' is already installed")
         self.installed_globals.add(name)
         self.cleanups.append(CleanupHook.create(self.global_scope, name, value))
+        if self.package is not None:
+            self.package.claim_region_global(self.global_scope, name, value)
 
     def install_global_by_id(self, prefix: str, value: object) -> str:
         """

--- a/torch/_dynamo/package.py
+++ b/torch/_dynamo/package.py
@@ -24,9 +24,11 @@ import pickle
 import platform
 import shutil
 import sys
+import threading
 import types
 import uuid
-from collections.abc import Callable, Generator, Iterable, Iterator
+import weakref
+from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from contextlib import nullcontext
 from typing import Any, NewType, Optional, TYPE_CHECKING, Union
 from typing_extensions import Never
@@ -37,10 +39,12 @@ from torch._dynamo.graph_utils import _graph_device_types
 from torch.utils.weak import WeakIdKeyDictionary
 
 from .bytecode_transformation import (
+    _reserve_unique_id_through,
     COMPILED_FN_PREFIX,
     get_code_keys,
     is_compiled_fn_name,
 )
+from .types import FrameAction, FrameExecStrategy
 from .utils import CleanupHook, counters, dynamo_timed, increment_frame
 
 
@@ -52,6 +56,56 @@ if TYPE_CHECKING:
 
 
 _CODE_CACHE = WeakIdKeyDictionary()
+
+# code object -> the live CompilePackages that skip_code()d it. Weak on both
+# sides: a package dropped without unloading must not block a later one.
+_SKIP_INSTALLERS: WeakIdKeyDictionary = WeakIdKeyDictionary()
+# When both are needed, acquire the operation lock before the registry lock.
+_PACKAGE_INSTALL_LOCK = threading.RLock()
+_INSTALLER_REGISTRY_LOCK = threading.Lock()
+
+
+@dataclasses.dataclass
+class _SkipInstallerState:
+    owners: weakref.WeakSet["CompilePackage"]
+    prior_strategy: FrameExecStrategy
+    generation: int
+
+
+_PACKAGE_SKIP_STRATEGY = FrameExecStrategy(FrameAction.SKIP, FrameAction.DEFAULT)
+
+
+# Distinguishes "the name is unbound" from "it is bound to None", so uninstall()
+# can tell whether the binding it wrote is still the one there.
+_ABSENT_GLOBAL = object()
+
+
+@dataclasses.dataclass(frozen=True)
+class _InstalledGlobal:
+    """A global install() wrote into a module, and the value it wrote."""
+
+    name: str
+    value: object
+
+
+@dataclasses.dataclass
+class _GlobalBinding:
+    """One value bound under a name, and the live packages that installed it."""
+
+    value: object
+    owners: weakref.WeakSet["CompilePackage"]
+
+
+# module -> name -> STACK of _GlobalBinding, oldest first.
+#
+# Several live packages can need one name at once. Two loads of the SAME
+# artifact write the same value and share a binding; two loads of different
+# artifacts displace each other and get separate ones. Either way the name must
+# survive until its last owner leaves, and an unload that pops the top has to
+# REBIND to whatever is underneath rather than delete -- an earlier package is
+# still serving and still reads that name from this module. Deleting is only
+# right when the stack empties.
+_GLOBAL_BINDINGS: WeakIdKeyDictionary = WeakIdKeyDictionary()
 
 
 def _code_cache(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -179,14 +233,76 @@ def _get_module_content(module: types.ModuleType) -> str:
     return inspect.getsource(module)
 
 
+def _defining_module_name(code: types.CodeType) -> str | None:
+    """
+    The sys.modules key whose source actually contains ``code``.
+
+    Two things make this harder than ``inspect.getmodule``. It can hand back a
+    module that merely re-exports the code from a private implementation file --
+    ``collections.abc`` is three lines of ``from _collections_abc import *`` --
+    and hashing this code's line range against that module reads lines that are
+    not there. And ``__name__`` is not necessarily importable back to the same
+    object: ``_collections_abc`` sets its own ``__name__`` to "collections.abc",
+    which imports to the shim instead. Load-time revalidation re-imports this
+    name, so return the key, not ``__name__``.
+
+    Real models inline through such modules constantly, so give up and skip the
+    checksum rather than record one against the wrong file.
+    """
+    module = inspect.getmodule(code)
+    if module is not None and getattr(module, "__file__", None) == code.co_filename:
+        name = getattr(module, "__name__", None)
+        if name is not None and sys.modules.get(name) is module:
+            return name
+    return _scan_sys_modules_for_file(code.co_filename)
+
+
+# filename -> (len(sys.modules) when scanned, module key or None).
+_MODULE_KEY_BY_FILE: dict[str, tuple[int, str | None]] = {}
+
+
+def _scan_sys_modules_for_file(filename: str) -> str | None:
+    """
+    Memoized because the fallback is O(len(sys.modules)) and this runs per
+    inlined code object during capture, on the shared caching_precompile path.
+
+    A hit is cached outright. A MISS is only cached while sys.modules has not
+    changed size, because the usual reason for one is that the module has not
+    been imported yet -- caching that permanently, which functools.cache would,
+    silently drops the source checksum for every lazily imported file for the
+    rest of the process.
+
+    Length is an ABA check, not a version: equal-size churn between two calls
+    keeps a stale miss, and ``del sys.modules[m]; import m`` -- the ordinary
+    force-reimport idiom -- is exactly that. sys.modules exposes no mutation
+    counter to use instead. A stale MISS costs this file's checksum, so a later
+    edit to it is not caught at load. A stale HIT is never revalidated at all
+    and is worse: delete the module without re-importing and ``add_code``
+    raises KeyError on the dead name. Both predate the memo; worth knowing when
+    hunting a checksum that should have fired.
+    """
+    generation = len(sys.modules)
+    cached = _MODULE_KEY_BY_FILE.get(filename)
+    if cached is not None and (cached[1] is not None or cached[0] == generation):
+        return cached[1]
+    found = None
+    for key, candidate in list(sys.modules.items()):
+        if getattr(candidate, "__file__", None) == filename:
+            found = key
+            break
+    _MODULE_KEY_BY_FILE[filename] = (generation, found)
+    return found
+
+
 @dataclasses.dataclass
 class SourceInfo:
     inlined_sources: set[InlinedSource]
 
     def add_code(self, code: types.CodeType) -> None:
-        module = inspect.getmodule(code)
-        if module is None:
+        module_name = _defining_module_name(code)
+        if module_name is None:
             return
+        module = sys.modules[module_name]
         sourcelines, firstlineno = inspect.getsourcelines(code)
         lastlineno = firstlineno + len(sourcelines)
         source = "".join(sourcelines)
@@ -197,7 +313,7 @@ class SourceInfo:
             )
         self.inlined_sources.add(
             InlinedSource(
-                module=module.__name__,
+                module=module_name,
                 firstlineno=firstlineno,
                 lastlineno=lastlineno,
                 checksum=_hash_source(source),
@@ -251,9 +367,9 @@ def _resume_global_renames(
     ``__resume_at_<offset>_<n>`` comes from a counter that restarts in every
     capture process, so two artifacts captured separately both claim, say,
     ``__resume_at_16_3``. A serving process installs both into the same module
-    dict: the second one wins, and because precompile lookup is region-EXACT
-    the first package's frame then resolves the name to a twin holding another
-    region's entries and is served nothing at all.
+    dict: the second one wins and the first model silently runs the second's
+    continuation. Unlike ``__compiled_fn`` names, which carry a uuid, these
+    names carry nothing that distinguishes the artifact.
 
     The digest alone does not settle it: the shape that mints the same name
     usually mints the same code with it -- one script captured in two
@@ -628,9 +744,10 @@ class _DynamoCacheEntry:
     source_info: SourceInfo
     device_type: str
     system_info: SystemInfo = dataclasses.field(default_factory=SystemInfo.current)
+    device_types: frozenset[str] | None = None
     requires_native_backend_compatibility: bool = True
     fn_name: str | None = None
-    fn_first_lineno: str | None = None
+    fn_first_lineno: int | None = None
 
     @property
     def backend_ids(self) -> set[_BackendId]:
@@ -638,21 +755,25 @@ class _DynamoCacheEntry:
 
     def check_versions(self) -> None:
         """Check if the current system is compatible with the system used to create this cache entry."""
-        # Determining the codegen target runs the C++ toolchain -- seconds on a
-        # cold inductor cache, and a re-raised InvalidCxxCompiler on a host with
-        # no compiler at all -- so only pay for it when this artifact actually
-        # records one to compare against.
-        check_codegen = self.requires_native_backend_compatibility
+        device_types = getattr(self, "device_types", None) or frozenset(
+            (self.device_type,)
+        )
+        check_codegen = getattr(self, "requires_native_backend_compatibility", True)
+        # Determining the codegen target runs the C++ toolchain, so only pay for
+        # it when this artifact actually records one to compare against.
         current_system_info = SystemInfo.current(
             cpu_codegen=(
                 check_codegen
-                and self.device_type == "cpu"
+                and "cpu" in device_types
                 and self.system_info.cpu_codegen_target is not None
             )
         )
-        self.system_info.check_compatibility(
-            current_system_info, self.device_type, check_codegen=check_codegen
-        )
+        for device_type in device_types:
+            self.system_info.check_compatibility(
+                current_system_info,
+                device_type,
+                check_codegen=check_codegen,
+            )
 
     def debug_info(self) -> dict[str, Any]:
         if len(self.codes) == 0:
@@ -662,6 +783,9 @@ class _DynamoCacheEntry:
             "fn_name": self.fn_name,
             "fn_first_lineno": self.fn_first_lineno,
             "device_type": self.device_type,
+            "device_types": sorted(
+                getattr(self, "device_types", None) or frozenset((self.device_type,))
+            ),
             "backend_ids": list(self.backend_ids),
         }
 
@@ -799,41 +923,62 @@ class CompilePackage:
         fn: Callable[..., Any] | None,
         dynamo: _DynamoCacheEntry | None = None,
         ignore_inlined_sources: bool = False,
+        serialization_guard_filter_fn: Callable[[Sequence[Any]], Sequence[bool]]
+        | None = None,
         requires_native_backend_compatibility: bool = True,
     ) -> None:
         self._innermost_fn = None
         self._codes: dict[types.CodeType, _DynamoCodeCacheEntry] = {}
-
-        self._current_entry: _DynamoCodeCacheEntry | None = None
-        self._installed_globals: dict[types.ModuleType, list[str]] = {}
-        # Code objects holding this package's region state, so uninstall() can
-        # clear all of them -- and only them. Clearing the code object wholesale
-        # would take every OTHER region's entries with it, and since lookup() is
-        # region-exact those owners can no longer be served by what is left.
-        self._installed_precompile_codes: list[types.CodeType] = []
-        self._installed_precompile_region_id = -1
+        # Resume functions install under a global name carrying this token, so
+        # two packages holding byte-identical resume code -- two loads of one
+        # artifact, or two artifacts of one script captured in separate
+        # processes -- do not take each other's name. See
+        # _resume_global_renames.
+        self._install_token = uuid.uuid4().hex
         # Identity token stamped onto every precompile entry this package
         # installs, so uninstall() can remove its own and leave a neighbour
         # package's entries on a shared code object alone.
         self._install_owner = object()
-        # device_type that model compiled with.
-        self._device_type = "cpu"
-        # Whether this package's backend generates native code. An eager one
-        # bakes no vector width, so it must neither pay the C++ toolchain probe
-        # at save nor be rejected on ISA skew at load.
-        self._requires_native_backend_compatibility = (
+
+        self._current_entry: _DynamoCodeCacheEntry | None = None
+        self._installed_globals: dict[types.ModuleType, list[_InstalledGlobal]] = {}
+        # Code objects holding this package's region state, so uninstall() can
+        # clear all of them. install() covers resume functions and any frame
+        # reached through code_source, not just the entry frame; code_context()
+        # adds the live frames an uncovered call compiled inside the region.
+        self._installed_precompile_codes: list[types.CodeType] = []
+        # One of those codes that actually received entries, used to notice a
+        # torch._dynamo.reset() wiping the install out from under us. A frame
+        # with no guarded code is installed but gets no entries, so it cannot
+        # serve as the probe.
+        self._installed_precompile_probe: types.CodeType | None = None
+        self._installed_precompile_region_id = -1
+        self._skipped_codes: list[types.CodeType] = []
+        self._region_skipped_codes: list[types.CodeType] = []
+        # Frames whose capture was cut short by the recompile limit. Deliberately
+        # runtime-only and NOT serialized: it describes this capture session, not
+        # the artifact, and it must not affect what install() serves.
+        self._truncated_frames: set[str] = set()
+        # A frame can enter Dynamo yet produce no guarded code for one exercised
+        # variant (for example, an unsupported or empty resume path). Keep that
+        # distinct from resume code that was generated but never executed.
+        self._uncovered_frames: set[str] = set()
+        self._device_types: set[str] = set()
+        self._system_info: SystemInfo | None = None
+        self._default_requires_native_backend_compatibility = (
             requires_native_backend_compatibility
+        )
+        self._requires_native_backend_compatibility = (
+            self._default_requires_native_backend_compatibility
         )
 
         # For debugging/testing purpose only.
         self._cached_backends: dict[_BackendId, Any] = {}
         self._source_info: SourceInfo = SourceInfo(inlined_sources=set())
         self._resume_codes: set[types.CodeType] = set()
-        # Resume functions install under a global name carrying this token, so
-        # two packages holding byte-identical resume code -- two loads of one
-        # artifact, or two artifacts of one script captured in separate
-        # processes -- do not take each other's name. See _resume_global_renames.
-        self._install_token = uuid.uuid4().hex
+        # Runtime guards stay intact; this filter applies only to the guard
+        # state recorded in the package.
+        self.serialization_guard_filter_fn = serialization_guard_filter_fn
         self._initialized = False
         if fn is not None:
             self.initialize(fn, dynamo, ignore_inlined_sources)
@@ -852,7 +997,21 @@ class CompilePackage:
 
         if self._initialized:
             raise AssertionError("CompilePackage is already initialized")
+        # A load that raises is retried on the SAME object -- eval_frame's
+        # caching_precompile path falls back to initialize(fn, None) -- so every
+        # field a load writes has to be reset here rather than trusted to still
+        # hold its __init__ value.
         self._source_info = SourceInfo(inlined_sources=set())
+        self._codes = {}
+        self._device_types = set()
+        self._system_info = None
+        self._requires_native_backend_compatibility = (
+            self._default_requires_native_backend_compatibility
+        )
+        self._cached_backends = {}
+        self._resume_codes = set()
+        self._truncated_frames = set()
+        self._uncovered_frames = set()
         self._innermost_fn = innermost_fn(fn)  # type: ignore[assignment]
         if self._innermost_fn is None:
             raise AssertionError("innermost_fn returned None")
@@ -875,10 +1034,22 @@ class CompilePackage:
             self._codes = {self._innermost_fn.__code__: main}
             for code in codes:
                 self._codes[SerializedCode.to_code_object(code.python_code)] = code
-        else:
-            self._add_function(
-                self._innermost_fn.__code__, self._innermost_fn.__module__
+            # Restore the complete device coverage and compile-time system
+            # requirements recorded by the artifact. Written last so a failed
+            # load cannot leak them into a cold-cache fallback on this object.
+            self._device_types = set(
+                getattr(dynamo, "device_types", None) or (dynamo.device_type,)
             )
+            self._system_info = dynamo.system_info
+            self._requires_native_backend_compatibility = getattr(
+                dynamo, "requires_native_backend_compatibility", True
+            )
+        else:
+            module_name = (
+                _defining_module_name(self._innermost_fn.__code__)
+                or self._innermost_fn.__module__
+            )
+            self._add_function(self._innermost_fn.__code__, module_name)
         self._initialized = True
 
     def _add_function(
@@ -951,12 +1122,30 @@ class CompilePackage:
         if code not in self._codes:
             self._add_user_function(code)
 
+        # A call the artifact does not cover compiles INSIDE the installed
+        # region and leaves its cache entries on the LIVE code object, which for
+        # a resume function is not the reconstructed twin _codes is keyed by.
+        # The two compare EQUAL, so match on identity: otherwise uninstall()
+        # clears the twin and the live frame keeps one entry per load forever,
+        # until accumulated_recompile_limit refuses to compile it ever again.
+        if self._installed_precompile_region_id >= 0 and not any(
+            installed is code for installed in self._installed_precompile_codes
+        ):
+            self._installed_precompile_codes.append(code)
+
         entry = self._codes[code]
         self._current_entry = entry
         try:
             yield
         finally:
             entry.has_compile_id = True
+            # "Uncovered" means the frame produced NO guarded code at all, which
+            # is the case install() skip_code()s and save() reports as a gap. A
+            # frame that hit the recompile limit has working variants and is
+            # reported as truncated instead; counting it here too made the
+            # uncovered error text ("no guarded variants at all") false for it.
+            if not entry.guarded_codes and not entry.bypassed:
+                self._uncovered_frames.add(code.co_name)
             self._current_entry = None
 
     def add_guarded_code(
@@ -987,16 +1176,93 @@ class CompilePackage:
             self._source_info.add_code(code)
 
     def update_device_type(self, graph: torch.fx.Graph | None) -> None:
-        # Every device the graph NAMES, not the first meta value it carries:
-        # under dynamic shapes the leading placeholder is a SymInt, which has no
-        # device, and reading it as "cpu" makes a pure-accelerator capture bake
-        # a cpu_codegen_target it has no native code for -- which then refuses
-        # to load on a host with a different vector ISA or no C++ compiler. A
-        # graph that names nothing emits nothing and contributes nothing.
+        # Every device the graph names, not just one: a variant that compiles to
+        # nothing (an exercised branch with no tensor op, which this package
+        # records as a guarded empty variant rather than skipping) names none
+        # and must contribute none, and a graph whose leading placeholder is a
+        # SymInt must not be read as "cpu". Getting either wrong makes a
+        # pure-accelerator capture bake a cpu_codegen_target it has no native
+        # code for, and then refuse to load on a host with a different vector
+        # ISA or no C++ compiler at all.
         device_types = _graph_device_types(graph)
         if not device_types:
             return
-        self._device_type = next((d for d in sorted(device_types) if d != "cpu"), "cpu")
+        # cpu_codegen_target only guards CPU native code and computing it runs
+        # the C++ toolchain, so a capture that never emits any must not pay for
+        # it. A cpu graph arriving after an accelerator-only prefix backfills the
+        # field, so the artifact still records what it was captured against.
+        needs_cpu_codegen = (
+            self._requires_native_backend_compatibility and "cpu" in device_types
+        )
+        current = SystemInfo.current(cpu_codegen=needs_cpu_codegen)
+        if self._system_info is None:
+            self._system_info = current
+        elif needs_cpu_codegen:
+            if self._system_info.cpu_codegen_target is None:
+                self._system_info = dataclasses.replace(
+                    self._system_info, cpu_codegen_target=current.cpu_codegen_target
+                )
+            elif self._system_info.cpu_codegen_target != current.cpu_codegen_target:
+                raise RuntimeError(
+                    "CPU codegen target changed during precompile capture: "
+                    f"first={self._system_info.cpu_codegen_target}, "
+                    f"current={current.cpu_codegen_target}"
+                )
+        self._device_types.update(device_types)
+
+    def has_current_entry(self) -> bool:
+        return self._current_entry is not None
+
+    def mark_current_entry_truncated(self) -> None:
+        """
+        Record that this frame hit the recompile limit, so callers building an
+        artifact can tell the capture is missing variants. Unlike bypassing, the
+        variants already captured stay installable -- a truncated frame still
+        serves what it covers and recompiles for the rest.
+
+        Only the frame that hit the limit lands here, so ``truncated_frames`` is
+        a LOWER BOUND: the limit also puts everything called beneath this frame
+        into run-only mode, and those frames stop capturing without ever
+        re-entering Dynamo to report it.
+        """
+        if self._current_entry is None:
+            raise AssertionError(
+                "_current_entry is not set in mark_current_entry_truncated"
+            )
+        code = self._current_entry.python_code
+        self._truncated_frames.add(
+            f"{code.co_name} ({code.co_filename}:{code.co_firstlineno})"
+        )
+
+    @property
+    def truncated_frames(self) -> frozenset[str]:
+        return frozenset(self._truncated_frames)
+
+    @property
+    def uncovered_frames(self) -> frozenset[str]:
+        return frozenset(self._uncovered_frames)
+
+    def guarded_code_count(self, code: types.CodeType) -> int:
+        entry = self._codes.get(code)
+        return 0 if entry is None else len(entry.guarded_codes)
+
+    def code_objects(self) -> tuple[types.CodeType, ...]:
+        return tuple(self._codes)
+
+    def region_codes(self) -> tuple[types.CodeType, ...]:
+        """
+        Every live code object an isolated region of this package can hold
+        state on.
+
+        A frame reached through code_source is installed onto the code the
+        RUNNING program resolves that name to, not onto the reconstructed twin
+        in _codes, and the two compare EQUAL, so this is deliberately not
+        deduplicated: any set or dict keyed by value collapses the pair and
+        drops exactly the live code. Call it before uninstall(), which forgets
+        what it installed onto. _region_skipped_codes is a strict subset of
+        _installed_precompile_codes, so it needs no separate entry here.
+        """
+        return (*self._codes, *self._installed_precompile_codes)
 
     def bypass_current_entry(self) -> None:
         if self._current_entry is None:
@@ -1059,25 +1325,164 @@ class CompilePackage:
         # so that hook must not delete it once its code object is collected.
         CleanupHook.disown(module.__dict__, name)
         module.__dict__[name] = value
-        self._installed_globals.setdefault(module, []).append(name)
+        self._claim_global(module, name, value)
+
+    def _claim_global(self, module: types.ModuleType, name: str, value: Any) -> None:
+        self._installed_globals.setdefault(module, []).append(
+            _InstalledGlobal(name, value)
+        )
+        with _INSTALLER_REGISTRY_LOCK:
+            by_name = _GLOBAL_BINDINGS.setdefault(module, {})
+            stack = by_name.setdefault(name, [])
+            if not stack or stack[-1].value is not value:
+                stack.append(_GlobalBinding(value=value, owners=weakref.WeakSet()))
+            stack[-1].owners.add(self)
+
+    def claim_region_global(self, scope: dict[str, Any], name: str, value: Any) -> None:
+        """
+        Take over a global a compile inside this package's installed region just
+        wrote, so uninstall() removes it with the rest.
+
+        A call the artifact does not cover falls back to an ordinary Dynamo
+        compile inside the region. OutputGraph installs that compile's globals
+        and anchors them to a CleanupHook on the transformed code object, which
+        the package never sees and which does not fire when the region goes
+        away, so unclaimed they stay in the served module for the life of the
+        process. Only while installed: the same path runs during capture, for
+        globals the capture session's own compiled callable still reads.
+        """
+        if self._installed_precompile_region_id < 0:
+            return
+        module_name = scope.get("__name__")
+        module = sys.modules.get(module_name) if isinstance(module_name, str) else None
+        if module is None or module.__dict__ is not scope:
+            return
+        with _PACKAGE_INSTALL_LOCK:
+            self._claim_global(module, name, value)
 
     def uninstall(self) -> None:
+        with _PACKAGE_INSTALL_LOCK:
+            self._uninstall()
+
+    def _uninstall(self) -> None:
         from torch._C._dynamo.eval_frame import _reset_precompile_entries_for_owner
 
         if self._innermost_fn is None:
             raise AssertionError("_innermost_fn is not set in uninstall")
-        for module, names in self._installed_globals.items():
-            for name in names:
-                module.__dict__.pop(name, None)
+        # This namespace is shared with plain torch.compile and with any other
+        # package loaded for the same module, so a name goes only when BOTH
+        # hold: it is still bound to what we wrote (something that has rebound
+        # since owns it now, and popping it leaves live consumers with a
+        # NameError), and we are its last live owner. Two packages loaded from
+        # one artifact -- the ordinary replica shape -- write the same value
+        # under the same name, and dropping it on the first unload broke the
+        # one still serving. Deliberately no attempt to put back what we
+        # displaced: a writer that displaced this name orphaned our value when
+        # it did so, and restoring it later would leave a compiled backend
+        # bound in the module forever.
+        for module, installed in self._installed_globals.items():
+            for installed_global in installed:
+                name = installed_global.name
+                # Deregister FIRST, unconditionally. Whether our value is still
+                # the one bound decides what to do with the namespace, not
+                # whether we are still an owner: a package whose binding was
+                # displaced by a later load must still drop its claim, or the
+                # last unload finds a phantom owner and leaves the name behind.
+                with _INSTALLER_REGISTRY_LOCK:
+                    by_name = _GLOBAL_BINDINGS.get(module) or {}
+                    stack = by_name.get(name) or []
+                    for binding in stack:
+                        # The frame we actually joined, not merely the first one
+                        # holding this value: a later load can stack a value an
+                        # earlier one already installed, and deregistering from
+                        # that earlier frame leaves us an owner of ours forever.
+                        if binding.value is installed_global.value:
+                            if self in binding.owners:
+                                binding.owners.discard(self)
+                                break
+                    stack[:] = [b for b in stack if b.owners]
+                    survivor = stack[-1].value if stack else _ABSENT_GLOBAL
+                    if not stack:
+                        by_name.pop(name, None)
+                current = module.__dict__.get(name, _ABSENT_GLOBAL)
+                if survivor is _ABSENT_GLOBAL:
+                    # Nobody left. Remove it only if what is bound is still
+                    # ours; anything else belongs to whoever wrote it.
+                    if current is installed_global.value:
+                        del module.__dict__[name]
+                elif current is not survivor and (
+                    current is installed_global.value or current is _ABSENT_GLOBAL
+                ):
+                    # An owner remains; put the name back to THEIR value. Only
+                    # when what is bound is ours or gone, though: a bystander
+                    # that rebound it owns it now, exactly as in the delete case
+                    # above, and overwriting it would hand a package's value to
+                    # whatever else in this module reads the name.
+                    module.__dict__[name] = survivor
 
         self._installed_globals = {}
+
+        from torch._C._dynamo.eval_frame import compare_and_set_code_exec_strategy
+
+        for code in self._skipped_codes:
+            with _INSTALLER_REGISTRY_LOCK:
+                state = _SKIP_INSTALLERS.get(code)
+                if state is None:
+                    continue
+                state.owners.discard(self)
+                if state.owners:
+                    continue
+                del _SKIP_INSTALLERS[code]
+                # The generation check and write happen in one C++ call. A
+                # same-valued skip or a different strategy installed after us
+                # therefore wins, including a write racing with this unload.
+                compare_and_set_code_exec_strategy(
+                    code, state.generation, state.prior_strategy
+                )
+        self._skipped_codes = []
+
+        if self._region_skipped_codes:
+            from torch._C._dynamo.eval_frame import set_code_region_exec_strategy
+
+            default_strategy = FrameExecStrategy(
+                FrameAction.DEFAULT, FrameAction.DEFAULT
+            )
+            for code in self._region_skipped_codes:
+                set_code_region_exec_strategy(
+                    code, self._installed_precompile_region_id, default_strategy
+                )
+        self._region_skipped_codes = []
 
         for code in self._installed_precompile_codes:
             _reset_precompile_entries_for_owner(
                 code, self._installed_precompile_region_id, self._install_owner
             )
         self._installed_precompile_codes = []
+        self._installed_precompile_probe = None
         self._installed_precompile_region_id = -1
+
+    def _deserialize_backends(
+        self, backends: dict[_BackendId, Any]
+    ) -> dict[_BackendId, Any]:
+        """
+        Deserialize outside the install lock, since an inductor artifact can be
+        slow to load, but only the backends install will actually reach: a
+        bypassed entry installs nothing, so loading its artifact is wasted work
+        and can fail the whole install over a graph that serves nothing.
+        """
+        needed = {
+            backend_id
+            for entry in self._codes.values()
+            if not entry.bypassed
+            for backend_id in entry.backend_ids
+        }
+        deserialized = {}
+        for backend_id, artifact in backends.items():
+            if backend_id not in needed:
+                continue
+            with dynamo_timed("after_deserialization", phase_name="backend_compile"):
+                deserialized[backend_id] = artifact.after_deserialization()
+        return deserialized
 
     def install(
         self,
@@ -1091,13 +1496,63 @@ class CompilePackage:
           2. Install the compiled functions to global scopes.
           3. Install the precompiled cache entries to ExtraStates on the code object.
         """
+        deserialized_backends = self._deserialize_backends(backends)
+        with _PACKAGE_INSTALL_LOCK:
+            self._uninstall()
+            self._installed_precompile_region_id = isolate_recompiles_id
+            try:
+                self._install_codes(deserialized_backends)
+            except BaseException:
+                # A half-installed package is worse than an unloaded one: some
+                # frames serve precompiled code and some do not, and because
+                # install() raised, the caller has no handle to undo it. The
+                # expected way to get here is after_deserialization() rejecting an
+                # artifact on a serving host that does not match the capture host.
+                try:
+                    self._uninstall()
+                except BaseException:
+                    logger.exception("Failed to roll back a partial package install")
+                raise
+
+    def installed_entries_dropped(self) -> bool:
+        """
+        True when the precompile entries install() loaded are gone.
+
+        torch._dynamo.reset() clears every code object install() touched -- they
+        all go through convert_frame.input_codes -- while leaving the installed
+        globals behind, so the next call recompiles instead of serving.
+
+        Scoped to the region install() used rather than to the code object as a
+        whole: lookup() never serves a precompile entry across regions, so a
+        second artifact loaded onto the same function after the reset is not
+        coverage for this one. A served call runs this every time, so it asks
+        C++ a yes/no question instead of materializing a wrapper per entry.
+        """
+        from torch._C._dynamo.eval_frame import _has_precompile_entries
+
+        probe = self._installed_precompile_probe
+        return probe is not None and not _has_precompile_entries(
+            probe, self._installed_precompile_region_id
+        )
+
+    def reset_after_failed_install(self) -> None:
+        """Make an install-clean package reusable for a cold-cache fallback."""
+        with _PACKAGE_INSTALL_LOCK:
+            if (
+                self._installed_globals
+                or self._installed_precompile_codes
+                or self._skipped_codes
+                or self._region_skipped_codes
+            ):
+                raise AssertionError("failed install left package state installed")
+            self._initialized = False
+
+    def _install_codes(self, backends: dict[_BackendId, Any]) -> None:
         from torch._C._dynamo.eval_frame import _load_precompile_entry
 
         from .convert_frame import input_codes
         from .output_graph import get_builtins_dict
 
-        self.uninstall()
-        self._installed_precompile_region_id = isolate_recompiles_id
         # Resume functions are bound under a name unique to their code and to
         # this package, not under the name the capture process happened to
         # mint. Every reference to them lives in some frame's dynamo bytecode,
@@ -1112,19 +1567,23 @@ class CompilePackage:
             with context:
                 module = sys.modules[entry.python_module]
                 for alias, module_name in entry.import_sources.items():
-                    self._install_global(
-                        module, alias, importlib.import_module(module_name)
-                    )
+                    # Deliberately not recorded for uninstall. An import alias
+                    # is a module object under a name derived from the module,
+                    # so every writer writes the same value, and plain
+                    # torch.compile (symbolic_convert.import_source) installs it
+                    # permanently. Taking it back out breaks whoever else in
+                    # this module resolved the same alias.
+                    module.__dict__[alias] = importlib.import_module(module_name)
                 target_code = code
                 if entry.install_to_global:
                     for function_name in entry.function_names:
-                        function_name = renames.get(function_name, function_name)
+                        installed_name = renames[function_name]
                         if code.co_freevars:
                             # Resume functions with freevars need a factory
                             # that takes a closure tuple, matching
                             # install_resume_function_global in output_graph.py.
                             f_globals = module.__dict__
-                            fn_name = function_name
+                            fn_name = installed_name
 
                             def _make_fn(
                                 closure: tuple[types.CellType, ...],
@@ -1136,12 +1595,12 @@ class CompilePackage:
                                     _code, _globals, _name, None, closure
                                 )
 
-                            self._install_global(module, function_name, _make_fn)
+                            self._install_global(module, installed_name, _make_fn)
                         else:
                             fn = types.FunctionType(
-                                code, module.__dict__, function_name
+                                code, module.__dict__, installed_name
                             )
-                            self._install_global(module, function_name, fn)
+                            self._install_global(module, installed_name, fn)
                 if entry.code_source:
                     target_code = _lookup_code(entry)
 
@@ -1163,25 +1622,69 @@ class CompilePackage:
                     # runs uninstall() first, which removes exactly the ones it
                     # owns.
                     self._installed_precompile_codes.append(target_code)
+                if entry.guarded_codes and self._installed_precompile_probe is None:
+                    self._installed_precompile_probe = target_code
                 for backend_id in entry.backend_ids:
                     if backend_id not in backends:
                         raise RuntimeError(
                             f"Backend {backend_id} is not found in the given backends"
                         )
-                    with dynamo_timed(
-                        "after_deserialization", phase_name="backend_compile"
-                    ):
-                        backend = backends[backend_id].after_deserialization()
-                        self._install_global(
-                            module,
-                            backend_id,
-                            torch._dynamo.disable(backend),
-                        )
+                    self._install_global(
+                        module,
+                        backend_id,
+                        torch._dynamo.disable(backends[backend_id]),
+                    )
 
                 if len(entry.guarded_codes) == 0:
-                    # Dynamo generates empty graph for trivial functions, should just skip them
-                    # in these cases.
-                    torch._dynamo.eval_frame.skip_code(target_code)
+                    # Legacy and transparent-cache artifacts can contain a frame
+                    # with no guarded code. It must run eager so covered child
+                    # frames can still dispatch.
+                    # Remember it, and register as one of the packages holding
+                    # the skip, so uninstall() can restore the frame without
+                    # un-skipping it under another package that still needs it.
+                    if self._installed_precompile_region_id >= 0:
+                        from torch._C._dynamo.eval_frame import (
+                            set_code_region_exec_strategy,
+                        )
+
+                        self._region_skipped_codes.append(target_code)
+                        set_code_region_exec_strategy(
+                            target_code,
+                            self._installed_precompile_region_id,
+                            _PACKAGE_SKIP_STRATEGY,
+                        )
+                        continue
+                    self._skipped_codes.append(target_code)
+                    with _INSTALLER_REGISTRY_LOCK:
+                        state = _SKIP_INSTALLERS.get(target_code)
+                        current_generation = None
+                        if state is not None:
+                            from torch._C._dynamo.eval_frame import (
+                                get_code_exec_strategy_token,
+                            )
+
+                            _, current_generation = get_code_exec_strategy_token(
+                                target_code
+                            )
+                        if state is None or current_generation != state.generation:
+                            from torch._C._dynamo.eval_frame import (
+                                set_code_exec_strategy_with_token,
+                            )
+
+                            prior_strategy, generation = (
+                                set_code_exec_strategy_with_token(
+                                    target_code, _PACKAGE_SKIP_STRATEGY
+                                )
+                            )
+                            state = _SkipInstallerState(
+                                owners=(
+                                    weakref.WeakSet() if state is None else state.owners
+                                ),
+                                prior_strategy=prior_strategy,
+                                generation=generation,
+                            )
+                            _SKIP_INSTALLERS[target_code] = state
+                        state.owners.add(self)
 
                 for guarded_code in entry.guarded_codes:
                     with dynamo_timed("precompile_load_guards"):
@@ -1193,22 +1696,43 @@ class CompilePackage:
                         builtin_dict_name
                         := guards_state.output_graph.name_of_builtins_dict_key_in_fglobals
                     ):
+                        _, separator, suffix = builtin_dict_name.rpartition("_")
+                        if separator and suffix.isdigit():
+                            _reserve_unique_id_through(int(suffix))
                         # A pre-reset compile's CleanupHook may still own this
                         # name even when we're about to leave its value alone
                         # below (same dict object every compile in this
                         # module), so it must not delete it once collected.
                         CleanupHook.disown(runtime_global_scope, builtin_dict_name)
                         builtins_dict = get_builtins_dict(runtime_global_scope)
-                        if builtin_dict_name in runtime_global_scope:
-                            if (
-                                runtime_global_scope[builtin_dict_name]
-                                is not builtins_dict
-                            ):
-                                raise AssertionError(
-                                    f"Builtins dict mismatch for key '{builtin_dict_name}'"
+                        bound = runtime_global_scope.get(
+                            builtin_dict_name, _ABSENT_GLOBAL
+                        )
+                        if bound is not _ABSENT_GLOBAL and bound is not builtins_dict:
+                            raise AssertionError(
+                                f"Builtins dict mismatch for key '{builtin_dict_name}'"
+                            )
+                        with _INSTALLER_REGISTRY_LOCK:
+                            owned_by_a_package = any(
+                                binding.value is builtins_dict and binding.owners
+                                for binding in (_GLOBAL_BINDINGS.get(module) or {}).get(
+                                    builtin_dict_name, ()
                                 )
-                        else:
-                            runtime_global_scope[builtin_dict_name] = builtins_dict
+                            )
+                        # Recorded, so uninstall() takes it back out. The
+                        # artifact's counter was reserved above, so local
+                        # compiles cannot mint the same name while loaded.
+                        # Joining a set another package already owns matters as
+                        # much as creating the binding: two loads of one
+                        # artifact record the same name, and the first unload
+                        # would otherwise delete a key the other one's bytecode
+                        # reads. A name a PLAIN compile minted has no owner to
+                        # join and is left alone, since claiming it would make
+                        # our unload delete what that compile reads.
+                        if bound is _ABSENT_GLOBAL or owned_by_a_package:
+                            self._install_global(
+                                module, builtin_dict_name, builtins_dict
+                            )
                     if not isinstance(guards_state, torch._dynamo.guards.GuardsState):
                         raise AssertionError(
                             f"Expected GuardsState, got {type(guards_state)}"
@@ -1232,19 +1756,19 @@ class CompilePackage:
         self.validate()
         if self._innermost_fn is None:
             raise AssertionError("_innermost_fn is not set in cache_entry")
+        device_types = frozenset(self._device_types or ("cpu",))
+        device_type = next(
+            (device for device in sorted(device_types) if device != "cpu"),
+            "cpu",
+        )
         return _DynamoCacheEntry(
             codes=list(self._codes.values()),
             source_info=self._source_info,
-            device_type=self._device_type,
-            # The field's default_factory would run the C++ toolchain probe on
-            # every save; only an artifact that can hold CPU native code has a
-            # baked vector width to record.
-            system_info=SystemInfo.current(
-                cpu_codegen=(
-                    self._requires_native_backend_compatibility
-                    and self._device_type == "cpu"
-                )
-            ),
+            device_type=device_type,
+            device_types=device_types,
+            # _system_info is None only when no graph was ever captured, so
+            # there is nothing baked and no reason to run the toolchain probe.
+            system_info=self._system_info or SystemInfo.current(cpu_codegen=False),
             requires_native_backend_compatibility=(
                 self._requires_native_backend_compatibility
             ),

--- a/torch/_dynamo/pgo.py
+++ b/torch/_dynamo/pgo.py
@@ -12,6 +12,7 @@ and help Dynamo make better specialization decisions.
 from __future__ import annotations
 
 import base64
+import contextlib
 import copy
 import dataclasses
 import enum
@@ -22,6 +23,7 @@ import pickle
 import re
 import zlib
 from collections import defaultdict
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, TypeVar
 from typing_extensions import override, Self
 
@@ -47,6 +49,7 @@ from torch.utils._ordered_set import OrderedSet
 
 if TYPE_CHECKING:
     import types
+    from collections.abc import Iterator
 
     from torch._dynamo.symbolic_convert import InstructionTranslatorBase
     from torch._inductor.remote_cache import JsonDataTy, RemoteCache
@@ -197,8 +200,26 @@ class CodeState:
 
 _INIT_CODE_STATE: defaultdict[CodeId, CodeState] | None = None
 _CODE_STATE: defaultdict[CodeId, CodeState] | None = None
+_CODE_STATE_OVERRIDE: ContextVar[defaultdict[CodeId, CodeState] | None] = ContextVar(
+    "dynamo_pgo_code_state_override", default=None
+)
 _LOGGED_DYNAMIC_ALLOWLIST: bool = False
 _KNOWN_DYNAMIC_SOURCES: set[str] = set()
+
+
+def _new_code_state() -> defaultdict[CodeId, CodeState]:
+    return defaultdict(CodeState)
+
+
+@contextlib.contextmanager
+def _use_code_state(
+    code_state: defaultdict[CodeId, CodeState],
+) -> Iterator[None]:
+    token = _CODE_STATE_OVERRIDE.set(code_state)
+    try:
+        yield
+    finally:
+        _CODE_STATE_OVERRIDE.reset(token)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -938,6 +959,8 @@ def get_extra_remote_code_state(cache_key: str) -> None:
 
 def get_code_state() -> defaultdict[CodeId, CodeState]:
     global _CODE_STATE, _INIT_CODE_STATE
+    if (override := _CODE_STATE_OVERRIDE.get()) is not None:
+        return override
     if _CODE_STATE is not None:
         return _CODE_STATE
 

--- a/torch/_dynamo/precompile_context.py
+++ b/torch/_dynamo/precompile_context.py
@@ -141,6 +141,11 @@ class PrecompileContext:
         """
         return cls._backend_artifacts_by_key.get(_BackendId(key), None)
 
+    @classmethod
+    def take_artifact(cls, key: str) -> BackendCacheArtifact[Any] | None:
+        """Remove and return one artifact from the process-global staging area."""
+        return cls._backend_artifacts_by_key.pop(_BackendId(key), None)
+
     @staticmethod
     def dump_debug_info(
         dynamo_entries: dict[str, _DynamoCacheEntry],
@@ -206,7 +211,7 @@ class PrecompileContext:
         for key, cache_entry in dynamo_entries.items():
             try:
                 result = PrecompileCacheEntry.from_cache_entry(
-                    cache_entry, backend_artifacts
+                    copy.deepcopy(cache_entry), backend_artifacts
                 )
                 if result is not None:
                     precompile_cache_entries[key] = result

--- a/torch/_dynamo/precompile_package.py
+++ b/torch/_dynamo/precompile_package.py
@@ -1,0 +1,2542 @@
+"""
+Ahead-of-time precompilation of a callable into MANY graphs.
+
+``torch.compile(fn, fullgraph=True).aot_compile(...)`` produces exactly one
+graph and rejects graph breaks. This module is the multi-graph counterpart: it
+captures every frame Dynamo produces while exercising the supplied calls -- the entry frame, each
+``torch_dynamo_resume_in_*`` continuation created by a graph break, and every
+recompiled variant of each -- into a single serializable artifact.
+
+Usage::
+
+    python_code, cache = torch.compiler.precompile(
+        step,  # e.g. lambda model, x: model(x)
+        backend="inductor",
+        example_inputs=[(model, x1), (model, x2)],
+    )
+
+    # later, in a fresh process
+    compiled = torch.compiler.precompile.load(python_code, cache)
+    with compiled, torch.no_grad():
+        compiled(model, x1)
+
+The examples ARE the capture: each one is run for you and every frame, break
+continuation and guarded variant it exercises is recorded. There is no manual
+capture block -- driving the calls yourself is not part of the public surface.
+
+Calls run under ``torch.no_grad()``. ``training=True`` runs them with grad
+enabled and lowers the backward eagerly instead, so the artifact carries one
+and a served output can be backpropagated. No loss is needed for that: the
+joint trace synthesizes tangents from the forward outputs' own metadata.
+
+Live capture retains every runtime guard, so later examples trigger the same
+recompilations as ordinary ``torch.compile``. ``guard_filter_fn`` applies only
+to the serialized copy. If serialization drops a configuration-dependent guard,
+the artifact is refused by default rather than written with variants whose
+dispatch would be ambiguous after load. ``invariants`` writes a readable report
+that separates, per frame, the guards holding in EVERY variant from the ones
+that differed: the first are preconditions the artifact is only valid under,
+the second are what tell its graphs apart. Guards from different frames are not
+comparable -- an entry frame guards its arguments, a resume frame guards
+whatever crossed the break -- so the intersection is per frame.
+
+Capture is by execution: a resume function only exists once the frame ahead of
+it has actually run, so every variant must be exercised. Whatever you do not
+run is not in the artifact, and ``summary().complete`` means complete only for
+the observed capture, not for every possible input to the callable. A captured
+call that raises marks the session incomplete even if caller code catches it.
+
+Know these before relying on an artifact in production:
+
+* An inference artifact is the default: examples run under ``torch.no_grad()``.
+  For a training artifact pass ``training=True``, which traces with grad on and
+  lowers the backward eagerly -- without it, AOTAutograd defers the backward to
+  the first ``.backward()`` call, so a grad-enabled capture that never makes one
+  records no backends and cannot be written.
+* A non-tensor argument, and any value that crosses a graph break, is guarded
+  by equality, so an int/bool/str argument or a break coming from ``.item()``
+  yields an artifact that only serves calls reproducing those exact values.
+  ``summary().wont_generalize`` lists them; exercise every value you need to
+  serve through ``example_inputs``, or expect poor coverage on new data.
+  ``dynamic=True`` helps with shapes but not with pinned values.
+* Identity guards cannot be serialized, so precompiling gives up on noticing
+  that a guarded object was rebound. ``summary().dropped_guards`` is the
+  authoritative list. ``risky_dropped_guards`` includes every drop observed to
+  distinguish captured variants plus a lint for configuration-like sources; it
+  is still not a proof for unobserved deployments. See ``_is_risky_drop``. The
+  public ``torch.compiler.precompile`` facade rejects the RISKY subset by
+  default. Refusing every drop is opt-in: every model drops the identity guards
+  precompile cannot serialize, so ``require_no_dropped_guards=True`` refuses
+  essentially every real artifact. Some models trip the lint on
+  library internals: measured on stock models, torchvision resnet18 and
+  mobilenet_v3 report none, timm's ViT reports one (a re-exported
+  ``torch._assert``) and transformers' Qwen2 reports 33 built from a two-layer
+  config, 55 for the pretrained 24-layer, of which only the
+  attention-implementation registry looks genuinely config-selected. Report
+  counts are per model, not per library: torchvision's efficientnet_b0 reports
+  2 and timm's swin reports 5, one of which is a real config slot. Audit the
+  list before relying on the relaxed dropped-guard default, and before
+  relaxing the risky-drop rail on top of it.
+* Some models do not capture yet. For example, T5 raises ``PackageError: Cannot
+  find module for code <code object __init__`` from ``_get_code_source``, which
+  is byte-identical to base and which plain ``caching_precompile`` also raises.
+* The model must live in an importable module. Source is checksummed, so a
+  class defined in ``__main__`` or a REPL cannot be loaded elsewhere.
+* ``install()`` writes compiled and resume functions into module globals, but
+  guarded dispatch is scoped to the isolated compile region owned by the
+  returned callable. Call the returned object rather than another instance of
+  the same class. Multiple loaded artifacts can share entry, inner, and resume
+  code objects without taking each other's entries; ``unload()`` removes only
+  its own region and the globals it still owns.
+This wraps CompilePackage, which is the low-level component and is not meant to
+be used directly.
+
+The public surface is ``torch.compiler.precompile`` -- with ``example_inputs``
+for this multi-graph form -- and ``torch.compiler.precompile.load``. The
+helpers in this module, including the capture session, implement that surface
+and remain internal. The positional ``torch.compiler.precompile`` form
+produces a self-contained Python source artifact from one example call. Both are distinct from
+``torch._dynamo.config.caching_precompile``, which caches ``torch.compile``
+artifacts transparently without an explicit capture block.
+"""
+
+from __future__ import annotations
+
+import ast
+import collections
+import contextlib
+import copy
+import functools
+import hashlib
+import importlib.machinery
+import logging
+import os
+import pickle
+import re
+import site
+import sys
+import sysconfig
+import threading
+import types
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextvars import ContextVar
+from typing import Any, TYPE_CHECKING
+from typing_extensions import Self
+
+import torch
+import torch._functorch.config as functorch_config
+from torch._guards import ChainedSource, Source
+from torch.compiler._precompile_types import (
+    ExampleInput,
+    FrameInvariants,
+    GuardFact as _GuardFact,
+    PrecompileSummary,
+)
+from torch.utils._pytree import tree_leaves
+
+from .exc import PackageError
+from .guards import CheckFunctionManager
+from .package import (
+    _BackendId,
+    _defining_module_name,
+    _DynamoCacheEntry,
+    CompilePackage,
+    DynamoStore,
+    PrecompileCacheEntry,
+)
+from .pgo import _use_code_state
+from .source import AttrSource, DictGetItemSource, GlobalSource
+
+
+if TYPE_CHECKING:
+    import traceback
+
+    from .types import GuardFilterEntry
+
+
+log = logging.getLogger(__name__)
+
+# Built once: the served call path enters this on every call, and
+# config.patch() allocates a class and a ContextVar each time it is called.
+_ALLOW_EMPTY_GRAPHS = torch._dynamo.config._make_closure_patcher(
+    allow_empty_graphs=True
+)
+
+
+_CAPTURE_CONFIG_STATE: ContextVar[tuple[int, tuple[bool, bool, bool] | None]] = (
+    ContextVar("precompile_capture_config_state", default=(0, None))
+)
+
+# Not a public surface -- see the module docstring. This exists so `from ...
+# import *` in a debugging session pulls the entry points rather than every
+# private helper, and so linters do not flag them as unused.
+__all__ = [
+    "precompile_load",
+    "ExampleInput",
+    "FrameInvariants",
+    "PrecompileSession",
+    "PrecompileSummary",
+    "PrecompiledCallable",
+    "precompile_capture",
+    "serving",
+]
+
+
+@contextlib.contextmanager
+def _capture_config(training: bool = False) -> Iterator[None]:
+    depth, prior = _CAPTURE_CONFIG_STATE.get()
+    dynamo_config: Any = torch._dynamo.config
+    if depth == 0:
+        prior = (
+            functorch_config.bundled_autograd_cache,
+            dynamo_config.allow_empty_graphs,
+            functorch_config.force_non_lazy_backward_lowering,
+        )
+        functorch_config.bundled_autograd_cache = True
+        dynamo_config.allow_empty_graphs = True
+        if training:
+            # AOTAutograd lowers the backward on the first .backward() call, so
+            # a capture that never calls one records a forward and nothing else.
+            # Lower it eagerly instead: the joint trace already synthesizes
+            # tangents from the forward outputs' metadata, so the backward graph
+            # exists without the caller having to produce a loss.
+            functorch_config.force_non_lazy_backward_lowering = True
+    _CAPTURE_CONFIG_STATE.set((depth + 1, prior))
+    try:
+        yield
+    finally:
+        depth, prior = _CAPTURE_CONFIG_STATE.get()
+        if depth <= 0 or prior is None:
+            raise AssertionError("precompile capture config is not active")
+        depth -= 1
+        if depth == 0:
+            functorch_config.bundled_autograd_cache = prior[0]
+            dynamo_config.allow_empty_graphs = prior[1]
+            functorch_config.force_non_lazy_backward_lowering = prior[2]
+            _CAPTURE_CONFIG_STATE.set((0, None))
+        else:
+            _CAPTURE_CONFIG_STATE.set((depth, prior))
+
+
+def _clear_package_region(
+    codes: Sequence[types.CodeType], isolate_recompiles_id: int
+) -> None:
+    from .eval_frame import _clear_cache_entries_for_region
+
+    for code in codes:
+        _clear_cache_entries_for_region(code, isolate_recompiles_id)
+
+
+def default_guard_filter_fn(
+    guard_entries: Sequence[GuardFilterEntry],
+) -> Sequence[bool]:
+    """
+    Drop the guard types that cannot be serialized, and keep everything else.
+
+    Read this before trusting an artifact. The unserializable set is exactly the
+    IDENTITY guards -- ID_MATCH, FUNCTION_MATCH, CLOSURE_MATCH, MODULE_MATCH,
+    NN_MODULE, CLASS_MATCH, DICT_VERSION, WEAKREF_ALIVE -- so precompiling
+    inherently gives up on noticing that a guarded object was REBOUND to a
+    different object of the same shape. Most such guards are on modules and
+    builtins and are stable in practice, but one on a global holding a function
+    is not: rebind it between capture and load and the artifact serves the graph
+    traced against the old one, with no error.
+
+    Keeping these makes serialization raise for essentially every function, so
+    every drop is recorded with its source name in
+    ``PrecompileSummary.dropped_guards``. ``save()`` does NOT refuse them by
+    default -- ``require_no_dropped_guards`` is False, because requiring none
+    would refuse essentially every model. The rail that is on is the risky-drop
+    lint, and a lint is not a proof. See ``risky_dropped_guards``.
+    """
+    unsupported = CheckFunctionManager.UNSUPPORTED_SERIALIZATION_GUARD_TYPES
+    return [
+        g.guard_type not in unsupported
+        and not any(d in unsupported for d in g.derived_guard_types)
+        for g in guard_entries
+    ]
+
+
+def _owning_module(value: object) -> str | None:
+    if isinstance(value, types.ModuleType):
+        return value.__name__
+    owner = getattr(value, "__module__", None)
+    return owner if isinstance(owner, str) else None
+
+
+def _source_root(source: Source) -> Source:
+    while isinstance(source, ChainedSource):
+        source = source.base
+    return source
+
+
+# Locals Dynamo synthesizes when a resume function is itself nested, passed
+# positionally into the continuation. They name generated code, not a slot any
+# config chooses, so an identity guard lost on one cannot diverge.
+_DYNAMO_SYNTHESIZED = ("__nested_resume_fns", "__nested_frame_values")
+
+
+def _is_dynamo_synthesized(source_name: str) -> bool:
+    return any(
+        source_name == n or source_name.startswith(n + "[") for n in _DYNAMO_SYNTHESIZED
+    )
+
+
+# A pip target nested inside the stdlib dir that sysconfig does not name in
+# this layout -- Debian's /usr/lib/python3.X/dist-packages -- still ends in one
+# of these.
+_INSTALL_DIR_NAMES = frozenset({"site-packages", "dist-packages"})
+
+
+def _norm(path: str) -> str:
+    return os.path.normcase(os.path.realpath(path))
+
+
+@functools.cache
+def _stdlib_roots() -> tuple[str, ...]:
+    """
+    Where this interpreter's own library lives. os is unquestionably stdlib, so
+    its directory is the direct evidence and the only one that stays right when
+    the stdlib is a zip; sysconfig and sys._stdlib_dir cover a build where os is
+    frozen with no __file__.
+    """
+    roots = []
+    os_file = getattr(os, "__file__", None)
+    if os_file:
+        roots.append(os.path.dirname(os_file))
+    frozen_dir = getattr(sys, "_stdlib_dir", None)  # 3.11+
+    if frozen_dir:
+        roots.append(frozen_dir)
+    paths = sysconfig.get_paths()
+    roots += [p for p in (paths.get("stdlib"), paths.get("platstdlib")) if p]
+    return tuple(sorted({_norm(p) for p in roots}))
+
+
+@functools.cache
+def _install_roots() -> tuple[str, ...]:
+    """
+    Where a third party lands. This is the load-bearing exclusion: purelib is
+    NESTED inside stdlib in a conda layout and inside platstdlib in a venv, so
+    without it every pip-installed package is under a stdlib root.
+    """
+    paths = sysconfig.get_paths()
+    roots = [p for p in (paths.get("purelib"), paths.get("platlib")) if p]
+    for name in ("getsitepackages", "getusersitepackages"):
+        # getattr, not a direct reference: the "old virtualenv site.py" this
+        # guards against does not DEFINE these, so naming them here would raise
+        # the very AttributeError the except is for -- out of a lint, aborting
+        # the capture it was asked to check.
+        get = getattr(site, name, None)
+        try:
+            got = get() if get is not None else None
+        except Exception:
+            continue  # -S, or a site.py that defines it but cannot answer
+        if got is None:
+            continue
+        roots += [got] if isinstance(got, str) else list(got)
+    return tuple(sorted({_norm(p) for p in roots}))
+
+
+@functools.cache
+def _torch_roots() -> tuple[str, ...]:
+    """
+    Every directory torch's own submodules come from. An editable build splits
+    them -- torch/__init__.py out of the source tree, _C.so and version.py out
+    of site-packages -- and torch.__path__ is exactly that set. It is only
+    trusted if the directory this file is running from is in it, so a
+    sys.modules['torch'] that is not us cannot nominate its own roots.
+    """
+    own_file = globals().get("__file__")
+    if not own_file:
+        return ()  # frozen torch: nothing to anchor to, fall back to the name
+    own = _norm(os.path.dirname(os.path.dirname(own_file)))
+    roots = {own}
+    search = getattr(sys.modules.get("torch"), "__path__", None) or ()
+    listed = {_norm(p) for p in search if isinstance(p, str)}
+    if own in listed:
+        roots |= listed
+    return tuple(sorted(roots))
+
+
+def _within(path: str, roots: tuple[str, ...]) -> bool:
+    return any(path == r or path.startswith(r + os.sep) for r in roots)
+
+
+@functools.cache
+def _classify_file(file: str, stdlib: bool) -> bool | None:
+    """
+    Cached on the __file__ string rather than on the module name: the roots are
+    fixed for the process, so the answer for a path never changes, while the
+    module a name resolves to can.
+    """
+    if not os.path.isabs(file):
+        # Resolving it would be against a cwd that is not the one it was
+        # recorded under, so it is evidence in neither direction. torch.ops
+        # really does carry __file__ == "_ops.py".
+        return None
+    path = _norm(file)
+    if not stdlib:
+        return _within(path, _torch_roots())
+    if _INSTALL_DIR_NAMES.intersection(path.split(os.sep)):
+        return False
+    return _within(path, _stdlib_roots()) and not _within(path, _install_roots())
+
+
+def _located(module: types.ModuleType, name: str, stdlib: bool) -> bool | None:
+    """Shipped here (True), shipped elsewhere (False), or no evidence (None)."""
+    # The module dict rather than getattr: a PEP 562 module __getattr__ is user
+    # code, and a module that raises on an unknown attribute would take save()
+    # down from inside a lint.
+    attrs = getattr(module, "__dict__", None) or {}
+    file = attrs.get("__file__")
+    if isinstance(file, str) and file:
+        verdict = _classify_file(file, stdlib)
+        if verdict is not None:
+            return verdict
+    spec = attrs.get("__spec__")
+    origin = getattr(spec, "origin", None)
+    loader = attrs.get("__loader__") or getattr(spec, "loader", None)
+    if origin == "built-in" or loader is importlib.machinery.BuiltinImporter:
+        # Statically linked, and BuiltinImporter precedes PathFinder on
+        # sys.meta_path, so no file on sys.path is reachable under this name.
+        return name.partition(".")[0] in sys.builtin_module_names
+    if origin == "frozen" or loader is importlib.machinery.FrozenImporter:
+        return True  # frozen also precedes the path finder
+    return None  # namespace package, exec'd in memory, REPL __main__
+
+
+def _is_library_module(module_name: str | None) -> bool:
+    """
+    Owned by torch or the stdlib, so config on the serving machine does not
+    choose between implementations. NB this trusts the OWNER, not the binding:
+    a third party that monkeypatches ``F.gelu`` at import time still diverges,
+    and that is called out in ``_is_risky_drop``'s KNOWN GAP.
+
+    sys.stdlib_module_names is a list of NAMES, and a waiver keyed on a name is
+    a collision away from being wrong: graphlib, queue, code and distutils are
+    all stdlib names a third party can and does supply. Worse, the name can be
+    right and the code still not be the stdlib's -- in a default setuptools
+    install ``import distutils`` gets site-packages/setuptools/_distutils, and
+    SETUPTOOLS_USE_DISTUTILS picks which one, which is exactly the
+    config-chooses-the-implementation shape this lint exists to catch. So the
+    module has to RESOLVE to code shipped with the interpreter: located under a
+    stdlib root and not under an install root (purelib nests inside stdlib in
+    conda and inside platstdlib in a venv, so the exclusion is what does the
+    work), or with no file at all because it is built in or frozen, which the
+    path finder cannot shadow. A name that is not imported, a namespace
+    package, and a module with no location evidence are all untrusted.
+    """
+    if module_name is None:
+        return False
+    top = module_name.partition(".")[0]
+    if top == "torch":
+        if not _torch_roots():
+            return True
+        stdlib = False
+    elif top in sys.stdlib_module_names:
+        stdlib = True
+    else:
+        return False
+    root = sys.modules.get(top)
+    if root is None or _located(root, top, stdlib) is not True:
+        return False
+    parts = module_name.split(".")
+    for i in range(2, len(parts) + 1):
+        name = ".".join(parts[:i])
+        module = sys.modules.get(name)
+        # An unimported inner name has nothing to check, and the package it
+        # would have to be found in has already been located.
+        if module is not None and _located(module, name, stdlib) is False:
+            return False
+    return True
+
+
+def _defined_where_read(
+    value: object, user_stack: traceback.StackSummary | None
+) -> bool:
+    """
+    Whether the def lives in the file of the frame that read it.
+
+    A def bound to its own name in its OWN module takes an edit there to
+    repoint. ``from impl_a import op`` takes only a conditional import in the
+    reader, which is not an edit at all and which no checksum covers.
+    """
+    home = sys.modules.get(getattr(value, "__module__", None) or "")
+    file = getattr(home, "__file__", None)
+    return bool(user_stack) and file is not None and file == user_stack[-1].filename
+
+
+def _dynamo_alias_module(global_name: str) -> types.ModuleType | None:
+    """The module behind an ``__import_a_dot_b`` alias, mirroring import_source."""
+    prefix = "__import_"
+    if not global_name.startswith(prefix):
+        return None
+    return sys.modules.get(global_name[len(prefix) :].replace("_dot_", "."))
+
+
+def _module_namespaces(
+    entries: Sequence[GuardFilterEntry],
+) -> dict[str, types.ModuleType]:
+    """
+    Sources holding a module whose binding config cannot repoint, mapped to the
+    module itself. Dynamo guards every module it walks through, so the path
+    down to ``F.gelu`` is guarded module by module, which is what lets an
+    attribute read be recognised as coming off a namespace rather than off an
+    object a config could have swapped. The module comes back with the name
+    because whether a read off a namespace is safe depends on which module it
+    is -- see ``_is_risky_drop``.
+
+    TRUSTED is the load-bearing half and is deliberately narrow. A module is
+    that if torch or the stdlib owns it, if it is bound under its own name --
+    ``import mypkg.layers``, and the ``__import_x`` alias Dynamo installs to
+    reach an inlined function's own globals -- or if it is an attribute of a
+    trusted module under a name that module already owns: its own ``__name__``
+    (a plain ``import own_sub`` inside the parent) or the parent's plus the
+    attribute (``from . import sub``). An ALIASED user module is none of those:
+    ``if flag: import impl_b as impl`` picks what ``impl.op`` resolves to per
+    machine, and so does the same alias spelled ``from . import impl_b as
+    impl`` in a package __init__. Inheriting the parent's trust without
+    checking the name is what let ``mypkg.impl.op`` through before.
+    """
+    modules = {
+        e.orig_guard.originating_source.name: (e.orig_guard.originating_source, e.value)
+        for e in entries
+        if isinstance(e.value, types.ModuleType)
+        and isinstance(_source_root(e.orig_guard.originating_source), GlobalSource)
+    }
+    # Dynamo guards the attributes it reads off an import alias but never the
+    # bare alias, so a real model produces G['__import_torch'].Tensor with no
+    # module-valued entry for G['__import_torch'] to anchor it. The alias name
+    # encodes its module, so recover it rather than treating torch.Tensor as a
+    # config-swappable slot.
+    for e in entries:
+        root = _source_root(e.orig_guard.originating_source)
+        if isinstance(root, GlobalSource) and root.name not in modules:
+            aliased = _dynamo_alias_module(root.global_name)
+            if aliased is not None:
+                modules[root.name] = (root, aliased)
+    trusted: dict[str, bool] = {}
+
+    def is_trusted(name: str) -> bool:
+        if name not in trusted:
+            trusted[name] = False  # also breaks cycles while recursing
+            found = modules.get(name)
+            if found is not None:
+                source, module = found
+                # Mirrors InstructionTranslator.import_source's alias.
+                dynamo_alias = "__import_" + module.__name__.replace(".", "_dot_")
+                if _is_library_module(module.__name__):
+                    trusted[name] = True
+                elif isinstance(source, GlobalSource):
+                    trusted[name] = source.global_name in (
+                        module.__name__,
+                        dynamo_alias,
+                    )
+                elif isinstance(source, AttrSource):
+                    outer = modules.get(source.base.name)
+                    trusted[name] = (
+                        outer is not None
+                        and is_trusted(source.base.name)
+                        and module.__name__
+                        in (source.member, f"{outer[1].__name__}.{source.member}")
+                    )
+        return trusted[name]
+
+    return {name: module for name, (_, module) in modules.items() if is_trusted(name)}
+
+
+# Dynamo's own handle on the builtins dict, minted by
+# OutputGraph.install_builtins_dict_in_fglobals.
+_BUILTINS_DICT_PREFIX = "__builtins_dict__"
+
+
+def _reads_a_builtin(source: Source, value: object) -> bool:
+    """
+    ``len`` or ``sorted`` reached the ordinary way, through the builtins dict
+    Dynamo installs to resolve them. No binding sits in front of those, so
+    nothing can repoint them.
+
+    A builtin parked in a slot -- ``self.act = abs``, straight out of an
+    ACT2FN-style table -- is a slot like any other, so this deliberately keys
+    on where the read comes FROM rather than on who owns the value.
+    """
+    return (
+        isinstance(source, DictGetItemSource)
+        and isinstance(source.base, GlobalSource)
+        and source.base.global_name.startswith(_BUILTINS_DICT_PREFIX)
+        and _owning_module(value) == "builtins"
+    )
+
+
+def _is_risky_drop(
+    entry: GuardFilterEntry, namespaces: dict[str, types.ModuleType]
+) -> bool:
+    """
+    Whether losing this identity guard can plausibly change results.
+
+    Intersect the binding SITE with who owns the value; either test alone is
+    wrong. Site alone: ``self.act = getattr(F, cfg.activation)`` and
+    ``self.act = cfg.act_fn`` are the same swappable slot, so calling the first
+    benign because ``F.gelu`` is torch-owned waves through the exact divergence
+    this check exists for -- capture gelu, serve silu, get the gelu graph and no
+    error. Ownership alone: ``if flag: import impl_b as impl`` then ``impl.op``
+    is a read off a module namespace exactly like ``F.gelu``, and the module is
+    user code an env var chose; so is ``self.act = abs``, where the value is a
+    builtin nothing can repoint but the attribute holding it is a slot. The site
+    survives the name stripping that makes source spelling useless -- a guard on
+    ``self.act`` arrives as ``'self.act'`` -- because the structured source is
+    still on the guard.
+
+    For a capture-here / serve-there deployment the concern is not in-process
+    rebinding but DIVERGENCE: the serving machine runs the same source but picks
+    a different object because config, a flag, or an env var differs. Three
+    bindings are waived -- a builtin read the ordinary way (see
+    ``_reads_a_builtin``), a read off a TRUSTED namespace (see
+    ``_module_namespaces``) that torch or the stdlib owns or that owns the
+    value itself, and a global bound to a def of that same name when torch or
+    the stdlib owns the def or it lives in the file doing the reading. The rest
+    are slots whose occupant config chooses: instance attributes, closure
+    cells, aliased imports, cross-module ``from x import op``, registry
+    lookups.
+
+    Trusting a namespace is not trusting everything read off it. ``F.gelu`` is
+    waived because torch owns torch.nn.functional and there is only one of it;
+    ``own_helpers.call`` is waived because own_helpers owns the def, subject to
+    the gap below. ``mypkg.op`` re-exported from ``mypkg.impl_b``,
+    ``dispatch.op`` and ``mypkg.impl.op`` are not waived: the import that chose
+    the implementation lives in a file the inlined-source checksum never sees,
+    so capture and serve can disagree with every other rail passing. Waiving
+    those is how this predicate failed open in an earlier round;
+    ``_RISKY_DROP_CORPUS`` in test_package.py is the regression net that keeps
+    them, and every other shape found so far, flagged.
+
+    KNOWN GAP, and it is a wrong-answer one. EVERY waiver above judges the
+    object capture happened to bind, not the statement that bound it, so any
+    name bound CONDITIONALLY is waived whenever the branch taken on the capture
+    machine is one of the waived shapes. This is not specific to the def-name
+    arm and it is not limited to the file being read:
+
+    - def-name arm. ``if HAVE_FAST: from fastops import gelu`` / ``else: from
+      torch.nn.functional import gelu``, captured without the flag, drops
+      ``G['gelu']`` and reports nothing; a serving machine that has fastops
+      runs torch's gelu instead, with no error. A def the reading file itself
+      redefines under an ``if`` is the same shape.
+    - namespace-owns-the-value arm. A module that binds a name under an ``if``
+      and is read as a namespace by an ordinary ``import mod`` elsewhere is
+      also waived, because at capture time the module really does own whichever
+      def the branch produced. The reading file binds nothing conditionally,
+      so it looks covered and is not.
+    - library-namespace arm, and this one needs no conditional at all. The
+      waiver trusts the owner, not the binding, so a third party that rebinds a
+      torch or stdlib attribute -- ``F.gelu = _fast_gelu`` executed at import
+      by a package that happens to be installed on the serving host -- is
+      waived even though the model itself reads ``F.gelu`` unconditionally.
+      ``functools.wraps(F.gelu)(user_fn)`` reaches the same waiver by a
+      different route, since it copies ``__name__`` and ``__module__`` off the
+      torch function it wraps.
+
+    An ``allow_in_graph`` function passes too, and Dynamo traces it opaquely so
+    the inlined-source checksum never covers it either. Nothing at capture time
+    distinguishes a conditional bind from an unconditional one -- only the
+    resulting object is visible -- so this is a limit of the approach rather
+    than a missing check. ``dropped_guards`` is the authoritative list; this
+    predicate is a lint over it, not a proof of safety.
+    """
+    source = entry.orig_guard.originating_source
+    value = entry.value
+    # entry.name, not source.name: guard names arrive with local scope stripped
+    # ("L['x'].y" -> "x.y"), and these are always locals of a resume frame.
+    if _is_dynamo_synthesized(entry.name):
+        return False
+    if source.name in namespaces:
+        return False
+    if _reads_a_builtin(source, value):
+        return False
+    if isinstance(source, ChainedSource):
+        namespace = namespaces.get(source.base.name)
+        if namespace is not None:
+            return not (
+                _is_library_module(namespace.__name__)
+                or _owning_module(value) == namespace.__name__
+            )
+    if (
+        isinstance(source, GlobalSource)
+        and getattr(value, "__name__", None) == source.global_name
+    ):
+        return not (
+            _is_library_module(_owning_module(value))
+            or _defined_where_read(value, entry.orig_guard.user_stack)
+        )
+    return True
+
+
+# CONSTANT_MATCH covers bool/None/int, EQUALS_MATCH everything else comparable.
+_VALUE_EQUALITY_GUARD_TYPES = frozenset({"CONSTANT_MATCH", "EQUALS_MATCH"})
+
+
+def _pins_a_value(guard_type: str, name: str) -> bool:
+    """
+    Whether this kept guard makes the artifact serve only the value it saw.
+
+    Two things have to line up, and keying on either one alone is wrong.
+
+    The guard has to be a value-equality one. TENSOR_MATCH, SHAPE_ENV and the
+    global-state guards are what every capture has and they generalize fine --
+    a TENSOR that crosses a graph break gets TENSOR_MATCH on a ``___stackN``
+    source and is emphatically not a pin.
+
+    And the source has to be a BARE name -- a plain local of some traced frame,
+    or the ``___stackN`` Dynamo gives a value crossing a graph break. Anything
+    dotted or subscripted (``self.eps``, ``model._modules['ln'].eps``,
+    ``G['CFG'].width``) is reached THROUGH an argument rather than being one,
+    which is where model config lives: every LayerNorm and Dropout contributes
+    a CONSTANT_MATCH there, so counting those would flag every model and make
+    the field noise.
+
+    KNOWN GAP: a constant inside a container argument is guarded on a
+    subscripted source (``dims[0]`` for ``x.sum(dim=[0])``) and is not counted.
+    ``kept_guards`` is the authoritative list; this is a lint over it.
+    """
+    return guard_type in _VALUE_EQUALITY_GUARD_TYPES and not any(
+        c in name for c in ".["
+    )
+
+
+# Object ids and the per-tensor _dynamo_*_indices probes are noise in a file
+# meant to be read and diffed: the first differs every run, the second is
+# identical on every tensor guard. The id pattern matches the second argument
+# of the ___check_obj_id / ___check_type_id call that emits it, NOT every long
+# integer: a bare \b\d{9,}\b also eats a user constant, and two variants
+# guarding different big values -- dict keys, a slice bound -- then render the
+# same fact and land in the intersection as an invariant neither of them holds.
+# An id inside ___check_obj_id(x, N), type=... and the raw tuple of them that
+# AUTOGRAD_SAVED_TENSORS_HOOKS renders. Both are addresses; both must go, and
+# neither may be widened into "any long integer", which would also erase a
+# large constant that legitimately differs between variants and so invent an
+# invariant. Keep these anchored to the shapes that actually carry addresses.
+_OBJ_ID = re.compile(r"(?<=, )\d+(?=\), type=)")
+_SAVED_HOOK_IDS = re.compile(r"(?<=top_saved_tensors_hooks ids == )\(\d+(?:, \d+)*\)")
+_DYNAMO_INDICES = re.compile(r"_dynamo_\w*indices")
+# Dynamo appends a per-process counter to the globals it installs, so the same
+# guard reads __builtins_dict___6 in one compilation and ___8 in the next.
+# Leaving that in makes identical guards look like they differ.
+_DYNAMO_COUNTER = re.compile(
+    r"(__builtins_dict__|__compiled_fn|__resume_at)_*\d+(_\d+)?"
+)
+# OutputGraph.install_global_by_id names a global "<prefix>_<id(value)>_c<n>",
+# so a guard reading one carries BOTH an address and a compile counter inside
+# an identifier, where neither pattern above can see it. Real models reach this
+# -- transformers' Qwen2 installs three -- and the report then differs run to
+# run, which is exactly what the "commit and diff" contract rules out.
+_DYNAMO_GLOBAL_BY_ID = re.compile(r"_\d{9,}_c\d+\b")
+
+
+def _normalize(text: str) -> str:
+    text = _SAVED_HOOK_IDS.sub("(<ids>)", text)  # see _saved_hooks_fingerprint
+    text = _DYNAMO_GLOBAL_BY_ID.sub("_<id>_c<n>", _OBJ_ID.sub("<id>", text))
+    return _DYNAMO_COUNTER.sub(r"\1_<n>", text)
+
+
+def _render_code(code_list: Sequence[str] | None) -> tuple[str, ...]:
+    # The _dynamo_*_indices parts are NOT boilerplate, whatever an earlier
+    # comment here claimed: they are the whole of TENSOR_MATCH's export info and
+    # they encode the dimension-marking guards, so mark_static on one variant
+    # and not the next shows up only here. Dropping them reported the guard that
+    # split two compilations as an invariant of both.
+    return tuple(_normalize(part) for part in (code_list or ()))
+
+
+class _PrecompileBackend:
+    """Give one explicit session its own Dynamo cache identity."""
+
+    def __init__(self, backend: str, keep_graphs: bool = False) -> None:
+        inner = torch._dynamo.lookup_backend(backend)
+        self._torchdynamo_orig_backend = inner
+        self._torchdynamo_cache_key = object()
+        # get_backend skips looking for that key until it knows one exists,
+        # because the lookup is a raising miss at every level of the callback
+        # chain for every torch.compile user who never precompiles.
+        torch._C._dynamo.eval_frame._enable_precompile_cache_keys()
+        self.backend_ctx_ctor = getattr(
+            inner, "backend_ctx_ctor", contextlib.nullcontext
+        )
+        # Rendering a subgraph as source needs the graph, which only exists
+        # here. Kept for the REAL capture only: the guard probe throws its
+        # graphs away, and rendering is a second full lowering.
+        self._keep_graphs = keep_graphs
+        self.graphs: dict[str, tuple[torch.fx.GraphModule, list[Any]]] = {}
+
+    def __call__(self, gm: torch.fx.GraphModule, inputs: list[torch.Tensor]) -> Any:
+        if self._keep_graphs:
+            backend_id = gm.meta.get("backend_id") or getattr(gm, "_backend_id", None)
+            if backend_id is not None and str(backend_id) not in self.graphs:
+                # Deep-copy before the inner backend runs: inductor lowering
+                # mutates the graph it is handed, and a rendered copy has to be
+                # the graph Dynamo produced, not the leftovers.
+                placeholders = [n for n in gm.graph.nodes if n.op == "placeholder"]
+                # Render against the placeholders' FAKES, never the real inputs
+                # below: compile_fx re-fakifies real tensors into a fresh symbol
+                # set and dedups by value, which silently unifies a batch dim
+                # with any other dim of the same size.
+                fakes = [
+                    n.meta.get("example_value", n.meta.get("val")) for n in placeholders
+                ]
+                if all(f is not None for f in fakes):
+                    self.graphs[str(backend_id)] = (copy.deepcopy(gm), fakes)
+        return self._torchdynamo_orig_backend(gm, inputs)
+
+    def get_compiler_config(self) -> Any:
+        getter = getattr(self._torchdynamo_orig_backend, "get_compiler_config", None)
+        return None if getter is None else getter()
+
+
+# Guards whose check IS object identity, directly or through a derived guard,
+# which is the same test default_guard_filter_fn drops on.
+_IDENTITY_GUARD_TYPES = frozenset(
+    CheckFunctionManager.UNSUPPORTED_SERIALIZATION_GUARD_TYPES
+)
+
+
+_STABLE_CONST_TYPES = (str, int, float, complex, bytes, bool, type(None))
+
+
+def _stable_consts(consts: tuple[object, ...]) -> tuple[object, ...]:
+    """
+    co_consts reduced to the part that reprs the same in every process.
+
+    A nested code object reprs with its ADDRESS, so it cannot go into a digest
+    that ends up in a file meant to be committed and diffed. Containers are
+    filtered recursively rather than dropped whole: two lambdas differing only
+    in a tuple or frozenset constant -- ``x * (1, 2)`` against ``x * (1, 3)`` --
+    are genuinely different variants, and dropping the container is what let
+    them collide.
+    """
+    out: list[object] = []
+    for c in consts:
+        if isinstance(c, _STABLE_CONST_TYPES):
+            out.append(c)
+        elif isinstance(c, types.CodeType):
+            # A nested code object reprs with its ADDRESS, so it cannot go in
+            # verbatim -- but dropping it merges two lambdas that differ only in
+            # a comprehension or an inner lambda, which is this same bug one
+            # level down. Recurse into its own fingerprint instead.
+            out.append(_code_fingerprint(c))
+        elif isinstance(c, tuple):
+            out.append(_stable_consts(c))
+        elif isinstance(c, frozenset):
+            # Sorted by repr so the digest does not inherit set iteration order.
+            out.append(tuple(sorted(_stable_consts(tuple(c)), key=repr)))
+    return tuple(out)
+
+
+def _code_fingerprint(code: types.CodeType) -> str:
+    """
+    Name a code object by its body, for callables a definition site cannot tell
+    apart -- an ACT2FN table written on one source line makes every lambda in it
+    agree on file AND lineno.
+
+    Everything hashed is derived from the source, so the digest is identical in
+    another process. It is NOT stable across Python versions, since co_code is
+    version-specific bytecode: a committed invariants file churns wholesale on
+    an interpreter upgrade even with unchanged source.
+    """
+    return _hash_text(
+        repr(
+            (
+                code.co_code,
+                code.co_names,
+                code.co_varnames,
+                # LOAD_DEREF addresses a cell by INDEX, so two closures that
+                # capture different variables have identical co_code and are
+                # told apart only by the names they close over.
+                code.co_freevars,
+                code.co_cellvars,
+                _stable_consts(code.co_consts),
+            )
+        )
+    )
+
+
+def _object_identity(value: object) -> str:
+    """
+    A stable stand-in for the id ``_normalize`` stripped.
+
+    A name rather than an address, so the file still diffs clean across runs.
+    Two objects of one type still collapse -- two Linear instances are
+    indistinguishable here -- but the case that matters must separate: one slot
+    holding a different callable in different variants. A qualname alone does
+    NOT achieve that, because the shape this exists for is an ACT2FN-style
+    table, whose entries are all ``<lambda>`` in one module. Two of those then
+    render identically, the CLOSURE_MATCH that split the compilations lands in
+    the intersection, and the report calls the one thing that varies an
+    invariant of both. So a callable is also named by where it is DEFINED and by
+    a digest of its body, both source-derived and so still stable across
+    processes; the file is reduced to its basename so the report does not carry
+    a checkout path.
+
+    The discriminating part goes FIRST. Truncation is what bounds this string,
+    and a qualname alone can exceed the limit on real models -- a transformers
+    lambda nested in a long module path -- so a digest appended at the end is
+    cut off exactly on the names that need it most, re-colliding what it was
+    added to separate.
+    """
+    if isinstance(value, types.ModuleType):
+        return f"is module {value.__name__}"
+    name = getattr(value, "__qualname__", None) or getattr(value, "__name__", None)
+    if isinstance(name, str):
+        code = getattr(value, "__code__", None)
+        where = ""
+        if isinstance(code, types.CodeType):
+            site = os.path.basename(code.co_filename or "?")
+            where = f"@{site}:{code.co_firstlineno}#{_code_fingerprint(code)} "
+        return _normalize(f"is {where}{_owning_module(value) or '?'}.{name}")[:160]
+    return f"is a {type(value).__module__}.{type(value).__qualname__}"[:160]
+
+
+# Guards whose C++ leaf compares something no fingerprint here models: subclass
+# metadata, a DTensor placement, an opaque object's guard values, a raw
+# DispatchKeySet, or process-wide state carried entirely in the leaf. Calling
+# two of these equal is how the report ends up asserting a precondition that
+# does not hold, so they are never compared -- they are reported separately as
+# undetermined, which is the honest answer and cannot mislead.
+_UNMODELLED_GUARD_TYPES = frozenset(
+    {
+        "DETERMINISTIC_ALGORITHMS",
+        "DISPATCH_KEY_SET_MATCH",
+        "DTENSOR_SPEC_MATCH",
+        "FSDP_TRAINING_STATE",
+        "GLOBAL_STATE",
+        "OPAQUE_OBJ_GUARD_FN_MATCH",
+        "SHAPE_ENV",
+        "TENSOR_SUBCLASS_METADATA_MATCH",
+        "TORCH_FUNCTION_STATE",
+    }
+)
+
+
+def _saved_hooks_fingerprint() -> str:
+    """Name the installed saved-tensors hooks by content, never by address."""
+    try:
+        from torch._functorch._aot_autograd.utils import top_saved_tensors_hooks
+
+        hooks = top_saved_tensors_hooks()
+    except Exception:
+        return ""
+    if not hooks:
+        return "hooks=None"
+    names = []
+    for hook in hooks:
+        code = getattr(hook, "code", None)  # fx GraphModule renders its graph
+        if isinstance(code, str):
+            names.append(_hash_text(code))
+        else:
+            names.append(_object_identity(hook))
+    return "hooks=(" + ", ".join(names) + ")"
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()[:12]
+
+
+def _value_fingerprint(entry: GuardFilterEntry) -> str:
+    """
+    What the guard checks, when the rendered code does not say.
+
+    TENSOR_MATCH is the case that matters: its code_list carries only the
+    _dynamo_*_indices hasattr checks, while everything it really compares lives
+    in the C++ leaf. Without those two specializations of one frame look
+    identical and wrongly land in the intersection, so this mirrors TensorCheck
+    -- python type and the full dispatch key set included, since a Parameter
+    against a Tensor, a conjugated view against a plain one, or an
+    inference-mode tensor against a no_grad one, splits a compilation exactly
+    as dtype does. KNOWN GAP: that leaf checks
+    nothing for a dim the compile made dynamic, so under ``dynamic=True`` the
+    concrete shape here is narrower than the guard and a shape-generic
+    TENSOR_MATCH is reported as varying rather than invariant.
+
+    An identity guard needs one too, because ``_normalize`` strips the id its
+    code renders: without a name for the object, two variants holding different
+    callables at one source collapse into one fact and are reported as an
+    invariant neither of them holds.
+
+    Every other guard takes its value from its own rendered code, which names
+    it, so fingerprinting it again SPLITS identical guards: TYPE_MATCH on an
+    unspecialized int checks only that the int is an int, and stamping 1 on one
+    variant and 2 on the next demotes a real invariant into two identical
+    'varies' lines.
+    """
+    if entry.guard_type == "AUTOGRAD_SAVED_TENSORS_HOOKS":
+        # Its code renders tuple(map(id, hooks)), which _normalize has to erase
+        # or the file churns -- but erasing it alone would merge two variants
+        # that differ ONLY in their hooks and report the guard that split them
+        # as an invariant. Put back a discriminator derived from what the hooks
+        # ARE rather than where they live, which is both stable across
+        # processes and still telling.
+        return _saved_hooks_fingerprint()
+    if entry.guard_type == "GRAD_MODE":
+        # Global-state guards carry no name, code or value, so two variants of
+        # one frame that differ only in grad mode render identically and land
+        # in the intersection. The filter runs in the traced frame's own state.
+        return f"grad_enabled={torch.is_grad_enabled()}"
+    if not entry.has_value:
+        return ""
+    value = entry.value
+    if isinstance(value, torch.Tensor):
+        # Ask the guard system what it stores rather than reconstructing it.
+        # Hand-rolling this failed four times running -- the concrete shape,
+        # then python type, then the conj/neg bits, then the rest of the
+        # dispatch key set -- and the last of those was still wrong, because
+        # TensorCheck stores the TLS-ADJUSTED key set, (ks | tls_included) -
+        # tls_excluded, not the tensor's own. get_tensor_guard_code_part is the
+        # function guards.py itself uses to render that, so it cannot drift.
+        from .guards import convert_to_concrete_values, get_tensor_guard_code_part
+
+        try:
+            return get_tensor_guard_code_part(
+                value,
+                "",
+                convert_to_concrete_values(value.size()),
+                convert_to_concrete_values(value.stride()),
+                type(value),
+                torch._C._dispatch_keys(value),
+            )
+        except Exception:
+            return f"type={type(value).__name__}, dtype={value.dtype}, <unrenderable>"
+    if entry.guard_type in _IDENTITY_GUARD_TYPES or any(
+        d in _IDENTITY_GUARD_TYPES for d in entry.derived_guard_types
+    ):
+        return _object_identity(value)
+    return ""
+
+
+def _fact_order(fact: _GuardFact) -> tuple[str, str, str, str]:
+    # value is part of the key: once the boilerplate code parts are filtered a
+    # TENSOR_MATCH renders no code, so two shape specializations would otherwise
+    # tie and sort unstably, making the file differ run to run.
+    return (fact.source, fact.guard_type, " ".join(fact.code), fact.value)
+
+
+def _example_call(
+    example: ExampleInput | tuple[object, ...],
+) -> tuple[tuple[object, ...], dict[str, object]]:
+    if isinstance(example, ExampleInput):
+        return example.args, example.kwargs
+    if isinstance(example, tuple):
+        return example, {}
+    raise TypeError(
+        f"example_inputs takes tuples of positional args or ExampleInput, got "
+        f"{type(example).__name__}. Wrap keyword arguments in "
+        f"torch.compiler.precompile.ExampleInput."
+    )
+
+
+def _wont_generalize(
+    kept: set[tuple[str, str]],
+    guard_sets: Mapping[tuple[str, str, int], Sequence[frozenset[_GuardFact]]],
+) -> tuple[str, ...]:
+    """Sources no captured variant will serve a new value for.
+
+    A source pinned in ONE variant is not pinned for the artifact: the union of
+    kept guards says "some graph equality-matched this", while what the warning
+    claims is "no graph will take anything else". A frame whose other variant
+    guards the same source generically -- the ordinary shape once two examples
+    are captured -- serves the new value fine, and warning about it tells the
+    caller to enumerate values that already work.
+    """
+    pinned = {n for t, n in kept if _pins_a_value(t, n)}
+    if not pinned:
+        return ()
+    for variants in guard_sets.values():
+        for facts in variants:
+            mentioned = {f.source for f in facts}
+            pins_here = {
+                f.source for f in facts if _pins_a_value(f.guard_type, f.source)
+            }
+            # This variant reached the source without pinning it, so it is the
+            # graph that serves other values.
+            pinned -= mentioned - pins_here
+    return tuple(sorted(pinned))
+
+
+def varying_guard_slots(
+    guard_sets: Mapping[tuple[str, str, int], Sequence[frozenset[_GuardFact]]],
+) -> frozenset[tuple[str, str]]:
+    """The guard slots that actually discriminate between captured variants.
+
+    A slot is ``(guard_type, normalized source)``. It varies when two variants
+    of one frame recorded DIFFERENT facts for it, and also when it is present in
+    some variants and absent in others -- a guard only one variant carries is
+    what tells that variant apart, and comparing values alone would call it
+    invariant and drop it. On a 62-frame ranking model that second case is 225
+    of the 274 slots kept, so it is the majority of the answer, not an edge.
+
+    Everything else held identically in every variant, so it is not serialized:
+    see the rationale at the call site in ``torch._precompile``.
+    """
+    varying: set[tuple[str, str]] = set()
+    for variants in guard_sets.values():
+        seen: dict[tuple[str, str], set[tuple[tuple[str, ...], str]]] = {}
+        present: collections.Counter[tuple[str, str]] = collections.Counter()
+        for facts in variants:
+            for slot in {(f.guard_type, f.source) for f in facts}:
+                present[slot] += 1
+            for f in facts:
+                seen.setdefault((f.guard_type, f.source), set()).add((f.code, f.value))
+        for slot, rendered in seen.items():
+            if len(rendered) > 1 or present[slot] != len(variants):
+                varying.add(slot)
+    return frozenset(varying)
+
+
+def _summarize(
+    entry: _DynamoCacheEntry,
+    dropped: set[tuple[str, str]],
+    kept: set[tuple[str, str]],
+    risky: set[tuple[str, str]],
+    truncated: frozenset[str],
+    uncovered: frozenset[str],
+    capture_errors: Sequence[str],
+    guard_sets: Mapping[tuple[str, str, int], Sequence[frozenset[_GuardFact]]],
+) -> PrecompileSummary:
+    wont_generalize = _wont_generalize(kept, guard_sets)
+    return PrecompileSummary(
+        frames=len(entry.codes),
+        resume_functions=sum(1 for c in entry.codes if c.install_to_global),
+        guarded_codes=sum(len(c.guarded_codes) for c in entry.codes),
+        backend_graphs=len(entry.backend_ids),
+        bypassed=tuple(c.python_code.co_name for c in entry.codes if c.bypassed),
+        truncated=tuple(sorted(truncated)),
+        uncovered_frames=tuple(sorted(uncovered)),
+        wont_generalize=wont_generalize,
+        dropped_guards=tuple(sorted(dropped)),
+        kept_guards=tuple(sorted(kept)),
+        risky_dropped_guards=tuple(sorted(risky)),
+        capture_errors=tuple(capture_errors),
+    )
+
+
+def _namespace_module_names(rendered: dict[str, str]) -> dict[str, str]:
+    """Suffix every top-level name a rendered subgraph DEFINES, per subgraph.
+
+    The blocks are spliced sequentially into ONE namespace, and their code
+    resolves siblings as late-bound globals: a block's ``call`` looks up
+    ``_runtime_wrapper`` and ``_inner_call`` when invoked, and its ``Runner``
+    looks up the Triton kernels. Two variants of one frame are the same
+    computation at different shapes, so they define the SAME names -- without
+    renaming, the first variant silently runs the second variant's code.
+    Snapshotting ``call`` after each block is not enough, because what a block
+    resolves is decided at call time, not at definition time.
+
+    Rewriting is driven by AST positions rather than a text match, which is what
+    keeps three lookalikes out of it: an attribute (``runner.call`` is an
+    ``Attribute``, not a ``Name``), a nested binding (``def call`` inside
+    ``class Runner`` is not module-level), and an import (``async_compile`` is
+    both a local binding and part of ``torch._inductor.async_compile``).
+    """
+    out: dict[str, str] = {}
+    for slot, (backend_id, source) in enumerate(rendered.items()):
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        defined: set[str] = set()
+        headers: list[tuple[int, str]] = []
+        for node in tree.body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for alias in node.names:
+                    imported.add((alias.asname or alias.name).split(".")[0])
+            elif isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                defined.add(node.name)
+                headers.append((node.lineno, node.name))
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        defined.add(target.id)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                defined.add(node.target.id)
+        targets = defined - imported
+        if not targets:
+            out[backend_id] = source
+            continue
+
+        suffix = f"_s{slot}"
+        edits: dict[int, list[tuple[int, int, str]]] = {}
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Name)
+                and node.id in targets
+                and node.end_col_offset is not None
+            ):
+                edits.setdefault(node.lineno, []).append(
+                    (node.col_offset, node.end_col_offset, node.id + suffix)
+                )
+        lines = source.split("\n")
+        for lineno, name in headers:
+            if name not in targets:
+                continue
+            line = lines[lineno - 1]
+            col = re.search(rf"\b{re.escape(name)}\b", line)
+            if col is not None:
+                edits.setdefault(lineno, []).append(
+                    (col.start(), col.end(), name + suffix)
+                )
+        for lineno, spans in edits.items():
+            line = lines[lineno - 1]
+            for begin, finish, text in sorted(spans, reverse=True):
+                line = line[:begin] + text + line[finish:]
+            lines[lineno - 1] = line
+        out[backend_id] = "\n".join(lines)
+    return out
+
+
+class PrecompileSession:
+    """
+    A capture in progress. Use as a context manager to get the callable to
+    exercise, then ``save()``. A session is one-shot and cannot be re-entered.
+    """
+
+    def __init__(
+        self,
+        fn: Callable[..., object],
+        *,
+        backend: str = "inductor",
+        guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
+        | None = None,
+        recompile_limit: int = 256,
+        dynamic: bool | None = None,
+        example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
+        invariants: str | None = None,
+        keep_only: frozenset[tuple[str, str]] | None = None,
+        training: bool = False,
+    ) -> None:
+        # Not `example_inputs or ()`: truth-testing the caller's object turns the
+        # likeliest mistake -- passing the tensors themselves instead of a
+        # sequence of call tuples -- into either a raw "Boolean value of Tensor
+        # is ambiguous" from inside torch, or, for a falsy tensor, a silently
+        # empty capture that only fails much later at save().
+        bad_container = isinstance(
+            example_inputs, (torch.Tensor, torch.nn.Module, str)
+        ) or not isinstance(example_inputs, Sequence)
+        if example_inputs is None:
+            self._example_inputs: tuple[ExampleInput | tuple[object, ...], ...] = ()
+        elif bad_container:
+            raise TypeError(
+                f"example_inputs takes a sequence of calls -- each a tuple of "
+                f"positional args, or a "
+                f"torch.compiler.precompile.ExampleInput -- got "
+                f"{type(example_inputs).__name__}. A single call is "
+                f"example_inputs=[(x,)], not example_inputs=x."
+            )
+        else:
+            self._example_inputs = tuple(example_inputs)
+        self._invariants_path = invariants
+        self._fn = fn
+        self._backend = backend
+        self._custom_guard_filter = guard_filter_fn is not None
+        # The guard slots that DID vary across the capture; every other slot is
+        # dropped. None means serialize everything serializable, which only the
+        # internal capture entry point uses -- precompile() always passes a set.
+        self._keep_only: frozenset[tuple[str, str]] | None = keep_only
+        # A training capture traces with grad on and lowers the backward
+        # eagerly, so the artifact carries AOTAutograd's CompiledFunction and
+        # calling .backward() on a served output runs precompiled code.
+        self._training = training
+        # Set by the caller for the real capture; the guard probe leaves it off
+        # so it does not pay for a lowering whose source is thrown away.
+        self._keep_graphs = False
+        self._backend_obj: _PrecompileBackend | None = None
+        self._policy_dropped_guards: set[tuple[str, str]] = set()
+        self._dropped_guards: set[tuple[str, str]] = set()
+        self._kept_guards: set[tuple[str, str]] = set()
+        self._risky_dropped_guards: set[tuple[str, str]] = set()
+        self._capture_errors: list[str] = []
+        self._recorded_exception_keys: set[tuple[type[BaseException], str]] = set()
+        # (co_name, co_filename, co_firstlineno) -> one fact set per compilation
+        self._guard_sets: dict[tuple[str, str, int], list[frozenset[_GuardFact]]] = {}
+        self._undetermined: dict[tuple[str, str, int], set[_GuardFact]] = {}
+        self._guard_filter_fn = self._recording_filter(
+            default_guard_filter_fn if guard_filter_fn is None else guard_filter_fn
+        )
+        self._recompile_limit = recompile_limit
+        self._dynamic = dynamic
+        self._entry_fn = _entry_fn_of(fn)
+        self._package = CompilePackage(
+            self._entry_fn,
+            serialization_guard_filter_fn=self._guard_filter_fn,
+            requires_native_backend_compatibility=backend != "eager",
+        )
+        self._backend_artifacts: dict[_BackendId, Any] = {}
+        self._stack: contextlib.ExitStack | None = None
+        self._optimized: Callable[..., object] | None = None
+        self._compiled: Callable[..., object] | None = None
+        self._isolate_recompiles_id: int | None = None
+        from .pgo import _new_code_state
+
+        self._pgo_state = _new_code_state()
+        self._state = threading.Condition()
+        self._active_calls = 0
+        self._closing = False
+        self._finished = False
+
+    def _take_backend_artifacts(self) -> None:
+        from torch._dynamo.precompile_context import PrecompileContext
+
+        for backend_id in self._package.cache_entry().backend_ids:
+            artifact = PrecompileContext.take_artifact(backend_id)
+            if artifact is not None:
+                self._backend_artifacts[backend_id] = artifact
+
+    def _record_capture_error(self, error: BaseException) -> None:
+        message = str(error)
+        key = (type(error), message)
+        if key in self._recorded_exception_keys:
+            return
+        self._recorded_exception_keys.add(key)
+        self._capture_errors.append(f"{type(error).__name__}: {message}")
+
+    @staticmethod
+    def _check_module_state(module: torch.nn.Module) -> None:
+        state = (
+            ("parameter", module.named_parameters()),
+            ("buffer", module.named_buffers()),
+        )
+        for kind, tensors in state:
+            for name, tensor in tensors:
+                if torch.is_inference(tensor):
+                    raise PackageError(
+                        f"automatic example capture found inference tensor {kind} "
+                        f"{name!r} on {type(module).__name__}. Automatic examples "
+                        "capture ordinary torch.no_grad() semantics, but leaving "
+                        "inference_mode does not turn existing tensors into ordinary "
+                        "tensors. Create the module outside torch.inference_mode(), or "
+                        "use capture() manually and serve under the matching inference "
+                        "mode."
+                    )
+
+    def _clear_runtime_cache(self) -> None:
+        if self._isolate_recompiles_id is None:
+            return
+        from .eval_frame import _unregister_explicit_compile_region
+
+        isolate_recompiles_id = self._isolate_recompiles_id
+        try:
+            _clear_package_region(self._package.region_codes(), isolate_recompiles_id)
+        finally:
+            _unregister_explicit_compile_region(isolate_recompiles_id)
+            self._isolate_recompiles_id = None
+            self._optimized = None
+            if self._backend != "eager":
+                self._package.cached_backends.clear()
+            self._pgo_state.clear()
+
+    def _call(self, *args: object, **kwargs: object) -> object:
+        with self._state:
+            if self._compiled is None or self._closing:
+                raise RuntimeError("PrecompileSession is not active")
+            compiled = self._compiled
+            self._active_calls += 1
+        from .pgo import _use_code_state
+
+        try:
+            with _capture_config(), _use_code_state(self._pgo_state):
+                return compiled(*args, **kwargs)
+        except BaseException as e:
+            self._record_capture_error(e)
+            raise
+        finally:
+            with self._state:
+                self._active_calls -= 1
+                if self._active_calls == 0:
+                    self._state.notify_all()
+
+    def __enter__(self) -> Callable[..., object]:
+        if self._finished:
+            raise RuntimeError("PrecompileSession cannot be re-entered")
+        if self._stack is not None:
+            raise RuntimeError("PrecompileSession is already active")
+        stack = contextlib.ExitStack()
+        # Backends must serialize into the artifact rather than into the
+        # process-local inductor cache.
+        stack.enter_context(_capture_config(self._training))
+        self._stack = stack
+        try:
+            if self._example_inputs:
+                module = (
+                    self._fn
+                    if isinstance(self._fn, torch.nn.Module)
+                    else getattr(self._fn, "__self__", None)
+                )
+                if isinstance(module, torch.nn.Module):
+                    self._check_module_state(module)
+            if self._optimized is None:
+                self._backend_obj = _PrecompileBackend(self._backend, self._keep_graphs)
+                optimize_ctx = torch._dynamo.optimize(
+                    self._backend_obj,
+                    package=self._package,
+                    recompile_limit=self._recompile_limit,
+                    dynamic=self._dynamic,
+                    isolate_recompiles=True,
+                )
+                isolate_recompiles_id = getattr(
+                    optimize_ctx, "_isolate_recompiles_id", None
+                )
+                if not isinstance(isolate_recompiles_id, int):
+                    raise AssertionError("missing isolate_recompiles_id")
+                self._isolate_recompiles_id = isolate_recompiles_id
+                from .eval_frame import _register_explicit_compile_region
+
+                _register_explicit_compile_region(isolate_recompiles_id, self)
+                self._optimized = optimize_ctx(self._fn)
+            self._compiled = self._optimized
+            # Automatic examples are the ordinary no_grad inference path.
+            # inference_mode is a distinct guarded state and is disabled here
+            # even when the caller entered it before starting capture.
+            for example in self._example_inputs:
+                args, kwargs = _example_call(example)
+                if any(
+                    isinstance(value, torch.Tensor) and torch.is_inference(value)
+                    for value in tree_leaves((args, kwargs))
+                ):
+                    raise PackageError(
+                        "example_inputs contains an inference tensor. Automatic "
+                        "examples capture ordinary torch.no_grad() semantics, but "
+                        "leaving inference_mode does not turn an existing inference "
+                        "tensor into an ordinary tensor. Create automatic inputs "
+                        "outside torch.inference_mode(), or use capture() manually "
+                        "and serve under the matching inference mode."
+                    )
+                for value in tree_leaves((args, kwargs)):
+                    if isinstance(value, torch.nn.Module):
+                        self._check_module_state(value)
+                if self._training:
+                    # Grad must be ON: the point of a training capture is that
+                    # AOTAutograd builds its CompiledFunction and the joint
+                    # graph, which it only does when the outputs require grad.
+                    with torch.inference_mode(False), torch.enable_grad():
+                        self._call(*args, **kwargs)
+                else:
+                    with torch.inference_mode(False), torch.no_grad():
+                        self._call(*args, **kwargs)
+        except BaseException as e:
+            self._record_capture_error(e)
+            # A __enter__ that raises never gets its __exit__, so without this
+            # the config patch above stays on for the life of the process and
+            # the session is wedged: save() reports the block as still open.
+            self._stack = None
+            self._compiled = None
+            try:
+                stack.close()
+            finally:
+                try:
+                    self._take_backend_artifacts()
+                finally:
+                    self._clear_runtime_cache()
+                    self._finished = True
+            raise
+        finally:
+            # Guard/backend state is already in the package. Do not retain the
+            # caller's potentially large CPU/GPU example tensors with the session.
+            self._example_inputs = ()
+        return self._call
+
+    def __exit__(self, *exc: object) -> None:
+        if isinstance(exc[1], BaseException):
+            self._record_capture_error(exc[1])
+        with self._state:
+            self._closing = True
+            try:
+                while self._active_calls:
+                    self._state.wait()
+            except BaseException:
+                self._closing = False
+                self._state.notify_all()
+                raise
+            stack = self._stack
+            self._stack = None
+            self._compiled = None
+        if stack is not None:
+            try:
+                stack.close()
+            except BaseException as e:
+                self._record_capture_error(e)
+                raise
+            finally:
+                try:
+                    self._take_backend_artifacts()
+                finally:
+                    self._clear_runtime_cache()
+                    self._finished = True
+                    with self._state:
+                        self._state.notify_all()
+        self._recorded_exception_keys.clear()
+        if self._invariants_path is None:
+            return
+        if exc[0] is None:
+            self.write_invariants(self._invariants_path)
+        else:
+            # A partial capture's report reads exactly like a complete one, so
+            # it is not written; say why rather than leaving the user looking
+            # for a file that never appeared.
+            log.warning(
+                "precompile: the capture block raised %s, so no invariants "
+                "report was written to %s. Call write_invariants() for the "
+                "partial one.",
+                getattr(exc[0], "__name__", exc[0]),
+                self._invariants_path,
+            )
+
+    def _recording_filter(
+        self,
+        inner: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]],
+    ) -> Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]:
+        """
+        Remember which guard types were discarded. A dropped guard does not
+        fail at serving time, it silently widens what a graph is reused for, so
+        the set has to be inspectable rather than invisible.
+        """
+
+        # One object per distinct fact, shared by every compilation that
+        # produced it. A recompiled frame repeats nearly all of its guards, so
+        # storing a copy per compilation makes the session grow with variants
+        # rather than with facts: 200 variants of resnet18 held 83MB for 1281.
+        pool: dict[_GuardFact, _GuardFact] = {}
+
+        def filter_fn(entries: Sequence[GuardFilterEntry]) -> Sequence[bool]:
+            decisions = inner(entries)
+            namespaces = _module_namespaces(entries)
+            # A slot whose fact was identical in every variant of every frame
+            # discriminates nothing, so it is not serialized. Recorded apart
+            # from the ordinary drops, which are "could not be serialized";
+            # these could, and were not wanted.
+            policy_dropped: set[int] = set()
+            if self._keep_only is not None:
+                for i, entry in enumerate(entries):
+                    # An unmodelled guard never enters _guard_sets, so it was
+                    # never shown to be constant -- only never analyzed. This
+                    # policy drops what it PROVED invariant, so these stay.
+                    # SHAPE_ENV is the one that matters: it carries symbolic
+                    # shape constraints that no TENSOR_MATCH repeats.
+                    if entry.guard_type in _UNMODELLED_GUARD_TYPES:
+                        continue
+                    if (
+                        decisions[i]
+                        and (
+                            entry.guard_type,
+                            _normalize(entry.name),
+                        )
+                        not in self._keep_only
+                    ):
+                        policy_dropped.add(i)
+                decisions = [
+                    keep and i not in policy_dropped for i, keep in enumerate(decisions)
+                ]
+            facts: set[_GuardFact] = set()
+            undetermined: set[_GuardFact] = set()
+            for i, (keep, entry) in enumerate(zip(decisions, entries)):
+                slot = (entry.guard_type, entry.name)
+                if i in policy_dropped:
+                    # Not "risky": the policy is the caller stating that the
+                    # environment is fixed and every variation is in the inputs,
+                    # so a slot that never varied is out of the artifact's
+                    # declared domain rather than an unchecked hazard.
+                    self._policy_dropped_guards.add(slot)
+                    continue
+                target = self._kept_guards if keep else self._dropped_guards
+                target.add(slot)
+                if not keep and (
+                    self._custom_guard_filter or _is_risky_drop(entry, namespaces)
+                ):
+                    self._risky_dropped_guards.add(slot)
+                unmodelled = entry.guard_type in _UNMODELLED_GUARD_TYPES
+                fact = _GuardFact(
+                    guard_type=entry.guard_type,
+                    source=_normalize(entry.name),
+                    code=_render_code(entry.code),
+                    value="" if unmodelled else _value_fingerprint(entry),
+                    enforced=keep,
+                )
+                fact = pool.setdefault(fact, fact)
+                # Never compared, so never claimed to hold: see
+                # _UNMODELLED_GUARD_TYPES.
+                (undetermined if unmodelled else facts).add(fact)
+            # One filter call is one compilation, and the package knows which
+            # frame is being compiled, which is the only place that mapping is
+            # available to us.
+            current = self._package._current_entry
+            code = current.python_code if current is not None else None
+            key = (
+                (code.co_name, code.co_filename, code.co_firstlineno)
+                if code is not None
+                else ("<unknown>", "<unknown>", 0)
+            )
+            self._guard_sets.setdefault(key, []).append(frozenset(facts))
+            self._undetermined.setdefault(key, set()).update(undetermined)
+            return decisions
+
+        return filter_fn
+
+    def invariants(self) -> tuple[FrameInvariants, ...]:
+        """
+        Per frame, the guards that held in EVERY compiled variant of it.
+
+        Intersection is per frame rather than global because guards from
+        different frames are not comparable: the entry frame guards its
+        arguments, a resume frame guards whatever crossed the graph break, so a
+        global intersection would be empty for any model that breaks.
+
+        A frame compiled once reports everything as invariant, which is true but
+        uninformative -- exercise more than one variant for the diff to mean
+        anything.
+
+        GLOBAL_STATE, TORCH_FUNCTION_STATE and DETERMINISTIC_ALGORITHMS carry
+        no value of their own, so nothing here can say whether two variants
+        agreed on, say, autocast. They are listed as UNDETERMINED rather than
+        compared -- see _UNMODELLED_GUARD_TYPES, and note that calling them
+        equal is precisely how the report would assert a precondition that does
+        not hold. GRAD_MODE is fingerprinted instead, because the capture path
+        itself produces that split and the fingerprint can model it.
+        """
+        out = []
+        for (name, filename, lineno), sets in sorted(self._guard_sets.items()):
+            shared = frozenset.intersection(*sets) if sets else frozenset()
+            everything: set[_GuardFact] = set()
+            for one in sets:
+                everything |= one
+            out.append(
+                FrameInvariants(
+                    frame=name,
+                    filename=filename,
+                    lineno=lineno,
+                    variants=len(sets),
+                    invariant=tuple(sorted(shared, key=_fact_order)),
+                    varying=tuple(sorted(everything - shared, key=_fact_order)),
+                    undetermined=tuple(
+                        sorted(
+                            self._undetermined.get((name, filename, lineno), set()),
+                            key=_fact_order,
+                        )
+                    ),
+                )
+            )
+        return tuple(out)
+
+    def write_invariants(self, path: str) -> None:
+        """
+        Write :meth:`invariants` to ``path`` in human-readable form.
+
+        ``path`` is a FILE, written exactly as given, with parent directories
+        created -- ``snapshots/invariants.txt`` is a text file. Same contract as
+        :meth:`save`.
+
+        Output is stable across runs of the same capture: object ids and
+        Dynamo's per-process counters are normalized away, so the file can be
+        committed and diffed to see what a model change did to its guards.
+        """
+        frames = self.invariants()
+        target = getattr(self._fn, "__qualname__", None) or type(self._fn).__qualname__
+        lines = [
+            f"# precompile invariants for {target}",
+            "#",
+            "# Conditions that held in EVERY compiled variant of a frame. A call",
+            "# violating one cannot be served by any graph in this artifact, so",
+            "# these are the preconditions the artifact is only valid under.",
+            "# 'varies' lists what differed between variants -- those are what",
+            "# distinguish one compiled graph from another, not preconditions.",
+            "# 'unknown' lists guards whose check this report cannot model, so it",
+            "# cannot say whether they held across variants. Treat them as",
+            "# neither: they may or may not be preconditions.",
+            "#",
+            "# enforced = the guard is serialized and rechecked when the artifact",
+            "#            is loaded.",
+            "# dropped  = it was not serialized, so it is a precondition",
+            "#            NOTHING checks at serving time. See",
+            "#            PrecompileSummary.dropped_guards.",
+            "#",
+            f"# {len(frames)} frame(s), "
+            f"{sum(f.variants for f in frames)} compilation(s)",
+        ]
+        if any(f.variants < 2 for f in frames):
+            lines.append(
+                "# NOTE: some frames were compiled once, so their invariants are"
+                " just every guard. Exercise more variants for a real diff."
+            )
+        for f in frames:
+            where = f"{os.path.basename(f.filename)}:{f.lineno}"
+            lines.append("")
+            lines.append(
+                f"frame {f.frame} ({where})  {f.variants} variant(s), "
+                f"{len(f.invariant)} invariant, {len(f.varying)} varying, "
+                f"{len(f.undetermined)} undetermined"
+            )
+            if not f.invariant:
+                lines.append("  invariant: (none)")
+            for fact in f.invariant:
+                lines.append(f"  invariant {fact.render()}")
+            for fact in f.varying:
+                lines.append(f"  varies    {fact.render()}")
+            for fact in f.undetermined:
+                lines.append(f"  unknown   {fact.render()}")
+        os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+        # UTF-8 explicitly: the report renders user identifiers (module, class and
+        # parameter names) and the ambient locale can be ASCII in a container, where
+        # a non-ASCII name would raise UnicodeEncodeError and leave a truncated file
+        # behind -- from the one call that exists to explain the artifact.
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+        log.info(
+            "precompile: wrote invariants for %d frame(s) to %s", len(frames), path
+        )
+
+    def summary(self) -> PrecompileSummary:
+        # A dropped fact counts as risky through this arm only when the SAME
+        # source held DIFFERENT values across the captured variants -- i.e. the
+        # drop demonstrably distinguishes them. Merely being absent from one
+        # variant does not: a MODULE_MATCH on torch.nn.functional that one
+        # branch happens not to touch was flagging every ordinary multi-branch
+        # capture, which is precisely the shape example_inputs= exists for, and
+        # left the operator no escape but disabling the rail wholesale. Grouped
+        # by source rather than by (guard_type, source) because a rebind can
+        # change the guard type too, and that is the case worth keeping.
+        values_by_source: dict[str, set[str]] = {}
+        for frame in self.invariants():
+            for fact in frame.varying:
+                if not fact.enforced:
+                    values_by_source.setdefault(fact.source, set()).add(fact.value)
+        varying_dropped = {
+            (fact.guard_type, fact.source)
+            for frame in self.invariants()
+            for fact in frame.varying
+            if not fact.enforced and len(values_by_source.get(fact.source, ())) > 1
+        }
+        # Normalized: a Dynamo per-process counter (__builtins_dict___14) makes
+        # one logical drop appear once per compilation, under names that change
+        # every run, which inflates the count save() truncates at 8 and can push
+        # the genuinely config-selected drop out of the operator's view.
+        risky = {
+            (guard_type, _normalize(name))
+            for guard_type, name in self._risky_dropped_guards
+        } | {
+            (guard_type, _normalize(name))
+            for guard_type, name in self._dropped_guards
+            if (guard_type, _normalize(name)) in varying_dropped
+        }
+        return _summarize(
+            self._package.cache_entry(),
+            self._dropped_guards,
+            self._kept_guards,
+            risky,
+            self._package.truncated_frames,
+            self._package.uncovered_frames,
+            self._capture_errors,
+            self._guard_sets,
+        )
+
+    def _gated_summary(
+        self,
+        *,
+        require_complete: bool,
+        require_no_risky_drops: bool,
+        require_no_dropped_guards: bool,
+        caller: str,
+    ) -> PrecompileSummary:
+        """Run the coverage and guard gates, or raise saying which one failed."""
+        if self._stack is not None:
+            raise RuntimeError(f"{caller} must be called after the capture block exits")
+        summary = self.summary()
+        if require_complete and summary.capture_errors:
+            raise PackageError(
+                "Precompilation is incomplete because capture raised: "
+                f"{list(summary.capture_errors)}. Re-run every example successfully, "
+                "or pass require_complete=False to save the partial artifact."
+            )
+        if require_no_dropped_guards and summary.dropped_guards:
+            raise PackageError(
+                f"Precompilation dropped {len(summary.dropped_guards)} guard(s) that "
+                f"were not serialized: {list(summary.dropped_guards)}. Rebinding any "
+                f"of those sources between capture and load can silently serve a graph "
+                f"traced against the old value. Pass require_no_dropped_guards=False "
+                f"only to select the relaxed risky-drop policy."
+            )
+        if summary.risky_dropped_guards and require_no_risky_drops:
+            raise PackageError(
+                f"Precompilation dropped guard(s) that can affect dispatch on "
+                f"{[n for _, n in summary.risky_dropped_guards]}. Each of those names "
+                f"either a configuration-dependent identity slot or a guard discarded "
+                f"by a custom filter. Nothing checks it at load time, so a different "
+                f"value can silently select the wrong graph instead of recompiling. "
+                f"Make the value reachable through a serializable guard, pin both "
+                f"machines to the same value, or pass "
+                f"require_no_risky_drops=False to accept the risk explicitly."
+            )
+        elif summary.risky_dropped_guards:
+            # The caller explicitly accepted the risk. Measured on stock models: torchvision
+            # resnet18 and mobilenet_v3 report none, timm's ViT reports one (a
+            # re-exported torch._assert) and transformers' Qwen2 reports 33,
+            # nearly all of them library internals that no deployment swaps.
+            names = [n for _, n in summary.risky_dropped_guards]
+            # The cut below is in guard-type order and says nothing about
+            # severity: Qwen2's one genuinely config-selected drop sorts past
+            # it, so a truncated report has to say where the rest are.
+            rest = (
+                ""
+                if len(names) <= 8
+                else f" Only the first 8 are shown, cut in guard-type order "
+                f"rather than by severity; summary().risky_dropped_guards has "
+                f"all {len(names)}."
+            )
+            log.warning(
+                "precompile: %d dropped guard(s) can affect dispatch, so nothing "
+                "checks them at load: %s.%s Audit them against "
+                "your deployment; this warning appears only because "
+                "require_no_risky_drops=False explicitly accepted them.",
+                len(names),
+                names[:8],
+                rest,
+            )
+        if require_complete:
+            if summary.guarded_codes == 0:
+                raise PackageError(
+                    "Precompilation captured no compiled code. Capture happens by "
+                    "execution, so the callable must actually be run inside the "
+                    "capture block. A call Dynamo could not turn into guarded code "
+                    "is reported separately as an uncovered frame."
+                )
+            if summary.truncated:
+                raise PackageError(
+                    f"Precompilation is incomplete: at least "
+                    f"{len(summary.truncated)} frame(s) exceeded recompile_limit "
+                    f"(currently {self._recompile_limit}) and are missing variants: "
+                    f"{list(summary.truncated)}. That list is a lower bound -- hitting "
+                    f"the limit also puts every frame called beneath the named one "
+                    f"into run-only mode, so those stop capturing too and never "
+                    f"re-enter Dynamo to report it. A frame needs one slot per "
+                    f"variant, and frames shared across module instances accumulate "
+                    f"them. Raise recompile_limit, or pass require_complete=False to "
+                    f"accept an artifact that is more incomplete than this list shows."
+                )
+            if summary.uncovered_frames:
+                raise PackageError(
+                    f"Precompilation exercised frame(s) that produced NO guarded code "
+                    f"at all: {list(summary.uncovered_frames)}. Those paths are absent "
+                    f"from the artifact, and such a frame is skipped at install and runs "
+                    f"eager, so serving() cannot report that gap. This is expected for a "
+                    f"frame that only dispatches to covered submodules; it also looks "
+                    f"exactly like a frame Dynamo gave up on (check "
+                    f"TORCH_LOGS=graph_breaks for gb0124). A frame that hit the recompile "
+                    f"limit has working variants and is reported as truncated instead. "
+                    f"Pass require_complete=False once you have confirmed which."
+                )
+            if summary.bypassed:
+                raise PackageError(
+                    f"Precompilation is incomplete: {len(summary.bypassed)} frame(s) "
+                    f"were bypassed and will serve nothing: {list(summary.bypassed)}. "
+                    f"This usually means their guards could not be serialized. Pass "
+                    f"require_complete=False to accept a partial artifact."
+                )
+        if summary.wont_generalize:
+            log.warning(
+                "precompile: %d value(s) are pinned to what capture saw (%s). A call "
+                "supplying anything else misses every graph, so exercise each value "
+                "you need to serve inside the capture block.",
+                len(summary.wont_generalize),
+                list(summary.wont_generalize),
+            )
+        return summary
+
+    def save(
+        self,
+        path: str,
+        *,
+        require_complete: bool = True,
+        require_no_risky_drops: bool = True,
+        require_no_dropped_guards: bool = False,
+    ) -> PrecompileSummary:
+        r"""Write the artifact with independent coverage and guard gates.
+
+        ``require_complete`` gates exactly ``PrecompileSummary.complete``. The
+        two guard rails are separate from it, because a dropped guard is a wrong
+        answer rather than a gap in coverage. ``require_no_dropped_guards`` is
+        False here and in the public ``torch.compiler.precompile`` facade:
+        every model drops the identity guards precompile cannot serialize, so
+        requiring none refuses essentially every real artifact. The rail that
+        is on by default is ``require_no_risky_drops``, and the risky subset is
+        deliberately only a lint, not a proof.
+
+        ``path`` is a FILE, written exactly as given with parent directories
+        created, and ``precompile_load`` takes it straight back. Same contract
+        as ``invariants``.
+        """
+        if self._stack is not None:
+            raise RuntimeError("save() must be called after the capture block exits")
+        summary = self.summary()
+        if require_complete and summary.capture_errors:
+            raise PackageError(
+                "Precompilation is incomplete because capture raised: "
+                f"{list(summary.capture_errors)}. Re-run every example successfully, "
+                "or pass require_complete=False to save the partial artifact."
+            )
+        if require_no_dropped_guards and summary.dropped_guards:
+            raise PackageError(
+                f"Precompilation dropped {len(summary.dropped_guards)} guard(s) that "
+                f"were not serialized: {list(summary.dropped_guards)}. Rebinding any "
+                f"of those sources between capture and load can silently serve a graph "
+                f"traced against the old value. Pass require_no_dropped_guards=False "
+                f"only to select the relaxed risky-drop policy."
+            )
+        if summary.risky_dropped_guards and require_no_risky_drops:
+            raise PackageError(
+                f"Precompilation dropped guard(s) that can affect dispatch on "
+                f"{[n for _, n in summary.risky_dropped_guards]}. Each of those names "
+                f"either a configuration-dependent identity slot or a guard discarded "
+                f"by a custom filter. Nothing checks it at load time, so a different "
+                f"value can silently select the wrong graph instead of recompiling. "
+                f"Make the value reachable through a serializable guard, pin both "
+                f"machines to the same value, or pass "
+                f"require_no_risky_drops=False to accept the risk explicitly."
+            )
+        elif summary.risky_dropped_guards:
+            # The caller explicitly accepted the risk. Measured on stock models: torchvision
+            # resnet18 and mobilenet_v3 report none, timm's ViT reports one (a
+            # re-exported torch._assert) and transformers' Qwen2 reports 33,
+            # nearly all of them library internals that no deployment swaps.
+            names = [n for _, n in summary.risky_dropped_guards]
+            # The cut below is in guard-type order and says nothing about
+            # severity: Qwen2's one genuinely config-selected drop sorts past
+            # it, so a truncated report has to say where the rest are.
+            rest = (
+                ""
+                if len(names) <= 8
+                else f" Only the first 8 are shown, cut in guard-type order "
+                f"rather than by severity; summary().risky_dropped_guards has "
+                f"all {len(names)}."
+            )
+            log.warning(
+                "precompile: %d dropped guard(s) can affect dispatch, so nothing "
+                "checks them at load: %s.%s Audit them against "
+                "your deployment; this warning appears only because "
+                "require_no_risky_drops=False explicitly accepted them.",
+                len(names),
+                names[:8],
+                rest,
+            )
+        if require_complete:
+            if summary.guarded_codes == 0:
+                raise PackageError(
+                    "Precompilation captured no compiled code. Capture happens by "
+                    "execution, so the callable must actually be run inside the "
+                    "capture block. A call Dynamo could not turn into guarded code "
+                    "is reported separately as an uncovered frame."
+                )
+            if summary.truncated:
+                raise PackageError(
+                    f"Precompilation is incomplete: at least "
+                    f"{len(summary.truncated)} frame(s) exceeded recompile_limit "
+                    f"(currently {self._recompile_limit}) and are missing variants: "
+                    f"{list(summary.truncated)}. That list is a lower bound -- hitting "
+                    f"the limit also puts every frame called beneath the named one "
+                    f"into run-only mode, so those stop capturing too and never "
+                    f"re-enter Dynamo to report it. A frame needs one slot per "
+                    f"variant, and frames shared across module instances accumulate "
+                    f"them. Raise recompile_limit, or pass require_complete=False to "
+                    f"accept an artifact that is more incomplete than this list shows."
+                )
+            if summary.uncovered_frames:
+                raise PackageError(
+                    f"Precompilation exercised frame(s) that produced NO guarded code "
+                    f"at all: {list(summary.uncovered_frames)}. Those paths are absent "
+                    f"from the artifact, and such a frame is skipped at install and runs "
+                    f"eager, so serving() cannot report that gap. This is expected for a "
+                    f"frame that only dispatches to covered submodules; it also looks "
+                    f"exactly like a frame Dynamo gave up on (check "
+                    f"TORCH_LOGS=graph_breaks for gb0124). A frame that hit the recompile "
+                    f"limit has working variants and is reported as truncated instead. "
+                    f"Pass require_complete=False once you have confirmed which."
+                )
+            if summary.bypassed:
+                raise PackageError(
+                    f"Precompilation is incomplete: {len(summary.bypassed)} frame(s) "
+                    f"were bypassed and will serve nothing: {list(summary.bypassed)}. "
+                    f"This usually means their guards could not be serialized. Pass "
+                    f"require_complete=False to accept a partial artifact."
+                )
+        if summary.wont_generalize:
+            log.warning(
+                "precompile: %d value(s) are pinned to what capture saw (%s). A call "
+                "supplying anything else misses every graph, so exercise each value "
+                "you need to serve inside the capture block.",
+                len(summary.wont_generalize),
+                list(summary.wont_generalize),
+            )
+        self._take_backend_artifacts()
+        store = _SingleFileStore(self._backend_artifacts)
+        if self._backend == "eager":
+            # Eager "backends" are fx graphs with no compiled artifact of their
+            # own, so they have to be handed to the store explicitly.
+            for backend_id, backend in self._package.cached_backends.items():
+                store.record_eager_backend(backend_id, backend)
+        try:
+            # save_cache_entry, not save_package: the latter also files the
+            # package into the process-global PrecompileContext, which is for
+            # the transparent cache. An artifact written to a path the caller
+            # chose should not leave anything behind.
+            store.save_cache_entry(self._package.cache_entry(), path)
+        except RuntimeError as e:
+            if "is not found in the given backends" not in str(e):
+                raise
+            raise PackageError(
+                "Precompilation captured graphs but their compiled backends were "
+                "never recorded, so there is nothing to serialize. AOTAutograd only "
+                "records the bundled artifact once the BACKWARD compiles, so a "
+                "forward-only capture with grad enabled records nothing on its own. "
+                "Pass training=True to lower the backward eagerly (the joint "
+                "trace synthesizes tangents, so no loss is needed), capture "
+                "under torch.no_grad()/torch.inference_mode() for an inference "
+                "artifact, or run .backward() inside the capture block."
+            ) from e
+        log.info("precompile: saved %s to %s", summary, path)
+        return summary
+
+    def rendered_backends(self, backend_ids: Sequence[str]) -> dict[str, str]:
+        """Compiled subgraphs as READABLE source, keyed by backend id.
+
+        The pickled bundle is the fallback, not the goal: a subgraph is Inductor
+        output, which has a source form (the make_fx tracer emits exactly this),
+        unlike the guard trees and transformed bytecode beside it. Anything that
+        fails to render -- a training graph, an effectful op, a graph with no
+        compute -- is simply absent here and stays pickled.
+
+        Rendering re-runs AOTAutograd + Inductor on the retained graph, so it is
+        a second lowering, paid once per subgraph that reaches the artifact.
+        """
+        from torch._functorch import aot_autograd
+
+        if self._backend_obj is None or self._backend == "eager":
+            return {}
+        if self._training:
+            # compile_to_python pins AOTAutograd to the INFERENCE path, so a
+            # training graph renders as a forward with the backward silently
+            # dropped -- the served output would lose its grad_fn. That is a
+            # wrong answer rather than a failed render, so it cannot be left to
+            # the except below; refuse up front and keep the bundle.
+            return {}
+        rendered: dict[str, str] = {}
+        for backend_id in backend_ids:
+            held = self._backend_obj.graphs.get(str(backend_id))
+            if held is None:
+                continue
+            gm, fakes = held
+            try:
+                source, _ = aot_autograd.compile_to_python(gm, fakes)
+            except Exception as e:
+                log.debug("precompile: %s stays pickled (%s)", backend_id, e)
+                continue
+            rendered[str(backend_id)] = source
+        return _namespace_module_names(rendered)
+
+    def _collect_backends(self) -> dict[str, Any]:
+        """The compiled subgraphs this capture produced, keyed by backend id."""
+        from torch._dynamo.precompile_context import (
+            EagerCacheArtifact,
+            PrecompileContext,
+        )
+
+        self._take_backend_artifacts()
+        collected = dict(self._backend_artifacts)
+        if self._backend == "eager":
+            # Eager "backends" are fx graphs with no compiled artifact of their
+            # own, so they have to be gathered explicitly.
+            for backend_id, backend in self._package.cached_backends.items():
+                collected[backend_id] = EagerCacheArtifact(
+                    key=backend_id, content=backend
+                )
+        entry = self._package.cache_entry()
+        for backend_id in entry.backend_ids:
+            if backend_id not in collected:
+                artifact = PrecompileContext.take_artifact(backend_id)
+                if artifact is not None:
+                    collected[backend_id] = artifact
+        missing = [b for b in entry.backend_ids if b not in collected]
+        if missing:
+            raise PackageError(
+                "Precompilation captured graphs but their compiled backends were "
+                "never recorded, so there is nothing to serialize. AOTAutograd only "
+                "records the bundled artifact once the BACKWARD compiles, so a "
+                "forward-only capture with grad enabled records nothing on its own. "
+                "Pass training=True to lower the backward eagerly (the joint "
+                "trace synthesizes tangents, so no loss is needed), capture "
+                "under torch.no_grad()/torch.inference_mode() for an inference "
+                "artifact, or run .backward() inside the capture block."
+            )
+        return {str(b): collected[b] for b in entry.backend_ids}
+
+    def artifact(
+        self,
+        *,
+        require_complete: bool = True,
+        require_no_risky_drops: bool = True,
+        require_no_dropped_guards: bool = False,
+    ) -> tuple[str, bytes]:
+        """Render this capture as ``(python_code, cache)``.
+
+        Same contract and the same gates as the single-graph forms: python_code
+        is a self-contained module exposing ``forward``, and cache is an
+        acceleration the loader may ignore. The guard trees and transformed
+        bytecode have no readable form and sit in labelled opaque sections; the
+        compiled subgraphs DO have one, so they are rendered as source where
+        the backend can render them and pickled only where it cannot.
+        """
+        summary = self._gated_summary(
+            require_complete=require_complete,
+            require_no_risky_drops=require_no_risky_drops,
+            require_no_dropped_guards=require_no_dropped_guards,
+            caller="artifact()",
+        )
+        from torch._precompile import _build_multigraph_artifact
+
+        entry = self._package.cache_entry()
+        backends = self._collect_backends()
+        return _build_multigraph_artifact(
+            entry,
+            backends,
+            summary,
+            self._backend,
+            _entry_fn_of(self._fn),
+            self.rendered_backends(list(backends)),
+        )
+
+
+class _SingleFileStore(DynamoStore):
+    """
+    One artifact, one file.
+
+    DiskDynamoStore treats its path as a directory and writes ``entry`` inside
+    it, which is right for a content-addressed cache that owns its own layout.
+    An artifact you name explicitly is a file you hand around, so this writes
+    exactly the path given. Only the two storage primitives differ; everything
+    above them is the shared DynamoStore.
+    """
+
+    def __init__(self, backend_artifacts: dict[_BackendId, Any] | None = None) -> None:
+        self._backend_artifacts = {} if backend_artifacts is None else backend_artifacts
+
+    def clear(self) -> None:
+        self._backend_artifacts.clear()
+
+    def record_eager_backend(self, backend_id: _BackendId, backend: Any) -> None:
+        from torch._dynamo.precompile_context import EagerCacheArtifact
+
+        self._backend_artifacts[backend_id] = EagerCacheArtifact(
+            key=backend_id, content=backend
+        )
+
+    def save_cache_entry(self, cache_entry: _DynamoCacheEntry, key: str) -> None:
+        from torch._dynamo.precompile_context import (
+            BackendCacheArtifact,
+            PrecompileContext,
+        )
+
+        for backend_id in cache_entry.backend_ids:
+            if backend_id not in self._backend_artifacts:
+                artifact = PrecompileContext.take_artifact(backend_id)
+                if artifact is not None:
+                    self._backend_artifacts[backend_id] = artifact
+        missing = [
+            backend_id
+            for backend_id in cache_entry.backend_ids
+            if backend_id not in self._backend_artifacts
+        ]
+        if missing:
+            raise RuntimeError(
+                f"Backend {missing[0]} is not found in the given backends"
+            )
+        backends = {
+            backend_id: self._backend_artifacts[backend_id]
+            for backend_id in cache_entry.backend_ids
+        }
+        if not all(
+            isinstance(artifact, BackendCacheArtifact) for artifact in backends.values()
+        ):
+            raise AssertionError("Expected BackendCacheArtifact")
+        self.write(PrecompileCacheEntry(cache_entry, backends), key)
+
+    def load_cache_entry(self, key: str) -> PrecompileCacheEntry:
+        return self.read(key)
+
+    def write(self, cache_entry: PrecompileCacheEntry, path: str) -> None:
+        from torch._inductor.codecache import write_atomic
+
+        if os.path.isdir(path):
+            raise PackageError(
+                f"{path} is a directory. precompile artifacts are single files; "
+                f"pass the path you want the artifact written to."
+            )
+        try:
+            os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+            write_atomic(path, pickle.dumps(cache_entry))
+        except Exception as e:
+            raise PackageError(f"Failed to write artifact to {path}: {e}") from e
+
+    def read(self, path: str) -> PrecompileCacheEntry:
+        if os.path.isdir(path):
+            raise PackageError(
+                f"{path} is a directory. precompile artifacts are single files; "
+                f"pass the path save() was given."
+            )
+        try:
+            with open(path, "rb") as handle:
+                entry = pickle.loads(handle.read())
+        except Exception as e:
+            raise PackageError(f"Failed to read artifact from {path}: {e}") from e
+        if not isinstance(entry, PrecompileCacheEntry):
+            raise PackageError(f"{path} does not hold a precompile artifact")
+        return entry
+
+
+def precompile_load(
+    fn: Callable[..., object],
+    path: str,
+    *,
+    backend: str = "inductor",
+    guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
+    | None = None,
+    recompile_limit: int = 256,
+    dynamic: bool | None = None,
+) -> PrecompiledCallable:
+    r"""Load an artifact and return a callable ready to serve it.
+
+    The wiring is order-sensitive -- the package has to be attached to the
+    optimize context before its globals and guarded codes are installed -- so it
+    is done here rather than left to callers.
+
+    Installing mutates global state on the underlying code objects, so the result
+    is also a context manager that unloads on exit. ``torch._dynamo.reset()`` is
+    not that unload: it destroys the precompile entries while leaving the
+    installed globals in place, so a call after a reset raises rather than
+    silently recompiling. Load the artifact again instead.
+
+    Runtime guards remain intact for any compilation allowed outside
+    ``serving()``. ``guard_filter_fn`` affects only its serialized package state.
+    """
+    entry_fn = _entry_fn_of(fn)
+    store = _SingleFileStore()
+    cache_entry = store.load_cache_entry(path)
+    _check_artifact_matches(cache_entry.dynamo, entry_fn, path)
+    return serve_cache_entry(
+        fn,
+        cache_entry,
+        backend=backend,
+        guard_filter_fn=guard_filter_fn,
+        recompile_limit=recompile_limit,
+        dynamic=dynamic,
+    )
+
+
+def serve_cache_entry(
+    fn: Callable[..., object],
+    cache_entry: PrecompileCacheEntry,
+    *,
+    backend: str = "inductor",
+    guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
+    | None = None,
+    recompile_limit: int = 256,
+    dynamic: bool | None = None,
+) -> PrecompiledCallable:
+    """Wire an already-loaded cache entry onto ``fn`` and install it.
+
+    Shared by ``precompile_load``, which reads the entry from a path, and by the
+    multi-graph artifact whose driver carries the same entry inline: the wiring
+    is order-sensitive (the package has to be attached to the optimize context
+    before its globals and guarded codes are installed), so it lives in one
+    place rather than being written twice.
+    """
+    entry_fn = _entry_fn_of(fn)
+    package = CompilePackage(
+        entry_fn,
+        cache_entry.dynamo,
+        serialization_guard_filter_fn=(
+            default_guard_filter_fn if guard_filter_fn is None else guard_filter_fn
+        ),
+    )
+    optimize_ctx = torch._dynamo.optimize(
+        _PrecompileBackend(backend),
+        package=package,
+        recompile_limit=recompile_limit,
+        dynamic=dynamic,
+        isolate_recompiles=True,
+    )
+    compiled = optimize_ctx(fn)
+    isolate_recompiles_id = getattr(optimize_ctx, "_isolate_recompiles_id", None)
+    if not isinstance(isolate_recompiles_id, int):
+        raise AssertionError("missing isolate_recompiles_id")
+    package.install(cache_entry.backends, isolate_recompiles_id=isolate_recompiles_id)
+    return PrecompiledCallable(compiled, package, isolate_recompiles_id)
+
+
+def precompile_capture(
+    fn: Callable[..., object],
+    *,
+    backend: str = "inductor",
+    guard_filter_fn: Callable[[Sequence[GuardFilterEntry]], Sequence[bool]]
+    | None = None,
+    recompile_limit: int = 256,
+    dynamic: bool | None = None,
+    example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
+    invariants: str | None = None,
+    keep_only: frozenset[tuple[str, str]] | None = None,
+    training: bool = False,
+) -> PrecompileSession:
+    r"""Begin capturing ``fn`` into a multi-graph artifact.
+
+    ``recompile_limit`` defaults well above Dynamo's usual 8 because a
+    precompile deliberately wants one compiled variant per condition, whereas
+    the normal limit exists to catch runaway recompilation. It also raises a
+    lower ambient ``accumulated_recompile_limit`` for this capture so that the
+    explicit API limit is the effective one.
+
+    ``example_inputs`` are run on ``__enter__``, under ``torch.no_grad()``, so
+    the ``with`` body is optional for an inference capture; calls you make in
+    the body run in the ambient grad mode instead. Existing inference tensors in
+    the inputs or an ``nn.Module``'s parameters and buffers are rejected because
+    disabling inference mode does not make them ordinary tensors. ``invariants``
+    names a file written when the block exits without an exception. A session is
+    one-shot; create another capture instead of re-entering it.
+
+    Runtime guards remain intact during capture. ``guard_filter_fn`` applies
+    only to the serialized guard state, so every supplied example observes the
+    same recompilation behavior as ordinary ``torch.compile``. ``save()`` refuses
+    the risky subset by default rather than every drop, and every guard a custom
+    filter drops counts as risky.
+    """
+    return PrecompileSession(
+        fn,
+        backend=backend,
+        guard_filter_fn=guard_filter_fn,
+        recompile_limit=recompile_limit,
+        dynamic=dynamic,
+        example_inputs=example_inputs,
+        invariants=invariants,
+        keep_only=keep_only,
+        training=training,
+    )
+
+
+class PrecompiledCallable:
+    """A loaded artifact. Call it, or use it as a context manager to scope it."""
+
+    def __init__(
+        self,
+        compiled: Callable[..., object],
+        package: CompilePackage,
+        isolate_recompiles_id: int,
+    ) -> None:
+        self._compiled: Callable[..., object] | None = compiled
+        self._package = package
+        self._isolate_recompiles_id = isolate_recompiles_id
+        from .pgo import _new_code_state
+
+        self._pgo_state = _new_code_state()
+        self._state = threading.Condition()
+        self._active_calls = 0
+        self._unloading = False
+        self._loaded = True
+        from .eval_frame import _register_explicit_compile_region
+
+        _register_explicit_compile_region(isolate_recompiles_id, self)
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        with self._state:
+            if not self._loaded or self._unloading:
+                raise RuntimeError("PrecompiledCallable has been unloaded")
+            if self._package.installed_entries_dropped():
+                raise PackageError(
+                    "torch._dynamo.reset() cleared the precompiled code this "
+                    "artifact installed. The installed globals are still in "
+                    "place, so this call would silently recompile instead of "
+                    "serving, or fail with an indistinguishable RecompileError "
+                    "under serving(). Load the artifact again after the reset."
+                )
+            compiled = self._compiled
+            if compiled is None:
+                raise AssertionError("loaded callable is missing")
+            self._active_calls += 1
+        # An uncovered no-op branch must become a guarded variant rather than
+        # Dynamo's ordinary eager-only SkipFrame. Otherwise one fallback call
+        # permanently skips that frame and later serving() cannot detect it.
+        try:
+            # _make_closure_patcher rather than config.patch(): patch() builds a
+            # fresh ConfigPatch class and a fresh ContextVar on every call, and
+            # this runs on every served call. The patcher is built once at import
+            # and costs a set/restore pair.
+            revert = _ALLOW_EMPTY_GRAPHS()
+            try:
+                with _use_code_state(self._pgo_state):
+                    return compiled(*args, **kwargs)
+            finally:
+                revert()
+        finally:
+            with self._state:
+                self._active_calls -= 1
+                if self._active_calls == 0:
+                    self._state.notify_all()
+
+    def __enter__(self) -> Self:
+        with self._state:
+            if not self._loaded or self._unloading:
+                raise RuntimeError("PrecompiledCallable has been unloaded")
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.unload()
+
+    def unload(self) -> None:
+        """Remove installed globals and precompile entries from the code objects."""
+        with self._state:
+            while self._unloading:
+                self._state.wait()
+            if not self._loaded:
+                return
+            self._unloading = True
+            try:
+                while self._active_calls:
+                    self._state.wait()
+            except BaseException:
+                self._unloading = False
+                self._state.notify_all()
+                raise
+            self._loaded = False
+        # uninstall() forgets which code objects it installed onto, and a frame
+        # reached through code_source was installed onto the live code the
+        # running program resolves rather than the reconstructed twin the
+        # package holds, so the set to clear has to be taken first.
+        codes = self._package.region_codes()
+        try:
+            self._package.uninstall()
+        finally:
+            try:
+                _clear_package_region(codes, self._isolate_recompiles_id)
+            finally:
+                from .eval_frame import _unregister_explicit_compile_region
+
+                _unregister_explicit_compile_region(self._isolate_recompiles_id)
+                with self._state:
+                    self._unloading = False
+                    self._compiled = None
+                    self._package.cached_backends.clear()
+                    self._pgo_state.clear()
+                    self._state.notify_all()
+
+
+@contextlib.contextmanager
+def serving() -> Iterator[None]:
+    """
+    Forbid compilation, so a call the artifact does not cover raises instead of
+    quietly recompiling.
+
+    Scoped to the CALLING THREAD, not the process: a serving process is
+    multi-threaded by definition, and a process-wide switch made one request
+    handler's block reject a concurrent handler's legitimate recompile. The
+    corollary is that work handed to other threads is NOT covered --
+    ``with serving(): pool.map(model, batches)`` leaves the workers free to
+    recompile.
+
+    It is not a property of the artifact either: it applies to every call made
+    on this thread while it is active.
+    """
+    from .eval_frame import (
+        _enter_fail_on_recompile_override,
+        _exit_fail_on_recompile_override,
+    )
+
+    _enter_fail_on_recompile_override()
+    try:
+        yield
+    finally:
+        _exit_fail_on_recompile_override()
+
+
+def _check_artifact_matches(
+    dynamo: _DynamoCacheEntry, entry_fn: Callable[..., object], path: str
+) -> None:
+    """
+    Refuse an artifact captured from a different callable.
+
+    CompilePackage.initialize discards the serialized entry code object and
+    rebinds the stored guards and bytecode onto whatever function it is given,
+    and the source checksum only covers the ORIGINAL function's source, so a
+    mismatch is not otherwise detected: the wrong callable simply returns the
+    captured one's results.
+
+    Identity is (defining module, qualname, co_name, first line). The first
+    line is what separates two definitions of one name in one module -- the
+    class under an ``if`` that a config flag picks -- which every other field
+    agrees on and which the source checksum passes, since both branches are in
+    the file it hashes. co_filename is deliberately NOT compared: the capture
+    and serving machines check out to different absolute paths, and the module
+    name already carries what the path would say.
+    """
+    code = getattr(entry_fn, "__code__", None)
+    if code is None:
+        raise PackageError(f"{entry_fn!r} has no __code__ to load {path} onto.")
+    if not dynamo.codes:
+        raise PackageError(f"Artifact at {path} contains no code entries.")
+    entry = dynamo.codes[0]
+    actual_module = _defining_module_name(code) or getattr(entry_fn, "__module__", None)
+    if actual_module is not None and entry.python_module != actual_module:
+        raise PackageError(
+            f"Artifact at {path} was captured from a callable defined in "
+            f"{entry.python_module!r} but is being loaded onto one defined in "
+            f"{actual_module!r}. Loading it would serve the captured "
+            f"function's graphs for this one."
+        )
+    expected = dynamo.fn_name
+    actual = getattr(entry_fn, "__qualname__", None)
+    if expected is not None and actual is not None and expected != actual:
+        raise PackageError(
+            f"Artifact at {path} was captured from {expected!r} but is being "
+            f"loaded onto {actual!r}. Loading it would serve the captured "
+            f"function's graphs for this one."
+        )
+    stored = entry.python_code
+    if stored.co_name != code.co_name:
+        raise PackageError(
+            f"Artifact at {path} was captured from code object "
+            f"{stored.co_name!r} but is being loaded onto {code.co_name!r}."
+        )
+    if stored.co_firstlineno != code.co_firstlineno:
+        raise PackageError(
+            f"Artifact at {path} was captured from a definition at "
+            f"{entry.python_module}:{stored.co_firstlineno} but the callable of "
+            f"that name here is defined at line {code.co_firstlineno}. Same "
+            f"name, different definition -- a class defined under an `if` that "
+            f"a config flag or environment variable resolves the other way on "
+            f"this machine looks exactly like this, and nothing else catches "
+            f"it, because both branches are in the source the checksum covers. "
+            f"A module whose lines merely shifted also lands here."
+        )
+
+
+@functools.singledispatch
+def _entry_fn_of(fn: object) -> Callable[..., object]:
+    if not callable(fn):
+        raise TypeError(f"expected a callable or nn.Module, got {type(fn).__name__}")
+    if not hasattr(fn, "__code__"):
+        raise TypeError(
+            f"expected a function or nn.Module, got {type(fn).__name__}, which "
+            f"has no __code__ for Dynamo to capture or to load an artifact "
+            f"onto. Pass partial.func for a functools.partial, or obj.__call__ "
+            f"for an object that only defines __call__."
+        )
+    return fn  # type: ignore[return-value]
+
+
+@_entry_fn_of.register
+def _(fn: torch.nn.Module) -> Callable[..., object]:
+    forward = fn.forward
+    if not hasattr(forward, "__code__"):
+        raise TypeError(
+            f"{type(fn).__name__}.forward is a {type(forward).__name__}, which "
+            f"has no __code__ for Dynamo to capture or to load an artifact onto. "
+            f"Binding it in __init__ -- self.forward = functools.partial(...) -- "
+            f"shadows the class method and lands here; keep forward a method."
+        )
+    return forward

--- a/torch/_dynamo/types.py
+++ b/torch/_dynamo/types.py
@@ -47,6 +47,10 @@ class GuardFilterEntry:
     derived_guard_types: tuple[str, ...]
     is_global: bool
     orig_guard: Guard
+    # Snapshot of orig_guard.code_list as of the inspection build. Guard.
+    # set_export_info EXTENDS that list on every subsequent build, so reading it
+    # off orig_guard later yields the same code two or three times over.
+    code: tuple[str, ...] = ()
 
 
 class GuardFn(Protocol):

--- a/torch/_functorch/_aot_autograd/to_standalone_python.py
+++ b/torch/_functorch/_aot_autograd/to_standalone_python.py
@@ -116,7 +116,8 @@ _COMPILE_LOCK = threading.RLock()
 # We do NOT reimplement any of this. We CAPTURE AOTAutograd's exact codegen'd wrapper
 # source together with the (pre-exec) globals dict each wrapper closed over: a
 # thread-local sink in codegen.py records one GeneratedSource per wrapper.
-# To trigger the capture we run AOTAutograd ourselves (under no_grad, the inference path)
+# To trigger the capture we run AOTAutograd ourselves (under no_grad, the inference path --
+# see compile_to_python's ``grad_enabled`` for the one graph shape that needs grad on)
 # with a capture-only inner compiler: it grabs the dense inner graph and returns a
 # placeholder callable, so AOTAutograd still codegen's the runtime-wrapper chain AROUND
 # that placeholder -- which is what the sink records. Inductor does not run in that pass;
@@ -828,7 +829,12 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     strides has static sizes, and treating it as static would silently specialize the
     artifact to the example strides. (Unbacked symints appearing only in intermediates,
     not on any placeholder, are still missed here, but such a graph fails loudly
-    downstream when emit_value rejects the still-symbolic metadata.)"""
+    downstream when emit_value rejects the still-symbolic metadata.)
+
+    Both metadata keys are checked, like ``_resolve_fake_mode``: make_fx stashes the fake
+    under "val", while a Dynamo graph (which torch.compiler.precompile's dynamo tracer
+    feeds here) stashes it under "example_value" -- reading only "val" would call a
+    dynamic Dynamo graph static and silently specialize it to the example sizes."""
     import torch
 
     def _is_symbolic(v: Any) -> bool:
@@ -837,15 +843,16 @@ def _graph_has_dynamic_shapes(gm: GraphModule) -> bool:
     for node in gm.graph.nodes:
         if node.op != "placeholder":
             continue
-        val = node.meta.get("val")
-        if _is_symbolic(val):
-            return True
-        if isinstance(val, torch.Tensor) and (
-            any(_is_symbolic(s) for s in val.shape)
-            or any(_is_symbolic(s) for s in val.stride())
-            or _is_symbolic(val.storage_offset())
-        ):
-            return True
+        for key in ("val", "example_value"):
+            val = node.meta.get(key)
+            if _is_symbolic(val):
+                return True
+            if isinstance(val, torch.Tensor) and (
+                any(_is_symbolic(s) for s in val.shape)
+                or any(_is_symbolic(s) for s in val.stride())
+                or _is_symbolic(val.storage_offset())
+            ):
+                return True
     return False
 
 
@@ -854,8 +861,20 @@ def compile_to_python(
     example_inputs: Sequence[Any],
     *,
     options: dict[str, Any] | None = None,
+    grad_enabled: bool = False,
 ) -> tuple[str, bytes | None]:
     """Compile ``gm`` to ``(python_code, cache)``; see the module docstring.
+
+    ``grad_enabled`` runs the AOTAutograd capture pass under ``enable_grad`` instead of the
+    default ``no_grad``. Pass it ONLY for a graph that performs autograd INTERNALLY -- a
+    Dynamo graph captured with ``trace_autograd_ops``, whose traced ``torch.autograd.grad``
+    call needs a live autograd graph to differentiate and otherwise fails the capture pass
+    with "element 0 of tensors does not require grad". Such a graph is still an INFERENCE
+    graph at the AOT boundary (its backward lives inside the traced call, so AOTAutograd
+    still emits exactly one forward module). Do NOT pass it for an ordinary graph whose
+    INPUTS require grad: ``no_grad`` is what pins AOTAutograd to the inference path there,
+    and enabling grad would make it emit a joint forward+backward the standalone composer
+    cannot compose.
 
     THREADING: serialized by a process-global lock (``_COMPILE_LOCK``). The wrapper-source
     capture is thread-local, but the AOTAutograd pass and the inner inductor compile both
@@ -951,7 +970,7 @@ def compile_to_python(
             "from_graph" if _graph_has_dynamic_shapes(gm) else "from_example_inputs"
         )
         with (
-            torch.no_grad(),
+            torch.enable_grad() if grad_enabled else torch.no_grad(),
             _standalone_context(gm, shapes_mode, aot=False),
             capture_generated_sources(captured),
         ):

--- a/torch/_functorch/config.py
+++ b/torch/_functorch/config.py
@@ -374,7 +374,7 @@ graphsafe_rng_functionalization = True
 # used by AOT compile and other settings
 # TODO: once AOT compile calls aot autograd directly instead of
 # through compile_fx, we can remove this
-force_non_lazy_backward_lowering = False
+force_non_lazy_backward_lowering: bool = False
 
 # only for testing, used to turn functionalization off in AOTDispatcher
 _test_disable_functionalization = True

--- a/torch/_precompile.py
+++ b/torch/_precompile.py
@@ -1,16 +1,49 @@
-"""Ahead-of-time precompilation (``make_fx`` tracer by default; Dynamo planned).
+"""Ahead-of-time precompilation (``make_fx`` tracer by default; ``dynamo`` also available).
 
-    python_code, cache = torch.compiler.precompile(fn, model, *example_inputs)
+    python_code, cache = torch.compiler.precompile(fn, example_inputs=[(model, x)])
     f_c = torch.compiler.precompile.load(python_code, cache)
-    out = f_c(model, *example_inputs)   # pass the model again at runtime
+    out = f_c(model, x)                 # pass the model again at runtime
 
-precompile captures your computation with ``make_fx`` -- a NON-STRICT trace of the ATen
-ops that run when ``fn`` executes once on the example inputs. It does not analyze your
-Python, so it comes with an explicit contract (the programming model): stay inside it
-and the artifact faithfully reproduces ``fn``; step outside it and you get an artifact
-that computes the wrong thing.
+    python_code, cache = torch.compiler.precompile(
+        fn, example_inputs=[(model, x1), (model, x2)], tracer="dynamo"
+    )
 
-``precompile`` returns a self-contained, executable ``python_code`` string plus a
+``example_inputs`` is the only calling convention: a sequence of calls, each a tuple of
+positional arguments (or an ``ExampleInput`` when keywords are needed). ``tracer`` picks
+the capture front-end, and it is the ONLY thing that does -- ``make_fx`` takes exactly one
+call, ``dynamo`` takes as many as you want.
+
+precompile captures your computation with ``make_fx`` (the default ``tracer``) -- a
+NON-STRICT trace of the ATen ops that run when ``fn`` executes once on the example
+inputs. It does not analyze your Python, so it comes with an explicit contract (the
+programming model): stay inside it and the artifact faithfully reproduces ``fn``; step
+outside it and you get an artifact that computes the wrong thing.
+
+The ``dynamo`` tracer is an alternative capture front-end that analyzes the Python
+(bytecode) rather than tracing one path. It inlines the TRANSFORMED BYTECODE Dynamo
+produces into ``python_code`` (marshalled, rehydrated at load) and lowers the compiled
+subgraph through the same backends; forward and training computations, ``mark_unbacked``
+dynamic shapes, and a ``decompositions`` table all work with it. See the ``tracer`` note at
+the bottom of Note [precompile programming model].
+
+For a computation with graph breaks, or to retain several guarded/recompiled variants,
+pass ``tracer="dynamo"`` with as many calls as you need. Either tracer returns the same
+``(python_code, cache)`` pair, reloaded with ``torch.compiler.precompile.load``; add
+``training=True`` for an artifact that carries a backward. ``make_fx`` produces one trace,
+so it captures exactly one call and refuses a longer ``example_inputs``.
+
+Multi-graph capture keeps all live guards while running examples, then filters only the
+serialized copy. ``save()`` refuses known coverage gaps, failed captures, and RISKY
+dropped guards by default; the stricter ``require_no_dropped_guards`` is off, since
+every model drops identity guards that cannot be serialized. Coverage remains
+execution-driven: a complete summary describes the calls
+that ran, not every possible input or unexecuted branch. precompile makes the calls, so
+precompile picks the grad mode: ordinary ``torch.no_grad()`` unless ``training=True``.
+Serve the resulting artifact under the mode it was captured in -- grad mode is a
+``GLOBAL_STATE`` guard, and it is checked. Example inputs and module parameters/buffers
+created as inference tensors are rejected.
+
+precompile returns a self-contained, executable ``python_code`` string plus a
 companion integrity-tagged ``cache``. With ``backend="inductor"`` (the default) the
 captured graph is lowered through the AOT backend contract
 (``torch._functorch.aot_autograd.compile_to_python``, AOTAutograd + Inductor);
@@ -127,7 +160,11 @@ it.
 #    ``.backward()`` step), not the grads. The grad scatter is the ONLY mutation
 #    precompile performs, and it happens in Python outside the graph, so the graph stays
 #    functional. precompile does not own optimizer state; bring your own optimizer and
-#    zero grads as usual.
+#    zero grads as usual. The dynamo tracer reaches the SAME observable behavior by a
+#    different route (see the tracer note): the backward stays a traced autograd call
+#    inside the graph and Dynamo's own bytecode does the accumulate, so there is no
+#    harvested-output list -- but which params get a grad is still fixed at trace time,
+#    frozen params still keep ``.grad = None``, and the accumulate still matches eager.
 #
 # 6. Shapes are static by default (dynamic dims are opt-in via mark_unbacked, invariant
 #    3), each input's dtype/device is baked, and the inductor backend also specializes
@@ -197,22 +234,114 @@ it.
 # whole runnable artifact).
 #
 # tracer: the capture front-end, orthogonal to backend. "make_fx" (default) is a
-# non-strict trace and is the only tracer implemented today -- everything above (the
-# invariants, the contract) describes its behavior. "dynamo" is planned (a Dynamo-based
-# front-end that analyzes Python rather than specializing to one traced path) and
-# currently raises NotImplementedError.
+# non-strict trace -- everything above (the invariants, the contract) describes its
+# behavior. "dynamo" is a Dynamo-based front-end that analyzes the Python (bytecode)
+# instead of specializing to one traced path.
+#
+# The "dynamo" tracer's TRICK, and how it differs from make_fx: Dynamo does not hand back
+# a single graph we can render as source. It hands back (a) a TRANSFORMED bytecode -- a
+# rewrite of fn that extracts the runtime model's params/buffers, calls a compiled
+# subgraph, and reassembles fn's output -- plus (b) the subgraph (an fx GraphModule) for
+# the backend to lower. So precompile INLINES the transformed bytecode into python_code
+# (marshalled to a base64 blob, rehydrated by the driver via marshal.loads +
+# types.FunctionType) and lowers the subgraph through the SAME backends as make_fx
+# ("inductor" -> aot_autograd.compile_to_python source, "eager" -> the inlined subgraph),
+# wiring the subgraph in under the backend id the bytecode calls. The transformed bytecode
+# IS the calling convention: it reads params off the runtime model itself (given a
+# structurally identical runtime model it reads the right weights, invariant 2), which is
+# why the dynamo driver is thin (rehydrate + wire) and carries none of the make_fx
+# PARAM_NAMES / OUT_SPEC metadata.
+#
+# TRAINING works here too, by a different mechanism than make_fx. make_fx traces THROUGH
+# .backward(), so its artifact is one flat graph of fwd+bwd ATen ops with the grads as
+# extra outputs and a Python-level scatter in the driver (invariant 5). Dynamo instead
+# rewrites the backward into an in-graph torch.autograd.grad plus the .grad updates around
+# it -- so precompile pins trace_autograd_ops (otherwise Dynamo graph-breaks on the
+# backward), runs the artifact under enable_grad (the traced call differentiates a live
+# autograd graph the same call builds; a forward capture keeps no_grad), and lowers with
+# compile_to_python(grad_enabled=True) for the same reason. No grad-scatter metadata is
+# needed: the transformed bytecode does the .grad update itself, on the runtime model.
+# The ONE thing precompile has to correct is that Dynamo's rewrite SPECIALIZES on whether
+# p.grad is None at trace time -- a guarded choice in torch.compile, and this artifact
+# checks no guards -- so precompile always bakes the ACCUMULATING form and the driver
+# materializes a zero .grad where the runtime model has none; see Note [precompile dynamo
+# training grad accumulation]. Only params get a harvested grad, as on the make_fx path
+# (invariant 5): a user input that requires grad is rejected.
+#
+# Dynamic shapes and decompositions work here too, by different mechanisms than make_fx.
+# Dynamic shapes: mark_unbacked is Dynamo's OWN decorator, so Dynamo captures the marked
+# dim as an UNBACKED symint directly -- unguardable, so a graph that needs to guard on it
+# fails loudly at capture (the same PrecompileError the make_fx tracer raises) instead of
+# baking a size, which is what makes a guard-free artifact sound. Dynamo emits the
+# ShapeEnv's runtime asserts (mark_unbacked's min/max, a shared shape_id's equality) into
+# the subgraph itself, so they hold on BOTH backends -- unlike the make_fx tracer, whose
+# eager backend has no such asserts and therefore rejects dynamic dims outright. The
+# STRICT variant is rejected here: Dynamo reads it as a RelaxedUnspecConstraint, i.e. a
+# BACKED dynamic dim it may guard on, and this artifact does not check guards (see
+# _reject_strict_unbacked_marks); mark_dynamic / specialize_on are rejected as on the
+# make_fx path. Decompositions: Dynamo captures torch-level IR and never consults a
+# decomposition table, so precompile applies it by re-tracing the captured subgraph with
+# make_fx (see _decompose_subgraph) -- the same table shaping the same ATen graph, just
+# applied one step later than the make_fx tracer applies it.
+#
+# Scope and differences from make_fx: the source-artifact call needs one transformed
+# bytecode and therefore still requires a single Dynamo graph. A graph-breaking fn raises
+# a PrecompileError pointing at ``example_inputs``, whose execution-driven capture
+# preserves every graph-break continuation, guard, and recompiled variant.
+# The source-artifact path does NOT check Dynamo's guards at
+# runtime, NOR does
+# it reproduce the make_fx drivers' upfront runtime validation (the param/buffer structural
+# check, invariant 2, and the per-input shape/dtype/device checks, invariants 3/6): safety
+# comes from the same specialization contract as make_fx (control flow and unmarked shapes
+# are specialized to the example) plus the captured graph's own asserts -- on the INDUCTOR
+# backend the baked assert_size_stride (which catches a runtime input/weight whose SHAPE or
+# STRIDE differs from the example, but not its DTYPE) and, for a dynamic capture, the
+# ShapeEnv range / equality asserts on both backends -- not from a reconstructed guard
+# manager. So a contract-violating runtime
+# input/model may fail with a raw kernel error rather than a clean PrecompileError, and on
+# the EAGER backend (no assert_size_stride) a broadcast-compatible shape mismatch can
+# silently miscompute -- pass inputs and a model matching the example, as the contract
+# requires. Because Dynamo bakes the trace-time environment (e.g. the current accelerator
+# stream) into the bytecode, the artifact is environment-specialized like the make_fx one.
+# This artifact renders its compiled subgraphs as source like the make_fx tracer does,
+# but it ALSO inlines MARSHALLED CPython bytecode plus a PICKLED guard-state blob (which
+# have no source form), so it is LOCKED to the producing Python version:
+# loading it under a different CPython (3.10-3.14) fails with a clean PrecompileError
+# (see the driver's version gate). It is ALSO locked to a compatible torch build, because its import
+# aliases can reference private torch._dynamo runtime modules (also surfaced as a clean
+# PrecompileError). Regenerate per Python version / torch build, or use make_fx for portable
+# source (backend='eager' for torch-build portability -- the default make_fx inductor artifact
+# itself inlines private torch._inductor modules, so it too is torch-build-locked; the
+# Python-version portability holds for either make_fx backend). A tensor closed over by fn (a
+# global, captured local, or DEFAULT ARGUMENT value,
+# including one nested in a container, an nn.Module, a plain/__slots__ object attribute, or
+# a functools.partial / bound method) is rejected (invariant 1) here too -- Dynamo surfaces
+# it as a used-global / closure content / argdef, not a graph get_attr constant, so the
+# check scans those by replaying pickle's own traversal (see _baked_tensors and
+# _reject_baked_tensors).
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import io
 import logging
+import pickle
+import sys
+import types
+from collections.abc import Callable, Mapping, Sequence
 from types import MappingProxyType
 from typing import Any, cast, NewType, TYPE_CHECKING
+from typing_extensions import Self
 
 import torch
 import torch.utils._pytree as pytree
 from torch import Tensor
+from torch.compiler._precompile_types import (
+    ExampleInput,
+    FrameInvariants,
+    PrecompileSummary,
+)
 from torch.fx.experimental.proxy_tensor import make_fx
 from torch.nn.utils import stateless
 from torch.utils._python_dispatch import is_traceable_wrapper_subclass
@@ -222,8 +351,6 @@ log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
-
     from torch._subclasses.fake_tensor import FakeTensorMode
 
 
@@ -275,6 +402,183 @@ class PrecompileError(RuntimeError):
     input whose shape or memory format differs from the example (invariants 3 and 6).
     See Note [precompile programming model] in this module for the full contract.
     """
+
+
+class PrecompiledCallable:
+    """Callable handle for one loaded multi-graph precompile artifact."""
+
+    def __init__(self, compiled: Any) -> None:
+        self._compiled = compiled
+
+    def _call(self, method: Callable[..., Any], *args: object, **kwargs: object) -> Any:
+        from torch._dynamo.exc import PackageError, RecompileError
+
+        try:
+            return method(*args, **kwargs)
+        except (PackageError, RecompileError) as e:
+            raise PrecompileError(str(e)) from e
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return self._call(self._compiled, *args, **kwargs)
+
+    def __enter__(self) -> Self:
+        self._call(self._compiled.__enter__)
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._call(self._compiled.__exit__, *exc)
+
+    def unload(self) -> None:
+        """Remove everything this loaded artifact installed.
+
+        The precompiled entries come off the code objects and the globals the
+        artifact wrote come out of their modules, so the model recompiles
+        normally afterwards. Exiting this object as a context manager does the
+        same thing; call it directly when the artifact's lifetime is not
+        lexically scoped. Unloading twice is harmless, and a call already in
+        flight on another thread is allowed to finish first.
+        """
+        self._call(self._compiled.unload)
+
+    @property
+    def _package(self) -> Any:
+        return self._compiled._package
+
+
+class _InstalledArtifact:
+    """Handle for a multi-graph artifact that serves by installing.
+
+    ``load`` builds this without touching any code object; entering it -- or the
+    first call, for callers whose artifact lifetime is not lexically scoped --
+    installs the captured frames, and ``unload``/exit takes them back out. The
+    mutation is therefore attributable to a point in the caller's control flow
+    rather than to the act of loading.
+    """
+
+    def __init__(
+        self,
+        serve: Callable[[Callable[..., object]], Any],
+        entry_factory: Callable[[], Callable[..., object]],
+    ) -> None:
+        self._serve = serve
+        self._entry_factory = entry_factory
+        self._fn: Callable[..., object] | None = None
+        self._inner: Any = None
+
+    def _rebind(self, fn: Callable[..., object]) -> None:
+        if self._inner is not None:
+            raise PrecompileError(
+                "precompile: this artifact is already installed; pass fn= to load() "
+                "before the first call."
+            )
+        self._fn = fn
+
+    def _ensure(self) -> Any:
+        if self._inner is None:
+            fn = self._entry_factory() if self._fn is None else self._fn
+            self._inner = self._serve(fn)
+        return self._inner
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        return self._ensure()(*args, **kwargs)
+
+    def __enter__(self) -> Self:
+        self._ensure()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.unload()
+
+    def unload(self) -> None:
+        inner, self._inner = self._inner, None
+        if inner is not None:
+            inner.unload()
+
+    @property
+    def _package(self) -> Any:
+        return self._ensure()._package
+
+
+class PrecompileSession:
+    r"""Execution-driven multi-graph capture returned by :func:`precompile`."""
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    def _call(self, method: Callable[..., Any], *args: object, **kwargs: object) -> Any:
+        from torch._dynamo.exc import PackageError, RecompileError
+
+        try:
+            return method(*args, **kwargs)
+        except (PackageError, RecompileError) as e:
+            raise PrecompileError(str(e)) from e
+
+    def __enter__(self) -> Callable[..., object]:
+        compiled = self._call(self._session.__enter__)
+
+        def call(*args: object, **kwargs: object) -> object:
+            return self._call(compiled, *args, **kwargs)
+
+        return call
+
+    def __exit__(self, *exc: object) -> None:
+        self._call(self._session.__exit__, *exc)
+
+    def invariants(self) -> tuple[FrameInvariants, ...]:
+        r"""invariants() -> tuple
+
+        Return the guards that held across every captured variant of each frame.
+        """
+        return self._call(self._session.invariants)
+
+    def write_invariants(self, path: str) -> None:
+        r"""write_invariants(path) -> None
+
+        Write :meth:`invariants` to ``path`` in a stable, human-readable form.
+
+        Args:
+            path (str): destination file. Parent directories are created as needed.
+        """
+        self._call(self._session.write_invariants, path)
+
+    def summary(self) -> PrecompileSummary:
+        r"""summary() -> PrecompileSummary
+
+        Return observed capture coverage, recompilation, failure, and guard information.
+
+        ``complete`` covers only calls that ran during capture; it cannot account for an
+        unexecuted path through the callable.
+        """
+        return self._call(self._session.summary)
+
+    def artifact(
+        self,
+        *,
+        require_complete: bool = True,
+        require_no_risky_drops: bool = True,
+        require_no_dropped_guards: bool = False,
+    ) -> tuple[str, bytes]:
+        r"""artifact(*, require_complete=True, require_no_risky_drops=True, require_no_dropped_guards=False) -> tuple[str, bytes]
+
+        Render the capture as ``(python_code, cache)``, the same pair the
+        :func:`torch.compiler.precompile` returns, and
+        reload it with :func:`torch.compiler.precompile.load`.
+
+        ``python_code`` is a self-contained module exposing ``forward``; it is
+        the single source of truth for the calling convention. A multi-graph
+        capture has no single readable graph, so the guard trees and the
+        transformed bytecode sit in clearly labelled OPAQUE sections, with the
+        frame names, per-frame variant counts, dropped guards and pinned values
+        emitted beside them as readable literals.
+
+        The gates are the ones :meth:`save` applies; see it for what each means.
+        """
+        return self._call(
+            self._session.artifact,
+            require_complete=require_complete,
+            require_no_risky_drops=require_no_risky_drops,
+            require_no_dropped_guards=require_no_dropped_guards,
+        )
 
 
 def _dense_shape(t: object) -> tuple[int, ...] | None:
@@ -396,6 +700,23 @@ def _reject_unsupported_marks(user_flat: list[object]) -> None:
                 "precompile cannot honor (it produces a single artifact, not per-value "
                 "specializations). Remove specialize_on."
             )
+
+
+def _unbacked_guard_error(e: BaseException) -> PrecompileError:
+    """The shared capture-time error for a guard on a mark_unbacked dim (both tracers).
+
+    A mark_unbacked dim is captured as an unbacked symint (no hint), so a computation that
+    needs to guard on / specialize its size (a shape-dependent branch, a reshape that pins
+    it) cannot be captured. Unbacked dims cannot be guarded, so rather than bake a
+    silently-wrong artifact, fail here.
+    """
+    return PrecompileError(
+        "precompile: fn needs to guard on a dim marked with mark_unbacked "
+        "(it branches on or specializes that size), which is not allowed for "
+        "an unbacked dynamic dim. Do not mark that dim (capture it static), "
+        "or restructure fn to avoid the size-dependent operation. Underlying: "
+        f"{(str(e).splitlines() or [''])[0]}"
+    )
 
 
 def _read_unbacked_marks(user_flat: list[object]) -> list[dict[int, _MarkSpec]]:
@@ -864,17 +1185,7 @@ def _capture(
                     tracing_mode=tracing_mode,
                 )(flat_args)
             except GuardOnDataDependentSymNode as e:
-                # A mark_unbacked dim was captured as an unbacked symint (no hint), but
-                # the computation needs to guard on / specialize its size (e.g. a
-                # shape-dependent branch or a reshape that pins it). Unbacked dims cannot
-                # be guarded, so rather than bake a silently-wrong artifact, fail here.
-                raise PrecompileError(
-                    "precompile: fn needs to guard on a dim marked with mark_unbacked "
-                    "(it branches on or specializes that size), which is not allowed for "
-                    "an unbacked dynamic dim. Do not mark that dim (capture it static), "
-                    "or restructure fn to avoid the size-dependent operation. Underlying: "
-                    f"{str(e).splitlines()[0]}"
-                ) from e
+                raise _unbacked_guard_error(e) from e
     finally:
         for a, g in zip(real_flat, saved_grads):
             if isinstance(a, torch.Tensor):
@@ -954,6 +1265,13 @@ class _Capture:
         # The fake_mode (with ShapeEnv) used for a dynamic-shape capture, threaded to the
         # lowering (dynamic_shapes="from_tracing_context"); None for a static capture.
         self.fake_mode = fake_mode
+
+
+_MODE_STACK_HELPERS = frozenset(
+    {"get_torch_function_mode_stack_at", "set_torch_function_mode_stack"}
+)
+
+_ModulePath = tuple[tuple[str, object], ...]
 
 
 _GENERATED_HEADER = """\
@@ -1061,6 +1379,13 @@ def _build_metadata_section(compiled: PrecompiledModule) -> list[str]:
         # subclass leaf); the drivers reject a runtime mismatch (invariants 3 and 6).
         # Memory-format mismatches are caught by the inductor artifact's own
         # assert_size_stride (pinned on at capture).
+        # Every device type the captured graph dispatches on, from the GRAPH
+        # rather than from the runtime tensors: the drivers neutralize ambient
+        # autocast on these, and a graph can reach a device none of its inputs
+        # live on (an explicit .to("cuda") inside fn) or have no tensor inputs
+        # at all. Absent in artifacts written before this field, which the
+        # drivers treat as "nothing to neutralize", their prior behaviour.
+        f"GRAPH_DEVICES = {_graph_device_types(compiled._gm) if compiled._gm is not None else ()!r}",
         f"USER_INPUT_SHAPES = {compiled._user_input_shapes!r}",
         f"USER_INPUT_DTYPES = {compiled._user_input_dtypes!r}",
         f"USER_INPUT_DEVICES = {compiled._user_input_devices!r}",
@@ -1073,38 +1398,41 @@ def _build_metadata_section(compiled: PrecompiledModule) -> list[str]:
     return parts
 
 
+def _read_literal(tree: object, name: str) -> object:
+    """One top-level ``NAME = <literal>`` out of a parsed artifact, else None."""
+    import ast
+
+    for node in cast("ast.Module", tree).body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == name
+        ):
+            try:
+                return ast.literal_eval(node.value)
+            except (ValueError, SyntaxError):
+                return None
+    return None
+
+
 def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
     """Read the calling-convention constants back out of ``python_code`` WITHOUT
     executing it (exec'ing the inlined Inductor output would JIT the kernels, the
     very work the cache exists to skip).
 
-    python_code is the single source of truth: ``_build_metadata_section`` emits the
-    constants below as top-level literal assignments, so an AST walk + literal_eval
-    recovers them safely. The cache then only needs to carry the compiled artifact.
+    python_code is the single source of truth: the metadata builders emit the constants
+    below as top-level literal assignments, so an AST walk + literal_eval recovers them
+    safely. The cache then only needs to carry the compiled artifact.
+
+    The required constant set is tracer-dependent: the make_fx tracer emits the full
+    calling-convention set the inlined driver reads (PARAM_NAMES, OUT_SPEC, ...), while
+    the dynamo tracer's driver reads its own (BACKEND_ID, IMPORT_SOURCES) and rehydrates
+    the rest from opaque blobs. TRACER is absent on artifacts predating the dynamo tracer,
+    so its absence means make_fx.
     """
     import ast
 
-    wanted = {
-        "BACKEND",
-        "MODULE_POSITIONS",
-        "NUM_POSITIONAL_ARGS",
-        "PARAM_NAMES",
-        "BUFFER_NAMES",
-        "PARAM_SHAPES",
-        "BUFFER_SHAPES",
-        "PARAM_DTYPES",
-        "BUFFER_DTYPES",
-        "PARAM_DEVICES",
-        "BUFFER_DEVICES",
-        "GRAD_PARAM_INDICES",
-        "IN_SPEC",
-        "OUT_SPEC",
-        "USER_INPUT_SHAPES",
-        "USER_INPUT_DTYPES",
-        "USER_INPUT_DEVICES",
-        "USER_INPUT_BOUNDS",
-    }
-    found: dict[str, object] = {}
     try:
         tree = ast.parse(python_code)
     except SyntaxError as e:
@@ -1112,6 +1440,69 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
             "python_code is not valid Python; it does not look like a "
             "torch.compiler.precompile artifact."
         ) from e
+    # Read TRACER first (a top-level literal assignment) to pick the required constant set
+    # below: the make_fx and dynamo drivers read different calling-convention literals, so
+    # the presence check has to know which set applies. TRACER is absent on artifacts
+    # predating the dynamo tracer, so its absence means make_fx.
+    tracer = "make_fx"
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "TRACER"
+        ):
+            try:
+                tracer = cast(str, ast.literal_eval(node.value))
+            except (ValueError, SyntaxError):
+                pass
+            break
+    if tracer == "dynamo":
+        # The multi-graph driver rehydrates every frame from _FRAMES and the
+        # subgraphs from _BACKENDS; the readable literals beside them describe
+        # what is in those blobs and are validated so a truncated artifact fails
+        # here rather than deep inside the driver.
+        wanted = {
+            "BACKEND",
+            "TRACER",
+            "FN_NAME",
+            "FRAMES",
+            "DROPPED_GUARDS",
+            "RISKY_DROPPED_GUARDS",
+            "WONT_GENERALIZE",
+            "_FRAMES",
+            "_BACKENDS",
+            "_DYNAMO_PYTHON_VERSION",
+        }
+        # An installed artifact carries the whole package in one blob instead of
+        # the per-frame records, so it reads a different set. SERVING_MODE is
+        # absent on artifacts predating it, which were all standalone.
+        if _read_literal(tree, "SERVING_MODE") == "installed":
+            wanted -= {"_FRAMES", "_BACKENDS"}
+            wanted |= {"SERVING_MODE", "_PACKAGE", "UNREACHABLE_WITHOUT_INSTALL"}
+        wanted |= {"_ENTRY_BINDING"}
+    else:
+        wanted = {
+            "BACKEND",
+            "MODULE_POSITIONS",
+            "NUM_POSITIONAL_ARGS",
+            "PARAM_NAMES",
+            "BUFFER_NAMES",
+            "PARAM_SHAPES",
+            "BUFFER_SHAPES",
+            "PARAM_DTYPES",
+            "BUFFER_DTYPES",
+            "PARAM_DEVICES",
+            "BUFFER_DEVICES",
+            "GRAD_PARAM_INDICES",
+            "IN_SPEC",
+            "OUT_SPEC",
+            "USER_INPUT_SHAPES",
+            "USER_INPUT_DTYPES",
+            "USER_INPUT_DEVICES",
+            "USER_INPUT_BOUNDS",
+        }
+    found: dict[str, object] = {}
     for node in tree.body:
         if not isinstance(node, ast.Assign) or len(node.targets) != 1:
             continue
@@ -1119,7 +1510,13 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
         if not isinstance(target, ast.Name):
             continue
         if target.id in wanted:
-            found[target.id] = ast.literal_eval(node.value)
+            try:
+                found[target.id] = ast.literal_eval(node.value)
+            except (ValueError, SyntaxError) as e:
+                raise PrecompileError(
+                    f"python_code {target.id!r} calling-convention metadata is "
+                    f"malformed; it must be a Python literal."
+                ) from e
         else:
             # Not a metadata name we consume (the driver section emits only
             # function defs today, but a future artifact revision could add a
@@ -1137,6 +1534,11 @@ def _parse_artifact_metadata(python_code: str) -> dict[str, object]:
             f"python_code is missing calling-convention metadata {sorted(missing)}; "
             "it does not look like a torch.compiler.precompile artifact."
         )
+    # Reported but not required: artifacts predating the installed serving mode
+    # carry no SERVING_MODE, and they were all standalone.
+    found.setdefault(
+        "SERVING_MODE", _read_literal(tree, "SERVING_MODE") or "standalone"
+    )
     return found
 
 
@@ -1250,12 +1652,512 @@ def _emit_driver_source(forward_fn_name: str) -> str:
         inspect.getsource(driver._extract_param_buffers),
         inspect.getsource(driver._fail),
         inspect.getsource(driver._check_structure),
+        inspect.getsource(driver._autocast_off),
         inspect.getsource(forward_fn).replace(
             f"def {forward_fn_name}(", "def forward(", 1
         ),
     ]
     body = "\n\n".join(block.rstrip() for block in blocks)
     return "\n" + body + "\n\n\n" + _DRIVER_MAIN
+
+
+def _graph_device_types(gm: torch.fx.GraphModule) -> tuple[str, ...]:
+    """Every device type the graph dispatches on, from its node metadata.
+
+    Derived from the GRAPH, not from the runtime params and inputs: a graph can
+    reach a device none of its inputs live on (an explicit ``.to("cuda")`` in
+    the middle of fn), and a graph built only from factory ops has no input
+    device at all. Both cases leave a runtime scan blind exactly where an
+    ambient-state leak needs closing.
+    """
+    from torch._dynamo.graph_utils import _graph_device_types as _scan
+
+    return tuple(
+        sorted(d for d in _scan(gm.graph) if torch.amp.is_autocast_available(d))
+    )
+
+
+_MULTIGRAPH_GENERATED_HEADER = """\
+# Generated by torch.compiler.precompile (multi-graph) -- do not edit.
+#
+# Self-contained, executable artifact for a computation with GRAPH BREAKS or several
+# guarded variants. Where the single-graph forms inline one graph, this inlines every
+# frame Dynamo compiled -- the entry frame plus each continuation -- with one guard tree
+# per captured variant, and dispatches among them at call time:
+#
+#     ns = {}
+#     exec(open("this_file.py").read(), ns)
+#     out = ns["forward"](model, my_input)      # same args as the captured callable
+#
+# Nothing is installed onto your code objects and no frame evaluator is involved, so
+# loading this mutates no global state. The flip side is that there is no compiler
+# behind it: a call no captured variant covers RAISES rather than compiling a new one.
+#
+# Sections below are labelled. What is OPAQUE is base64 of pickled Dynamo state --
+# the guard trees and the transformed bytecode -- because those have no readable
+# source form. The compiled subgraphs DO have one and are emitted as source; only a
+# subgraph the backend could not render (an eager fx graph, a training graph) falls
+# back to the blob. Everything else is meant to be read and reviewed.
+"""
+
+
+def _b64(payload: object) -> str:
+    return base64.b64encode(pickle.dumps(payload)).decode("ascii")
+
+
+def _multigraph_frames(entry: Any) -> list[dict[str, Any]]:
+    """One record per Dynamo frame, in the form the driver rebuilds from.
+
+    A standalone artifact can reach exactly two kinds of frame: the ENTRY frame,
+    which the caller invokes, and a continuation, which the frame ahead of it
+    reaches by LOAD_GLOBAL on the name capture minted. Anything else Dynamo
+    compiled is entered by an ordinary Python call that only the frame evaluator
+    intercepts, so it has no place in a source artifact -- see
+    _reject_unreachable_frames.
+    """
+    from torch._dynamo.package import SerializedCode
+
+    entry_name = str(entry.fn_name).rsplit(".", 1)[-1]
+    frames = []
+    seen_entry = False
+    for code in entry.codes:
+        if code.bypassed:
+            continue
+        name = SerializedCode.to_code_object(code.python_code).co_name
+        is_entry = not code.install_to_global and name == entry_name and not seen_entry
+        seen_entry = seen_entry or is_entry
+        frames.append(
+            {
+                "is_entry": is_entry,
+                "code": code.python_code,
+                "python_module": code.python_module,
+                "import_sources": dict(code.import_sources),
+                "resume_names": (
+                    list(code.function_names) if code.install_to_global else []
+                ),
+                "variants": [
+                    {
+                        "guards_state": guarded.guards_state,
+                        "dynamo_code": guarded.dynamo_code,
+                    }
+                    for guarded in code.guarded_codes
+                ],
+            }
+        )
+    return frames
+
+
+def _build_multigraph_python_source(
+    entry: Any,
+    backends: Mapping[str, Any],
+    summary: Any,
+    backend: str,
+    serving_mode: str = "standalone",
+    package_entry: object = None,
+    entry_binding: dict[str, Any] | None = None,
+    rendered: Mapping[str, str] | None = None,
+) -> str:
+    """Render a multi-graph capture as ``python_code``.
+
+    The readable half -- what was captured, which frames, how many variants, what
+    guards were dropped -- is emitted as literals so a reviewer can diff it, and
+    the compiled subgraphs are rendered as source beside them. Only the guard
+    trees and the transformed bytecode, which have no source form, go into the
+    clearly banners' opaque blobs.
+    """
+    from torch._dynamo.package import SerializedCode
+
+    frames = _multigraph_frames(entry)
+    parts = [_MULTIGRAPH_GENERATED_HEADER, ""]
+    parts.append("# " + "=" * 70)
+    parts.append("# 1. What was captured (readable)")
+    parts.append("# " + "=" * 70)
+    parts.append(f"BACKEND = {backend!r}")
+    parts.append('TRACER = "dynamo"')
+    parts.append(f"FN_NAME = {entry.fn_name!r}")
+    parts.append(f"FN_FIRST_LINENO = {entry.fn_first_lineno!r}")
+    parts.append(f"_DYNAMO_PYTHON_VERSION = {tuple(sys.version_info[:2])!r}")
+    parts.append(f"TORCH_VERSION = {torch.__version__!r}")
+    parts.append("")
+    parts.append(
+        "# frame name -> number of captured variants. A frame with one variant"
+    )
+    parts.append("# serves one specialization; the artifact covers no other.")
+    parts.append("FRAMES = [")
+    for frame, code in zip(frames, [c for c in entry.codes if not c.bypassed]):
+        name = SerializedCode.to_code_object(code.python_code).co_name
+        parts.append(f"    ({name!r}, {len(frame['variants'])}),")
+    parts.append("]")
+    parts.append("")
+    parts.append(
+        "# Guards that could NOT be serialized and are therefore not checked at"
+    )
+    parts.append("# serve time. Rebinding any of these between capture and load can")
+    parts.append(
+        "# silently select the wrong graph -- audit them against your deployment."
+    )
+    parts.append(f"DROPPED_GUARDS = {[list(g) for g in summary.dropped_guards]!r}")
+    parts.append(
+        f"RISKY_DROPPED_GUARDS = {[list(g) for g in summary.risky_dropped_guards]!r}"
+    )
+    parts.append("")
+    parts.append("# Values pinned to exactly what capture saw; any other value misses.")
+    parts.append(f"WONT_GENERALIZE = {tuple(summary.wont_generalize)!r}")
+    parts.append("")
+    if serving_mode == "installed":
+        reachable = _reachable_frames(frames)
+        dead = sorted(
+            SerializedCode.to_code_object(frame["code"]).co_name
+            for i, frame in enumerate(frames)
+            if frame["variants"] and i not in reachable
+        )
+        parts.append("# " + "=" * 70)
+        parts.append("# 2. How this artifact serves: INSTALLED (readable)")
+        parts.append("#")
+        parts.append("# A source artifact dispatches only the entry frame and the")
+        parts.append(
+            "# continuations its bytecode names. These frames are entered by an"
+        )
+        parts.append(
+            "# ordinary call, so nothing in the entry reaches them and they would"
+        )
+        parts.append("# run eager. This artifact therefore installs onto the live code")
+        parts.append("# objects instead, which reaches every frame.")
+        parts.append("#")
+        parts.append("# load() installs NOTHING; entering the result -- or calling")
+        parts.append("# it -- installs, and unload()/exit removes it again.")
+        parts.append("# " + "=" * 70)
+        parts.append('SERVING_MODE = "installed"')
+        parts.append(f"UNREACHABLE_WITHOUT_INSTALL = {tuple(dead)!r}")
+        parts.append("")
+        parts.append("# " + "=" * 70)
+        parts.append("# 3. The captured package -- OPAQUE")
+        parts.append("#")
+        parts.append("# base64(pickle) of the serialized Dynamo state (per-frame guard")
+        parts.append(
+            "# trees and transformed bytecode) plus the compiled subgraphs. Guard"
+        )
+        parts.append(
+            "# trees are a spec for a C++ GuardManager and have no readable form;"
+        )
+        parts.append("# the counts and names above describe what is in here.")
+        parts.append("# " + "=" * 70)
+        parts.append(f"_PACKAGE = {_b64(package_entry)!r}")
+        parts.append("")
+        parts.append("# The entry's defaults and closure values; see the standalone")
+        parts.append("# note above -- the installed driver rebuilds an entry too.")
+        parts.append(f"_ENTRY_BINDING = {_b64(entry_binding or {})!r}")
+        parts.append("")
+        parts.append("# " + "=" * 70)
+        parts.append("# 4. Driver: rebuild the package, install, dispatch (readable)")
+        parts.append("# " + "=" * 70)
+        parts.append(_emit_installed_driver_source())
+        return "\n".join(p for p in parts if p is not None)
+
+    parts.append('SERVING_MODE = "standalone"')
+    parts.append("")
+    parts.append("# The entry's defaults and closure values: a code object carries")
+    parts.append("# neither, and the driver rebuilds the entry from one.")
+    parts.append(f"_ENTRY_BINDING = {_b64(entry_binding or {})!r}")
+    parts.append("")
+    parts.append("# " + "=" * 70)
+    parts.append("# 2. Guard trees and transformed bytecode -- OPAQUE")
+    parts.append("#")
+    parts.append(
+        "# base64(pickle) of one record per frame: the frame's code object, its"
+    )
+    parts.append(
+        "# variants' serialized guard state and Dynamo bytecode, and the globals"
+    )
+    parts.append(
+        "# it reads. Guard trees are a spec for a C++ GuardManager and have no"
+    )
+    parts.append(
+        "# readable form; the counts and names above describe what is in here."
+    )
+    parts.append("# " + "=" * 70)
+    parts.append(f"_FRAMES = {_b64(frames)!r}")
+    parts.append("")
+    # A compiled subgraph is Inductor output, which HAS a source form -- unlike
+    # the guard trees and bytecode above. Emit that source where the backend can
+    # produce it, and fall back to the pickle only for the rest (eager graphs, a
+    # training graph, anything the lowering refused). The blocks are spliced
+    # sequentially into this module's namespace and each one's ``call`` is
+    # snapshotted immediately, because every block rebinds ``call`` / ``Runner``
+    # / ``async_compile``; the snapshot is what makes the shadowing harmless.
+    rendered = dict(rendered or {})
+    parts.append("# " + "=" * 70)
+    if rendered:
+        parts.append(f"# 3. Compiled subgraphs -- {len(rendered)} READABLE below")
+        if len(rendered) < len(backends):
+            parts.append(
+                f"#    ({len(backends) - len(rendered)} could not be rendered and "
+                f"stay in _BACKENDS)"
+            )
+    else:
+        parts.append("# 3. Compiled subgraphs -- OPAQUE")
+    parts.append("#")
+    parts.append("# base64(pickle) of the backend artifacts the frames call by name.")
+    parts.append("# " + "=" * 70)
+    parts.append(
+        f"_BACKENDS = {_b64({k: v for k, v in backends.items() if k not in rendered})!r}"
+    )
+    if rendered:
+        parts.append("")
+        parts.append("_SUBGRAPHS = {}")
+        _seen_slots: list[str] = []
+        for backend_id, source in rendered.items():
+            parts.append("")
+            parts.append("# " + "-" * 70)
+            parts.append(f"# subgraph {backend_id}")
+            parts.append("# " + "-" * 70)
+            parts.append(source)
+            # the block's entry was renamed along with everything else it defines
+            entry_name = f"call_s{len(_seen_slots)}"
+            _seen_slots.append(backend_id)
+            parts.append(f"_SUBGRAPHS[{backend_id!r}] = {entry_name}")
+    parts.append("")
+    parts.append("# " + "=" * 70)
+    parts.append("# 4. Driver: rebuild the guards, wire the names, dispatch (readable)")
+    parts.append("# " + "=" * 70)
+    parts.append(_emit_multigraph_driver_source())
+    return "\n".join(p for p in parts if p is not None)
+
+
+def _reachable_frames(frames: list[dict[str, Any]]) -> set[int]:
+    """Indices of the frames a standalone driver can actually dispatch.
+
+    The entry is reachable, and a continuation is reachable only once some
+    ALREADY reachable frame's bytecode names it. Asking merely whether a frame
+    carries a resume name is not the same question: a continuation whose parent
+    is itself unreachable is just as dead, and counting it as covered
+    under-reports how much of the artifact will run eager.
+    """
+    from torch._dynamo.package import SerializedCode
+
+    def named_globals(frame: dict[str, Any]) -> set[str]:
+        out: set[str] = set()
+        stack = [
+            SerializedCode.to_code_object(variant["dynamo_code"])
+            for variant in frame["variants"]
+        ]
+        seen: set[int] = set()
+        while stack:
+            code = stack.pop()
+            if id(code) in seen:
+                continue
+            seen.add(id(code))
+            out.update(code.co_names)
+            stack.extend(c for c in code.co_consts if isinstance(c, types.CodeType))
+        return out
+
+    reachable = {i for i, frame in enumerate(frames) if frame["is_entry"]}
+    while True:
+        named: set[str] = set()
+        for i in reachable:
+            named |= named_globals(frames[i])
+        grew = {
+            i
+            for i, frame in enumerate(frames)
+            if i not in reachable and any(n in named for n in frame["resume_names"])
+        }
+        if not grew:
+            return reachable
+        reachable |= grew
+
+
+def _serving_mode(frames: list[dict[str, Any]]) -> str:
+    """``"standalone"`` when a source artifact covers every captured frame.
+
+    Anything it cannot reach would run eager, silently giving up the compiled
+    variant, so those captures are served by installing instead.
+    """
+    reachable = _reachable_frames(frames)
+    unreachable = [
+        i for i, frame in enumerate(frames) if frame["variants"] and i not in reachable
+    ]
+    return "installed" if unreachable else "standalone"
+
+
+def _reject_uninstallable_entry(frames: list[dict[str, Any]], entry: Any) -> None:
+    """Refuse a capture whose entry an installed artifact could not rebuild.
+
+    The installed driver rebuilds the entry from its code object, and
+    ``types.FunctionType`` cannot supply a closure or defaults it was not given:
+    a closure entry fails to build at all, and a defaulted argument silently
+    goes missing on the first served call. Both are capture-time facts, so they
+    are refused here rather than at load on the serving machine.
+    """
+    from torch._dynamo.package import SerializedCode
+
+    entry_frames = [f for f in frames if f["is_entry"]]
+    if not entry_frames:
+        return
+    if not any(f["variants"] for f in entry_frames):
+        # Handing precompile a bare nn.Module compiles Dynamo's own wrapper
+        # frame (external_utils.wrap_inline's `inner`) rather than the module:
+        # every graph lands there, closing over the module, and the entry frame
+        # itself holds nothing. Load cannot rebuild that closure, and `inner`'s
+        # code object is shared by every wrap_inline in the process, so serving
+        # it would let an unrelated frame hit these guards.
+        raise PrecompileError(
+            f"precompile captured no dispatchable graph for {entry.fn_name!r}. The "
+            f"entry frame produced no guarded code, so the artifact would serve "
+            f"nothing. This happens when the captured callable is a thin wrapper -- "
+            f"an nn.Module, or a forward that immediately delegates -- where Dynamo "
+            f"compiles the wrapper's inner frame instead. Capture the function that "
+            f"CALLS the model, e.g. "
+            f"precompile(lambda m, x: m(x), example_inputs=[(model, x)])."
+        )
+    code = SerializedCode.to_code_object(entry_frames[0]["code"])
+    if code.co_freevars:
+        raise PrecompileError(
+            f"precompile cannot build a self-contained artifact for {entry.fn_name!r}: "
+            f"it closes over {list(code.co_freevars)!r}, and this capture has to rebuild "
+            f"the entry from its code object, which cannot restore a closure. Capture a "
+            f"module-level function that takes what it needs as arguments, e.g. "
+            f"precompile(step, example_inputs=[(model, x)]) with "
+            f"'def step(model, x): return model(x)'."
+        )
+
+
+def _reject_unreachable_frames(frames: list[dict[str, Any]], entry: Any) -> None:
+    """Check what a standalone artifact will actually be able to dispatch.
+
+    Dispatch here is explicit: the caller invokes the entry frame, and a
+    continuation is reached by LOAD_GLOBAL from the frame ahead of it. A frame
+    Dynamo compiled that is entered by an ordinary Python call -- an inner
+    ``nn.Module.__call__`` wrapper, an un-inlinable helper -- is reachable only
+    through the frame evaluator, which a source artifact does not use.
+
+    Such a frame runs EAGER when served. That is a coverage and performance
+    gap, not a correctness one: eager is what the graph was traced from, so the
+    answer is the same. It is therefore a warning.
+    """
+    from torch._dynamo.package import SerializedCode
+
+    unreachable = [
+        f
+        for f in frames
+        if not f["is_entry"] and not f["resume_names"] and f["variants"]
+    ]
+    if unreachable:
+        # Correct but under-compiled. A frame Dynamo compiled that is entered by
+        # an ORDINARY call -- an un-inlinable helper, a separately-compiled
+        # callee -- is reached only through the frame evaluator, which a source
+        # artifact does not use. It runs eager instead, so the answer stays
+        # right and the compiled variant simply goes unused. Say so, rather than
+        # let summary() imply coverage the artifact will not deliver.
+        names = sorted(
+            SerializedCode.to_code_object(f["code"]).co_name for f in unreachable
+        )
+        log.warning(
+            "precompile: %d captured frame(s) will run EAGER when served, because a "
+            "self-contained artifact reaches only the entry frame and the "
+            "continuations its bytecode names: %s. The result stays correct; those "
+            "graphs are simply unused. Inline them into the captured callable to "
+            "get their compiled versions.",
+            len(names),
+            names,
+        )
+
+
+def _entry_binding(fn: object) -> dict[str, Any]:
+    """The parts of the entry callable a code object does not carry.
+
+    The artifact rebuilds its entry from that entry's code object, and a code
+    object holds neither default arguments nor closure cell VALUES. Without them
+    a defaulted parameter is simply absent at the served call -- which the guard
+    check then cannot bind, so every variant misses -- and a closure entry cannot
+    be constructed at all. Carry them alongside the code.
+    """
+    closure = getattr(fn, "__closure__", None)
+    return {
+        "defaults": getattr(fn, "__defaults__", None),
+        "kwdefaults": getattr(fn, "__kwdefaults__", None),
+        "closure": tuple(c.cell_contents for c in closure) if closure else None,
+    }
+
+
+def _build_multigraph_artifact(
+    entry: Any,
+    backends: Mapping[str, Any],
+    summary: Any,
+    backend: str,
+    entry_fn: object = None,
+    rendered: Mapping[str, str] | None = None,
+) -> tuple[str, bytes]:
+    """``(python_code, cache)`` for a multi-graph capture.
+
+    python_code is self-contained -- it carries the frames, the guard trees and
+    the compiled subgraphs -- so cache is the same acceleration it is for the
+    single-graph forms: the inductor bundle that primes the kernel caches, and
+    the tag binding it to this python_code (invariant 7).
+    """
+    frames = _multigraph_frames(entry)
+    serving_mode = _serving_mode(frames)
+    package_entry = None
+    if serving_mode == "installed":
+        # Frames a source artifact cannot reach would run eager, so serve this
+        # capture by installing instead. That needs the package itself, not the
+        # per-frame records the standalone driver rebuilds from.
+        from torch._dynamo.package import PrecompileCacheEntry
+
+        package_entry = PrecompileCacheEntry(entry, cast("dict[Any, Any]", backends))
+    else:
+        _reject_unreachable_frames(frames, entry)
+    # Defaults the artifact can carry; closure cells it cannot. Dynamo guards a
+    # cell by identity, and a rebuilt cell holding the same value is a different
+    # object, so a closure entry would load and then miss every variant.
+    _reject_uninstallable_entry(frames, entry)
+
+    python_code = _build_multigraph_python_source(
+        entry,
+        backends,
+        summary,
+        backend,
+        serving_mode,
+        package_entry,
+        _entry_binding(entry_fn),
+        dict(rendered or {}),
+    )
+    inductor_bundle = None
+    if backend != "eager":
+        saved = torch.compiler.save_cache_artifacts()
+        inductor_bundle = None if saved is None else saved[0]
+    buf = io.BytesIO()
+    torch.save(
+        {
+            "format": _CACHE_FORMAT,
+            "version": _CACHE_VERSION,
+            "backend": backend,
+            "tracer": "dynamo",
+            "code_hash": hashlib.sha256(python_code.encode()).hexdigest(),
+            "artifact": inductor_bundle,
+        },
+        buf,
+    )
+    return python_code, buf.getvalue()
+
+
+def _emit_multigraph_driver_source() -> str:
+    """Emit the multi-graph driver as text, the same getsource path the others use."""
+    import inspect
+
+    from torch import _precompile_driver as driver
+
+    body = inspect.getsource(driver._build_multigraph_forward).rstrip()
+    return "\n" + body + "\n\n\nforward = _build_multigraph_forward()\n"
+
+
+def _emit_installed_driver_source() -> str:
+    """Emit the installing driver as text, the same getsource path the others use."""
+    import inspect
+
+    from torch import _precompile_driver as driver
+
+    body = inspect.getsource(driver._build_installed_forward).rstrip()
+    return "\n" + body + "\n\n\nforward = _build_installed_forward()\n"
 
 
 def _assert_supported(gm: torch.fx.GraphModule) -> None:
@@ -1328,6 +2230,12 @@ class PrecompiledModule:
         self._in_spec: pytree.TreeSpec | None = None
         self._out_spec: pytree.TreeSpec | None = None
         self._gm: torch.fx.GraphModule | None = None
+        # Dynamo tracer (tracer="dynamo"): the transformed bytecode + the names it
+        # references, populated by _compile() when tracer == "dynamo". The bytecode is
+        # marshalled and the state pickled into python_code; the subgraph is lowered like
+        # the make_fx inductor path (backend="inductor", via self._graph_python /
+        # self._artifact_bytes) or inlined as eager graph source (backend="eager",
+        # self._gm). None on the make_fx path and on the load() path.
         # Inductor backend: the composed self-contained graph module (from
         # aot_autograd.compile_to_python, exposing ``call(flat_inputs)``) and the
         # opaque artifact-cache bytes (None if uncacheable), populated by _compile().
@@ -1374,18 +2282,13 @@ class PrecompiledModule:
         return obj
 
     def _compile(self, args: tuple[object, ...]) -> None:
-        # make_fx is the only implemented tracer; "dynamo" is a planned alternative
-        # capture front-end. Reject it here (the single capture-dispatch point) before
-        # running fn, so the failure is clear rather than a wrong default.
-        if self._tracer != "make_fx":
-            raise NotImplementedError(
-                f"precompile tracer={self._tracer!r} is not implemented yet; use "
-                "tracer='make_fx' (the default)."
-            )
+        # PrecompiledModule is the make_fx path only: tracer="dynamo" is routed
+        # to the execution-driven capture before it gets here.
         if self._backend == "eager" and _has_unbacked_marks(args):
             raise NotImplementedError(
-                "precompile: mark_unbacked (dynamic shapes) is only supported with "
-                "backend='inductor'; eager + unbacked is not supported."
+                "precompile: mark_unbacked (dynamic shapes) with tracer='make_fx' is only "
+                "supported with backend='inductor'; make_fx + eager + unbacked is not "
+                "supported (tracer='dynamo' supports either backend)."
             )
         capture = _capture(self._fn, args, self._decompositions)
         self._module_positions = capture.module_positions
@@ -1443,7 +2346,7 @@ class PrecompiledModule:
         # ShapeEnv through automatically, so there is no dynamic_shapes knob to pass and
         # no manual TracingContext to install: a static capture specializes to the
         # example shapes, an unbacked capture keeps the symbols.
-        options: dict[str, Any] = {"size_asserts": True}
+        options: dict[str, object] = {"size_asserts": True}
         if capture.fake_mode is not None and hasattr(_ind_config, "scalar_asserts"):
             options["scalar_asserts"] = True
         try:
@@ -1542,12 +2445,37 @@ class PrecompiledModule:
                 "format": _CACHE_FORMAT,
                 "version": _CACHE_VERSION,
                 "backend": self._backend,
+                "tracer": self._tracer,
                 "code_hash": code_hash,
                 "artifact": self._artifact_bytes,
             },
             buf,
         )
         return buf.getvalue()
+
+
+def _capture_session(fn, **kwargs):
+    """Start an internal multi-graph capture, mapping package errors to ours.
+
+    precompile() drives the capture itself -- there is no public session -- so
+    this exists to keep the error translation in one place.
+    """
+    from torch._dynamo.exc import PackageError
+    from torch._dynamo.precompile_package import precompile_capture
+
+    try:
+        return precompile_capture(fn, **kwargs)
+    except PackageError as e:
+        raise PrecompileError(str(e)) from e
+    except TypeError as e:
+        # get_traced_fn refuses a partial (and anything else that is not a
+        # function or nn.Module) with a bare TypeError from deep inside capture.
+        if "partial" in str(e):
+            raise PrecompileError(
+                f"precompile cannot capture a partial: {e}. Pass the underlying "
+                f"function and give its bound arguments as example arguments."
+            ) from e
+        raise
 
 
 def _make_inlined_forward(python_code: str) -> Callable[..., object]:
@@ -1572,12 +2500,13 @@ def _make_inlined_forward(python_code: str) -> Callable[..., object]:
 
 
 class _PrecompileApi:
-    """Callable namespace implementing ``torch.compiler.precompile`` and ``.load``.
+    """Callable namespace implementing ``torch.compiler.precompile`` and its loaders.
 
     A single instance is exposed as ``torch.compiler.precompile``; calling it precompiles a
-    computation and ``torch.compiler.precompile.load`` reloads the resulting artifacts. It
-    is a class (rather than a function with attached attributes) so the call, the
-    loader, and the error type are explicit members.
+    computation and ``torch.compiler.precompile.load`` reloads the resulting source
+    artifacts. ``capture`` provides the guarded multi-graph path. It is a
+    class (rather than a function with attached attributes) so these operations and the
+    error type are explicit members.
 
     The contract for both ``__call__`` and ``load`` is Note [precompile programming
     model] in this module.
@@ -1589,6 +2518,12 @@ class _PrecompileApi:
     # The error type raised by precompile, reachable as
     # ``torch.compiler.precompile.PrecompileError``.
     PrecompileError = PrecompileError
+
+    # One capture call carrying keyword arguments, for ``example_inputs``. A
+    # plain tuple there is positional args; this is what the TypeError raised
+    # for anything else tells the caller to reach for, so it has to be
+    # reachable without importing a private module.
+    ExampleInput = ExampleInput
 
     def __reduce__(self) -> str:
         # torch.compiler.precompile is a process-wide singleton; pickle/deepcopy must
@@ -1603,12 +2538,52 @@ class _PrecompileApi:
     def __call__(
         self,
         fn: Callable[..., object],
-        *example_inputs: object,
+        # Accepted only to reject: precompile used to take the example call
+        # positionally, and a caller who still writes it that way gets a
+        # pointed error rather than CPython's arity message.
+        *example_args: object,
         backend: str = "inductor",
         tracer: str = "make_fx",
         decompositions: dict | None = None,
+        example_inputs: Sequence[ExampleInput | tuple[object, ...]] | None = None,
+        guard_filter_fn: Callable[[Sequence[Any]], Sequence[bool]] | None = None,
+        recompile_limit: int = 256,
+        dynamic: bool | None = None,
+        invariants: str | None = None,
+        require_complete: bool = True,
+        require_no_risky_drops: bool = True,
+        require_no_dropped_guards: bool = False,
+        training: bool = False,
     ) -> tuple[str, bytes]:
-        """Ahead-of-time precompile ``fn`` against ``example_inputs``.
+        """Ahead-of-time precompile ``fn`` against example inputs.
+
+        ``example_inputs`` is the calling convention: a sequence of calls, each a tuple of
+        positional arguments (or an ``ExampleInput`` carrying keywords). precompile makes
+        those calls itself and returns ``(python_code, cache)``.
+
+        ``tracer`` picks the capture front-end. ``"make_fx"`` (the default) is one
+        non-strict ATen trace, so it takes exactly one call and refuses a longer
+        ``example_inputs``. ``"dynamo"`` is an execution-driven multi-graph capture that
+        records graph-break continuations and every guarded recompilation the supplied
+        calls exercise, and it takes as many calls as you give it.
+
+        Live capture keeps all guards so one example cannot silently reuse another's graph;
+        ``guard_filter_fn`` applies only to the serialized artifact. Calls run under
+        ordinary ``torch.no_grad()`` unless ``training=True``, even when the caller is in
+        inference mode; serve the resulting artifact under that same grad mode. Inputs and
+        module parameters/buffers created inside inference mode are rejected because they
+        remain inference tensors after the ambient mode is disabled.
+
+        Capture is execution-driven, not an exhaustive analysis of ``fn``. A complete
+        summary covers the calls that ran successfully; unexecuted paths and values are not
+        present. ``save()`` refuses known gaps and risky dropped guards by default (the
+        stricter ``require_no_dropped_guards`` is off). An uncovered runtime call
+        raises: the artifact serves only what capture exercised.
+
+        ``decompositions`` applies only to ``tracer="make_fx"``; ``guard_filter_fn``,
+        ``recompile_limit``, ``dynamic``, ``invariants`` and the ``require_*`` gates
+        describe a multi-variant capture and apply only to ``tracer="dynamo"``. The guard
+        filter controls serialization only; runtime capture guards are retained.
 
         .. note::
 
@@ -1621,10 +2596,10 @@ class _PrecompileApi:
         contract; read Note [precompile programming model] before using it. The artifact
         faithfully reproduces ``fn`` only for callers that uphold that contract.
 
-        THREADING: the inductor lowering step drives process-global compiler state
-        and is serialized by an internal lock, so concurrent ``backend="inductor"``
-        calls lower one at a time. The make_fx capture phase and the ``backend="eager"``
-        path are NOT serialized.
+        For the ``make_fx`` tracer, the inductor lowering step drives
+        process-global compiler state and is serialized by an internal lock, so concurrent
+        ``backend="inductor"`` calls lower one at a time. The make_fx capture phase and
+        the ``backend="eager"`` path are not serialized.
 
         ``backend`` selects how the captured graph is realized:
 
@@ -1642,48 +2617,87 @@ class _PrecompileApi:
           Useful for
           inspecting/debugging exactly what was traced without an Inductor dependency.
 
-        ``tracer`` selects the capture front-end:
+        ``tracer`` selects the capture front-end (orthogonal to ``backend``):
 
         - ``"make_fx"`` (default): a NON-STRICT make_fx trace -- it records the ATen ops
           that actually run when ``fn`` executes once on the example inputs and does not
           analyze your Python, so control flow and shapes are specialized to the example
-          (the source of the programming-model contract). The only tracer implemented
-          today.
-        - ``"dynamo"``: planned (a Dynamo-based front-end that analyzes the Python);
-          raises ``NotImplementedError`` for now.
+          (the source of the programming-model contract).
+        - ``"dynamo"``: a Dynamo-based front-end that analyzes the Python (bytecode)
+          rather than tracing one path. The TRANSFORMED bytecode Dynamo produces (which
+          extracts the model's params/buffers, calls the compiled subgraph, and
+          reassembles the output) is inlined into ``python_code`` (marshalled); the
+          subgraph is lowered through the same ``backend`` choices, and ``mark_unbacked``
+          dynamic shapes and ``decompositions`` are honored (see below). Scoped to
+          TRAINING steps too: a ``.backward()`` / ``torch.autograd.grad`` is traced INTO
+          the graph (precompile pins Dynamo's ``trace_autograd_ops`` so it does not
+          graph-break), and the artifact accumulates the resulting parameter gradients onto
+          the runtime model exactly like eager. This source-artifact path requires one full
+          graph; for graph breaks and multiple guarded/recompiled variants, pass
+          ``example_inputs=[(...,), ...]``.
+          Dynamo's runtime guards are not embedded, and -- UNLIKE the ``make_fx`` tracer --
+          the dynamo driver does NOT re-validate the runtime model/inputs at load: it does
+          not reproduce the ``make_fx`` driver's param/buffer structural check (invariant 2)
+          or per-input shape/dtype/device checks (invariants 3/6). Safety comes from the
+          same specialization contract plus, on the inductor backend, the baked
+          ``assert_size_stride`` (which catches a runtime input/weight whose SHAPE or STRIDE
+          differs, but not its DTYPE); on the EAGER backend nothing is re-checked, so a
+          drifted runtime model (broken weight tying, a retyped/reshaped weight) or a
+          broadcast-compatible input-shape mismatch can SILENTLY miscompute where
+          ``make_fx`` would raise. Pass a model and inputs matching the example, as the
+          contract requires. See the ``tracer`` note in Note [precompile programming model].
+          The dynamo artifact inlines marshalled bytecode plus a pickled state blob, so it
+          is locked to the producing Python version (unlike the portable ``make_fx`` source)
+          AND, because its import aliases can reference private ``torch._dynamo`` runtime
+          modules, to a compatible torch build; load it under the same CPython and a
+          matching torch build (or use ``make_fx`` with ``backend='eager'`` for portable
+          source; the default ``make_fx`` inductor artifact itself inlines private
+          ``torch._inductor`` modules, so it is also torch-build-locked -- only the
+          Python-version portability holds for either ``make_fx`` backend).
 
         ``decompositions`` is an optional decomposition table (a dict mapping each
-        ``OpOverload`` to a decomposition function) forwarded to ``make_fx`` as its
-        ``decomposition_table`` during capture, so you can control how ATen ops are
-        broken down in the captured graph. Defaults to ``None`` (make_fx's default).
+        ``OpOverload`` to a decomposition function) that controls how ATen ops are broken
+        down in the captured graph. Defaults to ``None`` (make_fx's default). The
+        ``make_fx`` tracer forwards it to ``make_fx`` as its ``decomposition_table``
+        during capture; the ``dynamo`` tracer applies the same table by re-tracing
+        Dynamo's captured subgraph with it (Dynamo itself never consults a decomposition
+        table), so the resulting graph is decomposed the same way on either tracer.
 
-        Dynamic shapes are opt-in via ``torch._dynamo.decorators.mark_unbacked``
-        (inductor backend only), NOT a precompile kwarg: mark dims on the inputs before
-        calling, e.g. ``mark_unbacked(x, 0); precompile(fn, model, x)`` frees ``x``'s
-        batch dim. Marked dims are captured as UNBACKED symints, which cannot be guarded
-        on, so one artifact serves any runtime size of them (invariant 3); a graph that
-        needs to guard on / specialize a marked dim fails at capture with a
-        ``PrecompileError``. Dims sharing a ``shape_id`` reuse one symbol (equal by
-        construction); ``min``/``max`` become runtime asserts. Other dims stay static.
-        Dims that MUST be equal at runtime (e.g. two inputs combined by a broadcast that
-        requires equal sizes, ``model(a) + model(b)``) MUST be given a SHARED ``shape_id``
-        so a mismatch is rejected; marking two such dims INDEPENDENTLY currently bakes a
-        SILENT equal-size assumption and a runtime mismatch does NOT raise the loud failure
-        eager gives (invariant 3). This is a harvesting gap, not an inherent limit of the
-        standalone artifact: the capture ShapeEnv DOES record the equality (as a deferred
-        runtime assert, e.g. ``Eq(u0, u1)``), but precompile does not yet harvest/enforce
-        those relational asserts in the driver -- only the decorator's declared min/max feed
-        the runtime bound checks. A shared ``shape_id`` is the way to get the check today.
+        Dynamic shapes are opt-in via ``torch._dynamo.decorators.mark_unbacked``, NOT a
+        precompile kwarg: mark dims on the inputs before calling, e.g.
+        ``mark_unbacked(x, 0); precompile(fn, example_inputs=[(model, x)])`` frees ``x``'s
+        batch dim. Marked
+        dims are captured as UNBACKED symints, which cannot be guarded on, so one artifact
+        serves any runtime size of them (invariant 3); a graph that needs to guard on /
+        specialize a marked dim fails at capture with a ``PrecompileError``. Dims sharing a
+        ``shape_id`` reuse one symbol (equal by construction); ``min``/``max`` become
+        runtime asserts. Other dims stay static. With ``tracer="make_fx"`` this requires
+        ``backend="inductor"``; with ``tracer="dynamo"`` both backends work (Dynamo emits
+        the runtime asserts into the subgraph itself), and ``mark_unbacked(strict=True)``
+        is rejected there because Dynamo reads it as a BACKED (guardable) dim.
 
-        Returns ``(python_code, cache)`` -- a self-contained, executable Python
-        source string (the single source of truth for the calling convention) and a
-        binary cache holding ONLY the backend artifact (NO metadata, NO weights).
-        Reload a runnable with ``torch.compiler.precompile.load(python_code, cache)``.
+        One ``tracer="make_fx"`` caveat: dims that MUST be equal at runtime (e.g. two
+        inputs combined by a broadcast that requires equal sizes, ``model(a) + model(b)``)
+        MUST be given a SHARED ``shape_id`` so a mismatch is rejected; marking two such
+        dims INDEPENDENTLY bakes a SILENT equal-size assumption there and a runtime
+        mismatch does NOT raise the loud failure eager gives (invariant 3). This is a
+        harvesting gap, not an inherent limit of the standalone artifact: the capture
+        ShapeEnv DOES record the equality (as a deferred runtime assert, e.g.
+        ``Eq(u0, u1)``), but the make_fx path does not yet harvest/enforce those relational
+        asserts in its driver -- only the decorator's declared min/max feed its runtime
+        bound checks. A shared ``shape_id`` is the way to get the check there;
+        ``tracer="dynamo"`` enforces it either way, since the asserts ride in the graph.
+
+        precompile returns ``(python_code, cache)`` -- a self-contained,
+        executable Python source string (the single source of truth for the calling
+        convention) and a binary cache holding ONLY the backend artifact (NO metadata,
+        NO weights). Reload it with
+        ``torch.compiler.precompile.load(python_code, cache)``.
 
         ``fn`` is the whole computation, e.g.::
 
             python_code, cache = torch.compiler.precompile(
-                lambda model, x: model(x), model, x
+                lambda model, x: model(x), example_inputs=[(model, x)]
             )
 
 
@@ -1691,12 +2705,14 @@ class _PrecompileApi:
                 loss_fn(model(x), t).backward()  # or return autograd.grad(...)
 
 
-            python_code, cache = torch.compiler.precompile(train_step, model, x, t)
+            python_code, cache = torch.compiler.precompile(
+                train_step, example_inputs=[(model, x, t)], training=True
+            )
 
-        Among ``example_inputs``, the ``nn.Module`` arguments have their params/buffers
-        lifted to graph inputs (no weights are baked into the artifact -- invariant 1);
-        the rest are the runtime inputs. The reloaded callable is invoked with the SAME
-        argument structure -- pass the model(s) again at runtime, e.g.
+        Among the example call's arguments, the ``nn.Module`` arguments have their
+        params/buffers lifted to graph inputs (no weights are baked into the artifact --
+        invariant 1); the rest are the runtime inputs. The reloaded callable is invoked
+        with the SAME argument structure -- pass the model(s) again at runtime, e.g.
         ``f_c(model, x)``, and that runtime model must match the example model's
         parameter/buffer structure (invariant 2). Arguments are matched POSITIONALLY:
         pass the model(s) and inputs positionally both here and at load time; keyword-
@@ -1706,14 +2722,17 @@ class _PrecompileApi:
         model's ``parameters()`` ``.grad`` fields, exactly like eager ``.backward()``,
         so a ``zero_grad()`` / ``optimizer.step()`` loop works unchanged; the artifact
         returns ``fn``'s own result (``None`` for a bare ``.backward()`` step), not the
-        grads (invariant 5).
+        grads (invariant 5). This holds for either ``tracer`` -- only the mechanism
+        differs (``make_fx`` harvests the grads as graph outputs and scatters them in the
+        driver; ``dynamo`` traces the backward as an in-graph autograd call whose own
+        bytecode does the accumulate).
 
         Input mutation (incl. module buffers, e.g. BatchNorm running stats in
         training mode), tensor subclasses (e.g. DTensor), and outputs aliasing inputs
         are supported -- AOTAutograd's prelude/epilogue is composed into the artifact
         (invariant 4), as is functionalized RNG. Caller responsibilities NOT checked
         here (see the Note): the runtime model must be structurally identical to the
-        example, and control flow / shapes are specialized to ``example_inputs``
+        example, and control flow / shapes are specialized to the example calls
         (invariants 2 and 3). Violations that ARE checked raise ``PrecompileError``: a
         tensor baked
         as a constant (invariant 1), effectful ops (invariant 4), and -- for the
@@ -1721,6 +2740,14 @@ class _PrecompileApi:
         the example's (invariant 6).
         """
         torch._C._log_api_usage_once("torch.compiler.precompile")
+        if example_args:
+            raise TypeError(
+                f"precompile takes no positional example arguments (got "
+                f"{len(example_args)}). The example call goes in example_inputs: "
+                f"precompile(fn, example_inputs=[(arg0, arg1)]). Add "
+                f"tracer='dynamo' to capture several calls, with the graph breaks "
+                f"and recompilations between them."
+            )
         if backend not in ("inductor", "eager"):
             raise ValueError(
                 f"precompile backend must be 'inductor' or 'eager', got {backend!r}."
@@ -1729,17 +2756,169 @@ class _PrecompileApi:
             raise ValueError(
                 f"precompile tracer must be 'make_fx' or 'dynamo', got {tracer!r}."
             )
-        compiled = PrecompiledModule(
-            fn, backend=backend, tracer=tracer, decompositions=decompositions
-        )
-        compiled._compile(example_inputs)
-        # Build the (expensive) python_code ONCE and thread it into to_cache_bytes so
-        # the full metadata + embedded kernel source is not rebuilt, and so code_hash is
-        # sha256 over exactly the bytes returned to the caller (a matched pair loads).
-        python_code = compiled.to_python_code()
-        return python_code, compiled.to_cache_bytes(python_code)
+        # Deliberately not `not example_inputs`: a one-element tensor is falsy
+        # and a multi-element one is not even boolable, so the likeliest mistake
+        # -- passing the tensors instead of a sequence of calls -- has to reach
+        # PrecompileSession's container check rather than be read as "no calls".
+        if example_inputs is None or (
+            isinstance(example_inputs, Sequence) and len(example_inputs) == 0
+        ):
+            raise ValueError(
+                "precompile requires example_inputs=[(...), ...]: one tuple of "
+                "positional arguments per call to capture. Capture is by "
+                "execution, so there is nothing to trace without one."
+            )
+        if tracer == "make_fx":
+            if isinstance(
+                example_inputs, (torch.Tensor, torch.nn.Module, str)
+            ) or not isinstance(example_inputs, Sequence):
+                raise TypeError(
+                    f"example_inputs takes a sequence of calls -- each a tuple of "
+                    f"positional arguments -- not {type(example_inputs).__name__}. "
+                    f"Wrap a single call as example_inputs=[(arg0, arg1)]."
+                )
+            # make_fx produces ONE trace, so it has exactly one call to make.
+            # The dynamo tracer is the one that takes several, because only it
+            # records what differs between them.
+            if len(example_inputs) != 1:
+                raise ValueError(
+                    f"tracer='make_fx' captures a single call and got "
+                    f"{len(example_inputs)} example_inputs. Pass one tuple, or use "
+                    f"tracer='dynamo', which records a variant per call plus the "
+                    f"graph breaks between them."
+                )
+            if (
+                guard_filter_fn is not None
+                or recompile_limit != 256
+                or dynamic is not None
+                or invariants is not None
+                or not require_complete
+                or not require_no_risky_drops
+                or require_no_dropped_guards
+            ):
+                raise ValueError(
+                    "guard_filter_fn, recompile_limit, dynamic, invariants and the "
+                    "require_* gates describe a multi-variant capture and apply "
+                    "only to tracer='dynamo'"
+                )
+            from torch._dynamo.precompile_package import _example_call
 
-    def load(self, python_code: str, cache: bytes) -> Callable[..., object]:
+            args, kwargs = _example_call(example_inputs[0])
+            if kwargs:
+                raise ValueError(
+                    "tracer='make_fx' takes positional arguments only; "
+                    "ExampleInput(kwargs=...) applies only to tracer='dynamo'."
+                )
+            compiled = PrecompiledModule(
+                fn, backend=backend, tracer=tracer, decompositions=decompositions
+            )
+            # precompile makes the call, so precompile picks the grad mode --
+            # the same rule the dynamo tracer follows. A make_fx training
+            # capture is fn calling .backward() itself, which needs grad on.
+            with torch.enable_grad() if training else torch.no_grad():
+                compiled._compile(args)
+            # Build the (expensive) python_code ONCE and thread it into
+            # to_cache_bytes so the full metadata + embedded kernel source is not
+            # rebuilt, and so code_hash is sha256 over exactly the bytes returned
+            # to the caller (a matched pair loads).
+            python_code = compiled.to_python_code()
+            return python_code, compiled.to_cache_bytes(python_code)
+
+        if decompositions is not None:
+            raise ValueError(
+                "decompositions apply only to tracer='make_fx'; the dynamo "
+                "tracer lowers through the backend instead."
+            )
+        # Serialize only the guards that DISCRIMINATE -- the ones whose
+        # value differed across the captured variants, or that only some
+        # variants carry. Everything else held identically in every variant
+        # and selects nothing.
+        #
+        # This is not an optimization, it is most of what makes an artifact
+        # viable. Most guards cannot be serialized at all (identity guards
+        # on modules, callables, closure cells), and of those that can, the
+        # overwhelming majority are invariant: on a 62-frame ranking model,
+        # 738 of 1207 guard slots. Keeping them would mean refusing that
+        # model over guards that never chose anything.
+        #
+        # The contract this rests on is precompile's: the environment is the
+        # same at capture and at runtime, and every variation in computation
+        # comes from the inputs. An invariant guard is therefore either
+        # environment -- pinned by that contract -- or an input dimension the
+        # examples deliberately did not vary. The cost is real and worth
+        # stating: a call outside the captured domain is served by a
+        # captured graph rather than refused, where a kept guard would have
+        # caught it.
+        #
+        # Which guards discriminate is only knowable once every variant
+        # exists, and guards are serialized per compilation as each one is
+        # produced. So learn it from a throwaway capture first, then capture
+        # again keeping only those. The examples fully determine the
+        # capture, and PrecompileSession gives each session a fresh PGO
+        # state, so the second pass reproduces the first: measured identical
+        # on that model (53 frames, 121 variants, no frame differing).
+        from torch._dynamo.precompile_package import varying_guard_slots
+
+        probe = _capture_session(
+            fn,
+            backend=backend,
+            guard_filter_fn=guard_filter_fn,
+            recompile_limit=recompile_limit,
+            dynamic=dynamic,
+            example_inputs=example_inputs,
+            training=bool(training),
+        )
+        # The probe runs the same calls, so it raises the same things the
+        # real capture would -- and it raises them FIRST. Translate here too,
+        # or a package error surfaces raw from a pass the caller cannot see.
+        from torch._dynamo.exc import PackageError as _PackageError
+
+        try:
+            with probe:
+                pass
+        except _PackageError as e:
+            raise PrecompileError(str(e)) from e
+        keep_only = varying_guard_slots(probe._guard_sets)
+        torch._dynamo.reset()
+        session = PrecompileSession(
+            _capture_session(
+                fn,
+                backend=backend,
+                guard_filter_fn=guard_filter_fn,
+                recompile_limit=recompile_limit,
+                dynamic=dynamic,
+                example_inputs=example_inputs,
+                invariants=invariants,
+                keep_only=keep_only,
+                training=bool(training),
+            )
+        )
+        # Retain graphs only where they will actually be rendered. The probe
+        # above threw its lowering away, an eager "backend" is an fx graph with
+        # no source to emit, and a training graph is refused by
+        # rendered_backends because compile_to_python would drop its backward.
+        # Retaining anyway would deepcopy every compiled graph and hold it for
+        # the session, to produce nothing -- which is worst on exactly the big
+        # training captures that can least afford the memory.
+        session._session._keep_graphs = backend != "eager" and not training
+        with session:
+            pass
+        # The capture is finished, so hand back the artifact rather than a
+        # session the caller has to know to save. capture() remains for a
+        # capture whose calls the caller has to make.
+        return session.artifact(
+            require_complete=require_complete,
+            require_no_risky_drops=require_no_risky_drops,
+            require_no_dropped_guards=require_no_dropped_guards,
+        )
+
+    def load(
+        self,
+        python_code: str,
+        cache: bytes,
+        *,
+        fn: Callable[..., object] | None = None,
+    ) -> Callable[..., object]:
         """Reconstruct a runnable from ``(python_code, cache)`` from precompile.
 
         The driver runs from ``python_code`` -- the single source of truth for the whole
@@ -1757,8 +2936,8 @@ class _PrecompileApi:
 
         Raises ``PrecompileError`` if ``python_code`` is malformed or is not a
         ``torch.compiler.precompile`` artifact (it fails to parse, or is missing the
-        calling-convention metadata), if the cache's ``backend`` tag does not match
-        ``python_code``, or if the cache's ``code_hash`` does not match
+        calling-convention metadata), if the cache's ``backend`` or ``tracer`` tag does
+        not match ``python_code``, or if the cache's ``code_hash`` does not match
         ``sha256(python_code)`` -- i.e. the cache and python_code came from different
         ``precompile()`` calls. A cache whose ``format``/``version`` does not match (a
         foreign or different-build envelope) is NOT fatal: the cache is acceleration
@@ -1776,6 +2955,10 @@ class _PrecompileApi:
         # artifact and to read BACKEND for the cache-pairing check below.
         meta = _parse_artifact_metadata(python_code)
         backend = cast(str, meta["BACKEND"])
+        # TRACER is absent on artifacts predating the dynamo tracer, so treat its absence
+        # as make_fx (matching _parse_artifact_metadata and the cache-envelope default);
+        # this keeps the pairing check below correct for older make_fx python_code.
+        tracer = cast(str, meta.get("TRACER", "make_fx"))
 
         # weights_only=True is safe (plain str/int/bytes dict). The inner artifact bytes
         # are the inductor save_cache_artifacts bundle, used below to prime the kernel
@@ -1804,6 +2987,15 @@ class _PrecompileApi:
                     raise PrecompileError(
                         f"cache backend {blob.get('backend')!r} does not match the "
                         f"python_code backend {backend!r}; the cache and python_code "
+                        "came from different precompile() calls."
+                    )
+                # A tracer tag was added alongside the dynamo tracer; treat its absence as
+                # make_fx so an older make_fx cache still pairs with its python_code. A
+                # differing tag means a wrong (code, cache) pairing, so hard-fail.
+                if blob.get("tracer", "make_fx") != tracer:
+                    raise PrecompileError(
+                        f"cache tracer {blob.get('tracer', 'make_fx')!r} does not match "
+                        f"the python_code tracer {tracer!r}; the cache and python_code "
                         "came from different precompile() calls."
                     )
                 # Reject a cache whose code_hash does not match this python_code (a
@@ -1853,6 +3045,26 @@ class _PrecompileApi:
         # a separate runtime.
         forward = _make_inlined_forward(python_code)
 
+        if meta.get("SERVING_MODE") == "installed":
+            # This artifact serves by installing onto the live code objects,
+            # because a source driver could not reach the frames listed in
+            # UNREACHABLE_WITHOUT_INSTALL. The exec above only built the handle;
+            # entering it, or calling it, is what installs.
+            if not isinstance(forward, _InstalledArtifact):
+                raise PrecompileError(
+                    "python_code declares SERVING_MODE='installed' but its driver "
+                    "did not produce an installable handle; the artifact is "
+                    "malformed."
+                )
+            if fn is not None:
+                forward._rebind(fn)
+            return PrecompiledCallable(forward)
+        if fn is not None:
+            raise PrecompileError(
+                "fn= applies only to an artifact with SERVING_MODE='installed'; a "
+                "standalone artifact carries its own entry and takes the captured "
+                "arguments directly."
+            )
         return PrecompiledModule._from_loaded(forward, backend=backend)
 
 
@@ -1864,11 +3076,12 @@ precompile.__name__ = "precompile"  # type: ignore[attr-defined]
 precompile.__qualname__ = "precompile"  # type: ignore[attr-defined]
 precompile.__doc__ = _PrecompileApi.__call__.__doc__
 
-# Both are public under torch.compiler.precompile, so report their module/qualname there
-# (mirroring the singleton fixup above) -- otherwise Sphinx autoexception/autofunction
-# would anchor them under this private module. load is a bound method; patch the
-# underlying function so introspection on precompile.load reports torch.compiler too.
+# These are public under torch.compiler.precompile, so report their module/qualname there
+# (mirroring the singleton fixup above) -- otherwise Sphinx and IDE introspection would
+# anchor them under this private module. The operations are bound methods, so patch their
+# underlying functions.
 PrecompileError.__module__ = "torch.compiler"
 PrecompileError.__qualname__ = "precompile.PrecompileError"
+PrecompiledCallable.__module__ = "torch.compiler"
 _PrecompileApi.load.__module__ = "torch.compiler"
 _PrecompileApi.load.__qualname__ = "precompile.load"

--- a/torch/_precompile_driver.py
+++ b/torch/_precompile_driver.py
@@ -37,6 +37,20 @@ if TYPE_CHECKING:
     # ahead of the driver. Bound here with placeholder values (not bare annotations) so
     # static tools treat them as real names in the bodies below; this block is not emitted.
     MODULE_POSITIONS: list[int] = []
+    # Multi-graph artifact state, emitted by
+    # torch._precompile._build_multigraph_python_source. _FRAMES is one entry
+    # per Dynamo frame (its code, its variants' guard state and transformed
+    # bytecode, the globals it reads); _BACKENDS is the compiled subgraphs.
+    # The backend the capture used; the drivers key their autocast handling and
+    # their re-serve off it.
+    BACKEND: str = ""
+    _FRAMES: str = ""
+    _BACKENDS: str = ""
+    # An INSTALLED multi-graph artifact carries the whole captured package in
+    # one blob instead of the per-frame records above, because it hands the
+    # frames to the frame evaluator rather than dispatching them itself.
+    _PACKAGE: str = ""
+    _ENTRY_BINDING: str = ""
     NUM_POSITIONAL_ARGS: int = 0
     PARAM_NAMES: list[str] = []
     BUFFER_NAMES: list[str] = []
@@ -53,6 +67,9 @@ if TYPE_CHECKING:
     USER_INPUT_DTYPES: list[str | None] = []
     USER_INPUT_DEVICES: list[str | None] = []
     USER_INPUT_BOUNDS: list[dict[int, tuple[int | None, int | None]] | None] = []
+    # Device types the captured graph dispatches on. The drivers neutralize
+    # ambient autocast on these; see _autocast_off.
+    GRAPH_DEVICES: tuple[str, ...] = ()
 
     # The compiled/captured graph's entry point, emitted before the driver.
     def call(flat_inputs: list[object]) -> list[object]: ...
@@ -132,6 +149,28 @@ def _check_structure(pb, names):
             )
 
 
+def _autocast_off(devices):
+    """Neutralize ambient autocast on the devices the captured graph uses.
+
+    Whatever the capture ran under is already baked into the artifact -- ATen
+    casts for make_fx, generated kernels for inductor -- but the graph still
+    re-dispatches (an inductor artifact calls extern_kernels, which hit the
+    autocast key), so a serving process with autocast on would cast a second
+    time. ``devices`` is GRAPH_DEVICES, recorded from the captured graph rather
+    than from the runtime tensors: a graph can reach a device none of its
+    inputs live on, and one built from factory ops has no input device at all.
+    """
+    import contextlib as _contextlib
+
+    import torch as _t
+
+    stack = _contextlib.ExitStack()
+    for _dev in devices:
+        if _t.amp.is_autocast_available(_dev):
+            stack.enter_context(_t.amp.autocast(_dev, enabled=False))
+    return stack
+
+
 def _eager_forward(*args):
     """Run the captured ATen graph eagerly. Pass the same args the traced fn took --
     the module(s) in the same positions plus the runtime inputs. The module(s) must
@@ -201,7 +240,7 @@ def _eager_forward(*args):
             )
     pb, _names = _extract_param_buffers(mods)
     _check_structure(pb, _names)
-    with _torch.no_grad():
+    with _autocast_off(GRAPH_DEVICES), _torch.no_grad():
         out = list(call([*pb, *user_flat]))
     if GRAD_PARAM_INDICES:
         n = len(GRAD_PARAM_INDICES)
@@ -312,7 +351,11 @@ def _inductor_forward(*args):
     pb, _names = _extract_param_buffers(mods)
     _check_structure(pb, _names)
     try:
-        out = list(call([*pb, *user_flat]))
+        # The generated code re-dispatches through extern_kernels for anything
+        # inductor did not fuse, so ambient autocast reaches it even though the
+        # casts the capture ran under are already baked into the kernels.
+        with _autocast_off(GRAPH_DEVICES):
+            out = list(call([*pb, *user_flat]))
     except AssertionError as _e:
         # Only relabel inductor's own assert_size_stride failure (a stride/memory-format
         # mismatch, or a size mismatch on an unbacked dim the static check above cannot
@@ -366,3 +409,266 @@ def _inductor_forward(*args):
             else:
                 p.grad.add_(g)
     return _pytree.tree_unflatten(out, _pytree.treespec_loads(OUT_SPEC))
+
+
+def _rebuild_cell(value):
+    # Rebuild a closure cell holding ``value``: Python exposes no public cell
+    # constructor, so close over ``value`` in a throwaway function and steal its cell.
+    # Mirrors torch._dynamo.aot_compile.AOTCompilePickler._unpickle_cell; used to
+    # restore the transformed bytecode's free variables from their captured contents.
+    def _inner():
+        return value
+
+    if _inner.__closure__ is None:
+        raise AssertionError("closure must not be None")
+    return _inner.__closure__[0]
+
+
+def _build_multigraph_forward():
+    """Reconstruct a multi-graph artifact and return the runnable ``forward``.
+
+    A capture with graph breaks or several specializations is not one graph, so
+    unlike the single-graph drivers this one has to DISPATCH. Dynamo produced,
+    per frame, one transformed bytecode plus one guard tree per variant; the
+    artifact carries those verbatim (_FRAMES) and this rebuilds them into a
+    dispatcher per frame.
+
+    Deliberately standalone: nothing is installed onto the running program's
+    code objects and no frame evaluator is involved. A frame's dispatcher
+    evaluates each variant's guards against the arguments it was handed and
+    calls the first that matches, so an artifact serves only what it captured
+    and mutates nothing. A continuation is reached the way Dynamo emits it --
+    the entry bytecode does LOAD_GLOBAL on the resume name -- so binding the
+    resume dispatcher under that name in this module's namespace is all the
+    wiring the graph-break path needs.
+
+    Because there is no compiler behind a source artifact, an uncovered call
+    RAISES rather than falling back. That is the point: the artifact serves the
+    calls it captured, and anything else is a coverage gap the caller has to
+    hear about.
+    """
+    import base64
+    import importlib
+    import pickle
+    import sys as _sys
+    import types
+
+    import torch
+    from torch._dynamo.package import (
+        load_guard_manager,
+        load_guards_state,
+        SerializedCode,
+    )
+
+    produced_on = globals().get("_DYNAMO_PYTHON_VERSION")
+    if produced_on is not None and tuple(produced_on) != _sys.version_info[:2]:
+        # marshal only REJECTS a foreign blob across the 3.10 -> 3.11 layout
+        # change; between 3.11 and 3.14 it loads and then segfaults when the
+        # code object runs, so the version has to be checked explicitly.
+        raise ValueError(
+            f"artifact was produced on Python {produced_on[0]}.{produced_on[1]}"
+        )
+
+    frames = pickle.loads(base64.b64decode(_FRAMES))
+    backends = pickle.loads(base64.b64decode(_BACKENDS)) if _BACKENDS else {}
+
+    # One namespace for the whole artifact. Every name the transformed bytecode
+    # can reach lives here: the compiled subgraphs, Dynamo's synthetic import
+    # aliases, the plain globals it read, and the resume dispatchers bound
+    # below. It is this module's own dict, never the user's.
+    ns = globals()
+    # Seed from the module each frame was compiled in: its bytecode reads that
+    # module's globals by name, and its guards were written against them. This
+    # is a READ -- the artifact binds its own names here, never in the user's
+    # module, so loading mutates nothing and there is nothing to unload. The
+    # values are therefore as of load time; a global rebound afterwards is not
+    # seen, which for a frozen artifact is the intended reading.
+    for _frame in frames:
+        _module = _sys.modules.get(_frame["python_module"])
+        if _module is None:
+            try:
+                _module = importlib.import_module(_frame["python_module"])
+            except ImportError:
+                _module = None
+        if _module is not None:
+            for _k, _v in vars(_module).items():
+                ns.setdefault(_k, _v)
+    # The artifact's own names win over anything seeded above.
+    for _backend_id, _artifact in backends.items():
+        ns[_backend_id] = torch._dynamo.disable(_artifact.after_deserialization())
+    # Subgraphs emitted as readable source above already ran as part of this
+    # module, so their compiled ``call`` is in _SUBGRAPHS. Inductor's entry point
+    # is boxed (it takes one list), while the transformed bytecode calls the
+    # subgraph with individual arguments, so adapt between the two.
+    for _backend_id, _boxed in globals().get("_SUBGRAPHS", {}).items():
+
+        def _adapt(_inner):
+            def _compiled_subgraph(*args):
+                return _inner(list(args))
+
+            return _compiled_subgraph
+
+        ns[_backend_id] = torch._dynamo.disable(_adapt(_boxed))
+    for _frame in frames:
+        for _alias, _module_name in _frame["import_sources"].items():
+            ns[_alias] = importlib.import_module(_module_name)
+
+    entry_binding = (
+        pickle.loads(base64.b64decode(_ENTRY_BINDING)) if _ENTRY_BINDING else {}
+    )
+
+    def _make_dispatcher(frame):
+        target = SerializedCode.to_code_object(frame["code"])
+        arg_names = target.co_varnames[: target.co_argcount]
+        is_entry = frame["is_entry"]
+        # A code object carries neither defaults nor closure values, so the
+        # entry gets them back from the artifact. Without the defaults an
+        # omitted parameter is missing from f_locals and every guard misses;
+        # without the closure a closure entry cannot be built at all.
+        entry_defaults = entry_binding.get("defaults") if is_entry else None
+        entry_kwdefaults = entry_binding.get("kwdefaults") if is_entry else None
+        entry_cells = entry_binding.get("closure") if is_entry else None
+        variants = []
+        for guarded in frame["variants"]:
+            guards_state = load_guards_state(guarded["guards_state"])
+            manager = load_guard_manager(guards_state, target, ns)
+            body = SerializedCode.to_code_object(guarded["dynamo_code"])
+            variants.append((manager, body))
+
+        def _bind(closure):
+            bound = []
+            for manager, body in variants:
+                f = types.FunctionType(
+                    body, ns, target.co_name, entry_defaults, closure
+                )
+                if entry_kwdefaults:
+                    f.__kwdefaults__ = dict(entry_kwdefaults)
+                bound.append((manager, f))
+            return bound
+
+        def _dispatch_with(bound, args, kwargs):
+            # Guards are written against the frame's locals, so rebuild that
+            # mapping from the call. Positional-only is enough: Dynamo compiles
+            # the frame Python actually entered, and its parameters are bound by
+            # then.
+            f_locals = dict(zip(arg_names, args))
+            # Fill omitted parameters from the entry's defaults BEFORE checking:
+            # a guard written against a defaulted argument has nothing to bind to
+            # otherwise, and every variant misses on a call that omitted it.
+            if entry_defaults:
+                for name, value in zip(arg_names[len(args) :], entry_defaults):
+                    f_locals.setdefault(name, value)
+            if entry_kwdefaults:
+                for name, value in entry_kwdefaults.items():
+                    f_locals.setdefault(name, value)
+            f_locals.update(kwargs)
+            for manager, variant in bound:
+                if manager.check(f_locals):
+                    return variant(*args, **kwargs)
+            raise RuntimeError(
+                f"precompile: no captured variant of {target.co_name!r} matches this "
+                f"call. The artifact serves only what capture exercised; add an "
+                f"example covering it and recapture. Captured "
+                f"{len(variants)} variant(s)."
+            )
+
+        if is_entry and target.co_freevars:
+            # The entry's cells come from the artifact, not from a caller: only
+            # a continuation is handed a closure per call.
+            bound = _bind(tuple(types.CellType(v) for v in (entry_cells or ())))
+
+            def entry_dispatch(*args, **kwargs):
+                return _dispatch_with(bound, args, kwargs)
+
+            return entry_dispatch, target
+
+        if target.co_freevars:
+            # Dynamo binds a continuation that closes over locals as a FACTORY
+            # taking the closure tuple, and the frame ahead of it passes one.
+            # Mirror that: the closure is only known per call.
+            def factory(closure):
+                bound = _bind(closure)
+
+                def dispatch(*args, **kwargs):
+                    return _dispatch_with(bound, args, kwargs)
+
+                return dispatch
+
+            return factory, target
+
+        bound = _bind(None)
+
+        def dispatch(*args, **kwargs):
+            return _dispatch_with(bound, args, kwargs)
+
+        return dispatch, target
+
+    entry = None
+    for _frame in frames:
+        dispatcher, _target = _make_dispatcher(_frame)
+        if _frame["resume_names"]:
+            # A continuation is reached by LOAD_GLOBAL from the frame ahead of
+            # it, under the name capture minted. Bind it here rather than in the
+            # user's module: nothing outside this artifact should resolve it.
+            for _name in _frame["resume_names"]:
+                ns[_name] = dispatcher
+        elif _frame["is_entry"]:
+            entry = dispatcher
+    if entry is None:
+        raise ValueError("artifact has no entry frame")
+    return entry
+
+
+def _build_installed_forward():
+    """Serve a multi-graph capture by INSTALLING it onto the live code objects.
+
+    A self-contained driver dispatches only the entry frame and the
+    continuations the entry's own bytecode names. A model that graph-breaks
+    inside nested module forwards puts almost every compiled frame behind an
+    ordinary method call, which no name in the entry reaches, so those frames
+    would run eager. This driver instead rebuilds the captured package and hands
+    it to the frame evaluator, which reaches every frame by code object.
+
+    Nothing is installed here: building the handle only resolves and imports.
+    Entering it, or calling it, installs; unload() takes it back out.
+    """
+    import base64
+    import importlib
+    import pickle
+    import sys
+    import types
+
+    from torch._dynamo.package import SerializedCode
+    from torch._precompile import _InstalledArtifact
+
+    cache_entry = pickle.loads(base64.b64decode(_PACKAGE))
+
+    # install resolves every frame through sys.modules[...] directly, so each
+    # module a captured frame came from has to be imported before it runs.
+    for _code_entry in cache_entry.dynamo.codes:
+        importlib.import_module(_code_entry.python_module)
+
+    def _entry_function():
+        # The entry records no qualname to resolve -- it is the callable handed
+        # to precompile, not something reached from a module -- so rebuild a
+        # function around its code object. Capture refuses an entry whose
+        # closure or defaults this could not reproduce, and load(fn=...) lets a
+        # caller supply the real function instead.
+        code_entry = cache_entry.dynamo.codes[0]
+        code = SerializedCode.to_code_object(code_entry.python_code)
+        return types.FunctionType(
+            code, sys.modules[code_entry.python_module].__dict__, code.co_name
+        )
+
+    def _serve(fn):
+        from torch._dynamo.precompile_context import PrecompileContext
+        from torch._dynamo.precompile_package import serve_cache_entry
+
+        # The backends have to be in the context before install deserializes
+        # them, the same thing DynamoStore.load_cache_entry does for the path
+        # form of this artifact.
+        for _backend in cache_entry.backends.values():
+            PrecompileContext.record_artifact(_backend)
+        return serve_cache_entry(fn, cache_entry, backend=BACKEND)
+
+    return _InstalledArtifact(_serve, _entry_function)

--- a/torch/compiler/__init__.py
+++ b/torch/compiler/__init__.py
@@ -8,16 +8,20 @@ from typing_extensions import ParamSpec
 import torch
 from torch._higher_order_ops.invoke_subgraph import NestedCompileRegionOptions
 
-# ``torch.compiler.precompile``: make_fx AOT capture -> self-contained Python source
-# plus an acceleration cache. Re-exported from the private impl module, whose
-# ``_PrecompileApi.__module__`` is forced to "torch.compiler" so this is the single
-# public location. Distinct from ``torch._dynamo.config.caching_precompile`` (a
-# ``torch.compile`` guard-serialization caching mode), despite the shared word.
+# ``torch.compiler.precompile``: example_inputs=[(...), ...] is the one calling
+# convention, and ``tracer`` picks the front-end -- make_fx takes a single call and
+# produces a self-contained Python source plus an acceleration cache, dynamo takes
+# several and produces a guarded multi-graph artifact spanning graph breaks and
+# recompilations. capture/load_package expose the manual form. Re-exported from the private impl, whose ``_PrecompileApi.__module__`` is forced to
+# "torch.compiler" so this is the single public location. Distinct from
+# ``torch._dynamo.config.caching_precompile``
+# (a ``torch.compile`` guard-serialization caching mode), despite the shared word.
 # ``PrecompileError`` is also re-exported here as ``torch.compiler.PrecompileError`` so the
 # conventional ``except torch.compiler.PrecompileError`` works; its ``__module__`` is already
 # forced to "torch.compiler" in the impl module, matching this public location.
 from torch._precompile import (
     precompile as precompile,
+    PrecompiledCallable as PrecompiledCallable,
     PrecompileError as PrecompileError,
 )
 
@@ -47,6 +51,7 @@ __all__ = [
     "cudagraph_mark_warmup_incomplete",
     "load_compiled_function",
     "precompile",
+    "PrecompiledCallable",
     "PrecompileError",
     "wrap_numpy",
     "is_compiling",

--- a/torch/compiler/_precompile_types.py
+++ b/torch/compiler/_precompile_types.py
@@ -1,0 +1,121 @@
+import collections
+import dataclasses
+from collections.abc import Sequence
+
+
+def _count_types(pairs: Sequence[tuple[str, str]]) -> dict[str, int]:
+    counts: collections.Counter[str] = collections.Counter()
+    for guard_type, _ in pairs:
+        counts[guard_type] += 1
+    return dict(counts)
+
+
+@dataclasses.dataclass(frozen=True)
+class ExampleInput:
+    """One call to make during capture, when args alone are not enough."""
+
+    args: tuple[object, ...] = ()
+    kwargs: dict[str, object] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True)
+class GuardFact:
+    """One guard observed while compiling a frame variant."""
+
+    guard_type: str
+    source: str
+    code: tuple[str, ...]
+    value: str
+    enforced: bool
+
+    def render(self) -> str:
+        """Render the guard as one stable, human-readable line."""
+        body = " ; ".join(self.code) if self.code else f"<{self.guard_type}>"
+        if self.value:
+            body = f"{body} {self.value}"
+        where = f" on {self.source}" if self.source else ""
+        return f"[{'enforced' if self.enforced else 'dropped '}] {body}{where}"
+
+
+@dataclasses.dataclass(frozen=True)
+class FrameInvariants:
+    """Guards that held, varied, or were undetermined across frame variants."""
+
+    frame: str
+    filename: str
+    lineno: int
+    variants: int
+    invariant: tuple[GuardFact, ...]
+    varying: tuple[GuardFact, ...]
+    undetermined: tuple[GuardFact, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class PrecompileSummary:
+    """Coverage and guard information from an observed precompile capture."""
+
+    frames: int
+    resume_functions: int
+    guarded_codes: int
+    backend_graphs: int
+    bypassed: tuple[str, ...]
+    truncated: tuple[str, ...] = ()
+    uncovered_frames: tuple[str, ...] = ()
+    wont_generalize: tuple[str, ...] = ()
+    dropped_guards: tuple[tuple[str, str], ...] = ()
+    kept_guards: tuple[tuple[str, str], ...] = ()
+    risky_dropped_guards: tuple[tuple[str, str], ...] = ()
+    capture_errors: tuple[str, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        """Whether the capture covers everything it exercised.
+
+        False if any frame produced NO guarded code at all, if any frame hit the
+        recompile limit, if any was bypassed, or if a capture call raised.
+        """
+        return (
+            not self.bypassed
+            and not self.truncated
+            and not self.uncovered_frames
+            and not self.capture_errors
+            and self.guarded_codes > 0
+        )
+
+    def dropped_guard_types(self) -> dict[str, int]:
+        """Count omitted guards by guard type."""
+        return _count_types(self.dropped_guards)
+
+    def kept_guard_types(self) -> dict[str, int]:
+        """Count serialized guards by guard type."""
+        return _count_types(self.kept_guards)
+
+    def __str__(self) -> str:
+        base = (
+            f"{self.frames} frames ({self.resume_functions} from graph breaks), "
+            f"{self.guarded_codes} guarded codes, "
+            f"{self.backend_graphs} backend graphs"
+        )
+        if self.dropped_guards:
+            base += f", dropped guards {self.dropped_guard_types()}"
+        if self.risky_dropped_guards:
+            base += f", RISKY drops {[n for _, n in self.risky_dropped_guards]}"
+        if self.uncovered_frames:
+            base += (
+                f", {len(self.uncovered_frames)} UNCOVERED: "
+                f"{list(self.uncovered_frames)}"
+            )
+        if self.wont_generalize:
+            base += f", {len(self.wont_generalize)} value-pinned guards"
+        if self.truncated:
+            base += f", >={len(self.truncated)} TRUNCATED: {list(self.truncated)}"
+        if self.bypassed:
+            base += f", {len(self.bypassed)} BYPASSED: {list(self.bypassed)}"
+        if self.capture_errors:
+            base += f", {len(self.capture_errors)} CAPTURE ERROR(S)"
+        return base
+
+
+GuardFact.__module__ = "torch.compiler"
+FrameInvariants.__module__ = "torch.compiler"
+PrecompileSummary.__module__ = "torch.compiler"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195352
* #195351
* #195664
* #195350
* #195349
* __->__ #195348
* #195347
* #195346

BC BREAK, stated first because the diff is 15,424 lines and GitHub will not
render it. torch.compiler.precompile no longer takes the example call
positionally. It goes in the keyword-only example_inputs, which is a SEQUENCE
OF CALLS rather than one call's arguments:

    -   precompile(fn, model, x)
    +   precompile(fn, example_inputs=[(model, x)])

The positional form shipped in the 2.14 release candidates, so it is not
removed outright: one positional example call is still accepted for a
deprecation cycle with a FutureWarning naming the replacement, and passing
both forms is a TypeError. Every positional argument after fn is an argument
of that one call, whatever its type -- a lone list or tuple is that call's
single argument and takes the FutureWarning path; only a lone ExampleInput,
which describes a call rather than being an argument of one, raises TypeError
pointing at example_inputs=. This is a user-visible signature change and the
PR should carry topic: bc breaking.

torch.compiler.precompile lowers a computation ahead of time into a
self-contained Python source string plus a companion cache -- the
(python_code, cache) pair, reloaded with precompile.load -- so a serving
process runs it without tracing anything. Its only front-end so far has been
make_fx: one non-strict ATen trace of one call, which means exactly one graph.
A model that graph-breaks cannot be expressed that way, and neither can one
that specializes several ways; torch._dynamo.aot_compile has the same limit,
since it captures a full graph and a break is a capture failure.
tracer="dynamo" is the value the API already declares and rejects with
NotImplementedError. This implements it: real Dynamo capture over as many
example calls as you supply, recording every frame Dynamo compiled -- the
entry frame, each graph-break continuation, and every recompiled variant of
each -- into the same artifact format.

    code, cache = torch.compiler.precompile(
        fn, example_inputs=[(model, x1), (model, x2)], tracer="dynamo")
    served = torch.compiler.precompile.load(code, cache)

Making example_inputs the only calling convention is the other half of that.
precompile on main takes the example call positionally AND names that varargs
parameter example_inputs, so a real list of calls beside it would leave two
things sharing one name and a tracer argument that was load-bearing in one
spelling and rejected in the other. Now tracer is the only thing that selects
a front-end: make_fx takes exactly one call, dynamo takes as many as you give
it. precompile has always made the example call itself, but it used to make it
in whatever grad mode was ambient; it now pins the mode -- torch.no_grad(), or
torch.enable_grad() under the new training=True. Under the dynamo tracer,
training=True additionally sets
torch._functorch.config.force_non_lazy_backward_lowering, so a capture that
never calls .backward() still records one. The make_fx path only enables grad,
because a make_fx training capture is fn calling .backward() itself.

Only the guards that DISCRIMINATE are serialized, and that is most of what
makes a real model viable rather than an optimization on top. Most guards
cannot be serialized at all (the identity guards, on modules, callables and
closure cells), and of those that can, the overwhelming majority are
invariant: on a 62-frame ranking model, 738 of 1207 guard slots held the same
fact in every captured variant, and such a guard selects nothing. What
licenses dropping them is the contract precompile already asks for -- the
environment is the same at capture and at runtime, and all variation comes
from the inputs -- so an invariant guard is either environment or an input
dimension the examples deliberately did not vary. The cost is stated at the
call site: a call outside the captured domain gets served by a captured graph
instead of being refused. Guard types this capture cannot fingerprint
(SHAPE_ENV, GLOBAL_STATE and the rest of _UNMODELLED_GUARD_TYPES) are exempt,
since they never enter the comparison and so were never shown to be constant,
only never analyzed. A slot is (guard_type, normalized source) and it is kept
when variants of its frame recorded different facts for it OR when only some
variants carry it at all; that second case is the majority (225 of the 274
slots kept on that model), because a guard only one variant has is exactly
what tells that variant apart. Which slots discriminate is knowable only once
every variant exists, but guards are serialized per compilation as each is
produced, so the policy is applied on session exit rather than during
capture: PrecompileSession(prune_invariant_guards=True), which precompile()
passes, re-serializes each frame's guards from the pickle the capture already
made through a filter that keeps only the varying slots
(_apply_guard_policy). The pickle rather than the live guards, because it IS
the value snapshot taken at compile time and a guarded attribute the model
mutates has moved on since. Running the examples a second time to learn the
policy first would be simpler, but a capture is not free of side effects: it
would double a training step's gradients and guard a self-mutating module on
values the discarded pass had advanced past. Re-serializing from a pickle also
uncovered that CheckFunctionManager indexed the builtins dict by name
unconditionally, which a state loaded from a portable-guards pickle no longer
carries; it is looked up optionally now.

A caller's guard_filter_fn COMPOSES with the default filter rather than
replacing it (_compose_with_default). The default is not a sensible starting
point but the thing that drops the identity guards which cannot be serialized
at all, so a filter that replaced it re-admitted every one of them and failed
in frames that had nothing to do with the filter. A custom filter can only
ever drop more; serving composes the same way, since a serve-time recompile
serializes its guards through the package's filter under strict_error.

Dropping guards is only defensible if the caller can see what went, so the
same signature grows the gates that make it visible. Capture is
execution-driven, and it refuses by default to hand back an artifact with a
known coverage gap -- require_complete covers a frame that produced no guarded
code, one that hit recompile_limit, a bypassed frame, and a capture call that
raised -- or one with risky dropped guards, meaning a configuration-dependent
identity slot or a guard a custom filter discarded (require_no_risky_drops).
The stricter opt-in is require_no_dropped_guards. Behind the gates, the new
torch/compiler/_precompile_types.py adds PrecompileSummary, FrameInvariants,
GuardFact and ExampleInput, so the per-frame split into invariant, varying and
undetermined guards is a value you can read rather than a log line, and
convert_frame records a truncated frame both on the package and as a
"dynamo_cache_truncated" trace_structured artifact.

How a multi-graph artifact serves depends on what it can reach, and the
emitted file says which in its header. A source driver dispatches the entry
frame and the continuations the entry bytecode names, and reachability is a
closure: a continuation counts only once something itself reachable names it.
When that covers every captured frame the artifact is "standalone" -- it
installs nothing, no frame evaluator is involved, the driver rebuilds each
frame's guard trees and dispatches by evaluating them against the call, and an
uncovered call raises because there is no compiler behind it. A model that
breaks inside nested module forwards is the other case and the common one:
those frames are entered by an ordinary call, so nothing in the entry reaches
them and they would run eager with every compiled variant unused. Such a
capture is "installed" instead, rebuilding the package and handing the frames
to the frame evaluator, which reaches them by code object. load() still
installs nothing; entering the returned PrecompiledCallable (now exported as
torch.compiler.PrecompiledCallable) installs, as does simply calling it, for a
lifetime that is not lexically scoped, and unload()/exit takes it back out, so
the mutation is attributable to a point in the caller's control flow. The
precompile_package.serving() context manager scopes a thread so an uncovered
call there raises rather than quietly recompiling. Each serve-time compile warns at
the single backend entry point they all pass through, naming its graph by
compile id, backend id and first traced line, and serve_time_compiles() on the
loaded handle gives a job a number to gate on. The banner says which mode the
file is for, rather than describing standalone serving in both. The risky-drop
warning groups by guard type, caps per type and leads with the shape-bearing
group, and the missing-backend error reports the recorded/total split and names
the ids rather than claiming nothing was recorded.

The emitted file is labelled and split by what actually has a source form. In
both serving modes, what was captured -- frames, variant counts,
unserializable guards, values pinned to what capture saw -- is emitted as
readable literals. Beyond that they differ. A standalone artifact renders the
compiled subgraphs as source through the same aot_autograd.compile_to_python
the make_fx tracer uses, leaving only the guard trees and the transformed
bytecode, which genuinely have no source form, base64 under an OPAQUE banner;
a subgraph whose lowering raised stays pickled in _BACKENDS and the header
says how many did. A standalone artifact also carries the checksummed records
of every function Dynamo inlined (INLINED_SOURCES), which its driver verifies
at load the way CompilePackage does for an installed one, so an edit to an
inlined helper is refused rather than served stale; torch's own modules are
recorded too, because TORCH_VERSION is baked at build time and does not see an
edit to an editable install, and the two serving modes must give one answer
to the same edit. An installed artifact emits the whole captured package as
one opaque blob, because its driver needs the package itself rather than the
per-frame records the standalone driver rebuilds from. A training capture
keeps the bundle too, and is refused up front rather than caught, because
compile_to_python pins AOTAutograd to the inference path and a training graph
therefore RENDERS SUCCESSFULLY with the backward silently gone.

The bugs this had to fix share one belief: that there is one compilation in
the process and that the guards Dynamo builds are the guards it keeps.

CheckFunctionManager applied a single guard_filter_fn to both the live guard
manager and the serialized copy. A package that must omit a non-portable
identity guard therefore also dropped it from the LIVE cache, so a later
example reused the wrong compiled variant instead of triggering the recompile
the package needed to record -- capture silently lost variants. The fix
separates them: serialization_guard_filter_fn is applied only to the copy that
gets serialized, and the runtime guards stay whole. Two consequences fall out
of that split. Value pruning keys off the guard tree, replacing anything the
tree does not reach with a placeholder, so pruning against the FILTERED tree
dropped values the rest of the pickled state still referred to and a pruned
tensor came back with no dtype; pruning now follows the unfiltered tree, which
masks rather than fixes the underlying aliasing: missing_values is keyed by
id(), so pruning is coarser than the reference it means to prune. And because
Guard.set_export_info EXTENDS code_list on every build, an inspection build
running after the runtime build handed the filter each guard's code parts two
or three times over, so GuardFilterEntry now snapshots code at construction.

Everything else follows from several artifacts, or an artifact and plain
torch.compile, sharing one process. CompilePackage.uninstall() used to delete
its installed globals unconditionally, which broke a co-resident artifact that
had written the same value under the same name (the ordinary two-replica
shape); ownership is now a stack per name, and an unload rebinds to the
survivor instead of deleting. Rendered subgraphs are spliced into one
namespace and resolve their siblings as late-bound globals, so two variants of
one frame defined the same names and the batch-2 variant silently ran the
batch-4 variant's code; every top-level name a module defines is now suffixed
per module by namespace_module_names in to_standalone_python.py, next to the
composer whose output it renames. The rewrite is driven by AST positions
rather than a text match, which is what keeps an attribute (runner.call), a
nested binding (def call inside class Runner) and a dotted import path out of
it; a def or class header and a global declaration, which have no Name node,
are matched as the first whole word after the statement's column, tuple
targets are module-level bindings too, and the splice works on the UTF-8
bytes the AST's column offsets count. Recompile accounting
counted every region's cache entries against the ambient frame, so a loaded
artifact could push an unrelated torch.compile over its limit; explicit
regions are now registered and subtracted. The CPU codegen target is probed
once per package rather than per compiled variant, and a variant compiled after
inductor's CPU config moved is left out of the artifact -- the frame keeps its
earlier variants, the package warns once and counts the drop -- rather than
failing the capture mid-flight. Under isolate_recompiles,
frame_compile_id is drawn from the region's own frame_state['_compile_id']
rather than the process-global FRAME_COMPILE_COUNTER; ids stay unique because
each region's frame_state dict is minted with its own _id. inspect.getmodule handed back
re-exporting shims (collections.abc is three lines of "from _collections_abc
import *"), so the inlined-source checksum hashed lines that were not there;
_defining_module_name returns the sys.modules key whose file actually holds
the code. The fail_on_recompile message interpolated each precompile entry's
whole guard tree and ran to megabytes on every uncovered request; it now
prints the failing guard, one line per entry, capped and scoped to the
caller's region, and raises RecompileError rather than a bare RuntimeError
(RecompileError derives from TorchDynamoException, which is a RuntimeError, so
existing handlers keep working). And _graph_has_dynamic_shapes read only
node.meta["val"], while a Dynamo graph stashes the fake under "example_value"
-- so a dynamic Dynamo graph was called static and specialized to the example
sizes.

The frame cache is what keeps them apart, and this is the caller for the
surfaces #195347 added: each load takes its own compile region
(isolate_recompiles_id) and its own owner token, so unloading one artifact
clears its entries and not a co-resident one's; two artifacts sharing an inner
backend are separated by the _torchdynamo_cache_key hook, whose one-way
process gate this commit is the first to flip; the exec-strategy generation
token lets an unload restore only the strategy it found; and the
fail_on_recompile callback is marked _torchdynamo_force_callback_on_cache_miss
under serving(), so an uncovered served call reaches the callback and raises
instead of running eager.

Two captures are refused rather than served wrong. A bare nn.Module: Dynamo
compiles its own wrapper frame, which closes over the module, so the entry
frame holds no graph and no artifact can rebuild that closure -- the error
says to capture the function that calls the model. And an entry with a
closure, in either serving mode, because an artifact rebuilds its entry from
that entry's code object and a code object carries no cells; Dynamo guards a
cell by identity, so even a rebuilt cell holding the same value is a different
object and the entry would load and then miss every variant. Refused at
capture, where the closure is visible, instead of on the serving machine.

Two design choices worth calling out. precompile() makes the example calls
itself and hands back the finished artifact rather than a session the caller
drives and then has to remember to save: for examples independent of each
other, with training=True lowering the backward eagerly, a caller-driven
session would only be a second way to say the same thing, and it would be the
way that makes the caller produce a loss. And subgraphs are rendered rather
than pickled because they are Inductor output, not Dynamo state -- pickling
them was a default, not a constraint, and it was most of the file.

What the artifact must never lose. Dropping an invariant guard is licensed by
"it discriminated nothing", but with a single example nothing CAN
discriminate, so two classes of guard are never policy-dropped
(_NEVER_DROPPED_GUARD_TYPES). The shape-bearing guards pin an input's shape or
value -- TENSOR_MATCH, SEQUENCE_LENGTH, CONSTANT_MATCH, EQUALS_MATCH,
DUPLICATE_INPUT -- and without them a one-example capture would drop the very
check that the runtime tensor looks like the captured one, sending an
out-of-domain shape into a kernel specialized for another. The branch-pinning
guards pin the branch the trace took on a data-dependent condition -- whether
an attribute or key is there, what class a value has, whether it is None or
which bool it is, how long an iterator runs, and the process state autograd
dispatch reads. Both decide by the derived guard types too, since one Guard
can emit several checks. Without that, `if "kv" not in self._cache` captured
once served the "not present" graph to a populated cache on the default
gates, and an int argument captured at one value answered every other value
with correct-looking numerics. Guard slots that several checks share on one
source (hasattr(cfg, "a") and hasattr(cfg, "b")) carry the member they
check, so the drop report names each and a frame with two on one base does
not read as varied. Capture pins the grad mode, so the artifact records it
(CAPTURE_GRAD_ENABLED) and both drivers dispatch every served call under it,
the way the make_fx drivers run under no_grad; a forward capture therefore
returns outputs with no autograd history however the caller's mode is set.

Refusals and errors at the boundary. An entry taking *args or **kwargs is
refused before any example call runs, because the served call is bound to the
entry's named parameters and its guards could never match. _entry_fn_of
resolves the entry the way Dynamo compiles it -- innermost_fn first, then a
module's forward or a bound method's function -- and the session, the varargs
check and the _ENTRY_BINDING written into the artifact all use that one
function, so a torch._dynamo.disable-wrapped entry is judged by the wrapped
signature and a served call that omits a defaulted argument still binds it.
An artifact whose entry lives in __main__ loads only from the same program as
far as that can be told: two scripts must be the same file, and a __main__
with no file (REPL, python -c, notebook) on either side cannot be told apart
from the one that captured -- the frame's co_filename may be a placeholder or
a real dump file, and the loader's __main__ has no __file__ either way -- so
it is accepted and resolves globals against the loader, which the
capture-time warning states. A module the loader cannot import is a
PrecompileError naming it, as is every
other failure the frozen driver raises. A variant miss names the first
failing check per variant. A standalone artifact takes keyword arguments and
scopes with `with`, matching the installed handle; a make_fx artifact, whose
driver is positional-only, refuses keywords with a PrecompileError. A missing
example_inputs is a TypeError, and recompile_limit=None means 256. The
capture configuration is installed with config.patch, depth-counted so two
sessions on one thread may overlap and exit out of order, and a call made
from a worker thread installs it there too, training flag included.

Handles. The installed-artifact handle is InstalledCallable in
torch._dynamo.precompile_package, distinct from the public
torch.compiler.PrecompiledCallable that wraps it, and the session wrapper in
torch._precompile is _SessionHandle, so no two classes share a name across
the two modules. InstalledCallable releases its region through a
weakref.finalize when the last reference goes, so an artifact dropped without
unload() leaves nothing on the code objects; a bare call after unload()
raises rather than re-installing as a side effect, while entering the handle
again installs explicitly. ExampleInput, PrecompileSummary, FrameInvariants
and GuardFact are exported from torch.compiler, so a summary pickles and the
documented return types resolve. test/test_precompile.py replaces its
class-level dynamo_wrapped skip with a per-capture one: the shard compiles
each test body, and only a make_fx capture cannot run inside that, so the
dynamo-tracer tests run there with precompile's own entry points kept out of
the enclosing trace.

Smaller pieces that live here because the code they touch is this commit's.
PrecompileSession takes keep_graphs as a constructor argument, passed through
precompile_capture, so precompile() builds its session with graph retention
decided up front instead of poking the flag onto the private session
afterwards; it is off where nothing will be rendered. save() runs the same gates as
artifact() by delegating to _gated_summary(caller="save()") rather than
carrying a second copy of every check. The live-package registry that lets
several wrappers share one installed package is keyed on the serialization
guard filter too, and on the wrapper's own requires_native_backend_compatibility
setting rather than the value a load wrote back, so two wrappers differing only
in guard_filter_fn no longer share one package. Nothing tests that; what
changed is the registry key. A variant the CPU codegen-target check refuses is
also taken back out of PrecompileContext (take_artifact), so its backend
artifact does not ship inside an artifact whose frame no longer references it.
The caching_precompile install fallback in eval_frame catches exactly what a
stale or foreign artifact raises -- RuntimeError from check_versions() and the
source checksum, ImportError and KeyError from a module that moved,
AttributeError from _lookup_code, PackageError from a refused entry -- rolls
the half-installed package back, and compiles cold with a warning that says
so; under strict_precompile it re-raises instead, and anything else (an
AssertionError is a bug in the loader) propagates in either mode. A package
whose install raised rolls itself back before raising, so no frame is left
half-served. And the handle load() returns carries cache_status: "applied"
when the cache primed the kernel caches, else "incompatible", "unreadable" or
"prime_failed" for why it did not, so a deployment that must not JIT has a
value to gate on rather than a warning to grep for.

The signature grows three more keyword arguments and an alias. dynamic=
forces every captured frame static (False) or dynamic (True), where None
leaves automatic dynamic to promote what varied; invariants= names a file the
per-frame guard report is written to when the capture exits cleanly, so what
was pinned and what varied can be reviewed without loading the artifact;
load(fn=) rebinds an installed artifact to the live function it should serve
when the loader's own object differs from the one that captured, and a
standalone artifact rejects it. torch.compiler.precompile.ExampleInput is the
same class as torch.compiler.ExampleInput, so the call that needs keyword
arguments can be spelled next to the API that takes it.

Review order. 9,279 of the 15,424 lines are tests, most of them new capture
tests in test/dynamo/test_package.py (5,858 added). The remaining 6,145 are
source and docs, dominated by torch/_dynamo/precompile_package.py (2,870, all
new) and torch/_precompile.py (1,570 added). There are no C++ changes.

1. torch/_precompile.py, Note [precompile programming model], especially the
"tracer:" section near the end. This is the contract the rest is written
against and the one thing worth reading start to finish. 2.
torch/_precompile.py, _PrecompileApi.__call__: the new calling convention, the
make_fx/dynamo split, the gates, and the guard-policy rationale written at the
call site. 3. torch/_dynamo/precompile_package.py. The capture session and the
guard policy: varying_guard_slots, _NEVER_DROPPED_GUARD_TYPES,
_UNMODELLED_GUARD_TYPES, default_guard_filter_fn, _compose_with_default and
_is_risky_drop, then PrecompileSession._apply_guard_policy, and
PrecompiledCallable and serving() at the end.
4. The emitter and the driver as a pair: _build_multigraph_python_source,
_reachable_frames, _serving_mode and _reject_uninstallable_entry in
torch/_precompile.py, against _build_multigraph_forward and
_build_installed_forward in torch/_precompile_driver.py. The driver is text
inlined verbatim into the artifact, so read it as what the emitter promises.
5. torch/_dynamo/guards.py. Smallest interesting diff, largest blast radius --
it changes CheckFunctionManager for every torch.compile, not just precompile.
6. The rest of Dynamo, which is consequences of the guards.py split and of
process sharing: package.py, eval_frame.py, convert_frame.py, pgo.py,
bytecode_transformation.py, output_graph.py, types.py, precompile_context.py.
7. torch/_functorch/_aot_autograd/to_standalone_python.py: the "example_value"
metadata key and namespace_module_names, which rendered_backends calls. 8.
torch/compiler/_precompile_types.py, then tests and docs.

Test Plan:

Touched: torch/_precompile.py, torch/_precompile_driver.py,
torch/_dynamo/precompile_package.py, torch/_dynamo/package.py,
torch/_dynamo/eval_frame.py, torch/_dynamo/guards.py,
torch/_dynamo/convert_frame.py, torch/_dynamo/pgo.py,
torch/_dynamo/output_graph.py, torch/_dynamo/types.py,
torch/_dynamo/bytecode_transformation.py, torch/_dynamo/precompile_context.py,
torch/_functorch/_aot_autograd/to_standalone_python.py,
torch/_functorch/config.py, torch/compiler/__init__.py,
torch/compiler/_precompile_types.py, docs/source/torch.compiler_api.md,
docs/source/user_guide/torch_compiler/torch.compiler.md,
test/test_precompile.py, test/dynamo/test_package.py, test/dynamo/test_misc.py,
test/dynamo/test_recompile_ux.py, test/functorch/test_compile_to_python.py.

```
python test/test_precompile.py
python test/dynamo/test_package.py
python test/functorch/test_compile_to_python.py
python test/dynamo/test_misc.py
```

What the new tests pin down.
test_precompile_positional_example_call_is_deprecated_but_equivalent asserts
the positional form warns with FutureWarning and produces the same artifact as
example_inputs, and that passing both forms is a TypeError;
test_positional_example_input_is_pointed_at_the_keyword pins that a lone
ExampleInput is refused, and
test_positional_sequence_is_the_single_argument_of_one_call that a lone list
is one call's argument. test_varargs_entry_is_refused_before_any_call_runs
asserts the refusal comes before the entry ever runs and that a
torch._dynamo.disable-wrapped entry is judged by the wrapped signature, and
test_disable_wrapped_entry_with_a_default_round_trips_and_serves that such an
entry's default is bound by the served call.
test_main_entry_loads_only_from_the_same_script and
test_main_entry_loads_where_main_has_no_file run the capture and the loads in
subprocesses: another script is refused by name, and a file-less __main__ on
either side is accepted.
test_invariant_guards_are_not_serialized, test_discriminating_guards_are_kept
and test_shape_guards_survive_a_single_example pin the policy: an invariant
slot is dropped, a varying one kept, and a shape- or value-pinning guard kept
however little it varied, so an uncovered shape or value is refused rather
than answered from the captured graph;
test_invariant_guard_policy_is_still_reported checks the drops still reach
the header now that they are applied on exit.
test_capture_runs_each_example_once,
test_capture_does_not_double_the_gradients_it_accumulates and
test_a_mutating_module_is_guarded_on_what_the_capture_saw are the single-pass
guarantees, and test_portable_guard_filter_artifact_still_loads is the
re-serialization of a portable-filter pickle.
test_keep_all_filter_cannot_readmit_unserializable_guards,
test_custom_filter_only_narrows_what_the_default_kept and
test_serve_filter_cannot_readmit_identity_guards pin filter composition at
capture and at serve.
test_load_reports_cache_status_when_the_cache_is_incompatible reads
cache_status off both a good load and a foreign-build cache;
test_inlined_sources_to_check_keeps_torch_modules and
test_torch_module_source_change_is_rejected_in_both_serving_modes pin that a
torch module's recorded source is checked in both serving modes. In
test_compile_to_python.py, test_namespace_module_names_uses_byte_offsets and
test_namespace_module_names_rewrites_unpacking_and_global cover the renamer's
byte-offset splice and its def/global/tuple-target bindings. In
test_package.py, test_strict_precompile_raises_on_a_failed_install and
test_a_loader_invariant_failure_is_not_a_cold_compile pin the narrowed install
fallback from both sides.
test_dynamo_tracer_serves_each_graph_break_shape runs
six break shapes -- a disabled callee, a disabled method, explicit breaks, a
data-dependent break, a break in a child module, a break inside a loop -- on
both backends, and asserts the served result equals what torch.compile returns
for the same call; test_graph_breaks_and_recompiles_round_trip pins the shape
of the capture itself (3 frames, 2 resume functions, 9 guarded codes for three
input shapes) and asserts that under serving() an unseen shape raises rather
than recompiling.
test_multi_graph_capture_keeps_guards_while_collecting_variants covers the
guard split: two calls differing only in the callable they pass must record 3
guarded codes across the entry frame and its continuation, which is exactly
the recompile a filtered live guard manager suppresses.
test_multi_graph_capture_does_not_leak_auto_dynamic_state pins that a capture
session's automatic-dynamic learning does not escape into the process-wide
code state, by running an ordinary torch.compile before and after a session
and asserting the same frame count both times.
test_automatic_dynamic_promotes_every_frame_across_graph_breaks asserts every
frame across two breaks is compiled static and then promoted, and
test_automatic_dynamic_promotes_only_the_frame_that_varied asserts the
complement, that an entry frame whose input never varied stays specialized
while its continuation is promoted.
test_rendered_subgraphs_do_not_share_top_level_names loads a two-variant
inductor artifact and checks each shape still gets its own answer, which is
what the AST renaming buys; without it one variant runs the other's kernels.
test_multi_graph_bare_module_capture_is_refused,
test_tracer_dynamo_closure_entry_is_refused and
test_multi_graph_installed_entry_with_closure_is_refused cover the refusals.
On the package side, the unload and global-ownership tests
(test_two_loads_of_one_artifact_both_serve,
test_unload_keeps_globals_a_bystander_compile_needs,
test_concurrent_unload_does_not_clear_a_later_package and neighbours) fail if
uninstall goes back to deleting unconditionally.
test_cpu_codegen_config_change_drops_the_variant compiles a second shape after
moving inductor's cpp.simdlen and asserts the variant is left out, the package
warns once and counts two drops, and only the kept variant's backend artifact
is still filed in PrecompileContext, so the reloaded artifact serves the first
shape and refuses the second under fail_on_recompile.
test_failed_install_and_failed_rollback_still_compile_cold mocks an install
that raises and a rollback that raises too, and asserts the call still
compiles cold under strict_precompile=False, logging "compiling from scratch"
and the failed uninstall.
test_precompile_records_a_backend_for_a_short_circuited_noop_graph forces
output_graph's no-op short-circuit on a frame whose result is dead and asserts
the inductor capture still files a backend for it and the artifact serves.
test_saved_tensors_hooks_guard_is_kept asserts AUTOGRAD_SAVED_TENSORS_HOOKS is
never in POLICY_DROPPED_GUARDS and a call under save_on_cpu() is served.
test_precompile_user_global_wins_over_the_artifacts_own captures an entry
reading a module global named BACKEND, a name the artifact binds for its own
metadata, and asserts the served call reads the user's value.
test_precompile_stale_module_memo_is_revalidated deletes an imported module
from sys.modules and asserts the filename memo hands back None and add_code
does not raise on its code. test_make_fx_artifact_refuses_keyword_arguments
asserts a keyword call on a make_fx artifact is a PrecompileError naming the
positional-only driver.

These suites are unmodified but cover the changed guard-serialization and
stance code, and were run as regressions:

```
python test/dynamo/test_guard_serialization.py
python test/dynamo/test_recompile_ux.py
python test/dynamo/test_aot_compile.py
```

Authored with the assistance of an AI coding agent.