### PR TITLE
Don't override a caller's -std in Windows CUDA extension builds

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1237,7 +1237,7 @@ class BuildExtension(_LazyBuildExt):
             cuda_post_cflags = None
             cuda_cflags = None
             if with_cuda:
-                cuda_cflags = ['-std=c++20']
+                cuda_cflags = []
                 for common_cflag in common_cflags:
                     cuda_cflags.append('-Xcompiler')
                     cuda_cflags.append(common_cflag)
@@ -1255,6 +1255,10 @@ class BuildExtension(_LazyBuildExt):
                     cuda_post_cflags = win_hip_flags(cuda_post_cflags)
                 else:
                     cuda_post_cflags = win_cuda_flags(cuda_post_cflags)
+                # NVCC does not allow multiple -std to be passed, so we avoid
+                # overriding the option if the user explicitly passed it.
+                if not any(flag.startswith('-std=') for flag in cuda_post_cflags):
+                    cuda_cflags.insert(0, '-std=c++20')
             cflags = _nt_quote_args(cflags)
             post_cflags = _nt_quote_args(post_cflags)
             if with_cuda:


### PR DESCRIPTION
### Summary

`win_wrap_ninja_compile` guards the C++ path against clobbering a caller-supplied language standard:

```python
append_std17_if_no_std_present(post_cflags)
```

whose helper explains the reasoning:

```python
# NVCC does not allow multiple -std to be passed, so we avoid
# overriding the option if the user explicitly passed it.
```

A few lines below, the CUDA path applies no such guard:

```python
if with_cuda:
    cuda_cflags = ['-std=c++20']
```

So the protection written specifically for nvcc is applied only to the non-nvcc branch. An extension that sets its own standard in `extra_compile_args['nvcc']` ends up with `-std=c++20` in `cuda_cflags` and its own `-std=...` in `cuda_post_cflags`, producing two `-std` flags on every nvcc invocation:

```
nvcc warning : incompatible redefinition for option 'std', the last value of this option was used
```

once per CUDA translation unit.

The non-Windows path in `_write_ninja_file` already has the intended behaviour:

```python
cuda_flags += extra_cuda_cflags
if not any(flag.startswith('-std=') for flag in cuda_flags):
    cuda_flags.append('-std=c++20')
```

This PR makes the Windows ninja path match: supply the default only when `cuda_post_cflags` does not already select a standard. `append_std17_if_no_std_present` itself is not reused here because it emits the MSVC `/std:` spelling when `compiler_type == 'msvc'`, which is not what nvcc wants.

### Repro

Build any Windows CUDA extension that pins a standard — e.g. [xformers](https://github.com/facebookresearch/xformers) v0.0.35, which passes `-std=c++17` in its nvcc flags — against a recent torch. Before this change the generated `build.ninja` contains:

```
cuda_cflags = -std=c++20 -Xcompiler /MD ...
cuda_post_cflags = ... -std=c++17 ...
```

and every nvcc line warns. After, `cuda_cflags` carries no `-std` and only the extension's `-std=c++17` reaches nvcc.

### Testing

Windows 11, MSVC 19.44 (VS 2022), CUDA 13.2, Python 3.11, torch 2.13.0+cu132, `TORCH_CUDA_ARCH_LIST=8.9`:

- xformers v0.0.35 (sets `-std=c++17`): nvcc `std` redefinition warnings **11 → 0** across 11 CUDA TUs; wheel still builds and imports, and only `-std=c++17` appears on the nvcc command lines.
- A minimal `CUDAExtension` passing **no** nvcc flags: `cuda_cflags` still begins with `-std=c++20`, confirming the default path is unaffected.

Windows-only code path; non-Windows and HIP branches are untouched. I do not have a Windows ROCm setup, so the `IS_HIP_EXTENSION` case is unverified beyond inspection — the guard is applied after both the HIP and CUDA `*_flags` calls, so it should behave the same for both.
