### PR TITLE
[BE] Remove obsolete `isLowPower` check

### DIFF
--- a/aten/src/ATen/mps/MPSDevice.mm
+++ b/aten/src/ATen/mps/MPSDevice.mm
@@ -30,9 +30,6 @@ MPSDevice::MPSDevice() : _mtl_device(nil) {
   NSArray* devices = [MTLCopyAllDevices() autorelease];
   for (unsigned long i = 0; i < [devices count]; i++) {
     id<MTLDevice> device = devices[i];
-    if ([device isLowPower]) { // exclude Intel GPUs
-      continue;
-    }
     if (![device supportsFamily:MTLGPUFamilyMac2]) {
       // Exclude devices that does not support Metal 2.0
       // Virtualised MPS device on MacOS 12.6 should fail this check


### PR DESCRIPTION
Which only made sense on Intel Macs, which have not been supported for quite some time.
Discovered while compiling on MacOS-27, where this function is deprecated.
