### PR TITLE
[MPS] Migrate constant pad to metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/Pad.h
+++ b/aten/src/ATen/native/mps/kernels/Pad.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <c10/metal/common.h>
+
+struct ConstantPadDenseParams {
+  ::c10::metal::array<uint32_t, 3> input_sizes;
+  ::c10::metal::array<uint32_t, 3> output_sizes;
+  ::c10::metal::array<uint32_t, 3> left_pad;
+};
+
+template <typename idx_t = uint32_t>
+struct ConstantPadNdParams {
+  ::c10::metal::array<idx_t, ::c10::metal::max_ndim> output_sizes;
+  ::c10::metal::array<idx_t, ::c10::metal::max_ndim> input_sizes;
+  ::c10::metal::array<idx_t, ::c10::metal::max_ndim> input_strides;
+  ::c10::metal::array<idx_t, ::c10::metal::max_ndim> output_strides;
+  ::c10::metal::array<idx_t, ::c10::metal::max_ndim> left_pad;
+  uint32_t ndim;
+};

--- a/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
+++ b/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
@@ -1,8 +1,129 @@
+#include <ATen/native/mps/kernels/Pad.h>
 #include <c10/metal/utils.h>
 #include <metal_stdlib>
 
 using namespace metal;
 using namespace c10::metal;
+
+template <typename T>
+kernel void constant_pad_nd_dense(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant ConstantPadDenseParams& params [[buffer(2)]],
+    constant T& fill_value [[buffer(3)]],
+    uint3 tid [[thread_position_in_grid]],
+    uint3 grid [[threads_per_grid]]) {
+  const uint input_w = params.input_sizes[0];
+  const uint input_h = params.input_sizes[1];
+  const uint input_d = params.input_sizes[2];
+  const uint output_w = params.output_sizes[0];
+  const uint output_h = params.output_sizes[1];
+  const uint output_d = params.output_sizes[2];
+  const uint left_w = params.left_pad[0];
+  const uint left_h = params.left_pad[1];
+  const uint left_d = params.left_pad[2];
+  const uint output_d_idx = tid.z % output_d;
+  const uint outer_idx = tid.z / output_d;
+  const bool h_in_bounds = tid.y >= left_h && tid.y - left_h < input_h;
+  const bool d_in_bounds =
+      output_d_idx >= left_d && output_d_idx - left_d < input_d;
+  const bool outer_in_bounds = h_in_bounds && d_in_bounds;
+  const uint input_h_idx = h_in_bounds ? tid.y - left_h : 0;
+  const uint input_d_idx = d_in_bounds ? output_d_idx - left_d : 0;
+  const ulong output_base = (ulong(tid.z) * output_h + tid.y) * output_w;
+  const ulong input_base =
+      ((ulong(outer_idx) * input_d + input_d_idx) * input_h + input_h_idx) *
+      input_w;
+
+  for (uint i = 0; i < ILP_PER_THREAD; ++i) {
+    const uint output_w_idx = tid.x + i * grid.x;
+    if (output_w_idx >= output_w) {
+      break;
+    }
+    const bool w_in_bounds =
+        output_w_idx >= left_w && output_w_idx - left_w < input_w;
+    const uint input_w_idx = w_in_bounds ? output_w_idx - left_w : 0;
+    output[output_base + output_w_idx] = outer_in_bounds && w_in_bounds
+        ? input[input_base + input_w_idx]
+        : fill_value;
+  }
+}
+
+template <typename T, typename idx_t>
+kernel void constant_pad_nd(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant ConstantPadNdParams<idx_t>& params [[buffer(2)]],
+    constant T& fill_value [[buffer(3)]],
+    uint2 tid [[thread_position_in_grid]],
+    uint2 grid [[threads_per_grid]]) {
+  idx_t input_offset = 0;
+  idx_t output_offset = 0;
+  idx_t outer_idx = tid.y;
+  bool outer_in_bounds = true;
+  for (uint dim = 1; dim < params.ndim; ++dim) {
+    const idx_t output_idx = outer_idx % params.output_sizes[dim];
+    outer_idx /= params.output_sizes[dim];
+    const bool dim_in_bounds = output_idx >= params.left_pad[dim] &&
+        output_idx - params.left_pad[dim] < params.input_sizes[dim];
+    const idx_t input_idx =
+        dim_in_bounds ? output_idx - params.left_pad[dim] : 0;
+    output_offset += output_idx * params.output_strides[dim];
+    input_offset += input_idx * params.input_strides[dim];
+    outer_in_bounds = outer_in_bounds && dim_in_bounds;
+  }
+
+  for (uint i = 0; i < ILP_PER_THREAD; ++i) {
+    const auto output_idx = idx_t(tid.x) + idx_t(i) * idx_t(grid.x);
+    if (output_idx >= params.output_sizes[0]) {
+      break;
+    }
+    const bool dim_in_bounds = output_idx >= params.left_pad[0] &&
+        output_idx - params.left_pad[0] < params.input_sizes[0];
+    const idx_t input_idx = dim_in_bounds ? output_idx - params.left_pad[0] : 0;
+    output[output_offset + output_idx * params.output_strides[0]] =
+        outer_in_bounds && dim_in_bounds
+        ? input[input_offset + input_idx * params.input_strides[0]]
+        : fill_value;
+  }
+}
+
+#define INSTANTIATE_CONSTANT_PAD_ND_IDX(DTYPE, IDX, SUFFIX) \
+  template [[host_name("constant_pad_nd_" #DTYPE #SUFFIX)]] \
+  kernel void constant_pad_nd<DTYPE, IDX>(                  \
+      constant DTYPE*,                                      \
+      device DTYPE*,                                        \
+      constant ConstantPadNdParams<IDX>&,                   \
+      constant DTYPE&,                                      \
+      uint2,                                                \
+      uint2)
+
+#define INSTANTIATE_CONSTANT_PAD_ND(DTYPE)                \
+  template [[host_name("constant_pad_nd_dense_" #DTYPE)]] \
+  kernel void constant_pad_nd_dense<DTYPE>(               \
+      constant DTYPE*,                                    \
+      device DTYPE*,                                      \
+      constant ConstantPadDenseParams&,                   \
+      constant DTYPE&,                                    \
+      uint3,                                              \
+      uint3);                                             \
+  INSTANTIATE_CONSTANT_PAD_ND_IDX(DTYPE, uint, _u32);     \
+  INSTANTIATE_CONSTANT_PAD_ND_IDX(DTYPE, ulong, _u64)
+
+INSTANTIATE_CONSTANT_PAD_ND(float);
+INSTANTIATE_CONSTANT_PAD_ND(half);
+INSTANTIATE_CONSTANT_PAD_ND(bfloat);
+INSTANTIATE_CONSTANT_PAD_ND(long);
+INSTANTIATE_CONSTANT_PAD_ND(ulong);
+INSTANTIATE_CONSTANT_PAD_ND(int);
+INSTANTIATE_CONSTANT_PAD_ND(uint);
+INSTANTIATE_CONSTANT_PAD_ND(short);
+INSTANTIATE_CONSTANT_PAD_ND(ushort);
+INSTANTIATE_CONSTANT_PAD_ND(char);
+INSTANTIATE_CONSTANT_PAD_ND(uchar);
+INSTANTIATE_CONSTANT_PAD_ND(bool);
+INSTANTIATE_CONSTANT_PAD_ND(float2);
+INSTANTIATE_CONSTANT_PAD_ND(half2);
 
 template <typename T>
 kernel void replication_pad1d_forward(

--- a/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
+++ b/aten/src/ATen/native/mps/kernels/ReplicationPad.metal
@@ -5,6 +5,132 @@ using namespace metal;
 using namespace c10::metal;
 
 template <typename T>
+kernel void constant_pad_nd_dense(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant uint* params [[buffer(2)]],
+    constant T& fill_value [[buffer(3)]],
+    uint3 tid [[thread_position_in_grid]],
+    uint3 grid [[threads_per_grid]]) {
+  const uint input_w = params[0];
+  const uint input_h = params[1];
+  const uint input_d = params[2];
+  const uint output_w = params[3];
+  const uint output_h = params[4];
+  const uint output_d = params[5];
+  const uint output_d_idx = tid.z % output_d;
+  const uint outer_idx = tid.z / output_d;
+  const bool h_in_bounds = tid.y >= params[7] && tid.y - params[7] < input_h;
+  const bool d_in_bounds =
+      output_d_idx >= params[8] && output_d_idx - params[8] < input_d;
+  const bool outer_in_bounds = h_in_bounds && d_in_bounds;
+  const uint input_h_idx = h_in_bounds ? tid.y - params[7] : 0;
+  const uint input_d_idx = d_in_bounds ? output_d_idx - params[8] : 0;
+  const ulong output_base = (ulong(tid.z) * output_h + tid.y) * output_w;
+  const ulong input_base =
+      ((ulong(outer_idx) * input_d + input_d_idx) * input_h + input_h_idx) *
+      input_w;
+
+  for (uint i = 0; i < ILP_PER_THREAD; ++i) {
+    const uint output_w_idx = tid.x + i * grid.x;
+    if (output_w_idx >= output_w) {
+      break;
+    }
+    const bool w_in_bounds =
+        output_w_idx >= params[6] && output_w_idx - params[6] < input_w;
+    const uint input_w_idx = w_in_bounds ? output_w_idx - params[6] : 0;
+    output[output_base + output_w_idx] = outer_in_bounds && w_in_bounds
+        ? input[input_base + input_w_idx]
+        : fill_value;
+  }
+}
+
+template <typename T, typename I>
+kernel void constant_pad_nd_strided(
+    constant T* input [[buffer(0)]],
+    device T* output [[buffer(1)]],
+    constant I* output_sizes [[buffer(2)]],
+    constant I* input_sizes [[buffer(3)]],
+    constant I* input_strides [[buffer(4)]],
+    constant I* output_strides [[buffer(5)]],
+    constant I* left_pad [[buffer(6)]],
+    constant uint& ndim [[buffer(7)]],
+    constant T& fill_value [[buffer(8)]],
+    uint2 tid [[thread_position_in_grid]],
+    uint2 grid [[threads_per_grid]]) {
+  I input_offset = 0;
+  I output_offset = 0;
+  I outer_idx = tid.y;
+  bool outer_in_bounds = true;
+  for (uint dim = 1; dim < ndim; ++dim) {
+    const I output_idx = outer_idx % output_sizes[dim];
+    outer_idx /= output_sizes[dim];
+    const bool dim_in_bounds = output_idx >= left_pad[dim] &&
+        output_idx - left_pad[dim] < input_sizes[dim];
+    const I input_idx = dim_in_bounds ? output_idx - left_pad[dim] : 0;
+    output_offset += output_idx * output_strides[dim];
+    input_offset += input_idx * input_strides[dim];
+    outer_in_bounds = outer_in_bounds && dim_in_bounds;
+  }
+
+  for (uint i = 0; i < ILP_PER_THREAD; ++i) {
+    const I output_idx = I(tid.x) + I(i) * I(grid.x);
+    if (output_idx >= output_sizes[0]) {
+      break;
+    }
+    const bool dim_in_bounds =
+        output_idx >= left_pad[0] && output_idx - left_pad[0] < input_sizes[0];
+    const I input_idx = dim_in_bounds ? output_idx - left_pad[0] : 0;
+    output[output_offset + output_idx * output_strides[0]] =
+        outer_in_bounds && dim_in_bounds
+        ? input[input_offset + input_idx * input_strides[0]]
+        : fill_value;
+  }
+}
+
+#define INSTANTIATE_CONSTANT_PAD_ND_STRIDED(DTYPE, INDEX, SUFFIX)       \
+  template [[host_name("constant_pad_nd_strided_" #SUFFIX "_" #DTYPE)]] \
+  kernel void constant_pad_nd_strided<DTYPE, INDEX>(                    \
+      constant DTYPE*,                                                  \
+      device DTYPE*,                                                    \
+      constant INDEX*,                                                  \
+      constant INDEX*,                                                  \
+      constant INDEX*,                                                  \
+      constant INDEX*,                                                  \
+      constant INDEX*,                                                  \
+      constant uint&,                                                   \
+      constant DTYPE&,                                                  \
+      uint2,                                                            \
+      uint2)
+
+#define INSTANTIATE_CONSTANT_PAD_ND(DTYPE)                \
+  template [[host_name("constant_pad_nd_dense_" #DTYPE)]] \
+  kernel void constant_pad_nd_dense<DTYPE>(               \
+      constant DTYPE*,                                    \
+      device DTYPE*,                                      \
+      constant uint*,                                     \
+      constant DTYPE&,                                    \
+      uint3,                                              \
+      uint3);                                             \
+  INSTANTIATE_CONSTANT_PAD_ND_STRIDED(DTYPE, uint, u32);  \
+  INSTANTIATE_CONSTANT_PAD_ND_STRIDED(DTYPE, ulong, u64)
+
+INSTANTIATE_CONSTANT_PAD_ND(float);
+INSTANTIATE_CONSTANT_PAD_ND(half);
+INSTANTIATE_CONSTANT_PAD_ND(bfloat);
+INSTANTIATE_CONSTANT_PAD_ND(long);
+INSTANTIATE_CONSTANT_PAD_ND(ulong);
+INSTANTIATE_CONSTANT_PAD_ND(int);
+INSTANTIATE_CONSTANT_PAD_ND(uint);
+INSTANTIATE_CONSTANT_PAD_ND(short);
+INSTANTIATE_CONSTANT_PAD_ND(ushort);
+INSTANTIATE_CONSTANT_PAD_ND(char);
+INSTANTIATE_CONSTANT_PAD_ND(uchar);
+INSTANTIATE_CONSTANT_PAD_ND(bool);
+INSTANTIATE_CONSTANT_PAD_ND(float2);
+INSTANTIATE_CONSTANT_PAD_ND(half2);
+
+template <typename T>
 kernel void replication_pad1d_forward(
     constant T* input [[buffer(0)]],
     device T* output [[buffer(1)]],

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -72,11 +72,17 @@ static Tensor& pad_out_template(Tensor& output,
   int dim_slices = 0;
 
   if (!is_backward_pass && ndims > padding_dim) {
-    bool valid_dims = input_.size(1) != 0 && input_.size(padding_dim) != 0;
-    TORCH_CHECK((ndims == 1 + padding_dim && valid_dims) ||
-                    (ndims == 2 + padding_dim && valid_dims && input_.size(1 + padding_dim) != 0),
-                "3D or 4D (batch mode) tensor expected for input, but got: ",
-                input_);
+    // allow empty batch size but not other dimensions
+    const bool batch_mode = ndims == 2 + padding_dim;
+    const auto non_batch_sizes = input_.sizes().slice(batch_mode ? 1 : 0);
+    TORCH_CHECK((batch_mode || ndims == 1 + padding_dim) &&
+                    std::ranges::all_of(non_batch_sizes, [](int64_t size) { return size != 0; }),
+                "Expected ",
+                1 + padding_dim,
+                "D or ",
+                2 + padding_dim,
+                "D (batch mode) tensor with possibly 0 batch size and other non-zero dimensions for input, but got: ",
+                input_.sizes());
   }
 
   if (ndims == padding_dim) {

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -2,12 +2,19 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <c10/metal/common.h>
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/constant_pad_nd_native.h>
+#include <ATen/ops/empty_like.h>
+#include <ATen/ops/empty_strided.h>
 #include <ATen/ops/reflection_pad1d_backward_native.h>
 #include <ATen/ops/reflection_pad1d_native.h>
 #include <ATen/ops/reflection_pad2d_backward_native.h>
@@ -330,10 +337,7 @@ static Tensor& pad_out_template(Tensor& output,
   return output;
 }
 
-static MTLSize replication_pad1d_threadgroup(id<MTLComputePipelineState> pso,
-                                             NSUInteger gx,
-                                             NSUInteger gy,
-                                             NSUInteger gz) {
+static MTLSize pad_threadgroup(id<MTLComputePipelineState> pso, NSUInteger gx, NSUInteger gy, NSUInteger gz) {
   const auto maxTPG = [pso maxTotalThreadsPerThreadgroup];
   const auto tg_x = std::min<NSUInteger>(maxTPG, gx);
   const auto tg_y = std::min<NSUInteger>(maxTPG / tg_x, gy);
@@ -373,7 +377,7 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
       [encoder setComputePipelineState:pso];
       mtl_setArgs(encoder, input, output_c, sizes_pad);
       [encoder dispatchThreads:MTLSizeMake(output_W, nplane, nbatch)
-          threadsPerThreadgroup:replication_pad1d_threadgroup(pso, output_W, nplane, nbatch)];
+          threadsPerThreadgroup:pad_threadgroup(pso, output_W, nplane, nbatch)];
       getMPSProfiler().endProfileKernel(pso, stream);
     }
   });
@@ -417,13 +421,51 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
       [encoder setComputePipelineState:pso];
       mtl_setArgs(encoder, grad_output, grad_input_c, sizes_pad);
       [encoder dispatchThreads:MTLSizeMake(input_W, nplane, nbatch)
-          threadsPerThreadgroup:replication_pad1d_threadgroup(pso, input_W, nplane, nbatch)];
+          threadsPerThreadgroup:pad_threadgroup(pso, input_W, nplane, nbatch)];
       getMPSProfiler().endProfileKernel(pso, stream);
     }
   });
   if (grad_input_needs_copy) {
     grad_input.copy_(grad_input_buf);
   }
+}
+
+template <typename index_t>
+static void constant_pad_nd_strided_kernel_mps(const Tensor& input,
+                                               const Tensor& output,
+                                               const Scalar& value,
+                                               const std::vector<index_t>& output_sizes,
+                                               const std::vector<index_t>& input_sizes,
+                                               const std::vector<index_t>& input_strides,
+                                               const std::vector<index_t>& output_strides,
+                                               const std::vector<index_t>& left_pad,
+                                               NSUInteger grid_x,
+                                               NSUInteger grid_y) {
+  const auto metal_ndim = static_cast<uint32_t>(output.dim());
+  const auto index_type = sizeof(index_t) == sizeof(uint32_t) ? "u32" : "u64";
+  auto pso = lib.getPipelineStateForFunc("constant_pad_nd_strided_" + std::string(index_type) + "_" +
+                                         scalarToMetalTypeString(input));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      getMPSProfiler().beginProfileKernel(pso, "constant_pad_nd", {input, output}, stream);
+      auto encoder = stream->commandEncoder();
+      auto fill_value = getMPSScalar(value, input.scalar_type());
+      [encoder setComputePipelineState:pso];
+      mtl_setArgs(encoder,
+                  input,
+                  output,
+                  output_sizes,
+                  input_sizes,
+                  input_strides,
+                  output_strides,
+                  left_pad,
+                  metal_ndim,
+                  fill_value);
+      mtl_dispatch2DJob(encoder, pso, grid_x, grid_y);
+      getMPSProfiler().endProfileKernel(pso, stream);
+    }
+  });
 }
 
 } // namespace mps
@@ -559,17 +601,189 @@ Tensor replication_pad3d_backward_mps(const Tensor& grad_output, const Tensor& i
 
 // backward pass is explicitly handled in autograd by negating the "pad" argument
 Tensor constant_pad_nd_mps(const Tensor& self, IntArrayRef pad, const Scalar& value) {
-  if (pad.empty()) {
-    return self.clone();
+  TORCH_CHECK(pad.size() % 2 == 0, "Length of pad must be even but instead it equals ", pad.size());
+
+  const auto ndim = self.dim();
+  const auto padding_dim = static_cast<int64_t>(pad.size() / 2);
+  TORCH_CHECK(ndim >= padding_dim,
+              "Length of pad should be no more than twice the number of dimensions of the input. Pad length is ",
+              pad.size(),
+              " while the input has ",
+              ndim,
+              " dimensions.");
+
+  bool all_pads_non_positive = true;
+  auto cropped = self;
+  for (const auto dim : c10::irange(ndim - padding_dim, ndim)) {
+    const auto pad_idx = 2 * (ndim - dim - 1);
+    if (pad[pad_idx] < 0) {
+      cropped = cropped.narrow(dim, -pad[pad_idx], cropped.size(dim) + pad[pad_idx]);
+    } else if (pad[pad_idx] != 0) {
+      all_pads_non_positive = false;
+    }
+    if (pad[pad_idx + 1] < 0) {
+      cropped = cropped.narrow(dim, 0, cropped.size(dim) + pad[pad_idx + 1]);
+    } else if (pad[pad_idx + 1] != 0) {
+      all_pads_non_positive = false;
+    }
   }
-  if (pad.size() > 6) {
-    TORCH_WARN_ONCE("MPS: The constant padding of more than 3 dimensions is not currently supported natively. ",
-                    "It uses View Ops default implementation to run. This may have performance implications.");
+
+  if (all_pads_non_positive && cropped.is_contiguous()) {
+    return cropped.clone();
+  }
+
+  if (self.is_quantized() || self.is_conj() || self.is_neg() || ndim > c10::metal::max_ndim) {
     return at::native::constant_pad_nd(self, pad, value);
   }
-  Tensor output = at::empty({0}, self.options());
-  return mps::pad_out_template(
-      output, self, pad, std::nullopt, MPSGraphPaddingModeConstant, value.toDouble(), __func__);
+
+  std::vector<int64_t> output_sizes;
+  if (all_pads_non_positive) {
+    output_sizes = cropped.sizes().vec();
+  } else {
+    output_sizes = self.sizes().vec();
+    for (const auto dim : c10::irange(ndim - padding_dim, ndim)) {
+      const auto pad_idx = 2 * (ndim - dim - 1);
+      const auto output_size = self.size(dim) + pad[pad_idx] + pad[pad_idx + 1];
+      TORCH_CHECK(output_size >= 0,
+                  "The input size ",
+                  self.size(dim),
+                  ", plus negative padding ",
+                  pad[pad_idx],
+                  " and ",
+                  pad[pad_idx + 1],
+                  " resulted in a negative output size, which is invalid. Check dimension ",
+                  dim,
+                  " of your input.");
+      output_sizes[dim] = output_size;
+    }
+  }
+
+  Tensor output;
+  if (all_pads_non_positive && cropped.is_non_overlapping_and_dense()) {
+    output = at::empty_strided(cropped.sizes(), cropped.strides(), cropped.options());
+  } else if (all_pads_non_positive) {
+    output = at::empty_like(cropped);
+  } else {
+    output = at::empty(output_sizes, self.options().memory_format(self.suggest_memory_format()));
+  }
+  if (output.numel() == 0) {
+    return output;
+  }
+
+  const Scalar kernel_value = all_pads_non_positive ? Scalar(0) : value;
+  constexpr auto uint_max = std::numeric_limits<uint32_t>::max();
+  const auto type = mps::scalarToMetalTypeString(self);
+  const auto stream = getCurrentMPSStream();
+  const bool use_dense = padding_dim <= 3 && cropped.is_contiguous() && output.is_contiguous();
+
+  if (use_dense) {
+    const auto in_w = cropped.size(-1);
+    const auto in_h = padding_dim >= 2 ? cropped.size(-2) : 1;
+    const auto in_d = padding_dim >= 3 ? cropped.size(-3) : 1;
+    const auto out_w = output.size(-1);
+    const auto out_h = padding_dim >= 2 ? output.size(-2) : 1;
+    const auto out_d = padding_dim >= 3 ? output.size(-3) : 1;
+    const auto grid_x = c10::metal::ceil_div(out_w, static_cast<int64_t>(c10::metal::ILP_PER_THREAD));
+    const auto grid_z = output.numel() / (out_w * out_h);
+    const auto left_w = padding_dim >= 1 ? std::max<int64_t>(pad[0], 0) : 0;
+    const auto left_h = padding_dim >= 2 ? std::max<int64_t>(pad[2], 0) : 0;
+    const auto left_d = padding_dim >= 3 ? std::max<int64_t>(pad[4], 0) : 0;
+    const std::array<int64_t, 9> params64 = {in_w, in_h, in_d, out_w, out_h, out_d, left_w, left_h, left_d};
+    const bool params_fit_uint = std::all_of(
+        params64.begin(), params64.end(), [](int64_t param) { return param <= std::numeric_limits<uint32_t>::max(); });
+
+    if (params_fit_uint && grid_x <= uint_max && out_h <= uint_max && grid_z <= uint_max) {
+      std::array<uint32_t, 9> params;
+      std::transform(
+          params64.begin(), params64.end(), params.begin(), [](int64_t param) { return static_cast<uint32_t>(param); });
+      auto pso = mps::lib.getPipelineStateForFunc("constant_pad_nd_dense_" + type);
+      dispatch_sync_with_rethrow(stream->queue(), ^() {
+        @autoreleasepool {
+          getMPSProfiler().beginProfileKernel(pso, "constant_pad_nd", {cropped, output}, stream);
+          auto encoder = stream->commandEncoder();
+          auto fill_value = mps::getMPSScalar(kernel_value, self.scalar_type());
+          [encoder setComputePipelineState:pso];
+          mps::mtl_setArgs(encoder, cropped, output, params, fill_value);
+          [encoder dispatchThreads:MTLSizeMake(grid_x, out_h, grid_z)
+              threadsPerThreadgroup:mps::pad_threadgroup(pso, grid_x, out_h, grid_z)];
+          getMPSProfiler().endProfileKernel(pso, stream);
+        }
+      });
+      return output;
+    }
+  }
+
+  std::vector<int64_t> dim_order(ndim);
+  std::iota(dim_order.begin(), dim_order.end(), 0);
+  std::stable_sort(dim_order.begin(), dim_order.end(), [&](int64_t lhs, int64_t rhs) {
+    return output.stride(lhs) < output.stride(rhs);
+  });
+
+  std::vector<int64_t> ordered_output_sizes(ndim);
+  std::vector<int64_t> ordered_input_sizes(ndim);
+  std::vector<int64_t> ordered_output_strides(ndim);
+  std::vector<int64_t> ordered_input_strides(ndim);
+  std::vector<int64_t> ordered_left_pad(ndim);
+  for (const auto ordered_dim : c10::irange(ndim)) {
+    const auto dim = dim_order[ordered_dim];
+    ordered_output_sizes[ordered_dim] = output.size(dim);
+    ordered_input_sizes[ordered_dim] = cropped.size(dim);
+    ordered_output_strides[ordered_dim] = output.stride(dim);
+    ordered_input_strides[ordered_dim] = cropped.stride(dim);
+    if (dim >= ndim - padding_dim) {
+      const auto pad_idx = 2 * (ndim - dim - 1);
+      ordered_left_pad[ordered_dim] = std::max<int64_t>(pad[pad_idx], 0);
+    }
+  }
+
+  const auto inner = ordered_output_sizes[0];
+  const auto grid_x = c10::metal::ceil_div(inner, static_cast<int64_t>(c10::metal::ILP_PER_THREAD));
+  const auto grid_y = output.numel() / inner;
+  if (grid_x > uint_max || grid_y > uint_max) {
+    return at::native::constant_pad_nd(self, pad, value);
+  }
+
+  const auto values_fit_uint = [](const std::vector<int64_t>& values) {
+    return std::all_of(
+        values.begin(), values.end(), [](int64_t value) { return value <= std::numeric_limits<uint32_t>::max(); });
+  };
+  const bool use_32bit_index = mps::offsetsFitIn<uint32_t>(cropped, output) && values_fit_uint(ordered_output_sizes) &&
+      values_fit_uint(ordered_input_sizes) && values_fit_uint(ordered_output_strides) &&
+      values_fit_uint(ordered_input_strides) && values_fit_uint(ordered_left_pad);
+
+  if (use_32bit_index) {
+    const auto to_uint = [](const std::vector<int64_t>& values) {
+      std::vector<uint32_t> result(values.size());
+      std::transform(
+          values.begin(), values.end(), result.begin(), [](int64_t value) { return static_cast<uint32_t>(value); });
+      return result;
+    };
+    mps::constant_pad_nd_strided_kernel_mps(cropped,
+                                            output,
+                                            kernel_value,
+                                            to_uint(ordered_output_sizes),
+                                            to_uint(ordered_input_sizes),
+                                            to_uint(ordered_input_strides),
+                                            to_uint(ordered_output_strides),
+                                            to_uint(ordered_left_pad),
+                                            grid_x,
+                                            grid_y);
+  } else {
+    const auto to_uint64 = [](const std::vector<int64_t>& values) {
+      return std::vector<uint64_t>(values.begin(), values.end());
+    };
+    mps::constant_pad_nd_strided_kernel_mps(cropped,
+                                            output,
+                                            kernel_value,
+                                            to_uint64(ordered_output_sizes),
+                                            to_uint64(ordered_input_sizes),
+                                            to_uint64(ordered_input_strides),
+                                            to_uint64(ordered_output_strides),
+                                            to_uint64(ordered_left_pad),
+                                            grid_x,
+                                            grid_y);
+  }
+  return output;
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -2,6 +2,12 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/Pad.h>
+#include <c10/metal/common.h>
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -330,10 +336,7 @@ static Tensor& pad_out_template(Tensor& output,
   return output;
 }
 
-static MTLSize replication_pad1d_threadgroup(id<MTLComputePipelineState> pso,
-                                             NSUInteger gx,
-                                             NSUInteger gy,
-                                             NSUInteger gz) {
+static MTLSize pad_threadgroup(id<MTLComputePipelineState> pso, NSUInteger gx, NSUInteger gy, NSUInteger gz) {
   const auto maxTPG = [pso maxTotalThreadsPerThreadgroup];
   const auto tg_x = std::min<NSUInteger>(maxTPG, gx);
   const auto tg_y = std::min<NSUInteger>(maxTPG / tg_x, gy);
@@ -373,7 +376,7 @@ static void replication_pad1d_kernel_mps(const Tensor& input_, IntArrayRef paddi
       [encoder setComputePipelineState:pso];
       mtl_setArgs(encoder, input, output_c, sizes_pad);
       [encoder dispatchThreads:MTLSizeMake(output_W, nplane, nbatch)
-          threadsPerThreadgroup:replication_pad1d_threadgroup(pso, output_W, nplane, nbatch)];
+          threadsPerThreadgroup:pad_threadgroup(pso, output_W, nplane, nbatch)];
       getMPSProfiler().endProfileKernel(pso, stream);
     }
   });
@@ -417,13 +420,149 @@ static void replication_pad1d_backward_kernel_mps(const Tensor& grad_output_,
       [encoder setComputePipelineState:pso];
       mtl_setArgs(encoder, grad_output, grad_input_c, sizes_pad);
       [encoder dispatchThreads:MTLSizeMake(input_W, nplane, nbatch)
-          threadsPerThreadgroup:replication_pad1d_threadgroup(pso, input_W, nplane, nbatch)];
+          threadsPerThreadgroup:pad_threadgroup(pso, input_W, nplane, nbatch)];
       getMPSProfiler().endProfileKernel(pso, stream);
     }
   });
   if (grad_input_needs_copy) {
     grad_input.copy_(grad_input_buf);
   }
+}
+
+static Tensor crop_negative_pads(const Tensor& self, IntArrayRef pad, int64_t padding_dim) {
+  const auto ndim = self.dim();
+  auto cropped = self;
+  for (const auto dim : c10::irange(ndim - padding_dim, ndim)) {
+    const auto pad_idx = 2 * (ndim - dim - 1);
+    if (pad[pad_idx] < 0) {
+      cropped = cropped.narrow(dim, -pad[pad_idx], cropped.size(dim) + pad[pad_idx]);
+    }
+    if (pad[pad_idx + 1] < 0) {
+      cropped = cropped.narrow(dim, 0, cropped.size(dim) + pad[pad_idx + 1]);
+    }
+  }
+  return cropped;
+}
+
+static Tensor allocate_pad_output(const Tensor& self,
+                                  const Tensor& cropped,
+                                  IntArrayRef pad,
+                                  int64_t padding_dim,
+                                  bool all_pads_non_positive) {
+  if (all_pads_non_positive) {
+    return at::empty_like(cropped);
+  }
+  const auto ndim = self.dim();
+  auto output_sizes = self.sizes().vec();
+  for (const auto dim : c10::irange(ndim - padding_dim, ndim)) {
+    const auto pad_idx = 2 * (ndim - dim - 1);
+    const auto output_size = self.size(dim) + pad[pad_idx] + pad[pad_idx + 1];
+    TORCH_CHECK(output_size >= 0,
+                "The input size ",
+                self.size(dim),
+                ", plus negative padding ",
+                pad[pad_idx],
+                " and ",
+                pad[pad_idx + 1],
+                " resulted in a negative output size, which is invalid. Check dimension ",
+                dim,
+                " of your input.");
+    output_sizes[dim] = output_size;
+  }
+  return at::empty(output_sizes, self.options().memory_format(self.suggest_memory_format()));
+}
+
+static bool constant_pad_dense_eligible(const Tensor& input, const Tensor& output, int64_t padding_dim) {
+  if (padding_dim > 3 || !input.is_contiguous() || !output.is_contiguous()) {
+    return false;
+  }
+  constexpr auto uint_max = std::numeric_limits<uint32_t>::max();
+  const auto out_w = output.size(-1);
+  const auto out_h = padding_dim >= 2 ? output.size(-2) : 1;
+  const auto out_d = padding_dim >= 3 ? output.size(-3) : 1;
+  const bool sizes_fit = out_w <= uint_max && out_h <= uint_max && out_d <= uint_max;
+  return sizes_fit && output.numel() / (out_w * out_h) <= uint_max;
+}
+
+static void constant_pad_dense_kernel_mps(const Tensor& input,
+                                          const Tensor& output,
+                                          IntArrayRef pad,
+                                          int64_t padding_dim,
+                                          const Scalar& fill) {
+  const auto in_w = input.size(-1);
+  const auto in_h = padding_dim >= 2 ? input.size(-2) : 1;
+  const auto in_d = padding_dim >= 3 ? input.size(-3) : 1;
+  const auto out_w = output.size(-1);
+  const auto out_h = padding_dim >= 2 ? output.size(-2) : 1;
+  const auto out_d = padding_dim >= 3 ? output.size(-3) : 1;
+  const auto left_w = padding_dim >= 1 ? std::max<int64_t>(pad[0], 0) : 0;
+  const auto left_h = padding_dim >= 2 ? std::max<int64_t>(pad[2], 0) : 0;
+  const auto left_d = padding_dim >= 3 ? std::max<int64_t>(pad[4], 0) : 0;
+  const auto grid_x = c10::metal::ceil_div(out_w, static_cast<int64_t>(c10::metal::ILP_PER_THREAD));
+  const auto grid_z = output.numel() / (out_w * out_h);
+  const ConstantPadDenseParams params = {
+      {static_cast<uint32_t>(in_w), static_cast<uint32_t>(in_h), static_cast<uint32_t>(in_d)},
+      {static_cast<uint32_t>(out_w), static_cast<uint32_t>(out_h), static_cast<uint32_t>(out_d)},
+      {static_cast<uint32_t>(left_w), static_cast<uint32_t>(left_h), static_cast<uint32_t>(left_d)}};
+  auto pso = lib.getPipelineStateForFunc("constant_pad_nd_dense_" + scalarToMetalTypeString(input));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      getMPSProfiler().beginProfileKernel(pso, "constant_pad_nd", {input, output}, stream);
+      auto encoder = stream->commandEncoder();
+      auto fill_value = getMPSScalar(fill, input.scalar_type());
+      [encoder setComputePipelineState:pso];
+      mtl_setArgs(encoder, input, output, params, fill_value);
+      [encoder dispatchThreads:MTLSizeMake(grid_x, out_h, grid_z)
+          threadsPerThreadgroup:pad_threadgroup(pso, grid_x, out_h, grid_z)];
+      getMPSProfiler().endProfileKernel(pso, stream);
+    }
+  });
+}
+
+static void constant_pad_strided_kernel_mps(const Tensor& input,
+                                            const Tensor& output,
+                                            IntArrayRef pad,
+                                            int64_t padding_dim,
+                                            const Scalar& fill) {
+  const auto ndim = output.dim();
+  DimVector dim_order(ndim);
+  std::iota(dim_order.begin(), dim_order.end(), 0);
+  std::stable_sort(dim_order.begin(), dim_order.end(), [&](int64_t lhs, int64_t rhs) {
+    return output.stride(lhs) < output.stride(rhs);
+  });
+  const auto inner = output.size(dim_order[0]);
+  const auto grid_x = c10::metal::ceil_div(inner, static_cast<int64_t>(c10::metal::ILP_PER_THREAD));
+  const auto grid_y = output.numel() / inner;
+  const bool use_u32 = offsetsFitIn<uint32_t>(input, output);
+  auto pso = lib.getPipelineStateForFunc(
+      fmt::format("constant_pad_nd_{}{}", scalarToMetalTypeString(input), mtlIdxSuffix(use_u32)));
+  auto stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      getMPSProfiler().beginProfileKernel(pso, "constant_pad_nd", {input, output}, stream);
+      auto encoder = stream->commandEncoder();
+      auto fill_value = getMPSScalar(fill, input.scalar_type());
+      [encoder setComputePipelineState:pso];
+      mtlDispatchByIndexWidth<uint32_t, uint64_t>(use_u32, [&](auto idx_tag) {
+        using idx_t = typename decltype(idx_tag)::type;
+        ConstantPadNdParams<idx_t> params{};
+        params.ndim = static_cast<uint32_t>(ndim);
+        for (const auto i : c10::irange(ndim)) {
+          const auto dim = dim_order[i];
+          const auto pad_idx = 2 * (ndim - dim - 1);
+          params.output_sizes[i] = static_cast<idx_t>(output.size(dim));
+          params.input_sizes[i] = static_cast<idx_t>(input.size(dim));
+          params.input_strides[i] = static_cast<idx_t>(input.stride(dim));
+          params.output_strides[i] = static_cast<idx_t>(output.stride(dim));
+          params.left_pad[i] = static_cast<idx_t>(dim >= ndim - padding_dim ? std::max<int64_t>(pad[pad_idx], 0) : 0);
+        }
+        mtl_setArgs(encoder, input, output, params, fill_value);
+      });
+      mtl_dispatch2DJob(encoder, pso, grid_x, grid_y);
+      getMPSProfiler().endProfileKernel(pso, stream);
+    }
+  });
 }
 
 } // namespace mps
@@ -559,17 +698,41 @@ Tensor replication_pad3d_backward_mps(const Tensor& grad_output, const Tensor& i
 
 // backward pass is explicitly handled in autograd by negating the "pad" argument
 Tensor constant_pad_nd_mps(const Tensor& self, IntArrayRef pad, const Scalar& value) {
-  if (pad.empty()) {
-    return self.clone();
+  TORCH_CHECK(pad.size() % 2 == 0, "Length of pad must be even but instead it equals ", pad.size());
+
+  const auto ndim = self.dim();
+  const auto padding_dim = static_cast<int64_t>(pad.size() / 2);
+  TORCH_CHECK(ndim >= padding_dim,
+              "Length of pad should be no more than twice the number of dimensions of the input. Pad length is ",
+              pad.size(),
+              " while the input has ",
+              ndim,
+              " dimensions.");
+
+  // Negative pads mean we crop the input
+  const bool all_pads_non_positive = std::ranges::all_of(pad, [](int64_t p) { return p <= 0; });
+  const auto cropped = mps::crop_negative_pads(self, pad, padding_dim);
+  if (all_pads_non_positive && cropped.is_contiguous()) {
+    return cropped.clone();
   }
-  if (pad.size() > 6) {
-    TORCH_WARN_ONCE("MPS: The constant padding of more than 3 dimensions is not currently supported natively. ",
-                    "It uses View Ops default implementation to run. This may have performance implications.");
+
+  auto output = mps::allocate_pad_output(self, cropped, pad, padding_dim, all_pads_non_positive);
+  if (output.numel() == 0) {
+    return output;
+  }
+  if (cropped.numel() == 0) {
+    return output.fill_(value);
+  }
+
+  const Scalar fill = all_pads_non_positive ? Scalar(0) : value;
+  if (mps::constant_pad_dense_eligible(cropped, output, padding_dim)) {
+    mps::constant_pad_dense_kernel_mps(cropped, output, pad, padding_dim, fill);
+  } else if (output.numel() > std::numeric_limits<uint32_t>::max()) {
     return at::native::constant_pad_nd(self, pad, value);
+  } else {
+    mps::constant_pad_strided_kernel_mps(cropped, output, pad, padding_dim, fill);
   }
-  Tensor output = at::empty({0}, self.options());
-  return mps::pad_out_template(
-      output, self, pad, std::nullopt, MPSGraphPaddingModeConstant, value.toDouble(), __func__);
+  return output;
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/Pad.mm
+++ b/aten/src/ATen/native/mps/operations/Pad.mm
@@ -43,7 +43,6 @@ static Tensor& pad_out_template(Tensor& output,
                                 IntArrayRef padding,
                                 const std::optional<Tensor>& grad_output_opt,
                                 MPSGraphPaddingMode mode,
-                                double constantValue,
                                 const std::string& op_name) {
   using CachedGraph = MPSUnaryGradCachedGraph;
   const int padding_size = (int)padding.size();
@@ -72,7 +71,7 @@ static Tensor& pad_out_template(Tensor& output,
   int dim_d = padding_dim - 2;
   int dim_slices = 0;
 
-  if (!is_backward_pass && mode != MPSGraphPaddingModeConstant && ndims > padding_dim) {
+  if (!is_backward_pass && ndims > padding_dim) {
     bool valid_dims = input_.size(1) != 0 && input_.size(padding_dim) != 0;
     TORCH_CHECK((ndims == 1 + padding_dim && valid_dims) ||
                     (ndims == 2 + padding_dim && valid_dims && input_.size(1 + padding_dim) != 0),
@@ -125,77 +124,57 @@ static Tensor& pad_out_template(Tensor& output,
                 output_w);
 
     std::vector<int64_t> outputSizes;
-    if (mode == MPSGraphPaddingModeConstant) {
-      // support arbitrary input dimensions for constant pad.
-      auto input_sizes = input_.sizes();
-      auto ori_padding_dim = padding_size / 2;
-      auto l_diff = ndims - ori_padding_dim;
+    // these checks are only relevant for reflection padding (code taken from ReflectionPad.cpp)
+    if (mode == MPSGraphPaddingModeReflect) {
+      TORCH_CHECK(pad_l < input_w && pad_r < input_w,
+                  "Argument #4: Padding size should be less than the corresponding "
+                  "input dimension, but got: padding (",
+                  pad_l,
+                  ", ",
+                  pad_r,
+                  ") at dimension ",
+                  dim_w,
+                  " of input ",
+                  input_.sizes());
 
-      for (size_t i = 0; i < (size_t)l_diff; i++) {
-        outputSizes.emplace_back(input_sizes[i]);
-      }
-      for (const auto i : c10::irange((size_t)ori_padding_dim)) {
-        auto pad_idx = padding.size() - ((i + 1) * 2);
-        auto new_dim = input_sizes[l_diff + i] + padding[pad_idx] + padding[pad_idx + 1];
-        outputSizes.emplace_back(new_dim);
-      }
-    } else {
-      // these checks are only relevant for reflection padding (code taken from ReflectionPad.cpp)
-      if (mode == MPSGraphPaddingModeReflect) {
-        TORCH_CHECK(pad_l < input_w && pad_r < input_w,
-                    "Argument #4: Padding size should be less than the corresponding "
+      if (padding_dim > 1) {
+        TORCH_CHECK(pad_t < input_h && pad_b < input_h,
+                    "Argument #6: Padding size should be less than the corresponding "
                     "input dimension, but got: padding (",
-                    pad_l,
+                    pad_t,
                     ", ",
-                    pad_r,
+                    pad_b,
                     ") at dimension ",
-                    dim_w,
+                    dim_h,
                     " of input ",
                     input_.sizes());
-
-        if (padding_dim > 1) {
-          TORCH_CHECK(pad_t < input_h && pad_b < input_h,
-                      "Argument #6: Padding size should be less than the corresponding "
-                      "input dimension, but got: padding (",
-                      pad_t,
-                      ", ",
-                      pad_b,
-                      ") at dimension ",
-                      dim_h,
-                      " of input ",
-                      input_.sizes());
-        }
-        if (padding_dim > 2) {
-          TORCH_CHECK(pad_front < input_d && pad_back < input_d,
-                      "Argument #8: Padding size should be less than the corresponding "
-                      "input dimension, but got: padding (",
-                      pad_front,
-                      ", ",
-                      pad_back,
-                      ") at dimension ",
-                      dim_d,
-                      " of input ",
-                      input_.sizes());
-        }
       }
-      outputSizes.insert(outputSizes.begin(), output_w);
-      if (padding_dim >= 2)
-        outputSizes.insert(outputSizes.begin(), output_h);
-      if (padding_dim >= 3)
-        outputSizes.insert(outputSizes.begin(), output_d);
-      if (ndims >= 1 + padding_dim)
-        outputSizes.insert(outputSizes.begin(), nplane);
-      if (ndims >= 2 + padding_dim)
-        outputSizes.insert(outputSizes.begin(), nbatch);
+      if (padding_dim > 2) {
+        TORCH_CHECK(pad_front < input_d && pad_back < input_d,
+                    "Argument #8: Padding size should be less than the corresponding "
+                    "input dimension, but got: padding (",
+                    pad_front,
+                    ", ",
+                    pad_back,
+                    ") at dimension ",
+                    dim_d,
+                    " of input ",
+                    input_.sizes());
+      }
     }
+    outputSizes.insert(outputSizes.begin(), output_w);
+    if (padding_dim >= 2)
+      outputSizes.insert(outputSizes.begin(), output_h);
+    if (padding_dim >= 3)
+      outputSizes.insert(outputSizes.begin(), output_d);
+    if (ndims >= 1 + padding_dim)
+      outputSizes.insert(outputSizes.begin(), nplane);
+    if (ndims >= 2 + padding_dim)
+      outputSizes.insert(outputSizes.begin(), nbatch);
 
     output.resize_(outputSizes);
 
     if (output.numel() == 0) {
-      return output;
-    }
-    if (input_.numel() == 0) {
-      output.fill_(constantValue);
       return output;
     }
     input = input_.contiguous();
@@ -257,8 +236,8 @@ static Tensor& pad_out_template(Tensor& output,
   }
 
   @autoreleasepool {
-    std::string key = op_name + getTensorsStringKey({input, grad_output, output}) + ":[" + getArrayRefString(padding) +
-        "]:" + std::to_string(constantValue);
+    std::string key =
+        op_name + getTensorsStringKey({input, grad_output, output}) + ":[" + getArrayRefString(padding) + "]";
 
     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
       newCachedGraph->inputTensor_ = mpsGraphRankedPlaceHolder(mpsGraph, dataType, getMPSShape(input));
@@ -269,7 +248,7 @@ static Tensor& pad_out_template(Tensor& output,
                                         withPaddingMode:mode
                                             leftPadding:leftPadding
                                            rightPadding:rightPadding
-                                          constantValue:constantValue
+                                          constantValue:0.0
                                                    name:nil];
         // workaround for the right padding bug in Monterey
         if (needsSlice) {
@@ -575,7 +554,6 @@ TORCH_IMPL_FUNC(reflection_pad1d_out_mps)
                         padding,
                         std::nullopt,
                         MPSGraphPaddingModeReflect,
-                        0.0,
                         "reflection_pad1d_out_mps");
 }
 
@@ -587,7 +565,6 @@ TORCH_IMPL_FUNC(reflection_pad1d_backward_out_mps)
                         padding,
                         grad_output,
                         MPSGraphPaddingModeReflect,
-                        0.0,
                         "reflection_pad1d_backward_out_mps");
 }
 
@@ -603,12 +580,12 @@ TORCH_IMPL_FUNC(replication_pad1d_backward_out_mps)
 
 // 2D Reflection and Replication Padding
 Tensor& reflection_pad2d_out_mps(const Tensor& input, IntArrayRef padding, Tensor& output) {
-  return mps::pad_out_template(output, input, padding, std::nullopt, MPSGraphPaddingModeReflect, 0.0, __func__);
+  return mps::pad_out_template(output, input, padding, std::nullopt, MPSGraphPaddingModeReflect, __func__);
 }
 
 Tensor reflection_pad2d_mps(const Tensor& input, IntArrayRef padding) {
   Tensor output = at::empty({0}, input.options());
-  return mps::pad_out_template(output, input, padding, std::nullopt, MPSGraphPaddingModeReflect, 0.0, __func__);
+  return mps::pad_out_template(output, input, padding, std::nullopt, MPSGraphPaddingModeReflect, __func__);
 }
 
 Tensor& reflection_pad2d_backward_out_mps(const Tensor& grad_output,
@@ -616,12 +593,12 @@ Tensor& reflection_pad2d_backward_out_mps(const Tensor& grad_output,
                                           IntArrayRef padding,
                                           Tensor& grad_input) {
   grad_input.resize_as_(input).zero_();
-  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeReflect, 0.0, __func__);
+  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeReflect, __func__);
 }
 
 Tensor reflection_pad2d_backward_mps(const Tensor& grad_output, const Tensor& input, IntArrayRef padding) {
   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeReflect, 0.0, __func__);
+  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeReflect, __func__);
 }
 
 TORCH_IMPL_FUNC(replication_pad2d_out_mps)
@@ -631,7 +608,6 @@ TORCH_IMPL_FUNC(replication_pad2d_out_mps)
                         padding,
                         std::nullopt,
                         MPSGraphPaddingModeClampToEdge,
-                        0.0,
                         "replication_pad2d_out_mps");
 }
 
@@ -640,12 +616,12 @@ Tensor& replication_pad2d_backward_out_mps(const Tensor& grad_output,
                                            IntArrayRef padding,
                                            Tensor& grad_input) {
   grad_input.resize_as_(input).zero_();
-  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, 0.0, __func__);
+  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, __func__);
 }
 
 Tensor replication_pad2d_backward_mps(const Tensor& grad_output, const Tensor& input, IntArrayRef padding) {
   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, 0.0, __func__);
+  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, __func__);
 }
 
 // 3D Reflection and Replication Padding
@@ -656,7 +632,6 @@ TORCH_IMPL_FUNC(reflection_pad3d_out_mps)
                         padding,
                         std::nullopt,
                         MPSGraphPaddingModeReflect,
-                        0.0,
                         "reflection_pad3d_out_mps");
 }
 
@@ -668,7 +643,6 @@ TORCH_IMPL_FUNC(reflection_pad3d_backward_out_mps)
                         padding,
                         grad_output,
                         MPSGraphPaddingModeReflect,
-                        0.0,
                         "reflection_pad3d_backward_out_mps");
 }
 
@@ -679,7 +653,6 @@ TORCH_IMPL_FUNC(replication_pad3d_out_mps)
                         padding,
                         std::nullopt,
                         MPSGraphPaddingModeClampToEdge,
-                        0.0,
                         "replication_pad3d_out_mps");
 }
 
@@ -688,12 +661,12 @@ Tensor& replication_pad3d_backward_out_mps(const Tensor& grad_output,
                                            IntArrayRef padding,
                                            Tensor& grad_input) {
   grad_input.resize_as_(input).zero_();
-  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, 0.0, __func__);
+  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, __func__);
 }
 
 Tensor replication_pad3d_backward_mps(const Tensor& grad_output, const Tensor& input, IntArrayRef padding) {
   auto grad_input = at::zeros_like(input, LEGACY_CONTIGUOUS_MEMORY_FORMAT);
-  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, 0.0, __func__);
+  return mps::pad_out_template(grad_input, input, padding, grad_output, MPSGraphPaddingModeClampToEdge, __func__);
 }
 
 // backward pass is explicitly handled in autograd by negating the "pad" argument
@@ -727,7 +700,7 @@ Tensor constant_pad_nd_mps(const Tensor& self, IntArrayRef pad, const Scalar& va
   const Scalar fill = all_pads_non_positive ? Scalar(0) : value;
   if (mps::constant_pad_dense_eligible(cropped, output, padding_dim)) {
     mps::constant_pad_dense_kernel_mps(cropped, output, pad, padding_dim, fill);
-  } else if (output.numel() > std::numeric_limits<uint32_t>::max()) {
+  } else if (output.numel() > std::numeric_limits<uint32_t>::max() || ndim > c10::metal::max_ndim) {
     return at::native::constant_pad_nd(self, pad, value);
   } else {
     mps::constant_pad_strided_kernel_mps(cropped, output, pad, padding_dim, fill);

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -11854,6 +11854,41 @@ class TestNNMPS(NNTestCase):
 
 
 class TestPad(TestCaseMPS):
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16, torch.int32, torch.bool])
+    def test_constant_pad_nd_5d(self, dtype):
+        pad = (1, 1, 1, 1, 2, 0)
+        value = True if dtype == torch.bool else 1.25
+        input_cpu = make_tensor((1, 3, 1, 4, 4), device="cpu", dtype=dtype, low=-2, high=2)
+        expected = F.pad(input_cpu, pad, value=value)
+        actual = F.pad(input_cpu.to("mps"), pad, value=value)
+        self.assertEqual(actual.cpu(), expected)
+
+    @parametrize("layout", ["contiguous", "transposed", "sliced", "channels_last_3d"])
+    @parametrize("pad", [
+        (1, 2, -1, 2, 1, -1),
+        (1, 0, 0, 1, -1, 1, 1, 0),
+        (0, 0, 0, 0, 0, 0),
+        (-1, 0, 0, -1),
+    ])
+    def test_constant_pad_nd_layouts(self, layout, pad):
+        input_cpu = torch.randn((2, 3, 4, 5, 6))
+        input_mps = input_cpu.to("mps")
+        if layout == "transposed":
+            input_cpu = input_cpu.transpose(-1, -2)
+            input_mps = input_mps.transpose(-1, -2)
+        elif layout == "sliced":
+            input_cpu = input_cpu[..., ::2]
+            input_mps = input_mps[..., ::2]
+        elif layout == "channels_last_3d":
+            input_cpu = input_cpu.contiguous(memory_format=torch.channels_last_3d)
+            input_mps = input_mps.contiguous(memory_format=torch.channels_last_3d)
+
+        expected = F.pad(input_cpu, pad, value=2.25)
+        actual = F.pad(input_mps, pad, value=2.25)
+        self.assertEqual(actual.cpu(), expected)
+        if all(value <= 0 for value in pad):
+            self.assertEqual(actual.stride(), expected.stride())
+
     def test_constant_pad(self):
         m = torch.nn.ConstantPad2d((-2, -2, -2, -2), 3.5)
         input_cpu = torch.randn(1, 16, 16, 16)
@@ -11887,7 +11922,7 @@ class TestPad(TestCaseMPS):
 
         self.assertEqual(y_cpu, y_mps.cpu())
 
-    def test_constant_pad_4d_warning(self):
+    def test_constant_pad_4d(self):
         inputCPU = torch.rand((1, 2, 2, 2, 1, 1))
         inputMPS = inputCPU.detach().clone().to('mps')
         outputCPU = F.pad(inputCPU, [0, 0, 0, 0, 0, 0, 1, 0])
@@ -11959,7 +11994,7 @@ class TestPad(TestCaseMPS):
         helper((1, 2, 2, 2, 2), (0, 1), nn.ConstantPad3d)
 
     def test_constant_pad_nd_preserves_memory_format(self):
-        nchw_tensor = torch.rand((1, 2, 5, 3))
+        nchw_tensor = torch.rand((1, 2, 5, 3), device="mps")
         nchw_padded = torch.constant_pad_nd(nchw_tensor, [1, 2], 0.5)
         self.assertTrue(nchw_padded.is_contiguous(memory_format=torch.contiguous_format))
 
@@ -11973,6 +12008,7 @@ class TestPad(TestCaseMPS):
         input_mps = torch.randn((2, 3, 4), device="mps")
         output_mps = torch.constant_pad_nd(input_mps, [])
         self.assertEqual(output_mps, input_mps)
+        self.assertNotEqual(output_mps.data_ptr(), input_mps.data_ptr())
 
     def test_replication_pad1d_non_contig_out(self):
         x = torch.randn(2, 3, 5, device="mps")
@@ -17462,6 +17498,7 @@ instantiate_parametrized_tests(TestAutocastMPS)
 instantiate_parametrized_tests(MatmulTest)
 instantiate_parametrized_tests(TestBinaryIteratorConformance)
 instantiate_parametrized_tests(TestLogical)
+instantiate_parametrized_tests(TestPad)
 instantiate_parametrized_tests(TestMPS)
 instantiate_parametrized_tests(TestSDPA)
 instantiate_parametrized_tests(TestSmoothL1Loss)

--- a/torch/testing/_internal/common_modules.py
+++ b/torch/testing/_internal/common_modules.py
@@ -5154,15 +5154,9 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.ZeroPad2d,
                module_inputs_func=module_inputs_torch_nn_ZeroPad2d,
-               skips=(
-                   # Fails with channels last test on MPS backend
-                   DecorateInfo(unittest.expectedFailure, "TestModule", "test_memory_format", device_type='mps'),)
                ),
     ModuleInfo(torch.nn.ZeroPad3d,
                module_inputs_func=module_inputs_torch_nn_ZeroPad3d,
-               skips=(
-                   # Fails with channels last test on MPS backend
-                   DecorateInfo(unittest.expectedFailure, "TestModule", "test_memory_format", device_type='mps'),)
                ),
     ModuleInfo(torch.nn.CircularPad1d,
                module_inputs_func=module_inputs_torch_nn_CircularPad1d,
@@ -5184,14 +5178,8 @@ module_db: list[ModuleInfo] = [
                ),
     ModuleInfo(torch.nn.ConstantPad2d,
                module_inputs_func=module_inputs_torch_nn_ConstantPad2d,
-               skips=(
-                   # Fails with channels last test on MPS backend
-                   DecorateInfo(unittest.expectedFailure, "TestModule", "test_memory_format", device_type='mps'),)
                ),
     ModuleInfo(torch.nn.ConstantPad3d,
                module_inputs_func=module_inputs_torch_nn_ConstantPad3d,
-               skips=(
-                   # Fails with channels last test on MPS backend
-                   DecorateInfo(unittest.expectedFailure, "TestModule", "test_memory_format", device_type='mps'),)
                )
 ]


### PR DESCRIPTION
Following this PR https://github.com/pytorch/pytorch/pull/195153 I tried to pin down other ops which might make memory usage high as the nll_loss backward did.
To make findings meaningful, I tried doing inference of various LLM/image/video generation models and found that for `Wan-AI/Wan2.2-TI2V-5B-Diffusers` memory usage explodes because of the pad function that is used during VAE decode phase of the model. 

PR migrates MPS Graph constant pad to metal kernels. Perf:

| Metric | MPSGraph | Fused Metal | Change |
|---|---:|---:|---:|
| MPS current-memory peak | 4.422 GiB | 4.095 GiB | -0.327 GiB |
| MPS allocator-reserved peak | 8.070 GiB | 8.070 GiB | unchanged |
| Driver memory outside allocator | 262.065 GiB | 0.038 GiB | -262.027 GiB (-99.986%) |
| Total driver-memory peak | 270.135 GiB | 8.108 GiB | -262.027 GiB (-97.0%) |

The reason for such huge memory is because of Wan model calling `F.pad` before every 3D convolution where one spatial tile makes 300+ calls to this function, the complete 28-tile decode makes 8,764 calls.

The way kernels work is simple, there are dense and strided kernels:

- **Dense** (`constant_pad_nd_dense`): input and output contiguous, at most 3 padded dims. The output is treated as `[outer, D, H, W]` (`outer` = all leading dims flattened) and dispatched as the matching 3D grid `(W / ILP_PER_THREAD, H, outer * D)`, each thread writing 4 elements along `W`. One of the reason of this is kernel speed, with this, we avoid the stride calculations which makes the kernel faster.
- **Strided** (`constant_pad_nd`): everything else. Dims are sorted by output stride, `tid.x` walks the innermost dim, `tid.y` is decomposed over the remaining dims and per-dim input/output strides are applied directly. Offsets use uint32 when every element offset of both tensors fits or uint64 otherwise.

<details> 
<summary> Latency changes </summary>

| Case | Input shape | Padding | Dtype | Layout | Before | After | Speedup |
|---|---|---|---|---|---:|---:|---:|
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `float32` | `contiguous` | 0.0178 ms | 0.0118 ms | 1.52x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `float32` | `transposed` | 0.0192 ms | 0.0121 ms | 1.58x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `float32` | `sliced` | 0.0189 ms | 0.0090 ms | 2.10x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `float16` | `contiguous` | 0.0159 ms | 0.0077 ms | 2.07x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `float16` | `transposed` | 0.0187 ms | 0.0116 ms | 1.61x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `float16` | `sliced` | 0.0186 ms | 0.0080 ms | 2.33x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `bfloat16` | `contiguous` | 0.0152 ms | 0.0081 ms | 1.88x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `bfloat16` | `transposed` | 0.0187 ms | 0.0120 ms | 1.56x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `bfloat16` | `sliced` | 0.0185 ms | 0.0084 ms | 2.20x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `int32` | `contiguous` | 0.0152 ms | 0.0079 ms | 1.94x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `int32` | `transposed` | 0.0189 ms | 0.0120 ms | 1.58x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `int32` | `sliced` | 0.0187 ms | 0.0088 ms | 2.12x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `bool` | `contiguous` | 0.0164 ms | 0.0072 ms | 2.29x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `bool` | `transposed` | 0.0188 ms | 0.0098 ms | 1.92x |
| `vector_2d` | `(32, 4096)` | `(8, 8)` | `bool` | `sliced` | 0.0189 ms | 0.0083 ms | 2.27x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `float32` | `contiguous` | 0.0190 ms | 0.0143 ms | 1.33x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `float32` | `transposed` | 0.0531 ms | 0.0190 ms | 2.80x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `float32` | `sliced` | 0.0317 ms | 0.0176 ms | 1.80x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `float16` | `contiguous` | 0.0176 ms | 0.0123 ms | 1.42x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `float16` | `transposed` | 0.0369 ms | 0.0167 ms | 2.22x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `float16` | `sliced` | 0.0256 ms | 0.0159 ms | 1.61x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `bfloat16` | `contiguous` | 0.0166 ms | 0.0124 ms | 1.33x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `bfloat16` | `transposed` | 0.0369 ms | 0.0168 ms | 2.20x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `bfloat16` | `sliced` | 0.0256 ms | 0.0159 ms | 1.61x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `int32` | `contiguous` | 0.0168 ms | 0.0143 ms | 1.17x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `int32` | `transposed` | 0.0411 ms | 0.0191 ms | 2.16x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `int32` | `sliced` | 0.0302 ms | 0.0177 ms | 1.71x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `bool` | `contiguous` | 0.0185 ms | 0.0108 ms | 1.72x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `bool` | `transposed` | 0.0350 ms | 0.0150 ms | 2.33x |
| `image_4d` | `(1, 64, 128, 128)` | `(1, 1, 1, 1)` | `bool` | `sliced` | 0.0234 ms | 0.0145 ms | 1.61x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `float32` | `contiguous` | 0.0186 ms | 0.0127 ms | 1.46x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `float32` | `transposed` | 0.0217 ms | 0.0130 ms | 1.67x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `float32` | `sliced` | 0.0213 ms | 0.0129 ms | 1.66x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `float16` | `contiguous` | 0.0191 ms | 0.0115 ms | 1.66x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `float16` | `transposed` | 0.0215 ms | 0.0120 ms | 1.79x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `float16` | `sliced` | 0.0212 ms | 0.0120 ms | 1.77x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `bfloat16` | `contiguous` | 0.0183 ms | 0.0116 ms | 1.57x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `bfloat16` | `transposed` | 0.0214 ms | 0.0119 ms | 1.80x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `bfloat16` | `sliced` | 0.0213 ms | 0.0118 ms | 1.80x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `int32` | `contiguous` | 0.0182 ms | 0.0130 ms | 1.40x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `int32` | `transposed` | 0.0217 ms | 0.0132 ms | 1.65x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `int32` | `sliced` | 0.0212 ms | 0.0128 ms | 1.66x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `bool` | `contiguous` | 0.0187 ms | 0.0109 ms | 1.71x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `bool` | `transposed` | 0.0214 ms | 0.0115 ms | 1.86x |
| `mixed_crop_4d` | `(2, 32, 64, 96)` | `(-2, 3, 1, -1)` | `bool` | `sliced` | 0.0209 ms | 0.0115 ms | 1.81x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `float32` | `contiguous` | 0.0286 ms | 0.0074 ms | 3.86x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `float32` | `transposed` | 0.0310 ms | 0.0107 ms | 2.90x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `float32` | `sliced` | 0.0311 ms | 0.0101 ms | 3.09x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `float16` | `contiguous` | 0.0284 ms | 0.0074 ms | 3.82x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `float16` | `transposed` | 0.0313 ms | 0.0104 ms | 3.00x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `float16` | `sliced` | 0.0310 ms | 0.0099 ms | 3.14x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `bfloat16` | `contiguous` | 0.0287 ms | 0.0075 ms | 3.85x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `bfloat16` | `transposed` | 0.0312 ms | 0.0105 ms | 2.98x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `bfloat16` | `sliced` | 0.0308 ms | 0.0095 ms | 3.26x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `int32` | `contiguous` | 0.0288 ms | 0.0073 ms | 3.95x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `int32` | `transposed` | 0.0309 ms | 0.0103 ms | 3.01x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `int32` | `sliced` | 0.0312 ms | 0.0099 ms | 3.15x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `bool` | `contiguous` | 0.0285 ms | 0.0073 ms | 3.92x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `bool` | `transposed` | 0.0307 ms | 0.0101 ms | 3.04x |
| `wan_small_5d` | `(1, 48, 1, 16, 16)` | `(1, 1, 1, 1, 2, 0)` | `bool` | `sliced` | 0.0309 ms | 0.0096 ms | 3.21x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `float32` | `contiguous` | 0.1519 ms | 0.0430 ms | 3.54x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `float32` | `transposed` | 0.2057 ms | 0.0644 ms | 3.20x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `float32` | `sliced` | 0.1902 ms | 0.0693 ms | 2.74x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `float16` | `contiguous` | 0.1059 ms | 0.0396 ms | 2.68x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `float16` | `transposed` | 0.1534 ms | 0.0607 ms | 2.53x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `float16` | `sliced` | 0.1308 ms | 0.0609 ms | 2.15x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `bfloat16` | `contiguous` | 0.1057 ms | 0.0393 ms | 2.69x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `bfloat16` | `transposed` | 0.1533 ms | 0.0607 ms | 2.52x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `bfloat16` | `sliced` | 0.1303 ms | 0.0609 ms | 2.14x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `int32` | `contiguous` | 0.1522 ms | 0.0430 ms | 3.54x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `int32` | `transposed` | 0.2045 ms | 0.0670 ms | 3.05x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `int32` | `sliced` | 0.1906 ms | 0.0684 ms | 2.79x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `bool` | `contiguous` | 0.0973 ms | 0.0303 ms | 3.21x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `bool` | `transposed` | 0.1432 ms | 0.0541 ms | 2.64x |
| `wan_mid_5d` | `(1, 512, 1, 64, 64)` | `(1, 1, 1, 1, 2, 0)` | `bool` | `sliced` | 0.1194 ms | 0.0545 ms | 2.19x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `float32` | `contiguous` | 0.0461 ms | 0.0526 ms | 0.88x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `float32` | `transposed` | 0.2299 ms | 0.0767 ms | 3.00x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `float32` | `sliced` | 0.1857 ms | 0.0960 ms | 1.94x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `float16` | `contiguous` | 0.0386 ms | 0.0279 ms | 1.38x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `float16` | `transposed` | 0.2154 ms | 0.0699 ms | 3.08x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `float16` | `sliced` | 0.1240 ms | 0.0721 ms | 1.72x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `bfloat16` | `contiguous` | 0.0384 ms | 0.0285 ms | 1.35x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `bfloat16` | `transposed` | 0.2150 ms | 0.0710 ms | 3.03x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `bfloat16` | `sliced` | 0.1256 ms | 0.0733 ms | 1.71x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `int32` | `contiguous` | 0.0514 ms | 0.0520 ms | 0.99x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `int32` | `transposed` | 0.2317 ms | 0.0753 ms | 3.08x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `int32` | `sliced` | 0.1884 ms | 0.1065 ms | 1.77x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `bool` | `contiguous` | 0.0359 ms | 0.0174 ms | 2.07x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `bool` | `transposed` | 0.2035 ms | 0.0635 ms | 3.21x |
| `zero_pad_5d` | `(1, 512, 4, 64, 64)` | `(0, 0, 0, 0, 0, 0)` | `bool` | `sliced` | 0.1162 ms | 0.0637 ms | 1.82x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `float32` | `contiguous` | 0.6938 ms | 0.2953 ms | 2.35x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `float32` | `transposed` | 1.2018 ms | 0.3505 ms | 3.43x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `float32` | `sliced` | 1.1201 ms | 0.4372 ms | 2.56x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `float16` | `contiguous` | 0.4209 ms | 0.1144 ms | 3.68x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `float16` | `transposed` | 0.9549 ms | 0.1926 ms | 4.96x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `float16` | `sliced` | 0.7193 ms | 0.2155 ms | 3.34x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `bfloat16` | `contiguous` | 0.4179 ms | 0.1097 ms | 3.81x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `bfloat16` | `transposed` | 0.9514 ms | 0.1937 ms | 4.91x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `bfloat16` | `sliced` | 0.7133 ms | 0.2131 ms | 3.35x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `int32` | `contiguous` | 0.6962 ms | 0.2960 ms | 2.35x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `int32` | `transposed` | 1.2045 ms | 0.3451 ms | 3.49x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `int32` | `sliced` | 1.1212 ms | 0.4381 ms | 2.56x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `bool` | `contiguous` | 0.3444 ms | 0.0948 ms | 3.63x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `bool` | `transposed` | 0.8468 ms | 0.1806 ms | 4.69x |
| `wan_large_5d` | `(1, 256, 6, 128, 128)` | `(1, 1, 1, 1, 0, 0)` | `bool` | `sliced` | 0.5935 ms | 0.1726 ms | 3.44x |

</details>