### PR TITLE
[BE][Ez]: Enable CPP20 heterogenous lookups in STL collections

### DIFF
--- a/c10/test/util/string_view_test.cpp
+++ b/c10/test/util/string_view_test.cpp
@@ -2,6 +2,22 @@
 
 #include <gmock/gmock.h>
 
+#include <string>
+#include <unordered_map>
+
+TEST(StringViewTest, TransparentStringHash) {
+  std::unordered_map<
+      std::string,
+      int,
+      c10::TransparentStringHash,
+      std::equal_to<>>
+      values{{"value", 1}};
+
+  const std::string_view key = "value";
+  EXPECT_EQ(values.find(key)->second, 1);
+  EXPECT_TRUE(values.contains(key));
+}
+
 // NOLINTBEGIN(modernize*, readability*, bugprone-string-constructor)
 using string_view = c10::c10_string_view;
 

--- a/c10/util/Gauge.cpp
+++ b/c10/util/Gauge.cpp
@@ -1,6 +1,7 @@
 #include <c10/util/Gauge.h>
 
 #include <c10/util/Synchronized.h>
+#include <c10/util/string_view.h>
 
 #include <memory>
 #include <string>
@@ -24,12 +25,14 @@ Synchronized<GaugeBackendFactories>& gaugeBackendFactories() {
 class GaugeImpl {
  public:
   static GaugeImpl& getInstance(std::string_view key) {
-    static auto& implMapSynchronized = *new Synchronized<
-        std::unordered_map<std::string, std::unique_ptr<GaugeImpl>>>();
+    static auto& implMapSynchronized = *new Synchronized<std::unordered_map<
+        std::string,
+        std::unique_ptr<GaugeImpl>,
+        TransparentStringHash,
+        std::equal_to<>>>();
 
     return *implMapSynchronized.withLock([&](auto& implMap) {
-      if (auto implIt = implMap.find(std::string(key));
-          implIt != implMap.end()) {
+      if (auto implIt = implMap.find(key); implIt != implMap.end()) {
         return implIt->second.get();
       }
 

--- a/c10/util/Logging.cpp
+++ b/c10/util/Logging.cpp
@@ -209,7 +209,8 @@ DDPUsageLoggerType* GetDDPUsageLogger() {
 
 auto& EventSampledHandlerRegistry() {
   static auto& registry =
-      *new std::map<std::string, std::unique_ptr<EventSampledHandler>>();
+      *new std::
+          map<std::string, std::unique_ptr<EventSampledHandler>, std::less<>>();
   return registry;
 }
 
@@ -222,7 +223,7 @@ void InitEventSampledHandlers(
   static bool flag [[maybe_unused]] = [&]() {
     auto& registry = EventSampledHandlerRegistry();
     for (auto& [event, handler] : handlers) {
-      auto entry = registry.find(std::string{event});
+      auto entry = registry.find(event);
       if (entry == registry.end()) {
         entry = registry.emplace(event, nullptr).first;
       }
@@ -239,7 +240,7 @@ const std::unique_ptr<EventSampledHandler>& GetEventSampledHandler(
 
   // The getter can be executed from different threads.
   std::lock_guard<std::mutex> lock(guard);
-  auto entry = registry.find(std::string{event});
+  auto entry = registry.find(event);
   if (entry == registry.end()) {
     entry = registry.emplace(event, nullptr).first;
   }

--- a/c10/util/WaitCounter.cpp
+++ b/c10/util/WaitCounter.cpp
@@ -2,6 +2,7 @@
 
 #include <c10/util/Synchronized.h>
 #include <c10/util/WaitCounterDynamicBackend.h>
+#include <c10/util/string_view.h>
 
 #include <chrono>
 #include <memory>
@@ -87,12 +88,14 @@ std::unique_ptr<WaitCounterBackendIf> getDynamicBackend(std::string_view key) {
 class WaitCounterImpl {
  public:
   static WaitCounterImpl& getInstance(std::string_view key) {
-    static auto& implMapSynchronized = *new Synchronized<
-        std::unordered_map<std::string, std::unique_ptr<WaitCounterImpl>>>();
+    static auto& implMapSynchronized = *new Synchronized<std::unordered_map<
+        std::string,
+        std::unique_ptr<WaitCounterImpl>,
+        TransparentStringHash,
+        std::equal_to<>>>();
 
     return *implMapSynchronized.withLock([&](auto& implMap) {
-      if (auto implIt = implMap.find(std::string(key));
-          implIt != implMap.end()) {
+      if (auto implIt = implMap.find(key); implIt != implMap.end()) {
         return implIt->second.get();
       }
 

--- a/c10/util/string_view.h
+++ b/c10/util/string_view.h
@@ -57,6 +57,14 @@ inline std::basic_ostream<CharT>& operator<<(
 using string_view = std::string_view;
 using c10_string_view = basic_string_view<char>;
 
+struct TransparentStringHash {
+  using is_transparent = void;
+
+  size_t operator()(std::string_view value) const noexcept {
+    return std::hash<std::string_view>{}(value);
+  }
+};
+
 // NOTE: In C++20, this function should be replaced by string_view.starts_with
 [[nodiscard]] constexpr bool starts_with(
     const std::string_view s,

--- a/torch/nativert/detail/ITree.cpp
+++ b/torch/nativert/detail/ITree.cpp
@@ -326,8 +326,9 @@ class PytreeNodeRegistry {
     return it->second;
   }
   void registerNode(std::string_view typeName, NodeDef nodeDef) {
-    TORCH_CHECK(!hasNodeDef(typeName));
-    registry_.emplace(typeName, nodeDef);
+    auto [_, inserted] =
+        registry_.try_emplace(std::string(typeName), std::move(nodeDef));
+    TORCH_CHECK(inserted);
   }
 
   void registerOrReplaceNode(std::string_view typeName, NodeDef nodeDef) {

--- a/torch/nativert/detail/ITree.cpp
+++ b/torch/nativert/detail/ITree.cpp
@@ -6,6 +6,7 @@
 
 #include <ATen/core/ivalue.h>
 #include <c10/util/Synchronized.h>
+#include <c10/util/string_view.h>
 #include <nlohmann/json.hpp>
 
 namespace torch::nativert::detail {
@@ -316,10 +317,13 @@ class PytreeNodeRegistry {
             }});
   }
   bool hasNodeDef(std::string_view typeName) const {
-    return registry_.contains(std::string{typeName});
+    return registry_.contains(typeName);
   }
   const NodeDef& getNodeDef(std::string_view typeName) const {
-    return registry_.at(std::string{typeName});
+    auto it = registry_.find(typeName);
+    TORCH_CHECK_INDEX(
+        it != registry_.end(), "Unknown pytree node type: ", typeName);
+    return it->second;
   }
   void registerNode(std::string_view typeName, NodeDef nodeDef) {
     TORCH_CHECK(!hasNodeDef(typeName));
@@ -327,7 +331,7 @@ class PytreeNodeRegistry {
   }
 
   void registerOrReplaceNode(std::string_view typeName, NodeDef nodeDef) {
-    auto it = registry_.find(std::string{typeName});
+    auto it = registry_.find(typeName);
     if (it != registry_.end()) {
       it->second = nodeDef;
     } else {
@@ -336,7 +340,12 @@ class PytreeNodeRegistry {
   }
 
  private:
-  std::unordered_map<std::string, NodeDef> registry_;
+  std::unordered_map<
+      std::string,
+      NodeDef,
+      c10::TransparentStringHash,
+      std::equal_to<>>
+      registry_;
 };
 
 c10::Synchronized<PytreeNodeRegistry>& getPytreeNodeRegistry() {

--- a/torch/nativert/detail/ITree.cpp
+++ b/torch/nativert/detail/ITree.cpp
@@ -334,9 +334,9 @@ class PytreeNodeRegistry {
   void registerOrReplaceNode(std::string_view typeName, NodeDef nodeDef) {
     auto it = registry_.find(typeName);
     if (it != registry_.end()) {
-      it->second = nodeDef;
+      it->second = std::move(nodeDef);
     } else {
-      registry_.emplace(typeName, nodeDef);
+      registry_.emplace(typeName, std::move(nodeDef));
     }
   }
 
@@ -389,7 +389,8 @@ ITreeSpec makeITreeSpec(
     offset += children.back().numIValues();
   }
 
-  return ITreeSpec(name, context, std::move(children), nodeDefCache);
+  return ITreeSpec(
+      name, std::move(context), std::move(children), std::move(nodeDefCache));
 }
 
 } // namespace
@@ -427,7 +428,7 @@ c10::IValue itreeUnflatten(
   if (spec.isIValue()) {
     return std::move(ivalues[0]);
   }
-  auto unflattenFn = spec.nodeDefCache().unflattenFn;
+  const auto& unflattenFn = spec.nodeDefCache().unflattenFn;
   if (spec.allIValues()) {
     return unflattenFn(std::move(ivalues), spec.context());
   }
@@ -599,7 +600,7 @@ ITreeSpec::ITreeSpec(
     : uniformName_(uniformName),
       context_(std::move(context)),
       children_(std::move(children)),
-      nodeDefCache_(nodeDefCache),
+      nodeDefCache_(std::move(nodeDefCache)),
       numIValues_(0),
       value_(nullptr),
       isUsed_(false) {

--- a/torch/nativert/graph/Graph.cpp
+++ b/torch/nativert/graph/Graph.cpp
@@ -467,16 +467,13 @@ Value* Graph::createConstantSymIntValue(int value) {
 }
 
 Value* Graph::getValue(std::string_view name) const {
-  // TODO: can eliminate this string copy by enabling heterogeneous lookup for
-  // the container
-  return values_.at(std::string(name)).get();
+  auto it = values_.find(name);
+  TORCH_CHECK_INDEX(it != values_.end(), "Unknown value: ", name);
+  return it->second.get();
 }
 
 Value* Graph::tryGetValue(std::string_view name) const {
-  // TODO: can eliminate this string copy by enabling heterogeneous lookup for
-  // the container
-  const auto key = std::string(name);
-  if (auto it = values_.find(key); it != values_.end()) {
+  if (auto it = values_.find(name); it != values_.end()) {
     return it->second.get();
   }
   return nullptr;
@@ -821,7 +818,7 @@ void Graph::removeNode(Node* n) {
 void Graph::removeValue(Value* value) {
   // TODO: assuming not removing from constantSymIntValues_
   TORCH_CHECK(value->users().empty(), "Cannot erase a value with users.");
-  auto it = values_.find(std::string(value->name()));
+  auto it = values_.find(value->name());
   TORCH_CHECK(
       it != values_.end(),
       "Attempted to erase a value not in graph ",

--- a/torch/nativert/graph/Graph.h
+++ b/torch/nativert/graph/Graph.h
@@ -10,6 +10,7 @@
 #include <ATen/core/ivalue.h>
 #include <c10/util/IntrusiveList.h>
 #include <c10/util/Logging.h>
+#include <c10/util/string_view.h>
 
 #include <torch/csrc/utils/generated_serialization_types.h>
 #include <torch/nativert/executor/Placement.h>
@@ -671,7 +672,12 @@ class Graph {
   // AKA "sink" of a graph.
   Node* outputNode_; // target: prim.Output
 
-  std::unordered_map<std::string, std::unique_ptr<Value>> values_;
+  std::unordered_map<
+      std::string,
+      std::unique_ptr<Value>,
+      c10::TransparentStringHash,
+      std::equal_to<>>
+      values_;
   // constantSymIntValues_ is a subset of values_
   std::unordered_map<ValueId, int> constantSymIntValues_;
   // Output values of the graph, which is a subset of values_.


### PR DESCRIPTION
* Uses some fancy CPP20 features to avoid allocating an std::string_view to an std::string just to check if a key exists. Sadly due to BC ABI compatibility, this feature is not default and requires feeding an transparent functor. I also created a TransparentStringView hasher for similar handling.

Follow up to #195299 