### PR TITLE
[BE]: Inline the BlockComparison set comporator for MPS allocator

### DIFF
--- a/aten/src/ATen/mps/MPSAllocator.h
+++ b/aten/src/ATen/mps/MPSAllocator.h
@@ -87,15 +87,6 @@ struct BufferBlock {
 
   BufferBlock(size_t Size, size_t Offset = 0, HeapBlock* Heap = nullptr) : size(Size), offset(Offset), heap(Heap) {}
 
-  static bool Comparator(const BufferBlock* a, const BufferBlock* b) {
-    if (a->size != b->size) {
-      return a->size < b->size;
-    }
-    if (a->heap != b->heap) {
-      return reinterpret_cast<uintptr_t>(a->heap) < reinterpret_cast<uintptr_t>(b->heap);
-    }
-    return a->offset < b->offset;
-  }
   static size_t alignUp(size_t Size, size_t Alignment) {
     assert(((Alignment - 1) & Alignment) == 0);
     return ((Size + Alignment - 1) & ~(Alignment - 1));
@@ -104,7 +95,18 @@ struct BufferBlock {
     return [buffer retainCount];
   }
 };
-typedef bool (*BufferComparison)(const BufferBlock*, const BufferBlock*);
+
+struct BufferComparison {
+  bool operator()(const BufferBlock* a, const BufferBlock* b) const {
+    if (a->size != b->size) {
+      return a->size < b->size;
+    }
+    if (a->heap != b->heap) {
+      return reinterpret_cast<uintptr_t>(a->heap) < reinterpret_cast<uintptr_t>(b->heap);
+    }
+    return a->offset < b->offset;
+  }
+};
 
 struct BufferPool;
 struct AllocParams {
@@ -208,9 +210,6 @@ struct HeapBlock {
     }
     return heapBlock;
   }
-  static bool Comparator(const HeapBlock* a, const HeapBlock* b) {
-    return a->heap_id < b->heap_id;
-  }
   id<MTLBuffer> newMTLBuffer(size_t length, uint32_t usage, size_t offset) {
     id<MTLBuffer> buf = [heap newBufferWithLength:length options:getOptions(usage) offset:offset];
     if (buf) {
@@ -239,7 +238,12 @@ struct HeapBlock {
     return [heap retainCount];
   }
 };
-typedef bool (*HeapComparison)(const HeapBlock*, const HeapBlock*);
+
+struct HeapComparison {
+  bool operator()(const HeapBlock* a, const HeapBlock* b) const {
+    return a->heap_id < b->heap_id;
+  }
+};
 
 struct BufferPool {
   enum class Kind {
@@ -252,9 +256,7 @@ struct BufferPool {
       : device(Device),
         usage(Usage),
         alignment([Device heapBufferSizeAndAlignWithLength:1 options:HeapBlock::getOptions(Usage)].align),
-        min_split((Usage & UsageFlags::SMALL) ? alignment : kMaxSmallAlloc),
-        heaps(HeapBlock::Comparator),
-        available_buffers(BufferBlock::Comparator) {}
+        min_split((Usage & UsageFlags::SMALL) ? alignment : kMaxSmallAlloc) {}
 
   const id<MTLDevice> device;
   // usage flags to customize the pool for various purposes (see UsageFlags enum)

--- a/aten/src/ATen/mps/MPSAllocator.mm
+++ b/aten/src/ATen/mps/MPSAllocator.mm
@@ -493,8 +493,7 @@ bool MPSHeapAllocatorImpl::insert_available_buffer(BufferPool& pool, BufferBlock
   bool inserted = pool.available_buffers.insert(buffer_block).second;
   auto it = pool.available_buffers_by_stream.find(buffer_block->stream);
   if (it == pool.available_buffers_by_stream.end()) {
-    it = pool.available_buffers_by_stream
-             .emplace(buffer_block->stream, std::set<BufferBlock*, BufferComparison>(BufferBlock::Comparator))
+    it = pool.available_buffers_by_stream.emplace(buffer_block->stream, std::set<BufferBlock*, BufferComparison>())
              .first;
   }
   it->second.insert(buffer_block);


### PR DESCRIPTION
Follow up to #195176 #195129 . Similarly this allows the inlining of a very hot function