### PR TITLE
Give the nearest-upsample meta checks a boolean predicate

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2337,6 +2337,35 @@ class TestMetaKernelRegistrations(TestCase):
                 inp, dim=-1, keepdim=False, min=out_min, max=out_max
             )
 
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    @parametrize("num_spatial_dims", [1, 2, 3])
+    @parametrize("exact", [False, True])
+    def test_upsample_nearest_meta_empty_input(self, num_spatial_dims, exact):
+        # The non-empty guard passed `torch._check` the product of the non-batch
+        # sizes, which is an int, so every zero-element input raised TypeError out
+        # of the check itself rather than the intended RuntimeError. A zero batch is
+        # not an error at all: eager upsamples it and returns a zero-batch output.
+        name = f"upsample_nearest{num_spatial_dims}d"
+        if exact:
+            name = f"_upsample_nearest_exact{num_spatial_dims}d"
+        op = getattr(torch.ops.aten, name).default
+        spatial = (4,) * num_spatial_dims
+        output_size = [8] * num_spatial_dims
+
+        empty_batch = torch.empty((0, 3, *spatial))
+        expected = op(empty_batch, output_size)
+        actual = op(empty_batch.to("meta"), output_size)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertEqual(actual.stride(), expected.stride())
+        self.assertEqual(actual.dtype, expected.dtype)
+
+        # A zero non-batch dimension is still rejected, and eager rejects it too.
+        empty_channels = torch.empty((1, 0, *spatial))
+        with self.assertRaisesRegex(RuntimeError, "Non-empty"):
+            op(empty_channels, output_size)
+        with self.assertRaisesRegex(RuntimeError, "Non-empty"):
+            op(empty_channels.to("meta"), output_size)
+
     def test_grid_sampler_2d_cpu_fallback_meta(self):
         # The meta kernels' whole contract is output metadata, so compare
         # shape/stride/dtype against eager for the forward and both backward

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7541,7 +7541,7 @@ def upsample_common_check(input_size, output_size, num_spatial_dims):
 )
 def upsample_nearest1d(input, output_size, scales=None):
     torch._check(
-        input.numel() != 0 or multiply_integers(input.size()[1:]),
+        input.numel() != 0 or multiply_integers(input.size()[1:]) != 0,
         lambda: f"Non-empty 3D data tensor expected but got a tensor with sizes {input.size()}",
     )
     full_output_size = upsample_common_check(
@@ -7557,7 +7557,7 @@ def upsample_nearest1d(input, output_size, scales=None):
 )
 def upsample_nearest2d(input, output_size, scales_h=None, scales_w=None):
     torch._check(
-        input.numel() != 0 or multiply_integers(input.size()[1:]),
+        input.numel() != 0 or multiply_integers(input.size()[1:]) != 0,
         lambda: f"Non-empty 4D data tensor expected but got a tensor with sizes {input.size()}",
     )
     full_output_size = upsample_common_check(
@@ -7618,7 +7618,7 @@ def upsample_nearest2d_backward(
 )
 def upsample_nearest3d(input, output_size, scales_d=None, scales_h=None, scales_w=None):
     torch._check(
-        input.numel() != 0 or multiply_integers(input.size()[1:]),
+        input.numel() != 0 or multiply_integers(input.size()[1:]) != 0,
         lambda: f"Non-empty 5D data tensor expected but got a tensor with sizes {input.size()}",
     )
     full_output_size = upsample_common_check(


### PR DESCRIPTION
### Symptom

Nearest upsampling on a meta tensor raises a `TypeError` out of `torch._check`, on shapes that eager handles fine:

```python
>>> import torch, torch.nn.functional as F
>>> F.interpolate(torch.randn(0, 3, 4, 4), scale_factor=2, mode="nearest").shape
torch.Size([0, 3, 8, 8])
>>> F.interpolate(torch.randn(0, 3, 4, 4, device="meta"), scale_factor=2, mode="nearest")
TypeError: cond must be a bool, but got <class 'int'>
```

Same for `torch.ops.aten.upsample_nearest2d.default` on a meta tensor, and under `FakeTensorMode`. It affects 1d, 2d and 3d, and the `_upsample_nearest_exact*` variants with them, for every zero-element input, including the ones eager rejects (those get a `TypeError` instead of the intended `RuntimeError`).

### Root cause

`torch/_meta_registrations.py`, the non-empty guard in `upsample_nearest1d/2d/3d`:

```python
    torch._check(
        input.numel() != 0 or multiply_integers(input.size()[1:]),
        lambda: f"Non-empty 4D data tensor expected but got a tensor with sizes {input.size()}",
    )
```

`multiply_integers` returns the product of the sizes, an `int`. The `or` only reaches it when `numel()` is 0, and `torch._check` rejects a non-bool predicate, so it raises `TypeError` before ever evaluating the guard. The expression reads naturally in the C++ this was ported from, where a non-zero int is truthy.

The intent is visible in the sibling a few hundred lines down, `upsample_bilinear2d`, which spells exactly this condition as a bool and is correct today:

```python
    torch._check(
        input.numel() != 0 or all(size > 0 for size in input.size()[1:]),
        lambda: f"Non-empty 4D data tensor expected but got a tensor with sizes {input.size()}",
    )
```

So three of the four copies of this guard are wrong and one is right.

### Fix

Compare the product against 0 in all three. I kept the single-expression form rather than copying the bilinear spelling because `all(size > 0 for ...)` calls `bool()` on one `SymBool` per dimension, which forces a guard under dynamic shapes, whereas the product stays a single `SymBool`.

### Verification

Eager vs meta on the affected ops, before and after (torch 2.11.0, whose copy of these three lines is identical to main's):

| input | eager | meta before | meta after |
|---|---|---|---|
| `(0, 3, 4, 4)` zero batch | `(0, 3, 8, 8)` | `TypeError` | `(0, 3, 8, 8)` |
| `(1, 0, 4, 4)` zero channels | `RuntimeError` | `TypeError` | `RuntimeError` |
| `(1, 3, 0, 4)` zero spatial | `RuntimeError` | `TypeError` | `RuntimeError` |
| `(2, 3, 4, 4)` ordinary (control) | `(2, 3, 8, 8)` | `(2, 3, 8, 8)` | `(2, 3, 8, 8)` |

10 of 10 cases agree with eager after the change, 0 divergences; before, every zero-element row diverged.

### Test

`test_upsample_nearest_meta_empty_input` in `TestMetaKernelRegistrations`, parametrized over 1d/2d/3d and exact/non-exact, comparing shape, stride and dtype against the eager call and asserting the zero-non-batch-dimension case still raises `RuntimeError`.

```
# this branch
6 passed
# against main
6 failed, all with: TypeError: cond must be a bool, but got <class 'int'>
```

`test/test_meta.py` cannot be collected against a released wheel (it needs newer internals than 2.11.0 ships), so the method was extracted with `ast` and driven directly for each parametrize combination, once against the released `_meta_registrations.py` and once with only these three lines changed. `ruff check` and `ruff format --check` report the identical set of pre-existing findings on both files before and after.

### Note on scope

For a zero *spatial* dimension the meta now raises `RuntimeError` with the "Non-empty ... data tensor expected" message while eager raises "Input and output sizes should be greater than 0", because the nearest metas run the non-empty check before `upsample_common_check` and eager checks in the other order (`upsample_bilinear2d`'s meta already runs them the other way round). Both reject, and both raise `RuntimeError`. Happy to swap the two statements so the messages line up too if you would rather have that in the same PR.

Draft because this account cannot open a non-draft pull request here.