### PR TITLE
Remove out= from torch.std_mean and torch.var_mean docstrings

### DIFF
--- a/torch/_torch_docs.py
+++ b/torch/_torch_docs.py
@@ -11168,7 +11168,7 @@ Example:
 add_docstr(
     torch.std_mean,
     r"""
-std_mean(input, dim=None, *, correction=1, keepdim=False, out=None) -> (Tensor, Tensor)
+std_mean(input, dim=None, *, correction=1, keepdim=False) -> (Tensor, Tensor)
 
 Calculates the standard deviation and mean over the dimensions specified by
 :attr:`dim`. :attr:`dim` can be a single dimension, list of dimensions, or
@@ -11200,7 +11200,6 @@ Keyword args:
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
     {opt_keepdim}
-    {out}
 
 Returns:
     A tuple (std, mean) containing the standard deviation and mean.
@@ -12561,7 +12560,7 @@ Example:
 add_docstr(
     torch.var_mean,
     r"""
-var_mean(input, dim=None, *, correction=1, keepdim=False, out=None) -> (Tensor, Tensor)
+var_mean(input, dim=None, *, correction=1, keepdim=False) -> (Tensor, Tensor)
 
 Calculates the variance and mean over the dimensions specified by :attr:`dim`.
 :attr:`dim` can be a single dimension, list of dimensions, or ``None`` to
@@ -12592,7 +12591,6 @@ Keyword args:
             with ``True`` corresponding to ``correction=1`` and ``False`` being
             ``correction=0``.
     {opt_keepdim}
-    {out}
 
 Returns:
     A tuple (var, mean) containing the variance and mean.


### PR DESCRIPTION
Fixes #195019 partially.

`torch.std_mean` and `torch.var_mean` document an `out=None` parameter, but
neither accepts `out` in any of their registered overloads:

```python
>>> torch.std_mean(torch.randn(5), out=(torch.empty(()), torch.empty(())))
TypeError: std_mean() received an invalid combination of arguments
```

This removes `out=None` from both signature lines and the `{out}` block from
their keyword args.

`torch.var` is left unchanged: it does accept `out`, and all three documented
forms work —

```python
torch.var(a, out=o)            # OK
torch.var(a, dim=0, out=o)     # OK
torch.var(a, dim=None, out=o)  # OK
```

The failing example for `var` in the issue passes the deprecated `unbiased=`
argument, which routes to a legacy overload that has no `out`. The current
docstring is accurate for the documented signature.

Tested on torch 2.6.0.