### PR TITLE
Check num_heads in F::multi_head_attention_forward

### DIFF
--- a/test/cpp/api/modules.cpp
+++ b/test/cpp/api/modules.cpp
@@ -3195,6 +3195,33 @@ TEST_F(ModulesTest, PoissonNLLLoss) {
   }
 }
 
+TEST_F(ModulesTest, MultiheadAttentionZeroNumHeads) {
+  // num_heads == 0 used to reach `embed_dim / num_heads` and crash the process
+  // with an integer division by zero. See gh-106700.
+  ASSERT_THROWS_WITH(
+      MultiheadAttention(MultiheadAttentionOptions(4, 0)),
+      "num_heads must be greater than 0");
+
+  auto query = torch::randn({2, 1, 4});
+  ASSERT_THROWS_WITH(
+      torch::nn::functional::multi_head_attention_forward(
+          query,
+          query,
+          query,
+          torch::nn::functional::MultiheadAttentionForwardFuncOptions(
+              /*embed_dim_to_check=*/4,
+              /*num_heads=*/0,
+              /*in_proj_weight=*/torch::randn({12, 4}),
+              /*in_proj_bias=*/torch::zeros({12}),
+              /*bias_k=*/torch::Tensor(),
+              /*bias_v=*/torch::Tensor(),
+              /*add_zero_attn=*/false,
+              /*dropout_p=*/0.0,
+              /*out_proj_weight=*/torch::randn({4, 4}),
+              /*out_proj_bias=*/torch::zeros({4}))),
+      "num_heads must be greater than 0");
+}
+
 TEST_F(ModulesTest, MarginRankingLoss) {
   {
     MarginRankingLoss loss;

--- a/torch/csrc/api/include/torch/nn/functional/activation.h
+++ b/torch/csrc/api/include/torch/nn/functional/activation.h
@@ -672,6 +672,7 @@ inline std::tuple<Tensor, Tensor> multi_head_attention_forward(
   TORCH_INTERNAL_ASSERT(embed_dim == embed_dim_to_check);
   TORCH_INTERNAL_ASSERT(key.sizes() == value.sizes());
 
+  TORCH_CHECK(num_heads > 0, "num_heads must be greater than 0");
   const auto head_dim = embed_dim / num_heads;
   TORCH_CHECK(
       head_dim * num_heads == embed_dim,


### PR DESCRIPTION
Fixes #106700.

`torch::nn::functional::multi_head_attention_forward` divides before it validates:

```cpp
const auto head_dim = embed_dim / num_heads;
TORCH_CHECK(head_dim * num_heads == embed_dim, "embed_dim must be divisible by num_heads");
```

so `num_heads == 0` is an integer division by zero. That is not a catchable exception — the
process dies. Running the call in a subprocess on Windows exits with `0xC0000094`
(`STATUS_INTEGER_DIVIDE_BY_ZERO`) with no stdout, no stderr and no traceback; the original report
shows the same as SIGFPE on Linux.

### Half of this issue is already fixed — this is the other half

#186376 added `TORCH_CHECK(options.num_heads() > 0, ...)` to `MultiheadAttentionImpl::reset`
(`activation.cpp:504`) and landed as `e71ac681afa`. That closed the case in the issue *body*: the
module constructor. The reporter raised a second case in a follow-up comment — the functional
entry point — and it was never covered. This adds the same check with the same message,
immediately before the division.

@malfet approved the earlier #106778, which fixed both halves; it went stale on unrelated CI in
2023 and closed without landing.

### Test

`ModulesTest.MultiheadAttentionZeroNumHeads` covers both halves — the module constructor and the
functional call. #186376 already covered the constructor with `MultiheadAttentionRejectsZeroNumHeads`;
this adds the missing coverage for the functional entry point.

The crash cannot be caught in-process, so I verified through a `cpp_extension` harness run in a
subprocess. Against current headers:

```
stdout: (empty)
stderr: (empty)
exit code: 3221225620          # 0xC0000094, STATUS_INTEGER_DIVIDE_BY_ZERO
```

With this change, the same harness:

```
stdout: RAISED RuntimeError num_heads must be greater than 0
exit code: 0
```

`cl.exe /Zs test\cpp\api\modules.cpp` is clean against the build's flags; the gtest binary itself
is left to CI, as this machine cannot launch freshly linked executables.

Developed with AI assistance (Claude); I reproduced the crash, wrote the fix and ran the checks
above.

cc @malfet @drisspg

