### PR TITLE
[nativert] Handle UINT64/UINT32/FLOAT8E8M0FNU in convertJsonScalarType

### DIFF
--- a/torch/nativert/graph/TensorMeta.cpp
+++ b/torch/nativert/graph/TensorMeta.cpp
@@ -43,6 +43,12 @@ c10::ScalarType convertJsonScalarType(
       return c10::ScalarType::Float8_e4m3fnuz;
     case torch::_export::ScalarType::FLOAT8E5M2FNUZ:
       return c10::ScalarType::Float8_e5m2fnuz;
+    case torch::_export::ScalarType::FLOAT8E8M0FNU:
+      return c10::ScalarType::Float8_e8m0fnu;
+    case torch::_export::ScalarType::UINT32:
+      return c10::ScalarType::UInt32;
+    case torch::_export::ScalarType::UINT64:
+      return c10::ScalarType::UInt64;
     default:
       TORCH_CHECK(false, "unknown scalar type", static_cast<int>(scalarType));
   }


### PR DESCRIPTION
Summary:
`convertJsonScalarType` in `fbcode/caffe2/torch/nativert/graph/TensorMeta.cpp` had no `case` for three `torch::_export::ScalarType` enumerators that already exist in the generated schema header, so any graph carrying one of them hits the `default:` arm and dies at load with `unknown scalar type`.

The enumerators were added to `schema.py` / `schema.yaml` / `generated_serialization_types.h` (`FLOAT8E8M0FNU = 33`, `UINT32 = 34`, `UINT64 = 35`, see `generated_serialization_types.h:290-292`) but the nativert switch was never extended to match. This adds the three missing cases; no other change is needed since the enumerators are already defined.

`UINT64` is the one hit in practice. A merge net's exported program carries `dtype: 35` tensors as the `philox_seed` / `philox_offset` outputs of `torch.ops.aten._flash_attention_forward.default` whenever flash attention stays outside the AOTI-delegated region. Concretely, in model `1134238897` snapshot 1 the delegate graph `models/merge.json` has 12 such tensor values in `exportedProgram.graph_module.graph` (6 flash-attention calls x 2 outputs); the four per-arch delegate subgraphs have none.

This is unconditionally fatal rather than lazily triggered: `Serialization.cpp:614` calls `Graph::setTensorValuesMeta`, which at `Graph.h:624-626` constructs a `TensorMeta` for *every* entry in the graph's `tensor_values` map, and the `TensorMeta` constructor calls `convertJsonScalarType` on the dtype. One unhandled dtype anywhere in the graph fails the whole load.

Nothing downstream needs to change to accept the new dtypes: the only two consumers of `tensorValuesMeta_` (`Graph.cpp:722` and `Graph.cpp:743`) read `device` only, never `dtype`.

Follows the same shape as D78395110, which added the FP8 enumerators and their switch cases together.

Note this only covers the deserialize direction (schema -> c10). The mirrored serialize direction in `fbcode/sigmoid/backend/graph/TensorMeta.cpp` is left alone: its enum comes from `configerator::structs::caffe2::torch::export_schema::ScalarType`, which still stops at `FLOAT8E5M2FNUZ = 32`, so `schema::ScalarType::UINT64` is a missing symbol there rather than a missing case. Extending it requires adding the enumerators to the configerator-repo thrift first and re-syncing with `configerator-thrift-updater caffe2/torch/export/schema.thrift`.

Test Plan:
Builds clean:

```
buck2 build mode/opt fbcode//caffe2:_libtorch
```

exit 0, no errors.

Lint:

```
arc lint fbcode/caffe2/torch/nativert/graph/TensorMeta.cpp
```

`ok No lint issues.`

Verified the dtype actually occurs in a real published merge net, and only in the eager graph:

```
graph object                              nodes  tensorValues  dtype==35
exportedProgram.graph_module.graph         2859          5434         12
delegates.SM90_X86.graph_module.graph         1           902          0
delegates.SM80_X86.graph_module.graph         1           902          0
delegates.GFX942_X86.graph_module.graph       1           902          0
delegates.GFX950_X86.graph_module.graph       1           902          0
```

from `/data/users/kevinqfu/models/1134238897/1/archive_.predictor.disagg.gpu.merge/models/merge.json`, with all 12 traced back to `torch.ops.aten._flash_attention_forward.default` outputs.

Differential Revision: D118069165


