### PR TITLE
[BE][CI]  Don't require grad on non-autograd ops in test_consistency

### DIFF
--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16338,7 +16338,7 @@ class TestConsistency(TestCaseMPS):
         for mps_sample in op.sample_inputs(
                 device,
                 dtype,
-                requires_grad=(dtype.is_floating_point or dtype.is_complex),
+                requires_grad=(op.supports_autograd and (dtype.is_floating_point or dtype.is_complex)),
                 include_conjugated_inputs=include_conjugated_inputs,
                 set_seed=True):
 
@@ -16436,7 +16436,7 @@ class TestConsistency(TestCaseMPS):
 
         for mps_sample in op.sample_inputs(
                 device, dtype,
-                requires_grad=(dtype.is_floating_point or dtype.is_complex),
+                requires_grad=(op.supports_autograd and (dtype.is_floating_point or dtype.is_complex)),
                 set_seed=True):
             #
             # Forward check

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -64,13 +64,10 @@ if torch.backends.mps.is_available():
             "nn.functional.dropout3d",
             "nn.functional.feature_alpha_dropoutwith_train",
             "nn.functional.padreplicate_negative",
-            "nn.functional.silucomplex",
             "ormqr",
             "pow",
             "randint",
             "renorm",
-            "resize_",
-            "resize_as_",
             "sparse.sampled_addmm",
             "to",
             "to_sparse",
@@ -394,8 +391,6 @@ if torch.backends.mps.is_available():
             ],
             # zero to negative integer powers are undefined
             "__rpow__": [torch.int8, torch.int16, torch.int32, torch.int64],
-            "resize_": [torch.float16, torch.float32, torch.bfloat16],
-            "resize_as_": [torch.float16, torch.float32, torch.bfloat16],
             # CPU Errors:
             "addr": [
                 torch.bool,
@@ -572,16 +567,10 @@ if torch.backends.mps.is_available():
     def mps_ops_grad_modifier(ops: Sequence[OpInfo]) -> Sequence[OpInfo]:
         XFAILLIST_GRAD = {
             # Unimplemented ops
-            "_chunk_cat": [torch.float16, torch.float32],
             "sparse.mmreduce": [torch.float32],  # csr not supported
             "linalg.householder_product": None,
             "linalg.lstsq": [torch.float32],
             "linalg.lstsqgrad_oriented": [torch.float32],
-            "geqrf": None,
-            "unique_consecutive": [torch.float16, torch.float32],
-            "scalar_tensor": [torch.float16, torch.float32],
-            "igamma": None,  # currently not supported for any device
-            "igammac": None,  # currently not supported for any device
             # Correctness issues
             # Same issue as `argsort` and `sort` with duplicate elements (undefined behaviour).
             # Forward pass is passing since `msort` doesn't return the indices, just the values, which match the CPU.
@@ -609,37 +598,13 @@ if torch.backends.mps.is_available():
             # sign choices.
             "pca_lowrank": [torch.float32],
             # CPU errors
-            # derivative for zeta is not implemented
-            "special.zeta": None,
-            # derivative for aten::floor_divide is not implemented on CPU
-            "floor_divide": [torch.float16, torch.float32],
-            # derivative for aten::_histogramdd_from_bin_cts is not implemented on CPU
-            "histogramdd": [torch.float16, torch.float32],
-            # derivative for aten::histogram is not implemented
-            "histogram": [torch.float16, torch.float32],
             # 'bool' object is not iterable
             "allclose": [torch.float16, torch.float32],
             "equal": [torch.float16, torch.float32],
             # 'float' object is not iterable
             "item": [torch.float16, torch.float32],
-            # cpu error: grad requires non-empty inputs
-            "randn": [torch.float16, torch.float32],
-            "signal.windows.bartlett": [torch.float32],
-            "signal.windows.blackman": [torch.float32],
-            "signal.windows.cosine": [torch.float32],
-            "signal.windows.exponential": [torch.float32],
-            "signal.windows.gaussian": [torch.float32],
-            "signal.windows.general_cosine": [torch.float32],
-            "signal.windows.general_hamming": [torch.float32],
-            "signal.windows.hamming": [torch.float32],
-            "signal.windows.hann": [torch.float32],
-            "signal.windows.kaiser": [torch.float32],
-            "signal.windows.nuttall": [torch.float32],
-            "eye": [torch.float16, torch.float32],
             # Could not run 'aten::uniform_' with arguments from the 'SparseCPU' backend
             "to_sparse": None,
-            # Exception: the derivative for '_unique2' is not implemented.
-            "unique": None,
         }
 
         SKIPLIST_GRAD = {


### PR DESCRIPTION
`test_output_match` / `test_output_grad_match` in `test_mps.py` built sample inputs with `requires_grad=(dtype.is_floating_point or dtype.is_complex)` regardless of whether the op supports autograd.
For `supports_autograd=False` ops this is a latent harness bug : the grad-requiring input makes the op raise in forward or makes CPU raise *"derivative is not implemented"* / *"grad requires non-empty inputs"*. 
These failures had nothing to do with the complex dtype or MPS , so one can delete numerous false-negative xfails.
The fix gates `requires_grad` on `op.supports_autograd`, then removes the xfails that only existed to mask this harness bug.



🤖 Generated with [Claude Code](https://claude.com/claude-code)