### PR TITLE
Name RowwiseScaledMM's EVT arguments, drop dead warning suppression

### DIFF
--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -252,9 +252,14 @@ void f8f8bf16_rowwise_impl(
        reinterpret_cast<DtypeB*>(WQ.data_ptr()),
        stride_b},
       {{{{bias.has_value() ? reinterpret_cast<DtypeBias*>(bias->data_ptr())
-                           : nullptr},
+                           : nullptr},                        // Bias
          {{reinterpret_cast<DtypeScale*>(w_scale.data_ptr())},
-          {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())}}}}},
+          {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())},
+           {},                                                // Accum
+           {}},                                               // XScale * Accum
+          {}},                                                // WScale * that
+         {}},                                                 // Bias + that
+        {}},                                                  // Cast to output
        nullptr,
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),
@@ -445,9 +450,14 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
        reinterpret_cast<DtypeB*>(WQ.data_ptr()),
        stride_b},
       {{{{bias.has_value() ? reinterpret_cast<DtypeBias*>(bias->data_ptr())
-                           : nullptr},
+                           : nullptr},                        // Bias
          {{reinterpret_cast<DtypeScale*>(w_scale.data_ptr())},
-          {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())}}}}},
+          {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())},
+           {},                                                // Accum
+           {}},                                               // XScale * Accum
+          {}},                                                // WScale * that
+         {}},                                                 // Bias + that
+        {}},                                                  // Cast to output
        nullptr,
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.data_ptr()),

--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -5,12 +5,6 @@
 #include <ATen/cuda/nvrtc_stub/ATenNVRTC.h>
 #include <c10/macros/Macros.h>
 
-// Two warnings in Cutlass included header files
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wset-but-not-used")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-but-set-parameter")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wmissing-field-initializers")
-C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-but-set-variable")
-
 // Determine if the architecture supports rowwise scaled mm
 // Currently failing on windows with:
 // https://github.com/NVIDIA/cutlass/issues/1571
@@ -44,10 +38,6 @@ C10_DIAGNOSTIC_PUSH_AND_IGNORED_IF_DEFINED("-Wunused-but-set-variable")
 #include <cutlass/util/packed_stride.hpp>
 
 #include <ATen/native/cuda/cutlass_common.cuh>
-
-C10_DIAGNOSTIC_POP()
-C10_DIAGNOSTIC_POP()
-C10_DIAGNOSTIC_POP()
 
 namespace {
 
@@ -253,14 +243,14 @@ void f8f8bf16_rowwise_impl(
        stride_b},
       {{{{bias.has_value()
                ? reinterpret_cast<const DtypeBias*>(bias->const_data_ptr())
-               : nullptr},                                    // Bias
+               : nullptr}, // Bias
          {{reinterpret_cast<const DtypeScale*>(w_scale.const_data_ptr())},
           {{reinterpret_cast<const DtypeScale*>(x_scale.const_data_ptr())},
-           {},                                                // Accum
-           {}},                                               // XScale * Accum
-          {}},                                                // WScale * that
-         {}},                                                 // Bias + that
-        {}},                                                  // Cast to output
+           {}, // Accum
+           {}}, // XScale * Accum
+          {}}, // WScale * that
+         {}}, // Bias + that
+        {}}, // Cast to output
        nullptr,
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.mutable_data_ptr()),
@@ -452,14 +442,14 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
        stride_b},
       {{{{bias.has_value()
                ? reinterpret_cast<const DtypeBias*>(bias->const_data_ptr())
-               : nullptr},                                    // Bias
+               : nullptr}, // Bias
          {{reinterpret_cast<const DtypeScale*>(w_scale.const_data_ptr())},
           {{reinterpret_cast<const DtypeScale*>(x_scale.const_data_ptr())},
-           {},                                                // Accum
-           {}},                                               // XScale * Accum
-          {}},                                                // WScale * that
-         {}},                                                 // Bias + that
-        {}},                                                  // Cast to output
+           {}, // Accum
+           {}}, // XScale * Accum
+          {}}, // WScale * that
+         {}}, // Bias + that
+        {}}, // Cast to output
        nullptr,
        stride_output,
        reinterpret_cast<DtypeOutput*>(out.mutable_data_ptr()),
@@ -1158,5 +1148,3 @@ void f8f8bf16_rowwise(
 }
 
 } // namespace at::cuda::detail
-
-C10_DIAGNOSTIC_POP()

--- a/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
+++ b/aten/src/ATen/native/cuda/RowwiseScaledMM.cu
@@ -247,14 +247,15 @@ void f8f8bf16_rowwise_impl(
   typename Gemm::Arguments arguments{
       cutlass::gemm::GemmUniversalMode::kGemm,
       {M, N, K},
-      {reinterpret_cast<DtypeA*>(XQ.data_ptr()),
+      {reinterpret_cast<const DtypeA*>(XQ.const_data_ptr()),
        stride_a,
-       reinterpret_cast<DtypeB*>(WQ.data_ptr()),
+       reinterpret_cast<const DtypeB*>(WQ.const_data_ptr()),
        stride_b},
-      {{{{bias.has_value() ? reinterpret_cast<DtypeBias*>(bias->data_ptr())
-                           : nullptr},                        // Bias
-         {{reinterpret_cast<DtypeScale*>(w_scale.data_ptr())},
-          {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())},
+      {{{{bias.has_value()
+               ? reinterpret_cast<const DtypeBias*>(bias->const_data_ptr())
+               : nullptr},                                    // Bias
+         {{reinterpret_cast<const DtypeScale*>(w_scale.const_data_ptr())},
+          {{reinterpret_cast<const DtypeScale*>(x_scale.const_data_ptr())},
            {},                                                // Accum
            {}},                                               // XScale * Accum
           {}},                                                // WScale * that
@@ -262,7 +263,7 @@ void f8f8bf16_rowwise_impl(
         {}},                                                  // Cast to output
        nullptr,
        stride_output,
-       reinterpret_cast<DtypeOutput*>(out.data_ptr()),
+       reinterpret_cast<DtypeOutput*>(out.mutable_data_ptr()),
        stride_output}};
 
   Gemm gemm;
@@ -293,7 +294,7 @@ void f8f8bf16_rowwise_impl(
   }
 
   // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.data_ptr(), at::cuda::getCurrentCUDAStream());
+  status = gemm.initialize(arguments, workspace.mutable_data_ptr(), at::cuda::getCurrentCUDAStream());
   if (status != cutlass::Status::kSuccess) {
     throw std::runtime_error("cutlass cannot initialize");
   }
@@ -445,14 +446,15 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
   typename Gemm::Arguments arguments{
       cutlass::gemm::GemmUniversalMode::kGemm,
       {M, N, K},
-      {reinterpret_cast<DtypeA*>(XQ.data_ptr()),
+      {reinterpret_cast<const DtypeA*>(XQ.const_data_ptr()),
        stride_a,
-       reinterpret_cast<DtypeB*>(WQ.data_ptr()),
+       reinterpret_cast<const DtypeB*>(WQ.const_data_ptr()),
        stride_b},
-      {{{{bias.has_value() ? reinterpret_cast<DtypeBias*>(bias->data_ptr())
-                           : nullptr},                        // Bias
-         {{reinterpret_cast<DtypeScale*>(w_scale.data_ptr())},
-          {{reinterpret_cast<DtypeScale*>(x_scale.data_ptr())},
+      {{{{bias.has_value()
+               ? reinterpret_cast<const DtypeBias*>(bias->const_data_ptr())
+               : nullptr},                                    // Bias
+         {{reinterpret_cast<const DtypeScale*>(w_scale.const_data_ptr())},
+          {{reinterpret_cast<const DtypeScale*>(x_scale.const_data_ptr())},
            {},                                                // Accum
            {}},                                               // XScale * Accum
           {}},                                                // WScale * that
@@ -460,7 +462,7 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
         {}},                                                  // Cast to output
        nullptr,
        stride_output,
-       reinterpret_cast<DtypeOutput*>(out.data_ptr()),
+       reinterpret_cast<DtypeOutput*>(out.mutable_data_ptr()),
        stride_output}};
 
   Gemm gemm;
@@ -491,7 +493,7 @@ void f8f8bf16_rowwise_impl_sm100_sm120(
   }
 
   // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.data_ptr(), at::cuda::getCurrentCUDAStream());
+  status = gemm.initialize(arguments, workspace.mutable_data_ptr(), at::cuda::getCurrentCUDAStream());
   if (status != cutlass::Status::kSuccess) {
     throw std::runtime_error("cutlass cannot initialize");
   }
@@ -636,22 +638,22 @@ void f8f8bf16_rowwise_impl_sm89(
   constexpr auto SplitKFactor = 1;
 
   XScaleArguments x_scale_arguments{
-      (DtypeScale*)x_scale.data_ptr(),
+      reinterpret_cast<const DtypeScale*>(x_scale.const_data_ptr()),
       DtypeScale(1),
       {cute::_1{}, cute::_0{}, problem_size.m()}
   };
   WScaleArguments w_scale_arguments{
-      (DtypeScale*)w_scale.data_ptr(),
+      reinterpret_cast<const DtypeScale*>(w_scale.const_data_ptr()),
       DtypeScale(1),
       {cute::_0{}, cute::_1{}, problem_size.n()}
   };
   BiasArguments bias_arguments{
-      bias.has_value() ? reinterpret_cast<DtypeBias*>(bias->data_ptr()) : nullptr,
+      bias.has_value() ? reinterpret_cast<const DtypeBias*>(bias->const_data_ptr()) : nullptr,
       DtypeBias(0),
       {cute::_0{}, cute::_1{}, problem_size.n()}
   };
   typename Output::Arguments output_arguments{
-    (DtypeOutput*)out.data_ptr(),
+    reinterpret_cast<DtypeOutput*>(out.mutable_data_ptr()),
     {problem_size.n(), cute::_1{}, problem_size.mn().product()}
   };
   typename EVTOutput::Arguments callback_arguments{
@@ -676,8 +678,8 @@ void f8f8bf16_rowwise_impl_sm89(
     problem_size,
     SplitKFactor,
     callback_arguments,           // arguments of EVT callbacks
-    (DtypeA*)XQ.data_ptr(),
-    (DtypeB*)WQ.data_ptr(),
+    reinterpret_cast<const DtypeA*>(XQ.const_data_ptr()),
+    reinterpret_cast<const DtypeB*>(WQ.const_data_ptr()),
     nullptr,                      // ptr C (unused)
     nullptr,                      // ptr D (unused)
     problem_size.mk().product(),  // batch stride A
@@ -707,7 +709,7 @@ void f8f8bf16_rowwise_impl_sm89(
   }
 
   // Initialize CUTLASS kernel with arguments and workspace pointer
-  status = gemm.initialize(arguments, workspace.data_ptr(), at::cuda::getCurrentCUDAStream());
+  status = gemm.initialize(arguments, workspace.mutable_data_ptr(), at::cuda::getCurrentCUDAStream());
   if (status != cutlass::Status::kSuccess) {
     throw std::runtime_error("cutlass cannot initialize");
   }


### PR DESCRIPTION
Explicitly name every CUTLASS EVT argument-tree member and switch data_ptr()
to const_data_ptr()/mutable_data_ptr() with matching const-correct casts.
With every member named, none of the four suppressed warnings still fires --
and -Wset-but-not-used was never real to begin with (unrecognized by both
clang and gcc; a typo/duplicate of -Wunused-but-set-variable, which is
already suppressed separately two lines down). Same dead entry exists in
GroupMM.cu, ScaledGroupMM.cu, AsyncMM.cu; this commit only touches the file
it removes the block from.

Test Plan: compiled on a CUDA machine with all four warnings passed
explicitly and -Werror on, under both clang and gcc host compilers; zero
diagnostics.

This change was authored with AI assistance (Claude Code).

