### PR TITLE
Free make_graphed_callables' CUDA graphs by refcount, not by the cyclic GC

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5050,16 +5050,19 @@ exit(2)
                 1 for o in gc.get_objects() if isinstance(o, torch.cuda.CUDAGraph)
             )
 
+        def graph_and_drop(as_module):
+            # Everything the callable owns goes out of scope when this returns.
+            module = torch.nn.Linear(8, 8, device="cuda")
+            x = torch.randn(4, 8, device="cuda", requires_grad=True)
+            target = module if as_module else (lambda t: module(t))
+            torch.cuda.make_graphed_callables(target, (x,), num_warmup_iters=3)
+
         for as_module in (True, False):
             gc.collect()
             before = live_graphs()
             gc.disable()
             try:
-                module = torch.nn.Linear(8, 8, device="cuda")
-                x = torch.randn(4, 8, device="cuda", requires_grad=True)
-                target = module if as_module else (lambda t: module(t))
-                torch.cuda.make_graphed_callables(target, (x,), num_warmup_iters=3)
-                del module, x, target
+                graph_and_drop(as_module)
                 self.assertEqual(
                     live_graphs() - before,
                     0,

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5040,6 +5040,39 @@ exit(2)
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )
+    def test_graph_make_graphed_callables_freed_by_refcount(self):
+        # Dropping a graphed callable must free its CUDAGraphs right there rather than
+        # leaving them for the cyclic collector: freeing one runs cudaGraphDestroy and
+        # releasePool, which are illegal while some unrelated stream is capturing, and
+        # the collector picks its own moment to run.
+        def live_graphs():
+            return sum(
+                1 for o in gc.get_objects() if isinstance(o, torch.cuda.CUDAGraph)
+            )
+
+        for as_module in (True, False):
+            gc.collect()
+            before = live_graphs()
+            gc.disable()
+            try:
+                module = torch.nn.Linear(8, 8, device="cuda")
+                x = torch.randn(4, 8, device="cuda", requires_grad=True)
+                target = module if as_module else (lambda t: module(t))
+                torch.cuda.make_graphed_callables(target, (x,), num_warmup_iters=3)
+                del module, x, target
+                self.assertEqual(
+                    live_graphs() - before,
+                    0,
+                    f"graphed callable (as_module={as_module}) left CUDAGraphs "
+                    "reachable only through a reference cycle",
+                )
+            finally:
+                gc.enable()
+                gc.collect()
+
+    @unittest.skipIf(
+        not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
+    )
     def test_graph_make_graphed_callables_same_pool(self):
         torch.manual_seed(5)
         torch.cuda.manual_seed(5)

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -104,9 +104,7 @@ class TestMarkKernels(TestCase):
         # Annotations are enabled per-capture via torch.cuda.graph(..,
         # enable_annotations=True); there is no global toggle.
         clear_kernel_annotations()
-
-    def tearDown(self):
-        clear_kernel_annotations()
+        self.addCleanup(clear_kernel_annotations)
 
     def _count_phases(self, name):
         """Count (forward, backward) annotations recorded under ``name``."""

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -8,7 +8,7 @@ import warnings
 import weakref
 from collections import OrderedDict
 from collections.abc import Callable
-from typing import overload, TYPE_CHECKING, TypeAlias, TypeGuard, Union
+from typing import Any, overload, TYPE_CHECKING, TypeAlias, TypeGuard, Union
 from typing_extensions import ParamSpec, Self, TypeVar
 
 import torch
@@ -1603,10 +1603,23 @@ def make_graphed_callables(
         static_grad_outputs: tuple[Tensor | None, ...],
         static_grad_inputs: tuple[Tensor, ...],
     ) -> Callable[..., object]:
+        # Handed to Graphed.apply per call rather than closed over. A class and its
+        # methods' closure cells form a reference cycle, so anything the methods close
+        # over is freed by the cyclic collector rather than by refcount -- and freeing a
+        # CUDAGraph runs cudaGraphDestroy/releasePool, which are illegal while some
+        # unrelated stream is capturing. Passing them in keeps the graphs off the class,
+        # so dropping the graphed callable releases them immediately, while ctx still
+        # holds bwd_graph for as long as a backward can be run.
+        graphs = (fwd_graph, bwd_graph)
+
         class Graphed(torch.autograd.Function):
             @staticmethod
             # pyrefly: ignore [bad-override]
-            def forward(ctx: object, *inputs: Tensor) -> tuple[Tensor, ...]:
+            def forward(
+                ctx: Any, graphs: tuple[CUDAGraph, CUDAGraph], *inputs: Tensor
+            ) -> tuple[Tensor, ...]:
+                fwd_graph, bwd_graph = graphs
+                ctx.bwd_graph = bwd_graph
                 # At this stage, only the user args may (potentially) be new tensors.
                 for i in range(len_user_args):
                     if static_input_surface[i].data_ptr() != inputs[i].data_ptr():
@@ -1621,7 +1634,7 @@ def make_graphed_callables(
             @staticmethod
             @torch.autograd.function.once_differentiable
             # pyrefly: ignore [bad-override]
-            def backward(ctx: object, *grads: Tensor) -> tuple[Tensor, ...]:
+            def backward(ctx: Any, *grads: Tensor) -> tuple[Tensor | None, ...]:
                 if len(grads) != len(static_grad_outputs):
                     raise AssertionError(
                         f"len(grads)={len(grads)} != len(static_grad_outputs)={len(static_grad_outputs)}"
@@ -1632,14 +1645,15 @@ def make_graphed_callables(
                         # incoming grad is already in the right place
                         if g.data_ptr() != grad.data_ptr():
                             g.copy_(grad)
-                bwd_graph.replay()
+                ctx.bwd_graph.replay()
 
                 # Input args that didn't require grad expect a None gradient.
                 if not isinstance(static_grad_inputs, tuple):
                     raise AssertionError(
                         f"static_grad_inputs must be tuple, got {type(static_grad_inputs)}"
                     )
-                return tuple(
+                # Leading None is the gradient for the graphs argument of forward.
+                return (None,) + tuple(
                     # pyrefly: ignore [bad-argument-type]
                     b.detach() if b is not None else b
                     for b in static_grad_inputs
@@ -1650,7 +1664,7 @@ def make_graphed_callables(
             # (explicit user args + module parameters)
             # Assumes module params didn't change since capture.
             flatten_user_args = torch.utils._pytree.arg_tree_leaves(*user_args)
-            out = Graphed.apply(*(tuple(flatten_user_args) + module_params))
+            out = Graphed.apply(graphs, *(tuple(flatten_user_args) + module_params))
             return torch.utils._pytree.tree_unflatten(out, output_unflatten_spec)
 
         return functionalized
@@ -1678,13 +1692,41 @@ def make_graphed_callables(
                 graphed: Callable[_P, _R],
                 orig_fwd: Callable[_P, _R],
             ) -> Callable[_P, _R]:
+                # This closure is installed as func.forward, so closing over func (or over
+                # orig_fwd, which is bound to it) would make the module a reference cycle
+                # and everything it reaches -- including the CUDAGraphs graphed owns --
+                # collectable only by the cyclic GC. That matters because freeing a
+                # CUDAGraph runs cudaGraphDestroy/releasePool, which are illegal while an
+                # unrelated stream is capturing, and the collector picks its own moment.
+                # Hold the module weakly and rebind its original forward per call instead.
+                func_ref = weakref.ref(func)
+                # Exactly one of these ends up in new_fwd's closure. orig_fwd is bound to
+                # func, so keeping it would reinstate the very cycle func_ref avoids;
+                # unbind it and rebind per call. If forward was already an instance
+                # attribute rather than a bound method there is nothing to unbind, and
+                # that (rare) case keeps holding the module.
+                orig_bound_to_func = getattr(orig_fwd, "__self__", None) is func
+                orig_call: Callable[..., _R] = (
+                    orig_fwd.__func__  # type: ignore[attr-defined]
+                    if orig_bound_to_func
+                    else orig_fwd
+                )
+
                 def new_fwd(*user_args: _P.args, **user_kwargs: _P.kwargs) -> _R:
+                    module = func_ref()
+                    if module is None:
+                        raise RuntimeError(
+                            "the graphed module has been freed; its forward cannot be "
+                            "called on its own"
+                        )
                     # If the module's training-or-eval state matches what we graphed,
                     # run the graph, otherwise run the original forward method
-                    if func.training == graph_training_state:
+                    if module.training == graph_training_state:
                         return graphed(*user_args, **user_kwargs)
+                    elif orig_bound_to_func:
+                        return orig_call(module, *user_args, **user_kwargs)
                     else:
-                        return orig_fwd(*user_args, **user_kwargs)
+                        return orig_call(*user_args, **user_kwargs)
 
                 return new_fwd
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #195398
* __->__ #195397
* #194854

Human note:

fix refcycles in make_graphed_callables so that gc doesn't unexpectedly kick in during graph capture

Destroying a CUDAGraph runs cudaGraphDestroy / cudaGraphExecDestroy / releasePool
(aten/src/ATen/cuda/CUDAGraph.cpp:399-408), none of which are permitted while a stream is
capturing. Doing it mid-capture warns "operation not permitted when stream is capturing
(function reset)" and invalidates that capture, after which the next allocation trips
TORCH_INTERNAL_ASSERT(info.status != cudaStreamCaptureStatusInvalidated) in
CUDACachingAllocator. So *when* a CUDAGraph is freed matters, and make_graphed_callables
was handing that decision to the cyclic collector, which picks an arbitrary allocation
point -- including one inside an unrelated capture.

Two reference cycles put the graphs in the collector's hands. The autograd Function
subclass closed over fwd_graph/bwd_graph, and a class plus its methods' closure cells is
a cycle, so anything those methods captured could only be reclaimed by the GC. On the
nn.Module path the closure installed as func.forward also closed over func -- and over
func.forward, a bound method holding it -- so the module, and through it the graphs, was
cyclic as well. Fixing only one of the two leaves the graphs stranded via the other.

The graphs are now passed to Graphed.apply per call and stashed on ctx, so the class
holds none of them while ctx keeps bwd_graph alive for exactly as long as a backward can
still run. new_fwd holds the module weakly and rebinds its original forward per call.
One case still retains: a module whose forward was already an instance attribute rather
than a bound method has nothing to unbind, so that path keeps holding the module; it is
commented where it happens.

Worth calling out as a behaviour change: calling a graphed module's forward after the
module itself has been freed now raises instead of working by accident. Holding
module.forward while the module is alive is unaffected.

This also removes a workaround. TestMarkKernels in test_cuda_graph_utils.py had a
tearDown that did not chain to super().tearDown(), and restoring the chain made a later
capture in that class fail with exactly the assert above -- the base tearDown shifted
allocation timing enough for a collection to land inside a capture. With the cycles gone
the fixture folds into the ordinary setUp + addCleanup.

Test Plan:

```
python test/test_cuda.py -k make_graphed
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda_graph_utils.py
```

8 and 115 tests pass (make_graphed has 3 pre-existing expected failures).
test_graph_make_graphed_callables_freed_by_refcount is the regression test: it drops a
graphed callable with the cyclic GC disabled and asserts no CUDAGraph survives, for both
the nn.Module and plain-callable paths, and fails on the parent commit. The original
end-to-end symptom reproduces via agent_space/repro_gc_capture_invalidate.py, which
stops reproducing with this change.

Authored with assistance from Claude Code.