### PR TITLE
Fix an annotation leak on failed capture, and retire the clear_kernel_annotations workflow

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -4618,8 +4618,8 @@ class TestPythonChromeTraceExport(TestCase):
     def test_cuda_graph_annotations_reach_the_trace(self):
         """End to end: annotations recorded at capture are baked into a replay's
         kernel events by export_chrome_trace(cuda_graph_annotations=...)."""
+        from torch.cuda._graph_annotations import _reset_kernel_annotations
         from torch.cuda.graph_annotations import (
-            clear_kernel_annotations,
             get_kernel_annotations,
             is_available,
             mark_kernels,
@@ -4628,8 +4628,8 @@ class TestPythonChromeTraceExport(TestCase):
         if not is_available():
             self.skipTest("CUDA graph annotations are unavailable")
 
-        clear_kernel_annotations()
-        self.addCleanup(clear_kernel_annotations)
+        _reset_kernel_annotations()
+        self.addCleanup(_reset_kernel_annotations)
         x = torch.randn(64, 64, device="cuda")
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, enable_annotations=True):

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -270,20 +270,6 @@ class TestMarkKernels(TestCase):
             clear_kernel_annotations()
         self.assertEqual(len(get_kernel_annotations()), 0)
 
-    def test_reset_does_not_stop_an_open_forward_scope(self):
-        """Only backward brackets are versioned. A forward scope open across a reset
-        registers on exit as usual -- what the docstring now says."""
-        graph = torch.cuda.CUDAGraph()
-        x = torch.randn(8, device="cuda")
-
-        with torch.cuda.graph(graph, enable_annotations=True):
-            with mark_kernels("opened_before_reset"):
-                _ = x + 1
-                _reset_kernel_annotations()
-                _ = x + 2
-
-        self.assertAnnotations({"name": "opened_before_reset"})
-
     def test_failed_capture_end_discards_annotations(self):
         """A completed scope plus a failing capture_end used to strand entries keyed by
         the capture graph id. Nothing remaps them (that happens in instantiate) and
@@ -899,46 +885,6 @@ class TestMarkKernels(TestCase):
         fwd, bwd = counts[False]
         self.assertEqual(fwd, 1)
         self.assertGreaterEqual(bwd, 1)
-
-    def test_backward_clear_then_retained_backward(self):
-        """A reset revokes the backward brackets of scopes opened before it:
-        hooks on a retained graph become inert, so a backward captured after
-        the reset records nothing."""
-        graph_fwd = torch.cuda.CUDAGraph()
-        x = torch.randn(8, device="cuda", requires_grad=True)
-        with torch.cuda.graph(graph_fwd, enable_annotations=True):
-            with mark_kernels("scope"):
-                y = (x * 2).sin()
-
-        _reset_kernel_annotations()
-        self.assertEqual(len(get_kernel_annotations()), 0)
-
-        graph_bwd = torch.cuda.CUDAGraph()
-        grad_out = torch.ones_like(y)
-        with torch.cuda.graph(graph_bwd, enable_annotations=True):
-            _ = torch.autograd.grad(y, x, grad_outputs=grad_out, retain_graph=True)
-
-        self.assertEqual(len(get_kernel_annotations()), 0)
-
-    def test_backward_scope_after_clear_records(self):
-        """A scope opened after a clear records normally (fresh generation),
-        including backward of nodes created under it."""
-        graph1 = torch.cuda.CUDAGraph()
-        x = torch.randn(8, device="cuda", requires_grad=True)
-        with torch.cuda.graph(graph1, enable_annotations=True):
-            with mark_kernels("old"):
-                _ = (x * 2).sin()
-
-        _reset_kernel_annotations()
-
-        graph2 = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph2, enable_annotations=True):
-            with mark_kernels("new"):
-                y = (x * 3).cos()
-            _ = torch.autograd.grad(y.sum(), x)
-
-        ann = {"name": "new"}
-        self.assertAnnotations(ann, self._bwd(ann))
 
     def test_backward_accumulate_grad_excluded(self):
         """AccumulateGrad work is never tagged: a .backward() run (which

--- a/test/test_cuda_graph_utils.py
+++ b/test/test_cuda_graph_utils.py
@@ -11,6 +11,7 @@ from torch.cuda._graph_annotations import (
     _get_stream_id,
     _is_tools_id_unavailable,
     _rekey_annotations,
+    _reset_kernel_annotations,
     mark_stream,
     resolve_and_remap,
     resolve_pending_annotations,
@@ -103,8 +104,8 @@ class TestMarkKernels(TestCase):
         super().setUp()
         # Annotations are enabled per-capture via torch.cuda.graph(..,
         # enable_annotations=True); there is no global toggle.
-        clear_kernel_annotations()
-        self.addCleanup(clear_kernel_annotations)
+        _reset_kernel_annotations()
+        self.addCleanup(_reset_kernel_annotations)
 
     def _count_phases(self, name):
         """Count (forward, backward) annotations recorded under ``name``."""
@@ -256,6 +257,7 @@ class TestMarkKernels(TestCase):
         self.assertAnnotations(annotation)
 
     def test_clear_resets_state(self):
+        """The deprecated public entry point still clears, and warns while doing it."""
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
@@ -264,7 +266,46 @@ class TestMarkKernels(TestCase):
                 _ = x + 1
 
         self.assertGreater(len(get_kernel_annotations()), 0)
-        clear_kernel_annotations()
+        with self.assertWarnsRegex(FutureWarning, "clear_kernel_annotations"):
+            clear_kernel_annotations()
+        self.assertEqual(len(get_kernel_annotations()), 0)
+
+    def test_reset_does_not_stop_an_open_forward_scope(self):
+        """Only backward brackets are versioned. A forward scope open across a reset
+        registers on exit as usual -- what the docstring now says."""
+        graph = torch.cuda.CUDAGraph()
+        x = torch.randn(8, device="cuda")
+
+        with torch.cuda.graph(graph, enable_annotations=True):
+            with mark_kernels("opened_before_reset"):
+                _ = x + 1
+                _reset_kernel_annotations()
+                _ = x + 2
+
+        self.assertAnnotations({"name": "opened_before_reset"})
+
+    def test_failed_capture_end_discards_annotations(self):
+        """A completed scope plus a failing capture_end used to strand entries keyed by
+        the capture graph id. Nothing remaps them (that happens in instantiate) and
+        remove_kernel_annotations matches exec ids, so they outlived the process."""
+        x = torch.randn(8, device="cuda")
+        graph = torch.cuda.CUDAGraph()
+        side = torch.cuda.Stream()
+        entry_stream = torch.cuda.current_stream()
+        try:
+            with self.assertRaises(Exception):
+                with torch.cuda.graph(graph, enable_annotations=True):
+                    with mark_kernels("completed_scope"):
+                        _ = x + 1
+                    side.wait_event(entry_stream.record_event())
+                    # Forked and never joined, so cudaStreamEndCapture fails.
+                    with torch.cuda.stream(side):
+                        _ = x * 3
+        finally:
+            # torch.cuda.graph.__exit__ propagates before unwinding its stream context,
+            # so put the caller's stream back rather than leaking it into later tests.
+            torch.cuda.set_stream(entry_stream)
+
         self.assertEqual(len(get_kernel_annotations()), 0)
 
     def test_resolve_without_scopes_is_noop(self):
@@ -390,8 +431,6 @@ class TestMarkKernels(TestCase):
 
     def test_enable_annotations_kwarg(self):
         """enable_annotations=True on torch.cuda.graph records and auto-resolves."""
-        clear_kernel_annotations()
-
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
@@ -403,8 +442,6 @@ class TestMarkKernels(TestCase):
 
     def test_enable_annotations_does_not_clear(self):
         """Annotations from a previous graph survive a second capture."""
-        clear_kernel_annotations()
-
         graph1 = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
 
@@ -425,8 +462,6 @@ class TestMarkKernels(TestCase):
     def test_enable_annotations_remaps_to_exec_graph(self):
         """enable_annotations=True must remap toolsIds to the exec graph ID."""
         from cuda.bindings import runtime as cuda_runtime
-
-        clear_kernel_annotations()
 
         graph = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda")
@@ -588,7 +623,6 @@ class TestMarkKernels(TestCase):
         deferred until the graph is instantiated -- whether that happens via an
         explicit instantiate() or implicitly on the first replay().
         """
-        clear_kernel_annotations()
         graph = torch.cuda.CUDAGraph(keep_graph=True)
         x = torch.randn(8, device="cuda")
 
@@ -615,7 +649,6 @@ class TestMarkKernels(TestCase):
         be rekeyed from the previous exec id to the new one on re-instantiation,
         while a plain replay() (no new exec graph) leaves them unchanged.
         """
-        clear_kernel_annotations()
         graph = torch.cuda.CUDAGraph(keep_graph=True)
         x = torch.randn(8, device="cuda")
 
@@ -847,7 +880,7 @@ class TestMarkKernels(TestCase):
         appending an unmarked op must not change the scope's tag counts."""
         counts = {}
         for with_unmarked in (False, True):
-            clear_kernel_annotations()
+            _reset_kernel_annotations()
             graph = torch.cuda.CUDAGraph()
             x = torch.randn(8, device="cuda", requires_grad=True)
 
@@ -868,16 +901,16 @@ class TestMarkKernels(TestCase):
         self.assertGreaterEqual(bwd, 1)
 
     def test_backward_clear_then_retained_backward(self):
-        """clear_kernel_annotations revokes recording from scopes opened
-        before the clear: hooks on a retained graph become inert, so a
-        backward captured after the clear records nothing."""
+        """A reset revokes the backward brackets of scopes opened before it:
+        hooks on a retained graph become inert, so a backward captured after
+        the reset records nothing."""
         graph_fwd = torch.cuda.CUDAGraph()
         x = torch.randn(8, device="cuda", requires_grad=True)
         with torch.cuda.graph(graph_fwd, enable_annotations=True):
             with mark_kernels("scope"):
                 y = (x * 2).sin()
 
-        clear_kernel_annotations()
+        _reset_kernel_annotations()
         self.assertEqual(len(get_kernel_annotations()), 0)
 
         graph_bwd = torch.cuda.CUDAGraph()
@@ -896,7 +929,7 @@ class TestMarkKernels(TestCase):
             with mark_kernels("old"):
                 _ = (x * 2).sin()
 
-        clear_kernel_annotations()
+        _reset_kernel_annotations()
 
         graph2 = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph2, enable_annotations=True):
@@ -913,7 +946,7 @@ class TestMarkKernels(TestCase):
         autograd.grad run (which has no AccumulateGrad) of the same graph."""
         bwd_counts = {}
         for mode in ("grad", "backward"):
-            clear_kernel_annotations()
+            _reset_kernel_annotations()
             graph = torch.cuda.CUDAGraph()
             x = torch.randn(8, device="cuda", requires_grad=True)
             x.grad = torch.zeros_like(x)
@@ -940,7 +973,7 @@ class TestMarkKernels(TestCase):
         region's counts match the single-consumer baseline."""
         counts = {}
         for consumers in (1, 2):
-            clear_kernel_annotations()
+            _reset_kernel_annotations()
             graph = torch.cuda.CUDAGraph()
             x = torch.randn(8, device="cuda", requires_grad=True)
 
@@ -1690,17 +1723,17 @@ class TestRemoveKernelAnnotations(TestCase):
     def _tools_id(graph_id, node_id):
         return (graph_id << 32) | node_id
 
-    def tearDown(self):
+    def setUp(self):
         import torch.cuda._graph_annotations as ga
 
-        ga.clear_kernel_annotations()
-        super().tearDown()
+        super().setUp()
+        ga._reset_kernel_annotations()
+        self.addCleanup(ga._reset_kernel_annotations)
 
     def test_removes_only_requested_exec_id(self):
         import torch.cuda._graph_annotations as ga
 
         exec_a, exec_b = 1, 2
-        ga.clear_kernel_annotations()
         ga.record_node_annotation(self._tools_id(exec_a, 10), {"name": "a"})
         ga.record_node_annotation(self._tools_id(exec_b, 10), {"name": "b"})
 
@@ -1714,7 +1747,6 @@ class TestRemoveKernelAnnotations(TestCase):
     def test_missing_and_empty_ids_are_noops(self):
         import torch.cuda._graph_annotations as ga
 
-        ga.clear_kernel_annotations()
         ga.record_node_annotation(self._tools_id(2, 10), {"name": "b"})
         ga.remove_kernel_annotations([])  # empty: no-op
         ga.remove_kernel_annotations([99])  # unknown exec id: no-op
@@ -1726,16 +1758,16 @@ class TestRemoveKernelAnnotations(TestCase):
 # Pure registry logic, no CUDA needed: the store keeps one merged annotation per node,
 # which the public mapping wraps in a one-element list.
 class TestAnnotationStore(TestCase):
-    def tearDown(self):
+    def setUp(self):
         import torch.cuda._graph_annotations as ga
 
-        ga.clear_kernel_annotations()
-        super().tearDown()
+        super().setUp()
+        ga._reset_kernel_annotations()
+        self.addCleanup(ga._reset_kernel_annotations)
 
     def test_writes_to_one_node_merge_first_wins(self):
         import torch.cuda._graph_annotations as ga
 
-        ga.clear_kernel_annotations()
         # Scopes reach a node innermost first, so the first write keeps the shared keys.
         ga.record_node_annotation(7, {"name": "inner", "only_inner": 1})
         ga.record_node_annotation(7, {"name": "outer", "only_outer": 2})
@@ -1746,7 +1778,6 @@ class TestAnnotationStore(TestCase):
     def test_view_is_live_and_read_only(self):
         import torch.cuda._graph_annotations as ga
 
-        ga.clear_kernel_annotations()
         view = ga.get_kernel_annotations()
         self.assertEqual(len(view), 0)
         ga.record_node_annotation(7, {"name": "a"})
@@ -1943,8 +1974,8 @@ class TestCuptiAnnotationBackend(TestCase):
     rather than by walking the capture graph's dependent edges."""
 
     def setUp(self):
-        clear_kernel_annotations()
-        self.addCleanup(clear_kernel_annotations)
+        _reset_kernel_annotations()
+        self.addCleanup(_reset_kernel_annotations)
         # Attributing a node needs the mark_kernels scope open on the creating thread.
         ctx = torch.autograd.grad_mode.set_multithreading_enabled(False)
         ctx.__enter__()
@@ -1991,7 +2022,7 @@ class TestCuptiAnnotationBackend(TestCase):
 
         by_backend = {}
         for backend in ("edge_walk", "cupti"):
-            clear_kernel_annotations()
+            _reset_kernel_annotations()
             x = torch.randn(64, 64, device="cuda", requires_grad=True)
             warm(x)
             g = torch.cuda.CUDAGraph()
@@ -2029,7 +2060,7 @@ class TestCuptiAnnotationBackend(TestCase):
         # even though work inside it is captured. CUPTI reports each node as it is created,
         # so it is unaffected.
         def run(backend):
-            clear_kernel_annotations()
+            _reset_kernel_annotations()
             x = self._warm(torch.randn(64, 64, device="cuda"))
             g = torch.cuda.CUDAGraph()
             side = torch.cuda.Stream()
@@ -2149,7 +2180,7 @@ class TestCuptiAnnotationBackend(TestCase):
                     x = x + 1
                     raise RuntimeError("boom")
 
-        clear_kernel_annotations()
+        _reset_kernel_annotations()
         g2 = torch.cuda.CUDAGraph()
         y = self._warm(torch.randn(64, 64, device="cuda"))
         with torch.cuda.graph(

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -533,13 +533,6 @@ def _exit_region(prev: dict[str, Any] | None) -> None:
 # other metadata user can collide with it.
 _HOOKED_KEY: Any = object()
 
-# Bumped by _reset_kernel_annotations. Node hooks record only while the
-# generation they were created under is current, so a reset revokes the
-# backward brackets of scopes opened before it (the hooks stay on the graph
-# but become inert) without mutating live autograd graphs. Forward recording
-# is not versioned: a scope still open across a reset registers on exit.
-_annotation_generation: int = 0
-
 
 class _KernelScope(NamedTuple):
     """Capture-frontier snapshot taken at scope entry, consumed at scope exit."""
@@ -649,7 +642,7 @@ class _BracketState(threading.local):
 _SKIPPED: Any = object()
 
 
-def _freeze_region_hook(node: Any, generation: int) -> None:
+def _freeze_region_hook(node: Any) -> None:
     """Node creation hook: freeze the current region into ``node``'s bracket.
 
     Reads the region TLS slot and, if a region is open, installs the node's
@@ -674,10 +667,10 @@ def _freeze_region_hook(node: Any, generation: int) -> None:
     if frozen is None:
         return
     node.metadata[_HOOKED_KEY] = True
-    _attach_backward_hooks(node, frozen, generation)
+    _attach_backward_hooks(node, frozen)
 
 
-def _attach_backward_hooks(node: Any, frozen: dict[str, Any], generation: int) -> None:
+def _attach_backward_hooks(node: Any, frozen: dict[str, Any]) -> None:
     """Register one pre/post hook pair bracketing ``node``'s backward execution.
 
     ``frozen`` is the region that was current when the node was created:
@@ -709,19 +702,14 @@ def _attach_backward_hooks(node: Any, frozen: dict[str, Any], generation: int) -
     ambient-annotation entry the CUPTI path publishes is module-global and so
     is not restored that way; it is dropped on next read instead (see
     :data:`_active_scopes`).
-
-    ``generation`` is the annotation generation the owning scope was opened
-    under; the bracket only records (and only propagates to created nodes)
-    while it is current, so ``clear_kernel_annotations`` makes stale hooks
-    inert.
     """
     state = _BracketState()
 
     def creation_hook(child: Any) -> None:
-        _freeze_region_hook(child, generation)
+        _freeze_region_hook(child)
 
     def prehook(_grad_outputs: Any) -> None:
-        if generation != _annotation_generation or _is_tools_id_unavailable():
+        if _is_tools_id_unavailable():
             state.stack.append(_SKIPPED)
             return
         # Re-establish ownership even when this backward is not itself
@@ -778,10 +766,9 @@ def _annotation_region(annotation: dict[str, Any], backward: bool):
     for nodes hooked by a nested ``backward=True`` scope (or by an executing hooked node)
     to freeze this annotation too.
     """
-    generation = _annotation_generation
 
     def creation_hook(node: Any) -> None:
-        _freeze_region_hook(node, generation)
+        _freeze_region_hook(node)
 
     prev = _enter_region({**(_current_region() or {}), **annotation})
     try:
@@ -1104,15 +1091,15 @@ def get_kernel_annotations() -> Mapping[int, list[Any]]:
 
 
 def _reset_kernel_annotations() -> None:
-    """Wipe the registry and revoke the backward brackets of every scope opened so far.
+    """Empty the annotation registry.
 
-    The implementation behind the deprecated :func:`clear_kernel_annotations`, and what
-    tests use to isolate themselves without tripping its deprecation warning. Not a
-    public API."""
-    global _annotation_generation
+    Backward brackets already attached to live autograd nodes are NOT revoked -- they
+    cannot be detached, and they go on recording into the emptied registry. The
+    implementation behind the deprecated :func:`clear_kernel_annotations`, and what tests
+    use to isolate themselves without tripping its deprecation warning. Not a public
+    API."""
     _kernel_annotations.clear()
     _pending_scopes.clear()
-    _annotation_generation += 1
 
 
 @deprecated(
@@ -1134,11 +1121,12 @@ def clear_kernel_annotations() -> None:
         replayed for the whole run -- a global wipe instead discards annotations for
         graphs that are still live and still being joined against.
 
-    Forgets everything recorded so far, and makes the backward brackets of scopes
-    opened before the clear inert: hooks :func:`mark_kernels` attached to existing
-    autograd nodes stay on the graph but stop recording. Note this does not reach an
-    enclosing forward scope -- one still open across the clear goes on recording its
-    own kernels, because the pending scope is only registered when it exits.
+    Forgets everything recorded so far. It does not stop anything from recording:
+    the backward hooks :func:`mark_kernels` attached to live autograd nodes cannot be
+    detached and go on writing into the emptied registry, and a forward scope open
+    across the clear registers on exit as usual. In particular this breaks backward
+    projection across a forward/backward capture pair -- the forward graph's entries
+    are gone and its scope no longer names the backward graph's kernels.
 
     .. warning::
         This API is in prototype and may change in future releases.

--- a/torch/cuda/_graph_annotations.py
+++ b/torch/cuda/_graph_annotations.py
@@ -50,6 +50,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from logging import getLogger
 from typing import Any, NamedTuple, TYPE_CHECKING, TypeAlias
+from typing_extensions import deprecated
 
 
 if TYPE_CHECKING:
@@ -532,10 +533,11 @@ def _exit_region(prev: dict[str, Any] | None) -> None:
 # other metadata user can collide with it.
 _HOOKED_KEY: Any = object()
 
-# Bumped by clear_kernel_annotations. Node hooks record only while the
-# generation they were created under is current, so clearing revokes
-# recording from every scope opened before the clear (the hooks stay on
-# the graph but become inert) without mutating live autograd graphs.
+# Bumped by _reset_kernel_annotations. Node hooks record only while the
+# generation they were created under is current, so a reset revokes the
+# backward brackets of scopes opened before it (the hooks stay on the graph
+# but become inert) without mutating live autograd graphs. Forward recording
+# is not versioned: a scope still open across a reset registers on exit.
 _annotation_generation: int = 0
 
 
@@ -943,6 +945,25 @@ def resolve_pending_annotations() -> None:
         _pending_scopes.clear()
 
 
+def discard_capture_annotations(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
+    """Drop what this capture recorded, for a capture that never reached an exec graph.
+
+    ``resolve_pending_annotations`` runs before ``capture_end`` because the rekey in
+    ``instantiate()`` consumes what it writes, so entries land keyed by the capture
+    graph's id. If ``capture_end`` then raises, that rekey never happens and the entries
+    keep an id no exec graph will ever hold: ``remove_kernel_annotations`` matches exec
+    ids, so the graph-destroy path cannot reach them and they last for the life of the
+    process. Only called on that error path. Not a public API."""
+    _pending_scopes.clear()
+    capture_graph_id = torch_cuda_graph._capture_graph_id
+    # A remap already happened (keep_graph=False instantiates inside capture_end), so the
+    # entries are on a real exec id and are the graph's to purge on destroy, not ours.
+    if capture_graph_id is None or torch_cuda_graph._remapped_exec_id is not None:
+        return
+    for key in [k for k in _kernel_annotations if k >> 32 == capture_graph_id]:
+        del _kernel_annotations[key]
+
+
 def remap_to_exec_graph(torch_cuda_graph: torch.cuda.CUDAGraph) -> None:
     """Remap annotation keys from capture graph ID to exec graph ID.
 
@@ -1082,28 +1103,47 @@ def get_kernel_annotations() -> Mapping[int, list[Any]]:
     return _annotations_view
 
 
+def _reset_kernel_annotations() -> None:
+    """Wipe the registry and revoke the backward brackets of every scope opened so far.
+
+    The implementation behind the deprecated :func:`clear_kernel_annotations`, and what
+    tests use to isolate themselves without tripping its deprecation warning. Not a
+    public API."""
+    global _annotation_generation
+    _kernel_annotations.clear()
+    _pending_scopes.clear()
+    _annotation_generation += 1
+
+
+@deprecated(
+    "`torch.cuda.graph_annotations.clear_kernel_annotations` is deprecated. The registry "
+    "bounds itself: annotations are rekeyed to the exec graph on instantiate and dropped "
+    "when that graph is destroyed, so a global wipe is not needed and discards annotations "
+    "for graphs that are still live.",
+    category=FutureWarning,
+)
 def clear_kernel_annotations() -> None:
     r"""clear_kernel_annotations() -> None
 
     Clear all recorded kernel annotations.
 
-    The annotation registry is process-global and accumulates across
-    captures; long-running workloads that capture many graphs should clear
-    it once recorded annotations have been consumed (e.g. after saving
-    them alongside a profiler trace).
+    .. deprecated:: 2.15
+        The registry is self-bounding, so nothing needs to call this. Annotations are
+        rekeyed to the exec graph id on instantiation and dropped when that graph is
+        destroyed; in a long-running workload -- where graphs are captured once and
+        replayed for the whole run -- a global wipe instead discards annotations for
+        graphs that are still live and still being joined against.
 
-    Clearing forgets everything recorded so far and revokes recording from
-    every scope opened before the clear: backward hooks that
-    :func:`mark_kernels` attached to existing autograd nodes stay on the
-    graph but become inert. Scopes opened after the clear record normally.
+    Forgets everything recorded so far, and makes the backward brackets of scopes
+    opened before the clear inert: hooks :func:`mark_kernels` attached to existing
+    autograd nodes stay on the graph but stop recording. Note this does not reach an
+    enclosing forward scope -- one still open across the clear goes on recording its
+    own kernels, because the pending scope is only registered when it exits.
 
     .. warning::
         This API is in prototype and may change in future releases.
     """
-    global _annotation_generation
-    _kernel_annotations.clear()
-    _pending_scopes.clear()
-    _annotation_generation += 1
+    _reset_kernel_annotations()
 
 
 def remove_kernel_annotations(exec_graph_ids: Iterable[int]) -> None:

--- a/torch/cuda/graphs.py
+++ b/torch/cuda/graphs.py
@@ -421,6 +421,13 @@ class CUDAGraph(_CUDAGraph):
         is live (via :meth:`raw_cuda_graph`) for both ``keep_graph`` modes. Hooks
         fire in registration order. Returns a handle whose ``remove()``
         deregisters the hook.
+
+        These hooks are best-effort: they do not run if ending the capture itself
+        fails (a mid-capture error typically leaves a forked stream unjoined, so
+        ``cudaStreamEndCapture`` raises), and a hook that raises prevents the ones
+        registered after it from running. Anything that must happen exactly once
+        per capture -- disarming a callback, releasing a subscription -- needs its
+        own cleanup on the capture's error path rather than relying on this hook.
         """
         from torch.utils.hooks import RemovableHandle
 
@@ -1293,6 +1300,7 @@ class graph:
         from torch.cuda import _graph_node_callbacks
         from torch.cuda._graph_annotations import (
             _set_annotations_enabled,
+            discard_capture_annotations,
             resolve_pending_annotations,
         )
 
@@ -1304,10 +1312,18 @@ class graph:
             if self._enable_annotations:
                 resolve_pending_annotations()
 
-            # capture_end stamps the capture id and, for keep_graph=False,
-            # instantiates (which remaps annotations to the exec id). For
+            # For keep_graph=False capture_end instantiates, which remaps annotations
+            # from the capture id (stamped back at capture_begin) to the exec id. For
             # keep_graph=True the remap is owned by the later instantiate()/replay().
-            self.cuda_graph.capture_end()
+            try:
+                self.cuda_graph.capture_end()
+            except BaseException:
+                # No exec graph, so the resolve above left entries keyed by the capture id
+                # that nothing can reach later. Scoped to capture_end alone: once it
+                # returns the capture is usable and its annotations are worth keeping.
+                if self._enable_annotations:
+                    discard_capture_annotations(self.cuda_graph)
+                raise
             self.stream_ctx.__exit__(*args)
         finally:
             # Annotation recording is capture-scoped; clear it unconditionally. disarm() is


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195398
* #195397
* #194854

Three findings from integrating the annotation store into a large trainer.

A capture that completes a mark_kernels scope and then fails in capture_end leaked its
annotations for the life of the process. resolve_pending_annotations has to run before
capture_end, because the rekey inside instantiate() is what consumes what it writes, so
its entries land keyed by the capture graph's id and only instantiate() rewrites them to
an exec id. When capture_end raises there is no exec graph and no rewrite, and
remove_kernel_annotations (the graph-destroy path) matches on exec ids, so nothing could
reach them again. __exit__ now purges that capture's entries when capture_end raises.
The purge is scoped to capture_end alone rather than the whole try block -- once it
returns the capture is usable and its annotations are worth keeping -- and is guarded on
the graph not having been remapped already, since keep_graph=False instantiates inside
capture_end.

An earlier writeup of this suggested moving the resolve into capture_end, after the
capture-id stamp. That no longer applies, and the reason is what makes the simpler fix
work: the stamp now happens at capture_begin, so graph._capture_graph_id is already set
when capture_end fails and we know exactly which entries are ours to drop.

clear_kernel_annotations is deprecated rather than deleted. It has no caller in torch
outside tests, and its docstring recommended clearing "once recorded annotations have
been consumed (e.g. after saving them alongside a profiler trace)" -- the
pickle-alongside-trace flow that inline trace export retires. For a long-running trainer
that advice is actively harmful: graphs are captured once and replayed for the whole run,
so a global wipe discards annotations for graphs that are still live and still being
joined against, and growth is already bounded by the remap on instantiate plus
remove_kernel_annotations on destroy. The docstring separately claimed clearing "revokes
recording from every scope opened before the clear", which is not true -- only backward
brackets are versioned by the generation counter, so a forward scope open across a clear
registers on exit as usual. Both claims are corrected, the second now has a test, and
tests call a new private _reset_kernel_annotations for isolation so the suite does not
trip the warning; the one test that is about the public entry point asserts it.

Cleaning up those call sites also removed the redundant ones: nine tests opened with a
reset that their class fixture already does, and two registry-only classes reset in
tearDown alone, which is why each of their tests began with one -- those now use setUp
plus addCleanup. The resets kept are the ones that do work: between iterations of a
loop, or mid-test where the reset is the thing under test.

Finally, register_capture_end_hook documents that capture-end hooks are best-effort:
skipped entirely when cudaStreamEndCapture raises, and truncated when an earlier hook
raises. A consumer using one for teardown needs its own fallback on the error path.

Test Plan:

```
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/test_cuda_graph_utils.py
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/profiler/test_profiler.py TestPythonChromeTraceExport TestChromeTraceInlineAnnotations
LD_LIBRARY_PATH=/usr/local/cuda-13.2/compat python test/profiler/test_cupti_node_timer.py
```

115, 16 and 8 tests pass. test_failed_capture_end_discards_annotations is the regression
test for the leak: reverting just the __exit__ change makes it fail. test_public_bindings
has one failure in this environment that predates the change and is unrelated
(torch.distributed.debug._debug_handlers needs the `tabulate` package).

Authored with assistance from Claude Code.