### PR TITLE
[xpu][fix]Relax fp16 grad tolerance for combinations on XPU

### DIFF
--- a/test/inductor/test_torchinductor_opinfo.py
+++ b/test/inductor/test_torchinductor_opinfo.py
@@ -599,6 +599,10 @@ inductor_override_kwargs["xpu"] = {
     ("cross", f16): {"reference_in_float": True},
     ("addr", f16): {"reference_in_float": True},
     ("baddbmm", f16): {"atol": 2e-3, "rtol": 0.002},  # decomp affects accuracy
+    ("combinations", f16): {
+        "grad_atol": 2e-3,
+        "grad_rtol": 0.01,
+    },  # inductor does accum in fp16
     ("angle", f64): {"reference_in_float": True},
     ("asin", f16): {"reference_in_float": True},
     ("asin", f32): {"reference_in_float": True, "atol": 1e-4, "rtol": 1e-4},


### PR DESCRIPTION
## Motivation

pytorch/pytorch#189102 bumped the gradient tolerances for
`test_comprehensive_combinations_cuda_float16` after #186595 / #189305
reimplemented `torch.combinations` on top of `index_put`, whose fp16 backward
Inductor accumulates in fp16. That PR only added the override to
`inductor_override_kwargs["cuda"]`; `inductor_override_kwargs["xpu"]` is a
separate dict and never got the equivalent entry, leaving XPU on the default
fp16 gradient tolerance (`atol=1e-5, rtol=1e-3`), which is too tight for the
fp16 accumulation rounding. Result: #195071
(`test_comprehensive_combinations_xpu_float16`) was disabled on 2026-08-27.

## Root cause on the failing sample

Sample 17: `input=(4,) fp16, r=4, with_replacement=True` -> output `(35, 4)`.
Each of the 4 inputs is copied into 35 output slots, so its gradient is the sum
of 35 fp16 contributions.

Forward is bit-identical between eager and Inductor; only the backward differs.
Inductor lowers the `index_put(accumulate=True)` backward to a single fp16
atomic scatter (`triton_poi_fused_index_put_new_zeros_1`):

```python
tmp6 = tl.load(in_ptr1 + (x0), xmask).to(tl.float32)
tl.atomic_add(out_ptr0 + (tl.broadcast_to(tmp4, [XBLOCK])), tmp6, xmask, sem='relaxed')
```

`out_ptr0` is `*fp16`, so the 35 additions per slot round to fp16 on every step,
in hardware-scheduling order. The XPU aten `index_put` accumulates in higher
precision and rounds once:

```
# accumulate 100 x 0.0002 into an fp16 slot initialised to 1.0 (exact = 1.02)
eager    index_put_(accumulate=True) -> 1.01953125
inductor same op                     -> 1.0          (== naive fp16 read-add-write)
```

Against an fp64 reference on the failing sample:

```
grad(input):
  eager    vs ref-fp64: max_rel = 3.65e-04
  inductor vs ref-fp64: max_rel = 3.99e-03
  inductor vs eager   : max_rel = 1.6e-03 .. 4.9e-03 across runs (>> default rtol=1e-3)
```

The run-to-run spread comes from the nondeterministic atomic order: the same
input produced 14 distinct fp16 results in 20 Inductor runs, vs 1 for eager.
This is intrinsic fp16 accumulation rounding, not a correctness bug on either
side, and matches the situation upstream addressed on CUDA in #189102.

## Fix

Add the same `(combinations, f16)` override that #189102 added for CUDA to
`inductor_override_kwargs["xpu"]`. Observed max abs diff is 1.22e-03 against an
allowance of `2e-3 + 0.01 * 0.5 ~= 7e-3`, i.e. about 5.7x headroom.

## Test plan

Nightly wheel `torch==2.15.0.dev20260830+xpu`, triton-xpu 3.8.0, on Intel Arc
B390. Run from the pytorch checkout root:

```
PYTORCH_OPINFO_SAMPLE_INPUT_INDEX=17 TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
    python test/inductor/test_torchinductor_opinfo.py \
    TestInductorOpInfoXPU.test_comprehensive_combinations_xpu_float16
```
```
# before: FAILED  Tensor-likes are not close! 1/4 mismatched,
#                 rel 1.066e-03 > 1e-03 allowed
# after:  OK
```

All samples, three consecutive runs:

```
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
    python test/inductor/test_torchinductor_opinfo.py \
    TestInductorOpInfoXPU.test_comprehensive_combinations_xpu_float16
```
```
# OK / OK / OK
```

All dtypes, cpu and xpu:

```
TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 \
    python test/inductor/test_torchinductor_opinfo.py \
    -k test_comprehensive_combinations -v
```
```
# Ran 14 tests    OK (skipped=2)
```

Fixes #195071

_Note: authored with AI assistance._


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo