### PR TITLE
Refactor scaled matmul meta validation

### DIFF
--- a/aten/src/ATen/native/ScaledBlas.cpp
+++ b/aten/src/ATen/native/ScaledBlas.cpp
@@ -30,6 +30,74 @@ namespace at::meta {
 
 namespace scaled_blas = at::native::scaled;
 
+namespace {
+
+void validate_scaled_mm_meta_inputs(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const at::ITensorListRef& scale_a,
+    at::IntArrayRef recipe_a,
+    at::IntArrayRef swizzle_a,
+    const at::ITensorListRef& scale_b,
+    at::IntArrayRef recipe_b,
+    at::IntArrayRef swizzle_b,
+    at::IntArrayRef contraction_dim) {
+  TORCH_CHECK_VALUE(mat_a.dim() == 2, "mat_a must be a matrix");
+  TORCH_CHECK_VALUE(mat_b.dim() == 2, "mat_b must be a matrix");
+
+  if (!contraction_dim.empty()) {
+    TORCH_CHECK_VALUE(
+        contraction_dim.size() == 2,
+        "contraction_dim must have exactly 2 elements");
+    auto mat_a_dim = contraction_dim[0];
+    auto mat_b_dim = contraction_dim[1];
+    TORCH_CHECK_VALUE(
+        mat_a.sym_size(mat_a_dim) == mat_b.sym_size(mat_b_dim),
+        "mat_a and mat_b shapes cannot be multiplied (",
+        mat_a.sym_size(0),
+        "x",
+        mat_a.sym_size(1),
+        " and ",
+        mat_b.sym_size(0),
+        "x",
+        mat_b.sym_size(1),
+        ") with contraction dims mat_a: ",
+        mat_a_dim,
+        ", mat_b: ",
+        mat_b_dim);
+  } else {
+    TORCH_CHECK_VALUE(
+        mat_a.sym_size(1) == mat_b.sym_size(0),
+        "mat_a and mat_b shapes cannot be multiplied (",
+        mat_a.sym_size(0),
+        "x",
+        mat_a.sym_size(1),
+        " and ",
+        mat_b.sym_size(0),
+        "x",
+        mat_b.sym_size(1),
+        ")");
+  }
+
+  std::vector<Tensor> scale_a_vec(scale_a.begin(), scale_a.end());
+  std::vector<Tensor> scale_b_vec(scale_b.begin(), scale_b.end());
+  auto recipe_a_enum = scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_a);
+  auto recipe_b_enum = scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_b);
+  auto swizzle_a_enum = scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_a);
+  auto swizzle_b_enum = scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_b);
+  scaled_blas::validate_scaled_mm_v2_inputs(
+      mat_a,
+      mat_b,
+      scale_a_vec,
+      recipe_a_enum,
+      swizzle_a_enum,
+      scale_b_vec,
+      recipe_b_enum,
+      swizzle_b_enum);
+}
+
+} // namespace
+
 // V2: Computes matrix multiply + bias while applying scaling to input and output matrices.
 // Scales are only applicable when matrices are of Float8 / Float4 type and assumed to be 1.0
 // by default. Shape inference + full input validation runs here in eager (before
@@ -64,39 +132,20 @@ TORCH_META_FUNC(_scaled_mm_v2)(
     std::optional<c10::ScalarType> out_dtype,
     at::IntArrayRef contraction_dim,
     bool use_fast_accum) {
-  TORCH_CHECK_VALUE(self.dim() == 2, "mat_a must be a matrix");
-  TORCH_CHECK_VALUE(mat2.dim() == 2, "mat_b must be a matrix");
-
-  if (!contraction_dim.empty()) {
-    TORCH_CHECK_VALUE(contraction_dim.size() == 2, "contraction_dim must have exactly 2 elements");
-    auto mat_a_dim = contraction_dim[0];
-    auto mat_b_dim = contraction_dim[1];
-    TORCH_CHECK_VALUE(
-        self.sym_size(mat_a_dim) == mat2.sym_size(mat_b_dim), "mat_a and mat_b shapes cannot be multiplied (",
-        self.sym_size(0), "x", self.sym_size(1), " and ", mat2.sym_size(0), "x", mat2.sym_size(1), ") ",
-        "with contraction dims mat_a: ", mat_a_dim, ", mat_b: ", mat_b_dim);
-  } else {
-    TORCH_CHECK_VALUE(
-        self.sym_size(1) == mat2.sym_size(0), "mat_a and mat_b shapes cannot be multiplied (",
-        self.sym_size(0), "x", self.sym_size(1), " and ", mat2.sym_size(0), "x", mat2.sym_size(1), ")");
-  }
+  validate_scaled_mm_meta_inputs(
+      self,
+      mat2,
+      scale_a,
+      recipe_a,
+      swizzle_a,
+      scale_b,
+      recipe_b,
+      swizzle_b,
+      contraction_dim);
 
   TORCH_CHECK_VALUE(
       !bias.has_value() || bias->sym_numel() == mat2.sym_size(1),
       "Bias must be size ", mat2.sym_size(1), " but got ", bias->sym_numel());
-
-  // Layout / per-recipe scale-shape validation. Materialize the lists so the
-  // helper sees ArrayRef<Tensor> rather than ITensorListRef.
-  std::vector<Tensor> scale_a_vec(scale_a.begin(), scale_a.end());
-  std::vector<Tensor> scale_b_vec(scale_b.begin(), scale_b.end());
-  auto recipe_a_enum = scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_a);
-  auto recipe_b_enum = scaled_blas::convert_int_to_enum<at::blas::ScalingType>(recipe_b);
-  auto swizzle_a_enum = scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_a);
-  auto swizzle_b_enum = scaled_blas::convert_int_to_enum<at::blas::SwizzleType>(swizzle_b);
-  scaled_blas::validate_scaled_mm_v2_inputs(
-      self, mat2,
-      scale_a_vec, recipe_a_enum, swizzle_a_enum,
-      scale_b_vec, recipe_b_enum, swizzle_b_enum);
 
   const auto out_dtype_ = out_dtype.value_or(self.scalar_type());
   set_output_raw_strided(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

## Human Note

> Keep the behavior-preserving validation refactor separate so the scaled-addmm feature is easier to review.

## Agent note

This extracts the common scaled-matmul shape and recipe validation from the structured meta implementation without changing its contract. The following stack commit reuses this boundary for scaled addmm.

Authored with assistance from an AI coding assistant.

## Test Plan

```bash
bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260829-pytorch-adhoc-7b52f7/pytorch
gpu-run --timeout 60 auto -- timeout --signal=TERM --kill-after=5s 1800s ../.venv/bin/python test/test_scaled_matmul_cuda.py -v
spin quicklint
git diff --check
```

The scaled-matmul suite completed 1,900 tests successfully: 558 passed and 1,342 were skipped for unavailable hardware or backends.