### PR TITLE
Add scaled addmm functional and in-place APIs

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1858,14 +1858,18 @@ void scaled_gemm(
     int64_t result_ld,
     ScalarType result_dtype,
     bool use_fast_accum,
-    const std::optional<Tensor>& alpha) {
+    const std::optional<Tensor>& alpha,
+    const void* c_ptr,
+    float beta,
+    float alpha_multiplier,
+    const Tensor* device_beta) {
   // Note: see `cublasCommonArgs` for various non-intuitive manipulations
   // of input arguments to this function.
   const auto computeType = CUBLAS_COMPUTE_32F;
   const auto scaleType = CUDA_R_32F;
   // Note: alpha_val may change later depending on user-passed argument
-  float alpha_val = 1.0;
-  float beta_val = 0.0;
+  float alpha_val = alpha_multiplier;
+  float beta_val = beta;
 #ifndef USE_ROCM
   // Note: unused, but cublasLtMatmul requires a C pointer that is not result_ptr or nullptr
   const void* dummy_C_ptr = mat1_ptr;
@@ -1932,12 +1936,15 @@ void scaled_gemm(
 #endif // ifndef USE_ROCM
   CuBlasLtMatrixLayout Adesc(ScalarTypeToCudaDataType(mat1_dtype), m, k, mat1_ld, transa == 't');
   CuBlasLtMatrixLayout Bdesc(ScalarTypeToCudaDataType(mat2_dtype), k, n, mat2_ld, transb == 't');
+  TORCH_INTERNAL_ASSERT(c_ptr != nullptr || beta_val == 0.0f);
+  TORCH_INTERNAL_ASSERT(c_ptr == nullptr || bias_ptr == nullptr);
 #ifdef USE_ROCM
-  // Cdesc is unused, beta is 0. But hipblaslt needs this set to something reasonable.
-  CuBlasLtMatrixLayout Cdesc(ScalarTypeToCudaDataType(result_dtype), m, n, result_ld);
+  const auto c_desc_dtype = result_dtype;
 #else
-  CuBlasLtMatrixLayout Cdesc(ScalarTypeToCudaDataType(bias_dtype), m, n, result_ld);
-#endif // ifdef USE_ROCM
+  const auto c_desc_dtype = c_ptr == nullptr ? bias_dtype : result_dtype;
+#endif
+  CuBlasLtMatrixLayout Cdesc(
+      ScalarTypeToCudaDataType(c_desc_dtype), m, n, result_ld);
   CuBlasLtMatrixLayout Ddesc(ScalarTypeToCudaDataType(result_dtype), m, n, result_ld);
   if (bias_ptr) {
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_BIAS_POINTER, bias_ptr);
@@ -1945,22 +1952,33 @@ void scaled_gemm(
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, ScalarTypeToCudaDataType(bias_dtype));
   }
 
-  // Handle user-passed alpha
+  // Handle user-passed alpha and its optional device-side beta.
   const float* alpha_ptr = &alpha_val;
   const float* beta_ptr = &beta_val;
+  TORCH_INTERNAL_ASSERT(device_beta == nullptr || alpha.has_value());
 
   if (alpha.has_value()) {
     auto& a = alpha.value();
 
     // if device-tensor
     if (a.is_cuda()) {
+      TORCH_INTERNAL_ASSERT(alpha_multiplier == 1.0f);
       // Tell cublasLt we're using device-side pointers for alpha/beta
       auto pointer_mode = CUBLASLT_POINTER_MODE_DEVICE;
       computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_POINTER_MODE, pointer_mode);
       alpha_ptr = a.const_data_ptr<float>();
-      beta_ptr = at::cuda::detail::get_cublas_device_zero();
+      if (device_beta != nullptr) {
+        TORCH_INTERNAL_ASSERT(
+            device_beta->is_cuda() && device_beta->device() == a.device() &&
+            device_beta->numel() == 1 && device_beta->scalar_type() == kFloat);
+        beta_ptr = device_beta->const_data_ptr<float>();
+      } else {
+        TORCH_INTERNAL_ASSERT(beta_val == 0.0f);
+        beta_ptr = at::cuda::detail::get_cublas_device_zero();
+      }
     } else {
-      alpha_val = a.item<float>();
+      TORCH_INTERNAL_ASSERT(device_beta == nullptr);
+      alpha_val = a.item<float>() * alpha_multiplier;
     }
   }
     // For other data types, use the get_scale_mode function based on scaling type
@@ -1977,6 +1995,16 @@ void scaled_gemm(
   CuBlasLtMatmulPreference preference;
   auto ltworkspace = CublasLtWorkspace();
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, ltworkspace.size);
+#ifndef USE_ROCM
+  if (c_ptr != nullptr) {
+    preference.setAttribute(
+        CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_C_BYTES,
+        detail::getAlignment(reinterpret_cast<uintptr_t>(c_ptr)));
+    preference.setAttribute(
+        CUBLASLT_MATMUL_PREF_MIN_ALIGNMENT_D_BYTES,
+        detail::getAlignment(reinterpret_cast<uintptr_t>(result_ptr)));
+  }
+#endif
   cublasLtMatmulHeuristicResult_t heuristicResult = {};
   int returnedResult = 0;
   cublasLtHandle_t ltHandle = at::cuda::getCurrentCUDABlasLtHandle();
@@ -2050,9 +2078,9 @@ void scaled_gemm(
       Bdesc.descriptor(),
       beta_ptr,
 #ifdef USE_ROCM
-      result_ptr, // unused, since beta_val is 0, but hipblaslt can't handle nullptr
+      c_ptr == nullptr ? result_ptr : c_ptr,
 #else
-      dummy_C_ptr, // also unused, but cuBLAS can't use nullptr or result_ptr
+      c_ptr == nullptr ? dummy_C_ptr : c_ptr,
 #endif // ifdef USE_ROCM
       Cdesc.descriptor(),
       result_ptr,

--- a/aten/src/ATen/cuda/CUDABlas.h
+++ b/aten/src/ATen/cuda/CUDABlas.h
@@ -176,7 +176,12 @@ void scaled_gemm(
     int64_t result_ld,
     ScalarType result_dtype,
     bool use_fast_accum,
-    const std::optional<Tensor>& alpha);
+    const std::optional<Tensor>& alpha,
+    // C uses the result dtype and leading dimension. A nonzero beta requires C.
+    const void* c_ptr = nullptr,
+    float beta = 0.0f,
+    float alpha_multiplier = 1.0f,
+    const Tensor* device_beta = nullptr);
 
 void grouped_gemm(
       char transa,

--- a/aten/src/ATen/native/ScaledBlas.cpp
+++ b/aten/src/ATen/native/ScaledBlas.cpp
@@ -1,4 +1,5 @@
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <algorithm>
 #include <ATen/core/Tensor.h>
 #include <ATen/ExpandUtils.h>
 
@@ -17,6 +18,7 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
+#include <ATen/ops/_scaled_addmm_native.h>
 #include <ATen/ops/copy_native.h>
 #include <ATen/ops/empty.h>
 #include <ATen/ops/_scaled_mm_native.h>
@@ -153,6 +155,61 @@ TORCH_META_FUNC(_scaled_mm_v2)(
       {self.size(0), mat2.size(1)},
       {},
       self.options().dtype(out_dtype_));
+}
+
+TORCH_META_FUNC(_scaled_addmm)(
+    const Tensor& self,
+    const Tensor& mat1,
+    const Tensor& mat2,
+    const at::ITensorListRef& scale_a,
+    at::IntArrayRef recipe_a,
+    at::IntArrayRef swizzle_a,
+    const at::ITensorListRef& scale_b,
+    at::IntArrayRef recipe_b,
+    at::IntArrayRef swizzle_b,
+    at::IntArrayRef contraction_dim,
+    const Scalar& beta,
+    const Scalar& alpha,
+    bool use_fast_accum) {
+  TORCH_CHECK_VALUE(
+      !alpha.isComplex() && !beta.isComplex(),
+      "torch._scaled_addmm only supports real alpha and beta values");
+  TORCH_CHECK_VALUE(self.dim() == 2, "input must be a matrix");
+  validate_scaled_mm_meta_inputs(
+      mat1,
+      mat2,
+      scale_a,
+      recipe_a,
+      swizzle_a,
+      scale_b,
+      recipe_b,
+      swizzle_b,
+      contraction_dim);
+
+  TORCH_CHECK_VALUE(
+      self.sym_size(0) == mat1.sym_size(0) &&
+          self.sym_size(1) == mat2.sym_size(1),
+      "input must have shape (",
+      mat1.sym_size(0),
+      ", ",
+      mat2.sym_size(1),
+      "), but got ",
+      self.sym_sizes());
+  TORCH_CHECK_VALUE(
+      self.scalar_type() == kBFloat16 || self.scalar_type() == kHalf ||
+          self.scalar_type() == kFloat,
+      "input must have dtype BFloat16, Half, or Float, but got ",
+      self.scalar_type());
+  TORCH_CHECK_VALUE(
+      self.stride(1) == 1 &&
+          self.stride(0) == std::max<int64_t>(1, self.size(1)),
+      "input must have canonical contiguous row-major strides");
+
+  set_output_raw_strided(
+      0,
+      {mat1.size(0), mat2.size(1)},
+      {},
+      self.options());
 }
 
 // V2: Grouped scaled matrix multiply. Shape inference + output allocation runs

--- a/aten/src/ATen/native/cuda/ScaledBlas.cpp
+++ b/aten/src/ATen/native/cuda/ScaledBlas.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <c10/util/typeid.h>
 #include <c10/util/Exception.h>
@@ -8,6 +9,7 @@
 #include <ATen/core/Tensor.h>
 #include <ATen/Dispatch.h>
 #include <ATen/ExpandUtils.h>
+#include <ATen/MemoryOverlap.h>
 #include <ATen/OpMathType.h>
 #include <ATen/TensorUtils.h>
 #include <ATen/cuda/CUDABlas.h>
@@ -34,6 +36,7 @@
 #else
 #include <ATen/ops/_addmm_activation_native.h>
 #include <ATen/ops/_efficientzerotensor.h>
+#include <ATen/ops/_scaled_addmm_native.h>
 #include <ATen/ops/_scaled_mm_native.h>
 #include <ATen/ops/_scaled_mm_v2_native.h>
 #include <ATen/ops/abs.h>
@@ -49,6 +52,7 @@
 #include <ATen/ops/mul.h>
 #include <ATen/ops/relu.h>
 #include <ATen/ops/ones.h>
+#include <ATen/ops/scalar_tensor.h>
 #endif
 
 // forward declare
@@ -366,6 +370,12 @@ _tunable_scaled_gemm_rocm(
 #endif
 }
 
+struct ScaledGemmEpilogue {
+  std::optional<Tensor> accumulator;
+  float beta = 0.0f;
+  float alpha = 1.0f;
+};
+
 Tensor&
 _scaled_gemm(
           const Tensor& mat1, const Tensor& mat2,
@@ -374,8 +384,9 @@ _scaled_gemm(
           const std::optional<Tensor>& bias,
           const bool use_fast_accum,
           Tensor& out,
+          const ScaledGemmEpilogue& epilogue = {},
           const std::optional<Tensor>& scale_result = std::nullopt,
-          const std::optional<Tensor>& alpha = std::nullopt) {
+          const std::optional<Tensor>& device_alpha = std::nullopt) {
   cublasCommonArgs args(
       mat1,
       mat2,
@@ -390,6 +401,17 @@ _scaled_gemm(
   if (scaled_mm_arch_allowed(/*sm90_only=*/true, /*sm100_only=*/false)) {
     TORCH_CHECK(args.transa == 't' && args.transb == 'n', "Only multiplication of row-major and column-major matrices is supported by cuBLASLt");
   }
+  std::optional<Tensor> effective_accumulator = epilogue.accumulator;
+  // Some cuBLASLt algorithms skip the D write for distinct C/D when M=1.
+  if (effective_accumulator && mat1.size(0) == 1 &&
+      effective_accumulator->const_data_ptr() != out.const_data_ptr()) {
+    out.copy_(*effective_accumulator);
+    effective_accumulator = out;
+  }
+  TORCH_INTERNAL_ASSERT_DEBUG_ONLY(
+      !effective_accumulator ||
+          (effective_accumulator->stride(0) == args.result_ld &&
+           effective_accumulator->scalar_type() == out_dtype_));
 // ROCM enables the TunableOp path only
 // but can fallback to at::cuda::blas::scaled_gemm
 #ifdef USE_ROCM
@@ -417,6 +439,18 @@ _scaled_gemm(
       }
   }
   {
+      std::optional<Tensor> effective_device_alpha = device_alpha;
+      std::optional<Tensor> device_beta;
+      float alpha_multiplier = epilogue.alpha;
+      if (device_alpha && device_alpha->is_cuda()) {
+        if (alpha_multiplier != 1.0f) {
+          effective_device_alpha = device_alpha->mul(alpha_multiplier);
+        }
+        alpha_multiplier = 1.0f;
+        if (epilogue.beta != 0.0f) {
+          device_beta = at::scalar_tensor(epilogue.beta, device_alpha->options());
+        }
+      }
       at::cuda::blas::scaled_gemm(
           args.transa,
           args.transb,
@@ -442,7 +476,11 @@ _scaled_gemm(
           args.result_ld,
           out_dtype_,
           use_fast_accum,
-          alpha);
+          effective_device_alpha,
+          effective_accumulator ? effective_accumulator->const_data_ptr() : nullptr,
+          epilogue.beta,
+          alpha_multiplier,
+          device_beta ? &*device_beta : nullptr);
       return out;
   }
 }
@@ -457,7 +495,8 @@ _scaled_rowwise_rowwise(
           const std::optional<Tensor>& /*bias*/,
           const c10::ScalarType /*out_dtype*/,
           bool /*use_fast_accum*/,
-          Tensor& /*out*/);
+          Tensor& /*out*/,
+          const ScaledGemmEpilogue& /*epilogue*/ = {});
 
 } // namespace
 
@@ -662,7 +701,18 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
 #endif
   }
 
-  return _scaled_gemm(mat1, mat2, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out, scale_result);
+  return _scaled_gemm(
+      mat1,
+      mat2,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out,
+      {},
+      scale_result);
 }
 
 Tensor
@@ -705,7 +755,8 @@ _scaled_tensorwise_tensorwise(
           const std::optional<Tensor>& bias,
           const c10::ScalarType out_dtype,
           bool use_fast_accum,
-          Tensor& out) {
+          Tensor& out,
+          const ScaledGemmEpilogue& epilogue = {}) {
   // Restrictions:
   // A, B are FP8, scales are fp32
   //
@@ -717,11 +768,36 @@ _scaled_tensorwise_tensorwise(
   auto scaling_choice_a = ScalingType::TensorWise;
   auto scaling_choice_b = ScalingType::TensorWise;
 
-  _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out,
+      epilogue);
 
   return out;
 }
 
+
+bool rowwise_uses_cublas(
+    const Tensor& scale_a,
+    const Tensor& scale_b) {
+#ifndef USE_ROCM
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  // Blackwell cuBLAS only accepts tiled 1D factors, not 2D block scales.
+  return dprops->major >= 9 && CUBLAS_VERSION >= 120900 &&
+      cublasLtGetVersion() >= 120900 &&
+      (dprops->major < 10 ||
+       (scale_a.sizes().empty() && scale_b.sizes().empty()));
+#else
+  return true;
+#endif
+}
 
 Tensor&
 _scaled_rowwise_rowwise(
@@ -730,7 +806,8 @@ _scaled_rowwise_rowwise(
           const std::optional<Tensor>& bias,
           const c10::ScalarType out_dtype,
           bool use_fast_accum,
-          Tensor& out) {
+          Tensor& out,
+          const ScaledGemmEpilogue& epilogue) {
   // Restrictions:
   // A, B are FP8, scales are fp32, shape M/N for A/B
   TORCH_CHECK_VALUE(isFloat8Type(mat_a.scalar_type()) && isFloat8Type(mat_b.scalar_type()), "mat_a and mat_b must be fp8 types, got: ",
@@ -754,10 +831,7 @@ _scaled_rowwise_rowwise(
   // and only for compute capability 9.0+. In other cases we use CUTLASS.
 #ifndef USE_ROCM
   // We are doing row-wise scaling
-  auto dprops = at::cuda::getCurrentDeviceProperties();
-  if (((dprops->major < 9 || CUBLAS_VERSION < 120900 || cublasLtGetVersion() < 120900)
-      // cuBLAS only supports tiled 1D factor layout for 1D block scaling, no 2D block scales
-      ||  (dprops->major >= 10 && (!scale_a.sizes().empty() || !scale_b.sizes().empty())))) {
+  if (!rowwise_uses_cublas(scale_a, scale_b)) {
     TORCH_CHECK_VALUE(
         out.dtype() == kBFloat16 || out.dtype() == kHalf ||
             out.dtype() == kFloat,
@@ -787,7 +861,17 @@ _scaled_rowwise_rowwise(
        "hipblaslt rowwise _scaled_mm only supports BFloat16 output but got ", out.scalar_type());
 #endif
 
-  _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out,
+      epilogue);
 
   return out;
 }
@@ -817,7 +901,8 @@ _scaled_block1x128_block1x128(
           const std::optional<Tensor>& bias,
           const c10::ScalarType out_dtype,
           const bool use_fast_accum,
-          Tensor& out) {
+          Tensor& out,
+          const ScaledGemmEpilogue& epilogue = {}) {
 #ifndef USE_ROCM
   // Restrictions:
   // A, B are FP8, scales are fp32, shape K//128
@@ -876,7 +961,17 @@ _scaled_block1x128_block1x128(
   auto scaling_choice_a = ScalingType::BlockWise1x128;
   auto scaling_choice_b = ScalingType::BlockWise1x128;
 
-  _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out,
+      epilogue);
 
   return out;
 #else
@@ -894,7 +989,8 @@ _scaled_block128x128_block1x128(
           const std::optional<Tensor>& bias,
           const c10::ScalarType out_dtype,
           const bool use_fast_accum,
-          Tensor& out) {
+          Tensor& out,
+          const ScaledGemmEpilogue& epilogue = {}) {
 #ifndef USE_ROCM
   // Restrictions:
   _check_deepseek_support();
@@ -956,7 +1052,17 @@ _scaled_block128x128_block1x128(
   auto scaling_choice_a = ScalingType::BlockWise128x128;
   auto scaling_choice_b = ScalingType::BlockWise1x128;
 
-  _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out,
+      epilogue);
 
   return out;
 #else
@@ -974,7 +1080,8 @@ _scaled_block1x128_block128x128(
           const std::optional<Tensor>& bias,
           const c10::ScalarType out_dtype,
           const bool use_fast_accum,
-          Tensor& out) {
+          Tensor& out,
+          const ScaledGemmEpilogue& epilogue = {}) {
 #ifndef USE_ROCM
   // Restrictions:
   _check_deepseek_support();
@@ -1033,7 +1140,17 @@ _scaled_block1x128_block128x128(
   auto scaling_choice_a = ScalingType::BlockWise1x128;
   auto scaling_choice_b = ScalingType::BlockWise128x128;
 
-  _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, use_fast_accum, out);
+  _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      use_fast_accum,
+      out,
+      epilogue);
 
   return out;
 #else
@@ -1051,7 +1168,8 @@ _scaled_mxfp8_mxfp8(
           const Tensor& scale_b, const SwizzleType swizzle_b,
           const std::optional<Tensor>& bias,
           const c10::ScalarType out_dtype,
-          Tensor& out) {
+          Tensor& out,
+          const ScaledGemmEpilogue& epilogue = {}) {
   // Restrictions:
   // A, B are FP8, scales are e8m0, A: shape K//32, B: K, N//32
   // Scales must be swizzled
@@ -1094,12 +1212,32 @@ _scaled_mxfp8_mxfp8(
   TORCH_CHECK_VALUE(out.scalar_type() == ScalarType::BFloat16 ||
               out.scalar_type() == ScalarType::Half,
               "Block-wise scaling only supports BFloat16 or Half output types");
-  return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out);
+  return _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      false /* use_fast_accum */,
+      out,
+      epilogue);
 #else
     TORCH_CHECK_NOT_IMPLEMENTED(false, "Block-wise scaling for Float8_e8m0fnu requires ROCm 7.0 or later");
 #endif
 #else
-  return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out);
+  return _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      false /* use_fast_accum */,
+      out,
+      epilogue);
 #endif
 }
 
@@ -1207,7 +1345,8 @@ _scaled_nvfp4_nvfp4(
           const c10::ScalarType out_dtype,
           Tensor& out,
           const std::optional<Tensor>& global_scale_a = std::nullopt,
-          const std::optional<Tensor>& global_scale_b = std::nullopt) {
+          const std::optional<Tensor>& global_scale_b = std::nullopt,
+          const ScaledGemmEpilogue& epilogue = {}) {
 #ifndef USE_ROCM
   std::optional<Tensor> alpha = std::nullopt;
   // Note: "Or" here means that if only one scale is passed, we check for the other. Otherwise,
@@ -1241,7 +1380,19 @@ _scaled_nvfp4_nvfp4(
 
   auto scaling_choice_a = ScalingType::BlockWise1x16;
   auto scaling_choice_b = ScalingType::BlockWise1x16;
-  return _scaled_gemm(mat_a, mat_b, scale_a, scale_b, scaling_choice_a, scaling_choice_b, bias, false /* use_fast_accum */, out, std::nullopt, alpha);
+  return _scaled_gemm(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaling_choice_a,
+      scaling_choice_b,
+      bias,
+      false /* use_fast_accum */,
+      out,
+      epilogue,
+      std::nullopt,
+      alpha);
 #else
   TORCH_CHECK_NOT_IMPLEMENTED(false, "NVFP4 scaling not supported on ROCM");
 #endif
@@ -1307,12 +1458,24 @@ void check_swizzle_lengths(ScaledGemmImplementation impl,
   }
 }
 
-};  // anonymous namespace
+bool is_cublas_accumulator_layout(const Tensor& tensor) {
+  return tensor.dim() == 2 && tensor.stride(1) == 1 &&
+      tensor.stride(0) == std::max<int64_t>(1, tensor.size(1));
+}
 
-// V2: Computes matrix multiply + bias while applying scaling to input and output matrices.
-// Shape inference + output allocation happens in TORCH_META_FUNC(_scaled_mm_v2);
-// this impl handles dtype/recipe/swizzle validation and kernel dispatch.
-TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
+bool is_exact_alias(const Tensor& lhs, const Tensor& rhs) {
+  return lhs.is_same(rhs) ||
+      (lhs.is_alias_of(rhs) && lhs.const_data_ptr() == rhs.const_data_ptr() &&
+       lhs.sizes() == rhs.sizes() && lhs.strides() == rhs.strides());
+}
+
+bool is_aligned_for_cublas(const Tensor& tensor) {
+  return reinterpret_cast<uintptr_t>(tensor.const_data_ptr()) % 16 == 0;
+}
+
+// Shared v2 implementation for scaled_mm and scaled_addmm. The accumulator
+// path is limited to recipes that execute through cuBLASLt.
+void scaled_mm_cuda_v2_impl(
           const Tensor& mat_a, const Tensor& mat_b,
           const at::ITensorListRef& scale_a_list,
           IntArrayRef scale_recipe_a,
@@ -1320,14 +1483,32 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
           const at::ITensorListRef& scale_b_list,
           IntArrayRef scale_recipe_b,
           IntArrayRef swizzle_b,
-          at::OptionalTensorRef bias,
-          std::optional<c10::ScalarType> out_dtype,
-          IntArrayRef contraction_dim,
+          const std::optional<Tensor>& bias,
           bool use_fast_accum,
-          const Tensor& out) {
+          const Tensor& out,
+          const std::optional<Tensor>& accumulator,
+          const Scalar& beta,
+          const Scalar& alpha) {
+  const char* op_name = accumulator ? "torch._scaled_addmm" : "torch._scaled_mm";
   bool allowed_device = scaled_mm_arch_allowed();
-  TORCH_CHECK_NOT_IMPLEMENTED(allowed_device,
-      "torch._scaled_mm is only supported on CUDA devices with compute capability >= 9.0 or 8.9, or ROCm MI300+");
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      allowed_device,
+      op_name,
+      " is only supported on CUDA devices with compute capability >= 9.0 or 8.9, or ROCm MI300+");
+#ifdef USE_ROCM
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      !accumulator.has_value(), op_name, " is not implemented for ROCm");
+#endif
+  if (accumulator) {
+    TORCH_INTERNAL_ASSERT_DEBUG_ONLY(is_cublas_accumulator_layout(*accumulator));
+    TORCH_CHECK_VALUE(
+        is_aligned_for_cublas(*accumulator),
+        "input data pointer must be 16-byte aligned");
+    TORCH_CHECK_VALUE(
+        !accumulator->is_conj() && !accumulator->is_neg() &&
+            !out.is_conj() && !out.is_neg(),
+        "input and out must not have conjugate or negative view bits set");
+  }
 
   // Materialize the scale lists so the existing acceptance helpers (which
   // take ArrayRef<Tensor>) work unchanged.
@@ -1339,7 +1520,8 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
   // If any of M, K, N is 0 - return early (the float8/float4 gemm kernels
   // do not support this case). The output has already been sized by the
   // structured-op meta function; we only need to zero-fill when K=0.
-  if (mat_a.size(0) == 0 || mat_a.size(1) == 0 || mat_b.size(1) == 0) {
+  if (!accumulator &&
+      (mat_a.size(0) == 0 || mat_a.size(1) == 0 || mat_b.size(1) == 0)) {
     if (mat_a.size(1) == 0) {
       const_cast<Tensor&>(out).zero_();
     }
@@ -1409,20 +1591,34 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
     auto bias_ = bias.has_value() ? *bias : Tensor();
     auto global_scale_a = scale_a.size() > 1 ? scale_a[1] : Tensor();
     auto global_scale_b = scale_b.size() > 1 ? scale_b[1] : Tensor();
+    auto accumulator_ = accumulator.value_or(Tensor());
 
     // NOLINTNEXTLINE(*c-array*)
     TensorArg targs[]{{out, "out", 0}, {mat_a, "mat_a", 1}, {mat_b, "mat_b", 2},
                       {bias_, "bias", 3}, {scale_a[0], "scale_a", 4}, {scale_b[0], "scale_b", 5},
-                      {global_scale_a, "global_scale_a", 6}, {global_scale_b, "global_scale_b", 7}};
+                      {global_scale_a, "global_scale_a", 6}, {global_scale_b, "global_scale_b", 7},
+                      {accumulator_, "input", 8}};
     checkAllSameGPU(__func__, targs);
   }
 
-  std::optional<Tensor> bias_opt = bias.has_value()
-      ? std::optional<Tensor>{*bias}
-      : std::optional<Tensor>{std::nullopt};
+  bool accumulator_is_out = false;
+  if (accumulator) {
+    accumulator_is_out = is_exact_alias(out, *accumulator);
+    at::assert_no_internal_overlap(out);
+    if (!accumulator_is_out) {
+      at::assert_no_overlap(out, *accumulator);
+    }
+    at::assert_no_overlap(out, mat_a);
+    at::assert_no_overlap(out, mat_b);
+    for (const auto& scale : scale_a) {
+      at::assert_no_overlap(out, scale);
+    }
+    for (const auto& scale : scale_b) {
+      at::assert_no_overlap(out, scale);
+    }
+  }
 
   auto out_dtype_ = out.scalar_type();
-  Tensor& out_mut = const_cast<Tensor&>(out);
 
   // Conversion of implicitly-defined enums to explicit
   auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
@@ -1457,29 +1653,221 @@ TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
 
   check_swizzle_lengths(gemm_impl, swizzle_a_enum, swizzle_b_enum);
 
+  ScaledGemmEpilogue epilogue;
+  if (accumulator) {
+    TORCH_CHECK_NOT_IMPLEMENTED(
+        gemm_impl != ScaledGemmImplementation::MXFP4_MXFP4,
+        op_name,
+        " does not support the selected non-cuBLAS implementation");
+    if (gemm_impl == ScaledGemmImplementation::ROWWISE_ROWWISE) {
+      TORCH_CHECK_NOT_IMPLEMENTED(
+          rowwise_uses_cublas(scale_a[0], scale_b[0]),
+          op_name,
+          " does not support the row-wise CUTLASS fallback");
+    }
+    if (gemm_impl == ScaledGemmImplementation::BLOCK_128x128_1x128 ||
+        gemm_impl == ScaledGemmImplementation::BLOCK_1x128_128x128 ||
+        gemm_impl == ScaledGemmImplementation::BLOCK_1x128_1x128) {
+      _check_deepseek_support();
+    }
+    epilogue.beta = beta.to<float>();
+    epilogue.alpha = alpha.to<float>();
+    if (mat_a.size(0) == 0 || mat_a.size(1) == 0 ||
+        mat_b.size(1) == 0 || epilogue.alpha == 0.0f) {
+      Tensor& result = const_cast<Tensor&>(out);
+      if (epilogue.beta == 0.0f) {
+        result.zero_();
+      } else {
+        at::mul_out(result, *accumulator, beta);
+      }
+      return;
+    }
+    if (epilogue.beta != 0.0f) {
+      epilogue.accumulator = accumulator;
+    }
+  }
+
+  Tensor temporary;
+  if (accumulator && !accumulator_is_out &&
+      (!is_cublas_accumulator_layout(out) || !is_aligned_for_cublas(out))) {
+    temporary = at::empty(out.sizes(), out.options());
+  }
+  Tensor& kernel_out = temporary.defined() ? temporary : const_cast<Tensor&>(out);
   // dispatch to appropriate lower-level calls for error checking & execution
   if (gemm_impl == ScaledGemmImplementation::TENSORWISE_TENSORWISE) {
-    _scaled_tensorwise_tensorwise(mat_a, mat_b, scale_a[0], scale_b[0], bias_opt, out_dtype_, use_fast_accum, out_mut);
+    _scaled_tensorwise_tensorwise(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        kernel_out,
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::ROWWISE_ROWWISE) {
-    _scaled_rowwise_rowwise(mat_a, mat_b, scale_a[0], scale_b[0], bias_opt, out_dtype_, use_fast_accum, out_mut);
+    _scaled_rowwise_rowwise(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        kernel_out,
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::BLOCK_128x128_1x128) {
-    _scaled_block128x128_block1x128(mat_a, mat_b, scale_a[0], scale_b[0], bias_opt, out_dtype_, use_fast_accum, out_mut);
+    _scaled_block128x128_block1x128(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        kernel_out,
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::BLOCK_1x128_128x128) {
-    _scaled_block1x128_block128x128(mat_a, mat_b, scale_a[0], scale_b[0], bias_opt, out_dtype_, use_fast_accum, out_mut);
+    _scaled_block1x128_block128x128(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        kernel_out,
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::BLOCK_1x128_1x128) {
-    _scaled_block1x128_block1x128(mat_a, mat_b, scale_a[0], scale_b[0], bias_opt, out_dtype_, use_fast_accum, out_mut);
+    _scaled_block1x128_block1x128(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        scale_b[0],
+        bias,
+        out_dtype_,
+        use_fast_accum,
+        kernel_out,
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::MXFP8_MXFP8) {
-    _scaled_mxfp8_mxfp8(mat_a, mat_b, scale_a[0], swizzle_a_enum[0], scale_b[0], swizzle_b_enum[0], bias_opt, out_dtype_, out_mut);
+    _scaled_mxfp8_mxfp8(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        swizzle_a_enum[0],
+        scale_b[0],
+        swizzle_b_enum[0],
+        bias,
+        out_dtype_,
+        kernel_out,
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4) {
-    _scaled_nvfp4_nvfp4(mat_a, mat_b, scale_a[0], swizzle_a_enum[0], scale_b[0], swizzle_b_enum[0], bias_opt, out_dtype_, out_mut,
-                        scale_a[1], scale_b[1]);
+    _scaled_nvfp4_nvfp4(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        swizzle_a_enum[0],
+        scale_b[0],
+        swizzle_b_enum[0],
+        bias,
+        out_dtype_,
+        kernel_out,
+        scale_a[1],
+        scale_b[1],
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4_SINGLE_SCALE) {
-    _scaled_nvfp4_nvfp4(mat_a, mat_b, scale_a[0], swizzle_a_enum[0], scale_b[0], swizzle_b_enum[0], bias_opt, out_dtype_, out_mut);
+    _scaled_nvfp4_nvfp4(
+        mat_a,
+        mat_b,
+        scale_a[0],
+        swizzle_a_enum[0],
+        scale_b[0],
+        swizzle_b_enum[0],
+        bias,
+        out_dtype_,
+        kernel_out,
+        std::nullopt,
+        std::nullopt,
+        epilogue);
   } else if (gemm_impl == ScaledGemmImplementation::MXFP4_MXFP4) {
-    _scaled_mxfp4_mxfp4(mat_a, mat_b, scale_a[0], swizzle_a_enum[0], scale_b[0], swizzle_b_enum[0], bias_opt, out_dtype_, out_mut);
+    _scaled_mxfp4_mxfp4(mat_a, mat_b, scale_a[0], swizzle_a_enum[0], scale_b[0], swizzle_b_enum[0], bias, out_dtype_, kernel_out);
   } else {
     TORCH_CHECK_VALUE(false, "Invalid state - found an implementation, but not really");
   }
+
+  if (temporary.defined()) {
+    const_cast<Tensor&>(out).copy_(temporary);
+  }
+}
+
+} // namespace
+
+// V2: Computes matrix multiply + bias while applying scaling to input and output matrices.
+// Shape inference + output allocation happens in TORCH_META_FUNC(_scaled_mm_v2);
+// this impl handles dtype/recipe/swizzle validation and kernel dispatch.
+TORCH_IMPL_FUNC(_scaled_mm_cuda_v2_out)(
+          const Tensor& mat_a, const Tensor& mat_b,
+          const at::ITensorListRef& scale_a_list,
+          IntArrayRef scale_recipe_a,
+          IntArrayRef swizzle_a,
+          const at::ITensorListRef& scale_b_list,
+          IntArrayRef scale_recipe_b,
+          IntArrayRef swizzle_b,
+          at::OptionalTensorRef bias,
+          std::optional<c10::ScalarType> out_dtype,
+          IntArrayRef contraction_dim,
+          bool use_fast_accum,
+          const Tensor& out) {
+  std::optional<Tensor> bias_opt = bias.has_value()
+      ? std::optional<Tensor>{*bias}
+      : std::nullopt;
+  scaled_mm_cuda_v2_impl(
+      mat_a,
+      mat_b,
+      scale_a_list,
+      scale_recipe_a,
+      swizzle_a,
+      scale_b_list,
+      scale_recipe_b,
+      swizzle_b,
+      bias_opt,
+      use_fast_accum,
+      out,
+      std::nullopt,
+      Scalar(0),
+      Scalar(1));
+}
+
+TORCH_IMPL_FUNC(_scaled_addmm_cuda_out)(
+          const Tensor& self,
+          const Tensor& mat1,
+          const Tensor& mat2,
+          const at::ITensorListRef& scale_a,
+          IntArrayRef recipe_a,
+          IntArrayRef swizzle_a,
+          const at::ITensorListRef& scale_b,
+          IntArrayRef recipe_b,
+          IntArrayRef swizzle_b,
+          IntArrayRef contraction_dim,
+          const Scalar& beta,
+          const Scalar& alpha,
+          bool use_fast_accum,
+          const Tensor& out) {
+  scaled_mm_cuda_v2_impl(
+      mat1,
+      mat2,
+      scale_a,
+      recipe_a,
+      swizzle_a,
+      scale_b,
+      recipe_b,
+      swizzle_b,
+      std::nullopt,
+      use_fast_accum,
+      out,
+      std::optional<Tensor>{self},
+      beta,
+      alpha);
 }
 
 } // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -7151,6 +7151,23 @@
     XPU: _scaled_mm_xpu_v2_out
   tags: needs_exact_strides
 
+- func: _scaled_addmm(Tensor self, Tensor mat1, Tensor mat2, Tensor[] scale_a, int[] recipe_a, int[] swizzle_a, Tensor[] scale_b, int[] recipe_b, int[] swizzle_b, int[] contraction_dim=[], *, Scalar beta=1, Scalar alpha=1, bool use_fast_accum=False) -> Tensor
+  structured_delegate: _scaled_addmm.out
+  variants: function
+  tags: needs_exact_strides
+
+- func: _scaled_addmm_(Tensor(a!) self, Tensor mat1, Tensor mat2, Tensor[] scale_a, int[] recipe_a, int[] swizzle_a, Tensor[] scale_b, int[] recipe_b, int[] swizzle_b, int[] contraction_dim=[], *, Scalar beta=1, Scalar alpha=1, bool use_fast_accum=False) -> Tensor(a!)
+  structured_delegate: _scaled_addmm.out
+  variants: function
+  tags: needs_exact_strides
+
+- func: _scaled_addmm.out(Tensor self, Tensor mat1, Tensor mat2, Tensor[] scale_a, int[] recipe_a, int[] swizzle_a, Tensor[] scale_b, int[] recipe_b, int[] swizzle_b, int[] contraction_dim=[], *, Scalar beta=1, Scalar alpha=1, bool use_fast_accum=False, Tensor(a!) out) -> Tensor(a!)
+  structured: True
+  variants: function
+  dispatch:
+    CUDA: _scaled_addmm_cuda_out
+  tags: needs_exact_strides
+
 - func: _scaled_grouped_mm(Tensor self, Tensor mat2, Tensor scale_a, Tensor scale_b, Tensor? offs=None, Tensor? bias=None, Tensor? scale_result=None, ScalarType? out_dtype=None, bool use_fast_accum=False) -> Tensor
   variants: function
   dispatch:

--- a/docs/source/nn.functional.md
+++ b/docs/source/nn.functional.md
@@ -243,5 +243,7 @@ scaled_dot_product_attention.
     SwizzleType
     grouped_mm
     scaled_mm
+    scaled_addmm
+    scaled_addmm_
     scaled_grouped_mm
 ```

--- a/test/test_scaled_matmul_cuda.py
+++ b/test/test_scaled_matmul_cuda.py
@@ -14,11 +14,14 @@ import torch
 from torch.nn.functional import (
     grouped_mm,
     pad,
+    scaled_addmm,
+    scaled_addmm_,
     scaled_mm,
     scaled_grouped_mm,
     ScalingType,
     SwizzleType,
 )
+from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.testing._internal.common_cuda import (
     IS_SM90,
     _get_torch_cuda_version,
@@ -395,6 +398,65 @@ def to_fp8_saturated(
     return x.to(fp8_dtype)
 
 
+def tensorwise_scaled_mm_args(
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    ScalingType,
+    torch.Tensor,
+    ScalingType,
+]:
+    """Pack operands for the tensorwise scaled-matmul APIs."""
+    return (
+        mat1,
+        mat2,
+        scale_a,
+        ScalingType.TensorWise,
+        scale_b,
+        ScalingType.TensorWise,
+    )
+
+
+def make_tensorwise_scaled_addmm_inputs(
+    m: int,
+    n: int,
+    k: int,
+    device: str,
+    output_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create scaled-addmm operands and their tensorwise decoding scales."""
+    input = torch.randn(m, n, device=device, dtype=output_dtype)
+    mat1_hp = torch.randn(m, k, device=device, dtype=torch.float32)
+    mat2_hp = torch.randn(n, k, device=device, dtype=torch.float32)
+    quant_scale_a = tensor_to_scale(mat1_hp, e4m3_type).float()
+    quant_scale_b = tensor_to_scale(mat2_hp, e4m3_type).float()
+    mat1 = to_fp8_saturated(mat1_hp * quant_scale_a, e4m3_type)
+    mat2 = to_fp8_saturated(mat2_hp * quant_scale_b, e4m3_type).t()
+    return (
+        input,
+        mat1,
+        mat2,
+        quant_scale_a.reciprocal(),
+        quant_scale_b.reciprocal(),
+    )
+
+
+def make_cublas_block_scale(
+    recipe: ScalingType, outer: int, k: int, device: str
+) -> torch.Tensor:
+    """Create an all-ones scale with the layout required by a cuBLAS block recipe."""
+    shape = (
+        (k // 128, outer)
+        if recipe == ScalingType.BlockWise1x128
+        else (outer // 128, round_up(k // 128, 4))
+    )
+    return torch.ones(shape, device=device).t()
+
 
 def compute_error(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     """Computes the error between two tensors in dB.
@@ -682,6 +744,35 @@ class TestFP8Matmul(TestCase):
         if out_dtype is not None:
             self.assertEqual(out_dtype, out_fp8.dtype)
         self.assertEqual(out_fp32, out_fp8.to(torch.float))
+
+    def assert_scaled_addmm_inplace(self, input, expected, args, **kwargs):
+        """Check the identity, storage, version, and value contract."""
+        data_ptr = input.data_ptr()
+        version = input._version
+        returned = scaled_addmm_(input, *args, **kwargs)
+        self.assertIs(returned, input)
+        self.assertEqual(input.data_ptr(), data_ptr)
+        self.assertEqual(input._version, version + 1)
+        self.assertEqual(input, expected, atol=5e-2, rtol=5e-2)
+
+    def assert_scaled_addmm_cudagraph(self, input, expected, args, **kwargs):
+        """Check in-place scaled-addmm capture and replay."""
+        for _ in range(3):
+            scaled_addmm_(input.clone(), *args, **kwargs)
+        torch.cuda.synchronize()
+
+        captured_input = input.clone()
+        data_ptr = captured_input.data_ptr()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            captured_output = scaled_addmm_(captured_input, *args, **kwargs)
+        captured_input.copy_(input)
+        graph.replay()
+        torch.cuda.synchronize()
+
+        self.assertIs(captured_output, captured_input)
+        self.assertEqual(captured_input.data_ptr(), data_ptr)
+        self.assertEqual(captured_input, expected, atol=5e-2, rtol=5e-2)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @parametrize(
@@ -1100,6 +1191,344 @@ class TestFP8Matmul(TestCase):
             atol, rtol = 3e-3, 3e-3
 
         torch.testing.assert_close(out_scaled_mm, out_emulated, atol=atol, rtol=rtol)
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    @parametrize("output_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize("m", [1, 64])
+    def test_scaled_addmm_tensorwise(self, device, output_dtype, m):
+        torch.manual_seed(42)
+        alpha, beta = 1.25, -0.5
+        input, mat1, mat2, scale_a, scale_b = make_tensorwise_scaled_addmm_inputs(
+            m, 48, 32, device, output_dtype
+        )
+        input_before = input.clone()
+        reference = (
+            beta * input.float()
+            + alpha * ((mat1.float() * scale_a) @ (mat2.float() * scale_b))
+        ).to(output_dtype)
+
+        args = tensorwise_scaled_mm_args(mat1, mat2, scale_a, scale_b)
+        kwargs = {"beta": beta, "alpha": alpha}
+        actual = scaled_addmm(input, *args, **kwargs)
+        self.assertEqual(input, input_before)
+        self.assertEqual(actual, reference, atol=5e-2, rtol=5e-2)
+
+        out = torch.empty(0, device=device, dtype=output_dtype)
+        self.assertIs(scaled_addmm(input, *args, out=out, **kwargs), out)
+        self.assertEqual(out.shape, input.shape)
+        self.assertEqual(out, actual)
+
+        self.assert_scaled_addmm_inplace(input.clone(), actual, args, **kwargs)
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_scaled_addmm_wgrad_accumulation(self, device):
+        torch.manual_seed(42)
+        _, mat1_a, mat2_a, scale_a_a, scale_b_a = make_tensorwise_scaled_addmm_inputs(
+            64, 48, 32, device, torch.bfloat16
+        )
+        _, mat1_b, mat2_b, scale_a_b, scale_b_b = make_tensorwise_scaled_addmm_inputs(
+            64, 48, 32, device, torch.bfloat16
+        )
+        args_a = tensorwise_scaled_mm_args(mat1_a, mat2_a, scale_a_a, scale_b_a)
+        args_b = tensorwise_scaled_mm_args(mat1_b, mat2_b, scale_a_b, scale_b_b)
+        grad = scaled_mm(*args_a, output_dtype=torch.bfloat16)
+        reference = (
+            grad.float()
+            + (mat1_b.float() * scale_a_b) @ (mat2_b.float() * scale_b_b)
+        )
+        self.assert_scaled_addmm_inplace(grad, reference.to(grad.dtype), args_b)
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    @parametrize("inplace", [False, True])
+    def test_scaled_addmm_scalar_semantics(self, device, inplace):
+        op = scaled_addmm_ if inplace else scaled_addmm
+        m = n = k = 32
+        scale_a = torch.ones(1, device=device)
+        scale_b = torch.ones(1, device=device)
+        input = torch.randn(m, n, device=device, dtype=torch.bfloat16)
+        mat1 = torch.full((m, k), float("nan"), device=device, dtype=e4m3_type)
+        mat2 = torch.full((n, k), float("nan"), device=device, dtype=e4m3_type).t()
+        args = tensorwise_scaled_mm_args(mat1, mat2, scale_a, scale_b)
+
+        self.assertEqual(
+            op(input.clone(), *args, alpha=0, beta=0.5),
+            input * 0.5,
+        )
+
+        mat1.fill_(1)
+        mat2.fill_(1)
+        self.assertEqual(
+            op(torch.full_like(input, float("nan")), *args, beta=0),
+            (mat1.float() @ mat2.float()).to(input.dtype),
+        )
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    @parametrize("inplace", [False, True])
+    @parametrize("m,n,k", [(0, 32, 16), (32, 0, 16), (32, 32, 0)])
+    def test_scaled_addmm_empty(self, device, inplace, m, n, k):
+        op = scaled_addmm_ if inplace else scaled_addmm
+        input = torch.randn(m, n, device=device, dtype=torch.bfloat16)
+        mat1 = torch.empty(m, k, device=device, dtype=e4m3_type)
+        mat2 = torch.empty(n, k, device=device, dtype=e4m3_type).t()
+        scale_a = torch.ones(1, device=device)
+        scale_b = torch.ones(1, device=device)
+        args = tensorwise_scaled_mm_args(mat1, mat2, scale_a, scale_b)
+
+        self.assertEqual(op(input.clone(), *args, beta=2), input * 2)
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_scaled_addmm_validation(self, device):
+        input, mat1, mat2, scale_a, scale_b = make_tensorwise_scaled_addmm_inputs(
+            32, 32, 32, device, torch.bfloat16
+        )
+        args = tensorwise_scaled_mm_args(mat1, mat2, scale_a, scale_b)
+
+        with self.assertRaisesRegex(ValueError, "input must have shape"):
+            scaled_addmm(input[:1], *args)
+        with self.assertRaisesRegex(ValueError, "canonical contiguous"):
+            scaled_addmm(input.t(), *args)
+        with self.assertRaisesRegex(ValueError, "real alpha and beta"):
+            scaled_addmm(input, *args, alpha=1j)
+
+        input_before = input.clone()
+        noncontiguous_out = torch.empty_like(input).t()
+        expected = scaled_addmm(input, *args)
+        self.assertIs(
+            scaled_addmm(input, *args, out=noncontiguous_out), noncontiguous_out
+        )
+        self.assertEqual(noncontiguous_out, expected)
+        self.assertEqual(input, input_before)
+
+        misaligned_out = input.new_empty(input.numel() + 1)[1:].view_as(input)
+        self.assertIs(scaled_addmm(input, *args, out=misaligned_out), misaligned_out)
+        self.assertEqual(misaligned_out, expected)
+
+        overlapping_out = input.new_empty(1).expand_as(input)
+        with self.assertRaisesRegex(RuntimeError, "single memory location"):
+            scaled_addmm(input, *args, out=overlapping_out)
+
+        exact_alias = input.view_as(input)
+        self.assertIs(scaled_addmm(input, *args, out=exact_alias), exact_alias)
+        self.assertEqual(exact_alias, expected, atol=5e-2, rtol=5e-2)
+
+        alignment_offset = 16 // input.element_size()
+        aliased_storage = input.new_empty(input.numel() + alignment_offset)
+        aliased_input = aliased_storage[:-alignment_offset].view_as(input)
+        aliased_out = aliased_storage[alignment_offset:].view_as(input)
+        with self.assertRaisesRegex(RuntimeError, "single memory location"):
+            scaled_addmm(aliased_input, *args, out=aliased_out)
+
+        misaligned = input.new_empty(input.numel() + 1)[1:].view_as(input)
+        with self.assertRaisesRegex(ValueError, "16-byte aligned"):
+            scaled_addmm_(misaligned, *args)
+
+        aligned_16 = input.new_empty(input.numel() + alignment_offset)[
+            alignment_offset:
+        ].view_as(input)
+        aligned_16.copy_(input_before)
+        self.assertIs(scaled_addmm_(aligned_16, *args), aligned_16)
+        self.assertEqual(aligned_16, expected, atol=5e-2, rtol=5e-2)
+
+        invalid_ld = input.new_empty_strided((1, 32), (1, 1))
+        with self.assertRaisesRegex(ValueError, "canonical contiguous"):
+            scaled_addmm_(invalid_ld, mat1[:1], *args[1:])
+
+        if not (IS_SM90 and _get_torch_cuda_version() >= (12, 9)):
+            row_scale_a = torch.ones(32, 1, device=device)
+            row_scale_b = torch.ones(1, 32, device=device)
+            with self.assertRaisesRegex(
+                NotImplementedError, "row-wise CUTLASS fallback"
+            ):
+                scaled_addmm(
+                    input,
+                    mat1,
+                    mat2,
+                    row_scale_a,
+                    ScalingType.RowWise,
+                    row_scale_b,
+                    ScalingType.RowWise,
+                )
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not IS_SM90, "cuBLASLt accumulation requires SM90")
+    @unittest.skipIf(
+        _get_torch_cuda_version() < (12, 9),
+        "cuBLASLt accumulation requires CUDA 12.9+",
+    )
+    @parametrize("output_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @parametrize(
+        "recipe_a,recipe_b",
+        [
+            (ScalingType.RowWise, ScalingType.RowWise),
+            (ScalingType.BlockWise1x128, ScalingType.BlockWise1x128),
+            (ScalingType.BlockWise128x128, ScalingType.BlockWise1x128),
+            (ScalingType.BlockWise1x128, ScalingType.BlockWise128x128),
+        ],
+    )
+    def test_scaled_addmm_cublas_recipes(
+        self, device, output_dtype, recipe_a, recipe_b
+    ):
+        is_rowwise = recipe_a == ScalingType.RowWise
+        m = n = k = 32 if is_rowwise else 256
+        alpha, beta = 1.25, -0.5
+        input = torch.randn(m, n, device=device, dtype=output_dtype)
+        mat1 = torch.eye(m, k, device=device, dtype=e4m3_type)
+        mat2 = torch.eye(n, k, device=device, dtype=e4m3_type).t()
+        if is_rowwise:
+            scale_a = torch.ones(m, 1, device=device)
+            scale_b = torch.ones(1, n, device=device)
+        else:
+            scale_a = make_cublas_block_scale(recipe_a, m, k, device)
+            scale_b = make_cublas_block_scale(recipe_b, n, k, device)
+
+        expected = (beta * input.float() + alpha * mat1.float() @ mat2.float()).to(
+            output_dtype
+        )
+        actual = scaled_addmm(
+            input,
+            mat1,
+            mat2,
+            scale_a,
+            recipe_a,
+            scale_b,
+            recipe_b,
+            beta=beta,
+            alpha=alpha,
+        )
+        self.assertEqual(actual, expected, atol=5e-2, rtol=5e-2)
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
+    @parametrize("output_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    def test_scaled_addmm_mxfp8(self, device, output_dtype):
+        m = n = k = 128
+        input = torch.randn(m, n, device=device, dtype=output_dtype)
+        mat1_ref = torch.eye(m, k, device=device, dtype=torch.bfloat16)
+        mat2_ref = torch.eye(n, k, device=device, dtype=torch.bfloat16)
+        mat1 = mat1_ref.to(e4m3_type)
+        mat2 = mat2_ref.to(e4m3_type).t()
+        scale_a = to_blocked(
+            torch.ones(m, k // 32, device=device, dtype=torch.float8_e8m0fnu)
+        )
+        scale_b = to_blocked(
+            torch.ones(n, k // 32, device=device, dtype=torch.float8_e8m0fnu)
+        )
+
+        args = (
+            mat1,
+            mat2,
+            scale_a,
+            ScalingType.BlockWise1x32,
+            scale_b,
+            ScalingType.BlockWise1x32,
+        )
+        kwargs = {
+            "swizzle_a": SwizzleType.SWIZZLE_32_4_4,
+            "swizzle_b": SwizzleType.SWIZZLE_32_4_4,
+        }
+        actual = scaled_addmm(input, *args, **kwargs)
+        reference = (
+            input.float() + mat1_ref.float() @ mat2_ref.float().t()
+        ).to(output_dtype)
+        self.assertEqual(actual, reference)
+
+        self.assert_scaled_addmm_inplace(input.clone(), actual, args, **kwargs)
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
+    @parametrize("two_level", [False, True])
+    @parametrize("output_dtype", [torch.bfloat16, torch.float16, torch.float32])
+    def test_scaled_addmm_nvfp4(self, device, two_level, output_dtype):
+        m = n = k = 128
+        alpha, beta = 4.0, -0.5
+        input = torch.randn(m, n, device=device, dtype=output_dtype)
+        input_before = input.clone()
+        mat1_ref = torch.eye(m, k, device=device, dtype=torch.bfloat16)
+        mat2_ref = torch.eye(n, k, device=device, dtype=torch.bfloat16)
+        mat1 = _bfloat16_to_float4_e2m1fn_x2(mat1_ref)
+        mat2 = _bfloat16_to_float4_e2m1fn_x2(mat2_ref).t()
+        scale_a = to_blocked(
+            torch.ones(m, k // 16, device=device, dtype=torch.float8_e4m3fn)
+        )
+        scale_b = to_blocked(
+            torch.ones(n, k // 16, device=device, dtype=torch.float8_e4m3fn)
+        )
+        swizzle = SwizzleType.SWIZZLE_32_4_4
+        gemm_scale = 1.0
+        if two_level:
+            global_scale_a = torch.full((1,), 0.5, device=device)
+            global_scale_b = torch.full((1,), 0.25, device=device)
+            gemm_scale = 0.125
+            scale_a = [scale_a, global_scale_a]
+            scale_b = [scale_b, global_scale_b]
+            recipe = [ScalingType.BlockWise1x16, ScalingType.TensorWise]
+            swizzle = [swizzle, SwizzleType.NO_SWIZZLE]
+        else:
+            recipe = ScalingType.BlockWise1x16
+
+        args = (mat1, mat2, scale_a, recipe, scale_b, recipe)
+        kwargs = {"swizzle_a": swizzle, "swizzle_b": swizzle}
+        product = mat1_ref.float() @ mat2_ref.float().t()
+        expected = (beta * input.float() + alpha * gemm_scale * product).to(
+            output_dtype
+        )
+        actual = scaled_addmm(input, *args, beta=beta, alpha=alpha, **kwargs)
+        self.assertEqual(input, input_before)
+        self.assertEqual(actual, expected, atol=5e-2, rtol=5e-2)
+        self.assert_scaled_addmm_inplace(
+            input.clone(), actual, args, beta=beta, alpha=alpha, **kwargs
+        )
+
+        if two_level and output_dtype == torch.bfloat16:
+            ignored_input = torch.full_like(input, float("nan"))
+            ignored = scaled_addmm(ignored_input, *args, beta=0, **kwargs)
+            expected_ignored = (gemm_scale * product).to(output_dtype)
+            self.assertEqual(ignored, expected_ignored, atol=5e-2, rtol=5e-2)
+            self.assert_scaled_addmm_cudagraph(
+                input, actual, args, beta=beta, alpha=alpha, **kwargs
+            )
+
+    @onlyCUDA
+    @skipIfRocm
+    def test_scaled_addmm_fake_tensor(self, device):
+        with FakeTensorMode():
+            input = torch.empty(16, 32, device=device, dtype=torch.bfloat16)
+            mat1 = torch.empty(16, 16, device=device, dtype=e4m3_type)
+            mat2 = torch.empty(16, 32, device=device, dtype=e4m3_type)
+            scale_a = torch.ones(1, device=device)
+            scale_b = torch.ones(1, device=device)
+            args = tensorwise_scaled_mm_args(mat1, mat2, scale_a, scale_b)
+
+            result = scaled_addmm(input, *args)
+            self.assertEqual(result.shape, input.shape)
+            self.assertEqual(result.dtype, input.dtype)
+
+            out = torch.empty_like(input)
+            self.assertIs(scaled_addmm(input, *args, out=out), out)
+            self.assertIs(scaled_addmm_(input, *args), input)
+
+    @onlyCUDA
+    @skipIfRocm
+    @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
+    def test_scaled_addmm_cudagraph(self, device):
+        input, mat1, mat2, scale_a, scale_b = make_tensorwise_scaled_addmm_inputs(
+            32, 32, 32, device, torch.bfloat16
+        )
+        args = tensorwise_scaled_mm_args(mat1, mat2, scale_a, scale_b)
+        self.assert_scaled_addmm_cudagraph(input, scaled_addmm(input, *args), args)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, f8_msg)
     @parametrize("base_dtype", [torch.float16, torch.bfloat16, torch.float32])

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7481,6 +7481,63 @@ def meta_scaled_mm_v2(
     return torch.empty(self.size(0), mat2.size(1), dtype=_out_dtype, device=self.device)
 
 
+@register_meta([aten._scaled_addmm.default])
+def meta_scaled_addmm(
+    self: torch.Tensor,
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+    scale_a: list[torch.Tensor],
+    scale_recipe_a: list[int],
+    swizzle_a: list[int],
+    scale_b: list[torch.Tensor],
+    scale_recipe_b: list[int],
+    swizzle_b: list[int],
+    contraction_dim: list[int] | None = None,
+    *,
+    beta=1,
+    alpha=1,
+    use_fast_accum: bool = False,
+):
+    torch._check(
+        not isinstance(alpha, complex) and not isinstance(beta, complex),
+        lambda: "torch._scaled_addmm only supports real alpha and beta values",
+    )
+    result = meta_scaled_mm_v2(
+        mat1,
+        mat2,
+        scale_a,
+        scale_recipe_a,
+        swizzle_a,
+        scale_b,
+        scale_recipe_b,
+        swizzle_b,
+        out_dtype=self.dtype,
+        contraction_dim=contraction_dim,
+        use_fast_accum=use_fast_accum,
+    )
+    torch._check(
+        self.dim() == 2,
+        lambda: f"input must be a matrix, but got {self.dim()} dimensions",
+    )
+    torch._check(
+        self.size(0) == result.size(0),
+        lambda: f"input dim 0 must be {result.size(0)}, but got {self.size(0)}",
+    )
+    torch._check(
+        self.size(1) == result.size(1),
+        lambda: f"input dim 1 must be {result.size(1)}, but got {self.size(1)}",
+    )
+    torch._check(
+        self.dtype in (torch.bfloat16, torch.float16, torch.float32),
+        lambda: f"input must have dtype BFloat16, Half, or Float, but got {self.dtype}",
+    )
+    torch._check(
+        self.stride(1) == 1 and self.stride(0) == torch.sym_max(1, self.size(1)),
+        lambda: "input must have canonical contiguous row-major strides",
+    )
+    return result
+
+
 @register_meta([aten.scatter_reduce.two, aten.scatter_reduce.two_out])
 @out_wrapper()
 def meta_scatter_reduce_two(self, dim, index, src, reduce, include_self=True):

--- a/torch/nn/functional.py
+++ b/torch/nn/functional.py
@@ -7263,6 +7263,133 @@ def scaled_mm(
     return out
 
 
+def scaled_addmm(
+    input: Tensor,
+    mat1: Tensor,
+    mat2: Tensor,
+    scale_a: Tensor | list[Tensor],
+    scale_recipe_a: ScalingType | list[ScalingType],
+    scale_b: Tensor | list[Tensor],
+    scale_recipe_b: ScalingType | list[ScalingType],
+    swizzle_a: SwizzleType | list[SwizzleType] | None = None,
+    swizzle_b: SwizzleType | list[SwizzleType] | None = None,
+    contraction_dim: list[int] | tuple[int, ...] = (),
+    use_fast_accum: bool = False,
+    *,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    out: Tensor | None = None,
+) -> Tensor:
+    r"""Compute a scaled matrix product and add it to ``input``.
+
+    The result is
+
+    .. math::
+        \mathrm{out} = \beta\,\mathrm{input} +
+        \alpha\,\mathrm{scaled\_mm}(\mathrm{mat1}, \mathrm{mat2}).
+
+    The scaling recipes and swizzles have the same meaning as in
+    :func:`scaled_mm`. ``input`` must be a canonically contiguous, 16-byte-aligned
+    matrix with shape ``(mat1.size(0), mat2.size(1))`` and dtype ``float16``, ``bfloat16``, or
+    ``float32``. CUDA recipes are supported when their selected implementation
+    uses cuBLASLt; non-cuBLAS fallbacks and ROCm are not supported.
+
+    Args:
+        input: Matrix accumulated into the scaled matrix product.
+        mat1: Left matrix operand.
+        mat2: Right matrix operand.
+        scale_a: Tensor containing decoding scaling factors for ``mat1``.
+        scale_recipe_a: Scaling recipe for ``mat1``.
+        scale_b: Tensor containing decoding scaling factors for ``mat2``.
+        scale_recipe_b: Scaling recipe for ``mat2``.
+        swizzle_a: Swizzling pattern, if any, for ``scale_a``.
+        swizzle_b: Swizzling pattern, if any, for ``scale_b``.
+        contraction_dim: Dimensions contracted by the matrix multiply.
+        use_fast_accum: Whether to enable tensor-core fast accumulation.
+        beta: Multiplier for ``input``.
+        alpha: Multiplier for the scaled matrix product.
+        out: Optional destination tensor.
+
+    .. note::
+        Fusing the addition removes an intermediate output rounding step, so
+        the result need not be bitwise equal to a separate scaled matrix
+        multiply followed by an addition.
+    """
+    scale_a = _expand_single_value(scale_a)
+    scale_recipe_a = _expand_single_value(scale_recipe_a)
+    scale_b = _expand_single_value(scale_b)
+    scale_recipe_b = _expand_single_value(scale_recipe_b)
+    swizzle_a = _expand_single_value(swizzle_a)
+    swizzle_b = _expand_single_value(swizzle_b)
+
+    return torch._scaled_addmm(
+        input,
+        mat1,
+        mat2,
+        scale_a,
+        _enum_list_as_int_list(scale_recipe_a),
+        _enum_list_as_int_list(_list_or_empty(swizzle_a)),
+        scale_b,
+        _enum_list_as_int_list(scale_recipe_b),
+        _enum_list_as_int_list(_list_or_empty(swizzle_b)),
+        contraction_dim,
+        beta=beta,
+        alpha=alpha,
+        use_fast_accum=use_fast_accum,
+        out=out,
+    )
+
+
+def scaled_addmm_(
+    input: Tensor,
+    mat1: Tensor,
+    mat2: Tensor,
+    scale_a: Tensor | list[Tensor],
+    scale_recipe_a: ScalingType | list[ScalingType],
+    scale_b: Tensor | list[Tensor],
+    scale_recipe_b: ScalingType | list[ScalingType],
+    swizzle_a: SwizzleType | list[SwizzleType] | None = None,
+    swizzle_b: SwizzleType | list[SwizzleType] | None = None,
+    contraction_dim: list[int] | tuple[int, ...] = (),
+    use_fast_accum: bool = False,
+    *,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+) -> Tensor:
+    r"""In-place version of :func:`scaled_addmm`.
+
+    This function preserves the storage of ``input`` and returns ``input``. A
+    serialized WGRAD loop can create the first contribution with
+    :func:`scaled_mm`, then use ``scaled_addmm_`` for later contributions.
+
+    .. warning::
+        In-place accumulation is not safe for concurrent writers. Callers must
+        serialize writes or provide external coordination.
+    """
+    scale_a = _expand_single_value(scale_a)
+    scale_recipe_a = _expand_single_value(scale_recipe_a)
+    scale_b = _expand_single_value(scale_b)
+    scale_recipe_b = _expand_single_value(scale_recipe_b)
+    swizzle_a = _expand_single_value(swizzle_a)
+    swizzle_b = _expand_single_value(swizzle_b)
+
+    return torch._scaled_addmm_(
+        input,
+        mat1,
+        mat2,
+        scale_a,
+        _enum_list_as_int_list(scale_recipe_a),
+        _enum_list_as_int_list(_list_or_empty(swizzle_a)),
+        scale_b,
+        _enum_list_as_int_list(scale_recipe_b),
+        _enum_list_as_int_list(_list_or_empty(swizzle_b)),
+        contraction_dim,
+        beta=beta,
+        alpha=alpha,
+        use_fast_accum=use_fast_accum,
+    )
+
+
 def scaled_grouped_mm(
     mat_a: Tensor,
     mat_b: Tensor,

--- a/torch/nn/functional.pyi.in
+++ b/torch/nn/functional.pyi.in
@@ -750,6 +750,45 @@ def scaled_mm(
 
 __all__ += ["scaled_mm"]
 
+def scaled_addmm(
+    input: Tensor,
+    mat1: Tensor,
+    mat2: Tensor,
+    scale_a: Tensor | list[Tensor],
+    scale_recipe_a: ScalingType | list[ScalingType],
+    scale_b: Tensor | list[Tensor],
+    scale_recipe_b: ScalingType | list[ScalingType],
+    swizzle_a: SwizzleType | list[SwizzleType] | None = None,
+    swizzle_b: SwizzleType | list[SwizzleType] | None = None,
+    contraction_dim: list[int] | tuple[int, ...] = (),
+    use_fast_accum: bool = False,
+    *,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    out: Tensor | None = None,
+) -> Tensor: ...
+
+__all__ += ["scaled_addmm"]
+
+def scaled_addmm_(
+    input: Tensor,
+    mat1: Tensor,
+    mat2: Tensor,
+    scale_a: Tensor | list[Tensor],
+    scale_recipe_a: ScalingType | list[ScalingType],
+    scale_b: Tensor | list[Tensor],
+    scale_recipe_b: ScalingType | list[ScalingType],
+    swizzle_a: SwizzleType | list[SwizzleType] | None = None,
+    swizzle_b: SwizzleType | list[SwizzleType] | None = None,
+    contraction_dim: list[int] | tuple[int, ...] = (),
+    use_fast_accum: bool = False,
+    *,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+) -> Tensor: ...
+
+__all__ += ["scaled_addmm_"]
+
 def grouped_mm(
     mat_a: Tensor,
     mat_b: Tensor,

--- a/torch/overrides.py
+++ b/torch/overrides.py
@@ -256,6 +256,8 @@ def get_ignored_functions() -> set[Callable]:
         torch.nn.functional.has_torch_function_variadic,
         torch.nn.functional.handle_torch_function,
         torch.nn.functional.grouped_mm,
+        torch.nn.functional.scaled_addmm,
+        torch.nn.functional.scaled_addmm_,
         torch.nn.functional.scaled_grouped_mm,
         torch.nn.functional.scaled_mm,
         torch.nn.functional.sigmoid,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

## Human Note

> Add the public scaled analogue of addmm, including a true in-place form for serialized WGRAD accumulation, and support every existing scaled-mm recipe that reaches cuBLASLt.

## Agent note

This adds `torch.nn.functional.scaled_addmm(..., out=...)` and `scaled_addmm_(...)` on top of structured `_scaled_addmm`, `_scaled_addmm.out`, and `_scaled_addmm_` operators. It computes `beta * input + alpha * scaled_mm(mat1, mat2)` inside one cuBLASLt GEMM while preserving the existing scaled-mm beta-zero path.

The implementation supports TensorWise FP8, cuBLAS rowwise FP8, the SM90 DeepSeek block recipes, MXFP8, and single- or two-level NVFP4 with FP16, BF16, or FP32 destinations. The in-place form preserves identity and storage, while distinct noncanonical outputs use a temporary and copy back; unsafe partial aliases and internal overlap are rejected. Two-level NVFP4 retains device-side global scaling and materializes only scalar alpha/beta state.

For review, start with the schemas and public wrappers, then the `_scaled_addmm` Meta contract, the shared CUDA dispatcher and output ownership rules, and finally the cuBLASLt C/D scalar plumbing. The tests cover eager functional/out/in-place behavior, all supported recipes and dtypes, WGRAD accumulation, aliasing, empty and zero-scalar semantics, FakeTensor, and CUDA graph replay.

Authored with assistance from an AI coding assistant.

## Test Plan

```bash
../.venv/bin/python -m torchgen.gen --source-path aten/src/ATen --install_dir build/aten/src/ATen --headeronly-install-dir build/torch/headeronly/core --per-operator-headers --generate sources --output-dependencies build/aten/src/ATen/generated_sources.cmake
bash ~/.ptq_workspace/scripts/rebuild.sh ~/.ptq_workspace/jobs/20260829-pytorch-adhoc-7b52f7/pytorch
gpu-run --timeout 60 auto -- timeout --signal=TERM --kill-after=5s 900s ../.venv/bin/python test/test_scaled_matmul_cuda.py -k scaled_addmm -v
gpu-run --timeout 60 auto -- timeout --signal=TERM --kill-after=5s 1800s ../.venv/bin/python test/test_scaled_matmul_cuda.py -v
../.venv/bin/python test/test_public_bindings.py TestPublicBindings.test_correct_module_names TestPublicBindings.test_no_new_bindings TestPublicBindings.test_no_new_reexport_callables -v
../.venv/bin/python test/test_overrides.py TestTorchFunctionOverride.test_dtype_override -v
python -m torchgen.gen --dry-run
python -m py_compile test/test_scaled_matmul_cuda.py torch/nn/functional.py torch/_meta_registrations.py
spin quicklint
git diff --check
```

The focused eager layer completed 78 tests with 27 passes and 51 hardware/backend skips. The complete scaled-matmul file completed 1,978 tests with 585 passes and 1,393 skips. The SM90-only rowwise and DeepSeek cases remain unexecuted locally on GB200. Full-repository `spin lint` was also run; changed-file lint passed, while the all-files pass reported unrelated pre-existing ShellCheck findings in `.ci` scripts.