### PR TITLE
[MPS] Fix nll_loss_backward for 1D (no batch dim) input

### DIFF
--- a/aten/src/ATen/native/mps/operations/LossOps.mm
+++ b/aten/src/ATen/native/mps/operations/LossOps.mm
@@ -363,13 +363,18 @@ static void nllnd_loss_backward_impl(Tensor& grad_input_arg,
                   getMTLBufferStorage(target),
                   getMTLBufferStorage(weight),
                   getMTLBufferStorage(total_weight_cast));
+      // For 1D (no batch dim) input the loss has a single element and only
+      // target[0] is used; dispatching target.numel() threads would read
+      // grad_output (a single element) out of bounds and scatter garbage into
+      // grad_input. See https://github.com/pytorch/pytorch/issues/195391.
+      const int64_t num_outputs = input_arg.dim() == 1 ? 1 : target.numel();
       // Chunk only when the target exceeds Metal's uint32 thread-grid limit.
       constexpr auto max_threads = int64_t{std::numeric_limits<uint32_t>::max()};
       auto dispatch_params = params;
-      for (auto offset = int64_t{0}; offset < target.numel(); offset += max_threads) {
+      for (auto offset = int64_t{0}; offset < num_outputs; offset += max_threads) {
         dispatch_params.tid_offset = offset;
         mtl_setArgs<5>(encoder, dispatch_params, stream->getErrorBuffer());
-        mtl_dispatch1DJob(encoder, pso, std::min(max_threads, target.numel() - offset));
+        mtl_dispatch1DJob(encoder, pso, std::min(max_threads, num_outputs - offset));
       }
     }
   });

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12055,6 +12055,25 @@ class TestNNDeviceType(NNTestCase):
             with self.assertRaisesRegex(RuntimeError, msg):
                 F.nll_loss(x, t, weight=weight)
 
+    @onlyAccelerator
+    def test_nll_loss_1d_input_backward(self, device):
+        # For 1D (no batch dim) input aten.nll_loss_backward uses only target[0].
+        # The MPS Metal kernel used to dispatch target.numel() threads, reading
+        # the single-element grad_output out of bounds and scattering garbage
+        # into grad_input. Back grad_output with a larger sentinel-filled tensor
+        # and view out a single element so any out-of-bounds read is a
+        # deterministic non-zero value. gh-195391
+        input = torch.randn(3, device=device)
+        target = torch.tensor([2, 0, 1], device=device)
+        total_weight = torch.tensor(1.0, device=device)
+        grad_output_storage = torch.full((4,), torch.finfo(torch.float32).max, device=device)
+        grad_output_storage[0] = torch.randn(())
+        grad_output = grad_output_storage[:1]
+        args = (grad_output, input, target, None, 0, 10, total_weight)
+        ref = torch.ops.aten.nll_loss_backward(*(a.cpu() if torch.is_tensor(a) else a for a in args))
+        out = torch.ops.aten.nll_loss_backward(*args)
+        self.assertEqual(out.cpu(), ref)
+
     # Ref: https://github.com/pytorch/pytorch/issues/85005
     @onlyCUDA
     @largeTensorTest("120GB", "cpu")


### PR DESCRIPTION
For 1D input `nll_loss` has a single loss element and only `target[0]` is used. The Metal kernel added in #195153 unconditionally dispatched `target.numel()` threads. When `aten.nll_loss_backward` is called directly with a 1D input and a multi-element target (as the inductor decomposition test does), the extra threads read the single-element `grad_output` out of bounds and scatter that garbage into `grad_input[target[i]]`.

In clean memory the out-of-bounds read is zero, so the result happens to match the reference; when the caching allocator hands back a dirty buffer it is garbage (e.g. `FLT_MAX`). That is why `test_nll_loss_backward_1d_input_mps` was flaky (#195391, #195392).

## How the previous (MPSGraph) op handled this
The MPSGraph implementation that #195153 replaced reshaped a 1D input `[C]` to `[1, C]` (an explicit batch of one) up front:
```objc
auto grad_input = grad_input_arg.dim() == 1 ? grad_input_arg.view({1, grad_input_arg.size(0)}) : grad_input_arg;
```
so the number of output rows was structurally pinned to 1, independent of the target's element count. The Metal migration dropped this normalization and instead derives the iteration count from `target.numel()`, which is where the out-of-bounds read comes from.

Note this 1D handling was **not** present in the original MPS op (#77343) -- it was added later in #81290 ("[MPS] Handle 1D inputs for NLL") and then lost in the migration.

## Fix
Dispatch a single thread for 1D input, matching the CPU and decomposition semantics ("the C++ kernel only uses `target[0]`") and re-instating the old `view({1, C})` invariant as a thread count. The 2D and 2D-loss paths are unchanged since `target.numel()` already equals the number of loss elements there.

## Test
Added a device-generic regression test that backs `grad_output` with a larger sentinel-filled tensor and views out a single element, so the out-of-bounds read is a deterministic non-zero value rather than relying on allocator state. It fails before the fix and passes after (`@onlyAccelerator`; the CPU path is correct and used as the reference).


Fixes #195389
Fixes #195390
Fixes #195391
Fixes #195392

🤖 Generated with [Claude Code](https://claude.com/claude-code)