### PR TITLE
[dynamo] Fix SourcelessBuilder crash for grad-mode-decorated methods on graph-internal objects

### DIFF
--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -15926,6 +15926,474 @@ fn
         res = opt_fn(t)
         self.assertEqual(ref, res)
 
+    @parametrize(
+        "grad_mode_decorator",
+        ["no_grad", "enable_grad", "dual_level"],
+    )
+    def test_sourceless_bound_method_in_closure(self, grad_mode_decorator):
+        # Constructing an object inside the graph and calling a grad-mode
+        # decorated method on it (e.g. @torch.no_grad()) requires wrapping a
+        # bound method (the decorator's ctx_factory closure cell) whose
+        # __self__ was never observed directly by Dynamo, and then cloning
+        # that context manager (self.__class__()) without a source to
+        # construct from. See gh-194763.
+        #
+        # Each case runs under an ambient state the decorator actually
+        # flips, so a version that silently dropped the decorator's effect
+        # (rather than truly applying it) would produce a different,
+        # detectably wrong result -- not just coincidentally match the
+        # no-op default.
+        if grad_mode_decorator == "no_grad":
+
+            class A:
+                @torch.no_grad()
+                def method(self, x):
+                    return x + 1
+
+            def fn(x):
+                return A().method(x)
+
+        elif grad_mode_decorator == "enable_grad":
+
+            class A:
+                @torch.enable_grad()
+                def method(self, x):
+                    return x + 1
+
+            def fn(x):
+                # Ambient grad is enabled by default, so enable_grad's
+                # effect is only observable if the call itself happens
+                # inside an outer no_grad -- otherwise "did the decorator
+                # apply" and "did it get silently dropped" look identical.
+                with torch.no_grad():
+                    return A().method(x)
+
+        else:
+
+            class A:
+                @torch.autograd.forward_ad.dual_level()
+                def method(self, x):
+                    # _current_level is -1 outside any dual_level context and
+                    # >= 0 inside one; reading it directly makes a dropped
+                    # dual_level entry (silently falling back to -1) produce
+                    # a different, wrong numeric result instead of an
+                    # incidental match.
+                    return x + torch.autograd.forward_ad._current_level
+
+            def fn(x):
+                return A().method(x)
+
+        x = torch.tensor(1.0, requires_grad=True)
+        ref = fn(x)
+        torch._dynamo.reset()
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        if grad_mode_decorator in ("no_grad", "enable_grad"):
+            # Value equality alone doesn't exercise what these decorators
+            # actually control; assert the grad-mode side effect matches
+            # too.
+            self.assertEqual(ref.requires_grad, res.requires_grad)
+
+    def test_sourceless_bound_method_in_closure_set_grad_enabled_graph_breaks(self):
+        # set_grad_enabled.clone() forwards a saved constructor arg and
+        # mutates real global autograd state as a side effect of
+        # construction (unlike no_grad/enable_grad/dual_level's unmodified
+        # clone), so it is deliberately NOT in
+        # maybe_reconstruct_decorator_ctx_manager_clone's allowlist. It
+        # should graph-break cleanly under fullgraph=True (and fall back to
+        # eager under fullgraph=False), not silently drop the decorator's
+        # effect. See gh-194763.
+        class A:
+            @torch.set_grad_enabled(False)
+            def method(self, x):
+                return x + 1
+
+        def fn(x):
+            return A().method(x)
+
+        x = torch.tensor(1.0, requires_grad=True)
+        ref = fn(x)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=False)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(ref.requires_grad, res.requires_grad)
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        # The shared reconstruction predicate rejects set_grad_enabled's
+        # overridden clone/class pair at SourcelessBuilder's gate.
+        self.assertEqual(
+            ctx.exception.gb_type,
+            "Sourceless _DecoratorContextManager method reconstruction unsupported",
+        )
+
+    @parametrize("mode", [True, False])
+    def test_sourceless_bound_method_in_closure_inference_mode_graph_breaks(self, mode):
+        # inference_mode.clone() forwards a saved constructor arg
+        # (self.mode). maybe_reconstruct_decorator_ctx_manager_clone
+        # resolves this symbolically (avoiding the torch/autograd skip-list
+        # break) only when it can build a real source for self.mode --
+        # otherwise baking it in as an unguarded constant would silently
+        # reuse a stale value if the real instance's .mode is mutated
+        # between compiles without an intervening reset. Here `self` (the
+        # inference_mode instance) is reached only via a closure cell of a
+        # method that's itself reached off a graph-internal object (A()) --
+        # genuinely sourceless, gh-194763's exact scope -- so no source is
+        # available and this case correctly falls through: graph-break
+        # cleanly under fullgraph=True, fall back to eager under
+        # fullgraph=False. Contrast with a *sourced* inference_mode
+        # instance (e.g. `@torch.inference_mode()` applied directly to a
+        # module-level function), which does get the fast path -- see
+        # test_torch_inference_mode_ctx in test_export.py.
+        class A:
+            @torch.inference_mode(mode)
+            def method(self, x):
+                return x + 1
+
+        def fn(x):
+            return A().method(x)
+
+        x = torch.tensor(1.0, requires_grad=True)
+        ref = fn(x)
+        torch._dynamo.reset()
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=False)
+        res = opt_fn(x)
+        self.assertEqual(ref, res)
+        self.assertEqual(torch.is_inference(ref), torch.is_inference(res))
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        # Although the function/class pair is otherwise reconstructable,
+        # inference_mode.clone needs a source for self.mode. SourcelessBuilder
+        # rejects it before constructing an untracked receiver VT.
+        self.assertEqual(
+            ctx.exception.gb_type,
+            "Sourceless _DecoratorContextManager method reconstruction unsupported",
+        )
+
+    def test_sourced_inference_mode_clone_guards_on_mode(self):
+        # Contrast with test_sourceless_bound_method_in_closure_inference_mode_graph_breaks
+        # above: here the inference_mode instance itself IS sourced (a
+        # module-scope-like local reachable directly from the compiled
+        # root function's closure, the same shape as
+        # test_torch_inference_mode_ctx in test_export.py), so
+        # maybe_reconstruct_decorator_ctx_manager_clone's inference_mode
+        # case takes the fast path and builds mode_var with a real source
+        # (AttrSource(obj_source, "mode")) rather than falling through.
+        # That source is what makes this safe: without it (or without
+        # this whole case, as an earlier version of this fix mistakenly
+        # dropped it entirely), mutating .mode and recompiling without an
+        # intervening torch._dynamo.reset() would either silently keep
+        # using the stale cached value or -- as actually happened -- lose
+        # the fast path altogether and regress a pre-existing, unrelated
+        # upstream test (test_torch_inference_mode_ctx) by forcing a graph
+        # break on ordinary sourced @torch.inference_mode() usage.
+        im = torch.inference_mode(True)
+
+        @im
+        def fn(x):
+            return x + 1
+
+        x = torch.tensor(1.0)
+
+        torch._dynamo.reset()
+        res1 = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(torch.is_inference(res1), True)
+
+        im.mode = False
+        # No reset() -- the guard on im.mode must catch this and recompile,
+        # not silently reuse the fullgraph=True-compiled result above.
+        res2 = torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(torch.is_inference(res2), False)
+
+    def test_sourceless_generic_ctx_manager_with_usage_graph_breaks(self):
+        # A context manager reached without a source (e.g. pulled out of a
+        # closure cell whose enclosing function is itself reached off a
+        # graph-internal object -- see gh-194763) has no way for Dynamo to
+        # codegen a mutation replay, since there's no source to locate the
+        # real object at runtime. `with cm:` (which calls __enter__/
+        # __exit__, mutating self.entered) must graph-break cleanly, and
+        # under fullgraph=False must fall back far enough that the real
+        # __enter__/__exit__ still run -- not silently skip them while
+        # still returning a plausible-looking value.
+        class MyCM:
+            def __init__(self):
+                self.entered = 0
+                self.exited = 0
+
+            def __enter__(self):
+                self.entered += 1
+                return self
+
+            def __exit__(self, *a):
+                self.exited += 1
+                return False
+
+        def make_method(cm):
+            local_cm = cm
+
+            def method(self, x):
+                with local_cm:
+                    return x + 1
+
+            return method
+
+        class A:
+            method = make_method(MyCM())
+
+        def fn(x):
+            return A().method(x)
+
+        x = torch.tensor(1.0)
+        ref = fn(x)
+        cm = A.method.__closure__[0].cell_contents
+        self.assertEqual((cm.entered, cm.exited), (1, 1))
+
+        torch._dynamo.reset()
+        res = torch.compile(fn, backend="eager", fullgraph=False)(x)
+        self.assertEqual(ref, res)
+        self.assertEqual((cm.entered, cm.exited), (2, 2))
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        # The builder rejects the sourceless context manager before creating
+        # an untracked wrapper that could lose __enter__/__exit__ mutations.
+        self.assertEqual(
+            ctx.exception.gb_type,
+            "Sourceless context manager entered without mutation support",
+        )
+
+    def test_sourceless_generic_ctx_manager_method_call_graph_breaks(self):
+        # Same setup as test_sourceless_generic_ctx_manager_with_usage_graph_breaks,
+        # but for an ordinary (non-`with`) method call rather than __enter__/
+        # __exit__. This must graph-break cleanly too -- not silently drop
+        # the call's return value and mutation (as happens if the object is
+        # incorrectly treated as safe to inline methods on), and not crash
+        # with an internal AssertionError in method_setattr_standard.
+        class Counter:
+            # __enter__/__exit__ are what used to make is_generic_ctx_manager_cls
+            # match this class and route it through the removed
+            # GenericContextWrappingVariable branch; without them, this test
+            # would exercise a different, never-buggy code path.
+            def __init__(self):
+                self.log = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def rec(self, v):
+                self.log.append(v)
+                return len(self.log)
+
+        def make_method(counter):
+            local_counter = counter
+
+            def method(self, x):
+                return x + local_counter.rec(1)
+
+            return method
+
+        class A:
+            method = make_method(Counter())
+
+        def fn(x):
+            return A().method(x)
+
+        x = torch.tensor(1.0)
+        ref = fn(x)
+        counter = A.method.__closure__[0].cell_contents
+        # rec() returns len(self.log) after appending, so each call's
+        # result -- and therefore fn's return value -- depends on how many
+        # times rec() has been called before it. ref != the next call's
+        # result by construction; check both against the counter state that
+        # produced them instead of comparing them to each other.
+        self.assertEqual((ref.item(), counter.log), (2.0, [1]))
+
+        torch._dynamo.reset()
+        res = torch.compile(fn, backend="eager", fullgraph=False)(x)
+        self.assertEqual((res.item(), counter.log), (3.0, [1, 1]))
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        # The same raise-only gate also prevents ordinary methods from being
+        # inlined against a sourceless, mutation-unsafe receiver.
+        self.assertEqual(
+            ctx.exception.gb_type,
+            "Sourceless context manager entered without mutation support",
+        )
+
+    def test_sourceless_decorator_ctx_manager_other_method_graph_breaks(self):
+        # SourcelessBuilder.create's types.MethodType branch builds a fresh,
+        # untracked UserDefinedObjectVariable for __self__ when it's a
+        # torch.utils._contextlib._DecoratorContextManager instance reached
+        # via a closure cell -- but only to support resolving a bound
+        # *.clone* call symbolically (see
+        # maybe_reconstruct_decorator_ctx_manager_clone in user_defined.py).
+        # That untracked VT must never be used as the receiver for inlining
+        # some OTHER method: it has no source, so a mutation performed by an
+        # inlined call wouldn't be replayable, and a non-mutating call's
+        # return value would be used without ever having actually run on the
+        # real object. The gate must key off which *method* is bound
+        # (value.__func__ is the base class's .clone), not just the type of
+        # __self__ -- a user-defined _DecoratorContextManager subclass with
+        # an extra method is the case that would slip through a type-only
+        # gate. See gh-194763.
+        class MyCM(torch.utils._contextlib._DecoratorContextManager):
+            def __init__(self):
+                self.log = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def rec(self, v):
+                self.log.append(v)
+                return len(self.log)
+
+        def make_method(bound):
+            local_bound = bound
+
+            def method(self, x):
+                return x + local_bound(1)
+
+            return method
+
+        class A:
+            method = make_method(MyCM().rec)
+
+        def fn(x):
+            return A().method(x)
+
+        cm = A.method.__closure__[0].cell_contents.__self__
+        x = torch.tensor(1.0)
+        ref = fn(x)
+        self.assertEqual((ref.item(), cm.log), (2.0, [1]))
+
+        torch._dynamo.reset()
+        res = torch.compile(fn, backend="eager", fullgraph=False)(x)
+        # If local_bound(1) were silently inlined with an untracked self (the
+        # bug this test guards), the real cm.log would never be appended to
+        # and res would incorrectly equal ref instead of reflecting the real
+        # call's effect.
+        self.assertEqual((res.item(), cm.log), (3.0, [1, 1]))
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(
+            ctx.exception.gb_type,
+            "Sourceless _DecoratorContextManager method reconstruction unsupported",
+        )
+
+    def test_sourceless_decorator_ctx_manager_inherited_clone_graph_breaks(self):
+        # A sourceless subclass that inherits the base clone() has the same
+        # function identity as supported context managers, but its class is
+        # not reconstructable. The shared allowlist must reject that pair at
+        # the builder gate instead of handing an untracked self to normal
+        # method inlining. See gh-194763.
+        class MyCM(torch.utils._contextlib._DecoratorContextManager):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        def make_method(bound):
+            local_bound = bound
+
+            def method(self, x):
+                local_bound()
+                return x + 1
+
+            return method
+
+        class A:
+            method = make_method(MyCM().clone)
+
+        def fn(x):
+            return A().method(x)
+
+        x = torch.tensor(1.0)
+        ref = fn(x)
+        torch._dynamo.reset()
+        res = torch.compile(fn, backend="eager", fullgraph=False)(x)
+        self.assertEqual(ref, res)
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(
+            ctx.exception.gb_type,
+            "Sourceless _DecoratorContextManager method reconstruction unsupported",
+        )
+
+    def test_sourceless_decorator_ctx_manager_mutating_method_graph_breaks(self):
+        # Same bug as test_sourceless_decorator_ctx_manager_other_method_graph_breaks,
+        # but for a method that mutates self directly (STORE_ATTR) rather
+        # than a tracked container -- this is what would hit the internal
+        # AssertionError in method_setattr_standard if the untracked VT were
+        # incorrectly used as an inlining receiver, under both
+        # fullgraph=False and fullgraph=True.
+        class MyCM(torch.utils._contextlib._DecoratorContextManager):
+            def __init__(self):
+                self.n = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def bump(self):
+                self.n = self.n + 1
+                return self.n
+
+        def make_method(bound):
+            local_bound = bound
+
+            def method(self, x):
+                return x + local_bound()
+
+            return method
+
+        class A:
+            method = make_method(MyCM().bump)
+
+        def fn(x):
+            return A().method(x)
+
+        cm = A.method.__closure__[0].cell_contents.__self__
+        x = torch.tensor(1.0)
+        ref = fn(x)
+        self.assertEqual((ref.item(), cm.n), (2.0, 1))
+
+        torch._dynamo.reset()
+        # Must not raise AssertionError: Attempted setattr on a user-defined
+        # object that does not have an AttributeMutation mutation_type.
+        # bump() returns self.n after incrementing it, so (like rec() above)
+        # each call's result depends on cm.n's state at that point -- check
+        # against that state rather than comparing to `ref` directly.
+        res = torch.compile(fn, backend="eager", fullgraph=False)(x)
+        self.assertEqual((res.item(), cm.n), (3.0, 2))
+
+        torch._dynamo.reset()
+        with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
+            torch.compile(fn, backend="eager", fullgraph=True)(x)
+        self.assertEqual(
+            ctx.exception.gb_type,
+            "Sourceless _DecoratorContextManager method reconstruction unsupported",
+        )
+
     def test_inspect_signature_parameters(self):
         import inspect
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -15931,18 +15931,7 @@ fn
         ["no_grad", "enable_grad", "dual_level"],
     )
     def test_sourceless_bound_method_in_closure(self, grad_mode_decorator):
-        # Constructing an object inside the graph and calling a grad-mode
-        # decorated method on it (e.g. @torch.no_grad()) requires wrapping a
-        # bound method (the decorator's ctx_factory closure cell) whose
-        # __self__ was never observed directly by Dynamo, and then cloning
-        # that context manager (self.__class__()) without a source to
-        # construct from. See gh-194763.
-        #
-        # Each case runs under an ambient state the decorator actually
-        # flips, so a version that silently dropped the decorator's effect
-        # (rather than truly applying it) would produce a different,
-        # detectably wrong result -- not just coincidentally match the
-        # no-op default.
+        # Each case makes the decorator's state change observable.
         if grad_mode_decorator == "no_grad":
 
             class A:
@@ -15961,10 +15950,6 @@ fn
                     return x + 1
 
             def fn(x):
-                # Ambient grad is enabled by default, so enable_grad's
-                # effect is only observable if the call itself happens
-                # inside an outer no_grad -- otherwise "did the decorator
-                # apply" and "did it get silently dropped" look identical.
                 with torch.no_grad():
                     return A().method(x)
 
@@ -15973,11 +15958,6 @@ fn
             class A:
                 @torch.autograd.forward_ad.dual_level()
                 def method(self, x):
-                    # _current_level is -1 outside any dual_level context and
-                    # >= 0 inside one; reading it directly makes a dropped
-                    # dual_level entry (silently falling back to -1) produce
-                    # a different, wrong numeric result instead of an
-                    # incidental match.
                     return x + torch.autograd.forward_ad._current_level
 
             def fn(x):
@@ -15990,20 +15970,10 @@ fn
         res = opt_fn(x)
         self.assertEqual(ref, res)
         if grad_mode_decorator in ("no_grad", "enable_grad"):
-            # Value equality alone doesn't exercise what these decorators
-            # actually control; assert the grad-mode side effect matches
-            # too.
             self.assertEqual(ref.requires_grad, res.requires_grad)
 
     def test_sourceless_bound_method_in_closure_set_grad_enabled_graph_breaks(self):
-        # set_grad_enabled.clone() forwards a saved constructor arg and
-        # mutates real global autograd state as a side effect of
-        # construction (unlike no_grad/enable_grad/dual_level's unmodified
-        # clone), so it is deliberately NOT in
-        # maybe_reconstruct_decorator_ctx_manager_clone's allowlist. It
-        # should graph-break cleanly under fullgraph=True (and fall back to
-        # eager under fullgraph=False), not silently drop the decorator's
-        # effect. See gh-194763.
+        # set_grad_enabled.clone() is excluded because its constructor needs an arg.
         class A:
             @torch.set_grad_enabled(False)
             def method(self, x):
@@ -16022,8 +15992,6 @@ fn
         torch._dynamo.reset()
         with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
             torch.compile(fn, backend="eager", fullgraph=True)(x)
-        # The shared reconstruction predicate rejects set_grad_enabled's
-        # overridden clone/class pair at SourcelessBuilder's gate.
         self.assertEqual(
             ctx.exception.gb_type,
             "Sourceless _DecoratorContextManager method reconstruction unsupported",
@@ -16031,22 +15999,7 @@ fn
 
     @parametrize("mode", [True, False])
     def test_sourceless_bound_method_in_closure_inference_mode_graph_breaks(self, mode):
-        # inference_mode.clone() forwards a saved constructor arg
-        # (self.mode). maybe_reconstruct_decorator_ctx_manager_clone
-        # resolves this symbolically (avoiding the torch/autograd skip-list
-        # break) only when it can build a real source for self.mode --
-        # otherwise baking it in as an unguarded constant would silently
-        # reuse a stale value if the real instance's .mode is mutated
-        # between compiles without an intervening reset. Here `self` (the
-        # inference_mode instance) is reached only via a closure cell of a
-        # method that's itself reached off a graph-internal object (A()) --
-        # genuinely sourceless, gh-194763's exact scope -- so no source is
-        # available and this case correctly falls through: graph-break
-        # cleanly under fullgraph=True, fall back to eager under
-        # fullgraph=False. Contrast with a *sourced* inference_mode
-        # instance (e.g. `@torch.inference_mode()` applied directly to a
-        # module-level function), which does get the fast path -- see
-        # test_torch_inference_mode_ctx in test_export.py.
+        # inference_mode.clone() needs a source to guard self.mode.
         class A:
             @torch.inference_mode(mode)
             def method(self, x):
@@ -16066,31 +16019,12 @@ fn
         torch._dynamo.reset()
         with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
             torch.compile(fn, backend="eager", fullgraph=True)(x)
-        # Although the function/class pair is otherwise reconstructable,
-        # inference_mode.clone needs a source for self.mode. SourcelessBuilder
-        # rejects it before constructing an untracked receiver VT.
         self.assertEqual(
             ctx.exception.gb_type,
             "Sourceless _DecoratorContextManager method reconstruction unsupported",
         )
 
     def test_sourced_inference_mode_clone_guards_on_mode(self):
-        # Contrast with test_sourceless_bound_method_in_closure_inference_mode_graph_breaks
-        # above: here the inference_mode instance itself IS sourced (a
-        # module-scope-like local reachable directly from the compiled
-        # root function's closure, the same shape as
-        # test_torch_inference_mode_ctx in test_export.py), so
-        # maybe_reconstruct_decorator_ctx_manager_clone's inference_mode
-        # case takes the fast path and builds mode_var with a real source
-        # (AttrSource(obj_source, "mode")) rather than falling through.
-        # That source is what makes this safe: without it (or without
-        # this whole case, as an earlier version of this fix mistakenly
-        # dropped it entirely), mutating .mode and recompiling without an
-        # intervening torch._dynamo.reset() would either silently keep
-        # using the stale cached value or -- as actually happened -- lose
-        # the fast path altogether and regress a pre-existing, unrelated
-        # upstream test (test_torch_inference_mode_ctx) by forcing a graph
-        # break on ordinary sourced @torch.inference_mode() usage.
         im = torch.inference_mode(True)
 
         @im
@@ -16104,21 +16038,11 @@ fn
         self.assertEqual(torch.is_inference(res1), True)
 
         im.mode = False
-        # No reset() -- the guard on im.mode must catch this and recompile,
-        # not silently reuse the fullgraph=True-compiled result above.
+        # No reset: the guard on im.mode must trigger recompilation.
         res2 = torch.compile(fn, backend="eager", fullgraph=True)(x)
         self.assertEqual(torch.is_inference(res2), False)
 
     def test_sourceless_generic_ctx_manager_with_usage_graph_breaks(self):
-        # A context manager reached without a source (e.g. pulled out of a
-        # closure cell whose enclosing function is itself reached off a
-        # graph-internal object -- see gh-194763) has no way for Dynamo to
-        # codegen a mutation replay, since there's no source to locate the
-        # real object at runtime. `with cm:` (which calls __enter__/
-        # __exit__, mutating self.entered) must graph-break cleanly, and
-        # under fullgraph=False must fall back far enough that the real
-        # __enter__/__exit__ still run -- not silently skip them while
-        # still returning a plausible-looking value.
         class MyCM:
             def __init__(self):
                 self.entered = 0
@@ -16160,25 +16084,13 @@ fn
         torch._dynamo.reset()
         with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
             torch.compile(fn, backend="eager", fullgraph=True)(x)
-        # The builder rejects the sourceless context manager before creating
-        # an untracked wrapper that could lose __enter__/__exit__ mutations.
         self.assertEqual(
             ctx.exception.gb_type,
-            "Sourceless context manager entered without mutation support",
+            "Sourceless context manager without mutation support",
         )
 
     def test_sourceless_generic_ctx_manager_method_call_graph_breaks(self):
-        # Same setup as test_sourceless_generic_ctx_manager_with_usage_graph_breaks,
-        # but for an ordinary (non-`with`) method call rather than __enter__/
-        # __exit__. This must graph-break cleanly too -- not silently drop
-        # the call's return value and mutation (as happens if the object is
-        # incorrectly treated as safe to inline methods on), and not crash
-        # with an internal AssertionError in method_setattr_standard.
         class Counter:
-            # __enter__/__exit__ are what used to make is_generic_ctx_manager_cls
-            # match this class and route it through the removed
-            # GenericContextWrappingVariable branch; without them, this test
-            # would exercise a different, never-buggy code path.
             def __init__(self):
                 self.log = []
 
@@ -16209,11 +16121,6 @@ fn
         x = torch.tensor(1.0)
         ref = fn(x)
         counter = A.method.__closure__[0].cell_contents
-        # rec() returns len(self.log) after appending, so each call's
-        # result -- and therefore fn's return value -- depends on how many
-        # times rec() has been called before it. ref != the next call's
-        # result by construction; check both against the counter state that
-        # produced them instead of comparing them to each other.
         self.assertEqual((ref.item(), counter.log), (2.0, [1]))
 
         torch._dynamo.reset()
@@ -16223,29 +16130,12 @@ fn
         torch._dynamo.reset()
         with self.assertRaises(torch._dynamo.exc.Unsupported) as ctx:
             torch.compile(fn, backend="eager", fullgraph=True)(x)
-        # The same raise-only gate also prevents ordinary methods from being
-        # inlined against a sourceless, mutation-unsafe receiver.
         self.assertEqual(
             ctx.exception.gb_type,
-            "Sourceless context manager entered without mutation support",
+            "Sourceless context manager without mutation support",
         )
 
     def test_sourceless_decorator_ctx_manager_other_method_graph_breaks(self):
-        # SourcelessBuilder.create's types.MethodType branch builds a fresh,
-        # untracked UserDefinedObjectVariable for __self__ when it's a
-        # torch.utils._contextlib._DecoratorContextManager instance reached
-        # via a closure cell -- but only to support resolving a bound
-        # *.clone* call symbolically (see
-        # maybe_reconstruct_decorator_ctx_manager_clone in user_defined.py).
-        # That untracked VT must never be used as the receiver for inlining
-        # some OTHER method: it has no source, so a mutation performed by an
-        # inlined call wouldn't be replayable, and a non-mutating call's
-        # return value would be used without ever having actually run on the
-        # real object. The gate must key off which *method* is bound
-        # (value.__func__ is the base class's .clone), not just the type of
-        # __self__ -- a user-defined _DecoratorContextManager subclass with
-        # an extra method is the case that would slip through a type-only
-        # gate. See gh-194763.
         class MyCM(torch.utils._contextlib._DecoratorContextManager):
             def __init__(self):
                 self.log = []
@@ -16281,10 +16171,6 @@ fn
 
         torch._dynamo.reset()
         res = torch.compile(fn, backend="eager", fullgraph=False)(x)
-        # If local_bound(1) were silently inlined with an untracked self (the
-        # bug this test guards), the real cm.log would never be appended to
-        # and res would incorrectly equal ref instead of reflecting the real
-        # call's effect.
         self.assertEqual((res.item(), cm.log), (3.0, [1, 1]))
 
         torch._dynamo.reset()
@@ -16296,11 +16182,6 @@ fn
         )
 
     def test_sourceless_decorator_ctx_manager_inherited_clone_graph_breaks(self):
-        # A sourceless subclass that inherits the base clone() has the same
-        # function identity as supported context managers, but its class is
-        # not reconstructable. The shared allowlist must reject that pair at
-        # the builder gate instead of handing an untracked self to normal
-        # method inlining. See gh-194763.
         class MyCM(torch.utils._contextlib._DecoratorContextManager):
             def __enter__(self):
                 return self
@@ -16338,12 +16219,6 @@ fn
         )
 
     def test_sourceless_decorator_ctx_manager_mutating_method_graph_breaks(self):
-        # Same bug as test_sourceless_decorator_ctx_manager_other_method_graph_breaks,
-        # but for a method that mutates self directly (STORE_ATTR) rather
-        # than a tracked container -- this is what would hit the internal
-        # AssertionError in method_setattr_standard if the untracked VT were
-        # incorrectly used as an inlining receiver, under both
-        # fullgraph=False and fullgraph=True.
         class MyCM(torch.utils._contextlib._DecoratorContextManager):
             def __init__(self):
                 self.n = 0
@@ -16378,11 +16253,6 @@ fn
         self.assertEqual((ref.item(), cm.n), (2.0, 1))
 
         torch._dynamo.reset()
-        # Must not raise AssertionError: Attempted setattr on a user-defined
-        # object that does not have an AttributeMutation mutation_type.
-        # bump() returns self.n after incrementing it, so (like rec() above)
-        # each call's result depends on cm.n's state at that point -- check
-        # against that state rather than comparing to `ref` directly.
         res = torch.compile(fn, backend="eager", fullgraph=False)(x)
         self.assertEqual((res.item(), cm.n), (3.0, 2))
 

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2556,6 +2556,16 @@
       ]
     }
   ],
+  "GB6956": [
+    {
+      "Gb_type": "Sourceless _DecoratorContextManager method reconstruction unsupported",
+      "Context": "{type(value.__self__)}.{value.__func__.__name__}",
+      "Explanation": "{type(value.__self__)} was reached without a source (e.g. via a closure cell) and {value.__func__.__name__} cannot be reconstructed safely, so Dynamo cannot safely inline it without risking a mutation on an object it can't track.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
+      ]
+    }
+  ],
   "GB8335": [
     {
       "Gb_type": "Generator reconstruction with mutations",
@@ -5498,6 +5508,16 @@
       "Explanation": "Expected additional_inputs to be a list/tuple but got {additional_inputs.python_type()}",
       "Hints": [
         "This is likely to be a Dynamo bug. Please report an issue to PyTorch."
+      ]
+    }
+  ],
+  "GB2710": [
+    {
+      "Gb_type": "Sourceless context manager entered without mutation support",
+      "Context": "{value_type.__module__}.{value_type.__qualname__}",
+      "Explanation": "{value_type} was reached without a source (e.g. via a closure cell) and Dynamo cannot safely enter it or call its methods without a way to replay any resulting mutation on the real object.",
+      "Hints": [
+        "It may be possible to write Dynamo tracing rules for this code. Please report an issue to PyTorch if you encounter this graph break often and it is causing performance issues."
       ]
     }
   ],

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -5513,7 +5513,7 @@
   ],
   "GB2710": [
     {
-      "Gb_type": "Sourceless context manager entered without mutation support",
+      "Gb_type": "Sourceless context manager without mutation support",
       "Context": "{value_type.__module__}.{value_type.__qualname__}",
       "Explanation": "{value_type} was reached without a source (e.g. via a closure cell) and Dynamo cannot safely enter it or call its methods without a way to replay any resulting mutation on the real object.",
       "Hints": [

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -330,6 +330,8 @@ from .user_defined import (
     FrozenDataClassVariable,
     InspectVariable,
     IntWrapperVariable,
+    is_generic_ctx_manager_cls,
+    is_reconstructable_decorator_ctx_manager_clone,
     KeyedJaggedTensorVariable,
     MutableMappingVariable,
     SimpleNamespaceVariable,
@@ -5376,8 +5378,64 @@ class SourcelessBuilder:
                 except NotImplementedError:
                     pass  # failthrough to unimplemented branch
             else:
-                # Instance method — look up the VT for __self__ via side effects
+                # Instance method - look up the VT for __self__ via side
+                # effects. Fall back to building __self__ fresh only for the
+                # narrow case this supports safely: a closure cell holding a
+                # bound _DecoratorContextManager.clone method Dynamo never
+                # observed directly (e.g. the @torch.no_grad()-style
+                # decorator's ctx_factory -- see gh-194763). The fresh VT is
+                # a plain UserDefinedObjectVariable, not a
+                # GenericContextWrappingVariable -- it has no source and so
+                # no way to track/replay mutations, so only a clone/class
+                # pair that can be reconstructed without a source may use
+                # it. Gating on the shared reconstruction predicate and
+                # excluding inference_mode.clone (which needs a source for
+                # self.mode) makes that true: supported pairs are resolved
+                # exclusively as a .value-read by
+                # user_defined.maybe_reconstruct_decorator_ctx_manager_clone,
+                # which never inlines anything on this VT. Without the
+                # shared pair check, an arbitrary bound method or an
+                # unlisted subclass inheriting the base clone could get this
+                # same untracked VT and fall through to normal inlining in
+                # UserMethodVariable.call_function -- silently wrong results
+                # or an internal crash, the same bug class this branch exists
+                # to prevent. Unsupported decorator context-manager pairs
+                # take the dedicated `unimplemented` path below.
                 obj_vt = tx.output.side_effects.id_to_variable.get(id(value.__self__))
+                if obj_vt is None and isinstance(
+                    value.__self__, torch.utils._contextlib._DecoratorContextManager
+                ):
+                    if is_reconstructable_decorator_ctx_manager_clone(
+                        value.__func__, type(value.__self__)
+                    ) and (
+                        value.__func__
+                        is not torch.autograd.grad_mode.inference_mode.clone
+                    ):
+                        obj_vt = UserDefinedObjectVariable(value.__self__)
+                    else:
+                        # This function/class pair cannot be reconstructed.
+                        # Building the untracked VT above is only safe because
+                        # it's never inlined; inlining an unsupported method
+                        # on it would reopen the bug this branch exists to
+                        # prevent (see comment above).
+                        # Raise here with a precise, supportable-limitation
+                        # message rather than silently falling through to
+                        # SourcelessBuilder.create's generic catch-all, which
+                        # carries a "this is a Dynamo bug" hint that's wrong
+                        # for this well-understood case.
+                        unimplemented(
+                            gb_type="Sourceless _DecoratorContextManager method reconstruction unsupported",
+                            context=f"{type(value.__self__)}.{value.__func__.__name__}",
+                            explanation=(
+                                f"{type(value.__self__)} was reached without a "
+                                "source (e.g. via a closure cell) and "
+                                f"{value.__func__.__name__} cannot be "
+                                "reconstructed safely, so "
+                                "Dynamo cannot safely inline it without risking "
+                                "a mutation on an object it can't track."
+                            ),
+                            hints=[*graph_break_hints.SUPPORTABLE],
+                        )
                 if obj_vt is not None:
                     return torch._dynamo.variables.UserMethodVariable(
                         value.__func__, obj_vt
@@ -5443,6 +5501,23 @@ class SourcelessBuilder:
             return SliceVariable(items, tx)  # pyrefly: ignore[bad-argument-type]
         elif isinstance(value, torch.nn.parallel.distributed.DistributedDataParallel):
             return UnspecializedNNModuleVariable(value)
+        # This raise-only branch is the structural counterpart to the
+        # _DecoratorContextManager bound-method rejection above: a generic
+        # context-manager object reached without a source cannot safely replay
+        # mutations. Do not restore the removed unsafe wrapping path. See
+        # gh-194763.
+        elif is_generic_ctx_manager_cls(type(value)):
+            unimplemented(
+                gb_type="Sourceless context manager entered without mutation support",
+                context=f"{value_type.__module__}.{value_type.__qualname__}",
+                explanation=(
+                    f"{value_type} was reached without a source (e.g. via a "
+                    "closure cell) and Dynamo cannot safely enter it or call "
+                    "its methods without a way to replay any resulting "
+                    "mutation on the real object."
+                ),
+                hints=[*graph_break_hints.SUPPORTABLE],
+            )
         elif istype(value, object):
             return ObjectVariable(value)
         elif (

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -5379,28 +5379,10 @@ class SourcelessBuilder:
                     pass  # failthrough to unimplemented branch
             else:
                 # Instance method - look up the VT for __self__ via side
-                # effects. Fall back to building __self__ fresh only for the
-                # narrow case this supports safely: a closure cell holding a
-                # bound _DecoratorContextManager.clone method Dynamo never
-                # observed directly (e.g. the @torch.no_grad()-style
-                # decorator's ctx_factory -- see gh-194763). The fresh VT is
-                # a plain UserDefinedObjectVariable, not a
-                # GenericContextWrappingVariable -- it has no source and so
-                # no way to track/replay mutations, so only a clone/class
-                # pair that can be reconstructed without a source may use
-                # it. Gating on the shared reconstruction predicate and
-                # excluding inference_mode.clone (which needs a source for
-                # self.mode) makes that true: supported pairs are resolved
-                # exclusively as a .value-read by
-                # user_defined.maybe_reconstruct_decorator_ctx_manager_clone,
-                # which never inlines anything on this VT. Without the
-                # shared pair check, an arbitrary bound method or an
-                # unlisted subclass inheriting the base clone could get this
-                # same untracked VT and fall through to normal inlining in
-                # UserMethodVariable.call_function -- silently wrong results
-                # or an internal crash, the same bug class this branch exists
-                # to prevent. Unsupported decorator context-manager pairs
-                # take the dedicated `unimplemented` path below.
+                # effects. Build a sourceless receiver only for allowlisted
+                # clone/class pairs whose clone reconstruction does not read
+                # or mutate it. inference_mode.clone is excluded because it
+                # requires a source for self.mode.
                 obj_vt = tx.output.side_effects.id_to_variable.get(id(value.__self__))
                 if obj_vt is None and isinstance(
                     value.__self__, torch.utils._contextlib._DecoratorContextManager
@@ -5413,16 +5395,6 @@ class SourcelessBuilder:
                     ):
                         obj_vt = UserDefinedObjectVariable(value.__self__)
                     else:
-                        # This function/class pair cannot be reconstructed.
-                        # Building the untracked VT above is only safe because
-                        # it's never inlined; inlining an unsupported method
-                        # on it would reopen the bug this branch exists to
-                        # prevent (see comment above).
-                        # Raise here with a precise, supportable-limitation
-                        # message rather than silently falling through to
-                        # SourcelessBuilder.create's generic catch-all, which
-                        # carries a "this is a Dynamo bug" hint that's wrong
-                        # for this well-understood case.
                         unimplemented(
                             gb_type="Sourceless _DecoratorContextManager method reconstruction unsupported",
                             context=f"{type(value.__self__)}.{value.__func__.__name__}",
@@ -5501,14 +5473,10 @@ class SourcelessBuilder:
             return SliceVariable(items, tx)  # pyrefly: ignore[bad-argument-type]
         elif isinstance(value, torch.nn.parallel.distributed.DistributedDataParallel):
             return UnspecializedNNModuleVariable(value)
-        # This raise-only branch is the structural counterpart to the
-        # _DecoratorContextManager bound-method rejection above: a generic
-        # context-manager object reached without a source cannot safely replay
-        # mutations. Do not restore the removed unsafe wrapping path. See
-        # gh-194763.
+        # A sourceless context manager cannot safely replay mutations.
         elif is_generic_ctx_manager_cls(type(value)):
             unimplemented(
-                gb_type="Sourceless context manager entered without mutation support",
+                gb_type="Sourceless context manager without mutation support",
                 context=f"{value_type.__module__}.{value_type.__qualname__}",
                 explanation=(
                     f"{value_type} was reached without a source (e.g. via a "

--- a/torch/_dynamo/variables/functions.py
+++ b/torch/_dynamo/variables/functions.py
@@ -103,7 +103,11 @@ from .base import (
     VariableTracker,
 )
 from .constant import ConstantVariable
-from .user_defined import UserDefinedObjectVariable
+from .user_defined import (
+    is_reconstructable_decorator_ctx_manager_clone,
+    maybe_reconstruct_decorator_ctx_manager_clone,
+    UserDefinedObjectVariable,
+)
 
 
 try:
@@ -1840,6 +1844,31 @@ class UserMethodVariable(UserFunctionVariable):
         if self.is_constant:
             fn = getattr(self.obj.value, self.fn.__name__)  # type: ignore[attr-defined]
             return invoke_and_store_as_constant(tx, fn, self.get_name(), args, kwargs)
+        if (
+            self.source is None
+            and isinstance(self.obj, variables.UserDefinedObjectVariable)
+            and isinstance(
+                self.obj.value, torch.utils._contextlib._DecoratorContextManager
+            )
+            and is_reconstructable_decorator_ctx_manager_clone(
+                self.fn, type(self.obj.value)
+            )
+        ):
+            # A bound `clone` method reached with no source -- e.g. via a
+            # closure cell wrapping a context manager created outside the
+            # traced region (see gh-194763) -- can't be inlined the normal
+            # way: constructing a fresh instance requires a `source` on the
+            # class reference (see UserDefinedClassVariable.call_function's
+            # generic-construction gate). maybe_reconstruct_decorator_ctx_manager_clone
+            # handles this the same way UserDefinedObjectVariable.call_function
+            # already does for a bound `clone` reached as a plain callable
+            # value. The predicate guarantees a supported function/class
+            # pair; only source-dependent reconstruction can still decline.
+            reconstructed = maybe_reconstruct_decorator_ctx_manager_clone(
+                tx, self.fn, self.obj.value, self.obj.source, args, kwargs
+            )
+            if reconstructed is not None:
+                return reconstructed
         return super().call_function(tx, args, kwargs)
 
     def _get_func(self, tx: "InstructionTranslatorBase") -> VariableTracker:

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -242,6 +242,92 @@ def is_forbidden_context_manager(ctx: object) -> bool:
     return ctx in f_ctxs
 
 
+def is_reconstructable_decorator_ctx_manager_clone(
+    func: Callable[..., Any], obj_cls: type[Any]
+) -> bool:
+    return (
+        func is torch.utils._contextlib._DecoratorContextManager.clone
+        and obj_cls
+        in (torch.no_grad, torch.enable_grad, torch.autograd.forward_ad.dual_level)
+        or func is torch.autograd.grad_mode.inference_mode.clone
+        and obj_cls is torch.autograd.grad_mode.inference_mode
+    )
+
+
+def maybe_reconstruct_decorator_ctx_manager_clone(
+    tx: "InstructionTranslatorBase",
+    func: Callable[..., Any],
+    obj: Any,
+    obj_source: "Source | None",
+    args: "list[VariableTracker]",
+    kwargs: "dict[str, VariableTracker]",
+    /,
+) -> "VariableTracker | None":
+    """Symbolically (non-eager) reconstruct a call to a bound
+    _DecoratorContextManager.clone method, for a fixed allowlist of
+    PyTorch-owned subclasses. `func` is the unbound function
+    (`bound_method.__func__`), `obj` is the real Python object it's bound to
+    (`bound_method.__self__`), `obj_source` is `obj`'s source if Dynamo has
+    one (e.g. the closure cell of a directly-compiled root function), else
+    None (e.g. reached only via a closure cell nested off a graph-internal
+    object -- see gh-194763).
+
+    clone() is `return self.__class__()` (or `self.__class__(self.mode)` for
+    inference_mode, which overrides it). Constructing a fresh instance
+    normally requires inlining through UserDefinedClassVariable.call_function,
+    which needs a `source` on the class reference. When the bound `clone`
+    itself has no source, inlining isn't available, so the class is
+    reconstructed directly via TorchCtxManagerClassVariable instead (the
+    same path a sourced `torch.no_grad()` call would take). This is also
+    used for a SOURCED `clone` to skip inlining, since `clone` lives under
+    torch/autograd and is skip-listed from tracing -- without this fast
+    path, even the fully-sourced case would take an unnecessary graph break.
+
+    Deliberately an explicit allowlist, not "any class using the base
+    clone": TorchCtxManagerClassVariable.call_function hard-asserts on
+    argument arity per class (e.g. it requires exactly one arg for
+    set_grad_enabled, _set_fwd_grad_enabled), so blindly forwarding to it
+    for an unhandled class can crash with an internal AssertionError instead
+    of a graph break. Other _DecoratorContextManager subclasses
+    (set_grad_enabled, set_multithreading_enabled,
+    _force_original_view_tracking, set_stance, _set_fwd_grad_enabled, ...)
+    return None here. SourcelessBuilder rejects those unsupported pairs
+    before constructing an untracked receiver VT; sourced callers retain
+    their normal handling.
+
+    inference_mode.clone() forwards `self.mode`, which needs its own source
+    to be guarded safely -- baking it in as an unguarded constant would let
+    a cached compile silently go stale if the real object's `.mode` is
+    mutated later without an intervening recompile (reproduced via
+    `im = torch.inference_mode(True); ...; im.mode = False` with no
+    `torch._dynamo.reset()` between compiles). When `obj_source` is None
+    (the object itself has no source -- gh-194763's actual scope), there is
+    no way to derive a source for `.mode` either, so this case falls
+    through (return None) instead of guessing. The primary sourceless
+    builder path rejects this pair before constructing an untracked
+    receiver; other callers apply their own unsupported fallback.
+
+    Returns None if `func`/`obj` don't match a handled case; the caller
+    should fall through to its own default handling in that case.
+    """
+    if (
+        args
+        or kwargs
+        or not is_reconstructable_decorator_ctx_manager_clone(func, obj.__class__)
+    ):
+        return None
+    if func is torch.utils._contextlib._DecoratorContextManager.clone:
+        return variables.TorchCtxManagerClassVariable(obj.__class__).call_function(
+            tx, [], {}
+        )
+    if obj_source is None:
+        return None
+    mode_var = VariableTracker.build(tx, obj.mode, AttrSource(obj_source, "mode"))
+    return variables.TorchCtxManagerClassVariable(obj.__class__).call_function(
+        tx, [mode_var], {}
+    )
+
+
 def is_generic_ctx_manager_cls(cls: type) -> bool:
     # A class is wrapped/entered as a GenericContextWrappingVariable only when
     # its __enter__/__exit__ are plain Python-function methods: GCWV.enter/exit
@@ -3159,26 +3245,14 @@ class UserDefinedObjectVariable(UserDefinedVariable):
         elif istype(self.value, types.MethodType):
             func = self.value.__func__
             obj = self.value.__self__
-            if (
-                func is torch.utils._contextlib._DecoratorContextManager.clone
-                and variables.TorchCtxManagerClassVariable.is_matching_cls(
-                    obj.__class__
-                )
-                and not (args or kwargs)
-            ):
-                return variables.TorchCtxManagerClassVariable(
-                    obj.__class__
-                ).call_function(tx, args, kwargs)
-
-            if (
-                func is torch.autograd.grad_mode.inference_mode.clone
-                and obj.__class__ is torch.autograd.grad_mode.inference_mode
-            ):
-                # simulate the inference_mode.clone implementation
-                var = VariableTracker.build(tx, obj.mode)  # type: ignore[attr-defined]
-                return variables.TorchCtxManagerClassVariable(
-                    obj.__class__
-                ).call_function(tx, [var], kwargs)
+            obj_source = (
+                AttrSource(self.source, "__self__") if self.source is not None else None
+            )
+            reconstructed = maybe_reconstruct_decorator_ctx_manager_clone(
+                tx, func, obj, obj_source, args, kwargs
+            )
+            if reconstructed is not None:
+                return reconstructed
 
             if self.source is None:
                 unimplemented(

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -248,8 +248,13 @@ def is_reconstructable_decorator_ctx_manager_clone(
     return (
         func is torch.utils._contextlib._DecoratorContextManager.clone
         and obj_cls
-        in (torch.no_grad, torch.enable_grad, torch.autograd.forward_ad.dual_level)
-        or func is torch.autograd.grad_mode.inference_mode.clone
+        in (
+            torch.no_grad,
+            torch.enable_grad,
+            torch.autograd.forward_ad.dual_level,
+        )
+    ) or (
+        func is torch.autograd.grad_mode.inference_mode.clone
         and obj_cls is torch.autograd.grad_mode.inference_mode
     )
 
@@ -263,52 +268,12 @@ def maybe_reconstruct_decorator_ctx_manager_clone(
     kwargs: "dict[str, VariableTracker]",
     /,
 ) -> "VariableTracker | None":
-    """Symbolically (non-eager) reconstruct a call to a bound
-    _DecoratorContextManager.clone method, for a fixed allowlist of
-    PyTorch-owned subclasses. `func` is the unbound function
-    (`bound_method.__func__`), `obj` is the real Python object it's bound to
-    (`bound_method.__self__`), `obj_source` is `obj`'s source if Dynamo has
-    one (e.g. the closure cell of a directly-compiled root function), else
-    None (e.g. reached only via a closure cell nested off a graph-internal
-    object -- see gh-194763).
+    """Reconstruct an allowlisted bound _DecoratorContextManager.clone call.
 
-    clone() is `return self.__class__()` (or `self.__class__(self.mode)` for
-    inference_mode, which overrides it). Constructing a fresh instance
-    normally requires inlining through UserDefinedClassVariable.call_function,
-    which needs a `source` on the class reference. When the bound `clone`
-    itself has no source, inlining isn't available, so the class is
-    reconstructed directly via TorchCtxManagerClassVariable instead (the
-    same path a sourced `torch.no_grad()` call would take). This is also
-    used for a SOURCED `clone` to skip inlining, since `clone` lives under
-    torch/autograd and is skip-listed from tracing -- without this fast
-    path, even the fully-sourced case would take an unnecessary graph break.
-
-    Deliberately an explicit allowlist, not "any class using the base
-    clone": TorchCtxManagerClassVariable.call_function hard-asserts on
-    argument arity per class (e.g. it requires exactly one arg for
-    set_grad_enabled, _set_fwd_grad_enabled), so blindly forwarding to it
-    for an unhandled class can crash with an internal AssertionError instead
-    of a graph break. Other _DecoratorContextManager subclasses
-    (set_grad_enabled, set_multithreading_enabled,
-    _force_original_view_tracking, set_stance, _set_fwd_grad_enabled, ...)
-    return None here. SourcelessBuilder rejects those unsupported pairs
-    before constructing an untracked receiver VT; sourced callers retain
-    their normal handling.
-
-    inference_mode.clone() forwards `self.mode`, which needs its own source
-    to be guarded safely -- baking it in as an unguarded constant would let
-    a cached compile silently go stale if the real object's `.mode` is
-    mutated later without an intervening recompile (reproduced via
-    `im = torch.inference_mode(True); ...; im.mode = False` with no
-    `torch._dynamo.reset()` between compiles). When `obj_source` is None
-    (the object itself has no source -- gh-194763's actual scope), there is
-    no way to derive a source for `.mode` either, so this case falls
-    through (return None) instead of guessing. The primary sourceless
-    builder path rejects this pair before constructing an untracked
-    receiver; other callers apply their own unsupported fallback.
-
-    Returns None if `func`/`obj` don't match a handled case; the caller
-    should fall through to its own default handling in that case.
+    The positive allowlist excludes subclasses whose constructor arity is not
+    compatible with clone(). inference_mode.clone also requires obj_source so
+    self.mode can be guarded rather than baked into the graph. Unsupported
+    cases return None for the caller to handle.
     """
     if (
         args


### PR DESCRIPTION
Fixes #194763.

## Summary

`torch.compile(fullgraph=True)` raised `Unsupported: Unexpected type in sourceless builder` when a function constructed an object inside the traced region and called one of its grad-mode-decorated methods (`@torch.no_grad()`, `@torch.enable_grad()`, `@torch.autograd.forward_ad.dual_level()`, `@torch.inference_mode()`):

```python
class A:
    @torch.no_grad()
    def method(self, x):
        return x + 1

def fn(x):
    return A().method(x)

torch.compile(fn, fullgraph=True)(torch.tensor(1.0))  # crashed
```

### Root cause

The decorator wraps the method in a closure (`torch/utils/_contextlib.py`) whose `ctx_factory` cell holds a bound `<ctx_manager>.clone` method of a context-manager instance Dynamo never observed directly. Reached off a graph-internal object, that bound method has no source, so `SourcelessBuilder.create` is asked to wrap it -- and its `types.MethodType` branch had no handling for the case, so it fell through to the terminal "unknown type" graph break.

### Fix

`SourcelessBuilder.create`'s `types.MethodType` branch now builds a fresh, sourceless `UserDefinedObjectVariable` for `__self__`, but only for an explicit allowlist of `(clone, class)` pairs whose reconstruction neither reads nor mutates that receiver: the base `_DecoratorContextManager.clone` on `no_grad` / `enable_grad` / `dual_level`, plus `inference_mode.clone`. The call is then resolved by a shared symbolic (non-eager) reconstruction helper, `maybe_reconstruct_decorator_ctx_manager_clone`, instead of by inlining `clone()` (which lives under `torch/autograd` and is skip-listed).

- The allowlist is positive, not "any base clone". `TorchCtxManagerClassVariable.call_function` asserts on constructor arity per class, so e.g. `_set_fwd_grad_enabled` (inherits the base zero-arg `clone`, but its `__init__` needs an arg) would hit a hard internal `AssertionError`; excluding it yields a clean graph break.
- `set_grad_enabled` mutates global autograd state as a side effect of construction, so it is also excluded and keeps graph-breaking until a source is available, rather than being executed.
- A plain sourceless object that merely looks like a context manager (`__enter__`/`__exit__`) now gets a dedicated `SUPPORTABLE`-hinted graph break instead of the generic `DYNAMO_BUG`-hinted "unknown type" one.

### Also: guard `inference_mode.mode`

The pre-existing sourced reconstruction path built `VariableTracker.build(tx, obj.mode)` with no source, so `.mode` was baked into the graph unguarded -- a compiled function closing over a *sourced* `inference_mode` instance would keep a stale `is_inference()` result if `.mode` were mutated between compiles without an intervening `torch._dynamo.reset()`. This PR passes the missing source (`AttrSource(obj_source, "mode")`); when no source is available (this PR's sourceless case) the pair is excluded from the gate and graph-breaks cleanly rather than baking in a constant. `test_sourced_inference_mode_clone_guards_on_mode` covers the guard.

## Test plan

New / updated regression tests in `test/dynamo/test_misc.py`:
- `test_sourceless_bound_method_in_closure` -- `no_grad` / `enable_grad` / `dual_level` apply their real effect (asserts grad-mode / dual-level state, not just value equality).
- `test_sourceless_bound_method_in_closure_{set_grad_enabled,inference_mode}_graph_breaks` -- excluded classes and the sourceless `inference_mode` case graph-break cleanly.
- `test_sourceless_decorator_ctx_manager_{other_method,mutating_method,inherited_clone}_graph_breaks` -- user-defined `_DecoratorContextManager` subclasses (extra method, mutating method, inherits base `clone` but outside the allowlist) graph-break instead of silently dropping the call or hitting an internal assert.
- `test_sourceless_generic_ctx_manager_{with_usage,method_call}_graph_breaks` -- plain sourceless context-manager objects graph-break with real side effects tracked (entered/exited counters, call log).
- `test_sourced_inference_mode_clone_guards_on_mode` -- the `.mode` guard triggers a recompile on mutation.

```
python test/dynamo/test_misc.py -k sourceless -v              # 16 passed
python test/dynamo/test_misc.py -k sourced_inference_mode -v  # 1 passed
python test/dynamo/test_ctx_manager.py                        # 141 passed, 34 skipped
python test/dynamo/test_functions.py                          # 565 passed, 9 skipped, 2 xfail
python test/dynamo/test_user_defined_object.py                # 97 passed, 8 skipped, 1 xfail
python test/dynamo/test_repros.py                             # 389 passed, 19 skipped, 4 xfail
python test/dynamo/test_export.py                             # 185 passed, 4 xfail
```

All pass. `spin quicklint`: clean.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98
