### PR TITLE
Fix numeric_limits<BFloat16>::signaling_NaN returning infinity

### DIFF
--- a/aten/src/ATen/test/half_test.cpp
+++ b/aten/src/ATen/test/half_test.cpp
@@ -83,6 +83,14 @@ TEST(TestHalf, HalfNumericLimits) {
   ASSERT_NE(limits::signaling_NaN(), limits::signaling_NaN());
 }
 
+TEST(TestBFloat16, BFloat16NumericLimits) {
+  using limits = std::numeric_limits<BFloat16>;
+  ASSERT_EQ(limits::infinity(), std::numeric_limits<float>::infinity());
+  ASSERT_NE(limits::quiet_NaN(), limits::quiet_NaN());
+  ASSERT_NE(limits::signaling_NaN(), limits::signaling_NaN());
+  ASSERT_NE(limits::signaling_NaN(), limits::infinity());
+}
+
 // Check the declared type of members of numeric_limits<Half> matches
 // the declared type of that member on numeric_limits<float>
 

--- a/torch/headeronly/util/BFloat16.h
+++ b/torch/headeronly/util/BFloat16.h
@@ -471,7 +471,7 @@ class numeric_limits<c10::BFloat16> {
     return c10::BFloat16(0x7FC0, c10::BFloat16::from_bits());
   }
   static constexpr c10::BFloat16 signaling_NaN() {
-    return c10::BFloat16(0x7F80, c10::BFloat16::from_bits());
+    return c10::BFloat16(0x7FA0, c10::BFloat16::from_bits());
   }
   static constexpr c10::BFloat16 denorm_min() {
     return c10::BFloat16(0x0001, c10::BFloat16::from_bits());


### PR DESCRIPTION
signaling_NaN() returned 0x7F80, byte-for-byte identical to infinity() two
lines above -- not a NaN at all. Use 0x7FA0 instead (exponent all ones,
mantissa non-zero, quiet bit clear), matching Half's signaling_NaN() pattern
and leaving quiet_NaN()'s 0x7FC0 as its counterpart.

Test Plan: printed the bit pattern before/after. Before: bits=0x7F80 isnan=0
==inf=1. After: bits=0x7FA0 isnan=1 ==inf=0.

This change was authored with AI assistance (Claude Code).

