### PR TITLE
[XPU][Refactor] Refactor test decoupling and device-agnostic in test_error_messages.py‎ and test_logging.py‎

### DIFF
--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -23,20 +23,12 @@ from torch._dynamo.exc import (
 )
 from torch._dynamo.testing import skipIfNotPy312, skipIfOnlyNotPy312
 from torch._dynamo.utils import counters
-<<<<<<< HEAD
-from torch.testing._internal.common_utils import IS_FBCODE, IS_S390X, munge_exc
-from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
-
-
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-=======
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_FBCODE,
+    IS_S390X,
     munge_exc,
->>>>>>> 08cd179086b (refctor 3 files)
 )
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -27,6 +27,11 @@ from torch.testing._internal.common_utils import IS_FBCODE, IS_S390X, munge_exc
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 """
 NOTE Adding tests to this file:
 
@@ -1050,9 +1055,9 @@ from user code:
     return x + y""",
         )
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+    @unittest.skipIf(not torch.accelerator.is_available(), "requires accelerator")
     def test_fx_node_error_cross_device(self):
-        linear = torch.nn.Linear(10, 20, device="cuda").eval()
+        linear = torch.nn.Linear(10, 20, device=device_type).eval()
 
         def fn(x):
             return linear(x)
@@ -1064,7 +1069,7 @@ from user code:
         self.assertIn("Tensor device mismatch", msg)
         self.assertIn("Expected all tensors to be on the same device", msg)
         self.assertIn("cpu", msg)
-        self.assertIn("cuda", msg)
+        self.assertIn(f"{device_type}", msg)
         self.assertNotIn("Dynamo failed to run FX node with fake tensors", msg)
         self.assertNotIn("Unhandled FakeTensor Device Propagation", msg)
 

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -23,13 +23,22 @@ from torch._dynamo.exc import (
 )
 from torch._dynamo.testing import skipIfNotPy312, skipIfOnlyNotPy312
 from torch._dynamo.utils import counters
+<<<<<<< HEAD
 from torch.testing._internal.common_utils import IS_FBCODE, IS_S390X, munge_exc
 from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
 device_type = (
     acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+=======
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    IS_FBCODE,
+    munge_exc,
+>>>>>>> 08cd179086b (refctor 3 files)
 )
+from torch.testing._internal.logging_utils import LoggingTestCase, make_logging_test
 
 
 """
@@ -1054,24 +1063,6 @@ from user code:
    File "test_error_messages.py", line N, in fn
     return x + y""",
         )
-
-    @unittest.skipIf(not torch.accelerator.is_available(), "requires accelerator")
-    def test_fx_node_error_cross_device(self):
-        linear = torch.nn.Linear(10, 20, device=device_type).eval()
-
-        def fn(x):
-            return linear(x)
-
-        with self.assertRaises(TorchRuntimeError) as cm:
-            torch.compile(fn, backend="eager", fullgraph=True)(torch.randn(1, 10))
-
-        msg = str(cm.exception)
-        self.assertIn("Tensor device mismatch", msg)
-        self.assertIn("Expected all tensors to be on the same device", msg)
-        self.assertIn("cpu", msg)
-        self.assertIn(f"{device_type}", msg)
-        self.assertNotIn("Dynamo failed to run FX node with fake tensors", msg)
-        self.assertNotIn("Unhandled FakeTensor Device Propagation", msg)
 
     def test_data_dependent_branching_fullgraph(self):
         def fn(x):
@@ -3031,6 +3022,32 @@ User code traceback:
     ~~~~~~~~~~~~~~~~~~~~~~~~~^^
 """,
         )
+
+
+class ErrorMessagesTestDevice(LoggingTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def test_fx_node_error_cross_device(self, device):
+        linear = torch.nn.Linear(10, 20, device=device).eval()
+
+        def fn(x):
+            return linear(x)
+
+        with self.assertRaises(TorchRuntimeError) as cm:
+            torch.compile(fn, backend="eager", fullgraph=True)(torch.randn(1, 10))
+
+        msg = str(cm.exception)
+        self.assertIn("Tensor device mismatch", msg)
+        self.assertIn("Expected all tensors to be on the same device", msg)
+        self.assertIn("cpu", msg)
+        self.assertIn(device, msg)
+        self.assertNotIn("Dynamo failed to run FX node with fake tensors", msg)
+        self.assertNotIn("Unhandled FakeTensor Device Propagation", msg)
+
+
+instantiate_device_type_tests(
+    ErrorMessagesTestDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -185,7 +185,7 @@ class LoggingTests(LoggingTestCase):
             len(records), 8 * (1 + torch._inductor.config.loop_ordering_after_fusion)
         )
 
-    @requires_cuda_and_triton
+    @requires_gpu
     @make_logging_test(cudagraphs=True)
     def test_cudagraphs(self, records):
         fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)  # noqa: UNSPECIFIED_BACKEND
@@ -1363,7 +1363,9 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
 
     @make_logging_test(autotuning=True)
     @requires_gpu
-    @unittest.skipIf(not SM90OrLater, "requires H100+ GPU")
+    @unittest.skipIf(
+        torch.cuda.is_available() and not SM90OrLater, "requires H100+ GPU"
+    )
     def test_autotuning(self, records):
         with torch._inductor.utils.fresh_cache():
 

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -19,27 +19,23 @@ from torch._dynamo.testing import (
 from torch._dynamo.trace_rules import _as_posix_path
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.testing._internal.common_cuda import SM90OrLater
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_utils import (
     find_free_port,
+    HardwareClassification,
     IS_WINDOWS,
     munge_exc,
     skipIfTorchDynamo,
     skipIfWindows,
-)
-from torch.testing._internal.inductor_utils import (
-    HAS_CUDA_AND_TRITON,
-    HAS_XPU_AND_TRITON,
 )
 from torch.testing._internal.logging_utils import (
     LoggingTestCase,
     make_logging_test,
     make_settings_test,
 )
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
-
-
-requires_gpu = unittest.skipUnless(
-    HAS_CUDA_AND_TRITON or HAS_XPU_AND_TRITON, "requires cuda or xpu with triton"
+from torch.testing._internal.triton_utils import (
+    requires_cuda_and_triton,
+    requires_gpu_and_triton,
 )
 
 requires_distributed = functools.partial(
@@ -165,34 +161,6 @@ class LoggingTests(LoggingTestCase):
     test_output_code = multi_record_test(3, output_code=True)
     test_aot_graphs = multi_record_test(3, aot_graphs=True)
 
-    @requires_gpu
-    @make_logging_test(schedule=True)
-    def test_schedule(self, records):
-        fn_opt = torch.compile(inductor_schedule_fn, backend="inductor")
-        fn_opt(torch.ones(1000, 1000, device=device_type))
-        self.assertGreater(len(records), 0)
-        self.assertLess(len(records), 5)
-
-    @requires_gpu
-    @make_logging_test(fusion=True)
-    def test_fusion(self, records):
-        fn_opt = torch.compile(inductor_schedule_fn, backend="inductor")
-        fn_opt(torch.ones(1000, 1000, device=device_type))
-        self.assertGreater(len(records), 0)
-
-        # LOAF will add an extra round of fusion and result in more logs
-        self.assertLess(
-            len(records), 8 * (1 + torch._inductor.config.loop_ordering_after_fusion)
-        )
-
-    @requires_gpu
-    @make_logging_test(cudagraphs=True)
-    def test_cudagraphs(self, records):
-        fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)  # noqa: UNSPECIFIED_BACKEND
-        fn_opt(torch.ones(1000, 1000, device=device_type))
-        self.assertGreater(len(records), 0)
-        self.assertLess(len(records), 8)
-
     @make_logging_test(recompiles=True)
     def test_recompiles(self, records):
         def outmost_fn(x, ys, zs):
@@ -225,13 +193,13 @@ class LoggingTests(LoggingTestCase):
         self.assertIn(
             """\
     - User stack trace:
-    -   File [file_path], line 199, in outmost_fn
+    -   File [file_path], line 167, in outmost_fn
     -     return outer_fn(x, ys, zs)
-    -   File [file_path], line 202, in outer_fn
+    -   File [file_path], line 170, in outer_fn
     -     return fn(x, ys, zs)
-    -   File [file_path], line 205, in fn
+    -   File [file_path], line 173, in fn
     -     return inner(x, ys, zs)
-    -   File [file_path], line 208, in inner
+    -   File [file_path], line 176, in inner
     -     for y, z in zip(ys, zs):""",
             record_str,
         )
@@ -1349,37 +1317,6 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
         self.assertGreater(len(records), 0)
         self.assertLess(len(records), 4)
 
-    @make_logging_test(perf_hints=True)
-    @requires_gpu
-    def test_optimizer_non_static_param(self, records):
-        params = [torch.randn(10, 10, device=device_type) for _ in range(2)]
-        for param in params:
-            param.grad = torch.zeros_like(param)
-        opt = torch.optim.Adam(params)
-        compiled_opt_step = torch.compile(opt.step, mode="reduce-overhead")  # noqa: UNSPECIFIED_BACKEND
-        compiled_opt_step()
-        self.assertGreater(len(records), 0)
-        self.assertLess(len(records), 3)
-
-    @make_logging_test(autotuning=True)
-    @requires_gpu
-    @unittest.skipIf(
-        torch.cuda.is_available() and not SM90OrLater, "requires H100+ GPU"
-    )
-    def test_autotuning(self, records):
-        with torch._inductor.utils.fresh_cache():
-
-            def f(a, b):
-                return torch.mm(a, b)
-
-            f = torch.compile(f, mode="max-autotune-no-cudagraphs")  # noqa: UNSPECIFIED_BACKEND
-            f(
-                torch.randn(10, 10, device=device_type),
-                torch.randn(10, 10, device=device_type),
-            )
-            self.assertGreater(len(records), 0)
-            self.assertLess(len(records), 40)
-
     @make_logging_test(graph_region_expansion=True)
     def test_graph_region_expansion(self, records):
         with torch._dynamo.config.patch("track_nodes_for_deduplication", True):
@@ -1552,15 +1489,77 @@ TorchDynamo attempted to trace the following frames: [
         self.assertIn("non-infra torch dispatch mode present", msg)
         self.assertIn("fn", msg)
 
-    @requires_gpu
+class LoggingTestsDevice(LoggingTestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @requires_gpu_and_triton
+    @make_logging_test(schedule=True)
+    def test_schedule(self, records, device):
+        fn_opt = torch.compile(self.inductor_schedule_fn, backend="inductor")
+        fn_opt(torch.ones(1000, 1000, device=device))
+        self.assertGreater(len(records), 0)
+        self.assertLess(len(records), 5)
+
+    @requires_gpu_and_triton
+    @make_logging_test(fusion=True)
+    def test_fusion(self, records, device):
+        fn_opt = torch.compile(self.inductor_schedule_fn, backend="inductor")
+        fn_opt(torch.ones(1000, 1000, device=device))
+        self.assertGreater(len(records), 0)
+
+        # LOAF will add an extra round of fusion and result in more logs
+        self.assertLess(
+            len(records), 8 * (1 + torch._inductor.config.loop_ordering_after_fusion)
+        )
+
+    @requires_gpu_and_triton
+    @make_logging_test(cudagraphs=True)
+    def test_cudagraphs(self, records, device):
+        fn_opt = torch.compile(mode="reduce-overhead")(self.inductor_schedule_fn)  # noqa: UNSPECIFIED_BACKEND
+        fn_opt(torch.ones(1000, 1000, device=device))
+        self.assertGreater(len(records), 0)
+        self.assertLess(len(records), 8)
+
+    @requires_gpu_and_triton
+    @make_logging_test(perf_hints=True)
+    def test_optimizer_non_static_param(self, records, device):
+        params = [torch.randn(10, 10, device=device) for _ in range(2)]
+        for param in params:
+            param.grad = torch.zeros_like(param)
+        opt = torch.optim.Adam(params)
+        compiled_opt_step = torch.compile(opt.step, mode="reduce-overhead")  # noqa: UNSPECIFIED_BACKEND
+        compiled_opt_step()
+        self.assertGreater(len(records), 0)
+        self.assertLess(len(records), 3)
+
+    @requires_gpu_and_triton
+    @make_logging_test(autotuning=True)
+    def test_autotuning(self, records, device):
+        if device == "cuda" and not SM90OrLater:
+            raise unittest.SkipTest("requires H100+ GPU")
+
+        with torch._inductor.utils.fresh_cache():
+
+            def f(a, b):
+                return torch.mm(a, b)
+
+            f = torch.compile(f, mode="max-autotune-no-cudagraphs")  # noqa: UNSPECIFIED_BACKEND
+            f(
+                torch.randn(10, 10, device=device),
+                torch.randn(10, 10, device=device),
+            )
+            self.assertGreater(len(records), 0)
+            self.assertLess(len(records), 40)
+
+    @requires_gpu_and_triton
     @torch._inductor.config.patch("force_disable_caches", True)
     @make_logging_test(autotuning_inputs=True)
-    def test_autotuning_inputs(self, records):
+    def test_autotuning_inputs(self, records, device):
         @torch.compile(mode="max-autotune")  # noqa: UNSPECIFIED_BACKEND
         def f(x):
             return (x * 2.0 + 1.0).sum(dim=1)
 
-        f(torch.randn(2048, 4096, device=device_type))
+        f(torch.randn(2048, 4096, device=device))
 
         autotune_records = [r for r in records if ".__autotuning_inputs" in r.name]
         self.assertGreater(len(autotune_records), 0)
@@ -1570,16 +1569,16 @@ TorchDynamo attempted to trace the following frames: [
         self.assertIn("dtype=torch.float32", msg)
         self.assertIn("stride=(", msg)
 
-    @requires_gpu
+    @requires_gpu_and_triton
     @torch._inductor.config.patch("force_disable_caches", True)
     @make_logging_test(inductor=logging.DEBUG)
-    def test_autotuning_inputs_off_by_default(self, records):
+    def test_autotuning_inputs_off_by_default(self, records, device):
         # off_by_default: must stay silent even with the parent inductor log at DEBUG
         @torch.compile(mode="max-autotune")  # noqa: UNSPECIFIED_BACKEND
         def f(x):
             return (x * 2.0 + 1.0).sum(dim=1)
 
-        f(torch.randn(2048, 4096, device=device_type))
+        f(torch.randn(2048, 4096, device=device))
         self.assertEqual(
             len([r for r in records if ".__autotuning_inputs" in r.name]), 0
         )
@@ -1675,6 +1674,11 @@ exclusions = {
 for name in torch._logging._internal.log_registry.artifact_names:
     if name not in exclusions:
         setattr(LoggingTests, f"test_{name}", single_record_test(**{name: True}))
+
+
+instantiate_device_type_tests(
+    LoggingTestsDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 if __name__ == "__main__":
     from torch._dynamo.test_case import run_tests

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -38,6 +38,7 @@ from torch.testing._internal.triton_utils import (
     requires_gpu_and_triton,
 )
 
+
 requires_distributed = functools.partial(
     unittest.skipIf, not dist.is_available(), "requires distributed"
 )
@@ -193,13 +194,13 @@ class LoggingTests(LoggingTestCase):
         self.assertIn(
             """\
     - User stack trace:
-    -   File [file_path], line 167, in outmost_fn
+    -   File [file_path], line 168, in outmost_fn
     -     return outer_fn(x, ys, zs)
-    -   File [file_path], line 170, in outer_fn
+    -   File [file_path], line 171, in outer_fn
     -     return fn(x, ys, zs)
-    -   File [file_path], line 173, in fn
+    -   File [file_path], line 174, in fn
     -     return inner(x, ys, zs)
-    -   File [file_path], line 176, in inner
+    -   File [file_path], line 177, in inner
     -     for y, z in zip(ys, zs):""",
             record_str,
         )
@@ -1489,22 +1490,23 @@ TorchDynamo attempted to trace the following frames: [
         self.assertIn("non-infra torch dispatch mode present", msg)
         self.assertIn("fn", msg)
 
+
 class LoggingTestsDevice(LoggingTestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @requires_gpu_and_triton
     @make_logging_test(schedule=True)
-    def test_schedule(self, records, device):
-        fn_opt = torch.compile(self.inductor_schedule_fn, backend="inductor")
-        fn_opt(torch.ones(1000, 1000, device=device))
+    def test_schedule(self, records):
+        fn_opt = torch.compile(inductor_schedule_fn, backend="inductor")
+        fn_opt(torch.ones(1000, 1000, device=self.device_type))
         self.assertGreater(len(records), 0)
         self.assertLess(len(records), 5)
 
     @requires_gpu_and_triton
     @make_logging_test(fusion=True)
-    def test_fusion(self, records, device):
-        fn_opt = torch.compile(self.inductor_schedule_fn, backend="inductor")
-        fn_opt(torch.ones(1000, 1000, device=device))
+    def test_fusion(self, records):
+        fn_opt = torch.compile(inductor_schedule_fn, backend="inductor")
+        fn_opt(torch.ones(1000, 1000, device=self.device_type))
         self.assertGreater(len(records), 0)
 
         # LOAF will add an extra round of fusion and result in more logs
@@ -1514,16 +1516,16 @@ class LoggingTestsDevice(LoggingTestCase):
 
     @requires_gpu_and_triton
     @make_logging_test(cudagraphs=True)
-    def test_cudagraphs(self, records, device):
-        fn_opt = torch.compile(mode="reduce-overhead")(self.inductor_schedule_fn)  # noqa: UNSPECIFIED_BACKEND
-        fn_opt(torch.ones(1000, 1000, device=device))
+    def test_cudagraphs(self, records):
+        fn_opt = torch.compile(mode="reduce-overhead")(inductor_schedule_fn)  # noqa: UNSPECIFIED_BACKEND
+        fn_opt(torch.ones(1000, 1000, device=self.device_type))
         self.assertGreater(len(records), 0)
         self.assertLess(len(records), 8)
 
     @requires_gpu_and_triton
     @make_logging_test(perf_hints=True)
-    def test_optimizer_non_static_param(self, records, device):
-        params = [torch.randn(10, 10, device=device) for _ in range(2)]
+    def test_optimizer_non_static_param(self, records):
+        params = [torch.randn(10, 10, device=self.device_type) for _ in range(2)]
         for param in params:
             param.grad = torch.zeros_like(param)
         opt = torch.optim.Adam(params)
@@ -1534,8 +1536,8 @@ class LoggingTestsDevice(LoggingTestCase):
 
     @requires_gpu_and_triton
     @make_logging_test(autotuning=True)
-    def test_autotuning(self, records, device):
-        if device == "cuda" and not SM90OrLater:
+    def test_autotuning(self, records):
+        if self.device_type == "cuda" and not SM90OrLater:
             raise unittest.SkipTest("requires H100+ GPU")
 
         with torch._inductor.utils.fresh_cache():
@@ -1545,8 +1547,8 @@ class LoggingTestsDevice(LoggingTestCase):
 
             f = torch.compile(f, mode="max-autotune-no-cudagraphs")  # noqa: UNSPECIFIED_BACKEND
             f(
-                torch.randn(10, 10, device=device),
-                torch.randn(10, 10, device=device),
+                torch.randn(10, 10, device=self.device_type),
+                torch.randn(10, 10, device=self.device_type),
             )
             self.assertGreater(len(records), 0)
             self.assertLess(len(records), 40)
@@ -1554,12 +1556,12 @@ class LoggingTestsDevice(LoggingTestCase):
     @requires_gpu_and_triton
     @torch._inductor.config.patch("force_disable_caches", True)
     @make_logging_test(autotuning_inputs=True)
-    def test_autotuning_inputs(self, records, device):
+    def test_autotuning_inputs(self, records):
         @torch.compile(mode="max-autotune")  # noqa: UNSPECIFIED_BACKEND
         def f(x):
             return (x * 2.0 + 1.0).sum(dim=1)
 
-        f(torch.randn(2048, 4096, device=device))
+        f(torch.randn(2048, 4096, device=self.device_type))
 
         autotune_records = [r for r in records if ".__autotuning_inputs" in r.name]
         self.assertGreater(len(autotune_records), 0)
@@ -1572,13 +1574,13 @@ class LoggingTestsDevice(LoggingTestCase):
     @requires_gpu_and_triton
     @torch._inductor.config.patch("force_disable_caches", True)
     @make_logging_test(inductor=logging.DEBUG)
-    def test_autotuning_inputs_off_by_default(self, records, device):
+    def test_autotuning_inputs_off_by_default(self, records):
         # off_by_default: must stay silent even with the parent inductor log at DEBUG
         @torch.compile(mode="max-autotune")  # noqa: UNSPECIFIED_BACKEND
         def f(x):
             return (x * 2.0 + 1.0).sum(dim=1)
 
-        f(torch.randn(2048, 4096, device=device))
+        f(torch.randn(2048, 4096, device=self.device_type))
         self.assertEqual(
             len([r for r in records if ".__autotuning_inputs" in r.name]), 0
         )

--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -157,7 +157,9 @@ def single_record_test(**kwargs):
     return multi_record_test(1, **kwargs)
 
 
-class LoggingTests(LoggingTestCase):
+class TestLogging(LoggingTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     test_bytecode = multi_record_test(2, bytecode=True)
     test_output_code = multi_record_test(3, output_code=True)
     test_aot_graphs = multi_record_test(3, aot_graphs=True)
@@ -194,13 +196,13 @@ class LoggingTests(LoggingTestCase):
         self.assertIn(
             """\
     - User stack trace:
-    -   File [file_path], line 168, in outmost_fn
+    -   File [file_path], line 170, in outmost_fn
     -     return outer_fn(x, ys, zs)
-    -   File [file_path], line 171, in outer_fn
+    -   File [file_path], line 173, in outer_fn
     -     return fn(x, ys, zs)
-    -   File [file_path], line 174, in fn
+    -   File [file_path], line 176, in fn
     -     return inner(x, ys, zs)
-    -   File [file_path], line 177, in inner
+    -   File [file_path], line 179, in inner
     -     for y, z in zip(ys, zs):""",
             record_str,
         )
@@ -396,33 +398,6 @@ Found from :
         )
 
         exitstack.close()
-
-    @requires_distributed()
-    @requires_cuda_and_triton
-    @make_logging_test(ddp_graphs=True)
-    def test_ddp_graphs(self, records):
-        class ToyModel(torch.nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.layers = torch.nn.Sequential(
-                    torch.nn.Linear(1024, 1024),
-                    torch.nn.Linear(1024, 1024),
-                )
-
-            def forward(self, x):
-                return self.layers(x)
-
-        os.environ["MASTER_ADDR"] = "localhost"
-        os.environ["MASTER_PORT"] = str(find_free_port())
-        dist.init_process_group("gloo", rank=0, world_size=1)
-
-        model = DDP(ToyModel().to("cuda:0"), device_ids=[0], bucket_cap_mb=4)
-        ddp_model = torch.compile(model, backend="inductor")
-
-        ddp_model(torch.randn(1024, 1024, device="cuda:0"))
-
-        dist.destroy_process_group()
-        self.assertEqual(len([r for r in records if "__ddp_graphs" in r.name]), 4)
 
     # check that logging to a child log of a registered logger
     # does not register it and result in duplicated records
@@ -1136,7 +1111,7 @@ print("arf")
         self.assertExpectedInline(
             msg0,
             """\
-TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_prefix.fn)
+TRACE FX call mul from test_logging.py:N in fn (TestLogging.test_trace_call_prefix.fn)
             return (x * 2) @ (y * 3)
                     ~~^~~""",
         )
@@ -1491,7 +1466,38 @@ TorchDynamo attempted to trace the following frames: [
         self.assertIn("fn", msg)
 
 
-class LoggingTestsDevice(LoggingTestCase):
+class TestLoggingCUDA(LoggingTestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @requires_distributed()
+    @requires_cuda_and_triton
+    @make_logging_test(ddp_graphs=True)
+    def test_ddp_graphs(self, records):
+        class ToyModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layers = torch.nn.Sequential(
+                    torch.nn.Linear(1024, 1024),
+                    torch.nn.Linear(1024, 1024),
+                )
+
+            def forward(self, x):
+                return self.layers(x)
+
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = str(find_free_port())
+        dist.init_process_group("gloo", rank=0, world_size=1)
+
+        model = DDP(ToyModel().to("cuda:0"), device_ids=[0], bucket_cap_mb=4)
+        ddp_model = torch.compile(model, backend="inductor")
+
+        ddp_model(torch.randn(1024, 1024, device="cuda:0"))
+
+        dist.destroy_process_group()
+        self.assertEqual(len([r for r in records if "__ddp_graphs" in r.name]), 4)
+
+
+class TestLoggingDevice(LoggingTestCase):
     hw_classification = HardwareClassification.ACCELERATOR
 
     @requires_gpu_and_triton
@@ -1675,11 +1681,11 @@ exclusions = {
 }
 for name in torch._logging._internal.log_registry.artifact_names:
     if name not in exclusions:
-        setattr(LoggingTests, f"test_{name}", single_record_test(**{name: True}))
+        setattr(TestLogging, f"test_{name}", single_record_test(**{name: True}))
 
 
 instantiate_device_type_tests(
-    LoggingTestsDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+    TestLoggingDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True
 )
 
 if __name__ == "__main__":

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -88,7 +88,6 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
-    onlyOn,
     PYTORCH_CUDA_MEMCHECK,
 )
 from torch.testing._internal.common_methods_invocations import (
@@ -288,6 +287,61 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertTrue(same(val3, correct3))
         self.assertTrue(same(val4, correct1))
         self.assertEqual(counter.frame_count, 3)
+
+    @unittest.skipIf(not TEST_CUDA, "cuda needed")
+    def test_assume_32_bit_indexing(self):
+        @torch.compile(backend="inductor")
+        def func(a, b):
+            # Multiple concat operations
+            x = torch.concat([a, b], dim=0)
+            y = torch.concat([a, b], dim=1)
+
+            # Reshape to create indexing patterns
+            x_flat = x.reshape(-1)
+            y_flat = y.reshape(-1)
+
+            # Take the smaller one and expand
+            min_size = min(x_flat.shape[0], y_flat.shape[0])
+            x_trunc = x_flat[:min_size]
+            y_trunc = y_flat[:min_size]
+
+            # Combine and compute
+            result = (x_trunc + y_trunc) * 10
+
+            # Cumulative operations create complex indexing
+            cumsum = result.cumsum(dim=0)
+
+            return cumsum.sum()
+
+        a = torch.rand(100, 30, device="cuda")
+        b = torch.rand(100, 30, device="cuda")
+
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(a, 1)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 1)
+
+        source_code = run_and_get_code(func, a, b)[1]
+        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
+        self.assertTrue(
+            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+        )
+        # Check that 32-bit indexing is NOT used
+        self.assertFalse(
+            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
+            and ".to(tl.int64)" not in str(source_code)
+        )
+
+        torch._dynamo.reset()
+
+        with torch._inductor.config.patch(assume_32bit_indexing=True):
+            source_code = run_and_get_code(func, a, b)[1]
+            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
+            self.assertFalse(
+                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+            )
 
     def test_dynamo_side_effect(self):
         class GlobalContext:
@@ -1138,6 +1192,102 @@ graph():
         res = opt_f(x, True)
         self.assertEqual(res, torch.ones(5) + 1)
         self.assertTrue(res.offloading_activation)
+
+    @unittest.skipIf(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
+        "requires Hopper+ (SM >= 9.0) for TMA",
+    )
+    @unittest.skipIf(
+        not torch.utils._triton.has_triton()
+        or not hasattr(__import__("triton"), "set_allocator"),
+        "requires triton with set_allocator support",
+    )
+    def test_triton_set_allocator_no_graph_break(self):
+        """set_allocator inside torch.compile does not graph break and
+        replays correctly at runtime (including cache hits)."""
+        import triton
+        import triton.language as tl
+        from triton.runtime._allocation import NullAllocator
+
+        @triton.jit
+        def tma_copy_kernel(
+            x_ptr,
+            out_ptr,
+            M,
+            N,
+            stride_m,
+            stride_n,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            pid = tl.program_id(0)
+            desc = tl.make_tensor_descriptor(
+                x_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
+            out_desc = tl.make_tensor_descriptor(
+                out_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
+
+        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
+
+        def run_kernel(x):
+            out = torch.empty_like(x)
+            tma_copy_kernel[(M // BLOCK_M,)](
+                x,
+                out,
+                M,
+                N,
+                x.stride(0),
+                x.stride(1),
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+            )
+            return out
+
+        x = torch.randn(M, N, device="cuda")
+
+        from contextlib import contextmanager
+
+        from triton.runtime._allocation import _allocator
+
+        @contextmanager
+        def triton_allocator(allocator):
+            prev = _allocator.get()
+            triton.set_allocator(allocator)
+            try:
+                yield
+            finally:
+                triton.set_allocator(prev)
+
+        def fn_with_set_allocator(x):
+            triton.set_allocator(
+                lambda size, alignment, stream: torch.empty(
+                    size, device="cuda", dtype=torch.int8
+                )
+            )
+            return run_kernel(x)
+
+        opt_fn = torch.compile(
+            fn_with_set_allocator, backend="aot_eager", fullgraph=True
+        )
+
+        # set_allocator inside compiled region does NOT graph break
+        with triton_allocator(NullAllocator()):
+            out = opt_fn(x)
+            self.assertEqual(out, x)
+
+            # Verify set_allocator replays on cache hit (not just tracing)
+            triton.set_allocator(NullAllocator())
+            out2 = opt_fn(x)
+            self.assertEqual(out2, x)
 
     def test_closure_recompiles(self):
         cnt = CompileCounter()
@@ -6826,7 +6976,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
                 # Make sure sparse clone is successful.
                 self.assertEqual(sparse_input, sparse_copy)
 
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test requires CUDA or XPU.")
+    @unittest.skipIf(not TEST_CUDA, "pinned CPU memory requires CUDA")
     @unittest.skipIf(
         PYTORCH_CUDA_MEMCHECK, "is_pinned uses failure to detect pointer property"
     )
@@ -6919,6 +7069,20 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         opt_fn = torch.compile(fn, backend="eager")
         for x in [torch.contiguous_format, torch.channels_last]:
             self.assertEqual(fn(x), opt_fn(x))
+
+    @unittest.skipIf(not TEST_CUDA, "cuda needed")
+    def test_cuda_tensor_is_pinned_constant_false(self):
+        def pinned_memory_of(arg):
+            return arg.is_pinned()
+
+        def fn(x):
+            if pinned_memory_of(x) or x.is_pinned(None) or x.is_pinned(device=None):
+                return x + 1
+            return x + 2
+
+        x = torch.randn(4, device="cuda")
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), opt_fn(x))
 
     def test_python_slice(self):
         def f1(input):
@@ -18612,174 +18776,6 @@ class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
 
 
 class MiscTestsDevice(torch._inductor.test_case.TestCase):
-    @onlyOn(["cuda", "xpu"])
-    @unittest.skipIf(
-        not torch.utils._triton.has_triton()
-        or not hasattr(__import__("triton"), "set_allocator"),
-        "requires triton with set_allocator support",
-    )
-    def test_triton_set_allocator_no_graph_break(self, device):
-        """set_allocator inside torch.compile does not graph break and
-        replays correctly at runtime (including cache hits)."""
-        import triton
-        import triton.language as tl
-        from triton.runtime._allocation import NullAllocator
-
-        if device == "cuda" and torch.cuda.get_device_capability() < (
-            9,
-            0,
-        ):
-            self.skipTest("requires Hopper+ (SM >= 9.0) for TMA, or XPU")
-
-        @triton.jit
-        def tma_copy_kernel(
-            x_ptr,
-            out_ptr,
-            M,
-            N,
-            stride_m,
-            stride_n,
-            BLOCK_M: tl.constexpr,
-            BLOCK_N: tl.constexpr,
-        ):
-            pid = tl.program_id(0)
-            desc = tl.make_tensor_descriptor(
-                x_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
-            out_desc = tl.make_tensor_descriptor(
-                out_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
-
-        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
-
-        def run_kernel(x):
-            out = torch.empty_like(x)
-            tma_copy_kernel[(M // BLOCK_M,)](
-                x,
-                out,
-                M,
-                N,
-                x.stride(0),
-                x.stride(1),
-                BLOCK_M=BLOCK_M,
-                BLOCK_N=BLOCK_N,
-            )
-            return out
-
-        x = torch.randn(M, N, device=device)
-
-        from contextlib import contextmanager
-
-        from triton.runtime._allocation import _allocator
-
-        @contextmanager
-        def triton_allocator(allocator):
-            prev = _allocator.get()
-            triton.set_allocator(allocator)
-            try:
-                yield
-            finally:
-                triton.set_allocator(prev)
-
-        def fn_with_set_allocator(x):
-            triton.set_allocator(
-                lambda size, alignment, stream: torch.empty(
-                    size, device=device, dtype=torch.int8
-                )
-            )
-            return run_kernel(x)
-
-        opt_fn = torch.compile(
-            fn_with_set_allocator, backend="aot_eager", fullgraph=True
-        )
-
-        # set_allocator inside compiled region does NOT graph break
-        with triton_allocator(NullAllocator()):
-            out = opt_fn(x)
-            self.assertEqual(out, x)
-
-            # Verify set_allocator replays on cache hit (not just tracing)
-            triton.set_allocator(NullAllocator())
-            out2 = opt_fn(x)
-            self.assertEqual(out2, x)
-
-    @onlyOn(["cuda", "xpu"])
-    def test_assume_32_bit_indexing(self, device):
-        @torch.compile(backend="inductor")
-        def func(a, b):
-            # Multiple concat operations
-            x = torch.concat([a, b], dim=0)
-            y = torch.concat([a, b], dim=1)
-
-            # Reshape to create indexing patterns
-            x_flat = x.reshape(-1)
-            y_flat = y.reshape(-1)
-
-            # Take the smaller one and expand
-            min_size = min(x_flat.shape[0], y_flat.shape[0])
-            x_trunc = x_flat[:min_size]
-            y_trunc = y_flat[:min_size]
-
-            # Combine and compute
-            result = (x_trunc + y_trunc) * 10
-
-            # Cumulative operations create complex indexing
-            cumsum = result.cumsum(dim=0)
-
-            return cumsum.sum()
-
-        a = torch.rand(100, 30, device=device)
-        b = torch.rand(100, 30, device=device)
-
-        torch._dynamo.decorators.mark_unbacked(a, 0)
-        torch._dynamo.decorators.mark_unbacked(a, 1)
-        torch._dynamo.decorators.mark_unbacked(b, 0)
-        torch._dynamo.decorators.mark_unbacked(b, 1)
-
-        source_code = run_and_get_code(func, a, b)[1]
-        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
-        self.assertTrue(
-            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-        )
-        # Check that 32-bit indexing is NOT used
-        self.assertFalse(
-            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
-            and ".to(tl.int64)" not in str(source_code)
-        )
-
-        torch._dynamo.reset()
-
-        with torch._inductor.config.patch(assume_32bit_indexing=True):
-            source_code = run_and_get_code(func, a, b)[1]
-            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
-            self.assertFalse(
-                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-            )
-
-    @onlyOn(["cuda", "xpu"])
-    def test_cuda_tensor_is_pinned_constant_false(self, device):
-        def pinned_memory_of(arg):
-            return arg.is_pinned()
-
-        def fn(x):
-            if pinned_memory_of(x) or x.is_pinned(None) or x.is_pinned(device=None):
-                return x + 1
-            return x + 2
-
-        x = torch.randn(4, device=device)
-        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertEqual(fn(x), opt_fn(x))
-
     def test_rand(self, device):
         cnts = torch._dynamo.testing.CompileCounter()
         device = device
@@ -18953,9 +18949,10 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
         self.assertEqual(out, opt_out)
 
     def test_torch_device_python_type(self, device):
-        for device_name, expected_device_type, index in [
+        device_type = torch.device(device).type
+        for device, device_type, index in [
             ("cpu", "cpu", None),
-            (device, device, 0),
+            (device, device_type, 0),
         ]:
 
             def fn(target):
@@ -18963,7 +18960,7 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
                 a = torch.zeros(2, 3, device=target_device)
                 # Constant assert at trace time
                 assert isinstance(target_device, torch.device)  # noqa: S101
-                assert target_device.type == expected_device_type  # noqa: S101
+                assert target_device.type == device_type  # noqa: S101
                 assert target_device.index == index  # noqa: S101
                 b = torch.zeros(2, 3, device=target_device)
                 c = torch.zeros(2, 3, device=target_device)
@@ -18971,12 +18968,12 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
 
             from torch._dynamo.variables import ConstantVariable
 
-            target_device = torch.device(device_name)
-            expected_variable = ConstantVariable(target_device)
-            self.assertEqual(expected_variable.python_type(), type(target_device))
+            device = torch.device(device)
+            expected_variable = ConstantVariable(device)
+            self.assertEqual(expected_variable.python_type(), type(device))
 
             opt_func = torch.compile(fn, backend="eager", fullgraph=True)
-            a = torch.tensor([2, 3], device=target_device)
+            a = torch.tensor([2, 3], device=device)
             res = opt_func(a)
             self.assertIsInstance(res, torch.Tensor)
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -114,6 +114,11 @@ from torch.testing._internal.jit_utils import JitTestCase
 from torch.utils._sympy.numbers import int_oo
 
 
+device_type = (
+    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
+)
+
+
 pytree_modules = {
     "python": python_pytree,
 }
@@ -288,7 +293,7 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertTrue(same(val4, correct1))
         self.assertEqual(counter.frame_count, 3)
 
-    @unittest.skipIf(not TEST_CUDA, "cuda needed")
+    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test requires CUDA or XPU.")
     def test_assume_32_bit_indexing(self):
         @torch.compile(backend="inductor")
         def func(a, b):
@@ -313,8 +318,8 @@ class MiscTests(torch._inductor.test_case.TestCase):
 
             return cumsum.sum()
 
-        a = torch.rand(100, 30, device="cuda")
-        b = torch.rand(100, 30, device="cuda")
+        a = torch.rand(100, 30, device=device_type)
+        b = torch.rand(100, 30, device=device_type)
 
         torch._dynamo.decorators.mark_unbacked(a, 0)
         torch._dynamo.decorators.mark_unbacked(a, 1)
@@ -1194,8 +1199,12 @@ graph():
         self.assertTrue(res.offloading_activation)
 
     @unittest.skipIf(
-        not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0),
-        "requires Hopper+ (SM >= 9.0) for TMA",
+        not TEST_XPU
+        and (
+            not torch.cuda.is_available()
+            or torch.cuda.get_device_capability() < (9, 0)
+        ),
+        "requires Hopper+ (SM >= 9.0) for TMA, or XPU",
     )
     @unittest.skipIf(
         not torch.utils._triton.has_triton()
@@ -1252,7 +1261,7 @@ graph():
             )
             return out
 
-        x = torch.randn(M, N, device="cuda")
+        x = torch.randn(M, N, device=device_type)
 
         from contextlib import contextmanager
 
@@ -1270,7 +1279,7 @@ graph():
         def fn_with_set_allocator(x):
             triton.set_allocator(
                 lambda size, alignment, stream: torch.empty(
-                    size, device="cuda", dtype=torch.int8
+                    size, device=device_type, dtype=torch.int8
                 )
             )
             return run_kernel(x)
@@ -6976,7 +6985,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
                 # Make sure sparse clone is successful.
                 self.assertEqual(sparse_input, sparse_copy)
 
-    @unittest.skipIf(not TEST_CUDA, "pinned CPU memory requires CUDA")
+    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test requires CUDA or XPU.")
     @unittest.skipIf(
         PYTORCH_CUDA_MEMCHECK, "is_pinned uses failure to detect pointer property"
     )
@@ -7070,7 +7079,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         for x in [torch.contiguous_format, torch.channels_last]:
             self.assertEqual(fn(x), opt_fn(x))
 
-    @unittest.skipIf(not TEST_CUDA, "cuda needed")
+    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test requires CUDA or XPU.")
     def test_cuda_tensor_is_pinned_constant_false(self):
         def pinned_memory_of(arg):
             return arg.is_pinned()
@@ -7080,7 +7089,7 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
                 return x + 1
             return x + 2
 
-        x = torch.randn(4, device="cuda")
+        x = torch.randn(4, device=device_type)
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(fn(x), opt_fn(x))
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -1201,8 +1201,7 @@ graph():
     @unittest.skipIf(
         not TEST_XPU
         and (
-            not torch.cuda.is_available()
-            or torch.cuda.get_device_capability() < (9, 0)
+            not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0)
         ),
         "requires Hopper+ (SM >= 9.0) for TMA, or XPU",
     )

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -88,6 +88,7 @@ from torch.testing._internal.common_cuda import (
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCUDA,
+    onlyOn,
     PYTORCH_CUDA_MEMCHECK,
 )
 from torch.testing._internal.common_methods_invocations import (
@@ -112,11 +113,6 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.jit_utils import JitTestCase
 from torch.utils._sympy.numbers import int_oo
-
-
-device_type = (
-    acc.type if (acc := torch.accelerator.current_accelerator(True)) else "cpu"
-)
 
 
 pytree_modules = {
@@ -292,61 +288,6 @@ class MiscTests(torch._inductor.test_case.TestCase):
         self.assertTrue(same(val3, correct3))
         self.assertTrue(same(val4, correct1))
         self.assertEqual(counter.frame_count, 3)
-
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test requires CUDA or XPU.")
-    def test_assume_32_bit_indexing(self):
-        @torch.compile(backend="inductor")
-        def func(a, b):
-            # Multiple concat operations
-            x = torch.concat([a, b], dim=0)
-            y = torch.concat([a, b], dim=1)
-
-            # Reshape to create indexing patterns
-            x_flat = x.reshape(-1)
-            y_flat = y.reshape(-1)
-
-            # Take the smaller one and expand
-            min_size = min(x_flat.shape[0], y_flat.shape[0])
-            x_trunc = x_flat[:min_size]
-            y_trunc = y_flat[:min_size]
-
-            # Combine and compute
-            result = (x_trunc + y_trunc) * 10
-
-            # Cumulative operations create complex indexing
-            cumsum = result.cumsum(dim=0)
-
-            return cumsum.sum()
-
-        a = torch.rand(100, 30, device=device_type)
-        b = torch.rand(100, 30, device=device_type)
-
-        torch._dynamo.decorators.mark_unbacked(a, 0)
-        torch._dynamo.decorators.mark_unbacked(a, 1)
-        torch._dynamo.decorators.mark_unbacked(b, 0)
-        torch._dynamo.decorators.mark_unbacked(b, 1)
-
-        source_code = run_and_get_code(func, a, b)[1]
-        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
-        self.assertTrue(
-            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-        )
-        # Check that 32-bit indexing is NOT used
-        self.assertFalse(
-            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
-            and ".to(tl.int64)" not in str(source_code)
-        )
-
-        torch._dynamo.reset()
-
-        with torch._inductor.config.patch(assume_32bit_indexing=True):
-            source_code = run_and_get_code(func, a, b)[1]
-            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
-            self.assertFalse(
-                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
-                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
-            )
 
     def test_dynamo_side_effect(self):
         class GlobalContext:
@@ -1197,105 +1138,6 @@ graph():
         res = opt_f(x, True)
         self.assertEqual(res, torch.ones(5) + 1)
         self.assertTrue(res.offloading_activation)
-
-    @unittest.skipIf(
-        not TEST_XPU
-        and (
-            not torch.cuda.is_available() or torch.cuda.get_device_capability() < (9, 0)
-        ),
-        "requires Hopper+ (SM >= 9.0) for TMA, or XPU",
-    )
-    @unittest.skipIf(
-        not torch.utils._triton.has_triton()
-        or not hasattr(__import__("triton"), "set_allocator"),
-        "requires triton with set_allocator support",
-    )
-    def test_triton_set_allocator_no_graph_break(self):
-        """set_allocator inside torch.compile does not graph break and
-        replays correctly at runtime (including cache hits)."""
-        import triton
-        import triton.language as tl
-        from triton.runtime._allocation import NullAllocator
-
-        @triton.jit
-        def tma_copy_kernel(
-            x_ptr,
-            out_ptr,
-            M,
-            N,
-            stride_m,
-            stride_n,
-            BLOCK_M: tl.constexpr,
-            BLOCK_N: tl.constexpr,
-        ):
-            pid = tl.program_id(0)
-            desc = tl.make_tensor_descriptor(
-                x_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
-            out_desc = tl.make_tensor_descriptor(
-                out_ptr,
-                shape=[M, N],
-                strides=[stride_m, stride_n],
-                block_shape=[BLOCK_M, BLOCK_N],
-            )
-            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
-
-        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
-
-        def run_kernel(x):
-            out = torch.empty_like(x)
-            tma_copy_kernel[(M // BLOCK_M,)](
-                x,
-                out,
-                M,
-                N,
-                x.stride(0),
-                x.stride(1),
-                BLOCK_M=BLOCK_M,
-                BLOCK_N=BLOCK_N,
-            )
-            return out
-
-        x = torch.randn(M, N, device=device_type)
-
-        from contextlib import contextmanager
-
-        from triton.runtime._allocation import _allocator
-
-        @contextmanager
-        def triton_allocator(allocator):
-            prev = _allocator.get()
-            triton.set_allocator(allocator)
-            try:
-                yield
-            finally:
-                triton.set_allocator(prev)
-
-        def fn_with_set_allocator(x):
-            triton.set_allocator(
-                lambda size, alignment, stream: torch.empty(
-                    size, device=device_type, dtype=torch.int8
-                )
-            )
-            return run_kernel(x)
-
-        opt_fn = torch.compile(
-            fn_with_set_allocator, backend="aot_eager", fullgraph=True
-        )
-
-        # set_allocator inside compiled region does NOT graph break
-        with triton_allocator(NullAllocator()):
-            out = opt_fn(x)
-            self.assertEqual(out, x)
-
-            # Verify set_allocator replays on cache hit (not just tracing)
-            triton.set_allocator(NullAllocator())
-            out2 = opt_fn(x)
-            self.assertEqual(out2, x)
 
     def test_closure_recompiles(self):
         cnt = CompileCounter()
@@ -7077,20 +6919,6 @@ not ___dict_contains('cccccccc', G['sys'].modules)""",
         opt_fn = torch.compile(fn, backend="eager")
         for x in [torch.contiguous_format, torch.channels_last]:
             self.assertEqual(fn(x), opt_fn(x))
-
-    @unittest.skipIf(not TEST_CUDA and not TEST_XPU, "Test requires CUDA or XPU.")
-    def test_cuda_tensor_is_pinned_constant_false(self):
-        def pinned_memory_of(arg):
-            return arg.is_pinned()
-
-        def fn(x):
-            if pinned_memory_of(x) or x.is_pinned(None) or x.is_pinned(device=None):
-                return x + 1
-            return x + 2
-
-        x = torch.randn(4, device=device_type)
-        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
-        self.assertEqual(fn(x), opt_fn(x))
 
     def test_python_slice(self):
         def f1(input):
@@ -18784,6 +18612,174 @@ class TestCustomFunction(torch.testing._internal.common_utils.TestCase):
 
 
 class MiscTestsDevice(torch._inductor.test_case.TestCase):
+    @onlyOn(["cuda", "xpu"])
+    @unittest.skipIf(
+        not torch.utils._triton.has_triton()
+        or not hasattr(__import__("triton"), "set_allocator"),
+        "requires triton with set_allocator support",
+    )
+    def test_triton_set_allocator_no_graph_break(self, device):
+        """set_allocator inside torch.compile does not graph break and
+        replays correctly at runtime (including cache hits)."""
+        import triton
+        import triton.language as tl
+        from triton.runtime._allocation import NullAllocator
+
+        if device == "cuda" and torch.cuda.get_device_capability() < (
+            9,
+            0,
+        ):
+            self.skipTest("requires Hopper+ (SM >= 9.0) for TMA, or XPU")
+
+        @triton.jit
+        def tma_copy_kernel(
+            x_ptr,
+            out_ptr,
+            M,
+            N,
+            stride_m,
+            stride_n,
+            BLOCK_M: tl.constexpr,
+            BLOCK_N: tl.constexpr,
+        ):
+            pid = tl.program_id(0)
+            desc = tl.make_tensor_descriptor(
+                x_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            block = tl.load_tensor_descriptor(desc, [pid * BLOCK_M, 0])
+            out_desc = tl.make_tensor_descriptor(
+                out_ptr,
+                shape=[M, N],
+                strides=[stride_m, stride_n],
+                block_shape=[BLOCK_M, BLOCK_N],
+            )
+            tl.store_tensor_descriptor(out_desc, [pid * BLOCK_M, 0], block)
+
+        M, N, BLOCK_M, BLOCK_N = 128, 64, 64, 64
+
+        def run_kernel(x):
+            out = torch.empty_like(x)
+            tma_copy_kernel[(M // BLOCK_M,)](
+                x,
+                out,
+                M,
+                N,
+                x.stride(0),
+                x.stride(1),
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+            )
+            return out
+
+        x = torch.randn(M, N, device=device)
+
+        from contextlib import contextmanager
+
+        from triton.runtime._allocation import _allocator
+
+        @contextmanager
+        def triton_allocator(allocator):
+            prev = _allocator.get()
+            triton.set_allocator(allocator)
+            try:
+                yield
+            finally:
+                triton.set_allocator(prev)
+
+        def fn_with_set_allocator(x):
+            triton.set_allocator(
+                lambda size, alignment, stream: torch.empty(
+                    size, device=device, dtype=torch.int8
+                )
+            )
+            return run_kernel(x)
+
+        opt_fn = torch.compile(
+            fn_with_set_allocator, backend="aot_eager", fullgraph=True
+        )
+
+        # set_allocator inside compiled region does NOT graph break
+        with triton_allocator(NullAllocator()):
+            out = opt_fn(x)
+            self.assertEqual(out, x)
+
+            # Verify set_allocator replays on cache hit (not just tracing)
+            triton.set_allocator(NullAllocator())
+            out2 = opt_fn(x)
+            self.assertEqual(out2, x)
+
+    @onlyOn(["cuda", "xpu"])
+    def test_assume_32_bit_indexing(self, device):
+        @torch.compile(backend="inductor")
+        def func(a, b):
+            # Multiple concat operations
+            x = torch.concat([a, b], dim=0)
+            y = torch.concat([a, b], dim=1)
+
+            # Reshape to create indexing patterns
+            x_flat = x.reshape(-1)
+            y_flat = y.reshape(-1)
+
+            # Take the smaller one and expand
+            min_size = min(x_flat.shape[0], y_flat.shape[0])
+            x_trunc = x_flat[:min_size]
+            y_trunc = y_flat[:min_size]
+
+            # Combine and compute
+            result = (x_trunc + y_trunc) * 10
+
+            # Cumulative operations create complex indexing
+            cumsum = result.cumsum(dim=0)
+
+            return cumsum.sum()
+
+        a = torch.rand(100, 30, device=device)
+        b = torch.rand(100, 30, device=device)
+
+        torch._dynamo.decorators.mark_unbacked(a, 0)
+        torch._dynamo.decorators.mark_unbacked(a, 1)
+        torch._dynamo.decorators.mark_unbacked(b, 0)
+        torch._dynamo.decorators.mark_unbacked(b, 1)
+
+        source_code = run_and_get_code(func, a, b)[1]
+        # Check that int64 indexing is used (either 1D [:] or 2D [:, None] form)
+        self.assertTrue(
+            "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+            or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+        )
+        # Check that 32-bit indexing is NOT used
+        self.assertFalse(
+            "tl.arange(0, XBLOCK)[:]\n" in str(source_code)
+            and ".to(tl.int64)" not in str(source_code)
+        )
+
+        torch._dynamo.reset()
+
+        with torch._inductor.config.patch(assume_32bit_indexing=True):
+            source_code = run_and_get_code(func, a, b)[1]
+            # Check that int64 indexing is NOT used when assume_32bit_indexing=True
+            self.assertFalse(
+                "tl.arange(0, XBLOCK)[:].to(tl.int64)" in str(source_code)
+                or "tl.arange(0, XBLOCK)[:, None].to(tl.int64)" in str(source_code)
+            )
+
+    @onlyOn(["cuda", "xpu"])
+    def test_cuda_tensor_is_pinned_constant_false(self, device):
+        def pinned_memory_of(arg):
+            return arg.is_pinned()
+
+        def fn(x):
+            if pinned_memory_of(x) or x.is_pinned(None) or x.is_pinned(device=None):
+                return x + 1
+            return x + 2
+
+        x = torch.randn(4, device=device)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+        self.assertEqual(fn(x), opt_fn(x))
+
     def test_rand(self, device):
         cnts = torch._dynamo.testing.CompileCounter()
         device = device
@@ -18957,10 +18953,9 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
         self.assertEqual(out, opt_out)
 
     def test_torch_device_python_type(self, device):
-        device_type = torch.device(device).type
-        for device, device_type, index in [
+        for device_name, expected_device_type, index in [
             ("cpu", "cpu", None),
-            (device, device_type, 0),
+            (device, device, 0),
         ]:
 
             def fn(target):
@@ -18968,7 +18963,7 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
                 a = torch.zeros(2, 3, device=target_device)
                 # Constant assert at trace time
                 assert isinstance(target_device, torch.device)  # noqa: S101
-                assert target_device.type == device_type  # noqa: S101
+                assert target_device.type == expected_device_type  # noqa: S101
                 assert target_device.index == index  # noqa: S101
                 b = torch.zeros(2, 3, device=target_device)
                 c = torch.zeros(2, 3, device=target_device)
@@ -18976,12 +18971,12 @@ class MiscTestsDevice(torch._inductor.test_case.TestCase):
 
             from torch._dynamo.variables import ConstantVariable
 
-            device = torch.device(device)
-            expected_variable = ConstantVariable(device)
-            self.assertEqual(expected_variable.python_type(), type(device))
+            target_device = torch.device(device_name)
+            expected_variable = ConstantVariable(target_device)
+            self.assertEqual(expected_variable.python_type(), type(target_device))
 
             opt_func = torch.compile(fn, backend="eager", fullgraph=True)
-            a = torch.tensor([2, 3], device=device)
+            a = torch.tensor([2, 3], device=target_device)
             res = opt_func(a)
             self.assertIsInstance(res, torch.Tensor)
 


### PR DESCRIPTION
Refactor test decoupling in test_error_messages.py‎ and test_logging.py‎:

- move GPU-only cases to class `ErrorMessagesTestDevice` in test_error_messages.py
- move GPU-only cases to class `TestsLoggingDevice` in test_logging.py
- move CUDA-only cases to class `TestsLoggingCUDA` in test_logging.py
- port device agnostic cases to xpu
- add hardware classification


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98