### PR TITLE
Fix FakeTensor/concrete metadata mismatch for log_sigmoid on MPS

### DIFF
--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -3534,7 +3534,7 @@ def _index_copy(
 def log_sigmoid_forward(self: Tensor) -> tuple[Tensor, Tensor]:
     min = torch.minimum(self.new_zeros(()), self)
     z = torch.exp(-torch.abs(self))
-    if self.is_cuda or self.is_xpu:
+    if self.is_cuda or self.is_xpu or self.is_mps:
         buffer = self.new_zeros((0,))
     else:
         buffer = z

--- a/torch/_decomp/decompositions_for_jvp.py
+++ b/torch/_decomp/decompositions_for_jvp.py
@@ -107,7 +107,7 @@ def trace(self: Tensor) -> Tensor:
 def log_sigmoid_forward(self: Tensor) -> tuple[Tensor, Tensor]:
     min = torch.minimum(self.new_zeros(()), self)
     z = torch.exp(-torch.abs(self))
-    if self.is_cuda or self.is_xpu:
+    if self.is_cuda or self.is_xpu or self.is_mps:
         buffer = self.new_zeros((0,))
     else:
         buffer = z


### PR DESCRIPTION
## Summary

`log_sigmoid_forward`'s decomposition (used for FakeTensor/meta shape
inference, e.g. under `CrossRefFakeMode` and `torch.compile`) only
special-cased CUDA and XPU when deciding the shape of its second,
mostly-unused output (`buffer`). Those backends get an empty `(0,)`
buffer, everything else (including MPS) falls through to a full
self-shaped buffer. MPS's native `log_sigmoid_forward`/`log_sigmoid_backward`
kernels have always allocated `buffer` as `at::empty({0}, ...)` and ignored
its contents, matching CUDA/XPU, not CPU -- so FakeTensor-inferred output
shape for an MPS tensor diverges from what the real kernel produces.

This is the same class of bug already fixed for XPU in #141333, which
touched the same two files (`torch/_decomp/decompositions.py` and
`torch/_decomp/decompositions_for_jvp.py`); MPS was never added alongside
XPU at the time. This PR adds `self.is_mps` to the same condition in both
files.

Part of the device-decoupling initiative proposed in #194355.

## Test Plan

Reproduced the exact failure mode from the original XPU issue
(#141332), swapped to MPS:

```python
import torch
from torch._subclasses import CrossRefFakeMode
import torch.nn.functional as F

with CrossRefFakeMode():
    input = torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0], device='mps')
    F.logsigmoid(input)
```

- [x] Before the fix: raises `MetadataMismatchError: ... found mismatched
      tensor metadata for output[1]: Shapes torch.Size([0]) and
      torch.Size([5]) are not equal!`
- [x] After the fix: runs cleanly
- [x] Verified no correctness regression on MPS vs CPU for plain
      forward/backward and forward-mode-AD double backward (which is what
      `decompositions_for_jvp.py`'s version is used for) -- max diffs at
      fp32 precision level (`1.19e-07` / `3.73e-09`)
- [x] `lintrunner -a` on both changed files: clean

---