### PR TITLE
Remove redundant MPS branch from tensor repr device-print check

### DIFF
--- a/torch/_tensor_str.py
+++ b/torch/_tensor_str.py
@@ -433,13 +433,8 @@ def _str_intern(inp, *, tensor_contents=None):
     # torch._C._get_default_device() only returns either cpu or cuda.
     # In other cases, we don't have a way to set them as default yet,
     # and we should always print out device for them.
-    if (
-        self.device.type != torch._C._get_default_device()
-        or (
-            self.device.type == "cuda"
-            and torch.cuda.current_device() != self.device.index
-        )
-        or (self.device.type == "mps")
+    if self.device.type != torch._C._get_default_device() or (
+        self.device.type == "cuda" and torch.cuda.current_device() != self.device.index
     ):
         suffixes.append("device='" + str(self.device) + "'")
 


### PR DESCRIPTION
## Summary

`_str_intern`'s device-suffix printing logic in `torch/_tensor_str.py` had
an explicit `or (self.device.type == "mps")` branch, added during the
original MPS backend bring-up (#76725, 2022). This branch is redundant:
the comment directly above it documents the invariant that
`torch._C._get_default_device()` can only ever return `"cpu"` or `"cuda"`
(backed by the legacy, deprecated `torch.set_default_tensor_type()`,
which only CPU and CUDA register legacy tensor-type classes for --
verified `torch.mps.FloatTensor` / `torch.xpu.FloatTensor` don't exist).
Given that invariant, `self.device.type != torch._C._get_default_device()`
is already unconditionally `True` for any MPS tensor, so the explicit MPS
branch can never affect the result. This PR removes it; no behavior
change.

## Test Plan

```python
import torch
x = torch.randn(3, device='mps')
assert "device='mps" in repr(x)
y = torch.randn(3)
assert 'device=' not in repr(y)
torch.set_default_device('mps')
z = torch.randn(3)
print(repr(z))
```

- [x] MPS tensor repr still includes `device='mps:0'`
- [x] CPU tensor repr still omits the device suffix
- [x] Tensor created under `torch.set_default_device('mps')` still prints
      the device suffix, matching pre-existing (unrelated, unchanged)
      behavior
- [x] `lintrunner -a`: clean

---