### PR TITLE
Make pr-review skill discoverable by Codex

### DIFF
--- a/.agents/skills/pr-review
+++ b/.agents/skills/pr-review
@@ -1,0 +1,1 @@
+../../.claude/skills/pr-review


### PR DESCRIPTION
I reviewed the linked skill layout and verified that this change adds only a relative symlink, so I believe it resolves #195305 without duplicating the review workflow.

> Codex assisted with drafting the following summary and test record:
>
> Codex scans `.agents/skills` for repository-scoped skills, while the existing `pr-review` skill is stored in `.claude/skills`. This change adds `.agents/skills/pr-review` as a relative symlink to the existing skill so both agents use the same workflow.
>
> Test Plan:
>
> ```bash
> lintrunner -a
> test -L .agents/skills/pr-review
> test -f .agents/skills/pr-review/SKILL.md
> ```