### PR TITLE
[xpu][1/N] Integrate OneDNN grouped_mm and scaled_grouped_mm

### DIFF
--- a/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
@@ -43,25 +43,37 @@ inline GroupedScaleSpec make_grouped_scale_spec(
   bool is_src = (arg_type == GroupedGemmArgType::Src);
 
   switch (scaling_type) {
+      // Refer to
+      // https://uxlfoundation.github.io/oneDNN/dev_guide_attributes_quantization.html#relevant-apis-and-supported-granularity-levels
     case at::blas::ScalingType::RowWise:
-      // For FP8 rowwise with grouped matmul, use set_scales_mask (no groups)
-      // following the official grouped matmul example:
-      //   src: mask=(1<<0) -> per-token scale, shape [M]
-      //   wei: mask=(1<<0)|(1<<2) -> per-group-per-N scale, shape [G, N]
+      // For FP8 rowwise with grouped matmul, use mask only to configure the
+      // scales.
+      //   src: mask=(1<<0)=0x1 -> scale vary along 0th dimension, shape [M]
+      //   wei: mask=(1<<0)|(1<<2)=0x5 -> scale vary along 0th and 2nd
+      //   dimensions, shape [G, N]
       return {
-          is_src ? (1 << 0) : (1 << 0) | (1 << 2),
+          is_src ? 0x1 : 0x5,
           {},
           dnnl::memory::data_type::f32,
           /*use_mask_only=*/true};
     case at::blas::ScalingType::BlockWise1x32:
+      // For MxFP8/MxFP4 blockwise scaling, use mask and groups to configure the
+      // scales.
+      //   src: mask=(1<<0)|(1<<1)=0x3 -> the 0th and 1st dimensions will be
+      //   divided into groups,
+      //        group shape=[1, 32]
+      //   wei: mask=(1<<0)|(1<<1)|(1<<2)=0x7 -> the 0th, 1st, and 2nd
+      //   dimensions will be divided into groups,
+      //        group shape=[1, 32, 1] but OneDNN only accepts 2D group shapes
+      //        now so uses [32, 1].
       return {
-          is_src ? (1 << 0) | (1 << 1) : (1 << 0) | (1 << 1) | (1 << 2),
+          is_src ? 0x3 : 0x7,
           is_src ? dnnl::memory::dims{1, 32} : dnnl::memory::dims{32, 1},
           dnnl::memory::data_type::e8m0,
           /*use_mask_only=*/false};
     case at::blas::ScalingType::BlockWise1x16:
       return {
-          is_src ? (1 << 0) | (1 << 1) : (1 << 0) | (1 << 1) | (1 << 2),
+          is_src ? 0x3 : 0x7,
           is_src ? dnnl::memory::dims{1, 16} : dnnl::memory::dims{16, 1},
           dnnl::memory::data_type::f8_e4m3,
           /*use_mask_only=*/false};

--- a/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
@@ -1,0 +1,315 @@
+#include <ATen/Tensor.h>
+#include <ATen/core/Tensor.h>
+#include <c10/core/ScalarType.h>
+
+#include <ATen/native/mkldnn/xpu/detail/Attr.h>
+#include <ATen/native/mkldnn/xpu/detail/Utils.h>
+#include <ATen/native/mkldnn/xpu/detail/oneDNN.h>
+#include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
+
+#include <oneapi/dnnl/dnnl.hpp>
+
+namespace at::native::onednn {
+
+// Describes how to configure oneDNN scales for a given role/ScalingType.
+// When use_mask_only is true, apply via set_scales_mask(arg, mask).
+// Otherwise, apply via set_scales(arg, mask, groups, dtype).
+struct ScaleSpec {
+  int mask;
+  dnnl::memory::dims groups;
+  dnnl::memory::data_type dtype;
+  bool use_mask_only;
+
+  void apply(dnnl::primitive_attr& attr, int arg) const {
+    if (use_mask_only) {
+      attr.set_scales_mask(arg, mask);
+    } else {
+      attr.set_scales(arg, mask, groups, dtype);
+    }
+  }
+};
+
+inline ScaleSpec make_scale_spec(
+    at::blas::ScalingType scaling_type,
+    int64_t K,
+    const std::string& arg_type,
+    bool a_is_2d,
+    bool b_is_2d) {
+  TORCH_CHECK(
+      arg_type == "src" || arg_type == "wei",
+      "Expected arg_type to be 'src' or 'wei', but got '",
+      arg_type,
+      "'");
+  TORCH_CHECK(
+      a_is_2d && !b_is_2d,
+      "Currently only 2d x 3d grouped matmul with offsets is supported");
+  bool is_src = (arg_type == "src");
+
+  switch (scaling_type) {
+    case at::blas::ScalingType::RowWise:
+      // For FP8 rowwise with grouped matmul, use set_scales_mask (no groups)
+      // following the official grouped matmul example:
+      //   src: mask=(1<<0) -> per-token scale, shape [M]
+      //   wei: mask=(1<<0)|(1<<2) -> per-group-per-N scale, shape [G, N]
+      return {
+          is_src ? (1 << 0) : (1 << 0) | (1 << 2),
+          {},
+          dnnl::memory::data_type::f32,
+          /*use_mask_only=*/true};
+    case at::blas::ScalingType::BlockWise1x32:
+      return {
+          is_src ? (1 << 0) | (1 << 1) : (1 << 0) | (1 << 1) | (1 << 2),
+          is_src ? dnnl::memory::dims{1, 32} : dnnl::memory::dims{32, 1},
+          dnnl::memory::data_type::e8m0,
+          /*use_mask_only=*/false};
+    case at::blas::ScalingType::BlockWise1x16:
+      return {
+          is_src ? (1 << 0) | (1 << 1) : (1 << 0) | (1 << 1) | (1 << 2),
+          is_src ? dnnl::memory::dims{1, 16} : dnnl::memory::dims{16, 1},
+          dnnl::memory::data_type::f8_e4m3,
+          /*use_mask_only=*/false};
+    default:
+      TORCH_CHECK(
+          false, "Unknown scaling_type: ", static_cast<int>(scaling_type));
+  }
+}
+
+// Prepare input tensors for grouped matmul: ensure proper contiguity and
+// 64-byte alignment. 2D x 3D (inference): mat_a needs K-contiguous, mat_b needs
+// K-contiguous or N-contiguous 2D x 2D (training grad_B): mat_a needs col-major
+// (dim0 stride=1), mat_b needs row-major (N-contiguous)
+std::tuple<Tensor, Tensor, Tensor> prepare_grouped_matmul_inputs(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    Tensor& out,
+    bool a_is_2d,
+    bool b_is_2d) {
+  Tensor prepared_mat_a, prepared_mat_b, prepared_out;
+  if (a_is_2d && !b_is_2d) {
+    // 2D x 3D: A[M,K] needs K-contiguous (row-major), B[E,K,N] should be
+    // K-contiguous or N-contiguous
+    prepared_mat_a = make_contiguous_and_aligned(mat_a);
+    prepared_mat_b = !is_64_bytes_aligned(mat_b) ||
+            !(mat_b.is_contiguous() || mat_b.transpose(-2, -1).is_contiguous())
+        ? make_contiguous_and_aligned(mat_b.transpose(-2, -1)).transpose(-2, -1)
+        : mat_b;
+  } else if (a_is_2d && b_is_2d) {
+    // 2D x 2D: A[M,K] needs col-major (M-major, dim0 stride=1), B[K,N] needs
+    // row-major (N-contiguous)
+    prepared_mat_a =
+        make_contiguous_and_aligned(mat_a.transpose(-2, -1)).transpose(-2, -1);
+    prepared_mat_b = make_contiguous_and_aligned(mat_b);
+  } else {
+    TORCH_CHECK(false, "Unsupported grouped matmul input dimensions");
+  }
+  TORCH_CHECK(
+      out.is_contiguous() && is_64_bytes_aligned(out),
+      "Output tensor must be contiguous and 64-byte aligned for oneDNN");
+  prepared_out = out;
+  return {prepared_mat_a, prepared_mat_b, prepared_out};
+}
+
+std::tuple<dnnl::memory::desc, dnnl::memory::desc, dnnl::memory::desc>
+get_grouped_gemm_md(
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t group_count,
+    dnnl::memory::data_type dtype,
+    dnnl::memory::data_type dst_dtype,
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& out,
+    bool a_is_2d,
+    bool b_is_2d) {
+  dnnl::memory::desc src_md, weights_md, dst_md;
+  if (a_is_2d && !b_is_2d) {
+    src_md = dnnl::memory::desc::grouped({M, K}, dtype, 0, group_count);
+    weights_md = get_onednn_md(mat_b);
+    dst_md = dnnl::memory::desc::grouped({M, N}, dst_dtype, 0, group_count);
+  } else if (a_is_2d && b_is_2d) {
+    src_md = dnnl::memory::desc::grouped({M, K}, dtype, 1, group_count);
+    weights_md = dnnl::memory::desc::grouped({K, N}, dtype, 0, group_count);
+    dst_md = get_onednn_md(out);
+  } else {
+    TORCH_CHECK(
+        false,
+        "Unsupported grouped matmul dimensions: mat_a.dim() = ",
+        a_is_2d ? 2 : 3,
+        ", mat_b.dim() = ",
+        b_is_2d ? 2 : 3);
+  }
+  return {src_md, weights_md, dst_md};
+}
+
+std::tuple<dnnl::memory, dnnl::memory, dnnl::memory> make_grouped_gemm_mem(
+    const dnnl::memory::desc& src_md,
+    const dnnl::memory::desc& weights_md,
+    const dnnl::memory::desc& dst_md,
+    const Tensor& src,
+    const Tensor& weights,
+    const Tensor& dst,
+    const Tensor& offs,
+    dnnl::engine& engine,
+    bool a_is_2d,
+    bool b_is_2d) {
+  dnnl::memory src_mem, weights_mem, dst_mem;
+  if (a_is_2d && !b_is_2d) {
+    src_mem = make_onednn_grouped_memory(
+        src_md, engine, src.data_ptr(), offs.data_ptr());
+    weights_mem = make_onednn_memory(weights_md, engine, weights.data_ptr());
+    dst_mem = make_onednn_grouped_memory(
+        dst_md, engine, dst.data_ptr(), offs.data_ptr());
+  } else if (a_is_2d && b_is_2d) {
+    src_mem = make_onednn_grouped_memory(
+        src_md, engine, src.data_ptr(), offs.data_ptr());
+    weights_mem = make_onednn_grouped_memory(
+        weights_md, engine, weights.data_ptr(), offs.data_ptr());
+    dst_mem = make_onednn_memory(dst_md, engine, dst.data_ptr());
+  } else {
+    TORCH_CHECK(
+        false,
+        "Unsupported grouped matmul dimensions: mat_a.dim() = ",
+        src.dim(),
+        ", mat_b.dim() = ",
+        weights.dim());
+  }
+  return {src_mem, weights_mem, dst_mem};
+}
+
+sycl::event scaled_grouped_matmul(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const std::optional<Tensor> scale_a,
+    const std::optional<Tensor> scale_b,
+    const std::optional<at::blas::ScalingType> scaling_choice_a,
+    const std::optional<at::blas::ScalingType> scaling_choice_b,
+    const Tensor& offs,
+    Tensor& out,
+    const std::optional<Tensor> alpha) {
+  bool a_is_2d = mat_a.dim() == 2;
+  bool b_is_2d = mat_b.dim() == 2;
+
+  TORCH_CHECK(
+      (a_is_2d && !b_is_2d),
+      "Currently only 2d x 3d grouped matmul with offsets is supported");
+
+  bool is_fp4 = mat_a.scalar_type() == at::kFloat4_e2m1fn_x2;
+  int32_t M, N, K, group_count;
+  M = mat_a.size(-2);
+  K = is_fp4 ? mat_a.size(-1) * 2 : mat_a.size(-1);
+  N = mat_b.size(-1);
+  group_count = offs.size(0);
+
+  auto [prepared_mat_a, prepared_mat_b, prepared_out] =
+      prepare_grouped_matmul_inputs(mat_a, mat_b, out, a_is_2d, b_is_2d);
+
+  auto& engine = GpuEngineManager::Instance().get_engine();
+  auto& stream = GpuStreamManager::Instance().get_stream();
+
+  // 1.1 Create memory descriptor
+  dnnl::memory::data_type dtype = get_onednn_dtype(mat_a);
+  dnnl::memory::data_type dst_dtype = get_onednn_dtype(out);
+  auto [src_md, weights_md, dst_md] = get_grouped_gemm_md(
+      M,
+      N,
+      K,
+      group_count,
+      dtype,
+      dst_dtype,
+      prepared_mat_a,
+      prepared_mat_b,
+      prepared_out,
+      a_is_2d,
+      b_is_2d);
+
+  // 1.2 Create the matmul primitive descriptor
+  dnnl::primitive_attr op_attr = dnnl::primitive_attr();
+
+  if (scaling_choice_a.has_value() && scaling_choice_b.has_value()) {
+    const ScaleSpec src_spec =
+        make_scale_spec(scaling_choice_a.value(), K, "src", a_is_2d, b_is_2d);
+    const ScaleSpec wei_spec =
+        make_scale_spec(scaling_choice_b.value(), K, "wei", a_is_2d, b_is_2d);
+    src_spec.apply(op_attr, DNNL_ARG_SRC);
+    wei_spec.apply(op_attr, DNNL_ARG_WEIGHTS);
+  }
+
+  dnnl::memory::desc alpha_md;
+  if (alpha.has_value()) {
+    // set alpha in post-op attr, this is used for NVFP4 case where we need to
+    // combine two global fp32 scales into a single alpha value
+    TORCH_CHECK(
+        alpha.value().dim() == 1 && alpha.value().size(0) == group_count,
+        "Expected alpha to be a 1D tensor of size ",
+        group_count,
+        ", but got shape: ",
+        alpha.value().sizes());
+    alpha_md = get_onednn_md(alpha.value().view({group_count, 1}));
+    dnnl::post_ops post_ops;
+    post_ops.append_binary(dnnl::algorithm::binary_mul, alpha_md);
+    op_attr.set_post_ops(post_ops);
+  }
+
+#if ONEDNN_SUPPORT_DETERMINISTIC
+  if (at::globalContext().deterministicAlgorithms() ||
+      at::globalContext().deterministicMkldnn())
+    op_attr.set_deterministic(true);
+#endif
+
+  op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+  // 1.3 Create the matmul primitive descriptor
+  dnnl::matmul::primitive_desc matmul_pd =
+      dnnl::matmul::primitive_desc(engine, src_md, weights_md, dst_md, op_attr);
+
+  // 2. Prepare memory
+  auto [src_mem, weights_mem, dst_mem] = make_grouped_gemm_mem(
+      src_md,
+      weights_md,
+      dst_md,
+      prepared_mat_a,
+      prepared_mat_b,
+      prepared_out,
+      offs,
+      engine,
+      a_is_2d,
+      b_is_2d);
+  dnnl::memory scratchpad =
+      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, (void*)nullptr);
+
+  // 3. Setup Args for exec
+  std::unordered_map<int, dnnl::memory> args;
+  args.insert({DNNL_ARG_SRC, src_mem});
+  args.insert({DNNL_ARG_WEIGHTS, weights_mem});
+  args.insert({DNNL_ARG_DST, dst_mem});
+  args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
+
+  if (scaling_choice_a.has_value() && scaling_choice_b.has_value()) {
+    at::Tensor src_scale = make_contiguous_and_aligned(scale_a.value());
+    at::Tensor wei_scale = make_contiguous_and_aligned(scale_b.value());
+    dnnl::memory::desc src_scale_md = get_onednn_md(src_scale);
+    dnnl::memory::desc wei_scale_md = get_onednn_md(wei_scale);
+    auto src_scale_mem =
+        make_onednn_memory(src_scale_md, engine, src_scale.data_ptr());
+    auto wei_scale_mem =
+        make_onednn_memory(wei_scale_md, engine, wei_scale.data_ptr());
+
+    args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, src_scale_mem});
+    args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, wei_scale_mem});
+  }
+  if (alpha.has_value()) {
+    // set alpha in args for post-op binary
+    dnnl::memory alpha_mem =
+        make_onednn_memory(alpha_md, engine, alpha.value().data_ptr());
+    args.insert(
+        {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, alpha_mem});
+  }
+
+  dnnl::matmul matmul_p = dnnl::matmul(matmul_pd);
+  sycl::event matmul_fwd_event =
+      dnnl::sycl_interop::execute(matmul_p, stream, args);
+  return matmul_fwd_event;
+}
+
+} // namespace at::native::onednn

--- a/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
@@ -14,7 +14,7 @@ namespace at::native::onednn {
 // Describes how to configure oneDNN scales for a given role/ScalingType.
 // When use_mask_only is true, apply via set_scales_mask(arg, mask).
 // Otherwise, apply via set_scales(arg, mask, groups, dtype).
-struct ScaleSpec {
+struct GroupedScaleSpec {
   int mask;
   dnnl::memory::dims groups;
   dnnl::memory::data_type dtype;
@@ -29,9 +29,8 @@ struct ScaleSpec {
   }
 };
 
-inline ScaleSpec make_scale_spec(
+inline GroupedScaleSpec make_grouped_scale_spec(
     at::blas::ScalingType scaling_type,
-    int64_t K,
     const std::string& arg_type,
     bool a_is_2d,
     bool b_is_2d) {
@@ -195,7 +194,7 @@ sycl::event scaled_grouped_matmul(
       "Currently only 2d x 3d grouped matmul with offsets is supported");
 
   bool is_fp4 = mat_a.scalar_type() == at::kFloat4_e2m1fn_x2;
-  int32_t M, N, K, group_count;
+  int64_t M, N, K, group_count;
   M = mat_a.size(-2);
   K = is_fp4 ? mat_a.size(-1) * 2 : mat_a.size(-1);
   N = mat_b.size(-1);
@@ -227,10 +226,10 @@ sycl::event scaled_grouped_matmul(
   dnnl::primitive_attr op_attr = dnnl::primitive_attr();
 
   if (scaling_choice_a.has_value() && scaling_choice_b.has_value()) {
-    const ScaleSpec src_spec =
-        make_scale_spec(scaling_choice_a.value(), K, "src", a_is_2d, b_is_2d);
-    const ScaleSpec wei_spec =
-        make_scale_spec(scaling_choice_b.value(), K, "wei", a_is_2d, b_is_2d);
+    const GroupedScaleSpec src_spec = make_grouped_scale_spec(
+        scaling_choice_a.value(), "src", a_is_2d, b_is_2d);
+    const GroupedScaleSpec wei_spec = make_grouped_scale_spec(
+        scaling_choice_b.value(), "wei", a_is_2d, b_is_2d);
     src_spec.apply(op_attr, DNNL_ARG_SRC);
     wei_spec.apply(op_attr, DNNL_ARG_WEIGHTS);
   }
@@ -275,8 +274,13 @@ sycl::event scaled_grouped_matmul(
       engine,
       a_is_2d,
       b_is_2d);
-  dnnl::memory scratchpad =
-      make_onednn_memory(matmul_pd.scratchpad_desc(), engine, (void*)nullptr);
+  size_t scratchpad_size = matmul_pd.scratchpad_desc().get_size();
+  at::Tensor scratchpad_tensor = at::empty(
+      {static_cast<int64_t>(scratchpad_size)},
+      mat_a.options().dtype(at::kByte),
+      std::nullopt);
+  dnnl::memory scratchpad = make_onednn_memory(
+      matmul_pd.scratchpad_desc(), engine, scratchpad_tensor.data_ptr());
 
   // 3. Setup Args for exec
   std::unordered_map<int, dnnl::memory> args;

--- a/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/GroupedMatmul.cpp
@@ -11,6 +11,9 @@
 
 namespace at::native::onednn {
 
+// Identifies which matmul operand a GroupedScaleSpec is being built for.
+enum class GroupedGemmArgType { Src, Wei };
+
 // Describes how to configure oneDNN scales for a given role/ScalingType.
 // When use_mask_only is true, apply via set_scales_mask(arg, mask).
 // Otherwise, apply via set_scales(arg, mask, groups, dtype).
@@ -31,18 +34,13 @@ struct GroupedScaleSpec {
 
 inline GroupedScaleSpec make_grouped_scale_spec(
     at::blas::ScalingType scaling_type,
-    const std::string& arg_type,
+    GroupedGemmArgType arg_type,
     bool a_is_2d,
     bool b_is_2d) {
   TORCH_CHECK(
-      arg_type == "src" || arg_type == "wei",
-      "Expected arg_type to be 'src' or 'wei', but got '",
-      arg_type,
-      "'");
-  TORCH_CHECK(
       a_is_2d && !b_is_2d,
       "Currently only 2d x 3d grouped matmul with offsets is supported");
-  bool is_src = (arg_type == "src");
+  bool is_src = (arg_type == GroupedGemmArgType::Src);
 
   switch (scaling_type) {
     case at::blas::ScalingType::RowWise:
@@ -116,7 +114,6 @@ get_grouped_gemm_md(
     int64_t group_count,
     dnnl::memory::data_type dtype,
     dnnl::memory::data_type dst_dtype,
-    const Tensor& mat_a,
     const Tensor& mat_b,
     const Tensor& out,
     bool a_is_2d,
@@ -216,7 +213,6 @@ sycl::event scaled_grouped_matmul(
       group_count,
       dtype,
       dst_dtype,
-      prepared_mat_a,
       prepared_mat_b,
       prepared_out,
       a_is_2d,
@@ -227,9 +223,9 @@ sycl::event scaled_grouped_matmul(
 
   if (scaling_choice_a.has_value() && scaling_choice_b.has_value()) {
     const GroupedScaleSpec src_spec = make_grouped_scale_spec(
-        scaling_choice_a.value(), "src", a_is_2d, b_is_2d);
+        scaling_choice_a.value(), GroupedGemmArgType::Src, a_is_2d, b_is_2d);
     const GroupedScaleSpec wei_spec = make_grouped_scale_spec(
-        scaling_choice_b.value(), "wei", a_is_2d, b_is_2d);
+        scaling_choice_b.value(), GroupedGemmArgType::Wei, a_is_2d, b_is_2d);
     src_spec.apply(op_attr, DNNL_ARG_SRC);
     wei_spec.apply(op_attr, DNNL_ARG_WEIGHTS);
   }
@@ -237,7 +233,9 @@ sycl::event scaled_grouped_matmul(
   dnnl::memory::desc alpha_md;
   if (alpha.has_value()) {
     // set alpha in post-op attr, this is used for NVFP4 case where we need to
-    // combine two global fp32 scales into a single alpha value
+    // combine two global fp32 scales into a single alpha value.
+    // For grouped_matmul, alpha is per-group, so it should have one scale
+    // per group.
     TORCH_CHECK(
         alpha.value().dim() == 1 && alpha.value().size(0) == group_count,
         "Expected alpha to be a 1D tensor of size ",

--- a/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/Utils.cpp
@@ -26,6 +26,15 @@ dnnl::memory make_onednn_memory(
   return make_onednn_memory(md, engine, const_cast<void*>(ptr));
 }
 
+dnnl::memory make_onednn_grouped_memory(
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    void* ptr,
+    void* offs_ptr) {
+  return dnnl::sycl_interop::make_memory(
+      md, engine, dnnl::sycl_interop::memory_kind::usm, {ptr, offs_ptr});
+}
+
 dnnl::memory::format_tag get_dnnl_default_format(
     int ndims,
     bool is_channels_last,

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNN.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ATen/BlasBackend.h>
+#include <ATen/native/ScaledBlasUtils.h>
 #include <ATen/native/mkldnn/xpu/detail/Attr.h>
 #include <ATen/native/mkldnn/xpu/detail/Utils.h>
 #include <ATen/native/mkldnn/xpu/detail/oneDNNContext.h>
@@ -217,4 +218,15 @@ sycl::event scaled_matmul(
     const std::optional<at::Tensor>& scale_result,
     bool use_fast_accum,
     const std::optional<at::Tensor>& alpha = std::nullopt);
+
+sycl::event scaled_grouped_matmul(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const std::optional<Tensor> scale_a,
+    const std::optional<Tensor> scale_b,
+    const std::optional<at::blas::ScalingType> scaling_choice_a,
+    const std::optional<at::blas::ScalingType> scaling_choice_b,
+    const Tensor& offs,
+    Tensor& out,
+    const std::optional<Tensor> alpha = std::nullopt);
 } // namespace at::native::onednn

--- a/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
+++ b/aten/src/ATen/native/mkldnn/xpu/detail/oneDNNContext.h
@@ -18,10 +18,18 @@ dnnl::memory make_onednn_memory(
     dnnl::engine& engine,
     void* ptr);
 
-TORCH_XPU_API dnnl::memory make_onednn_memory(
+dnnl::memory make_onednn_memory(
     dnnl::memory::desc md,
     dnnl::engine& engine,
     const void* ptr);
+
+// This version is used for grouped matmul.
+// see https://uxlfoundation.github.io/oneDNN/dev_guide_grouped_mem.html
+dnnl::memory make_onednn_grouped_memory(
+    dnnl::memory::desc md,
+    dnnl::engine& engine,
+    void* ptr,
+    void* offs_ptr);
 
 // Keep non-static and non-inline
 bool set_onednn_verbose(int level);

--- a/aten/src/ATen/native/xpu/GroupedBlas.cpp
+++ b/aten/src/ATen/native/xpu/GroupedBlas.cpp
@@ -144,7 +144,7 @@ void _check_scales_blocked(
       const int fp4_elems_per_byte = 2;
       K *= fp4_elems_per_byte;
     }
-    int blocked_scaled_K = (K + blocksize - 1) / blocksize;
+    int64_t blocked_scaled_K = (K + blocksize - 1) / blocksize;
     int64_t N = mat.size(2);
 
     // OneDNN expects scales as 3d tensor, shape (G, ceil(K/block_size), N).
@@ -281,8 +281,8 @@ Tensor _scaled_grouped_mm_xpu(
 
   const int scale_multiplier =
       (mat_a.dim() == 2 && mat_b.dim() == 2) ? offs->size(0) : 1;
-  xpu::check_scale(mat_a, scale_a, 0, 0, scale_multiplier);
-  xpu::check_scale(mat_b, scale_b, 1, 1, scale_multiplier);
+  check_scale(mat_a, scale_a, 0, 0, scale_multiplier);
+  check_scale(mat_b, scale_b, 1, 1, scale_multiplier);
 
   const auto out_dtype_ = out_dtype.value_or(at::kBFloat16);
   TORCH_CHECK_VALUE(

--- a/aten/src/ATen/native/xpu/GroupedBlas.cpp
+++ b/aten/src/ATen/native/xpu/GroupedBlas.cpp
@@ -21,28 +21,8 @@
 #include <ATen/Functions.h>
 #include <ATen/NativeFunctions.h>
 #else
-#include <ATen/ops/_addmm_activation_native.h>
-#include <ATen/ops/_efficientzerotensor.h>
 #include <ATen/ops/_scaled_grouped_mm_v2_native.h>
 #include <ATen/ops/_scaled_mm_native.h>
-#include <ATen/ops/_unsafe_view_native.h>
-#include <ATen/ops/abs.h>
-#include <ATen/ops/addmm_native.h>
-#include <ATen/ops/addmv_native.h>
-#include <ATen/ops/baddbmm_native.h>
-#include <ATen/ops/bmm_native.h>
-#include <ATen/ops/copy_native.h>
-#include <ATen/ops/dot_native.h>
-#include <ATen/ops/empty.h>
-#include <ATen/ops/empty_strided.h>
-#include <ATen/ops/gelu.h>
-#include <ATen/ops/max.h>
-#include <ATen/ops/mm_native.h>
-#include <ATen/ops/mul.h>
-#include <ATen/ops/ones.h>
-#include <ATen/ops/relu.h>
-#include <ATen/ops/scalar_tensor_native.h>
-#include <ATen/ops/vdot_native.h>
 #endif
 
 using at::blas::ScalingType;
@@ -54,7 +34,7 @@ using scaled_blas::ScaledGemmImplementation;
 
 namespace at::native {
 
-namespace xpu {
+namespace {
 
 void _check_scales_fp8_rowwise(
     const Tensor& mat,
@@ -232,7 +212,7 @@ void check_swizzle(ArrayType& swizzle_enums) {
   }
 }
 
-} // namespace xpu
+} // namespace
 
 Tensor _scaled_grouped_mm_xpu(
     const Tensor& mat_a,
@@ -419,8 +399,8 @@ TORCH_IMPL_FUNC(_scaled_grouped_mm_xpu_v2_out)
   auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
 
   // swizze checks
-  xpu::check_swizzle(swizzle_a_enum);
-  xpu::check_swizzle(swizzle_b_enum);
+  check_swizzle(swizzle_a_enum);
+  check_swizzle(swizzle_b_enum);
 
   // at this point we can start working out what we want to be doing
   // Try to do as few steps as possible.
@@ -446,35 +426,21 @@ TORCH_IMPL_FUNC(_scaled_grouped_mm_xpu_v2_out)
     case ScaledGemmImplementation::ROWWISE_ROWWISE: {
       const int scale_multiplier =
           (mat_a.dim() == 2 && mat_b.dim() == 2) ? offs->size(0) : 1;
-      xpu::_check_scales_fp8_rowwise(
+      _check_scales_fp8_rowwise(
           mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */, scale_multiplier);
-      xpu::_check_scales_fp8_rowwise(
+      _check_scales_fp8_rowwise(
           mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */, scale_multiplier);
       break;
     }
-    case ScaledGemmImplementation::MXFP8_MXFP8: {
-      // scale shape checks
-      xpu::_check_scales_blocked(
-          mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */);
-      xpu::_check_scales_blocked(
-          mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */);
-      break;
-    }
-    case ScaledGemmImplementation::MXFP4_MXFP4: {
-      // scale shape checks
-      xpu::_check_scales_blocked(
-          mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */);
-      xpu::_check_scales_blocked(
-          mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */);
-      break;
-    }
+    case ScaledGemmImplementation::MXFP8_MXFP8:
+    case ScaledGemmImplementation::MXFP4_MXFP4:
     case ScaledGemmImplementation::NVFP4_NVFP4: {
       // scale shape checks
-      xpu::_check_scales_blocked(
-          mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */);
-      xpu::_check_scales_blocked(
-          mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */);
-      alpha = scale_a[1].mul(scale_b[1]);
+      _check_scales_blocked(mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */);
+      _check_scales_blocked(mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */);
+      if (gemm_impl == ScaledGemmImplementation::NVFP4_NVFP4) {
+        alpha = scale_a[1].mul(scale_b[1]);
+      }
       break;
     }
     default:
@@ -502,15 +468,12 @@ Tensor _grouped_mm_xpu(
     const std::optional<at::Tensor>& bias,
     std::optional<c10::ScalarType> out_dtype) {
   _grouped_mm_validate_inputs(mat_a, mat_b, offs, bias, out_dtype);
-  const bool a_b_and_out_are_same_type =
-      mat_a.dtype() == mat_b.dtype() && out_dtype.has_value()
-      ? (mat_a.dtype() == out_dtype.value())
-      : true;
+  const bool a_b_and_out_are_same_type = (mat_a.dtype() == mat_b.dtype()) &&
+      (!out_dtype.has_value() || mat_a.dtype() == *out_dtype);
 
   const bool a_is_2d = mat_a.dim() == 2;
   const bool b_is_2d = mat_b.dim() == 2;
-  const bool supported_cases =
-      ((a_is_2d && !b_is_2d) || (a_is_2d && b_is_2d)) && !bias.has_value();
+  const bool supported_cases = (a_is_2d && !b_is_2d) && !bias.has_value();
 
   bool use_fast_path = a_b_and_out_are_same_type && supported_cases;
   const auto out_dtype_ =

--- a/aten/src/ATen/native/xpu/GroupedBlas.cpp
+++ b/aten/src/ATen/native/xpu/GroupedBlas.cpp
@@ -1,0 +1,537 @@
+#include <c10/core/Scalar.h>
+#include <c10/core/ScalarType.h>
+#include <c10/util/Exception.h>
+#include <c10/util/SmallVector.h>
+#include <c10/util/typeid.h>
+#include <cstdint>
+#define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/Context.h>
+#include <ATen/Dispatch.h>
+#include <ATen/ExpandUtils.h>
+#include <ATen/OpMathType.h>
+#include <ATen/TensorUtils.h>
+#include <ATen/core/Tensor.h>
+#include <ATen/native/GroupedMMUtils.h>
+#include <ATen/native/Resize.h>
+#include <ATen/native/ScaledBlasUtils.h>
+#include <ATen/native/mkldnn/xpu/detail/oneDNN.h>
+#include <c10/util/MaybeOwned.h>
+
+#ifndef AT_PER_OPERATOR_HEADERS
+#include <ATen/Functions.h>
+#include <ATen/NativeFunctions.h>
+#else
+#include <ATen/ops/_addmm_activation_native.h>
+#include <ATen/ops/_efficientzerotensor.h>
+#include <ATen/ops/_scaled_grouped_mm_v2_native.h>
+#include <ATen/ops/_scaled_mm_native.h>
+#include <ATen/ops/_unsafe_view_native.h>
+#include <ATen/ops/abs.h>
+#include <ATen/ops/addmm_native.h>
+#include <ATen/ops/addmv_native.h>
+#include <ATen/ops/baddbmm_native.h>
+#include <ATen/ops/bmm_native.h>
+#include <ATen/ops/copy_native.h>
+#include <ATen/ops/dot_native.h>
+#include <ATen/ops/empty.h>
+#include <ATen/ops/empty_strided.h>
+#include <ATen/ops/gelu.h>
+#include <ATen/ops/max.h>
+#include <ATen/ops/mm_native.h>
+#include <ATen/ops/mul.h>
+#include <ATen/ops/ones.h>
+#include <ATen/ops/relu.h>
+#include <ATen/ops/scalar_tensor_native.h>
+#include <ATen/ops/vdot_native.h>
+#endif
+
+using at::blas::ScalingType;
+using at::blas::SwizzleType;
+
+namespace scaled_blas = at::native::scaled;
+using scaled_blas::convert_int_to_enum;
+using scaled_blas::ScaledGemmImplementation;
+
+namespace at::native {
+
+namespace xpu {
+
+void _check_scales_fp8_rowwise(
+    const Tensor& mat,
+    const Tensor& scale,
+    const int dim,
+    const int arg_idx,
+    const int scale_multiplier = 1) {
+  // Checks scales for 2d or 3d target tensors (`mat`).
+  if (mat.dim() == 2) {
+    TORCH_CHECK(
+        scale.dim() == 1,
+        "scale must be a 1D tensor, but got ",
+        scale.dim(),
+        "D, arg ",
+        arg_idx);
+    TORCH_CHECK(
+        scale.is_contiguous(), "scale must be contiguous for arg ", arg_idx);
+    TORCH_CHECK(
+        scale.size(0) == mat.size(dim) * scale_multiplier,
+        "scale must have the same length as mat for arg ",
+        arg_idx);
+  } else {
+    TORCH_CHECK(
+        scale.dim() == 2,
+        "scale must be a 2D tensor, but got ",
+        scale.dim(),
+        "D for arg ",
+        arg_idx);
+    TORCH_CHECK(
+        scale.stride(1) == 1,
+        "scale must be contiguous in the last dimension for arg ",
+        arg_idx);
+    TORCH_CHECK(
+        scale.size(0) == mat.size(0),
+        "scale must have the same batch dimension as mat for arg ",
+        arg_idx);
+    TORCH_CHECK(
+        scale.size(1) == mat.size(1 + dim),
+        "scale must have the same first dimension as mat for arg ",
+        arg_idx);
+  }
+}
+
+void _check_scales_blocked(
+    const Tensor& mat,
+    const Tensor& scale,
+    const int dim,
+    const int arg_idx) {
+  // if {mx,nv}fp4, will need to modify K later
+  bool is_fp4 = (mat.scalar_type() == kFloat4_e2m1fn_x2);
+  int blocksize = 32;
+  // check for nvfp4 vs. mxfp4 to fix blocksize
+  if (is_fp4 && scale.scalar_type() == kFloat8_e4m3fn) {
+    blocksize = 16;
+  }
+
+  // Checks scales for 2d or 3d target tensors (`mat`).
+  if (mat.dim() == 2) {
+    // For MXFP8, 2d tensors have variable size groups represented as
+    // subtensors, so we can't check the scale sizes without doing a d2h sync to
+    // get the group sizes here.
+    TORCH_CHECK(
+        scale.dim() == mat.dim(),
+        "for block-scaled, scale must have same number of dimensions as parent tensor, but got mat.dim() = ",
+        mat.dim(),
+        " and scale.dim() = ",
+        scale.dim(),
+        " for arg ",
+        arg_idx);
+
+    // LHS mat shape (M, total_K) -> scale shape (M,
+    // rounded_up_per_group(K/blocksize)) RHS mat shape (total_K, N) -> scale
+    // shape (rounded_up_per_group(K/blocksize), N)
+    //   * weight is transposed prior to the call, scale stays non-transposed.
+    bool LHS = arg_idx == 0;
+    int dim_to_check = LHS ? 0 : 1;
+
+    TORCH_CHECK(
+        scale.size(dim_to_check) >= mat.size(dim_to_check),
+        "for block-scaled, arg ",
+        arg_idx,
+        " tensor shape (",
+        mat.size(0),
+        ", ",
+        mat.size(1),
+        ") ",
+        "must have scale.shape[",
+        dim_to_check,
+        "] >= ",
+        mat.size(dim_to_check),
+        " but got scale.shape=(",
+        scale.size(0),
+        ", ",
+        scale.size(1),
+        ")");
+  } else {
+    // For MXFP8, 3d tensors have static group sizes (stack of 2d tensors),
+    // so we can check the exact expected scale sizes here without a d2h sync.
+    // TODO: this is for 3d tensor in 2d-3d case specifically.
+    // We'll need to support 3d-3d and 3d-2d cases once mxfp8/nvfp4 grouped gemm
+    // supports them.
+    int64_t G = mat.size(0);
+    int64_t K = mat.size(1);
+    if (is_fp4) {
+      // FP4 packs 2 values into a single 8b word - the "real" K is 2x the
+      // reported K. Reverse that adjustment.
+      const int fp4_elems_per_byte = 2;
+      K *= fp4_elems_per_byte;
+    }
+    int blocked_scaled_K = (K + blocksize - 1) / blocksize;
+    int64_t N = mat.size(2);
+
+    // OneDNN expects scales as 3d tensor, shape (G, ceil(K/block_size), N).
+    TORCH_CHECK(
+        scale.dim() == mat.dim(),
+        "for block-scaled 2d-3d grouped GEMM, the 3d tensor of shape (G,K,N) must have a 3d scale of shape (G, ceil(K/block_size), N),",
+        "but scale is ",
+        scale.dim(),
+        "D for arg ",
+        arg_idx);
+    TORCH_CHECK(
+        scale.size(0) == G && scale.size(1) == blocked_scaled_K &&
+            scale.size(2) == N,
+        "for block-scaled grouped GEMM, the tensor shape (",
+        G,
+        ", ",
+        K,
+        ", ",
+        N,
+        ") must have scale shape (",
+        G,
+        ",",
+        blocked_scaled_K,
+        ",",
+        N,
+        ")",
+        " for arg ",
+        arg_idx,
+        ", got: ",
+        scale.size(0),
+        ", ",
+        scale.size(1),
+        ", ",
+        scale.size(2));
+  }
+}
+
+void check_scale(
+    const Tensor& mat,
+    const Tensor& scale,
+    const int dim,
+    const int arg_idx,
+    const int scale_multiplier = 1) {
+  bool using_fp8_rowwise = scale.scalar_type() == kFloat;
+  bool using_mx = scale.scalar_type() == at::kFloat8_e8m0fnu;
+  if (using_fp8_rowwise) {
+    _check_scales_fp8_rowwise(mat, scale, dim, arg_idx, scale_multiplier);
+  } else if (using_mx) {
+    _check_scales_blocked(mat, scale, dim, arg_idx);
+  } else {
+    TORCH_CHECK(
+        false,
+        "scale must be float32 or float8_e8m0fnu, but got ",
+        scale.dtype());
+  }
+}
+
+template <class ArrayType>
+void check_swizzle(ArrayType& swizzle_enums) {
+  for (auto swizzle_enum : swizzle_enums) {
+    TORCH_CHECK(
+        swizzle_enum == SwizzleType::NO_SWIZZLE,
+        "XPU grouped GEMM currently only supports SWIZZLE_NONE swizzle type, but got swizzle type ",
+        swizzle_enum);
+  }
+}
+
+} // namespace xpu
+
+Tensor _scaled_grouped_mm_xpu(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const Tensor& scale_a,
+    const Tensor& scale_b,
+    const std::optional<at::Tensor>& offs,
+    const std::optional<at::Tensor>& bias,
+    const std::optional<at::Tensor>& scale_result,
+    std::optional<c10::ScalarType> out_dtype,
+    bool use_fast_accum) {
+  TORCH_CHECK_VALUE(
+      !check_valid_strides_and_return_transposed(mat_a),
+      "Expected mat1 to not be transposed");
+  TORCH_CHECK_VALUE(
+      check_valid_strides_and_return_transposed(mat_b),
+      "Expected mat2 to be transposed");
+  TORCH_CHECK_VALUE(
+      mat_a.dim() == 2 || mat_a.dim() == 3, "mat_a has to be 2 or 3d");
+  TORCH_CHECK_VALUE(
+      mat_b.dim() == 2 || mat_b.dim() == 3, "mat_b has to be 2 or 3d");
+  const bool a_is_2d = mat_a.dim() == 2;
+  const bool b_is_2d = mat_b.dim() == 2;
+
+  TORCH_CHECK_VALUE(
+      (a_is_2d && !b_is_2d),
+      "Only 2d x 3d with offsets is supported for XPU scaled_grouped_mm for now");
+
+  if (!a_is_2d || !b_is_2d) {
+    TORCH_CHECK_VALUE(
+        mat_a.size(-1) == mat_b.size(-2),
+        "contraction dimension of mat_a and mat_b must match");
+  }
+  TORCH_CHECK_VALUE(
+      mat_a.size(-1) % 16 == 0,
+      "Expected trailing dimension of mat_a to be divisible by 16 ",
+      "but got mat1 shape: (",
+      mat_a.sizes(),
+      ").");
+  TORCH_CHECK_VALUE(
+      mat_b.size(-2) % 16 == 0 && mat_b.size(-1) % 16 == 0,
+      "Expected mat_b shape to be divisible by 16 ",
+      "but got mat_b shape: (",
+      mat_b.sizes(),
+      ").");
+
+  TORCH_CHECK_VALUE(!bias.has_value(), "Bias not supported yet");
+  TORCH_CHECK_VALUE(
+      !scale_result.has_value(), "Scale result not supported yet");
+  TORCH_CHECK_VALUE(
+      offs.has_value() == (a_is_2d || b_is_2d),
+      "Have to provide offsets if there is a 2d matrix");
+
+  if (offs.has_value()) {
+    TORCH_CHECK_VALUE(offs->dim() == 1, "offs has to be 1D");
+    TORCH_CHECK_VALUE(offs->dtype() == at::kInt, "Offsets have to be int32");
+  }
+
+  // FP8 per-row scaling expect fp32 scales.
+  // MXFP8 expects float8_e8m0fnu scales.
+  TORCH_CHECK_VALUE(
+      (scale_a.scalar_type() == kFloat && scale_b.scalar_type() == kFloat) ||
+          (scale_a.scalar_type() == at::kFloat8_e8m0fnu &&
+           scale_b.scalar_type() == at::kFloat8_e8m0fnu),
+      "For FP8 rowwise, both scales must both be float32 tensors. For MXFP8, scales must both be float8_e8m0fnu tensors.");
+
+  const int scale_multiplier =
+      (mat_a.dim() == 2 && mat_b.dim() == 2) ? offs->size(0) : 1;
+  xpu::check_scale(mat_a, scale_a, 0, 0, scale_multiplier);
+  xpu::check_scale(mat_b, scale_b, 1, 1, scale_multiplier);
+
+  const auto out_dtype_ = out_dtype.value_or(at::kBFloat16);
+  TORCH_CHECK_VALUE(
+      out_dtype_ == at::kBFloat16,
+      "Only bf16 high precision output types are supported for grouped gemm");
+
+  Tensor out =
+      create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+
+  // MXFP8 grouped GEMM dispatching
+  bool is_mxf8 =
+      ((mat_a.scalar_type() == at::kFloat8_e4m3fn ||
+        mat_a.scalar_type() == at::kFloat8_e5m2) &&
+       (mat_b.scalar_type() == at::kFloat8_e4m3fn ||
+        mat_b.scalar_type() == at::kFloat8_e5m2) &&
+       scale_a.scalar_type() == at::kFloat8_e8m0fnu &&
+       scale_b.scalar_type() == at::kFloat8_e8m0fnu);
+
+  // FP8 Rowwise grouped GEMM dispatching
+  bool is_fp8_rowwise =
+      ((mat_a.scalar_type() == kFloat8_e4m3fn ||
+        mat_a.scalar_type() == kFloat8_e5m2) &&
+       (mat_b.scalar_type() == kFloat8_e4m3fn ||
+        mat_b.scalar_type() == kFloat8_e5m2) &&
+       scale_a.scalar_type() == kFloat && scale_b.scalar_type() == kFloat);
+
+  TORCH_CHECK_VALUE(
+      is_mxf8 || is_fp8_rowwise,
+      "Only FP8 rowwise or blocked (MXFP8) grouped GEMM is supported for XPU at the moment");
+
+  auto scaled_choice = is_mxf8 ? at::blas::ScalingType::BlockWise1x32
+                               : at::blas::ScalingType::RowWise;
+  at::native::onednn::scaled_grouped_matmul(
+      mat_a,
+      mat_b,
+      scale_a,
+      scale_b,
+      scaled_choice,
+      scaled_choice,
+      offs.value(),
+      out);
+  return out;
+}
+
+namespace {
+
+using acceptance_fn = std::function<bool(
+    c10::ScalarType,
+    std::vector<ScalingType>&,
+    ArrayRef<Tensor>&,
+    c10::ScalarType,
+    std::vector<ScalingType>&,
+    ArrayRef<Tensor>&)>;
+
+std::array<std::tuple<std::string, acceptance_fn, ScaledGemmImplementation>, 4>
+    scale_grouped_kernel_dispatch = {
+        {{"rowwise_rowwise",
+          scaled_blas::check_rowwise_recipe,
+          ScaledGemmImplementation::ROWWISE_ROWWISE},
+         {"mxfp8_mxfp8",
+          scaled_blas::check_mxfp8_recipe,
+          ScaledGemmImplementation::MXFP8_MXFP8},
+         {"mxfp4_mxfp4",
+          scaled_blas::check_mxfp4_recipe,
+          ScaledGemmImplementation::MXFP4_MXFP4},
+         {"nvfp4_nvfp4",
+          scaled_blas::check_nvfp4_recipe,
+          ScaledGemmImplementation::NVFP4_NVFP4}}};
+
+} // anonymous namespace
+
+// V2: Grouped scaled matrix multiply. Shape inference + output allocation and
+// recipe-independent input validation run in
+// TORCH_META_FUNC(_scaled_grouped_mm_v2); this impl handles strides/dtype
+// validation that needs device context, the per-recipe scale-shape checks, and
+// kernel dispatch.
+TORCH_IMPL_FUNC(_scaled_grouped_mm_xpu_v2_out)
+(const Tensor& mat_a,
+ const Tensor& mat_b,
+ const at::ITensorListRef& scale_a_list,
+ IntArrayRef scale_recipe_a,
+ IntArrayRef swizzle_a,
+ const at::ITensorListRef& scale_b_list,
+ IntArrayRef scale_recipe_b,
+ IntArrayRef swizzle_b,
+ at::OptionalTensorRef offs,
+ at::OptionalTensorRef bias,
+ std::optional<c10::ScalarType> out_dtype,
+ IntArrayRef contraction_dim,
+ bool use_fast_accum,
+ const Tensor& out) {
+  TORCH_CHECK_VALUE(
+      !check_valid_strides_and_return_transposed(mat_a),
+      "Expected mat1 to not be transposed");
+  TORCH_CHECK_VALUE(
+      check_valid_strides_and_return_transposed(mat_b),
+      "Expected mat2 to be transposed");
+  TORCH_CHECK_VALUE(
+      (mat_a.dim() == 2 && mat_b.dim() == 3),
+      "Only 2d x 3d with offsets is supported for XPU scaled_grouped_mm for now");
+
+  // Materialize the scale lists so the existing acceptance helpers (which take
+  // ArrayRef<Tensor>) work unchanged.
+  std::vector<Tensor> scale_a(scale_a_list.begin(), scale_a_list.end());
+  std::vector<Tensor> scale_b(scale_b_list.begin(), scale_b_list.end());
+  ArrayRef<Tensor> scale_a_ref(scale_a);
+  ArrayRef<Tensor> scale_b_ref(scale_b);
+
+  // The output has already been sized by the structured-op meta function.
+  Tensor& out_mut = const_cast<Tensor&>(out);
+
+  // Conversion of implicitly-defined enums to explicit
+  auto swizzle_a_enum = convert_int_to_enum<SwizzleType>(swizzle_a);
+  auto swizzle_b_enum = convert_int_to_enum<SwizzleType>(swizzle_b);
+
+  // swizze checks
+  xpu::check_swizzle(swizzle_a_enum);
+  xpu::check_swizzle(swizzle_b_enum);
+
+  // at this point we can start working out what we want to be doing
+  // Try to do as few steps as possible.
+  // NOTE: support is deliberately sparse, can explicitly enumerate all
+  // combinations allowed. Do this via a list of defined (name, acceptance,
+  // concrete_impl) tuples.
+  auto scale_recipe_a_enum = convert_int_to_enum<ScalingType>(scale_recipe_a);
+  auto scale_recipe_b_enum = convert_int_to_enum<ScalingType>(scale_recipe_b);
+  ScaledGemmImplementation gemm_impl = scaled_blas::find_scaled_gemm_impl(
+      scale_grouped_kernel_dispatch,
+      mat_a.scalar_type(),
+      scale_recipe_a_enum,
+      scale_a_ref,
+      mat_b.scalar_type(),
+      scale_recipe_b_enum,
+      scale_b_ref);
+  TORCH_CHECK_VALUE(
+      gemm_impl != ScaledGemmImplementation::NONE,
+      "No gemm implementation was found");
+
+  std::optional<Tensor> alpha = std::nullopt;
+  switch (gemm_impl) {
+    case ScaledGemmImplementation::ROWWISE_ROWWISE: {
+      const int scale_multiplier =
+          (mat_a.dim() == 2 && mat_b.dim() == 2) ? offs->size(0) : 1;
+      xpu::_check_scales_fp8_rowwise(
+          mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */, scale_multiplier);
+      xpu::_check_scales_fp8_rowwise(
+          mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */, scale_multiplier);
+      break;
+    }
+    case ScaledGemmImplementation::MXFP8_MXFP8: {
+      // scale shape checks
+      xpu::_check_scales_blocked(
+          mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */);
+      xpu::_check_scales_blocked(
+          mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */);
+      break;
+    }
+    case ScaledGemmImplementation::MXFP4_MXFP4: {
+      // scale shape checks
+      xpu::_check_scales_blocked(
+          mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */);
+      xpu::_check_scales_blocked(
+          mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */);
+      break;
+    }
+    case ScaledGemmImplementation::NVFP4_NVFP4: {
+      // scale shape checks
+      xpu::_check_scales_blocked(
+          mat_a, scale_a[0], 0 /* dim */, 0 /* arg_idx */);
+      xpu::_check_scales_blocked(
+          mat_b, scale_b[0], 1 /* dim */, 1 /* arg_idx */);
+      alpha = scale_a[1].mul(scale_b[1]);
+      break;
+    }
+    default:
+      TORCH_CHECK_NOT_IMPLEMENTED(
+          false,
+          "_scaled_grouped_mm_xpu_v2 is in an inconsistent state - should never reach here");
+  }
+  at::native::onednn::scaled_grouped_matmul(
+      mat_a,
+      mat_b,
+      scale_a[0],
+      scale_b[0],
+      scale_recipe_a_enum[0],
+      scale_recipe_b_enum[0],
+      *offs,
+      out_mut,
+      alpha);
+  return;
+}
+
+Tensor _grouped_mm_xpu(
+    const Tensor& mat_a,
+    const Tensor& mat_b,
+    const std::optional<at::Tensor>& offs,
+    const std::optional<at::Tensor>& bias,
+    std::optional<c10::ScalarType> out_dtype) {
+  _grouped_mm_validate_inputs(mat_a, mat_b, offs, bias, out_dtype);
+  const bool a_b_and_out_are_same_type =
+      mat_a.dtype() == mat_b.dtype() && out_dtype.has_value()
+      ? (mat_a.dtype() == out_dtype.value())
+      : true;
+
+  const bool a_is_2d = mat_a.dim() == 2;
+  const bool b_is_2d = mat_b.dim() == 2;
+  const bool supported_cases =
+      ((a_is_2d && !b_is_2d) || (a_is_2d && b_is_2d)) && !bias.has_value();
+
+  bool use_fast_path = a_b_and_out_are_same_type && supported_cases;
+  const auto out_dtype_ =
+      _resolve_grouped_mm_out_dtype(mat_a, mat_b, out_dtype);
+  Tensor out =
+      create_grouped_gemm_output_tensor(mat_a, mat_b, offs, out_dtype_);
+  if (use_fast_path) {
+    at::native::onednn::scaled_grouped_matmul(
+        mat_a,
+        mat_b,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        offs.value(),
+        out);
+  } else {
+    _grouped_mm_fallback(mat_a, mat_b, offs, bias, out_dtype, out);
+  }
+
+  return out;
+}
+
+} // namespace at::native

--- a/cmake/Modules/FindMKLDNN.cmake
+++ b/cmake/Modules/FindMKLDNN.cmake
@@ -56,7 +56,7 @@ IF(NOT MKLDNN_FOUND)
     endif()
     ExternalProject_Add(xpu_mkldnn_proj
       GIT_REPOSITORY https://github.com/uxlfoundation/oneDNN
-      GIT_TAG v3.12.3
+      GIT_TAG rls-v3.13
       PREFIX ${XPU_MKLDNN_DIR_PREFIX}
       BUILD_IN_SOURCE 0
       CMAKE_ARGS  -DCMAKE_C_COMPILER=${DNNL_C_COMPILER}
@@ -65,6 +65,7 @@ IF(NOT MKLDNN_FOUND)
       -DDNNL_CPU_RUNTIME=NONE
       -DDNNL_BUILD_TESTS=OFF
       -DDNNL_BUILD_EXAMPLES=OFF
+      -DONEDNN_EXPERIMENTAL_GROUPED_MEMORY=ON
       -DONEDNN_BUILD_GRAPH=ON
       -DDNNL_LIBRARY_TYPE=STATIC
       -DDNNL_DPCPP_HOST_COMPILER=${DNNL_HOST_COMPILER} # Use global cxx compiler as host compiler


### PR DESCRIPTION
This is the first PR to enable `grouped_mm`, `scaled_grouped_mm` and `scaled_grouped_mm_v2` for Intel XPU device with OneDNN.

This PR integrate the OneDNN part. Has dependency on OneDNN v3.13 upgrade.

The GroupedMM in OneDNN reuses the matmul primitive. The changes is the new proposed grouped_memory API.
Refer to 
- Matmul Doc: https://uxlfoundation.github.io/oneDNN/dev_guide_matmul.html#grouped-gemm-support
- Grouped Memory Doc: https://uxlfoundation.github.io/oneDNN/dev_guide_grouped_mem.html
- Grouped Matmul example: https://uxlfoundation.github.io/oneDNN/page_matmul_grouped_cpp.html#doxid-matmul-grouped-cpp

This PR targets for Pytorch2.15 with OneDNN v3.13 release which only supports grouped_mm 2dx3d (fp16/bf16/fp32/fp8/mxfp8/mxfp4/nvfp4).

PR lists:

1. https://github.com/pytorch/pytorch/pull/195427
2. https://github.com/pytorch/pytorch/pull/195428


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01 @gujinghui @PenghuiCheng @jianyuh @min-jean-cho @yanbing-j @Guobing-Chen @Xia-Weiwen @snadampal