### PR TITLE
[Testcase Refactoring] Relax is_big_gpu check for PU1

### DIFF
--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1801,6 +1801,10 @@ def is_big_gpu(index_or_device: int | torch.device = 0) -> bool:
             return False
         return True
 
+    from torch._utils import _is_privateuse1_backend_available
+    if _is_privateuse1_backend_available():
+        return True
+
     min_sms = 16 if device.type == "xpu" else 68  # 3080
     avail_sms = prop.multi_processor_count
     if avail_sms < min_sms:


### PR DESCRIPTION
## Summary
This PR Relax is_big_gpu check for PU1 so out-of-tree accelerator backends can run these tests.

## Changes
- Relax is_big_gpu check for PU1.

## Motivation
This allows out-of-tree accelerators to be recognized correctly when deciding whether a depended big gpu test has enough devices to run.

## Test Plan
- CI: `python test/inductor/test_analysis.py`
- Verified test cases correctly on CPU, GPU, XPU.

## Notes
- This is part of the test case refactoring initiative tracked in #185590.
- Make CUDA/XPU device-generic in #189138.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo