### PR TITLE
[Dynamo] route PrivateUse1 autocast classes

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
@@ -1,5 +1,7 @@
 # Owner(s): ["module: PrivateUse1"]
 
+from unittest import mock
+
 import torch
 import torch._dynamo
 from torch._dynamo.test_case import run_tests, TestCase
@@ -197,6 +199,59 @@ class TestAutocast(TestCase):
         self.assertEqual(
             enter_autocast_nodes[0].args,
             ("openreg", torch.float16, True, True),
+        )
+
+    def test_compile_with_minimal_backend_autocast(self):
+        class MinimalAutocast(torch.amp.autocast_mode.autocast):
+            def __init__(self):
+                super().__init__("openreg")
+
+        with mock.patch.object(torch.openreg.amp, "autocast", MinimalAutocast):
+            backend = EagerAndRecordGraphs()
+
+            @torch.compile(backend=backend, fullgraph=True)
+            def fn(x):
+                with torch.openreg.amp.autocast():
+                    return x + 1
+
+            x = torch.randn(4, device="openreg")
+            self.assertEqual(fn(x), x + 1)
+
+        enter_autocast_nodes = [
+            node
+            for node in backend.graphs[0].graph.nodes
+            if node.target is torch.amp._enter_autocast
+        ]
+        self.assertEqual(len(enter_autocast_nodes), 1)
+        self.assertEqual(
+            enter_autocast_nodes[0].args,
+            ("openreg", None, True, None),
+        )
+
+    def test_compile_with_backend_autocast_preserves_device_type(self):
+        class DeviceTypeAutocast(torch.amp.autocast_mode.autocast):
+            pass
+
+        with mock.patch.object(torch.openreg.amp, "autocast", DeviceTypeAutocast):
+            backend = EagerAndRecordGraphs()
+
+            @torch.compile(backend=backend, fullgraph=True)
+            def fn(x):
+                with torch.openreg.amp.autocast("cpu"):
+                    return x + 1
+
+            x = torch.randn(4, device="openreg")
+            self.assertEqual(fn(x), x + 1)
+
+        enter_autocast_nodes = [
+            node
+            for node in backend.graphs[0].graph.nodes
+            if node.target is torch.amp._enter_autocast
+        ]
+        self.assertEqual(len(enter_autocast_nodes), 1)
+        self.assertEqual(
+            enter_autocast_nodes[0].args,
+            ("cpu", None, True, None),
         )
 
     def test_compile_with_autocast(self):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
@@ -3,7 +3,7 @@
 import torch
 import torch._dynamo
 from torch._dynamo.test_case import run_tests, TestCase
-from torch._dynamo.testing import CompileCounterWithBackend
+from torch._dynamo.testing import CompileCounterWithBackend, EagerAndRecordGraphs
 
 
 class TestBackendRegistration(TestCase):
@@ -175,6 +175,30 @@ class TestGraphBreaks(TestCase):
 
 
 class TestAutocast(TestCase):
+    def test_compile_with_backend_autocast(self):
+        backend = EagerAndRecordGraphs()
+
+        @torch.compile(backend=backend, fullgraph=True)
+        def fn(x, y):
+            with torch.openreg.amp.autocast():
+                return torch.mm(x, y)
+
+        x = torch.randn(2, 3, device="openreg")
+        y = torch.randn(3, 3, device="openreg")
+        result = fn(x, y)
+        self.assertEqual(result.dtype, torch.float16)
+
+        enter_autocast_nodes = [
+            node
+            for node in backend.graphs[0].graph.nodes
+            if node.target is torch.amp._enter_autocast
+        ]
+        self.assertEqual(len(enter_autocast_nodes), 1)
+        self.assertEqual(
+            enter_autocast_nodes[0].args,
+            ("openreg", torch.float16, True, True),
+        )
+
     def test_compile_with_autocast(self):
         @torch.compile(backend="openreg")
         def fn(x, y):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py
@@ -228,6 +228,130 @@ class TestAutocast(TestCase):
             ("openreg", None, True, None),
         )
 
+    def test_compile_with_backend_autocast_wrapper_defaults(self):
+        class WrapperDefaultsAutocast(torch.amp.autocast_mode.autocast):
+            def __init__(
+                self,
+                dtype=torch.bfloat16,
+                enabled=False,
+                cache_enabled=None,
+            ):
+                super().__init__(
+                    "openreg",
+                    dtype=dtype,
+                    enabled=enabled,
+                    cache_enabled=cache_enabled,
+                )
+
+        with mock.patch.object(torch.openreg.amp, "autocast", WrapperDefaultsAutocast):
+            backend = EagerAndRecordGraphs()
+
+            def fn(x):
+                with torch.openreg.amp.autocast():
+                    return (
+                        x + 1,
+                        torch.is_autocast_enabled("openreg"),
+                        torch.get_autocast_dtype("openreg"),
+                    )
+
+            x = torch.randn(4, device="openreg")
+            expected = fn(x)
+            actual = torch.compile(backend=backend, fullgraph=True)(fn)(x)
+            self.assertEqual(actual, expected)
+
+        enter_autocast_nodes = [
+            node
+            for node in backend.graphs[0].graph.nodes
+            if node.target is torch.amp._enter_autocast
+        ]
+        self.assertEqual(len(enter_autocast_nodes), 1)
+        self.assertEqual(
+            enter_autocast_nodes[0].args,
+            (
+                "openreg",
+                torch.bfloat16,
+                False,
+                None,
+            ),
+        )
+
+    def test_compile_with_backend_autocast_registry_guard(self):
+        class RegisteredAutocast(torch.amp.autocast_mode.autocast):
+            def __init__(self):
+                super().__init__("openreg")
+
+        class ReplacementAutocast(torch.amp.autocast_mode.autocast):
+            def __init__(self):
+                super().__init__("openreg")
+
+        autocast = RegisteredAutocast
+
+        def fn(x):
+            with autocast():
+                return x + 1
+
+        backend = EagerAndRecordGraphs()
+        optimized_fn = torch.compile(fn, backend=backend)
+        x = torch.randn(4, device="openreg")
+        with mock.patch.object(torch.openreg.amp, "autocast", RegisteredAutocast):
+            self.assertEqual(optimized_fn(x), x + 1)
+        with mock.patch.object(torch.openreg.amp, "autocast", ReplacementAutocast):
+            self.assertEqual(optimized_fn(x), x + 1)
+        self.assertEqual(len(backend.graphs), 2)
+
+    def test_compile_with_backend_autocast_kwargs(self):
+        class KwargsAutocast(torch.amp.autocast_mode.autocast):
+            def __init__(self, **kwargs):
+                super().__init__("openreg", **kwargs)
+
+        with mock.patch.object(torch.openreg.amp, "autocast", KwargsAutocast):
+            backend = EagerAndRecordGraphs()
+
+            @torch.compile(backend=backend, fullgraph=True)
+            def fn(x):
+                with torch.openreg.amp.autocast(
+                    dtype=torch.bfloat16, enabled=True, cache_enabled=False
+                ):
+                    return x + 1
+
+            x = torch.randn(4, device="openreg")
+            self.assertEqual(fn(x), x + 1)
+
+            disabled_backend = EagerAndRecordGraphs()
+
+            @torch.compile(backend=disabled_backend, fullgraph=True)
+            def disabled_fn(x):
+                with torch.openreg.amp.autocast(dtype=torch.bfloat16, enabled=False):
+                    return x + 1
+
+            self.assertEqual(disabled_fn(x), x + 1)
+
+        enter_autocast_nodes = [
+            node
+            for node in backend.graphs[0].graph.nodes
+            if node.target is torch.amp._enter_autocast
+        ]
+        self.assertEqual(len(enter_autocast_nodes), 1)
+        self.assertEqual(
+            enter_autocast_nodes[0].args,
+            ("openreg", torch.bfloat16, True, False),
+        )
+        disabled_enter_autocast_nodes = [
+            node
+            for node in disabled_backend.graphs[0].graph.nodes
+            if node.target is torch.amp._enter_autocast
+        ]
+        self.assertEqual(len(disabled_enter_autocast_nodes), 1)
+        self.assertEqual(
+            disabled_enter_autocast_nodes[0].args,
+            (
+                "openreg",
+                torch.bfloat16,
+                False,
+                None,
+            ),
+        )
+
     def test_compile_with_backend_autocast_preserves_device_type(self):
         class DeviceTypeAutocast(torch.amp.autocast_mode.autocast):
             pass
@@ -251,7 +375,12 @@ class TestAutocast(TestCase):
         self.assertEqual(len(enter_autocast_nodes), 1)
         self.assertEqual(
             enter_autocast_nodes[0].args,
-            ("cpu", None, True, None),
+            (
+                "cpu",
+                None,
+                True,
+                None,
+            ),
         )
 
     def test_compile_with_autocast(self):

--- a/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/amp/__init__.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/torch_openreg/openreg/amp/__init__.py
@@ -1,6 +1,13 @@
 import torch
 
 
+class autocast(torch.amp.autocast_mode.autocast):
+    def __init__(self, enabled=True, dtype=torch.float16, cache_enabled=True):
+        super().__init__(
+            "openreg", dtype=dtype, enabled=enabled, cache_enabled=cache_enabled
+        )
+
+
 # LITERALINCLUDE START: AMP GET_SUPPORTED_DTYPE
 def get_amp_supported_dtype():
     return [torch.float16, torch.bfloat16]

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -114,23 +114,6 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
             self.assertFalse(torch_variables._is_privateuse1_autocast(object))
             get_privateuse1_autocast.assert_not_called()
 
-    def test_privateuse1_autocast_preserves_device_type(self):
-        from torch._dynamo.variables.ctx_manager import AutocastModeVariable
-
-        class DeviceTypeAutocast(torch.amp.autocast_mode.autocast):
-            pass
-
-        variable = AutocastModeVariable.create(DeviceTypeAutocast, ["cpu"], {})
-        self.assertEqual(
-            variable.target_values,
-            [
-                "cpu",
-                None,
-                True,
-                None,
-            ],
-        )
-
     def test_no_grad(self):
         def fn1(a, b):
             x = a + 1

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 from collections import defaultdict
 from contextlib import contextmanager
+from unittest import mock
 
 import torch
 import torch._dynamo.test_case
@@ -90,6 +91,62 @@ def customized_ctx_manager_with_graph_break(mode):
 
 
 class CtxManagerTests(torch._dynamo.test_case.TestCase):
+    def test_privateuse1_autocast_class_match(self):
+        from torch._dynamo.variables import torch as torch_variables
+
+        base = torch.amp.autocast_mode.autocast
+        registered = type("BackendAutocast", (base,), {"__module__": __name__})
+        duplicate = type("BackendAutocast", (base,), {"__module__": __name__})
+        sibling = type("SiblingAutocast", (base,), {"__module__": __name__})
+
+        with mock.patch.object(
+            torch_variables,
+            "_get_privateuse1_autocast",
+            return_value=registered,
+        ):
+            self.assertTrue(torch_variables._is_privateuse1_autocast(registered))
+            self.assertTrue(torch_variables._is_privateuse1_autocast(duplicate))
+            self.assertFalse(torch_variables._is_privateuse1_autocast(sibling))
+            self.assertFalse(
+                torch_variables._is_privateuse1_autocast(
+                    torch.amp.autocast_mode._UnmanagedAutocast
+                )
+            )
+
+    def test_privateuse1_autocast_argument_binding(self):
+        from torch._dynamo.variables import torch as torch_variables
+        from torch._dynamo.variables.ctx_manager import AutocastModeVariable
+
+        class ReorderedAutocast(torch.amp.autocast_mode.autocast):
+            def __init__(
+                self,
+                enabled=True,
+                dtype=torch.float16,
+                cache_enabled=True,
+            ):
+                super().__init__(
+                    torch._C._get_privateuse1_backend_name(),
+                    dtype=dtype,
+                    enabled=enabled,
+                    cache_enabled=cache_enabled,
+                )
+
+        with mock.patch.object(
+            torch_variables,
+            "_get_privateuse1_autocast",
+            return_value=ReorderedAutocast,
+        ):
+            variable = AutocastModeVariable.create(ReorderedAutocast, [False], {})
+        self.assertEqual(
+            variable.target_values,
+            [
+                torch._C._get_privateuse1_backend_name(),
+                torch.float16,
+                False,
+                True,
+            ],
+        )
+
     def test_no_grad(self):
         def fn1(a, b):
             x = a + 1

--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -96,54 +96,38 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
 
         base = torch.amp.autocast_mode.autocast
         registered = type("BackendAutocast", (base,), {"__module__": __name__})
-        duplicate = type("BackendAutocast", (base,), {"__module__": __name__})
         sibling = type("SiblingAutocast", (base,), {"__module__": __name__})
 
         with mock.patch.object(
             torch_variables,
             "_get_privateuse1_autocast",
             return_value=registered,
-        ):
+        ) as get_privateuse1_autocast:
             self.assertTrue(torch_variables._is_privateuse1_autocast(registered))
-            self.assertTrue(torch_variables._is_privateuse1_autocast(duplicate))
             self.assertFalse(torch_variables._is_privateuse1_autocast(sibling))
             self.assertFalse(
                 torch_variables._is_privateuse1_autocast(
                     torch.amp.autocast_mode._UnmanagedAutocast
                 )
             )
+            get_privateuse1_autocast.reset_mock()
+            self.assertFalse(torch_variables._is_privateuse1_autocast(object))
+            get_privateuse1_autocast.assert_not_called()
 
-    def test_privateuse1_autocast_argument_binding(self):
-        from torch._dynamo.variables import torch as torch_variables
+    def test_privateuse1_autocast_preserves_device_type(self):
         from torch._dynamo.variables.ctx_manager import AutocastModeVariable
 
-        class ReorderedAutocast(torch.amp.autocast_mode.autocast):
-            def __init__(
-                self,
-                enabled=True,
-                dtype=torch.float16,
-                cache_enabled=True,
-            ):
-                super().__init__(
-                    torch._C._get_privateuse1_backend_name(),
-                    dtype=dtype,
-                    enabled=enabled,
-                    cache_enabled=cache_enabled,
-                )
+        class DeviceTypeAutocast(torch.amp.autocast_mode.autocast):
+            pass
 
-        with mock.patch.object(
-            torch_variables,
-            "_get_privateuse1_autocast",
-            return_value=ReorderedAutocast,
-        ):
-            variable = AutocastModeVariable.create(ReorderedAutocast, [False], {})
+        variable = AutocastModeVariable.create(DeviceTypeAutocast, ["cpu"], {})
         self.assertEqual(
             variable.target_values,
             [
-                torch._C._get_privateuse1_backend_name(),
-                torch.float16,
-                False,
+                "cpu",
+                None,
                 True,
+                None,
             ],
         )
 

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1080,11 +1080,7 @@ class AutocastModeVariable(ContextWrappingVariable):
         args: Sequence[Any],
         kwargs: dict[str, Any],
     ) -> "AutocastModeVariable":
-        if func not in [
-            torch.amp.autocast_mode.autocast,
-            torch.cuda.amp.autocast,
-            torch.cpu.amp.autocast,
-        ] and not (
+        if not (
             isinstance(func, type)
             and issubclass(func, torch.amp.autocast_mode.autocast)
         ):
@@ -1098,7 +1094,12 @@ class AutocastModeVariable(ContextWrappingVariable):
         target_values = []
         kwargs.clear()
 
-        for key in ["device_type", "dtype", "enabled", "cache_enabled"]:
+        for key, default in [
+            ("device_type", None),
+            ("dtype", None),
+            ("enabled", True),
+            ("cache_enabled", None),
+        ]:
             if key == "device_type" and func in [
                 torch.cuda.amp.autocast,
                 torch.cpu.amp.autocast,
@@ -1108,7 +1109,7 @@ class AutocastModeVariable(ContextWrappingVariable):
             elif key == "device_type" and key not in bound_args.arguments:
                 arg = torch._C._get_privateuse1_backend_name()
             else:
-                arg = bound_args.arguments[key]
+                arg = bound_args.arguments.get(key, default)
             if isinstance(arg, VariableTracker):
                 target_values.append(arg.as_python_constant())
             else:

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1080,17 +1080,13 @@ class AutocastModeVariable(ContextWrappingVariable):
         args: Sequence[Any],
         kwargs: dict[str, Any],
     ) -> "AutocastModeVariable":
-        from .torch import _is_privateuse1_autocast
-
-        is_privateuse1_autocast = _is_privateuse1_autocast(func)
-        if (
-            func
-            not in [
-                torch.amp.autocast_mode.autocast,
-                torch.cuda.amp.autocast,
-                torch.cpu.amp.autocast,
-            ]
-            and not is_privateuse1_autocast
+        if func not in [
+            torch.amp.autocast_mode.autocast,
+            torch.cuda.amp.autocast,
+            torch.cpu.amp.autocast,
+        ] and not (
+            isinstance(func, type)
+            and issubclass(func, torch.amp.autocast_mode.autocast)
         ):
             raise AssertionError(f"unexpected autocast function: {func}")
         # device_type : str,
@@ -1109,7 +1105,7 @@ class AutocastModeVariable(ContextWrappingVariable):
             ]:
                 # pyrefly: ignore [unnecessary-comparison]
                 arg = "cuda" if func is torch.cuda.amp.autocast else "cpu"
-            elif key == "device_type" and is_privateuse1_autocast:
+            elif key == "device_type" and key not in bound_args.arguments:
                 arg = torch._C._get_privateuse1_backend_name()
             else:
                 arg = bound_args.arguments[key]

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1080,11 +1080,18 @@ class AutocastModeVariable(ContextWrappingVariable):
         args: Sequence[Any],
         kwargs: dict[str, Any],
     ) -> "AutocastModeVariable":
-        if func not in [
-            torch.amp.autocast_mode.autocast,
-            torch.cuda.amp.autocast,
-            torch.cpu.amp.autocast,
-        ]:
+        from .torch import _is_privateuse1_autocast
+
+        is_privateuse1_autocast = _is_privateuse1_autocast(func)
+        if (
+            func
+            not in [
+                torch.amp.autocast_mode.autocast,
+                torch.cuda.amp.autocast,
+                torch.cpu.amp.autocast,
+            ]
+            and not is_privateuse1_autocast
+        ):
             raise AssertionError(f"unexpected autocast function: {func}")
         # device_type : str,
         # dtype : Optional[_dtype] = None,
@@ -1102,6 +1109,8 @@ class AutocastModeVariable(ContextWrappingVariable):
             ]:
                 # pyrefly: ignore [unnecessary-comparison]
                 arg = "cuda" if func is torch.cuda.amp.autocast else "cpu"
+            elif key == "device_type" and is_privateuse1_autocast:
+                arg = torch._C._get_privateuse1_backend_name()
             else:
                 arg = bound_args.arguments[key]
             if isinstance(arg, VariableTracker):

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -1080,11 +1080,40 @@ class AutocastModeVariable(ContextWrappingVariable):
         args: Sequence[Any],
         kwargs: dict[str, Any],
     ) -> "AutocastModeVariable":
+        from .torch import _is_privateuse1_autocast
+
         if not (
             isinstance(func, type)
             and issubclass(func, torch.amp.autocast_mode.autocast)
         ):
             raise AssertionError(f"unexpected autocast function: {func}")
+        if func not in [
+            torch.amp.autocast_mode.autocast,
+            torch.cuda.amp.autocast,
+            torch.cpu.amp.autocast,
+        ] and _is_privateuse1_autocast(func):
+            signature = inspect.signature(func)
+            bound_args = signature.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+            arguments = dict(bound_args.arguments)
+            for name, parameter in signature.parameters.items():
+                if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+                    arguments.update(arguments.pop(name))
+
+            arguments.setdefault(
+                "device_type", torch._C._get_privateuse1_backend_name()
+            )
+            arguments.setdefault("dtype", None)
+            arguments.setdefault("enabled", True)
+            arguments.setdefault("cache_enabled", None)
+            target_values = []
+            for key in ["device_type", "dtype", "enabled", "cache_enabled"]:
+                arg = arguments[key]
+                if isinstance(arg, VariableTracker):
+                    target_values.append(arg.as_python_constant())
+                else:
+                    target_values.append(arg)
+            return AutocastModeVariable(target_values, initial_values=None)
         # device_type : str,
         # dtype : Optional[_dtype] = None,
         # enabled : bool = True,
@@ -1092,30 +1121,22 @@ class AutocastModeVariable(ContextWrappingVariable):
         bound_args = inspect.signature(func).bind(*args, **kwargs)
         bound_args.apply_defaults()
         target_values = []
-        kwargs.clear()
 
-        for key, default in [
-            ("device_type", None),
-            ("dtype", None),
-            ("enabled", True),
-            ("cache_enabled", None),
-        ]:
+        for key in ["device_type", "dtype", "enabled", "cache_enabled"]:
             if key == "device_type" and func in [
                 torch.cuda.amp.autocast,
                 torch.cpu.amp.autocast,
             ]:
                 # pyrefly: ignore [unnecessary-comparison]
                 arg = "cuda" if func is torch.cuda.amp.autocast else "cpu"
-            elif key == "device_type" and key not in bound_args.arguments:
-                arg = torch._C._get_privateuse1_backend_name()
             else:
-                arg = bound_args.arguments.get(key, default)
+                arg = bound_args.arguments[key]
             if isinstance(arg, VariableTracker):
                 target_values.append(arg.as_python_constant())
             else:
                 target_values.append(arg)
 
-        var = AutocastModeVariable(target_values, initial_values=None, **kwargs)
+        var = AutocastModeVariable(target_values, initial_values=None)
         return var
 
     def __init__(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -199,6 +199,28 @@ supported_ctx_manager_classes = dict.fromkeys(
 )
 
 
+def _get_privateuse1_autocast() -> Any:
+    device_type = torch._C._get_privateuse1_backend_name()
+    device_module = getattr(torch, device_type, None)
+    amp_module = getattr(device_module, "amp", None)
+    return getattr(amp_module, "autocast", None)
+
+
+def _is_privateuse1_autocast(value: Any) -> bool:
+    privateuse1_autocast = _get_privateuse1_autocast()
+    if value is privateuse1_autocast:
+        return privateuse1_autocast is not None
+    if not isinstance(value, type) or not isinstance(privateuse1_autocast, type):
+        return False
+    try:
+        return (
+            inspect.getfile(value) == inspect.getfile(privateuse1_autocast)
+            and value.__qualname__ == privateuse1_autocast.__qualname__
+        )
+    except (TypeError, OSError):
+        return False
+
+
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(
     [
         torch._shape_as_tensor,
@@ -691,7 +713,10 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             callable(value)
             and (
                 hashable(value)  # accesses value.__hash__()
-                and value in supported_ctx_manager_classes
+                and (
+                    value in supported_ctx_manager_classes
+                    or _is_privateuse1_autocast(value)
+                )
             )
         )
 
@@ -813,7 +838,7 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             torch.amp.autocast_mode.autocast,
             torch.cuda.amp.autocast,
             torch.cpu.amp.autocast,
-        ):
+        ) or _is_privateuse1_autocast(self.value):
             # pyrefly: ignore [bad-argument-type]
             return AutocastModeVariable.create(self.value, args, kwargs)
         elif self.value in (

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -207,18 +207,11 @@ def _get_privateuse1_autocast() -> Any:
 
 
 def _is_privateuse1_autocast(value: Any) -> bool:
-    privateuse1_autocast = _get_privateuse1_autocast()
-    if value is privateuse1_autocast:
-        return privateuse1_autocast is not None
-    if not isinstance(value, type) or not isinstance(privateuse1_autocast, type):
+    if not isinstance(value, type) or not issubclass(
+        value, torch.amp.autocast_mode.autocast
+    ):
         return False
-    try:
-        return (
-            inspect.getfile(value) == inspect.getfile(privateuse1_autocast)
-            and value.__qualname__ == privateuse1_autocast.__qualname__
-        )
-    except (TypeError, OSError):
-        return False
+    return value is _get_privateuse1_autocast()
 
 
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -214,6 +214,20 @@ def _is_privateuse1_autocast(value: Any) -> bool:
     return value is _get_privateuse1_autocast()
 
 
+def _install_privateuse1_autocast_guards() -> None:
+    torch_source = ImportSource("torch")
+    backend_name_source = CallFunctionNoArgsSource(
+        AttrSource(AttrSource(torch_source, "_C"), "_get_privateuse1_backend_name")
+    )
+    install_guard(backend_name_source.make_guard(GuardBuilder.EQUALS_MATCH))
+
+    device_type = torch._C._get_privateuse1_backend_name()
+    autocast_source = AttrSource(
+        AttrSource(AttrSource(torch_source, device_type), "amp"), "autocast"
+    )
+    install_guard(autocast_source.make_guard(GuardBuilder.CLASS_MATCH))
+
+
 REWRITE_OPS_TO_TENSOR_SIZE_METHOD = dict.fromkeys(
     [
         torch._shape_as_tensor,
@@ -690,6 +704,11 @@ class BaseTorchVariable(VariableTracker):
 
 class TorchCtxManagerClassVariable(BaseTorchVariable):
     """Points to a context manager class in torch.* that dynamo has implementations"""
+
+    def __init__(self, value: Any, **kwargs: Any) -> None:
+        super().__init__(value, **kwargs)
+        if _is_privateuse1_autocast(value):
+            _install_privateuse1_autocast_guards()
 
     def __repr__(self) -> str:
         return f"TorchCtxManagerClassVariable({self.value})"


### PR DESCRIPTION
  Dynamo recognizes the built-in autocast context managers, but an autocast
  subclass exposed by a registered PrivateUse1 device module can otherwise fall
  through to the user-defined class path. This prevents the context manager from
  being represented as an AutocastModeVariable during tracing.

  This change resolves `torch.<registered_backend>.amp.autocast` through the
  registered device module and routes the exact registered class through
  `TorchCtxManagerClassVariable`.

  The lookup first rejects ordinary functions and unrelated classes before
  accessing the registered device module. Class matching uses identity only;
  there is no source-file or qualified-name fallback.

  When reconstructing the context:

  - `device_type` is supplied from the registered backend only when the wrapper
    signature does not expose it.
  - An explicitly supplied `device_type` is preserved.
  - Missing `dtype`, `enabled`, and `cache_enabled` values use the base autocast
    defaults instead of raising an internal `KeyError`.

  The open registration tests exercise the actual `torch.compile(fullgraph=True)`
  routing path. Reduced-signature behavior is covered by a temporary registered
  test class, leaving the existing open registration wrapper API unchanged.

  This does not add a `DeviceInterface` slot, backend-specific metadata, or a new
  trace rule.

  Test Plan:

  ```bash
  python test/dynamo/test_ctx_manager.py \
    CtxManagerTests.test_autocast_cpu \
    CtxManagerTests.test_privateuse1_autocast_class_match

  python test/cpp_extensions/open_registration_extension/torch_openreg/tests/test_compile.py \
    TestAutocast

  spin quicklint -a

  Results:

  - Targeted Dynamo tests: 2 passed
  - Open registration TestAutocast: 4 passed
  - Fullgraph autocast execution on a physical PrivateUse1 device: passed
  - Inductor execution with triton_experimental on a physical PrivateUse1
    device: passed

  - spin quicklint -a: passed

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98