### PR TITLE
Instantiate the flash attention kernels only for masks that can reach them

### DIFF
--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -1131,20 +1131,25 @@ void cpu_flash_attention_backward(
   });
 }
 
-#define AT_DISPATCH_MASK_TYPES(TYPE, NAME, ...)            \
-  AT_DISPATCH_SWITCH(                                      \
-      TYPE,                                                \
-      NAME,                                                \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
-          at::ScalarType::Bool, mask_t, __VA_ARGS__)       \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
-          at::ScalarType::Float, mask_t, __VA_ARGS__)      \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
-          at::ScalarType::Double, mask_t, __VA_ARGS__)     \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
-          at::ScalarType::BFloat16, mask_t, __VA_ARGS__)   \
-      AT_PRIVATE_CASE_TYPE_USING_HINT(                     \
-          at::ScalarType::Half, mask_t, __VA_ARGS__))
+// Only Float or scalar_t masks can reach here: attention.cpp requires one of
+// the two before dispatching, and bool masks are pre-widened to scalar_t by
+// convert_boolean_attn_mask.
+#define AT_DISPATCH_MASK_TYPES(TYPE, NAME, ...)                              \
+  [&] {                                                                      \
+    if ((TYPE) == at::ScalarType::Float) {                                   \
+      using mask_t = float;                                                  \
+      return (__VA_ARGS__)();                                                \
+    }                                                                        \
+    TORCH_CHECK(                                                             \
+        (TYPE) == at::CppTypeToScalarType<scalar_t>::value,                  \
+        NAME,                                                                \
+        ": expected the mask to be Float or ",                               \
+        at::CppTypeToScalarType<scalar_t>::value,                            \
+        ", got ",                                                            \
+        (TYPE));                                                             \
+    using mask_t = scalar_t;                                                 \
+    return (__VA_ARGS__)();                                                  \
+  }()
 
 #define FLASH_ATTENTION_KERNEL(FNAME, PACK, TYPE1, TYPE2, SEQ1, SEQ2, ...)   \
   if (PACK) {                                                      \

--- a/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
+++ b/aten/src/ATen/native/cpu/FlashAttentionKernel.cpp
@@ -1140,7 +1140,7 @@ void cpu_flash_attention_backward(
       using mask_t = float;                                                  \
       return (__VA_ARGS__)();                                                \
     }                                                                        \
-    TORCH_CHECK(                                                             \
+    TORCH_CHECK_VALUE(                                                       \
         (TYPE) == at::CppTypeToScalarType<scalar_t>::value,                  \
         NAME,                                                                \
         ": expected the mask to be Float or ",                               \


### PR DESCRIPTION
AT_DISPATCH_MASK_TYPES dispatched over Bool/Float/Double/BFloat16/Half, so
each of the 4 scalar_t types instantiated this 400-line kernel 5 times over
even though only 2 (mask_t == Float or mask_t == scalar_t) can ever be
reached -- attention.cpp requires the mask to be Float or the query's own
dtype before dispatching, and a bool mask is already widened to the query
dtype by convert_boolean_attn_mask. Replace the 5-way switch with a 2-way
branch plus a TORCH_CHECK stating the invariant, so a change to the caller's
validation surfaces here instead of silently picking a wrong branch.

FlashAttentionKernel.cpp.AVX2 is the slowest object file in the tree at 250s;
this drops 13 of its 20 dead (scalar_t, mask_t) instantiations.

This change was authored with AI assistance (Claude Code).



cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01