### PR TITLE
[Dynamo] route PrivateUse1 tensor classes in graph

### DIFF
--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -1217,6 +1217,49 @@ class TestUserDefinedSetitem(TestCase):
 
 
 class TestObjectConstruction(TestCase):
+    def test_privateuse1_tensor_types_in_graph_classes(self):
+        from torch._dynamo.variables.user_defined import UserDefinedClassVariable
+
+        class PrivateUse1FloatTensor:
+            pass
+
+        class UnregisteredDoubleTensor:
+            pass
+
+        privateuse1_module = types.SimpleNamespace(
+            FloatTensor=PrivateUse1FloatTensor,
+            DoubleTensor=UnregisteredDoubleTensor,
+        )
+        UserDefinedClassVariable._in_graph_classes.cache_clear()
+        self.addCleanup(UserDefinedClassVariable._in_graph_classes.cache_clear)
+
+        with (
+            unittest.mock.patch.object(
+                torch._C,
+                "_get_privateuse1_backend_name",
+                return_value="stub_privateuse1",
+            ),
+            unittest.mock.patch.object(
+                torch,
+                "stub_privateuse1",
+                privateuse1_module,
+                create=True,
+            ),
+            unittest.mock.patch.object(
+                torch,
+                "_tensor_classes",
+                torch._tensor_classes | {PrivateUse1FloatTensor},
+            ),
+        ):
+            self.assertIn(
+                PrivateUse1FloatTensor,
+                UserDefinedClassVariable._in_graph_classes(),
+            )
+            self.assertNotIn(
+                UnregisteredDoubleTensor,
+                UserDefinedClassVariable._in_graph_classes(),
+            )
+
     @make_dynamo_test
     def test_object_call_identity(self):
         a = object()

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -10,7 +10,11 @@ import torch
 import torch._dynamo.testing as dynamo_testing
 from torch._dynamo.exc import Unsupported
 from torch._dynamo.test_case import run_tests, TestCase
-from torch.testing._internal.common_utils import make_dynamo_test
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    make_dynamo_test,
+    parametrize,
+)
 
 
 class SlotsOnly:
@@ -1217,23 +1221,34 @@ class TestUserDefinedSetitem(TestCase):
 
 
 class TestObjectConstruction(TestCase):
-    def test_privateuse1_tensor_constructor_routed_in_graph(self):
+    @parametrize(
+        "tensor_type_name,dtype",
+        [
+            ("FloatTensor", torch.float32),
+            ("BoolTensor", torch.bool),
+        ],
+    )
+    def test_privateuse1_tensor_constructor_routed_in_graph(
+        self, tensor_type_name, dtype
+    ):
         from torch._dynamo.variables.user_defined import UserDefinedClassVariable
 
         class TensorTypeMeta(type):
             def __call__(cls, value):
-                return torch.as_tensor(value, dtype=torch.float32)
+                return torch.as_tensor(value, dtype=cls.dtype)
 
-        class PrivateUse1FloatTensor(metaclass=TensorTypeMeta):
-            pass
+        PrivateUse1Tensor = TensorTypeMeta(
+            f"PrivateUse1{tensor_type_name}", (), {"dtype": dtype}
+        )
+        UnregisteredTensor = TensorTypeMeta(tensor_type_name, (), {"dtype": dtype})
 
         privateuse1_module = types.SimpleNamespace(
-            FloatTensor=PrivateUse1FloatTensor,
+            **{tensor_type_name: PrivateUse1Tensor},
         )
 
         # The static class cache may be populated before a backend is registered.
         self.assertNotIn(
-            PrivateUse1FloatTensor,
+            PrivateUse1Tensor,
             UserDefinedClassVariable._in_graph_classes(),
         )
 
@@ -1249,20 +1264,20 @@ class TestObjectConstruction(TestCase):
                 privateuse1_module,
                 create=True,
             ),
-            unittest.mock.patch.object(
-                torch,
-                "_tensor_classes",
-                torch._tensor_classes | {PrivateUse1FloatTensor},
-            ),
         ):
+            self.assertFalse(
+                UserDefinedClassVariable._is_privateuse1_tensor_class(
+                    UnregisteredTensor
+                )
+            )
             backend = dynamo_testing.EagerAndRecordGraphs()
 
             @torch.compile(backend=backend, fullgraph=True)
             def fn(x, y):
-                return PrivateUse1FloatTensor([x, y])
+                return PrivateUse1Tensor([x, y])
 
-            x = torch.randn(())
-            y = torch.randn(())
+            x = torch.tensor(1, dtype=dtype)
+            y = torch.tensor(0, dtype=dtype)
             self.assertEqual(fn(x, y), torch.stack([x, y]))
             self.assertEqual(len(backend.graphs), 1)
             self.assertTrue(
@@ -1273,7 +1288,7 @@ class TestObjectConstruction(TestCase):
             )
             self.assertTrue(
                 any(
-                    node.op == "call_function" and node.target is PrivateUse1FloatTensor
+                    node.op == "call_function" and node.target is PrivateUse1Tensor
                     for node in backend.graphs[0].graph.nodes
                 )
             )
@@ -1614,6 +1629,9 @@ class TestSimpleNamespace(TestCase):
         ns_compiled = types.SimpleNamespace(name="cfg", scale=2)
         self.assertEqual(fn(ns_eager, x), opt_fn(ns_compiled, x))
         self.assertEqual(vars(ns_eager), vars(ns_compiled))
+
+
+instantiate_parametrized_tests(TestObjectConstruction)
 
 
 if __name__ == "__main__":

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -1217,21 +1217,25 @@ class TestUserDefinedSetitem(TestCase):
 
 
 class TestObjectConstruction(TestCase):
-    def test_privateuse1_tensor_types_in_graph_classes(self):
+    def test_privateuse1_tensor_constructor_routed_in_graph(self):
         from torch._dynamo.variables.user_defined import UserDefinedClassVariable
 
-        class PrivateUse1FloatTensor:
-            pass
+        class TensorTypeMeta(type):
+            def __call__(cls, value):
+                return torch.as_tensor(value, dtype=torch.float32)
 
-        class UnregisteredDoubleTensor:
+        class PrivateUse1FloatTensor(metaclass=TensorTypeMeta):
             pass
 
         privateuse1_module = types.SimpleNamespace(
             FloatTensor=PrivateUse1FloatTensor,
-            DoubleTensor=UnregisteredDoubleTensor,
         )
-        UserDefinedClassVariable._in_graph_classes.cache_clear()
-        self.addCleanup(UserDefinedClassVariable._in_graph_classes.cache_clear)
+
+        # The static class cache may be populated before a backend is registered.
+        self.assertNotIn(
+            PrivateUse1FloatTensor,
+            UserDefinedClassVariable._in_graph_classes(),
+        )
 
         with (
             unittest.mock.patch.object(
@@ -1251,13 +1255,20 @@ class TestObjectConstruction(TestCase):
                 torch._tensor_classes | {PrivateUse1FloatTensor},
             ),
         ):
-            self.assertIn(
-                PrivateUse1FloatTensor,
-                UserDefinedClassVariable._in_graph_classes(),
-            )
-            self.assertNotIn(
-                UnregisteredDoubleTensor,
-                UserDefinedClassVariable._in_graph_classes(),
+            backend = dynamo_testing.EagerAndRecordGraphs()
+
+            @torch.compile(backend=backend, fullgraph=True)
+            def fn(x):
+                return PrivateUse1FloatTensor(x)
+
+            x = torch.randn(3)
+            self.assertEqual(fn(x), x)
+            self.assertEqual(len(backend.graphs), 1)
+            self.assertTrue(
+                any(
+                    node.op == "call_function" and node.target is PrivateUse1FloatTensor
+                    for node in backend.graphs[0].graph.nodes
+                )
             )
 
     @make_dynamo_test

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -1258,12 +1258,19 @@ class TestObjectConstruction(TestCase):
             backend = dynamo_testing.EagerAndRecordGraphs()
 
             @torch.compile(backend=backend, fullgraph=True)
-            def fn(x):
-                return PrivateUse1FloatTensor(x)
+            def fn(x, y):
+                return PrivateUse1FloatTensor([x, y])
 
-            x = torch.randn(3)
-            self.assertEqual(fn(x), x)
+            x = torch.randn(())
+            y = torch.randn(())
+            self.assertEqual(fn(x, y), torch.stack([x, y]))
             self.assertEqual(len(backend.graphs), 1)
+            self.assertTrue(
+                any(
+                    node.op == "call_function" and node.target is torch.stack
+                    for node in backend.graphs[0].graph.nodes
+                )
+            )
             self.assertTrue(
                 any(
                     node.op == "call_function" and node.target is PrivateUse1FloatTensor

--- a/test/dynamo/test_user_defined_object.py
+++ b/test/dynamo/test_user_defined_object.py
@@ -1221,6 +1221,35 @@ class TestUserDefinedSetitem(TestCase):
 
 
 class TestObjectConstruction(TestCase):
+    def test_privateuse1_tensor_class_without_tensor_classes_registration(self):
+        from torch._dynamo.variables.user_defined import UserDefinedClassVariable
+
+        class FooBackFloatTensor:
+            def __new__(cls, value):
+                return torch.as_tensor(value, dtype=torch.float32)
+
+        privateuse1_module = types.SimpleNamespace(FloatTensor=FooBackFloatTensor)
+        self.assertNotIn(FooBackFloatTensor, torch._tensor_classes)
+
+        with (
+            unittest.mock.patch.object(
+                torch._C,
+                "_get_privateuse1_backend_name",
+                return_value="fooback",
+            ),
+            unittest.mock.patch.object(
+                torch,
+                "fooback",
+                privateuse1_module,
+                create=True,
+            ),
+        ):
+            self.assertTrue(
+                UserDefinedClassVariable._is_privateuse1_tensor_class(
+                    FooBackFloatTensor
+                )
+            )
+
     @parametrize(
         "tensor_type_name,dtype",
         [

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -1569,7 +1569,10 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
             if (
                 np
-                and self.value in tensortype_to_dtype
+                and (
+                    self.value in tensortype_to_dtype
+                    or self._is_privateuse1_tensor_class(self.value)
+                )
                 and len(args) == 1
                 and isinstance(args[0], ListVariable)
                 and len(args[0].items) > 1

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -415,20 +415,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 }
             )
 
-        privateuse1_module = getattr(
-            torch, torch._C._get_privateuse1_backend_name(), None
-        )
-        if privateuse1_module is not None:
-            for tensor_type in tensortype_to_dtype:
-                privateuse1_tensor_type = getattr(
-                    privateuse1_module, tensor_type.__name__, None
-                )
-                if (
-                    isinstance(privateuse1_tensor_type, type)
-                    and privateuse1_tensor_type in torch._tensor_classes
-                ):
-                    _in_graph_class_list.add(privateuse1_tensor_type)
-
         for _, device_interface in get_registered_device_interfaces():
             stream_class = getattr(device_interface, "Stream", None)
             if isinstance(stream_class, type) and issubclass(
@@ -441,6 +427,21 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 _in_graph_class_list.add(event_class)
 
         return set(tensortype_to_dtype.keys()) | _in_graph_class_list
+
+    @staticmethod
+    def _is_privateuse1_tensor_class(value: type[object]) -> bool:
+        # PrivateUse1 tensor classes can be registered after the static class cache
+        # is populated, so resolve them at the constructor routing point.
+        if value not in torch._tensor_classes:
+            return False
+
+        privateuse1_module = getattr(
+            torch, torch._C._get_privateuse1_backend_name(), None
+        )
+        return privateuse1_module is not None and any(
+            value is getattr(privateuse1_module, tensor_type.__name__, None)
+            for tensor_type in tensortype_to_dtype
+        )
 
     @staticmethod
     @functools.cache
@@ -1559,6 +1560,7 @@ class UserDefinedClassVariable(UserDefinedVariable):
             )
         elif (
             self.value in self._in_graph_classes()
+            or self._is_privateuse1_tensor_class(self.value)
             or is_traceable_wrapper_subclass_type(self.value)
         ):
             # torch.LongTensor cannot accept a list of FakeTensors.

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -430,11 +430,6 @@ class UserDefinedClassVariable(UserDefinedVariable):
 
     @staticmethod
     def _is_privateuse1_tensor_class(value: type[object]) -> bool:
-        # PrivateUse1 tensor classes can be registered after the static class cache
-        # is populated, so resolve them at the constructor routing point.
-        if value not in torch._tensor_classes:
-            return False
-
         privateuse1_module = getattr(
             torch, torch._C._get_privateuse1_backend_name(), None
         )

--- a/torch/_dynamo/variables/user_defined.py
+++ b/torch/_dynamo/variables/user_defined.py
@@ -415,6 +415,20 @@ class UserDefinedClassVariable(UserDefinedVariable):
                 }
             )
 
+        privateuse1_module = getattr(
+            torch, torch._C._get_privateuse1_backend_name(), None
+        )
+        if privateuse1_module is not None:
+            for tensor_type in tensortype_to_dtype:
+                privateuse1_tensor_type = getattr(
+                    privateuse1_module, tensor_type.__name__, None
+                )
+                if (
+                    isinstance(privateuse1_tensor_type, type)
+                    and privateuse1_tensor_type in torch._tensor_classes
+                ):
+                    _in_graph_class_list.add(privateuse1_tensor_type)
+
         for _, device_interface in get_registered_device_interfaces():
             stream_class = getattr(device_interface, "Stream", None)
             if isinstance(stream_class, type) and issubclass(


### PR DESCRIPTION
Dynamo builds its in-graph class set from built-in tensor types and registered device Stream/Event classes. Legacy tensor constructors exposed by a renamed PrivateUse1 module are therefore routed through UserDefinedClassVariable instead of the existing tensor-constructor path.

Look up tensor type names on the renamed PrivateUse1 module and add only real types already registered in torch._tensor_classes. This keeps the routing local to the existing in-graph class construction without adding backend metadata or trace-rule handling.

Test Plan:
```
spin quicklint -a test/dynamo/test_user_defined_object.py torch/_dynamo/variables/user_defined.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98