### PR TITLE
[test][xpu] Make `test/export/test_export_opinfo.py` tests device-generic and enable testing XPU.

### DIFF
--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -11,9 +11,8 @@ import torch
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
-    onlyCUDA,
+    onlyAccelerator,
     ops,
-    skip,
     skipOps,
     xfail,
 )
@@ -22,8 +21,8 @@ from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_FBCODE,
     IS_WINDOWS,
+    parametrize,
     run_tests,
-    skipIfRocm,
     TestCase,
 )
 from torch.utils import _pytree as pytree
@@ -80,11 +79,10 @@ fake_decomposition_failures = {
 }
 
 
-def _test_export_helper(self, dtype, op):
+def _test_export_helper(self, target_device, dtype, op):
     sample_inputs_itr = op.sample_inputs("cpu", dtype, requires_grad=False)
 
     mode = FakeTensorMode(allow_non_fake_inputs=True)
-    target_device = "cuda:0"
 
     def to_fake_device(x):
         return x.to(target_device)
@@ -129,8 +127,9 @@ class TestExportOpInfo(TestCase):
     @ops(op_db, allowed_dtypes=(torch.float,))
     @skipOps(export_failures | fake_export_failures)
     @unittest.skipIf(IS_FBCODE, "tests broken with unexpected successes internally")
-    def test_fake_export(self, device, dtype, op):
-        _test_export_helper(self, dtype, op)
+    @parametrize("target_device", ["cuda:0"])
+    def test_fake_export(self, target_device, dtype, op):
+        _test_export_helper(self, target_device, dtype, op)
 
 
 instantiate_device_type_tests(TestExportOpInfo, globals(), only_for="cpu")
@@ -148,16 +147,25 @@ selected_ops = {
 selected_op_db = [op for op in op_db if op.name in selected_ops]
 
 
-class TestExportOnFakeCuda(TestCase):
-    hw_classification = HardwareClassification.CUDA
+def _get_env_by_device(device):
+    env = {}
+    device_type = torch.device(device).type
+    if device_type == "cuda":
+        env = {"CUDA_VISIBLE_DEVICES": ""}
+    # elif other device
+    return env
 
-    # In CI, this test runs on a CUDA machine with cuda build
-    # We set CUDA_VISIBLE_DEVICES="" to simulate a CPU machine with cuda build
+
+class TestExportOnFakeDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    # In CI, this test runs on a GPU machine with gpu build
+    # We set device-specific env variable to simulate a CPU machine with gpu build
     # Running this on all ops in op_db is too slow, so we only run on a selected subset
-    @onlyCUDA
+    @onlyAccelerator
     @unittest.skipIf(
         IS_WINDOWS,
-        'Subprocess with CUDA_VISIBLE_DEVICES="" imports op_db which triggers '
+        "Subprocess with simulated CPU machine imports op_db which triggers "
         "get_device_capability(); 0 devices raises Invalid device id on Windows.",
     )
     @ops(selected_op_db, allowed_dtypes=(torch.float,))
@@ -177,7 +185,7 @@ for op in ops:
 
     mode = FakeTensorMode(allow_non_fake_inputs=True)
 
-    target_device = "cuda:0"
+    target_device = "{device}"
 
     def to_fake_device(x):
         return x.to(target_device)
@@ -217,7 +225,7 @@ for op in ops:
             (
                 subprocess.check_output(
                     [sys.executable, "-c", test_script],
-                    env={"CUDA_VISIBLE_DEVICES": ""},
+                    env=_get_env_by_device(device),
                 )
             )
             .decode("ascii")
@@ -225,66 +233,66 @@ for op in ops:
         )
         self.assertEqual(r, "")
 
-    @unittest.skipIf(not torch.backends.cuda.is_built(), "requires CUDA build")
+    @onlyAccelerator
     @unittest.skipIf(
         IS_WINDOWS,
         "Failing on Windows, device_count() changes from 0 to 1 ",
     )
-    def test_preserve_original_behavior(self):
+    def test_preserve_original_behavior(self, device):
         test_script = f"""\
 import torch
 from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 
-def cuda_calls_behavior_unchanged():
+def accelerator_calls_behavior_unchanged():
     exception_count = 0
 
     try:
         cpu_x = torch.randn(2)
-        cuda_x = cpu_x.to("cuda")
+        accelerator_x = cpu_x.to("{device}")
     except Exception as e:
         exception_count += 1
 
     try:
-        torch.randn(2, device="cuda")
+        torch.randn(2, device="{device}")
     except Exception as e:
         exception_count += 1
 
     try:
-        torch.cuda.get_device_capability()
+        torch.accelerator.get_device_capability()
     except Exception as e:
         exception_count += 1
 
     try:
-        torch.cuda.set_device(1)
+        torch.accelerator.set_device_index(1)
     except Exception as e:
         exception_count += 1
 
     try:
-        torch.cuda.current_device()
+        torch.get_device_module("{device}").current_device()
     except Exception as e:
         exception_count += 1
 
-    assert torch.cuda.is_available() == False
-    assert torch.cuda.device_count() == 0
+    assert torch.accelerator.is_available() == False
+    assert torch.accelerator.device_count() == 0
     assert exception_count == 5
 
-cuda_calls_behavior_unchanged()
+accelerator_calls_behavior_unchanged()
 
 cpu_x = torch.randn(2)
 with FakeTensorMode(allow_non_fake_inputs=True) as mode:
-    cuda_x = mode.from_tensor(cpu_x)
-    cuda_x.fake_device = torch.device("cuda")
-    cuda_y = cuda_x + cuda_x
-    assert cuda_y.device.type == "cuda"
+    accelerator_x = mode.from_tensor(cpu_x)
+    accelerator_x.fake_device = torch.device("{device}")
+    accelerator_y = accelerator_x + accelerator_x
+    assert accelerator_y.device.type == torch.device("{device}").type
 
 # should fail again after exiting the fake mode, with the identical error message
-cuda_calls_behavior_unchanged()
+accelerator_calls_behavior_unchanged()
 """
         r = (
             (
                 subprocess.check_output(
                     [sys.executable, "-c", test_script],
-                    env={"CUDA_VISIBLE_DEVICES": ""},
+                    env=_get_env_by_device(device),
                 )
             )
             .decode("ascii")
@@ -293,7 +301,7 @@ cuda_calls_behavior_unchanged()
         self.assertEqual(r, "")
 
 
-instantiate_device_type_tests(TestExportOnFakeCuda, globals(), only_for="cuda")
+instantiate_device_type_tests(TestExportOnFakeDevice, globals(), only_for=("cuda",))
 
 
 if __name__ == "__main__":

--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -3,6 +3,7 @@
 # flake8: noqa
 
 import itertools
+import os
 import subprocess
 import sys
 import unittest
@@ -14,6 +15,7 @@ from torch.testing._internal.common_device_type import (
     onlyAccelerator,
     ops,
     skipOps,
+    skipXPUIf,
     xfail,
 )
 from torch.testing._internal.common_methods_invocations import op_db
@@ -21,7 +23,6 @@ from torch.testing._internal.common_utils import (
     HardwareClassification,
     IS_FBCODE,
     IS_WINDOWS,
-    parametrize,
     run_tests,
     TestCase,
 )
@@ -41,7 +42,7 @@ export_failures = {
     xfail("tensor_split"),
 }
 
-# following are failing fake export on cuda device
+# following are failing fake export on gpu device
 fake_export_failures = {
     xfail("histogram"),
     xfail("masked.amax"),
@@ -57,17 +58,38 @@ fake_export_failures = {
     xfail("masked.var"),
 }
 
-# These pass with CUDA enabled but still fail fake CUDA export on CPU-only builds.
+# following are failing fake export with no gpu device available
+fake_export_no_gpu_failures = {
+    xfail("geqrf"),
+    xfail("sparse.sampled_addmm"),
+    xfail("to_sparse"),
+    xfail("__getitem__"),
+    xfail("nn.functional.batch_norm"),
+    xfail("nn.functional.grid_sample"),
+    xfail("nn.functional.instance_norm"),
+    xfail("nn.functional.multi_margin_loss"),
+    xfail("nonzero"),
+}
+
+fake_export_failures_cuda = fake_export_failures.copy()
+fake_export_failures_xpu = fake_export_failures.copy()
+
 if not torch.backends.cuda.is_built():
-    fake_export_failures.add(xfail("geqrf"))
-    fake_export_failures.add(xfail("sparse.sampled_addmm"))
-    fake_export_failures.add(xfail("to_sparse"))
-    fake_export_failures.add(xfail("__getitem__"))
-    fake_export_failures.add(xfail("nn.functional.batch_norm"))
-    fake_export_failures.add(xfail("nn.functional.grid_sample"))
-    fake_export_failures.add(xfail("nn.functional.instance_norm"))
-    fake_export_failures.add(xfail("nn.functional.multi_margin_loss"))
-    fake_export_failures.add(xfail("nonzero"))
+    fake_export_failures_cuda |= fake_export_no_gpu_failures
+
+if not torch.xpu._is_compiled():
+    fake_export_failures_xpu |= fake_export_no_gpu_failures
+    fake_export_failures_xpu |= {
+        # https://github.com/intel/torch-xpu-ops/issues/5256
+        xfail("nn.functional.max_unpool2d"),
+        xfail("nn.functional.max_unpool2d", "grad"),
+        # https://github.com/intel/torch-xpu-ops/issues/5277
+        xfail("nn.functional.scaled_dot_product_attention"),
+    }
+
+if torch.xpu.is_available():
+    # https://github.com/intel/torch-xpu-ops/issues/5283
+    fake_export_failures_xpu -= {xfail("histogram")}
 
 fake_decomposition_failures = {
     xfail("linalg.matrix_rank"),
@@ -125,10 +147,17 @@ class TestExportOpInfo(TestCase):
     hw_classification = HardwareClassification.CPU
 
     @ops(op_db, allowed_dtypes=(torch.float,))
-    @skipOps(export_failures | fake_export_failures)
+    @skipOps(export_failures | fake_export_failures_cuda)
     @unittest.skipIf(IS_FBCODE, "tests broken with unexpected successes internally")
-    @parametrize("target_device", ["cuda:0"])
-    def test_fake_export(self, target_device, dtype, op):
+    def test_fake_export_cuda(self, dtype, op):
+        target_device = "cuda:0"
+        _test_export_helper(self, target_device, dtype, op)
+
+    @ops(op_db, allowed_dtypes=(torch.float,))
+    @skipOps(export_failures | fake_export_failures_xpu)
+    @unittest.skipIf(IS_FBCODE, "tests broken with unexpected successes internally")
+    def test_fake_export_xpu(self, dtype, op):
+        target_device = "xpu:0"
         _test_export_helper(self, target_device, dtype, op)
 
 
@@ -152,7 +181,9 @@ def _get_env_by_device(device):
     device_type = torch.device(device).type
     if device_type == "cuda":
         env = {"CUDA_VISIBLE_DEVICES": ""}
-    # elif other device
+    elif device_type == "xpu":
+        env = os.environ.copy()
+        env["ONEAPI_DEVICE_SELECTOR"] = "*:cpu"
     return env
 
 
@@ -163,6 +194,7 @@ class TestExportOnFakeDevice(TestCase):
     # We set device-specific env variable to simulate a CPU machine with gpu build
     # Running this on all ops in op_db is too slow, so we only run on a selected subset
     @onlyAccelerator
+    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/5157")
     @unittest.skipIf(
         IS_WINDOWS,
         "Subprocess with simulated CPU machine imports op_db which triggers "
@@ -301,7 +333,9 @@ accelerator_calls_behavior_unchanged()
         self.assertEqual(r, "")
 
 
-instantiate_device_type_tests(TestExportOnFakeDevice, globals(), only_for=("cuda",))
+instantiate_device_type_tests(
+    TestExportOnFakeDevice, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors `test/export/test_export_opinfo.py` test file to make it device-generic and allow extending its coverage to other devices in much simpler way. It also enables testing XPU.

### Main Changes

- Change hardcoded `"cuda:0"` and `"cuda"` to using function parameter instead, so the parametrization with device type is in one place.
- Add `HardwareClassification` to all test classes.
- Change hardcoded variable names cuda -> accelerator.
- Rename `TestExportOnFakeCuda` -> `TestExportOnFakeDevice`.
- Change simulating CPU-only platform by setting the cuda-specific `"CUDA_VISIBLE_DEVICES"` env variable to `_get_env_by_device(device)` helper method call that internally allows to set device-specific env variables.
- Change `torch.cuda` calls to either `torch.get_device_module(device)` or `torch.accelerator` if supported.
- Use `@onlyAccelerator` decorator for tests that were originally cuda-hardcoded.
- Enable testing XPU.
- Add necessary skips for tests failing on XPU with linked issue url.
