### PR TITLE
[MPS] migrate log softmax to metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/LogSoftmax.h
+++ b/aten/src/ATen/native/mps/kernels/LogSoftmax.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <c10/metal/common.h>
+
+C10_METAL_CONSTEXPR unsigned kLogSoftmaxThreads = 256;
+C10_METAL_CONSTEXPR unsigned kLogSoftmaxMaxThreads = 1024;
+
+template <typename index_t = uint64_t>
+struct LogSoftmaxParams {
+  index_t dim_size;
+  index_t num_rows;
+  index_t inner_size;
+  index_t chunk_size;
+  index_t n_chunks;
+  uint32_t ndim;
+  uint32_t dim;
+  ::c10::metal::array<index_t, ::c10::metal::max_ndim> sizes;
+  ::c10::metal::array<index_t, ::c10::metal::max_ndim> strides;
+};

--- a/aten/src/ATen/native/mps/kernels/LogSoftmax.metal
+++ b/aten/src/ATen/native/mps/kernels/LogSoftmax.metal
@@ -1,0 +1,245 @@
+#include <ATen/native/mps/kernels/LogSoftmax.h>
+#include <c10/metal/reduction_utils.h>
+#include <metal_stdlib>
+using namespace metal;
+using c10::metal::simdgroup_size;
+
+template <typename idx_t>
+inline idx_t out_row_offset(idx_t row, idx_t dim_size, idx_t out_inner) {
+  return (row / out_inner) * dim_size * out_inner + row % out_inner;
+}
+
+template <typename idx_t>
+inline idx_t input_row_offset(
+    idx_t row,
+    constant LogSoftmaxParams<idx_t>& params) {
+  idx_t offset = 0;
+  for (uint d = params.ndim; d > 0; --d) {
+    const uint dim = d - 1;
+    if (dim != params.dim) {
+      const idx_t coordinate = row % params.sizes[dim];
+      row /= params.sizes[dim];
+      offset += coordinate * params.strides[dim];
+    }
+  }
+  return offset;
+}
+
+// fast path for contiguous case (e.g. dim=-1), when reduction dim is up to 1024
+// or when reduction dim is between 1025 and 2048 but there are enough rows
+// to fill the GPU with one simdgroup per row (only if there are at least 128
+// rows)
+template <typename T, typename idx_t>
+[[max_total_threads_per_threadgroup(kLogSoftmaxThreads)]] [[kernel]] void
+log_softmax_row(
+    constant T* input,
+    device T* output,
+    constant LogSoftmaxParams<idx_t>& params,
+    uint tptg [[threads_per_threadgroup]],
+    uint tgid [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint sg [[simdgroup_index_in_threadgroup]]) {
+  const auto dim_size = params.dim_size;
+  const idx_t row = idx_t(tgid) * (tptg / simdgroup_size) + sg;
+  if (row >= params.num_rows) {
+    return;
+  }
+  const idx_t in_base = row * dim_size;
+  float max_val = -INFINITY;
+  for (idx_t col = lane; col < dim_size; col += simdgroup_size) {
+    max_val = c10::metal::max(max_val, float(input[in_base + col]));
+  }
+  max_val = c10::metal::simd_max(max_val);
+  float sum = 0;
+  for (idx_t col = lane; col < dim_size; col += simdgroup_size) {
+    sum += precise::exp(float(input[in_base + col]) - max_val);
+  }
+  const float logsum = precise::log(c10::metal::simd_sum(sum));
+  for (idx_t col = lane; col < dim_size; col += simdgroup_size) {
+    output[in_base + col] =
+        static_cast<T>(float(input[in_base + col]) - max_val - logsum);
+  }
+}
+
+// First pass of the split path for long contiguous rows. Used when the
+// reduction width exceeds 2048 and there are at most 256 logical rows
+// and the input consists of contiguous rows.
+template <typename T, typename idx_t>
+[[max_total_threads_per_threadgroup(kLogSoftmaxThreads)]] [[kernel]] void
+log_softmax_partial(
+    constant T* input,
+    device float2* partials,
+    constant LogSoftmaxParams<idx_t>& params,
+    uint2 tgid [[threadgroup_position_in_grid]],
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 tptg [[threads_per_threadgroup]]) {
+  const auto dim_size = params.dim_size;
+  const auto chunk_size = params.chunk_size;
+  const uint ltid = tid.x;
+  const uint lsize = tptg.x;
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+  const idx_t in_base = idx_t(tgid.y) * dim_size;
+  const idx_t chunk_begin = idx_t(tgid.x) * chunk_size;
+  const idx_t chunk_end = min(chunk_begin + chunk_size, dim_size);
+  float max_val = -INFINITY;
+  for (idx_t col = chunk_begin + ltid; col < chunk_end; col += lsize) {
+    max_val = c10::metal::max(max_val, float(input[in_base + col]));
+  }
+  max_val = c10::metal::threadgroup_max(shared_max, max_val, ltid, lsize);
+  float sum = 0;
+  for (idx_t col = chunk_begin + ltid; col < chunk_end; col += lsize) {
+    sum += precise::exp(float(input[in_base + col]) - max_val);
+  }
+  sum = c10::metal::threadgroup_sum(shared_sum, sum, ltid, lsize);
+  if (ltid == 0) {
+    partials[idx_t(tgid.y) * params.n_chunks + tgid.x] =
+        float2(max_val, max_val == -INFINITY ? 0.f : sum);
+  }
+}
+
+// Second pass of the split path. Combines all chunk partials into row-wide
+// statistics, then each threadgroup writes final log-softmax values for one
+// chunk.
+template <typename T, typename idx_t>
+[[max_total_threads_per_threadgroup(kLogSoftmaxThreads)]] [[kernel]] void
+log_softmax_finalize(
+    constant T* input,
+    device T* output,
+    constant float2* partials,
+    constant LogSoftmaxParams<idx_t>& params,
+    uint2 tgid [[threadgroup_position_in_grid]],
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 tptg [[threads_per_threadgroup]]) {
+  const auto dim_size = params.dim_size;
+  const auto chunk_size = params.chunk_size;
+  const auto n_chunks = params.n_chunks;
+  const uint ltid = tid.x;
+  const uint lsize = tptg.x;
+  threadgroup float shared_max[simdgroup_size];
+  threadgroup float shared_sum[simdgroup_size];
+  constant float2* row_partials = partials + idx_t(tgid.y) * n_chunks;
+  float max_val = -INFINITY;
+  for (idx_t i = ltid; i < n_chunks; i += lsize) {
+    max_val = c10::metal::max(max_val, row_partials[i].x);
+  }
+  max_val = c10::metal::threadgroup_max(shared_max, max_val, ltid, lsize);
+  float sum = 0;
+  for (idx_t i = ltid; i < n_chunks; i += lsize) {
+    sum += row_partials[i].y * precise::exp(row_partials[i].x - max_val);
+  }
+  sum = c10::metal::threadgroup_sum(shared_sum, sum, ltid, lsize);
+  const float logsum = precise::log(sum);
+  const idx_t row_base = idx_t(tgid.y) * dim_size;
+  const idx_t chunk_begin = idx_t(tgid.x) * chunk_size;
+  const idx_t chunk_end = min(chunk_begin + chunk_size, dim_size);
+  for (idx_t col = chunk_begin + ltid; col < chunk_end; col += lsize) {
+    output[row_base + col] =
+        static_cast<T>(float(input[row_base + col]) - max_val - logsum);
+  }
+}
+
+// General 2D fallback for strided input and contiguous rows that do not use a
+// specialized kernel.
+template <typename T, typename idx_t>
+[[max_total_threads_per_threadgroup(kLogSoftmaxMaxThreads)]] [[kernel]] void
+log_softmax(
+    constant T* input,
+    device T* output,
+    constant LogSoftmaxParams<idx_t>& params,
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 tptg [[threads_per_threadgroup]],
+    uint2 tgid [[threadgroup_position_in_grid]]) {
+  threadgroup float shared[kLogSoftmaxMaxThreads];
+  const auto dim_size = params.dim_size;
+  const auto inner_size = params.inner_size;
+  const idx_t col = idx_t(tgid.x) * tptg.x + tid.x;
+  const idx_t row = idx_t(tgid.y) * inner_size + col;
+  const idx_t base = input_row_offset(row, params);
+  const idx_t out_base = out_row_offset(row, dim_size, inner_size);
+  const idx_t dim_stride = params.strides[params.dim];
+  const uint shared_idx = tid.y * tptg.x + tid.x;
+  const bool active = col < inner_size;
+
+  float max_val = -INFINITY;
+  for (idx_t r = tid.y; active && r < dim_size; r += tptg.y) {
+    max_val = c10::metal::max(max_val, float(input[base + r * dim_stride]));
+  }
+  shared[shared_idx] = max_val;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint stride = tptg.y / 2; stride > 0; stride /= 2) {
+    if (tid.y < stride) {
+      shared[shared_idx] = c10::metal::max(
+          shared[shared_idx], shared[shared_idx + stride * tptg.x]);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  max_val = shared[tid.x];
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  float sum = 0;
+  for (idx_t r = tid.y; active && r < dim_size; r += tptg.y) {
+    sum += precise::exp(float(input[base + r * dim_stride]) - max_val);
+  }
+  shared[shared_idx] = sum;
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for (uint stride = tptg.y / 2; stride > 0; stride /= 2) {
+    if (tid.y < stride) {
+      shared[shared_idx] += shared[shared_idx + stride * tptg.x];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  const float logsum = precise::log(shared[tid.x]);
+
+  for (idx_t r = tid.y; active && r < dim_size; r += tptg.y) {
+    output[out_base + r * inner_size] =
+        static_cast<T>(float(input[base + r * dim_stride]) - max_val - logsum);
+  }
+}
+
+#define REGISTER_LOG_SOFTMAX_IDX(DTYPE, IDX_T, SUFFIX)                         \
+  template                                                                     \
+      [[host_name("log_softmax_row_" #DTYPE "_" #SUFFIX)]] [[kernel]] void     \
+      log_softmax_row<DTYPE, IDX_T>(                                           \
+          constant DTYPE * input,                                              \
+          device DTYPE * output,                                               \
+          constant LogSoftmaxParams<IDX_T> & params,                           \
+          uint tptg [[threads_per_threadgroup]],                               \
+          uint tgid [[threadgroup_position_in_grid]],                          \
+          uint lane [[thread_index_in_simdgroup]],                             \
+          uint sg [[simdgroup_index_in_threadgroup]]);                         \
+  template                                                                     \
+      [[host_name("log_softmax_partial_" #DTYPE "_" #SUFFIX)]] [[kernel]] void \
+      log_softmax_partial<DTYPE, IDX_T>(                                       \
+          constant DTYPE * input,                                              \
+          device float2 * partials,                                            \
+          constant LogSoftmaxParams<IDX_T> & params,                           \
+          uint2 tgid [[threadgroup_position_in_grid]],                         \
+          uint2 tid [[thread_position_in_threadgroup]],                        \
+          uint2 tptg [[threads_per_threadgroup]]);                             \
+  template [[host_name("log_softmax_finalize_" #DTYPE                          \
+                       "_" #SUFFIX)]] [[kernel]] void                          \
+  log_softmax_finalize<DTYPE, IDX_T>(                                          \
+      constant DTYPE * input,                                                  \
+      device DTYPE * output,                                                   \
+      constant float2 * partials,                                              \
+      constant LogSoftmaxParams<IDX_T> & params,                               \
+      uint2 tgid [[threadgroup_position_in_grid]],                             \
+      uint2 tid [[thread_position_in_threadgroup]],                            \
+      uint2 tptg [[threads_per_threadgroup]]);                                 \
+  template [[host_name("log_softmax_" #DTYPE "_" #SUFFIX)]] [[kernel]] void    \
+  log_softmax<DTYPE, IDX_T>(                                                   \
+      constant DTYPE * input,                                                  \
+      device DTYPE * output,                                                   \
+      constant LogSoftmaxParams<IDX_T> & params,                               \
+      uint2 tid [[thread_position_in_threadgroup]],                            \
+      uint2 tptg [[threads_per_threadgroup]],                                  \
+      uint2 tgid [[threadgroup_position_in_grid]]);
+
+#define REGISTER_LOG_SOFTMAX(DTYPE)          \
+  REGISTER_LOG_SOFTMAX_IDX(DTYPE, uint, u32) \
+  REGISTER_LOG_SOFTMAX_IDX(DTYPE, ulong, u64)
+
+REGISTER_LOG_SOFTMAX(float);
+REGISTER_LOG_SOFTMAX(half);
+REGISTER_LOG_SOFTMAX(bfloat);

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -1,8 +1,13 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
+#include <ATen/ceil_div.h>
 #include <ATen/native/Activation.h>
 #include <ATen/native/Gelu.h>
 #include <ATen/native/mps/OperationUtils.h>
+#include <ATen/native/mps/kernels/LogSoftmax.h>
+#include <c10/util/TypeCast.h>
+#include <c10/util/accumulate.h>
+#include <bit>
 
 #ifndef AT_PER_OPERATOR_HEADERS
 #include <ATen/Functions.h>
@@ -12,6 +17,7 @@
 #include <ATen/ops/_log_softmax_native.h>
 #include <ATen/ops/_prelu_kernel_backward_native.h>
 #include <ATen/ops/_prelu_kernel_native.h>
+#include <ATen/ops/empty.h>
 #include <ATen/ops/gelu_backward_native.h>
 #include <ATen/ops/gelu_native.h>
 #include <ATen/ops/hardtanh_backward_native.h>
@@ -26,52 +32,123 @@
 using namespace at::mps;
 
 namespace at::native {
+using namespace mps;
+
+#ifndef PYTORCH_JIT_COMPILE_SHADERS
+static auto& lib = MetalShaderLibrary::getBundledLibrary();
+#else
+#include <ATen/native/mps/LogSoftmax_metallib.h>
+#endif
+
+static LogSoftmaxParams<uint32_t> narrow_params(const LogSoftmaxParams<uint64_t>& params) {
+  LogSoftmaxParams<uint32_t> result{.dim_size = c10::checked_convert<uint32_t>(params.dim_size, "uint32_t"),
+                                    .num_rows = c10::checked_convert<uint32_t>(params.num_rows, "uint32_t"),
+                                    .inner_size = c10::checked_convert<uint32_t>(params.inner_size, "uint32_t"),
+                                    .chunk_size = c10::checked_convert<uint32_t>(params.chunk_size, "uint32_t"),
+                                    .n_chunks = c10::checked_convert<uint32_t>(params.n_chunks, "uint32_t"),
+                                    .ndim = params.ndim,
+                                    .dim = params.dim};
+  for (const auto d : c10::irange(params.ndim)) {
+    result.sizes[d] = c10::checked_convert<uint32_t>(params.sizes[d], "uint32_t");
+    result.strides[d] = c10::checked_convert<uint32_t>(params.strides[d], "uint32_t");
+  }
+  return result;
+}
+
+template <typename... Tensors>
+static void run_log_softmax(MPSStream* stream,
+                            const std::string& kernel,
+                            const Tensor& self,
+                            bool use_u32,
+                            MTLSize grid,
+                            MTLSize group,
+                            const LogSoftmaxParams<uint64_t>& params,
+                            const Tensors&... tensors) {
+  auto encoder = stream->commandEncoder();
+  auto pso =
+      lib.getPipelineStateForFunc(fmt::format("{}_{}{}", kernel, scalarToMetalTypeString(self), mtlIdxSuffix(use_u32)));
+  getMPSProfiler().beginProfileKernel(pso, kernel, {self}, stream);
+  [encoder setComputePipelineState:pso];
+  if (use_u32) {
+    mtl_setArgs(encoder, tensors..., narrow_params(params));
+  } else {
+    mtl_setArgs(encoder, tensors..., params);
+  }
+  [encoder dispatchThreadgroups:grid threadsPerThreadgroup:group];
+  getMPSProfiler().endProfileKernel(pso, stream);
+}
 
 TORCH_IMPL_FUNC(log_softmax_mps_out)
 (const Tensor& self, const int64_t dim, const bool half_to_float, const Tensor& out) {
-  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kLong, "MPS doesn't know how to do exponent_i64");
-  TORCH_CHECK_NOT_IMPLEMENTED(!c10::isComplexType(self.scalar_type()),
-                              "log_softmax for complex is not supported for MPS");
-  TORCH_CHECK_NOT_IMPLEMENTED(self.scalar_type() != kBool, "log_softmax for bool is not supported for MPS");
-  using namespace mps;
-  using CachedGraph = MPSUnaryCachedGraph;
+  TORCH_CHECK(!half_to_float, "log_softmax with half to float conversion is not supported on MPS");
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      supportedFloatingType(self), "log_softmax not implemented on MPS for ", self.scalar_type());
 
   if (self.numel() == 0) {
     return;
   }
 
-  MPSStream* stream = at::mps::getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "log_softmax_mps_out" + getTensorsStringKey({self}) + ":" + std::to_string(dim);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, self);
-
-      MPSGraphTensor* maximumsTensor = [mpsGraph reductionMaximumWithTensor:inputTensor axis:dim name:nil];
-      MPSGraphTensor* inputTensorSubMax = [mpsGraph subtractionWithPrimaryTensor:inputTensor
-                                                                 secondaryTensor:maximumsTensor
-                                                                            name:nil];
-      MPSGraphTensor* exponentTensor = [mpsGraph exponentWithTensor:inputTensorSubMax name:nil];
-
-      MPSGraphTensor* exponentTensorReduced = [mpsGraph reductionSumWithTensor:exponentTensor axis:dim name:nil];
-
-      MPSGraphTensor* logSumExpTensor = [mpsGraph logarithmWithTensor:exponentTensorReduced name:nil];
-
-      MPSGraphTensor* outputTensor = [mpsGraph subtractionWithPrimaryTensor:inputTensorSubMax
-                                                            secondaryTensor:logSumExpTensor
-                                                                       name:nil];
-
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-    });
-
-    Placeholder selfPlaceholder = Placeholder(cachedGraph->inputTensor_, self);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, out);
-
-    // Create dictionary of inputs and outputs
-    auto feeds = dictionaryFromPlaceholders(selfPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, outputPlaceholder);
+  const auto self_ = self.dim() == 0 ? self.view(1) : self;
+  const auto wrapped_dim = maybe_wrap_dim(dim, self_.dim());
+  const auto dim_size = static_cast<uint64_t>(self_.size(wrapped_dim));
+  const auto inner_size = static_cast<uint64_t>(c10::multiply_integers(self_.sizes().slice(wrapped_dim + 1)));
+  const auto num_rows = static_cast<uint64_t>(self_.numel()) / dim_size;
+  const bool use_u32 = offsetsFitIn<uint32_t>(self_, out);
+  const bool contiguous_rows = self_.is_contiguous() && wrapped_dim == self_.dim() - 1;
+  // one simdgroup per row stops paying off past this width
+  constexpr uint64_t row_kernel_max_dim = 2048;
+  // rows wider than this need many rows to fill the GPU
+  constexpr uint64_t row_kernel_solo_dim = 1024;
+  constexpr uint64_t row_kernel_min_rows = 128;
+  const bool row_dim_fits = dim_size <= row_kernel_solo_dim || num_rows >= row_kernel_min_rows;
+  const bool use_row_kernel = contiguous_rows && dim_size <= row_kernel_max_dim && row_dim_fits;
+  // split long rows into enough chunks to occupy the GPU
+  constexpr uint64_t split_target_groups = 512;
+  // below this width a chunk cannot amortize the second pass
+  constexpr uint64_t split_min_chunk = 2048;
+  const auto n_chunks = std::clamp(split_target_groups / num_rows, uint64_t(1), ceil_div(dim_size, split_min_chunk));
+  const auto chunk_size = ceil_div(dim_size, n_chunks);
+  const bool use_split = contiguous_rows && !use_row_kernel && n_chunks > 1;
+  LogSoftmaxParams<uint64_t> params{.dim_size = dim_size,
+                                    .num_rows = num_rows,
+                                    .inner_size = inner_size,
+                                    .chunk_size = chunk_size,
+                                    .n_chunks = n_chunks,
+                                    .ndim = static_cast<uint32_t>(self_.dim()),
+                                    .dim = static_cast<uint32_t>(wrapped_dim)};
+  for (const auto d : c10::irange(self_.dim())) {
+    params.sizes[d] = self_.size(d);
+    params.strides[d] = self_.stride(d);
   }
+  const auto partials = use_split
+      ? at::empty({static_cast<int64_t>(num_rows), static_cast<int64_t>(n_chunks), 2}, self.options().dtype(kFloat))
+      : Tensor();
+
+  MPSStream* stream = getCurrentMPSStream();
+  dispatch_sync_with_rethrow(stream->queue(), ^() {
+    @autoreleasepool {
+      if (use_row_kernel) {
+        constexpr auto rows_per_group = kLogSoftmaxThreads / c10::metal::simdgroup_size;
+        const auto grid = MTLSizeMake(ceil_div(num_rows, uint64_t(rows_per_group)), 1, 1);
+        const auto group = MTLSizeMake(kLogSoftmaxThreads, 1, 1);
+        run_log_softmax(stream, "log_softmax_row", self, use_u32, grid, group, params, self_, out);
+      } else if (use_split) {
+        const auto grid = MTLSizeMake(n_chunks, num_rows, 1);
+        const auto group = MTLSizeMake(kLogSoftmaxThreads, 1, 1);
+        run_log_softmax(stream, "log_softmax_partial", self, use_u32, grid, group, params, self_, partials);
+        run_log_softmax(stream, "log_softmax_finalize", self, use_u32, grid, group, params, self_, out, partials);
+      } else {
+        // double the width for 2-byte dtypes so a threadgroup row spans a full 128-byte cache line
+        const auto max_tg_x = uint64_t((self.element_size() == 2 ? 2u : 1u) * c10::metal::simdgroup_size);
+        const auto tg_x = std::min(inner_size, max_tg_x);
+        const auto tg_y = std::min(
+            {std::bit_ceil(dim_size), uint64_t(kLogSoftmaxThreads), std::bit_floor(kLogSoftmaxMaxThreads / tg_x)});
+        const auto grid = MTLSizeMake(ceil_div(inner_size, tg_x), num_rows / inner_size, 1);
+        const auto group = MTLSizeMake(tg_x, tg_y, 1);
+        run_log_softmax(stream, "log_softmax", self, use_u32, grid, group, params, self_, out);
+      }
+    }
+  });
 }
 
 TORCH_IMPL_FUNC(log_softmax_backward_mps_out)

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -81,19 +81,18 @@ static void run_log_softmax(MPSStream* stream,
 TORCH_IMPL_FUNC(log_softmax_mps_out)
 (const Tensor& self, const int64_t dim, const bool half_to_float, const Tensor& out) {
   TORCH_CHECK(!half_to_float, "log_softmax with half to float conversion is not supported on MPS");
-  TORCH_CHECK_NOT_IMPLEMENTED(
-      supportedFloatingType(self), "log_softmax not implemented on MPS for ", self.scalar_type());
-
   if (self.numel() == 0) {
     return;
   }
+  TORCH_CHECK_NOT_IMPLEMENTED(
+      supportedFloatingType(self), "log_softmax not implemented on MPS for ", self.scalar_type());
 
   const auto self_ = self.dim() == 0 ? self.view(1) : self;
   const auto wrapped_dim = maybe_wrap_dim(dim, self_.dim());
   const auto dim_size = static_cast<uint64_t>(self_.size(wrapped_dim));
   const auto inner_size = static_cast<uint64_t>(c10::multiply_integers(self_.sizes().slice(wrapped_dim + 1)));
   const auto num_rows = static_cast<uint64_t>(self_.numel()) / dim_size;
-  const bool use_u32 = offsetsFitIn<uint32_t>(self_, out);
+  const bool use_u32 = offsetsFitIn<int32_t>(self_, out);
   const bool contiguous_rows = self_.is_contiguous() && wrapped_dim == self_.dim() - 1;
   // one simdgroup per row stops paying off past this width
   constexpr uint64_t row_kernel_max_dim = 2048;
@@ -118,7 +117,7 @@ TORCH_IMPL_FUNC(log_softmax_mps_out)
                                     .dim = static_cast<uint32_t>(wrapped_dim)};
   for (const auto d : c10::irange(self_.dim())) {
     params.sizes[d] = self_.size(d);
-    params.strides[d] = self_.stride(d);
+    params.strides[d] = self_.size(d) == 1 ? 0 : self_.stride(d);
   }
   const auto partials = use_split
       ? at::empty({static_cast<int64_t>(num_rows), static_cast<int64_t>(n_chunks), 2}, self.options().dtype(kFloat))

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -5685,6 +5685,25 @@ class TestMPS(TestCaseMPS):
 
         self.assertEqual(cpu_x.grad, mps_x.grad.to('cpu'))
 
+    @parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    @parametrize("shape,dim", [((3, 8192), -1), ((4100, 7), 0), ((600, 3000), -1)])
+    def test_log_softmax_metal_paths(self, dtype, shape, dim):
+        # Shapes pin the non-row Metal kernels: the split partial/finalize pair
+        # (dim > 2048, few rows), the 2D kernel (dim not innermost), and the 2D
+        # fallback for long rows (num_rows > 256 disables the split).
+        cpu_x = torch.randn(shape, dtype=dtype)
+        mps_out = F.log_softmax(cpu_x.to('mps'), dim=dim)
+        self.assertEqual(mps_out.cpu(), F.log_softmax(cpu_x, dim=dim))
+
+    def test_log_softmax_split_inf_chunk(self):
+        # A 2048-wide all -inf chunk must not poison the split-path logsumexp;
+        # a fully -inf row stays NaN to match CPU.
+        cpu_x = torch.randn(3, 8192)
+        cpu_x[1, 2048:6144] = -math.inf
+        cpu_x[2] = -math.inf
+        mps_out = F.log_softmax(cpu_x.to('mps'), dim=-1)
+        self.assertEqual(mps_out.cpu(), F.log_softmax(cpu_x, dim=-1))
+
     def test_eq(self):
         values1 = [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]]]
         values2 = [[[1.0, 2.0, 15.0], [4.0, 5.0, 6.0]], [[7.0, 8.0, 9.0], [0.0, 11.0, 12.0]]]

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10649,6 +10649,58 @@ class TestNNDeviceType(NNTestCase):
 
         run_test(1024 * 256 + 1, 8192)  # https://github.com/pytorch/pytorch/issues/84144
 
+    @dtypes(torch.half)
+    @largeTensorTest("20GB")
+    def test_log_softmax_64bit_indexing(self, device, dtype):
+        # The last row begins exactly at element offset 2**32; 32-bit index
+        # math would wrap it back onto row 0.
+        x = torch.ones(2**22 + 1, 1024, device=device, dtype=dtype)
+        x[0] = torch.randn(1024, device=device, dtype=dtype)
+        x[-1] = torch.randn(1024, device=device, dtype=dtype)
+        y = F.log_softmax(x, dim=-1)
+        self.assertEqual(y[0], F.log_softmax(x[0].clone(), dim=-1))
+        self.assertEqual(y[-1], F.log_softmax(x[-1].clone(), dim=-1))
+
+    @onlyAccelerator
+    @dtypes(torch.float, torch.half, torch.bfloat16)
+    @parametrize_test(
+        "layout,dim",
+        [
+            ("slice", -1),
+            ("slice", 1),
+            ("transpose_last", -1),
+            ("expanded_outer", -1),
+            ("outer_transpose", -1),
+        ],
+    )
+    def test_log_softmax_strided_input(self, device, dtype, layout, dim):
+        cpu_base = torch.randn(4, 6, 16, dtype=dtype)
+        device_base = cpu_base.to(device)
+
+        if layout == "slice":
+            cpu_input = cpu_base[..., ::2]
+            device_input = device_base[..., ::2]
+        elif layout == "transpose_last":
+            cpu_input = cpu_base.transpose(-2, -1)
+            device_input = device_base.transpose(-2, -1)
+        elif layout == "expanded_outer":
+            cpu_input = cpu_base[:1].expand(4, -1, -1)
+            device_input = device_base[:1].expand(4, -1, -1)
+        elif layout == "outer_transpose":
+            cpu_input = cpu_base.transpose(0, 1)
+            device_input = device_base.transpose(0, 1)
+        else:
+            raise AssertionError(f"unknown layout: {layout}")
+
+        self.assertFalse(device_input.is_contiguous())
+        atol = 4e-2 if dtype == torch.bfloat16 else 1e-3
+        rtol = 2e-2 if dtype == torch.bfloat16 else 2e-3
+        self.assertEqual(
+            F.log_softmax(device_input, dim=dim).cpu(),
+            F.log_softmax(cpu_input, dim=dim),
+            atol=atol,
+            rtol=rtol,
+        )
 
     @dtypes(torch.float)
     @dtypesIfCUDA(torch.float, torch.half)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -21357,11 +21357,6 @@ DecorateInfo(unittest.skip("Skipped!"), 'TestDecomp', 'test_quick'),
         sample_inputs_func=sample_inputs_softmax_variant,
         supports_forward_ad=True,
         supports_fwgrad_bwgrad=True,
-        skips=(
-            # The following dtypes worked in forward but are not listed by the
-            # OpInfo: {torch.int16, torch.int8, torch.uint8, torch.int32}.
-            DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_dtypes', device_type='mps'),
-        ),
         assert_autodiffed=True),
     OpInfo(
         'log_softmax',

--- a/torch/testing/_internal/opinfo/definitions/_masked.py
+++ b/torch/testing/_internal/opinfo/definitions/_masked.py
@@ -1218,14 +1218,6 @@ op_db: list[OpInfo] = [
         "masked.log_softmax",
         method_variant=None,
         dtypes=floating_types_and(torch.half, torch.bfloat16),
-        dtypesIfMPS=floating_types_and(
-            torch.half,
-            torch.bfloat16,
-            torch.uint8,
-            torch.int32,
-            torch.int16,
-            torch.int8,
-        ),
         sample_inputs_func=sample_inputs_masked_softmax,
         skips=(
             DecorateInfo(


### PR DESCRIPTION
Following https://github.com/pytorch/pytorch/pull/195368 of PRs for reducing memory usage for the ops which are mainly on modern model inference/training side and use MPS Graph, next one being log_softmax.

To briefly explain the kernels, there are 4:
- `log_softmax_row` - used when dim we are reducing on is relatively small (<=1024) or when reduction dim is between 1025 and 2048 but there are enough "rows" (>=128) to keep gpu saturated (reduction dim should be contiguous)
- `log_softmax_partial` and `log_softmax_finalize` - Regular 2 pass kernel, used when reduction dim is >2048 and there are < 256 rows to reduce (reduction dim should be contiguous)
- `log_softmax` - generic kernel, which works on strided tensors and tensors which do not dispatch to the above more optimized ones

<details>
<summary> Latency </summary>

| Shape | Dtype | Before (us) | After (us) | Speedup | Model |
|---|---|---:|---:|---:|---|
| `4x499x46` | fp32 | 34.9 | 5.1 | **6.819x** | wav2vec2-xlsr-53-pt |
| `1x201088` | fp32 | 45.1 | 9.3 | **4.851x** | gpt-oss-20b |
| `5x51866` | fp32 | 46.9 | 11.4 | **4.126x** | whisper-large-v3-turbo |
| `1x151936` | fp32 | 45.5 | 11.9 | **3.838x** | Qwen3 |
| `64x1000` | fp32 | 33.3 | 9.0 | **3.694x** | ViT-base |
| `4x129280` | fp32 | 51.2 | 16.6 | **3.075x** | DeepSeek-V4-Flash |
| `1x151936` | fp32 | 49.8 | 20.8 | **2.401x** | Qwen3 |
| `4096x30522` | fp32 | 8927.1 | 5079.3 | **1.758x** | bert-base-uncased |
| `2x150x512x512` | fp32 | 4881.9 | 2873.2 | **1.699x** | SegFormer-b0 |
| `8x154880` | fp32 | 80.8 | 49.6 | **1.629x** | GLM-5.3 |
| `4x499x2341` | fp32 | 242.9 | 167.1 | **1.454x** | wav2vec2-xlsr-53-ja |
| `1024x50257` | fp32 | 3641.2 | 2960.5 | **1.230x** | gpt2 |
| `2048x128256` | fp32 | 15348.7 | 15238.8 | **1.007x** | Llama-3.2 |
| `2048x129280` | fp32 | 15357.3 | 15380.9 | **0.998x** | DeepSeek-V4-Flash |
| `2048x151936` | fp32 | 17924.8 | 18055.6 | **0.993x** | Qwen3 |
| `8192x151936` | fp32 | 72202.2 | 73142.5 | **0.987x** | Qwen3 |
| `2048x154880` | fp32 | 18289.3 | 18554.2 | **0.986x** | GLM-5.3 |
| `1024x201088` | fp32 | 11830.8 | 12034.2 | **0.983x** | gpt-oss-20b |
| `4x1023x151936` | bf16 | 17874.3 | 19306.0 | **0.926x** | Qwen3 |
| `4x151936x128` | fp32 | 4860.5 | 5352.9 | **0.908x** | Qwen3 |


</details>

<details> 
<summary> Memory usage before: </summary>

```
baseline driver memory: 32.7 MiB
tokens= 1024 tensor=   32.0 MiB driver=    32.7 MiB (+    0.0)
tokens= 1124 tensor=   35.1 MiB driver=    68.7 MiB (+   36.0)
tokens= 1224 tensor=   38.2 MiB driver=   108.7 MiB (+   40.0)
tokens= 1324 tensor=   41.4 MiB driver=   150.7 MiB (+   42.0)
tokens= 1424 tensor=   44.5 MiB driver=   196.7 MiB (+   46.0)
tokens= 1524 tensor=   47.6 MiB driver=   244.7 MiB (+   48.0)
tokens= 1624 tensor=   50.8 MiB driver=   296.7 MiB (+   52.0)
tokens= 1724 tensor=   53.9 MiB driver=   350.7 MiB (+   54.0)
tokens= 1824 tensor=   57.0 MiB driver=   408.7 MiB (+   58.0)
tokens= 1924 tensor=   60.1 MiB driver=   470.7 MiB (+   62.0)
tokens= 2024 tensor=   63.2 MiB driver=   534.7 MiB (+   64.0)
tokens= 2124 tensor=   66.4 MiB driver=   602.7 MiB (+   68.0)
tokens= 2224 tensor=   69.5 MiB driver=   672.7 MiB (+   70.0)
tokens= 2324 tensor=   72.6 MiB driver=   746.7 MiB (+   74.0)
tokens= 2424 tensor=   75.8 MiB driver=   822.7 MiB (+   76.0)
tokens= 2524 tensor=   78.9 MiB driver=   902.7 MiB (+   80.0)
tokens= 2624 tensor=   82.0 MiB driver=   984.7 MiB (+   82.0)
tokens= 2724 tensor=   85.1 MiB driver=  1070.7 MiB (+   86.0)
tokens= 2824 tensor=   88.2 MiB driver=  1160.7 MiB (+   90.0)
tokens= 2924 tensor=   91.4 MiB driver=  1252.7 MiB (+   92.0)
tokens= 3024 tensor=   94.5 MiB driver=  1348.7 MiB (+   96.0)
tokens= 3124 tensor=   97.6 MiB driver=  1446.7 MiB (+   98.0)
tokens= 3224 tensor=  100.8 MiB driver=  1548.7 MiB (+  102.0)
tokens= 3324 tensor=  103.9 MiB driver=  1652.7 MiB (+  104.0)
growth over 24 new shapes: 1620.0 MiB
growth over 24 repeated shapes: -1548.0 MiB
[3812, 32000] fp32 retained: 466.0 MiB
final driver memory: 570.7 MiB
```

</details> 

<details> 
<summary> Memory usage after </summary>

```
baseline driver memory: 0.5 MiB
tokens= 1024 tensor=   32.0 MiB driver=     0.5 MiB (+    0.0)
tokens= 1124 tensor=   35.1 MiB driver=     0.5 MiB (+    0.0)
tokens= 1224 tensor=   38.2 MiB driver=     0.5 MiB (+    0.0)
tokens= 1324 tensor=   41.4 MiB driver=     0.5 MiB (+    0.0)
tokens= 1424 tensor=   44.5 MiB driver=     0.5 MiB (+    0.0)
tokens= 1524 tensor=   47.6 MiB driver=     0.5 MiB (+    0.0)
tokens= 1624 tensor=   50.8 MiB driver=     0.5 MiB (+    0.0)
tokens= 1724 tensor=   53.9 MiB driver=     0.5 MiB (+    0.0)
tokens= 1824 tensor=   57.0 MiB driver=     0.5 MiB (+    0.0)
tokens= 1924 tensor=   60.1 MiB driver=     0.5 MiB (+    0.0)
tokens= 2024 tensor=   63.2 MiB driver=     0.5 MiB (+    0.0)
tokens= 2124 tensor=   66.4 MiB driver=     0.5 MiB (+    0.0)
tokens= 2224 tensor=   69.5 MiB driver=     0.4 MiB (+   -0.0)
tokens= 2324 tensor=   72.6 MiB driver=     0.4 MiB (+    0.0)
tokens= 2424 tensor=   75.8 MiB driver=     0.4 MiB (+    0.0)
tokens= 2524 tensor=   78.9 MiB driver=     0.4 MiB (+    0.0)
tokens= 2624 tensor=   82.0 MiB driver=     0.4 MiB (+    0.0)
tokens= 2724 tensor=   85.1 MiB driver=     0.4 MiB (+    0.0)
tokens= 2824 tensor=   88.2 MiB driver=     0.4 MiB (+    0.0)
tokens= 2924 tensor=   91.4 MiB driver=     0.4 MiB (+    0.0)
tokens= 3024 tensor=   94.5 MiB driver=     0.4 MiB (+    0.0)
tokens= 3124 tensor=   97.6 MiB driver=     0.4 MiB (+    0.0)
tokens= 3224 tensor=  100.8 MiB driver=     0.4 MiB (+    0.0)
tokens= 3324 tensor=  103.9 MiB driver=     0.4 MiB (+    0.0)
growth over 24 new shapes: -0.0 MiB
growth over 24 repeated shapes: 0.0 MiB
[3812, 32000] fp32 retained: 0.0 MiB
final driver memory: 0.4 MiB
```

</details>