### PR TITLE
Stop unloading spirv_utils.pyd in unload_xpu_triton_pyds

### DIFF
--- a/test/inductor/test_codecache.py
+++ b/test/inductor/test_codecache.py
@@ -15,6 +15,7 @@ import textwrap
 import types
 import unittest
 import warnings
+import weakref
 from contextlib import contextmanager
 from typing import Any, cast
 from typing_extensions import override
@@ -5720,6 +5721,46 @@ class TestAutotuneCacheExtraOptions(TestCase):
         mock_local_backend.put.assert_called_once()
         saved_data = mock_local_backend.put.call_args[0][1]
         self.assertNotIn("extra_options", saved_data)
+
+
+@unittest.skipUnless(HAS_XPU_AND_TRITON, "requires XPU and Triton")
+class TestUnloadXpuTritonPyds(TestCase):
+    def test_unload_keeps_xpu_utils_alive(self):
+        """
+        ``unload_xpu_triton_pyds`` must not drop Triton's ``XPUUtils`` singleton. That object owns
+        the only handle to ``spirv_utils.pyd``, so destroying it ``FreeLibrary()``s a library whose
+        type objects Triton still publishes in its module globals, and the next gc pass aborts the
+        process with an access violation.
+
+        The abort itself cannot be asserted -- it kills the interpreter, and it only triggers with a
+        full test-harness object graph. Assert the invariant that prevents it instead: the singleton
+        must survive the call. Called directly rather than via ``fresh_cache`` so that non-Windows
+        CI covers it too.
+        """
+        from torch._inductor.utils import unload_xpu_triton_pyds
+
+        def fn(x):
+            return x * 2 + 1
+
+        x = torch.randn(64, device="xpu")
+        self.assertEqual(torch.compile(fn)(x), fn(x))
+
+        active = sys.modules["triton.runtime.driver"].driver._active
+        self.assertIsNotNone(active, "compiling on xpu should have built the Triton driver")
+        self.assertIn("utils", vars(active), "compiling should have created XPUUtils")
+
+        # Weak, so the test itself does not keep the singleton alive.
+        utils_ref = weakref.ref(active.utils)
+
+        unload_xpu_triton_pyds()
+
+        self.assertIsNotNone(
+            utils_ref(), "XPUUtils was destroyed, so spirv_utils.pyd got unloaded"
+        )
+        self.assertIs(active.utils, utils_ref())
+
+        torch._dynamo.reset()
+        self.assertEqual(torch.compile(fn)(x), fn(x))
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/utils.py
+++ b/torch/_inductor/utils.py
@@ -1671,16 +1671,8 @@ def unload_xpu_triton_pyds() -> None:
                                 run.mod.__del__()
         del sys.modules[module_name]
 
-    # unload spirv_utils.pyd
-    if "triton.runtime.driver" in sys.modules:
-        driver_mod = sys.modules["triton.runtime.driver"]
-        if hasattr(driver_mod.driver.active, "utils"):
-            utils_cls = type(driver_mod.driver.active.utils)
-            if hasattr(utils_cls, "instance"):
-                del utils_cls.instance
-            elif hasattr(utils_cls, "_instance"):
-                utils_cls._instance = None
-            del driver_mod.driver.active.utils
+    # Never unload spirv_utils.pyd: Triton publishes type objects from it in its own module
+    # globals, so freeing the library crashes the next gc pass.
 
     gc.collect()
 


### PR DESCRIPTION
Fixes a Windows fatal exception (access violation, 0xC0000005) that kills the inhterpreter during inductor test teardown on XPU.

fresh_cache(0 calls unload_xpu_triton_pyds( before shutil.rmtree() its temp cache dir, so that Windows can delete the .pyd files compiled into it. Besides the per-kernel __triton_launcher.pyd, that helper also dropped Triton's XPUUtils singleton ('del type(...utils).instance; del driver.active.utils') to force spirv_utils.pyd out of the process.

Since #148323 landed, Triton renamed that singleton attribute instance -> _instance, so the 'del' raised AttributeError and aborted the helper before it could drop the singleton - the unload was effectively dead code. #189147 fixed the AttributeError by handling both attribute shapes, which revived the unload and exposed the latent crash.

Root cause:
triton.backends.intel.driver.XPUUtils.__init__ publishes a type object owned by spirv_utils.pyd into its own module globals:

	mod = compile_module_from_src(..., name="spirv_utils")
	global PyKernelArg
	PyKernelArg = mod.init_PyKernelArgType()

and SpirvUtils.__del__ FreeLibrary()s the DLL on Windows. The singleton holds the last reference to the module, so dropping it unmaps the memory backing PyKernelArg while PyKernelArg is still reachable from module globals. The nest garbage collection walks that dangling type and the process dies:

	Windows fatal exception: access violation
	Current thread 0x00004700 (most recent call first):
	  Garbage-collecting
	  File "torch\_inductor\utils.py", line 1685 in unload_xpu_triton_pyds
          File "torch\_inductor\utils.py", line 1771 in fresh_cache
	  File "torch\_inductor\test_case.py", line 50 in tearDown

Triton documents this invariant in driver.py, right above the call: "we save 'spirv_utils' module so that the destructor is not called prematurely, which will unload the dll and can cause `Fatal Python error: Segmentation fault`".

Fix:
Drop the spirv_utils.pyd unload entirely and keep the __triton_launcher.pyd unload, which is per-kernel and safe. spirv_utils.pyd is a process-wide, hash-cached singleton artifact, not per-test garbage, so keeping it loaded is also what the enxt compile in the same process wants.

Validation (Windows 11, Arc B580):
Regression test added: test_codecache.py
TestUnloadXpuTritonPyds.test_unload_keeps_xpu_utils_alive.

	before/after (fix reverted vs. applied)
	test_unload_keeps_xpu_utils_alive PASS->FAIL
	the 5 cases from intel/torch-xpu-ops#5040 in
	test/dynamo/test_dynamic_shapes.py exit-1073741819 (0xC0000005)
	-> 5 passed

Full re-run of every suite named in intel/torch-xpu-ops#4037 and #4038 to confirm no regression: No occurence of "XPUUtils", "XPULauncher", "spirv_utils" or "acccess violation" in any suite log.

Fixes: https://github.com/intel/torch-xpu-ops/issues/5040

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo