### PR TITLE
[MPS] Match CPU bin-range semantics in the histogram kernel

### DIFF
--- a/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/HistogramKernel.metal
@@ -40,7 +40,6 @@ kernel void histogramdd(
     constant uint8_t& algorithm [[buffer(8)]],
     constant int64_t& weight_stride [[buffer(9)]],
     uint tid [[thread_position_in_grid]]) {
-  constexpr auto eps = T(4e-6);
   bool skip_element = false;
   int64_t hist_index = 0;
   int64_t bin_seq_offset = 0;
@@ -51,11 +50,7 @@ kernel void histogramdd(
     const T rightmost_edge = bin_seq[bin_seq_offset + num_bin_edges[dim] - 1];
 
     // Skips elements which fall outside the specified bins and NaN elements
-    // Adding an eps to the edges to eliminate precision issues that cause
-    // elements accidentally skipped, this is likely due to the minuscule
-    // implementation differences between the CPU and MPS's linspace.
-    if (!(element >= (leftmost_edge - eps) &&
-          element <= (rightmost_edge + eps))) {
+    if (!(element >= leftmost_edge && element <= rightmost_edge)) {
       skip_element = true;
       break;
     }

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3274,8 +3274,11 @@ def sample_inputs_histogram(op_info, device, dtype, requires_grad, **kwargs):
     above = torch.nextafter(torch.tensor(3., dtype=dtype),
                             torch.tensor(9., dtype=dtype)).to(device)
     mid = torch.tensor(1.5, dtype=dtype, device=device)
-    yield SampleInput(torch.stack([mid, below, edges[0],
-                                   above, edges[2], mid]), edges)
+    boundary = torch.stack([mid, below, edges[0], above, edges[2], mid])
+    # An explicit edge tensor selects a binary search over the edges, while an
+    # explicit range selects linear interpolation with a local search.
+    yield SampleInput(boundary, edges)
+    yield SampleInput(boundary, 2, range=(1., 3.))
 
 def sample_inputs_histogramdd(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, dtype=dtype, device=device, requires_grad=requires_grad)
@@ -3327,6 +3330,20 @@ def sample_inputs_histc(op_info, device, dtype, requires_grad, **kwargs):
         # construct sample inputs with a few different bins values
         for bins in [1, 3, 10]:
             yield SampleInput(make_arg(size), bins=bins, min=min, max=max)
+
+    if dtype.is_floating_point:
+        # Elements one ulp outside the explicit min and max are out of range and
+        # must not be counted. The out of range elements are not first, so that
+        # an invalid bin index cannot be hidden by a write past the histogram.
+        below = torch.nextafter(torch.tensor(1., dtype=dtype),
+                                torch.tensor(0., dtype=dtype)).to(device)
+        above = torch.nextafter(torch.tensor(3., dtype=dtype),
+                                torch.tensor(9., dtype=dtype)).to(device)
+        mid = torch.tensor(1.5, dtype=dtype, device=device)
+        lo = torch.tensor(1., dtype=dtype, device=device)
+        hi = torch.tensor(3., dtype=dtype, device=device)
+        yield SampleInput(torch.stack([mid, below, lo, above, hi, mid]),
+                          bins=2, min=1., max=3.)
 
 def sample_inputs_bincount(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, dtype=dtype, device=device, requires_grad=requires_grad)

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3263,6 +3263,20 @@ def sample_inputs_histogram(op_info, device, dtype, requires_grad, **kwargs):
     yield SampleInput(torch.linspace(0., 1., 6, dtype=dtype, device=device),
                       torch.linspace(0., 1., 9000, dtype=dtype, device=device))
 
+    # Elements lying on, and one ulp outside, the outermost bin edges. Out of
+    # range elements are dropped, and backends are expected to agree on which
+    # those are. The out of range elements are deliberately neither first nor
+    # binned alongside the in range ones: an invalid bin index computed for the
+    # first element can be masked by writing outside the accumulator entirely.
+    edges = torch.tensor([1., 2., 3.], dtype=dtype, device=device)
+    below = torch.nextafter(torch.tensor(1., dtype=dtype),
+                            torch.tensor(0., dtype=dtype)).to(device)
+    above = torch.nextafter(torch.tensor(3., dtype=dtype),
+                            torch.tensor(9., dtype=dtype)).to(device)
+    mid = torch.tensor(1.5, dtype=dtype, device=device)
+    yield SampleInput(torch.stack([mid, below, edges[0],
+                                   above, edges[2], mid]), edges)
+
 def sample_inputs_histogramdd(op_info, device, dtype, requires_grad, **kwargs):
     make_arg = partial(make_tensor, dtype=dtype, device=device, requires_grad=requires_grad)
 


### PR DESCRIPTION
Fixes #195076

`histogramdd` widens the bin-range accept test by a fixed `eps = 4e-6` on both sides:

```metal
if (!(element >= (leftmost_edge[dim] - eps) &&
      element <= (rightmost_edge[dim] + eps))) {
```

The CPU kernel it was ported from has no such widening. This is a user-visible behaviour change: elements lying just outside the outermost edges were counted on MPS and are now dropped. Checking against numpy as an independent reference rather than against CPU alone:

```
input [-1e-6, 0., 0.5, 1., 2., 2+1e-6], bins [0., 1., 2.]

before   CPU=[2,2]   MPS=[2,3]   numpy=[2,2]
after    CPU=[2,2]   MPS=[2,2]   numpy=[2,2]
```

MPS was the outlier. Anyone relying on the old behaviour was relying on MPS counting elements that both CPU and numpy exclude. This affects all three bin-selection algorithms, `histc` included.

There is a second consequence. For an element below the leftmost edge `upper_bound` returns `first`, so `pos` is `-1`; the existing clamp only folds the top edge down, so the kernel stores through a negative index — either into the previous thread's slice of `thread_histograms`, or, when the first thread owns the element, outside the accumulator entirely. Both effects also occur for non-contiguous input: a transposed view and a strided slice feeding `histogramdd` gave `[1, 1, 2, 0]` on MPS against `[1, 1, 0, 0]` on CPU, so the wrong counts arrive through the strided index indirection as well as through contiguous input.

## Why remove the widening rather than guard `pos`

On the binary-search path the CPU kernel never checks `pos >= 0` because it does not need to. `leftmost_edge[dim]` is assigned directly from `bin_seq[bin_seq_offset]`, so the accept test and the start of the search compare against the same value; an unwidened `element >= leftmost_edge[dim]` therefore guarantees `upper_bound` advances past the first edge and `pos >= 0`. Widening the accept test is what breaks that, and the rest of the kernel was ported assuming it holds. Removing the widening restores the invariant rather than adding a guard downstream.

Scope of that argument: it covers `BINARY_SEARCH`. The two linear-interpolation paths compute `pos` by division instead, and I have not proved the same property for them.

The `eps` was introduced with the original implementation in #96652 to compensate for suspected `linspace` differences between CPU and MPS, and is not a documented decision. That justification no longer holds for the ranges the widening can affect: across the normal-float ranges I tested, bin edges are bitwise identical between CPU and MPS and `linspace` endpoints are exact on MPS. There is one exception — for denormal ranges such as `range=(0, 1e-38)`, CPU produces `[0, 3.33e-39, 6.67e-39, 1e-38]` while MPS produces all zeros — but a `4e-6` window is nine orders of magnitude too coarse to be compensating for that, and it is a separate problem in `linspace` rather than in the accept test.

The widening is also already inert for most of the type matrix: `T(4e-6)` truncates to `0` for the five integer instantiations, and sits below half the edge spacing for `half` and `bfloat` outside a neighbourhood of zero, so those dtypes have always had the CPU behaviour. This change extends it to `float`.

## Testing

Three OpInfo samples place elements one ulp outside the outer edges, covering all three bin-selection algorithms: an explicit edge tensor for `BINARY_SEARCH`, an explicit `range=` for `LINEAR_INTERPOLATION_WITH_LOCAL_SEARCH`, and a `histc` sample with explicit `min`/`max` for `LINEAR_INTERPOLATION`. On the unfixed kernel each of the three diverges from CPU independently. The `histc` sample is guarded on `dtype.is_floating_point`, since `histc` also runs on integer dtypes.

Neither existing yield in `sample_inputs_histogram` could place an element in the widened window, for different reasons. The int-bins yield passes no `range=`, so the outer edges are the input's own min and max via `at::aminmax(input, 0)` (`HistogramKernel.mm:227`) and the extreme elements land exactly on the edges by construction. The explicit-edges yield draws both the input and the edges from `make_tensor`, where the odds of landing within `4e-6` of an edge are negligible. That is why the existing coverage passed.

Two details are deliberate. The out-of-range elements are not placed first, because an invalid bin index computed for the first element writes outside the accumulator and leaves the result looking correct. And the in-range elements do not share a bin with the target of that invalid write, because the accumulator update is not atomic and the two writes otherwise race, losing the evidence.

The samples run on every backend through the device-generic OpInfo tests. On MPS they are picked up by `TestConsistencyMPS.test_output_match` and `test_output_grad_match`, both of which compare forward output against CPU for these ops, and which fail without the kernel change and pass with it.
