### PR TITLE
[Test][Refactor] Make `test/export/test_package.py` tests device-generic.

### DIFF
--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -13,6 +13,7 @@ from torch.export import Dim
 from torch.export.experimental import _ExportPackage
 from torch.export.pt2_archive._package import _load_aoti
 from torch.testing._internal.common_utils import (
+    decorateIf,
     HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
@@ -112,12 +113,12 @@ class TestAOTIPackageDeviceValidation(TestCase):
         class FakeAOTIModelPackageLoader:
             @staticmethod
             def load_metadata_from_package(file, model_name):
-                return {"AOTI_DEVICE_KEY": "accelerator"}
+                return {"AOTI_DEVICE_KEY": "cuda"}
 
             def __init__(self, *args, **kwargs):
                 raise RuntimeError(
-                    "Cannot load AOTInductor package for device 'accelerator' because "
-                    "ACCELERATOR is not available in this process."
+                    "Cannot load AOTInductor package for device 'cuda' because "
+                    "CUDA is not available in this process."
                 )
 
         with (
@@ -128,7 +129,7 @@ class TestAOTIPackageDeviceValidation(TestCase):
         ):
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Cannot load AOTInductor package.*ACCELERATOR is not available",
+                "Cannot load AOTInductor package.*CUDA is not available",
             ):
                 _load_aoti("model.pt2", "model", False, 1, -1)
 
@@ -143,8 +144,8 @@ class TestAOTIPackageDeviceValidation(TestCase):
             mock.patch(
                 "torch._inductor.package.package.load_pt2",
                 side_effect=RuntimeError(
-                    "Cannot load AOTInductor package for device 'accelerator' because "
-                    "ACCELERATOR is not available in this process."
+                    "Cannot load AOTInductor package for device 'cuda' because "
+                    "CUDA is not available in this process."
                 ),
             ),
             mock.patch.object(
@@ -153,11 +154,15 @@ class TestAOTIPackageDeviceValidation(TestCase):
         ):
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Cannot load AOTInductor package.*ACCELERATOR is not available",
+                "Cannot load AOTInductor package.*CUDA is not available",
             ):
                 load_package("model.pt2")
 
-    @parametrize("device_type", ["cuda"])
+    @parametrize("device_type", ["cuda", "xpu"])
+    @decorateIf(
+        unittest.skip("https://github.com/intel/torch-xpu-ops/issues/5156"),
+        lambda params: params["device_type"] == "xpu",
+    )
     def test_cpp_aoti_package_loader_validates_accelerator_availability(
         self, device_type
     ):

--- a/test/export/test_package.py
+++ b/test/export/test_package.py
@@ -12,11 +12,19 @@ from torch._inductor.package import load_package
 from torch.export import Dim
 from torch.export.experimental import _ExportPackage
 from torch.export.pt2_archive._package import _load_aoti
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
+    TestCase,
+)
 
 
 @unittest.skipIf(not is_dynamo_supported(), "dynamo isn't supported")
 class TestPackage(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_basic(self):
         def fn(x: torch.Tensor) -> torch.Tensor:
             return x + 1
@@ -98,16 +106,18 @@ class TestPackage(TestCase):
 
 
 class TestAOTIPackageDeviceValidation(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_aoti_load_uses_cpp_device_validation_before_device_info(self):
         class FakeAOTIModelPackageLoader:
             @staticmethod
             def load_metadata_from_package(file, model_name):
-                return {"AOTI_DEVICE_KEY": "cuda"}
+                return {"AOTI_DEVICE_KEY": "accelerator"}
 
             def __init__(self, *args, **kwargs):
                 raise RuntimeError(
-                    "Cannot load AOTInductor package for device 'cuda' because "
-                    "CUDA is not available in this process."
+                    "Cannot load AOTInductor package for device 'accelerator' because "
+                    "ACCELERATOR is not available in this process."
                 )
 
         with (
@@ -118,7 +128,7 @@ class TestAOTIPackageDeviceValidation(TestCase):
         ):
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Cannot load AOTInductor package.*CUDA is not available",
+                "Cannot load AOTInductor package.*ACCELERATOR is not available",
             ):
                 _load_aoti("model.pt2", "model", False, 1, -1)
 
@@ -133,8 +143,8 @@ class TestAOTIPackageDeviceValidation(TestCase):
             mock.patch(
                 "torch._inductor.package.package.load_pt2",
                 side_effect=RuntimeError(
-                    "Cannot load AOTInductor package for device 'cuda' because "
-                    "CUDA is not available in this process."
+                    "Cannot load AOTInductor package for device 'accelerator' because "
+                    "ACCELERATOR is not available in this process."
                 ),
             ),
             mock.patch.object(
@@ -143,28 +153,34 @@ class TestAOTIPackageDeviceValidation(TestCase):
         ):
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Cannot load AOTInductor package.*CUDA is not available",
+                "Cannot load AOTInductor package.*ACCELERATOR is not available",
             ):
                 load_package("model.pt2")
 
-    @unittest.skipIf(
-        torch.cuda.is_available(), "requires CUDA to be unavailable in this process"
-    )
-    def test_cpp_aoti_package_loader_validates_cuda_availability(self):
+    @parametrize("device_type", ["cuda"])
+    def test_cpp_aoti_package_loader_validates_accelerator_availability(
+        self, device_type
+    ):
+        if torch.get_device_module(device_type).is_available():
+            self.skipTest(f"Requires {device_type} to be unavailable in this process.")
         with tempfile.TemporaryDirectory() as tmp:
             model_dir = Path(tmp) / "data" / "aotinductor" / "model"
             model_dir.mkdir(parents=True)
             extension = ".pyd" if sys.platform == "win32" else ".so"
             (model_dir / f"model{extension}").touch()
             (model_dir / "model_metadata.json").write_text(
-                json.dumps({"AOTI_DEVICE_KEY": "cuda"}), encoding="utf-8"
+                json.dumps({"AOTI_DEVICE_KEY": device_type}), encoding="utf-8"
             )
 
             with self.assertRaisesRegex(
                 RuntimeError,
-                "Cannot load AOTInductor package.*(CUDA|ROCm) is not available",
+                "Cannot load AOTInductor package"
+                f".*({device_type.upper()}|ROCm) is not available",
             ):
                 torch._C._aoti.AOTIModelPackageLoader(str(tmp), "model", False, 1, -1)
+
+
+instantiate_parametrized_tests(TestAOTIPackageDeviceValidation)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors `test/export/test_package.py` to make it device-generic and adds xpu device_type parameter for parametrized test functions.

### Main Changes

- Add `HardwareClassification` to all test classes.
- Change hardcoded `"cuda"` calls to test function `device_type` parameter. The `test_cpp_aoti_package_loader_validates_accelerator_availability` test function is being parametrized using `@parametrize("device_type", ["cuda"])` insted of `instantiate_device_type_tests` because those tests doesn't need any accelerator to be available. More, this test requires given device to be unavailable, because it tests exactly that - if the cpp aoti package loader returns early when selected device is not currently available.
- Add `"xpu"` device_type to parametrization, but skip it with linked issue as it currently fails.