### PR TITLE
[Test] Enable test_dlpack.py on XPU and fix two DLPack device bugs

### DIFF
--- a/aten/src/ATen/DLConvertor.cpp
+++ b/aten/src/ATen/DLConvertor.cpp
@@ -180,9 +180,26 @@ Device dlDeviceToTorchDevice(
 #else
       return at::Device(DeviceType::HIP, index);
 #endif
-    case DLDeviceType::kDLOneAPI:
-      TORCH_CHECK(data != nullptr, "Can't get ATen device for XPU without XPU data.");
-      return at::detail::getXPUHooks().getDeviceFromPtr(data);
+    case DLDeviceType::kDLOneAPI: {
+      const auto& xpu_hooks = at::detail::getXPUHooks();
+      if (data != nullptr) {
+        return xpu_hooks.getDeviceFromPtr(data);
+      }
+      TORCH_CHECK_BUFFER(
+          xpu_hooks.isBuilt(),
+          "Cannot get XPU device index without ATen_xpu library.");
+      // For XPU, device_id is the index into sycl::device::get_devices() rather
+      // than the ATen device index (see torchDeviceToDLDevice), so invert the
+      // mapping instead of using it as an index.
+      for (DeviceIndex i = 0; i < xpu_hooks.deviceCount(); i++) {
+        at::Device device(DeviceType::XPU, i);
+        if (xpu_hooks.getGlobalIdxFromDevice(device) == index) {
+          return device;
+        }
+      }
+      TORCH_CHECK_BUFFER(
+          false, "No XPU device with global index ", static_cast<int>(index));
+    }
     case DLDeviceType::kDLMAIA:
       return at::Device(DeviceType::MAIA, index);
     case DLDeviceType::kDLExtDev:

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -554,7 +554,6 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyOn(["xpu", "cuda"])
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/3077")
     def test_no_copy(self, device):
         # No copy, since tensor lives in the same device.
         self._test_from_dlpack(device)

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -378,8 +378,9 @@ class TestTorchDlPack(TestCase):
         with torch.device(dev0):
             x = make_tensor((5,), dtype=torch.float32, device=dev0)
 
+        device_type = torch.device(dev0).type.upper()
         with self.assertRaisesRegex(
-            BufferError, r"Can't export tensors on a different CUDA device"
+            BufferError, rf"Can't export tensors on a different {device_type} device"
         ):
             with torch.accelerator.device_index(torch.device(dev1).index):
                 x.__dlpack__()

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -8,19 +8,16 @@ from torch.testing._internal.common_device_type import (
     dtypes,
     dtypesIfMPS,
     instantiate_device_type_tests,
-    onlyCPU,
-    onlyCUDA,
     onlyNativeDeviceTypes,
-    onlyOn,
     skipCUDAIfNotRocm,
     skipMeta,
-    skipXPUIf,
 )
 from torch.testing._internal.common_dtype import (
     all_mps_types_and,
     all_types_and_complex_and,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     IS_JETSON,
     run_tests,
     skipIfTorchDynamo,
@@ -54,6 +51,94 @@ class TensorDLPackWrapper:
 
 
 class TestTorchDlPack(TestCase):
+    # These tests exercise the parts of the DLPack protocol that don't depend on
+    # where the tensor lives: export rejections, stride handling and the NumPy
+    # producer path.
+    hw_classification = HardwareClassification.GENERIC
+
+    def test_dlpack_invalid_cpu_stream(self):
+        x = make_tensor((5,), dtype=torch.float32, device="cpu")
+        with self.assertRaisesRegex(AssertionError, r"stream should be None on cpu."):
+            x.__dlpack__(stream=0)
+
+    # TODO: add interchange tests once NumPy 1.22 (dlpack support) is required
+    def test_dlpack_export_requires_grad(self):
+        x = torch.zeros(10, dtype=torch.float32, requires_grad=True)
+        with self.assertRaisesRegex(BufferError, r"require gradient"):
+            x.__dlpack__()
+
+    def test_dlpack_export_is_conj(self):
+        x = torch.tensor([-1 + 1j, -2 + 2j, 3 - 3j])
+        y = torch.conj(x)
+        with self.assertRaisesRegex(BufferError, r"conjugate bit"):
+            y.__dlpack__()
+
+    def test_dlpack_export_non_strided(self):
+        x = torch.sparse_coo_tensor([[0]], [1], size=(1,))
+        y = torch.conj(x)
+        with self.assertRaisesRegex(BufferError, r"strided"):
+            y.__dlpack__()
+
+    def test_dlpack_normalize_strides(self):
+        x = torch.rand(16)
+        y = x[::3][:1]
+        self.assertEqual(y.shape, (1,))
+        self.assertEqual(y.stride(), (3,))
+        z = from_dlpack(y)
+        self.assertEqual(z.shape, (1,))
+        # Stride normalization has been removed, strides should be preserved
+        self.assertEqual(z.stride(), (3,))
+
+    @xfailIfTorchDynamo
+    def test_from_dlpack_negative_strides(self):
+        # torch.from_dlpack() on a NumPy array with negative strides used to
+        # abort the process instead of raising a catchable Python exception.
+        # See https://github.com/pytorch/pytorch/issues/188023.
+        import numpy as np
+
+        # 1-D negative stride
+        a1 = np.arange(8.0)[::-1]
+        with self.assertRaisesRegex(
+            RuntimeError, "Storage size calculation overflowed"
+        ):
+            torch.from_dlpack(a1)
+
+        # 2-D, one negative axis
+        a2 = np.arange(12.0).reshape(3, 4)[:, ::-1]
+        with self.assertRaisesRegex(
+            RuntimeError, "Storage size calculation overflowed"
+        ):
+            torch.from_dlpack(a2)
+
+    def test_dlpack_copy_fallback(self):
+        """Test that copy parameter works even with producers that don't support it"""
+        import numpy as np
+
+        # Test copy=True - should work even if NumPy doesn't support copy parameter
+        np_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        t = from_dlpack(np_array, copy=True)
+
+        # Verify it's a copy by modifying tensor and checking NumPy unchanged
+        t[0] = 999.0
+        self.assertEqual(np_array[0], 1.0)
+
+        # Test copy=None (default) - should be zero-copy view
+        np_array2 = np.array([10.0, 20.0, 30.0], dtype=np.float32)
+        t2 = from_dlpack(np_array2)
+        t2[0] = 999.0
+        self.assertEqual(np_array2[0], 999.0)
+
+    def test_dlpack_unsupported_dtype_error(self):
+        inp = torch.quantize_per_tensor(torch.randn(()), 0.1, 10, torch.qint8)
+
+        with self.assertRaisesRegex(
+            BufferError, ".* types are not supported by dlpack"
+        ):
+            from_dlpack(inp)
+
+
+class TestTorchDlPackDevice(TestCase):
+    hw_classification = HardwareClassification.GENERIC
     exact_dtype = True
 
     @skipMeta
@@ -100,51 +185,6 @@ class TestTorchDlPack(TestCase):
         z = from_dlpack(to_dlpack(x))
         z[0] = z[0] + 20.0
         self.assertEqual(z, x)
-
-    def _dlpack_conversion_with_streams(self, stream, x):
-        # DLPack protocol helps establish a correct stream order
-        # (hence data dependency) at the exchange boundary.
-        # DLPack manages this synchronization for us, so we don't need to
-        # explicitly wait until x is populated
-        if IS_JETSON:
-            # DLPack protocol that establishes correct stream order
-            # does not behave as expected on Jetson
-            stream.synchronize()
-        stream = torch.Stream()
-        with stream:
-            z = from_dlpack(x)
-        stream.synchronize()
-        return z
-
-    @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
-    def test_dlpack_conversion_with_streams(self, device, dtype):
-        # Create a stream where the tensor will reside
-        stream = torch.Stream()
-        with stream:
-            # Do an operation in the actual stream
-            x = make_tensor((5,), dtype=dtype, device=device) + 1
-        z = self._dlpack_conversion_with_streams(stream, x)
-        self.assertEqual(z, x)
-
-    @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @dtypes(
-        torch.float8_e5m2,
-        torch.float8_e5m2fnuz,
-        torch.float8_e4m3fn,
-        torch.float8_e4m3fnuz,
-        torch.float8_e8m0fnu,
-        torch.float4_e2m1fn_x2,
-    )
-    def test_dlpack_conversion_with_streams_narrow_precision(self, device, dtype):
-        stream = torch.Stream()
-        with stream:
-            x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
-            x = x.view(dtype)
-        z = self._dlpack_conversion_with_streams(stream, x)
-        self.assertEqual(z.view(torch.uint8), x.view(torch.uint8))
 
     @skipMeta
     @onlyNativeDeviceTypes
@@ -205,44 +245,6 @@ class TestTorchDlPack(TestCase):
         self.assertEqual(y5, y5_dl)
 
     @skipMeta
-    @onlyCUDA
-    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
-    def test_dlpack_conversion_with_diff_streams(self, device, dtype):
-        stream_a = torch.cuda.Stream()
-        stream_b = torch.cuda.Stream()
-        # DLPack protocol helps establish a correct stream order
-        # (hence data dependency) at the exchange boundary.
-        # the `tensor.__dlpack__` method will insert a synchronization event
-        # in the current stream to make sure that it was correctly populated.
-        with torch.cuda.stream(stream_a):
-            x = make_tensor((5,), dtype=dtype, device=device) + 1
-            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
-            stream_a.synchronize()
-        stream_b.synchronize()
-        self.assertEqual(z, x)
-
-    @skipMeta
-    @onlyCUDA
-    @dtypes(
-        torch.float8_e5m2,
-        torch.float8_e5m2fnuz,
-        torch.float8_e4m3fn,
-        torch.float8_e4m3fnuz,
-        torch.float8_e8m0fnu,
-        torch.float4_e2m1fn_x2,
-    )
-    def test_dlpack_conversion_with_diff_streams_narrow_precision(self, device, dtype):
-        stream_a = torch.cuda.Stream()
-        stream_b = torch.cuda.Stream()
-        with torch.cuda.stream(stream_a):
-            x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
-            x = x.view(dtype)
-            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
-            stream_a.synchronize()
-        stream_b.synchronize()
-        self.assertEqual(z.view(torch.uint8), x.view(torch.uint8))
-
-    @skipMeta
     @onlyNativeDeviceTypes
     @dtypes(
         *all_types_and_complex_and(
@@ -262,51 +264,6 @@ class TestTorchDlPack(TestCase):
             raise AssertionError(f"dtype mismatch: {x.dtype} != {y.dtype}")
 
     @skipMeta
-    @onlyCUDA
-    def test_dlpack_default_stream(self, device):
-        class DLPackTensor:
-            def __init__(self, tensor):
-                self.tensor = tensor
-
-            def __dlpack_device__(self):
-                return self.tensor.__dlpack_device__()
-
-            def __dlpack__(self, stream=None):
-                if torch.version.hip is None:
-                    if stream != 1:
-                        raise AssertionError(f"expected stream=1, got {stream}")
-                else:
-                    if stream != 0:
-                        raise AssertionError(f"expected stream=0, got {stream}")
-                capsule = self.tensor.__dlpack__(stream=stream)
-                return capsule
-
-        # CUDA-based tests runs on non-default streams
-        with torch.cuda.stream(torch.cuda.default_stream()):
-            x = DLPackTensor(make_tensor((5,), dtype=torch.float32, device=device))
-            from_dlpack(x)
-
-    @skipMeta
-    @onlyCUDA
-    def test_dlpack_convert_default_stream(self, device):
-        # tests run on non-default stream, so _sleep call
-        # below will run on a non-default stream, causing
-        # default stream to wait due to inserted syncs
-        torch.cuda.default_stream().synchronize()
-        # run _sleep call on a non-default stream, causing
-        # default stream to wait due to inserted syncs
-        side_stream = torch.cuda.Stream()
-        with torch.cuda.stream(side_stream):
-            x = torch.zeros(1, device=device)
-            torch.cuda._sleep(2**20)
-            self.assertTrue(torch.cuda.default_stream().query())
-            # ROCm uses stream 0 for default stream, CUDA uses stream 1
-            default_stream_id = 0 if torch.version.hip else 1
-            x.__dlpack__(stream=default_stream_id)
-        # check that the default stream has work (a pending cudaStreamWaitEvent)
-        self.assertFalse(torch.cuda.default_stream().query())
-
-    @skipMeta
     @onlyNativeDeviceTypes
     @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16))
     def test_dlpack_tensor_invalid_stream(self, device, dtype):
@@ -315,136 +272,10 @@ class TestTorchDlPack(TestCase):
             x.__dlpack__(stream=object())
 
     @skipMeta
-    @onlyCUDA
-    def test_dlpack_cuda_per_thread_stream(self, device):
-        # Test whether we raise an error if we are trying to use per-thread default
-        # stream, which is currently not supported by PyTorch.
-        x = make_tensor((5,), dtype=torch.float32, device=device)
-
-        if TEST_WITH_ROCM:
-            context = self.assertRaisesRegex(
-                AssertionError, r"unsupported stream on ROCm: 2"
-            )
-        else:
-            context = self.assertRaisesRegex(
-                BufferError, "per-thread default stream is not supported"
-            )
-
-        with context:
-            x.__dlpack__(stream=2)
-
-    @skipMeta
-    @onlyCUDA
-    @skipCUDAIfNotRocm
-    def test_dlpack_invalid_rocm_streams(self, device):
-        # Test that we correctly raise errors on unsupported ROCm streams.
-        def test(x, stream):
-            with self.assertRaisesRegex(
-                AssertionError, r"unsupported stream on ROCm: \d"
-            ):
-                x.__dlpack__(stream=stream)
-
-        x = make_tensor((5,), dtype=torch.float32, device=device)
-        test(x, stream=1)
-        test(x, stream=2)
-
-    @skipMeta
-    @onlyCUDA
-    def test_dlpack_invalid_cuda_streams(self, device):
-        x = make_tensor((5,), dtype=torch.float32, device=device)
-
-        if TEST_WITH_ROCM:
-            # On ROCm, stream=0 is valid (default stream).
-            self.assertIsNotNone(x.__dlpack__(stream=0))
-        else:
-            # CUDA raises AssertionError for stream=0
-            with self.assertRaisesRegex(
-                AssertionError, r"unsupported stream on CUDA: \d"
-            ):
-                x.__dlpack__(stream=0)
-
-    @skipMeta
-    def test_dlpack_invalid_cpu_stream(self):
-        x = make_tensor((5,), dtype=torch.float32, device="cpu")
-        with self.assertRaisesRegex(AssertionError, r"stream should be None on cpu."):
-            x.__dlpack__(stream=0)
-
-    @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    @deviceCountAtLeast(2)
-    def test_dlpack_tensor_on_different_device(self, devices):
-        dev0, dev1 = devices[:2]
-
-        with torch.device(dev0):
-            x = make_tensor((5,), dtype=torch.float32, device=dev0)
-
-        device_type = torch.device(dev0).type.upper()
-        with self.assertRaisesRegex(
-            BufferError, rf"Can't export tensors on a different {device_type} device"
-        ):
-            with torch.accelerator.device_index(torch.device(dev1).index):
-                x.__dlpack__()
-
-    # TODO: add interchange tests once NumPy 1.22 (dlpack support) is required
-    @skipMeta
-    def test_dlpack_export_requires_grad(self):
-        x = torch.zeros(10, dtype=torch.float32, requires_grad=True)
-        with self.assertRaisesRegex(BufferError, r"require gradient"):
-            x.__dlpack__()
-
-    @skipMeta
-    def test_dlpack_export_is_conj(self):
-        x = torch.tensor([-1 + 1j, -2 + 2j, 3 - 3j])
-        y = torch.conj(x)
-        with self.assertRaisesRegex(BufferError, r"conjugate bit"):
-            y.__dlpack__()
-
-    @skipMeta
-    def test_dlpack_export_non_strided(self):
-        x = torch.sparse_coo_tensor([[0]], [1], size=(1,))
-        y = torch.conj(x)
-        with self.assertRaisesRegex(BufferError, r"strided"):
-            y.__dlpack__()
-
-    @skipMeta
-    def test_dlpack_normalize_strides(self):
-        x = torch.rand(16)
-        y = x[::3][:1]
-        self.assertEqual(y.shape, (1,))
-        self.assertEqual(y.stride(), (3,))
-        z = from_dlpack(y)
-        self.assertEqual(z.shape, (1,))
-        # Stride normalization has been removed, strides should be preserved
-        self.assertEqual(z.stride(), (3,))
-
-    @xfailIfTorchDynamo
-    @skipMeta
-    @onlyCPU
-    def test_from_dlpack_negative_strides(self, device):
-        # torch.from_dlpack() on a NumPy array with negative strides used to
-        # abort the process instead of raising a catchable Python exception.
-        # See https://github.com/pytorch/pytorch/issues/188023.
-        import numpy as np
-
-        # 1-D negative stride
-        a1 = np.arange(8.0)[::-1]
-        with self.assertRaisesRegex(
-            RuntimeError, "Storage size calculation overflowed"
-        ):
-            torch.from_dlpack(a1)
-
-        # 2-D, one negative axis
-        a2 = np.arange(12.0).reshape(3, 4)[:, ::-1]
-        with self.assertRaisesRegex(
-            RuntimeError, "Storage size calculation overflowed"
-        ):
-            torch.from_dlpack(a2)
-
-    @skipMeta
     @onlyNativeDeviceTypes
     def test_automatically_select_in_creation(self, device):
         # Create a new tensor, and wrap it using TensorDLPackWrapper.
-        tensor = torch.rand(10)
+        tensor = torch.rand(10, device=device)
         wrap = TensorDLPackWrapper(tensor)
         # Create a new tensor from the wrapper.
         # This should identify that the wrapper class provides the DLPack methods
@@ -485,108 +316,6 @@ class TestTorchDlPack(TestCase):
         test(device, max_version=(2, 0))
 
     @skipMeta
-    @onlyCPU
-    @dtypes(
-        # Note: NumPy DLPack bool support only landed in 1.25.
-        *all_types_and_complex_and(
-            torch.half,
-            torch.uint16,
-            torch.uint32,
-            torch.uint64,
-        )
-    )
-    def test_numpy_dlpack_protocol_conversion(self, device, dtype):
-        import numpy as np
-
-        t = make_tensor((5,), dtype=dtype, device=device)
-
-        if hasattr(np, "from_dlpack"):
-            # DLPack support only available from NumPy 1.22 onwards.
-            # Here, we test having another framework (NumPy) calling our
-            # Tensor.__dlpack__ implementation.
-            np_from_dlpack = np.from_dlpack(t)
-            np_from_copy = t.numpy()
-            self.assertEqual(np_from_dlpack, np_from_copy)
-
-        # We can't use the array created above as input to from_dlpack.
-        # That's because DLPack imported NumPy arrays are read-only.
-        # Thus, we need to convert it to NumPy by using the numpy() method.
-        t_arr = t.numpy()
-
-        # Transform the NumPy array back using DLPack.
-        res = from_dlpack(t_arr)
-
-        self.assertEqual(t, res)
-        self.assertEqual(t.data_ptr(), res.data_ptr())
-
-    def _test_from_dlpack(self, device, out_device=None, copy=None):
-        if isinstance(device, str):
-            device = torch.device(device)
-
-        inp = make_tensor((5,), dtype=torch.float32, device=device)
-        out = torch.from_dlpack(inp, device=out_device, copy=copy)
-
-        if out_device is None:
-            out_device = device
-        if isinstance(out_device, str):
-            out_device = torch.device(out_device)
-
-        self.assertEqual(inp, out)
-        self.assertEqual(out.device, out_device)
-
-        # They should be moved (i.e. not copied) only if:
-        #   (a) we are forcing move, i.e. copy=False
-        #   (b) the output device is the same as the input one AND copy is None
-        if copy is False or (copy is None and device == out_device):
-            self.assertEqual(inp.data_ptr(), out.data_ptr())
-        else:
-            # Otherwise, inp should be copied.
-            self.assertNotEqual(inp.data_ptr(), out.data_ptr())
-
-    @skipMeta
-    @onlyCUDA
-    def test_copy(self, device):
-        # Force-copy same device tensor.
-        self._test_from_dlpack(device, copy=True)
-        self._test_from_dlpack(device, out_device=device, copy=True)
-        # Output should be in a different device, i.e. should have been copied.
-        self._test_from_dlpack(device, out_device="cpu")
-        self._test_from_dlpack(device, out_device="cpu", copy=True)
-
-    @skipMeta
-    @onlyOn(["xpu", "cuda"])
-    def test_no_copy(self, device):
-        # No copy, since tensor lives in the same device.
-        self._test_from_dlpack(device)
-        self._test_from_dlpack(device, copy=False)
-        self._test_from_dlpack(device, out_device=device)
-        self._test_from_dlpack(device, out_device=device, copy=False)
-
-    @skipMeta
-    @onlyCUDA
-    def test_needs_copy_error(self, device):
-        with self.assertRaisesRegex(ValueError, r"cannot move .* tensor from .*"):
-            self._test_from_dlpack(device, out_device="cpu", copy=False)
-
-    def test_dlpack_copy_fallback(self):
-        """Test that copy parameter works even with producers that don't support it"""
-        import numpy as np
-
-        # Test copy=True - should work even if NumPy doesn't support copy parameter
-        np_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-        t = from_dlpack(np_array, copy=True)
-
-        # Verify it's a copy by modifying tensor and checking NumPy unchanged
-        t[0] = 999.0
-        self.assertEqual(np_array[0], 1.0)
-
-        # Test copy=None (default) - should be zero-copy view
-        np_array2 = np.array([10.0, 20.0, 30.0], dtype=np.float32)
-        t2 = from_dlpack(np_array2)
-        t2[0] = 999.0
-        self.assertEqual(np_array2[0], 999.0)
-
-    @skipMeta
     @onlyNativeDeviceTypes
     def test_unsupported_device_error(self, device):
         inp = make_tensor((5,), dtype=torch.float32, device=device)
@@ -597,20 +326,9 @@ class TestTorchDlPack(TestCase):
         ):
             inp.__dlpack__(max_version=(1, 0), dl_device=(dl_device_type, 0))
 
-    @skipMeta
-    @onlyCPU
-    def test_dlpack_unsupported_dtype_error(self, device):
-        inp = torch.quantize_per_tensor(torch.randn(()), 0.1, 10, torch.qint8)
-
-        with self.assertRaisesRegex(
-            BufferError, ".* types are not supported by dlpack"
-        ):
-            from_dlpack(inp)
-
     @xfailCUDAIfSM89OrLaterOnWindows
     @skipMeta
     @onlyNativeDeviceTypes
-    @skipXPUIf(True, "https://github.com/intel/torch-xpu-ops/issues/3074")
     def test_dlpack_exchange_api(self, device):
         """Comprehensive test of all DLPack Exchange API functions using inline C++"""
         # Check that the C API capsule exists and get it
@@ -845,8 +563,111 @@ class TestTorchDlPack(TestCase):
             tensor, api_capsule, device.startswith(("cuda", "xpu"))
         )
 
-    @skipMeta
-    @onlyOn(["xpu", "cuda"])
+
+class TestTorchDlPackAccelerator(TestCase):
+    # Device-to-device transfers and stream-ordered exchange, which have no
+    # meaning on CPU. Kept device-generic so every accelerator gets them.
+    hw_classification = HardwareClassification.ACCELERATOR
+    exact_dtype = True
+
+    def _dlpack_conversion_with_streams(self, stream, x):
+        # DLPack protocol helps establish a correct stream order
+        # (hence data dependency) at the exchange boundary.
+        # DLPack manages this synchronization for us, so we don't need to
+        # explicitly wait until x is populated
+        if IS_JETSON:
+            # DLPack protocol that establishes correct stream order
+            # does not behave as expected on Jetson
+            stream.synchronize()
+        stream = torch.Stream()
+        with stream:
+            z = from_dlpack(x)
+        stream.synchronize()
+        return z
+
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
+    def test_dlpack_conversion_with_streams(self, device, dtype):
+        # Create a stream where the tensor will reside
+        stream = torch.Stream()
+        with stream:
+            # Do an operation in the actual stream
+            x = make_tensor((5,), dtype=dtype, device=device) + 1
+        z = self._dlpack_conversion_with_streams(stream, x)
+        self.assertEqual(z, x)
+
+    @dtypes(
+        torch.float8_e5m2,
+        torch.float8_e5m2fnuz,
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e8m0fnu,
+        torch.float4_e2m1fn_x2,
+    )
+    def test_dlpack_conversion_with_streams_narrow_precision(self, device, dtype):
+        stream = torch.Stream()
+        with stream:
+            x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
+            x = x.view(dtype)
+        z = self._dlpack_conversion_with_streams(stream, x)
+        self.assertEqual(z.view(torch.uint8), x.view(torch.uint8))
+
+    @deviceCountAtLeast(2)
+    def test_dlpack_tensor_on_different_device(self, devices):
+        dev0, dev1 = devices[:2]
+
+        with torch.device(dev0):
+            x = make_tensor((5,), dtype=torch.float32, device=dev0)
+
+        device_type = torch.device(dev0).type.upper()
+        with self.assertRaisesRegex(
+            BufferError, rf"Can't export tensors on a different {device_type} device"
+        ):
+            with torch.accelerator.device_index(torch.device(dev1).index):
+                x.__dlpack__()
+
+    def _test_from_dlpack(self, device, out_device=None, copy=None):
+        if isinstance(device, str):
+            device = torch.device(device)
+
+        inp = make_tensor((5,), dtype=torch.float32, device=device)
+        out = torch.from_dlpack(inp, device=out_device, copy=copy)
+
+        if out_device is None:
+            out_device = device
+        if isinstance(out_device, str):
+            out_device = torch.device(out_device)
+
+        self.assertEqual(inp, out)
+        self.assertEqual(out.device, out_device)
+
+        # They should be moved (i.e. not copied) only if:
+        #   (a) we are forcing move, i.e. copy=False
+        #   (b) the output device is the same as the input one AND copy is None
+        if copy is False or (copy is None and device == out_device):
+            self.assertEqual(inp.data_ptr(), out.data_ptr())
+        else:
+            # Otherwise, inp should be copied.
+            self.assertNotEqual(inp.data_ptr(), out.data_ptr())
+
+    def test_copy(self, device):
+        # Force-copy same device tensor.
+        self._test_from_dlpack(device, copy=True)
+        self._test_from_dlpack(device, out_device=device, copy=True)
+        # Output should be in a different device, i.e. should have been copied.
+        self._test_from_dlpack(device, out_device="cpu")
+        self._test_from_dlpack(device, out_device="cpu", copy=True)
+
+    def test_no_copy(self, device):
+        # No copy, since tensor lives in the same device.
+        self._test_from_dlpack(device)
+        self._test_from_dlpack(device, copy=False)
+        self._test_from_dlpack(device, out_device=device)
+        self._test_from_dlpack(device, out_device=device, copy=False)
+
+    def test_needs_copy_error(self, device):
+        with self.assertRaisesRegex(ValueError, r"cannot move .* tensor from .*"):
+            self._test_from_dlpack(device, out_device="cpu", copy=False)
+
     def test_numpy_cross_device_transfer(self, device):
         """Test cross-device transfer from NumPy (CPU) to PyTorch (CUDA/XPU).
 
@@ -896,8 +717,6 @@ class TestTorchDlPack(TestCase):
         t_cpu[0] = 999
         self.assertEqual(np_array2[0], 999)
 
-    @skipMeta
-    @onlyOn(["xpu", "cuda"])
     @deviceCountAtLeast(2)
     def test_numpy_cross_device_multi_gpu(self, devices):
         """Test cross-device transfer to specific CUDA devices (cuda:0, cuda:1, etc)."""
@@ -922,9 +741,179 @@ class TestTorchDlPack(TestCase):
         self.assertNotEqual(t0.device, t1.device)
 
 
+# NumPy is the other end of every exchange below, so CPU is a real dependency
+# rather than an untested restriction.
+class TestTorchDlPackCPUOnly(TestCase):
+    hw_classification = HardwareClassification.CPU
+    exact_dtype = True
+
+    @dtypes(
+        # Note: NumPy DLPack bool support only landed in 1.25.
+        *all_types_and_complex_and(
+            torch.half,
+            torch.uint16,
+            torch.uint32,
+            torch.uint64,
+        )
+    )
+    def test_numpy_dlpack_protocol_conversion(self, device, dtype):
+        import numpy as np
+
+        t = make_tensor((5,), dtype=dtype, device=device)
+
+        if hasattr(np, "from_dlpack"):
+            # DLPack support only available from NumPy 1.22 onwards.
+            # Here, we test having another framework (NumPy) calling our
+            # Tensor.__dlpack__ implementation.
+            np_from_dlpack = np.from_dlpack(t)
+            np_from_copy = t.numpy()
+            self.assertEqual(np_from_dlpack, np_from_copy)
+
+        # We can't use the array created above as input to from_dlpack.
+        # That's because DLPack imported NumPy arrays are read-only.
+        # Thus, we need to convert it to NumPy by using the numpy() method.
+        t_arr = t.numpy()
+
+        # Transform the NumPy array back using DLPack.
+        res = from_dlpack(t_arr)
+
+        self.assertEqual(t, res)
+        self.assertEqual(t.data_ptr(), res.data_ptr())
+
+
+class TestTorchDlPackStreams(TestCase):
+    # DLPack stream exchange is only specified for CUDA and ROCm; the sentinel
+    # stream values below have no meaning on any other backend.
+    hw_classification = HardwareClassification.CUDA
+    exact_dtype = True
+
+    @dtypes(*all_types_and_complex_and(torch.half, torch.bfloat16, torch.bool))
+    def test_dlpack_conversion_with_diff_streams(self, device, dtype):
+        stream_a = torch.cuda.Stream()
+        stream_b = torch.cuda.Stream()
+        # DLPack protocol helps establish a correct stream order
+        # (hence data dependency) at the exchange boundary.
+        # the `tensor.__dlpack__` method will insert a synchronization event
+        # in the current stream to make sure that it was correctly populated.
+        with torch.cuda.stream(stream_a):
+            x = make_tensor((5,), dtype=dtype, device=device) + 1
+            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
+            stream_a.synchronize()
+        stream_b.synchronize()
+        self.assertEqual(z, x)
+
+    @dtypes(
+        torch.float8_e5m2,
+        torch.float8_e5m2fnuz,
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e8m0fnu,
+        torch.float4_e2m1fn_x2,
+    )
+    def test_dlpack_conversion_with_diff_streams_narrow_precision(self, device, dtype):
+        stream_a = torch.cuda.Stream()
+        stream_b = torch.cuda.Stream()
+        with torch.cuda.stream(stream_a):
+            x = make_tensor((5,), dtype=torch.uint8, device=device) + 1
+            x = x.view(dtype)
+            z = torch.from_dlpack(x.__dlpack__(stream=stream_b.cuda_stream))
+            stream_a.synchronize()
+        stream_b.synchronize()
+        self.assertEqual(z.view(torch.uint8), x.view(torch.uint8))
+
+    def test_dlpack_default_stream(self, device):
+        class DLPackTensor:
+            def __init__(self, tensor):
+                self.tensor = tensor
+
+            def __dlpack_device__(self):
+                return self.tensor.__dlpack_device__()
+
+            def __dlpack__(self, stream=None):
+                if torch.version.hip is None:
+                    if stream != 1:
+                        raise AssertionError(f"expected stream=1, got {stream}")
+                else:
+                    if stream != 0:
+                        raise AssertionError(f"expected stream=0, got {stream}")
+                capsule = self.tensor.__dlpack__(stream=stream)
+                return capsule
+
+        # CUDA-based tests runs on non-default streams
+        with torch.cuda.stream(torch.cuda.default_stream()):
+            x = DLPackTensor(make_tensor((5,), dtype=torch.float32, device=device))
+            from_dlpack(x)
+
+    def test_dlpack_convert_default_stream(self, device):
+        # tests run on non-default stream, so _sleep call
+        # below will run on a non-default stream, causing
+        # default stream to wait due to inserted syncs
+        torch.cuda.default_stream().synchronize()
+        # run _sleep call on a non-default stream, causing
+        # default stream to wait due to inserted syncs
+        side_stream = torch.cuda.Stream()
+        with torch.cuda.stream(side_stream):
+            x = torch.zeros(1, device=device)
+            torch.cuda._sleep(2**20)
+            self.assertTrue(torch.cuda.default_stream().query())
+            # ROCm uses stream 0 for default stream, CUDA uses stream 1
+            default_stream_id = 0 if torch.version.hip else 1
+            x.__dlpack__(stream=default_stream_id)
+        # check that the default stream has work (a pending cudaStreamWaitEvent)
+        self.assertFalse(torch.cuda.default_stream().query())
+
+    def test_dlpack_cuda_per_thread_stream(self, device):
+        # Test whether we raise an error if we are trying to use per-thread default
+        # stream, which is currently not supported by PyTorch.
+        x = make_tensor((5,), dtype=torch.float32, device=device)
+
+        if TEST_WITH_ROCM:
+            context = self.assertRaisesRegex(
+                AssertionError, r"unsupported stream on ROCm: 2"
+            )
+        else:
+            context = self.assertRaisesRegex(
+                BufferError, "per-thread default stream is not supported"
+            )
+
+        with context:
+            x.__dlpack__(stream=2)
+
+    @skipCUDAIfNotRocm
+    def test_dlpack_invalid_rocm_streams(self, device):
+        # Test that we correctly raise errors on unsupported ROCm streams.
+        def test(x, stream):
+            with self.assertRaisesRegex(
+                AssertionError, r"unsupported stream on ROCm: \d"
+            ):
+                x.__dlpack__(stream=stream)
+
+        x = make_tensor((5,), dtype=torch.float32, device=device)
+        test(x, stream=1)
+        test(x, stream=2)
+
+    def test_dlpack_invalid_cuda_streams(self, device):
+        x = make_tensor((5,), dtype=torch.float32, device=device)
+
+        if TEST_WITH_ROCM:
+            # On ROCm, stream=0 is valid (default stream).
+            self.assertIsNotNone(x.__dlpack__(stream=0))
+        else:
+            # CUDA raises AssertionError for stream=0
+            with self.assertRaisesRegex(
+                AssertionError, r"unsupported stream on CUDA: \d"
+            ):
+                x.__dlpack__(stream=0)
+
+
 instantiate_device_type_tests(
-    TestTorchDlPack, globals(), allow_mps=True, allow_xpu=True
+    TestTorchDlPackDevice, globals(), allow_mps=True, allow_xpu=True
 )
+instantiate_device_type_tests(
+    TestTorchDlPackAccelerator, globals(), only_for=("cuda", "xpu"), allow_xpu=True
+)
+instantiate_device_type_tests(TestTorchDlPackCPUOnly, globals(), only_for="cpu")
+instantiate_device_type_tests(TestTorchDlPackStreams, globals(), only_for="cuda")
 
 
 # ReadOnlyTensorWrapper is an eager, runtime-only export shim that rejects all
@@ -935,6 +924,8 @@ instantiate_device_type_tests(
     "ReadOnlyTensorWrapper is eager-only; __dlpack__ unsupported in dynamo"
 )
 class TestReadOnlyDLPack(TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     # These tests exercise the read-only DLPack export path and the
     # ReadOnlyTensorWrapper subclass. The behavior (const_data_ptr export, the
     # READ_ONLY flag, copy-on-write preservation, op rejection) is device

--- a/torch/_tensor.py
+++ b/torch/_tensor.py
@@ -1616,15 +1616,18 @@ class Tensor(torch._C.TensorBase):
                 "Can't export tensors with layout other than torch.strided"
             )
 
-        if (
-            self.device.type == "cuda"
-            and self.device.index != torch.cuda.current_device()
-        ):
-            raise BufferError(
-                "Can't export tensors on a different CUDA device index. "
-                f"Expected: {self.device.index}. "
-                f"Current device: {torch.cuda.current_device()}."
-            )
+        # The consumer resolves the capsule against the current device of the
+        # accelerator, so exporting from any other device index would silently
+        # hand out a pointer belonging to another device.
+        acc = torch.accelerator.current_accelerator()
+        if acc is not None and self.device.type == acc.type:
+            current_index = torch.accelerator.current_device_index()
+            if self.device.index != current_index:
+                raise BufferError(
+                    f"Can't export tensors on a different {acc.type.upper()} device index. "
+                    f"Expected: {self.device.index}. "
+                    f"Current device: {current_index}."
+                )
 
         if stream is not None and type(stream) is not int:
             # Stream pointers in CUDA/ROCm are uniquely numbered and can


### PR DESCRIPTION
Makes `test/test_dlpack.py` device-agnostic and enables it on Intel GPU (#142029 scope). Three commits, review in order:

1. **`630fcbbd87c`** -- resolve the XPU DLPack device when no data pointer is available. Fixes intel/torch-xpu-ops#3077.
2. **`a1a6c340f81`** -- generalize `__dlpack__`'s cross-device export guard from CUDA to any accelerator.
3. **`6d642b6d8a6`** -- split the file by device specificity, tag each class with `hw_classification`, and replace `@onlyX` decorators with `only_for=` on instantiation.

Root causes, trade-offs and per-commit test plans are in the commit messages.

### Coverage delta

`python test/test_dlpack.py -v` on one Intel Battlemage GPU, before -> after, 0 failures either way:

| bucket | collected | executed | skipped |
| --- | --- | --- | --- |
| **xpu** | 159 -> 115 | 115 -> 113 | 44 -> 2 |
| **cpu** | 159 -> 104 | 112 -> 104 | 47 -> 0 |
| device-generic | 9 -> 17 | 7 -> 15 | 2 -> 2 |
| total | 327 -> 236 | 234 -> 232 | 93 -> 4 |

Four XPU tests go from skipped to passing: `test_no_copy` (torch-xpu-ops#3077), `test_dlpack_exchange_api` (torch-xpu-ops#3074, closed), and `test_copy` / `test_needs_copy_error` (were `Only runs on cuda`). The 2 remaining XPU skips need a second GPU, the 2 device-generic ones a newer NumPy.

The 91 dropped entries were clones `instantiate_device_type_tests` generated per backend that an `@onlyX` decorator then skipped, plus 8 device-unrelated tests that now run once instead of once per backend. No test that executed before stops executing.

Authored with the help of an AI assistant (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
