### PR TITLE
[XPU] Enable TestHigherOrderOperatorInteraction by adding AutogradXPU dispatch for mysum

### DIFF
--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5357,6 +5357,10 @@ def construct_sum_pyop():
     def mysum_autograd_cuda(x, dim):
         return torch.sum(x, dim)
 
+    @mysum.py_impl(torch._C.DispatchKey.AutogradXPU)
+    def mysum_autograd_xpu(x, dim):
+        return torch.sum(x, dim)
+
     return mysum
 
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -5766,7 +5766,8 @@ instantiate_device_type_tests(
 instantiate_device_type_tests(
     TestHigherOrderOperatorInteraction,
     globals(),
-    only_for=only_for,
+    only_for=("cpu", "cuda", "xpu"),
+    allow_xpu=True,
 )
 instantiate_device_type_tests(
     TestFunctionalize,


### PR DESCRIPTION
This PR fixes https://github.com/intel/torch-xpu-ops/issues/4283.

`TestHigherOrderOperatorInteraction` in `test/functorch/test_eager_transforms.py` is currently excluded on XPU. The 7 tests that exercise the custom `mysum` HigherOrderOperator fail with:
```
NotImplementedError: could not find kernel for HigherOrderOperator mysum at dispatch key DispatchKey.AutogradXPU (resolved from DispatchKey.AutogradXPU)
```
The test-local `mysum` operator registers `py_impl` for `AutogradCPU` and `AutogradCUDA` but has no `AutogradXPU` equivalent, so dispatching on an XPU tensor finds no kernel.

## Changes

1. Added an `AutogradXPU` `py_impl` registration for `mysum`, mirroring the existing `AutogradCPU`/`AutogradCUDA` implementations.
2. Lifted the XPU exclusion for `TestHigherOrderOperatorInteraction` (`only_for=("cpu", "cuda", "xpu")`, `allow_xpu=True`) so the XPU variants are generated and run.

## Verification
```
python -m pytest test/functorch/test_eager_transforms.py -v -k "TestHigherOrderOperatorInteractionXPU"
```
- Before: 7 failed, 2 passed
- After: 9 passed