### PR TITLE
Disable addr2line symbolization by default

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -969,6 +969,29 @@ class TestCppExtensionUtils(TestCase):
 
 
 class TestTraceback(TestCase):
+    def test_symbolize_mode(self):
+        script = "import torch; print(torch._C._get_symbolize_mode())"
+        for disable_addr2line, expected in [
+            (None, "dladdr"),
+            ("0", "addr2line"),
+            ("1", "dladdr"),
+        ]:
+            with self.subTest(disable_addr2line=disable_addr2line):
+                env = os.environ.copy()
+                env.pop("TORCH_SYMBOLIZE_MODE", None)
+                if disable_addr2line is None:
+                    env.pop("TORCH_DISABLE_ADDR2LINE", None)
+                else:
+                    env["TORCH_DISABLE_ADDR2LINE"] = disable_addr2line
+                result = subprocess.run(
+                    [sys.executable, "-c", script],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), expected)
+
     @staticmethod
     @torch._dynamo.disable
     def _context_decorator_traceback_frame_names():

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1365,6 +1365,7 @@ def _get_cpp_backtrace(
     frames_to_skip: _int,
     maximum_number_of_frames: _int,
 ) -> str: ...  # THPModule_getCppBacktrace
+def _get_symbolize_mode() -> str: ...  # THPModule_getSymbolizeMode
 def set_flush_denormal(arg: _bool) -> _bool: ...  # THPModule_setFlushDenormal
 def get_default_dtype() -> _dtype: ...  # THPModule_getDefaultDtype
 def _get_all_dtypes() -> list[_dtype]: ...  # THPModule_getAllDtypes

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -96,6 +96,7 @@
 #include <torch/csrc/onnx/init.h>
 #include <torch/csrc/profiler/python/init.h>
 #include <torch/csrc/tensor/python_tensor.h>
+#include <torch/csrc/utils/cpp_stacktraces.h>
 #include <torch/csrc/utils/disable_torch_function.h>
 #include <torch/csrc/utils/init.h>
 #include <torch/csrc/utils/pycfunction_helpers.h>
@@ -892,6 +893,22 @@ static PyObject* THModule_getCppBacktrace(PyObject* _unused, PyObject* args) {
   }
   return THPUtils_packString(
       c10::get_backtrace(frames_to_skip, maximum_number_of_frames, true));
+  END_HANDLE_TH_ERRORS
+}
+
+static PyObject* THModule_getSymbolizeMode(
+    PyObject* _unused,
+    PyObject* noargs) {
+  HANDLE_TH_ERRORS
+  switch (torch::get_symbolize_mode()) {
+    case torch::unwind::Mode::addr2line:
+      return THPUtils_packString("addr2line");
+    case torch::unwind::Mode::fast:
+      return THPUtils_packString("fast");
+    case torch::unwind::Mode::dladdr:
+      return THPUtils_packString("dladdr");
+  }
+  TORCH_INTERNAL_ASSERT(false, "Unknown symbolize mode");
   END_HANDLE_TH_ERRORS
 }
 
@@ -2303,6 +2320,7 @@ static std::initializer_list<PyMethodDef> TorchMethods = {
      METH_NOARGS,
      nullptr},
     {"_get_cpp_backtrace", THModule_getCppBacktrace, METH_VARARGS, nullptr},
+    {"_get_symbolize_mode", THModule_getSymbolizeMode, METH_NOARGS, nullptr},
     {"_rename_privateuse1_backend",
      THModule_rename_privateuse1_backend,
      METH_O,

--- a/torch/csrc/utils/cpp_stacktraces.cpp
+++ b/torch/csrc/utils/cpp_stacktraces.cpp
@@ -10,7 +10,7 @@ bool compute_cpp_stack_traces_enabled() {
 }
 
 bool compute_disable_addr2line() {
-  return c10::utils::check_env("TORCH_DISABLE_ADDR2LINE") == true;
+  return c10::utils::check_env("TORCH_DISABLE_ADDR2LINE").value_or(true);
 }
 } // namespace
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195462

Motivation: I noticed people keep disabling this in production jobs because the addr2line symbolization is really slow. If this really is a problem, we should disable it in OSS too.

Human direction: Flip TORCH_DISABLE_ADDR2LINE so it is true by default, and expose a private torch._C API so the behavior can be tested without compiling a C++ extension.

> AI-assisted implementation summary:
>
> Default C++ stack trace symbolization to dladdr to avoid the latency and potential hangs of launching addr2line. Setting TORCH_DISABLE_ADDR2LINE=0 continues to opt into addr2line, while TORCH_SYMBOLIZE_MODE retains precedence.
>
> Expose the effective symbolization mode through a private torch._C API and test the environment behavior in lightweight subprocesses.
>
> Test Plan:
>
> ```text
> bash /home/ezyang/local/ptq_workspace/scripts/rebuild.sh /home/ezyang/local/ptq_workspace/jobs/20260831-pytorch-adhoc-73ff67/pytorch
> /home/ezyang/local/ptq_workspace/jobs/20260831-pytorch-adhoc-73ff67/.venv/bin/python test/test_utils.py TestTraceback
> PATH=/home/ezyang/local/ptq_workspace/jobs/20260831-pytorch-adhoc-73ff67/.venv/bin:$PATH lintrunner -a
> ```
>
> Authored with an AI assistant.