### PR TITLE
[TorchInductor] Fix batch_aten_sub dropping alpha argument during post-grad fusion

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -10,7 +10,13 @@ import torch._inductor
 import torch._inductor.fx_passes.group_batch_fusion
 from torch._dynamo.utils import counters
 from torch._inductor import config
+from torch._inductor.fx_passes.group_batch_fusion import (
+    apply_group_batch_fusion,
+    BatchSubPostGradFusion,
+)
 from torch._inductor.test_case import run_tests, TestCase
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch.fx.experimental.proxy_tensor import make_fx
 from torch.testing._internal.common_cuda import BF16X9_SUPPORTED
 from torch.testing._internal.common_utils import recover_orig_fp32_precision
 from torch.testing._internal.inductor_utils import GPU_TYPE, requires_gpu
@@ -251,6 +257,22 @@ class _TestPointwiseOps(torch.nn.Module):
         sub = [torch.sub(mul[i], mul[i]) for i in range(len(mul))]
         div = [torch.div(sub[i], sub[i]) for i in range(len(sub))]
         return torch.cat(div, dim=1)
+
+
+class _TestPointwiseOpsWithAlpha(torch.nn.Module):
+    def __init__(self, device):
+        super().__init__()
+        self.device = device
+
+    def forward(self, x):
+        inputs = torch.split(x.to(self.device), 500, dim=1)
+        x_split = torch.split(inputs[0], 50, dim=1)
+        y_split = torch.split(inputs[1], 50, dim=1)
+        add = [
+            torch.add(x_split[i], y_split[i], alpha=3.0) for i in range(len(x_split))
+        ]
+        sub = [torch.sub(add[i], y_split[i], alpha=2.0) for i in range(len(add))]
+        return torch.cat(sub, dim=1)
 
 
 class _TestPointwiseOpsPostGrad(torch.nn.Module):
@@ -679,6 +701,101 @@ class TestGroupBatchFusion(TestCase):
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)
         self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
+
+    @requires_gpu()
+    @torch._inductor.config.patch(
+        pre_grad_fusion_options={},
+        post_grad_fusion_options={
+            "batch_aten_add": {},
+            "batch_aten_sub": {},
+        },
+    )
+    def test_pointwise_math_ops_with_alpha_fusion(self):
+        counters.clear()
+        module = _TestPointwiseOpsWithAlpha(GPU_TYPE)
+        input_ref = [torch.randn(50, 1000, requires_grad=True, device=GPU_TYPE)]
+        input_res = [input_ref[0].detach().clone().requires_grad_(True)]
+        traced = torch.compile(module)
+        ref = module(*input_ref)
+        res = traced(*input_res)
+        self.assertEqual(ref, res, rtol=1e-5, atol=1e-5)
+        self.assertEqual(counters["inductor"]["batch_aten_add"], 1)
+        self.assertEqual(counters["inductor"]["batch_aten_sub"], 1)
+        ref.sum().backward()
+        res.sum().backward()
+        self.assertEqual(input_ref[0].grad, input_res[0].grad, rtol=1e-5, atol=1e-5)
+        counters.clear()
+
+    def test_batch_aten_sub_preserves_alpha(self):
+        class Model(torch.nn.Module):
+            def forward(self, *args):
+                # Two fusion groups: five subs with alpha=2.0, five with
+                # alpha=3.5.
+                alphas = [2.0] * 5 + [3.5] * 5
+                return tuple(
+                    torch.ops.aten.sub.Tensor(
+                        args[2 * i], args[2 * i + 1], alpha=alphas[i]
+                    )
+                    for i in range(10)
+                )
+
+        inputs = [torch.randn(16, 16) for _ in range(20)]
+        model = Model()
+        with FakeTensorMode() as fake_mode:
+            fake_inputs = [fake_mode.from_tensor(t) for t in inputs]
+            gm = make_fx(model)(*fake_inputs)
+            apply_group_batch_fusion(gm.graph, BatchSubPostGradFusion())
+
+        fused_sub_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target == torch.ops.aten.sub.Tensor
+        ]
+        self.assertEqual(len(fused_sub_nodes), 2)
+        alphas = {n.kwargs.get("alpha") for n in fused_sub_nodes}
+        self.assertEqual(alphas, {2.0, 3.5})
+
+        res = gm(*inputs)
+        ref = model(*inputs)
+        self.assertEqual(res, ref)
+
+    def test_batch_aten_sub_normalizes_default_alpha(self):
+        # The dispatcher elides kwargs equal to their schema defaults, so
+        # sub(x, y) and sub(x, y, alpha=1) trace to identical nodes and
+        # fuse into a single group: keying on node.kwargs loses no fusion
+        # opportunity for default-valued kwargs.
+        class Model(torch.nn.Module):
+            def forward(self, *args):
+                bare = [
+                    torch.ops.aten.sub.Tensor(args[2 * i], args[2 * i + 1])
+                    for i in range(5)
+                ]
+                explicit = [
+                    torch.ops.aten.sub.Tensor(
+                        args[10 + 2 * i], args[11 + 2 * i], alpha=1
+                    )
+                    for i in range(5)
+                ]
+                return tuple(bare + explicit)
+
+        inputs = [torch.randn(16, 16) for _ in range(20)]
+        model = Model()
+        with FakeTensorMode() as fake_mode:
+            fake_inputs = [fake_mode.from_tensor(t) for t in inputs]
+            gm = make_fx(model)(*fake_inputs)
+            apply_group_batch_fusion(gm.graph, BatchSubPostGradFusion())
+
+        fused_sub_nodes = [
+            n
+            for n in gm.graph.nodes
+            if n.op == "call_function" and n.target == torch.ops.aten.sub.Tensor
+        ]
+        self.assertEqual(len(fused_sub_nodes), 1)
+        self.assertEqual(dict(fused_sub_nodes[0].kwargs), {})
+
+        res = gm(*inputs)
+        ref = model(*inputs)
+        self.assertEqual(res, ref)
 
     @requires_gpu()
     @torch._inductor.config.patch(

--- a/torch/_inductor/fx_passes/group_batch_fusion.py
+++ b/torch/_inductor/fx_passes/group_batch_fusion.py
@@ -421,8 +421,9 @@ class BatchPointwiseMathOpsPostGradFusion(BatchPointwiseOpsFusionFactory):
         if CallFunctionVarArgs(self.op).match(
             node
         ) and self._pointwise_node_can_be_fused(node):
-            alpha = node.kwargs.get("alpha", DEFAULT_ALPHA)
-            rounding_mode = node.kwargs.get("rounding_mode", None)
+            # NOTE: fuse() propagates subset[0].kwargs verbatim onto the
+            # fused node, so the group key must encode everything that is
+            # copied; key on node.kwargs rather than individual fields.
             input, other = node.args
             shape = list(input.meta["val"].shape)  # type: ignore[union-attr]
             if self.graph_search_options.get("fuse_nodes_with_same_parent", False):
@@ -445,8 +446,7 @@ class BatchPointwiseMathOpsPostGradFusion(BatchPointwiseOpsFusionFactory):
                 str(shape),
                 str(input.meta["val"].dtype),  # type: ignore[union-attr]
                 str(other.meta["val"].dtype),  # type: ignore[union-attr]
-                str(alpha),
-                str(rounding_mode),
+                str(node.kwargs),
                 str(parent),
             )
         else:
@@ -455,7 +455,9 @@ class BatchPointwiseMathOpsPostGradFusion(BatchPointwiseOpsFusionFactory):
 
     def fuse(self, graph: torch.fx.GraphModule, subset: list[torch.fx.Node]):
         batch_inputs, batch_others = [], []
-        alpha = subset[0].kwargs.get("alpha", DEFAULT_ALPHA)
+        # Safe because match() keys the group on str(node.kwargs): every
+        # node in the subset shares the same kwargs.
+        kwargs = subset[0].kwargs
         batch_inputs_meta, batch_others_meta = [], []
 
         for node in subset:
@@ -478,17 +480,19 @@ class BatchPointwiseMathOpsPostGradFusion(BatchPointwiseOpsFusionFactory):
             batch_op = graph.call_function(  # type: ignore[operator]
                 self.op,
                 args=(stack_inputs, stack_others),
-                kwargs={"alpha": alpha} if self.op == aten.add.Tensor else {},
+                kwargs=kwargs,
             )
-            batch_op.meta["val"] = self.op(stack_inputs_meta, stack_others_meta)
-            for i, original_add in enumerate(subset):
+            batch_op.meta["val"] = self.op(
+                stack_inputs_meta, stack_others_meta, **kwargs
+            )
+            for i, original_node in enumerate(subset):
                 with graph.inserting_after(batch_op):  # type: ignore[operator]
-                    new_add = graph.call_function(  # type: ignore[operator]
+                    new_node = graph.call_function(  # type: ignore[operator]
                         torch.ops.aten.select, args=((batch_op, 0, i))
                     )
-                original_add.replace_all_uses_with(new_add)
-                new_add.meta.update(original_add.meta)
-                graph.erase_node(original_add)  # type: ignore[operator]
+                original_node.replace_all_uses_with(new_node)
+                new_node.meta.update(original_node.meta)
+                graph.erase_node(original_node)  # type: ignore[operator]
         counters["inductor"][
             "batch_aten_" + self.op.__name__.lower().split(".")[0]
         ] += 1


### PR DESCRIPTION
Fixes #195442

### Description
In `BatchPointwiseMathOpsPostGradFusion.fuse()` (`torch/_inductor/fx_passes/group_batch_fusion.py`), `kwargs` was hardcoded to `{"alpha": alpha} if self.op == aten.add.Tensor else {}`. When `batch_aten_sub` post-grad horizontal fusion matched `aten.sub.Tensor` operations with a non-default `alpha` (e.g. `alpha=2.0`), `kwargs` defaulted to `{}` in the fused call. Consequently, the batched subtraction computed `x - y` instead of `x - alpha * y`, leading to silent numerical divergence.

This PR:
1. Passes `subset[0].kwargs` directly to `graph.call_function` in `BatchPointwiseMathOpsPostGradFusion.fuse()`.
2. Forwards `**kwargs` when evaluating `batch_op.meta["val"] = self.op(stack_inputs_meta, stack_others_meta, **kwargs)` so the fused node's metadata is computed with the same arguments it will be executed with (hygiene; `alpha` does not affect shape/dtype/device meta).
3. Keys the fusion group on `str(node.kwargs)` in `match()` (mirroring `BatchMathOpsPreGradFusion`), which guarantees the kwargs copied by `fuse()` are uniform across the subset.
4. Adds `test_pointwise_math_ops_with_alpha_fusion` and `test_batch_aten_sub_preserves_alpha` to `test/inductor/test_group_batch_fusion.py` to verify forward correctness, input gradient equivalence, and multi-group `alpha` separation.

### Test Plan
Ran local regression test:
```bash
python -m unittest test.inductor.test_group_batch_fusion.TestGroupBatchFusion.test_batch_aten_sub_preserves_alpha
```
Ran linter and formatter:
```bash
ruff check torch/_inductor/fx_passes/group_batch_fusion.py test/inductor/test_group_batch_fusion.py
ruff format --check torch/_inductor/fx_passes/group_batch_fusion.py test/inductor/test_group_batch_fusion.py
```
Verified that `batch_aten_sub` with non-default `alpha` produces exact numerical equality with eager execution.

> **AI Disclosure:** An AI coding assistant was used to assist in locating the regression and drafting the unit test. The root cause, architectural fix, and test verification were independently validated.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
