### PR TITLE
[fx] Fix autowrap_modules type annotation to tuple[ModuleType, ...]

### DIFF
--- a/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
+++ b/test/expect/TestFXAPIBackwardCompatibility.test_function_back_compat-fx_backcompat_function_signatures.expect
@@ -1,4 +1,4 @@
-torch.fx._symbolic_trace.Tracer.__init__(self, autowrap_modules: Tuple[Callable] = (<module math>,), autowrap_functions: Tuple[Callable[..., Any], ...] = (,), param_shapes_constant: bool = False) -> None
+torch.fx._symbolic_trace.Tracer.__init__(self, autowrap_modules: Tuple[types.ModuleType, ...] = (<module math>,), autowrap_functions: Tuple[Callable[..., Any], ...] = (,), param_shapes_constant: bool = False) -> None
 torch.fx._symbolic_trace.Tracer.call_module(self, m: torch.nn.modules.module.Module, forward: Callable[..., Any], args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Any
 torch.fx._symbolic_trace.Tracer.create_arg(self, a: Any) -> 'Argument'
 torch.fx._symbolic_trace.Tracer.get_fresh_qualname(self, prefix: str) -> str

--- a/test/test_fx.py
+++ b/test/test_fx.py
@@ -5330,6 +5330,7 @@ class TestFXAPIBackwardCompatibility(JitTestCase):
         None: "None",
         typing.Iterator: "Iterator",
         collections.abc.Iterator: "Iterator",
+        types.ModuleType: "types.ModuleType",
     }
 
     _UNBOUND_TYPES = {

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -302,7 +302,7 @@ class Tracer(TracerBase):
     @compatibility(is_backward_compatible=True)
     def __init__(
         self,
-        autowrap_modules: tuple[ModuleType] = (math,),
+        autowrap_modules: tuple[ModuleType, ...] = (math,),
         autowrap_functions: tuple[Callable[..., Any], ...] = (),
         param_shapes_constant: bool = False,
     ) -> None:
@@ -315,7 +315,7 @@ class Tracer(TracerBase):
 
         Args:
 
-            autowrap_modules (Tuple[ModuleType]): defaults to `(math, )`,
+            autowrap_modules (Tuple[ModuleType, ...]): defaults to `(math, )`,
                 Python modules whose functions should be wrapped automatically
                 without needing to use fx.wrap(). Backward-compatibility for
                 this parameter is guaranteed.

--- a/torch/fx/experimental/proxy_tensor.py
+++ b/torch/fx/experimental/proxy_tensor.py
@@ -1610,7 +1610,7 @@ class PythonKeyTracer(Tracer):
     enable_thunkify: bool = False
 
     def __init__(self, *, autowrap_modules: tuple[types.ModuleType, ...] = ()) -> None:
-        super().__init__(autowrap_modules=autowrap_modules)  # type: ignore[arg-type]
+        super().__init__(autowrap_modules=autowrap_modules)
         _init_proxy_trackers(self)
 
     # In general, we don't want to make modules leaves. In principle, users of


### PR DESCRIPTION
Fixes #165277

### Description
In PEP 484/585, `tuple[T]` denotes a 1-tuple containing exactly one element of type `T`, rather than a variable-length homogeneous tuple.

In `torch.fx._symbolic_trace.Tracer.__init__`, `autowrap_modules` was typed as `tuple[ModuleType]` instead of `tuple[ModuleType, ...]`, which produced typechecker errors whenever callers provided an empty tuple `()` or a multi-module tuple (for example, in `PythonKeyTracer` which previously required `# type: ignore[arg-type]`).

This patch:
1. Updates `Tracer.__init__`'s `autowrap_modules` type annotation to `tuple[ModuleType, ...]`.
2. Updates corresponding docstrings.
3. Removes the now unnecessary `# type: ignore[arg-type]` in `PythonKeyTracer.__init__` (`torch/fx/experimental/proxy_tensor.py`).
4. Adds `types.ModuleType` to `_trivial_mappings` in `TestFXAPIBackwardCompatibility` test harness and updates the expect file.

### Test Plan
- `test/test_fx.py::TestFXAPIBackwardCompatibility::test_function_back_compat`


cc @lolpack @maggiemoss @ndmitchell @kinto0 @samwgoldman