### PR TITLE
[Inductor] Reuse preallocated indexed-update workspace

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -1695,6 +1695,55 @@ class CPUReproTests(TestCase):
             torch.compile(fn)(y_clone, index0_clone, index1_clone)
             self.assertEqual(y, y_clone, atol=1e-3, rtol=1e-3)
 
+    def test_index_put_preallocated_workspace(self):
+        # https://github.com/pytorch/pytorch/issues/195330
+        def preallocated(field, indices, gain, workspace):
+            torch.index_select(field, 0, indices, out=workspace)
+            workspace.mul_(gain)
+            field.index_copy_(0, indices, workspace)
+
+        def dependent(field, indices, gain):
+            values = torch.index_select(field, 0, indices) * gain
+            field.index_copy_(0, indices, values)
+
+        field = torch.linspace(0.25, 1.25, 16, dtype=torch.float64)
+        indices = torch.tensor([2, 5, 2])
+        gain = torch.tensor([2.0, 3.0, 5.0], dtype=torch.float64)
+
+        expected_field = field.clone()
+        expected_workspace = torch.empty_like(gain)
+        preallocated(expected_field, indices, gain, expected_workspace)
+        actual_field = field.clone()
+        actual_workspace = torch.empty_like(gain)
+        with fresh_cache():
+            _, code = run_and_get_cpp_code(
+                torch.compile(preallocated, fullgraph=True, dynamic=False),
+                actual_field,
+                indices,
+                gain,
+                actual_workspace,
+            )
+        self.assertEqual(actual_field, expected_field)
+        self.assertEqual(actual_workspace, expected_workspace)
+
+        allocation = (
+            "aoti_torch_empty_strided(" if config.cpp_wrapper else "empty_strided_cpu("
+        )
+        self.assertEqual(code.count(allocation), 0)
+
+        expected_field = field.clone()
+        dependent(expected_field, indices, gain)
+        actual_field = field.clone()
+        with fresh_cache():
+            _, code = run_and_get_cpp_code(
+                torch.compile(dependent, fullgraph=True, dynamic=False),
+                actual_field,
+                indices,
+                gain,
+            )
+        self.assertEqual(actual_field, expected_field)
+        self.assertEqual(code.count(allocation), 1)
+
     def test_index_put_bool_accumulate_codegen(self):
         # https://github.com/pytorch/pytorch/issues/113692
         def fn(x, index, values):

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import (
 )
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 from torch.testing._internal.logging_utils import logs_to_string
+from torch.utils._pytree import tree_map
 
 
 aten = torch.ops.aten
@@ -255,6 +256,58 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         gm(actual_field, indices, gain, actual_workspace)
         self.assertEqual(actual_field, expected_field)
         self.assertEqual(actual_workspace, expected_workspace)
+
+    @parametrize("effect", ["none", "valid", "invalid"])
+    def test_index_put_multiple_copy_back_candidates(self, effect):
+        def f(fields, indices, gain, workspaces, other, other_indices, other_values):
+            for i in range(3):
+                gathered = aten.index.Tensor(fields[i], [indices])
+                values = aten.mul.Tensor(gathered, gain)
+                updated = aten.index_put.default(fields[i], [indices], values)
+                aten.copy_.default(fields[i], updated)
+                if i == 1 and effect != "none":
+                    other_updated = aten.index_put.default(
+                        other, [other_indices], other_values
+                    )
+                    aten.copy_.default(other, other_updated)
+                aten.copy_.default(workspaces[i], values)
+
+        args = (
+            tuple(torch.randn(8) for _ in range(3)),
+            torch.tensor([2, 5, 2]),
+            torch.tensor([2.0, 3.0, 5.0]),
+            tuple(torch.full((3,), -1.0) for _ in range(3)),
+            torch.randn(8),
+            torch.tensor([4]),
+            torch.randn(1),
+        )
+        gm = make_fx(f, tracing_mode="fake")(*tree_map(torch.clone, args))
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        reused_workspaces = sum(
+            node.args[2].target is aten.copy_.default
+            for node in gm.graph.nodes
+            if node.target is aten.index_put_.default
+        )
+        self.assertEqual(reused_workspaces, 3 if effect == "none" else 2)
+
+        expected_args = tree_map(torch.clone, args)
+        actual_args = tree_map(torch.clone, args)
+        if effect == "invalid":
+            expected_args[5].fill_(99)
+            actual_args[5].fill_(99)
+            with self.assertRaises(IndexError):
+                f(*expected_args)
+            with self.assertRaises(IndexError):
+                gm(*actual_args)
+            for workspace in actual_args[3][1:]:
+                self.assertEqual(workspace, torch.full_like(workspace, -1.0))
+        else:
+            f(*expected_args)
+            gm(*actual_args)
+        self.assertEqual(actual_args, expected_args)
 
     @parametrize("alias", ["field", "indices", "gain"])
     def test_index_put_does_not_reuse_aliasing_copy_back(self, alias):

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -220,6 +220,150 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(actual, expected)
         self.assertEqual(actual_cache, expected_cache)
 
+    def test_index_put_reuses_matching_value_copy_back(self):
+        def f(field, indices, gain, workspace):
+            gathered = aten.index.Tensor(field, [indices])
+            values = aten.mul.Tensor(gathered, gain)
+            updated = aten.index_put.default(field, [indices], values)
+            aten.copy_.default(field, updated)
+            aten.copy_.default(workspace, values)
+
+        field = torch.randn(8)
+        indices = torch.tensor([2, 5, 2])
+        gain = torch.tensor([2.0, 3.0, 5.0])
+        workspace = torch.empty(3)
+
+        gm = make_fx(f, tracing_mode="fake")(
+            field.clone(), indices, gain, workspace.clone()
+        )
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        nodes = list(gm.graph.nodes)
+        put = next(node for node in nodes if node.target is aten.index_put_.default)
+        copies = [node for node in nodes if node.target is aten.copy_.default]
+        self.assertEqual(len(copies), 1)
+        self.assertIs(put.args[2], copies[0])
+        self.assertLess(nodes.index(copies[0]), nodes.index(put))
+
+        expected_field = field.clone()
+        expected_workspace = workspace.clone()
+        f(expected_field, indices, gain, expected_workspace)
+        actual_field = field.clone()
+        actual_workspace = workspace.clone()
+        gm(actual_field, indices, gain, actual_workspace)
+        self.assertEqual(actual_field, expected_field)
+        self.assertEqual(actual_workspace, expected_workspace)
+
+    @parametrize("alias", ["field", "indices"])
+    def test_index_put_does_not_reuse_aliasing_copy_back(self, alias):
+        def f(field, indices, gain, workspace):
+            gathered = aten.index.Tensor(field, [indices])
+            values = aten.mul.Tensor(gathered, gain)
+            updated = aten.index_put.default(field, [indices], values)
+            aten.copy_.default(field, updated)
+            aten.copy_.default(workspace, values)
+
+        field = torch.arange(8)
+        indices = torch.tensor([2, 5, 2])
+        gain = torch.tensor([2, 3, 5])
+
+        traced_field = field.clone()
+        traced_indices = indices.clone()
+        traced_workspace = (
+            traced_field[:3] if alias == "field" else traced_indices.view(-1)
+        )
+        gm = make_fx(f, tracing_mode="fake")(
+            traced_field, traced_indices, gain, traced_workspace
+        )
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        nodes = list(gm.graph.nodes)
+        put = next(
+            node
+            for node in nodes
+            if node.target in (aten.index_put.default, aten.index_put_.default)
+        )
+        values = next(node for node in nodes if node.target is aten.mul.Tensor)
+        workspace_copy = next(
+            node
+            for node in nodes
+            if node.target is aten.copy_.default and node.args[1] is values
+        )
+        self.assertIsNot(put.args[2], workspace_copy)
+        self.assertLess(nodes.index(put), nodes.index(workspace_copy))
+
+        expected_field = field.clone()
+        expected_indices = indices.clone()
+        expected_workspace = (
+            expected_field[:3] if alias == "field" else expected_indices.view(-1)
+        )
+        f(expected_field, expected_indices, gain, expected_workspace)
+        actual_field = field.clone()
+        actual_indices = indices.clone()
+        actual_workspace = (
+            actual_field[:3] if alias == "field" else actual_indices.view(-1)
+        )
+        gm(actual_field, actual_indices, gain, actual_workspace)
+        self.assertEqual(actual_field, expected_field)
+        self.assertEqual(actual_indices, expected_indices)
+
+    def test_index_put_does_not_reorder_copy_back_across_mutation(self):
+        def f(field, indices, gain, other, other_indices, other_values, workspace):
+            gathered = aten.index.Tensor(field, [indices])
+            values = aten.mul.Tensor(gathered, gain)
+            updated = aten.index_put.default(field, [indices], values)
+            aten.copy_.default(field, updated)
+            other_updated = aten.index_put.default(other, [other_indices], other_values)
+            aten.copy_.default(other, other_updated)
+            aten.copy_.default(workspace, values)
+
+        field = torch.randn(8)
+        indices = torch.tensor([2, 5, 2])
+        gain = torch.randn(3)
+        other = torch.randn(8)
+        other_indices = torch.tensor([4])
+        other_values = torch.randn(1)
+        workspace = torch.full((3,), -1.0)
+
+        gm = make_fx(f, tracing_mode="fake")(
+            field.clone(),
+            indices,
+            gain,
+            other.clone(),
+            other_indices,
+            other_values,
+            workspace.clone(),
+        )
+        reinplace_inplaceable_ops_core(gm.graph)
+        gm.graph.lint()
+        gm.recompile()
+
+        nodes = list(gm.graph.nodes)
+        puts = [node for node in nodes if node.target is aten.index_put_.default]
+        workspace_copy = next(
+            node for node in nodes if node.target is aten.copy_.default
+        )
+        self.assertEqual(len(puts), 2)
+        self.assertLess(nodes.index(puts[0]), nodes.index(puts[1]))
+        self.assertLess(nodes.index(puts[1]), nodes.index(workspace_copy))
+
+        invalid_indices = torch.tensor([99])
+        with self.assertRaises(IndexError):
+            gm(
+                field.clone(),
+                indices,
+                gain,
+                other.clone(),
+                invalid_indices,
+                other_values,
+                workspace,
+            )
+        self.assertEqual(workspace, torch.full_like(workspace, -1.0))
+
     def test_counters_functionalize_old(self):
         ReinplaceCounters.clear()
 

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -256,7 +256,7 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         self.assertEqual(actual_field, expected_field)
         self.assertEqual(actual_workspace, expected_workspace)
 
-    @parametrize("alias", ["field", "indices"])
+    @parametrize("alias", ["field", "indices", "gain"])
     def test_index_put_does_not_reuse_aliasing_copy_back(self, alias):
         def f(field, indices, gain, workspace):
             gathered = aten.index.Tensor(field, [indices])
@@ -269,13 +269,19 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         indices = torch.tensor([2, 5, 2])
         gain = torch.tensor([2, 3, 5])
 
+        def aliasing_workspace(field, indices, gain):
+            if alias == "field":
+                return field[:3]
+            if alias == "indices":
+                return indices.view(-1)
+            return gain.view(-1)
+
         traced_field = field.clone()
         traced_indices = indices.clone()
-        traced_workspace = (
-            traced_field[:3] if alias == "field" else traced_indices.view(-1)
-        )
+        traced_gain = gain.clone()
+        traced_workspace = aliasing_workspace(traced_field, traced_indices, traced_gain)
         gm = make_fx(f, tracing_mode="fake")(
-            traced_field, traced_indices, gain, traced_workspace
+            traced_field, traced_indices, traced_gain, traced_workspace
         )
         reinplace_inplaceable_ops_core(gm.graph)
         gm.graph.lint()
@@ -298,18 +304,19 @@ class TestReinplacingPassCorrectness(InductorTestCase):
 
         expected_field = field.clone()
         expected_indices = indices.clone()
-        expected_workspace = (
-            expected_field[:3] if alias == "field" else expected_indices.view(-1)
+        expected_gain = gain.clone()
+        expected_workspace = aliasing_workspace(
+            expected_field, expected_indices, expected_gain
         )
-        f(expected_field, expected_indices, gain, expected_workspace)
+        f(expected_field, expected_indices, expected_gain, expected_workspace)
         actual_field = field.clone()
         actual_indices = indices.clone()
-        actual_workspace = (
-            actual_field[:3] if alias == "field" else actual_indices.view(-1)
-        )
-        gm(actual_field, actual_indices, gain, actual_workspace)
+        actual_gain = gain.clone()
+        actual_workspace = aliasing_workspace(actual_field, actual_indices, actual_gain)
+        gm(actual_field, actual_indices, actual_gain, actual_workspace)
         self.assertEqual(actual_field, expected_field)
         self.assertEqual(actual_indices, expected_indices)
+        self.assertEqual(actual_gain, expected_gain)
 
     def test_index_put_does_not_reorder_copy_back_across_mutation(self):
         def f(field, indices, gain, other, other_indices, other_values, workspace):

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -729,14 +729,18 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         ):
             return None
 
+        if len(src.users) != 2:
+            return None
         candidates = [
-            (dst, copy_node)
-            for (dst, copy_src), copy_node in copy_args_to_copy_nodes.items()
-            if copy_src is src
+            copy_node
+            for copy_node in src.users
+            if copy_node.target is aten.copy_.default
+            and copy_args_to_copy_nodes.get((copy_node.args[0], src)) is copy_node
         ]
         if len(candidates) != 1:
             return None
-        dst, copy_node = candidates[0]
+        copy_node = candidates[0]
+        dst = cast(torch.fx.Node, copy_node.args[0])
         non_blocking = (
             copy_node.args[2]
             if len(copy_node.args) > 2
@@ -746,7 +750,6 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         if (
             copy_nodes.get(dst) is not copy_node
             or node_order[copy_node] <= node_order[node]
-            or len(src.users) != 2
             or non_blocking is not False
             or not can_inplace(node, dst)
         ):
@@ -1136,12 +1139,20 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     replace_dict[copy_node] = copy_node.args[0]
 
                 node.target = inplaceable_op.inplace_op
+    surviving_node_order: dict[torch.fx.Node, int] = {}
+    if copy_back_reuses:
+        # Count surviving nodes once, before moving any copy-back nodes.
+        surviving_count = 0
+        for other in graph.nodes:
+            if other not in replace_dict:
+                surviving_count += 1
+            surviving_node_order[other] = surviving_count
+
     for node, copy_node in copy_back_reuses:
         # Do not move a mutation across nodes whose effects remain observable.
-        if copy_node in replace_dict or any(
-            node_order[node] < node_order[other] < node_order[copy_node]
-            and other not in replace_dict
-            for other in graph.nodes
+        if (
+            copy_node in replace_dict
+            or surviving_node_order[copy_node] != surviving_node_order[node] + 1
         ):
             continue
         node.update_arg(2, copy_node)

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -747,37 +747,22 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
             copy_nodes.get(dst) is not copy_node
             or node_order[copy_node] <= node_order[node]
             or len(src.users) != 2
-            or node not in src.users
-            or copy_node not in src.users
             or non_blocking is not False
-            or not _same_tensor_metadata(dst, src)
             or not can_inplace(node, dst)
         ):
             return None
 
-        dst_val = dst.meta.get("val")
-        src_val = src.meta.get("val")
-        if not (
-            isinstance(dst_val, torch.Tensor)
-            and isinstance(src_val, torch.Tensor)
-            and dst_val.dtype == src_val.dtype
-            and dst_val.device == src_val.device
-        ):
+        if not _same_tensor_metadata(dst, src):
+            return None
+        dst_val = dst.meta["val"]
+        src_val = src.meta["val"]
+        if dst_val.dtype != src_val.dtype or dst_val.device != src_val.device:
             return None
         if torch._debug_has_internal_overlap(dst_val) != 0:
             return None
 
         dst_storage = get_node_storage(dst)
         if dst_storage is None or get_node_storage(src) == dst_storage:
-            return None
-
-        other_args = pytree.tree_leaves((node.args, node.kwargs))
-        if any(
-            isinstance(arg, torch.fx.Node)
-            and arg is not src
-            and get_node_storage(arg) == dst_storage
-            for arg in other_args
-        ):
             return None
 
         pending = list(pytree.tree_leaves((src.args, src.kwargs)))

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -697,6 +697,102 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
     def all_can_inplace(node, mutated_args):
         return all(can_inplace(node, arg) for arg in mutated_args)
 
+    def copy_back_reuse_candidate(node):
+        if node.target is not aten.index_put.default:
+            return None
+
+        field, indices, src = node.args[:3]
+        accumulate = (
+            node.args[3] if len(node.args) > 3 else node.kwargs.get("accumulate", False)
+        )
+        if (
+            accumulate is not False
+            or not isinstance(field, torch.fx.Node)
+            or not isinstance(indices, (list, tuple))
+            or not isinstance(src, torch.fx.Node)
+            or src.target is not aten.mul.Tensor
+        ):
+            return None
+
+        gather = src.args[0]
+        # The matching gather checks the same indices before the copy is moved
+        # ahead of index_put, preserving mutation order when indexing fails.
+        if (
+            not isinstance(gather, torch.fx.Node)
+            or gather.target is not aten.index.Tensor
+            or len(gather.users) != 1
+            or gather.args[0] is not field
+            or not isinstance(gather.args[1], (list, tuple))
+            or len(indices) != 1
+            or len(gather.args[1]) != 1
+            or gather.args[1][0] is not indices[0]
+        ):
+            return None
+
+        candidates = [
+            (dst, copy_node)
+            for (dst, copy_src), copy_node in copy_args_to_copy_nodes.items()
+            if copy_src is src
+        ]
+        if len(candidates) != 1:
+            return None
+        dst, copy_node = candidates[0]
+        non_blocking = (
+            copy_node.args[2]
+            if len(copy_node.args) > 2
+            else copy_node.kwargs.get("non_blocking", False)
+        )
+
+        if (
+            copy_nodes.get(dst) is not copy_node
+            or node_order[copy_node] <= node_order[node]
+            or len(src.users) != 2
+            or node not in src.users
+            or copy_node not in src.users
+            or non_blocking is not False
+            or not _same_tensor_metadata(dst, src)
+            or not can_inplace(node, dst)
+        ):
+            return None
+
+        dst_val = dst.meta.get("val")
+        src_val = src.meta.get("val")
+        if not (
+            isinstance(dst_val, torch.Tensor)
+            and isinstance(src_val, torch.Tensor)
+            and dst_val.dtype == src_val.dtype
+            and dst_val.device == src_val.device
+        ):
+            return None
+        if torch._debug_has_internal_overlap(dst_val) != 0:
+            return None
+
+        dst_storage = get_node_storage(dst)
+        if dst_storage is None or get_node_storage(src) == dst_storage:
+            return None
+
+        other_args = pytree.tree_leaves((node.args, node.kwargs))
+        if any(
+            isinstance(arg, torch.fx.Node)
+            and arg is not src
+            and get_node_storage(arg) == dst_storage
+            for arg in other_args
+        ):
+            return None
+
+        pending = list(pytree.tree_leaves((src.args, src.kwargs)))
+        seen: OrderedSet[torch.fx.Node] = OrderedSet()
+        while pending:
+            arg = pending.pop()
+            if not isinstance(arg, torch.fx.Node) or arg in seen:
+                continue
+            seen.add(arg)
+            if get_node_storage(arg) == dst_storage:
+                return None
+            pending.extend(pytree.tree_leaves((arg.args, arg.kwargs)))
+
+        return node, copy_node
+
     def log_inplace_results(
         node_name,
         old_tensors_to_clone,
@@ -742,6 +838,7 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         ReinplaceCounters.add_missed_bytes(trigger, missed_bytes)
 
     replace_dict: dict[torch.fx.Node, torch.fx.Node] = {}
+    copy_back_reuses: list[tuple[torch.fx.Node, torch.fx.Node]] = []
 
     def reinplace_and_refine_tensors_to_clone(
         old_tensors_to_clone, kwargs, node_name, trigger
@@ -826,6 +923,8 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     copy_node = copy_node_for_reinplaced_arg(node, mutated_arg)
                     if copy_node is not None:
                         replace_dict[copy_node] = copy_node.args[0]
+                if candidate := copy_back_reuse_candidate(node):
+                    copy_back_reuses.append(candidate)
                 node.target = inplaceable_op.inplace_op
         elif node.target is torch.ops.higher_order.auto_functionalized_v2:
             _mutable_op = node.args[0]
@@ -1052,6 +1151,17 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     replace_dict[copy_node] = copy_node.args[0]
 
                 node.target = inplaceable_op.inplace_op
+    for node, copy_node in copy_back_reuses:
+        # Do not move a mutation across nodes whose effects remain observable.
+        if copy_node in replace_dict or any(
+            node_order[node] < node_order[other] < node_order[copy_node]
+            and other not in replace_dict
+            for other in graph.nodes
+        ):
+            continue
+        node.update_arg(2, copy_node)
+        node.prepend(copy_node)
+
     for node, replacement in replace_dict.items():
         while replacement in replace_dict:
             replacement = replace_dict[replacement]


### PR DESCRIPTION
## Human commentary

I am opening this as a draft only. The contained AI-assisted analysis below is relevant because it documents both the allocation improvement for #195330 and a known correctness dependency that must be resolved before this PR can be marked ready for review.

> **AI assistance disclosure**
>
> Codex assisted with the implementation, generated-code inspection, regression testing, and the technical analysis below. This PR must not be merged in its current state.
>
> ## Status
>
> **Blocked by #185891 — do not merge.**
>
> AOTAutograd currently does not guard a transition from disjoint input storages to overlapping views in this case. This branch relies on that relationship when reusing the caller-provided workspace.
>
> After #185891 lands, this branch will be rebased and extended with a cross-call overlap regression before being marked ready.
>
> ## Summary
>
> Fixes #195330.
>
> Functionalization converts the preallocated update into functional values followed by copy-back epilogues. After `index_put` is reinplaced onto `field`, Inductor still allocates a temporary for the indexed values and later copies those values into the caller-provided workspace.
>
> This change recognizes the narrow non-accumulating pattern:
>
> ```text
> index(field, indices)
> -> mul(gain)
> -> index_put(field, indices, values)
> -> copy_(workspace, values)
> ```
>
> When the copy-back destination has compatible metadata and is known not to alias the value dependencies, the pass moves that copy immediately before the reinplaced `index_put` and makes `index_put` consume the copy result. The indexed snapshot is therefore realized directly into the supplied workspace.
>
> The transformation remains conservative around:
>
> - field, index, and gain storage aliasing;
> - internal overlap;
> - dtype, device, and layout differences;
> - accumulating indexed updates;
> - additional value users;
> - non-blocking copies;
> - surviving operations between the indexed update and workspace copy-back.
>
> ## Performance result
>
> The original CPU allocation reproducer changes from:
>
> ```text
> {
>     "independent": {},
>     "dependent": {792: 5},
>     "preallocated": {792: 5},
> }
> ```
>
> to:
>
> ```text
> {
>     "independent": {},
>     "dependent": {792: 5},
>     "preallocated": {},
> }
> ```
>
> The generated preallocated path has one kernel with two loops:
>
> 1. gather and multiply directly into `workspace`;
> 2. scatter from `workspace` into `field`.
>
> The direct dependent form retains its temporary because it is required for duplicate-index snapshot semantics.
>
> ## Blocking correctness dependency
>
> The same post-grad graph can also come from a valid explicit final-copy program:
>
> ```python
> values = torch.index_select(field, 0, indices) * gain
> field.index_copy_(0, indices, values)
> workspace.copy_(values)
> ```
>
> If it is compiled with disjoint `gain` and `workspace`, then invoked with shifted overlapping views:
>
> ```python
> gain = backing[:-1]
> workspace = backing[1:]
> ```
>
> current main retains the temporary and matches eager. This branch removes the temporary, does not recompile, and produces incorrect `field` and backing-storage values because workspace writes overwrite gain values needed by a later vectorized chunk.
>
> PR #185891 adds the required storage-overlap partition guard. A changed overlap relationship should then fail the guard and trigger recompilation, allowing the alias-aware graph to retain the safe path.
>
> ## Design and complexity assessment
>
> This is intentionally limited to the non-accumulating `index -> mul -> index_put -> copy_` pattern. Matching the same gather and indices establishes the indexed read before advancing the workspace mutation. Metadata, storage-alias, source-dependency, and intervening-effect checks remain part of the safety conditions.
>
> Candidate discovery examines the value node's two users instead of scanning every copy-back entry. Both copy-back mapping identity checks are retained. This lookup is `O(1)` per candidate.
>
> Deferred validation computes surviving-node counts once, before any copy is moved. With `N` graph nodes and `C` candidates, this stage takes `O(N + C)` time and `O(N)` additional space instead of a full graph scan per candidate. This does not make the entire reinplace pass linear: candidate-specific dependency and alias analysis remain.
>
> The matcher remains narrow. Generic output-buffer reuse is not a drop-in replacement for the snapshot and mutation-order guarantees required here.
>
> ## Validation completed
>
> The following focused CPU tests passed on the rebased branch, before the final typing-only cast:
>
> ```bash
> .venv/bin/python -m pytest test/inductor/test_inplacing_pass.py -k test_index_put -q
> # 8 passed, 28 deselected
>
> .venv/bin/python test/run_test.py -i inductor/test_cpu_repro -k test_index_put_preallocated_workspace
> # 1 passed, 811 deselected
> ```
>
> The reinplace selection covers multiple reuse candidates, intervening operations, and mutation ordering when an intervening operation raises, alongside the existing positive and known-alias negative cases. The CPU workspace regression checks generated allocation calls and eager/compiled results.
>
> Final `lintrunner -a` and `git diff --check`: passed. The last change was a typing-only cast; runtime tests were not rerun for it.
>
> Earlier validation established the allocation histogram above and duplicate-index equality. The runtime allocation measurements were not repeated for this cleanup.
>
> GPU validation remains outstanding in the local CPU-only build.
>
> ## Before marking ready
>
> - [ ] Wait for #185891 to merge
> - [ ] Rebase onto current `main`
> - [ ] Add a disjoint-first-call → shifted-overlap-second-call regression
> - [ ] Assert that the overlap change recompiles and matches eager
> - [x] Remove the per-candidate scan over all copy-back entries
> - [x] Avoid scanning the full graph separately for every reuse candidate
> - [ ] Rename or document the matcher so its exact `index_put` scope is explicit
> - [ ] Confirm that reinplacing is the appropriate ownership point instead of generic output-buffer reuse
> - [ ] Re-run the allocation reproducer and focused test suites
> - [ ] Run applicable CI/GPU coverage
> - [ ] Squash the cleanup commit and update the final commit message
>
> Related: #139789, #185891, #195330


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo

