### PR TITLE
Enable flake8-bugbear B028: add explicit stacklevel to warnings.warn

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,7 +12,7 @@ ignore =
     # to line this up with executable bit
     EXE001,
     # these ignores are from flake8-bugbear; please fix!
-    B007,B008,B017,B019,B023,B028,B903,B905,B906,B907,B908,B910,
+    B007,B008,B017,B019,B023,B903,B905,B906,B907,B908,B910,
     # these ignores are from flake8-simplify. please fix or ignore with commented reason
     SIM105,SIM108,SIM110,SIM111,SIM113,SIM114,SIM115,SIM116,SIM117,SIM118,SIM119,SIM12,
     # SIM104 is already covered by pyupgrade ruff

--- a/.github/scripts/filter_test_configs.py
+++ b/.github/scripts/filter_test_configs.py
@@ -121,7 +121,7 @@ def get_pr_info(pr_number: int) -> dict[str, Any]:
     )
 
     if not json_response:
-        warnings.warn(f"Failed to get the labels for #{pr_number}")
+        warnings.warn(f"Failed to get the labels for #{pr_number}", stacklevel=2)
         return {}
 
     return json_response
@@ -332,7 +332,7 @@ def process_jobs(
         # it into its two components first
         current_platform, _ = (n.strip() for n in job_name.split(JOB_NAME_SEP, 1) if n)
     except ValueError:
-        warnings.warn(f"Invalid job name {job_name}, returning")
+        warnings.warn(f"Invalid job name {job_name}, returning", stacklevel=2)
         return test_matrix
 
     for record in download_json(url=url, headers={}).values():
@@ -433,7 +433,8 @@ def process_jobs(
         else:
             warnings.warn(
                 f"Found a matching {issue_type.value} issue {target_url} for {workflow} / {job_name}, "
-                + f"but the name {target_job_cfg} is invalid"
+                + f"but the name {target_job_cfg} is invalid",
+                stacklevel=2,
             )
 
     # Found no matching target, return the same input test matrix
@@ -447,9 +448,11 @@ def download_json(url: str, headers: dict[str, str], num_retries: int = 3) -> An
             content = urlopen(req, timeout=5).read().decode("utf-8")
             return json.loads(content)
         except Exception as e:
-            warnings.warn(f"Could not download {url}: {e}")
+            warnings.warn(f"Could not download {url}: {e}", stacklevel=2)
 
-    warnings.warn(f"All {num_retries} retries exhausted, downloading {url} failed")
+    warnings.warn(
+        f"All {num_retries} retries exhausted, downloading {url} failed", stacklevel=2
+    )
     return {}
 
 
@@ -489,7 +492,7 @@ def get_reenabled_issues(pr_body: str = "") -> list[str]:
             timeout=60,
         ).decode("utf-8")
     except Exception as e:
-        warnings.warn(f"failed to get commit messages: {e}")
+        warnings.warn(f"failed to get commit messages: {e}", stacklevel=2)
         commit_messages = ""
     return parse_reenabled_issues(pr_body) + parse_reenabled_issues(commit_messages)
 
@@ -593,7 +596,9 @@ def main() -> None:
     test_matrix = yaml.safe_load(args.test_matrix)
 
     if test_matrix is None:
-        warnings.warn(f"Invalid test matrix input '{args.test_matrix}', exiting")
+        warnings.warn(
+            f"Invalid test matrix input '{args.test_matrix}', exiting", stacklevel=2
+        )
         # We handle invalid test matrix gracefully by marking it as empty
         set_output("is-test-matrix-empty", True)
         sys.exit(0)

--- a/.github/scripts/github_utils.py
+++ b/.github/scripts/github_utils.py
@@ -231,10 +231,13 @@ def gh_fetch_merge_base(org: str, repo: str, base: str, head: str) -> str:
             merge_base = json_data.get("merge_base_commit", {}).get("sha", "")
         else:
             warnings.warn(
-                f"Failed to get merge base for {base}...{head}: Empty response"
+                f"Failed to get merge base for {base}...{head}: Empty response",
+                stacklevel=2,
             )
     except Exception as error:
-        warnings.warn(f"Failed to get merge base for {base}...{head}: {error}")
+        warnings.warn(
+            f"Failed to get merge base for {base}...{head}: {error}", stacklevel=2
+        )
 
     return merge_base
 
@@ -248,7 +251,8 @@ def gh_update_pr_state(org: str, repo: str, pr_num: int, state: str = "open") ->
         # has been deleted and the API couldn't re-open it
         if err.code == 422 and state == "open":
             warnings.warn(
-                f"Failed to open {pr_num} because its head branch has been deleted: {err}"
+                f"Failed to open {pr_num} because its head branch has been deleted: {err}",
+                stacklevel=2,
             )
         else:
             raise

--- a/.github/scripts/trymerge.py
+++ b/.github/scripts/trymerge.py
@@ -550,7 +550,7 @@ def gh_get_team_members(org: str, name: str) -> list[str]:
         )
         team = query["data"]["organization"]["team"]
         if team is None:
-            warn(f"Requested non-existing team {org}/{name}")
+            warn(f"Requested non-existing team {org}/{name}", stacklevel=2)
             return []
         team_members = team["members"]
         rc += [member["login"] for member in team_members["nodes"]]
@@ -639,7 +639,10 @@ def add_workflow_conclusions(
             while checkruns is not None:
                 for checkrun_node in checkruns["nodes"]:
                     if not isinstance(checkrun_node, dict):
-                        warn(f"Expected dictionary, but got {type(checkrun_node)}")
+                        warn(
+                            f"Expected dictionary, but got {type(checkrun_node)}",
+                            stacklevel=2,
+                        )
                         continue
                     checkrun_name = f"{get_check_run_name_prefix(workflow_run)}{checkrun_node['name']}"
                     existing_checkrun = workflow_obj.jobs.get(checkrun_name)
@@ -2518,7 +2521,7 @@ def get_classifications(
             print(f"From Dr.CI checkrun summary: {drci_summary}")
             drci_classifications = json.loads(str(drci_summary))
         except json.JSONDecodeError:
-            warn("Invalid Dr.CI checkrun summary")
+            warn("Invalid Dr.CI checkrun summary", stacklevel=2)
             drci_classifications = {}
 
     checks_with_classifications = checks.copy()
@@ -2905,7 +2908,8 @@ def categorize_checks(
                 if ok_failed_checks_threshold is not None
                 and len(flaky_or_broken_trunk) > ok_failed_checks_threshold
                 else ""
-            )
+            ),
+            stacklevel=2,
         )
 
     if (

--- a/benchmarks/fastrnns/custom_lstms.py
+++ b/benchmarks/fastrnns/custom_lstms.py
@@ -370,7 +370,8 @@ class StackedLSTMWithDropout(jit.ScriptModule):
             warnings.warn(
                 "dropout lstm adds dropout layers after all but last "
                 "recurrent layer, it expects num_layers greater than "
-                "1, but got num_layers = 1"
+                "1, but got num_layers = 1",
+                stacklevel=2,
             )
 
         self.dropout_layer = nn.Dropout(0.4)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ try:
 except ImportError:
     import warnings
 
-    warnings.warn('unable to load "torchvision" package')
+    warnings.warn('unable to load "torchvision" package', stacklevel=2)
 
 RELEASE = os.environ.get("RELEASE", False)
 

--- a/functorch/einops/_parsing.py
+++ b/functorch/einops/_parsing.py
@@ -185,11 +185,13 @@ class ParsedExpression:
                 warnings.warn(
                     f"It is discouraged to use axes names that are keywords: {name}",
                     RuntimeWarning,
+                    stacklevel=2,
                 )
             if name == "axis":
                 warnings.warn(
                     "It is discouraged to use 'axis' as an axis name and will raise an error in future",
                     FutureWarning,
+                    stacklevel=2,
                 )
             return True, ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -478,7 +478,6 @@ ignore = [
     "B007", "B008", "B017",
     "B018", # Useless expression
     "B023",
-    "B028", # No explicit `stacklevel` keyword argument found
     "E402",
     "C408", # C408 ignored because we like the dict keyword argument syntax
     "E501", # E501 is not flexible enough, we're using B950 instead

--- a/scripts/compile_tests/common.py
+++ b/scripts/compile_tests/common.py
@@ -13,7 +13,8 @@ except ImportError:
 
     parse = ET.parse
     warnings.warn(
-        "lxml was not found. `pip install lxml` to make this script run much faster"
+        "lxml was not found. `pip install lxml` to make this script run much faster",
+        stacklevel=2,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,11 @@ def main() -> int:
     replacement = FORWARDS.get(command)
     if replacement is None:
         raise SystemExit(f"error: {notice}")
-    warnings.warn(notice, DeprecationWarning)
+    warnings.warn(notice, DeprecationWarning, stacklevel=2)
     if len(sys.argv) > 2:
-        warnings.warn(f"ignoring extra arguments: {shlex.join(sys.argv[2:])}")
+        warnings.warn(
+            f"ignoring extra arguments: {shlex.join(sys.argv[2:])}", stacklevel=2
+        )
     print(f"Forwarding to `{shlex.join(replacement)}`.", file=sys.stderr)
     return subprocess.run(replacement).returncode
 

--- a/test/cpp_api_parity/utils.py
+++ b/test/cpp_api_parity/utils.py
@@ -398,5 +398,6 @@ def try_remove_folder(folder_path):
             shutil.rmtree(folder_path)
         except Exception as e:
             warnings.warn(
-                f"Non-blocking folder removal fails with the following error:\n{str(e)}"
+                f"Non-blocking folder removal fails with the following error:\n{str(e)}",
+                stacklevel=2,
             )

--- a/test/dynamo/test_dynamic_shapes.py
+++ b/test/dynamo/test_dynamic_shapes.py
@@ -102,7 +102,8 @@ if __name__ == "__main__":
     if not TEST_Z3:
         warnings.warn(
             "translation validation is off. "
-            "Testing with translation validation requires Z3."
+            "Testing with translation validation requires Z3.",
+            stacklevel=2,
         )
 
     run_tests()

--- a/test/dynamo/test_error_messages.py
+++ b/test/dynamo/test_error_messages.py
@@ -527,7 +527,7 @@ from user code:
 
     def test_warnings(self):
         def fn():
-            warnings.warn("test")
+            warnings.warn("test", stacklevel=2)
 
         self.assertExpectedInlineMunged(
             Unsupported,

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -3792,7 +3792,7 @@ class FuncTorchHigherOrderOpTests(torch._dynamo.test_case.TestCase):
                         "Interpreter stack is not empty. Test should have called "
                         "'torch._C._functorch._vmap_decrement_nesting()'"
                     )
-                    warnings.warn(msg)
+                    warnings.warn(msg, stacklevel=2)
         finally:
             super().tearDown()
 

--- a/test/dynamo/test_reorder_logs.py
+++ b/test/dynamo/test_reorder_logs.py
@@ -277,9 +277,9 @@ class ReorderLogsTests(torch._dynamo.test_case.TestCase):
 
         def f(x):
             x1 = x + x
-            warnings.warn("moo")
+            warnings.warn("moo", stacklevel=2)
             x2 = x1 * x1
-            warnings.warn(f"{x2}")
+            warnings.warn(f"{x2}", stacklevel=2)
             x3 = x2 + x2
             return x3
 

--- a/test/dynamo/test_repros.py
+++ b/test/dynamo/test_repros.py
@@ -9578,7 +9578,7 @@ class ReproTestsDevice(torch._dynamo.test_case.TestCase):
         x = torch.ones(2, 2, requires_grad=True)
 
         def call_foobar(x):
-            warnings.warn("foobar")
+            warnings.warn("foobar", stacklevel=2)
 
         @torch.compile(backend="eager")
         def f(x):

--- a/test/functorch/test_aotdispatch.py
+++ b/test/functorch/test_aotdispatch.py
@@ -133,6 +133,7 @@ except ImportError:
         "to install it with commands from pytorch.org, post-fixed with "
         "`--no-deps` to avoid overwriting the pytorch installation",
         UserWarning,
+        stacklevel=2,
     )
 
 USE_NETWORKX = False
@@ -141,7 +142,9 @@ try:
 
     USE_NETWORKX = True
 except ImportError:
-    warnings.warn("Some tests use networkx but it was not installed", UserWarning)
+    warnings.warn(
+        "Some tests use networkx but it was not installed", UserWarning, stacklevel=2
+    )
 
 # NB: numpy is a testing dependency!
 

--- a/test/functorch/test_eager_transforms.py
+++ b/test/functorch/test_eager_transforms.py
@@ -91,6 +91,7 @@ except ImportError:
         "to install it with commands from pytorch.org, post-fixed with "
         "`--no-deps` to avoid overwriting the pytorch installation",
         UserWarning,
+        stacklevel=2,
     )
 
 
@@ -155,7 +156,7 @@ class VmapTearDownMixin:
                 "Interpreter stack is not empty. Test should have called "
                 "'torch._C._functorch._vmap_decrement_nesting()'"
             )
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
 
 @markDynamoStrictTest

--- a/test/jit/test_warn.py
+++ b/test/jit/test_warn.py
@@ -21,7 +21,7 @@ class TestWarn(JitTestCase):
     def test_warn(self):
         @torch.jit.script
         def fn():
-            warnings.warn("I am warning you")
+            warnings.warn("I am warning you", stacklevel=2)
 
         f = io.StringIO()
         with redirect_stderr(f):
@@ -35,7 +35,7 @@ class TestWarn(JitTestCase):
         @torch.jit.script
         def fn():
             for _ in range(10):
-                warnings.warn("I am warning you")
+                warnings.warn("I am warning you", stacklevel=2)
 
         f = io.StringIO()
         with redirect_stderr(f):
@@ -47,7 +47,7 @@ class TestWarn(JitTestCase):
 
     def test_warn_only_once_in_loop_func(self):
         def w():
-            warnings.warn("I am warning you")
+            warnings.warn("I am warning you", stacklevel=2)
 
         @torch.jit.script
         def fn():
@@ -64,10 +64,10 @@ class TestWarn(JitTestCase):
 
     def test_warn_once_per_func(self):
         def w1():
-            warnings.warn("I am warning you")
+            warnings.warn("I am warning you", stacklevel=2)
 
         def w2():
-            warnings.warn("I am warning you")
+            warnings.warn("I am warning you", stacklevel=2)
 
         @torch.jit.script
         def fn():
@@ -84,10 +84,10 @@ class TestWarn(JitTestCase):
 
     def test_warn_once_per_func_in_loop(self):
         def w1():
-            warnings.warn("I am warning you")
+            warnings.warn("I am warning you", stacklevel=2)
 
         def w2():
-            warnings.warn("I am warning you")
+            warnings.warn("I am warning you", stacklevel=2)
 
         @torch.jit.script
         def fn():
@@ -106,7 +106,7 @@ class TestWarn(JitTestCase):
     def test_warn_multiple_calls_multiple_warnings(self):
         @torch.jit.script
         def fn():
-            warnings.warn("I am warning you")
+            warnings.warn("I am warning you", stacklevel=2)
 
         f = io.StringIO()
         with redirect_stderr(f):
@@ -119,7 +119,7 @@ class TestWarn(JitTestCase):
 
     def test_warn_multiple_calls_same_func_diff_stack(self):
         def warn(caller: str):
-            warnings.warn("I am warning you from " + caller)
+            warnings.warn("I am warning you from " + caller, stacklevel=2)
 
         @torch.jit.script
         def foo():

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -11673,7 +11673,7 @@ for shape in [(1,), ()]:
         #  - test_saved_variable_packing_unpacking_saved_original_with_hooks
 
         def pack(x):
-            warnings.warn("pack")
+            warnings.warn("pack", stacklevel=2)
             return x
 
         with torch.autograd.graph.saved_tensors_hooks(pack, lambda x: x):
@@ -16340,7 +16340,7 @@ class TestMultithreadAutograd(TestCase):
 
     def test_dataparallel_saved_tensors_hooks(self):
         def pack(x):
-            warnings.warn("pack")
+            warnings.warn("pack", stacklevel=2)
             return x
 
         _self = self

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -80,7 +80,7 @@ except ModuleNotFoundError:
     if IS_CI:
         raise ModuleNotFoundError(err_msg) from None
     else:
-        warnings.warn(err_msg)
+        warnings.warn(err_msg, stacklevel=2)
 
 
 try:

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -284,7 +284,8 @@ class TestIterableDataPipeBasic(TestCase):
             self.temp_dir.cleanup()
         except Exception as e:
             warnings.warn(
-                f"TestIterableDatasetBasic was not able to cleanup temp dir due to {str(e)}"
+                f"TestIterableDatasetBasic was not able to cleanup temp dir due to {str(e)}",
+                stacklevel=2,
             )
 
     def test_listdirfiles_iterable_datapipe(self):

--- a/test/test_jit.py
+++ b/test/test_jit.py
@@ -2799,13 +2799,13 @@ graph(%Ra, %Rb):
 
         def fn(x):
             if bool(x < 2):
-                warnings.warn("x is less than 2")
+                warnings.warn("x is less than 2", stacklevel=2)
             return x
 
         class M(torch.nn.Module):
             def forward(self, x):
                 if bool(x < 2):
-                    warnings.warn("x is less than 2")
+                    warnings.warn("x is less than 2", stacklevel=2)
                 return x
 
 
@@ -2830,7 +2830,7 @@ graph(%Ra, %Rb):
 
         def fn(x):
             if bool(x > 0):
-                warnings.warn('This should NOT be printed')
+                warnings.warn('This should NOT be printed', stacklevel=2)
                 x += 1
             return x
 

--- a/test/test_jit_fuser.py
+++ b/test/test_jit_fuser.py
@@ -805,7 +805,8 @@ class TestFuser(JitTestCase):
             if 'Failed to compile' in e.args[0]:
                 warnings.warn('CPU fuser test has failed! This is not a hard failure, '  # noqa: F821
                               'because the kernels sometimes trigger bugs in compilers '
-                              '(most notably GCC 7.2).')
+                              '(most notably GCC 7.2).',
+                              stacklevel=2)
                 raise unittest.SkipTest('Failed to compile') from e
             else:
                 raise

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -161,7 +161,7 @@ class MpsMemoryLeakCheck:
                    f"Caching allocator allocated memory was {self.caching_allocator_before} "
                    f"and is now reported as {caching_allocator_mem_allocated}. "
                    f"MPS driver allocated memory was {self.driver_before} and is now {driver_mem_allocated}.")
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
         elif caching_allocator_discrepancy and driver_discrepancy:
             # A caching allocator discrepancy validated by the driver API is a failure
             msg = (f"MPS driver API confirmed a leak in {self.name}! "

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -702,7 +702,7 @@ class TestCommon(TestCase):
         # Reports numerical accuracy discrepancies
         if ex is not None:
             msg = "Test passed because the reference was more accurate than the torch operator."
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
 
     # Tests that experimental Python References perform the same computation
     # as the operators they reference, when operator calls in the torch

--- a/test/test_proxy_tensor.py
+++ b/test/test_proxy_tensor.py
@@ -104,7 +104,8 @@ except ImportError:
     warnings.warn("Couldn't import torchvision. Some of our tests use it, try "
                   "to install it with commands from pytorch.org, post-fixed with "
                   "`--no-deps` to avoid overwriting the pytorch installation",
-                  UserWarning)
+                  UserWarning,
+                  stacklevel=2)
 
 
 def _create_new_input(x):

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -2897,7 +2897,7 @@ class TestSparseCSR(TestCase):
             a = sample.args[0].relu().to_sparse_csr()
             if sample.args[0].shape == sample.args[1].shape:
                 import warnings
-                warnings.warn("Broken for square matrices, see https://github.com/pytorch/pytorch/issues/116565")
+                warnings.warn("Broken for square matrices, see https://github.com/pytorch/pytorch/issues/116565", stacklevel=2)
                 continue
 
             # This path tests the autograd path wrt dense inputs

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -913,7 +913,8 @@ class TestTorchDeviceType(TestCase):
 
         # Checks jitted Python warning
         def warn_fn():
-            warnings.warn("Warning!")
+            # stacklevel=1 so warning.lineno points at this line, as asserted below
+            warnings.warn("Warning!", stacklevel=1)
 
         # The jit mimics an eager-mode Python warning in this case
         with warnings.catch_warnings(record=True) as w:

--- a/tools/dynamo/verify_dynamo.py
+++ b/tools/dynamo/verify_dynamo.py
@@ -93,20 +93,23 @@ def check_cuda():
     if cuda_ver != torch_cuda_ver:
         # raise VerifyDynamoError(
         warnings.warn(
-            f"CUDA version mismatch, `torch` version: {torch_cuda_ver}, env version: {cuda_ver}"
+            f"CUDA version mismatch, `torch` version: {torch_cuda_ver}, env version: {cuda_ver}",
+            stacklevel=2,
         )
 
     if torch_cuda_ver < MIN_CUDA_VERSION:
         # raise VerifyDynamoError(
         warnings.warn(
             f"(`torch`) CUDA version not supported: {torch_cuda_ver} "
-            f"- minimum requirement: {MIN_CUDA_VERSION}"
+            f"- minimum requirement: {MIN_CUDA_VERSION}",
+            stacklevel=2,
         )
     if cuda_ver < MIN_CUDA_VERSION:
         # raise VerifyDynamoError(
         warnings.warn(
             f"(env) CUDA version not supported: {cuda_ver} "
-            f"- minimum requirement: {MIN_CUDA_VERSION}"
+            f"- minimum requirement: {MIN_CUDA_VERSION}",
+            stacklevel=2,
         )
 
     return cuda_ver if torch.version.hip is None else "None"
@@ -126,17 +129,20 @@ def check_rocm():
     rocm_ver = get_rocm_version()
     if rocm_ver != torch_rocm_ver:
         warnings.warn(
-            f"ROCm version mismatch, `torch` version: {torch_rocm_ver}, env version: {rocm_ver}"
+            f"ROCm version mismatch, `torch` version: {torch_rocm_ver}, env version: {rocm_ver}",
+            stacklevel=2,
         )
     if torch_rocm_ver < MIN_ROCM_VERSION:
         warnings.warn(
             f"(`torch`) ROCm version not supported: {torch_rocm_ver} "
-            f"- minimum requirement: {MIN_ROCM_VERSION}"
+            f"- minimum requirement: {MIN_ROCM_VERSION}",
+            stacklevel=2,
         )
     if rocm_ver < MIN_ROCM_VERSION:
         warnings.warn(
             f"(env) ROCm version not supported: {rocm_ver} "
-            f"- minimum requirement: {MIN_ROCM_VERSION}"
+            f"- minimum requirement: {MIN_ROCM_VERSION}",
+            stacklevel=2,
         )
 
     return rocm_ver if torch.version.hip else "None"
@@ -217,7 +223,7 @@ def main() -> None:
     )
     for args in _SANITY_CHECK_ARGS:
         if sys.version_info >= (3, 15):
-            warnings.warn("Dynamo not yet supported in Python 3.15.")
+            warnings.warn("Dynamo not yet supported in Python 3.15.", stacklevel=2)
         check_dynamo(*args)
     print("All required checks passed")
 

--- a/tools/pyi/gen_pyi.py
+++ b/tools/pyi/gen_pyi.py
@@ -1002,7 +1002,8 @@ def gather_docstrs() -> dict[str, str]:
         except ModuleNotFoundError:
             # Gracefully fail if these modules are not importable
             warn(
-                "Failed to import _torch_docs/_tensor_docs, skipping docstring in pyi files."
+                "Failed to import _torch_docs/_tensor_docs, skipping docstring in pyi files.",
+                stacklevel=2,
             )
 
     return docstrs

--- a/tools/stats/upload_metrics.py
+++ b/tools/stats/upload_metrics.py
@@ -137,7 +137,7 @@ def emit_metric(
             **{m.name: m.value() for m in env_var_metrics if m.value()},
         }
     except ValueError as e:
-        warn(f"Not emitting metrics for {metric_name}. {e}")
+        warn(f"Not emitting metrics for {metric_name}. {e}", stacklevel=2)
         return
 
     # Prefix key with metric name and timestamp to derisk chance of a uuid1 name collision
@@ -153,7 +153,7 @@ def emit_metric(
         except Exception as e:
             # We don't want to fail the job if we can't upload the metric.
             # We still raise the ValueErrors outside this try block since those indicate improperly configured metrics
-            warn(f"Error uploading metric {metric_name} to DynamoDB: {e}")
+            warn(f"Error uploading metric {metric_name} to DynamoDB: {e}", stacklevel=2)
             return
     else:
         print(f"Not emitting metrics for {metric_name}. Boto wasn't imported.")

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -118,6 +118,7 @@ class FakeBackwardCFunction:
             warnings.warn(
                 "'saved_variables' is deprecated; use 'saved_tensors'",
                 DeprecationWarning,
+                stacklevel=2,
             )
             return self.saved_tensors
 

--- a/torch/_dynamo/graph_id_filter.py
+++ b/torch/_dynamo/graph_id_filter.py
@@ -415,6 +415,7 @@ def _create_dynamo_config_router(config_str: str) -> GraphConfigRouter:
             "keyed by frame ID. Some dynamo configs can affect graph breaks, "
             "which may alter the number of frames and shift frame IDs, causing "
             "overrides to target the wrong graphs.",
+            stacklevel=2,
         )
     return router
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -1496,6 +1496,7 @@ class GuardBuilder(GuardBuilderBase):
             warnings.warn(
                 "Guards may run slower on Python 3.13.0. Consider upgrading to Python 3.13.1+.",
                 RuntimeWarning,
+                stacklevel=2,
             )
             return None
         return example_value

--- a/torch/_dynamo/output_graph.py
+++ b/torch/_dynamo/output_graph.py
@@ -2469,7 +2469,8 @@ class OutputGraph(OutputGraphCommon):
                 if torch._dynamo.config.side_effect_replay_policy == "warn":
                     warnings.warn(
                         f"While compiling, we found certain side effects happened in the model.forward. "
-                        f"Here are the list of potential sources you can double check: {side_effect_refs}"
+                        f"Here are the list of potential sources you can double check: {side_effect_refs}",
+                        stacklevel=2,
                     )
                 else:
                     raise RuntimeError(

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2417,6 +2417,7 @@ class CondHigherOrderVariable(TorchHigherOrderOperatorVariable):
                 "Pred is a Python constant. When used with torch.cond, it specializes on one of the branches."
                 " If you want torch.cond to preserve two branches, please make the predicate a boolean tensor or a SymBool.",
                 UserWarning,
+                stacklevel=2,
             )
             if pred.as_python_constant():
                 return true_fn.call_function(tx, unpack_iterable(tx, operands), {})
@@ -2643,6 +2644,7 @@ class SwitchHigherOrderVariable(TorchHigherOrderOperatorVariable):
                 "Index is a Python constant. When used with torch.switch, it specializes on one of the branches."
                 " If you want torch.switch to preserve the branches, please make the index a tensor or SymInt.",
                 UserWarning,
+                stacklevel=2,
             )
             idx = index.as_python_constant()
             branch_fns = branches.unpack_var_sequence(tx)

--- a/torch/_functorch/partitioners.py
+++ b/torch/_functorch/partitioners.py
@@ -1669,7 +1669,8 @@ def default_partition(
             # eventually flip the switch to make this a hard error.
             warnings.warn(
                 "Trying to unsafely apply AC to a non-functional graph with the "
-                "default partitioner. Falling back to min-cut partitioner."
+                "default partitioner. Falling back to min-cut partitioner.",
+                stacklevel=2,
             )
             return min_cut_rematerialization_partition(
                 joint_module,

--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -400,14 +400,16 @@ class TuningProcessPool:
         except TimeoutError:
             warnings.warn(
                 f"Timed out benchmarking choice '{choice}'. It will be ignored. "
-                "Please debug the root cause in case the choice can bring perf gains."
+                "Please debug the root cause in case the choice can bring perf gains.",
+                stacklevel=2,
             )
             # Set to INF so this choice will be ignored
             return float("inf")
         except Exception as process_exception:
             warnings.warn(
                 f"Failed to benchmark choice '{choice}'. It will be ignored. "
-                "Please debug the root cause in case the choice can bring perf gains."
+                "Please debug the root cause in case the choice can bring perf gains.",
+                stacklevel=2,
             )
             # Sticky CUDA errors corrupt the context, making it unrecoverable.
             # The process must be restarted to restore CUDA functionality.

--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -826,7 +826,8 @@ class FxGraphCachePickler(pickle.Pickler):
         if elapsed > 1.0:
             warnings.warn(
                 f"FX graph cache copying of a large constant took {elapsed:.1}s. "
-                "Please file an issue."
+                "Please file an issue.",
+                stacklevel=2,
             )
 
         return (_ident, (TensorMetadataAndValues(metadata, values),))

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -4113,7 +4113,10 @@ def get_loop_body_lowp_fp(_body: LoopBody) -> tuple[torch.dtype | None, bool]:
                     _use_fp32 = True
                 elif _lowp_fp_type is not None:
                     if _lowp_fp_type != opt_ctx.dtype:
-                        warnings.warn("bf16 and fp16 are mixed in the scheduler node.")
+                        warnings.warn(
+                            "bf16 and fp16 are mixed in the scheduler node.",
+                            stacklevel=2,
+                        )
                 else:
                     _lowp_fp_type = opt_ctx.dtype
             else:

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -3584,7 +3584,8 @@ def _check_triton_bf16_support(graph: GraphLowering) -> None:
         device_interface = get_interface_for_device(device.type)
         device_props = device_interface.get_device_properties(device)
         warnings.warn(
-            f"{device_props.name} does not support bfloat16 compilation natively, skipping"
+            f"{device_props.name} does not support bfloat16 compilation natively, skipping",
+            stacklevel=2,
         )
         raise SkipFrame("BF16 is not supported")
 

--- a/torch/_inductor/cpp_builder.py
+++ b/torch/_inductor/cpp_builder.py
@@ -1452,7 +1452,7 @@ def _get_python_include_dirs() -> list[str]:
         std_lib = Path(sysconfig.get_path("stdlib"))
         include_dir = (std_lib.parent.parent / "Headers").absolute()
     if not (include_dir / "Python.h").exists():
-        warnings.warn(f"Can't find Python.h in {str(include_dir)}")
+        warnings.warn(f"Can't find Python.h in {str(include_dir)}", stacklevel=2)
     return [str(include_dir)]
 
 
@@ -1586,7 +1586,9 @@ def _get_openmp_args(
                 include_dir_paths.append(os.path.join(omp_prefix, "include"))
                 lib_dir_paths.append(os.path.join(omp_prefix, "lib"))
             else:
-                warnings.warn("environment variable `OMP_PREFIX` is invalid.")
+                warnings.warn(
+                    "environment variable `OMP_PREFIX` is invalid.", stacklevel=2
+                )
             omp_available = omp_available or valid_env
 
         if not omp_available:

--- a/torch/_inductor/cpu_vec_isa.py
+++ b/torch/_inductor/cpu_vec_isa.py
@@ -609,7 +609,9 @@ def get_isa_from_cpu_capability(
                 return vec_isa
 
     if capability:
-        warnings.warn(f"ignoring invalid value for ATEN_CPU_CAPABILITY {capability}")
+        warnings.warn(
+            f"ignoring invalid value for ATEN_CPU_CAPABILITY {capability}", stacklevel=2
+        )
 
     return vec_isa_list[0]
 

--- a/torch/_inductor/cudagraph_trees.py
+++ b/torch/_inductor/cudagraph_trees.py
@@ -3108,7 +3108,8 @@ class CUDAGraphTreeManager:
         warnings.warn(
             "Unable to hit fast path of CUDAGraphs because outputs from a previous step "
             "still require backward. Ensure backward() is invoked or detach outputs. "
-            "You may also call torch.compiler.cudagraph_mark_step_begin() before each model invocation."
+            "You may also call torch.compiler.cudagraph_mark_step_begin() before each model invocation.",
+            stacklevel=2,
         )
 
     @staticmethod

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -419,7 +419,8 @@ def _extract_subgraphs_and_args(
         yield args[1], tuple(args[2])
     else:
         warnings.warn(
-            f"Please add support for subgraph args to function {node.target}!"
+            f"Please add support for subgraph args to function {node.target}!",
+            stacklevel=2,
         )
 
         # By default, just return the detected list of subgraphs so that we can run

--- a/torch/_inductor/kernel/flex/flex_flash_attention.py
+++ b/torch/_inductor/kernel/flex/flex_flash_attention.py
@@ -860,6 +860,7 @@ def create_flex_flash_attention_backward_kernel(
             "a deterministic implementation for this configuration, but you set "
             "'torch.use_deterministic_algorithms(True, warn_only=True)'. "
             "Running non-deterministic backward.",
+            stacklevel=2,
         )
 
     has_score_mod = fw_subgraph_buffer is not None and joint_subgraph_buffer is not None

--- a/torch/_inductor/lowering.py
+++ b/torch/_inductor/lowering.py
@@ -2782,7 +2782,8 @@ def fallback_handler(kernel, add_to_fallback_set=True):
 @functools.cache
 def _warn_complex_not_supported():
     warnings.warn(
-        "Torchinductor does not support code generation for complex operators. Performance may be worse than eager."
+        "Torchinductor does not support code generation for complex operators. Performance may be worse than eager.",
+        stacklevel=2,
     )
 
 

--- a/torch/_inductor/ops_handler.py
+++ b/torch/_inductor/ops_handler.py
@@ -823,7 +823,9 @@ class DefaultHandler(OpsHandler[Any]):
             return self._default(name, args, kwargs)
 
         # would like to remove this function entirely, but it's used in MTIA backend
-        warnings.warn(f"undefined OpHandler.{name}, please add missing op schema")
+        warnings.warn(
+            f"undefined OpHandler.{name}, please add missing op schema", stacklevel=2
+        )
         return fallback
 
     @staticmethod

--- a/torch/_inductor/runtime/compile_tasks.py
+++ b/torch/_inductor/runtime/compile_tasks.py
@@ -50,7 +50,7 @@ def _set_triton_ptxas_path() -> None:
     if ptxas.is_file() and os.access(ptxas, os.X_OK):
         os.environ["TRITON_PTXAS_PATH"] = str(ptxas)
     else:
-        warnings.warn(f"{ptxas} exists but is not an executable")
+        warnings.warn(f"{ptxas} exists but is not an executable", stacklevel=2)
 
 
 def _set_triton_libdevice_path() -> None:

--- a/torch/_inductor/runtime/triton_helpers.py
+++ b/torch/_inductor/runtime/triton_helpers.py
@@ -46,7 +46,8 @@ def set_driver_to_cpu():
         return
     # This can be a hard error once triton-cpu is merged into fbcode
     warnings.warn(
-        "Could not find an active CPU backend. Generated kernels will not be executable!"
+        "Could not find an active CPU backend. Generated kernels will not be executable!",
+        stacklevel=2,
     )
 
 

--- a/torch/_subclasses/complex_tensor/_ops/aten.py
+++ b/torch/_subclasses/complex_tensor/_ops/aten.py
@@ -752,7 +752,9 @@ def copy__impl(
 ) -> ComplexTensor | torch.Tensor:
     if not self.dtype.is_complex:
         warnings.warn(
-            "Casting complex values to real discards the imaginary part", UserWarning
+            "Casting complex values to real discards the imaginary part",
+            UserWarning,
+            stacklevel=2,
         )
         src_re, src_im = split_complex_arg(src)
         return self.copy_(src_re)

--- a/torch/autograd/profiler.py
+++ b/torch/autograd/profiler.py
@@ -253,7 +253,8 @@ class profile:
             warn(
                 "trace_only=True is incompatible with with_stack=True "
                 "(stack traces require event post-processing). "
-                "Disabling trace_only."
+                "Disabling trace_only.",
+                stacklevel=2,
             )
             experimental_config = copy.copy(experimental_config)
             experimental_config.trace_only = False

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1471,7 +1471,8 @@ def _get_amdsmi_device_index_from_hip_index(device: int) -> int:
                 "Cannot translate HIP ID to AMD SMI ID due to"
                 " lack of translation information prior to ROCm 6.4."
                 " Functions that rely on amdsmi"
-                " (e.g. temperature()) may operate on wrong devices."
+                " (e.g. temperature()) may operate on wrong devices.",
+                stacklevel=2,
             )
     if device not in _cached_hip_to_amdsmi:
         warnings.warn(
@@ -1480,7 +1481,8 @@ def _get_amdsmi_device_index_from_hip_index(device: int) -> int:
             " amdsmi_get_gpu_enumeration_info() only report these HIP IDs"
             f" {list(_cached_hip_to_amdsmi.keys())}."
             " Functions that rely on amdsmi"
-            " (e.g. temperature()) may operate on wrong devices."
+            " (e.g. temperature()) may operate on wrong devices.",
+            stacklevel=2,
         )
     return _cached_hip_to_amdsmi.get(device, device)
 

--- a/torch/cuda/green_contexts.py
+++ b/torch/cuda/green_contexts.py
@@ -41,7 +41,7 @@ def _get_driver_version() -> int:
         # pyrefly: ignore [missing-attribute]
         return _check_cuda_bindings(_drv.cuDriverGetVersion())
     except RuntimeError as e:
-        warnings.warn(f"Error while querying CUDA driver version: {e}")
+        warnings.warn(f"Error while querying CUDA driver version: {e}", stacklevel=2)
         return -1
 
 
@@ -236,14 +236,17 @@ class GreenContext:
             except RuntimeError as e:
                 warnings.warn(
                     f"Error while destroying green context stream at idx {idx} "
-                    f"for green context {green_ctx}: {e}"
+                    f"for green context {green_ctx}: {e}",
+                    stacklevel=2,
                 )
         self._green_ctx = None
         try:
             # pyrefly: ignore [missing-attribute]
             _check_cuda_bindings(_drv.cuGreenCtxDestroy(green_ctx))
         except RuntimeError as e:
-            warnings.warn(f"Error while destroying green context {green_ctx}: {e}")
+            warnings.warn(
+                f"Error while destroying green context {green_ctx}: {e}", stacklevel=2
+            )
 
     def _init_from_cuda_objects(self, device_id: int, green_ctx, context) -> None:
         self._device_id = device_id

--- a/torch/distributed/checkpoint/filesystem.py
+++ b/torch/distributed/checkpoint/filesystem.py
@@ -474,7 +474,8 @@ def _write_files_from_queue(
                         os.fsync(stream.fileno())
                     except (AttributeError, UnsupportedOperation) as e:
                         warnings.warn(
-                            f"fsync not supported for this stream, relying on flush(): {e}"
+                            f"fsync not supported for this stream, relying on flush(): {e}",
+                            stacklevel=2,
                         )
                 stream.close()
             result_queue.put(write_results)
@@ -783,7 +784,8 @@ class _FileSystemWriter(StorageWriter):
                     os.fsync(metadata_file.fileno())
                 except (AttributeError, UnsupportedOperation) as e:
                     warnings.warn(
-                        f"fsync not supported for this stream, relying on flush(): {e}"
+                        f"fsync not supported for this stream, relying on flush(): {e}",
+                        stacklevel=2,
                     )
 
         # delete in-case other checkpoints were present.

--- a/torch/fx/_symbolic_trace.py
+++ b/torch/fx/_symbolic_trace.py
@@ -1026,7 +1026,8 @@ class Tracer(TracerBase):
                     warnings.warn(
                         f"Was not able to add assertion to guarantee correct input {name} to "
                         f"specialized function. It is up to the user to make sure that your inputs match the "
-                        f"inputs you specialized the function with."
+                        f"inputs you specialized the function with.",
+                        stacklevel=2,
                     )
 
                 return x

--- a/torch/fx/experimental/meta_tracer.py
+++ b/torch/fx/experimental/meta_tracer.py
@@ -279,7 +279,10 @@ class MetaTracer(torch.fx.Tracer):
                 raise AssertionError("Don't support composite output yet")
             rv.install_tensor_meta(meta_out)
         except Exception as e:
-            warnings.warn(f"Could not compute metadata for {kind} target {target}: {e}")
+            warnings.warn(
+                f"Could not compute metadata for {kind} target {target}: {e}",
+                stacklevel=2,
+            )
 
         return rv  # pyrefly: ignore [bad-return]
 

--- a/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
+++ b/torch/fx/experimental/migrate_gradual_types/constraint_generator.py
@@ -859,7 +859,8 @@ def gt_inference_rule(
             # then we made the wrong assumption about the argument being a tensor
             # so we should fix the assumption
             warnings.warn(
-                f"Made the wrong assumption for node {n}. Correctness not guaranteed."
+                f"Made the wrong assumption for node {n}. Correctness not guaranteed.",
+                stacklevel=2,
             )
 
             new_e1, counter = gen_dvar(counter)

--- a/torch/fx/experimental/unification/multipledispatch/dispatcher.py
+++ b/torch/fx/experimental/unification/multipledispatch/dispatcher.py
@@ -54,7 +54,7 @@ def ambiguity_warn(
     Dispatcher.add
     warning_text
     """
-    warn(warning_text(dispatcher.name, ambiguities), AmbiguityWarning)
+    warn(warning_text(dispatcher.name, ambiguities), AmbiguityWarning, stacklevel=2)
 
 
 @deprecated(

--- a/torch/fx/graph.py
+++ b/torch/fx/graph.py
@@ -1691,7 +1691,9 @@ class Graph:
         if to_erase.graph != self:
             raise RuntimeError(f"Attempting to remove {to_erase} from wrong graph!")
         if to_erase._erased:
-            warnings.warn(f"erase_node({to_erase}) on an already erased node")
+            warnings.warn(
+                f"erase_node({to_erase}) on an already erased node", stacklevel=2
+            )
             return
 
         if (
@@ -1831,7 +1833,7 @@ class Graph:
             try:
                 submod: torch.nn.Module = mod.get_submodule(module_path)
             except AttributeError:
-                warnings.warn(f"Failed to fetch module {module_path}!")
+                warnings.warn(f"Failed to fetch module {module_path}!", stacklevel=2)
                 return False
 
             if not hasattr(submod, name):
@@ -1912,7 +1914,8 @@ class Graph:
                 "no underlying reference in the owning "
                 "GraphModule! Call "
                 "GraphModule.add_submodule to add the "
-                "necessary submodule"
+                "necessary submodule",
+                stacklevel=2,
             )
         return self.create_node(
             "call_module", module_name, args, kwargs, type_expr=type_expr

--- a/torch/fx/graph_module.py
+++ b/torch/fx/graph_module.py
@@ -769,7 +769,8 @@ class {module_name}(torch.nn.Module):
         if len(blobified_modules) > 0:
             warnings.warn(
                 "Was not able to save the following children modules as reprs -"
-                f"saved as pickled files instead: {blobified_modules}"
+                f"saved as pickled files instead: {blobified_modules}",
+                stacklevel=2,
             )
 
     @compatibility(is_backward_compatible=True)

--- a/torch/fx/operator_schemas.py
+++ b/torch/fx/operator_schemas.py
@@ -304,7 +304,8 @@ def create_type_hint(x: object) -> object:
     except Exception:
         # We tried to create a type hint for list but failed.
         warnings.warn(
-            f"We were not able to successfully create type hint from the type {x}"
+            f"We were not able to successfully create type hint from the type {x}",
+            stacklevel=2,
         )
     return x
 
@@ -331,7 +332,8 @@ def type_matches(signature_type: Any, argument_type: Any) -> bool:
 
         if not inspect.isclass(sig_el_type):
             warnings.warn(
-                f"Does not support nested parametric types, got {signature_type}. Please file a bug."
+                f"Does not support nested parametric types, got {signature_type}. Please file a bug.",
+                stacklevel=2,
             )
             return False
         if getattr(argument_type, "__origin__", None) is list:

--- a/torch/jit/_async.py
+++ b/torch/jit/_async.py
@@ -104,6 +104,7 @@ def fork(func, *args, **kwargs):
     warnings.warn(
         "`torch.jit.fork` is deprecated. Please use `torch.compile` instead.",
         FutureWarning,
+        stacklevel=2,
     )
     return torch._C.fork(func, *args, **kwargs)
 
@@ -124,6 +125,7 @@ def wait(future):
     warnings.warn(
         "`torch.jit.wait` is deprecated. Please use `torch.compile` instead.",
         FutureWarning,
+        stacklevel=2,
     )
     return torch._C.wait(future)
 

--- a/torch/jit/_freeze.py
+++ b/torch/jit/_freeze.py
@@ -106,6 +106,7 @@ def freeze(
     warnings.warn(
         "`torch.jit.freeze` is deprecated. Please use `torch.compile` instead.",
         FutureWarning,
+        stacklevel=2,
     )
     if not isinstance(mod, ScriptModule):
         raise RuntimeError(
@@ -230,6 +231,7 @@ def optimize_for_inference(
     warnings.warn(
         "`torch.jit.optimize_for_inference` is deprecated. Please use `torch.compile` instead.",
         FutureWarning,
+        stacklevel=2,
     )
     if not isinstance(mod, ScriptModule):
         raise RuntimeError(

--- a/torch/jit/_fuser.py
+++ b/torch/jit/_fuser.py
@@ -169,5 +169,6 @@ def set_fusion_strategy(strategy: list[tuple[str, int]]):
     warnings.warn(
         "`torch.jit.set_fusion_strategy` is deprecated. Please use `torch.compile` instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return torch._C._jit_set_fusion_strategy(strategy)

--- a/torch/jit/_script.py
+++ b/torch/jit/_script.py
@@ -360,11 +360,13 @@ def script_method(fn):
             "`torch.jit.script_method` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     else:
         warnings.warn(
             "`torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     if not _enabled:
         return fn
@@ -1486,11 +1488,13 @@ def script(
             "`torch.jit.script` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     else:
         warnings.warn(
             "`torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     if not _enabled:
         return obj
@@ -1643,6 +1647,7 @@ def interface(obj: _T) -> _T:
     warnings.warn(
         "`torch.jit.interface` is deprecated. Please use `torch.compile` instead.",
         FutureWarning,
+        stacklevel=2,
     )
     if not inspect.isclass(obj):
         raise RuntimeError("interface must be applied to a class")

--- a/torch/jit/_serialization.py
+++ b/torch/jit/_serialization.py
@@ -84,11 +84,13 @@ def save(m, f, _extra_files=None) -> None:
             "`torch.jit.save` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     else:
         warnings.warn(
             "`torch.jit.save` is deprecated. Please switch to `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     log_torchscript_usage("save", model_id=_get_model_id(m))
     if _extra_files is None:
@@ -171,11 +173,13 @@ def load(f, map_location=None, _extra_files=None, _restore_shapes=False):
             "`torch.jit.load` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     else:
         warnings.warn(
             "`torch.jit.load` is deprecated. Please switch to `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     if isinstance(f, (str, os.PathLike)):
         if not os.path.exists(f):

--- a/torch/jit/_trace.py
+++ b/torch/jit/_trace.py
@@ -1001,11 +1001,13 @@ def trace(
             "`torch.jit.trace` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     else:
         warnings.warn(
             "`torch.jit.trace` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     if not _enabled:
         return func
@@ -1140,11 +1142,13 @@ def trace_module(
             "`torch.jit.trace_method` is not supported in Python 3.14+ and may break. "
             "Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     else:
         warnings.warn(
             "`torch.jit.trace_method` is deprecated. Please switch to `torch.compile` or `torch.export`.",
             FutureWarning,
+            stacklevel=2,
         )
     if not _enabled:
         return mod

--- a/torch/nn/attention/_fa3.py
+++ b/torch/nn/attention/_fa3.py
@@ -143,6 +143,7 @@ def _fa3_common_support_error(
             "_scaled_dot_product_attention_quantized and "
             "provide the descale tensors.",
             UserWarning,
+            stacklevel=2,
         )
     if cum_seq_q is None and query.dim() != 4:
         return "dense query must be 4D"

--- a/torch/nn/attention/experimental/_scaled_dot_product_attention_quantized.py
+++ b/torch/nn/attention/experimental/_scaled_dot_product_attention_quantized.py
@@ -136,6 +136,7 @@ def _scaled_dot_product_attention_quantized(
             "_scaled_dot_product_attention_quantized does not support backward pass. "
             "Gradients will not be computed for query, key, or value.",
             UserWarning,
+            stacklevel=2,
         )
     # Directly call the internal flash attention operator which has descale support
     # NOTE: This should be torch._scaled_dot_product_flash_attention, but it does not work with torch.compile

--- a/torch/profiler/profiler.py
+++ b/torch/profiler/profiler.py
@@ -241,7 +241,8 @@ class _KinetoProfile:
             warn(
                 "trace_only=True is incompatible with with_stack=True "
                 "(stack traces require event post-processing). "
-                "Disabling trace_only."
+                "Disabling trace_only.",
+                stacklevel=2,
             )
             experimental_config_copy: _ExperimentalConfig = copy.copy(
                 experimental_config
@@ -1306,7 +1307,8 @@ class profile(_KinetoProfile):
             warn(
                 "Device profiling activity collection was stopped early "
                 f"at step {self.step_num}. Profiler schedule is proceeding "
-                "until next cycle without actual profiler activity collection."
+                "until next cycle without actual profiler activity collection.",
+                stacklevel=2,
             )
             self.current_action = ProfilerAction.DEVICE_STOPPED
 

--- a/torch/serialization.py
+++ b/torch/serialization.py
@@ -1517,7 +1517,9 @@ def load(
             pickle_module = pickle
 
     if pickle_load_args != {} and weights_only:
-        warnings.warn("pickle_load_args only works if `weights_only=False`.")
+        warnings.warn(
+            "pickle_load_args only works if `weights_only=False`.", stacklevel=2
+        )
 
     # make flipping default BC-compatible
     if mmap is None:

--- a/torch/utils/hipify/constants.py
+++ b/torch/utils/hipify/constants.py
@@ -8,7 +8,7 @@ mapping.
 """
 
 import warnings
-warnings.warn("hipify's constants.py is no longer used as of version 2.0.0", FutureWarning)
+warnings.warn("hipify's constants.py is no longer used as of version 2.0.0", FutureWarning, stacklevel=2)
 
 CONV_VERSION = 0,
 CONV_INIT = 1


### PR DESCRIPTION
## Summary

Enable flake8-bugbear **B028** ("no explicit `stacklevel` keyword argument found in `warnings.warn`") as part of the tracker in #106571.

Replaces #195466 (superseded: the previous head commits lacked DCO sign-off; this branch is a single signed commit with an identical tree).

## Changes

- Removed `B028` from the `ignore` list in `.flake8`.
- Removed the mirrored `"B028"` ignore from `[tool.ruff.lint]` in `pyproject.toml` (both files mandate keeping their ignore lists in sync; CI runs both flake8 and ruff via lintrunner).
- Added an explicit `stacklevel=2` to all 129 `warnings.warn()` sites flagged across the tree (union of flake8-bugbear's 118 and ruff's 128 findings — flake8-bugbear does not flag `from warnings import warn; warn(...)` calls, but ruff does, and CI enforces both).
- Multi-line calls got a trailing comma plus `stacklevel=2,` on its own line.
- One deliberate exception: `test/test_torch.py` keeps `stacklevel=1` (with a comment) because a test asserts `warning.lineno == frameinfo.lineno - 12`, which only holds when the warning is attributed to the `warn` line itself.

## Verification

- `ruff 0.14.4 --select B028 --config=pyproject.toml` (CI-pinned) over the full tree: 0 findings.
- `flake8 7.3.0` + `flake8-bugbear 24.12.12` (CI-pinned) with `B028` enabled over the full tree: 0 findings.
- Real CI linter adapters (`tools/linter/adapters/flake8_linter.py`, `ruff_linter.py`) clean.
- `lintrunner -m main` over all 74 changed files: exit 0 (205 findings, all pre-existing on untouched lines, 0 B028).
- All 72 changed `.py` files parse cleanly; 14 files pushed over 88 chars reformatted with CI-pinned ruff format.

Part of #106571

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98