### PR TITLE
[BE][Ez]: Use inlined std::sort in CUDA maybeOverlappingIndices

### DIFF
--- a/aten/src/ATen/cuda/detail/IndexUtils.cu
+++ b/aten/src/ATen/cuda/detail/IndexUtils.cu
@@ -1,4 +1,6 @@
 #include <ATen/cuda/detail/IndexUtils.cuh>
+
+#include <algorithm>
 #include <vector>
 
 namespace at::cuda::detail {
@@ -6,20 +8,11 @@ namespace at::cuda::detail {
 struct SizeAndStride {
   int64_t size;
   int64_t stride;
+
+  bool operator<(const SizeAndStride& other) const {
+    return stride < other.stride;
+  }
 };
-
-/*
- A comparator that will sort SizeAndStride structs by stride,
- in ascending order.
- */
- int compareSizeAndStride(const void* a, const void* b) {
-  const SizeAndStride* aS = (const SizeAndStride*) a;
-  const SizeAndStride* bS = (const SizeAndStride*) b;
-
-  if (aS->stride < bS->stride) return -1;
-  if (aS->stride == bS->stride) return 0;
-  return 1;
-}
 
 /*
 Returns false if there is no possibility that the tensor
@@ -57,7 +50,7 @@ bool maybeOverlappingIndices(const TensorBase& t) {
   }
 
   /* Ascending order (innermost dimension in sorted view is at [0]) */
-  qsort(info.data(), nonSize1Dims, sizeof(SizeAndStride), compareSizeAndStride);
+  std::sort(info.begin(), info.begin() + nonSize1Dims);
 
   for (int i = 0; i < (nonSize1Dims - 1); ++i) {
     if (((info[i].size - 1) * info[i].stride) >= info[i + 1].stride) {


### PR DESCRIPTION
Replace the C qsort call in CUDA index utilities with typed std::sort.
The existing comparator accepted void* arguments and was invoked through qsort’s function-pointer interface, preventing normal comparator inlining. Define the ordering directly on SizeAndStride and use std::sort over the populated portion of the vector instead.
This preserves the existing unstable ascending ordering by stride. Stable sorting is unnecessary because dimensions with equal nonzero strides are detected as overlapping regardless of their relative order.
This change was prepared with assistance from an AI coding tool.