### PR TITLE
[profiler][cupti] Stop freeing activity buffers CUPTI may still own

### DIFF
--- a/test/profiler/test_cupti_monitor.py
+++ b/test/profiler/test_cupti_monitor.py
@@ -3692,6 +3692,10 @@ _cupti_monitor.enable_hes_early()
         self.assertEqual(stats["buffers_pending"], 0)
         self.assertGreater(len(start), 0)
 
+        # obs.close() unregistered the last observer, stopping the monitor. The pool
+        # must survive that: CUPTI can still own buffers it never returned.
+        self.assertGreater(torch._C._profiler._cupti_monitor.allocated_buffers(), 0)
+
     @unittest.skipIf(not TEST_CUPTI_V13_3, "requires libcupti >= 13.3")
     @_isolated
     def test_graph_host_node_collected_on_device(self):

--- a/torch/profiler/_cupti/monitor.py
+++ b/torch/profiler/_cupti/monitor.py
@@ -403,8 +403,8 @@ class CuptiMonitor:
         self._clock = _SynchronizedClock()
         self._timestamp_callback_active = False
 
-        # Snapshot of the native pool size taken before stop() frees it, so
-        # stats() stays meaningful after the monitor has been stopped.
+        # Snapshot of the native pool size taken at stop(), so stats() stays
+        # meaningful after the monitor has been stopped.
         self._final_allocated_buffers = 0
         self._outstanding_warned = False
         self._dropped_records = 0
@@ -608,7 +608,6 @@ class CuptiMonitor:
     def start(self) -> None:
         if self._started:
             raise RuntimeError("CUPTI monitor is already started")
-        _cupti_monitor_native.reset_buffers()
         _cupti_monitor_native.configure_buffers(self.buffer_size)
         self.register_callbacks()
         # Put activity records on kineto's unix timeline via the clock (see _SynchronizedClock):
@@ -723,7 +722,6 @@ class CuptiMonitor:
         # holds it either -- a handler must survive an activity session ending.
         self._release_subscriber_if_idle()
         self._final_allocated_buffers = _cupti_monitor_native.allocated_buffers()
-        _cupti_monitor_native.reset_buffers()
         self._clock.reset()
 
     def flush(self, *, sync: bool = False, timeout_s: float = 5.0) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195471

CUPTI owns each activity buffer from the `bufferRequested` callback until it
invokes the matching completion callback, and it writes into a buffer it owns
whenever it gets around to it. `CuptiMonitor.start()` and `stop()` called
`reset_buffers()`, which frees every buffer the pool ever allocated -- including
ones CUPTI had requested and never returned. Worse, `stop()` runs it *after* the
unsubscribe, past which those buffers are never completed at all. Core dumps
from an intermittent heap-corruption abort at teardown show a freed 4 MiB
activity buffer, still full of CUPTI activity records, whose glibc free-list
pointer had a single bit cleared; the process then aborts in whatever `malloc`s
next, which is typically unrelated code and misattributes the failure.

Stop freeing the pool. It is already a reuse cache, so leaving it up across
sessions costs nothing but the buffers themselves, and the process reclaims it
at exit.

Test plan:

`python test/profiler/test_cupti_monitor.py TestCuptiMonitorNative.test_cupti_monitor_buffer_pool_reuse`

Unchanged and unaffected: the native pool's semantics are untouched here, and
`reset_buffers()` still frees everything for the tests and any direct user of
the native module. This diff only removes the monitor's two calls to it.