### PR TITLE
Use cdsort instead of hfsort for BOLT optimization

### DIFF
--- a/cmake/public/utils.cmake
+++ b/cmake/public/utils.cmake
@@ -599,7 +599,7 @@ function(torch_optimize_layout_if_enabled tgt)
               -o "$<TARGET_FILE:${tgt}>"
               "-data=${_profile}" "-log-file=${_logfile}"
               -lite -infer-stale-profile
-              -reorder-blocks=ext-tsp -reorder-functions=hfsort
+              -reorder-blocks=ext-tsp -reorder-functions=cdsort
               -split-functions -split-all-cold -split-eh -dyno-stats
               --update-debug-sections
       COMMENT "Optimizing $<TARGET_FILE_NAME:${tgt}> with LLVM BOLT (original kept in prebolt/)"


### PR DESCRIPTION
This was recommended by @aaupov. It does not show any perf change in NVIDIA internal benchmarks but should be smarter theoretically.

Related-to: https://github.com/pytorch/pytorch/issues/188602