### PR TITLE
Fix traceable wrapper subclass protocol check to use the type, not the instance

### DIFF
--- a/test/dynamo/test_subclasses.py
+++ b/test/dynamo/test_subclasses.py
@@ -3203,6 +3203,26 @@ class GraphModule(torch.nn.Module):
         self.assertIsInstance(result, MyTensor)
         self.assertEqual(result, x)
 
+    def test_bare_subclass_with_nonraising_getattr_compiles(self):
+        # Regression test for #194323: a bare torch.Tensor subclass
+        # (no __torch_dispatch__, no __tensor_flatten__) whose __getattr__
+        # returns a value instead of raising AttributeError used to be
+        # misdetected as a traceable wrapper subclass, and Dynamo crashed
+        # with InternalTorchDynamoError: AttributeError: ... no attribute
+        # '__tensor_flatten__'. It must now trace through the ordinary
+        # tensor path.
+        def fn():
+            class CustomTensor(torch.Tensor):
+                def __getattr__(self, attr):
+                    if attr == "custom_method":
+                        return lambda x: self + x
+                    return None
+
+            ct = CustomTensor([1, 2, 3])
+            return ct.custom_method(torch.tensor([4, 5, 6]))
+
+        self.assertEqual(torch.compile(fn)(), fn())
+
 
 instantiate_parametrized_tests(SubclassTests)
 

--- a/test/test_python_dispatch.py
+++ b/test/test_python_dispatch.py
@@ -1288,6 +1288,24 @@ $6: f32[1] = torch._ops.aten.add_.Tensor($1, $5)""",
 
         run_checks()
 
+    def test_traceable_wrapper_protocol_not_faked_by_getattr(self) -> None:
+        # Regression test for #194323: a bare tensor subclass whose
+        # __getattr__ returns a value (instead of raising AttributeError)
+        # must not be classified as a traceable wrapper subclass merely
+        # because hasattr(instance, ...), which consults __getattr__,
+        # reports __tensor_flatten__/__tensor_unflatten__ as present.
+        # The protocol is checked on the type, where such methods must
+        # actually be defined for them to exist.
+        class BareSubclass(torch.Tensor):
+            def __getattr__(self, attr):
+                if attr == "custom_method":
+                    return lambda x: self + x
+                return None
+
+        t = BareSubclass(torch.tensor([1.0, 2.0, 3.0]))
+        self.assertFalse(is_traceable_wrapper_subclass(t))
+        self.assertFalse(is_traceable_wrapper_subclass_type(BareSubclass))
+
     def test_make_fx_with_subclass(self) -> None:
         def f(x, y):
             # Returns (TwoTensor, Tensor)

--- a/torch/utils/_python_dispatch.py
+++ b/torch/utils/_python_dispatch.py
@@ -541,7 +541,19 @@ TensorWithFlatten = TraceableWrapperSubclass
 
 
 def _has_traceable_wrapper_subclass_protocol(t: object) -> bool:
-    return hasattr(t, "__tensor_flatten__") and hasattr(t, "__tensor_unflatten__")
+    # Check the protocol on the type, not the instance: every real
+    # __tensor_flatten__/__tensor_unflatten__ is defined on the class (and the
+    # callers below read it off the type as well), whereas an instance-level
+    # ``__getattr__`` that does not raise AttributeError would make hasattr()
+    # on the instance report the protocol methods as present on a bare
+    # subclass that never defined them. That misclassification made Dynamo
+    # call type(t).__tensor_flatten__(t) and crash with a raw AttributeError
+    # instead of tracing the subclass through the normal tensor path.
+    if isinstance(t, type):
+        cls = t
+    else:
+        cls = type(t)
+    return hasattr(cls, "__tensor_flatten__") and hasattr(cls, "__tensor_unflatten__")
 
 
 def is_traceable_wrapper_subclass(t: object) -> TypeIs[TraceableWrapperSubclass]:


### PR DESCRIPTION
## 📌 Checklist

- [x] I have read the [contributing guidelines](https://www.pytorch.org/docs/stable/notes/contributing.html).
- [x] I've run the [`scripts/lint.sh`](https://github.com/pytorch/pytorch/blob/main/scripts/lint.sh) style checker, and my code passes the checks.
- [x] I've made sure that when I changed a public method or function that's used by our users, I've documented it according to the [documentation guidelines](https://github.com/pytorch/pytorch/blob/main/.github/CONTRIBUTING.md#documentation).
- [x] I've added tests that pass when running `python test/test_*.py` on the relevant file(s).
- [x] I've made sure the [tests](https://github.com/pytorch/pytorch/blob/main/.github/CONTRIBUTING.md#tests) locally pass with the new code I'm adding by running those tests.

## Proposed changes

Fixes #194323.

## What was happening

A `torch.Tensor` subclass whose `__getattr__` returns a value (instead of raising `AttributeError`) — e.g. to implement lazy properties — was being misclassified as a *traceable wrapper subclass*. The runtime protocol check used `hasattr(instance, "__tensor_flatten__")`, and instance-level `hasattr` consults `__getattr__`, so the protocol looked present on a bare subclass that never defined it. Dynamo then treated the tensor as a wrapper subclass and called `type(t).__tensor_flatten__(t)` in `is_fake()`, which raised:

```
torch._dynamo.exc.InternalTorchDynamoError: AttributeError: type object 'CustomTensor' has no attribute '__tensor_flatten__'
```

## The fix

`_has_traceable_wrapper_subclass_protocol` in `torch/utils/_python_dispatch.py` now checks the protocol on the **type**, not the instance. This is correct by construction:

- every genuine subclass defines `__tensor_flatten__`/`__tensor_unflatten__` on the class, and all existing callers already read them off the type (`type(t).__tensor_flatten__(t)`);
- Python dunder lookup bypasses instance `__getattr__` entirely, so an instance `__getattr__` that doesn't raise `AttributeError` can no longer fake the protocol;
- genuine wrapper subclasses are still detected — a type-level `hasattr` finds class-level methods exactly as before.

## Verification

- Added `test_traceable_wrapper_protocol_not_faked_by_getattr` to `test/test_python_dispatch.py` (asserts the bug's repro subclass is *not* classified as traceable, covering both the instance and `_type` variants).
- Added `test_bare_subclass_with_nonraising_getattr_compiles` to `test/dynamo/test_subclasses.py` (the full issue repro through `torch.compile`).
- Reproduced the crash on torch 2.5.1 (identical code path): red without the change, and with the change the compiled function traces through the ordinary tensor path and returns the correct `CustomTensor([5., 7., 9.])`.
- Unit-tested the exact fixed function against 7 cases: the bug repro, a well-behaved `__getattr__` that raises `AttributeError`, a genuine protocol subclass (still detected), plain `Tensor`, `Parameter`, and both `is_traceable_wrapper_subclass_type` variants — all correct.

I have read the Contributing Guide and I'll join the PyTorch Devchat.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98