### PR TITLE
[dynamo] Migrate remaining NumpyNdarrayVariable attrs to tp_getset

### DIFF
--- a/torch/_dynamo/variables/tensor.py
+++ b/torch/_dynamo/variables/tensor.py
@@ -3305,13 +3305,56 @@ class NumpyNdarrayVariable(TensorVariable):
         )
         return NumpyNdarrayVariable.create(tx, proxy)
 
+    def _insert_attr_into_graph(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        from ..utils import numpy_attr_wrapper
+        from .builder import wrap_fx_proxy
+
+        return wrap_fx_proxy(
+            tx,
+            tx.output.create_proxy(
+                "call_function", numpy_attr_wrapper, (self.as_proxy(), name), {}
+            ),
+        )
+
+    def _get_shape_or_strides(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        example_ndarray = tnp.ndarray(self.as_proxy().node.meta["example_value"])
+        if not has_free_symbols(r := getattr(example_ndarray, name)):
+            return VariableTracker.build(tx, tuple(int(r) for r in r))
+        return self._insert_attr_into_graph(tx, name)
+
+    def _get_size(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        example_ndarray = tnp.ndarray(self.as_proxy().node.meta["example_value"])
+        if not has_free_symbols(r := example_ndarray.size):
+            return VariableTracker.build(tx, int(r))
+        return self._insert_attr_into_graph(tx, "size")
+
+    def _unsupported_attr(
+        self, tx: "InstructionTranslatorBase", name: str
+    ) -> VariableTracker:
+        unimplemented(
+            gb_type="Unsupported ndarray attribute access",
+            context=f"tp_getattro_impl {self} {name}",
+            explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
+            hints=[],
+        )
+
     tp_getset = {
         "ndim": GetSet(_get_ndim, None),
         "itemsize": GetSet(_get_itemsize, None),
-        "T": GetSet(lambda s, tx: s._get_numpy_attr(tx, "T")),
-        "real": GetSet(lambda s, tx: s._get_numpy_attr(tx, "real")),
-        "imag": GetSet(lambda s, tx: s._get_numpy_attr(tx, "imag")),
-        "flat": GetSet(lambda s, tx: s._get_numpy_attr(tx, "flat")),
+        "T": GetSet(lambda s, tx: s._get_numpy_attr(tx, "T"), None),
+        "real": GetSet(lambda s, tx: s._get_numpy_attr(tx, "real"), None),
+        "imag": GetSet(lambda s, tx: s._get_numpy_attr(tx, "imag"), None),
+        "flat": GetSet(lambda s, tx: s._get_numpy_attr(tx, "flat"), None),
+        "shape": GetSet(lambda s, tx: s._get_shape_or_strides(tx, "shape"), None),
+        "strides": GetSet(lambda s, tx: s._get_shape_or_strides(tx, "strides"), None),
+        "size": GetSet(_get_size, None),
+        "base": GetSet(lambda s, tx: s._unsupported_attr(tx, "base"), None),
+        "flags": GetSet(lambda s, tx: s._unsupported_attr(tx, "flags"), None),
+        "dtype": GetSet(lambda s, tx: s._unsupported_attr(tx, "dtype"), None),
     }
 
     def tp_getattro_impl(
@@ -3320,58 +3363,9 @@ class NumpyNdarrayVariable(TensorVariable):
         # NB: This INTENTIONALLY does not call super(), because there is
         # no intrinsic reason ndarray properties are related to Tensor
         # properties.  The inheritance here is for implementation sharing.
-        # tp_getset (ndim/itemsize/T/real/imag/flat) is resolved by
-        # generic_getattr before this method is reached, so it is not
-        # consulted here.
-        from ..utils import numpy_attr_wrapper
-        from .builder import wrap_fx_proxy
-
-        example_value = self.as_proxy().node.meta["example_value"]
-        example_ndarray = tnp.ndarray(example_value)
-
-        def insert_into_graph() -> VariableTracker:
-            return wrap_fx_proxy(
-                tx,
-                tx.output.create_proxy(
-                    "call_function", numpy_attr_wrapper, (self.as_proxy(), name), {}
-                ),
-            )
-
-        # These are awkward to implement.  The standard playbook for torch._numpy
-        # interop is to trace a call into the torch._numpy wrapper which works for
-        # Tensor operations.  However, we don't want to do this for calls
-        # that don't return Tensors, because in those cases we may not want
-        # to trace the attribute access into the graph at all (it is sort
-        # of harmless to do so, because AOTAutograd will eliminate them,
-        # but it's best not to trace them in to begin with.)  But in any
-        # case, tracing these into the graph is like trying to fit a square
-        # peg into a round hole; best not to do it.  So instead we
-        # painstakingly implement these by hand
-        #
-        # NB: only ALWAYS specialized attributes can go here; notably,
-        # size/shape not allowed!
-        if name in ("shape", "stride"):
-            if not has_free_symbols(r := getattr(example_ndarray, name)):
-                return VariableTracker.build(tx, tuple(int(r) for r in r))
-            return insert_into_graph()
-        elif name == "size":
-            if not has_free_symbols(r := example_ndarray.size):
-                return VariableTracker.build(tx, int(r))
-            return insert_into_graph()
-        elif name in ["base", "flags", "dtype"]:
-            unimplemented(
-                gb_type="Unsupported ndarray attribute access",
-                context=f"tp_getattro_impl {self} {name}",
-                explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
-                hints=[],
-            )
-        elif name == "__version__":
-            unimplemented(
-                gb_type="Unsupported ndarray.__version__ access",
-                context=f"tp_getattro_impl {self} {name}",
-                explanation=f"Dynamo currently does not support tracing `ndarray.{name}`.",
-                hints=[],
-            )
+        # Handled attributes are declared in tp_getset above (resolved by
+        # generic_getattr before this method). Raising NotImplementedError
+        # defers unknown attrs to GetAttrVariable.
         raise NotImplementedError
 
     @staticmethod


### PR DESCRIPTION
## Summary
Completes the `tp_getset` migration for `NumpyNdarrayVariable`: remaining `if name == ...` branches in `tp_getattro_impl` move onto the declarative table alongside the existing `ndim`/`itemsize`/`T`/`real`/`imag`/`flat` entries.

Reopens the work from closed #195216 (CLA / abandoned), incorporating @guilhermeleobas review feedback:
- All `GetSet` entries pass an explicit setter (`None` for read-only).
- Attribute name is `strides` (NumPy / `torch._numpy`), not `stride`.
- Drop `__version__` handling — it is not a NumPy ndarray attribute.
- Keep a single `_unsupported_attr` helper for `base`/`flags`/`dtype` (preserve existing `gb_type`).
- Keep `raise NotImplementedError` instead of `super().tp_getattro_impl`: ndarray must not inherit Tensor attribute semantics; `NotImplementedError` is what defers unknown attrs to `GetAttrVariable`.

`shape`/`strides`/`size` keep free-symbol specialization, falling back to tracing via `numpy_attr_wrapper` when symbolic.

Part of #195165.

## Test plan
- [x] `black --line-length 88 --check torch/_dynamo/variables/tensor.py`
- [ ] CI: `test/dynamo/test_functions.py` (`test_numpy_attributes`, `test_numpy_size`)
- [ ] Confirm `base`/`flags`/`dtype` still graph-break with `Unsupported ndarray attribute access`

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @guilhermeleobas @jansel