### PR TITLE
[inductor] Don't let a bounds-check throw escape the OpenMP region

### DIFF
--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -7754,6 +7754,44 @@ class CPUReproTests(TestCase):
                 with self.assertRaisesRegex(RuntimeError, "index out of bounds"):
                     fn_opt(x, out_of_bounds)
 
+    def test_exception_plumbing_only_when_kernel_can_throw(self):
+        # https://github.com/pytorch/pytorch/issues/195402
+        # Only kernels that emit a throwing check need the try/catch and the
+        # exception_ptr that ferries the throw out of the OpenMP region.  The
+        # vast majority of parallel kernels have no bounds check at all, and
+        # their generated code must be left exactly as it was.
+        def no_bounds_check(x):
+            return x * 2.0
+
+        def with_bounds_check(x, idx):
+            return (x - 0.5)[idx]
+
+        patches = {"cpp.threads": 8, "cpp.min_chunk_size": 1}
+
+        with config.patch(patches):
+            torch._dynamo.reset()
+            _, code = run_and_get_cpp_code(
+                torch.compile(no_bounds_check, dynamic=False), torch.randn(65536)
+            )
+        self.assertIn("#pragma omp", code)
+        # assert on the C++ constructs rather than the variable names inductor
+        # happens to pick, so a rename cannot make this pass vacuously
+        self.assertNotIn("std::exception_ptr", code)
+        self.assertNotIn("std::rethrow_exception", code)
+        self.assertNotIn("catch (...)", code)
+
+        with config.patch(patches):
+            torch._dynamo.reset()
+            _, code = run_and_get_cpp_code(
+                torch.compile(with_bounds_check, dynamic=False),
+                torch.randn(8, 4096),
+                torch.tensor([0, 1, 3]),
+            )
+        self.assertIn("#pragma omp", code)
+        self.assertIn("std::exception_ptr", code)
+        self.assertIn("std::rethrow_exception", code)
+        self.assertIn("catch (...)", code)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/test/inductor/test_cpu_repro.py
+++ b/test/inductor/test_cpu_repro.py
@@ -7689,6 +7689,71 @@ class CPUReproTests(TestCase):
         )
         self.assertTrue(cuda_storage.has_exceeded_max_reads())
 
+    def test_index_out_of_bounds_in_collapsed_parallel_region(self):
+        # https://github.com/pytorch/pytorch/issues/195402
+        # collapse(n) needs perfectly nested loops, so guarding the outer loop
+        # instead of the innermost one fails to compile.
+        def fn(x, idx):
+            return (x - 0.5)[idx]
+
+        x = torch.randn(8, 4096)
+        in_bounds = torch.tensor([0, 1, 3])
+        out_of_bounds = torch.tensor([0, 1, 9])  # dim 0 has size 8
+
+        with config.patch({"cpp.threads": 32, "cpp.min_chunk_size": 1}):
+            torch._dynamo.reset()
+            fn_opt = torch.compile(fn, dynamic=False)
+            _, code = run_and_get_cpp_code(fn_opt, x, in_bounds)
+            self.assertIn("collapse(2)", code)
+            with self.assertRaisesRegex(RuntimeError, "index out of bounds"):
+                fn_opt(x, out_of_bounds)
+
+    def test_index_out_of_bounds_under_omp_single(self):
+        # https://github.com/pytorch/pytorch/issues/195402
+        # A kernel too small to parallelise still runs under `omp single`
+        # inside the open parallel region, so a throw escapes there too.
+        def fn(a, b, idx):
+            return a * 2.0, (b - 0.5)[idx]
+
+        a = torch.randn(65536)
+        b = torch.randn(4, 2)
+        in_bounds = torch.tensor([0, 1])
+        out_of_bounds = torch.tensor([0, 9])  # dim 0 of b has size 4
+
+        with config.patch({"cpp.threads": 8, "cpp.min_chunk_size": 1}):
+            torch._dynamo.reset()
+            fn_opt = torch.compile(fn, dynamic=False)
+            _, code = run_and_get_cpp_code(fn_opt, a, b, in_bounds)
+            self.assertIn("#pragma omp single", code)
+            with self.assertRaisesRegex(RuntimeError, "index out of bounds"):
+                fn_opt(a, b, out_of_bounds)
+
+    def test_index_out_of_bounds_in_parallel_region(self):
+        # https://github.com/pytorch/pytorch/issues/195402
+        # A throw from a parallelised kernel used to abort the process. Whether
+        # the loop is parallelised depends on the tensor size, so pin it here
+        # instead of relying on the host thread count.
+        def fn(x, idx):
+            return (x - 0.5)[idx]
+
+        x = torch.randn(1, 8, 66, 66)
+        in_bounds = torch.tensor([[0]])
+        out_of_bounds = torch.tensor([[1]])  # dim 0 has size 1
+
+        for expect_parallel, patches in (
+            (True, {"cpp.threads": 4, "cpp.min_chunk_size": 1}),
+            (False, {"cpp.threads": 1, "cpp.min_chunk_size": 2**40}),
+        ):
+            with config.patch(patches):
+                torch._dynamo.reset()
+                fn_opt = torch.compile(fn, dynamic=False)
+                # compile with a valid index so we can inspect the kernel
+                _, code = run_and_get_cpp_code(fn_opt, x, in_bounds)
+                self.assertEqual("#pragma omp" in code, expect_parallel)
+                # the process must survive and raise something catchable
+                with self.assertRaisesRegex(RuntimeError, "index out of bounds"):
+                    fn_opt(x, out_of_bounds)
+
 
 if __name__ == "__main__":
     from torch._inductor.test_case import run_tests

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -69,6 +69,8 @@ from .common import (
 from .cpp_utils import (
     _get_dtype_from_loopbodies,
     _get_loop_body,
+    capture_exceptions_in_parallel_region,
+    catch_exceptions_inside_parallel_region,
     cexpr,
     cexpr_index,
     codegen_rand,
@@ -2612,6 +2614,8 @@ class CppKernel(Kernel):
             elif threads > 1:
                 if worksharing.single():
                     stack.enter_context(code.indent())
+                    # `omp single` is still inside the parallel region
+                    stack.enter_context(catch_exceptions_inside_parallel_region(code))
 
             def gen_kernel(_loop_nest: LoopNest):
                 def is_parallel_reduction():
@@ -2698,6 +2702,10 @@ class CppKernel(Kernel):
                         return
                     code.writelines(loop_lines)
                     stack.enter_context(code.indent())
+                    if loop.catch_exception:
+                        stack.enter_context(
+                            catch_exceptions_inside_parallel_region(code)
+                        )
                     gen_loop_nest(_loop_nest, depth + 1, loop.is_reduction)
 
             def gen_loop_nest(
@@ -6218,6 +6226,8 @@ class WorkSharing:
                 # Thread count differs from system (user probably set it so hardcode)
                 use_dynamic = False
 
+            self.stack.enter_context(self.code.indent())
+            self.stack.enter_context(capture_exceptions_in_parallel_region(self.code))
             if use_dynamic or config.cpp.dynamic_threads:
                 self.code.writeline("#pragma omp parallel")
             else:
@@ -6260,6 +6270,8 @@ class LoopLevel:
     tiled_size: sympy.Expr = sympy.S.Zero
     steps: sympy.Expr = sympy.S.One
     parallel: int = 0
+    # guard this loop's body so a throw cannot escape the OpenMP region
+    catch_exception: bool = False
     simd_omp: bool = False
     simd_vec: bool = False
     collapsed: bool = False
@@ -6451,6 +6463,10 @@ class LoopNest:
             raise AssertionError("expected len(self.loops) >= par_depth.parallel_depth")
         loop = self.loops[par_depth.start_depth]
         loop.parallel = par_depth.parallel_depth
+        # collapse(n) needs the n loops perfectly nested, so the guard has to
+        # go in the innermost one rather than around the whole nest.
+        innermost_parallel = max(par_depth.start_depth, par_depth.parallel_depth - 1)
+        self.loops[innermost_parallel].catch_exception = True
         if loop.is_reduction:
             # pyrefly: ignore [bad-assignment]
             metrics.parallel_reduction_count += 1

--- a/torch/_inductor/codegen/cpp.py
+++ b/torch/_inductor/codegen/cpp.py
@@ -80,6 +80,7 @@ from .cpp_utils import (
     INDEX_TYPE,
     LocalBufferContext,
     may_unify_binary_op_mask_type,
+    ParallelExceptionCapture,
     promote_args,
     template_fusion_with_epilogues_supported,
     unify_mask_base_type,
@@ -2111,6 +2112,10 @@ class CppKernel(Kernel):
         # Indicate when this kernel is active, for example
         # {x0, {24, 26}} -> this kernel is active when x0 >= 24 and x0 < 26
         self.active_ranges: dict[sympy.Expr, tuple[sympy.Expr, ...]] = {}
+        # Set when this kernel emits something that can throw (a bounds check).
+        # Only such kernels need the OpenMP exception plumbing; see
+        # ParallelExceptionCapture and pytorch#195402.
+        self._may_throw = False
         # Indicate this kernel will be moved under the inner for-loop
         # See move_code_under_inner_loop
         self.inner_itervars: list[sympy.Symbol] = []
@@ -2307,6 +2312,7 @@ class CppKernel(Kernel):
         line = self.indirect_assert(
             csevar, "0" if lower else None, size_str, self._load_mask
         )
+        self._may_throw = True
         self.cse.generate(buffer, line, assignment=False)
 
     def load(self, name: str, index: sympy.Expr):
@@ -2585,6 +2591,16 @@ class CppKernel(Kernel):
         return V.graph.sizevars.optimization_hint(expr)
 
     def codegen_loops_impl(self, loop_nest, code, worksharing):
+        """Emit the C++ loop nest around this kernel's body.
+
+        Decides how deep to parallelize, opens or reuses the OpenMP region via
+        `worksharing`, then walks the nest emitting loops, reduction
+        prefixes/suffixes and finally the kernel body at the leaf.
+
+        Loops carrying a throwing bounds check are wrapped in a try/catch so
+        the exception cannot escape the OpenMP region; see
+        ParallelExceptionCapture and pytorch#195402.
+        """
         if not isinstance(self, CppKernelProxy):
             raise AssertionError("expected isinstance(self, CppKernelProxy)")
         threads = parallel_num_threads()
@@ -2614,8 +2630,16 @@ class CppKernel(Kernel):
             elif threads > 1:
                 if worksharing.single():
                     stack.enter_context(code.indent())
-                    # `omp single` is still inside the parallel region
-                    stack.enter_context(catch_exceptions_inside_parallel_region(code))
+                    # `omp single` still sits inside the enclosing parallel
+                    # region, so a throw here would escape it too.  The region
+                    # was opened by an earlier kernel in this group, which is
+                    # why its declarations are deferred rather than decided
+                    # when it was opened.
+                    capture = worksharing.exception_capture
+                    if capture is not None and loop_nest.get_kernel().may_throw():
+                        stack.enter_context(
+                            catch_exceptions_inside_parallel_region(code, capture)
+                        )
 
             def gen_kernel(_loop_nest: LoopNest):
                 def is_parallel_reduction():
@@ -2703,8 +2727,13 @@ class CppKernel(Kernel):
                     code.writelines(loop_lines)
                     stack.enter_context(code.indent())
                     if loop.catch_exception:
+                        capture = worksharing.exception_capture
+                        if capture is None:
+                            raise AssertionError(
+                                "expected an open parallel region around a guarded loop"
+                            )
                         stack.enter_context(
-                            catch_exceptions_inside_parallel_region(code)
+                            catch_exceptions_inside_parallel_region(code, capture)
                         )
                     gen_loop_nest(_loop_nest, depth + 1, loop.is_reduction)
 
@@ -2756,6 +2785,10 @@ class CppKernel(Kernel):
             return "AOTI_TORCH_CHECK"
         else:
             return "TORCH_CHECK"
+
+    def may_throw(self) -> bool:
+        """Whether the body generated for this kernel contains a throwing check."""
+        return self._may_throw
 
     def decide_parallel_depth(self, max_parallel_depth, threads):
         if self.call_ranges is None:
@@ -4973,6 +5006,11 @@ class CppKernelProxy(CppKernel):
         for kernel in self.kernels:
             kernel.update_stores_with_parallel_reduction()
 
+    def may_throw(self) -> bool:
+        # The bounds check is emitted while running the body under one of the
+        # sub-kernels, so the flag lands there rather than on the proxy.
+        return self._may_throw or any(kernel.may_throw() for kernel in self.kernels)
+
     def gen_body(self, code: BracesBuffer | None = None):
         if code is None:
             raise AssertionError("expected code is not None")
@@ -5081,6 +5119,11 @@ class OuterLoopFusedKernel(CppKernel):
     def __init__(self, kernel_group):
         super().__init__(kernel_group.args, kernel_group.ws.num_threads)
         self.inner: list[LoopNest] = []
+
+    def may_throw(self) -> bool:
+        return self._may_throw or any(
+            loop_nest.get_kernel().may_throw() for loop_nest in self.inner
+        )
 
     def decide_parallel_depth(self, max_parallel_depth, threads):
         kernels_parallel_depth = []
@@ -6206,6 +6249,11 @@ class WorkSharing:
         self.in_parallel = False
         self.num_threads = None
         self.stack = contextlib.ExitStack()
+        # Exception plumbing for the region currently open, if any.  Guards
+        # emitted inside the region are handed this so they can name its
+        # variables and mark it as actually needed.
+        self.exception_capture: ParallelExceptionCapture | None = None
+        self.num_regions = 0
 
     def parallel(self, threads):
         if self.in_parallel and threads != self.num_threads:
@@ -6226,8 +6274,13 @@ class WorkSharing:
                 # Thread count differs from system (user probably set it so hardcode)
                 use_dynamic = False
 
-            self.stack.enter_context(self.code.indent())
-            self.stack.enter_context(capture_exceptions_in_parallel_region(self.code))
+            # The declarations are emitted in the enclosing scope, so name them
+            # per region: a function may contain more than one.  They are
+            # deferred lines and disappear entirely if no guard is emitted.
+            self.exception_capture = self.stack.enter_context(
+                capture_exceptions_in_parallel_region(self.code, f"_{self.num_regions}")
+            )
+            self.num_regions += 1
             if use_dynamic or config.cpp.dynamic_threads:
                 self.code.writeline("#pragma omp parallel")
             else:
@@ -6245,6 +6298,7 @@ class WorkSharing:
     def close(self):
         self.stack.close()
         self.in_parallel = False
+        self.exception_capture = None
 
     def __enter__(self):
         self.stack.__enter__()
@@ -6463,10 +6517,13 @@ class LoopNest:
             raise AssertionError("expected len(self.loops) >= par_depth.parallel_depth")
         loop = self.loops[par_depth.start_depth]
         loop.parallel = par_depth.parallel_depth
-        # collapse(n) needs the n loops perfectly nested, so the guard has to
-        # go in the innermost one rather than around the whole nest.
-        innermost_parallel = max(par_depth.start_depth, par_depth.parallel_depth - 1)
-        self.loops[innermost_parallel].catch_exception = True
+        if self.get_kernel().may_throw():
+            # collapse(n) needs the n loops perfectly nested, so the guard has to
+            # go in the innermost one rather than around the whole nest.
+            innermost_parallel = max(
+                par_depth.start_depth, par_depth.parallel_depth - 1
+            )
+            self.loops[innermost_parallel].catch_exception = True
         if loop.is_reduction:
             # pyrefly: ignore [bad-assignment]
             metrics.parallel_reduction_count += 1

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -822,3 +822,43 @@ def template_fusion_with_epilogues_supported(
         if n.node is not None
     ]
     return _template_fusion_supported(template_outputs, epilogue_nodes)
+
+
+@contextlib.contextmanager
+def capture_exceptions_in_parallel_region(code):
+    """Shared state for carrying an exception out of an OpenMP region.
+
+    An exception must not leave an OpenMP structured block, so we stash the
+    first one and rethrow it once the region has joined, as
+    at::internal::invoke_parallel does.
+    """
+    code.writelines(
+        [
+            "std::atomic<bool> inductor_kernel_err_flag{false};",
+            "std::exception_ptr inductor_kernel_eptr;",
+        ]
+    )
+    yield
+    code.writelines(
+        [
+            "if (inductor_kernel_eptr) {",
+            "    std::rethrow_exception(inductor_kernel_eptr);",
+            "}",
+        ]
+    )
+
+
+@contextlib.contextmanager
+def catch_exceptions_inside_parallel_region(code):
+    """Body half of :func:`capture_exceptions_in_parallel_region`."""
+    code.writeline("try {")
+    yield
+    code.writelines(
+        [
+            "} catch (...) {",
+            "    if (!inductor_kernel_err_flag.exchange(true)) {",
+            "        inductor_kernel_eptr = std::current_exception();",
+            "    }",
+            "}",
+        ]
+    )

--- a/torch/_inductor/codegen/cpp_utils.py
+++ b/torch/_inductor/codegen/cpp_utils.py
@@ -23,7 +23,12 @@ from ..dependencies import Dep
 from ..loop_body import LoopBody
 from ..scheduler import BaseSchedulerNode, SchedulerBuffer
 from ..shape_propagation import BlockShapeType
-from ..utils import IndentedBuffer, sympy_index_symbol_with_prefix, sympy_subs
+from ..utils import (
+    DeferredLineBase,
+    IndentedBuffer,
+    sympy_index_symbol_with_prefix,
+    sympy_subs,
+)
 from ..virtualized import ops, OpsValue, V
 from .common import CSEVariable, Kernel, KernelArgs, OptimizationContext
 
@@ -824,40 +829,86 @@ def template_fusion_with_epilogues_supported(
     return _template_fusion_supported(template_outputs, epilogue_nodes)
 
 
-@contextlib.contextmanager
-def capture_exceptions_in_parallel_region(code):
-    """Shared state for carrying an exception out of an OpenMP region.
+class ParallelExceptionCapture:
+    """Plumbing that carries an exception out of one OpenMP region.
 
-    An exception must not leave an OpenMP structured block, so we stash the
-    first one and rethrow it once the region has joined, as
-    at::internal::invoke_parallel does.
+    An exception may not leave an OpenMP structured block: doing so calls
+    std::terminate and aborts the process instead of raising into Python
+    (pytorch#195402, pytorch#126691).  Each thread stashes the first exception
+    it sees and we rethrow it once the region has joined, mirroring
+    at::internal::invoke_parallel in ATen/ParallelOpenMP.h.
+
+    Most kernels contain nothing that can throw, so the declarations and the
+    trailing rethrow are written as deferred lines and only materialize if
+    something inside the region actually asks for a guard (`needed` is set by
+    :func:`catch_exceptions_inside_parallel_region`).  That keeps the generated
+    code byte-for-byte unchanged for the common case.  The guards may be
+    requested after the declarations have been written -- a later kernel in the
+    same group can land under `omp single` inside an already-open region -- so
+    the decision cannot be made eagerly.
     """
+
+    def __init__(self, suffix: str = ""):
+        self.flag = f"inductor_kernel_err_flag{suffix}"
+        self.eptr = f"inductor_kernel_eptr{suffix}"
+        self.needed = False
+
+
+class _DeferredExceptionLine(DeferredLineBase):
+    """A line that is dropped unless its region ended up needing a guard."""
+
+    def __init__(self, line: str, capture: ParallelExceptionCapture):
+        super().__init__(line)
+        self.capture = capture
+
+    def __call__(self):
+        return self.line if self.capture.needed else None
+
+    def _new_line(self, line: str):
+        return _DeferredExceptionLine(line, self.capture)
+
+
+@contextlib.contextmanager
+def capture_exceptions_in_parallel_region(code, suffix: str = ""):
+    """Declare the state used to ferry an exception out of an OpenMP region.
+
+    Yields the :class:`ParallelExceptionCapture` that the guards inside the
+    region must be given, so they can name its variables and mark it needed.
+    """
+    capture = ParallelExceptionCapture(suffix)
     code.writelines(
         [
-            "std::atomic<bool> inductor_kernel_err_flag{false};",
-            "std::exception_ptr inductor_kernel_eptr;",
+            _DeferredExceptionLine(line, capture)
+            for line in (
+                f"std::atomic<bool> {capture.flag}{{false}};",
+                f"std::exception_ptr {capture.eptr};",
+            )
         ]
     )
-    yield
+    yield capture
     code.writelines(
         [
-            "if (inductor_kernel_eptr) {",
-            "    std::rethrow_exception(inductor_kernel_eptr);",
-            "}",
+            _DeferredExceptionLine(line, capture)
+            for line in (
+                f"if ({capture.eptr}) {{",
+                f"    std::rethrow_exception({capture.eptr});",
+                "}",
+            )
         ]
     )
 
 
 @contextlib.contextmanager
-def catch_exceptions_inside_parallel_region(code):
-    """Body half of :func:`capture_exceptions_in_parallel_region`."""
+def catch_exceptions_inside_parallel_region(code, capture: ParallelExceptionCapture):
+    """Body-wrapping half of :func:`capture_exceptions_in_parallel_region`."""
+    capture.needed = True
     code.writeline("try {")
     yield
     code.writelines(
         [
             "} catch (...) {",
-            "    if (!inductor_kernel_err_flag.exchange(true)) {",
-            "        inductor_kernel_eptr = std::current_exception();",
+            f"    if (!{capture.flag}.exchange(true)) {{",
+            f"        {capture.eptr} = std::current_exception();",
             "    }",
             "}",
         ]

--- a/torch/csrc/inductor/cpp_prefix.h
+++ b/torch/csrc/inductor/cpp_prefix.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <cmath>
 #include <cstdlib>
+#include <exception>
 #include <limits>
 #include <map>
 #include <unordered_map>


### PR DESCRIPTION
## Summary

An out-of-bounds index in a `torch.compile`d CPU kernel kills the process instead of raising. Eager gives you a catchable `IndexError`; the compiled version dies with `SIGABRT` and no traceback.

```python
import torch

def f(x, idx):
    return (x - 0.5)[idx]

x = torch.randn(1, 8, 66, 66)     # dim 0 has size 1
idx = torch.tensor([[1]])         # out of bounds on dim 0

torch.compile(f, backend="inductor")(x, idx)
print("NOT REACHED")
```

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  kernel, /tmp/.../main.cpp:34, index out of bounds: 0 <= tmp7 < 1L
Aborted (core dumped)
```

What makes this easy to miss is that it depends on the tensor size. `config.cpp.min_chunk_size` is 512, so with N threads inductor parallelises once the iteration space reaches `512 * N`:

| input | elements | generated kernel | result |
|---|---|---|---|
| `(1, 8, 4, 4)` | 128 | no `#pragma omp` | catchable `RuntimeError` | | `(1, 8, 66, 66)` | 34,848 | `#pragma omp parallel` + `#pragma omp for` | **SIGABRT** |

## Root cause

Inductor emits the bounds check as a `TORCH_CHECK` inside the generated loop body. That part is fine. The problem is that a C++ exception may not leave an OpenMP structured block, so as soon as the loop carrying the check is parallelised, the throw crosses the boundary of `#pragma omp parallel` and the runtime calls `std::terminate`.

## Fix

Capture the first exception per region and rethrow it once the region has joined. This is the same thing `at::internal::invoke_parallel` already does in `ATen/ParallelOpenMP.h`:

```cpp
std::atomic<bool> inductor_kernel_err_flag{false};
std::exception_ptr inductor_kernel_eptr;
#pragma omp parallel num_threads(4)
{
    #pragma omp for
    for (...) {
        try { /* body, including the TORCH_CHECK */ }
        catch (...) {
            if (!inductor_kernel_err_flag.exchange(true))
                inductor_kernel_eptr = std::current_exception();
        }
    }
}
if (inductor_kernel_eptr) std::rethrow_exception(inductor_kernel_eptr);
```

Three things worth pointing out for review:

**The guard has to go inside the innermost collapsed loop.** `#pragma omp for collapse(n)` requires the n loops to be perfectly nested, so wrapping the outer loop still raises correctly but stops the kernel compiling (`error: expected 2 for loops after '#pragma omp for', but found only 1`). I got this wrong first time round; `test_index_out_of_bounds_in_collapsed_parallel_region` pins it down.

**`#pragma omp single` has the same hole.** A kernel too small to parallelise is still emitted under `omp single` when an earlier kernel in the same group has already opened a parallel region, so a throw from it escapes as well. That isn't mentioned in the issue.

**No new libtorch dependency.** The generated `TORCH_CHECK` resolves to the header-only `STD_TORCH_CHECK`, which throws `std::runtime_error`, so `catch (...)` plus `std::exception_ptr` is enough. This is deliberately unlike the stale #127868, which flipped `include_pytorch` to `True` to reach `torch::translate_exception_to_python` — that would put libtorch behind every inductor CPU kernel and works against the ABI note at the top of `cpp_prefix.h`.

## What this fixes, and what I checked

All of it on macOS / arm64 / Apple clang, torch 2.13.0.

| Case | Before | After | How I checked |
|---|---|---|---|
| Parallelised `omp for` (the reported repro) | SIGABRT, exit 134 | catchable `RuntimeError` | the repro above, plus `test_index_out_of_bounds_in_parallel_region` | | Kernel under `#pragma omp single` | SIGABRT, exit 134 | catchable `RuntimeError` | `test_index_out_of_bounds_under_omp_single` | | AOTInductor (`aoti_compile_and_package`) | SIGABRT, exit 134 | catchable `RuntimeError` | export + compile + run with a bad index | | `collapse(2)` / `collapse(3)` kernels compile | n/a (bug I introduced mid-way) | loops stay perfectly nested | `test_index_out_of_bounds_in_collapsed_parallel_region` | | Serial kernels unchanged | catchable `RuntimeError` | catchable `RuntimeError` | small-tensor case | | Divide-by-zero deferral still works | raises | raises | integer `//` by zero on a parallel kernel | | Numerics unchanged | — | correct | pointwise, reduction, dynamic-shape and gather kernels vs eager | | No regressions in the CPU inductor tests | — | same failures as baseline | 68-test subset of `test_cpu_repro.py` vs a pristine 2.13.0 install |

On the AOTI row: that path throws `c10::Error` through `AOTI_TORCH_CHECK` -> `aoti_torch_check` -> `c10::detail::torchCheckFail`, not `std::runtime_error`. `catch (...)` and `std::rethrow_exception` cover both, and the pre-fix backtrace shows `torchCheckFail` unwinding straight through `omp_outlined`.

Generated code was also checked structurally across flattened 1-D, `collapse(2)`, `collapse(3)`, reduction, vectorized, tiled-transpose and `index_put` scatter kernels: `collapse(n)` stays perfectly nested, the `try` only ever appears in the innermost collapsed loop, and there is exactly one capture/rethrow pair per parallel region.

The one test failing in my run, `test_vertical_reduction_tail_store_uses_tail_width`, fails identically without this change, so it is pre-existing and unrelated.

## Could not check due to MacBook constraints

I only have a MacBook (arm64, Apple clang) to work on, so the following are genuinely untested and I would like CI and reviewers to cover them:

| Not covered | Why it matters |
|---|---|
| GCC, x86-64, Linux | The most important gap. The `collapse(n)` mistake above was caught by a *compiler-enforced* OpenMP rule, and I have no evidence for how GCC diagnoses perfect nesting or compiles these exception paths. | | `test_cpu_repro.py` as CI runs it | The file is skipped on macOS upstream (`if HAS_CPU and not IS_MACOS`). I ran it through pytest directly, bypassing that guard, so my numbers come from a platform it isn't expected to pass on. | | The rest of the inductor suites | I ran 68 of roughly 790 tests in one file. Nothing from `test_torchinductor.py` or `test_cpu_select_algorithm.py`. | | A stock OpenMP setup | Two OpenMP runtimes in one process (torch's bundled libomp plus the Homebrew one inductor picks for the kernel compile) crash this machine on *any* parallel CPU kernel, with or without this patch. I had to point `OMP_PREFIX` at torch's own OpenMP, so these results come from a hand-configured environment. | | Performance | I have no meaningful benchmark numbers on this hardware. The guard is only emitted around parallel regions and inductor's SIMD is explicit `at::vec` intrinsics rather than auto-vectorization, so I do not expect a hit, but I have not measured it. |

## Out of scope

The issue also notes the compiled path raises `RuntimeError` where eager raises `IndexError`. That is a separate user-visible behaviour change — `test_torchinductor.py` and `test_embedding.py` currently assert `RuntimeError` for this message — so it belongs in its own PR with its own sign-off rather than riding along with a crash fix.

Fixes #195402. Same root cause as #126691, open since May 2024. Approach follows #127868, which went stale.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @leslie-fang-intel @chunyuan-w