### PR TITLE
[inductor] Don't reinplace generalized_scatter when the result escapes the graph

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -28,7 +28,9 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
 )
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
+    instantiate_parametrized_tests,
     IS_LINUX,
+    parametrize,
     run_tests,
     TEST_WITH_TORCHINDUCTOR,
     TestCase,
@@ -951,6 +953,64 @@ def find_buffer_assignments(code):
     pattern = r"buf(\d+) = empty_strided_"
     matches = re.finditer(pattern, code)
     return tuple(f"buf{match.group(1)}" for match in matches)
+
+
+@instantiate_parametrized_tests
+class CollectiveReinplaceTestCPU(TestCase):
+    def setUp(self):
+        super().setUp()
+        dummy_init_pg()
+
+    def tearDown(self):
+        if dist.is_initialized():
+            dist.destroy_process_group()
+        torch._dynamo.reset()
+        super().tearDown()
+
+    @fresh_cache()
+    @parametrize("collective", ("single", "coalesced"))
+    @parametrize("collective_first", (False, True))
+    def test_scatter_collective_result_does_not_alias_input(
+        self, collective, collective_first
+    ):
+        def reduce(tensor):
+            if collective == "single":
+                reduced = torch.ops._c10d_functional.all_reduce.default(
+                    tensor, "sum", "0"
+                )
+                return torch.ops._c10d_functional.wait_tensor.default(reduced)
+
+            reduced = torch.ops._c10d_functional.all_reduce_coalesced.default(
+                [tensor], "sum", "0"
+            )
+            return torch.ops._c10d_functional.wait_tensors.default(reduced)[0]
+
+        def fn(x, diag):
+            if collective_first:
+                reduced = reduce(x)
+                updated = torch.diagonal_scatter(reduced, diag)
+            else:
+                updated = torch.diagonal_scatter(x, diag)
+                updated = reduce(updated)
+            x.copy_(updated)
+            return updated
+
+        def run(callable_):
+            x = torch.arange(16.0).reshape(4, 4)
+            diag = torch.full((4,), -1.0)
+            out = callable_(x, diag)
+            x_after_call = x.clone()
+            out_after_call = out.clone()
+            self.assertNotEqual(
+                out.untyped_storage().data_ptr(), x.untyped_storage().data_ptr()
+            )
+            out.add_(100)
+            self.assertEqual(x, x_after_call)
+            return x_after_call, out_after_call
+
+        eager = run(fn)
+        compiled = run(torch.compile(fn, fullgraph=True))
+        self.assertEqual(compiled, eager)
 
 
 class CompileTestCPU(TestCase):

--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -524,6 +524,72 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         result = torch.compile(fn, fullgraph=True, backend="inductor")(x)
         self.assertEqual(result, expected)
 
+    def test_generalized_scatter_uses_live_inplaceable_ops(self):
+        from torch._guards import detect_fake_mode
+        from torch._inductor.fx_passes.reinplace import (
+            inplaceable_ops,
+            InplaceableOp,
+            reinplace_inplaceable_ops,
+        )
+        from torch._inductor.fx_utils import FakeTensorUpdater
+        from torch._inductor.virtualized import V
+
+        with torch.library._scoped_library(
+            "_test_live_reinplace_registry", "FRAGMENT"
+        ) as lib:
+            lib.define("functional(Tensor x, Tensor y) -> Tensor")
+            lib.define(
+                "mutating(Tensor(a!) x, Tensor y) -> Tensor(a!)",
+                tags=[torch.Tag.inplace],
+            )
+            lib.impl("functional", lambda x, y: x + y, "CompositeExplicitAutograd")
+            lib.impl("mutating", lambda x, y: x.add_(y), "CompositeExplicitAutograd")
+            torch.library.register_fake(
+                "_test_live_reinplace_registry::functional",
+                lambda x, y: x + y,
+                lib=lib,
+            )
+
+            functional = torch.ops._test_live_reinplace_registry.functional.default
+            mutating = torch.ops._test_live_reinplace_registry.mutating.default
+            inplaceable_ops[functional] = InplaceableOp(mutating, 0)
+            try:
+
+                def fn(x, diag, y):
+                    updated = torch.diagonal_scatter(x, diag)
+                    result = functional(updated, y)
+                    x.copy_(result)
+                    return result
+
+                x = torch.arange(16.0, device=device).reshape(4, 4)
+                diag = torch.full((4,), -1.0, device=device)
+                y = torch.ones(4, 4, device=device)
+                expected_x = x.clone()
+                expected = fn(expected_x, diag, y)
+
+                gm = make_fx(fn, tracing_mode="fake")(x, diag, y)
+                fake_mode = detect_fake_mode(
+                    [node.meta.get("val") for node in gm.graph.nodes]
+                )
+                with V.set_fake_mode(fake_mode):
+                    reinplace_inplaceable_ops(FakeTensorUpdater(gm), gm.graph)
+                gm.graph.lint()
+                gm.recompile()
+
+                targets = [node.target for node in gm.graph.nodes]
+                self.assertIn(mutating, targets)
+                self.assertIn(aten.clone, targets)
+
+                actual_x = x.clone()
+                actual = gm(actual_x, diag, y)
+                self.assertEqual(actual, expected)
+                self.assertEqual(actual_x, expected_x)
+                actual_x_after_call = actual_x.clone()
+                actual.add_(100)
+                self.assertEqual(actual_x, actual_x_after_call)
+            finally:
+                inplaceable_ops.pop(functional, None)
+
     @parametrize(
         "factory_op",
         [

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12085,6 +12085,114 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                     out.add_(100)
                 self.assertEqual(x, x_after_call)
 
+    @config.patch(implicit_fallbacks=True)
+    def test_reinplace_result_escapes_via_auto_functionalized(self):
+        # https://github.com/pytorch/pytorch/pull/195484
+        # auto_functionalized{,_v2} is a second way this pass drops a clone: a
+        # mutable argument the pass leaves out of only_clone_these_tensors is
+        # mutated in place, so the output holding its new value aliases it.
+        # A scatter on either side of such an op must not let that turn the
+        # returned result into an alias of the graph input.
+        device = self.device
+
+        def scatter_then_mutate(x, diag):
+            updated = torch.diagonal_scatter(x, diag)
+            torch.ops.mylib.inc_(updated)
+            x.copy_(updated)
+            return updated
+
+        def mutate_then_scatter(x, diag):
+            torch.ops.mylib.inc_(x)
+            updated = torch.diagonal_scatter(x, diag)
+            x.copy_(updated)
+            return updated
+
+        def mutate_view_then_scatter(x, diag):
+            view = x.view_as(x)
+            torch.ops.mylib.inc_(view)
+            updated = torch.diagonal_scatter(view, diag)
+            x.copy_(updated)
+            return updated
+
+        def make_inputs():
+            return (
+                torch.arange(16.0, device=device).reshape(4, 4),
+                torch.full((4,), -1.0, device=device),
+            )
+
+        def inc_(x):
+            x.add_(1.0)
+
+        with torch.library._scoped_library("mylib", "FRAGMENT") as m:
+            m.define("inc_(Tensor(a!) x) -> ()")
+            m.impl("inc_", inc_, "CompositeExplicitAutograd")
+            torch.library.register_fake("mylib::inc_", lambda x: None, lib=m)
+
+            for v2 in (False, True):
+                for fn in (
+                    scatter_then_mutate,
+                    mutate_then_scatter,
+                    mutate_view_then_scatter,
+                ):
+                    with self.subTest(fn=fn.__name__, auto_functionalized_v2=v2):
+                        eager_args = make_inputs()
+                        out_eager = fn(*eager_args)
+
+                        compiled_args = make_inputs()
+                        with config.patch(enable_auto_functionalized_v2=v2):
+                            torch._dynamo.reset()
+                            out = torch.compile(fn, fullgraph=True)(*compiled_args)
+
+                        x = compiled_args[0]
+                        self.assertEqual(out_eager, out)
+                        self.assertEqual(eager_args[0], x)
+                        self.assertIsNot(out, x)
+                        self.assertNotEqual(
+                            out.untyped_storage().data_ptr(),
+                            x.untyped_storage().data_ptr(),
+                        )
+                        x_after_call = x.clone()
+                        out.add_(100)
+                        self.assertEqual(x, x_after_call)
+
+    def test_scatter_reinplace_not_blocked_by_functional_user(self):
+        # https://github.com/pytorch/pytorch/pull/195484
+        # The scatter's escape check reads the graph this pass has already
+        # rewritten, so an index_put that was *not* reinplaced (its result has
+        # to stay live for the return) is not mistaken for an alias of the
+        # scatter. Reinplacing the scatter is safe here and saves a kernel and
+        # a full-size buffer over refusing on the possibility.
+        def fn(x, diag, idx, val):
+            a = torch.diagonal_scatter(x, diag)
+            b = torch.index_put(a, (idx,), val)
+            x.copy_(a)
+            return b
+
+        def make_inputs():
+            return (
+                torch.arange(16.0, device=self.device).reshape(4, 4),
+                torch.full((4,), -1.0, device=self.device),
+                torch.tensor([0, 2], device=self.device),
+                torch.full((2, 4), 10.0, device=self.device),
+            )
+
+        eager_args = make_inputs()
+        out_eager = fn(*eager_args)
+
+        compiled_args = make_inputs()
+        torch._dynamo.reset()
+        torch._inductor.metrics.reset()
+        out = torch.compile(fn, fullgraph=True)(*compiled_args)
+
+        self.assertEqual(out_eager, out)
+        self.assertEqual(eager_args[0], compiled_args[0])
+        self.assertNotEqual(
+            out.untyped_storage().data_ptr(),
+            compiled_args[0].untyped_storage().data_ptr(),
+        )
+        # diagonal copy_, index_put, copy_ back into x -- no extra clone kernel
+        assertGeneratedKernelCountEqual(self, 3)
+
     def test_slice_scatter_dtype_consistency(self):
         # Test dtype consistency of slice_scatter
         def fn(x, y):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12007,6 +12007,84 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
             self.assertEqual(y_eager, y_compiled)
             self.assertEqual(out_eager, out_compiled)
 
+    def test_reinplace_result_escapes_via_input_alias(self):
+        # https://github.com/pytorch/pytorch/pull/195484
+        # The scatter input can reach the graph input through a view chain or
+        # through an op the pass already reinplaced onto the input, and the
+        # result can reach the output through an op the pass reinplaces later.
+        # A returned result must not become an alias of the input in any case.
+        def view_of_input(x, weight, src):
+            view = x.permute(1, 0)
+            before = view @ weight
+            updated = torch.slice_scatter(view, src, 0, 0, 1)
+            x.copy_(updated.permute(1, 0))
+            return before, updated
+
+        def reinplaced_chain(x, diag, idx, val):
+            a = torch.diagonal_scatter(x, diag)
+            b = torch.index_put(a, (idx,), val)
+            x.copy_(b)
+            return b
+
+        def reinplaced_then_scatter(x, idx, val, diag):
+            a = torch.index_put(x, (idx,), val)
+            b = torch.diagonal_scatter(a, diag)
+            x.copy_(b)
+            return b
+
+        device = self.device
+        cases = [
+            (
+                view_of_input,
+                lambda: (
+                    torch.arange(24.0, device=device).reshape(4, 6),
+                    torch.arange(12.0, device=device).reshape(4, 3),
+                    torch.full((1, 4), 10.0, device=device),
+                ),
+            ),
+            (
+                reinplaced_chain,
+                lambda: (
+                    torch.arange(16.0, device=device).reshape(4, 4),
+                    torch.full((4,), -1.0, device=device),
+                    torch.tensor([0, 2], device=device),
+                    torch.full((2, 4), 10.0, device=device),
+                ),
+            ),
+            (
+                reinplaced_then_scatter,
+                lambda: (
+                    torch.arange(16.0, device=device).reshape(4, 4),
+                    torch.tensor([0, 2], device=device),
+                    torch.full((2, 4), 10.0, device=device),
+                    torch.full((4,), -1.0, device=device),
+                ),
+            ),
+        ]
+        for fn, make_inputs in cases:
+            with self.subTest(fn=fn.__name__):
+                eager_args = make_inputs()
+                compiled_args = make_inputs()
+                outs_eager = fn(*eager_args)
+                outs_compiled = torch.compile(fn, fullgraph=True)(*compiled_args)
+                self.assertEqual(outs_eager, outs_compiled)
+                x = compiled_args[0]
+                self.assertEqual(eager_args[0], x)
+                outs = (
+                    outs_compiled
+                    if isinstance(outs_compiled, tuple)
+                    else (outs_compiled,)
+                )
+                x_after_call = x.clone()
+                for out in outs:
+                    self.assertIsNot(out, x)
+                    self.assertNotEqual(
+                        out.untyped_storage().data_ptr(),
+                        x.untyped_storage().data_ptr(),
+                    )
+                    out.add_(100)
+                self.assertEqual(x, x_after_call)
+
     def test_slice_scatter_dtype_consistency(self):
         # Test dtype consistency of slice_scatter
         def fn(x, y):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -11908,6 +11908,105 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         else:
             assertGeneratedKernelCountEqual(self, 1)
 
+    def test_slice_scatter_reinplace_result_escapes(self):
+        # https://github.com/pytorch/pytorch/issues/195451
+        # Reinplacing the scatter onto its input makes the two the same tensor.
+        # The copy_ back hides that from the rest of the graph, but a returned
+        # result would alias the input, where the functional scatter hands back
+        # a fresh tensor. Mutating the result would then corrupt the input.
+        def returns_result(x, src):
+            updated = torch.slice_scatter(x, src, 0, 0, 1)
+            x.copy_(updated)
+            return updated
+
+        def returns_view_of_result(x, src):
+            updated = torch.slice_scatter(x, src, 0, 0, 1)
+            x.copy_(updated)
+            return updated[1:]
+
+        def returns_split_of_result(x, src):
+            updated = torch.slice_scatter(x, src, 0, 0, 1)
+            x.copy_(updated)
+            a, b = updated.split(2, dim=0)
+            return a, b
+
+        for fn in (returns_result, returns_view_of_result, returns_split_of_result):
+            with self.subTest(fn=fn.__name__):
+
+                def run(compiled_fn, fn=fn):
+                    x = torch.arange(4.0, device=self.device)
+                    src = torch.full((1,), 10.0, device=self.device)
+                    outs = compiled_fn(x, src)
+                    outs = outs if isinstance(outs, tuple) else (outs,)
+                    for out in outs:
+                        out.add_(100)
+                    return x, outs
+
+                x_eager, outs_eager = run(fn)
+                x_compiled, outs_compiled = run(torch.compile(fn, fullgraph=True))
+                self.assertEqual(x_eager, x_compiled)
+                self.assertEqual(outs_eager, outs_compiled)
+
+        # get_attr inputs (e.g. a module buffer) hit the same aliasing hazard as
+        # placeholders. Note: AOTAutograd lifts buffers used by the traced graph
+        # into explicit placeholder inputs, so this scatter's inp is expected to
+        # be a placeholder by the time reinplace runs, exercising the same arm
+        # as returns_result above rather than the get_attr one; the guard's
+        # get_attr branch covers graphs (e.g. from export) where the buffer
+        # survives as a get_attr node. Either way, eager/compiled parity is what
+        # matters here.
+        with self.subTest(fn="returns_result_buffer"):
+            device = self.device
+
+            class BufferModule(nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.register_buffer("buf", torch.arange(4.0, device=device))
+
+                def forward(self, src):
+                    updated = torch.slice_scatter(self.buf, src, 0, 0, 1)
+                    self.buf.copy_(updated)
+                    return updated
+
+            def run_buffer(mod):
+                src = torch.full((1,), 10.0, device=device)
+                out = mod(src)
+                out.add_(100)
+                return mod.buf.clone(), out
+
+            buf_eager, out_eager = run_buffer(BufferModule())
+            buf_compiled, out_compiled = run_buffer(
+                torch.compile(BufferModule(), fullgraph=True)
+            )
+            self.assertEqual(buf_eager, buf_compiled)
+            self.assertEqual(out_eager, out_compiled)
+
+        # The scatter result can be copied back into more than one input; each
+        # copy-back target must stay independent of the (mutated) returned result.
+        with self.subTest(fn="returns_result_multi_target"):
+
+            def multi_target(x, y, src):
+                updated = torch.slice_scatter(x, src, 0, 0, 1)
+                x.copy_(updated)
+                y.copy_(updated)
+                return updated
+
+            def run_multi(compiled_fn):
+                x = torch.arange(4.0, device=self.device)
+                y = torch.zeros(4, device=self.device)
+                src = torch.full((1,), 10.0, device=self.device)
+                out = compiled_fn(x, y, src)
+                out.add_(100)
+                return x, y, out
+
+            x_eager, y_eager, out_eager = run_multi(multi_target)
+            x_compiled, y_compiled, out_compiled = run_multi(
+                torch.compile(multi_target, fullgraph=True)
+            )
+            self.assertEqual(x_eager, x_compiled)
+            self.assertEqual(y_eager, y_compiled)
+            self.assertEqual(out_eager, out_compiled)
+
     def test_slice_scatter_dtype_consistency(self):
         # Test dtype consistency of slice_scatter
         def fn(x, y):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -12155,6 +12155,48 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
                         out.add_(100)
                         self.assertEqual(x, x_after_call)
 
+    @config.patch(implicit_fallbacks=True)
+    def test_reinplace_result_escapes_via_inplace_op_return(self):
+        device = self.device
+
+        def fn(x, diag):
+            updated = torch.diagonal_scatter(x, diag)
+            result = torch.ops.reinplace_return.inc_(updated.T)
+            x.copy_(result.T)
+            return result
+
+        def make_inputs():
+            return (
+                torch.arange(16.0, device=device).reshape(4, 4),
+                torch.full((4,), -1.0, device=device),
+            )
+
+        def inc_(x):
+            return x.add_(1.0)
+
+        with torch.library._scoped_library("reinplace_return", "FRAGMENT") as lib:
+            lib.define("inc_(Tensor(a!) x) -> Tensor(a!)", tags=[torch.Tag.inplace])
+            lib.impl("inc_", inc_, "CompositeExplicitAutograd")
+            torch.library.register_fake("reinplace_return::inc_", lambda x: x, lib=lib)
+
+            eager_args = make_inputs()
+            out_eager = fn(*eager_args)
+
+            compiled_args = make_inputs()
+            torch._dynamo.reset()
+            out = torch.compile(fn, fullgraph=True)(*compiled_args)
+
+            x = compiled_args[0]
+            self.assertEqual(out_eager, out)
+            self.assertEqual(eager_args[0], x)
+            self.assertNotEqual(
+                out.untyped_storage().data_ptr(),
+                x.untyped_storage().data_ptr(),
+            )
+            x_after_call = x.clone()
+            out.add_(100)
+            self.assertEqual(x, x_after_call)
+
     def test_scatter_reinplace_not_blocked_by_functional_user(self):
         # https://github.com/pytorch/pytorch/pull/195484
         # The scatter's escape check reads the graph this pass has already

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -219,22 +219,187 @@ def scatter_always_uses_mutation(node: torch.fx.Node) -> bool:
     )
 
 
-def _reinplace_aliases_arg(node: torch.fx.Node, arg: torch.fx.Node) -> bool:
-    """Whether reinplacing node, an inplaceable op, makes its result alias arg."""
-    inplaceable_op = inplaceable_ops.get(node.target)
-    return inplaceable_op is not None and any(
-        node.args[idx] is arg for idx in inplaceable_op.mutated_args
-    )
+# Sentinel for a multi-output node that hands some of its arguments back
+# unchanged in a layout this pass cannot read; callers must then assume every
+# tensor argument is aliased.
+_UNRESOLVED_ALIASES = object()
+
+
+def _flat_node_args(node: torch.fx.Node) -> list[torch.fx.Node]:
+    """Every fx Node in node's args/kwargs, looking inside containers."""
+    flat_args = pytree.tree_leaves((node.args, node.kwargs))
+    return [arg for arg in flat_args if isinstance(arg, torch.fx.Node)]
+
+
+def _as_alias_nodes(value: Any) -> list[torch.fx.Node]:
+    if isinstance(value, torch.fx.Node):
+        return [value]
+    if isinstance(value, (list, tuple)):
+        return [v for v in value if isinstance(v, torch.fx.Node)]
+    return []
+
+
+def _auto_functionalized_result_offset(mutable_op: Any) -> int | None:
+    """Where the mutated arguments start in an auto_functionalized{,_v2} result.
+
+    Both dense implementations return the wrapped op's own result followed by
+    the new value of each mutated argument (v1) or base (v2). An op returning
+    nothing, or a single value, still occupies exactly one leading slot.
+    """
+    if not isinstance(mutable_op, torch._ops.OpOverload):
+        return None
+    return max(1, len(mutable_op._schema.returns))
+
+
+def _multi_output_aliases(node: torch.fx.Node) -> Any:
+    """Which elements of a multi-output node alias one of its arguments.
+
+    Returns a dict mapping the index (or, for the Triton wrapper, the key) of
+    each aliasing element to the argument it aliases; None when node's result
+    is not such a container; and _UNRESOLVED_ALIASES when it is one whose
+    layout cannot be read here.
+
+    Everything is read off the graph as the pass has already rewritten it, so
+    an in-place target, a narrowed only_clone_these_tensors or a narrowed
+    tensors_to_clone is what decides whether an element aliases.
+    """
+    target = node.target
+    if node.op != "call_function" or isinstance(target, str):
+        return None
+
+    if target is operator.getitem:
+        # An element that is itself a list of tensors (a Tensor(a!)[] argument
+        # handed back by auto_functionalized) is a container in its own right.
+        parent = node.args[0]
+        if not isinstance(parent, torch.fx.Node):
+            return None
+        parent_aliases = _multi_output_aliases(parent)
+        if not isinstance(parent_aliases, dict):
+            return None
+        element = parent_aliases.get(node.args[1])
+        return dict(enumerate(element)) if isinstance(element, (list, tuple)) else None
+
+    if target is _WAIT_TENSORS_OP:
+        waited = node.args[0] if node.args else None
+        return dict(enumerate(waited)) if isinstance(waited, (list, tuple)) else None
+
+    if (mutated_args := _INPLACE_OP_TO_MUTATED_ARGS.get(target)) is not None:
+        # An op the pass reinplaced over a list of tensors -- the coalesced
+        # collectives and the foreach ops -- returns each element in place.
+        arg = node.args[mutated_args[0]] if mutated_args[0] < len(node.args) else None
+        return dict(enumerate(arg)) if isinstance(arg, (list, tuple)) else None
+
+    if target is torch.ops.higher_order.auto_functionalized:
+        from torch._higher_order_ops.auto_functionalize import get_mutable_args
+
+        offset = _auto_functionalized_result_offset(node.args[0])
+        to_clone = node.meta.get("only_clone_these_tensors")
+        if offset is None or to_clone is None:
+            return _UNRESOLVED_ALIASES
+        names, _ = get_mutable_args(node.args[0])  # type: ignore[arg-type]
+        return {
+            offset + i: node.kwargs[name]
+            for i, name in enumerate(names)
+            if name not in to_clone and node.kwargs.get(name) is not None
+        }
+
+    if target is torch.ops.higher_order.auto_functionalized_v2:
+        offset = _auto_functionalized_result_offset(node.args[0])
+        to_clone = node.meta.get("only_clone_these_tensors")
+        all_bases = node.kwargs.get("_all_bases")
+        if (
+            offset is None
+            or to_clone is None
+            or not isinstance(all_bases, (list, tuple))
+        ):
+            return _UNRESOLVED_ALIASES
+        return {
+            offset + i: base
+            for i, base in enumerate(all_bases)
+            if i not in to_clone  # type: ignore[operator]
+        }
+
+    if target is torch.ops.higher_order.with_effects:
+        # with_effects(token, op, *args) -> (token, *results). Once the pass
+        # swaps in the mutating op, result i is its i-th mutated argument.
+        inner_op = node.args[1] if len(node.args) > 1 else None
+        inner_mutated_args = _INPLACE_OP_TO_MUTATED_ARGS.get(inner_op)  # type: ignore[arg-type]
+        if inner_mutated_args is None:
+            return {}
+        return {
+            position + 1: node.args[idx + 2]
+            for position, idx in enumerate(inner_mutated_args)
+            if idx + 2 < len(node.args)
+        }
+
+    if target in inplaceable_triton_ops:
+        # The wrapper only returns the tensors it cloned. Dropping a name from
+        # tensors_to_clone makes the matching getitem the kwarg itself.
+        kernel_kwargs = node.kwargs.get("kwargs") or {}
+        tensors_to_clone = node.kwargs.get("tensors_to_clone") or ()
+        return {
+            name: value
+            for name, value in kernel_kwargs.items()  # type: ignore[union-attr]
+            if name not in tensors_to_clone  # type: ignore[operator]
+        }
+
+    return None
+
+
+def _alias_sources(node: torch.fx.Node) -> list[torch.fx.Node]:
+    """The nodes whose result node's result aliases in the rewritten graph.
+
+    This is the one place the pass' copy-removal mechanisms are turned into
+    alias edges: view chains, ops already rewritten in place (whose result is
+    their mutated arg), the collectives' wait_tensor(s), and the elements a
+    multi-output node hands back untouched.
+    """
+    target = node.target
+    if node.op != "call_function" or isinstance(target, str):
+        return []
+
+    if target is operator.getitem:
+        parent = node.args[0]
+        if not isinstance(parent, torch.fx.Node):
+            return []
+        # getitem only aliases parent when parent is a multi-output view
+        if _is_view_op(parent.target):
+            return [parent]
+        parent_aliases = _multi_output_aliases(parent)
+        if parent_aliases is _UNRESOLVED_ALIASES:
+            return _flat_node_args(parent)
+        if isinstance(parent_aliases, dict):
+            return _as_alias_nodes(parent_aliases.get(node.args[1]))
+        return []
+
+    if node.args and (_is_view_op(target) or target is _WAIT_TENSOR_OP):
+        return _as_alias_nodes(node.args[0])
+
+    if (mutated_args := _INPLACE_OP_TO_MUTATED_ARGS.get(target)) is not None:
+        if mutated_args[0] < len(node.args):
+            return _as_alias_nodes(node.args[mutated_args[0]])
+
+    return []
+
+
+def _carries_alias(node: torch.fx.Node, known: OrderedSet[torch.fx.Node]) -> bool:
+    """Whether node's result is, or contains, an alias of a node in known."""
+    if any(source in known for source in _alias_sources(node)):
+        return True
+    aliases = _multi_output_aliases(node)
+    if aliases is _UNRESOLVED_ALIASES:
+        return any(arg in known for arg in _flat_node_args(node))
+    if isinstance(aliases, dict):
+        return any(
+            source in known
+            for element in aliases.values()
+            for source in _as_alias_nodes(element)
+        )
+    return False
 
 
 def _result_escapes_graph(node: torch.fx.Node) -> bool:
-    """Whether node's result, or an alias of it, is returned from the graph.
-
-    Views alias their input. So does the result of an inplaceable op once the
-    pass reinplaces it onto that input; the pass visits it after node, so the
-    escape check here treats it as an alias to stay valid for the rewritten
-    graph.
-    """
+    """Whether node's result, or an alias of it, is returned from the graph."""
     aliases = OrderedSet([node])
     stack = [node]
     while stack:
@@ -244,38 +409,25 @@ def _result_escapes_graph(node: torch.fx.Node) -> bool:
                 return True
             if user in aliases:
                 continue
-            # getitem only aliases cur when cur is a multi-output view (e.g. split)
-            if (
-                _is_view_op(user.target)
-                or (user.target is operator.getitem and _is_view_op(cur.target))
-                or _reinplace_aliases_arg(user, cur)
-            ):
+            if _carries_alias(user, aliases):
                 aliases.add(user)
                 stack.append(user)
     return False
 
 
 def _aliases_graph_input(node: torch.fx.Node) -> bool:
-    """Whether node is a graph input or aliases one.
-
-    Follows view chains (and getitem on multi-output views) back to their base,
-    and steps through ops the pass already rewrote in place, whose result is
-    their mutated arg.
-    """
-    while node.op not in ("placeholder", "get_attr"):
-        if (mutated_args := _INPLACE_OP_TO_MUTATED_ARGS.get(node.target)) is not None:
-            base = node.args[mutated_args[0]]
-        elif node.args and (
-            _is_view_op(node.target)
-            or (node.target is operator.getitem and _is_view_op(node.args[0].target))  # type: ignore[union-attr]
-        ):
-            base = node.args[0]
-        else:
-            return False
-        if not isinstance(base, torch.fx.Node):
-            return False
-        node = base
-    return True
+    """Whether node is a graph input or aliases one."""
+    seen = OrderedSet([node])
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        if cur.op in ("placeholder", "get_attr"):
+            return True
+        for source in _alias_sources(cur):
+            if source not in seen:
+                seen.add(source)
+                stack.append(source)
+    return False
 
 
 def should_reinplace_scatter(node: torch.fx.Node) -> bool:
@@ -459,6 +611,11 @@ inplaceable_ops: dict[Callable[..., Any], InplaceableOp] = {
     aten._philox_randint.default: InplaceableOp(aten._philox_randint_.default, 0),
 }
 
+# wait_tensor / wait_tensors are not reinplacing decisions: their lowering
+# hands back the collective's own buffer, so they are plain alias edges.
+_WAIT_TENSOR_OP: Any = None
+_WAIT_TENSORS_OP: Any = None
+
 try:
     c10d_functional = torch.ops._c10d_functional
     inplaceable_collective_ops: dict[Callable[..., Any], InplaceableOp] = {
@@ -470,6 +627,8 @@ try:
         ),
     }
     inplaceable_ops.update(inplaceable_collective_ops)
+    _WAIT_TENSOR_OP = c10d_functional.wait_tensor.default
+    _WAIT_TENSORS_OP = c10d_functional.wait_tensors.default
 except AttributeError:
     # _c10d_functional ops are only available when torch
     # is built with USE_DISTRIBUTED=1.
@@ -482,6 +641,12 @@ _INPLACE_OP_TO_MUTATED_ARGS = {
 inplaceable_foreach_ops: dict[torch._ops.OpOverload, InplaceableOp] = {}
 for outplace_op, inplace_op in inplaceable_foreach_ops_lowerings.items():
     inplaceable_foreach_ops[outplace_op] = InplaceableOp(inplace_op, 0)
+
+# The alias walks read node.target after this pass rewrote it, so they need the
+# mutated-argument layout of every op the pass can swap in, foreach included.
+_INPLACE_OP_TO_MUTATED_ARGS.update(
+    {op.inplace_op: op.mutated_args for op in inplaceable_foreach_ops.values()}
+)
 
 
 inplaceable_triton_ops = OrderedSet([triton_kernel_wrapper_functional])
@@ -887,17 +1052,37 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
         )
         return tensors_to_clone
 
+    def reinplace_registry_op(node, inplaceable_op) -> None:
+        # Check if ALL mutated args can be inplaced
+        # Only convert if we don't need to clone any tensor
+        mutated_args = [node.args[idx] for idx in inplaceable_op.mutated_args]
+        if all_can_inplace(node, mutated_args) and inplaceable_op.extra_check(node):
+            for mutated_arg in mutated_args:
+                copy_node = copy_node_for_reinplaced_arg(node, mutated_arg)
+                if copy_node is not None:
+                    replace_dict[copy_node] = copy_node.args[0]
+            node.target = inplaceable_op.inplace_op
+
+    # Scatters are decided in a second sweep, once every other decision in this
+    # graph has been taken. should_reinplace_scatter has to know whether the
+    # scatter's result can escape as an alias of a graph input, and that
+    # depends on which of the other copy-removal mechanisms here fired -- the
+    # in-place rewrites, only_clone_these_tensors, tensors_to_clone. Deferring
+    # lets the alias walks read the answer off the rewritten graph instead of
+    # predicting it, which no prediction can do exactly.
+    #
+    # No decision below depends on a scatter's own decision: can_inplace and
+    # the copy_ bookkeeping read storage, node_order, meta["val"] and the users
+    # of a node, none of which reinplacing a scatter changes; the only targets
+    # they compare against (view ops and aten.copy_) are never rewritten here.
+    deferred_scatters: list[tuple[torch.fx.Node, InplaceableOp]] = []
+
     for node in graph.nodes:
         if (inplaceable_op := inplaceable_ops.get(node.target)) is not None:
-            # Check if ALL mutated args can be inplaced
-            # Only convert if we don't need to clone any tensor
-            mutated_args = [node.args[idx] for idx in inplaceable_op.mutated_args]
-            if all_can_inplace(node, mutated_args) and inplaceable_op.extra_check(node):
-                for mutated_arg in mutated_args:
-                    copy_node = copy_node_for_reinplaced_arg(node, mutated_arg)
-                    if copy_node is not None:
-                        replace_dict[copy_node] = copy_node.args[0]
-                node.target = inplaceable_op.inplace_op
+            if node.target is _generalized_scatter:
+                deferred_scatters.append((node, inplaceable_op))
+            else:
+                reinplace_registry_op(node, inplaceable_op)
         elif node.target is torch.ops.higher_order.auto_functionalized_v2:
             _mutable_op = node.args[0]
             kwargs = node.kwargs
@@ -1123,6 +1308,15 @@ def reinplace_inplaceable_ops_core(graph: torch.fx.Graph) -> None:
                     replace_dict[copy_node] = copy_node.args[0]
 
                 node.target = inplaceable_op.inplace_op
+
+    # Second sweep: the scatters, in graph order. Every node upstream of a
+    # scatter has been decided, so its input walk is exact; the only undecided
+    # nodes its escape walk can reach are later scatters, and each of those
+    # re-runs the input walk with this decision in place before it can build an
+    # alias of its own.
+    for node, inplaceable_op in deferred_scatters:
+        reinplace_registry_op(node, inplaceable_op)
+
     for node, replacement in replace_dict.items():
         while replacement in replace_dict:
             replacement = replace_dict[replacement]

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -219,8 +219,22 @@ def scatter_always_uses_mutation(node: torch.fx.Node) -> bool:
     )
 
 
+def _reinplace_aliases_arg(node: torch.fx.Node, arg: torch.fx.Node) -> bool:
+    """Whether reinplacing node, an inplaceable op, makes its result alias arg."""
+    inplaceable_op = inplaceable_ops.get(node.target)
+    return inplaceable_op is not None and any(
+        node.args[idx] is arg for idx in inplaceable_op.mutated_args
+    )
+
+
 def _result_escapes_graph(node: torch.fx.Node) -> bool:
-    """Whether node's result, or a view alias of it, is returned from the graph."""
+    """Whether node's result, or an alias of it, is returned from the graph.
+
+    Views alias their input. So does the result of an inplaceable op once the
+    pass reinplaces it onto that input; the pass visits it after node, so the
+    escape check here treats it as an alias to stay valid for the rewritten
+    graph.
+    """
     aliases = OrderedSet([node])
     stack = [node]
     while stack:
@@ -231,12 +245,37 @@ def _result_escapes_graph(node: torch.fx.Node) -> bool:
             if user in aliases:
                 continue
             # getitem only aliases cur when cur is a multi-output view (e.g. split)
-            if _is_view_op(user.target) or (
-                user.target is operator.getitem and _is_view_op(cur.target)
+            if (
+                _is_view_op(user.target)
+                or (user.target is operator.getitem and _is_view_op(cur.target))
+                or _reinplace_aliases_arg(user, cur)
             ):
                 aliases.add(user)
                 stack.append(user)
     return False
+
+
+def _aliases_graph_input(node: torch.fx.Node) -> bool:
+    """Whether node is a graph input or aliases one.
+
+    Follows view chains (and getitem on multi-output views) back to their base,
+    and steps through ops the pass already rewrote in place, whose result is
+    their mutated arg.
+    """
+    while node.op not in ("placeholder", "get_attr"):
+        if (mutated_args := _INPLACE_OP_TO_MUTATED_ARGS.get(node.target)) is not None:
+            base = node.args[mutated_args[0]]
+        elif node.args and (
+            _is_view_op(node.target)
+            or (node.target is operator.getitem and _is_view_op(node.args[0].target))  # type: ignore[union-attr]
+        ):
+            base = node.args[0]
+        else:
+            return False
+        if not isinstance(base, torch.fx.Node):
+            return False
+        node = base
+    return True
 
 
 def should_reinplace_scatter(node: torch.fx.Node) -> bool:
@@ -250,10 +289,11 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
     inp, _src, _view_ops = node.args
 
     # Reinplacing makes the result the same tensor as inp. When inp is a graph
-    # input, reinplacing here is paired with dropping the copy_ back into it, so
-    # the caller holds inp itself; returning the result as well would hand back an
-    # alias of inp where the functional scatter returns a fresh tensor.
-    if inp.op in ("placeholder", "get_attr") and _result_escapes_graph(node):  # type: ignore[union-attr]
+    # input, or aliases one, reinplacing here is paired with dropping the copy_
+    # back into it, so the caller holds inp itself; returning the result as well
+    # would hand back an alias of inp where the functional scatter returns a
+    # fresh tensor.
+    if _aliases_graph_input(inp) and _result_escapes_graph(node):  # type: ignore[arg-type]
         return False
 
     # Mutating scatter ops unconditionally realize input and output
@@ -434,6 +474,10 @@ except AttributeError:
     # _c10d_functional ops are only available when torch
     # is built with USE_DISTRIBUTED=1.
     pass
+
+_INPLACE_OP_TO_MUTATED_ARGS = {
+    op.inplace_op: op.mutated_args for op in inplaceable_ops.values()
+}
 
 inplaceable_foreach_ops: dict[torch._ops.OpOverload, InplaceableOp] = {}
 for outplace_op, inplace_op in inplaceable_foreach_ops_lowerings.items():

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -219,6 +219,26 @@ def scatter_always_uses_mutation(node: torch.fx.Node) -> bool:
     )
 
 
+def _result_escapes_graph(node: torch.fx.Node) -> bool:
+    """Whether node's result, or a view alias of it, is returned from the graph."""
+    aliases = OrderedSet([node])
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        for user in cur.users:
+            if user.op == "output":
+                return True
+            if user in aliases:
+                continue
+            # getitem only aliases cur when cur is a multi-output view (e.g. split)
+            if _is_view_op(user.target) or (
+                user.target is operator.getitem and _is_view_op(cur.target)
+            ):
+                aliases.add(user)
+                stack.append(user)
+    return False
+
+
 def should_reinplace_scatter(node: torch.fx.Node) -> bool:
     """Choose between mutating and functional scatter decompositions
 
@@ -228,6 +248,13 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
 
     """
     inp, _src, _view_ops = node.args
+
+    # Reinplacing makes the result the same tensor as inp. When inp is a graph
+    # input, reinplacing here is paired with dropping the copy_ back into it, so
+    # the caller holds inp itself; returning the result as well would hand back an
+    # alias of inp where the functional scatter returns a fresh tensor.
+    if inp.op in ("placeholder", "get_attr") and _result_escapes_graph(node):  # type: ignore[union-attr]
+        return False
 
     # Mutating scatter ops unconditionally realize input and output
     if scatter_always_uses_mutation(node):

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -313,11 +313,22 @@ def _multi_output_aliases(node: torch.fx.Node) -> Any:
             or not isinstance(all_bases, (list, tuple))
         ):
             return _UNRESOLVED_ALIASES
-        return {
+        aliases = {
             offset + i: base
             for i, base in enumerate(all_bases)
             if i not in to_clone  # type: ignore[operator]
         }
+        mutable_op = node.args[0]
+        if (
+            isinstance(mutable_op, torch._ops.OpOverload)
+            and torch.Tag.inplace in mutable_op.tags
+        ):
+            # The op's own return may be a view of the mutated base.
+            name = mutable_op._schema.arguments[0].name
+            base_index = node.kwargs.get(f"_{name}_base_index")
+            if isinstance(base_index, int) and offset + base_index in aliases:
+                aliases[0] = aliases[offset + base_index]
+        return aliases
 
     if target is torch.ops.higher_order.with_effects:
         # with_effects(token, op, *args) -> (token, *results). Once the pass

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -251,7 +251,10 @@ def _auto_functionalized_result_offset(mutable_op: Any) -> int | None:
     return max(1, len(mutable_op._schema.returns))
 
 
-def _multi_output_aliases(node: torch.fx.Node) -> Any:
+def _multi_output_aliases(
+    node: torch.fx.Node,
+    mutated_args_by_op: dict[Callable[..., Any], tuple[int, ...]],
+) -> Any:
     """Which elements of a multi-output node alias one of its arguments.
 
     Returns a dict mapping the index (or, for the Triton wrapper, the key) of
@@ -273,7 +276,7 @@ def _multi_output_aliases(node: torch.fx.Node) -> Any:
         parent = node.args[0]
         if not isinstance(parent, torch.fx.Node):
             return None
-        parent_aliases = _multi_output_aliases(parent)
+        parent_aliases = _multi_output_aliases(parent, mutated_args_by_op)
         if not isinstance(parent_aliases, dict):
             return None
         element = parent_aliases.get(node.args[1])
@@ -283,7 +286,7 @@ def _multi_output_aliases(node: torch.fx.Node) -> Any:
         waited = node.args[0] if node.args else None
         return dict(enumerate(waited)) if isinstance(waited, (list, tuple)) else None
 
-    if (mutated_args := _INPLACE_OP_TO_MUTATED_ARGS.get(target)) is not None:
+    if (mutated_args := mutated_args_by_op.get(target)) is not None:
         # An op the pass reinplaced over a list of tensors -- the coalesced
         # collectives and the foreach ops -- returns each element in place.
         arg = node.args[mutated_args[0]] if mutated_args[0] < len(node.args) else None
@@ -334,7 +337,7 @@ def _multi_output_aliases(node: torch.fx.Node) -> Any:
         # with_effects(token, op, *args) -> (token, *results). Once the pass
         # swaps in the mutating op, result i is its i-th mutated argument.
         inner_op = node.args[1] if len(node.args) > 1 else None
-        inner_mutated_args = _INPLACE_OP_TO_MUTATED_ARGS.get(inner_op)  # type: ignore[arg-type]
+        inner_mutated_args = mutated_args_by_op.get(inner_op)  # type: ignore[arg-type]
         if inner_mutated_args is None:
             return {}
         return {
@@ -357,7 +360,10 @@ def _multi_output_aliases(node: torch.fx.Node) -> Any:
     return None
 
 
-def _alias_sources(node: torch.fx.Node) -> list[torch.fx.Node]:
+def _alias_sources(
+    node: torch.fx.Node,
+    mutated_args_by_op: dict[Callable[..., Any], tuple[int, ...]],
+) -> list[torch.fx.Node]:
     """The nodes whose result node's result aliases in the rewritten graph.
 
     This is the one place the pass' copy-removal mechanisms are turned into
@@ -376,7 +382,7 @@ def _alias_sources(node: torch.fx.Node) -> list[torch.fx.Node]:
         # getitem only aliases parent when parent is a multi-output view
         if _is_view_op(parent.target):
             return [parent]
-        parent_aliases = _multi_output_aliases(parent)
+        parent_aliases = _multi_output_aliases(parent, mutated_args_by_op)
         if parent_aliases is _UNRESOLVED_ALIASES:
             return _flat_node_args(parent)
         if isinstance(parent_aliases, dict):
@@ -386,18 +392,22 @@ def _alias_sources(node: torch.fx.Node) -> list[torch.fx.Node]:
     if node.args and (_is_view_op(target) or target is _WAIT_TENSOR_OP):
         return _as_alias_nodes(node.args[0])
 
-    if (mutated_args := _INPLACE_OP_TO_MUTATED_ARGS.get(target)) is not None:
+    if (mutated_args := mutated_args_by_op.get(target)) is not None:
         if mutated_args[0] < len(node.args):
             return _as_alias_nodes(node.args[mutated_args[0]])
 
     return []
 
 
-def _carries_alias(node: torch.fx.Node, known: OrderedSet[torch.fx.Node]) -> bool:
+def _carries_alias(
+    node: torch.fx.Node,
+    known: OrderedSet[torch.fx.Node],
+    mutated_args_by_op: dict[Callable[..., Any], tuple[int, ...]],
+) -> bool:
     """Whether node's result is, or contains, an alias of a node in known."""
-    if any(source in known for source in _alias_sources(node)):
+    if any(source in known for source in _alias_sources(node, mutated_args_by_op)):
         return True
-    aliases = _multi_output_aliases(node)
+    aliases = _multi_output_aliases(node, mutated_args_by_op)
     if aliases is _UNRESOLVED_ALIASES:
         return any(arg in known for arg in _flat_node_args(node))
     if isinstance(aliases, dict):
@@ -409,7 +419,10 @@ def _carries_alias(node: torch.fx.Node, known: OrderedSet[torch.fx.Node]) -> boo
     return False
 
 
-def _result_escapes_graph(node: torch.fx.Node) -> bool:
+def _result_escapes_graph(
+    node: torch.fx.Node,
+    mutated_args_by_op: dict[Callable[..., Any], tuple[int, ...]],
+) -> bool:
     """Whether node's result, or an alias of it, is returned from the graph."""
     aliases = OrderedSet([node])
     stack = [node]
@@ -420,13 +433,16 @@ def _result_escapes_graph(node: torch.fx.Node) -> bool:
                 return True
             if user in aliases:
                 continue
-            if _carries_alias(user, aliases):
+            if _carries_alias(user, aliases, mutated_args_by_op):
                 aliases.add(user)
                 stack.append(user)
     return False
 
 
-def _aliases_graph_input(node: torch.fx.Node) -> bool:
+def _aliases_graph_input(
+    node: torch.fx.Node,
+    mutated_args_by_op: dict[Callable[..., Any], tuple[int, ...]],
+) -> bool:
     """Whether node is a graph input or aliases one."""
     seen = OrderedSet([node])
     stack = [node]
@@ -434,7 +450,7 @@ def _aliases_graph_input(node: torch.fx.Node) -> bool:
         cur = stack.pop()
         if cur.op in ("placeholder", "get_attr"):
             return True
-        for source in _alias_sources(cur):
+        for source in _alias_sources(cur, mutated_args_by_op):
             if source not in seen:
                 seen.add(source)
                 stack.append(source)
@@ -451,12 +467,21 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
     """
     inp, _src, _view_ops = node.args
 
+    # Read the live registries once for both alias walks.
+    mutated_args_by_op = {
+        op.inplace_op: op.mutated_args
+        for op in itertools.chain(
+            inplaceable_ops.values(), inplaceable_foreach_ops.values()
+        )
+    }
+
     # Reinplacing makes the result the same tensor as inp. When inp is a graph
     # input, or aliases one, reinplacing here is paired with dropping the copy_
     # back into it, so the caller holds inp itself; returning the result as well
     # would hand back an alias of inp where the functional scatter returns a
     # fresh tensor.
-    if _aliases_graph_input(inp) and _result_escapes_graph(node):  # type: ignore[arg-type]
+    aliases_input = _aliases_graph_input(inp, mutated_args_by_op)  # type: ignore[arg-type]
+    if aliases_input and _result_escapes_graph(node, mutated_args_by_op):
         return False
 
     # Mutating scatter ops unconditionally realize input and output
@@ -645,20 +670,9 @@ except AttributeError:
     # is built with USE_DISTRIBUTED=1.
     pass
 
-_INPLACE_OP_TO_MUTATED_ARGS = {
-    op.inplace_op: op.mutated_args for op in inplaceable_ops.values()
-}
-
 inplaceable_foreach_ops: dict[torch._ops.OpOverload, InplaceableOp] = {}
 for outplace_op, inplace_op in inplaceable_foreach_ops_lowerings.items():
     inplaceable_foreach_ops[outplace_op] = InplaceableOp(inplace_op, 0)
-
-# The alias walks read node.target after this pass rewrote it, so they need the
-# mutated-argument layout of every op the pass can swap in, foreach included.
-_INPLACE_OP_TO_MUTATED_ARGS.update(
-    {op.inplace_op: op.mutated_args for op in inplaceable_foreach_ops.values()}
-)
-
 
 inplaceable_triton_ops = OrderedSet([triton_kernel_wrapper_functional])
 


### PR DESCRIPTION
Fixes #195451

Under `torch.compile`, returning the result of a `slice_scatter` that is also copied back into its input hands the caller an alias of the input. Eager returns an independent tensor. Any later in-place op on the returned value then silently corrupts the input: the issue's repro reads back `[110., 102.]` where eager keeps `[10., 2.]`. A defensive `.clone()` inside the compiled function does not help; the returned tensor still aliases the input.

The cause is in `should_reinplace_scatter()` (`torch/_inductor/fx_passes/reinplace.py`). The `is_node_realized(inp) and is_node_realized(node)` shortcut treats a scatter result whose user is the graph output as "realized" and approves reinplacing, without checking that the result is still needed by the caller. Reinplacing then fuses the result into the input tensor, and the two become one.

The fix adds `_result_escapes_graph()`: walk the scatter result's users through view and getitem-of-view aliasing, and refuse to reinplace when the walk reaches the graph output. The check runs first in `should_reinplace_scatter()`, ahead of the realization shortcut and `scatter_always_uses_mutation`, so it covers every path that could approve the unsafe reinplace. Results that stay inside the graph are unaffected: `y = scatter(x); x.copy_(y); return y.sum()` still reinplaces, and the existing legality layer still handles in-graph mutation ordering.

Test plan:

    TORCHINDUCTOR_FORCE_DISABLE_CACHES=1 python -m pytest test/inductor/test_torchinductor.py -v -k "slice_scatter_reinplace"

Five new subtests: plain return, view of the result, split/getitem, module buffer, multi-target copy-back. All five fail without the fix and pass with it (`2 passed, 1464 deselected, 5 subtests passed`). The buffer case lowers to a placeholder input since AOTAutograd lifts mutated buffers, so the guard's `get_attr` arm is defense-in-depth for export-style graphs rather than directly exercised; a test comment documents this.

Also ran: 93 targeted `test_torchinductor` selections and 47 `auto_functionalize`/`control_deps` tests, all passing; `lintrunner` clean. Verification was CPU-only; the guard is device-independent FX logic and the new tests are device-generic, so CUDA coverage rides CI.

AI assisted.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo