### PR TITLE
[c10d] Make NCCL2 Work teardown lifetime-safe

### DIFF
--- a/test/distributed/test_c10d_nccl2.py
+++ b/test/distributed/test_c10d_nccl2.py
@@ -3,6 +3,7 @@
 # Tests specific to the in-tree torchcomms NCCL backends.
 
 import ctypes
+import gc
 import json
 import os
 import pickle
@@ -20,6 +21,7 @@ import torch.distributed as dist
 from torch._C._distributed_c10d import ErrorType, ReconfigureOptions
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
+    MultiProcessTestCase,
     requires_nccl,
     requires_nccl_version,
     skip_if_lt_x_gpu,
@@ -204,6 +206,46 @@ class ProcessGroupNCCL2Test(MultiProcContinuousTest):
             work.wait()
             time.sleep(0.1)
         self.fail("ephemeral timeout was not reset after collective completion")
+
+
+class ProcessGroupNCCL2WorkLifetimeTest(MultiProcessTestCase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    @property
+    def destroy_pg_upon_exit(self) -> bool:
+        return False
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        try:
+            os.remove(self.file_name)
+        except OSError:
+            pass
+
+    @requires_nccl()
+    @skip_if_lt_x_gpu(2)
+    def test_work_outlives_process_group(self) -> None:
+        device = torch.device("cuda", self.rank)
+        torch.cuda.set_device(device)
+        dist.init_process_group(
+            "nccl2",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=dist.FileStore(self.file_name, self.world_size),
+            device_id=device,
+        )
+        work = dist.all_reduce(torch.ones(4, device=device), async_op=True)
+        work.wait()
+
+        dist.destroy_process_group()
+        del work
+        gc.collect()
 
 
 class _ProcessGroupNCCL2OptionsTest(MultiProcContinuousTest):

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp
@@ -269,8 +269,6 @@ void ProcessGroupNCCL::initNcclResources() {
     dependency_event_.emplace(cudaEventDisableTiming);
   }
 
-  max_event_pool_size_ = kDefaultMaxEventPoolSize;
-
   NCCL_CHECK(
       nccl_api_,
       nccl_comm_,
@@ -559,13 +557,7 @@ void ProcessGroupNCCL::finalize() {
     }
   }
 
-  // Clean up event pool
-  {
-    std::lock_guard<std::mutex> lock(event_pool_mutex_);
-    while (!event_pool_.empty()) {
-      event_pool_.pop();
-    }
-  }
+  event_pool_->clear();
 
   barrier_buffer_.clear();
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp
@@ -371,21 +371,16 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // Underlying host ncclComm_t as an opaque integer pointer.
   int64_t getCommPtr() const;
   bool collectivesTimingEnabled() const {
-    return timing_enabled_.load();
+    return event_pool_->timingEnabled();
+  }
+  const std::shared_ptr<NCCLEventPool>& getEventPool() const {
+    return event_pool_;
   }
 
   friend class WorkNCCL;
   friend class WindowNCCL;
 
  protected:
-  // Events are pooled per timing mode: an event created with timing disabled
-  // cannot serve a work that needs elapsed_time(), so `timing_enabled` must
-  // describe the work the event is taken for / returned from.
-  [[nodiscard]] std::unique_ptr<at::cuda::CUDAEvent> getEvent(
-      bool timing_enabled);
-  void returnEvent(
-      std::unique_ptr<at::cuda::CUDAEvent> event,
-      bool timing_enabled);
   void waitForNcclOperation(
       ncclResult_t status,
       std::chrono::milliseconds timeout,
@@ -629,7 +624,6 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   // NOTE: the rank is stored in the inherited c10d::Backend::rank_ (set in the
   // ctor and refreshed from NCCL in initNcclResources). The ported engine code
   // reads/writes `rank_` directly, which resolves to that protected member.
-  size_t max_event_pool_size_{};
   std::optional<at::cuda::CUDAStream> internal_stream_;
   std::optional<at::cuda::CUDAEvent> dependency_event_;
   at::DataPtr barrier_buffer_;
@@ -647,12 +641,7 @@ class TORCH_API ProcessGroupNCCL : public ::c10d::Backend {
   std::shared_ptr<NcclApi> nccl_api_;
   std::unique_ptr<at::cuda::MemPool> memPool_;
 
-  std::queue<std::unique_ptr<at::cuda::CUDAEvent>> event_pool_;
-  std::mutex event_pool_mutex_;
-  const bool event_cache_enabled_;
-  // Set by enableCollectivesTiming(); mutated under event_pool_mutex_ so the
-  // pool never holds events whose timing mode disagrees with it.
-  std::atomic<bool> timing_enabled_{false};
+  std::shared_ptr<NCCLEventPool> event_pool_;
 
   WorkNCCLQueue workq_;
 

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp
@@ -88,9 +88,10 @@ ProcessGroupNCCL::ProcessGroupNCCL(
     : Backend(rank, size),
       device_(at::kCUDA),
       store_(std::move(store)),
-      event_cache_enabled_(
-          getCvarBool(::c10d::TORCH_NCCL_CUDA_EVENT_CACHE, true)),
-      timing_enabled_(getCvarBool(::c10d::TORCH_NCCL_ENABLE_TIMING, false)),
+      event_pool_(std::make_shared<NCCLEventPool>(
+          getCvarBool(::c10d::TORCH_NCCL_CUDA_EVENT_CACHE, true),
+          getCvarBool(::c10d::TORCH_NCCL_ENABLE_TIMING, false),
+          kDefaultMaxEventPoolSize)),
       async_error_handling_(static_cast<::c10d::ErrorHandlingMode>(getCvarInt(
           ::c10d::TORCH_NCCL_ASYNC_ERROR_HANDLING,
           ::c10d::SkipCleanUp))),

--- a/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp
@@ -542,41 +542,8 @@ void ProcessGroupNCCL::checkTensorsDevice(
   }
 }
 
-// Protected methods (not in the private section of the header)
-std::unique_ptr<at::cuda::CUDAEvent> ProcessGroupNCCL::getEvent(
-    bool timing_enabled) {
-  std::lock_guard<std::mutex> lock(event_pool_mutex_);
-
-  if (event_cache_enabled_ && timing_enabled == timing_enabled_.load() &&
-      !event_pool_.empty()) {
-    auto event = std::move(event_pool_.front());
-    event_pool_.pop();
-    return event;
-  }
-
-  return std::make_unique<at::cuda::CUDAEvent>(
-      timing_enabled ? cudaEventDefault : cudaEventDisableTiming);
-}
-
-void ProcessGroupNCCL::returnEvent(
-    std::unique_ptr<at::cuda::CUDAEvent> event,
-    bool timing_enabled) {
-  std::lock_guard<std::mutex> lock(event_pool_mutex_);
-
-  if (event_cache_enabled_ && timing_enabled == timing_enabled_.load() &&
-      event_pool_.size() < max_event_pool_size_) {
-    event_pool_.push(std::move(event));
-  }
-}
-
 void ProcessGroupNCCL::enableCollectivesTiming() {
-  std::lock_guard<std::mutex> lock(event_pool_mutex_);
-  if (timing_enabled_.exchange(true)) {
-    return;
-  }
-  // Pooled events were created with timing disabled and cannot serve
-  // getDuration(); drop them so later works get timing-capable events.
-  std::queue<std::unique_ptr<at::cuda::CUDAEvent>>().swap(event_pool_);
+  event_pool_->enableTiming();
 }
 
 void ProcessGroupNCCL::attachMemoryHook() {

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp
@@ -23,12 +23,60 @@ namespace {
 std::atomic<uint64_t> nextCompletionKey{1};
 } // namespace
 
+NCCLEventPool::NCCLEventPool(
+    bool cacheEnabled,
+    bool timingEnabled,
+    size_t maxSize)
+    : event_cache_enabled_(cacheEnabled),
+      max_event_pool_size_(maxSize),
+      timing_enabled_(timingEnabled) {}
+
+std::unique_ptr<at::cuda::CUDAEvent> NCCLEventPool::getEvent(
+    bool timingEnabled) {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  if (event_cache_enabled_ && timingEnabled == timing_enabled_.load() &&
+      !event_pool_.empty()) {
+    auto event = std::move(event_pool_.front());
+    event_pool_.pop();
+    return event;
+  }
+  return std::make_unique<at::cuda::CUDAEvent>(
+      timingEnabled ? cudaEventDefault : cudaEventDisableTiming);
+}
+
+void NCCLEventPool::returnEvent(
+    std::unique_ptr<at::cuda::CUDAEvent> event,
+    bool timingEnabled) {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  if (event_cache_enabled_ && timingEnabled == timing_enabled_.load() &&
+      event_pool_.size() < max_event_pool_size_) {
+    event_pool_.push(std::move(event));
+  }
+}
+
+void NCCLEventPool::clear() {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  std::queue<std::unique_ptr<at::cuda::CUDAEvent>>().swap(event_pool_);
+}
+
+void NCCLEventPool::enableTiming() {
+  std::lock_guard<std::mutex> lock(event_pool_mutex_);
+  if (timing_enabled_.exchange(true)) {
+    return;
+  }
+  std::queue<std::unique_ptr<at::cuda::CUDAEvent>>().swap(event_pool_);
+}
+
+bool NCCLEventPool::timingEnabled() const {
+  return timing_enabled_.load();
+}
+
 struct WorkNCCL::Events {
-  Events(ProcessGroupNCCL* comm, bool timing_enabled)
-      : comm(comm),
+  Events(const std::shared_ptr<NCCLEventPool>& eventPool, bool timing_enabled)
+      : eventPool(eventPool),
         timingEnabled(timing_enabled),
-        start(comm->getEvent(timing_enabled)),
-        end(comm->getEvent(timing_enabled)) {}
+        start(eventPool->getEvent(timing_enabled)),
+        end(eventPool->getEvent(timing_enabled)) {}
 
   Events(const Events&) = delete;
   Events(Events&&) = delete;
@@ -36,11 +84,13 @@ struct WorkNCCL::Events {
   Events& operator=(Events&&) = delete;
 
   ~Events() {
-    comm->returnEvent(std::move(start), timingEnabled);
-    comm->returnEvent(std::move(end), timingEnabled);
+    if (auto pool = eventPool.lock()) {
+      pool->returnEvent(std::move(start), timingEnabled);
+      pool->returnEvent(std::move(end), timingEnabled);
+    }
   }
 
-  ProcessGroupNCCL* comm;
+  std::weak_ptr<NCCLEventPool> eventPool;
   bool timingEnabled;
   std::unique_ptr<at::cuda::CUDAEvent> start;
   std::unique_ptr<at::cuda::CUDAEvent> end;
@@ -76,7 +126,7 @@ WorkNCCL::State::State(
       timeout(timeout),
       completionKey(nextCompletionKey.fetch_add(1, std::memory_order_relaxed)),
       timingEnabled(comm->collectivesTimingEnabled()),
-      events(std::make_shared<Events>(comm, timingEnabled)),
+      events(std::make_shared<Events>(comm->getEventPool(), timingEnabled)),
       durationStartEvents(events),
       futureWorkResult(
           c10::make_intrusive<c10::ivalue::Future>(c10::AnyEnumType::get())) {}

--- a/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
+++ b/torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
@@ -26,14 +26,36 @@ namespace c10d::nccl2 {
 
 class ProcessGroupNCCL;
 
+// Kept separate from ProcessGroupNCCL so a Work can safely drop its events
+// after the process group is destroyed without extending the group's lifetime.
+class NCCLEventPool {
+ public:
+  NCCLEventPool(bool cacheEnabled, bool timingEnabled, size_t maxSize);
+
+  std::unique_ptr<at::cuda::CUDAEvent> getEvent(bool timingEnabled);
+  void returnEvent(
+      std::unique_ptr<at::cuda::CUDAEvent> event,
+      bool timingEnabled);
+  void clear();
+  void enableTiming();
+  bool timingEnabled() const;
+
+ private:
+  std::mutex event_pool_mutex_;
+  std::queue<std::unique_ptr<at::cuda::CUDAEvent>> event_pool_;
+  const bool event_cache_enabled_;
+  const size_t max_event_pool_size_;
+  std::atomic<bool> timing_enabled_;
+};
+
 // Work object for the NCCL TorchComms backend. Ported from torchcomms'
 // WorkNCCL, but rebased onto c10d::Work (upstream subclassed
 // torchcomms::TorchWork). Completion is tracked with a pair of CUDA events;
 // the Future/result handling that BackendWrapper::WorkWrapper used to provide
 // is folded in here (see setOutputs/getFuture). The back-pointer to the owning
-// backend is non-owning: the backend drains its work queue in finalize()/dtor,
-// so a work never outlives its backend (upstream held a shared_ptr, which is
-// incompatible with c10d's intrusive_ptr ownership of the backend).
+// backend is non-owning: finalize() completes pending work before destroying
+// the backend, while the event pool is independently lifetime-safe for a
+// completed caller-owned Work that outlives the backend.
 class WorkNCCL : public c10d::Work {
  public:
   enum class WorkStatus {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #193241
* #192281
* __->__ #195485

WorkNCCL event bundles returned CUDA events through a raw ProcessGroupNCCL pointer. Caller-owned async Work can remain alive after destroy_process_group drains and destroys the backend, so later Work destruction dereferenced freed memory and caused heap corruption or a hang.

Move event-cache state into a separately owned object. Work event bundles keep a weak cache reference and return events only while the cache remains alive; otherwise the events are destroyed directly. This preserves caching and timing without keeping the process group alive or creating a cycle with coalesced work.

Add a regression that destroys the process group before releasing completed Work.

Test Plan:

```bash
BUILD_TEST=0 USE_FBGEMM=0 USE_NNPACK=0 USE_QNNPACK=0 USE_XNNPACK=0 USE_FLASH_ATTENTION=0 USE_MEM_EFF_ATTENTION=0 USE_DISTRIBUTED=1 USE_CUDA=1 VIRTUAL_ENV=/home/tristanr/pytorch/.venv PATH=/home/tristanr/pytorch/.venv/bin:$PATH uv pip install -e . -v --no-build-isolation
```

```bash
env VIRTUAL_ENV=/home/tristanr/pytorch/.venv PATH=/home/tristanr/pytorch/.venv/bin:/home/tristanr/.local/bin:/usr/local/bin:/usr/bin:/bin CUDA_VISIBLE_DEVICES=0,1 NCCL_DEBUG=WARN uv run --no-project test/distributed/test_c10d_nccl2.py ProcessGroupNCCL2WorkLifetimeTest.test_work_outlives_process_group
```

```bash
env -u LOCAL_RANK VIRTUAL_ENV=/home/tristanr/pytorch/.venv PATH=/home/tristanr/pytorch/.venv/bin:/home/tristanr/.local/bin:/usr/local/bin:/usr/bin:/bin CUDA_VISIBLE_DEVICES=0,1 NCCL_DEBUG=WARN uv run --no-project test/distributed/tensor/debug/test_debug_mode.py TestDTensorDebugModeNCCLBackend.test_allgather_base_async_op
```

```bash
env VIRTUAL_ENV=/home/tristanr/pytorch/.venv PATH=/home/tristanr/pytorch/.venv/bin:/home/tristanr/.local/bin:/usr/local/bin:/usr/bin:/bin CUDA_VISIBLE_DEVICES=0,1 NCCL_DEBUG=WARN TORCH_NCCL_CUDA_EVENT_CACHE=0 TORCH_NCCL_ENABLE_TIMING=1 uv run --no-project test/distributed/test_c10d_nccl2.py ProcessGroupNCCL2WorkLifetimeTest.test_work_outlives_process_group
```

```bash
env VIRTUAL_ENV=/home/tristanr/pytorch/.venv PATH=/home/tristanr/pytorch/.venv/bin:/home/tristanr/.local/bin:/usr/local/bin:/usr/bin:/bin .venv/bin/spin lint test/distributed/test_c10d_nccl2.py torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.cpp torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCL.hpp torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLBackend.cpp torch/csrc/distributed/c10d/nccl2/ProcessGroupNCCLUtils.cpp torch/csrc/distributed/c10d/nccl2/WorkNCCL.cpp torch/csrc/distributed/c10d/nccl2/WorkNCCL.hpp
```

```bash
env VIRTUAL_ENV=/home/tristanr/pytorch/.venv PATH=/home/tristanr/pytorch/.venv/bin:/home/tristanr/.local/bin:/usr/local/bin:/usr/bin:/bin .venv/bin/lintrunner -a
```

Authored with an AI assistant.