### PR TITLE
Ignore periodic decorator tests internally

### DIFF
--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -663,6 +663,9 @@ class TestPeriodicDecorator(TestCase):
         self.assertEqual(result.failures, [])
         self.assertEqual(result.errors, [])
 
+    @unittest.skipIf(
+        IS_FBCODE, "run_test.py periodic filtering is only exercised by OSS CI"
+    )
     @skipIfTorchDynamo("subprocess test does not need Dynamo coverage")
     def test_periodic_config_selects_only_periodic_tests(self):
         source = """\


### PR DESCRIPTION
Summary: There is no point in running these GitHub specific tests internally. This does not skip the periodic tests themselves, just the tests that test the marker.

Test Plan: sandcastle

Reviewed By: izaitsevfb


