### PR TITLE
Align isScalar and toScalar implementations in IValue

### DIFF
--- a/aten/src/ATen/core/ivalue.h
+++ b/aten/src/ATen/core/ivalue.h
@@ -938,7 +938,7 @@ struct TORCH_API IValue final {
 
   bool isScalar() const {
     return isDouble() || isInt() || isComplexDouble() || isBool() ||
-        isSymInt() || isSymFloat() || isSymBool();
+        isSymInt() || isSymFloat() || isSymBool() || isUnsigned();
   }
 
   at::Scalar toScalar() const {


### PR DESCRIPTION
I noticed the discrepancy between isScalar and toScalar functions in ivalue.h. I am not sure if this is intentional and couldn't figure it out from the commit history. Creating this PR to bring this to the attention of someone more knowledgeable.