### PR TITLE
[CI] Advisor: install Bun from a pinned URL to skip a GitHub API call

### DIFF
--- a/.github/workflows/claude-autorevert-advisor.yml
+++ b/.github/workflows/claude-autorevert-advisor.yml
@@ -41,6 +41,32 @@ jobs:
         run: |
           git fetch origin ${{ inputs.suspect_commit }} --depth=32 || true
 
+      # Install Bun ourselves so that claude-code-action skips its own "Install
+      # Bun" step. That step runs oven-sh/setup-bun, which resolves the Bun
+      # version by requesting the oven-sh/bun tag list from api.github.com on
+      # every run, even though the version is already pinned. That request counts
+      # against this workflow's GITHUB_TOKEN API rate limit, and a 403 there fails
+      # the advisor run outright. Supplying an explicit download URL skips version
+      # resolution, so when this step succeeds that request is never made.
+      #
+      # continue-on-error preserves the existing bootstrap path: if this step
+      # fails, path_to_bun_executable below resolves to the empty string and the
+      # action falls back to installing Bun itself, as it does today.
+      #
+      # This runs before the AWS credentials are configured so that the download
+      # happens without them in the environment.
+      #
+      # The URL selects OS, architecture and version -- it does not pin the
+      # asset's bytes. Keep it consistent with the runs-on label above and with
+      # the bun-version pinned inside the claude-code-action ref below;
+      # -baseline is the portable x86-64 build.
+      - name: Install Bun
+        id: bun
+        continue-on-error: true
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-download-url: https://github.com/oven-sh/bun/releases/download/bun-v1.3.6/bun-linux-x64-baseline.zip
+
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
@@ -56,6 +82,9 @@ jobs:
           # source of the observed intermittent "Workflow validation failed"
           # 401s, which require the workflow to match the default branch.
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Skips the action's own Install Bun step. Empty if that install
+          # failed, in which case the action installs Bun itself -- see the note.
+          path_to_bun_executable: ${{ steps.bun.outcome == 'success' && steps.bun.outputs.bun-path || '' }}
           allowed_bots: "pytorch-auto-revert[bot],pytorch-bot[bot]"
           use_bedrock: "true"
           claude_args: |


### PR DESCRIPTION
✴️ iz2: ## Summary

Every run of the Claude CI Advisor makes an authenticated `api.github.com` request purely to resolve a Bun version that is already pinned.

`anthropics/claude-code-action`'s first composite step installs Bun with `oven-sh/setup-bun`, guarded only by `if: inputs.path_to_bun_executable == ''`:

```yaml
- name: Install Bun
  if: inputs.path_to_bun_executable == ''
  uses: oven-sh/setup-bun@3d267786... # v2.1.2
  with:
    bun-version: 1.3.6
    token: ${{ inputs.github_token || github.token }}
```

`setup-bun` resolves that version by fetching `https://api.github.com/repos/oven-sh/bun/git/refs/tags`, and it does so unconditionally — `getDownloadUrl()` returns early only when `bun-download-url` is supplied, and the request is issued before any cache or existing-install check. So an exact pin does not avoid it, and a tool-cache hit does not avoid it.

On 2026-08-28 that request began returning `403 API rate limit exceeded for installation` and **24 advisor runs failed** in two bursts before the limit recovered. The failure mode is hard rather than graceful: Bun is left uninstalled and the next composite step's `bun install` exits 127.

## What this changes

Install Bun in the workflow from an explicit release URL — which skips `setup-bun`'s version resolution, so the request is never made — and pass the resulting path as `path_to_bun_executable`, so the action skips its own install step.

`continue-on-error: true` plus the `steps.bun.outcome == 'success'` guard preserve today's bootstrap path: if the download fails, `path_to_bun_executable` resolves to the empty string and the action installs Bun itself.

The `claude-code-action` pin is untouched.

## Test plan

Both shapes were run end-to-end in `pytorch/ciforge` on `ubuntu-24.04`, against the same action pin, model, `--json-schema` and `settings` this workflow uses (run `33436700593`), with the same step ordering as this PR:

| arm | the action's own `Install Bun` | result |
| --- | --- | --- |
| this PR's shape | `skipped`, `duration_ms=0` | structured verdict produced, job green |
| same, download URL pointed at a nonexistent asset | ran, `duration_ms=1241` | structured verdict produced, job green |

The second arm exercises the fallback: `steps.bun.outcome` was `failure`, the resolved `path_to_bun_executable` was the empty string, and the action installed Bun itself.

A separate control established that `bun-download-url` genuinely bypasses version resolution rather than merely appearing to: `setup-bun` given *both* an unresolvable `bun-version: 99.99.99` *and* a valid download URL installed 1.3.6 and succeeded, where the semver path would have raised `No Bun release found matching version '99.99.99'`.

The runner image was also measured: no preinstalled Bun, `x86_64` — so the workflow does have to supply Bun itself.

## Trade-offs

- **Bun is downloaded on every run.** Supplying a custom URL disables `setup-bun`'s tool cache, so the archive is fetched each time instead of sometimes being restored from cache. That swaps a rate-limited authenticated API request for an unauthenticated release-asset download.
- **The URL selects OS, architecture and version — it does not pin the asset's bytes.** It is the same download source the action already uses today.
- **The version coupling is a comment, not a mechanism.** The Bun version needs to stay compatible with whatever `claude-code-action` ref this workflow pins, and the URL's platform needs to stay consistent with the `runs-on` label. Both are noted inline.
- `-baseline` is used rather than the AVX2 build. The runner we measured reports AVX2, but that is a property of the machine we happened to get, not a guarantee of the label.

The durable fix belongs upstream: `setup-bun` could construct the release URL directly for exact versions and query the tags API only for ranges and aliases. This is the repo-local workaround until then.