### PR TITLE
[Dynamo] Load graph_break_registry.json using importlib.resources

### DIFF
--- a/torch/_dynamo/exc.py
+++ b/torch/_dynamo/exc.py
@@ -61,12 +61,11 @@ import types
 import typing
 from enum import auto, Enum
 from functools import lru_cache
-from pathlib import Path
+from importlib import resources
 from traceback import format_exc, format_list, FrameSummary, StackSummary
 from typing import Any, NoReturn, TYPE_CHECKING
 
 import torch._guards
-from torch._utils_internal import get_file_path_2
 
 from . import config
 from .utils import counters
@@ -691,11 +690,8 @@ def _load_gb_type_to_gb_id_map() -> dict[str, Any]:
     Includes historical gb_type (mapping behavior of duplicate gb_types with different gb_ids is undefined).
     """
     try:
-        script_dir = Path(__file__).resolve().parent
-        registry_path = get_file_path_2(
-            "", str(script_dir), "graph_break_registry.json"
-        )
-        with open(registry_path) as f:
+        resource = resources.files(__package__).joinpath("graph_break_registry.json")
+        with resource.open("r", encoding="utf-8") as f:
             registry = json.load(f)
     except Exception:
         log.exception("Error accessing the registry file")


### PR DESCRIPTION
## Summary
Update `_load_gb_type_to_gb_id_map()` in `torch._dynamo.exc` to locate and load `graph_break_registry.json` using standard library `importlib.resources` instead of relying on `Path(__file__)` resolution and `get_file_path_2`.

## Motivation
- **Package Portability & Hermetic Environments**: Resolving `Path(__file__).resolve().parent` and accessing files via raw filesystem `open()` fails in environments where packages are distributed or executed from archives (e.g., zipapps, PARs, wheels, frozen binaries, or custom package loaders).
- **Idiomatic Resource Loading**: `importlib.resources.files(__package__).joinpath(...)` is the standard, modern (Python 3.9+) API for accessing package data assets across all execution environments.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98