### PR TITLE
[ROCm][CK] Remove host-side FMHA sequence padding workaround

### DIFF
--- a/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/ck/mha_fwd_ck.hip
@@ -3,7 +3,6 @@
  ******************************************************************************/
 
 #include <ATen/native/transformers/hip/flash_attn/flash_common_hip.hpp>
-#include <ATen/detail/CUDAHooksInterface.h>
 #include <fmha_fwd.hpp>
 #include <mask.hpp>
 
@@ -413,50 +412,6 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
     {
       attn_bias = attn_bias_;
     }
-    // === [stopgap] gfx950 CK FMHA tile-tail OOB guard ===
-    // The generated no-seqlen-pad fwd instances issue unpredicated tile loads/
-    // stores of round_up(seqlen, tile) rows. For tile-unaligned seqlens this
-    // over-reads Q/K/V and over-writes O/LSE past the tensor end, which faults
-    // ("Memory access fault by GPU node-N ... Reason: Unknown") when the buffer
-    // ends on an unmapped page (observed on MI350X AOTT lowering, fwd pass).
-    // Hand the kernel seqlen-padded *allocations* (the extra rows are mapped
-    // scratch) while leaving seqlen_q/seqlen_k unchanged, so the kernel's logical
-    // masking is identical and numerics are unchanged; the real rows are copied
-    // back into the caller-visible tensors below. Engages only on gfx950 (MI350X)
-    // for tile-unaligned seqlens on the non-swapped path; skipped when seqlenq_ngroups_swapped is
-    // active (that fast path reshapes seqlen_q into the batch/group dim, so the
-    // tile-tail over-read does not apply).
-    // Scope: covers Q/K/V (read) and O/LSE (write) only. attn_bias (bias_ptr,
-    // seqlen_q x seqlen_k) and the dropout randval buffer (p / rand_val_ptr) are
-    // touched by the same round_up(seqlen, tile) pattern but are left unpadded
-    // here -- out of scope for this stopgap (pre-existing, not in the observed
-    // fault repro; whether CK issues full-tile loads on them is upstream-
-    // dependent). The proper fix is upstream CK kPadSeqLen fwd instances.
-    // TODO: remove once CK generates/selects kPadSeqLen fwd instances upstream.
-    at::Tensor q_arg = q_padded, k_arg = k_padded, v_arg = v_padded;
-    at::Tensor out_arg = out, lse_arg = softmax_lse;
-    constexpr int kCkSeqTileLCM = 256; // >= every fwd kM0/kN0 in the generated set
-    const int seqlen_q_pad = round_multiple(seqlen_q, kCkSeqTileLCM);
-    const int seqlen_k_pad = round_multiple(seqlen_k, kCkSeqTileLCM);
-    // Restrict to gfx950 (MI350X): the only arch observed to fault on the tile-
-    // tail over-read. Elsewhere (e.g. gfx942/MI300X) the pad+copy is pure
-    // overhead with no fault to avoid. Placed last so isGPUArch is evaluated only
-    // for the rare tile-unaligned non-swapped shapes.
-    const bool ck_oob_guard = !seqlenq_ngroups_swapped &&
-        ((seqlen_q_pad != seqlen_q) || (seqlen_k_pad != seqlen_k)) &&
-        at::detail::getCUDAHooks().isGPUArch({"gfx950"});
-    if (ck_oob_guard) {
-        if (seqlen_q_pad != seqlen_q) {
-            q_arg   = at::pad(q_padded, {0, 0, 0, 0, 0, seqlen_q_pad - seqlen_q});
-            out_arg = at::empty({out.size(0), seqlen_q_pad, out.size(2), out.size(3)}, out.options());
-            lse_arg = at::empty({batch_size, num_heads, seqlen_q_pad}, softmax_lse.options());
-        }
-        if (seqlen_k_pad != seqlen_k) {
-            k_arg = at::pad(k_padded, {0, 0, 0, 0, 0, seqlen_k_pad - seqlen_k});
-            v_arg = at::pad(v_padded, {0, 0, 0, 0, 0, seqlen_k_pad - seqlen_k});
-        }
-    }
-
     if (seqlen_k > 0) {
         drop_seed_offset.first = rng_state[0].data_ptr<uint64_t>();
         drop_seed_offset.second = rng_state[1].data_ptr<uint64_t>();
@@ -483,23 +438,18 @@ mha_fwd_ck(const at::Tensor &q,                      // batch_size x seqlen_q x 
                 num_heads,
                 num_heads_k,
                 head_size_8x,
-                q_arg,
-                k_arg,
-                v_arg,
+                q_padded,
+                k_padded,
+                v_padded,
                 attn_bias,
-                out_arg,
-                lse_arg,
+                out,
+                softmax_lse,
                 p,
                 softmax_scale,
                 p_dropout,
                 drop_seed_offset);
         float t = fmha_fwd(traits, args, stream_config);
         TORCH_CHECK(t >= 0, "invalid argument for fmha_fwd");
-        if (ck_oob_guard && seqlen_q_pad != seqlen_q) {
-            // copy the real rows out of the padded scratch into the caller tensors
-            out.copy_(out_arg.narrow(1, 0, seqlen_q));
-            softmax_lse.copy_(lse_arg.narrow(2, 0, seqlen_q));
-        }
     }
     else {
         // If seqlen_k == 0, then we have an empty tensor. We need to set the output to 0.

--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -5378,6 +5378,247 @@ class TestSDPACudaOnly(NNTestCase):
         not PLATFORM_SUPPORTS_FLASH_ATTENTION,
         "Does not support SDPA or pre-SM80 hardware",
     )
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CK_SDPA,
+        "Regression is specific to the ROCm CK SDPA backend",
+    )
+    @setSdpaBackendsToDefaultFinally
+    def test_flash_attention_ck_unaligned_sequence_padding(self, device):
+        # This and the three CK tests below run wherever CK SDPA is built -- the
+        # gate is is_ck_sdpa_available(), not an arch list -- and none of them
+        # branch on gfx950. What they prove does vary by arch: the generator
+        # emits the qr_async_trload instances this change re-guards only in the
+        # gfx950 bucket (gfx950 gets 192 of them, gfx9 none), so the emitted gfx9
+        # dispatch chain is byte-identical before and after. On gfx942 these are
+        # no-regression coverage; on gfx950 they also cover the re-routed arms.
+        torch.backends.cuda.preferred_rocm_fa_library("ck")
+        if (
+            torch.backends.cuda.preferred_rocm_fa_library()
+            != torch._C._ROCmFABackend.Ck
+        ):
+            self.skipTest("CK SDPA backend not available")
+
+        cases = (
+            ("cmf_self_d128", torch.float16, 128, 1, 24, 24, 128),
+            ("gfx950_fault", torch.bfloat16, 5, 2, 4, 656, 128),
+            ("oba_self_d192", torch.float16, 128, 1, 200, 200, 192),
+            ("cmf_self_d256", torch.float16, 128, 1, 24, 24, 256),
+            ("cmf_cross_aligned", torch.float16, 1, 1, 16, 96, 128),
+        )
+        for name, dtype, batch, heads, seqlen_q, seqlen_k, head_dim in cases:
+            with self.subTest(name=name):
+                q = torch.rand(
+                    batch, heads, seqlen_q, head_dim, device=device, dtype=dtype
+                )
+                k = torch.rand(
+                    batch, heads, seqlen_k, head_dim, device=device, dtype=dtype
+                )
+                v = torch.rand(
+                    batch, heads, seqlen_k, head_dim, device=device, dtype=dtype
+                )
+                with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+                    out = F.scaled_dot_product_attention(q, k, v)
+                with sdpa_kernel(backends=[SDPBackend.MATH]):
+                    ref = F.scaled_dot_product_attention(q.float(), k.float(), v.float())
+                self.assertFalse(torch.isnan(out).any().item(), name)
+                self.assertFalse(torch.isinf(out).any().item(), name)
+                self.assertEqual(out, ref.to(out.dtype), atol=2e-2, rtol=2e-2)
+
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_MEM_EFF_ATTENTION,
+        "Does not support Efficient Attention",
+    )
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CK_SDPA,
+        "Regression is specific to the ROCm CK SDPA backend",
+    )
+    @setSdpaBackendsToDefaultFinally
+    def test_mem_eff_attention_ck_unaligned_dense_bias(self, device):
+        # Numerical/path coverage for the one entry point that hands CK a dense
+        # additive bias. FLASH_ATTENTION rejects attn_mask outright and the flash
+        # wrapper passes mha_fwd_ck a null bias (attention.cu:136), so the
+        # bias-carrying instances are reachable only through
+        # _efficient_attention_forward (attention.cu:1661 -> mem_eff_forward_ck).
+        # Not a fail-before repro on any arch; see the note above about what the
+        # gfx9 and gfx950 dispatch chains actually differ in.
+        torch.backends.cuda.preferred_rocm_fa_library("ck")
+        if (
+            torch.backends.cuda.preferred_rocm_fa_library()
+            != torch._C._ROCmFABackend.Ck
+        ):
+            self.skipTest("CK SDPA backend not available")
+
+        # CK wants the bias dtype to match q/k/v (sdp_utils.cpp:1230-1236) and
+        # ROCm mem-eff declines GQA/MQA, so the head counts stay equal.
+        cases = (
+            ("bias_d128_cmf_self", torch.float16, 4, 2, 24, 24, 128),
+            ("bias_d128_tail", torch.bfloat16, 2, 4, 4, 656, 128),
+            ("bias_d64_tail", torch.float16, 2, 4, 17, 129, 64),
+        )
+        for name, dtype, batch, heads, seqlen_q, seqlen_k, head_dim in cases:
+            with self.subTest(name=name):
+                q = torch.rand(
+                    batch, heads, seqlen_q, head_dim, device=device, dtype=dtype
+                )
+                k = torch.rand(
+                    batch, heads, seqlen_k, head_dim, device=device, dtype=dtype
+                )
+                v = torch.rand(
+                    batch, heads, seqlen_k, head_dim, device=device, dtype=dtype
+                )
+                bias = torch.randn(
+                    batch, heads, seqlen_q, seqlen_k, device=device, dtype=dtype
+                )
+                with sdpa_kernel(backends=[SDPBackend.EFFICIENT_ATTENTION]):
+                    out = F.scaled_dot_product_attention(q, k, v, attn_mask=bias)
+                with sdpa_kernel(backends=[SDPBackend.MATH]):
+                    with tf32_off():
+                        golden = F.scaled_dot_product_attention(
+                            q.float(), k.float(), v.float(), attn_mask=bias.float()
+                        )
+                    lp_ref = F.scaled_dot_product_attention(q, k, v, attn_mask=bias)
+                self.assertFalse(torch.isnan(out).any().item(), name)
+                self.assertFalse(torch.isinf(out).any().item(), name)
+                _check_equal(golden, lp_ref, out, 4.0, f"out[{name}]")
+
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "Does not support SDPA or pre-SM80 hardware",
+    )
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CK_SDPA,
+        "Regression is specific to the ROCm CK SDPA backend",
+    )
+    @setSdpaBackendsToDefaultFinally
+    def test_flash_attention_ck_unaligned_dropout(self, device):
+        # Dropout selects a different set of CK instances (randval is its own
+        # trait) and writes one mask element per (row, column), so comparing
+        # against a plain math reference would only show that `out` is finite.
+        # Reuse the debug-mask replay test_flash_attention_vs_math_ref_grads
+        # uses, so the reference applies exactly the mask CK applied and the
+        # comparison is sensitive to the tile tails these shapes land on.
+        torch.backends.cuda.preferred_rocm_fa_library("ck")
+        if (
+            torch.backends.cuda.preferred_rocm_fa_library()
+            != torch._C._ROCmFABackend.Ck
+        ):
+            self.skipTest("CK SDPA backend not available")
+
+        # Every head_dim here is already a multiple of 8, so unlike
+        # test_flash_attention_vs_math_ref_grads there is no pad_last_dim round trip.
+        cases = (
+            ("dropout_d128_cmf_self", torch.float16, 4, 2, 24, 24, 128, 0.25),
+            ("dropout_d128_tail", torch.bfloat16, 2, 4, 4, 656, 128, 0.5),
+            ("dropout_d64_tail", torch.float16, 2, 4, 17, 129, 64, 0.33),
+        )
+        for name, dtype, batch, heads, sq, sk, head_dim, dropout_p in cases:
+            with self.subTest(name=name):
+                q = torch.rand(batch, heads, sq, head_dim, device=device, dtype=dtype)
+                k = torch.rand(batch, heads, sk, head_dim, device=device, dtype=dtype)
+                v = torch.rand(batch, heads, sk, head_dim, device=device, dtype=dtype)
+
+                output_tuple = torch.ops.aten._scaled_dot_product_flash_attention(
+                    q, k, v, dropout_p=dropout_p, is_causal=False, return_debug_mask=True
+                )
+                out = output_tuple[0]
+                softmax_mask = self.convert_flash_attn_S_to_softmax(
+                    output_tuple[-1],
+                    sq,
+                    sk,
+                    torch.ones(batch, sq, device=device, dtype=torch.bool),
+                    torch.ones(batch, sk, device=device, dtype=torch.bool),
+                    causal=False,
+                )[:, :, :sq, :sk]
+                # CK cannot be handed a dropout mask, so recover the one it used
+                # from the randval it reported -- same threshold as the sweep above.
+                dropout_mask = (
+                    softmax_mask <= int((1.0 - dropout_p) * 255.0)
+                ).to(torch.float32)
+                self.assertEqual(
+                    tuple(dropout_mask.shape), (batch, heads, sq, sk), name
+                )
+
+                with tf32_off():
+                    golden = torch.ops.aten._scaled_dot_product_attention_math(
+                        q.float(), k.float(), v.float(), dropout_p=dropout_p,
+                        is_causal=False, dropout_mask=dropout_mask,
+                    )[0]
+                lp_ref = torch.ops.aten._scaled_dot_product_attention_math(
+                    q, k, v, dropout_p=dropout_p,
+                    is_causal=False, dropout_mask=dropout_mask,
+                )[0]
+                self.assertFalse(torch.isnan(out).any().item(), name)
+                self.assertFalse(torch.isinf(out).any().item(), name)
+                _check_equal(golden, lp_ref, out, 4.0, f"out[{name}]")
+
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "Does not support SDPA or pre-SM80 hardware",
+    )
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_CK_SDPA,
+        "Regression is specific to the ROCm CK SDPA backend",
+    )
+    @setSdpaBackendsToDefaultFinally
+    def test_flash_attention_ck_gqa_seqlen_q_1_large_ngroups(self, device):
+        # The shape from D108947199: 4000 query heads over 2 kv heads at
+        # seqlen_q == 1, which mha_fwd_ck.hip:314 rewrites into a seqlen_q == 2000
+        # launch (ngroups becomes the query length). test_flash_attention_ck_gqa_
+        # seqlen_q_1 above only reaches ngroups 4 and 8, so nothing else covers a
+        # post-swap query length in the thousands. D108947199 itself is a separate
+        # accepted-but-unlanded follow-up; this pins the numerics of the swapped
+        # launch, it is not a fail-before repro for that diff.
+        torch.backends.cuda.preferred_rocm_fa_library("ck")
+        if (
+            torch.backends.cuda.preferred_rocm_fa_library()
+            != torch._C._ROCmFABackend.Ck
+        ):
+            self.skipTest("CK SDPA backend not available")
+
+        batch, num_heads_q, num_heads_kv = 32, 4000, 2
+        seqlen_q, seqlen_k, head_dim = 1, 656, 128
+        ngroups = num_heads_q // num_heads_kv
+        dtype = torch.float16
+        # The fp32 reference materializes a [32, 2, 2000, 656] score matrix.
+        if torch.cuda.get_device_properties(device).total_memory < 16 * 2**30:
+            self.skipTest("Reference for the exact D108947199 shape needs ~1GB")
+        torch.cuda.empty_cache()
+
+        q = torch.rand(
+            batch, num_heads_q, seqlen_q, head_dim, device=device, dtype=dtype
+        )
+        k = torch.rand(
+            batch, num_heads_kv, seqlen_k, head_dim, device=device, dtype=dtype
+        )
+        v = torch.rand(
+            batch, num_heads_kv, seqlen_k, head_dim, device=device, dtype=dtype
+        )
+        with sdpa_kernel(backends=[SDPBackend.FLASH_ATTENTION]):
+            out = F.scaled_dot_product_attention(q, k, v, enable_gqa=True)
+
+        # Reference through the same rewrite the wrapper performs. GQA maps query
+        # head h onto kv head h // ngroups, so folding the groups into the query
+        # length is exact -- and it avoids expanding kv to 4000 heads, which at
+        # this shape would be several terabytes.
+        q_swapped = q.reshape(batch, num_heads_kv, ngroups * seqlen_q, head_dim)
+        with sdpa_kernel(backends=[SDPBackend.MATH]):
+            with tf32_off():
+                golden = F.scaled_dot_product_attention(
+                    q_swapped.float(), k.float(), v.float()
+                ).reshape(batch, num_heads_q, seqlen_q, head_dim)
+            lp_ref = F.scaled_dot_product_attention(q_swapped, k, v).reshape(
+                batch, num_heads_q, seqlen_q, head_dim
+            )
+
+        self.assertEqual(out.shape, q.shape)
+        self.assertFalse(torch.isnan(out).any().item())
+        self.assertFalse(torch.isinf(out).any().item())
+        _check_equal(golden, lp_ref, out, 4.0, "out")
+
+    @unittest.skipIf(
+        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
+        "Does not support SDPA or pre-SM80 hardware",
+    )
     @unittest.skipIf(IS_JETSON, "causing sigkill on Jetson")
     @setSdpaBackendsToDefaultFinally
     @parametrize("batch_size", [1, 8])


### PR DESCRIPTION
Summary:
## Context
- https://github.com/pytorch/pytorch/pull/187152 added a gfx950 host-side pad/copy stopgap after unpadded CK FMHA TRLOAD instances faulted on tile-unaligned Q/K sequence lengths.
- https://github.com/ROCm/rocm-libraries/pull/11519 guards those generated dispatch arms so unaligned requests select CK's existing tail-safe `kPadSeqLenQ/K` instances.

## What
- Remove the external Q/K/V sequence padding, O/LSE scratch allocation, and output copies from the PyTorch CK FMHA wrapper.
- Pass the original logical tensors directly to CK now that the generated dispatcher rejects unsafe unpadded instances.
- Add operator coverage for unaligned sequence lengths, dense bias, dropout replay, and grouped-query attention.


Test Plan:
- MI350X/gfx950 operator coverage - https://www.internalfb.com/intern/testinfra/testrun/21392098272848663

```
buck2 test --local-only fbcode//mode/opt-amd-gpu -m rocm70 -c fbcode.disable_re_tests=True -c fbcode.rocm_arch=mi350 -c 'cxx.extra_cxxflags=-DAT_ROCM_CK_SDPA_ARCHS="gfx950"' fbcode//caffe2/test:test_transformers_cuda -- --regex 'unaligned_sequence_padding|unaligned_dense_bias|unaligned_dropout|gqa_seqlen_q_1' --env PYTORCH_TESTING_DEVICE_EXCEPT_FOR=cpu --env PYTORCH_TEST_REMOTE_GPU=1 --env TORCH_ROCM_FA_PREFER_CK=1 --env ROCM_HOME=/usr/local/fbcode/platform010/lib/rocm-7.0 --env ROCM_PATH=/usr/local/fbcode/platform010/lib/rocm-7.0 --env ROCR_VISIBLE_DEVICES=7
```

Covers CMF D128/D256, OBA D192, the original BF16 `B=5,H=2,Sq=4,Sk=656,D=128` fault shape, aligned fast-path control, dense bias D64/D128, dropout/randval replay, ordinary GQA, and the exact large-GQA case from D108947199.

- MI300X/gfx942 operator coverage - https://www.internalfb.com/intern/testinfra/testrun/4785074992482465

```
buck2 test --local-only fbcode//mode/opt-amd-gpu -m rocm70 -c fbcode.disable_re_tests=True -c fbcode.rocm_arch=mi300 fbcode//caffe2/test:test_transformers_cuda -- --regex 'unaligned_sequence_padding|unaligned_dense_bias|unaligned_dropout|gqa_seqlen_q_1' --env PYTORCH_TESTING_DEVICE_EXCEPT_FOR=cpu --env PYTORCH_TEST_REMOTE_GPU=1 --env TORCH_ROCM_FA_PREFER_CK=1 --env ROCM_HOME=/usr/local/fbcode/platform010/lib/rocm-7.0 --env ROCM_PATH=/usr/local/fbcode/platform010/lib/rocm-7.0 --env ROCR_VISIBLE_DEVICES=0
```



Differential Revision: D118174824




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang