### PR TITLE
[compiled autograd] Reuse custom-function backward graphs

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -1986,6 +1986,45 @@ main()
             fn, count=2
         )  # should compile once for MyFn1 and once for MyFn2
 
+    def test_compiled_custom_fn_with_eager_backend_cache_hit(self):
+        class MyFn1(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x
+
+            @staticmethod
+            def backward(ctx, gO):
+                return gO * 2
+
+        class MyFn2(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, x):
+                return x
+
+            @staticmethod
+            def backward(ctx, gO):
+                return gO * 3
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn1(x):
+            return MyFn1.apply(x)
+
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn2(x):
+            return MyFn2.apply(x)
+
+        def fn():
+            for compiled_fn in (fn1, fn1, fn2, fn2):
+                x = torch.arange(0.0, 10, requires_grad=True)
+                compiled_fn(x).sum().backward()
+                yield x.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            count=[2, 0],
+            compiler_fn=make_compiler_fn(backend="ca_eager"),
+        )
+
     def test_custom_fn_dynamically_defined_class(self):
         def fn():
             def create_class(multiplier: int):

--- a/torch/_functorch/autograd_function.py
+++ b/torch/_functorch/autograd_function.py
@@ -824,6 +824,10 @@ class AutogradFunctionApply(HigherOrderOperator):
 
         class ApplyTemplate(torch.autograd.Function):
             @staticmethod
+            def _compiled_autograd_key(ctx: Any) -> tuple[int]:
+                return (id(bwd),)
+
+            @staticmethod
             def forward(*args: Any, **kwargs: Any) -> Any:
                 nonlocal saved_values
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195508
* #195507
* #195506
* #195505
* __->__ #195504

Issue

`autograd_function_apply` creates a new local `ApplyTemplate` class on every
invocation. The default compiled-autograd key uses that generated class's
autograd function ID, so an unchanged captured backward graph misses the cache.

Fix

Key `ApplyTemplate` by the captured backward `GraphModule` identity. Repeated
execution of one compiled custom function now shares a cache entry, while
different backward graphs still receive different keys.

Before

```text
fn1, fn1, fn2, fn2 -> 4 compiled-autograd captures
```

After

```text
fn1, fn1, fn2, fn2 -> 2 compiled-autograd captures
```

Fixes #155105

Test Plan:

```bash
python - <<'PY'
import runpy
import sys
import torch
lib = torch.library.Library("_c10d_functional", "FRAGMENT")
lib.define("wait_tensors(Tensor[] tensors) -> Tensor[]")
sys.argv = ["test/inductor/test_compiled_autograd.py", "TestCompiledAutograd.test_custom_fn_with_same_graph", "TestCompiledAutograd.test_compiled_custom_fn_with_eager_backend_cache_hit", "TestCompiledAutograd.test_custom_fn_dynamically_defined_class", "-v"]
runpy.run_path("test/inductor/test_compiled_autograd.py", run_name="__main__")
PY
lintrunner -a
```

The focused tests pass. `lintrunner` reports only the pre-existing clang-tidy
backlog in `torch/csrc/distributed/c10d/Functional.cpp`.

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo