### PR TITLE
[dynamo] Report custom JVP errors at custom_function_call

### DIFF
--- a/test/dynamo/test_autograd_function.py
+++ b/test/dynamo/test_autograd_function.py
@@ -10,6 +10,7 @@ import torch._dynamo.test_case
 import torch._dynamo.testing
 import torch._dynamo.utils
 from torch._dynamo.testing import AotEagerAndRecordGraphs
+from torch._functorch.autograd_function import custom_function_call
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
@@ -3094,6 +3095,43 @@ class GraphModule(torch.nn.Module):
         x.grad = None
         res.backward()
         self.assertEqual(x.grad, grad_ref)
+
+    def test_custom_function_call_custom_jvp_unsupported(self):
+        class MySin(torch.autograd.Function):
+            @staticmethod
+            def forward(x):
+                return torch.sin(x)
+
+            @staticmethod
+            def setup_context(ctx, inputs, output):
+                pass
+
+            @staticmethod
+            def backward(ctx, grad_output):
+                return grad_output
+
+            @staticmethod
+            def jvp(ctx, x_t):
+                return x_t
+
+        def fn(x):
+            return custom_function_call(MySin, x)
+
+        x = torch.randn(2, requires_grad=True)
+        opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
+
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported, "Unsupported custom jvp"
+        ) as cm:
+            opt_fn(x)
+        self.assertIn(
+            "Higher Order Operator: torch.ops.higher_order.custom_function_call",
+            str(cm.exception),
+        )
+        self.assertIn(
+            "Developer debug context: custom_function_call",
+            str(cm.exception),
+        )
 
     def test_apply_kwargs_setup_context(self):
         class MyScale(torch.autograd.Function):

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -2222,7 +2222,7 @@
   "GB0144": [
     {
       "Gb_type": "Unsupported custom jvp",
-      "Context": "call_apply {self} {args} {kwargs}",
+      "Context": "context",
       "Explanation": "Dynamo does not support tracing `torch.autograd.Function` subclasses that define a custom `jvp` method.",
       "Hints": [
         "Remove the custom `jvp` method if possible.",
@@ -2233,7 +2233,7 @@
   "GB0145": [
     {
       "Gb_type": "Unsupported custom vjp",
-      "Context": "call_apply {self} {args} {kwargs}",
+      "Context": "context",
       "Explanation": "Dynamo does not support tracing `torch.autograd.Function` subclasses that define a custom `vjp` method.",
       "Hints": [
         "Remove the custom `vjp` method if possible.",

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -2360,6 +2360,33 @@ class CustomFunctionHigherOrderOperatorVariable(TorchHigherOrderOperatorVariable
     ) -> VariableTracker:
         if self.source is None:
             raise AssertionError("source must not be None")
+        if args and torch.is_grad_enabled():
+            from .misc import (
+                AutogradFunctionVariable,
+                raise_if_unsupported_autograd_function_methods,
+            )
+
+            autograd_function = args[0]
+            requires_grad = False
+
+            def visit(vt: VariableTracker) -> None:
+                nonlocal requires_grad
+                if vt.is_tensor():
+                    # type: ignore[attr-defined]
+                    if vt.requires_grad is not False:
+                        requires_grad = True
+                if isinstance(vt, variables.NNModuleVariable):
+                    if vt.is_training(tx):
+                        requires_grad = True
+
+            VariableTracker.visit(visit, (args[1:], kwargs))
+            if requires_grad and isinstance(
+                autograd_function, AutogradFunctionVariable
+            ):
+                raise_if_unsupported_autograd_function_methods(
+                    autograd_function.fn_cls,
+                    f"custom_function_call {autograd_function} {args[1:]} {kwargs}",
+                )
         return torch._dynamo.variables.UserMethodVariable(
             self.value.__call__.__func__,
             torch._dynamo.variables.UserDefinedObjectVariable(

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -1091,6 +1091,37 @@ def produce_trampoline_autograd_apply(fn_cls: Any) -> Callable[..., Any]:
     return trampoline_autograd_apply
 
 
+def raise_if_unsupported_autograd_function_methods(fn_cls: Any, context: str) -> None:
+    vjp_fn = fn_cls.vjp  # type: ignore[attr-defined]
+    if vjp_fn is not torch.autograd.Function.vjp:
+        unimplemented(
+            gb_type="Unsupported custom vjp",
+            context=context,
+            explanation="Dynamo does not support tracing "
+            "`torch.autograd.Function` subclasses that define "
+            "a custom `vjp` method.",
+            hints=[
+                "Remove the custom `vjp` method if possible.",
+                "Use standard `backward` instead if applicable.",
+                *graph_break_hints.SUPPORTABLE,
+            ],
+        )
+
+    jvp_fn = fn_cls.jvp  # type: ignore[attr-defined]
+    if jvp_fn is not torch.autograd.Function.jvp:
+        unimplemented(
+            gb_type="Unsupported custom jvp",
+            context=context,
+            explanation="Dynamo does not support tracing "
+            "`torch.autograd.Function` subclasses that define "
+            "a custom `jvp` method.",
+            hints=[
+                "Remove the custom `jvp` method if possible.",
+                *graph_break_hints.SUPPORTABLE,
+            ],
+        )
+
+
 class AutogradFunctionVariable(VariableTracker):
     """represents a torch.autograd.Function subclass"""
 
@@ -1217,34 +1248,9 @@ class AutogradFunctionVariable(VariableTracker):
                 # is_setup_ctx_defined
                 source = None
 
-            vjp_fn = self.fn_cls.vjp  # type: ignore[attr-defined]
-            if vjp_fn is not torch.autograd.Function.vjp:
-                unimplemented(
-                    gb_type="Unsupported custom vjp",
-                    context=f"call_apply {self} {args} {kwargs}",
-                    explanation="Dynamo does not support tracing "
-                    "`torch.autograd.Function` subclasses that define "
-                    "a custom `vjp` method.",
-                    hints=[
-                        "Remove the custom `vjp` method if possible.",
-                        "Use standard `backward` instead if applicable.",
-                        *graph_break_hints.SUPPORTABLE,
-                    ],
-                )
-
-            jvp_fn = self.fn_cls.jvp  # type: ignore[attr-defined]
-            if jvp_fn is not torch.autograd.Function.jvp:
-                unimplemented(
-                    gb_type="Unsupported custom jvp",
-                    context=f"call_apply {self} {args} {kwargs}",
-                    explanation="Dynamo does not support tracing "
-                    "`torch.autograd.Function` subclasses that define "
-                    "a custom `jvp` method.",
-                    hints=[
-                        "Remove the custom `jvp` method if possible.",
-                        *graph_break_hints.SUPPORTABLE,
-                    ],
-                )
+            raise_if_unsupported_autograd_function_methods(
+                self.fn_cls, f"call_apply {self} {args} {kwargs}"
+            )
 
             from .higher_order_ops import AutogradFunctionApplyVariable
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195508
* #195507
* #195506
* __->__ #195505
* #195504

Issue

The `custom_function_call` higher-order-op path reaches the inner
`torch.autograd.Function.apply` before checking for unsupported custom `jvp`
and `vjp` methods. The resulting diagnostic is attributed to `call_apply`
instead of the higher-order operator that the user invoked.

Fix

Share the existing custom `jvp`/`vjp` validation between direct `apply` and
`custom_function_call`, and run it before tracing the higher-order operator
when gradient-relevant inputs are present.

Before

```text
Developer debug context: call_apply AutogradFunctionVariable(...)
```

After

```text
Higher Order Operator: torch.ops.higher_order.custom_function_call
Developer debug context: custom_function_call AutogradFunctionVariable(...)
```

Fixes #180284

Test Plan:

```bash
python - <<'PY'
import runpy
import sys
import torch
lib = torch.library.Library("_c10d_functional", "FRAGMENT")
lib.define("wait_tensors(Tensor[] tensors) -> Tensor[]")
sys.argv = ["test/dynamo/test_autograd_function.py", "AutogradFunctionTests.test_custom_function_call_custom_jvp_unsupported", "-v"]
runpy.run_path("test/dynamo/test_autograd_function.py", run_name="__main__")
PY
lintrunner -a
```

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98