### PR TITLE
[dynamo] Support _AutoDispatchBelowAutograd

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -140,6 +140,35 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
                 self, fn=fn4, nargs=2, expected_ops=3
             )  # coalesced noop
 
+    def test_auto_dispatch_below_autograd_fullgraph(self):
+        @torch.compile(backend="eager", fullgraph=True)
+        def fn():
+            with torch._C._AutoDispatchBelowAutograd():
+                pass
+
+        fn()
+
+    def test_auto_dispatch_below_autograd_runtime_state(self):
+        def fn(x):
+            with torch._C._AutoDispatchBelowAutograd():
+                return x.sin()
+
+        x = torch.randn(3, requires_grad=True)
+        ref = fn(x)
+
+        backend = EagerAndRecordGraphs()
+        opt_fn = torch.compile(fn, backend=backend, fullgraph=True)
+        res = opt_fn(x)
+
+        self.assertTrue(same(ref, res))
+        self.assertFalse(res.requires_grad)
+        self.assertIsNone(res.grad_fn)
+        self.assertTrue(x.sin().requires_grad)
+        self.assertEqual(len(backend.graphs), 1)
+        graph_code = backend.graphs[0].code
+        self.assertIn("enter_autodispatch_below_autograd", graph_code)
+        self.assertIn("exit_autodispatch_below_autograd", graph_code)
+
     def test_grad_mode_guard(self):
         def fn(a, b):
             prev_grad = torch.is_grad_enabled()

--- a/test/dynamo/test_graph_deduplication.py
+++ b/test/dynamo/test_graph_deduplication.py
@@ -858,6 +858,37 @@ class <lambda>(torch.nn.Module):
 """,
         )
 
+    def test_auto_dispatch_below_autograd_ordering(self):
+        from torch._dynamo.external_utils import (
+            enter_autodispatch_below_autograd,
+            exit_autodispatch_below_autograd,
+        )
+        from torch._dynamo.graph_deduplication import (
+            _populate_additional_deps,
+            _stable_topological_sort,
+        )
+
+        graph = torch.fx.Graph()
+        x = graph.placeholder("x")
+        before = graph.call_function(torch.ops.aten.cos.default, (x,))
+        enter = graph.call_function(enter_autodispatch_below_autograd)
+        inside = graph.call_function(torch.ops.aten.sin.default, (x,))
+        exit = graph.call_function(exit_autodispatch_below_autograd, (enter,))
+        after = graph.call_function(torch.ops.aten.tan.default, (x,))
+        graph.output((before, inside, after))
+
+        additional_deps = _populate_additional_deps(graph, {})
+
+        before.append(inside)
+        inside.append(after)
+        _stable_topological_sort(graph, additional_deps)
+
+        node_names = [node.name for node in graph.nodes]
+        self.assertLess(node_names.index(before.name), node_names.index(enter.name))
+        self.assertLess(node_names.index(enter.name), node_names.index(inside.name))
+        self.assertLess(node_names.index(inside.name), node_names.index(exit.name))
+        self.assertLess(node_names.index(exit.name), node_names.index(after.name))
+
     def test_output_nodes_last(self):
         from torch._dynamo.graph_deduplication import _stable_topological_sort
 

--- a/test/dynamo/test_higher_order_ops.py
+++ b/test/dynamo/test_higher_order_ops.py
@@ -220,6 +220,32 @@ class HigherOrderOpTests(torch._dynamo.test_case.TestCase):
         ):
             f(x)
 
+    def test_run_with_rng_state_graph_breaks_on_python_callable(self):
+        def fn(rng_state):
+            return torch._prims.rng_prims.run_with_rng_state(
+                rng_state, torch.rand, 3, device="cpu"
+            )
+
+        rng_state = torch.get_rng_state()
+        expected = fn(rng_state)
+
+        counters.clear()
+        result = torch.compile(fn, backend="eager", fullgraph=False)(rng_state)
+        self.assertEqual(result, expected)
+        self.assertTrue(
+            any(
+                key.startswith("HOP: unsupported run_with_rng_state argument")
+                for key in counters["graph_break"]
+            )
+        )
+
+        torch._dynamo.reset()
+        with self.assertRaisesRegex(
+            torch._dynamo.exc.Unsupported,
+            "run_with_rng_state received an argument",
+        ):
+            torch.compile(fn, backend="eager", fullgraph=True)(rng_state)
+
     def test_no_freevars(self):
         def f(x):
             return wrap(lambda x: torch.sin(x), x)

--- a/torch/_dynamo/external_utils.py
+++ b/torch/_dynamo/external_utils.py
@@ -71,6 +71,16 @@ def wrap_inline(fn: Callable[_P, _R]) -> Callable[_P, _R]:
     return inner
 
 
+@torch.fx.has_side_effect
+def enter_autodispatch_below_autograd() -> Any:
+    return torch._C._AutoDispatchBelowAutograd()
+
+
+@torch.fx.has_side_effect
+def exit_autodispatch_below_autograd(cm: Any) -> None:
+    cm.__exit__(None, None, None)
+
+
 def call_hook(
     hook: Callable[..., torch.Tensor | None], *args: Any, **kwargs: Any
 ) -> torch.Tensor:

--- a/torch/_dynamo/graph_break_registry.json
+++ b/torch/_dynamo/graph_break_registry.json
@@ -291,6 +291,14 @@
       ]
     }
   ],
+  "GB6360": [
+    {
+      "Gb_type": "HOP: unsupported run_with_rng_state argument",
+      "Context": "str(exc)",
+      "Explanation": "run_with_rng_state received an argument that cannot be represented in the FX graph.",
+      "Hints": []
+    }
+  ],
   "GB0022": [
     {
       "Gb_type": "Bad import result",

--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -428,10 +428,20 @@ def _add_global_state_dependencies(
 ) -> None:
     import torch.amp
 
+    from .external_utils import (
+        enter_autodispatch_below_autograd,
+        exit_autodispatch_below_autograd,
+    )
+
     all_nodes = list(graph.nodes)
 
     # These are targets of the nodes which need to stay in the same relative place in the graph
-    global_state_targets = {torch.amp._enter_autocast, torch.amp._exit_autocast}
+    global_state_targets = {
+        torch.amp._enter_autocast,
+        torch.amp._exit_autocast,
+        enter_autodispatch_below_autograd,
+        exit_autodispatch_below_autograd,
+    }
     all_nodes_dep_on: list[Node] = []
 
     def prev_cur_nodes(

--- a/torch/_dynamo/variables/__init__.py
+++ b/torch/_dynamo/variables/__init__.py
@@ -30,6 +30,7 @@ from .builtin import (
 from .constant import ConstantVariable
 from .ctx_manager import (
     AcceleratorDeviceIndexVariable,
+    AutoDispatchBelowAutogradVariable,
     CatchWarningsCtxManagerVariable,
     ContextWrappingVariable,
     CUDADeviceVariable,

--- a/torch/_dynamo/variables/ctx_manager.py
+++ b/torch/_dynamo/variables/ctx_manager.py
@@ -35,6 +35,10 @@ from torch._logging import warning_once
 from .. import graph_break_hints, variables
 from ..bytecode_transformation import create_call_function
 from ..exc import unimplemented
+from ..external_utils import (
+    enter_autodispatch_below_autograd,
+    exit_autodispatch_below_autograd,
+)
 from ..guards import GuardBuilder, install_guard
 from ..source import AttrSource, GlobalStateSource
 from ..utils import _get_error_on_graph_break, _set_error_on_graph_break
@@ -797,6 +801,64 @@ class InferenceModeVariable(ContextWrappingVariable):
 
     def python_type(self) -> type:
         return torch.inference_mode
+
+
+class AutoDispatchBelowAutogradVariable(ContextWrappingVariable):
+    @staticmethod
+    def create(
+        tx: "InstructionTranslatorBase", **kwargs: Any
+    ) -> "AutoDispatchBelowAutogradVariable":
+        var = AutoDispatchBelowAutogradVariable(
+            target_values=[], initial_values=[], **kwargs
+        )
+        var.initialize(tx)
+        return var
+
+    def __init__(
+        self,
+        target_values: Sized,
+        initial_values: Sized | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if len(target_values) != 0:
+            raise AssertionError(f"expected 0 target_values, got {len(target_values)}")
+        if initial_values is None:
+            raise AssertionError("initial_values must not be None")
+        if len(initial_values) != 0:
+            raise AssertionError(
+                f"expected 0 initial_values, got {len(initial_values)}"
+            )
+        super().__init__(
+            target_values=target_values, initial_values=initial_values, **kwargs
+        )
+
+    def initialize(self, tx: "InstructionTranslatorBase") -> None:
+        cm_obj = enter_autodispatch_below_autograd()
+        self.set_cleanup_hook(tx, lambda: exit_autodispatch_below_autograd(cm_obj))
+        self.proxy = tx.output.create_node(
+            "call_function", enter_autodispatch_below_autograd, (), {}
+        )
+
+    def enter(self, tx: "InstructionTranslatorBase") -> VariableTracker:
+        return variables.ConstantVariable.create(None)
+
+    def exit(
+        self, tx: "InstructionTranslatorBase", *args: VariableTracker
+    ) -> VariableTracker:
+        self.cleanup_assert()
+        tx.output.create_node(
+            "call_function", exit_autodispatch_below_autograd, (self.proxy,), {}
+        )
+        return variables.ConstantVariable.create(None)
+
+    def module_name(self) -> str:
+        return "torch._C"
+
+    def fn_name(self) -> str:
+        return "_AutoDispatchBelowAutograd"
+
+    def python_type(self) -> type:
+        return torch._C._AutoDispatchBelowAutograd  # pyrefly: ignore[bad-return]
 
 
 class GenericDeviceVariable(ContextWrappingVariable):

--- a/torch/_dynamo/variables/higher_order_ops.py
+++ b/torch/_dynamo/variables/higher_order_ops.py
@@ -4616,14 +4616,27 @@ class RunWithRNGStateHigherOrderVariable(TorchHigherOrderOperatorVariable):
 
         p_args = tuple(arg.as_proxy() for arg in args)
         p_kwargs = {key: arg.as_proxy() for key, arg in kwargs.items()}
-        return wrap_fx_proxy(
-            tx=tx,
-            proxy=tx.output.create_proxy(
+        try:
+            proxy = tx.output.create_proxy(
                 "call_function",
                 self.value,
                 args=p_args,
                 kwargs=p_kwargs,
-            ),
+            )
+        except NotImplementedError as exc:
+            unimplemented(
+                gb_type="HOP: unsupported run_with_rng_state argument",
+                context=str(exc),
+                explanation=(
+                    "run_with_rng_state received an argument that cannot be "
+                    "represented in the FX graph."
+                ),
+                hints=[],
+                from_exc=exc,
+            )
+        return wrap_fx_proxy(
+            tx=tx,
+            proxy=proxy,
             example_value=None,
         )
 

--- a/torch/_dynamo/variables/torch.py
+++ b/torch/_dynamo/variables/torch.py
@@ -169,6 +169,7 @@ supported_ctx_manager_classes = dict.fromkeys(
         torch.autograd.forward_ad.dual_level,
         torch.autograd.profiler.profile,
         torch.autograd.profiler.record_function,
+        torch._C._AutoDispatchBelowAutograd,
         torch._C.DisableTorchFunctionSubclass,
         torch._C.DisableTorchFunction,
         torch._functorch.vmap.vmap_increment_nesting,
@@ -702,6 +703,7 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
         kwargs: "dict[str, VariableTracker]",
     ) -> "VariableTracker":
         from . import (
+            AutoDispatchBelowAutogradVariable,
             CUDAMemPoolContextVariable,
             DisabledSavedTensorsHooksVariable,
             DualLevelContextManager,
@@ -840,6 +842,12 @@ class TorchCtxManagerClassVariable(BaseTorchVariable):
             return TorchFunctionDisableVariable.create(
                 tx, only_subclass=self.value is torch._C.DisableTorchFunctionSubclass
             )
+        elif self.value is torch._C._AutoDispatchBelowAutograd:
+            if args or kwargs:
+                raise AssertionError(
+                    "_AutoDispatchBelowAutograd expects no args or kwargs"
+                )
+            return AutoDispatchBelowAutogradVariable.create(tx)
         elif self.value is torch._functorch.vmap.vmap_increment_nesting:
             if len(args) != 2:
                 raise AssertionError(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195508
* #195507
* __->__ #195506
* #195505
* #195504

Issue

Dynamo treats `_AutoDispatchBelowAutograd` as a user-defined pybind class and
tries to inline its constructor. Fullgraph tracing then fails in
`pybind11_object.__new__` instead of preserving the dispatcher state change.

Fix

Register the context manager with Dynamo and model construction and exit as
ordered, side-effectful FX nodes. Also convert the newly reachable
`run_with_rng_state` Python-callable representation failure into a normal graph
break instead of an internal Dynamo error.

Before

```python
with torch._C._AutoDispatchBelowAutograd():
    pass
# Unsupported while tracing pybind11_object.__new__
```

After

```text
enter_autodispatch_below_autograd()
<compiled operations below autograd>
exit_autodispatch_below_autograd()
```

Fixes #149586

Test Plan:

```bash
python test/dynamo/test_ctx_manager.py -k auto_dispatch_below_autograd -v
python test/dynamo/test_graph_deduplication.py -k auto_dispatch_below_autograd_ordering -v
python test/dynamo/test_higher_order_ops.py HigherOrderOpTests.test_run_with_rng_state_graph_breaks_on_python_callable -v
PYTORCH_TEST_WITH_DYNAMO=1 python test/test_prims.py TestPrimsCPU.test_functional_rng_wrappers_cpu_float32 -v
lintrunner -a
```

The commands were run through a temporary schema shim because the installed
extension predates the checkout. The translation-validation variant could not
run because `z3-solver` is unavailable.

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98