### PR TITLE
[compiled autograd] Capture retain_grad hooks in fullgraph

### DIFF
--- a/test/inductor/test_compiled_autograd.py
+++ b/test/inductor/test_compiled_autograd.py
@@ -359,6 +359,20 @@ main()
         with compiled_autograd._enable(compiler_fn):
             y.backward()
 
+    def test_retain_grad_fullgraph(self):
+        def fn():
+            x = torch.rand(1, 3, requires_grad=True)
+            intermediate = x * 3
+            intermediate.retain_grad()
+            (intermediate * intermediate).sum().backward()
+            yield intermediate.grad
+
+        self.check_output_and_recompiles(
+            fn,
+            count=[1, 0],
+            compiler_fn=make_compiler_fn(backend="eager", fullgraph=True),
+        )
+
     def test_tensor_grad_hook1(self):
         def fn():
             for _ in range(3):
@@ -5526,18 +5540,8 @@ known_graph_breaks_tests = {
     "test_checkpointing_without_reentrant_memory_savings",  # reentrant .backward
     "test_dtensor_basic",  # torch._dynamo.exc.Unsupported: Failed to convert args/kwargs to proxy
     "test_dtensor_contiguous_dtensor_noncontiguous_local_as_tangent",  # subclass constructor
-    "test_retain_grad",  # retains_grad_hooks
-    "test_retain_grad_cycle",  # retains_grad_hooks
-    "test_retain_grad_inplace",  # retains_grad_hooks
-    "test_retain_grad_inplace_over_view",  # retains_grad_hooks
-    "test_retains_grad_can_always_observe_tensor_prehook",  # retains_grad_hooks
-    "test_retains_grad_inplace_multiple_outputs",  # retains_grad_hooks
-    "test_hook_edge_case_when_called_with_grad",  # retains_grad_hooks
-    "test_multi_grad_all_hooks",  # retains_grad_hooks
-    "test_prehook_ordering",  # retains_grad_hooks
-    "test_will_engine_execute_node",  # retains_grad_hooks
-    "test_backward_to_node",  # retains_grad_hooks
-    "test_backward_with_nonleaf_inputs",  # retains_grad_hook on non-leaf input
+    "test_multi_grad_all_hooks",  # register_multi_grad_hook is in a skip file
+    "test_will_engine_execute_node",  # AccumulateGrad cannot be converted to a proxy
     "test_create_graph_and_full_backward_hook_cycle",  # _pack_with_none
     "test_full_backward_hook_double_backward",  # _pack_with_none
     "test_grad_mode_restored_reentrant",  # assertTrue

--- a/torch/_dynamo/compiled_autograd.py
+++ b/torch/_dynamo/compiled_autograd.py
@@ -109,6 +109,17 @@ def maybe_clone(x: torch.Tensor | None) -> torch.Tensor | None:
     return x
 
 
+@torch.library.custom_op("compiled_autograd::call_cpp_tensor_pre_hook", mutates_args=())
+def call_cpp_tensor_pre_hook(hook_id: int, grad: torch.Tensor) -> torch.Tensor:
+    result = torch._C._dynamo.compiled_autograd.call_cpp_tensor_pre_hooks(hook_id, grad)
+    return result.clone()
+
+
+@call_cpp_tensor_pre_hook.register_fake
+def _(hook_id: int, grad: torch.Tensor) -> torch.Tensor:
+    return grad.clone()
+
+
 class _AOTCompiledFunction(Protocol):
     """Structural type for the AOTAutograd autograd.Function subclass that
     compiled autograd retraces. The concrete class is generated locally inside
@@ -963,7 +974,7 @@ class AutogradCompilerInstance:
     ) -> list[torch.Tensor]:
         proxy = self.fx_tracer.create_proxy(
             "call_function",
-            torch._C._dynamo.compiled_autograd.call_cpp_tensor_pre_hooks,
+            torch.ops.compiled_autograd.call_cpp_tensor_pre_hook.default,
             (hook_id, self.to_proxy(inputs[i])),
             {},
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* #195508
* __->__ #195507
* #195506
* #195505
* #195504

Issue

Compiled autograd emits the raw `call_cpp_tensor_pre_hooks` C-extension
function into its FX graph. Dynamo cannot trace that builtin, so retained-grad
hooks force a graph break even though C++ runtime state already carries them.

Fix

Route the runtime hook through an internal custom operator with a fake
implementation. Runtime still invokes the active C++ hook and returns a
non-aliasing clone, while tracing keeps the operation as an opaque graph node.
Enable the retained-grad tests whose only graph break came from this call.

Before

```text
torch._C._dynamo.compiled_autograd.call_cpp_tensor_pre_hooks(...)
-> Dynamo graph break
```

After

```text
torch.ops.compiled_autograd.call_cpp_tensor_pre_hook(...)
-> captured in the full backward graph
```

Fixes #138901

Test Plan:

```bash
python - <<'PY'
import runpy
import sys
import torch
lib = torch.library.Library("_c10d_functional", "FRAGMENT")
lib.define("wait_tensors(Tensor[] tensors) -> Tensor[]")
sys.argv = ["test/inductor/test_compiled_autograd.py", "TestCompiledAutograd.test_retain_grad_fullgraph", "-v"]
runpy.run_path("test/inductor/test_compiled_autograd.py", run_name="__main__")
PY
lintrunner -a
```

The retained-grad conformance cases also pass in fullgraph with eager,
`aot_eager`, and Inductor compiled-autograd backends.

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98 @aditvenk