### PR TITLE
[python dispatch] Validate redispatch keysets before torch function handling

### DIFF
--- a/test/test_custom_ops.py
+++ b/test/test_custom_ops.py
@@ -889,6 +889,17 @@ class TestCustomOp(CustomOpTestCaseBase):
         ):
             op._pyobj_dispatcher.redispatch()
 
+        class RedispatchMode(torch.overrides.TorchFunctionMode):
+            def __torch_function__(self, func, types, args=(), kwargs=None):
+                return torch.overrides.redispatch_function(func, types, args, kwargs)
+
+        with RedispatchMode():
+            with self.assertRaisesRegex(
+                TypeError,
+                "redispatch\\(\\) expected redispatch\\(keyset, \\*args, \\*\\*kwargs\\)",
+            ):
+                op._pyobj_dispatcher.redispatch()
+
     @skipIfTorchDynamo("PyObject dispatch test is eager-only")
     def test_pyobject_dispatch_respects_torch_function_mode(self):
         import torch._refs

--- a/torch/csrc/utils/python_dispatch.cpp
+++ b/torch/csrc/utils/python_dispatch.cpp
@@ -538,18 +538,18 @@ static PyObject* pyobject_redispatch_vectorcall(
   auto* self = reinterpret_cast<PyObjectRedispatchFunc*>(callable);
   Py_ssize_t nargs = PyVectorcall_NARGS(nargsf);
   Py_ssize_t nkwargs = kwnames == nullptr ? 0 : PyTuple_GET_SIZE(kwnames);
+  if (nargs == 0) {
+    PyErr_SetString(
+        PyExc_TypeError,
+        "redispatch() expected redispatch(keyset, *args, **kwargs)");
+    return nullptr;
+  }
   bool skip_torch_function = torch::peek_should_skip_torch_function();
   if (C10_UNLIKELY(
           !skip_torch_function &&
           pyobject_dispatch_has_torch_function(args, nargs, nkwargs, 1))) {
     return PyObject_Vectorcall(
         self->cpp_redispatch_fn, args, static_cast<size_t>(nargs), kwnames);
-  }
-  if (nargs == 0) {
-    PyErr_SetString(
-        PyExc_TypeError,
-        "redispatch() expected redispatch(keyset, *args, **kwargs)");
-    return nullptr;
   }
 
   PyObject* raw_key_set = PyObject_CallMethod(args[0], "raw_repr", nullptr);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195508
* #195507
* #195506
* #195505
* #195504

Issue

`pyobject_redispatch_vectorcall` checks `TorchFunctionMode` before checking for
the required keyset argument. With a mode active, zero-argument `redispatch()`
delegates to the pybind entry and emits its generated signature error, making
the test depend on ambient torch-function state.

Fix

Validate the positional keyset before torch-function delegation. Add a
mode-scoped regression case that deterministically exercises the flaky branch.

Before

```text
redispatch_boxed(): incompatible function arguments
```

After

```text
redispatch() expected redispatch(keyset, *args, **kwargs)
```

Fixes #189067

Test Plan:

```bash
python - <<'PY'
import runpy
import sys
import torch
lib = torch.library.Library("_c10d_functional", "FRAGMENT")
lib.define("wait_tensors(Tensor[] tensors) -> Tensor[]")
sys.argv = ["test/test_custom_ops.py", "TestCustomOp.test_pyobject_redispatch_requires_keyset", "-v"]
runpy.run_path("test/test_custom_ops.py", run_name="__main__")
PY
lintrunner -a
```

The mode-scoped case reproduces the CI failure against the pre-fix installed
extension. Positive execution requires rebuilding PyTorch and remains pending
because no build environment configuration was provided. `lintrunner` reports
only the pre-existing `performance-inefficient-vector-operation` finding at
`torch/csrc/utils/python_dispatch.cpp:1476`.

Authored with AI assistance.