### PR TITLE
Fix missing `typename` on dependent type in `IValue::to() const&`

### DIFF
--- a/aten/src/ATen/core/ivalue_inl.h
+++ b/aten/src/ATen/core/ivalue_inl.h
@@ -1961,7 +1961,8 @@ inline T IValue::to() && {
 
 template <typename T>
 inline typename c10::detail::ivalue_to_const_ref_overload_return<T>::type IValue::to() const& {
-  using return_type = c10::detail::ivalue_to_const_ref_overload_return<T>::type;
+  using return_type =
+      typename c10::detail::ivalue_to_const_ref_overload_return<T>::type;
 #define DEFINE_BRANCH(type, converter)                                         \
   if constexpr (std::is_same_v<T, type>) {                                     \
     return static_cast<return_type>(this->converter());                        \


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195509

D117709455 (pytorch/pytorch#194769) rewrote `IValue::to` from a set of
`DEFINE_TO` explicit specializations into a single template using an
`if constexpr` chain. In the `const&` overload the rewrite introduced a new
alias-declaration:

```
using return_type = c10::detail::ivalue_to_const_ref_overload_return<T>::type;
```

`ivalue_to_const_ref_overload_return<T>` is a dependent scope, so naming
`::type` requires `typename`. P0634R3 (C++20) made it optional in the
defining-type-id of an alias-declaration, but clang 15 has not implemented
P0634R3 for alias-declarations and rejects the construct at both `-std=c++17`
and `-std=c++20`. Measured across the toolchains in
`third-party-buck/platform010`:

| Compiler | `-std=c++17` | `-std=c++20` |
| --- | --- | --- |
| clang 15 | error | error |
| clang 17 / 19 / 21 | ok, warns `-Wc++20-extensions` | ok |
| gcc 11.2 | error | ok |

The failing configuration is the arvr/ovrsource one,
`opt-linux-x86_64-fbcode-platform010-clang15-arvr`. fbcode caffe2 builds with
clang 21, which accepts it, so nothing on the fbcode side broke.

This broke `fbsource//xplat/caffe2:ATen_lib_ovrsource` and
`fbsource//xplat/caffe2:torch_lib_mobile_ovrsource`, and in turn arvr firmware
targets depending on them. None of the contbuilds pinned by the diff-train
`@build_only[...]` list cover the ovrsource configuration, which is why
D117709455 landed green.

This is an internal-only fix. Upstream PyTorch requires C++20 and hard-errors on
clang < 16 and gcc < 11.3 (`CMakeLists.txt`), so the construct is valid
everywhere upstream supports; the break is specific to the clang-15 toolchain
that ovrsource is pinned to. Adding the explicit `typename` is valid under every
compiler and standard above, so it is safe for all consumers.

Differential Revision: [D118186514](https://our.internmc.facebook.com/intern/diff/D118186514/)