### PR TITLE
[CUDA] Introduce CUDA graph memory management

### DIFF
--- a/c10/cuda/CMakeLists.txt
+++ b/c10/cuda/CMakeLists.txt
@@ -31,6 +31,7 @@ set(C10_CUDA_SRCS
     CUDADeviceAssertionHost.cpp
     CUDAException.cpp
     CUDAFunctions.cpp
+    CUDAGraphMemory.cpp
     CUDAMallocAsyncAllocator.cpp
     CUDAMiscFunctions.cpp
     CUDAStream.cpp
@@ -52,6 +53,7 @@ set(C10_CUDA_HEADERS
     CUDAMiscFunctions.h
     CUDAStream.h
     PeerToPeerAccess.h
+    impl/CUDAGraphMemory.h
     impl/CUDAGuardImpl.h
     impl/CUDATest.h
 )

--- a/c10/cuda/CUDACachingAllocator.cpp
+++ b/c10/cuda/CUDACachingAllocator.cpp
@@ -7,6 +7,7 @@
 #include <c10/cuda/CUDAFunctions.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/PeerToPeerAccess.h>
+#include <c10/cuda/impl/CUDAGraphMemory.h>
 #include <c10/util/Gauge.h>
 #include <c10/util/Logging.h>
 #include <c10/util/ScopeExit.h>
@@ -1518,23 +1519,13 @@ class DeviceCachingAllocator {
   // CUDAGraph capture, torch.cuda.use_mem_pool, ProcessGroupNCCL
   // registration, inductor cudagraph_trees warmup, and the allocator's own
   // try_mempool_fallback. Note: a non-empty list does NOT imply an active
-  // CUDA stream capture; for that, see num_active_captures_ below.
+  // CUDA stream capture; for that, see capture_tracker_ below.
   // Most of the time it's empty, so malloc can short-circuit on the hot path.
   std::vector<std::pair<MempoolId_t, std::function<bool(cudaStream_t)>>>
       allocation_scopes_;
 
-  // Count of in-progress CUDA stream captures on this device. Bumped by
-  // CUDAGraph's capture_begin / capture_end (and conditional-node helpers)
-  // around cudaStreamBeginCapture / cudaStreamEndCapture. Distinct from
-  // allocation_scopes_, which tracks pool routing — the latter can be
-  // populated without an active capture (e.g. torch.cuda.use_mem_pool,
-  // NCCL registration, inductor cudagraph_trees warmup, internal
-  // try_mempool_fallback).
-  //
-  // Plain int because all access is serialized through `mutex`. Promote to
-  // std::atomic<int> (relaxed) if begin/end ever need to race or if any
-  // reader wants lock-free access.
-  int num_active_captures_ = 0;
+  // Graph-specific capture state. CCA retains ownership of allocator Blocks.
+  CUDAGraphMemory::CaptureTracker capture_tracker_;
 
   // tracks which pools we can use as a last resort before ooming
   ska::flat_hash_set<MempoolId_t, MempoolIdHash> use_on_oom_pools;
@@ -3328,16 +3319,13 @@ class DeviceCachingAllocator {
   // begin/end for one capture are not racing each other.
   void markCaptureBegin() {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    num_active_captures_++;
+    capture_tracker_.captureBegin();
   }
 
   // Called by CUDAGraph after cudaStreamEndCapture.
   void markCaptureEnd() {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    TORCH_INTERNAL_ASSERT(
-        num_active_captures_ > 0,
-        "markCaptureEnd called with no captures in progress");
-    num_active_captures_--;
+    capture_tracker_.captureEnd();
   }
 
   // Called by CUDAGraph::reset and MemPool::~MemPool()
@@ -3764,7 +3752,7 @@ class DeviceCachingAllocator {
   // not mistaken for a real capture.
   //
   // Two layers, from cheapest to most expensive:
-  //   1. Device-wide counter: num_active_captures_ == 0 means no capture is
+  //   1. Device-wide state: CUDAGraphMemory reports whether a capture is
   //      in progress anywhere on this device, so the answer is trivially
   //      false. This is the common case and the hot path.
   //   2. Per-stream syscall: cudaStreamGetCaptureInfo on the current stream.
@@ -3773,10 +3761,10 @@ class DeviceCachingAllocator {
   //      device that has another stream capturing (eager-eligible) from the
   //      capturing stream itself (must follow capture rules).
   //
-  // The counter read is safe because all callers hold `mutex`
-  // (see num_active_captures_).
+  // The device-wide state read is safe because all callers hold `mutex`
+  // (see CUDAGraphMemory::CaptureTracker::hasActiveCaptures()).
   bool is_capture_context() {
-    if (C10_LIKELY(num_active_captures_ == 0)) {
+    if (C10_LIKELY(!capture_tracker_.hasActiveCaptures())) {
       return false;
     }
     cudaStream_t stream = cuda::getCurrentCUDAStream(device_id).stream();

--- a/c10/cuda/CUDAGraphMemory.cpp
+++ b/c10/cuda/CUDAGraphMemory.cpp
@@ -1,0 +1,17 @@
+#include <c10/cuda/impl/CUDAGraphMemory.h>
+
+#include <c10/util/Exception.h>
+
+namespace c10::cuda::CUDAGraphMemory {
+
+void CaptureTracker::captureBegin() {
+  ++active_captures_;
+}
+
+void CaptureTracker::captureEnd() {
+  TORCH_INTERNAL_ASSERT(
+      active_captures_ > 0, "captureEnd called with no active capture");
+  --active_captures_;
+}
+
+} // namespace c10::cuda::CUDAGraphMemory

--- a/c10/cuda/impl/CUDAGraphMemory.h
+++ b/c10/cuda/impl/CUDAGraphMemory.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace c10::cuda::CUDAGraphMemory {
+
+// Owns CUDA Graph-specific capture state for the native allocator. Block
+// lifecycle and conditional-capture policy are added only when CCA starts
+// delegating them.
+class CaptureTracker {
+ public:
+  void captureBegin();
+  void captureEnd();
+  bool hasActiveCaptures() const {
+    return active_captures_ != 0;
+  }
+
+ private:
+  int active_captures_{0};
+};
+
+} // namespace c10::cuda::CUDAGraphMemory

--- a/torch/utils/hipify/cuda_to_hip_mappings.py
+++ b/torch/utils/hipify/cuda_to_hip_mappings.py
@@ -3463,6 +3463,7 @@ C10_MAPPINGS = collections.OrderedDict([
     ("c10/cuda/CUDADeviceAssertionHost.h", "c10/hip/HIPDeviceAssertionHost.h"),
     ("c10/cuda/CUDAException.h", "c10/hip/HIPException.h"),
     ("c10/cuda/CUDAFunctions.h", "c10/hip/HIPFunctions.h"),
+    ("c10/cuda/impl/CUDAGraphMemory.h", "c10/hip/impl/HIPGraphMemory.h"),
     ("c10/cuda/CUDAGraphsC10Utils.h", "c10/hip/HIPGraphsC10Utils.h"),
     ("c10/cuda/CUDAGuard.h", "c10/hip/HIPGuard.h"),
     ("c10/cuda/CUDAMacros.h", "c10/hip/HIPMacros.h"),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #195513
* #176670
* #195512
* #195511
* #192098
* #176657
* __->__ #195510

Move the native allocator active-capture counter behind a small per-device CUDAGraphMemory tracker without changing capture behavior.

cc @mcarilli @ezyang @eellison @penguinwu @BoyuanFeng