### PR TITLE
[inductor] Avoid eager fusion-candidate metadata walks

### DIFF
--- a/test/inductor/test_inductor_scheduler.py
+++ b/test/inductor/test_inductor_scheduler.py
@@ -41,6 +41,7 @@ from torch._inductor.scheduler import (
     SubParentEpilogueCandidate,
     SubParentEpilogueGrouping,
     SubParentOutputGroup,
+    WhyNoFuse,
 )
 from torch._inductor.sizevars import SizeVarAllocator
 from torch._inductor.utils import fresh_inductor_cache, snode_args_kwargs
@@ -116,6 +117,35 @@ def _test_cases(device, dtype):
 
 
 class TestScheduler(TestCase):
+    def test_why_no_fuse_names_are_lazy(self):
+        node1 = Mock()
+        node2 = Mock()
+        node1.get_name.return_value = "node1"
+        node2.get_name.return_value = "node2"
+
+        why = WhyNoFuse(node1, node2)
+        node1.get_name.assert_not_called()
+        node2.get_name.assert_not_called()
+
+        with patch(
+            "torch._inductor.scheduler.fusion_log.isEnabledFor", return_value=False
+        ):
+            why("reason")
+        node1.get_name.assert_not_called()
+        node2.get_name.assert_not_called()
+
+        with (
+            patch(
+                "torch._inductor.scheduler.fusion_log.isEnabledFor",
+                return_value=True,
+            ),
+            patch("torch._inductor.scheduler.fusion_log.debug") as debug,
+        ):
+            why("reason %s", "details")
+        debug.assert_called_once_with(
+            "cannot fuse %s with %s: reason %s", "node1", "node2", "details"
+        )
+
     def _mock_base_snode(self, name, device=None):
         node = Mock()
         node.get_name.return_value = name

--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -19,6 +19,7 @@ from torch._inductor.codegen.triton import TritonScheduling
 from torch._inductor.graph import GraphLowering
 from torch._inductor.invert_expr_analysis import generate_inverse_formula
 from torch._inductor.scheduler import (
+    _active_loop_mutation_trackers,
     _LoopMutationTracker,
     ForeachKernelSchedulerNode,
     FusedSchedulerNode,
@@ -279,13 +280,9 @@ class ImplDetailTest(MockSchedulerTest):
             V.graph.scheduler, self._create_computed_buffer_ax2()
         )
         original_body = computed_node._body
-        tracker = _LoopMutationTracker.create((template_node, computed_node))
-
-        try:
+        with _LoopMutationTracker.create((template_node, computed_node)):
             computed_node.apply_indexing_exprs({})
             self.assertIsNot(computed_node._body, original_body)
-        finally:
-            tracker.finish(rollback=True)
 
         self.assertIsNone(template_node._body)
         self.assertIs(computed_node._body, original_body)
@@ -294,30 +291,69 @@ class ImplDetailTest(MockSchedulerTest):
         """A nested scope committing must not hide the mutation from the outer one."""
         snode = SchedulerNode(V.graph.scheduler, self._create_computed_buffer_ax2())
         original_body = snode._body
-        outer = _LoopMutationTracker.create((snode,))
-        inner = _LoopMutationTracker.create((snode,))
-
-        try:
-            snode.apply_new_loop_order([1, 0])
+        with _LoopMutationTracker.create((snode,)):
+            with _LoopMutationTracker.create((snode,)) as inner:
+                snode.apply_new_loop_order([1, 0])
+                self.assertIsNot(snode._body, original_body)
+                # The inner scope keeps the mutation, but the outer scope still
+                # saw it and can roll it back.
+                inner.commit()
             self.assertIsNot(snode._body, original_body)
-            # The inner scope keeps the mutation, but the outer scope still saw
-            # it via the chained listener and can roll it back.
-            inner.finish(rollback=False)
-            self.assertIsNot(snode._body, original_body)
-        finally:
-            outer.finish(rollback=True)
 
         self.assertIs(snode._body, original_body)
-        self.assertIsNone(snode._loop_mutation_listener)
+
+    def test_loop_mutation_tracker_does_not_eagerly_walk_fused_node(self):
+        snodes = [
+            SchedulerNode(V.graph.scheduler, self._create_computed_buffer_ax2())
+            for _ in range(2)
+        ]
+        for order, snode in enumerate(snodes):
+            snode.min_order = snode.max_order = order
+            snode.min_input_distance = snode.max_input_distance = 0
+        fused = FusedSchedulerNode(V.graph.scheduler, snodes)
+
+        with mock.patch.object(fused, "get_nodes", wraps=fused.get_nodes) as get_nodes:
+            with _LoopMutationTracker.create((fused,)) as tracker:
+                self.assertEqual(get_nodes.call_count, 0)
+                tracker.commit()
+
+    def test_loop_mutation_tracker_rolls_back_committed_state_on_exception(self):
+        snode = SchedulerNode(V.graph.scheduler, self._create_computed_buffer_ax2())
+        original_body = snode._body
+
+        with self.assertRaisesRegex(RuntimeError, "stop"):
+            with _LoopMutationTracker.create((snode,)) as tracker:
+                snode.apply_new_loop_order([1, 0])
+                tracker.commit()
+                raise RuntimeError("stop")
+
+        self.assertIs(snode._body, original_body)
+
+    def test_can_fuse_loop_state_tracker_cleanup_on_base_exception(self):
+        snodes = [
+            SchedulerNode(V.graph.scheduler, self._create_computed_buffer_ax2())
+            for _ in range(2)
+        ]
+        original_body = snodes[0]._body
+        scheduler = mock.Mock(spec=Scheduler)
+
+        def interrupt(*args, **kwargs):
+            snodes[0].apply_new_loop_order([1, 0])
+            raise KeyboardInterrupt("stop")
+
+        scheduler._can_fuse_impl.side_effect = interrupt
+        with self.assertRaisesRegex(KeyboardInterrupt, "stop"):
+            Scheduler.can_fuse(scheduler, *snodes)
+
+        self.assertIs(snodes[0]._body, original_body)
+        self.assertEqual(_active_loop_mutation_trackers.get(), ())
 
     def test_expand_dimension_loop_state_rollback(self):
         snode = SchedulerNode(V.graph.scheduler, self._create_computed_buffer_ax2())
         original_state = snode.snapshot_loop_state()
-        tracker = _LoopMutationTracker.create((snode,))
-
-        snode.expand_dimension_for_pointwise_node(0, 64)
-        self.assertNotEqual(snode.snapshot_loop_state(), original_state)
-        tracker.finish(rollback=True)
+        with _LoopMutationTracker.create((snode,)):
+            snode.expand_dimension_for_pointwise_node(0, 64)
+            self.assertNotEqual(snode.snapshot_loop_state(), original_state)
 
         self.assertEqual(snode.snapshot_loop_state(), original_state)
 
@@ -338,13 +374,11 @@ class ImplDetailTest(MockSchedulerTest):
         original_body = snodes[0]._body
         original_group = subkernel.group
         original_read_writes = foreach.read_writes
-        tracker = _LoopMutationTracker.create((foreach,))
-
-        snodes[0].expand_dimension_for_pointwise_node(0, 64)
-        subkernel.group = (original_group[0], (sympy.S.One, sympy.S.One))
-        refresh_group_node_dependencies(subkernel)
-        refresh_group_node_dependencies(foreach)
-        tracker.finish(rollback=True)
+        with _LoopMutationTracker.create((foreach,)):
+            snodes[0].expand_dimension_for_pointwise_node(0, 64)
+            subkernel.group = (original_group[0], (sympy.S.One, sympy.S.One))
+            refresh_group_node_dependencies(subkernel)
+            refresh_group_node_dependencies(foreach)
 
         self.assertIs(snodes[0]._body, original_body)
         self.assertEqual(subkernel.group, original_group)

--- a/torch/_inductor/codegen/cutlass/scheduling.py
+++ b/torch/_inductor/codegen/cutlass/scheduling.py
@@ -34,8 +34,7 @@ log = logging.getLogger(__name__)
 
 class WhyNoFuseNames(WhyNoFuse):
     def __init__(self, name1: str, name2: str) -> None:
-        self.name1 = name1
-        self.name2 = name2
+        super().__init__(name1, name2)
 
 
 class CUTLASSScheduling(BaseScheduling):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -5423,7 +5423,7 @@ class _LoopMutationTracker:
         """Create an inactive rollback scope without walking candidate leaves."""
         return cls(nodes=tuple(OrderedSet(nodes)))
 
-    def __enter__(self) -> _LoopMutationTracker:
+    def __enter__(self) -> typing.Self:
         if self.token is not None:
             raise AssertionError("loop mutation tracker already active")
         active = _active_loop_mutation_trackers.get()

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import contextlib
+import contextvars
 import dataclasses
 import enum
 import functools
@@ -3284,24 +3285,21 @@ def maybe_estimate_runtime_benchmark(snode: BaseSchedulerNode) -> float | None:
 
 @dataclasses.dataclass(slots=True)
 class WhyNoFuse:
-    name1: str
-    name2: str
-    reason: str
-    args: tuple[Any, ...]
+    node1: BaseSchedulerNode | str
+    node2: BaseSchedulerNode | str
 
-    def __init__(self, node1: BaseSchedulerNode, node2: BaseSchedulerNode) -> None:
-        self.name1 = node1.get_name()
-        self.name2 = node2.get_name()
+    @staticmethod
+    def _name(node: BaseSchedulerNode | str) -> str:
+        return node if isinstance(node, str) else node.get_name()
 
     def __call__(self, reason: str, *args: Any) -> None:
-        self.reason = reason
-        self.args = args
-        fusion_log.debug(self)
-
-    def __str__(self) -> str:
-        return f"cannot fuse {self.name1} with {self.name2}: " + (
-            self.reason % self.args
-        )
+        if fusion_log.isEnabledFor(logging.DEBUG):
+            fusion_log.debug(
+                "cannot fuse %s with %s: " + reason,
+                self._name(self.node1),
+                self._name(self.node2),
+                *args,
+            )
 
 
 def pformat(obj: Any) -> str:
@@ -3436,7 +3434,6 @@ class SchedulerNode(BaseSchedulerNode):
         node: ir.ComputedBuffer | ir.TemplateBuffer,
     ) -> None:
         super().__init__(scheduler)
-        self._loop_mutation_listener: Callable[[SchedulerNode], None] | None = None
         self._loop_state_gen = 0
         self._init_from_node(node)
         self._compute_attrs()
@@ -3555,11 +3552,11 @@ class SchedulerNode(BaseSchedulerNode):
         self.clear_loop_body_dependent_caches(need_clear_tiling_cache=True)
 
     def _before_loop_state_mutation(self) -> None:
-        if self._loop_mutation_listener is not None:
-            self._loop_mutation_listener(self)
+        for tracker in _active_loop_mutation_trackers.get():
+            tracker.track(self)
         # Identifies the current loop state, so analyses derived from it can be
         # cached across the O(n^2) fusion pair search. Bumped after notifying
-        # the listener, which snapshots the pre-mutation state: snapshot and
+        # active trackers, which snapshot the pre-mutation state: snapshot and
         # restore then carry the generation, so rolling a trial reindex back
         # also restores cache validity.
         self._loop_state_gen += 1
@@ -5408,62 +5405,61 @@ class _LoopMutationTracker:
     candidates do not inherit a speculative layout chosen for a fusion
     that did not happen.
 
-    Recursive can_fuse() calls chain their listeners so each scope captures its
-    own decision boundary while the outer scope still sees nested mutations.
+    Recursive can_fuse() calls share a context-local tracker stack so each scope
+    captures its own decision boundary while the outer scope still sees nested
+    mutations.
 
-    Use finish(rollback=False) to keep mutations or finish(rollback=True) to
-    restore the original state. If no mutation occurred, finish() is a no-op.
+    The context rolls back by default. Call commit() before leaving it to keep
+    mutations. If no mutation occurred, exiting is a no-op.
     """
 
     nodes: tuple[BaseSchedulerNode, ...]
-    watched_nodes: OrderedSet[SchedulerNode] = dataclasses.field(
-        default_factory=OrderedSet
-    )
-    previous_listeners: dict[SchedulerNode, Callable[[SchedulerNode], None] | None] = (
-        dataclasses.field(default_factory=dict)
-    )
     state: _LoopStateSnapshot | None = None
+    token: contextvars.Token[tuple[_LoopMutationTracker, ...]] | None = None
+    committed: bool = False
 
     @classmethod
     def create(cls, nodes: tuple[BaseSchedulerNode, ...]) -> _LoopMutationTracker:
-        """Create a rollback scope and watch mutable leaf scheduler nodes."""
-        seen = OrderedSet(nodes)
-        tracker = cls(nodes=tuple(seen))
-        for node in _iter_loop_state_nodes(seen):
-            if isinstance(node, SchedulerNode):
-                tracker.watch(node)
-        return tracker
+        """Create an inactive rollback scope without walking candidate leaves."""
+        return cls(nodes=tuple(OrderedSet(nodes)))
 
-    def watch(self, sn: SchedulerNode) -> None:
-        """Install this scope as the mutation listener for a leaf node."""
-        if sn in self.watched_nodes:
-            return
-        self.previous_listeners[sn] = sn._loop_mutation_listener
-        self.watched_nodes.add(sn)
-        sn._loop_mutation_listener = self.track
+    def __enter__(self) -> _LoopMutationTracker:
+        if self.token is not None:
+            raise AssertionError("loop mutation tracker already active")
+        active = _active_loop_mutation_trackers.get()
+        self.token = _active_loop_mutation_trackers.set((*active, self))
+        return self
 
     def track(self, sn: SchedulerNode) -> None:
         """Lazily snapshot candidate roots when the first mutation occurs."""
-        if sn not in self.watched_nodes:
-            raise AssertionError(f"scheduler node {sn} is not being watched")
-        if previous := self.previous_listeners[sn]:
-            previous(sn)
         if self.state is not None:
             # Keep the original pre-mutation snapshot for the whole scope.
             return
+        if not any(sn in node.get_nodes() for node in self.nodes):
+            return
 
-        # The listener tells us a child loop mutated. Snapshot the original
-        # candidate roots here so we also capture fused-node group state,
-        # which is reassigned directly and has no listener of its own.
+        # The mutation tells us a child loop changed. Snapshot the original
+        # candidate roots so we also capture fused-node group state, which is
+        # reassigned directly and has no mutation hook of its own.
         self.state = _LoopStateSnapshot.create(self.nodes)
 
-    def finish(self, *, rollback: bool) -> None:
-        """Detach listeners and restore captured state if rolling back."""
-        for sn in self.watched_nodes:
-            sn._loop_mutation_listener = self.previous_listeners[sn]
-        if not rollback or self.state is None:
+    def commit(self) -> None:
+        self.committed = True
+
+    def __exit__(self, exc_type: type[BaseException] | None, *args: Any) -> None:
+        """Leave the tracking scope, restoring state unless it was committed."""
+        if self.token is None:
+            raise AssertionError("loop mutation tracker is not active")
+        _active_loop_mutation_trackers.reset(self.token)
+        self.token = None
+        if (self.committed and exc_type is None) or self.state is None:
             return
         self.state.restore()
+
+
+_active_loop_mutation_trackers: contextvars.ContextVar[
+    tuple[_LoopMutationTracker, ...]
+] = contextvars.ContextVar("active_loop_mutation_trackers", default=())
 
 
 # Distinguishes "not cached" from a cached None in _tiling_memory_cache.
@@ -9570,15 +9566,16 @@ class Scheduler:
         Speculative loop mutations (reordering, reindexing) are automatically
         rolled back if the fusion decision ultimately fails.
         """
-        tracker = _LoopMutationTracker.create((node1, node2))
-        can_fuse = self._can_fuse_impl(
-            node1,
-            node2,
-            can_reorder=can_reorder,
-            allow_mix_order_reduction=allow_mix_order_reduction,
-        )
-        tracker.finish(rollback=not can_fuse)
-        return can_fuse
+        with _LoopMutationTracker.create((node1, node2)) as tracker:
+            can_fuse = self._can_fuse_impl(
+                node1,
+                node2,
+                can_reorder=can_reorder,
+                allow_mix_order_reduction=allow_mix_order_reduction,
+            )
+            if can_fuse:
+                tracker.commit()
+            return can_fuse
 
     def _can_fuse_impl(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195515

Fusion legality installed mutation listeners across every leaf in both candidate
nodes before each check, even though most checks never mutate loop state. Wide
fused nodes therefore repeated an increasingly large traversal for every
candidate pair. Rejected candidates also materialized their full fused names
when fusion debug logging was disabled.

Track active rollback scopes in context-local state and discover affected leaf
nodes only when a mutation actually occurs. The rollback-by-default context
manager preserves nested decision boundaries and restores state on rejection or
exceptions. Gate fusion diagnostics at the logging level before constructing
candidate names, following the existing Inductor logging pattern.

The alternative was to skip tracking based on individual fusion options, but
that would couple correctness to an incomplete list of mutation paths. Lazy
notification keeps every mutation covered.

Test Plan:

```
python test/inductor/test_inductor_scheduler.py -k fusion
python test/inductor/test_loop_ordering.py -k loop_state
python test/inductor/test_loop_ordering.py -k loop_mutation
```

Local cold-compile benchmarks on two representative large fusion workloads
improved by 28.1% and 24.3%.

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo