### PR TITLE
[Inductor dependency][Fix] Keep control_deps on its dedicated lowering (#195517)

### DIFF
--- a/test/inductor/test_control_deps.py
+++ b/test/inductor/test_control_deps.py
@@ -20,6 +20,39 @@ requires_cuda_triton = unittest.skipUnless(HAS_CUDA_AND_TRITON, "requires CUDA")
 
 
 class TestControlDeps(InductorTestCase):
+    def test_control_deps_wraps_fallback_op(self):
+        def fn(x):
+            dependency = x + 1
+            fallback = torch.neg(x)
+            return dependency + fallback
+
+        def add_control_deps(graph):
+            from torch._inductor.fx_passes.control_dependencies import (
+                preserve_node_ordering,
+            )
+            from torch.utils._ordered_set import OrderedSet
+
+            add_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.add.Tensor
+            )
+            neg_nodes = graph.find_nodes(
+                op="call_function", target=torch.ops.aten.neg.default
+            )
+            if len(add_nodes) != 2 or len(neg_nodes) != 1:
+                raise AssertionError("Unexpected graph structure")
+
+            fallback = neg_nodes[0]
+            fallback.meta["should_fallback"] = True
+            fallback.meta["custom"] = {"fallback_to_eager": True}
+            preserve_node_ordering(graph, {fallback: OrderedSet([add_nodes[0]])})
+            return graph
+
+        x = torch.randn(8)
+        with config.patch(post_grad_custom_post_pass=add_control_deps):
+            actual = torch.compile(fn)(x)
+
+        torch.testing.assert_close(actual, fn(x))
+
     @config.patch(reorder_for_locality=False)
     @requires_gpu()
     def test_control_deps_prevents_fusion(self):

--- a/torch/_inductor/fx_passes/control_dependencies.py
+++ b/torch/_inductor/fx_passes/control_dependencies.py
@@ -203,6 +203,14 @@ def preserve_node_ordering(
         ordered_node.meta = original_meta
         # this will be constrained on the target node in subgraph if it exists
         ordered_node.meta.pop("eager_input_vals", None)
+        # The wrapped operation retains its fallback metadata in the subgraph.
+        # The control_deps HOP itself must use its dedicated lowering because
+        # FallbackKernel cannot handle its Subgraph argument.
+        ordered_node.meta.pop("should_fallback", None)
+        custom_meta = ordered_node.meta.get("custom")
+        if isinstance(custom_meta, dict) and "fallback_to_eager" in custom_meta:
+            ordered_node.meta["custom"] = custom_meta.copy()
+            ordered_node.meta["custom"].pop("fallback_to_eager")
 
         # Replace all uses of the original node with the ordered version
         dependent_node.replace_all_uses_with(ordered_node)


### PR DESCRIPTION
Summary:

**tl ; dr:**

The wrapper accidentally copies fallback_to_eager from neg:
Subgraph argument that an ordinary fallback kernel cannot handle.

Before the fix, both nodes inherited fallback metadata:

```
  control_deps: fallback_to_eager   ← wrong
  subgraph neg: fallback_to_eager  ← correct
        → FallbackKernel(neg, x)
```

The fix makes it:
```
  control_deps                 no fallback metadata
  └── subgraph: neg(x)         metadata: fallback_to_eager
```

Failure mode:
the problem is metadata inheritance:
```
  Original fallback op: neg(x)
          │ wrap for ordering
          ▼
  control_deps(dependency, subgraph[neg], x)
```

In the following combination:

An operation is marked “fallback to eager” +
The operation is wrapped by control_deps

- AutoParallel overlap scheduling creates control_deps wrappers.
- Custom ASIC operators (eg: MTIA) exposes the bug more frequently because more  operations use eager fallback.

Test Plan:
# Unit tests

```bash
buck2 test fbcode//caffe2/test/inductor:control_deps -- test_control_deps_wraps_fallback_op
```
https://www.internalfb.com/intern/testinfra/testrun/25051272968829630

```
[caoyancharles@devvm43345.ftw0 /data/repos/fbsource (6371b1ef56)]$ buck2 test fbcode//caffe2/test/inductor:control_deps -- test_control_deps_wraps_fallback_op
File changed (since mergebase): fbcode//caffe2/test/inductor/test_control_deps.py
File changed (since mergebase): fbcode//caffe2/torch/_inductor/fx_passes/control_dependencies.py
File changed (since mergebase): fbcode//pytorch/autoparallel/BUCK
5 additional file change events (since mergebase)
File Watcher fresh instance: cleared graph state, cleared dep files
Buck UI: https://www.internalfb.com/buck2/885fade1-3c21-4bb0-bd02-061075dcbe99
Test UI: https://www.internalfb.com/intern/testinfra/testrun/27866022737603414
Network: up 1.1GiB  down 2.3GiB
Phase                   Remaining  Details
Loading targets          0/  8359  123916 dirs read, 922060 targets declared
Analyzing targets        0/135069  3687522 actions, 5304003 artifacts declared
Executing actions        0/794021  196:24:48.3s exec time total
Command test                       Finished 108 local, 6149 remote, 224796 cache (97% hit)  186:34:06.3s exec time cached (94%)
elapsed 10:45.3s
Buck UI: https://www.internalfb.com/buck2/885fade1-3c21-4bb0-bd02-061075dcbe99
Tests finished: Pass 2. Fail 0. Timeout 0. Fatal 0. Skip 0. Omit 0. Infra Failure 0. Build failure 0
```

Reviewed By: guangyuwang

Differential Revision: D118191147


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo