### PR TITLE
[Inductor][MTIA][Cuda stream async] Support dynamo trace the de-allocation of MTIA tensor (#195524)

### DIFF
--- a/torch/_dynamo/symbolic_convert.py
+++ b/torch/_dynamo/symbolic_convert.py
@@ -2281,7 +2281,7 @@ class InstructionTranslatorBase(
         from .variables.streams import get_current_stream, new_event
 
         device = var.device
-        if device is None or device.type not in ("cuda", "xpu"):
+        if device is None or device.type not in ("cuda", "mtia", "xpu"):
             return
 
         node = var.proxy.node


### PR DESCRIPTION
Summary:

in Cuda, Inductor supports cross stream safety for example: https://fburl.com/u3jkovf3 

model code like: 
```
x = torch.rand(1024, device="cuda") 
with consumer_stream:
      y = kernel_b(x)
del x 
z = allocate_something_else()
```
is supported in Cuda. 

however, MTIA currently doesn't support this functionality. 
this add MTIA to dynamo trace de-allocation of MTIA tensor to support this. 

It currently covers:
  - Explicit del x
  - Code captured by Dynamo
  - A cross-stream use visible inside the compiled graph
  - Safe caching-allocator reuse

Test Plan:
`buck2 test fbcode//mtia/host_runtime/torch_mtia/tests/pt2:test_fie_ptr64_cross_stream_lifetime-athena` 

- fails without D117143122 because the FIE intermediate is reused while the consumer stream is pending
- passes with D117143122 overlaid

Differential Revision: D118215013




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98