### PR TITLE
Fix torch.Stream silently no-op'ing for Python-registered PrivateUse1 backends

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -558,6 +558,7 @@
 # /test/test_per_overload_api.py
 # /test/test_prims.py
 # /test/test_privateuseone_python_backend.py
+# /test/test_privateuseone_python_backend_streams.py
 # /test/test_proxy_tensor.py
 # /test/test_pruning_op.py
 # /test/test_python_dispatch.py

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -317,6 +317,7 @@ RUN_PARALLEL_BLOCKLIST = [
     "test_autograd_fallback",
     "inductor/test_compiler_bisector",
     "test_privateuseone_python_backend",
+    "test_privateuseone_python_backend_streams",
     "functorch/test_control_flow_cuda_initialization",
 ] + FSDP_TEST
 

--- a/test/test_privateuseone_python_backend.py
+++ b/test/test_privateuseone_python_backend.py
@@ -140,6 +140,15 @@ class PrivateUse1BackendTest(TestCase):
         # Assert this don't throw:
         _ = a_cpu.is_pinned()
 
+    def test_new_stream_raises_without_python_impl(self):
+        # This backend's device guard does not define `get_new_stream`, so
+        # asking for a stream must raise rather than silently returning the
+        # default stream. See https://github.com/pytorch/pytorch/issues/195458
+        with self.assertRaisesRegex(
+            RuntimeError, "Backend doesn't support create a new Stream"
+        ):
+            torch.Stream(device="npy")
+
     @unittest.skip(
         "Disabled due to CI failures; see "
         "https://github.com/pytorch/pytorch/issues/190232"

--- a/test/test_privateuseone_python_backend_streams.py
+++ b/test/test_privateuseone_python_backend_streams.py
@@ -1,0 +1,62 @@
+# Owner(s): ["module: PrivateUse1"]
+
+import torch
+import torch._C
+from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
+
+
+_DEVICE_TYPE = torch._C._autograd.DeviceType.PrivateUse1
+
+
+class StreamDeviceGuard(torch._C._acc.DeviceGuard):
+    """A python-only backend that defines how to create a stream."""
+
+    def __init__(self):
+        super().__init__()
+        self.next_id = 0
+        self.calls = []
+
+    def type_(self):
+        return _DEVICE_TYPE
+
+    def get_new_stream(self, device, priority):
+        self.calls.append((device.type, device.index, priority))
+        self.next_id += 1
+        # NOTE: the stream has to be built with the
+        # (stream_id, device_index, device_type) overload. Stream(device=...)
+        # would call back into this method and recurse forever.
+        index = device.index if device.index is not None else 0
+        return torch.Stream(self.next_id, index, int(_DEVICE_TYPE))
+
+
+# NOTE: device guard registration is process-global and first-wins, so this
+# guard must be registered before _setup_privateuseone_for_python_backend
+# installs its default one, and only one guard can be tested per process.
+_GUARD = StreamDeviceGuard()
+torch._C._acc.register_python_privateuseone_device_guard(_GUARD)
+_setup_privateuseone_for_python_backend("mydev")
+
+
+class PrivateUse1PythonStreamTest(TestCase):
+    def test_new_stream_dispatches_to_python(self):
+        before = len(_GUARD.calls)
+        torch.Stream(device="mydev")
+        self.assertEqual(len(_GUARD.calls), before + 1)
+
+    def test_new_streams_are_distinct(self):
+        s1 = torch.Stream(device="mydev")
+        s2 = torch.Stream(device="mydev")
+        self.assertNotEqual(s1.stream_id, s2.stream_id)
+
+    def test_priority_is_forwarded(self):
+        torch.Stream(device="mydev", priority=-1)
+        self.assertEqual(_GUARD.calls[-1][2], -1)
+
+    def test_stream_keeps_device(self):
+        s = torch.Stream(device="mydev")
+        self.assertEqual(s.device.type, "mydev")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/test_privateuseone_python_backend_streams.py
+++ b/test/test_privateuseone_python_backend_streams.py
@@ -2,7 +2,7 @@
 
 import torch
 import torch._C
-from torch.testing._internal.common_utils import run_tests, TestCase
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
 from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
 
 
@@ -38,11 +38,14 @@ torch._C._acc.register_python_privateuseone_device_guard(_GUARD)
 _setup_privateuseone_for_python_backend("mydev")
 
 
+@skipIfTorchDynamo("stream creation is device plumbing, not traceable work")
 class PrivateUse1PythonStreamTest(TestCase):
     def test_new_stream_dispatches_to_python(self):
         before = len(_GUARD.calls)
-        torch.Stream(device="mydev")
+        stream = torch.Stream(device="mydev")
         self.assertEqual(len(_GUARD.calls), before + 1)
+        # The old no-op handed back the default stream, whose id is 0.
+        self.assertNotEqual(stream.stream_id, 0)
 
     def test_new_streams_are_distinct(self):
         s1 = torch.Stream(device="mydev")
@@ -51,7 +54,7 @@ class PrivateUse1PythonStreamTest(TestCase):
 
     def test_priority_is_forwarded(self):
         torch.Stream(device="mydev", priority=-1)
-        self.assertEqual(_GUARD.calls[-1][2], -1)
+        self.assertIn(-1, [priority for _, _, priority in _GUARD.calls])
 
     def test_stream_keeps_device(self):
         s = torch.Stream(device="mydev")

--- a/torch/_C/_acc/__init__.pyi
+++ b/torch/_C/_acc/__init__.pyi
@@ -1,4 +1,4 @@
-from torch import Tensor
+from torch import Stream, Tensor
 from torch.types import _dtype, _int, Device
 
 # Defined in torch/csrc/acc/Module.cpp
@@ -9,6 +9,11 @@ class PrivateUse1Hooks:
 
 class DeviceGuard:
     def type_(self) -> Device: ...
+    # Optional. If a subclass does not define this, creating a stream for the
+    # device raises instead of returning the default stream. The returned
+    # Stream must be built with the (stream_id, device_index, device_type)
+    # overload; Stream(device=...) would re-enter this method.
+    def get_new_stream(self, device: Device, priority: _int) -> Stream: ...
 
 def register_python_privateuseone_device_guard(guard: DeviceGuard) -> bool: ...
 def register_python_privateuseone_hook(hook: PrivateUse1Hooks) -> bool: ...

--- a/torch/csrc/acc/Module.cpp
+++ b/torch/csrc/acc/Module.cpp
@@ -81,11 +81,19 @@ struct PythonDeviceGuard final : public c10::impl::DeviceGuardImplInterface {
     return c10::Stream(c10::Stream::DEFAULT, getDevice());
   }
 
-  c10::Stream getNewStream(c10::Device /*unused*/, int priority = 0)
+  // Dispatches to a `get_new_stream` defined on the Python subclass, if there
+  // is one. Otherwise falls back to DeviceGuardImplInterface::getNewStream,
+  // which raises: a backend that has not defined streams should say so rather
+  // than silently hand back the default stream.
+  c10::Stream getNewStream(c10::Device device, int priority = 0)
       const override {
-    // no-op
-    (void)priority;
-    return c10::Stream(c10::Stream::DEFAULT, getDevice());
+    PYBIND11_OVERRIDE_NAME(
+        c10::Stream,
+        c10::impl::DeviceGuardImplInterface,
+        "get_new_stream",
+        getNewStream,
+        device,
+        priority);
   }
 
   c10::Stream exchangeStream(c10::Stream /*unused*/) const noexcept override {


### PR DESCRIPTION
Fixes #195458

## Problem

`PythonDeviceGuard::getNewStream` returned `Stream(Stream::DEFAULT, ...)` unconditionally. That overrides `DeviceGuardImplInterface::getNewStream`, which already raises "Backend doesn't support create a new Stream.".

So a backend registered purely in Python through `_setup_privateuseone_for_python_backend` gets a `torch.Stream` back from `torch.Stream(device=...)` whose `stream_id` is always 0 and never increments. There is no way to say what a stream means for that device, and no error telling you it was never defined.

Running the reproducer from the issue on main prints `0` twice. After this change it raises `RuntimeError: Backend doesn't support create a new Stream.`

## Fix

Use `PYBIND11_OVERRIDE_NAME` so the call dispatches to a `get_new_stream` defined on the Python subclass when there is one, and otherwise falls through to the base class, which raises.

That covers both things asked for in the issue: an undefined stream errors instead of handing back a bogus value, and a backend can now define streams in Python.

Two constraints worth knowing if you write such a backend, both noted in the `.pyi` and exercised in the test:

* the override has to build its return value with the `(stream_id, device_index, device_type)` overload, because `Stream(device=...)` re-enters `THPStream_pynew` and recurses
* `device.index` arrives as `None` when the caller did not pass an index

## Behavior change

Code that relied on the old silent no-op now gets a `RuntimeError`. That is what the issue asks for, but it is a visible change, so calling it out.

Arguments that it does not need a deprecation window: the API was added in #157859 (Oct 2025), it is private (`torch._C._acc`, underscore-prefixed setup helper), and its docstring already says "this API is experimental and might change without notice". The only behavior being removed is a `stream_id` that was permanently 0, which nothing can be depending on for anything correct.

Happy to gate it behind a warning first if reviewers would rather.

## Scope

Only `getNewStream` is forwarded here. `getStream` and `exchangeStream` are declared `noexcept override` in `PythonDeviceGuard` while the base class does not declare them `noexcept`, so forwarding those to Python would turn a Python exception into `std::terminate`. That needs the specifier dropped first, so it is left for a follow-up along with the event functions still marked TODO at `Module.cpp:99`.

## Blast radius

`PythonDeviceGuard` is registered from exactly one place, `register_python_privateuseone_device_guard`, which is only called from `backend_registration.py`. In-tree C++ backends including `torch_openreg` register through `C10_REGISTER_GUARD_IMPL` and never reach this code.

## Testing

Built from source on macOS arm64, CPU only, at `ae08e11d38`.

* Reproduced the issue on unpatched main: `stream_id` 0 twice, no error raised.
* After the patch: a guard without `get_new_stream` raises, and a guard with one returns ids 1, 2, 3 with `priority` forwarded correctly.
* Confirmed the new tests actually fail without the fix. Reverted only `Module.cpp`, rebuilt, and both files went red (`AssertionError: RuntimeError not raised`, plus 2 failures and 1 error in the new file). Restored the patch, rebuilt, both green.
* `test_privateuseone_python_backend`, `test_extension_utils`, `test_rename_privateuse1_to_existing_device` and `test_autoload` all pass.
* `lintrunner` clean.

Two things I could not cover locally and am relying on CI for: `test_accelerator` skips on a CPU-only build, and I could not get the `torch_openreg` extension to build locally, so its stream and event tests did not run.

On the test layout: device guard registration is process global and first-wins (`Module.cpp:140` returns false if a guard is already registered), so only one guard is testable per process. The negative case therefore lives in the existing test file, which uses the default `_DummyDeviceGuard`, and the Python-defined case needs a file of its own.


cc @NmomoN @mengpenghui @fwenguang @cdzhan @1274085042 @PHLens @albanD @guangyey @EikanWang