### PR TITLE
Add nccl4py as an optional dependency 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,6 +408,7 @@ Forum = "https://discuss.pytorch.org"
 optree = ["optree>=0.13.0"]
 opt-einsum = ["opt-einsum>=3.3"]
 pyyaml = ["pyyaml"]
+nccl4py = ["nccl4py==0.3.1"]
 
 # Linter tools #################################################################
 


### PR DESCRIPTION
Declares nccl4py  as an opt in dependency installable via `torch[nccl4py]`. 