### PR TITLE
[xpu][fix]Enable memory-aware partitioned scatter on XPU

### DIFF
--- a/test/inductor/test_scatter_optimization.py
+++ b/test/inductor/test_scatter_optimization.py
@@ -575,7 +575,7 @@ class TestPartitionedScatterOpt(TestCase):
         with torch.no_grad():
             expected = f(out, idx, vals, persistent)
 
-        _, total_gpu = torch.cuda.mem_get_info()
+        _, total_gpu = torch.accelerator.get_memory_info()
 
         out_bytes = output_size * 4
         baseline_peak = out_bytes + N * 8 + N * 4 + persist_n * 4 + out_bytes
@@ -662,7 +662,7 @@ class TestPartitionedScatterOpt(TestCase):
         with torch.no_grad():
             expected = f(*args)
 
-        _, total_gpu = torch.cuda.mem_get_info()
+        _, total_gpu = torch.accelerator.get_memory_info()
 
         # Each out dies right after its own scatter, so the peak at every
         # index_put is the three inputs plus that node's 20 MB output.

--- a/torch/_inductor/fx_passes/reduced_atomic_contention.py
+++ b/torch/_inductor/fx_passes/reduced_atomic_contention.py
@@ -232,13 +232,13 @@ def _scan_candidates(graph: fx.Graph, ctx: ScatterPassContext) -> None:
 def _build_scatter_memory_state(graph: fx.Graph) -> "ScatterMemoryState | None":
     """
     Build a per-node peak-memory profile of the original graph.
-    Returns None when CUDA is unavailable or the profile can't be built; the
-    pass then runs unconstrained by the memory budget.
+    Returns None when no supported accelerator is available or the profile
+    can't be built; the pass then runs unconstrained by the memory budget.
     """
-    if not torch.cuda.is_available():
+    if not torch.accelerator.is_available():
         return None
 
-    _, total_gpu = torch.cuda.mem_get_info()
+    _, total_gpu = torch.accelerator.get_memory_info()
 
     floor_bytes: int = config.partitioned_scatter_non_model_floor_bytes
     allowed_peak = max(0, total_gpu - floor_bytes)


### PR DESCRIPTION
## Summary

Fix XPU support for the partitioned scatter memory-budget gate.

The pass initialized `ScatterMemoryState` only when CUDA was available. In XPU-only builds, it therefore fell back to an effectively unlimited budget, ignoring `partitioned_scatter_non_model_floor_bytes` and previously committed scatter-buffer overhead.

Use `torch.accelerator.get_memory_info()` so the same memory-budget logic applies to CUDA and XPU. Update the memory-budget tests to use the same device-agnostic API.

This fixes both XPU disabled tests:

- Fixes #192011: `test_memory_aware_partition_count`
- Fixes #192012: `test_memory_budget_shared_across_scatters`


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @gujinghui @fengyuan14 @guangyey