### PR TITLE
Skip test_index_add_bfloat16_deterministic on XPU

### DIFF
--- a/test/inductor/test_cuda_repro.py
+++ b/test/inductor/test_cuda_repro.py
@@ -2903,6 +2903,7 @@ def triton_poi_fused_add_reflection_pad2d_0(in_ptr0, in_ptr1, out_ptr0, xnumel, 
         ).run(code)
         self.assertEqual(out, compiled_out)
 
+    @skipIfXpu(msg="XPU deterministic mode does not use the aten.index_put_ fallback")
     @skipCUDAIf(
         not SM90OrLater and not TEST_WITH_ROCM,
         "requires ROCm or NVIDIA SM90+ bfloat16 atomic add support",


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.17.0) (oldest at bottom):
* __->__ #195534

test_index_add_bfloat16_deterministic (added in #195192) asserts that
compiling index_add under deterministic mode falls back to
aten.index_put_. Its skipCUDAIf gate only applies on CUDA devices, so
the test runs on XPU CI, where deterministic mode does not take the
index_put_ fallback path, and the FileCheck fails:

  RuntimeError: Expected to find "aten.index_put_" but did not find it

This has failed the xpu workflow on every trunk commit since the PR
landed (first red 0af5860a2e7, prior commit green). The sibling
test_index_add_bfloat16_* tests pass on XPU since triton-xpu supports
bf16 atomic_add; only the deterministic-fallback expectation is
CUDA/ROCm-specific. Skip it on XPU.

Test Plan: Cannot be tested locally (requires an Intel XPU runner); the
skip decorator matches existing skipIfXpu usages in this file and was
verified by review. Lint passes:

```
lintrunner -a test/inductor/test_cuda_repro.py
```

Authored with an AI assistant (Claude Code).

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo