### PR TITLE
Do not dereference the absent backend when reusing one in setBackend

### DIFF
--- a/test/distributed/test_c10d_common.py
+++ b/test/distributed/test_c10d_common.py
@@ -2699,6 +2699,21 @@ class SplitGroupOptionsTest(TestCase):
         self.assertEqual(opts._timeout, timedelta(seconds=5))
 
 
+class RegisterBackendWithoutBackendTest(TestCase):
+    def test_second_device_reuses_backend(self):
+        # _register_backend's backend argument defaults to None, and when the
+        # BackendType is already registered setBackend reuses the backend
+        # already stored for it. That reuse path used to dereference the
+        # absent optional to compare bound device ids.
+        backend = C10DBackend(0, 1)
+        pg = dist.ProcessGroup(dist.HashStore(), 0, 1)
+        pg._register_backend(
+            torch.device("cpu"), dist.ProcessGroup.BackendType.CUSTOM, backend
+        )
+        pg._register_backend(torch.device("cuda"), dist.ProcessGroup.BackendType.CUSTOM)
+        self.assertEqual(pg._get_backend(torch.device("cuda")), backend)
+
+
 class ProcessGroupWithDispatchedCollectivesTests(MultiProcessTestCase):
     @property
     def world_size(self):

--- a/torch/csrc/distributed/c10d/ProcessGroup.hpp
+++ b/torch/csrc/distributed/c10d/ProcessGroup.hpp
@@ -945,13 +945,16 @@ class TORCH_API ProcessGroup : public torch::CustomClassHolder {
     deviceTypeToBackendType_[deviceType] = backendType;
     deviceTypes_.insert(deviceType);
     // if the backendType is already set then reuse it for this device
-    if (backendTypeToBackend_.find(backendType) !=
-        backendTypeToBackend_.end()) {
-      auto existingBackend = backendTypeToBackend_.at(backendType);
+    if (auto it = backendTypeToBackend_.find(backendType);
+        it != backendTypeToBackend_.end()) {
+      const auto& existingBackend = it->second;
       deviceTypeToBackend_[deviceType] = existingBackend;
-      TORCH_CHECK(
-          existingBackend->getBoundDeviceId() ==
-          (*backend)->getBoundDeviceId());
+      // Python's binding defaults backend to None; skip the check when absent.
+      if (backend.has_value()) {
+        TORCH_CHECK(
+            existingBackend->getBoundDeviceId() ==
+            (*backend)->getBoundDeviceId());
+      }
     } else {
       // check if backend has value
       if (backend.has_value()) {


### PR DESCRIPTION
`setBackend` reuses an already-registered backend for a new device and unconditionally dereferenced the optional `backend` parameter to compare bound device ids. Python's `_register_backend` defaults `backend` to `None`, so registering a second device against an already-registered `BackendType` without passing a backend segfaults. The comparison now only runs when a backend was actually supplied, matching the guard already used on the new-`BackendType` branch.

Test plan:

```
python test/distributed/test_c10d_common.py RegisterBackendWithoutBackendTest
```

This change was authored with the assistance of an AI coding agent; the diagnosis, fix, and test were reviewed before submission.
