### PR TITLE
Restore unserializable weakrefs as dead refs, not live placeholders

### DIFF
--- a/test/dynamo/test_guard_serialization.py
+++ b/test/dynamo/test_guard_serialization.py
@@ -1,6 +1,7 @@
 # Owner(s): ["module: dynamo"]
 
 import dataclasses
+import io
 import itertools
 import pickle
 import sys
@@ -20,7 +21,7 @@ import torch.onnx.operators
 import torch.utils.cpp_extension
 from torch._dynamo.bytecode_transformation import transform_code_object
 from torch._dynamo.exc import PackageError
-from torch._dynamo.guards import CheckFunctionManager, CompileId
+from torch._dynamo.guards import CheckFunctionManager, CompileId, GuardsStatePickler
 from torch._dynamo.package import CompilePackage
 from torch._dynamo.source import LocalSource
 from torch._dynamo.symbolic_convert import (
@@ -1737,6 +1738,30 @@ class TestGuardSerialization(TestGuardSerializationBase):
             "TENSOR_MATCH", foo, Inputs(x, weakref.ref(x))
         )
         self._test_check_fn(ref, loaded, {"inputs": Inputs(x, weakref.ref(x))}, True)
+
+    def test_dead_weakref_reduce(self):
+        # Restored weakref must be dead, not a live-looking _Missing.
+        x = torch.randn(3)
+        ref = weakref.ref(x)
+        buf = io.BytesIO()
+        GuardsStatePickler({}, {}, {}, buf).dump(ref)
+        buf.seek(0)
+        restored = pickle.load(buf)
+
+        self.assertIs(type(restored), weakref.ref)
+        self.assertIsNone(restored())
+
+    def test_dead_weakref_distinct_hashes(self):
+        # Restored refs must hash distinctly, or unpickling goes quadratic.
+        tensors = [torch.randn(3) for _ in range(2000)]
+        d = {weakref.ref(t): i for i, t in enumerate(tensors)}
+        buf = io.BytesIO()
+        GuardsStatePickler({}, {}, {}, buf).dump(d)
+        buf.seek(0)
+        restored = pickle.load(buf)
+
+        self.assertEqual(len(restored), len(d))
+        self.assertEqual(len({hash(k) for k in restored}), len(d))
 
     def test_unused_stream(self):
         if not torch.accelerator.is_available():

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4498,6 +4498,9 @@ class GuardsStatePickler(pickle.Pickler):
             # None slips past it. This matters most for the removal callbacks
             # of weak containers, which are restored from their pickled closure
             # and would otherwise run against a bogus self.
+            #
+            # No callback is attached, so a restored container's len()/bool()
+            # still count the dead entry even though iteration skips it.
             return _make_dead_weakref, ()
 
         elif isinstance(obj, _get_unsupported_types()):

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -4139,13 +4139,39 @@ class _Missing:
         return _Missing()
 
 
+class _DeadReferent:
+    """Sole purpose is to be immediately collected so a weakref to it is dead.
+
+    The hash is drawn from a counter rather than left to id(): every instance
+    is freed the moment it is made, so the allocator hands back the same
+    address over and over and id-derived hashes would nearly all collide.
+    """
+
+    __slots__ = ("_hash", "__weakref__")
+
+    _counter = itertools.count()
+
+    def __init__(self) -> None:
+        self._hash = next(self._counter)
+
+    def __hash__(self) -> int:
+        return self._hash
+
+
+def _make_dead_weakref() -> weakref.ref:  # type: ignore[type-arg]
+    obj = _DeadReferent()
+    ref = weakref.ref(obj)
+    # A weakref is only hashable while its referent is alive, or if it was
+    # hashed before the referent died; weak containers keyed on refs need this.
+    hash(ref)
+    del obj
+    return ref
+
+
 @functools.cache
 def _get_unsupported_types() -> tuple[type, ...]:
     # We only do ID_MATCH on C objects which is already banned from guards serialization.
-    ret: tuple[type, ...] = (
-        torch._C.Stream,
-        weakref.ReferenceType,
-    )
+    ret: tuple[type, ...] = (torch._C.Stream,)
     try:
         ret += (torch._C._distributed_c10d.ProcessGroup,)
     except AttributeError:
@@ -4463,6 +4489,16 @@ class GuardsStatePickler(pickle.Pickler):
         ):
             # Skipping PyCapsule since there isn't much to be guarded about them.
             return _Missing, ("capsule",)
+
+        elif isinstance(obj, weakref.ReferenceType):
+            # The referent isn't serialized, so restore a weakref that is
+            # already dead rather than a live-looking placeholder. Code holding
+            # a weakref universally spells the liveness check as
+            # `obj = ref(); if obj is None: ...`, and a placeholder that is not
+            # None slips past it. This matters most for the removal callbacks
+            # of weak containers, which are restored from their pickled closure
+            # and would otherwise run against a bogus self.
+            return _make_dead_weakref, ()
 
         elif isinstance(obj, _get_unsupported_types()):
             return _Missing, ("unsupported",)


### PR DESCRIPTION
`GuardsStatePickler` restored every weakref as a `_Missing` sentinel, which is neither `None` nor falsy-on-call — defeating the universal `obj = ref(); if obj is None: ...` idiom every weakref holder uses. This broke the rebuilt removal callbacks of every builtin weak container (`WeakValueDictionary`, `WeakKeyDictionary`, `WeakSet`, `WeakIdKeyDictionary`), producing swallowed "Exception ignored while calling weakref callback" errors, and entries that reported as live when they were actually gone.

Fix: restore a genuinely dead weakref instead — one pointing at an already-collected private object, hashed before it's dropped (a weakref is only hashable while its referent is alive, or if hashed beforehand) with a counter-based hash so bulk unpickling doesn't collide on a reused address.

See the commit message for the full root-cause writeup, the rejected container-level-reducer alternative, and before/after test numbers.

This change was authored with the assistance of an AI coding agent; the diagnosis, fix, and test were reviewed before submission.


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98