### PR TITLE
Add double backward support for CTC loss

### DIFF
--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2029,7 +2029,7 @@
   autogen: _ctc_loss.Tensor_out
   tags: dynamic_output_shape  # the shape of second output is data dependent
 
-- func: _ctc_loss_backward(Tensor grad, Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, Tensor neg_log_likelihood, Tensor log_alpha, int blank, bool zero_infinity=False) -> Tensor
+- func: _ctc_loss_backward(Tensor grad_out, Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, Tensor neg_log_likelihood, Tensor log_alpha, int blank, bool zero_infinity=False) -> Tensor
   dispatch:
     CPU: ctc_loss_backward_cpu
     CUDA: ctc_loss_backward_gpu
@@ -2037,7 +2037,7 @@
     MPS: ctc_loss_backward_mps
   autogen: _ctc_loss_backward.out
 
-- func: _ctc_loss_backward.Tensor(Tensor grad, Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, Tensor neg_log_likelihood, Tensor log_alpha, int blank, bool zero_infinity=False) -> Tensor
+- func: _ctc_loss_backward.Tensor(Tensor grad_out, Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, Tensor neg_log_likelihood, Tensor log_alpha, int blank, bool zero_infinity=False) -> Tensor
   dispatch:
     CPU, CUDA, XPU, MPS: ctc_loss_backward_tensor
 

--- a/test/forward_backward_compatibility/check_forward_backward_compatibility.py
+++ b/test/forward_backward_compatibility/check_forward_backward_compatibility.py
@@ -90,6 +90,7 @@ ALLOW_LIST = [
     ("aten::qr.Q", datetime.date(9999, 1, 1), None, True),
     ("aten::adaptive_avg_pool3d_backward", datetime.date(9999, 1, 1)),
     ("aten::_embedding_bag_dense_backward", datetime.date(9999, 1, 1)),
+    ("aten::_ctc_loss_backward", datetime.date(9999, 1, 1)),
     ("aten::_cdist_backward", datetime.date(9999, 1, 1)),
     ("aten::_pdist_backward", datetime.date(9999, 1, 1)),
     ("aten::matrix_rank", datetime.date(9999, 1, 1)),

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -849,7 +849,6 @@ class TestOperators(TestCase):
             {
                 skip("nn.functional.max_unpool1d"),  # silent incorrectness; Flaky
                 skip("nn.functional.max_unpool2d"),  # silent incorrectness; Flaky
-                xfail("nn.functional.ctc_loss"),  # Not Implemented
                 xfail(
                     "native_layer_norm", ""
                 ),  # Expected a proper Tensor but got None for argument #1 'other'
@@ -963,9 +962,7 @@ class TestOperators(TestCase):
                 xfail(
                     "nn.functional.binary_cross_entropy"
                 ),  # vmap: inplace into a regular tensor
-                xfail(
-                    "nn.functional.ctc_loss"
-                ),  # derivate not implemented for _ctc_loss_backward
+                xfail("nn.functional.ctc_loss", device_type="cuda"),
                 # flaky on ROCM needs investigation
                 decorate("nn.functional.conv_transpose2d", decorator=skipIfRocm),
                 skip("nn.functional.dropout"),  # calls random op

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11740,6 +11740,38 @@ class TestNNDeviceType(NNTestCase):
         self.assertTrue((loss >= 0).all().item())
         self.assertEqual(-log_probs.sum(0)[[0, 2], 0], loss[[0, 2]])
 
+    @onlyCPU
+    def test_ctc_loss_double_backward(self, device):
+        test_cases = [
+            (torch.tensor([1, 2, 2, 2], device=device), [4, 3], [2, 2], False),
+            (
+                torch.tensor([[1, 1, 1]], device=device),
+                torch.tensor([2], device=device),
+                torch.tensor([3], device=device),
+                True,
+            ),
+        ]
+        for targets, input_lengths, target_lengths, zero_infinity in test_cases:
+            log_probs = torch.randn(
+                int(max(input_lengths)),
+                len(input_lengths),
+                5,
+                device=device,
+                dtype=torch.double,
+            ).log_softmax(2).requires_grad_()
+
+            def ctc_loss(log_probs):
+                return F.ctc_loss(
+                    log_probs,
+                    targets,
+                    input_lengths,
+                    target_lengths,
+                    reduction="sum",
+                    zero_infinity=zero_infinity,
+                )
+
+            gradgradcheck(ctc_loss, (log_probs,))
+
     # Merge into OpInfo?
     @skipCUDAIf(True, """Test is flaky on Linux and Windows, typical error message:
                           https://github.com/pytorch/pytorch/issues/34870""")

--- a/test/test_ops_gradients.py
+++ b/test/test_ops_gradients.py
@@ -120,7 +120,6 @@ class TestBwdGradients(TestGradients):
             skip("nn.functional.max_unpool1d"),
             skip("nn.functional.max_unpool2d"),
             skip("nn.functional.max_unpool3d"),
-            xfail("nn.functional.ctc_loss", dtypes=(torch.float64,)),
             xfail("nn.functional.linear_cross_entropy", variant_name="chunked_none"),
             xfail("nn.functional.linear_cross_entropy", variant_name="chunked"),
             xfail("linalg.norm"),

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -548,6 +548,16 @@
 - name: _ctc_loss.Tensor(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, int blank=0, bool zero_infinity=False) -> (Tensor, Tensor)
   log_probs: _ctc_loss_backward(grad, log_probs, targets, input_lengths, target_lengths, result0, result1, blank, zero_infinity)
 
+- name: _ctc_loss_backward(Tensor grad_out, Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, Tensor neg_log_likelihood, Tensor log_alpha, int blank, bool zero_infinity=False) -> Tensor
+  grad_out, log_probs: "grad.defined() ? ctc_loss_double_backward(grad, grad_out, log_probs, targets, input_lengths, target_lengths, blank, zero_infinity) : std::make_tuple(zeros_like(grad_out), zeros_like(log_probs))"
+  neg_log_likelihood: non_differentiable
+  log_alpha: non_differentiable
+
+- name: _ctc_loss_backward.Tensor(Tensor grad_out, Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, Tensor neg_log_likelihood, Tensor log_alpha, int blank, bool zero_infinity=False) -> Tensor
+  grad_out, log_probs: "grad.defined() ? ctc_loss_double_backward(grad, grad_out, log_probs, targets, input_lengths, target_lengths, blank, zero_infinity) : std::make_tuple(zeros_like(grad_out), zeros_like(log_probs))"
+  neg_log_likelihood: non_differentiable
+  log_alpha: non_differentiable
+
 - name: deg2rad(Tensor self) -> Tensor
   self: deg2rad_backward(grad)
   result: auto_element_wise
@@ -2751,10 +2761,10 @@
 
 # cudnn
 - name: _cudnn_ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
-  log_probs: _cudnn_ctc_loss_backward(grad, result0, result1, zero_infinity)
+  log_probs: ctc_loss_fused_backward(grads, log_probs, targets, input_lengths, target_lengths, result0, result1, blank, zero_infinity)
 
 - name: _cudnn_ctc_loss.Tensor(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
-  log_probs: _cudnn_ctc_loss_backward(grad, result0, result1, zero_infinity)
+  log_probs: ctc_loss_fused_backward(grads, log_probs, targets, input_lengths, target_lengths, result0, result1, blank, zero_infinity)
 
 - name: cudnn_convolution_transpose(Tensor self, Tensor weight, SymInt[] padding, SymInt[] output_padding, SymInt[] stride, SymInt[] dilation, SymInt groups, bool benchmark, bool deterministic, bool allow_tf32) -> Tensor
   self, weight: "_cudnn_convolution_backward(self, grad, weight, padding, output_padding, stride, dilation, true, groups, {grad_input_mask[0], grad_input_mask[1]})"
@@ -2856,10 +2866,10 @@
   dropout_state: non_differentiable
 
 - name: miopen_ctc_loss(Tensor log_probs, Tensor targets, int[] input_lengths, int[] target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
-  log_probs: _miopen_ctc_loss_backward(grad, result0, result1, zero_infinity)
+  log_probs: ctc_loss_fused_backward(grads, log_probs, targets, input_lengths, target_lengths, result0, result1, blank, zero_infinity)
 
 - name: miopen_ctc_loss.Tensor(Tensor log_probs, Tensor targets, Tensor input_lengths, Tensor target_lengths, int blank, bool deterministic, bool zero_infinity) -> (Tensor, Tensor)
-  log_probs: _miopen_ctc_loss_backward(grad, result0, result1, zero_infinity)
+  log_probs: ctc_loss_fused_backward(grads, log_probs, targets, input_lengths, target_lengths, result0, result1, blank, zero_infinity)
 
 - name: mkldnn_rnn_layer(Tensor input, Tensor weight0, Tensor weight1, Tensor weight2, Tensor weight3, Tensor hx_, Tensor cx_, bool reverse, int[] batch_sizes, int mode, int hidden_size, int num_layers, bool has_biases, bool bidirectional, bool batch_first, bool train) -> (Tensor, Tensor, Tensor, Tensor)
   output_differentiability: [True, True, True, False]

--- a/torch/csrc/autograd/FunctionsManual.cpp
+++ b/torch/csrc/autograd/FunctionsManual.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 #include <numeric>
 #include <utility>
 
@@ -49,6 +50,333 @@ Tensor apply_loss_reduction(const Tensor& unreduced, int64_t reduction) {
     return unreduced.sum();
   }
   return unreduced;
+}
+
+namespace {
+
+// Avoid undefined gradients when every input is -inf.
+Tensor safe_logsumexp(TensorList values) {
+  auto stacked = at::stack(values);
+  auto maximum = at::amax(stacked, {0});
+  auto finite = at::isfinite(maximum);
+  auto safe_maximum = at::where(finite, maximum, at::zeros_like(maximum));
+  auto exp_sum = at::sum(at::exp(stacked - safe_maximum), {0});
+  auto safe_exp_sum = at::where(exp_sum.eq(0), at::ones_like(exp_sum), exp_sum);
+  auto result = at::log(safe_exp_sum) + safe_maximum;
+  return at::where(
+      finite,
+      result,
+      at::full_like(result, -std::numeric_limits<double>::infinity()));
+}
+
+Tensor safe_logsumexp_jvp(TensorList values, TensorList tangents) {
+  auto stacked = at::stack(values);
+  auto stacked_tangents = at::stack(tangents);
+  auto maximum = at::amax(stacked, {0});
+  auto finite = at::isfinite(maximum);
+  auto safe_maximum = at::where(finite, maximum, at::zeros_like(maximum));
+  auto weights = at::exp(stacked - safe_maximum);
+  auto denominator = at::sum(weights, {0});
+  auto safe_denominator =
+      at::where(denominator.eq(0), at::ones_like(denominator), denominator);
+  auto result = at::sum(weights * stacked_tangents, {0}) / safe_denominator;
+  return at::where(finite, result, at::zeros_like(result));
+}
+
+// The CTC gradient is exp(log_probs) minus the label posteriors. Propagate
+// grad_grad through the forward-backward recurrences to compute its JVP, which
+// equals the VJP needed here because the Hessian is symmetric.
+std::tuple<Tensor, Tensor> ctc_loss_double_backward_sample(
+    const Tensor& grad_grad,
+    const Tensor& grad_out,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    int64_t input_length,
+    int64_t blank,
+    bool zero_infinity) {
+  const auto max_input_length = log_probs.size(0);
+  const auto num_labels = log_probs.size(1);
+  const auto target_length = targets.numel();
+  if (input_length == 0) {
+    return {at::zeros_like(grad_out), at::zeros_like(log_probs)};
+  }
+
+  Tensor state_labels;
+  if (target_length == 0) {
+    state_labels = at::full({1}, blank, log_probs.options().dtype(at::kLong));
+  } else {
+    state_labels =
+        at::stack({at::full_like(targets, blank), targets}, 1).flatten();
+    state_labels = at::cat(
+        {state_labels,
+         at::full({1}, blank, log_probs.options().dtype(at::kLong))});
+  }
+
+  const auto num_states = state_labels.numel();
+  auto emissions =
+      log_probs.narrow(0, 0, input_length).index_select(1, state_labels);
+  auto emission_tangents =
+      grad_grad.narrow(0, 0, input_length).index_select(1, state_labels);
+  auto neginf = at::full(
+      {}, -std::numeric_limits<double>::infinity(), log_probs.options());
+  auto zero = at::zeros({}, log_probs.options());
+  auto state_indices =
+      at::arange(num_states, log_probs.options().dtype(at::kLong));
+
+  std::vector<Tensor> alpha;
+  std::vector<Tensor> alpha_tangents;
+  alpha.reserve(input_length);
+  alpha_tangents.reserve(input_length);
+  auto initial_mask = state_indices < std::min<int64_t>(2, num_states);
+  alpha.push_back(at::where(initial_mask, emissions.select(0, 0), neginf));
+  alpha_tangents.push_back(
+      at::where(initial_mask, emission_tangents.select(0, 0), zero));
+  Tensor skip_mask;
+  if (num_states > 2) {
+    skip_mask = at::cat(
+        {at::zeros({2}, log_probs.options().dtype(at::kBool)),
+         state_labels.slice(0, 2) != state_labels.slice(0, 0, num_states - 2)});
+  } else {
+    skip_mask = at::zeros({num_states}, log_probs.options().dtype(at::kBool));
+  }
+  for (const auto t : c10::irange<int64_t>(1, input_length)) {
+    const auto& previous = alpha.back();
+    const auto& previous_tangent = alpha_tangents.back();
+    auto step =
+        at::cat({neginf.expand({1}), previous.narrow(0, 0, num_states - 1)});
+    auto step_tangent = at::cat(
+        {zero.expand({1}), previous_tangent.narrow(0, 0, num_states - 1)});
+    auto skip = num_states > 2
+        ? at::cat({neginf.expand({2}), previous.narrow(0, 0, num_states - 2)})
+        : neginf.expand({num_states});
+    auto skip_tangent = num_states > 2
+        ? at::cat(
+              {zero.expand({2}), previous_tangent.narrow(0, 0, num_states - 2)})
+        : zero.expand({num_states});
+    skip = at::where(skip_mask, skip, neginf);
+    skip_tangent = at::where(skip_mask, skip_tangent, zero);
+    alpha.push_back(
+        emissions.select(0, t) + safe_logsumexp({previous, step, skip}));
+    alpha_tangents.push_back(
+        emission_tangents.select(0, t) +
+        safe_logsumexp_jvp(
+            {previous, step, skip},
+            {previous_tangent, step_tangent, skip_tangent}));
+  }
+
+  Tensor neg_log_likelihood;
+  Tensor neg_log_likelihood_tangent;
+  if (target_length == 0) {
+    neg_log_likelihood = -alpha.back().select(0, 0);
+    neg_log_likelihood_tangent = -alpha_tangents.back().select(0, 0);
+  } else {
+    neg_log_likelihood = -safe_logsumexp(
+        {alpha.back().select(0, num_states - 1),
+         alpha.back().select(0, num_states - 2)});
+    neg_log_likelihood_tangent = -safe_logsumexp_jvp(
+        {alpha.back().select(0, num_states - 1),
+         alpha.back().select(0, num_states - 2)},
+        {alpha_tangents.back().select(0, num_states - 1),
+         alpha_tangents.back().select(0, num_states - 2)});
+  }
+
+  std::vector<Tensor> beta(input_length);
+  std::vector<Tensor> beta_tangents(input_length);
+  auto final_mask = state_indices >= std::max<int64_t>(num_states - 2, 0);
+  beta.back() =
+      at::where(final_mask, emissions.select(0, input_length - 1), neginf);
+  beta_tangents.back() = at::where(
+      final_mask, emission_tangents.select(0, input_length - 1), zero);
+  if (num_states > 2) {
+    skip_mask = at::cat(
+        {state_labels.slice(0, 0, num_states - 2) != state_labels.slice(0, 2),
+         at::zeros({2}, log_probs.options().dtype(at::kBool))});
+  }
+  for (int64_t t = input_length - 2; t >= 0; --t) {
+    const auto& following = beta[t + 1];
+    const auto& following_tangent = beta_tangents[t + 1];
+    auto step =
+        at::cat({following.narrow(0, 1, num_states - 1), neginf.expand({1})});
+    auto step_tangent = at::cat(
+        {following_tangent.narrow(0, 1, num_states - 1), zero.expand({1})});
+    auto skip = num_states > 2
+        ? at::cat({following.narrow(0, 2, num_states - 2), neginf.expand({2})})
+        : neginf.expand({num_states});
+    auto skip_tangent = num_states > 2
+        ? at::cat(
+              {following_tangent.narrow(0, 2, num_states - 2),
+               zero.expand({2})})
+        : zero.expand({num_states});
+    skip = at::where(skip_mask, skip, neginf);
+    skip_tangent = at::where(skip_mask, skip_tangent, zero);
+    beta[t] = emissions.select(0, t) + safe_logsumexp({following, step, skip});
+    beta_tangents[t] = emission_tangents.select(0, t) +
+        safe_logsumexp_jvp({following, step, skip},
+                           {following_tangent, step_tangent, skip_tangent});
+  }
+
+  auto infinite = at::isinf(neg_log_likelihood);
+  auto safe_neg_log_likelihood = zero_infinity
+      ? at::where(
+            infinite, at::zeros_like(neg_log_likelihood), neg_log_likelihood)
+      : neg_log_likelihood;
+  auto safe_neg_log_likelihood_tangent = zero_infinity
+      ? at::where(
+            infinite,
+            at::zeros_like(neg_log_likelihood_tangent),
+            neg_log_likelihood_tangent)
+      : neg_log_likelihood_tangent;
+  auto state_posteriors = at::exp(
+      at::stack(alpha) + at::stack(beta) + safe_neg_log_likelihood - emissions);
+  auto state_posterior_tangents = state_posteriors *
+      (at::stack(alpha_tangents) + at::stack(beta_tangents) +
+       safe_neg_log_likelihood_tangent - emission_tangents);
+  auto state_to_label =
+      at::one_hot(state_labels, num_labels).to(log_probs.scalar_type());
+  auto posteriors = at::matmul(state_posteriors, state_to_label);
+  auto posterior_tangents =
+      at::matmul(state_posterior_tangents, state_to_label);
+  auto base_gradient =
+      at::exp(log_probs.narrow(0, 0, input_length)) - posteriors;
+  auto gradient_tangent = at::exp(log_probs.narrow(0, 0, input_length)) *
+          grad_grad.narrow(0, 0, input_length) -
+      posterior_tangents;
+  if (zero_infinity) {
+    base_gradient =
+        at::where(infinite, at::zeros_like(base_gradient), base_gradient);
+    gradient_tangent =
+        at::where(infinite, at::zeros_like(gradient_tangent), gradient_tangent);
+  }
+  if (input_length < max_input_length) {
+    base_gradient = at::cat(
+        {base_gradient, at::zeros_like(log_probs.slice(0, input_length))});
+    gradient_tangent = at::cat(
+        {gradient_tangent, at::zeros_like(log_probs.slice(0, input_length))});
+  }
+  return {at::sum(grad_grad * base_gradient), gradient_tangent * grad_out};
+}
+
+} // namespace
+
+std::tuple<Tensor, Tensor> ctc_loss_double_backward(
+    const Tensor& grad_grad,
+    const Tensor& grad_out,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    IntArrayRef input_lengths,
+    IntArrayRef target_lengths,
+    int64_t blank,
+    bool zero_infinity) {
+  std::vector<Tensor> grad_grad_outs;
+  std::vector<Tensor> grad_log_probs;
+  grad_grad_outs.reserve(log_probs.size(1));
+  grad_log_probs.reserve(log_probs.size(1));
+  auto targets_device = targets.to(log_probs.device(), at::kLong);
+  int64_t target_offset = 0;
+  for (const auto b : c10::irange(log_probs.size(1))) {
+    const auto target_length = target_lengths[b];
+    Tensor sample_targets;
+    if (targets.dim() == 1) {
+      sample_targets =
+          targets_device.slice(0, target_offset, target_offset + target_length);
+      target_offset += target_length;
+    } else {
+      sample_targets = targets_device.select(0, b).slice(0, 0, target_length);
+    }
+    auto [grad_grad_out, grad_log_prob] = ctc_loss_double_backward_sample(
+        grad_grad.select(1, b),
+        grad_out.select(0, b),
+        log_probs.select(1, b),
+        sample_targets,
+        input_lengths[b],
+        blank,
+        zero_infinity);
+    grad_grad_outs.push_back(std::move(grad_grad_out));
+    grad_log_probs.push_back(std::move(grad_log_prob));
+  }
+  return {at::stack(grad_grad_outs), at::stack(grad_log_probs, 1)};
+}
+
+std::tuple<Tensor, Tensor> ctc_loss_double_backward(
+    const Tensor& grad_grad,
+    const Tensor& grad_out,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    int64_t blank,
+    bool zero_infinity) {
+  auto input_lengths_cpu = input_lengths.to(at::kCPU, at::kLong).contiguous();
+  auto target_lengths_cpu = target_lengths.to(at::kCPU, at::kLong).contiguous();
+  return ctc_loss_double_backward(
+      grad_grad,
+      grad_out,
+      log_probs,
+      targets,
+      IntArrayRef(
+          input_lengths_cpu.const_data_ptr<int64_t>(),
+          input_lengths_cpu.numel()),
+      IntArrayRef(
+          target_lengths_cpu.const_data_ptr<int64_t>(),
+          target_lengths_cpu.numel()),
+      blank,
+      zero_infinity);
+}
+
+Tensor ctc_loss_fused_backward(
+    const variable_list& grads,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    IntArrayRef input_lengths,
+    IntArrayRef target_lengths,
+    const Tensor& loss,
+    const Tensor& raw_grad,
+    int64_t blank,
+    bool zero_infinity) {
+  auto grad_log_probs = grads[0].defined()
+      ? _cudnn_ctc_loss_backward(grads[0], loss, raw_grad, zero_infinity)
+      : at::zeros_like(log_probs);
+  if (grads[1].defined()) {
+    grad_log_probs = grad_log_probs +
+        std::get<1>(ctc_loss_double_backward(
+            grads[1],
+            at::ones_like(loss),
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            blank,
+            zero_infinity));
+  }
+  return grad_log_probs;
+}
+
+Tensor ctc_loss_fused_backward(
+    const variable_list& grads,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    const Tensor& loss,
+    const Tensor& raw_grad,
+    int64_t blank,
+    bool zero_infinity) {
+  auto input_lengths_cpu = input_lengths.to(at::kCPU, at::kLong).contiguous();
+  auto target_lengths_cpu = target_lengths.to(at::kCPU, at::kLong).contiguous();
+  return ctc_loss_fused_backward(
+      grads,
+      log_probs,
+      targets,
+      IntArrayRef(
+          input_lengths_cpu.const_data_ptr<int64_t>(),
+          input_lengths_cpu.numel()),
+      IntArrayRef(
+          target_lengths_cpu.const_data_ptr<int64_t>(),
+          target_lengths_cpu.numel()),
+      loss,
+      raw_grad,
+      blank,
+      zero_infinity);
 }
 
 static bool isDefined(const std::optional<Tensor>& t) {

--- a/torch/csrc/autograd/FunctionsManual.h
+++ b/torch/csrc/autograd/FunctionsManual.h
@@ -42,6 +42,44 @@ inline std::optional<Tensor> wrap_opt_if(const Tensor& t, const bool cond) {
 
 TORCH_API Tensor
 apply_loss_reduction(const Tensor& unreduced, int64_t reduction);
+TORCH_API std::tuple<Tensor, Tensor> ctc_loss_double_backward(
+    const Tensor& grad_grad,
+    const Tensor& grad_out,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    IntArrayRef input_lengths,
+    IntArrayRef target_lengths,
+    int64_t blank,
+    bool zero_infinity);
+TORCH_API std::tuple<Tensor, Tensor> ctc_loss_double_backward(
+    const Tensor& grad_grad,
+    const Tensor& grad_out,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    int64_t blank,
+    bool zero_infinity);
+TORCH_API Tensor ctc_loss_fused_backward(
+    const variable_list& grads,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    IntArrayRef input_lengths,
+    IntArrayRef target_lengths,
+    const Tensor& loss,
+    const Tensor& raw_grad,
+    int64_t blank,
+    bool zero_infinity);
+TORCH_API Tensor ctc_loss_fused_backward(
+    const variable_list& grads,
+    const Tensor& log_probs,
+    const Tensor& targets,
+    const Tensor& input_lengths,
+    const Tensor& target_lengths,
+    const Tensor& loss,
+    const Tensor& raw_grad,
+    int64_t blank,
+    bool zero_infinity);
 TORCH_API bool any_variable_defined(const variable_list& variables);
 TORCH_API void update_wrapped_number(Tensor& input, Tensor& output);
 TORCH_API void copy_range(


### PR DESCRIPTION
# Fixing an Issue

## Issue

Fixes #70108

## Summary

Adds double backward support for CTC loss by recomputing the CTC forward-backward variables with differentiable ATen operations when higher-order gradients are enabled. First-order backward continues to use the existing native, cuDNN, and MIOpen implementations.

## Testing

- `python test/test_nn.py -k ctc_loss` : 12 passed, 5 skipped
- CPU and CUDA gradgradcheck, including both list and tensor length inputs and `zero_infinity`: passed
- cuDNN CTC Hessian-vector product comparison against native CTC: passed
- Autograd code generation: passed
- `python -m spin quicklint`: passed
- `git diff --check`: passed

GPU validation was run on an NVIDIA GeForce RTX 3090 with CUDA and cuDNN.

## Checklist

- [x] Passes lint (`spin quicklint`)
- [x] Added/updated tests
- [ ] Updated documentation (not applicable)
- [ ] Included benchmark results (not applicable)

## BC-breaking?

No.

## AI assistance

I used Codex to assist with investigation and validation, as well as parts of the implementation in `torch/csrc/autograd/FunctionsManual.cpp`. I reviewed the final diff and test results.