### PR TITLE
[ATen] Vectorize bf16/fp16 -> fp32 copies on CUDA

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -55,7 +55,6 @@ void bfloat16_copy_kernel_cuda(TensorIteratorBase &iter) {
     });
 }
 
-#ifdef USE_ROCM
 void bfloat16tofloat32_copy_kernel_cuda(TensorIteratorBase &iter) {
     gpu_kernel_nocast(iter, [] GPU_LAMBDA(at::BFloat16 value) {
         return static_cast<float>(value);
@@ -66,7 +65,6 @@ void float16tofloat32_copy_kernel_cuda(TensorIteratorBase &iter) {
         return static_cast<float>(value);
     });
 }
-#endif
 
 template <typename SrcT>
 struct ConvertToFloat8E4M3fnOp {
@@ -225,7 +223,6 @@ void direct_copy_kernel_cuda(TensorIteratorBase &iter) {
        float16_copy_kernel_cuda(iter);
      }
   }
-#ifdef USE_ROCM
   else if ((iter.dtype(1) == kBFloat16 || iter.dtype(1) == kHalf) && dtype == kFloat) {
     if (iter.dtype(1) == kBFloat16) {
       bfloat16tofloat32_copy_kernel_cuda(iter);
@@ -233,7 +230,6 @@ void direct_copy_kernel_cuda(TensorIteratorBase &iter) {
       float16tofloat32_copy_kernel_cuda(iter);
     }
   }
-#endif
   else if (isBitsType(dtype)) {
     TORCH_CHECK(dtype == iter.dtype(1), "copy_() does not support casting "
       "bits types to different bits types. Source dtype is ", iter.dtype(1), "target dtype is ", dtype);

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -67,6 +67,7 @@ from torch.testing._internal.common_dtype import (
     get_all_qint_dtypes, all_types_complex_float8_and, all_passthru_types_and,
 )
 from torch.testing._internal.two_tensor import TwoTensor
+from torch.profiler import kineto_available
 from torch.testing._internal.common_utils import IS_WINDOWS
 
 if TEST_WITH_TORCHINDUCTOR:
@@ -3384,7 +3385,7 @@ class TestTorchDeviceType(TestCase):
         self.assertEqual(src.neg().bfloat16(), src_bf16.neg())
         self.assertEqual(src.abs().bfloat16(), src_bf16.abs())
 
-    @onlyCPU
+    @onlyNativeDeviceTypes
     @dtypes(torch.bfloat16, torch.half)
     def test_reduced_type_float_copy(self, device, dtype):
         for shape in [(20, 7), (249, 137), (1029, 917), (1, 7, 19, 17), (3, 77, 1091)]:
@@ -3399,6 +3400,33 @@ class TestTorchDeviceType(TestCase):
             self.assertEqual(input_s, out1, atol=None, rtol=None, exact_dtype=False)
             out2 = out1.to(torch.float)
             self.assertEqual(out2, out1, atol=0, rtol=0, exact_dtype=False)
+
+    @onlyCUDA
+    @dtypes(torch.bfloat16, torch.half)
+    def test_reduced_type_float_copy_special_values(self, device, dtype):
+        special = torch.tensor(
+            [float("nan"), -float("nan"), float("inf"), -float("inf"), 0.0, -0.0,
+             torch.finfo(dtype).tiny, torch.finfo(dtype).tiny / 2],
+            dtype=dtype, device=device)
+        dense = torch.randn(4099, dtype=dtype, device=device)
+        dense[:special.numel()] = special
+        strided = torch.empty(4099 * 2, dtype=dtype, device=device)[::2]
+        strided.copy_(dense)
+        self.assertEqual(
+            dense.to(torch.float32).view(torch.uint8),
+            strided.to(torch.float32).view(torch.uint8))
+
+    @onlyCUDA
+    @unittest.skipIf(not kineto_available(), "Kineto is required")
+    @dtypes(torch.bfloat16, torch.half)
+    def test_reduced_type_float_copy_emits_vectorized_kernel(self, device, dtype):
+        src = make_tensor((1024, 1024), dtype=dtype, device=device)
+        torch.cuda.synchronize()
+        with torch.profiler.profile() as prof:
+            src.to(torch.float32)
+            torch.cuda.synchronize()
+        names = tuple(event.key for event in prof.key_averages())
+        self.assertTrue(any("vectorized_elementwise_kernel" in name for name in names), names)
 
     # FIXME: move to data movement test suite
     @onlyNativeDeviceTypes


### PR DESCRIPTION
Summary:
# Context
Converting bf16/fp16 to fp32 is an extremely common pattern in training jobs, in order to accumulate gradients and run the optimizer step in full precision.

[#163869](https://github.com/pytorch/pytorch/pull/163869) added an optimized kernel for this conversion, but gated it via preprocessor to AMD only.

# This PR
Delete the two `#ifdef USE_ROCM` gates so the existing upcast kernels compile for CUDA as well.

Test Plan:
# Automated
Added tests.

# Benchmarks

Sources in D118216441. Device wall time, means of 200 iterations. Control = base, test = this diff.

Speedup for both dtypes across all numel.

**A100:**

| dtype | numel | control | test | ratio |
| --- | --- | --- | --- | --- |
| `bfloat16` | 512 | 8.63 us | 6.52 us | 1.32x |
| `bfloat16` | 8,192 | 9.38 us | 6.58 us | 1.43x |
| `bfloat16` | 131,072 | 9.98 us | 7.13 us | 1.40x |
| `bfloat16` | 524,288 | 11.01 us | 8.46 us | 1.30x |
| `bfloat16` | 1,048,576 | 15.12 us | 10.35 us | 1.46x |
| `bfloat16` | 2,097,152 | 20.30 us | 14.89 us | 1.36x |
| `bfloat16` | 8,388,608 | 53.87 us | 45.65 us | 1.18x |
| `bfloat16` | 67,108,864 | 362.46 us | 322.09 us | 1.13x |
| `float16` | 512 | 8.63 us | 6.58 us | 1.31x |
| `float16` | 8,192 | 9.36 us | 6.59 us | 1.42x |
| `float16` | 131,072 | 9.95 us | 7.08 us | 1.41x |
| `float16` | 524,288 | 10.97 us | 8.49 us | 1.29x |
| `float16` | 1,048,576 | 15.06 us | 10.33 us | 1.46x |
| `float16` | 2,097,152 | 20.31 us | 14.90 us | 1.36x |
| `float16` | 8,388,608 | 53.66 us | 45.64 us | 1.18x |
| `float16` | 67,108,864 | 361.67 us | 322.16 us | 1.12x |

**H100:**

| dtype | numel | control | test | ratio |
| --- | --- | --- | --- | --- |
| `bfloat16` | 512 | 7.28 us | 5.58 us | 1.30x |
| `bfloat16` | 8,192 | 7.61 us | 5.63 us | 1.35x |
| `bfloat16` | 131,072 | 7.96 us | 5.97 us | 1.33x |
| `bfloat16` | 524,288 | 8.70 us | 6.71 us | 1.30x |
| `bfloat16` | 1,048,576 | 9.45 us | 8.01 us | 1.18x |
| `bfloat16` | 2,097,152 | 12.77 us | 9.84 us | 1.30x |
| `bfloat16` | 8,388,608 | 32.23 us | 23.07 us | 1.40x |
| `bfloat16` | 67,108,864 | 210.48 us | 141.20 us | 1.49x |
| `float16` | 512 | 7.28 us | 5.58 us | 1.30x |
| `float16` | 8,192 | 7.60 us | 5.64 us | 1.35x |
| `float16` | 131,072 | 7.92 us | 5.97 us | 1.33x |
| `float16` | 524,288 | 8.67 us | 6.73 us | 1.29x |
| `float16` | 1,048,576 | 9.41 us | 7.93 us | 1.19x |
| `float16` | 2,097,152 | 12.73 us | 9.81 us | 1.30x |
| `float16` | 8,388,608 | 32.12 us | 23.04 us | 1.39x |
| `float16` | 67,108,864 | 209.69 us | 141.20 us | 1.49x |

**B200:**

| dtype | numel | control | test | ratio |
| --- | --- | --- | --- | --- |
| `bfloat16` | 512 | 8.19 us | 6.64 us | 1.23x |
| `bfloat16` | 8,192 | 9.21 us | 6.77 us | 1.36x |
| `bfloat16` | 131,072 | 9.21 us | 6.74 us | 1.37x |
| `bfloat16` | 524,288 | 9.20 us | 6.85 us | 1.34x |
| `bfloat16` | 1,048,576 | 10.37 us | 7.59 us | 1.37x |
| `bfloat16` | 2,097,152 | 13.30 us | 8.78 us | 1.52x |
| `bfloat16` | 8,388,608 | 29.69 us | 14.78 us | 2.01x |
| `bfloat16` | 67,108,864 | 185.34 us | 65.71 us | 2.82x |
| `float16` | 512 | 8.19 us | 6.62 us | 1.24x |
| `float16` | 8,192 | 9.22 us | 6.73 us | 1.37x |
| `float16` | 131,072 | 9.22 us | 6.75 us | 1.37x |
| `float16` | 524,288 | 9.20 us | 6.83 us | 1.35x |
| `float16` | 1,048,576 | 10.17 us | 7.59 us | 1.34x |
| `float16` | 2,097,152 | 13.30 us | 8.78 us | 1.51x |
| `float16` | 8,388,608 | 29.70 us | 14.70 us | 2.02x |
| `float16` | 67,108,864 | 181.24 us | 65.66 us | 2.76x |

Differential Revision: D118209494


