### PR TITLE
elastic: make exit_barrier_timeout configurable via env var and CLI flag

### DIFF
--- a/test/distributed/elastic/agent/server/test/exit_barrier_timeout_test.py
+++ b/test/distributed/elastic/agent/server/test/exit_barrier_timeout_test.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Owner(s): ["oncall: r2p"]
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import signal
+import tempfile
+from typing import Any
+from unittest.mock import Mock, patch
+
+from torch.distributed.elastic.agent.server.api import (
+    RunResult,
+    SimpleElasticAgent,
+    WorkerGroup,
+    WorkerSpec,
+    WorkerState,
+)
+from torch.distributed.elastic.agent.server.local_elastic_agent import LocalElasticAgent
+from torch.distributed.elastic.multiprocessing import DefaultLogsSpecs
+from torch.distributed.launcher.api import LaunchConfig
+from torch.testing._internal.common_utils import run_tests, TestCase
+
+
+# ---------------------------------------------------------------------------
+# Concrete stub so we can instantiate SimpleElasticAgent without a full env.
+# Mirrors the pattern used in shutdown_timeout_test.py
+# ---------------------------------------------------------------------------
+class _ConcreteAgent(SimpleElasticAgent):
+    def _start_workers(self, worker_group: WorkerGroup) -> dict[int, Any]:
+        return {}
+
+    def _stop_workers(self, worker_group: WorkerGroup, is_restart: bool = False) -> None:
+        pass
+
+    def _monitor_workers(self, worker_group: WorkerGroup) -> RunResult:
+        return RunResult(state=WorkerState.HEALTHY)
+
+    def _shutdown(
+        self, death_sig: signal.Signals = signal.SIGTERM, timeout: int = 30
+    ) -> None:
+        pass
+
+
+def _make_mock_spec(local_world_size: int = 1) -> Mock:
+    """Return a Mock that satisfies WorkerGroup's attribute requirements."""
+    spec = Mock(spec=WorkerSpec)
+    spec.max_restarts = 3
+    spec.local_world_size = local_world_size
+    spec.rdzv_handler = Mock()
+    spec.role = "default"
+    spec.monitor_interval = 0.1
+    spec.master_addr = None
+    spec.master_port = None
+    return spec
+
+
+class ExitBarrierTimeoutTest(TestCase):
+    """Tests for the configurable exit_barrier_timeout feature.
+
+    Mirrors the structure of shutdown_timeout_test.py.
+    """
+
+    # ------------------------------------------------------------------
+    # LaunchConfig: default / explicit / env-var / env-var-override
+    # ------------------------------------------------------------------
+
+    def test_launch_config_default_exit_barrier_timeout(self):
+        """When no value is given, LaunchConfig resolves to the 300-second default."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT", None)
+            config = LaunchConfig(min_nodes=1, max_nodes=1, nproc_per_node=2)
+        self.assertEqual(config.exit_barrier_timeout, 300.0)
+
+    def test_launch_config_custom_exit_barrier_timeout(self):
+        """An explicit value is stored verbatim."""
+        config = LaunchConfig(
+            min_nodes=1, max_nodes=1, nproc_per_node=2, exit_barrier_timeout=600
+        )
+        self.assertEqual(config.exit_barrier_timeout, 600.0)
+
+    def test_launch_config_env_var_exit_barrier_timeout(self):
+        """TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT is picked up when no explicit value is given."""
+        with patch.dict(os.environ, {"TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT": "900"}):
+            config = LaunchConfig(min_nodes=1, max_nodes=1, nproc_per_node=2)
+        self.assertEqual(config.exit_barrier_timeout, 900.0)
+
+    def test_launch_config_explicit_overrides_env(self):
+        """An explicit constructor arg wins over the env var."""
+        with patch.dict(os.environ, {"TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT": "900"}):
+            config = LaunchConfig(
+                min_nodes=1, max_nodes=1, nproc_per_node=2, exit_barrier_timeout=120
+            )
+        self.assertEqual(config.exit_barrier_timeout, 120.0)
+
+    def test_exit_barrier_timeout_validation_negative(self):
+        """A negative explicit value raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            LaunchConfig(
+                min_nodes=1, max_nodes=1, nproc_per_node=2, exit_barrier_timeout=-1
+            )
+        self.assertIn("exit_barrier_timeout must be non-negative", str(cm.exception))
+
+    def test_exit_barrier_timeout_zero(self):
+        """Zero is a valid (instant) timeout."""
+        config = LaunchConfig(
+            min_nodes=1, max_nodes=1, nproc_per_node=2, exit_barrier_timeout=0
+        )
+        self.assertEqual(config.exit_barrier_timeout, 0.0)
+
+    # ------------------------------------------------------------------
+    # SimpleElasticAgent (via concrete stub): explicit / env-var / default
+    # ------------------------------------------------------------------
+
+    def test_simple_elastic_agent_receives_exit_barrier_timeout(self):
+        """An explicit value is stored on the agent."""
+        agent = _ConcreteAgent(
+            spec=_make_mock_spec(),
+            exit_barrier_timeout=450,
+            shutdown_timeout=30,
+        )
+        self.assertEqual(agent._exit_barrier_timeout, 450.0)
+
+    def test_simple_elastic_agent_default_exit_barrier_timeout(self):
+        """Without any explicit value or env var, the agent uses 300 seconds."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT", None)
+            agent = _ConcreteAgent(spec=_make_mock_spec())
+        self.assertEqual(agent._exit_barrier_timeout, 300.0)
+
+    def test_simple_elastic_agent_env_var_exit_barrier_timeout(self):
+        """TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT is picked up by SimpleElasticAgent."""
+        with patch.dict(os.environ, {"TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT": "750"}):
+            agent = _ConcreteAgent(spec=_make_mock_spec())
+        self.assertEqual(agent._exit_barrier_timeout, 750.0)
+
+    def test_simple_elastic_agent_explicit_overrides_env(self):
+        """Explicit constructor arg wins over env var in SimpleElasticAgent."""
+        with patch.dict(os.environ, {"TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT": "750"}):
+            agent = _ConcreteAgent(spec=_make_mock_spec(), exit_barrier_timeout=200)
+        self.assertEqual(agent._exit_barrier_timeout, 200.0)
+
+    # ------------------------------------------------------------------
+    # LocalElasticAgent: explicit / env-var / default
+    # ------------------------------------------------------------------
+
+    def test_local_elastic_agent_receives_exit_barrier_timeout(self):
+        """LocalElasticAgent stores an explicit exit_barrier_timeout."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            agent = LocalElasticAgent(
+                spec=_make_mock_spec(),
+                logs_specs=DefaultLogsSpecs(log_dir=tmpdir),
+                start_method="spawn",
+                exit_barrier_timeout=500,
+                shutdown_timeout=30,
+            )
+        self.assertEqual(agent._exit_barrier_timeout, 500.0)
+
+    def test_local_elastic_agent_default_exit_barrier_timeout(self):
+        """LocalElasticAgent defaults to 300 s when nothing is specified."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT", None)
+                agent = LocalElasticAgent(
+                    spec=_make_mock_spec(),
+                    logs_specs=DefaultLogsSpecs(log_dir=tmpdir),
+                    start_method="spawn",
+                )
+        self.assertEqual(agent._exit_barrier_timeout, 300.0)
+
+    def test_local_elastic_agent_env_var_exit_barrier_timeout(self):
+        """TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT is picked up by LocalElasticAgent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT": "800"}):
+                agent = LocalElasticAgent(
+                    spec=_make_mock_spec(),
+                    logs_specs=DefaultLogsSpecs(log_dir=tmpdir),
+                    start_method="spawn",
+                )
+        self.assertEqual(agent._exit_barrier_timeout, 800.0)
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/test/distributed/test_run.py
+++ b/test/distributed/test_run.py
@@ -206,6 +206,44 @@ class RunTest(TestCase):
             with redirect_stderr(io.StringIO()):
                 self._parse_args(["--print-completion=notashell"])
 
+    # ------------------------------------------------------------------
+    # --exit-barrier-timeout flag
+    # ------------------------------------------------------------------
+
+    def test_exit_barrier_timeout_flag_default(self):
+        """--exit-barrier-timeout defaults to None (resolved later in LaunchConfig)."""
+        parser = run.get_args_parser()
+        args = parser.parse_args(["dummy_script.py"])
+        self.assertIsNone(args.exit_barrier_timeout)
+
+    def test_exit_barrier_timeout_flag_custom(self):
+        """--exit-barrier-timeout parses a float value."""
+        parser = run.get_args_parser()
+        args = parser.parse_args(["--exit-barrier-timeout=600", "dummy_script.py"])
+        self.assertEqual(args.exit_barrier_timeout, 600.0)
+
+    def test_exit_barrier_timeout_underscore_alias(self):
+        """--exit_barrier_timeout (underscore form) is also accepted."""
+        parser = run.get_args_parser()
+        args = parser.parse_args(["--exit_barrier_timeout=450", "dummy_script.py"])
+        self.assertEqual(args.exit_barrier_timeout, 450.0)
+
+    def test_config_from_args_exit_barrier_timeout(self):
+        """config_from_args forwards --exit-barrier-timeout to LaunchConfig."""
+        args = self._parse_args(["--exit-barrier-timeout=750", "dummy_script.py"])
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT", None)
+            config, _, _ = run.config_from_args(args)
+        self.assertEqual(config.exit_barrier_timeout, 750.0)
+
+    def test_config_from_args_exit_barrier_timeout_default(self):
+        """Without the flag, config_from_args falls back to the 300-second default."""
+        args = self._parse_args(["dummy_script.py"])
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT", None)
+            config, _, _ = run.config_from_args(args)
+        self.assertEqual(config.exit_barrier_timeout, 300.0)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/torch/distributed/elastic/agent/server/api.py
+++ b/torch/distributed/elastic/agent/server/api.py
@@ -462,13 +462,20 @@ class SimpleElasticAgent(ElasticAgent):
     def __init__(
         self,
         spec: WorkerSpec,
-        exit_barrier_timeout: float = 300,
+        exit_barrier_timeout: float | None = None,
         shutdown_timeout: int = 30,
     ):
         self._worker_group = WorkerGroup(spec)
         self._remaining_restarts = self._worker_group.spec.max_restarts
         self._store = None
-        self._exit_barrier_timeout = exit_barrier_timeout
+        # Resolve exit_barrier_timeout: explicit arg wins, then env var, then
+        # the historical default of 300 s.
+        if exit_barrier_timeout is None:
+            self._exit_barrier_timeout = float(
+                os.environ.get("TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT", "300")
+            )
+        else:
+            self._exit_barrier_timeout = exit_barrier_timeout
         self._shutdown_timeout = shutdown_timeout
         self._total_execution_time = 0
         self._in_exit_barrier: bool = False

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -137,7 +137,9 @@ class LocalElasticAgent(SimpleElasticAgent):
     workers finish at different times, to prevent agents from viewing workers
     that finished early as a scale-down event. It is strongly advised that the
     user code deal with ensuring that workers are terminated in a synchronous
-    manner rather than relying on the exit_barrier_timeout.
+    manner rather than relying on the exit_barrier_timeout. The default value of
+    300 seconds can be overridden via the ``TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT``
+    environment variable or by passing ``exit_barrier_timeout`` explicitly.
 
     A named pipe based watchdog can be enabled in ```LocalElasticAgent``` if an
     environment variable ``TORCHELASTIC_ENABLE_FILE_TIMER`` with value 1 has

--- a/torch/distributed/elastic/agent/server/local_elastic_agent.py
+++ b/torch/distributed/elastic/agent/server/local_elastic_agent.py
@@ -214,7 +214,7 @@ class LocalElasticAgent(SimpleElasticAgent):
         spec: WorkerSpec,
         logs_specs: LogsSpecs,
         start_method="spawn",
-        exit_barrier_timeout: float = 300,
+        exit_barrier_timeout: float | None = None,
         log_line_prefix_template: str | None = None,
         shutdown_timeout: int = 30,
         health_check_server: HealthCheckServer | None = None,

--- a/torch/distributed/launcher/api.py
+++ b/torch/distributed/launcher/api.py
@@ -90,6 +90,10 @@ class LaunchConfig:
         shutdown_timeout: Time in seconds to wait for graceful shutdown of workers before
                         sending SIGKILL. Can also be set via TORCH_ELASTIC_SHUTDOWN_TIMEOUT
                         environment variable. Defaults to 30 seconds.
+        exit_barrier_timeout: Time in seconds to wait for all agents to finish before
+                        the exit barrier is released. Can also be set via
+                        TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT environment variable.
+                        Defaults to 300 seconds.
 
 
     .. note::
@@ -121,6 +125,7 @@ class LaunchConfig:
     duplicate_stderr_filters: list[str] | None = None
     virtual_local_rank: bool = False
     shutdown_timeout: int | None = None
+    exit_barrier_timeout: float | None = None
 
     def __post_init__(self):
         default_timeout = 900
@@ -153,6 +158,16 @@ class LaunchConfig:
         elif self.shutdown_timeout < 0:
             raise ValueError(
                 f"shutdown_timeout must be non-negative, got {self.shutdown_timeout}"
+            )
+
+        # Set exit_barrier_timeout from environment variable if not explicitly set
+        if self.exit_barrier_timeout is None:
+            self.exit_barrier_timeout = float(
+                os.environ.get("TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT", "300")
+            )
+        elif self.exit_barrier_timeout < 0:
+            raise ValueError(
+                f"exit_barrier_timeout must be non-negative, got {self.exit_barrier_timeout}"
             )
 
 
@@ -361,6 +376,7 @@ def launch_agent(
         logs_specs=config.logs_specs,  # type: ignore[arg-type]
         start_method=config.start_method,
         log_line_prefix_template=config.log_line_prefix_template,
+        exit_barrier_timeout=config.exit_barrier_timeout,  # type: ignore[arg-type]
         shutdown_timeout=config.shutdown_timeout,  # type: ignore[arg-type]
         health_check_server=health_check_server,
     )

--- a/torch/distributed/run.py
+++ b/torch/distributed/run.py
@@ -783,6 +783,17 @@ def get_args_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
+        "--exit-barrier-timeout",
+        "--exit_barrier_timeout",
+        action=env,
+        type=float,
+        default=None,
+        help="Time in seconds to wait for all agents to finish before the exit barrier "
+        "is released. If not specified, uses TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT environment "
+        "variable or defaults to 300 seconds.",
+    )
+
+    parser.add_argument(
         "--virtual-local-rank",
         "--virtual_local_rank",
         action=check_env,
@@ -1049,6 +1060,7 @@ def config_from_args(args) -> tuple[LaunchConfig, Callable | str, list[str]]:
         duplicate_stderr_filters=args.duplicate_stderr_filters,
         virtual_local_rank=args.virtual_local_rank,
         shutdown_timeout=args.shutdown_timeout,
+        exit_barrier_timeout=args.exit_barrier_timeout,
     )
 
     with_python = not args.no_python


### PR DESCRIPTION
Fixes #157318

## Summary

The 300-second exit-barrier timeout was hardcoded in `SimpleElasticAgent`, making it impossible to tune for workloads where workers finish at very different times (large-scale training, slow checkpointing, etc.), resulting in:

```
Error waiting on exit barrier. Elapsed: 300.1... seconds
```

This PR exposes the timeout through the same three-layer precedence already used by `shutdown_timeout` / `TORCH_ELASTIC_SHUTDOWN_TIMEOUT`:

```
explicit constructor / LaunchConfig arg  >  env var  >  historical default (300 s)
```

## Changes

- **`torch/distributed/elastic/agent/server/api.py`** — `SimpleElasticAgent.__init__`: resolve `TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT` env var when no explicit value is passed; fallback stays 300 s
- **`torch/distributed/elastic/agent/server/local_elastic_agent.py`** — same default change (`float | None = None`) + updated docstring
- **`torch/distributed/launcher/api.py`** — new `exit_barrier_timeout: float | None = None` field on `LaunchConfig`, resolved in `__post_init__` (mirrors `shutdown_timeout` exactly), forwarded to `LocalElasticAgent` in `launch_agent()`
- **`torch/distributed/run.py`** — new `--exit-barrier-timeout` / `--exit_barrier_timeout` argparse flag wired into `config_from_args()`
- **`test/distributed/elastic/agent/server/test/exit_barrier_timeout_test.py`** — new test file (13 tests) mirroring `shutdown_timeout_test.py`
- **`test/distributed/test_run.py`** — 5 new argparse tests for the CLI flag

## Usage

```bash
# env var (zero code change required)
TORCH_ELASTIC_EXIT_BARRIER_TIMEOUT=600 torchrun train.py

# CLI flag
torchrun --exit-barrier-timeout 600 train.py

# Python API
LaunchConfig(..., exit_barrier_timeout=600)
LocalElasticAgent(spec, logs_specs, exit_barrier_timeout=600)
```

## Checklist

- [x] Passes lint (`pyflakes` — clean on all 6 changed files)
- [x] Added/updated tests (13 unit tests + 5 argparse tests, all green)
- [x] Updated documentation (docstrings in all changed files)
- [x] BC-breaking? **No** — default is still 300 s; any caller passing an explicit float continues to work unchanged

> **AI-Assisted Development disclosure**: This change was developed with AI assistance per the [AI_POLICY.md](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) guidelines.