### PR TITLE
[PyTorch] Make `has_triton` accelerator-only by default (#195544)

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -1181,7 +1181,14 @@ class TestHasTriton(TestCase):
         triton_utils.has_triton.cache_clear()
         super().tearDown()
 
-    def _run(self, registered, *, has_package=True, detection_disabled=False):
+    def _run(
+        self,
+        registered,
+        *,
+        has_package=True,
+        detection_disabled=False,
+        include_cpu=False,
+    ):
         with (
             mock.patch.object(
                 triton_utils, "has_triton_package", return_value=has_package
@@ -1193,6 +1200,9 @@ class TestHasTriton(TestCase):
             ),
         ):
             triton_utils.has_triton.cache_clear()
+            # Exercise the public default when CPU is not requested.
+            if include_cpu:
+                return triton_utils.has_triton(include_cpu=True)
             return triton_utils.has_triton()
 
     def test_no_triton_package(self):
@@ -1230,6 +1240,11 @@ class TestHasTriton(TestCase):
     def test_indexed_device_name_skipped(self):
         # "fake:0" is available+capable but must be skipped as an indexed alias.
         self.assertFalse(self._run([("fake:0", _make_triton_interface())]))
+
+    def test_cpu_ignored_by_default_and_included_when_requested(self):
+        registered = [("cpu", _make_triton_interface())]
+        self.assertFalse(self._run(registered))
+        self.assertTrue(self._run(registered, include_cpu=True))
 
     def test_first_working_device_wins(self):
         registered = [

--- a/torch/_dynamo/variables/builder.py
+++ b/torch/_dynamo/variables/builder.py
@@ -1111,7 +1111,8 @@ class VariableBuilder:
             ErrorOnGraphBreakDecoratorContextManager,
         )
 
-        if has_triton():
+        # Triton runtime types are shared across backends, including CPU.
+        if has_triton(include_cpu=True):
             from triton.runtime.autotuner import Autotuner
             from triton.runtime.jit import JITFunction
         else:
@@ -1144,7 +1145,8 @@ class VariableBuilder:
             )
         if has_triton_tensor_descriptor_host_tma():
             from triton.tools.tensor_descriptor import TensorDescriptor
-        if has_triton():
+        # The allocator hook is shared across Triton backends, including CPU.
+        if has_triton(include_cpu=True):
             import triton as triton_mod
 
             if hasattr(triton_mod, "set_allocator"):

--- a/torch/_export/serde/serialize.py
+++ b/torch/_export/serde/serialize.py
@@ -554,7 +554,8 @@ def get_triton_kernel_and_cache_entry(node: torch.fx.Node):
             f"expected triton_kernel_wrapper_functional, got {node.target}"
         )
 
-    if not has_triton():
+    # Triton kernel serialization also supports the CPU backend.
+    if not has_triton(include_cpu=True):
         raise AssertionError("triton required to serialize triton kernels")
     from triton.runtime.autotuner import Autotuner
     from triton.runtime.jit import JITFunction

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -2599,8 +2599,11 @@ def get_cpp_wrapper_config(log_cudagraph_skip: bool = True) -> dict[str, object]
     autotune_at_compile_time = (
         config.triton.autotune_at_compile_time
         if config.triton.autotune_at_compile_time is not None
-        # Default to True for AOTI. Subject to change in future.
-        else has_triton() and V.aot_compilation
+        # Default to True for AOTI when an accelerator or the selected CPU
+        # Triton backend is available. Subject to change in future.
+        else (
+            has_triton(include_cpu=config.cpu_backend == "triton") and V.aot_compilation
+        )
     )
     return {
         "triton.autotune_at_compile_time": autotune_at_compile_time,

--- a/torch/_inductor/runtime/autotune_cache.py
+++ b/torch/_inductor/runtime/autotune_cache.py
@@ -67,7 +67,8 @@ def inductor_meta_from_config() -> _InductorMetaTy:
     from torch._inductor import config
 
     backend_hash = None
-    if has_triton():
+    # CPU Triton artifacts also need a backend-specific cache key.
+    if has_triton(include_cpu=True):
         try:
             backend_hash = torch.utils._triton.triton_hash_with_backend()
         except RuntimeError:

--- a/torch/testing/_internal/inductor_utils.py
+++ b/torch/testing/_internal/inductor_utils.py
@@ -23,7 +23,11 @@ from torch._inductor.utils import (
 )
 from torch.utils._helion import has_helion
 from torch.utils._pallas import has_pallas_package, has_tpu_pallas
-from torch.utils._triton import has_triton, has_triton_block_ptr
+from torch.utils._triton import (
+    has_triton,
+    has_triton_block_ptr,
+    has_triton_cpu_backend,
+)
 from torch.utils._config_module import ConfigModule
 from torch.testing._internal.common_device_type import (
     get_desired_device_type_test_bases,
@@ -58,18 +62,12 @@ def test_cpu():
 HAS_CPU = LazyVal(test_cpu)
 
 HAS_TRITON = has_triton()
+# Respect triton_disable_device_detection when probing the CPU backend.
+TRITON_HAS_CPU = has_triton(include_cpu=True) and has_triton_cpu_backend()
 
 HAS_PALLAS = LazyVal(has_pallas_package)
 
 HAS_HELION = has_helion()
-
-if HAS_TRITON:
-    import triton
-
-    TRITON_HAS_CPU = "cpu" in triton.backends.backends
-else:
-    TRITON_HAS_CPU = False
-
 
 HAS_CUDA_AND_TRITON = torch.cuda.is_available() and HAS_TRITON
 

--- a/torch/testing/_internal/triton_utils.py
+++ b/torch/testing/_internal/triton_utils.py
@@ -23,7 +23,8 @@ requires_gpu_and_triton = unittest.skipUnless(
 )
 requires_gpu = unittest.skipUnless(HAS_GPU, "requires gpu")
 
-if has_triton():
+# Test kernels are shared across accelerator and CPU Triton backends.
+if has_triton(include_cpu=True):
     import triton
     from triton import language as tl
 

--- a/torch/utils/_triton.py
+++ b/torch/utils/_triton.py
@@ -222,7 +222,12 @@ def has_triton_reduction_ordering() -> bool:
 
 
 @functools.cache
-def has_triton() -> bool:
+def has_triton(*, include_cpu: bool = False) -> bool:
+    """Return whether a usable Triton backend is available.
+
+    By default, this helper only considers accelerator devices; callers must
+    explicitly include CPU.
+    """
     if not has_triton_package():
         return False
 
@@ -241,7 +246,7 @@ def has_triton() -> bool:
     # specific TritonUnavailableError rather than RuntimeError so unexpected
     # errors are not silently swallowed.
     for name, device_interface in get_registered_device_interfaces():
-        if ":" in name:
+        if ":" in name or (name == "cpu" and not include_cpu):
             continue
         if not (
             device_interface.is_available() and device_interface.is_triton_capable()


### PR DESCRIPTION
Summary:

The next Meta's internal triton release (version 3.8) ships a CPU backend that is available on every host. Counting it in bare `has_triton()` would silently change existing GPU and accelerator gates on CPU-only machines.

Keep `has_triton()` accelerator-only by default, and let backend-neutral or explicitly CPU-Triton paths opt in with `include_cpu=True`. Existing package, device-detection, capability, and backend-availability checks remain in force.

Test Plan:
`buck test fbcode//caffe2/test/inductor:utils -- TestHasTriton` — 12 passed

`buck test fbcode//unified_mapping/utils/tests:test_inductor_remote_cache` — 5 passed

`buck test fbcode//sigmoid/inference/test:test_passes -- test_triton_hop_cpu` — 2 passed

Reviewed By: jeanschmidt

Differential Revision: D118188207




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98