### PR TITLE
[inductor] Fix incorrect grid size in test_graph_partition_user_defined_triton_kernel_reuse

### DIFF
--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6177,10 +6177,6 @@ if HAS_CUDA_AND_TRITON:
                         "def triton_poi_fused_add_", 1, exactly=True
                     ).run(code[0])
 
-        @unittest.skipIf(
-            IS_LINUX or TEST_WITH_SLOW,
-            "https://github.com/pytorch/pytorch/issues/176144",
-        )
         @unittest.skipUnless(
             config.graph_partition, "Test requires graph_partition to be enabled"
         )
@@ -6192,12 +6188,12 @@ if HAS_CUDA_AND_TRITON:
             def foo(x, y):
                 # partition 1
                 output1 = torch.empty_like(x)
-                add_kernel[(4,)](x, y, output1, n_elements=128, BLOCK_SIZE=16)
+                add_kernel[(8,)](x, y, output1, n_elements=128, BLOCK_SIZE=16)
                 output1_cpu = output1.cpu() + 1
                 # partition 2 should reuse the user-defined kernel
                 x2 = output1_cpu.to("cuda")
                 output2 = torch.empty_like(x)
-                add_kernel[(4,)](x2, y, output2, n_elements=128, BLOCK_SIZE=16)
+                add_kernel[(8,)](x2, y, output2, n_elements=128, BLOCK_SIZE=16)
                 return output1, output2
 
             compiled_foo = torch.compile(foo)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -6185,14 +6185,21 @@ if HAS_CUDA_AND_TRITON:
             from torch.testing._internal.triton_utils import add_kernel
 
             def foo(x, y):
+                n_elements = 128
+                BLOCK_SIZE = 16
+                grid = ((n_elements + BLOCK_SIZE - 1) // BLOCK_SIZE,)
                 # partition 1
                 output1 = torch.empty_like(x)
-                add_kernel[(8,)](x, y, output1, n_elements=128, BLOCK_SIZE=16)
+                add_kernel[grid](
+                    x, y, output1, n_elements=n_elements, BLOCK_SIZE=BLOCK_SIZE
+                )
                 output1_cpu = output1.cpu() + 1
                 # partition 2 should reuse the user-defined kernel
                 x2 = output1_cpu.to("cuda")
                 output2 = torch.empty_like(x)
-                add_kernel[(8,)](x2, y, output2, n_elements=128, BLOCK_SIZE=16)
+                add_kernel[grid](
+                    x2, y, output2, n_elements=n_elements, BLOCK_SIZE=BLOCK_SIZE
+                )
                 return output1, output2
 
             compiled_foo = torch.compile(foo)

--- a/test/inductor/test_cudagraph_trees.py
+++ b/test/inductor/test_cudagraph_trees.py
@@ -45,7 +45,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     skipIfRocm,
     TEST_CUDA_GRAPH,
-    TEST_WITH_SLOW,
 )
 from torch.testing._internal.inductor_utils import HAS_CUDA_AND_TRITON
 from torch.testing._internal.logging_utils import logs_to_string


### PR DESCRIPTION
Fixes #195535

`add_kernel[(4,)](..., n_elements=128, BLOCK_SIZE=16)` only launches `4*16=64` Triton programs — `n_elements` only bounds the load/store mask, it doesn't grow the grid. Elements `[64:128]` of both `output1` and `output2` (allocated via `torch.empty_like`) were never written, so the eager-vs-compiled comparison was silently checking uninitialized memory. This is why failures showed as `64/128 mismatched elements` and depended on allocator residue rather than reproducing reliably.

Fix: use `grid=(8,)` so `8*16=128` covers the full tensor, on both kernel launches.

Also removes the `skipIf(IS_LINUX or TEST_WITH_SLOW, ...)` guard added for #176144 (the disable tracking this same flakiness), since the root cause is now fixed.

Verified locally on a Colab T4 by pinning to the exact commit matching an installed nightly build and running the test 20/20 times, all passing.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo