### PR TITLE
Run pr_time_benchmarks only once per commit (drop the CUDA 13.0 copy)

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -134,7 +134,6 @@ jobs:
           { config: "distributed", shard: 8, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.12xlarge.nvidia.gpu" },
           { config: "distributed", shard: 9, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.12xlarge.nvidia.gpu" },
           { config: "distributed", shard: 10, num_shards: 10, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.12xlarge.nvidia.gpu" },
-          { config: "pr_time_benchmarks", shard: 1, num_shards: 1, runner: "${{ needs.get-label-type.outputs.label-type }}linux.g4dn.metal.nvidia.gpu" },
         ]}
       python-version: "3.10"
       compiler: gcc11


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
## Run `pr_time_benchmarks` only once per commit (drop the CUDA 13.0 copy)

### Summary

`pr_time_benchmarks` was listed in two separate `trunk.yml` test matrices, so the entire compile-time benchmark suite ran twice on every commit landed to trunk:

- `linux-jammy-cuda13.0-py3.10-gcc11` (`cuda-version: "13.0"`)
- `linux-jammy-cuda13.2-py3.10-gcc11` (`cuda-version: "13.2"`)

Both entries were identical (`shard: 1, num_shards: 1` on `linux.g4dn.metal.nvidia.gpu`) and these were the only two occurrences anywhere in `.github/workflows/`.

### Why this is a problem

**1. Wasted compute.** The suite is slow and runs on `linux.g4dn.metal.nvidia.gpu`, a scarce and expensive bare-metal runner. Every trunk commit paid for two full runs of it, for zero added signal. These benchmarks measure CPU-side Dynamo/Inductor compile-time instruction counts and are insensitive to the CUDA toolkit version, so a second CUDA version buys no coverage.

**2. The logged data cannot distinguish the two runs, which breaks both CI and the dashboard.** The records emitted by `benchmark_base._write_to_json` for the OSS benchmark database contain only `benchmark.name` (`"pr_time_benchmarks"`), `mode`, `extra_info{is_dynamic, device, description}`, `model{name, type, backend}` and `metric{name, benchmark_values}`. No CUDA version, build environment, or job name appears anywhere in the payload. Consequences:

- **Dashboard:** both runs land under identical keys for the same commit, so they show up as two values for what looks like a single measurement — apparent noise and a bimodal series, with no way to attribute a point to its build.
- **CI:** `expected_results.csv` holds one expected value per `(benchmark_name, metric_name)`, and `check_results.py` runs independently in each job against that same baseline. Any systematic instruction-count difference between the two builds leaves one of them permanently closer to (or outside) its noise margin — a standing false-failure source. Re-baselining to satisfy one job pushes the other out, and the failure output doesn't say which build produced it.

(The internal scribe path does carry `job_name` via `TorchOpenSourceSignpost`, but nothing in the benchmark payload records the build, and the dashboard doesn't key on it.)

### How this happened — a recurring regression

This is the **third** instance of this exact duplicate, and the second removal:

| Date | Commit / PR | Effect |
|---|---|---|
| 2025-12-08 | #167207 "[CI] Add eager tests for CUDA 13.0" (Ting Lu) | Added a `pr_time_benchmarks` entry to `trunk.yml` alongside the new CUDA 13.0 job → first duplicate |
| 2026-04-13 | #180308 "[BE][CI] Remove duplicate pr_time_benchmarks from pull and trunk" (Nikita Shulga) | Removed the `trunk.yml` duplicate and dropped the 44-line `pr_time_benchmarks` job from `pull.yml`. Reverted 2026-04-14, then re-landed |
| 2026-07-23 | #190641 "[CI] Add CUDA 13.2 CI coverage for stable version" (Ting Lu) | Copied the CUDA 13.0 matrix into a new CUDA 13.2 job → duplicate reintroduced |
| this change | — | Removed again, keeping the CUDA 13.2 run |

The mechanism is the same every time: a CUDA-version-bump PR duplicates an entire existing test matrix into a new job, and `pr_time_benchmarks` silently comes along. Nothing in CI or in the logged data flags it, so it survives until someone notices the doubled dashboard series.

### Change

Removes the `pr_time_benchmarks` entry from the CUDA 13.0 matrix, keeping the run under `linux-jammy-cuda13.2-py3.10-gcc11` since 13.2 is the stable-version target going forward. One-line deletion.

### Test plan

Verified `trunk.yml` parses (32 jobs) and that the embedded `test-matrix` strings parse, with per-job `pr_time_benchmarks` counts:

- `linux-jammy-cuda13_0-py3_10-gcc11-build` → cuda 13.0, count **0**, 24 matrix entries
- `linux-jammy-cuda13_2-py3_10-gcc11-build` → cuda 13.2, count **1**, 25 matrix entries

### Follow-ups

- `expected_results.csv` may need a one-time re-baseline, since the surviving series now comes from the 13.2 build. `check_results.py` prints the ready-to-paste `cat > ... << EOF` block on failure.
- If the `pt2_diff_time_metrics` dashboard filters on `job_name`, point it at the cuda13.2 job; the historical 13.0 series ends here.
- **Add a guard so this doesn't recur a fourth time** — either a lint check that `pr_time_benchmarks` appears at most once across `.github/workflows/`, or record the build environment in `_write_to_json`'s `extra_info` so a duplicate is at least visible in the data instead of silently corrupting the series.