### PR TITLE
[XPU] Remove uint8 and int8 scaled_dot_product_attention

### DIFF
--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -17287,7 +17287,7 @@ op_db: list[OpInfo] = [
                wrapper_set_seed(torch.nn.functional.scaled_dot_product_attention, *args, **kwargs),
         sample_inputs_func=sample_inputs_scaled_dot_product_attention,
         dtypes=floating_types_and(torch.float16, torch.bfloat16),
-        dtypesIfXPU=floating_types_and(torch.float16, torch.bfloat16, torch.int8, torch.uint8),
+        dtypesIfXPU=floating_types_and(torch.float16, torch.bfloat16),
         supports_out=False,
         supports_forward_ad=False,
         supports_fwgrad_bwgrad=True,


### PR DESCRIPTION
The tests for uint8 and int8 were added in https://github.com/pytorch/pytorch/commit/0efdd5cf0645586e0f129985a88027e723dd7a56. But because the aten.bmm.default
don't support uint8 and int8 the tests fail:
```
test_dispatch_symbolic_meta_outplace_nn_functional_scaled_dot_product_attention_xpu_int8
test_dispatch_symbolic_meta_outplace_nn_functional_scaled_dot_product_attention_xpu_uint8 
test_dispatch_meta_outplace_nn_functional_scaled_dot_product_attention_xpu_int8
test_dispatch_meta_outplace_nn_functional_scaled_dot_product_attention_xpu_uint8
```
Skipping test will allow to tests runs correctly and also sdpa for uint8 and int8 will be still supported. torch-xpu-ops issue: https://github.com/intel/torch-xpu-ops/issues/4461
cc: @LuFinch @daisyden 