### PR TITLE
Use TORCH_CHECK_VALUE for adaptive_avg_pool2d input validation

### DIFF
--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -25,18 +25,18 @@ namespace {
     at::Tensor const& input,
     IntArrayRef output_size)
   {
-    TORCH_CHECK(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
+    TORCH_CHECK_VALUE(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
     int64_t ndim = input.dim();
-    TORCH_CHECK((ndim == 3 || ndim == 4),
+    TORCH_CHECK_VALUE((ndim == 3 || ndim == 4),
       "adaptive_avg_pool2d(): Expected 3D or 4D tensor, but got ", input.sizes());
     for (const auto i : {-2, -1}) {
-      TORCH_CHECK(input.size(i) > 0,
+      TORCH_CHECK_VALUE(input.size(i) > 0,
         "adaptive_avg_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
         "but input has sizes ", input.sizes(), " with dimension ", i + ndim, " being "
         "empty");
     }
 
-    TORCH_CHECK(input.dtype() == output.dtype(),
+    TORCH_CHECK_VALUE(input.dtype() == output.dtype(),
       "expected dtype ", input.dtype(), " for `output` but got dtype ", output.dtype());
 
     int64_t channels  = input.size(-3);
@@ -64,18 +64,18 @@ namespace {
   {
     adaptive_pool_empty_output_check(grad_output, "adaptive_avg_pool2d_backward");
     int64_t ndim = grad_output.dim();
-    TORCH_CHECK(input.dim() == ndim,
+    TORCH_CHECK_VALUE(input.dim() == ndim,
       __func__, ": Expected dimensions ", input.dim(), " for `grad_output` but got dimensions ", ndim);
-    TORCH_CHECK((ndim == 3 || ndim == 4),
+    TORCH_CHECK_VALUE((ndim == 3 || ndim == 4),
       __func__, ": Expected 3D or 4D tensor, but got ", input.sizes());
     for (const auto i : c10::irange(ndim - 2)) {
-      TORCH_CHECK(input.size(i) == grad_output.size(i),
+      TORCH_CHECK_VALUE(input.size(i) == grad_output.size(i),
         __func__, ": input and grad_output must have the same size at dim ", i,
         ", but got ", input.size(i), " and ", grad_output.size(i));
     }
-    TORCH_CHECK(input.dtype() == grad_output.dtype(),
+    TORCH_CHECK_VALUE(input.dtype() == grad_output.dtype(),
       __func__, ": Expected dtype ", input.dtype(), " for `grad_output` but got dtype ", grad_output.dtype());
-    TORCH_CHECK(input.dtype() == grad_input.dtype(),
+    TORCH_CHECK_VALUE(input.dtype() == grad_input.dtype(),
       __func__, ": Expected dtype ", input.dtype(), " for `grad_input` but got dtype ", grad_input.dtype());
 
     grad_input.resize_(input.sizes(), input.suggest_memory_format());
@@ -107,8 +107,8 @@ namespace {
   }
 
   Tensor adaptive_avg_pool2d_symint(at::Tensor const& input, SymIntArrayRef output_size) {
-    TORCH_CHECK(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
-    TORCH_CHECK(
+    TORCH_CHECK_VALUE(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
+    TORCH_CHECK_VALUE(
         (output_size[0] >= 0 && output_size[1] >= 0),
         "adaptive_avg_pool2d: elements of output_size must be greater than or equal to 0 ",
         "but received {", output_size[0], ", ", output_size[1], "}");

--- a/aten/src/ATen/native/AdaptiveAveragePooling.cpp
+++ b/aten/src/ATen/native/AdaptiveAveragePooling.cpp
@@ -68,6 +68,11 @@ namespace {
       __func__, ": Expected dimensions ", input.dim(), " for `grad_output` but got dimensions ", ndim);
     TORCH_CHECK((ndim == 3 || ndim == 4),
       __func__, ": Expected 3D or 4D tensor, but got ", input.sizes());
+    for (const auto i : c10::irange(ndim - 2)) {
+      TORCH_CHECK(input.size(i) == grad_output.size(i),
+        __func__, ": input and grad_output must have the same size at dim ", i,
+        ", but got ", input.size(i), " and ", grad_output.size(i));
+    }
     TORCH_CHECK(input.dtype() == grad_output.dtype(),
       __func__, ": Expected dtype ", input.dtype(), " for `grad_output` but got dtype ", grad_output.dtype());
     TORCH_CHECK(input.dtype() == grad_input.dtype(),

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -616,6 +616,11 @@ namespace {
     adaptive_pool_empty_output_check(gradOutput_, "adaptive_avg_pool2d_backward");
     TORCH_CHECK(input.dim() == gradOutput_.dim(),
       __func__, ": Expected dimensions ", input.dim(), " for `gradOutput_` but got dimensions ", gradOutput_.dim());
+    for (const auto i : c10::irange(input.dim() - 2)) {
+      TORCH_CHECK(input.size(i) == gradOutput_.size(i),
+        __func__, ": input and gradOutput_ must have the same size at dim ", i,
+        ", but got ", input.size(i), " and ", gradOutput_.size(i));
+    }
 
     checkAllSameGPU(__func__, {grad_input_arg, grad_output_arg, input_arg});
 

--- a/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
+++ b/aten/src/ATen/native/cuda/AdaptiveAveragePooling.cu
@@ -444,12 +444,12 @@ namespace {
               output_arg{ output, "output", 2 };
     checkAllSameGPU(__func__, {input_arg, output_arg});
 
-    TORCH_CHECK(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
+    TORCH_CHECK_VALUE(output_size.size() == 2, "adaptive_avg_pool2d: output_size must be 2");
     int64_t ndim = input.dim();
-    TORCH_CHECK((ndim == 3 || ndim == 4),
+    TORCH_CHECK_VALUE((ndim == 3 || ndim == 4),
       "adaptive_avg_pool2d(): Expected 3D or 4D tensor, but got ", input.sizes());
     for (const auto i : {-2, -1}) {
-      TORCH_CHECK(input.size(i) > 0,
+      TORCH_CHECK_VALUE(input.size(i) > 0,
         "adaptive_avg_pool2d(): Expected input to have non-zero size for non-batch dimensions, "
         "but input has sizes ", input.sizes(), " with dimension ", i + ndim, " being "
         "empty");
@@ -459,7 +459,7 @@ namespace {
     switch (input.suggest_memory_format()) {
       case at::MemoryFormat::ChannelsLast: {
         // special case for tensor memory format in channels_last
-        TORCH_CHECK(input.ndimension() == 4,
+        TORCH_CHECK_VALUE(input.ndimension() == 4,
                     "adaptive_avg_pool2d(): Expected 4D tensor, but got ",
                     input.sizes());
 
@@ -614,10 +614,10 @@ namespace {
               input_arg{ input, "input", 3 };
 
     adaptive_pool_empty_output_check(gradOutput_, "adaptive_avg_pool2d_backward");
-    TORCH_CHECK(input.dim() == gradOutput_.dim(),
+    TORCH_CHECK_VALUE(input.dim() == gradOutput_.dim(),
       __func__, ": Expected dimensions ", input.dim(), " for `gradOutput_` but got dimensions ", gradOutput_.dim());
     for (const auto i : c10::irange(input.dim() - 2)) {
-      TORCH_CHECK(input.size(i) == gradOutput_.size(i),
+      TORCH_CHECK_VALUE(input.size(i) == gradOutput_.size(i),
         __func__, ": input and gradOutput_ must have the same size at dim ", i,
         ", but got ", input.size(i), " and ", gradOutput_.size(i));
     }
@@ -627,7 +627,7 @@ namespace {
     switch (input.suggest_memory_format()) {
       case at::MemoryFormat::ChannelsLast: {
         // special case for tensor memory format in channels_last
-        TORCH_CHECK(input.ndimension() == 4,
+        TORCH_CHECK_VALUE(input.ndimension() == 4,
                     "adaptive_avg_pool2d_backward_cuda(): Expected 4D tensor, but got ", input.ndimension());
 
         int sizeB = input.size(0);

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -823,6 +823,18 @@ class TestPoolingNNDevice(NNTestCase):
         with self.assertRaisesRegex(RuntimeError, "Expected dimensions"):
             torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
 
+        grad_output = torch.randn(1, 3, 7, 7, device=device)
+        input = torch.randn(1, 2, 3, 3, device=device)
+        with self.assertRaisesRegex(RuntimeError, "must have the same size at dim"):
+            torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
+
+        # channels_last takes the channel count from input and strides
+        # grad_output with it, so it runs off grad_output rather than grad_input
+        grad_output = torch.randn(1, 2, 7, 7, device=device).to(memory_format=torch.channels_last)
+        input = torch.randn(1, 3, 3, 3, device=device).to(memory_format=torch.channels_last)
+        with self.assertRaisesRegex(RuntimeError, "must have the same size at dim"):
+            torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
+
         grad_output = torch.randn(1, 2, 7, 7, device=device)
         input = torch.randn(1, 2, 3, 3, 3, device=device)
         with self.assertRaisesRegex(RuntimeError, "Expected dimensions"):

--- a/test/nn/test_pooling.py
+++ b/test/nn/test_pooling.py
@@ -820,19 +820,21 @@ class TestPoolingNNDevice(NNTestCase):
     def test_adaptive_avg_pooling_backward_fails(self, device):
         grad_output = torch.randn(1, 2, 7, device=device)
         input = torch.randn(1, 2, 3, 3, device=device)
-        with self.assertRaisesRegex(RuntimeError, "Expected dimensions"):
+        with self.assertRaisesRegex(ValueError, "Expected dimensions"):
             torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
 
         grad_output = torch.randn(1, 3, 7, 7, device=device)
         input = torch.randn(1, 2, 3, 3, device=device)
-        with self.assertRaisesRegex(RuntimeError, "must have the same size at dim"):
+        with self.assertRaisesRegex(ValueError, "must have the same size at dim"):
             torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
 
         # channels_last takes the channel count from input and strides
         # grad_output with it, so it runs off grad_output rather than grad_input
-        grad_output = torch.randn(1, 2, 7, 7, device=device).to(memory_format=torch.channels_last)
-        input = torch.randn(1, 3, 3, 3, device=device).to(memory_format=torch.channels_last)
-        with self.assertRaisesRegex(RuntimeError, "must have the same size at dim"):
+        grad_output = torch.randn(1, 2, 7, 7, device=device)
+        grad_output = grad_output.to(memory_format=torch.channels_last)
+        input = torch.randn(1, 3, 3, 3, device=device)
+        input = input.to(memory_format=torch.channels_last)
+        with self.assertRaisesRegex(ValueError, "must have the same size at dim"):
             torch.ops.aten._adaptive_avg_pool2d_backward(grad_output, input)
 
         grad_output = torch.randn(1, 2, 7, 7, device=device)

--- a/torch/_decomp/decompositions.py
+++ b/torch/_decomp/decompositions.py
@@ -2820,12 +2820,12 @@ def adaptive_avg_pool2d(input: Tensor, output_size: tuple[int, int]):
     device = input.device
     shape = input.shape
     ndim = len(shape)
-    torch._check(
+    torch._check_value(
         ndim in (3, 4),
         lambda: f"adaptive_avg_pool2d(): Expected 3D or 4D tensor, but got {ndim}",
     )
     for d in input.shape[-2:]:
-        torch._check(
+        torch._check_value(
             d != 0,
             lambda: "adaptive_avg_pool2d(): Expected input to have non-zero size for "
             f"non-batch dimensions, but input has shape {tuple(shape)}.",

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -3658,7 +3658,7 @@ def meta_avg_pool3d_backward(
 
 @register_meta(aten._adaptive_avg_pool2d.default)
 def meta_adaptive_avg_pool2d(self, output_size):
-    torch._check(
+    torch._check_value(
         self.ndim == 3 or self.ndim == 4,
         lambda: f"Expected 3D or 4D tensor, but got {self.shape}",
     )
@@ -3692,11 +3692,11 @@ def meta__adaptive_avg_pool2d_backward(grad_out, self):
             lambda: f"adaptive_avg_pool2d_backward(): Expected grad_output to have non-zero \
                       size for non-batch dimensions, {grad_out.shape} with dimension {i} being empty",
         )
-    torch._check(
+    torch._check_value(
         ndim == 3 or ndim == 4,
         lambda: f"adaptive_avg_pool2d_backward(): Expected 3D or 4D tensor, but got {self.shape}",
     )
-    torch._check(
+    torch._check_value(
         self.dtype == grad_out.dtype,
         lambda: f"expected dtype {self.dtype} for `grad_output` but got dtype {grad_out.dtype}",
     )

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -3551,7 +3551,9 @@ def error_inputs_adaptive_avg_pool1d(opinfo, device, **kwargs):
                      error_regex="'output_size' should contain one int")
 
     # error inputs for output_size lesser than 0
+    # adaptive_avg_pool1d forwards to adaptive_avg_pool2d, which raises ValueError
     yield ErrorInput(SampleInput(make_arg((1, 1, 1)), output_size=(-1,)),
+                     error_type=ValueError,
                      error_regex="elements of output_size must be greater than or equal to 0")
 
 
@@ -3583,10 +3585,11 @@ def error_inputs_adaptive_avg_pool2d(opinfo, device, **kwargs):
 
     # error inputs for empty output
     yield ErrorInput(SampleInput(make_arg((1, 2, 3, 4)), output_size=()),
-                     error_regex="output_size must be 2")
+                     error_type=ValueError, error_regex="output_size must be 2")
 
     # error inputs for output_size lesser than 0
     yield ErrorInput(SampleInput(make_arg((1, 1, 1, 1)), output_size=(-1, 0)),
+                     error_type=ValueError,
                      error_regex="elements of output_size must be greater than or equal to 0")
 
 


### PR DESCRIPTION
Follow-up to #195339, addressing review feedback from @Skylion007:

> We should have a follow up PR that replaces all these input validations with TORCH_CHECK_VALUE

(https://github.com/pytorch/pytorch/pull/195339#discussion_r3890348538)

### What changed

The input validations in `adaptive_avg_pool2d` now use `TORCH_CHECK_VALUE`, so
they raise `ValueError` instead of `RuntimeError` - 11 sites in
`AdaptiveAveragePooling.cpp` and 7 in the CUDA counterpart.

Swapping the macro alone would have split the operator's behaviour, so the
mirrored checks in the meta registration and the decomposition move to
`torch._check_value` in the same change. Without that, eager would raise
`ValueError` while `torch.compile` and fake-tensor tracing kept raising
`RuntimeError` for the same input.

This also lines the C++ layer up with the Python one, which already raises
`ValueError` for this operator family: `torch/nn/modules/utils.py` raises it for
rank errors, and `error_inputs_adaptive_avg_pool2d` already encoded
`error_type=ValueError` for that case.

### Scope

Limited to `adaptive_avg_pool2d`. Three nearby validations are deliberately left
on `TORCH_CHECK`:

- `adaptive_pool_empty_output_check` in `AdaptivePooling.h` is shared with
  `adaptive_max_pool2d/3d`. Converting it would change error types for operators
  this review did not cover.
- The two `TORCH_CHECK(false, "Unsupported memory format")` guards in the CUDA
  file report an unsupported configuration rather than a bad value;
  `TORCH_CHECK_NOT_IMPLEMENTED` would be the right macro there.
- The MPS-only check in `mps/operations/AdaptivePooling.mm` is untouched, so MPS
  still raises `RuntimeError` for zero-size non-batch dimensions.

`adaptive_avg_pool3d` is left for a separate change because #195304 is still
open against those same files.

Happy to fold any of these in if you would rather see them all move at once.

### BC-breaking

`ValueError` is not a subclass of `RuntimeError`, so code catching
`RuntimeError` from these operators needs updating.

Two callers forward into `adaptive_avg_pool2d` and change with it:
`adaptive_avg_pool1d` (via `Pooling.cpp`) and `F.interpolate(mode="area")`.
`error_inputs_adaptive_avg_pool1d` is updated accordingly.

This mirrors #155460, which made the same `TORCH_CHECK` -> `TORCH_CHECK_VALUE`
change for `torch.cat` and was treated as `[BE]` rather than labelled
BC-breaking.

### Test Plan

```
python test/nn/test_pooling.py -k adaptive
python test/test_ops.py -k errors_nn_functional_adaptive
python test/test_meta.py -k adaptive_avg_pool
python test/test_decomp.py -k adaptive_avg_pool
python test/test_fake_tensor.py -k adaptive_avg_pool
```

| Suite | Result |
| --- | --- |
| `test_ops.py -k errors_nn_functional_adaptive` | 6 passed |
| `test_meta.py -k adaptive_avg_pool` | 78 passed (42 skipped) |
| `test_fake_tensor.py -k adaptive_avg_pool` | 2 passed |
| `test_pooling.py -k adaptive` | 38 run, 12 failures |
| `test_decomp.py -k adaptive_avg_pool` | 12 run, 4 errors |

The `test_pooling` failures and `test_decomp` errors are all numerics tests
(nhwc and lower-precision). The identical set fails on an unmodified tree in
this environment, which is a CPU-only build without MKL/BLAS, so they are
pre-existing rather than caused by this change.

Also checked directly that each converted site raises `ValueError` and each
deliberately-unconverted one still raises `RuntimeError`, including that
`adaptive_avg_pool1d` picks up the change through the 2d path.

The CUDA sources are changed but were not executed locally on this CPU-only
build; they are a mechanical mirror of the CPU checks and rely on CI.