### PR TITLE
Add vmap rules for multi_margin_loss

### DIFF
--- a/aten/src/ATen/functorch/BatchRulesLoss.cpp
+++ b/aten/src/ATen/functorch/BatchRulesLoss.cpp
@@ -74,6 +74,155 @@ smooth_l1_loss_batch_rule(const at::Tensor& self, std::optional<int64_t> self_bd
                                 });
 }
 
+static std::tuple<Tensor, Tensor, int64_t, bool, VmapDimVector> multi_margin_loss_prepare_inputs(
+    const Tensor& self,
+    std::optional<int64_t> self_bdim,
+    const Tensor& target,
+    std::optional<int64_t> target_bdim,
+    int64_t bdim_size) {
+  auto self_ = moveBatchDimToFront(self, self_bdim);
+  auto target_ = moveBatchDimToFront(target, target_bdim);
+  self_ = ensure_has_bdim(self_, self_bdim.has_value(), bdim_size);
+  target_ = ensure_has_bdim(target_, target_bdim.has_value(), bdim_size);
+
+  const auto self_logical_rank = rankWithoutBatchDim(self, self_bdim);
+  TORCH_CHECK(
+      self_logical_rank <= 2,
+      "vmap: Expected input for multi_margin_loss to have logical rank <= 2, but got ",
+      self_logical_rank);
+
+  VmapDimVector self_logical_sizes;
+  self_logical_sizes.reserve(self_logical_rank);
+  for (int64_t dim = 1; dim < self_.dim(); dim++) {
+    self_logical_sizes.push_back(self_.size(dim));
+  }
+
+  Tensor self_flat;
+  Tensor target_flat;
+  int64_t nframe;
+  bool target_has_logical_dim = rankWithoutBatchDim(target, target_bdim) > 0;
+  if (self_logical_rank <= 1) {
+    self_flat = self_.reshape({bdim_size, self_.numel() / bdim_size});
+    target_flat = target_.reshape({bdim_size});
+    nframe = 1;
+  } else {
+    nframe = self_.size(1);
+    const auto nclass = self_.size(2);
+    self_flat = self_.reshape({bdim_size * nframe, nclass});
+    target_flat = target_.reshape({bdim_size * nframe});
+  }
+  return std::make_tuple(
+      std::move(self_flat),
+      std::move(target_flat),
+      nframe,
+      target_has_logical_dim,
+      std::move(self_logical_sizes));
+}
+
+static Tensor multi_margin_loss_restore_forward(
+    const Tensor& result,
+    int64_t bdim_size,
+    int64_t nframe,
+    bool target_has_logical_dim,
+    int64_t reduction) {
+  auto result_ = result.reshape({bdim_size, nframe});
+  if (reduction == Reduction::None) {
+    return target_has_logical_dim ? result_ : result_.squeeze(1);
+  }
+  if (nframe == 1) {
+    return result_.squeeze(1);
+  }
+  if (reduction == Reduction::Sum) {
+    return result_.sum(1);
+  }
+  if (reduction == Reduction::Mean) {
+    return result_.mean(1);
+  }
+  TORCH_INTERNAL_ASSERT(false);
+}
+
+static std::tuple<at::Tensor, std::optional<int64_t>>
+multi_margin_loss_batch_rule(
+    const Tensor& self,
+    std::optional<int64_t> self_bdim,
+    const Tensor& target,
+    std::optional<int64_t> target_bdim,
+    const Scalar& p,
+    const Scalar& margin,
+    const std::optional<Tensor>& weight_opt,
+    std::optional<int64_t> weight_bdim,
+    int64_t reduction) {
+  TORCH_CHECK(
+      !weight_bdim.has_value(),
+      "vmap: batching over the weight argument of multi_margin_loss is not supported");
+
+  const auto bdim_size = get_bdim_size2(self, self_bdim, target, target_bdim);
+  auto [self_flat, target_flat, nframe, target_has_logical_dim, self_logical_sizes] =
+      multi_margin_loss_prepare_inputs(self, self_bdim, target, target_bdim, bdim_size);
+  (void)self_logical_sizes;
+  auto result = at::multi_margin_loss(
+      self_flat, target_flat, p, margin, weight_opt, Reduction::None);
+  result = multi_margin_loss_restore_forward(
+      result, bdim_size, nframe, target_has_logical_dim, reduction);
+  return std::make_tuple(std::move(result), 0);
+}
+
+static Tensor multi_margin_loss_prepare_grad_output(
+    const Tensor& grad_output,
+    std::optional<int64_t> grad_output_bdim,
+    int64_t bdim_size,
+    int64_t nframe,
+    int64_t reduction) {
+  auto grad_output_ = moveBatchDimToFront(grad_output, grad_output_bdim);
+  grad_output_ = ensure_has_bdim(
+      grad_output_, grad_output_bdim.has_value(), bdim_size);
+  if (reduction == Reduction::None) {
+    return grad_output_.reshape({bdim_size * nframe});
+  }
+  return grad_output_.reshape({bdim_size})
+      .unsqueeze(1)
+      .expand({bdim_size, nframe})
+      .reshape({bdim_size * nframe});
+}
+
+static std::tuple<at::Tensor, std::optional<int64_t>>
+multi_margin_loss_backward_batch_rule(
+    const Tensor& grad_output,
+    std::optional<int64_t> grad_output_bdim,
+    const Tensor& self,
+    std::optional<int64_t> self_bdim,
+    const Tensor& target,
+    std::optional<int64_t> target_bdim,
+    const Scalar& p,
+    const Scalar& margin,
+    const std::optional<Tensor>& weight_opt,
+    std::optional<int64_t> weight_bdim,
+    int64_t reduction) {
+  TORCH_CHECK(
+      !weight_bdim.has_value(),
+      "vmap: batching over the weight argument of multi_margin_loss_backward is not supported");
+
+  const auto bdim_size = get_bdim_size3(
+      grad_output, grad_output_bdim, self, self_bdim, target, target_bdim);
+  auto [self_flat, target_flat, nframe, target_has_logical_dim, self_logical_sizes] =
+      multi_margin_loss_prepare_inputs(self, self_bdim, target, target_bdim, bdim_size);
+  (void)target_has_logical_dim;
+  auto grad_output_flat = multi_margin_loss_prepare_grad_output(
+      grad_output, grad_output_bdim, bdim_size, nframe, reduction);
+  auto grad_input = at::multi_margin_loss_backward(
+      grad_output_flat, self_flat, target_flat, p, margin, weight_opt, Reduction::None);
+  if (reduction == Reduction::Mean && nframe > 1) {
+    grad_input.div_(nframe);
+  }
+
+  VmapDimVector grad_input_shape;
+  grad_input_shape.reserve(self_logical_sizes.size() + 1);
+  grad_input_shape.push_back(bdim_size);
+  grad_input_shape.insert(grad_input_shape.end(), self_logical_sizes.begin(), self_logical_sizes.end());
+  grad_input = grad_input.reshape(grad_input_shape);
+  return std::make_tuple(std::move(grad_input), 0);
+}
+
 static Tensor apply_loss_reduction(const at::Tensor& unreduced, int64_t reduction) {
   if (reduction == at::Reduction::Mean) {
     return unreduced.mean();
@@ -176,6 +325,8 @@ TORCH_LIBRARY_IMPL(aten, FuncTorchBatched, m) {
   // huber_loss_backward uses a decomposition for its batch rule
   VMAP_SUPPORT(smooth_l1_loss, smooth_l1_loss_batch_rule);
   // smooth_l1_loss_backward uses a decomposition for its batch rule
+  VMAP_SUPPORT(multi_margin_loss, multi_margin_loss_batch_rule);
+  VMAP_SUPPORT(multi_margin_loss_backward, multi_margin_loss_backward_batch_rule);
   m.impl("binary_cross_entropy", binary_cross_entropy_plumbing);
   m.impl("binary_cross_entropy_backward", binary_cross_entropy_backward_plumbing);
 }

--- a/aten/src/ATen/functorch/BatchRulesLoss.cpp
+++ b/aten/src/ATen/functorch/BatchRulesLoss.cpp
@@ -112,10 +112,10 @@ static std::tuple<Tensor, Tensor, int64_t, bool, VmapDimVector> multi_margin_los
 
   Tensor self_flat;
   Tensor target_flat;
-  int64_t nframe;
+  int64_t nframe = 0;
   bool target_has_logical_dim = rankWithoutBatchDim(target, target_bdim) > 0;
   if (self_logical_rank <= 1) {
-    self_flat = self_.reshape({bdim_size, self_.numel() / bdim_size});
+    self_flat = self_.reshape({bdim_size, -1});
     target_flat = target_.reshape({bdim_size});
     nframe = 1;
   } else {
@@ -156,14 +156,19 @@ static Tensor multi_margin_loss_per_frame_weight(
     std::optional<int64_t> weight_bdim,
     const Tensor& target_flat,
     int64_t bdim_size,
-    int64_t nframe) {
+    int64_t nframe,
+    int64_t nclass) {
   auto weight_ = moveBatchDimToFront(weight, weight_bdim);
   weight_ = ensure_has_bdim(weight_, weight_bdim.has_value(), bdim_size);
-  const auto nclass = weight_.size(-1);
-  auto weight_flat = weight_.unsqueeze(1)
-                         .expand({bdim_size, nframe, nclass})
-                         .reshape({bdim_size * nframe, nclass});
-  return weight_flat.gather(1, target_flat.unsqueeze(1)).squeeze(1);
+  // The native op validates weight against nclass, but the batched path passes
+  // weight=None to it, so re-check here to stay in parity with eager instead of
+  // silently gathering with a mismatched (or wrong-rank) weight.
+  TORCH_CHECK(
+      weight_.dim() == 2 && weight_.size(-1) == nclass,
+      "inconsistent weight size, expected ", nclass, " but got ",
+      weight_.sizes().slice(1));
+  auto per_frame = weight_.gather(1, target_flat.view({bdim_size, nframe}));
+  return per_frame.reshape({bdim_size * nframe});
 }
 
 static std::tuple<at::Tensor, std::optional<int64_t>>
@@ -189,7 +194,8 @@ multi_margin_loss_batch_rule(
       weight_batched ? std::optional<Tensor>() : weight_opt, Reduction::None);
   if (weight_batched) {
     result = result * multi_margin_loss_per_frame_weight(
-                          *weight_opt, weight_bdim, target_flat, bdim_size, nframe);
+                          *weight_opt, weight_bdim, target_flat, bdim_size, nframe,
+                          self_flat.size(1));
   }
   result = multi_margin_loss_restore_forward(
       result, bdim_size, nframe, target_has_logical_dim, reduction);
@@ -242,7 +248,7 @@ multi_margin_loss_backward_batch_rule(
   if (weight_batched) {
     // weight scales every frame's whole gradient row by weight[target].
     auto w = multi_margin_loss_per_frame_weight(
-        *weight_opt, weight_bdim, target_flat, bdim_size, nframe);
+        *weight_opt, weight_bdim, target_flat, bdim_size, nframe, self_flat.size(1));
     grad_input = grad_input * w.unsqueeze(1);
   }
   if (reduction == Reduction::Mean && nframe > 1) {

--- a/aten/src/ATen/functorch/BatchRulesLoss.cpp
+++ b/aten/src/ATen/functorch/BatchRulesLoss.cpp
@@ -74,6 +74,19 @@ smooth_l1_loss_batch_rule(const at::Tensor& self, std::optional<int64_t> self_bd
                                 });
 }
 
+static Tensor apply_loss_reduction(
+    const at::Tensor& unreduced,
+    int64_t reduction,
+    std::optional<int64_t> dim = std::nullopt) {
+  if (reduction == at::Reduction::Mean) {
+    return dim.has_value() ? unreduced.mean(*dim) : unreduced.mean();
+  }
+  if (reduction == at::Reduction::Sum) {
+    return dim.has_value() ? unreduced.sum(*dim) : unreduced.sum();
+  }
+  return unreduced;
+}
+
 static std::tuple<Tensor, Tensor, int64_t, bool, VmapDimVector> multi_margin_loss_prepare_inputs(
     const Tensor& self,
     std::optional<int64_t> self_bdim,
@@ -86,7 +99,7 @@ static std::tuple<Tensor, Tensor, int64_t, bool, VmapDimVector> multi_margin_los
   target_ = ensure_has_bdim(target_, target_bdim.has_value(), bdim_size);
 
   const auto self_logical_rank = rankWithoutBatchDim(self, self_bdim);
-  TORCH_CHECK(
+  TORCH_CHECK_VALUE(
       self_logical_rank <= 2,
       "vmap: Expected input for multi_margin_loss to have logical rank <= 2, but got ",
       self_logical_rank);
@@ -132,13 +145,25 @@ static Tensor multi_margin_loss_restore_forward(
   if (nframe == 1) {
     return result_.squeeze(1);
   }
-  if (reduction == Reduction::Sum) {
-    return result_.sum(1);
-  }
-  if (reduction == Reduction::Mean) {
-    return result_.mean(1);
-  }
-  TORCH_INTERNAL_ASSERT(false);
+  return apply_loss_reduction(result_, reduction, /*dim=*/1);
+}
+
+// The native op takes weight as a single shared per-class vector (length nclass),
+// so it has no batch dim to absorb a batched weight. Its only effect is the scalar
+// factor weight[target] per frame, which we compute here to apply outside the op.
+static Tensor multi_margin_loss_per_frame_weight(
+    const Tensor& weight,
+    std::optional<int64_t> weight_bdim,
+    const Tensor& target_flat,
+    int64_t bdim_size,
+    int64_t nframe) {
+  auto weight_ = moveBatchDimToFront(weight, weight_bdim);
+  weight_ = ensure_has_bdim(weight_, weight_bdim.has_value(), bdim_size);
+  const auto nclass = weight_.size(-1);
+  auto weight_flat = weight_.unsqueeze(1)
+                         .expand({bdim_size, nframe, nclass})
+                         .reshape({bdim_size * nframe, nclass});
+  return weight_flat.gather(1, target_flat.unsqueeze(1)).squeeze(1);
 }
 
 static std::tuple<at::Tensor, std::optional<int64_t>>
@@ -152,16 +177,20 @@ multi_margin_loss_batch_rule(
     const std::optional<Tensor>& weight_opt,
     std::optional<int64_t> weight_bdim,
     int64_t reduction) {
-  TORCH_CHECK(
-      !weight_bdim.has_value(),
-      "vmap: batching over the weight argument of multi_margin_loss is not supported");
-
-  const auto bdim_size = get_bdim_size2(self, self_bdim, target, target_bdim);
-  auto [self_flat, target_flat, nframe, target_has_logical_dim, self_logical_sizes] =
+  const bool weight_batched = weight_bdim.has_value();
+  const auto bdim_size = weight_batched
+      ? get_bdim_size3(self, self_bdim, target, target_bdim, *weight_opt, weight_bdim)
+      : get_bdim_size2(self, self_bdim, target, target_bdim);
+  // forward does not need self_logical_sizes (only the backward reshapes grad_input to it)
+  [[maybe_unused]] auto [self_flat, target_flat, nframe, target_has_logical_dim, self_logical_sizes] =
       multi_margin_loss_prepare_inputs(self, self_bdim, target, target_bdim, bdim_size);
-  (void)self_logical_sizes;
   auto result = at::multi_margin_loss(
-      self_flat, target_flat, p, margin, weight_opt, Reduction::None);
+      self_flat, target_flat, p, margin,
+      weight_batched ? std::optional<Tensor>() : weight_opt, Reduction::None);
+  if (weight_batched) {
+    result = result * multi_margin_loss_per_frame_weight(
+                          *weight_opt, weight_bdim, target_flat, bdim_size, nframe);
+  }
   result = multi_margin_loss_restore_forward(
       result, bdim_size, nframe, target_has_logical_dim, reduction);
   return std::make_tuple(std::move(result), 0);
@@ -198,19 +227,24 @@ multi_margin_loss_backward_batch_rule(
     const std::optional<Tensor>& weight_opt,
     std::optional<int64_t> weight_bdim,
     int64_t reduction) {
-  TORCH_CHECK(
-      !weight_bdim.has_value(),
-      "vmap: batching over the weight argument of multi_margin_loss_backward is not supported");
-
-  const auto bdim_size = get_bdim_size3(
-      grad_output, grad_output_bdim, self, self_bdim, target, target_bdim);
-  auto [self_flat, target_flat, nframe, target_has_logical_dim, self_logical_sizes] =
+  const bool weight_batched = weight_bdim.has_value();
+  const auto bdim_size = weight_batched
+      ? get_bdim_size4(grad_output, grad_output_bdim, self, self_bdim, target, target_bdim, *weight_opt, weight_bdim)
+      : get_bdim_size3(grad_output, grad_output_bdim, self, self_bdim, target, target_bdim);
+  // backward does not need target_has_logical_dim (only the forward uses it to squeeze)
+  [[maybe_unused]] auto [self_flat, target_flat, nframe, target_has_logical_dim, self_logical_sizes] =
       multi_margin_loss_prepare_inputs(self, self_bdim, target, target_bdim, bdim_size);
-  (void)target_has_logical_dim;
   auto grad_output_flat = multi_margin_loss_prepare_grad_output(
       grad_output, grad_output_bdim, bdim_size, nframe, reduction);
   auto grad_input = at::multi_margin_loss_backward(
-      grad_output_flat, self_flat, target_flat, p, margin, weight_opt, Reduction::None);
+      grad_output_flat, self_flat, target_flat, p, margin,
+      weight_batched ? std::optional<Tensor>() : weight_opt, Reduction::None);
+  if (weight_batched) {
+    // weight scales every frame's whole gradient row by weight[target].
+    auto w = multi_margin_loss_per_frame_weight(
+        *weight_opt, weight_bdim, target_flat, bdim_size, nframe);
+    grad_input = grad_input * w.unsqueeze(1);
+  }
   if (reduction == Reduction::Mean && nframe > 1) {
     grad_input.div_(nframe);
   }
@@ -221,15 +255,6 @@ multi_margin_loss_backward_batch_rule(
   grad_input_shape.insert(grad_input_shape.end(), self_logical_sizes.begin(), self_logical_sizes.end());
   grad_input = grad_input.reshape(grad_input_shape);
   return std::make_tuple(std::move(grad_input), 0);
-}
-
-static Tensor apply_loss_reduction(const at::Tensor& unreduced, int64_t reduction) {
-  if (reduction == at::Reduction::Mean) {
-    return unreduced.mean();
-  } else if (reduction == at::Reduction::Sum) {
-    return unreduced.sum();
-  }
-  return unreduced;
 }
 
 static Tensor binary_cross_entropy_plumbing(

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1456,7 +1456,6 @@ class TestOperators(TestCase):
                 xfail("nn.functional.feature_alpha_dropout", "without_train"),
                 xfail("svd_lowrank", ""),
                 xfail("nn.functional.max_unpool2d", ""),
-                xfail("nn.functional.multi_margin_loss", ""),
                 xfail("nn.functional.multilabel_margin_loss", ""),
                 xfail("nn.functional.pdist", ""),
                 xfail("nn.functional.max_unpool1d", ""),

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -4703,7 +4703,6 @@ class TestVmapOperatorsOpInfo(TestCase):
                 xfail("nn.functional.triplet_margin_loss", ""),
                 xfail("nn.functional.pdist", ""),
                 xfail("nn.functional.max_unpool1d", "grad"),
-                xfail("nn.functional.multi_margin_loss", ""),
                 xfail("nn.functional.multilabel_margin_loss", ""),
                 xfail("nn.functional.max_unpool3d", "grad"),
                 xfail("nn.functional.max_unpool2d", ""),

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -1528,27 +1528,68 @@ class TestVmapOperators(Namespace.TestVmapBase):
     def _vmap_view_test(self, *args, **kwargs):
         self._vmap_test(*args, **kwargs, check_view=True)
 
-    def test_multi_margin_loss_batched_weight(self):
-        # multi_margin_loss's weight is a shared per-class vector, so the OpInfo
-        # vmap tests (which only batch positional args) never batch it. Cover the
-        # batched-weight path of its batch rule here against a for-loop reference.
+    # multi_margin_loss's weight is a shared per-class vector, so the OpInfo vmap
+    # tests (which only batch positional args) never batch it. Cover the
+    # batched-weight path of its batch rule here against a for-loop reference.
+    @parametrize("reduction", ["none", "mean", "sum"])
+    @parametrize("p", [1, 2])
+    @parametrize("case", ["rank2_weight_only", "rank2_all", "rank1"])
+    def test_multi_margin_loss_batched_weight(self, reduction, p, case):
         B, N, C = 2, 4, 5
-        # (batch_input, batch_target, batch_weight)
-        configs = [(False, False, True), (True, True, True)]
-        for reduction, p, (bi, bt, bw) in itertools.product(
-            ("none", "mean", "sum"), (1, 2), configs
-        ):
-            inp = torch.randn(B, N, C) if bi else torch.randn(N, C)
-            tgt = torch.randint(0, C, (B, N)) if bt else torch.randint(0, C, (N,))
-            wgt = torch.randn(B, C) if bw else torch.randn(C)
-            in_dims = (0 if bi else None, 0 if bt else None, 0 if bw else None)
+        if case == "rank1":  # logical rank 1 input -> nframe == 1 branch
+            inp = torch.randn(C)
+            tgt = torch.randint(0, C, ())
+            inp_bdim = None
+        elif case == "rank2_all":
+            inp = torch.randn(B, N, C)
+            tgt = torch.randint(0, C, (N,))
+            inp_bdim = 0
+        else:  # rank2_weight_only: only weight is batched
+            inp = torch.randn(N, C)
+            tgt = torch.randint(0, C, (N,))
+            inp_bdim = None
+        wgt = torch.randn(B, C)
 
-            def op(inp, tgt, wgt, p=p, reduction=reduction):
-                return F.multi_margin_loss(
-                    inp, tgt, p=p, weight=wgt, reduction=reduction
-                )
+        def op(i, w):
+            return F.multi_margin_loss(i, tgt, p=p, weight=w, reduction=reduction)
 
-            self._vmap_test(op, (inp, tgt, wgt), in_dims=in_dims)
+        expected = torch.stack(
+            [op(inp[b] if inp_bdim == 0 else inp, wgt[b]) for b in range(B)]
+        )
+        actual = vmap(op, in_dims=(inp_bdim, 0))(inp, wgt)
+        self.assertEqual(actual, expected)
+
+    # Exercises the backward batch rule's batched-weight path via vmap(grad),
+    # which the forward-only _vmap_test above does not reach.
+    @parametrize("reduction", ["mean", "sum"])
+    @parametrize("p", [1, 2])
+    def test_multi_margin_loss_batched_weight_backward(self, reduction, p):
+        B, N, C = 2, 4, 5
+        inp = torch.randn(N, C)
+        tgt = torch.randint(0, C, (N,))
+        wgt = torch.randn(B, C)
+
+        def loss(i, w):
+            return F.multi_margin_loss(i, tgt, p=p, weight=w, reduction=reduction)
+
+        grad_fn = grad(loss)  # grad wrt input
+        expected = torch.stack([grad_fn(inp, wgt[b]) for b in range(B)])
+        actual = vmap(grad_fn, in_dims=(None, 0))(inp, wgt)
+        self.assertEqual(actual, expected)
+
+    def test_multi_margin_loss_batched_weight_size_mismatch(self):
+        # A batched weight bypasses the native weight-size check, so the batch rule
+        # must re-validate; otherwise vmap silently gathers instead of erroring.
+        N, C = 4, 5
+        inp = torch.randn(N, C)
+        tgt = torch.randint(0, C, (N,))
+        wgt = torch.randn(2, C + 2)  # wrong number of classes
+
+        def op(w):
+            return F.multi_margin_loss(inp, tgt, weight=w, reduction="sum")
+
+        with self.assertRaisesRegex(RuntimeError, "inconsistent weight size"):
+            vmap(op)(wgt)
 
     def _test_unary(self, op, getter, device, *args, **kwargs):
         test = functools.partial(self._vmap_test, *args, **kwargs)

--- a/test/functorch/test_vmap.py
+++ b/test/functorch/test_vmap.py
@@ -1528,6 +1528,28 @@ class TestVmapOperators(Namespace.TestVmapBase):
     def _vmap_view_test(self, *args, **kwargs):
         self._vmap_test(*args, **kwargs, check_view=True)
 
+    def test_multi_margin_loss_batched_weight(self):
+        # multi_margin_loss's weight is a shared per-class vector, so the OpInfo
+        # vmap tests (which only batch positional args) never batch it. Cover the
+        # batched-weight path of its batch rule here against a for-loop reference.
+        B, N, C = 2, 4, 5
+        # (batch_input, batch_target, batch_weight)
+        configs = [(False, False, True), (True, True, True)]
+        for reduction, p, (bi, bt, bw) in itertools.product(
+            ("none", "mean", "sum"), (1, 2), configs
+        ):
+            inp = torch.randn(B, N, C) if bi else torch.randn(N, C)
+            tgt = torch.randint(0, C, (B, N)) if bt else torch.randint(0, C, (N,))
+            wgt = torch.randn(B, C) if bw else torch.randn(C)
+            in_dims = (0 if bi else None, 0 if bt else None, 0 if bw else None)
+
+            def op(inp, tgt, wgt, p=p, reduction=reduction):
+                return F.multi_margin_loss(
+                    inp, tgt, p=p, weight=wgt, reduction=reduction
+                )
+
+            self._vmap_test(op, (inp, tgt, wgt), in_dims=in_dims)
+
     def _test_unary(self, op, getter, device, *args, **kwargs):
         test = functools.partial(self._vmap_test, *args, **kwargs)
         B0, B1 = 7, 11


### PR DESCRIPTION
Fixes #139241

Adds batching rules for `aten::multi_margin_loss` and
`aten::multi_margin_loss_backward`.

Previously, using `vmap` with `torch.nn.functional.multi_margin_loss`
or per-example gradients through it could hit missing batching rule warnings.
This patch handles batched `self`/`target` inputs by moving the vmap batch
dimension to the front, flattening the logical input into the native loss
shape, calling the existing `multi_margin_loss` implementation with
`Reduction::None`, then restoring the expected logical output shape and
applying reduction without reducing over the vmap dimension.

The backward rule mirrors the same logical flattening and calls the native
`multi_margin_loss_backward` implementation.

This intentionally does not add support for batching over the `weight`
argument. `weight=None` and shared/unbatched `weight` are supported.

Test plan:
- `python3 test/functorch/test_ops.py -k multi_margin_loss`
- `python3 test/functorch/test_vmap.py -k multi_margin_loss`
- `python3 test/functorch/test_vmap_registrations.py`
- `python3 /Users/vineet/projects/issues/repro_pytorch_139241_vmap_multi_margin_loss.py`
- `git diff --check`

cc @Chillee @samdow @kshitij12345