### PR TITLE
Fix device-dependent kernel count in test_combo_kernel_split_large_reductions

### DIFF
--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1243,7 +1243,7 @@ class ComboKernelTests(TestCase):
     def test_combo_kernel_split_large_reductions(self):
         # squeezenet1_1 backward (combo regression sum_sum_8bcd6e12dcd4):
         # two very large reductions (sum over [0,2,3] of [512,64,55,55]) must NOT be
-        # co-fused into one combo kernel -- each is split out (5 kernels, vs 4 if fused).
+        # co-fused into one combo kernel -- each is split out into its own kernel.
         import torch._inductor.inductor_prims
 
         class Model(torch.nn.Module):
@@ -1289,10 +1289,21 @@ class ComboKernelTests(TestCase):
         torch._dynamo.reset()
         torch._inductor.metrics.reset()
         out_eager = m(*inps)
-        out_compiled = torch.compile(m)(*inps)
+        with fresh_cache():
+            out_compiled, code = run_and_get_code(torch.compile(m), *inps)
         torch.testing.assert_close(out_eager, out_compiled, rtol=1e-4, atol=1e-4)
-        # Very-large reductions split out instead of co-fused: 5 kernels (4 = the regression).
-        self.assertEqual(torch._inductor.metrics.generated_kernel_count, 5)
+        # The total kernel count is device dependent: reduction_split_factor only
+        # splits these 64-output reductions into a second phase when
+        # 2 * multi_processor_count > 64, so a low-SM GPU legitimately emits one
+        # kernel fewer. Assert the invariant instead -- each very-large reduction
+        # (the same numel gate the partitioner uses) gets a kernel of its own.
+        # Co-fusing them emits both sub-kernels in a single async_compile block.
+        separated = 0
+        for kernel_src in " ".join(code).split("async_compile.triton(")[1:]:
+            numels = re.findall(r"xnumel = (\d+)\s+r0_numel = (\d+)", kernel_src)
+            if any(int(x) * int(r) > LARGE_NUMELS for x, r in numels):
+                separated += 1
+        self.assertEqual(separated, 2)
 
     @requires_gpu_and_triton
     @skipIfXpu(

--- a/test/inductor/test_combo_kernels.py
+++ b/test/inductor/test_combo_kernels.py
@@ -1287,7 +1287,6 @@ class ComboKernelTests(TestCase):
 
         m = Model()
         torch._dynamo.reset()
-        torch._inductor.metrics.reset()
         out_eager = m(*inps)
         with fresh_cache():
             out_compiled, code = run_and_get_code(torch.compile(m), *inps)


### PR DESCRIPTION
`test_combo_kernel_split_large_reductions` fails on Intel BMG with `Expected 5 but got 4` while passing on PVC.

## Root cause

The test was added in #186668 together with the `very_large_reduction` partitioning rule it guards: the two very large reductions (sum over `[0,2,3]` of `[512,64,55,55]`) must not be co-fused into one combo kernel. It asserts that invariant indirectly, via an absolute total kernel count (`generated_kernel_count == 5`), and one of those 5 kernels comes from an unrelated, SM-count-dependent heuristic.

Both reductions have `numel=64`, `rnumel=1548800`. `InductorChoices.reduction_split_factor` (`torch/_inductor/choices.py:580`) returns 1 once `numel_hint >= 2 * multi_processor_count`. BMG reports `multi_processor_count=20`, so `64 >= 40` holds and neither reduction is split. A 64-SM part makes the same call return 12: each reduction becomes a partial + final pair, the two small finals co-fuse, and the total reaches 5. The asserted 5 is unreachable on a 20-SM GPU.

The total also cannot distinguish correct from regressed codegen there:

|                 | correct codegen | co-fused (the regression) |
|-----------------|-----------------|---------------------------|
| BMG (20 SM)     | **4**           | 3                         |
| PVC-sim (64 SM) | **5**           | 4                         |

So 4 — which the old comment labelled "the regression" — is BMG's *correct* value. The guarded behaviour itself is intact on BMG: instrumenting `_default_custom_combo_kernel_horizontal_partition` shows the two reductions landing in separate partitions `[['op2'], ['op3']]`, exactly as the comment requires.

## Fix

Assert the invariant directly instead of a proxy for it: count the generated kernels that contain a very large reduction, using the same `xnumel * rnumel > LARGE_NUMELS` gate the partitioner itself applies, and require exactly 2.

`xnumel * rnumel` is conserved when a reduction is split — both the unsplit kernel (`64 * 1548800`) and the partial (`768 * 129067`) carry the graph's ~99.1M element total — so the count does not depend on `multi_processor_count`. Co-fusion emits both sub-kernels inside a single `async_compile.triton` block, dropping the count to 1 on every configuration, so the regression is still caught. `fresh_cache()` is added because the assertion reads generated code, the same pattern the neighbouring `run_and_get_code` tests in this file use.

The test is defined once and inherited by `ComboKernelTestsPerSubkernelBlocks`, so one edit covers both failing node ids.

## Test plan

On an Intel BMG GPU (Arc Pro B60, `multi_processor_count=20`), both node ids:

```bash
pytest -sv test/inductor/test_combo_kernels.py -k "test_combo_kernel_split_large_reductions"
```

| Configuration | Result |
|---|---|
| Fixed test | **2 passed** (was: 2 failed, `Expected 5 but got 4`) |
| Regression reintroduced (co-fusion re-enabled) | **2 failed**, `Expected 2 but got 1` |
| PVC-sim (`multi_processor_count=64`), correct codegen | **2 passed** |
| PVC-sim, regression reintroduced | **2 failed** |

The full 2x2 matrix of {BMG, PVC-sim} x {correct, regressed} agrees, so the new assertion is device independent and keeps its regression power. Co-fusion was reintroduced by raising only the partitioner's `LARGE_NUMELS`, after the test module had already bound the real `51_200_000` for its own gate.

`lintrunner -a test/inductor/test_combo_kernels.py` reports no issues.

Fixes https://github.com/intel/torch-xpu-ops/issues/5079

<sub>This change was authored with the assistance of an AI coding agent (Claude).</sub>


cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
