### PR TITLE
[Testcase Refactoring] Refactor test_ctx_manager.py for test cases classification and device generalization--part1

### DIFF
--- a/test/dynamo/test_ctx_manager.py
+++ b/test/dynamo/test_ctx_manager.py
@@ -16,16 +16,18 @@ from torch._dynamo.testing import (
 )
 from torch._dynamo.utils import counters
 from torch.nn import functional as F
-from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_device_type import (
+    Capability,
     instantiate_device_type_tests,
-    onlyCUDA,
+    requires_capabilities,
 )
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     instantiate_parametrized_tests,
     parametrize,
+    skipIfXpu,
 )
-from torch.testing._internal.triton_utils import requires_cuda_and_triton
+from torch.testing._internal.inductor_utils import HAS_TRITON
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
@@ -90,6 +92,8 @@ def customized_ctx_manager_with_graph_break(mode):
 
 
 class CtxManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_no_grad(self):
         def fn1(a, b):
             x = a + 1
@@ -260,67 +264,6 @@ class CtxManagerTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         res = opt_fn(a, b)
         self.assertTrue(same(ref, res))
-
-    @unittest.skipIf(
-        not PLATFORM_SUPPORTS_FLASH_ATTENTION,
-        "Can't run fused SDPA on this platform",
-    )
-    def test_autocast_sdpa(self):
-        class MyModule(torch.nn.Module):
-            def forward(self, query, key, value):
-                with torch.autocast("cpu"):
-                    with torch.autocast(device_type, dtype=torch.float32):
-                        out = F.scaled_dot_product_attention(
-                            query, key, value, None, 0.0, True
-                        )
-                return out
-
-        dtype = torch.float32
-        seq_len_q = 1
-        seq_len_k = 1
-        head_dim = 8
-        query = torch.ones(
-            1,
-            8,
-            seq_len_q,
-            head_dim,
-            device=device_type,
-            dtype=dtype,
-            requires_grad=True,
-        )
-        key = torch.ones(
-            1,
-            8,
-            seq_len_k,
-            head_dim,
-            device=device_type,
-            dtype=dtype,
-            requires_grad=True,
-        )
-        value = torch.ones(
-            1,
-            8,
-            seq_len_k,
-            head_dim,
-            device=device_type,
-            dtype=dtype,
-            requires_grad=True,
-        )
-
-        module = MyModule()
-        real = module(query, key, value)
-        real_device = real.device
-        real_dtype = real.dtype
-
-        opt_mod = torch.compile(module, backend="inductor")
-        compiled = opt_mod(query, key, value)
-
-        self.assertEqual(compiled.device, real_device)
-        self.assertEqual(compiled.dtype, real_dtype)
-
-        self.assertEqual(compiled.device.type, device_type)
-        self.assertEqual(compiled.device.index, 0)
-        self.assertEqual(compiled.dtype, torch.float32)
 
     def test_autocast_cpu(self):
         class MyModule(torch.nn.Module):
@@ -1103,37 +1046,6 @@ class GraphModule(torch.nn.Module):
         opt_fn(x, y, z).sum().backward()
 
         self.assertEqual(cnts.frame_count, 2)
-
-    def _graph_break_inlining_autocast_test_helper(self, device):
-        def gn(x, y):
-            with torch.autocast(device_type=device, dtype=torch.bfloat16):
-                z = torch.mm(x, y)
-                torch._dynamo.graph_break()
-                return torch.sin(z)
-
-        def fn(x, y):
-            z = torch.mm(x, y)
-            z = z + gn(x, y)
-            return z
-
-        x = torch.rand(3, 3).to(device)
-        y = torch.rand(3, 3).to(device)
-        opt_fn = torch.compile(backend="eager")(fn)
-        ref = fn(x, y)
-        res = opt_fn(x, y)
-        self.assertEqual(ref, res)
-
-    def test_graph_break_inlining_autocast(self):
-        for device in ["cuda", "cpu", "xpu"]:
-            if device == "cuda" and not (
-                torch.cuda.is_available() and torch.cuda.is_bf16_supported()
-            ):
-                continue
-            if device == "xpu" and not (
-                torch.xpu.is_available() and torch.xpu.is_bf16_supported()
-            ):
-                continue
-            self._graph_break_inlining_autocast_test_helper(device)
 
     def test_disable_saved_tensors_hooks(self):
         def fn(z):
@@ -2083,9 +1995,7 @@ class GraphModule(torch.nn.Module):
         ):
             ContextWrappingVariable(target_values={"key": "val"})
 
-
-class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
-    def test_cuda_use_mem_pool_fx_cse_preserves_distinct_contexts(self):
+    def test_fx_cse_preserves_distinct_contexts(self):
         from torch._functorch.compile_utils import fx_graph_cse
 
         graph = torch.fx.Graph()
@@ -2104,12 +2014,16 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         ]
         self.assertEqual(len(add_nodes), 2)
 
-    def _check_cuda_use_mem_pool(self, backend=None):
+
+class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    def _check_cuda_use_mem_pool(self, device, backend=None):
         torch.cuda.empty_cache()
 
         def fn(pool):
             with torch.cuda.use_mem_pool(pool):
-                return torch.ones(16, device="cuda") + 1
+                return torch.ones(16, device=device) + 1
 
         pool = torch.cuda.MemPool()
         opt_fn = (
@@ -2119,16 +2033,14 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         )
         res = opt_fn(pool)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((16,), 2.0, device="cuda"))
+        self.assertEqual(res, torch.full((16,), 2.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_use_mem_pool_context_manager(self):
-        self._check_cuda_use_mem_pool(backend="eager")
+    def test_cuda_use_mem_pool_context_manager(self, device):
+        self._check_cuda_use_mem_pool(device, backend="eager")
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_mem_pool_id(self):
+    def test_cuda_mem_pool_id(self, device):
         def fn(pool):
             return pool.id
 
@@ -2136,15 +2048,15 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         opt_fn = torch.compile(fn, backend="eager", fullgraph=True)
         self.assertEqual(opt_fn(pool), pool.id)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_context_manager_inductor(self):
-        self._check_cuda_use_mem_pool()
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_context_manager_inductor(self, device):
+        self._check_cuda_use_mem_pool(device)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_cpp_wrapper_unsupported(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_cpp_wrapper_unsupported(self, device):
         def fn(pool):
             with torch.cuda.use_mem_pool(pool):
-                return torch.ones(16, device="cuda")
+                return torch.ones(16, device=device)
 
         pool = torch.cuda.MemPool()
         with (
@@ -2162,8 +2074,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         ):
             torch.compile(fn, backend="inductor", fullgraph=True)(pool)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_realize_at_boundary_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_realize_at_boundary_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, inp):
@@ -2172,15 +2084,15 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
             return x + 1
 
         pool = torch.cuda.MemPool()
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool, inp)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((16,), 3.0, device="cuda"))
+        self.assertEqual(res, torch.full((16,), 3.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_fallback_alloc_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_fallback_alloc_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, inp):
@@ -2188,15 +2100,15 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 return torch.histc(inp, bins=4, min=0, max=4)
 
         pool = torch.cuda.MemPool()
-        inp = torch.arange(16, device="cuda", dtype=torch.float32) % 4
+        inp = torch.arange(16, device=device, dtype=torch.float32) % 4
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool, inp)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((4,), 4.0, device="cuda"))
+        self.assertEqual(res, torch.full((4,), 4.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_foreach_alloc_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_foreach_alloc_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, xs):
@@ -2205,18 +2117,18 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
 
         pool = torch.cuda.MemPool()
         xs = [
-            torch.ones(64, device="cuda"),
-            torch.full((64,), 2.0, device="cuda"),
+            torch.ones(64, device=device),
+            torch.full((64,), 2.0, device=device),
         ]
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool, xs)
         torch.cuda.synchronize()
-        self.assertEqual(res[0], torch.full((64,), 2.0, device="cuda"))
-        self.assertEqual(res[1], torch.full((64,), 3.0, device="cuda"))
+        self.assertEqual(res[0], torch.full((64,), 2.0, device=device))
+        self.assertEqual(res[1], torch.full((64,), 3.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_forced_extern_multi_template_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_forced_extern_multi_template_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, x, y):
@@ -2224,8 +2136,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 return x @ y
 
         pool = torch.cuda.MemPool()
-        x = torch.randn(32, 32, device="cuda")
-        y = torch.randn(32, 32, device="cuda")
+        x = torch.randn(32, 32, device=device)
+        y = torch.randn(32, 32, device=device)
         with torch._inductor.config.patch(
             {
                 "test_configs.force_extern_kernel_in_multi_template": True,
@@ -2243,8 +2155,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_nested_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_nested_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(outer_pool, inner_pool, inp):
@@ -2257,20 +2169,20 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
 
         outer_pool = torch.cuda.MemPool()
         inner_pool = torch.cuda.MemPool()
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         outer, inner = torch.compile(fn, backend="inductor", fullgraph=True)(
             outer_pool, inner_pool, inp
         )
         torch.cuda.synchronize()
-        self.assertEqual(outer, torch.full((16,), 5.0, device="cuda"))
-        self.assertEqual(inner, torch.full((16,), 3.0, device="cuda"))
+        self.assertEqual(outer, torch.full((16,), 5.0, device=device))
+        self.assertEqual(inner, torch.full((16,), 3.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(outer_pool.id)), 0)
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(inner_pool.id)), 0)
         self.assertEqual(outer_pool.use_count(), 1)
         self.assertEqual(inner_pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_distinct_pools_not_cse_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_distinct_pools_not_cse_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool_a, pool_b, inp):
@@ -2282,17 +2194,17 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
 
         pool_a = torch.cuda.MemPool()
         pool_b = torch.cuda.MemPool()
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         res = torch.compile(fn, backend="inductor", fullgraph=True)(pool_a, pool_b, inp)
         torch.cuda.synchronize()
-        self.assertEqual(res, torch.full((16,), 4.0, device="cuda"))
+        self.assertEqual(res, torch.full((16,), 4.0, device=device))
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool_a.id)), 0)
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool_b.id)), 0)
         self.assertEqual(pool_a.use_count(), 1)
         self.assertEqual(pool_b.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_reduce_overhead_cudagraph_asserts_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_reduce_overhead_cudagraph_asserts_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool, x, w):
@@ -2300,8 +2212,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 return (x @ w).relu()
 
         pool = torch.cuda.MemPool()
-        x = torch.randn(64, 64, device="cuda")
-        w = torch.randn(64, 64, device="cuda")
+        x = torch.randn(64, 64, device=device)
+        w = torch.randn(64, 64, device=device)
         with torch._inductor.config.patch({"triton.slow_path_cudagraph_asserts": True}):
             opt_fn = torch.compile(
                 fn, backend="inductor", mode="reduce-overhead", fullgraph=True
@@ -2314,8 +2226,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
         self.assertGreater(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @requires_cuda_and_triton
-    def test_cuda_use_mem_pool_stream_order_inductor(self):
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
+    def test_cuda_use_mem_pool_stream_order_inductor(self, device):
         from torch._inductor.utils import run_and_get_code
 
         torch.cuda.empty_cache()
@@ -2330,7 +2242,7 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 with torch.cuda.use_mem_pool(pool):
                     return inp + 2
 
-        inp = torch.ones(16, device="cuda")
+        inp = torch.ones(16, device=device)
         stream = torch.cuda.Stream()
         for fn in (pool_outer, stream_outer):
             with self.subTest(fn=fn.__name__):
@@ -2355,47 +2267,46 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 stream_enter = source.index("with stream")
                 self.assertLess(mempool_enter, stream_enter)
 
-    @requires_cuda_and_triton
+    @unittest.skipIf(not HAS_TRITON, "requires triton")
     @unittest.skipIf(torch.cuda.device_count() < 2, "requires multiple cuda devices")
-    def test_cuda_use_mem_pool_device_none_resolves_at_entry_inductor(self):
+    def test_cuda_use_mem_pool_device_none_resolves_at_entry_inductor(self, device):
         torch.cuda.empty_cache()
 
         def fn(pool):
             with torch.cuda.use_mem_pool(pool):
-                return torch.ones(16, device="cuda:0")
+                return torch.ones(16, device=device)
 
         with torch.cuda.device(1):
             pool = torch.cuda.MemPool()
             res = torch.compile(fn, backend="inductor", fullgraph=True)(pool)
         torch.cuda.synchronize(0)
         torch.cuda.synchronize(1)
-        self.assertEqual(res, torch.ones(16, device="cuda:0"))
+        self.assertEqual(res, torch.ones(16, device=device))
         self.assertEqual(len(torch.cuda.memory.memory_snapshot(pool.id)), 0)
         self.assertEqual(pool.use_count(), 1)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_use_mem_pool_invalid_signatures(self):
+    def test_cuda_use_mem_pool_invalid_signatures(self, device):
         pool = torch.cuda.MemPool()
 
-        def missing(_pool):
+        def missing(_pool, device):
             with torch.cuda.use_mem_pool():
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def too_many(pool):
+        def too_many(pool, device):
             with torch.cuda.use_mem_pool(pool, None, None):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def unexpected_kwarg(pool):
+        def unexpected_kwarg(pool, device):
             with torch.cuda.use_mem_pool(pool, foo=None):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def duplicate_pool(pool):
+        def duplicate_pool(pool, device):
             with torch.cuda.use_mem_pool(pool, pool=pool):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
-        def duplicate_device(pool):
+        def duplicate_device(pool, device):
             with torch.cuda.use_mem_pool(pool, None, device=None):
-                return torch.ones(1, device="cuda")
+                return torch.ones(1, device=device)
 
         cases = [
             (missing, "missing 1 required positional argument: 'pool'"),
@@ -2412,206 +2323,10 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
                 self.subTest(msg=msg),
                 self.assertRaisesRegex(torch._dynamo.exc.Unsupported, msg),
             ):
-                torch.compile(fn, backend="eager", fullgraph=True)(pool)
+                torch.compile(fn, backend="eager", fullgraph=True)(pool, device)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager1(self):
-        def fn(x):
-            s = torch.cuda.Stream()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-            with torch.cuda.stream(s):
-                x = torch.relu(x)
-            current_stream.wait_stream(s)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
 
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """9""")
-
-    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_across_graph_break(self):
-        def fn(x):
-            s = torch.cuda.Stream()
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            print("foo")
-
-            tcs = torch.cuda.stream(s)
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-
-            with tcs:
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(cnts.op_count, 9)
-
-    @unittest.expectedFailure  # https://github.com/pytorch/pytorch/issues/118204
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_context_manager2(self):
-        def fn(x, s):
-            x = torch.mul(x, 5)
-            x = torch.add(x, 2)
-
-            current_stream = torch.cuda.current_stream()
-            s.wait_stream(current_stream)
-
-            with torch.cuda.stream(s):
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s)
-            with torch.cuda.stream(current_stream):
-                x = torch.relu(x)
-
-            s2 = torch.cuda.Stream()
-            s2.wait_stream(current_stream)
-            with torch.cuda.stream(s2):
-                x = torch.relu(x)
-
-            current_stream.wait_stream(s2)
-            x = torch.add(x, 1)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        s = torch.cuda.Stream()
-        ref = fn(x, s)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x, s)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(cnts.op_count, 18)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_method(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            new_stream = torch.cuda.Stream()
-            cur_stream = torch.cuda.current_stream()
-            new_stream.wait_stream(cur_stream)
-
-            with torch.cuda.stream(new_stream):
-                x = torch.sin(x)
-                x = torch.add(x, 3)
-
-            cur_stream.wait_stream(new_stream)
-
-            x = torch.add(x, 4)
-            cur_stream.query()
-            cur_stream.synchronize()
-
-            with torch.cuda.stream(new_stream):
-                x = torch.add(x, 5)
-            new_stream.synchronize()
-
-            x = torch.relu(x)
-            x = torch.cos(x)
-            return x
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertExpectedInline(str(cnts.op_count), """15""")
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_constant(self):
-        def fn(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            if cur_stream is not None:
-                return x + 1
-            return x - 1
-
-        def fn2(x):
-            x = torch.mul(x, 1)
-            x = torch.add(x, 2)
-
-            cur_stream = torch.cuda.current_stream()
-            if cur_stream != "const_str":
-                return x + 1
-            return x - 1
-
-        x = torch.randn((2, 2), device="cuda")
-        ref = fn(x)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-        opt_fn2 = torch.compile(fn2, backend=cnts, fullgraph=True)
-        res = opt_fn(x)
-        res2 = opt_fn2(x)
-        self.assertEqual(ref, res)
-        self.assertEqual(ref, res2)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
-    def test_cuda_stream_compared_with_stream(self):
-        def fn(x, s0, s1):
-            if s0 == s1:
-                return x + 1
-            else:
-                return x - 1
-
-        s0 = torch.cuda.Stream()
-        s1 = torch.cuda.Stream()
-        x = torch.randn(2, 2)
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-
-        ref0 = fn(x, s0, s1)
-        res0 = opt_fn(x, s0, s1)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(ref0, res0)
-
-        ref1 = fn(x, s1, s1)
-        res1 = opt_fn(x, s1, s1)
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(ref1, res1)
-
-        torch._dynamo.reset()
-        cnts = torch._dynamo.testing.CompileCounter()
-        opt_fn = torch.compile(fn, backend=cnts, fullgraph=True)
-
-        ref1 = fn(x, s1, s1)
-        res1 = opt_fn(x, s1, s1)
-        self.assertEqual(cnts.frame_count, 1)
-        self.assertEqual(ref1, res1)
-
-        ref0 = fn(x, s0, s1)
-        res0 = opt_fn(x, s0, s1)
-        self.assertEqual(cnts.frame_count, 2)
-        self.assertEqual(ref0, res0)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "requires cuda")
+class CUDACtxManagerTestsPart(torch._dynamo.test_case.TestCase):
     @unittest.skip(
         "Will not support external events for now: https://github.com/pytorch/pytorch/issues/167257"
     )
@@ -2969,6 +2684,8 @@ class CUDACtxManagerTests(torch._dynamo.test_case.TestCase):
 
 
 class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
     def test_stream_context_manager1(self, device):
         def fn(x):
             s = torch.Stream(device=device)
@@ -3328,11 +3045,8 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         res = opt_fn(x)
         self.assertEqual(ref, res)
 
-    @onlyCUDA
+    @requires_capabilities(Capability.dtype.bf16)
     def test_autocast_bf16(self, device):
-        if not torch.cuda.is_bf16_supported():
-            raise unittest.SkipTest("requires bf16")
-
         device_type = torch.device(device).type
 
         class MyModule(torch.nn.Module):
@@ -3361,7 +3075,7 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.dtype, torch.bfloat16)
 
     # autocast with float64 not support on XPU
-    @onlyCUDA
+    @skipIfXpu
     def test_amp_autocast(self, device):
         device_type = torch.device(device).type
 
@@ -3388,7 +3102,7 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertEqual(exported.device.index, 0)
         self.assertEqual(exported.dtype, torch.float64)
 
-    @onlyCUDA
+    @skipIfXpu
     def test_autocast_float64(self, device):
         device_type = torch.device(device).type
 
@@ -3509,8 +3223,97 @@ class CtxManagerTestsDevice(torch._dynamo.test_case.TestCase):
         self.assertTrue(res[0].dtype == torch.float16)
         self.assertTrue(res[1].dtype == torch.float16)
 
+    @requires_capabilities(Capability.attention.flash_attention)
+    def test_autocast_sdpa(self, device):
+        device_type = torch.device(device).type
+
+        class MyModule(torch.nn.Module):
+            def forward(self, query, key, value):
+                with torch.autocast("cpu"):
+                    with torch.autocast(device_type, dtype=torch.float32):
+                        out = F.scaled_dot_product_attention(
+                            query, key, value, None, 0.0, True
+                        )
+                return out
+
+        dtype = torch.float32
+        seq_len_q = 1
+        seq_len_k = 1
+        head_dim = 8
+        query = torch.ones(
+            1,
+            8,
+            seq_len_q,
+            head_dim,
+            device=device_type,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        key = torch.ones(
+            1,
+            8,
+            seq_len_k,
+            head_dim,
+            device=device_type,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        value = torch.ones(
+            1,
+            8,
+            seq_len_k,
+            head_dim,
+            device=device_type,
+            dtype=dtype,
+            requires_grad=True,
+        )
+
+        module = MyModule()
+        real = module(query, key, value)
+        real_device = real.device
+        real_dtype = real.dtype
+
+        opt_mod = torch.compile(module, backend="inductor")
+        compiled = opt_mod(query, key, value)
+
+        self.assertEqual(compiled.device, real_device)
+        self.assertEqual(compiled.dtype, real_dtype)
+
+        self.assertEqual(compiled.device.type, device_type)
+        self.assertEqual(compiled.device.index, 0)
+        self.assertEqual(compiled.dtype, torch.float32)
+
+
+class DeviceCtxManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    def _graph_break_inlining_autocast_test_helper(self, device):
+        def gn(x, y):
+            with torch.autocast(device_type=device, dtype=torch.bfloat16):
+                z = torch.mm(x, y)
+                torch._dynamo.graph_break()
+                return torch.sin(z)
+
+        def fn(x, y):
+            z = torch.mm(x, y)
+            z = z + gn(x, y)
+            return z
+
+        x = torch.rand(3, 3).to(device)
+        y = torch.rand(3, 3).to(device)
+        opt_fn = torch.compile(backend="eager")(fn)
+        ref = fn(x, y)
+        res = opt_fn(x, y)
+        self.assertEqual(ref, res)
+
+    @requires_capabilities(Capability.dtype.bf16)
+    def test_graph_break_inlining_autocast(self, device):
+        self._graph_break_inlining_autocast_test_helper(device)
+
 
 class ContextlibContextManagerTests(torch._dynamo.test_case.TestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self._prev = torch._dynamo.config.enable_trace_contextlib
@@ -4475,6 +4278,8 @@ instantiate_parametrized_tests(ContextlibContextManagerTests)
 instantiate_device_type_tests(
     CtxManagerTestsDevice, globals(), except_for=("cpu",), allow_xpu=True
 )
+instantiate_device_type_tests(DeviceCtxManagerTests, globals(), allow_xpu=True)
+instantiate_device_type_tests(CUDACtxManagerTests, globals(), only_for="cuda")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR decouples test/dynamo/test_ctx_manager.py from specific hardware accelerators by splitting tests into hardware-classified classes (GENERIC, ACCELERATOR, CUDA) and replacing hardcoded CUDA APIs with device-parameterized equivalents.

## Changes

- Tagged `CtxManagerTests` as `HardwareClassification.GENERIC`, `CUDACtxManagerTests` as `HardwareClassification.CUDA`, `CtxManagerTestsDevice` as `HardwareClassification.ACCELERATOR`, `DeviceCtxManagerTests ` as `HardwareClassification.ACCELERATOR`, and `ContextlibContextManagerTests` as `HardwareClassification.GENERIC`.
- Moved `test_autocast_sdpa` from `CtxManagerTests` to `CtxManagerTestsDevice` with a `device` parameter and moved `test_graph_break_inlining_autocast` from `CtxManagerTests` to `DeviceCtxManagerTests` with a `device` parameter ; guarded SDPA with `@requires_capabilities(Capability.attention.flash_attention)`.
- Moved `test_fx_cse_preserves_distinct_contexts` from `CUDACtxManagerTests` into `CtxManagerTests` since it does not require CUDA.
- Removed six CUDA stream tests (`test_cuda_stream_context_manager1`, `test_cuda_stream_across_graph_break`, `test_cuda_stream_context_manager2`, `test_cuda_stream_method`, `test_cuda_stream_compared_with_constant`, `test_cuda_stream_compared_with_stream`) already covered by device-parameterized tests in `CtxManagerTestsDevice`.

| Removed CUDA test cases | corresponding ACCELERATOR test cases |
| ----------- | ----------- |
| test_cuda_stream_context_manager1 | test_stream_context_manager1  |
| test_cuda_stream_across_graph_break | test_stream_across_graph_break  | 
| test_cuda_stream_context_manager2 | test_stream_context_manager2 |
| test_cuda_stream_method | test_stream_method |
| test_cuda_stream_compared_with_constant | test_stream_compared_with_constant |
| test_cuda_stream_compared_with_stream | test_stream_compared_with_stream |

- Converted `CUDACtxManagerTests` to use `instantiate_device_type_tests(CUDACtxManagerTests, globals(), only_for="cuda")` so all methods receive a `device` parameter and use `device` instead of hardcoded `"cuda"`.
- Replaced `@requires_cuda_and_triton` with `@unittest.skipIf(not HAS_TRITON, "requires triton")` and switched the import from `triton_utils` to `inductor_utils`.
- Replaced `@onlyCUDA` on `test_autocast_bf16` with `@requires_capabilities(Capability.dtype.bf16)` and removed the manual `is_bf16_supported()` check.
- Replaced `@onlyCUDA` on `test_amp_autocast` and `test_autocast_float64` with `@skipIfXpu`.
- Removed `PLATFORM_SUPPORTS_FLASH_ATTENTION` import; removed `onlyCUDA` import.
- Some test cases from `CUDACtxManagerTests` have been extracted into the `CUDACtxManagerTestsPart` test class and are not subject to changes this time.

## Notes

- For the complete modifications to the test_structured_trace.py file, please refer to [#193088](https://github.com/pytorch/pytorch/pull/193088). Since the changes involve a large number of lines, some modifications have been split into this PR to facilitate review and merging.
- This is part of the test case refactoring initiative tracked in [Test] PyTorch Test Case Refactoring and Track https://github.com/pytorch/pytorch/issues/185590

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98