### PR TITLE
[Testcase Refactoring] Split TestShardingSpec into GENERIC/ACCELERATOR classes and decouple from CUDA hardcoding

### DIFF
--- a/test/distributed/_shard/sharding_spec/test_sharding_spec.py
+++ b/test/distributed/_shard/sharding_spec/test_sharding_spec.py
@@ -24,11 +24,13 @@ from torch.distributed._shard.sharding_spec._internals import (
     get_split_size,
     validate_non_overlapping_shards_metadata,
 )
-from torch.testing._internal.common_cuda import TEST_MULTIGPU
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
 from torch.testing._internal.common_distributed import requires_nccl, skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     run_tests,
     skip_but_pass_in_sandcastle_if,
+    TEST_MULTIACCELERATOR,
     TestCase,
 )
 from torch.testing._internal.distributed._shard.sharded_tensor import (
@@ -41,227 +43,7 @@ from torch.testing._internal.distributed._shard.sharded_tensor._test_st_common i
 
 
 class TestShardingSpec(TestCase):
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
-    def test_device_placement(self):
-        # valid devices
-        DevicePlacementSpec("cuda:0")
-        DevicePlacementSpec(torch.device(0))
-        DevicePlacementSpec(torch.device("cuda:0"))
-        DevicePlacementSpec("rank:0/cuda:0")
-        DevicePlacementSpec("rank:0/cpu")
-        DevicePlacementSpec("rank:0")
-
-        # invalid devices
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            DevicePlacementSpec("cuda:foo")
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            DevicePlacementSpec("foo:0")
-        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            DevicePlacementSpec("rank:0/cuda:foo")
-        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            DevicePlacementSpec("rank:0/cpu2")
-
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
-    def test_chunked_sharding_spec(self):
-        # Test valid specs.
-        ChunkShardingSpec(0, [torch.device(0), torch.device(1)])
-        ChunkShardingSpec(0, [torch.device("cuda:0"), torch.device("cuda:1")])
-        ChunkShardingSpec(-1, ["cuda:0", "cuda:1"])
-        ChunkShardingSpec(0, ["rank:0/cuda:0", "rank:0/cuda:1"])
-        ChunkShardingSpec(0, ["rank:0", "rank:1"])
-        ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
-
-        # Test unimplemented error
-        with self.assertRaisesRegex(NotImplementedError, "not support named dimension"):
-            # Named dimension.
-            ChunkShardingSpec("N", ["cuda:0", "cuda:1"])
-
-        # Test invalid specs
-        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec(None, ["cuda:0", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
-            ChunkShardingSpec({}, ["cuda:0", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["random:0", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["cuda:foo", "cuda:1"])
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ChunkShardingSpec(0, ["rank:foo", "cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/foo", "cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
-            ChunkShardingSpec(0, ["rank:0/random:0", "cuda:1"])
-        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
-            ChunkShardingSpec(0, ["rank:0/cuda:foo", "cuda:1"])
-
-    @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")
-    def test_enumerable_sharding_spec(self):
-        # test valid specs
-
-        # test row-wise sharding
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="cuda:1",
-                ),
-            ]
-        )
-        check_tensor(spec.shards, torch.Size([10, 5]))
-
-        # test row and column sharding
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[3, 3],
-                    placement="cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 3],
-                    shard_sizes=[3, 3],
-                    placement="cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[3, 0],
-                    shard_sizes=[3, 3],
-                    placement="cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[3, 3],
-                    shard_sizes=[3, 3],
-                    placement="cuda:3",
-                ),
-            ]
-        )
-        check_tensor(spec.shards, torch.Size([6, 6]))
-
-        # test uneven shard sizes.
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[2, 4],
-                    placement="cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[0, 4],
-                    shard_sizes=[4, 2],
-                    placement="cuda:1",
-                ),
-                ShardMetadata(
-                    shard_offsets=[2, 0],
-                    shard_sizes=[4, 4],
-                    placement="cuda:2",
-                ),
-                ShardMetadata(
-                    shard_offsets=[4, 4],
-                    shard_sizes=[2, 2],
-                    placement="cuda:3",
-                ),
-            ]
-        )
-        check_tensor(spec.shards, torch.Size([6, 6]))
-
-        # test invalid sharding
-        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
-            ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement="cuda:foo")
-
-        with self.assertRaisesRegex(ValueError, "same number of elements"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[1], placement="cuda:0")
-
-        with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
-            ShardMetadata(shard_offsets=[-1, 0], shard_sizes=[1, 1], placement="cuda:0")
-
-        with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
-            ShardMetadata(shard_offsets=[0, 0], shard_sizes=[-1, 1], placement="cuda:0")
-
-        with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
-            EnumerableShardingSpec([])
-
-        with self.assertRaisesRegex(ValueError, "Found inconsistent ranks for shards"):
-            EnumerableShardingSpec(
-                [
-                    ShardMetadata(
-                        shard_offsets=[0, 0], shard_sizes=[1, 1], placement="cpu"
-                    ),
-                    ShardMetadata(
-                        shard_offsets=[0, 0, 0], shard_sizes=[1, 1, 1], placement="cpu"
-                    ),
-                ]
-            )
-
-        with self.assertRaisesRegex(ValueError, "Shards.*overlap"):
-            EnumerableShardingSpec(
-                [
-                    ShardMetadata(
-                        shard_offsets=[0, 0], shard_sizes=[3, 3], placement="cpu"
-                    ),
-                    ShardMetadata(
-                        shard_offsets=[2, 0], shard_sizes=[3, 3], placement="cpu"
-                    ),
-                ]
-            )
-
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="cuda:1",
-                ),
-            ]
-        )
-
-        with self.assertRaisesRegex(ValueError, "Rank of tensor is.*but shards rank"):
-            check_tensor(spec.shards, torch.Size([10, 10, 10]))
-
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 0],
-                    shard_sizes=[5, 5],
-                    placement="cuda:1",
-                ),
-            ]
-        )
-
-        with self.assertRaisesRegex(ValueError, "exceeds tensor dim"):
-            check_tensor(spec.shards, torch.Size([10, 3]))
-
-        spec = EnumerableShardingSpec(
-            [
-                ShardMetadata(
-                    shard_offsets=[0, 0],
-                    shard_sizes=[5, 5],
-                    placement="cuda:0",
-                ),
-                ShardMetadata(
-                    shard_offsets=[5, 5],
-                    shard_sizes=[5, 5],
-                    placement="cuda:1",
-                ),
-            ]
-        )
-
-        with self.assertRaisesRegex(ValueError, "does not match tensor volume"):
-            check_tensor(spec.shards, torch.Size([10, 10]))
+    hw_classification = HardwareClassification.GENERIC
 
     def test_get_split_size(self):
         self.assertEqual(3, get_split_size(11, 4))
@@ -280,12 +62,7 @@ class TestShardingSpec(TestCase):
         self.assertEqual(0, get_chunked_dim_size(5, 2, 3))
 
     def test_get_chunk_sharding_params(self):
-        ranks = [
-            "rank:0/cuda:0",
-            "rank:1/cuda:1",
-            "rank:2/cuda:2",
-            "rank:3/cuda:3",
-        ]
+        ranks = [f"rank:{i}/cpu:{i}" for i in range(4)]
         spec = ChunkShardingSpec(
             dim=0,
             placements=ranks,
@@ -311,12 +88,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[10, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -327,12 +104,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0],
                 shard_sizes=[16],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[16],
                 shard_sizes=[9],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -343,22 +120,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="rank:0/cuda:0",
+                placement="rank:0/cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="rank:1/cuda:1",
+                placement="rank:1/cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement="rank:2/cuda:2",
+                placement="rank:2/cpu:2",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="rank:3/cuda:3",
+                placement="rank:3/cpu:3",
             ),
         ]
         spec = _infer_sharding_spec_from_shards_metadata(shards_metadata)
@@ -405,12 +182,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -419,12 +196,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[4, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -434,12 +211,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 4],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -449,12 +226,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -463,12 +240,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -478,12 +255,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[5, 0, 5],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 4, 9],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
@@ -493,22 +270,22 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[0, 5],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:2",
+                placement="cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="cuda:3",
+                placement="cpu:3",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -517,12 +294,12 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0],
                 shard_sizes=[5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 5],
                 shard_sizes=[5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
         ]
         validate_non_overlapping_shards_metadata(shards)
@@ -531,26 +308,279 @@ class TestShardingSpec(TestCase):
             ShardMetadata(
                 shard_offsets=[0, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:0",
+                placement="cpu:0",
             ),
             ShardMetadata(
                 shard_offsets=[5, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:1",
+                placement="cpu:1",
             ),
             ShardMetadata(
                 shard_offsets=[10, 0, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:2",
+                placement="cpu:2",
             ),
             ShardMetadata(
                 shard_offsets=[10, 3, 0],
                 shard_sizes=[5, 5, 5],
-                placement="cuda:3",
+                placement="cpu:3",
             ),
         ]
         with self.assertRaisesRegex(ValueError, "overlap"):
             validate_non_overlapping_shards_metadata(shards)
+
+
+class TestShardingSpecDevice(TestCase):
+    hw_classification = HardwareClassification.ACCELERATOR
+
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerators are needed"
+    )
+    def test_device_placement(self, device):
+        device_type = torch.device(device).type
+
+        # valid devices
+        DevicePlacementSpec(f"{device_type}:0")
+        DevicePlacementSpec(torch.device(0))
+        DevicePlacementSpec(torch.device(f"{device_type}:0"))
+        DevicePlacementSpec(f"rank:0/{device_type}:0")
+        DevicePlacementSpec("rank:0/cpu")
+        DevicePlacementSpec("rank:0")
+
+        # invalid devices
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            DevicePlacementSpec("cuda:foo")
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            DevicePlacementSpec("foo:0")
+        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
+            DevicePlacementSpec("rank:0/cuda:foo")
+        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
+            DevicePlacementSpec("rank:0/cpu2")
+
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerators are needed"
+    )
+    def test_chunked_sharding_spec(self, device):
+        device_type = torch.device(device).type
+
+        # Test valid specs
+        ChunkShardingSpec(0, [torch.device(0), torch.device(1)])
+        ChunkShardingSpec(
+            0,
+            [
+                torch.device(f"{device_type}:0"),
+                torch.device(f"{device_type}:1"),
+            ],
+        )
+        ChunkShardingSpec(-1, [f"{device_type}:0", f"{device_type}:1"])
+        ChunkShardingSpec(0, [f"rank:0/{device_type}:0", f"rank:0/{device_type}:1"])
+        ChunkShardingSpec(0, ["rank:0", "rank:1"])
+        ChunkShardingSpec(0, ["rank:0/cpu", "rank:1/cpu"])
+
+        # Test unimplemented error
+        with self.assertRaisesRegex(NotImplementedError, "not support named dimension"):
+            # Named dimension.
+            ChunkShardingSpec("N", [f"{device_type}:0", f"{device_type}:1"])
+
+        # Test invalid specs
+        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
+            ChunkShardingSpec(None, [f"{device_type}:0", f"{device_type}:1"])
+        with self.assertRaisesRegex(ValueError, "needs to be an integer"):
+            ChunkShardingSpec({}, [f"{device_type}:0", f"{device_type}:1"])
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ChunkShardingSpec(0, ["random:0", f"{device_type}:1"])
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ChunkShardingSpec(0, ["cuda:foo", f"{device_type}:1"])
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ChunkShardingSpec(0, ["rank:foo", f"{device_type}:1"])
+        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
+            ChunkShardingSpec(0, ["rank:0/foo", f"{device_type}:1"])
+        with self.assertRaisesRegex(RuntimeError, "Expected one of"):
+            ChunkShardingSpec(0, ["rank:0/random:0", f"{device_type}:1"])
+        with self.assertRaisesRegex(RuntimeError, "Invalid device string"):
+            ChunkShardingSpec(0, ["rank:0/cuda:foo", f"{device_type}:1"])
+
+    @skip_but_pass_in_sandcastle_if(
+        not TEST_MULTIACCELERATOR, "2 accelerators are needed"
+    )
+    def test_enumerable_sharding_spec(self, device):
+        device_type = torch.device(device).type
+
+        # test valid specs
+
+        # test row-wise sharding
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        check_tensor(spec.shards, torch.Size([10, 5]))
+
+        # test row and column sharding
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 3],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[3, 0],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[3, 3],
+                    shard_sizes=[3, 3],
+                    placement=f"{device_type}:3",
+                ),
+            ]
+        )
+        check_tensor(spec.shards, torch.Size([6, 6]))
+
+        # test uneven shard sizes.
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[2, 4],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[0, 4],
+                    shard_sizes=[4, 2],
+                    placement=f"{device_type}:1",
+                ),
+                ShardMetadata(
+                    shard_offsets=[2, 0],
+                    shard_sizes=[4, 4],
+                    placement=f"{device_type}:2",
+                ),
+                ShardMetadata(
+                    shard_offsets=[4, 4],
+                    shard_sizes=[2, 2],
+                    placement=f"{device_type}:3",
+                ),
+            ]
+        )
+        check_tensor(spec.shards, torch.Size([6, 6]))
+
+        # test invalid sharding
+        with self.assertRaisesRegex(ValueError, "Could not parse remote_device"):
+            ShardMetadata(shard_offsets=[0], shard_sizes=[1], placement="cuda:foo")
+
+        with self.assertRaisesRegex(ValueError, "same number of elements"):
+            ShardMetadata(
+                shard_offsets=[0, 0], shard_sizes=[1], placement=f"{device_type}:0"
+            )
+
+        with self.assertRaisesRegex(ValueError, "shard_offsets should be >=0"):
+            ShardMetadata(
+                shard_offsets=[-1, 0], shard_sizes=[1, 1], placement=f"{device_type}:0"
+            )
+
+        with self.assertRaisesRegex(ValueError, "shard_sizes should be >= 0"):
+            ShardMetadata(
+                shard_offsets=[0, 0], shard_sizes=[-1, 1], placement=f"{device_type}:0"
+            )
+
+        with self.assertRaisesRegex(ValueError, "Empty shard list provided"):
+            EnumerableShardingSpec([])
+
+        with self.assertRaisesRegex(ValueError, "Found inconsistent ranks for shards"):
+            EnumerableShardingSpec(
+                [
+                    ShardMetadata(
+                        shard_offsets=[0, 0], shard_sizes=[1, 1], placement="cpu"
+                    ),
+                    ShardMetadata(
+                        shard_offsets=[0, 0, 0],
+                        shard_sizes=[1, 1, 1],
+                        placement="cpu",
+                    ),
+                ]
+            )
+
+        with self.assertRaisesRegex(ValueError, "Shards.*overlap"):
+            EnumerableShardingSpec(
+                [
+                    ShardMetadata(
+                        shard_offsets=[0, 0], shard_sizes=[3, 3], placement="cpu"
+                    ),
+                    ShardMetadata(
+                        shard_offsets=[2, 0], shard_sizes=[3, 3], placement="cpu"
+                    ),
+                ]
+            )
+
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "Rank of tensor is.*but shards rank"):
+            check_tensor(spec.shards, torch.Size([10, 10, 10]))
+
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "exceeds tensor dim"):
+            check_tensor(spec.shards, torch.Size([10, 3]))
+
+        spec = EnumerableShardingSpec(
+            [
+                ShardMetadata(
+                    shard_offsets=[0, 0],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:0",
+                ),
+                ShardMetadata(
+                    shard_offsets=[5, 5],
+                    shard_sizes=[5, 5],
+                    placement=f"{device_type}:1",
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "does not match tensor volume"):
+            check_tensor(spec.shards, torch.Size([10, 10]))
 
 
 # Custom ShardingSpec, an simple example to do grid sharding
@@ -679,6 +709,11 @@ class TestCustomShardingSpec(ShardedTensorTestBase):
 
         with self.assertRaisesRegex(NotImplementedError, "not implemented"):
             _shard_tensor(torch.randn(8, 8), grid_spec)
+
+
+instantiate_device_type_tests(
+    TestShardingSpecDevice, globals(), except_for="cpu", allow_xpu=True
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`TestShardingSpec` in `test/distributed/_shard/sharding_spec/test_sharding_spec.py`
mixes pure-logic tests (spec construction and metadata validation) with
device-dependent tests gated by `TEST_MULTIGPU` (a CUDA-only whitelist) and
hardcoded `"cuda:N"` device strings.

This PR fully decouples `TestShardingSpec` by splitting it into two
single-responsibility classes. `TestCustomShardingSpec` is intentionally
left untouched — it is fully addressed in a follow-up PR.

## Changes

- Split `TestShardingSpec` into two classes:
  - `TestShardingSpec` (GENERIC): retains the 5 pure-logic tests
    (`test_get_split_size`, `test_get_chunked_dim_size`,
    `test_get_chunk_sharding_params`, `test_infer_sharding_spec_from_shards_metadata`,
    `test_check_overlapping`). Device strings use `"cpu"` directly — these
    tests construct spec objects and validate metadata only.
  - `TestShardingSpecDevice` (ACCELERATOR): contains the 3 device tests
    (`test_device_placement`, `test_chunked_sharding_spec`,
    `test_enumerable_sharding_spec`), refactored with the
    framework-injected `device` parameter. Device strings use
    `torch.device(device).type`.
- Replaced `@skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "2 CUDA GPUs are needed")`
  with `@skip_but_pass_in_sandcastle_if(not TEST_MULTIACCELERATOR, "2 accelerators are needed")`
  (`TEST_MULTIACCELERATOR` was introduced by #167196).
- Added `instantiate_device_type_tests(TestShardingSpecDevice, globals(), except_for="cpu")`.
- Added `hw_classification` class attributes:
  - `TestShardingSpec`: `HardwareClassification.GENERIC`
  - `TestShardingSpecDevice`: `HardwareClassification.ACCELERATOR`
- Invalid-device test cases that intentionally test parser errors (e.g.
  `"cuda:foo"`, `"rank:0/foo"`) are kept as-is.

## Not changed

- `TestCustomShardingSpec` is unchanged (gating `@requires_nccl()`, hardcoded
  device strings) — fully addressed in a follow-up PR.
- `GridShardingSpec` dataclass unchanged.
- No `Capability`/`requires_capabilities` usage in this PR — `TestShardingSpec`
  does not need capability-based gating.

## Dependencies

| Infrastructure | Source PR | Status |
|---|---|---|
| `TEST_MULTIACCELERATOR` | #167196 | Merged |

## Test plan

- NPU (Ascend 910B3, 4 cards): 11 tests — 9 passed, 2 skipped
  (`OK (skipped=2)`). `TestShardingSpec` (GENERIC) 5 tests pass;
  `TestShardingSpecDevicePRIVATEUSE1` 3 device tests pass;
  `TestCustomShardingSpec` (unchanged) 1 test passes, and its 2
  `@with_comms` tests skip because `with_comms` defaults to
  `backend="nccl"`, which does not match the NPU default backend
  (dynamic backend resolution is addressed by #194992).
- CPU (no accelerator): 8 tests — 6 passed, 2 skipped
  (`OK (skipped=2)`). GENERIC 5 tests pass; unchanged
  `TestCustomShardingSpec` 1 test passes, 2 `@with_comms` tests skip
  (no accelerator); `TestShardingSpecDevice` generates no CPU variant
  (`except_for="cpu"`).
- CUDA (A100 x4, CUDA 12.8): 11 tests — 11 passed (`OK`), including the
  2 distributed `@with_comms` tests executing over NCCL. Confirms no
  CUDA regression.