### PR TITLE
[refactor] Make the parameters_to_vector device check device-generic

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -16194,6 +16194,40 @@ if __name__ == '__main__':
         self.assertEqual(tuple(result.shape), tuple(ref_output.shape))
         torch.testing.assert_close(result, ref_output, rtol=1e-7, atol=1e-5)
 
+    @skipMeta
+    def test_parameters_to_vector_roundtrip(self, device):
+        model = nn.Sequential(nn.Conv2d(3, 10, 5), nn.Linear(10, 20)).to(device)
+
+        vec = parameters_to_vector(model.parameters())
+        self.assertEqual(vec.size(0), 980)
+        self.assertEqual(vec.device, torch.device(device))
+
+        vector_to_parameters(vec * 2, model.parameters())
+        self.assertEqual(parameters_to_vector(model.parameters()), vec * 2)
+        for param in model.parameters():
+            self.assertEqual(param.device, torch.device(device))
+
+    @skipMeta
+    def test_parameters_to_vector_mixed_device_types(self, device):
+        if torch.device(device).type == "cpu":
+            self.skipTest("needs a device type other than cpu")
+        params = [nn.Parameter(torch.zeros(4, device=device)), nn.Parameter(torch.zeros(6))]
+
+        with self.assertRaisesRegex(TypeError, "different devices"):
+            parameters_to_vector(params)
+        with self.assertRaisesRegex(TypeError, "different devices"):
+            vector_to_parameters(torch.zeros(10, device=device), params)
+
+    @deviceCountAtLeast(2)
+    @skipMeta
+    def test_parameters_to_vector_multiple_device_indices(self, devices):
+        params = [nn.Parameter(torch.zeros(4, device=devices[0])), nn.Parameter(torch.zeros(6, device=devices[1]))]
+
+        with self.assertRaisesRegex(TypeError, "different devices"):
+            parameters_to_vector(params)
+        with self.assertRaisesRegex(TypeError, "different devices"):
+            vector_to_parameters(torch.zeros(10, device=devices[0]), params)
+
 
 class TestNNCUDA(NNTestCase):
     @skipCUDAIfNoCudnn

--- a/torch/nn/utils/convert_parameters.py
+++ b/torch/nn/utils/convert_parameters.py
@@ -54,37 +54,29 @@ def vector_to_parameters(vec: torch.Tensor, parameters: Iterable[torch.Tensor]) 
         pointer += num_param
 
 
-def _check_param_device(param: torch.Tensor, old_param_device: int | None) -> int:
+def _check_param_device(
+    param: torch.Tensor, old_param_device: torch.device | None
+) -> torch.device:
     r"""Check if the parameters are located on the same device.
 
     Currently, the conversion between model parameters and single vector form is not supported
-    for multiple allocations, e.g. parameters in different GPUs/PrivateUse1s, or mixture of CPU/GPU/PrivateUse1.
+    for multiple allocations, e.g. parameters on different devices of the same device type,
+    or a mixture of devices of different types.
 
     Args:
         param ([Tensor]): a Tensor of a parameter of a model
-        old_param_device (int): the device where the first parameter of a
-                                model is allocated.
+        old_param_device (torch.device): the device where the first parameter of
+                                a model is allocated.
 
     Returns:
-        old_param_device (int): report device for the first time
+        old_param_device (torch.device): report device for the first time
     """
     # Meet the first parameter
-    support_device_types = ["cuda", torch._C._get_privateuse1_backend_name()]
     if old_param_device is None:
-        old_param_device = (
-            param.get_device() if param.device.type in support_device_types else -1
+        return param.device
+    if param.device != old_param_device:
+        raise TypeError(
+            f"Found two parameters on different devices ({old_param_device} and "
+            f"{param.device}), this is currently not supported."
         )
-    else:
-        warn = False
-        if (
-            param.device.type in support_device_types
-        ):  # Check if in same GPU/PrivateUse1
-            warn = param.get_device() != old_param_device
-        else:  # Check if in CPU
-            warn = old_param_device != -1
-        if warn:
-            raise TypeError(
-                "Found two parameters on different devices, "
-                "this is currently not supported."
-            )
     return old_param_device


### PR DESCRIPTION
### Summary

`torch.nn.utils.parameters_to_vector` / `vector_to_parameters` reject parameters spread
across multiple devices via the private helper `_check_param_device`. That check only
recognised CUDA and PrivateUse1, so on every other accelerator it silently accepted
mixed-device parameter lists. This makes the check device-generic by comparing
`torch.device` objects instead of integer device indices.

### The bug

`_check_param_device` mapped each parameter to an integer device index, using an
allow-list to decide which device types have one:

```python
support_device_types = ["cuda", torch._C._get_privateuse1_backend_name()]
```

Any device type outside that list fell into the CPU branch and was encoded as `-1`. On
XPU, MPS, MTIA and HPU that makes every parameter compare equal to every other parameter
and to CPU tensors.

Widening the allow-list would not be enough: comparing bare device indices cannot
distinguish device types, so `cuda:0` and `privateuseone:0` both reduce to index `0` and
compare equal on `main` today.

Behaviour before/after, probed under `FakeTensorMode` so the non-CUDA backends do not need
to be present:

| parameters | before | after |
| --- | --- | --- |
| `xpu:0` + `xpu:1` | accepted silently | `TypeError` |
| `cpu` + `xpu:1` | accepted silently | `TypeError` |
| `cuda:0` + `privateuseone:0` | accepted silently | `TypeError` |
| `cuda:0` + `cpu` | `TypeError` | `TypeError` |
| matching devices | accepted | accepted |

Slipping past the check is not benign. `vector_to_parameters` assigns through
`param.data`, so an uncaught parameter is silently rebound to the other device rather than
raising:

```python
p = torch.nn.Parameter(torch.zeros(4))       # cpu
vec = torch.arange(4., device='cuda')
vector_to_parameters(vec, [p])
# p.device -> cuda:0, no warning
```

### Root cause and fix

The integer encoding is a leftover from when `Tensor.get_device()` raised on CPU tensors.
It returns `-1` for `cpu` and `meta` now, so the allow-list was guarding against an
exception that can no longer happen, while forcing a representation that cannot
distinguish device types.

This drops the allow-list and compares `torch.device` objects directly: exact on every
backend, no device-type test at all, and the error can name both devices. Tensor devices
are always index-resolved (`cuda:0`, `xpu:1`, `mps:0`), and
`torch.zeros(1, device='cpu:0').device == torch.device('cpu')`, so CPU needs no special
case.

### Backward compatibility

`_check_param_device` is private, absent from `__all__` and not re-exported by
`torch/nn/utils/__init__.py`; its only callers are the two functions in the same file. Its
parameter and return type change from `int` to `torch.device`.

`torch.device` equality compares device type *and* index, so every case the old check
handled correctly is preserved exactly - `cuda:0` + `cuda:1` still raises, `cuda:0` +
`cuda:0` still passes, `cuda` + `cpu` still raises. Comparing all ordered pairs over
`{cpu, meta, cuda:0, cuda:1, xpu:0, xpu:1, mps:0, privateuseone:0, privateuseone:1, hpu:0}`,
66/100 are unchanged and the other 34 all move in one direction, from silently accepted to
raising. No pair that raised before is accepted now.

For `parameters_to_vector` no previously-succeeding call starts failing: every newly
rejected pair failed immediately afterwards in `torch.cat` anyway. The observable change
there is the exception - a `RuntimeError` from `cat` becomes an earlier `TypeError` from
the check.

For `vector_to_parameters` the change is real: it assigns through `param.data`, so a
mismatched pair that slipped past the old check silently rebound the parameter to the
vector's device instead of raising. Callers relying on that implicit transfer will now get
a `TypeError`. That is the defect this PR fixes.

### Test plan

The two existing tests (`TestNN.test_parameters_to_vector`,
`TestNN.test_vector_to_parameters`) live in a non-device-generic class and only ever ran on
CPU, and there was no mixed-device test at all. Three tests are added to
`TestNNDeviceType` so they instantiate per backend:

- `test_parameters_to_vector_roundtrip` - flatten/unflatten round trip, asserting values
  and that the vector and every parameter stay on `device`
- `test_parameters_to_vector_mixed_device_types` - accelerator + CPU raises
- `test_parameters_to_vector_multiple_device_indices` - two indices of the same device type
  raise; `@deviceCountAtLeast(2)`, so it only runs on multi-device shards

```
python test/test_nn.py -v -k vector
python test/nn/test_pruning.py -v
lintrunner torch/nn/utils/convert_parameters.py test/test_nn.py
```

`test_pruning.py` covers the only in-tree caller of `parameters_to_vector`
(`prune.global_unstructured`, which flattens weights and masks across modules to compute a
global pruning threshold). These were run on a single-GPU host, so
`test_parameters_to_vector_multiple_device_indices` skipped locally and needs a
multi-device shard.

Authored with the assistance of Claude (Claude Code); I have reviewed the change.