### PR TITLE
Treat an engaged-but-undefined optional weight as no weight in rms_norm

### DIFF
--- a/aten/src/ATen/native/layer_norm.cpp
+++ b/aten/src/ATen/native/layer_norm.cpp
@@ -300,12 +300,16 @@ std::tuple<Tensor, Tensor> rms_norm_composite(
 
     Tensor upcasted_result = upcasted_input.mul(rqrst_input);
 
-    if (weight_opt.has_value()) {
+    // An engaged optional can still hold an undefined tensor, which is what a
+    // C++ caller passing a possibly-undefined Tensor for `Tensor?` produces.
+    const bool has_weight = weight_opt.has_value() && weight_opt->defined();
+
+    if (has_weight) {
       upcasted_result = upcasted_result.mul(weight_opt.value());
     }
 
     // if nested do not make contiguous
-    if(input.is_nested() || (weight_opt.has_value() && weight_opt.value().is_nested())){
+    if (input.is_nested() || (has_weight && weight_opt.value().is_nested())) {
       return std::make_tuple(std::move(upcasted_result), std::move(rqrst_input));
     }
 
@@ -351,7 +355,8 @@ Tensor rms_norm_symint(
   }
 
   #ifdef USE_MPS
-  if (input.device().type() == DeviceType::MPS && weight_opt.has_value()) {
+  if (input.device().type() == DeviceType::MPS && weight_opt.has_value() &&
+      weight_opt->defined()) {
     const Tensor weight = weight_opt.value();
     const bool any_inputs_require_grad = input.requires_grad() || weight.requires_grad();
 

--- a/aten/src/ATen/test/undefined_tensor_test.cpp
+++ b/aten/src/ATen/test/undefined_tensor_test.cpp
@@ -71,3 +71,14 @@ TEST(TestUndefined, UndefinedTest) {
   ASSERT_FALSE(to_move.defined());
   ASSERT_EQ(to_move.unsafeGetTensorImpl(), UndefinedTensorImpl::singleton());
 }
+
+TEST(TestUndefined, RMSNormUndefinedWeight) {
+  manual_seed(123);
+
+  // A C++ caller forwarding a possibly-undefined weight for `Tensor?` yields an
+  // engaged optional holding an undefined tensor; it must behave like nullopt.
+  Tensor und;
+  auto input = rand({4, 5});
+  ASSERT_TRUE(at::rms_norm(input, {5}, und, 1e-5)
+                  .equal(at::rms_norm(input, {5}, std::nullopt, 1e-5)));
+}


### PR DESCRIPTION
`aten::rms_norm` declares `Tensor? weight=None`, but `rms_norm_composite` gates the weight multiply on `weight_opt.has_value()` alone. A C++ caller forwarding a possibly-undefined Tensor where an optional is expected produces an engaged optional holding an undefined tensor, and that reaches `upcasted_result.mul(<undefined>)`:

```
Expected a proper Tensor but got None (or an undefined Tensor in C++) for argument #1 'other'
```

`at::layer_norm` accepts the same call, because `math_native_layer_norm` also checks `.defined()`. That asymmetry is the bug.

The MPS branch of `rms_norm_symint` had the same gate and would have handed an undefined weight to `_fused_rms_norm_mps`, so it is fixed here rather than left as a twin of the one being removed. I have no MPS hardware; that half is reasoned from the source and left to CI.

### Test

The failure is only reachable from C++ — Python cannot construct an engaged optional holding an undefined tensor — so the regression test is a gtest in `undefined_tensor_test.cpp`, which `aten/tools/run_tests.sh` already runs. It went there rather than `math_kernel_test.cpp`, which is built but appears in no runner list and so would not have gated this PR.

This machine's Device Guard policy refuses to launch freshly linked gtest binaries, so the assertions were exercised through a `cpp_extension` against a locally built `torch_cpu`. Same harness before and after:

```
before:  engaged-but-undefined  : THREW -> Expected a proper Tensor but got None ...
after:   engaged-but-undefined  : ok, numel=6
```

and the test's own assertion, plus a check that a real weight is still applied:

```
equal(undef, nullopt)  : true
max abs diff           : 0
weight still applied   : true
```

### Related

#193936 adds `torch::nn::RMSNorm` and currently works around this by converting an undefined weight to `std::nullopt` before calling `at::rms_norm`. If this lands first, that conversion and its comment can be dropped there.

Developed with AI assistance (Claude); I reproduced the failure, wrote the fix and ran the checks above.
