### PR TITLE
[Test] Add `HardwareClassification` to `test_cutedsl_smoketest.py` and move device-generalized tests to `test_dlpack.py`

### DIFF
--- a/test/python_native/test_cutedsl_smoketest.py
+++ b/test/python_native/test_cutedsl_smoketest.py
@@ -820,6 +820,21 @@ class TestCuteDSLReadOnlyWrapperCUDA(TestCase):
     The tvm-ffi exchange path is the supported route: it goes through the const
     DLPack C exchange API, exports via const_data_ptr() (so a copy-on-write
     tensor is not materialized) and advertises DLPACK_FLAG_BITMASK_READ_ONLY.
+
+    The non-tvm-ffi (bare PyCapsule) path is intentionally NOT exercised against
+    cuteDSL. cuteDSL's DLTensorWrapper mis-parses the *versioned* DLPack struct
+    (DLManagedTensorVersioned) and crashes ("LLVM ERROR: SmallVector unable to
+    grow" / segfault) on a garbage size, which would take down the whole test
+    process. This is independent of the read-only flag: a versioned-but-writable
+    capsule (read_only=False) crashes identically, while an unversioned capsule
+    is consumed fine. read_only requires the versioned protocol, so the bare
+    path is unusable for cuteDSL until cuteDSL fixes its versioned-struct
+    parsing. The capsule itself is valid; see, in test_dlpack.py,
+    TestTorchDlPack.test_read_only_wrapper_export_preserves_cow (torch consumes
+    it, COW preserved) and
+    TestReadOnlyDLPack.test_wrapper_numpy_export_is_read_only (numpy honors the
+    read-only flag). The tvm-ffi path avoids all of this by going through the C
+    exchange API rather than parsing a capsule.
     """
 
     hw_classification = HardwareClassification.CUDA
@@ -892,35 +907,6 @@ class TestCuteDSLReadOnlyWrapperCUDA(TestCase):
             _ptr(ReadOnlyTensorWrapper.__dlpack_c_exchange_api__),
             _ptr(torch._C._dlpack_exchange_api()),
         )
-
-    # NOTE: The non-tvm-ffi (bare PyCapsule) path is intentionally NOT exercised
-    # against cuteDSL here. cuteDSL's DLTensorWrapper mis-parses the *versioned*
-    # DLPack struct (DLManagedTensorVersioned) and crashes
-    # ("LLVM ERROR: SmallVector unable to grow" / segfault) on a garbage size,
-    # which would take down the whole test process. This is independent of the
-    # read-only flag: a versioned-but-writable capsule (read_only=False) crashes
-    # identically, while an unversioned capsule is consumed fine. read_only
-    # requires the versioned protocol, so the bare path is unusable for cuteDSL
-    # until cuteDSL fixes its versioned-struct parsing. The capsule itself is
-    # valid (numpy and torch consume the versioned read-only capsule correctly;
-    # see test_dlpack.py). The tvm-ffi path avoids this entirely by going
-    # through the C exchange API rather than parsing a capsule.
-    @unittest.skipIf(not SM80OrLater, "SM80+ required")
-    def test_readonly_wrapper_bare_capsule_is_valid(self):
-        # Verify the wrapper's bare (non-tvm-ffi) capsule is a well-formed,
-        # read-only, copy-on-write-preserving export -- the thing cuteDSL's bare
-        # path *would* receive -- without handing it to cuteDSL.
-        a = torch.randn(8, device="cuda", dtype=torch.float32)
-        a_cow = a._lazy_clone()
-        self.assertTrue(torch._C._is_cow_tensor(a_cow))
-        addr = a_cow.const_data_ptr()
-
-        # This is exactly the call cuteDSL's bare path makes: __dlpack__(stream=-1).
-        back = torch.from_dlpack(ReadOnlyTensorWrapper(a_cow))
-
-        self.assertTrue(torch._C._is_cow_tensor(a_cow))
-        self.assertEqual(a_cow.const_data_ptr(), addr)
-        torch.testing.assert_close(back, a)
 
 
 if __name__ == "__main__":

--- a/test/python_native/test_cutedsl_smoketest.py
+++ b/test/python_native/test_cutedsl_smoketest.py
@@ -14,7 +14,12 @@ import unittest
 
 import torch
 from torch.testing._internal.common_cuda import SM80OrLater, TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfNoCuteDSL, TestCase
+from torch.testing._internal.common_utils import (
+    HardwareClassification,
+    run_tests,
+    skipIfNoCuteDSL,
+    TestCase,
+)
 from torch.utils.dlpack import ReadOnlyTensorWrapper
 
 
@@ -673,11 +678,13 @@ def _build_cta_norm():
 
 @skipIfNoCuteDSL
 @unittest.skipIf(not TEST_CUDA, "CUDA required")
-class TestCuteDSLSmoketest(TestCase):
+class TestCuteDSLSmoketestCUDA(TestCase):
     """Smoke tests that compile, run, and verify cuteDSL kernels.
 
     Run before bumping cuteDSL version pins in torch/_native/cutedsl_utils.py.
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     def test_runtime_version_is_supported(self):
         from torch._native import cutedsl_utils
@@ -807,13 +814,15 @@ class TestCuteDSLSmoketest(TestCase):
 
 @skipIfNoCuteDSL
 @unittest.skipIf(not TEST_CUDA, "CUDA required")
-class TestCuteDSLReadOnlyWrapper(TestCase):
+class TestCuteDSLReadOnlyWrapperCUDA(TestCase):
     """ReadOnlyTensorWrapper interop with cuteDSL.
 
     The tvm-ffi exchange path is the supported route: it goes through the const
     DLPack C exchange API, exports via const_data_ptr() (so a copy-on-write
     tensor is not materialized) and advertises DLPACK_FLAG_BITMASK_READ_ONLY.
     """
+
+    hw_classification = HardwareClassification.CUDA
 
     @unittest.skipIf(not SM80OrLater, "SM80+ required")
     def test_readonly_wrapper_tvm_ffi_kernel(self):

--- a/test/python_native/test_cutedsl_smoketest.py
+++ b/test/python_native/test_cutedsl_smoketest.py
@@ -830,7 +830,7 @@ class TestCuteDSLReadOnlyWrapperCUDA(TestCase):
     is consumed fine. read_only requires the versioned protocol, so the bare
     path is unusable for cuteDSL until cuteDSL fixes its versioned-struct
     parsing. The capsule itself is valid; see, in test_dlpack.py,
-    TestTorchDlPack.test_read_only_wrapper_export_preserves_cow (torch consumes
+    TestTorchDlPack.test_readonly_wrapper_bare_capsule_is_valid (torch consumes
     it, COW preserved) and
     TestReadOnlyDLPack.test_wrapper_numpy_export_is_read_only (numpy honors the
     read-only flag). The tvm-ffi path avoids all of this by going through the C

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -2,7 +2,10 @@
 
 import torch
 from torch.testing import make_tensor
-from torch.testing._internal.common_cuda import xfailCUDAIfSM89OrLaterOnWindows
+from torch.testing._internal.common_cuda import (
+    SM80OrLater,
+    xfailCUDAIfSM89OrLaterOnWindows,
+)
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
     dtypes,
@@ -12,6 +15,7 @@ from torch.testing._internal.common_device_type import (
     onlyCUDA,
     onlyNativeDeviceTypes,
     onlyOn,
+    skipCUDAIf,
     skipCUDAIfNotRocm,
     skipMeta,
     skipXPUIf,
@@ -923,22 +927,24 @@ class TestTorchDlPack(TestCase):
 
     @skipMeta
     @onlyOn(["xpu", "cuda"])
+    @skipCUDAIf(not SM80OrLater, "SM80+ required")
     @skipIfTorchDynamo(
         "ReadOnlyTensorWrapper is eager-only; __dlpack__ unsupported in dynamo"
     )
-    def test_read_only_wrapper_export_preserves_cow(self, device):
-        x = make_tensor((8,), device=device, dtype=torch.float32)
-        cow = x._lazy_clone()
-        self.assertTrue(torch._C._is_cow_tensor(cow))
-        addr = cow.const_data_ptr()
+    def test_readonly_wrapper_bare_capsule_is_valid(self, device):
+        a = torch.randn(8, device=device, dtype=torch.float32)
+        a_cow = a._lazy_clone()
+        self.assertTrue(torch._C._is_cow_tensor(a_cow))
+        addr = a_cow.const_data_ptr()
 
-        back = from_dlpack(ReadOnlyTensorWrapper(cow))
+        # Bare-capsule protocol: from_dlpack() calls __dlpack__() directly and
+        # ignores __dlpack_c_exchange_api__ (the fast path covered by
+        # TestReadOnlyDLPack.test_wrapper_routes_fast_path_to_const_api).
+        back = torch.from_dlpack(ReadOnlyTensorWrapper(a_cow))
 
-        self.assertEqual(back.device, x.device)
-        self.assertEqual(back.data_ptr(), addr)
-        self.assertEqual(back, x)
-        self.assertTrue(torch._C._is_cow_tensor(cow))
-        self.assertEqual(cow.const_data_ptr(), addr)
+        self.assertTrue(torch._C._is_cow_tensor(a_cow))
+        self.assertEqual(a_cow.const_data_ptr(), addr)
+        torch.testing.assert_close(back, a)
 
 
 instantiate_device_type_tests(

--- a/test/test_dlpack.py
+++ b/test/test_dlpack.py
@@ -921,6 +921,25 @@ class TestTorchDlPack(TestCase):
         # Verify they're on different devices
         self.assertNotEqual(t0.device, t1.device)
 
+    @skipMeta
+    @onlyOn(["xpu", "cuda"])
+    @skipIfTorchDynamo(
+        "ReadOnlyTensorWrapper is eager-only; __dlpack__ unsupported in dynamo"
+    )
+    def test_read_only_wrapper_export_preserves_cow(self, device):
+        x = make_tensor((8,), device=device, dtype=torch.float32)
+        cow = x._lazy_clone()
+        self.assertTrue(torch._C._is_cow_tensor(cow))
+        addr = cow.const_data_ptr()
+
+        back = from_dlpack(ReadOnlyTensorWrapper(cow))
+
+        self.assertEqual(back.device, x.device)
+        self.assertEqual(back.data_ptr(), addr)
+        self.assertEqual(back, x)
+        self.assertTrue(torch._C._is_cow_tensor(cow))
+        self.assertEqual(cow.const_data_ptr(), addr)
+
 
 instantiate_device_type_tests(
     TestTorchDlPack, globals(), allow_mps=True, allow_xpu=True


### PR DESCRIPTION
### Changes

- Add `HardwareClassification` to all test classes in `test/python_native/test_cutedsl_smoketest.py`.
- Add `CUDA` suffixes to cuda-specific test classes.
- Move generalized version of  cuda-specific test case `test_readonly_wrapper_bare_capsule_is_valid` from `test_cutedsl_smoketest.py` into device-generic test class in `test_dlpack.py`.

The cuda-specific test file `test_cutedsl_smoketest.py` has only one test that doesn't depend on cuda-specific CuteDSL and can be made generic. It is `test_readonly_wrapper_bare_capsule_is_valid` test function. To mark the whole test class as `HardwareClassification.CUDA` I generalized it and moved it to the `test_dlpack.py` not to loose the features test coverage.
