### PR TITLE
[Test] Classify FX quantization CUDA-only tests separately

### DIFF
--- a/test/quantization/fx/test_quantize_fx.py
+++ b/test/quantization/fx/test_quantize_fx.py
@@ -190,6 +190,7 @@ from torch.testing._internal.common_quantized import (
 )
 
 from torch.testing._internal.common_utils import (
+    HardwareClassification,
     TemporaryFileName,
     IS_ARM64,
     skipIfTorchDynamo,
@@ -268,6 +269,8 @@ def _user_func_with_complex_return_type(x):
     return list(torch.split(x, 1, 1))
 
 class TestFuseFx(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_fuse_conv_bn_relu(self):
         class M(torch.nn.Module):
             def __init__(self) -> None:
@@ -895,6 +898,8 @@ class TestFuseFx(QuantizationTestCase):
 
 @skipIfNoFBGEMM
 class TestQuantizeFx(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def test_pattern_match(self):
         """ test MatchAllNode with
             conv - bn - add - relu pattern
@@ -1862,49 +1867,6 @@ class TestQuantizeFx(QuantizationTestCase):
                     ns.call_function(torch.ops.quantized.linear_prepack_fp16): 0,
                 },
             )
-
-
-
-    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @override_qengines
-    def test_qat_prepare_device_affinity(self):
-        """
-        Tests that FX QAT prepare pass respects device affinity
-        """
-        class Model(nn.Module):
-
-            def __init__(self) -> None:
-                super().__init__()
-                self.conv = nn.Conv2d(1, 1, 1)
-                self.bn = nn.BatchNorm2d(1)
-                self.relu = nn.ReLU()
-
-            def forward(self, x):
-                x = self.conv(x)
-                x = self.bn(x)
-                x = self.relu(x)
-                return x
-
-        model = Model()
-        qengine = torch.backends.quantized.engine
-        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig(qengine)}
-        device = torch.device('cuda:0')
-        model.to(device)
-
-        example_inputs = (torch.randn(4, 1, 4, 4, device=device),)
-        # QAT prepare
-        model = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
-
-        # ensure that running an input on CUDA works without any needed changes
-        model(*example_inputs)
-
-        # ensure all buffers and parameters are on the device we expect
-        model_devices = {p.device for p in model.parameters()} | \
-            {p.device for p in model.buffers()}
-        self.assertEqual(len(model_devices), 1)
-        model_device = next(iter(model_devices))
-        self.assertEqual(model_device, device)
 
     @skipIfNoFBGEMM
     def test_dict_output(self):
@@ -6833,8 +6795,134 @@ class TestQuantizeFx(QuantizationTestCase):
             None
         )
 
+class TestQuantizeFxCUDASpecific(QuantizationTestCase):
+    hw_classification = HardwareClassification.CUDA
+
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @override_qengines
+    def test_qat_prepare_device_affinity(self):
+        """
+        Tests that FX QAT prepare pass respects device affinity
+        """
+        class Model(nn.Module):
+
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(1, 1, 1)
+                self.bn = nn.BatchNorm2d(1)
+                self.relu = nn.ReLU()
+
+            def forward(self, x):
+                x = self.conv(x)
+                x = self.bn(x)
+                x = self.relu(x)
+                return x
+
+        model = Model()
+        qengine = torch.backends.quantized.engine
+        qconfig_dict = {'': torch.ao.quantization.get_default_qat_qconfig(qengine)}
+        device = torch.device('cuda:0')
+        model.to(device)
+
+        example_inputs = (torch.randn(4, 1, 4, 4, device=device),)
+        model = prepare_qat_fx(model, qconfig_dict, example_inputs=example_inputs)
+        model(*example_inputs)
+
+        model_devices = {p.device for p in model.parameters()} | {p.device for p in model.buffers()}
+        self.assertEqual(len(model_devices), 1)
+        model_device = next(iter(model_devices))
+        self.assertEqual(model_device, device)
+
+    @skipIfNoFBGEMM
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_static_gpu_convert_basic(self):
+
+        class Net(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.relu1 = nn.ReLU()
+                self.conv1 = nn.Conv2d(1, 6, 5)
+                self.linear1 = nn.Linear(120, 1)
+
+            def forward(self, x):
+                x = self.relu1(self.conv1(x))
+                y = self.linear1(x.view(-1))
+                return y
+
+        input = torch.randn((5, 1, 6, 6)).to('cuda')
+        example_inputs = (input,)
+        model = Net().to('cuda').eval()
+        qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
+        model_prepared = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
+        model_prepared(*example_inputs)
+        model_quantized = convert_to_reference_fx(model_prepared)
+        out = model_quantized(*example_inputs)
+        self.assertEqual(out.device.type, 'cuda')
+
+    @skipIfNoFBGEMM
+    @unittest.skipIf(not TEST_CUDA, "gpu is not available.")
+    def test_switch_device_prepare_convert(self):
+
+        class Net(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.relu1 = nn.ReLU()
+                self.conv1 = nn.Conv2d(1, 6, 5)
+                self.linear1 = nn.Linear(120, 1)
+
+            def forward(self, x):
+                x = self.relu1(self.conv1(x))
+                y = self.linear1(x.view(-1))
+                return y
+
+        for device in ['cuda', 'cpu']:
+            device_after = 'cuda' if device == 'cpu' else 'cpu'
+            input = torch.randn((5, 1, 6, 6)).to(device)
+            model = Net().to(device).eval()
+            qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
+            model_prepared = prepare_fx(model, qconfig_dict, example_inputs=(input,))
+            model_prepared(input)
+            model_prepared.to(device_after)
+            model_quantized = convert_to_reference_fx(model_prepared)
+            out = model_quantized(input.to(device_after))
+            self.assertEqual(out.device.type, device_after)
+
+    @skipIfNoFBGEMM
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_prepare_serialize_switch_device_convert(self):
+        class Net(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv1 = nn.Conv2d(1, 6, 5)
+                self.linear1 = nn.Linear(120, 1)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                y = self.linear1(x.view(-1))
+                return y
+
+        for device in ['cuda', 'cpu']:
+            for device_after in ['cuda', 'cpu']:
+                input = torch.randn((5, 1, 6, 6)).to(device)
+                model = Net().to(device).eval()
+                qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
+                model_prepared_first = prepare_fx(model, qconfig_dict, example_inputs=(input,))
+                model_prepared_second = prepare_fx(model, qconfig_dict, example_inputs=(input,))
+                model_prepared_first(input)
+                state_dict = model_prepared_first.state_dict()
+                del model_prepared_first
+                model_prepared_second.load_state_dict(state_dict)
+                model_prepared_second.to(device_after)
+                model_quantized = convert_to_reference_fx(model_prepared_second)
+                out = model_quantized(input.to(device_after))
+                self.assertEqual(out.device.type, device_after)
+
+
 @skipIfNoFBGEMM
 class TestQuantizeFxOps(QuantizationTestCase):
+    hw_classification = HardwareClassification.GENERIC
+
     def setUp(self):
         super().setUp()
         self.custom_qconfig = torch.ao.quantization.QConfig(
@@ -9374,89 +9462,7 @@ class TestQuantizeFxOps(QuantizationTestCase):
             self.checkGraphModuleNodes(m, expected_node_occurrence=expected_occurrence)
 
 class TestQuantizeFxModels(QuantizationTestCase):
-    @skipIfNoFBGEMM
-    @unittest.skipIf(not TEST_CUDA, "gpu is not available.")
-    def test_static_gpu_convert_basic(self):
-
-        class Net(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.relu1 = nn.ReLU()
-                self.conv1 = nn.Conv2d(1, 6, 5)
-                self.linear1 = nn.Linear(120, 1)
-
-            def forward(self, x):
-                x = self.relu1(self.conv1(x))
-                y = self.linear1(x.view(-1))
-                return y
-
-        input = torch.randn((5, 1, 6, 6)).to('cuda')
-        example_inputs = (input,)
-        model = Net().to('cuda').eval()
-        qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
-        model_prepared = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
-        model_prepared(*example_inputs)
-        model_quantized = convert_to_reference_fx(model_prepared)
-        out = model_quantized(*example_inputs)
-        self.assertEqual(out.device.type, 'cuda')
-
-    @skipIfNoFBGEMM
-    @unittest.skipIf(not TEST_CUDA, "gpu is not available.")
-    def test_switch_device_prepare_convert(self):
-
-        class Net(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.relu1 = nn.ReLU()
-                self.conv1 = nn.Conv2d(1, 6, 5)
-                self.linear1 = nn.Linear(120, 1)
-
-            def forward(self, x):
-                x = self.relu1(self.conv1(x))
-                y = self.linear1(x.view(-1))
-                return y
-
-        for device in ['cuda', 'cpu']:
-            device_after = 'cuda' if device == 'cpu' else 'cpu'
-            input = torch.randn((5, 1, 6, 6)).to(device)
-            model = Net().to(device).eval()
-            qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
-            model_prepared = prepare_fx(model, qconfig_dict, example_inputs=(input,))
-            model_prepared(input)
-            model_prepared.to(device_after)
-            model_quantized = convert_to_reference_fx(model_prepared)
-            out = model_quantized(input.to(device_after))
-            self.assertEqual(out.device.type, device_after)
-
-    @skipIfNoFBGEMM
-    @unittest.skipIf(not TEST_CUDA, "gpu is not available.")
-    def test_prepare_serialize_switch_device_convert(self):
-        class Net(nn.Module):
-            def __init__(self) -> None:
-                super().__init__()
-                self.conv1 = nn.Conv2d(1, 6, 5)
-                self.linear1 = nn.Linear(120, 1)
-
-            def forward(self, x):
-                x = self.conv1(x)
-                y = self.linear1(x.view(-1))
-                return y
-
-        for device in ['cuda', 'cpu']:
-            for device_after in ['cuda', 'cpu']:
-                input = torch.randn((5, 1, 6, 6)).to(device)
-                model = Net().to(device).eval()
-                qconfig_dict = {"": torch.ao.quantization.get_default_qconfig('fbgemm')}
-                model_prepared_first = prepare_fx(model, qconfig_dict, example_inputs=(input,))
-                model_prepared_second = prepare_fx(model, qconfig_dict, example_inputs=(input,))
-                model_prepared_first(input)
-                state_dict = model_prepared_first.state_dict()
-                del model_prepared_first
-                model_prepared_second.load_state_dict(state_dict)
-                model_prepared_second.to(device_after)
-                model_quantized = convert_to_reference_fx(model_prepared_second)
-                out = model_quantized(input.to(device_after))
-                self.assertEqual(out.device.type, device_after)
+    hw_classification = HardwareClassification.GENERIC
 
     @skipIfTorchDynamo("too slow")
     @skip_if_no_torchvision
@@ -9820,7 +9826,7 @@ class TestQuantizeFxModels(QuantizationTestCase):
 
     @given(
         device=st.sampled_from(
-            ["cpu", "cuda"] if torch.cuda.is_available() else ["cpu"]
+            ["cpu"] + (["cuda"] if torch.cuda.is_available() else []) + (["xpu"] if torch.xpu.is_available() else [])
         )
     )
     @settings(deadline=None)

--- a/test/test_quantization.py
+++ b/test/test_quantization.py
@@ -66,6 +66,7 @@ log = logging.getLogger(__name__)
 try:
     from quantization.fx.test_quantize_fx import TestFuseFx  # noqa: F401
     from quantization.fx.test_quantize_fx import TestQuantizeFx  # noqa: F401
+    from quantization.fx.test_quantize_fx import TestQuantizeFxCUDASpecific  # noqa: F401
     from quantization.fx.test_quantize_fx import TestQuantizeFxOps  # noqa: F401
     from quantization.fx.test_quantize_fx import TestQuantizeFxModels  # noqa: F401
     from quantization.fx.test_subgraph_rewriter import TestSubgraphRewriter  # noqa: F401


### PR DESCRIPTION
## Summary

This refactor classifies the FX quantization tests by actual device specificity without changing the file's overall coverage.

Main changes:
- mark the device-agnostic FX quantization classes as `HardwareClassification.GENERIC`
- move the 4 CUDA-only tests into `TestQuantizeFxCUDASpecific`, and restore the device-affinity assertion in `test_qat_prepare_device_affinity`
- widen XPU only in `test_qat_functional_linear`'s local device list, and import the CUDA-specific class from `test/test_quantization.py`

## Why the XPU change stays local

The XPU widening is intentionally scoped to `test_qat_functional_linear`'s device list only.

The shared `get_supported_device_types()` helper is deliberately unchanged because `QuantizedXPU` does not yet have the required kernels. Widening that helper causes 15 tests in `test/quantization/core/test_quantized_tensor.py` to fail with:

```text
NotImplementedError: Could not run 'aten::_empty_affine_quantized' with arguments from the 'QuantizedXPU' backend.
```

That broader enablement should happen in a follow-up once kernel support exists.

## Coverage delta

| slice | before | after |
|---|---|---|
| overall file | 246 collected, 226 pass, 0 fail, 2 error, 18 skip, 0 xfail, 0 xpass | 246 collected, 226 pass, 0 fail, 2 error, 18 skip, 0 xfail, 0 xpass |
| cpu+xpu hw-classification selection | 0 collected | 242 collected, 226 pass, 0 fail, 2 error, 14 skip, 0 xfail, 0 xpass |

Within the class split, `TestQuantizeFx` changes from `155 -> 154` tests, the prior CUDA-only slice changes from `27 -> 24`, and the 4 moved tests reappear in `TestQuantizeFxCUDASpecific`.

The 2 errors in the post-change CPU/XPU slice are not introduced by this refactor; they match the pre-existing baseline for this file.

## Testing

```bash
python test/test_quantization.py TestQuantizeFx.test_dynamic_quant_fp16
python test/test_quantization.py TestQuantizeFxCUDASpecific.test_qat_prepare_device_affinity
```
