### PR TITLE
[dynamo] ConstantVariable tp_methods with value-type lookup filter

### DIFF
--- a/torch/_dynamo/variables/constant.py
+++ b/torch/_dynamo/variables/constant.py
@@ -25,7 +25,7 @@ from ..utils import (
     raise_args_mismatch,
     unpack_iterable,
 )
-from .base import ValueMutationNew, VariableTracker
+from .base import Method, ValueMutationNew, VariableTracker
 
 
 if TYPE_CHECKING:
@@ -321,6 +321,102 @@ class ConstantVariable(VariableTracker):
                 pass
         return super().tp_iter_impl(tx)
 
+    def _tp_method_applies_to_value(self, name: str) -> bool:
+        if name in ("format", "join"):
+            return istype(self.value, str)
+        if name == "decode":
+            return isinstance(self.value, bytes)
+        if name == "__iter__":
+            return isinstance(self.value, Iterable)
+        return True
+
+    def _lookup_tp_table(self, name: str, *table_attrs: str) -> Any:
+        entry = super()._lookup_tp_table(name, *table_attrs)
+        if entry is not None and "tp_methods" in table_attrs:
+            if not self._tp_method_applies_to_value(name):
+                return None
+        return entry
+
+    def format_(
+        self,
+        tx: InstructionTranslatorBase,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker | None:
+        if not istype(self.value, str):
+            return None
+        return variables.BuiltinVariable(str.format).call_function(
+            tx, [self, *args], kwargs
+        )
+
+    def join(
+        self,
+        tx: InstructionTranslatorBase,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker | None:
+        if not istype(self.value, str):
+            return None
+        if kwargs or len(args) != 1:
+            raise_args_mismatch(
+                tx,
+                "join",
+                "1 args and 0 kwargs",
+                f"{len(args)} args and {len(kwargs)} kwargs",
+            )
+        arg_unpacked = unpack_iterable(tx, args[0])
+        try:
+            arg_const = [x.as_python_constant() for x in arg_unpacked]
+            return ConstantVariable.create(self.value.join(arg_const))
+        except NotImplementedError:
+            return None
+
+    def iter_(
+        self,
+        tx: InstructionTranslatorBase,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker | None:
+        from .tensor import SymNodeVariable
+
+        if not isinstance(self.value, Iterable):
+            return None
+        if any(isinstance(x, SymNodeVariable) for x in args):
+            return None
+        try:
+            [a.as_python_constant() for a in args]
+            {k: v.as_python_constant() for k, v in kwargs.items()}
+        except NotImplementedError:
+            return None
+        return self.tp_iter_impl(tx)
+
+    def decode(
+        self,
+        tx: InstructionTranslatorBase,
+        args: list[VariableTracker],
+        kwargs: dict[str, VariableTracker],
+    ) -> VariableTracker | None:
+        from .tensor import SymNodeVariable
+
+        if not isinstance(self.value, bytes):
+            return None
+        if any(isinstance(x, SymNodeVariable) for x in args):
+            return None
+        try:
+            const_args = [a.as_python_constant() for a in args]
+            const_kwargs = {k: v.as_python_constant() for k, v in kwargs.items()}
+        except NotImplementedError:
+            return None
+        method = getattr(self.value, "decode")
+        return ConstantVariable.create(method(*const_args, **const_kwargs))
+
+    tp_methods = {
+        "format": Method(format_),
+        "join": Method(join),
+        "__iter__": Method(iter_),
+        "decode": Method(decode),
+    }
+
     def call_method(
         self,
         tx: InstructionTranslatorBase,
@@ -330,26 +426,11 @@ class ConstantVariable(VariableTracker):
     ) -> VariableTracker:
         from .tensor import SymNodeVariable
 
-        if name == "format" and istype(self.value, str):
-            return variables.BuiltinVariable(str.format).call_function(
-                tx,
-                [self, *args],
-                kwargs,
-            )
-        elif name == "join" and istype(self.value, str):
-            if kwargs or len(args) != 1:
-                raise_args_mismatch(
-                    tx,
-                    name,
-                    "1 args and 0 kwargs",
-                    f"{len(args)} args and {len(kwargs)} kwargs",
-                )
-            arg_unpacked = unpack_iterable(tx, args[0])
-            try:
-                arg_const = [x.as_python_constant() for x in arg_unpacked]
-                return ConstantVariable.create(self.value.join(arg_const))
-            except NotImplementedError:
-                return super().call_method(tx, name, args, kwargs)
+        method = self.lookup_tp_method(name)
+        if method is not None:
+            result = method(self, tx, name, args, kwargs)
+            if result is not None:
+                return result
 
         if any(isinstance(x, SymNodeVariable) for x in args):
             # Promote to SymNodeVariable for operations involving dynamic shapes.
@@ -362,9 +443,6 @@ class ConstantVariable(VariableTracker):
             const_kwargs = {k: v.as_python_constant() for k, v in kwargs.items()}
         except NotImplementedError:
             return super().call_method(tx, name, args, kwargs)
-
-        if name == "__iter__":
-            return self.tp_iter_impl(tx)
 
         if isinstance(self.value, str) and name in str.__dict__:
             method = getattr(self.value, name)
@@ -407,9 +485,6 @@ class ConstantVariable(VariableTracker):
                         return ConstantVariable.create(op(self.value, add_target))
                     except Exception as e:
                         raise_observed_exception(type(e), tx, args=list(e.args))
-        elif isinstance(self.value, bytes) and name == "decode":
-            method = getattr(self.value, name)
-            return ConstantVariable.create(method(*const_args, **const_kwargs))
         elif type(self.value) is complex and name in complex.__dict__:
             method = getattr(self.value, name)
             try:


### PR DESCRIPTION
## Summary

Reopens the work from closed #195184 with a fix for @guilhermeleobas's review feedback.

**Problem (#195184):** Moving `format` / `join` / `__iter__` / `decode` onto class-level `tp_methods` made `object_generic_getattr` treat every `ConstantVariable` as exposing those methods (it checks `_lookup_tp_table(name, "tp_methods")` before call-time handler decline). That is wrong for a multi-type VT: `ConstantVariable` wraps str, int, bytes, complex, iterables, etc.

**Fix (this PR):** Keep the declarative `tp_methods` table but override `_lookup_tp_table` so entries are only visible when the wrapped value type matches (`_tp_method_applies_to_value`). getattr and `lookup_tp_method` both go through this hook, so e.g. `join` is not advertised on non-str constants.

## Evidence from existing PyTorch patterns

| Pattern | Example in tree | Why it works |
|---------|-----------------|--------------|
| Dedicated VT per Python type | `UserDefinedDictVariable` / `ListVariable` / `TupleVariable` each have their own `tp_methods` | One class ↔ one type family; no cross-type method leakage |
| Homogeneous builtin VT | `DictBuiltinVariable.fromkeys` (#195181) | Only wraps `dict`; method always applies |
| Homogeneous ndarray VT | `NumpyNdarrayVariable` tp_getset (#195477) | Dedicated subclass; attrs match `np.ndarray` |
| Partial + runtime guard | `TensorVariable.call_method` checks `hasattr(check_type, name)` on `example_value` before generic proxy | Handles tensor subtypes (sparse, DTensor, …) |
| **This PR** | Value-filtered `_lookup_tp_table` on `ConstantVariable` | Multi-type VT kept as one class; table filtered per instance value |

`ConstantVariable` is listed under "defer" on #195165 because it is multi-type; this PR proposes a middle ground without splitting into `StrConstantVariable` / `BytesConstantVariable` / … (larger refactor).

## What moved to `tp_methods`

| Method | Applies when |
|--------|----------------|
| `format` | str constant |
| `join` | str constant |
| `__iter__` | iterable constant (same as before) |
| `decode` | bytes constant |

Generic str/int/float/complex dispatch, SymNode promotion, and `__round__` stay in `call_method`.

## Alternatives considered

1. **Revert only (#195184 outcome)** — safe but no migration progress.
2. **Split VT subclasses** — cleanest long-term, out of scope for a small PR.
3. **Change `object_generic_getattr` globally** — infra-wide; needs maintainer design.
4. **Value-filtered lookup (chosen)** — localized to `ConstantVariable`; please say if you prefer a different approach.

## Test plan

- [ ] CI: `test/dynamo/test_tp_getattro.py` (`test_str_format_via_bound_method`, `test_str_join_via_bound_method`, `test_bytes_method_via_generic_getattr`)
- [ ] CI: `test/dynamo/test_misc.py -k format`
- [ ] CI: `test/dynamo/test_dicts.py -k decode`

Part of #195165. Supersedes closed #195184.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98 @guilhermeleobas @jansel