### PR TITLE
[MPS] Migrate `pow_Tensor_Tensor.out` to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -327,6 +327,13 @@ struct atan2_functor {
   }
 };
 
+struct pow_functor {
+  template <typename T>
+  inline T operator()(const T a, const T b) {
+    return static_cast<T>(c10::metal::pow(a, b));
+  }
+};
+
 // Complex binary functors
 struct polar_functor {
   template <typename U>
@@ -644,6 +651,10 @@ REGISTER_FLOAT_BINARY_OP(hermite_polynomial_he);
 REGISTER_INT2FLOAT_BINARY_OP(hermite_polynomial_he);
 REGISTER_FLOAT_BINARY_OP(laguerre_polynomial_l);
 REGISTER_INT2FLOAT_BINARY_OP(laguerre_polynomial_l);
+REGISTER_FLOAT_BINARY_OP(pow);
+REGISTER_INTEGER_BINARY_OP(pow);
+REGISTER_BINARY_OP(pow, float2, float2);
+REGISTER_BINARY_OP(pow, half2, half2);
 REGISTER_FLOAT_BINARY_OP(add);
 REGISTER_INTEGER_BINARY_OP(add);
 REGISTER_OPMATH_FLOAT_BINARY_OP(mul);

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -4,6 +4,7 @@
 #include <ATen/mps/MPSProfiler.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/Lerp.h>
+#include <ATen/native/Pow.h>
 #include <ATen/native/TensorFactories.h>
 #include <ATen/native/TensorIterator.h>
 #include <ATen/native/mps/OperationUtils.h>
@@ -61,6 +62,10 @@ void binary_op_kernel(const std::string func_name,
 
 static void atan2_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "atan2");
+}
+
+static void pow_tensor_tensor_mps_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "pow");
 }
 
 static void fmax_mps_kernel(TensorIteratorBase& iter) {
@@ -401,6 +406,7 @@ REGISTER_DISPATCH(igammac_stub, &igammac_mps_kernel)
 REGISTER_DISPATCH(hypot_stub, &hypot_mps_kernel)
 REGISTER_DISPATCH(gcd_stub, &gcd_mps_kernel)
 REGISTER_DISPATCH(lcm_stub, &lcm_mps_kernel)
+REGISTER_DISPATCH(pow_tensor_tensor_stub, &pow_tensor_tensor_mps_kernel)
 REGISTER_DISPATCH(bitwise_and_stub, &bitwise_and_mps_kernel)
 REGISTER_DISPATCH(bitwise_or_stub, &bitwise_or_mps_kernel)
 REGISTER_DISPATCH(bitwise_xor_stub, &bitwise_xor_mps_kernel)

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -208,7 +208,6 @@ static void add_sub_lerp_template(const Tensor& self,
   }
 
 // Arithmetic Binary Ops
-CREATE_MPS_STRUCTURED_BINARY_OP_FUNC(pow_tensor_tensor_out_mps, power, Tensor);
 CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_and_out_mps, logicalAND, Tensor);
 CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_or_out_mps, logicalOR, Tensor);
 CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_xor_out_mps, logicalXOR, Tensor);

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -10261,8 +10261,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: pow_Tensor_Tensor_out
-    MPS: pow_tensor_tensor_out_mps
+    CPU, CUDA, MPS, XPU: pow_Tensor_Tensor_out
   tags: pointwise
 
 - func: pow.Tensor_Tensor(Tensor self, Tensor exponent) -> Tensor

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -16417,6 +16417,11 @@ class TestConsistency(TestCaseMPS):
         if dtype == torch.complex64:
             if op.name == "mv":
                 return (2e-5, 1e-5)
+            # Complex pow uses the float32 polar form exp(y*log(x)); its
+            # precise:: transcendentals round differently than CPU libm, and
+            # the phase error is amplified by the result magnitude.
+            if op.name in ("pow", "__rpow__"):
+                return (1e-4, 3e-5)
         return (None, None)
 
     # Used for accept mode only

--- a/torch/testing/_internal/common_mps.py
+++ b/torch/testing/_internal/common_mps.py
@@ -23,17 +23,10 @@ if torch.backends.mps.is_available():
         # ops below are xfailed for complex32/complex64. Drill this list down as
         # complex support is added.
         UNSUPPORTED_COMPLEX_OPS = {
-            "__rpow__",
             "addr",
-            "as_stridedpartial_views",
             "cholesky_inverse",
             "float_power",
             "geqrf",
-            "jiterator_2inputs_2outputs",
-            "jiterator_4inputs_with_extra_args",
-            "jiterator_binary",
-            "jiterator_binary_return_by_ref",
-            "jiterator_unary",
             "linalg.eig",
             "linalg.eigvals",
             "linalg.inv",
@@ -50,7 +43,6 @@ if torch.backends.mps.is_available():
             "nn.functional.conv3d",
             "nn.functional.padreplicate_negative",
             "ormqr",
-            "pow",
             "renorm",
             "sparse.sampled_addmm",
             "to_sparse",
@@ -368,8 +360,6 @@ if torch.backends.mps.is_available():
                 torch.float16,
                 torch.bfloat16,
             ],
-            # zero to negative integer powers are undefined
-            "__rpow__": [torch.int8, torch.int16, torch.int32, torch.int64],
             # CPU Errors:
             "addr": [
                 torch.bool,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #195585
* #195592

That is just a binary op using all the existing binary iterator machinery plus `c10::metal::pow` functor, yields 2x speedups on small tensors, on part on large ones

`pow_Scalar_Tensor` still must be a separate dispatch, as unified machinery converts Double to float tensors

Allows one to remove some xfails where MPSGraph handling of ineger powers diverges and remove complex xfails (although with a small tolerance adjustement, because Metal and host triage functions slightly differ)

Also remove some non-relevant functions from UNSUPPORTED_COMPLEX_OPS
list