### PR TITLE
Anchor torch's installed artifacts on the import system, not on `__file__`

### DIFF
--- a/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
+++ b/test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
@@ -34,9 +34,10 @@ def get_pytorch_dir():
     # We only need to get the PyTorch installation directory, so whether the accelerator is loaded or not is irrelevant
     # If the accelerator has been previously built and not uninstalled, importing torch will cause a circular import error
     os.environ["TORCH_DEVICE_BACKEND_AUTOLOAD"] = "0"
-    import torch
+    from torch._utils_internal import get_file_path
 
-    return os.path.dirname(os.path.realpath(torch.__file__))
+    # Not torch.__file__: an editable install serves that from the source tree.
+    return os.path.realpath(get_file_path("torch"))
 
 
 def build_deps():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1038,6 +1038,12 @@ class TestTorchPathResolution(TestCase):
 
 
 class TestCppExtensionUtils(TestCase):
+    @unittest.skipIf(IS_FBCODE, "CMake package files are not shipped in fbcode")
+    def test_cmake_prefix_path(self):
+        prefix = torch.utils.cmake_prefix_path
+        config = os.path.join(prefix, "Torch", "TorchConfig.cmake")
+        self.assertTrue(os.path.isfile(config), f"{config} does not exist")
+
     def test_cpp_compiler_is_ok(self):
         self.assertTrue(torch.utils.cpp_extension.check_compiler_ok_for_platform("c++"))
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -966,6 +966,77 @@ class TestDeviceUtils(TestCase):
 instantiate_device_type_tests(TestDeviceUtils, globals())
 
 
+class TestTorchPathResolution(TestCase):
+    @unittest.skipIf(IS_FBCODE, "fbcode lays torch out differently")
+    def test_torch_parent_follows_the_extension_module(self):
+        spec = importlib.util.find_spec("torch._C")
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.origin)
+        expected = os.path.dirname(os.path.dirname(spec.origin))
+        self.assertEqual(torch._utils_internal.torch_parent, expected)
+
+    @unittest.skipIf(IS_FBCODE, "fbcode lays torch out differently")
+    def test_installed_torch_dir_prefers_the_editable_loader_paths(self):
+        installed_torch_dir = torch._utils_internal._installed_torch_dir
+        spec = importlib.util.find_spec("torch._C")
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.origin)
+        spec_dir = os.path.dirname(spec.origin)
+        with tempfile.TemporaryDirectory() as root:
+            checkout = os.path.join(root, "src", "torch")
+            installed = os.path.join(root, "site-packages", "torch")
+            # A checkout has a tracked torch/lib too, so lib/ alone cannot
+            # tell the trees apart; the checkout is excluded by identity.
+            os.makedirs(os.path.join(checkout, "lib"))
+            os.makedirs(os.path.join(installed, "lib"))
+            loader = types.SimpleNamespace(paths=[checkout, installed])
+            with mock.patch.object(torch, "__loader__", loader):
+                self.assertEqual(installed_torch_dir(checkout), installed)
+            if not IS_WINDOWS:
+                os.symlink(os.path.join(root, "src"), os.path.join(root, "alias"))
+                aliased = os.path.join(root, "alias", "torch")
+                loader = types.SimpleNamespace(paths=[aliased, installed])
+                with mock.patch.object(torch, "__loader__", loader):
+                    self.assertEqual(installed_torch_dir(checkout), installed)
+            # Only an entry holding lib/ is an install tree; otherwise the
+            # extension module's spec decides, as it does without any paths.
+            loader = types.SimpleNamespace(paths=[checkout, os.path.join(root, "x")])
+            with mock.patch.object(torch, "__loader__", loader):
+                self.assertEqual(installed_torch_dir(checkout), spec_dir)
+            with mock.patch.object(torch, "__loader__", types.SimpleNamespace()):
+                self.assertEqual(installed_torch_dir(checkout), spec_dir)
+
+    def test_stale_checkout_artifacts(self):
+        with tempfile.TemporaryDirectory() as root:
+            checkout = os.path.join(root, "torch")
+            for d in ("csrc", "lib/libshm", "bin", "include"):
+                os.makedirs(os.path.join(checkout, d))
+            os.makedirs(os.path.join(root, "torch.egg-info"))
+            ext = "_C.cpython-310-x86_64-linux-gnu.so"
+            deps = os.path.join("lib", "libtorch_global_deps.so")
+            c10 = os.path.join("lib", "libc10.so.1")
+            for f in (ext, deps, c10):
+                open(os.path.join(checkout, f), "w").close()
+            found = torch._utils_internal._stale_checkout_artifacts(checkout)
+            names = [ext, "bin", "include", c10, deps]
+            expected = [os.path.join(checkout, f) for f in names]
+            self.assertEqual(found, expected + [os.path.join(root, "torch.egg-info")])
+            clean = os.path.join(root, "clean", "torch")
+            os.makedirs(os.path.join(clean, "lib", "libshm"))
+            self.assertEqual(torch._utils_internal._stale_checkout_artifacts(clean), [])
+
+    @unittest.skipIf(IS_WINDOWS, "_load_global_deps is a no-op on Windows")
+    def test_load_global_deps_reports_missing_library(self):
+        real_exists = os.path.exists
+
+        def exists(path):
+            return "libtorch_global_deps" not in path and real_exists(path)
+
+        with unittest.mock.patch("os.path.exists", side_effect=exists):
+            with self.assertRaisesRegex(OSError, "libtorch_global_deps"):
+                torch._load_global_deps()
+
+
 class TestCppExtensionUtils(TestCase):
     def test_cpp_compiler_is_ok(self):
         self.assertTrue(torch.utils.cpp_extension.check_compiler_ok_for_platform("c++"))

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -406,28 +406,15 @@ def _load_global_deps() -> None:
     # Determine the file extension based on the platform
     lib_ext = ".dylib" if platform.system() == "Darwin" else ".so"
     lib_name = f"libtorch_global_deps{lib_ext}"
-    here = os.path.abspath(__file__)
-    global_deps_lib_path = os.path.join(os.path.dirname(here), "lib", lib_name)
-
-    # In scikit-build-core editable installs with redirect mode, native libs are
-    # installed to the dist package location rather than relative to __file__.
+    # get_file_path follows the compiled extension, which under a redirect-mode
+    # editable install lives beside the installed distribution, not __file__.
+    global_deps_lib_path = get_file_path("torch", "lib", lib_name)
     if not os.path.exists(global_deps_lib_path):
-        try:
-            from importlib.metadata import distribution
-
-            installed = distribution("torch").locate_file(
-                os.path.join("torch", "lib", lib_name)
-            )
-            # The importlib metadata SimplePath protocol was missing the exists
-            # method in older versions; however, the actual Path implementation
-            # has it and newer versions of importlib metadata have added it to
-            # the protocol, making the following ignore unnecessary from
-            # importlib_metadata 7.0.1 and Python 3.13 onwards.
-            # pyrefly: ignore[missing-attribute]
-            if installed.exists():
-                global_deps_lib_path = str(installed)
-        except Exception:
-            pass
+        # Handing a missing path to CDLL would surface as an unrelated dlopen
+        # failure through the CUDA-dependency retry below.
+        raise OSError(
+            f"{global_deps_lib_path} is missing; torch is not fully installed"
+        )
 
     try:
         ctypes.CDLL(global_deps_lib_path, mode=ctypes.RTLD_GLOBAL)

--- a/torch/_inductor/codegen/mps.py
+++ b/torch/_inductor/codegen/mps.py
@@ -13,6 +13,7 @@ import sympy
 from sympy.printing.precedence import PRECEDENCE
 
 import torch
+from torch._utils_internal import get_file_path
 from torch.utils._cpp_embed_headers import _embed_headers
 from torch.utils._ordered_set import OrderedSet
 from torch.utils._sympy.functions import Min
@@ -985,7 +986,7 @@ class MetalKernel(SIMDKernel):
                 ]
                 header_contents = _embed_headers(
                     headers,
-                    [Path(__file__).parent.parent.parent / "include"],
+                    [Path(get_file_path("torch")) / "include"],
                     OrderedSet(),  # type: ignore[arg-type]
                 )
                 code.writeline(header_contents)

--- a/torch/_utils_internal.py
+++ b/torch/_utils_internal.py
@@ -1,10 +1,12 @@
 # mypy: allow-untyped-defs
 import functools
+import importlib.util
 import logging
 import os
 import sys
 import tempfile
 import typing_extensions
+import warnings
 from collections.abc import Callable
 from typing import Any, TypeVar
 from typing_extensions import ParamSpec
@@ -35,24 +37,72 @@ if os.environ.get("TORCH_COMPILE_STROBELIGHT", False):
 # by an equivalent.
 
 
+def _stale_checkout_artifacts(checkout_torch_dir: str) -> list[str]:
+    """Build outputs left inside a source checkout's torch/ by an in-tree build
+    or an old setup.py install, which coexist badly with an editable install."""
+    found = []
+    for name in sorted(os.listdir(checkout_torch_dir)):
+        if name.startswith("_C.") and name.endswith((".so", ".pyd")):
+            found.append(os.path.join(checkout_torch_dir, name))
+    for sub in ("bin", "include", "share"):
+        path = os.path.join(checkout_torch_dir, sub)
+        if os.path.isdir(path):
+            found.append(path)
+    lib = os.path.join(checkout_torch_dir, "lib")
+    if os.path.isdir(lib):
+        for name in sorted(os.listdir(lib)):
+            if name.endswith((".so", ".dylib", ".dll")) or ".so." in name:
+                found.append(os.path.join(lib, name))
+    egg_info = os.path.join(os.path.dirname(checkout_torch_dir), "torch.egg-info")
+    if os.path.isdir(egg_info):
+        found.append(egg_info)
+    return found
+
+
+def _installed_torch_dir(torch_dir: str) -> str | None:
+    """The torch/ directory holding the compiled extension and the CMake-installed
+    lib/, include/, share/ and bin/. Under a redirect-mode editable install that is
+    beside the installed distribution, not torch_dir (the source checkout); for a
+    wheel or an in-tree build both are the same directory. None means no importable
+    extension, i.e. a libtorch wheel build (BUILD_LIBTORCH_WHL) or a frozen
+    interpreter."""
+    # scikit-build-core exposes a package's search locations as __loader__.paths
+    # (scikit-build/scikit-build-core#1567); the attribute is absent on older
+    # releases and in wheel installs. Their order is not guaranteed before
+    # scikit-build/scikit-build-core#1566, so the checkout is excluded by
+    # identity. lib/ cannot tell the trees apart (torch/lib is tracked); it only
+    # rejects an entry that is neither.
+    checkout = os.path.normcase(os.path.realpath(torch_dir))
+    for path in getattr(torch.__loader__, "paths", None) or []:
+        if os.path.normcase(os.path.realpath(path)) == checkout:
+            continue
+        if os.path.isdir(os.path.join(path, "lib")):
+            return os.path.abspath(path)
+    spec = importlib.util.find_spec("torch._C")
+    if spec is None or not spec.origin:
+        return None
+    return os.path.dirname(spec.origin)
+
+
 def _compute_torch_parent() -> str:
     torch_dir = os.path.dirname(os.path.abspath(__file__))
     if os.path.basename(torch_dir) == "shared":
         return os.path.dirname(os.path.dirname(torch_dir))
-    # In scikit-build-core editable installs with redirect mode, binary
-    # artifacts (bin/, lib/) are installed to the dist package directory
-    # rather than the source tree. Fall back to the installed package
-    # location for get_file_path.
-    if not os.path.isdir(os.path.join(torch_dir, "bin")):
-        try:
-            from importlib.metadata import distribution
-
-            installed = str(distribution("torch").locate_file("torch"))
-            if os.path.isdir(os.path.join(installed, "bin")):
-                return os.path.dirname(installed)
-        except Exception:
-            pass
-    return os.path.dirname(torch_dir)
+    installed_dir = _installed_torch_dir(torch_dir)
+    if installed_dir is None:
+        return os.path.dirname(torch_dir)
+    is_checkout = os.path.isfile(os.path.join(torch_dir, "CMakeLists.txt"))
+    if installed_dir != torch_dir and is_checkout:
+        stale = _stale_checkout_artifacts(torch_dir)
+        if stale:
+            listing = "\n  ".join(stale)
+            warnings.warn(
+                f"torch is installed at {installed_dir}, but the source checkout "
+                f"at {torch_dir} still holds build artifacts that tooling may "
+                f"pick up instead:\n  {listing}\nRemove them with `spin clean`.",
+                stacklevel=2,
+            )
+    return os.path.dirname(installed_dir)
 
 
 torch_parent = _compute_torch_parent()

--- a/torch/utils/__init__.py
+++ b/torch/utils/__init__.py
@@ -1,10 +1,10 @@
 # mypy: allow-untyped-defs
 
 import copyreg
-import os.path as _osp
 import weakref
 
 import torch
+from torch._utils_internal import get_file_path as _get_file_path
 from torch.utils import (
     backcompat as backcompat,
     collect_env as collect_env,
@@ -29,7 +29,7 @@ def set_module(obj, mod):
     obj.__module__ = mod
 
 
-cmake_prefix_path = _osp.join(_osp.dirname(_osp.dirname(__file__)), "share", "cmake")
+cmake_prefix_path = _get_file_path("torch", "share", "cmake")
 
 
 def swap_tensors(t1, t2):


### PR DESCRIPTION
## Summary

Follow-up to #195293, which #195295 closed by fixing the reported symptom. This fixes the path-resolution mechanism underneath it, including a hard `import torch` failure that nothing had reported and a defect that made #195295 itself correct only some of the time, and then applies the mechanism to three call sites that were waiting on it. Fixes #191752.

Redirect-mode editable installs (scikit-build-core) are the first layout where Python sources and CMake-installed artifacts live in different trees: `.py` in the checkout, `include/ lib/ bin/ share/` beside the installed distribution. Two lookups added in #180247 to cope with that ask a question a source checkout can answer wrongly.

**`_load_global_deps`** fell back to `importlib.metadata.distribution("torch")`, which returns the *first* torch distribution on `sys.path`, not necessarily the installed one. A checkout carrying a setuptools-era `torch.egg-info` supplies a nearer match whose `locate_file` resolves into the checkout, the `exists()` guard declines it, and `CDLL` proceeds with the path it already knew was missing. `import torch` fails, and since the `OSError` is routed through the CUDA-dependency retry it surfaces as an unrelated dlopen error naming the source tree.

**`_compute_torch_parent`** only consulted the distribution when `bin/` was absent beside the module. `tools/build_libtorch.py` installs into `<repo>/torch` by design (`docs/libtorch.rst` documents that flow), so a checkout can hold one while the artifacts that matter live elsewhere. The presence test then kept the fallback from firing and `get_file_path("torch")` silently returned the source tree, which made every caller conditionally wrong, including the already-merged #195295.

Both now ask the import system where torch is installed, through one helper, `_installed_torch_dir`, in the order RFC-0060 (pytorch/rfcs#109) prescribes:

1. the editable loader's `paths` (scikit-build/scikit-build-core#1567, in review): the entry that is not the checkout and holds `lib/`. Identity, not `lib/`, is what excludes the checkout, since `torch/lib` is a tracked source directory; the order of `paths` is only fixed by scikit-build/scikit-build-core#1566, hence the probe rather than `paths[0]`;
2. `importlib.util.find_spec("torch._C").origin`, the directory `_C` will actually be imported from in every layout, and the anchor `torch/__init__.py` already uses for the Windows DLL directory. This is the path every released scikit-build-core hits today;
3. `__file__`, only when there is no spec at all (`BUILD_LIBTORCH_WHL`, a frozen interpreter).

Instead of reasoning around leftovers, the helper detects them: in a checkout whose `_C` resolves elsewhere, an in-tree `_C`, `lib/*.so`, `bin/`, `include/`, `share/` or `torch.egg-info` produces a warning listing the paths and pointing at `spin clean`. A warning rather than an error, because the editable finder maps `_C` and every other CMake-installed module by name to the install tree, so the stale copies are never imported; they only mislead tooling that walks metadata or `__file__`.

`_load_global_deps` resolves through `get_file_path` like every other consumer and raises `OSError` when the library is missing, which is what `ctypes.CDLL` raised and what `torch.utils.collect_env` catches.

With `get_file_path` sound, three further commits apply it to call sites that derived an asset path from `__file__`. **`torch.utils.cmake_prefix_path`** computed `share/cmake` with no fallback at all, so `find_package(Torch)` failed against every editable install; it is a public API, documented in `docs/cpp/source/installing.md`, and gets a regression test that asserts `Torch/TorchConfig.cmake` is actually present. **`torch/_inductor/codegen/mps.py`** embedded `c10/metal/*.h` from `Path(__file__).parent.parent.parent / "include"` on the cpp_wrapper path, the twin of the site #195295 fixed. **`torch_openreg`'s `get_pytorch_dir()`** passed `dirname(torch.__file__)` as `-DPYTORCH_INSTALL_DIR`. The last two are taken from #192559 by @guptaishaan.

**Revision history.** The first revision of this PR resolved the installed tree through `importlib.metadata.distributions()` with a METADATA-versus-PKG-INFO filter, and was reviewed in that form on 2026-09-04. A self-review found the indirection leaking (a built checkout shadowing a wheel could pair the wheel's `libtorch_global_deps` with the checkout's `_C`), and the review's `bin/`-probe finding pointed the same way; the import-system anchor replaces it. The reply below the review maps each of its points to the current revision.

**Still not fixed here.** More `__file__`-derived lookups remain, in inductor, in distributed, and in the testing helpers. All are `exists()`-guarded, so they degrade quietly rather than failing, and each wants its own decision. They are inventoried in #195887, together with the sites that were checked and deliberately excluded.

This PR was authored with the assistance of an AI coding assistant.

## Test Plan

**Linux, redirect-mode editable install (scikit-build-core 1.0.0), checkout holding a stale `_C`, 13 in-tree libraries and a `torch.egg-info`**, patch applied then reverted:

```
python test/test_utils.py -k TestTorchPathResolution -k test_cmake_prefix_path -v
```

5 passed against the pushed head. The warning listed all leftovers; `torch_parent` and `cmake_prefix_path` resolve to site-packages. scikit-build-core 1.0.0 has no `__loader__.paths`, so this exercises the `_C`-spec step end to end; the loader-paths step is pinned by `test_installed_torch_dir_prefers_the_editable_loader_paths` with a fake loader, including the case where the checkout appears in `paths` under a symlinked spelling.

**Windows, redirect-mode editable install (MSVC, Ninja, scikit-build-core 1.0.0), clean checkout**, run against the `_C`-spec revision:

```
python test\test_utils.py -k TestTorchPathResolution -k test_cmake_prefix_path -v
```

3 passed, 1 skipped (the global-deps test is a no-op on Windows); no warning; `cmake_prefix_path` resolves to site-packages with `TorchConfig.cmake` present.

**`cmake_prefix_path`** was also checked on a macOS arm64 editable install (scikit-build-core 1.0.3) by configuring a real project, since printing the path proves nothing when the stale value is a well-formed string:

```cmake
cmake_minimum_required(VERSION 3.27)
project(probe LANGUAGES CXX)
find_package(Torch REQUIRED)
message(STATUS "PROBE_OK TORCH_LIBRARIES=${TORCH_LIBRARIES}")
```

configured with `-DCMAKE_PREFIX_PATH=$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')`:

| tree | result |
| --- | --- |
| before | exit 1, "Could not find a package configuration file provided by Torch" |
| after | exit 0, `PROBE_OK`, `TORCH_LIBRARIES` resolved into site-packages |
| reverted | exit 1 again |

The inductor MPS path needs a Metal device and was not exercised; it is the same one-line change as the merged #195295. Building torch_openreg needs a full extension build and was not run; the change substitutes one directory computation for another, and both resolve to `<site-packages>/torch` in a wheel install.

Lint:

```
spin lint -- torch/_utils_internal.py torch/__init__.py torch/utils/__init__.py torch/_inductor/codegen/mps.py test/test_utils.py test/cpp_extensions/open_registration_extension/torch_openreg/setup.py
```

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo
