### PR TITLE
[NCCL] Use get_window_offset for nccl_all_gather_offset

### DIFF
--- a/torch/csrc/distributed/c10d/symm_mem/ops/nccl_all_gather_offset.cu
+++ b/torch/csrc/distributed/c10d/symm_mem/ops/nccl_all_gather_offset.cu
@@ -276,7 +276,9 @@ void nccl_all_gather_offset(
   auto out_window = out_hdl->get_window();
   TORCH_CHECK(
       out_window != nullptr, "nccl_all_gather_offset: out window is null");
-  const size_t out_window_base_offset = out_hdl->get_offset();
+  // The window base is the signal pad, so offsets into it must skip the pad;
+  // use get_window_offset() (buffer_offset + get_offset()), not get_offset().
+  const size_t out_window_base_offset = out_hdl->get_window_offset();
   TORCH_CHECK(
       reinterpret_cast<uintptr_t>(input.data_ptr()) % AG_ALIGN == 0,
       "nccl_all_gather_offset: input must be 16-byte aligned");


### PR DESCRIPTION
Many `all_gather_offset` tests are failing in `test_nccl.py`. `nccl_all_gather_offset.cu` uses `get_offset()` instead of `get_window_offset` like the other symmem ops, `all_to_all` and `reduce_scatter_offset`, causing the kernel to write to the wrong offset, leaving the output all zero. This PR simply updates the allgather offset kernel to used window offset, which I confirmed fixes all the test failures.

A representative failure (recorded on GB200 but I don't expect it to be arch-dependent): 
```
======================================================================
ERROR: test_all_gather_offset_split_sizes0_explicit_offsets_False_bfloat16 (__main__.NCCLSymmetricMemoryTest.test_all_gather_offset_split_sizes0_explicit_offsets_False_bfloat16)
all_gather_offset: gather each rank's parameter shards into a
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 2203, in wrapper
    raise deferred_exception
RuntimeError: Exception in worker process:
Traceback (most recent call last):
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 1962, in _worker_loop
    cls._run_test_given_id(test_id)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 1910, in _run_test_given_id
    test_fn(**kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 2206, in wrapper
    fn()
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 3886, in wrapper
    method(*args, **kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 754, in instantiated_test
    test(self, **param_kwargs)
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_distributed.py", line 315, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/pytorch/test/distributed/test_nccl.py", line 1090, in test_all_gather_offset
    self.assertEqual(
  File "/opt/pytorch/pytorch/torch/testing/_internal/common_utils.py", line 4936, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Tensor-likes are not close!

Mismatched elements: 64 / 64 (100.0%)
Greatest absolute difference: 11.0 at index (0,) (up to 1e-05 allowed)
Greatest relative difference: 1.0 at index (0,) (up to 0.016 allowed)
rank 0: param 0 from src rank 0 mismatch

To execute this test, run the following from the base repo dir:
    python test/distributed/test_nccl.py NCCLSymmetricMemoryTest.test_all_gather_offset_split_sizes0_explicit_offsets_False_bfloat16

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0


----------------------------------------------------------------------

```

cc @eqy

Authored with assistance from agents