### PR TITLE
[BE][MPS] Migrate remaining logical ops to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/BinaryKernel.metal
@@ -546,6 +546,28 @@ DEFINE_BINARY_COMPARISON_FUNCTOR(le, <=);
 DEFINE_BINARY_COMPARISON_FUNCTOR(gt, >);
 DEFINE_BINARY_COMPARISON_FUNCTOR(ge, >=);
 
+// Logical ops test truthiness of each operand then combine. cast_to<bool>
+// handles every dtype: scalars as x != 0, complex as the per-component nonzero
+// test.
+struct logical_and_functor {
+  template <typename T>
+  inline bool operator()(const T a, const T b) {
+    return c10::metal::cast_to<bool>(a) && c10::metal::cast_to<bool>(b);
+  }
+};
+struct logical_or_functor {
+  template <typename T>
+  inline bool operator()(const T a, const T b) {
+    return c10::metal::cast_to<bool>(a) || c10::metal::cast_to<bool>(b);
+  }
+};
+struct logical_xor_functor {
+  template <typename T>
+  inline bool operator()(const T a, const T b) {
+    return c10::metal::cast_to<bool>(a) != c10::metal::cast_to<bool>(b);
+  }
+};
+
 #define REGISTER_INTEGER_BINARY_OP_NO_BOOL(NAME) \
   REGISTER_BINARY_OP(NAME, long, long);          \
   REGISTER_BINARY_OP(NAME, int, int);            \
@@ -599,8 +621,8 @@ DEFINE_BINARY_COMPARISON_FUNCTOR(ge, >=);
   REGISTER_BINARY_OP(NAME, bool, bool);           \
   REGISTER_BINARY_CASTOUT_OP(NAME, bool, bool)
 
-// Complex variants for eq/ne only -- lt/le/gt/ge are not well-defined on
-// complex numbers.
+// Complex variants for eq/ne and the logical ops (complex->bool). lt/le/gt/ge
+// are not well-defined on complex numbers, so they don't use this.
 #define REGISTER_COMPLEX_EQ_OP(NAME)              \
   REGISTER_BINARY_OP(NAME, float2, bool);         \
   REGISTER_BINARY_CASTOUT_OP(NAME, float2, bool); \
@@ -688,6 +710,12 @@ REGISTER_COMPARISON_OP(lt);
 REGISTER_COMPARISON_OP(le);
 REGISTER_COMPARISON_OP(gt);
 REGISTER_COMPARISON_OP(ge);
+REGISTER_COMPARISON_OP(logical_and);
+REGISTER_COMPLEX_EQ_OP(logical_and);
+REGISTER_COMPARISON_OP(logical_or);
+REGISTER_COMPLEX_EQ_OP(logical_or);
+REGISTER_COMPARISON_OP(logical_xor);
+REGISTER_COMPLEX_EQ_OP(logical_xor);
 REGISTER_BINARY_ALPHA_OP(add_alpha, long, long, long);
 REGISTER_BINARY_ALPHA_OP(add_alpha, int, int, int);
 REGISTER_BINARY_ALPHA_OP(add_alpha, float, float, float);

--- a/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/UnaryKernel.metal
@@ -677,13 +677,9 @@ REGISTER_UNARY_OP(bitwise_not, uchar, uchar);
 REGISTER_UNARY_OP(bitwise_not, bool, bool);
 
 struct logical_not_functor {
-  template <typename T, enable_if_t<!is_complex_v<T>, bool> = true>
+  template <typename T>
   inline bool operator()(const T x) {
-    return x == T(0);
-  }
-  template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
-  inline bool operator()(const T x) {
-    return x.x == 0 && x.y == 0;
+    return !c10::metal::cast_to<bool>(x);
   }
 };
 

--- a/aten/src/ATen/native/mps/operations/BinaryKernel.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryKernel.mm
@@ -368,6 +368,18 @@ static void ge_mps_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "ge", std::nullopt, std::nullopt, kBool, kCmpILPThreshold);
 }
 
+static void logical_and_mps_kernel(TensorIterator& iter) {
+  lib.exec_binary_kernel(iter, "logical_and", std::nullopt, std::nullopt, kBool, kCmpILPThreshold);
+}
+
+static void logical_or_mps_kernel(TensorIterator& iter) {
+  lib.exec_binary_kernel(iter, "logical_or", std::nullopt, std::nullopt, kBool, kCmpILPThreshold);
+}
+
+static void logical_xor_mps_kernel(TensorIterator& iter) {
+  lib.exec_binary_kernel(iter, "logical_xor", std::nullopt, std::nullopt, kBool, kCmpILPThreshold);
+}
+
 REGISTER_DISPATCH(atan2_stub, &atan2_mps_kernel)
 REGISTER_DISPATCH(fmax_stub, &fmax_mps_kernel)
 REGISTER_DISPATCH(fmin_stub, &fmin_mps_kernel)
@@ -418,4 +430,7 @@ REGISTER_DISPATCH(lt_stub, &lt_mps_kernel)
 REGISTER_DISPATCH(le_stub, &le_mps_kernel)
 REGISTER_DISPATCH(gt_stub, &gt_mps_kernel)
 REGISTER_DISPATCH(ge_stub, &ge_mps_kernel)
+REGISTER_DISPATCH(logical_and_stub, &logical_and_mps_kernel)
+REGISTER_DISPATCH(logical_or_stub, &logical_or_mps_kernel)
+REGISTER_DISPATCH(logical_xor_stub, &logical_xor_mps_kernel)
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/BinaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/BinaryOps.mm
@@ -1,7 +1,5 @@
 //  Copyright © 2022 Apple Inc.
 #define TORCH_ASSERT_ONLY_METHOD_OPERATORS
-#include <ATen/ExpandUtils.h>
-#include <ATen/ScalarOps.h>
 #include <ATen/native/BinaryOps.h>
 #include <ATen/native/mps/OperationUtils.h>
 #include <ATen/native/mps/operations/BinaryKernel.h>
@@ -11,146 +9,14 @@
 #include <ATen/NativeFunctions.h>
 #else
 #include <ATen/ops/add_native.h>
-#include <ATen/ops/div_native.h>
-#include <ATen/ops/logical_and_native.h>
-#include <ATen/ops/logical_or_native.h>
-#include <ATen/ops/logical_xor_native.h>
 #include <ATen/ops/pow.h>
 #include <ATen/ops/pow_native.h>
 #include <ATen/ops/result_type.h>
 #include <ATen/ops/sub_native.h>
-#include <ATen/ops/view_as_real.h>
 #endif
 
 namespace at::native {
 namespace mps {
-
-struct BinaryOpCachedGraph : public MPSCachedGraph {
-  BinaryOpCachedGraph(MPSGraph* graph) : MPSCachedGraph(graph) {}
-  MPSGraphTensor *primaryTensor = nil, *secondaryTensor = nil;
-  MPSGraphTensor* outputTensor = nil;
-};
-
-typedef MPSGraphTensor* (^BinaryOpBlock)(BinaryOpCachedGraph*, MPSGraphTensor*, MPSGraphTensor*);
-#define BinaryOpFn(graph, primary, secondary) \
-  MPSGraphTensor*(mps::BinaryOpCachedGraph * graph, MPSGraphTensor * primary, MPSGraphTensor * secondary)
-
-static void binaryOpTensor(const Tensor& self,
-                           const Tensor& other,
-                           const Tensor& output_,
-                           std::string op_name,
-                           BinaryOpBlock binaryBlock) {
-  MPSStream* mpsStream = getCurrentMPSStream();
-
-  const bool is_self_scalar = self.dim() == 0;
-  const bool is_other_scalar = other.dim() == 0;
-
-  auto new_size = at::infer_size(self.sizes(), other.sizes());
-  if (!output_.sizes().equals(new_size)) {
-    output_.resize_(new_size);
-  }
-
-  // it's possible to receive empty tensors here
-  if (self.numel() == 0 || other.numel() == 0) {
-    return;
-  }
-
-  Tensor output = output_;
-  bool needsCopyToOutput = false;
-
-  static const bool is_macOS_15_0_or_newer = is_macos_at_least(MacOSVersion::MACOS_15_0);
-  if (!is_macOS_15_0_or_newer &&
-      (needsGather(output_) || (output_.is_view() && (self.is_alias_of(output_) || other.is_alias_of(output_))))) {
-    output = at::empty(output_.sizes(), output_.scalar_type(), std::nullopt, kMPS, std::nullopt, std::nullopt);
-    needsCopyToOutput = true;
-  }
-
-  auto inputDataType = self.scalar_type();
-  auto otherDataType = other.scalar_type();
-  auto outputDataType = output_.scalar_type();
-  auto common_dtype = c10::promoteTypes(inputDataType, otherDataType);
-  // this type inference is only required at the time of graph creation
-  if (isIntegralType(common_dtype, true)) {
-    // integer inputs must be cast to float, if output is float
-    if (isFloatingType(outputDataType)) {
-      common_dtype = outputDataType;
-      // in boolean comparison ops with signed vs. unsigned integers, we always cast to the unsigned type
-    } else if (outputDataType == ScalarType::Bool &&
-               (inputDataType == ScalarType::Byte || otherDataType == ScalarType::Byte)) {
-      common_dtype = ScalarType::Byte;
-    }
-  }
-
-  @autoreleasepool {
-    std::string key = op_name + getTensorsStringKey({self, other, output_});
-    auto cachedGraph = LookUpOrCreateCachedGraph<BinaryOpCachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      newCachedGraph->primaryTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(inputDataType), getMPSShape(self));
-      newCachedGraph->secondaryTensor =
-          mpsGraphRankedPlaceHolder(mpsGraph, getMPSScalarType(otherDataType), getMPSShape(other));
-
-      MPSGraphTensor* primaryCastTensor = newCachedGraph->primaryTensor;
-      MPSGraphTensor* secondaryCastTensor = newCachedGraph->secondaryTensor;
-
-      if (inputDataType != common_dtype) {
-        primaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->primaryTensor, common_dtype);
-      }
-      if (otherDataType != common_dtype) {
-        secondaryCastTensor = castMPSTensor(mpsGraph, newCachedGraph->secondaryTensor, common_dtype);
-      }
-      newCachedGraph->outputTensor = binaryBlock(newCachedGraph, primaryCastTensor, secondaryCastTensor);
-      // Cast output tensor to an expected type if needed, which addresses discrepancy when int64 scalar is added to
-      // int32 tensor Output tensor should have been promoted but it remains an int32 tensor
-      if (outputDataType != common_dtype || [newCachedGraph->outputTensor dataType] != getMPSDataType(outputDataType)) {
-        newCachedGraph->outputTensor = castMPSTensor(mpsGraph, newCachedGraph->outputTensor, outputDataType);
-      }
-    });
-
-    NSMutableDictionary* feeds = [[NSMutableDictionary new] autorelease];
-    Placeholder selfPlaceholder;
-    Placeholder otherPlaceholder;
-    MPSScalar self_scalar;
-    MPSScalar other_scalar;
-
-    if (is_self_scalar && !self.is_mps()) {
-      self_scalar = getMPSScalar(self.item(), inputDataType);
-      feeds[cachedGraph->primaryTensor] = getMPSGraphTensorFromScalar(mpsStream, self_scalar);
-    } else {
-      selfPlaceholder = Placeholder(cachedGraph->primaryTensor,
-                                    self,
-                                    /*mpsShape*/ nil,
-                                    /*gatherTensorData=*/true,
-                                    getMPSScalarType(inputDataType));
-      feeds[selfPlaceholder.getMPSGraphTensor()] = selfPlaceholder.getMPSGraphTensorData();
-    }
-    if (is_other_scalar && !other.is_mps()) {
-      other_scalar = getMPSScalar(other.item(), otherDataType);
-      feeds[cachedGraph->secondaryTensor] = getMPSGraphTensorFromScalar(mpsStream, other_scalar);
-    } else {
-      otherPlaceholder = Placeholder(cachedGraph->secondaryTensor,
-                                     other,
-                                     /*mpsShape*/ nil,
-                                     /*gatherTensorData=*/true,
-                                     getMPSScalarType(otherDataType));
-      feeds[otherPlaceholder.getMPSGraphTensor()] = otherPlaceholder.getMPSGraphTensorData();
-    }
-
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor, needsCopyToOutput ? output : output_);
-    runMPSGraph(mpsStream, cachedGraph->graph(), feeds, outputPlaceholder);
-
-    if (needsCopyToOutput) {
-      output_.copy_(output);
-    }
-  }
-}
-
-static void binaryOpScalar(const Tensor& self,
-                           const Scalar& other,
-                           const Tensor& output,
-                           std::string op_name,
-                           BinaryOpBlock binaryBlock) {
-  binaryOpTensor(self, wrapped_scalar_tensor(other), output, op_name, binaryBlock);
-}
 
 static void add_sub_lerp_template(const Tensor& self,
                                   const Tensor& other,
@@ -182,35 +48,6 @@ static void add_sub_lerp_template(const Tensor& self,
 }
 
 } // namespace mps
-
-#define CREATE_MPS_BINARY_COMPARISON_OP_FUNC(func_out, func_stub, other_type)                               \
-  Tensor& func_out(const Tensor& self, const other_type& other, Tensor& output) {                           \
-    mps::binaryOp##other_type(                                                                              \
-        self, other, output, #func_stub, ^BinaryOpFn(cachedGraph, primaryCastTensor, secondaryCastTensor) { \
-          MPSGraph* mpsGraph = cachedGraph->graph();                                                        \
-          return [mpsGraph func_stub##                                                                      \
-              WithPrimaryTensor:mps::castMPSTensor(mpsGraph, primaryCastTensor, ScalarType::Bool)           \
-                secondaryTensor:mps::castMPSTensor(mpsGraph, secondaryCastTensor, ScalarType::Bool)         \
-                           name:nil];                                                                       \
-        });                                                                                                 \
-    return output;                                                                                          \
-  }
-
-#define CREATE_MPS_STRUCTURED_BINARY_OP_FUNC(func_out, func_stub, other_type)                               \
-  TORCH_IMPL_FUNC(func_out)(const Tensor& self, const other_type& other, const Tensor& output) {            \
-    mps::binaryOp##other_type(                                                                              \
-        self, other, output, #func_stub, ^BinaryOpFn(cachedGraph, primaryCastTensor, secondaryCastTensor) { \
-          MPSGraph* mpsGraph = cachedGraph->graph();                                                        \
-          return [mpsGraph func_stub##WithPrimaryTensor:primaryCastTensor                                   \
-                                        secondaryTensor:secondaryCastTensor                                 \
-                                                   name:nil];                                               \
-        });                                                                                                 \
-  }
-
-// Arithmetic Binary Ops
-CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_and_out_mps, logicalAND, Tensor);
-CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_or_out_mps, logicalOR, Tensor);
-CREATE_MPS_BINARY_COMPARISON_OP_FUNC(logical_xor_out_mps, logicalXOR, Tensor);
 
 TORCH_IMPL_FUNC(add_out_mps)(const Tensor& self, const Tensor& other, const Scalar& alpha, const Tensor& output) {
   mps::add_sub_lerp_template(self, other, alpha, output, "add");

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1293,8 +1293,7 @@
 - func: logical_xor.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA, MTIA, XPU: logical_xor_out
-    MPS: logical_xor_out_mps
+    CPU, CUDA, MPS, MTIA, XPU: logical_xor_out
   tags: pointwise
 
 - func: logical_and(Tensor self, Tensor other) -> Tensor
@@ -1314,8 +1313,7 @@
 - func: logical_and.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA, MTIA, XPU: logical_and_out
-    MPS: logical_and_out_mps
+    CPU, CUDA, MPS, MTIA, XPU: logical_and_out
   tags: pointwise
 
 - func: logical_or(Tensor self, Tensor other) -> Tensor
@@ -1335,8 +1333,7 @@
 - func: logical_or.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   device_check: NoCheck   # TensorIterator
   dispatch:
-    CPU, CUDA, MTIA, XPU: logical_or_out
-    MPS: logical_or_out_mps
+    CPU, CUDA, MPS, MTIA, XPU: logical_or_out
   tags: pointwise
 
 - func: blackman_window(int window_length, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None) -> Tensor

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -14858,13 +14858,6 @@ op_db: list[OpInfo] = [
                     dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int32, torch.int8, torch.bool),
                     supports_autograd=False,
                     always_returns_bool=True,
-                    skips=(
-                        # AssertionError: UserWarning not triggered : Resized a non-empty tensor but did not warn about it.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-                        # AssertionError: RuntimeError not raised : Expected RuntimeError when calling with
-                        # input.device=mps:0 and out.device=cpu.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                    ),
                     supports_rhs_python_scalar=False),
     BinaryUfuncInfo('logical_or',
                     ref=np.logical_or,
@@ -14872,13 +14865,6 @@ op_db: list[OpInfo] = [
                     dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int8, torch.bool),
                     supports_autograd=False,
                     always_returns_bool=True,
-                    skips=(
-                        # AssertionError: UserWarning not triggered : Resized a non-empty tensor but did not warn about it.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-                        # AssertionError: RuntimeError not raised : Expected RuntimeError when calling with
-                        # input.device=mps:0 and out.device=cpu.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                    ),
                     supports_rhs_python_scalar=False),
     BinaryUfuncInfo('logical_xor',
                     ref=np.logical_xor,
@@ -14886,14 +14872,7 @@ op_db: list[OpInfo] = [
                     dtypesIfHpu=custom_types(torch.float32, torch.bfloat16, torch.int8, torch.bool),
                     supports_autograd=False,
                     always_returns_bool=True,
-                    supports_rhs_python_scalar=False,
-                    skips=(
-                        # AssertionError: UserWarning not triggered : Resized a non-empty tensor but did not warn about it.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out_warning', device_type='mps'),
-                        # AssertionError: RuntimeError not raised : Expected RuntimeError when calling with
-                        # input.device=mps:0 and out.device=cpu.
-                        DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_out', device_type='mps'),
-                    )),
+                    supports_rhs_python_scalar=False),
     BinaryUfuncInfo('bitwise_and',
                     ref=np.bitwise_and,
                     dtypes=integral_types_and(torch.bool),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* #195585
* __->__ #195592

Using `c10:metal::cast_to<bool>` primitive to have consistent behavior for complex numbers, which fixes bug in MPSGraph implementation when op was called for complex types (previously only real part were checked, not complex value is truthy when either real or complex parts are nonzero)
