### PR TITLE
[MPS] Reject an output_padding that CPU and CUDA reject

### DIFF
--- a/aten/src/ATen/native/mps/operations/Convolution.mm
+++ b/aten/src/ATen/native/mps/operations/Convolution.mm
@@ -1226,6 +1226,18 @@ Tensor _mps_convolution_transpose(const Tensor& input_t,
       (input_t.dim() == 5 && (input_t.scalar_type() == kHalf || input_t.scalar_type() == kBFloat16));
   TORCH_CHECK(!is_unsupported_3d_dtype, "ConvTranspose 3D with BF16 or FP16 types is not supported on MPS");
 
+  // conv_input_size() below computes a size from output_padding without checking it, so an
+  // out-of-range value silently widens the output instead of erroring as it does on CPU and CUDA.
+  for (const auto i : c10::irange(output_padding.size())) {
+    TORCH_CHECK(output_padding[i] < stride[i] || output_padding[i] < dilation[i],
+                "output padding must be smaller than either stride or dilation, but got output_padding: ",
+                output_padding,
+                " stride: ",
+                stride,
+                " dilation: ",
+                dilation);
+  }
+
   auto output_t =
       mps_convolution_transpose_forward(input_t, weight_t, padding, output_padding, stride, dilation, groups);
   return output_t;

--- a/test/test_mps.py
+++ b/test/test_mps.py
@@ -3562,6 +3562,16 @@ class TestMPS(TestCaseMPS):
                         helper((N, C_out, H, W), (C_out, C_in, kH, kW), bias_shape=(C_in), stride=stride,
                                padding=padding, output_padding=output_padding, dilation=dilation)
 
+    def test_conv_transpose_output_padding_validation(self):
+        # MPS accepted an out-of-range output_padding and silently widened the output,
+        # where CPU and CUDA raise. https://github.com/pytorch/pytorch/issues/169236
+        for dims, ctor in ((2, torch.nn.ConvTranspose2d), (3, torch.nn.ConvTranspose3d)):
+            x = torch.randn(1, 1, *([8] * dims))
+            for device in ("cpu", "mps"):
+                m = ctor(1, 1, 3, stride=1, output_padding=2).to(device)
+                with self.assertRaisesRegex(RuntimeError, "output padding must be smaller"):
+                    m(x.to(device))
+
     # Test sigmoid
     def test_sigmoid(self):
         def helper(shape):


### PR DESCRIPTION
Fixes #169236.

I built this branch and ran its test locally on Apple silicon before submitting.
The description below was drafted with an AI assistant, so it is quoted rather than
presented as my own prose.

> ## Why this is needed
>
> `ConvTranspose{1,2,3}d` on MPS accepts an `output_padding` that CPU and CUDA reject,
> and silently returns a differently shaped tensor instead of raising:
>
> ```python
> import torch.nn as nn
> m = nn.ConvTranspose2d(1, 1, 3, stride=1, output_padding=2)
> x = torch.randn(1, 1, 8, 8)
>
> m(x)                          # RuntimeError: output padding must be smaller than
>                               # either stride or dilation, but got
>                               # output_padding_height: 2 output_padding_width: 2
> m.to("mps")(x.to("mps"))      # returns shape (1, 1, 12, 12)
> ```
>
> A model that is wrong on CPU runs to completion on MPS with a wider output, which
> then propagates through the rest of the network. Silent divergence rather than a
> loud one.
>
> ## Root cause
>
> The validation lives in the naive kernels: `NaiveConvolutionTranspose2d.cpp` and
> `NaiveConvolutionTranspose3d.cpp` for CPU, and the matching `.cu` files for CUDA.
> `ConvParams::is_output_padding_big()` in `Convolution.cpp` exists but is only
> consulted for backend selection, not as a check, and the only unconditional check in
> the dispatcher is `is_output_padding_neg()`.
>
> `_mps_convolution_transpose` never validates. It hands `output_padding` straight to
> `conv_input_size()`, which happily computes a larger input size from it, and that
> size becomes the output shape.
>
> ## Change
>
> Adds the check to `_mps_convolution_transpose`, before the size is computed. The
> condition is the one the CPU kernels use, `output_padding < stride ||
> output_padding < dilation` per spatial dimension, so all three backends now accept
> and reject the same arguments.
>
> The message keeps the CPU wording for its first clause, so anything matching on
> `"output padding must be smaller than either stride or dilation"` still matches, but
> prints the three arrays rather than naming each axis. That keeps one loop for 1d, 2d
> and 3d instead of three spellings of the same check.

## Test plan

Added `test_conv_transpose_output_padding_validation` to `test/test_mps.py`. It asserts
the same rejection on `cpu` and on `mps`, for 2d and 3d, so it fails on `main` at the
`mps` leg and passes with this change.

```
python test/test_mps.py -k test_conv_transpose_output_padding_validation -v
python test/test_mps.py -k test_conv_transpose2d -v
```

The existing `test_conv_transpose2d` already skips out-of-range combinations
(`test_mps.py`, the `output_padding >= stride or output_padding >= dilation` continue),
so it never exercised this path and is unaffected.

> Also checked against CPU directly, so that the accept/reject boundary is
> compared backend to backend for 1d, 2d and 3d and for the dilation branch as
> well as the stride branch, rather than only at the single point the unit test
> uses:
>
> ```python
> import torch
> import torch.nn as nn
>
> msg = "output padding must be smaller than either stride or dilation"
>
> for dim, mod in ((1, nn.ConvTranspose1d), (2, nn.ConvTranspose2d), (3, nn.ConvTranspose3d)):
>     x = torch.randn(1, 1, *([8] * dim))
>
>     # output_padding >= stride and >= dilation: both backends must reject
>     for stride, dilation, output_padding in ((1, 1, 1), (2, 1, 2), (1, 2, 2), (2, 3, 3)):
>         m = mod(1, 1, 3, stride=stride, dilation=dilation, output_padding=output_padding)
>         for dev in ("cpu", "mps"):
>             try:
>                 m.to(dev)(x.to(dev))
>             except RuntimeError as e:
>                 if msg not in str(e):
>                     raise AssertionError(f"{dev} {dim}d: wrong message: {e}") from e
>             else:
>                 raise AssertionError(f"{dev} {dim}d: accepted output_padding={output_padding}")
>
>     # below the boundary: both backends must accept, and agree on the shape
>     for stride, dilation, output_padding in ((2, 1, 1), (3, 1, 2), (1, 3, 2)):
>         m = mod(1, 1, 3, stride=stride, dilation=dilation, output_padding=output_padding)
>         ref = m.to("cpu")(x)
>         got = m.to("mps")(x.to("mps"))
>         if got.shape != ref.shape:
>             raise AssertionError(f"{dim}d: {got.shape} vs {ref.shape}")
>         torch.testing.assert_close(got.cpu(), ref, atol=1e-5, rtol=1e-5)
> ```
