### PR TITLE
[MPS] Migrate logit_backward and tanh_backward to Metal

### DIFF
--- a/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
+++ b/aten/src/ATen/native/mps/kernels/ActivationKernel.metal
@@ -354,6 +354,49 @@ REGISTER_BINARY_OP(sigmoid_backward, bfloat, bfloat);
 REGISTER_BINARY_OP(sigmoid_backward, float2, float2);
 REGISTER_BINARY_OP(sigmoid_backward, half2, half2);
 
+struct tanh_backward_functor {
+  template <typename T, enable_if_t<is_scalar_floating_point_v<T>, bool> = true>
+  inline T operator()(const T grad_output, const T output) {
+    const float o = float(output);
+    return static_cast<T>(float(grad_output) * (1.0f - o * o));
+  }
+  template <typename T, enable_if_t<is_complex_v<T>, bool> = true>
+  inline T operator()(const T grad_output, const T output) {
+    return c10::metal::mul(
+        grad_output,
+        c10::metal::conj(T(1, 0) - c10::metal::mul(output, output)));
+  }
+};
+
+REGISTER_BINARY_OP(tanh_backward, float, float);
+REGISTER_BINARY_OP(tanh_backward, half, half);
+REGISTER_BINARY_OP(tanh_backward, bfloat, bfloat);
+REGISTER_BINARY_OP(tanh_backward, float2, float2);
+REGISTER_BINARY_OP(tanh_backward, half2, half2);
+
+// grad wrt logit input: dy / (x * (1 - x)), zeroed (eps set) or NaN'd (no eps)
+// outside the valid interval. Matches logit_backward_kernel in
+// native/cpu/BinaryOpsKernel.cpp; eps < 0 signals the no-clamp variant.
+struct logit_backward_functor {
+  template <typename T>
+  inline T operator()(const T grad_output, const T x, const T eps) {
+    const float xf = float(x);
+    const float e = float(eps);
+    if (e < 0.0f) {
+      if (xf < 0.0f || xf > 1.0f) {
+        return static_cast<T>(NAN);
+      }
+    } else if (xf < e || xf > 1.0f - e) {
+      return static_cast<T>(0);
+    }
+    return static_cast<T>(float(grad_output) / (xf * (1.0f - xf)));
+  }
+};
+
+REGISTER_BINARY_ALPHA_OP(logit_backward, float, float, float);
+REGISTER_BINARY_ALPHA_OP(logit_backward, half, half, half);
+REGISTER_BINARY_ALPHA_OP(logit_backward, bfloat, bfloat, bfloat);
+
 struct glu_functor {
   template <typename T>
   inline T operator()(const T a, const T b) {

--- a/aten/src/ATen/native/mps/operations/Activation.mm
+++ b/aten/src/ATen/native/mps/operations/Activation.mm
@@ -18,7 +18,6 @@
 #include <ATen/ops/relu_native.h>
 #include <ATen/ops/softplus_backward_native.h>
 #include <ATen/ops/softplus_native.h>
-#include <ATen/ops/tanh_backward_native.h>
 #include <ATen/ops/threshold_backward_native.h>
 #include <ATen/ops/threshold_native.h>
 #endif
@@ -116,46 +115,6 @@ TORCH_IMPL_FUNC(log_softmax_backward_mps_out)
     // Create dictionary of inputs and outputs
     auto feeds = dictionaryFromPlaceholders(gradPlaceholder, outputPlaceholder);
     runMPSGraph(stream, cachedGraph->graph(), feeds, resultPlaceholder);
-  }
-}
-
-TORCH_IMPL_FUNC(tanh_backward_out_mps)(const Tensor& grad_output, const Tensor& output, const Tensor& grad_input) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-  TORCH_CHECK(grad_input.is_mps());
-
-  if (grad_output.numel() == 0) {
-    return;
-  }
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "tanh_backward_out_mps:" + getMPSTypeString(grad_output);
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* gradOutputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(grad_output));
-      MPSGraphTensor* outputTensor = mpsGraphUnrankedPlaceHolder(mpsGraph, getMPSDataType(output));
-
-      MPSGraphTensor* unitTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:getMPSDataType(grad_output)];
-      MPSGraphTensor* tanh2Tensor = [mpsGraph squareWithTensor:outputTensor name:nil];
-      MPSGraphTensor* oneMinusTanh2Tensor = [mpsGraph subtractionWithPrimaryTensor:unitTensor
-                                                                   secondaryTensor:tanh2Tensor
-                                                                              name:nil];
-      MPSGraphTensor* gradInputTensor = [mpsGraph multiplicationWithPrimaryTensor:gradOutputTensor
-                                                                  secondaryTensor:oneMinusTanh2Tensor
-                                                                             name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->outputTensor_ = outputTensor;
-      newCachedGraph->gradInputTensor_ = gradInputTensor;
-    });
-
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder outputPlaceholder = Placeholder(cachedGraph->outputTensor_, output);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-
-    auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, outputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
   }
 }
 

--- a/aten/src/ATen/native/mps/operations/ActivationKernel.mm
+++ b/aten/src/ATen/native/mps/operations/ActivationKernel.mm
@@ -161,6 +161,14 @@ static void sigmoid_backward_kernel(TensorIteratorBase& iter) {
   lib.exec_binary_kernel(iter, "sigmoid_backward");
 }
 
+static void tanh_backward_kernel(TensorIteratorBase& iter) {
+  lib.exec_binary_kernel(iter, "tanh_backward");
+}
+
+static void logit_backward_kernel(TensorIteratorBase& iter, const Scalar& eps) {
+  lib.exec_binary_kernel(iter, "logit_backward", eps);
+}
+
 // Collapse a tensor around the split dim into [outer, 2*L], where
 // L = (size[dim]/2) * product(size[dim+1:]) is the contiguous run per outer row
 // (the two halves of a row sit L elements apart). Valid only for a contiguous
@@ -359,5 +367,7 @@ REGISTER_DISPATCH(mish_backward_stub, mish_backward_kernel);
 REGISTER_DISPATCH(GeluKernel, gelu_kernel);
 REGISTER_DISPATCH(GeluBackwardKernel, gelu_backward_kernel);
 REGISTER_DISPATCH(sigmoid_backward_stub, sigmoid_backward_kernel);
+REGISTER_DISPATCH(tanh_backward_stub, tanh_backward_kernel);
+REGISTER_DISPATCH(logit_backward_stub, logit_backward_kernel);
 
 } // namespace at::native

--- a/aten/src/ATen/native/mps/operations/UnaryOps.mm
+++ b/aten/src/ATen/native/mps/operations/UnaryOps.mm
@@ -25,7 +25,6 @@
 #include <ATen/ops/frac_native.h>
 #include <ATen/ops/imag.h>
 #include <ATen/ops/logical_not_native.h>
-#include <ATen/ops/logit_backward_native.h>
 #include <ATen/ops/logit_native.h>
 #include <ATen/ops/neg.h>
 #include <ATen/ops/neg_native.h>
@@ -248,66 +247,6 @@ Tensor logit_mps(const Tensor& self, std::optional<double> eps) {
   Tensor result = at::empty(self.sizes(), out_dtype, std::nullopt, kMPS, std::nullopt, std::nullopt);
   logit_mps_impl(self, eps, result, "logit_mps");
   return result;
-}
-
-TORCH_IMPL_FUNC(logit_backward_out_mps)
-(const Tensor& grad_output, const Tensor& input, std::optional<double> eps, const Tensor& grad_input) {
-  using namespace mps;
-  using CachedGraph = MPSUnaryGradCachedGraph;
-
-  // Empty output
-  if (grad_input.numel() == 0)
-    return;
-
-  double eps_ = eps ? eps.value() : -1.0;
-
-  MPSStream* stream = getCurrentMPSStream();
-
-  @autoreleasepool {
-    std::string key = "logit_backward_out_mps:" + getTensorsStringKey({grad_output, input}) + ":" + "[" +
-        (eps.has_value() ? std::to_string(eps.value()) : "-1") + "]";
-
-    auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
-      MPSGraphTensor* inputTensor = mpsGraphRankedPlaceHolder(mpsGraph, input);
-      MPSGraphTensor* gradOutputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_output);
-      MPSGraphTensor* outputTensor = mpsGraphRankedPlaceHolder(mpsGraph, grad_input);
-      MPSGraphTensor* zeroTensor = [mpsGraph constantWithScalar:0.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-      MPSGraphTensor* oneTensor = [mpsGraph constantWithScalar:1.0 shape:@[ @1 ] dataType:inputTensor.dataType];
-      MPSGraphTensor* lowTensor = [mpsGraph constantWithScalar:eps_ shape:@[ @1 ] dataType:inputTensor.dataType];
-      MPSGraphTensor* inputLessThanLowPredicateTensor = [mpsGraph lessThanWithPrimaryTensor:inputTensor
-                                                                            secondaryTensor:lowTensor
-                                                                                       name:nil];
-      MPSGraphTensor* highTensor = [mpsGraph subtractionWithPrimaryTensor:oneTensor secondaryTensor:lowTensor name:nil];
-      MPSGraphTensor* inputGreaterThanHighPredicateTensor = [mpsGraph greaterThanWithPrimaryTensor:inputTensor
-                                                                                   secondaryTensor:highTensor
-                                                                                              name:nil];
-      MPSGraphTensor* outOfIntervalTensor = [mpsGraph logicalORWithPrimaryTensor:inputLessThanLowPredicateTensor
-                                                                 secondaryTensor:inputGreaterThanHighPredicateTensor
-                                                                            name:nil];
-      MPSGraphTensor* oneMinusInputTensor = [mpsGraph subtractionWithPrimaryTensor:oneTensor
-                                                                   secondaryTensor:inputTensor
-                                                                              name:nil];
-      outputTensor = [mpsGraph multiplicationWithPrimaryTensor:inputTensor
-                                               secondaryTensor:oneMinusInputTensor
-                                                          name:nil];
-      outputTensor = [mpsGraph divisionWithPrimaryTensor:gradOutputTensor secondaryTensor:outputTensor name:nil];
-      outputTensor = [mpsGraph selectWithPredicateTensor:outOfIntervalTensor
-                                     truePredicateTensor:zeroTensor
-                                    falsePredicateTensor:outputTensor
-                                                    name:nil];
-
-      newCachedGraph->gradOutputTensor_ = gradOutputTensor;
-      newCachedGraph->inputTensor_ = inputTensor;
-      newCachedGraph->gradInputTensor_ = outputTensor;
-    });
-    Placeholder gradOutputPlaceholder = Placeholder(cachedGraph->gradOutputTensor_, grad_output);
-    Placeholder inputPlaceholder = Placeholder(cachedGraph->inputTensor_, input);
-    Placeholder gradInputPlaceholder = Placeholder(cachedGraph->gradInputTensor_, grad_input);
-
-    // Create dictionary of inputs and outputs
-    auto feeds = dictionaryFromPlaceholders(gradOutputPlaceholder, inputPlaceholder);
-    runMPSGraph(stream, cachedGraph->graph(), feeds, gradInputPlaceholder);
-  }
 }
 
 static void cumulative_op_impl(const Tensor& self,

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -13321,8 +13321,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, XPU: logit_backward_out
-    MPS: logit_backward_out_mps
+    CPU, CUDA, MPS, XPU: logit_backward_out
   tags: pointwise
 
 - func: logit_backward(Tensor grad_output, Tensor self, float? eps=None) -> Tensor
@@ -13335,8 +13334,7 @@
   structured: True
   structured_inherits: TensorIteratorBase
   dispatch:
-    CPU, CUDA, MTIA, XPU: tanh_backward_out
-    MPS: tanh_backward_out_mps
+    CPU, CUDA, MPS, MTIA, XPU: tanh_backward_out
   tags: pointwise
 
 - func: tanh_backward(Tensor grad_output, Tensor output) -> Tensor


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.14.0) (oldest at bottom):
* __->__ #195601

Last MPSGraph backward ops in this stub family (sigmoid_backward was already
native). logit_backward carries its eps scalar via the binary-alpha path;
tanh_backward gains complex support for free.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>