### PR TITLE
[AOTI] Speed up large runtime checks test

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -6030,20 +6030,20 @@ class AOTInductorTestsTemplate:
                 super().__init__()
 
             def forward(self, *inputs):
-                result = inputs[0]
-                for i in range(1, len(inputs)):
-                    result = result + inputs[i]
-                return result
+                # Export preserves unused user inputs and generates runtime checks for them.
+                return inputs[0]
 
+        num_inputs = 100 if self.use_minimal_arrayref_interface else 1000
         inputs = []
-        for _ in range(1000):
+        for _ in range(num_inputs):
             inputs.append(torch.ones(8, 8, 8, dtype=torch.float16, device=self.device))
         inputs = tuple(inputs)
         model = Model()
         with torch.no_grad():
             # This test calls compile directly rather than self.check_model, so
             # propagate the copied test class' ArrayRef settings explicitly.
-            AOTIRunnerUtil.compile(
+            _, code = run_and_get_cpp_code(
+                AOTIRunnerUtil.compile,
                 model,
                 inputs,
                 inductor_configs={
@@ -6051,6 +6051,7 @@ class AOTInductorTestsTemplate:
                     "aot_inductor.use_minimal_arrayref_interface": self.use_minimal_arrayref_interface,
                 },
             )
+        FileCheck().check(f"check_input_{num_inputs - 1}(input_handles);").run(code)
 
     def test_runtime_checks_complex(self):
         class Model(torch.nn.Module):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

The test combines a 1,000-input runtime-check stress case with a chain of 999 additions. With the minimal ArrayRef interface, compiling this synthetic workload exceeds the 10-minute test timeout.

Export preserves unused user inputs, so return only the first input. Keep the full 1,000-input compiler regression for ordinary configurations while using 100 inputs for the more expensive minimal ArrayRef path. Check the final generated input helper explicitly so both paths retain runtime-check coverage.

Authored with AI assistance.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo