### PR TITLE
Reject bool and complex input in the argmax/argmin meta kernels

### DIFF
--- a/test/test_meta.py
+++ b/test/test_meta.py
@@ -2631,6 +2631,24 @@ class TestMetaKernelRegistrations(TestCase):
             torch.fill(x_meta, value_meta)
 
     @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
+    def test_argmax_argmin_reject_bool_and_complex(self):
+        # Ports of check_argmax_argmin in aten/src/ATen/native/ReduceOps.cpp,
+        # which rejects both dtypes. Without them a compiled argmax over a bool
+        # mask silently produced an index instead of raising.
+        for op, name in ((torch.argmax, "argmax"), (torch.argmin, "argmin")):
+            inp = torch.zeros(2, 3, dtype=torch.bool, device="meta")
+            with self.assertRaisesRegex(
+                NotImplementedError, rf"{name}\(\): does not support bool input"
+            ):
+                op(inp, dim=1)
+
+            inp = torch.zeros(2, 3, dtype=torch.complex64, device="meta")
+            with self.assertRaisesRegex(
+                TypeError, rf"{name}\(\): does not support complex input"
+            ):
+                op(inp, dim=1)
+
+    @skipIfTorchDynamo("tests raw meta kernel, not dynamo")
     def test_fill_out_of_place_tensor_scalar_ok(self):
         x_cpu = torch.randn(3, 4)
         value_cpu = torch.tensor(1.0)

--- a/torch/_meta_registrations.py
+++ b/torch/_meta_registrations.py
@@ -7882,6 +7882,12 @@ def zero_numel_check_dims(self, dim, fn_name):
 
 # From aten/src/ATen/native/ReduceOps.cpp
 def check_argmax_argmin(name, self, dim):
+    torch._check_type(
+        not self.is_complex(), lambda: f"{name}: does not support complex input"
+    )
+    torch._check_not_implemented(
+        self.dtype is not torch.bool, lambda: f"{name}: does not support bool input"
+    )
     if dim is not None:
         dim = maybe_wrap_dim(dim, self.dim())
         zero_numel_check_dims(self, dim, name)
@@ -7892,12 +7898,21 @@ def check_argmax_argmin(name, self, dim):
         )
 
 
-@register_meta([aten.argmax.default, aten.argmin.default])
-def argmax_argmin_meta(self, dim=None, keepdim=False):
-    check_argmax_argmin("argmax", self, dim)
+def _argmax_argmin_meta(name, self, dim, keepdim):
+    check_argmax_argmin(name, self, dim)
     dims = utils.reduction_dims(self.shape, (dim,) if dim is not None else None)
     shape = _compute_reduction_shape(self, dims, keepdim)
     return self.new_empty(shape, dtype=torch.int64)
+
+
+@register_meta(aten.argmax.default)
+def argmax_meta(self, dim=None, keepdim=False):
+    return _argmax_argmin_meta("argmax()", self, dim, keepdim)
+
+
+@register_meta(aten.argmin.default)
+def argmin_meta(self, dim=None, keepdim=False):
+    return _argmax_argmin_meta("argmin()", self, dim, keepdim)
 
 
 @register_meta(aten.scalar_tensor.default)


### PR DESCRIPTION
Fixes #185481.

`check_argmax_argmin` in `torch/_meta_registrations.py` is a port of the function of the same name in `aten/src/ATen/native/ReduceOps.cpp:221` — its comment says so — but the port dropped the two dtype checks the C++ version starts with:

```cpp
TORCH_CHECK_TYPE(!self.is_complex(), name, ": does not support complex input");
TORCH_CHECK_NOT_IMPLEMENTED(!(self.scalar_type() == kBool), name, ": does not support bool input");
```

There is no decomposition for `argmax`/`argmin`, so the meta kernel is the only shape and dtype authority during tracing. With those checks missing, meta and FakeTensor accepted input eager rejects:

| | eager | meta / FakeTensor |
|---|---|---|
| `argmax(bool)` | `NotImplementedError` | returned `int64[2]` |
| `argmin(bool)` | `NotImplementedError` | returned `int64[2]` |
| `argmax(complex)` | `TypeError` | returned `int64[2]` |

so a compiled `argmax` over a comparison mask produced an index, which was then used for downstream indexing and the graph returned a number.

The registration also hardcoded `"argmax"` for both ops, so an argmin error read `argmax: ...`, and it omitted the `()` the C++ messages carry. Splitting the registration mirrors the C++ structure, where one helper is called from `TORCH_META_FUNC(argmax)` and `TORCH_META_FUNC(argmin)` with their own names.

### Test

The new test pins both dtypes for both ops and fails without the change:

```
python -m pytest test/test_meta.py -k "argmax_argmin_reject" -q
```

with the change `1 passed`; with the meta kernel reverted, `AssertionError: NotImplementedError not raised`.

No regressions:

```
test/test_meta.py                   -k "argmax or argmin"   108 passed, 116 skipped
test/test_ops.py                    -k "argmax or argmin"    60 passed,  12 skipped
test/test_reductions.py             -k "argmax or argmin"   382 passed,  18 xfailed
test/inductor/test_torchinductor.py -k "argmax or argmin"     9 passed
```

On the issue's reproducer, with the default `fullgraph=False`, all three backends now match eager exactly:

```
                     before                  after
eager                NotImplementedError     NotImplementedError
aot_eager            NotImplementedError     NotImplementedError
inductor             returned 30.0           NotImplementedError
```

### One thing to flag

Under `fullgraph=True` the failure is now raised during fake-tensor propagation, so dynamo reports `Unsupported: NotImplementedError/UnsupportedFakeTensorException when running FX node` rather than the eager message. That is a wording regression for the `eager` and `aot_eager` backends, which previously surfaced the clean error there. It buys inductor no longer returning a silently wrong result, which seems the better trade, but say the word if you would rather see the message preserved.

Developed with AI assistance (Claude); I reproduced the divergence, located it and ran the checks above.
