### PR TITLE
[inductor] Add opt-in structural outer reductions

### DIFF
--- a/test/inductor/test_mix_order_reduction.py
+++ b/test/inductor/test_mix_order_reduction.py
@@ -11,7 +11,7 @@ from torch import nn
 from torch._dynamo.utils import same
 from torch._inductor import metrics, utils
 from torch._inductor.codegen.triton import TritonKernel
-from torch._inductor.runtime.hints import DeviceProperties
+from torch._inductor.runtime.hints import DeviceProperties, ReductionHint
 from torch._inductor.runtime.triton_heuristics import persistent_reduction
 from torch._inductor.scheduler import MixOrderReduction
 from torch._inductor.test_case import run_tests, TestCase
@@ -1487,6 +1487,19 @@ class MixOrderReductionHeuristicTest(TestBase):
     heuristic. These exercise the config generation logic directly (via
     ``return_configs=True``) without needing a GPU.
     """
+
+    def test_contiguous_reduction_hint_allowlist(self):
+        for hint in (
+            ReductionHint.INNER,
+            ReductionHint.DEFAULT,
+            ReductionHint.OUTER_NO_SPLIT,
+        ):
+            self.assertTrue(
+                MixOrderReduction.supports_contiguous_reduction_hint(hint)
+            )
+        self.assertFalse(
+            MixOrderReduction.supports_contiguous_reduction_hint(ReductionHint.OUTER)
+        )
 
     def test_uses_tma_tracks_emitted_descriptors(self):
         for source in (None, "host", "device"):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -19098,6 +19098,88 @@ def forward(self, arg0_1: "Sym(s77)", arg1_1: "Sym(s27)", arg2_1: "Sym(s53)", ar
         self.assertTrue("ReductionHint.OUTER" in code)
         self.assertFalse("ReductionHint.INNER" in code)
 
+    @config.patch(
+        {
+            "max_autotune": True,
+            "compile_threads": 1,
+            "force_disable_caches": True,
+        }
+    )
+    @skipIfRocm
+    @skipIfXpu
+    @xfail_if_mps
+    def test_large_outer_reduction_preserves_unsplit_hint(self):
+        if self.device == "cpu":
+            self.skipTest("Skip for CPU device")
+        if torch.cuda.get_device_capability()[0] < 10:
+            self.skipTest("OUTER_NO_SPLIT is currently restricted to SM100+")
+
+        x = torch.randn(2049, 32768, device=self.device, dtype=torch.bfloat16)
+
+        def f(x):
+            return x.float().sum(dim=0)
+
+        expected = f(x)
+        actual, source_codes = run_and_get_code(torch.compile(f, fullgraph=True), x)
+        self.assertEqual(expected, actual, atol=0.125, rtol=0.01)
+        code = source_codes[0]
+        self.assertIn("ReductionHint.OUTER_NO_SPLIT", code)
+        self.assertEqual(code.count("@triton_heuristics.reduction("), 1)
+
+    @config.patch(
+        {
+            "max_autotune": True,
+            "compile_threads": 1,
+            "force_disable_caches": True,
+            "triton.enable_experimental_large_output_outer_reductions": True,
+        }
+    )
+    @skipIfRocm
+    @skipIfXpu
+    @xfail_if_mps
+    def test_experimental_large_outer_reduction_plan(self):
+        if self.device == "cpu":
+            self.skipTest("Skip for CPU device")
+        if torch.cuda.get_device_capability()[0] < 10:
+            self.skipTest("experimental large OUTER plan is restricted to SM100+")
+
+        x = torch.randn(
+            5247, 96, 128, device=self.device, dtype=torch.bfloat16
+        )
+        y = torch.randn(
+            5247, 96, 128, device=self.device, dtype=torch.bfloat16
+        )
+        stats = torch.rand(5247, 96, 1, device=self.device, dtype=torch.float32)
+
+        def f(x, y, stats):
+            return (x.float() * y.float() * torch.rsqrt(stats + 1e-5)).sum(dim=0)
+
+        expected = f(x, y, stats)
+        actual, source_codes = run_and_get_code(
+            torch.compile(f, fullgraph=True), x, y, stats
+        )
+        self.assertEqual(expected, actual, atol=0.125, rtol=0.01)
+        code = source_codes[0]
+        self.assertNotIn("ReductionHint.OUTER_NO_SPLIT", code)
+        self.assertGreaterEqual(code.count("ReductionHint.OUTER"), 2)
+        # The first stage may preserve the logical output as a 2D tile rather
+        # than flattening it.  Check the split reduction extents instead of a
+        # wrapper allocation's exact textual shape.
+        self.assertIn("r0_numel = 132", code)
+        self.assertIn("r0_numel = 40", code)
+
+        def simple(x):
+            return x.float().sum(dim=0)
+
+        expected_simple = simple(x)
+        actual_simple, simple_source_codes = run_and_get_code(
+            torch.compile(simple, fullgraph=True), x
+        )
+        self.assertEqual(expected_simple, actual_simple, atol=0.125, rtol=0.01)
+        simple_code = simple_source_codes[0]
+        self.assertIn("ReductionHint.OUTER_NO_SPLIT", simple_code)
+        self.assertEqual(simple_code.count("@triton_heuristics.reduction("), 1)
+
     @config.patch(force_disable_caches=True)
     @xfail_if_mps  # MPS codegen does not emit ReductionHint.OUTER
     def test_broadcasted_inner_reduction_detection(self):

--- a/test/inductor/test_triton_heuristics.py
+++ b/test/inductor/test_triton_heuristics.py
@@ -36,6 +36,7 @@ except ImportError:
     raise unittest.SkipTest("requires triton")  # noqa: B904
 
 from torch._inductor import config
+from torch._inductor.ir import Reduction
 from torch._inductor.runtime.hints import (
     AttrsDescriptorWrapper,
     AutotuneHint,
@@ -43,6 +44,7 @@ from torch._inductor.runtime.hints import (
     HeuristicType,
     native_matmul_block_numel,
     native_matmul_persistent_rblock,
+    ReductionHint,
     TRITON_MAX_BLOCK,
     TRITON_MAX_TENSOR_NUMEL,
 )
@@ -209,6 +211,129 @@ class TestTritonHeuristics(TestCase):
         with self.assertRaisesRegex(AssertionError, "exceeds Triton maximum"):
             make_matmul_triton_config({"x": 256, "y": 128, "r": 64}, 8, 1)
 
+    def test_blackwell_outer_no_split_max_autotune_config(self):
+        expected = (64, 128, 16)
+
+        def config_set(*, meta, x=16384, r=8192, major=10):
+            result = _reduction_configs(
+                size_hints={"x": x, "r0_": r},
+                inductor_meta=meta,
+                triton_meta={
+                    "device": self._fake_cuda_device_properties(major=major)
+                },
+            )
+            return {
+                (c.kwargs["XBLOCK"], c.kwargs["R0_BLOCK"], c.num_warps)
+                for c in result
+            }
+
+        outer_meta = {
+            "max_autotune": True,
+            "reduction_hint": ReductionHint.OUTER_NO_SPLIT,
+        }
+        self.assertIn(expected, config_set(meta=outer_meta))
+        self.assertNotIn(
+            expected,
+            config_set(
+                meta={"max_autotune": True, "reduction_hint": ReductionHint.DEFAULT}
+            ),
+        )
+        self.assertNotIn(
+            expected,
+            config_set(
+                meta={
+                    "max_autotune_pointwise": True,
+                    "reduction_hint": ReductionHint.OUTER_NO_SPLIT,
+                }
+            ),
+        )
+        self.assertNotIn(expected, config_set(meta=outer_meta, x=4096))
+        self.assertNotIn(expected, config_set(meta=outer_meta, r=1024))
+        self.assertNotIn(expected, config_set(meta=outer_meta, major=9))
+
+        no_autotune_outer = config_set(
+            meta={"reduction_hint": ReductionHint.OUTER_NO_SPLIT}
+        )
+        no_autotune_default = config_set(
+            meta={"reduction_hint": ReductionHint.DEFAULT}
+        )
+        self.assertEqual(no_autotune_outer, no_autotune_default)
+
+        # Runtime decorator callsites historically use False when no explicit
+        # reduction hint is supplied. Preserve that sentinel behavior.
+        self.assertTrue(
+            config_set(meta={"max_autotune": True, "reduction_hint": False})
+        )
+
+    def test_experimental_large_output_outer_split_factor(self):
+        split = Reduction._experimental_large_output_outer_split_factor
+        self.assertEqual(split(5247, 9472, 148), 56)
+        self.assertEqual(split(5247, 12288, 148), 40)
+        self.assertEqual(split(5247, 16384, 148), 32)
+        self.assertEqual(split(5247, 22528, 148), 16)
+        self.assertEqual(split(5247, 32768, 148), 16)
+        self.assertEqual(split(1023, 8192, 148), 1)
+        self.assertEqual(split(5247, 12288, 74), 16)
+        self.assertEqual(split(5247, 1 << 30, 148), 1)
+
+        should_use = Reduction._should_use_experimental_large_output_outer_plan
+        self.assertTrue(should_use(5247, 9472, 56))
+        self.assertTrue(should_use(5247, 12288, 40))
+        self.assertTrue(should_use(5247, 16384, 32))
+        self.assertTrue(should_use(5247, 22528, 16))
+        self.assertTrue(should_use(5247, 32768, 16))
+        self.assertTrue(should_use(6145, 12288, 40))
+        self.assertTrue(should_use(7169, 12288, 40))
+        self.assertTrue(should_use(8193, 12288, 40))
+        self.assertFalse(should_use(4096, 12288, 40))
+        self.assertFalse(should_use(5248, 12288, 40))
+        self.assertFalse(should_use(6144, 12288, 40))
+        self.assertFalse(should_use(1023, 12288, 40))
+        self.assertFalse(should_use(5247, 9471, 56))
+        self.assertFalse(should_use(5247, 9473, 56))
+        self.assertTrue(should_use(5247, 32896, 16))
+        self.assertTrue(should_use(5246, 12288, 40))
+
+        producer_profitable = (
+            Reduction._is_experimental_large_output_outer_producer_profitable
+        )
+        self.assertTrue(producer_profitable(12, 4, False))
+        self.assertTrue(producer_profitable(11, 3, True))
+        self.assertFalse(producer_profitable(7, 4, True))
+        self.assertFalse(producer_profitable(16, 3, False))
+
+    def test_experimental_large_output_outer_config(self):
+        candidate = (128, 8, 1)
+
+        def config_set(
+            *, enabled=True, deterministic=False, max_autotune=True, major=10, r=256
+        ):
+            with config.patch(
+                "triton.enable_experimental_large_output_outer_reductions", enabled
+            ):
+                result = _reduction_configs(
+                    size_hints={"x": 16384, "r0_": r},
+                    inductor_meta={
+                        "max_autotune": max_autotune,
+                        "reduction_hint": ReductionHint.OUTER,
+                        "deterministic": deterministic,
+                    },
+                    triton_meta={
+                        "device": self._fake_cuda_device_properties(major=major)
+                    },
+                )
+            return {
+                (c.kwargs["XBLOCK"], c.kwargs["R0_BLOCK"], c.num_warps)
+                for c in result
+            }
+
+        self.assertIn(candidate, config_set())
+        self.assertNotIn(candidate, config_set(enabled=False))
+        self.assertNotIn(candidate, config_set(deterministic=True))
+        self.assertNotIn(candidate, config_set(max_autotune=False))
+        self.assertNotIn(candidate, config_set(major=9))
+        self.assertNotIn(candidate, config_set(r=64))
+
     def test_reduction_min_block_preserves_tile_product(self):
         cfg = _enforce_reduction_config_block_minimums(
             [triton.Config({"XBLOCK": 64, "R0_BLOCK": 1024})],
@@ -252,13 +377,13 @@ class TestTritonHeuristics(TestCase):
         self.assertEqual(cfg.kwargs["R0_BLOCK"], 512)
 
     @staticmethod
-    def _fake_cuda_device_properties():
+    def _fake_cuda_device_properties(major=8):
         return DeviceProperties(
             type="cuda",
             index=0,
             multi_processor_count=1,
-            cc=80,
-            major=8,
+            cc=major * 10,
+            major=major,
             regs_per_multiprocessor=65536,
             max_threads_per_multi_processor=2048,
             max_threads_per_block=1024,

--- a/torch/_inductor/codegen/triton.py
+++ b/torch/_inductor/codegen/triton.py
@@ -7159,6 +7159,15 @@ class TritonKernel(SIMDKernel[TritonCSEVariable]):
             "dynamic_disable_pipelining": config.triton.dynamic_disable_pipelining,
         }
 
+        if (
+            config.max_autotune
+            and config.triton.enable_experimental_large_output_outer_reductions
+            and not config.deterministic
+            and not config.batch_invariant
+            and not torch.are_deterministic_algorithms_enabled()
+        ):
+            inductor_meta["enable_experimental_large_output_outer_reductions"] = True
+
         if config.write_are_deterministic_algorithms_enabled:
             inductor_meta["are_deterministic_algorithms_enabled"] = (
                 torch.are_deterministic_algorithms_enabled()

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -1952,6 +1952,16 @@ class triton:
     Config specific to codegen/triton.py
     """
 
+    # Select a bounded two-stage OUTER plan for large, aligned leading-dimension
+    # reductions on Blackwell. This remains opt-in until Inductor can benchmark
+    # split and unsplit graph plans against one another end to end.
+    enable_experimental_large_output_outer_reductions = (
+        os.environ.get(
+            "TORCHINDUCTOR_ENABLE_EXPERIMENTAL_LARGE_OUTPUT_OUTER_REDUCTIONS", "0"
+        )
+        == "1"
+    )
+
     # torchTLX enablement. None (the default) means TLX is never considered
     # (standard Inductor behavior); "allow" lets TLX compete via autotuning;
     # "force" uses only TLX templates plus forced epilogue fusion. Also a

--- a/torch/_inductor/heuristics/triton_codegen/reduction.py
+++ b/torch/_inductor/heuristics/triton_codegen/reduction.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 import torch
+from torch._inductor import config
 from torch._inductor.heuristics.registry import (
     CodegenConfigHeuristics,
     register_codegen_heuristic,
@@ -197,6 +198,12 @@ class ReductionHeuristic(CodegenConfigHeuristics):
         )
 
         reduction_hint = inductor_meta.get("reduction_hint")
+        config_reduction_hint = (
+            ReductionHint.DEFAULT
+            if isinstance(reduction_hint, ReductionHint)
+            and reduction_hint.is_default_scheduling()
+            else reduction_hint
+        )
         rnumel = get_total_reduction_numel(size_hints)
 
         max_autotune_enabled = inductor_meta.get("max_autotune") or inductor_meta.get(
@@ -237,6 +244,7 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             register_intensive=False,
             dynamic_scale_rblock=True,
             waves_per_eu=None,
+            min_num_warps=None,
         ):
             if "y" in size_hints:
                 tiling_scores = _get_tiling_scores(inductor_meta, size_hints)
@@ -261,7 +269,8 @@ class ReductionHeuristic(CodegenConfigHeuristics):
                     register_intensive=register_intensive,
                     waves_per_eu=waves_per_eu,
                     dynamic_scale_rblock=dynamic_scale_rblock,
-                    reduction_hint=reduction_hint,
+                    reduction_hint=config_reduction_hint,
+                    min_num_warps=min_num_warps,
                     warp_size=warp_size,
                 )
 
@@ -348,6 +357,48 @@ class ReductionHeuristic(CodegenConfigHeuristics):
             make_config(8, 512),
             make_config(64, 4, num_warps=8),
         ]
+
+        # Coordinate descent can reach this neighbor from (64, 64), but
+        # max-autotune only benchmarks explicitly enumerated configurations.
+        if (
+            inductor_meta.get("max_autotune")
+            and reduction_hint == ReductionHint.OUTER_NO_SPLIT
+            and triton_meta["device"].type == "cuda"
+            and torch.version.hip is None
+            and device_major is not None
+            and device_major >= 10
+            and "y" not in size_hints
+            and size_hints["x"] >= 8192
+            and rnumel >= 2048
+        ):
+            result_configs.append(make_config(64, 128, num_warps=16))
+
+        # The opt-in structural plan's first stage is deliberately represented
+        # by one extra configuration. Its split heuristic is derived from this
+        # X128/R8/one-warp geometry, so do not independently grow either search
+        # dimension here.
+        if (
+            inductor_meta.get("max_autotune")
+            and (
+                inductor_meta.get(
+                    "enable_experimental_large_output_outer_reductions"
+                )
+                or config.triton.enable_experimental_large_output_outer_reductions
+            )
+            and not inductor_meta.get("deterministic")
+            and not inductor_meta.get("are_deterministic_algorithms_enabled")
+            and reduction_hint == ReductionHint.OUTER
+            and triton_meta["device"].type == "cuda"
+            and torch.version.hip is None
+            and device_major is not None
+            and device_major >= 10
+            and "y" not in size_hints
+            and size_hints["x"] >= 8192
+            and rnumel >= 128
+        ):
+            result_configs.append(
+                make_config(128, 8, num_warps=1, min_num_warps=1)
+            )
 
         return self._finalize_configs(
             result_configs, make_config, size_hints, inductor_meta

--- a/torch/_inductor/ir.py
+++ b/torch/_inductor/ir.py
@@ -1474,6 +1474,74 @@ class Reduction(Loops):
         )
 
     @staticmethod
+    def _experimental_large_output_outer_split_factor(
+        reduction_numel_hint: int,
+        numel_hint: int,
+        num_sm: int,
+    ) -> int:
+        """Choose one bounded split for the experimental large-output OUTER plan.
+
+        The measured first-stage schedule uses XBLOCK=128, R0_BLOCK=8, and one
+        warp. Targeting 28 one-warp CTAs per SM and rounding down to an eight-way
+        split quantum reproduces the useful graph-206 split band without a split
+        sweep. The result is also bounded by FP32 workspace traffic and capacity.
+        """
+        first_stage_xblock = 128
+        target_ctas_per_sm = 28
+        split_quantum = 8
+        min_splits = 16
+        max_splits = 64
+        max_workspace_bytes = 128 * 1024 * 1024
+
+        xblocks = (numel_hint + first_stage_xblock - 1) // first_stage_xblock
+        target_splits = (target_ctas_per_sm * num_sm) // max(xblocks, 1)
+        target_splits = (target_splits // split_quantum) * split_quantum
+
+        # Writing and rereading S FP32 partials costs 8*S*X bytes. Relative to
+        # the BF16 input's 2*R*X bytes, S <= R/64 keeps this below 6.25%.
+        traffic_limited_splits = reduction_numel_hint // 64
+        workspace_limited_splits = max_workspace_bytes // (4 * max(numel_hint, 1))
+        legal_max = min(max_splits, traffic_limited_splits, workspace_limited_splits)
+        legal_max = (legal_max // split_quantum) * split_quantum
+        if legal_max < min_splits:
+            return 1
+
+        return max(min_splits, min(target_splits, legal_max))
+
+    @staticmethod
+    def _should_use_experimental_large_output_outer_plan(
+        reduction_numel_hint: int,
+        numel_hint: int,
+        split: int,
+    ) -> bool:
+        # The normal one-pass Blackwell plan uses R0_BLOCK=64. Runtime-matched
+        # production sweeps show a sharp schedule cliff when a deep leading
+        # reduction has a tail at that granularity, while aligned depths favor
+        # the one-pass plan. Keep output tails and shallow reductions on the
+        # one-pass path, and rely on the split/workspace bounds above.
+        return (
+            reduction_numel_hint >= 4096
+            and reduction_numel_hint % 64 != 0
+            and numel_hint >= 8192
+            and numel_hint % 128 == 0
+            and split > 1
+        )
+
+    @staticmethod
+    def _is_experimental_large_output_outer_producer_profitable(
+        num_ops: int,
+        nontrivial_read_count: int,
+        has_partial_output_broadcast_read: bool,
+    ) -> bool:
+        # Structural OUTER pays for a workspace and a final reduction.  Favor
+        # fused producers with enough work/read pressure to amortize that cost,
+        # including partially-broadcast reduction reads whose one-pass access
+        # pattern is particularly inefficient.
+        return num_ops >= 8 and (
+            nontrivial_read_count >= 4 or has_partial_output_broadcast_read
+        )
+
+    @staticmethod
     def num_splits(
         device: torch.device,
         dst_dtype: torch.dtype,
@@ -1580,10 +1648,39 @@ class Reduction(Loops):
                         # use reduction_sizes of this node or its dependent nodes directly.
                         return ReductionHint.INNER, -1
             return ReductionHint.INNER, split
-        if (
-            reduction_numel_hint <= min_elements_per_thread
-            or numel_hint >= num_sm * 2 * 32
-        ):
+        if reduction_numel_hint <= min_elements_per_thread:
+            return ReductionHint.DEFAULT, 1
+
+        large_output = numel_hint >= num_sm * 2 * 32
+        preserve_large_outer_hint = (
+            config.max_autotune
+            and reduction_type == "sum"
+            and src_dtype in (torch.float16, torch.bfloat16, torch.float32)
+            and dst_dtype == torch.float32
+            and device.type == "cuda"
+            and torch.version.hip is None
+            and props.major is not None
+            and props.major >= 10
+            and reduction_numel_hint >= 2048
+            and (
+                _is_static(reduction_numel)
+                or V.graph.sizevars.statically_known_equals(
+                    reduction_numel, reduction_numel_hint
+                )
+            )
+            and (
+                _is_static(numel)
+                or V.graph.sizevars.statically_known_equals(numel, numel_hint)
+            )
+        )
+        split_large_outer = (
+            preserve_large_outer_hint
+            and config.triton.enable_experimental_large_output_outer_reductions
+            and not config.deterministic
+            and not config.batch_invariant
+            and not torch.are_deterministic_algorithms_enabled()
+        )
+        if large_output and not preserve_large_outer_hint:
             return ReductionHint.DEFAULT, 1
 
         r = Reduction(
@@ -1597,7 +1694,9 @@ class Reduction(Loops):
             reduction_hint=ReductionHint.DEFAULT,
         )
 
-        def get_read_indices(r: Reduction) -> tuple[Sequence[Expr], bool]:
+        def get_read_indices(
+            r: Reduction,
+        ) -> tuple[Sequence[Expr], bool, list[torch.dtype | None], bool]:
             device = r.get_device()
             if device is None:
                 raise AssertionError("Expected device is not None")
@@ -1621,9 +1720,14 @@ class Reduction(Loops):
                 for var in read_writes.range_vars
                 if isinstance(var, Expr) and not isinstance(var, sympy.Number)
             ]
-            (_, reduction_vars), _ = dependencies.index_vars_squeeze(
+            (pointwise_vars, reduction_vars), _ = dependencies.index_vars_squeeze(
                 r.get_size(), r.get_reduction_size()
             )
+            pointwise_vars = [
+                var
+                for var in pointwise_vars
+                if isinstance(var, Expr) and not isinstance(var, sympy.Number)
+            ]
             reduction_vars = [
                 var
                 for var in reduction_vars
@@ -1631,6 +1735,8 @@ class Reduction(Loops):
             ]
             indices = []
             broadcasted_reduction_indices = []
+            source_dtypes = []
+            has_partial_output_broadcast_read = False
             changed = False
             for md in sorted(read_writes.reads, key=lambda x: x.name):
                 free_symbols = md.index.free_symbols
@@ -1641,22 +1747,53 @@ class Reduction(Loops):
                 is_broadcasted_reduction_read = not is_full_size_read and any(
                     var in free_symbols for var in reduction_vars
                 )
+                has_any_pointwise_var = any(
+                    var in free_symbols for var in pointwise_vars
+                )
+                has_all_pointwise_vars = all(
+                    var in free_symbols for var in pointwise_vars
+                )
+                has_partial_output_broadcast_read |= (
+                    has_any_pointwise_var
+                    and not has_all_pointwise_vars
+                    and any(var in free_symbols for var in reduction_vars)
+                )
                 if is_full_size_read:
                     indices.append(md.index)
                 elif is_broadcasted_reduction_read:
                     broadcasted_reduction_indices.append(md.index)
                 if is_full_size_read or is_broadcasted_reduction_read:
+                    if split_large_outer:
+                        try:
+                            source_dtypes.append(V.graph.get_dtype(md.name))
+                        except KeyError:
+                            source_dtypes.append(None)
                     if md.name in V.graph.name_to_buffer:
                         buf = V.graph.name_to_buffer[md.name]
                         original_stride = getattr(buf.layout, "stride", None)
                         buf.decide_layout()
                         if getattr(buf.layout, "stride", None) != original_stride:
                             changed = True
-            return indices or broadcasted_reduction_indices, changed
+            return (
+                indices or broadcasted_reduction_indices,
+                changed,
+                source_dtypes,
+                has_partial_output_broadcast_read,
+            )
 
-        indices, changed = get_read_indices(r)
+        (
+            indices,
+            changed,
+            source_dtypes,
+            has_partial_output_broadcast_read,
+        ) = get_read_indices(r)
         if changed:
-            indices, _ = get_read_indices(r)
+            (
+                indices,
+                _,
+                source_dtypes,
+                has_partial_output_broadcast_read,
+            ) = get_read_indices(r)
 
         if len(indices) == 0:
             # TODO determine splits when all inputs are broadcast
@@ -1680,10 +1817,40 @@ class Reduction(Loops):
             else:
                 num_inner += 1
         if num_inner > num_outer:
+            if large_output:
+                return ReductionHint.DEFAULT, 1
             return ReductionHint.INNER, inner_reduction_splits(
                 reduction_numel_hint, numel_hint
             )
         else:
+            if large_output:
+                producer_profitable = False
+                if split_large_outer:
+                    opcount = r.inner_fn_opcount()
+                    producer_profitable = (
+                        Reduction._is_experimental_large_output_outer_producer_profitable(
+                            opcount.num_ops,
+                            opcount.nontrivial_read_count,
+                            has_partial_output_broadcast_read,
+                        )
+                    )
+                if (
+                    split_large_outer
+                    and torch.bfloat16 in source_dtypes
+                    and all(
+                        dtype in (torch.bfloat16, torch.float32)
+                        for dtype in source_dtypes
+                    )
+                    and producer_profitable
+                ):
+                    split = Reduction._experimental_large_output_outer_split_factor(
+                        reduction_numel_hint, numel_hint, num_sm
+                    )
+                    if Reduction._should_use_experimental_large_output_outer_plan(
+                        reduction_numel_hint, numel_hint, split
+                    ):
+                        return ReductionHint.OUTER, split
+                return ReductionHint.OUTER_NO_SPLIT, 1
             return ReductionHint.OUTER, outer_reduction_splits(
                 reduction_numel_hint, numel_hint
             )
@@ -1810,9 +1977,9 @@ class Reduction(Loops):
         strict_split = None
         strict_reduction_multirow = False
         strict_reduction_rblock = None
-        if strict_reduction and reduction_hint in (
-            ReductionHint.DEFAULT,
-            ReductionHint.INNER,
+        if strict_reduction and (
+            reduction_hint == ReductionHint.INNER
+            or reduction_hint.is_default_scheduling()
         ):
             num_outputs = sympy_product(ranges)
             if V.graph.sizevars.all_unbacked_explicitly_hinted(

--- a/torch/_inductor/runtime/hints.py
+++ b/torch/_inductor/runtime/hints.py
@@ -52,6 +52,13 @@ class ReductionHint(Enum):
     OUTER = 1
     OUTER_TINY = 2
     DEFAULT = 3
+    # The reduction dimension is outer-strided, but the IR deliberately kept
+    # the reduction as a single-stage plan. Scheduling otherwise treats this
+    # like DEFAULT.
+    OUTER_NO_SPLIT = 4
+
+    def is_default_scheduling(self) -> bool:
+        return self in (ReductionHint.DEFAULT, ReductionHint.OUTER_NO_SPLIT)
 
 
 class TileHint(Enum):

--- a/torch/_inductor/scheduler.py
+++ b/torch/_inductor/scheduler.py
@@ -200,6 +200,10 @@ class MixOrderReduction:
     """
 
     @staticmethod
+    def supports_contiguous_reduction_hint(hint: ReductionHint) -> bool:
+        return hint == ReductionHint.INNER or hint.is_default_scheduling()
+
+    @staticmethod
     def is_split_reduction(node: BaseSchedulerNode) -> bool:
         return node.is_reduction() and all(
             subnode.node._split_size is not None
@@ -414,10 +418,8 @@ class MixOrderReduction:
 
         # Make sure a persistent reduction will be generated
         if any(
-            subnode.node.data.reduction_hint  # type: ignore[union-attr]
-            not in (
-                ReductionHint.INNER,
-                ReductionHint.DEFAULT,
+            not cls.supports_contiguous_reduction_hint(
+                subnode.node.data.reduction_hint  # type: ignore[union-attr]
             )
             for subnode in contiguous_node.get_nodes()
             if subnode.is_reduction()


### PR DESCRIPTION
Adds a default-off, SM100+-gated structural plan for large leading-dimension reductions with sufficiently complex fused producers.

The plan uses a bounded first-stage split with an FP32 partial workspace and final reduction, while simple producers and unsupported cases retain the existing path.

Validation:
- focused split/config and generated-code tests
- BF16/FP32 correctness checks
- extracted graph 206: 83.680 ms to 80.364 ms (-3.96%)
- graphs 192 and 213 remain zero-candidate controls

True-model validation remains open: a warm-cache two-rank retry did not reach batch 1 within a ten-minute cutoff. This remains a draft and the feature is disabled by default.