### PR TITLE
[Inductor] Lower eligible slice_scatter as partial-range writes

### DIFF
--- a/test/inductor/test_inplacing_pass.py
+++ b/test/inductor/test_inplacing_pass.py
@@ -13,6 +13,7 @@ from torch._higher_order_ops.auto_functionalize import (
 )
 from torch._inductor.fx_passes.reinplace import reinplace_inplaceable_ops_core
 from torch._inductor.test_case import run_tests, TestCase as InductorTestCase
+from torch._inductor.utils import run_and_get_code
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     IS_LINUX,
@@ -47,6 +48,16 @@ def sin(x: torch.Tensor, result: torch.Tensor) -> None:
 def sin_cos(x: torch.Tensor, out_sin: torch.Tensor, out_cos: torch.Tensor) -> None:
     out_sin.copy_(x.sin())
     out_cos.copy_(x.cos())
+
+
+@torch.library.custom_op("_reinplacing::opaque_clone", mutates_args=())
+def opaque_clone(x: torch.Tensor) -> torch.Tensor:
+    return x.clone()
+
+
+@opaque_clone.register_fake
+def _(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
 
 
 if HAS_GPU:
@@ -523,6 +534,90 @@ class TestReinplacingPassCorrectness(InductorTestCase):
         expected = fn(x)
         result = torch.compile(fn, fullgraph=True, backend="inductor")(x)
         self.assertEqual(result, expected)
+
+    def test_slice_scatter_fallback_output_partial_range(self):
+        def fn(x, src):
+            base = opaque_clone(x)
+            return aten.slice_scatter(base, src, 1, 0, 2)
+
+        # This is a device-independent post-grad decision.  Keep the focused
+        # graph-shape test on CPU so it does not require a GPU test worker.
+        x = torch.randn(10, 8)
+        src = torch.randn(10, 2)
+        expected = fn(x, src)
+
+        log_stream, ctx = logs_to_string(
+            "torch._inductor.compile_fx", "post_grad_graphs"
+        )
+        with ctx():
+            actual, (code,) = run_and_get_code(
+                torch.compile(fn, fullgraph=True, backend="inductor"), x, src
+            )
+
+        self.assertEqual(actual, expected)
+        post_grad_graph = log_stream.getvalue()
+        self.assertIn("torch.ops.aten.slice.Tensor", post_grad_graph)
+        self.assertIn("torch.ops.aten.copy_.default", post_grad_graph)
+        self.assertNotIn("torch.ops.aten.slice_scatter.default", post_grad_graph)
+        # The generated mutation iterates over only the 10x2 destination view,
+        # rather than selecting and rewriting all 10x8 elements.
+        self.assertIn("x1<static_cast<int64_t>(2L)", code)
+        self.assertNotIn("x1<static_cast<int64_t>(8L)", code)
+
+    def test_slice_scatter_aliasing_source_not_reinplaced(self):
+        def fn(x):
+            base = opaque_clone(x)
+            src = base[:, :2]
+            # Source and destination overlap.  Functional slice_scatter reads
+            # from an unmodified snapshot; a direct copy_ does not.
+            return aten.slice_scatter(base, src, 1, 1, 3)
+
+        x = torch.randn(10, 8)
+        expected = fn(x)
+
+        log_stream, ctx = logs_to_string(
+            "torch._inductor.compile_fx", "post_grad_graphs"
+        )
+        with ctx():
+            actual = torch.compile(fn, fullgraph=True, backend="inductor")(x)
+
+        self.assertEqual(actual, expected)
+        post_grad_graph = log_stream.getvalue()
+        self.assertIn("torch.ops.aten.slice_scatter.default", post_grad_graph)
+
+    def test_slice_scatter_fallback_output_with_other_user_not_reinplaced(self):
+        def fn(x, src):
+            base = opaque_clone(x)
+            updated = aten.slice_scatter(base, src, 1, 0, 2)
+            return updated, base + 1
+
+        x = torch.randn(10, 8)
+        src = torch.randn(10, 2)
+        expected = fn(x, src)
+
+        log_stream, ctx = logs_to_string(
+            "torch._inductor.compile_fx", "post_grad_graphs"
+        )
+        with ctx():
+            actual = torch.compile(fn, fullgraph=True, backend="inductor")(x, src)
+
+        self.assertEqual(actual, expected)
+        post_grad_graph = log_stream.getvalue()
+        self.assertIn("torch.ops.aten.slice_scatter.default", post_grad_graph)
+
+    def test_slice_scatter_partial_range_noncontiguous_step(self):
+        def fn(x, src):
+            base = opaque_clone(x)
+            return aten.slice_scatter(base, src, 1, 1, 5, 2)
+
+        x = torch.randn(8, 10).t()
+        self.assertFalse(x.is_contiguous())
+        src = torch.randn(10, 2)
+        expected = fn(x, src)
+        actual = torch.compile(fn, fullgraph=True, backend="inductor")(x, src)
+
+        self.assertEqual(actual, expected, exact_dtype=True)
+        self.assertEqual(actual.stride(), expected.stride())
 
     @parametrize(
         "factory_op",

--- a/test/inductor/test_perf.py
+++ b/test/inductor/test_perf.py
@@ -926,6 +926,28 @@ class NoopTests(TestCase):
         inp = T(10)
         self.assertExpectedInline(count_numel(f, inp), """20""")
 
+    def test_noop_slice_scatter_same_split(self):
+        def f(a):
+            parts = aten.split_with_sizes(a, [3, 2, 3], 1)
+            b = aten.slice_scatter(a, parts[1], 1, 3, 5)
+            c = unfusible(b)
+            return c
+
+        # This is a device-independent post-grad rewrite.  Keep the focused
+        # regression test on CPU so it does not require a GPU test worker.
+        inp = T(10, 8, device="cpu")
+        self.assertExpectedInline(count_numel(f, inp), """160""")
+
+    def test_slice_scatter_different_split_is_not_noop(self):
+        def f(a):
+            parts = aten.split_with_sizes(a, [3, 2, 3], 1)
+            b = aten.slice_scatter(a, parts[1], 1, 0, 2)
+            c = unfusible(b)
+            return c
+
+        inp = T(10, 8, device="cpu")
+        self.assertExpectedInline(count_numel(f, inp), """320""")
+
     def test_noop_dtype_conversion(self):
         def f(a):
             b = torch.ops.prims.convert_element_type(a, torch.float32)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1225,14 +1225,78 @@ def slice_noop(self, dim=0, start=None, end=None, step=1):
     return False
 
 
-@register_noop_decomp(aten.slice_scatter, 1)
+def _slice_scatter_noop_replacement(args):
+    """Return ``self`` when ``src`` is exactly the slice being overwritten.
+
+    Functionalization can produce split/getitem/slice_scatter chains that copy
+    an unmodified view back to the same range of its base.  Replacing such a
+    scatter with the base avoids materializing the whole tensor.  Fall back to
+    the historical full-replacement behavior (replace with ``src``).
+    """
+    self, src = args[:2]
+    if not isinstance(self, torch.fx.Node) or not isinstance(src, torch.fx.Node):
+        return src
+    if src.target is not operator.getitem or not isinstance(
+        src.args[0], torch.fx.Node
+    ):
+        return src
+
+    split = src.args[0]
+    if split.target is not aten.split_with_sizes.default or split.args[0] is not self:
+        return src
+    split_sizes = get_arg_value(split, 1, "split_sizes")
+    split_dim = get_arg_value(split, 2, "dim")
+    index = get_arg_value(src, 1)
+    scatter_dim = args[2] if len(args) > 2 else 0
+    start = args[3] if len(args) > 3 else None
+    end = args[4] if len(args) > 4 else None
+    step = args[5] if len(args) > 5 else 1
+    if split_dim is None:
+        split_dim = 0
+    if scatter_dim is None:
+        scatter_dim = 0
+    if step is None:
+        step = 1
+    if (
+        not isinstance(split_sizes, (list, tuple))
+        or not all(isinstance(size, int) for size in split_sizes)
+        or not isinstance(index, int)
+        or not isinstance(split_dim, int)
+        or not isinstance(scatter_dim, int)
+        or (start is not None and not isinstance(start, int))
+        or (end is not None and not isinstance(end, int))
+        or (step is not None and not isinstance(step, int))
+    ):
+        return src
+    self_val = self.meta.get("val")
+    if not isinstance(self_val, torch.Tensor):
+        return src
+    ndim = self_val.dim()
+    if ndim == 0:
+        return src
+    split_dim %= ndim
+    scatter_dim %= ndim
+    if split_dim != scatter_dim or step != 1 or not 0 <= index < len(split_sizes):
+        return src
+    expected_start = sum(split_sizes[:index])
+    expected_end = expected_start + split_sizes[index]
+    if start is None:
+        start = 0
+    if end is None:
+        end = 2**63 - 1
+    if start == expected_start and end == expected_end:
+        return self
+    return src
+
+
+@register_noop_decomp(aten.slice_scatter, _slice_scatter_noop_replacement)
 def slice_scatter_noop(self, src, dim=0, start=None, end=None, step=1):
     if start is None:
         start = 0
     if end is None:
         end = 2**63 - 1
     slice_scatter_dim_size = self.shape[dim]
-    if (
+    full_replacement = (
         self.shape == src.shape
         and start == 0
         and (
@@ -1240,9 +1304,19 @@ def slice_scatter_noop(self, src, dim=0, start=None, end=None, step=1):
             or statically_known_true(end >= slice_scatter_dim_size)
         )
         and step == 1
-    ):
-        return True
-    return False
+    )
+    partial_self_replacement = (
+        step == 1
+        and 0 <= dim < self.dim()
+        and self.dim() == src.dim()
+        and all(
+            statically_known_true(sym_eq(src.shape[d], self.shape[d]))
+            for d in range(self.dim())
+            if d != dim
+        )
+        and statically_known_true(sym_eq(src.shape[dim], end - start))
+    )
+    return full_replacement or partial_self_replacement
 
 
 @register_noop_decomp(aten.repeat)

--- a/torch/_inductor/fx_passes/post_grad.py
+++ b/torch/_inductor/fx_passes/post_grad.py
@@ -1236,9 +1236,7 @@ def _slice_scatter_noop_replacement(args):
     self, src = args[:2]
     if not isinstance(self, torch.fx.Node) or not isinstance(src, torch.fx.Node):
         return src
-    if src.target is not operator.getitem or not isinstance(
-        src.args[0], torch.fx.Node
-    ):
+    if src.target is not operator.getitem or not isinstance(src.args[0], torch.fx.Node):
         return src
 
     split = src.args[0]

--- a/torch/_inductor/fx_passes/reinplace.py
+++ b/torch/_inductor/fx_passes/reinplace.py
@@ -22,6 +22,7 @@ from torch._inductor import config, inductor_prims
 from torch._inductor.fx_utils import get_node_storage, is_node_realized
 from torch._inductor.lowering import (
     inplaceable_foreach_ops as inplaceable_foreach_ops_lowerings,
+    lowerings,
 )
 from torch._inductor.virtualized import V
 from torch.fx.experimental.symbolic_shapes import (
@@ -227,13 +228,41 @@ def should_reinplace_scatter(node: torch.fx.Node) -> bool:
     input and output would have been realized anyway.
 
     """
-    inp, _src, _view_ops = node.args
+    inp, src, _view_ops = node.args
+
+    # _inplace_generalized_scatter ultimately lowers to a view followed by
+    # copy_.  When src aliases inp, those source and destination views can
+    # overlap, and copy_ does not provide the snapshot semantics of functional
+    # slice_scatter.  Exact self-copies are removed earlier as no-ops; keep all
+    # remaining aliasing cases functional unless/until overlap is proven safe.
+    inp_storage = get_node_storage(inp)  # type: ignore[arg-type]
+    src_storage = get_node_storage(src)  # type: ignore[arg-type]
+    if inp_storage is not None and inp_storage == src_storage:
+        return False
 
     # Mutating scatter ops unconditionally realize input and output
     if scatter_always_uses_mutation(node):
         return True
 
-    if is_node_realized(inp) and is_node_realized(node):  # type: ignore[arg-type]
+    def is_realized_or_fallback(node: torch.fx.Node) -> bool:
+        if is_node_realized(node):
+            return True
+
+        # Unknown OpOverloads are lowered through FallbackKernel.create(), so
+        # their outputs are real buffers even though they are not present in
+        # the statically registered ``fallbacks`` set consulted by
+        # is_node_realized().  This is common for custom operators.  Treating
+        # such an input as realized lets a dead functional slice_scatter be
+        # decomposed to slice + copy_ instead of scanning and rewriting the
+        # full input.  Restrict this to OpOverload: higher-order/callable nodes
+        # can have lowering behavior that this check cannot infer.
+        return (
+            node.op == "call_function"
+            and isinstance(node.target, torch._ops.OpOverload)
+            and node.target not in lowerings
+        )
+
+    if is_realized_or_fallback(inp) and is_node_realized(node):  # type: ignore[arg-type]
         return True
 
     # If the output is copied back into the input, this forces both to be


### PR DESCRIPTION
When a realized fallback buffer is dead after `slice_scatter`, let the existing reinplacing path reuse it and lower the update as a destination slice plus `copy_`. This avoids reading and rewriting the full base tensor when only a narrow range changes.

The transformation fails closed when the source aliases the base, preserving `slice_scatter` snapshot semantics.

This is stacked on #195608.

Production-scale B200 validation on a source-faithful `K x 512` region changes the generated scatter from a full-tensor read/modify/write to a `K x 128` source read and strided destination write. The scatter measured 5.952 -> 1.493 ms, with total DRAM traffic down 77.9%; the complete dual-GEMM region measured 19.710 -> 14.181 ms.

Exact-site recovery remains open: a fresh run of the current local production config emitted the newer `K x 384`/all-self-scatter variant, and the older profiler job's Torch compile logs are no longer retrievable through tlparse. This remains a draft until an FX capture from the width-512 model revision is available.
