### PR TITLE
[serialization] Reject dunder attributes in tensor state under weights_only

### DIFF
--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -5264,6 +5264,22 @@ class TestGetStateSubclass(torch.Tensor):
         self.reloaded = True
 
 
+class TestDunderStateSubclass(torch.Tensor):
+    # Keeps a dunder-named attribute in its Python state. Has no __setstate__,
+    # so the state is restored through torch._utils._set_obj_state.
+    def __getstate__(self):
+        return {"__custom_dunder__": 42}
+
+
+class TestDunderStateWithSetStateSubclass(torch.Tensor):
+    # Same, but defines __setstate__, so _set_obj_state is never reached.
+    def __getstate__(self):
+        return {"__custom_dunder__": 7}
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
+
 class TestEmptySubclass(torch.Tensor):
     ...
 
@@ -5305,6 +5321,67 @@ class TestSubclassSerialization(TestCase):
         self.assertEqual(new_tensor.elem, my_tensor.elem)
         self.assertEqual(new_tensor.foo, foo_val)
         self.assertTrue(new_tensor.reloaded)
+
+    def test_dunder_state_restored_when_unrestricted(self):
+        # BC: unrestricted loading must still restore dunder-named state, which
+        # weights_only=True deliberately rejects (see the test below).
+        my_tensor = TestDunderStateSubclass(torch.rand(2))
+
+        with BytesIOContext() as f:
+            torch.save(my_tensor, f)
+            f.seek(0)
+            new_tensor = torch.load(f, weights_only=False)
+
+        self.assertIsInstance(new_tensor, TestDunderStateSubclass)
+        self.assertEqual(new_tensor.__custom_dunder__, 42)
+
+    def test_dunder_state_rejected_when_weights_only(self):
+        my_tensor = TestDunderStateSubclass(torch.rand(2))
+
+        with BytesIOContext() as f:
+            torch.save(my_tensor, f)
+            f.seek(0)
+            with safe_globals([TestDunderStateSubclass]):
+                with self.assertRaisesRegex(UnpicklingError, "__custom_dunder__"):
+                    torch.load(f, weights_only=True)
+
+    def test_dunder_state_with_setstate_allowed_when_weights_only(self):
+        # A subclass that defines __setstate__ never routes its state through
+        # _set_obj_state, so it keeps full control of its own state.
+        my_tensor = TestDunderStateWithSetStateSubclass(torch.rand(2))
+
+        with BytesIOContext() as f:
+            torch.save(my_tensor, f)
+            f.seek(0)
+            with safe_globals([TestDunderStateWithSetStateSubclass]):
+                new_tensor = torch.load(f, weights_only=True)
+
+        self.assertEqual(new_tensor.__custom_dunder__, 7)
+
+    def test_parameter_dunder_state_rejected_when_weights_only(self):
+        # A Parameter with non-empty state serializes via
+        # _rebuild_parameter_with_state, the other path into _set_obj_state.
+        p = torch.nn.Parameter(torch.rand(2))
+        p.__dict__["__class__"] = torch.Tensor
+
+        with BytesIOContext() as f:
+            torch.save(p, f)
+            f.seek(0)
+            with self.assertRaisesRegex(UnpicklingError, "__class__"):
+                torch.load(f, weights_only=True)
+
+    def test_parameter_with_attribute_still_loads_when_weights_only(self):
+        # Non-dunder state on a Parameter is unaffected.
+        p = torch.nn.Parameter(torch.rand(2))
+        p.foo = "bar"
+
+        with BytesIOContext() as f:
+            torch.save(p, f)
+            f.seek(0)
+            new_p = torch.load(f, weights_only=True)
+
+        self.assertIsInstance(new_p, torch.nn.Parameter)
+        self.assertEqual(new_p.foo, "bar")
 
     def test_tensor_subclass_deepcopy(self):
         wrapped_tensor = torch.rand(2)

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -574,26 +574,15 @@ def _set_obj_state(obj, state):
         dict_state = state
         slots_state = None
 
-    def _setattr(k, v):
-        # A normal torch.save never emits dunder keys here. Rejecting them keeps
-        # a crafted state dict from setting attributes such as __class__ (which
-        # would silently change the object's type) when loading with
-        # weights_only=True.
-        if isinstance(k, str) and k.startswith("__") and k.endswith("__"):
-            raise RuntimeError(
-                f"_set_obj_state: refusing to set dunder attribute '{k}'"
-            )
-        setattr(obj, k, v)
-
     # Starting with Python 3.11, the __dict__ attribute is lazily created
     # and is serialized as None when not needed.
     if dict_state:
         for k, v in dict_state.items():
-            _setattr(k, v)
+            setattr(obj, k, v)
 
     if slots_state:
         for k, v in slots_state.items():
-            _setattr(k, v)
+            setattr(obj, k, v)
     return obj
 
 

--- a/torch/_utils.py
+++ b/torch/_utils.py
@@ -574,15 +574,26 @@ def _set_obj_state(obj, state):
         dict_state = state
         slots_state = None
 
+    def _setattr(k, v):
+        # A normal torch.save never emits dunder keys here. Rejecting them keeps
+        # a crafted state dict from setting attributes such as __class__ (which
+        # would silently change the object's type) when loading with
+        # weights_only=True.
+        if isinstance(k, str) and k.startswith("__") and k.endswith("__"):
+            raise RuntimeError(
+                f"_set_obj_state: refusing to set dunder attribute '{k}'"
+            )
+        setattr(obj, k, v)
+
     # Starting with Python 3.11, the __dict__ attribute is lazily created
     # and is serialized as None when not needed.
     if dict_state:
         for k, v in dict_state.items():
-            setattr(obj, k, v)
+            _setattr(k, v)
 
     if slots_state:
         for k, v in slots_state.items():
-            setattr(obj, k, v)
+            _setattr(k, v)
     return obj
 
 

--- a/torch/_weights_only_unpickler.py
+++ b/torch/_weights_only_unpickler.py
@@ -3,6 +3,7 @@
 # Restrict constructing types to a list defined in _get_allowed_globals()
 # Restrict BUILD operation to `Tensor`, `Parameter` and `OrderedDict` types only
 # Restrict APPEND/APPENDS to `list` (and allowlisted list subclasses)
+# Restrict object state restored via `_set_obj_state` to non-dunder attribute names
 # In `GLOBALS` operation do not do class lookup by name, but rather rely on dictionary
 # defined by `_get_allowed_globals()` method, that contains:
 # - torch types (Storage, dtypes, Tensor, `torch.Size`),
@@ -173,6 +174,43 @@ def _tensor_rebuild_functions():
         torch._utils._rebuild_device_tensor_from_cpu_tensor,
     }
 
+def _check_no_dunder_attrs(state):
+    # ``torch._utils._set_obj_state`` restores attributes by calling ``setattr``
+    # with keys taken straight from the pickle stream. A normal ``torch.save`` never
+    # emits dunder-named keys, and allowing them lets a crafted state dict set e.g.
+    # ``__class__``, silently turning an ``nn.Parameter`` into a plain ``Tensor``.
+    parts = state if isinstance(state, tuple) and len(state) == 2 else (state,)
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        for k in part:
+            if isinstance(k, str) and k.startswith("__") and k.endswith("__"):
+                raise UnpicklingError(
+                    f"Trying to set dunder attribute '{k}' on the object state of "
+                    f"a reconstructed tensor, which is not allowed when loading "
+                    f"with weights_only=True"
+                )
+
+
+def _rebuild_parameter_with_state_restricted(
+    data, requires_grad, backward_hooks, state
+):
+    _check_no_dunder_attrs(state)
+    return torch._utils._rebuild_parameter_with_state(
+        data, requires_grad, backward_hooks, state
+    )
+
+
+def _rebuild_from_type_v2_restricted(func, new_type, args, state):
+    # Only check when the state would reach ``_set_obj_state``, i.e. when the
+    # subclass does not define a ``__setstate__`` of its own.
+    if (
+        getattr(new_type, "__setstate__", torch.Tensor.__setstate__)
+        is torch.Tensor.__setstate__
+    ):
+        _check_no_dunder_attrs(state)
+    return torch._tensor._rebuild_from_type_v2(func, new_type, args, state)
+
 
 # Unpickling machinery
 @_functools.lru_cache(maxsize=1)
@@ -228,7 +266,15 @@ def _get_allowed_globals():
 
     # Handles Tensor Subclasses, Tensor's with attributes.
     # NOTE: It calls into above rebuild functions for regular Tensor types.
-    rc["torch._tensor._rebuild_from_type_v2"] = torch._tensor._rebuild_from_type_v2
+    rc["torch._tensor._rebuild_from_type_v2"] = _rebuild_from_type_v2_restricted
+
+    # These two are the only allowlisted rebuild functions that pass a
+    # stream-controlled state dict to ``_set_obj_state``, so both are routed through
+    # wrappers rejecting dunder-named keys. ``_set_obj_state`` is shared with
+    # unrestricted loading and is deliberately left untouched.
+    rc["torch._utils._rebuild_parameter_with_state"] = (
+        _rebuild_parameter_with_state_restricted
+    )
     return rc
 
 


### PR DESCRIPTION
Fixes #195607

## Summary

`_set_obj_state` restores a checkpoint's Python attributes with `setattr(obj, k, v)`. The keys come straight from the pickle stream, unfiltered. Under `weights_only=True` that's the one place a stream-controlled key reaches `setattr`.

So a crafted state dict can set dunder attributes. `{"__class__": torch.Tensor}` is the interesting one: Parameter and Tensor share a layout, so CPython allows the reassignment. The Parameter quietly becomes a plain Tensor and `isinstance(x, nn.Parameter)` starts returning False. No error, no warning.

This isn't an RCE, and values still go through the restricted unpickler, so it's a hardening change rather than a security fix. A normal `torch.save` never writes dunder keys here. Rejecting them is cheap and avoids a class of confusing failures from malformed or hand-crafted checkpoints.

## Change

`_set_obj_state` is left alone. The check now lives in `_weights_only_unpickler.py` instead.

Two allowlisted rebuild functions hand a stream-controlled state dict to `_set_obj_state`: `_rebuild_parameter_with_state` and `_rebuild_from_type_v2`. Their allowlist entries now point at thin wrappers that reject dunder-named keys. GLOBAL and REDUCE both resolve through that same dict, so the wrappers are always what a restricted load gets, and nothing else is affected.

One detail: `_rebuild_from_type_v2` skips `_set_obj_state` when the subclass has its own `__setstate__`. The wrapper mirrors that, so those subclasses keep full control of their state.

## Test plan

Checked on 2.13.0:

- The crafted checkpoint from the issue now raises `UnpicklingError` instead of quietly handing back a `Tensor`.
- `nn.Parameter` with a custom attribute, a plain `state_dict`, and `TwoTensor` all still round-trip under `weights_only=True`.
- `weights_only=False` still restores dunder-named state that weights-only rejects.
- Subclasses with their own `__setstate__` are unaffected.
- Non-dict `__getstate__` results are ignored.