### PR TITLE
[inductor] Make manual wait-user repair linear

### DIFF
--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -2078,6 +2078,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
     )
     def test_manual_bucketing_ag_late_input_repairs_wait_consumer(self):
         from torch._inductor.fx_passes.overlap_manual_scheduling import (
+            _move_wait_users_after_latest_inputs,
             ManualOverlapPreservingBucketer,
         )
         from torch._inductor.fx_passes.overlap_scheduling import CollectiveInfo
@@ -2174,7 +2175,10 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
                 OrderedSet(gm.graph.nodes),
                 bucket_mode="custom_ops",
             )
-            bucketer._bucket_group([ag1, ag2])
+            replacements, replaced_users = bucketer._bucket_group([ag1, ag2])
+            _move_wait_users_after_latest_inputs(
+                gm.graph, replacements, replaced_users
+            )
             gm.graph.lint()
 
             (

--- a/test/distributed/test_aten_comm_compute_reordering.py
+++ b/test/distributed/test_aten_comm_compute_reordering.py
@@ -2176,9 +2176,7 @@ class TestManualOverlapBucketing(TestComputeCommReorderingMultiProc):
                 bucket_mode="custom_ops",
             )
             replacements, replaced_users = bucketer._bucket_group([ag1, ag2])
-            _move_wait_users_after_latest_inputs(
-                gm.graph, replacements, replaced_users
-            )
+            _move_wait_users_after_latest_inputs(gm.graph, replacements, replaced_users)
             gm.graph.lint()
 
             (

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -2009,6 +2009,147 @@ class TestOverlapSchedulingFixes(InductorTestCase):
             graph.run(a, b, gen)
 
 
+class TestManualOverlapSchedulingUnit(TestCase):
+    def test_late_wait_user_repair_is_linear_for_high_fan_in(self):
+        """Ensure reverse-ordered replacement inputs are each visited only once."""
+        from torch._inductor.fx_passes.overlap_manual_scheduling import (
+            _move_wait_users_after_latest_inputs,
+        )
+
+        class CountingInputs(dict[fx.Node, None]):
+            def __init__(self, inputs: dict[fx.Node, None]) -> None:
+                super().__init__(inputs)
+                self.num_visits = 0
+
+            def __iter__(self):
+                for node in super().__iter__():
+                    self.num_visits += 1
+                    yield node
+
+            def __reversed__(self):
+                for node in super().__reversed__():
+                    self.num_visits += 1
+                    yield node
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        old_waits = [graph.call_function(torch.neg, (x,)) for _ in range(32)]
+        user = graph.call_function(torch.cat, (old_waits,))
+        new_waits = [graph.call_function(torch.clone, (x,)) for _ in range(32)]
+        graph.output(user)
+        graph.lint()
+
+        replacements = dict(zip(old_waits, reversed(new_waits), strict=True))
+        for old_wait, new_wait in replacements.items():
+            user.replace_input_with(old_wait, new_wait)
+        counting_inputs = CountingInputs(user._input_nodes)
+        user._input_nodes = counting_inputs
+
+        _move_wait_users_after_latest_inputs(
+            graph,
+            replacements=replacements,
+            replaced_users={old_wait: [user] for old_wait in old_waits},
+        )
+
+        self.assertEqual(counting_inputs.num_visits, len(new_waits))
+        graph.lint()
+
+    def test_late_wait_user_repair_detects_cycle(self):
+        """Ensure replacement-introduced dependency cycles are rejected."""
+        from torch._inductor.fx_passes.overlap_manual_scheduling import (
+            _move_wait_users_after_latest_inputs,
+        )
+
+        graph = fx.Graph()
+        x = graph.placeholder("x")
+        old_wait = graph.call_function(torch.neg, (x,))
+        user = graph.call_function(torch.relu, (old_wait,))
+        new_wait = graph.call_function(torch.clone, (user,))
+        graph.output(new_wait)
+        graph.lint()
+
+        user.replace_input_with(old_wait, new_wait)
+        with self.assertRaisesRegex(AssertionError, "stable topological sort failed"):
+            _move_wait_users_after_latest_inputs(
+                graph,
+                replacements={old_wait: new_wait},
+                replaced_users={old_wait: [user]},
+            )
+
+    def test_late_wait_user_repair_is_stable_and_bounded(self):
+        """Ensure repair preserves stable order without repeated graph scans."""
+        from torch._inductor.fx_passes.overlap_manual_scheduling import (
+            _move_wait_users_after_latest_inputs,
+        )
+
+        class CountingGraph(fx.Graph):
+            def __init__(self):
+                super().__init__()
+                self.num_nodes_accesses = 0
+
+            @property
+            def nodes(self):
+                self.num_nodes_accesses += 1
+                return super().nodes
+
+        graph = CountingGraph()
+        x = graph.placeholder("x")
+        y = graph.placeholder("y")
+        old_wait = graph.call_function(torch.neg, (x,))
+        other_old_wait = graph.call_function(torch.neg, (y,))
+        first_user = graph.call_function(torch.relu, (old_wait,))
+        last_user = first_user
+        for _ in range(50):
+            last_user = graph.call_function(torch.relu, (last_user,))
+        second_user = graph.call_function(torch.sigmoid, (old_wait,))
+        third_user = graph.call_function(torch.relu, (other_old_wait,))
+        unrelated_before = graph.call_function(torch.sin, (x,))
+        new_wait = graph.call_function(torch.clone, (x,))
+        other_new_wait = graph.call_function(torch.clone, (y,))
+        unrelated_after = graph.call_function(torch.cos, (x,))
+        graph.output(
+            (last_user, second_user, third_user, unrelated_before, unrelated_after)
+        )
+        graph.lint()
+
+        first_user.replace_input_with(old_wait, new_wait)
+        second_user.replace_input_with(old_wait, new_wait)
+        third_user.replace_input_with(other_old_wait, other_new_wait)
+        with self.assertRaisesRegex(RuntimeError, "used before it has been defined"):
+            graph.lint()
+
+        accesses_before_repair = graph.num_nodes_accesses
+        _move_wait_users_after_latest_inputs(
+            graph,
+            replacements={old_wait: new_wait, other_old_wait: other_new_wait},
+            replaced_users={
+                old_wait: [first_user, second_user],
+                other_old_wait: [third_user],
+            },
+        )
+        repair_nodes_accesses = graph.num_nodes_accesses - accesses_before_repair
+
+        graph.lint()
+        node_positions = {node: i for i, node in enumerate(graph.nodes)}
+        self.assertLess(node_positions[new_wait], node_positions[first_user])
+        self.assertLess(node_positions[other_new_wait], node_positions[third_user])
+        self.assertLess(node_positions[last_user], node_positions[second_user])
+        self.assertLess(node_positions[unrelated_before], node_positions[new_wait])
+        self.assertLess(node_positions[third_user], node_positions[unrelated_after])
+        self.assertLess(repair_nodes_accesses, 10)
+
+        repaired_order = list(graph.nodes)
+        _move_wait_users_after_latest_inputs(
+            graph,
+            replacements={old_wait: new_wait, other_old_wait: other_new_wait},
+            replaced_users={
+                old_wait: [first_user, second_user],
+                other_old_wait: [third_user],
+            },
+        )
+        self.assertEqual(list(graph.nodes), repaired_order)
+
+
 class TestForeachGroupsUnit(InductorTestCase):
     """Unit tests for _compute_foreach_groups and _pre_bucket_all_gather foreach optimization."""
 

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -2010,6 +2010,84 @@ class TestOverlapSchedulingFixes(InductorTestCase):
 
 
 class TestManualOverlapSchedulingUnit(TestCase):
+    def test_wait_user_repair_runs_once_after_all_bucket_groups(self):
+        from torch._dynamo import graph_deduplication
+        from torch._inductor.fx_passes import overlap_manual_scheduling
+        from torch._inductor.fx_passes.overlap_scheduling import CollectiveInfo
+
+        def func(a, b, c, d):
+            all_reduce = torch.ops._c10d_functional.all_reduce
+            wait = torch.ops._c10d_functional.wait_tensor
+            first0 = wait(all_reduce(a, "sum", "0"))
+            early_user = -first0
+            first1 = wait(all_reduce(b + 1, "sum", "0"))
+            second0 = wait(all_reduce(first0 + c, "sum", "0"))
+            second1 = wait(all_reduce(first1 + d, "sum", "0"))
+            return early_user.sum() + second0.sum() + second1.sum()
+
+        with FakeTensorMode():
+            inputs = [torch.ones(4, 4) for _ in range(4)]
+            traced = make_fx(func)(*inputs)
+
+        collective_info = {}
+        for wait in traced.graph.find_nodes(
+            op="call_function",
+            target=torch.ops._c10d_functional.wait_tensor.default,
+        ):
+            start = wait.args[0]
+            if isinstance(start, fx.Node):
+                collective_info[start] = CollectiveInfo(start, wait, 0, 0, 0)
+
+        bucketer = overlap_manual_scheduling.ManualOverlapPreservingBucketer(
+            traced.graph, collective_info, OrderedSet(traced.graph.nodes)
+        )
+        bucket_group = bucketer._bucket_group
+        bucket_group_calls = 0
+
+        def bucket_group_and_check(coll_nodes):
+            nonlocal bucket_group_calls
+            result = bucket_group(coll_nodes)
+            bucket_group_calls += 1
+            if bucket_group_calls == 1:
+                with self.assertRaisesRegex(
+                    RuntimeError, "used before it has been defined"
+                ):
+                    traced.graph.lint()
+            return result
+
+        with (
+            patch.object(
+                bucketer, "_bucket_group", side_effect=bucket_group_and_check
+            ),
+            patch.object(
+                overlap_manual_scheduling,
+                "_move_wait_users_after_latest_inputs",
+                wraps=overlap_manual_scheduling._move_wait_users_after_latest_inputs,
+            ) as repair,
+            patch.object(
+                graph_deduplication,
+                "_stable_topological_sort",
+                wraps=graph_deduplication._stable_topological_sort,
+            ) as stable_sort,
+        ):
+            bucketer.manual_bucket_collectives(list(traced.graph.nodes))
+
+        self.assertEqual(bucket_group_calls, 2)
+        self.assertEqual(repair.call_count, 1)
+        self.assertEqual(stable_sort.call_count, 1)
+        self.assertEqual(len(repair.call_args.args[1]), 4)
+        self.assertEqual(len(repair.call_args.args[2]), 4)
+        self.assertEqual(
+            len(
+                traced.graph.find_nodes(
+                    op="call_function",
+                    target=torch.ops._c10d_functional.all_reduce.default,
+                )
+            ),
+            2,
+        )
+        traced.graph.lint()
+
     def test_late_wait_user_repair_is_linear_for_high_fan_in(self):
         """Ensure reverse-ordered replacement inputs are each visited only once."""
         from torch._inductor.fx_passes.overlap_manual_scheduling import (

--- a/test/distributed/test_overlap_bucketing_unit.py
+++ b/test/distributed/test_overlap_bucketing_unit.py
@@ -2056,9 +2056,7 @@ class TestManualOverlapSchedulingUnit(TestCase):
             return result
 
         with (
-            patch.object(
-                bucketer, "_bucket_group", side_effect=bucket_group_and_check
-            ),
+            patch.object(bucketer, "_bucket_group", side_effect=bucket_group_and_check),
             patch.object(
                 overlap_manual_scheduling,
                 "_move_wait_users_after_latest_inputs",

--- a/torch/_dynamo/graph_deduplication.py
+++ b/torch/_dynamo/graph_deduplication.py
@@ -10,7 +10,7 @@ structures across different parts of the network.
 import logging
 import operator
 from collections import defaultdict, deque
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Iterator
 
 import torch
 import torch.fx
@@ -343,6 +343,9 @@ def _stable_topological_sort_impl(
     #   dependency.
     waiting = defaultdict(list)
 
+    # Resume dependency scans where a node last blocked so traversal stays linear.
+    dep_iters: dict[Node, Iterator[Node]] = {}
+
     # - `outputs` are always at the end of the graph
     outputs = OrderedSet[Node]()
 
@@ -360,21 +363,21 @@ def _stable_topological_sort_impl(
                 raise AssertionError("output nodes should have no users")
             continue
 
-        # node._input_nodes is maintained by FX and already contains the
-        # unique set of input nodes — avoid rebuilding it via map_arg.
-        if has_additional_deps:
-            deps = _get_flat_args_unique(node, node_to_additional_deps)
-        else:
-            deps = node._input_nodes
+        dep_iter = dep_iters.pop(node, None)
+        if dep_iter is None:
+            # node._input_nodes is maintained by FX and already contains the
+            # unique set of input nodes — avoid rebuilding it via map_arg.
+            if has_additional_deps:
+                deps = _get_flat_args_unique(node, node_to_additional_deps)
+            else:
+                deps = node._input_nodes
+            dep_iter = reversed(deps)
 
-        last_unready = None
-        for x in deps:
-            if x not in ready and (region is None or x in region):
-                last_unready = x
-        if last_unready is not None:
-            # We have unprocessed input nodes. Wait for the last unready
-            # arg so an already sorted list will only recheck this node once.
-            waiting[last_unready].append(node)
+        for dep in dep_iter:
+            if dep not in ready and (region is None or dep in region):
+                dep_iters[node] = dep_iter
+                waiting[dep].append(node)
+                break
         else:
             ready.add(node)
             if cursor and cursor.next is not node and do_sort:

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -127,32 +127,10 @@ def _move_wait_users_after_latest_inputs(
             ):
                 initial_users.add(user)
 
-    pending = sorted(initial_users, key=lambda n: node_positions[n])
-    queued = OrderedSet(pending)
-    while pending:
-        node = pending.pop(0)
-        queued.discard(node)
+    if initial_users:
+        from torch._dynamo.graph_deduplication import _stable_topological_sort
 
-        node_positions = {n: i for i, n in enumerate(graph.nodes)}
-        if node not in node_positions:
-            continue
-
-        input_nodes = [inp for inp in node.all_input_nodes if inp in node_positions]
-        if not input_nodes:
-            continue
-
-        latest_input = max(input_nodes, key=lambda n: node_positions[n])
-        if node_positions[node] >= node_positions[latest_input]:
-            continue
-
-        # Replacing old waits can leave existing consumers before the new bucket
-        # outputs. Pull each affected consumer after its latest input.
-        latest_input.append(node)
-        node_positions = {n: i for i, n in enumerate(graph.nodes)}
-        for user in node.users:
-            if user in node_positions and user.op != "output" and user not in queued:
-                queued.add(user)
-                pending.append(user)
+        _stable_topological_sort(graph, {})
 
 
 def _move_overlap_nodes(

--- a/torch/_inductor/fx_passes/overlap_manual_scheduling.py
+++ b/torch/_inductor/fx_passes/overlap_manual_scheduling.py
@@ -194,7 +194,14 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         # instance so metadata doesn't leak across separate invocations.
         self.bucketed_node_types: dict[fx.Node, str] = {}
 
-    def _bucket_group(self, coll_nodes: list[fx.Node]) -> None:
+    def _bucket_group(
+        self, coll_nodes: list[fx.Node]
+    ) -> tuple[dict[fx.Node, fx.Node], dict[fx.Node, list[fx.Node]]]:
+        """Bucket one group and return metadata for deferred wait-user repair.
+
+        The graph may not be topologically ordered until the caller repairs the
+        accumulated replacements.
+        """
         if len(coll_nodes) <= 0:
             raise AssertionError("bucketed coll_nodes should have nonzero node")
 
@@ -243,7 +250,6 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
             insert_before=next_node,
             mode=self.bucket_mode,
         )
-        _move_wait_users_after_latest_inputs(self.graph, replacements, replaced_users)
 
         logger.debug(f"bucketing nodes: {coll_nodes} into {new_nodes}")  # noqa: G004
 
@@ -272,6 +278,8 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
                 self.node_to_wait_map[n] = new_wait
             elif n is new_start:
                 self.bucketed_node_types[n] = node_type
+
+        return replacements, replaced_users
 
     def _split_independent_collectives(
         self, coll_nodes: OrderedSet[fx.Node], scope_nodes: list[fx.Node]
@@ -347,8 +355,18 @@ class ManualOverlapPreservingBucketer(OverlapPreservingBucketer):
         for key, key_nodes in grouped_collectives.items():
             sub_buckets.extend(self._split_independent_collectives(key_nodes, nodes))
 
+        replacements: dict[fx.Node, fx.Node] = {}
+        replaced_users: dict[fx.Node, list[fx.Node]] = {}
         for sub_bucket in sub_buckets:
-            self._bucket_group(sub_bucket)
+            group_replacements, group_replaced_users = self._bucket_group(sub_bucket)
+            replacements.update(group_replacements)
+            replaced_users.update(group_replaced_users)
+
+        # Repair after all groups so the full-graph sort runs at most once.
+        if replacements:
+            _move_wait_users_after_latest_inputs(
+                self.graph, replacements, replaced_users
+            )
 
 
 class ManualOverlapScheduler(OverlapScheduler):


### PR DESCRIPTION
Manual collective bucketing can replace wait outputs with graph nodes that appear later than their existing consumers. The previous repair moved each consumer separately and rebuilt the full node-position map twice per move. Long dependent chains therefore caused quadratic work and made large sharded graphs appear to hang.

Run the stable topological sort once when a replacement introduces a backward data edge. Preserve its ordering semantics while making dependency traversal linear by resuming each blocked node's reverse dependency iterator instead of rescanning all inputs after every wakeup. This also detects cycles rather than leaving an invalid graph behind.

Tests cover transitive chains, multiple replacements, stable unrelated-node ordering, idempotence, reverse high fan-in, bounded traversal, and cycles.

Test Plan:

```
PYTHONDONTWRITEBYTECODE=1 python test/distributed/test_overlap_bucketing_unit.py -v
python test/dynamo/test_graph_deduplication.py
PYTHONDONTWRITEBYTECODE=1 python test/distributed/test_aten_comm_compute_reordering.py TestManualOverlapBucketing -v
```

Authored with assistance from an AI coding assistant.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo @azahed98