### PR TITLE
[inductor] Reuse complete AOT fake tensor metadata

### DIFF
--- a/test/inductor/test_utils.py
+++ b/test/inductor/test_utils.py
@@ -18,7 +18,10 @@ from torch._dynamo.exc import TritonUnavailableError
 from torch._dynamo.testing import AotEagerAndRecordGraphs
 from torch._dynamo.utils import detect_fake_mode
 from torch._inductor import config as inductor_config
-from torch._inductor.compile_fx import _get_subgraph_names
+from torch._inductor.compile_fx import (
+    _can_reuse_fake_tensor_metadata,
+    _get_subgraph_names,
+)
 from torch._inductor.fx_utils import (
     _is_fake_tensor_same,
     count_flops_fx,
@@ -469,6 +472,24 @@ class TestTritonTypeMapping(TestCase):
 
 
 class TestFakeTensorUpdater(TestCase):
+    def test_reuse_complete_fake_tensor_metadata(self):
+        fake_mode = torch._subclasses.FakeTensorMode()
+        x = fake_mode.from_tensor(torch.randn(3))
+        gm = make_fx(lambda value: value.sin())(x)
+
+        self.assertTrue(_can_reuse_fake_tensor_metadata(gm, [x], fake_mode))
+
+        different_input = fake_mode.from_tensor(torch.randn(3))
+        self.assertFalse(
+            _can_reuse_fake_tensor_metadata(gm, [different_input], fake_mode)
+        )
+
+        sin_node = gm.graph.find_nodes(
+            op="call_function", target=torch.ops.aten.sin.default
+        )[0]
+        del sin_node.meta["val"]
+        self.assertFalse(_can_reuse_fake_tensor_metadata(gm, [x], fake_mode))
+
     @staticmethod
     def _get_faketensormode(
         graph: torch.fx.GraphModule,

--- a/torch/_inductor/compile_fx.py
+++ b/torch/_inductor/compile_fx.py
@@ -103,6 +103,7 @@ from torch._inductor.utils import (
 from torch._library.fake_class_registry import FakeScriptObject
 from torch._library.opaque_object import is_custom_class
 from torch._logging import trace_structured
+from torch._subclasses.fake_tensor import is_fake_tensor
 from torch._utils_internal import compile_time_strobelight_meta
 from torch.fx import GraphModule
 from torch.fx.experimental.symbolic_shapes import free_unbacked_symbols, SymExprPrinter
@@ -974,6 +975,62 @@ def fake_tensor_prop(
     return fake_mode
 
 
+def _can_reuse_fake_tensor_metadata(
+    gm: GraphModule,
+    example_inputs: Sequence[InputType],
+    fake_mode: torch._subclasses.FakeTensorMode,
+) -> bool:
+    if any(isinstance(module, GraphModule) for module in list(gm.modules())[1:]):
+        return False
+
+    placeholders = gm.graph.find_nodes(op="placeholder")
+    if len(placeholders) != len(example_inputs):
+        return False
+
+    def same_ints(lhs: Sequence[Any], rhs: Sequence[Any]) -> bool:
+        return len(lhs) == len(rhs) and all(
+            a is b or (type(a) is int and type(b) is int and a == b)
+            for a, b in zip(lhs, rhs)
+        )
+
+    for node, value in zip(placeholders, example_inputs):
+        meta_value = node.meta.get("val")
+        if isinstance(value, torch.Tensor):
+            if not (
+                is_fake_tensor(meta_value)
+                and detect_fake_mode((meta_value,)) is fake_mode
+                and meta_value.layout == value.layout
+                and meta_value.dtype == value.dtype
+                and meta_value.device == value.device
+                and meta_value.requires_grad == value.requires_grad
+                and same_ints(meta_value.shape, value.shape)
+                and same_ints(meta_value.stride(), value.stride())
+                and (
+                    meta_value.storage_offset() is value.storage_offset()
+                    or (
+                        type(meta_value.storage_offset()) is int
+                        and type(value.storage_offset()) is int
+                        and meta_value.storage_offset() == value.storage_offset()
+                    )
+                )
+                and meta_value.untyped_storage()._cdata
+                == value.untyped_storage()._cdata
+            ):
+                return False
+        elif meta_value is not value:
+            return False
+
+    for node in gm.graph.nodes:
+        if node.op == "output":
+            continue
+        if "val" not in node.meta:
+            return False
+        for value in pytree.tree_leaves(node.meta["val"]):
+            if is_fake_tensor(value) and detect_fake_mode((value,)) is not fake_mode:
+                return False
+    return True
+
+
 # pass config dict back to user
 def get_patched_config_dict(
     config_patches: str | dict[str, Any] | None = None,
@@ -1657,7 +1714,11 @@ class _InProcessFxCompile(FxCompile):
                 # of autograd, so there should be no more autograd-related API's in the
                 # graph.
                 with torch.no_grad():
-                    fake_mode = fake_tensor_prop(gm, example_inputs)
+                    fake_mode = detect_fake_mode(example_inputs)
+                    if fake_mode is None or not _can_reuse_fake_tensor_metadata(
+                        gm, example_inputs, fake_mode
+                    ):
+                        fake_mode = fake_tensor_prop(gm, example_inputs)
 
             _recursive_record_original_output_strides(gm)
 

--- a/torch/_inductor/fx_utils.py
+++ b/torch/_inductor/fx_utils.py
@@ -525,7 +525,8 @@ class FakeTensorUpdater:
             node: torch.fx.Node, *args: Any, **kwargs: Any
         ) -> bool:
             return (
-                node.op == "call_function"
+                bool(self.subgraph_updaters)
+                and node.op == "call_function"
                 and node.target
                 not in (
                     # auto_functionalized doesn't call a subgraph, but the pytree call


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195617

Inductor reran fake tensor propagation after AOTAutograd even when the graph
already carried complete metadata produced with the same fake inputs. This
duplicated every fake operator invocation on large graphs.

Reuse metadata only for flat graphs whose nodes are complete, whose fake values
belong to the input fake mode, and whose placeholder metadata matches input
shape, stride, storage, and tensor properties. Fall back to propagation for
missing, nested, stale, real, or differently sourced metadata.

Test Plan:

```
python test/inductor/test_utils.py -k FakeTensorUpdater
python -c 'import torch; f=torch.compile(lambda x:(x.sin().view(-1), x.transpose(0,1)+1),fullgraph=True,dynamic=True); x=torch.randn(3,4,device="cuda"); torch.testing.assert_close(f(x),(x.sin().view(-1),x.transpose(0,1)+1))'
lintrunner -a
```

This commit was authored with the assistance of an AI agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo