### PR TITLE
[cuDNN][CTCLoss][TEST] Don't use blank targets in cuDNN CTCLoss tests

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11871,7 +11871,7 @@ class TestNNDeviceType(NNTestCase):
 
         input_lengths = torch.full((N,), T, dtype=other_dtype).to(other_device)
         target_lengths = torch.randint(low=1, high=S, size=(N,), dtype=other_dtype).to(other_device)
-        targets = torch.randint(low=0, high=C, size=(sum(target_lengths),), dtype=other_dtype).to(other_device)
+        targets = torch.randint(low=1, high=C, size=(sum(target_lengths),), dtype=other_dtype).to(other_device)
 
         ctc_loss = torch.nn.functional.ctc_loss(
             log_probs=log_probs,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1792,7 +1792,7 @@ class TestTorchDeviceType(TestCase):
     def test_nondeterministic_alert_CTCLoss(self, device):
         module = torch.nn.CTCLoss()
         input = torch.randn(50, 3, 15, device=device, requires_grad=True)
-        target = torch.randint(0, 14, (3, 30), device=device)
+        target = torch.randint(1, 14, (3, 30), device=device)
         input_lengths = [50, 50, 50]
         target_lengths = [30, 25, 20]
         res = module(input, target, input_lengths, target_lengths)


### PR DESCRIPTION
new cuDNN upgrade explicitly errors out on this disallowed case, fixes test failures from incorrect tests after #195492

authored with codex

cc @csarofeen @ptrblck @nWEIdia @mruberry