### PR TITLE
[Tasks][TEST ISSUE] [T286529310] Fix 2 broken tests

### DIFF
--- a/torch/headeronly/util/complex.h
+++ b/torch/headeronly/util/complex.h
@@ -17,6 +17,9 @@ C10_CLANG_DIAGNOSTIC_IGNORE("-Wimplicit-float-conversion")
 #if C10_CLANG_HAS_WARNING("-Wfloat-conversion")
 C10_CLANG_DIAGNOSTIC_IGNORE("-Wfloat-conversion")
 #endif
+#if C10_CLANG_HAS_WARNING("-Wdeprecated-literal-operator")
+C10_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-literal-operator")
+#endif
 
 namespace c10 {
 


### PR DESCRIPTION
## Summary

  Suppress `-Wdeprecated-literal-operator` around the complex-number user-defined
  literal declarations in `torch/headeronly/util/complex.h`.

  ## Motivation

  The checked-in source already uses the correct C++ spelling:

  ```cpp
  operator""_if
  operator""_id
```
  However, NVCC's cudafe++ pass re-emits these declarations in generated host
  code with whitespace:
```
  operator "" _if
  operator "" _id
```
  Clang diagnoses that generated spelling with
  -Wdeprecated-literal-operator. With Clang 21 and -Werror, this becomes a
  build failure for CUDA consumers of this header.

  The diagnostic points back to complex.h, even though the deprecated spelling
  does not exist in the checked-in source.

  PyTorch's CMake configuration already suppresses this NVCC-generated warning.
  Other build integrations do not necessarily inherit those CMake flags, so the
  same source currently fails when built through those paths.

Differential Revision: D117844433


