### PR TITLE
[dynamo] Index bytecode constants by identity

### DIFF
--- a/test/dynamo/test_bytecode_utils.py
+++ b/test/dynamo/test_bytecode_utils.py
@@ -27,6 +27,26 @@ def coalesced_co_lines(code):
 
 
 class BytecodeTests(torch._dynamo.test_case.TestCase):
+    def test_get_const_index_uses_identity(self):
+        first = []
+        equal_but_distinct = []
+        code_options = {"co_consts": (first,)}
+        const_indices = {id(first): 0}
+
+        self.assertEqual(
+            bytecode_transformation.get_const_index(
+                code_options, equal_but_distinct, const_indices
+            ),
+            1,
+        )
+        self.assertEqual(
+            bytecode_transformation.get_const_index(
+                code_options, equal_but_distinct, const_indices
+            ),
+            1,
+        )
+        self.assertIs(code_options["co_consts"][1], equal_but_distinct)
+
     @skipIfNotPy311
     def test_linetable_311_writer1(self):
         def fn():

--- a/torch/_dynamo/bytecode_transformation.py
+++ b/torch/_dynamo/bytecode_transformation.py
@@ -1606,16 +1606,18 @@ HAS_FREE = set(dis.hasfree)
 HAS_CONST = set(dis.hasconst)
 
 
-def get_const_index(code_options: dict[str, Any], val: Any) -> int:
-    for i, v in enumerate(code_options["co_consts"]):
-        # NOTE: stronger comparison is required, since we have
-        # examples where two values compare equal but have
-        # different semantic meaning in some cases, e.g.
-        # 0.0 == -0.0 but have different effects in torch.copysign.
-        if val is v:
-            return i
+def get_const_index(
+    code_options: dict[str, Any], val: Any, const_indices: dict[int, int]
+) -> int:
+    # Identity is required because equal constants can have different semantics,
+    # such as 0.0 and -0.0 in torch.copysign.
+    index = const_indices.get(id(val))
+    if index is not None:
+        return index
     code_options["co_consts"] += (val,)
-    return len(code_options["co_consts"]) - 1
+    index = len(code_options["co_consts"]) - 1
+    const_indices[id(val)] = index
+    return index
 
 
 def fix_vars(
@@ -1625,6 +1627,9 @@ def fix_vars(
 ) -> None:
     # compute instruction arg from argval if arg is not provided
     names = {name: idx for idx, name in enumerate(code_options["co_names"])}
+    const_indices: dict[int, int] = {}
+    for idx, value in enumerate(code_options["co_consts"]):
+        const_indices.setdefault(id(value), idx)
 
     def get_name_index(name: str) -> int:
         try:
@@ -1758,8 +1763,9 @@ def fix_vars(
             # NOTE: only update argval if arg is not provided. This assumes
             # that any additions to co_consts are appended.
             if instructions[i].arg is None:
-                # cannot use a dictionary since consts may not be hashable
-                idx = get_const_index(code_options, instructions[i].argval)
+                idx = get_const_index(
+                    code_options, instructions[i].argval, const_indices
+                )
                 if idx < 0:
                     raise AssertionError(
                         f"failed to find constant index for {instructions[i].argval}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195622

Bytecode assembly located every LOAD_CONST by linearly scanning the growing
constant tuple. Large generated functions therefore spent quadratic time in
constant lookup.

Build an identity-to-index table once per assembly and update it when constants
are appended. Object identity remains the key because equal constants can have
different semantics, and unlike hashing it also supports unhashable constants.

Test Plan:

```
python test/dynamo/test_bytecode_utils.py
lintrunner -a
```

This commit was authored with the assistance of an AI agent.

cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @kadeng @chauhang @amjames @jataylo @azahed98