### PR TITLE
[symbolic shapes] Reuse expression symbols during axiom matching

### DIFF
--- a/torch/fx/experimental/symbolic_shapes.py
+++ b/torch/fx/experimental/symbolic_shapes.py
@@ -7411,8 +7411,9 @@ class ShapeEnv:
             subst = self.axioms
         else:
             subst = {}
+            expr_free_symbols = expr.free_symbols
             for e in axioms:
-                if e.free_symbols.issubset(expr.free_symbols):
+                if e.free_symbols.issubset(expr_free_symbols):
                     subst.update(dict(self.get_implications(self.simplify(e))))
 
             resimplify_floor_div(subst)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195623

Static evaluation tested every supplied axiom against the same expression but
recomputed that expression's free-symbol set for each test. Large symbolic
expressions made each redundant traversal expensive.

Compute the expression symbols once before filtering the axioms. The expression
does not change during the loop, so this preserves the matching behavior while
removing repeated SymPy tree walks.

Test Plan:

```
python test/test_dynamic_shapes.py -k floor_clean_div_axioms
lintrunner -a
```

This commit was authored with the assistance of an AI agent.