### PR TITLE
[inductor][ROCm] Add a 256x128x64 GEMM autotune config

### DIFF
--- a/torch/_inductor/heuristics/template/triton.py
+++ b/torch/_inductor/heuristics/template/triton.py
@@ -1648,6 +1648,9 @@ class ROCmConfigHeuristic(BaseConfigHeuristic):
             ROCmGemmConfig(
                 256, 128, 32, self.default_num_stages, 4, group_m=4, waves_per_eu=2
             ),
+            ROCmGemmConfig(
+                256, 128, 64, self.default_num_stages, 4, group_m=4, waves_per_eu=2
+            ),
             ROCmGemmConfig(256, 128, 32, self.default_num_stages, 8, group_m=16),
             ROCmGemmConfig(256, 128, 64, self.default_num_stages, 8, group_m=4),
             ROCmGemmConfig(256, 256, 64, self.default_num_stages, 8, group_m=4),


### PR DESCRIPTION
Summary:
Add a four-wave `BLOCK_M=256`, `BLOCK_N=128`, `BLOCK_K=64` ROCm GEMM configuration with `waves_per_eu=2` to the normal max-autotune search space.

On MI350X this schedule reduces an internal models broadcast BMM/slice kernel from 679.4 us to 375.0 us per iteration. It also improves a second production BMM from 140.3 us to 118.3 us. Offline testing with this new autotune config measure 28.93 ms and 28.82 ms versus the retained-stack 29.19 ms and 29.08 ms, with accuracy passing.

Test Plan:
- MI350X exact-shape benchmark for `bmm(3072x472x680, 3072x680x112)`: candidate selected at 0.4757 ms versus 0.5111 ms for the prior config; correctness passed
- MI350X full-model runs for model: 28.93 ms and 28.82 ms, accuracy passed at `rtol=0.01`
- MI350X trace: target kernel 679.4 us to 375.0 us per iteration; traced model 29.07 ms to 28.87 ms

Reviewed By: njriasan

Differential Revision: D117535340




cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @naromero77amd @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben