### PR TITLE
[quantization] Reject negative ch_axis in fused observer fake quant

### DIFF
--- a/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
+++ b/aten/src/ATen/native/quantized/cpu/fused_obs_fake_quant.cpp
@@ -235,6 +235,10 @@ at::Tensor fused_moving_avg_obs_fake_quant(
   if (self.sym_numel() == 0) {
     return self.clone();
   }
+  TORCH_CHECK(
+      !per_row_fake_quant || ch_axis >= 0,
+      "Error in fused_moving_avg_obs_fake_quant: ch_axis must be non-negative "
+      "when per_row_fake_quant is true");
   auto res = at::_fused_moving_avg_obs_fq_helper(
       self,
       observer_on,

--- a/test/quantization/core/test_workflow_ops.py
+++ b/test/quantization/core/test_workflow_ops.py
@@ -1100,6 +1100,62 @@ class TestFakeQuantizeOps(TestCase):
 
 
 class TestFusedObsFakeQuant(TestCase):
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']))
+    @settings(deadline=None)
+    def test_fused_obs_fake_quant_rejects_negative_per_channel_axis(self, device) -> None:
+        x = torch.randn(1, device=device)
+        observer_on = torch.tensor([1], device=device)
+        fake_quant_on = torch.tensor([1], device=device)
+        running_min = torch.tensor([float("inf")], device=device)
+        running_max = torch.tensor([float("-inf")], device=device)
+        scale = torch.tensor([1.0], device=device)
+        zero_point = torch.tensor([0], dtype=torch.int, device=device)
+
+        with self.assertRaisesRegex(RuntimeError, "ch_axis must be non-negative"):
+            torch.fused_moving_avg_obs_fake_quant(
+                x,
+                observer_on,
+                fake_quant_on,
+                running_min,
+                running_max,
+                scale,
+                zero_point,
+                0.01,
+                0,
+                255,
+                -1250999896764,
+                True,
+                False,
+            )
+
+    @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']))
+    @settings(deadline=None)
+    def test_fused_obs_fake_quant_allows_per_tensor_axis_sentinel(self, device) -> None:
+        x = torch.randn(2, 3, device=device)
+        running_min = torch.tensor(float("inf"), device=device)
+        running_max = torch.tensor(float("-inf"), device=device)
+        scale = torch.tensor([1.0], device=device)
+        zero_point = torch.tensor([0], dtype=torch.int, device=device)
+        disabled = torch.tensor([0], device=device)
+
+        out = torch.fused_moving_avg_obs_fake_quant(
+            x,
+            disabled,
+            disabled,
+            running_min,
+            running_max,
+            scale,
+            zero_point,
+            0.01,
+            0,
+            255,
+            -1,
+            False,
+            False,
+        )
+
+        self.assertEqual(out, x)
+
     @given(device=st.sampled_from(['cpu', 'cuda'] if torch.cuda.is_available() else ['cpu']),
            sampled_dtype=st.sampled_from(['bf16', 'fp16', 'fp32']),
            symmetric_quant=st.booleans(), use_bool=st.booleans())


### PR DESCRIPTION
# Fixing an Issue

Before submitting, please review:

- [The Ultimate Guide to PyTorch Contributions](https://github.com/pytorch/pytorch/wiki/The-Ultimate-Guide-to-PyTorch-Contributions#getting-started-with-pull-requests)
- [AI-Assisted Development](https://github.com/pytorch/pytorch/blob/main/AI_POLICY.md) policy

---

## Issue

Fixes #128693

## Summary

I reviewed the exact two-file diff that this PR will land:

- aten/src/ATen/native/quantized/cpu/fused\_obs\_fake\_quant.cpp
- test/quantization/core/test\_workflow\_ops.py

The quoted analysis is relevant because it matches what those files actually change. The existing helper only rejected `ch_axis >= rank`. For a non-empty per-channel input, a large negative axis such as the value in #128693 therefore passed the check and later hit an unchecked `self.size(ch_axis)` / permute index, which is the SEGV reported against `fused_moving_avg_obs_fake_quant`. The C++ change rejects negative per-channel axes in the common public wrapper before backend dispatch, and it leaves the documented per-tensor `ch_axis=-1` sentinel alone. The Python test covers that reported extreme negative value plus the per-tensor sentinel.

I take responsibility for this implementation: I read both files line by line, confirmed the 4 C++ + 56 Python insertions, and agree this is the correct fix for #128693 rather than a backend-only or docs-only change.

> **AI-assisted draft, prepared with Codex:**
>
> The helper's initial bounds check rejected only axes greater than or equal to
> the input rank. For non-empty per-channel inputs, a large negative `ch_axis`
> could therefore reach an unchecked indexed access and crash instead of
> producing a Python exception. This change rejects negative per-channel axes
> in the common public wrapper before backend dispatch, preserves the existing
> per-tensor `ch_axis=-1` sentinel, and adds CPU/CUDA-when-available regression
> coverage for the extreme negative value reported in #128693 plus the
> per-tensor sentinel.

## Checklist

- [x] Passes lint (`spin fixlint`)
- [x] Added/updated tests
- [ ] Updated documentation (if applicable)
- [ ] Included benchmark results (for PRs impacting perf)

## Test plan

I verified the following on the two-file working tree. I am not marking runtime tests as passing.

Lint (ran; exit 0):

- `git diff --check`
- default changed-file `lintrunner -a -vv` (no `--skip`, `--take`, explicit path, or `--all-files`)
- follow-up non-autofix `lintrunner -vv`
- official `spin regenerate-clangtidy-files` to produce real `build/compile_commands.json` and generated ATen headers
- bare `spin fixlint` with the project-pinned lintrunner; both the repository-wide fast/all-files phase and the changed-file slow phase printed `ok No lint issues.`

After autofix the changed set was still exactly those two files (4 C++ / 56 Python additions), modes stayed `0644`, and the stable patch-id was unchanged.

Runtime (not run):

- I did not build the modified C++ source locally.
- I did not execute the new CPU tests or the CUDA-when-available tests from a build that contains this change.

CI should run `test/quantization/core/test_workflow_ops.py` on CPU and, when a GPU is present, the CUDA path added for the #128693 axis and the per-tensor `ch_axis=-1` sentinel.

> **AI-assisted test-status draft, prepared with Codex:**
>
> - Codex ran `git diff --check`; it exited 0.
> - Codex reproduced the exact two-file patch on a Linux-native tree reconstructed
>   from the official PyTorch source archive at
>   `d7bd5744202e655027716498bbf4064da94efe1b`. The two baseline blob IDs match
>   the local branch. The reconstructed baseline has all 21,681 tracked entries,
>   including all 37 submodule gitlinks, and its root tree hash matches the
>   upstream commit's root tree hash.
> - Codex ran the default changed-file `lintrunner -a -vv`; it exited 0
>   with `ok No lint issues.` It used no `--skip`, `--take`, explicit path, or
>   `--all-files` option; lintrunner selected exactly the two changed files.
> - Codex ran a second non-autofix `lintrunner -vv`; it also exited 0 with
>   `ok No lint issues.`
> - Codex initialized and verified all 65 recursive submodule entries, then ran
>   the project's official `spin regenerate-clangtidy-files`. It produced a
>   real `build/compile_commands.json`, generated ATen headers, and the generated
>   header required by `CLANGTIDY_EXECUTORCH_COMPATIBILITY`.
> - Codex then ran the bare `spin fixlint` command with the project's pinned
>   `lintrunner 0.12.7`; it exited 0. The repository-wide fast/all-files phase
>   and the changed-file slow phase both ended with `ok No lint issues.` No
>   project check was skipped, and the command used no user-supplied `--skip`,
>   `--take`, or path restriction.
> - Both target files remained mode `0644`, the changed set stayed at 4 C++ additions
>   plus 56 Python additions, and stable patch-id
>   `b13f50a8a1570bc5b0ee2001e9f4b702d97de6fc` was unchanged after autofix.
> - Runtime CPU/CUDA tests were not run because the modified C++ source was not
>   built locally.

## BC-breaking?

> **AI-assisted draft, prepared with Codex:**
>
> No for valid inputs. For non-empty per-channel inputs, invalid negative axes
> now raise a runtime error instead of potentially reaching an out-of-bounds
> access or process crash.

## AI disclosure

> The quoted sections above and the implementation were prepared with
> assistance from Codex. Joy's unquoted commentary records the contributor's
> own review, understanding, and responsibility, including which checks Joy
> personally ran or reviewed.


cc @jgong5 @mingfeima @XiaobingSuper @sanchitintel @ashokei @jingxu10 @aditew01