### PR TITLE
[Inductor] Restrict mutation analysis for `tt.addptr`

### DIFF
--- a/test/inductor/test_triton_kernels.py
+++ b/test/inductor/test_triton_kernels.py
@@ -4459,6 +4459,67 @@ class MutationTests(torch._inductor.test_case.TestCase):
             ["out_ptr"],
         )
 
+    def test_store_offset_tensor_is_not_marked_mutated(self):
+        from torch._higher_order_ops.triton_kernel_wrap import (
+            analyze_kernel_access,
+            get_tma_stores,
+            Intermediate,
+            Op,
+            Param,
+        )
+
+        # The offset must come from an op that is not literally named "tt.load",
+        # otherwise skip_loads already truncates the write traversal and the
+        # tt.addptr restriction is not exercised.
+        loaded_offset = Intermediate(idx=0)
+        output_address = Intermediate(idx=1)
+        functions = {
+            "main": {
+                loaded_offset: [
+                    Op("tt.call", "load_offset", [Param(idx=1)], loaded_offset)
+                ],
+                output_address: [
+                    Op(
+                        "tt.addptr",
+                        None,
+                        [Param(idx=0), loaded_offset],
+                        output_address,
+                    )
+                ],
+                Intermediate(idx=-1): [
+                    Op(
+                        "tt.store",
+                        None,
+                        [output_address, loaded_offset],
+                        Intermediate(idx=-1),
+                    )
+                ],
+            },
+            "load_offset": {
+                Intermediate(idx=0): [
+                    Op("tt.load", None, [Param(idx=0)], Intermediate(idx=0))
+                ],
+            },
+        }
+
+        analyze_kernel_access.reset()
+        try:
+            tensor_accesses = analyze_kernel_access(
+                functions,
+                "main",
+                2,
+                ("output_ptr", "offset_ptr"),
+                frozenset({0, 1}),
+            )
+
+            read_names = [dep.name for dep in tensor_accesses.read_writes.reads]
+            write_names = [dep.name for dep in tensor_accesses.read_writes.writes]
+            self.assertListEqual(read_names, ["offset_ptr"])
+            self.assertListEqual(write_names, ["output_ptr"])
+        finally:
+            analyze_kernel_access.reset()
+            get_tma_stores.reset()
+
     def test_get_tma_stores(self):
         from torch._higher_order_ops.triton_kernel_wrap import (
             get_tma_stores,

--- a/torch/_higher_order_ops/triton_kernel_wrap.py
+++ b/torch/_higher_order_ops/triton_kernel_wrap.py
@@ -1095,6 +1095,7 @@ def analyze_kernel_access(
     # memory. The remaining arguments are shape/stride/offset metadata and
     # should not be traced during mutation analysis.
     POINTER_ONLY_OPS = {
+        "tt.addptr",
         "tt.make_tensor_ptr",
         "tt.advance",
         "tt.make_tensor_descriptor",


### PR DESCRIPTION
Summary:
Treat only the base-pointer operand of `tt.addptr` as pointer provenance during Triton mutation analysis. Numeric offset operands may depend on read-only tensors and must not cause those tensors to be reported as mutated.

Add a focused regression test where a loaded tensor supplies a store offset and verify that only the output pointer is classified as written.


Test Plan:
`buck2 run mode/opt //caffe2/test/inductor:triton_kernels -- caffe2.test.inductor.test_triton_kernels.MutationTests.test_store_offset_tensor_is_not_marked_mutated`

`buck2 test mode/opt -c fbcode.enable_gpu_sections=true -c fbcode.nvcc_arch=a100,h100 //trp/stdlib/transforms/tests:pyper_triton_ts_aoti_transform_offsets_correctness_tests_gpu -- test_grouped_nonzero_member_consumed_by_ngram --return-nonzero-on-failures --print-passing-details`

Differential Revision: D118228893

@diff-train-skip-merge




cc @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben @jataylo