### PR TITLE
[CI] Install flash-linear-attention for the torchtitan tests

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2255,6 +2255,11 @@ test_torchtitan() {
   ci_built_versions=$(get_pkg_versions torch torchao torchcomms)
 
   pip_install helion
+  # qwen3_5 imports fla (flash-linear-attention) at model-build time. torchtitan's
+  # own CI image installs it; this one does not.
+  # The pip_install flash-linear-attention is unpinned, matching torchtitan's own
+  # requirements-vlm.txt:5.
+  pip_install flash-linear-attention
 
   pushd torchtitan
   pip_install -e .

--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -2254,12 +2254,10 @@ test_torchtitan() {
   local ci_built_versions
   ci_built_versions=$(get_pkg_versions torch torchao torchcomms)
 
-  pip_install helion
-  # qwen3_5 imports fla (flash-linear-attention) at model-build time. torchtitan's
-  # own CI image installs it; this one does not.
-  # The pip_install flash-linear-attention is unpinned, matching torchtitan's own
-  # requirements-vlm.txt:5.
-  pip_install flash-linear-attention
+  # fla (flash-linear-attention) is imported by qwen3_5 at model-build time;
+  # torchtitan's own CI image installs it, this one does not. Unpinned to match
+  # torchtitan's own requirements-vlm.txt:5.
+  pip_install helion flash-linear-attention
 
   pushd torchtitan
   pip_install -e .


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #195630

address https://github.com/pytorch/pytorch/actions/runs/33430519915/job/99626897037?pr=193241
```
  RuntimeError: 1 integration test(s) failed:
    qwen3_5_moe_fsdp+tp+ep: No module named 'fla'
```

triggered CI and it's working: https://github.com/pytorch/pytorch/actions/runs/33555466765/job/100028330549?pr=195630
```
  ===== [qwen3_5_moe_fsdp+tp+ep] start 2026-09-02 02:03:13 end 2026-09-02 02:06:27
        flavor: Qwen3.5 MoE FSDP+TP+EP (rc=0) =====

  3m14s, 8 ranks on A10G. What it actually did:
  
  Building device mesh with parallelism: pp=1, dp_replicate=1, dp_shard=4, cp=1,
  tp=2, ep=4
  Building qwen3_5 debugmodel_moe
  CUDA capacity: NVIDIA A10G with 22.30GiB memory
  Model qwen3_5 debugmodel_moe size: 138,312,792 total parameters
  Applied SelectiveAC activation checkpointing to the model
  Applied FSDP to the model
  Trainer is initialized with 512 tokens per DP rank, 2048 tokens per train step, ...
  total steps 10 (warmup 2)
  Training starts at step 1
  step: 1  loss: 12.86756  grad_norm: 1.4758
  step: 2  loss: 12.23245  grad_norm: 1.7861
  step: 3  loss:  9.71753  grad_norm: 2.9347
  ...
  step: 9  loss:  3.63730  grad_norm: 1.5302
  Training completed
  Process group destroyed
```